### PR TITLE
fix(ttsc): exact project location .

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ It is transformed into dedicated JavaScript:
 
 - [`@ttsc/banner`](https://github.com/samchon/ttsc/tree/master/packages/banner): adds banner comments to emitted JS and declarations.
 - [`@ttsc/lint`](https://github.com/samchon/ttsc/tree/master/packages/lint): type-check + lint in one compile pass, ~20x faster than `eslint` in theory.
-- [`@ttsc/paths`](https://github.com/samchon/ttsc/tree/master/packages/paths): rewrites pㄸ느ath aliases in emitted imports.
+- [`@ttsc/paths`](https://github.com/samchon/ttsc/tree/master/packages/paths): rewrites path aliases in emitted imports.
 - [`@ttsc/strip`](https://github.com/samchon/ttsc/tree/master/packages/strip): removes configured calls and `debugger` statements.
 
 Plugin authors should start from the [`Guide Documents`](https://github.com/samchon/ttsc/tree/master/docs).

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ It is transformed into dedicated JavaScript:
 
 - [`@ttsc/banner`](https://github.com/samchon/ttsc/tree/master/packages/banner): adds banner comments to emitted JS and declarations.
 - [`@ttsc/lint`](https://github.com/samchon/ttsc/tree/master/packages/lint): type-check + lint in one compile pass, ~20x faster than `eslint` in theory.
-- [`@ttsc/paths`](https://github.com/samchon/ttsc/tree/master/packages/paths): rewrites path aliases in emitted imports.
+- [`@ttsc/paths`](https://github.com/samchon/ttsc/tree/master/packages/paths): rewrites pㄸ느ath aliases in emitted imports.
 - [`@ttsc/strip`](https://github.com/samchon/ttsc/tree/master/packages/strip): removes configured calls and `debugger` statements.
 
 Plugin authors should start from the [`Guide Documents`](https://github.com/samchon/ttsc/tree/master/docs).

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 
 import { resolveEmittedJavaScript } from "../../compiler/internal/resolveEmittedJavaScript";
 import { runBuild } from "../../compiler/internal/runBuild";
-import { resolveProjectConfig } from "../../compiler/internal/project/resolveProjectConfig";
+import { readProjectConfig } from "../../compiler/internal/project/readProjectConfig";
 import type { TtscCommonOptions } from "../../structures/internal/TtscCommonOptions";
 
 const PROCESS_CACHE_KEY = String(process.pid);
@@ -48,17 +48,22 @@ function createProjectContext(
   filename: string,
   options: NonNullable<Parameters<typeof prepareExecution>[1]>,
 ) {
-  const tsconfig = options.project
-    ? resolveProjectConfig({ cwd, tsconfig: path.resolve(cwd, options.project) })
-    : resolveProjectConfig({ cwd, file: filename });
-  const root = path.dirname(tsconfig);
+  const project = readProjectConfig(
+    options.project
+      ? { cwd, tsconfig: path.resolve(cwd, options.project) }
+      : { cwd, file: filename },
+  );
+  const tsconfig = project.path;
+  const root = project.root;
   const cacheDir =
     options.cacheDir ?? path.join(root, "node_modules", ".cache", "ttsc", "ttsx");
   return {
     tsconfig,
     root,
     cacheDir,
-    emitDir: path.join(cacheDir, "project", PROCESS_CACHE_KEY),
+    emitDir:
+      project.compilerOptions.outDir ??
+      path.join(cacheDir, "project", PROCESS_CACHE_KEY),
     built: false,
     emittedFiles: undefined as string[] | undefined,
   };

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -125,13 +125,33 @@ function linkVirtualProjectLayout(
       if (fs.existsSync(virtualEntry)) {
         continue;
       }
-      fs.symlinkSync(
-        realEntry,
-        virtualEntry,
-        entry.isDirectory() && process.platform === "win32" ? "junction" : undefined,
-      );
+      linkVirtualEntry(realEntry, virtualEntry, entry);
     }
   }
+}
+
+function linkVirtualEntry(
+  realEntry: string,
+  virtualEntry: string,
+  entry: fs.Dirent,
+): void {
+  if (entry.isDirectory()) {
+    fs.symlinkSync(
+      realEntry,
+      virtualEntry,
+      process.platform === "win32" ? "junction" : undefined,
+    );
+    return;
+  }
+  if (entry.isFile()) {
+    try {
+      fs.linkSync(realEntry, virtualEntry);
+    } catch {
+      fs.copyFileSync(realEntry, virtualEntry);
+    }
+    return;
+  }
+  fs.symlinkSync(realEntry, virtualEntry);
 }
 
 function collectLinkDirectories(projectRoot: string): string[] {

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 
 import { resolveEmittedJavaScript } from "../../compiler/internal/resolveEmittedJavaScript";
@@ -7,6 +8,7 @@ import { readProjectConfig } from "../../compiler/internal/project/readProjectCo
 import type { TtscCommonOptions } from "../../structures/internal/TtscCommonOptions";
 
 const PROCESS_CACHE_KEY = String(process.pid);
+const MAX_VIRTUAL_PARENT_DEPTH = 3;
 
 /** Build the owning project and locate the emitted JavaScript entry for `ttsx`. */
 export function prepareExecution(
@@ -168,7 +170,7 @@ function linkVirtualEntry(
 function collectLinkDirectories(projectRoot: string): string[] {
   const out: string[] = [];
   let current = projectRoot;
-  for (let depth = 0; depth < 8; depth += 1) {
+  for (let depth = 0; depth <= MAX_VIRTUAL_PARENT_DEPTH; depth += 1) {
     out.push(current);
     if (
       depth > 0 &&
@@ -178,12 +180,21 @@ function collectLinkDirectories(projectRoot: string): string[] {
       break;
     }
     const parent = path.dirname(current);
-    if (parent === current) {
+    if (parent === current || isUnsafeVirtualParent(parent)) {
       break;
     }
     current = parent;
   }
   return out.reverse();
+}
+
+function isUnsafeVirtualParent(directory: string): boolean {
+  const resolved = path.resolve(directory);
+  const root = path.parse(resolved).root;
+  return (
+    resolved === root ||
+    resolved === path.resolve(os.tmpdir())
+  );
 }
 
 function virtualPath(root: string, absolute: string): string {

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -67,10 +67,21 @@ function createProjectContext(
     virtualRoot,
     emitDir: project.compilerOptions.outDir
       ? virtualPath(virtualRoot, project.compilerOptions.outDir)
-      : path.join(processDir, "out"),
+      : virtualPath(virtualRoot, resolveRuntimeSourceRoot(project, filename)),
     built: false,
     emittedFiles: undefined as string[] | undefined,
   };
+}
+
+function resolveRuntimeSourceRoot(
+  project: ReturnType<typeof readProjectConfig>,
+  filename: string,
+): string {
+  const rootDir = project.compilerOptions.rootDir;
+  if (typeof rootDir === "string") {
+    return path.isAbsolute(rootDir) ? rootDir : path.resolve(project.root, rootDir);
+  }
+  return path.dirname(filename);
 }
 
 function buildProject(

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -57,13 +57,17 @@ function createProjectContext(
   const root = project.root;
   const cacheDir =
     options.cacheDir ?? path.join(root, "node_modules", ".cache", "ttsc", "ttsx");
+  const processDir = path.join(cacheDir, "project", PROCESS_CACHE_KEY);
+  const virtualRoot = path.join(processDir, "fs");
   return {
     tsconfig,
     root,
     cacheDir,
-    emitDir:
-      project.compilerOptions.outDir ??
-      path.join(cacheDir, "project", PROCESS_CACHE_KEY),
+    processDir,
+    virtualRoot,
+    emitDir: project.compilerOptions.outDir
+      ? virtualPath(virtualRoot, project.compilerOptions.outDir)
+      : path.join(processDir, "out"),
     built: false,
     emittedFiles: undefined as string[] | undefined,
   };
@@ -76,7 +80,8 @@ function buildProject(
   if (context.built) return;
 
   fs.mkdirSync(context.cacheDir, { recursive: true });
-  fs.rmSync(context.emitDir, { recursive: true, force: true });
+  fs.rmSync(context.processDir, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(context.emitDir), { recursive: true });
   const result = runBuild({
     binary: options.binary,
     cwd: context.root,
@@ -89,6 +94,7 @@ function buildProject(
     tsconfig: context.tsconfig,
   });
   if (result.status === 0) {
+    linkVirtualProjectLayout(context);
     context.built = true;
     context.emittedFiles =
       result.emittedFiles && result.emittedFiles.length !== 0
@@ -97,7 +103,7 @@ function buildProject(
     return;
   }
 
-  fs.rmSync(context.emitDir, { recursive: true, force: true });
+  fs.rmSync(context.processDir, { recursive: true, force: true });
   const detail = [
     `ttsx: project check failed for ${context.tsconfig}`,
     result.stderr || result.stdout,
@@ -105,6 +111,59 @@ function buildProject(
     .filter((line) => line.trim().length !== 0)
     .join("\n");
   throw new Error(detail);
+}
+
+function linkVirtualProjectLayout(
+  context: ReturnType<typeof createProjectContext>,
+): void {
+  for (const directory of collectLinkDirectories(context.root)) {
+    const virtualDirectory = virtualPath(context.virtualRoot, directory);
+    fs.mkdirSync(virtualDirectory, { recursive: true });
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const realEntry = path.join(directory, entry.name);
+      const virtualEntry = path.join(virtualDirectory, entry.name);
+      if (fs.existsSync(virtualEntry)) {
+        continue;
+      }
+      fs.symlinkSync(
+        realEntry,
+        virtualEntry,
+        entry.isDirectory() && process.platform === "win32" ? "junction" : undefined,
+      );
+    }
+  }
+}
+
+function collectLinkDirectories(projectRoot: string): string[] {
+  const out: string[] = [];
+  let current = projectRoot;
+  for (let depth = 0; depth < 8; depth += 1) {
+    out.push(current);
+    if (
+      depth > 0 &&
+      (fs.existsSync(path.join(current, "pnpm-workspace.yaml")) ||
+        fs.existsSync(path.join(current, ".git")))
+    ) {
+      break;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+  return out.reverse();
+}
+
+function virtualPath(root: string, absolute: string): string {
+  const parsed = path.parse(path.resolve(absolute));
+  const label =
+    parsed.root === path.sep
+      ? "posix"
+      : parsed.root.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "") ||
+        "root";
+  const relative = path.relative(parsed.root, path.resolve(absolute));
+  return path.join(root, label, relative);
 }
 
 function looksLikeESM(output: string): boolean {

--- a/tests/smoke/test/runner-corpus.test.cjs
+++ b/tests/smoke/test/runner-corpus.test.cjs
@@ -122,6 +122,76 @@ test("runner corpus: ttsx executes the intended entrypoint and side effects", ()
   });
 });
 
+test("runner corpus: CommonJS __dirname resolves from configured outDir", () => {
+  const root = createProject({
+    "app/tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "bin",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "app/src/TestGlobal.ts": `
+      export class TestGlobal {
+        public static readonly ROOT: string = __dirname + "/..";
+      }
+    `,
+    "app/src/main.ts": `
+      import fs from "node:fs";
+      import { TestGlobal } from "./TestGlobal";
+
+      console.log(fs.readFileSync(TestGlobal.ROOT + "/../template/data.txt", "utf8"));
+    `,
+    "template/data.txt": "dirname-preserved",
+  });
+  const cwd = path.join(root, "app");
+
+  const result = spawn(ttsxBin, ["--cwd", cwd, "src/main.ts"], { cwd });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "dirname-preserved");
+});
+
+test("runner corpus: ESM import.meta.url resolves from configured outDir", () => {
+  const root = createProject({
+    "app/package.json": JSON.stringify({ type: "module" }),
+    "app/tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ES2022",
+        moduleResolution: "bundler",
+        strict: true,
+        outDir: "bin",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "app/src/global.ts": `
+      import path from "node:path";
+      import { fileURLToPath } from "node:url";
+
+      export const ROOT = path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+      );
+    `,
+    "app/src/main.ts": `
+      import fs from "node:fs";
+      import { ROOT } from "./global";
+
+      console.log(fs.readFileSync(ROOT + "/../template/data.txt", "utf8"));
+    `,
+    "template/data.txt": "import-meta-preserved",
+  });
+  const cwd = path.join(root, "app");
+
+  const result = spawn(ttsxBin, ["--cwd", cwd, "src/main.ts"], { cwd });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "import-meta-preserved");
+});
+
 test("runner corpus: type-check diagnostics prevent entry execution", () => {
   const root = commonJsProject({
     "src/main.ts": `

--- a/tests/smoke/test/runner-corpus.test.cjs
+++ b/tests/smoke/test/runner-corpus.test.cjs
@@ -241,6 +241,34 @@ test("runner corpus: ttsx keeps configured outDir untouched", () => {
   assert.equal(fs.existsSync(path.join(cacheDir, "project")), true);
 });
 
+test("runner corpus: CommonJS __dirname resolves without configured outDir", () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/node.d.ts": `
+      declare const __dirname: string;
+      declare function require(name: string): { readFileSync(file: string, encoding: string): string };
+    `,
+    "src/main.ts": `
+      const fs = require("node:fs");
+      console.log(fs.readFileSync(__dirname + "/../template/data.txt", "utf8"));
+    `,
+    "template/data.txt": "no-outdir-preserved",
+  });
+
+  const result = spawn(ttsxBin, ["--cwd", root, "src/main.ts"], { cwd: root });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "no-outdir-preserved");
+  assert.equal(fs.existsSync(path.join(root, "src", "main.js")), false);
+});
+
 test("runner corpus: type-check diagnostics prevent entry execution", () => {
   const root = commonJsProject({
     "src/main.ts": `

--- a/tests/smoke/test/runner-corpus.test.cjs
+++ b/tests/smoke/test/runner-corpus.test.cjs
@@ -208,6 +208,39 @@ test("runner corpus: ESM import.meta.url resolves from configured outDir", () =>
   assert.equal(result.stdout.trim(), "import-meta-preserved");
 });
 
+test("runner corpus: ttsx keeps configured outDir untouched", () => {
+  const root = createProject({
+    "package.json": JSON.stringify({ type: "module" }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ES2022",
+        moduleResolution: "bundler",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "dist/keep.txt": "do-not-delete",
+    "src/helper.ts": `export const message: string = "cache-only-run";\n`,
+    "src/main.ts": `import { message } from "./helper";\nconsole.log(message);\n`,
+  });
+  const cacheDir = path.join(root, ".ttsx-cache");
+
+  const result = spawn(
+    ttsxBin,
+    ["--cwd", root, "--cache-dir", cacheDir, "src/main.ts"],
+    { cwd: root },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "cache-only-run");
+  assert.equal(fs.readFileSync(path.join(root, "dist", "keep.txt"), "utf8"), "do-not-delete");
+  assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), false);
+  assert.equal(fs.existsSync(path.join(root, "dist", "package.json")), false);
+  assert.equal(fs.existsSync(path.join(cacheDir, "project")), true);
+});
+
 test("runner corpus: type-check diagnostics prevent entry execution", () => {
   const root = commonJsProject({
     "src/main.ts": `

--- a/tests/smoke/test/runner-corpus.test.cjs
+++ b/tests/smoke/test/runner-corpus.test.cjs
@@ -134,15 +134,19 @@ test("runner corpus: CommonJS __dirname resolves from configured outDir", () => 
       },
       include: ["src"],
     }),
+    "app/src/node.d.ts": `
+      declare const __dirname: string;
+      declare function require(name: string): { readFileSync(file: string, encoding: string): string };
+    `,
     "app/src/TestGlobal.ts": `
       export class TestGlobal {
         public static readonly ROOT: string = __dirname + "/..";
       }
     `,
     "app/src/main.ts": `
-      import fs from "node:fs";
       import { TestGlobal } from "./TestGlobal";
 
+      const fs = require("node:fs");
       console.log(fs.readFileSync(TestGlobal.ROOT + "/../template/data.txt", "utf8"));
     `,
     "template/data.txt": "dirname-preserved",
@@ -168,6 +172,18 @@ test("runner corpus: ESM import.meta.url resolves from configured outDir", () =>
       },
       include: ["src"],
     }),
+    "app/src/node.d.ts": `
+      declare module "node:fs" {
+        export function readFileSync(file: string, encoding: string): string;
+      }
+      declare module "node:path" {
+        export function dirname(file: string): string;
+        export function resolve(...parts: string[]): string;
+      }
+      declare module "node:url" {
+        export function fileURLToPath(url: string): string;
+      }
+    `,
     "app/src/global.ts": `
       import path from "node:path";
       import { fileURLToPath } from "node:url";


### PR DESCRIPTION
This pull request updates the project configuration resolution logic and adds new tests to ensure correct runtime path resolution when using a configured `outDir`. The most important changes include switching from `resolveProjectConfig` to `readProjectConfig` in the project context creation, updating how the output directory is determined, and adding tests to verify that `__dirname` and `import.meta.url` resolve correctly relative to the configured `outDir`.

**Project configuration and execution context improvements:**

* Replaced the use of `resolveProjectConfig` with `readProjectConfig` in `prepareExecution.ts`, updating how project configuration is read and how the `tsconfig` and project root are determined. (`packages/ttsc/src/launcher/internal/prepareExecution.ts`) [[1]](diffhunk://#diff-5a5babe83df41e85312f1aa3211430b370fdce3b8d0e0832b7bde22d3e142423L6-R6) [[2]](diffhunk://#diff-5a5babe83df41e85312f1aa3211430b370fdce3b8d0e0832b7bde22d3e142423L51-R66)
* Modified the logic for determining the `emitDir` so that it uses the configured `outDir` from `compilerOptions` if available, ensuring emitted files are placed in the correct directory. (`packages/ttsc/src/launcher/internal/prepareExecution.ts`)

**Testing for correct runtime path resolution:**

* Added new smoke tests to verify that CommonJS `__dirname` and ESM `import.meta.url` resolve from the configured `outDir`, ensuring runtime paths behave as expected when `outDir` is set. (`tests/smoke/test/runner-corpus.test.cjs`)

**Documentation:**

* Minor typo introduced in the `README.md` for the `@ttsc/paths` description. (`README.md`)