### PR TITLE
feat(ttsc): new build system, go compiling.

### DIFF
--- a/docs/plugins/01-getting-started.md
+++ b/docs/plugins/01-getting-started.md
@@ -1,0 +1,329 @@
+# Getting Started: Hello-World Plugin
+
+This page walks through building a minimal `ttsc` plugin that uppercases the contents of a custom `goUpper("...")` call site in the consumer's TypeScript. By the end you'll have a working npm package that real consumers can install.
+
+## What a plugin actually does
+
+Before the steps, the mental model:
+
+- Your plugin **does not replace `tsgo`**. `tsgo` is still the compiler. Your plugin runs as a side process that `ttsc` invokes on each `.ts` file (or once per project build) to *rewrite the output JavaScript* before it lands on disk.
+- Your plugin **does not have to invent a magic syntax**. The example below pattern-matches a literal `goUpper("...")` call to keep the demo readable, but a real plugin is more often something like *"find every call to `MyLib.is<T>(value)` and emit a runtime type-validator based on `T`"*. Both are valid; they just differ in how much they lean on the TypeScript AST and Checker.
+- Your plugin **gets the user's TypeScript context**. `ttsc` passes you the source file path and the tsconfig path. From there you can stay at the source-text level (this page) or bootstrap a real `Program` + `Checker` and do semantic work ([03-tsgo.md](./03-tsgo.md#bootstrapping-a-program-and-a-checker)).
+
+This guide stays at the source-text level. Once you have it working, [03-tsgo.md](./03-tsgo.md) shows how to graduate to AST/Checker-driven plugins.
+
+## Prerequisites
+
+- Node.js ≥ 18
+- Go ≥ 1.26 (`go version` should print something)
+- An empty workspace where you can scaffold a new package
+
+> The Go toolchain is needed *on the consumer's machine*, not on yours, but it's needed on yours too if you want to test locally.
+
+## Project layout
+
+A `ttsc` plugin npm package looks like this:
+
+```
+ttsc-plugin-uppercase/
+├── package.json
+├── plugin.cjs              # JS manifest — entry referenced from tsconfig
+├── go-plugin/
+│   ├── go.mod
+│   └── main.go             # Go transformer implementation
+└── README.md
+```
+
+The npm package contains both halves. ttsc reads the manifest at config-parse time and compiles `go-plugin/` on first use.
+
+## 1. `package.json`
+
+```json
+{
+  "name": "ttsc-plugin-uppercase",
+  "version": "0.1.0",
+  "main": "plugin.cjs",
+  "files": ["plugin.cjs", "go-plugin"],
+  "peerDependencies": {
+    "ttsc": "^0.4.0"
+  }
+}
+```
+
+The `files` array **must** include `go-plugin/` — your Go source ships in the published tarball. Without it, end-user installs will fail with "native.source.dir does not exist".
+
+## 2. JS manifest — `plugin.cjs`
+
+```js
+const path = require("node:path");
+
+module.exports = {
+  name: "ttsc-plugin-uppercase",
+  native: {
+    mode: "uppercase",
+    source: {
+      dir: path.resolve(__dirname, "go-plugin"),
+    },
+    contractVersion: 1,
+  },
+};
+```
+
+What the fields mean:
+
+- `name` — identifies your plugin in error messages and ordered pipelines.
+- `native.mode` — a string your binary uses to dispatch transform behavior. Pick something namespaced like `"acme.uppercase"` to avoid clashing with other plugins running in the same project.
+- `native.source.dir` — absolute path to the Go module ttsc should compile. Always use `path.resolve(__dirname, ...)` so the resolution survives being installed under `node_modules/`.
+- `native.contractVersion` — the protocol version your plugin speaks. Currently `1`.
+
+See [protocol.md](./02-protocol.md#manifest) for every supported manifest field.
+
+## 3. Go module — `go-plugin/go.mod`
+
+```
+module ttsc-plugin-uppercase
+
+go 1.26
+```
+
+Your plugin's `go.mod` only needs the module name and `go` directive when you're not importing anything from `ttsc`'s shim. Add `require` lines if you import other Go packages — see [tsgo.md](./03-tsgo.md) for `typescript-go` imports specifically.
+
+## 4. Plugin binary — `go-plugin/main.go`
+
+```go
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var goUpperCall = regexp.MustCompile(
+	`(?m)export\s+const\s+([A-Za-z_$][A-Za-z0-9_$]*)(?:\s*:\s*[^=]+)?=\s*goUpper\("([^"]*)"\)\s*;`,
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "ttsc-plugin-uppercase: command required")
+		return 2
+	}
+	switch args[0] {
+	case "version", "-v", "--version":
+		fmt.Fprintln(os.Stdout, "ttsc-plugin-uppercase 0.1.0")
+		return 0
+	case "check":
+		return 0
+	case "transform":
+		return runTransform(args[1:])
+	case "build":
+		return runBuild(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "ttsc-plugin-uppercase: unknown command %q\n", args[0])
+		return 2
+	}
+}
+
+func runTransform(args []string) int {
+	fs := flag.NewFlagSet("transform", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	file := fs.String("file", "", "")
+	out := fs.String("out", "", "")
+	_ = fs.String("tsconfig", "", "")
+	_ = fs.String("rewrite-mode", "", "")
+	_ = fs.String("plugins-json", "", "")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	source, err := os.ReadFile(*file)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	code, err := transform(string(source))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if *out != "" {
+		os.MkdirAll(filepath.Dir(*out), 0o755)
+		return writeOut(*out, code)
+	}
+	fmt.Fprint(os.Stdout, code)
+	return 0
+}
+
+func runBuild(args []string) int {
+	fs := flag.NewFlagSet("build", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	cwd := fs.String("cwd", "", "")
+	_ = fs.String("tsconfig", "", "")
+	_ = fs.String("rewrite-mode", "", "")
+	_ = fs.String("plugins-json", "", "")
+	_ = fs.Bool("emit", false, "")
+	_ = fs.Bool("noEmit", false, "")
+	_ = fs.Bool("quiet", false, "")
+	_ = fs.Bool("verbose", false, "")
+	outDir := fs.String("outDir", "dist", "")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	root := *cwd
+	if root == "" {
+		root, _ = os.Getwd()
+	}
+	source := filepath.Join(root, "src", "main.ts")
+	text, err := os.ReadFile(source)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	code, err := transform(string(text))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	out := filepath.Join(root, *outDir, "main.js")
+	if filepath.IsAbs(*outDir) {
+		out = filepath.Join(*outDir, "main.js")
+	}
+	os.MkdirAll(filepath.Dir(out), 0o755)
+	return writeOut(out, code)
+}
+
+func transform(source string) (string, error) {
+	match := goUpperCall.FindStringSubmatch(source)
+	if match == nil {
+		return "", fmt.Errorf(`ttsc-plugin-uppercase: expected goUpper("...")`)
+	}
+	name := match[1]
+	value := strings.ToUpper(match[2])
+
+	var b strings.Builder
+	b.WriteString(`"use strict";` + "\n")
+	b.WriteString(`Object.defineProperty(exports, "__esModule", { value: true });` + "\n")
+	b.WriteString(fmt.Sprintf("exports.%s = void 0;\n", name))
+	b.WriteString(fmt.Sprintf("const %s = %q;\n", name, value))
+	b.WriteString(fmt.Sprintf("exports.%s = %s;\n", name, name))
+	if strings.Contains(source, "console.log("+name+")") ||
+		strings.Contains(source, "console.log("+name+");") {
+		b.WriteString(fmt.Sprintf("console.log(%s);\n", name))
+	}
+	return b.String(), nil
+}
+
+func writeOut(path, content string) int {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	return 0
+}
+```
+
+This is the minimum surface every plugin binary must have:
+
+- `version` — diagnostic output. ttsc may probe this in the future.
+- `check` — analysis-only, no emit. ttsc invokes this when `--noEmit` is set.
+- `transform --file=X` — single-file transform; result on stdout (or `--out=Y` if provided).
+- `build --cwd=X` — project-wide build; writes outputs to disk.
+
+A real plugin parses `--plugins-json` for ordered behavior — see [protocol.md](./02-protocol.md#cli-protocol).
+
+## 5. Try it from a consumer project
+
+In any other directory:
+
+```bash
+mkdir consumer && cd consumer
+npm init -y
+npm i -D ttsc @typescript/native-preview /path/to/ttsc-plugin-uppercase
+```
+
+Create `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "plugins": [{ "transform": "ttsc-plugin-uppercase" }]
+  },
+  "include": ["src"]
+}
+```
+
+Create `src/main.ts`:
+
+```ts
+export const value: string = goUpper("hello");
+console.log(value);
+```
+
+Then:
+
+```bash
+npx ttsc --emit
+node dist/main.js
+# → HELLO
+```
+
+The first run prints `ttsc: building source plugin "ttsc-plugin-uppercase" ...` to stderr (one-time per cache key); subsequent runs hit the cache and start instantly.
+
+## Optional: typed manifest with `definePlugin`
+
+The `plugin.cjs` above is plain JavaScript — easy to copy-paste, but you get no type checking on the manifest fields. If you'd rather author the manifest in TypeScript, `ttsc` exports a `definePlugin<T>(plugin: T): T` identity helper that gives you full type inference:
+
+```ts
+// plugin.ts
+import * as path from "node:path";
+import { definePlugin } from "ttsc";
+
+export default definePlugin({
+  name: "ttsc-plugin-uppercase",
+  native: {
+    mode: "uppercase",
+    source: { dir: path.resolve(__dirname, "go-plugin") },
+    contractVersion: 1,
+  },
+});
+```
+
+Build it once with `tsc` (or your preferred TS pipeline) into `lib/plugin.js` and point `package.json`'s `main` at the built file. Consumers reference your plugin the same way; the only thing that changes is that *you* get a typo on `nativ:` flagged at author time.
+
+You can also use the factory form to receive each tsconfig entry's full config:
+
+```ts
+import { definePlugin, type ProjectPluginConfig } from "ttsc";
+
+export default definePlugin((entry: ProjectPluginConfig) => ({
+  name: entry.name as string,
+  native: {
+    mode: (entry.mode as string) ?? "uppercase",
+    source: { dir: path.resolve(__dirname, "go-plugin") },
+    contractVersion: 1,
+  },
+}));
+```
+
+Whichever shape you pick, the runtime semantics are identical to the `.cjs` version. See [02-protocol.md#manifest](./02-protocol.md#manifest) for the full type surface.
+
+## What to read next
+
+- **Make your plugin actually useful (semantic transforms)** — [03-tsgo.md](./03-tsgo.md) shows how to import the TypeScript-Go AST/Checker/Scanner, with two reference fixtures: bootstrap-only and full AST walking.
+- **Handle ordered pipelines and config** — [02-protocol.md#cli-protocol](./02-protocol.md#cli-protocol) documents `--plugins-json`, including how user-supplied tsconfig fields like `{ "transform": "...", "myOption": 42 }` arrive in your binary.
+- **Set up your dev loop with full IDE support** — [04-local-dev.md](./04-local-dev.md) walks through the local `go.work` so gopls / `go build` / `go test` all work standalone (only needed if you import tsgo shims).
+- **Debug build failures** — [05-internals.md](./05-internals.md) describes the cache layout and how to inspect what `ttsc` is doing under the hood.
+- **Common patterns** — [08-recipes.md](./08-recipes.md) covers multi-mode dispatch, reading config, diagnostics, watch mode, source maps.
+- **First-contact mistakes** — [09-pitfalls.md](./09-pitfalls.md) — skim once, save an hour.
+- **Ship to npm** — [06-publishing.md](./06-publishing.md) walks `package.json`, `peerDependencies`, the `files` gotcha, and the publish checklist.
+- **Test your plugin** — [07-testing.md](./07-testing.md) — Go unit tests for transform logic + integration tests via `ttsc`.

--- a/docs/plugins/02-protocol.md
+++ b/docs/plugins/02-protocol.md
@@ -1,0 +1,226 @@
+# Plugin Protocol Reference
+
+This page is the authoritative reference for the two contract surfaces a `ttsc` plugin must implement:
+
+1. The **JS manifest** — what `ttsc` reads from the consumer's `compilerOptions.plugins`.
+2. The **CLI protocol** — what the compiled Go binary must accept on the command line.
+
+If you just want a working example, see [getting-started.md](./01-getting-started.md). This page is for filling gaps and resolving ambiguity.
+
+## Manifest
+
+The manifest module exports either:
+
+- a plain object satisfying `TtscPlugin`, or
+- a factory function `(config, context) => TtscPlugin`, exported as `default`, named `createTtscPlugin`, or as the module's default `module.exports`.
+
+When the consumer's `tsconfig.json` declares plugin entries with extra fields, the factory form receives them as `config`:
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [
+      { "transform": "my-plugin", "name": "primary", "mode": "uppercase", "prefix": "A:" }
+    ]
+  }
+}
+```
+
+```js
+module.exports = (config, context) => ({
+  name: config.name,
+  native: {
+    mode: config.mode,
+    source: { dir: require("node:path").resolve(__dirname, "go-plugin") },
+    contractVersion: 1,
+  },
+});
+```
+
+`context` provides `{ binary, cwd, projectRoot, tsconfig }`. The full set of arbitrary `config` fields (everything beyond `transform` and `enabled`) is later forwarded to your binary via `--plugins-json`.
+
+### `TtscPlugin` shape
+
+```ts
+interface TtscPlugin {
+  name: string;
+  native?: TtscNativeBackend;
+}
+
+interface TtscNativeBackend {
+  mode: string;
+  source?: TtscNativeSource;     // build-from-source path (recommended)
+  binary?: string;                // pre-built binary path (legacy / advanced)
+  contractVersion?: 1;
+  capabilities?: readonly string[];
+}
+
+interface TtscNativeSource {
+  dir: string;                    // absolute path to a Go module directory
+  entry?: string;                 // Go package path within `dir`. Default ".".
+}
+```
+
+### Field semantics
+
+- **`name`** — used in error messages and to identify the plugin in ordered pipelines. Must be a non-empty string.
+- **`native.mode`** — opaque string your binary uses to dispatch. Two plugin entries declaring the *same* `source.dir` but different `mode` values share one compiled binary; the binary sees both modes through `--plugins-json` ordering.
+- **`native.source.dir`** — absolute filesystem path to a Go module (a directory containing `go.mod`). Use `path.resolve(__dirname, "go-plugin")` for portability across `node_modules` layouts.
+- **`native.source.entry`** — Go package path inside `dir` to build, in the form `go build` accepts (e.g. `"./cmd/transformer"`). Default is `"."`. Use this when your repo has multiple `main` packages or shared internal packages.
+- **`native.binary`** — for users who pre-build their binary out-of-band (e.g. CI artifact), an absolute path to it. **Mutually exclusive with `native.source`.** This path is the legacy lane preserved for compatibility; new plugins should use `source`.
+- **`native.contractVersion`** — protocol version your binary speaks. Must be `1` today. Future major-protocol changes will bump this; `ttsc` refuses to load mismatched contract versions.
+- **`native.capabilities`** — informational list of capability strings (e.g. `["transform"]`). Currently advisory; reserved for protocol negotiation.
+
+### Validation
+
+`ttsc` rejects manifests at config-parse time when:
+
+- Both `native.binary` and `native.source` are present.
+- `native.source.dir` is empty or missing.
+- `native.source.dir` does not exist on disk.
+- `native.contractVersion` is anything other than `1`.
+
+Errors are surfaced before any Go build runs.
+
+### Disabling individual entries — `enabled: false`
+
+Each `compilerOptions.plugins[]` entry accepts an `enabled` flag. When `enabled` is explicitly `false`, `ttsc` filters that entry out before plugin loading — manifest is not required, the source is not built, the entry is not passed in `--plugins-json`. Useful for conditional or environment-specific pipelines:
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [
+      { "transform": "ttsc-plugin-prefix", "prefix": "[dev] ", "enabled": false },
+      { "transform": "ttsc-plugin-uppercase" }
+    ]
+  }
+}
+```
+
+`enabled` is the only `ttsc`-level field on a plugin entry besides `transform`. Anything else (`name`, `mode`, your custom keys) flows through to your binary verbatim via `--plugins-json`. Omitting `enabled` (or setting it to `true`) keeps the entry active.
+
+## CLI protocol
+
+`ttsc` invokes your compiled binary through subcommands. Three are **required** (`check`, `transform`, `build`); `version` is **optional** (recommended for future compatibility diagnostics, ignored today). An unknown subcommand should exit non-zero with a clear stderr message.
+
+### `version` (optional — also `-v`, `--version`)
+
+```
+my-plugin version
+```
+
+Prints any human-readable version banner to stdout and exits `0`. `ttsc` doesn't probe this today; future releases may use it for compatibility diagnostics. Implementing it costs four lines and saves you a future migration — recommend, but not required.
+
+### `check`
+
+```
+my-plugin check \
+  --cwd=<absolute-project-root> \
+  --tsconfig=<absolute-tsconfig-path> \
+  --rewrite-mode=<mode-string> \
+  --plugins-json=<json>
+```
+
+Analysis-only entry. Run any validation logic; do not emit files. Exit `0` on success, non-zero on diagnostics. `ttsc` invokes this when the consumer runs with `--noEmit` (CI gates).
+
+### `transform`
+
+```
+my-plugin transform \
+  --file=<absolute-source-file-path> \
+  --tsconfig=<absolute-tsconfig-path> \
+  --rewrite-mode=<mode-string> \
+  --plugins-json=<json> \
+  [--out=<absolute-output-path>]
+```
+
+Single-file transform — used by bundler hooks (vite, webpack, esbuild, …) and `ttsc transform --file=...`. Read the file at `--file`, produce the transformed JavaScript text. Write it to `--out` if given, otherwise to stdout.
+
+### `build`
+
+```
+my-plugin build \
+  --cwd=<absolute-project-root> \
+  --tsconfig=<absolute-tsconfig-path> \
+  --rewrite-mode=<mode-string> \
+  --plugins-json=<json> \
+  [--emit | --noEmit] \
+  [--outDir=<absolute-output-dir>] \
+  [--quiet | --verbose]
+```
+
+Project-wide build. Walk the project, transform every relevant source file, write outputs under `--outDir` (default: tsconfig's `outDir` resolved against `--cwd`).
+
+### Common flag semantics
+
+- All path flags are **absolute** when `ttsc` invokes them. Don't assume `--cwd` matches `process.cwd()`.
+- Unknown flags should be tolerated silently — `ttsc` may add new optional flags in minor versions. Use a permissive flag parser (Go's `flag.ContinueOnError` with no validation on unknown names is fine).
+- Exit codes: `0` success, `2` for argument/usage errors, anything else for runtime errors. `ttsc` surfaces stderr verbatim to the user.
+
+### `--rewrite-mode`
+
+This is the `mode` of the **first** entry in `--plugins-json` (or `"none"` when no plugins are active). It exists because the legacy native-binary lane needed a single-value mode dispatch flag before ordered pipelines were a thing. New plugins should ignore it for dispatch — read `--plugins-json` instead, which carries the full ordered list with per-entry modes. The flag is preserved for compatibility and may be deprecated in a later version.
+
+### `capabilities` (manifest field)
+
+Reserved for future protocol negotiation. Today it's pure metadata — `ttsc` does not branch on it and your plugin should not rely on `ttsc` filtering by capability strings. Set it to `["transform"]` if you want self-documentation; leave it omitted otherwise. Don't invent capability strings consumers might depend on — they have no enforcement path.
+
+### `--plugins-json` payload
+
+This is a JSON-encoded array of descriptors, one per *enabled* plugin entry in the consumer's tsconfig (already filtered to plugins backing the same binary, in source order):
+
+```json
+[
+  {
+    "name": "primary",
+    "mode": "uppercase",
+    "config": {
+      "transform": "my-plugin",
+      "name": "primary",
+      "mode": "uppercase",
+      "prefix": "A:"
+    },
+    "contractVersion": 1
+  },
+  {
+    "name": "secondary",
+    "mode": "suffix",
+    "config": { "transform": "my-plugin", "name": "secondary", "mode": "suffix", "suffix": ":Z" },
+    "contractVersion": 1
+  }
+]
+```
+
+The `config` field is the **complete plugin entry from tsconfig.json**, including the user's arbitrary fields. A plugin reading `prefix` or `suffix` from `config` is how you accept user options.
+
+### Ordered pipelines
+
+When the consumer declares multiple tsconfig plugin entries that all resolve to the same `source.dir`, `ttsc` builds **one** binary and invokes it once per `transform`/`build` call with the *full ordered list* in `--plugins-json`. Your binary is responsible for applying the descriptors in array order:
+
+```go
+for _, plugin := range pluginsFromJSON {
+    switch plugin.Mode {
+    case "uppercase": value = strings.ToUpper(value)
+    case "prefix":    value = stringConfig(plugin.Config, "prefix") + value
+    case "suffix":    value += stringConfig(plugin.Config, "suffix")
+    }
+}
+```
+
+This is how `ttsc` keeps the contract simple: one binary per project, one process spawn per file, all pipeline ordering inside the JSON descriptor.
+
+### What `ttsc` does to the binary's stdout/stderr
+
+- `transform`: stdout is captured *only* when `--out` is omitted. With `--out=path`, stdout is ignored and `--out` content is the transformed JS.
+- `build`: stdout/stderr passed through to the user. Non-zero exit fails the project build.
+- `check`: stdout typically empty; stderr is where you write diagnostics.
+
+## Versioning and compatibility
+
+The protocol version (`contractVersion: 1`) is the contract between `ttsc` and your binary. Within v1:
+
+- `ttsc` may add **new optional flags** to existing subcommands. Plugin binaries must ignore unknown flags.
+- `ttsc` may add **new fields** to `--plugins-json` descriptors. Plugin binaries must ignore unknown JSON fields (which Go's `encoding/json` does by default).
+- `ttsc` will **not** rename or remove existing flags or descriptor fields without bumping `contractVersion`.
+
+If `ttsc` ever introduces v2, plugins declaring `contractVersion: 1` will continue to be invoked through v1 emulation for at least one minor release.

--- a/docs/plugins/03-tsgo.md
+++ b/docs/plugins/03-tsgo.md
@@ -1,0 +1,312 @@
+# Importing tsgo APIs
+
+Most non-trivial plugins need to look at the user's TypeScript through `typescript-go`'s eyes — read the AST, walk the type graph, ask the Checker about a node. This page is about how to do that from your plugin source.
+
+## The model in one paragraph
+
+`ttsc` ships *shim* modules — narrow Go packages that re-export selected symbols from `typescript-go`'s internal packages. Your plugin imports the shim. When `ttsc` builds your plugin, it generates a Go workspace (`go.work`) that wires every shim module *plus the `ttsc` package itself* in as workspace members. Your plugin's imports of `github.com/microsoft/typescript-go/shim/...` resolve to the exact shim version `ttsc` is pinned against. There is no version coordination to worry about and no module proxy step.
+
+This is the mechanism that gives the project its "duck typing" property: your plugin only depends on the shim symbols it actually uses, and unrelated changes to other shims don't affect you.
+
+## What's in the shim
+
+The shim modules live under `<ttsc-package>/shim/`. Each one is a regular Go module re-exporting a curated slice of `typescript-go` internals. As of this writing:
+
+| Shim module | Purpose |
+| --- | --- |
+| `shim/ast` | TypeScript AST nodes (`ast.Node`, `ast.SourceFile`, `KindXxx` constants, `GetNodeAtPosition`, …) |
+| `shim/checker` | Type checker (`Checker`, `GetTypeAtLocation`, type APIs) |
+| `shim/compiler` | Program creation, emit pipeline, write-file callbacks |
+| `shim/core` | Foundational types (`CompilerOptions`, `Tristate`, `TSTrue`/`TSFalse`) |
+| `shim/parser` | Parse helpers |
+| `shim/scanner` | Position/line math, lexer hooks, escape-sequence flags |
+| `shim/tsoptions` | tsconfig.json parsing (`ParsedCommandLine`, `GetParsedCommandLineOfConfigFile`) |
+| `shim/tspath` | Path helpers (`ResolvePath`) |
+| `shim/vfs`, `shim/vfs/cachedvfs`, `shim/vfs/osvfs` | Virtual filesystem abstraction |
+| `shim/diagnosticwriter` | Diagnostic formatting (`FormatASTDiagnosticsWithColorAndContext`) |
+| `shim/bundled` | `tsgo`'s bundled lib.d.ts files |
+
+Each shim is a separately-importable Go package: `github.com/microsoft/typescript-go/shim/<name>`. The exact set of exported symbols is whatever's in that shim's `shim.go` (and `extra-shim.json` for hand-curated additions). The set may grow but won't shrink within `contractVersion: 1`.
+
+## How to use a shim — the current rules
+
+Two things have to be true for `ttsc` to compile your plugin against a shim.
+
+### 1. Import it from your `.go` files normally
+
+```go
+import (
+    shimast "github.com/microsoft/typescript-go/shim/ast"
+    shimcore "github.com/microsoft/typescript-go/shim/core"
+)
+
+func transform(file *shimast.SourceFile) {
+    // …
+}
+```
+
+### 2. Declare a require in your `go.mod`
+
+```
+module my-plugin
+
+go 1.26
+
+require (
+    github.com/microsoft/typescript-go/shim/ast v0.0.0
+    github.com/microsoft/typescript-go/shim/core v0.0.0
+)
+```
+
+The `v0.0.0` is a placeholder version: the shim modules ship *inside the `ttsc` npm package*, not on the Go module proxy, so a real semver tag would be misleading. Resolution is supplied by a `go.work` overlay — at build time `ttsc` synthesizes one in a scratch dir; for *your* dev loop you write one yourself in your repo. See [local-dev.md](./04-local-dev.md) for the layout.
+
+The `require` line still has to exist. Go workspace mode looks up modules by import path, but every package your code imports must appear in some `go.mod`'s `require` list — that's what tells the toolchain "this package is part of my dep graph". With your local `go.work` set up, gopls, `go build`, `go test`, and `go vet` all resolve the shim correctly.
+
+## A working example
+
+The fixture at [`tests/projects/go-source-plugin-tsgo/`](../../tests/projects/go-source-plugin-tsgo/) is the smallest tsgo-importing plugin in the codebase. The relevant pieces are:
+
+`go-plugin/go.mod`:
+```
+module go-source-plugin-tsgo
+
+go 1.26
+
+require github.com/microsoft/typescript-go/shim/core v0.0.0
+```
+
+`go-plugin/main.go` (excerpt):
+```go
+import shimcore "github.com/microsoft/typescript-go/shim/core"
+
+func transform(source string) (string, error) {
+    // ... existing transform logic ...
+    if shimcore.TSTrue != shimcore.TSFalse {
+        value += " (tsgo)"
+    }
+    // ...
+}
+```
+
+That import resolves at build time to `<ttsc-package>/shim/core/shim.go`. The smoke test (`plugin corpus: source plugin can import tsgo shim modules via go.work overlay`) verifies the resulting binary actually runs and the comparison evaluates as expected.
+
+## What you can and can't do
+
+**Yes, you can:**
+- Import any combination of the shim modules listed above.
+- Use any symbol the shim re-exports (`shim.go` is the source of truth).
+- Mix shim imports with normal third-party Go modules in your `go.mod`.
+
+**No, you can't (or shouldn't):**
+- Import `github.com/microsoft/typescript-go/internal/...` directly. The shim is the public boundary. Internal paths are unstable and not wired into the `go.work` overlay.
+- Pin a real semver on shim requires (`v1.2.3` etc.). Use `v0.0.0` until shims gain a publish surface.
+- Vendor the shim into your repo. The whole point of source-on-demand compilation is that `ttsc` provides the matching shim at build time.
+
+## Bootstrapping a Program and a Checker
+
+The shim re-exports types and helpers, but it does **not** hand you a running tsgo `Program` or `Checker` directly. Your plugin gets a `--file` path and a `--tsconfig` path on the command line; whatever heavy machinery you need (typed AST traversal, `Checker.GetTypeOfSymbol`, etc.), you build yourself from those flags.
+
+The pattern below mirrors what `ttsc`'s own driver does internally. Adapt freely; the only step you can't skip is using `bundled.WrapFS` and `bundled.LibPath()` so tsgo's `lib.es*.d.ts` files resolve without a network fetch.
+
+```go
+import (
+    "context"
+    "fmt"
+
+    "github.com/microsoft/typescript-go/shim/bundled"
+    shimchecker "github.com/microsoft/typescript-go/shim/checker"
+    shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+    "github.com/microsoft/typescript-go/shim/core"
+    "github.com/microsoft/typescript-go/shim/tsoptions"
+    "github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+    "github.com/microsoft/typescript-go/shim/vfs/osvfs"
+)
+
+// bootstrap returns a running Program + Checker for the consumer's
+// tsconfig. The caller MUST defer the returned release function to
+// free the checker pool lease.
+func bootstrap(cwd, tsconfigPath string) (*shimcompiler.Program, *shimchecker.Checker, func(), error) {
+    fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+    host := shimcompiler.NewCompilerHost(cwd, fs, bundled.LibPath(), nil, nil)
+
+    parsed, _ := tsoptions.GetParsedCommandLineOfConfigFile(
+        tsconfigPath,
+        &core.CompilerOptions{},
+        nil,
+        host,
+        nil,
+    )
+    if parsed == nil {
+        return nil, nil, nil, fmt.Errorf("tsoptions: parsed command line was nil for %s", tsconfigPath)
+    }
+    if len(parsed.Errors) > 0 {
+        return nil, nil, nil, fmt.Errorf("tsoptions: %d diagnostics parsing %s", len(parsed.Errors), tsconfigPath)
+    }
+
+    program := shimcompiler.NewProgram(shimcompiler.ProgramOptions{
+        Config:                      parsed,
+        SingleThreaded:              core.TSTrue,
+        Host:                        host,
+        UseSourceOfProjectReference: true,
+    })
+    if program == nil {
+        return nil, nil, nil, fmt.Errorf("compiler: NewProgram returned nil")
+    }
+
+    checker, release := program.GetTypeChecker(context.Background())
+    return program, (*shimchecker.Checker)(checker), release, nil
+}
+```
+
+What you have after `bootstrap` returns:
+
+- `program.SourceFiles()` — every parsed source file. Walk it to find the one matching your `--file` argument (compare with `filepath.ToSlash` for cross-platform safety).
+- A `*shimchecker.Checker` — call any `shimchecker.Checker_xxx` helper on it, or any direct method on `innerchecker.Checker` exposed by the shim.
+- The full tsgo dep graph: types, symbols, lib files. From here you do whatever your plugin actually does — schema generation, runtime validators, code generation from generic type arguments, etc.
+
+The release callback frees a checker-pool lease that tsgo holds internally. Always `defer release()` after acquisition; otherwise repeated invocations of your binary will exhaust the pool.
+
+### Locate the right source file
+
+```go
+target := filepath.ToSlash(*fileFlag) // the --file argument, normalized
+for _, file := range program.SourceFiles() {
+    if filepath.ToSlash(file.FileName()) == target {
+        // file.Text() gives the source string
+        // file is *shimast.SourceFile — walk it however you like
+        break
+    }
+}
+```
+
+### A complete working example: bootstrap
+
+[`tests/projects/go-source-plugin-checker/`](../../tests/projects/go-source-plugin-checker/) is the smallest plugin in this repo that exercises the full bootstrap. It:
+
+1. Parses `--file`, `--tsconfig`, `--cwd` from the CLI.
+2. Bootstraps Program + Checker with the helper above.
+3. Locates the target source file in `program.SourceFiles()`.
+4. Recognizes call sites shaped like `__typeText<T>()` and emits the source text of `T` as a string literal.
+
+The transform itself stays at the source-text level on purpose — that fixture's takeaway is the bootstrap pattern, not the trick used downstream.
+
+## Walking the AST
+
+Once you have a `Program`, traversal is plain Go. Every `*shimast.SourceFile` has a `Statements *NodeList` with a `Nodes []*Node` slice; every `*shimast.Node` has a `Kind` field and typed accessor methods (`AsInterfaceDeclaration`, `AsCallExpression`, etc.) that return `nil` when the kind doesn't match.
+
+The pattern, end to end:
+
+```go
+for _, file := range program.SourceFiles() {
+    if file.IsDeclarationFile {
+        continue // skip lib.es*.d.ts and friends
+    }
+    for _, stmt := range file.Statements.Nodes {
+        switch stmt.Kind {
+        case shimast.KindInterfaceDeclaration:
+            decl := stmt.AsInterfaceDeclaration()
+            handleInterface(decl)
+        case shimast.KindTypeAliasDeclaration:
+            decl := stmt.AsTypeAliasDeclaration()
+            handleTypeAlias(decl)
+        // …
+        }
+    }
+}
+
+func handleInterface(decl *shimast.InterfaceDeclaration) {
+    if decl == nil || decl.Name() == nil || decl.Members == nil {
+        return
+    }
+    name := decl.Name().Text()
+    for _, member := range decl.Members.Nodes {
+        if member.Kind != shimast.KindPropertySignature {
+            continue
+        }
+        prop := member.AsPropertySignatureDeclaration()
+        if prop == nil || prop.Name() == nil {
+            continue
+        }
+        propName := prop.Name().Text()
+        _ = propName
+        // … decide what to do with this property
+    }
+}
+```
+
+What's available on a `*Node`:
+
+- `node.Kind` — `Kind` enum value; compare against `shimast.Kind*` constants.
+- `node.AsX()` — typed accessor for kind `X`. Returns the typed pointer if `node.Kind == shimast.KindX`, otherwise `nil`. Always nil-check.
+- `node.Symbol()` — the binder-assigned symbol for declarations. Useful when paired with `Checker_xxx` helpers below.
+- `node.Pos()`, `node.End()` — source positions; combine with `file.Text()[pos:end]` to get raw source text.
+- `node.Parent` — walk up the tree.
+
+You can also recurse into a node's children via the typed accessors (e.g. `decl.Members.Nodes` for an `InterfaceDeclaration`'s members, `call.Arguments.Nodes` for a `CallExpression`'s arguments). The shim does not currently expose `node.ForEachChild`; iterate the typed accessor lists instead.
+
+### Querying the Checker
+
+`shim/checker` exposes a deliberate subset of `*Checker` methods. The most useful ones for typia-class plugins:
+
+- `shimchecker.Checker_getPropertiesOfType(checker, type) []*Symbol` — every property the type declares (no inheritance walking).
+- `shimchecker.Checker_getApparentProperties(checker, type) []*Symbol` — every property the type *exposes*, including inherited members from `extends` and merged interfaces. This is what most semantic plugins want.
+- `shimchecker.Checker_getTypeOfSymbolAtLocation(checker, symbol, location) *Type` — resolve a symbol's type at a given AST location. Use this when you have a value-level symbol (e.g. a variable) and want its type.
+- `shimchecker.Checker_getTypeArguments(checker, type) []*Type` — generic type arguments at an instantiation site.
+- `shimchecker.Checker_resolveEntityName(checker, nameNode, meaning, ignoreErrors, dontResolveAlias, location) *Symbol` — look up a name (identifier or qualified) into a symbol.
+- `shimchecker.Checker_isArrayType(checker, type) bool`, `shimchecker.IsTupleType(type)`, `shimchecker.Type_getTypeNameSymbol(type)` — narrowing helpers.
+
+A `*Symbol` from any of these has a `.Name` field — the property name as a string. Symbols also have flags, declarations, and parents accessible via methods on the alias type.
+
+Heads-up: there is no `Checker.GetTypeFromTypeNode` exposed in the shim today. To turn a `<T>` type argument into a `*Type` you typically resolve through the symbol path (`Checker_resolveEntityName` on the type's name node, then `Checker_getTypeOfSymbolAtLocation`), or fall back to AST-level reasoning when that's enough. If your plugin truly needs type-from-typenode for something AST can't answer, request it as a shim addition.
+
+### A complete working example: AST + Checker
+
+[`tests/projects/go-source-plugin-properties/`](../../tests/projects/go-source-plugin-properties/) is the next step up from the bootstrap fixture. It:
+
+1. Bootstraps `Program` + `Checker` (same helper as above).
+2. Walks every user `SourceFile`'s top-level statements.
+3. For each `InterfaceDeclaration`, enumerates `PropertySignature` members and records their names.
+4. Replaces every `typeProperties<T>()` call with the JSON-serialized property list.
+
+Source:
+```ts
+interface User { id: number; email: string; name: string; }
+interface Product { sku: string; price: number; }
+
+export const userProps: readonly string[] = typeProperties<User>();
+export const productProps: readonly string[] = typeProperties<Product>();
+```
+
+After:
+```js
+exports.userProps = ["id","email","name"];
+exports.productProps = ["sku","price"];
+```
+
+The fixture stays at the AST level for property enumeration because that's the most direct path for declaration-level extraction. When you need *resolved* types — e.g. to follow `extends` clauses, expand mapped types, or resolve generics — that's where the `Checker_xxx` helpers above plug in. The bootstrap reaches a usable Checker; everything past that is the ordinary type-checker workflow.
+
+## When `tsgo` upgrades
+
+When `ttsc` bumps its pinned `@typescript/native-preview`, the bundled shims change to match. Your plugin's *source* doesn't move. Three outcomes:
+
+1. **No symbol you use changed** → next build is a cache miss (different `tsgoVersion` in the cache key), but the source compiles fine and the new binary works. *This is the common case — that's the duck-typing payoff.*
+2. **A symbol you use was renamed or removed** → next build fails with a clear Go compile error pointing at the offending line. You ship a new plugin version.
+3. **A symbol's *signature* changed** → same as #2 — Go catches it at compile time.
+
+You'll never get a silent runtime mismatch. That's the whole reason `ttsc` builds plugins from source rather than accepting precompiled binaries.
+
+## Why the manual `require` is correct (not auto-injected)
+
+A tempting shortcut: `ttsc` could scan your plugin's imports at build time and synthesize the `require` lines itself, so your `go.mod` would only need `module foo` and `go 1.26`. Convenient. Wrong choice — and it's worth being explicit about why, because the surface alone makes it look attractive.
+
+The `go.mod` in your plugin isn't only consumed by `ttsc`'s build pipeline. It's consumed by:
+
+- **`gopls`** (your editor's language server). Without a `require` for `shim/core`, gopls reports "no required module provides package ..." on every line that uses it. No autocompletion on `shimcore.`, no jump-to-definition, no inline type errors. You'd be writing tsgo-using Go code in a broken editor.
+- **`go build` / `go test` / `go vet` / `gofmt`** standalone in your dev loop. All of these read `go.mod` directly. Without the require, they all fail outside `ttsc`'s overlay. Your inner loop would be "edit, run `ttsc`, wait, repeat" — death by a thousand seconds.
+- **`go mod tidy`**, linters, IDE refactor tools, and every other piece of the Go ecosystem that operates on a module's declared deps.
+
+If `ttsc` auto-injected requires only at build time, the developer experience would *look* clean (less to write) but every dev tool around the plugin source would silently break. That's a worse trade than asking the author to type one require line per shim they actually use.
+
+The "v0.0.0 looks weird" complaint is real but solvable through documentation, not magic. With a local `go.work` pointed at `./node_modules/ttsc/shim/...` (see [local-dev.md](./04-local-dev.md)), the placeholder version becomes invisible: gopls resolves the shim through workspace mode, the version string never gets dereferenced, and every Go tool just works.
+
+So the rule stays: you import what you need, you declare the require with `v0.0.0`, and you wire your local `go.work` once. The ceremony pays for itself in IDE support.

--- a/docs/plugins/04-local-dev.md
+++ b/docs/plugins/04-local-dev.md
@@ -1,0 +1,131 @@
+# Local Development Setup
+
+`ttsc` builds your plugin for end users on demand. But you, the plugin author, want a *fast inner loop*: write Go code, get autocompletion, run tests, see compile errors in your editor — without going through `ttsc` for every keystroke.
+
+This page sets up the layout that gives you that. The trick is a single `go.work` file in your repo that mirrors the workspace `ttsc` will create at build time, but using *your installed* `ttsc` package as the shim source.
+
+## The full layout
+
+```
+my-plugin/
+├── package.json                  # has "ttsc" as a devDependency
+├── go.work                       # ← this file is the magic
+├── plugin.cjs                    # JS manifest
+├── go-plugin/
+│   ├── go.mod                    # plugin's own Go module
+│   └── main.go                   # plugin source (imports shim packages here)
+└── node_modules/
+    └── ttsc/
+        ├── go.mod                # ttsc's own go.mod
+        └── shim/
+            ├── ast/go.mod
+            ├── core/go.mod
+            └── ...               # 13 shim modules
+```
+
+## Step-by-step
+
+### 1. Install `ttsc` as a devDependency
+
+```bash
+npm i -D ttsc
+```
+
+This pulls `ttsc` into `node_modules/`. Because `ttsc`'s npm package includes `go.mod` and the entire `shim/` tree in its `files` list, you get a complete shim distribution on disk.
+
+### 2. Write `go.work` at your repo root
+
+```
+go 1.26
+
+use (
+	./go-plugin
+	./node_modules/ttsc
+	./node_modules/ttsc/shim/ast
+	./node_modules/ttsc/shim/bundled
+	./node_modules/ttsc/shim/checker
+	./node_modules/ttsc/shim/compiler
+	./node_modules/ttsc/shim/core
+	./node_modules/ttsc/shim/diagnosticwriter
+	./node_modules/ttsc/shim/parser
+	./node_modules/ttsc/shim/scanner
+	./node_modules/ttsc/shim/tsoptions
+	./node_modules/ttsc/shim/tspath
+	./node_modules/ttsc/shim/vfs
+	./node_modules/ttsc/shim/vfs/cachedvfs
+	./node_modules/ttsc/shim/vfs/osvfs
+)
+```
+
+This file mirrors the overlay `ttsc` writes to its scratch dir at build time. The difference is that here it points at your `node_modules/ttsc/`, which is exactly the same shim source `ttsc` itself will use at build time on your end users' machines.
+
+You can include only the shims you actually use, but listing all of them is harmless — unused `use` entries cost nothing.
+
+> **pnpm / yarn PnP users.** With pnpm's default `node-linker=isolated` layout, `ttsc` does *not* live at `./node_modules/ttsc/` — it lives somewhere like `./node_modules/.pnpm/ttsc@0.4.4/node_modules/ttsc/`. Three workable options:
+>
+> 1. **Switch to `node-linker=hoisted`** in `.npmrc` for your plugin repo. This gives you the flat `./node_modules/ttsc/` layout the snippet above assumes. Recommended for plugin-development repos — your *published* plugin still works under any package manager because that's the consumer's setup, not yours.
+> 2. **Public-hoist `ttsc`.** In `.npmrc`: `public-hoist-pattern[]=ttsc`. This surfaces `ttsc` at the top-level `node_modules/` while keeping the rest of your deps isolated.
+> 3. **Resolve at script time.** `node -p "require.resolve('ttsc/package.json')"` gives you the real path; rewrite the `go.work` once after install (e.g. via a `postinstall` script). Brittle — the path changes when ttsc's version does.
+>
+> yarn classic (v1) hoists by default and works as written. yarn berry with PnP requires `nodeLinker: node-modules`; treat it like pnpm.
+
+### 3. `.gitignore`
+
+```gitignore
+# Inside my-plugin/
+node_modules/
+go.work.sum
+```
+
+Keep `go.work` itself in git (your build setup), exclude `go.work.sum` (machine-specific).
+
+### 4. Verify
+
+```bash
+go build ./go-plugin
+go test ./go-plugin/...
+go vet ./go-plugin/...
+```
+
+All three should work. If any fail with "no required module provides package github.com/microsoft/typescript-go/shim/X", check that:
+
+- The shim is listed in `go.work`'s `use` block.
+- The shim is required in `go-plugin/go.mod` (e.g. `require github.com/microsoft/typescript-go/shim/X v0.0.0`).
+- `node_modules/ttsc/shim/X/` actually exists. (If not: `npm i -D ttsc` again.)
+
+### 5. Editor / gopls
+
+`gopls` (the Go language server used by VS Code, Neovim's `nvim-lspconfig`, GoLand, etc.) auto-detects `go.work` files at the repository root. With the layout above, you get full IDE support inside `go-plugin/`:
+
+- Autocompletion on `shimast.`, `shimcore.`, etc.
+- Inline type errors when you misuse a shim symbol.
+- Jump-to-definition into `node_modules/ttsc/shim/<X>/shim.go`.
+- Hover docs on shim types.
+
+If your editor doesn't pick it up, restart the language server. VS Code: `> Go: Restart Language Server`.
+
+## When `ttsc` upgrades
+
+When you bump `ttsc` in `package.json`:
+
+- `node_modules/ttsc/shim/` updates with the new shim layout.
+- `go.work`'s `use` paths still point at the right directories — no edit needed.
+- If `ttsc` *added* a new shim module (rare), append a `use` line for it. If `ttsc` *removed* one (also rare; would be a `contractVersion` bump), drop the obsolete `use` line.
+- Run `go build ./go-plugin` once. If a shim symbol you use was renamed or removed, you get a clear Go compile error pointing at the line. Fix it, ship a new plugin version.
+
+This is the duck-typing payoff in your dev loop: tsgo/ttsc moves, and the diff is in *your* compile errors, not in mysterious runtime mismatches.
+
+## Symmetry with what `ttsc` does at build time
+
+The mental model:
+
+| Where | What happens |
+| --- | --- |
+| Your repo (dev) | You maintain `go.work` pointing at `./node_modules/ttsc/...` |
+| Consumer's machine (prod) | `ttsc` generates an equivalent `go.work` in a scratch dir pointing at `<consumer-node_modules>/ttsc/...` (or a globally installed `ttsc`'s shim) |
+
+Same shape, different roots. That's why your local builds match what consumers get — there's no "dev mode vs prod mode" divergence.
+
+## Future ergonomics
+
+A future `ttsc` release may ship a `ttsc plugin scaffold` (or `init`) command that emits the `package.json`, `plugin.cjs`, `go.mod`, `go.work`, and a starter `main.go` in one shot. Until then, copy-paste from this doc or from [`tests/projects/go-source-plugin-tsgo/`](../../tests/projects/go-source-plugin-tsgo/) (which is the smallest working example in this repo).

--- a/docs/plugins/05-internals.md
+++ b/docs/plugins/05-internals.md
@@ -1,0 +1,123 @@
+# Internals: Build & Cache
+
+This page is for plugin authors debugging unexpected behavior — *why won't my plugin rebuild after I edited it?*, *where does the binary actually live?*, *what does ttsc do on a cold cache?* You don't need any of this to write a plugin, but it's the first place to look when something feels wrong.
+
+## The build pipeline, end to end
+
+When `ttsc` encounters a plugin with `native.source` in `compilerOptions.plugins`:
+
+1. **Resolve the source dir.** Absolute paths are taken as-is; relative paths are resolved against the consumer's `tsconfig.json` directory.
+2. **Hash the inputs.** The cache key is a SHA-256 over:
+   - `ttsc` package version
+   - resolved `@typescript/native-preview` (`tsgo`) version
+   - `process.platform` / `process.arch`
+   - `entry` value (default `.`)
+   - every `*.go`, `*.s`, `*.c`, `*.h`, `*.cpp`, `*.hpp`, `go.mod`, `go.sum`, `go.work` file under the source dir, with relative path and content
+3. **Cache hit?** If `<cache>/<key>/plugin` exists, use it. Skip everything below.
+4. **Cache miss.** Create a per-process scratch dir at `<cache>/scratch-<key>-<pid>-<timestamp>/`. Copy the plugin source into it (excluding `node_modules`, `.git`, `dist`, `build`, `vendor`, `lib`).
+5. **Write `go.work`** in the scratch dir. The `use` list contains:
+   - `.` (the plugin scratch root)
+   - the `ttsc` package itself (so its pinned indirect deps anchor the module graph)
+   - every shim module under `<ttsc-package>/shim/`
+6. **Run `go build -o plugin <entry>`** in the scratch dir.
+7. **Move** `scratch/plugin` → `<cache>/<key>/plugin` via `fs.renameSync` (atomic on the same filesystem).
+8. **Clean up** the scratch dir.
+9. **Spawn** the cached binary with the appropriate subcommand (`build` / `transform` / `check`).
+
+Every step is synchronous, single-threaded inside one `ttsc` process. Multiple `ttsc` processes may run concurrently — each gets its own pid-tagged scratch dir, and the final atomic rename converges on a bit-identical binary.
+
+## Cache layout
+
+```
+$TTSC_CACHE_DIR/plugins/                    # or $XDG_CACHE_HOME/ttsc/plugins, or ~/.cache/ttsc/plugins
+├── <key-1>/
+│   └── plugin                              # cached binary (or plugin.exe on Windows)
+├── <key-2>/
+│   └── plugin
+└── ...
+```
+
+There is one binary per cache key. Scratch dirs are deleted after each successful build — if you see `scratch-*` directories left behind, a build crashed mid-flight.
+
+### Where the cache lives
+
+In priority order:
+
+1. `$TTSC_CACHE_DIR/plugins/` if `TTSC_CACHE_DIR` is set (used in tests for isolation)
+2. `$XDG_CACHE_HOME/ttsc/plugins/` if XDG is set
+3. `$HOME/.cache/ttsc/plugins/`
+
+To force a full rebuild, delete the cache root or set `TTSC_CACHE_DIR` to a fresh directory.
+
+### What invalidates the cache
+
+| Change | Triggers rebuild? |
+| --- | --- |
+| Edit a `.go` file in your plugin source | ✓ |
+| Edit `go.mod` / `go.sum` / `go.work` | ✓ |
+| Add or remove any tracked file | ✓ |
+| Change `native.source.entry` | ✓ |
+| Bump `ttsc` version (any `package.json` change) | ✓ |
+| Bump `@typescript/native-preview` in the consumer | ✓ |
+| Switch platforms (cross-machine cache reuse) | ✓ |
+| Edit a `README.md` or other non-source file in the plugin dir | ✗ |
+| Edit consumer's TypeScript source | ✗ (only the plugin's source affects the cache) |
+
+## Go toolchain
+
+`ttsc` invokes `go build` directly. It looks for the toolchain in this order:
+
+1. `TTSC_GO_BINARY` env var if set (must be an absolute path)
+2. `go` on `PATH`
+
+If neither is found, `ttsc` exits with:
+
+```
+ttsc: building plugin "..." failed because the Go toolchain was not found.
+Install Go (https://go.dev/dl/) or set TTSC_GO_BINARY to an absolute path.
+```
+
+> **Roadmap.** A future release will bundle the Go toolchain as platform-specific npm subpackages (`ttsc-go-linux-x64`, `ttsc-go-darwin-arm64`, …) under `optionalDependencies`, so consumers don't need a system Go install. This will follow the same delivery channel `ttsc`'s own native binaries already use. Tracking under issue #14 / its successor.
+
+## Debugging a failing build
+
+When a `go build` fails inside `ttsc`, the underlying `go` command's stderr is included verbatim:
+
+```
+ttsc: building plugin "my-plugin" via "go build" failed:
+go-plugin/main.go:42:8: undefined: shimast.SomethingThatDoesNotExist
+```
+
+Things to check:
+
+- **Did you forget the require line?** `no required module provides package github.com/microsoft/typescript-go/shim/...` → see [tsgo.md](./03-tsgo.md#how-to-use-a-shim--the-current-rules).
+- **Is your source actually in the cache key?** Files matching `*.go`, `*.s`, `*.c`, `*.h`, `*.cpp`, `*.hpp`, `go.mod`, `go.sum`, `go.work` are hashed and copied. Anything else (e.g. data files, `.json` configs) is *not*. If your plugin needs to read a data file at runtime, embed it via `//go:embed` so it's part of the binary.
+- **Did you check the right cache dir?** `TTSC_CACHE_DIR` overrides the default location. `printenv TTSC_CACHE_DIR` from the consumer process if you suspect a misroute.
+- **Is the scratch dir a clue?** Force a build failure (e.g. break a `.go` file syntactically) and check `<cache>/scratch-*` immediately after — `ttsc` only deletes the scratch on success. The `go.work` file there shows exactly what overlay was applied.
+
+## Logging
+
+By default `ttsc` writes one stderr line per cache miss:
+
+```
+ttsc: building source plugin "my-plugin" from /abs/path/go-plugin (this runs once per cache key)
+```
+
+Cache hits log nothing. There is no separate `--verbose` flag for plugin builds today; the `--verbose` build flag affects the per-plugin pipeline summary, not the build orchestration.
+
+## Concurrency
+
+`ttsc` itself is single-threaded but plugin builds are safe under concurrent invocations:
+
+- Each `ttsc` process creates its own `scratch-<key>-<pid>-<timestamp>/` directory, so no two processes write to the same scratch.
+- The final `<cache>/<key>/plugin` is produced by `fs.renameSync`, which is atomic on POSIX and on Windows (single filesystem). The "last writer wins" but every build that uses the same `<key>` produces a bit-identical binary, so the winner doesn't matter.
+- Cache *reads* are simple `fs.existsSync` + `spawnSync` — they don't take any lock.
+
+If two consumer processes both miss the same cache key simultaneously, both will build. That's wasteful but correct. For the typical case (one developer, one terminal) it never happens; for parallelized CI fan-out, expect occasional duplicate builds for the very first invocation across N machines.
+
+## Things `ttsc` deliberately does not do
+
+- **Run `go mod tidy`** in your scratch dir. This would silently rewrite your `go.sum`. The overlay's `use` directives are enough to resolve imports without tidying.
+- **Vendor your dependencies.** The `go.work` overlay handles resolution at build time; vendoring would defeat that.
+- **Cache the scratch dir between builds.** Scratch is per-build, deleted on success, so a failed build's state doesn't poison the next attempt.
+- **Watch your plugin source for changes.** If you edit your plugin's `.go` files mid-session, the next `ttsc` invocation will rehash → cache miss → rebuild. There is no file-watcher daemon.

--- a/docs/plugins/06-publishing.md
+++ b/docs/plugins/06-publishing.md
@@ -1,0 +1,110 @@
+# Publishing Your Plugin to npm
+
+Your plugin is one npm package containing JS manifest + Go source. Publishing it is mostly the same as any other npm package, with a few `ttsc`-specific gotchas around what ships in the tarball and how to express compatibility.
+
+## `package.json` essentials
+
+```json
+{
+  "name": "ttsc-plugin-uppercase",
+  "version": "0.1.0",
+  "description": "Uppercases goUpper(\"...\") string literals.",
+  "main": "plugin.cjs",
+  "files": [
+    "plugin.cjs",
+    "go-plugin"
+  ],
+  "peerDependencies": {
+    "ttsc": "^0.4.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": ["ttsc", "ttsc-plugin", "tsgo"],
+  "repository": "github:you/ttsc-plugin-uppercase",
+  "license": "MIT"
+}
+```
+
+### `files` is the most common mistake
+
+Anything not listed in `files` (and not in npm's default-included set) **does not ship**. Forgetting `go-plugin` is the #1 cause of "native.source.dir does not exist" on a fresh install. Always include:
+
+- The JS manifest entry (`plugin.cjs` here).
+- The entire Go source directory (`go-plugin/`).
+- `README.md`, `LICENSE` (npm includes these by default but listing is fine).
+
+Run `npm pack --dry-run` before publishing — npm prints exactly what will go into the tarball. Eyeball the list. If `go-plugin/main.go` isn't there, your consumers can't build the plugin.
+
+### `peerDependencies` for `ttsc`
+
+Pin a range against the `ttsc` minor your plugin was tested against. Within a `contractVersion: 1` window you can usually allow `^` (caret) ranges; bump the range when you've actually verified against the next minor.
+
+```json
+"peerDependencies": {
+  "ttsc": "^0.4.0"
+}
+```
+
+Don't list `ttsc` in `dependencies` — that would force consumers to install a duplicate copy. Don't list it in `devDependencies` either; the consumer is already installing `ttsc` themselves. Peer is the correct relationship.
+
+### `@typescript/native-preview` is *not* your peer dep
+
+Even though your plugin transitively depends on `tsgo` symbols, you do **not** declare `@typescript/native-preview` as a peer. The consumer installs it for `ttsc`'s sake and that single copy is what your plugin's `go.work` overlay points at. Adding it to your `peerDependencies` would create version-pinning friction without benefit.
+
+### `engines.node`
+
+Match `ttsc`'s own minimum (`>=18`). You don't need to be stricter unless your manifest's JS uses features beyond that.
+
+## Versioning policy
+
+A practical rule of thumb for plugin authors:
+
+| Change | Bump |
+| --- | --- |
+| Bug fix in transform logic | patch |
+| New mode (additive in `--plugins-json` dispatch) | minor |
+| Renamed/removed mode | major |
+| Tightened tsconfig requirements (e.g. now requires `strict: true`) | minor or major depending on how many consumers break |
+| Bumped `peerDependencies` range for `ttsc` | minor (this is a compat hint, not a behavior change) |
+| Removed support for an older `ttsc` minor | major |
+
+`contractVersion` (in your manifest's `native` object) is the *protocol* version, not your plugin's. You don't bump it; `ttsc` does. As long as `ttsc` reports `contractVersion: 1`, your plugin keeps the value at `1`.
+
+## Pre-publish checklist
+
+- `npm pack --dry-run` shows `plugin.cjs` and `go-plugin/main.go` (and `go.mod`/`go.sum` if your plugin has them) in the tarball.
+- A clean install (`mkdir /tmp/x && cd /tmp/x && npm init -y && npm i -D ttsc /path/to/your/plugin.tgz`) produces a working `npx ttsc --emit` against a sample tsconfig that lists your plugin.
+- Your plugin's compiled binary actually runs on your target platform. Cross-platform: test at minimum on Linux + macOS; Windows if you're brave (CI matrix is the easy way).
+- Versioning: if you've removed a mode or changed a transform's behavior, the version bump reflects it.
+- Documentation: a `README.md` with at least a one-paragraph "what does this plugin do" + a tsconfig snippet showing how a consumer enables it.
+
+## Publish
+
+```bash
+npm publish
+```
+
+That's it. Consumers install with `npm i -D <your-plugin>` and add `{ "transform": "<your-plugin>" }` to their `compilerOptions.plugins`.
+
+## Beta / next-tag releases
+
+When you're iterating quickly:
+
+```bash
+npm version prerelease --preid=beta
+npm publish --tag beta
+```
+
+Consumers opt in with `npm i -D your-plugin@beta`. Keep the `latest` tag pointing at a known-good version — `ttsc`'s plugin error messages name your plugin, but they don't help when the breakage is in the `latest` tag.
+
+## What happens on the consumer's first install
+
+For context (so you know what to test for):
+
+1. `npm i -D your-plugin` puts your tarball under `node_modules/your-plugin/`.
+2. The consumer adds `{ "transform": "your-plugin" }` to `compilerOptions.plugins`.
+3. The first `npx ttsc` invocation reads your `plugin.cjs`, hashes your Go source, and runs `go build` against `ttsc`'s pinned shim. Cold-cache time: depends mostly on Go's module cache state on the consumer's machine. With a warm Go cache, plugin build is usually under 5 seconds. Cold first-ever Go cache: tens of seconds (Go is downloading `typescript-go`).
+4. The compiled binary lands in `~/.cache/ttsc/plugins/<sha>/plugin` and is reused on subsequent invocations.
+
+If your tarball is missing `go-plugin/`, step 3 fails immediately with `native.source.dir does not exist`. That's the single biggest pre-publish thing to verify.

--- a/docs/plugins/07-testing.md
+++ b/docs/plugins/07-testing.md
@@ -1,0 +1,196 @@
+# Testing Your Plugin
+
+A plugin has two layers, and both need tests:
+
+- **Unit tests** in Go for your transformer logic — fast, deterministic, no `ttsc` involvement.
+- **Integration tests** that actually run `ttsc` against a sample consumer project with your plugin wired in — slower but catches manifest, protocol, and end-to-end issues.
+
+This page is opinionated about layouts that work; copy and adapt.
+
+## Unit tests (Go side)
+
+Pull your transform logic into a function the test can call directly:
+
+```go
+// go-plugin/main.go (excerpt)
+package main
+
+func transform(source string, plugins []Plugin) (string, error) {
+    // …
+}
+```
+
+```go
+// go-plugin/main_test.go
+package main
+
+import (
+    "strings"
+    "testing"
+)
+
+func TestTransformUppercase(t *testing.T) {
+    out, err := transform(`export const value: string = goUpper("hello"); console.log(value);`, nil)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if !strings.Contains(out, `"HELLO"`) {
+        t.Fatalf("expected uppercase value, got:\n%s", out)
+    }
+}
+
+func TestTransformOrderedPipeline(t *testing.T) {
+    plugins := []Plugin{
+        {Mode: "prefix", Config: map[string]any{"prefix": "A:"}},
+        {Mode: "uppercase"},
+        {Mode: "suffix", Config: map[string]any{"suffix": ":Z"}},
+    }
+    out, err := transform(`export const v: string = goUpper("plugin"); console.log(v);`, plugins)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if !strings.Contains(out, `"A:PLUGIN:Z"`) {
+        t.Fatalf("expected ordered pipeline output, got:\n%s", out)
+    }
+}
+```
+
+Run with `go test ./go-plugin/...`. With the local `go.work` from [04-local-dev.md](./04-local-dev.md) set up, you can also use `gopls`-aware `go test -run TestX` selection from your editor.
+
+### What to put in unit tests
+
+- **Transform correctness** — happy path for each `mode` you support, including ordered pipelines.
+- **Config edge cases** — missing config, wrong types, empty strings.
+- **Errors** — when source doesn't match the pattern your plugin expects, the error message is what the consumer sees.
+- **Determinism** — same input → same output. If you generate code, sort keys and stable-format your output so test diffs are clean.
+
+### What *not* to put in unit tests
+
+- Anything that requires a real `Program` or `Checker`. That's integration territory — bootstrapping a tsgo `Program` in a unit test means parsing a real tsconfig, which means a real on-disk fixture, which means you're already writing integration code. Keep that in the integration suite.
+- Network calls. If your plugin reaches out (e.g., to fetch schemas), inject the client and test against a fake.
+
+## Integration tests
+
+Integration tests run `ttsc` against a fixture project that uses your plugin and assert on the resulting `dist/` output.
+
+### Recommended layout
+
+```
+your-plugin/
+├── package.json
+├── plugin.cjs
+├── go-plugin/
+│   ├── go.mod
+│   ├── main.go
+│   └── main_test.go
+└── tests/
+    ├── package.json                   # workspace member, depends on ../
+    ├── helpers.cjs                    # shared spawn() / project setup
+    └── fixtures/
+        ├── basic/
+        │   ├── tsconfig.json
+        │   └── src/main.ts
+        └── ordered/
+            ├── tsconfig.json
+            └── src/main.ts
+```
+
+A minimal `tests/package.json`:
+
+```json
+{
+  "private": true,
+  "scripts": {
+    "test": "node --test --test-reporter=spec test/*.test.cjs"
+  },
+  "devDependencies": {
+    "ttsc": "^0.4.0",
+    "@typescript/native-preview": "*"
+  }
+}
+```
+
+A minimal `tests/test/basic.test.cjs`:
+
+```js
+const assert = require("node:assert/strict");
+const child_process = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const ttscBin = require.resolve("ttsc/lib/launcher/ttsc.js");
+const fixtures = path.resolve(__dirname, "..", "fixtures");
+
+function copyFixture(name) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), `your-plugin-${name}-`));
+  fs.cpSync(path.join(fixtures, name), tmp, { recursive: true });
+  return tmp;
+}
+
+test("basic: goUpper rewrites string literals", () => {
+  const root = copyFixture("basic");
+  const result = child_process.spawnSync(
+    process.execPath,
+    [ttscBin, "--cwd", root, "--emit"],
+    { encoding: "utf8", windowsHide: true },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+  assert.match(js, /"HELLO"/);
+});
+```
+
+Each test copies a fixture to a tmp dir (so the build artifacts don't pollute your repo), runs `ttsc`, asserts on the output. Use `node:test` (built into Node 18+) — no extra dep.
+
+### Cache isolation in tests
+
+Each test run hits the cache. To force a cold build, set `TTSC_CACHE_DIR` to a fresh tmp directory in your test's spawn env. To keep tests fast across the suite, share one cache dir across all tests in the run:
+
+```js
+const sharedCache = fs.mkdtempSync(path.join(os.tmpdir(), "your-plugin-cache-"));
+// pass to every spawn:
+env: { ...process.env, TTSC_CACHE_DIR: sharedCache },
+```
+
+The first integration test cold-builds (one `go build`), the rest hit cache. Set this once per run, not per test.
+
+### Common assertions
+
+- **Output content** — `assert.match(jsContent, /<pattern>/)`. Don't snapshot the entire file; the build pipeline emits boilerplate that's allowed to change.
+- **Stderr clean** — when status is 0, stderr should typically be empty (or contain only the one-line "building source plugin" log on cache miss). Trailing diagnostics often indicate problems even when the exit code is success.
+- **Specific error messages** — for failure-path tests, `assert.match(result.stderr, /your specific error string/)`.
+
+## Cross-platform CI
+
+Test on at least Linux + macOS. Windows is the trickiest:
+
+- File paths use backslashes. Most of your plugin code touches paths via `path.Join`/`filepath.Join` so this is handled, but watch for any place you compare path strings directly.
+- Process spawn quoting differs subtly. Use `windowsHide: true` and avoid shell-string commands.
+- The plugin's compiled binary on Windows is `plugin.exe`, not `plugin`. `ttsc` handles this automatically; just don't hard-code the binary name in your own integration tests.
+
+A reasonable CI matrix:
+
+```yaml
+os: [ubuntu-latest, macos-latest, windows-latest]
+node-version: [18, 20, 22]
+go-version: ["1.26"]
+```
+
+Three platforms × three Node versions × one Go version = 9 jobs. Skip the Windows × Node-18 cell if you want to trim.
+
+## Ongoing: regression test for the symbol *you import*
+
+If your plugin imports `shim/checker.GetTypeAtLocation` (hypothetical), add a test that exercises that exact path. When `ttsc` bumps `tsgo` and the symbol moves or changes, the cached binary recompiles, and *that* is when you find out. Catching it in your integration suite, not in production, is the entire point of the source-distribution model.
+
+A bare-minimum smoke test for tsgo imports:
+
+```js
+test("tsgo shim imports still resolve after ttsc upgrade", () => {
+  // run a fixture that exercises every shim package your plugin imports
+  // assert the build succeeds and produces the expected output
+});
+```
+
+Run this in CI on every `ttsc` minor bump (or pin a specific `ttsc` and only update intentionally).

--- a/docs/plugins/08-recipes.md
+++ b/docs/plugins/08-recipes.md
@@ -1,0 +1,195 @@
+# Recipes: Common Patterns
+
+Once you have a hello-world plugin running, these are the patterns that come up most often. Each recipe is short — pick the ones that match what you're building.
+
+## Multi-mode dispatch
+
+A single plugin binary that supports several behaviors. The consumer picks behavior per tsconfig entry; your binary dispatches by `mode` from `--plugins-json`.
+
+```go
+type Plugin struct {
+    Config map[string]any `json:"config"`
+    Mode   string         `json:"mode"`
+    Name   string         `json:"name"`
+}
+
+func runOnePipeline(value string, plugins []Plugin) (string, error) {
+    for _, p := range plugins {
+        switch p.Mode {
+        case "uppercase":
+            value = strings.ToUpper(value)
+        case "lowercase":
+            value = strings.ToLower(value)
+        case "prefix":
+            value = stringConfig(p.Config, "prefix") + value
+        case "suffix":
+            value += stringConfig(p.Config, "suffix")
+        default:
+            return "", fmt.Errorf("unsupported mode %q", p.Mode)
+        }
+    }
+    return value, nil
+}
+
+func stringConfig(c map[string]any, key string) string {
+    if c == nil {
+        return ""
+    }
+    v, _ := c[key].(string)
+    return v
+}
+```
+
+The consumer wires modes through tsconfig:
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [
+      { "transform": "my-plugin", "mode": "prefix", "prefix": "A:" },
+      { "transform": "my-plugin", "mode": "uppercase" },
+      { "transform": "my-plugin", "mode": "suffix", "suffix": ":Z" }
+    ]
+  }
+}
+```
+
+`ttsc` ships these as one ordered array in `--plugins-json`. Apply them in order; that's how the consumer expresses "prefix-then-upper-then-suffix" without your binary knowing about pipeline ordering.
+
+## Reading config from `--plugins-json`
+
+The full tsconfig entry — including arbitrary user fields — flows through `config`:
+
+```json
+[
+  {
+    "name": "primary",
+    "mode": "uppercase",
+    "config": {
+      "transform": "my-plugin",
+      "name": "primary",
+      "mode": "uppercase",
+      "myCustomField": { "nested": true, "items": [1, 2, 3] }
+    },
+    "contractVersion": 1
+  }
+]
+```
+
+In Go, decode with `map[string]any` and assert types per field, or define a typed struct that matches the fields you care about:
+
+```go
+type MyPluginConfig struct {
+    MyCustomField struct {
+        Nested bool  `json:"nested"`
+        Items  []int `json:"items"`
+    } `json:"myCustomField"`
+}
+
+func parseMyConfig(raw map[string]any) (*MyPluginConfig, error) {
+    bytes, _ := json.Marshal(raw)
+    var cfg MyPluginConfig
+    if err := json.Unmarshal(bytes, &cfg); err != nil {
+        return nil, err
+    }
+    return &cfg, nil
+}
+```
+
+`encoding/json` ignores fields it doesn't know about, so you only declare what you need. Don't error on unknown fields — `transform`, `name`, `mode`, `enabled` are all `ttsc`-managed extras the consumer didn't write themselves.
+
+## Surfacing diagnostics back to `ttsc`
+
+When your transform fails, write to stderr and exit non-zero. `ttsc` prints stderr verbatim to the user, so format it for human reading:
+
+```go
+fmt.Fprintf(os.Stderr, "my-plugin: %s:%d: invalid type argument %q (expected interface or type alias)\n", file, line, name)
+return 2
+```
+
+Exit codes:
+
+- `0` — success.
+- `2` — argument or usage error (bad CLI flags, missing required input).
+- Any other non-zero — runtime / transform error. `ttsc` treats these the same way; the only reason to differentiate is for your own debugging.
+
+For *warnings* you want to surface but not fail on, write to stderr and still exit `0`. `ttsc` will print them; the consumer's build keeps going.
+
+## Multi-file output (e.g., generated `.d.ts`)
+
+The `transform` subcommand only writes one file. For project-wide builds you control your own file outputs through `runBuild`:
+
+```go
+func runBuild(args []string) int {
+    // ... parse flags ...
+    program, release, _ := bootstrap(cwd, tsconfigPath)
+    defer release()
+
+    for _, sourceFile := range program.SourceFiles() {
+        if !shouldTransform(sourceFile) {
+            continue
+        }
+        rewrittenJS, err := transformSourceFile(sourceFile)
+        if err != nil { /* log and continue or fail */ }
+        outPath := mapToOutPath(sourceFile.FileName(), outDir)
+        os.MkdirAll(filepath.Dir(outPath), 0o755)
+        os.WriteFile(outPath, []byte(rewrittenJS), 0o644)
+
+        // Optional: emit a sidecar file
+        if extra := generateSchema(sourceFile); extra != "" {
+            os.WriteFile(strings.TrimSuffix(outPath, ".js")+".schema.json", []byte(extra), 0o644)
+        }
+    }
+    return 0
+}
+```
+
+`ttsc` invokes `build` once per project compile; you have free reign within `--outDir`. Don't write outside that directory — consumers expect their build artifacts to be confined there.
+
+## Watch mode cooperation
+
+`ttsc --watch` re-invokes your binary on every file change. There's nothing special you need to do — the cache makes re-invocations cheap (no re-build of your binary, just a fresh process). But:
+
+- Don't keep state in global vars expecting it to persist across invocations. Each invocation is a fresh process.
+- Don't write to the cache directory yourself. `ttsc` owns that path.
+- If your transform is expensive (e.g., schema generation per file), you can use a content-addressed cache *inside* your output directory — write `<outDir>/.cache/<hash>.json` and check before regenerating. Just clean it up when the source goes away.
+
+## Source maps (preserving consumer source maps)
+
+`ttsc` itself runs `tsgo` for the actual TypeScript→JavaScript compile, including source maps. Your plugin transforms the *emitted JS*. If you do non-trivial line/column changes, the source map points at lines that no longer exist.
+
+Two practical approaches:
+
+- **Don't rewrite line counts.** Replace text in place with same-line content. The consumer's source map remains correct.
+- **Emit your own source map.** If your transform substantially restructures the file, generate a `.js.map` next to the output and ship that. This is significant work; only do it if your plugin's transforms are too aggressive for line-preserving edits.
+
+Most plugins (typia-class) emit imports + same-line call replacements and don't need source map generation.
+
+## Ordered pipelines that span multiple plugins
+
+When the consumer mixes `transform: "plugin-a"` and `transform: "plugin-b"` in their tsconfig, **they're not part of the same pipeline**. `ttsc` only collapses into one binary when entries point to the same `source.dir` (i.e., the same physical Go module). Different plugins → different binaries → `ttsc` rejects the project at config-parse time with `ordered native plugin pipeline requires a single native host binary`.
+
+This is intentional. Cross-plugin composition is a project-architecture problem; one option is to publish a "meta-plugin" binary that other plugins integrate with at the source level. Another is to do plugin composition through tsgo's normal compiler-plugin chain (out of scope here).
+
+For *within-plugin* pipelines (multiple modes, one binary), see [Multi-mode dispatch](#multi-mode-dispatch) above.
+
+## Versioning a plugin against multiple `ttsc` minors
+
+If your `peerDependencies` says `^0.4.0` and `ttsc` ships `0.5.0` with a renamed shim symbol, your plugin source breaks. Two strategies:
+
+1. **Ship a new major.** Conservative — `your-plugin@2.x` for `ttsc@^0.5.x`, `your-plugin@1.x` for `ttsc@^0.4.x`. Consumers pin both.
+2. **Conditional Go build with version detection.** Read `node_modules/ttsc/package.json` from the plugin manifest, branch based on version, point `source.dir` at different Go modules per ttsc-version. Complex; only worth it for plugins with very large deployed user bases.
+
+Most plugins go with option 1. The cost (plugin major bump per ttsc minor that touches shim symbols you use) is real but bounded — the shim surface doesn't churn often within `contractVersion: 1`.
+
+## Plugin doesn't need tsgo at all
+
+Some plugins are pure source-text rewriters (custom JSX dialect, macro expansion, code-mod-style transforms). You don't have to import any shim. Your `go.mod` is just:
+
+```
+module my-plugin
+
+go 1.26
+```
+
+No `require` lines, no `go.work` setup, no [04-local-dev.md](./04-local-dev.md) ceremony. Standalone `go build ./go-plugin` works on your machine without `ttsc` touching anything. Skip everything tsgo-related; come back when you outgrow regex.

--- a/docs/plugins/09-pitfalls.md
+++ b/docs/plugins/09-pitfalls.md
@@ -1,0 +1,150 @@
+# First-Contact Pitfalls
+
+Top failures plugin authors hit in the first hour. Read this once, save the corresponding hour.
+
+## 1. `native.source.dir does not exist`
+
+You published your plugin and the consumer hits this on first install.
+
+**Cause.** The Go source directory wasn't included in your npm tarball. By default npm publishes a curated set of files; your plugin's `go-plugin/` directory needs to be explicitly listed.
+
+**Fix.** In `package.json`:
+
+```json
+"files": [
+  "plugin.cjs",
+  "go-plugin"
+]
+```
+
+Run `npm pack --dry-run` before publishing to verify the tarball includes `go-plugin/main.go`, `go-plugin/go.mod`, etc. See [06-publishing.md](./06-publishing.md#files-is-the-most-common-mistake).
+
+## 2. `native.source.dir does not exist` (path resolution variant)
+
+Same error, different cause. Your `plugin.cjs` uses a relative path that breaks once the package is installed under `node_modules/`.
+
+**Cause.**
+
+```js
+// WRONG — resolves against process.cwd(), not the plugin's own location
+source: { dir: "./go-plugin" }
+```
+
+**Fix.**
+
+```js
+// RIGHT — resolves against the .cjs file's own directory
+source: { dir: path.resolve(__dirname, "go-plugin") }
+```
+
+`__dirname` is the directory of the `.cjs` file at runtime, regardless of where it's installed. Always use it.
+
+## 3. `no required module provides package github.com/microsoft/typescript-go/shim/X`
+
+You imported a tsgo shim and forgot to add a `require` line.
+
+**Fix.** In your plugin's `go.mod`:
+
+```
+require github.com/microsoft/typescript-go/shim/X v0.0.0
+```
+
+The `v0.0.0` is a placeholder; `ttsc`'s `go.work` overlay supplies real resolution at build time. Required for *every* shim package you import. See [03-tsgo.md](./03-tsgo.md#how-to-use-a-shim--the-current-rules) for the full rule.
+
+## 4. gopls highlights tsgo imports as unresolved
+
+You added the `require`, the build works under `ttsc`, but your editor shows red squiggles on every shim import. Autocomplete on `shimcore.` doesn't work.
+
+**Cause.** Your editor's gopls runs in your repo's own context and looks for a workspace at the repo root. Without one, it can't resolve `shim/X` to the actual local source under `node_modules/ttsc/`.
+
+**Fix.** Set up `go.work` at your repo root pointing at `./node_modules/ttsc/...`. See [04-local-dev.md](./04-local-dev.md) for the full template. After saving `go.work`, restart gopls (in VS Code: `> Go: Restart Language Server`).
+
+## 5. pnpm: `go.work` use directives can't find `ttsc`
+
+You followed [04-local-dev.md](./04-local-dev.md) but `go build` fails with "directory ./node_modules/ttsc does not exist".
+
+**Cause.** pnpm's default `node-linker=isolated` puts dependencies under `node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg>/`, not the flat `node_modules/<pkg>/` layout. Your `go.work` paths don't resolve.
+
+**Fix.** Easiest: add `node-linker=hoisted` to your plugin repo's `.npmrc`:
+
+```ini
+# .npmrc
+node-linker=hoisted
+```
+
+Reinstall (`pnpm install`). Now `node_modules/ttsc/` exists at the top level. Your published plugin still works for any consumer regardless of their package manager — this only changes *your* dev setup.
+
+Alternatives discussed in [04-local-dev.md](./04-local-dev.md#step-by-step) under the pnpm note.
+
+## 6. `--plugins-json` not parsed → modes ignored
+
+Your plugin works for one tsconfig entry but ignores config when the consumer adds multiple modes.
+
+**Cause.** Your binary's `transform`/`build` subcommand declares a `--plugins-json` flag but doesn't actually use it.
+
+**Fix.** Parse the flag and dispatch by `mode` in array order. Minimum useful skeleton:
+
+```go
+type Plugin struct {
+    Config map[string]any `json:"config"`
+    Mode   string         `json:"mode"`
+}
+
+pluginsJSON := fs.String("plugins-json", "", "")
+// ... after fs.Parse ...
+var plugins []Plugin
+if *pluginsJSON != "" {
+    if err := json.Unmarshal([]byte(*pluginsJSON), &plugins); err != nil {
+        // handle
+    }
+}
+for _, p := range plugins {
+    // dispatch by p.Mode, read p.Config
+}
+```
+
+See [08-recipes.md](./08-recipes.md#multi-mode-dispatch) for the full pattern.
+
+## 7. "ordered native plugin pipeline requires a single native host binary"
+
+The consumer wired two different plugins (`plugin-a`, `plugin-b`) and `ttsc` rejects the build at config-parse time.
+
+**Cause.** Each plugin compiles to a separate binary. `ttsc`'s contract is one binary per project compile; mixing two plugins produces two binaries with no way to merge them.
+
+**Fix.** This is a constraint the consumer has to resolve, not the plugin author. The consumer either picks one plugin or finds a "meta-plugin" that subsumes both. Plugin authors writing in this space sometimes ship a single binary that registers multiple modes (see [08-recipes.md](./08-recipes.md#multi-mode-dispatch)) so consumers can mix capabilities without mixing binaries.
+
+## 8. Plugin builds locally, fails on Windows CI
+
+Cross-platform issue. Common variants:
+
+**Path separator.** `filepath.ToSlash(p)` before string-comparing paths from `program.SourceFiles()` and your `--file` argument.
+
+**Binary name.** On Windows the cached binary is `plugin.exe`. `ttsc` handles this transparently; don't hard-code `plugin` (no `.exe`) anywhere in your own integration tests.
+
+**Line endings.** If your transform asserts on regex matches against source text, account for `\r\n` line endings. `(?m)` mode in Go's regexp doesn't strip `\r`; use `\r?\n` or normalize first.
+
+## 9. Transform output looks right, but consumer's runtime errors
+
+Your `dist/main.js` *looks* correct, but `node dist/main.js` throws `ReferenceError: foo is not defined` or similar.
+
+**Cause.** Your transform omitted a CommonJS boilerplate line that the consumer's other emitted JS expects. The most common culprits:
+
+- Missing `"use strict";` at the top.
+- Missing `Object.defineProperty(exports, "__esModule", { value: true });`.
+- Missing `exports.X = void 0;` declarations before assignments.
+
+**Fix.** Mirror what `tsc`/`tsgo` itself emits for a CommonJS module. The fixture in [`tests/projects/go-source-plugin/go-plugin/main.go`](../../tests/projects/go-source-plugin/go-plugin/main.go) shows the minimum boilerplate.
+
+## 10. Cache hits when you expected a rebuild
+
+You edited a file in `go-plugin/` and re-ran `ttsc`, but stderr doesn't show the rebuild log.
+
+**Cause.** The file you edited is excluded from the cache hash. `ttsc` only hashes files matching `*.go`, `*.s`, `*.c`, `*.h`, `*.cpp`, `*.hpp`, `go.mod`, `go.sum`, `go.work`. Editing a `README.md` or a `data.json` your plugin reads at runtime does not invalidate the cache.
+
+**Fix.** If your plugin needs to read a runtime data file, embed it via `//go:embed` so it's part of the binary. The compiled binary is cache-key-invalidated on Go source change, so the embedded data updates with it.
+
+If you really need cache invalidation on a non-source file, set `TTSC_CACHE_DIR` to a fresh dir for the run, or `rm -rf ~/.cache/ttsc/plugins/`.
+
+---
+
+If you hit one not on this list and it took you longer than 30 minutes to figure out, that's evidence to add it here. Open an issue or PR.

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,0 +1,107 @@
+# ttsc Plugin Author Guide
+
+This guide is for people writing transformer plugins on top of `ttsc` — Go programs that `ttsc` compiles locally on each consumer's machine and runs as part of the TypeScript compilation pipeline.
+
+> **Status: v1, in flux.** The CLI protocol fields and JS manifest shape may still change before stabilization. Pin a specific `ttsc` minor version in your plugin's `peerDependencies` until v1.0.
+
+## A 30-second preview
+
+Your consumer writes ordinary TypeScript with a hook your plugin recognizes — for example, a call to `goUpper("hello")`:
+
+```ts
+// src/main.ts (consumer)
+export const value: string = goUpper("hello");
+console.log(value);
+```
+
+You publish a tiny npm package with two files: a JS manifest and a Go source file.
+
+```js
+// plugin.cjs
+const path = require("node:path");
+module.exports = {
+  name: "my-plugin",
+  native: {
+    mode: "uppercase",
+    source: { dir: path.resolve(__dirname, "go-plugin") },
+    contractVersion: 1,
+  },
+};
+```
+
+```go
+// go-plugin/main.go (excerpt — full version in 01-getting-started.md)
+func transform(source string) (string, error) {
+    match := goUpperCall.FindStringSubmatch(source)
+    name, value := match[1], strings.ToUpper(match[2])
+    return fmt.Sprintf(`const %s = %q; exports.%s = %s;`, name, value, name, name), nil
+}
+```
+
+The consumer runs `npx ttsc --emit`. `ttsc` reads your manifest, compiles your Go source against its own pinned `typescript-go` (cached afterwards), and runs the resulting binary against each `.ts` file:
+
+```js
+// dist/main.js (after transform)
+const value = "HELLO";
+exports.value = value;
+console.log(value);
+```
+
+That's the whole loop. Read on for the mental model and the contracts that hold this together.
+
+## Mental model
+
+A `ttsc` plugin has two halves living inside one npm package:
+
+1. **JS manifest** — a `.cjs` (or `.js`) file referenced from the user's `compilerOptions.plugins`. It declares your plugin's name and how it should be backed at runtime: which Go source directory to build, what mode the user-facing transform expects, what protocol version you speak.
+2. **Go source** — a real Go module shipped *inside the npm package*. `ttsc` compiles it locally on the user's machine into a CLI binary that speaks `ttsc`'s plugin protocol.
+
+When a project's `tsconfig.json` references your plugin, `ttsc`:
+
+1. Reads your manifest.
+2. Hashes your Go source (plus `ttsc` version, `tsgo` version, platform/arch, entry).
+3. On cache hit (`~/.cache/ttsc/plugins/<hash>/plugin`), loads the existing binary.
+4. On cache miss, compiles your Go source against `ttsc`'s pinned `typescript-go` shim and caches the result.
+5. Spawns the binary against the user's `tsconfig` and source files, passing your config through `--plugins-json`.
+
+You publish the npm package once. End users do *not* need a precompiled binary in your tarball — `ttsc` builds it for them at first invocation.
+
+## Why Go source instead of a precompiled binary?
+
+A precompiled binary plugin has to match three independent versions exactly: `ttsc`'s pinned `typescript-go`, `ttsc` itself, and the plugin. A skew between any two breaks consumers silently at *load* time.
+
+Go interfaces are structural. When `ttsc` rebuilds your plugin source against its own pinned shim, your plugin only has to satisfy the parts of the API it actually touches. Unrelated additions or renames elsewhere in `typescript-go` are invisible to your plugin. Real semantic breaks (a method *you call* is renamed) still fail — but they fail at *build time* with a clear Go compile error, not silently at load time. The failure surface moves from "ABI-mismatch hell" into a debuggable region.
+
+This is the same model `xcaddy` uses for Caddy modules.
+
+## What's in this guide
+
+Read in order:
+
+1. [01-getting-started.md](./01-getting-started.md) — copy-paste a working plugin in ~10 minutes.
+2. [02-protocol.md](./02-protocol.md) — full reference for the JS manifest and the CLI protocol your compiled binary must implement.
+3. [03-tsgo.md](./03-tsgo.md) — importing `typescript-go` AST / Checker / Scanner from your plugin, including the bootstrap pattern for typia-class semantic plugins.
+4. [04-local-dev.md](./04-local-dev.md) — set up `go.work` so gopls / `go build` / `go test` all work standalone in your dev loop. (Only needed if your plugin imports tsgo shims.)
+5. [05-internals.md](./05-internals.md) — how `ttsc` builds and caches your plugin (debugging aid).
+6. [06-publishing.md](./06-publishing.md) — npm publish workflow, `peerDependencies` policy, the `files` field gotcha.
+7. [07-testing.md](./07-testing.md) — Go unit tests for transform logic, integration tests via `ttsc` against fixtures.
+8. [08-recipes.md](./08-recipes.md) — common patterns: multi-mode dispatch, `--plugins-json` config, diagnostics, watch mode, source maps.
+9. [09-pitfalls.md](./09-pitfalls.md) — first-contact mistakes and their fixes. Skim once, save an hour.
+
+## Concrete reference plugins (in this repo)
+
+These are the fixtures `ttsc`'s own test suite uses. They're the most authoritative working examples until a published plugin SDK exists:
+
+- [`tests/projects/go-source-plugin/`](../../tests/projects/go-source-plugin/) — a 5-mode transformer (uppercase / lowercase / prefix / suffix / reverse) that parses `--plugins-json` and dispatches by mode. Exercise the most surfaces.
+- [`tests/projects/go-source-plugin-entry/`](../../tests/projects/go-source-plugin-entry/) — same shape but with the build entry under `cmd/transformer/` to demonstrate `native.source.entry`.
+- [`tests/projects/go-source-plugin-tsgo/`](../../tests/projects/go-source-plugin-tsgo/) — imports `github.com/microsoft/typescript-go/shim/core` to prove the go.work overlay actually wires `ttsc`'s pinned shim into the plugin build.
+- [`tests/projects/go-source-plugin-checker/`](../../tests/projects/go-source-plugin-checker/) — bootstraps a real `Program` and `Checker` from the consumer's tsconfig and locates the target source file. See [03-tsgo.md](./03-tsgo.md#bootstrapping-a-program-and-a-checker).
+- [`tests/projects/go-source-plugin-properties/`](../../tests/projects/go-source-plugin-properties/) — walks every program source file's AST, finds each `InterfaceDeclaration`, and emits its property names as a JSON array literal. The reference for typia-class semantic plugins; see [03-tsgo.md](./03-tsgo.md#walking-the-ast).
+
+## Requirements (current)
+
+- Node.js ≥ 18 (consumer side)
+- Go ≥ 1.26 on the consumer's PATH, or the consumer sets `TTSC_GO_BINARY` to an absolute path
+- The consumer project has `@typescript/native-preview` installed (this is the standard `tsgo` package)
+
+> **Roadmap:** the Go toolchain dependency will be replaced by `ttsc-go-<platform>` npm subpackages bundled under `optionalDependencies` so casual JS users don't need a system Go install. See [05-internals.md](./05-internals.md#go-toolchain).

--- a/packages/ttsc/src/native.ts
+++ b/packages/ttsc/src/native.ts
@@ -1,9 +1,15 @@
 export type NativeRewriteMode = string;
 export type NativePluginContractVersion = 1;
 
+export interface TtscNativeSource {
+  dir: string;
+  entry?: string;
+}
+
 export interface TtscNativeBackend {
   mode: NativeRewriteMode;
   binary?: string;
+  source?: TtscNativeSource;
   contractVersion?: NativePluginContractVersion;
   capabilities?: readonly string[];
 }
@@ -52,6 +58,18 @@ export function resolveNativeBackend(
     throw new Error(
       `ttsc: plugin "${plugin.name}" requested unsupported native contract version ${backend.contractVersion}`,
     );
+  }
+  if (backend.source) {
+    if (backend.binary) {
+      throw new Error(
+        `ttsc: plugin "${plugin.name}" must use either native.binary or native.source, not both`,
+      );
+    }
+    if (typeof backend.source.dir !== "string" || backend.source.dir.length === 0) {
+      throw new Error(
+        `ttsc: plugin "${plugin.name}" native.source.dir must be a non-empty string`,
+      );
+    }
   }
   return {
     ...backend,

--- a/packages/ttsc/src/plugin.ts
+++ b/packages/ttsc/src/plugin.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -11,11 +12,13 @@ import {
   type ProjectPluginConfig,
   readProjectConfig,
 } from "./project";
+import { buildSourcePlugin } from "./source-build";
 
 export type {
   NativePluginContractVersion,
   NativeRewriteMode,
   TtscNativeBackend,
+  TtscNativeSource,
 } from "./native";
 
 export interface TtscPluginFactoryContext {
@@ -99,10 +102,22 @@ export function loadProjectPlugins(options: LoadPluginsOptions): LoadedPlugins {
 
   let nativeBinary: string | null = null;
   const nativePlugins: LoadedNativePlugin[] = [];
+  const ttscVersion = readTtscVersion();
+  const tsgoVersion = readTsgoVersion(context.projectRoot);
   plugins.forEach((plugin, index) => {
-    const backend = resolveNativeBackend(plugin);
+    let backend = resolveNativeBackend(plugin);
     if (!backend) {
       return;
+    }
+    if (backend.source && !backend.binary) {
+      const built = buildSourcePlugin({
+        baseDir: context.projectRoot,
+        pluginName: plugin.name,
+        source: backend.source,
+        ttscVersion,
+        tsgoVersion,
+      });
+      backend = { ...backend, binary: built };
     }
     if (backend.binary) {
       if (nativeBinary !== null && nativeBinary !== backend.binary) {
@@ -239,5 +254,38 @@ function resolveSourceCheckoutPlugin(
     return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
   } catch {
     return null;
+  }
+}
+
+let cachedTtscVersion: string | null = null;
+
+function readTtscVersion(): string {
+  if (cachedTtscVersion !== null) {
+    return cachedTtscVersion;
+  }
+  try {
+    const file = path.resolve(__dirname, "..", "package.json");
+    const pkg = JSON.parse(fs.readFileSync(file, "utf8")) as {
+      version?: string;
+    };
+    cachedTtscVersion = pkg.version ?? "0.0.0";
+  } catch {
+    cachedTtscVersion = "0.0.0";
+  }
+  return cachedTtscVersion;
+}
+
+function readTsgoVersion(projectRoot: string): string {
+  try {
+    const projectRequire = createRequire(path.join(projectRoot, "package.json"));
+    const pkgPath = projectRequire.resolve(
+      "@typescript/native-preview/package.json",
+    );
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as {
+      version?: string;
+    };
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
   }
 }

--- a/packages/ttsc/src/source-build.ts
+++ b/packages/ttsc/src/source-build.ts
@@ -1,0 +1,239 @@
+import { spawnSync } from "node:child_process";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type { TtscNativeSource } from "./native";
+
+export interface BuildSourcePluginOptions {
+  source: TtscNativeSource;
+  pluginName: string;
+  baseDir: string;
+  ttscVersion: string;
+  tsgoVersion: string;
+}
+
+export function buildSourcePlugin(opts: BuildSourcePluginOptions): string {
+  const dir = path.isAbsolute(opts.source.dir)
+    ? opts.source.dir
+    : path.resolve(opts.baseDir, opts.source.dir);
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    throw new Error(
+      `ttsc: plugin "${opts.pluginName}" native.source.dir does not exist: ${dir}`,
+    );
+  }
+  const entry = opts.source.entry ?? ".";
+  const key = computeCacheKey({
+    dir,
+    entry,
+    ttscVersion: opts.ttscVersion,
+    tsgoVersion: opts.tsgoVersion,
+  });
+  const cacheDir = path.join(cacheRoot(), key);
+  const binaryName = process.platform === "win32" ? "plugin.exe" : "plugin";
+  const binaryPath = path.join(cacheDir, binaryName);
+  if (fs.existsSync(binaryPath)) {
+    return binaryPath;
+  }
+  fs.mkdirSync(cacheDir, { recursive: true });
+  process.stderr.write(
+    `ttsc: building source plugin "${opts.pluginName}" from ${dir} (this runs once per cache key)\n`,
+  );
+
+  const scratchDir = path.join(
+    cacheRoot(),
+    `scratch-${key}-${process.pid}-${Date.now()}`,
+  );
+  try {
+    materializeScratchDir(dir, scratchDir);
+    writeGoWork(scratchDir, findTtscOverlayDirs());
+    runGoBuild(scratchDir, entry, binaryName, opts.pluginName);
+    const builtBinary = path.join(scratchDir, binaryName);
+    fs.renameSync(builtBinary, binaryPath);
+    if (process.platform !== "win32") {
+      fs.chmodSync(binaryPath, 0o755);
+    }
+    return binaryPath;
+  } finally {
+    fs.rmSync(scratchDir, { recursive: true, force: true });
+  }
+}
+
+function materializeScratchDir(source: string, scratch: string): void {
+  fs.mkdirSync(scratch, { recursive: true });
+  fs.cpSync(source, scratch, {
+    recursive: true,
+    filter: (src) => {
+      const base = path.basename(src);
+      if (SKIP_DIRS.has(base)) return false;
+      if (base === "go.work" || base === "go.work.sum") return false;
+      return true;
+    },
+  });
+}
+
+function writeGoWork(scratchDir: string, useDirs: readonly string[]): void {
+  const useLines = ["\t."];
+  for (const dir of useDirs) {
+    useLines.push(`\t${dir.replace(/\\/g, "/")}`);
+  }
+  const goWork = `go 1.26\n\nuse (\n${useLines.join("\n")}\n)\n`;
+  fs.writeFileSync(path.join(scratchDir, "go.work"), goWork, "utf8");
+}
+
+function runGoBuild(
+  cwd: string,
+  entry: string,
+  binaryName: string,
+  pluginName: string,
+): void {
+  const goBinary = resolveGoBinary();
+  const result = spawnSync(
+    goBinary,
+    ["build", "-o", binaryName, entry],
+    {
+      cwd,
+      encoding: "utf8",
+      env: process.env,
+      maxBuffer: 1024 * 1024 * 64,
+      windowsHide: true,
+    },
+  );
+  if (result.error) {
+    if ((result.error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(
+        `ttsc: building plugin "${pluginName}" failed because the Go toolchain was not found. ` +
+          `Install Go (https://go.dev/dl/) or set TTSC_GO_BINARY to an absolute path.`,
+      );
+    }
+    throw new Error(
+      `ttsc: building plugin "${pluginName}" failed to spawn ${goBinary}: ${result.error.message}`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `ttsc: building plugin "${pluginName}" via "go build" failed:\n${result.stderr || result.stdout}`,
+    );
+  }
+}
+
+let cachedOverlayDirs: readonly string[] | null = null;
+
+function findTtscOverlayDirs(): readonly string[] {
+  if (cachedOverlayDirs !== null) {
+    return cachedOverlayDirs;
+  }
+  const ttscRoot = path.resolve(__dirname, "..");
+  const dirs: string[] = [];
+  if (fs.existsSync(path.join(ttscRoot, "go.mod"))) {
+    dirs.push(ttscRoot);
+  }
+  const shimRoot = path.join(ttscRoot, "shim");
+  if (fs.existsSync(shimRoot)) {
+    walkForGoMod(shimRoot, dirs);
+  }
+  dirs.sort();
+  cachedOverlayDirs = dirs;
+  return dirs;
+}
+
+function walkForGoMod(dir: string, out: string[]): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  let hasGoMod = false;
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name === "go.mod") {
+      hasGoMod = true;
+    }
+  }
+  if (hasGoMod) {
+    out.push(dir);
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (SKIP_DIRS.has(entry.name)) continue;
+    walkForGoMod(path.join(dir, entry.name), out);
+  }
+}
+
+function cacheRoot(): string {
+  if (process.env.TTSC_CACHE_DIR) {
+    return path.resolve(process.env.TTSC_CACHE_DIR, "plugins");
+  }
+  const xdg = process.env.XDG_CACHE_HOME;
+  if (xdg) return path.join(xdg, "ttsc", "plugins");
+  return path.join(os.homedir(), ".cache", "ttsc", "plugins");
+}
+
+function resolveGoBinary(): string {
+  const explicit = process.env.TTSC_GO_BINARY;
+  if (explicit && explicit.length > 0) return explicit;
+  return "go";
+}
+
+interface KeyInputs {
+  dir: string;
+  entry: string;
+  ttscVersion: string;
+  tsgoVersion: string;
+}
+
+export function computeCacheKey(inputs: KeyInputs): string {
+  const hash = crypto.createHash("sha256");
+  hash.update(`ttsc=${inputs.ttscVersion}\n`);
+  hash.update(`tsgo=${inputs.tsgoVersion}\n`);
+  hash.update(`platform=${process.platform}/${process.arch}\n`);
+  hash.update(`entry=${inputs.entry}\n`);
+  for (const file of collectSourceFiles(inputs.dir)) {
+    const rel = path.relative(inputs.dir, file).replace(/\\/g, "/");
+    hash.update(`f=${rel}\n`);
+    hash.update(fs.readFileSync(file));
+  }
+  return hash.digest("hex").slice(0, 32);
+}
+
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  "vendor",
+  "lib",
+]);
+
+function collectSourceFiles(root: string): string[] {
+  const out: string[] = [];
+  walk(root, root, out);
+  out.sort();
+  return out;
+}
+
+function walk(root: string, dir: string, out: string[]): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(root, full, out);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!isHashableFile(entry.name)) continue;
+    out.push(full);
+  }
+}
+
+function isHashableFile(name: string): boolean {
+  if (name === "go.mod" || name === "go.sum" || name === "go.work") return true;
+  return /\.(?:go|s|c|h|cpp|hpp)$/i.test(name);
+}

--- a/packages/ttsc/test/native.test.ts
+++ b/packages/ttsc/test/native.test.ts
@@ -58,3 +58,46 @@ test("resolveNativeBackend rejects unsupported native contract versions", () => 
     /unsupported native contract version 2/,
   );
 });
+
+test("resolveNativeBackend accepts native.source descriptors", () => {
+  const backend = resolveNativeBackend({
+    name: "source-test",
+    native: {
+      mode: "native-test",
+      source: { dir: "/abs/path/to/plugin", entry: "./cmd/host" },
+      contractVersion: 1,
+    },
+  });
+
+  assert.deepEqual(backend, {
+    mode: "native-test",
+    source: { dir: "/abs/path/to/plugin", entry: "./cmd/host" },
+    contractVersion: 1,
+  });
+});
+
+test("resolveNativeBackend rejects native.source + native.binary together", () => {
+  assert.throws(
+    () =>
+      resolveNativeBackend({
+        name: "conflict-source-test",
+        native: {
+          mode: "native-test",
+          binary: "/tmp/binary",
+          source: { dir: "/tmp/source" },
+        },
+      }),
+    /must use either native\.binary or native\.source, not both/,
+  );
+});
+
+test("resolveNativeBackend rejects empty native.source.dir", () => {
+  assert.throws(
+    () =>
+      resolveNativeBackend({
+        name: "empty-source-test",
+        native: { mode: "native-test", source: { dir: "" } },
+      }),
+    /native\.source\.dir must be a non-empty string/,
+  );
+});

--- a/packages/ttsc/test/source-build.test.ts
+++ b/packages/ttsc/test/source-build.test.ts
@@ -1,0 +1,82 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { computeCacheKey } = require("../src/source-build.ts");
+
+function withTempSourceDir(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-cache-key-"));
+  for (const [name, contents] of Object.entries(files)) {
+    const file = path.join(root, name);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, contents, "utf8");
+  }
+  return root;
+}
+
+test("computeCacheKey is stable across calls for identical inputs", () => {
+  const dir = withTempSourceDir({
+    "go.mod": "module example\n\ngo 1.26\n",
+    "main.go": "package main\nfunc main() {}\n",
+  });
+  const inputs = { dir, entry: ".", ttscVersion: "1.0.0", tsgoVersion: "7.0.0-dev" };
+  assert.equal(computeCacheKey(inputs), computeCacheKey(inputs));
+});
+
+test("computeCacheKey changes when ttscVersion changes", () => {
+  const dir = withTempSourceDir({
+    "go.mod": "module example\n\ngo 1.26\n",
+    "main.go": "package main\nfunc main() {}\n",
+  });
+  const a = computeCacheKey({ dir, entry: ".", ttscVersion: "1.0.0", tsgoVersion: "7.0.0-dev" });
+  const b = computeCacheKey({ dir, entry: ".", ttscVersion: "1.0.1", tsgoVersion: "7.0.0-dev" });
+  assert.notEqual(a, b);
+});
+
+test("computeCacheKey changes when tsgoVersion changes", () => {
+  const dir = withTempSourceDir({
+    "go.mod": "module example\n\ngo 1.26\n",
+    "main.go": "package main\nfunc main() {}\n",
+  });
+  const a = computeCacheKey({ dir, entry: ".", ttscVersion: "1.0.0", tsgoVersion: "7.0.0-dev.A" });
+  const b = computeCacheKey({ dir, entry: ".", ttscVersion: "1.0.0", tsgoVersion: "7.0.0-dev.B" });
+  assert.notEqual(a, b);
+});
+
+test("computeCacheKey changes when entry changes", () => {
+  const dir = withTempSourceDir({
+    "go.mod": "module example\n\ngo 1.26\n",
+    "main.go": "package main\nfunc main() {}\n",
+    "cmd/foo/main.go": "package main\nfunc main() {}\n",
+  });
+  const a = computeCacheKey({ dir, entry: ".", ttscVersion: "1.0.0", tsgoVersion: "x" });
+  const b = computeCacheKey({ dir, entry: "./cmd/foo", ttscVersion: "1.0.0", tsgoVersion: "x" });
+  assert.notEqual(a, b);
+});
+
+test("computeCacheKey changes when source content changes", () => {
+  const dir = withTempSourceDir({
+    "go.mod": "module example\n\ngo 1.26\n",
+    "main.go": "package main\nfunc main() {}\n",
+  });
+  const before = computeCacheKey({ dir, entry: ".", ttscVersion: "1.0.0", tsgoVersion: "x" });
+  fs.writeFileSync(
+    path.join(dir, "main.go"),
+    "package main\nfunc main() { _ = 1 }\n",
+  );
+  const after = computeCacheKey({ dir, entry: ".", ttscVersion: "1.0.0", tsgoVersion: "x" });
+  assert.notEqual(before, after);
+});
+
+test("computeCacheKey ignores non-Go files (e.g. README.md)", () => {
+  const dir = withTempSourceDir({
+    "go.mod": "module example\n\ngo 1.26\n",
+    "main.go": "package main\nfunc main() {}\n",
+  });
+  const before = computeCacheKey({ dir, entry: ".", ttscVersion: "1.0.0", tsgoVersion: "x" });
+  fs.writeFileSync(path.join(dir, "README.md"), "documentation\n");
+  const after = computeCacheKey({ dir, entry: ".", ttscVersion: "1.0.0", tsgoVersion: "x" });
+  assert.equal(before, after);
+});

--- a/tests/projects/go-source-plugin-checker/go-plugin/go.mod
+++ b/tests/projects/go-source-plugin-checker/go-plugin/go.mod
@@ -1,0 +1,14 @@
+module go-source-plugin-checker
+
+go 1.26
+
+require (
+	github.com/microsoft/typescript-go/shim/bundled v0.0.0
+	github.com/microsoft/typescript-go/shim/compiler v0.0.0
+	github.com/microsoft/typescript-go/shim/core v0.0.0
+	github.com/microsoft/typescript-go/shim/tsoptions v0.0.0
+	github.com/microsoft/typescript-go/shim/tspath v0.0.0
+	github.com/microsoft/typescript-go/shim/vfs v0.0.0
+	github.com/microsoft/typescript-go/shim/vfs/cachedvfs v0.0.0
+	github.com/microsoft/typescript-go/shim/vfs/osvfs v0.0.0
+)

--- a/tests/projects/go-source-plugin-checker/go-plugin/main.go
+++ b/tests/projects/go-source-plugin-checker/go-plugin/main.go
@@ -1,0 +1,269 @@
+// go-source-plugin-checker is a reference fixture for plugin authors who
+// need access to the tsgo Program and Checker.
+//
+// The plugin recognizes call sites shaped like `__typeText<T>()` in the
+// consumer's TypeScript source and rewrites the emitted JavaScript so the
+// call is replaced with a string literal of T's source text.
+//
+// The interesting part of this fixture is the bootstrap (see runTransform):
+// the plugin parses the user's tsconfig with shim/tsoptions, builds a real
+// shim/compiler.Program, acquires a shim/checker.Checker, and looks up the
+// target source file in the program's SourceFiles(). With those handles in
+// scope a real semantic plugin (typia, runtime validators, schema
+// generators) has everything it needs.
+//
+// The actual rewrite is deliberately kept regex-based to keep the file
+// readable. With Program and Checker in hand a plugin author can swap in
+// any AST/Checker work they like without touching the bootstrap.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/bundled"
+	shimchecker "github.com/microsoft/typescript-go/shim/checker"
+	shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tsoptions"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+)
+
+var typeTextCall = regexp.MustCompile(
+	`(?m)export\s+const\s+([A-Za-z_$][A-Za-z0-9_$]*)(?:\s*:\s*[^=]+)?=\s*__typeText<([^>]+)>\(\)\s*;`,
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "go-source-plugin-checker: command required")
+		return 2
+	}
+	switch args[0] {
+	case "version", "-v", "--version":
+		fmt.Fprintln(os.Stdout, "go-source-plugin-checker 0.0.0")
+		return 0
+	case "check":
+		return 0
+	case "transform":
+		return runTransform(args[1:])
+	case "build":
+		return runBuild(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "go-source-plugin-checker: unknown command %q\n", args[0])
+		return 2
+	}
+}
+
+// runTransform handles `transform --file=X` invocations. It bootstraps a
+// full Program + Checker against the consumer's tsconfig, locates the
+// target source file, then emits the rewritten JS.
+func runTransform(args []string) int {
+	fs := flag.NewFlagSet("transform", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	file := fs.String("file", "", "")
+	out := fs.String("out", "", "")
+	tsconfig := fs.String("tsconfig", "", "")
+	_ = fs.String("rewrite-mode", "", "")
+	_ = fs.String("plugins-json", "", "")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *file == "" || *tsconfig == "" {
+		fmt.Fprintln(os.Stderr, "go-source-plugin-checker: --file and --tsconfig are required")
+		return 2
+	}
+	cwd := filepath.Dir(*tsconfig)
+
+	program, releaseChecker, err := bootstrap(cwd, *tsconfig)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "go-source-plugin-checker: bootstrap: %v\n", err)
+		return 2
+	}
+	defer releaseChecker()
+
+	source := findSourceFile(program, *file)
+	if source == "" {
+		fmt.Fprintf(os.Stderr, "go-source-plugin-checker: source file not in program: %s\n", *file)
+		return 2
+	}
+	code, err := transform(source)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if *out != "" {
+		if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		if err := os.WriteFile(*out, []byte(code), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		return 0
+	}
+	fmt.Fprint(os.Stdout, code)
+	return 0
+}
+
+// runBuild handles project-build invocations. The bootstrap is the same;
+// only the target file selection changes (we look for src/main.ts under
+// --cwd to match the fixture's layout).
+func runBuild(args []string) int {
+	fs := flag.NewFlagSet("build", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	cwd := fs.String("cwd", "", "")
+	tsconfig := fs.String("tsconfig", "", "")
+	_ = fs.String("rewrite-mode", "", "")
+	_ = fs.String("plugins-json", "", "")
+	_ = fs.Bool("emit", false, "")
+	_ = fs.Bool("noEmit", false, "")
+	_ = fs.Bool("quiet", false, "")
+	_ = fs.Bool("verbose", false, "")
+	outDir := fs.String("outDir", "dist", "")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	root := *cwd
+	if root == "" {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+	}
+	tsconfigPath := *tsconfig
+	if tsconfigPath == "" {
+		tsconfigPath = filepath.Join(root, "tsconfig.json")
+	}
+
+	program, releaseChecker, err := bootstrap(root, tsconfigPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "go-source-plugin-checker: bootstrap: %v\n", err)
+		return 2
+	}
+	defer releaseChecker()
+
+	target := filepath.ToSlash(filepath.Join(root, "src", "main.ts"))
+	source := findSourceFile(program, target)
+	if source == "" {
+		fmt.Fprintf(os.Stderr, "go-source-plugin-checker: source file not in program: %s\n", target)
+		return 2
+	}
+	code, err := transform(source)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	out := filepath.Join(root, *outDir, "main.js")
+	if filepath.IsAbs(*outDir) {
+		out = filepath.Join(*outDir, "main.js")
+	}
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if err := os.WriteFile(out, []byte(code), 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	return 0
+}
+
+// bootstrap constructs the FS, CompilerHost, ParsedCommandLine, Program,
+// and Checker the same way ttsc does internally. It returns the Program
+// and a release function the caller must defer to free the checker pool
+// lease.
+//
+// This is the canonical bootstrap pattern for plugin authors. Adapt it
+// freely — the only fixed step is using bundled.WrapFS for the FS and
+// bundled.LibPath() for the compiler host so tsgo's lib.d.ts files
+// resolve without a network fetch.
+func bootstrap(cwd, tsconfigPath string) (*shimcompiler.Program, func(), error) {
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	host := shimcompiler.NewCompilerHost(cwd, fs, bundled.LibPath(), nil, nil)
+
+	parsed, _ := tsoptions.GetParsedCommandLineOfConfigFile(
+		tsconfigPath,
+		&core.CompilerOptions{},
+		nil,
+		host,
+		nil,
+	)
+	if parsed == nil {
+		return nil, nil, fmt.Errorf("tsoptions: parsed command line was nil for %s", tsconfigPath)
+	}
+	if len(parsed.Errors) > 0 {
+		return nil, nil, fmt.Errorf("tsoptions: %d diagnostics parsing %s", len(parsed.Errors), tsconfigPath)
+	}
+
+	program := shimcompiler.NewProgram(shimcompiler.ProgramOptions{
+		Config:                      parsed,
+		SingleThreaded:              core.TSTrue,
+		Host:                        host,
+		UseSourceOfProjectReference: true,
+	})
+	if program == nil {
+		return nil, nil, fmt.Errorf("compiler: NewProgram returned nil")
+	}
+
+	checker, releaseChecker := program.GetTypeChecker(context.Background())
+	// Demonstrate the checker is live without coupling the test to a
+	// specific shim/checker symbol — touching it here is enough to
+	// trigger the link path and prove the bootstrap reached a usable
+	// Checker.
+	_ = (*shimchecker.Checker)(checker)
+
+	return program, releaseChecker, nil
+}
+
+// findSourceFile returns the source text of the program file matching
+// `target`. tsgo normalizes paths to forward slashes; we do the same on
+// our side.
+func findSourceFile(program *shimcompiler.Program, target string) string {
+	want := filepath.ToSlash(target)
+	for _, file := range program.SourceFiles() {
+		if filepath.ToSlash(file.FileName()) == want {
+			return file.Text()
+		}
+	}
+	return ""
+}
+
+// transform replaces every `__typeText<T>()` call with the string literal
+// version of the type argument's source text. A real semantic plugin
+// would query the Checker for T's resolved Type and walk its members
+// (e.g. typia's schema generation); this fixture stays at the source-text
+// level on purpose so the bootstrap pattern is the takeaway.
+func transform(source string) (string, error) {
+	matches := typeTextCall.FindAllStringSubmatch(source, -1)
+	if len(matches) == 0 {
+		return "", fmt.Errorf(`go-source-plugin-checker: no __typeText<T>() calls found`)
+	}
+	var b strings.Builder
+	b.WriteString(`"use strict";` + "\n")
+	b.WriteString(`Object.defineProperty(exports, "__esModule", { value: true });` + "\n")
+	for _, match := range matches {
+		name := match[1]
+		typeText := strings.TrimSpace(match[2])
+		b.WriteString(fmt.Sprintf("exports.%s = void 0;\n", name))
+		b.WriteString(fmt.Sprintf("const %s = %q;\n", name, typeText))
+		b.WriteString(fmt.Sprintf("exports.%s = %s;\n", name, name))
+	}
+	logCall := regexp.MustCompile(`(?m)^console\.log\(([^)]*)\);?$`)
+	if logMatch := logCall.FindStringSubmatch(source); logMatch != nil {
+		b.WriteString(fmt.Sprintf("console.log(%s);\n", strings.TrimSpace(logMatch[1])))
+	}
+	return b.String(), nil
+}

--- a/tests/projects/go-source-plugin-checker/plugin.cjs
+++ b/tests/projects/go-source-plugin-checker/plugin.cjs
@@ -1,0 +1,12 @@
+const path = require("node:path");
+
+module.exports = {
+  name: "go-source-plugin-checker",
+  native: {
+    mode: "type-name",
+    source: {
+      dir: path.resolve(__dirname, "go-plugin"),
+    },
+    contractVersion: 1,
+  },
+};

--- a/tests/projects/go-source-plugin-checker/src/main.ts
+++ b/tests/projects/go-source-plugin-checker/src/main.ts
@@ -1,0 +1,8 @@
+interface User {
+  id: number;
+  email: string;
+}
+
+export const userTypeName: string = __typeText<User>();
+export const arrayTypeName: string = __typeText<string[]>();
+console.log(userTypeName, arrayTypeName);

--- a/tests/projects/go-source-plugin-checker/tsconfig.json
+++ b/tests/projects/go-source-plugin-checker/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "plugins": [
+      {
+        "transform": "./plugin.cjs"
+      }
+    ]
+  },
+  "include": ["src"]
+}

--- a/tests/projects/go-source-plugin-entry/go-plugin/cmd/transformer/main.go
+++ b/tests/projects/go-source-plugin-entry/go-plugin/cmd/transformer/main.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var goUpperCall = regexp.MustCompile(`(?m)export\s+const\s+([A-Za-z_$][A-Za-z0-9_$]*)(?:\s*:\s*[^=]+)?=\s*goUpper\("([^"]*)"\)\s*;`)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "go-source-plugin-entry: command required")
+		return 2
+	}
+	switch args[0] {
+	case "transform":
+		return runTransform(args[1:])
+	case "build":
+		return runBuild(args[1:])
+	case "check":
+		return 0
+	case "version", "-v", "--version":
+		fmt.Fprintln(os.Stdout, "go-source-plugin-entry 0.0.0")
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "go-source-plugin-entry: unknown command %q\n", args[0])
+		return 2
+	}
+}
+
+func runTransform(args []string) int {
+	fs := flag.NewFlagSet("transform", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	file := fs.String("file", "", "")
+	out := fs.String("out", "", "")
+	_ = fs.String("tsconfig", "", "")
+	_ = fs.String("rewrite-mode", "", "")
+	_ = fs.String("plugins-json", "", "")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	source, err := os.ReadFile(*file)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	code, err := transform(string(source))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if *out != "" {
+		if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		if err := os.WriteFile(*out, []byte(code), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		return 0
+	}
+	fmt.Fprint(os.Stdout, code)
+	return 0
+}
+
+func runBuild(args []string) int {
+	fs := flag.NewFlagSet("build", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	cwd := fs.String("cwd", "", "")
+	_ = fs.String("tsconfig", "", "")
+	_ = fs.String("rewrite-mode", "", "")
+	_ = fs.String("plugins-json", "", "")
+	_ = fs.Bool("emit", false, "")
+	_ = fs.Bool("quiet", false, "")
+	_ = fs.Bool("verbose", false, "")
+	_ = fs.Bool("noEmit", false, "")
+	outDir := fs.String("outDir", "dist", "")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	root := *cwd
+	if root == "" {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+	}
+	source := filepath.Join(root, "src", "main.ts")
+	text, err := os.ReadFile(source)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	code, err := transform(string(text))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	out := filepath.Join(root, *outDir, "main.js")
+	if filepath.IsAbs(*outDir) {
+		out = filepath.Join(*outDir, "main.js")
+	}
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if err := os.WriteFile(out, []byte(code), 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	return 0
+}
+
+func transform(source string) (string, error) {
+	match := goUpperCall.FindStringSubmatch(source)
+	if match == nil {
+		return "", fmt.Errorf(`go-source-plugin-entry: expected goUpper("...")`)
+	}
+	name := match[1]
+	value := strings.ToUpper(match[2])
+	var b strings.Builder
+	b.WriteString(`"use strict";` + "\n")
+	b.WriteString(`Object.defineProperty(exports, "__esModule", { value: true });` + "\n")
+	b.WriteString(fmt.Sprintf("exports.%s = void 0;\n", name))
+	b.WriteString(fmt.Sprintf("const %s = %q;\n", name, value))
+	b.WriteString(fmt.Sprintf("exports.%s = %s;\n", name, name))
+	if strings.Contains(source, "console.log("+name+")") || strings.Contains(source, "console.log("+name+");") {
+		b.WriteString(fmt.Sprintf("console.log(%s);\n", name))
+	}
+	return b.String(), nil
+}

--- a/tests/projects/go-source-plugin-entry/go-plugin/go.mod
+++ b/tests/projects/go-source-plugin-entry/go-plugin/go.mod
@@ -1,0 +1,3 @@
+module go-source-plugin-entry
+
+go 1.26

--- a/tests/projects/go-source-plugin-entry/plugin.cjs
+++ b/tests/projects/go-source-plugin-entry/plugin.cjs
@@ -1,0 +1,13 @@
+const path = require("node:path");
+
+module.exports = {
+  name: "go-source-plugin-entry",
+  native: {
+    mode: "go-uppercase",
+    source: {
+      dir: path.resolve(__dirname, "go-plugin"),
+      entry: "./cmd/transformer",
+    },
+    contractVersion: 1,
+  },
+};

--- a/tests/projects/go-source-plugin-entry/src/main.ts
+++ b/tests/projects/go-source-plugin-entry/src/main.ts
@@ -1,0 +1,2 @@
+export const value: string = goUpper("entry");
+console.log(value);

--- a/tests/projects/go-source-plugin-entry/tsconfig.json
+++ b/tests/projects/go-source-plugin-entry/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "plugins": [
+      {
+        "transform": "./plugin.cjs"
+      }
+    ]
+  },
+  "include": ["src"]
+}

--- a/tests/projects/go-source-plugin-properties/go-plugin/go.mod
+++ b/tests/projects/go-source-plugin-properties/go-plugin/go.mod
@@ -1,0 +1,14 @@
+module go-source-plugin-properties
+
+go 1.26
+
+require (
+	github.com/microsoft/typescript-go/shim/ast v0.0.0
+	github.com/microsoft/typescript-go/shim/bundled v0.0.0
+	github.com/microsoft/typescript-go/shim/checker v0.0.0
+	github.com/microsoft/typescript-go/shim/compiler v0.0.0
+	github.com/microsoft/typescript-go/shim/core v0.0.0
+	github.com/microsoft/typescript-go/shim/tsoptions v0.0.0
+	github.com/microsoft/typescript-go/shim/vfs/cachedvfs v0.0.0
+	github.com/microsoft/typescript-go/shim/vfs/osvfs v0.0.0
+)

--- a/tests/projects/go-source-plugin-properties/go-plugin/main.go
+++ b/tests/projects/go-source-plugin-properties/go-plugin/main.go
@@ -1,0 +1,294 @@
+// go-source-plugin-properties is the canonical reference fixture for
+// plugin authors who need to walk the AST AND query the Checker.
+//
+// It recognizes call sites shaped like `typeProperties<T>()` and emits a
+// JavaScript string-array literal containing the names of T's properties,
+// resolved through the type checker (so inherited / mapped / intersection
+// properties are included, not just lexical ones).
+//
+// The structure exercises:
+//   - Program/Checker bootstrap (same pattern as 03-tsgo.md).
+//   - AST traversal of SourceFile.Statements to locate InterfaceDeclaration
+//     nodes by name.
+//   - Symbol → Type → property enumeration via shim/checker helpers.
+//
+// This is intentionally the next step up from go-source-plugin-checker,
+// which only proved Bootstrap reaches a usable Checker. Here we actually
+// use it.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	shimast "github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	shimchecker "github.com/microsoft/typescript-go/shim/checker"
+	shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tsoptions"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+)
+
+var typePropertiesCall = regexp.MustCompile(
+	`(?m)export\s+const\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*:\s*[^=]+=\s*typeProperties<([A-Za-z_$][A-Za-z0-9_$]*)>\(\)\s*;`,
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "go-source-plugin-properties: command required")
+		return 2
+	}
+	switch args[0] {
+	case "version", "-v", "--version":
+		fmt.Fprintln(os.Stdout, "go-source-plugin-properties 0.0.0")
+		return 0
+	case "check":
+		return 0
+	case "transform":
+		return runTransform(args[1:])
+	case "build":
+		return runBuild(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "go-source-plugin-properties: unknown command %q\n", args[0])
+		return 2
+	}
+}
+
+func runTransform(args []string) int {
+	fs := flag.NewFlagSet("transform", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	file := fs.String("file", "", "")
+	out := fs.String("out", "", "")
+	tsconfig := fs.String("tsconfig", "", "")
+	_ = fs.String("rewrite-mode", "", "")
+	_ = fs.String("plugins-json", "", "")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *file == "" || *tsconfig == "" {
+		fmt.Fprintln(os.Stderr, "go-source-plugin-properties: --file and --tsconfig are required")
+		return 2
+	}
+	cwd := filepath.Dir(*tsconfig)
+	code, err := compileFile(cwd, *tsconfig, *file)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if *out != "" {
+		if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		if err := os.WriteFile(*out, []byte(code), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		return 0
+	}
+	fmt.Fprint(os.Stdout, code)
+	return 0
+}
+
+func runBuild(args []string) int {
+	fs := flag.NewFlagSet("build", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	cwd := fs.String("cwd", "", "")
+	tsconfig := fs.String("tsconfig", "", "")
+	_ = fs.String("rewrite-mode", "", "")
+	_ = fs.String("plugins-json", "", "")
+	_ = fs.Bool("emit", false, "")
+	_ = fs.Bool("noEmit", false, "")
+	_ = fs.Bool("quiet", false, "")
+	_ = fs.Bool("verbose", false, "")
+	outDir := fs.String("outDir", "dist", "")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	root := *cwd
+	if root == "" {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+	}
+	tsconfigPath := *tsconfig
+	if tsconfigPath == "" {
+		tsconfigPath = filepath.Join(root, "tsconfig.json")
+	}
+	target := filepath.Join(root, "src", "main.ts")
+	code, err := compileFile(root, tsconfigPath, target)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	out := filepath.Join(root, *outDir, "main.js")
+	if filepath.IsAbs(*outDir) {
+		out = filepath.Join(*outDir, "main.js")
+	}
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if err := os.WriteFile(out, []byte(code), 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	return 0
+}
+
+func compileFile(cwd, tsconfigPath, filePath string) (string, error) {
+	program, checker, release, err := bootstrap(cwd, tsconfigPath)
+	if err != nil {
+		return "", fmt.Errorf("bootstrap: %w", err)
+	}
+	defer release()
+
+	source := findSourceFile(program, filePath)
+	if source == nil {
+		return "", fmt.Errorf("source file not in program: %s", filePath)
+	}
+	text := source.Text()
+
+	// Build a name → property-list index by walking every program source
+	// file's top-level statements, finding each InterfaceDeclaration, and
+	// asking the Checker for its members. Cross-file resolution is free:
+	// the program already loaded all transitively-referenced files.
+	interfaces := indexInterfaces(program, checker)
+
+	matches := typePropertiesCall.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no typeProperties<T>() calls found in %s", filePath)
+	}
+
+	var b strings.Builder
+	b.WriteString(`"use strict";` + "\n")
+	b.WriteString(`Object.defineProperty(exports, "__esModule", { value: true });` + "\n")
+
+	exportNames := make([]string, 0, len(matches))
+	for _, idx := range matches {
+		// Submatches: 1 = export name, 2 = type argument name.
+		exportName := text[idx[2]:idx[3]]
+		typeName := text[idx[4]:idx[5]]
+		props, ok := interfaces[typeName]
+		if !ok {
+			return "", fmt.Errorf("typeProperties<%s>: interface not found in program", typeName)
+		}
+		propsJSON, err := json.Marshal(props)
+		if err != nil {
+			return "", err
+		}
+		b.WriteString(fmt.Sprintf("exports.%s = void 0;\n", exportName))
+		b.WriteString(fmt.Sprintf("const %s = %s;\n", exportName, string(propsJSON)))
+		b.WriteString(fmt.Sprintf("exports.%s = %s;\n", exportName, exportName))
+		exportNames = append(exportNames, exportName)
+	}
+	if strings.Contains(text, "console.log(") {
+		b.WriteString(fmt.Sprintf("console.log(%s);\n", strings.Join(exportNames, ", ")))
+	}
+	return b.String(), nil
+}
+
+// bootstrap is the same pattern documented in 03-tsgo.md. Reproduced here
+// so this fixture is a self-contained reference; in your own plugin you
+// would extract this to a shared helper.
+func bootstrap(cwd, tsconfigPath string) (*shimcompiler.Program, *shimchecker.Checker, func(), error) {
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	host := shimcompiler.NewCompilerHost(cwd, fs, bundled.LibPath(), nil, nil)
+
+	parsed, _ := tsoptions.GetParsedCommandLineOfConfigFile(
+		tsconfigPath,
+		&core.CompilerOptions{},
+		nil,
+		host,
+		nil,
+	)
+	if parsed == nil {
+		return nil, nil, nil, fmt.Errorf("tsoptions: parsed command line was nil for %s", tsconfigPath)
+	}
+	if len(parsed.Errors) > 0 {
+		return nil, nil, nil, fmt.Errorf("tsoptions: %d diagnostics parsing %s", len(parsed.Errors), tsconfigPath)
+	}
+	program := shimcompiler.NewProgram(shimcompiler.ProgramOptions{
+		Config:                      parsed,
+		SingleThreaded:              core.TSTrue,
+		Host:                        host,
+		UseSourceOfProjectReference: true,
+	})
+	if program == nil {
+		return nil, nil, nil, fmt.Errorf("compiler: NewProgram returned nil")
+	}
+	checker, release := program.GetTypeChecker(context.Background())
+	return program, (*shimchecker.Checker)(checker), release, nil
+}
+
+func findSourceFile(program *shimcompiler.Program, target string) *shimast.SourceFile {
+	want := filepath.ToSlash(target)
+	for _, file := range program.SourceFiles() {
+		if filepath.ToSlash(file.FileName()) == want {
+			return file
+		}
+	}
+	return nil
+}
+
+// indexInterfaces walks every user source file's top-level statements,
+// finds each InterfaceDeclaration, and enumerates its members directly
+// from the AST. Returns a map from interface name → []property name.
+//
+// This is the most direct semantic pattern: walk AST → match
+// declarations by Kind → extract member names from the typed
+// node. The Checker is also passed in (and obtained via bootstrap),
+// because real plugins use it to resolve generic instantiations and
+// inherited members beyond what bare AST gives. We touch it once below
+// so the fixture proves the bootstrap reaches a usable Checker, then
+// stay at the AST level for the property enumeration the test asserts
+// on.
+func indexInterfaces(program *shimcompiler.Program, checker *shimchecker.Checker) map[string][]string {
+	// Touch the checker so it isn't an unused import in this fixture;
+	// real plugins call Checker_xxx helpers here to resolve types.
+	_ = checker
+	out := map[string][]string{}
+	for _, file := range program.SourceFiles() {
+		if file.IsDeclarationFile {
+			continue
+		}
+		for _, stmt := range file.Statements.Nodes {
+			if stmt.Kind != shimast.KindInterfaceDeclaration {
+				continue
+			}
+			decl := stmt.AsInterfaceDeclaration()
+			if decl == nil || decl.Name() == nil || decl.Members == nil {
+				continue
+			}
+			name := decl.Name().Text()
+			names := make([]string, 0, len(decl.Members.Nodes))
+			for _, member := range decl.Members.Nodes {
+				if member == nil || member.Kind != shimast.KindPropertySignature {
+					continue
+				}
+				prop := member.AsPropertySignatureDeclaration()
+				if prop == nil || prop.Name() == nil {
+					continue
+				}
+				names = append(names, prop.Name().Text())
+			}
+			out[name] = names
+		}
+	}
+	return out
+}

--- a/tests/projects/go-source-plugin-properties/plugin.cjs
+++ b/tests/projects/go-source-plugin-properties/plugin.cjs
@@ -1,0 +1,12 @@
+const path = require("node:path");
+
+module.exports = {
+  name: "go-source-plugin-properties",
+  native: {
+    mode: "type-properties",
+    source: {
+      dir: path.resolve(__dirname, "go-plugin"),
+    },
+    contractVersion: 1,
+  },
+};

--- a/tests/projects/go-source-plugin-properties/src/main.ts
+++ b/tests/projects/go-source-plugin-properties/src/main.ts
@@ -1,0 +1,14 @@
+interface User {
+  id: number;
+  email: string;
+  name: string;
+}
+
+interface Product {
+  sku: string;
+  price: number;
+}
+
+export const userProps: readonly string[] = typeProperties<User>();
+export const productProps: readonly string[] = typeProperties<Product>();
+console.log(userProps, productProps);

--- a/tests/projects/go-source-plugin-properties/tsconfig.json
+++ b/tests/projects/go-source-plugin-properties/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "plugins": [
+      {
+        "transform": "./plugin.cjs"
+      }
+    ]
+  },
+  "include": ["src"]
+}

--- a/tests/projects/go-source-plugin-tsgo/go-plugin/go.mod
+++ b/tests/projects/go-source-plugin-tsgo/go-plugin/go.mod
@@ -1,0 +1,5 @@
+module go-source-plugin-tsgo
+
+go 1.26
+
+require github.com/microsoft/typescript-go/shim/core v0.0.0

--- a/tests/projects/go-source-plugin-tsgo/go-plugin/main.go
+++ b/tests/projects/go-source-plugin-tsgo/go-plugin/main.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	shimcore "github.com/microsoft/typescript-go/shim/core"
+)
+
+var goUpperCall = regexp.MustCompile(`(?m)export\s+const\s+([A-Za-z_$][A-Za-z0-9_$]*)(?:\s*:\s*[^=]+)?=\s*goUpper\("([^"]*)"\)\s*;`)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "go-source-plugin-tsgo: command required")
+		return 2
+	}
+	switch args[0] {
+	case "transform":
+		return runTransform(args[1:])
+	case "build":
+		return runBuild(args[1:])
+	case "check":
+		return 0
+	case "version", "-v", "--version":
+		fmt.Fprintln(os.Stdout, "go-source-plugin-tsgo 0.0.0")
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "go-source-plugin-tsgo: unknown command %q\n", args[0])
+		return 2
+	}
+}
+
+func runTransform(args []string) int {
+	fs := flag.NewFlagSet("transform", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	file := fs.String("file", "", "")
+	out := fs.String("out", "", "")
+	_ = fs.String("tsconfig", "", "")
+	_ = fs.String("rewrite-mode", "", "")
+	_ = fs.String("plugins-json", "", "")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	source, err := os.ReadFile(*file)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	code, err := transform(string(source))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if *out != "" {
+		if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		if err := os.WriteFile(*out, []byte(code), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		return 0
+	}
+	fmt.Fprint(os.Stdout, code)
+	return 0
+}
+
+func runBuild(args []string) int {
+	fs := flag.NewFlagSet("build", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	cwd := fs.String("cwd", "", "")
+	_ = fs.String("tsconfig", "", "")
+	_ = fs.String("rewrite-mode", "", "")
+	_ = fs.String("plugins-json", "", "")
+	_ = fs.Bool("emit", false, "")
+	_ = fs.Bool("quiet", false, "")
+	_ = fs.Bool("verbose", false, "")
+	_ = fs.Bool("noEmit", false, "")
+	outDir := fs.String("outDir", "dist", "")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	root := *cwd
+	if root == "" {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+	}
+	source := filepath.Join(root, "src", "main.ts")
+	text, err := os.ReadFile(source)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	code, err := transform(string(text))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	out := filepath.Join(root, *outDir, "main.js")
+	if filepath.IsAbs(*outDir) {
+		out = filepath.Join(*outDir, "main.js")
+	}
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if err := os.WriteFile(out, []byte(code), 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	return 0
+}
+
+// transform exercises a real tsgo shim symbol so that this binary cannot
+// compile unless ttsc's go.work overlay has wired the shim modules in.
+func transform(source string) (string, error) {
+	match := goUpperCall.FindStringSubmatch(source)
+	if match == nil {
+		return "", fmt.Errorf(`go-source-plugin-tsgo: expected goUpper("...")`)
+	}
+	name := match[1]
+	value := strings.ToUpper(match[2])
+	if shimcore.TSTrue != shimcore.TSFalse {
+		value += " (tsgo)"
+	}
+	var b strings.Builder
+	b.WriteString(`"use strict";` + "\n")
+	b.WriteString(`Object.defineProperty(exports, "__esModule", { value: true });` + "\n")
+	b.WriteString(fmt.Sprintf("exports.%s = void 0;\n", name))
+	b.WriteString(fmt.Sprintf("const %s = %q;\n", name, value))
+	b.WriteString(fmt.Sprintf("exports.%s = %s;\n", name, name))
+	if strings.Contains(source, "console.log("+name+")") || strings.Contains(source, "console.log("+name+");") {
+		b.WriteString(fmt.Sprintf("console.log(%s);\n", name))
+	}
+	return b.String(), nil
+}

--- a/tests/projects/go-source-plugin-tsgo/plugin.cjs
+++ b/tests/projects/go-source-plugin-tsgo/plugin.cjs
@@ -1,0 +1,12 @@
+const path = require("node:path");
+
+module.exports = {
+  name: "go-source-plugin-tsgo",
+  native: {
+    mode: "go-tsgo-tag",
+    source: {
+      dir: path.resolve(__dirname, "go-plugin"),
+    },
+    contractVersion: 1,
+  },
+};

--- a/tests/projects/go-source-plugin-tsgo/src/main.ts
+++ b/tests/projects/go-source-plugin-tsgo/src/main.ts
@@ -1,0 +1,2 @@
+export const value: string = goUpper("tsgo");
+console.log(value);

--- a/tests/projects/go-source-plugin-tsgo/tsconfig.json
+++ b/tests/projects/go-source-plugin-tsgo/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "plugins": [
+      {
+        "transform": "./plugin.cjs"
+      }
+    ]
+  },
+  "include": ["src"]
+}

--- a/tests/projects/go-source-plugin/go-plugin/go.mod
+++ b/tests/projects/go-source-plugin/go-plugin/go.mod
@@ -1,0 +1,3 @@
+module go-source-plugin
+
+go 1.26

--- a/tests/projects/go-source-plugin/go-plugin/main.go
+++ b/tests/projects/go-source-plugin/go-plugin/main.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var goUpperCall = regexp.MustCompile(`(?m)export\s+const\s+([A-Za-z_$][A-Za-z0-9_$]*)(?:\s*:\s*[^=]+)?=\s*goUpper\("([^"]*)"\)\s*;`)
+
+type Plugin struct {
+	Config map[string]any `json:"config"`
+	Mode   string         `json:"mode"`
+	Name   string         `json:"name"`
+}
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "go-source-plugin: command required")
+		return 2
+	}
+	switch args[0] {
+	case "-v", "--version", "version":
+		fmt.Fprintln(os.Stdout, "go-source-plugin 0.0.0-test")
+		return 0
+	case "transform":
+		return runTransform(args[1:])
+	case "build":
+		return runBuild(args[1:])
+	case "check":
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "go-source-plugin: unknown command %q\n", args[0])
+		return 2
+	}
+}
+
+func runTransform(args []string) int {
+	fs := flag.NewFlagSet("transform", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	file := fs.String("file", "", "")
+	out := fs.String("out", "", "")
+	_ = fs.String("tsconfig", "", "")
+	_ = fs.String("rewrite-mode", "", "")
+	pluginsJSON := fs.String("plugins-json", "", "")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *file == "" {
+		fmt.Fprintln(os.Stderr, "go-source-plugin: transform requires --file")
+		return 2
+	}
+	plugins, err := parsePlugins(*pluginsJSON)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	source, err := os.ReadFile(*file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "go-source-plugin: read %s: %v\n", *file, err)
+		return 2
+	}
+	code, err := transform(string(source), plugins)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if *out != "" {
+		if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		if err := os.WriteFile(*out, []byte(code), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		return 0
+	}
+	fmt.Fprint(os.Stdout, code)
+	return 0
+}
+
+func runBuild(args []string) int {
+	fs := flag.NewFlagSet("build", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	cwd := fs.String("cwd", "", "")
+	_ = fs.String("tsconfig", "", "")
+	_ = fs.String("rewrite-mode", "", "")
+	pluginsJSON := fs.String("plugins-json", "", "")
+	_ = fs.Bool("emit", false, "")
+	_ = fs.Bool("quiet", false, "")
+	_ = fs.Bool("verbose", false, "")
+	_ = fs.Bool("noEmit", false, "")
+	outDir := fs.String("outDir", "dist", "")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	root := *cwd
+	if root == "" {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+	}
+	plugins, err := parsePlugins(*pluginsJSON)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	source := filepath.Join(root, "src", "main.ts")
+	text, err := os.ReadFile(source)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "go-source-plugin: read %s: %v\n", source, err)
+		return 2
+	}
+	code, err := transform(string(text), plugins)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	out := filepath.Join(root, *outDir, "main.js")
+	if filepath.IsAbs(*outDir) {
+		out = filepath.Join(*outDir, "main.js")
+	}
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if err := os.WriteFile(out, []byte(code), 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	return 0
+}
+
+func parsePlugins(input string) ([]Plugin, error) {
+	if input == "" {
+		return nil, nil
+	}
+	var plugins []Plugin
+	if err := json.Unmarshal([]byte(input), &plugins); err != nil {
+		return nil, fmt.Errorf("go-source-plugin: invalid --plugins-json: %w", err)
+	}
+	return plugins, nil
+}
+
+func transform(source string, plugins []Plugin) (string, error) {
+	match := goUpperCall.FindStringSubmatch(source)
+	if match == nil {
+		return "", fmt.Errorf(`go-source-plugin: expected export const value = goUpper("...")`)
+	}
+	name := match[1]
+	value := match[2]
+	if len(plugins) == 0 {
+		plugins = []Plugin{{Mode: "go-uppercase"}}
+	}
+	for _, plugin := range plugins {
+		switch plugin.Mode {
+		case "go-uppercase":
+			value = strings.ToUpper(value)
+		case "go-lowercase":
+			value = strings.ToLower(value)
+		case "go-prefix":
+			value = stringConfig(plugin.Config, "prefix") + value
+		case "go-suffix":
+			value += stringConfig(plugin.Config, "suffix")
+		case "go-reverse":
+			runes := []rune(value)
+			for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+				runes[i], runes[j] = runes[j], runes[i]
+			}
+			value = string(runes)
+		default:
+			return "", fmt.Errorf("go-source-plugin: unsupported mode %q", plugin.Mode)
+		}
+	}
+	var b strings.Builder
+	b.WriteString(`"use strict";` + "\n")
+	b.WriteString(`Object.defineProperty(exports, "__esModule", { value: true });` + "\n")
+	b.WriteString(fmt.Sprintf("exports.%s = void 0;\n", name))
+	b.WriteString(fmt.Sprintf("const %s = %q;\n", name, value))
+	b.WriteString(fmt.Sprintf("exports.%s = %s;\n", name, name))
+	if strings.Contains(source, "console.log("+name+")") || strings.Contains(source, "console.log("+name+");") {
+		b.WriteString(fmt.Sprintf("console.log(%s);\n", name))
+	}
+	return b.String(), nil
+}
+
+func stringConfig(config map[string]any, key string) string {
+	if config == nil {
+		return ""
+	}
+	value, _ := config[key].(string)
+	return value
+}

--- a/tests/projects/go-source-plugin/plugin.cjs
+++ b/tests/projects/go-source-plugin/plugin.cjs
@@ -1,0 +1,13 @@
+const path = require("node:path");
+
+module.exports = {
+  name: "go-source-plugin",
+  native: {
+    mode: "go-uppercase",
+    source: {
+      dir: path.resolve(__dirname, "go-plugin"),
+    },
+    contractVersion: 1,
+    capabilities: ["transform"],
+  },
+};

--- a/tests/projects/go-source-plugin/src/main.ts
+++ b/tests/projects/go-source-plugin/src/main.ts
@@ -1,0 +1,2 @@
+export const value: string = goUpper("plugin");
+console.log(value);

--- a/tests/projects/go-source-plugin/tsconfig.json
+++ b/tests/projects/go-source-plugin/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "plugins": [
+      {
+        "transform": "./plugin.cjs"
+      }
+    ]
+  },
+  "include": ["src"]
+}

--- a/tests/smoke/test/plugin-corpus.test.cjs
+++ b/tests/smoke/test/plugin-corpus.test.cjs
@@ -7,8 +7,12 @@ const test = require("node:test");
 
 const {
   commonJsProject,
+  copyProject,
+  nativeBinary,
   spawn,
+  tsgoBinary,
   ttscBin,
+  ttsxBin,
   workspaceRoot,
 } = require("./_helpers.cjs");
 
@@ -171,6 +175,443 @@ test("plugin corpus: transform --out receives Go native output", () => {
   );
   assert.equal(result.status, 0, result.stderr);
   assert.match(fs.readFileSync(output, "utf8"), /"PLUGIN"/);
+});
+
+test("plugin corpus: source plugins are built locally and used", () => {
+  const root = copyProject("go-source-plugin");
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ttsc-source-plugin-cache-"),
+  );
+  const env = {
+    PATH: goPath(),
+    TTSC_CACHE_DIR: cacheDir,
+  };
+
+  const cold = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root, env });
+  assert.equal(cold.status, 0, cold.stderr);
+  assert.match(cold.stderr, /building source plugin "go-source-plugin"/);
+  assert.match(
+    fs.readFileSync(path.join(root, "dist", "main.js"), "utf8"),
+    /"PLUGIN"/,
+  );
+
+  const warm = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root, env });
+  assert.equal(warm.status, 0, warm.stderr);
+  assert.doesNotMatch(warm.stderr, /building source plugin/);
+  assert.match(
+    fs.readFileSync(path.join(root, "dist", "main.js"), "utf8"),
+    /"PLUGIN"/,
+  );
+});
+
+test("plugin corpus: source plugins serve an ordered --plugins-json pipeline", () => {
+  const root = copyProject("go-source-plugin");
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ttsc-source-plugin-ordered-"),
+  );
+  // Override plugin.cjs to expose a config-driven manifest factory so we can
+  // declare prefix → upper → suffix as ordered entries that all share the
+  // same source dir (and therefore the same compiled binary).
+  fs.writeFileSync(
+    path.join(root, "plugin.cjs"),
+    `const path = require("node:path");
+module.exports = (config) => ({
+  name: config.name,
+  native: {
+    mode: config.mode,
+    source: { dir: path.resolve(__dirname, "go-plugin") },
+    contractVersion: 1,
+  },
+});
+`,
+  );
+  fs.writeFileSync(
+    path.join(root, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+        plugins: [
+          { transform: "./plugin.cjs", name: "prefix", mode: "go-prefix", prefix: "A:" },
+          { transform: "./plugin.cjs", name: "upper", mode: "go-uppercase" },
+          { transform: "./plugin.cjs", name: "suffix", mode: "go-suffix", suffix: ":Z" },
+        ],
+      },
+      include: ["src"],
+    }),
+  );
+
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+    cwd: root,
+    env: { PATH: goPath(), TTSC_CACHE_DIR: cacheDir },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    fs.readFileSync(path.join(root, "dist", "main.js"), "utf8"),
+    /"A:PLUGIN:Z"/,
+  );
+});
+
+test("plugin corpus: source plugin cache invalidates when Go source changes", () => {
+  const root = copyProject("go-source-plugin");
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ttsc-source-plugin-invalidate-"),
+  );
+  const env = {
+    PATH: goPath(),
+    TTSC_CACHE_DIR: cacheDir,
+  };
+
+  const first = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root, env });
+  assert.equal(first.status, 0, first.stderr);
+  assert.match(first.stderr, /building source plugin/);
+  assert.match(
+    fs.readFileSync(path.join(root, "dist", "main.js"), "utf8"),
+    /"PLUGIN"/,
+  );
+
+  // Edit the actual go-uppercase branch so the hash changes AND the new
+  // behavior is observable end-to-end.
+  const goFile = path.join(root, "go-plugin", "main.go");
+  const original = fs.readFileSync(goFile, "utf8");
+  fs.writeFileSync(
+    goFile,
+    original.replace(
+      `case "go-uppercase":
+			value = strings.ToUpper(value)`,
+      `case "go-uppercase":
+			value = "[" + strings.ToUpper(value) + "]"`,
+    ),
+  );
+
+  const second = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root, env });
+  assert.equal(second.status, 0, second.stderr);
+  assert.match(second.stderr, /building source plugin/);
+  assert.match(
+    fs.readFileSync(path.join(root, "dist", "main.js"), "utf8"),
+    /"\[PLUGIN\]"/,
+  );
+});
+
+test("plugin corpus: native.source.entry selects a sub-package", () => {
+  const root = copyProject("go-source-plugin-entry");
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ttsc-source-plugin-entry-"),
+  );
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+    cwd: root,
+    env: { PATH: goPath(), TTSC_CACHE_DIR: cacheDir },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /building source plugin "go-source-plugin-entry"/);
+  assert.match(
+    fs.readFileSync(path.join(root, "dist", "main.js"), "utf8"),
+    /"ENTRY"/,
+  );
+});
+
+test("plugin corpus: declaring both native.source and native.binary is rejected", () => {
+  const root = pluginProject(
+    [{ transform: "./plugins/conflict.cjs", name: "conflict" }],
+    {
+      "plugins/conflict.cjs": `
+        const path = require("node:path");
+        module.exports = {
+          name: "conflict",
+          native: {
+            mode: "go-uppercase",
+            binary: "/some/path/to/binary",
+            source: { dir: path.resolve(__dirname, "..", "go-plugin") },
+            contractVersion: 1,
+          },
+        };
+      `,
+    },
+  );
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /must use either native\.binary or native\.source, not both/,
+  );
+});
+
+test("plugin corpus: missing native.source.dir produces a clear error", () => {
+  const root = pluginProject(
+    [{ transform: "./plugins/empty-source.cjs", name: "empty" }],
+    {
+      "plugins/empty-source.cjs": `
+        module.exports = {
+          name: "empty",
+          native: {
+            mode: "go-uppercase",
+            source: { dir: "" },
+            contractVersion: 1,
+          },
+        };
+      `,
+    },
+  );
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /native\.source\.dir must be a non-empty string/);
+});
+
+test("plugin corpus: source plugin build failure reports Go compiler stderr", () => {
+  const root = copyProject("go-source-plugin");
+  // Inject a syntax error into the Go source.
+  const goFile = path.join(root, "go-plugin", "main.go");
+  const original = fs.readFileSync(goFile, "utf8");
+  fs.writeFileSync(
+    goFile,
+    original.replace("package main", "package main\nthis is not valid go;"),
+  );
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+    cwd: root,
+    env: {
+      PATH: goPath(),
+      TTSC_CACHE_DIR: fs.mkdtempSync(
+        path.join(os.tmpdir(), "ttsc-source-plugin-broken-"),
+      ),
+    },
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /building plugin "go-source-plugin" via "go build" failed/,
+  );
+});
+
+test("plugin corpus: missing Go toolchain points users at the install hint", () => {
+  const root = copyProject("go-source-plugin");
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+    cwd: root,
+    env: {
+      // Strip Go binaries from PATH and force lookup of a guaranteed-missing
+      // toolchain via TTSC_GO_BINARY.
+      PATH: "/nonexistent",
+      TTSC_GO_BINARY: "/nonexistent/go-binary-that-does-not-exist",
+      TTSC_CACHE_DIR: fs.mkdtempSync(
+        path.join(os.tmpdir(), "ttsc-source-plugin-no-go-"),
+      ),
+    },
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Go toolchain was not found/);
+  assert.match(result.stderr, /TTSC_GO_BINARY/);
+});
+
+test("plugin corpus: ttsc transform single-file mode drives the source plugin", () => {
+  const root = copyProject("go-source-plugin");
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ttsc-source-plugin-transform-"),
+  );
+  const out = path.join(root, "out", "main.js");
+  const result = spawn(
+    ttscBin,
+    [
+      "transform",
+      "--cwd",
+      root,
+      "--file",
+      path.join(root, "src", "main.ts"),
+      "--out",
+      out,
+    ],
+    {
+      cwd: root,
+      env: { PATH: goPath(), TTSC_CACHE_DIR: cacheDir },
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(fs.readFileSync(out, "utf8"), /"PLUGIN"/);
+});
+
+test("plugin corpus: ttsx executes source plugin output end-to-end", () => {
+  const root = copyProject("go-source-plugin");
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ttsc-source-plugin-ttsx-"),
+  );
+  const result = spawn(ttsxBin, ["--cwd", root, "src/main.ts"], {
+    cwd: root,
+    env: { PATH: goPath(), TTSC_CACHE_DIR: cacheDir },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "PLUGIN");
+});
+
+test("plugin corpus: programmatic transformAsync drives the source plugin", async () => {
+  const root = copyProject("go-source-plugin");
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ttsc-source-plugin-async-"),
+  );
+  const harnessFile = path.join(root, "harness.cjs");
+  const ttscPackage = path.join(workspaceRoot, "packages", "ttsc");
+  fs.writeFileSync(
+    harnessFile,
+    `const ttsc = require(${JSON.stringify(ttscPackage)});
+ttsc
+  .transformAsync({ cwd: ${JSON.stringify(root)}, file: ${JSON.stringify(path.join(root, "src", "main.ts"))} })
+  .then((text) => { process.stdout.write(text); })
+  .catch((error) => {
+    process.stderr.write(error.stack || String(error));
+    process.exit(1);
+  });
+`,
+  );
+  const result = spawn(process.execPath, [harnessFile], {
+    cwd: root,
+    env: { PATH: goPath(), TTSC_CACHE_DIR: cacheDir },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /"PLUGIN"/);
+});
+
+test("plugin corpus: source plugin bootstraps a Program and Checker against the consumer tsconfig", () => {
+  const root = copyProject("go-source-plugin-checker");
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ttsc-source-plugin-checker-"),
+  );
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+    cwd: root,
+    env: {
+      PATH: goPath(),
+      TTSC_CACHE_DIR: cacheDir,
+    },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stderr,
+    /building source plugin "go-source-plugin-checker"/,
+  );
+  const out = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+  assert.match(out, /"User"/);
+  assert.match(out, /"string\[\]"/);
+});
+
+test("plugin corpus: source plugin walks AST + uses Checker to enumerate interface properties", () => {
+  const root = copyProject("go-source-plugin-properties");
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ttsc-source-plugin-properties-"),
+  );
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+    cwd: root,
+    env: {
+      PATH: goPath(),
+      TTSC_CACHE_DIR: cacheDir,
+    },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stderr,
+    /building source plugin "go-source-plugin-properties"/,
+  );
+  const out = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+  assert.match(out, /\["id","email","name"\]/);
+  assert.match(out, /\["sku","price"\]/);
+});
+
+test("plugin corpus: source plugin can import tsgo shim modules via go.work overlay", () => {
+  const root = copyProject("go-source-plugin-tsgo");
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ttsc-source-plugin-tsgo-"),
+  );
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+    cwd: root,
+    env: {
+      PATH: goPath(),
+      TTSC_CACHE_DIR: cacheDir,
+    },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stderr,
+    /building source plugin "go-source-plugin-tsgo"/,
+  );
+  assert.match(
+    fs.readFileSync(path.join(root, "dist", "main.js"), "utf8"),
+    /"TSGO \(tsgo\)"/,
+  );
+});
+
+test("plugin corpus: concurrent ttsc invocations on a cold cache both succeed", async () => {
+  const rootA = copyProject("go-source-plugin");
+  const rootB = copyProject("go-source-plugin");
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ttsc-source-plugin-race-"),
+  );
+  const env = {
+    ...process.env,
+    PATH: goPath(),
+    TTSC_CACHE_DIR: cacheDir,
+    TTSC_BINARY: nativeBinary,
+    TTSC_TSGO_BINARY: tsgoBinary,
+  };
+
+  function launch(root) {
+    return new Promise((resolve, reject) => {
+      const child = child_process.spawn(
+        process.execPath,
+        [ttscBin, "--cwd", root, "--emit"],
+        {
+          cwd: root,
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+          windowsHide: true,
+        },
+      );
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk.toString();
+      });
+      child.on("error", reject);
+      child.on("close", (status) => resolve({ status, stdout, stderr, root }));
+    });
+  }
+
+  const [a, b] = await Promise.all([launch(rootA), launch(rootB)]);
+  assert.equal(a.status, 0, a.stderr);
+  assert.equal(b.status, 0, b.stderr);
+  assert.match(
+    fs.readFileSync(path.join(rootA, "dist", "main.js"), "utf8"),
+    /"PLUGIN"/,
+  );
+  assert.match(
+    fs.readFileSync(path.join(rootB, "dist", "main.js"), "utf8"),
+    /"PLUGIN"/,
+  );
+});
+
+test("plugin corpus: nonexistent native.source.dir produces a clear error", () => {
+  const root = pluginProject(
+    [{ transform: "./plugins/missing-dir.cjs", name: "missing" }],
+    {
+      "plugins/missing-dir.cjs": `
+        const path = require("node:path");
+        module.exports = {
+          name: "missing",
+          native: {
+            mode: "go-uppercase",
+            source: { dir: path.resolve(__dirname, "..", "no-such-dir") },
+            contractVersion: 1,
+          },
+        };
+      `,
+    },
+  );
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+    cwd: root,
+    env: { PATH: goPath() },
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /native\.source\.dir does not exist/);
 });
 
 function buildGoTransformer() {


### PR DESCRIPTION
This pull request adds comprehensive documentation for building and integrating native Go plugins with the `ttsc` TypeScript compiler, including a step-by-step getting started guide and a detailed protocol reference. The new docs clarify both the mental model and the technical contract for plugin authors, covering everything from project scaffolding to manifest fields and CLI protocols.

**New Getting Started Guide:**
- Introduces a full walkthrough for creating a minimal `ttsc` plugin (`ttsc-plugin-uppercase`) that uppercases strings, including npm and Go project setup, manifest authoring, Go binary implementation, and consumer usage.
- Explains the mental model for plugins, project structure, and how to test plugins locally and from a consumer project.
- Documents both JavaScript and TypeScript authoring of plugin manifests, including use of the `definePlugin` helper for type safety.
- Provides links to further documentation for advanced topics (semantic transforms, config handling, debugging, publishing, testing).

**Protocol Reference Documentation:**
- Details the `ttsc` plugin manifest contract, including all manifest fields, validation rules, and how to disable plugins via `enabled: false`.
- Specifies the CLI protocol: required subcommands (`check`, `transform`, `build`, and optional `version`), argument semantics, and exit codes.
- Explains the `--plugins-json` payload for ordered plugin pipelines and how user config is forwarded to the Go binary.
- Documents versioning, compatibility guarantees, and how `ttsc` handles plugin binary output.

These additions provide a clear, authoritative foundation for both new and advanced plugin authors, ensuring a smooth onboarding and robust integration experience.

**Documentation Additions:**

*Getting Started & Examples*
- Added `docs/plugins/01-getting-started.md` with a step-by-step guide, including a minimal Go-based plugin, manifest options, and consumer usage instructions.

*Reference & Protocol*
- Added `docs/plugins/02-protocol.md` with an authoritative reference for