### PR TITLE
docs(website): add ttsc lint blog article

### DIFF
--- a/website/build/blog-metadata.cjs
+++ b/website/build/blog-metadata.cjs
@@ -1,0 +1,161 @@
+const fs = require("fs");
+const path = require("path");
+
+const CONTENT_DIR =
+  [
+    path.join(process.cwd(), "src", "content", "blog"),
+    path.join(process.cwd(), "website", "src", "content", "blog"),
+    path.join(__dirname, "..", "src", "content", "blog"),
+  ].find((candidate) => fs.existsSync(candidate)) ??
+  path.join(process.cwd(), "src", "content", "blog");
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---/;
+const DESCRIPTION_MAX_LENGTH = 180;
+
+const decodeHtmlEntities = (value) =>
+  value
+    .replaceAll("&amp;", "&")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&#39;", "'");
+
+const collapseWhitespace = (value) => value.replace(/\s+/g, " ").trim();
+
+const trimDescription = (value) => {
+  if (value.length <= DESCRIPTION_MAX_LENGTH) return value;
+  const sliced = value.slice(0, DESCRIPTION_MAX_LENGTH - 3);
+  const sentenceBoundary = Math.max(
+    sliced.lastIndexOf(". "),
+    sliced.lastIndexOf("! "),
+    sliced.lastIndexOf("? "),
+  );
+  if (sentenceBoundary > 96)
+    return sliced.slice(0, sentenceBoundary + 1).trim();
+  const boundary = sliced.lastIndexOf(" ");
+  return `${(boundary > 96 ? sliced.slice(0, boundary) : sliced).trim()}...`;
+};
+
+const cleanText = (value) =>
+  trimDescription(
+    collapseWhitespace(
+      decodeHtmlEntities(value)
+        .replace(/\{\/\*[\s\S]*?\*\/\}/g, " ")
+        .replace(/`([^`]+)`/g, "$1")
+        .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+        .replace(/<\/?[^>]+>/g, " ")
+        .replace(/[*_~>#]+/g, " "),
+    ),
+  );
+
+const looksCodeLike = (value) =>
+  /https?:\/\//i.test(value) ||
+  /(^| )\/\/ /.test(value) ||
+  /\bimport\s+\w|\bexport\s+(?:function|const|namespace)|\binterface\s+\w|\bconst\s+\w+\s*=/.test(
+    value,
+  ) ||
+  /[{};]/.test(value);
+
+const isUsableDescription = (value) => {
+  if (!value || value.length < 40) return false;
+  if (looksCodeLike(value)) return false;
+  if (/^(outline|preface|summary)\b/i.test(value)) return false;
+  return true;
+};
+
+const stripFrontmatter = (content) =>
+  content.replace(FRONTMATTER_PATTERN, "").trim();
+
+const parseFrontmatter = (content) => {
+  const match = content.match(FRONTMATTER_PATTERN);
+  if (!match) return {};
+
+  const metadata = {};
+  let currentKey = null;
+  for (const rawLine of match[1].split(/\r?\n/)) {
+    if (!rawLine.trim()) continue;
+
+    const listMatch = rawLine.match(/^\s*-\s+(.*)$/);
+    if (listMatch && currentKey) {
+      metadata[currentKey].push(listMatch[1].trim().replace(/^"|"$/g, ""));
+      continue;
+    }
+
+    const keyValueMatch = rawLine.match(/^\s*([A-Za-z0-9_]+):\s*(.*)$/);
+    if (!keyValueMatch) continue;
+
+    const [, key, value] = keyValueMatch;
+    if (value === "") {
+      metadata[key] = [];
+      currentKey = key;
+    } else {
+      metadata[key] = value.trim().replace(/^"|"$/g, "");
+      currentKey = key;
+    }
+  }
+  return metadata;
+};
+
+const extractDescriptionFromBody = (content) => {
+  const blocks = stripFrontmatter(content)
+    .replace(/```[\s\S]*?```/g, "\n\n")
+    .split(/\r?\n\s*\r?\n/);
+
+  for (const block of blocks) {
+    const trimmed = block.trim();
+    if (!trimmed) continue;
+    if (/^(import|export)\s/.test(trimmed)) continue;
+    if (/^#{1,6}\s/.test(trimmed)) continue;
+    if (/^>/.test(trimmed)) continue;
+    if (/^[-*+]\s/.test(trimmed)) continue;
+    if (/^\d+\.\s/.test(trimmed)) continue;
+    if (/^<[^>]+>/.test(trimmed)) continue;
+    if (/^\{[\s\S]*\}$/.test(trimmed)) continue;
+
+    const sentence = cleanText(trimmed);
+    if (!isUsableDescription(sentence)) continue;
+    return sentence;
+  }
+  return "";
+};
+
+const readBlogPosts = () =>
+  fs
+    .readdirSync(CONTENT_DIR)
+    .filter((file) => file.endsWith(".md") || file.endsWith(".mdx"))
+    .map((file) => {
+      const fullPath = path.join(CONTENT_DIR, file);
+      const source = fs.readFileSync(fullPath, "utf8");
+      const frontMatter = parseFrontmatter(source);
+      const slug = file.replace(/\.mdx?$/, "");
+      const explicitDescription = cleanText(frontMatter.description ?? "");
+      const description = isUsableDescription(explicitDescription)
+        ? explicitDescription
+        : extractDescriptionFromBody(source) || explicitDescription;
+      return {
+        file,
+        slug,
+        route: `/blog/${slug}`,
+        frontMatter: {
+          ...frontMatter,
+          description,
+        },
+      };
+    })
+    .filter((post) => post.frontMatter.title)
+    .sort(
+      (a, b) =>
+        new Date(b.frontMatter.date ?? 0).getTime() -
+        new Date(a.frontMatter.date ?? 0).getTime(),
+    );
+
+const readBlogPost = (slug) =>
+  readBlogPosts().find((post) => post.slug === slug) ?? null;
+
+module.exports = {
+  CONTENT_DIR,
+  parseFrontmatter,
+  readBlogPost,
+  readBlogPosts,
+};

--- a/website/build/blog.cjs
+++ b/website/build/blog.cjs
@@ -1,0 +1,47 @@
+const fs = require("fs");
+const path = require("path");
+
+const { readBlogPosts } = require("./blog-metadata.cjs");
+
+const OUTPUT_DIR = path.join(__dirname, "..", "public", "blog");
+const SITE_URL = "https://ttsc.dev";
+
+const escapeXml = (value) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+
+const posts = readBlogPosts().map((post) => ({
+  title: post.frontMatter.title ?? post.slug,
+  description: post.frontMatter.description ?? "",
+  date: post.frontMatter.date ?? new Date().toISOString().slice(0, 10),
+  slug: post.slug,
+}));
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>ttsc Blog</title>
+    <link>${SITE_URL}/blog/</link>
+    <description>Engineering notes, releases, and deep dives from ttsc.</description>
+    <language>en</language>
+${posts
+  .map(
+    (post) => `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${SITE_URL}/blog/${post.slug}/</link>
+      <guid>${SITE_URL}/blog/${post.slug}/</guid>
+      <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+      <description>${escapeXml(post.description)}</description>
+    </item>`,
+  )
+  .join("\n")}
+  </channel>
+</rss>
+`;
+
+fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+fs.writeFileSync(path.join(OUTPUT_DIR, "rss.xml"), xml);

--- a/website/mdx-components-blog.jsx
+++ b/website/mdx-components-blog.jsx
@@ -1,0 +1,127 @@
+import { useMDXComponents as getDocsMDXComponents } from "nextra-theme-docs";
+
+const docsComponents = getDocsMDXComponents();
+
+function formatDate(value) {
+  const date = value ? new Date(value) : null;
+  return Number.isNaN(date?.getTime?.()) ? null : date;
+}
+
+function groupHeadings(toc) {
+  const headings = Array.isArray(toc)
+    ? toc.filter((item) => Number(item.depth) <= 3)
+    : [];
+  const groups = [];
+  let currentGroup = null;
+  for (const item of headings) {
+    if (Number(item.depth) <= 2) {
+      currentGroup = {
+        ...item,
+        children: [],
+      };
+      groups.push(currentGroup);
+      continue;
+    }
+    if (currentGroup) currentGroup.children.push(item);
+    else {
+      groups.push({
+        ...item,
+        children: [],
+      });
+    }
+  }
+  return groups;
+}
+
+export function useMDXComponents(components) {
+  return {
+    ...docsComponents,
+    ...components,
+    wrapper({ children, metadata, toc }) {
+      const date = formatDate(metadata?.date);
+      const tags = metadata?.tags ?? [];
+      const groups = groupHeadings(toc);
+      const hasToc = groups.length > 0;
+
+      return (
+        <div
+          className={
+            hasToc
+              ? "ttsc-blog-post-page ttsc-blog-post-layout"
+              : "ttsc-blog-post-page"
+          }
+        >
+          <div className="ttsc-blog-post-main">
+            {metadata?.ogImage ? (
+              <img
+                src={metadata.ogImage}
+                alt={metadata.title ?? "Blog cover image"}
+                className="ttsc-blog-hero"
+              />
+            ) : null}
+            <h1>{metadata?.title}</h1>
+            <div className="ttsc-blog-meta">
+              {date ? (
+                <time dateTime={date.toISOString()}>
+                  {date.toLocaleDateString()}
+                </time>
+              ) : null}
+              {metadata?.author ? <span>{metadata.author}</span> : null}
+              {metadata?.devtoUrl ? (
+                <a href={metadata.devtoUrl} target="_blank" rel="noreferrer">
+                  Original on DEV
+                </a>
+              ) : null}
+            </div>
+            {tags.length ? (
+              <div className="ttsc-blog-tags">
+                {tags.map((tag) => (
+                  <span key={tag}>#{tag}</span>
+                ))}
+              </div>
+            ) : null}
+            {children}
+          </div>
+          {hasToc ? (
+            <aside className="ttsc-blog-toc" aria-label="Table of contents">
+              <div className="ttsc-blog-toc-inner">
+                <div className="ttsc-blog-toc-title">On This Page</div>
+                <nav aria-label="Table of contents">
+                  <ul className="ttsc-blog-toc-list">
+                    {groups.map((item) => (
+                      <li key={item.id} className="ttsc-blog-toc-item">
+                        <a
+                          href={`#${item.id}`}
+                          className={`ttsc-blog-toc-link ttsc-blog-toc-depth-${item.depth}`}
+                        >
+                          {item.value}
+                        </a>
+                        {item.children.length ? (
+                          <ul className="ttsc-blog-toc-sublist">
+                            {item.children.map((child) => (
+                              <li
+                                key={child.id}
+                                className="ttsc-blog-toc-subitem"
+                              >
+                                <a
+                                  href={`#${child.id}`}
+                                  className={`ttsc-blog-toc-link ttsc-blog-toc-depth-${child.depth}`}
+                                >
+                                  {child.value}
+                                </a>
+                              </li>
+                            ))}
+                          </ul>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                </nav>
+              </div>
+            </aside>
+          ) : null}
+        </div>
+      );
+    },
+  };
+}

--- a/website/package.json
+++ b/website/package.json
@@ -5,9 +5,10 @@
   "private": true,
   "scripts": {
     "build": "pnpm run prebuild && pnpm run build:next && pnpm run postbuild",
-    "prebuild": "rimraf .next && rimraf out && pnpm run build:compiler",
+    "prebuild": "rimraf .next && rimraf out && pnpm run build:compiler && pnpm run build:blog:rss",
     "build:next": "next build",
     "build:compiler": "node build/compiler.cjs",
+    "build:blog:rss": "node build/blog.cjs",
     "postbuild": "pnpm run build:pagefind && pnpm run build:sitemap",
     "build:pagefind": "pagefind --site .next/server/app --output-path out/_pagefind",
     "build:sitemap": "next-sitemap",

--- a/website/src/app/[[...mdxPath]]/page.jsx
+++ b/website/src/app/[[...mdxPath]]/page.jsx
@@ -2,7 +2,7 @@ import { generateStaticParamsFor, importPage } from "nextra/pages";
 
 import { useMDXComponents as getMDXComponents } from "../../../mdx-components";
 
-const CUSTOM_ROUTES = new Set(["playground"]);
+const CUSTOM_ROUTES = new Set(["blog", "playground"]);
 
 export async function generateStaticParams() {
   const params = await generateStaticParamsFor("mdxPath")();

--- a/website/src/app/blog/BlogPostCard.jsx
+++ b/website/src/app/blog/BlogPostCard.jsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+
+function formatDate(date) {
+  const value = date ? new Date(date) : null;
+  return Number.isNaN(value?.getTime?.()) ? null : value.toLocaleDateString();
+}
+
+export default function BlogPostCard({ post }) {
+  const { frontMatter } = post;
+  const tags = frontMatter.tags ?? [];
+  const date = formatDate(frontMatter.date);
+
+  return (
+    <Link href={post.route} className="ttsc-blog-card">
+      <img
+        src={frontMatter.ogImage ?? "/og.jpg"}
+        alt={frontMatter.title ?? "Blog cover image"}
+        className="ttsc-blog-card-image"
+      />
+      <div className="ttsc-blog-card-body">
+        <h2 className="ttsc-blog-card-title">{frontMatter.title}</h2>
+        {frontMatter.description ? (
+          <p className="ttsc-blog-card-description">
+            {frontMatter.description}
+          </p>
+        ) : null}
+        {tags.length ? (
+          <div className="ttsc-blog-card-tags">
+            {tags.slice(0, 4).map((tag) => (
+              <span key={tag}>#{tag}</span>
+            ))}
+          </div>
+        ) : null}
+        <div className="ttsc-blog-card-meta">
+          {date ? <span>{date}</span> : null}
+          {frontMatter.author ? <span>{frontMatter.author}</span> : null}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/website/src/app/blog/[slug]/page.jsx
+++ b/website/src/app/blog/[slug]/page.jsx
@@ -1,0 +1,63 @@
+import { importPage } from "nextra/pages";
+
+import { useMDXComponents as getMDXComponents } from "../../../../mdx-components-blog";
+import { getPostBySlug, getPosts } from "../get-posts";
+
+const Wrapper = getMDXComponents().wrapper;
+
+export async function generateStaticParams() {
+  const posts = await getPosts();
+  return posts.map((post) => ({
+    slug: post.slug,
+  }));
+}
+
+export async function generateMetadata(props) {
+  const params = await props.params;
+  const { metadata } = await importPage(["blog", params.slug]);
+  const post = await getPostBySlug(params.slug);
+  const frontMatter = post?.frontMatter ?? {};
+  const title = frontMatter.title ?? metadata.title ?? "ttsc Blog";
+  const description =
+    frontMatter.description ??
+    metadata.description ??
+    "Engineering notes, releases, and deep dives from ttsc.";
+  const image =
+    frontMatter.ogImage ?? metadata.ogImage ?? "https://ttsc.dev/og.jpg";
+  const url = `https://ttsc.dev/blog/${params.slug}/`;
+
+  return {
+    ...metadata,
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "article",
+      images: [
+        {
+          url: image,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [image],
+    },
+  };
+}
+
+export default async function BlogPostPage(props) {
+  const params = await props.params;
+  const result = await importPage(["blog", params.slug]);
+  const { default: MDXContent, toc, metadata } = result;
+
+  return (
+    <Wrapper toc={toc} metadata={metadata}>
+      <MDXContent {...props} params={params} />
+    </Wrapper>
+  );
+}

--- a/website/src/app/blog/blog.css
+++ b/website/src/app/blog/blog.css
@@ -1,0 +1,261 @@
+.x\:prose {
+  max-width: none;
+}
+
+:has(.ttsc-blog-page) .nextra-sidebar-container,
+:has(.ttsc-blog-page) .nextra-sidebar,
+:has(.ttsc-blog-page) .nextra-breadcrumb,
+:has(.ttsc-blog-page) .nextra-toc,
+:has(.ttsc-blog-page) nav.nextra-toc {
+  display: none !important;
+}
+
+:has(.ttsc-blog-page) article {
+  max-width: 100% !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+:has(.ttsc-blog-page) main {
+  max-width: 100% !important;
+  margin: 0 !important;
+}
+
+.ttsc-blog-list-page {
+  max-width: min(1180px, calc(100vw - 2rem));
+  margin-left: auto;
+  margin-right: auto;
+  padding: 2rem 1.5rem 0;
+}
+
+.ttsc-blog-list-page > :first-child {
+  margin-top: 0;
+}
+
+.ttsc-blog-list-page > p {
+  max-width: 72rem;
+  line-height: 1.7;
+}
+
+.ttsc-blog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.25rem;
+  margin-top: 2rem;
+}
+
+.ttsc-blog-card {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid rgba(127, 127, 127, 0.2);
+  border-radius: 8px;
+  background: color-mix(in srgb, rgb(var(--nextra-bg)) 92%, white 8%);
+  text-decoration: none;
+  color: inherit;
+}
+
+.dark .ttsc-blog-card {
+  background: color-mix(in srgb, rgb(var(--nextra-bg)) 94%, white 6%);
+}
+
+.ttsc-blog-card:hover {
+  transform: translateY(-2px);
+  transition: transform 0.18s ease;
+}
+
+.ttsc-blog-card-image {
+  width: 100%;
+  aspect-ratio: 1.91 / 1;
+  object-fit: cover;
+  background: rgba(127, 127, 127, 0.08);
+}
+
+.ttsc-blog-card-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1.1rem 1.1rem 1.2rem;
+}
+
+.ttsc-blog-card-title {
+  margin: 0;
+  font-size: 1.15rem;
+  line-height: 1.35;
+}
+
+.ttsc-blog-card-description {
+  margin: 0;
+  color: rgb(95 95 95);
+  line-height: 1.6;
+}
+
+.dark .ttsc-blog-card-description {
+  color: rgb(170 170 170);
+}
+
+.ttsc-blog-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: auto;
+  font-size: 0.9rem;
+  color: rgb(110 110 110);
+}
+
+.dark .ttsc-blog-card-meta {
+  color: rgb(155 155 155);
+}
+
+.ttsc-blog-card-tags,
+.ttsc-blog-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.ttsc-blog-card-tags span,
+.ttsc-blog-tags span {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.24rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(127, 127, 127, 0.12);
+  font-size: 0.84rem;
+}
+
+.ttsc-blog-hero {
+  width: 100%;
+  max-height: 30rem;
+  object-fit: cover;
+  border-radius: 8px;
+  margin: 0 0 1.5rem;
+  background: rgba(127, 127, 127, 0.08);
+}
+
+.ttsc-blog-meta,
+.ttsc-blog-tags {
+  margin: 0 0 1rem;
+}
+
+.ttsc-blog-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: rgb(110 110 110);
+  font-size: 0.95rem;
+}
+
+.dark .ttsc-blog-meta {
+  color: rgb(160 160 160);
+}
+
+.ttsc-blog-post-page {
+  max-width: min(1100px, calc(100vw - 2rem));
+  margin-left: auto;
+  margin-right: auto;
+  padding: 2rem 1.5rem 0;
+}
+
+.ttsc-blog-post-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 260px;
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.ttsc-blog-post-main {
+  min-width: 0;
+}
+
+.ttsc-blog-toc {
+  position: sticky;
+  top: 5.5rem;
+  align-self: start;
+  max-height: calc(100vh - 7rem);
+  overflow: auto;
+}
+
+.ttsc-blog-toc-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding-left: 1rem;
+  border-left: 1px solid rgba(127, 127, 127, 0.18);
+}
+
+.ttsc-blog-toc-title {
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgb(115 115 115);
+}
+
+.dark .ttsc-blog-toc-title {
+  color: rgb(165 165 165);
+}
+
+.ttsc-blog-toc-list,
+.ttsc-blog-toc-sublist {
+  margin: 0;
+  padding-left: 1.05rem;
+}
+
+.ttsc-blog-toc-list {
+  list-style: disc;
+}
+
+.ttsc-blog-toc-sublist {
+  list-style: circle;
+  margin-top: 0.35rem;
+}
+
+.ttsc-blog-toc-item + .ttsc-blog-toc-item {
+  margin-top: 0.55rem;
+}
+
+.ttsc-blog-toc-subitem + .ttsc-blog-toc-subitem {
+  margin-top: 0.3rem;
+}
+
+.ttsc-blog-toc-link {
+  display: inline-block;
+  color: rgb(90 90 90);
+  text-decoration: none;
+  line-height: 1.45;
+  font-size: 0.95rem;
+}
+
+.dark .ttsc-blog-toc-link {
+  color: rgb(175 175 175);
+}
+
+.ttsc-blog-toc-link:hover {
+  color: inherit;
+}
+
+.ttsc-blog-toc-depth-3 {
+  font-size: 0.9rem;
+}
+
+@media (max-width: 1024px) {
+  .ttsc-blog-post-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .ttsc-blog-toc {
+    position: static;
+    top: auto;
+    max-height: none;
+    overflow: visible;
+  }
+
+  .ttsc-blog-toc-inner {
+    margin-top: 1rem;
+    padding: 1rem 0 0;
+    border-left: 0;
+    border-top: 1px solid rgba(127, 127, 127, 0.18);
+  }
+}

--- a/website/src/app/blog/get-posts.js
+++ b/website/src/app/blog/get-posts.js
@@ -1,0 +1,29 @@
+import blogMetadata from "../../../build/blog-metadata.cjs";
+
+const { readBlogPost, readBlogPosts } = blogMetadata;
+
+export async function getPosts() {
+  return readBlogPosts();
+}
+
+export async function getTagCounts() {
+  const tags = new Map();
+  for (const post of await getPosts()) {
+    for (const tag of post.frontMatter.tags ?? []) {
+      tags.set(tag, (tags.get(tag) ?? 0) + 1);
+    }
+  }
+  return [...tags.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, count]) => ({ count, name }));
+}
+
+export async function getPostsByTag(tag) {
+  return (await getPosts()).filter((post) =>
+    (post.frontMatter.tags ?? []).includes(tag),
+  );
+}
+
+export async function getPostBySlug(slug) {
+  return readBlogPost(slug);
+}

--- a/website/src/app/blog/layout.jsx
+++ b/website/src/app/blog/layout.jsx
@@ -1,0 +1,10 @@
+import "./blog.css";
+
+export const metadata = {
+  title: "Blog",
+  description: "Engineering notes, releases, and deep dives from ttsc.",
+};
+
+export default function BlogLayout(props) {
+  return <div className="ttsc-blog-page">{props.children}</div>;
+}

--- a/website/src/app/blog/page.jsx
+++ b/website/src/app/blog/page.jsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+
+import BlogPostCard from "./BlogPostCard";
+import { getPosts, getTagCounts } from "./get-posts";
+
+export const metadata = {
+  title: "Blog",
+  description: "Engineering notes, releases, and deep dives from ttsc.",
+};
+
+export default async function BlogPage() {
+  const [posts, tags] = await Promise.all([getPosts(), getTagCounts()]);
+
+  return (
+    <section className="ttsc-blog-list-page">
+      <h1>ttsc Blog</h1>
+      <p>
+        Engineering notes, release essays, and practical articles about
+        TypeScript-Go, compiler plugins, typed execution, linting, and the ttsc
+        toolchain.
+      </p>
+      {tags.length ? (
+        <p>
+          Browse by tag:{" "}
+          {tags.map((tag, index) => (
+            <span key={tag.name}>
+              {index ? " · " : ""}
+              <Link href={`/blog/tags/${encodeURIComponent(tag.name)}`}>
+                {tag.name} ({tag.count})
+              </Link>
+            </span>
+          ))}
+        </p>
+      ) : null}
+      <div className="ttsc-blog-grid">
+        {posts.map((post) => (
+          <BlogPostCard key={post.route} post={post} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/website/src/app/blog/tags/[id]/page.jsx
+++ b/website/src/app/blog/tags/[id]/page.jsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import BlogPostCard from "../../BlogPostCard";
+import { getPostsByTag, getTagCounts } from "../../get-posts";
+
+export async function generateStaticParams() {
+  const tags = await getTagCounts();
+  return tags.map((tag) => ({ id: encodeURIComponent(tag.name) }));
+}
+
+export async function generateMetadata(props) {
+  const params = await props.params;
+  const tag = decodeURIComponent(params.id);
+  return {
+    title: `#${tag}`,
+    description: `Posts tagged ${tag} on the ttsc blog.`,
+  };
+}
+
+export default async function BlogTagPage(props) {
+  const params = await props.params;
+  const tag = decodeURIComponent(params.id);
+  const posts = await getPostsByTag(tag);
+
+  if (!posts.length) notFound();
+
+  return (
+    <section className="ttsc-blog-list-page">
+      <p>
+        <Link href="/blog">Back to all posts</Link>
+      </p>
+      <h1>#{tag}</h1>
+      <p>{posts.length} post(s) tagged here.</p>
+      <div className="ttsc-blog-grid">
+        {posts.map((post) => (
+          <BlogPostCard key={post.route} post={post} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/website/src/app/layout.jsx
+++ b/website/src/app/layout.jsx
@@ -5,6 +5,7 @@ import { getPageMap } from "nextra/page-map";
 import "./global.css";
 
 export const metadata = {
+  metadataBase: new URL("https://ttsc.dev"),
   title: {
     default: "ttsc — TypeScript-Go toolchain for compiler-powered plugins",
     template: "%s · ttsc",

--- a/website/src/content/_meta.ts
+++ b/website/src/content/_meta.ts
@@ -16,6 +16,10 @@ const meta: MetaRecord = {
     type: "page",
     title: "📖 Guide Documents",
   },
+  blog: {
+    type: "page",
+    title: "📝 Blog Articles",
+  },
   playground: {
     type: "page",
     title: "🛝 Playground",

--- a/website/src/content/blog/500x-faster-typescript-lint.mdx
+++ b/website/src/content/blog/500x-faster-typescript-lint.mdx
@@ -1,0 +1,462 @@
+---
+title: "500x Faster TypeScript Lint: I Moved Lint Into TypeScript-Go"
+description: "@ttsc/lint moves lint into the TypeScript-Go-backed check path and ships a separate native format command: 500x faster lint and 70x faster format on the VS Code fixture."
+date: "2026-05-25"
+author: "Jeongho Nam"
+ogImage: "/og.jpg"
+tags:
+  - typescript
+  - go
+  - eslint
+  - opensource
+---
+
+> ## TL;DR
+>
+> I built [`@ttsc/lint`](https://github.com/samchon/ttsc/tree/master/packages/lint), a native TypeScript lint engine for [`ttsc`](https://github.com/samchon/ttsc).
+>
+> It also ships the separate `ttsc format` command.
+>
+> On the VS Code benchmark fixture:
+>
+> - `ttsc` type-checks up to **10x faster** than legacy `tsc`;
+> - the measured `@ttsc/lint` pass is around **500x faster** than ESLint;
+> - the separate `ttsc format` command is around **70x faster** than `prettier --check`.
+>
+> Yes, 500x sounds like bait.
+>
+> It is bait.
+>
+> It is also measured, and the reason is simple: once TypeScript-Go has already built the Program, lint should not start a second TypeScript pipeline.
+>
+> Benchmark: https://ttsc.dev/docs/benchmark
+>
+> Repository: https://github.com/samchon/ttsc
+
+---
+
+## 1. The Tax Nobody Questions
+
+Most TypeScript projects still run some version of this:
+
+```bash
+npx tsc --noEmit
+npx eslint .
+npx prettier --check .
+```
+
+It feels normal because we have done it for years.
+
+But if you step back, it is a weird amount of duplicate work.
+
+The compiler reads the project, parses TypeScript, builds a Program, and checks types.
+
+Then ESLint reads the project again, parses TypeScript again, builds another view of the code, and runs rules.
+
+Then Prettier reads the project again, parses enough of it again, and checks whether the printed version is stable.
+
+The source tree did not change between those commands.
+
+The question did not change either:
+
+> Is this TypeScript project acceptable enough to merge?
+
+We just ask it three different ways.
+
+[`@ttsc/lint`](https://ttsc.dev/docs/lint) is my attempt to remove the second TypeScript pipeline.
+
+Formatting is related, but it is not the same command. `@ttsc/lint` owns the `format/*` rules and the `ttsc format` command, but `ttsc --noEmit` and `ttsc format` are separate surfaces.
+
+That separation is important.
+
+---
+
+## 2. The 500x And 70x Numbers
+
+The headline numbers come from the public [`ttsc` benchmark](https://ttsc.dev/docs/benchmark). The reference project for this article is the VS Code fixture.
+
+That matters. I do not want to hide the benchmark behind a vague "large project" claim. The fixture is concrete, recognizable, and big enough that startup noise is not the whole story.
+
+On that fixture:
+
+- `ttsc` type-checks up to **10x faster** than legacy `tsc`;
+- the measured `@ttsc/lint` pass is around **500x faster** than ESLint;
+- `ttsc format` is around **70x faster** than `prettier --check`.
+
+The concrete row behind the lint headline is about 65.6 seconds for ESLint versus 129 milliseconds for the native `@ttsc/lint time` line in the `ttsc --noEmit --checkers 2` run. That is 508x, rounded down to 500x.
+
+This is not a universal promise that every repository will see exactly the same ratio. File count, rule set, TypeScript options, config shape, and plugins all matter.
+
+But the direction is the important part.
+
+Traditional linting pays for another parser and another rule runtime.
+
+Traditional formatting pays for another parse-and-print pipeline.
+
+`@ttsc/lint` moves lint into the native check lane, and gives formatting its own native command.
+
+---
+
+## 3. What I Actually Moved
+
+The title says "moved lint into TypeScript-Go", so here is the precise version.
+
+`@ttsc/lint` is not a fork of Microsoft's `tsgo` binary. It is a `ttsc` check-stage native sidecar that builds on TypeScript-Go's Program, AST, and Checker.
+
+That is still the important move.
+
+The old workflow looks like this:
+
+```text
+tsc                 -> type diagnostics
+@typescript-eslint  -> lint diagnostics
+prettier            -> format check
+```
+
+The `ttsc` workflow is split correctly:
+
+```text
+ttsc --noEmit -> TypeScript-Go Program -> type diagnostics
+                                      -> native lint diagnostics
+
+ttsc format  -> TypeScript-Go AST     -> format/* rewrites
+```
+
+`ttsc --noEmit` is the check path. It catches TypeScript diagnostics and lint diagnostics.
+
+`ttsc format` is the write path. It rewrites source using the formatter rules.
+
+Same package. Separate commands.
+
+The compiler has already opened the project for the check path. It already knows the source files. It already has TypeScript diagnostics. If a lint rule needs type information, the Checker is there too.
+
+So the linter should not rebuild the world.
+
+---
+
+## 4. The Honest Cost Model
+
+This is where performance posts usually get sloppy, so let me be explicit.
+
+I am not claiming a full command invocation costs zero milliseconds.
+
+A real `ttsc --noEmit` run with `@ttsc/lint` still has surrounding work:
+
+- starting the native sidecar process;
+- checking or building the cached plugin binary;
+- loading `lint.config.ts`;
+- reading `tsconfig.json`;
+- building the TypeScript-Go Program;
+- collecting TypeScript bind and semantic diagnostics;
+- acquiring a Checker when a type-aware rule needs one;
+- rendering diagnostics.
+
+Those costs are real.
+
+They are just not the lint pass.
+
+The benchmark's `@ttsc/lint time` line measures the native rule walk after the Program has already been loaded. In code terms, the timer starts immediately before the engine runs over the selected source files and stops immediately after that rule walk returns.
+
+What remains is mostly:
+
+- pick the project-owned source files;
+- walk TypeScript-Go AST nodes;
+- dispatch only to rules interested in each node kind;
+- call the Checker only for type-aware rules;
+- collect findings.
+
+That is why the additional lint cost can be so close to zero in practice.
+
+Not literally zero.
+
+Close enough that the old mental model breaks.
+
+```text
+legacy check = tsc + eslint
+ttsc check   = TypeScript-Go check + tiny native lint pass
+```
+
+For formatting, the benchmark is a different comparison:
+
+```text
+legacy format = prettier --check
+ttsc format   = native format/* rule walk
+```
+
+On the same VS Code fixture, `prettier --check` takes about 118.3 seconds and `ttsc format` takes about 1.5 seconds in the default run. That is roughly 76x, so I call it **70x faster format**.
+
+---
+
+## 5. What It Feels Like
+
+Take a small file:
+
+```ts
+var x: number = 3;
+let y: number = 4;
+const z: string = 5;
+
+console.log(x + y + z);
+```
+
+There are three issues:
+
+- `var x` violates `no-var`;
+- `let y` should be `const`;
+- `const z: string = 5` is a TypeScript type error.
+
+In the usual setup, TypeScript reports one of them and ESLint reports the other two.
+
+With `ttsc --noEmit` and `@ttsc/lint`, they are all compiler-style diagnostics:
+
+```text
+src/lint.ts:3:7 - error TS2322: Type 'number' is not assignable to type 'string'.
+
+3 const z: string = 5;
+        ~
+
+src/lint.ts:2:5 - error TS17397: [prefer-const] Use const instead of let.
+
+2 let y: number = 4;
+      ~~~~~~~~~~~~~
+
+src/lint.ts:1:1 - error TS11966: [no-var] Unexpected var, use let or const instead.
+
+1 var x: number = 3;
+  ~~~~~~~~~~~~~~~~~~
+```
+
+The exact diagnostic codes are not the interesting part.
+
+The shape is.
+
+Types and lint share one terminal output and one CI gate.
+
+Formatting stays a separate write command.
+
+That is a different product from "ESLint, but faster."
+
+---
+
+## 6. Setup
+
+Install:
+
+```bash
+npm install -D ttsc @ttsc/lint @typescript/native-preview
+```
+
+Create `lint.config.ts` next to `tsconfig.json`:
+
+```ts
+import type { ITtscLintConfig } from "@ttsc/lint";
+
+export default {
+  rules: {
+    "no-var": "error",
+    "prefer-const": "error",
+    "no-explicit-any": "warning",
+  },
+  format: {
+    printWidth: 100,
+    singleQuote: true,
+    trailingComma: "all",
+  },
+} satisfies ITtscLintConfig;
+```
+
+Run the check path:
+
+```bash
+npx ttsc --noEmit
+```
+
+Run the separate format path:
+
+```bash
+npx ttsc format
+```
+
+Use autofix when you want lint and format edits applied before a re-check:
+
+```bash
+npx ttsc fix
+```
+
+The commands are intentionally boring. The interesting part is what they replace.
+
+---
+
+## 7. Why A Separate lint.config.ts?
+
+Early versions of this idea put lint options inside `compilerOptions.plugins`.
+
+I backed away from that.
+
+`tsconfig.json` should describe the TypeScript project. It can point at compiler plugins, but it should not become the home for every plugin's private configuration language.
+
+So `@ttsc/lint` uses dedicated config files:
+
+```text
+lint.config.ts
+lint.config.mts
+lint.config.cts
+lint.config.js
+lint.config.mjs
+lint.config.cjs
+lint.config.json
+```
+
+The file is discovered by walking upward from the project. If a project needs an explicit path, the tsconfig plugin entry accepts `configFile`.
+
+That keeps the migration legible:
+
+```text
+.eslintrc.*      -> lint.config.ts rules
+.prettierrc.*    -> lint.config.ts format
+tsconfig.json    -> TypeScript project
+```
+
+Small boundary, big difference.
+
+---
+
+## 8. Formatting Is Not The Check Command
+
+The package is called `@ttsc/lint`, but it also owns common TypeScript formatting.
+
+That does not mean `ttsc --noEmit` secretly runs `ttsc format`.
+
+It does not.
+
+`ttsc format` is a separate command because formatting writes source files. That command uses `format/*` rules from `@ttsc/lint`:
+
+```ts
+format: {
+  printWidth: 100,
+  singleQuote: true,
+  trailingComma: "all",
+}
+```
+
+The formatter covers rules such as semicolons, quotes, trailing commas, print-width reflow, import ordering, and JSDoc normalization.
+
+This does not mean "every Prettier plugin is replaced."
+
+It means the common TypeScript formatting path can stay in the same native toolchain while keeping the right command boundary:
+
+```bash
+npx ttsc --noEmit  # type + lint
+npx ttsc format    # format
+```
+
+---
+
+## 9. What This Does Not Replace Yet
+
+`@ttsc/lint` does not run existing ESLint plugins.
+
+It does not run existing Prettier plugins.
+
+It does not mean every project should delete ESLint today.
+
+That tradeoff is real:
+
+| Path         | Best at                                         |
+| ------------ | ----------------------------------------------- |
+| ESLint       | Huge JavaScript rule ecosystem                  |
+| Prettier     | Huge formatting ecosystem and language coverage |
+| `@ttsc/lint` | Native TypeScript-focused compiler integration  |
+
+If your repo depends on a pile of custom ESLint plugins, keep them.
+
+If your repo mostly needs TypeScript rules, type-aware checks, core formatting, and faster CI feedback, `@ttsc/lint` is worth trying now.
+
+You do not have to migrate in one dramatic pull request.
+
+Start small. Run it beside the old pipeline. Delete old steps only after the new one becomes boring.
+
+---
+
+## 10. Why This Is Part One
+
+This article is about `@ttsc/lint` because **500x faster lint** and a separate **70x faster format** command are the easiest way to make the architecture obvious.
+
+But this is not the whole `ttsc` story.
+
+The bigger idea is:
+
+> TypeScript-Go should not only be a faster `tsc`. It should become a base for a compiler-powered TypeScript toolchain.
+
+That bigger story includes runtime execution, compiler plugins, bundlers, and ecosystem packages.
+
+Those deserve their own posts.
+
+This first one only needs to land one point:
+
+> Lint does not have to be a second TypeScript pipeline.
+
+That is the opening shot.
+
+---
+
+## 11. Try It
+
+Install:
+
+```bash
+npm install -D ttsc @ttsc/lint @typescript/native-preview
+```
+
+Create `lint.config.ts`:
+
+```ts
+import type { ITtscLintConfig } from "@ttsc/lint";
+
+export default {
+  rules: {
+    "no-var": "error",
+    "prefer-const": "error",
+  },
+  format: {
+    printWidth: 100,
+    singleQuote: true,
+    trailingComma: "all",
+  },
+} satisfies ITtscLintConfig;
+```
+
+Run:
+
+```bash
+npx ttsc --noEmit
+npx ttsc format
+npx ttsc fix
+```
+
+Read next:
+
+- Benchmark: https://ttsc.dev/docs/benchmark
+- Lint overview: https://ttsc.dev/docs/lint
+- Format config: https://ttsc.dev/docs/lint/format
+- Rule catalog: https://ttsc.dev/docs/lint/rules
+- Repository: https://github.com/samchon/ttsc
+
+The old workflow:
+
+```bash
+npx tsc --noEmit
+npx eslint .
+npx prettier --check .
+```
+
+The `@ttsc/lint` workflow:
+
+```bash
+npx ttsc --noEmit  # type + lint
+npx ttsc format    # format
+```
+
+Same package, separate commands.
+
+That is the first chapter.


### PR DESCRIPTION
## Intent
Add the ttsc website blog surface and the first @ttsc/lint-focused article for the dev.to/blog series.

## Scope
- Adds blog routes, tag pages, MDX wrappers, and blog styling for the website.
- Adds RSS metadata/build generation wired into the website prebuild.
- Adds the “500x Faster TypeScript Lint” article with the VS Code fixture benchmark basis, 500x lint claim, separate 70x `ttsc format` claim, and clear `ttsc --noEmit` versus `ttsc format` command boundary.
- Adds the top-level Blog Articles menu item in the requested Guide Documents, Blog Articles, Playground order.

## Deferred
- No additional series articles in this PR.
- Generated RSS output is build output and is not committed.

## Test plan
- `pnpm --dir website exec prettier --parser mdx --write src/content/blog/500x-faster-typescript-lint.mdx`
- `pnpm --dir website run build:blog:rss`
- `pnpm --dir website run build:next`
- `git diff --cached --check`
- `node website/build/blog.cjs`
