### PR TITLE
feat(test): test whether `ttsc` and `ttsx` working well or not.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: build
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/build.yml"
+      - "config/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+
+jobs:
+  Ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/ttsc/go.mod
+          cache-dependency-path: |
+            packages/ttsc/go.sum
+            tests/go-transformer/go.mod
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.4
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Packages
+        run: pnpm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+# author: elliot-huffman
+name: release
+on:
+  push:
+    tags:
+      - "*"
+permissions:
+  id-token: write
+  contents: write
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: https://registry.npmjs.org/
+      - uses: pnpm/action-setup@v4
+      - name: Install dependencies
+        run: pnpm install
+      - name: Publish to npm
+        run: pnpm run package:latest --no-git-checks --provenance
+  release:
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - run: pnpm dlx changelogithub
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: test
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/test.yml"
+      - "config/**"
+      - "packages/**"
+      - "tests/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+
+jobs:
+  Ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/ttsc/go.mod
+          cache-dependency-path: |
+            packages/ttsc/go.sum
+            tests/go-transformer/go.mod
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.4
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Tests
+        run: pnpm test
+
+      - name: Go Vet
+        run: pnpm --filter ttsc go:vet

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,17 @@ Do not respond to that risk with vague confidence. Keep the test harness sharp. 
 - `packages/ttsc`: compiler adapter, JS API, plugin host, Go native CLI, TypeScript-Go shims.
 - `packages/ttsx`: runner package that reuses `ttsc`.
 - `tests/smoke`: standalone end-to-end tests for generic projects and generic plugins.
+- `tests/projects`: real fixture projects copied by the smoke suite. Add project-shaped regressions here instead of hiding every case inside test functions.
+- `tests/go-transformer`: Go transformer library and native backend fixture used to prove that plugin-selected native binaries can participate in the transform pipeline.
 - `config`: shared TypeScript compiler configuration.
+
+The smoke suite must stay as a corpus, not a single happy-path file. Add new reference-derived cases under:
+
+- `tests/smoke/test/compiler-corpus.test.cjs`
+- `tests/smoke/test/plugin-corpus.test.cjs`
+- `tests/smoke/test/runner-corpus.test.cjs`
+- `tests/smoke/test/transform-projects.test.cjs`
+- `tests/smoke/test/_helpers.cjs`
 
 ## Required Commands
 
@@ -34,12 +44,6 @@ For TypeScript-Go or shim changes, also run:
 ```bash
 pnpm --filter ttsc go:vet
 cd packages/ttsc && go list -deps ./cmd/ttsc
-```
-
-For package-boundary changes, run:
-
-```bash
-pnpm --filter ./packages/* -r pack
 ```
 
 ## Review Discipline
@@ -89,6 +93,9 @@ Local references commonly used for audits:
 - `/home/samchon/github/contributions/tsgolint`
 - `/home/samchon/github/contributions/tsgonest`
 - `/home/samchon/github/contributions/typical`
+- `/home/samchon/github/contributions/ts-patch`
+- `/home/samchon/github/contributions/tsx`
+- `/home/samchon/github/contributions/ts-node`
 - `/home/samchon/github/samchon/typia@next`
 
 Use them when a change touches TypeScript-Go internals, shim generation, Go compiler-host patterns, emitted JS rewrite strategy, or runner behavior. Be ready to read exact files line by line instead of relying on memory.

--- a/docs/REVIEW-CYCLES.md
+++ b/docs/REVIEW-CYCLES.md
@@ -45,3 +45,59 @@ This file records the initial standalone migration review from `../typia@next/to
 
 - Added `AGENTS.md` with TypeScript-Go drift policy, required commands, review surfaces, and local reference repositories.
 - Added root workspace README.
+
+## Cycle 9. Reference Repository Review
+
+- Compared `ttsc`/`ttsx` against `/home/samchon/github/contributions/typescript-go`, `tsgolint`, `tsgonest`, and `typical`.
+- Replaced manual diagnostic collection with `GetDiagnosticsOfAnyProgram` to match TypeScript-Go and `tsgonest` diagnostic ordering.
+- Added bind-diagnostic smoke coverage.
+- Added `ttsx` ESM runner smoke coverage.
+- Added `wiki/` reference ledgers, gap analysis, self-review, and CI/test documentation.
+- Added GitHub Actions workflow for the build/test/vet gate.
+
+## Cycle 10. Reference Test Corpus Hardening
+
+- Borrowed test pressure from `../../contributions/ts-patch`, `tsx`, `ts-node`, and TypeScript-Go.
+- Added package tests for package `extends`, JSONC config, and circular `extends`.
+- Added smoke tests for chained/disabled plugins, `jsconfig` auto-detection, current `paths` resolution, declaration emit, `transformAsync`, argv/preload, and `.mts` execution.
+- Fixed JS API config forwarding so auto-detected `jsconfig.json` reaches the native binary.
+- Fixed emitted extension handling for `.mjs` / `.cjs` outputs in `ttsc` and `ttsx`.
+
+## Cycle 11. Multi-Project Test Program Expansion
+
+- Split smoke coverage into a shared helper plus separate compiler/plugin/runner corpus files.
+- Added compiler projects for single-file mode, explicit external project config, noEmit, emitDeclarationOnly, source maps, and syntax diagnostic blocking.
+- Added plugin projects for default export factory, `createTtscPlugin`, native mode conflict, invalid export, and transform `--out`.
+- Added runner projects for `.cts`, nested tsconfig discovery, explicit project override, and diagnostic-blocked execution.
+- Raised smoke end-to-end coverage to 30 tests.
+
+## Cycle 12. ts-node-Style Transform Project Corpus
+
+- Removed tarball/package validation from the active gate; correctness is build/test/vet.
+- Added `tests/smoke/test/transform-projects.test.cjs` with multiple small transform projects modeled after `ts-node` fixture pressure.
+- Covered CommonJS `.ts`, `.cts -> .cjs`, `.mts -> .mjs`, `.tsx` JSX lowering, file paths with spaces, tsconfig `extends`, and transform diagnostics.
+- Raised smoke end-to-end coverage to 37 tests.
+
+## Cycle 13. Monorepo Export Contract
+
+- Changed `ttsc` and `ttsx` package metadata so workspace `main`, `types`, and `exports.types` point at `src/index.ts`.
+- Added `publishConfig.main`, `publishConfig.types`, and `publishConfig.exports` that point at built `lib` outputs.
+- Kept runtime `exports.default` on built `lib` so CommonJS smoke plugins can still `require("ttsc")` during local tests.
+- Added package metadata tests for the source-vs-publish export split.
+
+## Cycle 14. Real Fixture Projects And Go Transformer Backend
+
+- Moved the ts-node-style transform corpus into real project directories under `tests/projects/*`.
+- Changed `tests/smoke/test/transform-projects.test.cjs` to copy those projects and execute them instead of hiding the corpus inside test-local builders.
+- Added `tests/go-transformer`, a standalone Go module with a transformer library, Go unit test, and `cmd/ttsc-go-transformer` native backend binary.
+- Added `tests/projects/go-native-transformer`, which selects the Go native transformer through plugin configuration and verifies the transformed JavaScript by running the emitted file.
+- Added the Go transformer module to the root `test` gate and kept the active correctness gate on build/test/vet, not tarball packaging.
+- Raised smoke end-to-end coverage to 38 tests.
+
+## Cycle 15. Root Scripts And Release Workflows
+
+- Reduced root development scripts to direct `build` and full `test` gates, with `test` building required local artifacts before package, Go transformer, and smoke tests.
+- Split GitHub Actions into typia-style `build.yml` and `test.yml` with PR path triggers.
+- Added typia-style `release.yml` for tag-triggered npm publish plus `changelogithub`, without adding extra CI setup steps beyond the copied release shape.
+- Added `package:latest`, `package:next`, `release`, and `next.bash`; publishing targets only `packages/*` because this repository has no `toolchain/*` workspace.
+- Added `bumpp` as the release-versioning dependency.

--- a/next.bash
+++ b/next.bash
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+pnpm bumpp "$1" --no-commit --no-tag --no-push --recursive --yes
+pnpm --filter=./packages/* -r publish --tag next --access public --no-git-checks

--- a/package.json
+++ b/package.json
@@ -4,16 +4,11 @@
   "version": "0.1.0-dev",
   "description": "Standalone TypeScript-Go compiler adapter and runner workspace.",
   "scripts": {
-    "build": "pnpm run build:packages",
-    "build:packages": "pnpm --filter ttsc build && pnpm --filter ttsc go:build && pnpm --filter ttsx build",
-    "build:ttsc-runtime": "pnpm run build:packages",
-    "test": "pnpm run test:packages && pnpm run test:toolchain",
-    "test:packages": "pnpm --filter ttsc test",
-    "test:toolchain": "pnpm --filter ./tests/* -r start",
-    "go:test": "pnpm --filter ttsc go:test",
-    "go:vet": "pnpm --filter ttsc go:vet",
-    "package:tgz": "pnpm --filter ./packages/* -r pack",
-    "prepack": "pnpm run build"
+    "build": "pnpm --filter ttsc build && pnpm --filter ttsc go:build && pnpm --filter ttsx build",
+    "package:latest": "bash -c 'pnpm --filter=./packages/* -r publish --tag latest --access public \"$@\"' --",
+    "package:next": "bash next.bash",
+    "release": "bumpp -r",
+    "test": "pnpm run build && pnpm --filter ttsc test && bash -c 'export PATH=\"$HOME/go-sdk/go/bin:$PATH\"; cd tests/go-transformer && go test ./...' && pnpm --dir tests/smoke start"
   },
   "repository": {
     "type": "git",
@@ -29,6 +24,7 @@
   "devDependencies": {
     "@types/node": "catalog:utils",
     "@typescript/native-preview": "catalog:typescript",
+    "bumpp": "^10.4.1",
     "rimraf": "catalog:utils",
     "typescript": "catalog:typescript"
   }

--- a/packages/ttsc/cmd/ttsc/transform.go
+++ b/packages/ttsc/cmd/ttsc/transform.go
@@ -92,7 +92,7 @@ func runTransform(args []string) int {
 	var captured []byte
 	capture := func(name, text string, _ *shimcompiler.WriteFileData) error {
 		rel := filepath.ToSlash(name)
-		if !strings.HasSuffix(rel, ".js") {
+		if !isJavaScriptOutput(rel) {
 			return nil
 		}
 		captured = []byte(text)
@@ -154,4 +154,13 @@ func sharedSourceStemSegments(outPath, srcPath string) int {
 		shared++
 	}
 	return shared
+}
+
+func isJavaScriptOutput(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".js", ".mjs", ".cjs":
+		return true
+	default:
+		return false
+	}
 }

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -232,12 +232,14 @@ func (p *Program) Diagnostics() []Diagnostic {
 		return []Diagnostic{{Message: "driver: nil program"}}
 	}
 	ctx := context.Background()
-	raw := make([]*ast.Diagnostic, 0)
-	raw = append(raw, p.TSProgram.GetConfigFileParsingDiagnostics()...)
-	raw = append(raw, p.TSProgram.GetProgramDiagnostics()...)
-	raw = append(raw, p.TSProgram.GetSyntacticDiagnostics(ctx, nil)...)
-	raw = append(raw, p.TSProgram.GetSemanticDiagnostics(ctx, nil)...)
-	raw = append(raw, p.TSProgram.GetGlobalDiagnostics(ctx)...)
+	raw := shimcompiler.GetDiagnosticsOfAnyProgram(
+		ctx,
+		p.TSProgram,
+		nil,
+		false,
+		p.TSProgram.GetBindDiagnostics,
+		p.TSProgram.GetSemanticDiagnostics,
+	)
 	raw = filterDiagnostics(raw)
 	return convertDiagnostics(shimcompiler.SortAndDeduplicateDiagnostics(raw))
 }

--- a/packages/ttsc/package.json
+++ b/packages/ttsc/package.json
@@ -2,20 +2,18 @@
   "name": "ttsc",
   "version": "0.1.0-dev",
   "description": "General-purpose compiler adapter and plugin host for tsgo.",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "bin": {
     "ttsc": "src/launcher/ttsc.js"
   },
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.js",
+      "types": "./src/index.ts",
       "default": "./lib/index.js"
     },
     "./plugin": {
-      "types": "./lib/plugin.d.ts",
-      "import": "./lib/plugin.js",
+      "types": "./src/plugin.ts",
       "default": "./lib/plugin.js"
     },
     "./package.json": "./package.json"
@@ -62,6 +60,22 @@
   ],
   "packageManager": "pnpm@10.6.4",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "bin": {
+      "ttsc": "src/launcher/ttsc.js"
+    },
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      },
+      "./plugin": {
+        "types": "./lib/plugin.d.ts",
+        "default": "./lib/plugin.js"
+      },
+      "./package.json": "./package.json"
+    }
   }
 }

--- a/packages/ttsc/src/api.ts
+++ b/packages/ttsc/src/api.ts
@@ -187,9 +187,9 @@ export function transform(options: TransformOptions): string {
   const args = [
     "transform",
     "--file=" + sourceFile,
+    "--tsconfig=" + execution.tsconfig,
     "--rewrite-mode=" + execution.nativeMode,
   ];
-  if (options.tsconfig) args.push("--tsconfig=" + options.tsconfig);
 
   const res = spawnBinary(execution.bin, args, {
     cwd: options.cwd,
@@ -249,8 +249,11 @@ export interface BuildResult {
  */
 export function build(options: BuildOptions = {}): BuildResult {
   const execution = resolveExecutionContext(options);
-  const args = ["build", "--rewrite-mode=" + execution.nativeMode];
-  if (options.tsconfig) args.push("--tsconfig=" + options.tsconfig);
+  const args = [
+    "build",
+    "--tsconfig=" + execution.tsconfig,
+    "--rewrite-mode=" + execution.nativeMode,
+  ];
   if (options.emit === true) args.push("--emit");
   else if (options.emit === false) args.push("--noEmit");
   if (options.outDir) args.push("--outDir=" + options.outDir);
@@ -385,7 +388,7 @@ function applyBuildPlugins(
     return;
   }
   for (const file of emittedFiles) {
-    if (!file.endsWith(".js") || !fs.existsSync(file)) {
+    if (!isJavaScriptOutput(file) || !fs.existsSync(file)) {
       continue;
     }
     const current = fs.readFileSync(file, "utf8");
@@ -401,6 +404,10 @@ function applyBuildPlugins(
       fs.writeFileSync(file, next, "utf8");
     }
   }
+}
+
+function isJavaScriptOutput(file: string): boolean {
+  return /\.(?:[cm]?js)$/i.test(file);
 }
 
 function createTempManifestPath(): string {

--- a/packages/ttsc/src/launcher/ttsc.js
+++ b/packages/ttsc/src/launcher/ttsc.js
@@ -13,7 +13,7 @@ if (fs.existsSync(builtCli)) {
   }
 } else {
   process.stderr.write(
-    "ttsc: lib/cli.js is missing. Build ttsc first with `pnpm run build:toolchain`.\n",
+    "ttsc: lib/cli.js is missing. Build ttsc first with `pnpm run build`.\n",
   );
   process.exitCode = 1;
 }

--- a/packages/ttsc/src/platform.ts
+++ b/packages/ttsc/src/platform.ts
@@ -13,7 +13,7 @@
  *   2. `ttsc-{platform}-{arch}/bin/ttsc{.exe}` optional dependency.
  *      Standard distribution path.
  *   3. A package-local `native/ttsc-native` binary. Used by this
- *      repository's local `pnpm run build:toolchain` output before the
+   *      repository's local `pnpm run build` output before the
  *      platform packages exist on npm.
  *
  * If every strategy fails, `resolveBinary` returns `null` so the caller can print a

--- a/packages/ttsc/src/project.ts
+++ b/packages/ttsc/src/project.ts
@@ -1,5 +1,6 @@
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import * as path from "node:path";
 
 export interface ProjectLocatorOptions {
@@ -183,10 +184,11 @@ function resolveExtendsConfig(tsconfig: string, specifier: string): string {
   if (isRelativePluginSpecifier(specifier)) {
     return resolveExistingExtendsPath(path.resolve(baseDir, specifier));
   }
+  const resolver = createRequire(tsconfig);
   try {
-    return resolveRealPath(require.resolve(specifier, { paths: [baseDir] }));
+    return resolveRealPath(resolver.resolve(specifier));
   } catch {
-    return resolveRealPath(require.resolve(`${specifier}.json`, { paths: [baseDir] }));
+    return resolveRealPath(resolver.resolve(`${specifier}.json`));
   }
 }
 

--- a/packages/ttsc/test/package.test.ts
+++ b/packages/ttsc/test/package.test.ts
@@ -1,0 +1,48 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const workspaceRoot = path.resolve(__dirname, "../../..");
+
+test("package metadata separates monorepo source exports from publish exports", () => {
+  for (const packageName of ["ttsc", "ttsx"]) {
+    const packageJson = readPackageJson(packageName);
+    assert.match(packageJson.main, /^src\/.+\.ts$/);
+    assert.match(packageJson.types, /^src\/.+\.ts$/);
+    assert.equal(packageJson.exports["."].types, "./src/index.ts");
+    assert.equal(packageJson.publishConfig.main, "lib/index.js");
+    assert.equal(packageJson.publishConfig.types, "lib/index.d.ts");
+    assert.equal(
+      packageJson.publishConfig.exports["."].types,
+      "./lib/index.d.ts",
+    );
+    assert.equal(
+      packageJson.publishConfig.exports["."].default,
+      "./lib/index.js",
+    );
+  }
+});
+
+test("ttsc plugin subpath also separates source and publish declarations", () => {
+  const packageJson = readPackageJson("ttsc");
+  assert.equal(packageJson.exports["./plugin"].types, "./src/plugin.ts");
+  assert.equal(packageJson.exports["./plugin"].default, "./lib/plugin.js");
+  assert.equal(
+    packageJson.publishConfig.exports["./plugin"].types,
+    "./lib/plugin.d.ts",
+  );
+  assert.equal(
+    packageJson.publishConfig.exports["./plugin"].default,
+    "./lib/plugin.js",
+  );
+});
+
+function readPackageJson(packageName) {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(workspaceRoot, "packages", packageName, "package.json"),
+      "utf8",
+    ),
+  );
+}

--- a/packages/ttsc/test/project.test.ts
+++ b/packages/ttsc/test/project.test.ts
@@ -106,3 +106,90 @@ test("readProjectConfig lets child tsconfig override inherited plugins", () => {
     { transform: "./local-plugin.cjs" },
   ]);
 });
+
+test("readProjectConfig resolves package tsconfig extends", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+  const preset = path.join(root, "node_modules", "@scope", "tsconfig");
+  const project = path.join(root, "project");
+  fs.mkdirSync(preset, { recursive: true });
+  fs.mkdirSync(project, { recursive: true });
+  fs.writeFileSync(
+    path.join(preset, "base.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          outDir: "../../dist/preset",
+          plugins: [{ transform: "./plugins/from-preset.cjs" }],
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(project, "tsconfig.json"),
+    JSON.stringify(
+      {
+        extends: "@scope/tsconfig/base.json",
+        compilerOptions: {},
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  const parsed = readProjectConfig({
+    tsconfig: path.join(project, "tsconfig.json"),
+  });
+  assert.deepEqual(parsed.compilerOptions.plugins, [
+    { transform: "./plugins/from-preset.cjs" },
+  ]);
+  assert.equal(
+    parsed.compilerOptions.outDir,
+    path.join(root, "node_modules", "dist", "preset"),
+  );
+});
+
+test("readProjectConfig accepts JSONC comments and trailing commas", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+  fs.writeFileSync(
+    path.join(root, "tsconfig.json"),
+    `{
+      // plugin host configuration may live in JSONC tsconfig files
+      "compilerOptions": {
+        "plugins": [
+          { "transform": "./plugins/jsonc.cjs" },
+        ],
+      },
+    }\n`,
+    "utf8",
+  );
+
+  const parsed = readProjectConfig({
+    tsconfig: path.join(root, "tsconfig.json"),
+  });
+  assert.deepEqual(parsed.compilerOptions.plugins, [
+    { transform: "./plugins/jsonc.cjs" },
+  ]);
+});
+
+test("readProjectConfig rejects circular tsconfig extends", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+  fs.writeFileSync(
+    path.join(root, "a.json"),
+    JSON.stringify({ extends: "./b.json" }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(root, "b.json"),
+    JSON.stringify({ extends: "./a.json" }),
+    "utf8",
+  );
+
+  assert.throws(
+    () => readProjectConfig({ tsconfig: path.join(root, "a.json") }),
+    /circular tsconfig extends detected/,
+  );
+});

--- a/packages/ttsx/package.json
+++ b/packages/ttsx/package.json
@@ -2,15 +2,14 @@
   "name": "ttsx",
   "version": "0.1.0-dev",
   "description": "Standalone tsgo runner built on top of the ttsc host.",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "bin": {
     "ttsx": "src/launcher/ttsx.js"
   },
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.js",
+      "types": "./src/index.ts",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"
@@ -52,6 +51,18 @@
   ],
   "packageManager": "pnpm@10.6.4",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "bin": {
+      "ttsx": "src/launcher/ttsx.js"
+    },
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   }
 }

--- a/packages/ttsx/src/cli.ts
+++ b/packages/ttsx/src/cli.ts
@@ -235,7 +235,7 @@ function rewriteEsmSpecifiers(root: string): void {
         stack.push(next);
         continue;
       }
-      if (!entry.isFile() || !next.endsWith(".js")) {
+      if (!entry.isFile() || !isJavaScriptOutput(next)) {
         continue;
       }
       const before = fs.readFileSync(next, "utf8");
@@ -243,12 +243,12 @@ function rewriteEsmSpecifiers(root: string): void {
         .replace(
           /\bfrom\s+(['"])(\.[^'"]+)\1/g,
           (_, quote: string, specifier: string) =>
-            `from ${quote}${withJsExtension(specifier)}${quote}`,
+            `from ${quote}${withResolvableExtension(next, specifier)}${quote}`,
         )
         .replace(
           /\bimport\(\s*(['"])(\.[^'"]+)\1\s*\)/g,
           (_, quote: string, specifier: string) =>
-            `import(${quote}${withJsExtension(specifier)}${quote})`,
+            `import(${quote}${withResolvableExtension(next, specifier)}${quote})`,
         );
       if (after !== before) {
         fs.writeFileSync(next, after, "utf8");
@@ -257,12 +257,31 @@ function rewriteEsmSpecifiers(root: string): void {
   }
 }
 
-function withJsExtension(specifier: string): string {
+function withResolvableExtension(fromFile: string, specifier: string): string {
   if (!specifier.startsWith(".")) {
     return specifier;
   }
   if (/\.(?:[cm]?js|json|node)$/i.test(specifier)) {
     return specifier;
   }
+  const [pathname, suffix = ""] = splitSpecifierSuffix(specifier);
+  const fromDir = path.dirname(fromFile);
+  for (const extension of [".js", ".mjs", ".cjs"]) {
+    if (fs.existsSync(path.resolve(fromDir, pathname + extension))) {
+      return pathname + extension + suffix;
+    }
+  }
   return `${specifier}.js`;
+}
+
+function splitSpecifierSuffix(specifier: string): [string, string?] {
+  const index = specifier.search(/[?#]/);
+  if (index === -1) {
+    return [specifier];
+  }
+  return [specifier.slice(0, index), specifier.slice(index)];
+}
+
+function isJavaScriptOutput(filename: string): boolean {
+  return /\.(?:[cm]?js)$/i.test(filename);
 }

--- a/packages/ttsx/src/launcher/ttsx.js
+++ b/packages/ttsx/src/launcher/ttsx.js
@@ -13,7 +13,7 @@ if (fs.existsSync(builtCli)) {
   }
 } else {
   process.stderr.write(
-    "ttsx: lib/cli.js is missing. Build ttsc and ttsx first with `pnpm run build:toolchain`.\n",
+    "ttsx: lib/cli.js is missing. Build ttsc and ttsx first with `pnpm run build`.\n",
   );
   process.exitCode = 1;
 }

--- a/packages/ttsx/src/register.ts
+++ b/packages/ttsx/src/register.ts
@@ -414,7 +414,8 @@ function resolveExactEmittedFile(
   }
   return path.resolve(
     context.emitDir,
-    relative.slice(0, relative.length - path.extname(relative).length) + ".js",
+    relative.slice(0, relative.length - path.extname(relative).length) +
+      emittedJavaScriptExtension(filename),
   );
 }
 
@@ -428,7 +429,7 @@ function listEmittedFiles(root: string): string[] {
       const next = path.join(current, entry.name);
       if (entry.isDirectory()) {
         stack.push(next);
-      } else if (entry.isFile() && next.endsWith(".js")) {
+      } else if (entry.isFile() && isJavaScriptOutput(next)) {
         output.push(path.resolve(next));
       }
     }
@@ -464,4 +465,19 @@ function looksLikeESM(output: string): boolean {
     return false;
   }
   return /^\s*(import|export)\s/m.test(output);
+}
+
+function emittedJavaScriptExtension(filename: string): string {
+  switch (path.extname(filename).toLowerCase()) {
+    case ".mts":
+      return ".mjs";
+    case ".cts":
+      return ".cjs";
+    default:
+      return ".js";
+  }
+}
+
+function isJavaScriptOutput(filename: string): boolean {
+  return /\.(?:[cm]?js)$/i.test(filename);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:typescript
         version: 7.0.0-dev.20260421.2
+      bumpp:
+        specifier: ^10.4.1
+        version: 10.4.1
       rimraf:
         specifier: catalog:utils
         version: 6.1.3
@@ -126,6 +129,13 @@ packages:
     resolution: {integrity: sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==}
     hasBin: true
 
+  ansis@4.2.0:
+    resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
+    engines: {node: '>=14'}
+
+  args-tokenizer@0.3.0:
+    resolution: {integrity: sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -134,9 +144,70 @@ packages:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
+  bumpp@10.4.1:
+    resolution: {integrity: sha512-X/bwWs5Gbb/D7rN4aHLB7zdjiA6nGdjckM1sTHhI9oovIbEw2L5pw5S4xzk8ZTeOZ8EnwU/Ze4SoZ6/Vr3pM2Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  c12@3.3.4:
+    resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
+    peerDependencies:
+      magicast: '*'
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  giget@3.2.0:
+    resolution: {integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==}
+    hasBin: true
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -150,17 +221,56 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  rc9@3.0.1:
+    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
     hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -169,6 +279,11 @@ packages:
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
 snapshots:
 
@@ -207,17 +322,80 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260421.2
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260421.2
 
+  ansis@4.2.0: {}
+
+  args-tokenizer@0.3.0: {}
+
   balanced-match@4.0.4: {}
 
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
+  bumpp@10.4.1:
+    dependencies:
+      ansis: 4.2.0
+      args-tokenizer: 0.3.0
+      c12: 3.3.4
+      cac: 6.7.14
+      escalade: 3.2.0
+      jsonc-parser: 3.3.1
+      package-manager-detector: 1.6.0
+      semver: 7.7.4
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - magicast
+
+  c12@3.3.4:
+    dependencies:
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 17.4.2
+      exsolve: 1.0.8
+      giget: 3.2.0
+      jiti: 2.6.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.0
+      rc9: 3.0.1
+
+  cac@6.7.14: {}
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
+  confbox@0.2.4: {}
+
+  defu@6.1.7: {}
+
+  destr@2.0.5: {}
+
+  dotenv@17.4.2: {}
+
+  escalade@3.2.0: {}
+
+  exsolve@1.0.8: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  giget@3.2.0: {}
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  jiti@2.6.1: {}
+
+  jsonc-parser@3.3.1: {}
 
   lru-cache@11.3.5: {}
 
@@ -227,18 +405,52 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  ohash@2.0.11: {}
+
   package-json-from-dist@1.0.1: {}
+
+  package-manager-detector@1.6.0: {}
 
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.3.5
       minipass: 7.1.3
 
+  pathe@2.0.3: {}
+
+  perfect-debounce@2.1.0: {}
+
+  picomatch@4.0.4: {}
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
+  rc9@3.0.1:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
+
+  readdirp@5.0.0: {}
+
   rimraf@6.1.3:
     dependencies:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
+  semver@7.7.4: {}
+
+  tinyexec@1.1.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   typescript@5.9.3: {}
 
   undici-types@7.19.2: {}
+
+  yaml@2.8.3: {}

--- a/tests/go-transformer/cmd/ttsc-go-transformer/main.go
+++ b/tests/go-transformer/cmd/ttsc-go-transformer/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/samchon/ttsc/tests/go-transformer/transformer"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "ttsc-go-transformer: command is required")
+		return 2
+	}
+	switch args[0] {
+	case "-v", "--version", "version":
+		fmt.Fprintln(os.Stdout, "ttsc-go-transformer 0.1.0-test")
+		return 0
+	case "transform":
+		return runTransform(args[1:])
+	case "build", "check":
+		fmt.Fprintf(os.Stderr, "ttsc-go-transformer: %s is not implemented in the test backend\n", args[0])
+		return 2
+	default:
+		fmt.Fprintf(os.Stderr, "ttsc-go-transformer: unknown command %q\n", args[0])
+		return 2
+	}
+}
+
+func runTransform(args []string) int {
+	fs := flag.NewFlagSet("transform", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	file := fs.String("file", "", "source file")
+	out := fs.String("out", "", "output file")
+	_ = fs.String("tsconfig", "", "owning tsconfig")
+	_ = fs.String("rewrite-mode", "", "rewrite mode")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *file == "" {
+		fmt.Fprintln(os.Stderr, "ttsc-go-transformer: transform requires --file")
+		return 2
+	}
+	source, err := os.ReadFile(*file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ttsc-go-transformer: read %s: %v\n", *file, err)
+		return 2
+	}
+	result, err := transformer.Transform(string(source))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if *out != "" {
+		if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "ttsc-go-transformer: mkdir: %v\n", err)
+			return 2
+		}
+		if err := os.WriteFile(*out, []byte(result.Code), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "ttsc-go-transformer: write %s: %v\n", *out, err)
+			return 2
+		}
+		return 0
+	}
+	fmt.Fprint(os.Stdout, result.Code)
+	return 0
+}

--- a/tests/go-transformer/go.mod
+++ b/tests/go-transformer/go.mod
@@ -1,0 +1,3 @@
+module github.com/samchon/ttsc/tests/go-transformer
+
+go 1.26

--- a/tests/go-transformer/transformer/transformer.go
+++ b/tests/go-transformer/transformer/transformer.go
@@ -1,0 +1,32 @@
+package transformer
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var goUpperCall = regexp.MustCompile(`(?m)export\s+const\s+([A-Za-z_$][A-Za-z0-9_$]*)(?:\s*:\s*[^=]+)?=\s*goUpper\("([^"]*)"\)\s*;`)
+
+type Result struct {
+	Code string
+}
+
+func Transform(source string) (Result, error) {
+	match := goUpperCall.FindStringSubmatch(source)
+	if match == nil {
+		return Result{}, fmt.Errorf(`go transformer: expected export const value = goUpper("...")`)
+	}
+	name := match[1]
+	value := strings.ToUpper(match[2])
+	var builder strings.Builder
+	builder.WriteString(`"use strict";` + "\n")
+	builder.WriteString(`Object.defineProperty(exports, "__esModule", { value: true });` + "\n")
+	builder.WriteString(fmt.Sprintf("exports.%s = void 0;\n", name))
+	builder.WriteString(fmt.Sprintf("const %s = %q;\n", name, value))
+	builder.WriteString(fmt.Sprintf("exports.%s = %s;\n", name, name))
+	if strings.Contains(source, "console.log("+name+")") || strings.Contains(source, "console.log("+name+");") {
+		builder.WriteString(fmt.Sprintf("console.log(%s);\n", name))
+	}
+	return Result{Code: builder.String()}, nil
+}

--- a/tests/go-transformer/transformer/transformer_test.go
+++ b/tests/go-transformer/transformer/transformer_test.go
@@ -1,0 +1,16 @@
+package transformer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTransformGoUpper(t *testing.T) {
+	result, err := Transform(`export const message: string = goUpper("hello"); console.log(message);`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result.Code, `"HELLO"`) {
+		t.Fatalf("expected transformed literal, got:\n%s", result.Code)
+	}
+}

--- a/tests/projects/go-native-transformer/plugin.cjs
+++ b/tests/projects/go-native-transformer/plugin.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  name: "go-native-transformer-test",
+  native: {
+    mode: "go-native-transformer-test",
+    binary: process.env.TTSC_GO_TRANSFORMER_BINARY,
+    contractVersion: 1,
+    capabilities: ["transform"],
+  },
+};

--- a/tests/projects/go-native-transformer/src/main.ts
+++ b/tests/projects/go-native-transformer/src/main.ts
@@ -1,0 +1,4 @@
+declare function goUpper(input: string): string;
+
+export const message: string = goUpper("go native transformer");
+console.log(message);

--- a/tests/projects/go-native-transformer/tsconfig.json
+++ b/tests/projects/go-native-transformer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "plugins": [
+      {
+        "transform": "./plugin.cjs"
+      }
+    ]
+  },
+  "include": ["src"]
+}

--- a/tests/projects/transform-cts/src/main.cts
+++ b/tests/projects/transform-cts/src/main.cts
@@ -1,0 +1,2 @@
+const value: string = "cts-transform";
+console.log(value);

--- a/tests/projects/transform-cts/tsconfig.json
+++ b/tests/projects/transform-cts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/tests/projects/transform-diagnostic/src/main.ts
+++ b/tests/projects/transform-diagnostic/src/main.ts
@@ -1,0 +1,5 @@
+function upper(str: string) {
+  return str.toUpperCase();
+}
+
+upper(10);

--- a/tests/projects/transform-diagnostic/tsconfig.json
+++ b/tests/projects/transform-diagnostic/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/tests/projects/transform-extends/src/main.ts
+++ b/tests/projects/transform-extends/src/main.ts
@@ -1,0 +1,2 @@
+export const value: string = "extends-transform";
+console.log(value);

--- a/tests/projects/transform-extends/tsconfig.base.json
+++ b/tests/projects/transform-extends/tsconfig.base.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/tests/projects/transform-extends/tsconfig.json
+++ b/tests/projects/transform-extends/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": ["src"]
+}

--- a/tests/projects/transform-hello/src/hello.ts
+++ b/tests/projects/transform-hello/src/hello.ts
@@ -1,0 +1,1 @@
+console.log("Hello, world!");

--- a/tests/projects/transform-hello/tsconfig.json
+++ b/tests/projects/transform-hello/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/tests/projects/transform-mts/src/main.mts
+++ b/tests/projects/transform-mts/src/main.mts
@@ -1,0 +1,2 @@
+const value: string = "mts-transform";
+console.log(value);

--- a/tests/projects/transform-mts/tsconfig.json
+++ b/tests/projects/transform-mts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/tests/projects/transform-space/src/throw error.ts
+++ b/tests/projects/transform-space/src/throw error.ts
@@ -1,0 +1,2 @@
+export const spaced: string = "space-ok";
+console.log(spaced);

--- a/tests/projects/transform-space/tsconfig.json
+++ b/tests/projects/transform-space/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/tests/projects/transform-tsx/src/view.tsx
+++ b/tests/projects/transform-tsx/src/view.tsx
@@ -1,0 +1,9 @@
+declare function h(tag: string, props: null): string;
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      div: {};
+    }
+  }
+}
+export const node = <div />;

--- a/tests/projects/transform-tsx/tsconfig.json
+++ b/tests/projects/transform-tsx/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "jsx": "react",
+    "jsxFactory": "h",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/tests/smoke/test/_helpers.cjs
+++ b/tests/smoke/test/_helpers.cjs
@@ -1,0 +1,117 @@
+const child_process = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const workspaceRoot = path.resolve(__dirname, "../../..");
+const testPackageRoot = path.resolve(__dirname, "..");
+const projectsRoot = path.resolve(testPackageRoot, "..", "projects");
+const ttscBin = path.join(
+  testPackageRoot,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "ttsc.cmd" : "ttsc",
+);
+const ttsxBin = path.join(
+  testPackageRoot,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "ttsx.cmd" : "ttsx",
+);
+const nativeBinary = path.join(
+  workspaceRoot,
+  "packages",
+  "ttsc",
+  "native",
+  process.platform === "win32" ? "ttsc-native.exe" : "ttsc-native",
+);
+
+function createProject(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-smoke-"));
+  writeFiles(root, files);
+  return root;
+}
+
+function copyProject(name) {
+  const source = path.join(projectsRoot, name);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `ttsc-${name}-`));
+  copyDirectory(source, root);
+  return root;
+}
+
+function copyDirectory(source, target) {
+  fs.mkdirSync(target, { recursive: true });
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    const from = path.join(source, entry.name);
+    const to = path.join(target, entry.name);
+    if (entry.isDirectory()) {
+      copyDirectory(from, to);
+    } else if (entry.isFile()) {
+      fs.copyFileSync(from, to);
+    }
+  }
+}
+
+function writeFiles(root, files) {
+  for (const [name, contents] of Object.entries(files)) {
+    const file = path.join(root, name);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, contents, "utf8");
+  }
+}
+
+function tsconfig(compilerOptions, extra = {}) {
+  return JSON.stringify({
+    compilerOptions,
+    include: ["src"],
+    ...extra,
+  });
+}
+
+function commonJsProject(files, options = {}) {
+  return createProject({
+    "tsconfig.json": tsconfig({
+      target: "ES2022",
+      module: "commonjs",
+      strict: true,
+      outDir: "dist",
+      rootDir: "src",
+      ...options.compilerOptions,
+    }, options.config ?? {}),
+    ...files,
+  });
+}
+
+function spawn(command, args, options = {}) {
+  return child_process.spawnSync(command, args, {
+    ...options,
+    env: {
+      ...process.env,
+      TTSC_BINARY: nativeBinary,
+      ...options.env,
+    },
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 64,
+    windowsHide: true,
+  });
+}
+
+function runNode(file, options = {}) {
+  return spawn(process.execPath, [file], options);
+}
+
+module.exports = {
+  commonJsProject,
+  copyProject,
+  createProject,
+  nativeBinary,
+  projectsRoot,
+  runNode,
+  spawn,
+  testPackageRoot,
+  ttscBin,
+  ttsxBin,
+  tsconfig,
+  workspaceRoot,
+  writeFiles,
+};

--- a/tests/smoke/test/compiler-corpus.test.cjs
+++ b/tests/smoke/test/compiler-corpus.test.cjs
@@ -1,0 +1,134 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  commonJsProject,
+  createProject,
+  runNode,
+  spawn,
+  ttscBin,
+} = require("./_helpers.cjs");
+
+const compilerProjects = [
+  {
+    name: "single file compatibility mode writes to explicit outDir",
+    root: () =>
+      commonJsProject({
+        "src/main.ts": `export const value: number = 7;\nconsole.log(value);\n`,
+      }),
+    run(root) {
+      const result = spawn(ttscBin, ["--cwd", root, "--outDir", "single", "src/main.ts"], {
+        cwd: root,
+      });
+      assert.equal(result.status, 0, result.stderr);
+      const output = path.join(root, "single", "src", "main.js");
+      assert.equal(fs.existsSync(output), true);
+      const run = runNode(output, { cwd: root });
+      assert.equal(run.status, 0, run.stderr);
+      assert.equal(run.stdout.trim(), "7");
+    },
+  },
+  {
+    name: "explicit project path can live outside cwd root",
+    root: () =>
+      createProject({
+        "configs/tsconfig.app.json": JSON.stringify({
+          compilerOptions: {
+            target: "ES2022",
+            module: "commonjs",
+            strict: true,
+            outDir: "../dist/app",
+            rootDir: "../src",
+          },
+          include: ["../src"],
+        }),
+        "src/main.ts": `export const message: string = "explicit-project";\nconsole.log(message);\n`,
+      }),
+    run(root) {
+      const result = spawn(
+        ttscBin,
+        ["--cwd", root, "--project", "configs/tsconfig.app.json", "--emit"],
+        { cwd: root },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(
+        fs.readFileSync(path.join(root, "dist", "app", "main.js"), "utf8").includes("explicit-project"),
+        true,
+      );
+    },
+  },
+  {
+    name: "noEmit mode blocks output writes even when sources are valid",
+    root: () =>
+      commonJsProject({
+        "src/main.ts": `export const value: string = "noemit";\n`,
+      }),
+    run(root) {
+      const result = spawn(ttscBin, ["--cwd", root, "--noEmit"], { cwd: root });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), false);
+    },
+  },
+  {
+    name: "emitDeclarationOnly writes declarations without JavaScript",
+    root: () =>
+      commonJsProject(
+        {
+          "src/main.ts": `export type Pair = [string, number];\nexport interface Bag { pair: Pair }\n`,
+        },
+        {
+          compilerOptions: {
+            declaration: true,
+            emitDeclarationOnly: true,
+          },
+        },
+      ),
+    run(root) {
+      const result = spawn(ttscBin, ["--cwd", root], { cwd: root });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(fs.existsSync(path.join(root, "dist", "main.d.ts")), true);
+      assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), false);
+    },
+  },
+  {
+    name: "sourceMap emits a JavaScript map next to output",
+    root: () =>
+      commonJsProject(
+        {
+          "src/main.ts": `export const mapped = () => "map";\n`,
+        },
+        {
+          compilerOptions: {
+            sourceMap: true,
+          },
+        },
+      ),
+    run(root) {
+      const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(fs.existsSync(path.join(root, "dist", "main.js.map")), true);
+    },
+  },
+  {
+    name: "syntax diagnostics stop emit before JavaScript is written",
+    root: () =>
+      commonJsProject({
+        "src/main.ts": `export const broken = ;\n`,
+      }),
+    run(root) {
+      const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /Expression expected|Declaration or statement expected/);
+      assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), false);
+    },
+  },
+];
+
+for (const project of compilerProjects) {
+  test(`compiler corpus: ${project.name}`, () => {
+    const root = project.root();
+    project.run(root);
+  });
+}

--- a/tests/smoke/test/compiler-corpus.test.cjs
+++ b/tests/smoke/test/compiler-corpus.test.cjs
@@ -124,6 +124,33 @@ const compilerProjects = [
       assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), false);
     },
   },
+  {
+    name: "semantic diagnostics stop emit before JavaScript is written",
+    root: () =>
+      commonJsProject({
+        "src/main.ts": `const value: string = 123;\nconsole.log(value);\n`,
+      }),
+    run(root) {
+      const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /Type 'number' is not assignable to type 'string'/);
+      assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), false);
+    },
+  },
+  {
+    name: "invalid tsconfig is rejected before emit",
+    root: () =>
+      createProject({
+        "tsconfig.json": `{"compilerOptions":{"target":"ES2022","module":"commonjs","strict":true,`,
+        "src/main.ts": `console.log("invalid-config-should-not-emit");\n`,
+      }),
+    run(root) {
+      const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /Unexpected end of JSON input|Expected/);
+      assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), false);
+    },
+  },
 ];
 
 for (const project of compilerProjects) {

--- a/tests/smoke/test/plugin-corpus.test.cjs
+++ b/tests/smoke/test/plugin-corpus.test.cjs
@@ -1,0 +1,126 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  commonJsProject,
+  spawn,
+  ttscBin,
+} = require("./_helpers.cjs");
+
+function pluginProject(pluginEntries, pluginFiles) {
+  return commonJsProject(
+    {
+      ...pluginFiles,
+      "src/main.ts": `export const value: string = "plugin";\n`,
+    },
+    {
+      compilerOptions: {
+        plugins: pluginEntries,
+      },
+    },
+  );
+}
+
+test("plugin corpus: default export factory is accepted", () => {
+  const root = pluginProject(
+    [{ transform: "./plugins/default.cjs", label: "default-shape" }],
+    {
+      "plugins/default.cjs": `
+        exports.default = (config) => ({
+          name: "default-export",
+          transformOutput(context) {
+            return context.code + "\\n// " + config.label + ":" + context.command;
+          },
+        });
+      `,
+    },
+  );
+
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    fs.readFileSync(path.join(root, "dist", "main.js"), "utf8"),
+    /\/\/ default-shape:build\s*$/,
+  );
+});
+
+test("plugin corpus: createTtscPlugin export is accepted", () => {
+  const root = pluginProject(
+    [{ transform: "./plugins/create.cjs" }],
+    {
+      "plugins/create.cjs": `
+        exports.createTtscPlugin = () => ({
+          name: "create-export",
+          transformOutput(context) {
+            return "// create:" + context.command + "\\n" + context.code;
+          },
+        });
+      `,
+    },
+  );
+
+  const result = spawn(
+    ttscBin,
+    ["transform", "--cwd", root, "--file", "src/main.ts"],
+    { cwd: root },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^\/\/ create:transform\n/);
+});
+
+test("plugin corpus: conflicting native modes fail before build", () => {
+  const root = pluginProject(
+    [
+      { transform: "./plugins/a.cjs" },
+      { transform: "./plugins/b.cjs" },
+    ],
+    {
+      "plugins/a.cjs": `module.exports = { name: "a", native: { mode: "alpha" } };\n`,
+      "plugins/b.cjs": `module.exports = { name: "b", native: { mode: "beta" } };\n`,
+    },
+  );
+
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /multiple native plugin modes requested/);
+});
+
+test("plugin corpus: invalid plugin export reports the bad specifier", () => {
+  const root = pluginProject(
+    [{ transform: "./plugins/invalid.cjs" }],
+    {
+      "plugins/invalid.cjs": `module.exports = 123;\n`,
+    },
+  );
+
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not export a valid ttsc plugin/);
+});
+
+test("plugin corpus: transform --out receives transformOutput text", () => {
+  const root = pluginProject(
+    [{ transform: "./plugins/out.cjs" }],
+    {
+      "plugins/out.cjs": `
+        module.exports = {
+          name: "out",
+          transformOutput(context) {
+            return context.code + "\\n// out:" + context.command;
+          },
+        };
+      `,
+    },
+  );
+  const output = path.join(root, "custom", "main.js");
+
+  const result = spawn(
+    ttscBin,
+    ["transform", "--cwd", root, "--file", "src/main.ts", "--out", output],
+    { cwd: root },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(fs.readFileSync(output, "utf8"), /\/\/ out:transform\s*$/);
+});

--- a/tests/smoke/test/runner-corpus.test.cjs
+++ b/tests/smoke/test/runner-corpus.test.cjs
@@ -1,4 +1,6 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const test = require("node:test");
 
 const {
@@ -76,13 +78,107 @@ test("runner corpus: explicit project option overrides entry discovery", () => {
   assert.equal(result.stdout.trim(), "explicit-runner-project");
 });
 
-test("runner corpus: diagnostics prevent entry execution", () => {
+test("runner corpus: ttsx executes the intended entrypoint and side effects", () => {
   const root = commonJsProject({
-    "src/main.ts": `const message: string = 123;\nconsole.log("should-not-run", message);\n`,
-  });
+    "src/main.ts": `
+      declare const process: {
+        argv: string[];
+        cwd(): string;
+        env: { TTSX_MARKER?: string };
+      };
+      declare function require(name: string): {
+        writeFileSync(file: string, text: string): void;
+      };
 
-  const result = spawn(ttsxBin, ["--cwd", root, "src/main.ts"], { cwd: root });
+      const fs = require("node:fs");
+      const marker = process.env.TTSX_MARKER;
+      if (!marker) throw new Error("missing marker path");
+      fs.writeFileSync(marker, JSON.stringify({
+        argv: process.argv.slice(2),
+        cwd: process.cwd(),
+        executed: true,
+      }));
+      console.log("ttsx-intended-execution");
+    `,
+  });
+  const marker = path.join(root, "runner-marker.json");
+
+  const result = spawn(
+    ttsxBin,
+    ["--cwd", root, "src/main.ts", "--", "--mode", "probe"],
+    {
+      cwd: root,
+      env: {
+        TTSX_MARKER: marker,
+      },
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "ttsx-intended-execution");
+  assert.deepEqual(JSON.parse(fs.readFileSync(marker, "utf8")), {
+    argv: ["--mode", "probe"],
+    cwd: root,
+    executed: true,
+  });
+});
+
+test("runner corpus: type-check diagnostics prevent entry execution", () => {
+  const root = commonJsProject({
+    "src/main.ts": `
+      declare const process: { env: { TTSX_MARKER?: string } };
+      declare function require(name: string): {
+        writeFileSync(file: string, text: string): void;
+      };
+
+      const fs = require("node:fs");
+      const marker = process.env.TTSX_MARKER;
+      if (!marker) throw new Error("missing marker path");
+      fs.writeFileSync(marker, "executed");
+      const message: string = 123;
+      console.log("should-not-run", message);
+    `,
+  });
+  const marker = path.join(root, "type-error-marker.txt");
+
+  const result = spawn(ttsxBin, ["--cwd", root, "src/main.ts"], {
+    cwd: root,
+    env: {
+      TTSX_MARKER: marker,
+    },
+  });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /project check failed/);
+  assert.match(result.stderr, /Type 'number' is not assignable to type 'string'/);
   assert.doesNotMatch(result.stdout, /should-not-run/);
+  assert.equal(fs.existsSync(marker), false);
+});
+
+test("runner corpus: invalid tsconfig prevents entry execution", () => {
+  const root = createProject({
+    "tsconfig.json": `{"compilerOptions":{"target":"ES2022","module":"commonjs","strict":true,`,
+    "src/main.ts": `
+      declare const process: { env: { TTSX_MARKER?: string } };
+      declare function require(name: string): {
+        writeFileSync(file: string, text: string): void;
+      };
+
+      const fs = require("node:fs");
+      const marker = process.env.TTSX_MARKER;
+      if (!marker) throw new Error("missing marker path");
+      fs.writeFileSync(marker, "executed");
+      console.log("invalid-config-should-not-run");
+    `,
+  });
+  const marker = path.join(root, "invalid-config-marker.txt");
+
+  const result = spawn(ttsxBin, ["--cwd", root, "src/main.ts"], {
+    cwd: root,
+    env: {
+      TTSX_MARKER: marker,
+    },
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unexpected end of JSON input|Expected/);
+  assert.doesNotMatch(result.stdout, /invalid-config-should-not-run/);
+  assert.equal(fs.existsSync(marker), false);
 });

--- a/tests/smoke/test/runner-corpus.test.cjs
+++ b/tests/smoke/test/runner-corpus.test.cjs
@@ -1,0 +1,88 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  commonJsProject,
+  createProject,
+  spawn,
+  ttsxBin,
+} = require("./_helpers.cjs");
+
+test("runner corpus: .cts entry executes through CommonJS output", () => {
+  const root = createProject({
+    "package.json": JSON.stringify({ type: "module" }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.cts": `const message: string = "cts-runner-ok";\nconsole.log(message);\n`,
+  });
+
+  const result = spawn(ttsxBin, ["--cwd", root, "src/main.cts"], { cwd: root });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "cts-runner-ok");
+});
+
+test("runner corpus: nested entry discovers nearest package tsconfig", () => {
+  const root = createProject({
+    "packages/app/tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "packages/app/src/main.ts": `const message: string = "nested-tsconfig-ok";\nconsole.log(message);\n`,
+  });
+
+  const result = spawn(ttsxBin, ["--cwd", root, "packages/app/src/main.ts"], {
+    cwd: root,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "nested-tsconfig-ok");
+});
+
+test("runner corpus: explicit project option overrides entry discovery", () => {
+  const root = createProject({
+    "configs/app.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "../dist",
+        rootDir: "../src",
+      },
+      include: ["../src"],
+    }),
+    "src/main.ts": `const message: string = "explicit-runner-project";\nconsole.log(message);\n`,
+  });
+
+  const result = spawn(
+    ttsxBin,
+    ["--cwd", root, "--project", "configs/app.json", "src/main.ts"],
+    { cwd: root },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "explicit-runner-project");
+});
+
+test("runner corpus: diagnostics prevent entry execution", () => {
+  const root = commonJsProject({
+    "src/main.ts": `const message: string = 123;\nconsole.log("should-not-run", message);\n`,
+  });
+
+  const result = spawn(ttsxBin, ["--cwd", root, "src/main.ts"], { cwd: root });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /project check failed/);
+  assert.doesNotMatch(result.stdout, /should-not-run/);
+});

--- a/tests/smoke/test/toolchain.test.cjs
+++ b/tests/smoke/test/toolchain.test.cjs
@@ -96,6 +96,158 @@ test("ttsc JS plugin transformOutput composes with native emit", () => {
   assert.match(result.stdout, /exports\.value/);
 });
 
+test("ttsc build applies chained plugins and skips disabled plugin entries", () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+        plugins: [
+          { transform: "./plugins/first.cjs", label: "first" },
+          { transform: "./plugins/disabled.cjs", enabled: false },
+          { transform: "./plugins/second.cjs" },
+        ],
+      },
+      include: ["src"],
+    }),
+    "plugins/first.cjs": `
+      const { definePlugin } = require("ttsc");
+      module.exports = definePlugin((config) => ({
+        name: "first",
+        transformOutput(context) {
+          return context.code + "\\n// " + config.label + ":" + context.command;
+        },
+      }));
+    `,
+    "plugins/second.cjs": `
+      exports.plugin = {
+        name: "second",
+        transformOutput(context) {
+          return context.code + "\\n// second:" + context.command;
+        },
+      };
+    `,
+    "plugins/disabled.cjs": `
+      module.exports = {
+        name: "disabled",
+        transformOutput(context) {
+          return context.code + "\\n// disabled";
+        },
+      };
+    `,
+    "src/main.ts": `export const value: string = "chain";\n`,
+  });
+
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+  assert.equal(result.status, 0, result.stderr);
+  const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+  assert.match(js, /\/\/ first:build\n\/\/ second:build\s*$/);
+  assert.doesNotMatch(js, /disabled/);
+});
+
+test("ttsc transform writes --out and honors auto-detected jsconfig", () => {
+  const root = createProject({
+    "jsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const answer: number = 42;\n`,
+  });
+  const out = path.join(root, "out", "main.js");
+
+  const result = spawn(
+    ttscBin,
+    ["transform", "--cwd", root, "--file", "src/main.ts", "--out", out],
+    { cwd: root },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const js = fs.readFileSync(out, "utf8");
+  assert.match(js, /exports\.answer/);
+});
+
+test("ttsc check resolves paths mappings under current TypeScript-Go policy", () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ES2022",
+        moduleResolution: "bundler",
+        strict: true,
+        paths: {
+          "@lib/*": ["./lib/*"],
+          "exact-lib": ["./lib/exact.ts"],
+        },
+      },
+      include: ["src", "lib"],
+    }),
+    "lib/exact.ts": `export const exact = "exact" as const;\n`,
+    "lib/tool.ts": `export const tool = "tool" as const;\n`,
+    "src/main.ts": `
+      import { exact } from "exact-lib";
+      import { tool } from "@lib/tool";
+      export const joined: string = exact + ":" + tool;
+    `,
+  });
+
+  const result = spawn(ttscBin, ["check", "--cwd", root], { cwd: root });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("ttsc emits declaration files when the project requests them", () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        declaration: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export interface Box<T> { value: T }\nexport const box = <T>(value: T): Box<T> => ({ value });\n`,
+  });
+
+  const result = spawn(ttscBin, ["--cwd", root], { cwd: root });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), true);
+  assert.equal(fs.existsSync(path.join(root, "dist", "main.d.ts")), true);
+});
+
+test("ttsc programmatic transformAsync uses the resolved native binary", async () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const value: string = "api";\n`,
+  });
+  const { transformAsync } = require("ttsc");
+
+  const js = await transformAsync({
+    binary: nativeBinary,
+    cwd: root,
+    file: path.join(root, "src", "main.ts"),
+  });
+  assert.match(js, /exports\.value/);
+});
+
 test("ttsc blocks semantic diagnostics before emit", () => {
   const root = createProject({
     "tsconfig.json": JSON.stringify({
@@ -117,6 +269,27 @@ test("ttsc blocks semantic diagnostics before emit", () => {
   assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), false);
 });
 
+test("ttsc reports bind diagnostics through the tsgo diagnostic pipeline", () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `let value = 1;\nlet value = 2;\nconsole.log(value);\n`,
+  });
+
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Cannot redeclare block-scoped variable 'value'/);
+  assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), false);
+});
+
 test("ttsx runs a CommonJS TypeScript entry through ttsc", () => {
   const root = createProject({
     "tsconfig.json": JSON.stringify({
@@ -135,6 +308,86 @@ test("ttsx runs a CommonJS TypeScript entry through ttsc", () => {
   const result = spawn(ttsxBin, ["--cwd", root, "src/main.ts"], { cwd: root });
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout.trim(), "runner-ok");
+});
+
+test("ttsx forwards argv after -- and runs preload modules", () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "preload.cjs": `globalThis.__ttsxPreload = "loaded";\n`,
+    "src/main.ts": `
+      declare const process: { argv: string[] };
+      console.log(JSON.stringify({
+        preload: (globalThis as any).__ttsxPreload,
+        argv: process.argv.slice(2),
+      }));
+    `,
+  });
+
+  const result = spawn(
+    ttsxBin,
+    ["--cwd", root, "-r", "./preload.cjs", "src/main.ts", "--", "--flag", "value"],
+    { cwd: root },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout.trim()), {
+    preload: "loaded",
+    argv: ["--flag", "value"],
+  });
+});
+
+test("ttsx runs an ESM TypeScript entry through the emitted project path", () => {
+  const root = createProject({
+    "package.json": JSON.stringify({ type: "module" }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ES2022",
+        moduleResolution: "bundler",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/helper.ts": `export const message: string = "esm-runner-ok";\n`,
+    "src/main.ts": `import { message } from "./helper";\nconsole.log(message);\n`,
+  });
+
+  const result = spawn(ttsxBin, ["--cwd", root, "src/main.ts"], { cwd: root });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "esm-runner-ok");
+});
+
+test("ttsx runs an .mts entry and resolves emitted .mjs imports", () => {
+  const root = createProject({
+    "package.json": JSON.stringify({ type: "module" }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/helper.mts": `export const message: string = "mts-runner-ok";\n`,
+    "src/main.mts": `import { message } from "./helper.mjs";\nconsole.log(message);\n`,
+  });
+
+  const result = spawn(ttsxBin, ["--cwd", root, "src/main.mts"], { cwd: root });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "mts-runner-ok");
 });
 
 test("local native binary was built for the test run", () => {

--- a/tests/smoke/test/transform-projects.test.cjs
+++ b/tests/smoke/test/transform-projects.test.cjs
@@ -1,0 +1,156 @@
+const assert = require("node:assert/strict");
+const child_process = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  copyProject,
+  runNode,
+  spawn,
+  ttscBin,
+  workspaceRoot,
+} = require("./_helpers.cjs");
+
+function transformToFile(root, source, out, options = {}) {
+  const result = spawn(
+    ttscBin,
+    ["transform", "--cwd", root, "--file", source, "--out", out],
+    { cwd: root, env: options.env },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  return fs.readFileSync(out, "utf8");
+}
+
+const transformProjects = [
+  {
+    name: "ts-node hello-world style CommonJS transform executes",
+    fixture: "transform-hello",
+    source: "src/hello.ts",
+    out: "out/hello.js",
+    assert(root, out) {
+      const run = runNode(out, { cwd: root });
+      assert.equal(run.status, 0, run.stderr);
+      assert.equal(run.stdout.trim(), "Hello, world!");
+    },
+  },
+  {
+    name: "ts-node ext-cts style .cts transform executes as .cjs",
+    fixture: "transform-cts",
+    source: "src/main.cts",
+    out: "out/main.cjs",
+    assert(root, out) {
+      const run = runNode(out, { cwd: root });
+      assert.equal(run.status, 0, run.stderr);
+      assert.equal(run.stdout.trim(), "cts-transform");
+    },
+  },
+  {
+    name: "ts-node ext-mts style .mts transform executes as .mjs",
+    fixture: "transform-mts",
+    source: "src/main.mts",
+    out: "out/main.mjs",
+    assert(root, out) {
+      const run = runNode(out, { cwd: root });
+      assert.equal(run.status, 0, run.stderr);
+      assert.equal(run.stdout.trim(), "mts-transform");
+    },
+  },
+  {
+    name: "tsx file transform preserves JSX lowering settings",
+    fixture: "transform-tsx",
+    source: "src/view.tsx",
+    out: "out/view.js",
+    assert(_root, out) {
+      const js = fs.readFileSync(out, "utf8");
+      assert.match(js, /h\("div", null\)/);
+    },
+  },
+  {
+    name: "file paths with spaces transform without shell quoting assumptions",
+    fixture: "transform-space",
+    source: "src/throw error.ts",
+    out: "out/throw error.js",
+    assert(root, out) {
+      const run = runNode(out, { cwd: root });
+      assert.equal(run.status, 0, run.stderr);
+      assert.equal(run.stdout.trim(), "space-ok");
+    },
+  },
+  {
+    name: "transform respects tsconfig extends chain",
+    fixture: "transform-extends",
+    source: "src/main.ts",
+    out: "out/main.js",
+    assert(root, out) {
+      const run = runNode(out, { cwd: root });
+      assert.equal(run.status, 0, run.stderr);
+      assert.equal(run.stdout.trim(), "extends-transform");
+    },
+  },
+];
+
+for (const project of transformProjects) {
+  test(`transform project corpus: ${project.name}`, () => {
+    const root = copyProject(project.fixture);
+    const out = path.join(root, project.out);
+    transformToFile(root, project.source, out);
+    project.assert(root, out);
+  });
+}
+
+test("transform project corpus: transform diagnostics fail before writing output", () => {
+  const root = copyProject("transform-diagnostic");
+  const out = path.join(root, "out", "main.js");
+  const result = spawn(
+    ttscBin,
+    ["transform", "--cwd", root, "--file", "src/main.ts", "--out", out],
+    { cwd: root },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /Argument of type 'number' is not assignable to parameter of type 'string'/,
+  );
+  assert.equal(fs.existsSync(out), false);
+});
+
+test("transform project corpus: Go native transformer library backs plugin-selected binary", () => {
+  const transformerBinary = buildGoTransformer();
+  const root = copyProject("go-native-transformer");
+  const out = path.join(root, "out", "main.js");
+  transformToFile(root, "src/main.ts", out, {
+    env: {
+      TTSC_GO_TRANSFORMER_BINARY: transformerBinary,
+    },
+  });
+  const js = fs.readFileSync(out, "utf8");
+  assert.match(js, /GO NATIVE TRANSFORMER/);
+  const run = runNode(out, { cwd: root });
+  assert.equal(run.status, 0, run.stderr);
+  assert.equal(run.stdout.trim(), "GO NATIVE TRANSFORMER");
+});
+
+function buildGoTransformer() {
+  const root = path.join(workspaceRoot, "tests", "go-transformer");
+  const output = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-go-transformer-")),
+    process.platform === "win32" ? "ttsc-go-transformer.exe" : "ttsc-go-transformer",
+  );
+  const result = child_process.spawnSync(
+    "bash",
+    [
+      "-c",
+      `export PATH="$HOME/go-sdk/go/bin:$PATH"; go build -o ${JSON.stringify(output)} ./cmd/ttsc-go-transformer`,
+    ],
+    {
+      cwd: root,
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 64,
+      windowsHide: true,
+    },
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return output;
+}


### PR DESCRIPTION
This pull request introduces several significant improvements to the build, test, and release workflows, updates to package metadata for clearer separation between source and published outputs, and some important codebase enhancements and bug fixes for better correctness and maintainability. The changes also expand and clarify documentation, especially around testing and review processes.

**Workflow automation and release process:**

* Added GitHub Actions workflows for build (`build.yml`), test (`test.yml`), and release (`release.yml`) to automate CI/CD processes, including npm publishing and changelog generation. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R38) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R1-R42) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R36)
* Introduced new root scripts and release commands in `package.json` and `next.bash` for streamlined builds, tests, and versioned publishing (`package:latest`, `package:next`, `release`). [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R11) [[2]](diffhunk://#diff-7d6b9fa4a65f216e85dcf25d64cfdae5bb3d7dcd972a7ee395cdeac34246a732R1-R4)

**Package metadata and monorepo export contract:**

* Changed `ttsc` and `ttsx` package metadata to distinguish between monorepo source exports (pointing at `src/`) and publish exports (pointing at built `lib/`), including updates to `exports`, `main`, `types`, and `publishConfig`. Added tests to verify this separation. [[1]](diffhunk://#diff-32d1b82feb94b1021cbf5c518154da28a99b14b2f844ef97a43d167a7ea6414aL5-R16) [[2]](diffhunk://#diff-32d1b82feb94b1021cbf5c518154da28a99b14b2f844ef97a43d167a7ea6414aL65-R79) [[3]](diffhunk://#diff-e0cbd3c7dbf4ec2c868fe7939c1035163600b85db06b759e124cc86ad5410fbcR1-R48)
* Updated the launcher and platform scripts to reflect the new build command naming and paths. [[1]](diffhunk://#diff-35c6a9f697bb3968ed9a3d74e84bfb23d049da12fbc1bf61e4c1262272a2f5aaL16-R16) [[2]](diffhunk://#diff-b47420835b8d060b71f3d4a94543e342e9cd531bf2c166f424b87e85f37ef787L16-R16)

**Codebase correctness and API improvements:**

* Refactored diagnostic collection in the Go driver to use `GetDiagnosticsOfAnyProgram` for more accurate and consistent diagnostics, matching upstream projects.
* Improved file extension handling by centralizing JavaScript output detection in both Go and TypeScript code, ensuring all relevant JS file types are processed correctly. [[1]](diffhunk://#diff-3265a705d1ee8b33adcbeace105623b74c78f740723902f3c0aa61d3733e4428L95-R95) [[2]](diffhunk://#diff-3265a705d1ee8b33adcbeace105623b74c78f740723902f3c0aa61d3733e4428R158-R166) [[3]](diffhunk://#diff-dbbd2b6b66d275903dffea76f052c3947e7b43f91ce87a39e541690ae19596a4L388-R391) [[4]](diffhunk://#diff-dbbd2b6b66d275903dffea76f052c3947e7b43f91ce87a39e541690ae19596a4R409-R412)
* Fixed project config resolution to use Node's `createRequire` for better reliability with `extends` fields. [[1]](diffhunk://#diff-b040e903f1ef88e90e9d544116b7df28e65751b8fb3998209c43136c53b7696bR3) [[2]](diffhunk://#diff-b040e903f1ef88e90e9d544116b7df28e65751b8fb3998209c43136c53b7696bR187-R191)
* Updated API to always pass the resolved `tsconfig` path, removing redundant logic. [[1]](diffhunk://#diff-dbbd2b6b66d275903dffea76f052c3947e7b43f91ce87a39e541690ae19596a4R190-L192) [[2]](diffhunk://#diff-dbbd2b6b66d275903dffea76f052c3947e7b43f91ce87a39e541690ae19596a4L252-R256)

**Documentation and review discipline:**

* Expanded `AGENTS.md` and `REVIEW-CYCLES.md` with new sections on test corpus structure, reference repositories, required commands, and detailed review cycles. Clarified the importance of maintaining a diverse and comprehensive test suite. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R20-R31) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L39-L44) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R96-R98) [[4]](diffhunk://#diff-3731bfe15e05d131b7370ea85bb9e45ae615e03f2faa780245555f4c585571feR48-R103)

These changes collectively improve the project's reliability, maintainability, and release confidence, and provide a solid foundation for future development.