### PR TITLE
feat(test): test typia for extreme use case.

### DIFF
--- a/.github/workflows/typia.yml
+++ b/.github/workflows/typia.yml
@@ -58,5 +58,5 @@ jobs:
       - name: Test typia next
         working-directory: experimental/typia
         run: |
-          pnpm install
+          pnpm install --no-frozen-lockfile
           pnpm test

--- a/.github/workflows/typia.yml
+++ b/.github/workflows/typia.yml
@@ -1,0 +1,62 @@
+name: typia
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/typia.yml"
+      - "experimental/**"
+      - "scripts/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+  workflow_dispatch:
+
+jobs:
+  Ubuntu:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/ttsc/go.mod
+          cache-dependency-path: |
+            packages/ttsc/go.sum
+            tests/go-transformer/go.mod
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.4
+
+      - name: Install ttsc dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build ttsc tarballs
+        run: pnpm package:tgz
+
+      - name: Clone typia next
+        run: |
+          rm -rf experimental/typia
+          git clone --depth=1 --branch next https://github.com/samchon/typia experimental/typia
+
+      - name: Use local ttsc tarballs
+        working-directory: experimental/typia
+        run: |
+          cat >> pnpm-workspace.yaml <<'YAML'
+
+          overrides:
+            ttsc: file:../tarballs/ttsc.tgz
+            '@ttsc/linux-x64': file:../tarballs/ttsc-linux-x64.tgz
+          YAML
+
+      - name: Test typia next
+        working-directory: experimental/typia
+        run: |
+          pnpm install
+          pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bin/
 coverage/
 .turbo/
 .references/
+experimental/typia/
 **/node_modules/
 **/lib/
 **/native/


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate testing for the `typia` project and its integration with local `ttsc` tarballs. The workflow is triggered on pull requests affecting relevant files and can also be run manually. It sets up the required environments, builds dependencies, clones the latest `typia` code, applies local overrides, and runs the test suite.

**CI/CD automation for typia integration:**

* Added a new workflow file `.github/workflows/typia.yml` that sets up Node.js and Go environments, installs dependencies, builds local `ttsc` tarballs, clones the latest `typia` repository, overrides dependencies to use local tarballs, and runs the `typia` test suite.