### PR TITLE
feat(lint): add fix cli feature.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,12 +10,15 @@ coverage/
 
 # Local caches and package archives
 .cache/
-.claude/
-.codex/
 .turbo/
 *.tgz
 *.tsbuildinfo
 *.log
+
+# AI assistant data
+.claude/
+.codex/
+.discussions/
 
 # Local Go workspace overlays
 go.work

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# AGENTS.md
+## 1. Project
 
-## What `ttsc` Is
+### 1.1. Product Contract
 
 `ttsc` is a standalone TypeScript-Go compiler, runtime, and plugin host. It ships two CLIs and a plugin protocol:
 
@@ -10,7 +10,7 @@
 
 The contract is general-purpose. Downstream projects like `typia` and `nestia` are compatibility fixtures, not the product definition.
 
-## Layout
+### 1.2. Layout
 
 - `packages/ttsc`: JS launcher/API, Go host (`cmd`, `driver`, `internal`, `utility`), and `shim/` for TypeScript-Go internals.
 - `packages/{banner,paths,strip}`: first-party utility plugins sharing `packages/ttsc/utility/host.go`.
@@ -23,7 +23,7 @@ The contract is general-purpose. Downstream projects like `typia` and `nestia` a
 - `tests/<plugin-name>`: workspace packages that need to be `require.resolve`-able from a fixture's `node_modules` (e.g. `tests/lint-contributor-demo`). Built by `scripts/build-current.cjs` before tests run.
 - `docs`, `config`, `scripts`: guide docs, shared tsconfig, workspace scripts.
 
-## Commands
+### 1.3. Commands
 
 ```bash
 pnpm install
@@ -32,7 +32,9 @@ pnpm build
 pnpm test
 ```
 
-## Work Rules
+## 2. Development
+
+### 2.1. Work Rules
 
 - Match existing conventions. Before adding a file, function, or test, open a nearby peer and mirror its naming, location, and code style — don't create parallel structures.
 - Respect existing package boundaries. Don't hardcode consumer-specific behavior into the compiler host.
@@ -40,7 +42,7 @@ pnpm test
 - `shim.go` files marked `gen_shims:hand-maintained` are not regenerated.
 - When code behavior changes, update the matching page under `docs/` in the same change.
 
-## Testing
+### 2.2. Testing
 
 **One test case per file, named after what it asserts.** Applies to both layers.
 
@@ -67,3 +69,71 @@ export const test_plugin_corpus_composes_rejects_cycle_between_two_plugins =
 ```
 
 Use the shared helpers in `tests/utils` and the per-suite `internal/` modules; do not reach into another suite's internals. Regressions that need a real directory layout (not just a synthetic temp file map) go under `tests/projects`.
+
+### 2.3. Validation
+
+Run the narrowest command that proves the change first, then a broader command when shared behavior or packaging changed. Report any command that could not be run.
+
+### 2.4. Change Integrity
+
+Treat tests, fixtures, snapshots, CI workflows, package wiring, dependencies, core algorithms, and generated baselines as part of the specification. Changing them requires an explicit user request or a clear product reason, and the final report must call it out.
+
+For mechanical ports, migrations, or broad rewrites, preserve the existing algorithm and public behavior in reviewable slices. Prefer a concrete exemplar over abstract instructions, and inspect the diff before trusting a green test run.
+
+## 3. Documentation
+
+### 3.1. READMEs
+
+README files are for the final reader of that package or directory. Start with what it is, when to use it, installation, the smallest working setup, and the common path.
+
+Keep README language direct and practical. Avoid compiler theory, protocol details, internal architecture, and edge cases unless the reader must know them to use the package. Move deep explanations into `docs/` and link them only as the next step.
+
+### 3.2. Guide Documents
+
+Guide documents under `docs/` are the detailed layer. Each guide must name its reader: consumer, package user, bundler user, runtime user, plugin author, or maintainer.
+
+Package guides may go deeper than README with full options, recipes, troubleshooting, compatibility notes, and migration details. Plugin-author guides may cover protocol, Go APIs, testing, publishing, and internals. Keep one audience and task per page, and update `docs/README.md` when adding or moving a guide.
+
+### 3.3. AGENTS.md Maintenance
+
+Update `AGENTS.md` when the repository contract changes: new package families, moved directories, new commands, testing conventions, documentation policy, release flow, or coding-agent workflow rules.
+
+Keep `AGENTS.md` systematic, natural to read, and concise. Preserve the numbered H2/H3 structure, place new guidance in the smallest fitting section, and prefer direct rules over long rationale.
+
+When adding agent-facing rules, state the desired workflow first. Use negative constraints only for named failure modes, and include the reason so the rule points back to the intended behavior.
+
+## 4. Multi-Agent Workflows
+
+Use these workflows only when the user explicitly asks for the named workflow, a multi-agent review, or a multi-agent discussion. Use Review Cycles for direct review of changed source, docs, and tests; Discussions for open-ended topic exploration; and Research Review Rounds when review needs shared research before individual proposals.
+
+### 4.1. Review Cycles
+
+For an explicitly requested review cycle, form a team of six agents. Each agent must read the changed source, docs, and tests in full, then propose concrete improvements.
+
+The lead agent rechecks every proposal, verifies it against the codebase, and applies only changes that are technically sound and relevant.
+
+That is one cycle. For the next cycle, form a fresh team of six different agents and repeat. Continue while at least one verified proposal is accepted. Stop when no agent proposes an improvement, or when no proposal survives lead-agent validation.
+
+### 4.2. Discussions
+
+For a discussion task, create a new topic directory under `.discussions/<topic>/`. Use a short filesystem-safe topic name. Do not delete or overwrite existing discussion directories unless the user explicitly requests it.
+
+Form a team of six agents. Each agent researches the topic, creates a personal subdirectory under the topic directory, and continuously maintains its own wiki-style knowledge base there.
+
+When all agents are ready, run three unrestricted discussion rounds recorded as `round1.md`, `round2.md`, and `round3.md` in the topic directory. Each round has a one-hour budget. The lead agent moderates, acts as scribe, and does not narrow the topic unless the user did.
+
+The transcript files must record the live discussion, not a retrospective summary. The lead agent writes each statement in speaking order. Team agents read the updated transcript before speaking again and continue researching, revising their own knowledge bases, and preparing notes while waiting for their next turn.
+
+After `round3.md` is complete, the lead agent writes the agreed conclusions and major open points into `summary.md` in the topic directory, reports them to the user, and waits for the next instruction.
+
+### 4.3. Research Review Rounds
+
+For an explicitly requested research review, combine the `.discussions` knowledge-base workflow with the review validation loop.
+
+Create a new topic directory under `.discussions/<topic>/`. Each research review round gets its own `review-round-N/` subdirectory with six fresh agents, agent knowledge-base folders, `round1.md`, `round2.md`, `round3.md`, `proposals.md`, and `lead-validation.md`.
+
+In each round, agents build their own knowledge bases from the changed source, docs, tests, and any relevant research. Run the three live discussion transcripts as in Discussions: the lead agent records statements in speaking order while team agents read each other's statements, keep researching between turns, and refine their notes.
+
+At the end of a round, each agent submits its own concrete improvement proposals. Do not require consensus; discussion is for shared understanding, not voting. The lead agent verifies every proposal and applies only changes that are technically sound and relevant.
+
+For the next round, replace the team with six different agents and repeat. Continue while at least one verified proposal is accepted. Stop when no meaningful proposal remains, or when no proposal survives lead-agent validation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/00-consumer-quickstart.md
+++ b/docs/00-consumer-quickstart.md
@@ -44,7 +44,7 @@ Add `lint.config.json` when the plugin requires one:
 }
 ```
 
-Then run the same command:
+Run `--noEmit` to type-check and report lint findings. Run `ttsc fix` to rewrite source files in place using built-in autofixers (`no-var`, `prefer-const`, `eqeqeq`), then re-check:
 
 ```bash
 npx ttsc --noEmit

--- a/docs/00-consumer-quickstart.md
+++ b/docs/00-consumer-quickstart.md
@@ -48,6 +48,7 @@ Then run the same command:
 
 ```bash
 npx ttsc --noEmit
+npx ttsc fix
 ```
 
 ## Bundlers

--- a/docs/02-protocol.md
+++ b/docs/02-protocol.md
@@ -98,9 +98,15 @@ Public stages are deliberately small:
 | Stage                   | Host behavior                                    | Binary commands               |
 | ----------------------- | ------------------------------------------------ | ----------------------------- |
 | omitted / `"transform"` | participates in the TypeScript-Go transform path | `check`, `transform`, `build` |
-| `"check"`               | reports diagnostics before emit                  | `check`                       |
+| `"check"`               | reports diagnostics before emit                  | `check`; optional `fix`       |
 
 There is no public `output` stage. Plugins do not receive generated JavaScript text or emitted file text for post-processing.
+
+When the user runs `ttsc fix` or `ttsc --fix`, `ttsc` invokes check-stage
+plugins with the `fix` command and keeps JavaScript/declaration emit disabled.
+Fix-capable plugins should rewrite source files, reload any compiler state they
+need, and report remaining diagnostics through the same renderer contract as
+`check`. Plugins that do not implement fixes may reject the command.
 
 ## Composition
 

--- a/docs/02-protocol.md
+++ b/docs/02-protocol.md
@@ -103,10 +103,8 @@ Public stages are deliberately small:
 There is no public `output` stage. Plugins do not receive generated JavaScript text or emitted file text for post-processing.
 
 When the user runs `ttsc fix` or `ttsc --fix`, `ttsc` invokes check-stage
-plugins with the `fix` command and keeps JavaScript/declaration emit disabled.
-Fix-capable plugins should rewrite source files, reload any compiler state they
-need, and report remaining diagnostics through the same renderer contract as
-`check`. Plugins that do not implement fixes may reject the command.
+plugins with the `fix` subcommand and keeps JavaScript/declaration emit
+disabled. See [CLI Commands → `fix`](#fix) for the subcommand contract.
 
 ## Composition
 
@@ -234,6 +232,25 @@ my-plugin check \
 ```
 
 Run diagnostics only. Write diagnostics to stderr. Exit non-zero for errors.
+
+### `fix`
+
+```bash
+my-plugin fix \
+  --cwd=/project \
+  --tsconfig=/project/tsconfig.json \
+  --plugins-json='[...]'
+```
+
+Optional for check-stage plugins. Invoked when the user runs `ttsc fix` or
+`ttsc --fix`. Apply autofixes to source files in place, then render any
+remaining diagnostics through the same renderer contract as `check`. Emit
+stays disabled — fix plugins must not write JavaScript or declaration output.
+
+Plugins that do not support fixes should exit `2` with a stderr message of the
+form `<plugin-name>: fix not supported`. The host surfaces that as a build
+failure. Plugins that support fixes but find nothing to apply exit `0` with
+empty stderr.
 
 ### `transform`
 

--- a/docs/10-reference-plugins.md
+++ b/docs/10-reference-plugins.md
@@ -215,6 +215,8 @@ npm install -D @ttsc/lint
 
 When neither `rules` (inline severity map) nor `extends` (file path) is written in `tsconfig.json`, use `lint.config.*`, `ttsc-lint.config.*`, or a supported ESLint flat config file (`eslint.config.js`, `.mjs`, `.cjs`, `.ts`, `.mts`, or `.cts`). If no config file exists, the build fails.
 
+Run `ttsc fix` (or `ttsc --fix`) to apply supported lint fixes before the final no-emit check. Native fixers are attached as source-text edits on rule findings; ESLint-backed configs delegate to ESLint's `fix` runtime and then reload the TypeScript-Go Program before diagnostics are rendered.
+
 What to learn:
 
 - Reporting diagnostics before emit.
@@ -222,6 +224,7 @@ What to learn:
 - Rule registry keyed by rule name.
 - Rule dispatch by `shimast.Kind`.
 - Token-oriented diagnostic ranges with `shim/scanner`.
+- Autofix text edits for selected native rules and ESLint runtime delegation.
 - Rendering lint diagnostics beside TypeScript-Go diagnostics.
 
 Core architecture:
@@ -233,6 +236,11 @@ compile.go
   runs compiler diagnostics
   runs lint Engine
   renders diagnostics
+
+fix.go
+  applies native text edits
+  delegates ESLint runtime fixes
+  reloads Program before final diagnostics
 
 engine.go
   maps Kind -> active rules
@@ -251,6 +259,7 @@ Read:
 - [`packages/lint/plugin/host.go`](../packages/lint/plugin/host.go)
 - [`packages/lint/plugin/engine.go`](../packages/lint/plugin/engine.go)
 - [`packages/lint/plugin/compile.go`](../packages/lint/plugin/compile.go)
+- [`packages/lint/plugin/fix.go`](../packages/lint/plugin/fix.go)
 - [`packages/lint/plugin`](../packages/lint/plugin/)
 - [`tests/test-lint/src/cases`](../tests/test-lint/src/cases/)
 

--- a/docs/10-reference-plugins.md
+++ b/docs/10-reference-plugins.md
@@ -336,6 +336,40 @@ Read:
 - [`tests/lint-contributor-demo`](../tests/lint-contributor-demo/) — the canonical reference contributor used by the e2e tests.
 - [`tests/test-lint/src/features/contributor`](../tests/test-lint/src/features/contributor/) — end-to-end coverage for both discovery surfaces.
 
+### Emitting Autofixes
+
+A contributor rule can attach source-text edits to a finding by calling `ctx.ReportFix` (single edit) or `ctx.ReportRangeFix` (explicit pos/end). The host applies edits between the cascading native passes and the final no-emit check; if the host build did not opt into fix mode the edits are silently dropped and only the diagnostic is rendered — see `rule.ReportFix` GoDoc for the silent-fallback contract. Do not rely on edits being applied; design the rule so the diagnostic alone is useful.
+
+```go
+package demo
+
+import (
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+func init() { rule.Register(noTodoComment{}) }
+
+type noTodoComment struct{}
+
+func (noTodoComment) Name() string           { return "demo/no-todo-comment" }
+func (noTodoComment) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSourceFile} }
+func (noTodoComment) Check(ctx *rule.Context, node *shimast.Node) {
+  // Resolve pos/end from a shim/scanner trivia walk over ctx.File.Text();
+  // see tests/lint-contributor-demo/rules/no_todo_comment.go for the runnable form.
+  ctx.ReportFix(node, "drop TODO comment", rule.TextEdit{
+    Pos:  pos,
+    End:  end,
+    Text: "",
+  })
+}
+```
+
+See [`tests/lint-contributor-demo/rules/no_todo_comment.go`](../tests/lint-contributor-demo/rules/no_todo_comment.go) for a real contributor that computes the byte range via `shim/scanner` trivia tokenization.
+
+Edits within a single finding must not overlap; ordering inside the slice does not matter, and an empty `Text` deletes the range. The host discards the whole set if any edit is malformed, so prefer one tight edit per finding over speculative multi-edit batches.
+
 ## Combined Project
 
 ```jsonc

--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -122,6 +122,24 @@ npx ttsx src/index.ts
 - Under `ttsx`, lint errors stop the program before your entrypoint runs.
 - Lint warnings are printed without changing the exit code.
 
+### Fix
+
+Run `ttsc fix` to apply supported autofixes and then run the same no-emit
+typecheck + lint pass:
+
+```bash
+npx ttsc fix
+# equivalent flag form
+npx ttsc --fix
+```
+
+Native `@ttsc/lint` fixers currently cover `no-var`, single-declaration
+`prefer-const`, and ESLint-safe `eqeqeq` cases (`typeof` comparisons and
+same-type literal comparisons). When a supported `eslint.config.*` file runs
+through an installed ESLint runtime, `ttsc fix` delegates to ESLint's own fixers
+and then reloads the TypeScript-Go Program before reporting any remaining
+diagnostics.
+
 ### Config Files
 
 By default, `@ttsc/lint` reads config files such as `lint.config.ts` or `eslint.config.ts` next to the selected `tsconfig.json`.
@@ -162,7 +180,7 @@ ttsc copies each declared contributor's Go source into a sub-package of `@ttsc/l
 
 ## Scope
 
-Diagnostic-only today: no autofix and no bundled recommended preset.
+No bundled recommended preset yet. Rules remain off until you enable them.
 
 ## Rules
 

--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -140,6 +140,15 @@ through an installed ESLint runtime, `ttsc fix` delegates to ESLint's own fixers
 and then reloads the TypeScript-Go Program before reporting any remaining
 diagnostics.
 
+`ttsc fix` is a one-shot project pass: it does not combine with `--watch`,
+single-file mode, or `--emit`. The launcher rejects those combinations with an
+explicit error. Applied fixes are written to disk before the recheck runs, so
+source files stay modified even when `ttsc fix` exits non-zero on remaining
+type errors or un-fixable lint violations.
+
+Run `ttsc fix` locally, commit, then have CI run `ttsc --noEmit` to enforce
+zero remaining errors.
+
 ### Config Files
 
 By default, `@ttsc/lint` reads config files such as `lint.config.ts` or `eslint.config.ts` next to the selected `tsconfig.json`.

--- a/packages/lint/plugin/ast_helpers.go
+++ b/packages/lint/plugin/ast_helpers.go
@@ -26,6 +26,57 @@ func nodeText(file *shimast.SourceFile, node *shimast.Node) string {
   return strings.TrimRight(src[pos:end], " \t\r\n")
 }
 
+// keywordStart returns the source offset of a declaration keyword such as
+// `var` or `let` at the start of a node after leading trivia.
+func keywordStart(file *shimast.SourceFile, node *shimast.Node, keyword string) int {
+  if file == nil || node == nil || keyword == "" {
+    return -1
+  }
+  src := file.Text()
+  pos := shimscanner.SkipTrivia(src, node.Pos())
+  end := pos + len(keyword)
+  if pos < 0 || end > len(src) {
+    return -1
+  }
+  if strings.HasPrefix(src[pos:], keyword) && (end == len(src) || !isIdentifierPart(src[end])) {
+    return pos
+  }
+  limit := node.End()
+  if limit > len(src) {
+    limit = len(src)
+  }
+  for i := pos; i+len(keyword) <= limit && i < pos+32; i++ {
+    end = i + len(keyword)
+    if strings.HasPrefix(src[i:], keyword) &&
+      (i == 0 || !isIdentifierPart(src[i-1])) &&
+      (end == len(src) || !isIdentifierPart(src[end])) {
+      return i
+    }
+  }
+  return -1
+}
+
+func tokenRange(file *shimast.SourceFile, node *shimast.Node) (int, int) {
+  if file == nil || node == nil {
+    return -1, -1
+  }
+  src := file.Text()
+  pos := shimscanner.SkipTrivia(src, node.Pos())
+  end := node.End()
+  if pos < 0 || pos > len(src) || end < pos || end > len(src) {
+    return -1, -1
+  }
+  return pos, end
+}
+
+func isIdentifierPart(ch byte) bool {
+  return (ch >= 'a' && ch <= 'z') ||
+    (ch >= 'A' && ch <= 'Z') ||
+    (ch >= '0' && ch <= '9') ||
+    ch == '_' ||
+    ch == '$'
+}
+
 // identifierText returns the lexical name of an Identifier node, or "" if
 // the node isn't an Identifier.
 func identifierText(node *shimast.Node) string {

--- a/packages/lint/plugin/contrib_adapter.go
+++ b/packages/lint/plugin/contrib_adapter.go
@@ -90,6 +90,29 @@ func (r contextReporter) Report(node *shimast.Node, message string) {
   r.ctx.Report(node, message)
 }
 
+func (r contextReporter) ReportFix(node *shimast.Node, message string, edits ...rule.TextEdit) {
+  r.ctx.ReportFix(node, message, toInternalTextEdits(edits)...)
+}
+
 func (r contextReporter) ReportRange(pos, end int, message string) {
   r.ctx.ReportRange(pos, end, message)
+}
+
+func (r contextReporter) ReportRangeFix(pos, end int, message string, edits ...rule.TextEdit) {
+  r.ctx.ReportRangeFix(pos, end, message, toInternalTextEdits(edits)...)
+}
+
+func toInternalTextEdits(edits []rule.TextEdit) []TextEdit {
+  if len(edits) == 0 {
+    return nil
+  }
+  out := make([]TextEdit, len(edits))
+  for i, edit := range edits {
+    out[i] = TextEdit{
+      Pos:  edit.Pos,
+      End:  edit.End,
+      Text: edit.Text,
+    }
+  }
+  return out
 }

--- a/packages/lint/plugin/engine.go
+++ b/packages/lint/plugin/engine.go
@@ -62,6 +62,16 @@ type Finding struct {
   Pos      int
   End      int
   Message  string
+  Fix      []TextEdit
+}
+
+// TextEdit is one byte-range replacement offered by an autofixable finding.
+// Positions use the same byte offsets as shim AST nodes and must point inside
+// the finding's source file.
+type TextEdit struct {
+  Pos  int
+  End  int
+  Text string
 }
 
 // Report records a finding at the given node's source range. The pos is
@@ -71,6 +81,11 @@ type Finding struct {
 // configured severity is `off` (defensive — the engine already filters
 // by severity before calling Check, but Report is the final gate).
 func (c *Context) Report(node *shimast.Node, message string) {
+  c.ReportFix(node, message)
+}
+
+// ReportFix records a node-scoped finding with optional autofix edits.
+func (c *Context) ReportFix(node *shimast.Node, message string, edits ...TextEdit) {
   if c.Severity == SeverityOff || node == nil {
     return
   }
@@ -85,6 +100,7 @@ func (c *Context) Report(node *shimast.Node, message string) {
     Pos:      pos,
     End:      node.End(),
     Message:  message,
+    Fix:      cloneTextEdits(edits),
   })
 }
 
@@ -92,6 +108,11 @@ func (c *Context) Report(node *shimast.Node, message string) {
 // current file. Use this when the rule wants to highlight a sub-token of
 // a node (e.g. an operator inside a BinaryExpression).
 func (c *Context) ReportRange(pos, end int, message string) {
+  c.ReportRangeFix(pos, end, message)
+}
+
+// ReportRangeFix records an explicit-range finding with optional autofix edits.
+func (c *Context) ReportRangeFix(pos, end int, message string, edits ...TextEdit) {
   if c.Severity == SeverityOff || c.File == nil {
     return
   }
@@ -105,7 +126,17 @@ func (c *Context) ReportRange(pos, end int, message string) {
     Pos:      pos,
     End:      end,
     Message:  message,
+    Fix:      cloneTextEdits(edits),
   })
+}
+
+func cloneTextEdits(edits []TextEdit) []TextEdit {
+  if len(edits) == 0 {
+    return nil
+  }
+  out := make([]TextEdit, len(edits))
+  copy(out, edits)
+  return out
 }
 
 // registry stores the package-global rule list keyed by name. Tests can

--- a/packages/lint/plugin/eslint_runtime.go
+++ b/packages/lint/plugin/eslint_runtime.go
@@ -134,14 +134,14 @@ func runExternalESLintFixes(
   resolver RuleResolver,
   cwd string,
   files []*shimast.SourceFile,
-) (int, bool, error) {
+) (int, error) {
   provider, ok := resolver.(eslintRuntimeProvider)
   if !ok || !provider.WantsESLintRuntime() {
-    return 0, false, nil
+    return 0, nil
   }
   configPath := provider.ExternalConfigPath()
   if configPath == "" {
-    return 0, false, nil
+    return 0, nil
   }
 
   fileNames := make([]string, 0, len(files))
@@ -159,25 +159,25 @@ func runExternalESLintFixes(
     fileNames = append(fileNames, name)
   }
   if len(fileNames) == 0 {
-    return 0, true, nil
+    return 0, nil
   }
 
   payload, err := json.Marshal(fileNames)
   if err != nil {
-    return 0, false, fmt.Errorf("@ttsc/lint: encode ESLint file list: %w", err)
+    return 0, fmt.Errorf("@ttsc/lint: encode ESLint file list: %w", err)
   }
 
   output, err := runExternalESLintWithMode(cwd, configPath, string(payload), true)
   if err != nil {
-    return 0, false, err
+    return 0, err
   }
   if output.Missing {
     if provider.RequiresESLintRuntime() {
-      return 0, false, fmt.Errorf("@ttsc/lint: ESLint runtime is required by %s; install eslint in the project or replace runtime-only config features", configPath)
+      return 0, fmt.Errorf("@ttsc/lint: ESLint runtime is required by %s; install eslint in the project or replace runtime-only config features", configPath)
     }
-    return 0, false, nil
+    return 0, nil
   }
-  return output.Fixed, true, nil
+  return output.Fixed, nil
 }
 
 func runExternalESLintWithMode(cwd, configPath, fileListJSON string, fix bool) (*eslintRuntimeOutput, error) {

--- a/packages/lint/plugin/eslint_runtime.go
+++ b/packages/lint/plugin/eslint_runtime.go
@@ -21,6 +21,7 @@ type eslintRuntimeProvider interface {
 
 type eslintRuntimeOutput struct {
   Missing bool                `json:"missing"`
+  Fixed   int                 `json:"fixed"`
   Results []eslintRuntimeFile `json:"results"`
 }
 
@@ -126,11 +127,69 @@ func runExternalESLintDiagnostics(
 }
 
 func runExternalESLint(cwd, configPath, fileListJSON string) (*eslintRuntimeOutput, error) {
+  return runExternalESLintWithMode(cwd, configPath, fileListJSON, false)
+}
+
+func runExternalESLintFixes(
+  resolver RuleResolver,
+  cwd string,
+  files []*shimast.SourceFile,
+) (int, bool, error) {
+  provider, ok := resolver.(eslintRuntimeProvider)
+  if !ok || !provider.WantsESLintRuntime() {
+    return 0, false, nil
+  }
+  configPath := provider.ExternalConfigPath()
+  if configPath == "" {
+    return 0, false, nil
+  }
+
+  fileNames := make([]string, 0, len(files))
+  for _, file := range files {
+    if file == nil || file.IsDeclarationFile {
+      continue
+    }
+    name := file.FileName()
+    if !filepath.IsAbs(name) {
+      name = filepath.Join(cwd, name)
+    }
+    if abs, err := filepath.Abs(name); err == nil {
+      name = abs
+    }
+    fileNames = append(fileNames, name)
+  }
+  if len(fileNames) == 0 {
+    return 0, true, nil
+  }
+
+  payload, err := json.Marshal(fileNames)
+  if err != nil {
+    return 0, false, fmt.Errorf("@ttsc/lint: encode ESLint file list: %w", err)
+  }
+
+  output, err := runExternalESLintWithMode(cwd, configPath, string(payload), true)
+  if err != nil {
+    return 0, false, err
+  }
+  if output.Missing {
+    if provider.RequiresESLintRuntime() {
+      return 0, false, fmt.Errorf("@ttsc/lint: ESLint runtime is required by %s; install eslint in the project or replace runtime-only config features", configPath)
+    }
+    return 0, false, nil
+  }
+  return output.Fixed, true, nil
+}
+
+func runExternalESLintWithMode(cwd, configPath, fileListJSON string, fix bool) (*eslintRuntimeOutput, error) {
   node := os.Getenv("TTSC_NODE_BINARY")
   if node == "" {
     node = "node"
   }
-  cmd := exec.Command(node, "-e", externalESLintRunnerScript, cwd, configPath, fileListJSON)
+  mode := "check"
+  if fix {
+    mode = "fix"
+  }
+  cmd := exec.Command(node, "-e", externalESLintRunnerScript, cwd, configPath, fileListJSON, mode)
   cmd.Env = nodeConfigLoaderEnv(configPath)
   cmd.Dir = cwd
   raw, err := cmd.Output()
@@ -196,6 +255,7 @@ const path = require("node:path");
   const cwd = process.argv[1];
   const configPath = process.argv[2];
   const files = JSON.parse(process.argv[3]);
+  const shouldFix = process.argv[4] === "fix";
   const requireFromProject = createRequire(path.join(cwd, "package.json"));
   let eslintPath;
   try {
@@ -220,12 +280,26 @@ const path = require("node:path");
   const eslint = new ESLintCtor({
     cwd,
     overrideConfigFile: configPath,
+    fix: shouldFix,
     ignore: true,
     warnIgnored: false,
   });
   const results = await eslint.lintFiles(files);
+  if (shouldFix) {
+    const outputFixes =
+      ESLintCtor.outputFixes ||
+      eslintModule.ESLint?.outputFixes ||
+      eslintModule.default?.ESLint?.outputFixes;
+    if (typeof outputFixes !== "function") {
+      throw new Error("installed eslint package does not expose ESLint.outputFixes");
+    }
+    await outputFixes.call(ESLintCtor, results);
+  }
   process.stdout.write(JSON.stringify({
     missing: false,
+    fixed: shouldFix
+      ? results.filter((result) => typeof result.output === "string").length
+      : 0,
     results: results.map((result) => ({
       filePath: result.filePath,
       messages: result.messages.map((message) => ({

--- a/packages/lint/plugin/fix.go
+++ b/packages/lint/plugin/fix.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+  "fmt"
+  "os"
+  "path/filepath"
+  "sort"
+
+  shimdw "github.com/microsoft/typescript-go/shim/diagnosticwriter"
+)
+
+const maxFixPasses = 10
+
+// RunFix implements `@ttsc/lint fix` — apply autofixes, then report any
+// remaining type or lint diagnostics without emitting JavaScript.
+func RunFix(args []string) int {
+  opts, err := parseSubcommandFlags("fix", args)
+  if err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    return 2
+  }
+  if opts.emit {
+    fmt.Fprintln(os.Stderr, "@ttsc/lint fix: --emit is not supported")
+    return 2
+  }
+  opts.noEmit = true
+  return runFix(opts)
+}
+
+func runFix(opts *subcommandOpts) int {
+  rules, err := loadRules(opts.pluginsJSON, opts.cwd, opts.tsconfig)
+  if err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    return 2
+  }
+
+  prog, code := loadFixProgram(opts)
+  if code != 0 {
+    return code
+  }
+  defer func() {
+    if prog != nil {
+      prog.close()
+    }
+  }()
+
+  totalFixes := 0
+  if fixed, _, err := runExternalESLintFixes(rules, opts.cwd, prog.userSourceFiles()); err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    return 2
+  } else if fixed > 0 {
+    totalFixes += fixed
+    prog, code = reloadFixProgram(prog, opts)
+    if code != 0 {
+      return code
+    }
+  }
+
+  for pass := 0; pass < maxFixPasses; pass++ {
+    engine := NewEngineWithResolver(rules)
+    findings := engine.Run(prog.userSourceFiles(), prog.checker)
+    fixed, err := applyFindingFixes(opts.cwd, findings)
+    if err != nil {
+      fmt.Fprintln(os.Stderr, err)
+      return 3
+    }
+    if fixed == 0 {
+      break
+    }
+    totalFixes += fixed
+    prog, code = reloadFixProgram(prog, opts)
+    if code != 0 {
+      return code
+    }
+  }
+
+  engine := NewEngineWithResolver(rules)
+  astDiags, lintDiags, externalRan, err := collectDiagnostics(prog, engine)
+  if err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    return 2
+  }
+  if !externalRan {
+    warnUnknownRules(os.Stderr, engine.UnknownRules())
+  }
+  if errCount := shimdw.FormatMixedDiagnostics(os.Stderr, astDiags, lintDiags, opts.cwd); errCount > 0 {
+    return 2
+  }
+  if opts.verbose && totalFixes > 0 {
+    fmt.Fprintf(os.Stdout, "@ttsc/lint: fixed=%d edits\n", totalFixes)
+  }
+  return 0
+}
+
+func loadFixProgram(opts *subcommandOpts) (*program, int) {
+  prog, parseDiags, err := loadProgram(opts.cwd, opts.tsconfig, loadProgramOptions{
+    forceNoEmit: true,
+    outDir:      opts.outDir,
+  })
+  if err != nil {
+    fmt.Fprintf(os.Stderr, "@ttsc/lint: %v\n", err)
+    return nil, 2
+  }
+  if len(parseDiags) > 0 {
+    shimdw.FormatASTDiagnosticsWithColorAndContext(os.Stderr, parseDiags, opts.cwd)
+    return nil, 2
+  }
+  return prog, 0
+}
+
+func reloadFixProgram(current *program, opts *subcommandOpts) (*program, int) {
+  if current != nil {
+    current.close()
+  }
+  return loadFixProgram(opts)
+}
+
+type fileFixes struct {
+  path  string
+  text  string
+  edits []TextEdit
+}
+
+func applyFindingFixes(cwd string, findings []*Finding) (int, error) {
+  byFile := map[string]*fileFixes{}
+  for _, finding := range findings {
+    if finding == nil || finding.File == nil || len(finding.Fix) == 0 {
+      continue
+    }
+    path := finding.File.FileName()
+    if path == "" {
+      continue
+    }
+    if !filepath.IsAbs(path) {
+      path = filepath.Join(cwd, path)
+    }
+    if abs, err := filepath.Abs(path); err == nil {
+      path = abs
+    }
+    bucket := byFile[path]
+    if bucket == nil {
+      bucket = &fileFixes{path: path, text: finding.File.Text()}
+      byFile[path] = bucket
+    }
+    bucket.edits = append(bucket.edits, finding.Fix...)
+  }
+
+  total := 0
+  for _, bucket := range byFile {
+    fixed, err := applyTextEditsToFile(bucket.path, bucket.text, bucket.edits)
+    if err != nil {
+      return total, err
+    }
+    total += fixed
+  }
+  return total, nil
+}
+
+func applyTextEditsToFile(path, source string, edits []TextEdit) (int, error) {
+  selected := selectTextEdits(len(source), edits)
+  if len(selected) == 0 {
+    return 0, nil
+  }
+  next := source
+  for i := len(selected) - 1; i >= 0; i-- {
+    edit := selected[i]
+    next = next[:edit.Pos] + edit.Text + next[edit.End:]
+  }
+  if next == source {
+    return 0, nil
+  }
+  if err := os.WriteFile(path, []byte(next), 0o644); err != nil {
+    return 0, fmt.Errorf("@ttsc/lint fix: write %s: %w", path, err)
+  }
+  return len(selected), nil
+}
+
+func selectTextEdits(sourceLen int, edits []TextEdit) []TextEdit {
+  if len(edits) == 0 {
+    return nil
+  }
+  sorted := make([]TextEdit, 0, len(edits))
+  seen := map[TextEdit]struct{}{}
+  for _, edit := range edits {
+    if edit.Pos < 0 || edit.End < edit.Pos || edit.End > sourceLen {
+      continue
+    }
+    if _, exists := seen[edit]; exists {
+      continue
+    }
+    seen[edit] = struct{}{}
+    sorted = append(sorted, edit)
+  }
+  sort.SliceStable(sorted, func(i, j int) bool {
+    if sorted[i].Pos != sorted[j].Pos {
+      return sorted[i].Pos < sorted[j].Pos
+    }
+    if sorted[i].End != sorted[j].End {
+      return sorted[i].End < sorted[j].End
+    }
+    return sorted[i].Text < sorted[j].Text
+  })
+
+  selected := make([]TextEdit, 0, len(sorted))
+  lastEnd := -1
+  for _, edit := range sorted {
+    if edit.Pos < lastEnd {
+      continue
+    }
+    selected = append(selected, edit)
+    lastEnd = edit.End
+  }
+  return selected
+}

--- a/packages/lint/plugin/fix.go
+++ b/packages/lint/plugin/fix.go
@@ -9,6 +9,10 @@ import (
   shimdw "github.com/microsoft/typescript-go/shim/diagnosticwriter"
 )
 
+// maxFixPasses bounds the native cascade after the one-shot ESLint runtime
+// pass. Real-world cascades (no-var → prefer-const → eqeqeq …) settle in a
+// handful of passes; the cap exists so a buggy rule that re-reports its own
+// edit cannot loop forever.
 const maxFixPasses = 10
 
 // RunFix implements `@ttsc/lint fix` — apply autofixes, then report any
@@ -45,7 +49,7 @@ func runFix(opts *subcommandOpts) int {
   }()
 
   totalFixes := 0
-  if fixed, _, err := runExternalESLintFixes(rules, opts.cwd, prog.userSourceFiles()); err != nil {
+  if fixed, err := runExternalESLintFixes(rules, opts.cwd, prog.userSourceFiles()); err != nil {
     fmt.Fprintln(os.Stderr, err)
     return 2
   } else if fixed > 0 {
@@ -145,8 +149,14 @@ func applyFindingFixes(cwd string, findings []*Finding) (int, error) {
     bucket.edits = append(bucket.edits, finding.Fix...)
   }
 
+  paths := make([]string, 0, len(byFile))
+  for p := range byFile {
+    paths = append(paths, p)
+  }
+  sort.Strings(paths)
   total := 0
-  for _, bucket := range byFile {
+  for _, p := range paths {
+    bucket := byFile[p]
     fixed, err := applyTextEditsToFile(bucket.path, bucket.text, bucket.edits)
     if err != nil {
       return total, err

--- a/packages/lint/plugin/main.go
+++ b/packages/lint/plugin/main.go
@@ -6,6 +6,7 @@
 //   - `version` / `-v` / `--version` — print the binary banner.
 //   - `check` — typecheck + lint without emit. Failure exit code if any
 //     error-severity diagnostic fires.
+//   - `fix` — apply autofixes, then typecheck + lint without emit.
 //   - `build` — typecheck + lint, then run the standard tsgo emit pipeline
 //     so JS files land on disk.
 //   - `transform --file=PATH` — single-file emit with the same lint pass.
@@ -28,7 +29,7 @@ func main() {
 
 func run(args []string) int {
   if len(args) == 0 {
-    fmt.Fprintln(os.Stderr, "@ttsc/lint: command required (expected check|build|transform|version)")
+    fmt.Fprintln(os.Stderr, "@ttsc/lint: command required (expected check|fix|build|transform|version)")
     return 2
   }
   switch args[0] {
@@ -36,7 +37,7 @@ func run(args []string) int {
     // Don't pay contributor-registration cost for the version banner.
     fmt.Fprintf(os.Stdout, "@ttsc/lint %s\n", version)
     return 0
-  case "check", "build", "transform":
+  case "check", "fix", "build", "transform":
   default:
     fmt.Fprintf(os.Stderr, "@ttsc/lint: unknown command %q\n", args[0])
     return 2
@@ -47,6 +48,8 @@ func run(args []string) int {
   switch args[0] {
   case "check":
     return RunCheck(args[1:])
+  case "fix":
+    return RunFix(args[1:])
   case "build":
     return RunBuild(args[1:])
   case "transform":

--- a/packages/lint/plugin/rules_logic.go
+++ b/packages/lint/plugin/rules_logic.go
@@ -119,10 +119,62 @@ func (eqeqeq) Check(ctx *Context, node *shimast.Node) {
   }
   switch expr.OperatorToken.Kind {
   case shimast.KindEqualsEqualsToken:
-    ctx.ReportRange(expr.OperatorToken.Pos(), expr.OperatorToken.End(), "Expected '===' and instead saw '=='.")
+    reportEqeqeq(ctx, expr.OperatorToken, expr, "Expected '===' and instead saw '=='.", "===")
   case shimast.KindExclamationEqualsToken:
-    ctx.ReportRange(expr.OperatorToken.Pos(), expr.OperatorToken.End(), "Expected '!==' and instead saw '!='.")
+    reportEqeqeq(ctx, expr.OperatorToken, expr, "Expected '!==' and instead saw '!='.", "!==")
   }
+}
+
+func reportEqeqeq(ctx *Context, operator *shimast.Node, expr *shimast.BinaryExpression, message, replacement string) {
+  pos, end := tokenRange(ctx.File, operator)
+  if pos < 0 {
+    pos, end = operator.Pos(), operator.End()
+  }
+  if isEqeqeqAutoFixSafe(expr) {
+    ctx.ReportRangeFix(
+      pos,
+      end,
+      message,
+      TextEdit{Pos: pos, End: end, Text: replacement},
+    )
+    return
+  }
+  ctx.ReportRange(pos, end, message)
+}
+
+func isEqeqeqAutoFixSafe(expr *shimast.BinaryExpression) bool {
+  if expr == nil {
+    return false
+  }
+  left := stripParens(expr.Left)
+  right := stripParens(expr.Right)
+  if left == nil || right == nil {
+    return false
+  }
+  if left.Kind == shimast.KindTypeOfExpression || right.Kind == shimast.KindTypeOfExpression {
+    return true
+  }
+  leftKind := comparableLiteralKind(left)
+  return leftKind != "" && leftKind == comparableLiteralKind(right)
+}
+
+func comparableLiteralKind(node *shimast.Node) string {
+  if node == nil {
+    return ""
+  }
+  switch node.Kind {
+  case shimast.KindStringLiteral:
+    return "string"
+  case shimast.KindNumericLiteral:
+    return "number"
+  case shimast.KindBigIntLiteral:
+    return "bigint"
+  case shimast.KindTrueKeyword, shimast.KindFalseKeyword:
+    return "boolean"
+  case shimast.KindNullKeyword:
+    return "object"
+  }
+  return ""
 }
 
 // use-isnan: `x === NaN` is always false. Use `Number.isNaN(x)`.

--- a/packages/lint/plugin/rules_var.go
+++ b/packages/lint/plugin/rules_var.go
@@ -14,6 +14,16 @@ func (noVar) Check(ctx *Context, node *shimast.Node) {
     return
   }
   if shimast.IsVar(stmt.DeclarationList) {
+    start := keywordStart(ctx.File, stmt.DeclarationList, "var")
+    if start >= 0 {
+      ctx.ReportRangeFix(
+        start,
+        start+len("var"),
+        "Unexpected var, use let or const instead.",
+        TextEdit{Pos: start, End: start + len("var"), Text: "let"},
+      )
+      return
+    }
     ctx.Report(node, "Unexpected var, use let or const instead.")
   }
 }
@@ -29,8 +39,9 @@ func (preferConst) Name() string           { return "prefer-const" }
 func (preferConst) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSourceFile} }
 func (preferConst) Check(ctx *Context, node *shimast.Node) {
   type candidate struct {
-    name string
-    node *shimast.Node
+    name     string
+    node     *shimast.Node
+    listNode *shimast.Node
   }
   var candidates []candidate
   assigned := map[string]bool{}
@@ -53,7 +64,7 @@ func (preferConst) Check(ctx *Context, node *shimast.Node) {
       if !isConstEligibleLetDeclaration(child, decl) {
         return
       }
-      candidates = append(candidates, candidate{name: name, node: child})
+      candidates = append(candidates, candidate{name: name, node: child, listNode: listNode})
     case shimast.KindBinaryExpression:
       expr := child.AsBinaryExpression()
       if expr == nil || expr.OperatorToken == nil || !isAssignmentOperator(expr.OperatorToken.Kind) {
@@ -87,9 +98,29 @@ func (preferConst) Check(ctx *Context, node *shimast.Node) {
 
   for _, c := range candidates {
     if !assigned[c.name] {
-      ctx.Report(c.node, "Use const instead of let.")
+      start := -1
+      if isSingleDeclarationList(c.listNode) {
+        start = keywordStart(ctx.File, c.listNode, "let")
+      }
+      if start >= 0 {
+        ctx.ReportFix(
+          c.node,
+          "Use const instead of let.",
+          TextEdit{Pos: start, End: start + len("let"), Text: "const"},
+        )
+      } else {
+        ctx.Report(c.node, "Use const instead of let.")
+      }
     }
   }
+}
+
+func isSingleDeclarationList(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  list := node.AsVariableDeclarationList()
+  return list != nil && list.Declarations != nil && len(list.Declarations.Nodes) == 1
 }
 
 func isConstEligibleLetDeclaration(node *shimast.Node, decl *shimast.VariableDeclaration) bool {

--- a/packages/lint/rule/rule.go
+++ b/packages/lint/rule/rule.go
@@ -90,6 +90,10 @@ type Reporter interface {
   ReportRange(pos, end int, message string)
 }
 
+// fixReporter is the optional extension a host implements to receive
+// autofix edits alongside a finding. The public `rule.Context` type-asserts
+// against this shape so any host whose reporter exposes both methods opts
+// into fix support without depending on the unexported interface name.
 type fixReporter interface {
   ReportFix(node *shimast.Node, message string, edits ...TextEdit)
   ReportRangeFix(pos, end int, message string, edits ...TextEdit)
@@ -98,6 +102,13 @@ type fixReporter interface {
 // TextEdit is one byte-range replacement offered by an autofixable finding.
 // Positions use the same byte offsets as shim AST nodes and must point inside
 // the current source file.
+//
+// When a rule reports several edits in one call, the host applies them as a
+// set: edits must not overlap each other, order in the slice does not matter,
+// and an empty `Text` deletes the range. The host may discard the whole set
+// if any edit is malformed (negative or out-of-file offsets, overlapping
+// ranges). Rules that need separate independent fixes should emit each as its
+// own `ReportFix` / `ReportRangeFix` call.
 type TextEdit struct {
   Pos  int
   End  int
@@ -155,6 +166,7 @@ func (c *Context) Report(node *shimast.Node, message string) {
 // ReportFix records a finding at the given node's source range with optional
 // autofix edits. Older hosts that do not implement fix reporting receive the
 // diagnostic without edits.
+// Treat edits as best-effort: design the rule so the diagnostic alone is useful.
 func (c *Context) ReportFix(node *shimast.Node, message string, edits ...TextEdit) {
   if c == nil || c.reporter == nil || c.Severity == SeverityOff || node == nil {
     return
@@ -183,6 +195,7 @@ func (c *Context) ReportRange(pos, end int, message string) {
 // ReportRangeFix records a finding at an explicit byte range with optional
 // autofix edits. Older hosts that do not implement fix reporting receive the
 // diagnostic without edits.
+// Treat edits as best-effort: design the rule so the diagnostic alone is useful.
 func (c *Context) ReportRangeFix(pos, end int, message string, edits ...TextEdit) {
   if c == nil || c.reporter == nil || c.Severity == SeverityOff {
     return

--- a/packages/lint/rule/rule.go
+++ b/packages/lint/rule/rule.go
@@ -84,10 +84,25 @@ type Rule interface {
 type Reporter interface {
   // Report records a finding at the given node's source range.
   Report(node *shimast.Node, message string)
+  // ReportFix records a finding at the given node's source range with
+  // byte-range text edits that can be applied by the host's fix command.
+  ReportFix(node *shimast.Node, message string, edits ...TextEdit)
   // ReportRange records a finding at an explicit byte range inside the
   // current file. Use this when the rule wants to highlight a
   // sub-token.
   ReportRange(pos, end int, message string)
+  // ReportRangeFix records an explicit-range finding with byte-range
+  // text edits that can be applied by the host's fix command.
+  ReportRangeFix(pos, end int, message string, edits ...TextEdit)
+}
+
+// TextEdit is one byte-range replacement offered by an autofixable finding.
+// Positions use the same byte offsets as shim AST nodes and must point inside
+// the current source file.
+type TextEdit struct {
+  Pos  int
+  End  int
+  Text string
 }
 
 // Context is the per-(file, rule) handle the engine passes to `Check`.
@@ -132,19 +147,31 @@ func NewContext(
 // ignored when severity is `off` (defensive — the engine already filters
 // by severity before invoking Check) or when no reporter is attached.
 func (c *Context) Report(node *shimast.Node, message string) {
+  c.ReportFix(node, message)
+}
+
+// ReportFix records a finding at the given node's source range with optional
+// autofix edits. Silently ignored when severity is off or no reporter exists.
+func (c *Context) ReportFix(node *shimast.Node, message string, edits ...TextEdit) {
   if c == nil || c.reporter == nil || c.Severity == SeverityOff || node == nil {
     return
   }
-  c.reporter.Report(node, message)
+  c.reporter.ReportFix(node, message, edits...)
 }
 
 // ReportRange records a finding at an explicit byte range inside the
 // current file.
 func (c *Context) ReportRange(pos, end int, message string) {
+  c.ReportRangeFix(pos, end, message)
+}
+
+// ReportRangeFix records a finding at an explicit byte range with optional
+// autofix edits.
+func (c *Context) ReportRangeFix(pos, end int, message string, edits ...TextEdit) {
   if c == nil || c.reporter == nil || c.Severity == SeverityOff {
     return
   }
-  c.reporter.ReportRange(pos, end, message)
+  c.reporter.ReportRangeFix(pos, end, message, edits...)
 }
 
 var registry []Rule

--- a/packages/lint/rule/rule.go
+++ b/packages/lint/rule/rule.go
@@ -84,15 +84,14 @@ type Rule interface {
 type Reporter interface {
   // Report records a finding at the given node's source range.
   Report(node *shimast.Node, message string)
-  // ReportFix records a finding at the given node's source range with
-  // byte-range text edits that can be applied by the host's fix command.
-  ReportFix(node *shimast.Node, message string, edits ...TextEdit)
   // ReportRange records a finding at an explicit byte range inside the
   // current file. Use this when the rule wants to highlight a
   // sub-token.
   ReportRange(pos, end int, message string)
-  // ReportRangeFix records an explicit-range finding with byte-range
-  // text edits that can be applied by the host's fix command.
+}
+
+type fixReporter interface {
+  ReportFix(node *shimast.Node, message string, edits ...TextEdit)
   ReportRangeFix(pos, end int, message string, edits ...TextEdit)
 }
 
@@ -147,31 +146,57 @@ func NewContext(
 // ignored when severity is `off` (defensive — the engine already filters
 // by severity before invoking Check) or when no reporter is attached.
 func (c *Context) Report(node *shimast.Node, message string) {
-  c.ReportFix(node, message)
+  if c == nil || c.reporter == nil || c.Severity == SeverityOff || node == nil {
+    return
+  }
+  c.reporter.Report(node, message)
 }
 
 // ReportFix records a finding at the given node's source range with optional
-// autofix edits. Silently ignored when severity is off or no reporter exists.
+// autofix edits. Older hosts that do not implement fix reporting receive the
+// diagnostic without edits.
 func (c *Context) ReportFix(node *shimast.Node, message string, edits ...TextEdit) {
   if c == nil || c.reporter == nil || c.Severity == SeverityOff || node == nil {
     return
   }
-  c.reporter.ReportFix(node, message, edits...)
+  if len(edits) == 0 {
+    c.reporter.Report(node, message)
+    return
+  }
+  fixer, ok := c.reporter.(fixReporter)
+  if !ok {
+    c.reporter.Report(node, message)
+    return
+  }
+  fixer.ReportFix(node, message, edits...)
 }
 
 // ReportRange records a finding at an explicit byte range inside the
 // current file.
 func (c *Context) ReportRange(pos, end int, message string) {
-  c.ReportRangeFix(pos, end, message)
+  if c == nil || c.reporter == nil || c.Severity == SeverityOff {
+    return
+  }
+  c.reporter.ReportRange(pos, end, message)
 }
 
 // ReportRangeFix records a finding at an explicit byte range with optional
-// autofix edits.
+// autofix edits. Older hosts that do not implement fix reporting receive the
+// diagnostic without edits.
 func (c *Context) ReportRangeFix(pos, end int, message string, edits ...TextEdit) {
   if c == nil || c.reporter == nil || c.Severity == SeverityOff {
     return
   }
-  c.reporter.ReportRangeFix(pos, end, message, edits...)
+  if len(edits) == 0 {
+    c.reporter.ReportRange(pos, end, message)
+    return
+  }
+  fixer, ok := c.reporter.(fixReporter)
+  if !ok {
+    c.reporter.ReportRange(pos, end, message)
+    return
+  }
+  fixer.ReportRangeFix(pos, end, message, edits...)
 }
 
 var registry []Rule

--- a/packages/lint/src/defineConfig.ts
+++ b/packages/lint/src/defineConfig.ts
@@ -29,24 +29,22 @@ import type { TtscLintPlugins } from "./structures/TtscLintPlugins";
  * The function is a pure pass-through at runtime. The generic gymnastics below
  * gather every `plugins` map across the array of config entries into one
  * intersected `TtscLintPlugins` shape that gets threaded back into the
- * `TtscLintConfig<P>` constraint. Without this, the default `P =
- * Record<string, ITtscLintPlugin>` widens `PluginRuleNames<P>` to
- * `${string}/${string}` and `{ "no-varXXX": "error" }`-style typos pass
- * through unchecked.
+ * `TtscLintConfig<P>` constraint. Without this, the default `P = Record<string,
+ * ITtscLintPlugin>` widens `PluginRuleNames<P>` to `${string}/${string}` and `{
+ * "no-varXXX": "error" }`-style typos pass through unchecked.
  */
-export function defineConfig<
-  const T extends TtscLintConfig<GatherPlugins<T>>,
->(config: T): T {
+export function defineConfig<const T extends TtscLintConfig<GatherPlugins<T>>>(
+  config: T,
+): T {
   return config;
 }
 
 /**
  * Walks the input type to collect every plugin map declared across entries.
  * Single entries yield the entry's `plugins`; arrays intersect every entry's
- * `plugins` so each entry's rule-name union remains valid for the whole
- * array. The intersection (vs. union) is load-bearing — TypeScript's
- * `keyof (A | B)` collapses to `never`, which would reject every namespaced
- * rule name.
+ * `plugins` so each entry's rule-name union remains valid for the whole array.
+ * The intersection (vs. union) is load-bearing — TypeScript's `keyof (A | B)`
+ * collapses to `never`, which would reject every namespaced rule name.
  */
 type GatherPlugins<T> = T extends { plugins?: infer P }
   ? P extends TtscLintPlugins

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -38,11 +38,11 @@ type TtscPluginFactoryContext<TConfig> = {
 const NAMESPACE_PATTERN = /^[a-z][a-z0-9_-]*$/;
 
 /**
- * Map a user-facing namespace (`react-hooks`) to a Go-valid sub-package
- * name (`react_hooks`). Required because ttsc's plugin builder uses the
- * `name` field as a directory and import-path suffix, both of which must
- * satisfy Go's stricter `[a-z][a-z0-9_]*` identifier rules. The function
- * is total over namespaces that already passed `NAMESPACE_PATTERN`.
+ * Map a user-facing namespace (`react-hooks`) to a Go-valid sub-package name
+ * (`react_hooks`). Required because ttsc's plugin builder uses the `name` field
+ * as a directory and import-path suffix, both of which must satisfy Go's
+ * stricter `[a-z][a-z0-9_]*` identifier rules. The function is total over
+ * namespaces that already passed `NAMESPACE_PATTERN`.
  */
 function goSubpackageName(namespace: string): string {
   return namespace.replace(/-/g, "_");

--- a/packages/lint/src/structures/ITtscLintPluginConfig.ts
+++ b/packages/lint/src/structures/ITtscLintPluginConfig.ts
@@ -72,9 +72,9 @@ export interface ITtscLintPluginConfig {
    *   new field and emits a one-time stderr deprecation notice. Removed in a
    *   future minor.
    *
-   *   The legacy shape is intentionally narrower than `rules`/`extends`: a
-   *   string (file path) or a flat rule-name → severity map. The Go-side
-   *   parser only accepts those two shapes; widening the TS type to the new
+   *   The legacy shape is intentionally narrower than `rules`/`extends`: a string
+   *   (file path) or a flat rule-name → severity map. The Go-side parser only
+   *   accepts those two shapes; widening the TS type to the new
    *   `TtscLintConfig` union would silently let `config: [{ rules: {...} }]`
    *   pass type-checking and fail at runtime.
    */

--- a/packages/lint/test/command/command_fix_applies_native_autofixes_test.go
+++ b/packages/lint/test/command/command_fix_applies_native_autofixes_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestCommandFixAppliesNativeAutofixes verifies fix rewrites native rule findings.
+//
+// Fix runs before the final diagnostic render and may need multiple native
+// passes: no-var first rewrites `var` to `let`, then prefer-const can see the
+// newly block-scoped declaration and rewrite it to `const`.
+//
+// 1. Create a project with no-var, prefer-const, and eqeqeq violations.
+// 2. Run the fix command with those native rules enabled.
+// 3. Assert the command succeeds and the source file contains the fixed text.
+func TestCommandFixAppliesNativeAutofixes(t *testing.T) {
+  root := seedLintProject(t, "var legacy = 1;\nlet stable = legacy;\nif (typeof stable == \"number\") { JSON.stringify(stable); }\n")
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "fix",
+      "--cwd", root,
+      "--plugins-json", lintManifest(t, map[string]string{
+        "eqeqeq":       "error",
+        "no-var":       "error",
+        "prefer-const": "error",
+      }),
+    })
+  })
+  if code != 0 || stdout != "" || stderr != "" {
+    t.Fatalf("fix command mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  got, err := os.ReadFile(filepath.Join(root, "src", "main.ts"))
+  if err != nil {
+    t.Fatalf("ReadFile: %v", err)
+  }
+  want := "const legacy = 1;\nconst stable = legacy;\nif (typeof stable === \"number\") { JSON.stringify(stable); }\n"
+  if string(got) != want {
+    t.Fatalf("fixed source mismatch:\nwant %q\ngot  %q", want, string(got))
+  }
+}

--- a/packages/lint/test/command/command_fix_rejects_emit_flag_test.go
+++ b/packages/lint/test/command/command_fix_rejects_emit_flag_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestCommandFixRejectsEmitFlag verifies fix refuses --emit before doing work.
+//
+// `ttsc fix` keeps emit disabled by contract — the host launcher already
+// guarantees this, but the sidecar must still fail loudly when a caller
+// bypasses the launcher and passes `--emit` directly. Otherwise fix could
+// silently emit JavaScript alongside the rewritten sources.
+//
+// 1. Run the lint sidecar's fix command with --emit attached.
+// 2. Capture stdout/stderr/status.
+// 3. Assert exit code 2 with the documented refusal message on stderr.
+func TestCommandFixRejectsEmitFlag(t *testing.T) {
+  root := seedLintProject(t, "const value = 1;\nJSON.stringify(value);\n")
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "fix",
+      "--emit",
+      "--cwd", root,
+      "--plugins-json", lintManifest(t, map[string]string{}),
+    })
+  })
+  if code != 2 {
+    t.Fatalf("expected exit code 2, got code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  if !strings.Contains(stderr, "@ttsc/lint fix: --emit is not supported") {
+    t.Fatalf("expected refusal message on stderr, got %q", stderr)
+  }
+}

--- a/packages/lint/test/engine/engine_dedupes_duplicate_kinds_in_visits_test.go
+++ b/packages/lint/test/engine/engine_dedupes_duplicate_kinds_in_visits_test.go
@@ -18,10 +18,10 @@ import (
 // engine wiring time, not in the rule itself, so both built-in and
 // contributor rules are covered transparently.
 //
-// 1. Register a custom rule whose `Visits()` returns the same Kind
-//    twice.
-// 2. Parse a source file that contains one node of that Kind.
-// 3. Run the engine and assert exactly one finding (not two).
+//  1. Register a custom rule whose `Visits()` returns the same Kind
+//     twice.
+//  2. Parse a source file that contains one node of that Kind.
+//  3. Run the engine and assert exactly one finding (not two).
 func TestEngineDedupesDuplicateKindsInVisits(t *testing.T) {
   // Defensive: `Register` panics on duplicates, so a `go test -count=N`
   // re-run would crash before `defer` could clean up. Drop any prior

--- a/packages/lint/test/eslint/run_external_eslint_fixes_reports_fixed_count_test.go
+++ b/packages/lint/test/eslint/run_external_eslint_fixes_reports_fixed_count_test.go
@@ -16,7 +16,7 @@ import (
 //
 // 1. Create a fake Node executable that returns an ESLint fix payload.
 // 2. Run the external ESLint fix bridge for one source file.
-// 3. Assert the bridge ran and reported the fixed file count.
+// 3. Assert the bridge reports the fixed file count.
 func TestRunExternalESLintFixesReportsFixedCount(t *testing.T) {
   root := t.TempDir()
   config := filepath.Join(root, "eslint.config.js")
@@ -30,11 +30,11 @@ func TestRunExternalESLintFixesReportsFixedCount(t *testing.T) {
 
   store := &ConfigStore{externalConfigPath: config, eslintRuntime: true}
   file := parseTSFile(t, filepath.Join(root, "src", "main.ts"), "var value = 1;\n")
-  fixed, ran, err := runExternalESLintFixes(store, root, []*shimast.SourceFile{file})
+  fixed, err := runExternalESLintFixes(store, root, []*shimast.SourceFile{file})
   if err != nil {
     t.Fatalf("runExternalESLintFixes: %v", err)
   }
-  if !ran || fixed != 2 {
-    t.Fatalf("fix bridge mismatch: ran=%v fixed=%d", ran, fixed)
+  if fixed != 2 {
+    t.Fatalf("fix bridge mismatch: fixed=%d", fixed)
   }
 }

--- a/packages/lint/test/eslint/run_external_eslint_fixes_reports_fixed_count_test.go
+++ b/packages/lint/test/eslint/run_external_eslint_fixes_reports_fixed_count_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestRunExternalESLintFixesReportsFixedCount verifies runtime fix plumbing.
+//
+// The fix command delegates ESLint-backed configs to the installed ESLint API.
+// The Go side only owns file-list encoding, missing-runtime handling, and the
+// fixed-count result that decides whether the Program must be reloaded.
+//
+// 1. Create a fake Node executable that returns an ESLint fix payload.
+// 2. Run the external ESLint fix bridge for one source file.
+// 3. Assert the bridge ran and reported the fixed file count.
+func TestRunExternalESLintFixesReportsFixedCount(t *testing.T) {
+  root := t.TempDir()
+  config := filepath.Join(root, "eslint.config.js")
+  writeFile(t, config, "export default [];")
+  fakeNode := filepath.Join(root, "fake-node")
+  writeFile(t, fakeNode, "#!/bin/sh\nprintf '{\"missing\":false,\"fixed\":2,\"results\":[]}'\n")
+  if err := os.Chmod(fakeNode, 0o755); err != nil {
+    t.Fatalf("chmod fake node: %v", err)
+  }
+  t.Setenv("TTSC_NODE_BINARY", fakeNode)
+
+  store := &ConfigStore{externalConfigPath: config, eslintRuntime: true}
+  file := parseTSFile(t, filepath.Join(root, "src", "main.ts"), "var value = 1;\n")
+  fixed, ran, err := runExternalESLintFixes(store, root, []*shimast.SourceFile{file})
+  if err != nil {
+    t.Fatalf("runExternalESLintFixes: %v", err)
+  }
+  if !ran || fixed != 2 {
+    t.Fatalf("fix bridge mismatch: ran=%v fixed=%d", ran, fixed)
+  }
+}

--- a/packages/lint/test/fix/fix_eqeqeq_replaces_same_type_literal_operator_test.go
+++ b/packages/lint/test/fix/fix_eqeqeq_replaces_same_type_literal_operator_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+// TestFixEqeqeqReplacesSameTypeLiteralOperator verifies eqeqeq literal autofix output.
+//
+// Same-type literal comparisons are safe under ESLint's eqeqeq fixer because
+// strict equality preserves the comparison result. The native fixer should
+// offer the same automatic edit for that branch.
+//
+// 1. Parse a source file with a loose comparison between two number literals.
+// 2. Apply the eqeqeq finding's text edit through the disk-backed fixer.
+// 3. Assert only the operator changes from `!=` to `!==`.
+func TestFixEqeqeqReplacesSameTypeLiteralOperator(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "eqeqeq",
+    "const changed = 1 != 2;\nJSON.stringify(changed);\n",
+    "const changed = 1 !== 2;\nJSON.stringify(changed);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_eqeqeq_replaces_typeof_operator_test.go
+++ b/packages/lint/test/fix/fix_eqeqeq_replaces_typeof_operator_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+// TestFixEqeqeqReplacesTypeofOperator verifies eqeqeq safe typeof autofix output.
+//
+// ESLint treats `typeof value == "string"` as safe to fix because `typeof`
+// always returns a string. The native fixer mirrors that branch and should
+// replace only the equality operator token.
+//
+// 1. Parse a source file with a loose typeof comparison.
+// 2. Apply the eqeqeq finding's text edit through the disk-backed fixer.
+// 3. Assert `==` changed to `===` without changing surrounding spaces.
+func TestFixEqeqeqReplacesTypeofOperator(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "eqeqeq",
+    "declare const value: unknown;\nif (typeof value == \"string\") { JSON.stringify(value); }\n",
+    "declare const value: unknown;\nif (typeof value === \"string\") { JSON.stringify(value); }\n",
+  )
+}

--- a/packages/lint/test/fix/fix_eqeqeq_skips_unsafe_identifier_comparison_test.go
+++ b/packages/lint/test/fix/fix_eqeqeq_skips_unsafe_identifier_comparison_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+// TestFixEqeqeqSkipsUnsafeIdentifierComparison verifies eqeqeq avoids unsafe autofix.
+//
+// A loose comparison between arbitrary identifiers can depend on JavaScript
+// coercion. The rule should still report the diagnostic, but the fix command
+// must not rewrite the operator automatically.
+//
+// 1. Parse a source file with `left == right`.
+// 2. Run eqeqeq and apply any offered text edits.
+// 3. Assert the source remains unchanged.
+func TestFixEqeqeqSkipsUnsafeIdentifierComparison(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "eqeqeq",
+    "declare const left: unknown;\ndeclare const right: unknown;\nif (left == right) { JSON.stringify(left); }\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_replaces_var_keyword_test.go
+++ b/packages/lint/test/fix/fix_no_var_replaces_var_keyword_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+// TestFixNoVarReplacesVarKeyword verifies no-var autofix output.
+//
+// The no-var fixer is intentionally token-scoped: it should replace only the
+// declaration keyword and leave declarations, spacing, and trailing code
+// untouched.
+//
+// 1. Parse a source file with one `var` declaration.
+// 2. Apply the no-var finding's text edit through the disk-backed fixer.
+// 3. Assert only `var` changed to `let`.
+func TestFixNoVarReplacesVarKeyword(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-var",
+    "var legacy = 1;\nJSON.stringify(legacy);\n",
+    "let legacy = 1;\nJSON.stringify(legacy);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_prefer_const_replaces_single_let_keyword_test.go
+++ b/packages/lint/test/fix/fix_prefer_const_replaces_single_let_keyword_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+// TestFixPreferConstReplacesSingleLetKeyword verifies prefer-const autofix output.
+//
+// A single initialized `let` declaration can be rewritten by replacing the
+// declaration keyword. The edit must not touch the binding name, initializer,
+// comments, or statement terminator.
+//
+// 1. Parse a source file with an initialized `let` that is never reassigned.
+// 2. Apply the prefer-const finding's text edit through the disk-backed fixer.
+// 3. Assert only `let` changed to `const`.
+func TestFixPreferConstReplacesSingleLetKeyword(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "prefer-const",
+    "let stable = 1;\nJSON.stringify(stable);\n",
+    "const stable = 1;\nJSON.stringify(stable);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_prefer_const_skips_multi_declaration_list_test.go
+++ b/packages/lint/test/fix/fix_prefer_const_skips_multi_declaration_list_test.go
@@ -1,0 +1,17 @@
+package main
+
+import "testing"
+
+// TestFixPreferConstSkipsMultiDeclarationList verifies conservative prefer-const fixing.
+//
+// The current native rule reports each declaration in a multi-declaration
+// `let` list independently. Replacing the shared keyword would affect every
+// declaration in the list, so the fixer must leave that source unchanged until
+// the rule can split declarations safely.
+//
+// 1. Parse a `let` declaration list with two never-reassigned bindings.
+// 2. Run prefer-const and apply any offered text edits.
+// 3. Assert diagnostics exist but no automatic edit is applied.
+func TestFixPreferConstSkipsMultiDeclarationList(t *testing.T) {
+  assertNoFixSnapshot(t, "prefer-const", "let left = 1, right = 2;\nJSON.stringify(left + right);\n")
+}

--- a/packages/lint/test/fix/fix_select_text_edits_drops_duplicate_edits_test.go
+++ b/packages/lint/test/fix/fix_select_text_edits_drops_duplicate_edits_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+// TestFixSelectTextEditsDropsDuplicateEdits verifies dedup independent of overlap.
+//
+// selectTextEdits keeps the source single-pass deterministic by deduping
+// byte-identical edits before the overlap filter runs. The dedup branch
+// composes with sort stability, so a refactor that swaps the `seen` key
+// shape or replaces the map with a position-only set must not change the
+// surviving-edit count under identical inputs.
+//
+// 1. Build three edits where the first two are byte-identical and the third
+//    targets a disjoint range.
+// 2. Run `selectTextEdits` against a synthetic source length.
+// 3. Assert exactly two edits survive and both ranges are accounted for.
+func TestFixSelectTextEditsDropsDuplicateEdits(t *testing.T) {
+  duplicate := TextEdit{Pos: 0, End: 3, Text: "let"}
+  edits := []TextEdit{
+    duplicate,
+    duplicate,
+    {Pos: 5, End: 8, Text: "var"},
+  }
+  selected := selectTextEdits(10, edits)
+  if len(selected) != 2 {
+    t.Fatalf("expected 2 surviving edits, got %d (%+v)", len(selected), selected)
+  }
+  if selected[0] != duplicate {
+    t.Fatalf("expected first surviving edit to be the dedup'd entry, got %+v", selected[0])
+  }
+  if selected[1].Pos != 5 || selected[1].End != 8 || selected[1].Text != "var" {
+    t.Fatalf("expected second surviving edit to be the disjoint entry, got %+v", selected[1])
+  }
+}

--- a/packages/lint/test/fix/fix_select_text_edits_drops_overlapping_ranges_test.go
+++ b/packages/lint/test/fix/fix_select_text_edits_drops_overlapping_ranges_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+// TestFixSelectTextEditsDropsOverlappingRanges verifies overlap policy.
+//
+// `selectTextEdits` is the gate that prevents two rule fixes from clobbering
+// each other when their edit ranges intersect. The policy is "first one in
+// sort order wins" so the function must drop any edit whose start sits before
+// the previously-accepted edit's end.
+//
+// 1. Build two edits whose ranges overlap on a shared source position.
+// 2. Run `selectTextEdits` against the synthetic source length.
+// 3. Assert only the earlier-starting edit survives.
+func TestFixSelectTextEditsDropsOverlappingRanges(t *testing.T) {
+  edits := []TextEdit{
+    {Pos: 0, End: 5, Text: "first"},
+    {Pos: 3, End: 8, Text: "later"},
+  }
+  selected := selectTextEdits(10, edits)
+  if len(selected) != 1 {
+    t.Fatalf("expected 1 surviving edit, got %d (%+v)", len(selected), selected)
+  }
+  if selected[0].Pos != 0 || selected[0].End != 5 || selected[0].Text != "first" {
+    t.Fatalf("unexpected surviving edit: %+v", selected[0])
+  }
+}

--- a/packages/lint/test/plugin/public_rule_context_accepts_legacy_reporter_test.go
+++ b/packages/lint/test/plugin/public_rule_context_accepts_legacy_reporter_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestPublicRuleContextAcceptsLegacyReporter verifies contributor reporter compatibility.
+//
+// ReportFix is a new convenience on the public contributor Context, but the
+// existing Reporter interface must remain source-compatible for contributor
+// tests or helpers that implement only Report and ReportRange.
+//
+// 1. Construct a public rule.Context with a legacy two-method Reporter.
+// 2. Call ReportRangeFix with one text edit.
+// 3. Assert the diagnostic falls back to ReportRange instead of requiring a new method.
+func TestPublicRuleContextAcceptsLegacyReporter(t *testing.T) {
+  reporter := &legacyReporter{}
+  ctx := rule.NewContext(nil, nil, rule.SeverityError, reporter)
+  ctx.ReportRangeFix(1, 2, "message", rule.TextEdit{Pos: 1, End: 2, Text: "x"})
+  if reporter.ranges != 1 {
+    t.Fatalf("legacy reporter should receive ReportRange fallback, got %d", reporter.ranges)
+  }
+}
+
+type legacyReporter struct {
+  ranges int
+}
+
+func (r *legacyReporter) Report(_ *shimast.Node, _ string) {}
+
+func (r *legacyReporter) ReportRange(_, _ int, _ string) {
+  r.ranges++
+}

--- a/packages/lint/test/shared/helpers_test.go
+++ b/packages/lint/test/shared/helpers_test.go
@@ -284,3 +284,55 @@ func lintManifest(t *testing.T, rules map[string]string) string {
   }
   return string(data)
 }
+
+// assertFixSnapshot runs one rule's findings through the native fix applier.
+//
+// Fixer tests need the real file-writing path, not just in-memory edit
+// selection, because RunFix reloads a fresh Program from disk after every pass.
+//
+// 1. Materialize a real source file and parse it through the shim parser.
+// 2. Run one enabled rule and apply collected text edits to disk.
+// 3. Compare the rewritten source exactly.
+func assertFixSnapshot(t *testing.T, ruleName, source, expected string) {
+  t.Helper()
+  got, fixed := runFixSnapshot(t, ruleName, source)
+  if fixed == 0 {
+    t.Fatalf("%s: expected at least one applied fix", ruleName)
+  }
+  if got != expected {
+    t.Fatalf("%s fixed source mismatch:\nwant %q\ngot  %q", ruleName, expected, got)
+  }
+}
+
+// assertNoFixSnapshot verifies a reported rule does not offer automatic edits.
+func assertNoFixSnapshot(t *testing.T, ruleName, source string) {
+  t.Helper()
+  got, fixed := runFixSnapshot(t, ruleName, source)
+  if fixed != 0 {
+    t.Fatalf("%s: expected no applied fixes, got %d", ruleName, fixed)
+  }
+  if got != source {
+    t.Fatalf("%s source should remain unchanged:\nwant %q\ngot  %q", ruleName, source, got)
+  }
+}
+
+func runFixSnapshot(t *testing.T, ruleName, source string) (string, int) {
+  t.Helper()
+  root := t.TempDir()
+  filePath := filepath.Join(root, "src", "main.ts")
+  writeFile(t, filePath, source)
+  file := parseTSFile(t, filePath, source)
+  findings := NewEngine(RuleConfig{ruleName: SeverityError}).Run([]*shimast.SourceFile{file}, nil)
+  if len(findings) == 0 {
+    t.Fatalf("%s: expected at least one finding", ruleName)
+  }
+  fixed, err := applyFindingFixes(root, findings)
+  if err != nil {
+    t.Fatalf("%s: applyFindingFixes: %v", ruleName, err)
+  }
+  got, err := os.ReadFile(filePath)
+  if err != nil {
+    t.Fatalf("%s: ReadFile: %v", ruleName, err)
+  }
+  return string(got), fixed
+}

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -298,7 +298,7 @@ function createNativeCheckArgs(
   options: TtscBuildOptions,
 ): string[] {
   const args = [
-    "check",
+    options.fix === true ? "fix" : "check",
     "--tsconfig=" + execution.tsconfig,
     "--plugins-json=" + serializeNativePlugins(execution.nativePlugins),
     "--cwd=" + execution.projectRoot,

--- a/packages/ttsc/src/launcher/internal/runTtsc.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsc.ts
@@ -34,6 +34,8 @@ export function runTtsc(
         return runCompatibleBuild(rest, false);
       case "check":
         return runCompatibleBuild(rest, true);
+      case "fix":
+        return runCompatibleBuild(["--fix", ...rest], true);
       case "clean":
         return runClean(rest);
       case "prepare":
@@ -73,13 +75,24 @@ function runCompatibleBuild(
   checkOnly: boolean,
 ): number {
   const options = normalizeBuildOptions(parseBuildArgs(argv, checkOnly));
+  if (options.fix) {
+    options.emit = false;
+  }
   if (options.watch) {
+    if (options.fix) {
+      throw new Error("ttsc: fix does not support watch mode");
+    }
     return runWatch(options, checkOnly);
   }
   if (options.files.length !== 0) {
+    if (options.fix) {
+      throw new Error("ttsc: fix requires a project, not single-file mode");
+    }
     return runSingleFile(options);
   }
-  const result = runBuild(checkOnly ? { ...options, emit: false } : options);
+  const result = runBuild(
+    checkOnly || options.fix ? { ...options, emit: false } : options,
+  );
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);
   return result.status;
@@ -268,6 +281,7 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
   let cwd: string | undefined;
   let emit: boolean | undefined = checkOnly ? false : undefined;
   const files: string[] = [];
+  let fix = false;
   let outDir: string | undefined;
   let preserveWatchOutput = false;
   let quiet = true;
@@ -280,6 +294,10 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
     switch (current) {
       case "--emit":
         emit = true;
+        break;
+      case "--fix":
+        fix = true;
+        emit = false;
         break;
       case "--noEmit":
         emit = false;
@@ -325,6 +343,9 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
           tsconfig = current.slice("--tsconfig=".length);
         } else if (current.startsWith("--project=")) {
           tsconfig = current.slice("--project=".length);
+        } else if (current.startsWith("--fix=")) {
+          fix = current.slice("--fix=".length) !== "false";
+          if (fix) emit = false;
         } else if (current.startsWith("--preserveWatchOutput=")) {
           preserveWatchOutput =
             current.slice("--preserveWatchOutput=".length) !== "false";
@@ -348,6 +369,7 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
     cwd,
     emit,
     files,
+    fix,
     outDir,
     preserveWatchOutput,
     quiet,
@@ -366,6 +388,7 @@ function printHelp(): void {
       "  ttsc -p tsconfig.json",
       "  ttsc --watch",
       "  ttsc --noEmit",
+      "  ttsc fix",
       "  ttsc prepare [options]",
       "  ttsc clean [options]",
       "  ttsc version",
@@ -376,6 +399,7 @@ function printHelp(): void {
       "  --tsconfig <file>      Resolve project settings from this tsconfig",
       "  --cwd <dir>            Resolve project-relative paths from this directory",
       "  --emit                 Force emitted files during build",
+      "  --fix                  Run fix-capable check plugins and rewrite source files",
       "  --noEmit               Force analysis-only build with no file writes",
       "  -w, --watch            Rebuild when project files change",
       "  --preserveWatchOutput  Do not clear the screen between watch rebuilds",
@@ -393,6 +417,7 @@ function printHelp(): void {
       "Compatibility aliases:",
       "  ttsc build [options]       Same project build lane as `ttsc [options]`.",
       "  ttsc check [options]       Same as `ttsc --noEmit [options]`.",
+      "  ttsc fix [options]         Apply check-plugin fixes, then run `ttsc --noEmit`.",
       "  ttsc prepare [options]     Build configured source-plugin binaries into cache.",
       "  ttsc clean [options]       Delete local source-plugin cache directories.",
     ].join("\n"),

--- a/packages/ttsc/src/launcher/internal/runTtsc.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsc.ts
@@ -80,7 +80,9 @@ function runCompatibleBuild(
   }
   if (options.watch) {
     if (options.fix) {
-      throw new Error("ttsc: fix does not support watch mode");
+      throw new Error(
+        "ttsc: fix does not support watch mode; use ttsc --noEmit --watch for incremental checks",
+      );
     }
     return runWatch(options, checkOnly);
   }
@@ -280,6 +282,7 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
   let cacheDir: string | undefined;
   let cwd: string | undefined;
   let emit: boolean | undefined = checkOnly ? false : undefined;
+  let emitForced = false;
   const files: string[] = [];
   let fix = false;
   let outDir: string | undefined;
@@ -294,6 +297,7 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
     switch (current) {
       case "--emit":
         emit = true;
+        emitForced = true;
         break;
       case "--fix":
         fix = true;
@@ -363,6 +367,9 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
         break;
     }
   }
+  if (fix && emitForced) {
+    throw new Error("ttsc: --fix and --emit are mutually exclusive");
+  }
   return {
     binary,
     cacheDir,
@@ -399,7 +406,8 @@ function printHelp(): void {
       "  --tsconfig <file>      Resolve project settings from this tsconfig",
       "  --cwd <dir>            Resolve project-relative paths from this directory",
       "  --emit                 Force emitted files during build",
-      "  --fix                  Run fix-capable check plugins and rewrite source files",
+      "  --fix                  Run fix-capable check plugins and rewrite source files.",
+      "                         Incompatible with --watch, --emit, single-file mode.",
       "  --noEmit               Force analysis-only build with no file writes",
       "  -w, --watch            Rebuild when project files change",
       "  --preserveWatchOutput  Do not clear the screen between watch rebuilds",

--- a/packages/ttsc/src/structures/ITtscPlugin.ts
+++ b/packages/ttsc/src/structures/ITtscPlugin.ts
@@ -61,7 +61,9 @@ export interface ITtscPlugin {
    * Pipeline stage implemented by the sidecar.
    *
    * Omit this field for normal compiler-transform plugins. The only explicit
-   * non-transform stage is `"check"`.
+   * non-transform stage is `"check"`. Check-stage plugins receive `check`
+   * during normal builds and may implement `fix` for `ttsc fix` / `ttsc
+   * --fix`.
    *
    * @default "transform"
    */

--- a/packages/ttsc/src/structures/ITtscPluginContributor.ts
+++ b/packages/ttsc/src/structures/ITtscPluginContributor.ts
@@ -11,8 +11,8 @@ export interface ITtscPluginContributor {
    *
    * Forms the final import path together with the host plugin's Go module path;
    * must match `/^[a-z][a-z0-9_]*$/` — a lowercase ASCII letter followed by
-   * lowercase letters, digits, or underscores — and be unique within one
-   * plugin build.
+   * lowercase letters, digits, or underscores — and be unique within one plugin
+   * build.
    */
   name: string;
 

--- a/packages/ttsc/src/structures/TtscPluginStage.ts
+++ b/packages/ttsc/src/structures/TtscPluginStage.ts
@@ -3,8 +3,9 @@
  *
  * - `"transform"`: participates in the TypeScript-Go transform path. Transform
  *   plugins do not receive emitted JavaScript or emitted file text.
- * - `"check"`: runs before emit and reports diagnostics only. Use this for lint
- *   or validation plugins that should fail the compile before JavaScript or
- *   declaration output is generated.
+ * - `"check"`: runs before emit and reports diagnostics. Use this for lint or
+ *   validation plugins that should fail the compile before JavaScript or
+ *   declaration output is generated. Check plugins may also implement a `fix`
+ *   command, which `ttsc fix` invokes with emit disabled.
  */
 export type TtscPluginStage = "transform" | "check";

--- a/packages/ttsc/src/structures/internal/TtscBuildOptions.ts
+++ b/packages/ttsc/src/structures/internal/TtscBuildOptions.ts
@@ -12,6 +12,11 @@ export interface TtscBuildOptions extends TtscCommonOptions {
    * - `undefined`: follow the resolved tsconfig exactly.
    */
   emit?: boolean;
+  /**
+   * Invoke fix-capable check-stage plugins before the final no-emit check.
+   * Source files may be rewritten; JavaScript/declaration emit stays disabled.
+   */
+  fix?: boolean;
   /** Per-call TypeScript-Go `outDir` override. */
   outDir?: string;
   /** Suppress summary banners from ttsc/native sidecars. Defaults to `true`. */

--- a/scripts/build-platform-package.cjs
+++ b/scripts/build-platform-package.cjs
@@ -217,7 +217,8 @@ function copyPrunedGoRoot(sourceRoot, targetRoot) {
 
 function copyRecursive(current, target, rootDir) {
   const rel = path.relative(rootDir, current).replace(/\\/g, "/");
-  const stat = fs.lstatSync(current);
+  const linkStat = fs.lstatSync(current);
+  const stat = linkStat.isSymbolicLink() ? fs.statSync(current) : linkStat;
   if (stat.isDirectory()) {
     if (!shouldCopyGoPath(rel, true)) return;
     fs.mkdirSync(target, { recursive: true });
@@ -308,6 +309,14 @@ function verifyEmbeddedGoToolchain() {
     throw new Error(
       `build-platform-package: bundled Go compiler missing after copy: ${embeddedGo}`,
     );
+  }
+  for (const rel of ["src/fmt", "src/encoding/json"]) {
+    const required = path.join(bundledGoDir, rel);
+    if (!fs.existsSync(required)) {
+      throw new Error(
+        `build-platform-package: bundled Go compiler missing standard library source: ${required}`,
+      );
+    }
   }
 }
 

--- a/tests/test-lint/fixtures/fix-projects/native-fixes/expected/main.ts
+++ b/tests/test-lint/fixtures/fix-projects/native-fixes/expected/main.ts
@@ -1,0 +1,12 @@
+const legacy = 1;
+const stable = legacy;
+let untouched = legacy;
+untouched += 1;
+
+if (typeof stable === "number") {
+  JSON.stringify(stable);
+}
+
+if (stable == untouched) {
+  JSON.stringify(untouched);
+}

--- a/tests/test-lint/fixtures/fix-projects/native-fixes/src/main.ts
+++ b/tests/test-lint/fixtures/fix-projects/native-fixes/src/main.ts
@@ -1,0 +1,12 @@
+var legacy = 1;
+let stable = legacy;
+let untouched = legacy;
+untouched += 1;
+
+if (typeof stable == "number") {
+  JSON.stringify(stable);
+}
+
+if (stable == untouched) {
+  JSON.stringify(untouched);
+}

--- a/tests/test-lint/fixtures/fix-projects/native-fixes/tsconfig.json
+++ b/tests/test-lint/fixtures/fix-projects/native-fixes/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "noEmit": true,
+    "rootDir": "src",
+    "plugins": [
+      {
+        "transform": "@ttsc/lint",
+        "rules": {
+          "eqeqeq": "warning",
+          "no-var": "error",
+          "prefer-const": "error"
+        }
+      }
+    ]
+  },
+  "include": ["src"]
+}

--- a/tests/test-lint/src/features/config/test_lint_config_file_wrapper_tsconfig_outside_cwd_discovers_wrapper_config.ts
+++ b/tests/test-lint/src/features/config/test_lint_config_file_wrapper_tsconfig_outside_cwd_discovers_wrapper_config.ts
@@ -69,7 +69,7 @@ export const test_lint_config_file_wrapper_tsconfig_outside_cwd_discovers_wrappe
         result.diagnostics.map((d) => [d.messageText, d.category]),
         [
           [
-            "[no-var] Unexpected var, use let or const instead.\n  ~~~~~~~~~~~~~~",
+            "[no-var] Unexpected var, use let or const instead.\n  ~~~",
             "error",
           ],
         ],

--- a/tests/test-lint/src/features/fix/test_lint_fix_native_project_rewrites_temp_copy_only.ts
+++ b/tests/test-lint/src/features/fix/test_lint_fix_native_project_rewrites_temp_copy_only.ts
@@ -1,0 +1,94 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Verifies lint fix: native project fixture rewrites only the temp copy.
+ *
+ * Locks the observable `ttsc --fix` behavior against a checked-in project
+ * fixture. The source fixture must stay immutable; the command runs against a
+ * writable copy so the test can inspect real file changes without damaging the
+ * repository baseline.
+ *
+ * 1. Copy `fixtures/fix-projects/native-fixes` into a temp project.
+ * 2. Run `ttsc --fix` through the real launcher with `@ttsc/lint` linked.
+ * 3. Assert the temp source matches `expected/main.ts` and the fixture source is
+ *    unchanged.
+ */
+export const test_lint_fix_native_project_rewrites_temp_copy_only = () => {
+  const fixture = path.join(
+    process.cwd(),
+    "fixtures",
+    "fix-projects",
+    "native-fixes",
+  );
+  const originalSource = fs.readFileSync(
+    path.join(fixture, "src", "main.ts"),
+    "utf8",
+  );
+  const expectedSource = fs.readFileSync(
+    path.join(fixture, "expected", "main.ts"),
+    "utf8",
+  );
+  const root = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-lint-fix-project-")),
+    "project",
+  );
+
+  try {
+    fs.cpSync(fixture, root, { recursive: true });
+    linkLintPackage(root);
+
+    const result = TestProject.spawn(
+      TestProject.TTSC_BIN,
+      ["--cwd", root, "--fix"],
+      {
+        cwd: root,
+        env: {
+          PATH: goPath(),
+          TTSC_CACHE_DIR: fs.mkdtempSync(
+            path.join(os.tmpdir(), "ttsc-lint-fix-cache-"),
+          ),
+          TTSC_GO_BINARY: goBinary(),
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stderr, /\[eqeqeq\]/);
+    assert.equal(
+      fs.readFileSync(path.join(root, "src", "main.ts"), "utf8"),
+      expectedSource,
+    );
+    assert.equal(
+      fs.readFileSync(path.join(fixture, "src", "main.ts"), "utf8"),
+      originalSource,
+    );
+  } finally {
+    fs.rmSync(path.dirname(root), { recursive: true, force: true });
+  }
+};
+
+function linkLintPackage(root: string): void {
+  const linkDir = path.join(root, "node_modules", "@ttsc");
+  fs.mkdirSync(linkDir, { recursive: true });
+  fs.symlinkSync(
+    path.join(TestProject.WORKSPACE_ROOT, "packages", "lint"),
+    path.join(linkDir, "lint"),
+    "junction",
+  );
+}
+
+function goPath(): string | undefined {
+  const localGo = path.join(os.homedir(), "go-sdk", "go", "bin");
+  return fs.existsSync(localGo)
+    ? `${localGo}${path.delimiter}${process.env.PATH ?? ""}`
+    : process.env.PATH;
+}
+
+function goBinary(): string {
+  const localGo = path.join(os.homedir(), "go-sdk", "go", "bin", "go");
+  return fs.existsSync(localGo) ? localGo : "go";
+}

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_rejects_fix_in_single_file_mode.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_rejects_fix_in_single_file_mode.ts
@@ -1,0 +1,41 @@
+import {
+  assert,
+  createProject,
+  spawn,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies ttsc rejects --fix when a positional file is passed.
+ *
+ * Fix mode needs the full tsconfig program so check-stage plugins can reload
+ * the Program between passes. Single-file mode bypasses tsconfig discovery, so
+ * the launcher refuses to mix them before spawning any plugin.
+ *
+ * 1. Materialize a tsconfig project with one source file.
+ * 2. Run `ttsc --fix src/main.ts` through the real launcher.
+ * 3. Assert non-zero exit and the documented refusal message on stderr.
+ */
+export const test_ttsc_rejects_fix_in_single_file_mode = () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+        noEmit: true,
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const value = 1;\n`,
+  });
+
+  const result = spawn(ttscBin, ["--fix", "src/main.ts", "--cwd", root], {
+    cwd: root,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /fix requires a project/);
+};

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_rejects_fix_with_emit_flag.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_rejects_fix_with_emit_flag.ts
@@ -1,0 +1,42 @@
+import {
+  assert,
+  createProject,
+  spawn,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies ttsc rejects --fix combined with --emit.
+ *
+ * Fix mode keeps JavaScript and declaration emit disabled — combining it with
+ * --emit silently let the last flag win before this guard. The launcher now
+ * fails fast with a clear message so a misconfigured wrapper script does not
+ * accidentally write build artifacts during an autofix pass.
+ *
+ * 1. Materialize a tsconfig project with one source file.
+ * 2. Run `ttsc --fix --emit` through the real launcher.
+ * 3. Assert non-zero exit and the mutual-exclusion message on stderr.
+ */
+export const test_ttsc_rejects_fix_with_emit_flag = () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+        noEmit: true,
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const value = 1;\n`,
+  });
+
+  const result = spawn(ttscBin, ["--fix", "--emit", "--cwd", root], {
+    cwd: root,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--fix and --emit are mutually exclusive/);
+};

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_rejects_fix_with_watch_mode.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_rejects_fix_with_watch_mode.ts
@@ -1,0 +1,42 @@
+import {
+  assert,
+  createProject,
+  spawn,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies ttsc rejects --fix combined with --watch.
+ *
+ * Watch mode rebuilds on file changes, so combining it with a one-shot
+ * source-rewriting pass would loop the watcher against its own edits. The
+ * launcher refuses the combination before any plugin spawns; this test pins
+ * the user-facing error message and exit path.
+ *
+ * 1. Materialize a minimal tsconfig project.
+ * 2. Run `ttsc --fix --watch` through the real launcher.
+ * 3. Assert non-zero exit and the documented refusal message on stderr.
+ */
+export const test_ttsc_rejects_fix_with_watch_mode = () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+        noEmit: true,
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const value = 1;\n`,
+  });
+
+  const result = spawn(ttscBin, ["--fix", "--watch", "--cwd", root], {
+    cwd: root,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /fix does not support watch mode/);
+};

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_reports_help_text_for_public_commands.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_reports_help_text_for_public_commands.ts
@@ -25,4 +25,5 @@ export const test_ttsc_reports_help_text_for_public_commands = () => {
   assert.match(result.stdout, /ttsc prepare \[options\]/);
   assert.match(result.stdout, /ttsc clean \[options\]/);
   assert.match(result.stdout, /Plugin contract:/);
+  assert.match(result.stdout, /Incompatible with --watch, --emit, single-file mode\./);
 };

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_contributor_duplicate_names_are_rejected.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_contributor_duplicate_names_are_rejected.ts
@@ -6,21 +6,20 @@ import {
 } from "../../internal/plugin-corpus";
 
 /**
- * Verifies plugin corpus: two contributors with the same name fail
- * validation before the host binary is built.
+ * Verifies plugin corpus: two contributors with the same name fail validation
+ * before the host binary is built.
  *
  * Pins one half of the contributor uniqueness invariant: the synthesized
  * `ttsc_contributions.go` blank-imports one Go sub-package per name, so a
  * duplicate would either silently overwrite the earlier copy or trigger an
- * opaque Go build error far downstream. ttsc must reject the descriptor at
- * load time with a message that names both the host plugin and the
- * offending name.
+ * opaque Go build error far downstream. ttsc must reject the descriptor at load
+ * time with a message that names both the host plugin and the offending name.
  *
- * 1. Materialize a host plugin whose factory declares two contributors that
- *    share the same `name`.
+ * 1. Materialize a host plugin whose factory declares two contributors that share
+ *    the same `name`.
  * 2. Run ttsc and capture its stderr.
- * 3. Assert non-zero exit and a stderr that contains "duplicate" and the
- *    repeated name.
+ * 3. Assert non-zero exit and a stderr that contains "duplicate" and the repeated
+ *    name.
  */
 export const test_plugin_corpus_contributor_duplicate_names_are_rejected =
   () => {
@@ -44,10 +43,8 @@ export const test_plugin_corpus_contributor_duplicate_names_are_rejected =
             ],
           });
         `,
-        "plugins/source/go.mod":
-          "module example.com/host\n\ngo 1.26\n",
-        "plugins/source/main.go":
-          "package main\n\nfunc main() {}\n",
+        "plugins/source/go.mod": "module example.com/host\n\ngo 1.26\n",
+        "plugins/source/main.go": "package main\n\nfunc main() {}\n",
         "plugins/contrib_a/a.go": "package dupe\n",
         "plugins/contrib_b/b.go": "package dupe\n",
       },

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_contributor_with_own_go_mod_is_rejected.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_contributor_with_own_go_mod_is_rejected.ts
@@ -9,17 +9,17 @@ import {
 } from "../../internal/plugin-corpus";
 
 /**
- * Verifies plugin corpus: a contributor that ships its own `go.mod` is
- * rejected before any compilation happens.
+ * Verifies plugin corpus: a contributor that ships its own `go.mod` is rejected
+ * before any compilation happens.
  *
- * Locks the supply-chain firewall added with the `contributors` mechanism:
- * a contributor must compile inside the host plugin's module graph so that
- * every transitive Go dependency is resolved through the host's pinned
- * `go.sum`. A contributor with its own `go.mod` would silently pull in
- * arbitrary modules at build time; ttsc must refuse to merge it.
+ * Locks the supply-chain firewall added with the `contributors` mechanism: a
+ * contributor must compile inside the host plugin's module graph so that every
+ * transitive Go dependency is resolved through the host's pinned `go.sum`. A
+ * contributor with its own `go.mod` would silently pull in arbitrary modules at
+ * build time; ttsc must refuse to merge it.
  *
- * 1. Materialize a host plugin whose factory declares one contributor whose
- *    source directory contains a `go.mod` file.
+ * 1. Materialize a host plugin whose factory declares one contributor whose source
+ *    directory contains a `go.mod` file.
  * 2. Run ttsc and capture its stderr.
  * 3. Assert non-zero exit and a stderr message that names the offending
  *    contributor and points at the `go.mod` path.
@@ -42,12 +42,9 @@ export const test_plugin_corpus_contributor_with_own_go_mod_is_rejected =
             ],
           });
         `,
-        "plugins/source/go.mod":
-          "module example.com/host\n\ngo 1.26\n",
-        "plugins/source/main.go":
-          "package main\n\nfunc main() {}\n",
-        "plugins/rogue/go.mod":
-          "module example.com/rogue\n\ngo 1.26\n",
+        "plugins/source/go.mod": "module example.com/host\n\ngo 1.26\n",
+        "plugins/source/main.go": "package main\n\nfunc main() {}\n",
+        "plugins/rogue/go.mod": "module example.com/rogue\n\ngo 1.26\n",
         "plugins/rogue/rule.go": "package rogue\n",
       },
     );
@@ -64,6 +61,9 @@ export const test_plugin_corpus_contributor_with_own_go_mod_is_rejected =
       0,
       `expected non-zero exit; stderr:\n${result.stderr}`,
     );
-    assert.match(result.stderr, /contributor "rogue" must ship Go source as a package/);
+    assert.match(
+      result.stderr,
+      /contributor "rogue" must ship Go source as a package/,
+    );
     assert.match(result.stderr, /go\.mod found/);
   };

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_fix_rewrites_source_before_final_check.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_fix_rewrites_source_before_final_check.ts
@@ -1,0 +1,70 @@
+import {
+  assert,
+  commonJsProject,
+  fs,
+  goPath,
+  os,
+  path,
+  spawn,
+  ttscBin,
+  workspaceRoot,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: @ttsc/lint fix rewrites source before final check.
+ *
+ * This pins the user-facing `ttsc fix` path, not just the native sidecar. The
+ * launcher must route fix mode to check-stage plugins, and the lint sidecar
+ * must reload the project before reporting remaining diagnostics.
+ *
+ * 1. Materialize a project with fixable native lint violations.
+ * 2. Run `ttsc fix` through the real launcher and source-plugin cache.
+ * 3. Assert the source file is rewritten and no JavaScript output is emitted.
+ */
+export const test_plugin_corpus_ttsc_lint_fix_rewrites_source_before_final_check =
+  () => {
+    const root = commonJsProject(
+      {
+        "src/main.ts": `var legacy = 1;\nlet stable = legacy;\nif (typeof stable == "number") { JSON.stringify(stable); }\n`,
+      },
+      {
+        compilerOptions: {
+          plugins: [
+            {
+              transform: "@ttsc/lint",
+              rules: {
+                eqeqeq: "error",
+                "no-var": "error",
+                "prefer-const": "error",
+              },
+            },
+          ],
+        },
+      },
+    );
+    const linkDir = path.join(root, "node_modules", "@ttsc");
+    fs.mkdirSync(linkDir, { recursive: true });
+    fs.symlinkSync(
+      path.join(workspaceRoot, "packages", "lint"),
+      path.join(linkDir, "lint"),
+      "junction",
+    );
+
+    const goBinary = path.join(os.homedir(), "go-sdk", "go", "bin", "go");
+    const result = spawn(ttscBin, ["fix", "--cwd", root], {
+      cwd: root,
+      env: {
+        PATH: goPath(),
+        TTSC_CACHE_DIR: fs.mkdtempSync(
+          path.join(os.tmpdir(), "ttsc-lint-fix-"),
+        ),
+        TTSC_GO_BINARY: fs.existsSync(goBinary) ? goBinary : "go",
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      fs.readFileSync(path.join(root, "src", "main.ts"), "utf8"),
+      'const legacy = 1;\nconst stable = legacy;\nif (typeof stable === "number") { JSON.stringify(stable); }\n',
+    );
+    assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), false);
+  };


### PR DESCRIPTION
This pull request adds autofix ("fix") support to `@ttsc/lint`, allowing users to automatically apply supported lint fixes using `ttsc fix` or `ttsc --fix`. It introduces a new fix command, extends the lint engine and ESLint integration to support autofixes, and updates documentation to describe the new workflow. The implementation includes a new `fix.go` file for applying and managing text edits, and updates the plugin API to allow rules to report autofix edits.

**Major features and changes:**

### Fix Command and Workflow

* Adds a new `fix` subcommand to `@ttsc/lint`, implemented in the new `fix.go` file, which applies autofixes (both native and ESLint-based), reloads the program as needed, and then reports any remaining diagnostics without emitting JavaScript. (`packages/lint/plugin/fix.go`, `packages/lint/plugin/main.go`) [[1]](diffhunk://#diff-dafb4fe32856e152afbf374c41e5331d26bdcc9e27233a922f1dd941405ad1e5R1-R214) [[2]](diffhunk://#diff-189c3a2a64a42619d898db8f012ddc000b7d70fa5547c9d75bce5d964a225884R9) [[3]](diffhunk://#diff-189c3a2a64a42619d898db8f012ddc000b7d70fa5547c9d75bce5d964a225884L31-R40)
* Updates documentation to describe the new `ttsc fix` command, its usage, and which rules are currently autofixable. (`docs/00-consumer-quickstart.md`, `docs/02-protocol.md`, `docs/10-reference-plugins.md`, `packages/lint/README.md`) [[1]](diffhunk://#diff-590f0620b325c62bbc760b08aa1e7efd55c18f6bc64c3b7a2ecb194bf0b01e5aR51) [[2]](diffhunk://#diff-a251b049143e4256f2342aeeb81910af33774fbaff017d08e7ebfb5e4bb8ca53L101-R110) [[3]](diffhunk://#diff-1b8c3bc49028939e2295e9d86e57337428d70f2b24272df09b04189afda1213dR218-R227) [[4]](diffhunk://#diff-1b8c3bc49028939e2295e9d86e57337428d70f2b24272df09b04189afda1213dR240-R244) [[5]](diffhunk://#diff-1b8c3bc49028939e2295e9d86e57337428d70f2b24272df09b04189afda1213dR262) [[6]](diffhunk://#diff-307e63d736491fa6936cbed4710f676124e2bc0b34f69598a571c4e7a44ef198R125-R142) [[7]](diffhunk://#diff-307e63d736491fa6936cbed4710f676124e2bc0b34f69598a571c4e7a44ef198L165-R183)

### Native Autofix Support

* Extends the lint engine to allow rules to report autofixable findings by attaching `TextEdit` objects, and adds new methods for reporting fixes (`ReportFix`, `ReportRangeFix`). (`packages/lint/plugin/engine.go`, `packages/lint/plugin/contrib_adapter.go`) [[1]](diffhunk://#diff-52f9945c674725ccdbe4a391a5e28b365d8010c0d3b6ce06923d25d9aee0f38eR65-R74) [[2]](diffhunk://#diff-52f9945c674725ccdbe4a391a5e28b365d8010c0d3b6ce06923d25d9aee0f38eR84-R88) [[3]](diffhunk://#diff-52f9945c674725ccdbe4a391a5e28b365d8010c0d3b6ce06923d25d9aee0f38eR103-R115) [[4]](diffhunk://#diff-52f9945c674725ccdbe4a391a5e28b365d8010c0d3b6ce06923d25d9aee0f38eR129-R141) [[5]](diffhunk://#diff-e7cf62b1c36f2c7ff9c5a2da2dda6396b8d6d6639a0bceac9a0f954c0e7809f0R93-R118)
* Adds AST helpers for fixable rules, such as finding keyword positions and token ranges. (`packages/lint/plugin/ast_helpers.go`)

### ESLint Integration

* Enhances ESLint runtime integration to support autofix: invokes ESLint with the `fix` mode, applies ESLint's output fixes, and reloads the program before reporting diagnostics. (`packages/lint/plugin/eslint_runtime.go`) [[1]](diffhunk://#diff-b594636b726170355693bffb1afbae9970f250ca8103d8f150a4abbf7578691eR24) [[2]](diffhunk://#diff-b594636b726170355693bffb1afbae9970f250ca8103d8f150a4abbf7578691eR130-R192) [[3]](diffhunk://#diff-b594636b726170355693bffb1afbae9970f250ca8103d8f150a4abbf7578691eR258) [[4]](diffhunk://#diff-b594636b726170355693bffb1afbae9970f250ca8103d8f150a4abbf7578691eR283-R302)

### Reference Documentation

* Updates plugin reference documentation and file lists to include the new `fix.go` and describe the autofix architecture. (`docs/10-reference-plugins.md`) [[1]](diffhunk://#diff-1b8c3bc49028939e2295e9d86e57337428d70f2b24272df09b04189afda1213dR218-R227) [[2]](diffhunk://#diff-1b8c3bc49028939e2295e9d86e57337428d70f2b24272df09b04189afda1213dR240-R244) [[3]](diffhunk://#diff-1b8c3bc49028939e2295e9d86e57337428d70f2b24272df09b04189afda1213dR262)

These changes collectively enable a modern autofix workflow for TypeScript linting with `@ttsc/lint`, providing both native and delegated ESLint fixes and improving developer productivity.