### PR TITLE
fix(ttsc): serialize EmitAllRaw's WriteFile callback under parallel emit

### DIFF
--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -279,7 +279,8 @@ func parseTsgoArgs(args []string, host shimcompiler.CompilerHost) (*core.Compile
 // phases ttsc layers on top — plugin application and the output rewriter —
 // still run serially against a single pooled checker, which stays valid
 // against the larger pool. Concurrency surfaces only inside each
-// TypeScript-Go phase; see EmitAll for the WriteFile-callback consequence.
+// TypeScript-Go phase; both EmitAll and EmitAllRaw serialize the WriteFile
+// callback under a mutex so the emit-stage rewriter never observes the pool.
 func CreateProgramFromConfig(parsed *tsoptions.ParsedCommandLine, host shimcompiler.CompilerHost) (*shimcompiler.Program, []Diagnostic, error) {
   if parsed == nil {
     return nil, nil, fmt.Errorf("driver: nil parsed command line")

--- a/packages/ttsc/driver/rewrite.go
+++ b/packages/ttsc/driver/rewrite.go
@@ -83,10 +83,14 @@ func (p *Program) EmitAll(rs *RewriteSet, writeFile shimcompiler.WriteFile) (*sh
 
 // EmitAllRaw runs TypeScript-Go emit without ttsc output-text rewrites.
 //
-// Unlike EmitAll, `writeFile` is handed straight to TypeScript-Go's parallel
-// emitter, so it MUST be safe to invoke concurrently: writing distinct files
-// (the default disk writer, the source-preamble writer) is fine; a callback
-// that mutates shared state must guard it.
+// `writeFile` does not need to be concurrency-safe: like EmitAll, EmitAllRaw
+// funnels every invocation through one mutex, so the callback never runs on
+// two goroutines at once even though TypeScript-Go emits files in parallel.
+// This is the contract a plugin's output rewriter relies on — it is the
+// emit-stage phase ttsc guarantees runs single-threaded (a plugin's WriteFile
+// is the standard place to carry per-file cursors or an output map), so ttsc
+// owns the serialization rather than pushing goroutine-safety onto every
+// plugin author. See the emit-concurrency contract in the plugin docs.
 func (p *Program) EmitAllRaw(writeFile shimcompiler.WriteFile) (*shimcompiler.EmitResult, []Diagnostic, error) {
   if p == nil || p.TSProgram == nil {
     return nil, nil, errors.New("driver: nil program")
@@ -94,11 +98,22 @@ func (p *Program) EmitAllRaw(writeFile shimcompiler.WriteFile) (*shimcompiler.Em
   if err := p.ApplyLinkedPlugins(); err != nil {
     return nil, nil, err
   }
-  wf := writeFile
-  if wf == nil {
-    wf = func(fileName, text string, data *shimcompiler.WriteFileData) error {
-      return DefaultWriteFile(fileName, text)
+  // TypeScript-Go's parallel emit invokes WriteFile once per emitted file,
+  // concurrently — one goroutine per source file. Serialize the whole callback
+  // under wfMu so a plugin's output rewriter sees one writer at a time: a
+  // callback that mutates shared state (e.g. @nestia/core's per-file rewrite
+  // cursors and runtime-alias cache) would otherwise trip `fatal error:
+  // concurrent map read and map write`. The callback is cheap I/O, so
+  // serializing it costs ~nothing while parse/check/emit-text still parallelize
+  // — the same trade EmitAll makes for its own WriteFile.
+  var wfMu sync.Mutex
+  wf := func(fileName, text string, data *shimcompiler.WriteFileData) error {
+    wfMu.Lock()
+    defer wfMu.Unlock()
+    if writeFile != nil {
+      return writeFile(fileName, text, data)
     }
+    return DefaultWriteFile(fileName, text)
   }
   result := p.TSProgram.Emit(context.Background(), shimcompiler.EmitOptions{
     WriteFile: wf,

--- a/packages/ttsc/test/driver/emit_raw_serializes_write_callback_under_parallel_emit_test.go
+++ b/packages/ttsc/test/driver/emit_raw_serializes_write_callback_under_parallel_emit_test.go
@@ -1,0 +1,78 @@
+package driver_test
+
+import (
+  "fmt"
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverEmitRawSerializesWriteCallbackUnderParallelEmit verifies that
+// EmitAllRaw funnels its WriteFile callback through one mutex even though
+// TypeScript-Go emits files in parallel.
+//
+// With SingleThreaded dropped (PR #112), TypeScript-Go runs one emitter
+// goroutine per source file. EmitAll already serializes its callback, but
+// EmitAllRaw — the seam a plugin's own output rewriter uses (e.g. @nestia/core,
+// which carries per-file rewrite cursors and a runtime-alias cache) — used to
+// hand the callback straight to the parallel emitter. A stateful callback then
+// tripped `fatal error: concurrent map read and map write` (issue #115). This
+// case mutates a bare, unguarded map from inside the callback across many
+// sources, so `go test -race` flags the regression if the mutex is ever
+// removed. A single-source fixture cannot surface it — only one emitter spawns.
+//
+// 1. Load a multi-file project so the parallel emitter actually fans out.
+// 2. EmitAllRaw with a callback that reads and writes a shared unguarded map.
+// 3. Assert every source produced exactly one output with no lost writes.
+func TestDriverEmitRawSerializesWriteCallbackUnderParallelEmit(t *testing.T) {
+  root := t.TempDir()
+
+  // Scenario setup: enough sources that TypeScript-Go's parallel emit spawns
+  // many concurrent emitter goroutines, each invoking the WriteFile callback.
+  names := []string{"index", "alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta"}
+  writeProjectFile(t, root, "tsconfig.json", fmt.Sprintf(`{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true
+  },
+  "files": [%s]
+}
+`, `"`+strings.Join(filesList(names), `", "`)+`"`))
+  for _, name := range names {
+    writeProjectFile(t, root, name+".ts", fmt.Sprintf("export const value = %q;\n", name))
+  }
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  // Emit assertion: `emitted` is a deliberately unguarded map standing in for a
+  // plugin's per-file rewrite state. Both the read (length probe) and the write
+  // happen inside the callback; without EmitAllRaw's mutex the concurrent
+  // emitter goroutines would race it.
+  emitted := map[string]bool{}
+  _, emitDiags, err := prog.EmitAllRaw(func(fileName, _ string, _ *shimcompiler.WriteFileData) error {
+    _ = len(emitted)
+    emitted[fileName] = true
+    return nil
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+  if len(emitted) != len(names) {
+    t.Fatalf("expected %d emitted outputs, got %d: %#v", len(names), len(emitted), emitted)
+  }
+}

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -52,6 +52,12 @@ text := shimprinter.EmitSourceFile(printer, file)
 
 For the `transform` subcommand, the host treats `typescript[fileName]` as opaque text — see [Plugin protocol → Transform](/docs/development/concepts/protocol#transform). Run a printer before placing AST-mutated source in the map.
 
+### Emit-concurrency contract
+
+TypeScript-Go emits source files in parallel — one emitter goroutine per source. ttsc nonetheless **guarantees your `WriteFile` callback runs single-threaded**: both `EmitAll` and `EmitAllRaw` funnel every invocation through one internal mutex, so the callback never executes on two goroutines at once. A plugin's output rewriter is therefore free to carry per-file state — rewrite cursors, an output map, a runtime-alias cache — in a plain Go map without locking it yourself; ttsc owns the serialization. The callback body is cheap I/O, so serializing it costs effectively nothing while parsing, type-checking, and emit-text generation still parallelize.
+
+This is the one ttsc-layered phase that observes emit at all; everything else a plugin does (`SourcePreamble`, `ApplyProgram`, rewrite collection against the pooled `Checker`) already runs on ttsc's own serial path.
+
 ## Diagnostics
 
 ```go


### PR DESCRIPTION
## Intent

Fixes #115 — `ttsc` builds of projects using the `@nestia/core` source plugin crash intermittently (~1 in 3) with `fatal error: concurrent map read and map write`.

## Root cause

PR #112 dropped `SingleThreaded`, so `Program.Emit` now runs one emitter goroutine per source file. That PR serialized `EmitAll`'s `WriteFile` callback under a mutex (to protect ttsc's `cursors` map and a caller's wrapped writer) — but `EmitAllRaw` was left handing the callback straight to the parallel emitter, documented as requiring a concurrency-safe callback.

`EmitAllRaw` is precisely the seam a plugin's *own* output rewriter uses: a plugin that does its own rewriting cannot use ttsc's `RewriteSet`. The `@nestia/core` plugin's `EmitAllRaw` callback carries per-file rewrite cursors and a lazily-populated runtime-alias map (`nativeRewriteSet.sortedAliasesByPath`). Running that callback on the parallel emitter races those maps. Confirmed crash trace: `nativeRewriteSet.RuntimeAliasesForOutput` → `runBuild.func1` → `EmitAllRaw.func1` → `emitter.writeText` → `printSourceFile`.

## Scope

ttsc owns the emit pass and the plugin contract, so it guarantees the emit-stage rewriter runs single-threaded rather than pushing goroutine-safety onto every plugin author — the same trade #112 made for `EmitAll`.

- `driver/rewrite.go` — `EmitAllRaw` now serializes its `WriteFile` callback under a per-call mutex (mirrors `emit()`'s `wfMu`). The callback is cheap I/O, so parse/check/emit-text generation still parallelize.
- `driver/program.go` — doc comment updated: both `EmitAll` and `EmitAllRaw` serialize the callback.
- `website/.../driver-api.mdx` — new "Emit-concurrency contract" section: ttsc guarantees `WriteFile` runs single-threaded; plugins may keep per-file state in a plain map without locking.
- New `-race` regression test: mutates an unguarded map from inside an `EmitAllRaw` callback across many sources.

No first-party plugin was affected — the only first-party `EmitAllRaw` caller (the utility source-preamble writer) is stateless. No change needed in the `nestia` or `typia` repos: the ttsc-side fix fully resolves the race for every plugin.

## Test plan

- `go test -race` on the new regression test: passes with the fix; reverting the mutex reproduces `DATA RACE` and a test failure.
- Full `driver` Go test suite passes (`-race`).
- Integration: rebuilt `ttsc`, installed into an isolated copy of `shopping-backend@next` (`@nestia/core` source plugin), looped `npm run build:main`:
  - **Fixed ttsc: 20/20 builds passed, 0 crashes.**
  - **Unfixed ttsc (control): 8/20 builds crashed** with `concurrent map read and map write` — matches the reported ~1-in-3 rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)