### PR TITLE
feat(ttsc): downgrade transformed source and mapping.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bin/
 coverage/
 .turbo/
 .references/
+.wiki/
 experimental/typia/
 **/node_modules/
 **/lib/

--- a/config/package.json
+++ b/config/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
   "name": "@ttsc/config",
-  "version": "0.4.3"
+  "version": "0.4.4-dev.20260426"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/station",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.20260426",
   "description": "Standalone TypeScript-Go compiler and runtime workspace.",
   "scripts": {
     "build": "pnpm --filter ttsc build && pnpm --filter ttsc go:build && pnpm --filter=\"./packages/ttsc-*\" -r build",

--- a/packages/ttsc-darwin-arm64/package.json
+++ b/packages/ttsc-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/darwin-arm64",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.20260426",
   "description": "macOS arm64 native binary for ttsc.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/packages/ttsc-darwin-x64/package.json
+++ b/packages/ttsc-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/darwin-x64",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.20260426",
   "description": "macOS x64 native binary for ttsc.",
   "os": ["darwin"],
   "cpu": ["x64"],

--- a/packages/ttsc-linux-arm/package.json
+++ b/packages/ttsc-linux-arm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/linux-arm",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.20260426",
   "description": "Linux arm native binary for ttsc.",
   "os": ["linux"],
   "cpu": ["arm"],

--- a/packages/ttsc-linux-arm64/package.json
+++ b/packages/ttsc-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/linux-arm64",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.20260426",
   "description": "Linux arm64 native binary for ttsc.",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/packages/ttsc-linux-x64/package.json
+++ b/packages/ttsc-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/linux-x64",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.20260426",
   "description": "Linux x64 native binary for ttsc.",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/packages/ttsc-win32-arm64/package.json
+++ b/packages/ttsc-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/win32-arm64",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.20260426",
   "description": "Windows arm64 native binary for ttsc.",
   "os": ["win32"],
   "cpu": ["arm64"],

--- a/packages/ttsc-win32-x64/package.json
+++ b/packages/ttsc-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/win32-x64",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.20260426",
   "description": "Windows x64 native binary for ttsc.",
   "os": ["win32"],
   "cpu": ["x64"],

--- a/packages/ttsc/package.json
+++ b/packages/ttsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttsc",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.20260426",
   "description": "General-purpose TypeScript-Go compiler, plugin host, and runtime.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/ttsc/src/api.ts
+++ b/packages/ttsc/src/api.ts
@@ -23,7 +23,9 @@ import * as path from "node:path";
 
 import { type ResolveOptions, resolveBinary } from "./platform";
 import {
+  type TtscSourceTransformStage,
   type TtscPlugin,
+  applyPluginSourceTransformsWithMap,
   applyPluginTransforms,
   loadProjectPlugins,
 } from "./plugin";
@@ -88,6 +90,8 @@ export interface BuildOptions extends CommonOptions {
   quiet?: boolean;
   /** @internal Caller already ran diagnostics and accepts responsibility. */
   skipDiagnosticsCheck?: boolean;
+  /** @internal Force `tsgo --listEmittedFiles` even when no output plugin runs. */
+  forceListEmittedFiles?: boolean;
 }
 
 /** Options for `check()`. */
@@ -168,6 +172,9 @@ export function transform(options: TransformOptions): string {
       ? options.file
       : path.resolve(options.cwd ?? process.cwd(), options.file),
   );
+  if (execution.sourcePlugins.length > 0) {
+    return transformWithSourceTransforms(options, execution, sourceFile);
+  }
   if (execution.nativeBinary) {
     return transformWithNativeBinary(options, execution, sourceFile);
   }
@@ -199,9 +206,10 @@ export function transform(options: TransformOptions): string {
       throw new Error(`ttsc.transform: no output produced for ${sourceFile}`);
     }
     const transformed = finalizeTransformText(
-      execution.plugins,
+      execution.outputPlugins,
       {
         command: "transform",
+        compilerOptions: execution.compilerOptions,
         cwd: execution.cwd,
         projectRoot: execution.projectRoot,
         sourceFile,
@@ -250,9 +258,10 @@ function transformWithNativeBinary(
     );
   }
   const transformed = finalizeTransformText(
-    execution.plugins,
+    execution.outputPlugins,
     {
       command: "transform",
+      compilerOptions: execution.compilerOptions,
       cwd: execution.cwd,
       projectRoot: execution.projectRoot,
       sourceFile,
@@ -267,6 +276,83 @@ function transformWithNativeBinary(
   return transformed;
 }
 
+function transformWithSourceTransforms(
+  options: TransformOptions,
+  execution: ExecutionContext,
+  sourceFile: string,
+): string {
+  if (execution.nativeBinary || execution.nativeMode !== "none") {
+    throw new Error(
+      "ttsc.transform: transformSource cannot be combined with native rewrite mode yet",
+    );
+  }
+  const materialized = materializeSourceTransformedProject(
+    execution,
+    "transform",
+    sourceFile,
+  );
+  const tempOutDir = path.join(materialized.root, ".ttsc-transform-out");
+  try {
+    const tempSourceFile = toMaterializedPath(sourceFile, materialized);
+    const result = build({
+      ...options,
+      cwd: materialized.root,
+      emit: true,
+      forceListEmittedFiles: true,
+      outDir: tempOutDir,
+      plugins: false,
+      tsconfig: materialized.tsconfig,
+    });
+    if (result.status !== 0) {
+      throw new Error(
+        "ttsc.transform exited " +
+          result.status +
+          "\n" +
+          (result.stderr || result.stdout),
+      );
+    }
+    const emitted = findEmittedFile(tempOutDir, materialized.root, tempSourceFile);
+    if (!emitted) {
+      throw new Error(`ttsc.transform: no output produced for ${sourceFile}`);
+    }
+    let transformed = finalizeTransformText(
+      execution.outputPlugins,
+      {
+        command: "transform",
+        compilerOptions: execution.compilerOptions,
+        cwd: execution.cwd,
+        projectRoot: execution.projectRoot,
+        sourceFile,
+        tsconfig: execution.tsconfig,
+      },
+      fs.readFileSync(emitted, "utf8"),
+    );
+    if (options.out) {
+      const mapFile = `${emitted}.map`;
+      if (fs.existsSync(mapFile)) {
+        const outMap = `${options.out}.map`;
+        fs.mkdirSync(path.dirname(outMap), { recursive: true });
+        fs.writeFileSync(
+          outMap,
+          patchSourceMapText(
+            fs.readFileSync(mapFile, "utf8"),
+            materialized,
+            outMap,
+            mapFile,
+          ),
+          "utf8",
+        );
+        transformed = rewriteSourceMapReference(transformed, path.basename(outMap));
+      }
+      fs.mkdirSync(path.dirname(options.out), { recursive: true });
+      fs.writeFileSync(options.out, transformed, "utf8");
+    }
+    return transformed;
+  } finally {
+    fs.rmSync(materialized.root, { recursive: true, force: true });
+  }
+}
+
 function realpathIfExists(file: string): string {
   try {
     return fs.realpathSync(file);
@@ -277,6 +363,7 @@ function realpathIfExists(file: string): string {
 
 /** Result of `build()`. Non-zero `status` means the build failed. */
 export interface BuildResult {
+  emittedFiles?: string[];
   status: number;
   stdout: string;
   stderr: string;
@@ -289,6 +376,9 @@ export interface BuildResult {
  */
 export function build(options: BuildOptions = {}): BuildResult {
   const execution = resolveExecutionContext(options);
+  if (execution.sourcePlugins.length > 0) {
+    return buildWithSourceTransforms(options, execution);
+  }
   if (execution.nativeBinary) {
     return buildWithNativeBinary(options, execution);
   }
@@ -310,7 +400,9 @@ export function build(options: BuildOptions = {}): BuildResult {
   }
 
   const args = createTsgoBuildArgs(execution, options, {
-    listEmittedFiles: options.emit !== false && execution.plugins.length > 0,
+    listEmittedFiles:
+      options.emit !== false &&
+      (execution.outputPlugins.length > 0 || options.forceListEmittedFiles === true),
   });
   const res = spawnBinary(execution.tsgo.binary, args, {
     cwd: execution.projectRoot,
@@ -334,10 +426,10 @@ export function build(options: BuildOptions = {}): BuildResult {
   if (emittedFiles.length !== 0) {
     result.stdout = stripEmittedFileLines(result.stdout);
   }
-  if (result.status === 0 && options.emit !== false && execution.plugins.length > 0) {
-    applyBuildPlugins(execution.plugins, execution, emittedFiles);
+  if (result.status === 0 && options.emit !== false && execution.outputPlugins.length > 0) {
+    applyBuildPlugins(execution.outputPlugins, execution, emittedFiles);
   }
-  return normalizeFailedDiagnostics(result);
+  return normalizeFailedDiagnostics({ ...result, emittedFiles });
 }
 
 function buildWithNativeBinary(
@@ -363,6 +455,42 @@ function buildWithNativeBinary(
     stdout: outputText(res.stdout),
     stderr: outputText(res.stderr),
   });
+}
+
+function buildWithSourceTransforms(
+  options: BuildOptions,
+  execution: ExecutionContext,
+): BuildResult {
+  if (execution.nativeBinary || execution.nativeMode !== "none") {
+    return {
+      status: 2,
+      stdout: "",
+      stderr:
+        "ttsc.build: transformSource cannot be combined with native rewrite mode yet\n",
+    };
+  }
+  const materialized = materializeSourceTransformedProject(execution, "build");
+  try {
+    const outDir = mapOutDirToMaterializedProject(options.outDir, execution, materialized);
+    const result = build({
+      ...options,
+      cwd: materialized.root,
+      forceListEmittedFiles: true,
+      outDir,
+      plugins: false,
+      tsconfig: materialized.tsconfig,
+    });
+    if (result.status === 0 && options.emit !== false) {
+      const copied = copyMaterializedEmittedFiles(materialized, result.emittedFiles ?? []);
+      result.emittedFiles = copied;
+      if (execution.outputPlugins.length > 0) {
+        applyBuildPlugins(execution.outputPlugins, execution, copied);
+      }
+    }
+    return result;
+  } finally {
+    fs.rmSync(materialized.root, { recursive: true, force: true });
+  }
 }
 
 /**
@@ -469,11 +597,13 @@ export function transformAsync(options: TransformOptions): Promise<string> {
 }
 
 interface ExecutionContext {
+  compilerOptions: Record<string, unknown>;
   cwd: string;
   nativeBinary: string | null;
   nativeMode: string;
-  plugins: readonly TtscPlugin[];
+  outputPlugins: readonly TtscPlugin[];
   projectRoot: string;
+  sourcePlugins: readonly TtscPlugin[];
   tsgo: ResolvedTsgo;
   tsconfig: string;
 }
@@ -496,11 +626,13 @@ function resolveExecutionContext(
     tsconfig,
   });
   return {
+    compilerOptions: loaded.project.compilerOptions,
     cwd,
     nativeBinary: loaded.nativeBinary ?? null,
     nativeMode: options.rewriteMode ?? loaded.nativeMode,
-    plugins: loaded.plugins.filter((plugin) => plugin.transformOutput),
+    outputPlugins: loaded.plugins.filter((plugin) => plugin.transformOutput),
     projectRoot,
+    sourcePlugins: loaded.plugins.filter((plugin) => plugin.transformSource),
     tsgo,
     tsconfig,
   };
@@ -536,6 +668,7 @@ function applyBuildPlugins(
     const next = applyPluginTransforms(plugins, {
       code: current,
       command: "build",
+      compilerOptions: execution.compilerOptions,
       cwd: execution.cwd,
       outputFile: file,
       projectRoot: execution.projectRoot,
@@ -578,6 +711,7 @@ function normalizeFailedDiagnostics(result: BuildResult): BuildResult {
     return result;
   }
   return {
+    emittedFiles: result.emittedFiles,
     status: result.status,
     stdout: "",
     stderr: result.stdout,
@@ -653,4 +787,491 @@ function readOwnPackageVersion(): string {
   } catch {
     return "0.0.0";
   }
+}
+
+interface MaterializedProject {
+  mappers: Map<string, SourcePositionMapper>;
+  originalRoot: string;
+  root: string;
+  tsconfig: string;
+}
+
+interface SourcePositionMapper {
+  finalCode: string;
+  originalCode: string;
+  stages: readonly TtscSourceTransformStage[];
+}
+
+function materializeSourceTransformedProject(
+  execution: ExecutionContext,
+  command: "build" | "transform",
+  onlySourceFile?: string,
+): MaterializedProject {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-"));
+  const materialized: MaterializedProject = {
+    mappers: new Map(),
+    originalRoot: execution.projectRoot,
+    root,
+    tsconfig: path.join(root, path.relative(execution.projectRoot, execution.tsconfig)),
+  };
+  copyProjectForSourceTransforms(execution.projectRoot, root, execution.compilerOptions);
+  const files = onlySourceFile
+    ? [toMaterializedPath(onlySourceFile, materialized)]
+    : listSourceTransformFiles(root);
+  for (const tempFile of files) {
+    if (!fs.existsSync(tempFile) || !fs.statSync(tempFile).isFile()) {
+      continue;
+    }
+    const originalFile = fromMaterializedPath(tempFile, materialized);
+    const current = fs.readFileSync(tempFile, "utf8");
+    const transformed = applyPluginSourceTransformsWithMap(execution.sourcePlugins, {
+      code: current,
+      command,
+      compilerOptions: execution.compilerOptions,
+      cwd: execution.cwd,
+      projectRoot: execution.projectRoot,
+      sourceFile: originalFile,
+      tsconfig: execution.tsconfig,
+    });
+    const next = transformed.code;
+    if (next !== current) {
+      fs.writeFileSync(tempFile, next, "utf8");
+    }
+    if (transformed.stages.length > 0) {
+      materialized.mappers.set(filepathKey(tempFile), {
+        finalCode: next,
+        originalCode: current,
+        stages: transformed.stages,
+      });
+    }
+  }
+  return materialized;
+}
+
+function copyProjectForSourceTransforms(
+  source: string,
+  target: string,
+  compilerOptions: Record<string, unknown>,
+): void {
+  const excluded = new Set([".git", "node_modules"]);
+  const outDir = typeof compilerOptions.outDir === "string" ? compilerOptions.outDir : "";
+  const resolvedOutDir = outDir ? path.resolve(outDir) : "";
+  copyDirectoryFiltered(source, target, (entry) => {
+    if (excluded.has(path.basename(entry))) {
+      return false;
+    }
+    if (resolvedOutDir && isPathInside(entry, resolvedOutDir)) {
+      return false;
+    }
+    return true;
+  });
+  const nodeModules = path.join(source, "node_modules");
+  if (fs.existsSync(nodeModules)) {
+    const targetNodeModules = path.join(target, "node_modules");
+    try {
+      fs.symlinkSync(nodeModules, targetNodeModules, "junction");
+    } catch {
+      copyDirectoryFiltered(nodeModules, targetNodeModules, () => true);
+    }
+  }
+}
+
+function copyDirectoryFiltered(
+  source: string,
+  target: string,
+  shouldCopy: (entry: string) => boolean,
+): void {
+  if (!shouldCopy(source)) {
+    return;
+  }
+  const stat = fs.lstatSync(source);
+  if (stat.isSymbolicLink()) {
+    const link = fs.readlinkSync(source);
+    fs.symlinkSync(link, target);
+    return;
+  }
+  if (stat.isDirectory()) {
+    fs.mkdirSync(target, { recursive: true });
+    for (const entry of fs.readdirSync(source)) {
+      copyDirectoryFiltered(path.join(source, entry), path.join(target, entry), shouldCopy);
+    }
+    return;
+  }
+  if (stat.isFile()) {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(source, target);
+  }
+}
+
+function listSourceTransformFiles(root: string): string[] {
+  const out: string[] = [];
+  const stack = [root];
+  while (stack.length !== 0) {
+    const current = stack.pop()!;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name === ".git") {
+        continue;
+      }
+      const next = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(next);
+      } else if (entry.isFile() && isTransformableSource(next)) {
+        out.push(next);
+      }
+    }
+  }
+  return out;
+}
+
+function isTransformableSource(file: string): boolean {
+  return /\.(?:[cm]?tsx?)$/i.test(file) && !/\.d\.[cm]?ts$/i.test(file);
+}
+
+function mapOutDirToMaterializedProject(
+  outDir: string | undefined,
+  execution: ExecutionContext,
+  materialized: MaterializedProject,
+): string | undefined {
+  if (!outDir) {
+    return undefined;
+  }
+  const resolved = path.resolve(execution.cwd, outDir);
+  if (isPathInside(resolved, execution.projectRoot)) {
+    return toMaterializedPath(resolved, materialized);
+  }
+  return path.join(materialized.root, ".ttsc-out");
+}
+
+function copyMaterializedEmittedFiles(
+  materialized: MaterializedProject,
+  emittedFiles: readonly string[],
+): string[] {
+  const copied: string[] = [];
+  for (const emitted of emittedFiles) {
+    if (!isPathInside(emitted, materialized.root)) {
+      continue;
+    }
+    const target = fromMaterializedPath(emitted, materialized);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    if (/\.map$/i.test(emitted)) {
+      fs.writeFileSync(
+        target,
+        patchSourceMapText(fs.readFileSync(emitted, "utf8"), materialized, target),
+        "utf8",
+      );
+    } else {
+      fs.copyFileSync(emitted, target);
+    }
+    copied.push(target);
+  }
+  return copied;
+}
+
+function toMaterializedPath(file: string, materialized: MaterializedProject): string {
+  const relative = path.relative(materialized.originalRoot, file);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return file;
+  }
+  return path.join(materialized.root, relative);
+}
+
+function fromMaterializedPath(file: string, materialized: MaterializedProject): string {
+  const relative = path.relative(materialized.root, file);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return file;
+  }
+  return path.join(materialized.originalRoot, relative);
+}
+
+function isPathInside(file: string, parent: string): boolean {
+  const relative = path.relative(parent, file);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function filepathKey(file: string): string {
+  return path.resolve(file).replace(/\\/g, "/");
+}
+
+function patchSourceMapText(
+  text: string,
+  materialized: MaterializedProject,
+  outputFile: string,
+  tempOutputFile = toMaterializedPath(outputFile, materialized),
+): string {
+  let map: {
+    sourceRoot?: string;
+    sources?: string[];
+    sourcesContent?: string[];
+    [key: string]: unknown;
+  };
+  try {
+    map = JSON.parse(text);
+  } catch {
+    return text;
+  }
+  if (!Array.isArray(map.sources)) {
+    return text;
+  }
+  const tempMapDir = path.dirname(tempOutputFile);
+  const originalMapDir = path.dirname(outputFile);
+  const nextSources: string[] = [];
+  const nextSourcesContent = Array.isArray(map.sourcesContent)
+    ? [...map.sourcesContent]
+    : undefined;
+  const sourceMappings = new Map<number, SourcePositionMapper>();
+  map.sources.forEach((source, index) => {
+    const tempSource = path.isAbsolute(source)
+      ? source
+      : path.resolve(tempMapDir, source);
+    if (isPathInside(tempSource, materialized.root)) {
+      const originalSource = fromMaterializedPath(tempSource, materialized);
+      const mapper = materialized.mappers.get(filepathKey(tempSource));
+      if (mapper) {
+        sourceMappings.set(index, mapper);
+      }
+      nextSources.push(relativeSourceMapPath(originalMapDir, originalSource));
+      if (nextSourcesContent) {
+        try {
+          nextSourcesContent[index] = fs.readFileSync(originalSource, "utf8");
+        } catch {
+          /* keep emitted sourcesContent */
+        }
+      }
+    } else {
+      nextSources.push(source);
+    }
+  });
+  if (sourceMappings.size > 0 && typeof map.mappings === "string") {
+    map.mappings = remapSourceMapMappings(map.mappings, sourceMappings);
+  }
+  map.sources = nextSources;
+  if (nextSourcesContent) {
+    map.sourcesContent = nextSourcesContent;
+  }
+  delete map.sourceRoot;
+  return JSON.stringify(map);
+}
+
+function relativeSourceMapPath(fromDir: string, file: string): string {
+  const relative = path.relative(fromDir, file).replace(/\\/g, "/");
+  return relative.startsWith(".") ? relative : `./${relative}`;
+}
+
+function rewriteSourceMapReference(code: string, mapFileName: string): string {
+  const reference = `//# sourceMappingURL=${mapFileName}`;
+  if (/\/\/# sourceMappingURL=.*(?:\r?\n)?$/m.test(code)) {
+    return code.replace(/\/\/# sourceMappingURL=.*(?:\r?\n)?$/m, `${reference}\n`);
+  }
+  return code.endsWith("\n") ? `${code}${reference}\n` : `${code}\n${reference}\n`;
+}
+
+function remapSourceMapMappings(
+  mappings: string,
+  sourceMappings: Map<number, SourcePositionMapper>,
+): string {
+  const decoded = decodeMappings(mappings);
+  for (const line of decoded) {
+    for (const segment of line) {
+      if (segment.length < 4) {
+        continue;
+      }
+      const mapper = sourceMappings.get(segment[1]!);
+      if (!mapper) {
+        continue;
+      }
+      const mapped = mapTransformedPositionToOriginal(mapper, {
+        column: segment[3]!,
+        line: segment[2]!,
+      });
+      segment[2] = mapped.line;
+      segment[3] = mapped.column;
+    }
+  }
+  return encodeMappings(decoded);
+}
+
+function mapTransformedPositionToOriginal(
+  mapper: SourcePositionMapper,
+  position: { line: number; column: number },
+): { line: number; column: number } {
+  let offset = lineColumnToOffset(mapper.finalCode, position.line, position.column);
+  for (let index = mapper.stages.length - 1; index >= 0; index -= 1) {
+    offset = mapOffsetToPreviousStage(offset, mapper.stages[index]!);
+  }
+  return offsetToLineColumn(mapper.originalCode, offset);
+}
+
+function mapOffsetToPreviousStage(
+  offset: number,
+  stage: TtscSourceTransformStage,
+): number {
+  let delta = 0;
+  for (const edit of stage.edits) {
+    if (offset < edit.newStart) {
+      return clampOffset(offset - delta, stage.before.length);
+    }
+    if (offset < edit.newEnd) {
+      return edit.start;
+    }
+    delta += edit.code.length - (edit.end - edit.start);
+  }
+  return clampOffset(offset - delta, stage.before.length);
+}
+
+function lineColumnToOffset(source: string, line: number, column: number): number {
+  const starts = lineStarts(source);
+  const start = starts[Math.min(Math.max(line, 0), starts.length - 1)] ?? 0;
+  return clampOffset(start + Math.max(column, 0), source.length);
+}
+
+function offsetToLineColumn(
+  source: string,
+  offset: number,
+): { line: number; column: number } {
+  const starts = lineStarts(source);
+  const clamped = clampOffset(offset, source.length);
+  let low = 0;
+  let high = starts.length - 1;
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    const start = starts[mid]!;
+    const next = starts[mid + 1] ?? Number.POSITIVE_INFINITY;
+    if (clamped < start) {
+      high = mid - 1;
+    } else if (clamped >= next) {
+      low = mid + 1;
+    } else {
+      return { column: clamped - start, line: mid };
+    }
+  }
+  const last = starts.length - 1;
+  return { column: clamped - (starts[last] ?? 0), line: last };
+}
+
+function lineStarts(source: string): number[] {
+  const starts = [0];
+  for (let index = 0; index < source.length; index += 1) {
+    const ch = source.charCodeAt(index);
+    if (ch === 13 /* \r */) {
+      if (source.charCodeAt(index + 1) === 10 /* \n */) {
+        index += 1;
+      }
+      starts.push(index + 1);
+    } else if (ch === 10 /* \n */) {
+      starts.push(index + 1);
+    }
+  }
+  return starts;
+}
+
+function clampOffset(offset: number, length: number): number {
+  return Math.min(Math.max(offset, 0), length);
+}
+
+type SourceMapSegment = number[];
+type DecodedMappings = SourceMapSegment[][];
+
+const BASE64_CHARS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const BASE64_VALUES = new Map(
+  [...BASE64_CHARS].map((char, index) => [char, index] as const),
+);
+
+function decodeMappings(mappings: string): DecodedMappings {
+  const lines: DecodedMappings = [];
+  let line: SourceMapSegment[] = [];
+  let segment: SourceMapSegment = [];
+  let index = 0;
+  const state = [0, 0, 0, 0, 0];
+  while (index < mappings.length) {
+    const char = mappings[index]!;
+    if (char === ";") {
+      if (segment.length > 0) {
+        line.push(segment);
+        segment = [];
+      }
+      lines.push(line);
+      line = [];
+      state[0] = 0;
+      index += 1;
+      continue;
+    }
+    if (char === ",") {
+      if (segment.length > 0) {
+        line.push(segment);
+        segment = [];
+      }
+      index += 1;
+      continue;
+    }
+    const read = readVlq(mappings, index);
+    index = read.next;
+    const field = segment.length;
+    state[field] = (state[field] ?? 0) + read.value;
+    segment.push(state[field]!);
+  }
+  if (segment.length > 0) {
+    line.push(segment);
+  }
+  lines.push(line);
+  return lines;
+}
+
+function encodeMappings(lines: DecodedMappings): string {
+  const state = [0, 0, 0, 0, 0];
+  return lines
+    .map((line) => {
+      state[0] = 0;
+      return line
+        .map((segment) =>
+          segment
+            .map((value, index) => {
+              const relative = value - (state[index] ?? 0);
+              state[index] = value;
+              return writeVlq(relative);
+            })
+            .join(""),
+        )
+        .join(",");
+    })
+    .join(";");
+}
+
+function readVlq(input: string, start: number): { next: number; value: number } {
+  let index = start;
+  let shift = 0;
+  let value = 0;
+  while (index < input.length) {
+    const digit = BASE64_VALUES.get(input[index]!);
+    if (digit === undefined) {
+      throw new Error(`ttsc: invalid source map VLQ digit ${input[index]}`);
+    }
+    index += 1;
+    const continuation = (digit & 32) !== 0;
+    value += (digit & 31) << shift;
+    shift += 5;
+    if (!continuation) {
+      const negative = (value & 1) === 1;
+      const decoded = value >> 1;
+      return { next: index, value: negative ? -decoded : decoded };
+    }
+  }
+  throw new Error("ttsc: unterminated source map VLQ segment");
+}
+
+function writeVlq(value: number): string {
+  let vlq = Math.abs(value) << 1;
+  if (value < 0) {
+    vlq |= 1;
+  }
+  let out = "";
+  do {
+    let digit = vlq & 31;
+    vlq >>>= 5;
+    if (vlq > 0) {
+      digit |= 32;
+    }
+    out += BASE64_CHARS[digit]!;
+  } while (vlq > 0);
+  return out;
 }

--- a/packages/ttsc/src/plugin.ts
+++ b/packages/ttsc/src/plugin.ts
@@ -29,10 +29,47 @@ export interface TtscTransformContext {
   code: string;
   command: "build" | "transform";
   cwd: string;
+  compilerOptions: Record<string, unknown>;
   outputFile?: string;
   projectRoot: string;
   sourceFile?: string;
   tsconfig: string;
+}
+
+export interface TtscSourceTransformContext {
+  code: string;
+  command: "build" | "transform";
+  compilerOptions: Record<string, unknown>;
+  cwd: string;
+  projectRoot: string;
+  sourceFile: string;
+  tsconfig: string;
+}
+
+export interface TtscSourceEdit {
+  code: string;
+  end: number;
+  start: number;
+}
+
+export interface TtscSourceTransformResult {
+  code?: string;
+  edits?: readonly TtscSourceEdit[];
+}
+
+export interface AppliedTtscSourceEdit extends TtscSourceEdit {
+  newEnd: number;
+  newStart: number;
+}
+
+export interface TtscSourceTransformStage {
+  before: string;
+  edits: readonly AppliedTtscSourceEdit[];
+}
+
+export interface TtscSourceTransformOutput {
+  code: string;
+  stages: readonly TtscSourceTransformStage[];
 }
 
 export interface TtscPlugin {
@@ -42,6 +79,9 @@ export interface TtscPlugin {
   nativeMode?: NativeRewriteMode;
   /** @deprecated Use `native.binary` instead. */
   nativeBinary?: string;
+  transformSource?(
+    context: TtscSourceTransformContext,
+  ): string | TtscSourceTransformResult | readonly TtscSourceEdit[] | undefined;
   transformOutput?(context: TtscTransformContext): string;
 }
 
@@ -150,6 +190,121 @@ export function applyPluginTransforms(
     code = plugin.transformOutput({ ...context, code });
   }
   return code;
+}
+
+export function applyPluginSourceTransforms(
+  plugins: readonly TtscPlugin[],
+  context: TtscSourceTransformContext,
+): string {
+  return applyPluginSourceTransformsWithMap(plugins, context).code;
+}
+
+export function applyPluginSourceTransformsWithMap(
+  plugins: readonly TtscPlugin[],
+  context: TtscSourceTransformContext,
+): TtscSourceTransformOutput {
+  let code = context.code;
+  const stages: TtscSourceTransformStage[] = [];
+  for (const plugin of plugins) {
+    if (!plugin.transformSource) {
+      continue;
+    }
+    const before = code;
+    const result = plugin.transformSource({ ...context, code });
+    if (typeof result === "string") {
+      code = result;
+      if (code !== before) {
+        stages.push({
+          before,
+          edits: createAppliedSourceEdits(before, [
+            { code, end: before.length, start: 0 },
+          ]),
+        });
+      }
+      continue;
+    }
+    if (isSourceEditArray(result)) {
+      const edits = createAppliedSourceEdits(before, result);
+      code = applySourceEdits(before, edits);
+      if (edits.length > 0) {
+        stages.push({ before, edits });
+      }
+      continue;
+    }
+    if (result?.code !== undefined) {
+      code = result.code;
+      if (code !== before) {
+        stages.push({
+          before,
+          edits: createAppliedSourceEdits(before, [
+            { code, end: before.length, start: 0 },
+          ]),
+        });
+      }
+      continue;
+    }
+    if (result?.edits) {
+      const edits = createAppliedSourceEdits(before, result.edits);
+      code = applySourceEdits(before, edits);
+      if (edits.length > 0) {
+        stages.push({ before, edits });
+      }
+    }
+  }
+  return { code, stages };
+}
+
+function isSourceEditArray(value: unknown): value is readonly TtscSourceEdit[] {
+  return Array.isArray(value);
+}
+
+function applySourceEdits(
+  source: string,
+  edits: readonly TtscSourceEdit[],
+): string {
+  if (edits.length === 0) {
+    return source;
+  }
+  const ordered = [...edits].sort((a, b) => b.start - a.start);
+  let output = source;
+  for (const edit of ordered) {
+    output = output.slice(0, edit.start) + edit.code + output.slice(edit.end);
+  }
+  return output;
+}
+
+function createAppliedSourceEdits(
+  source: string,
+  edits: readonly TtscSourceEdit[],
+): AppliedTtscSourceEdit[] {
+  if (edits.length === 0) {
+    return [];
+  }
+  const ordered = [...edits].sort((a, b) => a.start - b.start);
+  let previousEnd = 0;
+  let delta = 0;
+  const applied: AppliedTtscSourceEdit[] = [];
+  for (const edit of ordered) {
+    if (!Number.isInteger(edit.start) || !Number.isInteger(edit.end)) {
+      throw new Error("ttsc: transformSource edit offsets must be integers");
+    }
+    if (
+      edit.start < 0 ||
+      edit.end < edit.start ||
+      edit.end > source.length ||
+      edit.start < previousEnd
+    ) {
+      throw new Error(
+        `ttsc: invalid or overlapping transformSource edit ${edit.start}:${edit.end}`,
+      );
+    }
+    const newStart = edit.start + delta;
+    const newEnd = newStart + edit.code.length;
+    applied.push({ ...edit, newEnd, newStart });
+    delta += edit.code.length - (edit.end - edit.start);
+    previousEnd = edit.end;
+  }
+  return applied;
 }
 
 function loadPluginEntry(

--- a/packages/ttsc/src/project.ts
+++ b/packages/ttsc/src/project.ts
@@ -19,7 +19,7 @@ export interface ParsedProjectConfig {
   compilerOptions: {
     outDir?: string;
     plugins: ProjectPluginConfig[];
-  };
+  } & Record<string, unknown>;
   path: string;
   root: string;
 }
@@ -69,6 +69,7 @@ export function readProjectConfig(opts: ProjectLocatorOptions = {}): ParsedProje
   const compilerOptions = readResolvedCompilerOptions(tsconfig);
   return {
     compilerOptions: {
+      ...compilerOptions.options,
       outDir: compilerOptions.outDir,
       plugins: compilerOptions.plugins,
     },
@@ -130,13 +131,14 @@ function isProjectPluginConfig(value: unknown): value is ProjectPluginConfig {
 
 interface RawTsconfig {
   extends?: unknown;
-  compilerOptions?: {
+  compilerOptions?: Record<string, unknown> & {
     outDir?: unknown;
     plugins?: unknown;
   };
 }
 
 interface ResolvedCompilerOptions {
+  options: Record<string, unknown>;
   outDir?: string;
   plugins: ProjectPluginConfig[];
 }
@@ -164,8 +166,13 @@ function readResolvedCompilerOptions(
   const base =
     typeof parsed.extends === "string"
       ? readResolvedCompilerOptions(resolveExtendsConfig(canonical, parsed.extends), seen)
-      : { plugins: [] };
+      : { options: {}, plugins: [] };
+  const options = {
+    ...base.options,
+    ...(own ?? {}),
+  };
   return {
+    options,
     outDir:
       typeof own?.outDir === "string"
         ? resolveAbsolutePath(path.dirname(canonical), own.outDir)

--- a/tests/smoke/package.json
+++ b/tests/smoke/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-smoke",
-  "version": "0.4.3",
+  "version": "0.4.4-dev.20260426",
   "description": "Standalone end-to-end smoke tests for ttsc.",
   "scripts": {
     "start": "node --test --test-reporter=spec test/*.test.cjs"

--- a/tests/smoke/test/plugin-corpus.test.cjs
+++ b/tests/smoke/test/plugin-corpus.test.cjs
@@ -124,3 +124,191 @@ test("plugin corpus: transform --out receives transformOutput text", () => {
   assert.equal(result.status, 0, result.stderr);
   assert.match(fs.readFileSync(output, "utf8"), /\/\/ out:transform\s*$/);
 });
+
+test("plugin corpus: transformSource is lowered by the consumer tsgo target", () => {
+  const root = commonJsProject(
+    {
+      "plugins/source.cjs": `
+        module.exports = {
+          name: "source-expression",
+          transformSource(context) {
+            const needle = "makeModern()";
+            const start = context.code.lastIndexOf(needle);
+            if (start < 0) return;
+            return [{
+              start,
+              end: start + needle.length,
+              code: "({ value: 'TARGET-LOWERED' }?.value ?? 'fallback')",
+            }];
+          },
+        };
+      `,
+      "src/main.ts": `
+        function makeModern(): string {
+          return "not transformed";
+        }
+        export const value: string = makeModern();
+        console.log(value);
+      `,
+    },
+    {
+      compilerOptions: {
+        target: "ES2015",
+        plugins: [{ transform: "./plugins/source.cjs" }],
+      },
+    },
+  );
+
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+  assert.doesNotMatch(js, /\?\./);
+  assert.doesNotMatch(js, /\?\?/);
+  assert.match(js, /TARGET-LOWERED/);
+  const run = spawn(process.execPath, [path.join(root, "dist", "main.js")], {
+    cwd: root,
+  });
+  assert.equal(run.status, 0, run.stderr);
+  assert.equal(run.stdout.trim(), "TARGET-LOWERED");
+});
+
+test("plugin corpus: transformSource build preserves source map paths", () => {
+  const root = commonJsProject(
+    {
+      "plugins/source-map.cjs": `
+        module.exports = {
+          name: "source-map-expression",
+          transformSource(context) {
+            const needle = "makeModern<IMember>()";
+            const start = context.code.lastIndexOf(needle);
+            if (start < 0) return;
+            return {
+              edits: [{
+                start,
+                end: start + needle.length,
+                code: "(() => {\\n  const box = { value: 'MAP-LOWERED' };\\n  return box?.value ?? 'fallback';\\n})()",
+              }],
+            };
+          },
+        };
+      `,
+      "src/main.ts": [
+        "type IMember = { name: string };",
+        "",
+        "const assert = makeModern<IMember>();",
+        "",
+        'console.log("assert function ready");',
+        "",
+        "declare function makeModern<T>(): (input: T) => T;",
+        "",
+      ].join("\n"),
+    },
+    {
+      compilerOptions: {
+        inlineSources: true,
+        sourceMap: true,
+        target: "ES2015",
+        plugins: [{ transform: "./plugins/source-map.cjs" }],
+      },
+    },
+  );
+
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const mapFile = path.join(root, "dist", "main.js.map");
+  assert.equal(fs.existsSync(mapFile), true);
+  const mapText = fs.readFileSync(mapFile, "utf8");
+  const map = JSON.parse(mapText);
+  assert.deepEqual(map.sources, ["../src/main.ts"]);
+  assert.doesNotMatch(mapText, /ttsc-source-/);
+  assert.match(map.sourcesContent?.[0] ?? "", /makeModern<IMember>\(\)/);
+  const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+  assert.doesNotMatch(js, /\?\.|\?\?/);
+
+  const mappings = decodeMappings(map.mappings);
+  const generatedLines = js.split(/\r?\n/);
+  const replacementLine = generatedLines.findIndex((line) =>
+    line.includes("MAP-LOWERED"),
+  );
+  const consoleLine = generatedLines.findIndex((line) =>
+    line.includes("assert function ready"),
+  );
+  assert.notEqual(replacementLine, -1);
+  assert.notEqual(consoleLine, -1);
+  assert.equal(mappedOriginalLines(mappings, replacementLine).has(2), true);
+  assert.equal(mappedOriginalLines(mappings, consoleLine).has(4), true);
+});
+
+function mappedOriginalLines(mappings, generatedLine) {
+  return new Set(
+    (mappings[generatedLine] ?? [])
+      .filter((segment) => segment.length >= 4)
+      .map((segment) => segment[2]),
+  );
+}
+
+function decodeMappings(mappings) {
+  const lines = [];
+  let line = [];
+  let segment = [];
+  let index = 0;
+  const state = [0, 0, 0, 0, 0];
+  while (index < mappings.length) {
+    const char = mappings[index];
+    if (char === ";") {
+      if (segment.length > 0) {
+        line.push(segment);
+        segment = [];
+      }
+      lines.push(line);
+      line = [];
+      state[0] = 0;
+      index += 1;
+      continue;
+    }
+    if (char === ",") {
+      if (segment.length > 0) {
+        line.push(segment);
+        segment = [];
+      }
+      index += 1;
+      continue;
+    }
+    const read = readVlq(mappings, index);
+    index = read.next;
+    const field = segment.length;
+    state[field] += read.value;
+    segment.push(state[field]);
+  }
+  if (segment.length > 0) {
+    line.push(segment);
+  }
+  lines.push(line);
+  return lines;
+}
+
+const BASE64_CHARS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const BASE64_VALUES = new Map(
+  [...BASE64_CHARS].map((char, index) => [char, index]),
+);
+
+function readVlq(input, start) {
+  let index = start;
+  let shift = 0;
+  let value = 0;
+  while (index < input.length) {
+    const digit = BASE64_VALUES.get(input[index]);
+    assert.notEqual(digit, undefined);
+    index += 1;
+    const continuation = (digit & 32) !== 0;
+    value += (digit & 31) << shift;
+    shift += 5;
+    if (!continuation) {
+      const negative = (value & 1) === 1;
+      const decoded = value >> 1;
+      return { next: index, value: negative ? -decoded : decoded };
+    }
+  }
+  throw new Error("unterminated VLQ");
+}


### PR DESCRIPTION
This pull request introduces a new `transformSource` plugin API to the `ttsc` TypeScript compiler, allowing plugins to perform fine-grained source-level code transformations before the main compilation process. It also ensures that all TypeScript compiler options are correctly propagated and handled throughout the configuration and plugin system. Comprehensive tests are added to verify the new plugin API and its correct integration with source maps and code emission.

**New plugin API for source-level transforms:**

* Added the `transformSource` method to the `TtscPlugin` interface, along with supporting types (`TtscSourceTransformContext`, `TtscSourceEdit`, `TtscSourceTransformResult`, etc.), allowing plugins to perform targeted code edits before compilation. (`packages/ttsc/src/plugin.ts` [packages/ttsc/src/plugin.tsR32-R84](diffhunk://#diff-0662c595b4b67610627e69bb15e94cf24c5d4b8747b298dc20e5f33fd5f1c489R32-R84))
* Implemented `applyPluginSourceTransforms` and related helper functions to apply these source-level transforms, track transformation stages, and ensure edits are applied safely and in order. (`packages/ttsc/src/plugin.ts` [packages/ttsc/src/plugin.tsR195-R309](diffhunk://#diff-0662c595b4b67610627e69bb15e94cf24c5d4b8747b298dc20e5f33fd5f1c489R195-R309))

**Compiler options and configuration improvements:**

* Updated the handling of `compilerOptions` in project configuration to ensure all TypeScript options (not just `outDir` and `plugins`) are preserved and passed to plugins, improving compatibility and flexibility. (`packages/ttsc/src/project.ts` [[1]](diffhunk://#diff-b040e903f1ef88e90e9d544116b7df28e65751b8fb3998209c43136c53b7696bL22-R22) [[2]](diffhunk://#diff-b040e903f1ef88e90e9d544116b7df28e65751b8fb3998209c43136c53b7696bR72) [[3]](diffhunk://#diff-b040e903f1ef88e90e9d544116b7df28e65751b8fb3998209c43136c53b7696bL133-R141) [[4]](diffhunk://#diff-b040e903f1ef88e90e9d544116b7df28e65751b8fb3998209c43136c53b7696bL167-R175)

**Testing and verification:**

* Added new smoke tests to verify that `transformSource` plugins work as intended, both for target lowering and for preserving correct source map paths, ensuring robust integration with the build pipeline. (`tests/smoke/test/plugin-corpus.test.cjs` [tests/smoke/test/plugin-corpus.test.cjsR127-R314](diffhunk://#diff-96216306221a17d2da98cef0d74f7bc49df5227afd4e9d6e20f8fddf3fda2db3R127-R314))