### PR TITLE
feat(test): add nestia compatibility workflow

### DIFF
--- a/.github/workflows/nestia.yml
+++ b/.github/workflows/nestia.yml
@@ -1,0 +1,74 @@
+name: nestia
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/nestia.yml"
+      - "experimental/**"
+      - "scripts/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+  workflow_dispatch:
+
+jobs:
+  Ubuntu:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      # Only build + pack the current platform (ttsc-linux-x64) — nestia's
+      # overrides below pull in ttsc.tgz + ttsc-linux-x64.tgz only. The full
+      # cross-platform matrix takes ~20 min for tarballs we never consume.
+      TTSC_TARBALLS_CURRENT: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/ttsc/go.mod
+          cache-dependency-path: |
+            packages/ttsc/go.sum
+            tests/go-transformer/go.mod
+
+      - name: Install ttsc dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build ttsc tarballs (current platform only)
+        run: pnpm package:tgz
+
+      - name: Clone nestia next
+        run: |
+          rm -rf experimental/nestia
+          git clone --depth=1 --branch next https://github.com/samchon/nestia experimental/nestia
+
+      - name: Use local ttsc tarballs
+        working-directory: experimental/nestia
+        run: |
+          cat >> pnpm-workspace.yaml <<'YAML'
+
+          overrides:
+            ttsc: file:../tarballs/ttsc.tgz
+            '@ttsc/linux-x64': file:../tarballs/ttsc-linux-x64.tgz
+          YAML
+
+      - name: Test nestia next
+        working-directory: experimental/nestia
+        env:
+          # nestia's run-with-ttsc-env.cjs resolves the Go toolchain installed
+          # by setup-go above; --no-experimental-detect-module mirrors nestia's
+          # own test.yml so ESM/CJS detection stays off during the e2e run.
+          NODE_OPTIONS: --no-experimental-strip-types --no-experimental-detect-module
+        run: |
+          pnpm install --no-frozen-lockfile
+          pnpm run test

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ go.work.sum
 .references/
 .wiki/
 experimental/typia/
+experimental/nestia/
 
 # Stray native sanity binary from `go build ./cmd/ttsc-wasm` (host build).
 packages/wasm/ttsc-wasm


### PR DESCRIPTION
## Intent

Add a `nestia` PR workflow so ttsc is guarded against regressions in the **nestia** compatibility fixture, the same way `typia.yml` already guards the **typia** fixture.

## Scope

- **`.github/workflows/nestia.yml`** — mirrors `typia.yml`:
  1. Build current-platform ttsc tarballs (`TTSC_TARBALLS_CURRENT=1`, ~3 min).
  2. Clone the nestia `next` branch into `experimental/nestia`.
  3. Override `ttsc` / `@ttsc/linux-x64` in nestia's `pnpm-workspace.yaml` to the local tarballs.
  4. Run nestia's test suite (`pnpm run test`) against them.
- **`.gitignore`** — ignore the `experimental/nestia/` clone checkout, alongside `experimental/typia/`.

## Differences from `typia.yml`

- Clone uses `--branch next` explicitly: nestia's default branch is `master`, unlike typia.
- The test step sets `NODE_OPTIONS` to match nestia's own `test.yml`. nestia's `run-with-ttsc-env.cjs` only auto-appends `--no-experimental-strip-types`, so `--no-experimental-detect-module` is supplied via the step env.

## Test plan

- `nestia` workflow runs on this PR via the `experimental/**` + `.github/workflows/nestia.yml` path filter and exercises the full nestia `next` test suite against the locally-built ttsc.
- YAML syntax validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)