### PR TITLE
perf(ttsc): drop SingleThreaded so TypeScript-Go parses/checks/emits in parallel

### DIFF
--- a/packages/lint/linthost/compile.go
+++ b/packages/lint/linthost/compile.go
@@ -13,6 +13,7 @@ package linthost
 
 import (
   "context"
+  "encoding/json"
   "errors"
   "flag"
   "fmt"
@@ -61,6 +62,7 @@ func RunTransform(args []string) int {
   pluginsJSON := fs.String("plugins-json", "", "ttsc plugin manifest JSON")
   singleThreaded := fs.Bool("singleThreaded", false, "run TypeScript-Go single-threaded")
   checkers := fs.Int("checkers", 0, "type-checker pool size (0 = TypeScript-Go default)")
+  tsgoArgsRaw := fs.String("tsgo-args", "", "JSON array of forwarded tsgo CLI flags")
   if err := fs.Parse(filterKnownFlags(args, map[string]bool{
     "cwd":            true,
     "file":           true,
@@ -69,11 +71,17 @@ func RunTransform(args []string) int {
     "tsconfig":       true,
     "singleThreaded": false,
     "checkers":       true,
+    "tsgo-args":      true,
   })); err != nil {
     return 2
   }
   if *file == "" {
     fmt.Fprintln(os.Stderr, "@ttsc/lint transform: --file is required")
+    return 2
+  }
+  tsgoArgs, err := decodeTsgoArgs(*tsgoArgsRaw)
+  if err != nil {
+    fmt.Fprintln(os.Stderr, err)
     return 2
   }
   resolvedCwd, err := resolveCwd(*cwd)
@@ -85,6 +93,7 @@ func RunTransform(args []string) int {
     forceEmit:      true,
     singleThreaded: *singleThreaded,
     checkers:       *checkers,
+    tsgoArgs:       tsgoArgs,
   })
   if err != nil {
     fmt.Fprintf(os.Stderr, "@ttsc/lint: %v\n", err)
@@ -174,6 +183,7 @@ type subcommandOpts struct {
   outDir         string
   singleThreaded bool
   checkers       int
+  tsgoArgs       []string
 }
 
 // parseSubcommandFlags parses the shared flag set used by the `check`,
@@ -192,6 +202,7 @@ func parseSubcommandFlags(name string, args []string) (*subcommandOpts, error) {
   outDir := fs.String("outDir", "", "")
   singleThreaded := fs.Bool("singleThreaded", false, "")
   checkers := fs.Int("checkers", 0, "")
+  tsgoArgsRaw := fs.String("tsgo-args", "", "")
   if err := fs.Parse(filterKnownFlags(args, map[string]bool{
     "cwd":            true,
     "emit":           false,
@@ -203,11 +214,16 @@ func parseSubcommandFlags(name string, args []string) (*subcommandOpts, error) {
     "verbose":        false,
     "singleThreaded": false,
     "checkers":       true,
+    "tsgo-args":      true,
   })); err != nil {
     return nil, err
   }
   if *emit && *noEmit {
     return nil, errors.New("@ttsc/lint: --emit and --noEmit are mutually exclusive")
+  }
+  tsgoArgs, err := decodeTsgoArgs(*tsgoArgsRaw)
+  if err != nil {
+    return nil, err
   }
   resolvedCwd, err := resolveCwd(*cwd)
   if err != nil {
@@ -224,7 +240,22 @@ func parseSubcommandFlags(name string, args []string) (*subcommandOpts, error) {
     outDir:         *outDir,
     singleThreaded: *singleThreaded,
     checkers:       *checkers,
+    tsgoArgs:       tsgoArgs,
   }, nil
+}
+
+// decodeTsgoArgs decodes the JSON-array value of the `--tsgo-args` flag — the
+// tsgo CLI flags the `ttsc` launcher forwarded — into a string slice. An empty
+// flag yields a nil slice.
+func decodeTsgoArgs(raw string) ([]string, error) {
+  if raw == "" {
+    return nil, nil
+  }
+  var args []string
+  if err := json.Unmarshal([]byte(raw), &args); err != nil {
+    return nil, fmt.Errorf("@ttsc/lint: invalid --tsgo-args: %w", err)
+  }
+  return args, nil
 }
 
 // runProject is the shared body of RunCheck and RunBuild. It loads the
@@ -237,6 +268,7 @@ func runProject(opts *subcommandOpts) int {
     outDir:         opts.outDir,
     singleThreaded: opts.singleThreaded,
     checkers:       opts.checkers,
+    tsgoArgs:       opts.tsgoArgs,
   })
   if err != nil {
     fmt.Fprintf(os.Stderr, "@ttsc/lint: %v\n", err)

--- a/packages/lint/linthost/compile.go
+++ b/packages/lint/linthost/compile.go
@@ -59,12 +59,16 @@ func RunTransform(args []string) int {
   tsconfig := fs.String("tsconfig", "tsconfig.json", "tsconfig owning --file")
   cwd := fs.String("cwd", "", "override the working directory")
   pluginsJSON := fs.String("plugins-json", "", "ttsc plugin manifest JSON")
+  singleThreaded := fs.Bool("singleThreaded", false, "run TypeScript-Go single-threaded")
+  checkers := fs.Int("checkers", 0, "type-checker pool size (0 = TypeScript-Go default)")
   if err := fs.Parse(filterKnownFlags(args, map[string]bool{
-    "cwd":          true,
-    "file":         true,
-    "out":          true,
-    "plugins-json": true,
-    "tsconfig":     true,
+    "cwd":            true,
+    "file":           true,
+    "out":            true,
+    "plugins-json":   true,
+    "tsconfig":       true,
+    "singleThreaded": false,
+    "checkers":       true,
   })); err != nil {
     return 2
   }
@@ -78,7 +82,9 @@ func RunTransform(args []string) int {
     return 2
   }
   prog, parseDiags, err := loadProgram(resolvedCwd, *tsconfig, loadProgramOptions{
-    forceEmit: true,
+    forceEmit:      true,
+    singleThreaded: *singleThreaded,
+    checkers:       *checkers,
   })
   if err != nil {
     fmt.Fprintf(os.Stderr, "@ttsc/lint: %v\n", err)
@@ -158,14 +164,16 @@ func RunTransform(args []string) int {
 }
 
 type subcommandOpts struct {
-  cwd         string
-  tsconfig    string
-  pluginsJSON string
-  emit        bool
-  noEmit      bool
-  quiet       bool
-  verbose     bool
-  outDir      string
+  cwd            string
+  tsconfig       string
+  pluginsJSON    string
+  emit           bool
+  noEmit         bool
+  quiet          bool
+  verbose        bool
+  outDir         string
+  singleThreaded bool
+  checkers       int
 }
 
 // parseSubcommandFlags parses the shared flag set used by the `check`,
@@ -182,15 +190,19 @@ func parseSubcommandFlags(name string, args []string) (*subcommandOpts, error) {
   quiet := fs.Bool("quiet", false, "")
   verbose := fs.Bool("verbose", false, "")
   outDir := fs.String("outDir", "", "")
+  singleThreaded := fs.Bool("singleThreaded", false, "")
+  checkers := fs.Int("checkers", 0, "")
   if err := fs.Parse(filterKnownFlags(args, map[string]bool{
-    "cwd":          true,
-    "emit":         false,
-    "noEmit":       false,
-    "outDir":       true,
-    "plugins-json": true,
-    "quiet":        false,
-    "tsconfig":     true,
-    "verbose":      false,
+    "cwd":            true,
+    "emit":           false,
+    "noEmit":         false,
+    "outDir":         true,
+    "plugins-json":   true,
+    "quiet":          false,
+    "tsconfig":       true,
+    "verbose":        false,
+    "singleThreaded": false,
+    "checkers":       true,
   })); err != nil {
     return nil, err
   }
@@ -202,14 +214,16 @@ func parseSubcommandFlags(name string, args []string) (*subcommandOpts, error) {
     return nil, err
   }
   return &subcommandOpts{
-    cwd:         resolvedCwd,
-    tsconfig:    *tsconfig,
-    pluginsJSON: *pluginsJSON,
-    emit:        *emit,
-    noEmit:      *noEmit,
-    quiet:       *quiet,
-    verbose:     *verbose,
-    outDir:      *outDir,
+    cwd:            resolvedCwd,
+    tsconfig:       *tsconfig,
+    pluginsJSON:    *pluginsJSON,
+    emit:           *emit,
+    noEmit:         *noEmit,
+    quiet:          *quiet,
+    verbose:        *verbose,
+    outDir:         *outDir,
+    singleThreaded: *singleThreaded,
+    checkers:       *checkers,
   }, nil
 }
 
@@ -218,9 +232,11 @@ func parseSubcommandFlags(name string, args []string) (*subcommandOpts, error) {
 // JavaScript output when the config allows it.
 func runProject(opts *subcommandOpts) int {
   prog, parseDiags, err := loadProgram(opts.cwd, opts.tsconfig, loadProgramOptions{
-    forceEmit:   opts.emit,
-    forceNoEmit: opts.noEmit,
-    outDir:      opts.outDir,
+    forceEmit:      opts.emit,
+    forceNoEmit:    opts.noEmit,
+    outDir:         opts.outDir,
+    singleThreaded: opts.singleThreaded,
+    checkers:       opts.checkers,
   })
   if err != nil {
     fmt.Fprintf(os.Stderr, "@ttsc/lint: %v\n", err)

--- a/packages/lint/linthost/fix.go
+++ b/packages/lint/linthost/fix.go
@@ -137,6 +137,7 @@ func loadFixProgram(opts *subcommandOpts) (*program, int) {
     outDir:         opts.outDir,
     singleThreaded: opts.singleThreaded,
     checkers:       opts.checkers,
+    tsgoArgs:       opts.tsgoArgs,
   })
   if err != nil {
     fmt.Fprintf(os.Stderr, "@ttsc/lint: %v\n", err)

--- a/packages/lint/linthost/fix.go
+++ b/packages/lint/linthost/fix.go
@@ -133,8 +133,10 @@ func runFix(opts *subcommandOpts) int {
 // NoEmit forced on. Returns (nil, 2) when loading or config parsing fails.
 func loadFixProgram(opts *subcommandOpts) (*program, int) {
   prog, parseDiags, err := loadProgram(opts.cwd, opts.tsconfig, loadProgramOptions{
-    forceNoEmit: true,
-    outDir:      opts.outDir,
+    forceNoEmit:    true,
+    outDir:         opts.outDir,
+    singleThreaded: opts.singleThreaded,
+    checkers:       opts.checkers,
   })
   if err != nil {
     fmt.Fprintf(os.Stderr, "@ttsc/lint: %v\n", err)

--- a/packages/lint/linthost/host.go
+++ b/packages/lint/linthost/host.go
@@ -39,6 +39,12 @@ type loadProgramOptions struct {
   forceEmit   bool
   forceNoEmit bool
   outDir      string
+  // singleThreaded mirrors `tsgo --singleThreaded`: one checker, serial
+  // parse/check/emit.
+  singleThreaded bool
+  // checkers mirrors `tsgo --checkers`: type-checker pool size. Zero leaves
+  // TypeScript-Go's default; ignored when singleThreaded is set.
+  checkers int
 }
 
 // loadProgram parses the given tsconfig, builds a Program, and acquires a
@@ -88,6 +94,7 @@ func loadProgram(cwd, tsconfigPath string, options loadProgramOptions) (*program
   if options.outDir != "" {
     overrideOutDir(cwd, parsed, options.outDir)
   }
+  applyThreading(parsed, options.singleThreaded, options.checkers)
 
   // SingleThreaded is left unset so the program runs on TypeScript-Go's
   // multi-threaded default: parallel parsing, a pooled checker driving
@@ -188,6 +195,24 @@ func forceNoEmit(parsed *tsoptions.ParsedCommandLine) {
     return
   }
   parsed.ParsedConfig.CompilerOptions.NoEmit = shimcore.TSTrue
+}
+
+// applyThreading forwards the --singleThreaded / --checkers knobs onto the
+// parsed compiler options. ttsc mirrors tsgo here: the values land in
+// CompilerOptions, and both Program.SingleThreaded() and the checker pool read
+// them from there. SingleThreaded wins over Checkers, matching the pool.
+func applyThreading(parsed *tsoptions.ParsedCommandLine, singleThreaded bool, checkers int) {
+  if parsed == nil || parsed.ParsedConfig == nil || parsed.ParsedConfig.CompilerOptions == nil {
+    return
+  }
+  options := parsed.ParsedConfig.CompilerOptions
+  if singleThreaded {
+    options.SingleThreaded = shimcore.TSTrue
+  }
+  if checkers > 0 {
+    n := checkers
+    options.Checkers = &n
+  }
 }
 
 // overrideOutDir replaces the parsed config's OutDir with `outDir`.

--- a/packages/lint/linthost/host.go
+++ b/packages/lint/linthost/host.go
@@ -89,9 +89,14 @@ func loadProgram(cwd, tsconfigPath string, options loadProgramOptions) (*program
     overrideOutDir(cwd, parsed, options.outDir)
   }
 
+  // SingleThreaded is left unset so the program runs on TypeScript-Go's
+  // multi-threaded default: parallel parsing, a pooled checker driving
+  // parallel bind + semantic diagnostics, and parallel emit. The lint engine
+  // still walks files serially against a single pooled checker, which stays
+  // valid against the larger pool — the pool fans out only inside each
+  // TypeScript-Go phase, never across the engine's own traversal.
   tsProgram := shimcompiler.NewProgram(shimcompiler.ProgramOptions{
     Config:                      parsed,
-    SingleThreaded:              shimcore.TSTrue,
     Host:                        host,
     UseSourceOfProjectReference: true,
   })

--- a/packages/lint/linthost/host.go
+++ b/packages/lint/linthost/host.go
@@ -45,6 +45,11 @@ type loadProgramOptions struct {
   // checkers mirrors `tsgo --checkers`: type-checker pool size. Zero leaves
   // TypeScript-Go's default; ignored when singleThreaded is set.
   checkers int
+  // tsgoArgs carries tsgo CLI flags the `ttsc` launcher forwarded (`--strict`,
+  // `--target es2020`, …). They are parsed through TypeScript-Go's own
+  // command-line parser into a CompilerOptions overlay that wins over the
+  // tsconfig, exactly as tsgo's CLI merges them.
+  tsgoArgs []string
 }
 
 // loadProgram parses the given tsconfig, builds a Program, and acquires a
@@ -69,9 +74,14 @@ func loadProgram(cwd, tsconfigPath string, options loadProgramOptions) (*program
   fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
   host := shimcompiler.NewCompilerHost(cwd, fs, bundled.LibPath(), nil, nil)
 
+  cliOptions, cliDiags := parseTsgoArgs(options.tsgoArgs, host)
+  if len(cliDiags) > 0 {
+    return nil, cliDiags, nil
+  }
+
   parsed, parseDiags := tsoptions.GetParsedCommandLineOfConfigFile(
     resolved,
-    &shimcore.CompilerOptions{},
+    cliOptions,
     nil,
     host,
     nil,
@@ -195,6 +205,25 @@ func forceNoEmit(parsed *tsoptions.ParsedCommandLine) {
     return
   }
   parsed.ParsedConfig.CompilerOptions.NoEmit = shimcore.TSTrue
+}
+
+// parseTsgoArgs runs forwarded tsgo CLI flags through TypeScript-Go's own
+// command-line parser, yielding a CompilerOptions overlay loadProgram merges
+// over the tsconfig — so a flag like `ttsc --strict` reaches the in-process
+// lint program even though @ttsc/lint never shells out to `tsgo`. Returns an
+// empty (non-nil) options value when there are no forwarded flags.
+func parseTsgoArgs(args []string, host shimcompiler.CompilerHost) (*shimcore.CompilerOptions, []*shimast.Diagnostic) {
+  if len(args) == 0 {
+    return &shimcore.CompilerOptions{}, nil
+  }
+  cli := tsoptions.ParseCommandLine(args, host)
+  if cli == nil {
+    return &shimcore.CompilerOptions{}, nil
+  }
+  if len(cli.Errors) > 0 {
+    return nil, cli.Errors
+  }
+  return cli.CompilerOptions(), nil
 }
 
 // applyThreading forwards the --singleThreaded / --checkers knobs onto the

--- a/packages/lint/test/command/command_check_applies_forwarded_tsgo_flag_test.go
+++ b/packages/lint/test/command/command_check_applies_forwarded_tsgo_flag_test.go
@@ -1,0 +1,49 @@
+package linthost
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestCommandCheckAppliesForwardedTsgoFlag verifies a forwarded tsgo CLI flag
+// overrides the project tsconfig for the in-process lint program.
+//
+// `@ttsc/lint` builds its Program in-process, so a `ttsc --strict` the launcher
+// could not satisfy by shelling out to tsgo rides into the sidecar as the
+// `--tsgo-args` JSON payload instead. The sidecar replays it through tsgo's own
+// option parser and merges it over the tsconfig. The fixture's tsconfig sets
+// `strict: false`, so a strict-null diagnostic can only appear if the overlay
+// actually won.
+//
+//  1. Create a project whose tsconfig disables strict mode, with a possibly-null
+//     dereference in the source.
+//  2. Run `check` with `--tsgo-args ["--strict"]`.
+//  3. Assert a non-zero exit and a strict-null diagnostic on stderr.
+func TestCommandCheckAppliesForwardedTsgoFlag(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "files": ["src/main.ts"]
+}
+`)
+  writeFile(t, filepath.Join(root, "src", "main.ts"),
+    "export const len = (x: string | null): number => x.length;\n")
+
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "check",
+      "--cwd", root,
+      "--tsgo-args", `["--strict"]`,
+    })
+  })
+  if code != 2 || stdout != "" || !strings.Contains(stderr, "possibly") {
+    t.Fatalf("forwarded --strict not applied: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}

--- a/packages/ttsc/cmd/ttsc/api_compile.go
+++ b/packages/ttsc/cmd/ttsc/api_compile.go
@@ -47,6 +47,8 @@ func runAPICompile(args []string) int {
   fs.SetOutput(stderr)
   tsconfigPath := fs.String("tsconfig", "tsconfig.json", "path to tsconfig.json")
   cwdOverride := fs.String("cwd", "", "override the working directory")
+  singleThreaded := fs.Bool("singleThreaded", false, "run TypeScript-Go single-threaded")
+  checkers := fs.Int("checkers", 0, "type-checker pool size (0 = TypeScript-Go default)")
   if err := fs.Parse(args); err != nil {
     return 2
   }
@@ -58,7 +60,9 @@ func runAPICompile(args []string) int {
   }
 
   prog, diags, err := driver.LoadProgram(cwd, *tsconfigPath, driver.LoadProgramOptions{
-    ForceEmit: true,
+    ForceEmit:      true,
+    SingleThreaded: *singleThreaded,
+    Checkers:       *checkers,
   })
   if err != nil {
     fmt.Fprintf(stderr, "ttsc api-compile: %v\n", err)

--- a/packages/ttsc/cmd/ttsc/api_compile.go
+++ b/packages/ttsc/cmd/ttsc/api_compile.go
@@ -49,6 +49,7 @@ func runAPICompile(args []string) int {
   cwdOverride := fs.String("cwd", "", "override the working directory")
   singleThreaded := fs.Bool("singleThreaded", false, "run TypeScript-Go single-threaded")
   checkers := fs.Int("checkers", 0, "type-checker pool size (0 = TypeScript-Go default)")
+  tsgoArgsRaw := fs.String("tsgo-args", "", "JSON array of forwarded tsgo CLI flags")
   if err := fs.Parse(args); err != nil {
     return 2
   }
@@ -59,10 +60,17 @@ func runAPICompile(args []string) int {
     return 2
   }
 
+  tsgoArgs, err := decodeTsgoArgs(*tsgoArgsRaw)
+  if err != nil {
+    fmt.Fprintf(stderr, "ttsc: %v\n", err)
+    return 2
+  }
+
   prog, diags, err := driver.LoadProgram(cwd, *tsconfigPath, driver.LoadProgramOptions{
     ForceEmit:      true,
     SingleThreaded: *singleThreaded,
     Checkers:       *checkers,
+    TsgoArgs:       tsgoArgs,
   })
   if err != nil {
     fmt.Fprintf(stderr, "ttsc api-compile: %v\n", err)

--- a/packages/ttsc/cmd/ttsc/api_transform.go
+++ b/packages/ttsc/cmd/ttsc/api_transform.go
@@ -32,6 +32,8 @@ func runAPITransform(args []string) int {
   fs.SetOutput(stderr)
   tsconfigPath := fs.String("tsconfig", "tsconfig.json", "path to tsconfig.json")
   cwdOverride := fs.String("cwd", "", "override the working directory")
+  singleThreaded := fs.Bool("singleThreaded", false, "run TypeScript-Go single-threaded")
+  checkers := fs.Int("checkers", 0, "type-checker pool size (0 = TypeScript-Go default)")
   if err := fs.Parse(args); err != nil {
     return 2
   }
@@ -43,7 +45,9 @@ func runAPITransform(args []string) int {
   }
 
   prog, diags, err := driver.LoadProgram(cwd, *tsconfigPath, driver.LoadProgramOptions{
-    ForceNoEmit: true,
+    ForceNoEmit:    true,
+    SingleThreaded: *singleThreaded,
+    Checkers:       *checkers,
   })
   if err != nil {
     fmt.Fprintf(stderr, "ttsc api-transform: %v\n", err)

--- a/packages/ttsc/cmd/ttsc/api_transform.go
+++ b/packages/ttsc/cmd/ttsc/api_transform.go
@@ -34,6 +34,7 @@ func runAPITransform(args []string) int {
   cwdOverride := fs.String("cwd", "", "override the working directory")
   singleThreaded := fs.Bool("singleThreaded", false, "run TypeScript-Go single-threaded")
   checkers := fs.Int("checkers", 0, "type-checker pool size (0 = TypeScript-Go default)")
+  tsgoArgsRaw := fs.String("tsgo-args", "", "JSON array of forwarded tsgo CLI flags")
   if err := fs.Parse(args); err != nil {
     return 2
   }
@@ -44,10 +45,17 @@ func runAPITransform(args []string) int {
     return 2
   }
 
+  tsgoArgs, err := decodeTsgoArgs(*tsgoArgsRaw)
+  if err != nil {
+    fmt.Fprintf(stderr, "ttsc: %v\n", err)
+    return 2
+  }
+
   prog, diags, err := driver.LoadProgram(cwd, *tsconfigPath, driver.LoadProgramOptions{
     ForceNoEmit:    true,
     SingleThreaded: *singleThreaded,
     Checkers:       *checkers,
+    TsgoArgs:       tsgoArgs,
   })
   if err != nil {
     fmt.Fprintf(stderr, "ttsc api-transform: %v\n", err)

--- a/packages/ttsc/cmd/ttsc/build.go
+++ b/packages/ttsc/cmd/ttsc/build.go
@@ -35,6 +35,8 @@ func runBuild(args []string) int {
   noEmit := fs.Bool("noEmit", false, "force analysis-only run with no file writes")
   outDir := fs.String("outDir", "", "override compilerOptions.outDir for this build")
   manifestPath := fs.String("manifest", "", "write emitted file list as JSON to this path")
+  singleThreaded := fs.Bool("singleThreaded", false, "run TypeScript-Go single-threaded")
+  checkers := fs.Int("checkers", 0, "type-checker pool size (0 = TypeScript-Go default)")
   if err := fs.Parse(args); err != nil {
     return 2
   }
@@ -57,9 +59,11 @@ func runBuild(args []string) int {
   }
 
   prog, diags, err := driver.LoadProgram(cwd, *tsconfigPath, driver.LoadProgramOptions{
-    ForceEmit:   *emit,
-    ForceNoEmit: *noEmit,
-    OutDir:      *outDir,
+    ForceEmit:      *emit,
+    ForceNoEmit:    *noEmit,
+    OutDir:         *outDir,
+    SingleThreaded: *singleThreaded,
+    Checkers:       *checkers,
   })
   if err != nil {
     fmt.Fprintf(stderr, "ttsc: %v\n", err)

--- a/packages/ttsc/cmd/ttsc/build.go
+++ b/packages/ttsc/cmd/ttsc/build.go
@@ -37,7 +37,13 @@ func runBuild(args []string) int {
   manifestPath := fs.String("manifest", "", "write emitted file list as JSON to this path")
   singleThreaded := fs.Bool("singleThreaded", false, "run TypeScript-Go single-threaded")
   checkers := fs.Int("checkers", 0, "type-checker pool size (0 = TypeScript-Go default)")
+  tsgoArgsRaw := fs.String("tsgo-args", "", "JSON array of forwarded tsgo CLI flags")
   if err := fs.Parse(args); err != nil {
+    return 2
+  }
+  tsgoArgs, err := decodeTsgoArgs(*tsgoArgsRaw)
+  if err != nil {
+    fmt.Fprintf(stderr, "ttsc: %v\n", err)
     return 2
   }
   if *emit && *noEmit {
@@ -64,6 +70,7 @@ func runBuild(args []string) int {
     OutDir:         *outDir,
     SingleThreaded: *singleThreaded,
     Checkers:       *checkers,
+    TsgoArgs:       tsgoArgs,
   })
   if err != nil {
     fmt.Fprintf(stderr, "ttsc: %v\n", err)
@@ -138,4 +145,19 @@ func runBuild(args []string) int {
     fmt.Fprintf(stdout, "// ttsc: recognized=%d total=%d rewrites=%d\n", 0, 0, rewrites.Len())
   }
   return 0
+}
+
+// decodeTsgoArgs decodes the JSON-array value of the `--tsgo-args` flag — the
+// tsgo CLI flags the `ttsc` launcher forwarded — into a string slice. An empty
+// flag yields a nil slice. Shared by the build / api-compile / api-transform
+// subcommands, which all hand the result to driver.LoadProgram.
+func decodeTsgoArgs(raw string) ([]string, error) {
+  if raw == "" {
+    return nil, nil
+  }
+  var args []string
+  if err := json.Unmarshal([]byte(raw), &args); err != nil {
+    return nil, fmt.Errorf("invalid --tsgo-args: %w", err)
+  }
+  return args, nil
 }

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -204,6 +204,12 @@ type LoadProgramOptions struct {
   ForceNoEmit    bool
   OutDir         string
   SourcePreamble string
+  // SingleThreaded forces TypeScript-Go's single-threaded mode (one checker,
+  // serial parse/check/emit), mirroring `tsgo --singleThreaded`.
+  SingleThreaded bool
+  // Checkers overrides the type-checker pool size, mirroring `tsgo --checkers`.
+  // Zero leaves TypeScript-Go's default; ignored when SingleThreaded is set.
+  Checkers int
 }
 
 // Close releases the checker pool lease acquired by LoadProgram.
@@ -304,6 +310,7 @@ func LoadProgram(cwd, tsconfigPath string, options LoadProgramOptions) (*Program
   if options.OutDir != "" {
     overrideOutDir(cwd, parsed, options.OutDir)
   }
+  applyThreadingOptions(parsed, options.SingleThreaded, options.Checkers)
 
   tsProgram, _, _ := CreateProgramFromConfig(parsed, host)
 
@@ -338,6 +345,23 @@ func forceNoEmit(parsed *tsoptions.ParsedCommandLine) {
 // config, replacing any outDir already set in tsconfig.json.
 func overrideOutDir(cwd string, parsed *tsoptions.ParsedCommandLine, outDir string) {
   parsed.ParsedConfig.CompilerOptions.OutDir = tspath.ResolvePath(cwd, outDir)
+}
+
+// applyThreadingOptions forwards the CLI threading knobs onto the parsed
+// compiler options. ttsc mirrors tsgo here: `--singleThreaded` / `--checkers`
+// land in CompilerOptions, and both Program.SingleThreaded() and the checker
+// pool read them from there — ProgramOptions is left untouched, exactly as
+// tsgo's own CLI does. SingleThreaded wins over Checkers, matching the pool's
+// own precedence.
+func applyThreadingOptions(parsed *tsoptions.ParsedCommandLine, singleThreaded bool, checkers int) {
+  options := parsed.ParsedConfig.CompilerOptions
+  if singleThreaded {
+    options.SingleThreaded = core.TSTrue
+  }
+  if checkers > 0 {
+    n := checkers
+    options.Checkers = &n
+  }
 }
 
 // sourcePreambleFS wraps a vfs.FS and prepends the preamble string to every

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -235,13 +235,20 @@ func ParseTSConfig(fs vfs.FS, cwd, tsconfigPath string, host shimcompiler.Compil
 }
 
 // CreateProgramFromConfig builds a tsgo Program from the parsed config.
+//
+// SingleThreaded is intentionally left unset so the program falls back to
+// TypeScript-Go's multi-threaded default: parallel source parsing, a pooled
+// checker (parallel bind + semantic diagnostics), and parallel emit. The
+// phases ttsc layers on top — plugin application and the output rewriter —
+// still run serially against a single pooled checker, which stays valid
+// against the larger pool. Concurrency surfaces only inside each
+// TypeScript-Go phase; see EmitAll for the WriteFile-callback consequence.
 func CreateProgramFromConfig(parsed *tsoptions.ParsedCommandLine, host shimcompiler.CompilerHost) (*shimcompiler.Program, []Diagnostic, error) {
   if parsed == nil {
     return nil, nil, fmt.Errorf("driver: nil parsed command line")
   }
   opts := shimcompiler.ProgramOptions{
     Config:                      parsed,
-    SingleThreaded:              core.TSTrue,
     Host:                        host,
     UseSourceOfProjectReference: true,
   }

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -210,6 +210,11 @@ type LoadProgramOptions struct {
   // Checkers overrides the type-checker pool size, mirroring `tsgo --checkers`.
   // Zero leaves TypeScript-Go's default; ignored when SingleThreaded is set.
   Checkers int
+  // TsgoArgs carries tsgo CLI flags the `ttsc` launcher did not recognize as
+  // its own (`--strict`, `--target es2020`, …). They are parsed through
+  // TypeScript-Go's own command-line parser into a CompilerOptions overlay
+  // that wins over the tsconfig, exactly as `tsgo`'s CLI merges them.
+  TsgoArgs []string
 }
 
 // Close releases the checker pool lease acquired by LoadProgram.
@@ -227,17 +232,43 @@ func (p *Program) Close() error {
 // The absolute path is resolved against cwd before any VFS lookups because
 // tsgo's filesystem APIs require absolute paths — mirrors what tsc does when
 // you pass a relative `--project` flag.
-func ParseTSConfig(fs vfs.FS, cwd, tsconfigPath string, host shimcompiler.CompilerHost) (*tsoptions.ParsedCommandLine, []Diagnostic, error) {
+//
+// cliOptions is a CompilerOptions overlay (from forwarded `tsgo` CLI flags);
+// TypeScript-Go merges its non-zero fields over the tsconfig so the CLI wins,
+// the same precedence tsgo's own command line uses. Pass nil for none.
+func ParseTSConfig(fs vfs.FS, cwd, tsconfigPath string, host shimcompiler.CompilerHost, cliOptions *core.CompilerOptions) (*tsoptions.ParsedCommandLine, []Diagnostic, error) {
   resolved := tspath.ResolvePath(cwd, tsconfigPath)
   if !fs.FileExists(resolved) {
     return nil, nil, fmt.Errorf("tsconfig not found: %s", resolved)
   }
-  parsed, diags := tsoptions.GetParsedCommandLineOfConfigFile(resolved, &core.CompilerOptions{}, nil, host, nil)
+  if cliOptions == nil {
+    cliOptions = &core.CompilerOptions{}
+  }
+  parsed, diags := tsoptions.GetParsedCommandLineOfConfigFile(resolved, cliOptions, nil, host, nil)
   allDiags := append(diags, parsed.Errors...)
   if len(allDiags) > 0 {
     return nil, convertDiagnostics(allDiags), nil
   }
   return parsed, nil, nil
+}
+
+// parseTsgoArgs runs forwarded tsgo CLI flags through TypeScript-Go's own
+// command-line parser, yielding a CompilerOptions overlay ParseTSConfig merges
+// over the tsconfig. This is how a plugin build — which constructs its Program
+// in-process rather than shelling out to `tsgo` — still honors flags like
+// `ttsc --strict`. Returns (nil, nil, nil) when there are no forwarded flags.
+func parseTsgoArgs(args []string, host shimcompiler.CompilerHost) (*core.CompilerOptions, []Diagnostic, error) {
+  if len(args) == 0 {
+    return nil, nil, nil
+  }
+  cli := tsoptions.ParseCommandLine(args, host)
+  if cli == nil {
+    return nil, nil, fmt.Errorf("driver: tsgo argument parser returned nil")
+  }
+  if len(cli.Errors) > 0 {
+    return nil, convertDiagnostics(cli.Errors), nil
+  }
+  return cli.CompilerOptions(), nil, nil
 }
 
 // CreateProgramFromConfig builds a tsgo Program from the parsed config.
@@ -294,7 +325,15 @@ func LoadProgram(cwd, tsconfigPath string, options LoadProgramOptions) (*Program
   }
   host := DefaultHost(cwd, fs)
 
-  parsed, diags, err := ParseTSConfig(fs, cwd, tsconfigPath, host)
+  cliOptions, cliDiags, err := parseTsgoArgs(options.TsgoArgs, host)
+  if err != nil {
+    return nil, nil, err
+  }
+  if len(cliDiags) > 0 {
+    return nil, cliDiags, nil
+  }
+
+  parsed, diags, err := ParseTSConfig(fs, cwd, tsconfigPath, host, cliOptions)
   if err != nil {
     return nil, nil, err
   }

--- a/packages/ttsc/driver/rewrite.go
+++ b/packages/ttsc/driver/rewrite.go
@@ -73,11 +73,20 @@ const RewriteSentinel = "/* @ttsc-rewritten */"
 // the output. Returns the tsgo diagnostics and any patch-time error. When
 // `writeFile` is nil, the patched JS is written to disk via the standard
 // tsgo WriteFile.
+//
+// `writeFile` does not need to be concurrency-safe: emit() funnels every
+// invocation through one mutex, so the callback never runs on two goroutines
+// at once even though TypeScript-Go emits files in parallel.
 func (p *Program) EmitAll(rs *RewriteSet, writeFile shimcompiler.WriteFile) (*shimcompiler.EmitResult, []Diagnostic, error) {
   return p.emit(rs, nil, writeFile)
 }
 
 // EmitAllRaw runs TypeScript-Go emit without ttsc output-text rewrites.
+//
+// Unlike EmitAll, `writeFile` is handed straight to TypeScript-Go's parallel
+// emitter, so it MUST be safe to invoke concurrently: writing distinct files
+// (the default disk writer, the source-preamble writer) is fine; a callback
+// that mutates shared state must guard it.
 func (p *Program) EmitAllRaw(writeFile shimcompiler.WriteFile) (*shimcompiler.EmitResult, []Diagnostic, error) {
   if p == nil || p.TSProgram == nil {
     return nil, nil, errors.New("driver: nil program")
@@ -114,7 +123,18 @@ func (p *Program) emit(rs *RewriteSet, target *ast.SourceFile, writeFile shimcom
     rs = NewRewriteSet()
   }
   cursors := map[string]int{}
+  // TypeScript-Go's parallel emit invokes this WriteFile callback once per
+  // emitted file, concurrently — one goroutine per source file. Serialize the
+  // whole callback body under wfMu: the `cursors` map would otherwise trip
+  // `fatal error: concurrent map writes`, and the wrapped `writeFile` (which a
+  // caller may back with its own non-thread-safe state, e.g. api-compile's
+  // output map) must likewise see one writer at a time. The patch work here is
+  // cheap, so serializing only the callback costs ~nothing while parsing,
+  // checking, and emit-text generation still parallelize.
+  var wfMu sync.Mutex
   wf := func(fileName, text string, data *shimcompiler.WriteFileData) error {
+    wfMu.Lock()
+    defer wfMu.Unlock()
     // A patched file is idempotent: once the sentinel exists, the emitted text
     // is passed through unchanged. This matters for watch/rebuild loops and
     // tests that re-run emit over the same output directory.

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -197,6 +197,7 @@ function runTsgo(
       ...extraArgs,
       ...createTsgoDiagnosticArgs(options),
       ...createTsgoThreadingArgs(options),
+      ...(options.passthrough ?? []),
     ],
     {
       cwd: execution.projectRoot,
@@ -283,6 +284,7 @@ function createTsgoBuildArgs(
   }
   args.push(...createTsgoDiagnosticArgs(options));
   args.push(...createTsgoThreadingArgs(options));
+  args.push(...(options.passthrough ?? []));
   return args;
 }
 

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -339,6 +339,7 @@ function createNativeBuildArgs(
     args.push("--quiet");
   }
   args.push(...createNativeThreadingArgs(options));
+  args.push(...createNativeTsgoArgs(options));
   return args;
 }
 
@@ -362,6 +363,7 @@ function createNativeCheckArgs(
     args.push("--quiet");
   }
   args.push(...createNativeThreadingArgs(options));
+  args.push(...createNativeTsgoArgs(options));
   return args;
 }
 
@@ -380,6 +382,21 @@ function createNativeThreadingArgs(options: TtscCommonOptions): string[] {
     args.push("--checkers=" + String(options.checkers));
   }
   return args;
+}
+
+/**
+ * Forward the tsgo flags ttsc did not recognize to a native sidecar as one
+ * JSON-encoded `--tsgo-args` flag. The sidecar replays them through tsgo's own
+ * option parser onto `CompilerOptions`, so a flag like `ttsc --strict` reaches
+ * a plugin build the same way it reaches the plain tsgo lane. Encoded as a
+ * single token so the sidecars' unknown-flag filters keep it intact.
+ */
+function createNativeTsgoArgs(options: TtscCommonOptions): string[] {
+  const passthrough = options.passthrough;
+  if (passthrough === undefined || passthrough.length === 0) {
+    return [];
+  }
+  return ["--tsgo-args=" + JSON.stringify(passthrough)];
 }
 
 /**

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -195,6 +195,7 @@ function runTsgo(
       execution.tsconfig,
       ...extraArgs,
       ...createTsgoDiagnosticArgs(options),
+      ...createTsgoThreadingArgs(options),
     ],
     {
       cwd: execution.projectRoot,
@@ -277,6 +278,7 @@ function createTsgoBuildArgs(
     args.push("--listEmittedFiles");
   }
   args.push(...createTsgoDiagnosticArgs(options));
+  args.push(...createTsgoThreadingArgs(options));
   return args;
 }
 
@@ -286,6 +288,23 @@ function createTsgoBuildArgs(
  */
 function createTsgoDiagnosticArgs(options: TtscCommonOptions): string[] {
   return options.structuredDiagnostics === true ? ["--pretty", "false"] : [];
+}
+
+/**
+ * Forward the `--singleThreaded` / `--checkers` knobs to a `tsgo` invocation.
+ * tsgo accepts both flags natively, so the no-plugin build lane only has to
+ * pass them through; the type-check and emit passes share this so the checker
+ * pool size stays consistent across both.
+ */
+function createTsgoThreadingArgs(options: TtscCommonOptions): string[] {
+  const args: string[] = [];
+  if (options.singleThreaded === true) {
+    args.push("--singleThreaded");
+  }
+  if (options.checkers !== undefined) {
+    args.push("--checkers", String(options.checkers));
+  }
+  return args;
 }
 
 /** Build the argument list for a native plugin `build`/`check` invocation. */
@@ -313,6 +332,7 @@ function createNativeBuildArgs(
   } else if (options.quiet === true) {
     args.push("--quiet");
   }
+  args.push(...createNativeThreadingArgs(options));
   return args;
 }
 
@@ -334,6 +354,24 @@ function createNativeCheckArgs(
     args.push("--verbose");
   } else if (options.quiet === true) {
     args.push("--quiet");
+  }
+  args.push(...createNativeThreadingArgs(options));
+  return args;
+}
+
+/**
+ * Forward the `--singleThreaded` / `--checkers` knobs to a native sidecar
+ * (`@ttsc/lint`, transform plugins). Their Go flag sets accept the same two
+ * flags, which `driver.LoadProgram` maps onto `CompilerOptions` so the in-
+ * process program matches what `tsgo` would do on the no-plugin lane.
+ */
+function createNativeThreadingArgs(options: TtscCommonOptions): string[] {
+  const args: string[] = [];
+  if (options.singleThreaded === true) {
+    args.push("--singleThreaded");
+  }
+  if (options.checkers !== undefined) {
+    args.push("--checkers=" + String(options.checkers));
   }
   return args;
 }

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -252,7 +252,13 @@ function runTsgoBuild(
     stderr: outputText(res.stderr),
   };
   const emittedFiles = parseEmittedFiles(result.stdout);
-  if (emittedFiles.length !== 0) {
+  // The `TSFILE:` lines are tsgo's `--listEmittedFiles` output. ttsc adds that
+  // flag internally to learn the emitted paths and strips the lines back out
+  // as noise — but when the user themselves forwarded `--listEmittedFiles`,
+  // the listing is what they asked for, so it must survive to stdout.
+  const userListedEmitted =
+    options.passthrough?.includes("--listEmittedFiles") ?? false;
+  if (emittedFiles.length !== 0 && !userListedEmitted) {
     result.stdout = stripEmittedFileLines(result.stdout);
   }
   return normalizeBuildOutput(

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -115,7 +115,10 @@ export function runBuild(
         buildWithNativeCompilerPlugins(options, execution, compilers),
       );
     } else {
-      if (options.skipDiagnosticsCheck !== true) {
+      if (
+        options.skipDiagnosticsCheck !== true &&
+        !forwardsTerminalTsgoFlag(options)
+      ) {
         const tsgoChecked = runTsgo(execution, ["--noEmit"], options);
         if (tsgoChecked.status !== 0) {
           return appendBuildOutput(checked, tsgoChecked);
@@ -146,7 +149,11 @@ export function runBuild(
     };
   }
 
-  if (options.emit !== false && options.skipDiagnosticsCheck !== true) {
+  if (
+    options.emit !== false &&
+    options.skipDiagnosticsCheck !== true &&
+    !forwardsTerminalTsgoFlag(options)
+  ) {
     const checked = runTsgo(execution, ["--noEmit"], options);
     if (checked.status !== 0) {
       return checked;
@@ -158,6 +165,35 @@ export function runBuild(
       options.emit !== false && options.forceListEmittedFiles === true,
   });
   return runTsgoBuild(execution, options, args);
+}
+
+/**
+ * Tsgo CLI flags that make `tsgo` print something and exit instead of building
+ * (`--showConfig`, `--listFilesOnly`, `--help`, …). ttsc normally runs a
+ * `--noEmit` type-check pass before the emit pass; when one of these is
+ * forwarded, both passes would run `tsgo` and the output would print twice, so
+ * the pre-check is skipped and only one `tsgo` invocation remains.
+ */
+const TERMINAL_TSGO_FLAGS: ReadonlySet<string> = new Set([
+  "--help",
+  "-h",
+  "-?",
+  "--version",
+  "-v",
+  "--all",
+  "--showConfig",
+  "--init",
+  "--listFilesOnly",
+]);
+
+/**
+ * Report whether the caller forwarded a print-and-exit tsgo flag, so the
+ * pre-emit type-check pass can be skipped to avoid running it twice.
+ */
+function forwardsTerminalTsgoFlag(options: TtscCommonOptions): boolean {
+  return (
+    options.passthrough?.some((flag) => TERMINAL_TSGO_FLAGS.has(flag)) ?? false
+  );
 }
 
 /**

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -109,6 +109,7 @@ function buildProject(
   fs.mkdirSync(path.dirname(context.emitDir), { recursive: true });
   const result = runBuild({
     binary: options.binary,
+    checkers: options.checkers,
     cwd: context.root,
     emit: true,
     env: options.env,
@@ -117,6 +118,7 @@ function buildProject(
     outDir: context.emitDir,
     plugins: options.plugins,
     quiet: true,
+    singleThreaded: options.singleThreaded,
     tsconfig: context.tsconfig,
   });
   if (result.status === 0) {

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -116,6 +116,7 @@ function buildProject(
     forceListEmittedFiles: true,
     cacheDir: context.pluginCacheDir,
     outDir: context.emitDir,
+    passthrough: options.passthrough,
     plugins: options.plugins,
     quiet: true,
     singleThreaded: options.singleThreaded,

--- a/packages/ttsc/src/launcher/internal/runTtsc.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsc.ts
@@ -322,6 +322,7 @@ function parseProjectArgs(argv: readonly string[]) {
 function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
   let binary: string | undefined;
   let cacheDir: string | undefined;
+  let checkers: number | undefined;
   let cwd: string | undefined;
   let emit: boolean | undefined = checkOnly ? false : undefined;
   const files: string[] = [];
@@ -330,6 +331,7 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
   let outDir: string | undefined;
   let preserveWatchOutput = false;
   let quiet = true;
+  let singleThreaded = false;
   let tsconfig: string | undefined;
   let watch = false;
 
@@ -373,6 +375,12 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
       case "--cache-dir":
         cacheDir = takeValue(current, rest);
         break;
+      case "--singleThreaded":
+        singleThreaded = true;
+        break;
+      case "--checkers":
+        checkers = parseCheckersValue(takeValue(current, rest));
+        break;
       default:
         if (current.startsWith("--cwd=")) {
           cwd = current.slice("--cwd=".length);
@@ -393,6 +401,11 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
           binary = current.slice("--binary=".length);
         } else if (current.startsWith("--cache-dir=")) {
           cacheDir = current.slice("--cache-dir=".length);
+        } else if (current.startsWith("--checkers=")) {
+          checkers = parseCheckersValue(current.slice("--checkers=".length));
+        } else if (current.startsWith("--singleThreaded=")) {
+          singleThreaded =
+            current.slice("--singleThreaded=".length) !== "false";
         } else if (current === "--verbose") {
           // Unreachable: `--verbose` is handled by the switch case above.
           quiet = false;
@@ -407,6 +420,7 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
   return {
     binary,
     cacheDir,
+    checkers,
     cwd,
     emit,
     files,
@@ -415,9 +429,25 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
     outDir,
     preserveWatchOutput,
     quiet,
+    singleThreaded,
     tsconfig,
     watch,
   };
+}
+
+/**
+ * Parse the `--checkers` value into a positive integer. tsgo rejects a
+ * non-positive checker count (`minValue: 1`); ttsc mirrors that so a typo fails
+ * loudly instead of silently building with the default pool.
+ */
+function parseCheckersValue(raw: string): number {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(
+      `ttsc: --checkers expects a positive integer, got ${JSON.stringify(raw)}`,
+    );
+  }
+  return value;
 }
 
 function printHelp(): void {
@@ -450,6 +480,8 @@ function printHelp(): void {
       "  --verbose              Print the build summary and emitted files",
       "  --binary <path>        Use an explicit tsgo binary",
       "  --cache-dir <dir>      Use this cache root for source-plugin builds",
+      "  --singleThreaded       Run TypeScript-Go single-threaded (one checker)",
+      "  --checkers <n>         Type-checker pool size (default: TypeScript-Go's)",
       "",
       "Plugin contract:",
       "  ttsc reads compilerOptions.plugins from tsconfig.json.",

--- a/packages/ttsc/src/launcher/internal/runTtsc.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsc.ts
@@ -329,6 +329,7 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
   let fix = false;
   let format = false;
   let outDir: string | undefined;
+  const passthrough: string[] = [];
   let preserveWatchOutput = false;
   let quiet = true;
   let singleThreaded = false;
@@ -410,9 +411,17 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
           // Unreachable: `--verbose` is handled by the switch case above.
           quiet = false;
         } else if (current.startsWith("-")) {
-          throw new Error(`ttsc: unknown option ${current}`);
-        } else {
+          // Not one of ttsc's own flags. Forward it verbatim to tsgo, which
+          // owns the complete, arity-aware option parser — ttsc deliberately
+          // does not re-implement knowledge of every tsgo flag.
+          passthrough.push(current);
+        } else if (looksLikeInputFile(current)) {
           files.push(current);
+        } else {
+          // A bare non-file token — e.g. the `es2020` in `--target es2020` —
+          // is the value of a forwarded flag. Keep it next to the run so the
+          // flag and its value reach tsgo together.
+          passthrough.push(current);
         }
         break;
     }
@@ -427,12 +436,22 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
     fix,
     format,
     outDir,
+    passthrough,
     preserveWatchOutput,
     quiet,
     singleThreaded,
     tsconfig,
     watch,
   };
+}
+
+/**
+ * Report whether a bare CLI token is a TypeScript source file ttsc should
+ * compile in single-file mode. Anything without a TypeScript source extension
+ * is treated as a forwarded flag value rather than an input file.
+ */
+function looksLikeInputFile(token: string): boolean {
+  return [".ts", ".tsx", ".mts", ".cts"].some((ext) => token.endsWith(ext));
 }
 
 /**
@@ -483,6 +502,9 @@ function printHelp(): void {
       "  --singleThreaded       Run TypeScript-Go single-threaded (one checker)",
       "  --checkers <n>         Type-checker pool size (default: TypeScript-Go's)",
       "",
+      "  Any other flag is forwarded to tsgo as-is, so tsgo compiler options",
+      "  such as --strict or --target work directly (e.g. ttsc --strict file.ts).",
+      "",
       "Plugin contract:",
       "  ttsc reads compilerOptions.plugins from tsconfig.json.",
       "  Plugin modules are descriptors for ordered native transformer backends.",
@@ -516,9 +538,12 @@ function runSingleFile(options: ReturnType<typeof parseBuildArgs>): number {
   });
   const text = runSingleFileEmit({
     binary: options.binary,
+    checkers: options.checkers,
     cwd,
     file,
     out,
+    passthrough: options.passthrough,
+    singleThreaded: options.singleThreaded,
     tsconfig: options.tsconfig,
   });
   if (!fs.existsSync(out)) {

--- a/packages/ttsc/src/launcher/internal/runTtsx.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsx.ts
@@ -50,6 +50,7 @@ function run(argv: readonly string[]): number {
     cacheDir: resolveCacheDir(cwd, parsed.cacheDir),
     checkers: parsed.checkers,
     cwd,
+    passthrough: parsed.tsgoFlags,
     project: parsed.project,
     singleThreaded: parsed.singleThreaded,
   });
@@ -78,6 +79,7 @@ function parseCLI(argv: readonly string[]) {
   let entry: string | undefined;
   let project: string | undefined;
   let singleThreaded = false;
+  const tsgoFlags: string[] = [];
 
   while (head.length !== 0) {
     const current = head.shift()!;
@@ -130,9 +132,15 @@ function parseCLI(argv: readonly string[]) {
           singleThreaded =
             current.slice("--singleThreaded=".length) !== "false";
         } else if (current.startsWith("-")) {
-          throw new Error(`ttsx: unknown option ${current}`);
-        } else {
+          // Not a ttsx-owned flag: forward it to tsgo's project type-check,
+          // just like the `ttsc` launcher does for the build lane.
+          tsgoFlags.push(current);
+        } else if (looksLikeEntryFile(current)) {
           entry = current;
+        } else {
+          // A bare non-file token before the entry — e.g. the `es2020` in
+          // `--target es2020` — is a forwarded flag's value.
+          tsgoFlags.push(current);
         }
         break;
     }
@@ -152,7 +160,17 @@ function parseCLI(argv: readonly string[]) {
     preload,
     project,
     singleThreaded,
+    tsgoFlags,
   };
+}
+
+/**
+ * Report whether a bare CLI token is the TypeScript entry file rather than a
+ * forwarded flag's value. ttsx runs a TypeScript entrypoint, so only a token
+ * with a TypeScript source extension is treated as the entry.
+ */
+function looksLikeEntryFile(token: string): boolean {
+  return [".ts", ".tsx", ".mts", ".cts"].some((ext) => token.endsWith(ext));
 }
 
 /**
@@ -188,6 +206,9 @@ function printHelp(): void {
       "  --checkers <n>         Type-checker pool size (default: TypeScript-Go's)",
       "  -h, --help             Show this help",
       "  -v, --version          Print the runner version",
+      "",
+      "  Any other flag before the entry is forwarded to tsgo, so options like",
+      "  --strict apply to the type-check (e.g. ttsx --strict src/index.ts).",
       "",
       "Examples:",
       "  ttsx src/index.ts",

--- a/packages/ttsc/src/launcher/internal/runTtsx.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsx.ts
@@ -48,8 +48,10 @@ function run(argv: readonly string[]): number {
   const prepared = prepareExecution(entry, {
     binary: parsed.binary,
     cacheDir: resolveCacheDir(cwd, parsed.cacheDir),
+    checkers: parsed.checkers,
     cwd,
     project: parsed.project,
+    singleThreaded: parsed.singleThreaded,
   });
   return runPreparedEntry(parsed, prepared, cwd);
 }
@@ -71,9 +73,11 @@ function parseCLI(argv: readonly string[]) {
 
   let binary: string | undefined;
   let cacheDir: string | undefined;
+  let checkers: number | undefined;
   let cwd: string | undefined;
   let entry: string | undefined;
   let project: string | undefined;
+  let singleThreaded = false;
 
   while (head.length !== 0) {
     const current = head.shift()!;
@@ -105,6 +109,12 @@ function parseCLI(argv: readonly string[]) {
       case "--binary":
         binary = takeValue(current, head);
         break;
+      case "--singleThreaded":
+        singleThreaded = true;
+        break;
+      case "--checkers":
+        checkers = parseCheckersValue(takeValue(current, head));
+        break;
       default:
         if (current.startsWith("--project=")) {
           project = current.slice("--project=".length);
@@ -114,6 +124,11 @@ function parseCLI(argv: readonly string[]) {
           cacheDir = current.slice("--cache-dir=".length);
         } else if (current.startsWith("--binary=")) {
           binary = current.slice("--binary=".length);
+        } else if (current.startsWith("--checkers=")) {
+          checkers = parseCheckersValue(current.slice("--checkers=".length));
+        } else if (current.startsWith("--singleThreaded=")) {
+          singleThreaded =
+            current.slice("--singleThreaded=".length) !== "false";
         } else if (current.startsWith("-")) {
           throw new Error(`ttsx: unknown option ${current}`);
         } else {
@@ -130,12 +145,29 @@ function parseCLI(argv: readonly string[]) {
   return {
     binary,
     cacheDir,
+    checkers,
     cwd,
     entry,
     passthrough,
     preload,
     project,
+    singleThreaded,
   };
+}
+
+/**
+ * Parse the `--checkers` value into a positive integer. tsgo rejects a
+ * non-positive checker count (`minValue: 1`); ttsx mirrors that so a typo fails
+ * loudly instead of silently running with the default pool.
+ */
+function parseCheckersValue(raw: string): number {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(
+      `ttsx: --checkers expects a positive integer, got ${JSON.stringify(raw)}`,
+    );
+  }
+  return value;
 }
 
 function printHelp(): void {
@@ -152,6 +184,8 @@ function printHelp(): void {
       "  --cache-dir <dir>      Override the runner and source-plugin cache root",
       "  --binary <path>        Use an explicit tsgo binary",
       "  -r, --require <module> Preload a module before the entrypoint",
+      "  --singleThreaded       Run TypeScript-Go single-threaded (one checker)",
+      "  --checkers <n>         Type-checker pool size (default: TypeScript-Go's)",
       "  -h, --help             Show this help",
       "  -v, --version          Print the runner version",
       "",

--- a/packages/ttsc/src/structures/internal/TtscCommonOptions.ts
+++ b/packages/ttsc/src/structures/internal/TtscCommonOptions.ts
@@ -23,6 +23,17 @@ export interface TtscCommonOptions {
   /** Normalize compiler output so diagnostics can be parsed structurally. */
   structuredDiagnostics?: boolean;
   /**
+   * Run TypeScript-Go single-threaded — one checker, serial parse/check/emit.
+   * Mirrors `tsgo --singleThreaded`. Useful for deterministic debugging and CI
+   * repro.
+   */
+  singleThreaded?: boolean;
+  /**
+   * Type-checker pool size, mirroring `tsgo --checkers`. `undefined` leaves
+   * TypeScript-Go's default; ignored when `singleThreaded` is set.
+   */
+  checkers?: number;
+  /**
    * Override project plugin loading for this invocation.
    *
    * - `false`: ignore `compilerOptions.plugins` completely.

--- a/packages/ttsc/src/structures/internal/TtscCommonOptions.ts
+++ b/packages/ttsc/src/structures/internal/TtscCommonOptions.ts
@@ -34,6 +34,14 @@ export interface TtscCommonOptions {
    */
   checkers?: number;
   /**
+   * CLI tokens ttsc did not recognize as its own, forwarded verbatim to the
+   * underlying `tsgo` invocation. This is how a tsgo flag ttsc has no first-
+   * class option for (`--strict`, `--target es2020`, `--listFiles`, …) still
+   * reaches the compiler: ttsc owns its own flags and lets tsgo — which has the
+   * complete, arity-aware option parser — handle the rest.
+   */
+  passthrough?: readonly string[];
+  /**
    * Override project plugin loading for this invocation.
    *
    * - `false`: ignore `compilerOptions.plugins` completely.

--- a/packages/ttsc/test/driver/emit_rewrites_every_source_under_parallel_emit_test.go
+++ b/packages/ttsc/test/driver/emit_rewrites_every_source_under_parallel_emit_test.go
@@ -1,0 +1,112 @@
+package driver_test
+
+import (
+  "fmt"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverEmitRewritesEverySourceUnderParallelEmit verifies whole-program
+// emit patches every source file's output when TypeScript-Go emits in parallel.
+//
+// With SingleThreaded dropped, TypeScript-Go runs one emitter goroutine per
+// source file, so the driver's WriteFile callback is invoked concurrently. That
+// callback mutates the shared `cursors` map and resolves a per-output rewrite;
+// without the serializing mutex it would trip `fatal error: concurrent map
+// writes` or splice a replacement into the wrong file. A single-source fixture
+// cannot surface either bug because it spawns only one emitter — this case uses
+// four sources so the concurrent path is actually exercised.
+//
+// 1. Load a four-file project, each file owning a distinct plugin call.
+// 2. Register one rewrite per source with a file-unique replacement.
+// 3. Emit the whole program and assert every output carries its own rewrite.
+func TestDriverEmitRewritesEverySourceUnderParallelEmit(t *testing.T) {
+  root := t.TempDir()
+
+  // Scenario setup: four module-scoped sources. Each re-declares `plugin`
+  // locally (legal because the `export` makes every file its own module) and
+  // calls it with a file-unique argument so a misrouted rewrite is visible.
+  names := []string{"index", "alpha", "beta", "gamma"}
+  writeProjectFile(t, root, "tsconfig.json", fmt.Sprintf(`{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true
+  },
+  "files": [%s]
+}
+`, `"`+strings.Join(filesList(names), `", "`)+`"`))
+  for _, name := range names {
+    writeProjectFile(t, root, name+".ts", fmt.Sprintf(
+      "declare const plugin: { make(input: string): string };\n"+
+        "export const value = plugin.make(%q);\n", name))
+  }
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  // Rewrite setup: one replacement per source, each tagged with the file name
+  // so the assertion can prove every output received its own splice.
+  rewrites := driver.NewRewriteSet()
+  for _, name := range names {
+    source := prog.SourceFile(filepath.Join(root, name+".ts"))
+    if source == nil {
+      t.Fatalf("SourceFile did not find %s.ts", name)
+    }
+    rewrites.Add(driver.Rewrite{
+      File:          source,
+      RootName:      "plugin",
+      Method:        "make",
+      Replacement:   fmt.Sprintf("%q", "rewritten-"+name),
+      ConsumeParens: true,
+    })
+  }
+
+  // Emit assertion: the callback runs under emit()'s mutex, so writing this
+  // map is safe; the test still exercises the concurrent emitter goroutines.
+  emitted := map[string]string{}
+  _, emitDiags, err := prog.EmitAll(rewrites, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    emitted[filepath.Base(fileName)] = text
+    return nil
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+  for _, name := range names {
+    js := emitted[name+".js"]
+    if js == "" {
+      t.Fatalf("%s.js was not emitted: %#v", name, emitted)
+    }
+    if !strings.Contains(js, driver.RewriteSentinel) {
+      t.Fatalf("%s.js missing rewrite sentinel:\n%s", name, js)
+    }
+    if want := `"rewritten-` + name + `"`; !strings.Contains(js, want) {
+      t.Fatalf("%s.js missing its own replacement %s:\n%s", name, want, js)
+    }
+  }
+}
+
+// filesList appends the `.ts` extension to every entry in `names`, keeping the
+// tsconfig `files` array in step with the fixture written to disk.
+func filesList(names []string) []string {
+  out := make([]string, len(names))
+  for i, name := range names {
+    out[i] = name + ".ts"
+  }
+  return out
+}

--- a/packages/ttsc/test/driver/load_program_applies_tsgo_args_overlay_test.go
+++ b/packages/ttsc/test/driver/load_program_applies_tsgo_args_overlay_test.go
@@ -1,0 +1,49 @@
+package driver_test
+
+import (
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverLoadProgramAppliesTsgoArgsOverlay verifies forwarded tsgo CLI flags
+// override the tsconfig for an in-process program.
+//
+// A plugin build constructs its Program through driver.LoadProgram instead of
+// shelling out to `tsgo`, so a `ttsc --strict` the launcher could not satisfy
+// on the tsgo lane arrives as LoadProgramOptions.TsgoArgs. The driver replays
+// the flag through TypeScript-Go's own option parser and merges it over the
+// tsconfig with the CLI winning — this pins that merge.
+//
+// 1. Build a project whose tsconfig sets `strict: false`.
+// 2. Load it with TsgoArgs ["--strict"].
+// 3. Assert the resolved CompilerOptions report strict mode on.
+func TestDriverLoadProgramAppliesTsgoArgsOverlay(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "strict": false,
+    "outDir": "bin"
+  },
+  "files": ["index.ts"]
+}
+`)
+  writeProjectFile(t, root, "index.ts", "export const value = 1;\n")
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{
+    TsgoArgs: []string{"--strict"},
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  if !prog.ParsedConfig.ParsedConfig.CompilerOptions.Strict.IsTrue() {
+    t.Fatal("--strict from TsgoArgs did not override the tsconfig strict:false")
+  }
+}

--- a/packages/ttsc/test/utility/filter_host_args_keeps_tsgo_args_flag_test.go
+++ b/packages/ttsc/test/utility/filter_host_args_keeps_tsgo_args_flag_test.go
@@ -1,0 +1,35 @@
+package ttsc_test
+
+import (
+  "slices"
+  "testing"
+)
+
+// TestUtilityFilterHostArgsKeepsTsgoArgsFlag verifies the forwarded-flag
+// payload survives host-argument filtering.
+//
+// The `ttsc` launcher hands the transform-plugin host its forwarded tsgo flags
+// as one `--tsgo-args=<json>` token. filterHostArgs strips flags the Go flag
+// set does not declare, so `--tsgo-args` must be in its allow-list — otherwise
+// the payload is dropped before `parseHostOptions` ever decodes it and a flag
+// like `ttsc --strict` would be silently lost on a transform-plugin build. The
+// JSON value carries quotes, commas, and embedded `--`, so this also pins that
+// the whole token is kept intact rather than split.
+//
+// 1. Filter an argument list containing the inline `--tsgo-args=<json>` token.
+// 2. Assert the token survives verbatim alongside the other utility flags.
+func TestUtilityFilterHostArgsKeepsTsgoArgsFlag(t *testing.T) {
+  got := utilityFilterHostArgs([]string{
+    "--cwd", "/workspace/project",
+    `--tsgo-args=["--strict","--target","es2020"]`,
+    "--plugins-json", "[]",
+  })
+  want := []string{
+    "--cwd", "/workspace/project",
+    `--tsgo-args=["--strict","--target","es2020"]`,
+    "--plugins-json", "[]",
+  }
+  if !slices.Equal(got, want) {
+    t.Fatalf("filtered args mismatch:\nwant: %#v\n got: %#v", want, got)
+  }
+}

--- a/packages/ttsc/utility/host.go
+++ b/packages/ttsc/utility/host.go
@@ -27,6 +27,7 @@ type hostOptions struct {
   verbose        bool
   singleThreaded bool
   checkers       int
+  tsgoArgs       []string
 }
 
 // transformResult is the JSON envelope written to stdout by RunTransform.
@@ -138,8 +139,16 @@ func parseHostOptions(command string, args []string) (hostOptions, bool) {
   verbose := fs.Bool("verbose", false, "print summary")
   singleThreaded := fs.Bool("singleThreaded", false, "run TypeScript-Go single-threaded")
   checkers := fs.Int("checkers", 0, "type-checker pool size (0 = TypeScript-Go default)")
+  tsgoArgsRaw := fs.String("tsgo-args", "", "JSON array of forwarded tsgo CLI flags")
   if err := fs.Parse(filterHostArgs(args)); err != nil {
     return hostOptions{}, false
+  }
+  var tsgoArgs []string
+  if *tsgoArgsRaw != "" {
+    if err := json.Unmarshal([]byte(*tsgoArgsRaw), &tsgoArgs); err != nil {
+      fmt.Fprintf(os.Stderr, "ttsc utility: invalid --tsgo-args: %v\n", err)
+      return hostOptions{}, false
+    }
   }
   if *emit && *noEmit {
     fmt.Fprintln(os.Stderr, "ttsc utility: --emit and --noEmit are mutually exclusive")
@@ -173,6 +182,7 @@ func parseHostOptions(command string, args []string) (hostOptions, bool) {
     verbose:        *verbose,
     singleThreaded: *singleThreaded,
     checkers:       *checkers,
+    tsgoArgs:       tsgoArgs,
   }, true
 }
 
@@ -196,6 +206,7 @@ func filterHostArgs(args []string) []string {
     "verbose":        false,
     "singleThreaded": false,
     "checkers":       true,
+    "tsgo-args":      true,
   }
   filtered := make([]string, 0, len(args))
   for i := 0; i < len(args); i++ {
@@ -251,6 +262,7 @@ func loadUtilityProgram(opts hostOptions) (*driver.Program, []driver.PluginEntry
     OutDir:         opts.outDir,
     SingleThreaded: opts.singleThreaded,
     Checkers:       opts.checkers,
+    TsgoArgs:       opts.tsgoArgs,
   })
   if err != nil {
     fmt.Fprintf(os.Stderr, "ttsc utility: %v\n", err)

--- a/packages/ttsc/utility/host.go
+++ b/packages/ttsc/utility/host.go
@@ -17,14 +17,16 @@ import (
 // hostOptions is the parsed form of the flags accepted by all three
 // subcommands (check, build, transform).
 type hostOptions struct {
-  cwd         string
-  emit        bool
-  noEmit      bool
-  outDir      string
-  pluginsJSON string
-  quiet       bool
-  tsconfig    string
-  verbose     bool
+  cwd            string
+  emit           bool
+  noEmit         bool
+  outDir         string
+  pluginsJSON    string
+  quiet          bool
+  tsconfig       string
+  verbose        bool
+  singleThreaded bool
+  checkers       int
 }
 
 // transformResult is the JSON envelope written to stdout by RunTransform.
@@ -134,6 +136,8 @@ func parseHostOptions(command string, args []string) (hostOptions, bool) {
   quiet := fs.Bool("quiet", true, "suppress summary")
   tsconfig := fs.String("tsconfig", "tsconfig.json", "project tsconfig")
   verbose := fs.Bool("verbose", false, "print summary")
+  singleThreaded := fs.Bool("singleThreaded", false, "run TypeScript-Go single-threaded")
+  checkers := fs.Int("checkers", 0, "type-checker pool size (0 = TypeScript-Go default)")
   if err := fs.Parse(filterHostArgs(args)); err != nil {
     return hostOptions{}, false
   }
@@ -159,14 +163,16 @@ func parseHostOptions(command string, args []string) (hostOptions, bool) {
     resolvedCwd = abs
   }
   return hostOptions{
-    cwd:         filepath.Clean(resolvedCwd),
-    emit:        *emit,
-    noEmit:      *noEmit,
-    outDir:      *outDir,
-    pluginsJSON: *pluginsJSON,
-    quiet:       *quiet,
-    tsconfig:    *tsconfig,
-    verbose:     *verbose,
+    cwd:            filepath.Clean(resolvedCwd),
+    emit:           *emit,
+    noEmit:         *noEmit,
+    outDir:         *outDir,
+    pluginsJSON:    *pluginsJSON,
+    quiet:          *quiet,
+    tsconfig:       *tsconfig,
+    verbose:        *verbose,
+    singleThreaded: *singleThreaded,
+    checkers:       *checkers,
   }, true
 }
 
@@ -180,14 +186,16 @@ func filterHostArgs(args []string) []string {
   // true  = the flag accepts a value (--flag value or --flag=value).
   // false = the flag is boolean (no following value token).
   known := map[string]bool{
-    "cwd":          true,
-    "emit":         false,
-    "noEmit":       false,
-    "outDir":       true,
-    "plugins-json": true,
-    "quiet":        false,
-    "tsconfig":     true,
-    "verbose":      false,
+    "cwd":            true,
+    "emit":           false,
+    "noEmit":         false,
+    "outDir":         true,
+    "plugins-json":   true,
+    "quiet":          false,
+    "tsconfig":       true,
+    "verbose":        false,
+    "singleThreaded": false,
+    "checkers":       true,
   }
   filtered := make([]string, 0, len(args))
   for i := 0; i < len(args); i++ {
@@ -238,9 +246,11 @@ func loadUtilityProgram(opts hostOptions) (*driver.Program, []driver.PluginEntry
   defer restoreEnv()
 
   prog, diags, err := driver.LoadProgram(opts.cwd, opts.tsconfig, driver.LoadProgramOptions{
-    ForceEmit:   opts.emit,
-    ForceNoEmit: opts.noEmit,
-    OutDir:      opts.outDir,
+    ForceEmit:      opts.emit,
+    ForceNoEmit:    opts.noEmit,
+    OutDir:         opts.outDir,
+    SingleThreaded: opts.singleThreaded,
+    Checkers:       opts.checkers,
   })
   if err != nil {
     fmt.Fprintf(os.Stderr, "ttsc utility: %v\n", err)

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_checkers_flag_builds_the_project.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_checkers_flag_builds_the_project.ts
@@ -1,0 +1,43 @@
+import {
+  assert,
+  createProject,
+  fs,
+  path,
+  spawn,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies `ttsc --checkers <n>` is accepted and still builds the project.
+ *
+ * `--checkers` mirrors tsgo's flag for sizing the type-checker pool. ttsc's
+ * launcher must parse the value, forward `--checkers <n>` to the tsgo
+ * invocation, and not reject it as an unknown option. This pins that the flag
+ * travels end-to-end and leaves the emitted output untouched.
+ *
+ * 1. Create a minimal CommonJS project.
+ * 2. Run `ttsc --emit --checkers 2` and assert a zero exit.
+ * 3. Assert `dist/main.js` is written with the expected export.
+ */
+export const test_ttsc_checkers_flag_builds_the_project = () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const value: string = "checkers";\n`,
+  });
+
+  const result = spawn(ttscBin, ["--cwd", root, "--emit", "--checkers", "2"], {
+    cwd: root,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+  assert.match(js, /exports\.value/);
+};

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_checkers_flag_rejects_a_non_positive_value.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_checkers_flag_rejects_a_non_positive_value.ts
@@ -1,0 +1,41 @@
+import {
+  assert,
+  createProject,
+  spawn,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies `ttsc --checkers` rejects a non-positive checker count.
+ *
+ * Tsgo declares `--checkers` with `minValue: 1`. ttsc mirrors that in its
+ * launcher so a typo like `--checkers 0` fails loudly up front instead of
+ * silently building with the default pool. Pins the `parseCheckersValue` guard
+ * in the build-argument parser.
+ *
+ * 1. Create a project with a valid TypeScript source file.
+ * 2. Run `ttsc --checkers 0`.
+ * 3. Assert a non-zero exit and a "positive integer" message on stderr.
+ */
+export const test_ttsc_checkers_flag_rejects_a_non_positive_value = () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const answer: number = 42;\n`,
+  });
+
+  const result = spawn(ttscBin, ["--cwd", root, "--checkers", "0"], {
+    cwd: root,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--checkers expects a positive integer/);
+};

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_forwards_a_spaced_flag_value_to_tsgo.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_forwards_a_spaced_flag_value_to_tsgo.ts
@@ -1,0 +1,46 @@
+import {
+  assert,
+  createProject,
+  fs,
+  path,
+  spawn,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies ttsc forwards a space-separated flag value to tsgo as one unit.
+ *
+ * A forwarded tsgo flag may take a value (`--target es2020`). ttsc must not
+ * mistake the bare `es2020` token for a single-file input — it carries no
+ * TypeScript source extension, so it belongs with the forwarded flag. If it
+ * were misrouted into `files`, ttsc would drop into single-file mode and fail
+ * looking for an `es2020` entry instead of running the project build.
+ *
+ * 1. Create a minimal project.
+ * 2. Run `ttsc --emit --target es2020` and assert a zero exit.
+ * 3. Assert the project's JavaScript output was written — i.e. a project build
+ *    ran, not a misfired single-file emit.
+ */
+export const test_ttsc_forwards_a_spaced_flag_value_to_tsgo = () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const value: string = "spaced";\n`,
+  });
+
+  const result = spawn(
+    ttscBin,
+    ["--cwd", root, "--emit", "--target", "es2020"],
+    { cwd: root },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(path.join(root, "dist", "main.js")));
+};

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_forwards_an_unknown_flag_to_tsgo.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_forwards_an_unknown_flag_to_tsgo.ts
@@ -1,0 +1,43 @@
+import {
+  assert,
+  createProject,
+  spawn,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies ttsc forwards an unrecognized flag to the underlying tsgo binary.
+ *
+ * Ttsc owns a fixed set of CLI flags and deliberately does not re-implement
+ * tsgo's option table; every other flag must reach tsgo so `ttsc --strict
+ * file.ts` behaves like `tsgo --strict file.ts`. The fixture's tsconfig sets
+ * `strict: false`, so a strict-null diagnostic can only appear if `--strict`
+ * actually travelled through to tsgo and overrode the project setting.
+ *
+ * 1. Create a project whose tsconfig disables strict mode, with a source file that
+ *    dereferences a possibly-null value.
+ * 2. Run `ttsc --strict <file>`.
+ * 3. Assert a non-zero exit and the strict-null diagnostic in the output.
+ */
+export const test_ttsc_forwards_an_unknown_flag_to_tsgo = () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: false,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const len = (x: string | null): number => x.length;\n`,
+  });
+
+  const result = spawn(ttscBin, ["--cwd", root, "--strict", "src/main.ts"], {
+    cwd: root,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stdout}${result.stderr}`, /is possibly .?null/i);
+};

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_listemittedfiles_flag_surfaces_emitted_paths.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_listemittedfiles_flag_surfaces_emitted_paths.ts
@@ -1,0 +1,42 @@
+import {
+  assert,
+  createProject,
+  spawn,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies a forwarded `--listEmittedFiles` flag surfaces tsgo's file listing.
+ *
+ * Ttsc adds `--listEmittedFiles` to its own internal tsgo calls to learn the
+ * emitted paths, then strips the resulting `TSFILE:` lines back out as noise.
+ * That strip must not also eat the listing when the _user_ forwarded the flag —
+ * otherwise `ttsc --listEmittedFiles` would print nothing at all.
+ *
+ * 1. Create a minimal project.
+ * 2. Run `ttsc --emit --listEmittedFiles`.
+ * 3. Assert a zero exit and a `TSFILE:` listing line in stdout.
+ */
+export const test_ttsc_listemittedfiles_flag_surfaces_emitted_paths = () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const value: string = "listed";\n`,
+  });
+
+  const result = spawn(
+    ttscBin,
+    ["--cwd", root, "--emit", "--listEmittedFiles"],
+    { cwd: root },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /TSFILE:.*main\.js/);
+};

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_showconfig_flag_runs_tsgo_once.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_showconfig_flag_runs_tsgo_once.ts
@@ -1,0 +1,39 @@
+import {
+  assert,
+  createProject,
+  spawn,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies a forwarded print-and-exit tsgo flag runs tsgo exactly once.
+ *
+ * Ttsc runs a `--noEmit` type-check pass before the emit pass. A tsgo flag that
+ * prints and exits instead of building — such as `--showConfig` — would
+ * otherwise run in both passes and print its output twice. ttsc skips the
+ * pre-check when such a flag is forwarded, so the output appears exactly once.
+ *
+ * 1. Create a minimal project.
+ * 2. Run `ttsc --showConfig`.
+ * 3. Assert a zero exit and exactly one rendered config block.
+ */
+export const test_ttsc_showconfig_flag_runs_tsgo_once = () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const value: string = "config";\n`,
+  });
+
+  const result = spawn(ttscBin, ["--cwd", root, "--showConfig"], { cwd: root });
+  assert.equal(result.status, 0, result.stderr);
+  const blocks = result.stdout.split('"compilerOptions"').length - 1;
+  assert.equal(blocks, 1, `expected one config block, got ${blocks}`);
+};

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_single_threaded_flag_builds_the_project.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_single_threaded_flag_builds_the_project.ts
@@ -10,10 +10,10 @@ import {
 /**
  * Verifies `ttsc --singleThreaded` is accepted and still builds the project.
  *
- * `--singleThreaded` mirrors tsgo's flag of the same name. ttsc's launcher
- * rejects unknown `-`-prefixed options, so the flag must be parsed explicitly
- * and forwarded to the underlying tsgo invocation rather than throwing `unknown
- * option`. This pins that the flag travels end-to-end and leaves the emitted
+ * `--singleThreaded` mirrors tsgo's flag of the same name. It is a ttsc-owned
+ * flag — parsed explicitly and plumbed into the in-process program, not blindly
+ * forwarded — so it must be recognized by ttsc's launcher and reach the
+ * compiler. This pins that the flag travels end-to-end and leaves the emitted
  * output untouched.
  *
  * 1. Create a minimal CommonJS project.

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_single_threaded_flag_builds_the_project.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_single_threaded_flag_builds_the_project.ts
@@ -1,0 +1,44 @@
+import {
+  assert,
+  createProject,
+  fs,
+  path,
+  spawn,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies `ttsc --singleThreaded` is accepted and still builds the project.
+ *
+ * `--singleThreaded` mirrors tsgo's flag of the same name. ttsc's launcher
+ * rejects unknown `-`-prefixed options, so the flag must be parsed explicitly
+ * and forwarded to the underlying tsgo invocation rather than throwing `unknown
+ * option`. This pins that the flag travels end-to-end and leaves the emitted
+ * output untouched.
+ *
+ * 1. Create a minimal CommonJS project.
+ * 2. Run `ttsc --emit --singleThreaded` and assert a zero exit.
+ * 3. Assert `dist/main.js` is written with the expected export.
+ */
+export const test_ttsc_single_threaded_flag_builds_the_project = () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const value: string = "single";\n`,
+  });
+
+  const result = spawn(ttscBin, ["--cwd", root, "--emit", "--singleThreaded"], {
+    cwd: root,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+  assert.match(js, /exports\.value/);
+};

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_applies_forwarded_strict_flag.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_applies_forwarded_strict_flag.ts
@@ -1,0 +1,57 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  goPath,
+  path,
+  setupLintProject,
+  spawn,
+  ttscBin,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: a forwarded `--strict` flag is honored on a project
+ * that configures a ttsc plugin.
+ *
+ * A plugin-configured project builds through native sidecars, not a plain
+ * `tsgo` spawn, so a tsgo flag the `ttsc` launcher forwards must travel into
+ * those sidecars (as the `--tsgo-args` payload) and merge onto their compiler
+ * options. The tsconfig here sets `strict: false`; a strict-null error
+ * therefore proves `ttsc --strict` overrode the project setting end-to-end
+ * through the plugin lane, not only on the plain build path.
+ *
+ * 1. Configure a `@ttsc/lint` project whose tsconfig disables strict mode, with a
+ *    possibly-null dereference in the source.
+ * 2. Run `ttsc --noEmit --strict`.
+ * 3. Assert a non-zero exit and a strict-null diagnostic in the output.
+ */
+export const test_plugin_corpus_ttsc_lint_applies_forwarded_strict_flag =
+  () => {
+    const root = setupLintProject("lint-violations");
+    fs.writeFileSync(
+      path.join(root, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: false,
+          outDir: "dist",
+          rootDir: "src",
+          plugins: [{ transform: "@ttsc/lint", config: {} }],
+        },
+        include: ["src"],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(root, "src", "main.ts"),
+      `export const len = (x: string | null): number => x.length;\n`,
+    );
+    const cacheDir = TestProject.tmpdir("ttsc-lint-strict-");
+    const result = spawn(ttscBin, ["--cwd", root, "--noEmit", "--strict"], {
+      cwd: root,
+      env: { PATH: goPath(), TTSC_CACHE_DIR: cacheDir },
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(`${result.stdout}${result.stderr}`, /is possibly .?null/i);
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_forwards_an_unknown_flag_to_tsgo.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_forwards_an_unknown_flag_to_tsgo.ts
@@ -1,0 +1,35 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx forwards an unrecognized flag to the tsgo type-check.
+ *
+ * Ttsx type-checks the project before running the entry. Like the `ttsc`
+ * launcher, it owns a fixed set of flags and forwards every other flag (before
+ * the entry) to tsgo rather than rejecting it — so `ttsx --strict src/main.ts`
+ * behaves like the equivalent tsgo invocation. The fixture's tsconfig sets
+ * `strict: false`, so a strict-null diagnostic can only appear if `--strict`
+ * actually reached the type-check.
+ *
+ * 1. Create a project whose tsconfig disables strict mode, with a source file that
+ *    dereferences a possibly-null value.
+ * 2. Run `ttsx --strict src/main.ts`.
+ * 3. Assert a non-zero exit and the strict-null diagnostic in stderr.
+ */
+export const test_ttsx_forwards_an_unknown_flag_to_tsgo = () => {
+  const root = TestProject.commonJsProject(
+    {
+      "src/main.ts": `export const len = (x: string | null): number => x.length;\n`,
+    },
+    { compilerOptions: { strict: false } },
+  );
+
+  const result = TestProject.spawn(
+    TestProject.TTSX_BIN,
+    ["--cwd", root, "--strict", "src/main.ts"],
+    { cwd: root },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /is possibly .?null/i);
+};

--- a/website/src/content/docs/ttsc/compile.mdx
+++ b/website/src/content/docs/ttsc/compile.mdx
@@ -72,8 +72,17 @@ npx ttsc clean                      # drop the plugin cache
 | `--verbose` | Print build summary and emitted file paths. |
 | `--binary <path>` | Use a specific tsgo binary instead of the bundled one. |
 | `--cache-dir <dir>` | Plugin binary cache root. Defaults to the shared user-level ttsc cache. |
+| `--singleThreaded` | Run TypeScript-Go single-threaded — one checker, serial parse/check/emit. Mirrors `tsgo --singleThreaded`. |
+| `--checkers <n>` | Type-checker pool size. Mirrors `tsgo --checkers`; defaults to TypeScript-Go's own default. |
 
-Settings like `target`, `module`, `strict`, `lib`, `declaration`, `sourceMap`, and other classic `tsc` compilerOptions are read from `tsconfig.json`, not from CLI flags.
+Any flag `ttsc` does not own is forwarded as-is to `tsgo`, so classic `tsc`
+compilerOptions work on the command line too — `ttsc --strict src/main.ts`,
+`ttsc --target es2020`, `ttsc --listFiles`. The usual home for `target`,
+`module`, `strict`, `lib`, and friends is still `tsconfig.json`; the CLI form
+just overrides it for one run. On a project that configures a ttsc plugin, the
+forwarded flag still reaches the in-process compiler, though tsgo's reporting
+flags (`--listFiles`, `--showConfig`, …) only print on a plain, plugin-free
+build.
 
 ## Exit codes
 

--- a/website/src/content/docs/ttsc/execute.mdx
+++ b/website/src/content/docs/ttsc/execute.mdx
@@ -56,8 +56,15 @@ npx ttsx -P tsconfig.scripts.json src/seed.ts
 | `--cache-dir <dir>`      | Override the runtime and source-plugin cache root. |
 | `--binary <path>`        | Use an explicit TypeScript-Go binary. |
 | `-r, --require <module>` | Preload a module before the entrypoint. Repeatable. |
+| `--singleThreaded`       | Run TypeScript-Go single-threaded. Mirrors `tsgo --singleThreaded`. |
+| `--checkers <n>`         | Type-checker pool size. Mirrors `tsgo --checkers`. |
 | `-h, --help`             | Show help. |
 | `-v, --version`          | Print the runner version. |
+
+Any flag `ttsx` does not own, placed **before** the entry file, is forwarded
+to the tsgo type-check — `ttsx --strict src/index.ts` works like the matching
+tsgo invocation. Flags **after** the entry go to the running program as its
+own `process.argv`, the same as `node`.
 
 ## When ttsx vs ttsc
 


### PR DESCRIPTION
## Intent

Closes the first stage of #103. `ttsc` and `@ttsc/lint` both constructed every
TypeScript-Go `Program` with `SingleThreaded: TSTrue`, disabling **all** of
TypeScript-Go's concurrency — parallel parsing, the pooled checker, parallel
bind/semantic diagnostics, and parallel emit. The flag was inherited verbatim
from the first commit and never revisited. This PR drops it at both
construction sites so the program runs on TypeScript-Go's multi-threaded
default.

## Scope

This is **Commit 1 of the issue's plan only** — TypeScript-Go program
parallelism. The remaining stages are intentionally **not** in this PR and will
follow once this one is green:

- **Commit 2** — `@ttsc/lint` engine parallelism (parallel file walk across the
  checker pool). Not included.
- **Commit 3** — plugin traverse parallelism (typia/nestia). Crosses the public
  plugin API boundary; tracked as a separate PR per the issue.

## Changes

- `driver/program.go`, `linthost/host.go` — remove `SingleThreaded` from the
  two `ProgramOptions` so the program falls back to the multi-threaded default.
- `driver/rewrite.go` — `emit()` now serializes its whole `WriteFile` callback
  under a mutex. Parallel emit invokes that callback once per emitted file
  concurrently; the `cursors` map would otherwise trip `fatal error: concurrent
  map writes`, and a caller's wrapped `writeFile` (e.g. api-compile's output
  map) must also see one writer at a time. The patch work is cheap, so
  serializing only the callback costs ~nothing while parse/check/emit-text
  generation parallelize. `EmitAll`/`EmitAllRaw` doc comments now state the
  callback's concurrency contract.

## Why this is safe

The phases ttsc layers on top of TypeScript-Go — plugin application, the output
rewriter, and the (still serial) lint engine walk — keep using a single pooled
checker, which stays valid against the larger pool: TypeScript-Go fans out only
*inside* each phase, never across these serial phases. The only ttsc-side code
that now runs during a parallel phase is the emit `WriteFile` callback, which
this PR makes thread-safe. `EmittedFiles` ordering is unaffected —
`CombineEmitResults` reassembles per-emitter results in source-file order — so
the build manifest stays deterministic.

`ttscserver` is not affected: it delegates type-checking to a spawned
`tsgo --lsp --stdio` subprocess and never goes through `driver.LoadProgram`.

## Test plan

- New `packages/ttsc/test/driver/emit_rewrites_every_source_under_parallel_emit_test.go`
  emits a four-source project so multiple emitter goroutines exercise the
  `WriteFile` callback concurrently, and asserts every output gets its own
  rewrite. Verified that, with the mutex removed, `go test -race` reliably
  reports `DATA RACE`; with it in place the test passes under `-race`.
- `go build ./...` + `go vet ./...` clean for `packages/ttsc`.
- Full `go test ./...` green for `packages/ttsc`.
- CI (`test.yml` + `typia.yml`) gates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)