### PR TITLE
feat(lint): add react-refresh only-export-components

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -296,6 +296,7 @@ The rule corpus is tested in `tests/test-lint/src/cases/*.ts`, which is the best
 - [`prefer-spread`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/prefer-spread.ts): prefers spread arguments over `.apply`.
 - [`prefer-template`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/prefer-template.ts): prefers template literals over string concatenation.
 - [`radix`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/radix.ts): requires a radix argument for `parseInt`.
+- [`react-refresh/only-export-components`](https://github.com/samchon/ttsc/blob/master/packages/lint/test/rules/react-refresh/only_export_components_reports_non_component_export_test.go): keeps React Fast Refresh component modules from exporting non-components.
 - [`require-yield`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/require-yield.ts): requires generator functions to contain `yield`.
 - [`triple-slash-reference`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/triple-slash-reference/violation.ts): rejects triple-slash reference directives.
 - [`use-isnan`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/use-isnan.ts): requires `Number.isNaN`/`isNaN` for `NaN` checks.

--- a/packages/lint/linthost/rules_react_refresh.go
+++ b/packages/lint/linthost/rules_react_refresh.go
@@ -1,0 +1,583 @@
+package linthost
+
+import (
+  "strings"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// onlyExportComponents enforces React Fast Refresh's module boundary rule:
+// files that export React components should not also export non-components.
+// Ported from eslint-plugin-react-refresh's only-export-components rule.
+type onlyExportComponents struct{}
+
+type onlyExportComponentsOptions struct {
+  ExtraHOCs           []string `json:"extraHOCs"`
+  AllowExportNames    []string `json:"allowExportNames"`
+  AllowConstantExport bool     `json:"allowConstantExport"`
+  CheckJS             bool     `json:"checkJS"`
+}
+
+type reactRefreshScan struct {
+  ctx                 *Context
+  options             onlyExportComponentsOptions
+  allowedExportNames  map[string]bool
+  validHOCs           map[string]bool
+  requireReactImport  bool
+  hasExports          bool
+  hasReactExport      bool
+  reactIsInScope      bool
+  localComponents     []*shimast.Node
+  nonComponentExports []*shimast.Node
+  reactContextExports []*shimast.Node
+}
+
+type reactComponentExpressionResult int
+
+const (
+  reactComponentExpressionNo reactComponentExpressionResult = iota
+  reactComponentExpressionYes
+  reactComponentExpressionNeedName
+)
+
+const (
+  reactRefreshNamedExportMessage = "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  reactRefreshAnonymousMessage   = "Fast refresh can't handle anonymous components. Add a name to your export."
+  reactRefreshLocalMessage       = "Fast refresh only works when a file only exports components. Move your component(s) to a separate file. If all exports are HOCs, add them to the extraHOCs option."
+  reactRefreshNoExportMessage    = "Fast refresh only works when a file has exports. Move your component(s) to a separate file."
+  reactRefreshContextMessage     = "Fast refresh only works when a file only exports components. Move your React context(s) to a separate file."
+)
+
+func (onlyExportComponents) Name() string {
+  return "react-refresh/only-export-components"
+}
+
+func (onlyExportComponents) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindSourceFile}
+}
+
+func (onlyExportComponents) Check(ctx *Context, node *shimast.Node) {
+  if ctx.File == nil || node == nil || node.Kind != shimast.KindSourceFile {
+    return
+  }
+
+  var options onlyExportComponentsOptions
+  if err := ctx.DecodeOptions(&options); err != nil {
+    return
+  }
+  if !shouldScanReactRefreshFile(ctx.File.FileName(), options.CheckJS) {
+    return
+  }
+
+  scan := newReactRefreshScan(ctx, options, reactRefreshRequiresReactImport(ctx.File.FileName(), options.CheckJS))
+  for _, stmt := range node.Statements() {
+    scan.handleStatement(stmt)
+  }
+  scan.report()
+}
+
+func newReactRefreshScan(ctx *Context, options onlyExportComponentsOptions, requireReactImport bool) *reactRefreshScan {
+  validHOCs := map[string]bool{
+    "memo":       true,
+    "forwardRef": true,
+    "lazy":       true,
+  }
+  for _, name := range options.ExtraHOCs {
+    if name != "" {
+      validHOCs[name] = true
+    }
+  }
+  allowed := map[string]bool{}
+  for _, name := range options.AllowExportNames {
+    if name != "" {
+      allowed[name] = true
+    }
+  }
+  return &reactRefreshScan{
+    ctx:                ctx,
+    options:            options,
+    allowedExportNames: allowed,
+    validHOCs:          validHOCs,
+    requireReactImport: requireReactImport,
+  }
+}
+
+func shouldScanReactRefreshFile(fileName string, checkJS bool) bool {
+  lower := strings.ToLower(fileName)
+  if strings.Contains(lower, ".test.") ||
+    strings.Contains(lower, ".spec.") ||
+    strings.Contains(lower, ".cy.") ||
+    strings.Contains(lower, ".stories.") {
+    return false
+  }
+  return strings.HasSuffix(lower, ".tsx") ||
+    strings.HasSuffix(lower, ".jsx") ||
+    (checkJS && strings.HasSuffix(lower, ".js"))
+}
+
+func reactRefreshRequiresReactImport(fileName string, checkJS bool) bool {
+  return checkJS && strings.HasSuffix(strings.ToLower(fileName), ".js")
+}
+
+func (s *reactRefreshScan) handleStatement(stmt *shimast.Node) {
+  if stmt == nil {
+    return
+  }
+  switch stmt.Kind {
+  case shimast.KindImportDeclaration:
+    decl := stmt.AsImportDeclaration()
+    s.reactIsInScope = s.reactIsInScope ||
+      decl != nil && stringLiteralText(decl.ModuleSpecifier) == "react"
+
+  case shimast.KindExportDeclaration:
+    s.handleExportDeclaration(stmt)
+
+  case shimast.KindExportAssignment:
+    assignment := stmt.AsExportAssignment()
+    if assignment == nil || assignment.IsExportEquals || assignment.Expression == nil {
+      return
+    }
+    s.hasExports = true
+    s.handleDefaultExportExpression(assignment.Expression, stmt)
+
+  case shimast.KindVariableStatement:
+    if hasModifier(stmt, shimast.KindExportKeyword) {
+      s.hasExports = true
+      s.handleVariableStatement(stmt)
+      return
+    }
+    s.collectLocalVariableComponents(stmt)
+
+  case shimast.KindFunctionDeclaration:
+    if hasModifier(stmt, shimast.KindExportKeyword) {
+      s.hasExports = true
+      s.handleFunctionDeclaration(stmt)
+      return
+    }
+    if isReactComponentName(identifierText(stmt.Name())) {
+      s.localComponents = append(s.localComponents, stmt.Name())
+    }
+
+  case shimast.KindClassDeclaration:
+    if hasModifier(stmt, shimast.KindExportKeyword) {
+      s.hasExports = true
+      s.handleClassDeclaration(stmt)
+    }
+  }
+}
+
+func (s *reactRefreshScan) handleExportDeclaration(node *shimast.Node) {
+  decl := node.AsExportDeclaration()
+  if decl == nil || decl.IsTypeOnly {
+    return
+  }
+  s.hasExports = true
+  if decl.ExportClause == nil {
+    s.ctx.Report(node, "This rule can't verify that export * only exports components.")
+    return
+  }
+  if decl.ExportClause.Kind != shimast.KindNamedExports {
+    return
+  }
+  named := decl.ExportClause.AsNamedExports()
+  if named == nil || named.Elements == nil {
+    return
+  }
+  for _, el := range named.Elements.Nodes {
+    spec := el.AsExportSpecifier()
+    if spec == nil || spec.IsTypeOnly {
+      continue
+    }
+    exported := spec.Name()
+    if identifierText(exported) == "default" && spec.PropertyName != nil {
+      exported = spec.PropertyName
+    }
+    s.handleExportIdentifier(exported, nil)
+  }
+}
+
+func (s *reactRefreshScan) handleVariableStatement(node *shimast.Node) {
+  stmt := node.AsVariableStatement()
+  if stmt == nil || stmt.DeclarationList == nil {
+    return
+  }
+  list := stmt.DeclarationList.AsVariableDeclarationList()
+  if list == nil || list.Declarations == nil {
+    return
+  }
+  for _, declNode := range list.Declarations.Nodes {
+    decl := declNode.AsVariableDeclaration()
+    if decl == nil {
+      continue
+    }
+    if decl.Initializer == nil {
+      s.nonComponentExports = append(s.nonComponentExports, decl.Name())
+      continue
+    }
+    s.handleExportIdentifier(decl.Name(), decl.Initializer)
+  }
+}
+
+func (s *reactRefreshScan) collectLocalVariableComponents(node *shimast.Node) {
+  stmt := node.AsVariableStatement()
+  if stmt == nil || stmt.DeclarationList == nil {
+    return
+  }
+  list := stmt.DeclarationList.AsVariableDeclarationList()
+  if list == nil || list.Declarations == nil {
+    return
+  }
+  for _, declNode := range list.Declarations.Nodes {
+    decl := declNode.AsVariableDeclaration()
+    if decl == nil || decl.Initializer == nil || !isReactComponentName(identifierText(decl.Name())) {
+      continue
+    }
+    if s.isExpressionReactComponent(decl.Initializer) != reactComponentExpressionNo {
+      s.localComponents = append(s.localComponents, decl.Name())
+    }
+  }
+}
+
+func (s *reactRefreshScan) handleFunctionDeclaration(node *shimast.Node) {
+  name := node.Name()
+  if name == nil {
+    s.ctx.Report(node, reactRefreshAnonymousMessage)
+    return
+  }
+  s.handleExportIdentifier(name, nil)
+}
+
+func (s *reactRefreshScan) handleClassDeclaration(node *shimast.Node) {
+  name := node.Name()
+  if name == nil {
+    s.ctx.Report(node, reactRefreshAnonymousMessage)
+    return
+  }
+  if isReactComponentName(identifierText(name)) && classHasRenderMethod(node) {
+    s.hasReactExport = true
+    return
+  }
+  s.nonComponentExports = append(s.nonComponentExports, name)
+}
+
+func (s *reactRefreshScan) handleDefaultExportExpression(expr *shimast.Node, exportNode *shimast.Node) {
+  expr = skipReactRefreshTSWrapper(expr)
+  if expr == nil {
+    return
+  }
+  switch expr.Kind {
+  case shimast.KindIdentifier:
+    s.handleExportIdentifier(expr, nil)
+  case shimast.KindCallExpression:
+    switch result := s.isCallExpressionReactComponent(expr); result {
+    case reactComponentExpressionNo:
+      s.nonComponentExports = append(s.nonComponentExports, expr)
+    case reactComponentExpressionNeedName:
+      s.ctx.Report(exportNode, reactRefreshAnonymousMessage)
+    default:
+      s.hasReactExport = true
+    }
+  case shimast.KindArrowFunction:
+    s.ctx.Report(exportNode, reactRefreshAnonymousMessage)
+  case shimast.KindFunctionDeclaration, shimast.KindFunctionExpression:
+    name := expr.Name()
+    if name == nil {
+      s.ctx.Report(exportNode, reactRefreshAnonymousMessage)
+      return
+    }
+    s.handleExportIdentifier(name, nil)
+  case shimast.KindClassDeclaration:
+    s.handleClassDeclaration(expr)
+  default:
+    s.nonComponentExports = append(s.nonComponentExports, expr)
+  }
+}
+
+func (s *reactRefreshScan) handleExportIdentifier(nameNode *shimast.Node, init *shimast.Node) {
+  name := identifierText(nameNode)
+  if name == "" {
+    s.nonComponentExports = append(s.nonComponentExports, nameNode)
+    return
+  }
+  if s.allowedExportNames[name] {
+    return
+  }
+  if init == nil {
+    if isReactComponentName(name) {
+      s.hasReactExport = true
+      return
+    }
+    s.nonComponentExports = append(s.nonComponentExports, nameNode)
+    return
+  }
+
+  init = skipReactRefreshTSWrapper(init)
+  if s.options.AllowConstantExport && isReactRefreshConstantExpression(init) {
+    return
+  }
+  if isCreateContextCall(init) {
+    s.reactContextExports = append(s.reactContextExports, nameNode)
+    return
+  }
+  if isReactComponentName(name) && s.isExpressionReactComponent(init) != reactComponentExpressionNo {
+    s.hasReactExport = true
+    return
+  }
+  s.nonComponentExports = append(s.nonComponentExports, nameNode)
+}
+
+func (s *reactRefreshScan) report() {
+  if s.requireReactImport && !s.reactIsInScope {
+    return
+  }
+  if s.hasExports {
+    if s.hasReactExport {
+      for _, node := range s.nonComponentExports {
+        s.ctx.Report(node, reactRefreshNamedExportMessage)
+      }
+      for _, node := range s.reactContextExports {
+        s.ctx.Report(node, reactRefreshContextMessage)
+      }
+      return
+    }
+    for _, node := range s.localComponents {
+      s.ctx.Report(node, reactRefreshLocalMessage)
+    }
+    return
+  }
+  for _, node := range s.localComponents {
+    s.ctx.Report(node, reactRefreshNoExportMessage)
+  }
+}
+
+func isReactComponentName(name string) bool {
+  if name == "" {
+    return false
+  }
+  first := name[0]
+  if first < 'A' || first > 'Z' {
+    return false
+  }
+  for i := 1; i < len(name); i++ {
+    ch := name[i]
+    if (ch >= 'a' && ch <= 'z') ||
+      (ch >= 'A' && ch <= 'Z') ||
+      (ch >= '0' && ch <= '9') ||
+      ch == '_' {
+      continue
+    }
+    return false
+  }
+  return true
+}
+
+func skipReactRefreshTSWrapper(node *shimast.Node) *shimast.Node {
+  for node != nil {
+    switch node.Kind {
+    case shimast.KindParenthesizedExpression,
+      shimast.KindAsExpression,
+      shimast.KindSatisfiesExpression,
+      shimast.KindNonNullExpression,
+      shimast.KindTypeAssertionExpression:
+      next := node.Expression()
+      if next == nil {
+        return node
+      }
+      node = next
+    default:
+      return node
+    }
+  }
+  return nil
+}
+
+func (s *reactRefreshScan) isExpressionReactComponent(node *shimast.Node) reactComponentExpressionResult {
+  node = skipReactRefreshTSWrapper(node)
+  if node == nil {
+    return reactComponentExpressionNo
+  }
+  switch node.Kind {
+  case shimast.KindIdentifier:
+    if isReactComponentName(identifierText(node)) {
+      return reactComponentExpressionYes
+    }
+  case shimast.KindArrowFunction:
+    return reactComponentExpressionNeedName
+  case shimast.KindFunctionExpression:
+    name := identifierText(node.Name())
+    if name == "" {
+      return reactComponentExpressionNeedName
+    }
+    if isReactComponentName(name) {
+      return reactComponentExpressionYes
+    }
+  case shimast.KindConditionalExpression:
+    expr := node.AsConditionalExpression()
+    if expr == nil {
+      return reactComponentExpressionNo
+    }
+    left := s.isExpressionReactComponent(expr.WhenTrue)
+    right := s.isExpressionReactComponent(expr.WhenFalse)
+    if left == reactComponentExpressionNo || right == reactComponentExpressionNo {
+      return reactComponentExpressionNo
+    }
+    if left == reactComponentExpressionNeedName || right == reactComponentExpressionNeedName {
+      return reactComponentExpressionNeedName
+    }
+    return reactComponentExpressionYes
+  case shimast.KindCallExpression:
+    return s.isCallExpressionReactComponent(node)
+  case shimast.KindTaggedTemplateExpression:
+    if s.validHOCs[s.hocName(node)] {
+      return reactComponentExpressionNeedName
+    }
+  }
+  return reactComponentExpressionNo
+}
+
+func (s *reactRefreshScan) isCallExpressionReactComponent(node *shimast.Node) reactComponentExpressionResult {
+  hoc := s.hocName(node)
+  if !s.validHOCs[hoc] {
+    return reactComponentExpressionNo
+  }
+  if hoc != "memo" && hoc != "forwardRef" {
+    return reactComponentExpressionYes
+  }
+  call := node.AsCallExpression()
+  if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+    return reactComponentExpressionNo
+  }
+  arg := skipReactRefreshTSWrapper(call.Arguments.Nodes[0])
+  if arg == nil {
+    return reactComponentExpressionNo
+  }
+  switch arg.Kind {
+  case shimast.KindIdentifier:
+    if isReactComponentName(identifierText(arg)) {
+      return reactComponentExpressionYes
+    }
+  case shimast.KindFunctionExpression:
+    name := identifierText(arg.Name())
+    if name == "" {
+      return reactComponentExpressionNeedName
+    }
+    if isReactComponentName(name) {
+      return reactComponentExpressionYes
+    }
+  case shimast.KindArrowFunction:
+    return reactComponentExpressionNeedName
+  case shimast.KindCallExpression:
+    return s.isCallExpressionReactComponent(arg)
+  }
+  return reactComponentExpressionNo
+}
+
+func (s *reactRefreshScan) hocName(node *shimast.Node) string {
+  node = skipReactRefreshTSWrapper(node)
+  if node == nil {
+    return ""
+  }
+  var callee *shimast.Node
+  switch node.Kind {
+  case shimast.KindCallExpression:
+    call := node.AsCallExpression()
+    if call != nil {
+      callee = call.Expression
+    }
+  case shimast.KindTaggedTemplateExpression:
+    tagged := node.AsTaggedTemplateExpression()
+    if tagged != nil {
+      callee = tagged.Tag
+    }
+  default:
+    return ""
+  }
+  return s.calleeHOCName(callee)
+}
+
+func (s *reactRefreshScan) calleeHOCName(node *shimast.Node) string {
+  node = skipReactRefreshTSWrapper(node)
+  if node == nil {
+    return ""
+  }
+  switch node.Kind {
+  case shimast.KindIdentifier:
+    return identifierText(node)
+  case shimast.KindCallExpression:
+    return s.hocName(node)
+  case shimast.KindPropertyAccessExpression:
+    access := node.AsPropertyAccessExpression()
+    if access == nil {
+      return ""
+    }
+    property := identifierText(access.Name())
+    if s.validHOCs[property] {
+      return property
+    }
+    object := identifierText(access.Expression)
+    if s.validHOCs[object] {
+      return object
+    }
+    if access.Expression != nil && access.Expression.Kind == shimast.KindCallExpression {
+      return s.hocName(access.Expression)
+    }
+  }
+  return ""
+}
+
+func isReactRefreshConstantExpression(node *shimast.Node) bool {
+  node = skipReactRefreshTSWrapper(node)
+  if node == nil {
+    return false
+  }
+  switch node.Kind {
+  case shimast.KindStringLiteral,
+    shimast.KindNumericLiteral,
+    shimast.KindBigIntLiteral,
+    shimast.KindNoSubstitutionTemplateLiteral,
+    shimast.KindTrueKeyword,
+    shimast.KindFalseKeyword,
+    shimast.KindNullKeyword,
+    shimast.KindPrefixUnaryExpression,
+    shimast.KindTemplateExpression,
+    shimast.KindBinaryExpression:
+    return true
+  }
+  return false
+}
+
+func isCreateContextCall(node *shimast.Node) bool {
+  node = skipReactRefreshTSWrapper(node)
+  if node == nil || node.Kind != shimast.KindCallExpression {
+    return false
+  }
+  call := node.AsCallExpression()
+  if call == nil {
+    return false
+  }
+  if identifierText(call.Expression) == "createContext" {
+    return true
+  }
+  access := call.Expression.AsPropertyAccessExpression()
+  return access != nil && identifierText(access.Name()) == "createContext"
+}
+
+func classHasRenderMethod(node *shimast.Node) bool {
+  class := node.AsClassDeclaration()
+  if class == nil || class.Members == nil {
+    return false
+  }
+  for _, member := range class.Members.Nodes {
+    if member == nil || member.Kind != shimast.KindMethodDeclaration {
+      continue
+    }
+    if identifierText(member.Name()) == "render" {
+      return true
+    }
+  }
+  return false
+}
+
+func init() {
+  Register(onlyExportComponents{})
+}

--- a/packages/lint/src/structures/ITtscLintRules.ts
+++ b/packages/lint/src/structures/ITtscLintRules.ts
@@ -2,6 +2,7 @@ import type {
   ITtscLintJsdocRuleOptions,
   ITtscLintPrintWidthRuleOptions,
   ITtscLintQuotesRuleOptions,
+  ITtscLintReactRefreshOnlyExportComponentsRuleOptions,
   ITtscLintSemiRuleOptions,
   ITtscLintSortImportsRuleOptions,
   ITtscLintTrailingCommaRuleOptions,
@@ -425,6 +426,9 @@ export interface ITtscLintRules {
 
   /** requires generator functions to contain `yield`. */
   "require-yield"?: TtscLintRuleSetting;
+
+  /** keeps React Fast Refresh component modules from exporting non-components. */
+  "react-refresh/only-export-components"?: TtscLintRuleOptionsSetting<ITtscLintReactRefreshOnlyExportComponentsRuleOptions>;
 
   /** rejects triple-slash reference directives. */
   "triple-slash-reference"?: TtscLintRuleSetting;

--- a/packages/lint/src/structures/TtscLintRule.ts
+++ b/packages/lint/src/structures/TtscLintRule.ts
@@ -143,6 +143,7 @@ export type TtscLintRule =
   | "prefer-spread"
   | "prefer-template"
   | "radix"
+  | "react-refresh/only-export-components"
   | "require-yield"
   | "triple-slash-reference"
   | "use-isnan"

--- a/packages/lint/src/structures/TtscLintRuleOptions.ts
+++ b/packages/lint/src/structures/TtscLintRuleOptions.ts
@@ -137,8 +137,41 @@ export interface ITtscLintJsdocRuleOptions {
   sortTags?: boolean;
 }
 
+/** `react-refresh/only-export-components` rule options. */
+export interface ITtscLintReactRefreshOnlyExportComponentsRuleOptions {
+  /**
+   * Extra higher-order component names that wrap component exports.
+   *
+   * @default []
+   */
+  extraHOCs?: readonly string[];
+
+  /**
+   * Export names the active framework handles during refresh, such as route
+   * metadata exports.
+   *
+   * @default []
+   */
+  allowExportNames?: readonly string[];
+
+  /**
+   * Permit literal/string/boolean/template/binary constant exports alongside
+   * component exports.
+   *
+   * @default false
+   */
+  allowConstantExport?: boolean;
+
+  /**
+   * Also scan JavaScript files that import React. TSX files are always scanned.
+   *
+   * @default false
+   */
+  checkJS?: boolean;
+}
+
 /**
- * Index from format rule name to its option object. Kept as a public lookup
+ * Index from typed rule name to its option object. Kept as a public lookup
  * type for consumers that want to derive option helpers from the same rule
  * names accepted by `ITtscLintRules`.
  */
@@ -149,4 +182,5 @@ export interface ITtscLintRuleOptionsMap {
   "format/sort-imports": ITtscLintSortImportsRuleOptions;
   "format/jsdoc": ITtscLintJsdocRuleOptions;
   "format/print-width": ITtscLintPrintWidthRuleOptions;
+  "react-refresh/only-export-components": ITtscLintReactRefreshOnlyExportComponentsRuleOptions;
 }

--- a/packages/lint/test/rules/README.md
+++ b/packages/lint/test/rules/README.md
@@ -7,6 +7,7 @@ Rule corpus tests are grouped by rule semantics, not by alphabetic ranges.
 - `control-flow`: branches, loops, labels, fallthrough, and expression-flow rules.
 - `functions-classes`: functions, constructors, classes, methods, and call-shape rules.
 - `imports-modules`: imports, namespaces, require usage, and module-reference rules.
+- `react-refresh`: React Fast Refresh component-module boundary rules.
 - `runtime-safety`: runtime hazards, dangerous globals, equality, eval, and diagnostic sanity rules.
 - `strings-regex`: string literal, template, regex, whitespace, and octal-text rules.
 - `style-suggestions`: low-risk style/suggestion rules that do not fit a narrower domain.

--- a/packages/lint/test/rules/react-refresh/only_export_components_honors_allow_options_test.go
+++ b/packages/lint/test/rules/react-refresh/only_export_components_honors_allow_options_test.go
@@ -1,0 +1,36 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestOnlyExportComponentsHonorsAllowOptions verifies react-refresh/only-export-components options.
+//
+// Locks the compatibility branch for frameworks that safely refresh constants
+// or named route metadata. Without these options, both extra exports would be
+// reported beside the component export.
+//
+//  1. Parse a TSX module with a component, a literal constant, and route metadata.
+//  2. Enable allowConstantExport and allowExportNames.
+//  3. Assert the native Engine emits no findings.
+func TestOnlyExportComponentsHonorsAllowOptions(t *testing.T) {
+  const ruleName = "react-refresh/only-export-components"
+  source := `export const answer = 42;
+export const metadata = { title: "Home" };
+export const App = () => <main />;
+`
+  file := parseTSXFile(t, "/virtual/App.tsx", source)
+  resolver := InlineRuleResolver{
+    Rules: RuleConfig{ruleName: SeverityError},
+    Options: RuleOptionsMap{
+      ruleName: json.RawMessage(`{"allowConstantExport":true,"allowExportNames":["metadata"]}`),
+    },
+  }
+  findings := NewEngineWithResolver(resolver).Run([]*shimast.SourceFile{file}, nil)
+  if len(findings) != 0 {
+    t.Fatalf("expected zero findings, got %d (%+v)", len(findings), findings)
+  }
+}

--- a/packages/lint/test/rules/react-refresh/only_export_components_reports_non_component_export_test.go
+++ b/packages/lint/test/rules/react-refresh/only_export_components_reports_non_component_export_test.go
@@ -1,0 +1,32 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestOnlyExportComponentsReportsNonComponentExport verifies react-refresh/only-export-components.
+//
+// Locks the React Fast Refresh module-boundary branch where a TSX file already
+// exports a component and then adds a non-component export. That mixed export
+// shape forces refresh invalidation, so the rule must point at the shared value.
+//
+//  1. Parse a TSX module with one component export and one value export.
+//  2. Run only react-refresh/only-export-components.
+//  3. Assert the native Engine reports the non-component export line.
+func TestOnlyExportComponentsReportsNonComponentExport(t *testing.T) {
+  const ruleName = "react-refresh/only-export-components"
+  source := `export const version = "1.0.0";
+export function App() {
+  return <main />;
+}
+`
+  file := parseTSXFile(t, "/virtual/App.tsx", source)
+  findings := NewEngine(RuleConfig{ruleName: SeverityError}).Run([]*shimast.SourceFile{file}, nil)
+  actual := normalizeRuleFindings(file, findings)
+  expected := ruleExpectation{Rule: ruleName, Severity: SeverityError, Line: 1}
+  if len(actual) != 1 || actual[0] != expected {
+    t.Fatalf("want %v, got %v", []ruleExpectation{expected}, actual)
+  }
+}

--- a/website/src/content/docs/lint/rules.mdx
+++ b/website/src/content/docs/lint/rules.mdx
@@ -69,6 +69,12 @@ If you're skimming: the `error`-severity defaults at the bottom of this page are
 | `no-require-imports` | Reject `require(...)` outside CommonJS modules. |
 | `no-useless-empty-export` | Reject redundant empty `export {}` declarations in files that already use import/export syntax. |
 
+## React Fast Refresh
+
+| Rule | Effect |
+| ---- | ------ |
+| `react-refresh/only-export-components` | Reject non-component exports in TSX component modules so React Fast Refresh can preserve component state. Supports `extraHOCs`, `allowExportNames`, `allowConstantExport`, and `checkJS` options. |
+
 ## Promises and async
 
 | Rule | Effect |


### PR DESCRIPTION
## Intent
Add the core `react-refresh/only-export-components` rule from `eslint-plugin-react-refresh@0.5.2` to `@ttsc/lint` so TSX React Fast Refresh modules can reject mixed component/non-component exports.

## Scope
- Implements `react-refresh/only-export-components` in the native lint host with TSX/JSX scanning, test/spec/story skips, HOC handling, React context diagnostics, and typed options for `extraHOCs`, `allowExportNames`, `allowConstantExport`, and `checkJS`.
- Adds Go rule tests for mixed component/value exports and allow-option behavior.
- Updates public rule typings plus README and website rule catalog docs.

## Deferred
- Full JavaScript corpus coverage beyond the `checkJS` gate can be expanded later if `allowJs` JS projects become a primary lint target.

## Test Plan
- `pnpm --filter ttsc build`
- `node scripts/test-go-lint.cjs`
- `pnpm --filter @ttsc/lint build`
