### PR TITLE
fix(test): avoid rspack bug on `win32-arm64`.

### DIFF
--- a/experimental/test-unplugin/src/index.js
+++ b/experimental/test-unplugin/src/index.js
@@ -13,8 +13,9 @@ const platformKey = `${process.platform}-${process.arch}`;
 const platformTarball = `ttsc-${platformKey}`;
 const registryDependencies = [
   "@farmfe/core",
-  "@rspack/cli",
-  "@rspack/core",
+  // Rspack 2.0.1+ crashes on Windows ARM64 during native binding teardown.
+  "@rspack/cli@2.0.0",
+  "@rspack/core@2.0.0",
   "@types/react",
   "@types/react-dom",
   "@typescript/native-preview",


### PR DESCRIPTION
This pull request updates the dependencies in the `experimental/test-unplugin/src/index.js` file to address a compatibility issue with Rspack on Windows ARM64. Specifically, it pins the `@rspack/cli` and `@rspack/core` packages to version 2.0.0 to avoid crashes with newer versions.

Dependency management:

* Pinned `@rspack/cli` and `@rspack/core` to version 2.0.0 to prevent crashes on Windows ARM64 with Rspack 2.0.1 and above.