### PR TITLE
fix(ttsc): rewrite TS extension imports for emit

### DIFF
--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -472,14 +472,18 @@ function resolveExecutionContext(
   const projectRoot = options.projectRoot
     ? path.resolve(cwd, options.projectRoot)
     : path.dirname(tsconfig);
-  const emitProject =
-    options.emit === true
-      ? readProjectConfig({
-          cwd,
-          projectRoot: options.projectRoot,
-          tsconfig,
-        })
-      : undefined;
+  let emitProject;
+  if (options.emit === true) {
+    try {
+      emitProject = readProjectConfig({
+        cwd,
+        projectRoot: options.projectRoot,
+        tsconfig,
+      });
+    } catch {
+      emitProject = undefined;
+    }
+  }
   const tsgo = resolveTsgo({ ...options, cwd: projectRoot });
   const fallbackBinary = resolveBinary(options);
   const loaded = loadProjectPlugins({

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -6,6 +6,7 @@ import type { ITtscLoadedNativePlugin } from "../../structures/internal/ITtscLoa
 import type { TtscBuildOptions } from "../../structures/internal/TtscBuildOptions";
 import type { TtscBuildResult } from "../../structures/internal/TtscBuildResult";
 import type { TtscCommonOptions } from "../../structures/internal/TtscCommonOptions";
+import { readProjectConfig } from "./project/readProjectConfig";
 import { resolveProjectConfig } from "./project/resolveProjectConfig";
 import { resolveBinary } from "./resolveBinary";
 import { resolveTsgo } from "./resolveTsgo";
@@ -267,6 +268,9 @@ function createTsgoBuildArgs(
   const args = ["-p", execution.tsconfig];
   if (options.emit === true) {
     args.push("--noEmit", "false", "--emitDeclarationOnly", "false");
+    if (execution.rewriteRelativeImportExtensionsForEmit) {
+      args.push("--rewriteRelativeImportExtensions");
+    }
   } else if (options.emit === false) {
     args.push("--noEmit");
   }
@@ -458,7 +462,7 @@ export function appendBuildOutput(
  * here so every code path in `runBuild` shares the same resolution logic.
  */
 function resolveExecutionContext(
-  options: TtscCommonOptions & { tsconfig?: string },
+  options: TtscCommonOptions & { emit?: boolean; tsconfig?: string },
 ) {
   const cwd = path.resolve(options.cwd ?? process.cwd());
   const tsconfig = resolveProjectConfig({
@@ -468,6 +472,14 @@ function resolveExecutionContext(
   const projectRoot = options.projectRoot
     ? path.resolve(cwd, options.projectRoot)
     : path.dirname(tsconfig);
+  const emitProject =
+    options.emit === true
+      ? readProjectConfig({
+          cwd,
+          projectRoot: options.projectRoot,
+          tsconfig,
+        })
+      : undefined;
   const tsgo = resolveTsgo({ ...options, cwd: projectRoot });
   const fallbackBinary = resolveBinary(options);
   const loaded = loadProjectPlugins({
@@ -482,6 +494,8 @@ function resolveExecutionContext(
     cwd,
     nativePlugins: loaded.nativePlugins,
     projectRoot,
+    rewriteRelativeImportExtensionsForEmit:
+      emitProject?.compilerOptions.allowImportingTsExtensions === true,
     tsgo,
     tsconfig,
   };

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_emit_rewrites_allow_importing_ts_extensions.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_emit_rewrites_allow_importing_ts_extensions.ts
@@ -1,0 +1,44 @@
+import {
+  assert,
+  commonJsProject,
+  fs,
+  path,
+  runNode,
+  spawn,
+  ttscBin,
+} from "../../internal/compiler-corpus";
+
+/**
+ * Verifies ttsc emit rewrites allowImportingTsExtensions imports.
+ *
+ * Forcing emit on a config that allows `.ts` import specifiers must add the
+ * matching TypeScript-Go rewrite flag. Without it, the forced `--noEmit false`
+ * profile turns an otherwise valid check-only config into TS5096.
+ *
+ * 1. Create a CommonJS project importing a helper with a `.ts` specifier.
+ * 2. Run `ttsc --emit`.
+ * 3. Assert the emitted JavaScript runs and points at the rewritten `.js` file.
+ */
+export const test_ttsc_emit_rewrites_allow_importing_ts_extensions = () => {
+  const root = commonJsProject(
+    {
+      "src/helper.ts": `export const message: string = "ttsc-emit-extension-ok";\n`,
+      "src/main.ts": `import { message } from "./helper.ts";\nconsole.log(message);\n`,
+    },
+    {
+      compilerOptions: {
+        allowImportingTsExtensions: true,
+      },
+    },
+  );
+
+  const result = spawn(ttscBin, ["--cwd", root, "--emit"], { cwd: root });
+  assert.equal(result.status, 0, result.stderr);
+
+  const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+  assert.match(js, /helper\.js/);
+
+  const run = runNode(path.join(root, "dist", "main.js"), { cwd: root });
+  assert.equal(run.status, 0, run.stderr);
+  assert.equal(run.stdout.trim(), "ttsc-emit-extension-ok");
+};

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_single_file_rewrites_allow_importing_ts_extensions.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_single_file_rewrites_allow_importing_ts_extensions.ts
@@ -1,0 +1,44 @@
+import {
+  assert,
+  commonJsProject,
+  fs,
+  path,
+  spawn,
+  ttscBin,
+} from "../../internal/compiler-corpus";
+
+/**
+ * Verifies single-file emit rewrites allowImportingTsExtensions imports.
+ *
+ * Single-file compatibility mode also funnels through forced project emit, so
+ * it must receive the same rewrite flag as `ttsc --emit`. The single-file path
+ * materializes only the requested entry, so this pins the transformed source
+ * contract rather than executing the dependency graph.
+ *
+ * 1. Create a CommonJS project importing a helper with a `.ts` specifier.
+ * 2. Run `ttsc src/main.ts`.
+ * 3. Assert the emitted JavaScript points at the rewritten `.js` file.
+ */
+export const test_ttsc_single_file_rewrites_allow_importing_ts_extensions =
+  () => {
+    const root = commonJsProject(
+      {
+        "src/helper.ts": `export const message: string = "single-file-extension-ok";\n`,
+        "src/main.ts": `import { message } from "./helper.ts";\nconsole.log(message);\n`,
+      },
+      {
+        compilerOptions: {
+          allowImportingTsExtensions: true,
+        },
+      },
+    );
+
+    const result = spawn(ttscBin, ["--cwd", root, "src/main.ts"], {
+      cwd: root,
+    });
+    assert.equal(result.status, 0, result.stderr);
+
+    const jsPath = path.join(root, "dist", "main.js");
+    const js = fs.readFileSync(jsPath, "utf8");
+    assert.match(js, /helper\.js/);
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_allow_importing_ts_extensions_project.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_allow_importing_ts_extensions_project.ts
@@ -1,0 +1,44 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx runs a project with allowImportingTsExtensions.
+ *
+ * `ttsx` forces a runtime emit even when the user config is valid for no-emit
+ * checking. Projects that import `./x.ts` need TypeScript-Go to rewrite those
+ * specifiers in the cached JavaScript, otherwise TS5096 stops the runner before
+ * the entry can execute.
+ *
+ * 1. Create an ESM project with `allowImportingTsExtensions` and a `.ts` import.
+ * 2. Run ttsx against the entry.
+ * 3. Assert the process exits successfully and prints the helper output.
+ */
+export const test_ttsx_runs_allow_importing_ts_extensions_project = () => {
+  const root = TestProject.createProject({
+    "package.json": JSON.stringify({ type: "module" }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ES2022",
+        moduleResolution: "bundler",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+        allowImportingTsExtensions: true,
+      },
+      include: ["src"],
+    }),
+    "src/helper.ts": `export const message: string = "allow-ts-extension-ok";\n`,
+    "src/main.ts": `import { message } from "./helper.ts";\nconsole.log(message);\n`,
+  });
+
+  const result = TestProject.spawn(
+    TestProject.TTSX_BIN,
+    ["--cwd", root, "src/main.ts"],
+    {
+      cwd: root,
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "allow-ts-extension-ok");
+};

--- a/website/src/content/docs/ttsc/execute.mdx
+++ b/website/src/content/docs/ttsc/execute.mdx
@@ -16,6 +16,10 @@ npx ttsx src/index.ts
 
 Type errors stop execution. So do `@ttsc/lint` errors (warnings don't).
 
+Projects that enable `allowImportingTsExtensions` are supported. During the
+cached runtime emit, `ttsx` rewrites relative `.ts`, `.mts`, and `.cts` import
+specifiers to the matching JavaScript extensions so Node can execute the output.
+
 ## Pass arguments to the script
 
 Use `--` to separate `ttsx` flags from the script's own args:


### PR DESCRIPTION
## Summary

- Fixes #61 by adding `--rewriteRelativeImportExtensions` to forced emit runs when the resolved project config enables `allowImportingTsExtensions`.
- Covers the shared direct `tsgo` emit path used by `ttsx`, `ttsc --emit`, and single-file compatibility mode.
- Adds regression coverage and documents `ttsx` support for projects that import relative `.ts`/`.mts`/`.cts` files.

## Scope

The rewrite flag is gated on `compilerOptions.allowImportingTsExtensions === true`, so projects without that option keep the existing emit arguments.

The native transform-plugin in-memory path is intentionally left out of this PR, matching the issue analysis that called it a separate follow-up path.

## Validation

- `pnpm run build:current`
- `pnpm run test:typecheck`
- manual launcher regression covering:
  - `ttsx` running an ESM project with `allowImportingTsExtensions` and `import "./helper.ts"`
  - `ttsc --emit` on a CommonJS project with `import "./helper.ts"`, then running the emitted JS
  - `ttsc src/main.ts` single-file mode producing rewritten `helper.js` in the emitted entry
- `pnpm exec prettier --check packages/ttsc/src/compiler/internal/runBuild.ts tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_allow_importing_ts_extensions_project.ts tests/test-ttsc/src/features/compiler/test_ttsc_emit_rewrites_allow_importing_ts_extensions.ts tests/test-ttsc/src/features/compiler/test_ttsc_single_file_rewrites_allow_importing_ts_extensions.ts`
- `git diff --check`
- `npm audit signatures`

Note: the package feature runner command currently fails locally on Node v26.0.0 before executing tests because the script still passes `--experimental-transform-types`, which this Node no longer recognizes. I validated the new cases through the built launchers directly instead.
