### PR TITLE
feat(ttsc): diet binary size.

### DIFF
--- a/config/package.json
+++ b/config/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
   "name": "@ttsc/config",
-  "version": "0.4.3-dev.20260426-2"
+  "version": "0.4.3-dev.20260426-3"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/station",
-  "version": "0.4.3-dev.20260426-2",
+  "version": "0.4.3-dev.20260426-3",
   "description": "Standalone TypeScript-Go compiler and runtime workspace.",
   "scripts": {
     "build": "pnpm --filter ttsc build && pnpm --filter ttsc go:build && pnpm --filter=\"./packages/ttsc-*\" -r build",

--- a/packages/ttsc-darwin-arm64/package.json
+++ b/packages/ttsc-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/darwin-arm64",
-  "version": "0.4.3-dev.20260426-2",
+  "version": "0.4.3-dev.20260426-3",
   "description": "macOS arm64 native binary for ttsc.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/packages/ttsc-darwin-x64/package.json
+++ b/packages/ttsc-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/darwin-x64",
-  "version": "0.4.3-dev.20260426-2",
+  "version": "0.4.3-dev.20260426-3",
   "description": "macOS x64 native binary for ttsc.",
   "os": ["darwin"],
   "cpu": ["x64"],

--- a/packages/ttsc-linux-arm/package.json
+++ b/packages/ttsc-linux-arm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/linux-arm",
-  "version": "0.4.3-dev.20260426-2",
+  "version": "0.4.3-dev.20260426-3",
   "description": "Linux arm native binary for ttsc.",
   "os": ["linux"],
   "cpu": ["arm"],

--- a/packages/ttsc-linux-arm64/package.json
+++ b/packages/ttsc-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/linux-arm64",
-  "version": "0.4.3-dev.20260426-2",
+  "version": "0.4.3-dev.20260426-3",
   "description": "Linux arm64 native binary for ttsc.",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/packages/ttsc-linux-x64/package.json
+++ b/packages/ttsc-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/linux-x64",
-  "version": "0.4.3-dev.20260426-2",
+  "version": "0.4.3-dev.20260426-3",
   "description": "Linux x64 native binary for ttsc.",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/packages/ttsc-win32-arm64/package.json
+++ b/packages/ttsc-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/win32-arm64",
-  "version": "0.4.3-dev.20260426-2",
+  "version": "0.4.3-dev.20260426-3",
   "description": "Windows arm64 native binary for ttsc.",
   "os": ["win32"],
   "cpu": ["arm64"],

--- a/packages/ttsc-win32-x64/package.json
+++ b/packages/ttsc-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/win32-x64",
-  "version": "0.4.3-dev.20260426-2",
+  "version": "0.4.3-dev.20260426-3",
   "description": "Windows x64 native binary for ttsc.",
   "os": ["win32"],
   "cpu": ["x64"],

--- a/packages/ttsc/cmd/platform/main.go
+++ b/packages/ttsc/cmd/platform/main.go
@@ -76,8 +76,8 @@ which resolve the consuming project's @typescript/native-preview binary and any
 plugin-selected native sidecar.
 
 Usage:
-  ttsc-platform --version
-  ttsc-platform demo --type=string
+  ttsc --version
+  ttsc demo --type=string
 `))
 }
 

--- a/packages/ttsc/cmd/platform/main.go
+++ b/packages/ttsc/cmd/platform/main.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+)
+
+var (
+	version = "0.0.0-dev"
+	commit  = "dev"
+	date    = "unknown"
+)
+
+var (
+	stdout io.Writer = os.Stdout
+	stderr io.Writer = os.Stderr
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	if len(args) == 0 {
+		printHelp(stdout)
+		return 0
+	}
+
+	switch args[0] {
+	case "-h", "--help", "help":
+		printHelp(stdout)
+		return 0
+	case "-v", "--version", "version":
+		printVersion(stdout)
+		return 0
+	case "demo":
+		return runDemo(args[1:])
+	case "build", "check", "transform":
+		fmt.Fprintf(
+			stderr,
+			"ttsc platform helper: %s is provided by the JavaScript ttsc CLI using the consuming project's @typescript/native-preview, or by a plugin-selected native sidecar.\n",
+			args[0],
+		)
+		return 2
+	default:
+		fmt.Fprintf(stderr, "ttsc platform helper: unknown command %q\n", args[0])
+		fmt.Fprintln(stderr, `ttsc platform helper: run "ttsc --help" through the JavaScript CLI for compiler usage.`)
+		return 2
+	}
+}
+
+func printVersion(w io.Writer) {
+	fmt.Fprintf(
+		w,
+		"ttsc platform helper %s (commit %s, built %s, %s/%s, go %s)\n",
+		version,
+		commit,
+		date,
+		runtime.GOOS,
+		runtime.GOARCH,
+		runtime.Version(),
+	)
+}
+
+func printHelp(w io.Writer) {
+	fmt.Fprintln(w, strings.TrimSpace(`
+ttsc platform helper.
+
+This binary is a small compatibility helper shipped by @ttsc platform packages.
+Compiler and runner commands are provided by the JavaScript ttsc/ttsx launchers,
+which resolve the consuming project's @typescript/native-preview binary and any
+plugin-selected native sidecar.
+
+Usage:
+  ttsc-platform --version
+  ttsc-platform demo --type=string
+`))
+}
+
+func runDemo(args []string) int {
+	fs := flag.NewFlagSet("demo", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	typ := fs.String("type", "string", "atomic type to simulate")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	arrow, err := demoArrow(*typ)
+	if err != nil {
+		fmt.Fprintf(stderr, "ttsc platform helper demo: %v\n", err)
+		return 2
+	}
+
+	fmt.Fprintf(stdout, "// demo<%s> -> emitted by ttsc platform helper %s\n", *typ, version)
+	fmt.Fprintln(stdout, arrow)
+	return 0
+}
+
+func demoArrow(name string) (string, error) {
+	switch strings.ToLower(name) {
+	case "any":
+		return "(input) => true", nil
+	case "boolean":
+		return `(input) => "boolean" === typeof input`, nil
+	case "number":
+		return `(input) => "number" === typeof input`, nil
+	case "bigint":
+		return `(input) => "bigint" === typeof input`, nil
+	case "string", "":
+		return `(input) => "string" === typeof input`, nil
+	default:
+		return "", fmt.Errorf("unknown --type value %q (want: string|number|boolean|bigint|any)", name)
+	}
+}

--- a/packages/ttsc/package.json
+++ b/packages/ttsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttsc",
-  "version": "0.4.3-dev.20260426-2",
+  "version": "0.4.3-dev.20260426-3",
   "description": "General-purpose TypeScript-Go compiler, plugin host, and runtime.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/ttsc/src/index.ts
+++ b/packages/ttsc/src/index.ts
@@ -4,8 +4,8 @@
  * Exports:
  *   - tsgo helpers (`resolveTsgo`, …) — resolve the consuming project's
  *     `@typescript/native-preview` compiler binary.
- *   - platform helpers (`resolveBinary`, `installHint`, …) — legacy helpers
- *     for plugin-selected native sidecars.
+ *   - platform helpers (`resolveBinary`, `installHint`, …) — compatibility
+ *     helper resolution for commands such as `ttsc demo`.
  *   - programmatic API (`transform`, `build`, `check`, `version`) — a thin
  *     TS wrapper around the consumer `tsgo` binary plus JS output-plugin
  *     hooks. Adapters never have to shell out themselves; they call these

--- a/packages/ttsc/src/platform.ts
+++ b/packages/ttsc/src/platform.ts
@@ -1,18 +1,22 @@
 /**
- * Platform detection and binary resolution for ttsc.
+ * Platform detection and helper-binary resolution for ttsc.
  *
  * This is the tested implementation used by the ttsc launcher after build.
  * Keep it pure and dependency-free so it can be unit-tested without spawning
  * any child process.
  *
- * Resolution order:
+ * The platform packages now ship a small compatibility helper, not the
+ * TypeScript-Go compiler. Compiler calls resolve the consuming project's
+ * `@typescript/native-preview` through `tsgo.ts`.
+ *
+ * Helper resolution order:
  *
  *   1. `TTSC_BINARY` environment variable (absolute path). Highest priority —
  *      lets local devs or CI point at an ad-hoc build without touching
  *      node_modules.
  *   2. `@ttsc/{platform}-{arch}/bin/ttsc{.exe}` optional dependency.
- *      Standard distribution path.
- *   3. A package-local `native/ttsc-native` binary. Used by this
+ *      Standard distribution path for compatibility helper commands.
+ *   3. A package-local `native/ttsc-native` helper. Used by this
  *      repository's local `pnpm run build` output before the
  *      platform packages exist on npm.
  *
@@ -51,7 +55,7 @@ export function platformKey(opts: ResolveOptions = {}): string {
   return `${platform}-${arch}`;
 }
 
-/** Binary filename for the current platform (`.exe` on Windows, else none). */
+/** Helper binary filename for the current platform (`.exe` on Windows, else none). */
 export function binaryName(opts: ResolveOptions = {}): string {
   const platform = opts.platform ?? process.platform;
   return platform === "win32" ? "ttsc.exe" : "ttsc";
@@ -85,7 +89,7 @@ export function isSupported(key: string): boolean {
 }
 
 /**
- * Resolve an absolute path to the ttsc binary using the documented priority
+ * Resolve an absolute path to the ttsc helper using the documented priority
  * order. Returns `null` when every strategy fails — the launcher then prints
  * the install hint and exits non-zero.
  */
@@ -127,7 +131,7 @@ export function installHint(opts: ResolveOptions = {}): string {
   const pkg = `@ttsc/${key}`;
   const supported = SUPPORTED_PLATFORMS.join(", ");
   return [
-    `ttsc: platform-specific binary not found (${pkg}).`,
+    `ttsc: platform-specific helper binary not found (${pkg}).`,
     `Platform: ${opts.platform ?? process.platform}/${opts.arch ?? process.arch}.`,
     ``,
     `Resolution order:`,

--- a/scripts/build-platform-package.cjs
+++ b/scripts/build-platform-package.cjs
@@ -27,7 +27,7 @@ const pathValue = fs.existsSync(goRoot)
   : process.env.PATH;
 
 console.log(`Building ${manifest.name} -> ${path.relative(root, outFile)}`);
-cp.execFileSync("go", ["build", "-o", outFile, "./cmd/ttsc"], {
+cp.execFileSync("go", ["build", "-o", outFile, "./cmd/platform"], {
   cwd: source,
   env: {
     ...process.env,

--- a/scripts/go.cjs
+++ b/scripts/go.cjs
@@ -15,7 +15,7 @@ if (command === "build-native") {
     "build",
     "-o",
     path.join("native", process.platform === "win32" ? "ttsc-native.exe" : "ttsc-native"),
-    "./cmd/ttsc",
+    "./cmd/platform",
   ]);
 } else {
   runGo([command, ...rest]);

--- a/tests/smoke/package.json
+++ b/tests/smoke/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-smoke",
-  "version": "0.4.3-dev.20260426-2",
+  "version": "0.4.3-dev.20260426-3",
   "description": "Standalone end-to-end smoke tests for ttsc.",
   "scripts": {
     "start": "node --test --test-reporter=spec test/*.test.cjs"

--- a/tests/smoke/test/package-metadata.test.cjs
+++ b/tests/smoke/test/package-metadata.test.cjs
@@ -67,7 +67,7 @@ test("published package file lists keep TypeScript and Go sources", () => {
   assert.equal(fs.existsSync(path.join(workspaceRoot, "packages", "ttsx")), false);
 });
 
-test("platform package matrix follows the TypeScript-Go native package shape", () => {
+test("platform package matrix follows the ttsc helper package shape", () => {
   const packageJson = readPackageJson("ttsc");
   const expected = {
     "ttsc-linux-x64": ["@ttsc/linux-x64", "linux", "x64"],

--- a/tests/smoke/test/toolchain.test.cjs
+++ b/tests/smoke/test/toolchain.test.cjs
@@ -435,6 +435,18 @@ test("ttsx runs an .mts entry and resolves emitted .mjs imports", () => {
 
 test("current platform package binary was built for the test run", () => {
   assert.equal(fs.existsSync(nativeBinary), true);
+  assert.ok(
+    fs.statSync(nativeBinary).size < 5 * 1024 * 1024,
+    "platform helper should stay below 5MB",
+  );
+
+  const result = child_process.spawnSync(nativeBinary, ["--version"], {
+    cwd: workspaceRoot,
+    encoding: "utf8",
+    windowsHide: true,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^ttsc platform helper /);
 });
 
 function createProject(files) {


### PR DESCRIPTION
This pull request introduces a new Go-based "platform helper" binary for the `@ttsc` toolchain, replacing the previous native binary approach. The changes clarify the distinction between the main TypeScript-Go compiler and this lightweight compatibility helper, update the build and resolution scripts, and add a basic CLI with versioning and demo functionality. Documentation and tests are updated to reflect this new structure.

**Introduction of the platform helper binary:**

* Added a new Go program at `packages/ttsc/cmd/platform/main.go` implementing a lightweight CLI for platform-specific helper tasks, including version reporting and a demo command.
* Updated all references, documentation, and comments to clarify that platform packages now ship a "helper binary" instead of the full compiler, and updated terminology throughout the codebase and tests. [[1]](diffhunk://#diff-b47420835b8d060b71f3d4a94543e342e9cd531bf2c166f424b87e85f37ef787L2-R19) [[2]](diffhunk://#diff-b47420835b8d060b71f3d4a94543e342e9cd531bf2c166f424b87e85f37ef787L54-R58) [[3]](diffhunk://#diff-b47420835b8d060b71f3d4a94543e342e9cd531bf2c166f424b87e85f37ef787L88-R92) [[4]](diffhunk://#diff-b47420835b8d060b71f3d4a94543e342e9cd531bf2c166f424b87e85f37ef787L130-R134) [[5]](diffhunk://#diff-c85e48803cd37b0dc419e3f0ce76fd125c5db88a0270d645550084e786f87a64L7-R8) [[6]](diffhunk://#diff-3b1ef4dde686a99a45e2c820ab9d782e994ee73f70b7f01a7de730d66521d0c5L70-R70)

**Build and packaging updates:**

* Switched build scripts to compile the new helper binary from `cmd/platform` instead of the previous `cmd/ttsc` location. [[1]](diffhunk://#diff-bf36d19197f79f57e30abb41fd92a06724d4e40bff29898491d3b5f60e6d676fL30-R30) [[2]](diffhunk://#diff-ff01dd428f8577f96a58e8b3d76b98e8656d63229dd8a0c596585d6d4bf39729L18-R18)
* Ensured the helper binary is small (under 5MB) and added a test to verify its presence and size.

**Versioning:**

* Bumped the package version to `0.4.3-dev.20260426-3` to reflect these changes.