### PR TITLE
feat(ttsc): new CLI command `prepare`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ npx ttsc --noEmit
 npx ttsc --watch
 ```
 
-Clear cached transformer binaries when developing or debugging a plugin:
+Prebuild or clear cached source-plugin binaries:
 
 ```bash
+npx ttsc prepare
 npx ttsc clean
 ```
 

--- a/packages/ttsc/src/launcher/internal/runTtsc.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsc.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import { TtscCompiler } from "../../TtscCompiler";
 import { resolveBinary } from "../../compiler/internal/resolveBinary";
 import { runBuild } from "../../compiler/internal/runBuild";
 import { runSingleFileEmit } from "../../compiler/internal/runSingleFileEmit";
@@ -35,6 +36,8 @@ export function runTtsc(
         return runCompatibleBuild(rest, true);
       case "clean":
         return runClean(rest);
+      case "prepare":
+        return runPrepare(rest);
       case "demo":
         return delegateToNative(argv);
       case "-p":
@@ -82,8 +85,34 @@ function runCompatibleBuild(
   return result.status;
 }
 
+function runPrepare(argv: readonly string[]): number {
+  const options = parseProjectArgs(argv);
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  const compiler = new TtscCompiler({
+    cwd,
+    tsconfig: options.tsconfig,
+  });
+  const prepared = compiler.prepare();
+  if (prepared.length === 0) {
+    const projectRoot = path.dirname(
+      resolveProjectConfig({
+        cwd,
+        tsconfig: options.tsconfig,
+      }),
+    );
+    process.stdout.write(
+      `ttsc: no source plugins found under ${formatProjectPath(cwd, projectRoot)}\n`,
+    );
+    return 0;
+  }
+  for (const target of prepared) {
+    process.stdout.write(`ttsc: prepared ${formatProjectPath(cwd, target)}\n`);
+  }
+  return 0;
+}
+
 function runClean(argv: readonly string[]): number {
-  const options = parseCleanArgs(argv);
+  const options = parseProjectArgs(argv);
   const cwd = path.resolve(options.cwd ?? process.cwd());
   const projectRoot = resolveCleanProjectRoot(cwd, options.tsconfig);
   const targets = [
@@ -106,7 +135,7 @@ function runClean(argv: readonly string[]): number {
     return 0;
   }
   for (const target of removed) {
-    process.stdout.write(`ttsc: removed ${formatCleanPath(cwd, target)}\n`);
+    process.stdout.write(`ttsc: removed ${formatProjectPath(cwd, target)}\n`);
   }
   return 0;
 }
@@ -120,7 +149,7 @@ function resolveCleanProjectRoot(cwd: string, tsconfig?: string): string {
   }
 }
 
-function formatCleanPath(cwd: string, target: string): string {
+function formatProjectPath(cwd: string, target: string): string {
   const relative = path.relative(cwd, target);
   if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
     return target;
@@ -174,7 +203,7 @@ function ensureExecutable(binary: string): void {
   }
 }
 
-function parseCleanArgs(argv: readonly string[]) {
+function parseProjectArgs(argv: readonly string[]) {
   let cwd: string | undefined;
   let tsconfig: string | undefined;
 
@@ -303,6 +332,7 @@ function printHelp(): void {
       "  ttsc -p tsconfig.json",
       "  ttsc --watch",
       "  ttsc --noEmit",
+      "  ttsc prepare [options]",
       "  ttsc clean [options]",
       "  ttsc version",
       "  ttsc --help",
@@ -328,6 +358,7 @@ function printHelp(): void {
       "Compatibility aliases:",
       "  ttsc build [options]       Same project build lane as `ttsc [options]`.",
       "  ttsc check [options]       Same as `ttsc --noEmit [options]`.",
+      "  ttsc prepare [options]     Build configured source-plugin binaries into cache.",
       "  ttsc clean [options]       Delete local source-plugin cache directories.",
     ].join("\n"),
   );

--- a/tests/smoke/test/plugin-corpus.test.cjs
+++ b/tests/smoke/test/plugin-corpus.test.cjs
@@ -230,6 +230,47 @@ test("plugin corpus: source plugins are built locally and used", () => {
   );
 });
 
+test("plugin corpus: prepare builds source plugins without emitting project output", () => {
+  const root = copyProject("go-source-plugin");
+  const cacheDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ttsc-source-plugin-prepare-"),
+  );
+  const env = {
+    PATH: goPath(),
+    TTSC_CACHE_DIR: cacheDir,
+  };
+
+  const prepared = spawn(ttscBin, ["prepare", "--cwd", root], {
+    cwd: root,
+    env,
+  });
+  assert.equal(prepared.status, 0, prepared.stderr);
+  assert.match(prepared.stdout, /ttsc: prepared /);
+  assert.match(prepared.stderr, /building source plugin "go-source-plugin"/);
+  assert.equal(fs.existsSync(path.join(root, "dist")), false);
+  const pluginCache = path.join(cacheDir, "plugins");
+  const binaries = fs
+    .readdirSync(pluginCache, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) =>
+      path.join(
+        pluginCache,
+        entry.name,
+        process.platform === "win32" ? "plugin.exe" : "plugin",
+      ),
+    );
+  assert.equal(binaries.length, 1);
+  assert.equal(fs.existsSync(binaries[0]), true);
+
+  const built = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root, env });
+  assert.equal(built.status, 0, built.stderr);
+  assert.doesNotMatch(built.stderr, /building source plugin/);
+  assert.match(
+    fs.readFileSync(path.join(root, "dist", "main.js"), "utf8"),
+    /"PLUGIN"/,
+  );
+});
+
 test("plugin corpus: source plugins serve an ordered --plugins-json pipeline", () => {
   const root = copyProject("go-source-plugin");
   const cacheDir = fs.mkdtempSync(


### PR DESCRIPTION
This pull request adds a new `prepare` command to the `ttsc` CLI for prebuilding source-plugin binaries, improves the CLI help output, and refactors related argument parsing and output formatting for better consistency. It also introduces a new test to ensure the correct behavior of the `prepare` command.

**New CLI functionality and documentation:**

* Added a `prepare` command to `ttsc` that builds source-plugin binaries into the cache without emitting project output, and updated the CLI help and `README.md` to describe this new command. [[1]](diffhunk://#diff-1fff24d507287e3b2a9dba9144183de4835954dbbed8607aa434fe7487eea3a7R39-R40) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R47) [[3]](diffhunk://#diff-1fff24d507287e3b2a9dba9144183de4835954dbbed8607aa434fe7487eea3a7R335) [[4]](diffhunk://#diff-1fff24d507287e3b2a9dba9144183de4835954dbbed8607aa434fe7487eea3a7R361)

**Codebase refactoring and improvements:**

* Refactored argument parsing by replacing `parseCleanArgs` with a more general `parseProjectArgs`, which is now used by both `prepare` and `clean` commands. Also unified output formatting by renaming `formatCleanPath` to `formatProjectPath` and using it in both commands. [[1]](diffhunk://#diff-1fff24d507287e3b2a9dba9144183de4835954dbbed8607aa434fe7487eea3a7R88-R115) [[2]](diffhunk://#diff-1fff24d507287e3b2a9dba9144183de4835954dbbed8607aa434fe7487eea3a7L109-R138) [[3]](diffhunk://#diff-1fff24d507287e3b2a9dba9144183de4835954dbbed8607aa434fe7487eea3a7L123-R152) [[4]](diffhunk://#diff-1fff24d507287e3b2a9dba9144183de4835954dbbed8607aa434fe7487eea3a7L177-R206)
* Updated imports in `runTtsc.ts` to include `TtscCompiler`, supporting the new `prepare` workflow.

**Testing:**

* Added a smoke test to verify that the `prepare` command builds source plugins into the cache without emitting project output, and that subsequent builds do not rebuild the plugin unnecessarily.