### PR TITLE
test(infra): clean up temp dirs on process exit

### DIFF
--- a/tests/test-banner/src/features/test_banner_auto_discovered_config_requires_banner_config_file.ts
+++ b/tests/test-banner/src/features/test_banner_auto_discovered_config_requires_banner_config_file.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestBanner } from "../internal/TestBanner";
@@ -35,8 +34,8 @@ export const test_banner_auto_discovered_config_requires_banner_config_file =
         cwd: root,
         env: {
           PATH: TestBanner.goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(
-            path.join(os.tmpdir(), "ttsc-auto-banner-missing-config-"),
+          TTSC_CACHE_DIR: TestProject.tmpdir(
+            "ttsc-auto-banner-missing-config-",
           ),
         },
       },

--- a/tests/test-banner/src/features/test_banner_injects_javascript_and_declaration_jsdoc.ts
+++ b/tests/test-banner/src/features/test_banner_injects_javascript_and_declaration_jsdoc.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestBanner } from "../internal/TestBanner";
@@ -44,7 +43,7 @@ export const test_banner_injects_javascript_and_declaration_jsdoc = () => {
       cwd: root,
       env: {
         PATH: TestBanner.goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-banner-")),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-banner-"),
       },
     },
   );

--- a/tests/test-banner/src/features/test_banner_package_auto_discovers_config_file.ts
+++ b/tests/test-banner/src/features/test_banner_package_auto_discovers_config_file.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestBanner } from "../internal/TestBanner";
@@ -35,9 +34,7 @@ export const test_banner_package_auto_discovers_config_file = () => {
       cwd: root,
       env: {
         PATH: TestBanner.goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-auto-banner-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-auto-banner-"),
       },
     },
   );

--- a/tests/test-banner/src/features/test_banner_preserves_executable_shebang.ts
+++ b/tests/test-banner/src/features/test_banner_preserves_executable_shebang.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestBanner } from "../internal/TestBanner";
@@ -40,9 +39,7 @@ export const test_banner_preserves_executable_shebang = () => {
       cwd: root,
       env: {
         PATH: TestBanner.goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-banner-shebang-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-banner-shebang-"),
       },
     },
   );

--- a/tests/test-banner/src/features/test_banner_respects_remove_comments.ts
+++ b/tests/test-banner/src/features/test_banner_respects_remove_comments.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestBanner } from "../internal/TestBanner";
@@ -42,9 +41,7 @@ export const test_banner_respects_remove_comments = () => {
       cwd: root,
       env: {
         PATH: TestBanner.goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-banner-remove-comments-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-banner-remove-comments-"),
       },
     },
   );

--- a/tests/test-banner/src/features/test_banner_shared_host_ignores_future_optional_flags.ts
+++ b/tests/test-banner/src/features/test_banner_shared_host_ignores_future_optional_flags.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestBanner } from "../internal/TestBanner";
@@ -47,9 +46,7 @@ export const test_banner_shared_host_ignores_future_optional_flags = () => {
   const previousPath = process.env.PATH;
   const previousCacheDir = process.env.TTSC_CACHE_DIR;
   process.env.PATH = TestBanner.goPath();
-  process.env.TTSC_CACHE_DIR = fs.mkdtempSync(
-    path.join(os.tmpdir(), "ttsc-banner-future-flag-"),
-  );
+  process.env.TTSC_CACHE_DIR = TestProject.tmpdir("ttsc-banner-future-flag-");
   let loaded;
   try {
     loaded = loadProjectPlugins({

--- a/tests/test-banner/src/features/test_banner_tsconfig_config_overrides_package_auto_config.ts
+++ b/tests/test-banner/src/features/test_banner_tsconfig_config_overrides_package_auto_config.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestBanner } from "../internal/TestBanner";
@@ -50,9 +49,7 @@ export const test_banner_tsconfig_config_overrides_package_auto_config = () => {
       cwd: root,
       env: {
         PATH: TestBanner.goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-auto-banner-explicit-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-auto-banner-explicit-"),
       },
     },
   );

--- a/tests/test-lint/src/features/config/test_lint_config_file_wrapper_tsconfig_outside_cwd_discovers_wrapper_config.ts
+++ b/tests/test-lint/src/features/config/test_lint_config_file_wrapper_tsconfig_outside_cwd_discovers_wrapper_config.ts
@@ -1,5 +1,5 @@
+import { TestProject } from "@ttsc/testing";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TtscCompiler } from "../../../../../packages/ttsc/lib/index.js";
@@ -36,9 +36,7 @@ export const test_lint_config_file_wrapper_tsconfig_outside_cwd_discovers_wrappe
         }),
       },
     });
-    const wrapper = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-lint-wrapper-"),
-    );
+    const wrapper = TestProject.tmpdir("ttsc-lint-wrapper-");
     try {
       const tsconfig = path.join(wrapper, "tsconfig.json");
       fs.writeFileSync(

--- a/tests/test-lint/src/features/fix/test_lint_fix_contributor_rule_single_edit_applies_through_native_engine.ts
+++ b/tests/test-lint/src/features/fix/test_lint_fix_contributor_rule_single_edit_applies_through_native_engine.ts
@@ -39,7 +39,7 @@ export const test_lint_fix_contributor_rule_single_edit_applies_through_native_e
       "utf8",
     );
     const root = path.join(
-      fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-lint-fix-contrib-")),
+      TestProject.tmpdir("ttsc-lint-fix-contrib-"),
       "project",
     );
 
@@ -58,9 +58,7 @@ export const test_lint_fix_contributor_rule_single_edit_applies_through_native_e
           cwd: root,
           env: {
             PATH: goPath(),
-            TTSC_CACHE_DIR: fs.mkdtempSync(
-              path.join(os.tmpdir(), "ttsc-lint-fix-contrib-cache-"),
-            ),
+            TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-lint-fix-contrib-cache-"),
             TTSC_GO_BINARY: goBinary(),
           },
         },

--- a/tests/test-lint/src/features/fix/test_lint_fix_native_project_rewrites_temp_copy_only.ts
+++ b/tests/test-lint/src/features/fix/test_lint_fix_native_project_rewrites_temp_copy_only.ts
@@ -33,7 +33,7 @@ export const test_lint_fix_native_project_rewrites_temp_copy_only = () => {
     "utf8",
   );
   const root = path.join(
-    fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-lint-fix-project-")),
+    TestProject.tmpdir("ttsc-lint-fix-project-"),
     "project",
   );
 
@@ -48,9 +48,7 @@ export const test_lint_fix_native_project_rewrites_temp_copy_only = () => {
         cwd: root,
         env: {
           PATH: goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(
-            path.join(os.tmpdir(), "ttsc-lint-fix-cache-"),
-          ),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-lint-fix-cache-"),
           TTSC_GO_BINARY: goBinary(),
         },
       },

--- a/tests/test-lint/src/features/format/test_lint_format_jsdoc_rewrites_synonym_tags.ts
+++ b/tests/test-lint/src/features/format/test_lint_format_jsdoc_rewrites_synonym_tags.ts
@@ -29,7 +29,7 @@ export const test_lint_format_jsdoc_rewrites_synonym_tags = () => {
     "utf8",
   );
   const root = path.join(
-    fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-lint-format-jsdoc-")),
+    TestProject.tmpdir("ttsc-lint-format-jsdoc-"),
     "project",
   );
 
@@ -44,9 +44,7 @@ export const test_lint_format_jsdoc_rewrites_synonym_tags = () => {
         cwd: root,
         env: {
           PATH: goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(
-            path.join(os.tmpdir(), "ttsc-lint-format-jsdoc-cache-"),
-          ),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-lint-format-jsdoc-cache-"),
           TTSC_GO_BINARY: goBinary(),
         },
       },

--- a/tests/test-lint/src/features/format/test_lint_format_native_project_rewrites_temp_copy_only.ts
+++ b/tests/test-lint/src/features/format/test_lint_format_native_project_rewrites_temp_copy_only.ts
@@ -34,7 +34,7 @@ export const test_lint_format_native_project_rewrites_temp_copy_only = () => {
     "utf8",
   );
   const root = path.join(
-    fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-lint-format-project-")),
+    TestProject.tmpdir("ttsc-lint-format-project-"),
     "project",
   );
 
@@ -49,9 +49,7 @@ export const test_lint_format_native_project_rewrites_temp_copy_only = () => {
         cwd: root,
         env: {
           PATH: goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(
-            path.join(os.tmpdir(), "ttsc-lint-format-cache-"),
-          ),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-lint-format-cache-"),
           TTSC_GO_BINARY: goBinary(),
         },
       },

--- a/tests/test-lint/src/features/format/test_lint_format_quotes_rewrites_single_quoted_literals.ts
+++ b/tests/test-lint/src/features/format/test_lint_format_quotes_rewrites_single_quoted_literals.ts
@@ -29,7 +29,7 @@ export const test_lint_format_quotes_rewrites_single_quoted_literals = () => {
     "utf8",
   );
   const root = path.join(
-    fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-lint-format-quotes-")),
+    TestProject.tmpdir("ttsc-lint-format-quotes-"),
     "project",
   );
 
@@ -44,9 +44,7 @@ export const test_lint_format_quotes_rewrites_single_quoted_literals = () => {
         cwd: root,
         env: {
           PATH: goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(
-            path.join(os.tmpdir(), "ttsc-lint-format-quotes-cache-"),
-          ),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-lint-format-quotes-cache-"),
           TTSC_GO_BINARY: goBinary(),
         },
       },

--- a/tests/test-lint/src/features/format/test_lint_format_sort_imports_reorders_groups_and_specifiers.ts
+++ b/tests/test-lint/src/features/format/test_lint_format_sort_imports_reorders_groups_and_specifiers.ts
@@ -30,7 +30,7 @@ export const test_lint_format_sort_imports_reorders_groups_and_specifiers =
       "utf8",
     );
     const root = path.join(
-      fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-lint-format-sort-")),
+      TestProject.tmpdir("ttsc-lint-format-sort-"),
       "project",
     );
 
@@ -45,9 +45,7 @@ export const test_lint_format_sort_imports_reorders_groups_and_specifiers =
           cwd: root,
           env: {
             PATH: goPath(),
-            TTSC_CACHE_DIR: fs.mkdtempSync(
-              path.join(os.tmpdir(), "ttsc-lint-format-sort-cache-"),
-            ),
+            TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-lint-format-sort-cache-"),
             TTSC_GO_BINARY: goBinary(),
           },
         },

--- a/tests/test-lint/src/features/format/test_lint_format_trailing_comma_rewrites_multi_line_lists.ts
+++ b/tests/test-lint/src/features/format/test_lint_format_trailing_comma_rewrites_multi_line_lists.ts
@@ -30,10 +30,7 @@ export const test_lint_format_trailing_comma_rewrites_multi_line_lists = () => {
     path.join(fixture, "expected", "main.ts"),
     "utf8",
   );
-  const root = path.join(
-    fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-lint-format-tc-")),
-    "project",
-  );
+  const root = path.join(TestProject.tmpdir("ttsc-lint-format-tc-"), "project");
 
   try {
     fs.cpSync(fixture, root, { recursive: true });
@@ -46,9 +43,7 @@ export const test_lint_format_trailing_comma_rewrites_multi_line_lists = () => {
         cwd: root,
         env: {
           PATH: goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(
-            path.join(os.tmpdir(), "ttsc-lint-format-tc-cache-"),
-          ),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-lint-format-tc-cache-"),
           TTSC_GO_BINARY: goBinary(),
         },
       },

--- a/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
+++ b/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
@@ -23,8 +23,8 @@ import assert from "node:assert/strict";
  * - A lint-only rule (`no-var`) cannot carry an options object.
  *
  * The function runs at runtime as a sanity check that `satisfies
- * ITtscLintConfig` does not regress; the real assertion happens during `pnpm run
- * test:typecheck`.
+ * ITtscLintConfig` does not regress; the real assertion happens during `pnpm
+ * run test:typecheck`.
  *
  * 1. Construct configs exercising each tuple shape, both valid and broken.
  * 2. Verify the runtime objects exist (the happy paths must compile).

--- a/tests/test-paths/src/features/test_paths_rewrites_esm_imports_and_re_exports.ts
+++ b/tests/test-paths/src/features/test_paths_rewrites_esm_imports_and_re_exports.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestPaths } from "../internal/TestPaths";
@@ -66,7 +65,7 @@ export const test_paths_rewrites_esm_imports_and_re_exports = () => {
       cwd: root,
       env: {
         PATH: TestPaths.goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-paths-")),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-paths-"),
       },
     },
   );

--- a/tests/test-paths/src/features/test_paths_uses_nodenext_output_extensions_from_tsconfig.ts
+++ b/tests/test-paths/src/features/test_paths_uses_nodenext_output_extensions_from_tsconfig.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestPaths } from "../internal/TestPaths";
@@ -66,9 +65,7 @@ export const test_paths_uses_nodenext_output_extensions_from_tsconfig = () => {
       cwd: root,
       env: {
         PATH: TestPaths.goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-paths-nodenext-extensions-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-paths-nodenext-extensions-"),
       },
     },
   );

--- a/tests/test-strip/src/features/test_strip_package_auto_plugin_walks_to_ancestor_package_json.ts
+++ b/tests/test-strip/src/features/test_strip_package_auto_plugin_walks_to_ancestor_package_json.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestStrip } from "../internal/TestStrip";
@@ -51,9 +50,7 @@ export const test_strip_package_auto_plugin_walks_to_ancestor_package_json =
         cwd: project,
         env: {
           PATH: TestStrip.goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(
-            path.join(os.tmpdir(), "ttsc-ancestor-strip-"),
-          ),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-ancestor-strip-"),
         },
       },
     );

--- a/tests/test-strip/src/features/test_strip_package_auto_uses_default_config.ts
+++ b/tests/test-strip/src/features/test_strip_package_auto_uses_default_config.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestStrip } from "../internal/TestStrip";
@@ -43,9 +42,7 @@ export const test_strip_package_auto_uses_default_config = () => {
       cwd: root,
       env: {
         PATH: TestStrip.goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-auto-strip-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-auto-strip-"),
       },
     },
   );

--- a/tests/test-strip/src/features/test_strip_removes_configured_calls_and_debugger_statements.ts
+++ b/tests/test-strip/src/features/test_strip_removes_configured_calls_and_debugger_statements.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestStrip } from "../internal/TestStrip";
@@ -45,7 +44,7 @@ export const test_strip_removes_configured_calls_and_debugger_statements =
         cwd: root,
         env: {
           PATH: TestStrip.goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-strip-")),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-strip-"),
         },
       },
     );

--- a/tests/test-strip/src/features/test_strip_tsconfig_plugin_overrides_duplicate_package_auto_plugin.ts
+++ b/tests/test-strip/src/features/test_strip_tsconfig_plugin_overrides_duplicate_package_auto_plugin.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestStrip } from "../internal/TestStrip";
@@ -48,9 +47,7 @@ export const test_strip_tsconfig_plugin_overrides_duplicate_package_auto_plugin 
         cwd: root,
         env: {
           PATH: TestStrip.goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(
-            path.join(os.tmpdir(), "ttsc-auto-strip-explicit-"),
-          ),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-auto-strip-explicit-"),
         },
       },
     );

--- a/tests/test-ttsc/src/features/api/test_ttsccompiler_compile_discovers_package_plugins_from_ancestor_package_json.ts
+++ b/tests/test-ttsc/src/features/api/test_ttsccompiler_compile_discovers_package_plugins_from_ancestor_package_json.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   TtscCompiler,
   assert,
@@ -25,7 +27,7 @@ import {
  */
 export const test_ttsccompiler_compile_discovers_package_plugins_from_ancestor_package_json =
   () => {
-    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-workspace-"));
+    const workspace = TestProject.tmpdir("ttsc-workspace-");
     const project = path.join(workspace, "packages", "app");
     writeBasicProject(
       project,

--- a/tests/test-ttsc/src/features/api/test_ttsccompiler_compile_stops_package_plugin_discovery_at_nearest_package_json.ts
+++ b/tests/test-ttsc/src/features/api/test_ttsccompiler_compile_stops_package_plugin_discovery_at_nearest_package_json.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   TtscCompiler,
   assert,
@@ -25,7 +27,7 @@ import {
  */
 export const test_ttsccompiler_compile_stops_package_plugin_discovery_at_nearest_package_json =
   () => {
-    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-workspace-"));
+    const workspace = TestProject.tmpdir("ttsc-workspace-");
     const project = path.join(workspace, "packages", "app");
     writeBasicProject(
       project,

--- a/tests/test-ttsc/src/features/api/test_ttsccompiler_prepare_honors_projectroot_when_tsconfig_is_outside_the_project.ts
+++ b/tests/test-ttsc/src/features/api/test_ttsccompiler_prepare_honors_projectroot_when_tsconfig_is_outside_the_project.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   TtscCompiler,
   assert,
@@ -24,7 +26,7 @@ import {
  */
 export const test_ttsccompiler_prepare_honors_projectroot_when_tsconfig_is_outside_the_project =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-compiler-api-"));
+    const root = TestProject.tmpdir("ttsc-compiler-api-");
     const project = path.join(root, "project");
     const config = path.join(root, "config");
     fs.mkdirSync(project, { recursive: true });

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_auto_discovered_ttsc_lint_fails_when_no_config_file_exists.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_auto_discovered_ttsc_lint_fails_when_no_config_file_exists.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -50,9 +52,7 @@ export const test_plugin_corpus_auto_discovered_ttsc_lint_fails_when_no_config_f
       cwd: root,
       env: {
         PATH: goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-auto-lint-missing-config-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-auto-lint-missing-config-"),
       },
     });
     assert.notEqual(result.status, 0, "expected missing lint config to fail");

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_check_plugin_output_does_not_suppress_typescript_diagnostics.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_check_plugin_output_does_not_suppress_typescript_diagnostics.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   __dirname,
   assert,
@@ -60,7 +62,7 @@ export const test_plugin_corpus_check_plugin_output_does_not_suppress_typescript
       cwd: root,
       env: {
         PATH: goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-check-")),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-check-"),
       },
     });
 

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_concurrent_ttsc_invocations_on_a_cold_cache_both_succeed.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_concurrent_ttsc_invocations_on_a_cold_cache_both_succeed.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   child_process,
@@ -28,9 +30,7 @@ export const test_plugin_corpus_concurrent_ttsc_invocations_on_a_cold_cache_both
   async () => {
     const rootA = copyProject("go-source-plugin");
     const rootB = copyProject("go-source-plugin");
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-source-plugin-race-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-source-plugin-race-");
     const env = {
       ...process.env,
       PATH: goPath(),

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_missing_go_toolchain_points_users_at_the_install_hint.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_missing_go_toolchain_points_users_at_the_install_hint.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -30,9 +32,7 @@ export const test_plugin_corpus_missing_go_toolchain_points_users_at_the_install
         // toolchain via TTSC_GO_BINARY.
         PATH: "/nonexistent",
         TTSC_GO_BINARY: "/nonexistent/go-binary-that-does-not-exist",
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-source-plugin-no-go-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-source-plugin-no-go-"),
       },
     });
     assert.notEqual(result.status, 0);

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_package_relative_auto_plugins_do_not_collide_by_raw_transform.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_package_relative_auto_plugins_do_not_collide_by_raw_transform.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   commonJsProject,
@@ -55,9 +57,7 @@ export const test_plugin_corpus_package_relative_auto_plugins_do_not_collide_by_
       cwd: root,
       env: {
         PATH: goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-package-relative-plugins-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-package-relative-plugins-"),
       },
     });
     assert.equal(result.status, 0, result.stderr || result.stdout);

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_package_ttsc_plugin_auto_discovers_ttsc_lint_config_files.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_package_ttsc_plugin_auto_discovers_ttsc_lint_config_files.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -54,9 +56,7 @@ export const test_plugin_corpus_package_ttsc_plugin_auto_discovers_ttsc_lint_con
       cwd: root,
       env: {
         PATH: goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-auto-lint-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-auto-lint-"),
       },
     });
     assert.notEqual(result.status, 0, "expected auto-discovered lint to run");

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_prepare_builds_source_plugins_without_emitting_project_output.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_prepare_builds_source_plugins_without_emitting_project_output.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -24,9 +26,7 @@ import {
 export const test_plugin_corpus_prepare_builds_source_plugins_without_emitting_project_output =
   () => {
     const root = copyProject("go-source-plugin");
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-source-plugin-prepare-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-source-plugin-prepare-");
     const env = {
       PATH: goPath(),
       TTSC_CACHE_DIR: cacheDir,

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_relative_cache_dir_resolves_from_cwd_option.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_relative_cache_dir_resolves_from_cwd_option.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -23,7 +25,7 @@ import {
 export const test_plugin_corpus_relative_cache_dir_resolves_from_cwd_option =
   () => {
     const root = copyProject("go-source-plugin");
-    const driverCwd = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-driver-"));
+    const driverCwd = TestProject.tmpdir("ttsc-driver-");
     const cacheDir = "relative-cache";
 
     const result = spawn(

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_path_can_point_directly_at_go_mod.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_path_can_point_directly_at_go_mod.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   __dirname,
   assert,
@@ -37,9 +39,7 @@ module.exports = {
       cwd: root,
       env: {
         PATH: goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-source-plugin-gomod-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-source-plugin-gomod-"),
       },
     });
     assert.equal(result.status, 0, result.stderr);

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_path_searches_at_most_three_parents_for_go_mod.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_path_searches_at_most_three_parents_for_go_mod.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   __dirname,
   assert,
@@ -40,9 +42,7 @@ module.exports = {
       cwd: root,
       env: {
         PATH: goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-source-plugin-too-deep-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-source-plugin-too-deep-"),
       },
     });
     assert.notEqual(result.status, 0);

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_path_selects_a_sub_package.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_path_selects_a_sub_package.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -22,9 +24,7 @@ import {
  */
 export const test_plugin_corpus_source_path_selects_a_sub_package = () => {
   const root = copyProject("go-source-plugin-entry");
-  const cacheDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), "ttsc-source-plugin-entry-"),
-  );
+  const cacheDir = TestProject.tmpdir("ttsc-source-plugin-entry-");
   const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
     cwd: root,
     env: { PATH: goPath(), TTSC_CACHE_DIR: cacheDir },

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugin_bootstraps_a_program_and_checker_against_the_consumer_tsconfig.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugin_bootstraps_a_program_and_checker_against_the_consumer_tsconfig.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -24,9 +26,7 @@ import {
 export const test_plugin_corpus_source_plugin_bootstraps_a_program_and_checker_against_the_consumer_tsconfig =
   () => {
     const root = copyProject("go-source-plugin-checker");
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-source-plugin-checker-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-source-plugin-checker-");
     const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
       cwd: root,
       env: {

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugin_build_failure_reports_go_compiler_stderr.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugin_build_failure_reports_go_compiler_stderr.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -35,9 +37,7 @@ export const test_plugin_corpus_source_plugin_build_failure_reports_go_compiler_
       cwd: root,
       env: {
         PATH: goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-source-plugin-broken-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-source-plugin-broken-"),
       },
     });
     assert.notEqual(result.status, 0);

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugin_cache_invalidates_when_go_source_changes.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugin_cache_invalidates_when_go_source_changes.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -24,9 +26,7 @@ import {
 export const test_plugin_corpus_source_plugin_cache_invalidates_when_go_source_changes =
   () => {
     const root = copyProject("go-source-plugin");
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-source-plugin-invalidate-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-source-plugin-invalidate-");
     const env = {
       PATH: goPath(),
       TTSC_CACHE_DIR: cacheDir,

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugin_can_import_tsgo_shim_modules_via_go_work_overlay.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugin_can_import_tsgo_shim_modules_via_go_work_overlay.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -24,9 +26,7 @@ import {
 export const test_plugin_corpus_source_plugin_can_import_tsgo_shim_modules_via_go_work_overlay =
   () => {
     const root = copyProject("go-source-plugin-tsgo");
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-source-plugin-tsgo-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-source-plugin-tsgo-");
     const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
       cwd: root,
       env: {

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugin_rejects_ttsc_managed_replacements.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugin_rejects_ttsc_managed_replacements.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -25,9 +27,7 @@ import {
 export const test_plugin_corpus_source_plugin_rejects_ttsc_managed_replacements =
   () => {
     const root = copyProject("go-source-plugin-managed-replace");
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-source-plugin-managed-replace-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-source-plugin-managed-replace-");
     const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
       cwd: root,
       env: {

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugin_walks_ast_uses_checker_to_enumerate_interface_properties.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugin_walks_ast_uses_checker_to_enumerate_interface_properties.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -24,9 +26,7 @@ import {
 export const test_plugin_corpus_source_plugin_walks_ast_uses_checker_to_enumerate_interface_properties =
   () => {
     const root = copyProject("go-source-plugin-properties");
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-source-plugin-properties-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-source-plugin-properties-");
     const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
       cwd: root,
       env: {

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugins_are_built_locally_and_used.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugins_are_built_locally_and_used.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -23,9 +25,7 @@ import {
 export const test_plugin_corpus_source_plugins_are_built_locally_and_used =
   () => {
     const root = copyProject("go-source-plugin");
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-source-plugin-cache-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-source-plugin-cache-");
     const env = {
       PATH: goPath(),
       TTSC_CACHE_DIR: cacheDir,

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugins_build_with_the_bundled_go_compiler.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugins_build_with_the_bundled_go_compiler.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -26,9 +28,7 @@ export const test_plugin_corpus_source_plugins_build_with_the_bundled_go_compile
       cwd: root,
       env: {
         PATH: "/nonexistent",
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-source-plugin-bundled-go-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-source-plugin-bundled-go-"),
       },
     });
     assert.equal(result.status, 0, result.stderr);

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugins_serve_an_ordered_plugins_json_pipeline.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_source_plugins_serve_an_ordered_plugins_json_pipeline.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   __dirname,
   assert,
@@ -25,9 +27,7 @@ import {
 export const test_plugin_corpus_source_plugins_serve_an_ordered_plugins_json_pipeline =
   () => {
     const root = copyProject("go-source-plugin");
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-source-plugin-ordered-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-source-plugin-ordered-");
     // Override plugin.cjs to expose a context-driven manifest factory so we can
     // declare prefix → upper → suffix as ordered entries that all share the
     // same source dir (and therefore the same compiled binary).

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_clean_project_exits_zero.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_clean_project_exits_zero.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -27,7 +29,7 @@ export const test_plugin_corpus_ttsc_lint_clean_project_exits_zero = () => {
     path.join(root, "src", "main.ts"),
     `export const value: string = "hi";\nconst _value: number = value.length;\nvoid _value;\n`,
   );
-  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-lint-clean-"));
+  const cacheDir = TestProject.tmpdir("ttsc-lint-clean-");
   const result = spawn(ttscBin, ["--cwd", root, "--noEmit"], {
     cwd: root,
     env: { PATH: goPath(), TTSC_CACHE_DIR: cacheDir },

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_fix_rewrites_source_before_final_check.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_fix_rewrites_source_before_final_check.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   commonJsProject,
@@ -55,9 +57,7 @@ export const test_plugin_corpus_ttsc_lint_fix_rewrites_source_before_final_check
       cwd: root,
       env: {
         PATH: goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-lint-fix-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-lint-fix-"),
         TTSC_GO_BINARY: fs.existsSync(goBinary) ? goBinary : "go",
       },
     });

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_format_subcommand_rewrites_source.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_format_subcommand_rewrites_source.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   commonJsProject,
@@ -54,9 +56,7 @@ export const test_plugin_corpus_ttsc_lint_format_subcommand_rewrites_source =
       cwd: root,
       env: {
         PATH: goPath(),
-        TTSC_CACHE_DIR: fs.mkdtempSync(
-          path.join(os.tmpdir(), "ttsc-lint-format-subcmd-"),
-        ),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-lint-format-subcmd-"),
         TTSC_GO_BINARY: fs.existsSync(goBinary) ? goBinary : "go",
       },
     });

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_honors_emit_and_outdir_overrides.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_honors_emit_and_outdir_overrides.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -47,9 +49,7 @@ export const test_plugin_corpus_ttsc_lint_honors_emit_and_outdir_overrides =
       path.join(root, "src", "main.ts"),
       `export const value: string = "lint-outdir";\n`,
     );
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-lint-outdir-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-lint-outdir-");
 
     const result = spawn(
       ttscBin,

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_ignores_future_optional_flags.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_ignores_future_optional_flags.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -58,9 +60,7 @@ export const test_plugin_corpus_ttsc_lint_ignores_future_optional_flags =
     const previousPath = process.env.PATH;
     const previousCacheDir = process.env.TTSC_CACHE_DIR;
     process.env.PATH = goPath();
-    process.env.TTSC_CACHE_DIR = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-lint-future-flag-"),
-    );
+    process.env.TTSC_CACHE_DIR = TestProject.tmpdir("ttsc-lint-future-flag-");
     let loaded;
     try {
       loaded = loadProjectPlugins({

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_option_changes_reuse_the_source_plugin_binary_cache.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_option_changes_reuse_the_source_plugin_binary_cache.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -44,9 +46,7 @@ export const test_plugin_corpus_ttsc_lint_option_changes_reuse_the_source_plugin
         }),
       );
     };
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-lint-cache-options-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-lint-cache-options-");
     const env = { PATH: goPath(), TTSC_CACHE_DIR: cacheDir };
 
     writeConfig({ "no-var": "error" });

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_reports_unknown_rule_names.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_reports_unknown_rule_names.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -47,7 +49,7 @@ export const test_plugin_corpus_ttsc_lint_reports_unknown_rule_names = () => {
     path.join(root, "src", "main.ts"),
     `export const value: string = "ok";\n`,
   );
-  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-lint-unknown-"));
+  const cacheDir = TestProject.tmpdir("ttsc-lint-unknown-");
   const result = spawn(ttscBin, ["--cwd", root, "--noEmit"], {
     cwd: root,
     env: { PATH: goPath(), TTSC_CACHE_DIR: cacheDir },

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_surfaces_rule_violations_through_the_normal_failure_path.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_surfaces_rule_violations_through_the_normal_failure_path.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -26,9 +28,7 @@ import {
 export const test_plugin_corpus_ttsc_lint_surfaces_rule_violations_through_the_normal_failure_path =
   () => {
     const root = setupLintProject("lint-violations");
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-lint-violations-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-lint-violations-");
     const result = spawn(ttscBin, ["--cwd", root, "--noEmit"], {
       cwd: root,
       env: { PATH: goPath(), TTSC_CACHE_DIR: cacheDir },

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsx_executes_source_plugin_output_end_to_end.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsx_executes_source_plugin_output_end_to_end.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -23,9 +25,7 @@ import {
 export const test_plugin_corpus_ttsx_executes_source_plugin_output_end_to_end =
   () => {
     const root = copyProject("go-source-plugin");
-    const cacheDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-source-plugin-ttsx-"),
-    );
+    const cacheDir = TestProject.tmpdir("ttsc-source-plugin-ttsx-");
     const result = spawn(ttsxBin, ["--cwd", root, "src/main.ts"], {
       cwd: root,
       env: { PATH: goPath(), TTSC_CACHE_DIR: cacheDir },

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsx_relative_cache_dir_builds_source_plugin_under_cwd_option.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsx_relative_cache_dir_builds_source_plugin_under_cwd_option.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   copyProject,
@@ -24,7 +26,7 @@ import {
 export const test_plugin_corpus_ttsx_relative_cache_dir_builds_source_plugin_under_cwd_option =
   () => {
     const root = copyProject("go-source-plugin");
-    const driverCwd = fs.mkdtempSync(path.join(os.tmpdir(), "ttsx-driver-"));
+    const driverCwd = TestProject.tmpdir("ttsx-driver-");
     const cacheDir = ".ttsx-cache";
 
     const result = spawn(

--- a/tests/test-ttsc/src/features/project/test_loadprojectplugins_resolves_inherited_relative_transform_paths_from_the_declaring_file.ts
+++ b/tests/test-ttsc/src/features/project/test_loadprojectplugins_resolves_inherited_relative_transform_paths_from_the_declaring_file.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -20,7 +22,7 @@ import {
  */
 export const test_loadprojectplugins_resolves_inherited_relative_transform_paths_from_the_declaring_file =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+    const root = TestProject.tmpdir("ttsc-project-");
     const shared = path.join(root, "config");
     const project = path.join(root, "project");
     fs.mkdirSync(path.join(shared, "plugins"), { recursive: true });

--- a/tests/test-ttsc/src/features/project/test_loadprojectplugins_suppresses_package_auto_plugin_through_symlinked_explicit_path.ts
+++ b/tests/test-ttsc/src/features/project/test_loadprojectplugins_suppresses_package_auto_plugin_through_symlinked_explicit_path.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -20,7 +22,7 @@ import {
  */
 export const test_loadprojectplugins_suppresses_package_auto_plugin_through_symlinked_explicit_path =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+    const root = TestProject.tmpdir("ttsc-project-");
     const realPackage = path.join(root, "packages", "linked-plugin");
     const project = path.join(root, "project");
     const linkedPackage = path.join(project, "node_modules", "linked-plugin");

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_accepts_jsonc_comments_and_trailing_commas.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_accepts_jsonc_comments_and_trailing_commas.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -19,7 +21,7 @@ import {
  */
 export const test_readprojectconfig_accepts_jsonc_comments_and_trailing_commas =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+    const root = TestProject.tmpdir("ttsc-project-");
     fs.writeFileSync(
       path.join(root, "tsconfig.json"),
       `{

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_applies_array_extends_in_order.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_applies_array_extends_in_order.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -18,7 +20,7 @@ import {
  * 3. Assert the returned files, diagnostics, cache key, or descriptor contract.
  */
 export const test_readprojectconfig_applies_array_extends_in_order = () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+  const root = TestProject.tmpdir("ttsc-project-");
   const shared = path.join(root, "config");
   const project = path.join(root, "project");
   fs.mkdirSync(shared, { recursive: true });

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_inherits_plugins_and_outdir_through_tsconfig_extends.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_inherits_plugins_and_outdir_through_tsconfig_extends.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -20,7 +22,7 @@ import {
  */
 export const test_readprojectconfig_inherits_plugins_and_outdir_through_tsconfig_extends =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+    const root = TestProject.tmpdir("ttsc-project-");
     const shared = path.join(root, "config");
     const project = path.join(root, "project");
     fs.mkdirSync(shared, { recursive: true });

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_lets_child_tsconfig_override_inherited_plugins.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_lets_child_tsconfig_override_inherited_plugins.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -19,7 +21,7 @@ import {
  */
 export const test_readprojectconfig_lets_child_tsconfig_override_inherited_plugins =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+    const root = TestProject.tmpdir("ttsc-project-");
     const shared = path.join(root, "config");
     const project = path.join(root, "project");
     fs.mkdirSync(shared, { recursive: true });

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_lets_later_array_extends_clear_inherited_plugins.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_lets_later_array_extends_clear_inherited_plugins.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -19,7 +21,7 @@ import {
  */
 export const test_readprojectconfig_lets_later_array_extends_clear_inherited_plugins =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+    const root = TestProject.tmpdir("ttsc-project-");
     const shared = path.join(root, "config");
     const project = path.join(root, "project");
     fs.mkdirSync(shared, { recursive: true });

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_rejects_circular_tsconfig_extends.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_rejects_circular_tsconfig_extends.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -18,7 +20,7 @@ import {
  * 3. Assert the returned files, diagnostics, cache key, or descriptor contract.
  */
 export const test_readprojectconfig_rejects_circular_tsconfig_extends = () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+  const root = TestProject.tmpdir("ttsc-project-");
   fs.writeFileSync(
     path.join(root, "a.json"),
     JSON.stringify({ extends: "./b.json" }),

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_resolves_inherited_relative_path_options_from_the_declaring_file.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_resolves_inherited_relative_path_options_from_the_declaring_file.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -20,7 +22,7 @@ import {
  */
 export const test_readprojectconfig_resolves_inherited_relative_path_options_from_the_declaring_file =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+    const root = TestProject.tmpdir("ttsc-project-");
     const shared = path.join(root, "config");
     const project = path.join(root, "project");
     fs.mkdirSync(shared, { recursive: true });

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_resolves_package_tsconfig_extends.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_resolves_package_tsconfig_extends.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -18,7 +20,7 @@ import {
  * 3. Assert the returned files, diagnostics, cache key, or descriptor contract.
  */
 export const test_readprojectconfig_resolves_package_tsconfig_extends = () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+  const root = TestProject.tmpdir("ttsc-project-");
   const preset = path.join(root, "node_modules", "@scope", "tsconfig");
   const project = path.join(root, "project");
   fs.mkdirSync(preset, { recursive: true });

--- a/tests/test-ttsc/src/features/project/test_resolveprojectconfig_canonicalizes_symlinked_tsconfig_paths.ts
+++ b/tests/test-ttsc/src/features/project/test_resolveprojectconfig_canonicalizes_symlinked_tsconfig_paths.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -19,7 +21,7 @@ import {
  */
 export const test_resolveprojectconfig_canonicalizes_symlinked_tsconfig_paths =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-project-"));
+    const root = TestProject.tmpdir("ttsc-project-");
     const real = path.join(root, "real");
     const link = path.join(root, "link");
     fs.mkdirSync(real, { recursive: true });

--- a/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_makes_go_toolchain_executable_before_metadata_reads.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_makes_go_toolchain_executable_before_metadata_reads.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   buildSourcePlugin,
@@ -21,7 +23,7 @@ export const test_buildsourceplugin_makes_go_toolchain_executable_before_metadat
       return;
     }
 
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-go-mode-"));
+    const root = TestProject.tmpdir("ttsc-go-mode-");
     const plugin = path.join(root, "plugin");
     fs.mkdirSync(plugin, { recursive: true });
     fs.writeFileSync(

--- a/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_materializes_standard_go_source_directories.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_materializes_standard_go_source_directories.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   buildSourcePlugin,
@@ -20,7 +22,7 @@ import {
  */
 export const test_buildsourceplugin_materializes_standard_go_source_directories =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
     const plugin = path.join(root, "plugin");
     fs.mkdirSync(plugin, { recursive: true });
     fs.writeFileSync(

--- a/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_rejects_a_source_outside_a_nearby_go_module.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_rejects_a_source_outside_a_nearby_go_module.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   buildSourcePlugin,
@@ -19,7 +21,7 @@ import {
  */
 export const test_buildsourceplugin_rejects_a_source_outside_a_nearby_go_module =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
     const source = path.join(root, "a", "b", "c", "d", "cmd");
     fs.mkdirSync(source, { recursive: true });
 

--- a/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_rejects_non_directory_and_non_go_mod_sources.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_rejects_non_directory_and_non_go_mod_sources.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   buildSourcePlugin,
@@ -19,7 +21,7 @@ import {
  */
 export const test_buildsourceplugin_rejects_non_directory_and_non_go_mod_sources =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
     const source = path.join(root, "plugin.txt");
     fs.writeFileSync(source, "not a Go package\n", "utf8");
 

--- a/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_rejects_source_replace_for_ttsc_managed_modules.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_rejects_source_replace_for_ttsc_managed_modules.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   buildSourcePlugin,
@@ -24,7 +26,7 @@ import {
  */
 export const test_buildsourceplugin_rejects_source_replace_for_ttsc_managed_modules =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-replace-"));
+    const root = TestProject.tmpdir("ttsc-source-replace-");
     const source = path.join(root, "plugin");
     const overlay = path.join(root, "overlay", "ttsc");
     const overlayPrinter = path.join(overlay, "shim", "printer");

--- a/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_reuses_global_cache_across_project_roots.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_reuses_global_cache_across_project_roots.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   buildSourcePlugin,
@@ -21,7 +23,7 @@ import {
  */
 export const test_buildsourceplugin_reuses_global_cache_across_project_roots =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
     const cacheHome = path.join(root, "cache-home");
     const first = path.join(root, "project-a", "plugin");
     const second = path.join(root, "project-b", "plugin");

--- a/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_supports_project_root_sources_with_global_cache.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_buildsourceplugin_supports_project_root_sources_with_global_cache.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   buildSourcePlugin,
@@ -20,7 +22,7 @@ import {
  */
 export const test_buildsourceplugin_supports_project_root_sources_with_global_cache =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
     const cacheHome = path.join(root, "cache-home");
     fs.writeFileSync(
       path.join(root, "go.mod"),

--- a/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_effective_go_env_changes.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_effective_go_env_changes.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   computeCacheKey,
@@ -21,7 +23,7 @@ import {
  */
 export const test_computecachekey_changes_when_effective_go_env_changes =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
     const plugin = path.join(root, "plugin");
     fs.mkdirSync(plugin, { recursive: true });
     fs.writeFileSync(

--- a/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_embedded_data_changes.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_embedded_data_changes.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   computeCacheKey,
@@ -18,7 +20,7 @@ import {
  * 3. Assert the returned files, diagnostics, cache key, or descriptor contract.
  */
 export const test_computecachekey_changes_when_embedded_data_changes = () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+  const root = TestProject.tmpdir("ttsc-source-plugin-");
   const plugin = path.join(root, "plugin");
   fs.mkdirSync(plugin, { recursive: true });
   fs.writeFileSync(

--- a/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_external_tool_identity_changes.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_external_tool_identity_changes.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   computeCacheKey,
@@ -21,7 +23,7 @@ import {
  */
 export const test_computecachekey_changes_when_external_tool_identity_changes =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
     const plugin = path.join(root, "plugin");
     fs.mkdirSync(plugin, { recursive: true });
     fs.writeFileSync(

--- a/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_go_compiler_identity_changes.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_go_compiler_identity_changes.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   computeCacheKey,
@@ -19,7 +21,7 @@ import {
  */
 export const test_computecachekey_changes_when_go_compiler_identity_changes =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
     const plugin = path.join(root, "plugin");
     fs.mkdirSync(plugin, { recursive: true });
     fs.writeFileSync(

--- a/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_goroot_changes.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_goroot_changes.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   computeCacheKey,
@@ -19,7 +21,7 @@ import {
  * 3. Assert the keys differ.
  */
 export const test_computecachekey_changes_when_goroot_changes = () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+  const root = TestProject.tmpdir("ttsc-source-plugin-");
   const plugin = path.join(root, "plugin");
   fs.mkdirSync(plugin, { recursive: true });
   fs.writeFileSync(

--- a/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_goroot_source_changes.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_goroot_source_changes.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   computeCacheKey,
@@ -20,7 +22,7 @@ import {
  * 3. Assert the cache keys differ.
  */
 export const test_computecachekey_changes_when_goroot_source_changes = () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+  const root = TestProject.tmpdir("ttsc-source-plugin-");
   const plugin = path.join(root, "plugin");
   fs.mkdirSync(plugin, { recursive: true });
   fs.writeFileSync(

--- a/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_goroot_source_changes_in_place.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_goroot_source_changes_in_place.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   computeCacheKey,
@@ -21,7 +23,7 @@ import {
  */
 export const test_computecachekey_changes_when_goroot_source_changes_in_place =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
     const plugin = path.join(root, "plugin");
     fs.mkdirSync(plugin, { recursive: true });
     fs.writeFileSync(

--- a/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_overlay_source_changes.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_computecachekey_changes_when_overlay_source_changes.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   computeCacheKey,
@@ -18,7 +20,7 @@ import {
  * 3. Assert the returned files, diagnostics, cache key, or descriptor contract.
  */
 export const test_computecachekey_changes_when_overlay_source_changes = () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+  const root = TestProject.tmpdir("ttsc-source-plugin-");
   const plugin = path.join(root, "plugin");
   const overlay = path.join(root, "overlay");
   fs.mkdirSync(plugin, { recursive: true });

--- a/tests/test-ttsc/src/features/source-plugin/test_computecachekey_ignores_go_compiler_install_path_when_content_matches.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_computecachekey_ignores_go_compiler_install_path_when_content_matches.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   computeCacheKey,
@@ -22,7 +24,7 @@ import {
  */
 export const test_computecachekey_ignores_go_compiler_install_path_when_content_matches =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
     const plugin = path.join(root, "plugin");
     fs.mkdirSync(plugin, { recursive: true });
     fs.writeFileSync(

--- a/tests/test-ttsc/src/features/source-plugin/test_computecachekey_ignores_goroot_install_path_when_content_matches.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_computecachekey_ignores_goroot_install_path_when_content_matches.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   computeCacheKey,
@@ -20,7 +22,7 @@ import {
  */
 export const test_computecachekey_ignores_goroot_install_path_when_content_matches =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
     const plugin = path.join(root, "plugin");
     fs.mkdirSync(plugin, { recursive: true });
     fs.writeFileSync(

--- a/tests/test-ttsc/src/features/source-plugin/test_computecachekey_includes_linked_contributor_sources_order_stably.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_computecachekey_includes_linked_contributor_sources_order_stably.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   computeCacheKey,
@@ -20,7 +22,7 @@ import {
  */
 export const test_computecachekey_includes_linked_contributor_sources_order_stably =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-cache-"));
+    const root = TestProject.tmpdir("ttsc-source-cache-");
     const host = writeGoPackage(root, "host", "main", "const Host = 1\n");
     const left = writeGoPackage(root, "left", "left", "const Value = 1\n");
     const right = writeGoPackage(root, "right", "right", "const Value = 2\n");
@@ -47,7 +49,11 @@ export const test_computecachekey_includes_linked_contributor_sources_order_stab
     });
     assert.equal(reordered, first);
 
-    fs.writeFileSync(path.join(right, "value.go"), "package right\nconst Value = 3\n", "utf8");
+    fs.writeFileSync(
+      path.join(right, "value.go"),
+      "package right\nconst Value = 3\n",
+      "utf8",
+    );
     const changed = computeCacheKey({
       contributors: [
         { name: "left", source: left },

--- a/tests/test-ttsc/src/features/source-plugin/test_computecachekey_includes_standard_go_source_directories.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_computecachekey_includes_standard_go_source_directories.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   computeCacheKey,
@@ -19,7 +21,7 @@ import {
  */
 export const test_computecachekey_includes_standard_go_source_directories =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-source-plugin-"));
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
     const plugin = path.join(root, "plugin");
     fs.mkdirSync(plugin, { recursive: true });
     fs.writeFileSync(

--- a/tests/test-ttsc/src/features/source-plugin/test_resolveplugincacheroot_prunes_stale_global_cache_entries.ts
+++ b/tests/test-ttsc/src/features/source-plugin/test_resolveplugincacheroot_prunes_stale_global_cache_entries.ts
@@ -1,3 +1,5 @@
+import { TestProject } from "@ttsc/testing";
+
 import {
   assert,
   fs,
@@ -21,7 +23,7 @@ import {
  */
 export const test_resolveplugincacheroot_prunes_stale_global_cache_entries =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-cache-gc-"));
+    const root = TestProject.tmpdir("ttsc-cache-gc-");
     const previousCacheHome = process.env.XDG_CACHE_HOME;
     process.env.XDG_CACHE_HOME = path.join(root, "cache-home");
     try {

--- a/tests/test-ttsc/src/features/tsgo/test_resolvetsgo_accepts_ttsc_tsgo_binary_as_an_explicit_compiler.ts
+++ b/tests/test-ttsc/src/features/tsgo/test_resolvetsgo_accepts_ttsc_tsgo_binary_as_an_explicit_compiler.ts
@@ -1,6 +1,6 @@
+import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { resolveTsgo } from "../../../../../packages/ttsc/lib/compiler/internal/resolveTsgo.js";
@@ -18,7 +18,7 @@ import { resolveTsgo } from "../../../../../packages/ttsc/lib/compiler/internal/
  */
 export const test_resolvetsgo_accepts_ttsc_tsgo_binary_as_an_explicit_compiler =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-tsgo-test-"));
+    const root = TestProject.tmpdir("ttsc-tsgo-test-");
     const binary = path.join(root, "tsgo");
     fs.writeFileSync(binary, "", "utf8");
 

--- a/tests/test-ttsc/src/features/tsgo/test_resolvetsgo_resolves_the_consumer_native_preview_platform_package.ts
+++ b/tests/test-ttsc/src/features/tsgo/test_resolvetsgo_resolves_the_consumer_native_preview_platform_package.ts
@@ -1,6 +1,6 @@
+import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { resolveTsgo } from "../../../../../packages/ttsc/lib/compiler/internal/resolveTsgo.js";
@@ -18,7 +18,7 @@ import { resolveTsgo } from "../../../../../packages/ttsc/lib/compiler/internal/
  */
 export const test_resolvetsgo_resolves_the_consumer_native_preview_platform_package =
   () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-tsgo-test-"));
+    const root = TestProject.tmpdir("ttsc-tsgo-test-");
     const nativeRoot = path.join(
       root,
       "node_modules",

--- a/tests/test-ttsc/src/features/ttscserver/test_ttscserver_exits_on_stdin_close.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_ttscserver_exits_on_stdin_close.ts
@@ -8,8 +8,8 @@ import { TtscserverClient, assert } from "../../internal/ttscserver";
  *
  * Editors crash or get killed; the LSP host must not deadlock waiting for
  * shutdown notifications that will never arrive. This pins the
- * internal/lspserver proxy fallback that closes the upstream pipe on editor EOF,
- * which in turn lets the upstream tsgo process drain.
+ * internal/lspserver proxy fallback that closes the upstream pipe on editor
+ * EOF, which in turn lets the upstream tsgo process drain.
  *
  * 1. Spawn ttscserver.
  * 2. Close stdin immediately (no initialize, no shutdown).

--- a/tests/test-ttsc/src/features/ttscserver/test_ttscserver_launcher_respects_inline_tsgo_flag.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_ttscserver_launcher_respects_inline_tsgo_flag.ts
@@ -1,3 +1,4 @@
+import { TestProject } from "@ttsc/testing";
 import child_process from "node:child_process";
 import fs from "node:fs";
 import * as os from "node:os";
@@ -21,7 +22,7 @@ import { assert, ttscPackageRoot } from "../../internal/ttscserver";
 export const test_ttscserver_launcher_respects_inline_tsgo_flag = () => {
   const root = ttscPackageRoot();
   const launcher = path.join(root, "lib", "launcher", "ttscserver.js");
-  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "ttscserver-inline-tsgo-"));
+  const cwd = TestProject.tmpdir("ttscserver-inline-tsgo-");
   const record = path.join(cwd, "record.json");
   const fakeTsgo = path.join(cwd, "tsgo");
   fs.writeFileSync(fakeTsgo, "", "utf8");

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_cwd_becomes_the_child_process_cwd.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_cwd_becomes_the_child_process_cwd.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 /**
@@ -16,7 +15,7 @@ import path from "node:path";
  * 3. Assert the observable output, diagnostics, or plugin descriptor shape.
  */
 export const test_ttsx_cwd_becomes_the_child_process_cwd = () => {
-  const parent = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-smoke-parent-"));
+  const parent = TestProject.tmpdir("ttsc-smoke-parent-");
   const root = path.join(parent, "app");
   fs.mkdirSync(root, { recursive: true });
   for (const [name, contents] of Object.entries({

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_relative_cache_dir_resolves_from_cwd_option.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_relative_cache_dir_resolves_from_cwd_option.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 /**
@@ -29,7 +28,7 @@ export const test_ttsx_relative_cache_dir_resolves_from_cwd_option = () => {
     }),
     "src/main.ts": `const message: string = "relative-runner-cache";\nconsole.log(message);\n`,
   });
-  const driverCwd = fs.mkdtempSync(path.join(os.tmpdir(), "ttsx-driver-"));
+  const driverCwd = TestProject.tmpdir("ttsx-driver-");
   const cacheDir = ".ttsx-cache";
 
   const result = TestProject.spawn(

--- a/tests/test-ttsc/src/features/utility-plugins/test_ttsc_transform_plugins_fake_names_do_not_bypass_shared_host_error.ts
+++ b/tests/test-ttsc/src/features/utility-plugins/test_ttsc_transform_plugins_fake_names_do_not_bypass_shared_host_error.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestUtilityPlugins } from "../../internal/TestUtilityPlugins";
@@ -57,9 +56,7 @@ export const test_ttsc_transform_plugins_fake_names_do_not_bypass_shared_host_er
         cwd: root,
         env: {
           PATH: TestUtilityPlugins.goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(
-            path.join(os.tmpdir(), "ttsc-utility-fake-"),
-          ),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-utility-fake-"),
         },
       },
     );

--- a/tests/test-ttsc/src/features/utility-plugins/test_ttsc_utility_plugins_lint_banner_paths_and_strip_run_together_in_ttsc_build.ts
+++ b/tests/test-ttsc/src/features/utility-plugins/test_ttsc_utility_plugins_lint_banner_paths_and_strip_run_together_in_ttsc_build.ts
@@ -1,14 +1,13 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestUtilityPlugins } from "../../internal/TestUtilityPlugins";
 
 /**
- * Verifies ttsc utility plugins: lint, banner, paths, and strip run
- * together in ttsc build.
+ * Verifies ttsc utility plugins: lint, banner, paths, and strip run together in
+ * ttsc build.
  *
  * This scenario stays in the compiler package because it verifies linked host
  * behavior across package boundaries.
@@ -28,14 +27,15 @@ export const test_ttsc_utility_plugins_lint_banner_paths_and_strip_run_together_
         cwd: root,
         env: {
           PATH: TestUtilityPlugins.goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(
-            path.join(os.tmpdir(), "ttsc-utility-combo-"),
-          ),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-utility-combo-"),
         },
       },
     );
     assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stderr, /building linked plugin host "linked-plugin-host"/);
+    assert.match(
+      result.stderr,
+      /building linked plugin host "linked-plugin-host"/,
+    );
     assert.match(result.stderr, /\+ 3 contributor\(s\):/);
     assert.match(result.stderr, /building source plugin "@ttsc\/lint"/);
 

--- a/tests/test-ttsc/src/features/utility-plugins/test_ttsc_utility_plugins_paths_side_loads_into_driver_host.ts
+++ b/tests/test-ttsc/src/features/utility-plugins/test_ttsc_utility_plugins_paths_side_loads_into_driver_host.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestUtilityPlugins } from "../../internal/TestUtilityPlugins";
@@ -11,8 +10,8 @@ import { TestUtilityPlugins } from "../../internal/TestUtilityPlugins";
  *
  * Locks the mixed-host regression where one linked transform and one executable
  * transform resolved to separate native binaries. The linked source must not
- * become the compiler owner; it is applied inside the selected driver.LoadProgram
- * host.
+ * become the compiler owner; it is applied inside the selected
+ * driver.LoadProgram host.
  *
  * 1. Put `@ttsc/paths` before a custom driver-based transform plugin.
  * 2. Run ttsc so host selection cannot depend on descriptor order.
@@ -186,9 +185,7 @@ export const test_ttsc_utility_plugins_paths_side_loads_into_driver_host =
         cwd: root,
         env: {
           PATH: TestUtilityPlugins.goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(
-            path.join(os.tmpdir(), "ttsc-utility-driver-host-"),
-          ),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-utility-driver-host-"),
         },
       },
     );

--- a/tests/test-ttsc/src/features/utility-plugins/test_ttsc_utility_plugins_shared_transform_host_works_when_paths_is_first.ts
+++ b/tests/test-ttsc/src/features/utility-plugins/test_ttsc_utility_plugins_shared_transform_host_works_when_paths_is_first.ts
@@ -1,7 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { TestUtilityPlugins } from "../../internal/TestUtilityPlugins";
@@ -60,14 +59,15 @@ export const test_ttsc_utility_plugins_shared_transform_host_works_when_paths_is
         cwd: root,
         env: {
           PATH: TestUtilityPlugins.goPath(),
-          TTSC_CACHE_DIR: fs.mkdtempSync(
-            path.join(os.tmpdir(), "ttsc-utility-paths-first-"),
-          ),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-utility-paths-first-"),
         },
       },
     );
     assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stderr, /building linked plugin host "linked-plugin-host"/);
+    assert.match(
+      result.stderr,
+      /building linked plugin host "linked-plugin-host"/,
+    );
     assert.match(result.stderr, /\+ 3 contributor\(s\):/);
     const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
     const dts = fs.readFileSync(path.join(root, "dist", "main.d.ts"), "utf8");

--- a/tests/test-ttsc/src/internal/compiler.ts
+++ b/tests/test-ttsc/src/internal/compiler.ts
@@ -10,14 +10,9 @@ import {
   type ITtscCompilerContext,
 } from "../../../../packages/ttsc/lib/index.js";
 
-const SHARED_COMPILER_CACHE_DIR = fs.mkdtempSync(
-  path.join(os.tmpdir(), "ttsc-compiler-api-cache-"),
+const SHARED_COMPILER_CACHE_DIR = TestProject.tmpdir(
+  "ttsc-compiler-api-cache-",
 );
-process.on("exit", () => {
-  try {
-    fs.rmSync(SHARED_COMPILER_CACHE_DIR, { recursive: true, force: true });
-  } catch {}
-});
 
 class TtscCompiler extends BaseTtscCompiler {
   public constructor(context: ITtscCompilerContext = {}) {
@@ -52,7 +47,7 @@ interface ICompilerApiProjectOptions {
 }
 
 function createProject(options: ICompilerApiProjectOptions = {}) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-compiler-api-"));
+  const root = TestProject.tmpdir("ttsc-compiler-api-");
   writeBasicProject(
     root,
     options.source ??
@@ -107,7 +102,7 @@ function writeBasicProject(
 }
 
 function createDottedSourceProject() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-compiler-api-"));
+  const root = TestProject.tmpdir("ttsc-compiler-api-");
   fs.mkdirSync(path.join(root, "..src"), { recursive: true });
   fs.writeFileSync(
     path.join(root, "..src", "main.ts"),

--- a/tests/test-ttsc/src/internal/toolchain.ts
+++ b/tests/test-ttsc/src/internal/toolchain.ts
@@ -1,3 +1,4 @@
+import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import child_process from "node:child_process";
 import fs from "node:fs";
@@ -40,7 +41,7 @@ const nativeBinary = path.join(
 const tsgoBinary = resolveTsgoBinary();
 
 function createProject(files: Record<string, string>) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-smoke-"));
+  const root = TestProject.tmpdir("ttsc-smoke-");
   for (const [name, contents] of Object.entries(files) as [string, string][]) {
     const file = path.join(root, name);
     fs.mkdirSync(path.dirname(file), { recursive: true });

--- a/tests/utils/src/TestProject.ts
+++ b/tests/utils/src/TestProject.ts
@@ -4,6 +4,29 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 
+// Every temp dir handed out by this module is tracked here and removed on
+// process exit. Without this, each test case leaks one or more directories
+// under /tmp — across the full suite that runs into thousands of stale dirs
+// (the symptom that surfaced as Go-build ENOSPC when /tmp is a small tmpfs).
+const TRACKED_TEMP_DIRS = new Set<string>();
+let cleanupHookRegistered = false;
+
+function ensureCleanupHook(): void {
+  if (cleanupHookRegistered) return;
+  cleanupHookRegistered = true;
+  process.on("exit", () => {
+    for (const dir of TRACKED_TEMP_DIRS) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // Best-effort: a test that already removed its own dir is fine,
+        // and we don't want cleanup failures to mask the real exit code.
+      }
+    }
+    TRACKED_TEMP_DIRS.clear();
+  });
+}
+
 /**
  * Filesystem and process helpers for tests that must exercise the real
  * workspace toolchain instead of a mocked compiler API.
@@ -55,13 +78,27 @@ export namespace TestProject {
   export const TSGO_BINARY = resolveTsgoBinary();
 
   /**
+   * Create a tracked temp directory under the OS temp root.
+   *
+   * The returned path is removed on process exit so the suite doesn't pile up
+   * stale directories under `/tmp` (each test typically needs a project root
+   * plus a plugin cache dir, and there are hundreds of cases).
+   */
+  export function tmpdir(prefix: string): string {
+    ensureCleanupHook();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    TRACKED_TEMP_DIRS.add(dir);
+    return dir;
+  }
+
+  /**
    * Create an isolated project from an in-memory file map.
    *
-   * Callers own cleanup because many assertions inspect output files after the
-   * command under test exits.
+   * The project directory survives until the test process exits so assertions
+   * can still inspect output files after the command under test returns.
    */
   export function createProject(files: Record<string, string>) {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-smoke-"));
+    const root = tmpdir("ttsc-smoke-");
     writeFiles(root, files);
     return root;
   }
@@ -74,7 +111,7 @@ export namespace TestProject {
    */
   export function copyProject(name: string) {
     const source = path.join(PROJECTS_ROOT, name);
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), `ttsc-${name}-`));
+    const root = tmpdir(`ttsc-${name}-`);
     copyDirectory(source, root);
     return root;
   }

--- a/tests/utils/src/lint/TestLint.ts
+++ b/tests/utils/src/lint/TestLint.ts
@@ -27,7 +27,6 @@ import { TestProject } from "../TestProject";
 // doesn't match the banner regex is preserved as `result.stderr` so
 // failure messages can include the raw output.
 
-const LINT_SOURCE_DIR = path.join(TestProject.TEST_PACKAGE_ROOT, "src", "lint");
 const TESTING_PACKAGE_ROOT = TestProject.TEST_PACKAGE_ROOT;
 const TTSC_BIN = path.join(
   TestProject.WORKSPACE_ROOT,
@@ -72,15 +71,9 @@ const TSGO_BINARY = (function resolveTsgoBinary() {
 })();
 
 // Plugin builds (Go) take ~1-2s the first time; share the cache dir
-// across the whole test run so subsequent cases reuse the binary.
-const SHARED_CACHE_DIR = fs.mkdtempSync(
-  path.join(os.tmpdir(), "ttsc-lint-e2e-cache-"),
-);
-process.on("exit", () => {
-  try {
-    fs.rmSync(SHARED_CACHE_DIR, { recursive: true, force: true });
-  } catch {}
-});
+// across the whole test run so subsequent cases reuse the binary. The
+// shared TestProject cleanup hook removes it on process exit.
+const SHARED_CACHE_DIR = TestProject.tmpdir("ttsc-lint-e2e-cache-");
 
 export namespace TestLint {
   /** Normalized severities produced by the native lint plugin. */
@@ -152,8 +145,8 @@ export namespace TestLint {
   export function createProject(options: IRunLintOptions): IRunLintProject {
     const { name, source, rules, pluginConfig, extraSources, linkNodeModules } =
       options;
-    const tmpdir = fs.mkdtempSync(
-      path.join(os.tmpdir(), `ttsc-lint-case-${sanitizeForFsName(name)}-`),
+    const tmpdir = TestProject.tmpdir(
+      `ttsc-lint-case-${sanitizeForFsName(name)}-`,
     );
     try {
       writeFixtureProject(

--- a/tests/utils/src/unplugin/TestUnpluginProject.ts
+++ b/tests/utils/src/unplugin/TestUnpluginProject.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import { createRequire } from "node:module";
-import os from "node:os";
 import path from "node:path";
 
 import { TestProject } from "../TestProject";
@@ -42,7 +41,7 @@ export namespace TestUnpluginProject {
    */
   export function createProject(options: ICreateProjectOptions = {}) {
     ensureSharedCacheDir();
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-unplugin-"));
+    const root = TestProject.tmpdir("ttsc-unplugin-");
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     fs.writeFileSync(
       mainFile(root),
@@ -86,15 +85,8 @@ export namespace TestUnpluginProject {
     if (process.env.TTSC_CACHE_DIR !== undefined) {
       return;
     }
-    sharedCacheDir ??= fs.mkdtempSync(
-      path.join(os.tmpdir(), "ttsc-unplugin-cache-"),
-    );
+    sharedCacheDir ??= TestProject.tmpdir("ttsc-unplugin-cache-");
     process.env.TTSC_CACHE_DIR = sharedCacheDir;
-    process.once("exit", () => {
-      try {
-        fs.rmSync(sharedCacheDir!, { recursive: true, force: true });
-      } catch {}
-    });
   }
 
   /** Absolute path to the generated TypeScript entrypoint. */


### PR DESCRIPTION
## Summary
- Test cases mkdtemp'd at least one directory under `/tmp` (project root + plugin cache dir) and never removed them. Across the full suite that's thousands of stale dirs per run.
- On a tmpfs-backed `/tmp` the leak eventually exhausts the volume — observed downstream as `go build: no space left on device` when an unrelated consumer (`@samchon/shopping-backend`) tried `pnpm prepare` against typia's source plugin. The user's `/tmp` was a 15 GB tmpfs holding 2 121 stale `ttsc-*` / `go-build*` dirs at 95% use.

## Fix
- Add `TestProject.tmpdir(prefix)` that mkdtemps under the OS temp root and registers the path in a single `process.on("exit")` cleanup hook.
- Migrate every direct `fs.mkdtempSync` caller in test utilities (`TestProject`, `TestLint`, `TestUnpluginProject`, `test-ttsc/internal/{compiler,toolchain}.ts`) and feature suites (banner / strip / paths / lint / ttsc / ttsx-runtime / source-plugin / plugin / project / api / ttscserver / utility-plugins) to use it.
- Drop the now-redundant per-helper exit hooks in `TestLint` and `TestUnpluginProject`.
- Production ttsc code already wraps every mkdtemp in `try/finally` and is untouched.

## Test plan
- [x] `pnpm test:typecheck`
- [x] `pnpm --filter ./tests/test-banner start`
- [x] `pnpm --filter ./tests/test-strip start`
- [x] `pnpm --filter ./tests/test-paths start`
- [x] `pnpm --filter ./tests/test-unplugin start`
- [x] `pnpm --filter ./tests/test-lint start`
- [x] `pnpm --filter ./tests/test-ttsc start` (largest suite; 0 stale `/tmp/ttsc-*` after exit)
- [x] `cd ../shopping-backend && pnpm prepare` succeeds against the freshly built workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)