### PR TITLE
fix(lint): guard `extends` resolution against cyclic and unbounded config chains

### DIFF
--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -433,18 +433,74 @@ func parseExternalConfigRules(raw any) (RuleConfig, error) {
 // *ConfigStore. `configDir` anchors glob resolution and `extends` lookups; it
 // is empty for in-memory inputs that do not load from a real file.
 func parseExternalConfigStore(raw any, configDir string) (*ConfigStore, error) {
+  return collectConfigStore(raw, configDir, "")
+}
+
+// collectConfigStore parses a single `ITtscLintConfig` object into a fresh
+// *ConfigStore. `rootPath` is the absolute path of the file `raw` was loaded
+// from, or "" for in-memory inputs; when set it seeds the `extends` cycle
+// guard so a config that `extends` itself (directly or transitively) is
+// rejected.
+func collectConfigStore(raw any, configDir, rootPath string) (*ConfigStore, error) {
   store := &ConfigStore{}
-  if err := collectConfigObject(store, raw, configDir, "config"); err != nil {
+  var chain []string
+  if rootPath != "" {
+    chain = []string{filepath.Clean(rootPath)}
+  }
+  if err := collectConfigObject(store, raw, configDir, "config", chain); err != nil {
     return nil, err
   }
   return store, nil
+}
+
+// extendsDepthLimit caps how many `extends` hops collectConfigObject will
+// follow. The cycle check in appendExtendsLink already rejects every loop;
+// this is a backstop so a config chain that escapes that check (e.g. a future
+// change that resolves the same file under two different cleaned paths) still
+// fails fast instead of spawning an unbounded run of `ttsx`/`node`
+// config-loader subprocesses — one per hop.
+const extendsDepthLimit = 32
+
+// appendExtendsLink validates that following the `extends` target at `next`
+// neither closes a cycle nor exceeds extendsDepthLimit, then returns `chain`
+// extended by `next`. `chain` holds the resolved absolute paths of every
+// config file already on the current `extends` lineage, root first. The guard
+// runs before loadConfigFile so a cyclic chain fails fast instead of
+// re-reading files (and re-spawning subprocesses) without bound.
+func appendExtendsLink(chain []string, next string) ([]string, error) {
+  for i, prior := range chain {
+    if prior == next {
+      // chain[i:] capped at its own length so append allocates a fresh
+      // backing array rather than mutating the caller's `chain`.
+      cycle := append(chain[i:len(chain):len(chain)], next)
+      return nil, fmt.Errorf(
+        "@ttsc/lint: extends cycle detected: %s",
+        strings.Join(cycle, " -> "),
+      )
+    }
+  }
+  if len(chain) >= extendsDepthLimit {
+    return nil, fmt.Errorf(
+      "@ttsc/lint: extends chain exceeds the depth limit of %d: %s -> ...",
+      extendsDepthLimit,
+      strings.Join(chain, " -> "),
+    )
+  }
+  extended := make([]string, len(chain)+1)
+  copy(extended, chain)
+  extended[len(chain)] = next
+  return extended, nil
 }
 
 // collectConfigObject parses one `ITtscLintConfig` object into `store`,
 // appending one ConfigEntry for the object's own rules (and, recursively, the
 // entries of any `extends`-named config file). The extends-target's entries
 // are appended first so the extending file's local rules win on collision.
-func collectConfigObject(store *ConfigStore, raw any, baseDir, path string) error {
+//
+// `chain` carries the resolved absolute paths of the config files already on
+// the current `extends` lineage (root first); appendExtendsLink consults it to
+// reject cyclic or pathologically deep chains before another file is read.
+func collectConfigObject(store *ConfigStore, raw any, baseDir, path string, chain []string) error {
   if raw == nil {
     return nil
   }
@@ -468,11 +524,16 @@ func collectConfigObject(store *ConfigStore, raw any, baseDir, path string) erro
     if !filepath.IsAbs(location) {
       location = filepath.Join(baseDir, location)
     }
+    location = filepath.Clean(location)
+    extendedChain, err := appendExtendsLink(chain, location)
+    if err != nil {
+      return err
+    }
     extendedRaw, err := loadConfigFile(location)
     if err != nil {
       return err
     }
-    if err := collectConfigObject(store, extendedRaw, filepath.Dir(location), path+".extends"); err != nil {
+    if err := collectConfigObject(store, extendedRaw, filepath.Dir(location), path+".extends", extendedChain); err != nil {
       return err
     }
   }
@@ -702,7 +763,7 @@ func loadConfigResolver(location string) (RuleResolver, error) {
   if err != nil {
     return nil, err
   }
-  store, err := parseExternalConfigStore(raw, filepath.Dir(location))
+  store, err := collectConfigStore(raw, filepath.Dir(location), location)
   if err != nil {
     return nil, err
   }

--- a/packages/lint/test/config/files/load_rule_config_rejects_extends_cycle_between_two_configs_test.go
+++ b/packages/lint/test/config/files/load_rule_config_rejects_extends_cycle_between_two_configs_test.go
@@ -1,0 +1,50 @@
+package linthost
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestLoadRuleConfigRejectsExtendsCycleBetweenTwoConfigs verifies that two
+// config files that `extends` each other fail fast instead of recursing
+// without bound.
+//
+// `collectConfigObject` resolves `extends` recursively, reading (and, for
+// .ts/.js files, subprocess-evaluating) every named config file. Without a
+// visited-path guard a cycle `a -> b -> a` would recurse — and re-spawn a
+// loader subprocess — forever. The guard must reject the cycle before the
+// second hop re-reads `a.config.json`.
+//
+// 1. Write `a.config.json` and `b.config.json` that each `extends` the other.
+// 2. Call LoadRuleConfig with `configFile: "./a.config.json"`.
+// 3. Assert a non-nil error that says `extends cycle detected` and names both
+//    files.
+func TestLoadRuleConfigRejectsExtendsCycleBetweenTwoConfigs(t *testing.T) {
+  dir := t.TempDir()
+  writeFile(t, filepath.Join(dir, "tsconfig.json"), "{}")
+  writeFile(t, filepath.Join(dir, "a.config.json"), `{
+    "extends": "./b.config.json",
+    "rules": { "no-var": "error" }
+  }`)
+  writeFile(t, filepath.Join(dir, "b.config.json"), `{
+    "extends": "./a.config.json",
+    "rules": { "eqeqeq": "error" }
+  }`)
+
+  _, err := LoadRuleConfig(&PluginEntry{
+    Config: map[string]any{
+      "configFile": "./a.config.json",
+    },
+  }, dir, "tsconfig.json")
+  if err == nil {
+    t.Fatal("expected a cyclic extends chain to fail")
+  }
+  message := err.Error()
+  if !strings.Contains(message, "extends cycle detected") {
+    t.Fatalf("error should name the cycle, got %v", err)
+  }
+  if !strings.Contains(message, "a.config.json") || !strings.Contains(message, "b.config.json") {
+    t.Fatalf("error should name both files in the cycle, got %v", err)
+  }
+}

--- a/packages/lint/test/config/files/load_rule_config_rejects_overly_deep_extends_chain_test.go
+++ b/packages/lint/test/config/files/load_rule_config_rejects_overly_deep_extends_chain_test.go
@@ -1,0 +1,49 @@
+package linthost
+
+import (
+  "fmt"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestLoadRuleConfigRejectsOverlyDeepExtendsChain verifies that a linear,
+// non-cyclic `extends` chain longer than extendsDepthLimit fails fast.
+//
+// The visited-path check rejects every cycle, but a future change that resolves
+// the same file under two cleaned paths could let recursion escape it. The hard
+// depth cap is the backstop: even a strictly non-cyclic chain is bounded, so a
+// pathologically long chain cannot spawn an unbounded run of loader
+// subprocesses.
+//
+// 1. Write `cfg0.config.json` ... `cfgN.config.json` where each file `extends`
+//    the next and the chain length exceeds extendsDepthLimit.
+// 2. Call LoadRuleConfig with `configFile: "./cfg0.config.json"`.
+// 3. Assert a non-nil error that mentions the depth limit.
+func TestLoadRuleConfigRejectsOverlyDeepExtendsChain(t *testing.T) {
+  dir := t.TempDir()
+  writeFile(t, filepath.Join(dir, "tsconfig.json"), "{}")
+
+  const chainLength = extendsDepthLimit + 8
+  for i := 0; i < chainLength; i++ {
+    name := fmt.Sprintf("cfg%d.config.json", i)
+    if i == chainLength-1 {
+      writeFile(t, filepath.Join(dir, name), `{ "rules": { "no-var": "error" } }`)
+      continue
+    }
+    writeFile(t, filepath.Join(dir, name), fmt.Sprintf(
+      `{ "extends": "./cfg%d.config.json", "rules": { "no-var": "error" } }`, i+1))
+  }
+
+  _, err := LoadRuleConfig(&PluginEntry{
+    Config: map[string]any{
+      "configFile": "./cfg0.config.json",
+    },
+  }, dir, "tsconfig.json")
+  if err == nil {
+    t.Fatal("expected an over-deep extends chain to fail")
+  }
+  if !strings.Contains(err.Error(), "depth limit") {
+    t.Fatalf("error should mention the depth limit, got %v", err)
+  }
+}

--- a/packages/lint/test/config/files/load_rule_config_rejects_self_referential_extends_test.go
+++ b/packages/lint/test/config/files/load_rule_config_rejects_self_referential_extends_test.go
@@ -1,0 +1,44 @@
+package linthost
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestLoadRuleConfigRejectsSelfReferentialExtends verifies that a config file
+// whose `extends` points at itself fails fast.
+//
+// A one-file cycle escapes any guard that only tracks the *extended* files: it
+// is the root config that gets re-entered. The cycle guard must therefore be
+// seeded with the root config's own absolute path, so a config that `extends`
+// itself is caught on the first hop instead of recursing without bound.
+//
+// 1. Write a single `a.config.json` whose `extends` names `a.config.json`.
+// 2. Call LoadRuleConfig with `configFile: "./a.config.json"`.
+// 3. Assert a non-nil error that says `extends cycle detected` and names the
+//    file.
+func TestLoadRuleConfigRejectsSelfReferentialExtends(t *testing.T) {
+  dir := t.TempDir()
+  writeFile(t, filepath.Join(dir, "tsconfig.json"), "{}")
+  writeFile(t, filepath.Join(dir, "a.config.json"), `{
+    "extends": "./a.config.json",
+    "rules": { "no-var": "error" }
+  }`)
+
+  _, err := LoadRuleConfig(&PluginEntry{
+    Config: map[string]any{
+      "configFile": "./a.config.json",
+    },
+  }, dir, "tsconfig.json")
+  if err == nil {
+    t.Fatal("expected a self-referential extends to fail")
+  }
+  message := err.Error()
+  if !strings.Contains(message, "extends cycle detected") {
+    t.Fatalf("error should name the cycle, got %v", err)
+  }
+  if !strings.Contains(message, "a.config.json") {
+    t.Fatalf("error should name the self-referential file, got %v", err)
+  }
+}

--- a/packages/lint/test/config/files/load_rule_config_resolves_linear_extends_chain_test.go
+++ b/packages/lint/test/config/files/load_rule_config_resolves_linear_extends_chain_test.go
@@ -1,0 +1,45 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestLoadRuleConfigResolvesLinearExtendsChain verifies that a valid, acyclic
+// `extends` chain still merges rules in the documented order.
+//
+// The cycle/depth guard must not regress legitimate inheritance: the
+// extends-target's entries are appended first so the extending file's own
+// rules win on collision. This pins that a base file's rules are inherited and
+// that a local override outranks the inherited severity.
+//
+// 1. Write a base `b.config.json` (`no-var: warning`, `eqeqeq: error`).
+// 2. Write `a.config.json` that `extends` it and re-declares `no-var: error`.
+// 3. Call LoadRuleConfig and assert `eqeqeq` is inherited and the local
+//    `no-var: error` override wins over the base `warning`.
+func TestLoadRuleConfigResolvesLinearExtendsChain(t *testing.T) {
+  dir := t.TempDir()
+  writeFile(t, filepath.Join(dir, "tsconfig.json"), "{}")
+  writeFile(t, filepath.Join(dir, "b.config.json"), `{
+    "rules": { "no-var": "warning", "eqeqeq": "error" }
+  }`)
+  writeFile(t, filepath.Join(dir, "a.config.json"), `{
+    "extends": "./b.config.json",
+    "rules": { "no-var": "error" }
+  }`)
+
+  cfg, err := LoadRuleConfig(&PluginEntry{
+    Config: map[string]any{
+      "configFile": "./a.config.json",
+    },
+  }, dir, "tsconfig.json")
+  if err != nil {
+    t.Fatalf("LoadRuleConfig: %v", err)
+  }
+  if cfg.Severity("eqeqeq") != SeverityError {
+    t.Errorf("eqeqeq: want error inherited from base, got %v", cfg.Severity("eqeqeq"))
+  }
+  if cfg.Severity("no-var") != SeverityError {
+    t.Errorf("no-var: want error from local override, got %v", cfg.Severity("no-var"))
+  }
+}

--- a/tests/test-lint/src/features/config/test_lint_config_file_extends_rejects_cyclic_chain.ts
+++ b/tests/test-lint/src/features/config/test_lint_config_file_extends_rejects_cyclic_chain.ts
@@ -1,0 +1,28 @@
+import { assert, runLint } from "../../internal/config-file";
+
+/**
+ * Verifies that a config file whose `extends` chain forms a cycle is rejected.
+ *
+ * `extends` is resolved recursively, and for `.ts`/`.js` configs every hop
+ * spawns a loader subprocess. A cycle `lint.config.json -> b.config.json ->
+ * lint.config.json` must fail fast with a readable error instead of recursing
+ * (and re-spawning loaders) without bound — see issue #107.
+ *
+ * 1. Materialize a fixture whose discovered `lint.config.json` extends
+ *    `b.config.json`, which extends `lint.config.json` back.
+ * 2. Run ttsc.
+ * 3. Assert non-zero exit and stderr says `extends cycle detected`.
+ */
+export const test_lint_config_file_extends_rejects_cyclic_chain = () => {
+  const result = runLint({
+    name: "config-file-extends-cycle",
+    source: "export const ok = 1;\n",
+    extraSources: {
+      "lint.config.json": JSON.stringify({ extends: "./b.config.json" }),
+      "b.config.json": JSON.stringify({ extends: "./lint.config.json" }),
+    },
+  });
+
+  assert.notEqual(result.status, 0, result.stderr);
+  assert.match(result.stderr, /extends cycle detected/);
+};


### PR DESCRIPTION
Closes #107.

## Intent

`@ttsc/lint` config files support an `extends` key for file-to-file
inheritance. The Go-side resolver in `packages/lint/linthost/config.go`
followed `extends` with **unbounded recursion** — no visited-set, no
depth cap. A cyclic chain (`a.config.*` extends `b.config.*`,
`b.config.*` extends `a.config.*`) recursed forever.

Because every hop calls `loadConfigFile`, which spawns a `ttsx`
subprocess for `.ts`/`.cts`/`.mts` configs and a `node -e` subprocess
for `.js`/`.cjs`/`.mjs` configs, a cyclic chain among script/TS configs
amplified into an unbounded run of child processes — effectively a fork
bomb. A pure-JSON cycle was in-process recursion that grew the stack
until it crashed or hung. A non-cyclic but very deep chain had the same
per-hop subprocess cost.

## Scope

`packages/lint/linthost/config.go`:

- `collectConfigObject` now threads `chain []string` — the resolved
  absolute paths of every config file on the in-progress `extends`
  lineage, root first.
- New `appendExtendsLink` validates the next hop **before**
  `loadConfigFile` runs: a target already on the chain is a cycle; a
  chain at `extendsDepthLimit` (32) hops is over-deep. Either case
  returns a readable, chain-naming error (`@ttsc/lint: extends cycle
  detected: a.config.json -> b.config.json -> a.config.json`).
- The chain is seeded with the root config's own absolute path (via the
  new `collectConfigStore` helper, called from `loadConfigResolver`), so
  a config that `extends` itself is caught on the first hop.
- `extends` targets are normalized with `filepath.Clean` before the
  membership check.

Merge semantics are unchanged: the extends-target's entries are still
appended first so the extending file's local rules win on collision.
The per-subprocess `configLoaderTimeout` is left as-is — it bounds each
process, not the chain, so it is not a substitute for the in-process
guard.

## Test plan

New Go unit tests under `packages/lint/test/config/files/` (one
assertion per file, JSON configs so they stay in-process and fast):

- `load_rule_config_rejects_extends_cycle_between_two_configs_test.go` —
  two configs that `extends` each other fail with the cycle error.
- `load_rule_config_rejects_self_referential_extends_test.go` — a config
  that `extends` itself fails with the cycle error.
- `load_rule_config_rejects_overly_deep_extends_chain_test.go` — a
  linear non-cyclic chain past the depth cap fails with the depth-limit
  error.
- `load_rule_config_resolves_linear_extends_chain_test.go` — a valid
  linear chain still inherits base rules and lets local overrides win,
  so the guard does not regress legitimate inheritance.

New e2e test `tests/test-lint/src/features/config/test_lint_config_file_extends_rejects_cyclic_chain.ts`
locks the user-visible non-zero exit and `extends cycle detected` stderr.

## Notes

- Targets `feat/ttsc-lint-overhaul` (PR #104): the `extends`-loads-a-file
  behavior only exists on that branch, so the bug cannot be reproduced
  or fixed against `master`.
- The `extends` config key is not documented anywhere under
  `website/src/content/docs/lint/` — documenting it (and this
  cycle-detection behavior) is a separate, pre-existing gap, left out of
  scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)