### PR TITLE
fix(ttsc): more shim features.

### DIFF
--- a/config/package.json
+++ b/config/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
   "name": "@ttsc/config",
-  "version": "0.5.0"
+  "version": "0.5.0-dev.20260429-5"
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "name": "@ttsc/station",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "Standalone TypeScript-Go compiler and runtime workspace.",
   "scripts": {
     "build": "node scripts/build-platforms.cjs",
     "build:current": "node scripts/build-current.cjs",
     "experimental": "pnpm --dir experimental/install start -- --pack-current",
-    "package:latest": "pnpm build && pnpm --filter=./packages/* --filter=!ttsc -r publish --tag latest --access public && pnpm --filter ttsc publish --tag latest --access public",
+    "package:latest": "pnpm build && pnpm --filter=./packages/* --filter=!ttsc -r publish --tag latest --access public --no-git-checks --provenance && pnpm --filter ttsc publish --tag latest --access public --no-git-checks --provenance",
     "package:next": "bash next.bash",
     "package:tgz": "node experimental/tarballs",
     "release": "bumpp -r",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/banner",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "First-party ttsc plugin that prepends a banner comment to emitted files.",
   "main": "src/index.cjs",
   "exports": {

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/lint",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "Reference ttsc plugin: ESLint-style lint rules hosted in the same Program/Checker as the type-check pass.",
   "main": "src/index.cjs",
   "exports": {

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/paths",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "First-party ttsc plugin that rewrites emitted module specifiers from tsconfig paths.",
   "main": "src/index.cjs",
   "exports": {

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/strip",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "First-party ttsc plugin that removes configured calls and statements from emitted JavaScript.",
   "main": "src/index.cjs",
   "exports": {

--- a/packages/ttsc-darwin-arm64/package.json
+++ b/packages/ttsc-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/darwin-arm64",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "macOS arm64 native binary and bundled Go compiler for ttsc.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/packages/ttsc-darwin-x64/package.json
+++ b/packages/ttsc-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/darwin-x64",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "macOS x64 native binary and bundled Go compiler for ttsc.",
   "os": ["darwin"],
   "cpu": ["x64"],

--- a/packages/ttsc-linux-arm/package.json
+++ b/packages/ttsc-linux-arm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/linux-arm",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "Linux arm native binary and bundled Go compiler for ttsc.",
   "os": ["linux"],
   "cpu": ["arm"],

--- a/packages/ttsc-linux-arm64/package.json
+++ b/packages/ttsc-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/linux-arm64",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "Linux arm64 native binary and bundled Go compiler for ttsc.",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/packages/ttsc-linux-x64/package.json
+++ b/packages/ttsc-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/linux-x64",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "Linux x64 native binary and bundled Go compiler for ttsc.",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/packages/ttsc-win32-arm64/package.json
+++ b/packages/ttsc-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/win32-arm64",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "Windows arm64 native binary and bundled Go compiler for ttsc.",
   "os": ["win32"],
   "cpu": ["arm64"],

--- a/packages/ttsc-win32-x64/package.json
+++ b/packages/ttsc-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/win32-x64",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "Windows x64 native binary and bundled Go compiler for ttsc.",
   "os": ["win32"],
   "cpu": ["x64"],

--- a/packages/ttsc/package.json
+++ b/packages/ttsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttsc",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "General-purpose TypeScript-Go compiler, plugin host, and runtime.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/ttsc/shim/ast/shim.go
+++ b/packages/ttsc/shim/ast/shim.go
@@ -37,6 +37,8 @@ type TypeElementList = innerast.TypeElementList
 type Statement = innerast.Statement
 type Expression = innerast.Expression
 type TypeNode = innerast.TypeNode
+type TypePredicateParameterName = innerast.TypePredicateParameterName
+type AssertsKeyword = innerast.AssertsKeyword
 type BindingName = innerast.BindingName
 type BinaryOperatorToken = innerast.BinaryOperatorToken
 type PropertyName = innerast.PropertyName
@@ -147,6 +149,7 @@ const (
 	KindFunctionDeclaration           = innerast.KindFunctionDeclaration
 	KindMinusToken                    = innerast.KindMinusToken
 	KindQuestionDotToken              = innerast.KindQuestionDotToken
+	KindAssertsKeyword                = innerast.KindAssertsKeyword
 	KindEqualsGreaterThanToken        = innerast.KindEqualsGreaterThanToken
 
 	NodeFlagsOptionalChain = innerast.NodeFlagsOptionalChain
@@ -157,6 +160,10 @@ const (
 	SymbolFlagsAlias     = innerast.SymbolFlagsAlias
 	SymbolFlagsType      = innerast.SymbolFlagsType
 	SymbolFlagsNamespace = innerast.SymbolFlagsNamespace
+
+	ModifierFlagsPrivate   = innerast.ModifierFlagsPrivate
+	ModifierFlagsProtected = innerast.ModifierFlagsProtected
+	ModifierFlagsReadonly  = innerast.ModifierFlagsReadonly
 )
 
 func NewNodeFactory(hooks NodeFactoryHooks) *NodeFactory {

--- a/packages/ttsc/shim/checker/shim.go
+++ b/packages/ttsc/shim/checker/shim.go
@@ -13,6 +13,7 @@ type SignatureKind = innerchecker.SignatureKind
 type Type = innerchecker.Type
 type TypeFlags = innerchecker.TypeFlags
 type ObjectFlags = innerchecker.ObjectFlags
+type ElementFlags = innerchecker.ElementFlags
 
 const (
 	SignatureKindCall = innerchecker.SignatureKindCall
@@ -38,7 +39,16 @@ const (
 	TypeFlagsBigIntLike      = innerchecker.TypeFlagsBigIntLike
 	TypeFlagsBooleanLike     = innerchecker.TypeFlagsBooleanLike
 
-	ObjectFlagsReference = innerchecker.ObjectFlagsReference
+	ObjectFlagsReference        = innerchecker.ObjectFlagsReference
+	ObjectFlagsClass            = innerchecker.ObjectFlagsClass
+	ObjectFlagsInterface        = innerchecker.ObjectFlagsInterface
+	ObjectFlagsClassOrInterface = innerchecker.ObjectFlagsClassOrInterface
+
+	ElementFlagsNone     = innerchecker.ElementFlagsNone
+	ElementFlagsRequired = innerchecker.ElementFlagsRequired
+	ElementFlagsOptional = innerchecker.ElementFlagsOptional
+	ElementFlagsRest     = innerchecker.ElementFlagsRest
+	ElementFlagsVariadic = innerchecker.ElementFlagsVariadic
 )
 
 func IsTupleType(t *innerchecker.Type) bool {
@@ -143,4 +153,14 @@ func checkerIsArrayType(recv *innerchecker.Checker, t *innerchecker.Type) bool
 
 func Checker_isArrayType(recv *innerchecker.Checker, t *innerchecker.Type) bool {
 	return checkerIsArrayType(recv, t)
+}
+
+//go:linkname checkerGetBaseTypes github.com/microsoft/typescript-go/internal/checker.(*Checker).getBaseTypes
+func checkerGetBaseTypes(recv *innerchecker.Checker, t *innerchecker.Type) []*innerchecker.Type
+
+func Checker_getBaseTypes(recv *innerchecker.Checker, t *innerchecker.Type) []*innerchecker.Type {
+	if recv == nil || t == nil {
+		return nil
+	}
+	return checkerGetBaseTypes(recv, t)
 }

--- a/tests/lint/package.json
+++ b/tests/lint/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-lint",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "End-to-end rule corpus tests for @ttsc/lint. Each case ships a standalone .ts fixture with `// expect:` annotations; the runner spawns ttsc and verifies the rendered diagnostics match exactly.",
   "scripts": {
     "start": "node --test --test-reporter=spec --test-concurrency=4 *.test.cjs"

--- a/tests/smoke/package.json
+++ b/tests/smoke/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-smoke",
-  "version": "0.5.0",
+  "version": "0.5.0-dev.20260429-5",
   "description": "Standalone end-to-end smoke tests for ttsc.",
   "scripts": {
     "start": "node --test --test-reporter=spec test/*.test.cjs"


### PR DESCRIPTION
This pull request adds several new type and flag exports to the shim layers for the TypeScript compiler's AST and type checker, expanding the available API surface for downstream consumers. It also introduces a new function for retrieving base types from the checker. The most important changes are grouped below:

### AST Shim Enhancements

* Added new type exports: `TypePredicateParameterName` and `AssertsKeyword` to `shim.go`, making these AST node types available for consumers.
* Added new constant exports for node and modifier flags: `KindAssertsKeyword`, `ModifierFlagsPrivate`, `ModifierFlagsProtected`, and `ModifierFlagsReadonly`. [[1]](diffhunk://#diff-a79c62bc3ee9436b678e168846893a6f8820028095e12e31c633dc8e66d836eeR152) [[2]](diffhunk://#diff-a79c62bc3ee9436b678e168846893a6f8820028095e12e31c633dc8e66d836eeR163-R166)

### Type Checker Shim Enhancements

* Added new type and flag exports: `ElementFlags` type and constants such as `ObjectFlagsClass`, `ObjectFlagsInterface`, `ObjectFlagsClassOrInterface`, `ElementFlagsNone`, `ElementFlagsRequired`, `ElementFlagsOptional`, `ElementFlagsRest`, and `ElementFlagsVariadic`. [[1]](diffhunk://#diff-043442556f28d97bc86b2c9812f73495de8f3a14b9f23a459fa4592f512a2648R16) [[2]](diffhunk://#diff-043442556f28d97bc86b2c9812f73495de8f3a14b9f23a459fa4592f512a2648R43-R51)

### New Checker Utility

* Introduced a new function `Checker_getBaseTypes` (and its linked internal implementation) for retrieving the base types of a given type from the checker, improving type introspection capabilities.