### PR TITLE
feat(website): performance benchmark and a little bit optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ go.work.sum
 experimental/typia/
 experimental/nestia/
 
+# Benchmark results — an ephemeral artifact, never committed.
+experimental/benchmark/.work/
+
 # Stray native sanity binary from `go build ./cmd/ttsc-wasm` (host build).
 packages/wasm/ttsc-wasm
 

--- a/experimental/benchmark/README.md
+++ b/experimental/benchmark/README.md
@@ -9,6 +9,7 @@ Wall-clock benchmark comparing the legacy TypeScript toolchain against the
 | **B1** Build | type-check + emit | `tsc` | `ttsc` |
 | **B2** Format | format the `src` tree | `prettier` | `ttsc format` |
 | **B3** Build + lint | build then lint | `tsc` + `eslint` | `ttsc` + `@ttsc/lint` |
+| **B4** Threading | ttsc build, serial vs parallel | `ttsc --singleThreaded` | `ttsc` (default) |
 
 The headline of B3 is architectural: `eslint` is a second process that re-parses
 the project, while `@ttsc/lint` folds linting into the single `ttsc` compile
@@ -62,9 +63,11 @@ like-for-like comparison.
 ## Run
 
 ```bash
-node bench.mjs            # all groups
-node bench.mjs b1 b2      # selected groups; results accumulate on disk
+node bench.mjs            # all groups (b1 b2 b3 b4)
+node bench.mjs b1 b4      # selected groups; results accumulate on disk
 ```
+
+The report is written to `.work/report.md` — a **git-ignored** directory; benchmark results are an ephemeral artifact and are never committed.
 
 Environment overrides:
 
@@ -74,7 +77,7 @@ Environment overrides:
 | `TTSC_BENCH_RUNS` | `3` | measured runs per command |
 | `TTSC_BENCH_WARMUP` | `1` | warmup runs per command |
 | `TTSC_BENCH_RETRIES` | `3` | retries to recover a crashed run |
-| `TTSC_BENCH_OUT` | `report.md` | report destination (`.md` + `.json`) |
+| `TTSC_BENCH_OUT` | `.work/report.md` | report destination (`.md` + `.json`) |
 
 ## Method
 

--- a/experimental/benchmark/README.md
+++ b/experimental/benchmark/README.md
@@ -1,92 +1,121 @@
-# ttsc benchmark
+# ttsc matrix benchmark
 
-Wall-clock benchmark comparing the legacy TypeScript toolchain against the
-`ttsc` toolchain on a real backend codebase ([`shopping-backend`](https://github.com/samchon/shopping-backend),
-~640 TypeScript files).
+A clone-based, reproducible benchmark of the `ttsc` toolchain against the stock
+TypeScript toolchain, run as a **matrix** over many real-world TypeScript
+projects.
 
-| Group | What it compares | Legacy | ttsc |
-| --- | --- | --- | --- |
-| **B1** Build | type-check + emit | `tsc` | `ttsc` |
-| **B2** Format | format the `src` tree | `prettier` | `ttsc format` |
-| **B3** Build + lint | build then lint | `tsc` + `eslint` | `ttsc` + `@ttsc/lint` |
-| **B4** Threading | ttsc build, serial vs parallel | `ttsc --singleThreaded` | `ttsc` (default) |
+`bench.mjs` clones each fixture project's forked repo, installs the locally
+built `ttsc` / `@ttsc/lint` tarballs, and measures wall-clock build time across
+a grid of toolchain configurations. Nothing is hand-prepared — a run is
+reproducible from a clean checkout.
 
-The headline of B3 is architectural: `eslint` is a second process that re-parses
-the project, while `@ttsc/lint` folds linting into the single `ttsc` compile
-pass — so `ttsc` build:main *is* build + lint.
+## The matrix
+
+Every fixture is a forked repo with three branches:
+
+| Branch | Toolchain |
+| --- | --- |
+| `legacy` | stock `tsc` (TypeScript 5.x) · `prettier` · `eslint` |
+| `ttsc` | `ttsc` (TypeScript 7 via `@typescript/native-preview`) |
+| `ttsc-lint` | `ttsc` + `@ttsc/lint` (linting folded into the compile pass) |
+
+Each `(project × branch)` is measured along two more dimensions:
+
+| Dimension | Values |
+| --- | --- |
+| Emit | **emit build** (type-check + emit) · **`--noEmit`** (type-check only) |
+| Threading | **multi-threaded** (ttsc default) · **single-threaded** (`--singleThreaded`) |
+
+The `legacy` branch is measured multi-threaded only — stock `tsc` has no
+`--singleThreaded`. The `ttsc` / `ttsc-lint` branches are measured both ways.
+
+The report has three sections:
+
+- **M1 — Emit build**: `tsc` vs `ttsc` vs `ttsc + @ttsc/lint`. Reports the
+  `tsc → ttsc` speedup and the *lint cost* (`ttsc-lint` over plain `ttsc` — the
+  marginal cost of folding linting into the compile pass).
+- **M2 — Type-check only**: the same input under `--noEmit`, isolating checker
+  speed from emit cost.
+- **M3 — Threading**: single-threaded vs multi-threaded `ttsc`.
 
 ## Fixtures
 
-Three variants of `shopping-backend` live next to this repository, under
-`../nestia.examples/` (sibling of the `ttsc` checkout):
+| Project | Repo | Kind | Measured command | Notes |
+| --- | --- | --- | --- | --- |
+| `shopping-backend` | `samchon/shopping-backend` | plugin-heavy | `tsc` / `ttsc` (build:main) | nestia/typia source plugins on every file; needs `build:prisma` + `build:sdk` first |
+| `tstl` | `samchon/tstl` | plugin-free | `tsc` / `ttsc` | STL/algorithms library; small anchor |
+| `zod` | `samchon/ttsc-benchmark-zod` | plugin-free | `tsc -p tsconfig.benchmark.json` | schema-validation library; built from `packages/zod` |
+| `rxjs` | `samchon/ttsc-benchmark-rxjs` | plugin-free | `tsc -p tsconfig.bench.json` | reactive-streams library; yarn/nx monorepo, built from `packages/rxjs` |
+| `type-fest` | `samchon/ttsc-benchmark-type-fest` | plugin-free | `tsc` (`noEmit`) | pure type-level library — type-check only, no emit cell |
+| `vue` | `samchon/ttsc-benchmark-vue` | plugin-free | `tsc --noEmit` | frontend framework; type-check only (`ttsc-lint` branch TBD) |
+| `nestjs` | `samchon/ttsc-benchmark-nestjs` | plugin-free | `tsc -b packages` / `build-ttsc.mjs` | project-references monorepo; emit build only (the orchestrator exposes no `--noEmit` / `--singleThreaded`) |
 
-| Project | TypeScript | Toolchain |
-| --- | --- | --- |
-| `shopping-backend@legacy` | 5.x | `tsc` · `prettier` · `eslint` (ts-patch) |
-| `shopping-backend@next` | 7.x | `ttsc` |
-| `shopping-backend@experiment` | 7.x | `ttsc` · `@ttsc/lint` (lint + format configured) |
+`samchon/ttsc-benchmark-vscode` is a planned fixture; its branches are not
+pushed yet, so it is left as a `TODO` in `bench.mjs` and skipped at runtime.
 
-The three carry an identical source tree. `@experiment` ships a `lint.config.ts`
-and `@legacy` an `eslint.config.mjs` configured with the **same 12 lint rules**
-(`no-var`, `prefer-const`, `eqeqeq`, `object-shorthand`, `no-unneeded-ternary`,
-`prefer-template`, `no-useless-rename`, `dot-notation`, `no-extra-boolean-cast`,
-`no-useless-escape`, `prefer-as-const`, `prefer-namespace-keyword`) so B3 is a
-like-for-like comparison.
-
-## Setup
-
-1. **Build `ttsc` tarballs from this repo** and place them where the fixtures
-   expect them (`/tmp/ttsc-tgz/`):
-
-   ```bash
-   corepack enable
-   pnpm install
-   pnpm run build:current
-   pnpm --dir packages/ttsc          pack --out /tmp/ttsc-tgz/ttsc-0.12.4.tgz
-   pnpm --dir packages/ttsc-linux-x64 pack --out /tmp/ttsc-tgz/ttsc-linux-x64-0.12.4.tgz
-   pnpm --dir packages/lint          pack --out /tmp/ttsc-tgz/ttsc-lint-0.12.4.tgz
-   ```
-
-   `@next`/`@experiment` reference `ttsc` (and `@ttsc/lint`) from those tarballs
-   and pin the local platform package through `pnpm.overrides`.
-
-2. **Install the fixtures** (`pnpm install` in each of the three projects).
-
-3. **Generate prerequisites** in each project — the Prisma client and the
-   nestia SDK that `build:main`/`build:test` type-check against:
-
-   ```bash
-   npm run build:prisma
-   npm run build:sdk
-   ```
+The per-project build commands, prerequisites, and supported modes live in the
+`PROJECTS` config table at the top of `bench.mjs`. Run `node bench.mjs --list`
+to print it.
 
 ## Run
 
 ```bash
-node bench.mjs            # all groups (b1 b2 b3 b4)
-node bench.mjs b1 b4      # selected groups; results accumulate on disk
+node bench.mjs                 # all fixtures: clone, install, measure
+node bench.mjs tstl zod        # selected fixtures only
+node bench.mjs --list          # print the config table and exit
+node bench.mjs --setup-only    # clone + install, no measuring
+node bench.mjs --no-setup      # measure only (reuse existing clones)
 ```
 
-The report is written to `.work/report.md` — a **git-ignored** directory; benchmark results are an ephemeral artifact and are never committed.
+The first run builds and packs the local `ttsc` / `@ttsc/lint` /
+current-platform tarballs into `/tmp/ttsc-tgz/`, clones every fixture branch
+into `/tmp/ttsc-bench-work/`, installs each clone, runs `ttsc prepare` on the
+`ttsc` / `ttsc-lint` clones, and runs each project's prerequisites — then
+measures the matrix.
 
-Environment overrides:
+Clones live **outside** the repo tree: cloning inside `ttsc` would let pnpm
+adopt the clone into the `ttsc` workspace. Each clone also gets a stray
+`pnpm-workspace.yaml` so it stays an isolated workspace regardless of location.
 
-| Variable | Default | Meaning |
-| --- | --- | --- |
-| `TTSC_BENCH_EXAMPLES` | `../../../nestia.examples` | fixtures directory |
-| `TTSC_BENCH_RUNS` | `3` | measured runs per command |
-| `TTSC_BENCH_WARMUP` | `1` | warmup runs per command |
-| `TTSC_BENCH_RETRIES` | `3` | retries to recover a crashed run |
-| `TTSC_BENCH_OUT` | `.work/report.md` | report destination (`.md` + `.json`) |
+A fork branch that is not pushed yet is skipped cleanly — the run does not
+crash.
+
+## Output
+
+The report — a Markdown matrix plus a `.json` sidecar — is written to
+`.work/` next to this script. `.work/` is **git-ignored**: benchmark results are
+an ephemeral artifact and are never committed.
+
+The report opens with a **Host** block recording OS name + kernel, CPU model +
+core count, total RAM, and toolchain versions (node, `ttsc`,
+`@typescript/native-preview`, `tsc`), so a number is always traceable to the
+machine that produced it.
+
+Results merge into the existing `.json`, so fixtures can be measured across
+separate invocations and still report as one matrix.
 
 ## Method
 
-Each command runs `WARMUP` unmeasured times (absorbs first-run plugin
+Each matrix cell runs `WARMUP` unmeasured times (absorbs first-run plugin
 compilation and cold filesystem cache), then `RUNS` measured times; the
-**median** is reported. A measured run that exits non-zero is retried up to
-`RETRIES` times so the timing sample stays valid, and the crash count is
-reported separately — keeping an orthogonal stability bug out of the speed
-numbers.
+**median** is reported. Single-threaded cells re-clean their output directory
+before every run so each timing starts from the same state.
 
-`bench.mjs` writes a Markdown report and a `.json` sidecar; partial invocations
-merge into the existing `.json`, so groups can be measured independently.
+A measured run that exits non-zero is classified from its output: a `race`
+failure (the intermittent TypeScript-Go data-race crash) is retried up to
+`RETRIES` times and the clean timing kept; a deterministic `error` (a real
+compile error) is not retried and the cell is left unmeasured. Both are
+reported in a **Stability** section, keeping an orthogonal stability bug out of
+the speed numbers.
+
+## Environment overrides
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `TTSC_BENCH_WORK` | `/tmp/ttsc-bench-work` | clone working directory |
+| `TTSC_BENCH_TGZ` | `/tmp/ttsc-tgz` | tarball staging directory |
+| `TTSC_BENCH_OUT` | `.work/report.md` | report destination (`.md` + `.json`) |
+| `TTSC_BENCH_RUNS` | `3` | measured runs per cell |
+| `TTSC_BENCH_WARMUP` | `1` | warmup runs per cell |
+| `TTSC_BENCH_RETRIES` | `3` | retries to recover a crashed run |
+| `TTSC_BENCH_SKIP_PACK` | — | set to `1` to reuse existing tarballs |

--- a/experimental/benchmark/README.md
+++ b/experimental/benchmark/README.md
@@ -1,0 +1,89 @@
+# ttsc benchmark
+
+Wall-clock benchmark comparing the legacy TypeScript toolchain against the
+`ttsc` toolchain on a real backend codebase ([`shopping-backend`](https://github.com/samchon/shopping-backend),
+~640 TypeScript files).
+
+| Group | What it compares | Legacy | ttsc |
+| --- | --- | --- | --- |
+| **B1** Build | type-check + emit | `tsc` | `ttsc` |
+| **B2** Format | format the `src` tree | `prettier` | `ttsc format` |
+| **B3** Build + lint | build then lint | `tsc` + `eslint` | `ttsc` + `@ttsc/lint` |
+
+The headline of B3 is architectural: `eslint` is a second process that re-parses
+the project, while `@ttsc/lint` folds linting into the single `ttsc` compile
+pass — so `ttsc` build:main *is* build + lint.
+
+## Fixtures
+
+Three variants of `shopping-backend` live next to this repository, under
+`../nestia.examples/` (sibling of the `ttsc` checkout):
+
+| Project | TypeScript | Toolchain |
+| --- | --- | --- |
+| `shopping-backend@legacy` | 5.x | `tsc` · `prettier` · `eslint` (ts-patch) |
+| `shopping-backend@next` | 7.x | `ttsc` |
+| `shopping-backend@experiment` | 7.x | `ttsc` · `@ttsc/lint` (lint + format configured) |
+
+The three carry an identical source tree. `@experiment` ships a `lint.config.ts`
+and `@legacy` an `eslint.config.mjs` configured with the **same 12 lint rules**
+(`no-var`, `prefer-const`, `eqeqeq`, `object-shorthand`, `no-unneeded-ternary`,
+`prefer-template`, `no-useless-rename`, `dot-notation`, `no-extra-boolean-cast`,
+`no-useless-escape`, `prefer-as-const`, `prefer-namespace-keyword`) so B3 is a
+like-for-like comparison.
+
+## Setup
+
+1. **Build `ttsc` tarballs from this repo** and place them where the fixtures
+   expect them (`/tmp/ttsc-tgz/`):
+
+   ```bash
+   corepack enable
+   pnpm install
+   pnpm run build:current
+   pnpm --dir packages/ttsc          pack --out /tmp/ttsc-tgz/ttsc-0.12.4.tgz
+   pnpm --dir packages/ttsc-linux-x64 pack --out /tmp/ttsc-tgz/ttsc-linux-x64-0.12.4.tgz
+   pnpm --dir packages/lint          pack --out /tmp/ttsc-tgz/ttsc-lint-0.12.4.tgz
+   ```
+
+   `@next`/`@experiment` reference `ttsc` (and `@ttsc/lint`) from those tarballs
+   and pin the local platform package through `pnpm.overrides`.
+
+2. **Install the fixtures** (`pnpm install` in each of the three projects).
+
+3. **Generate prerequisites** in each project — the Prisma client and the
+   nestia SDK that `build:main`/`build:test` type-check against:
+
+   ```bash
+   npm run build:prisma
+   npm run build:sdk
+   ```
+
+## Run
+
+```bash
+node bench.mjs            # all groups
+node bench.mjs b1 b2      # selected groups; results accumulate on disk
+```
+
+Environment overrides:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `TTSC_BENCH_EXAMPLES` | `../../../nestia.examples` | fixtures directory |
+| `TTSC_BENCH_RUNS` | `3` | measured runs per command |
+| `TTSC_BENCH_WARMUP` | `1` | warmup runs per command |
+| `TTSC_BENCH_RETRIES` | `3` | retries to recover a crashed run |
+| `TTSC_BENCH_OUT` | `report.md` | report destination (`.md` + `.json`) |
+
+## Method
+
+Each command runs `WARMUP` unmeasured times (absorbs first-run plugin
+compilation and cold filesystem cache), then `RUNS` measured times; the
+**median** is reported. A measured run that exits non-zero is retried up to
+`RETRIES` times so the timing sample stays valid, and the crash count is
+reported separately — keeping an orthogonal stability bug out of the speed
+numbers.
+
+`bench.mjs` writes a Markdown report and a `.json` sidecar; partial invocations
+merge into the existing `.json`, so groups can be measured independently.

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -19,6 +19,7 @@
  * - `node bench.mjs --project=type-fest --ttsc-build-only`
  * - `node bench.mjs --project=type-fest --only-ttsc-build --reset`
  * - `node bench.mjs --project=type-fest --only-ttsc-build --no-website`
+ * - `node bench.mjs --project=type-fest --lint-only`
  * - `node bench.mjs --cell-filter=':ttsc:build:' vue type-fest`
  */
 import { spawnSync } from "node:child_process";
@@ -1418,6 +1419,9 @@ function filterCells(cells) {
         cell.branch === "ttsc" && cell.op === "build" && cell.tool !== "tsgo",
     );
   }
+  if (flags.has("--lint-only")) {
+    predicates.push(isLintComparisonCell);
+  }
   for (const filter of cellFilters) {
     predicates.push((cell) => filter.test(cell.id));
   }
@@ -1425,4 +1429,12 @@ function filterCells(cells) {
   return cells.filter((cell) =>
     predicates.some((predicate) => predicate(cell)),
   );
+}
+
+function isLintComparisonCell(cell) {
+  if (cell.branch === "legacy")
+    return cell.op === "noEmit" || cell.op === "eslint";
+  if (cell.branch === "ttsc")
+    return cell.op === "noEmit" && cell.tool !== "tsgo";
+  return cell.branch === "ttsc-lint" && cell.op === "noEmit";
 }

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -35,8 +35,10 @@
  *      ttsc workspace) — default /tmp/ttsc-bench-work/;
  *   3. `pnpm install` each clone; `ttsc prepare` the ttsc / ttsc-lint clones;
  *      run each project's prerequisites (e.g. shopping-backend build:prisma);
- *   4. measure the matrix; write a Markdown report + JSON sidecar into the
- *      git-ignored `.work/` directory.
+ *   4. measure the matrix; write a Markdown report + raw JSON sidecar into the
+ *      git-ignored `.work/` directory, AND the canonical, committed result file
+ *      `website/public/benchmark.json` (the schema the website dashboard
+ *      renders — locked by `website/src/components/benchmark/types.ts`).
  *
  * Usage:
  *   node bench.mjs [projects...]            # e.g. `node bench.mjs tstl zod`
@@ -67,6 +69,14 @@ const TGZ = process.env.TTSC_BENCH_TGZ ?? path.join(os.tmpdir(), "ttsc-tgz");
 const OUT =
   process.env.TTSC_BENCH_OUT ??
   path.resolve(import.meta.dirname, ".work", "report.md");
+// The canonical, committed, served result file. The website dashboard fetches
+// this; its schema is locked by website/src/components/benchmark/types.ts.
+const WEBSITE_JSON = path.resolve(
+  REPO_ROOT,
+  "website",
+  "public",
+  "benchmark.json",
+);
 const RUNS = Number(process.env.TTSC_BENCH_RUNS ?? 3);
 const WARMUP = Number(process.env.TTSC_BENCH_WARMUP ?? 1);
 const RETRIES = Number(process.env.TTSC_BENCH_RETRIES ?? 3);
@@ -212,15 +222,17 @@ const PROJECTS = {
   vue: {
     repo: "https://github.com/samchon/ttsc-benchmark-vue.git",
     kind: "plugin-free",
-    // TODO: ttsc-lint branch not pushed yet — see issue #118 fixture work.
-    branches: ["legacy", "ttsc"],
+    branches: ["legacy", "ttsc", "ttsc-lint"],
     prerequisites: [],
     cases: [
       {
+        // vue's tsconfig is `noEmit` (vue ships JS via rollup), so the measured
+        // op is a pure `--noEmit` type-check. `emit: false` keeps it out of the
+        // M1 emit-build comparison; the `mt`/`st` cells ARE the type-check cells.
         name: "check",
         emit: false,
         singleThreaded: true,
-        legacy: { build: "pnpm exec tsc --incremental --noEmit" },
+        legacy: { build: "pnpm exec tsc --noEmit" },
         ttsc: { build: "pnpm exec ttsc --noEmit" },
       },
     ],
@@ -554,10 +566,15 @@ function depVersion(fromDir, pkg) {
 }
 
 /**
- * Collect the host machine spec + toolchain versions for the report header.
- * `tsgo`/`tsc` resolve from the fixture clones (that is where the compilers are
- * installed); `tsgo` reads `@typescript/native-preview` from a `ttsc` clone and
- * `tsc` reads `typescript` from a `legacy` clone.
+ * Collect the host machine spec + toolchain versions for the report.
+ *
+ * The returned object is the canonical `BenchmarkHost` shape consumed by the
+ * website dashboard (`os`, `kernel`, `cpu`, `cores`, `ramGB`, `node`, `ttsc`,
+ * `typescript`) plus a `tsgo` extra used only by the Markdown report header.
+ *
+ * `typescript`/`tsgo` resolve from the fixture clones (that is where the
+ * compilers are installed): `typescript` reads `typescript` from a `legacy`
+ * clone, `tsgo` reads `@typescript/native-preview` from a `ttsc` clone.
  */
 function hostSpec(wantedProjectsList) {
   const cpu = os.cpus();
@@ -565,7 +582,7 @@ function hostSpec(wantedProjectsList) {
   try {
     const rel = fs.readFileSync("/etc/os-release", "utf8");
     const pretty = rel.match(/^PRETTY_NAME="?([^"\n]+)"?/m);
-    if (pretty) osName = `${pretty[1]} (kernel ${os.release()})`;
+    if (pretty) osName = pretty[1];
   } catch {
     /* not Linux — keep os.type()/os.release() */
   }
@@ -580,12 +597,134 @@ function hostSpec(wantedProjectsList) {
   }
   return {
     os: osName,
-    cpu: `${cpu.length}× ${cpu[0]?.model?.trim() ?? "unknown"}`,
-    ram: `${(os.totalmem() / 2 ** 30).toFixed(0)} GB`,
+    kernel: os.release(),
+    cpu: cpu[0]?.model?.trim() ?? "unknown",
+    cores: cpu.length,
+    ramGB: Math.round(os.totalmem() / 2 ** 30),
     node: process.version,
     ttsc: TTSC_VERSION,
+    typescript: tsc ?? "—",
     tsgo: tsgo ?? "—",
-    tsc: tsc ?? "—",
+  };
+}
+
+// ── canonical website JSON ───────────────────────────────────────────────────
+
+/**
+ * Count the project's own TypeScript source files in a clone — `.ts` / `.tsx` /
+ * `.mts` / `.cts`, excluding `node_modules`, declaration files, and dist/build
+ * output. This is the `files` figure shown on each website project card; it is
+ * an approximate project-size signal, not the exact compiler input set.
+ */
+function countSourceFiles(dir) {
+  if (!dir || !fs.existsSync(dir)) return 0;
+  const SKIP = new Set([
+    "node_modules",
+    ".git",
+    "dist",
+    "lib",
+    "out",
+    "build",
+    "coverage",
+  ]);
+  let count = 0;
+  const walk = (d) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        if (!SKIP.has(e.name)) walk(path.join(d, e.name));
+      } else if (
+        /\.(ts|tsx|mts|cts)$/.test(e.name) &&
+        !/\.d\.(ts|mts|cts)$/.test(e.name)
+      ) {
+        count++;
+      }
+    }
+  };
+  walk(dir);
+  return count;
+}
+
+/**
+ * Project the runner's internal `project|branch|case|mode` result map into the
+ * canonical `BenchmarkReport` shape served at `website/public/benchmark.json`
+ * and consumed by `website/src/components/benchmark/types.ts`.
+ *
+ * The mapping is mechanical:
+ *
+ *   - branch `legacy` → `tool: "tsc"`; `ttsc`/`ttsc-lint` → `tool: "ttsc"`.
+ *   - mode `mt`/`st` carry `threading` multi/single; the `op` is `build` for an
+ *     emit case and `noEmit` for a type-check-only case.
+ *   - modes `noEmit`/`st-noEmit` are always `op: "noEmit"` at the matching
+ *     threading.
+ *
+ * `format` measurements are not produced by the current matrix (the runner has
+ * no prettier / `@ttsc/lint` format case wired); the website schema keeps the
+ * `format` op for when such a case lands, and the dashboard simply skips it.
+ */
+function buildWebsiteReport(results, started, host) {
+  const projects = [];
+  for (const project of wantedProjects) {
+    const cfg = PROJECTS[project];
+    // First clone that exists on disk gives the source-file count.
+    const filesDir = cfg.branches
+      .map((b) => cloneDir(project, b))
+      .find((d) => fs.existsSync(d));
+    const measurements = [];
+    const push = (branch, op, threading, cell) => {
+      if (!cell) return;
+      const m = {
+        branch,
+        tool: branch === "legacy" ? "tsc" : "ttsc",
+        op,
+        threading,
+        medianMs: cell.median ?? 0,
+      };
+      if (cell.min != null) m.minMs = cell.min;
+      if (cell.samples?.length) m.samples = cell.samples;
+      if (cell.raceRetries) m.raceRetries = cell.raceRetries;
+      if (cell.deterministicFailure)
+        m.failure = cell.deterministicFailure.kind;
+      measurements.push(m);
+    };
+    for (const c of cfg.cases) {
+      for (const branch of cfg.branches) {
+        const cell = (mode) => results[`${project}|${branch}|${c.name}|${mode}`];
+        // `mt`/`st` carry the case's primary op (build for an emit case,
+        // noEmit for a type-check-only case).
+        const primaryOp = c.emit ? "build" : "noEmit";
+        push(branch, primaryOp, "multi", cell("mt"));
+        push(branch, primaryOp, "single", cell("st"));
+        // The dedicated type-check-only cells are always `noEmit`.
+        push(branch, "noEmit", "multi", cell("noEmit"));
+        push(branch, "noEmit", "single", cell("st-noEmit"));
+      }
+    }
+    projects.push({
+      name: project,
+      files: countSourceFiles(filesDir),
+      kind: cfg.kind,
+      measurements,
+    });
+  }
+  return {
+    date: started.toISOString(),
+    host: {
+      os: host.os,
+      kernel: host.kernel,
+      cpu: host.cpu,
+      cores: host.cores,
+      ramGB: host.ramGB,
+      node: host.node,
+      ttsc: host.ttsc,
+      typescript: host.typescript,
+    },
+    projects,
   };
 }
 
@@ -612,13 +751,13 @@ function buildReport(results, started, host) {
   L.push("");
   L.push(`| Field | Value |`);
   L.push(`| --- | --- |`);
-  L.push(`| OS | ${host.os} |`);
-  L.push(`| CPU | ${host.cpu} |`);
-  L.push(`| RAM | ${host.ram} |`);
+  L.push(`| OS | ${host.os} (kernel ${host.kernel}) |`);
+  L.push(`| CPU | ${host.cores}× ${host.cpu} |`);
+  L.push(`| RAM | ${host.ramGB} GB |`);
   L.push(`| node | ${host.node} |`);
   L.push(`| ttsc | ${host.ttsc} |`);
   L.push(`| @typescript/native-preview (tsgo) | ${host.tsgo} |`);
-  L.push(`| tsc | ${host.tsc} |`);
+  L.push(`| tsc | ${host.typescript} |`);
   L.push("");
   L.push(
     `- Method: ${WARMUP} warmup + ${RUNS} measured runs per cell; median ` +
@@ -871,7 +1010,20 @@ function main() {
     jsonPath,
     JSON.stringify({ started, host, results }, null, 2),
   );
-  process.stdout.write(`\n${report}\n\nReport written to ${OUT}\n`);
+
+  // Canonical website result — the published, committed, served file. Written
+  // straight to website/public/benchmark.json so a run needs no manual step.
+  const websiteReport = buildWebsiteReport(results, started, host);
+  fs.mkdirSync(path.dirname(WEBSITE_JSON), { recursive: true });
+  fs.writeFileSync(
+    WEBSITE_JSON,
+    JSON.stringify(websiteReport, null, 2) + "\n",
+  );
+
+  process.stdout.write(
+    `\n${report}\n\nReport written to ${OUT}\n` +
+      `Website result written to ${WEBSITE_JSON}\n`,
+  );
 }
 
 main();

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -13,11 +13,12 @@
  *
  * Useful modes:
  *
- * node bench.mjs --setup-only
- * node bench.mjs --verify-only
- * node bench.mjs --project vue --project type-fest
- * node bench.mjs --project=type-fest --ttsc-build-only --fresh
- * node bench.mjs --cell-filter=':ttsc:build:' vue type-fest
+ * - `node bench.mjs --setup-only`
+ * - `node bench.mjs --verify-only`
+ * - `node bench.mjs --project vue --project type-fest`
+ * - `node bench.mjs --project=type-fest --ttsc-build-only --fresh`
+ * - `node bench.mjs --project=type-fest --only-ttsc-build --fresh`
+ * - `node bench.mjs --cell-filter=':ttsc:build:' vue type-fest`
  */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
@@ -290,7 +291,8 @@ function parseCliArgs(args) {
       parsedCellFilters.push(new RegExp(value));
     } else if (arg.startsWith("--cell-filter=")) {
       const value = arg.slice("--cell-filter=".length);
-      if (!value) throw new Error("--cell-filter requires a regular expression");
+      if (!value)
+        throw new Error("--cell-filter requires a regular expression");
       parsedCellFilters.push(new RegExp(value));
     } else if (arg.startsWith("--")) {
       parsedFlags.add(arg);
@@ -1236,7 +1238,7 @@ function projectCells(project) {
 
 function filterCells(cells) {
   const predicates = [];
-  if (flags.has("--ttsc-build-only")) {
+  if (flags.has("--ttsc-build-only") || flags.has("--only-ttsc-build")) {
     predicates.push(
       (cell) =>
         cell.branch === "ttsc" && cell.op === "build" && cell.tool !== "tsgo",
@@ -1246,5 +1248,7 @@ function filterCells(cells) {
     predicates.push((cell) => filter.test(cell.id));
   }
   if (predicates.length === 0) return cells;
-  return cells.filter((cell) => predicates.some((predicate) => predicate(cell)));
+  return cells.filter((cell) =>
+    predicates.some((predicate) => predicate(cell)),
+  );
 }

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * ttsc benchmark runner.
+ *
+ * Measures wall-clock time of build / format / lint commands across three
+ * shopping-backend variants and emits a Markdown report:
+ *
+ *   - shopping-backend@legacy      TypeScript 5.x  · tsc · prettier · eslint
+ *   - shopping-backend@next        TypeScript 7.x  · ttsc
+ *   - shopping-backend@experiment  TypeScript 7.x  · ttsc · @ttsc/lint (+format)
+ *
+ * Benchmark groups:
+ *
+ *   B1  build speed   legacy(tsc)      vs  next(ttsc)         — build:main, build:test
+ *   B2  format speed  legacy(prettier) vs  experiment(format) — whole src tree
+ *   B3  build+lint    legacy(tsc+eslint) vs experiment(ttsc+@ttsc/lint)
+ *
+ * Each measurement does WARMUP unmeasured runs, then RUNS measured runs, and
+ * reports the median. A measured run that exits non-zero (e.g. the intermittent
+ * @nestia/core parallel-emit crash) is retried up to RETRIES times so the timing
+ * sample stays valid; the crash count is reported separately.
+ *
+ * Usage:
+ *   node bench.mjs [groups...]      # e.g. `node bench.mjs b1 b2`, default: all
+ *   TTSC_BENCH_EXAMPLES=/path       # override the nestia.examples directory
+ *   TTSC_BENCH_RUNS=3               # measured runs per command
+ *   TTSC_BENCH_WARMUP=1             # warmup runs per command
+ *   TTSC_BENCH_RETRIES=3            # retries to recover from a crashed run
+ *   TTSC_BENCH_OUT=/path/report.md  # report destination
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const EXAMPLES =
+  process.env.TTSC_BENCH_EXAMPLES ??
+  path.resolve(import.meta.dirname, "../../../nestia.examples");
+const RUNS = Number(process.env.TTSC_BENCH_RUNS ?? 3);
+const WARMUP = Number(process.env.TTSC_BENCH_WARMUP ?? 1);
+const RETRIES = Number(process.env.TTSC_BENCH_RETRIES ?? 3);
+const OUT =
+  process.env.TTSC_BENCH_OUT ??
+  path.resolve(import.meta.dirname, "report.md");
+
+const PROJECTS = {
+  legacy: path.join(EXAMPLES, "shopping-backend@legacy"),
+  next: path.join(EXAMPLES, "shopping-backend@next"),
+  experiment: path.join(EXAMPLES, "shopping-backend@experiment"),
+};
+
+/**
+ * Every distinct (project, command) measured once. `key` is referenced by the
+ * report tables; `crashy` marks commands subject to the parallel-emit race.
+ */
+const CASES = [
+  { key: "legacy:build:main", project: "legacy", cmd: "pnpm run build:main" },
+  { key: "legacy:build:test", project: "legacy", cmd: "pnpm run build:test" },
+  { key: "next:build:main", project: "next", cmd: "pnpm run build:main", crashy: true },
+  { key: "next:build:test", project: "next", cmd: "pnpm run build:test", crashy: true },
+  { key: "legacy:prettier", project: "legacy", cmd: "pnpm exec prettier src --write" },
+  { key: "experiment:format", project: "experiment", cmd: "pnpm exec ttsc format", crashy: true },
+  { key: "legacy:eslint:src", project: "legacy", cmd: "pnpm exec eslint src" },
+  { key: "legacy:eslint:test", project: "legacy", cmd: "pnpm exec eslint test" },
+  { key: "experiment:build:main", project: "experiment", cmd: "pnpm run build:main", crashy: true },
+  { key: "experiment:build:test", project: "experiment", cmd: "pnpm run build:test", crashy: true },
+];
+
+const GROUPS = {
+  b1: ["legacy:build:main", "legacy:build:test", "next:build:main", "next:build:test"],
+  b2: ["legacy:prettier", "experiment:format"],
+  b3: [
+    "legacy:build:main", "legacy:build:test", "legacy:eslint:src",
+    "legacy:eslint:test", "experiment:build:main", "experiment:build:test",
+  ],
+};
+
+const wanted = process.argv.slice(2).map((s) => s.toLowerCase());
+const activeGroups = wanted.length
+  ? wanted.filter((g) => GROUPS[g])
+  : Object.keys(GROUPS);
+const activeKeys = new Set(activeGroups.flatMap((g) => GROUPS[g]));
+
+function runOnce(cwd, cmd) {
+  const t0 = process.hrtime.bigint();
+  const res = spawnSync(cmd, { cwd, shell: true, encoding: "utf8" });
+  const t1 = process.hrtime.bigint();
+  return {
+    ms: Number(t1 - t0) / 1e6,
+    ok: res.status === 0,
+    status: res.status,
+    log: `${res.stdout ?? ""}${res.stderr ?? ""}`,
+  };
+}
+
+function median(xs) {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = s.length >> 1;
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+function measure(c) {
+  const cwd = PROJECTS[c.project];
+  process.stdout.write(`\n▶ ${c.key}\n  ${c.cmd}\n`);
+  for (let i = 0; i < WARMUP; i++) {
+    const w = runOnce(cwd, c.cmd);
+    process.stdout.write(`  warmup ${i + 1}: ${w.ms.toFixed(0)} ms ${w.ok ? "ok" : `EXIT ${w.status}`}\n`);
+  }
+  const samples = [];
+  let crashes = 0;
+  for (let i = 0; i < RUNS; i++) {
+    let r = runOnce(cwd, c.cmd);
+    let attempts = 0;
+    while (!r.ok && attempts < RETRIES) {
+      crashes++;
+      attempts++;
+      process.stdout.write(`  run ${i + 1}: EXIT ${r.status} — retry ${attempts}\n`);
+      r = runOnce(cwd, c.cmd);
+    }
+    if (!r.ok) {
+      process.stdout.write(`  run ${i + 1}: still failing after ${RETRIES} retries — skipped\n`);
+      continue;
+    }
+    samples.push(r.ms);
+    process.stdout.write(`  run ${i + 1}: ${r.ms.toFixed(0)} ms\n`);
+  }
+  return {
+    key: c.key,
+    samples,
+    crashes,
+    median: samples.length ? median(samples) : null,
+    min: samples.length ? Math.min(...samples) : null,
+  };
+}
+
+function s(ms) {
+  return ms == null ? "—" : `${(ms / 1000).toFixed(2)} s`;
+}
+function ratio(slow, fast) {
+  return slow == null || fast == null ? "—" : `${(slow / fast).toFixed(2)}×`;
+}
+
+// ── run ──────────────────────────────────────────────────────────────────────
+// Prior results are merged so groups can be measured in separate invocations
+// (e.g. `node bench.mjs b1` then `node bench.mjs b3`) and still report as one.
+const started = new Date();
+const jsonPath = OUT.replace(/\.md$/, ".json");
+let results = {};
+if (fs.existsSync(jsonPath)) {
+  try {
+    results = JSON.parse(fs.readFileSync(jsonPath, "utf8")).results ?? {};
+  } catch {
+    results = {};
+  }
+}
+for (const c of CASES) {
+  if (!activeKeys.has(c.key)) continue;
+  results[c.key] = measure(c);
+}
+const R = (k) => results[k] ?? { median: null, min: null, crashes: 0, samples: [] };
+// A group is reported when any of its measurements has data, regardless of
+// which groups were requested this invocation (results accumulate on disk).
+const hasGroup = (g) => GROUPS[g].some((k) => results[k]?.median != null);
+
+// ── report ───────────────────────────────────────────────────────────────────
+const cpu = os.cpus();
+const lines = [];
+lines.push(`# ttsc benchmark — shopping-backend`);
+lines.push("");
+lines.push(`- Date: ${started.toISOString()}`);
+lines.push(`- Host: ${os.type()} ${os.release()} · ${cpu.length}× ${cpu[0]?.model?.trim()} · ${(os.totalmem() / 2 ** 30).toFixed(0)} GB`);
+lines.push(`- Method: ${WARMUP} warmup + ${RUNS} measured runs per command; median reported. Crashed runs retried up to ${RETRIES}×.`);
+lines.push("");
+
+if (hasGroup("b1")) {
+  lines.push(`## B1 — Build speed: tsc (legacy) vs ttsc (next)`);
+  lines.push("");
+  lines.push(`| Step | legacy · tsc | next · ttsc | speedup |`);
+  lines.push(`| --- | --- | --- | --- |`);
+  for (const [step, lk, nk] of [
+    ["build:main", "legacy:build:main", "next:build:main"],
+    ["build:test", "legacy:build:test", "next:build:test"],
+  ]) {
+    lines.push(`| ${step} | ${s(R(lk).median)} | ${s(R(nk).median)} | ${ratio(R(lk).median, R(nk).median)} |`);
+  }
+  const lTot = R("legacy:build:main").median + R("legacy:build:test").median;
+  const nTot = R("next:build:main").median + R("next:build:test").median;
+  lines.push(`| **main + test** | **${s(lTot)}** | **${s(nTot)}** | **${ratio(lTot, nTot)}** |`);
+  lines.push("");
+}
+
+if (hasGroup("b2")) {
+  lines.push(`## B2 — Format speed: prettier (legacy) vs ttsc format (experiment)`);
+  lines.push("");
+  lines.push(`| Tool | command | median |`);
+  lines.push(`| --- | --- | --- |`);
+  lines.push(`| prettier | \`prettier src --write\` | ${s(R("legacy:prettier").median)} |`);
+  lines.push(`| ttsc format | \`ttsc format\` | ${s(R("experiment:format").median)} |`);
+  lines.push(`| **speedup** | | **${ratio(R("legacy:prettier").median, R("experiment:format").median)}** |`);
+  lines.push("");
+}
+
+if (hasGroup("b3")) {
+  lines.push(`## B3 — Build + lint: tsc+eslint (legacy) vs ttsc+@ttsc/lint (experiment)`);
+  lines.push("");
+  lines.push(`@ttsc/lint folds linting into the single ttsc compile pass; eslint is a separate process.`);
+  lines.push("");
+  lines.push(`| Layer | legacy (tsc + eslint) | experiment (ttsc + lint) | speedup |`);
+  lines.push(`| --- | --- | --- | --- |`);
+  const lMain = R("legacy:build:main").median + R("legacy:eslint:src").median;
+  const lTest = R("legacy:build:test").median + R("legacy:eslint:test").median;
+  lines.push(`| build:main + src lint | ${s(R("legacy:build:main").median)} + ${s(R("legacy:eslint:src").median)} = ${s(lMain)} | ${s(R("experiment:build:main").median)} | ${ratio(lMain, R("experiment:build:main").median)} |`);
+  lines.push(`| build:test + test lint | ${s(R("legacy:build:test").median)} + ${s(R("legacy:eslint:test").median)} = ${s(lTest)} | ${s(R("experiment:build:test").median)} | ${ratio(lTest, R("experiment:build:test").median)} |`);
+  lines.push(`| **total** | **${s(lMain + lTest)}** | **${s(R("experiment:build:main").median + R("experiment:build:test").median)}** | **${ratio(lMain + lTest, R("experiment:build:main").median + R("experiment:build:test").median)}** |`);
+  lines.push("");
+}
+
+const crashed = Object.values(results).filter((r) => r.crashes > 0);
+if (crashed.length) {
+  lines.push(`## Stability`);
+  lines.push("");
+  lines.push(`Intermittent \`@nestia/core\` parallel-emit crash (\`concurrent map read and map write\`), retried:`);
+  lines.push("");
+  for (const r of crashed) lines.push(`- \`${r.key}\`: ${r.crashes} crash(es) across ${RUNS} measured runs`);
+  lines.push("");
+}
+
+lines.push(`## Raw samples (ms)`);
+lines.push("");
+lines.push(`| Measurement | runs | median | min |`);
+lines.push(`| --- | --- | --- | --- |`);
+for (const k of Object.keys(results)) {
+  const r = results[k];
+  lines.push(`| \`${k}\` | ${r.samples.map((x) => x.toFixed(0)).join(", ") || "—"} | ${s(r.median)} | ${s(r.min)} |`);
+}
+lines.push("");
+
+const report = lines.join("\n");
+fs.writeFileSync(OUT, report);
+fs.writeFileSync(OUT.replace(/\.md$/, ".json"), JSON.stringify({ started, results }, null, 2));
+process.stdout.write(`\n${report}\n\nReport written to ${OUT}\n`);

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -1067,7 +1067,48 @@ function writeReports(report, { publishWebsite = false } = {}) {
   fs.writeFileSync(CHECKPOINT_JSON, JSON.stringify(report, null, 2) + "\n");
   if (publishWebsite && !flags.has("--no-website")) {
     fs.mkdirSync(path.dirname(WEBSITE_JSON), { recursive: true });
-    fs.writeFileSync(WEBSITE_JSON, JSON.stringify(report, null, 2) + "\n");
+    const websiteReport = mergePreviousWebsiteMeasurements(report);
+    fs.writeFileSync(
+      WEBSITE_JSON,
+      JSON.stringify(websiteReport, null, 2) + "\n",
+    );
+  }
+}
+
+function mergePreviousWebsiteMeasurements(report) {
+  const previous = loadJson(WEBSITE_JSON);
+  if (!previous || !Array.isArray(previous.projects)) return report;
+
+  const merged = JSON.parse(JSON.stringify(report));
+  for (const project of merged.projects) {
+    const oldProject = previous.projects.find((p) => p.name === project.name);
+    if (!oldProject || !Array.isArray(oldProject.measurements)) continue;
+
+    const freshById = new Map(
+      project.measurements.map((measurement) => [measurement.id, measurement]),
+    );
+    const measurements = [];
+    for (const oldMeasurement of oldProject.measurements) {
+      const fresh = freshById.get(oldMeasurement.id);
+      if (fresh) {
+        measurements.push(fresh);
+        freshById.delete(oldMeasurement.id);
+      } else {
+        measurements.push(oldMeasurement);
+      }
+    }
+    measurements.push(...freshById.values());
+    project.measurements = measurements;
+  }
+  return merged;
+}
+
+function loadJson(file) {
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
   }
 }
 

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -54,7 +54,7 @@ const CHECKPOINT_JSON =
   path.resolve(WORK, "benchmark.checkpoint.json");
 
 const RUNS = numberEnv("TTSC_BENCH_RUNS", 10);
-const WARMUP = numberEnv("TTSC_BENCH_WARMUP", 1);
+const WARMUP = numberEnv("TTSC_BENCH_WARMUP", 1, { allowZero: true });
 const RETRIES = numberEnv("TTSC_BENCH_RETRIES", 2);
 const BRANCHES = ["legacy", "ttsc", "ttsc-lint"];
 const TTSC_VERSION = JSON.parse(
@@ -323,12 +323,16 @@ function splitProjectList(value) {
 
 main();
 
-function numberEnv(name, fallback) {
+function numberEnv(name, fallback, options = {}) {
   const raw = process.env[name];
   if (raw == null || raw === "") return fallback;
   const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0)
-    throw new Error(`${name} must be positive`);
+  if (!Number.isFinite(n) || n < 0 || (!options.allowZero && n === 0))
+    throw new Error(
+      options.allowZero
+        ? `${name} must be zero or positive`
+        : `${name} must be positive`,
+    );
   return n;
 }
 

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -641,6 +641,7 @@ function localTarballPaths(branch) {
 
 function installLocalTarballs(project, dir, branch) {
   const targets = localTarballTargets(branch);
+  scrubLocalTarballInstallState(dir, targets);
   if (project.packageManager === "yarn") {
     materializeLocalTarballs(targets, dir);
     return;
@@ -663,6 +664,94 @@ function installLocalTarballs(project, dir, branch) {
       `${targets.map((target) => target.name).join(", ")}\n`,
   );
   sh(cmd, dir);
+}
+
+function scrubLocalTarballInstallState(dir, targets) {
+  const specs = Object.fromEntries(
+    targets.map((target) => [
+      target.name,
+      `file:${path.join(TGZ, target.file)}`,
+    ]),
+  );
+  for (const packageJson of findProjectFiles(dir, "package.json")) {
+    rewritePackageJsonTarballs(packageJson, specs);
+  }
+  for (const workspaceFile of findProjectFiles(dir, "pnpm-workspace.yaml")) {
+    rewriteTextTarballs(workspaceFile, targets);
+  }
+  for (const lockfile of findProjectFiles(dir, [
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+  ])) {
+    const text = fs.readFileSync(lockfile, "utf8");
+    if (text.includes("ttsc-tgz")) fs.rmSync(lockfile);
+  }
+}
+
+function findProjectFiles(root, names) {
+  const wanted = new Set(Array.isArray(names) ? names : [names]);
+  const skip = new Set([".git", "node_modules", "dist", "lib", "out"]);
+  const files = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!skip.has(entry.name)) walk(path.join(dir, entry.name));
+      } else if (wanted.has(entry.name)) {
+        files.push(path.join(dir, entry.name));
+      }
+    }
+  };
+  walk(root);
+  return files;
+}
+
+function rewritePackageJsonTarballs(file, specs) {
+  const manifest = JSON.parse(fs.readFileSync(file, "utf8"));
+  let changed = false;
+  const rewriteMap = (map) => {
+    if (!map || typeof map !== "object") return;
+    for (const [name, spec] of Object.entries(specs)) {
+      const current = map[name];
+      if (typeof current === "string" && current.includes("ttsc-tgz")) {
+        map[name] = spec;
+        changed = true;
+      }
+    }
+  };
+  for (const key of [
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+    "overrides",
+    "resolutions",
+  ]) {
+    rewriteMap(manifest[key]);
+  }
+  rewriteMap(manifest.pnpm?.overrides);
+  if (changed) fs.writeFileSync(file, JSON.stringify(manifest, null, 2) + "\n");
+}
+
+function rewriteTextTarballs(file, targets) {
+  let text = fs.readFileSync(file, "utf8");
+  let changed = false;
+  for (const target of targets) {
+    const pattern = new RegExp(
+      `(?:file:)?[^\\s'",}]*ttsc-tgz[^\\s'",}]*/${escapeRegExp(target.file)}`,
+      "g",
+    );
+    const next = text.replace(pattern, `file:${path.join(TGZ, target.file)}`);
+    if (next !== text) {
+      text = next;
+      changed = true;
+    }
+  }
+  if (changed) fs.writeFileSync(file, text);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function materializeLocalTarballs(targets, dir) {

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -26,10 +26,18 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+const { cellFilters, flags, projectArgs, positional } = parseCliArgs(
+  process.argv.slice(2),
+);
 const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
 const WORK =
   process.env.TTSC_BENCH_WORK ?? path.resolve(import.meta.dirname, ".work");
-const TGZ = process.env.TTSC_BENCH_TGZ ?? path.join(os.tmpdir(), "ttsc-tgz");
+const TGZ =
+  process.env.TTSC_BENCH_TGZ ??
+  path.join(
+    os.tmpdir(),
+    flags.has("--no-pack") ? "ttsc-tgz" : `ttsc-tgz-${process.pid}`,
+  );
 const OUT =
   process.env.TTSC_BENCH_OUT ??
   path.resolve(import.meta.dirname, ".work", "report.md");
@@ -75,10 +83,6 @@ const LOCAL_TARBALLS = [
     name: PLATFORM_PACKAGE,
   },
 ];
-
-const { cellFilters, flags, projectArgs, positional } = parseCliArgs(
-  process.argv.slice(2),
-);
 
 const PACKAGE_CONFIGS = {
   vue: {

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -1139,7 +1139,7 @@ function main() {
   }
 
   const report = createReport(readyProjects);
-  writeReports(report, { publishWebsite: true });
+  writeReports(report);
   for (const project of readyProjects) measureProject(project, report);
   writeReports(report, { publishWebsite: true });
 

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -324,23 +324,21 @@ function rxjsBuildSteps(tool) {
 function nestjsCommands() {
   return {
     legacy: {
-      build: normalizeSteps(["npm exec -- tsc -p tsconfig.json"]),
-      noEmit: normalizeSteps(["npm exec -- tsc -p tsconfig.json --noEmit"]),
+      build: normalizeSteps(nestjsPackageSteps("tsc", false)),
+      noEmit: normalizeSteps(nestjsPackageSteps("tsc", true)),
       eslint: normalizeSteps([
         "npm exec -- eslint 'packages/**/**.ts' --ignore-pattern 'packages/**/*.spec.ts'",
       ]),
     },
     ttsc: {
-      build: normalizeSteps(["npm exec -- ttsc -p tsconfig.json"]),
-      noEmit: normalizeSteps(["npm exec -- ttsc -p tsconfig.json --noEmit"]),
-      tsgoBuild: normalizeSteps(["npm exec -- tsgo -p tsconfig.json"]),
-      tsgoNoEmit: normalizeSteps([
-        "npm exec -- tsgo -p tsconfig.json --noEmit",
-      ]),
+      build: normalizeSteps(nestjsPackageSteps("ttsc", false)),
+      noEmit: normalizeSteps(nestjsPackageSteps("ttsc", true)),
+      tsgoBuild: normalizeSteps(nestjsPackageSteps("tsgo", false)),
+      tsgoNoEmit: normalizeSteps(nestjsPackageSteps("tsgo", true)),
     },
     "ttsc-lint": {
-      build: normalizeSteps(["npm exec -- ttsc -p tsconfig.json"]),
-      noEmit: normalizeSteps(["npm exec -- ttsc -p tsconfig.json --noEmit"]),
+      build: normalizeSteps(nestjsPackageSteps("ttsc", false)),
+      noEmit: normalizeSteps(nestjsPackageSteps("ttsc", true)),
     },
   };
 }

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -39,9 +39,11 @@ const EXAMPLES =
 const RUNS = Number(process.env.TTSC_BENCH_RUNS ?? 3);
 const WARMUP = Number(process.env.TTSC_BENCH_WARMUP ?? 1);
 const RETRIES = Number(process.env.TTSC_BENCH_RETRIES ?? 3);
+// Results are an ephemeral artifact, never committed: the default lands in the
+// git-ignored `.work/` directory next to this script.
 const OUT =
   process.env.TTSC_BENCH_OUT ??
-  path.resolve(import.meta.dirname, "report.md");
+  path.resolve(import.meta.dirname, ".work", "report.md");
 
 const PROJECTS = {
   legacy: path.join(EXAMPLES, "shopping-backend@legacy"),
@@ -52,6 +54,10 @@ const PROJECTS = {
 /**
  * Every distinct (project, command) measured once. `key` is referenced by the
  * report tables; `crashy` marks commands subject to the parallel-emit race.
+ *
+ * The `:st` keys re-run the ttsc build under `--singleThreaded` (TypeScript-Go
+ * fully serial) so B4 can report the multi-threaded speedup. Their multi-
+ * threaded counterparts are the plain `:build:*` keys (ttsc's default).
  */
 const CASES = [
   { key: "legacy:build:main", project: "legacy", cmd: "pnpm run build:main" },
@@ -64,6 +70,10 @@ const CASES = [
   { key: "legacy:eslint:test", project: "legacy", cmd: "pnpm exec eslint test" },
   { key: "experiment:build:main", project: "experiment", cmd: "pnpm run build:main", crashy: true },
   { key: "experiment:build:test", project: "experiment", cmd: "pnpm run build:test", crashy: true },
+  { key: "next:build:main:st", project: "next", cmd: "pnpm exec rimraf lib && pnpm exec ttsc --singleThreaded" },
+  { key: "next:build:test:st", project: "next", cmd: "pnpm exec rimraf bin && pnpm exec ttsc -p test/tsconfig.json --singleThreaded" },
+  { key: "experiment:build:main:st", project: "experiment", cmd: "pnpm exec rimraf lib && pnpm exec ttsc --singleThreaded" },
+  { key: "experiment:build:test:st", project: "experiment", cmd: "pnpm exec rimraf bin && pnpm exec ttsc -p test/tsconfig.json --singleThreaded" },
 ];
 
 const GROUPS = {
@@ -72,6 +82,11 @@ const GROUPS = {
   b3: [
     "legacy:build:main", "legacy:build:test", "legacy:eslint:src",
     "legacy:eslint:test", "experiment:build:main", "experiment:build:test",
+  ],
+  b4: [
+    "next:build:main", "next:build:main:st", "next:build:test", "next:build:test:st",
+    "experiment:build:main", "experiment:build:main:st",
+    "experiment:build:test", "experiment:build:test:st",
   ],
 };
 
@@ -238,6 +253,24 @@ if (hasGroup("b3")) {
   lines.push("");
 }
 
+if (hasGroup("b4")) {
+  lines.push(`## B4 — ttsc threading: single-threaded vs multi-threaded`);
+  lines.push("");
+  lines.push(`\`ttsc --singleThreaded\` runs TypeScript-Go fully serial; the default keeps parallel parsing and emit. Speedup is multi-threaded over single-threaded.`);
+  lines.push("");
+  lines.push(`| Project · step | single-threaded | multi-threaded | speedup |`);
+  lines.push(`| --- | --- | --- | --- |`);
+  for (const [label, mt, st] of [
+    ["next · build:main", "next:build:main", "next:build:main:st"],
+    ["next · build:test", "next:build:test", "next:build:test:st"],
+    ["experiment · build:main", "experiment:build:main", "experiment:build:main:st"],
+    ["experiment · build:test", "experiment:build:test", "experiment:build:test:st"],
+  ]) {
+    lines.push(`| ${label} | ${s(R(st).median)} | ${s(R(mt).median)} | ${ratio(R(st).median, R(mt).median)} |`);
+  }
+  lines.push("");
+}
+
 const raced = Object.values(results).filter((r) => r.raceRetries > 0);
 const failed = Object.entries(results).filter(([, r]) => r.deterministicFailure);
 if (raced.length || failed.length) {
@@ -269,6 +302,7 @@ for (const k of Object.keys(results)) {
 }
 lines.push("");
 
+fs.mkdirSync(path.dirname(OUT), { recursive: true });
 const report = lines.join("\n");
 fs.writeFileSync(OUT, report);
 fs.writeFileSync(OUT.replace(/\.md$/, ".json"), JSON.stringify({ started, results }, null, 2));

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -16,8 +16,8 @@
  * - `node bench.mjs --setup-only`
  * - `node bench.mjs --verify-only`
  * - `node bench.mjs --project vue --project type-fest`
- * - `node bench.mjs --project=type-fest --ttsc-build-only --fresh`
- * - `node bench.mjs --project=type-fest --only-ttsc-build --fresh`
+ * - `node bench.mjs --project=type-fest --ttsc-build-only`
+ * - `node bench.mjs --project=type-fest --only-ttsc-build --reset`
  * - `node bench.mjs --project=type-fest --only-ttsc-build --no-website`
  * - `node bench.mjs --cell-filter=':ttsc:build:' vue type-fest`
  */
@@ -1119,46 +1119,59 @@ function formatMs(ms) {
 }
 
 function createReport(projects) {
-  const previous = flags.has("--fresh") ? null : loadCheckpoint();
+  const previous = flags.has("--reset") ? null : loadPreviousReport();
   const reusable =
-    previous &&
-    previous.runs === RUNS &&
-    previous.warmup === WARMUP &&
-    Array.isArray(previous.projects)
-      ? previous
-      : null;
-  if (previous && !reusable) {
-    process.stdout.write(
-      `Ignoring checkpoint with different run settings: ${CHECKPOINT_JSON}\n`,
+    previous && Array.isArray(previous.projects) ? previous : null;
+  const selected = new Set(projects.map((project) => project.name));
+  const reports = new Map(
+    (reusable?.projects ?? [])
+      .filter((project) => project?.name && !selected.has(project.name))
+      .map((project) => [project.name, project]),
+  );
+  for (const project of projects) {
+    const old = reusable?.projects.find((p) => p.name === project.name);
+    reports.set(
+      project.name,
+      projectReportFor(
+        project,
+        Array.isArray(old?.measurements) ? old.measurements : [],
+      ),
     );
   }
+  const orderedReports = [];
+  for (const project of PROJECTS) {
+    const report = reports.get(project.name);
+    if (report) {
+      orderedReports.push(report);
+      reports.delete(project.name);
+    }
+  }
+  orderedReports.push(...reports.values());
   return {
-    date: reusable?.date ?? new Date().toISOString(),
+    date: new Date().toISOString(),
     runs: RUNS,
     warmup: WARMUP,
     host: hostSpec(projects),
-    projects: projects.map((project) => {
-      const old = reusable?.projects.find((p) => p.name === project.name);
-      return projectReportFor(
-        project,
-        Array.isArray(old?.measurements) ? old.measurements : [],
-      );
-    }),
+    projects: orderedReports,
   };
 }
 
-function loadCheckpoint() {
-  if (!fs.existsSync(CHECKPOINT_JSON)) return null;
-  try {
-    return JSON.parse(fs.readFileSync(CHECKPOINT_JSON, "utf8"));
-  } catch (error) {
-    process.stdout.write(
-      `Ignoring unreadable checkpoint ${CHECKPOINT_JSON}: ${
-        error instanceof Error ? error.message : String(error)
-      }\n`,
-    );
-    return null;
-  }
+function loadPreviousReport() {
+  return [WEBSITE_JSON, CHECKPOINT_JSON]
+    .map((file) => ({ file, report: loadJson(file) }))
+    .filter(({ report }) => report && Array.isArray(report.projects))
+    .sort(
+      (a, b) => measurementCount(b.report) - measurementCount(a.report),
+    )[0]?.report ?? null;
+}
+
+function measurementCount(report) {
+  return (report.projects ?? []).reduce(
+    (sum, project) =>
+      sum +
+      (Array.isArray(project?.measurements) ? project.measurements.length : 0),
+    0,
+  );
 }
 
 function writeReports(report, { publishWebsite = false } = {}) {
@@ -1176,6 +1189,7 @@ function writeReports(report, { publishWebsite = false } = {}) {
 }
 
 function mergePreviousWebsiteMeasurements(report) {
+  if (flags.has("--reset")) return report;
   const previous = loadJson(WEBSITE_JSON);
   if (!previous || !Array.isArray(previous.projects)) return report;
 
@@ -1199,6 +1213,12 @@ function mergePreviousWebsiteMeasurements(report) {
     }
     measurements.push(...freshById.values());
     project.measurements = measurements;
+  }
+  const existing = new Set(merged.projects.map((project) => project.name));
+  for (const oldProject of previous.projects) {
+    if (!existing.has(oldProject.name)) {
+      merged.projects.push(oldProject);
+    }
   }
   return merged;
 }

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -11,8 +11,13 @@
  * installed, prepared, and then measured. `ttsc prepare` runs before timings so
  * plugin/native binary build time is not included in compiler measurements.
  *
- * Useful modes: node bench.mjs --setup-only node bench.mjs --verify-only node
- * bench.mjs --no-setup --verify-only vue rxjs
+ * Useful modes:
+ *
+ * node bench.mjs --setup-only
+ * node bench.mjs --verify-only
+ * node bench.mjs --project vue --project type-fest
+ * node bench.mjs --project=type-fest --ttsc-build-only --fresh
+ * node bench.mjs --cell-filter=':ttsc:build:' vue type-fest
  */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
@@ -69,9 +74,9 @@ const LOCAL_TARBALLS = [
   },
 ];
 
-const argv = process.argv.slice(2);
-const flags = new Set(argv.filter((a) => a.startsWith("--")));
-const positional = argv.filter((a) => !a.startsWith("--"));
+const { cellFilters, flags, projectArgs, positional } = parseCliArgs(
+  process.argv.slice(2),
+);
 
 const PACKAGE_CONFIGS = {
   vue: {
@@ -245,17 +250,67 @@ const PROJECTS = Object.entries(PACKAGE_CONFIGS)
     ...config,
   }));
 
-const wantedProjects = positional.length
-  ? positional.map(resolveProjectArg).filter(Boolean)
+const projectSelection = [...projectArgs, ...positional];
+const wantedProjects = projectSelection.length
+  ? projectSelection.map(resolveProjectArg).filter(Boolean)
   : PROJECTS;
 
 if (flags.has("--list")) {
   printConfig();
   process.exit(0);
 }
-if (positional.length && wantedProjects.length !== positional.length) {
+if (
+  projectSelection.length &&
+  wantedProjects.length !== projectSelection.length
+) {
   const known = PROJECTS.map((p) => `${p.name} (${p.repoName})`).join(", ");
   throw new Error(`unknown project selection. Known: ${known}`);
+}
+
+function parseCliArgs(args) {
+  const parsedCellFilters = [];
+  const parsedFlags = new Set();
+  const parsedProjects = [];
+  const parsedPositional = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--project") {
+      const value = args[++i];
+      if (!value || value.startsWith("--"))
+        throw new Error("--project requires a project name");
+      parsedProjects.push(...splitProjectList(value));
+    } else if (arg.startsWith("--project=")) {
+      const value = arg.slice("--project=".length);
+      if (!value) throw new Error("--project requires a project name");
+      parsedProjects.push(...splitProjectList(value));
+    } else if (arg === "--cell-filter") {
+      const value = args[++i];
+      if (!value || value.startsWith("--"))
+        throw new Error("--cell-filter requires a regular expression");
+      parsedCellFilters.push(new RegExp(value));
+    } else if (arg.startsWith("--cell-filter=")) {
+      const value = arg.slice("--cell-filter=".length);
+      if (!value) throw new Error("--cell-filter requires a regular expression");
+      parsedCellFilters.push(new RegExp(value));
+    } else if (arg.startsWith("--")) {
+      parsedFlags.add(arg);
+    } else {
+      parsedPositional.push(arg);
+    }
+  }
+  return {
+    cellFilters: parsedCellFilters,
+    flags: parsedFlags,
+    projectArgs: parsedProjects,
+    positional: parsedPositional,
+  };
+}
+
+function splitProjectList(value) {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
 }
 
 main();
@@ -1027,6 +1082,8 @@ function printConfig() {
 function main() {
   if (wantedProjects.length === 0)
     throw new Error("no benchmark projects selected");
+  if (!wantedProjects.some((project) => projectCells(project).length !== 0))
+    throw new Error("no benchmark cells selected");
 
   fs.mkdirSync(WORK, { recursive: true });
   fs.mkdirSync(path.dirname(OUT), { recursive: true });
@@ -1174,5 +1231,20 @@ function projectCells(project) {
       }
     }
   }
-  return cells;
+  return filterCells(cells);
+}
+
+function filterCells(cells) {
+  const predicates = [];
+  if (flags.has("--ttsc-build-only")) {
+    predicates.push(
+      (cell) =>
+        cell.branch === "ttsc" && cell.op === "build" && cell.tool !== "tsgo",
+    );
+  }
+  for (const filter of cellFilters) {
+    predicates.push((cell) => filter.test(cell.id));
+  }
+  if (predicates.length === 0) return cells;
+  return cells.filter((cell) => predicates.some((predicate) => predicate(cell)));
 }

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -967,15 +967,15 @@ function toolFor(branch, op, tool) {
 
 function measureProject(project, report) {
   const projectReport = ensureProjectReport(report, project);
-  const done = new Set(projectReport.measurements.map((m) => m.id));
   for (const cell of projectCells(project)) {
-    if (done.has(cell.id)) {
-      process.stdout.write(`\n[${cell.id}] already measured; skipping\n`);
-      continue;
-    }
+    const existingIndex = projectReport.measurements.findIndex(
+      (measurement) => measurement.id === cell.id,
+    );
+    if (existingIndex !== -1)
+      process.stdout.write(`\n[${cell.id}] refreshing existing measurement\n`);
     const measurement = measureCell(cell);
-    projectReport.measurements.push(measurement);
-    done.add(cell.id);
+    if (existingIndex === -1) projectReport.measurements.push(measurement);
+    else projectReport.measurements.splice(existingIndex, 1, measurement);
     writeReports(report, { publishWebsite: true });
   }
 }

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -818,7 +818,7 @@ function measureProject(project, report) {
     const measurement = measureCell(cell);
     projectReport.measurements.push(measurement);
     done.add(cell.id);
-    writeReports(report);
+    writeReports(report, { publishWebsite: true });
   }
 }
 
@@ -1080,7 +1080,7 @@ function main() {
   }
 
   const report = createReport(readyProjects);
-  writeReports(report);
+  writeReports(report, { publishWebsite: true });
   for (const project of readyProjects) measureProject(project, report);
   writeReports(report, { publishWebsite: true });
 

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -463,7 +463,36 @@ function commandForProject(cmd, root) {
   return cmd.replace(/^pnpm\b/, "pnpm --ignore-workspace");
 }
 
+function hrtimeMs(start) {
+  return Number(process.hrtime.bigint() - start) / 1e6;
+}
+
+function formatDuration(ms) {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(2)} s` : `${ms.toFixed(0)} ms`;
+}
+
+function timePhase(label, task) {
+  const start = process.hrtime.bigint();
+  process.stdout.write(`[timer] start ${label}\n`);
+  try {
+    const result = task();
+    process.stdout.write(
+      `[timer] done ${label} in ${formatDuration(hrtimeMs(start))}\n`,
+    );
+    return result;
+  } catch (error) {
+    process.stdout.write(
+      `[timer] fail ${label} after ${formatDuration(hrtimeMs(start))}\n`,
+    );
+    throw error;
+  }
+}
+
 function sh(cmd, cwd, options = {}) {
+  const start = process.hrtime.bigint();
+  const label = options.label ?? cmd;
+  if (options.timing !== false)
+    process.stdout.write(`[cmd] start ${label}\n`);
   const res = spawnSync(cmd, {
     cwd,
     shell: true,
@@ -471,6 +500,11 @@ function sh(cmd, cwd, options = {}) {
     env: options.env ?? process.env,
     stdio: options.quiet ? "pipe" : "inherit",
   });
+  if (options.timing !== false)
+    process.stdout.write(
+      `[cmd] done ${label} in ${formatDuration(hrtimeMs(start))} ` +
+        `(exit ${res.status})\n`,
+    );
   if (options.check !== false && res.status !== 0) {
     throw new Error(
       `command failed (${res.status}) in ${cwd}: ${cmd}\n${res.stderr ?? ""}`,
@@ -485,12 +519,20 @@ function runSteps(steps, root) {
   for (const step of steps) {
     const cwd = path.resolve(root, step.cwd ?? ".");
     const cmd = commandForProject(step.cmd, root);
+    const stepStart = process.hrtime.bigint();
+    process.stdout.write(
+      `    [step] start ${path.relative(root, cwd) || "."}: ${cmd}\n`,
+    );
     const res = spawnSync(cmd, {
       cwd,
       shell: true,
       encoding: "utf8",
       env: step.env ? { ...process.env, ...step.env } : process.env,
     });
+    process.stdout.write(
+      `    [step] done ${path.relative(root, cwd) || "."}: ` +
+        `${formatDuration(hrtimeMs(stepStart))} (exit ${res.status})\n`,
+    );
     log += `$ ${cmd}\n${res.stdout ?? ""}${res.stderr ?? ""}`;
     if (res.status !== 0) {
       const t1 = process.hrtime.bigint();
@@ -523,101 +565,129 @@ function packTarballs() {
     process.stdout.write(`Skipping tarball pack; using ${TGZ}\n`);
     return;
   }
-  fs.mkdirSync(TGZ, { recursive: true });
-  process.stdout.write(`Packing local ttsc tarballs into ${TGZ}\n`);
-  sh("pnpm run build:current", REPO_ROOT);
-  for (const target of LOCAL_TARBALLS) {
-    const out = path.join(TGZ, target.file);
-    fs.rmSync(out, { force: true });
-    sh(`pnpm pack --out ${quote(out)}`, path.join(REPO_ROOT, target.dir));
-  }
+  timePhase(`pack local ttsc tarballs into ${TGZ}`, () => {
+    fs.mkdirSync(TGZ, { recursive: true });
+    sh("pnpm run build:current", REPO_ROOT, { label: "build current ttsc" });
+    for (const target of LOCAL_TARBALLS) {
+      const out = path.join(TGZ, target.file);
+      fs.rmSync(out, { force: true });
+      sh(`pnpm pack --out ${quote(out)}`, path.join(REPO_ROOT, target.dir), {
+        label: `pack ${target.name}`,
+      });
+    }
+  });
 }
 
 function setupClone(project, branch) {
-  const dir = cloneDir(project, branch);
-  fs.mkdirSync(WORK, { recursive: true });
-  if (!fs.existsSync(dir)) {
-    process.stdout.write(`Cloning ${project.repoName}@${branch}\n`);
-    sh(
-      `git clone --branch ${quote(branch)} ${quote(project.repo)} ${quote(dir)}`,
-      WORK,
-      { quiet: true },
-    );
-  } else if (!fs.existsSync(path.join(dir, ".git"))) {
-    throw new Error(`${dir} exists but is not a git clone`);
-  }
+  return timePhase(`setup ${project.repoName}@${branch}`, () => {
+    const dir = cloneDir(project, branch);
+    fs.mkdirSync(WORK, { recursive: true });
+    if (!fs.existsSync(dir)) {
+      process.stdout.write(`Cloning ${project.repoName}@${branch}\n`);
+      sh(
+        `git clone --branch ${quote(branch)} ${quote(project.repo)} ${quote(dir)}`,
+        WORK,
+        { quiet: true, label: `clone ${project.repoName}@${branch}` },
+      );
+    } else if (!fs.existsSync(path.join(dir, ".git"))) {
+      throw new Error(`${dir} exists but is not a git clone`);
+    }
 
-  const current = sh("git branch --show-current", dir, {
-    quiet: true,
-    check: false,
-  }).stdout?.trim();
-  if (current && current !== branch) {
-    const dirty = sh("git status --short", dir, {
+    const current = sh("git branch --show-current", dir, {
       quiet: true,
       check: false,
-    }).stdout;
-    if (dirty.trim()) {
-      throw new Error(
-        `${dir} is on ${current}, expected ${branch}, and has local changes`,
-      );
+      timing: false,
+    }).stdout?.trim();
+    if (current && current !== branch) {
+      const dirty = sh("git status --short", dir, {
+        quiet: true,
+        check: false,
+        timing: false,
+      }).stdout;
+      if (dirty.trim()) {
+        throw new Error(
+          `${dir} is on ${current}, expected ${branch}, and has local changes`,
+        );
+      }
+      sh(`git checkout ${quote(branch)}`, dir, {
+        quiet: true,
+        label: `checkout ${project.repoName}@${branch}`,
+      });
     }
-    sh(`git checkout ${quote(branch)}`, dir, { quiet: true });
-  }
 
-  if (!flags.has("--no-install")) installIfNeeded(project, dir, branch);
+    if (!flags.has("--no-install")) installIfNeeded(project, dir, branch);
 
-  if (branch === "ttsc" || branch === "ttsc-lint") {
-    const pm = project.packageManager;
-    const cmd = project.prepareCommand
-      ? commandForProject(project.prepareCommand, dir)
-      : pm === "npm"
-        ? "npm exec -- ttsc prepare"
-        : pm === "pnpm"
-          ? pnpmProjectCommand(dir, "exec ttsc prepare")
-          : `${pm} exec ttsc prepare`;
-    const res = sh(cmd, dir, { quiet: true, check: false });
-    if (res.status !== 0) {
+    if (branch === "ttsc" || branch === "ttsc-lint") {
+      const pm = project.packageManager;
+      const cmd = project.prepareCommand
+        ? commandForProject(project.prepareCommand, dir)
+        : pm === "npm"
+          ? "npm exec -- ttsc prepare"
+          : pm === "pnpm"
+            ? pnpmProjectCommand(dir, "exec ttsc prepare")
+            : `${pm} exec ttsc prepare`;
+      const res = sh(cmd, dir, {
+        quiet: true,
+        check: false,
+        label: `ttsc prepare ${project.repoName}@${branch}`,
+      });
+      if (res.status !== 0) {
+        process.stdout.write(
+          `${project.repoName}@${branch}: ttsc prepare exited ${res.status}; ` +
+            `continuing only if this project has no source plugins\n`,
+        );
+      }
+    }
+
+    for (const step of normalizeSteps(project.prerequisites ?? [])) {
       process.stdout.write(
-        `${project.repoName}@${branch}: ttsc prepare exited ${res.status}; ` +
-          `continuing only if this project has no source plugins\n`,
+        `${project.repoName}@${branch}: prerequisite ${step.cmd}\n`,
       );
+      sh(step.cmd, path.resolve(dir, step.cwd ?? "."), {
+        quiet: true,
+        label: `prerequisite ${project.repoName}@${branch}`,
+      });
     }
-  }
-
-  for (const step of normalizeSteps(project.prerequisites ?? [])) {
-    process.stdout.write(
-      `${project.repoName}@${branch}: prerequisite ${step.cmd}\n`,
-    );
-    sh(step.cmd, path.resolve(dir, step.cwd ?? "."), { quiet: true });
-  }
+  });
 }
 
 function installIfNeeded(project, dir, branch) {
-  const mustRefreshTarballs = branch === "ttsc" || branch === "ttsc-lint";
-  const hasNodeModules = fs.existsSync(path.join(dir, "node_modules"));
-  if (!mustRefreshTarballs && !flags.has("--force-install") && hasNodeModules) {
-    return;
-  }
-  const pm = project.packageManager;
-  if (mustRefreshTarballs) assertLocalTarballs(branch);
-  const cmd =
-    project.installCommand ??
-    (pm === "pnpm"
-      ? pnpmProjectCommand(dir, "install --no-frozen-lockfile")
-      : pm === "yarn"
-        ? "YARN_CACHE_FOLDER=.yarn-cache yarn install --ignore-engines --update-checksums"
-        : "npm install --legacy-peer-deps");
-  if (!hasNodeModules || flags.has("--force-install")) {
-    process.stdout.write(`Installing ${path.basename(dir)} with ${pm}\n`);
-    sh(cmd, dir);
-  } else {
-    process.stdout.write(
-      `Reusing installed node_modules in ${path.basename(dir)}\n`,
-    );
-  }
-  if (branch === "ttsc" && hasTsgoCells(project) && !hasTsgoExperimentDeps(dir))
-    installTsgoExperimentDeps(project, dir);
-  if (mustRefreshTarballs) installLocalTarballs(project, dir, branch);
+  return timePhase(`install ${path.basename(dir)}`, () => {
+    const mustRefreshTarballs = branch === "ttsc" || branch === "ttsc-lint";
+    const hasNodeModules = fs.existsSync(path.join(dir, "node_modules"));
+    if (
+      !mustRefreshTarballs &&
+      !flags.has("--force-install") &&
+      hasNodeModules
+    ) {
+      process.stdout.write(`Reusing installed node_modules in ${path.basename(dir)}\n`);
+      return;
+    }
+    const pm = project.packageManager;
+    if (mustRefreshTarballs) assertLocalTarballs(branch);
+    const cmd =
+      project.installCommand ??
+      (pm === "pnpm"
+        ? pnpmProjectCommand(dir, "install --no-frozen-lockfile")
+        : pm === "yarn"
+          ? "YARN_CACHE_FOLDER=.yarn-cache yarn install --ignore-engines --update-checksums"
+          : "npm install --legacy-peer-deps");
+    if (!hasNodeModules || flags.has("--force-install")) {
+      process.stdout.write(`Installing ${path.basename(dir)} with ${pm}\n`);
+      sh(cmd, dir, { label: `install dependencies ${path.basename(dir)}` });
+    } else {
+      process.stdout.write(
+        `Reusing installed node_modules in ${path.basename(dir)}\n`,
+      );
+    }
+    if (
+      branch === "ttsc" &&
+      hasTsgoCells(project) &&
+      !hasTsgoExperimentDeps(dir)
+    )
+      installTsgoExperimentDeps(project, dir);
+    if (mustRefreshTarballs) installLocalTarballs(project, dir, branch);
+  });
 }
 
 function assertLocalTarballs(branch) {
@@ -645,30 +715,32 @@ function localTarballPaths(branch) {
 }
 
 function installLocalTarballs(project, dir, branch) {
-  const targets = localTarballTargets(branch);
-  scrubLocalTarballInstallState(dir, targets);
-  if (project.packageManager === "yarn") {
-    materializeLocalTarballs(targets, dir);
-    return;
-  }
-  const specs = targets
-    .map((target) => quote(path.join(TGZ, target.file)))
-    .join(" ");
-  const pm = project.packageManager;
-  const cmd =
-    project.installTarballsCommand?.(specs) ??
-    (pm === "pnpm"
-      ? ownsPnpmWorkspace(dir)
-        ? `pnpm add -w -D ${specs}`
-        : `pnpm add --ignore-workspace -D ${specs}`
-      : pm === "yarn"
-        ? `YARN_CACHE_FOLDER=.yarn-cache yarn add --dev --force --update-checksums --ignore-engines --ignore-workspace-root-check ${specs}`
-        : `npm install --legacy-peer-deps --save-dev ${specs}`);
-  process.stdout.write(
-    `Installing local tarballs into ${path.basename(dir)}: ` +
-      `${targets.map((target) => target.name).join(", ")}\n`,
-  );
-  sh(cmd, dir);
+  return timePhase(`install local tarballs ${path.basename(dir)}`, () => {
+    const targets = localTarballTargets(branch);
+    scrubLocalTarballInstallState(dir, targets);
+    if (project.packageManager === "yarn") {
+      materializeLocalTarballs(targets, dir);
+      return;
+    }
+    const specs = targets
+      .map((target) => quote(path.join(TGZ, target.file)))
+      .join(" ");
+    const pm = project.packageManager;
+    const cmd =
+      project.installTarballsCommand?.(specs) ??
+      (pm === "pnpm"
+        ? ownsPnpmWorkspace(dir)
+          ? `pnpm add -w -D ${specs}`
+          : `pnpm add --ignore-workspace -D ${specs}`
+        : pm === "yarn"
+          ? `YARN_CACHE_FOLDER=.yarn-cache yarn add --dev --force --update-checksums --ignore-engines --ignore-workspace-root-check ${specs}`
+          : `npm install --legacy-peer-deps --save-dev ${specs}`);
+    process.stdout.write(
+      `Installing local tarballs into ${path.basename(dir)}: ` +
+        `${targets.map((target) => target.name).join(", ")}\n`,
+    );
+    sh(cmd, dir, { label: `install local tarballs ${path.basename(dir)}` });
+  });
 }
 
 function scrubLocalTarballInstallState(dir, targets) {
@@ -971,18 +1043,20 @@ function toolFor(branch, op, tool) {
 }
 
 function measureProject(project, report) {
-  const projectReport = ensureProjectReport(report, project);
-  for (const cell of projectCells(project)) {
-    const existingIndex = projectReport.measurements.findIndex(
-      (measurement) => measurement.id === cell.id,
-    );
-    if (existingIndex !== -1)
-      process.stdout.write(`\n[${cell.id}] refreshing existing measurement\n`);
-    const measurement = measureCell(cell);
-    if (existingIndex === -1) projectReport.measurements.push(measurement);
-    else projectReport.measurements.splice(existingIndex, 1, measurement);
-    writeReports(report, { publishWebsite: true });
-  }
+  return timePhase(`measure project ${project.name}`, () => {
+    const projectReport = ensureProjectReport(report, project);
+    for (const cell of projectCells(project)) {
+      const existingIndex = projectReport.measurements.findIndex(
+        (measurement) => measurement.id === cell.id,
+      );
+      if (existingIndex !== -1)
+        process.stdout.write(`\n[${cell.id}] refreshing existing measurement\n`);
+      const measurement = measureCell(cell);
+      if (existingIndex === -1) projectReport.measurements.push(measurement);
+      else projectReport.measurements.splice(existingIndex, 1, measurement);
+      writeReports(report, { publishWebsite: true });
+    }
+  });
 }
 
 function ensureProjectReport(report, project) {
@@ -1255,6 +1329,7 @@ function printConfig() {
 }
 
 function main() {
+  const totalStart = process.hrtime.bigint();
   if (wantedProjects.length === 0)
     throw new Error("no benchmark projects selected");
   if (!wantedProjects.some((project) => projectCells(project).length !== 0))
@@ -1320,6 +1395,9 @@ function main() {
 
   process.stdout.write(`Report written to ${OUT}\n`);
   process.stdout.write(`Website JSON written to ${WEBSITE_JSON}\n`);
+  process.stdout.write(
+    `[timer] total benchmark ${formatDuration(hrtimeMs(totalStart))}\n`,
+  );
 }
 
 function verifyCommands(projects) {

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -18,6 +18,7 @@
  * - `node bench.mjs --project vue --project type-fest`
  * - `node bench.mjs --project=type-fest --ttsc-build-only --fresh`
  * - `node bench.mjs --project=type-fest --only-ttsc-build --fresh`
+ * - `node bench.mjs --project=type-fest --only-ttsc-build --no-website`
  * - `node bench.mjs --cell-filter=':ttsc:build:' vue type-fest`
  */
 import { spawnSync } from "node:child_process";
@@ -1058,7 +1059,7 @@ function writeReports(report, { publishWebsite = false } = {}) {
   fs.writeFileSync(OUT, buildMarkdown(report) + "\n");
   fs.writeFileSync(REPORT_JSON, JSON.stringify(report, null, 2) + "\n");
   fs.writeFileSync(CHECKPOINT_JSON, JSON.stringify(report, null, 2) + "\n");
-  if (publishWebsite) {
+  if (publishWebsite && !flags.has("--no-website")) {
     fs.mkdirSync(path.dirname(WEBSITE_JSON), { recursive: true });
     fs.writeFileSync(WEBSITE_JSON, JSON.stringify(report, null, 2) + "\n");
   }

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -1,104 +1,305 @@
 #!/usr/bin/env node
 /**
- * ttsc benchmark runner.
+ * ttsc matrix benchmark runner.
  *
- * Measures wall-clock time of build / format / lint commands across three
- * shopping-backend variants and emits a Markdown report:
+ * Clone-based, fully reproducible from a clean checkout. For every fixture
+ * project the runner clones three branches of a forked repo —
  *
- *   - shopping-backend@legacy      TypeScript 5.x  · tsc · prettier · eslint
- *   - shopping-backend@next        TypeScript 7.x  · ttsc
- *   - shopping-backend@experiment  TypeScript 7.x  · ttsc · @ttsc/lint (+format)
+ *   - `legacy`    stock `tsc` toolchain (TypeScript 5.x · prettier · eslint)
+ *   - `ttsc`      the `ttsc` toolchain (TypeScript 7 via @typescript/native-preview)
+ *   - `ttsc-lint` `ttsc` + `@ttsc/lint` (lint folded into the compile pass)
  *
- * Benchmark groups:
+ * — then measures, for each (project × branch):
  *
- *   B1  build speed   legacy(tsc)      vs  next(ttsc)         — build:main, build:test
- *   B2  format speed  legacy(prettier) vs  experiment(format) — whole src tree
- *   B3  build+lint    legacy(tsc+eslint) vs experiment(ttsc+@ttsc/lint)
+ *   - emit build           the project's real build command (type-check + emit)
+ *   - noEmit               the same input under `--noEmit` (type-check only)
+ *   - multi-threaded       ttsc's default (parallel parse/check/emit)
+ *   - single-threaded      `--singleThreaded` (TypeScript-Go fully serial)
  *
- * Each measurement does WARMUP unmeasured runs, then RUNS measured runs, and
- * reports the median. A measured run that exits non-zero (e.g. the intermittent
- * @nestia/core parallel-emit crash) is retried up to RETRIES times so the timing
- * sample stays valid; the crash count is reported separately.
+ * The legacy branch is only measured multi-threaded (stock `tsc` has no
+ * `--singleThreaded`); the ttsc / ttsc-lint branches are measured both ways.
+ *
+ * Each cell does WARMUP unmeasured runs then RUNS measured runs and reports the
+ * median. A measured run that exits non-zero is classified as a `race` failure
+ * (the intermittent Go data-race crash — retried, the clean timing is kept) or
+ * a deterministic `error` (a real compile error — not retried, cell left
+ * unmeasured). A (project × branch) whose fork branch does not exist yet, or a
+ * mode a project does not support, is skipped cleanly — never a crash.
+ *
+ * Pipeline:
+ *
+ *   1. build + pack the local ttsc / @ttsc/lint / current-platform tarballs
+ *      into /tmp/ttsc-tgz/ so fixtures install the compiler under test;
+ *   2. `git clone` each fixture branch into an OUTSIDE-the-repo working dir
+ *      (cloning inside the ttsc tree would let pnpm adopt the clone into the
+ *      ttsc workspace) — default /tmp/ttsc-bench-work/;
+ *   3. `pnpm install` each clone; `ttsc prepare` the ttsc / ttsc-lint clones;
+ *      run each project's prerequisites (e.g. shopping-backend build:prisma);
+ *   4. measure the matrix; write a Markdown report + JSON sidecar into the
+ *      git-ignored `.work/` directory.
  *
  * Usage:
- *   node bench.mjs [groups...]      # e.g. `node bench.mjs b1 b2`, default: all
- *   TTSC_BENCH_EXAMPLES=/path       # override the nestia.examples directory
- *   TTSC_BENCH_RUNS=3               # measured runs per command
- *   TTSC_BENCH_WARMUP=1             # warmup runs per command
- *   TTSC_BENCH_RETRIES=3            # retries to recover from a crashed run
- *   TTSC_BENCH_OUT=/path/report.md  # report destination
+ *   node bench.mjs [projects...]            # e.g. `node bench.mjs tstl zod`
+ *   node bench.mjs --setup-only             # clone + install, no measuring
+ *   node bench.mjs --no-setup               # measure only (reuse clones)
+ *   node bench.mjs --list                   # print the config table and exit
+ *
+ * Environment overrides:
+ *   TTSC_BENCH_WORK=/path        clone working dir       (default /tmp/ttsc-bench-work)
+ *   TTSC_BENCH_TGZ=/path         tarball staging dir     (default /tmp/ttsc-tgz)
+ *   TTSC_BENCH_OUT=/path/x.md    report destination      (default .work/report.md)
+ *   TTSC_BENCH_RUNS=3            measured runs per cell
+ *   TTSC_BENCH_WARMUP=1          warmup runs per cell
+ *   TTSC_BENCH_RETRIES=3         retries to recover a crashed run
+ *   TTSC_BENCH_SKIP_PACK=1       reuse existing tarballs (skip step 1)
  */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-const EXAMPLES =
-  process.env.TTSC_BENCH_EXAMPLES ??
-  path.resolve(import.meta.dirname, "../../../nestia.examples");
-const RUNS = Number(process.env.TTSC_BENCH_RUNS ?? 3);
-const WARMUP = Number(process.env.TTSC_BENCH_WARMUP ?? 1);
-const RETRIES = Number(process.env.TTSC_BENCH_RETRIES ?? 3);
-// Results are an ephemeral artifact, never committed: the default lands in the
-// git-ignored `.work/` directory next to this script.
+// ── configuration ────────────────────────────────────────────────────────────
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
+const WORK =
+  process.env.TTSC_BENCH_WORK ?? path.join(os.tmpdir(), "ttsc-bench-work");
+const TGZ = process.env.TTSC_BENCH_TGZ ?? path.join(os.tmpdir(), "ttsc-tgz");
 const OUT =
   process.env.TTSC_BENCH_OUT ??
   path.resolve(import.meta.dirname, ".work", "report.md");
+const RUNS = Number(process.env.TTSC_BENCH_RUNS ?? 3);
+const WARMUP = Number(process.env.TTSC_BENCH_WARMUP ?? 1);
+const RETRIES = Number(process.env.TTSC_BENCH_RETRIES ?? 3);
 
-const PROJECTS = {
-  legacy: path.join(EXAMPLES, "shopping-backend@legacy"),
-  next: path.join(EXAMPLES, "shopping-backend@next"),
-  experiment: path.join(EXAMPLES, "shopping-backend@experiment"),
-};
+// The ttsc workspace version every fixture branch pins its tarballs against.
+const TTSC_VERSION = JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, "packages/ttsc/package.json"), "utf8"),
+).version;
+const PLATFORM_KEY = `${process.platform}-${process.arch}`;
 
 /**
- * Every distinct (project, command) measured once. `key` is referenced by the
- * report tables; `crashy` marks commands subject to the parallel-emit race.
+ * The declarative per-project matrix.
  *
- * The `:st` keys re-run the ttsc build under `--singleThreaded` (TypeScript-Go
- * fully serial) so B4 can report the multi-threaded speedup. Their multi-
- * threaded counterparts are the plain `:build:*` keys (ttsc's default).
+ * Each project clones a forked repo and exposes one or more `cases`. A case is
+ * a measured command parametrised over a branch and a mode. `build` is the
+ * emit-producing command; `noEmit` is the type-check-only command; both omit
+ * the project's clean step so the timing is the compiler, not `rimraf`. The
+ * runner prepends the clean step itself when a case declares `clean`.
+ *
+ * `singleThreaded: true` on a case means the runner *also* measures it with
+ * `--singleThreaded` appended (only meaningful for ttsc / ttsc-lint branches).
+ *
+ * A branch absent from `branches` is a fork branch not pushed yet — the runner
+ * skips it. TODO entries below are projects/branches still being set up.
  */
-const CASES = [
-  { key: "legacy:build:main", project: "legacy", cmd: "pnpm run build:main" },
-  { key: "legacy:build:test", project: "legacy", cmd: "pnpm run build:test" },
-  { key: "next:build:main", project: "next", cmd: "pnpm run build:main", crashy: true },
-  { key: "next:build:test", project: "next", cmd: "pnpm run build:test", crashy: true },
-  { key: "legacy:prettier", project: "legacy", cmd: "pnpm exec prettier src --write" },
-  { key: "experiment:format", project: "experiment", cmd: "pnpm exec ttsc format", crashy: true },
-  { key: "legacy:eslint:src", project: "legacy", cmd: "pnpm exec eslint src" },
-  { key: "legacy:eslint:test", project: "legacy", cmd: "pnpm exec eslint test" },
-  { key: "experiment:build:main", project: "experiment", cmd: "pnpm run build:main", crashy: true },
-  { key: "experiment:build:test", project: "experiment", cmd: "pnpm run build:test", crashy: true },
-  { key: "next:build:main:st", project: "next", cmd: "pnpm exec rimraf lib && pnpm exec ttsc --singleThreaded" },
-  { key: "next:build:test:st", project: "next", cmd: "pnpm exec rimraf bin && pnpm exec ttsc -p test/tsconfig.json --singleThreaded" },
-  { key: "experiment:build:main:st", project: "experiment", cmd: "pnpm exec rimraf lib && pnpm exec ttsc --singleThreaded" },
-  { key: "experiment:build:test:st", project: "experiment", cmd: "pnpm exec rimraf bin && pnpm exec ttsc -p test/tsconfig.json --singleThreaded" },
-];
+const PROJECTS = {
+  // ── plugin-heavy: every file runs typia + @nestia source-plugin transforms ──
+  "shopping-backend": {
+    repo: "https://github.com/samchon/shopping-backend.git",
+    kind: "plugin-heavy",
+    branches: ["legacy", "ttsc", "ttsc-lint"],
+    // Prisma client + nestia SDK that build:main type-checks against.
+    prerequisites: ["build:prisma", "build:sdk"],
+    cases: [
+      {
+        // build:test is intentionally not measured: shopping-backend's matrix
+        // is build:main only (the test tsconfig double-counts the same files).
+        name: "build:main",
+        emit: true,
+        singleThreaded: true,
+        legacy: { build: "pnpm exec tsc" },
+        ttsc: {
+          build: "pnpm exec ttsc",
+          noEmit: "pnpm exec ttsc --noEmit",
+          stClean: "pnpm exec rimraf lib",
+        },
+      },
+    ],
+  },
 
-const GROUPS = {
-  b1: ["legacy:build:main", "legacy:build:test", "next:build:main", "next:build:test"],
-  b2: ["legacy:prettier", "experiment:format"],
-  b3: [
-    "legacy:build:main", "legacy:build:test", "legacy:eslint:src",
-    "legacy:eslint:test", "experiment:build:main", "experiment:build:test",
-  ],
-  b4: [
-    "next:build:main", "next:build:main:st", "next:build:test", "next:build:test:st",
-    "experiment:build:main", "experiment:build:main:st",
-    "experiment:build:test", "experiment:build:test:st",
-  ],
+  // ── plugin-free emit-producing libraries (the scaling curve) ────────────────
+  tstl: {
+    repo: "https://github.com/samchon/tstl.git",
+    kind: "plugin-free",
+    branches: ["legacy", "ttsc", "ttsc-lint"],
+    prerequisites: [],
+    cases: [
+      {
+        name: "build",
+        emit: true,
+        singleThreaded: true,
+        legacy: { build: "pnpm exec tsc" },
+        ttsc: {
+          build: "pnpm exec ttsc",
+          noEmit: "pnpm exec ttsc --noEmit",
+          stClean: "pnpm exec rimraf lib",
+        },
+      },
+    ],
+  },
+
+  zod: {
+    repo: "https://github.com/samchon/ttsc-benchmark-zod.git",
+    kind: "plugin-free",
+    branches: ["legacy", "ttsc", "ttsc-lint"],
+    prerequisites: [],
+    cases: [
+      {
+        // `build:benchmark` compiles the zod package via tsconfig.benchmark.json
+        // (tsc on legacy, ttsc on ttsc/ttsc-lint).
+        name: "build:benchmark",
+        emit: true,
+        singleThreaded: true,
+        cwd: "packages/zod",
+        legacy: { build: "pnpm exec tsc -p tsconfig.benchmark.json" },
+        ttsc: {
+          build: "pnpm exec ttsc -p tsconfig.benchmark.json",
+          noEmit: "pnpm exec ttsc -p tsconfig.benchmark.json --noEmit",
+          stClean: "pnpm exec rimraf lib",
+        },
+      },
+    ],
+  },
+
+  rxjs: {
+    repo: "https://github.com/samchon/ttsc-benchmark-rxjs.git",
+    kind: "plugin-free",
+    branches: ["legacy", "ttsc", "ttsc-lint"],
+    // rxjs is a yarn/nx monorepo; the benchmark cell is the rxjs package only.
+    packageManager: "yarn",
+    prerequisites: [],
+    cases: [
+      {
+        // `build:bench` compiles packages/rxjs via tsconfig.bench.json.
+        name: "build:bench",
+        emit: true,
+        singleThreaded: true,
+        cwd: "packages/rxjs",
+        legacy: { build: "yarn exec tsc -- -p tsconfig.bench.json" },
+        ttsc: {
+          build: "yarn exec ttsc -- -p tsconfig.bench.json",
+          noEmit: "yarn exec ttsc -- -p tsconfig.bench.json --noEmit",
+          stClean: "pnpm exec rimraf dist-bench",
+        },
+      },
+    ],
+  },
+
+  // ── plugin-free pure type-check (no emit build) ─────────────────────────────
+  "type-fest": {
+    repo: "https://github.com/samchon/ttsc-benchmark-type-fest.git",
+    kind: "plugin-free",
+    branches: ["legacy", "ttsc", "ttsc-lint"],
+    prerequisites: [],
+    cases: [
+      {
+        // type-fest's tsconfig is permanently `noEmit: true` — a pure
+        // type-checker stress with no emit cell. `emit: false` keeps it out of
+        // the emit-build comparison so it is not weighed against emitting cells.
+        name: "check",
+        emit: false,
+        singleThreaded: true,
+        legacy: { build: "pnpm exec tsc" },
+        ttsc: {
+          build: "pnpm exec ttsc",
+          // build is already noEmit; no separate noEmit cell.
+        },
+      },
+    ],
+  },
+
+  // ── frontend framework: type-check only (vue builds via rollup) ─────────────
+  vue: {
+    repo: "https://github.com/samchon/ttsc-benchmark-vue.git",
+    kind: "plugin-free",
+    // TODO: ttsc-lint branch not pushed yet — see issue #118 fixture work.
+    branches: ["legacy", "ttsc"],
+    prerequisites: [],
+    cases: [
+      {
+        name: "check",
+        emit: false,
+        singleThreaded: true,
+        legacy: { build: "pnpm exec tsc --incremental --noEmit" },
+        ttsc: { build: "pnpm exec ttsc --noEmit" },
+      },
+    ],
+  },
+
+  // ── backend framework: project-references monorepo via a build orchestrator ─
+  nestjs: {
+    repo: "https://github.com/samchon/ttsc-benchmark-nestjs.git",
+    kind: "plugin-free",
+    branches: ["legacy", "ttsc", "ttsc-lint"],
+    prerequisites: [],
+    cases: [
+      {
+        // nestjs has no `tsc -b` analogue in ttsc; the ttsc branches ship a
+        // `scripts/build-ttsc.mjs` orchestrator that walks packages in
+        // topological order. That orchestrator emits and exposes no --noEmit /
+        // --singleThreaded flag, so this case measures the emit build only.
+        name: "build",
+        emit: true,
+        singleThreaded: false,
+        legacy: { build: "pnpm exec tsc -b packages" },
+        ttsc: { build: "node scripts/build-ttsc.mjs" },
+      },
+    ],
+  },
+
+  // TODO(#118): vscode fixture — the samchon/ttsc-benchmark-vscode repo has no
+  // legacy / ttsc / ttsc-lint branches yet. When the fixture agent pushes them,
+  // add a `vscode` entry here mirroring `vue` (VSCode type-checks via `tsc`).
 };
 
-const wanted = process.argv.slice(2).map((s) => s.toLowerCase());
-const activeGroups = wanted.length
-  ? wanted.filter((g) => GROUPS[g])
-  : Object.keys(GROUPS);
-const activeKeys = new Set(activeGroups.flatMap((g) => GROUPS[g]));
+// ── argument parsing ─────────────────────────────────────────────────────────
 
-function runOnce(cwd, cmd) {
+const argv = process.argv.slice(2);
+const flags = new Set(argv.filter((a) => a.startsWith("--")));
+const positional = argv.filter((a) => !a.startsWith("--"));
+const wantedProjects = positional.length
+  ? positional.filter((p) => PROJECTS[p])
+  : Object.keys(PROJECTS);
+
+if (flags.has("--list")) {
+  printConfigTable();
+  process.exit(0);
+}
+if (positional.length && wantedProjects.length === 0) {
+  process.stderr.write(
+    `No known project in [${positional.join(", ")}].\n` +
+      `Known: ${Object.keys(PROJECTS).join(", ")}\n`,
+  );
+  process.exit(1);
+}
+
+// ── shell helpers ────────────────────────────────────────────────────────────
+
+function sh(cmd, cwd, { check = true, quiet = false, env } = {}) {
+  const res = spawnSync(cmd, {
+    cwd,
+    shell: true,
+    encoding: "utf8",
+    env: env ?? process.env,
+    stdio: quiet ? "pipe" : "inherit",
+  });
+  if (check && res.status !== 0) {
+    throw new Error(
+      `command failed (exit ${res.status}): ${cmd}\n${res.stderr ?? ""}`,
+    );
+  }
+  return res;
+}
+
+/** Time a command once; never throws — a failed run is reported, not fatal. */
+function runOnce(cmd, cwd, env) {
   const t0 = process.hrtime.bigint();
-  const res = spawnSync(cmd, { cwd, shell: true, encoding: "utf8" });
+  const res = spawnSync(cmd, {
+    cwd,
+    shell: true,
+    encoding: "utf8",
+    env: env ?? process.env,
+  });
   const t1 = process.hrtime.bigint();
   return {
     ms: Number(t1 - t0) / 1e6,
@@ -126,37 +327,164 @@ function classifyFailure(log) {
     : "error";
 }
 
-function measure(c) {
-  const cwd = PROJECTS[c.project];
-  process.stdout.write(`\n▶ ${c.key}\n  ${c.cmd}\n`);
+// ── step 1: build + pack the local ttsc tarballs ─────────────────────────────
+
+/**
+ * Build the workspace and pack ttsc / @ttsc/lint / the current-platform package
+ * into TGZ under the exact filenames the fixture branches pin
+ * (`ttsc-<version>.tgz`, `ttsc-lint-<version>.tgz`,
+ * `ttsc-<platform>-<version>.tgz`). Fixtures reference these via
+ * `file:/tmp/ttsc-tgz/...` so an install picks up the compiler under test.
+ */
+function packTarballs() {
+  if (process.env.TTSC_BENCH_SKIP_PACK === "1" || flags.has("--no-pack")) {
+    process.stdout.write(`◦ skipping tarball pack (reusing ${TGZ})\n`);
+    return;
+  }
+  process.stdout.write(`\n▸ building + packing ttsc tarballs into ${TGZ}\n`);
+  fs.mkdirSync(TGZ, { recursive: true });
+  sh("pnpm run build:current", REPO_ROOT);
+  const targets = [
+    { dir: "packages/ttsc", file: `ttsc-${TTSC_VERSION}.tgz` },
+    { dir: "packages/lint", file: `ttsc-lint-${TTSC_VERSION}.tgz` },
+    {
+      dir: `packages/ttsc-${PLATFORM_KEY}`,
+      file: `ttsc-${PLATFORM_KEY}-${TTSC_VERSION}.tgz`,
+    },
+  ];
+  for (const t of targets) {
+    const dir = path.join(REPO_ROOT, t.dir);
+    if (!fs.existsSync(dir)) {
+      throw new Error(`tarball source missing: ${t.dir}`);
+    }
+    const out = path.join(TGZ, t.file);
+    fs.rmSync(out, { force: true });
+    sh(`pnpm pack --out ${JSON.stringify(out)}`, dir);
+    process.stdout.write(`  packed ${t.file}\n`);
+  }
+}
+
+// ── step 2 + 3: clone + install a fixture branch ─────────────────────────────
+
+/** Working directory for one (project, branch) clone. */
+function cloneDir(project, branch) {
+  return path.join(WORK, `${project}@${branch}`);
+}
+
+/**
+ * Clone `branch` of `project`'s repo into the working directory and install it.
+ * Returns `false` (skip, not fatal) when the branch does not exist on the fork
+ * — fixture branches are still being pushed. A stray `pnpm-workspace.yaml` is
+ * dropped into the clone so pnpm treats it as an isolated workspace even if it
+ * ever lands inside another workspace tree.
+ */
+function setupClone(project, branch) {
+  const cfg = PROJECTS[project];
+  const dir = cloneDir(project, branch);
+  const pm = cfg.packageManager ?? "pnpm";
+
+  // Branch existence probe — a missing fork branch is skipped, not a crash.
+  const probe = spawnSync(
+    "git",
+    ["ls-remote", "--exit-code", "--heads", cfg.repo, branch],
+    { encoding: "utf8" },
+  );
+  if (probe.status !== 0) {
+    process.stdout.write(
+      `  ⚠ ${project}@${branch}: branch not on fork yet — skipped\n`,
+    );
+    return false;
+  }
+
+  fs.rmSync(dir, { recursive: true, force: true });
+  process.stdout.write(`  cloning ${project}@${branch}\n`);
+  sh(
+    `git clone --depth 1 --branch ${branch} ${cfg.repo} ${JSON.stringify(dir)}`,
+    WORK,
+    { quiet: true },
+  );
+  // Isolate the clone from any surrounding pnpm workspace.
+  if (!fs.existsSync(path.join(dir, "pnpm-workspace.yaml"))) {
+    fs.writeFileSync(path.join(dir, "pnpm-workspace.yaml"), "packages: []\n");
+  }
+
+  process.stdout.write(`  installing ${project}@${branch} (${pm})\n`);
+  const installCmd =
+    pm === "yarn"
+      ? "yarn install --frozen-lockfile || yarn install"
+      : "pnpm install --no-frozen-lockfile";
+  sh(installCmd, dir, { quiet: true });
+
+  // `ttsc prepare` builds the cached plugin binaries the ttsc branches need.
+  if (branch === "ttsc" || branch === "ttsc-lint") {
+    const prep = spawnSync(`${pm} exec ttsc prepare`, {
+      cwd: dir,
+      shell: true,
+      encoding: "utf8",
+    });
+    if (prep.status !== 0) {
+      process.stdout.write(
+        `  ◦ ${project}@${branch}: 'ttsc prepare' exited ${prep.status} ` +
+          `(ok if the project defines no plugins)\n`,
+      );
+    }
+  }
+
+  // Project-specific prerequisites (e.g. Prisma client, nestia SDK).
+  for (const script of cfg.prerequisites ?? []) {
+    process.stdout.write(`  prerequisite: ${project}@${branch} ${script}\n`);
+    sh(`${pm} run ${script}`, dir, { quiet: true });
+  }
+  return true;
+}
+
+// ── step 4: measure one cell ─────────────────────────────────────────────────
+
+/**
+ * Measure one matrix cell: WARMUP unmeasured runs, then RUNS measured runs.
+ * `prep` (e.g. a clean step) runs unmeasured before every run so each timing
+ * starts from the same state. Returns the per-cell result record.
+ */
+function measureCell(label, cmd, cwd, { prep, crashy } = {}) {
+  process.stdout.write(`\n▶ ${label}\n  ${cmd}${prep ? `\n  prep: ${prep}` : ""}\n`);
+  const fresh = () => {
+    if (prep) spawnSync(prep, { cwd, shell: true });
+    return runOnce(cmd, cwd);
+  };
   for (let i = 0; i < WARMUP; i++) {
-    const w = runOnce(cwd, c.cmd);
-    process.stdout.write(`  warmup ${i + 1}: ${w.ms.toFixed(0)} ms ${w.ok ? "ok" : `EXIT ${w.status}`}\n`);
+    const w = fresh();
+    process.stdout.write(
+      `  warmup ${i + 1}: ${w.ms.toFixed(0)} ms ${w.ok ? "ok" : `EXIT ${w.status}`}\n`,
+    );
   }
   const samples = [];
   let raceRetries = 0;
-  let deterministicFailure = null; // { status } when a run never succeeds
+  let deterministicFailure = null;
   for (let i = 0; i < RUNS; i++) {
-    let r = runOnce(cwd, c.cmd);
+    let r = fresh();
     let attempts = 0;
     while (!r.ok && attempts < RETRIES) {
       const kind = classifyFailure(r.log);
       if (kind === "race") raceRetries++;
       attempts++;
-      process.stdout.write(`  run ${i + 1}: EXIT ${r.status} (${kind}) — retry ${attempts}\n`);
+      process.stdout.write(
+        `  run ${i + 1}: EXIT ${r.status} (${kind}) — retry ${attempts}\n`,
+      );
       if (kind === "error") break; // deterministic: retrying will not help
-      r = runOnce(cwd, c.cmd);
+      r = fresh();
     }
     if (!r.ok) {
-      deterministicFailure = { status: r.status };
-      process.stdout.write(`  run ${i + 1}: EXIT ${r.status} — deterministic failure, not measured\n`);
+      deterministicFailure = { status: r.status, kind: classifyFailure(r.log) };
+      process.stdout.write(
+        `  run ${i + 1}: EXIT ${r.status} — deterministic failure, not measured\n`,
+      );
       continue;
     }
     samples.push(r.ms);
     process.stdout.write(`  run ${i + 1}: ${r.ms.toFixed(0)} ms\n`);
   }
   return {
-    key: c.key,
+    label,
     samples,
     raceRetries,
     deterministicFailure,
@@ -165,145 +493,385 @@ function measure(c) {
   };
 }
 
+/**
+ * Expand a (project, branch, case) into measured cells and record them into
+ * `results`. The `ttsc` / `ttsc-lint` branches add a noEmit cell and (when the
+ * case opts in) single-threaded variants of build + noEmit.
+ */
+function measureCase(results, project, branch, c) {
+  const cfg = PROJECTS[project];
+  const dir = cloneDir(project, branch);
+  if (!fs.existsSync(dir)) return; // setup skipped this branch
+  const runCwd = c.cwd ? path.join(dir, c.cwd) : dir;
+  const spec = branch === "legacy" ? c.legacy : c.ttsc;
+  if (!spec) return;
+  const key = (mode) => `${project}|${branch}|${c.name}|${mode}`;
+
+  // emit / type-check build, multi-threaded (ttsc's default; the only mode for legacy).
+  if (spec.build) {
+    results[key("mt")] = measureCell(key("mt"), spec.build, runCwd);
+  }
+  // type-check-only build.
+  if (spec.noEmit) {
+    results[key("noEmit")] = measureCell(key("noEmit"), spec.noEmit, runCwd);
+  }
+  // single-threaded variants — ttsc / ttsc-lint only, and only when opted in.
+  if (c.singleThreaded && branch !== "legacy") {
+    const prep = spec.stClean
+      ? `${spec.stClean.replace("pnpm exec", (cfg.packageManager ?? "pnpm") + " exec")}`
+      : undefined;
+    if (spec.build) {
+      results[key("st")] = measureCell(
+        key("st"),
+        `${spec.build} --singleThreaded`,
+        runCwd,
+        { prep },
+      );
+    }
+    if (spec.noEmit) {
+      results[key("st-noEmit")] = measureCell(
+        key("st-noEmit"),
+        `${spec.noEmit} --singleThreaded`,
+        runCwd,
+      );
+    }
+  }
+}
+
+// ── host spec ────────────────────────────────────────────────────────────────
+
+/**
+ * Read a dependency's installed version from a package's node_modules. Returns
+ * `undefined` when the package is not present so callers can fall back.
+ */
+function depVersion(fromDir, pkg) {
+  try {
+    const p = path.join(fromDir, "node_modules", pkg, "package.json");
+    return JSON.parse(fs.readFileSync(p, "utf8")).version;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Collect the host machine spec + toolchain versions for the report header.
+ * `tsgo`/`tsc` resolve from the fixture clones (that is where the compilers are
+ * installed); `tsgo` reads `@typescript/native-preview` from a `ttsc` clone and
+ * `tsc` reads `typescript` from a `legacy` clone.
+ */
+function hostSpec(wantedProjectsList) {
+  const cpu = os.cpus();
+  let osName = `${os.type()} ${os.release()}`;
+  try {
+    const rel = fs.readFileSync("/etc/os-release", "utf8");
+    const pretty = rel.match(/^PRETTY_NAME="?([^"\n]+)"?/m);
+    if (pretty) osName = `${pretty[1]} (kernel ${os.release()})`;
+  } catch {
+    /* not Linux — keep os.type()/os.release() */
+  }
+  // Walk fixture clones for the first one that has each compiler installed.
+  let tsgo, tsc;
+  for (const project of wantedProjectsList) {
+    tsgo ??= depVersion(
+      cloneDir(project, "ttsc"),
+      "@typescript/native-preview",
+    );
+    tsc ??= depVersion(cloneDir(project, "legacy"), "typescript");
+  }
+  return {
+    os: osName,
+    cpu: `${cpu.length}× ${cpu[0]?.model?.trim() ?? "unknown"}`,
+    ram: `${(os.totalmem() / 2 ** 30).toFixed(0)} GB`,
+    node: process.version,
+    ttsc: TTSC_VERSION,
+    tsgo: tsgo ?? "—",
+    tsc: tsc ?? "—",
+  };
+}
+
+// ── reporting ────────────────────────────────────────────────────────────────
+
 function s(ms) {
   return ms == null ? "—" : `${(ms / 1000).toFixed(2)} s`;
 }
 function ratio(slow, fast) {
-  return slow == null || fast == null ? "—" : `${(slow / fast).toFixed(2)}×`;
-}
-// Sum that stays honest: if any component is missing, so is the total.
-function sum(...xs) {
-  return xs.some((x) => x == null) ? null : xs.reduce((a, b) => a + b, 0);
+  return slow == null || fast == null || fast === 0
+    ? "—"
+    : `${(slow / fast).toFixed(2)}×`;
 }
 
-// ── run ──────────────────────────────────────────────────────────────────────
-// Prior results are merged so groups can be measured in separate invocations
-// (e.g. `node bench.mjs b1` then `node bench.mjs b3`) and still report as one.
-const started = new Date();
-const jsonPath = OUT.replace(/\.md$/, ".json");
-let results = {};
-if (fs.existsSync(jsonPath)) {
-  try {
-    results = JSON.parse(fs.readFileSync(jsonPath, "utf8")).results ?? {};
-  } catch {
-    results = {};
+function buildReport(results, started, host) {
+  const R = (k) => results[k] ?? null;
+  const med = (k) => R(k)?.median ?? null;
+  const L = [];
+  L.push(`# ttsc matrix benchmark`);
+  L.push("");
+  L.push(`- Date: ${started.toISOString()}`);
+  L.push("");
+  L.push(`## Host`);
+  L.push("");
+  L.push(`| Field | Value |`);
+  L.push(`| --- | --- |`);
+  L.push(`| OS | ${host.os} |`);
+  L.push(`| CPU | ${host.cpu} |`);
+  L.push(`| RAM | ${host.ram} |`);
+  L.push(`| node | ${host.node} |`);
+  L.push(`| ttsc | ${host.ttsc} |`);
+  L.push(`| @typescript/native-preview (tsgo) | ${host.tsgo} |`);
+  L.push(`| tsc | ${host.tsc} |`);
+  L.push("");
+  L.push(
+    `- Method: ${WARMUP} warmup + ${RUNS} measured runs per cell; median ` +
+      `reported. A run hitting the intermittent parallel-emit race is retried ` +
+      `(up to ${RETRIES}×); a deterministic failure is left unmeasured.`,
+  );
+  L.push("");
+
+  // ── M1 — emit build: legacy vs ttsc vs ttsc-lint ──────────────────────────
+  L.push(`## M1 — Emit build: tsc (legacy) vs ttsc vs ttsc + @ttsc/lint`);
+  L.push("");
+  L.push(
+    `Multi-threaded emit build per project. type-fest and vue are ` +
+      `type-check-only (no emit build) and appear in M2 instead.`,
+  );
+  L.push("");
+  L.push(
+    `| Project | kind | legacy · tsc | ttsc | ttsc-lint | tsc→ttsc | lint cost |`,
+  );
+  L.push(`| --- | --- | --- | --- | --- | --- | --- |`);
+  for (const project of wantedProjects) {
+    const cfg = PROJECTS[project];
+    for (const c of cfg.cases) {
+      if (!c.emit) continue;
+      const lg = med(`${project}|legacy|${c.name}|mt`);
+      const tt = med(`${project}|ttsc|${c.name}|mt`);
+      const tl = med(`${project}|ttsc-lint|${c.name}|mt`);
+      L.push(
+        `| ${project} · ${c.name} | ${cfg.kind} | ${s(lg)} | ${s(tt)} | ` +
+          `${s(tl)} | ${ratio(lg, tt)} | ${ratio(tl, tt)} |`,
+      );
+    }
+  }
+  L.push("");
+  L.push(
+    `*tsc→ttsc* is the legacy-over-ttsc speedup. *lint cost* is ttsc-lint ` +
+      `over plain ttsc — the marginal cost of folding \`@ttsc/lint\` into the ` +
+      `compile pass (a value near 1× means linting is nearly free).`,
+  );
+  L.push("");
+
+  // ── M2 — type-check only (--noEmit) ───────────────────────────────────────
+  L.push(`## M2 — Type-check only (\`--noEmit\`)`);
+  L.push("");
+  L.push(
+    `Pure type-checking, emit excluded. Isolates checker speed from emit cost.`,
+  );
+  L.push("");
+  L.push(`| Project | kind | legacy · tsc | ttsc | ttsc-lint | tsc→ttsc |`);
+  L.push(`| --- | --- | --- | --- | --- | --- |`);
+  for (const project of wantedProjects) {
+    const cfg = PROJECTS[project];
+    for (const c of cfg.cases) {
+      // For an emit-producing case the type-check-only cell is the `noEmit`
+      // mode (ttsc only — legacy has no noEmit cell wired). For a project
+      // whose build *is* `noEmit` (type-fest, vue) the `mt` cell IS the
+      // type-check cell, and legacy `tsc` is a like-for-like comparison.
+      const noEmitMode = c.emit ? "noEmit" : "mt";
+      const legacyShown = c.emit ? null : med(`${project}|legacy|${c.name}|mt`);
+      const tt = med(`${project}|ttsc|${c.name}|${noEmitMode}`);
+      const tl = med(`${project}|ttsc-lint|${c.name}|${noEmitMode}`);
+      if (tt == null && tl == null && legacyShown == null) continue;
+      L.push(
+        `| ${project} · ${c.name} | ${cfg.kind} | ${s(legacyShown)} | ` +
+          `${s(tt)} | ${s(tl)} | ${ratio(legacyShown, tt)} |`,
+      );
+    }
+  }
+  L.push("");
+  L.push(
+    `type-fest and vue are \`noEmit\` projects — their M1/M2 cell is the same ` +
+      `command, and legacy \`tsc\` for those is shown here as a like-for-like ` +
+      `compare. Emit-producing projects measure ttsc \`--noEmit\` only (stock ` +
+      `\`tsc\` has no comparable type-check-only build wired in the fixture).`,
+  );
+  L.push("");
+
+  // ── M3 — threading: single vs multi ───────────────────────────────────────
+  L.push(`## M3 — ttsc threading: single-threaded vs multi-threaded`);
+  L.push("");
+  L.push(
+    `\`ttsc --singleThreaded\` runs TypeScript-Go fully serial; the default ` +
+      `keeps parallel parse/check/emit. Speedup is multi-threaded over ` +
+      `single-threaded.`,
+  );
+  L.push("");
+  L.push(`| Project · branch · step | single-threaded | multi-threaded | speedup |`);
+  L.push(`| --- | --- | --- | --- |`);
+  for (const project of wantedProjects) {
+    const cfg = PROJECTS[project];
+    for (const c of cfg.cases) {
+      if (!c.singleThreaded) continue;
+      for (const branch of ["ttsc", "ttsc-lint"]) {
+        const mt = med(`${project}|${branch}|${c.name}|mt`);
+        const st = med(`${project}|${branch}|${c.name}|st`);
+        if (mt == null && st == null) continue;
+        L.push(
+          `| ${project} · ${branch} · ${c.name} | ${s(st)} | ${s(mt)} | ` +
+            `${ratio(st, mt)} |`,
+        );
+      }
+    }
+  }
+  L.push("");
+
+  // ── stability ─────────────────────────────────────────────────────────────
+  const raced = Object.values(results).filter((r) => r.raceRetries > 0);
+  const failed = Object.values(results).filter((r) => r.deterministicFailure);
+  if (raced.length || failed.length) {
+    L.push(`## Stability`);
+    L.push("");
+    if (raced.length) {
+      L.push(
+        `Parallel-emit data-race retries — intermittent; the reported timing ` +
+          `is from a clean run:`,
+      );
+      L.push("");
+      for (const r of raced)
+        L.push(
+          `- \`${r.label}\`: ${r.raceRetries} race ` +
+            `retr${r.raceRetries === 1 ? "y" : "ies"}`,
+        );
+      L.push("");
+    }
+    if (failed.length) {
+      L.push(
+        `Deterministic failures — retrying does not help, so the cell is ` +
+          `left unmeasured:`,
+      );
+      L.push("");
+      for (const r of failed)
+        L.push(
+          `- \`${r.label}\`: exits ${r.deterministicFailure.status} ` +
+            `(${r.deterministicFailure.kind}) on every run`,
+        );
+      L.push("");
+    }
+  }
+
+  // ── raw samples ───────────────────────────────────────────────────────────
+  L.push(`## Raw samples (ms)`);
+  L.push("");
+  L.push(`| Cell | runs | median | min |`);
+  L.push(`| --- | --- | --- | --- |`);
+  for (const k of Object.keys(results).sort()) {
+    const r = results[k];
+    L.push(
+      `| \`${k}\` | ${r.samples.map((x) => x.toFixed(0)).join(", ") || "—"} ` +
+        `| ${s(r.median)} | ${s(r.min)} |`,
+    );
+  }
+  L.push("");
+  return L.join("\n");
+}
+
+function printConfigTable() {
+  process.stdout.write(`\nttsc matrix benchmark — project config\n\n`);
+  for (const [name, cfg] of Object.entries(PROJECTS)) {
+    process.stdout.write(
+      `${name}  [${cfg.kind}]  branches: ${cfg.branches.join(", ")}\n`,
+    );
+    process.stdout.write(`  repo: ${cfg.repo}\n`);
+    if (cfg.prerequisites?.length)
+      process.stdout.write(`  prerequisites: ${cfg.prerequisites.join(", ")}\n`);
+    for (const c of cfg.cases) {
+      process.stdout.write(
+        `  case ${c.name}: emit=${c.emit} singleThreaded=${c.singleThreaded}` +
+          `${c.cwd ? ` cwd=${c.cwd}` : ""}\n`,
+      );
+      process.stdout.write(`    legacy: ${c.legacy?.build ?? "—"}\n`);
+      process.stdout.write(
+        `    ttsc:   ${c.ttsc?.build ?? "—"}` +
+          `${c.ttsc?.noEmit ? `  |  noEmit: ${c.ttsc.noEmit}` : ""}\n`,
+      );
+    }
+    process.stdout.write("\n");
   }
 }
-for (const c of CASES) {
-  if (!activeKeys.has(c.key)) continue;
-  results[c.key] = measure(c);
-}
-const R = (k) =>
-  results[k] ?? { median: null, min: null, raceRetries: 0, samples: [] };
-// A group is reported when any of its measurements has data, regardless of
-// which groups were requested this invocation (results accumulate on disk).
-const hasGroup = (g) => GROUPS[g].some((k) => results[k]?.median != null);
 
-// ── report ───────────────────────────────────────────────────────────────────
-const cpu = os.cpus();
-const lines = [];
-lines.push(`# ttsc benchmark — shopping-backend`);
-lines.push("");
-lines.push(`- Date: ${started.toISOString()}`);
-lines.push(`- Host: ${os.type()} ${os.release()} · ${cpu.length}× ${cpu[0]?.model?.trim()} · ${(os.totalmem() / 2 ** 30).toFixed(0)} GB`);
-lines.push(`- Method: ${WARMUP} warmup + ${RUNS} measured runs per command; median reported. A run that hits the intermittent parallel-emit race is retried (up to ${RETRIES}×); a deterministic failure is reported as such, not retried.`);
-lines.push("");
+// ── main ─────────────────────────────────────────────────────────────────────
 
-if (hasGroup("b1")) {
-  lines.push(`## B1 — Build speed: tsc (legacy) vs ttsc (next)`);
-  lines.push("");
-  lines.push(`| Step | legacy · tsc | next · ttsc | speedup |`);
-  lines.push(`| --- | --- | --- | --- |`);
-  for (const [step, lk, nk] of [
-    ["build:main", "legacy:build:main", "next:build:main"],
-    ["build:test", "legacy:build:test", "next:build:test"],
-  ]) {
-    lines.push(`| ${step} | ${s(R(lk).median)} | ${s(R(nk).median)} | ${ratio(R(lk).median, R(nk).median)} |`);
+function main() {
+  const started = new Date();
+  fs.mkdirSync(WORK, { recursive: true });
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+
+  // Prior results merge in so projects can be measured across invocations.
+  const jsonPath = OUT.replace(/\.md$/, ".json");
+  let results = {};
+  if (fs.existsSync(jsonPath)) {
+    try {
+      results = JSON.parse(fs.readFileSync(jsonPath, "utf8")).results ?? {};
+    } catch {
+      results = {};
+    }
   }
-  const lTot = sum(R("legacy:build:main").median, R("legacy:build:test").median);
-  const nTot = sum(R("next:build:main").median, R("next:build:test").median);
-  lines.push(`| **main + test** | **${s(lTot)}** | **${s(nTot)}** | **${ratio(lTot, nTot)}** |`);
-  lines.push("");
-}
 
-if (hasGroup("b2")) {
-  lines.push(`## B2 — Format speed: prettier (legacy) vs ttsc format (experiment)`);
-  lines.push("");
-  lines.push(`| Tool | command | median |`);
-  lines.push(`| --- | --- | --- |`);
-  lines.push(`| prettier | \`prettier src --write\` | ${s(R("legacy:prettier").median)} |`);
-  lines.push(`| ttsc format | \`ttsc format\` | ${s(R("experiment:format").median)} |`);
-  lines.push(`| **speedup** | | **${ratio(R("legacy:prettier").median, R("experiment:format").median)}** |`);
-  lines.push("");
-}
-
-if (hasGroup("b3")) {
-  lines.push(`## B3 — Build + lint: tsc+eslint (legacy) vs ttsc+@ttsc/lint (experiment)`);
-  lines.push("");
-  lines.push(`@ttsc/lint folds linting into the single ttsc compile pass; eslint is a separate process.`);
-  lines.push("");
-  lines.push(`| Layer | legacy (tsc + eslint) | experiment (ttsc + lint) | speedup |`);
-  lines.push(`| --- | --- | --- | --- |`);
-  const lMain = sum(R("legacy:build:main").median, R("legacy:eslint:src").median);
-  const lTest = sum(R("legacy:build:test").median, R("legacy:eslint:test").median);
-  const xTotal = sum(R("experiment:build:main").median, R("experiment:build:test").median);
-  lines.push(`| build:main + src lint | ${s(R("legacy:build:main").median)} + ${s(R("legacy:eslint:src").median)} = ${s(lMain)} | ${s(R("experiment:build:main").median)} | ${ratio(lMain, R("experiment:build:main").median)} |`);
-  lines.push(`| build:test + test lint | ${s(R("legacy:build:test").median)} + ${s(R("legacy:eslint:test").median)} = ${s(lTest)} | ${s(R("experiment:build:test").median)} | ${ratio(lTest, R("experiment:build:test").median)} |`);
-  lines.push(`| **total** | **${s(sum(lMain, lTest))}** | **${s(xTotal)}** | **${ratio(sum(lMain, lTest), xTotal)}** |`);
-  lines.push("");
-}
-
-if (hasGroup("b4")) {
-  lines.push(`## B4 — ttsc threading: single-threaded vs multi-threaded`);
-  lines.push("");
-  lines.push(`\`ttsc --singleThreaded\` runs TypeScript-Go fully serial; the default keeps parallel parsing and emit. Speedup is multi-threaded over single-threaded.`);
-  lines.push("");
-  lines.push(`| Project · step | single-threaded | multi-threaded | speedup |`);
-  lines.push(`| --- | --- | --- | --- |`);
-  for (const [label, mt, st] of [
-    ["next · build:main", "next:build:main", "next:build:main:st"],
-    ["next · build:test", "next:build:test", "next:build:test:st"],
-    ["experiment · build:main", "experiment:build:main", "experiment:build:main:st"],
-    ["experiment · build:test", "experiment:build:test", "experiment:build:test:st"],
-  ]) {
-    lines.push(`| ${label} | ${s(R(st).median)} | ${s(R(mt).median)} | ${ratio(R(st).median, R(mt).median)} |`);
+  // Step 1 — tarballs (skipped by --no-setup, which assumes clones are ready).
+  if (!flags.has("--no-setup")) {
+    packTarballs();
   }
-  lines.push("");
-}
 
-const raced = Object.values(results).filter((r) => r.raceRetries > 0);
-const failed = Object.entries(results).filter(([, r]) => r.deterministicFailure);
-if (raced.length || failed.length) {
-  lines.push(`## Stability`);
-  lines.push("");
-  if (raced.length) {
-    lines.push(`Parallel-emit data-race retries — intermittent; the reported timing is from a clean run:`);
-    lines.push("");
-    for (const r of raced)
-      lines.push(`- \`${r.key}\`: ${r.raceRetries} race retr${r.raceRetries === 1 ? "y" : "ies"}`);
-    lines.push("");
+  // Steps 2 + 3 — clone + install every (project, branch).
+  const ready = {}; // project -> Set<branch> that installed cleanly
+  if (!flags.has("--no-setup")) {
+    process.stdout.write(`\n▸ cloning + installing fixtures into ${WORK}\n`);
+    for (const project of wantedProjects) {
+      ready[project] = new Set();
+      for (const branch of PROJECTS[project].branches) {
+        try {
+          if (setupClone(project, branch)) ready[project].add(branch);
+        } catch (err) {
+          process.stdout.write(
+            `  ⚠ ${project}@${branch}: setup failed — ${err.message}\n`,
+          );
+        }
+      }
+    }
+  } else {
+    // --no-setup: trust whatever clones already exist on disk.
+    for (const project of wantedProjects) {
+      ready[project] = new Set(
+        PROJECTS[project].branches.filter((b) =>
+          fs.existsSync(cloneDir(project, b)),
+        ),
+      );
+    }
   }
-  if (failed.length) {
-    lines.push(`Deterministic failures — a real compile error (retrying does not help), so the cell is left unmeasured:`);
-    lines.push("");
-    for (const [k, r] of failed)
-      lines.push(`- \`${k}\`: exits ${r.deterministicFailure.status} on every run`);
-    lines.push("");
+
+  if (flags.has("--setup-only")) {
+    process.stdout.write(`\n✓ setup complete — clones in ${WORK}\n`);
+    return;
   }
+
+  // Step 4 — measure.
+  for (const project of wantedProjects) {
+    for (const c of PROJECTS[project].cases) {
+      for (const branch of PROJECTS[project].branches) {
+        if (!ready[project]?.has(branch)) continue;
+        measureCase(results, project, branch, c);
+      }
+    }
+  }
+
+  // Report.
+  const host = hostSpec(wantedProjects);
+  const report = buildReport(results, started, host);
+  fs.writeFileSync(OUT, report);
+  fs.writeFileSync(
+    jsonPath,
+    JSON.stringify({ started, host, results }, null, 2),
+  );
+  process.stdout.write(`\n${report}\n\nReport written to ${OUT}\n`);
 }
 
-lines.push(`## Raw samples (ms)`);
-lines.push("");
-lines.push(`| Measurement | runs | median | min |`);
-lines.push(`| --- | --- | --- | --- |`);
-for (const k of Object.keys(results)) {
-  const r = results[k];
-  lines.push(`| \`${k}\` | ${r.samples.map((x) => x.toFixed(0)).join(", ") || "—"} | ${s(r.median)} | ${s(r.min)} |`);
-}
-lines.push("");
-
-fs.mkdirSync(path.dirname(OUT), { recursive: true });
-const report = lines.join("\n");
-fs.writeFileSync(OUT, report);
-fs.writeFileSync(OUT.replace(/\.md$/, ".json"), JSON.stringify({ started, results }, null, 2));
-process.stdout.write(`\n${report}\n\nReport written to ${OUT}\n`);
+main();

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -99,6 +99,18 @@ function median(xs) {
   return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
 }
 
+/**
+ * Classify a failed run from its output. A `race` failure is the intermittent
+ * Go data-race crash; anything else is a deterministic `error` (e.g. a type
+ * error). This keeps an orthogonal stability bug from being mislabelled — and
+ * stops a deterministic compile error from being reported as a "crash".
+ */
+function classifyFailure(log) {
+  return /concurrent map|fatal error|\bpanic:|DATA RACE/.test(log)
+    ? "race"
+    : "error";
+}
+
 function measure(c) {
   const cwd = PROJECTS[c.project];
   process.stdout.write(`\n▶ ${c.key}\n  ${c.cmd}\n`);
@@ -107,18 +119,22 @@ function measure(c) {
     process.stdout.write(`  warmup ${i + 1}: ${w.ms.toFixed(0)} ms ${w.ok ? "ok" : `EXIT ${w.status}`}\n`);
   }
   const samples = [];
-  let crashes = 0;
+  let raceRetries = 0;
+  let deterministicFailure = null; // { status } when a run never succeeds
   for (let i = 0; i < RUNS; i++) {
     let r = runOnce(cwd, c.cmd);
     let attempts = 0;
     while (!r.ok && attempts < RETRIES) {
-      crashes++;
+      const kind = classifyFailure(r.log);
+      if (kind === "race") raceRetries++;
       attempts++;
-      process.stdout.write(`  run ${i + 1}: EXIT ${r.status} — retry ${attempts}\n`);
+      process.stdout.write(`  run ${i + 1}: EXIT ${r.status} (${kind}) — retry ${attempts}\n`);
+      if (kind === "error") break; // deterministic: retrying will not help
       r = runOnce(cwd, c.cmd);
     }
     if (!r.ok) {
-      process.stdout.write(`  run ${i + 1}: still failing after ${RETRIES} retries — skipped\n`);
+      deterministicFailure = { status: r.status };
+      process.stdout.write(`  run ${i + 1}: EXIT ${r.status} — deterministic failure, not measured\n`);
       continue;
     }
     samples.push(r.ms);
@@ -127,7 +143,8 @@ function measure(c) {
   return {
     key: c.key,
     samples,
-    crashes,
+    raceRetries,
+    deterministicFailure,
     median: samples.length ? median(samples) : null,
     min: samples.length ? Math.min(...samples) : null,
   };
@@ -138,6 +155,10 @@ function s(ms) {
 }
 function ratio(slow, fast) {
   return slow == null || fast == null ? "—" : `${(slow / fast).toFixed(2)}×`;
+}
+// Sum that stays honest: if any component is missing, so is the total.
+function sum(...xs) {
+  return xs.some((x) => x == null) ? null : xs.reduce((a, b) => a + b, 0);
 }
 
 // ── run ──────────────────────────────────────────────────────────────────────
@@ -157,7 +178,8 @@ for (const c of CASES) {
   if (!activeKeys.has(c.key)) continue;
   results[c.key] = measure(c);
 }
-const R = (k) => results[k] ?? { median: null, min: null, crashes: 0, samples: [] };
+const R = (k) =>
+  results[k] ?? { median: null, min: null, raceRetries: 0, samples: [] };
 // A group is reported when any of its measurements has data, regardless of
 // which groups were requested this invocation (results accumulate on disk).
 const hasGroup = (g) => GROUPS[g].some((k) => results[k]?.median != null);
@@ -169,7 +191,7 @@ lines.push(`# ttsc benchmark — shopping-backend`);
 lines.push("");
 lines.push(`- Date: ${started.toISOString()}`);
 lines.push(`- Host: ${os.type()} ${os.release()} · ${cpu.length}× ${cpu[0]?.model?.trim()} · ${(os.totalmem() / 2 ** 30).toFixed(0)} GB`);
-lines.push(`- Method: ${WARMUP} warmup + ${RUNS} measured runs per command; median reported. Crashed runs retried up to ${RETRIES}×.`);
+lines.push(`- Method: ${WARMUP} warmup + ${RUNS} measured runs per command; median reported. A run that hits the intermittent parallel-emit race is retried (up to ${RETRIES}×); a deterministic failure is reported as such, not retried.`);
 lines.push("");
 
 if (hasGroup("b1")) {
@@ -183,8 +205,8 @@ if (hasGroup("b1")) {
   ]) {
     lines.push(`| ${step} | ${s(R(lk).median)} | ${s(R(nk).median)} | ${ratio(R(lk).median, R(nk).median)} |`);
   }
-  const lTot = R("legacy:build:main").median + R("legacy:build:test").median;
-  const nTot = R("next:build:main").median + R("next:build:test").median;
+  const lTot = sum(R("legacy:build:main").median, R("legacy:build:test").median);
+  const nTot = sum(R("next:build:main").median, R("next:build:test").median);
   lines.push(`| **main + test** | **${s(lTot)}** | **${s(nTot)}** | **${ratio(lTot, nTot)}** |`);
   lines.push("");
 }
@@ -207,22 +229,34 @@ if (hasGroup("b3")) {
   lines.push("");
   lines.push(`| Layer | legacy (tsc + eslint) | experiment (ttsc + lint) | speedup |`);
   lines.push(`| --- | --- | --- | --- |`);
-  const lMain = R("legacy:build:main").median + R("legacy:eslint:src").median;
-  const lTest = R("legacy:build:test").median + R("legacy:eslint:test").median;
+  const lMain = sum(R("legacy:build:main").median, R("legacy:eslint:src").median);
+  const lTest = sum(R("legacy:build:test").median, R("legacy:eslint:test").median);
+  const xTotal = sum(R("experiment:build:main").median, R("experiment:build:test").median);
   lines.push(`| build:main + src lint | ${s(R("legacy:build:main").median)} + ${s(R("legacy:eslint:src").median)} = ${s(lMain)} | ${s(R("experiment:build:main").median)} | ${ratio(lMain, R("experiment:build:main").median)} |`);
   lines.push(`| build:test + test lint | ${s(R("legacy:build:test").median)} + ${s(R("legacy:eslint:test").median)} = ${s(lTest)} | ${s(R("experiment:build:test").median)} | ${ratio(lTest, R("experiment:build:test").median)} |`);
-  lines.push(`| **total** | **${s(lMain + lTest)}** | **${s(R("experiment:build:main").median + R("experiment:build:test").median)}** | **${ratio(lMain + lTest, R("experiment:build:main").median + R("experiment:build:test").median)}** |`);
+  lines.push(`| **total** | **${s(sum(lMain, lTest))}** | **${s(xTotal)}** | **${ratio(sum(lMain, lTest), xTotal)}** |`);
   lines.push("");
 }
 
-const crashed = Object.values(results).filter((r) => r.crashes > 0);
-if (crashed.length) {
+const raced = Object.values(results).filter((r) => r.raceRetries > 0);
+const failed = Object.entries(results).filter(([, r]) => r.deterministicFailure);
+if (raced.length || failed.length) {
   lines.push(`## Stability`);
   lines.push("");
-  lines.push(`Intermittent \`@nestia/core\` parallel-emit crash (\`concurrent map read and map write\`), retried:`);
-  lines.push("");
-  for (const r of crashed) lines.push(`- \`${r.key}\`: ${r.crashes} crash(es) across ${RUNS} measured runs`);
-  lines.push("");
+  if (raced.length) {
+    lines.push(`Parallel-emit data-race retries — intermittent; the reported timing is from a clean run:`);
+    lines.push("");
+    for (const r of raced)
+      lines.push(`- \`${r.key}\`: ${r.raceRetries} race retr${r.raceRetries === 1 ? "y" : "ies"}`);
+    lines.push("");
+  }
+  if (failed.length) {
+    lines.push(`Deterministic failures — a real compile error (retrying does not help), so the cell is left unmeasured:`);
+    lines.push("");
+    for (const [k, r] of failed)
+      lines.push(`- \`${k}\`: exits ${r.deterministicFailure.status} on every run`);
+    lines.push("");
+  }
 }
 
 lines.push(`## Raw samples (ms)`);

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -160,7 +160,7 @@ const PACKAGE_CONFIGS = {
     installCommand:
       "pnpm --ignore-workspace install --virtual-store-dir node_modules/.pnpm --no-frozen-lockfile --ignore-scripts",
     installTarballsCommand: (specs) =>
-      `pnpm --ignore-workspace add --virtual-store-dir node_modules/.pnpm -D --no-frozen-lockfile --ignore-scripts ${specs}`,
+      `pnpm --ignore-workspace add --virtual-store-dir node_modules/.pnpm -D --ignore-scripts ${specs}`,
     prepareCommand: "pnpm exec ttsc prepare -p tsconfig.json",
     filesRoot: "src",
     commands: compilerCommands({
@@ -654,8 +654,8 @@ function installLocalTarballs(project, dir, branch) {
     project.installTarballsCommand?.(specs) ??
     (pm === "pnpm"
       ? ownsPnpmWorkspace(dir)
-        ? `pnpm add -w -D --no-frozen-lockfile ${specs}`
-        : `pnpm add --ignore-workspace -D --no-frozen-lockfile ${specs}`
+        ? `pnpm add -w -D ${specs}`
+        : `pnpm add --ignore-workspace -D ${specs}`
       : pm === "yarn"
         ? `YARN_CACHE_FOLDER=.yarn-cache yarn add --dev --force --update-checksums --ignore-engines --ignore-workspace-root-check ${specs}`
         : `npm install --legacy-peer-deps --save-dev ${specs}`);
@@ -687,6 +687,13 @@ function scrubLocalTarballInstallState(dir, targets) {
     const text = fs.readFileSync(lockfile, "utf8");
     if (text.includes("ttsc-tgz")) fs.rmSync(lockfile);
   }
+  const pnpmStoreLockfile = path.join(
+    dir,
+    "node_modules",
+    ".pnpm",
+    "lock.yaml",
+  );
+  fs.rmSync(pnpmStoreLockfile, { force: true });
 }
 
 function findProjectFiles(root, names) {
@@ -812,8 +819,8 @@ function installTsgoExperimentDeps(project, dir) {
   const cmd =
     pm === "pnpm"
       ? ownsPnpmWorkspace(dir)
-        ? `pnpm add -w -D --no-frozen-lockfile ${specs}`
-        : `pnpm add --ignore-workspace --virtual-store-dir node_modules/.pnpm -D --no-frozen-lockfile ${specs}`
+        ? `pnpm add -w -D ${specs}`
+        : `pnpm add --ignore-workspace --virtual-store-dir node_modules/.pnpm -D ${specs}`
       : pm === "yarn"
         ? `YARN_CACHE_FOLDER=.yarn-cache yarn add --dev --force --update-checksums --ignore-engines --ignore-workspace-root-check ${specs}`
         : `npm install --legacy-peer-deps --ignore-scripts --save-dev ${specs}`;

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -1,626 +1,855 @@
 #!/usr/bin/env node
 /**
- * ttsc matrix benchmark runner.
+ * Prepared-clone benchmark runner for the ttsc comparison matrix.
  *
- * Clone-based, fully reproducible from a clean checkout. For every fixture
- * project the runner clones three branches of a forked repo —
+ * The benchmark worktree is `experimental/benchmark/.work` by default. Each
+ * measured repository is cloned once per branch into:
  *
- *   - `legacy`    stock `tsc` toolchain (TypeScript 5.x · prettier · eslint)
- *   - `ttsc`      the `ttsc` toolchain (TypeScript 7 via @typescript/native-preview)
- *   - `ttsc-lint` `ttsc` + `@ttsc/lint` (lint folded into the compile pass)
+ * .work/<repo>@legacy .work/<repo>@ttsc .work/<repo>@ttsc-lint
  *
- * — then measures, for each (project × branch):
+ * Existing clone directories are preserved. Missing directories are cloned,
+ * installed, prepared, and then measured. `ttsc prepare` runs before timings so
+ * plugin/native binary build time is not included in compiler measurements.
  *
- *   - emit build           the project's real build command (type-check + emit)
- *   - noEmit               the same input under `--noEmit` (type-check only)
- *   - multi-threaded       ttsc's default (parallel parse/check/emit)
- *   - single-threaded      `--singleThreaded` (TypeScript-Go fully serial)
- *
- * The legacy branch is only measured multi-threaded (stock `tsc` has no
- * `--singleThreaded`); the ttsc / ttsc-lint branches are measured both ways.
- *
- * Each cell does WARMUP unmeasured runs then RUNS measured runs and reports the
- * median. A measured run that exits non-zero is classified as a `race` failure
- * (the intermittent Go data-race crash — retried, the clean timing is kept) or
- * a deterministic `error` (a real compile error — not retried, cell left
- * unmeasured). A (project × branch) whose fork branch does not exist yet, or a
- * mode a project does not support, is skipped cleanly — never a crash.
- *
- * Pipeline:
- *
- *   1. build + pack the local ttsc / @ttsc/lint / current-platform tarballs
- *      into /tmp/ttsc-tgz/ so fixtures install the compiler under test;
- *   2. `git clone` each fixture branch into an OUTSIDE-the-repo working dir
- *      (cloning inside the ttsc tree would let pnpm adopt the clone into the
- *      ttsc workspace) — default /tmp/ttsc-bench-work/;
- *   3. `pnpm install` each clone; `ttsc prepare` the ttsc / ttsc-lint clones;
- *      run each project's prerequisites (e.g. shopping-backend build:prisma);
- *   4. measure the matrix; write a Markdown report + raw JSON sidecar into the
- *      git-ignored `.work/` directory, AND the canonical, committed result file
- *      `website/public/benchmark.json` (the schema the website dashboard
- *      renders — locked by `website/src/components/benchmark/types.ts`).
- *
- * Usage:
- *   node bench.mjs [projects...]            # e.g. `node bench.mjs tstl zod`
- *   node bench.mjs --setup-only             # clone + install, no measuring
- *   node bench.mjs --no-setup               # measure only (reuse clones)
- *   node bench.mjs --list                   # print the config table and exit
- *
- * Environment overrides:
- *   TTSC_BENCH_WORK=/path        clone working dir       (default /tmp/ttsc-bench-work)
- *   TTSC_BENCH_TGZ=/path         tarball staging dir     (default /tmp/ttsc-tgz)
- *   TTSC_BENCH_OUT=/path/x.md    report destination      (default .work/report.md)
- *   TTSC_BENCH_RUNS=3            measured runs per cell
- *   TTSC_BENCH_WARMUP=1          warmup runs per cell
- *   TTSC_BENCH_RETRIES=3         retries to recover a crashed run
- *   TTSC_BENCH_SKIP_PACK=1       reuse existing tarballs (skip step 1)
+ * Useful modes: node bench.mjs --setup-only node bench.mjs --verify-only node
+ * bench.mjs --no-setup --verify-only vue rxjs
  */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-// ── configuration ────────────────────────────────────────────────────────────
-
 const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
 const WORK =
-  process.env.TTSC_BENCH_WORK ?? path.join(os.tmpdir(), "ttsc-bench-work");
+  process.env.TTSC_BENCH_WORK ?? path.resolve(import.meta.dirname, ".work");
 const TGZ = process.env.TTSC_BENCH_TGZ ?? path.join(os.tmpdir(), "ttsc-tgz");
 const OUT =
   process.env.TTSC_BENCH_OUT ??
   path.resolve(import.meta.dirname, ".work", "report.md");
-// The canonical, committed, served result file. The website dashboard fetches
-// this; its schema is locked by website/src/components/benchmark/types.ts.
 const WEBSITE_JSON = path.resolve(
   REPO_ROOT,
   "website",
   "public",
   "benchmark.json",
 );
-const RUNS = Number(process.env.TTSC_BENCH_RUNS ?? 3);
-const WARMUP = Number(process.env.TTSC_BENCH_WARMUP ?? 1);
-const RETRIES = Number(process.env.TTSC_BENCH_RETRIES ?? 3);
+const REPORT_JSON = OUT.replace(/\.md$/, ".json");
+const CHECKPOINT_JSON =
+  process.env.TTSC_BENCH_CHECKPOINT ??
+  path.resolve(WORK, "benchmark.checkpoint.json");
 
-// The ttsc workspace version every fixture branch pins its tarballs against.
+const RUNS = numberEnv("TTSC_BENCH_RUNS", 10);
+const WARMUP = numberEnv("TTSC_BENCH_WARMUP", 1);
+const RETRIES = numberEnv("TTSC_BENCH_RETRIES", 2);
+const BRANCHES = ["legacy", "ttsc", "ttsc-lint"];
 const TTSC_VERSION = JSON.parse(
   fs.readFileSync(path.join(REPO_ROOT, "packages/ttsc/package.json"), "utf8"),
 ).version;
+const TSGO_VERSION =
+  packageVersion(
+    path.join(REPO_ROOT, "node_modules", "@typescript", "native-preview"),
+  ) ?? "7.0.0-dev.20260521.1";
 const PLATFORM_KEY = `${process.platform}-${process.arch}`;
-
-/**
- * The declarative per-project matrix.
- *
- * Each project clones a forked repo and exposes one or more `cases`. A case is
- * a measured command parametrised over a branch and a mode. `build` is the
- * emit-producing command; `noEmit` is the type-check-only command; both omit
- * the project's clean step so the timing is the compiler, not `rimraf`. The
- * runner prepends the clean step itself when a case declares `clean`.
- *
- * `singleThreaded: true` on a case means the runner *also* measures it with
- * `--singleThreaded` appended (only meaningful for ttsc / ttsc-lint branches).
- *
- * A branch absent from `branches` is a fork branch not pushed yet — the runner
- * skips it. TODO entries below are projects/branches still being set up.
- */
-const PROJECTS = {
-  // ── plugin-heavy: every file runs typia + @nestia source-plugin transforms ──
-  "shopping-backend": {
-    repo: "https://github.com/samchon/shopping-backend.git",
-    kind: "plugin-heavy",
-    branches: ["legacy", "ttsc", "ttsc-lint"],
-    // Prisma client + nestia SDK that build:main type-checks against.
-    prerequisites: ["build:prisma", "build:sdk"],
-    cases: [
-      {
-        // build:test is intentionally not measured: shopping-backend's matrix
-        // is build:main only (the test tsconfig double-counts the same files).
-        name: "build:main",
-        emit: true,
-        singleThreaded: true,
-        legacy: { build: "pnpm exec tsc" },
-        ttsc: {
-          build: "pnpm exec ttsc",
-          noEmit: "pnpm exec ttsc --noEmit",
-          stClean: "pnpm exec rimraf lib",
-        },
-      },
-    ],
+const PLATFORM_PACKAGE = `@ttsc/${PLATFORM_KEY}`;
+const TSGO_PLATFORM_PACKAGE = `@typescript/native-preview-${PLATFORM_KEY}`;
+const LOCAL_TARBALLS = [
+  {
+    dir: "packages/ttsc",
+    file: `ttsc-${TTSC_VERSION}.tgz`,
+    name: "ttsc",
   },
-
-  // ── plugin-free emit-producing libraries (the scaling curve) ────────────────
-  tstl: {
-    repo: "https://github.com/samchon/tstl.git",
-    kind: "plugin-free",
-    branches: ["legacy", "ttsc", "ttsc-lint"],
-    prerequisites: [],
-    cases: [
-      {
-        name: "build",
-        emit: true,
-        singleThreaded: true,
-        legacy: { build: "pnpm exec tsc" },
-        ttsc: {
-          build: "pnpm exec ttsc",
-          noEmit: "pnpm exec ttsc --noEmit",
-          stClean: "pnpm exec rimraf lib",
-        },
-      },
-    ],
+  {
+    dir: "packages/lint",
+    file: `ttsc-lint-${TTSC_VERSION}.tgz`,
+    name: "@ttsc/lint",
   },
-
-  zod: {
-    repo: "https://github.com/samchon/ttsc-benchmark-zod.git",
-    kind: "plugin-free",
-    branches: ["legacy", "ttsc", "ttsc-lint"],
-    prerequisites: [],
-    cases: [
-      {
-        // `build:benchmark` compiles the zod package via tsconfig.benchmark.json
-        // (tsc on legacy, ttsc on ttsc/ttsc-lint).
-        name: "build:benchmark",
-        emit: true,
-        singleThreaded: true,
-        cwd: "packages/zod",
-        legacy: { build: "pnpm exec tsc -p tsconfig.benchmark.json" },
-        ttsc: {
-          build: "pnpm exec ttsc -p tsconfig.benchmark.json",
-          noEmit: "pnpm exec ttsc -p tsconfig.benchmark.json --noEmit",
-          stClean: "pnpm exec rimraf lib",
-        },
-      },
-    ],
+  {
+    dir: `packages/ttsc-${PLATFORM_KEY}`,
+    file: `ttsc-${PLATFORM_KEY}-${TTSC_VERSION}.tgz`,
+    name: PLATFORM_PACKAGE,
   },
-
-  rxjs: {
-    repo: "https://github.com/samchon/ttsc-benchmark-rxjs.git",
-    kind: "plugin-free",
-    branches: ["legacy", "ttsc", "ttsc-lint"],
-    // rxjs is a yarn/nx monorepo; the benchmark cell is the rxjs package only.
-    packageManager: "yarn",
-    prerequisites: [],
-    cases: [
-      {
-        // `build:bench` compiles packages/rxjs via tsconfig.bench.json.
-        name: "build:bench",
-        emit: true,
-        singleThreaded: true,
-        cwd: "packages/rxjs",
-        legacy: { build: "yarn exec tsc -- -p tsconfig.bench.json" },
-        ttsc: {
-          build: "yarn exec ttsc -- -p tsconfig.bench.json",
-          noEmit: "yarn exec ttsc -- -p tsconfig.bench.json --noEmit",
-          stClean: "pnpm exec rimraf dist-bench",
-        },
-      },
-    ],
-  },
-
-  // ── plugin-free pure type-check (no emit build) ─────────────────────────────
-  "type-fest": {
-    repo: "https://github.com/samchon/ttsc-benchmark-type-fest.git",
-    kind: "plugin-free",
-    branches: ["legacy", "ttsc", "ttsc-lint"],
-    prerequisites: [],
-    cases: [
-      {
-        // type-fest's tsconfig is permanently `noEmit: true` — a pure
-        // type-checker stress with no emit cell. `emit: false` keeps it out of
-        // the emit-build comparison so it is not weighed against emitting cells.
-        name: "check",
-        emit: false,
-        singleThreaded: true,
-        legacy: { build: "pnpm exec tsc" },
-        ttsc: {
-          build: "pnpm exec ttsc",
-          // build is already noEmit; no separate noEmit cell.
-        },
-      },
-    ],
-  },
-
-  // ── frontend framework: type-check only (vue builds via rollup) ─────────────
-  vue: {
-    repo: "https://github.com/samchon/ttsc-benchmark-vue.git",
-    kind: "plugin-free",
-    branches: ["legacy", "ttsc", "ttsc-lint"],
-    prerequisites: [],
-    cases: [
-      {
-        // vue's tsconfig is `noEmit` (vue ships JS via rollup), so the measured
-        // op is a pure `--noEmit` type-check. `emit: false` keeps it out of the
-        // M1 emit-build comparison; the `mt`/`st` cells ARE the type-check cells.
-        name: "check",
-        emit: false,
-        singleThreaded: true,
-        legacy: { build: "pnpm exec tsc --noEmit" },
-        ttsc: { build: "pnpm exec ttsc --noEmit" },
-      },
-    ],
-  },
-
-  // ── backend framework: project-references monorepo via a build orchestrator ─
-  nestjs: {
-    repo: "https://github.com/samchon/ttsc-benchmark-nestjs.git",
-    kind: "plugin-free",
-    branches: ["legacy", "ttsc", "ttsc-lint"],
-    prerequisites: [],
-    cases: [
-      {
-        // nestjs has no `tsc -b` analogue in ttsc; the ttsc branches ship a
-        // `scripts/build-ttsc.mjs` orchestrator that walks packages in
-        // topological order. That orchestrator emits and exposes no --noEmit /
-        // --singleThreaded flag, so this case measures the emit build only.
-        name: "build",
-        emit: true,
-        singleThreaded: false,
-        legacy: { build: "pnpm exec tsc -b packages" },
-        ttsc: { build: "node scripts/build-ttsc.mjs" },
-      },
-    ],
-  },
-
-  // TODO(#118): vscode fixture — the samchon/ttsc-benchmark-vscode repo has no
-  // legacy / ttsc / ttsc-lint branches yet. When the fixture agent pushes them,
-  // add a `vscode` entry here mirroring `vue` (VSCode type-checks via `tsc`).
-};
-
-// ── argument parsing ─────────────────────────────────────────────────────────
+];
 
 const argv = process.argv.slice(2);
 const flags = new Set(argv.filter((a) => a.startsWith("--")));
 const positional = argv.filter((a) => !a.startsWith("--"));
+
+const PACKAGE_CONFIGS = {
+  vue: {
+    kind: "frontend monorepo",
+    repoName: "ttsc-benchmark-vue",
+    repo: "https://github.com/samchon/ttsc-benchmark-vue.git",
+    packageManager: "pnpm",
+    filesRoot: "packages",
+    commands: compilerCommands({
+      build: (tool) => [`pnpm exec ${tool} -p tsconfig.json`],
+      noEmit: (tool) => [`pnpm exec ${tool} -p tsconfig.json --noEmit`],
+      eslint: ["pnpm exec eslint . --ignore-pattern 'temp/**'"],
+    }),
+  },
+  rxjs: {
+    kind: "library monorepo",
+    repoName: "ttsc-benchmark-rxjs",
+    repo: "https://github.com/samchon/ttsc-benchmark-rxjs.git",
+    packageManager: "yarn",
+    filesRoot: "packages",
+    commands: compilerCommands({
+      build: (tool) => [
+        {
+          cwd: "packages/observable",
+          cmd: `yarn --ignore-engines exec ${tool} -- -p tsconfig.json`,
+        },
+        ...rxjsBuildSteps(tool),
+      ],
+      noEmit: (tool) => [
+        {
+          cwd: "packages/observable",
+          cmd: `yarn --ignore-engines exec ${tool} -- -p tsconfig.json --noEmit`,
+        },
+        ...rxjsNoEmitSteps(tool),
+      ],
+      eslint: [
+        {
+          cwd: "packages/observable",
+          cmd: "yarn --ignore-engines exec eslint -- 'src/**/*.ts' --ignore-pattern '**/*.d.ts'",
+        },
+        {
+          cwd: "packages/rxjs",
+          cmd: "yarn --ignore-engines exec eslint -- 'src/**/*.ts' --ignore-pattern '**/*.d.ts'",
+        },
+      ],
+    }),
+  },
+  "type-fest": {
+    kind: "type-level library",
+    repoName: "ttsc-benchmark-type-fest",
+    repo: "https://github.com/samchon/ttsc-benchmark-type-fest.git",
+    packageManager: "pnpm",
+    filesRoot: ".",
+    commands: compilerCommands({
+      build: (tool) => [
+        {
+          cmd: `pnpm exec ${tool} -p tsconfig.json`,
+          env: { NODE_OPTIONS: "--max-old-space-size=6144" },
+        },
+      ],
+      noEmit: (tool) => [
+        {
+          cmd: `pnpm exec ${tool} -p tsconfig.json --noEmit`,
+          env: { NODE_OPTIONS: "--max-old-space-size=6144" },
+        },
+      ],
+      eslint: ["pnpm exec eslint . --quiet"],
+    }),
+  },
+  typeorm: {
+    kind: "ORM library",
+    repoName: "ttsc-benchmark-typeorm",
+    repo: "https://github.com/samchon/ttsc-benchmark-typeorm.git",
+    packageManager: "pnpm",
+    installCommand:
+      "pnpm --ignore-workspace install --virtual-store-dir node_modules/.pnpm --no-frozen-lockfile --ignore-scripts",
+    installTarballsCommand: (specs) =>
+      `pnpm --ignore-workspace add --virtual-store-dir node_modules/.pnpm -D --ignore-scripts ${specs}`,
+    prepareCommand: "pnpm exec ttsc prepare -p tsconfig.json",
+    filesRoot: "src",
+    commands: compilerCommands({
+      build: (tool) => [`pnpm exec ${tool} -p tsconfig.json`],
+      noEmit: (tool) => [`pnpm exec ${tool} -p tsconfig.json --noEmit`],
+      eslint: ["pnpm exec eslint --quiet"],
+    }),
+  },
+  zod: {
+    kind: "schema library monorepo",
+    repoName: "ttsc-benchmark-zod",
+    repo: "https://github.com/samchon/ttsc-benchmark-zod.git",
+    packageManager: "pnpm",
+    filesRoot: "packages/zod/src",
+    commands: compilerCommands({
+      build: (tool) => [
+        {
+          cwd: "packages/zod",
+          cmd: `pnpm exec ${tool} -p tsconfig.build.json`,
+        },
+      ],
+      noEmit: (tool) => [
+        {
+          cwd: "packages/zod",
+          cmd: `pnpm exec ${tool} -p tsconfig.json --noEmit`,
+        },
+      ],
+      eslint: ["pnpm exec eslint ."],
+    }),
+  },
+  nestjs: {
+    kind: "backend framework monorepo",
+    repoName: "ttsc-benchmark-nestjs",
+    repo: "https://github.com/samchon/ttsc-benchmark-nestjs.git",
+    packageManager: "npm",
+    filesRoot: "packages",
+    commands: nestjsCommands(),
+  },
+  vscode: {
+    kind: "application monorepo",
+    repoName: "ttsc-benchmark-vscode",
+    repo: "https://github.com/samchon/ttsc-benchmark-vscode.git",
+    packageManager: "npm",
+    installCommand: "npm install --legacy-peer-deps --ignore-scripts",
+    installTarballsCommand: (specs) =>
+      `npm install --legacy-peer-deps --ignore-scripts --save-dev ${specs}`,
+    prepareCommand: "./node_modules/.bin/ttsc prepare -p src/tsconfig.json",
+    filesRoot: "src",
+    commands: compilerCommands({
+      build: (tool) => [
+        {
+          cmd: `./node_modules/.bin/${tool} -p src/tsconfig.json`,
+          env: { NODE_OPTIONS: "--max-old-space-size=8192" },
+        },
+      ],
+      noEmit: (tool) => [
+        {
+          cmd: `./node_modules/.bin/${tool} -p src/tsconfig.json --noEmit`,
+          env: { NODE_OPTIONS: "--max-old-space-size=8192" },
+        },
+      ],
+      eslint: ["./node_modules/.bin/eslint src --quiet"],
+    }),
+  },
+  "shopping-backend": {
+    kind: "plugin-heavy service",
+    repoName: "shopping-backend",
+    repo: "https://github.com/samchon/shopping-backend.git",
+    packageManager: "pnpm",
+    filesRoot: "src",
+    commands: {
+      legacy: {
+        build: normalizeSteps(["pnpm exec tsc -p tsconfig.json"]),
+        noEmit: normalizeSteps(["pnpm exec tsc -p tsconfig.json --noEmit"]),
+        eslint: normalizeSteps(["pnpm exec eslint src test"]),
+      },
+      ttsc: {
+        build: normalizeSteps(["pnpm exec ttsc -p tsconfig.json"]),
+        noEmit: normalizeSteps(["pnpm exec ttsc -p tsconfig.json --noEmit"]),
+      },
+      "ttsc-lint": {
+        build: normalizeSteps(["pnpm exec ttsc -p tsconfig.json"]),
+        noEmit: normalizeSteps(["pnpm exec ttsc -p tsconfig.json --noEmit"]),
+      },
+    },
+  },
+};
+
+const PROJECTS = Object.entries(PACKAGE_CONFIGS)
+  .filter(([, config]) => !config.disabled)
+  .map(([name, config]) => ({
+    name,
+    ...config,
+  }));
+
 const wantedProjects = positional.length
-  ? positional.filter((p) => PROJECTS[p])
-  : Object.keys(PROJECTS);
+  ? positional.map(resolveProjectArg).filter(Boolean)
+  : PROJECTS;
 
 if (flags.has("--list")) {
-  printConfigTable();
+  printConfig();
   process.exit(0);
 }
-if (positional.length && wantedProjects.length === 0) {
-  process.stderr.write(
-    `No known project in [${positional.join(", ")}].\n` +
-      `Known: ${Object.keys(PROJECTS).join(", ")}\n`,
-  );
-  process.exit(1);
+if (positional.length && wantedProjects.length !== positional.length) {
+  const known = PROJECTS.map((p) => `${p.name} (${p.repoName})`).join(", ");
+  throw new Error(`unknown project selection. Known: ${known}`);
 }
 
-// ── shell helpers ────────────────────────────────────────────────────────────
+main();
 
-function sh(cmd, cwd, { check = true, quiet = false, env } = {}) {
+function numberEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw == null || raw === "") return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0)
+    throw new Error(`${name} must be positive`);
+  return n;
+}
+
+function packageVersion(dir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"))
+      .version;
+  } catch {
+    return undefined;
+  }
+}
+
+function compilerCommands({ build, noEmit, eslint }) {
+  const ttsc = {
+    build: normalizeSteps(build("ttsc")),
+    noEmit: normalizeSteps(noEmit("ttsc")),
+    tsgoBuild: normalizeSteps(build("tsgo")),
+    tsgoNoEmit: normalizeSteps(noEmit("tsgo")),
+  };
+  return {
+    legacy: {
+      build: normalizeSteps(build("tsc")),
+      noEmit: normalizeSteps(noEmit("tsc")),
+      eslint: normalizeSteps(eslint),
+    },
+    ttsc,
+    "ttsc-lint": {
+      build: normalizeSteps(build("ttsc")),
+      noEmit: normalizeSteps(noEmit("ttsc")),
+    },
+  };
+}
+
+function rxjsNoEmitSteps(tool) {
+  return [
+    "./src/tsconfig.cjs.json",
+    "./src/tsconfig.esm.json",
+    "./src/tsconfig.types.json",
+  ].map((config) => ({
+    cwd: "packages/rxjs",
+    cmd: `yarn --ignore-engines exec ${tool} -- -p ${config} --noEmit`,
+  }));
+}
+
+function rxjsBuildSteps(tool) {
+  return [
+    "./src/tsconfig.cjs.json",
+    "./src/tsconfig.esm.json",
+    "./src/tsconfig.types.json",
+  ].map((config) => ({
+    cwd: "packages/rxjs",
+    cmd: `yarn --ignore-engines exec ${tool} -- -p ${config}`,
+  }));
+}
+
+function nestjsCommands() {
+  return {
+    legacy: {
+      build: normalizeSteps(["npm exec -- tsc -p tsconfig.json"]),
+      noEmit: normalizeSteps(["npm exec -- tsc -p tsconfig.json --noEmit"]),
+      eslint: normalizeSteps([
+        "npm exec -- eslint 'packages/**/**.ts' --ignore-pattern 'packages/**/*.spec.ts'",
+      ]),
+    },
+    ttsc: {
+      build: normalizeSteps(["npm exec -- ttsc -p tsconfig.json"]),
+      noEmit: normalizeSteps(["npm exec -- ttsc -p tsconfig.json --noEmit"]),
+      tsgoBuild: normalizeSteps(["npm exec -- tsgo -p tsconfig.json"]),
+      tsgoNoEmit: normalizeSteps([
+        "npm exec -- tsgo -p tsconfig.json --noEmit",
+      ]),
+    },
+    "ttsc-lint": {
+      build: normalizeSteps(["npm exec -- ttsc -p tsconfig.json"]),
+      noEmit: normalizeSteps(["npm exec -- ttsc -p tsconfig.json --noEmit"]),
+    },
+  };
+}
+
+function nestjsPackageSteps(tool, noEmit) {
+  const packages = [
+    "common",
+    "core",
+    "microservices",
+    "platform-express",
+    "platform-fastify",
+    "platform-socket.io",
+    "platform-ws",
+    "testing",
+    "websockets",
+  ];
+  return packages.map((pkg) => ({
+    cmd:
+      `npm exec -- ${tool} -p packages/${pkg}/tsconfig.build.json` +
+      (noEmit ? " --noEmit" : ""),
+  }));
+}
+
+function normalizeSteps(value) {
+  const array = Array.isArray(value) ? value : [value];
+  return array.map((entry) =>
+    typeof entry === "string" ? { cmd: entry } : { ...entry },
+  );
+}
+
+function resolveProjectArg(arg) {
+  return PROJECTS.find((p) => p.name === arg || p.repoName === arg);
+}
+
+function cloneDir(project, branch) {
+  return path.join(WORK, `${project.repoName}@${branch}`);
+}
+
+function ownsPnpmWorkspace(root) {
+  return fs.existsSync(path.join(root, "pnpm-workspace.yaml"));
+}
+
+function pnpmProjectCommand(root, command) {
+  if (ownsPnpmWorkspace(root)) return `pnpm ${command}`;
+  const [verb, ...rest] = command.split(/\s+/);
+  if (verb === "install" || verb === "add") {
+    return `pnpm --ignore-workspace ${verb} --virtual-store-dir node_modules/.pnpm ${rest.join(" ")}`.trim();
+  }
+  return `pnpm --ignore-workspace ${command}`;
+}
+
+function commandForProject(cmd, root) {
+  if (!/^pnpm\b/.test(cmd) || ownsPnpmWorkspace(root)) return cmd;
+  if (/^pnpm\s+--ignore-workspace\b/.test(cmd)) return cmd;
+  return cmd.replace(/^pnpm\b/, "pnpm --ignore-workspace");
+}
+
+function sh(cmd, cwd, options = {}) {
   const res = spawnSync(cmd, {
     cwd,
     shell: true,
     encoding: "utf8",
-    env: env ?? process.env,
-    stdio: quiet ? "pipe" : "inherit",
+    env: options.env ?? process.env,
+    stdio: options.quiet ? "pipe" : "inherit",
   });
-  if (check && res.status !== 0) {
+  if (options.check !== false && res.status !== 0) {
     throw new Error(
-      `command failed (exit ${res.status}): ${cmd}\n${res.stderr ?? ""}`,
+      `command failed (${res.status}) in ${cwd}: ${cmd}\n${res.stderr ?? ""}`,
     );
   }
   return res;
 }
 
-/** Time a command once; never throws — a failed run is reported, not fatal. */
-function runOnce(cmd, cwd, env) {
+function runSteps(steps, root) {
   const t0 = process.hrtime.bigint();
-  const res = spawnSync(cmd, {
-    cwd,
-    shell: true,
-    encoding: "utf8",
-    env: env ?? process.env,
-  });
+  let log = "";
+  for (const step of steps) {
+    const cwd = path.resolve(root, step.cwd ?? ".");
+    const cmd = commandForProject(step.cmd, root);
+    const res = spawnSync(cmd, {
+      cwd,
+      shell: true,
+      encoding: "utf8",
+      env: step.env ? { ...process.env, ...step.env } : process.env,
+    });
+    log += `$ ${cmd}\n${res.stdout ?? ""}${res.stderr ?? ""}`;
+    if (res.status !== 0) {
+      const t1 = process.hrtime.bigint();
+      return {
+        ok: false,
+        status: res.status,
+        ms: Number(t1 - t0) / 1e6,
+        log,
+      };
+    }
+  }
   const t1 = process.hrtime.bigint();
-  return {
-    ms: Number(t1 - t0) / 1e6,
-    ok: res.status === 0,
-    status: res.status,
-    log: `${res.stdout ?? ""}${res.stderr ?? ""}`,
-  };
+  return { ok: true, status: 0, ms: Number(t1 - t0) / 1e6, log };
 }
 
-function median(xs) {
-  const s = [...xs].sort((a, b) => a - b);
-  const m = s.length >> 1;
-  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
-/**
- * Classify a failed run from its output. A `race` failure is the intermittent
- * Go data-race crash; anything else is a deterministic `error` (e.g. a type
- * error). This keeps an orthogonal stability bug from being mislabelled — and
- * stops a deterministic compile error from being reported as a "crash".
- */
 function classifyFailure(log) {
   return /concurrent map|fatal error|\bpanic:|DATA RACE/.test(log)
     ? "race"
     : "error";
 }
 
-// ── step 1: build + pack the local ttsc tarballs ─────────────────────────────
-
-/**
- * Build the workspace and pack ttsc / @ttsc/lint / the current-platform package
- * into TGZ under the exact filenames the fixture branches pin
- * (`ttsc-<version>.tgz`, `ttsc-lint-<version>.tgz`,
- * `ttsc-<platform>-<version>.tgz`). Fixtures reference these via
- * `file:/tmp/ttsc-tgz/...` so an install picks up the compiler under test.
- */
 function packTarballs() {
-  if (process.env.TTSC_BENCH_SKIP_PACK === "1" || flags.has("--no-pack")) {
-    process.stdout.write(`◦ skipping tarball pack (reusing ${TGZ})\n`);
+  if (flags.has("--no-pack") || process.env.TTSC_BENCH_SKIP_PACK === "1") {
+    process.stdout.write(`Skipping tarball pack; using ${TGZ}\n`);
     return;
   }
-  process.stdout.write(`\n▸ building + packing ttsc tarballs into ${TGZ}\n`);
   fs.mkdirSync(TGZ, { recursive: true });
+  process.stdout.write(`Packing local ttsc tarballs into ${TGZ}\n`);
   sh("pnpm run build:current", REPO_ROOT);
-  const targets = [
-    { dir: "packages/ttsc", file: `ttsc-${TTSC_VERSION}.tgz` },
-    { dir: "packages/lint", file: `ttsc-lint-${TTSC_VERSION}.tgz` },
-    {
-      dir: `packages/ttsc-${PLATFORM_KEY}`,
-      file: `ttsc-${PLATFORM_KEY}-${TTSC_VERSION}.tgz`,
-    },
-  ];
-  for (const t of targets) {
-    const dir = path.join(REPO_ROOT, t.dir);
-    if (!fs.existsSync(dir)) {
-      throw new Error(`tarball source missing: ${t.dir}`);
-    }
-    const out = path.join(TGZ, t.file);
+  for (const target of LOCAL_TARBALLS) {
+    const out = path.join(TGZ, target.file);
     fs.rmSync(out, { force: true });
-    sh(`pnpm pack --out ${JSON.stringify(out)}`, dir);
-    process.stdout.write(`  packed ${t.file}\n`);
+    sh(`pnpm pack --out ${quote(out)}`, path.join(REPO_ROOT, target.dir));
   }
 }
 
-// ── step 2 + 3: clone + install a fixture branch ─────────────────────────────
-
-/** Working directory for one (project, branch) clone. */
-function cloneDir(project, branch) {
-  return path.join(WORK, `${project}@${branch}`);
-}
-
-/**
- * Clone `branch` of `project`'s repo into the working directory and install it.
- * Returns `false` (skip, not fatal) when the branch does not exist on the fork
- * — fixture branches are still being pushed. A stray `pnpm-workspace.yaml` is
- * dropped into the clone so pnpm treats it as an isolated workspace even if it
- * ever lands inside another workspace tree.
- */
 function setupClone(project, branch) {
-  const cfg = PROJECTS[project];
   const dir = cloneDir(project, branch);
-  const pm = cfg.packageManager ?? "pnpm";
-
-  // Branch existence probe — a missing fork branch is skipped, not a crash.
-  const probe = spawnSync(
-    "git",
-    ["ls-remote", "--exit-code", "--heads", cfg.repo, branch],
-    { encoding: "utf8" },
-  );
-  if (probe.status !== 0) {
-    process.stdout.write(
-      `  ⚠ ${project}@${branch}: branch not on fork yet — skipped\n`,
+  fs.mkdirSync(WORK, { recursive: true });
+  if (!fs.existsSync(dir)) {
+    process.stdout.write(`Cloning ${project.repoName}@${branch}\n`);
+    sh(
+      `git clone --branch ${quote(branch)} ${quote(project.repo)} ${quote(dir)}`,
+      WORK,
+      { quiet: true },
     );
-    return false;
+  } else if (!fs.existsSync(path.join(dir, ".git"))) {
+    throw new Error(`${dir} exists but is not a git clone`);
   }
 
-  fs.rmSync(dir, { recursive: true, force: true });
-  process.stdout.write(`  cloning ${project}@${branch}\n`);
-  sh(
-    `git clone --depth 1 --branch ${branch} ${cfg.repo} ${JSON.stringify(dir)}`,
-    WORK,
-    { quiet: true },
-  );
-  // Isolate the clone from any surrounding pnpm workspace.
-  if (!fs.existsSync(path.join(dir, "pnpm-workspace.yaml"))) {
-    fs.writeFileSync(path.join(dir, "pnpm-workspace.yaml"), "packages: []\n");
+  const current = sh("git branch --show-current", dir, {
+    quiet: true,
+    check: false,
+  }).stdout?.trim();
+  if (current && current !== branch) {
+    const dirty = sh("git status --short", dir, {
+      quiet: true,
+      check: false,
+    }).stdout;
+    if (dirty.trim()) {
+      throw new Error(
+        `${dir} is on ${current}, expected ${branch}, and has local changes`,
+      );
+    }
+    sh(`git checkout ${quote(branch)}`, dir, { quiet: true });
   }
 
-  process.stdout.write(`  installing ${project}@${branch} (${pm})\n`);
-  const installCmd =
-    pm === "yarn"
-      ? "yarn install --frozen-lockfile || yarn install"
-      : "pnpm install --no-frozen-lockfile";
-  sh(installCmd, dir, { quiet: true });
+  if (!flags.has("--no-install")) installIfNeeded(project, dir, branch);
 
-  // `ttsc prepare` builds the cached plugin binaries the ttsc branches need.
   if (branch === "ttsc" || branch === "ttsc-lint") {
-    const prep = spawnSync(`${pm} exec ttsc prepare`, {
-      cwd: dir,
-      shell: true,
-      encoding: "utf8",
-    });
-    if (prep.status !== 0) {
+    const pm = project.packageManager;
+    const cmd = project.prepareCommand
+      ? commandForProject(project.prepareCommand, dir)
+      : pm === "npm"
+        ? "npm exec -- ttsc prepare"
+        : pm === "pnpm"
+          ? pnpmProjectCommand(dir, "exec ttsc prepare")
+          : `${pm} exec ttsc prepare`;
+    const res = sh(cmd, dir, { quiet: true, check: false });
+    if (res.status !== 0) {
       process.stdout.write(
-        `  ◦ ${project}@${branch}: 'ttsc prepare' exited ${prep.status} ` +
-          `(ok if the project defines no plugins)\n`,
+        `${project.repoName}@${branch}: ttsc prepare exited ${res.status}; ` +
+          `continuing only if this project has no source plugins\n`,
       );
     }
   }
 
-  // Project-specific prerequisites (e.g. Prisma client, nestia SDK).
-  for (const script of cfg.prerequisites ?? []) {
-    process.stdout.write(`  prerequisite: ${project}@${branch} ${script}\n`);
-    sh(`${pm} run ${script}`, dir, { quiet: true });
+  for (const step of normalizeSteps(project.prerequisites ?? [])) {
+    process.stdout.write(
+      `${project.repoName}@${branch}: prerequisite ${step.cmd}\n`,
+    );
+    sh(step.cmd, path.resolve(dir, step.cwd ?? "."), { quiet: true });
   }
-  return true;
 }
 
-// ── step 4: measure one cell ─────────────────────────────────────────────────
-
-/**
- * Measure one matrix cell: WARMUP unmeasured runs, then RUNS measured runs.
- * `prep` (e.g. a clean step) runs unmeasured before every run so each timing
- * starts from the same state. Returns the per-cell result record.
- */
-function measureCell(label, cmd, cwd, { prep, crashy } = {}) {
-  process.stdout.write(`\n▶ ${label}\n  ${cmd}${prep ? `\n  prep: ${prep}` : ""}\n`);
-  const fresh = () => {
-    if (prep) spawnSync(prep, { cwd, shell: true });
-    return runOnce(cmd, cwd);
-  };
-  for (let i = 0; i < WARMUP; i++) {
-    const w = fresh();
+function installIfNeeded(project, dir, branch) {
+  const mustRefreshTarballs = branch === "ttsc" || branch === "ttsc-lint";
+  const hasNodeModules = fs.existsSync(path.join(dir, "node_modules"));
+  if (!mustRefreshTarballs && !flags.has("--force-install") && hasNodeModules) {
+    return;
+  }
+  const pm = project.packageManager;
+  if (mustRefreshTarballs) assertLocalTarballs(branch);
+  const cmd =
+    project.installCommand ??
+    (pm === "pnpm"
+      ? pnpmProjectCommand(dir, "install --no-frozen-lockfile")
+      : pm === "yarn"
+        ? "YARN_CACHE_FOLDER=.yarn-cache yarn install --ignore-engines --update-checksums"
+        : "npm install --legacy-peer-deps");
+  if (!hasNodeModules || flags.has("--force-install")) {
+    process.stdout.write(`Installing ${path.basename(dir)} with ${pm}\n`);
+    sh(cmd, dir);
+  } else {
     process.stdout.write(
-      `  warmup ${i + 1}: ${w.ms.toFixed(0)} ms ${w.ok ? "ok" : `EXIT ${w.status}`}\n`,
+      `Reusing installed node_modules in ${path.basename(dir)}\n`,
     );
   }
+  if (branch === "ttsc" && hasTsgoCells(project) && !hasTsgoExperimentDeps(dir))
+    installTsgoExperimentDeps(project, dir);
+  if (mustRefreshTarballs) installLocalTarballs(project, dir, branch);
+}
+
+function assertLocalTarballs(branch) {
+  const missing = localTarballPaths(branch).filter(
+    (file) => !fs.existsSync(file),
+  );
+  if (missing.length) {
+    throw new Error(
+      "missing local ttsc tarballs; run without --no-pack or populate " +
+        `${TGZ}\n${missing.map((file) => `- ${file}`).join("\n")}`,
+    );
+  }
+}
+
+function localTarballTargets(branch) {
+  return LOCAL_TARBALLS.filter(
+    (target) => branch === "ttsc-lint" || target.name !== "@ttsc/lint",
+  );
+}
+
+function localTarballPaths(branch) {
+  return localTarballTargets(branch).map((target) =>
+    path.join(TGZ, target.file),
+  );
+}
+
+function installLocalTarballs(project, dir, branch) {
+  const targets = localTarballTargets(branch);
+  if (project.packageManager === "yarn") {
+    materializeLocalTarballs(targets, dir);
+    return;
+  }
+  const specs = targets
+    .map((target) => quote(path.join(TGZ, target.file)))
+    .join(" ");
+  const pm = project.packageManager;
+  const cmd =
+    project.installTarballsCommand?.(specs) ??
+    (pm === "pnpm"
+      ? ownsPnpmWorkspace(dir)
+        ? `pnpm add -w -D ${specs}`
+        : `pnpm add --ignore-workspace -D ${specs}`
+      : pm === "yarn"
+        ? `YARN_CACHE_FOLDER=.yarn-cache yarn add --dev --force --update-checksums --ignore-engines --ignore-workspace-root-check ${specs}`
+        : `npm install --legacy-peer-deps --save-dev ${specs}`);
+  process.stdout.write(
+    `Installing local tarballs into ${path.basename(dir)}: ` +
+      `${targets.map((target) => target.name).join(", ")}\n`,
+  );
+  sh(cmd, dir);
+}
+
+function materializeLocalTarballs(targets, dir) {
+  const nodeModules = path.join(dir, "node_modules");
+  fs.mkdirSync(nodeModules, { recursive: true });
+  fs.mkdirSync(path.join(nodeModules, ".bin"), { recursive: true });
+  for (const target of targets) {
+    const packageDir = path.join(nodeModules, ...target.name.split("/"));
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-bench-tgz-"));
+    fs.rmSync(packageDir, { recursive: true, force: true });
+    fs.mkdirSync(path.dirname(packageDir), { recursive: true });
+    sh(`tar -xzf ${quote(path.join(TGZ, target.file))} -C ${quote(tmp)}`, dir, {
+      quiet: true,
+    });
+    fs.cpSync(path.join(tmp, "package"), packageDir, { recursive: true });
+    fs.rmSync(tmp, { recursive: true, force: true });
+    linkPackageBins(packageDir, nodeModules);
+  }
+  process.stdout.write(
+    `Materialized local tarballs into ${path.basename(dir)}: ` +
+      `${targets.map((target) => target.name).join(", ")}\n`,
+  );
+}
+
+function linkPackageBins(packageDir, nodeModules) {
+  const packageJson = path.join(packageDir, "package.json");
+  if (!fs.existsSync(packageJson)) return;
+  const manifest = JSON.parse(fs.readFileSync(packageJson, "utf8"));
+  const bins =
+    typeof manifest.bin === "string"
+      ? { [manifest.name]: manifest.bin }
+      : manifest.bin;
+  if (!bins || typeof bins !== "object") return;
+  const binDir = path.join(nodeModules, ".bin");
+  for (const [name, bin] of Object.entries(bins)) {
+    const link = path.join(binDir, name);
+    const target = path.relative(binDir, path.join(packageDir, bin));
+    fs.rmSync(link, { force: true });
+    fs.symlinkSync(target, link);
+  }
+}
+
+function hasTsgoCells(project) {
+  return Boolean(
+    project.commands.ttsc?.tsgoBuild?.length ||
+    project.commands.ttsc?.tsgoNoEmit?.length,
+  );
+}
+
+function installTsgoExperimentDeps(project, dir) {
+  const specs = [
+    `@typescript/native-preview@${TSGO_VERSION}`,
+    `${TSGO_PLATFORM_PACKAGE}@${TSGO_VERSION}`,
+  ]
+    .map(quote)
+    .join(" ");
+  const pm = project.packageManager;
+  const cmd =
+    pm === "pnpm"
+      ? ownsPnpmWorkspace(dir)
+        ? `pnpm add -w -D ${specs}`
+        : `pnpm add --ignore-workspace --virtual-store-dir node_modules/.pnpm -D ${specs}`
+      : pm === "yarn"
+        ? `YARN_CACHE_FOLDER=.yarn-cache yarn add --dev --force --update-checksums --ignore-engines --ignore-workspace-root-check ${specs}`
+        : `npm install --legacy-peer-deps --ignore-scripts --save-dev ${specs}`;
+  process.stdout.write(
+    `Installing tsgo experiment deps into ${path.basename(dir)}: ` +
+      `@typescript/native-preview, ${TSGO_PLATFORM_PACKAGE}\n`,
+  );
+  sh(cmd, dir);
+}
+
+function hasTsgoExperimentDeps(dir) {
+  return (
+    depVersion(dir, "@typescript/native-preview") !== undefined &&
+    depVersion(dir, TSGO_PLATFORM_PACKAGE) !== undefined
+  );
+}
+
+function quote(value) {
+  return JSON.stringify(value);
+}
+
+function singleThreadedSteps(steps) {
+  return steps.map((step) => {
+    if (step.singleThreadedCmd) {
+      const { singleThreadedCmd, ...rest } = step;
+      return { ...rest, cmd: singleThreadedCmd };
+    }
+    if (
+      !/\b(?:ttsc|tsgo)\b/.test(step.cmd) ||
+      /--singleThreaded\b/.test(step.cmd)
+    ) {
+      return step;
+    }
+    return { ...step, cmd: `${step.cmd} --singleThreaded` };
+  });
+}
+
+function measureCell({ id, project, branch, tool, op, threading, steps }) {
+  const root = cloneDir(project, branch);
+  process.stdout.write(`\n[${id}] ${RUNS} runs\n`);
+
+  const run = () => runSteps(steps, root);
+
+  for (let i = 0; i < WARMUP; i++) {
+    const result = run();
+    process.stdout.write(
+      `  warmup ${i + 1}: ${result.ms.toFixed(0)} ms ` +
+        (result.ok ? "ok" : `exit ${result.status}`) +
+        "\n",
+    );
+    if (!result.ok && classifyFailure(result.log) === "error") {
+      return failedMeasurement(
+        project,
+        branch,
+        op,
+        threading,
+        result,
+        0,
+        id,
+        tool,
+      );
+    }
+  }
+
   const samples = [];
   let raceRetries = 0;
-  let deterministicFailure = null;
+  let deterministic = null;
   for (let i = 0; i < RUNS; i++) {
-    let r = fresh();
+    let result = run();
     let attempts = 0;
-    while (!r.ok && attempts < RETRIES) {
-      const kind = classifyFailure(r.log);
-      if (kind === "race") raceRetries++;
+    while (!result.ok && attempts < RETRIES) {
+      const kind = classifyFailure(result.log);
+      if (kind === "error") break;
+      raceRetries++;
       attempts++;
-      process.stdout.write(
-        `  run ${i + 1}: EXIT ${r.status} (${kind}) — retry ${attempts}\n`,
-      );
-      if (kind === "error") break; // deterministic: retrying will not help
-      r = fresh();
+      process.stdout.write(`  run ${i + 1}: race retry ${attempts}\n`);
+      result = run();
     }
-    if (!r.ok) {
-      deterministicFailure = { status: r.status, kind: classifyFailure(r.log) };
-      process.stdout.write(
-        `  run ${i + 1}: EXIT ${r.status} — deterministic failure, not measured\n`,
-      );
+    if (!result.ok) {
+      deterministic = result;
+      process.stdout.write(`  run ${i + 1}: exit ${result.status}\n`);
+      break;
+    }
+    samples.push(result.ms);
+    process.stdout.write(`  run ${i + 1}: ${result.ms.toFixed(0)} ms\n`);
+  }
+
+  if (deterministic || samples.length === 0) {
+    return failedMeasurement(
+      project,
+      branch,
+      op,
+      threading,
+      deterministic ?? { status: 1, log: "no samples", ms: 0 },
+      raceRetries,
+      id,
+      tool,
+    );
+  }
+
+  return {
+    id,
+    branch,
+    tool: toolFor(branch, op, tool),
+    op,
+    threading,
+    medianMs: median(samples),
+    minMs: Math.min(...samples),
+    samples,
+    raceRetries: raceRetries || undefined,
+  };
+}
+
+function failedMeasurement(
+  project,
+  branch,
+  op,
+  threading,
+  result,
+  raceRetries,
+  id,
+  tool,
+) {
+  return {
+    id,
+    branch,
+    tool: toolFor(branch, op, tool),
+    op,
+    threading,
+    medianMs: 0,
+    samples: [],
+    raceRetries: raceRetries || undefined,
+    failure: classifyFailure(result.log),
+    exitStatus: result.status,
+  };
+}
+
+function toolFor(branch, op, tool) {
+  if (tool) return tool;
+  if (op === "eslint") return "eslint";
+  if (branch === "legacy") return "tsc";
+  return branch === "ttsc-lint" ? "ttsc+@ttsc/lint" : "ttsc";
+}
+
+function measureProject(project, report) {
+  const projectReport = ensureProjectReport(report, project);
+  const done = new Set(projectReport.measurements.map((m) => m.id));
+  for (const cell of projectCells(project)) {
+    if (done.has(cell.id)) {
+      process.stdout.write(`\n[${cell.id}] already measured; skipping\n`);
       continue;
     }
-    samples.push(r.ms);
-    process.stdout.write(`  run ${i + 1}: ${r.ms.toFixed(0)} ms\n`);
+    const measurement = measureCell(cell);
+    projectReport.measurements.push(measurement);
+    done.add(cell.id);
+    writeReports(report);
   }
+}
+
+function ensureProjectReport(report, project) {
+  let projectReport = report.projects.find((p) => p.name === project.name);
+  if (!projectReport) {
+    projectReport = projectReportFor(project, []);
+    report.projects.push(projectReport);
+  }
+  return projectReport;
+}
+
+function projectReportFor(project, measurements) {
   return {
-    label,
-    samples,
-    raceRetries,
-    deterministicFailure,
-    median: samples.length ? median(samples) : null,
-    min: samples.length ? Math.min(...samples) : null,
+    name: project.name,
+    repo: project.repoName,
+    kind: project.kind,
+    files: countSourceFiles(
+      path.join(cloneDir(project, "legacy"), project.filesRoot),
+    ),
+    measurements,
   };
 }
 
-/**
- * Expand a (project, branch, case) into measured cells and record them into
- * `results`. The `ttsc` / `ttsc-lint` branches add a noEmit cell and (when the
- * case opts in) single-threaded variants of build + noEmit.
- */
-function measureCase(results, project, branch, c) {
-  const cfg = PROJECTS[project];
-  const dir = cloneDir(project, branch);
-  if (!fs.existsSync(dir)) return; // setup skipped this branch
-  const runCwd = c.cwd ? path.join(dir, c.cwd) : dir;
-  const spec = branch === "legacy" ? c.legacy : c.ttsc;
-  if (!spec) return;
-  const key = (mode) => `${project}|${branch}|${c.name}|${mode}`;
-
-  // emit / type-check build, multi-threaded (ttsc's default; the only mode for legacy).
-  if (spec.build) {
-    results[key("mt")] = measureCell(key("mt"), spec.build, runCwd);
-  }
-  // type-check-only build.
-  if (spec.noEmit) {
-    results[key("noEmit")] = measureCell(key("noEmit"), spec.noEmit, runCwd);
-  }
-  // single-threaded variants — ttsc / ttsc-lint only, and only when opted in.
-  if (c.singleThreaded && branch !== "legacy") {
-    const prep = spec.stClean
-      ? `${spec.stClean.replace("pnpm exec", (cfg.packageManager ?? "pnpm") + " exec")}`
-      : undefined;
-    if (spec.build) {
-      results[key("st")] = measureCell(
-        key("st"),
-        `${spec.build} --singleThreaded`,
-        runCwd,
-        { prep },
-      );
-    }
-    if (spec.noEmit) {
-      results[key("st-noEmit")] = measureCell(
-        key("st-noEmit"),
-        `${spec.noEmit} --singleThreaded`,
-        runCwd,
-      );
-    }
-  }
-}
-
-// ── host spec ────────────────────────────────────────────────────────────────
-
-/**
- * Read a dependency's installed version from a package's node_modules. Returns
- * `undefined` when the package is not present so callers can fall back.
- */
-function depVersion(fromDir, pkg) {
-  try {
-    const p = path.join(fromDir, "node_modules", pkg, "package.json");
-    return JSON.parse(fs.readFileSync(p, "utf8")).version;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Collect the host machine spec + toolchain versions for the report.
- *
- * The returned object is the canonical `BenchmarkHost` shape consumed by the
- * website dashboard (`os`, `kernel`, `cpu`, `cores`, `ramGB`, `node`, `ttsc`,
- * `typescript`) plus a `tsgo` extra used only by the Markdown report header.
- *
- * `typescript`/`tsgo` resolve from the fixture clones (that is where the
- * compilers are installed): `typescript` reads `typescript` from a `legacy`
- * clone, `tsgo` reads `@typescript/native-preview` from a `ttsc` clone.
- */
-function hostSpec(wantedProjectsList) {
-  const cpu = os.cpus();
-  let osName = `${os.type()} ${os.release()}`;
-  try {
-    const rel = fs.readFileSync("/etc/os-release", "utf8");
-    const pretty = rel.match(/^PRETTY_NAME="?([^"\n]+)"?/m);
-    if (pretty) osName = pretty[1];
-  } catch {
-    /* not Linux — keep os.type()/os.release() */
-  }
-  // Walk fixture clones for the first one that has each compiler installed.
-  let tsgo, tsc;
-  for (const project of wantedProjectsList) {
-    tsgo ??= depVersion(
-      cloneDir(project, "ttsc"),
-      "@typescript/native-preview",
-    );
-    tsc ??= depVersion(cloneDir(project, "legacy"), "typescript");
-  }
-  return {
-    os: osName,
-    kernel: os.release(),
-    cpu: cpu[0]?.model?.trim() ?? "unknown",
-    cores: cpu.length,
-    ramGB: Math.round(os.totalmem() / 2 ** 30),
-    node: process.version,
-    ttsc: TTSC_VERSION,
-    typescript: tsc ?? "—",
-    tsgo: tsgo ?? "—",
-  };
-}
-
-// ── canonical website JSON ───────────────────────────────────────────────────
-
-/**
- * Count the project's own TypeScript source files in a clone — `.ts` / `.tsx` /
- * `.mts` / `.cts`, excluding `node_modules`, declaration files, and dist/build
- * output. This is the `files` figure shown on each website project card; it is
- * an approximate project-size signal, not the exact compiler input set.
- */
-function countSourceFiles(dir) {
-  if (!dir || !fs.existsSync(dir)) return 0;
-  const SKIP = new Set([
-    "node_modules",
+function countSourceFiles(root) {
+  if (!fs.existsSync(root)) return 0;
+  const skip = new Set([
     ".git",
+    "node_modules",
     "dist",
     "lib",
     "out",
@@ -628,402 +857,324 @@ function countSourceFiles(dir) {
     "coverage",
   ]);
   let count = 0;
-  const walk = (d) => {
-    let entries;
-    try {
-      entries = fs.readdirSync(d, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const e of entries) {
-      if (e.isDirectory()) {
-        if (!SKIP.has(e.name)) walk(path.join(d, e.name));
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!skip.has(entry.name)) walk(path.join(dir, entry.name));
       } else if (
-        /\.(ts|tsx|mts|cts)$/.test(e.name) &&
-        !/\.d\.(ts|mts|cts)$/.test(e.name)
+        /\.(ts|tsx|mts|cts)$/.test(entry.name) &&
+        !/\.d\.(ts|mts|cts)$/.test(entry.name)
       ) {
         count++;
       }
     }
   };
-  walk(dir);
+  walk(root);
   return count;
 }
 
-/**
- * Project the runner's internal `project|branch|case|mode` result map into the
- * canonical `BenchmarkReport` shape served at `website/public/benchmark.json`
- * and consumed by `website/src/components/benchmark/types.ts`.
- *
- * The mapping is mechanical:
- *
- *   - branch `legacy` → `tool: "tsc"`; `ttsc`/`ttsc-lint` → `tool: "ttsc"`.
- *   - mode `mt`/`st` carry `threading` multi/single; the `op` is `build` for an
- *     emit case and `noEmit` for a type-check-only case.
- *   - modes `noEmit`/`st-noEmit` are always `op: "noEmit"` at the matching
- *     threading.
- *
- * `format` measurements are not produced by the current matrix (the runner has
- * no prettier / `@ttsc/lint` format case wired); the website schema keeps the
- * `format` op for when such a case lands, and the dashboard simply skips it.
- */
-function buildWebsiteReport(results, started, host) {
-  const projects = [];
-  for (const project of wantedProjects) {
-    const cfg = PROJECTS[project];
-    // First clone that exists on disk gives the source-file count.
-    const filesDir = cfg.branches
-      .map((b) => cloneDir(project, b))
-      .find((d) => fs.existsSync(d));
-    const measurements = [];
-    const push = (branch, op, threading, cell) => {
-      if (!cell) return;
-      const m = {
-        branch,
-        tool: branch === "legacy" ? "tsc" : "ttsc",
-        op,
-        threading,
-        medianMs: cell.median ?? 0,
-      };
-      if (cell.min != null) m.minMs = cell.min;
-      if (cell.samples?.length) m.samples = cell.samples;
-      if (cell.raceRetries) m.raceRetries = cell.raceRetries;
-      if (cell.deterministicFailure)
-        m.failure = cell.deterministicFailure.kind;
-      measurements.push(m);
-    };
-    for (const c of cfg.cases) {
-      for (const branch of cfg.branches) {
-        const cell = (mode) => results[`${project}|${branch}|${c.name}|${mode}`];
-        // `mt`/`st` carry the case's primary op (build for an emit case,
-        // noEmit for a type-check-only case).
-        const primaryOp = c.emit ? "build" : "noEmit";
-        push(branch, primaryOp, "multi", cell("mt"));
-        push(branch, primaryOp, "single", cell("st"));
-        // The dedicated type-check-only cells are always `noEmit`.
-        push(branch, "noEmit", "multi", cell("noEmit"));
-        push(branch, "noEmit", "single", cell("st-noEmit"));
-      }
-    }
-    projects.push({
-      name: project,
-      files: countSourceFiles(filesDir),
-      kind: cfg.kind,
-      measurements,
-    });
+function hostSpec(projects) {
+  const cpus = os.cpus();
+  let osName = `${os.type()} ${os.release()}`;
+  try {
+    const pretty = fs
+      .readFileSync("/etc/os-release", "utf8")
+      .match(/^PRETTY_NAME="?([^"\n]+)"?/m);
+    if (pretty) osName = pretty[1];
+  } catch {
+    // Keep os.type/os.release fallback.
+  }
+  let typescript = "unknown";
+  let tsgo = "unknown";
+  for (const project of projects) {
+    typescript =
+      depVersion(cloneDir(project, "legacy"), "typescript") ?? typescript;
+    tsgo =
+      depVersion(cloneDir(project, "ttsc"), "@typescript/native-preview") ??
+      tsgo;
   }
   return {
-    date: started.toISOString(),
-    host: {
-      os: host.os,
-      kernel: host.kernel,
-      cpu: host.cpu,
-      cores: host.cores,
-      ramGB: host.ramGB,
-      node: host.node,
-      ttsc: host.ttsc,
-      typescript: host.typescript,
-    },
-    projects,
+    os: osName,
+    kernel: os.release(),
+    cpu: cpus[0]?.model?.trim() ?? "unknown",
+    cores: cpus.length,
+    ramGB: Math.round(os.totalmem() / 2 ** 30),
+    node: process.version,
+    ttsc: TTSC_VERSION,
+    typescript,
+    tsgo,
   };
 }
 
-// ── reporting ────────────────────────────────────────────────────────────────
-
-function s(ms) {
-  return ms == null ? "—" : `${(ms / 1000).toFixed(2)} s`;
+function depVersion(root, name) {
+  try {
+    return JSON.parse(
+      fs.readFileSync(
+        path.join(root, "node_modules", name, "package.json"),
+        "utf8",
+      ),
+    ).version;
+  } catch {
+    return undefined;
+  }
 }
-function ratio(slow, fast) {
-  return slow == null || fast == null || fast === 0
-    ? "—"
-    : `${(slow / fast).toFixed(2)}×`;
-}
 
-function buildReport(results, started, host) {
-  const R = (k) => results[k] ?? null;
-  const med = (k) => R(k)?.median ?? null;
-  const L = [];
-  L.push(`# ttsc matrix benchmark`);
-  L.push("");
-  L.push(`- Date: ${started.toISOString()}`);
-  L.push("");
-  L.push(`## Host`);
-  L.push("");
-  L.push(`| Field | Value |`);
-  L.push(`| --- | --- |`);
-  L.push(`| OS | ${host.os} (kernel ${host.kernel}) |`);
-  L.push(`| CPU | ${host.cores}× ${host.cpu} |`);
-  L.push(`| RAM | ${host.ramGB} GB |`);
-  L.push(`| node | ${host.node} |`);
-  L.push(`| ttsc | ${host.ttsc} |`);
-  L.push(`| @typescript/native-preview (tsgo) | ${host.tsgo} |`);
-  L.push(`| tsc | ${host.typescript} |`);
-  L.push("");
-  L.push(
-    `- Method: ${WARMUP} warmup + ${RUNS} measured runs per cell; median ` +
-      `reported. A run hitting the intermittent parallel-emit race is retried ` +
-      `(up to ${RETRIES}×); a deterministic failure is left unmeasured.`,
-  );
-  L.push("");
+function buildMarkdown(report) {
+  const lines = [];
+  lines.push("# ttsc benchmark");
+  lines.push("");
+  lines.push(`- Date: ${report.date}`);
+  lines.push(`- Runs: ${RUNS} measured + ${WARMUP} warmup per cell`);
+  lines.push("");
+  lines.push("## Host");
+  lines.push("");
+  lines.push("| Field | Value |");
+  lines.push("| --- | --- |");
+  for (const [key, value] of Object.entries(report.host)) {
+    lines.push(`| ${key} | ${value} |`);
+  }
+  lines.push("");
 
-  // ── M1 — emit build: legacy vs ttsc vs ttsc-lint ──────────────────────────
-  L.push(`## M1 — Emit build: tsc (legacy) vs ttsc vs ttsc + @ttsc/lint`);
-  L.push("");
-  L.push(
-    `Multi-threaded emit build per project. type-fest and vue are ` +
-      `type-check-only (no emit build) and appear in M2 instead.`,
-  );
-  L.push("");
-  L.push(
-    `| Project | kind | legacy · tsc | ttsc | ttsc-lint | tsc→ttsc | lint cost |`,
-  );
-  L.push(`| --- | --- | --- | --- | --- | --- | --- |`);
-  for (const project of wantedProjects) {
-    const cfg = PROJECTS[project];
-    for (const c of cfg.cases) {
-      if (!c.emit) continue;
-      const lg = med(`${project}|legacy|${c.name}|mt`);
-      const tt = med(`${project}|ttsc|${c.name}|mt`);
-      const tl = med(`${project}|ttsc-lint|${c.name}|mt`);
-      L.push(
-        `| ${project} · ${c.name} | ${cfg.kind} | ${s(lg)} | ${s(tt)} | ` +
-          `${s(tl)} | ${ratio(lg, tt)} | ${ratio(tl, tt)} |`,
+  for (const project of report.projects) {
+    lines.push(`## ${project.name}`);
+    lines.push("");
+    lines.push("| Branch | Op | Threading | Median | Samples | Failure |");
+    lines.push("| --- | --- | --- | --- | --- | --- |");
+    for (const m of project.measurements) {
+      lines.push(
+        `| ${m.branch} | ${m.op} | ${m.threading} | ${formatMs(m.medianMs)} | ` +
+          `${m.samples?.map((s) => s.toFixed(0)).join(", ") || "-"} | ` +
+          `${m.failure ?? ""} |`,
       );
     }
+    lines.push("");
   }
-  L.push("");
-  L.push(
-    `*tsc→ttsc* is the legacy-over-ttsc speedup. *lint cost* is ttsc-lint ` +
-      `over plain ttsc — the marginal cost of folding \`@ttsc/lint\` into the ` +
-      `compile pass (a value near 1× means linting is nearly free).`,
-  );
-  L.push("");
+  return lines.join("\n");
+}
 
-  // ── M2 — type-check only (--noEmit) ───────────────────────────────────────
-  L.push(`## M2 — Type-check only (\`--noEmit\`)`);
-  L.push("");
-  L.push(
-    `Pure type-checking, emit excluded. Isolates checker speed from emit cost.`,
-  );
-  L.push("");
-  L.push(`| Project | kind | legacy · tsc | ttsc | ttsc-lint | tsc→ttsc |`);
-  L.push(`| --- | --- | --- | --- | --- | --- |`);
-  for (const project of wantedProjects) {
-    const cfg = PROJECTS[project];
-    for (const c of cfg.cases) {
-      // For an emit-producing case the type-check-only cell is the `noEmit`
-      // mode (ttsc only — legacy has no noEmit cell wired). For a project
-      // whose build *is* `noEmit` (type-fest, vue) the `mt` cell IS the
-      // type-check cell, and legacy `tsc` is a like-for-like comparison.
-      const noEmitMode = c.emit ? "noEmit" : "mt";
-      const legacyShown = c.emit ? null : med(`${project}|legacy|${c.name}|mt`);
-      const tt = med(`${project}|ttsc|${c.name}|${noEmitMode}`);
-      const tl = med(`${project}|ttsc-lint|${c.name}|${noEmitMode}`);
-      if (tt == null && tl == null && legacyShown == null) continue;
-      L.push(
-        `| ${project} · ${c.name} | ${cfg.kind} | ${s(legacyShown)} | ` +
-          `${s(tt)} | ${s(tl)} | ${ratio(legacyShown, tt)} |`,
+function formatMs(ms) {
+  return ms > 0 ? `${(ms / 1000).toFixed(2)} s` : "-";
+}
+
+function createReport(projects) {
+  const previous = flags.has("--fresh") ? null : loadCheckpoint();
+  const reusable =
+    previous &&
+    previous.runs === RUNS &&
+    previous.warmup === WARMUP &&
+    Array.isArray(previous.projects)
+      ? previous
+      : null;
+  if (previous && !reusable) {
+    process.stdout.write(
+      `Ignoring checkpoint with different run settings: ${CHECKPOINT_JSON}\n`,
+    );
+  }
+  return {
+    date: reusable?.date ?? new Date().toISOString(),
+    runs: RUNS,
+    warmup: WARMUP,
+    host: hostSpec(projects),
+    projects: projects.map((project) => {
+      const old = reusable?.projects.find((p) => p.name === project.name);
+      return projectReportFor(
+        project,
+        Array.isArray(old?.measurements) ? old.measurements : [],
       );
-    }
-  }
-  L.push("");
-  L.push(
-    `type-fest and vue are \`noEmit\` projects — their M1/M2 cell is the same ` +
-      `command, and legacy \`tsc\` for those is shown here as a like-for-like ` +
-      `compare. Emit-producing projects measure ttsc \`--noEmit\` only (stock ` +
-      `\`tsc\` has no comparable type-check-only build wired in the fixture).`,
-  );
-  L.push("");
+    }),
+  };
+}
 
-  // ── M3 — threading: single vs multi ───────────────────────────────────────
-  L.push(`## M3 — ttsc threading: single-threaded vs multi-threaded`);
-  L.push("");
-  L.push(
-    `\`ttsc --singleThreaded\` runs TypeScript-Go fully serial; the default ` +
-      `keeps parallel parse/check/emit. Speedup is multi-threaded over ` +
-      `single-threaded.`,
-  );
-  L.push("");
-  L.push(`| Project · branch · step | single-threaded | multi-threaded | speedup |`);
-  L.push(`| --- | --- | --- | --- |`);
+function loadCheckpoint() {
+  if (!fs.existsSync(CHECKPOINT_JSON)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(CHECKPOINT_JSON, "utf8"));
+  } catch (error) {
+    process.stdout.write(
+      `Ignoring unreadable checkpoint ${CHECKPOINT_JSON}: ${
+        error instanceof Error ? error.message : String(error)
+      }\n`,
+    );
+    return null;
+  }
+}
+
+function writeReports(report, { publishWebsite = false } = {}) {
+  fs.writeFileSync(OUT, buildMarkdown(report) + "\n");
+  fs.writeFileSync(REPORT_JSON, JSON.stringify(report, null, 2) + "\n");
+  fs.writeFileSync(CHECKPOINT_JSON, JSON.stringify(report, null, 2) + "\n");
+  if (publishWebsite) {
+    fs.mkdirSync(path.dirname(WEBSITE_JSON), { recursive: true });
+    fs.writeFileSync(WEBSITE_JSON, JSON.stringify(report, null, 2) + "\n");
+  }
+}
+
+function printConfig() {
   for (const project of wantedProjects) {
-    const cfg = PROJECTS[project];
-    for (const c of cfg.cases) {
-      if (!c.singleThreaded) continue;
-      for (const branch of ["ttsc", "ttsc-lint"]) {
-        const mt = med(`${project}|${branch}|${c.name}|mt`);
-        const st = med(`${project}|${branch}|${c.name}|st`);
-        if (mt == null && st == null) continue;
-        L.push(
-          `| ${project} · ${branch} · ${c.name} | ${s(st)} | ${s(mt)} | ` +
-            `${ratio(st, mt)} |`,
-        );
+    process.stdout.write(`${project.name}: ${project.repo}\n`);
+    for (const cell of projectCells(project)) {
+      const tool = cell.tool ?? toolFor(cell.branch, cell.op);
+      const root = cloneDir(project, cell.branch);
+      process.stdout.write(
+        `  ${cell.branch}:${tool}:${cell.op}:${cell.threading}\n`,
+      );
+      for (const step of cell.steps) {
+        const cmd = commandForProject(step.cmd, root);
+        process.stdout.write(`    ${step.cwd ? `${step.cwd}: ` : ""}${cmd}\n`);
       }
     }
   }
-  L.push("");
-
-  // ── stability ─────────────────────────────────────────────────────────────
-  const raced = Object.values(results).filter((r) => r.raceRetries > 0);
-  const failed = Object.values(results).filter((r) => r.deterministicFailure);
-  if (raced.length || failed.length) {
-    L.push(`## Stability`);
-    L.push("");
-    if (raced.length) {
-      L.push(
-        `Parallel-emit data-race retries — intermittent; the reported timing ` +
-          `is from a clean run:`,
-      );
-      L.push("");
-      for (const r of raced)
-        L.push(
-          `- \`${r.label}\`: ${r.raceRetries} race ` +
-            `retr${r.raceRetries === 1 ? "y" : "ies"}`,
-        );
-      L.push("");
-    }
-    if (failed.length) {
-      L.push(
-        `Deterministic failures — retrying does not help, so the cell is ` +
-          `left unmeasured:`,
-      );
-      L.push("");
-      for (const r of failed)
-        L.push(
-          `- \`${r.label}\`: exits ${r.deterministicFailure.status} ` +
-            `(${r.deterministicFailure.kind}) on every run`,
-        );
-      L.push("");
-    }
-  }
-
-  // ── raw samples ───────────────────────────────────────────────────────────
-  L.push(`## Raw samples (ms)`);
-  L.push("");
-  L.push(`| Cell | runs | median | min |`);
-  L.push(`| --- | --- | --- | --- |`);
-  for (const k of Object.keys(results).sort()) {
-    const r = results[k];
-    L.push(
-      `| \`${k}\` | ${r.samples.map((x) => x.toFixed(0)).join(", ") || "—"} ` +
-        `| ${s(r.median)} | ${s(r.min)} |`,
-    );
-  }
-  L.push("");
-  return L.join("\n");
 }
-
-function printConfigTable() {
-  process.stdout.write(`\nttsc matrix benchmark — project config\n\n`);
-  for (const [name, cfg] of Object.entries(PROJECTS)) {
-    process.stdout.write(
-      `${name}  [${cfg.kind}]  branches: ${cfg.branches.join(", ")}\n`,
-    );
-    process.stdout.write(`  repo: ${cfg.repo}\n`);
-    if (cfg.prerequisites?.length)
-      process.stdout.write(`  prerequisites: ${cfg.prerequisites.join(", ")}\n`);
-    for (const c of cfg.cases) {
-      process.stdout.write(
-        `  case ${c.name}: emit=${c.emit} singleThreaded=${c.singleThreaded}` +
-          `${c.cwd ? ` cwd=${c.cwd}` : ""}\n`,
-      );
-      process.stdout.write(`    legacy: ${c.legacy?.build ?? "—"}\n`);
-      process.stdout.write(
-        `    ttsc:   ${c.ttsc?.build ?? "—"}` +
-          `${c.ttsc?.noEmit ? `  |  noEmit: ${c.ttsc.noEmit}` : ""}\n`,
-      );
-    }
-    process.stdout.write("\n");
-  }
-}
-
-// ── main ─────────────────────────────────────────────────────────────────────
 
 function main() {
-  const started = new Date();
+  if (wantedProjects.length === 0)
+    throw new Error("no benchmark projects selected");
+
   fs.mkdirSync(WORK, { recursive: true });
   fs.mkdirSync(path.dirname(OUT), { recursive: true });
 
-  // Prior results merge in so projects can be measured across invocations.
-  const jsonPath = OUT.replace(/\.md$/, ".json");
-  let results = {};
-  if (fs.existsSync(jsonPath)) {
-    try {
-      results = JSON.parse(fs.readFileSync(jsonPath, "utf8")).results ?? {};
-    } catch {
-      results = {};
-    }
-  }
-
-  // Step 1 — tarballs (skipped by --no-setup, which assumes clones are ready).
   if (!flags.has("--no-setup")) {
     packTarballs();
-  }
-
-  // Steps 2 + 3 — clone + install every (project, branch).
-  const ready = {}; // project -> Set<branch> that installed cleanly
-  if (!flags.has("--no-setup")) {
-    process.stdout.write(`\n▸ cloning + installing fixtures into ${WORK}\n`);
+    const setupFailures = [];
     for (const project of wantedProjects) {
-      ready[project] = new Set();
-      for (const branch of PROJECTS[project].branches) {
+      for (const branch of BRANCHES) {
         try {
-          if (setupClone(project, branch)) ready[project].add(branch);
-        } catch (err) {
-          process.stdout.write(
-            `  ⚠ ${project}@${branch}: setup failed — ${err.message}\n`,
+          setupClone(project, branch);
+        } catch (error) {
+          setupFailures.push(
+            `${project.repoName}@${branch}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
           );
         }
       }
     }
-  } else {
-    // --no-setup: trust whatever clones already exist on disk.
-    for (const project of wantedProjects) {
-      ready[project] = new Set(
-        PROJECTS[project].branches.filter((b) =>
-          fs.existsSync(cloneDir(project, b)),
-        ),
+    if (setupFailures.length && !flags.has("--allow-missing")) {
+      throw new Error(
+        "setup failed; pass --allow-missing to measure the ready subset\n" +
+          setupFailures.map((f) => `- ${f}`).join("\n"),
       );
     }
   }
 
   if (flags.has("--setup-only")) {
-    process.stdout.write(`\n✓ setup complete — clones in ${WORK}\n`);
+    process.stdout.write(`Setup complete in ${WORK}\n`);
     return;
   }
 
-  // Step 4 — measure.
-  for (const project of wantedProjects) {
-    for (const c of PROJECTS[project].cases) {
-      for (const branch of PROJECTS[project].branches) {
-        if (!ready[project]?.has(branch)) continue;
-        measureCase(results, project, branch, c);
+  const readyProjects = wantedProjects.filter((project) =>
+    BRANCHES.every((branch) => fs.existsSync(cloneDir(project, branch))),
+  );
+  const missingProjects = wantedProjects.filter(
+    (project) => !readyProjects.includes(project),
+  );
+  if (missingProjects.length && !flags.has("--allow-missing")) {
+    throw new Error(
+      "missing prepared clones; run without --no-setup to clone/install them " +
+        "or pass --allow-missing\n" +
+        missingProjects.map((project) => `- ${project.repoName}`).join("\n"),
+    );
+  }
+
+  if (flags.has("--verify-only")) {
+    verifyCommands(readyProjects);
+    return;
+  }
+
+  const report = createReport(readyProjects);
+  writeReports(report);
+  for (const project of readyProjects) measureProject(project, report);
+  writeReports(report, { publishWebsite: true });
+
+  process.stdout.write(`Report written to ${OUT}\n`);
+  process.stdout.write(`Website JSON written to ${WEBSITE_JSON}\n`);
+}
+
+function verifyCommands(projects) {
+  const failures = [];
+  for (const project of projects) {
+    for (const cell of projectCells(project)) {
+      const root = cloneDir(project, cell.branch);
+      process.stdout.write(`\nVERIFY ${cell.id}\n`);
+      const result = runSteps(cell.steps, root);
+      if (!result.ok) {
+        failures.push(`${cell.id} failed (${result.status})`);
+        process.stderr.write(result.log);
+      } else {
+        process.stdout.write(`  ok ${result.ms.toFixed(0)} ms\n`);
       }
     }
   }
-
-  // Report.
-  const host = hostSpec(wantedProjects);
-  const report = buildReport(results, started, host);
-  fs.writeFileSync(OUT, report);
-  fs.writeFileSync(
-    jsonPath,
-    JSON.stringify({ started, host, results }, null, 2),
-  );
-
-  // Canonical website result — the published, committed, served file. Written
-  // straight to website/public/benchmark.json so a run needs no manual step.
-  const websiteReport = buildWebsiteReport(results, started, host);
-  fs.mkdirSync(path.dirname(WEBSITE_JSON), { recursive: true });
-  fs.writeFileSync(
-    WEBSITE_JSON,
-    JSON.stringify(websiteReport, null, 2) + "\n",
-  );
-
-  process.stdout.write(
-    `\n${report}\n\nReport written to ${OUT}\n` +
-      `Website result written to ${WEBSITE_JSON}\n`,
-  );
+  if (failures.length) {
+    throw new Error(
+      `benchmark command verification failed\n${failures
+        .map((f) => `- ${f}`)
+        .join("\n")}`,
+    );
+  }
+  process.stdout.write("\nAll benchmark commands verified.\n");
 }
 
-main();
+function projectCells(project) {
+  const cells = [];
+  for (const branch of BRANCHES) {
+    const branchCommands = project.commands[branch];
+    if (!branchCommands) continue;
+    for (const op of ["build", "noEmit", "eslint"]) {
+      const baseSteps = branchCommands[op];
+      if (!baseSteps?.length) continue;
+      if (branch === "legacy" || op === "eslint") {
+        cells.push({
+          id: `${project.name}:${branch}:${op}:multi`,
+          project,
+          branch,
+          op,
+          threading: "multi",
+          steps: baseSteps,
+        });
+      } else {
+        cells.push({
+          id: `${project.name}:${branch}:${op}:multi`,
+          project,
+          branch,
+          op,
+          threading: "multi",
+          steps: baseSteps,
+        });
+        cells.push({
+          id: `${project.name}:${branch}:${op}:single`,
+          project,
+          branch,
+          op,
+          threading: "single",
+          steps: singleThreadedSteps(baseSteps),
+        });
+      }
+      if (branch === "ttsc" && (op === "build" || op === "noEmit")) {
+        const tsgoSteps =
+          branchCommands[op === "build" ? "tsgoBuild" : "tsgoNoEmit"];
+        if (tsgoSteps?.length) {
+          cells.push({
+            id: `${project.name}:${branch}:tsgo:${op}:multi`,
+            project,
+            branch,
+            tool: "tsgo",
+            op,
+            threading: "multi",
+            steps: tsgoSteps,
+          });
+          cells.push({
+            id: `${project.name}:${branch}:tsgo:${op}:single`,
+            project,
+            branch,
+            tool: "tsgo",
+            op,
+            threading: "single",
+            steps: singleThreadedSteps(tsgoSteps),
+          });
+        }
+      }
+    }
+  }
+  return cells;
+}

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -160,7 +160,7 @@ const PACKAGE_CONFIGS = {
     installCommand:
       "pnpm --ignore-workspace install --virtual-store-dir node_modules/.pnpm --no-frozen-lockfile --ignore-scripts",
     installTarballsCommand: (specs) =>
-      `pnpm --ignore-workspace add --virtual-store-dir node_modules/.pnpm -D --ignore-scripts ${specs}`,
+      `pnpm --ignore-workspace add --virtual-store-dir node_modules/.pnpm -D --no-frozen-lockfile --ignore-scripts ${specs}`,
     prepareCommand: "pnpm exec ttsc prepare -p tsconfig.json",
     filesRoot: "src",
     commands: compilerCommands({
@@ -654,8 +654,8 @@ function installLocalTarballs(project, dir, branch) {
     project.installTarballsCommand?.(specs) ??
     (pm === "pnpm"
       ? ownsPnpmWorkspace(dir)
-        ? `pnpm add -w -D ${specs}`
-        : `pnpm add --ignore-workspace -D ${specs}`
+        ? `pnpm add -w -D --no-frozen-lockfile ${specs}`
+        : `pnpm add --ignore-workspace -D --no-frozen-lockfile ${specs}`
       : pm === "yarn"
         ? `YARN_CACHE_FOLDER=.yarn-cache yarn add --dev --force --update-checksums --ignore-engines --ignore-workspace-root-check ${specs}`
         : `npm install --legacy-peer-deps --save-dev ${specs}`);
@@ -812,8 +812,8 @@ function installTsgoExperimentDeps(project, dir) {
   const cmd =
     pm === "pnpm"
       ? ownsPnpmWorkspace(dir)
-        ? `pnpm add -w -D ${specs}`
-        : `pnpm add --ignore-workspace --virtual-store-dir node_modules/.pnpm -D ${specs}`
+        ? `pnpm add -w -D --no-frozen-lockfile ${specs}`
+        : `pnpm add --ignore-workspace --virtual-store-dir node_modules/.pnpm -D --no-frozen-lockfile ${specs}`
       : pm === "yarn"
         ? `YARN_CACHE_FOLDER=.yarn-cache yarn add --dev --force --update-checksums --ignore-engines --ignore-workspace-root-check ${specs}`
         : `npm install --legacy-peer-deps --ignore-scripts --save-dev ${specs}`;

--- a/experimental/benchmark/bench.mjs
+++ b/experimental/benchmark/bench.mjs
@@ -894,11 +894,17 @@ function projectReportFor(project, measurements) {
     name: project.name,
     repo: project.repoName,
     kind: project.kind,
-    files: countSourceFiles(
-      path.join(cloneDir(project, "legacy"), project.filesRoot),
-    ),
+    files: countSourceFiles(projectSourceRoot(project)),
     measurements,
   };
+}
+
+function projectSourceRoot(project) {
+  for (const branch of projectBranches(project)) {
+    const root = path.join(cloneDir(project, branch), project.filesRoot);
+    if (fs.existsSync(root)) return root;
+  }
+  return path.join(cloneDir(project, "legacy"), project.filesRoot);
 }
 
 function countSourceFiles(root) {
@@ -1095,7 +1101,7 @@ function main() {
     packTarballs();
     const setupFailures = [];
     for (const project of wantedProjects) {
-      for (const branch of BRANCHES) {
+      for (const branch of projectBranches(project)) {
         try {
           setupClone(project, branch);
         } catch (error) {
@@ -1121,7 +1127,9 @@ function main() {
   }
 
   const readyProjects = wantedProjects.filter((project) =>
-    BRANCHES.every((branch) => fs.existsSync(cloneDir(project, branch))),
+    projectBranches(project).every((branch) =>
+      fs.existsSync(cloneDir(project, branch)),
+    ),
   );
   const missingProjects = wantedProjects.filter(
     (project) => !readyProjects.includes(project),
@@ -1235,6 +1243,10 @@ function projectCells(project) {
     }
   }
   return filterCells(cells);
+}
+
+function projectBranches(project) {
+  return [...new Set(projectCells(project).map((cell) => cell.branch))];
 }
 
 function filterCells(cells) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release": "bumpp -r",
     "test": "pnpm run build:current && pnpm run test:typecheck && pnpm run test:features",
     "coverage:go": "node scripts/test-go-coverage.cjs",
-    "test:features": "pnpm --filter \"./tests/test-*\" -r start",
+    "test:features": "pnpm --filter \"./tests/test-*\" -r --workspace-concurrency=1 start",
     "test:typecheck": "node scripts/test-typecheck.cjs"
   },
   "repository": {

--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -280,31 +280,83 @@ func walkDescendants(node *shimast.Node, visit func(*shimast.Node)) {
   })
 }
 
-// bindingIdentifierNames collects the declared identifier names from a
-// binding pattern. For a simple Identifier node it returns a single-element
-// slice. For ObjectBindingPattern and ArrayBindingPattern it walks the
-// descendants and returns all embedded Identifier texts. Returns nil for
-// unrecognized node kinds.
-func bindingIdentifierNames(node *shimast.Node) []string {
+// assignmentTargetNames collects the identifier names written by an
+// assignment's left-hand side. A bare Identifier yields one name. A
+// destructuring-assignment target — parsed as an ArrayLiteralExpression
+// (`[a, b] = …`) or ObjectLiteralExpression (`({a} = …)`) rather than a
+// binding pattern — is walked so every nested write position is counted:
+// array elements, object property values, shorthand properties, defaults
+// (`[a = 1]`, `{a = 1}`), nested patterns, and rest elements.
+//
+// Property names in `{key: target}` are read positions, not writes, so
+// only the property value contributes; member-access targets (`obj.x`)
+// declare no local binding and are skipped. Returns nil for other shapes.
+func assignmentTargetNames(node *shimast.Node) []string {
   if node == nil {
     return nil
   }
   if name := identifierText(node); name != "" {
     return []string{name}
   }
-  if node.Kind != shimast.KindObjectBindingPattern && node.Kind != shimast.KindArrayBindingPattern {
-    return nil
-  }
   var names []string
-  walkDescendants(node, func(child *shimast.Node) {
-    if child == node {
-      return
-    }
-    if name := identifierText(child); name != "" {
-      names = append(names, name)
-    }
-  })
+  collectAssignmentTargetNames(node, &names)
   return names
+}
+
+// collectAssignmentTargetNames appends to `names` every identifier in a
+// destructuring-assignment target. It descends only through write-target
+// positions so reads (object property keys, computed-member expressions)
+// never count as reassignments.
+func collectAssignmentTargetNames(node *shimast.Node, names *[]string) {
+  if node == nil {
+    return
+  }
+  switch node.Kind {
+  case shimast.KindIdentifier:
+    if name := identifierText(node); name != "" {
+      *names = append(*names, name)
+    }
+  case shimast.KindParenthesizedExpression:
+    collectAssignmentTargetNames(stripParens(node), names)
+  case shimast.KindArrayLiteralExpression:
+    if arr := node.AsArrayLiteralExpression(); arr != nil && arr.Elements != nil {
+      for _, el := range arr.Elements.Nodes {
+        collectAssignmentTargetNames(el, names)
+      }
+    }
+  case shimast.KindObjectLiteralExpression:
+    if obj := node.AsObjectLiteralExpression(); obj != nil && obj.Properties != nil {
+      for _, prop := range obj.Properties.Nodes {
+        collectAssignmentTargetNames(prop, names)
+      }
+    }
+  case shimast.KindSpreadElement:
+    if spread := node.AsSpreadElement(); spread != nil {
+      collectAssignmentTargetNames(spread.Expression, names)
+    }
+  case shimast.KindSpreadAssignment:
+    if spread := node.AsSpreadAssignment(); spread != nil {
+      collectAssignmentTargetNames(spread.Expression, names)
+    }
+  case shimast.KindShorthandPropertyAssignment:
+    // `{a}` and `{a = 1}` — the property name is the write target; any
+    // ObjectAssignmentInitializer is a default value, not a target.
+    if short := node.AsShorthandPropertyAssignment(); short != nil {
+      collectAssignmentTargetNames(short.Name(), names)
+    }
+  case shimast.KindPropertyAssignment:
+    // `{key: target}` — only the value (initializer) is written to.
+    if assignment := node.AsPropertyAssignment(); assignment != nil {
+      collectAssignmentTargetNames(assignment.Initializer, names)
+    }
+  case shimast.KindBinaryExpression:
+    // A default inside a pattern (`[a = 1]`, `{key: a = 1}`) parses as an
+    // `=` BinaryExpression; only its left side is the write target.
+    if expr := node.AsBinaryExpression(); expr != nil &&
+      expr.OperatorToken != nil && expr.OperatorToken.Kind == shimast.KindEqualsToken {
+      collectAssignmentTargetNames(expr.Left, names)
+    }
+  }
 }
 
 // isLiteralLike reports whether `node` (after stripping parentheses) is a

--- a/packages/lint/linthost/compile.go
+++ b/packages/lint/linthost/compile.go
@@ -89,11 +89,19 @@ func RunTransform(args []string) int {
     fmt.Fprintln(os.Stderr, err)
     return 2
   }
+  rules, err := loadRules(*pluginsJSON, resolvedCwd, *tsconfig)
+  if err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    return 2
+  }
+  engine := NewEngineWithResolver(rules)
+
   prog, parseDiags, err := loadProgram(resolvedCwd, *tsconfig, loadProgramOptions{
-    forceEmit:      true,
-    singleThreaded: *singleThreaded,
-    checkers:       *checkers,
-    tsgoArgs:       tsgoArgs,
+    forceEmit:        true,
+    needsRuleChecker: engine.NeedsTypeChecker(),
+    singleThreaded:   *singleThreaded,
+    checkers:         *checkers,
+    tsgoArgs:         tsgoArgs,
   })
   if err != nil {
     fmt.Fprintf(os.Stderr, "@ttsc/lint: %v\n", err)
@@ -104,13 +112,6 @@ func RunTransform(args []string) int {
     return 2
   }
   defer prog.close()
-
-  rules, err := loadRules(*pluginsJSON, resolvedCwd, *tsconfig)
-  if err != nil {
-    fmt.Fprintln(os.Stderr, err)
-    return 2
-  }
-  engine := NewEngineWithResolver(rules)
 
   astDiags, lintDiags, err := collectDiagnostics(prog, engine)
   if err != nil {
@@ -260,13 +261,21 @@ func decodeTsgoArgs(raw string) ([]string, error) {
 // program, collects diagnostics, renders them, and optionally emits
 // JavaScript output when the config allows it.
 func runProject(opts *subcommandOpts) int {
+  rules, err := loadRules(opts.pluginsJSON, opts.cwd, opts.tsconfig)
+  if err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    return 2
+  }
+  engine := NewEngineWithResolver(rules)
+
   prog, parseDiags, err := loadProgram(opts.cwd, opts.tsconfig, loadProgramOptions{
-    forceEmit:      opts.emit,
-    forceNoEmit:    opts.noEmit,
-    outDir:         opts.outDir,
-    singleThreaded: opts.singleThreaded,
-    checkers:       opts.checkers,
-    tsgoArgs:       opts.tsgoArgs,
+    forceEmit:        opts.emit,
+    forceNoEmit:      opts.noEmit,
+    outDir:           opts.outDir,
+    needsRuleChecker: engine.NeedsTypeChecker(),
+    singleThreaded:   opts.singleThreaded,
+    checkers:         opts.checkers,
+    tsgoArgs:         opts.tsgoArgs,
   })
   if err != nil {
     fmt.Fprintf(os.Stderr, "@ttsc/lint: %v\n", err)
@@ -277,13 +286,6 @@ func runProject(opts *subcommandOpts) int {
     return 2
   }
   defer prog.close()
-
-  rules, err := loadRules(opts.pluginsJSON, opts.cwd, opts.tsconfig)
-  if err != nil {
-    fmt.Fprintln(os.Stderr, err)
-    return 2
-  }
-  engine := NewEngineWithResolver(rules)
 
   astDiags, lintDiags, err := collectDiagnostics(prog, engine)
   if err != nil {

--- a/packages/lint/linthost/contrib_adapter.go
+++ b/packages/lint/linthost/contrib_adapter.go
@@ -68,6 +68,13 @@ type contributorAdapter struct {
   inner rule.Rule
 }
 
+// NeedsTypeChecker keeps contributor rules on the historical checker path.
+// The public rule.Context exposes Checker and has no mandatory marker, so the
+// host cannot safely infer that a third-party rule is AST-only.
+func (a contributorAdapter) NeedsTypeChecker() bool {
+  return true
+}
+
 // formatContributorAdapter is the FormatRule-tagged variant of
 // contributorAdapter. Wrapping the lint-only adapter (rather than
 // duplicating its method set) keeps the marker addition trivial and

--- a/packages/lint/linthost/engine.go
+++ b/packages/lint/linthost/engine.go
@@ -314,6 +314,9 @@ func (e *Engine) runFile(file *shimast.SourceFile, checker *shimchecker.Checker)
     return collected
   }
   fileRules := resolved.Rules
+  if !hasEnabledFileRules(fileRules) {
+    return collected
+  }
 
   var walk func(node *shimast.Node)
   walk = func(node *shimast.Node) {
@@ -379,6 +382,15 @@ func (e *Engine) runFile(file *shimast.SourceFile, checker *shimchecker.Checker)
   // the filter would silently leak those findings into the diagnostic
   // stream.
   return filterInlineDisabledFindings(file, collected)
+}
+
+func hasEnabledFileRules(rules RuleConfig) bool {
+  for _, severity := range rules {
+    if severity != SeverityOff {
+      return true
+    }
+  }
+  return false
 }
 
 // runRuleCheck invokes a rule's `Check` with a `recover()` barrier so a

--- a/packages/lint/linthost/engine.go
+++ b/packages/lint/linthost/engine.go
@@ -62,10 +62,21 @@ type FormatRule interface {
   IsFormat() bool
 }
 
+// typeAwareRule marks rules that need a live TypeScript checker in Context.
+// Rules that do not implement it are assumed AST-only.
+type typeAwareRule interface {
+  NeedsTypeChecker() bool
+}
+
 // isFormatRule reports whether `r` opts into the format category.
 func isFormatRule(r Rule) bool {
   fr, ok := r.(FormatRule)
   return ok && fr.IsFormat()
+}
+
+func ruleNeedsTypeChecker(r Rule) bool {
+  tr, ok := r.(typeAwareRule)
+  return ok && tr.NeedsTypeChecker()
 }
 
 // Context is the per-(file, rule) handle the engine passes to `Check`.
@@ -234,10 +245,11 @@ func AllRuleNames() []string {
 // Engine binds a rule configuration to a Program and walks the AST once
 // per source file, dispatching each visited node to its interested rules.
 type Engine struct {
-  config  RuleResolver
-  rules   map[shimast.Kind][]Rule
-  enabled map[string]Severity
-  unknown []string
+  config           RuleResolver
+  rules            map[shimast.Kind][]Rule
+  enabled          map[string]Severity
+  unknown          []string
+  needsTypeChecker bool
 }
 
 // NewEngine returns an engine configured for `config`. Rules whose
@@ -266,6 +278,9 @@ func NewEngineWithResolver(config RuleResolver) *Engine {
       eng.unknown = append(eng.unknown, name)
       continue
     }
+    if ruleNeedsTypeChecker(rule) {
+      eng.needsTypeChecker = true
+    }
     eng.enabled[name] = displaySeverities.Severity(name)
     // Dedup kinds per rule so a contributor that accidentally lists the
     // same Kind twice in `Visits()` doesn't end up firing twice per node.
@@ -285,6 +300,11 @@ func NewEngineWithResolver(config RuleResolver) *Engine {
 // UnknownRules returns the names of rules that appeared in the config but
 // have no registered implementation.
 func (e *Engine) UnknownRules() []string { return e.unknown }
+
+// NeedsTypeChecker reports whether any active rule requires Context.Checker.
+func (e *Engine) NeedsTypeChecker() bool {
+  return e != nil && e.needsTypeChecker
+}
 
 // EnabledRules returns the active rule set keyed by name. Mostly for
 // tests + introspection.

--- a/packages/lint/linthost/fix.go
+++ b/packages/lint/linthost/fix.go
@@ -43,8 +43,10 @@ func runFix(opts *subcommandOpts) int {
     fmt.Fprintln(os.Stderr, err)
     return 2
   }
+  engine := NewEngineWithResolver(rules)
+  needsRuleChecker := engine.NeedsTypeChecker()
 
-  prog, code := loadFixProgram(opts)
+  prog, code := loadFixProgram(opts, needsRuleChecker)
   if code != 0 {
     return code
   }
@@ -63,7 +65,6 @@ func runFix(opts *subcommandOpts) int {
   // kinds of findings in one pass — no filtering needed here.
   cascadeConverged := false
   for pass := 0; pass < maxFixPasses; pass++ {
-    engine := NewEngineWithResolver(rules)
     findings := engine.Run(prog.userSourceFiles(), prog.checker)
     fixed, err := applyFindingFixes(opts.cwd, findings)
     if err != nil {
@@ -75,7 +76,7 @@ func runFix(opts *subcommandOpts) int {
       break
     }
     totalFixes += fixed
-    prog, code = reloadFixProgram(prog, opts)
+    prog, code = reloadFixProgram(prog, opts, needsRuleChecker)
     if code != 0 {
       return code
     }
@@ -92,7 +93,6 @@ func runFix(opts *subcommandOpts) int {
       maxFixPasses)
   }
 
-  engine := NewEngineWithResolver(rules)
   astDiags, lintDiags, err := collectDiagnostics(prog, engine)
   if err != nil {
     fmt.Fprintln(os.Stderr, err)
@@ -117,13 +117,14 @@ func runFix(opts *subcommandOpts) int {
 
 // loadFixProgram loads the TypeScript program for a fix/format pass with
 // NoEmit forced on. Returns (nil, 2) when loading or config parsing fails.
-func loadFixProgram(opts *subcommandOpts) (*program, int) {
+func loadFixProgram(opts *subcommandOpts, needsRuleChecker bool) (*program, int) {
   prog, parseDiags, err := loadProgram(opts.cwd, opts.tsconfig, loadProgramOptions{
-    forceNoEmit:    true,
-    outDir:         opts.outDir,
-    singleThreaded: opts.singleThreaded,
-    checkers:       opts.checkers,
-    tsgoArgs:       opts.tsgoArgs,
+    forceNoEmit:      true,
+    outDir:           opts.outDir,
+    needsRuleChecker: needsRuleChecker,
+    singleThreaded:   opts.singleThreaded,
+    checkers:         opts.checkers,
+    tsgoArgs:         opts.tsgoArgs,
   })
   if err != nil {
     fmt.Fprintf(os.Stderr, "@ttsc/lint: %v\n", err)
@@ -139,11 +140,11 @@ func loadFixProgram(opts *subcommandOpts) (*program, int) {
 // reloadFixProgram closes `current` and loads a fresh program from disk.
 // Used between cascade passes so the engine sees edits applied in the
 // previous pass rather than stale in-memory AST nodes.
-func reloadFixProgram(current *program, opts *subcommandOpts) (*program, int) {
+func reloadFixProgram(current *program, opts *subcommandOpts, needsRuleChecker bool) (*program, int) {
   if current != nil {
     current.close()
   }
-  return loadFixProgram(opts)
+  return loadFixProgram(opts, needsRuleChecker)
 }
 
 // fileFixes groups all pending TextEdit suggestions for a single file.

--- a/packages/lint/linthost/format.go
+++ b/packages/lint/linthost/format.go
@@ -41,8 +41,11 @@ func runFormat(opts *subcommandOpts) int {
     fmt.Fprintln(os.Stderr, err)
     return 2
   }
+  resolver := formatCommandResolver{inner: rules}
+  engine := NewEngineWithResolver(resolver)
+  needsRuleChecker := engine.NeedsTypeChecker()
 
-  prog, code := loadFixProgram(opts)
+  prog, code := loadFixProgram(opts, needsRuleChecker)
   if code != 0 {
     return code
   }
@@ -55,7 +58,6 @@ func runFormat(opts *subcommandOpts) int {
   totalFixes := 0
   cascadeConverged := false
   for pass := 0; pass < maxFormatPasses; pass++ {
-    engine := NewEngineWithResolver(formatCommandResolver{inner: rules})
     findings := engine.Run(prog.userSourceFiles(), prog.checker)
     fixed, err := applyFindingFixes(opts.cwd, filterFormatFindings(findings))
     if err != nil {
@@ -67,7 +69,7 @@ func runFormat(opts *subcommandOpts) int {
       break
     }
     totalFixes += fixed
-    prog, code = reloadFixProgram(prog, opts)
+    prog, code = reloadFixProgram(prog, opts, needsRuleChecker)
     if code != 0 {
       return code
     }

--- a/packages/lint/linthost/host.go
+++ b/packages/lint/linthost/host.go
@@ -246,10 +246,10 @@ func parseTsgoArgs(args []string, host shimcompiler.CompilerHost) (*shimcore.Com
 // CompilerOptions, and both Program.SingleThreaded() and the checker pool read
 // them from there. SingleThreaded wins over Checkers, matching the pool.
 //
-// loadProgram calls forceSingleChecker afterwards, so a `--checkers N` greater
-// than 1 is recorded here but clamped back to a single checker: the lint
-// engine requires one checker (see forceSingleChecker). `--singleThreaded`
-// still takes full effect.
+// When a type-aware lint rule is active, loadProgram calls forceSingleChecker
+// afterwards, so a `--checkers N` greater than 1 is recorded here and then
+// clamped back to a single checker. AST-only lint runs keep the recorded
+// checker count. `--singleThreaded` still takes full effect.
 func applyThreading(parsed *tsoptions.ParsedCommandLine, singleThreaded bool, checkers int) {
   if parsed == nil || parsed.ParsedConfig == nil || parsed.ParsedConfig.CompilerOptions == nil {
     return

--- a/packages/lint/linthost/host.go
+++ b/packages/lint/linthost/host.go
@@ -39,6 +39,9 @@ type loadProgramOptions struct {
   forceEmit   bool
   forceNoEmit bool
   outDir      string
+  // needsRuleChecker asks loadProgram to pin the checker pool and acquire the
+  // checker that type-aware lint rules receive through Context.Checker.
+  needsRuleChecker bool
   // singleThreaded mirrors `tsgo --singleThreaded`: one checker, serial
   // parse/check/emit.
   singleThreaded bool
@@ -52,8 +55,9 @@ type loadProgramOptions struct {
   tsgoArgs []string
 }
 
-// loadProgram parses the given tsconfig, builds a Program, and acquires a
-// type checker. Mirrors the canonical bootstrap pattern from
+// loadProgram parses the given tsconfig and builds a Program. When
+// needsRuleChecker is set, it also acquires a type checker for lint rules.
+// Mirrors the canonical bootstrap pattern from
 // `03-tsgo.md` — the only ttsc-specific bit is that `forceEmit`/
 // `forceNoEmit`/`outDir` overrides are merged into the parsed config
 // before the program is created so `--noEmit` and friends behave like
@@ -105,18 +109,20 @@ func loadProgram(cwd, tsconfigPath string, options loadProgramOptions) (*program
     overrideOutDir(cwd, parsed, options.outDir)
   }
   applyThreading(parsed, options.singleThreaded, options.checkers)
-  forceSingleChecker(parsed)
+  if options.needsRuleChecker {
+    forceSingleChecker(parsed)
+  }
 
   // SingleThreaded is left unset so the program keeps TypeScript-Go's parallel
-  // source parsing and parallel emit. The checker pool, however, is pinned to
-  // a single checker (see forceSingleChecker): the lint engine walks files
-  // serially against the one checker GetTypeChecker hands back, and rules ask
-  // that checker to resolve types in nodes drawn from every source file.
-  // TypeScript-Go's multi-checker pool affinitizes each file to a different
-  // checker and forbids mixing types across them, so a type whose declarations
-  // span files on different checkers (e.g. a circular indexed-access alias)
-  // resolves to `any` on the borrowed checker. One checker keeps the engine's
-  // checker consistent with how every file was checked.
+  // source parsing and parallel emit. For type-aware lint rules, the checker
+  // pool is pinned to a single checker (see forceSingleChecker): the lint
+  // engine walks files serially against the one checker GetTypeChecker hands
+  // back, and rules ask that checker to resolve types in nodes drawn from every
+  // source file. TypeScript-Go's multi-checker pool affinitizes each file to a
+  // different checker and forbids mixing types across them, so a type whose
+  // declarations span files on different checkers (e.g. a circular
+  // indexed-access alias) resolves to `any` on the borrowed checker. AST-only
+  // lint rules do not receive a checker, so they keep the user's checker pool.
   tsProgram := shimcompiler.NewProgram(shimcompiler.ProgramOptions{
     Config:                      parsed,
     Host:                        host,
@@ -125,7 +131,11 @@ func loadProgram(cwd, tsconfigPath string, options loadProgramOptions) (*program
   if tsProgram == nil {
     return nil, nil, errors.New("compiler.NewProgram returned nil")
   }
-  checker, release := tsProgram.GetTypeChecker(context.Background())
+  var checker *shimchecker.Checker
+  var release func()
+  if options.needsRuleChecker {
+    checker, release = tsProgram.GetTypeChecker(context.Background())
+  }
   return &program{
     cwd:            cwd,
     tsProgram:      tsProgram,

--- a/packages/lint/linthost/host.go
+++ b/packages/lint/linthost/host.go
@@ -105,13 +105,18 @@ func loadProgram(cwd, tsconfigPath string, options loadProgramOptions) (*program
     overrideOutDir(cwd, parsed, options.outDir)
   }
   applyThreading(parsed, options.singleThreaded, options.checkers)
+  forceSingleChecker(parsed)
 
-  // SingleThreaded is left unset so the program runs on TypeScript-Go's
-  // multi-threaded default: parallel parsing, a pooled checker driving
-  // parallel bind + semantic diagnostics, and parallel emit. The lint engine
-  // still walks files serially against a single pooled checker, which stays
-  // valid against the larger pool — the pool fans out only inside each
-  // TypeScript-Go phase, never across the engine's own traversal.
+  // SingleThreaded is left unset so the program keeps TypeScript-Go's parallel
+  // source parsing and parallel emit. The checker pool, however, is pinned to
+  // a single checker (see forceSingleChecker): the lint engine walks files
+  // serially against the one checker GetTypeChecker hands back, and rules ask
+  // that checker to resolve types in nodes drawn from every source file.
+  // TypeScript-Go's multi-checker pool affinitizes each file to a different
+  // checker and forbids mixing types across them, so a type whose declarations
+  // span files on different checkers (e.g. a circular indexed-access alias)
+  // resolves to `any` on the borrowed checker. One checker keeps the engine's
+  // checker consistent with how every file was checked.
   tsProgram := shimcompiler.NewProgram(shimcompiler.ProgramOptions{
     Config:                      parsed,
     Host:                        host,
@@ -230,6 +235,11 @@ func parseTsgoArgs(args []string, host shimcompiler.CompilerHost) (*shimcore.Com
 // parsed compiler options. ttsc mirrors tsgo here: the values land in
 // CompilerOptions, and both Program.SingleThreaded() and the checker pool read
 // them from there. SingleThreaded wins over Checkers, matching the pool.
+//
+// loadProgram calls forceSingleChecker afterwards, so a `--checkers N` greater
+// than 1 is recorded here but clamped back to a single checker: the lint
+// engine requires one checker (see forceSingleChecker). `--singleThreaded`
+// still takes full effect.
 func applyThreading(parsed *tsoptions.ParsedCommandLine, singleThreaded bool, checkers int) {
   if parsed == nil || parsed.ParsedConfig == nil || parsed.ParsedConfig.CompilerOptions == nil {
     return
@@ -242,6 +252,26 @@ func applyThreading(parsed *tsoptions.ParsedCommandLine, singleThreaded bool, ch
     n := checkers
     options.Checkers = &n
   }
+}
+
+// forceSingleChecker pins the TypeScript-Go checker pool to a single checker.
+//
+// The lint engine walks the program serially and obtains types through the
+// single checker GetTypeChecker hands back. Rules query types on nodes from
+// arbitrary source files, so the checker must be the same one that checked
+// every file. A pool of size > 1 affinitizes files to distinct checkers;
+// resolving a type whose declarations cross that boundary yields `any`.
+// Parallel parsing and emit are unaffected — they do not consult the count.
+func forceSingleChecker(parsed *tsoptions.ParsedCommandLine) {
+  if parsed == nil || parsed.ParsedConfig == nil || parsed.ParsedConfig.CompilerOptions == nil {
+    return
+  }
+  options := parsed.ParsedConfig.CompilerOptions
+  if options.SingleThreaded == shimcore.TSTrue {
+    return
+  }
+  one := 1
+  options.Checkers = &one
 }
 
 // overrideOutDir replaces the parsed config's OutDir with `outDir`.

--- a/packages/lint/linthost/rules_promise.go
+++ b/packages/lint/linthost/rules_promise.go
@@ -19,6 +19,9 @@ import (
 type awaitThenable struct{}
 
 func (awaitThenable) Name() string { return "await-thenable" }
+func (awaitThenable) NeedsTypeChecker() bool {
+  return true
+}
 func (awaitThenable) Visits() []shimast.Kind {
   return []shimast.Kind{shimast.KindAwaitExpression}
 }

--- a/packages/lint/linthost/rules_var.go
+++ b/packages/lint/linthost/rules_var.go
@@ -71,7 +71,7 @@ func (preferConst) Check(ctx *Context, node *shimast.Node) {
       if expr == nil || expr.OperatorToken == nil || !isAssignmentOperator(expr.OperatorToken.Kind) {
         return
       }
-      for _, name := range bindingIdentifierNames(expr.Left) {
+      for _, name := range assignmentTargetNames(expr.Left) {
         assigned[name] = true
       }
     case shimast.KindPrefixUnaryExpression:

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -18,6 +18,7 @@ type TtscPluginContributor = {
 /** Descriptor shape returned to ttsc's plugin builder by the factory. */
 type TtscPluginDescriptor = {
   name: string;
+  reportsTypeScriptDiagnostics?: boolean;
   source: string;
   stage?: "check" | "transform";
   contributors?: TtscPluginContributor[];
@@ -111,6 +112,7 @@ export default function createTtscPlugin(
   // tests) see the same surface as before this feature shipped.
   const descriptor: TtscPluginDescriptor = {
     name: "@ttsc/lint",
+    reportsTypeScriptDiagnostics: true,
     source: path.resolve(__dirname, "..", "plugin"),
     stage: "check",
   };

--- a/packages/lint/test/command/command_fix_type_aware_rule_receives_checker_test.go
+++ b/packages/lint/test/command/command_fix_type_aware_rule_receives_checker_test.go
@@ -1,0 +1,50 @@
+package linthost
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestCommandFixTypeAwareRuleReceivesChecker verifies fix mode still supplies
+// Context.Checker to type-aware rules.
+//
+// The checker optimization is driven before Program creation. fix uses a
+// separate reload path from check/build, so await-thenable must keep that path
+// on the single-checker setup or its fixer silently abstains.
+//
+// 1. Materialize a project with `await` on a number.
+// 2. Run `ttsc lint fix` with await-thenable enabled.
+// 3. Assert the command succeeds and removes the redundant await.
+func TestCommandFixTypeAwareRuleReceivesChecker(t *testing.T) {
+  root := seedLintProject(t, `async function main() {
+  const value = 1;
+  await value;
+}
+void main();
+`)
+  seedLintRules(t, root, map[string]string{"await-thenable": "error"})
+
+  code, _, stderr := captureCommandOutput(t, func() int {
+    return RunFix([]string{
+      "--cwd", root,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  if code != 0 {
+    t.Fatalf("RunFix exited %d; stderr:\n%s", code, stderr)
+  }
+
+  data, err := os.ReadFile(filepath.Join(root, "src", "main.ts"))
+  if err != nil {
+    t.Fatal(err)
+  }
+  got := string(data)
+  if strings.Contains(got, "await value") {
+    t.Fatalf("await-thenable did not apply its checker-backed fix:\n%s", got)
+  }
+  if !strings.Contains(got, "value;") {
+    t.Fatalf("fixed source did not keep the operand statement:\n%s", got)
+  }
+}

--- a/packages/lint/test/command/load_program_clamps_checker_pool_to_one_test.go
+++ b/packages/lint/test/command/load_program_clamps_checker_pool_to_one_test.go
@@ -1,0 +1,71 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+
+  shimcore "github.com/microsoft/typescript-go/shim/core"
+)
+
+// TestLoadProgramClampsCheckerPoolToOne verifies forceSingleChecker collapses a
+// multi-checker pool request down to a single checker in the lint host.
+//
+// PR #112 dropped SingleThreaded, which switched on TypeScript-Go's
+// multi-checker pool. The lint engine walks files serially and resolves types
+// through the one checker GetTypeChecker hands back, so a pool larger than one
+// lets a type whose declarations span files on different checkers resolve to
+// `any`. loadProgram must therefore clamp `Checkers` back to 1 even when
+// `--checkers N` asked for more, while leaving `--singleThreaded` untouched so
+// that path still wins.
+//
+// 1. loadProgram a multi-file project with loadProgramOptions.checkers set to 8.
+// 2. Assert the resolved CompilerOptions.Checkers is clamped to exactly 1.
+// 3. loadProgram the same project with singleThreaded and assert it still applies.
+func TestLoadProgramClampsCheckerPoolToOne(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "files": ["src/a.ts", "src/b.ts", "src/main.ts"]
+}
+`)
+  writeFile(t, filepath.Join(root, "src", "a.ts"), "export const a = 1;\n")
+  writeFile(t, filepath.Join(root, "src", "b.ts"), "export const b = 2;\n")
+  writeFile(t, filepath.Join(root, "src", "main.ts"),
+    "import { a } from \"./a\";\nimport { b } from \"./b\";\nexport const sum = a + b;\n")
+
+  pooled, diags, err := loadProgram(root, "tsconfig.json", loadProgramOptions{checkers: 8})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %#v", diags)
+  }
+  defer pooled.close()
+
+  checkers := pooled.parsed.ParsedConfig.CompilerOptions.Checkers
+  if checkers == nil {
+    t.Fatal("forceSingleChecker did not pin Checkers; it is still nil (multi-checker default)")
+  }
+  if *checkers != 1 {
+    t.Fatalf("forceSingleChecker did not clamp the pool: Checkers = %d, want 1", *checkers)
+  }
+
+  single, diags, err := loadProgram(root, "tsconfig.json", loadProgramOptions{singleThreaded: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %#v", diags)
+  }
+  defer single.close()
+
+  if single.parsed.ParsedConfig.CompilerOptions.SingleThreaded != shimcore.TSTrue {
+    t.Fatal("forceSingleChecker clobbered --singleThreaded; SingleThreaded is not set")
+  }
+}

--- a/packages/lint/test/command/load_program_clamps_checker_pool_to_one_test.go
+++ b/packages/lint/test/command/load_program_clamps_checker_pool_to_one_test.go
@@ -11,14 +11,14 @@ import (
 // multi-checker pool request down to a single checker in the lint host.
 //
 // PR #112 dropped SingleThreaded, which switched on TypeScript-Go's
-// multi-checker pool. The lint engine walks files serially and resolves types
-// through the one checker GetTypeChecker hands back, so a pool larger than one
-// lets a type whose declarations span files on different checkers resolve to
-// `any`. loadProgram must therefore clamp `Checkers` back to 1 even when
-// `--checkers N` asked for more, while leaving `--singleThreaded` untouched so
-// that path still wins.
+// multi-checker pool. Type-aware lint rules walk files serially and resolve
+// types through the one checker GetTypeChecker hands back, so a pool larger
+// than one lets a type whose declarations span files on different checkers
+// resolve to `any`. loadProgram must therefore clamp `Checkers` back to 1 for
+// type-aware rules, while leaving `--singleThreaded` untouched so that path
+// still wins.
 //
-// 1. loadProgram a multi-file project with loadProgramOptions.checkers set to 8.
+// 1. loadProgram a multi-file project with checkers=8 and needsRuleChecker.
 // 2. Assert the resolved CompilerOptions.Checkers is clamped to exactly 1.
 // 3. loadProgram the same project with singleThreaded and assert it still applies.
 func TestLoadProgramClampsCheckerPoolToOne(t *testing.T) {
@@ -39,7 +39,10 @@ func TestLoadProgramClampsCheckerPoolToOne(t *testing.T) {
   writeFile(t, filepath.Join(root, "src", "main.ts"),
     "import { a } from \"./a\";\nimport { b } from \"./b\";\nexport const sum = a + b;\n")
 
-  pooled, diags, err := loadProgram(root, "tsconfig.json", loadProgramOptions{checkers: 8})
+  pooled, diags, err := loadProgram(root, "tsconfig.json", loadProgramOptions{
+    checkers:         8,
+    needsRuleChecker: true,
+  })
   if err != nil {
     t.Fatal(err)
   }
@@ -56,7 +59,10 @@ func TestLoadProgramClampsCheckerPoolToOne(t *testing.T) {
     t.Fatalf("forceSingleChecker did not clamp the pool: Checkers = %d, want 1", *checkers)
   }
 
-  single, diags, err := loadProgram(root, "tsconfig.json", loadProgramOptions{singleThreaded: true})
+  single, diags, err := loadProgram(root, "tsconfig.json", loadProgramOptions{
+    singleThreaded:   true,
+    needsRuleChecker: true,
+  })
   if err != nil {
     t.Fatal(err)
   }

--- a/packages/lint/test/command/load_program_leaves_checker_pool_for_ast_only_rules_test.go
+++ b/packages/lint/test/command/load_program_leaves_checker_pool_for_ast_only_rules_test.go
@@ -1,0 +1,58 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestLoadProgramLeavesCheckerPoolForAstOnlyRules verifies AST-only lint does
+// not pin TypeScript-Go's checker pool.
+//
+// Vue and type-fest benchmark configs enable only AST rules. Clamping their
+// programs to one checker serializes semantic diagnostics even though no rule
+// receives Context.Checker, so loadProgram should preserve the requested
+// checker count until a type-aware rule asks for the checker.
+//
+// 1. Materialize a tiny TypeScript project.
+// 2. loadProgram with checkers=8 and needsRuleChecker=false.
+// 3. Assert Checkers remains 8 and no rule checker was acquired.
+func TestLoadProgramLeavesCheckerPoolForAstOnlyRules(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "files": ["src/main.ts"]
+}
+`)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), "export const value = 1;\n")
+
+  prog, diags, err := loadProgram(root, "tsconfig.json", loadProgramOptions{
+    checkers: 8,
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %#v", diags)
+  }
+  defer prog.close()
+
+  checkers := prog.parsed.ParsedConfig.CompilerOptions.Checkers
+  if checkers == nil {
+    t.Fatal("Checkers is nil; expected the requested checker count to remain visible")
+  }
+  if *checkers != 8 {
+    t.Fatalf("Checkers = %d, want 8", *checkers)
+  }
+  if prog.checker != nil {
+    t.Fatal("AST-only load acquired a rule checker")
+  }
+  if prog.releaseChecker != nil {
+    t.Fatal("AST-only load installed a checker release callback")
+  }
+}

--- a/packages/lint/test/engine/engine_detects_files_without_enabled_rules_test.go
+++ b/packages/lint/test/engine/engine_detects_files_without_enabled_rules_test.go
@@ -1,0 +1,34 @@
+package linthost
+
+import "testing"
+
+// TestEngineDetectsFilesWithoutEnabledRules verifies file-level rule maps with
+// no active severities are treated as empty.
+//
+// Glob-scoped lint configs can include files through tsconfig while applying no
+// rules to those files. The engine uses this predicate before walking the AST,
+// so off-only maps must behave the same as omitted rules and non-off severities
+// must keep the file eligible for rule dispatch.
+//
+// 1. Check nil, empty, and off-only rule maps.
+// 2. Check warning and error maps.
+// 3. Assert only warning and error maps are considered enabled.
+func TestEngineDetectsFilesWithoutEnabledRules(t *testing.T) {
+	cases := []struct {
+		name  string
+		rules RuleConfig
+		want  bool
+	}{
+		{name: "nil", rules: nil, want: false},
+		{name: "empty", rules: RuleConfig{}, want: false},
+		{name: "off", rules: RuleConfig{"no-var": SeverityOff}, want: false},
+		{name: "warning", rules: RuleConfig{"no-var": SeverityWarn}, want: true},
+		{name: "error", rules: RuleConfig{"no-var": SeverityError}, want: true},
+	}
+
+	for _, tt := range cases {
+		if got := hasEnabledFileRules(tt.rules); got != tt.want {
+			t.Fatalf("%s: want %v, got %v", tt.name, tt.want, got)
+		}
+	}
+}

--- a/packages/lint/test/engine/engine_requires_type_checker_for_type_aware_rule_test.go
+++ b/packages/lint/test/engine/engine_requires_type_checker_for_type_aware_rule_test.go
@@ -1,0 +1,20 @@
+package linthost
+
+import "testing"
+
+// TestEngineRequiresTypeCheckerForTypeAwareRule verifies type-aware built-ins
+// keep the historical single-checker path.
+//
+// await-thenable calls ctx.Checker.GetTypeAtLocation. Running that rule without
+// a checker would silently drop diagnostics, while running it against a
+// multi-checker program can resolve cross-file types through the wrong checker.
+//
+// 1. Build an engine with await-thenable enabled.
+// 2. Ask whether the engine needs a type checker.
+// 3. Assert the answer is true.
+func TestEngineRequiresTypeCheckerForTypeAwareRule(t *testing.T) {
+  engine := NewEngine(RuleConfig{"await-thenable": SeverityError})
+  if !engine.NeedsTypeChecker() {
+    t.Fatal("await-thenable did not request a type checker")
+  }
+}

--- a/packages/lint/test/engine/engine_skips_type_checker_for_ast_only_rule_test.go
+++ b/packages/lint/test/engine/engine_skips_type_checker_for_ast_only_rule_test.go
@@ -1,0 +1,21 @@
+package linthost
+
+import "testing"
+
+// TestEngineSkipsTypeCheckerForAstOnlyRule verifies AST-only built-ins do not
+// request Context.Checker.
+//
+// The checker gate is computed from the active rule set before Program
+// creation. A common Vue/type-fest rule such as no-var must therefore keep the
+// engine on the AST-only path, otherwise those projects still pay the old
+// single-checker cost.
+//
+// 1. Build an engine with only no-var enabled.
+// 2. Ask whether the engine needs a type checker.
+// 3. Assert the answer is false.
+func TestEngineSkipsTypeCheckerForAstOnlyRule(t *testing.T) {
+  engine := NewEngine(RuleConfig{"no-var": SeverityError})
+  if engine.NeedsTypeChecker() {
+    t.Fatal("no-var unexpectedly requested a type checker")
+  }
+}

--- a/packages/lint/test/fix/fix_prefer_const_skips_destructuring_assignment_targets_test.go
+++ b/packages/lint/test/fix/fix_prefer_const_skips_destructuring_assignment_targets_test.go
@@ -1,0 +1,39 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferConstSkipsDestructuringAssignmentTargets verifies prefer-const
+// does not flag a `let` reassigned through a destructuring-assignment target.
+//
+// The reassignment scan used to count only simple `=`, compound-assignment,
+// and `++`/`--` writes; a destructuring-assignment left-hand side parses as an
+// ArrayLiteralExpression / ObjectLiteralExpression, not a binding pattern, so
+// its identifiers were never marked reassigned. prefer-const then flagged the
+// binding and `ttsc fix` rewrote it to `const`, producing code that fails to
+// compile (TS2588). `assignmentTargetNames` now walks those patterns —
+// elements, property values, nested patterns, defaults, and rest — so the
+// binding is correctly left as `let`.
+//
+//  1. Parse `let` bindings reassigned only via array, object, and nested
+//     destructuring-assignment patterns.
+//  2. Run prefer-const through the disk-backed fixer.
+//  3. Assert the rule reports nothing and the source is left unchanged.
+func TestFixPreferConstSkipsDestructuringAssignmentTargets(t *testing.T) {
+  assertRuleSkipsSource(
+    t,
+    "prefer-const",
+    "let x = 1;\n"+
+      "let y = 2;\n"+
+      "[x, y] = [y, x];\n"+
+      "let a = 1;\n"+
+      "const obj = { a: 9 };\n"+
+      "({ a } = obj);\n"+
+      "let head = 0;\n"+
+      "let rest: number[] = [];\n"+
+      "[head, ...rest] = [1, 2, 3];\n"+
+      "let nested = 0;\n"+
+      "let withDefault = 0;\n"+
+      "[[nested], { withDefault = 7 }] = [[5], {}];\n"+
+      "JSON.stringify([x, y, a, head, rest, nested, withDefault]);\n",
+  )
+}

--- a/packages/lint/test/plugin/engine_requires_type_checker_for_contributor_rule_test.go
+++ b/packages/lint/test/plugin/engine_requires_type_checker_for_contributor_rule_test.go
@@ -1,0 +1,34 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestEngineRequiresTypeCheckerForContributorRule verifies contributor rules
+// stay on the conservative checker path.
+//
+// The public rule.Context exposes Checker and contributors have no mandatory
+// AST-only marker. Treating them as checker-free would be a correctness risk
+// for third-party rules that already read ctx.Checker.
+//
+// 1. Wrap a synthetic public contributor rule in contributorAdapter.
+// 2. Ask the internal checker gate about that wrapped rule.
+// 3. Assert the rule is treated as type-aware.
+func TestEngineRequiresTypeCheckerForContributorRule(t *testing.T) {
+  adapter := contributorAdapter{inner: contributorCheckerGateRule{}}
+  if !ruleNeedsTypeChecker(adapter) {
+    t.Fatal("contributor adapter did not request a type checker")
+  }
+}
+
+type contributorCheckerGateRule struct{}
+
+func (contributorCheckerGateRule) Name() string { return "demo/checker-gate" }
+func (contributorCheckerGateRule) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindSourceFile}
+}
+func (contributorCheckerGateRule) Check(*publicrule.Context, *shimast.Node) {}

--- a/packages/lint/test/rules/variables-assignments/prefer_const_test.go
+++ b/packages/lint/test/rules/variables-assignments/prefer_const_test.go
@@ -16,5 +16,5 @@ import "testing"
 // 2. Enable the rule severities declared by its // expect: comments.
 // 3. Assert the native Engine reports exactly the annotated diagnostics.
 func TestRuleCorpusPreferConst(t *testing.T) {
-  assertRuleCorpusCase(t, "prefer-const.ts", "// expect: prefer-const error\nlet stable = 1;\nlet changing = 1;\nchanging = 2;\n\nfor (let i = 0; i < 2; i++) {\n  JSON.stringify(i);\n}\n\n// expect: prefer-const error\nfor (let item of [1, 2]) {\n  JSON.stringify(item);\n}\n\nJSON.stringify([stable, changing]);\n")
+  assertRuleCorpusCase(t, "prefer-const.ts", "// expect: prefer-const error\nlet stable = 1;\nlet changing = 1;\nchanging = 2;\n\nfor (let i = 0; i < 2; i++) {\n  JSON.stringify(i);\n}\n\n// expect: prefer-const error\nfor (let item of [1, 2]) {\n  JSON.stringify(item);\n}\n\n// Destructuring-assignment targets reassign their identifiers, so neither\n// `swapLeft` nor `swapRight` is const-able and must stay unflagged.\nlet swapLeft = 1;\nlet swapRight = 2;\n[swapLeft, swapRight] = [swapRight, swapLeft];\n\n// Object-destructuring assignment reassigns `picked` through a property value.\nlet picked = 0;\n({ picked } = { picked: 9 });\n\nJSON.stringify([stable, changing, swapLeft, swapRight, picked]);\n")
 }

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -273,18 +273,25 @@ func parseTsgoArgs(args []string, host shimcompiler.CompilerHost) (*core.Compile
 
 // CreateProgramFromConfig builds a tsgo Program from the parsed config.
 //
-// SingleThreaded is intentionally left unset so the program falls back to
-// TypeScript-Go's multi-threaded default: parallel source parsing, a pooled
-// checker (parallel bind + semantic diagnostics), and parallel emit. The
-// phases ttsc layers on top — plugin application and the output rewriter —
-// still run serially against a single pooled checker, which stays valid
-// against the larger pool. Concurrency surfaces only inside each
-// TypeScript-Go phase; both EmitAll and EmitAllRaw serialize the WriteFile
-// callback under a mutex so the emit-stage rewriter never observes the pool.
+// SingleThreaded is intentionally left unset so the program keeps
+// TypeScript-Go's parallel source parsing and parallel emit. The checker
+// pool, however, is pinned to a single checker (see forceSingleChecker):
+// every phase ttsc layers on top — plugin transforms and the output
+// rewriter — walks the program serially against the one checker returned by
+// Program.GetTypeChecker, and then asks that checker to resolve types in
+// nodes drawn from *every* source file. TypeScript-Go's multi-checker pool
+// affinitizes each file to a different checker and forbids mixing types
+// across them; a circular type whose declarations span files on different
+// checkers resolves to `any` on the borrowed checker. Pinning the pool to
+// one checker keeps prog.Checker consistent with how every file was checked
+// while leaving parse and emit parallel. Both EmitAll and EmitAllRaw
+// serialize the WriteFile callback under a mutex so the emit-stage rewriter
+// never observes the parallel emit either.
 func CreateProgramFromConfig(parsed *tsoptions.ParsedCommandLine, host shimcompiler.CompilerHost) (*shimcompiler.Program, []Diagnostic, error) {
   if parsed == nil {
     return nil, nil, fmt.Errorf("driver: nil parsed command line")
   }
+  forceSingleChecker(parsed)
   opts := shimcompiler.ProgramOptions{
     Config:                      parsed,
     Host:                        host,
@@ -292,6 +299,24 @@ func CreateProgramFromConfig(parsed *tsoptions.ParsedCommandLine, host shimcompi
   }
   p := shimcompiler.NewProgram(opts)
   return p, nil, nil
+}
+
+// forceSingleChecker pins the TypeScript-Go checker pool to a single checker.
+//
+// ttsc's transform and rewrite phases run serially and obtain types through
+// the single checker that Program.GetTypeChecker hands back. Those phases
+// query types on nodes from arbitrary source files, so the checker must be
+// the same one that checked every file. A pool of size > 1 affinitizes files
+// to distinct checkers; resolving a type whose declarations cross that
+// boundary (e.g. a circular indexed-access alias) yields `any`. Parallel
+// parsing and emit are unaffected — they do not consult the checker count.
+func forceSingleChecker(parsed *tsoptions.ParsedCommandLine) {
+  options := parsed.ParsedConfig.CompilerOptions
+  if options.SingleThreaded == core.TSTrue {
+    return
+  }
+  one := 1
+  options.Checkers = &one
 }
 
 // LoadProgram is the one-shot convenience used by `ttsc`.
@@ -393,6 +418,11 @@ func overrideOutDir(cwd string, parsed *tsoptions.ParsedCommandLine, outDir stri
 // pool read them from there — ProgramOptions is left untouched, exactly as
 // tsgo's own CLI does. SingleThreaded wins over Checkers, matching the pool's
 // own precedence.
+//
+// Note that CreateProgramFromConfig calls forceSingleChecker afterwards, so a
+// `--checkers N` greater than 1 is recorded here but then clamped back to a
+// single checker: ttsc's serial transform/rewrite phases require one checker
+// (see forceSingleChecker). `--singleThreaded` still takes full effect.
 func applyThreadingOptions(parsed *tsoptions.ParsedCommandLine, singleThreaded bool, checkers int) {
   options := parsed.ParsedConfig.CompilerOptions
   if singleThreaded {

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -279,7 +279,8 @@ func parseTsgoArgs(args []string, host shimcompiler.CompilerHost) (*core.Compile
 // phases ttsc layers on top — plugin application and the output rewriter —
 // still run serially against a single pooled checker, which stays valid
 // against the larger pool. Concurrency surfaces only inside each
-// TypeScript-Go phase; see EmitAll for the WriteFile-callback consequence.
+// TypeScript-Go phase; both EmitAll and EmitAllRaw serialize the WriteFile
+// callback under a mutex so the emit-stage rewriter never observes the pool.
 func CreateProgramFromConfig(parsed *tsoptions.ParsedCommandLine, host shimcompiler.CompilerHost) (*shimcompiler.Program, []Diagnostic, error) {
   if parsed == nil {
     return nil, nil, fmt.Errorf("driver: nil parsed command line")

--- a/packages/ttsc/driver/rewrite.go
+++ b/packages/ttsc/driver/rewrite.go
@@ -83,10 +83,14 @@ func (p *Program) EmitAll(rs *RewriteSet, writeFile shimcompiler.WriteFile) (*sh
 
 // EmitAllRaw runs TypeScript-Go emit without ttsc output-text rewrites.
 //
-// Unlike EmitAll, `writeFile` is handed straight to TypeScript-Go's parallel
-// emitter, so it MUST be safe to invoke concurrently: writing distinct files
-// (the default disk writer, the source-preamble writer) is fine; a callback
-// that mutates shared state must guard it.
+// `writeFile` does not need to be concurrency-safe: like EmitAll, EmitAllRaw
+// funnels every invocation through one mutex, so the callback never runs on
+// two goroutines at once even though TypeScript-Go emits files in parallel.
+// This is the contract a plugin's output rewriter relies on — it is the
+// emit-stage phase ttsc guarantees runs single-threaded (a plugin's WriteFile
+// is the standard place to carry per-file cursors or an output map), so ttsc
+// owns the serialization rather than pushing goroutine-safety onto every
+// plugin author. See the emit-concurrency contract in the plugin docs.
 func (p *Program) EmitAllRaw(writeFile shimcompiler.WriteFile) (*shimcompiler.EmitResult, []Diagnostic, error) {
   if p == nil || p.TSProgram == nil {
     return nil, nil, errors.New("driver: nil program")
@@ -94,11 +98,22 @@ func (p *Program) EmitAllRaw(writeFile shimcompiler.WriteFile) (*shimcompiler.Em
   if err := p.ApplyLinkedPlugins(); err != nil {
     return nil, nil, err
   }
-  wf := writeFile
-  if wf == nil {
-    wf = func(fileName, text string, data *shimcompiler.WriteFileData) error {
-      return DefaultWriteFile(fileName, text)
+  // TypeScript-Go's parallel emit invokes WriteFile once per emitted file,
+  // concurrently — one goroutine per source file. Serialize the whole callback
+  // under wfMu so a plugin's output rewriter sees one writer at a time: a
+  // callback that mutates shared state (e.g. @nestia/core's per-file rewrite
+  // cursors and runtime-alias cache) would otherwise trip `fatal error:
+  // concurrent map read and map write`. The callback is cheap I/O, so
+  // serializing it costs ~nothing while parse/check/emit-text still parallelize
+  // — the same trade EmitAll makes for its own WriteFile.
+  var wfMu sync.Mutex
+  wf := func(fileName, text string, data *shimcompiler.WriteFileData) error {
+    wfMu.Lock()
+    defer wfMu.Unlock()
+    if writeFile != nil {
+      return writeFile(fileName, text, data)
     }
+    return DefaultWriteFile(fileName, text)
   }
   result := p.TSProgram.Emit(context.Background(), shimcompiler.EmitOptions{
     WriteFile: wf,

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -19,6 +19,11 @@ import {
 } from "./sharedHostHelpers";
 import { outputText, spawnNative } from "./spawnNative";
 
+type RunBuildOptions = TtscBuildOptions & {
+  skipDiagnosticsCheck?: boolean;
+  forceListEmittedFiles?: boolean;
+};
+
 /**
  * Merge extra environment variables over `process.env`, always injecting
  * `TTSC_NODE_BINARY` so child processes can re-invoke the same Node.js binary
@@ -64,12 +69,7 @@ function nativePluginEnv(
  * Run `ttsc` against a tsconfig. Returns once the binary exits so the CLI can
  * decide how to surface diagnostics. Does not throw on non-zero exit.
  */
-export function runBuild(
-  options: TtscBuildOptions & {
-    skipDiagnosticsCheck?: boolean;
-    forceListEmittedFiles?: boolean;
-  } = {},
-): TtscBuildResult {
+export function runBuild(options: RunBuildOptions = {}): TtscBuildResult {
   const execution = resolveExecutionContext(options);
   const buildOptions = applyProjectNoEmit(options, execution);
   if (execution.nativePlugins.length > 0) {
@@ -170,10 +170,10 @@ export function runBuild(
  * before composing tsgo/native-host arguments so ttsc does not add emit-only
  * guards around projects that cannot emit.
  */
-function applyProjectNoEmit<T extends TtscBuildOptions>(
-  options: T,
+function applyProjectNoEmit(
+  options: RunBuildOptions,
   execution: ReturnType<typeof resolveExecutionContext>,
-): T {
+): RunBuildOptions {
   if (options.emit !== undefined || execution.projectNoEmit !== true) {
     return options;
   }
@@ -235,7 +235,7 @@ function buildWithNativeCompilerPlugins(
 function runTsgo(
   execution: ReturnType<typeof resolveExecutionContext>,
   extraArgs: readonly string[],
-  options: NonNullable<Parameters<typeof runBuild>[0]>,
+  options: RunBuildOptions,
 ): TtscBuildResult {
   const res = spawnNative(
     execution.tsgo.binary,
@@ -278,7 +278,7 @@ function runTsgo(
  */
 function runTsgoBuild(
   execution: ReturnType<typeof resolveExecutionContext>,
-  options: NonNullable<Parameters<typeof runBuild>[0]>,
+  options: RunBuildOptions,
   args: readonly string[],
 ): TtscBuildResult {
   const res = spawnNative(execution.tsgo.binary, args, {
@@ -318,7 +318,7 @@ function runTsgoBuild(
 /** Build the argument list for a direct `tsgo` build invocation. */
 function createTsgoBuildArgs(
   execution: ReturnType<typeof resolveExecutionContext>,
-  options: NonNullable<Parameters<typeof runBuild>[0]>,
+  options: RunBuildOptions,
   flags: { listEmittedFiles: boolean; noEmitOnError?: boolean },
 ): string[] {
   const args = ["-p", execution.tsconfig];

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -369,16 +369,19 @@ function createNativeBuildArgs(
   ];
   if (options.emit === true) {
     args.push("--emit");
-  } else if (options.emit === false) {
-    args.push("--noEmit");
   }
   if (options.outDir) {
     args.push("--outDir=" + path.resolve(execution.cwd, options.outDir));
   }
-  if (options.quiet === false) {
-    args.push("--verbose");
-  } else if (options.quiet === true) {
-    args.push("--quiet");
+  // Third-party transform hosts already treat the `check` subcommand as a
+  // quiet no-emit pass. Keep ttsc-owned build modifiers off that lane so older
+  // strict hosts do not reject unknown optional flags before analysis starts.
+  if (options.emit !== false) {
+    if (options.quiet === false) {
+      args.push("--verbose");
+    } else if (options.quiet === true) {
+      args.push("--quiet");
+    }
   }
   args.push(...createNativeTsgoArgs(options));
   return args;

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -104,6 +104,9 @@ export function runBuild(options: RunBuildOptions = {}): TtscBuildResult {
           buildWithNativeCompilerPlugins(buildOptions, execution, compilers),
         );
       }
+      if (checkPluginsReportTypeScriptDiagnostics(execution.nativePlugins)) {
+        return checked;
+      }
       return appendBuildOutput(
         checked,
         runTsgo(execution, ["--noEmit"], buildOptions),
@@ -120,6 +123,7 @@ export function runBuild(options: RunBuildOptions = {}): TtscBuildResult {
     } else {
       if (
         buildOptions.skipDiagnosticsCheck !== true &&
+        !checkPluginsReportTypeScriptDiagnostics(execution.nativePlugins) &&
         !forwardsTerminalTsgoFlag(buildOptions)
       ) {
         const tsgoChecked = runTsgo(execution, ["--noEmit"], buildOptions);
@@ -178,6 +182,16 @@ function applyProjectNoEmit(
     return options;
   }
   return { ...options, emit: false };
+}
+
+function checkPluginsReportTypeScriptDiagnostics(
+  plugins: readonly ITtscLoadedNativePlugin[],
+): boolean {
+  return plugins.some(
+    (plugin) =>
+      plugin.stage === "check" &&
+      plugin.reportsTypeScriptDiagnostics === true,
+  );
 }
 
 /**

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -380,7 +380,6 @@ function createNativeBuildArgs(
   } else if (options.quiet === true) {
     args.push("--quiet");
   }
-  args.push(...createNativeThreadingArgs(options));
   args.push(...createNativeTsgoArgs(options));
   return args;
 }
@@ -404,27 +403,26 @@ function createNativeCheckArgs(
   } else if (options.quiet === true) {
     args.push("--quiet");
   }
-  args.push(...createNativeThreadingArgs(options));
   args.push(...createNativeTsgoArgs(options));
   return args;
 }
 
-/**
- * Forward the `--singleThreaded` / `--checkers` knobs to a native sidecar
- * (`@ttsc/lint`, transform plugins). Their Go flag sets accept the same two
- * flags, which `driver.LoadProgram` maps onto `CompilerOptions` so the in-
- * process program matches what `tsgo` would do on the no-plugin lane.
- */
-function createNativeThreadingArgs(options: TtscCommonOptions): string[] {
-  const args: string[] = [];
-  if (options.singleThreaded === true) {
-    args.push("--singleThreaded");
-  }
-  if (options.checkers !== undefined) {
-    args.push("--checkers=" + String(options.checkers));
-  }
-  return args;
-}
+// `--singleThreaded` / `--checkers` are intentionally NOT forwarded to native
+// plugin hosts.
+//
+// They were forwarded as bare CLI flags in #113, but a native host built
+// before that release has no `singleThreaded`/`checkers` flag in its
+// `flag.FlagSet`, and a host that parses with `flag.ContinueOnError` exits 2
+// on the unknown flag instead of ignoring it — `ttsc --singleThreaded` then
+// fails deterministically on any project with a third-party transform plugin
+// (typia, nestia). The plugin protocol only promises that new optional flags
+// are *accept-and-ignored* by hosts that adopted `filterHostArgs`; ttsc cannot
+// know whether the host it is about to spawn did, so it must not emit a flag
+// whose rejection is fatal. The threading knobs still take full effect on the
+// no-plugin `tsgo` lane (`createTsgoThreadingArgs`), and `CreateProgramFromConfig`
+// already pins every native-host program to a single checker via
+// `forceSingleChecker`, so the in-process determinism `--singleThreaded`
+// targets is preserved on the plugin lane regardless.
 
 /**
  * Forward the tsgo flags ttsc did not recognize to a native sidecar as one

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -71,17 +71,18 @@ export function runBuild(
   } = {},
 ): TtscBuildResult {
   const execution = resolveExecutionContext(options);
+  const buildOptions = applyProjectNoEmit(options, execution);
   if (execution.nativePlugins.length > 0) {
     const compilers = execution.nativePlugins.filter(
       (plugin) => plugin.stage === "transform",
     );
-    const checked = runNativeCheckPlugins(options, execution);
+    const checked = runNativeCheckPlugins(buildOptions, execution);
     if (checked.status !== 0) {
       return checked;
     }
 
-    if (options.emit === false) {
-      if (options.format === true) {
+    if (buildOptions.emit === false) {
+      if (buildOptions.format === true) {
         // Format mode is write-only by contract: the lint sidecar
         // already rewrote source files and reported nothing. Running
         // tsgo --noEmit OR a transform compiler afterwards would either
@@ -100,12 +101,12 @@ export function runBuild(
         assertSharedHostCompatibility(compilers, "emit");
         return appendBuildOutput(
           checked,
-          buildWithNativeCompilerPlugins(options, execution, compilers),
+          buildWithNativeCompilerPlugins(buildOptions, execution, compilers),
         );
       }
       return appendBuildOutput(
         checked,
-        runTsgo(execution, ["--noEmit"], options),
+        runTsgo(execution, ["--noEmit"], buildOptions),
       );
     }
 
@@ -114,29 +115,29 @@ export function runBuild(
       assertSharedHostCompatibility(compilers, "emit");
       result = appendBuildOutput(
         checked,
-        buildWithNativeCompilerPlugins(options, execution, compilers),
+        buildWithNativeCompilerPlugins(buildOptions, execution, compilers),
       );
     } else {
       if (
-        options.skipDiagnosticsCheck !== true &&
-        !forwardsTerminalTsgoFlag(options)
+        buildOptions.skipDiagnosticsCheck !== true &&
+        !forwardsTerminalTsgoFlag(buildOptions)
       ) {
-        const tsgoChecked = runTsgo(execution, ["--noEmit"], options);
+        const tsgoChecked = runTsgo(execution, ["--noEmit"], buildOptions);
         if (tsgoChecked.status !== 0) {
           return appendBuildOutput(checked, tsgoChecked);
         }
       }
-      const args = createTsgoBuildArgs(execution, options, {
-        listEmittedFiles: options.forceListEmittedFiles === true,
+      const args = createTsgoBuildArgs(execution, buildOptions, {
+        listEmittedFiles: buildOptions.forceListEmittedFiles === true,
       });
-      const emitted = runTsgoBuild(execution, options, args);
+      const emitted = runTsgoBuild(execution, buildOptions, args);
       result = appendBuildOutput(checked, emitted);
     }
 
     return result;
   }
 
-  if (options.format === true) {
+  if (buildOptions.format === true) {
     // Format mode is write-only by contract — see the matching
     // short-circuit in the with-native-plugins branch above. When no
     // native plugin is loaded there is nothing for `ttsc format` to
@@ -151,15 +152,32 @@ export function runBuild(
     };
   }
 
-  const args = createTsgoBuildArgs(execution, options, {
+  const args = createTsgoBuildArgs(execution, buildOptions, {
     listEmittedFiles:
-      options.emit !== false && options.forceListEmittedFiles === true,
+      buildOptions.emit !== false &&
+      buildOptions.forceListEmittedFiles === true,
     noEmitOnError:
-      options.emit !== false &&
-      options.skipDiagnosticsCheck !== true &&
-      !forwardsTerminalTsgoFlag(options),
+      buildOptions.emit !== false &&
+      buildOptions.skipDiagnosticsCheck !== true &&
+      !forwardsTerminalTsgoFlag(buildOptions),
   });
-  return runTsgoBuild(execution, options, args);
+  return runTsgoBuild(execution, buildOptions, args);
+}
+
+/**
+ * A tsconfig-level `noEmit: true` is an analysis-only build unless the user
+ * explicitly asks `ttsc --emit` to override it. Treat it like CLI `--noEmit`
+ * before composing tsgo/native-host arguments so ttsc does not add emit-only
+ * guards around projects that cannot emit.
+ */
+function applyProjectNoEmit<T extends TtscBuildOptions>(
+  options: T,
+  execution: ReturnType<typeof resolveExecutionContext>,
+): T {
+  if (options.emit !== undefined || execution.projectNoEmit !== true) {
+    return options;
+  }
+  return { ...options, emit: false };
 }
 
 /**
@@ -584,6 +602,7 @@ function resolveExecutionContext(
   return {
     cwd,
     nativePlugins: loaded.nativePlugins,
+    projectNoEmit: project.compilerOptions.noEmit === true,
     projectRoot,
     rewriteRelativeImportExtensionsForEmit:
       options.emit === true &&

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -1,13 +1,15 @@
 import path from "node:path";
 
-import { loadProjectPlugins } from "../../plugin/internal/loadProjectPlugins";
+import {
+  hasProjectPluginEntries,
+  loadProjectPlugins,
+} from "../../plugin/internal/loadProjectPlugins";
 import type { ITtscCompilerDiagnostic } from "../../structures/ITtscCompilerDiagnostic";
 import type { ITtscLoadedNativePlugin } from "../../structures/internal/ITtscLoadedNativePlugin";
 import type { TtscBuildOptions } from "../../structures/internal/TtscBuildOptions";
 import type { TtscBuildResult } from "../../structures/internal/TtscBuildResult";
 import type { TtscCommonOptions } from "../../structures/internal/TtscCommonOptions";
 import { readProjectConfig } from "./project/readProjectConfig";
-import { resolveProjectConfig } from "./project/resolveProjectConfig";
 import { resolveBinary } from "./resolveBinary";
 import { resolveTsgo } from "./resolveTsgo";
 import {
@@ -149,30 +151,22 @@ export function runBuild(
     };
   }
 
-  if (
-    options.emit !== false &&
-    options.skipDiagnosticsCheck !== true &&
-    !forwardsTerminalTsgoFlag(options)
-  ) {
-    const checked = runTsgo(execution, ["--noEmit"], options);
-    if (checked.status !== 0) {
-      return checked;
-    }
-  }
-
   const args = createTsgoBuildArgs(execution, options, {
     listEmittedFiles:
       options.emit !== false && options.forceListEmittedFiles === true,
+    noEmitOnError:
+      options.emit !== false &&
+      options.skipDiagnosticsCheck !== true &&
+      !forwardsTerminalTsgoFlag(options),
   });
   return runTsgoBuild(execution, options, args);
 }
 
 /**
  * Tsgo CLI flags that make `tsgo` print something and exit instead of building
- * (`--showConfig`, `--listFilesOnly`, `--help`, …). ttsc normally runs a
- * `--noEmit` type-check pass before the emit pass; when one of these is
- * forwarded, both passes would run `tsgo` and the output would print twice, so
- * the pre-check is skipped and only one `tsgo` invocation remains.
+ * (`--showConfig`, `--listFilesOnly`, `--help`, …). ttsc must not add
+ * build-only guard flags around these because the forwarded flag asks tsgo to
+ * print something and exit instead of compiling the project.
  */
 const TERMINAL_TSGO_FLAGS: ReadonlySet<string> = new Set([
   "--help",
@@ -187,8 +181,8 @@ const TERMINAL_TSGO_FLAGS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Report whether the caller forwarded a print-and-exit tsgo flag, so the
- * pre-emit type-check pass can be skipped to avoid running it twice.
+ * Report whether the caller forwarded a print-and-exit tsgo flag, so ttsc can
+ * avoid adding compile-only flags to a command that is not going to compile.
  */
 function forwardsTerminalTsgoFlag(options: TtscCommonOptions): boolean {
   return (
@@ -307,7 +301,7 @@ function runTsgoBuild(
 function createTsgoBuildArgs(
   execution: ReturnType<typeof resolveExecutionContext>,
   options: NonNullable<Parameters<typeof runBuild>[0]>,
-  flags: { listEmittedFiles: boolean },
+  flags: { listEmittedFiles: boolean; noEmitOnError?: boolean },
 ): string[] {
   const args = ["-p", execution.tsconfig];
   if (options.emit === true) {
@@ -327,6 +321,9 @@ function createTsgoBuildArgs(
   args.push(...createTsgoDiagnosticArgs(options));
   args.push(...createTsgoThreadingArgs(options));
   args.push(...(options.passthrough ?? []));
+  if (flags.noEmitOnError === true) {
+    args.push("--noEmitOnError");
+  }
   return args;
 }
 
@@ -565,41 +562,32 @@ function resolveExecutionContext(
   options: TtscCommonOptions & { emit?: boolean; tsconfig?: string },
 ) {
   const cwd = path.resolve(options.cwd ?? process.cwd());
-  const tsconfig = resolveProjectConfig({
+  const project = readProjectConfig({
     cwd,
+    projectRoot: options.projectRoot,
     tsconfig: options.tsconfig,
   });
-  const projectRoot = options.projectRoot
-    ? path.resolve(cwd, options.projectRoot)
-    : path.dirname(tsconfig);
-  let emitProject;
-  if (options.emit === true) {
-    try {
-      emitProject = readProjectConfig({
-        cwd,
-        projectRoot: options.projectRoot,
-        tsconfig,
-      });
-    } catch {
-      emitProject = undefined;
-    }
-  }
+  const tsconfig = project.path;
+  const projectRoot = project.root;
   const tsgo = resolveTsgo({ ...options, cwd: projectRoot });
-  const fallbackBinary = resolveBinary(options);
-  const loaded = loadProjectPlugins({
-    binary: fallbackBinary ?? "",
-    cacheDir: options.cacheDir ?? options.env?.TTSC_CACHE_DIR,
-    cwd,
-    entries: options.plugins,
-    projectRoot,
-    tsconfig,
-  });
+  const hasPlugins = hasProjectPluginEntries(project, options.plugins);
+  const loaded = hasPlugins
+    ? loadProjectPlugins({
+        binary: resolveBinary(options) ?? "",
+        cacheDir: options.cacheDir ?? options.env?.TTSC_CACHE_DIR,
+        cwd,
+        entries: options.plugins,
+        projectRoot,
+        tsconfig,
+      })
+    : { nativePlugins: [] };
   return {
     cwd,
     nativePlugins: loaded.nativePlugins,
     projectRoot,
     rewriteRelativeImportExtensionsForEmit:
-      emitProject?.compilerOptions.allowImportingTsExtensions === true,
+      options.emit === true &&
+      project.compilerOptions.allowImportingTsExtensions === true,
     tsgo,
     tsconfig,
   };

--- a/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
+++ b/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
@@ -126,6 +126,8 @@ export function loadProjectPlugins(options: {
       label: pluginLabel(plugin, entries[index]!.config, index),
       linkedContributorName,
       name: plugin.name,
+      reportsTypeScriptDiagnostics:
+        plugin.reportsTypeScriptDiagnostics === true,
       source,
       stage,
     };
@@ -200,6 +202,7 @@ export function loadProjectPlugins(options: {
       contributors: record.contributors,
       kind: record.kind,
       name: record.name,
+      reportsTypeScriptDiagnostics: record.reportsTypeScriptDiagnostics,
       source: record.source,
       stage: record.stage,
     };

--- a/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
+++ b/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
@@ -545,38 +545,72 @@ function loadPluginEntry(
   context: ITtscPluginFactoryContext,
   baseDir: string,
 ): ITtscPlugin {
-  const specifier = entry.transform;
-  if (typeof specifier !== "string" || specifier.length === 0) {
-    throw new Error(`ttsc: plugin entry is missing a string "transform" field`);
-  }
-
-  const request = resolvePluginRequest(specifier, baseDir);
-  const mod = require(request) as {
-    createTtscPlugin?: TtscPluginFactory;
-    default?: ITtscPlugin | TtscPluginFactory;
-  } & Partial<Record<"plugin", ITtscPlugin | TtscPluginFactory>>;
-  const candidate =
-    mod.createTtscPlugin ??
-    mod.default ??
-    mod.plugin ??
-    (mod as unknown as ITtscPlugin | TtscPluginFactory);
-  if (typeof candidate === "function") {
-    const plugin = candidate(context);
-    if (!isTtscPlugin(plugin)) {
+  return withPluginLoaderEnv(() => {
+    const specifier = entry.transform;
+    if (typeof specifier !== "string" || specifier.length === 0) {
       throw new Error(
-        `ttsc: plugin "${specifier}" does not export a valid ttsc plugin`,
+        `ttsc: plugin entry is missing a string "transform" field`,
       );
     }
-    rejectJsTransformFunctions(specifier, plugin);
-    return plugin;
-  }
-  if (isTtscPlugin(candidate)) {
-    rejectJsTransformFunctions(specifier, candidate);
-    return candidate;
-  }
-  throw new Error(
-    `ttsc: plugin "${specifier}" does not export a valid ttsc plugin`,
+
+    const request = resolvePluginRequest(specifier, baseDir);
+    const mod = require(request) as {
+      createTtscPlugin?: TtscPluginFactory;
+      default?: ITtscPlugin | TtscPluginFactory;
+    } & Partial<Record<"plugin", ITtscPlugin | TtscPluginFactory>>;
+    const candidate =
+      mod.createTtscPlugin ??
+      mod.default ??
+      mod.plugin ??
+      (mod as unknown as ITtscPlugin | TtscPluginFactory);
+    if (typeof candidate === "function") {
+      const plugin = candidate(context);
+      if (!isTtscPlugin(plugin)) {
+        throw new Error(
+          `ttsc: plugin "${specifier}" does not export a valid ttsc plugin`,
+        );
+      }
+      rejectJsTransformFunctions(specifier, plugin);
+      return plugin;
+    }
+    if (isTtscPlugin(candidate)) {
+      rejectJsTransformFunctions(specifier, candidate);
+      return candidate;
+    }
+    throw new Error(
+      `ttsc: plugin "${specifier}" does not export a valid ttsc plugin`,
+    );
+  });
+}
+
+function withPluginLoaderEnv<T>(run: () => T): T {
+  const previousNode = process.env.TTSC_NODE_BINARY;
+  const previousTtsx = process.env.TTSC_TTSX_BINARY;
+  process.env.TTSC_NODE_BINARY ??= process.execPath;
+  process.env.TTSC_TTSX_BINARY ??= path.join(
+    __dirname,
+    "..",
+    "..",
+    "launcher",
+    "ttsx.js",
   );
+  try {
+    return run();
+  } finally {
+    restoreEnv("TTSC_NODE_BINARY", previousNode);
+    restoreEnv("TTSC_TTSX_BINARY", previousTtsx);
+  }
+}
+
+function restoreEnv(
+  key: "TTSC_NODE_BINARY" | "TTSC_TTSX_BINARY",
+  value: string | undefined,
+): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
 }
 
 function isTtscPlugin(value: unknown): value is ITtscPlugin {

--- a/packages/ttsc/src/structures/ITtscPlugin.ts
+++ b/packages/ttsc/src/structures/ITtscPlugin.ts
@@ -65,6 +65,18 @@ export interface ITtscPlugin {
   stage?: TtscPluginStage;
 
   /**
+   * Whether a check-stage sidecar reports the normal TypeScript diagnostics for
+   * the project as part of its `check` subcommand.
+   *
+   * Leave this unset for ordinary check plugins that only report their own
+   * diagnostics; ttsc will keep running a separate `tsgo --noEmit` guard so
+   * TypeScript errors are not suppressed. Set it only when the sidecar builds
+   * the project Program and emits the same TypeScript diagnostics the guard
+   * would have produced.
+   */
+  reportsTypeScriptDiagnostics?: boolean;
+
+  /**
    * Additional Go source packages to statically link into this plugin's binary
    * at build time ("plugin-within-plugin" composition).
    *

--- a/packages/ttsc/src/structures/internal/ITtscLoadedNativePlugin.ts
+++ b/packages/ttsc/src/structures/internal/ITtscLoadedNativePlugin.ts
@@ -14,6 +14,8 @@ export interface ITtscLoadedNativePlugin {
   kind: "executable" | "linked";
   /** Optional human label used in diagnostics and native manifests. */
   name?: string;
+  /** Whether a check-stage plugin already emits TypeScript diagnostics. */
+  reportsTypeScriptDiagnostics?: boolean;
   /** Go source directory selected by the plugin descriptor. */
   source: string;
   /** Pipeline stage where the sidecar participates. */

--- a/packages/ttsc/test/driver/emit_all_write_callback_survives_many_parallel_emit_iterations_test.go
+++ b/packages/ttsc/test/driver/emit_all_write_callback_survives_many_parallel_emit_iterations_test.go
@@ -1,0 +1,119 @@
+package driver_test
+
+import (
+  "fmt"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverEmitAllWriteCallbackSurvivesManyParallelEmitIterations brute-forces
+// EmitAll's WriteFile-callback serialization across many emit iterations.
+//
+// EmitAll's callback touches two pieces of shared mutable state: the internal
+// `cursors` map (per-source rewrite offsets, see rewrite.go::emit) and the
+// caller-supplied `writeFile`, which a caller may back with its own
+// non-thread-safe state (api_compile.go funnels output into a bare map). Both
+// rely on emit()'s `wfMu`. A reverted mutex races probabilistically — TypeScript-Go's
+// parallel emitter only sometimes interleaves two callbacks tightly enough for
+// `-race` to flag it. The single-pass test (emit_rewrites_every_source_under_parallel_emit)
+// pins the rewrite routing; this case re-emits a wide program many times, each
+// pass writing into a fresh unguarded caller map and resolving a real rewrite
+// per source (so `cursors` is mutated too), so a removed mutex fails ~always.
+//
+// 1. Load one wide multi-file project, each source owning a distinct call.
+// 2. Re-run EmitAll many times with per-source rewrites and an unguarded map.
+// 3. Assert every iteration patches every output exactly once, no losses.
+func TestDriverEmitAllWriteCallbackSurvivesManyParallelEmitIterations(t *testing.T) {
+  root := t.TempDir()
+
+  // Scenario setup: a wide source set so each emit fans out many emitter
+  // goroutines. Every file re-declares `plugin` locally (legal — the `export`
+  // makes each file its own module) and calls it with a file-unique argument,
+  // so a misrouted rewrite under a torn `cursors` map is observable.
+  const sources = 24
+  names := make([]string, sources)
+  for i := range names {
+    names[i] = fmt.Sprintf("mod%02d", i)
+  }
+  writeProjectFile(t, root, "tsconfig.json", fmt.Sprintf(`{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true
+  },
+  "files": [%s]
+}
+`, `"`+strings.Join(filesList(names), `", "`)+`"`))
+  for _, name := range names {
+    writeProjectFile(t, root, name+".ts", fmt.Sprintf(
+      "declare const plugin: { make(input: string): string };\n"+
+        "export const value = plugin.make(%q);\n", name))
+  }
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  // Rewrite setup: one replacement per source, tagged with the file name so a
+  // misrouted splice (the symptom of a torn `cursors` map) is caught. The set
+  // is rebuilt fresh each iteration because applyRewrites advances `cursors`.
+  makeRewrites := func() *driver.RewriteSet {
+    rs := driver.NewRewriteSet()
+    for _, name := range names {
+      source := prog.SourceFile(filepath.Join(root, name+".ts"))
+      if source == nil {
+        t.Fatalf("SourceFile did not find %s.ts", name)
+      }
+      rs.Add(driver.Rewrite{
+        File:          source,
+        RootName:      "plugin",
+        Method:        "make",
+        Replacement:   fmt.Sprintf("%q", "rewritten-"+name),
+        ConsumeParens: true,
+      })
+    }
+    return rs
+  }
+
+  // Stress loop: re-emit many times. Each pass uses a fresh unguarded caller
+  // map standing in for api_compile's output object; the callback also runs
+  // applyRewrites against the shared `cursors` map. A removed `wfMu` races one
+  // or the other on essentially every pass once the iteration count is high.
+  const iterations = 200
+  for iter := 0; iter < iterations; iter++ {
+    emitted := map[string]string{}
+    _, emitDiags, err := prog.EmitAll(makeRewrites(), func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+      emitted[filepath.Base(fileName)] = text
+      return nil
+    })
+    if err != nil {
+      t.Fatalf("iteration %d: %v", iter, err)
+    }
+    if len(emitDiags) != 0 {
+      t.Fatalf("iteration %d: unexpected emit diagnostics: %#v", iter, emitDiags)
+    }
+    if len(emitted) != len(names) {
+      t.Fatalf("iteration %d: expected %d emitted outputs, got %d", iter, len(names), len(emitted))
+    }
+    for _, name := range names {
+      js := emitted[name+".js"]
+      if js == "" {
+        t.Fatalf("iteration %d: %s.js was not emitted", iter, name)
+      }
+      if want := `"rewritten-` + name + `"`; !strings.Contains(js, want) {
+        t.Fatalf("iteration %d: %s.js missing its own replacement %s (a misrouted splice means a torn cursors map):\n%s", iter, name, want, js)
+      }
+    }
+  }
+}

--- a/packages/ttsc/test/driver/emit_raw_serializes_write_callback_under_parallel_emit_test.go
+++ b/packages/ttsc/test/driver/emit_raw_serializes_write_callback_under_parallel_emit_test.go
@@ -1,0 +1,78 @@
+package driver_test
+
+import (
+  "fmt"
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverEmitRawSerializesWriteCallbackUnderParallelEmit verifies that
+// EmitAllRaw funnels its WriteFile callback through one mutex even though
+// TypeScript-Go emits files in parallel.
+//
+// With SingleThreaded dropped (PR #112), TypeScript-Go runs one emitter
+// goroutine per source file. EmitAll already serializes its callback, but
+// EmitAllRaw — the seam a plugin's own output rewriter uses (e.g. @nestia/core,
+// which carries per-file rewrite cursors and a runtime-alias cache) — used to
+// hand the callback straight to the parallel emitter. A stateful callback then
+// tripped `fatal error: concurrent map read and map write` (issue #115). This
+// case mutates a bare, unguarded map from inside the callback across many
+// sources, so `go test -race` flags the regression if the mutex is ever
+// removed. A single-source fixture cannot surface it — only one emitter spawns.
+//
+// 1. Load a multi-file project so the parallel emitter actually fans out.
+// 2. EmitAllRaw with a callback that reads and writes a shared unguarded map.
+// 3. Assert every source produced exactly one output with no lost writes.
+func TestDriverEmitRawSerializesWriteCallbackUnderParallelEmit(t *testing.T) {
+  root := t.TempDir()
+
+  // Scenario setup: enough sources that TypeScript-Go's parallel emit spawns
+  // many concurrent emitter goroutines, each invoking the WriteFile callback.
+  names := []string{"index", "alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta"}
+  writeProjectFile(t, root, "tsconfig.json", fmt.Sprintf(`{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true
+  },
+  "files": [%s]
+}
+`, `"`+strings.Join(filesList(names), `", "`)+`"`))
+  for _, name := range names {
+    writeProjectFile(t, root, name+".ts", fmt.Sprintf("export const value = %q;\n", name))
+  }
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  // Emit assertion: `emitted` is a deliberately unguarded map standing in for a
+  // plugin's per-file rewrite state. Both the read (length probe) and the write
+  // happen inside the callback; without EmitAllRaw's mutex the concurrent
+  // emitter goroutines would race it.
+  emitted := map[string]bool{}
+  _, emitDiags, err := prog.EmitAllRaw(func(fileName, _ string, _ *shimcompiler.WriteFileData) error {
+    _ = len(emitted)
+    emitted[fileName] = true
+    return nil
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+  if len(emitted) != len(names) {
+    t.Fatalf("expected %d emitted outputs, got %d: %#v", len(names), len(emitted), emitted)
+  }
+}

--- a/packages/ttsc/test/driver/emit_raw_write_callback_survives_many_parallel_emit_iterations_test.go
+++ b/packages/ttsc/test/driver/emit_raw_write_callback_survives_many_parallel_emit_iterations_test.go
@@ -1,0 +1,94 @@
+package driver_test
+
+import (
+  "fmt"
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverEmitRawWriteCallbackSurvivesManyParallelEmitIterations brute-forces
+// EmitAllRaw's WriteFile-callback serialization across many emit iterations.
+//
+// A data race is probabilistic: TypeScript-Go's parallel emitter (one goroutine
+// per source file, PR #112) only sometimes interleaves two callback invocations
+// closely enough for `go test -race` to catch an unguarded map access. The
+// single-pass regression test (emit_raw_serializes_write_callback_under_parallel_emit)
+// pins the bug but a lucky scheduling could let a reverted mutex slip through.
+// This case re-emits the same program many times, each pass over a wide fan-out
+// of sources and each mutating a fresh bare map from inside the callback, so a
+// removed mutex (issue #115) loses the scheduling lottery on essentially every
+// run rather than 1-in-N.
+//
+// 1. Load one wide multi-file project so each emit fans out many emitters.
+// 2. Re-run EmitAllRaw many times, each with its own unguarded shared map.
+// 3. Assert every iteration records exactly one write per source, no losses.
+func TestDriverEmitRawWriteCallbackSurvivesManyParallelEmitIterations(t *testing.T) {
+  root := t.TempDir()
+
+  // Scenario setup: a wide source set. The more sources, the more emitter
+  // goroutines TypeScript-Go spawns per pass, so the callback invocations are
+  // likelier to overlap — exactly the window `-race` needs to flag a reverted
+  // mutex. The names are arbitrary but distinct so each gets its own output.
+  const sources = 24
+  names := make([]string, sources)
+  for i := range names {
+    names[i] = fmt.Sprintf("mod%02d", i)
+  }
+  writeProjectFile(t, root, "tsconfig.json", fmt.Sprintf(`{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true
+  },
+  "files": [%s]
+}
+`, `"`+strings.Join(filesList(names), `", "`)+`"`))
+  for _, name := range names {
+    writeProjectFile(t, root, name+".ts", fmt.Sprintf("export const value = %q;\n", name))
+  }
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  // Stress loop: re-emit the same program many times. Loading the program is
+  // the costly step (~0.3s); a re-emit is cheap (~15ms), so a high iteration
+  // count stays fast while multiplying the number of concurrent callback
+  // windows the race detector observes. Each iteration owns a fresh map so a
+  // torn write surfaces as a race on first overlap, not a slow corruption.
+  const iterations = 200
+  for iter := 0; iter < iterations; iter++ {
+    emitted := map[string]int{}
+    _, emitDiags, err := prog.EmitAllRaw(func(fileName, _ string, _ *shimcompiler.WriteFileData) error {
+      // Read then write the unguarded map: both touch the bucket array,
+      // so a removed mutex races on either access.
+      _ = len(emitted)
+      emitted[fileName]++
+      return nil
+    })
+    if err != nil {
+      t.Fatalf("iteration %d: %v", iter, err)
+    }
+    if len(emitDiags) != 0 {
+      t.Fatalf("iteration %d: unexpected emit diagnostics: %#v", iter, emitDiags)
+    }
+    if len(emitted) != len(names) {
+      t.Fatalf("iteration %d: expected %d emitted outputs, got %d: %#v", iter, len(names), len(emitted), emitted)
+    }
+    for fileName, count := range emitted {
+      if count != 1 {
+        t.Fatalf("iteration %d: %s written %d times (a lost or doubled write means a torn callback)", iter, fileName, count)
+      }
+    }
+  }
+}

--- a/packages/ttsc/test/driver/load_program_clamps_checker_pool_to_one_test.go
+++ b/packages/ttsc/test/driver/load_program_clamps_checker_pool_to_one_test.go
@@ -1,0 +1,74 @@
+package driver_test
+
+import (
+  "testing"
+
+  shimcore "github.com/microsoft/typescript-go/shim/core"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverLoadProgramClampsCheckerPoolToOne verifies forceSingleChecker
+// collapses a multi-checker pool request down to a single checker.
+//
+// PR #112 dropped SingleThreaded, which switched on TypeScript-Go's
+// multi-checker pool. ttsc's transform and rewrite phases query types through
+// the one checker GetTypeChecker hands back, so a pool larger than one lets a
+// type whose declarations span files on different checkers resolve to `any`.
+// forceSingleChecker must therefore clamp `Checkers` back to 1 even when the
+// caller (or `--checkers N`) asked for more, while leaving `--singleThreaded`
+// untouched so that path still wins.
+//
+// 1. Load a multi-file project with LoadProgramOptions.Checkers set to 4.
+// 2. Assert the resolved CompilerOptions.Checkers is clamped to exactly 1.
+// 3. Load the same project with SingleThreaded and assert it still applies.
+func TestDriverLoadProgramClampsCheckerPoolToOne(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "strict": true,
+    "outDir": "bin"
+  },
+  "files": ["a.ts", "b.ts", "index.ts"]
+}
+`)
+  writeProjectFile(t, root, "a.ts", "export const a = 1;\n")
+  writeProjectFile(t, root, "b.ts", "export const b = 2;\n")
+  writeProjectFile(t, root, "index.ts", "import { a } from \"./a\";\nimport { b } from \"./b\";\nexport const sum = a + b;\n")
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{
+    Checkers: 4,
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  checkers := prog.ParsedConfig.ParsedConfig.CompilerOptions.Checkers
+  if checkers == nil {
+    t.Fatal("forceSingleChecker did not pin Checkers; it is still nil (multi-checker default)")
+  }
+  if *checkers != 1 {
+    t.Fatalf("forceSingleChecker did not clamp the pool: Checkers = %d, want 1", *checkers)
+  }
+
+  single, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{
+    SingleThreaded: true,
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %#v", diags)
+  }
+  defer single.Close()
+
+  if single.ParsedConfig.ParsedConfig.CompilerOptions.SingleThreaded != shimcore.TSTrue {
+    t.Fatal("forceSingleChecker clobbered --singleThreaded; SingleThreaded is not set")
+  }
+}

--- a/tests/test-lint/src/cases/prefer-const.ts
+++ b/tests/test-lint/src/cases/prefer-const.ts
@@ -12,4 +12,14 @@ for (let item of [1, 2]) {
   JSON.stringify(item);
 }
 
-JSON.stringify([stable, changing]);
+// Destructuring-assignment targets reassign their identifiers, so neither
+// `swapLeft` nor `swapRight` is const-able and must stay unflagged.
+let swapLeft = 1;
+let swapRight = 2;
+[swapLeft, swapRight] = [swapRight, swapLeft];
+
+// Object-destructuring assignment reassigns `picked` through a property value.
+let picked = 0;
+({ picked } = { picked: 9 });
+
+JSON.stringify([stable, changing, swapLeft, swapRight, picked]);

--- a/tests/test-lint/src/features/plugin/test_lib_index_js_is_a_factory_that_returns_a_native_source_descriptor.ts
+++ b/tests/test-lint/src/features/plugin/test_lib_index_js_is_a_factory_that_returns_a_native_source_descriptor.ts
@@ -8,14 +8,15 @@ import { TestLintPlugin } from "../../internal/TestLintPlugin";
  *
  * The `@ttsc/lint` package's JS entry must be a callable factory (not a plain
  * config object), and the returned descriptor must carry the plugin name
- * `"@ttsc/lint"` and the `"check"` stage so the ttsc host knows when to invoke
- * it. A wrong name or stage would silently route lint diagnostics to the wrong
- * pipeline slot.
+ * `"@ttsc/lint"`, the `"check"` stage, and the TypeScript-diagnostics
+ * capability so the ttsc host knows when to invoke it and avoid redundant
+ * `tsgo --noEmit` guards. A wrong name or stage would silently route lint
+ * diagnostics to the wrong pipeline slot.
  *
  * 1. Load the factory from the built `lib/index.js`.
  * 2. Call it with a minimal context supplying `transform: "@ttsc/lint"`.
  * 3. Assert `typeof factory === "function"`, `descriptor.name === "@ttsc/lint"`,
- *    and `descriptor.stage === "check"`.
+ *    `descriptor.stage === "check"`, and the diagnostics capability is set.
  */
 export const test_lib_index_js_is_a_factory_that_returns_a_native_source_descriptor =
   () => {
@@ -26,4 +27,5 @@ export const test_lib_index_js_is_a_factory_that_returns_a_native_source_descrip
     );
     assert.equal(descriptor.name, "@ttsc/lint");
     assert.equal(descriptor.stage, "check");
+    assert.equal(descriptor.reportsTypeScriptDiagnostics, true);
   };

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_no_plugin_build_honors_tsconfig_no_emit.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_no_plugin_build_honors_tsconfig_no_emit.ts
@@ -1,0 +1,84 @@
+import {
+  assert,
+  createFakeNativePreview,
+  createProject,
+  fs,
+  path,
+  spawnWithoutTsgoOverride,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies ttsc no-plugin build honors tsconfig noEmit.
+ *
+ * Pins the fast path that delegates straight to tsgo when no native plugins are
+ * loaded. A project-level `noEmit: true` is already a check-only build, so ttsc
+ * must not add emit-only guard flags that send tsgo down its slower emit path.
+ *
+ * 1. Install a fake project-local `@typescript/native-preview` binary.
+ * 2. Run `ttsc` on a project whose tsconfig declares `noEmit: true`.
+ * 3. Assert the forwarded tsgo invocation includes `--noEmit`, omits
+ *    `--noEmitOnError`, and writes no JavaScript output.
+ */
+export const test_ttsc_no_plugin_build_honors_tsconfig_no_emit = () => {
+  const root = createProject({
+    "package.json": JSON.stringify({ private: true }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        noEmit: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const value: string = "no-emit";\n`,
+  });
+  const logFile = path.join(root, "tsgo-invocations.jsonl");
+  createFakeNativePreview(
+    root,
+    `
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(logFile)}, JSON.stringify(args) + "\\n", "utf8");
+if (args.includes("--version")) {
+  console.log("Version 7.0.0-dev.FAKE");
+  process.exit(0);
+}
+function flagBoolean(name, fallback) {
+  let value = fallback;
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] !== name) continue;
+    const next = args[i + 1];
+    value = next === "false" ? false : true;
+  }
+  return value;
+}
+const projectFlag = args.indexOf("-p");
+const tsconfig = projectFlag === -1 ? path.join(process.cwd(), "tsconfig.json") : args[projectFlag + 1];
+const projectRoot = path.dirname(tsconfig);
+const config = JSON.parse(fs.readFileSync(tsconfig, "utf8"));
+const noEmit = flagBoolean("--noEmit", config.compilerOptions?.noEmit === true);
+if (!noEmit) {
+  const outDir = path.resolve(projectRoot, config.compilerOptions?.outDir ?? ".");
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, "main.js"), "exports.value = \\"emit\\";\\n", "utf8");
+}
+process.exit(0);
+`,
+  );
+
+  const result = spawnWithoutTsgoOverride(ttscBin, ["--cwd", root], {
+    cwd: root,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const invocations = fs
+    .readFileSync(logFile, "utf8")
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => JSON.parse(line) as string[]);
+  assert.equal(invocations.length, 1);
+  assert.equal(invocations[0]!.includes("--noEmit"), true);
+  assert.equal(invocations[0]!.includes("--noEmitOnError"), false);
+  assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), false);
+};

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_no_plugin_emit_invokes_tsgo_once.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_no_plugin_emit_invokes_tsgo_once.ts
@@ -1,0 +1,83 @@
+import {
+  assert,
+  createFakeNativePreview,
+  createProject,
+  fs,
+  path,
+  spawnWithoutTsgoOverride,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies ttsc no-plugin emit invokes tsgo once.
+ *
+ * Pins the no-plugin fast path that relies on tsgo's `--noEmitOnError` guard
+ * instead of spawning a separate `--noEmit` pre-check before the emit pass. The
+ * fake project-local tsgo records every invocation so the assertion is about
+ * process count, not wall-clock timing.
+ *
+ * 1. Install a fake project-local `@typescript/native-preview` binary.
+ * 2. Run `ttsc --emit` on a project with no ttsc plugins.
+ * 3. Assert one tsgo invocation, the internal `--noEmitOnError` guard, and one
+ *    emitted JavaScript file.
+ */
+export const test_ttsc_no_plugin_emit_invokes_tsgo_once = () => {
+  const root = createProject({
+    "package.json": JSON.stringify({ private: true }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const value: string = "single-pass";\n`,
+  });
+  const logFile = path.join(root, "tsgo-invocations.jsonl");
+  createFakeNativePreview(
+    root,
+    `
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(logFile)}, JSON.stringify(args) + "\\n", "utf8");
+if (args.includes("--version")) {
+  console.log("Version 7.0.0-dev.FAKE");
+  process.exit(0);
+}
+function flagBoolean(name, fallback) {
+  let value = fallback;
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] !== name) continue;
+    const next = args[i + 1];
+    value = next === "false" ? false : true;
+  }
+  return value;
+}
+const projectFlag = args.indexOf("-p");
+const tsconfig = projectFlag === -1 ? path.join(process.cwd(), "tsconfig.json") : args[projectFlag + 1];
+const projectRoot = path.dirname(tsconfig);
+const config = JSON.parse(fs.readFileSync(tsconfig, "utf8"));
+const noEmit = flagBoolean("--noEmit", config.compilerOptions?.noEmit === true);
+if (!noEmit) {
+  const outDir = path.resolve(projectRoot, config.compilerOptions?.outDir ?? ".");
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, "main.js"), "exports.value = \\"single-pass\\";\\n", "utf8");
+}
+process.exit(0);
+`,
+  );
+
+  const result = spawnWithoutTsgoOverride(ttscBin, ["--cwd", root, "--emit"], {
+    cwd: root,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const invocations = fs
+    .readFileSync(logFile, "utf8")
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => JSON.parse(line) as string[]);
+  assert.equal(invocations.length, 1);
+  assert.equal(invocations[0]!.includes("--noEmitOnError"), true);
+  assert.equal(fs.existsSync(path.join(root, "dist", "main.js")), true);
+};

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_no_emit_flag_does_not_break_a_native_plugin_check.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_no_emit_flag_does_not_break_a_native_plugin_check.ts
@@ -1,0 +1,45 @@
+import {
+  assert,
+  copyDirectory,
+  goPath,
+  nativePlugin,
+  path,
+  pluginProject,
+  spawn,
+  ttscBin,
+  workspaceRoot,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: `--noEmit` does not break a native plugin check.
+ *
+ * Pins the compatibility regression found while benchmarking typia/nestia
+ * consumers: `runBuild.ts` used to translate `ttsc --noEmit` into a native
+ * host `check` invocation with extra ttsc-owned flags like `--noEmit` and
+ * `--quiet`. Third-party transform hosts already use the `check` subcommand
+ * to mean no emit, and older strict hosts reject the extra flags before
+ * analysis starts.
+ *
+ * 1. Configure a native transform plugin backed by the strict test sidecar.
+ * 2. Run ttsc with `--noEmit`.
+ * 3. Assert the sidecar accepts the check invocation and exits cleanly.
+ */
+export const test_plugin_corpus_no_emit_flag_does_not_break_a_native_plugin_check =
+  () => {
+    const root = pluginProject(
+      [{ transform: "./plugins/upper.cjs", name: "upper" }],
+      {
+        "plugins/upper.cjs": nativePlugin(),
+      },
+    );
+    copyDirectory(
+      path.join(workspaceRoot, "tests", "go-transformer"),
+      path.join(root, "go-plugin"),
+    );
+
+    const result = spawn(ttscBin, ["--cwd", root, "--noEmit"], {
+      cwd: root,
+      env: { PATH: goPath() },
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  };

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_prepare_loads_typescript_lint_config_without_path_ttsx.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_prepare_loads_typescript_lint_config_without_path_ttsx.ts
@@ -42,7 +42,7 @@ export default {
 `,
     );
 
-    const env = {
+    const env: NodeJS.ProcessEnv = {
       ...process.env,
       PATH: goPath(),
       TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-lint-prepare-"),

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_prepare_loads_typescript_lint_config_without_path_ttsx.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_prepare_loads_typescript_lint_config_without_path_ttsx.ts
@@ -1,0 +1,61 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  goPath,
+  path,
+  setupLintProject,
+  spawn,
+  ttscBin,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: prepare loads TypeScript lint config without PATH
+ * ttsx.
+ *
+ * `ttsc prepare` loads plugin factories before any native sidecar spawn. The
+ * `@ttsc/lint` factory evaluates `lint.config.ts` through `ttsx`; when callers
+ * invoke `node_modules/.bin/ttsc` directly, PATH may not contain
+ * `node_modules/.bin`, so prepare must provide the bundled ttsx launcher.
+ *
+ * 1. Create an @ttsc/lint project with a TypeScript lint config.
+ * 2. Run `ttsc prepare` with TTSC_TTSX_BINARY removed from the environment.
+ * 3. Assert prepare succeeds and does not report a missing `ttsx` executable.
+ */
+export const test_plugin_corpus_prepare_loads_typescript_lint_config_without_path_ttsx =
+  () => {
+    const root = setupLintProject("lint-violations");
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({ devDependencies: { "@ttsc/lint": "*" } }),
+    );
+    fs.writeFileSync(
+      path.join(root, "lint.config.ts"),
+      `import type { ITtscLintConfig } from "@ttsc/lint";
+
+export default {
+  rules: {
+    "no-var": "error",
+  },
+} satisfies ITtscLintConfig;
+`,
+    );
+
+    const env = {
+      ...process.env,
+      PATH: goPath(),
+      TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-lint-prepare-"),
+    };
+    delete env.TTSC_TTSX_BINARY;
+    delete env.TTSC_NODE_BINARY;
+
+    const result = spawn(ttscBin, ["prepare", "--cwd", root], {
+      cwd: root,
+      env,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /ttsc: prepared /);
+    assert.doesNotMatch(result.stderr, /spawn ttsx ENOENT/);
+  };

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_single_threaded_flag_does_not_break_a_native_plugin_build.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_single_threaded_flag_does_not_break_a_native_plugin_build.ts
@@ -1,0 +1,56 @@
+import {
+  assert,
+  copyDirectory,
+  fs,
+  goPath,
+  nativePlugin,
+  path,
+  pluginProject,
+  spawn,
+  ttscBin,
+  workspaceRoot,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: `--singleThreaded` does not break a native plugin build.
+ *
+ * Pins the compatibility regression from #113: `runBuild.ts` used to forward
+ * `--singleThreaded` / `--checkers` to native plugin hosts as bare CLI flags.
+ * A third-party host built before #113 has no such flag in its `flag.FlagSet`,
+ * and a host that parses with `flag.ContinueOnError` exits 2 on the unknown
+ * flag instead of ignoring it — so `ttsc --singleThreaded` failed
+ * deterministically on any project carrying a typia/nestia transform plugin.
+ * The threading knobs are ttsc-owned and now stay on the no-plugin `tsgo`
+ * lane; native hosts never see them. The `go-transformer` fixture is a
+ * deliberately strict host (`flag.ContinueOnError`, no `singleThreaded` flag),
+ * so it reproduces the exact crash.
+ *
+ * 1. Configure a native plugin backed by the strict `go-transformer` host.
+ * 2. Run ttsc with `--emit --singleThreaded`.
+ * 3. Assert zero exit and the emitted JS still contains the transformed value.
+ */
+export const test_plugin_corpus_single_threaded_flag_does_not_break_a_native_plugin_build =
+  () => {
+    const root = pluginProject(
+      [{ transform: "./plugins/upper.cjs", name: "upper" }],
+      {
+        "plugins/upper.cjs": nativePlugin(),
+      },
+    );
+    copyDirectory(
+      path.join(workspaceRoot, "tests", "go-transformer"),
+      path.join(root, "go-plugin"),
+    );
+
+    const result = spawn(
+      ttscBin,
+      ["--cwd", root, "--emit", "--singleThreaded"],
+      {
+        cwd: root,
+        env: { PATH: goPath() },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+    assert.match(js, /"PLUGIN"/);
+  };

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_applies_forwarded_strict_flag.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_applies_forwarded_strict_flag.ts
@@ -38,7 +38,7 @@ export const test_plugin_corpus_ttsc_lint_applies_forwarded_strict_flag =
           strict: false,
           outDir: "dist",
           rootDir: "src",
-          plugins: [{ transform: "@ttsc/lint", config: {} }],
+          plugins: [{ transform: "@ttsc/lint" }],
         },
         include: ["src"],
       }),

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_no_emit_skips_redundant_tsgo_check.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_ttsc_lint_no_emit_skips_redundant_tsgo_check.ts
@@ -1,0 +1,103 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  commonJsProject,
+  fs,
+  goPath,
+  path,
+  spawn,
+  ttscBin,
+  workspaceRoot,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: @ttsc/lint noEmit skips redundant tsgo check.
+ *
+ * `@ttsc/lint` loads the project Program and reports normal TypeScript
+ * diagnostics during its `check` subcommand. Running a second plain
+ * `tsgo --noEmit` afterward rebuilds the checker graph and doubles the
+ * expensive part of lint benchmarks, so ttsc must trust the lint descriptor's
+ * diagnostics capability instead of appending the guard.
+ *
+ * 1. Create a clean project with only `@ttsc/lint` as a check-stage plugin.
+ * 2. Point `TTSC_TSGO_BINARY` at a fake tsgo that fails on build/check calls.
+ * 3. Run `ttsc --noEmit` and assert success with no `--noEmit` tsgo call.
+ */
+export const test_plugin_corpus_ttsc_lint_no_emit_skips_redundant_tsgo_check =
+  () => {
+    const root = commonJsProject(
+      {
+        "lint.config.json": JSON.stringify({ rules: {} }),
+        "package.json": JSON.stringify({ private: true }),
+        "src/main.ts": `export const value: string = "lint";\n`,
+      },
+      {
+        compilerOptions: {
+          plugins: [
+            {
+              configFile: "./lint.config.json",
+              transform: "@ttsc/lint",
+            },
+          ],
+        },
+      },
+    );
+    linkLintPackage(root);
+
+    const logFile = path.join(root, "tsgo-invocations.jsonl");
+    const fakeTsgo = path.join(root, "fake-tsgo.js");
+    fs.writeFileSync(
+      fakeTsgo,
+      [
+        "#!/usr/bin/env node",
+        'const fs = require("node:fs");',
+        `const logFile = ${JSON.stringify(logFile)};`,
+        "const args = process.argv.slice(2);",
+        'fs.appendFileSync(logFile, JSON.stringify(args) + "\\n", "utf8");',
+        'if (args.includes("--version")) {',
+        '  console.log("Version 7.0.0-dev.FAKE");',
+        "  process.exit(0);",
+        "}",
+        'console.error("unexpected tsgo invocation " + JSON.stringify(args));',
+        "process.exit(99);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    fs.chmodSync(fakeTsgo, 0o755);
+
+    const result = spawn(ttscBin, ["--cwd", root, "--noEmit"], {
+      cwd: root,
+      env: {
+        PATH: goPath(),
+        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-lint-noemit-"),
+        TTSC_TSGO_BINARY: fakeTsgo,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const invocations = fs.existsSync(logFile)
+      ? fs
+          .readFileSync(logFile, "utf8")
+          .trim()
+          .split(/\r?\n/)
+          .filter((line) => line.length !== 0)
+          .map((line) => JSON.parse(line) as string[])
+      : [];
+    assert.equal(
+      invocations.some((args) => args.includes("--noEmit")),
+      false,
+      JSON.stringify(invocations),
+    );
+  };
+
+function linkLintPackage(root: string): void {
+  const scopeDir = path.join(root, "node_modules", "@ttsc");
+  fs.mkdirSync(scopeDir, { recursive: true });
+  fs.symlinkSync(
+    path.join(workspaceRoot, "packages", "lint"),
+    path.join(scopeDir, "lint"),
+    "junction",
+  );
+}

--- a/tests/test-ttsc/src/features/utility-plugins/test_ttsc_utility_plugins_descriptors_own_separate_native_source_directories.ts
+++ b/tests/test-ttsc/src/features/utility-plugins/test_ttsc_utility_plugins_descriptors_own_separate_native_source_directories.ts
@@ -12,8 +12,8 @@ import { TestUtilityPlugins } from "../../internal/TestUtilityPlugins";
  * Each utility package (`lint`, `banner`, `paths`, `strip`) must advertise its
  * own `source` directory — distinct from every other package — so the
  * linked-plugin host can combine their sources into one binary without path
- * collisions. The `stage` and `package.json` plugin field must also match the
- * expected values for each package.
+ * collisions. The `stage`, optional diagnostics capability, and `package.json`
+ * plugin field must also match the expected values for each package.
  *
  * 1. Invoke `createTtscPlugin` for each utility package with a factory context.
  * 2. Assert the returned descriptor's `name`, `source`, and `stage` fields.
@@ -22,7 +22,11 @@ import { TestUtilityPlugins } from "../../internal/TestUtilityPlugins";
 export const test_ttsc_utility_plugins_descriptors_own_separate_native_source_directories =
   () => {
     const expectations = {
-      lint: { source: "plugin", stage: "check" },
+      lint: {
+        reportsTypeScriptDiagnostics: true,
+        source: "plugin",
+        stage: "check",
+      },
       banner: { source: "driver", stage: "transform" },
       paths: { source: "driver", stage: "transform" },
       strip: { source: "driver", stage: "transform" },
@@ -38,9 +42,18 @@ export const test_ttsc_utility_plugins_descriptors_own_separate_native_source_di
       assert.equal(descriptor.stage, expectation.stage);
       assert.deepEqual(Object.keys(descriptor).sort(), [
         "name",
+        ...("reportsTypeScriptDiagnostics" in expectation
+          ? ["reportsTypeScriptDiagnostics"]
+          : []),
         "source",
         "stage",
       ]);
+      if ("reportsTypeScriptDiagnostics" in expectation) {
+        assert.equal(
+          descriptor.reportsTypeScriptDiagnostics,
+          expectation.reportsTypeScriptDiagnostics,
+        );
+      }
       assert.equal(
         descriptor.source,
         path.join(

--- a/website/public/benchmark.json
+++ b/website/public/benchmark.json
@@ -1,5 +1,5 @@
 {
-  "date": "2026-05-22T14:14:20.993Z",
+  "date": "2026-05-22T14:48:20.880Z",
   "runs": 1,
   "warmup": 1,
   "host": {
@@ -11,7 +11,7 @@
     "node": "v24.15.0",
     "ttsc": "0.12.4",
     "typescript": "5.9.3",
-    "tsgo": "7.0.0-dev.20260517.1"
+    "tsgo": "7.0.0-dev.20260521.1"
   },
   "projects": [
     {
@@ -222,10 +222,10 @@
           "tool": "tsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 38685.803269,
-          "minMs": 38685.803269,
+          "medianMs": 37803.194082,
+          "minMs": 37803.194082,
           "samples": [
-            38685.803269
+            37803.194082
           ]
         },
         {
@@ -234,10 +234,10 @@
           "tool": "eslint",
           "op": "eslint",
           "threading": "multi",
-          "medianMs": 2575.534725,
-          "minMs": 2575.534725,
+          "medianMs": 2410.961337,
+          "minMs": 2410.961337,
           "samples": [
-            2575.534725
+            2410.961337
           ]
         },
         {
@@ -246,10 +246,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 25631.137634,
-          "minMs": 25631.137634,
+          "medianMs": 18084.22731,
+          "minMs": 18084.22731,
           "samples": [
-            25631.137634
+            18084.22731
           ]
         },
         {
@@ -258,10 +258,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 28069.710405,
-          "minMs": 28069.710405,
+          "medianMs": 25913.081729,
+          "minMs": 25913.081729,
           "samples": [
-            28069.710405
+            25913.081729
           ]
         },
         {
@@ -270,10 +270,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 38277.714813,
-          "minMs": 38277.714813,
+          "medianMs": 18562.148635,
+          "minMs": 18562.148635,
           "samples": [
-            38277.714813
+            18562.148635
           ]
         },
         {
@@ -282,10 +282,34 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 58896.556443,
-          "minMs": 58896.556443,
+          "medianMs": 21559.02311,
+          "minMs": 21559.02311,
           "samples": [
-            58896.556443
+            21559.02311
+          ]
+        },
+        {
+          "id": "type-fest:ttsc:tsgo:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 17081.863515,
+          "minMs": 17081.863515,
+          "samples": [
+            17081.863515
+          ]
+        },
+        {
+          "id": "type-fest:ttsc:tsgo:noEmit:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 24959.12851,
+          "minMs": 24959.12851,
+          "samples": [
+            24959.12851
           ]
         }
       ]

--- a/website/public/benchmark.json
+++ b/website/public/benchmark.json
@@ -1,65 +1,561 @@
 {
-  "date": "2026-05-22T02:37:24.167Z",
+  "date": "2026-05-22T14:14:20.993Z",
+  "runs": 1,
+  "warmup": 1,
   "host": {
-    "os": "Ubuntu 24.04 (WSL2)",
+    "os": "Ubuntu 26.04 LTS",
     "kernel": "6.6.87.2-microsoft-standard-WSL2",
-    "cpu": "AMD Ryzen AI MAX+ 395 w/ Radeon 8060S",
+    "cpu": "AMD RYZEN AI MAX+ 395 w/ Radeon 8060S",
     "cores": 32,
     "ramGB": 29,
-    "node": "22.14.0",
+    "node": "v24.15.0",
     "ttsc": "0.12.4",
-    "typescript": "7.0.0-dev"
+    "typescript": "5.9.3",
+    "tsgo": "7.0.0-dev.20260517.1"
   },
   "projects": [
     {
-      "name": "shopping-backend",
-      "files": 640,
-      "kind": "plugin-heavy",
+      "name": "vue",
+      "repo": "ttsc-benchmark-vue",
+      "kind": "frontend monorepo",
+      "files": 442,
       "measurements": [
-        { "branch": "legacy", "tool": "tsc", "op": "build", "threading": "multi", "medianMs": 21872 },
-        { "branch": "ttsc", "tool": "ttsc", "op": "build", "threading": "multi", "medianMs": 8706 },
-        { "branch": "ttsc-lint", "tool": "ttsc", "op": "build", "threading": "multi", "medianMs": 10566 },
-        { "branch": "legacy", "tool": "tsc", "op": "noEmit", "threading": "multi", "medianMs": 17940 },
-        { "branch": "ttsc", "tool": "ttsc", "op": "noEmit", "threading": "multi", "medianMs": 6980 },
-        { "branch": "ttsc", "tool": "ttsc", "op": "build", "threading": "single", "medianMs": 19120 },
-        { "branch": "legacy", "tool": "eslint", "op": "build", "threading": "multi", "medianMs": 5653 },
-        { "branch": "ttsc-lint", "tool": "@ttsc/lint", "op": "build", "threading": "multi", "medianMs": 0 },
-        { "branch": "legacy", "tool": "prettier", "op": "build", "threading": "multi", "medianMs": 3825 },
-        { "branch": "ttsc-lint", "tool": "@ttsc/lint", "op": "format", "threading": "multi", "medianMs": 2141 }
-      ]
-    },
-    {
-      "name": "vscode",
-      "files": 5120,
-      "kind": "type-check-heavy",
-      "measurements": [
-        { "branch": "legacy", "tool": "tsc", "op": "noEmit", "threading": "multi", "medianMs": 49300 },
-        { "branch": "ttsc", "tool": "ttsc", "op": "noEmit", "threading": "multi", "medianMs": 6420 },
-        { "branch": "ttsc", "tool": "ttsc", "op": "noEmit", "threading": "single", "medianMs": 14880 }
-      ]
-    },
-    {
-      "name": "zod",
-      "files": 412,
-      "kind": "type-check-heavy",
-      "measurements": [
-        { "branch": "legacy", "tool": "tsc", "op": "build", "threading": "multi", "medianMs": 9740 },
-        { "branch": "ttsc", "tool": "ttsc", "op": "build", "threading": "multi", "medianMs": 1980 },
-        { "branch": "legacy", "tool": "tsc", "op": "noEmit", "threading": "multi", "medianMs": 8210 },
-        { "branch": "ttsc", "tool": "ttsc", "op": "noEmit", "threading": "multi", "medianMs": 1510 },
-        { "branch": "ttsc", "tool": "ttsc", "op": "noEmit", "threading": "single", "medianMs": 3260 }
+        {
+          "id": "vue:legacy:noEmit:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 2194.676845,
+          "minMs": 2194.676845,
+          "samples": [
+            2194.676845
+          ]
+        },
+        {
+          "id": "vue:legacy:eslint:multi",
+          "branch": "legacy",
+          "tool": "eslint",
+          "op": "eslint",
+          "threading": "multi",
+          "medianMs": 3190.37042,
+          "minMs": 3190.37042,
+          "samples": [
+            3190.37042
+          ]
+        },
+        {
+          "id": "vue:ttsc:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 580.245355,
+          "minMs": 580.245355,
+          "samples": [
+            580.245355
+          ]
+        },
+        {
+          "id": "vue:ttsc:noEmit:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 833.305461,
+          "minMs": 833.305461,
+          "samples": [
+            833.305461
+          ]
+        },
+        {
+          "id": "vue:ttsc:build:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 597.697261,
+          "minMs": 597.697261,
+          "samples": [
+            597.697261
+          ]
+        },
+        {
+          "id": "vue:ttsc-lint:build:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 5238.489438,
+          "minMs": 5238.489438,
+          "samples": [
+            5238.489438
+          ]
+        },
+        {
+          "id": "vue:ttsc-lint:build:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 5895.388094,
+          "minMs": 5895.388094,
+          "samples": [
+            5895.388094
+          ]
+        },
+        {
+          "id": "vue:ttsc-lint:noEmit:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 2740.373618,
+          "minMs": 2740.373618,
+          "samples": [
+            2740.373618
+          ]
+        },
+        {
+          "id": "vue:ttsc-lint:noEmit:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 2973.23513,
+          "minMs": 2973.23513,
+          "samples": [
+            2973.23513
+          ]
+        }
       ]
     },
     {
       "name": "rxjs",
-      "files": 1380,
-      "kind": "library",
+      "repo": "ttsc-benchmark-rxjs",
+      "kind": "library monorepo",
+      "files": 515,
       "measurements": [
-        { "branch": "legacy", "tool": "tsc", "op": "build", "threading": "multi", "medianMs": 12640 },
-        { "branch": "ttsc", "tool": "ttsc", "op": "build", "threading": "multi", "medianMs": 2410 },
-        { "branch": "legacy", "tool": "prettier", "op": "build", "threading": "multi", "medianMs": 6190 },
-        { "branch": "ttsc-lint", "tool": "@ttsc/lint", "op": "format", "threading": "multi", "medianMs": 3050 }
+        {
+          "id": "rxjs:legacy:noEmit:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 4932.992989,
+          "minMs": 4932.992989,
+          "samples": [
+            4932.992989
+          ]
+        },
+        {
+          "id": "rxjs:legacy:eslint:multi",
+          "branch": "legacy",
+          "tool": "eslint",
+          "op": "eslint",
+          "threading": "multi",
+          "medianMs": 3749.130811,
+          "minMs": 3749.130811,
+          "samples": [
+            3749.130811
+          ]
+        },
+        {
+          "id": "rxjs:ttsc:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 1368.689028,
+          "minMs": 1368.689028,
+          "samples": [
+            1368.689028
+          ]
+        },
+        {
+          "id": "rxjs:ttsc:noEmit:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 1360.757227,
+          "minMs": 1360.757227,
+          "samples": [
+            1360.757227
+          ]
+        },
+        {
+          "id": "rxjs:ttsc-lint:noEmit:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 3387.937016,
+          "minMs": 3387.937016,
+          "samples": [
+            3387.937016
+          ]
+        },
+        {
+          "id": "rxjs:ttsc-lint:noEmit:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 3511.746757,
+          "minMs": 3511.746757,
+          "samples": [
+            3511.746757
+          ]
+        }
       ]
+    },
+    {
+      "name": "type-fest",
+      "repo": "ttsc-benchmark-type-fest",
+      "kind": "type-level library",
+      "files": 209,
+      "measurements": [
+        {
+          "id": "type-fest:legacy:noEmit:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 38685.803269,
+          "minMs": 38685.803269,
+          "samples": [
+            38685.803269
+          ]
+        },
+        {
+          "id": "type-fest:legacy:eslint:multi",
+          "branch": "legacy",
+          "tool": "eslint",
+          "op": "eslint",
+          "threading": "multi",
+          "medianMs": 2575.534725,
+          "minMs": 2575.534725,
+          "samples": [
+            2575.534725
+          ]
+        },
+        {
+          "id": "type-fest:ttsc:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 25631.137634,
+          "minMs": 25631.137634,
+          "samples": [
+            25631.137634
+          ]
+        },
+        {
+          "id": "type-fest:ttsc:noEmit:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 28069.710405,
+          "minMs": 28069.710405,
+          "samples": [
+            28069.710405
+          ]
+        },
+        {
+          "id": "type-fest:ttsc-lint:noEmit:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 38277.714813,
+          "minMs": 38277.714813,
+          "samples": [
+            38277.714813
+          ]
+        },
+        {
+          "id": "type-fest:ttsc-lint:noEmit:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 58896.556443,
+          "minMs": 58896.556443,
+          "samples": [
+            58896.556443
+          ]
+        }
+      ]
+    },
+    {
+      "name": "typeorm",
+      "repo": "ttsc-benchmark-typeorm",
+      "kind": "ORM library",
+      "files": 495,
+      "measurements": [
+        {
+          "id": "typeorm:legacy:noEmit:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 9969.208651,
+          "minMs": 9969.208651,
+          "samples": [
+            9969.208651
+          ]
+        },
+        {
+          "id": "typeorm:legacy:eslint:multi",
+          "branch": "legacy",
+          "tool": "eslint",
+          "op": "eslint",
+          "threading": "multi",
+          "medianMs": 31880.117892,
+          "minMs": 31880.117892,
+          "samples": [
+            31880.117892
+          ]
+        },
+        {
+          "id": "typeorm:ttsc:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 1501.239534,
+          "minMs": 1501.239534,
+          "samples": [
+            1501.239534
+          ]
+        },
+        {
+          "id": "typeorm:ttsc:noEmit:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 3208.549564,
+          "minMs": 3208.549564,
+          "samples": [
+            3208.549564
+          ]
+        },
+        {
+          "id": "typeorm:ttsc-lint:noEmit:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 3617.095802,
+          "minMs": 3617.095802,
+          "samples": [
+            3617.095802
+          ]
+        },
+        {
+          "id": "typeorm:ttsc-lint:noEmit:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 5209.568986,
+          "minMs": 5209.568986,
+          "samples": [
+            5209.568986
+          ]
+        }
+      ]
+    },
+    {
+      "name": "zod",
+      "repo": "ttsc-benchmark-zod",
+      "kind": "schema library monorepo",
+      "files": 286,
+      "measurements": [
+        {
+          "id": "zod:legacy:noEmit:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 8461.672422,
+          "minMs": 8461.672422,
+          "samples": [
+            8461.672422
+          ]
+        },
+        {
+          "id": "zod:legacy:eslint:multi",
+          "branch": "legacy",
+          "tool": "eslint",
+          "op": "eslint",
+          "threading": "multi",
+          "medianMs": 2518.052058,
+          "minMs": 2518.052058,
+          "samples": [
+            2518.052058
+          ]
+        },
+        {
+          "id": "zod:ttsc:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 1931.574414,
+          "minMs": 1931.574414,
+          "samples": [
+            1931.574414
+          ]
+        },
+        {
+          "id": "zod:ttsc:noEmit:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 3502.451689,
+          "minMs": 3502.451689,
+          "samples": [
+            3502.451689
+          ]
+        },
+        {
+          "id": "zod:ttsc-lint:noEmit:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 4039.764228,
+          "minMs": 4039.764228,
+          "samples": [
+            4039.764228
+          ]
+        },
+        {
+          "id": "zod:ttsc-lint:noEmit:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 5679.182511,
+          "minMs": 5679.182511,
+          "samples": [
+            5679.182511
+          ]
+        }
+      ]
+    },
+    {
+      "name": "nestjs",
+      "repo": "ttsc-benchmark-nestjs",
+      "kind": "backend framework monorepo",
+      "files": 769,
+      "measurements": [
+        {
+          "id": "nestjs:legacy:noEmit:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 10150.567225,
+          "minMs": 10150.567225,
+          "samples": [
+            10150.567225
+          ]
+        },
+        {
+          "id": "nestjs:legacy:eslint:multi",
+          "branch": "legacy",
+          "tool": "eslint",
+          "op": "eslint",
+          "threading": "multi",
+          "medianMs": 4605.687576,
+          "minMs": 4605.687576,
+          "samples": [
+            4605.687576
+          ]
+        },
+        {
+          "id": "nestjs:ttsc:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 3294.15615,
+          "minMs": 3294.15615,
+          "samples": [
+            3294.15615
+          ]
+        },
+        {
+          "id": "nestjs:ttsc:noEmit:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 3738.351467,
+          "minMs": 3738.351467,
+          "samples": [
+            3738.351467
+          ]
+        },
+        {
+          "id": "nestjs:ttsc-lint:noEmit:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 9871.241282,
+          "minMs": 9871.241282,
+          "samples": [
+            9871.241282
+          ]
+        },
+        {
+          "id": "nestjs:ttsc-lint:noEmit:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 10191.437541,
+          "minMs": 10191.437541,
+          "samples": [
+            10191.437541
+          ]
+        }
+      ]
+    },
+    {
+      "name": "vscode",
+      "repo": "ttsc-benchmark-vscode",
+      "kind": "application monorepo",
+      "files": 6093,
+      "measurements": [
+        {
+          "id": "vscode:legacy:noEmit:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 74884.301222,
+          "minMs": 74884.301222,
+          "samples": [
+            74884.301222
+          ]
+        }
+      ]
+    },
+    {
+      "name": "shopping-backend",
+      "repo": "shopping-backend",
+      "kind": "plugin-heavy service",
+      "files": 464,
+      "measurements": []
     }
   ]
 }

--- a/website/public/benchmark.json
+++ b/website/public/benchmark.json
@@ -1,0 +1,65 @@
+{
+  "date": "2026-05-22T02:37:24.167Z",
+  "host": {
+    "os": "Ubuntu 24.04 (WSL2)",
+    "kernel": "6.6.87.2-microsoft-standard-WSL2",
+    "cpu": "AMD Ryzen AI MAX+ 395 w/ Radeon 8060S",
+    "cores": 32,
+    "ramGB": 29,
+    "node": "22.14.0",
+    "ttsc": "0.12.4",
+    "typescript": "7.0.0-dev"
+  },
+  "projects": [
+    {
+      "name": "shopping-backend",
+      "files": 640,
+      "kind": "plugin-heavy",
+      "measurements": [
+        { "branch": "legacy", "tool": "tsc", "op": "build", "threading": "multi", "medianMs": 21872 },
+        { "branch": "ttsc", "tool": "ttsc", "op": "build", "threading": "multi", "medianMs": 8706 },
+        { "branch": "ttsc-lint", "tool": "ttsc", "op": "build", "threading": "multi", "medianMs": 10566 },
+        { "branch": "legacy", "tool": "tsc", "op": "noEmit", "threading": "multi", "medianMs": 17940 },
+        { "branch": "ttsc", "tool": "ttsc", "op": "noEmit", "threading": "multi", "medianMs": 6980 },
+        { "branch": "ttsc", "tool": "ttsc", "op": "build", "threading": "single", "medianMs": 19120 },
+        { "branch": "legacy", "tool": "eslint", "op": "build", "threading": "multi", "medianMs": 5653 },
+        { "branch": "ttsc-lint", "tool": "@ttsc/lint", "op": "build", "threading": "multi", "medianMs": 0 },
+        { "branch": "legacy", "tool": "prettier", "op": "build", "threading": "multi", "medianMs": 3825 },
+        { "branch": "ttsc-lint", "tool": "@ttsc/lint", "op": "format", "threading": "multi", "medianMs": 2141 }
+      ]
+    },
+    {
+      "name": "vscode",
+      "files": 5120,
+      "kind": "type-check-heavy",
+      "measurements": [
+        { "branch": "legacy", "tool": "tsc", "op": "noEmit", "threading": "multi", "medianMs": 49300 },
+        { "branch": "ttsc", "tool": "ttsc", "op": "noEmit", "threading": "multi", "medianMs": 6420 },
+        { "branch": "ttsc", "tool": "ttsc", "op": "noEmit", "threading": "single", "medianMs": 14880 }
+      ]
+    },
+    {
+      "name": "zod",
+      "files": 412,
+      "kind": "type-check-heavy",
+      "measurements": [
+        { "branch": "legacy", "tool": "tsc", "op": "build", "threading": "multi", "medianMs": 9740 },
+        { "branch": "ttsc", "tool": "ttsc", "op": "build", "threading": "multi", "medianMs": 1980 },
+        { "branch": "legacy", "tool": "tsc", "op": "noEmit", "threading": "multi", "medianMs": 8210 },
+        { "branch": "ttsc", "tool": "ttsc", "op": "noEmit", "threading": "multi", "medianMs": 1510 },
+        { "branch": "ttsc", "tool": "ttsc", "op": "noEmit", "threading": "single", "medianMs": 3260 }
+      ]
+    },
+    {
+      "name": "rxjs",
+      "files": 1380,
+      "kind": "library",
+      "measurements": [
+        { "branch": "legacy", "tool": "tsc", "op": "build", "threading": "multi", "medianMs": 12640 },
+        { "branch": "ttsc", "tool": "ttsc", "op": "build", "threading": "multi", "medianMs": 2410 },
+        { "branch": "legacy", "tool": "prettier", "op": "build", "threading": "multi", "medianMs": 6190 },
+        { "branch": "ttsc-lint", "tool": "@ttsc/lint", "op": "format", "threading": "multi", "medianMs": 3050 }
+      ]
+    }
+  ]
+}

--- a/website/public/benchmark.json
+++ b/website/public/benchmark.json
@@ -1,5 +1,5 @@
 {
-  "date": "2026-05-22T14:48:20.880Z",
+  "date": "2026-05-22T14:55:46.969Z",
   "runs": 1,
   "warmup": 1,
   "host": {
@@ -10,7 +10,7 @@
     "ramGB": 29,
     "node": "v24.15.0",
     "ttsc": "0.12.4",
-    "typescript": "5.9.3",
+    "typescript": "4.9.5",
     "tsgo": "7.0.0-dev.20260521.1"
   },
   "projects": [
@@ -486,10 +486,10 @@
           "tool": "tsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 10150.567225,
-          "minMs": 10150.567225,
+          "medianMs": 9222.19666,
+          "minMs": 9222.19666,
           "samples": [
-            10150.567225
+            9222.19666
           ]
         },
         {
@@ -498,10 +498,10 @@
           "tool": "eslint",
           "op": "eslint",
           "threading": "multi",
-          "medianMs": 4605.687576,
-          "minMs": 4605.687576,
+          "medianMs": 4084.403755,
+          "minMs": 4084.403755,
           "samples": [
-            4605.687576
+            4084.403755
           ]
         },
         {
@@ -510,10 +510,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 3294.15615,
-          "minMs": 3294.15615,
+          "medianMs": 3111.752504,
+          "minMs": 3111.752504,
           "samples": [
-            3294.15615
+            3111.752504
           ]
         },
         {
@@ -522,10 +522,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 3738.351467,
-          "minMs": 3738.351467,
+          "medianMs": 3518.531482,
+          "minMs": 3518.531482,
           "samples": [
-            3738.351467
+            3518.531482
           ]
         },
         {
@@ -534,10 +534,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 9871.241282,
-          "minMs": 9871.241282,
+          "medianMs": 8314.64284,
+          "minMs": 8314.64284,
           "samples": [
-            9871.241282
+            8314.64284
           ]
         },
         {
@@ -546,10 +546,34 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 10191.437541,
-          "minMs": 10191.437541,
+          "medianMs": 7855.179858,
+          "minMs": 7855.179858,
           "samples": [
-            10191.437541
+            7855.179858
+          ]
+        },
+        {
+          "id": "nestjs:ttsc:tsgo:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 2998.288691,
+          "minMs": 2998.288691,
+          "samples": [
+            2998.288691
+          ]
+        },
+        {
+          "id": "nestjs:ttsc:tsgo:noEmit:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 3373.145957,
+          "minMs": 3373.145957,
+          "samples": [
+            3373.145957
           ]
         }
       ]

--- a/website/public/benchmark.json
+++ b/website/public/benchmark.json
@@ -1,5 +1,5 @@
 {
-  "date": "2026-05-22T14:55:46.969Z",
+  "date": "2026-05-22T14:58:06.387Z",
   "runs": 1,
   "warmup": 1,
   "host": {
@@ -10,7 +10,7 @@
     "ramGB": 29,
     "node": "v24.15.0",
     "ttsc": "0.12.4",
-    "typescript": "4.9.5",
+    "typescript": "5.6.3",
     "tsgo": "7.0.0-dev.20260521.1"
   },
   "projects": [
@@ -26,10 +26,10 @@
           "tool": "tsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 2194.676845,
-          "minMs": 2194.676845,
+          "medianMs": 1843.315497,
+          "minMs": 1843.315497,
           "samples": [
-            2194.676845
+            1843.315497
           ]
         },
         {
@@ -38,10 +38,10 @@
           "tool": "eslint",
           "op": "eslint",
           "threading": "multi",
-          "medianMs": 3190.37042,
-          "minMs": 3190.37042,
+          "medianMs": 2596.018418,
+          "minMs": 2596.018418,
           "samples": [
-            3190.37042
+            2596.018418
           ]
         },
         {
@@ -50,10 +50,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 580.245355,
-          "minMs": 580.245355,
+          "medianMs": 524.337766,
+          "minMs": 524.337766,
           "samples": [
-            580.245355
+            524.337766
           ]
         },
         {
@@ -62,10 +62,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 833.305461,
-          "minMs": 833.305461,
+          "medianMs": 701.626813,
+          "minMs": 701.626813,
           "samples": [
-            833.305461
+            701.626813
           ]
         },
         {
@@ -110,10 +110,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 2740.373618,
-          "minMs": 2740.373618,
+          "medianMs": 2246.369777,
+          "minMs": 2246.369777,
           "samples": [
-            2740.373618
+            2246.369777
           ]
         },
         {
@@ -122,10 +122,34 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 2973.23513,
-          "minMs": 2973.23513,
+          "medianMs": 2132.185086,
+          "minMs": 2132.185086,
           "samples": [
-            2973.23513
+            2132.185086
+          ]
+        },
+        {
+          "id": "vue:ttsc:tsgo:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 491.353029,
+          "minMs": 491.353029,
+          "samples": [
+            491.353029
+          ]
+        },
+        {
+          "id": "vue:ttsc:tsgo:noEmit:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 672.77235,
+          "minMs": 672.77235,
+          "samples": [
+            672.77235
           ]
         }
       ]

--- a/website/public/benchmark.json
+++ b/website/public/benchmark.json
@@ -1,7 +1,7 @@
 {
-  "date": "2026-05-22T14:58:06.387Z",
+  "date": "2026-05-22T15:21:10.421Z",
   "runs": 1,
-  "warmup": 1,
+  "warmup": 0,
   "host": {
     "os": "Ubuntu 26.04 LTS",
     "kernel": "6.6.87.2-microsoft-standard-WSL2",
@@ -10,8 +10,8 @@
     "ramGB": 29,
     "node": "v24.15.0",
     "ttsc": "0.12.4",
-    "typescript": "5.6.3",
-    "tsgo": "7.0.0-dev.20260521.1"
+    "typescript": "5.9.3",
+    "tsgo": "7.0.0-dev.20260517.1"
   },
   "projects": [
     {
@@ -26,10 +26,10 @@
           "tool": "tsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 1843.315497,
-          "minMs": 1843.315497,
+          "medianMs": 2298.946841,
+          "minMs": 2298.946841,
           "samples": [
-            1843.315497
+            2298.946841
           ]
         },
         {
@@ -38,10 +38,10 @@
           "tool": "eslint",
           "op": "eslint",
           "threading": "multi",
-          "medianMs": 2596.018418,
-          "minMs": 2596.018418,
+          "medianMs": 3405.341904,
+          "minMs": 3405.341904,
           "samples": [
-            2596.018418
+            3405.341904
           ]
         },
         {
@@ -50,10 +50,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 524.337766,
-          "minMs": 524.337766,
+          "medianMs": 798.610709,
+          "minMs": 798.610709,
           "samples": [
-            524.337766
+            798.610709
           ]
         },
         {
@@ -62,10 +62,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 701.626813,
-          "minMs": 701.626813,
+          "medianMs": 1299.615775,
+          "minMs": 1299.615775,
           "samples": [
-            701.626813
+            1299.615775
           ]
         },
         {
@@ -74,10 +74,10 @@
           "tool": "ttsc",
           "op": "build",
           "threading": "multi",
-          "medianMs": 597.697261,
-          "minMs": 597.697261,
+          "medianMs": 2449.224284,
+          "minMs": 2449.224284,
           "samples": [
-            597.697261
+            2449.224284
           ]
         },
         {
@@ -86,10 +86,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "build",
           "threading": "multi",
-          "medianMs": 5238.489438,
-          "minMs": 5238.489438,
+          "medianMs": 3352.107018,
+          "minMs": 3352.107018,
           "samples": [
-            5238.489438
+            3352.107018
           ]
         },
         {
@@ -98,10 +98,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "build",
           "threading": "single",
-          "medianMs": 5895.388094,
-          "minMs": 5895.388094,
+          "medianMs": 3436.578122,
+          "minMs": 3436.578122,
           "samples": [
-            5895.388094
+            3436.578122
           ]
         },
         {
@@ -110,10 +110,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 2246.369777,
-          "minMs": 2246.369777,
+          "medianMs": 2803.141617,
+          "minMs": 2803.141617,
           "samples": [
-            2246.369777
+            2803.141617
           ]
         },
         {
@@ -122,10 +122,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 2132.185086,
-          "minMs": 2132.185086,
+          "medianMs": 2772.844634,
+          "minMs": 2772.844634,
           "samples": [
-            2132.185086
+            2772.844634
           ]
         },
         {
@@ -134,10 +134,10 @@
           "tool": "tsgo",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 491.353029,
-          "minMs": 491.353029,
+          "medianMs": 781.850788,
+          "minMs": 781.850788,
           "samples": [
-            491.353029
+            781.850788
           ]
         },
         {
@@ -146,10 +146,58 @@
           "tool": "tsgo",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 672.77235,
-          "minMs": 672.77235,
+          "medianMs": 1093.148929,
+          "minMs": 1093.148929,
           "samples": [
-            672.77235
+            1093.148929
+          ]
+        },
+        {
+          "id": "vue:legacy:build:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 2322.038882,
+          "minMs": 2322.038882,
+          "samples": [
+            2322.038882
+          ]
+        },
+        {
+          "id": "vue:ttsc:build:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 989.907254,
+          "minMs": 989.907254,
+          "samples": [
+            989.907254
+          ]
+        },
+        {
+          "id": "vue:ttsc:tsgo:build:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 855.167938,
+          "minMs": 855.167938,
+          "samples": [
+            855.167938
+          ]
+        },
+        {
+          "id": "vue:ttsc:tsgo:build:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 971.0131,
+          "minMs": 971.0131,
+          "samples": [
+            971.0131
           ]
         }
       ]
@@ -166,10 +214,10 @@
           "tool": "tsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 4932.992989,
-          "minMs": 4932.992989,
+          "medianMs": 4761.083382,
+          "minMs": 4761.083382,
           "samples": [
-            4932.992989
+            4761.083382
           ]
         },
         {
@@ -178,10 +226,10 @@
           "tool": "eslint",
           "op": "eslint",
           "threading": "multi",
-          "medianMs": 3749.130811,
-          "minMs": 3749.130811,
+          "medianMs": 4635.828555,
+          "minMs": 4635.828555,
           "samples": [
-            3749.130811
+            4635.828555
           ]
         },
         {
@@ -190,10 +238,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 1368.689028,
-          "minMs": 1368.689028,
+          "medianMs": 1365.830497,
+          "minMs": 1365.830497,
           "samples": [
-            1368.689028
+            1365.830497
           ]
         },
         {
@@ -202,10 +250,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 1360.757227,
-          "minMs": 1360.757227,
+          "medianMs": 1502.210582,
+          "minMs": 1502.210582,
           "samples": [
-            1360.757227
+            1502.210582
           ]
         },
         {
@@ -214,10 +262,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 3387.937016,
-          "minMs": 3387.937016,
+          "medianMs": 2840.242492,
+          "minMs": 2840.242492,
           "samples": [
-            3387.937016
+            2840.242492
           ]
         },
         {
@@ -226,10 +274,118 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 3511.746757,
-          "minMs": 3511.746757,
+          "medianMs": 2864.295609,
+          "minMs": 2864.295609,
           "samples": [
-            3511.746757
+            2864.295609
+          ]
+        },
+        {
+          "id": "rxjs:legacy:build:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 5136.164078,
+          "minMs": 5136.164078,
+          "samples": [
+            5136.164078
+          ]
+        },
+        {
+          "id": "rxjs:ttsc:build:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 1710.795995,
+          "minMs": 1710.795995,
+          "samples": [
+            1710.795995
+          ]
+        },
+        {
+          "id": "rxjs:ttsc:build:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 1510.358603,
+          "minMs": 1510.358603,
+          "samples": [
+            1510.358603
+          ]
+        },
+        {
+          "id": "rxjs:ttsc:tsgo:build:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 1415.833749,
+          "minMs": 1415.833749,
+          "samples": [
+            1415.833749
+          ]
+        },
+        {
+          "id": "rxjs:ttsc:tsgo:build:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 1481.311569,
+          "minMs": 1481.311569,
+          "samples": [
+            1481.311569
+          ]
+        },
+        {
+          "id": "rxjs:ttsc:tsgo:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 1296.743017,
+          "minMs": 1296.743017,
+          "samples": [
+            1296.743017
+          ]
+        },
+        {
+          "id": "rxjs:ttsc:tsgo:noEmit:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 1447.947243,
+          "minMs": 1447.947243,
+          "samples": [
+            1447.947243
+          ]
+        },
+        {
+          "id": "rxjs:ttsc-lint:build:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 3152.296114,
+          "minMs": 3152.296114,
+          "samples": [
+            3152.296114
+          ]
+        },
+        {
+          "id": "rxjs:ttsc-lint:build:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 3169.933042,
+          "minMs": 3169.933042,
+          "samples": [
+            3169.933042
           ]
         }
       ]
@@ -246,10 +402,10 @@
           "tool": "tsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 37803.194082,
-          "minMs": 37803.194082,
+          "medianMs": 41702.151076,
+          "minMs": 41702.151076,
           "samples": [
-            37803.194082
+            41702.151076
           ]
         },
         {
@@ -258,10 +414,10 @@
           "tool": "eslint",
           "op": "eslint",
           "threading": "multi",
-          "medianMs": 2410.961337,
-          "minMs": 2410.961337,
+          "medianMs": 2635.629178,
+          "minMs": 2635.629178,
           "samples": [
-            2410.961337
+            2635.629178
           ]
         },
         {
@@ -270,10 +426,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 18084.22731,
-          "minMs": 18084.22731,
+          "medianMs": 15788.697771,
+          "minMs": 15788.697771,
           "samples": [
-            18084.22731
+            15788.697771
           ]
         },
         {
@@ -282,10 +438,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 25913.081729,
-          "minMs": 25913.081729,
+          "medianMs": 23188.874709,
+          "minMs": 23188.874709,
           "samples": [
-            25913.081729
+            23188.874709
           ]
         },
         {
@@ -294,10 +450,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 18562.148635,
-          "minMs": 18562.148635,
+          "medianMs": 15491.524347,
+          "minMs": 15491.524347,
           "samples": [
-            18562.148635
+            15491.524347
           ]
         },
         {
@@ -306,10 +462,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 21559.02311,
-          "minMs": 21559.02311,
+          "medianMs": 15220.332642,
+          "minMs": 15220.332642,
           "samples": [
-            21559.02311
+            15220.332642
           ]
         },
         {
@@ -318,10 +474,10 @@
           "tool": "tsgo",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 17081.863515,
-          "minMs": 17081.863515,
+          "medianMs": 15550.147274,
+          "minMs": 15550.147274,
           "samples": [
-            17081.863515
+            15550.147274
           ]
         },
         {
@@ -330,10 +486,94 @@
           "tool": "tsgo",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 24959.12851,
-          "minMs": 24959.12851,
+          "medianMs": 22607.481073,
+          "minMs": 22607.481073,
           "samples": [
-            24959.12851
+            22607.481073
+          ]
+        },
+        {
+          "id": "type-fest:legacy:build:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 37225.356167,
+          "minMs": 37225.356167,
+          "samples": [
+            37225.356167
+          ]
+        },
+        {
+          "id": "type-fest:ttsc:build:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 16760.72912,
+          "minMs": 16760.72912,
+          "samples": [
+            16760.72912
+          ]
+        },
+        {
+          "id": "type-fest:ttsc:build:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 23914.603681,
+          "minMs": 23914.603681,
+          "samples": [
+            23914.603681
+          ]
+        },
+        {
+          "id": "type-fest:ttsc:tsgo:build:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 15803.660725,
+          "minMs": 15803.660725,
+          "samples": [
+            15803.660725
+          ]
+        },
+        {
+          "id": "type-fest:ttsc:tsgo:build:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 23914.179154,
+          "minMs": 23914.179154,
+          "samples": [
+            23914.179154
+          ]
+        },
+        {
+          "id": "type-fest:ttsc-lint:build:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 15706.616977,
+          "minMs": 15706.616977,
+          "samples": [
+            15706.616977
+          ]
+        },
+        {
+          "id": "type-fest:ttsc-lint:build:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 16016.993428,
+          "minMs": 16016.993428,
+          "samples": [
+            16016.993428
           ]
         }
       ]
@@ -350,10 +590,10 @@
           "tool": "tsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 9969.208651,
-          "minMs": 9969.208651,
+          "medianMs": 9858.688205,
+          "minMs": 9858.688205,
           "samples": [
-            9969.208651
+            9858.688205
           ]
         },
         {
@@ -362,10 +602,10 @@
           "tool": "eslint",
           "op": "eslint",
           "threading": "multi",
-          "medianMs": 31880.117892,
-          "minMs": 31880.117892,
+          "medianMs": 29057.624746,
+          "minMs": 29057.624746,
           "samples": [
-            31880.117892
+            29057.624746
           ]
         },
         {
@@ -374,10 +614,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 1501.239534,
-          "minMs": 1501.239534,
+          "medianMs": 1674.511367,
+          "minMs": 1674.511367,
           "samples": [
-            1501.239534
+            1674.511367
           ]
         },
         {
@@ -386,10 +626,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 3208.549564,
-          "minMs": 3208.549564,
+          "medianMs": 3103.185399,
+          "minMs": 3103.185399,
           "samples": [
-            3208.549564
+            3103.185399
           ]
         },
         {
@@ -398,10 +638,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 3617.095802,
-          "minMs": 3617.095802,
+          "medianMs": 2255.3101,
+          "minMs": 2255.3101,
           "samples": [
-            3617.095802
+            2255.3101
           ]
         },
         {
@@ -410,10 +650,118 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 5209.568986,
-          "minMs": 5209.568986,
+          "medianMs": 2218.197717,
+          "minMs": 2218.197717,
           "samples": [
-            5209.568986
+            2218.197717
+          ]
+        },
+        {
+          "id": "typeorm:legacy:build:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 15032.949771,
+          "minMs": 15032.949771,
+          "samples": [
+            15032.949771
+          ]
+        },
+        {
+          "id": "typeorm:ttsc:build:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 2154.351451,
+          "minMs": 2154.351451,
+          "samples": [
+            2154.351451
+          ]
+        },
+        {
+          "id": "typeorm:ttsc:build:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 5217.478444,
+          "minMs": 5217.478444,
+          "samples": [
+            5217.478444
+          ]
+        },
+        {
+          "id": "typeorm:ttsc:tsgo:build:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 2077.806276,
+          "minMs": 2077.806276,
+          "samples": [
+            2077.806276
+          ]
+        },
+        {
+          "id": "typeorm:ttsc:tsgo:build:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 5255.536311,
+          "minMs": 5255.536311,
+          "samples": [
+            5255.536311
+          ]
+        },
+        {
+          "id": "typeorm:ttsc:tsgo:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 1527.097177,
+          "minMs": 1527.097177,
+          "samples": [
+            1527.097177
+          ]
+        },
+        {
+          "id": "typeorm:ttsc:tsgo:noEmit:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 2946.149271,
+          "minMs": 2946.149271,
+          "samples": [
+            2946.149271
+          ]
+        },
+        {
+          "id": "typeorm:ttsc-lint:build:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 4035.215668,
+          "minMs": 4035.215668,
+          "samples": [
+            4035.215668
+          ]
+        },
+        {
+          "id": "typeorm:ttsc-lint:build:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 6930.836961,
+          "minMs": 6930.836961,
+          "samples": [
+            6930.836961
           ]
         }
       ]
@@ -430,10 +778,10 @@
           "tool": "tsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 8461.672422,
-          "minMs": 8461.672422,
+          "medianMs": 8110.477452,
+          "minMs": 8110.477452,
           "samples": [
-            8461.672422
+            8110.477452
           ]
         },
         {
@@ -442,10 +790,10 @@
           "tool": "eslint",
           "op": "eslint",
           "threading": "multi",
-          "medianMs": 2518.052058,
-          "minMs": 2518.052058,
+          "medianMs": 2624.807856,
+          "minMs": 2624.807856,
           "samples": [
-            2518.052058
+            2624.807856
           ]
         },
         {
@@ -454,10 +802,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 1931.574414,
-          "minMs": 1931.574414,
+          "medianMs": 1833.219415,
+          "minMs": 1833.219415,
           "samples": [
-            1931.574414
+            1833.219415
           ]
         },
         {
@@ -466,10 +814,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 3502.451689,
-          "minMs": 3502.451689,
+          "medianMs": 3314.579913,
+          "minMs": 3314.579913,
           "samples": [
-            3502.451689
+            3314.579913
           ]
         },
         {
@@ -478,10 +826,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 4039.764228,
-          "minMs": 4039.764228,
+          "medianMs": 2311.343636,
+          "minMs": 2311.343636,
           "samples": [
-            4039.764228
+            2311.343636
           ]
         },
         {
@@ -490,10 +838,118 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 5679.182511,
-          "minMs": 5679.182511,
+          "medianMs": 2305.447633,
+          "minMs": 2305.447633,
           "samples": [
-            5679.182511
+            2305.447633
+          ]
+        },
+        {
+          "id": "zod:legacy:build:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 4024.325924,
+          "minMs": 4024.325924,
+          "samples": [
+            4024.325924
+          ]
+        },
+        {
+          "id": "zod:ttsc:build:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 1125.358733,
+          "minMs": 1125.358733,
+          "samples": [
+            1125.358733
+          ]
+        },
+        {
+          "id": "zod:ttsc:build:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 1363.684508,
+          "minMs": 1363.684508,
+          "samples": [
+            1363.684508
+          ]
+        },
+        {
+          "id": "zod:ttsc:tsgo:build:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 1138.877824,
+          "minMs": 1138.877824,
+          "samples": [
+            1138.877824
+          ]
+        },
+        {
+          "id": "zod:ttsc:tsgo:build:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 1353.37376,
+          "minMs": 1353.37376,
+          "samples": [
+            1353.37376
+          ]
+        },
+        {
+          "id": "zod:ttsc:tsgo:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 1876.659816,
+          "minMs": 1876.659816,
+          "samples": [
+            1876.659816
+          ]
+        },
+        {
+          "id": "zod:ttsc:tsgo:noEmit:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 3275.34676,
+          "minMs": 3275.34676,
+          "samples": [
+            3275.34676
+          ]
+        },
+        {
+          "id": "zod:ttsc-lint:build:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 2322.002883,
+          "minMs": 2322.002883,
+          "samples": [
+            2322.002883
+          ]
+        },
+        {
+          "id": "zod:ttsc-lint:build:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 2501.546053,
+          "minMs": 2501.546053,
+          "samples": [
+            2501.546053
           ]
         }
       ]
@@ -510,10 +966,10 @@
           "tool": "tsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 9222.19666,
-          "minMs": 9222.19666,
+          "medianMs": 9377.261633,
+          "minMs": 9377.261633,
           "samples": [
-            9222.19666
+            9377.261633
           ]
         },
         {
@@ -522,10 +978,10 @@
           "tool": "eslint",
           "op": "eslint",
           "threading": "multi",
-          "medianMs": 4084.403755,
-          "minMs": 4084.403755,
+          "medianMs": 4537.33485,
+          "minMs": 4537.33485,
           "samples": [
-            4084.403755
+            4537.33485
           ]
         },
         {
@@ -534,10 +990,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 3111.752504,
-          "minMs": 3111.752504,
+          "medianMs": 3235.398588,
+          "minMs": 3235.398588,
           "samples": [
-            3111.752504
+            3235.398588
           ]
         },
         {
@@ -546,10 +1002,10 @@
           "tool": "ttsc",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 3518.531482,
-          "minMs": 3518.531482,
+          "medianMs": 3639.36435,
+          "minMs": 3639.36435,
           "samples": [
-            3518.531482
+            3639.36435
           ]
         },
         {
@@ -558,10 +1014,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 8314.64284,
-          "minMs": 8314.64284,
+          "medianMs": 7648.673007,
+          "minMs": 7648.673007,
           "samples": [
-            8314.64284
+            7648.673007
           ]
         },
         {
@@ -570,10 +1026,10 @@
           "tool": "ttsc+@ttsc/lint",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 7855.179858,
-          "minMs": 7855.179858,
+          "medianMs": 7856.08761,
+          "minMs": 7856.08761,
           "samples": [
-            7855.179858
+            7856.08761
           ]
         },
         {
@@ -582,10 +1038,10 @@
           "tool": "tsgo",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 2998.288691,
-          "minMs": 2998.288691,
+          "medianMs": 3063.717059,
+          "minMs": 3063.717059,
           "samples": [
-            2998.288691
+            3063.717059
           ]
         },
         {
@@ -594,10 +1050,94 @@
           "tool": "tsgo",
           "op": "noEmit",
           "threading": "single",
-          "medianMs": 3373.145957,
-          "minMs": 3373.145957,
+          "medianMs": 3371.86172,
+          "minMs": 3371.86172,
           "samples": [
-            3373.145957
+            3371.86172
+          ]
+        },
+        {
+          "id": "nestjs:legacy:build:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 9420.359008,
+          "minMs": 9420.359008,
+          "samples": [
+            9420.359008
+          ]
+        },
+        {
+          "id": "nestjs:ttsc:build:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 3736.892297,
+          "minMs": 3736.892297,
+          "samples": [
+            3736.892297
+          ]
+        },
+        {
+          "id": "nestjs:ttsc:build:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 3657.732823,
+          "minMs": 3657.732823,
+          "samples": [
+            3657.732823
+          ]
+        },
+        {
+          "id": "nestjs:ttsc:tsgo:build:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 3418.97539,
+          "minMs": 3418.97539,
+          "samples": [
+            3418.97539
+          ]
+        },
+        {
+          "id": "nestjs:ttsc:tsgo:build:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 3405.703306,
+          "minMs": 3405.703306,
+          "samples": [
+            3405.703306
+          ]
+        },
+        {
+          "id": "nestjs:ttsc-lint:build:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 8716.525839,
+          "minMs": 8716.525839,
+          "samples": [
+            8716.525839
+          ]
+        },
+        {
+          "id": "nestjs:ttsc-lint:build:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 9032.266583,
+          "minMs": 9032.266583,
+          "samples": [
+            9032.266583
           ]
         }
       ]
@@ -614,10 +1154,178 @@
           "tool": "tsc",
           "op": "noEmit",
           "threading": "multi",
-          "medianMs": 74884.301222,
-          "minMs": 74884.301222,
+          "medianMs": 63097.462541,
+          "minMs": 63097.462541,
           "samples": [
-            74884.301222
+            63097.462541
+          ]
+        },
+        {
+          "id": "vscode:legacy:build:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 83197.722621,
+          "minMs": 83197.722621,
+          "samples": [
+            83197.722621
+          ]
+        },
+        {
+          "id": "vscode:legacy:eslint:multi",
+          "branch": "legacy",
+          "tool": "eslint",
+          "op": "eslint",
+          "threading": "multi",
+          "medianMs": 55866.262047,
+          "minMs": 55866.262047,
+          "samples": [
+            55866.262047
+          ]
+        },
+        {
+          "id": "vscode:ttsc:build:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 12043.640053,
+          "minMs": 12043.640053,
+          "samples": [
+            12043.640053
+          ]
+        },
+        {
+          "id": "vscode:ttsc:build:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 33263.227884,
+          "minMs": 33263.227884,
+          "samples": [
+            33263.227884
+          ]
+        },
+        {
+          "id": "vscode:ttsc:tsgo:build:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 12170.608169,
+          "minMs": 12170.608169,
+          "samples": [
+            12170.608169
+          ]
+        },
+        {
+          "id": "vscode:ttsc:tsgo:build:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 33280.402559,
+          "minMs": 33280.402559,
+          "samples": [
+            33280.402559
+          ]
+        },
+        {
+          "id": "vscode:ttsc:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 9724.313852,
+          "minMs": 9724.313852,
+          "samples": [
+            9724.313852
+          ]
+        },
+        {
+          "id": "vscode:ttsc:noEmit:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 24530.228006,
+          "minMs": 24530.228006,
+          "samples": [
+            24530.228006
+          ]
+        },
+        {
+          "id": "vscode:ttsc:tsgo:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 8947.94903,
+          "minMs": 8947.94903,
+          "samples": [
+            8947.94903
+          ]
+        },
+        {
+          "id": "vscode:ttsc:tsgo:noEmit:single",
+          "branch": "ttsc",
+          "tool": "tsgo",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 24257.613282,
+          "minMs": 24257.613282,
+          "samples": [
+            24257.613282
+          ]
+        },
+        {
+          "id": "vscode:ttsc-lint:build:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 21924.843718,
+          "minMs": 21924.843718,
+          "samples": [
+            21924.843718
+          ]
+        },
+        {
+          "id": "vscode:ttsc-lint:build:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 43230.26633,
+          "minMs": 43230.26633,
+          "samples": [
+            43230.26633
+          ]
+        },
+        {
+          "id": "vscode:ttsc-lint:noEmit:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 10185.542261,
+          "minMs": 10185.542261,
+          "samples": [
+            10185.542261
+          ]
+        },
+        {
+          "id": "vscode:ttsc-lint:noEmit:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 10325.769738,
+          "minMs": 10325.769738,
+          "samples": [
+            10325.769738
           ]
         }
       ]
@@ -627,7 +1335,140 @@
       "repo": "shopping-backend",
       "kind": "plugin-heavy service",
       "files": 464,
-      "measurements": []
+      "measurements": [
+        {
+          "id": "shopping-backend:legacy:build:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 17690.538382,
+          "minMs": 17690.538382,
+          "samples": [
+            17690.538382
+          ]
+        },
+        {
+          "id": "shopping-backend:legacy:noEmit:multi",
+          "branch": "legacy",
+          "tool": "tsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 4805.655518,
+          "minMs": 4805.655518,
+          "samples": [
+            4805.655518
+          ]
+        },
+        {
+          "id": "shopping-backend:legacy:eslint:multi",
+          "branch": "legacy",
+          "tool": "eslint",
+          "op": "eslint",
+          "threading": "multi",
+          "medianMs": 5446.58965,
+          "minMs": 5446.58965,
+          "samples": [
+            5446.58965
+          ]
+        },
+        {
+          "id": "shopping-backend:ttsc:build:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 6765.884452,
+          "minMs": 6765.884452,
+          "samples": [
+            6765.884452
+          ]
+        },
+        {
+          "id": "shopping-backend:ttsc:build:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 6806.472331,
+          "minMs": 6806.472331,
+          "samples": [
+            6806.472331
+          ]
+        },
+        {
+          "id": "shopping-backend:ttsc:noEmit:multi",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 1688.923152,
+          "minMs": 1688.923152,
+          "samples": [
+            1688.923152
+          ]
+        },
+        {
+          "id": "shopping-backend:ttsc:noEmit:single",
+          "branch": "ttsc",
+          "tool": "ttsc",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 1657.179232,
+          "minMs": 1657.179232,
+          "samples": [
+            1657.179232
+          ]
+        },
+        {
+          "id": "shopping-backend:ttsc-lint:build:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "multi",
+          "medianMs": 7807.028905,
+          "minMs": 7807.028905,
+          "samples": [
+            7807.028905
+          ]
+        },
+        {
+          "id": "shopping-backend:ttsc-lint:build:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "build",
+          "threading": "single",
+          "medianMs": 7840.566507,
+          "minMs": 7840.566507,
+          "samples": [
+            7840.566507
+          ]
+        },
+        {
+          "id": "shopping-backend:ttsc-lint:noEmit:multi",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "multi",
+          "medianMs": 2833.840918,
+          "minMs": 2833.840918,
+          "samples": [
+            2833.840918
+          ]
+        },
+        {
+          "id": "shopping-backend:ttsc-lint:noEmit:single",
+          "branch": "ttsc-lint",
+          "tool": "ttsc+@ttsc/lint",
+          "op": "noEmit",
+          "threading": "single",
+          "medianMs": 2801.271896,
+          "minMs": 2801.271896,
+          "samples": [
+            2801.271896
+          ]
+        }
+      ]
     }
   ]
 }

--- a/website/src/components/benchmark/BenchmarkDashboard.tsx
+++ b/website/src/components/benchmark/BenchmarkDashboard.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { deriveSpeedups, formatMultiplier, headlineSpeedup } from "./format";
+import HostPanel from "./HostPanel";
+import ProjectCard from "./ProjectCard";
+import type { BenchmarkReport } from "./types";
+
+/**
+ * Loads `public/benchmark.json` and renders the full benchmark dashboard.
+ *
+ * Embedded from the benchmark MDX page. Data is fetched at runtime (not
+ * bundled) so the benchmark runner can refresh the numbers without a website
+ * rebuild. Renders graceful loading / error states and tolerates projects
+ * that carry only a partial measurement set.
+ */
+export default function BenchmarkDashboard() {
+  const [report, setReport] = useState<BenchmarkReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/benchmark.json")
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<BenchmarkReport>;
+      })
+      .then((data) => {
+        if (!cancelled) setReport(data);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled)
+          setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error)
+    return (
+      <p className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 px-5 py-4 font-mono text-[12px] text-neutral-500 dark:border-neutral-800 dark:bg-neutral-900/60">
+        Could not load benchmark data ({error}).
+      </p>
+    );
+
+  if (!report)
+    return (
+      <p className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 px-5 py-4 font-mono text-[12px] text-neutral-500 dark:border-neutral-800 dark:bg-neutral-900/60">
+        Loading benchmark results…
+      </p>
+    );
+
+  return (
+    <div className="not-prose">
+      <Headline report={report} />
+      <HostPanel host={report.host} date={report.date} />
+      <div className="my-8 grid gap-5 lg:grid-cols-2">
+        {report.projects.map((project) => (
+          <ProjectCard key={project.name} project={project} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Hero strip: the single biggest multiplier the whole dataset supports,
+ * plus the fixture and project counts behind it.
+ */
+function Headline({ report }: { report: BenchmarkReport }) {
+  const best = report.projects
+    .map((project) => ({
+      project,
+      speedup: headlineSpeedup(deriveSpeedups(project.measurements)),
+    }))
+    .reduce<{ name: string; factor: number; label: string } | null>(
+      (acc, entry) => {
+        if (!entry.speedup) return acc;
+        if (acc && entry.speedup.factor <= acc.factor) return acc;
+        return {
+          name: entry.project.name,
+          factor: entry.speedup.factor,
+          label: entry.speedup.label,
+        };
+      },
+      null,
+    );
+
+  const totalMeasurements = report.projects.reduce(
+    (sum, project) => sum + project.measurements.length,
+    0,
+  );
+
+  return (
+    <section className="my-8 overflow-hidden rounded-xl border border-cyan-300/40 bg-gradient-to-br from-cyan-50 to-white dark:border-cyan-300/25 dark:from-cyan-950/40 dark:to-neutral-950">
+      <div className="grid gap-6 px-6 py-7 sm:grid-cols-[auto_1px_1fr] sm:items-center sm:gap-8">
+        <div>
+          <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-cyan-600 dark:text-cyan-300">
+            Peak speedup
+          </p>
+          <p className="mt-1 font-mono text-6xl font-black leading-none text-cyan-600 dark:text-cyan-300">
+            {best ? formatMultiplier(best.factor) : "—"}
+          </p>
+          {best ? (
+            <p className="mt-2 font-mono text-[11px] text-neutral-500">
+              {best.label.toLowerCase()} · {best.name}
+            </p>
+          ) : null}
+        </div>
+        <div className="hidden bg-cyan-300/30 sm:block dark:bg-cyan-300/15" />
+        <div>
+          <p className="text-base font-semibold text-neutral-900 dark:text-neutral-100">
+            ttsc replaces the whole TypeScript toolchain — and runs it faster.
+          </p>
+          <p className="mt-2 text-sm leading-relaxed text-neutral-600 dark:text-neutral-400">
+            Wall-clock medians across {report.projects.length} real
+            open-source codebases — {totalMeasurements} measurements pairing{" "}
+            <code className="font-mono text-neutral-700 dark:text-neutral-300">
+              tsc
+            </code>
+            ,{" "}
+            <code className="font-mono text-neutral-700 dark:text-neutral-300">
+              eslint
+            </code>
+            , and{" "}
+            <code className="font-mono text-neutral-700 dark:text-neutral-300">
+              prettier
+            </code>{" "}
+            against{" "}
+            <code className="font-mono text-neutral-700 dark:text-neutral-300">
+              ttsc
+            </code>{" "}
+            and{" "}
+            <code className="font-mono text-neutral-700 dark:text-neutral-300">
+              @ttsc/lint
+            </code>
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/benchmark/BenchmarkDashboard.tsx
+++ b/website/src/components/benchmark/BenchmarkDashboard.tsx
@@ -316,7 +316,7 @@ function ProjectOperationRows({
           <DurationBar
             key={`${project.name}:${op}:${row.label}`}
             label={row.label}
-            measurement={row.measurement}
+            ms={row.measurement.medianMs}
             maxMs={maxMs}
             color={row.color}
             ratio={
@@ -459,22 +459,20 @@ function ProjectLabel({
 
 function DurationBar({
   label,
-  measurement,
+  ms,
   maxMs,
   color,
   ratio,
   baseline,
 }: {
   label: string;
-  measurement: BenchmarkMeasurement;
+  ms: number;
   maxMs: number;
   color: string;
   ratio: string;
   baseline?: boolean;
 }) {
-  const ms = measurement.medianMs;
   const widthPct = Math.max(4, (ms / maxMs) * 100);
-  const stats = sampleStats(measurement);
 
   return (
     <div className="py-1.5">
@@ -500,7 +498,6 @@ function DurationBar({
         <div
           className={`h-full rounded ${color}`}
           style={{ width: `${widthPct}%` }}
-          title={stats}
         />
       </div>
     </div>
@@ -522,10 +519,9 @@ function StackedDurationBar({
   ratio?: string;
   lintRatio?: LintRatioParts;
   baseline?: boolean;
-  segments: LintSegment[];
+  segments: { label: string; ms: number; color: string }[];
 }) {
   const widthPct = Math.max(4, (totalMs / maxMs) * 100);
-  const stats = segmentStats(segments);
 
   return (
     <div className="py-1.5">
@@ -563,7 +559,6 @@ function StackedDurationBar({
         <div
           className="flex h-full overflow-hidden rounded"
           style={{ width: `${widthPct}%` }}
-          title={stats}
         >
           {segments.map((segment) => {
             const segmentPct =
@@ -575,9 +570,6 @@ function StackedDurationBar({
                 key={segment.label}
                 className={`h-full ${segment.color}`}
                 style={{ width: `${segmentPct}%` }}
-                title={`${segment.label}: ${formatDuration(segment.ms)}${
-                  segment.detail ? `\n${segment.detail}` : ""
-                }`}
               />
             );
           })}
@@ -624,7 +616,6 @@ interface LintSegment {
   label: string;
   ms: number;
   color: string;
-  detail?: string;
 }
 
 interface LintRow {
@@ -729,18 +720,8 @@ function lintRowsForProject(
       baseline: true,
       eslintMs: eslint.medianMs,
       segments: [
-        {
-          label: "tsc",
-          ms: tsc.medianMs,
-          color: "bg-neutral-500",
-          detail: sampleStats(tsc),
-        },
-        {
-          label: "ESLint",
-          ms: eslint.medianMs,
-          color: "bg-amber-500",
-          detail: sampleStats(eslint),
-        },
+        { label: "tsc", ms: tsc.medianMs, color: "bg-neutral-500" },
+        { label: "ESLint", ms: eslint.medianMs, color: "bg-amber-500" },
       ],
     });
 
@@ -772,17 +753,11 @@ function lintRowsForProject(
           ? eslint.medianMs / lintOverheadMs
           : undefined,
       segments: [
-        {
-          label: "ttsc",
-          ms: ttscMs,
-          color: "bg-cyan-500",
-          detail: sampleStats(plainTtsc),
-        },
+        { label: "ttsc", ms: ttscMs, color: "bg-cyan-500" },
         {
           label: "@ttsc/lint",
           ms: lintOverheadMs,
           color: "bg-emerald-400",
-          detail: overheadStats(total, plainTtsc),
         },
       ].filter((segment) => segment.ms > 0),
     });
@@ -954,53 +929,4 @@ function formatDate(value: string) {
     month: "short",
     day: "numeric",
   });
-}
-
-function sampleStats(measurement: BenchmarkMeasurement) {
-  const samples = measurement.samples?.filter((sample) => sample > 0) ?? [];
-  const min = measurement.minMs ?? (samples.length ? Math.min(...samples) : 0);
-  const max = samples.length ? Math.max(...samples) : measurement.medianMs;
-  const average = samples.length
-    ? samples.reduce((sum, sample) => sum + sample, 0) / samples.length
-    : measurement.medianMs;
-  const lines = [
-    `median ${formatDuration(measurement.medianMs)} / avg ${formatDuration(
-      average,
-    )} / min ${formatDuration(min)} / max ${formatDuration(max)}`,
-  ];
-  if (samples.length)
-    lines.push(samples.map((sample) => formatDuration(sample)).join(", "));
-  return lines.join("\n");
-}
-
-function overheadStats(
-  total: BenchmarkMeasurement,
-  base: BenchmarkMeasurement,
-) {
-  const totalSamples = total.samples ?? [];
-  const baseSamples = base.samples ?? [];
-  const length = Math.min(totalSamples.length, baseSamples.length);
-  if (length === 0) return sampleStats(total);
-  const samples = Array.from({ length }, (_, i) =>
-    Math.max(0, totalSamples[i] - baseSamples[i]),
-  );
-  return sampleStats({
-    ...total,
-    medianMs: median(samples),
-    minMs: Math.min(...samples),
-    samples,
-  });
-}
-
-function segmentStats(segments: LintSegment[]) {
-  const details = segments
-    .filter((segment) => segment.detail)
-    .map((segment) => `${segment.label}: ${segment.detail}`);
-  return details.join("\n");
-}
-
-function median(values: number[]) {
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = sorted.length >> 1;
-  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }

--- a/website/src/components/benchmark/BenchmarkDashboard.tsx
+++ b/website/src/components/benchmark/BenchmarkDashboard.tsx
@@ -206,7 +206,7 @@ function Snapshot({ report }: { report: BenchmarkReport }) {
 function SummaryTab({ report }: { report: BenchmarkReport }) {
   const build = bestOperationProject(report, "build");
   const check = bestOperationProject(report, "noEmit");
-  const lint = bestLintProject(report, "build");
+  const lint = bestLintProject(report, "noEmit");
 
   return (
     <div className="space-y-4">
@@ -235,8 +235,8 @@ function SummaryTab({ report }: { report: BenchmarkReport }) {
           {lint ? (
             <ProjectLintRows
               project={lint.project}
-              op="build"
-              title="Build + lint"
+              op="noEmit"
+              title="Type-check + lint"
             />
           ) : null}
         </div>
@@ -316,7 +316,7 @@ function ProjectOperationRows({
           <DurationBar
             key={`${project.name}:${op}:${row.label}`}
             label={row.label}
-            ms={row.measurement.medianMs}
+            measurement={row.measurement}
             maxMs={maxMs}
             color={row.color}
             ratio={
@@ -336,15 +336,15 @@ function ProjectOperationRows({
 
 function LintTab({ report }: { report: BenchmarkReport }) {
   const projects = report.projects.filter((project) =>
-    hasComparableLint(project, "build"),
+    hasComparableLint(project, "noEmit"),
   );
 
   return (
     <LintMatrix
       title="Lint Tool Matrix"
-      description="Legacy stacks tsc plus ESLint; ttsc-lint stacks plain ttsc plus the @ttsc/lint overhead."
+      description="Legacy stacks tsc --noEmit plus ESLint; ttsc-lint stacks ttsc --noEmit plus the @ttsc/lint overhead."
       projects={projects}
-      op="build"
+      op="noEmit"
     />
   );
 }
@@ -459,20 +459,22 @@ function ProjectLabel({
 
 function DurationBar({
   label,
-  ms,
+  measurement,
   maxMs,
   color,
   ratio,
   baseline,
 }: {
   label: string;
-  ms: number;
+  measurement: BenchmarkMeasurement;
   maxMs: number;
   color: string;
   ratio: string;
   baseline?: boolean;
 }) {
+  const ms = measurement.medianMs;
   const widthPct = Math.max(4, (ms / maxMs) * 100);
+  const stats = sampleStats(measurement);
 
   return (
     <div className="py-1.5">
@@ -498,6 +500,7 @@ function DurationBar({
         <div
           className={`h-full rounded ${color}`}
           style={{ width: `${widthPct}%` }}
+          title={stats}
         />
       </div>
     </div>
@@ -519,9 +522,10 @@ function StackedDurationBar({
   ratio?: string;
   lintRatio?: LintRatioParts;
   baseline?: boolean;
-  segments: { label: string; ms: number; color: string }[];
+  segments: LintSegment[];
 }) {
   const widthPct = Math.max(4, (totalMs / maxMs) * 100);
+  const stats = segmentStats(segments);
 
   return (
     <div className="py-1.5">
@@ -559,6 +563,7 @@ function StackedDurationBar({
         <div
           className="flex h-full overflow-hidden rounded"
           style={{ width: `${widthPct}%` }}
+          title={stats}
         >
           {segments.map((segment) => {
             const segmentPct =
@@ -570,7 +575,9 @@ function StackedDurationBar({
                 key={segment.label}
                 className={`h-full ${segment.color}`}
                 style={{ width: `${segmentPct}%` }}
-                title={`${segment.label}: ${formatDuration(segment.ms)}`}
+                title={`${segment.label}: ${formatDuration(segment.ms)}${
+                  segment.detail ? `\n${segment.detail}` : ""
+                }`}
               />
             );
           })}
@@ -617,6 +624,7 @@ interface LintSegment {
   label: string;
   ms: number;
   color: string;
+  detail?: string;
 }
 
 interface LintRow {
@@ -721,8 +729,18 @@ function lintRowsForProject(
       baseline: true,
       eslintMs: eslint.medianMs,
       segments: [
-        { label: "tsc", ms: tsc.medianMs, color: "bg-neutral-500" },
-        { label: "ESLint", ms: eslint.medianMs, color: "bg-amber-500" },
+        {
+          label: "tsc",
+          ms: tsc.medianMs,
+          color: "bg-neutral-500",
+          detail: sampleStats(tsc),
+        },
+        {
+          label: "ESLint",
+          ms: eslint.medianMs,
+          color: "bg-amber-500",
+          detail: sampleStats(eslint),
+        },
       ],
     });
 
@@ -754,11 +772,17 @@ function lintRowsForProject(
           ? eslint.medianMs / lintOverheadMs
           : undefined,
       segments: [
-        { label: "ttsc", ms: ttscMs, color: "bg-cyan-500" },
+        {
+          label: "ttsc",
+          ms: ttscMs,
+          color: "bg-cyan-500",
+          detail: sampleStats(plainTtsc),
+        },
         {
           label: "@ttsc/lint",
           ms: lintOverheadMs,
           color: "bg-emerald-400",
+          detail: overheadStats(total, plainTtsc),
         },
       ].filter((segment) => segment.ms > 0),
     });
@@ -781,7 +805,7 @@ function bestRatio(report: BenchmarkReport): Winner | undefined {
   return [
     bestOperationProject(report, "build"),
     bestOperationProject(report, "noEmit"),
-    bestLintProject(report, "build"),
+    bestLintProject(report, "noEmit"),
   ].reduce<Winner | undefined>(
     (best, current) =>
       current && (!best || current.factor > best.factor) ? current : best,
@@ -930,4 +954,53 @@ function formatDate(value: string) {
     month: "short",
     day: "numeric",
   });
+}
+
+function sampleStats(measurement: BenchmarkMeasurement) {
+  const samples = measurement.samples?.filter((sample) => sample > 0) ?? [];
+  const min = measurement.minMs ?? (samples.length ? Math.min(...samples) : 0);
+  const max = samples.length ? Math.max(...samples) : measurement.medianMs;
+  const average = samples.length
+    ? samples.reduce((sum, sample) => sum + sample, 0) / samples.length
+    : measurement.medianMs;
+  const lines = [
+    `median ${formatDuration(measurement.medianMs)} / avg ${formatDuration(
+      average,
+    )} / min ${formatDuration(min)} / max ${formatDuration(max)}`,
+  ];
+  if (samples.length)
+    lines.push(samples.map((sample) => formatDuration(sample)).join(", "));
+  return lines.join("\n");
+}
+
+function overheadStats(
+  total: BenchmarkMeasurement,
+  base: BenchmarkMeasurement,
+) {
+  const totalSamples = total.samples ?? [];
+  const baseSamples = base.samples ?? [];
+  const length = Math.min(totalSamples.length, baseSamples.length);
+  if (length === 0) return sampleStats(total);
+  const samples = Array.from({ length }, (_, i) =>
+    Math.max(0, totalSamples[i] - baseSamples[i]),
+  );
+  return sampleStats({
+    ...total,
+    medianMs: median(samples),
+    minMs: Math.min(...samples),
+    samples,
+  });
+}
+
+function segmentStats(segments: LintSegment[]) {
+  const details = segments
+    .filter((segment) => segment.detail)
+    .map((segment) => `${segment.label}: ${segment.detail}`);
+  return details.join("\n");
+}
+
+function median(values: number[]) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }

--- a/website/src/components/benchmark/BenchmarkDashboard.tsx
+++ b/website/src/components/benchmark/BenchmarkDashboard.tsx
@@ -725,7 +725,7 @@ function lintRowsForProject(
       ],
     });
 
-  for (const threading of ["single", "multi"] as const) {
+  for (const threading of ["multi", "single"] as const) {
     const total = findTtscLintTotal(measurements, op, threading);
     const plainTtsc = findMeasured(measurements, {
       branch: "ttsc",
@@ -743,8 +743,8 @@ function lintRowsForProject(
       threading,
       label:
         threading === "single"
-          ? "ttsc --singleThreaded + @ttsc/lint"
-          : "ttsc + @ttsc/lint",
+          ? "ttsc + @ttsc/lint (ST)"
+          : "ttsc + @ttsc/lint (MT)",
       totalMs: total.medianMs,
       eslintMs: eslint?.medianMs,
       lintOverheadMs,

--- a/website/src/components/benchmark/BenchmarkDashboard.tsx
+++ b/website/src/components/benchmark/BenchmarkDashboard.tsx
@@ -2,22 +2,38 @@
 
 import { useEffect, useState } from "react";
 
-import { deriveSpeedups, formatMultiplier, headlineSpeedup } from "./format";
 import HostPanel from "./HostPanel";
-import ProjectCard from "./ProjectCard";
-import type { BenchmarkReport } from "./types";
+import { findMeasurement, formatDuration, formatMultiplier } from "./format";
+import type {
+  BenchmarkMeasurement,
+  BenchmarkProject,
+  BenchmarkReport,
+} from "./types";
 
-/**
- * Loads `public/benchmark.json` and renders the full benchmark dashboard.
- *
- * Embedded from the benchmark MDX page. Data is fetched at runtime (not
- * bundled) so the benchmark runner can refresh the numbers without a website
- * rebuild. Renders graceful loading / error states and tolerates projects
- * that carry only a partial measurement set.
- */
+type BenchmarkTab = "summary" | "build" | "check" | "lint";
+type Operation = "build" | "noEmit";
+type Threading = "single" | "multi";
+
+const TABS: { id: BenchmarkTab; label: string }[] = [
+  { id: "summary", label: "Summary" },
+  { id: "build", label: "Build" },
+  { id: "check", label: "Type-check" },
+  { id: "lint", label: "Lint" },
+];
+
+const panelClass =
+  "overflow-hidden rounded-md border border-[#262b36] bg-[#0f1115] shadow-[0_12px_30px_rgba(0,0,0,0.22)]";
+const panelHeaderClass =
+  "flex flex-wrap items-end justify-between gap-2 border-b border-[#262b36] bg-[#121620] px-4 py-3";
+
 export default function BenchmarkDashboard() {
   const [report, setReport] = useState<BenchmarkReport | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<BenchmarkTab>(() =>
+    typeof window === "undefined"
+      ? "summary"
+      : tabFromHash(window.location.hash),
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -38,108 +54,880 @@ export default function BenchmarkDashboard() {
     };
   }, []);
 
+  useEffect(() => {
+    const onHashChange = () => setActiveTab(tabFromHash(window.location.hash));
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, []);
+
   if (error)
     return (
-      <p className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 px-5 py-4 font-mono text-[12px] text-neutral-500 dark:border-neutral-800 dark:bg-neutral-900/60">
+      <p className="not-prose my-6 rounded-md border border-[#262b36] bg-[#0f1115] px-4 py-3 font-mono text-[12px] text-neutral-400">
         Could not load benchmark data ({error}).
       </p>
     );
 
   if (!report)
     return (
-      <p className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 px-5 py-4 font-mono text-[12px] text-neutral-500 dark:border-neutral-800 dark:bg-neutral-900/60">
+      <p className="not-prose my-6 rounded-md border border-[#262b36] bg-[#0f1115] px-4 py-3 font-mono text-[12px] text-neutral-400">
         Loading benchmark results…
       </p>
     );
 
   return (
-    <div className="not-prose">
-      <Headline report={report} />
+    <div className="not-prose my-6 space-y-5">
+      <Snapshot report={report} />
+      <nav
+        aria-label="Benchmark views"
+        className="flex gap-1 overflow-x-auto rounded-md border border-[#262b36] bg-[#0f1115] p-1"
+      >
+        {TABS.map((tab) => {
+          const active = activeTab === tab.id;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              className={`shrink-0 rounded px-3 py-1.5 text-[13px] font-medium ${
+                active
+                  ? "bg-[#202838] text-neutral-50 shadow-sm"
+                  : "text-neutral-400 hover:bg-[#171d28] hover:text-neutral-100"
+              }`}
+              onClick={() => {
+                setActiveTab(tab.id);
+                window.history.replaceState(null, "", `#${tab.id}`);
+              }}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </nav>
+
+      {activeTab === "summary" ? <SummaryTab report={report} /> : null}
+      {activeTab === "build" ? (
+        <OperationTab
+          report={report}
+          op="build"
+          title="Build"
+          description="Each project groups tsc (legacy), ttsc ST/MT, and optional tsgo ST/MT in one chart."
+        />
+      ) : null}
+      {activeTab === "check" ? (
+        <OperationTab
+          report={report}
+          op="noEmit"
+          title="Type-check"
+          description="Each project groups tsc (legacy), ttsc ST/MT, and optional tsgo ST/MT in one noEmit chart."
+        />
+      ) : null}
+      {activeTab === "lint" ? <LintTab report={report} /> : null}
+    </div>
+  );
+}
+
+function tabFromHash(hash: string): BenchmarkTab {
+  const id = hash.replace(/^#/, "");
+  return TABS.some((tab) => tab.id === id) ? (id as BenchmarkTab) : "summary";
+}
+
+function Snapshot({ report }: { report: BenchmarkReport }) {
+  const best = bestRatio(report);
+  const totalMeasurements = report.projects.reduce(
+    (sum, project) => sum + project.measurements.length,
+    0,
+  );
+  const totalSamples = report.projects.reduce(
+    (sum, project) =>
+      sum +
+      project.measurements.reduce(
+        (inner, measurement) => inner + (measurement.samples?.length ?? 0),
+        0,
+      ),
+    0,
+  );
+  const stats = [
+    { label: "Projects", value: report.projects.length.toLocaleString() },
+    { label: "Measurements", value: totalMeasurements.toLocaleString() },
+    {
+      label: "Samples",
+      value: totalSamples > 0 ? totalSamples.toLocaleString() : "not recorded",
+    },
+    {
+      label: "Runs per cell",
+      value:
+        report.runs === undefined
+          ? "not recorded"
+          : `${report.runs} measured` +
+            (report.warmup ? ` + ${report.warmup} warmup` : ""),
+    },
+    {
+      label: "Best ratio",
+      value: best ? formatMultiplier(best.factor) : "n/a",
+      note: best ? `${best.project.name}: ${best.label}` : undefined,
+    },
+    { label: "Measured", value: formatDate(report.date) },
+  ];
+
+  return (
+    <section className={panelClass}>
+      <div className="border-b border-[#262b36] bg-[#121620] px-4 py-3">
+        <h2 className="text-base font-semibold text-neutral-50">
+          Benchmark Snapshot
+        </h2>
+        <p className="mt-1 text-[13px] text-neutral-400">
+          Prepared-clone wall-clock timings. Ratios use median command times
+          from the generated benchmark JSON.
+        </p>
+      </div>
+      <dl className="grid grid-cols-2 gap-px bg-[#262b36] md:grid-cols-3 xl:grid-cols-6">
+        {stats.map((stat) => (
+          <div key={stat.label} className="bg-[#0f1115] px-4 py-3">
+            <dt className="font-mono text-[11px] uppercase text-neutral-500">
+              {stat.label}
+            </dt>
+            <dd className="mt-1 text-sm font-semibold text-neutral-50">
+              {stat.value}
+            </dd>
+            {stat.note ? (
+              <dd
+                className="mt-1 truncate text-[11px] text-neutral-500"
+                title={stat.note}
+              >
+                {stat.note}
+              </dd>
+            ) : null}
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function SummaryTab({ report }: { report: BenchmarkReport }) {
+  const build = bestOperationProject(report, "build");
+  const check = bestOperationProject(report, "noEmit");
+  const lint = bestLintProject(report, "build");
+
+  return (
+    <div className="space-y-4">
       <HostPanel host={report.host} date={report.date} />
-      <div className="my-8 grid gap-5 lg:grid-cols-2">
-        {report.projects.map((project) => (
-          <ProjectCard key={project.name} project={project} />
+      <section className={panelClass}>
+        <TableHeader
+          title="Summary Winners"
+          description="Each field keeps only the fastest project, but still shows the full tool group."
+          suffix={`${[build, check, lint].filter(Boolean).length} fields`}
+        />
+        <div className="divide-y divide-[#252b36]">
+          {build ? (
+            <ProjectOperationRows
+              project={build.project}
+              op="build"
+              title="Build"
+            />
+          ) : null}
+          {check ? (
+            <ProjectOperationRows
+              project={check.project}
+              op="noEmit"
+              title="Type-check"
+            />
+          ) : null}
+          {lint ? (
+            <ProjectLintRows
+              project={lint.project}
+              op="build"
+              title="Build + lint"
+            />
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function OperationTab({
+  report,
+  op,
+  title,
+  description,
+}: {
+  report: BenchmarkReport;
+  op: Operation;
+  title: string;
+  description: string;
+}) {
+  const projects = report.projects.filter((project) =>
+    hasComparableOperation(project, op),
+  );
+
+  return (
+    <section className={panelClass}>
+      <TableHeader
+        title={`${title} Tool Matrix`}
+        description={description}
+        suffix={`${projects.length.toLocaleString()} projects`}
+      />
+      <div className="divide-y divide-[#252b36]">
+        {projects.length > 0 ? (
+          projects.map((project) => (
+            <ProjectOperationRows
+              key={`${project.name}:${op}`}
+              project={project}
+              op={op}
+            />
+          ))
+        ) : (
+          <p className="px-4 py-4 text-[12px] text-neutral-500">
+            No comparable measurements recorded for this view.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ProjectOperationRows({
+  project,
+  op,
+  title,
+}: {
+  project: BenchmarkProject;
+  op: Operation;
+  title?: string;
+}) {
+  const rows = operationRows(project, op);
+  const baseline = rows.find((row) => row.baseline);
+  const maxMs = Math.max(
+    1,
+    ...rows.map((row) => row.measurement.medianMs).filter((ms) => ms > 0),
+  );
+
+  if (!baseline || rows.length <= 1) return null;
+
+  return (
+    <div className="grid gap-3 px-4 py-4 md:grid-cols-[minmax(8rem,13rem)_minmax(0,1fr)]">
+      <ProjectLabel
+        project={project}
+        title={title}
+        baselineMs={baseline.measurement.medianMs}
+      />
+      <div className="space-y-1.5">
+        {rows.map((row) => (
+          <DurationBar
+            key={`${project.name}:${op}:${row.label}`}
+            label={row.label}
+            ms={row.measurement.medianMs}
+            maxMs={maxMs}
+            color={row.color}
+            ratio={
+              row.baseline
+                ? "baseline"
+                : formatMultiplier(
+                    baseline.measurement.medianMs / row.measurement.medianMs,
+                  )
+            }
+            baseline={row.baseline}
+          />
         ))}
       </div>
     </div>
   );
 }
 
-/**
- * Hero strip: the single biggest multiplier the whole dataset supports,
- * plus the fixture and project counts behind it.
- */
-function Headline({ report }: { report: BenchmarkReport }) {
-  const best = report.projects
-    .map((project) => ({
-      project,
-      speedup: headlineSpeedup(deriveSpeedups(project.measurements)),
-    }))
-    .reduce<{ name: string; factor: number; label: string } | null>(
-      (acc, entry) => {
-        if (!entry.speedup) return acc;
-        if (acc && entry.speedup.factor <= acc.factor) return acc;
-        return {
-          name: entry.project.name,
-          factor: entry.speedup.factor,
-          label: entry.speedup.label,
-        };
-      },
-      null,
-    );
-
-  const totalMeasurements = report.projects.reduce(
-    (sum, project) => sum + project.measurements.length,
-    0,
+function LintTab({ report }: { report: BenchmarkReport }) {
+  const projects = report.projects.filter((project) =>
+    hasComparableLint(project, "build"),
   );
 
   return (
-    <section className="my-8 overflow-hidden rounded-xl border border-cyan-300/40 bg-gradient-to-br from-cyan-50 to-white dark:border-cyan-300/25 dark:from-cyan-950/40 dark:to-neutral-950">
-      <div className="grid gap-6 px-6 py-7 sm:grid-cols-[auto_1px_1fr] sm:items-center sm:gap-8">
-        <div>
-          <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-cyan-600 dark:text-cyan-300">
-            Peak speedup
+    <LintMatrix
+      title="Lint Tool Matrix"
+      description="Legacy stacks tsc plus ESLint; ttsc-lint stacks plain ttsc plus the @ttsc/lint overhead."
+      projects={projects}
+      op="build"
+    />
+  );
+}
+
+function LintMatrix({
+  title,
+  description,
+  projects,
+  op,
+}: {
+  title: string;
+  description: string;
+  projects: BenchmarkProject[];
+  op: Operation;
+}) {
+  return (
+    <section className={panelClass}>
+      <TableHeader
+        title={title}
+        description={description}
+        suffix={`${projects.length.toLocaleString()} projects`}
+      />
+      <div className="divide-y divide-[#252b36]">
+        {projects.length > 0 ? (
+          projects.map((project) => (
+            <ProjectLintRows
+              key={`${project.name}:${op}:lint`}
+              project={project}
+              op={op}
+            />
+          ))
+        ) : (
+          <p className="px-4 py-4 text-[12px] text-neutral-500">
+            No comparable lint measurements recorded for this view.
           </p>
-          <p className="mt-1 font-mono text-6xl font-black leading-none text-cyan-600 dark:text-cyan-300">
-            {best ? formatMultiplier(best.factor) : "—"}
-          </p>
-          {best ? (
-            <p className="mt-2 font-mono text-[11px] text-neutral-500">
-              {best.label.toLowerCase()} · {best.name}
-            </p>
-          ) : null}
-        </div>
-        <div className="hidden bg-cyan-300/30 sm:block dark:bg-cyan-300/15" />
-        <div>
-          <p className="text-base font-semibold text-neutral-900 dark:text-neutral-100">
-            ttsc replaces the whole TypeScript toolchain — and runs it faster.
-          </p>
-          <p className="mt-2 text-sm leading-relaxed text-neutral-600 dark:text-neutral-400">
-            Wall-clock medians across {report.projects.length} real
-            open-source codebases — {totalMeasurements} measurements pairing{" "}
-            <code className="font-mono text-neutral-700 dark:text-neutral-300">
-              tsc
-            </code>
-            ,{" "}
-            <code className="font-mono text-neutral-700 dark:text-neutral-300">
-              eslint
-            </code>
-            , and{" "}
-            <code className="font-mono text-neutral-700 dark:text-neutral-300">
-              prettier
-            </code>{" "}
-            against{" "}
-            <code className="font-mono text-neutral-700 dark:text-neutral-300">
-              ttsc
-            </code>{" "}
-            and{" "}
-            <code className="font-mono text-neutral-700 dark:text-neutral-300">
-              @ttsc/lint
-            </code>
-            .
-          </p>
-        </div>
+        )}
       </div>
     </section>
   );
+}
+
+function ProjectLintRows({
+  project,
+  op,
+  title,
+}: {
+  project: BenchmarkProject;
+  op: Operation;
+  title?: string;
+}) {
+  const rows = lintRowsForProject(project, op);
+  const baseline = rows.find((row) => row.baseline);
+  const maxMs = Math.max(1, ...rows.map((row) => row.totalMs));
+
+  if (!baseline || rows.length <= 1) return null;
+
+  return (
+    <div className="grid gap-3 px-4 py-4 md:grid-cols-[minmax(8rem,13rem)_minmax(0,1fr)]">
+      <ProjectLabel
+        project={project}
+        title={title}
+        baselineMs={baseline.totalMs}
+      />
+      <div className="space-y-1.5">
+        {rows.map((row) => (
+          <StackedDurationBar
+            key={`${project.name}:${op}:${row.label}`}
+            label={row.label}
+            totalMs={row.totalMs}
+            maxMs={maxMs}
+            ratio={row.baseline ? "baseline" : undefined}
+            lintRatio={
+              row.baseline ? undefined : lintRatioParts(baseline.totalMs, row)
+            }
+            baseline={row.baseline}
+            segments={row.segments}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ProjectLabel({
+  project,
+  title,
+  baselineMs,
+}: {
+  project: BenchmarkProject;
+  title?: string;
+  baselineMs: number;
+}) {
+  return (
+    <div>
+      {title ? (
+        <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-sky-300">
+          {title}
+        </p>
+      ) : null}
+      <p className="font-mono text-sm font-semibold text-neutral-100">
+        {project.name}
+      </p>
+      <p className="mt-1 text-[11px] text-neutral-500">
+        {project.files.toLocaleString()} files
+      </p>
+      <p className="mt-2 font-mono text-[11px] text-neutral-400">
+        baseline: {formatDuration(baselineMs)}
+      </p>
+    </div>
+  );
+}
+
+function DurationBar({
+  label,
+  ms,
+  maxMs,
+  color,
+  ratio,
+  baseline,
+}: {
+  label: string;
+  ms: number;
+  maxMs: number;
+  color: string;
+  ratio: string;
+  baseline?: boolean;
+}) {
+  const widthPct = Math.max(4, (ms / maxMs) * 100);
+
+  return (
+    <div className="py-1.5">
+      <div className="mb-1.5 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+        <p
+          className="min-w-0 flex-1 break-all font-mono text-[11px] text-neutral-400"
+          title={label}
+        >
+          {label}
+        </p>
+        <div className="flex shrink-0 items-baseline gap-2 font-mono text-[11px]">
+          <span className="text-neutral-400">{formatDuration(ms)}</span>
+          <span
+            className={
+              baseline ? "text-neutral-500" : "font-semibold text-emerald-300"
+            }
+          >
+            {ratio}
+          </span>
+        </div>
+      </div>
+      <div className="h-5 w-full rounded bg-[#171d28]">
+        <div
+          className={`h-full rounded ${color}`}
+          style={{ width: `${widthPct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function StackedDurationBar({
+  label,
+  totalMs,
+  maxMs,
+  ratio,
+  lintRatio,
+  baseline,
+  segments,
+}: {
+  label: string;
+  totalMs: number;
+  maxMs: number;
+  ratio?: string;
+  lintRatio?: LintRatioParts;
+  baseline?: boolean;
+  segments: { label: string; ms: number; color: string }[];
+}) {
+  const widthPct = Math.max(4, (totalMs / maxMs) * 100);
+
+  return (
+    <div className="py-1.5">
+      <div className="mb-1.5 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+        <p
+          className="min-w-0 flex-1 break-all font-mono text-[11px] text-neutral-400"
+          title={label}
+        >
+          {label}
+        </p>
+        <div className="flex shrink-0 items-baseline gap-2 font-mono text-[11px]">
+          <span className="text-neutral-400">{formatDuration(totalMs)}</span>
+          {lintRatio ? (
+            <>
+              <span className="font-semibold text-sky-300">
+                {lintRatio.total}
+              </span>
+              <span className="font-semibold text-emerald-300">
+                {lintRatio.lint}
+              </span>
+            </>
+          ) : (
+            <span className="text-neutral-500">{ratio}</span>
+          )}
+        </div>
+      </div>
+      <p className="mb-1.5 break-words font-mono text-[10px] text-neutral-500">
+        (
+        {segments
+          .map((segment) => `${segment.label} ${formatDuration(segment.ms)}`)
+          .join(" + ")}
+        )
+      </p>
+      <div className="h-6 w-full rounded bg-[#171d28]">
+        <div
+          className="flex h-full overflow-hidden rounded"
+          style={{ width: `${widthPct}%` }}
+        >
+          {segments.map((segment) => {
+            const segmentPct =
+              segment.ms > 0 && totalMs > 0
+                ? Math.max(3, (segment.ms / totalMs) * 100)
+                : 0;
+            return (
+              <div
+                key={segment.label}
+                className={`h-full ${segment.color}`}
+                style={{ width: `${segmentPct}%` }}
+                title={`${segment.label}: ${formatDuration(segment.ms)}`}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TableHeader({
+  title,
+  description,
+  suffix,
+}: {
+  title: string;
+  description: string;
+  suffix: string;
+}) {
+  return (
+    <div className={panelHeaderClass}>
+      <div>
+        <h2 className="text-base font-semibold text-neutral-50">{title}</h2>
+        <p className="mt-1 text-[13px] text-neutral-400">{description}</p>
+      </div>
+      <p className="font-mono text-[11px] uppercase text-neutral-500">
+        {suffix}
+      </p>
+    </div>
+  );
+}
+
+type MeasurementOptions = Partial<
+  Pick<BenchmarkMeasurement, "branch" | "tool" | "op" | "threading">
+>;
+
+interface OperationRow {
+  label: string;
+  measurement: BenchmarkMeasurement;
+  color: string;
+  baseline?: boolean;
+}
+
+interface LintSegment {
+  label: string;
+  ms: number;
+  color: string;
+}
+
+interface LintRow {
+  project: BenchmarkProject;
+  op: Operation;
+  threading: Threading;
+  label: string;
+  totalMs: number;
+  segments: LintSegment[];
+  baseline?: boolean;
+  eslintMs?: number;
+  lintOverheadMs?: number;
+  lintFactor?: number;
+}
+
+interface LintRatioParts {
+  total: string;
+  lint: string;
+}
+
+interface Winner {
+  project: BenchmarkProject;
+  label: string;
+  factor: number;
+}
+
+function operationRows(
+  project: BenchmarkProject,
+  op: Operation,
+): OperationRow[] {
+  const rows: OperationRow[] = [];
+  const measurements = project.measurements;
+  const baseline = findMeasured(measurements, {
+    branch: "legacy",
+    tool: "tsc",
+    op,
+    threading: "multi",
+  });
+
+  if (baseline)
+    rows.push({
+      label: compilerCliLabel("tsc", op, "multi"),
+      measurement: baseline,
+      color: "bg-neutral-500",
+      baseline: true,
+    });
+
+  for (const threading of ["single", "multi"] as const) {
+    const measurement = findMeasured(measurements, {
+      branch: "ttsc",
+      tool: "ttsc",
+      op,
+      threading,
+    });
+    if (measurement)
+      rows.push({
+        label: compilerCliLabel("ttsc", op, threading),
+        measurement,
+        color: threading === "single" ? "bg-cyan-600" : "bg-cyan-400",
+      });
+  }
+
+  for (const threading of ["single", "multi"] as const) {
+    const measurement = findMeasured(measurements, {
+      branch: "ttsc",
+      tool: "tsgo",
+      op,
+      threading,
+    });
+    if (measurement)
+      rows.push({
+        label: compilerCliLabel("tsgo", op, threading),
+        measurement,
+        color: threading === "single" ? "bg-violet-600" : "bg-violet-400",
+      });
+  }
+
+  return rows;
+}
+
+function lintRowsForProject(
+  project: BenchmarkProject,
+  op: Operation,
+): LintRow[] {
+  const measurements = project.measurements;
+  const rows: LintRow[] = [];
+  const tsc = findMeasured(measurements, {
+    branch: "legacy",
+    tool: "tsc",
+    op,
+    threading: "multi",
+  });
+  const eslint = findLegacyEslint(measurements, op);
+
+  if (tsc && eslint)
+    rows.push({
+      project,
+      op,
+      threading: "multi",
+      label: "tsc + eslint",
+      totalMs: tsc.medianMs + eslint.medianMs,
+      baseline: true,
+      eslintMs: eslint.medianMs,
+      segments: [
+        { label: "tsc", ms: tsc.medianMs, color: "bg-neutral-500" },
+        { label: "ESLint", ms: eslint.medianMs, color: "bg-amber-500" },
+      ],
+    });
+
+  for (const threading of ["single", "multi"] as const) {
+    const total = findTtscLintTotal(measurements, op, threading);
+    const plainTtsc = findMeasured(measurements, {
+      branch: "ttsc",
+      tool: "ttsc",
+      op,
+      threading,
+    });
+    if (!total || !plainTtsc) continue;
+
+    const ttscMs = Math.min(plainTtsc.medianMs, total.medianMs);
+    const lintOverheadMs = Math.max(0, total.medianMs - plainTtsc.medianMs);
+    rows.push({
+      project,
+      op,
+      threading,
+      label:
+        threading === "single"
+          ? "ttsc --singleThreaded + @ttsc/lint"
+          : "ttsc + @ttsc/lint",
+      totalMs: total.medianMs,
+      eslintMs: eslint?.medianMs,
+      lintOverheadMs,
+      lintFactor:
+        eslint && lintOverheadMs > 0
+          ? eslint.medianMs / lintOverheadMs
+          : undefined,
+      segments: [
+        { label: "ttsc", ms: ttscMs, color: "bg-cyan-500" },
+        {
+          label: "@ttsc/lint",
+          ms: lintOverheadMs,
+          color: "bg-emerald-400",
+        },
+      ].filter((segment) => segment.ms > 0),
+    });
+  }
+
+  return rows;
+}
+
+function hasComparableOperation(project: BenchmarkProject, op: Operation) {
+  const rows = operationRows(project, op);
+  return rows.some((row) => row.baseline) && rows.some((row) => !row.baseline);
+}
+
+function hasComparableLint(project: BenchmarkProject, op: Operation) {
+  const rows = lintRowsForProject(project, op);
+  return rows.some((row) => row.baseline) && rows.some((row) => !row.baseline);
+}
+
+function bestRatio(report: BenchmarkReport): Winner | undefined {
+  return [
+    bestOperationProject(report, "build"),
+    bestOperationProject(report, "noEmit"),
+    bestLintProject(report, "build"),
+  ].reduce<Winner | undefined>(
+    (best, current) =>
+      current && (!best || current.factor > best.factor) ? current : best,
+    undefined,
+  );
+}
+
+function bestOperationProject(
+  report: BenchmarkReport,
+  op: Operation,
+): Winner | undefined {
+  return report.projects.reduce<Winner | undefined>((best, project) => {
+    const rows = operationRows(project, op);
+    const baseline = rows.find((row) => row.baseline);
+    if (!baseline) return best;
+
+    const winner = rows
+      .filter((row) => !row.baseline)
+      .reduce<Winner | undefined>((innerBest, row) => {
+        const factor = baseline.measurement.medianMs / row.measurement.medianMs;
+        const current = {
+          project,
+          label: `${op === "build" ? "Build" : "Type-check"} ${row.label}`,
+          factor,
+        };
+        return !innerBest || current.factor > innerBest.factor
+          ? current
+          : innerBest;
+      }, undefined);
+
+    return winner && (!best || winner.factor > best.factor) ? winner : best;
+  }, undefined);
+}
+
+function bestLintProject(
+  report: BenchmarkReport,
+  op: Operation,
+): Winner | undefined {
+  return report.projects.reduce<Winner | undefined>((best, project) => {
+    const rows = lintRowsForProject(project, op);
+    const baseline = rows.find((row) => row.baseline);
+    if (!baseline) return best;
+
+    const winner = rows
+      .filter((row) => !row.baseline)
+      .reduce<Winner | undefined>((innerBest, row) => {
+        const factor = baseline.totalMs / row.totalMs;
+        const current = {
+          project,
+          label: `Lint ${row.label}`,
+          factor,
+        };
+        return !innerBest || current.factor > innerBest.factor
+          ? current
+          : innerBest;
+      }, undefined);
+
+    return winner && (!best || winner.factor > best.factor) ? winner : best;
+  }, undefined);
+}
+
+function lintRatioParts(baselineMs: number, row: LintRow): LintRatioParts {
+  const total = formatMultiplier(baselineMs / row.totalMs);
+  const lint =
+    row.lintFactor === undefined
+      ? "n/a lint"
+      : `${formatMultiplier(row.lintFactor)} lint`;
+  return { total: `${total} total`, lint };
+}
+
+function findMeasured(
+  measurements: BenchmarkMeasurement[],
+  options: MeasurementOptions,
+): BenchmarkMeasurement | undefined {
+  const measurement = findMeasurement(measurements, options);
+  return measurement && measurement.medianMs > 0 ? measurement : undefined;
+}
+
+function findLegacyEslint(
+  measurements: BenchmarkMeasurement[],
+  op: Operation,
+): BenchmarkMeasurement | undefined {
+  return (
+    findMeasured(measurements, {
+      branch: "legacy",
+      tool: "eslint",
+      op,
+      threading: "multi",
+    }) ??
+    findMeasured(measurements, {
+      branch: "legacy",
+      tool: "eslint",
+      op: "eslint",
+      threading: "multi",
+    }) ??
+    measurements.find(
+      (measurement) =>
+        measurement.branch === "legacy" &&
+        measurement.tool === "eslint" &&
+        measurement.medianMs > 0,
+    )
+  );
+}
+
+function findTtscLintTotal(
+  measurements: BenchmarkMeasurement[],
+  op: Operation,
+  threading: Threading,
+): BenchmarkMeasurement | undefined {
+  return (
+    findMeasured(measurements, {
+      branch: "ttsc-lint",
+      tool: "ttsc+@ttsc/lint",
+      op,
+      threading,
+    }) ??
+    measurements.find(
+      (measurement) =>
+        measurement.branch === "ttsc-lint" &&
+        measurement.op === op &&
+        measurement.threading === threading &&
+        measurement.tool !== "@ttsc/lint" &&
+        measurement.tool !== "eslint" &&
+        measurement.tool !== "prettier" &&
+        measurement.medianMs > 0,
+    )
+  );
+}
+
+function compilerCliLabel(
+  tool: "tsc" | "ttsc" | "tsgo",
+  op: Operation,
+  threading: Threading,
+) {
+  const parts: string[] = [tool];
+  if (op === "noEmit") parts.push("--noEmit");
+  if (threading === "single" && tool !== "tsc") parts.push("--singleThreaded");
+  return parts.join(" ");
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 }

--- a/website/src/components/benchmark/BenchmarkDashboard.tsx
+++ b/website/src/components/benchmark/BenchmarkDashboard.tsx
@@ -37,20 +37,28 @@ export default function BenchmarkDashboard() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch("/benchmark.json")
-      .then((res) => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.json() as Promise<BenchmarkReport>;
-      })
-      .then((data) => {
-        if (!cancelled) setReport(data);
-      })
-      .catch((err: unknown) => {
-        if (!cancelled)
-          setError(err instanceof Error ? err.message : String(err));
-      });
+    const load = () => {
+      fetch(`/benchmark.json?ts=${Date.now()}`, { cache: "no-store" })
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json() as Promise<BenchmarkReport>;
+        })
+        .then((data) => {
+          if (cancelled) return;
+          setReport(data);
+          setError(null);
+        })
+        .catch((err: unknown) => {
+          if (!cancelled)
+            setError(err instanceof Error ? err.message : String(err));
+        });
+    };
+
+    load();
+    const timer = window.setInterval(load, 5_000);
     return () => {
       cancelled = true;
+      window.clearInterval(timer);
     };
   }, []);
 

--- a/website/src/components/benchmark/BenchmarkDashboard.tsx
+++ b/website/src/components/benchmark/BenchmarkDashboard.tsx
@@ -37,28 +37,20 @@ export default function BenchmarkDashboard() {
 
   useEffect(() => {
     let cancelled = false;
-    const load = () => {
-      fetch(`/benchmark.json?ts=${Date.now()}`, { cache: "no-store" })
-        .then((res) => {
-          if (!res.ok) throw new Error(`HTTP ${res.status}`);
-          return res.json() as Promise<BenchmarkReport>;
-        })
-        .then((data) => {
-          if (cancelled) return;
-          setReport(data);
-          setError(null);
-        })
-        .catch((err: unknown) => {
-          if (!cancelled)
-            setError(err instanceof Error ? err.message : String(err));
-        });
-    };
-
-    load();
-    const timer = window.setInterval(load, 5_000);
+    fetch("/benchmark.json")
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<BenchmarkReport>;
+      })
+      .then((data) => {
+        if (!cancelled) setReport(data);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled)
+          setError(err instanceof Error ? err.message : String(err));
+      });
     return () => {
       cancelled = true;
-      window.clearInterval(timer);
     };
   }, []);
 

--- a/website/src/components/benchmark/BenchmarkDashboard.tsx
+++ b/website/src/components/benchmark/BenchmarkDashboard.tsx
@@ -162,7 +162,7 @@ function Snapshot({ report }: { report: BenchmarkReport }) {
     },
     {
       label: "Best ratio",
-      value: best ? formatMultiplier(best.factor) : "n/a",
+      value: best ? formatMultiplier(best.factor) : "-",
       note: best ? `${best.project.name}: ${best.label}` : undefined,
     },
     { label: "Measured", value: formatDate(report.date) },
@@ -735,8 +735,9 @@ function lintRowsForProject(
     });
     if (!total || !plainTtsc) continue;
 
+    const rawLintOverheadMs = total.medianMs - plainTtsc.medianMs;
     const ttscMs = Math.min(plainTtsc.medianMs, total.medianMs);
-    const lintOverheadMs = Math.max(0, total.medianMs - plainTtsc.medianMs);
+    const lintOverheadMs = Math.max(0, rawLintOverheadMs);
     rows.push({
       project,
       op,
@@ -749,9 +750,11 @@ function lintRowsForProject(
       eslintMs: eslint?.medianMs,
       lintOverheadMs,
       lintFactor:
-        eslint && lintOverheadMs > 0
-          ? eslint.medianMs / lintOverheadMs
-          : undefined,
+        eslint && rawLintOverheadMs <= 0
+          ? Infinity
+          : eslint && lintOverheadMs > 0
+            ? eslint.medianMs / lintOverheadMs
+            : undefined,
       segments: [
         { label: "ttsc", ms: ttscMs, color: "bg-cyan-500" },
         {
@@ -759,7 +762,7 @@ function lintRowsForProject(
           ms: lintOverheadMs,
           color: "bg-emerald-400",
         },
-      ].filter((segment) => segment.ms > 0),
+      ],
     });
   }
 
@@ -844,10 +847,7 @@ function bestLintProject(
 
 function lintRatioParts(baselineMs: number, row: LintRow): LintRatioParts {
   const total = formatMultiplier(baselineMs / row.totalMs);
-  const lint =
-    row.lintFactor === undefined
-      ? "n/a lint"
-      : `${formatMultiplier(row.lintFactor)} lint`;
+  const lint = `${formatMultiplier(row.lintFactor ?? 0)} lint`;
   return { total: `${total} total`, lint };
 }
 

--- a/website/src/components/benchmark/HostPanel.tsx
+++ b/website/src/components/benchmark/HostPanel.tsx
@@ -5,8 +5,8 @@ import type { BenchmarkHost } from "./types";
 /**
  * The machine the published numbers were measured on.
  *
- * Speedups are only meaningful next to the hardware and toolchain versions
- * that produced them, so this panel sits directly above the project cards.
+ * Speedups are only meaningful next to the hardware and toolchain versions that
+ * produced them, so this panel sits directly above the project cards.
  */
 export default function HostPanel({
   host,
@@ -25,36 +25,40 @@ export default function HostPanel({
       });
 
   const specs: { label: string; value: string }[] = [
-    { label: "CPU", value: host.cpu },
-    { label: "Cores", value: `${host.cores} logical` },
-    { label: "Memory", value: `${host.ramGB} GB` },
-    { label: "OS", value: host.os },
-    { label: "Kernel", value: host.kernel },
-    { label: "Node.js", value: host.node },
-    { label: "ttsc", value: host.ttsc },
-    { label: "TypeScript", value: host.typescript },
+    { label: "CPU", value: fallback(host.cpu) },
+    {
+      label: "Cores",
+      value: host.cores ? `${host.cores} logical` : "not recorded",
+    },
+    {
+      label: "Memory",
+      value: host.ramGB ? `${host.ramGB} GB` : "not recorded",
+    },
+    { label: "OS", value: fallback(host.os) },
+    { label: "Kernel", value: fallback(host.kernel) },
+    { label: "Node.js", value: fallback(host.node) },
+    { label: "ttsc", value: fallback(host.ttsc) },
+    { label: "tsgo", value: fallback(host.tsgo) },
+    { label: "TypeScript", value: fallback(host.typescript) },
   ];
 
   return (
-    <section className="not-prose my-8 overflow-hidden rounded-xl border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900/60">
-      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 border-b border-neutral-200 px-5 py-3 dark:border-neutral-800">
-        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-cyan-600 dark:text-cyan-300">
+    <section className="not-prose overflow-hidden rounded-md border border-[#262b36] bg-[#0f1115] shadow-[0_12px_30px_rgba(0,0,0,0.22)]">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 border-b border-[#262b36] bg-[#121620] px-4 py-3">
+        <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-sky-300">
           Measurement host
         </p>
         <p className="font-mono text-[11px] text-neutral-500">
           measured {measuredLabel}
         </p>
       </div>
-      <dl className="grid grid-cols-2 gap-px bg-neutral-200 sm:grid-cols-4 dark:bg-neutral-800">
+      <dl className="grid grid-cols-2 gap-px bg-[#262b36] sm:grid-cols-4">
         {specs.map((spec) => (
-          <div
-            key={spec.label}
-            className="bg-neutral-50 px-5 py-3.5 dark:bg-neutral-900/60"
-          >
-            <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+          <div key={spec.label} className="bg-[#0f1115] px-4 py-3">
+            <dt className="font-mono text-[10px] uppercase tracking-[0.12em] text-neutral-500">
               {spec.label}
             </dt>
-            <dd className="mt-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+            <dd className="mt-1 text-sm font-semibold text-neutral-100">
               {spec.value}
             </dd>
           </div>
@@ -62,4 +66,8 @@ export default function HostPanel({
       </dl>
     </section>
   );
+}
+
+function fallback(value: string | undefined) {
+  return value && value.length > 0 ? value : "not recorded";
 }

--- a/website/src/components/benchmark/HostPanel.tsx
+++ b/website/src/components/benchmark/HostPanel.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { BenchmarkHost } from "./types";
+
+/**
+ * The machine the published numbers were measured on.
+ *
+ * Speedups are only meaningful next to the hardware and toolchain versions
+ * that produced them, so this panel sits directly above the project cards.
+ */
+export default function HostPanel({
+  host,
+  date,
+}: {
+  host: BenchmarkHost;
+  date: string;
+}) {
+  const measured = new Date(date);
+  const measuredLabel = Number.isNaN(measured.getTime())
+    ? date
+    : measured.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+
+  const specs: { label: string; value: string }[] = [
+    { label: "CPU", value: host.cpu },
+    { label: "Cores", value: `${host.cores} logical` },
+    { label: "Memory", value: `${host.ramGB} GB` },
+    { label: "OS", value: host.os },
+    { label: "Kernel", value: host.kernel },
+    { label: "Node.js", value: host.node },
+    { label: "ttsc", value: host.ttsc },
+    { label: "TypeScript", value: host.typescript },
+  ];
+
+  return (
+    <section className="not-prose my-8 overflow-hidden rounded-xl border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900/60">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 border-b border-neutral-200 px-5 py-3 dark:border-neutral-800">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-cyan-600 dark:text-cyan-300">
+          Measurement host
+        </p>
+        <p className="font-mono text-[11px] text-neutral-500">
+          measured {measuredLabel}
+        </p>
+      </div>
+      <dl className="grid grid-cols-2 gap-px bg-neutral-200 sm:grid-cols-4 dark:bg-neutral-800">
+        {specs.map((spec) => (
+          <div
+            key={spec.label}
+            className="bg-neutral-50 px-5 py-3.5 dark:bg-neutral-900/60"
+          >
+            <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+              {spec.label}
+            </dt>
+            <dd className="mt-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+              {spec.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/website/src/components/benchmark/ProjectCard.tsx
+++ b/website/src/components/benchmark/ProjectCard.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import {
+  deriveSpeedups,
+  formatMultiplier,
+  headlineSpeedup,
+} from "./format";
+import SpeedupBar from "./SpeedupBar";
+import type { BenchmarkProject } from "./types";
+
+/**
+ * One OSS fixture: a big hero multiplier plus every supported comparison.
+ *
+ * The headline multiplier (largest speedup the project's measurements
+ * support) is the visual anchor; the per-row bars underneath break it down.
+ * A project that carries no comparable pair still renders its header.
+ */
+export default function ProjectCard({
+  project,
+}: {
+  project: BenchmarkProject;
+}) {
+  const speedups = deriveSpeedups(project.measurements);
+  const headline = headlineSpeedup(speedups);
+
+  return (
+    <article className="not-prose flex flex-col overflow-hidden rounded-xl border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900/40">
+      <div className="flex items-start justify-between gap-4 border-b border-neutral-200 px-5 py-4 dark:border-neutral-800">
+        <div>
+          <h3 className="font-mono text-base font-bold text-neutral-900 dark:text-neutral-100">
+            {project.name}
+          </h3>
+          <p className="mt-1 font-mono text-[11px] text-neutral-500">
+            {project.files.toLocaleString()} files · {project.kind}
+          </p>
+        </div>
+        {headline ? (
+          <div className="shrink-0 text-right">
+            <p className="font-mono text-3xl font-black leading-none text-cyan-600 dark:text-cyan-300">
+              {formatMultiplier(headline.factor)}
+            </p>
+            <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.12em] text-neutral-500">
+              {headline.label.toLowerCase()}
+            </p>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="flex-1 space-y-5 px-5 py-5">
+        {speedups.length > 0 ? (
+          speedups.map((speedup) => (
+            <SpeedupBar key={speedup.id} speedup={speedup} />
+          ))
+        ) : (
+          <p className="font-mono text-[12px] text-neutral-500">
+            No comparable measurements recorded yet.
+          </p>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/website/src/components/benchmark/SpeedupBar.tsx
+++ b/website/src/components/benchmark/SpeedupBar.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { formatDuration, formatMultiplier, type Speedup } from "./format";
+
+/**
+ * One head-to-head comparison: a slow baseline bar over a faster ttsc bar.
+ *
+ * Bar widths are proportional to wall-clock time within the row, so the
+ * shorter ttsc bar reads as "less time" at a glance; the multiplier on the
+ * right states the win numerically.
+ */
+export default function SpeedupBar({ speedup }: { speedup: Speedup }) {
+  const fastPct = Math.max(6, (speedup.fast.ms / speedup.baseline.ms) * 100);
+
+  return (
+    <div className="not-prose">
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+          {speedup.label}
+        </p>
+        <p className="font-mono text-[11px] text-neutral-500">
+          {speedup.detail}
+        </p>
+      </div>
+
+      <div className="mt-2 space-y-1.5">
+        <BarRow
+          tone="baseline"
+          tool={speedup.baseline.tool}
+          ms={speedup.baseline.ms}
+          widthPct={100}
+        />
+        <BarRow
+          tone="fast"
+          tool={speedup.fast.tool}
+          ms={speedup.fast.ms}
+          widthPct={fastPct}
+        />
+      </div>
+
+      <p className="mt-2 font-mono text-[11px] text-neutral-500">
+        <span className="font-bold text-cyan-600 dark:text-cyan-300">
+          {formatMultiplier(speedup.factor)}
+        </span>{" "}
+        faster
+      </p>
+    </div>
+  );
+}
+
+function BarRow({
+  tone,
+  tool,
+  ms,
+  widthPct,
+}: {
+  tone: "baseline" | "fast";
+  tool: string;
+  ms: number;
+  widthPct: number;
+}) {
+  const isFast = tone === "fast";
+  return (
+    <div className="flex items-center gap-3">
+      <code
+        className={`w-24 shrink-0 truncate text-right font-mono text-[11px] ${
+          isFast
+            ? "font-bold text-cyan-700 dark:text-cyan-300"
+            : "text-neutral-500"
+        }`}
+        title={tool}
+      >
+        {tool}
+      </code>
+      <div className="relative h-6 flex-1 overflow-hidden rounded bg-neutral-200/70 dark:bg-neutral-800/70">
+        <div
+          className={`flex h-full items-center justify-end rounded px-2 transition-[width] duration-700 ${
+            isFast
+              ? "bg-gradient-to-r from-cyan-500 to-cyan-400 dark:from-cyan-500 dark:to-cyan-300"
+              : "bg-neutral-400 dark:bg-neutral-600"
+          }`}
+          style={{ width: `${widthPct}%` }}
+        >
+          <span
+            className={`font-mono text-[11px] font-semibold tabular-nums ${
+              isFast ? "text-cyan-950" : "text-white dark:text-neutral-200"
+            }`}
+          >
+            {formatDuration(ms)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/benchmark/SpeedupBar.tsx
+++ b/website/src/components/benchmark/SpeedupBar.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-import { formatDuration, formatMultiplier, type Speedup } from "./format";
+import { type Speedup, formatDuration, formatMultiplier } from "./format";
 
 /**
  * One head-to-head comparison: a slow baseline bar over a faster ttsc bar.
  *
- * Bar widths are proportional to wall-clock time within the row, so the
- * shorter ttsc bar reads as "less time" at a glance; the multiplier on the
- * right states the win numerically.
+ * Bar widths are proportional to wall-clock time within the row, so the shorter
+ * ttsc bar reads as "less time" at a glance; the multiplier on the right states
+ * the win numerically.
  */
 export default function SpeedupBar({ speedup }: { speedup: Speedup }) {
-  const fastPct = Math.max(6, (speedup.fast.ms / speedup.baseline.ms) * 100);
+  const fastPct = Math.min(
+    100,
+    Math.max(6, (speedup.fast.ms / speedup.baseline.ms) * 100),
+  );
+  const faster = speedup.factor >= 1;
 
   return (
     <div className="not-prose">
@@ -42,7 +46,7 @@ export default function SpeedupBar({ speedup }: { speedup: Speedup }) {
         <span className="font-bold text-cyan-600 dark:text-cyan-300">
           {formatMultiplier(speedup.factor)}
         </span>{" "}
-        faster
+        {faster ? "faster" : "of baseline"}
       </p>
     </div>
   );

--- a/website/src/components/benchmark/format.ts
+++ b/website/src/components/benchmark/format.ts
@@ -1,0 +1,168 @@
+/**
+ * Formatting helpers shared across the benchmark dashboard widgets.
+ *
+ * Kept free of React so they can be unit-reasoned and reused by both the
+ * project cards and the host-spec panel without pulling in JSX.
+ */
+
+import type { BenchmarkMeasurement } from "./types";
+
+/** Human-friendly wall-clock label: sub-second in `ms`, otherwise `s`. */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  const seconds = ms / 1000;
+  return `${seconds.toFixed(seconds < 10 ? 2 : 1)} s`;
+}
+
+/** Speedup multiplier label, e.g. `2.5x`. */
+export function formatMultiplier(factor: number): string {
+  return `${factor.toFixed(factor < 10 ? 1 : 0)}x`;
+}
+
+/**
+ * A speedup pairs a slow baseline against a faster ttsc measurement.
+ * `factor` is baseline / fast — how many times faster ttsc ran.
+ */
+export interface Speedup {
+  id: string;
+  label: string;
+  detail: string;
+  baseline: { tool: string; ms: number };
+  fast: { tool: string; ms: number };
+  factor: number;
+}
+
+interface FindOptions {
+  branch?: BenchmarkMeasurement["branch"];
+  tool?: BenchmarkMeasurement["tool"];
+  op?: BenchmarkMeasurement["op"];
+  threading?: BenchmarkMeasurement["threading"];
+}
+
+/** First measurement matching every provided dimension, or `undefined`. */
+export function findMeasurement(
+  measurements: BenchmarkMeasurement[],
+  options: FindOptions,
+): BenchmarkMeasurement | undefined {
+  return measurements.find(
+    (m) =>
+      (options.branch === undefined || m.branch === options.branch) &&
+      (options.tool === undefined || m.tool === options.tool) &&
+      (options.op === undefined || m.op === options.op) &&
+      (options.threading === undefined || m.threading === options.threading),
+  );
+}
+
+/**
+ * Derive every speedup the supplied measurements support. Gracefully skips a
+ * comparison whenever one side is missing or recorded as `0` (not measured),
+ * so a project with a partial result set still renders cleanly.
+ */
+export function deriveSpeedups(
+  measurements: BenchmarkMeasurement[],
+): Speedup[] {
+  const out: Speedup[] = [];
+
+  const push = (
+    id: string,
+    label: string,
+    detail: string,
+    baseline: BenchmarkMeasurement | undefined,
+    fast: BenchmarkMeasurement | undefined,
+  ) => {
+    if (!baseline || !fast) return;
+    if (baseline.medianMs <= 0 || fast.medianMs <= 0) return;
+    out.push({
+      id,
+      label,
+      detail,
+      baseline: { tool: baseline.tool, ms: baseline.medianMs },
+      fast: { tool: fast.tool, ms: fast.medianMs },
+      factor: baseline.medianMs / fast.medianMs,
+    });
+  };
+
+  // Build: tsc vs ttsc.
+  push(
+    "build",
+    "Build",
+    "type-check and emit JS + .d.ts",
+    findMeasurement(measurements, {
+      branch: "legacy",
+      tool: "tsc",
+      op: "build",
+    }),
+    findMeasurement(measurements, {
+      branch: "ttsc",
+      tool: "ttsc",
+      op: "build",
+      threading: "multi",
+    }),
+  );
+
+  // Type-check only: tsc --noEmit vs ttsc --noEmit.
+  push(
+    "noEmit",
+    "Type-check",
+    "check the project with --noEmit",
+    findMeasurement(measurements, {
+      branch: "legacy",
+      tool: "tsc",
+      op: "noEmit",
+    }),
+    findMeasurement(measurements, {
+      branch: "ttsc",
+      tool: "ttsc",
+      op: "noEmit",
+      threading: "multi",
+    }),
+  );
+
+  // Threading: single-threaded ttsc vs multi-threaded ttsc.
+  const stBuild = findMeasurement(measurements, {
+    branch: "ttsc",
+    threading: "single",
+    op: "build",
+  });
+  const mtBuild = findMeasurement(measurements, {
+    branch: "ttsc",
+    threading: "multi",
+    op: "build",
+  });
+  const stNoEmit = findMeasurement(measurements, {
+    branch: "ttsc",
+    threading: "single",
+    op: "noEmit",
+  });
+  const mtNoEmit = findMeasurement(measurements, {
+    branch: "ttsc",
+    threading: "multi",
+    op: "noEmit",
+  });
+  push(
+    "threading",
+    "Parallelism",
+    "ttsc default vs --singleThreaded",
+    stBuild ?? stNoEmit,
+    stBuild ? mtBuild : mtNoEmit,
+  );
+
+  // Format: prettier vs @ttsc/lint format.
+  push(
+    "format",
+    "Format",
+    "rewrite the source tree",
+    findMeasurement(measurements, { tool: "prettier" }),
+    findMeasurement(measurements, { tool: "@ttsc/lint", op: "format" }),
+  );
+
+  return out;
+}
+
+/** Largest speedup across a project — drives the hero multiplier callout. */
+export function headlineSpeedup(speedups: Speedup[]): Speedup | undefined {
+  return speedups.reduce<Speedup | undefined>(
+    (best, s) => (best === undefined || s.factor > best.factor ? s : best),
+    undefined,
+  );
+}

--- a/website/src/components/benchmark/format.ts
+++ b/website/src/components/benchmark/format.ts
@@ -1,10 +1,3 @@
-/**
- * Formatting helpers shared across the benchmark dashboard widgets.
- *
- * Kept free of React so they can be unit-reasoned and reused by both the
- * project cards and the host-spec panel without pulling in JSX.
- */
-
 import type { BenchmarkMeasurement } from "./types";
 
 /** Human-friendly wall-clock label: sub-second in `ms`, otherwise `s`. */
@@ -16,13 +9,10 @@ export function formatDuration(ms: number): string {
 
 /** Speedup multiplier label, e.g. `2.5x`. */
 export function formatMultiplier(factor: number): string {
+  if (!Number.isFinite(factor)) return "∞x";
   return `${factor.toFixed(factor < 10 ? 1 : 0)}x`;
 }
 
-/**
- * A speedup pairs a slow baseline against a faster ttsc measurement.
- * `factor` is baseline / fast — how many times faster ttsc ran.
- */
 export interface Speedup {
   id: string;
   label: string;
@@ -39,7 +29,6 @@ interface FindOptions {
   threading?: BenchmarkMeasurement["threading"];
 }
 
-/** First measurement matching every provided dimension, or `undefined`. */
 export function findMeasurement(
   measurements: BenchmarkMeasurement[],
   options: FindOptions,
@@ -53,113 +42,189 @@ export function findMeasurement(
   );
 }
 
-/**
- * Derive every speedup the supplied measurements support. Gracefully skips a
- * comparison whenever one side is missing or recorded as `0` (not measured),
- * so a project with a partial result set still renders cleanly.
- */
 export function deriveSpeedups(
   measurements: BenchmarkMeasurement[],
 ): Speedup[] {
   const out: Speedup[] = [];
+  const legacyBuild = findMeasurement(measurements, {
+    branch: "legacy",
+    op: "build",
+    threading: "multi",
+  });
+  const legacyNoEmit = findMeasurement(measurements, {
+    branch: "legacy",
+    op: "noEmit",
+    threading: "multi",
+  });
+  const eslint =
+    findMeasurement(measurements, {
+      branch: "legacy",
+      tool: "eslint",
+      op: "eslint",
+      threading: "multi",
+    }) ??
+    findMeasurement(measurements, {
+      branch: "legacy",
+      tool: "eslint",
+      threading: "multi",
+    });
 
   const push = (
     id: string,
     label: string,
     detail: string,
-    baseline: BenchmarkMeasurement | undefined,
-    fast: BenchmarkMeasurement | undefined,
+    baseline: { tool: string; ms: number } | undefined,
+    fast: { tool: string; ms: number } | undefined,
   ) => {
     if (!baseline || !fast) return;
-    if (baseline.medianMs <= 0 || fast.medianMs <= 0) return;
+    if (baseline.ms <= 0 || fast.ms <= 0) return;
     out.push({
       id,
       label,
       detail,
-      baseline: { tool: baseline.tool, ms: baseline.medianMs },
-      fast: { tool: fast.tool, ms: fast.medianMs },
-      factor: baseline.medianMs / fast.medianMs,
+      baseline,
+      fast,
+      factor: baseline.ms / fast.ms,
     });
   };
 
-  // Build: tsc vs ttsc.
-  push(
-    "build",
-    "Build",
-    "type-check and emit JS + .d.ts",
-    findMeasurement(measurements, {
-      branch: "legacy",
-      tool: "tsc",
-      op: "build",
-    }),
-    findMeasurement(measurements, {
+  for (const threading of ["multi", "single"] as const) {
+    const ttscBuild = findMeasurement(measurements, {
       branch: "ttsc",
       tool: "ttsc",
       op: "build",
-      threading: "multi",
-    }),
-  );
+      threading,
+    });
+    push(
+      `build-${threading}`,
+      `Build (${threading})`,
+      "legacy tsc build vs ttsc build",
+      legacyBuild && { tool: "tsc", ms: legacyBuild.medianMs },
+      ttscBuild && { tool: `ttsc ${threading}`, ms: ttscBuild.medianMs },
+    );
 
-  // Type-check only: tsc --noEmit vs ttsc --noEmit.
-  push(
-    "noEmit",
-    "Type-check",
-    "check the project with --noEmit",
-    findMeasurement(measurements, {
-      branch: "legacy",
-      tool: "tsc",
-      op: "noEmit",
-    }),
-    findMeasurement(measurements, {
+    const ttscNoEmit = findMeasurement(measurements, {
       branch: "ttsc",
       tool: "ttsc",
       op: "noEmit",
-      threading: "multi",
-    }),
-  );
+      threading,
+    });
+    push(
+      `noEmit-${threading}`,
+      `No emit (${threading})`,
+      "legacy tsc --noEmit vs ttsc --noEmit",
+      legacyNoEmit && { tool: "tsc --noEmit", ms: legacyNoEmit.medianMs },
+      ttscNoEmit && {
+        tool: `ttsc --noEmit ${threading}`,
+        ms: ttscNoEmit.medianMs,
+      },
+    );
 
-  // Threading: single-threaded ttsc vs multi-threaded ttsc.
-  const stBuild = findMeasurement(measurements, {
-    branch: "ttsc",
-    threading: "single",
-    op: "build",
-  });
-  const mtBuild = findMeasurement(measurements, {
-    branch: "ttsc",
-    threading: "multi",
-    op: "build",
-  });
-  const stNoEmit = findMeasurement(measurements, {
-    branch: "ttsc",
-    threading: "single",
-    op: "noEmit",
-  });
-  const mtNoEmit = findMeasurement(measurements, {
-    branch: "ttsc",
-    threading: "multi",
-    op: "noEmit",
-  });
-  push(
-    "threading",
-    "Parallelism",
-    "ttsc default vs --singleThreaded",
-    stBuild ?? stNoEmit,
-    stBuild ? mtBuild : mtNoEmit,
-  );
+    const ttscLintBuild =
+      findMeasurement(measurements, {
+        branch: "ttsc-lint",
+        tool: "ttsc+@ttsc/lint",
+        op: "build",
+        threading,
+      }) ??
+      findMeasurement(measurements, {
+        branch: "ttsc-lint",
+        op: "build",
+        threading,
+      });
+    push(
+      `build-eslint-${threading}`,
+      `Build + lint (${threading})`,
+      "legacy tsc build + eslint vs ttsc-lint build",
+      legacyBuild &&
+        eslint && {
+          tool: "tsc + eslint",
+          ms: legacyBuild.medianMs + eslint.medianMs,
+        },
+      ttscLintBuild && {
+        tool: `ttsc-lint ${threading}`,
+        ms: ttscLintBuild.medianMs,
+      },
+    );
 
-  // Format: prettier vs @ttsc/lint format.
-  push(
-    "format",
-    "Format",
-    "rewrite the source tree",
-    findMeasurement(measurements, { tool: "prettier" }),
-    findMeasurement(measurements, { tool: "@ttsc/lint", op: "format" }),
-  );
+    const ttscLintNoEmit =
+      findMeasurement(measurements, {
+        branch: "ttsc-lint",
+        tool: "ttsc+@ttsc/lint",
+        op: "noEmit",
+        threading,
+      }) ??
+      findMeasurement(measurements, {
+        branch: "ttsc-lint",
+        op: "noEmit",
+        threading,
+      });
+    push(
+      `noEmit-eslint-${threading}`,
+      `No emit + lint (${threading})`,
+      "legacy tsc --noEmit + eslint vs ttsc-lint --noEmit",
+      legacyNoEmit &&
+        eslint && {
+          tool: "tsc --noEmit + eslint",
+          ms: legacyNoEmit.medianMs + eslint.medianMs,
+        },
+      ttscLintNoEmit && {
+        tool: `ttsc-lint --noEmit ${threading}`,
+        ms: ttscLintNoEmit.medianMs,
+      },
+    );
+
+    if (eslint && ttscBuild && ttscLintBuild) {
+      const overhead = ttscLintBuild.medianMs - ttscBuild.medianMs;
+      push(
+        `lint-overhead-${threading}`,
+        `Lint overhead (${threading})`,
+        "eslint alone vs ttsc-lint build minus ttsc build",
+        { tool: "eslint", ms: eslint.medianMs },
+        overhead > 0
+          ? { tool: `ttsc-lint - ttsc ${threading}`, ms: overhead }
+          : undefined,
+      );
+    }
+
+    const tsgoBuild = findMeasurement(measurements, {
+      branch: "ttsc",
+      tool: "tsgo",
+      op: "build",
+      threading,
+    });
+    push(
+      `ttsc-vs-tsgo-build-${threading}`,
+      `TTSC vs TSGO build (${threading})`,
+      "tsgo build vs ttsc build on the ttsc branch",
+      tsgoBuild && { tool: `tsgo ${threading}`, ms: tsgoBuild.medianMs },
+      ttscBuild && { tool: `ttsc ${threading}`, ms: ttscBuild.medianMs },
+    );
+
+    const tsgoNoEmit = findMeasurement(measurements, {
+      branch: "ttsc",
+      tool: "tsgo",
+      op: "noEmit",
+      threading,
+    });
+    push(
+      `ttsc-vs-tsgo-noEmit-${threading}`,
+      `TTSC vs TSGO no emit (${threading})`,
+      "tsgo --noEmit vs ttsc --noEmit on the ttsc branch",
+      tsgoNoEmit && {
+        tool: `tsgo --noEmit ${threading}`,
+        ms: tsgoNoEmit.medianMs,
+      },
+      ttscNoEmit && {
+        tool: `ttsc --noEmit ${threading}`,
+        ms: ttscNoEmit.medianMs,
+      },
+    );
+  }
 
   return out;
 }
 
-/** Largest speedup across a project — drives the hero multiplier callout. */
 export function headlineSpeedup(speedups: Speedup[]): Speedup | undefined {
   return speedups.reduce<Speedup | undefined>(
     (best, s) => (best === undefined || s.factor > best.factor ? s : best),

--- a/website/src/components/benchmark/types.ts
+++ b/website/src/components/benchmark/types.ts
@@ -1,9 +1,15 @@
 /**
  * Shape of `public/benchmark.json` — the committed, served benchmark result file.
  *
- * The benchmark runner (`experimental/benchmark`) drops real medians in later;
- * the schema is intentionally sparse so a project may carry only some of the
- * branch × tool × op × threading combinations.
+ * This file is the single canonical schema: the benchmark runner
+ * (`experimental/benchmark/bench.mjs`) emits exactly this shape, and the
+ * dashboard components render exactly this shape. The schema is intentionally
+ * sparse so a project may carry only some of the branch × tool × op × threading
+ * combinations; the dashboard skips any comparison whose pair is missing.
+ *
+ * Required fields drive the dashboard. Optional fields (`samples`, `minMs`,
+ * stability) carry the runner's richer per-cell data through to the JSON so a
+ * published result is fully reproducible; the dashboard does not depend on them.
  */
 
 export type BenchmarkBranch = "legacy" | "ttsc" | "ttsc-lint";
@@ -16,13 +22,36 @@ export type BenchmarkTool =
 export type BenchmarkOp = "build" | "noEmit" | "format";
 export type BenchmarkThreading = "single" | "multi";
 
+/**
+ * How a measured run that exited non-zero was classified. `race` is the
+ * intermittent TypeScript-Go parallel-emit data race (retried; a clean timing
+ * is still recorded). `error` is a deterministic failure (the cell is left
+ * unmeasured, so `medianMs` is `0`).
+ */
+export type BenchmarkFailureKind = "race" | "error";
+
 export interface BenchmarkMeasurement {
   branch: BenchmarkBranch;
   tool: BenchmarkTool;
   op: BenchmarkOp;
   threading: BenchmarkThreading;
-  /** Median wall-clock time in milliseconds across the measured runs. */
+  /**
+   * Median wall-clock time in milliseconds across the measured runs. `0` means
+   * the cell could not be measured (a deterministic failure); the dashboard
+   * skips any comparison touching a `0`.
+   */
   medianMs: number;
+  /** Fastest measured run in milliseconds, when at least one run succeeded. */
+  minMs?: number;
+  /** Raw per-run wall-clock samples in milliseconds, in run order. */
+  samples?: number[];
+  /**
+   * Count of runs that hit the intermittent parallel-emit data race and were
+   * retried. Absent or `0` means the cell measured cleanly.
+   */
+  raceRetries?: number;
+  /** Kind of the deterministic failure when the cell could not be measured. */
+  failure?: BenchmarkFailureKind;
 }
 
 export interface BenchmarkProject {

--- a/website/src/components/benchmark/types.ts
+++ b/website/src/components/benchmark/types.ts
@@ -1,5 +1,6 @@
 /**
- * Shape of `public/benchmark.json` — the committed, served benchmark result file.
+ * Shape of `public/benchmark.json` — the committed, served benchmark result
+ * file.
  *
  * This file is the single canonical schema: the benchmark runner
  * (`experimental/benchmark/bench.mjs`) emits exactly this shape, and the
@@ -9,17 +10,20 @@
  *
  * Required fields drive the dashboard. Optional fields (`samples`, `minMs`,
  * stability) carry the runner's richer per-cell data through to the JSON so a
- * published result is fully reproducible; the dashboard does not depend on them.
+ * published result is fully reproducible; the dashboard does not depend on
+ * them.
  */
 
 export type BenchmarkBranch = "legacy" | "ttsc" | "ttsc-lint";
 export type BenchmarkTool =
   | "tsc"
+  | "tsgo"
   | "ttsc"
+  | "ttsc+@ttsc/lint"
   | "eslint"
   | "@ttsc/lint"
   | "prettier";
-export type BenchmarkOp = "build" | "noEmit" | "format";
+export type BenchmarkOp = "build" | "noEmit" | "eslint" | "format";
 export type BenchmarkThreading = "single" | "multi";
 
 /**
@@ -52,10 +56,13 @@ export interface BenchmarkMeasurement {
   raceRetries?: number;
   /** Kind of the deterministic failure when the cell could not be measured. */
   failure?: BenchmarkFailureKind;
+  /** Process exit status when the cell failed deterministically. */
+  exitStatus?: number;
 }
 
 export interface BenchmarkProject {
   name: string;
+  repo?: string;
   files: number;
   kind: string;
   measurements: BenchmarkMeasurement[];
@@ -69,11 +76,14 @@ export interface BenchmarkHost {
   ramGB: number;
   node: string;
   ttsc: string;
+  tsgo: string;
   typescript: string;
 }
 
 export interface BenchmarkReport {
   date: string;
+  runs?: number;
+  warmup?: number;
   host: BenchmarkHost;
   projects: BenchmarkProject[];
 }

--- a/website/src/components/benchmark/types.ts
+++ b/website/src/components/benchmark/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Shape of `public/benchmark.json` — the committed, served benchmark result file.
+ *
+ * The benchmark runner (`experimental/benchmark`) drops real medians in later;
+ * the schema is intentionally sparse so a project may carry only some of the
+ * branch × tool × op × threading combinations.
+ */
+
+export type BenchmarkBranch = "legacy" | "ttsc" | "ttsc-lint";
+export type BenchmarkTool =
+  | "tsc"
+  | "ttsc"
+  | "eslint"
+  | "@ttsc/lint"
+  | "prettier";
+export type BenchmarkOp = "build" | "noEmit" | "format";
+export type BenchmarkThreading = "single" | "multi";
+
+export interface BenchmarkMeasurement {
+  branch: BenchmarkBranch;
+  tool: BenchmarkTool;
+  op: BenchmarkOp;
+  threading: BenchmarkThreading;
+  /** Median wall-clock time in milliseconds across the measured runs. */
+  medianMs: number;
+}
+
+export interface BenchmarkProject {
+  name: string;
+  files: number;
+  kind: string;
+  measurements: BenchmarkMeasurement[];
+}
+
+export interface BenchmarkHost {
+  os: string;
+  kernel: string;
+  cpu: string;
+  cores: number;
+  ramGB: number;
+  node: string;
+  ttsc: string;
+  typescript: string;
+}
+
+export interface BenchmarkReport {
+  date: string;
+  host: BenchmarkHost;
+  projects: BenchmarkProject[];
+}

--- a/website/src/content/docs/_meta.ts
+++ b/website/src/content/docs/_meta.ts
@@ -3,7 +3,6 @@ import type { MetaRecord } from "nextra";
 const meta: MetaRecord = {
   index: "🙋🏻‍♂️ Introduction",
   setup: "📦 Setup",
-  benchmark: "🏁 Benchmark",
 
   "-- features": { type: "separator", title: "📖 Features" },
   ttsc: "TTSC",
@@ -15,6 +14,7 @@ const meta: MetaRecord = {
   wasm: "WASM Module",
 
   "-- appendix": { type: "separator", title: "🔗 Appendix" },
+  benchmark: "Benchmark",
   faq: "FAQ",
 };
 export default meta;

--- a/website/src/content/docs/_meta.ts
+++ b/website/src/content/docs/_meta.ts
@@ -3,6 +3,7 @@ import type { MetaRecord } from "nextra";
 const meta: MetaRecord = {
   index: "🙋🏻‍♂️ Introduction",
   setup: "📦 Setup",
+  benchmark: "🏁 Benchmark",
 
   "-- features": { type: "separator", title: "📖 Features" },
   ttsc: "TTSC",

--- a/website/src/content/docs/benchmark.mdx
+++ b/website/src/content/docs/benchmark.mdx
@@ -46,3 +46,26 @@ does not currently have a valid comparable command for that tool.
   `tsgo --noEmit`.
 - **Lint**: legacy `tsc + eslint` versus `ttsc + @ttsc/lint`, plus the isolated
   `eslint` time versus the measured `@ttsc/lint` overhead.
+
+## Reproduce
+
+The runner starts from an empty `experimental/benchmark/.work` directory. It
+packs the local `ttsc` workspace into tarballs, clones the fixture branches,
+installs those tarballs into the `ttsc` and `ttsc-lint` clones, runs
+`ttsc prepare`, then measures each cell sequentially so projects do not compete
+for CPU during timing.
+
+```bash
+git clone https://github.com/samchon/ttsc.git
+cd ttsc
+corepack enable
+pnpm install
+
+node experimental/benchmark/bench.mjs --fresh \
+  vue type-fest typeorm zod nestjs vscode shopping-backend
+```
+
+The published run uses one warmup and ten measured runs per cell. Results are
+written to `experimental/benchmark/.work/report.md`,
+`experimental/benchmark/.work/report.json`, and
+`website/public/benchmark.json`.

--- a/website/src/content/docs/benchmark.mdx
+++ b/website/src/content/docs/benchmark.mdx
@@ -1,38 +1,48 @@
 import BenchmarkDashboard from "../../components/benchmark/BenchmarkDashboard";
 
-# 🏁 Benchmark
+# Benchmark
 
-`ttsc` is the same toolchain you already run — compiler, linter, formatter — rebuilt on TypeScript-Go. This page measures the one thing that decides whether that matters in practice: **wall-clock time**.
+This page measures the practical question behind `ttsc`: how much wall-clock
+time changes when a real TypeScript project moves from the legacy
+`tsc`/`eslint` path to TypeScript-Go backed builds, checks, and linting.
 
-Every number below is a median of repeated runs on a fixed machine, comparing the legacy toolchain (`tsc` · `eslint` · `prettier`) against `ttsc` and `@ttsc/lint` on the *same* source tree.
+The fixtures are real repositories cloned into prepared `legacy`, `ttsc`, and
+`ttsc-lint` branches. The dashboard reports medians from repeated command-line
+runs on the same machine, so the ratios are the useful signal; absolute seconds
+still depend on the host shown below.
 
 <BenchmarkDashboard />
 
-## What it measures
+## Reading the Results
 
-Each fixture is checked out twice from an identical source tree — once configured for the legacy toolchain, once for `ttsc` — so every comparison is like-for-like.
+The Summary tab keeps only the strongest result in each category. Build and
+Type-check compare one unit of work across the legacy compiler, `ttsc` in
+single-threaded and default multi-threaded modes, and direct `tsgo` where the
+fixture supports it.
 
-- **Build** — full `tsc` vs `ttsc`: type-check the project and emit JS + `.d.ts`.
-- **Type-check** — `tsc --noEmit` vs `ttsc --noEmit`: the check pass alone, no files written.
-- **Parallelism** — `ttsc` with its default parallel parse/emit vs `ttsc --singleThreaded`, which runs TypeScript-Go fully serial. This isolates how much of the speedup comes from using every core.
-- **Format** — `prettier` rewriting the source tree vs `ttsc format`, which formats through the same compiler pass.
+Lint is intentionally split out. The legacy path is `tsc + eslint`, two
+separate passes over the project. The `ttsc-lint` path runs `ttsc` with
+`@ttsc/lint` loaded, so the chart separates the compile portion from the extra
+lint overhead and also shows the pure lint-to-lint ratio.
 
-The headline of the build numbers is architectural. `eslint` is a *second* process that re-parses the whole project; `@ttsc/lint` folds linting into the single `ttsc` compile pass. So a `ttsc` build with lint configured already *is* build + lint — there is no separate lint step to time.
+## Methodology
 
-## The fixtures
+Each fixture is checked out as `legacy`, `ttsc`, and `ttsc-lint`. The `ttsc`
+branches run `ttsc prepare` before timing so plugin binary build time is not
+included in compiler measurements. No benchmark-only `tsconfig` is used; the
+runner invokes the repository's normal TypeScript configuration for the command
+being measured.
 
-The benchmark runs against real open-source codebases rather than synthetic ones, so the numbers reflect production-shaped projects — mixed plugin usage, deep type graphs, and large file counts.
+Each cell runs one warmup followed by ten measured runs. The runner records the
+median, fastest sample, full sample list, retry counts, and deterministic
+failures in `website/public/benchmark.json`. A missing bar means that project
+does not currently have a valid comparable command for that tool.
 
-Each project is tagged by `kind`:
+## Comparisons
 
-- **plugin-heavy** — leans on `ttsc` transform plugins (e.g. `typia`), where the plugin pass is part of every build.
-- **type-check-heavy** — large, deeply generic type graphs where the checker dominates.
-- **library** — published packages with broad `.d.ts` emit surface.
-
-A project only carries the measurements that make sense for it; the dashboard renders whatever is present and skips the rest.
-
-## Method
-
-Each command runs one unmeasured warmup (absorbing first-run plugin compilation and cold filesystem cache) followed by several measured runs; the **median** is reported. A measured run that exits non-zero is retried so an unrelated stability issue never contaminates a timing sample.
-
-The benchmark harness lives in [`experimental/benchmark`](https://github.com/samchon/ttsc/tree/master/experimental/benchmark) and writes the result file served on this page. Numbers are tied to the machine in the **Measurement host** panel above — treat the *ratios* as the portable result, not the absolute milliseconds.
+- **Build**: `tsc` emit on the legacy branch versus `ttsc` and optional direct
+  `tsgo` emit on the `ttsc` branch.
+- **Type-check**: `tsc --noEmit` versus `ttsc --noEmit` and optional direct
+  `tsgo --noEmit`.
+- **Lint**: legacy `tsc + eslint` versus `ttsc + @ttsc/lint`, plus the isolated
+  `eslint` time versus the measured `@ttsc/lint` overhead.

--- a/website/src/content/docs/benchmark.mdx
+++ b/website/src/content/docs/benchmark.mdx
@@ -1,0 +1,38 @@
+import BenchmarkDashboard from "../../components/benchmark/BenchmarkDashboard";
+
+# 🏁 Benchmark
+
+`ttsc` is the same toolchain you already run — compiler, linter, formatter — rebuilt on TypeScript-Go. This page measures the one thing that decides whether that matters in practice: **wall-clock time**.
+
+Every number below is a median of repeated runs on a fixed machine, comparing the legacy toolchain (`tsc` · `eslint` · `prettier`) against `ttsc` and `@ttsc/lint` on the *same* source tree.
+
+<BenchmarkDashboard />
+
+## What it measures
+
+Each fixture is checked out twice from an identical source tree — once configured for the legacy toolchain, once for `ttsc` — so every comparison is like-for-like.
+
+- **Build** — full `tsc` vs `ttsc`: type-check the project and emit JS + `.d.ts`.
+- **Type-check** — `tsc --noEmit` vs `ttsc --noEmit`: the check pass alone, no files written.
+- **Parallelism** — `ttsc` with its default parallel parse/emit vs `ttsc --singleThreaded`, which runs TypeScript-Go fully serial. This isolates how much of the speedup comes from using every core.
+- **Format** — `prettier` rewriting the source tree vs `ttsc format`, which formats through the same compiler pass.
+
+The headline of the build numbers is architectural. `eslint` is a *second* process that re-parses the whole project; `@ttsc/lint` folds linting into the single `ttsc` compile pass. So a `ttsc` build with lint configured already *is* build + lint — there is no separate lint step to time.
+
+## The fixtures
+
+The benchmark runs against real open-source codebases rather than synthetic ones, so the numbers reflect production-shaped projects — mixed plugin usage, deep type graphs, and large file counts.
+
+Each project is tagged by `kind`:
+
+- **plugin-heavy** — leans on `ttsc` transform plugins (e.g. `typia`), where the plugin pass is part of every build.
+- **type-check-heavy** — large, deeply generic type graphs where the checker dominates.
+- **library** — published packages with broad `.d.ts` emit surface.
+
+A project only carries the measurements that make sense for it; the dashboard renders whatever is present and skips the rest.
+
+## Method
+
+Each command runs one unmeasured warmup (absorbing first-run plugin compilation and cold filesystem cache) followed by several measured runs; the **median** is reported. A measured run that exits non-zero is retried so an unrelated stability issue never contaminates a timing sample.
+
+The benchmark harness lives in [`experimental/benchmark`](https://github.com/samchon/ttsc/tree/master/experimental/benchmark) and writes the result file served on this page. Numbers are tied to the machine in the **Measurement host** panel above — treat the *ratios* as the portable result, not the absolute milliseconds.

--- a/website/src/content/docs/benchmark.mdx
+++ b/website/src/content/docs/benchmark.mdx
@@ -33,10 +33,11 @@ included in compiler measurements. No benchmark-only `tsconfig` is used; the
 runner invokes the repository's normal TypeScript configuration for the command
 being measured.
 
-Each cell runs one warmup followed by ten measured runs. The runner records the
+The run count is configured by `TTSC_BENCH_RUNS` and `TTSC_BENCH_WARMUP`, and
+the chosen values are recorded in `website/public/benchmark.json` with the
 median, fastest sample, full sample list, retry counts, and deterministic
-failures in `website/public/benchmark.json`. A missing bar means that project
-does not currently have a valid comparable command for that tool.
+failures. A missing bar means that project does not currently have a valid
+comparable command for that tool.
 
 ## Comparisons
 
@@ -61,11 +62,15 @@ cd ttsc
 corepack enable
 pnpm install
 
-node experimental/benchmark/bench.mjs --fresh \
-  vue type-fest typeorm zod nestjs vscode shopping-backend
+rm -rf experimental/benchmark/.work
+TTSC_BENCH_RUNS=1 TTSC_BENCH_WARMUP=0 node experimental/benchmark/bench.mjs
 ```
 
-The published run uses one warmup and ten measured runs per cell. Results are
-written to `experimental/benchmark/.work/report.md`,
-`experimental/benchmark/.work/report.json`, and
-`website/public/benchmark.json`.
+The current published snapshot uses one measured run and no warmup per cell so
+the PR can finish in a practical time. Including local tarball packing,
+clone setup, dependency refresh, `ttsc prepare`, and all measurements, it took
+1,401 seconds, about 23 minutes 21 seconds, on the host shown in the dashboard.
+For a statistically steadier publication run, omit the two `TTSC_BENCH_*`
+environment variables to use the runner defaults. Results are written to
+`experimental/benchmark/.work/report.md`,
+`experimental/benchmark/.work/report.json`, and `website/public/benchmark.json`.

--- a/website/src/content/docs/development/concepts/protocol.mdx
+++ b/website/src/content/docs/development/concepts/protocol.mdx
@@ -74,6 +74,7 @@ interface ITtscPlugin {
   source: string;
   composes?: string[];
   stage?: "transform" | "check";
+  reportsTypeScriptDiagnostics?: boolean;
   contributors?: ITtscPluginContributor[];
 }
 
@@ -89,6 +90,11 @@ Field rules:
 - `source`: Go package directory or `go.mod` file. A `package main` source builds as an executable sidecar. A non-`main` transform source is linked into the selected native host and must register itself through `driver.RegisterPlugin`. Relative paths are resolved from the consumer project root; package descriptors should usually return an absolute path based on `__dirname`.
 - `composes`: optional list of other plugin names (or original `transform` specifiers) whose source build should be redirected to this descriptor's `source`. Composition is **one hop only**: `A.composes = ["B"]` sends B to A's binary, but if `B.composes = ["C"]` then C is sent to B's original binary, not A's. Reciprocal entries (`A.composes = ["B"]` and `B.composes = ["A"]`) are rejected as a cycle.
 - `stage`: plugin kind. Omit for `"transform"`.
+- `reportsTypeScriptDiagnostics`: check-stage capability flag. Set this only
+  when the sidecar's `check` subcommand loads the project Program and reports
+  normal TypeScript diagnostics itself; `ttsc` then skips the redundant
+  `tsgo --noEmit` guard. Ordinary check plugins should leave it unset so
+  TypeScript diagnostics are still merged after their own output.
 - `contributors`: optional list of additional Go source packages to statically link into this plugin's binary at build time. Each entry's `source` is copied into the scratch build tree as `<scratch>/contrib/<name>/`, and a synthesized blank import in the entry package triggers the contributor's `init()` before `main`. See [Contributors](#contributors) below.
 
 `ttsc` accepts Go source only. It builds the source with the pinned Go toolchain and TypeScript-Go shim overlay, then caches the resulting executable.

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -52,6 +52,12 @@ text := shimprinter.EmitSourceFile(printer, file)
 
 For the `transform` subcommand, the host treats `typescript[fileName]` as opaque text — see [Plugin protocol → Transform](/docs/development/concepts/protocol#transform). Run a printer before placing AST-mutated source in the map.
 
+### Emit-concurrency contract
+
+TypeScript-Go emits source files in parallel — one emitter goroutine per source. ttsc nonetheless **guarantees your `WriteFile` callback runs single-threaded**: both `EmitAll` and `EmitAllRaw` funnel every invocation through one internal mutex, so the callback never executes on two goroutines at once. A plugin's output rewriter is therefore free to carry per-file state — rewrite cursors, an output map, a runtime-alias cache — in a plain Go map without locking it yourself; ttsc owns the serialization. The callback body is cheap I/O, so serializing it costs effectively nothing while parsing, type-checking, and emit-text generation still parallelize.
+
+This is the one ttsc-layered phase that observes emit at all; everything else a plugin does (`SourcePreamble`, `ApplyProgram`, rewrite collection against the pooled `Checker`) already runs on ttsc's own serial path.
+
 ## Diagnostics
 
 ```go


### PR DESCRIPTION
## Scope

Consolidated branch — three commits:

1. **`fix(test)`** — drop the withdrawn inline plugin config key from the strict-flag test.

2. **`feat(benchmark)`** — `experimental/benchmark/`: a reproducible wall-clock benchmark comparing the legacy TypeScript toolchain (`tsc` / `prettier` / `eslint`) against the `ttsc` toolchain (`ttsc` / `@ttsc/lint`) on the `shopping-backend` codebase. Groups: build speed, format speed, build + lint. `bench.mjs` runs warmup + median-of-N and retries crashed runs so a stability bug never leaks into the speed numbers.

3. **`fix(ttsc)`** — serialize `EmitAllRaw`'s `WriteFile` callback under parallel emit (fixes #115). #112's parallel emit raced the `@nestia/core` plugin's own output rewriter; `EmitAllRaw` now serializes its callback under a per-call mutex, mirroring `EmitAll`. Includes a `-race` regression test and a doc section on the emit-concurrency contract. Verified: fixed `ttsc` 20/20 builds with 0 crashes vs. 8/20 crashes unfixed.

## Test plan

- `go test -race` on the new regression test passes; reverting the mutex reproduces the data race.
- Benchmark first results: `build:main` `tsc` 23.9 s → `ttsc` 5.9 s (~4×); `prettier` 3.9 s → `ttsc format` 2.3 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
