### PR TITLE
test(ttsc): lock composed plugin inheriting aggregate contributors

### DIFF
--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_composes_inherits_aggregate_contributors.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_composes_inherits_aggregate_contributors.ts
@@ -1,0 +1,75 @@
+import {
+  assert,
+  copyDirectory,
+  fs,
+  goPath,
+  path,
+  pluginProject,
+  spawn,
+  ttscBin,
+  workspaceRoot,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: a composed plugin inherits the aggregate's
+ * `contributors`.
+ *
+ * Regression lock for `loadProjectPlugins.ts::composePluginSources` (issue
+ * #101). A composed plugin is rerouted to the aggregate's `source`; it must
+ * ALSO inherit the aggregate's `contributors`, because `buildSourcePlugin` keys
+ * its native-binary cache on `source` + `contributors`. Without the inheritance
+ * the aggregate record (with contributors) and the composed record (without)
+ * resolve to two divergent binaries, and ttsc aborts with "multiple compiler
+ * native backends cannot share one emit pass". The separate guard that rejects
+ * a composed plugin declaring its OWN `contributors` is unaffected — "inherits
+ * the aggregate's" and "may not declare its own" are not in conflict.
+ *
+ * 1. Materialize an aggregate plugin that both `composes` a target transform and
+ *    declares a `contributors` entry, plus the redirected target whose own
+ *    `source` points at a missing directory.
+ * 2. Run `ttsc --emit`.
+ * 3. Assert a zero exit (the composed and aggregate records share one native host)
+ *    and that the target's suffix transform still reached the emitted
+ *    JavaScript.
+ */
+export const test_plugin_corpus_composes_inherits_aggregate_contributors =
+  () => {
+    const root = pluginProject(
+      [
+        { transform: "./plugins/aggregate.cjs" },
+        { transform: "./plugins/target.cjs", suffix: ":Z" },
+      ],
+      {
+        "plugins/aggregate.cjs": `module.exports = {
+  name: "compose-aggregate",
+  source: require("node:path").resolve(__dirname, "..", "go-plugin", "cmd", "ttsc-go-transformer"),
+  composes: ["compose-target"],
+  contributors: [
+    {
+      name: "demo",
+      source: require("node:path").resolve(__dirname, "contributor"),
+    },
+  ],
+};\n`,
+        "plugins/target.cjs": `module.exports = {
+  name: "compose-target",
+  source: require("node:path").resolve(__dirname, "missing-go-target"),
+};\n`,
+        "plugins/contributor/contributor.go": "package demo\n",
+      },
+    );
+    copyDirectory(
+      path.join(workspaceRoot, "tests", "go-transformer"),
+      path.join(root, "go-plugin"),
+    );
+
+    const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+      cwd: root,
+      env: { PATH: goPath() },
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(
+      fs.readFileSync(path.join(root, "dist", "main.js"), "utf8"),
+      /"PLUGIN:Z"/,
+    );
+  };


### PR DESCRIPTION
## Intent

Regression lock for `loadProjectPlugins.ts::composePluginSources`. The `contributors: aggregate.plugin.contributors` inheritance (added in #100) has no test pinning it; this PR adds one.

A composed plugin is rerouted to the aggregate's `source`. It must **also** inherit the aggregate's `contributors`, because `buildSourcePlugin` keys its native-binary cache on `source` + `contributors`. Without the inheritance, the aggregate record (with contributors) and the composed record (without) resolve to two divergent binaries, and ttsc aborts with `multiple compiler native backends cannot share one emit pass`.

## Scope

- One new e2e test, `test_plugin_corpus_composes_inherits_aggregate_contributors.ts`.
- No source, fixture, or wiring changes — `loadProjectPlugins.ts` is untouched.

## Test plan

- `--include=composes_inherits_aggregate_contributors` — passes with the fix in place.
- Verified it is a genuine lock, not a no-op: temporarily removed the `contributors: aggregate.plugin.contributors` line, recompiled `packages/ttsc/lib`, and the test failed with exactly the predicted error (`multiple compiler native backends cannot share one emit pass`, exit 2). Restored and rebuilt afterward.
- Full `composes` group (4 tests) passes.

## Deferred

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)