### PR TITLE
feat(lint): more rules following eslint.

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -29,6 +29,7 @@ Open your project's `tsconfig.json`, then add this entry under `compilerOptions.
         "transform": "@ttsc/lint",
         "rules": {
           "no-var": "error",
+          "prefer-const": "error",
           "no-explicit-any": "warning",
           "no-console": "off"
         }
@@ -56,7 +57,7 @@ Lint errors fail the command. With `ttsx`, lint errors stop the program before y
   "compilerOptions": {
     "plugins": [
       // Keep lint first.
-      { "transform": "@ttsc/lint", "rules": { "no-var": "error" } },
+      { "transform": "@ttsc/lint", "rules": { "no-var": "error", "prefer-const": "error" } },
 
       // Output plugins run after emit, in order.
       { "transform": "@ttsc/banner", "banner": "/*! @license MIT */" },
@@ -93,7 +94,10 @@ The rule corpus is tested in `tests/lint/cases/*.ts`, which is the best place to
 - [`ban-ts-comment`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/ban-ts-comment.ts): rejects TypeScript suppression comments such as `@ts-ignore`.
 - [`ban-tslint-comment`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/ban-tslint-comment.ts): rejects obsolete `tslint:` comments.
 - [`consistent-indexed-object-style`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/consistent-indexed-object-style.ts): prefers `Record` for single index-signature object types.
+- [`consistent-type-assertions`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/consistent-type-assertions.ts): prefers `as` type assertions over angle-bracket assertions.
+- [`consistent-type-definitions`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/consistent-type-definitions.ts): prefers interfaces for object-shaped type definitions.
 - [`consistent-type-imports`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/consistent-type-imports/violation.ts): uses `import type` when imported names are type-only.
+- [`dot-notation`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/dot-notation.ts): prefers dot property access when a string-literal key is a valid identifier.
 - [`eqeqeq`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/eqeqeq.ts): requires strict equality operators.
 - [`for-direction`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/for-direction.ts): catches loop counters updated in the wrong direction.
 - [`no-alert`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-alert.ts): rejects `alert`, `confirm`, and `prompt`.
@@ -118,12 +122,14 @@ The rule corpus is tested in `tests/lint/cases/*.ts`, which is the best place to
 - [`no-dupe-keys`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-dupe-keys.ts): rejects duplicate object keys.
 - [`no-duplicate-case`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-duplicate-case.ts): rejects duplicate `switch` case labels.
 - [`no-duplicate-enum-values`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-duplicate-enum-values.ts): rejects duplicate enum member values.
+- [`no-dynamic-delete`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-dynamic-delete.ts): rejects `delete` on dynamically computed property keys.
 - [`no-empty`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-empty.ts): rejects empty blocks.
 - [`no-empty-character-class`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-empty-character-class.ts): rejects empty regex character classes.
 - [`no-empty-function`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-empty-function.ts): rejects empty functions.
 - [`no-empty-interface`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-empty-interface.ts): rejects empty interfaces.
 - [`no-empty-object-type`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-empty-object-type.ts): rejects empty object type literals.
 - [`no-empty-pattern`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-empty-pattern.ts): rejects empty destructuring patterns.
+- [`no-empty-static-block`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-empty-static-block.ts): rejects empty class static blocks.
 - [`no-eq-null`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-eq-null.ts): rejects loose null comparisons.
 - [`no-eval`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-eval.ts): rejects `eval`.
 - [`no-ex-assign`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-ex-assign.ts): rejects reassignment of caught exceptions.
@@ -151,6 +157,7 @@ The rule corpus is tested in `tests/lint/cases/*.ts`, which is the best place to
 - [`no-new`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-new.ts): rejects `new` expressions used only for side effects.
 - [`no-new-func`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-new-func.ts): rejects `Function` constructors.
 - [`no-new-wrappers`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-new-wrappers.ts): rejects primitive wrapper constructors.
+- [`no-non-null-asserted-nullish-coalescing`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-non-null-asserted-nullish-coalescing.ts): rejects non-null assertions next to `??`.
 - [`no-non-null-asserted-optional-chain`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-non-null-asserted-optional-chain.ts): rejects non-null assertions on optional chains.
 - [`no-non-null-assertion`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-non-null-assertion.ts): rejects postfix non-null assertions.
 - [`no-obj-calls`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-obj-calls.ts): rejects calling global objects as functions.
@@ -168,6 +175,7 @@ The rule corpus is tested in `tests/lint/cases/*.ts`, which is the best place to
 - [`no-self-assign`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-self-assign.ts): rejects assignments to the same value.
 - [`no-self-compare`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-self-compare.ts): rejects comparing a value to itself.
 - [`no-sequences`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-sequences.ts): rejects comma expressions.
+- [`no-setter-return`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-setter-return.ts): rejects returned values from setters.
 - [`no-shadow-restricted-names`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-shadow-restricted-names.ts): rejects shadowing restricted globals.
 - [`no-sparse-arrays`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-sparse-arrays.ts): rejects sparse arrays.
 - [`no-template-curly-in-string`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-template-curly-in-string.ts): rejects `${...}` text inside normal strings.
@@ -175,24 +183,32 @@ The rule corpus is tested in `tests/lint/cases/*.ts`, which is the best place to
 - [`no-throw-literal`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-throw-literal.ts): rejects throwing literals.
 - [`no-undef-init`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-undef-init.ts): rejects initializing to `undefined`.
 - [`no-undefined`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-undefined.ts): rejects the global `undefined` identifier.
+- [`no-unnecessary-type-constraint`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-unnecessary-type-constraint.ts): rejects redundant `extends any` and `extends unknown` constraints.
 - [`no-unneeded-ternary`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-unneeded-ternary.ts): rejects redundant ternary expressions.
+- [`no-unsafe-declaration-merging`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-unsafe-declaration-merging.ts): rejects unsafe class/interface declaration merging.
 - [`no-unsafe-finally`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-unsafe-finally.ts): rejects control flow from `finally`.
+- [`no-unsafe-function-type`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-unsafe-function-type.ts): rejects the unsafe `Function` type.
 - [`no-unsafe-negation`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-unsafe-negation.ts): rejects unsafe negation before relational checks.
 - [`no-unused-expressions`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-unused-expressions.ts): rejects expression statements with no effect.
+- [`no-unused-labels`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-unused-labels.ts): rejects labels that no `break` or `continue` targets.
 - [`no-useless-call`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-useless-call.ts): rejects unnecessary `.call()` and `.apply()`.
 - [`no-useless-catch`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-useless-catch.ts): rejects catch blocks that only rethrow.
 - [`no-useless-computed-key`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-useless-computed-key.ts): rejects unnecessary computed property keys.
 - [`no-useless-concat`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-useless-concat.ts): rejects unnecessary string concatenation.
+- [`no-useless-constructor`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-useless-constructor.ts): rejects empty constructors with no parameters.
 - [`no-useless-rename`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-useless-rename.ts): rejects import/export/destructure renames to the same name.
 - [`no-var`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-var.ts): rejects `var`.
 - [`no-with`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-with.ts): rejects `with` statements.
+- [`no-wrapper-object-types`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/no-wrapper-object-types.ts): rejects boxed object type names such as `String` and `Boolean`.
 - [`object-shorthand`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/object-shorthand.ts): requires object property shorthand where possible.
 - [`operator-assignment`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/operator-assignment.ts): prefers compound assignment operators.
 - [`prefer-as-const`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/prefer-as-const.ts): prefers `as const` for literal assertions.
+- [`prefer-const`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/prefer-const.ts): prefers `const` for `let` bindings that are never reassigned.
 - [`prefer-enum-initializers`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/prefer-enum-initializers.ts): requires explicit enum member initializers.
 - [`prefer-exponentiation-operator`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/prefer-exponentiation-operator.ts): prefers `**` over `Math.pow`.
 - [`prefer-for-of`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/prefer-for-of.ts): prefers `for...of` for simple array iteration.
 - [`prefer-function-type`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/prefer-function-type.ts): prefers function type aliases over single-call interfaces.
+- [`prefer-literal-enum-member`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/prefer-literal-enum-member.ts): prefers literal enum member initializers over computed expressions.
 - [`prefer-namespace-keyword`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/prefer-namespace-keyword.ts): prefers `namespace` over TypeScript's legacy `module` keyword.
 - [`prefer-spread`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/prefer-spread.ts): prefers spread arguments over `.apply`.
 - [`prefer-template`](https://github.com/samchon/ttsc/blob/master/tests/lint/cases/prefer-template.ts): prefers template literals over string concatenation.

--- a/packages/lint/plugin/ast_helpers.go
+++ b/packages/lint/plugin/ast_helpers.go
@@ -168,3 +168,59 @@ func stringLiteralText(node *shimast.Node) string {
 	}
 	return ""
 }
+
+// walkDescendants visits node and every child below it, depth-first.
+func walkDescendants(node *shimast.Node, visit func(*shimast.Node)) {
+	if node == nil {
+		return
+	}
+	visit(node)
+	node.ForEachChild(func(child *shimast.Node) bool {
+		walkDescendants(child, visit)
+		return false
+	})
+}
+
+func bindingIdentifierNames(node *shimast.Node) []string {
+	if node == nil {
+		return nil
+	}
+	if name := identifierText(node); name != "" {
+		return []string{name}
+	}
+	if node.Kind != shimast.KindObjectBindingPattern && node.Kind != shimast.KindArrayBindingPattern {
+		return nil
+	}
+	var names []string
+	walkDescendants(node, func(child *shimast.Node) {
+		if child == node {
+			return
+		}
+		if name := identifierText(child); name != "" {
+			names = append(names, name)
+		}
+	})
+	return names
+}
+
+func isLiteralLike(node *shimast.Node) bool {
+	node = stripParens(node)
+	if node == nil {
+		return false
+	}
+	if isLiteralExpression(node) {
+		return true
+	}
+	if node.Kind == shimast.KindPrefixUnaryExpression {
+		prefix := node.AsPrefixUnaryExpression()
+		if prefix == nil {
+			return false
+		}
+		switch prefix.Operator {
+		case shimast.KindPlusToken, shimast.KindMinusToken:
+			return prefix.Operand != nil &&
+				(prefix.Operand.Kind == shimast.KindNumericLiteral || prefix.Operand.Kind == shimast.KindBigIntLiteral)
+		}
+	}
+	return false
+}

--- a/packages/lint/plugin/rules_gap.go
+++ b/packages/lint/plugin/rules_gap.go
@@ -1,0 +1,341 @@
+package main
+
+import shimast "github.com/microsoft/typescript-go/shim/ast"
+
+// no-empty-static-block: `class C { static {} }` has no effect.
+// ESLint recommended: https://eslint.org/docs/latest/rules/no-empty-static-block
+type noEmptyStaticBlock struct{}
+
+func (noEmptyStaticBlock) Name() string { return "no-empty-static-block" }
+func (noEmptyStaticBlock) Visits() []shimast.Kind {
+	return []shimast.Kind{shimast.KindClassStaticBlockDeclaration}
+}
+func (noEmptyStaticBlock) Check(ctx *Context, node *shimast.Node) {
+	block := node.AsClassStaticBlockDeclaration()
+	if block == nil || block.Body == nil {
+		return
+	}
+	body := block.Body.AsBlock()
+	if body == nil || body.Statements == nil || len(body.Statements.Nodes) == 0 {
+		ctx.Report(node, "Unexpected empty static block.")
+	}
+}
+
+// no-setter-return: setters must not return a value.
+// ESLint recommended: https://eslint.org/docs/latest/rules/no-setter-return
+type noSetterReturn struct{}
+
+func (noSetterReturn) Name() string           { return "no-setter-return" }
+func (noSetterReturn) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindReturnStatement} }
+func (noSetterReturn) Check(ctx *Context, node *shimast.Node) {
+	ret := node.AsReturnStatement()
+	if ret == nil || ret.Expression == nil || !isInsideDirectSetter(node) {
+		return
+	}
+	ctx.Report(node, "Setter should not return a value.")
+}
+
+func isInsideDirectSetter(node *shimast.Node) bool {
+	for p := node.Parent; p != nil; p = p.Parent {
+		if p.Kind == shimast.KindSetAccessor {
+			return true
+		}
+		if isFunctionLikeKind(p) {
+			return false
+		}
+	}
+	return false
+}
+
+// no-unused-labels: a label is useful only when a break/continue targets it.
+// ESLint recommended: https://eslint.org/docs/latest/rules/no-unused-labels
+type noUnusedLabels struct{}
+
+func (noUnusedLabels) Name() string           { return "no-unused-labels" }
+func (noUnusedLabels) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindLabeledStatement} }
+func (noUnusedLabels) Check(ctx *Context, node *shimast.Node) {
+	stmt := node.AsLabeledStatement()
+	if stmt == nil || stmt.Label == nil {
+		return
+	}
+	label := identifierText(stmt.Label)
+	if label == "" {
+		return
+	}
+	used := false
+	walkDescendants(stmt.Statement, func(child *shimast.Node) {
+		if used || child == nil {
+			return
+		}
+		switch child.Kind {
+		case shimast.KindBreakStatement:
+			br := child.AsBreakStatement()
+			used = br != nil && identifierText(br.Label) == label
+		case shimast.KindContinueStatement:
+			cont := child.AsContinueStatement()
+			used = cont != nil && identifierText(cont.Label) == label
+		}
+	})
+	if !used {
+		ctx.Report(stmt.Label, "Label '"+label+"' is defined but never used.")
+	}
+}
+
+// no-dynamic-delete: avoid deleting properties through dynamic keys.
+// typescript-eslint strict: https://typescript-eslint.io/rules/no-dynamic-delete/
+type noDynamicDelete struct{}
+
+func (noDynamicDelete) Name() string           { return "no-dynamic-delete" }
+func (noDynamicDelete) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindDeleteExpression} }
+func (noDynamicDelete) Check(ctx *Context, node *shimast.Node) {
+	del := node.AsDeleteExpression()
+	if del == nil || del.Expression == nil || del.Expression.Kind != shimast.KindElementAccessExpression {
+		return
+	}
+	access := del.Expression.AsElementAccessExpression()
+	if access == nil || isStaticPropertyKey(access.ArgumentExpression) {
+		return
+	}
+	ctx.Report(node, "Do not delete dynamically computed property keys.")
+}
+
+func isStaticPropertyKey(node *shimast.Node) bool {
+	node = stripParens(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case shimast.KindStringLiteral,
+		shimast.KindNoSubstitutionTemplateLiteral,
+		shimast.KindNumericLiteral:
+		return true
+	}
+	return false
+}
+
+// no-non-null-asserted-nullish-coalescing: `foo! ?? bar` is contradictory.
+// typescript-eslint strict: https://typescript-eslint.io/rules/no-non-null-asserted-nullish-coalescing/
+type noNonNullAssertedNullishCoalescing struct{}
+
+func (noNonNullAssertedNullishCoalescing) Name() string {
+	return "no-non-null-asserted-nullish-coalescing"
+}
+func (noNonNullAssertedNullishCoalescing) Visits() []shimast.Kind {
+	return []shimast.Kind{shimast.KindBinaryExpression}
+}
+func (noNonNullAssertedNullishCoalescing) Check(ctx *Context, node *shimast.Node) {
+	expr := node.AsBinaryExpression()
+	if expr == nil || expr.OperatorToken == nil || expr.OperatorToken.Kind != shimast.KindQuestionQuestionToken {
+		return
+	}
+	if left := stripParens(expr.Left); left != nil && left.Kind == shimast.KindNonNullExpression {
+		ctx.Report(left, "Nullish coalescing is unnecessary after a non-null assertion.")
+	}
+	if right := stripParens(expr.Right); right != nil && right.Kind == shimast.KindNonNullExpression {
+		ctx.Report(right, "Nullish coalescing is unnecessary before a non-null assertion.")
+	}
+}
+
+// no-unnecessary-type-constraint: `<T extends any>` / `<T extends unknown>`.
+// typescript-eslint recommended: https://typescript-eslint.io/rules/no-unnecessary-type-constraint/
+type noUnnecessaryTypeConstraint struct{}
+
+func (noUnnecessaryTypeConstraint) Name() string { return "no-unnecessary-type-constraint" }
+func (noUnnecessaryTypeConstraint) Visits() []shimast.Kind {
+	return []shimast.Kind{shimast.KindTypeParameter}
+}
+func (noUnnecessaryTypeConstraint) Check(ctx *Context, node *shimast.Node) {
+	param := node.AsTypeParameterDeclaration()
+	if param == nil || param.Constraint == nil {
+		return
+	}
+	if param.Constraint.Kind == shimast.KindAnyKeyword || param.Constraint.Kind == shimast.KindUnknownKeyword {
+		ctx.Report(param.Constraint, "Constraining a type parameter to any or unknown is unnecessary.")
+	}
+}
+
+// no-unsafe-function-type: `Function` accepts any callable shape.
+// typescript-eslint recommended: https://typescript-eslint.io/rules/no-unsafe-function-type/
+type noUnsafeFunctionType struct{}
+
+func (noUnsafeFunctionType) Name() string           { return "no-unsafe-function-type" }
+func (noUnsafeFunctionType) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindTypeReference} }
+func (noUnsafeFunctionType) Check(ctx *Context, node *shimast.Node) {
+	ref := node.AsTypeReferenceNode()
+	if ref == nil || identifierText(ref.TypeName) != "Function" {
+		return
+	}
+	ctx.Report(node, "The Function type is unsafe. Use a specific function type instead.")
+}
+
+// no-wrapper-object-types: prefer primitive type keywords over boxed object
+// type names such as `String` and `Boolean`.
+// typescript-eslint recommended: https://typescript-eslint.io/rules/no-wrapper-object-types/
+type noWrapperObjectTypes struct{}
+
+func (noWrapperObjectTypes) Name() string           { return "no-wrapper-object-types" }
+func (noWrapperObjectTypes) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindTypeReference} }
+func (noWrapperObjectTypes) Check(ctx *Context, node *shimast.Node) {
+	ref := node.AsTypeReferenceNode()
+	if ref == nil {
+		return
+	}
+	switch identifierText(ref.TypeName) {
+	case "String", "Number", "Boolean", "Symbol", "BigInt", "Object":
+		ctx.Report(node, "Use primitive type keywords instead of wrapper object types.")
+	}
+}
+
+// no-useless-constructor: an empty constructor with no parameters is noise.
+// typescript-eslint strict: https://typescript-eslint.io/rules/no-useless-constructor/
+type noUselessConstructor struct{}
+
+func (noUselessConstructor) Name() string           { return "no-useless-constructor" }
+func (noUselessConstructor) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindConstructor} }
+func (noUselessConstructor) Check(ctx *Context, node *shimast.Node) {
+	ctor := node.AsConstructorDeclaration()
+	if ctor == nil || ctor.Body == nil {
+		return
+	}
+	if len(node.Parameters()) != 0 {
+		return
+	}
+	body := ctor.Body.AsBlock()
+	if body == nil || body.Statements == nil || len(body.Statements.Nodes) == 0 {
+		ctx.Report(node, "Useless empty constructor.")
+	}
+}
+
+// prefer-literal-enum-member: computed enum members are harder to inspect.
+// typescript-eslint strict: https://typescript-eslint.io/rules/prefer-literal-enum-member/
+type preferLiteralEnumMember struct{}
+
+func (preferLiteralEnumMember) Name() string           { return "prefer-literal-enum-member" }
+func (preferLiteralEnumMember) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindEnumMember} }
+func (preferLiteralEnumMember) Check(ctx *Context, node *shimast.Node) {
+	member := node.AsEnumMember()
+	if member == nil || member.Initializer == nil || isLiteralLike(member.Initializer) {
+		return
+	}
+	ctx.Report(member.Initializer, "Enum member initializer should be a literal value.")
+}
+
+// consistent-type-assertions: prefer `value as Type` over `<Type>value`.
+// typescript-eslint stylistic: https://typescript-eslint.io/rules/consistent-type-assertions/
+type consistentTypeAssertions struct{}
+
+func (consistentTypeAssertions) Name() string { return "consistent-type-assertions" }
+func (consistentTypeAssertions) Visits() []shimast.Kind {
+	return []shimast.Kind{shimast.KindTypeAssertionExpression}
+}
+func (consistentTypeAssertions) Check(ctx *Context, node *shimast.Node) {
+	ctx.Report(node, "Use `as` type assertions instead of angle-bracket assertions.")
+}
+
+// consistent-type-definitions: prefer interfaces for object-shaped public
+// contracts. This mirrors typescript-eslint's default option.
+// typescript-eslint stylistic: https://typescript-eslint.io/rules/consistent-type-definitions/
+type consistentTypeDefinitions struct{}
+
+func (consistentTypeDefinitions) Name() string { return "consistent-type-definitions" }
+func (consistentTypeDefinitions) Visits() []shimast.Kind {
+	return []shimast.Kind{shimast.KindTypeAliasDeclaration}
+}
+func (consistentTypeDefinitions) Check(ctx *Context, node *shimast.Node) {
+	alias := node.AsTypeAliasDeclaration()
+	if alias == nil || alias.Type == nil || alias.Type.Kind != shimast.KindTypeLiteral {
+		return
+	}
+	ctx.Report(node, "Use an interface instead of a type literal alias.")
+}
+
+// dot-notation: `obj["prop"]` should be `obj.prop` when the key is a valid
+// identifier.
+// ESLint canonical: https://eslint.org/docs/latest/rules/dot-notation
+type dotNotation struct{}
+
+func (dotNotation) Name() string { return "dot-notation" }
+func (dotNotation) Visits() []shimast.Kind {
+	return []shimast.Kind{shimast.KindElementAccessExpression}
+}
+func (dotNotation) Check(ctx *Context, node *shimast.Node) {
+	access := node.AsElementAccessExpression()
+	if access == nil {
+		return
+	}
+	key := stringLiteralText(access.ArgumentExpression)
+	if key == "" || !isSimpleIdentifierName(key) {
+		return
+	}
+	ctx.Report(node, "Use dot notation instead of a string literal property access.")
+}
+
+func isSimpleIdentifierName(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i, r := range value {
+		if r == '_' || r == '$' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' {
+			continue
+		}
+		if i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// no-unsafe-declaration-merging: class/interface merging hides runtime vs type
+// surface differences.
+// typescript-eslint recommended: https://typescript-eslint.io/rules/no-unsafe-declaration-merging/
+type noUnsafeDeclarationMerging struct{}
+
+func (noUnsafeDeclarationMerging) Name() string { return "no-unsafe-declaration-merging" }
+func (noUnsafeDeclarationMerging) Visits() []shimast.Kind {
+	return []shimast.Kind{shimast.KindSourceFile}
+}
+func (noUnsafeDeclarationMerging) Check(ctx *Context, node *shimast.Node) {
+	classes := map[string]bool{}
+	var interfaces []*shimast.Node
+	walkDescendants(node, func(child *shimast.Node) {
+		switch child.Kind {
+		case shimast.KindClassDeclaration:
+			decl := child.AsClassDeclaration()
+			if decl != nil {
+				if name := identifierText(decl.Name()); name != "" {
+					classes[name] = true
+				}
+			}
+		case shimast.KindInterfaceDeclaration:
+			interfaces = append(interfaces, child)
+		}
+	})
+	for _, ifaceNode := range interfaces {
+		decl := ifaceNode.AsInterfaceDeclaration()
+		if decl == nil {
+			continue
+		}
+		name := identifierText(decl.Name())
+		if name != "" && classes[name] {
+			ctx.Report(ifaceNode, "Unsafe declaration merging between class and interface '"+name+"'.")
+		}
+	}
+}
+
+func init() {
+	Register(noEmptyStaticBlock{})
+	Register(noSetterReturn{})
+	Register(noUnusedLabels{})
+	Register(noDynamicDelete{})
+	Register(noNonNullAssertedNullishCoalescing{})
+	Register(noUnnecessaryTypeConstraint{})
+	Register(noUnsafeDeclarationMerging{})
+	Register(noUnsafeFunctionType{})
+	Register(noWrapperObjectTypes{})
+	Register(noUselessConstructor{})
+	Register(preferLiteralEnumMember{})
+	Register(consistentTypeAssertions{})
+	Register(consistentTypeDefinitions{})
+	Register(dotNotation{})
+}

--- a/packages/lint/plugin/rules_logic.go
+++ b/packages/lint/plugin/rules_logic.go
@@ -277,7 +277,20 @@ func isAssignmentOperator(kind shimast.Kind) bool {
 	switch kind {
 	case shimast.KindEqualsToken,
 		shimast.KindPlusEqualsToken,
-		shimast.KindMinusEqualsToken:
+		shimast.KindMinusEqualsToken,
+		shimast.KindAsteriskEqualsToken,
+		shimast.KindAsteriskAsteriskEqualsToken,
+		shimast.KindSlashEqualsToken,
+		shimast.KindPercentEqualsToken,
+		shimast.KindLessThanLessThanEqualsToken,
+		shimast.KindGreaterThanGreaterThanEqualsToken,
+		shimast.KindGreaterThanGreaterThanGreaterThanEqualsToken,
+		shimast.KindAmpersandEqualsToken,
+		shimast.KindBarEqualsToken,
+		shimast.KindCaretEqualsToken,
+		shimast.KindAmpersandAmpersandEqualsToken,
+		shimast.KindBarBarEqualsToken,
+		shimast.KindQuestionQuestionEqualsToken:
 		return true
 	}
 	return false

--- a/packages/lint/plugin/rules_var.go
+++ b/packages/lint/plugin/rules_var.go
@@ -18,6 +18,92 @@ func (noVar) Check(ctx *Context, node *shimast.Node) {
 	}
 }
 
+// prefer-const: flag `let` declarations whose binding is never reassigned.
+// This follows ESLint's core rule for the common AST-local cases. It is
+// intentionally conservative: destructuring and declaration-only `let`
+// variables are skipped until the lint host grows full scope/data-flow state.
+// ESLint canonical: https://eslint.org/docs/latest/rules/prefer-const
+type preferConst struct{}
+
+func (preferConst) Name() string           { return "prefer-const" }
+func (preferConst) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSourceFile} }
+func (preferConst) Check(ctx *Context, node *shimast.Node) {
+	type candidate struct {
+		name string
+		node *shimast.Node
+	}
+	var candidates []candidate
+	assigned := map[string]bool{}
+
+	walkDescendants(node, func(child *shimast.Node) {
+		switch child.Kind {
+		case shimast.KindVariableDeclaration:
+			decl := child.AsVariableDeclaration()
+			if decl == nil || child.Parent == nil || child.Parent.Kind != shimast.KindVariableDeclarationList {
+				return
+			}
+			listNode := child.Parent
+			if !shimast.IsLet(listNode) {
+				return
+			}
+			name := identifierText(decl.Name())
+			if name == "" {
+				return
+			}
+			if !isConstEligibleLetDeclaration(child, decl) {
+				return
+			}
+			candidates = append(candidates, candidate{name: name, node: child})
+		case shimast.KindBinaryExpression:
+			expr := child.AsBinaryExpression()
+			if expr == nil || expr.OperatorToken == nil || !isAssignmentOperator(expr.OperatorToken.Kind) {
+				return
+			}
+			for _, name := range bindingIdentifierNames(expr.Left) {
+				assigned[name] = true
+			}
+		case shimast.KindPrefixUnaryExpression:
+			expr := child.AsPrefixUnaryExpression()
+			if expr == nil {
+				return
+			}
+			if expr.Operator == shimast.KindPlusPlusToken || expr.Operator == shimast.KindMinusMinusToken {
+				if name := identifierText(expr.Operand); name != "" {
+					assigned[name] = true
+				}
+			}
+		case shimast.KindPostfixUnaryExpression:
+			expr := child.AsPostfixUnaryExpression()
+			if expr == nil {
+				return
+			}
+			if expr.Operator == shimast.KindPlusPlusToken || expr.Operator == shimast.KindMinusMinusToken {
+				if name := identifierText(expr.Operand); name != "" {
+					assigned[name] = true
+				}
+			}
+		}
+	})
+
+	for _, c := range candidates {
+		if !assigned[c.name] {
+			ctx.Report(c.node, "Use const instead of let.")
+		}
+	}
+}
+
+func isConstEligibleLetDeclaration(node *shimast.Node, decl *shimast.VariableDeclaration) bool {
+	if decl.Initializer != nil {
+		if node.Parent != nil && node.Parent.Parent != nil && node.Parent.Parent.Kind == shimast.KindForStatement {
+			list := node.Parent.AsVariableDeclarationList()
+			return list == nil || list.Declarations == nil || len(list.Declarations.Nodes) == 1
+		}
+		return true
+	}
+	return node.Parent != nil && node.Parent.Parent != nil &&
+		(node.Parent.Parent.Kind == shimast.KindForInStatement || node.Parent.Parent.Kind == shimast.KindForOfStatement)
+}
+
 // no-undef-init: forbid `let x = undefined` and `var x = undefined`.
 // ESLint canonical: https://eslint.org/docs/latest/rules/no-undef-init
 type noUndefInit struct{}
@@ -36,5 +122,6 @@ func (noUndefInit) Check(ctx *Context, node *shimast.Node) {
 
 func init() {
 	Register(noVar{})
+	Register(preferConst{})
 	Register(noUndefInit{})
 }

--- a/packages/ttsc/shim/ast/lint.go
+++ b/packages/ttsc/shim/ast/lint.go
@@ -55,6 +55,7 @@ type WithStatement = innerast.WithStatement
 
 type ClassDeclaration = innerast.ClassDeclaration
 type ClassExpression = innerast.ClassExpression
+type ClassStaticBlockDeclaration = innerast.ClassStaticBlockDeclaration
 type ConstructorDeclaration = innerast.ConstructorDeclaration
 type EnumDeclaration = innerast.EnumDeclaration
 type EnumMember = innerast.EnumMember
@@ -106,6 +107,7 @@ type TaggedTemplateExpression = innerast.TaggedTemplateExpression
 type TemplateExpression = innerast.TemplateExpression
 type TemplateSpan = innerast.TemplateSpan
 type TypeAssertion = innerast.TypeAssertion
+type TypeOperatorNode = innerast.TypeOperatorNode
 type TypeOfExpression = innerast.TypeOfExpression
 type VoidExpression = innerast.VoidExpression
 type YieldExpression = innerast.YieldExpression

--- a/packages/ttsc/src/source-build.ts
+++ b/packages/ttsc/src/source-build.ts
@@ -81,8 +81,40 @@ function writeGoWork(scratchDir: string, useDirs: readonly string[]): void {
   for (const dir of useDirs) {
     useLines.push(`\t${dir.replace(/\\/g, "/")}`);
   }
-  const goWork = `go 1.26\n\nuse (\n${useLines.join("\n")}\n)\n`;
+  const replaceLines = sourceBuildWorkspaceReplacements(useDirs);
+  const replaceBlock =
+    replaceLines.length === 0 ? "" : `\n\n${replaceLines.join("\n")}\n`;
+  const goWork = `go 1.26\n\nuse (\n${useLines.join("\n")}\n)${replaceBlock}`;
   fs.writeFileSync(path.join(scratchDir, "go.work"), goWork, "utf8");
+}
+
+export function sourceBuildWorkspaceReplacements(
+  useDirs: readonly string[],
+): string[] {
+  const ttscRoot = useDirs.find((dir) =>
+    hasModulePath(dir, "github.com/samchon/ttsc/packages/ttsc"),
+  );
+  if (!ttscRoot) {
+    return [];
+  }
+  return [
+    `replace github.com/samchon/ttsc/packages/ttsc v0.0.0 => ${ttscRoot.replace(/\\/g, "/")}`,
+  ];
+}
+
+function hasModulePath(dir: string, modulePath: string): boolean {
+  try {
+    const goMod = fs.readFileSync(path.join(dir, "go.mod"), "utf8");
+    return new RegExp(`^module\\s+${escapeRegExp(modulePath)}\\s*$`, "m").test(
+      goMod,
+    );
+  } catch {
+    return false;
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function runGoBuild(

--- a/packages/ttsc/test/source-build.test.ts
+++ b/packages/ttsc/test/source-build.test.ts
@@ -12,6 +12,7 @@ const {
   resolveDefaultPluginCacheRoot,
   resolveGoCompiler,
   resolvePluginCacheRoot,
+  sourceBuildWorkspaceReplacements,
 } = require("../src/source-build.ts");
 
 function withTempSourceDir(files: Record<string, string>): string {
@@ -147,6 +148,18 @@ test("bundled Go package request follows platform package layout", () => {
     bundledGoPackageRequest({ platform: "win32", arch: "x64" }),
     "@ttsc/win32-x64/bin/go/bin/go.exe",
   );
+});
+
+test("sourceBuildWorkspaceReplacements pins the ttsc module for source plugins", () => {
+  const ttscRoot = withTempSourceDir({
+    "go.mod": "module github.com/samchon/ttsc/packages/ttsc\n\ngo 1.26\n",
+  });
+  const otherRoot = withTempSourceDir({
+    "go.mod": "module example.com/other\n\ngo 1.26\n",
+  });
+  assert.deepEqual(sourceBuildWorkspaceReplacements([otherRoot, ttscRoot]), [
+    `replace github.com/samchon/ttsc/packages/ttsc v0.0.0 => ${ttscRoot.replace(/\\/g, "/")}`,
+  ]);
 });
 
 test("resolvePluginCacheRoot prefers project node_modules cache", () => {

--- a/tests/lint/cases/consistent-type-assertions.ts
+++ b/tests/lint/cases/consistent-type-assertions.ts
@@ -1,0 +1,5 @@
+declare const input: unknown;
+
+// expect: consistent-type-assertions error
+const value = <string>input;
+JSON.stringify(value);

--- a/tests/lint/cases/consistent-type-definitions.ts
+++ b/tests/lint/cases/consistent-type-definitions.ts
@@ -1,0 +1,6 @@
+// expect: consistent-type-definitions error
+type Shape = {
+  name: string;
+};
+
+JSON.stringify({} as Shape);

--- a/tests/lint/cases/dot-notation.ts
+++ b/tests/lint/cases/dot-notation.ts
@@ -1,0 +1,7 @@
+const box = { name: "ttsc", "not-valid-key": "kept" };
+
+// expect: dot-notation error
+const value = box["name"];
+const kept = box["not-valid-key"];
+
+JSON.stringify([value, kept]);

--- a/tests/lint/cases/no-dynamic-delete.ts
+++ b/tests/lint/cases/no-dynamic-delete.ts
@@ -1,0 +1,6 @@
+const key = "name";
+const box: Record<string, string> = { name: "ttsc" };
+
+// expect: no-dynamic-delete error
+delete box[key];
+delete box["name"];

--- a/tests/lint/cases/no-empty-static-block.ts
+++ b/tests/lint/cases/no-empty-static-block.ts
@@ -1,0 +1,4 @@
+class Holder {
+  // expect: no-empty-static-block error
+  static {}
+}

--- a/tests/lint/cases/no-non-null-asserted-nullish-coalescing.ts
+++ b/tests/lint/cases/no-non-null-asserted-nullish-coalescing.ts
@@ -1,0 +1,5 @@
+declare const maybe: string | undefined;
+
+// expect: no-non-null-asserted-nullish-coalescing error
+const value = maybe! ?? "fallback";
+JSON.stringify(value);

--- a/tests/lint/cases/no-setter-return.ts
+++ b/tests/lint/cases/no-setter-return.ts
@@ -1,0 +1,7 @@
+class Holder {
+  set value(input: string) {
+    JSON.stringify(input);
+    // expect: no-setter-return error
+    return "ignored";
+  }
+}

--- a/tests/lint/cases/no-unnecessary-type-constraint.ts
+++ b/tests/lint/cases/no-unnecessary-type-constraint.ts
@@ -1,0 +1,4 @@
+// expect: no-unnecessary-type-constraint error
+function identity<T extends unknown>(value: T): T {
+  return value;
+}

--- a/tests/lint/cases/no-unsafe-declaration-merging.ts
+++ b/tests/lint/cases/no-unsafe-declaration-merging.ts
@@ -1,0 +1,8 @@
+class Merged {
+  value = 1;
+}
+
+// expect: no-unsafe-declaration-merging error
+interface Merged {
+  other: string;
+}

--- a/tests/lint/cases/no-unsafe-function-type.ts
+++ b/tests/lint/cases/no-unsafe-function-type.ts
@@ -1,0 +1,4 @@
+// expect: no-unsafe-function-type error
+type Callback = Function;
+
+JSON.stringify({} as Callback);

--- a/tests/lint/cases/no-unused-labels.ts
+++ b/tests/lint/cases/no-unused-labels.ts
@@ -1,0 +1,8 @@
+// expect: no-unused-labels error
+unused: {
+  JSON.stringify("unused");
+}
+
+used: for (const value of [1]) {
+  break used;
+}

--- a/tests/lint/cases/no-useless-constructor.ts
+++ b/tests/lint/cases/no-useless-constructor.ts
@@ -1,0 +1,4 @@
+class Empty {
+  // expect: no-useless-constructor error
+  constructor() {}
+}

--- a/tests/lint/cases/no-wrapper-object-types.ts
+++ b/tests/lint/cases/no-wrapper-object-types.ts
@@ -1,0 +1,4 @@
+// expect: no-wrapper-object-types error
+type Name = String;
+
+JSON.stringify({} as Name);

--- a/tests/lint/cases/prefer-const.ts
+++ b/tests/lint/cases/prefer-const.ts
@@ -1,0 +1,15 @@
+// expect: prefer-const error
+let stable = 1;
+let changing = 1;
+changing = 2;
+
+for (let i = 0; i < 2; i++) {
+  JSON.stringify(i);
+}
+
+// expect: prefer-const error
+for (let item of [1, 2]) {
+  JSON.stringify(item);
+}
+
+JSON.stringify([stable, changing]);

--- a/tests/lint/cases/prefer-literal-enum-member.ts
+++ b/tests/lint/cases/prefer-literal-enum-member.ts
@@ -1,0 +1,7 @@
+const base = 1;
+
+enum Value {
+  Fixed = 1,
+  // expect: prefer-literal-enum-member error
+  Computed = base + 1,
+}


### PR DESCRIPTION
This pull request updates the `@ttsc/lint` documentation and adds new helper functions to the plugin's AST utilities. The documentation is expanded to include several new lint rules, and the example configuration now demonstrates the use of the `prefer-const` rule. Additionally, the plugin's Go code gains utility functions for AST traversal and analysis.

**Documentation updates:**

* Added the `prefer-const` rule to the example `tsconfig.json` configuration and plugin documentation, showing how to enforce `const` usage for variables that are never reassigned. [[1]](diffhunk://#diff-307e63d736491fa6936cbed4710f676124e2bc0b34f69598a571c4e7a44ef198R32) [[2]](diffhunk://#diff-307e63d736491fa6936cbed4710f676124e2bc0b34f69598a571c4e7a44ef198L59-R60) [[3]](diffhunk://#diff-307e63d736491fa6936cbed4710f676124e2bc0b34f69598a571c4e7a44ef198R178-R211)
* Expanded the documented rule list in `README.md` with several new rules, including `consistent-type-assertions`, `dot-notation`, `no-dynamic-delete`, `no-empty-static-block`, `no-non-null-asserted-nullish-coalescing`, `no-setter-return`, `no-unnecessary-type-constraint`, `no-unsafe-declaration-merging`, `no-unsafe-function-type`, `no-unused-labels`, `no-useless-constructor`, `no-wrapper-object-types`, `prefer-literal-enum-member`, and others. [[1]](diffhunk://#diff-307e63d736491fa6936cbed4710f676124e2bc0b34f69598a571c4e7a44ef198R97-R100) [[2]](diffhunk://#diff-307e63d736491fa6936cbed4710f676124e2bc0b34f69598a571c4e7a44ef198R125-R132) [[3]](diffhunk://#diff-307e63d736491fa6936cbed4710f676124e2bc0b34f69598a571c4e7a44ef198R160) [[4]](diffhunk://#diff-307e63d736491fa6936cbed4710f676124e2bc0b34f69598a571c4e7a44ef198R178-R211)

**Plugin utility enhancements:**

* Added `walkDescendants`, a depth-first AST traversal helper, and `bindingIdentifierNames`, which extracts all identifier names from a binding pattern, to `ast_helpers.go`.
* Introduced `isLiteralLike`, a function to check if a node is a literal or literal-like (including certain prefix unary expressions), also in `ast_helpers.go`.