### PR TITLE
fix(ttsc): wrap ttscserver around tsgo LSP process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,14 @@
 
 - `ttsc` — build, check, watch, and source-to-source transform on top of `@typescript/native-preview`.
 - `ttsx` — run a TypeScript entrypoint after a real type-check (a typed `tsx`/`ts-node`).
-- `ttscserver` — Language Server Protocol host: embeds tsgo's `internal/lsp.Server` and proxies JSON-RPC traffic so ttsc plugin diagnostics, code actions, and `workspace/executeCommand` handlers merge into the same stream the editor consumes.
+- `ttscserver` — Language Server Protocol host: wraps the project-selected `tsgo --lsp --stdio` process and proxies JSON-RPC traffic so ttsc plugin diagnostics, code actions, and `workspace/executeCommand` handlers merge into the same stream the editor consumes.
 - Plugins — Go sidecars that share TypeScript-Go's AST/Checker. `ttsc` builds plugin source on demand and caches the binary.
 
 The contract is general-purpose. Downstream projects like `typia` and `nestia` are compatibility fixtures, not the product definition.
 
 ### 1.2. Layout
 
-- `packages/ttsc`: JS launcher/API plus Go host (`cmd/*`, `driver`, `internal`, `utility`) and `shim/` over TypeScript-Go internals; `driver/lsp_*.go` is the byte-level LSP proxy embedded by ttscserver and `driver.PluginSource` is the public seam downstream pipelines (lint, format, third-party diagnostics) implement (reference client: `packages/vscode`).
+- `packages/ttsc`: JS launcher/API plus Go host (`cmd/*`, `driver`, `internal`, `utility`) and `shim/` over TypeScript-Go internals; `internal/lspserver` is the byte-level LSP proxy used by ttscserver, while `driver.PluginSource` remains the public seam downstream pipelines (lint, format, third-party diagnostics) implement (reference client: `packages/vscode`).
 - `packages/{banner,paths,strip}`: utility transform plugins with package-owned `driver/` logic linked into a generic native host.
 - `packages/lint`: `@ttsc/lint` with its own native engine. Rules may consult the TypeScript-Go Checker directly via `ctx.Checker`; third-party rules ship through the public `rule` package and may use the `rule/astutil` helpers.
 - `packages/unplugin`: bundler adapters.

--- a/packages/ttsc-darwin-arm64/README.md
+++ b/packages/ttsc-darwin-arm64/README.md
@@ -1,7 +1,7 @@
 # `@ttsc/darwin-arm64`
 
-macOS arm64 native binary and bundled Go compiler package for `ttsc`.
+macOS arm64 native binaries and bundled Go compiler package for `ttsc`.
 
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
-It contains the platform helper and Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.

--- a/packages/ttsc-darwin-x64/README.md
+++ b/packages/ttsc-darwin-x64/README.md
@@ -1,7 +1,7 @@
 # `@ttsc/darwin-x64`
 
-macOS x64 native binary and bundled Go compiler package for `ttsc`.
+macOS x64 native binaries and bundled Go compiler package for `ttsc`.
 
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
-It contains the platform helper and Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.

--- a/packages/ttsc-linux-arm/README.md
+++ b/packages/ttsc-linux-arm/README.md
@@ -1,7 +1,7 @@
 # `@ttsc/linux-arm`
 
-Linux arm native binary and bundled Go compiler package for `ttsc`.
+Linux arm native binaries and bundled Go compiler package for `ttsc`.
 
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
-It contains the platform helper and Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.

--- a/packages/ttsc-linux-arm64/README.md
+++ b/packages/ttsc-linux-arm64/README.md
@@ -1,7 +1,7 @@
 # `@ttsc/linux-arm64`
 
-Linux arm64 native binary and bundled Go compiler package for `ttsc`.
+Linux arm64 native binaries and bundled Go compiler package for `ttsc`.
 
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
-It contains the platform helper and Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.

--- a/packages/ttsc-linux-x64/README.md
+++ b/packages/ttsc-linux-x64/README.md
@@ -1,7 +1,7 @@
 # `@ttsc/linux-x64`
 
-Linux x64 native binary and bundled Go compiler package for `ttsc`.
+Linux x64 native binaries and bundled Go compiler package for `ttsc`.
 
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
-It contains the platform helper and Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.

--- a/packages/ttsc-win32-arm64/README.md
+++ b/packages/ttsc-win32-arm64/README.md
@@ -1,7 +1,7 @@
 # `@ttsc/win32-arm64`
 
-Windows arm64 native binary and bundled Go compiler package for `ttsc`.
+Windows arm64 native binaries and bundled Go compiler package for `ttsc`.
 
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
-It contains the platform helper and Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.

--- a/packages/ttsc-win32-x64/README.md
+++ b/packages/ttsc-win32-x64/README.md
@@ -1,7 +1,7 @@
 # `@ttsc/win32-x64`
 
-Windows x64 native binary and bundled Go compiler package for `ttsc`.
+Windows x64 native binaries and bundled Go compiler package for `ttsc`.
 
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
-It contains the platform helper and Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.

--- a/packages/ttsc/cmd/ttscserver/main.go
+++ b/packages/ttsc/cmd/ttscserver/main.go
@@ -12,34 +12,34 @@
 package main
 
 import (
-  "context"
-  "errors"
-  "flag"
-  "fmt"
-  "io"
-  "os"
-  "os/signal"
-  "runtime"
-  "strings"
-  "syscall"
-  "time"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
 
-  "github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
+	"github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
 )
 
 // Build metadata; overwritten via -ldflags in release builds.
 var (
-  version = "0.0.0-dev"
-  commit  = "dev"
-  date    = "unknown"
+	version = "0.0.0-dev"
+	commit  = "dev"
+	date    = "unknown"
 )
 
 // Package-level writers so command tests can capture output without
 // patching os.Stdout / os.Stderr globally.
 var (
-  stdout io.Writer = os.Stdout
-  stderr io.Writer = os.Stderr
-  stdin  io.Reader = os.Stdin
+	stdout io.Writer = os.Stdout
+	stderr io.Writer = os.Stderr
+	stdin  io.Reader = os.Stdin
 )
 
 // runLSPServer is the seam command tests use to substitute a fake LSP
@@ -56,89 +56,89 @@ var notifyContext = signal.NotifyContext
 var getwd = os.Getwd
 
 func main() {
-  os.Exit(run(os.Args[1:]))
+	os.Exit(run(os.Args[1:]))
 }
 
 func run(args []string) int {
-  if len(args) == 0 {
-    printHelp(stdout)
-    return 0
-  }
-  switch args[0] {
-  case "-h", "--help", "help":
-    printHelp(stdout)
-    return 0
-  case "-v", "--version", "version":
-    printVersion(stdout)
-    return 0
-  }
-  return runLSP(args)
+	if len(args) == 0 {
+		printHelp(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		printHelp(stdout)
+		return 0
+	case "-v", "--version", "version":
+		printVersion(stdout)
+		return 0
+	}
+	return runLSP(args)
 }
 
 func runLSP(args []string) int {
-  fs := flag.NewFlagSet("ttscserver", flag.ContinueOnError)
-  fs.SetOutput(stderr)
-  stdioFlag := fs.Bool("stdio", false, "communicate with the editor over stdin/stdout")
-  cwdFlag := fs.String("cwd", "", "project root (defaults to process cwd)")
-  tsgoFlag := fs.String("tsgo", "", "absolute tsgo binary path (defaults to TTSC_TSGO_BINARY)")
-  progressDelayFlag := fs.Duration("progress-delay", 250*time.Millisecond, "delay before showing tsgo's progress UI")
-  if err := fs.Parse(args); err != nil {
-    return 2
-  }
-  if !*stdioFlag {
-    fmt.Fprintln(stderr, "ttscserver: only --stdio transport is supported")
-    return 2
-  }
+	fs := flag.NewFlagSet("ttscserver", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	stdioFlag := fs.Bool("stdio", false, "communicate with the editor over stdin/stdout")
+	cwdFlag := fs.String("cwd", "", "project root (defaults to process cwd)")
+	tsgoFlag := fs.String("tsgo", "", "absolute tsgo binary path (defaults to TTSC_TSGO_BINARY)")
+	progressDelayFlag := fs.Duration("progress-delay", 250*time.Millisecond, "delay before showing tsgo's progress UI")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if !*stdioFlag {
+		fmt.Fprintln(stderr, "ttscserver: only --stdio transport is supported")
+		return 2
+	}
 
-  cwd := strings.TrimSpace(*cwdFlag)
-  if cwd == "" {
-    resolved, err := getwd()
-    if err != nil {
-      fmt.Fprintf(stderr, "ttscserver: could not resolve working directory: %v\n", err)
-      return 2
-    }
-    cwd = resolved
-  }
+	cwd := strings.TrimSpace(*cwdFlag)
+	if cwd == "" {
+		resolved, err := getwd()
+		if err != nil {
+			fmt.Fprintf(stderr, "ttscserver: could not resolve working directory: %v\n", err)
+			return 2
+		}
+		cwd = resolved
+	}
 
-  ctx, stop := notifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-  defer stop()
+	ctx, stop := notifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
-  tsgoBinary := strings.TrimSpace(*tsgoFlag)
-  if tsgoBinary == "" {
-    tsgoBinary = strings.TrimSpace(os.Getenv("TTSC_TSGO_BINARY"))
-  }
+	tsgoBinary := strings.TrimSpace(*tsgoFlag)
+	if tsgoBinary == "" {
+		tsgoBinary = strings.TrimSpace(os.Getenv("TTSC_TSGO_BINARY"))
+	}
 
-  err := runLSPServer(ctx, lspserver.LSPServerOptions{
-    In:            stdin,
-    Out:           stdout,
-    Err:           stderr,
-    Cwd:           cwd,
-    TsgoBinary:    tsgoBinary,
-    Source:        lspserver.NullPluginSource{},
-    ProgressDelay: *progressDelayFlag,
-  })
-  if err != nil && !errors.Is(err, context.Canceled) {
-    fmt.Fprintf(stderr, "ttscserver: %v\n", err)
-    return 1
-  }
-  return 0
+	err := runLSPServer(ctx, lspserver.LSPServerOptions{
+		In:            stdin,
+		Out:           stdout,
+		Err:           stderr,
+		Cwd:           cwd,
+		TsgoBinary:    tsgoBinary,
+		Source:        lspserver.NullPluginSource{},
+		ProgressDelay: *progressDelayFlag,
+	})
+	if err != nil && !errors.Is(err, context.Canceled) {
+		fmt.Fprintf(stderr, "ttscserver: %v\n", err)
+		return 1
+	}
+	return 0
 }
 
 func printVersion(w io.Writer) {
-  fmt.Fprintf(
-    w,
-    "ttscserver %s (commit %s, built %s, %s/%s, go %s)\n",
-    version,
-    commit,
-    date,
-    runtime.GOOS,
-    runtime.GOARCH,
-    runtime.Version(),
-  )
+	fmt.Fprintf(
+		w,
+		"ttscserver %s (commit %s, built %s, %s/%s, go %s)\n",
+		version,
+		commit,
+		date,
+		runtime.GOOS,
+		runtime.GOARCH,
+		runtime.Version(),
+	)
 }
 
 func printHelp(w io.Writer) {
-  fmt.Fprintln(w, strings.TrimSpace(`
+	fmt.Fprintln(w, strings.TrimSpace(`
 ttscserver — Language Server Protocol host for ttsc.
 
 Usage:

--- a/packages/ttsc/cmd/ttscserver/main.go
+++ b/packages/ttsc/cmd/ttscserver/main.go
@@ -1,14 +1,14 @@
-// Command ttscserver is the Go LSP host shipped by ttsc. It embeds
-// TypeScript-Go's LSP server unmodified and proxies traffic between the
-// editor and that server, splicing ttsc-plugin diagnostics, code actions,
-// and ttsc-owned executeCommand handling into the same stream.
+// Command ttscserver is the Go LSP host shipped by ttsc. It wraps the
+// project-selected TypeScript-Go LSP server process and proxies traffic
+// between the editor and that server, splicing ttsc-plugin diagnostics,
+// code actions, and ttsc-owned executeCommand handling into the same stream.
 //
 // The JavaScript launcher (`packages/ttsc/src/launcher/ttscserver.ts`)
 // resolves the native binary and forwards stdio so editors can spawn
 // `ttscserver --stdio` without worrying about platform helper packages.
 //
 // Everything here is deliberately small: flag parsing, version metadata,
-// and a single delegation to driver.RunLSPServer.
+// and a single delegation to lspserver.RunLSPServer.
 package main
 
 import (
@@ -24,7 +24,7 @@ import (
   "syscall"
   "time"
 
-  "github.com/samchon/ttsc/packages/ttsc/driver"
+  "github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
 )
 
 // Build metadata; overwritten via -ldflags in release builds.
@@ -43,8 +43,8 @@ var (
 )
 
 // runLSPServer is the seam command tests use to substitute a fake LSP
-// host. Production wires it to driver.RunLSPServer.
-var runLSPServer = driver.RunLSPServer
+// host. Production wires it to lspserver.RunLSPServer.
+var runLSPServer = lspserver.RunLSPServer
 
 // notifyContext is the seam command tests use to substitute a
 // deterministic context (no signal hookup) for the signal-aware default.
@@ -80,6 +80,7 @@ func runLSP(args []string) int {
   fs.SetOutput(stderr)
   stdioFlag := fs.Bool("stdio", false, "communicate with the editor over stdin/stdout")
   cwdFlag := fs.String("cwd", "", "project root (defaults to process cwd)")
+  tsgoFlag := fs.String("tsgo", "", "absolute tsgo binary path (defaults to TTSC_TSGO_BINARY)")
   progressDelayFlag := fs.Duration("progress-delay", 250*time.Millisecond, "delay before showing tsgo's progress UI")
   if err := fs.Parse(args); err != nil {
     return 2
@@ -102,12 +103,18 @@ func runLSP(args []string) int {
   ctx, stop := notifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
   defer stop()
 
-  err := runLSPServer(ctx, driver.LSPServerOptions{
+  tsgoBinary := strings.TrimSpace(*tsgoFlag)
+  if tsgoBinary == "" {
+    tsgoBinary = strings.TrimSpace(os.Getenv("TTSC_TSGO_BINARY"))
+  }
+
+  err := runLSPServer(ctx, lspserver.LSPServerOptions{
     In:            stdin,
     Out:           stdout,
     Err:           stderr,
     Cwd:           cwd,
-    Source:        driver.NullPluginSource{},
+    TsgoBinary:    tsgoBinary,
+    Source:        lspserver.NullPluginSource{},
     ProgressDelay: *progressDelayFlag,
   })
   if err != nil && !errors.Is(err, context.Canceled) {
@@ -141,14 +148,15 @@ Usage:
 
 Options:
   --stdio              Communicate with the editor over stdin/stdout.
-  --cwd <dir>          Project root passed to the embedded tsgo server.
-  --progress-delay D   Delay before tsgo shows its progress UI (default 250ms).
+  --cwd <dir>          Project root used as the tsgo server working directory.
+  --tsgo <path>        Absolute tsgo binary path (defaults to TTSC_TSGO_BINARY).
+  --progress-delay D   Accepted for compatibility; tsgo currently owns this value.
 
 Typical embedding:
   Editors spawn ttscserver via the JavaScript launcher (resolves the
-  per-platform native binary) and exchange LSP messages over stdio. The
-  embedded tsgo server provides hover/completion/definitions/diagnostics;
-  ttsc merges plugin (lint/format) diagnostics, code actions, and ttsc-
-  owned executeCommand handlers into the same stream.
+  per-platform native binary and passes the project tsgo path) and exchange
+  LSP messages over stdio. The upstream tsgo server provides hover,
+  completion, definitions, and diagnostics; ttsc merges plugin diagnostics,
+  code actions, and ttsc-owned executeCommand handlers into the same stream.
 `))
 }

--- a/packages/ttsc/cmd/ttscserver/run_lsp_prefers_tsgo_flag_test.go
+++ b/packages/ttsc/cmd/ttscserver/run_lsp_prefers_tsgo_flag_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-  "bytes"
-  "context"
-  "testing"
+	"bytes"
+	"context"
+	"testing"
 
-  "github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
+	"github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
 )
 
 // TestRunLSPPrefersTsgoFlag verifies the native command forwards an explicit
@@ -19,24 +19,24 @@ import (
 // 2. Run runLSP with --stdio, --cwd, and --tsgo.
 // 3. Assert the captured TsgoBinary is the flag value.
 func TestRunLSPPrefersTsgoFlag(t *testing.T) {
-  const expected = "/tmp/tsgo-test-binary"
-  prev := runLSPServer
-  var captured lspserver.LSPServerOptions
-  runLSPServer = func(_ context.Context, opts lspserver.LSPServerOptions) error {
-    captured = opts
-    return nil
-  }
-  defer func() { runLSPServer = prev }()
+	const expected = "/tmp/tsgo-test-binary"
+	prev := runLSPServer
+	var captured lspserver.LSPServerOptions
+	runLSPServer = func(_ context.Context, opts lspserver.LSPServerOptions) error {
+		captured = opts
+		return nil
+	}
+	defer func() { runLSPServer = prev }()
 
-  outBuf := &bytes.Buffer{}
-  errBuf := &bytes.Buffer{}
-  withIO(t, outBuf, errBuf, nil, func() {
-    if code := runLSP([]string{"--stdio", "--cwd", t.TempDir(), "--tsgo", expected}); code != 0 {
-      t.Fatalf("expected exit 0, got %d (stderr=%q)", code, errBuf.String())
-    }
-  })
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	withIO(t, outBuf, errBuf, nil, func() {
+		if code := runLSP([]string{"--stdio", "--cwd", t.TempDir(), "--tsgo", expected}); code != 0 {
+			t.Fatalf("expected exit 0, got %d (stderr=%q)", code, errBuf.String())
+		}
+	})
 
-  if captured.TsgoBinary != expected {
-    t.Fatalf("expected TsgoBinary %q, got %q", expected, captured.TsgoBinary)
-  }
+	if captured.TsgoBinary != expected {
+		t.Fatalf("expected TsgoBinary %q, got %q", expected, captured.TsgoBinary)
+	}
 }

--- a/packages/ttsc/cmd/ttscserver/run_lsp_prefers_tsgo_flag_test.go
+++ b/packages/ttsc/cmd/ttscserver/run_lsp_prefers_tsgo_flag_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+  "bytes"
+  "context"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
+)
+
+// TestRunLSPPrefersTsgoFlag verifies the native command forwards an explicit
+// upstream tsgo path into the LSP host options.
+//
+// Editors normally enter through the JavaScript launcher, but direct native
+// callers can pass --tsgo. This pins that flag path separately from the
+// TTSC_TSGO_BINARY environment fallback.
+//
+// 1. Substitute the runLSPServer seam and capture its options.
+// 2. Run runLSP with --stdio, --cwd, and --tsgo.
+// 3. Assert the captured TsgoBinary is the flag value.
+func TestRunLSPPrefersTsgoFlag(t *testing.T) {
+  const expected = "/tmp/tsgo-test-binary"
+  prev := runLSPServer
+  var captured lspserver.LSPServerOptions
+  runLSPServer = func(_ context.Context, opts lspserver.LSPServerOptions) error {
+    captured = opts
+    return nil
+  }
+  defer func() { runLSPServer = prev }()
+
+  outBuf := &bytes.Buffer{}
+  errBuf := &bytes.Buffer{}
+  withIO(t, outBuf, errBuf, nil, func() {
+    if code := runLSP([]string{"--stdio", "--cwd", t.TempDir(), "--tsgo", expected}); code != 0 {
+      t.Fatalf("expected exit 0, got %d (stderr=%q)", code, errBuf.String())
+    }
+  })
+
+  if captured.TsgoBinary != expected {
+    t.Fatalf("expected TsgoBinary %q, got %q", expected, captured.TsgoBinary)
+  }
+}

--- a/packages/ttsc/cmd/ttscserver/run_lsp_reports_server_error_test.go
+++ b/packages/ttsc/cmd/ttscserver/run_lsp_reports_server_error_test.go
@@ -4,7 +4,6 @@ import (
   "bytes"
   "context"
   "errors"
-  "io"
   "strings"
   "testing"
 
@@ -38,5 +37,4 @@ func TestRunLSPReportsServerError(t *testing.T) {
   if !strings.Contains(errBuf.String(), sentinel.Error()) {
     t.Fatalf("expected sentinel on stderr, got: %q", errBuf.String())
   }
-  _ = io.Discard
 }

--- a/packages/ttsc/cmd/ttscserver/run_lsp_reports_server_error_test.go
+++ b/packages/ttsc/cmd/ttscserver/run_lsp_reports_server_error_test.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-  "bytes"
-  "context"
-  "errors"
-  "strings"
-  "testing"
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
 
-  "github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
+	"github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
 )
 
 // TestRunLSPReportsServerError pins the non-cancellation error path in
@@ -19,22 +19,22 @@ import (
 // 2. Run runLSP with --stdio --cwd <tempdir>.
 // 3. Assert exit 1 and the sentinel text on stderr.
 func TestRunLSPReportsServerError(t *testing.T) {
-  sentinel := errors.New("lsp host blew up")
-  prev := runLSPServer
-  runLSPServer = func(_ context.Context, _ lspserver.LSPServerOptions) error {
-    return sentinel
-  }
-  defer func() { runLSPServer = prev }()
+	sentinel := errors.New("lsp host blew up")
+	prev := runLSPServer
+	runLSPServer = func(_ context.Context, _ lspserver.LSPServerOptions) error {
+		return sentinel
+	}
+	defer func() { runLSPServer = prev }()
 
-  outBuf := &bytes.Buffer{}
-  errBuf := &bytes.Buffer{}
-  withIO(t, outBuf, errBuf, nil, func() {
-    if code := runLSP([]string{"--stdio", "--cwd", t.TempDir()}); code != 1 {
-      t.Fatalf("expected exit 1, got %d", code)
-    }
-  })
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	withIO(t, outBuf, errBuf, nil, func() {
+		if code := runLSP([]string{"--stdio", "--cwd", t.TempDir()}); code != 1 {
+			t.Fatalf("expected exit 1, got %d", code)
+		}
+	})
 
-  if !strings.Contains(errBuf.String(), sentinel.Error()) {
-    t.Fatalf("expected sentinel on stderr, got: %q", errBuf.String())
-  }
+	if !strings.Contains(errBuf.String(), sentinel.Error()) {
+		t.Fatalf("expected sentinel on stderr, got: %q", errBuf.String())
+	}
 }

--- a/packages/ttsc/cmd/ttscserver/run_lsp_reports_server_error_test.go
+++ b/packages/ttsc/cmd/ttscserver/run_lsp_reports_server_error_test.go
@@ -8,11 +8,11 @@ import (
   "strings"
   "testing"
 
-  "github.com/samchon/ttsc/packages/ttsc/driver"
+  "github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
 )
 
 // TestRunLSPReportsServerError pins the non-cancellation error path in
-// runLSP. When RunLSPServer reports a real failure (the embedded server
+// runLSP. When RunLSPServer reports a real failure (the upstream server
 // crashed, an unrecoverable IO error, etc.) the launcher must exit 1
 // and copy the error message to stderr.
 //
@@ -22,7 +22,7 @@ import (
 func TestRunLSPReportsServerError(t *testing.T) {
   sentinel := errors.New("lsp host blew up")
   prev := runLSPServer
-  runLSPServer = func(_ context.Context, _ driver.LSPServerOptions) error {
+  runLSPServer = func(_ context.Context, _ lspserver.LSPServerOptions) error {
     return sentinel
   }
   defer func() { runLSPServer = prev }()

--- a/packages/ttsc/cmd/ttscserver/run_lsp_uses_tsgo_environment_test.go
+++ b/packages/ttsc/cmd/ttscserver/run_lsp_uses_tsgo_environment_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+  "bytes"
+  "context"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
+)
+
+// TestRunLSPUsesTsgoEnvironment verifies TTSC_TSGO_BINARY feeds the native host
+// when no --tsgo flag is present.
+//
+// The JavaScript launcher resolves @typescript/native-preview and passes the
+// absolute path through this environment variable, keeping the Go binary thin
+// and independent of Node's module resolver.
+//
+// 1. Set TTSC_TSGO_BINARY to a sentinel path.
+// 2. Substitute runLSPServer and capture its options.
+// 3. Assert TsgoBinary is populated from the environment.
+func TestRunLSPUsesTsgoEnvironment(t *testing.T) {
+  const expected = "/tmp/tsgo-env-binary"
+  t.Setenv("TTSC_TSGO_BINARY", expected)
+
+  prev := runLSPServer
+  var captured lspserver.LSPServerOptions
+  runLSPServer = func(_ context.Context, opts lspserver.LSPServerOptions) error {
+    captured = opts
+    return nil
+  }
+  defer func() { runLSPServer = prev }()
+
+  outBuf := &bytes.Buffer{}
+  errBuf := &bytes.Buffer{}
+  withIO(t, outBuf, errBuf, nil, func() {
+    if code := runLSP([]string{"--stdio", "--cwd", t.TempDir()}); code != 0 {
+      t.Fatalf("expected exit 0, got %d (stderr=%q)", code, errBuf.String())
+    }
+  })
+
+  if captured.TsgoBinary != expected {
+    t.Fatalf("expected TsgoBinary %q, got %q", expected, captured.TsgoBinary)
+  }
+}

--- a/packages/ttsc/cmd/ttscserver/run_lsp_uses_tsgo_environment_test.go
+++ b/packages/ttsc/cmd/ttscserver/run_lsp_uses_tsgo_environment_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-  "bytes"
-  "context"
-  "testing"
+	"bytes"
+	"context"
+	"testing"
 
-  "github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
+	"github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
 )
 
 // TestRunLSPUsesTsgoEnvironment verifies TTSC_TSGO_BINARY feeds the native host
@@ -19,26 +19,26 @@ import (
 // 2. Substitute runLSPServer and capture its options.
 // 3. Assert TsgoBinary is populated from the environment.
 func TestRunLSPUsesTsgoEnvironment(t *testing.T) {
-  const expected = "/tmp/tsgo-env-binary"
-  t.Setenv("TTSC_TSGO_BINARY", expected)
+	const expected = "/tmp/tsgo-env-binary"
+	t.Setenv("TTSC_TSGO_BINARY", expected)
 
-  prev := runLSPServer
-  var captured lspserver.LSPServerOptions
-  runLSPServer = func(_ context.Context, opts lspserver.LSPServerOptions) error {
-    captured = opts
-    return nil
-  }
-  defer func() { runLSPServer = prev }()
+	prev := runLSPServer
+	var captured lspserver.LSPServerOptions
+	runLSPServer = func(_ context.Context, opts lspserver.LSPServerOptions) error {
+		captured = opts
+		return nil
+	}
+	defer func() { runLSPServer = prev }()
 
-  outBuf := &bytes.Buffer{}
-  errBuf := &bytes.Buffer{}
-  withIO(t, outBuf, errBuf, nil, func() {
-    if code := runLSP([]string{"--stdio", "--cwd", t.TempDir()}); code != 0 {
-      t.Fatalf("expected exit 0, got %d (stderr=%q)", code, errBuf.String())
-    }
-  })
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	withIO(t, outBuf, errBuf, nil, func() {
+		if code := runLSP([]string{"--stdio", "--cwd", t.TempDir()}); code != 0 {
+			t.Fatalf("expected exit 0, got %d (stderr=%q)", code, errBuf.String())
+		}
+	})
 
-  if captured.TsgoBinary != expected {
-    t.Fatalf("expected TsgoBinary %q, got %q", expected, captured.TsgoBinary)
-  }
+	if captured.TsgoBinary != expected {
+		t.Fatalf("expected TsgoBinary %q, got %q", expected, captured.TsgoBinary)
+	}
 }

--- a/packages/ttsc/driver/lsp.go
+++ b/packages/ttsc/driver/lsp.go
@@ -1,0 +1,60 @@
+package driver
+
+import (
+  "encoding/json"
+
+  "github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
+)
+
+type LSPPosition = lspserver.LSPPosition
+type LSPRange = lspserver.LSPRange
+type LSPDiagnosticSeverity = lspserver.LSPDiagnosticSeverity
+
+const (
+  LSPDiagnosticSeverityError       = lspserver.LSPDiagnosticSeverityError
+  LSPDiagnosticSeverityWarning     = lspserver.LSPDiagnosticSeverityWarning
+  LSPDiagnosticSeverityInformation = lspserver.LSPDiagnosticSeverityInformation
+  LSPDiagnosticSeverityHint        = lspserver.LSPDiagnosticSeverityHint
+)
+
+type LSPDiagnostic = lspserver.LSPDiagnostic
+type LSPCodeAction = lspserver.LSPCodeAction
+type LSPCommand = lspserver.LSPCommand
+type LSPCodeActionContext = lspserver.LSPCodeActionContext
+type LSPWorkspaceEdit = lspserver.LSPWorkspaceEdit
+type LSPTextEdit = lspserver.LSPTextEdit
+type LSPDocumentVersion = lspserver.LSPDocumentVersion
+type PluginSource = lspserver.PluginSource
+type NullPluginSource = lspserver.NullPluginSource
+
+type ProxyOptions = lspserver.ProxyOptions
+type Proxy = lspserver.Proxy
+
+type FrameReader = lspserver.FrameReader
+type Envelope = lspserver.Envelope
+
+type LSPServerOptions = lspserver.LSPServerOptions
+type LSPUpstreamRunner = lspserver.LSPUpstreamRunner
+
+const MaxFrameBytes = lspserver.MaxFrameBytes
+
+var ErrCommandNotHandled = lspserver.ErrCommandNotHandled
+var ErrFrameClosed = lspserver.ErrFrameClosed
+var ErrFrameTooLarge = lspserver.ErrFrameTooLarge
+var ErrInvalidJSONRPC = lspserver.ErrInvalidJSONRPC
+var ErrLSPUpstreamPanic = lspserver.ErrLSPUpstreamPanic
+var ErrLSPCwdRequired = lspserver.ErrLSPCwdRequired
+var ErrLSPTsgoBinaryRequired = lspserver.ErrLSPTsgoBinaryRequired
+
+var NewProxy = lspserver.NewProxy
+var NewFrameReader = lspserver.NewFrameReader
+var WriteFrame = lspserver.WriteFrame
+var ParseEnvelope = lspserver.ParseEnvelope
+var RecoverPanicAs = lspserver.RecoverPanicAs
+var WithUpstreamRunnerForTest = lspserver.WithUpstreamRunnerForTest
+var RunLSPServer = lspserver.RunLSPServer
+var DenyNpmInstall = lspserver.DenyNpmInstall
+
+func idKeyFromRaw(raw json.RawMessage) string {
+  return lspserver.IDKeyFromRaw(raw)
+}

--- a/packages/ttsc/driver/lsp.go
+++ b/packages/ttsc/driver/lsp.go
@@ -1,9 +1,9 @@
 package driver
 
 import (
-  "encoding/json"
+	"encoding/json"
 
-  "github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
+	"github.com/samchon/ttsc/packages/ttsc/internal/lspserver"
 )
 
 type LSPPosition = lspserver.LSPPosition
@@ -11,10 +11,10 @@ type LSPRange = lspserver.LSPRange
 type LSPDiagnosticSeverity = lspserver.LSPDiagnosticSeverity
 
 const (
-  LSPDiagnosticSeverityError       = lspserver.LSPDiagnosticSeverityError
-  LSPDiagnosticSeverityWarning     = lspserver.LSPDiagnosticSeverityWarning
-  LSPDiagnosticSeverityInformation = lspserver.LSPDiagnosticSeverityInformation
-  LSPDiagnosticSeverityHint        = lspserver.LSPDiagnosticSeverityHint
+	LSPDiagnosticSeverityError       = lspserver.LSPDiagnosticSeverityError
+	LSPDiagnosticSeverityWarning     = lspserver.LSPDiagnosticSeverityWarning
+	LSPDiagnosticSeverityInformation = lspserver.LSPDiagnosticSeverityInformation
+	LSPDiagnosticSeverityHint        = lspserver.LSPDiagnosticSeverityHint
 )
 
 type LSPDiagnostic = lspserver.LSPDiagnostic
@@ -56,5 +56,5 @@ var RunLSPServer = lspserver.RunLSPServer
 var DenyNpmInstall = lspserver.DenyNpmInstall
 
 func idKeyFromRaw(raw json.RawMessage) string {
-  return lspserver.IDKeyFromRaw(raw)
+	return lspserver.IDKeyFromRaw(raw)
 }

--- a/packages/ttsc/internal/lspserver/lsp_envelope.go
+++ b/packages/ttsc/internal/lspserver/lsp_envelope.go
@@ -1,12 +1,12 @@
 package lspserver
 
 import (
-  "bytes"
-  "encoding/json"
-  "errors"
-  "fmt"
-  "strconv"
-  "strings"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 )
 
 // ErrInvalidJSONRPC is returned by ParseEnvelope when the body has a
@@ -19,12 +19,12 @@ var ErrInvalidJSONRPC = errors.New("lsp: jsonrpc field must be \"2.0\"")
 // because LSP allows both numbers and strings and we must round-trip
 // whichever shape the editor used in correlating responses.
 type Envelope struct {
-  JSONRPC string          `json:"jsonrpc,omitempty"`
-  ID      json.RawMessage `json:"id,omitempty"`
-  Method  string          `json:"method,omitempty"`
-  Params  json.RawMessage `json:"params,omitempty"`
-  Result  json.RawMessage `json:"result,omitempty"`
-  Error   json.RawMessage `json:"error,omitempty"`
+	JSONRPC string          `json:"jsonrpc,omitempty"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   json.RawMessage `json:"error,omitempty"`
 }
 
 // ParseEnvelope decodes the JSON-RPC envelope without consuming the
@@ -32,31 +32,31 @@ type Envelope struct {
 // matches the LSP base protocol's forward-compatibility expectation. A
 // non-empty `jsonrpc` value other than "2.0" is rejected.
 func ParseEnvelope(body []byte) (Envelope, error) {
-  var env Envelope
-  if err := json.Unmarshal(body, &env); err != nil {
-    return Envelope{}, fmt.Errorf("lsp: envelope decode: %w", err)
-  }
-  if env.JSONRPC != "" && env.JSONRPC != "2.0" {
-    return Envelope{}, fmt.Errorf("%w (got %q)", ErrInvalidJSONRPC, env.JSONRPC)
-  }
-  return env, nil
+	var env Envelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return Envelope{}, fmt.Errorf("lsp: envelope decode: %w", err)
+	}
+	if env.JSONRPC != "" && env.JSONRPC != "2.0" {
+		return Envelope{}, fmt.Errorf("%w (got %q)", ErrInvalidJSONRPC, env.JSONRPC)
+	}
+	return env, nil
 }
 
 // IsRequest reports whether the envelope represents a request expecting
 // a response (id present, method present).
 func (e Envelope) IsRequest() bool {
-  return len(e.ID) > 0 && e.Method != ""
+	return len(e.ID) > 0 && e.Method != ""
 }
 
 // IsNotification reports whether the envelope is a one-way notification.
 func (e Envelope) IsNotification() bool {
-  return len(e.ID) == 0 && e.Method != ""
+	return len(e.ID) == 0 && e.Method != ""
 }
 
 // IsResponse reports whether the envelope is a response (id present,
 // method absent — either result or error will be set).
 func (e Envelope) IsResponse() bool {
-  return len(e.ID) > 0 && e.Method == ""
+	return len(e.ID) > 0 && e.Method == ""
 }
 
 // IsErrorResponse reports whether a response envelope carries an error
@@ -64,7 +64,7 @@ func (e Envelope) IsResponse() bool {
 // on the same response, so the proxy uses this to skip merging plugin
 // contributions into upstream failures.
 func (e Envelope) IsErrorResponse() bool {
-  return e.IsResponse() && len(e.Error) > 0 && !bytes.Equal(bytes.TrimSpace(e.Error), []byte("null"))
+	return e.IsResponse() && len(e.Error) > 0 && !bytes.Equal(bytes.TrimSpace(e.Error), []byte("null"))
 }
 
 // IDKey returns a stable string key for matching request and response
@@ -76,13 +76,13 @@ func (e Envelope) IsErrorResponse() bool {
 // (LSP forbids these as request ids) produce the empty key, which
 // callers treat as "no entry".
 func (e Envelope) IDKey() string {
-  return idKeyFromRaw(e.ID)
+	return idKeyFromRaw(e.ID)
 }
 
 // IDKeyFromRaw exposes the shared id-key normalizer to the public driver
 // compatibility layer without exporting the helper from that package.
 func IDKeyFromRaw(raw json.RawMessage) string {
-  return idKeyFromRaw(raw)
+	return idKeyFromRaw(raw)
 }
 
 // idKeyFromRaw normalizes a raw id payload the same way IDKey does so
@@ -101,42 +101,42 @@ func IDKeyFromRaw(raw json.RawMessage) string {
 // (boolean, null, array, object — none of which LSP allows for ids)
 // falls through to the empty key, which callers treat as "no entry".
 func idKeyFromRaw(raw json.RawMessage) string {
-  if len(raw) == 0 {
-    return ""
-  }
-  dec := json.NewDecoder(bytes.NewReader(raw))
-  dec.UseNumber()
-  var decoded any
-  if err := dec.Decode(&decoded); err != nil {
-    return ""
-  }
-  switch v := decoded.(type) {
-  case json.Number:
-    lit := v.String()
-    if !strings.ContainsAny(lit, ".eE") {
-      // Integer-shaped literal. Use int64 when it fits so leading
-      // zeros and minus signs canonicalize, but preserve the literal
-      // for past-int64 ids — Float64 normalization would silently
-      // round 9999999999999999998 and 9999999999999999999 to the
-      // same key.
-      if n, err := v.Int64(); err == nil {
-        return strconv.FormatInt(n, 10)
-      }
-      return lit
-    }
-    // Float-shaped literal (`1.0`, `1.5`, `1e2`). Collapse to integer
-    // form only when the value is exactly representable as int64;
-    // 2^53 bounds the safe range because float64 loses unit precision
-    // past that magnitude.
-    if f, err := v.Float64(); err == nil {
-      const maxSafeFloat = float64(int64(1) << 53)
-      if f >= -maxSafeFloat && f <= maxSafeFloat && f == float64(int64(f)) {
-        return strconv.FormatInt(int64(f), 10)
-      }
-    }
-    return lit
-  case string:
-    return strconv.Quote(v)
-  }
-  return ""
+	if len(raw) == 0 {
+		return ""
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var decoded any
+	if err := dec.Decode(&decoded); err != nil {
+		return ""
+	}
+	switch v := decoded.(type) {
+	case json.Number:
+		lit := v.String()
+		if !strings.ContainsAny(lit, ".eE") {
+			// Integer-shaped literal. Use int64 when it fits so leading
+			// zeros and minus signs canonicalize, but preserve the literal
+			// for past-int64 ids — Float64 normalization would silently
+			// round 9999999999999999998 and 9999999999999999999 to the
+			// same key.
+			if n, err := v.Int64(); err == nil {
+				return strconv.FormatInt(n, 10)
+			}
+			return lit
+		}
+		// Float-shaped literal (`1.0`, `1.5`, `1e2`). Collapse to integer
+		// form only when the value is exactly representable as int64;
+		// 2^53 bounds the safe range because float64 loses unit precision
+		// past that magnitude.
+		if f, err := v.Float64(); err == nil {
+			const maxSafeFloat = float64(int64(1) << 53)
+			if f >= -maxSafeFloat && f <= maxSafeFloat && f == float64(int64(f)) {
+				return strconv.FormatInt(int64(f), 10)
+			}
+		}
+		return lit
+	case string:
+		return strconv.Quote(v)
+	}
+	return ""
 }

--- a/packages/ttsc/internal/lspserver/lsp_envelope.go
+++ b/packages/ttsc/internal/lspserver/lsp_envelope.go
@@ -1,4 +1,4 @@
-package driver
+package lspserver
 
 import (
   "bytes"
@@ -77,6 +77,12 @@ func (e Envelope) IsErrorResponse() bool {
 // callers treat as "no entry".
 func (e Envelope) IDKey() string {
   return idKeyFromRaw(e.ID)
+}
+
+// IDKeyFromRaw exposes the shared id-key normalizer to the public driver
+// compatibility layer without exporting the helper from that package.
+func IDKeyFromRaw(raw json.RawMessage) string {
+  return idKeyFromRaw(raw)
 }
 
 // idKeyFromRaw normalizes a raw id payload the same way IDKey does so

--- a/packages/ttsc/internal/lspserver/lsp_frame.go
+++ b/packages/ttsc/internal/lspserver/lsp_frame.go
@@ -11,12 +11,12 @@
 package lspserver
 
 import (
-  "bufio"
-  "errors"
-  "fmt"
-  "io"
-  "strconv"
-  "strings"
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
 )
 
 // ErrFrameClosed reports a clean EOF between frames. Callers use it to
@@ -40,69 +40,69 @@ const MaxFrameBytes = 64 << 20
 // peer sent) and strict about the Content-Length value because tsgo's
 // upstream writer always emits one.
 type FrameReader struct {
-  br *bufio.Reader
+	br *bufio.Reader
 }
 
 // NewFrameReader wraps r with an internal buffered reader. r is consumed
 // lazily; the underlying reader is never closed by the FrameReader.
 func NewFrameReader(r io.Reader) *FrameReader {
-  return &FrameReader{br: bufio.NewReader(r)}
+	return &FrameReader{br: bufio.NewReader(r)}
 }
 
 // Read returns the next message body together with the raw header block
 // (without trailing CRLFCRLF). The header block is preserved so callers
 // that proxy traffic verbatim do not lose Content-Type or vendor headers.
 func (fr *FrameReader) Read() (headers string, body []byte, err error) {
-  var headerBuf strings.Builder
-  contentLength := -1
-  for {
-    line, lineErr := fr.br.ReadString('\n')
-    if lineErr != nil {
-      if lineErr == io.EOF && headerBuf.Len() == 0 && line == "" {
-        return "", nil, ErrFrameClosed
-      }
-      return "", nil, fmt.Errorf("lsp: header read: %w", lineErr)
-    }
-    trimmed := strings.TrimRight(line, "\r\n")
-    if trimmed == "" {
-      break
-    }
-    headerBuf.WriteString(line)
-    if value, ok := parseContentLength(trimmed); ok {
-      contentLength = value
-    }
-  }
-  if contentLength < 0 {
-    return "", nil, errors.New("lsp: missing Content-Length header")
-  }
-  if contentLength > MaxFrameBytes {
-    return "", nil, fmt.Errorf("%w (got %d, max %d)", ErrFrameTooLarge, contentLength, MaxFrameBytes)
-  }
-  body = make([]byte, contentLength)
-  if _, err := io.ReadFull(fr.br, body); err != nil {
-    return "", nil, fmt.Errorf("lsp: body read: %w", err)
-  }
-  return headerBuf.String(), body, nil
+	var headerBuf strings.Builder
+	contentLength := -1
+	for {
+		line, lineErr := fr.br.ReadString('\n')
+		if lineErr != nil {
+			if lineErr == io.EOF && headerBuf.Len() == 0 && line == "" {
+				return "", nil, ErrFrameClosed
+			}
+			return "", nil, fmt.Errorf("lsp: header read: %w", lineErr)
+		}
+		trimmed := strings.TrimRight(line, "\r\n")
+		if trimmed == "" {
+			break
+		}
+		headerBuf.WriteString(line)
+		if value, ok := parseContentLength(trimmed); ok {
+			contentLength = value
+		}
+	}
+	if contentLength < 0 {
+		return "", nil, errors.New("lsp: missing Content-Length header")
+	}
+	if contentLength > MaxFrameBytes {
+		return "", nil, fmt.Errorf("%w (got %d, max %d)", ErrFrameTooLarge, contentLength, MaxFrameBytes)
+	}
+	body = make([]byte, contentLength)
+	if _, err := io.ReadFull(fr.br, body); err != nil {
+		return "", nil, fmt.Errorf("lsp: body read: %w", err)
+	}
+	return headerBuf.String(), body, nil
 }
 
 // parseContentLength extracts the integer value of a Content-Length header.
 // Header names are case-insensitive per the LSP base protocol; tsgo emits
 // "Content-Length" but some clients downcase, so we normalize here.
 func parseContentLength(line string) (int, bool) {
-  colon := strings.IndexByte(line, ':')
-  if colon < 0 {
-    return 0, false
-  }
-  name := strings.TrimSpace(line[:colon])
-  if !strings.EqualFold(name, "Content-Length") {
-    return 0, false
-  }
-  value := strings.TrimSpace(line[colon+1:])
-  n, err := strconv.Atoi(value)
-  if err != nil || n < 0 {
-    return 0, false
-  }
-  return n, true
+	colon := strings.IndexByte(line, ':')
+	if colon < 0 {
+		return 0, false
+	}
+	name := strings.TrimSpace(line[:colon])
+	if !strings.EqualFold(name, "Content-Length") {
+		return 0, false
+	}
+	value := strings.TrimSpace(line[colon+1:])
+	n, err := strconv.Atoi(value)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
 }
 
 // WriteFrame serializes body with a Content-Length header to w. The header
@@ -110,12 +110,12 @@ func parseContentLength(line string) (int, bool) {
 // that strict-parse the header block (notably VSCode's client) accept the
 // message without warnings.
 func WriteFrame(w io.Writer, body []byte) error {
-  header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))
-  if _, err := io.WriteString(w, header); err != nil {
-    return fmt.Errorf("lsp: header write: %w", err)
-  }
-  if _, err := w.Write(body); err != nil {
-    return fmt.Errorf("lsp: body write: %w", err)
-  }
-  return nil
+	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))
+	if _, err := io.WriteString(w, header); err != nil {
+		return fmt.Errorf("lsp: header write: %w", err)
+	}
+	if _, err := w.Write(body); err != nil {
+		return fmt.Errorf("lsp: body write: %w", err)
+	}
+	return nil
 }

--- a/packages/ttsc/internal/lspserver/lsp_frame.go
+++ b/packages/ttsc/internal/lspserver/lsp_frame.go
@@ -1,5 +1,5 @@
 // JSON-RPC Content-Length framing as used by LSP over stdio. ttscserver
-// embeds tsgo's LSP server but sits between it and the editor so it can
+// wraps tsgo's LSP server but sits between it and the editor so it can
 // merge plugin diagnostics into outgoing publishDiagnostics and inject
 // ttsc-owned code actions. Both legs of the proxy work on raw bytes.
 //
@@ -8,7 +8,7 @@
 // by WriteFrame include only Content-Length. That is intentional — the
 // LSP base protocol marks every other header optional and editors in
 // the wild do not require them on server output.
-package driver
+package lspserver
 
 import (
   "bufio"

--- a/packages/ttsc/internal/lspserver/lsp_plugin.go
+++ b/packages/ttsc/internal/lspserver/lsp_plugin.go
@@ -1,4 +1,4 @@
-package driver
+package lspserver
 
 import "encoding/json"
 

--- a/packages/ttsc/internal/lspserver/lsp_plugin.go
+++ b/packages/ttsc/internal/lspserver/lsp_plugin.go
@@ -7,14 +7,14 @@ import "encoding/json"
 // surface stays narrow; the merger marshals them straight into the array
 // the editor already expects.
 type LSPPosition struct {
-  Line      int `json:"line"`
-  Character int `json:"character"`
+	Line      int `json:"line"`
+	Character int `json:"character"`
 }
 
 // LSPRange is the closed-open [start, end) interval LSP uses for ranges.
 type LSPRange struct {
-  Start LSPPosition `json:"start"`
-  End   LSPPosition `json:"end"`
+	Start LSPPosition `json:"start"`
+	End   LSPPosition `json:"end"`
 }
 
 // LSPDiagnosticSeverity values match the LSP enum exactly so editors
@@ -22,66 +22,66 @@ type LSPRange struct {
 type LSPDiagnosticSeverity int
 
 const (
-  // LSPDiagnosticSeverityError is the most prominent severity; ttsc maps
-  // build-blocking findings (lint errors, parse errors) to it.
-  LSPDiagnosticSeverityError LSPDiagnosticSeverity = 1
-  // LSPDiagnosticSeverityWarning is rendered as a yellow squiggle in
-  // typical editor themes; ttsc maps lint warnings to it.
-  LSPDiagnosticSeverityWarning LSPDiagnosticSeverity = 2
-  // LSPDiagnosticSeverityInformation is rendered as a blue squiggle.
-  LSPDiagnosticSeverityInformation LSPDiagnosticSeverity = 3
-  // LSPDiagnosticSeverityHint is rendered as a faint underline or dots.
-  LSPDiagnosticSeverityHint LSPDiagnosticSeverity = 4
+	// LSPDiagnosticSeverityError is the most prominent severity; ttsc maps
+	// build-blocking findings (lint errors, parse errors) to it.
+	LSPDiagnosticSeverityError LSPDiagnosticSeverity = 1
+	// LSPDiagnosticSeverityWarning is rendered as a yellow squiggle in
+	// typical editor themes; ttsc maps lint warnings to it.
+	LSPDiagnosticSeverityWarning LSPDiagnosticSeverity = 2
+	// LSPDiagnosticSeverityInformation is rendered as a blue squiggle.
+	LSPDiagnosticSeverityInformation LSPDiagnosticSeverity = 3
+	// LSPDiagnosticSeverityHint is rendered as a faint underline or dots.
+	LSPDiagnosticSeverityHint LSPDiagnosticSeverity = 4
 )
 
 // LSPDiagnostic is the minimal subset of the LSP Diagnostic type
 // ttscserver injects into outgoing publishDiagnostics. omitempty is set
 // on optional fields so the merged JSON stays close to what tsgo emits.
 type LSPDiagnostic struct {
-  Range    LSPRange              `json:"range"`
-  Severity LSPDiagnosticSeverity `json:"severity,omitempty"`
-  Code     any                   `json:"code,omitempty"`
-  Source   string                `json:"source,omitempty"`
-  Message  string                `json:"message"`
+	Range    LSPRange              `json:"range"`
+	Severity LSPDiagnosticSeverity `json:"severity,omitempty"`
+	Code     any                   `json:"code,omitempty"`
+	Source   string                `json:"source,omitempty"`
+	Message  string                `json:"message"`
 }
 
 // LSPCodeAction is the minimal Code Action shape ttscserver returns from
 // the textDocument/codeAction handler. ttsc actions are always command-
 // driven (the server side does the heavy lifting) so Edit stays nil.
 type LSPCodeAction struct {
-  Title     string          `json:"title"`
-  Kind      string          `json:"kind,omitempty"`
-  Command   *LSPCommand     `json:"command,omitempty"`
-  Edit      json.RawMessage `json:"edit,omitempty"`
-  IsPreferred bool          `json:"isPreferred,omitempty"`
+	Title       string          `json:"title"`
+	Kind        string          `json:"kind,omitempty"`
+	Command     *LSPCommand     `json:"command,omitempty"`
+	Edit        json.RawMessage `json:"edit,omitempty"`
+	IsPreferred bool            `json:"isPreferred,omitempty"`
 }
 
 // LSPCommand is the wire shape of a workspace/executeCommand target.
 type LSPCommand struct {
-  Title     string            `json:"title"`
-  Command   string            `json:"command"`
-  Arguments []json.RawMessage `json:"arguments,omitempty"`
+	Title     string            `json:"title"`
+	Command   string            `json:"command"`
+	Arguments []json.RawMessage `json:"arguments,omitempty"`
 }
 
 // LSPCodeActionContext mirrors the context object the editor sends with
 // textDocument/codeAction. Only the diagnostics slice is consumed by
 // ttsc; the rest is opaque and forwarded by Proxy verbatim.
 type LSPCodeActionContext struct {
-  Diagnostics []json.RawMessage `json:"diagnostics,omitempty"`
-  Only        []string          `json:"only,omitempty"`
-  TriggerKind int               `json:"triggerKind,omitempty"`
+	Diagnostics []json.RawMessage `json:"diagnostics,omitempty"`
+	Only        []string          `json:"only,omitempty"`
+	TriggerKind int               `json:"triggerKind,omitempty"`
 }
 
 // LSPWorkspaceEdit is the wire shape ttscserver returns from custom
 // executeCommand handlers. It maps URIs to ordered text edits.
 type LSPWorkspaceEdit struct {
-  Changes map[string][]LSPTextEdit `json:"changes,omitempty"`
+	Changes map[string][]LSPTextEdit `json:"changes,omitempty"`
 }
 
 // LSPTextEdit is a single text edit in a workspace edit.
 type LSPTextEdit struct {
-  Range   LSPRange `json:"range"`
-  NewText string   `json:"newText"`
+	Range   LSPRange `json:"range"`
+	NewText string   `json:"newText"`
 }
 
 // LSPDocumentVersion carries the LSP textDocument version associated
@@ -93,8 +93,8 @@ type LSPTextEdit struct {
 // Version is nil when upstream omitted the field — that is legal in
 // LSP and the plugin source should treat it as "version unknown".
 type LSPDocumentVersion struct {
-  URI     string
-  Version *int
+	URI     string
+	Version *int
 }
 
 // PluginSource is the seam between the LSP proxy and ttsc's plugin
@@ -104,26 +104,26 @@ type LSPDocumentVersion struct {
 // The proxy never holds a PluginSource lock across upstream traffic, so
 // implementations must be safe to call from multiple goroutines.
 type PluginSource interface {
-  // Diagnostics returns ttsc plugin diagnostics for the document the
-  // proxy is about to publish. doc.Version is nil when upstream omitted
-  // the field. The proxy appends these to whatever upstream tsgo
-  // published, so duplicates between ttsc and tsgo must be deduplicated
-  // on the source side.
-  Diagnostics(doc LSPDocumentVersion) []LSPDiagnostic
+	// Diagnostics returns ttsc plugin diagnostics for the document the
+	// proxy is about to publish. doc.Version is nil when upstream omitted
+	// the field. The proxy appends these to whatever upstream tsgo
+	// published, so duplicates between ttsc and tsgo must be deduplicated
+	// on the source side.
+	Diagnostics(doc LSPDocumentVersion) []LSPDiagnostic
 
-  // CodeActions contributes additional actions for the given range. The
-  // proxy appends them to the upstream tsgo response.
-  CodeActions(uri string, rng LSPRange, ctx LSPCodeActionContext) []LSPCodeAction
+	// CodeActions contributes additional actions for the given range. The
+	// proxy appends them to the upstream tsgo response.
+	CodeActions(uri string, rng LSPRange, ctx LSPCodeActionContext) []LSPCodeAction
 
-  // ExecuteCommand handles workspace/executeCommand requests whose
-  // command id ttsc owns (CommandIDs reports the prefix). A nil edit
-  // means the command ran but produced no workspace changes; a non-nil
-  // error surfaces as an LSP error response.
-  ExecuteCommand(command string, args []json.RawMessage) (*LSPWorkspaceEdit, error)
+	// ExecuteCommand handles workspace/executeCommand requests whose
+	// command id ttsc owns (CommandIDs reports the prefix). A nil edit
+	// means the command ran but produced no workspace changes; a non-nil
+	// error surfaces as an LSP error response.
+	ExecuteCommand(command string, args []json.RawMessage) (*LSPWorkspaceEdit, error)
 
-  // CommandIDs lists the workspace command ids ttsc handles locally so
-  // the proxy never forwards them to upstream tsgo.
-  CommandIDs() []string
+	// CommandIDs lists the workspace command ids ttsc handles locally so
+	// the proxy never forwards them to upstream tsgo.
+	CommandIDs() []string
 }
 
 // NullPluginSource is the zero-contribution PluginSource used when the
@@ -137,12 +137,12 @@ func (NullPluginSource) Diagnostics(LSPDocumentVersion) []LSPDiagnostic { return
 
 // CodeActions returns no plugin code actions.
 func (NullPluginSource) CodeActions(string, LSPRange, LSPCodeActionContext) []LSPCodeAction {
-  return nil
+	return nil
 }
 
 // ExecuteCommand reports that the command is not handled.
 func (NullPluginSource) ExecuteCommand(string, []json.RawMessage) (*LSPWorkspaceEdit, error) {
-  return nil, ErrCommandNotHandled
+	return nil, ErrCommandNotHandled
 }
 
 // CommandIDs returns an empty slice so the proxy forwards every command

--- a/packages/ttsc/internal/lspserver/lsp_plugin.go
+++ b/packages/ttsc/internal/lspserver/lsp_plugin.go
@@ -116,7 +116,7 @@ type PluginSource interface {
 	CodeActions(uri string, rng LSPRange, ctx LSPCodeActionContext) []LSPCodeAction
 
 	// ExecuteCommand handles workspace/executeCommand requests whose
-	// command id ttsc owns (CommandIDs reports the prefix). A nil edit
+	// command id appears in CommandIDs. A nil edit
 	// means the command ran but produced no workspace changes; a non-nil
 	// error surfaces as an LSP error response.
 	ExecuteCommand(command string, args []json.RawMessage) (*LSPWorkspaceEdit, error)

--- a/packages/ttsc/internal/lspserver/lsp_proxy.go
+++ b/packages/ttsc/internal/lspserver/lsp_proxy.go
@@ -1,4 +1,4 @@
-package driver
+package lspserver
 
 import (
   "bytes"
@@ -23,17 +23,17 @@ const (
 )
 
 // ProxyOptions wires the byte-level proxy together. ttscserver creates
-// the upstream pipes around an embedded tsgo lsp.Server and hands the
-// proxy editor stdio plus those pipe ends.
+// the upstream pipes around `tsgo --lsp --stdio` and hands the proxy
+// editor stdio plus those pipe ends.
 type ProxyOptions struct {
   EditorIn   io.Reader
   EditorOut  io.Writer
-  UpstreamIn io.Writer // we write here; tsgo lsp.Server reads
-  UpstreamOut io.Reader // tsgo lsp.Server writes here; we read
+  UpstreamIn io.Writer // we write here; the tsgo LSP process reads
+  UpstreamOut io.Reader // the tsgo LSP process writes here; we read
   Source     PluginSource
 }
 
-// Proxy bridges the editor and an upstream tsgo lsp.Server, intercepting
+// Proxy bridges the editor and an upstream tsgo LSP process, intercepting
 // the message types ttsc cares about (publishDiagnostics merge, code
 // action augmentation, executeCommand for ttsc-owned commands).
 type Proxy struct {
@@ -125,7 +125,7 @@ func (p *Proxy) pumpEditorToUpstream(_ context.Context) error {
 }
 
 // closeUpstreamInput closes the upstream writer (if it is also an
-// io.Closer) so the embedded server reads io.EOF and exits its readLoop.
+// io.Closer) so the upstream process reads io.EOF and exits its read loop.
 // We type-assert because the public ProxyOptions surface promises only
 // io.Writer; RunLSPServer always passes an *io.PipeWriter in practice.
 func (p *Proxy) closeUpstreamInput() {
@@ -245,7 +245,7 @@ func (p *Proxy) ownsCommand(command string) bool {
   return false
 }
 
-// pumpUpstreamToEditor reads frames from the embedded tsgo server,
+// pumpUpstreamToEditor reads frames from the upstream tsgo server,
 // augments publishDiagnostics and codeAction responses, and forwards
 // every other frame untouched. The loop terminates on Read error; ctx
 // propagation happens through pipe closure by RunLSPServer's deferred

--- a/packages/ttsc/internal/lspserver/lsp_proxy.go
+++ b/packages/ttsc/internal/lspserver/lsp_proxy.go
@@ -114,7 +114,7 @@ func (p *Proxy) pumpEditorToUpstream(_ context.Context) error {
 			}
 			continue
 		}
-		handled, handleErr := p.handleEditorEnvelope(env, body)
+		handled, handleErr := p.handleEditorEnvelope(env)
 		if handleErr != nil {
 			return handleErr
 		}
@@ -139,7 +139,7 @@ func (p *Proxy) closeUpstreamInput() {
 
 // handleEditorEnvelope returns true if the envelope was fully processed
 // locally (responded to without forwarding upstream).
-func (p *Proxy) handleEditorEnvelope(env Envelope, body []byte) (bool, error) {
+func (p *Proxy) handleEditorEnvelope(env Envelope) (bool, error) {
 	switch env.Method {
 	case methodExecuteCommand:
 		if env.IsRequest() {

--- a/packages/ttsc/internal/lspserver/lsp_proxy.go
+++ b/packages/ttsc/internal/lspserver/lsp_proxy.go
@@ -114,7 +114,11 @@ func (p *Proxy) pumpEditorToUpstream(_ context.Context) error {
 			}
 			continue
 		}
-		if p.handleEditorEnvelope(env, body) {
+		handled, handleErr := p.handleEditorEnvelope(env, body)
+		if handleErr != nil {
+			return handleErr
+		}
+		if handled {
 			continue
 		}
 		if err := WriteFrame(p.upstreamIn, body); err != nil {
@@ -135,11 +139,11 @@ func (p *Proxy) closeUpstreamInput() {
 
 // handleEditorEnvelope returns true if the envelope was fully processed
 // locally (responded to without forwarding upstream).
-func (p *Proxy) handleEditorEnvelope(env Envelope, body []byte) bool {
+func (p *Proxy) handleEditorEnvelope(env Envelope, body []byte) (bool, error) {
 	switch env.Method {
 	case methodExecuteCommand:
-		if env.IsRequest() && p.tryExecuteCommand(env) {
-			return true
+		if env.IsRequest() {
+			return p.tryExecuteCommand(env)
 		}
 	case methodCodeAction:
 		if env.IsRequest() {
@@ -152,7 +156,7 @@ func (p *Proxy) handleEditorEnvelope(env Envelope, body []byte) bool {
 		// the notification continue to upstream.
 		p.forgetCancelledRequest(env)
 	}
-	return false
+	return false, nil
 }
 
 // forgetCancelledRequest removes any pending codeAction entry whose id
@@ -203,24 +207,23 @@ func (p *Proxy) rememberCodeActionRequest(env Envelope) {
 // command id is registered with the PluginSource. Returns true on a
 // successful local response; false when the command should fall through
 // to upstream tsgo.
-func (p *Proxy) tryExecuteCommand(env Envelope) bool {
+func (p *Proxy) tryExecuteCommand(env Envelope) (bool, error) {
 	var params struct {
 		Command   string            `json:"command"`
 		Arguments []json.RawMessage `json:"arguments,omitempty"`
 	}
 	if err := json.Unmarshal(env.Params, &params); err != nil {
-		return false
+		return false, nil
 	}
 	if !p.ownsCommand(params.Command) {
-		return false
+		return false, nil
 	}
 	edit, err := p.source.ExecuteCommand(params.Command, params.Arguments)
 	if errors.Is(err, ErrCommandNotHandled) {
-		return false
+		return false, nil
 	}
 	if err != nil {
-		p.writeError(env.ID, fmt.Sprintf("ttsc command %q failed: %v", params.Command, err))
-		return true
+		return true, p.writeError(env.ID, fmt.Sprintf("ttsc command %q failed: %v", params.Command, err))
 	}
 	// Cycle 1 returns the WorkspaceEdit inside the executeCommand response
 	// instead of sending workspace/applyEdit as a server→client request.
@@ -228,11 +231,9 @@ func (p *Proxy) tryExecuteCommand(env Envelope) bool {
 	// the edit on its side. Sticking to one direction avoids tracking our
 	// own outgoing request ids in the proxy.
 	if edit == nil {
-		p.writeResult(env.ID, nil)
-		return true
+		return true, p.writeResult(env.ID, nil)
 	}
-	p.writeResult(env.ID, edit)
-	return true
+	return true, p.writeResult(env.ID, edit)
 }
 
 func (p *Proxy) ownsCommand(command string) bool {

--- a/packages/ttsc/internal/lspserver/lsp_proxy.go
+++ b/packages/ttsc/internal/lspserver/lsp_proxy.go
@@ -1,75 +1,74 @@
 package lspserver
 
 import (
-  "bytes"
-  "context"
-  "encoding/json"
-  "errors"
-  "fmt"
-  "io"
-  "sync"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
 )
-
 
 // ErrCommandNotHandled is returned by PluginSource.ExecuteCommand for
 // commands ttsc does not own. Callers should fall through to upstream.
 var ErrCommandNotHandled = errors.New("lsp: command not handled by ttsc")
 
 const (
-  methodPublishDiagnostics = "textDocument/publishDiagnostics"
-  methodCodeAction         = "textDocument/codeAction"
-  methodExecuteCommand     = "workspace/executeCommand"
-  methodCancelRequest      = "$/cancelRequest"
+	methodPublishDiagnostics = "textDocument/publishDiagnostics"
+	methodCodeAction         = "textDocument/codeAction"
+	methodExecuteCommand     = "workspace/executeCommand"
+	methodCancelRequest      = "$/cancelRequest"
 )
 
 // ProxyOptions wires the byte-level proxy together. ttscserver creates
 // the upstream pipes around `tsgo --lsp --stdio` and hands the proxy
 // editor stdio plus those pipe ends.
 type ProxyOptions struct {
-  EditorIn   io.Reader
-  EditorOut  io.Writer
-  UpstreamIn io.Writer // we write here; the tsgo LSP process reads
-  UpstreamOut io.Reader // the tsgo LSP process writes here; we read
-  Source     PluginSource
+	EditorIn    io.Reader
+	EditorOut   io.Writer
+	UpstreamIn  io.Writer // we write here; the tsgo LSP process reads
+	UpstreamOut io.Reader // the tsgo LSP process writes here; we read
+	Source      PluginSource
 }
 
 // Proxy bridges the editor and an upstream tsgo LSP process, intercepting
 // the message types ttsc cares about (publishDiagnostics merge, code
 // action augmentation, executeCommand for ttsc-owned commands).
 type Proxy struct {
-  editorIn    io.Reader
-  editorOut   io.Writer
-  upstreamIn  io.Writer
-  upstreamOut io.Reader
-  source      PluginSource
+	editorIn    io.Reader
+	editorOut   io.Writer
+	upstreamIn  io.Writer
+	upstreamOut io.Reader
+	source      PluginSource
 
-  writeMu sync.Mutex // serializes WriteFrame calls to editorOut
+	writeMu sync.Mutex // serializes WriteFrame calls to editorOut
 
-  pendingMu       sync.Mutex
-  pendingActions  map[string]pendingCodeActionRequest
+	pendingMu      sync.Mutex
+	pendingActions map[string]pendingCodeActionRequest
 }
 
 type pendingCodeActionRequest struct {
-  uri string
-  rng LSPRange
-  ctx LSPCodeActionContext
+	uri string
+	rng LSPRange
+	ctx LSPCodeActionContext
 }
 
 // NewProxy returns a Proxy ready to Run. The PluginSource is required;
 // pass NullPluginSource{} for a no-contribution setup.
 func NewProxy(opts ProxyOptions) *Proxy {
-  source := opts.Source
-  if source == nil {
-    source = NullPluginSource{}
-  }
-  return &Proxy{
-    editorIn:       opts.EditorIn,
-    editorOut:      opts.EditorOut,
-    upstreamIn:     opts.UpstreamIn,
-    upstreamOut:    opts.UpstreamOut,
-    source:         source,
-    pendingActions: make(map[string]pendingCodeActionRequest),
-  }
+	source := opts.Source
+	if source == nil {
+		source = NullPluginSource{}
+	}
+	return &Proxy{
+		editorIn:       opts.EditorIn,
+		editorOut:      opts.EditorOut,
+		upstreamIn:     opts.UpstreamIn,
+		upstreamOut:    opts.UpstreamOut,
+		source:         source,
+		pendingActions: make(map[string]pendingCodeActionRequest),
+	}
 }
 
 // Run drives both pump goroutines until they return. Pumps return when
@@ -78,18 +77,18 @@ func NewProxy(opts ProxyOptions) *Proxy {
 // pipe write fails. ErrFrameClosed and context.Canceled are folded into
 // a nil result so editor shutdown does not look like a crash.
 func (p *Proxy) Run(ctx context.Context) error {
-  errCh := make(chan error, 2)
-  go func() { errCh <- p.pumpEditorToUpstream(ctx) }()
-  go func() { errCh <- p.pumpUpstreamToEditor(ctx) }()
+	errCh := make(chan error, 2)
+	go func() { errCh <- p.pumpEditorToUpstream(ctx) }()
+	go func() { errCh <- p.pumpUpstreamToEditor(ctx) }()
 
-  var first error
-  for i := 0; i < 2; i++ {
-    err := <-errCh
-    if first == nil && err != nil && !errors.Is(err, ErrFrameClosed) {
-      first = err
-    }
-  }
-  return first
+	var first error
+	for i := 0; i < 2; i++ {
+		err := <-errCh
+		if first == nil && err != nil && !errors.Is(err, ErrFrameClosed) {
+			first = err
+		}
+	}
+	return first
 }
 
 // pumpEditorToUpstream reads frames from the editor, decides whether to
@@ -99,29 +98,29 @@ func (p *Proxy) Run(ctx context.Context) error {
 // writer so tsgo's server-side Read returns EOF and its Run loop drains;
 // without that nudge tsgo would wait forever for more input.
 func (p *Proxy) pumpEditorToUpstream(_ context.Context) error {
-  fr := NewFrameReader(p.editorIn)
-  for {
-    _, body, err := fr.Read()
-    if err != nil {
-      if errors.Is(err, ErrFrameClosed) {
-        p.closeUpstreamInput()
-      }
-      return err
-    }
-    env, parseErr := ParseEnvelope(body)
-    if parseErr != nil {
-      if forwardErr := WriteFrame(p.upstreamIn, body); forwardErr != nil {
-        return forwardErr
-      }
-      continue
-    }
-    if p.handleEditorEnvelope(env, body) {
-      continue
-    }
-    if err := WriteFrame(p.upstreamIn, body); err != nil {
-      return err
-    }
-  }
+	fr := NewFrameReader(p.editorIn)
+	for {
+		_, body, err := fr.Read()
+		if err != nil {
+			if errors.Is(err, ErrFrameClosed) {
+				p.closeUpstreamInput()
+			}
+			return err
+		}
+		env, parseErr := ParseEnvelope(body)
+		if parseErr != nil {
+			if forwardErr := WriteFrame(p.upstreamIn, body); forwardErr != nil {
+				return forwardErr
+			}
+			continue
+		}
+		if p.handleEditorEnvelope(env, body) {
+			continue
+		}
+		if err := WriteFrame(p.upstreamIn, body); err != nil {
+			return err
+		}
+	}
 }
 
 // closeUpstreamInput closes the upstream writer (if it is also an
@@ -129,31 +128,31 @@ func (p *Proxy) pumpEditorToUpstream(_ context.Context) error {
 // We type-assert because the public ProxyOptions surface promises only
 // io.Writer; RunLSPServer always passes an *io.PipeWriter in practice.
 func (p *Proxy) closeUpstreamInput() {
-  if closer, ok := p.upstreamIn.(io.Closer); ok {
-    _ = closer.Close()
-  }
+	if closer, ok := p.upstreamIn.(io.Closer); ok {
+		_ = closer.Close()
+	}
 }
 
 // handleEditorEnvelope returns true if the envelope was fully processed
 // locally (responded to without forwarding upstream).
 func (p *Proxy) handleEditorEnvelope(env Envelope, body []byte) bool {
-  switch env.Method {
-  case methodExecuteCommand:
-    if env.IsRequest() && p.tryExecuteCommand(env) {
-      return true
-    }
-  case methodCodeAction:
-    if env.IsRequest() {
-      p.rememberCodeActionRequest(env)
-    }
-  case methodCancelRequest:
-    // $/cancelRequest names an in-flight id the editor has given up on.
-    // The proxy drops any pending codeAction entry for that id so the
-    // map cannot grow unbounded across long editor sessions, then lets
-    // the notification continue to upstream.
-    p.forgetCancelledRequest(env)
-  }
-  return false
+	switch env.Method {
+	case methodExecuteCommand:
+		if env.IsRequest() && p.tryExecuteCommand(env) {
+			return true
+		}
+	case methodCodeAction:
+		if env.IsRequest() {
+			p.rememberCodeActionRequest(env)
+		}
+	case methodCancelRequest:
+		// $/cancelRequest names an in-flight id the editor has given up on.
+		// The proxy drops any pending codeAction entry for that id so the
+		// map cannot grow unbounded across long editor sessions, then lets
+		// the notification continue to upstream.
+		p.forgetCancelledRequest(env)
+	}
+	return false
 }
 
 // forgetCancelledRequest removes any pending codeAction entry whose id
@@ -162,42 +161,42 @@ func (p *Proxy) handleEditorEnvelope(env Envelope, body []byte) bool {
 // through the shared normalizer so a cancel for `1.0` deletes an entry
 // stored under `1` (and vice versa for string-vs-numeric encodings).
 func (p *Proxy) forgetCancelledRequest(env Envelope) {
-  var params struct {
-    ID json.RawMessage `json:"id"`
-  }
-  if err := json.Unmarshal(env.Params, &params); err != nil {
-    return
-  }
-  key := idKeyFromRaw(params.ID)
-  if key == "" {
-    return
-  }
-  p.pendingMu.Lock()
-  defer p.pendingMu.Unlock()
-  delete(p.pendingActions, key)
+	var params struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if err := json.Unmarshal(env.Params, &params); err != nil {
+		return
+	}
+	key := idKeyFromRaw(params.ID)
+	if key == "" {
+		return
+	}
+	p.pendingMu.Lock()
+	defer p.pendingMu.Unlock()
+	delete(p.pendingActions, key)
 }
 
 // rememberCodeActionRequest stores the request payload so the matching
 // response from upstream can be augmented with ttsc-owned code actions
 // for the same range.
 func (p *Proxy) rememberCodeActionRequest(env Envelope) {
-  var params struct {
-    TextDocument struct {
-      URI string `json:"uri"`
-    } `json:"textDocument"`
-    Range   LSPRange             `json:"range"`
-    Context LSPCodeActionContext `json:"context"`
-  }
-  if err := json.Unmarshal(env.Params, &params); err != nil {
-    return
-  }
-  p.pendingMu.Lock()
-  defer p.pendingMu.Unlock()
-  p.pendingActions[env.IDKey()] = pendingCodeActionRequest{
-    uri: params.TextDocument.URI,
-    rng: params.Range,
-    ctx: params.Context,
-  }
+	var params struct {
+		TextDocument struct {
+			URI string `json:"uri"`
+		} `json:"textDocument"`
+		Range   LSPRange             `json:"range"`
+		Context LSPCodeActionContext `json:"context"`
+	}
+	if err := json.Unmarshal(env.Params, &params); err != nil {
+		return
+	}
+	p.pendingMu.Lock()
+	defer p.pendingMu.Unlock()
+	p.pendingActions[env.IDKey()] = pendingCodeActionRequest{
+		uri: params.TextDocument.URI,
+		rng: params.Range,
+		ctx: params.Context,
+	}
 }
 
 // tryExecuteCommand handles workspace/executeCommand requests whose
@@ -205,44 +204,44 @@ func (p *Proxy) rememberCodeActionRequest(env Envelope) {
 // successful local response; false when the command should fall through
 // to upstream tsgo.
 func (p *Proxy) tryExecuteCommand(env Envelope) bool {
-  var params struct {
-    Command   string            `json:"command"`
-    Arguments []json.RawMessage `json:"arguments,omitempty"`
-  }
-  if err := json.Unmarshal(env.Params, &params); err != nil {
-    return false
-  }
-  if !p.ownsCommand(params.Command) {
-    return false
-  }
-  edit, err := p.source.ExecuteCommand(params.Command, params.Arguments)
-  if errors.Is(err, ErrCommandNotHandled) {
-    return false
-  }
-  if err != nil {
-    p.writeError(env.ID, fmt.Sprintf("ttsc command %q failed: %v", params.Command, err))
-    return true
-  }
-  // Cycle 1 returns the WorkspaceEdit inside the executeCommand response
-  // instead of sending workspace/applyEdit as a server→client request.
-  // ttsc owns both ends (its VSCode extension), so the extension applies
-  // the edit on its side. Sticking to one direction avoids tracking our
-  // own outgoing request ids in the proxy.
-  if edit == nil {
-    p.writeResult(env.ID, nil)
-    return true
-  }
-  p.writeResult(env.ID, edit)
-  return true
+	var params struct {
+		Command   string            `json:"command"`
+		Arguments []json.RawMessage `json:"arguments,omitempty"`
+	}
+	if err := json.Unmarshal(env.Params, &params); err != nil {
+		return false
+	}
+	if !p.ownsCommand(params.Command) {
+		return false
+	}
+	edit, err := p.source.ExecuteCommand(params.Command, params.Arguments)
+	if errors.Is(err, ErrCommandNotHandled) {
+		return false
+	}
+	if err != nil {
+		p.writeError(env.ID, fmt.Sprintf("ttsc command %q failed: %v", params.Command, err))
+		return true
+	}
+	// Cycle 1 returns the WorkspaceEdit inside the executeCommand response
+	// instead of sending workspace/applyEdit as a server→client request.
+	// ttsc owns both ends (its VSCode extension), so the extension applies
+	// the edit on its side. Sticking to one direction avoids tracking our
+	// own outgoing request ids in the proxy.
+	if edit == nil {
+		p.writeResult(env.ID, nil)
+		return true
+	}
+	p.writeResult(env.ID, edit)
+	return true
 }
 
 func (p *Proxy) ownsCommand(command string) bool {
-  for _, id := range p.source.CommandIDs() {
-    if id == command {
-      return true
-    }
-  }
-  return false
+	for _, id := range p.source.CommandIDs() {
+		if id == command {
+			return true
+		}
+	}
+	return false
 }
 
 // pumpUpstreamToEditor reads frames from the upstream tsgo server,
@@ -251,24 +250,24 @@ func (p *Proxy) ownsCommand(command string) bool {
 // propagation happens through pipe closure by RunLSPServer's deferred
 // cleanup goroutines.
 func (p *Proxy) pumpUpstreamToEditor(_ context.Context) error {
-  fr := NewFrameReader(p.upstreamOut)
-  for {
-    _, body, err := fr.Read()
-    if err != nil {
-      return err
-    }
-    env, parseErr := ParseEnvelope(body)
-    if parseErr != nil {
-      if forwardErr := p.writeEditorFrame(body); forwardErr != nil {
-        return forwardErr
-      }
-      continue
-    }
-    augmented := p.augmentUpstream(env, body)
-    if err := p.writeEditorFrame(augmented); err != nil {
-      return err
-    }
-  }
+	fr := NewFrameReader(p.upstreamOut)
+	for {
+		_, body, err := fr.Read()
+		if err != nil {
+			return err
+		}
+		env, parseErr := ParseEnvelope(body)
+		if parseErr != nil {
+			if forwardErr := p.writeEditorFrame(body); forwardErr != nil {
+				return forwardErr
+			}
+			continue
+		}
+		augmented := p.augmentUpstream(env, body)
+		if err := p.writeEditorFrame(augmented); err != nil {
+			return err
+		}
+	}
 }
 
 // augmentUpstream returns the (possibly rewritten) body to forward. For
@@ -284,25 +283,25 @@ func (p *Proxy) pumpUpstreamToEditor(_ context.Context) error {
 // semantics. When the cancel wins, the pending entry is gone and
 // augmentation skips cleanly.
 func (p *Proxy) augmentUpstream(env Envelope, body []byte) []byte {
-  if env.IsNotification() && env.Method == methodPublishDiagnostics {
-    if merged, ok := p.mergePublishDiagnostics(env); ok {
-      return merged
-    }
-  }
-  if env.IsResponse() {
-    p.pendingMu.Lock()
-    pending, ok := p.pendingActions[env.IDKey()]
-    if ok {
-      delete(p.pendingActions, env.IDKey())
-    }
-    p.pendingMu.Unlock()
-    if ok {
-      if augmented, augOk := p.appendCodeActions(env, pending); augOk {
-        return augmented
-      }
-    }
-  }
-  return body
+	if env.IsNotification() && env.Method == methodPublishDiagnostics {
+		if merged, ok := p.mergePublishDiagnostics(env); ok {
+			return merged
+		}
+	}
+	if env.IsResponse() {
+		p.pendingMu.Lock()
+		pending, ok := p.pendingActions[env.IDKey()]
+		if ok {
+			delete(p.pendingActions, env.IDKey())
+		}
+		p.pendingMu.Unlock()
+		if ok {
+			if augmented, augOk := p.appendCodeActions(env, pending); augOk {
+				return augmented
+			}
+		}
+	}
+	return body
 }
 
 // mergePublishDiagnostics decodes the publishDiagnostics params, asks
@@ -312,25 +311,25 @@ func (p *Proxy) augmentUpstream(env Envelope, body []byte) []byte {
 // verbatim." Re-encoding our own types is guaranteed by their
 // definitions in lsp_plugin.go, so the marshal errors are not checked.
 func (p *Proxy) mergePublishDiagnostics(env Envelope) ([]byte, bool) {
-  var params struct {
-    URI         string            `json:"uri"`
-    Version     *int              `json:"version,omitempty"`
-    Diagnostics []json.RawMessage `json:"diagnostics"`
-  }
-  if err := json.Unmarshal(env.Params, &params); err != nil {
-    return nil, false
-  }
-  extras := p.source.Diagnostics(LSPDocumentVersion{URI: params.URI, Version: params.Version})
-  if len(extras) == 0 {
-    return nil, false
-  }
-  for _, extra := range extras {
-    raw, _ := json.Marshal(extra)
-    params.Diagnostics = append(params.Diagnostics, raw)
-  }
-  env.Params, _ = json.Marshal(params)
-  body, _ := json.Marshal(env)
-  return body, true
+	var params struct {
+		URI         string            `json:"uri"`
+		Version     *int              `json:"version,omitempty"`
+		Diagnostics []json.RawMessage `json:"diagnostics"`
+	}
+	if err := json.Unmarshal(env.Params, &params); err != nil {
+		return nil, false
+	}
+	extras := p.source.Diagnostics(LSPDocumentVersion{URI: params.URI, Version: params.Version})
+	if len(extras) == 0 {
+		return nil, false
+	}
+	for _, extra := range extras {
+		raw, _ := json.Marshal(extra)
+		params.Diagnostics = append(params.Diagnostics, raw)
+	}
+	env.Params, _ = json.Marshal(params)
+	body, _ := json.Marshal(env)
+	return body, true
 }
 
 // appendCodeActions adds ttsc-owned code actions to a forwarded
@@ -343,49 +342,49 @@ func (p *Proxy) mergePublishDiagnostics(env Envelope) ([]byte, bool) {
 // shape ttsc cannot splice into, so the proxy forwards verbatim
 // rather than corrupting it).
 func (p *Proxy) appendCodeActions(env Envelope, pending pendingCodeActionRequest) ([]byte, bool) {
-  if env.IsErrorResponse() {
-    return nil, false
-  }
-  trimmed := bytes.TrimSpace(env.Result)
-  if len(trimmed) > 0 && trimmed[0] != '[' && !bytes.Equal(trimmed, []byte("null")) {
-    return nil, false
-  }
-  actions := p.source.CodeActions(pending.uri, pending.rng, pending.ctx)
-  if len(actions) == 0 {
-    return nil, false
-  }
-  var existing []json.RawMessage
-  if len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null")) {
-    _ = json.Unmarshal(trimmed, &existing)
-  }
-  for _, action := range actions {
-    raw, _ := json.Marshal(action)
-    existing = append(existing, raw)
-  }
-  env.Result, _ = json.Marshal(existing)
-  body, _ := json.Marshal(env)
-  return body, true
+	if env.IsErrorResponse() {
+		return nil, false
+	}
+	trimmed := bytes.TrimSpace(env.Result)
+	if len(trimmed) > 0 && trimmed[0] != '[' && !bytes.Equal(trimmed, []byte("null")) {
+		return nil, false
+	}
+	actions := p.source.CodeActions(pending.uri, pending.rng, pending.ctx)
+	if len(actions) == 0 {
+		return nil, false
+	}
+	var existing []json.RawMessage
+	if len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null")) {
+		_ = json.Unmarshal(trimmed, &existing)
+	}
+	for _, action := range actions {
+		raw, _ := json.Marshal(action)
+		existing = append(existing, raw)
+	}
+	env.Result, _ = json.Marshal(existing)
+	body, _ := json.Marshal(env)
+	return body, true
 }
 
 func (p *Proxy) writeEditorFrame(body []byte) error {
-  p.writeMu.Lock()
-  defer p.writeMu.Unlock()
-  return WriteFrame(p.editorOut, body)
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
+	return WriteFrame(p.editorOut, body)
 }
 
 func (p *Proxy) writeResult(id json.RawMessage, result any) error {
-  rawResult, _ := json.Marshal(result)
-  env := Envelope{JSONRPC: "2.0", ID: id, Result: rawResult}
-  body, _ := json.Marshal(env)
-  return p.writeEditorFrame(body)
+	rawResult, _ := json.Marshal(result)
+	env := Envelope{JSONRPC: "2.0", ID: id, Result: rawResult}
+	body, _ := json.Marshal(env)
+	return p.writeEditorFrame(body)
 }
 
 func (p *Proxy) writeError(id json.RawMessage, message string) error {
-  errPayload, _ := json.Marshal(struct {
-    Code    int    `json:"code"`
-    Message string `json:"message"`
-  }{Code: -32603, Message: message})
-  env := Envelope{JSONRPC: "2.0", ID: id, Error: errPayload}
-  body, _ := json.Marshal(env)
-  return p.writeEditorFrame(body)
+	errPayload, _ := json.Marshal(struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}{Code: -32603, Message: message})
+	env := Envelope{JSONRPC: "2.0", ID: id, Error: errPayload}
+	body, _ := json.Marshal(env)
+	return p.writeEditorFrame(body)
 }

--- a/packages/ttsc/internal/lspserver/lsp_server.go
+++ b/packages/ttsc/internal/lspserver/lsp_server.go
@@ -43,7 +43,8 @@ func RecoverPanicAs(fn func() error) (err error) {
 // provides the upstream LSP server.
 type LSPServerOptions struct {
   // In is the editor-side reader; ttscserver reads JSON-RPC frames from
-  // it and forwards or handles them.
+  // it and forwards or handles them. RunLSPServer closes it on shutdown
+  // if it also implements io.Closer so blocked frame reads can unblock.
   In io.Reader
   // Out is the editor-side writer; ttscserver writes both upstream
   // responses and locally-synthesized messages to it.
@@ -167,9 +168,12 @@ func RunLSPServer(ctx context.Context, opts LSPServerOptions) error {
   // Watchdog: on cancel, close the writer ends of the upstream pipes so
   // both halves unblock with a clean io.EOF. Closing readers directly
   // would surface as io.ErrClosedPipe and make ttsc's error fold
-  // ambiguous; closing writers preserves the ErrFrameClosed signal.
+  // ambiguous; closing writers preserves the ErrFrameClosed signal. The
+  // editor input is also closed when possible so an upstream process-start
+  // failure cannot leave the editor->upstream pump blocked on stdin.
   go func() {
     <-serverCtx.Done()
+    closeIfCloser(opts.In)
     upstreamInW.Close()
     upstreamOutW.Close()
   }()
@@ -218,4 +222,10 @@ func RunLSPServer(ctx context.Context, opts LSPServerOptions) error {
 // override tsgo's internal ATA callback.
 func DenyNpmInstall(_ string, args []string) ([]byte, error) {
   return nil, fmt.Errorf("ttscserver: npm install disabled in LSP host (args=%v)", args)
+}
+
+func closeIfCloser(value any) {
+  if closer, ok := value.(io.Closer); ok {
+    _ = closer.Close()
+  }
 }

--- a/packages/ttsc/internal/lspserver/lsp_server.go
+++ b/packages/ttsc/internal/lspserver/lsp_server.go
@@ -1,15 +1,15 @@
 package lspserver
 
 import (
-  "context"
-  "errors"
-  "fmt"
-  "io"
-  "os/exec"
-  "path/filepath"
-  "runtime/debug"
-  "sync"
-  "time"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"runtime/debug"
+	"sync"
+	"time"
 )
 
 // ErrLSPUpstreamPanic wraps a panic recovered from inside an upstream
@@ -29,12 +29,12 @@ var ErrLSPUpstreamPanic = errors.New("ttscserver: tsgo upstream runner panicked"
 // goroutine and join on a sentinel channel — outside this helper's
 // scope today.
 func RecoverPanicAs(fn func() error) (err error) {
-  defer func() {
-    if r := recover(); r != nil {
-      err = fmt.Errorf("%w: %v\n%s", ErrLSPUpstreamPanic, r, debug.Stack())
-    }
-  }()
-  return fn()
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%w: %v\n%s", ErrLSPUpstreamPanic, r, debug.Stack())
+		}
+	}()
+	return fn()
 }
 
 // LSPServerOptions wires ttscserver to its three channels of state:
@@ -42,29 +42,29 @@ func RecoverPanicAs(fn func() error) (err error) {
 // merging plugin diagnostics into the stream, and the tsgo binary that
 // provides the upstream LSP server.
 type LSPServerOptions struct {
-  // In is the editor-side reader; ttscserver reads JSON-RPC frames from
-  // it and forwards or handles them. RunLSPServer closes it on shutdown
-  // if it also implements io.Closer so blocked frame reads can unblock.
-  In io.Reader
-  // Out is the editor-side writer; ttscserver writes both upstream
-  // responses and locally-synthesized messages to it.
-  Out io.Writer
-  // Err is the upstream tsgo server's stderr sink. ttscserver does not
-  // log to it directly.
-  Err io.Writer
+	// In is the editor-side reader; ttscserver reads JSON-RPC frames from
+	// it and forwards or handles them. RunLSPServer closes it on shutdown
+	// if it also implements io.Closer so blocked frame reads can unblock.
+	In io.Reader
+	// Out is the editor-side writer; ttscserver writes both upstream
+	// responses and locally-synthesized messages to it.
+	Out io.Writer
+	// Err is the upstream tsgo server's stderr sink. ttscserver does not
+	// log to it directly.
+	Err io.Writer
 
-  // Cwd is the project root used as the upstream tsgo process working
-  // directory. An empty string is rejected before any process starts.
-  Cwd string
-  // TsgoBinary is the absolute path to the project-selected
-  // @typescript/native-preview executable.
-  TsgoBinary string
-  // Source contributes ttsc plugin diagnostics / code actions /
-  // executeCommand handling. Nil falls back to NullPluginSource{}.
-  Source PluginSource
-  // ProgressDelay is accepted for CLI compatibility. The external tsgo
-  // LSP command does not currently expose a progress-delay flag.
-  ProgressDelay time.Duration
+	// Cwd is the project root used as the upstream tsgo process working
+	// directory. An empty string is rejected before any process starts.
+	Cwd string
+	// TsgoBinary is the absolute path to the project-selected
+	// @typescript/native-preview executable.
+	TsgoBinary string
+	// Source contributes ttsc plugin diagnostics / code actions /
+	// executeCommand handling. Nil falls back to NullPluginSource{}.
+	Source PluginSource
+	// ProgressDelay is accepted for CLI compatibility. The external tsgo
+	// LSP command does not currently expose a progress-delay flag.
+	ProgressDelay time.Duration
 }
 
 // ErrLSPCwdRequired is returned when LSPServerOptions.Cwd is empty.
@@ -92,39 +92,39 @@ var upstreamValidator = validateDefaultUpstreamOptions
 // production runner. The seam stays in the public driver API because
 // tests and embedders otherwise have no way to bypass tsgo.
 func WithUpstreamRunnerForTest(runner LSPUpstreamRunner) func() {
-  prev := upstreamRunner
-  prevValidator := upstreamValidator
-  upstreamRunner = runner
-  upstreamValidator = func(LSPServerOptions) error { return nil }
-  return func() {
-    upstreamRunner = prev
-    upstreamValidator = prevValidator
-  }
+	prev := upstreamRunner
+	prevValidator := upstreamValidator
+	upstreamRunner = runner
+	upstreamValidator = func(LSPServerOptions) error { return nil }
+	return func() {
+		upstreamRunner = prev
+		upstreamValidator = prevValidator
+	}
 }
 
 func validateDefaultUpstreamOptions(opts LSPServerOptions) error {
-  if opts.TsgoBinary == "" {
-    return ErrLSPTsgoBinaryRequired
-  }
-  if !filepath.IsAbs(opts.TsgoBinary) {
-    return fmt.Errorf("ttscserver: tsgo binary must be absolute: %s", opts.TsgoBinary)
-  }
-  return nil
+	if opts.TsgoBinary == "" {
+		return ErrLSPTsgoBinaryRequired
+	}
+	if !filepath.IsAbs(opts.TsgoBinary) {
+		return fmt.Errorf("ttscserver: tsgo binary must be absolute: %s", opts.TsgoBinary)
+	}
+	return nil
 }
 
 func defaultUpstreamRunner(ctx context.Context, in io.Reader, out io.Writer, opts LSPServerOptions) error {
-  cmd := exec.CommandContext(ctx, opts.TsgoBinary, "--lsp", "--stdio")
-  cmd.Dir = opts.Cwd
-  cmd.Stdin = in
-  cmd.Stdout = out
-  cmd.Stderr = opts.Err
-  if err := cmd.Run(); err != nil {
-    if ctx.Err() != nil {
-      return ctx.Err()
-    }
-    return fmt.Errorf("tsgo --lsp --stdio: %w", err)
-  }
-  return nil
+	cmd := exec.CommandContext(ctx, opts.TsgoBinary, "--lsp", "--stdio")
+	cmd.Dir = opts.Cwd
+	cmd.Stdin = in
+	cmd.Stdout = out
+	cmd.Stderr = opts.Err
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("tsgo --lsp --stdio: %w", err)
+	}
+	return nil
 }
 
 // RunLSPServer starts an upstream `tsgo --lsp --stdio` process and the byte-level
@@ -140,92 +140,92 @@ func defaultUpstreamRunner(ctx context.Context, in io.Reader, out io.Writer, opt
 //  4. A watchdog cascades context cancellation by closing every pipe so both
 //     halves unblock; the goroutines' own defers close the rest.
 func RunLSPServer(ctx context.Context, opts LSPServerOptions) error {
-  if opts.Cwd == "" {
-    return ErrLSPCwdRequired
-  }
-  if err := upstreamValidator(opts); err != nil {
-    return err
-  }
-  source := opts.Source
-  if source == nil {
-    source = NullPluginSource{}
-  }
+	if opts.Cwd == "" {
+		return ErrLSPCwdRequired
+	}
+	if err := upstreamValidator(opts); err != nil {
+		return err
+	}
+	source := opts.Source
+	if source == nil {
+		source = NullPluginSource{}
+	}
 
-  upstreamInR, upstreamInW := io.Pipe()
-  upstreamOutR, upstreamOutW := io.Pipe()
+	upstreamInR, upstreamInW := io.Pipe()
+	upstreamOutR, upstreamOutW := io.Pipe()
 
-  proxy := NewProxy(ProxyOptions{
-    EditorIn:    opts.In,
-    EditorOut:   opts.Out,
-    UpstreamIn:  upstreamInW,
-    UpstreamOut: upstreamOutR,
-    Source:      source,
-  })
+	proxy := NewProxy(ProxyOptions{
+		EditorIn:    opts.In,
+		EditorOut:   opts.Out,
+		UpstreamIn:  upstreamInW,
+		UpstreamOut: upstreamOutR,
+		Source:      source,
+	})
 
-  serverCtx, cancel := context.WithCancel(ctx)
-  defer cancel()
+	serverCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-  // Watchdog: on cancel, close the writer ends of the upstream pipes so
-  // both halves unblock with a clean io.EOF. Closing readers directly
-  // would surface as io.ErrClosedPipe and make ttsc's error fold
-  // ambiguous; closing writers preserves the ErrFrameClosed signal. The
-  // editor input is also closed when possible so an upstream process-start
-  // failure cannot leave the editor->upstream pump blocked on stdin.
-  go func() {
-    <-serverCtx.Done()
-    closeIfCloser(opts.In)
-    upstreamInW.Close()
-    upstreamOutW.Close()
-  }()
+	// Watchdog: on cancel, close the writer ends of the upstream pipes so
+	// both halves unblock with a clean io.EOF. Closing readers directly
+	// would surface as io.ErrClosedPipe and make ttsc's error fold
+	// ambiguous; closing writers preserves the ErrFrameClosed signal. The
+	// editor input is also closed when possible so an upstream process-start
+	// failure cannot leave the editor->upstream pump blocked on stdin.
+	go func() {
+		<-serverCtx.Done()
+		closeIfCloser(opts.In)
+		upstreamInW.Close()
+		upstreamOutW.Close()
+	}()
 
-  var wg sync.WaitGroup
-  var serverErr, proxyErr error
-  wg.Add(2)
-  go func() {
-    defer wg.Done()
-    defer cancel()
-    defer upstreamOutW.Close()
-    defer upstreamInR.Close()
-    serverErr = RecoverPanicAs(func() error {
-      return upstreamRunner(serverCtx, upstreamInR, upstreamOutW, opts)
-    })
-  }()
-  go func() {
-    defer wg.Done()
-    defer cancel()
-    defer upstreamInW.Close()
-    defer upstreamOutR.Close()
-    proxyErr = proxy.Run(serverCtx)
-  }()
-  wg.Wait()
+	var wg sync.WaitGroup
+	var serverErr, proxyErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		defer upstreamOutW.Close()
+		defer upstreamInR.Close()
+		serverErr = RecoverPanicAs(func() error {
+			return upstreamRunner(serverCtx, upstreamInR, upstreamOutW, opts)
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		defer upstreamInW.Close()
+		defer upstreamOutR.Close()
+		proxyErr = proxy.Run(serverCtx)
+	}()
+	wg.Wait()
 
-  for _, err := range []error{serverErr, proxyErr} {
-    if err == nil {
-      continue
-    }
-    if errors.Is(err, context.Canceled) {
-      continue
-    }
-    if errors.Is(err, ErrFrameClosed) {
-      continue
-    }
-    if errors.Is(err, io.ErrClosedPipe) {
-      continue
-    }
-    return err
-  }
-  return nil
+	for _, err := range []error{serverErr, proxyErr} {
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, context.Canceled) {
+			continue
+		}
+		if errors.Is(err, ErrFrameClosed) {
+			continue
+		}
+		if errors.Is(err, io.ErrClosedPipe) {
+			continue
+		}
+		return err
+	}
+	return nil
 }
 
 // DenyNpmInstall is kept for source compatibility with older driver
 // embedders that hosted tsgo in-process. The process wrapper cannot
 // override tsgo's internal ATA callback.
 func DenyNpmInstall(_ string, args []string) ([]byte, error) {
-  return nil, fmt.Errorf("ttscserver: npm install disabled in LSP host (args=%v)", args)
+	return nil, fmt.Errorf("ttscserver: npm install disabled in LSP host (args=%v)", args)
 }
 
 func closeIfCloser(value any) {
-  if closer, ok := value.(io.Closer); ok {
-    _ = closer.Close()
-  }
+	if closer, ok := value.(io.Closer); ok {
+		_ = closer.Close()
+	}
 }

--- a/packages/ttsc/internal/lspserver/lsp_server.go
+++ b/packages/ttsc/internal/lspserver/lsp_server.go
@@ -1,29 +1,26 @@
-package driver
+package lspserver
 
 import (
   "context"
   "errors"
   "fmt"
   "io"
+  "os/exec"
+  "path/filepath"
   "runtime/debug"
   "sync"
   "time"
-
-  "github.com/microsoft/typescript-go/shim/bundled"
-  shimlsp "github.com/microsoft/typescript-go/shim/lsp"
-  "github.com/microsoft/typescript-go/shim/vfs/osvfs"
 )
 
-// ErrLSPUpstreamPanic wraps a panic recovered from inside the embedded
-// tsgo lsp.Server. Without recovery the host process would die when
-// tsgo crashed; with this wrapper the proxy can surface a typed error
-// to the editor instead.
-var ErrLSPUpstreamPanic = errors.New("ttscserver: embedded tsgo server panicked")
+// ErrLSPUpstreamPanic wraps a panic recovered from inside an upstream
+// runner. The production runner is an external tsgo process, but tests
+// and embedders can still install in-process runners through
+// WithUpstreamRunnerForTest.
+var ErrLSPUpstreamPanic = errors.New("ttscserver: tsgo upstream runner panicked")
 
 // RecoverPanicAs runs fn and converts a panic into an
-// ErrLSPUpstreamPanic-wrapped error. defaultUpstreamRunner uses it and
-// downstream LSP-host embeddings can opt into the same recovery
-// contract; the recovered stack is attached for diagnostics.
+// ErrLSPUpstreamPanic-wrapped error. RunLSPServer uses it around the
+// upstream runner seam; the recovered stack is attached for diagnostics.
 //
 // recover() per the Go spec catches panics but NOT runtime.Goexit, so
 // a Goexit raised from inside fn surfaces as a clean nil return here
@@ -42,8 +39,8 @@ func RecoverPanicAs(fn func() error) (err error) {
 
 // LSPServerOptions wires ttscserver to its three channels of state:
 // editor stdio for the LSP transport, an optional ttsc PluginSource for
-// merging plugin diagnostics into the stream, and a working directory
-// the embedded tsgo server treats as the project root.
+// merging plugin diagnostics into the stream, and the tsgo binary that
+// provides the upstream LSP server.
 type LSPServerOptions struct {
   // In is the editor-side reader; ttscserver reads JSON-RPC frames from
   // it and forwards or handles them.
@@ -55,72 +52,98 @@ type LSPServerOptions struct {
   // log to it directly.
   Err io.Writer
 
-  // Cwd is the project root passed to tsgo's LSP. An empty string
-  // panics inside tsgo, so RunLSPServer validates it up front.
+  // Cwd is the project root used as the upstream tsgo process working
+  // directory. An empty string is rejected before any process starts.
   Cwd string
+  // TsgoBinary is the absolute path to the project-selected
+  // @typescript/native-preview executable.
+  TsgoBinary string
   // Source contributes ttsc plugin diagnostics / code actions /
   // executeCommand handling. Nil falls back to NullPluginSource{}.
   Source PluginSource
-  // ProgressDelay matches tsgo's option for delaying the progress UI;
-  // zero disables the delay.
+  // ProgressDelay is accepted for CLI compatibility. The external tsgo
+  // LSP command does not currently expose a progress-delay flag.
   ProgressDelay time.Duration
 }
 
 // ErrLSPCwdRequired is returned when LSPServerOptions.Cwd is empty.
-// ttsc surfaces a clean error here instead of letting tsgo's panic
-// reach the editor.
+// ttsc surfaces a clean error here instead of starting tsgo from an
+// undefined project directory.
 var ErrLSPCwdRequired = errors.New("ttscserver: cwd is required")
 
-// lspUpstreamRunner is the seam tests use to substitute the embedded
-// tsgo lsp.Server with a controllable fake. Production wires it to the
-// real shim-backed server.
-type lspUpstreamRunner func(ctx context.Context, in io.Reader, out io.Writer, opts LSPServerOptions) error
+// ErrLSPTsgoBinaryRequired is returned when no upstream tsgo executable
+// path was supplied by the JavaScript launcher or native caller.
+var ErrLSPTsgoBinaryRequired = errors.New("ttscserver: tsgo binary is required")
+
+// LSPUpstreamRunner is the seam tests use to substitute the external
+// tsgo process with a controllable fake.
+type LSPUpstreamRunner func(ctx context.Context, in io.Reader, out io.Writer, opts LSPServerOptions) error
 
 // upstreamRunner is replaced in tests via WithUpstreamRunnerForTest.
-var upstreamRunner lspUpstreamRunner = defaultUpstreamRunner
+var upstreamRunner LSPUpstreamRunner = defaultUpstreamRunner
+
+// upstreamValidator checks production-only upstream requirements before any
+// proxy goroutine starts. Test upstream runners replace it with a no-op.
+var upstreamValidator = validateDefaultUpstreamOptions
 
 // WithUpstreamRunnerForTest substitutes the upstream runner used by
 // RunLSPServer. Returns a function the caller defers to restore the
-// production runner. The seam stays in the public API because tests
-// live in driver_test and otherwise have no way to bypass tsgo.
-func WithUpstreamRunnerForTest(runner lspUpstreamRunner) func() {
+// production runner. The seam stays in the public driver API because
+// tests and embedders otherwise have no way to bypass tsgo.
+func WithUpstreamRunnerForTest(runner LSPUpstreamRunner) func() {
   prev := upstreamRunner
+  prevValidator := upstreamValidator
   upstreamRunner = runner
-  return func() { upstreamRunner = prev }
+  upstreamValidator = func(LSPServerOptions) error { return nil }
+  return func() {
+    upstreamRunner = prev
+    upstreamValidator = prevValidator
+  }
+}
+
+func validateDefaultUpstreamOptions(opts LSPServerOptions) error {
+  if opts.TsgoBinary == "" {
+    return ErrLSPTsgoBinaryRequired
+  }
+  if !filepath.IsAbs(opts.TsgoBinary) {
+    return fmt.Errorf("ttscserver: tsgo binary must be absolute: %s", opts.TsgoBinary)
+  }
+  return nil
 }
 
 func defaultUpstreamRunner(ctx context.Context, in io.Reader, out io.Writer, opts LSPServerOptions) error {
-  return RecoverPanicAs(func() error {
-    server := shimlsp.NewServer(&shimlsp.ServerOptions{
-      In:                 shimlsp.ToReader(in),
-      Out:                shimlsp.ToWriter(out),
-      Err:                opts.Err,
-      Cwd:                opts.Cwd,
-      FS:                 DefaultFS(),
-      DefaultLibraryPath: bundled.LibPath(),
-      TypingsLocation:    osvfs.GetGlobalTypingsCacheLocation(),
-      NpmInstall:         DenyNpmInstall,
-      ProgressDelay:      opts.ProgressDelay,
-    })
-    return server.Run(ctx)
-  })
+  cmd := exec.CommandContext(ctx, opts.TsgoBinary, "--lsp", "--stdio")
+  cmd.Dir = opts.Cwd
+  cmd.Stdin = in
+  cmd.Stdout = out
+  cmd.Stderr = opts.Err
+  if err := cmd.Run(); err != nil {
+    if ctx.Err() != nil {
+      return ctx.Err()
+    }
+    return fmt.Errorf("tsgo --lsp --stdio: %w", err)
+  }
+  return nil
 }
 
-// RunLSPServer starts the embedded tsgo lsp.Server and the byte-level
+// RunLSPServer starts an upstream `tsgo --lsp --stdio` process and the byte-level
 // proxy, blocking until either side returns. The first non-graceful
 // error wins; ErrFrameClosed and context cancellation are treated as
 // clean shutdown so editor close sequences do not look like crashes.
 //
 // The lifecycle is:
 //
-//  1. Open two pipes around the embedded server (editor->server, server->editor).
-//  2. Spawn the upstream runner (real tsgo or a test fake) reading/writing those pipes.
+//  1. Open two pipes around the tsgo process (editor->server, server->editor).
+//  2. Spawn the upstream runner (real tsgo process or a test fake) reading/writing those pipes.
 //  3. Run the proxy in parallel.
 //  4. A watchdog cascades context cancellation by closing every pipe so both
 //     halves unblock; the goroutines' own defers close the rest.
 func RunLSPServer(ctx context.Context, opts LSPServerOptions) error {
   if opts.Cwd == "" {
     return ErrLSPCwdRequired
+  }
+  if err := upstreamValidator(opts); err != nil {
+    return err
   }
   source := opts.Source
   if source == nil {
@@ -159,7 +182,9 @@ func RunLSPServer(ctx context.Context, opts LSPServerOptions) error {
     defer cancel()
     defer upstreamOutW.Close()
     defer upstreamInR.Close()
-    serverErr = upstreamRunner(serverCtx, upstreamInR, upstreamOutW, opts)
+    serverErr = RecoverPanicAs(func() error {
+      return upstreamRunner(serverCtx, upstreamInR, upstreamOutW, opts)
+    })
   }()
   go func() {
     defer wg.Done()
@@ -188,10 +213,9 @@ func RunLSPServer(ctx context.Context, opts LSPServerOptions) error {
   return nil
 }
 
-// DenyNpmInstall is the NpmInstall callback ttscserver passes to tsgo's
-// LSP. ttsc has its own plugin / cache pipeline; we never want the LSP
-// host running npm under the user's editor. Exposed so other LSP host
-// embeddings can opt into the same behavior without copying the body.
+// DenyNpmInstall is kept for source compatibility with older driver
+// embedders that hosted tsgo in-process. The process wrapper cannot
+// override tsgo's internal ATA callback.
 func DenyNpmInstall(_ string, args []string) ([]byte, error) {
   return nil, fmt.Errorf("ttscserver: npm install disabled in LSP host (args=%v)", args)
 }

--- a/packages/ttsc/shim/lsp/shim.go
+++ b/packages/ttsc/shim/lsp/shim.go
@@ -1,11 +1,10 @@
 // gen_shims:hand-maintained
 //
 // Minimal shim of tsgo's internal/lsp package. Hand-written instead of
-// generated so the surface stays narrow: ttscserver embeds the tsgo LSP
-// server unmodified and intercepts traffic at the byte level, so the only
-// types it touches are the opaque Server, its options struct, and the
-// Reader/Writer interfaces that ToReader/ToWriter return. The marker on
-// the first line tells gen_shims to skip this file.
+// generated so the surface stays narrow for custom in-process host
+// experiments. The shipped ttscserver wraps `tsgo --lsp --stdio` as an
+// external process and does not import this package. The marker on the
+// first line tells gen_shims to skip this file.
 package lsp
 
 import (
@@ -15,20 +14,15 @@ import (
   innerlsp "github.com/microsoft/typescript-go/internal/lsp"
 )
 
-// Server is the opaque LSP server type from tsgo. ttscserver does not poke
-// its internals; it only calls Run and (via wrapped Writer) observes the
-// traffic the server emits.
+// Server is the opaque LSP server type from tsgo.
 type Server = innerlsp.Server
 
 // ServerOptions mirrors the upstream construction parameters. Fields with
-// internal-package types (e.g. ParseCache *project.ParseCache) are left
-// unset by ttscserver, which is safe because every such field is an
-// optional pointer the upstream constructor accepts as nil.
+// internal-package types (e.g. ParseCache *project.ParseCache) can be left
+// unset by callers when upstream accepts nil.
 type ServerOptions = innerlsp.ServerOptions
 
-// Reader / Writer carry framed lsproto.Message values. ttscserver feeds
-// the server through io.Pipe shims of these so it can splice its own
-// JSON-RPC traffic into the same stream the editor speaks.
+// Reader / Writer carry framed lsproto.Message values.
 type Reader = innerlsp.Reader
 type Writer = innerlsp.Writer
 

--- a/packages/ttsc/shim/lsp/shim.go
+++ b/packages/ttsc/shim/lsp/shim.go
@@ -8,10 +8,10 @@
 package lsp
 
 import (
-  "io"
-  _ "unsafe"
+	"io"
+	_ "unsafe"
 
-  innerlsp "github.com/microsoft/typescript-go/internal/lsp"
+	innerlsp "github.com/microsoft/typescript-go/internal/lsp"
 )
 
 // Server is the opaque LSP server type from tsgo.

--- a/packages/ttsc/src/compiler/internal/resolveTsgo.ts
+++ b/packages/ttsc/src/compiler/internal/resolveTsgo.ts
@@ -8,6 +8,7 @@ export function resolveTsgo(
     binary?: string;
     cwd?: string;
     env?: NodeJS.ProcessEnv;
+    resolveFrom?: string;
   } = {},
 ) {
   const env = opts.env ?? process.env;
@@ -28,11 +29,13 @@ export function resolveTsgo(
 
   const cwd = path.resolve(opts.cwd ?? process.cwd());
   let packageJson: string;
-  try {
-    packageJson = createRequire(path.join(cwd, "package.json")).resolve(
-      "@typescript/native-preview/package.json",
-    );
-  } catch {
+  packageJson =
+    resolveNativePreviewPackageJson(path.join(cwd, "package.json")) ??
+    (opts.resolveFrom
+      ? resolveNativePreviewPackageJson(opts.resolveFrom)
+      : undefined) ??
+    "";
+  if (!packageJson) {
     throw new Error(
       [
         "ttsc: @typescript/native-preview is required.",
@@ -79,6 +82,16 @@ export function resolveTsgo(
     version:
       typeof manifest.version === "string" ? manifest.version : "unknown",
   };
+}
+
+function resolveNativePreviewPackageJson(from: string): string | undefined {
+  try {
+    return createRequire(from).resolve(
+      "@typescript/native-preview/package.json",
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 function readPackageJson(file: string): Record<string, unknown> {

--- a/packages/ttsc/src/launcher/internal/runTtscserver.ts
+++ b/packages/ttsc/src/launcher/internal/runTtscserver.ts
@@ -70,7 +70,7 @@ function resolveTtscserverEnv(argv: readonly string[]): NodeJS.ProcessEnv {
   if (!argv.includes("--stdio")) {
     return process.env;
   }
-  if (process.env.TTSC_TSGO_BINARY || hasOptionValue(argv, "--tsgo")) {
+  if (process.env.TTSC_TSGO_BINARY || hasTsgoOption(argv)) {
     return process.env;
   }
   const tsgo = resolveTsgo({
@@ -83,9 +83,8 @@ function resolveTtscserverEnv(argv: readonly string[]): NodeJS.ProcessEnv {
   };
 }
 
-function hasOptionValue(argv: readonly string[], option: string): boolean {
-  const index = argv.indexOf(option);
-  return index >= 0 && typeof argv[index + 1] === "string";
+function hasTsgoOption(argv: readonly string[]): boolean {
+  return argv.some((arg) => arg === "--tsgo" || arg.startsWith("--tsgo="));
 }
 
 function formatError(error: unknown): string {

--- a/packages/ttsc/src/launcher/internal/runTtscserver.ts
+++ b/packages/ttsc/src/launcher/internal/runTtscserver.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import * as os from "node:os";
 
+import { resolveTsgo } from "../../compiler/internal/resolveTsgo";
 import { resolveTtscserverBinary } from "./resolveTtscserverBinary";
 
 /**
@@ -11,6 +12,7 @@ import { resolveTtscserverBinary } from "./resolveTtscserverBinary";
  * performs only:
  *
  * - Resolve the platform binary,
+ * - Resolve the project TypeScript-Go binary for the native wrapper,
  * - Inject `--stdio` when the first arg is not a meta-command,
  * - Delegate to the binary with inherited stdio so OS-level signals reach the
  *   child via the parent's process group.
@@ -31,9 +33,18 @@ export function runTtscserver(
   ensureExecutable(binary);
 
   const args = needsStdio(argv) ? ["--stdio", ...argv] : [...argv];
+  let env: NodeJS.ProcessEnv;
+  try {
+    env = resolveTtscserverEnv(args);
+  } catch (error) {
+    process.stderr.write(
+      `ttscserver: ${stripTtscPrefix(formatError(error))}\n`,
+    );
+    return 1;
+  }
   const result = spawnSync(binary, args, {
     stdio: "inherit",
-    env: process.env,
+    env,
     windowsHide: true,
   });
   if (result.error) {
@@ -53,6 +64,38 @@ export function runTtscserver(
     return typeof signum === "number" ? 128 + signum : 1;
   }
   return result.status ?? 1;
+}
+
+function resolveTtscserverEnv(argv: readonly string[]): NodeJS.ProcessEnv {
+  if (!argv.includes("--stdio")) {
+    return process.env;
+  }
+  if (process.env.TTSC_TSGO_BINARY || hasOptionValue(argv, "--tsgo")) {
+    return process.env;
+  }
+  const tsgo = resolveTsgo({
+    cwd: process.cwd(),
+    resolveFrom: __filename,
+  });
+  return {
+    ...process.env,
+    TTSC_TSGO_BINARY: tsgo.binary,
+  };
+}
+
+function hasOptionValue(argv: readonly string[], option: string): boolean {
+  const index = argv.indexOf(option);
+  return index >= 0 && typeof argv[index + 1] === "string";
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function stripTtscPrefix(message: string): string {
+  return message.startsWith("ttsc: ")
+    ? message.slice("ttsc: ".length)
+    : message;
 }
 
 /**

--- a/packages/ttsc/test/driver/lsp_frame_reader_reports_header_read_errors_test.go
+++ b/packages/ttsc/test/driver/lsp_frame_reader_reports_header_read_errors_test.go
@@ -1,13 +1,13 @@
 package driver_test
 
 import (
-  "bytes"
-  "errors"
-  "io"
-  "strings"
-  "testing"
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
 
-  "github.com/samchon/ttsc/packages/ttsc/driver"
+	"github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
 // TestLSPFrameReaderReportsHeaderReadErrors locks the failure mode the
@@ -22,20 +22,20 @@ import (
 // 2. Assert Read returns a wrapped header-read error.
 // 3. Confirm the error is not ErrFrameClosed so the pump treats it as fatal.
 func TestLSPFrameReaderReportsHeaderReadErrors(t *testing.T) {
-  partial := []byte("Content-Length: 4\r")
-  fr := driver.NewFrameReader(bytes.NewReader(partial))
+	partial := []byte("Content-Length: 4\r")
+	fr := driver.NewFrameReader(bytes.NewReader(partial))
 
-  _, _, err := fr.Read()
-  if err == nil {
-    t.Fatal("expected error from truncated header")
-  }
-  if errors.Is(err, driver.ErrFrameClosed) {
-    t.Fatalf("truncated header must not look like a clean close: %v", err)
-  }
-  if !errors.Is(err, io.EOF) {
-    t.Fatalf("expected wrapped io.EOF, got %v", err)
-  }
-  if !strings.Contains(err.Error(), "header") {
-    t.Fatalf("error message should mention header: %v", err)
-  }
+	_, _, err := fr.Read()
+	if err == nil {
+		t.Fatal("expected error from truncated header")
+	}
+	if errors.Is(err, driver.ErrFrameClosed) {
+		t.Fatalf("truncated header must not look like a clean close: %v", err)
+	}
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected wrapped io.EOF, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "header") {
+		t.Fatalf("error message should mention header: %v", err)
+	}
 }

--- a/packages/ttsc/test/driver/lsp_frame_reader_reports_header_read_errors_test.go
+++ b/packages/ttsc/test/driver/lsp_frame_reader_reports_header_read_errors_test.go
@@ -16,7 +16,7 @@ import (
 //
 // The proxy distinguishes between "stream ended cleanly between frames"
 // (ErrFrameClosed) and "stream ended mid-header" (wrapped error) when
-// deciding whether to forward shutdown to the embedded tsgo server.
+// deciding whether to forward shutdown to the upstream tsgo server.
 //
 // 1. Feed a header line without the terminating empty line.
 // 2. Assert Read returns a wrapped header-read error.

--- a/packages/ttsc/test/driver/lsp_helpers_test.go
+++ b/packages/ttsc/test/driver/lsp_helpers_test.go
@@ -1,15 +1,15 @@
 package driver_test
 
 import (
-  "bytes"
-  "encoding/json"
-  "fmt"
-  "os"
-  "os/exec"
-  "path/filepath"
-  "runtime"
-  "strings"
-  "testing"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
 )
 
 // buildFrame produces a Content-Length-framed LSP wire message from the
@@ -17,89 +17,89 @@ import (
 // the latter case the helper marshals it. This keeps individual test
 // files focused on the assertion instead of repeating header math.
 func buildFrame(t *testing.T, body any) []byte {
-  t.Helper()
-  var raw []byte
-  switch v := body.(type) {
-  case []byte:
-    raw = v
-  case string:
-    raw = []byte(v)
-  default:
-    encoded, err := json.Marshal(body)
-    if err != nil {
-      t.Fatal(err)
-    }
-    raw = encoded
-  }
-  return append([]byte(fmt.Sprintf("Content-Length: %d\r\n\r\n", len(raw))), raw...)
+	t.Helper()
+	var raw []byte
+	switch v := body.(type) {
+	case []byte:
+		raw = v
+	case string:
+		raw = []byte(v)
+	default:
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw = encoded
+	}
+	return append([]byte(fmt.Sprintf("Content-Length: %d\r\n\r\n", len(raw))), raw...)
 }
 
 // chainFrames concatenates many wire frames into a single byte stream
 // for FrameReader tests that exercise multi-frame consumption.
 func chainFrames(frames ...[]byte) []byte {
-  var out bytes.Buffer
-  for _, frame := range frames {
-    out.Write(frame)
-  }
-  return out.Bytes()
+	var out bytes.Buffer
+	for _, frame := range frames {
+		out.Write(frame)
+	}
+	return out.Bytes()
 }
 
 // tsgoBinaryForTest resolves the workspace TypeScript-Go binary for tests that
 // exercise the real upstream LSP process. CI passes TTSC_TSGO_BINARY; local
 // runs fall back to Node's package resolver from packages/ttsc.
 func tsgoBinaryForTest(t *testing.T) string {
-  t.Helper()
-  if binary := os.Getenv("TTSC_TSGO_BINARY"); binary != "" {
-    return binary
-  }
-  _, file, _, ok := runtime.Caller(0)
-  if !ok {
-    t.Fatal("could not resolve test helper path")
-  }
-  packageRoot := filepath.Dir(filepath.Dir(filepath.Dir(file)))
-  script := `
+	t.Helper()
+	if binary := os.Getenv("TTSC_TSGO_BINARY"); binary != "" {
+		return binary
+	}
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not resolve test helper path")
+	}
+	packageRoot := filepath.Dir(filepath.Dir(filepath.Dir(file)))
+	script := `
 const path = require("node:path");
 const root = path.dirname(require.resolve("@typescript/native-preview/package.json", { paths: [process.cwd()] }));
 const platformPackage = "@typescript/native-preview-" + process.platform + "-" + process.arch;
 const platformRoot = path.dirname(require.resolve(platformPackage + "/package.json", { paths: [root] }));
 process.stdout.write(path.join(platformRoot, "lib", process.platform === "win32" ? "tsgo.exe" : "tsgo"));
 `
-  cmd := exec.Command("node", "-e", script)
-  cmd.Dir = packageRoot
-  output, err := cmd.CombinedOutput()
-  if err != nil {
-    t.Fatalf("could not resolve tsgo binary: %v\n%s", err, output)
-  }
-  binary := strings.TrimSpace(string(output))
-  if _, err := os.Stat(binary); err != nil {
-    t.Fatalf("resolved tsgo binary is not usable: %s: %v", binary, err)
-  }
-  return binary
+	cmd := exec.Command("node", "-e", script)
+	cmd.Dir = packageRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("could not resolve tsgo binary: %v\n%s", err, output)
+	}
+	binary := strings.TrimSpace(string(output))
+	if _, err := os.Stat(binary); err != nil {
+		t.Fatalf("resolved tsgo binary is not usable: %s: %v", binary, err)
+	}
+	return binary
 }
 
 // flakyWriter fails the configured byte boundary so write-error paths
 // can be exercised without depending on filesystem or network state.
 type flakyWriter struct {
-  failAfter int
-  written   int
-  err       error
+	failAfter int
+	written   int
+	err       error
 }
 
 // newFlakyWriter returns a writer that succeeds for the first failAfter
 // bytes and then returns the supplied error on every subsequent Write.
 func newFlakyWriter(failAfter int, err error) *flakyWriter {
-  return &flakyWriter{failAfter: failAfter, err: err}
+	return &flakyWriter{failAfter: failAfter, err: err}
 }
 
 func (w *flakyWriter) Write(p []byte) (int, error) {
-  if w.written >= w.failAfter {
-    return 0, w.err
-  }
-  remaining := w.failAfter - w.written
-  if len(p) <= remaining {
-    w.written += len(p)
-    return len(p), nil
-  }
-  w.written += remaining
-  return remaining, w.err
+	if w.written >= w.failAfter {
+		return 0, w.err
+	}
+	remaining := w.failAfter - w.written
+	if len(p) <= remaining {
+		w.written += len(p)
+		return len(p), nil
+	}
+	w.written += remaining
+	return remaining, w.err
 }

--- a/packages/ttsc/test/driver/lsp_helpers_test.go
+++ b/packages/ttsc/test/driver/lsp_helpers_test.go
@@ -4,6 +4,11 @@ import (
   "bytes"
   "encoding/json"
   "fmt"
+  "os"
+  "os/exec"
+  "path/filepath"
+  "runtime"
+  "strings"
   "testing"
 )
 
@@ -37,6 +42,39 @@ func chainFrames(frames ...[]byte) []byte {
     out.Write(frame)
   }
   return out.Bytes()
+}
+
+// tsgoBinaryForTest resolves the workspace TypeScript-Go binary for tests that
+// exercise the real upstream LSP process. CI passes TTSC_TSGO_BINARY; local
+// runs fall back to Node's package resolver from packages/ttsc.
+func tsgoBinaryForTest(t *testing.T) string {
+  t.Helper()
+  if binary := os.Getenv("TTSC_TSGO_BINARY"); binary != "" {
+    return binary
+  }
+  _, file, _, ok := runtime.Caller(0)
+  if !ok {
+    t.Fatal("could not resolve test helper path")
+  }
+  packageRoot := filepath.Dir(filepath.Dir(filepath.Dir(file)))
+  script := `
+const path = require("node:path");
+const root = path.dirname(require.resolve("@typescript/native-preview/package.json", { paths: [process.cwd()] }));
+const platformPackage = "@typescript/native-preview-" + process.platform + "-" + process.arch;
+const platformRoot = path.dirname(require.resolve(platformPackage + "/package.json", { paths: [root] }));
+process.stdout.write(path.join(platformRoot, "lib", process.platform === "win32" ? "tsgo.exe" : "tsgo"));
+`
+  cmd := exec.Command("node", "-e", script)
+  cmd.Dir = packageRoot
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("could not resolve tsgo binary: %v\n%s", err, output)
+  }
+  binary := strings.TrimSpace(string(output))
+  if _, err := os.Stat(binary); err != nil {
+    t.Fatalf("resolved tsgo binary is not usable: %s: %v", binary, err)
+  }
+  return binary
 }
 
 // flakyWriter fails the configured byte boundary so write-error paths

--- a/packages/ttsc/test/driver/lsp_proxy_forwards_unowned_command_test.go
+++ b/packages/ttsc/test/driver/lsp_proxy_forwards_unowned_command_test.go
@@ -1,11 +1,11 @@
 package driver_test
 
 import (
-  "bytes"
-  "encoding/json"
-  "testing"
+	"bytes"
+	"encoding/json"
+	"testing"
 
-  "github.com/samchon/ttsc/packages/ttsc/driver"
+	"github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
 // TestLSPProxyForwardsUnownedCommand verifies that the proxy does not
@@ -17,18 +17,18 @@ import (
 // 2. Send a request for the unowned command.
 // 3. Assert the request reaches upstream verbatim.
 func TestLSPProxyForwardsUnownedCommand(t *testing.T) {
-  source := &stubSource{
-    commands: []string{"ttsc.lint.fix"},
-    execute: func(string, []json.RawMessage) (*driver.LSPWorkspaceEdit, error) {
-      t.Fatal("execute should not be called for unowned command")
-      return nil, nil
-    },
-  }
-  h := newProxyHarness(t, source)
+	source := &stubSource{
+		commands: []string{"ttsc.lint.fix"},
+		execute: func(string, []json.RawMessage) (*driver.LSPWorkspaceEdit, error) {
+			t.Fatal("execute should not be called for unowned command")
+			return nil, nil
+		},
+	}
+	h := newProxyHarness(t, source)
 
-  request := []byte(`{"jsonrpc":"2.0","id":1,"method":"workspace/executeCommand","params":{"command":"tsgo.refactor.extract"}}`)
-  h.sendEditor(request)
-  if got := h.recvUpstream(); !bytes.Equal(got, request) {
-    t.Fatalf("upstream mismatch:\n%s", got)
-  }
+	request := []byte(`{"jsonrpc":"2.0","id":1,"method":"workspace/executeCommand","params":{"command":"tsgo.refactor.extract"}}`)
+	h.sendEditor(request)
+	if got := h.recvUpstream(); !bytes.Equal(got, request) {
+		t.Fatalf("upstream mismatch:\n%s", got)
+	}
 }

--- a/packages/ttsc/test/driver/lsp_proxy_forwards_unowned_command_test.go
+++ b/packages/ttsc/test/driver/lsp_proxy_forwards_unowned_command_test.go
@@ -11,7 +11,7 @@ import (
 // TestLSPProxyForwardsUnownedCommand verifies that the proxy does not
 // intercept commands the plugin source does not claim. tsgo's own
 // workspace commands (refactors, code-action commands) must continue to
-// reach the embedded server unmodified.
+// reach the upstream server unmodified.
 //
 // 1. Configure a source that owns one command id but not another.
 // 2. Send a request for the unowned command.

--- a/packages/ttsc/test/driver/lsp_proxy_harness_test.go
+++ b/packages/ttsc/test/driver/lsp_proxy_harness_test.go
@@ -1,14 +1,14 @@
 package driver_test
 
 import (
-  "context"
-  "errors"
-  "io"
-  "sync"
-  "testing"
-  "time"
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
 
-  "github.com/samchon/ttsc/packages/ttsc/driver"
+	"github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
 // proxyHarness wires the byte-level LSP proxy onto in-memory pipes so
@@ -17,139 +17,139 @@ import (
 // rewrite. Every test owns its own harness via t.Cleanup so closes are
 // deterministic even when an assertion fails mid-frame.
 type proxyHarness struct {
-  t      *testing.T
-  proxy  *driver.Proxy
-  cancel context.CancelFunc
+	t      *testing.T
+	proxy  *driver.Proxy
+	cancel context.CancelFunc
 
-  editorInW    *io.PipeWriter
-  upstreamOutW *io.PipeWriter
+	editorInW    *io.PipeWriter
+	upstreamOutW *io.PipeWriter
 
-  editorOutFR  *driver.FrameReader
-  upstreamInFR *driver.FrameReader
+	editorOutFR  *driver.FrameReader
+	upstreamInFR *driver.FrameReader
 
-  runErrMu sync.Mutex
-  runErr   error
-  runDone  chan struct{}
+	runErrMu sync.Mutex
+	runErr   error
+	runDone  chan struct{}
 }
 
 // newProxyHarness constructs the harness with the supplied PluginSource.
 // Passing a nil source makes the proxy fall back to NullPluginSource{}.
 func newProxyHarness(t *testing.T, source driver.PluginSource) *proxyHarness {
-  t.Helper()
-  edInR, edInW := io.Pipe()
-  edOutR, edOutW := io.Pipe()
-  upInR, upInW := io.Pipe()
-  upOutR, upOutW := io.Pipe()
+	t.Helper()
+	edInR, edInW := io.Pipe()
+	edOutR, edOutW := io.Pipe()
+	upInR, upInW := io.Pipe()
+	upOutR, upOutW := io.Pipe()
 
-  ctx, cancel := context.WithCancel(context.Background())
-  proxy := driver.NewProxy(driver.ProxyOptions{
-    EditorIn:    edInR,
-    EditorOut:   edOutW,
-    UpstreamIn:  upInW,
-    UpstreamOut: upOutR,
-    Source:      source,
-  })
+	ctx, cancel := context.WithCancel(context.Background())
+	proxy := driver.NewProxy(driver.ProxyOptions{
+		EditorIn:    edInR,
+		EditorOut:   edOutW,
+		UpstreamIn:  upInW,
+		UpstreamOut: upOutR,
+		Source:      source,
+	})
 
-  h := &proxyHarness{
-    t:            t,
-    proxy:        proxy,
-    cancel:       cancel,
-    editorInW:    edInW,
-    upstreamOutW: upOutW,
-    editorOutFR:  driver.NewFrameReader(edOutR),
-    upstreamInFR: driver.NewFrameReader(upInR),
-    runDone:      make(chan struct{}),
-  }
-  go func() {
-    err := proxy.Run(ctx)
-    h.runErrMu.Lock()
-    h.runErr = err
-    h.runErrMu.Unlock()
-    close(h.runDone)
-    edInR.Close()
-    edOutW.Close()
-    upInW.Close()
-    upOutR.Close()
-  }()
-  t.Cleanup(func() {
-    h.shutdown()
-  })
-  return h
+	h := &proxyHarness{
+		t:            t,
+		proxy:        proxy,
+		cancel:       cancel,
+		editorInW:    edInW,
+		upstreamOutW: upOutW,
+		editorOutFR:  driver.NewFrameReader(edOutR),
+		upstreamInFR: driver.NewFrameReader(upInR),
+		runDone:      make(chan struct{}),
+	}
+	go func() {
+		err := proxy.Run(ctx)
+		h.runErrMu.Lock()
+		h.runErr = err
+		h.runErrMu.Unlock()
+		close(h.runDone)
+		edInR.Close()
+		edOutW.Close()
+		upInW.Close()
+		upOutR.Close()
+	}()
+	t.Cleanup(func() {
+		h.shutdown()
+	})
+	return h
 }
 
 // shutdown closes the proxy by draining both inbound streams. Tests
 // should call this directly only when they need to assert on the
 // returned error; otherwise t.Cleanup runs it.
 func (h *proxyHarness) shutdown() error {
-  _ = h.editorInW.Close()
-  _ = h.upstreamOutW.Close()
-  select {
-  case <-h.runDone:
-  case <-time.After(3 * time.Second):
-    h.cancel()
-    select {
-    case <-h.runDone:
-    case <-time.After(time.Second):
-      h.t.Fatal("proxy.Run did not return after cancel")
-    }
-  }
-  h.runErrMu.Lock()
-  defer h.runErrMu.Unlock()
-  return h.runErr
+	_ = h.editorInW.Close()
+	_ = h.upstreamOutW.Close()
+	select {
+	case <-h.runDone:
+	case <-time.After(3 * time.Second):
+		h.cancel()
+		select {
+		case <-h.runDone:
+		case <-time.After(time.Second):
+			h.t.Fatal("proxy.Run did not return after cancel")
+		}
+	}
+	h.runErrMu.Lock()
+	defer h.runErrMu.Unlock()
+	return h.runErr
 }
 
 // sendEditor writes a frame to the editor->proxy stream.
 func (h *proxyHarness) sendEditor(body []byte) {
-  h.t.Helper()
-  if err := driver.WriteFrame(h.editorInW, body); err != nil {
-    h.t.Fatalf("sendEditor write: %v", err)
-  }
+	h.t.Helper()
+	if err := driver.WriteFrame(h.editorInW, body); err != nil {
+		h.t.Fatalf("sendEditor write: %v", err)
+	}
 }
 
 // sendUpstream writes a frame as if it came from the upstream tsgo
 // server toward the editor.
 func (h *proxyHarness) sendUpstream(body []byte) {
-  h.t.Helper()
-  if err := driver.WriteFrame(h.upstreamOutW, body); err != nil {
-    h.t.Fatalf("sendUpstream write: %v", err)
-  }
+	h.t.Helper()
+	if err := driver.WriteFrame(h.upstreamOutW, body); err != nil {
+		h.t.Fatalf("sendUpstream write: %v", err)
+	}
 }
 
 // recvUpstream returns the next frame the proxy forwarded to the
 // upstream tsgo server (i.e. an editor->server message after the proxy's
 // intercepts). Times out after two seconds to keep failing tests fast.
 func (h *proxyHarness) recvUpstream() []byte {
-  h.t.Helper()
-  return h.readWithTimeout(h.upstreamInFR, "upstream")
+	h.t.Helper()
+	return h.readWithTimeout(h.upstreamInFR, "upstream")
 }
 
 // recvEditor returns the next frame the proxy sent back to the editor.
 func (h *proxyHarness) recvEditor() []byte {
-  h.t.Helper()
-  return h.readWithTimeout(h.editorOutFR, "editor")
+	h.t.Helper()
+	return h.readWithTimeout(h.editorOutFR, "editor")
 }
 
 func (h *proxyHarness) readWithTimeout(fr *driver.FrameReader, label string) []byte {
-  h.t.Helper()
-  type readResult struct {
-    body []byte
-    err  error
-  }
-  result := make(chan readResult, 1)
-  go func() {
-    _, body, err := fr.Read()
-    result <- readResult{body, err}
-  }()
-  select {
-  case r := <-result:
-    if r.err != nil && !errors.Is(r.err, driver.ErrFrameClosed) {
-      h.t.Fatalf("%s frame read: %v", label, r.err)
-    }
-    return r.body
-  case <-time.After(2 * time.Second):
-    h.t.Fatalf("%s frame did not arrive in 2s", label)
-    return nil
-  }
+	h.t.Helper()
+	type readResult struct {
+		body []byte
+		err  error
+	}
+	result := make(chan readResult, 1)
+	go func() {
+		_, body, err := fr.Read()
+		result <- readResult{body, err}
+	}()
+	select {
+	case r := <-result:
+		if r.err != nil && !errors.Is(r.err, driver.ErrFrameClosed) {
+			h.t.Fatalf("%s frame read: %v", label, r.err)
+		}
+		return r.body
+	case <-time.After(2 * time.Second):
+		h.t.Fatalf("%s frame did not arrive in 2s", label)
+		return nil
+	}
 }
 
 // expectNoUpstreamFrame asserts that no frame is sitting in the upstream
@@ -158,22 +158,22 @@ func (h *proxyHarness) readWithTimeout(fr *driver.FrameReader, label string) []b
 // server. The window is generous enough to absorb goroutine scheduling
 // jitter while keeping failures fast.
 func (h *proxyHarness) expectNoUpstreamFrame(window time.Duration) {
-  h.t.Helper()
-  type readResult struct {
-    body []byte
-    err  error
-  }
-  done := make(chan readResult, 1)
-  go func() {
-    _, body, err := h.upstreamInFR.Read()
-    done <- readResult{body, err}
-  }()
-  select {
-  case r := <-done:
-    if r.err != nil {
-      return
-    }
-    h.t.Fatalf("upstream received a frame it should not have:\n%s", r.body)
-  case <-time.After(window):
-  }
+	h.t.Helper()
+	type readResult struct {
+		body []byte
+		err  error
+	}
+	done := make(chan readResult, 1)
+	go func() {
+		_, body, err := h.upstreamInFR.Read()
+		done <- readResult{body, err}
+	}()
+	select {
+	case r := <-done:
+		if r.err != nil {
+			return
+		}
+		h.t.Fatalf("upstream received a frame it should not have:\n%s", r.body)
+	case <-time.After(window):
+	}
 }

--- a/packages/ttsc/test/driver/lsp_proxy_harness_test.go
+++ b/packages/ttsc/test/driver/lsp_proxy_harness_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // proxyHarness wires the byte-level LSP proxy onto in-memory pipes so
-// tests can drive editor traffic, simulate the embedded tsgo server's
+// tests can drive editor traffic, simulate the upstream tsgo server's
 // outgoing traffic, and observe what the proxy chose to forward versus
 // rewrite. Every test owns its own harness via t.Cleanup so closes are
 // deterministic even when an assertion fails mid-frame.
@@ -106,7 +106,7 @@ func (h *proxyHarness) sendEditor(body []byte) {
   }
 }
 
-// sendUpstream writes a frame as if it came from the embedded tsgo
+// sendUpstream writes a frame as if it came from the upstream tsgo
 // server toward the editor.
 func (h *proxyHarness) sendUpstream(body []byte) {
   h.t.Helper()
@@ -154,7 +154,7 @@ func (h *proxyHarness) readWithTimeout(fr *driver.FrameReader, label string) []b
 
 // expectNoUpstreamFrame asserts that no frame is sitting in the upstream
 // buffer within a short window. Used by intercept tests to confirm
-// locally-handled requests do not leak through to the embedded tsgo
+// locally-handled requests do not leak through to the upstream tsgo
 // server. The window is generous enough to absorb goroutine scheduling
 // jitter while keeping failures fast.
 func (h *proxyHarness) expectNoUpstreamFrame(window time.Duration) {

--- a/packages/ttsc/test/driver/lsp_proxy_reports_editor_write_error_for_owned_command_test.go
+++ b/packages/ttsc/test/driver/lsp_proxy_reports_editor_write_error_for_owned_command_test.go
@@ -1,0 +1,77 @@
+package driver_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestLSPProxyReportsEditorWriteErrorForOwnedCommand verifies locally-handled
+// executeCommand responses surface editor write failures.
+//
+// The proxy writes ttsc-owned command responses directly to the editor instead
+// of forwarding them upstream. If that write fails because the editor side is
+// already closed, the proxy must return the IO error instead of swallowing it
+// and waiting for more input.
+//
+// 1. Create a proxy with a source that handles `ttsc.noop` locally.
+// 2. Close the editor output reader before sending the command request.
+// 3. Close upstream output so the sibling pump can drain.
+// 4. Assert Proxy.Run returns a closed-pipe write error.
+func TestLSPProxyReportsEditorWriteErrorForOwnedCommand(t *testing.T) {
+	editorInR, editorInW := io.Pipe()
+	editorOutR, editorOutW := io.Pipe()
+	upstreamInR, upstreamInW := io.Pipe()
+	upstreamOutR, upstreamOutW := io.Pipe()
+	defer editorInR.Close()
+	defer editorInW.Close()
+	defer editorOutW.Close()
+	defer upstreamInR.Close()
+	defer upstreamInW.Close()
+	defer upstreamOutR.Close()
+	defer upstreamOutW.Close()
+
+	source := &stubSource{
+		commands: []string{"ttsc.noop"},
+		execute: func(string, []json.RawMessage) (*driver.LSPWorkspaceEdit, error) {
+			return nil, nil
+		},
+	}
+	proxy := driver.NewProxy(driver.ProxyOptions{
+		EditorIn:    editorInR,
+		EditorOut:   editorOutW,
+		UpstreamIn:  upstreamInW,
+		UpstreamOut: upstreamOutR,
+		Source:      source,
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- proxy.Run(context.Background())
+	}()
+
+	if err := editorOutR.Close(); err != nil {
+		t.Fatalf("close editor output reader: %v", err)
+	}
+	request := []byte(`{"jsonrpc":"2.0","id":1,"method":"workspace/executeCommand","params":{"command":"ttsc.noop"}}`)
+	if err := driver.WriteFrame(editorInW, request); err != nil {
+		t.Fatalf("send command request: %v", err)
+	}
+	if err := upstreamOutW.Close(); err != nil {
+		t.Fatalf("close upstream output: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err == nil || !errors.Is(err, io.ErrClosedPipe) {
+			t.Fatalf("expected closed-pipe write error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("proxy.Run did not return after editor write failure")
+	}
+}

--- a/packages/ttsc/test/driver/lsp_server_default_runner_constructs_real_server_test.go
+++ b/packages/ttsc/test/driver/lsp_server_default_runner_constructs_real_server_test.go
@@ -1,14 +1,14 @@
 package driver_test
 
 import (
-  "context"
-  "encoding/json"
-  "io"
-  "strings"
-  "testing"
-  "time"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
 
-  "github.com/samchon/ttsc/packages/ttsc/driver"
+	"github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
 // TestLSPServerDefaultRunnerConstructsRealServer exercises the production
@@ -23,78 +23,78 @@ import (
 // 3. Read the response and assert it carries server capabilities.
 // 4. Cancel + close editor pipes; assert RunLSPServer returns nil.
 func TestLSPServerDefaultRunnerConstructsRealServer(t *testing.T) {
-  editorInR, editorInW := io.Pipe()
-  editorOutR, editorOutW := io.Pipe()
-  defer editorInR.Close()
-  defer editorOutW.Close()
+	editorInR, editorInW := io.Pipe()
+	editorOutR, editorOutW := io.Pipe()
+	defer editorInR.Close()
+	defer editorOutW.Close()
 
-  ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 
-  done := make(chan error, 1)
-  go func() {
-    done <- driver.RunLSPServer(ctx, driver.LSPServerOptions{
-      In:  editorInR,
-      Out: editorOutW,
-      Err: io.Discard,
-      Cwd: t.TempDir(),
-      TsgoBinary: tsgoBinaryForTest(t),
-    })
-  }()
+	done := make(chan error, 1)
+	go func() {
+		done <- driver.RunLSPServer(ctx, driver.LSPServerOptions{
+			In:         editorInR,
+			Out:        editorOutW,
+			Err:        io.Discard,
+			Cwd:        t.TempDir(),
+			TsgoBinary: tsgoBinaryForTest(t),
+		})
+	}()
 
-  initialize := []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":null,"capabilities":{}}}`)
-  if err := driver.WriteFrame(editorInW, initialize); err != nil {
-    t.Fatal(err)
-  }
+	initialize := []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":null,"capabilities":{}}}`)
+	if err := driver.WriteFrame(editorInW, initialize); err != nil {
+		t.Fatal(err)
+	}
 
-  type readResult struct {
-    body []byte
-    err  error
-  }
-  reader := driver.NewFrameReader(editorOutR)
-  resultCh := make(chan readResult, 4)
-  go func() {
-    for {
-      _, body, err := reader.Read()
-      resultCh <- readResult{body, err}
-      if err != nil {
-        return
-      }
-    }
-  }()
+	type readResult struct {
+		body []byte
+		err  error
+	}
+	reader := driver.NewFrameReader(editorOutR)
+	resultCh := make(chan readResult, 4)
+	go func() {
+		for {
+			_, body, err := reader.Read()
+			resultCh <- readResult{body, err}
+			if err != nil {
+				return
+			}
+		}
+	}()
 
-  deadline := time.After(10 * time.Second)
-  initialized := false
-  for !initialized {
-    select {
-    case r := <-resultCh:
-      if r.err != nil {
-        t.Fatalf("editor read errored before initialize response: %v", r.err)
-      }
-      var env struct {
-        ID     json.RawMessage `json:"id"`
-        Result json.RawMessage `json:"result"`
-      }
-      if err := json.Unmarshal(r.body, &env); err != nil {
-        continue
-      }
-      if !strings.Contains(string(env.Result), `"capabilities"`) {
-        continue
-      }
-      initialized = true
-    case <-deadline:
-      t.Fatal("initialize response did not arrive in 10s")
-    }
-  }
+	deadline := time.After(10 * time.Second)
+	initialized := false
+	for !initialized {
+		select {
+		case r := <-resultCh:
+			if r.err != nil {
+				t.Fatalf("editor read errored before initialize response: %v", r.err)
+			}
+			var env struct {
+				ID     json.RawMessage `json:"id"`
+				Result json.RawMessage `json:"result"`
+			}
+			if err := json.Unmarshal(r.body, &env); err != nil {
+				continue
+			}
+			if !strings.Contains(string(env.Result), `"capabilities"`) {
+				continue
+			}
+			initialized = true
+		case <-deadline:
+			t.Fatal("initialize response did not arrive in 10s")
+		}
+	}
 
-  cancel()
-  editorInW.Close()
+	cancel()
+	editorInW.Close()
 
-  select {
-  case err := <-done:
-    if err != nil {
-      t.Fatalf("RunLSPServer should shut down cleanly, got %v", err)
-    }
-  case <-time.After(10 * time.Second):
-    t.Fatal("RunLSPServer did not return after cancel")
-  }
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunLSPServer should shut down cleanly, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunLSPServer did not return after cancel")
+	}
 }

--- a/packages/ttsc/test/driver/lsp_server_default_runner_constructs_real_server_test.go
+++ b/packages/ttsc/test/driver/lsp_server_default_runner_constructs_real_server_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 // TestLSPServerDefaultRunnerConstructsRealServer exercises the production
-// path where defaultUpstreamRunner builds a real tsgo lsp.Server and
+// path where defaultUpstreamRunner starts a real `tsgo --lsp --stdio` process and
 // drives a minimal initialize round-trip through the proxy. Booting the
-// stack and immediately cancelling would still pass with FS=nil or
-// DefaultLibraryPath=""; sending initialize forces tsgo to evaluate
-// those fields, so a regression in the shim wiring turns the test red.
+// stack and immediately cancelling would still pass if the process never
+// answered; sending initialize forces the upstream LSP server to prove it
+// is really running behind the proxy.
 //
 // 1. Call RunLSPServer with a temp directory as Cwd (no runner override).
 // 2. Send a real initialize request.
@@ -37,6 +37,7 @@ func TestLSPServerDefaultRunnerConstructsRealServer(t *testing.T) {
       Out: editorOutW,
       Err: io.Discard,
       Cwd: t.TempDir(),
+      TsgoBinary: tsgoBinaryForTest(t),
     })
   }()
 

--- a/packages/ttsc/test/driver/lsp_server_deny_npm_install_test.go
+++ b/packages/ttsc/test/driver/lsp_server_deny_npm_install_test.go
@@ -7,9 +7,9 @@ import (
   "github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
-// TestLSPServerDenyNpmInstall covers the NpmInstall callback ttscserver
-// passes to tsgo's LSP. The host must report a clean refusal so tsgo
-// reports the failure back to the editor instead of attempting npm.
+// TestLSPServerDenyNpmInstall covers the legacy NpmInstall callback kept for
+// source compatibility with older in-process LSP embedders. It must keep
+// reporting a clean refusal instead of attempting npm.
 //
 // 1. Invoke DenyNpmInstall with a sample args slice.
 // 2. Assert the returned []byte is nil.

--- a/packages/ttsc/test/driver/lsp_server_deny_npm_install_test.go
+++ b/packages/ttsc/test/driver/lsp_server_deny_npm_install_test.go
@@ -1,10 +1,10 @@
 package driver_test
 
 import (
-  "strings"
-  "testing"
+	"strings"
+	"testing"
 
-  "github.com/samchon/ttsc/packages/ttsc/driver"
+	"github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
 // TestLSPServerDenyNpmInstall covers the legacy NpmInstall callback kept for
@@ -15,17 +15,17 @@ import (
 // 2. Assert the returned []byte is nil.
 // 3. Assert the error mentions "npm install disabled".
 func TestLSPServerDenyNpmInstall(t *testing.T) {
-  data, err := driver.DenyNpmInstall("/tmp/project", []string{"install", "@types/node"})
-  if data != nil {
-    t.Fatalf("expected nil data, got %q", data)
-  }
-  if err == nil {
-    t.Fatal("expected error, got nil")
-  }
-  if !strings.Contains(err.Error(), "npm install disabled") {
-    t.Fatalf("error message mismatch: %v", err)
-  }
-  if !strings.Contains(err.Error(), "install") {
-    t.Fatalf("error should echo the requested args: %v", err)
-  }
+	data, err := driver.DenyNpmInstall("/tmp/project", []string{"install", "@types/node"})
+	if data != nil {
+		t.Fatalf("expected nil data, got %q", data)
+	}
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "npm install disabled") {
+		t.Fatalf("error message mismatch: %v", err)
+	}
+	if !strings.Contains(err.Error(), "install") {
+		t.Fatalf("error should echo the requested args: %v", err)
+	}
 }

--- a/packages/ttsc/test/driver/lsp_server_prefers_runner_error_test.go
+++ b/packages/ttsc/test/driver/lsp_server_prefers_runner_error_test.go
@@ -10,7 +10,7 @@ import (
   "github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
-// TestLSPServerPrefersRunnerError pins the contract that the embedded
+// TestLSPServerPrefersRunnerError pins the contract that the upstream
 // tsgo server error wins over the proxy error in the final fold. A
 // future refactor that swapped the order (or replaced the slice with
 // errors.Join without an Is-aware unwrap) would silently flip the

--- a/packages/ttsc/test/driver/lsp_server_prefers_runner_error_test.go
+++ b/packages/ttsc/test/driver/lsp_server_prefers_runner_error_test.go
@@ -1,13 +1,13 @@
 package driver_test
 
 import (
-  "context"
-  "errors"
-  "io"
-  "testing"
-  "time"
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
 
-  "github.com/samchon/ttsc/packages/ttsc/driver"
+	"github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
 // TestLSPServerPrefersRunnerError pins the contract that the upstream
@@ -20,39 +20,39 @@ import (
 // 2. Force the proxy half to fail with a different sentinel.
 // 3. Assert RunLSPServer returns the runner sentinel.
 func TestLSPServerPrefersRunnerError(t *testing.T) {
-  runnerSentinel := errors.New("synthetic upstream failure")
-  restore := driver.WithUpstreamRunnerForTest(func(_ context.Context, _ io.Reader, _ io.Writer, _ driver.LSPServerOptions) error {
-    return runnerSentinel
-  })
-  defer restore()
+	runnerSentinel := errors.New("synthetic upstream failure")
+	restore := driver.WithUpstreamRunnerForTest(func(_ context.Context, _ io.Reader, _ io.Writer, _ driver.LSPServerOptions) error {
+		return runnerSentinel
+	})
+	defer restore()
 
-  // Editor pipes are set up so the proxy will fail too: closing the
-  // editor reader before the proxy's pumpUpstreamToEditor writes
-  // makes that write fail with io.ErrClosedPipe, distinct from the
-  // runner sentinel.
-  editorInR, editorInW := io.Pipe()
-  editorOutR, editorOutW := io.Pipe()
-  defer editorInR.Close()
-  defer editorOutW.Close()
-  editorOutR.Close()
-  editorInW.Close()
+	// Editor pipes are set up so the proxy will fail too: closing the
+	// editor reader before the proxy's pumpUpstreamToEditor writes
+	// makes that write fail with io.ErrClosedPipe, distinct from the
+	// runner sentinel.
+	editorInR, editorInW := io.Pipe()
+	editorOutR, editorOutW := io.Pipe()
+	defer editorInR.Close()
+	defer editorOutW.Close()
+	editorOutR.Close()
+	editorInW.Close()
 
-  done := make(chan error, 1)
-  go func() {
-    done <- driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
-      In:  editorInR,
-      Out: editorOutW,
-      Err: io.Discard,
-      Cwd: t.TempDir(),
-    })
-  }()
+	done := make(chan error, 1)
+	go func() {
+		done <- driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
+			In:  editorInR,
+			Out: editorOutW,
+			Err: io.Discard,
+			Cwd: t.TempDir(),
+		})
+	}()
 
-  select {
-  case err := <-done:
-    if !errors.Is(err, runnerSentinel) {
-      t.Fatalf("expected runner sentinel to win, got %v", err)
-    }
-  case <-time.After(3 * time.Second):
-    t.Fatal("RunLSPServer did not return")
-  }
+	select {
+	case err := <-done:
+		if !errors.Is(err, runnerSentinel) {
+			t.Fatalf("expected runner sentinel to win, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("RunLSPServer did not return")
+	}
 }

--- a/packages/ttsc/test/driver/lsp_server_rejects_missing_tsgo_binary_test.go
+++ b/packages/ttsc/test/driver/lsp_server_rejects_missing_tsgo_binary_test.go
@@ -1,13 +1,13 @@
 package driver_test
 
 import (
-  "context"
-  "errors"
-  "io"
-  "strings"
-  "testing"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
 
-  "github.com/samchon/ttsc/packages/ttsc/driver"
+	"github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
 // TestLSPServerRejectsMissingTsgoBinary verifies the native wrapper refuses to
@@ -21,13 +21,13 @@ import (
 // 2. Close editor input immediately so the proxy side can drain.
 // 3. Assert ErrLSPTsgoBinaryRequired is returned.
 func TestLSPServerRejectsMissingTsgoBinary(t *testing.T) {
-  err := driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
-    In:  strings.NewReader(""),
-    Out: io.Discard,
-    Err: io.Discard,
-    Cwd: t.TempDir(),
-  })
-  if !errors.Is(err, driver.ErrLSPTsgoBinaryRequired) {
-    t.Fatalf("expected ErrLSPTsgoBinaryRequired, got %v", err)
-  }
+	err := driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
+		In:  strings.NewReader(""),
+		Out: io.Discard,
+		Err: io.Discard,
+		Cwd: t.TempDir(),
+	})
+	if !errors.Is(err, driver.ErrLSPTsgoBinaryRequired) {
+		t.Fatalf("expected ErrLSPTsgoBinaryRequired, got %v", err)
+	}
 }

--- a/packages/ttsc/test/driver/lsp_server_rejects_missing_tsgo_binary_test.go
+++ b/packages/ttsc/test/driver/lsp_server_rejects_missing_tsgo_binary_test.go
@@ -1,0 +1,33 @@
+package driver_test
+
+import (
+  "context"
+  "errors"
+  "io"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestLSPServerRejectsMissingTsgoBinary verifies the native wrapper refuses to
+// start without an explicit upstream tsgo executable.
+//
+// The JavaScript launcher normally resolves @typescript/native-preview and
+// passes TTSC_TSGO_BINARY. Direct native hosts need the same contract; otherwise
+// ttscserver might accidentally run a stale tsgo from PATH.
+//
+// 1. Call RunLSPServer with Cwd set but no TsgoBinary.
+// 2. Close editor input immediately so the proxy side can drain.
+// 3. Assert ErrLSPTsgoBinaryRequired is returned.
+func TestLSPServerRejectsMissingTsgoBinary(t *testing.T) {
+  err := driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
+    In:  strings.NewReader(""),
+    Out: io.Discard,
+    Err: io.Discard,
+    Cwd: t.TempDir(),
+  })
+  if !errors.Is(err, driver.ErrLSPTsgoBinaryRequired) {
+    t.Fatalf("expected ErrLSPTsgoBinaryRequired, got %v", err)
+  }
+}

--- a/packages/ttsc/test/driver/lsp_server_rejects_relative_tsgo_binary_test.go
+++ b/packages/ttsc/test/driver/lsp_server_rejects_relative_tsgo_binary_test.go
@@ -1,12 +1,12 @@
 package driver_test
 
 import (
-  "context"
-  "io"
-  "strings"
-  "testing"
+	"context"
+	"io"
+	"strings"
+	"testing"
 
-  "github.com/samchon/ttsc/packages/ttsc/driver"
+	"github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
 // TestLSPServerRejectsRelativeTsgoBinary verifies the upstream binary contract
@@ -20,14 +20,14 @@ import (
 // 2. Close editor input immediately so the proxy side can drain.
 // 3. Assert the absolute-path validation error is surfaced.
 func TestLSPServerRejectsRelativeTsgoBinary(t *testing.T) {
-  err := driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
-    In:         strings.NewReader(""),
-    Out:        io.Discard,
-    Err:        io.Discard,
-    Cwd:        t.TempDir(),
-    TsgoBinary: "tsgo",
-  })
-  if err == nil || !strings.Contains(err.Error(), "must be absolute") {
-    t.Fatalf("expected absolute-path error, got %v", err)
-  }
+	err := driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
+		In:         strings.NewReader(""),
+		Out:        io.Discard,
+		Err:        io.Discard,
+		Cwd:        t.TempDir(),
+		TsgoBinary: "tsgo",
+	})
+	if err == nil || !strings.Contains(err.Error(), "must be absolute") {
+		t.Fatalf("expected absolute-path error, got %v", err)
+	}
 }

--- a/packages/ttsc/test/driver/lsp_server_rejects_relative_tsgo_binary_test.go
+++ b/packages/ttsc/test/driver/lsp_server_rejects_relative_tsgo_binary_test.go
@@ -1,0 +1,33 @@
+package driver_test
+
+import (
+  "context"
+  "io"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestLSPServerRejectsRelativeTsgoBinary verifies the upstream binary contract
+// requires an absolute path.
+//
+// ttscserver should run the project-selected TypeScript-Go binary, not whatever
+// happens to appear first on PATH. Keeping this validation in the native host
+// protects callers that bypass the JavaScript launcher.
+//
+// 1. Call RunLSPServer with TsgoBinary="tsgo".
+// 2. Close editor input immediately so the proxy side can drain.
+// 3. Assert the absolute-path validation error is surfaced.
+func TestLSPServerRejectsRelativeTsgoBinary(t *testing.T) {
+  err := driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
+    In:         strings.NewReader(""),
+    Out:        io.Discard,
+    Err:        io.Discard,
+    Cwd:        t.TempDir(),
+    TsgoBinary: "tsgo",
+  })
+  if err == nil || !strings.Contains(err.Error(), "must be absolute") {
+    t.Fatalf("expected absolute-path error, got %v", err)
+  }
+}

--- a/packages/ttsc/test/driver/lsp_server_reports_tsgo_spawn_error_test.go
+++ b/packages/ttsc/test/driver/lsp_server_reports_tsgo_spawn_error_test.go
@@ -1,14 +1,14 @@
 package driver_test
 
 import (
-  "context"
-  "io"
-  "path/filepath"
-  "strings"
-  "testing"
-  "time"
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
 
-  "github.com/samchon/ttsc/packages/ttsc/driver"
+	"github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
 // TestLSPServerReportsTsgoSpawnError verifies process-start failures keep the
@@ -21,27 +21,27 @@ import (
 // 2. Leave editor input open so the cancel watchdog must unblock the reader.
 // 3. Assert the returned error names `tsgo --lsp --stdio`.
 func TestLSPServerReportsTsgoSpawnError(t *testing.T) {
-  editorInR, editorInW := io.Pipe()
-  defer editorInR.Close()
-  defer editorInW.Close()
+	editorInR, editorInW := io.Pipe()
+	defer editorInR.Close()
+	defer editorInW.Close()
 
-  done := make(chan error, 1)
-  go func() {
-    done <- driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
-      In:         editorInR,
-      Out:        io.Discard,
-      Err:        io.Discard,
-      Cwd:        t.TempDir(),
-      TsgoBinary: filepath.Join(t.TempDir(), "missing-tsgo"),
-    })
-  }()
+	done := make(chan error, 1)
+	go func() {
+		done <- driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
+			In:         editorInR,
+			Out:        io.Discard,
+			Err:        io.Discard,
+			Cwd:        t.TempDir(),
+			TsgoBinary: filepath.Join(t.TempDir(), "missing-tsgo"),
+		})
+	}()
 
-  select {
-  case err := <-done:
-    if err == nil || !strings.Contains(err.Error(), "tsgo --lsp --stdio") {
-      t.Fatalf("expected tsgo spawn error, got %v", err)
-    }
-  case <-time.After(2 * time.Second):
-    t.Fatal("RunLSPServer did not return after tsgo spawn failure")
-  }
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "tsgo --lsp --stdio") {
+			t.Fatalf("expected tsgo spawn error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunLSPServer did not return after tsgo spawn failure")
+	}
 }

--- a/packages/ttsc/test/driver/lsp_server_reports_tsgo_spawn_error_test.go
+++ b/packages/ttsc/test/driver/lsp_server_reports_tsgo_spawn_error_test.go
@@ -1,0 +1,33 @@
+package driver_test
+
+import (
+  "context"
+  "io"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestLSPServerReportsTsgoSpawnError verifies process-start failures keep the
+// tsgo command context in the returned error.
+//
+// Missing or non-executable @typescript/native-preview binaries should produce
+// an actionable upstream failure instead of a generic proxy shutdown.
+//
+// 1. Point TsgoBinary at a missing absolute path.
+// 2. Close editor input immediately so the proxy side can drain.
+// 3. Assert the returned error names `tsgo --lsp --stdio`.
+func TestLSPServerReportsTsgoSpawnError(t *testing.T) {
+  err := driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
+    In:         strings.NewReader(""),
+    Out:        io.Discard,
+    Err:        io.Discard,
+    Cwd:        t.TempDir(),
+    TsgoBinary: filepath.Join(t.TempDir(), "missing-tsgo"),
+  })
+  if err == nil || !strings.Contains(err.Error(), "tsgo --lsp --stdio") {
+    t.Fatalf("expected tsgo spawn error, got %v", err)
+  }
+}

--- a/packages/ttsc/test/driver/lsp_server_reports_tsgo_spawn_error_test.go
+++ b/packages/ttsc/test/driver/lsp_server_reports_tsgo_spawn_error_test.go
@@ -6,6 +6,7 @@ import (
   "path/filepath"
   "strings"
   "testing"
+  "time"
 
   "github.com/samchon/ttsc/packages/ttsc/driver"
 )
@@ -17,17 +18,30 @@ import (
 // an actionable upstream failure instead of a generic proxy shutdown.
 //
 // 1. Point TsgoBinary at a missing absolute path.
-// 2. Close editor input immediately so the proxy side can drain.
+// 2. Leave editor input open so the cancel watchdog must unblock the reader.
 // 3. Assert the returned error names `tsgo --lsp --stdio`.
 func TestLSPServerReportsTsgoSpawnError(t *testing.T) {
-  err := driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
-    In:         strings.NewReader(""),
-    Out:        io.Discard,
-    Err:        io.Discard,
-    Cwd:        t.TempDir(),
-    TsgoBinary: filepath.Join(t.TempDir(), "missing-tsgo"),
-  })
-  if err == nil || !strings.Contains(err.Error(), "tsgo --lsp --stdio") {
-    t.Fatalf("expected tsgo spawn error, got %v", err)
+  editorInR, editorInW := io.Pipe()
+  defer editorInR.Close()
+  defer editorInW.Close()
+
+  done := make(chan error, 1)
+  go func() {
+    done <- driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
+      In:         editorInR,
+      Out:        io.Discard,
+      Err:        io.Discard,
+      Cwd:        t.TempDir(),
+      TsgoBinary: filepath.Join(t.TempDir(), "missing-tsgo"),
+    })
+  }()
+
+  select {
+  case err := <-done:
+    if err == nil || !strings.Contains(err.Error(), "tsgo --lsp --stdio") {
+      t.Fatalf("expected tsgo spawn error, got %v", err)
+    }
+  case <-time.After(2 * time.Second):
+    t.Fatal("RunLSPServer did not return after tsgo spawn failure")
   }
 }

--- a/packages/ttsc/test/ttscserver/command_handles_stdio_shutdown_test.go
+++ b/packages/ttsc/test/ttscserver/command_handles_stdio_shutdown_test.go
@@ -1,7 +1,7 @@
 package ttscserver_test
 
 import (
-  "testing"
+	"testing"
 )
 
 // TestTtscserverCommandHandlesStdioShutdown verifies that when the editor
@@ -12,8 +12,8 @@ import (
 // 1. Run ttscserver --stdio with an empty stdin (closed immediately).
 // 2. Assert exit code 0.
 func TestTtscserverCommandHandlesStdioShutdown(t *testing.T) {
-  code, _, errOut := runTtscserverWithStdin(t, "", "--stdio", "--cwd", t.TempDir())
-  if code != 0 {
-    t.Fatalf("expected clean exit, got %d (stderr=%q)", code, errOut)
-  }
+	code, _, errOut := runTtscserverWithStdin(t, "", "--stdio", "--cwd", t.TempDir())
+	if code != 0 {
+		t.Fatalf("expected clean exit, got %d (stderr=%q)", code, errOut)
+	}
 }

--- a/packages/ttsc/test/ttscserver/command_handles_stdio_shutdown_test.go
+++ b/packages/ttsc/test/ttscserver/command_handles_stdio_shutdown_test.go
@@ -7,7 +7,7 @@ import (
 // TestTtscserverCommandHandlesStdioShutdown verifies that when the editor
 // closes its end of stdin, the LSP host shuts down cleanly with exit 0
 // instead of treating EOF as a crash. This covers the runLSPServer happy
-// path through the real tsgo embedding.
+// path through the real upstream tsgo process.
 //
 // 1. Run ttscserver --stdio with an empty stdin (closed immediately).
 // 2. Assert exit code 0.

--- a/packages/ttsc/test/ttscserver/helpers_test.go
+++ b/packages/ttsc/test/ttscserver/helpers_test.go
@@ -1,32 +1,32 @@
 package ttscserver_test
 
 import (
-  "os"
-  "os/exec"
-  "path/filepath"
-  "runtime"
-  "strings"
-  "testing"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
 )
 
 // packageRoot returns the `packages/ttsc` module root from this black-box test
 // package. ttscserver command tests run from there so `go run ./cmd/ttscserver`
 // sees the same module graph as a developer launching the LSP host by hand.
 func packageRoot(t *testing.T) string {
-  t.Helper()
-  _, file, _, ok := runtime.Caller(0)
-  if !ok {
-    t.Fatal("could not resolve test helper path")
-  }
-  return filepath.Dir(filepath.Dir(filepath.Dir(file)))
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not resolve test helper path")
+	}
+	return filepath.Dir(filepath.Dir(filepath.Dir(file)))
 }
 
 // runTtscserver executes the ttscserver binary with the given args from the
 // `packages/ttsc` module root and returns its exit code, stdout, and stderr.
 // Tests use it for cases where the cwd should be the package root (default).
 func runTtscserver(t *testing.T, args ...string) (int, string, string) {
-  t.Helper()
-  return runTtscserverWithStdin(t, "", args...)
+	t.Helper()
+	return runTtscserverWithStdin(t, "", args...)
 }
 
 // runTtscserverWithStdin runs the command with the supplied stdin payload. An
@@ -34,59 +34,59 @@ func runTtscserver(t *testing.T, args ...string) (int, string, string) {
 // down cleanly — useful for exercising the happy-path return paths without
 // driving a real LSP handshake.
 func runTtscserverWithStdin(t *testing.T, stdin string, args ...string) (int, string, string) {
-  t.Helper()
-  return runTtscserverFromDir(t, packageRoot(t), stdin, args...)
+	t.Helper()
+	return runTtscserverFromDir(t, packageRoot(t), stdin, args...)
 }
 
 // runTtscserverFromDir runs the command from an explicit working directory.
 // Use it when a test needs the spawned binary to see a particular cwd (e.g.,
 // to exercise the implicit-cwd Getwd path).
 func runTtscserverFromDir(t *testing.T, runDir, stdin string, args ...string) (int, string, string) {
-  t.Helper()
-  bin := buildTtscserverBinary(t)
+	t.Helper()
+	bin := buildTtscserverBinary(t)
 
-  cmd := exec.Command(bin, args...)
-  cmd.Dir = runDir
-  cmd.Stdin = strings.NewReader(stdin)
-  cmd.Env = append(os.Environ(), "TTSC_TSGO_BINARY="+tsgoBinaryForCommandTest(t))
-  if coverDir := os.Getenv("TTSC_NATIVE_COMMAND_COVERDIR"); coverDir != "" {
-    cmd.Env = append(cmd.Env, "GOCOVERDIR="+coverDir)
-  }
-  out, err := cmd.Output()
-  stderr := ""
-  if exit, ok := err.(*exec.ExitError); ok {
-    stderr = string(exit.Stderr)
-    return exit.ExitCode(), string(out), stderr
-  }
-  if err != nil {
-    t.Fatalf("ttscserver failed before exit code: %v", err)
-  }
-  return 0, string(out), stderr
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = runDir
+	cmd.Stdin = strings.NewReader(stdin)
+	cmd.Env = append(os.Environ(), "TTSC_TSGO_BINARY="+tsgoBinaryForCommandTest(t))
+	if coverDir := os.Getenv("TTSC_NATIVE_COMMAND_COVERDIR"); coverDir != "" {
+		cmd.Env = append(cmd.Env, "GOCOVERDIR="+coverDir)
+	}
+	out, err := cmd.Output()
+	stderr := ""
+	if exit, ok := err.(*exec.ExitError); ok {
+		stderr = string(exit.Stderr)
+		return exit.ExitCode(), string(out), stderr
+	}
+	if err != nil {
+		t.Fatalf("ttscserver failed before exit code: %v", err)
+	}
+	return 0, string(out), stderr
 }
 
 func tsgoBinaryForCommandTest(t *testing.T) string {
-  t.Helper()
-  if binary := os.Getenv("TTSC_TSGO_BINARY"); binary != "" {
-    return binary
-  }
-  script := `
+	t.Helper()
+	if binary := os.Getenv("TTSC_TSGO_BINARY"); binary != "" {
+		return binary
+	}
+	script := `
 const path = require("node:path");
 const root = path.dirname(require.resolve("@typescript/native-preview/package.json", { paths: [process.cwd()] }));
 const platformPackage = "@typescript/native-preview-" + process.platform + "-" + process.arch;
 const platformRoot = path.dirname(require.resolve(platformPackage + "/package.json", { paths: [root] }));
 process.stdout.write(path.join(platformRoot, "lib", process.platform === "win32" ? "tsgo.exe" : "tsgo"));
 `
-  cmd := exec.Command("node", "-e", script)
-  cmd.Dir = packageRoot(t)
-  output, err := cmd.CombinedOutput()
-  if err != nil {
-    t.Fatalf("could not resolve tsgo binary: %v\n%s", err, output)
-  }
-  binary := strings.TrimSpace(string(output))
-  if _, err := os.Stat(binary); err != nil {
-    t.Fatalf("resolved tsgo binary is not usable: %s: %v", binary, err)
-  }
-  return binary
+	cmd := exec.Command("node", "-e", script)
+	cmd.Dir = packageRoot(t)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("could not resolve tsgo binary: %v\n%s", err, output)
+	}
+	binary := strings.TrimSpace(string(output))
+	if _, err := os.Stat(binary); err != nil {
+		t.Fatalf("resolved tsgo binary is not usable: %s: %v", binary, err)
+	}
+	return binary
 }
 
 // buildTtscserverBinary builds the ttscserver binary into a temp directory.
@@ -94,40 +94,40 @@ process.stdout.write(path.join(platformRoot, "lib", process.platform === "win32"
 // share it, but go test isolates each Test* per process so the simple
 // per-test build is fine for the tiny package.
 func buildTtscserverBinary(t *testing.T) string {
-  t.Helper()
-  bin := filepath.Join(t.TempDir(), "ttscserver")
-  if filepath.Separator == '\\' {
-    bin += ".exe"
-  }
-  goArgs := []string{"build"}
-  if coverDir := os.Getenv("TTSC_NATIVE_COMMAND_COVERDIR"); coverDir != "" {
-    if err := os.MkdirAll(coverDir, 0o755); err != nil {
-      t.Fatal(err)
-    }
-    goArgs = append(goArgs,
-      "-cover",
-      "-covermode=atomic",
-      "-coverpkg="+nativeCommandCoverPackages(),
-    )
-  }
-  goArgs = append(goArgs, "-o", bin, "./cmd/ttscserver")
-  build := exec.Command("go", goArgs...)
-  build.Dir = packageRoot(t)
-  if output, err := build.CombinedOutput(); err != nil {
-    t.Fatalf("go build ./cmd/ttscserver failed: %v\n%s", err, output)
-  }
-  return bin
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "ttscserver")
+	if filepath.Separator == '\\' {
+		bin += ".exe"
+	}
+	goArgs := []string{"build"}
+	if coverDir := os.Getenv("TTSC_NATIVE_COMMAND_COVERDIR"); coverDir != "" {
+		if err := os.MkdirAll(coverDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		goArgs = append(goArgs,
+			"-cover",
+			"-covermode=atomic",
+			"-coverpkg="+nativeCommandCoverPackages(),
+		)
+	}
+	goArgs = append(goArgs, "-o", bin, "./cmd/ttscserver")
+	build := exec.Command("go", goArgs...)
+	build.Dir = packageRoot(t)
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build ./cmd/ttscserver failed: %v\n%s", err, output)
+	}
+	return bin
 }
 
 // nativeCommandCoverPackages lists the packages charged to coverage profiles
 // when ttscserver black-box tests run with TTSC_NATIVE_COMMAND_COVERDIR. The
 // list mirrors the cli helper so a single -coverpkg arg covers both binaries.
 func nativeCommandCoverPackages() string {
-  return strings.Join([]string{
-    "github.com/samchon/ttsc/packages/ttsc/cmd/ttsc",
-    "github.com/samchon/ttsc/packages/ttsc/cmd/ttscserver",
-    "github.com/samchon/ttsc/packages/ttsc/driver",
-    "github.com/samchon/ttsc/packages/ttsc/internal/lspserver",
-    "github.com/samchon/ttsc/packages/ttsc/utility",
-  }, ",")
+	return strings.Join([]string{
+		"github.com/samchon/ttsc/packages/ttsc/cmd/ttsc",
+		"github.com/samchon/ttsc/packages/ttsc/cmd/ttscserver",
+		"github.com/samchon/ttsc/packages/ttsc/driver",
+		"github.com/samchon/ttsc/packages/ttsc/internal/lspserver",
+		"github.com/samchon/ttsc/packages/ttsc/utility",
+	}, ",")
 }

--- a/packages/ttsc/test/ttscserver/helpers_test.go
+++ b/packages/ttsc/test/ttscserver/helpers_test.go
@@ -48,8 +48,9 @@ func runTtscserverFromDir(t *testing.T, runDir, stdin string, args ...string) (i
   cmd := exec.Command(bin, args...)
   cmd.Dir = runDir
   cmd.Stdin = strings.NewReader(stdin)
+  cmd.Env = append(os.Environ(), "TTSC_TSGO_BINARY="+tsgoBinaryForCommandTest(t))
   if coverDir := os.Getenv("TTSC_NATIVE_COMMAND_COVERDIR"); coverDir != "" {
-    cmd.Env = append(os.Environ(), "GOCOVERDIR="+coverDir)
+    cmd.Env = append(cmd.Env, "GOCOVERDIR="+coverDir)
   }
   out, err := cmd.Output()
   stderr := ""
@@ -61,6 +62,31 @@ func runTtscserverFromDir(t *testing.T, runDir, stdin string, args ...string) (i
     t.Fatalf("ttscserver failed before exit code: %v", err)
   }
   return 0, string(out), stderr
+}
+
+func tsgoBinaryForCommandTest(t *testing.T) string {
+  t.Helper()
+  if binary := os.Getenv("TTSC_TSGO_BINARY"); binary != "" {
+    return binary
+  }
+  script := `
+const path = require("node:path");
+const root = path.dirname(require.resolve("@typescript/native-preview/package.json", { paths: [process.cwd()] }));
+const platformPackage = "@typescript/native-preview-" + process.platform + "-" + process.arch;
+const platformRoot = path.dirname(require.resolve(platformPackage + "/package.json", { paths: [root] }));
+process.stdout.write(path.join(platformRoot, "lib", process.platform === "win32" ? "tsgo.exe" : "tsgo"));
+`
+  cmd := exec.Command("node", "-e", script)
+  cmd.Dir = packageRoot(t)
+  output, err := cmd.CombinedOutput()
+  if err != nil {
+    t.Fatalf("could not resolve tsgo binary: %v\n%s", err, output)
+  }
+  binary := strings.TrimSpace(string(output))
+  if _, err := os.Stat(binary); err != nil {
+    t.Fatalf("resolved tsgo binary is not usable: %s: %v", binary, err)
+  }
+  return binary
 }
 
 // buildTtscserverBinary builds the ttscserver binary into a temp directory.
@@ -101,7 +127,7 @@ func nativeCommandCoverPackages() string {
     "github.com/samchon/ttsc/packages/ttsc/cmd/ttsc",
     "github.com/samchon/ttsc/packages/ttsc/cmd/ttscserver",
     "github.com/samchon/ttsc/packages/ttsc/driver",
+    "github.com/samchon/ttsc/packages/ttsc/internal/lspserver",
     "github.com/samchon/ttsc/packages/ttsc/utility",
   }, ",")
 }
-

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -38,15 +38,17 @@ let client: LanguageClient | undefined;
 function resolveServerLauncher(): ServerOptions | undefined {
   const config = workspace.getConfiguration("ttsc");
   const explicit = config.get<string>("serverPath", "").trim();
+  const bases = collectResolutionBases();
   if (explicit && path.isAbsolute(explicit)) {
     return {
       command: explicit,
       args: ["--stdio"],
+      options: bases[0] ? { cwd: bases[0] } : undefined,
       transport: TransportKind.stdio,
     };
   }
 
-  for (const base of collectResolutionBases()) {
+  for (const base of bases) {
     try {
       const launcher = require.resolve("ttsc/lib/launcher/ttscserver.js", {
         paths: [base],
@@ -54,6 +56,7 @@ function resolveServerLauncher(): ServerOptions | undefined {
       return {
         module: launcher,
         args: ["--stdio"],
+        options: { cwd: base },
         transport: TransportKind.stdio,
       };
     } catch {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -113,9 +113,10 @@ function resolveTsgoBinary(base: string): string | undefined {
  * untitled) are skipped because their `fsPath` is synthetic and would walk the
  * entire filesystem root. Workspace folders come next. If both lists are empty
  * (single file opened with no workspace) the function returns an empty slice so
- * the caller falls through to the bare-module branch; pushing `process.cwd()`
- * is not useful because the VSCode extension-host cwd is `/`, the install dir,
- * or `C:\Windows\System32` depending on platform — never the user's project.
+ * `activate` can report the missing project-local ttsc installation. Pushing
+ * `process.cwd()` is not useful because the VSCode extension-host cwd is `/`,
+ * the install dir, or `C:\Windows\System32` depending on platform, never the
+ * user's project.
  */
 function collectResolutionBases(): string[] {
   const bases: string[] = [];

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -43,7 +43,7 @@ function resolveServerLauncher(): ServerOptions | undefined {
     return {
       command: explicit,
       args: ["--stdio"],
-      options: bases[0] ? { cwd: bases[0] } : undefined,
+      options: serverProcessOptions(bases[0]),
       transport: TransportKind.stdio,
     };
   }
@@ -56,7 +56,7 @@ function resolveServerLauncher(): ServerOptions | undefined {
       return {
         module: launcher,
         args: ["--stdio"],
-        options: { cwd: base },
+        options: serverProcessOptions(base),
         transport: TransportKind.stdio,
       };
     } catch {
@@ -65,6 +65,44 @@ function resolveServerLauncher(): ServerOptions | undefined {
   }
 
   return undefined;
+}
+
+function serverProcessOptions(base?: string) {
+  const tsgo = base ? resolveTsgoBinary(base) : undefined;
+  if (!base && !tsgo) {
+    return undefined;
+  }
+  return {
+    cwd: base,
+    env: tsgo
+      ? {
+          ...process.env,
+          TTSC_TSGO_BINARY: tsgo,
+        }
+      : process.env,
+  };
+}
+
+function resolveTsgoBinary(base: string): string | undefined {
+  try {
+    const packageJson = require.resolve(
+      "@typescript/native-preview/package.json",
+      { paths: [base] },
+    );
+    const packageRoot = path.dirname(packageJson);
+    const platformPackage = `@typescript/native-preview-${process.platform}-${process.arch}`;
+    const platformPackageJson = require.resolve(
+      `${platformPackage}/package.json`,
+      { paths: [packageRoot] },
+    );
+    return path.join(
+      path.dirname(platformPackageJson),
+      "lib",
+      process.platform === "win32" ? "tsgo.exe" : "tsgo",
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/scripts/build-platform-package.cjs
+++ b/scripts/build-platform-package.cjs
@@ -4,11 +4,17 @@ const path = require("node:path");
 const zlib = require("node:zlib");
 
 const cwd = process.cwd();
-const manifest = JSON.parse(fs.readFileSync(path.join(cwd, "package.json"), "utf8"));
-const match = /^@ttsc\/(linux|darwin|win32)-(x64|arm|arm64)$/.exec(manifest.name);
+const manifest = JSON.parse(
+  fs.readFileSync(path.join(cwd, "package.json"), "utf8"),
+);
+const match = /^@ttsc\/(linux|darwin|win32)-(x64|arm|arm64)$/.exec(
+  manifest.name,
+);
 
 if (!match) {
-  throw new Error(`build-platform-package: unsupported package name ${manifest.name}`);
+  throw new Error(
+    `build-platform-package: unsupported package name ${manifest.name}`,
+  );
 }
 
 const [, npmOs, npmArch] = match;
@@ -32,32 +38,41 @@ const pathValue = fs.existsSync(localGoBin)
   ? `${localGoBin}${path.delimiter}${process.env.PATH ?? ""}`
   : process.env.PATH;
 const buildGo = resolveBuildGo();
+const goBuildFlags = ["-trimpath", "-ldflags=-s -w"];
 
 console.log(`Building ${manifest.name} -> ${path.relative(root, outFile)}`);
-cp.execFileSync(buildGo, ["build", "-o", outFile, "./cmd/platform"], {
-  cwd: source,
-  env: {
-    ...process.env,
-    CGO_ENABLED: "0",
-    GOARCH: goarch,
-    GOOS: goos,
-    PATH: pathValue,
+cp.execFileSync(
+  buildGo,
+  ["build", ...goBuildFlags, "-o", outFile, "./cmd/platform"],
+  {
+    cwd: source,
+    env: {
+      ...process.env,
+      CGO_ENABLED: "0",
+      GOARCH: goarch,
+      GOOS: goos,
+      PATH: pathValue,
+    },
+    stdio: "inherit",
   },
-  stdio: "inherit",
-});
+);
 
 console.log(`Building ${manifest.name} -> ${path.relative(root, serverFile)}`);
-cp.execFileSync(buildGo, ["build", "-o", serverFile, "./cmd/ttscserver"], {
-  cwd: source,
-  env: {
-    ...process.env,
-    CGO_ENABLED: "0",
-    GOARCH: goarch,
-    GOOS: goos,
-    PATH: pathValue,
+cp.execFileSync(
+  buildGo,
+  ["build", ...goBuildFlags, "-o", serverFile, "./cmd/ttscserver"],
+  {
+    cwd: source,
+    env: {
+      ...process.env,
+      CGO_ENABLED: "0",
+      GOARCH: goarch,
+      GOOS: goos,
+      PATH: pathValue,
+    },
+    stdio: "inherit",
   },
-  stdio: "inherit",
-});
+);
 
 embedGoToolchain();
 
@@ -82,7 +97,11 @@ function embedGoToolchain() {
     );
   }
   const realGoRoot = goroot ? fs.realpathSync(goroot) : "";
-  const goBinary = path.join(realGoRoot, "bin", npmOs === "win32" ? "go.exe" : "go");
+  const goBinary = path.join(
+    realGoRoot,
+    "bin",
+    npmOs === "win32" ? "go.exe" : "go",
+  );
   if (!realGoRoot || !fs.existsSync(goBinary)) {
     throw new Error(
       `build-platform-package: Go compiler root not found for ${manifest.name}. ` +
@@ -90,7 +109,9 @@ function embedGoToolchain() {
     );
   }
 
-  console.log(`Embedding Go compiler ${realGoRoot} -> ${path.relative(root, bundledGoDir)}`);
+  console.log(
+    `Embedding Go compiler ${realGoRoot} -> ${path.relative(root, bundledGoDir)}`,
+  );
   copyPrunedGoRoot(realGoRoot, bundledGoDir);
   verifyEmbeddedGoToolchain();
   chmodGoExecutables(bundledGoDir);
@@ -114,9 +135,16 @@ function ensureDownloadedGoRoot() {
   const version = process.env.TTSC_GO_VERSION || readGoVersion();
   const archive = goArchiveName(version);
   const cacheRoot = path.join(root, ".cache", "go-sdk", version);
-  const extractDir = path.join(cacheRoot, archive.replace(/\.tar\.gz$|\.zip$/g, ""));
+  const extractDir = path.join(
+    cacheRoot,
+    archive.replace(/\.tar\.gz$|\.zip$/g, ""),
+  );
   const goroot = path.join(extractDir, "go");
-  const goBinary = path.join(goroot, "bin", npmOs === "win32" ? "go.exe" : "go");
+  const goBinary = path.join(
+    goroot,
+    "bin",
+    npmOs === "win32" ? "go.exe" : "go",
+  );
   if (fs.existsSync(goBinary)) {
     return goroot;
   }
@@ -141,7 +169,9 @@ function ensureDownloadedGoRoot() {
     extractZipArchive(archivePath, extractDir);
   }
   if (!fs.existsSync(goBinary)) {
-    throw new Error(`build-platform-package: downloaded Go compiler missing: ${goBinary}`);
+    throw new Error(
+      `build-platform-package: downloaded Go compiler missing: ${goBinary}`,
+    );
   }
   return goroot;
 }
@@ -167,9 +197,7 @@ function goArchiveName(version) {
 function goArchiveTarget() {
   const os = npmOs === "win32" ? "windows" : npmOs;
   const arch =
-    npmArch === "x64" ? "amd64" :
-    npmArch === "arm" ? "armv6l" :
-    npmArch;
+    npmArch === "x64" ? "amd64" : npmArch === "arm" ? "armv6l" : npmArch;
   return `${os}-${arch}`;
 }
 
@@ -181,7 +209,9 @@ function extractZipArchive(archivePath, extractDir) {
 
   for (let i = 0; i < entries; i++) {
     if (data.readUInt32LE(offset) !== 0x02014b50) {
-      throw new Error(`build-platform-package: invalid zip central directory: ${archivePath}`);
+      throw new Error(
+        `build-platform-package: invalid zip central directory: ${archivePath}`,
+      );
     }
     const method = data.readUInt16LE(offset + 10);
     const compressedSize = data.readUInt32LE(offset + 20);
@@ -198,19 +228,25 @@ function extractZipArchive(archivePath, extractDir) {
     if (name.endsWith("/")) continue;
     const target = path.resolve(extractDir, name);
     if (!target.startsWith(path.resolve(extractDir) + path.sep)) {
-      throw new Error(`build-platform-package: refusing zip entry outside target: ${name}`);
+      throw new Error(
+        `build-platform-package: refusing zip entry outside target: ${name}`,
+      );
     }
     if (data.readUInt32LE(localOffset) !== 0x04034b50) {
-      throw new Error(`build-platform-package: invalid zip local header: ${name}`);
+      throw new Error(
+        `build-platform-package: invalid zip local header: ${name}`,
+      );
     }
     const localNameLength = data.readUInt16LE(localOffset + 26);
     const localExtraLength = data.readUInt16LE(localOffset + 28);
     const dataStart = localOffset + 30 + localNameLength + localExtraLength;
     const compressed = data.subarray(dataStart, dataStart + compressedSize);
     const contents =
-      method === 0 ? compressed :
-      method === 8 ? zlib.inflateRawSync(compressed) :
-      unsupportedZipMethod(method, name);
+      method === 0
+        ? compressed
+        : method === 8
+          ? zlib.inflateRawSync(compressed)
+          : unsupportedZipMethod(method, name);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, contents);
   }
@@ -221,11 +257,15 @@ function findEndOfCentralDirectory(data) {
   for (let i = data.length - 22; i >= min; --i) {
     if (data.readUInt32LE(i) === 0x06054b50) return i;
   }
-  throw new Error("build-platform-package: zip end-of-central-directory record not found");
+  throw new Error(
+    "build-platform-package: zip end-of-central-directory record not found",
+  );
 }
 
 function unsupportedZipMethod(method, name) {
-  throw new Error(`build-platform-package: unsupported zip compression method ${method}: ${name}`);
+  throw new Error(
+    `build-platform-package: unsupported zip compression method ${method}: ${name}`,
+  );
 }
 
 function copyPrunedGoRoot(sourceRoot, targetRoot) {
@@ -241,7 +281,11 @@ function copyRecursive(current, target, rootDir) {
     if (!shouldCopyGoPath(rel, true)) return;
     fs.mkdirSync(target, { recursive: true });
     for (const entry of fs.readdirSync(current)) {
-      copyRecursive(path.join(current, entry), path.join(target, entry), rootDir);
+      copyRecursive(
+        path.join(current, entry),
+        path.join(target, entry),
+        rootDir,
+      );
     }
     return;
   }
@@ -268,7 +312,12 @@ function shouldCopyGoPath(rel, isDir) {
   if (first === "bin") {
     if (isDir) return true;
     const base = path.basename(rel);
-    return base === "go" || base === "go.exe" || base === "gofmt" || base === "gofmt.exe";
+    return (
+      base === "go" ||
+      base === "go.exe" ||
+      base === "gofmt" ||
+      base === "gofmt.exe"
+    );
   }
   if (first === "pkg") {
     return parts[1] === "tool" || parts[1] === "include";

--- a/scripts/test-go-coverage.cjs
+++ b/scripts/test-go-coverage.cjs
@@ -38,10 +38,11 @@ function runTtscCoverage() {
       "./cmd/ttscserver",
       "./driver",
       "./internal/cwd",
+      "./internal/lspserver",
       "./test/...",
       "./utility",
       "-covermode=atomic",
-      "-coverpkg=./cmd/platform,./cmd/ttsc,./cmd/ttscserver,./driver,./internal/cwd,./utility",
+      "-coverpkg=./cmd/platform,./cmd/ttsc,./cmd/ttscserver,./driver,./internal/cwd,./internal/lspserver,./utility",
       `-coverprofile=${unitProfile}`,
     ],
     {
@@ -50,6 +51,7 @@ function runTtscCoverage() {
         ...goEnv(),
         TTSC_NATIVE_COMMAND_COVERDIR: commandCoverDir,
         TTSC_PLATFORM_COMMAND_COVERDIR: commandCoverDir,
+        TTSC_TSGO_BINARY: process.env.TTSC_TSGO_BINARY ?? resolveTsgoBinary(),
       },
     },
   );

--- a/tests/test-ttsc/src/features/ttscserver/test_ttscserver_exits_on_stdin_close.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_ttscserver_exits_on_stdin_close.ts
@@ -8,8 +8,8 @@ import { TtscserverClient, assert } from "../../internal/ttscserver";
  *
  * Editors crash or get killed; the LSP host must not deadlock waiting for
  * shutdown notifications that will never arrive. This pins the
- * driver/lsp_proxy.go fallback that closes the upstream pipe on editor EOF,
- * which in turn lets the embedded tsgo server drain.
+ * internal/lspserver proxy fallback that closes the upstream pipe on editor EOF,
+ * which in turn lets the upstream tsgo process drain.
  *
  * 1. Spawn ttscserver.
  * 2. Close stdin immediately (no initialize, no shutdown).

--- a/tests/test-ttsc/src/features/ttscserver/test_ttscserver_initializes_and_shuts_down.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_ttscserver_initializes_and_shuts_down.ts
@@ -7,11 +7,9 @@ import { TtscserverClient, assert } from "../../internal/ttscserver";
  *
  * Resolves the native binary the same way the JS launcher would (the helper
  * uses `resolveTtscserverBinary` directly) and drives stdio against the
- * resulting process. The launcher's spawn / IO wrapping in `runTtscserver.ts`
- * is intentionally not covered by this case; see the deferred D5 backlog item
- * for a full launcher feature suite. What this test pins is the proxy +
- * embedded tsgo lsp.Server initialize / shutdown handshake and the clean-exit
- * contract editors rely on.
+ * resulting process. Dedicated launcher tests cover argument/env wrapping; this
+ * case pins the proxy + upstream tsgo LSP initialize / shutdown handshake and
+ * the clean-exit contract editors rely on.
  *
  * 1. Spawn ttscserver via the resolved binary path.
  * 2. Send initialize and wait for the server capabilities response.

--- a/tests/test-ttsc/src/features/ttscserver/test_ttscserver_launcher_respects_inline_tsgo_flag.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_ttscserver_launcher_respects_inline_tsgo_flag.ts
@@ -1,0 +1,45 @@
+import child_process from "node:child_process";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { resolveTsgo } from "../../../../../packages/ttsc/lib/compiler/internal/resolveTsgo.js";
+import { assert, ttscPackageRoot } from "../../internal/ttscserver";
+
+/**
+ * Verifies ttscserver launcher respects `--tsgo=<path>` without resolving env.
+ *
+ * Locks the argument-shape regression where the launcher recognized only
+ * `--tsgo <path>`. Inline flags are common in generated editor configs; if the
+ * launcher misses this form, it tries to resolve @typescript/native-preview from
+ * the wrong cwd before the native host sees the explicit binary.
+ *
+ * 1. Resolve the workspace tsgo binary from the ttsc package root.
+ * 2. Spawn the JS ttscserver launcher from a temp cwd with TTSC_TSGO_BINARY unset.
+ * 3. Pass `--tsgo=<binary>` and closed stdin.
+ * 4. Assert the process exits cleanly.
+ */
+export const test_ttscserver_launcher_respects_inline_tsgo_flag = () => {
+  const root = ttscPackageRoot();
+  const launcher = path.join(root, "lib", "launcher", "ttscserver.js");
+  const tsgo = resolveTsgo({ cwd: root }).binary;
+  const env = { ...process.env };
+  delete env.TTSC_TSGO_BINARY;
+
+  const result = child_process.spawnSync(
+    process.execPath,
+    [launcher, "--stdio", "--cwd", os.tmpdir(), `--tsgo=${tsgo}`],
+    {
+      encoding: "utf8",
+      env,
+      input: "",
+      maxBuffer: 1024 * 1024 * 16,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  assert.equal(
+    result.status,
+    0,
+    `launcher should exit cleanly\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+};

--- a/tests/test-ttsc/src/features/ttscserver/test_ttscserver_launcher_respects_inline_tsgo_flag.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_ttscserver_launcher_respects_inline_tsgo_flag.ts
@@ -1,45 +1,81 @@
 import child_process from "node:child_process";
+import fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { resolveTsgo } from "../../../../../packages/ttsc/lib/compiler/internal/resolveTsgo.js";
 import { assert, ttscPackageRoot } from "../../internal/ttscserver";
 
 /**
  * Verifies ttscserver launcher respects `--tsgo=<path>` without resolving env.
  *
  * Locks the argument-shape regression where the launcher recognized only
- * `--tsgo <path>`. Inline flags are common in generated editor configs; if the
- * launcher misses this form, it tries to resolve @typescript/native-preview from
- * the wrong cwd before the native host sees the explicit binary.
+ * `--tsgo <path>`. A Node-backed fake native host records its environment so
+ * this test proves the launcher does not inject TTSC_TSGO_BINARY when the
+ * inline flag is present.
  *
- * 1. Resolve the workspace tsgo binary from the ttsc package root.
- * 2. Spawn the JS ttscserver launcher from a temp cwd with TTSC_TSGO_BINARY unset.
- * 3. Pass `--tsgo=<binary>` and closed stdin.
- * 4. Assert the process exits cleanly.
+ * 1. Prepare an isolated cwd plus a fake tsgo path.
+ * 2. Spawn the JS ttscserver launcher with TTSC_TSGO_BINARY unset.
+ * 3. Pass `--tsgo=<binary>`.
+ * 4. Assert the fake host saw no injected TTSC_TSGO_BINARY.
  */
 export const test_ttscserver_launcher_respects_inline_tsgo_flag = () => {
   const root = ttscPackageRoot();
   const launcher = path.join(root, "lib", "launcher", "ttscserver.js");
-  const tsgo = resolveTsgo({ cwd: root }).binary;
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "ttscserver-inline-tsgo-"));
+  const record = path.join(cwd, "record.json");
+  const fakeTsgo = path.join(cwd, "tsgo");
+  fs.writeFileSync(fakeTsgo, "", "utf8");
+  const fakeHostScript = [
+    "const fs = require('node:fs');",
+    `fs.writeFileSync(${JSON.stringify(record)}, JSON.stringify({`,
+    "  args: process.argv.slice(1),",
+    "  tsgo: process.env.TTSC_TSGO_BINARY || '',",
+    "}));",
+  ].join("\n");
   const env = { ...process.env };
+  env.TTSCSERVER_BINARY = process.execPath;
   delete env.TTSC_TSGO_BINARY;
 
-  const result = child_process.spawnSync(
-    process.execPath,
-    [launcher, "--stdio", "--cwd", os.tmpdir(), `--tsgo=${tsgo}`],
-    {
-      encoding: "utf8",
-      env,
-      input: "",
-      maxBuffer: 1024 * 1024 * 16,
-      windowsHide: true,
-    },
-  );
-  if (result.error) throw result.error;
-  assert.equal(
-    result.status,
-    0,
-    `launcher should exit cleanly\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
-  );
+  try {
+    const result = child_process.spawnSync(
+      process.execPath,
+      [
+        launcher,
+        "-e",
+        fakeHostScript,
+        "--",
+        "--stdio",
+        "--cwd",
+        cwd,
+        `--tsgo=${fakeTsgo}`,
+      ],
+      {
+        cwd,
+        encoding: "utf8",
+        env,
+        input: "",
+        maxBuffer: 1024 * 1024 * 16,
+        windowsHide: true,
+      },
+    );
+    if (result.error) throw result.error;
+    assert.equal(
+      result.status,
+      0,
+      `launcher should exit cleanly\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    const recorded = JSON.parse(fs.readFileSync(record, "utf8")) as {
+      args: string[];
+      tsgo: string;
+    };
+    assert.deepEqual(recorded.args, [
+      "--stdio",
+      "--cwd",
+      cwd,
+      `--tsgo=${fakeTsgo}`,
+    ]);
+    assert.equal(recorded.tsgo, "");
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
 };

--- a/tests/test-ttsc/src/internal/ttscserver.ts
+++ b/tests/test-ttsc/src/internal/ttscserver.ts
@@ -29,12 +29,17 @@ export class TtscserverClient {
   }>;
 
   constructor(binary: string, cwd: string) {
+    const tsgoBinary =
+      process.env.TTSC_TSGO_BINARY ??
+      resolveTsgo({
+        cwd,
+        resolveFrom: path.join(ttscPackageRoot(), "package.json"),
+      }).binary;
     this.child = spawn(binary, ["--stdio", "--cwd", cwd], {
       stdio: ["pipe", "pipe", "pipe"],
       env: {
         ...process.env,
-        TTSC_TSGO_BINARY:
-          process.env.TTSC_TSGO_BINARY ?? resolveTsgo({ cwd }).binary,
+        TTSC_TSGO_BINARY: tsgoBinary,
       },
       windowsHide: true,
     });
@@ -43,7 +48,14 @@ export class TtscserverClient {
     });
     this.child.stdout.on("data", (chunk: Buffer) => this.onData(chunk));
     this.exited = new Promise((resolve) => {
-      this.child.on("close", (code, signal) => resolve({ code, signal }));
+      this.child.on("close", (code, signal) => {
+        this.rejectPending(
+          new Error(
+            `ttscserver exited before response (code=${code}, signal=${signal})`,
+          ),
+        );
+        resolve({ code, signal });
+      });
     });
   }
 
@@ -161,6 +173,13 @@ export class TtscserverClient {
         }
       }
     }
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      pending.reject(error);
+    }
+    this.pending.clear();
   }
 }
 

--- a/tests/test-ttsc/src/internal/ttscserver.ts
+++ b/tests/test-ttsc/src/internal/ttscserver.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import * as path from "node:path";
 
+import { resolveTsgo } from "../../../../packages/ttsc/lib/compiler/internal/resolveTsgo.js";
 import { resolveTtscserverBinary } from "../../../../packages/ttsc/lib/launcher/internal/resolveTtscserverBinary.js";
 
 /**
@@ -29,6 +30,11 @@ export class TtscserverClient {
   constructor(binary: string, cwd: string) {
     this.child = spawn(binary, ["--stdio", "--cwd", cwd], {
       stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        TTSC_TSGO_BINARY:
+          process.env.TTSC_TSGO_BINARY ?? resolveTsgo({ cwd }).binary,
+      },
       windowsHide: true,
     });
     this.child.stderr.on("data", () => {

--- a/tests/test-ttsc/src/internal/ttscserver.ts
+++ b/tests/test-ttsc/src/internal/ttscserver.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import fs from "node:fs";
 import * as path from "node:path";
 
 import { resolveTsgo } from "../../../../packages/ttsc/lib/compiler/internal/resolveTsgo.js";
@@ -38,7 +39,7 @@ export class TtscserverClient {
       windowsHide: true,
     });
     this.child.stderr.on("data", () => {
-      // Drain stderr so the embedded tsgo logs do not block the pipe.
+      // Drain stderr so upstream tsgo logs do not block the pipe.
     });
     this.child.stdout.on("data", (chunk: Buffer) => this.onData(chunk));
     this.exited = new Promise((resolve) => {
@@ -168,7 +169,19 @@ export class TtscserverClient {
  * encode the absolute path themselves.
  */
 export function ttscPackageRoot(): string {
-  return path.resolve(__dirname, "..", "..", "..", "..", "packages", "ttsc");
+  return path.join(findWorkspaceRoot(process.cwd()), "packages", "ttsc");
+}
+
+function findWorkspaceRoot(start: string): string {
+  let dir = path.resolve(start);
+  for (;;) {
+    if (fs.existsSync(path.join(dir, "pnpm-workspace.yaml"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Unable to find workspace root from ${start}`);
+    }
+    dir = parent;
+  }
 }
 
 export { assert };

--- a/website/src/content/docs/development/authoring/local-dev.mdx
+++ b/website/src/content/docs/development/authoring/local-dev.mdx
@@ -51,7 +51,6 @@ use (
     ./node_modules/ttsc/shim/compiler
     ./node_modules/ttsc/shim/core
     ./node_modules/ttsc/shim/diagnosticwriter
-    ./node_modules/ttsc/shim/lsp
     ./node_modules/ttsc/shim/parser
     ./node_modules/ttsc/shim/printer
     ./node_modules/ttsc/shim/scanner
@@ -63,7 +62,7 @@ use (
 )
 ```
 
-`shim/lsp` is for `ttscserver` host embedders, not plugin authors — list it if you want gopls to resolve cross-references, leave it out otherwise.
+`shim/lsp` is intentionally omitted here. `ttscserver` wraps the project's `tsgo --lsp --stdio` process, and plugin authors should not need in-process LSP internals.
 
 ## `go.mod`
 

--- a/website/src/content/docs/development/concepts/tsgo.mdx
+++ b/website/src/content/docs/development/concepts/tsgo.mdx
@@ -75,7 +75,7 @@ Useful shim sub-packages:
 | `shim/diagnosticwriter` | render compiler-like diagnostics. `driver.WritePrettyDiagnostics` wraps this.                                                     |
 | `shim/bundled`          | TypeScript lib files for Program creation. `driver.DefaultFS` / `driver.DefaultHost` wrap this.                                   |
 | `shim/vfs`              | the `FS` interface plus `DirEntry`, `WalkDirFunc`, `SkipDir` / `SkipAll` sentinels. Use when implementing a custom VFS.           |
-| `shim/lsp`              | embedded `lsp.Server` for `ttscserver` hosts — not for plugin authors. Listed here so you know to skip it.                        |
+| `shim/lsp`              | Legacy in-process LSP access for custom host experiments — not used by `ttscserver` and not for plugin authors.                    |
 
 Do not import `github.com/microsoft/typescript-go/internal/...` directly. The shim is the plugin boundary.
 

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -120,19 +120,26 @@ Implement `SourcePreamble(ctx)` when the plugin needs text before parsing, and `
 
 These symbols are for embedders of `ttscserver`, **not for plugin authors**. Skip this section unless you are building a `ttsc`-aware editor extension.
 
+`ttscserver` is a process wrapper around the project-selected `tsgo --lsp --stdio` binary. Resolve `@typescript/native-preview` in the user project, pass its absolute executable path as `TsgoBinary`, and keep plugin diagnostics/code actions in your `PluginSource`.
+
 ```go
 err := driver.RunLSPServer(driver.LSPServerOptions{
-    PluginSource: source,           // your driver.PluginSource impl
-    DenyNpmInstall: false,          // disable inside untrusted workspaces
-    ErrorHandler:  nil,
+    In:         os.Stdin,
+    Out:        os.Stdout,
+    Err:        os.Stderr,
+    Cwd:        projectRoot,
+    TsgoBinary: tsgoBinary,
+    Source:     source,             // your driver.PluginSource impl
 })
 ```
 
 | Symbol                                                                                                              | Purpose                                                          |
 | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | `PluginSource` interface, `NullPluginSource`                                                                        | The seam downstream pipelines implement to feed ttsc plugins into the LSP. |
-| `RunLSPServer`, `LSPServerOptions`, `ErrCommandNotHandled`, `DenyNpmInstall`                                        | Host-side entry points.                                          |
+| `RunLSPServer`, `LSPServerOptions`, `ErrCommandNotHandled`                                                          | Host-side entry points.                                          |
 | `LSPDocumentVersion`, `LSPDiagnostic`, `LSPCodeAction`, `LSPRange`, `LSPWorkspaceEdit`                              | Wire types in the LSP envelope.                                  |
+
+`DenyNpmInstall` remains for older in-process embedders, but the shipped `ttscserver` no longer embeds tsgo and cannot override tsgo's internal ATA callback.
 
 ## Lower-level helpers
 

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -123,7 +123,7 @@ These symbols are for embedders of `ttscserver`, **not for plugin authors**. Ski
 `ttscserver` is a process wrapper around the project-selected `tsgo --lsp --stdio` binary. Resolve `@typescript/native-preview` in the user project, pass its absolute executable path as `TsgoBinary`, and keep plugin diagnostics/code actions in your `PluginSource`.
 
 ```go
-err := driver.RunLSPServer(driver.LSPServerOptions{
+err := driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
     In:         os.Stdin,
     Out:        os.Stdout,
     Err:        os.Stderr,


### PR DESCRIPTION
## Intent

Make `ttscserver` match the `ttsc` wrapper model: keep the shipped native LSP host thin, spawn the project-selected `tsgo --lsp --stdio` process, and keep ttsc's JSON-RPC proxy in between for plugin diagnostics, code actions, and owned commands.

## Scope

- Moved the LSP proxy/server implementation into `internal/lspserver` so `cmd/ttscserver` no longer imports the heavy compiler `driver` package.
- Kept the existing `driver` LSP surface as compatibility aliases for downstream embedders.
- Added `TTSC_TSGO_BINARY` / `--tsgo` wiring so the JS launcher resolves the consumer project's `@typescript/native-preview` binary and the native host wraps that exact executable.
- Updated VSCode launch cwd wiring so module resolution and tsgo process cwd are workspace-based.
- Added stripped Go build flags for platform binaries.
- Updated tests, coverage wiring, AGENTS, website docs, shim comments, and platform package READMEs.

## Impact

The Linux x64 `ttscserver` built by `pnpm run build:current` is now 2,494,626 bytes and has no `typescript-go` module dependency in `go version -m`. It delegates TypeScript language-server behavior to the project `tsgo` binary instead of embedding tsgo internals.

## Validation

- `go test -count=1 ./cmd/ttscserver ./internal/lspserver ./test/ttscserver ./test/driver` from `packages/ttsc`
- `pnpm run test:typecheck`
- `pnpm run coverage:go` (`packages/ttsc: Go logic coverage 100.0%`)
- `pnpm run build:current`
- `packages/ttsc-linux-x64/bin/ttscserver --version`
- `TTSC_TSGO_BINARY=<resolved tsgo> timeout 2s packages/ttsc-linux-x64/bin/ttscserver --stdio --cwd /tmp </dev/null`

`pnpm run test:features` was started after build, but was intentionally stopped to open this PR immediately per follow-up instruction. Continue it after PR creation.
