### PR TITLE
feat(ttsc): update README.md - introduce lint from the 1st section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A `typescript-go` toolchain for compiler-powered transforms and type-safe execut
   - 10x faster than `ts-node`.
   - type checking that `tsx` does not provide.
 - **transformer support**: compiler-powered libraries, such as `typia`.
-  - `@ttsc/lint`: lint violation as TS compile error.
+  - `@ttsc/lint`: lint violations as TS compile errors.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ A `typescript-go` toolchain for compiler-powered transforms and type-safe execut
   - 10x faster than `ts-node`.
   - type checking that `tsx` does not provide.
 - **transformer support**: compiler-powered libraries, such as `typia`.
-
-> `ttsx` (CLI command) can run existing `typescript@6` projects.
+  - `@ttsc/lint`: lint violation as TS compile error.
 
 ## Setup
 


### PR DESCRIPTION
This pull request updates the documentation for the `typescript-go` toolchain, specifically the `README.md` file. The main change is the addition of information about a new feature related to linting.

Documentation updates:

* Added a note that `@ttsc/lint` provides lint violation reporting as TypeScript compile errors, improving clarity on linting support in the toolchain.