### PR TITLE
feat(test): enhance test logics of unplugin.

### DIFF
--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -1,0 +1,44 @@
+name: bun
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/bun.yml"
+      - "experimental/test-unplugin/**"
+      - "scripts/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+  workflow_dispatch:
+
+jobs:
+  Unplugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/ttsc/go.mod
+          cache-dependency-path: |
+            packages/ttsc/go.sum
+            tests/go-transformer/go.mod
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify Unplugin With Bun Runtime
+        run: pnpm run experimental:unplugin

--- a/experimental/install/README.md
+++ b/experimental/install/README.md
@@ -13,10 +13,7 @@ verifies that:
   plugin builds;
 - `@ttsc/banner`, `@ttsc/paths`, and `@ttsc/strip` build from source with
   that bundled Go compiler;
-- `@ttsc/unplugin` installs from its tarball, exposes every adapter entrypoint
-  through ESM default import and CJS require, and runs inside a real Vite build;
-- `@ttsc/lint` and `@ttsc/unplugin` do not publish their local
-  `tsconfig.json` files;
+- `@ttsc/lint` does not publish its local `tsconfig.json` file;
 - `ttsc --version`, `ttsc --emit`, and `ttsx` execute through the installed
   package path and observe the emitted JavaScript, declarations, source maps,
   path rewrites, stripped statements, and runtime output.

--- a/experimental/install/src/index.js
+++ b/experimental/install/src/index.js
@@ -12,8 +12,9 @@ const packCurrent = process.argv.includes("--pack-current");
 const platformKey = `${process.platform}-${process.arch}`;
 const platformPackage = `@ttsc/${platformKey}`;
 const platformTarball = `ttsc-${platformKey}`;
-const packageTarballs = ["banner", "lint", "paths", "strip", "unplugin"];
-const registryDependencies = ["@typescript/native-preview", "vite"];
+const currentPackageTarballs = ["banner", "lint", "paths", "strip", "unplugin"];
+const packageTarballs = ["banner", "lint", "paths", "strip"];
+const registryDependencies = ["@typescript/native-preview"];
 
 main();
 
@@ -26,8 +27,6 @@ function main() {
   prepareWorkspace();
   installTarballs();
   verifyInstalledPackages();
-  verifyUnpluginEntrypoints();
-  verifyUnpluginViteBuild();
   verifyTtscBuild();
   verifyTtsxRun();
   console.log("Success");
@@ -37,13 +36,13 @@ function prepareCurrentTarballs() {
   run("pnpm run build:current", root);
 
   fs.mkdirSync(tarballs, { recursive: true });
-  for (const name of ["ttsc", platformTarball, ...packageTarballs]) {
+  for (const name of ["ttsc", platformTarball, ...currentPackageTarballs]) {
     fs.rmSync(path.join(tarballs, `${name}.tgz`), { force: true });
   }
 
   packPackage("ttsc", "ttsc");
   packPackage(platformTarball, platformTarball);
-  for (const name of packageTarballs) {
+  for (const name of currentPackageTarballs) {
     packPackage(name, name);
   }
 }
@@ -148,155 +147,6 @@ function prepareWorkspace() {
       "",
     ].join("\n"),
   );
-  writeUnpluginFixture();
-}
-
-function writeUnpluginFixture() {
-  fs.mkdirSync(path.join(workspace, "unplugin-src"), { recursive: true });
-  fs.writeFileSync(
-    path.join(workspace, "tsconfig.unplugin.json"),
-    JSON.stringify(
-      {
-        extends: "./tsconfig.json",
-        compilerOptions: {
-          module: "ESNext",
-          rootDir: ".",
-          plugins: [
-            {
-              transform: "./unplugin-transform.cjs",
-            },
-          ],
-        },
-        include: ["unplugin-src/bundler.ts"],
-      },
-      null,
-      2,
-    ),
-    "utf8",
-  );
-  fs.writeFileSync(
-    path.join(workspace, "unplugin-src", "bundler.ts"),
-    [
-      'export const bundled: string = goUpper("installed-unplugin-ok");',
-      "console.log(bundled);",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  writeUnpluginTransformPlugin();
-  fs.writeFileSync(
-    path.join(workspace, "vite.config.mjs"),
-    [
-      'import path from "node:path";',
-      'import ttsc from "@ttsc/unplugin/vite";',
-      'import { defineConfig } from "vite";',
-      "",
-      "export default defineConfig({",
-      "  build: {",
-      "    emptyOutDir: true,",
-      "    minify: false,",
-      '    outDir: "dist-vite",',
-      "    rollupOptions: {",
-      '      input: path.resolve("unplugin-src/bundler.ts"),',
-      "      output: {",
-      '        entryFileNames: "bundler.js",',
-      '        format: "es",',
-      "      },",
-      "    },",
-      "  },",
-      '  logLevel: "silent",',
-      '  plugins: [ttsc({ project: "tsconfig.unplugin.json" })],',
-      "});",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-}
-
-function writeUnpluginTransformPlugin() {
-  fs.writeFileSync(
-    path.join(workspace, "unplugin-transform.cjs"),
-    [
-      'const path = require("node:path");',
-      "",
-      "module.exports = function createUnpluginTransform() {",
-      "  return {",
-      '    name: "unplugin-transform-fixture",',
-      '    source: path.resolve(__dirname, "unplugin-transform-go"),',
-      "  };",
-      "};",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  fs.mkdirSync(path.join(workspace, "unplugin-transform-go"), {
-    recursive: true,
-  });
-  fs.writeFileSync(
-    path.join(workspace, "unplugin-transform-go", "go.mod"),
-    "module example.com/ttscunplugininstall\n\ngo 1.26\n",
-    "utf8",
-  );
-  fs.writeFileSync(
-    path.join(workspace, "unplugin-transform-go", "main.go"),
-    [
-      "package main",
-      "",
-      "import (",
-      '  "encoding/json"',
-      '  "flag"',
-      '  "fmt"',
-      '  "os"',
-      '  "path/filepath"',
-      '  "regexp"',
-      '  "strings"',
-      ")",
-      "",
-      'var goUpperCall = regexp.MustCompile(`goUpper\\("([^"]*)"\\)`)',
-      "",
-      "type transformResult struct {",
-      '  TypeScript map[string]string `json:"typescript"`',
-      "}",
-      "",
-      "func main() { os.Exit(run(os.Args[1:])) }",
-      "",
-      "func run(args []string) int {",
-      "  if len(args) == 0 { return 2 }",
-      "  switch args[0] {",
-      '  case "transform":',
-      "    return transform(args[1:])",
-      '  case "check", "version", "build":',
-      "    return 0",
-      "  default:",
-      '    fmt.Fprintf(os.Stderr, "unknown command %q\\n", args[0])',
-      "    return 2",
-      "  }",
-      "}",
-      "",
-      "func transform(args []string) int {",
-      '  fs := flag.NewFlagSet("transform", flag.ContinueOnError)',
-      '  cwd := fs.String("cwd", "", "")',
-      '  _ = fs.String("tsconfig", "", "")',
-      '  _ = fs.String("plugins-json", "", "")',
-      "  if err := fs.Parse(args); err != nil { return 2 }",
-      "  root := *cwd",
-      '  if root == "" { root, _ = os.Getwd() }',
-      '  source, err := os.ReadFile(filepath.Join(root, "unplugin-src", "bundler.ts"))',
-      "  if err != nil { fmt.Fprintln(os.Stderr, err); return 2 }",
-      "  code := goUpperCall.ReplaceAllStringFunc(string(source), func(call string) string {",
-      "    match := goUpperCall.FindStringSubmatch(call)",
-      "    if len(match) != 2 { return call }",
-      '    return fmt.Sprintf("%q", strings.ToUpper(match[1]))',
-      "  })",
-      '  data, err := json.Marshal(transformResult{TypeScript: map[string]string{"unplugin-src/bundler.ts": code}})',
-      "  if err != nil { fmt.Fprintln(os.Stderr, err); return 2 }",
-      "  fmt.Fprintln(os.Stdout, string(data))",
-      "  return 0",
-      "}",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
 }
 
 function installTarballs() {
@@ -368,117 +218,6 @@ function verifyInstalledPackages() {
   const ttsx = run("npx ttsx --version", workspace).stdout;
   assert(/^ttsx /m.test(ttsx), "npx ttsx --version must print ttsx banner");
   assertPackageFileMissing("@ttsc/lint", "tsconfig.json");
-  assertPackageFileMissing("@ttsc/unplugin", "tsconfig.json");
-  assertPackageFileMissing("@ttsc/unplugin", "lib/_virtual");
-  assertPackageFileMissing("@ttsc/unplugin", "lib/vite.cjs");
-  assertPackageFileExists("@ttsc/unplugin", "lib/vite.js");
-  assertPackageFileExists("@ttsc/unplugin", "lib/vite.mjs");
-  const unpluginPackage = readInstalledPackageJson("@ttsc/unplugin");
-  assert(
-    unpluginPackage.type === undefined,
-    "@ttsc/unplugin must not set package.json type=module",
-  );
-  assert(
-    unpluginPackage.peerDependencies === undefined,
-    "@ttsc/unplugin must not publish peerDependencies",
-  );
-  assert(
-    unpluginPackage.exports?.["./vite"]?.import === "./lib/vite.mjs" &&
-      unpluginPackage.exports?.["./vite"]?.default === "./lib/vite.js",
-    "@ttsc/unplugin must publish ESM through import and CJS through default",
-  );
-}
-
-function verifyUnpluginEntrypoints() {
-  fs.writeFileSync(
-    path.join(workspace, "verify-unplugin.mjs"),
-    [
-      'const root = await import("@ttsc/unplugin");',
-      'if (typeof root.default.vite !== "function") {',
-      '  throw new Error("@ttsc/unplugin ESM default import must expose adapters");',
-      "}",
-      "",
-      'const api = await import("@ttsc/unplugin/api");',
-      'if (typeof api.resolveOptions !== "function") {',
-      '  throw new Error("@ttsc/unplugin/api resolveOptions must be exported");',
-      "}",
-      'if (typeof api.transformTtsc !== "function") {',
-      '  throw new Error("@ttsc/unplugin/api transformTtsc must be exported");',
-      "}",
-      "",
-      "for (const entrypoint of [",
-      '  "bun",',
-      '  "esbuild",',
-      '  "farm",',
-      '  "next",',
-      '  "rolldown",',
-      '  "rollup",',
-      '  "rspack",',
-      '  "vite",',
-      '  "webpack",',
-      "]) {",
-      "  const mod = await import(`@ttsc/unplugin/${entrypoint}`);",
-      '  if (typeof mod.default !== "function") {',
-      "    throw new Error(`${entrypoint} ESM default import must be a function`);",
-      "  }",
-      "}",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  run("node verify-unplugin.mjs", workspace);
-  fs.writeFileSync(
-    path.join(workspace, "verify-unplugin.cjs"),
-    [
-      'const root = require("@ttsc/unplugin");',
-      'if (typeof root.default.vite !== "function") {',
-      '  throw new Error("@ttsc/unplugin CJS require must expose adapters");',
-      "}",
-      "",
-      'const api = require("@ttsc/unplugin/api");',
-      'if (typeof api.resolveOptions !== "function") {',
-      '  throw new Error("@ttsc/unplugin/api resolveOptions must be exported through CJS");',
-      "}",
-      'if (typeof api.transformTtsc !== "function") {',
-      '  throw new Error("@ttsc/unplugin/api transformTtsc must be exported through CJS");',
-      "}",
-      "",
-      "for (const entrypoint of [",
-      '  "bun",',
-      '  "esbuild",',
-      '  "farm",',
-      '  "next",',
-      '  "rolldown",',
-      '  "rollup",',
-      '  "rspack",',
-      '  "vite",',
-      '  "webpack",',
-      "]) {",
-      "  const mod = require(`@ttsc/unplugin/${entrypoint}`);",
-      '  if (typeof mod.default !== "function") {',
-      "    throw new Error(`${entrypoint} CJS require must expose a default function`);",
-      "  }",
-      "}",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  run("node verify-unplugin.cjs", workspace);
-}
-
-function verifyUnpluginViteBuild() {
-  run("npx vite build --config vite.config.mjs", workspace);
-  const output = path.join(workspace, "dist-vite", "bundler.js");
-  assert(fs.existsSync(output), "Vite must emit dist-vite/bundler.js");
-  const emitted = fs.readFileSync(output, "utf8");
-  assert(
-    emitted.includes("INSTALLED-UNPLUGIN-OK"),
-    "@ttsc/unplugin/vite must preserve the intended bundled source",
-  );
-  assert(
-    !/goUpper|installed-unplugin-ok/.test(emitted),
-    "@ttsc/unplugin/vite must run the configured ttsc source transform before Vite emits",
-  );
 }
 
 function assertPackageFileMissing(packageName, relative) {
@@ -489,26 +228,6 @@ function assertPackageFileMissing(packageName, relative) {
     relative,
   );
   assert(!fs.existsSync(file), `${packageName} must not ship ${relative}`);
-}
-
-function assertPackageFileExists(packageName, relative) {
-  const file = path.join(
-    workspace,
-    "node_modules",
-    ...packageName.split("/"),
-    relative,
-  );
-  assert(fs.existsSync(file), `${packageName} must ship ${relative}`);
-}
-
-function readInstalledPackageJson(packageName) {
-  const file = path.join(
-    workspace,
-    "node_modules",
-    ...packageName.split("/"),
-    "package.json",
-  );
-  return JSON.parse(fs.readFileSync(file, "utf8"));
 }
 
 function verifyTtscBuild() {

--- a/experimental/test-unplugin/.gitignore
+++ b/experimental/test-unplugin/.gitignore
@@ -1,0 +1,2 @@
+.tmp/
+node_modules/

--- a/experimental/test-unplugin/README.md
+++ b/experimental/test-unplugin/README.md
@@ -1,0 +1,5 @@
+# @ttsc/unplugin experimental install test
+
+This experiment installs packed `ttsc`, the current platform package, and `@ttsc/unplugin` into a clean consumer project.
+
+It verifies the published package contract, ESM imports, CJS requires, and real builds for the supported Node-run bundlers. Bun is executed when the local `bun` runtime is available.

--- a/experimental/test-unplugin/package.json
+++ b/experimental/test-unplugin/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "name": "@ttsc/experimental-test-unplugin",
+  "version": "0.0.0",
+  "description": "Experimental install check for @ttsc/unplugin tgz builds",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samchon/ttsc"
+  },
+  "author": "Jeongho Nam",
+  "license": "MIT"
+}

--- a/experimental/test-unplugin/src/index.js
+++ b/experimental/test-unplugin/src/index.js
@@ -1,0 +1,958 @@
+const cp = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const experimentRoot = path.resolve(__dirname, "..");
+const root = path.resolve(experimentRoot, "../..");
+const tarballs = path.join(root, "experimental", "tarballs");
+const workspace = path.join(experimentRoot, ".tmp", "project");
+const skipPack = process.argv.includes("--skip-pack");
+const packCurrent = process.argv.includes("--pack-current");
+const platformKey = `${process.platform}-${process.arch}`;
+const platformTarball = `ttsc-${platformKey}`;
+const registryDependencies = [
+  "@farmfe/core",
+  "@rspack/cli",
+  "@rspack/core",
+  "@types/react",
+  "@types/react-dom",
+  "@typescript/native-preview",
+  "esbuild",
+  "next",
+  "rolldown",
+  "rollup",
+  "react",
+  "react-dom",
+  "vite",
+  "webpack",
+  "webpack-cli",
+];
+const adapterEntrypoints = [
+  "bun",
+  "esbuild",
+  "farm",
+  "next",
+  "rolldown",
+  "rollup",
+  "rspack",
+  "vite",
+  "webpack",
+];
+const exportEntrypoints = ["index", "api", ...adapterEntrypoints];
+
+main();
+
+function main() {
+  if (packCurrent) {
+    prepareCurrentTarballs();
+  } else if (!skipPack) {
+    run("pnpm package:tgz", root);
+  }
+  prepareWorkspace();
+  installTarballs();
+  verifyPackageContract();
+  verifyEntrypoints();
+  verifyViteBuild();
+  verifyRollupBuild();
+  verifyRolldownBuild();
+  verifyEsbuildBuild();
+  verifyWebpackBuild();
+  verifyRspackBuild();
+  verifyFarmBuild();
+  verifyNextBuild();
+  verifyBunBuild();
+  console.log("Success");
+}
+
+function prepareCurrentTarballs() {
+  run("pnpm run build:current", root);
+
+  fs.mkdirSync(tarballs, { recursive: true });
+  for (const name of ["ttsc", platformTarball, "unplugin"]) {
+    fs.rmSync(path.join(tarballs, `${name}.tgz`), { force: true });
+  }
+
+  packPackage("ttsc", "ttsc");
+  packPackage(platformTarball, platformTarball);
+  packPackage("unplugin", "unplugin");
+}
+
+function packPackage(packageDirName, tarballName) {
+  const packageDir = path.join(root, "packages", packageDirName);
+  assert(fs.existsSync(packageDir), `${packageDirName} package must exist`);
+
+  for (const entry of fs.readdirSync(packageDir)) {
+    if (entry.endsWith(".tgz")) {
+      fs.rmSync(path.join(packageDir, entry), { force: true });
+    }
+  }
+
+  run("pnpm pack", packageDir);
+  const packed = fs
+    .readdirSync(packageDir)
+    .find((entry) => entry.endsWith(".tgz"));
+  assert(packed, `${packageDirName} package tarball must be created`);
+  fs.copyFileSync(
+    path.join(packageDir, packed),
+    path.join(tarballs, `${tarballName}.tgz`),
+  );
+}
+
+function prepareWorkspace() {
+  fs.rmSync(path.join(experimentRoot, ".tmp"), {
+    recursive: true,
+    force: true,
+  });
+  fs.mkdirSync(path.join(workspace, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(workspace, "package.json"),
+    JSON.stringify(
+      {
+        private: true,
+        name: "@ttsc/experimental-test-unplugin-consumer",
+        version: "0.0.0",
+        type: "module",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(workspace, "tsconfig.unplugin.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "ESNext",
+          strict: true,
+          rootDir: ".",
+          jsx: "preserve",
+          plugins: [
+            {
+              transform: "./unplugin-transform.cjs",
+            },
+          ],
+        },
+        include: ["src", "pages"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(workspace, "tsconfig.json"),
+    JSON.stringify(
+      {
+        extends: "./tsconfig.unplugin.json",
+        compilerOptions: {
+          allowJs: true,
+          esModuleInterop: true,
+          incremental: true,
+          isolatedModules: true,
+          lib: ["dom", "dom.iterable", "es2022"],
+          moduleResolution: "Bundler",
+          noEmit: true,
+          resolveJsonModule: true,
+        },
+        include: ["next-env.d.ts", "pages", "src"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(workspace, "next-env.d.ts"),
+    [
+      '/// <reference types="next" />',
+      '/// <reference types="next/image-types/global" />',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(workspace, "src", "globals.d.ts"),
+    "declare function mark(input: string): string;\n",
+    "utf8",
+  );
+  writeSource("vite-entry.ts", "vite-installed-ok");
+  writeSource("rollup-entry.ts", "rollup-installed-ok");
+  writeSource("rolldown-entry.ts", "rolldown-installed-ok");
+  writeSource("esbuild-entry.ts", "esbuild-installed-ok");
+  writeSource("webpack-entry.ts", "webpack-installed-ok");
+  writeSource("rspack-entry.ts", "rspack-installed-ok");
+  writeSource("farm-entry.ts", "farm-installed-ok");
+  writeSource("next-entry.ts", "next-installed-ok");
+  writeSource("bun-entry.ts", "bun-installed-ok");
+  writeNextPage();
+  writeTransformPlugin();
+  writeViteConfig();
+  writeRollupConfig();
+  writeRolldownConfig();
+  writeEsbuildConfig();
+  writeWebpackConfig();
+  writeRspackConfig();
+  writeFarmConfig();
+  writeNextConfig();
+  writeBunConfig();
+}
+
+function writeSource(file, marker) {
+  fs.writeFileSync(
+    path.join(workspace, "src", file),
+    [`export const value = mark("${marker}");`, "console.log(value);", ""].join(
+      "\n",
+    ),
+    "utf8",
+  );
+}
+
+function writeNextPage() {
+  fs.mkdirSync(path.join(workspace, "pages"), { recursive: true });
+  fs.writeFileSync(
+    path.join(workspace, "pages", "index.js"),
+    [
+      'import { value } from "../src/next-entry";',
+      "",
+      "export default function Page() {",
+      "  return value;",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeTransformPlugin() {
+  fs.writeFileSync(
+    path.join(workspace, "unplugin-transform.cjs"),
+    [
+      'const path = require("node:path");',
+      "",
+      "module.exports = function createUnpluginTransform() {",
+      "  return {",
+      '    name: "experimental-unplugin-transform",',
+      '    source: path.resolve(__dirname, "unplugin-transform-go"),',
+      "  };",
+      "};",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  fs.mkdirSync(path.join(workspace, "unplugin-transform-go"), {
+    recursive: true,
+  });
+  fs.writeFileSync(
+    path.join(workspace, "unplugin-transform-go", "go.mod"),
+    "module example.com/ttscunplugintest\n\ngo 1.26\n",
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(workspace, "unplugin-transform-go", "main.go"),
+    [
+      "package main",
+      "",
+      "import (",
+      '  "encoding/json"',
+      '  "flag"',
+      '  "fmt"',
+      '  "io/fs"',
+      '  "os"',
+      '  "path/filepath"',
+      '  "regexp"',
+      '  "strings"',
+      ")",
+      "",
+      'var markerCall = regexp.MustCompile(`mark\\("([^"]*)"\\)`)',
+      "",
+      "type transformResult struct {",
+      '  TypeScript map[string]string `json:"typescript"`',
+      "}",
+      "",
+      "func main() { os.Exit(run(os.Args[1:])) }",
+      "",
+      "func run(args []string) int {",
+      "  if len(args) == 0 { return 2 }",
+      "  switch args[0] {",
+      '  case "transform":',
+      "    return transform(args[1:])",
+      '  case "check", "version", "build":',
+      "    return 0",
+      "  default:",
+      '    fmt.Fprintf(os.Stderr, "unknown command %q\\n", args[0])',
+      "    return 2",
+      "  }",
+      "}",
+      "",
+      "func transform(args []string) int {",
+      '  flags := flag.NewFlagSet("transform", flag.ContinueOnError)',
+      '  cwd := flags.String("cwd", "", "")',
+      '  _ = flags.String("tsconfig", "", "")',
+      '  _ = flags.String("plugins-json", "", "")',
+      "  if err := flags.Parse(args); err != nil { return 2 }",
+      "  root := *cwd",
+      '  if root == "" { root, _ = os.Getwd() }',
+      "  out := map[string]string{}",
+      '  err := filepath.WalkDir(filepath.Join(root, "src"), func(file string, entry fs.DirEntry, err error) error {',
+      "    if err != nil { return err }",
+      '    if entry.IsDir() || strings.HasSuffix(file, ".d.ts") || (!strings.HasSuffix(file, ".ts") && !strings.HasSuffix(file, ".tsx")) {',
+      "      return nil",
+      "    }",
+      "    source, err := os.ReadFile(file)",
+      "    if err != nil { return err }",
+      "    code := markerCall.ReplaceAllStringFunc(string(source), func(call string) string {",
+      "      match := markerCall.FindStringSubmatch(call)",
+      "      if len(match) != 2 { return call }",
+      '      return fmt.Sprintf("%q", strings.ToUpper(match[1]))',
+      "    })",
+      "    relative, err := filepath.Rel(root, file)",
+      "    if err != nil { return err }",
+      "    out[filepath.ToSlash(relative)] = code",
+      "    return nil",
+      "  })",
+      "  if err != nil { fmt.Fprintln(os.Stderr, err); return 2 }",
+      '  if len(out) == 0 { fmt.Fprintln(os.Stderr, "no TypeScript sources found"); return 2 }',
+      "  data, err := json.Marshal(transformResult{TypeScript: out})",
+      "  if err != nil { fmt.Fprintln(os.Stderr, err); return 2 }",
+      "  fmt.Fprintln(os.Stdout, string(data))",
+      "  return 0",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeNextConfig() {
+  fs.writeFileSync(
+    path.join(workspace, "next.config.mjs"),
+    [
+      'import withTtsc from "@ttsc/unplugin/next";',
+      "",
+      "export default withTtsc(",
+      "  {",
+      '    distDir: "dist-next",',
+      "    typescript: {",
+      "      ignoreBuildErrors: true,",
+      "    },",
+      "  },",
+      "  {",
+      '    project: "tsconfig.unplugin.json",',
+      "  },",
+      ");",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeViteConfig() {
+  fs.writeFileSync(
+    path.join(workspace, "vite.config.mjs"),
+    [
+      'import path from "node:path";',
+      'import ttsc from "@ttsc/unplugin/vite";',
+      'import { defineConfig } from "vite";',
+      "",
+      "export default defineConfig({",
+      "  build: {",
+      "    emptyOutDir: true,",
+      "    minify: false,",
+      '    outDir: "dist-vite",',
+      "    rollupOptions: {",
+      '      input: path.resolve("src/vite-entry.ts"),',
+      "      output: {",
+      '        entryFileNames: "vite-entry.js",',
+      '        format: "es",',
+      "      },",
+      "    },",
+      "  },",
+      '  logLevel: "silent",',
+      '  plugins: [ttsc({ project: "tsconfig.unplugin.json" })],',
+      "});",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeRollupConfig() {
+  fs.writeFileSync(
+    path.join(workspace, "rollup.config.mjs"),
+    [
+      'import ttsc from "@ttsc/unplugin/rollup";',
+      "",
+      "export default {",
+      '  input: "src/rollup-entry.ts",',
+      "  output: {",
+      '    file: "dist-rollup/rollup-entry.js",',
+      '    format: "es",',
+      "  },",
+      '  plugins: [ttsc({ project: "tsconfig.unplugin.json" })],',
+      "};",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeRolldownConfig() {
+  fs.writeFileSync(
+    path.join(workspace, "rolldown.config.mjs"),
+    [
+      'import ttsc from "@ttsc/unplugin/rolldown";',
+      "",
+      "export default {",
+      '  input: "src/rolldown-entry.ts",',
+      "  output: {",
+      '    file: "dist-rolldown/rolldown-entry.js",',
+      '    format: "es",',
+      "  },",
+      '  plugins: [ttsc({ project: "tsconfig.unplugin.json" })],',
+      "};",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeEsbuildConfig() {
+  fs.writeFileSync(
+    path.join(workspace, "esbuild.config.cjs"),
+    [
+      'const esbuild = require("esbuild");',
+      'const ttsc = require("@ttsc/unplugin/esbuild").default;',
+      "",
+      "esbuild",
+      "  .build({",
+      '  entryPoints: ["src/esbuild-entry.ts"],',
+      "  bundle: true,",
+      '  format: "esm",',
+      '  outfile: "dist-esbuild/esbuild-entry.js",',
+      '  plugins: [ttsc({ project: "tsconfig.unplugin.json" })],',
+      "  })",
+      "  .catch((error) => {",
+      "    console.error(error);",
+      "    process.exit(1);",
+      "  });",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeWebpackConfig() {
+  fs.writeFileSync(
+    path.join(workspace, "webpack.config.cjs"),
+    [
+      'const path = require("node:path");',
+      'const ttsc = require("@ttsc/unplugin/webpack").default;',
+      "",
+      "module.exports = {",
+      '  mode: "production",',
+      '  target: "node",',
+      '  entry: path.resolve(__dirname, "src/webpack-entry.ts"),',
+      "  output: {",
+      '    path: path.resolve(__dirname, "dist-webpack"),',
+      '    filename: "webpack-entry.js",',
+      "  },",
+      "  resolve: {",
+      '    extensions: [".ts", ".js"],',
+      "  },",
+      "  module: {",
+      "    rules: [",
+      "      {",
+      "        test: /\\.ts$/,",
+      '        type: "javascript/auto",',
+      "      },",
+      "    ],",
+      "  },",
+      "  optimization: {",
+      "    minimize: false,",
+      "  },",
+      '  plugins: [ttsc({ project: "tsconfig.unplugin.json" })],',
+      "};",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeRspackConfig() {
+  fs.writeFileSync(
+    path.join(workspace, "rspack.config.cjs"),
+    [
+      'const path = require("node:path");',
+      'const ttsc = require("@ttsc/unplugin/rspack").default;',
+      "",
+      "module.exports = {",
+      '  mode: "production",',
+      '  target: "node",',
+      '  entry: path.resolve(__dirname, "src/rspack-entry.ts"),',
+      "  output: {",
+      '    path: path.resolve(__dirname, "dist-rspack"),',
+      '    filename: "rspack-entry.js",',
+      "  },",
+      "  resolve: {",
+      '    extensions: [".ts", ".js"],',
+      "  },",
+      "  module: {",
+      "    rules: [",
+      "      {",
+      "        test: /\\.ts$/,",
+      '        type: "javascript/auto",',
+      "      },",
+      "    ],",
+      "  },",
+      "  optimization: {",
+      "    minimize: false,",
+      "  },",
+      '  plugins: [ttsc({ project: "tsconfig.unplugin.json" })],',
+      "};",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeFarmConfig() {
+  fs.writeFileSync(
+    path.join(workspace, "farm-build.mjs"),
+    [
+      'import { build, defineConfig } from "@farmfe/core";',
+      'import ttsc from "@ttsc/unplugin/farm";',
+      "",
+      "await build(",
+      "  defineConfig({",
+      "    compilation: {",
+      "      input: {",
+      '        farm: "./src/farm-entry.ts",',
+      "      },",
+      "      output: {",
+      '        path: "./dist-farm",',
+      '        entryFilename: "farm-entry.js",',
+      '        filename: "[resourceName].js",',
+      '        format: "esm",',
+      '        targetEnv: "node",',
+      "      },",
+      "      minify: false,",
+      "      persistentCache: false,",
+      "    },",
+      '    plugins: [ttsc({ project: "tsconfig.unplugin.json" })],',
+      "  }),",
+      ");",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeBunConfig() {
+  fs.writeFileSync(
+    path.join(workspace, "bun-build.mjs"),
+    [
+      'import ttsc from "@ttsc/unplugin/bun";',
+      "",
+      "const result = await Bun.build({",
+      '  entrypoints: ["src/bun-entry.ts"],',
+      '  outdir: "dist-bun",',
+      '  format: "esm",',
+      "  minify: false,",
+      '  plugins: [ttsc({ project: "tsconfig.unplugin.json" })],',
+      "});",
+      "",
+      "if (!result.success) {",
+      "  for (const log of result.logs) console.error(log);",
+      '  throw new Error("Bun build failed");',
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function installTarballs() {
+  const command = [
+    "npm install",
+    "--ignore-scripts",
+    "--no-audit",
+    "--no-fund",
+    ...registryDependencies,
+    tarball("ttsc"),
+    tarball(platformTarball),
+    tarball("unplugin"),
+  ].join(" ");
+  run(command, workspace);
+}
+
+function verifyPackageContract() {
+  const manifest = readInstalledPackageJson("@ttsc/unplugin");
+  assert(
+    manifest.type === undefined,
+    "@ttsc/unplugin must not set package.json type=module",
+  );
+  assert(
+    manifest.peerDependencies === undefined,
+    "@ttsc/unplugin must not publish peerDependencies",
+  );
+  assertPackageFileMissing("@ttsc/unplugin", "tsconfig.json");
+  assertPackageFileMissing("@ttsc/unplugin", "lib/_virtual");
+
+  for (const entrypoint of exportEntrypoints) {
+    const subpath = entrypoint === "index" ? "." : `./${entrypoint}`;
+    const file = entrypoint === "index" ? "index" : entrypoint;
+    const exported = manifest.exports?.[subpath];
+    assert(exported, `@ttsc/unplugin must export ${subpath}`);
+    assert(
+      exported.types === `./lib/${file}.d.ts`,
+      `${subpath} must publish its declaration file`,
+    );
+    assert(
+      exported.import === `./lib/${file}.mjs`,
+      `${subpath} must publish ESM through import`,
+    );
+    assert(
+      exported.default === `./lib/${file}.js`,
+      `${subpath} must publish CJS through default`,
+    );
+    assertPackageFileExists("@ttsc/unplugin", `lib/${file}.d.ts`);
+    assertPackageFileExists("@ttsc/unplugin", `lib/${file}.js`);
+    assertPackageFileExists("@ttsc/unplugin", `lib/${file}.mjs`);
+    assertPackageFileMissing("@ttsc/unplugin", `lib/${file}.cjs`);
+  }
+
+  const transformCjs = readInstalledPackageFile(
+    "@ttsc/unplugin",
+    "lib/core/transform.js",
+  );
+  const transformEsm = readInstalledPackageFile(
+    "@ttsc/unplugin",
+    "lib/core/transform.mjs",
+  );
+  const coreCjs = readInstalledPackageFile(
+    "@ttsc/unplugin",
+    "lib/core/index.js",
+  );
+  const coreEsm = readInstalledPackageFile(
+    "@ttsc/unplugin",
+    "lib/core/index.mjs",
+  );
+  for (const [name, source] of [
+    ["core/index.js", coreCjs],
+    ["core/index.mjs", coreEsm],
+    ["core/transform.js", transformCjs],
+    ["core/transform.mjs", transformEsm],
+  ]) {
+    assert(
+      !source.includes("__dirname"),
+      `${name} must not depend on __dirname`,
+    );
+    assert(
+      !source.includes("_virtual"),
+      `${name} must not bundle virtual files`,
+    );
+    assert(
+      !source.includes("packages/ttsc"),
+      `${name} must not embed ttsc workspace internals`,
+    );
+  }
+  assert(
+    /require\(["']ttsc["']\)/.test(transformCjs),
+    "CJS transform output must keep ttsc external",
+  );
+  assert(
+    /from ["']ttsc["']/.test(transformEsm),
+    "ESM transform output must keep ttsc external",
+  );
+  assert(
+    /require\(["']unplugin["']\)/.test(coreCjs),
+    "CJS core output must keep unplugin external",
+  );
+  assert(
+    /from ["']unplugin["']/.test(coreEsm),
+    "ESM core output must keep unplugin external",
+  );
+}
+
+function verifyEntrypoints() {
+  fs.writeFileSync(
+    path.join(workspace, "verify-entrypoints.mjs"),
+    [
+      'const root = await import("@ttsc/unplugin");',
+      'if (typeof root.default.vite !== "function") {',
+      '  throw new Error("@ttsc/unplugin ESM default import must expose adapters");',
+      "}",
+      'const api = await import("@ttsc/unplugin/api");',
+      'if (typeof api.transformTtsc !== "function") {',
+      '  throw new Error("@ttsc/unplugin/api must expose transformTtsc");',
+      "}",
+      "for (const entrypoint of " + JSON.stringify(adapterEntrypoints) + ") {",
+      "  const mod = await import(`@ttsc/unplugin/${entrypoint}`);",
+      '  if (typeof mod.default !== "function") {',
+      "    throw new Error(`${entrypoint} ESM default import must be a function`);",
+      "  }",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  run("node verify-entrypoints.mjs", workspace);
+
+  fs.writeFileSync(
+    path.join(workspace, "verify-entrypoints.cjs"),
+    [
+      'const root = require("@ttsc/unplugin");',
+      'if (typeof root.default.vite !== "function") {',
+      '  throw new Error("@ttsc/unplugin CJS require must expose adapters");',
+      "}",
+      'const api = require("@ttsc/unplugin/api");',
+      'if (typeof api.transformTtsc !== "function") {',
+      '  throw new Error("@ttsc/unplugin/api must expose transformTtsc through CJS");',
+      "}",
+      "for (const entrypoint of " + JSON.stringify(adapterEntrypoints) + ") {",
+      "  const mod = require(`@ttsc/unplugin/${entrypoint}`);",
+      '  if (typeof mod.default !== "function") {',
+      "    throw new Error(`${entrypoint} CJS require must expose a default function`);",
+      "  }",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  run("node verify-entrypoints.cjs", workspace);
+}
+
+function verifyViteBuild() {
+  run("npx vite build --config vite.config.mjs", workspace);
+  assertBuiltOutput("dist-vite/vite-entry.js", "VITE-INSTALLED-OK", "vite");
+}
+
+function verifyRollupBuild() {
+  run("npx rollup -c rollup.config.mjs", workspace);
+  assertBuiltOutput(
+    "dist-rollup/rollup-entry.js",
+    "ROLLUP-INSTALLED-OK",
+    "rollup",
+  );
+}
+
+function verifyEsbuildBuild() {
+  run("node esbuild.config.cjs", workspace);
+  assertBuiltOutput(
+    "dist-esbuild/esbuild-entry.js",
+    "ESBUILD-INSTALLED-OK",
+    "esbuild",
+  );
+}
+
+function verifyRolldownBuild() {
+  run("npx rolldown -c rolldown.config.mjs", workspace);
+  assertBuiltOutput(
+    "dist-rolldown/rolldown-entry.js",
+    "ROLLDOWN-INSTALLED-OK",
+    "rolldown",
+  );
+}
+
+function verifyWebpackBuild() {
+  run("npx webpack --config webpack.config.cjs", workspace);
+  assertBuiltOutput(
+    "dist-webpack/webpack-entry.js",
+    "WEBPACK-INSTALLED-OK",
+    "webpack",
+  );
+}
+
+function verifyRspackBuild() {
+  run("npx rspack build --config rspack.config.cjs", workspace);
+  assertBuiltOutput(
+    "dist-rspack/rspack-entry.js",
+    "RSPACK-INSTALLED-OK",
+    "rspack",
+  );
+}
+
+function verifyFarmBuild() {
+  run("node farm-build.mjs", workspace);
+  const output = findSingleBuiltFile("dist-farm", "farm-entry");
+  assertBuiltOutput(output, "FARM-INSTALLED-OK", "farm");
+}
+
+function verifyNextBuild() {
+  run("npx next build --webpack", workspace);
+  assertBuiltTreeContains(
+    "dist-next",
+    "NEXT-INSTALLED-OK",
+    "next",
+    "next-installed-ok",
+  );
+}
+
+function verifyBunBuild() {
+  if (!commandExists("bun")) {
+    console.log("$ bun build skipped: bun executable is not available");
+    return;
+  }
+  run("bun bun-build.mjs", workspace);
+  const output = findSingleBuiltFile("dist-bun", "bun-entry");
+  assertBuiltOutput(output, "BUN-INSTALLED-OK", "bun");
+}
+
+function assertBuiltTreeContains(directory, expected, label, original) {
+  const rootDir = path.join(workspace, directory);
+  assert(fs.existsSync(rootDir), `${label} must emit ${directory}`);
+  let foundExpected = false;
+  let foundOriginal = false;
+  walk(rootDir, (file) => {
+    if (!/\.(?:html|js|json)$/.test(file)) {
+      return;
+    }
+    const emitted = fs.readFileSync(file, "utf8");
+    foundExpected = foundExpected || emitted.includes(expected);
+    foundOriginal = foundOriginal || emitted.includes(original);
+  });
+  assert(
+    foundExpected,
+    `${label} must emit the transformed marker ${expected}`,
+  );
+  assert(
+    !foundOriginal,
+    `${label} must not leave the original marker call in emitted assets`,
+  );
+}
+
+function assertBuiltOutput(relative, expected, label) {
+  const output = path.join(workspace, relative);
+  assert(fs.existsSync(output), `${label} must emit ${relative}`);
+  const emitted = fs.readFileSync(output, "utf8");
+  assert(
+    emitted.includes(expected),
+    `${label} must emit the transformed marker ${expected}`,
+  );
+  assert(
+    !/mark\(|installed-ok/.test(emitted),
+    `${label} must not leave the original marker call in emitted JavaScript`,
+  );
+  assertConsoleOutput(
+    `node ${relative}`,
+    runNode([output], workspace, `node ${relative}`).stdout,
+    expected,
+  );
+}
+
+function findSingleBuiltFile(directory, prefix) {
+  const rootDir = path.join(workspace, directory);
+  assert(fs.existsSync(rootDir), `${directory} must exist`);
+  const files = [];
+  walk(rootDir, (file) => {
+    if (file.endsWith(".js") && path.basename(file).startsWith(prefix)) {
+      files.push(path.relative(workspace, file));
+    }
+  });
+  assert(
+    files.length === 1,
+    `${directory} must contain one JavaScript output starting with ${prefix}, got ${files.join(", ")}`,
+  );
+  return files[0];
+}
+
+function walk(dir, visit) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const file = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(file, visit);
+    else visit(file);
+  }
+}
+
+function commandExists(command) {
+  const result = cp.spawnSync(command, ["--version"], {
+    cwd: workspace,
+    encoding: "utf8",
+    stdio: ["ignore", "ignore", "ignore"],
+    windowsHide: true,
+  });
+  return result.status === 0;
+}
+
+function assertPackageFileMissing(packageName, relative) {
+  const file = installedPackagePath(packageName, relative);
+  assert(!fs.existsSync(file), `${packageName} must not ship ${relative}`);
+}
+
+function assertPackageFileExists(packageName, relative) {
+  const file = installedPackagePath(packageName, relative);
+  assert(fs.existsSync(file), `${packageName} must ship ${relative}`);
+}
+
+function readInstalledPackageJson(packageName) {
+  return JSON.parse(
+    fs.readFileSync(installedPackagePath(packageName, "package.json"), "utf8"),
+  );
+}
+
+function readInstalledPackageFile(packageName, relative) {
+  return fs.readFileSync(installedPackagePath(packageName, relative), "utf8");
+}
+
+function installedPackagePath(packageName, relative) {
+  return path.join(
+    workspace,
+    "node_modules",
+    ...packageName.split("/"),
+    relative,
+  );
+}
+
+function assertConsoleOutput(command, stdout, expected) {
+  const actual = stdout.trim();
+  assert(
+    actual === expected,
+    `${command} must print ${JSON.stringify(expected)} to stdout, got ${JSON.stringify(actual)}`,
+  );
+}
+
+function tarball(name) {
+  const file = path.join(tarballs, `${name}.tgz`);
+  assert(fs.existsSync(file), `${name}.tgz must exist`);
+  return file;
+}
+
+function run(command, cwd) {
+  console.log(`$ ${command}`);
+  const result = cp.execSync(command, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      npm_config_cache: path.join(os.tmpdir(), "ttsc-npm-cache"),
+    },
+    maxBuffer: 1024 * 1024 * 64,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result) process.stdout.write(result);
+  return { stdout: result };
+}
+
+function runNode(args, cwd, label) {
+  console.log(`$ ${label ?? [process.execPath, ...args].join(" ")}`);
+  const result = cp.spawnSync(process.execPath, args, {
+    cwd,
+    encoding: "utf8",
+    env: process.env,
+    maxBuffer: 1024 * 1024 * 64,
+    windowsHide: true,
+  });
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  assert(result.status === 0, `node ${args.join(" ")} failed`);
+  return result;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "node scripts/build-platforms.cjs",
     "build:current": "node scripts/build-current.cjs",
-    "experimental": "pnpm --dir experimental/install start -- --pack-current",
+    "experimental": "pnpm --dir experimental/install start -- --pack-current && pnpm --dir experimental/test-unplugin start -- --skip-pack",
+    "experimental:install": "pnpm --dir experimental/install start -- --pack-current",
+    "experimental:unplugin": "pnpm --dir experimental/test-unplugin start -- --pack-current",
     "format": "prettier --write \"**/*.ts\" && pnpm run format:go",
     "format:go": "git ls-files -z \"*.go\" | xargs -0 ./.vscode/gofmt-2spaces.sh -w",
     "package:latest": "pnpm build && pnpm --filter=./packages/* --filter=!ttsc -r publish --tag latest --access public --no-git-checks --provenance && pnpm --filter ttsc publish --tag latest --access public --no-git-checks --provenance",

--- a/packages/unplugin/src/bun.ts
+++ b/packages/unplugin/src/bun.ts
@@ -16,7 +16,7 @@ export interface BunLikeBuild {
   ): void;
 }
 
-const sourceFilePattern = /\.[cm]?[jt]sx?$/;
+const sourceFilePattern = /\.[cm]?tsx?$/;
 
 export default function bun(options?: TtscUnpluginOptions): BunLikePlugin {
   return {

--- a/packages/unplugin/src/core/index.ts
+++ b/packages/unplugin/src/core/index.ts
@@ -6,7 +6,7 @@ import { resolveOptions } from "./options";
 import { isDeclarationFile, stripQuery, transformTtsc } from "./transform";
 
 const name = "ttsc-unplugin";
-const sourceFilePattern = /\.[cm]?[jt]sx?$/;
+const sourceFilePattern = /\.[cm]?tsx?$/;
 const nodeModulesPattern = /(?:^|[/\\])node_modules(?:[/\\]|$)/;
 const virtualModulePattern = /\0/;
 

--- a/tests/unplugin/adapter-entrypoints.test.cjs
+++ b/tests/unplugin/adapter-entrypoints.test.cjs
@@ -123,6 +123,8 @@ async function assertSharedAdapterFilter() {
   const raw = unplugin.raw(undefined, {});
   assert.equal(raw.transformInclude?.("main.ts"), true);
   assert.equal(raw.transformInclude?.("main.tsx"), true);
+  assert.equal(raw.transformInclude?.("main.js"), false);
+  assert.equal(raw.transformInclude?.("main.jsx"), false);
   assert.equal(raw.transformInclude?.("main.css"), false);
   assert.equal(raw.transformInclude?.("node_modules/pkg/main.ts"), false);
   assert.equal(raw.transformInclude?.("main.d.ts"), false);


### PR DESCRIPTION
This pull request makes significant changes to the experimental install and testing setup for `@ttsc/unplugin`, focusing on splitting the unplugin install tests into a dedicated experimental package, simplifying test logic, and improving maintainability. The main `experimental/install` script no longer verifies unplugin entrypoints or real builds; instead, these checks are now handled by the new `experimental/test-unplugin` package. Additional cleanups and minor fixes are included.

**Experimental test refactor and separation:**

* Created a new experimental package `experimental/test-unplugin` with its own `package.json`, `.gitignore`, and `README.md` to handle install and runtime tests for `@ttsc/unplugin` separately from the main install script. [[1]](diffhunk://#diff-91698f0fd89578b466fa22b3aa9934a31a3483a563160906cbdc3fc733054c36R1-R15) [[2]](diffhunk://#diff-e0ade45f79f8cf1a9b9c1ef44afbc3e8b9367a242ddee54e355efb584d8a3b7eR1-R2) [[3]](diffhunk://#diff-3f89430f8d186d5bebf4b726363008977459081e1b3ad4f5a409330cf9a25901R1-R5)
* Updated the main workflow (`.github/workflows/bun.yml`) and `package.json` scripts to run both install and unplugin tests, and added a dedicated `experimental:unplugin` script. [[1]](diffhunk://#diff-88dc73ea041a254f6d251b3eb8872104b6926163e8a022e18a9b7d6939a99e73R1-R44) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L9-R11)

**Simplification and cleanup of install script:**

* Removed all code and logic in `experimental/install/src/index.js` related to unplugin entrypoint and Vite build verification, as well as the associated test fixture generation. The install script now only verifies the core install contract and not unplugin specifics. [[1]](diffhunk://#diff-d9147bd907b5f4cda2d0ce086f392354d384a44d94d3c6bb814e140e0d0f92e7L15-R17) [[2]](diffhunk://#diff-d9147bd907b5f4cda2d0ce086f392354d384a44d94d3c6bb814e140e0d0f92e7L29-L30) [[3]](diffhunk://#diff-d9147bd907b5f4cda2d0ce086f392354d384a44d94d3c6bb814e140e0d0f92e7L40-R45) [[4]](diffhunk://#diff-d9147bd907b5f4cda2d0ce086f392354d384a44d94d3c6bb814e140e0d0f92e7L151-L299) [[5]](diffhunk://#diff-d9147bd907b5f4cda2d0ce086f392354d384a44d94d3c6bb814e140e0d0f92e7L371-L481) [[6]](diffhunk://#diff-d9147bd907b5f4cda2d0ce086f392354d384a44d94d3c6bb814e140e0d0f92e7L494-L513)
* Updated the install test to only check that `@ttsc/lint` does not publish its `tsconfig.json` file, removing checks for unplugin files.

**Bugfixes and test improvements:**

* Fixed the source file pattern in `packages/unplugin/src/bun.ts` and `packages/unplugin/src/core/index.ts` to exclude `.js`/`.jsx` files from plugin transforms, and updated tests to reflect this behavior. [[1]](diffhunk://#diff-2ddc2cc255b5a9551b6701898484abb1966a5683a6f14944f43050f0afbb783dL19-R19) [[2]](diffhunk://#diff-b25b3f85dfa58bdd8d65f7641c44f7ab50386fa75595292f1df85d50d2b6cf3bL9-R9) [[3]](diffhunk://#diff-dc91f73234636e1208eaff7fe29b3eefa0c487631c4caf3d1354902c2e84dc57R126-R127)

These changes improve test reliability, maintainability, and clarify the responsibilities of each experimental test package.