### PR TITLE
feat(test): shrink consumption time.

### DIFF
--- a/packages/ttsc/src/compiler/internal/compileProjectInMemory.ts
+++ b/packages/ttsc/src/compiler/internal/compileProjectInMemory.ts
@@ -29,7 +29,7 @@ export function compileProjectInMemory(options: ITtscCompilerContext): {
   const tsconfig = project.path;
   const binary = buildNativeCompiler({
     cacheBaseDir: project.root,
-    cacheDir: options.cacheDir,
+    cacheDir: options.cacheDir ?? options.env?.TTSC_CACHE_DIR,
     packageRoot: packageRootDir(),
   });
   const res = spawnSync(

--- a/packages/ttsc/src/compiler/internal/transformProjectInMemory.ts
+++ b/packages/ttsc/src/compiler/internal/transformProjectInMemory.ts
@@ -50,7 +50,7 @@ function transformProjectWithNativeHost(
 } {
   const binary = buildNativeCompiler({
     cacheBaseDir: project.root,
-    cacheDir: options.cacheDir,
+    cacheDir: options.cacheDir ?? options.env?.TTSC_CACHE_DIR,
     packageRoot: packageRootDir(),
   });
   const res = spawnNative(

--- a/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
+++ b/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
@@ -64,11 +64,14 @@ export function loadProjectPlugins(options: {
     projectRoot: project.root,
     tsconfig: project.path,
   };
-  const plugins = entries.map((entry) =>
+  const plugins = composePluginSources(
+    entries,
+    entries.map((entry) =>
     loadPluginEntry(
       entry.config,
       { ...context, plugin: entry.config },
       entry.baseDir,
+    ),
     ),
   );
 
@@ -98,6 +101,36 @@ export function loadProjectPlugins(options: {
     nativePlugins: orderNativePlugins(nativePlugins),
     project,
   };
+}
+
+function composePluginSources(
+  entries: readonly ProjectPluginEntry[],
+  plugins: readonly ITtscPlugin[],
+): ITtscPlugin[] {
+  const aggregates = plugins
+    .map((plugin, index) => ({ index, plugin }))
+    .filter(({ plugin }) => Array.isArray(plugin.composes));
+  if (aggregates.length === 0) {
+    return [...plugins];
+  }
+  return plugins.map((plugin, index) => {
+    const transform = entries[index]?.config.transform;
+    const aggregate = aggregates.find(
+      ({ index: aggregateIndex, plugin: aggregatePlugin }) =>
+        aggregateIndex !== index &&
+        aggregatePlugin.composes!.some(
+          (alias) =>
+            alias === plugin.name ||
+            (typeof transform === "string" && alias === transform),
+        ),
+    );
+    return aggregate === undefined
+      ? plugin
+      : {
+          ...plugin,
+          source: aggregate.plugin.source,
+        };
+  });
 }
 
 export function hasProjectPluginEntries(

--- a/packages/ttsc/src/structures/ITtscPlugin.ts
+++ b/packages/ttsc/src/structures/ITtscPlugin.ts
@@ -46,6 +46,17 @@ export interface ITtscPlugin {
   source: string;
 
   /**
+   * Other transform plugin names or transform specifiers that this native
+   * sidecar can execute in the same compiler pass.
+   *
+   * Package auto-discovery may find multiple transform packages that must share
+   * one emit host. When one descriptor lists another entry here, ttsc keeps the
+   * original plugin config in `--plugins-json` but points the composed entry at
+   * this descriptor's native source so both entries resolve to one binary.
+   */
+  composes?: string[];
+
+  /**
    * Pipeline stage implemented by the sidecar.
    *
    * Omit this field for normal compiler-transform plugins. The only explicit

--- a/packages/unplugin/src/core/transform.ts
+++ b/packages/unplugin/src/core/transform.ts
@@ -51,6 +51,9 @@ export async function transformTtsc(
   if (isDeclarationFile(file)) {
     return undefined;
   }
+  if (pluginsAreDisabled(options.plugins)) {
+    return undefined;
+  }
 
   const tsconfig = resolveTsconfig(file, options.project);
   const tsconfigDir = path.dirname(tsconfig);
@@ -104,6 +107,12 @@ export function stripQuery(id: string): string {
 
 export function isDeclarationFile(id: string): boolean {
   return id.endsWith(".d.ts") || id.endsWith(".d.mts") || id.endsWith(".d.cts");
+}
+
+function pluginsAreDisabled(
+  plugins: ResolvedTtscUnpluginOptions["plugins"],
+): boolean {
+  return plugins === false || (Array.isArray(plugins) && plugins.length === 0);
 }
 
 export function createTransformResult(

--- a/tests/test-ttsc/src/internal/compiler.ts
+++ b/tests/test-ttsc/src/internal/compiler.ts
@@ -3,9 +3,37 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { TtscCompiler } from "../../../../packages/ttsc/lib/index.js";
+import {
+  TtscCompiler as BaseTtscCompiler,
+  type ITtscCompilerContext,
+} from "../../../../packages/ttsc/lib/index.js";
 import { resolveTsgo } from "../../../../packages/ttsc/lib/compiler/internal/resolveTsgo.js";
 import { TestProject } from "@ttsc/testing";
+
+const SHARED_COMPILER_CACHE_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "ttsc-compiler-api-cache-"),
+);
+process.on("exit", () => {
+  try {
+    fs.rmSync(SHARED_COMPILER_CACHE_DIR, { recursive: true, force: true });
+  } catch {}
+});
+
+class TtscCompiler extends BaseTtscCompiler {
+  public constructor(context: ITtscCompilerContext = {}) {
+    super(
+      context.cacheDir
+        ? context
+        : {
+            ...context,
+            env: {
+              TTSC_CACHE_DIR: SHARED_COMPILER_CACHE_DIR,
+              ...context.env,
+            },
+          },
+    );
+  }
+}
 
 const ttscPackageRoot = path.join(
   TestProject.WORKSPACE_ROOT,

--- a/tests/utils/src/unplugin/TestUnpluginProject.ts
+++ b/tests/utils/src/unplugin/TestUnpluginProject.ts
@@ -33,6 +33,7 @@ export namespace TestUnpluginProject {
   // transformTtsc() runs in-process, so seed the same tsgo override that the
   // spawn-based helpers pass explicitly through child-process environments.
   process.env.TTSC_TSGO_BINARY ??= resolveTsgoBinary();
+  let sharedCacheDir: string | undefined;
 
   /**
    * Create a temporary project that transforms `goUpper("...")` through a Go
@@ -40,6 +41,7 @@ export namespace TestUnpluginProject {
    * probe adapter-specific behavior without duplicating fixture setup.
    */
   export function createProject(options: ICreateProjectOptions = {}) {
+    ensureSharedCacheDir();
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-unplugin-"));
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     fs.writeFileSync(
@@ -78,6 +80,21 @@ export namespace TestUnpluginProject {
     writePluginEntry(root);
     writeGoPlugin(root);
     return root;
+  }
+
+  function ensureSharedCacheDir(): void {
+    if (process.env.TTSC_CACHE_DIR !== undefined) {
+      return;
+    }
+    sharedCacheDir ??= fs.mkdtempSync(
+      path.join(os.tmpdir(), "ttsc-unplugin-cache-"),
+    );
+    process.env.TTSC_CACHE_DIR = sharedCacheDir;
+    process.once("exit", () => {
+      try {
+        fs.rmSync(sharedCacheDir!, { recursive: true, force: true });
+      } catch {}
+    });
   }
 
   /** Absolute path to the generated TypeScript entrypoint. */


### PR DESCRIPTION
This pull request introduces improvements to plugin composition, cache directory handling, and testing infrastructure for the `ttsc` compiler and related utilities. The main changes ensure robust plugin aggregation, more flexible cache directory resolution, and better test isolation through shared cache directories.

**Plugin composition and aggregation:**

* Added a `composes` property to the `ITtscPlugin` interface, allowing native plugins to declare other transform plugins they can aggregate in a single compiler pass. This enables multiple transform packages to share one emit host and ensures correct plugin resolution.
* Introduced the `composePluginSources` function in `loadProjectPlugins.ts` to aggregate plugin sources based on the new `composes` property, ensuring that composed plugins point to the correct native source. [[1]](diffhunk://#diff-e2a951374affef7cbc05ec92a2207bfb51c31017743d68dcde7d384fcc406f40L67-R75) [[2]](diffhunk://#diff-e2a951374affef7cbc05ec92a2207bfb51c31017743d68dcde7d384fcc406f40R106-R135)

**Cache directory handling:**

* Updated `compileProjectInMemory.ts` and `transformProjectInMemory.ts` to resolve the cache directory from either `options.cacheDir` or the `TTSC_CACHE_DIR` environment variable, improving flexibility for cache location configuration. [[1]](diffhunk://#diff-3084a94c85fc33c4db5b8daf624027b390c4e4855c3e47e94f8e576ad610f11dL32-R32) [[2]](diffhunk://#diff-2b3284a31823933c1903e2ee69b4e65dd12ea8a6c0d1833baeee38f149764b78L53-R53)

**Testing infrastructure improvements:**

* Modified test utilities (`compiler.ts`, `TestUnpluginProject.ts`) to create and clean up shared cache directories for test runs, ensuring isolation and preventing cache conflicts between tests. This includes setting the `TTSC_CACHE_DIR` environment variable for test processes. [[1]](diffhunk://#diff-91f5ccfa065769ffe4a02250060654763eab17aad07eeb00b95a3a2c0c0f1c1fL6-R37) [[2]](diffhunk://#diff-44624350a5039b10b8e00442e78f9504064c242291454ab1c84de5b8583ab3cdR36-R44) [[3]](diffhunk://#diff-44624350a5039b10b8e00442e78f9504064c242291454ab1c84de5b8583ab3cdR85-R99)

**Plugin disabling logic:**

* Added a helper function `pluginsAreDisabled` in `transform.ts` to short-circuit transformation when plugins are disabled or not provided, improving efficiency and correctness. [[1]](diffhunk://#diff-319ee5f514c0e56eb8cd68387ea8a1df6e4687067afa0160d2acbc2826f70c0cR54-R56) [[2]](diffhunk://#diff-319ee5f514c0e56eb8cd68387ea8a1df6e4687067afa0160d2acbc2826f70c0cR112-R117)