### PR TITLE
perf(ttsc): parallelize parse, type-check, and emit

### DIFF
--- a/packages/lint/linthost/host.go
+++ b/packages/lint/linthost/host.go
@@ -89,9 +89,14 @@ func loadProgram(cwd, tsconfigPath string, options loadProgramOptions) (*program
     overrideOutDir(cwd, parsed, options.outDir)
   }
 
+  // SingleThreaded is left unset so the program runs on TypeScript-Go's
+  // multi-threaded default: parallel parsing, a pooled checker driving
+  // parallel bind + semantic diagnostics, and parallel emit. The lint engine
+  // still walks files serially against a single pooled checker, which stays
+  // valid against the larger pool — the pool fans out only inside each
+  // TypeScript-Go phase, never across the engine's own traversal.
   tsProgram := shimcompiler.NewProgram(shimcompiler.ProgramOptions{
     Config:                      parsed,
-    SingleThreaded:              shimcore.TSTrue,
     Host:                        host,
     UseSourceOfProjectReference: true,
   })

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -235,13 +235,20 @@ func ParseTSConfig(fs vfs.FS, cwd, tsconfigPath string, host shimcompiler.Compil
 }
 
 // CreateProgramFromConfig builds a tsgo Program from the parsed config.
+//
+// SingleThreaded is intentionally left unset so the program falls back to
+// TypeScript-Go's multi-threaded default: parallel source parsing, a pooled
+// checker (parallel bind + semantic diagnostics), and parallel emit. The
+// phases ttsc layers on top — plugin application and the output rewriter —
+// still run serially against a single pooled checker, which stays valid
+// against the larger pool. Concurrency surfaces only inside each
+// TypeScript-Go phase; see EmitAll for the WriteFile-callback consequence.
 func CreateProgramFromConfig(parsed *tsoptions.ParsedCommandLine, host shimcompiler.CompilerHost) (*shimcompiler.Program, []Diagnostic, error) {
   if parsed == nil {
     return nil, nil, fmt.Errorf("driver: nil parsed command line")
   }
   opts := shimcompiler.ProgramOptions{
     Config:                      parsed,
-    SingleThreaded:              core.TSTrue,
     Host:                        host,
     UseSourceOfProjectReference: true,
   }

--- a/packages/ttsc/driver/rewrite.go
+++ b/packages/ttsc/driver/rewrite.go
@@ -73,11 +73,20 @@ const RewriteSentinel = "/* @ttsc-rewritten */"
 // the output. Returns the tsgo diagnostics and any patch-time error. When
 // `writeFile` is nil, the patched JS is written to disk via the standard
 // tsgo WriteFile.
+//
+// `writeFile` does not need to be concurrency-safe: emit() funnels every
+// invocation through one mutex, so the callback never runs on two goroutines
+// at once even though TypeScript-Go emits files in parallel.
 func (p *Program) EmitAll(rs *RewriteSet, writeFile shimcompiler.WriteFile) (*shimcompiler.EmitResult, []Diagnostic, error) {
   return p.emit(rs, nil, writeFile)
 }
 
 // EmitAllRaw runs TypeScript-Go emit without ttsc output-text rewrites.
+//
+// Unlike EmitAll, `writeFile` is handed straight to TypeScript-Go's parallel
+// emitter, so it MUST be safe to invoke concurrently: writing distinct files
+// (the default disk writer, the source-preamble writer) is fine; a callback
+// that mutates shared state must guard it.
 func (p *Program) EmitAllRaw(writeFile shimcompiler.WriteFile) (*shimcompiler.EmitResult, []Diagnostic, error) {
   if p == nil || p.TSProgram == nil {
     return nil, nil, errors.New("driver: nil program")
@@ -114,7 +123,18 @@ func (p *Program) emit(rs *RewriteSet, target *ast.SourceFile, writeFile shimcom
     rs = NewRewriteSet()
   }
   cursors := map[string]int{}
+  // TypeScript-Go's parallel emit invokes this WriteFile callback once per
+  // emitted file, concurrently — one goroutine per source file. Serialize the
+  // whole callback body under wfMu: the `cursors` map would otherwise trip
+  // `fatal error: concurrent map writes`, and the wrapped `writeFile` (which a
+  // caller may back with its own non-thread-safe state, e.g. api-compile's
+  // output map) must likewise see one writer at a time. The patch work here is
+  // cheap, so serializing only the callback costs ~nothing while parsing,
+  // checking, and emit-text generation still parallelize.
+  var wfMu sync.Mutex
   wf := func(fileName, text string, data *shimcompiler.WriteFileData) error {
+    wfMu.Lock()
+    defer wfMu.Unlock()
     // A patched file is idempotent: once the sentinel exists, the emitted text
     // is passed through unchanged. This matters for watch/rebuild loops and
     // tests that re-run emit over the same output directory.

--- a/packages/ttsc/test/driver/emit_rewrites_every_source_under_parallel_emit_test.go
+++ b/packages/ttsc/test/driver/emit_rewrites_every_source_under_parallel_emit_test.go
@@ -1,0 +1,112 @@
+package driver_test
+
+import (
+  "fmt"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverEmitRewritesEverySourceUnderParallelEmit verifies whole-program
+// emit patches every source file's output when TypeScript-Go emits in parallel.
+//
+// With SingleThreaded dropped, TypeScript-Go runs one emitter goroutine per
+// source file, so the driver's WriteFile callback is invoked concurrently. That
+// callback mutates the shared `cursors` map and resolves a per-output rewrite;
+// without the serializing mutex it would trip `fatal error: concurrent map
+// writes` or splice a replacement into the wrong file. A single-source fixture
+// cannot surface either bug because it spawns only one emitter — this case uses
+// four sources so the concurrent path is actually exercised.
+//
+// 1. Load a four-file project, each file owning a distinct plugin call.
+// 2. Register one rewrite per source with a file-unique replacement.
+// 3. Emit the whole program and assert every output carries its own rewrite.
+func TestDriverEmitRewritesEverySourceUnderParallelEmit(t *testing.T) {
+  root := t.TempDir()
+
+  // Scenario setup: four module-scoped sources. Each re-declares `plugin`
+  // locally (legal because the `export` makes every file its own module) and
+  // calls it with a file-unique argument so a misrouted rewrite is visible.
+  names := []string{"index", "alpha", "beta", "gamma"}
+  writeProjectFile(t, root, "tsconfig.json", fmt.Sprintf(`{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true
+  },
+  "files": [%s]
+}
+`, `"`+strings.Join(filesList(names), `", "`)+`"`))
+  for _, name := range names {
+    writeProjectFile(t, root, name+".ts", fmt.Sprintf(
+      "declare const plugin: { make(input: string): string };\n"+
+        "export const value = plugin.make(%q);\n", name))
+  }
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  // Rewrite setup: one replacement per source, each tagged with the file name
+  // so the assertion can prove every output received its own splice.
+  rewrites := driver.NewRewriteSet()
+  for _, name := range names {
+    source := prog.SourceFile(filepath.Join(root, name+".ts"))
+    if source == nil {
+      t.Fatalf("SourceFile did not find %s.ts", name)
+    }
+    rewrites.Add(driver.Rewrite{
+      File:          source,
+      RootName:      "plugin",
+      Method:        "make",
+      Replacement:   fmt.Sprintf("%q", "rewritten-"+name),
+      ConsumeParens: true,
+    })
+  }
+
+  // Emit assertion: the callback runs under emit()'s mutex, so writing this
+  // map is safe; the test still exercises the concurrent emitter goroutines.
+  emitted := map[string]string{}
+  _, emitDiags, err := prog.EmitAll(rewrites, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    emitted[filepath.Base(fileName)] = text
+    return nil
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+  for _, name := range names {
+    js := emitted[name+".js"]
+    if js == "" {
+      t.Fatalf("%s.js was not emitted: %#v", name, emitted)
+    }
+    if !strings.Contains(js, driver.RewriteSentinel) {
+      t.Fatalf("%s.js missing rewrite sentinel:\n%s", name, js)
+    }
+    if want := `"rewritten-` + name + `"`; !strings.Contains(js, want) {
+      t.Fatalf("%s.js missing its own replacement %s:\n%s", name, want, js)
+    }
+  }
+}
+
+// filesList appends the `.ts` extension to every entry in `names`, keeping the
+// tsconfig `files` array in step with the fixture written to disk.
+func filesList(names []string) []string {
+  out := make([]string, len(names))
+  for i, name := range names {
+    out[i] = name + ".ts"
+  }
+  return out
+}


### PR DESCRIPTION
## Intent

Issue #103, Commit 1 — standalone. `ttsc` and `@ttsc/lint` constructed every
TypeScript-Go `Program` with `SingleThreaded: TSTrue`, disabling **all** of
TypeScript-Go's concurrency: parallel parsing, the pooled checker, parallel
bind/semantic diagnostics, and parallel emit. The flag was inherited verbatim
from the first commit and never revisited.

## Change

- Remove `SingleThreaded` from the two `ProgramOptions` (`driver/program.go`,
  `linthost/host.go`) so the program runs on TypeScript-Go's multi-threaded
  default.
- `driver.emit()` now serializes its whole `WriteFile` callback under a mutex:
  parallel emit invokes it once per file concurrently, and the `cursors` map
  would otherwise trip `fatal error: concurrent map writes`. The patch work is
  cheap, so serializing just the callback costs ~nothing while parse/check/
  emit-text generation parallelize.

The phases ttsc layers on top — plugin application, the output rewriter, the
(still serial) lint engine walk — keep using a single pooled checker, valid
against the larger pool because TypeScript-Go fans out only *inside* each
phase. `EmittedFiles` ordering is unaffected (`CombineEmitResults` reassembles
per-emitter results in source order). `ttscserver` is not touched — it
delegates to a spawned `tsgo --lsp --stdio`.

## Scope

This is **only Commit 1** of #103. The CLI work (`--singleThreaded` /
`--checkers` knobs, tsgo-flag forwarding) is split into a follow-up PR that
stacks on this one. The lint-engine and plugin-traverse parallelism
(Commits 2-3) remain separate, later work.

## Test plan

- New `emit_rewrites_every_source_under_parallel_emit_test.go` emits a
  four-source project so multiple emitter goroutines exercise the `WriteFile`
  callback concurrently. Verified that, with the mutex removed, `go test -race`
  reports `DATA RACE`; with it in place the test passes under `-race`.
- `go build` / `go vet` clean; full `go test ./...` green for `packages/ttsc`.
- CI (`test.yml` + `typia.yml`) gates this PR.

Refs #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)