### PR TITLE
fix(wasm): emit CJS so Node can require @ttsc/wasm

### DIFF
--- a/packages/wasm/tsconfig.json
+++ b/packages/wasm/tsconfig.json
@@ -2,8 +2,8 @@
   "extends": "../../config/tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2022", "DOM", "WebWorker"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "outDir": "lib",
     "rootDir": "."
   },


### PR DESCRIPTION
## Summary

- Switch `packages/wasm/tsconfig.json` from `module: ESNext` + `moduleResolution: bundler` to `module: NodeNext` + `moduleResolution: nodenext`.
- The package has no `"type": "module"`, so under NodeNext tsgo emits CJS for each `.js`. Source imports stay extensionless; `require('@ttsc/wasm')` and `import` from ESM both resolve cleanly.

## Why

`release.yml`'s `wasm-smoke` job has been failing every release with:

\`\`\`
ERR_MODULE_NOT_FOUND
Cannot find module '/tmp/ttsc-wasm-smoke/node_modules/@ttsc/wasm/lib/src/instantiate'
imported from /tmp/ttsc-wasm-smoke/node_modules/@ttsc/wasm/lib/src/index.js
\`\`\`

Root cause: the published `lib/src/index.js` contained raw ESM (`export { bootTtsc } from "./instantiate";`) with no `"type": "module"` in package.json. Node 22+ auto-detects ESM from syntax, then the strict ESM resolver rejects extensionless relative imports.

## Test plan

- [x] `pnpm --filter @ttsc/wasm build:ts` — verified `lib/src/*.js` now contains `exports.bootTtsc = ...` (CJS).
- [x] Locally reproduced the release smoke: `pnpm pack` → `npm install ./ttsc-wasm-*.tgz` → `node -e "require('@ttsc/wasm')"` exits 0 and exposes `bootTtsc`/`createMemFS`/`MemFSError`/`parseResult`.
- [x] ESM consumer check: `node --input-type=module -e "import {...} from '@ttsc/wasm'"` resolves all named exports.

## Follow-up (not in this PR)

`wasm-smoke` only runs on tag push (after publish), so this kind of consumer-resolution defect can't be caught on PRs today. Worth adding an `npm install <local-tarball>` + `require()` step to the `wasm-build` job in `build.yml` so PRs catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)