### PR TITLE
docs(agents): introduce .codex/skills/ system, AGENTS.md as index

### DIFF
--- a/.codex/skills/benchmark/SKILL.md
+++ b/.codex/skills/benchmark/SKILL.md
@@ -1,0 +1,74 @@
+# Benchmark
+
+## What it measures
+
+`ttsc + @ttsc/lint + ttsc format` versus the legacy `tsc + eslint + prettier` toolchain, on seven real-world TypeScript projects. The runner clones each fixture's three branches into `experimental/benchmark/.work/`, replays each cell `RUNS` times, and writes the medians to `website/public/benchmark.json` for the public dashboard at https://ttsc.dev/benchmark.
+
+Cell ID = `project:branch:op:threading`.
+
+| Axis | Values |
+| --- | --- |
+| Project | `vue`, `rxjs`, `typeorm`, `zod`, `nestjs`, `vscode`, `shopping-backend` |
+| Branch | `legacy`, `ttsc`, `ttsc-lint` |
+| Op | `build`, `noEmit`, `eslint` (legacy only), `format` |
+| Threading | `single`, `checkers2`, `checkers4`, `checkers8` (`format` keeps `single` + default `multi`) |
+
+Methodology, per-axis interpretation, and dashboard tabs are documented in `website/src/content/docs/benchmark.mdx`. Flags and env vars are tabled in `experimental/benchmark/README.md`. This skill covers the higher-level rules that those references assume.
+
+## Running
+
+```bash
+node experimental/benchmark/bench.mjs                              # full matrix sweep
+node experimental/benchmark/bench.mjs --project=vue --no-website   # one fixture, do not touch dashboard
+node experimental/benchmark/bench.mjs --verify-only                # one pass per cell, no timing
+node experimental/benchmark/bench.mjs --list                       # print resolved grid
+```
+
+Option families:
+
+- **Scope** — `--project`, `--cell-filter`, `--lint-only`, `--format-only`, `--ttsc-build-only`. Every targeted run pairs with `--no-website` so the dashboard stays consistent.
+- **Setup** — `--setup-only`, `--no-setup`, `--no-install`, `--no-pack` (or `TTSC_BENCH_SKIP_PACK=1`), `--force-install`. Setup packs the local `ttsc` workspace into tarballs, clones the fixtures, installs the tarballs, and runs `ttsc prepare` so plugin binaries are warm before any measured cell.
+- **Sampling** — `TTSC_BENCH_RUNS` (5), `TTSC_BENCH_WARMUP` (1), `TTSC_BENCH_RETRIES` (2, applied only to `race`-classified failures). The reported number is the median; `min` and the full sample list stay in `report.json` for audit.
+- **Host gate** — `TTSC_BENCH_REQUIRE_QUIET=1` upgrades the load-average warning into a hard error and is set for every publication run; `TTSC_BENCH_SKIP_LOAD_CHECK=1` silences it for development iterations.
+- **Output** — `--no-website` skips merging into `website/public/benchmark.json`; `--reset` discards prior measurements instead of merging in place; `TTSC_BENCH_OUT` redirects the local report; `--verbose` tees child stdio with `[cmd]` / `[step]` / `[timer]` traces (default is milestone-only).
+
+Publication sweep:
+
+```bash
+TTSC_BENCH_REQUIRE_QUIET=1 node experimental/benchmark/bench.mjs
+```
+
+After the sweep, inspect the diff against `website/public/benchmark.json`: every fixture row present, row order preserved, host panel reflects the machine that produced the numbers.
+
+## Fixture repositories
+
+Each fixture is a forked GitHub repo at `samchon/ttsc-benchmark-<name>`, plus `samchon/shopping-backend` for the plugin-heavy case. Every fixture carries three independent branches:
+
+- **`legacy`** — upstream source with stock `tsc`, `eslint`, and `prettier`. TypeScript pinned to the Legacy TypeScript version shown on the dashboard host panel (currently `v6.0.3`).
+- **`ttsc`** — same source as `legacy`, with `tsc` swapped for `ttsc` on `@typescript/native-preview` and the workspace configured to install `ttsc` from the tarball the runner packs.
+- **`ttsc-lint`** — same source as `ttsc`, with `@ttsc/lint` folded into the compile pass so the `eslint` step is no longer invoked.
+
+### Source parity
+
+The three branches differ only in tooling — `package.json`, `tsconfig*.json`, `eslint.config.*`, `.prettierrc*`, lockfile, `ttsc` plugin descriptors. Application source is identical across `legacy`, `ttsc`, and `ttsc-lint`, so a cell delta reflects tool cost rather than workload drift.
+
+### Lint and format scope is the tsconfig program
+
+Across `legacy` and `ttsc-lint`, the lint and format cells process exactly the file set `tsconfig.json` compiles for that fixture. `eslint` and `@ttsc/lint` lint that set; `prettier --check` and `ttsc format` format that set.
+
+Nothing inside the program is excluded; nothing outside it is targeted. Carve-outs via `--ignore-pattern`, `eslint.config` `ignores`, `.prettierignore`, or extra `files`/`exclude` entries are rejected because they make the cells incomparable.
+
+### Editing workflow
+
+Edits go to the fixture repo on GitHub, not to the local clone. Setup runs `fetch + reset --hard` to the upstream branch tip on every run, so local changes in `.work/` disappear immediately.
+
+Finish every fixture-branch edit by running the branch's own build, format, and lint commands (e.g. `pnpm build`, `prettier --write` or `ttsc format`, `eslint --fix`) until the tree is green, then commit and push. A half-finished tip pollutes every later run because the runner pulls upstream every setup.
+
+READMEs and prose docs inside a fixture repo follow the same writing rules as ttsc itself — see AGENTS.md `## Maintenance § Writing style` and `.codex/skills/documentation/SKILL.md § READMEs`.
+
+### Other rules
+
+- **No tarball or built artifact in the fixture.** The runner packs and installs the local `ttsc` workspace during setup. The fixture repo must not carry pre-baked tarball paths, vendored `ttsc` builds, or stale `dist/` output.
+- **Pin major TypeScript in lockstep.** When the Legacy TypeScript headline version bumps, update every fixture's `legacy` branch in the same release so the `tsc` baseline stays one major across the matrix.
+- **Add fixtures by adding repos.** A new fixture means a new `samchon/ttsc-benchmark-<name>` repo carrying all three branches, plus a `PACKAGE_CONFIGS` entry at the top of `bench.mjs`. Multi-fixture tricks inside one repo are out of scope.
+- **Removed comparisons stay removed.** `tsgo` rows and the `type-fest` fixture were dropped deliberately.

--- a/.codex/skills/development/SKILL.md
+++ b/.codex/skills/development/SKILL.md
@@ -1,0 +1,63 @@
+# Development
+
+## Work Rules
+
+- Match existing conventions. Before adding a file, function, or test, open a nearby peer and mirror its naming, location, and code style — don't create parallel structures.
+- Respect existing package boundaries. Don't hardcode consumer-specific behavior into the compiler host.
+- Plugin descriptors are JS; transform logic is Go. JS transform functions (e.g. `transformSource`, `transformOutput`) are not part of the public contract.
+- `shim.go` files marked `gen_shims:hand-maintained` are not regenerated.
+- When code behavior changes, update the matching page under `website/src/content/docs/` in the same change.
+
+## Plugin Configuration
+
+First-party plugin configuration lives in dedicated `*.config.{ts,cts,mts,js,cjs,mjs,json}` files, auto-discovered by upward walk from the entry. Shipped ttsc packages accept only `configFile` (an explicit path) beyond host-owned entry keys.
+
+Inline option keys for `@ttsc/banner`, `@ttsc/paths`, `@ttsc/strip`, and `@ttsc/lint` were withdrawn so package config has one typed, discoverable home — do not reintroduce them.
+
+## Testing
+
+**One test case per file, named after what it asserts.** Applies to both layers.
+
+- **Go unit tests** live in `packages/*/test/`; one `Test*` per file. Run the real command entrypoint (e.g. `go run ./plugin`) so wrapper branches stay covered.
+- **TypeScript e2e tests** live in `tests/test-*/src/features/`. Each file exports exactly one `test_<snake_case>` function with a matching file name; `DynamicExecutor` discovers them by prefix. Materialize a temp project, spawn the real binary, and assert on observable output.
+
+Open every case with a doc comment in the same three-part shape: a one-line `Verifies …` headline, a short paragraph stating the non-obvious _why_ (which branch or regression is being pinned), and a 2–4-step numbered list summarizing the scenario.
+
+```ts
+/**
+ * Verifies plugin corpus: composes rejects cycle between two plugins.
+ *
+ * Locks the cycle-detection branch in
+ * `loadProjectPlugins.ts::composePluginSources`. Composition is one hop only;
+ * reciprocal `composes` arrays would silently reswap the binaries of both
+ * plugins, so ttsc throws an explicit error instead of routing to the wrong
+ * binary.
+ *
+ * 1. Two plugin descriptors each list the other in `composes`.
+ * 2. Run ttsc.
+ * 3. Assert non-zero exit and `composes cycle detected` in stderr.
+ */
+export const test_plugin_corpus_composes_rejects_cycle_between_two_plugins =
+  () => {
+    /* ... */
+  };
+```
+
+Use the shared helpers in `tests/utils` and the per-suite `internal/` modules; do not reach into another suite's internals. Regressions that need a real directory layout (not just a synthetic temp file map) go under `tests/projects`.
+
+## Validation
+
+Run the narrowest command that proves the change first, then a broader command when shared behavior or packaging changed. Report any command that could not be run.
+
+Verification shape depends on the change type:
+
+- **Bug fix** — name the failing case and the expected behavior; run a repro that fails before the fix and passes after.
+- **Feature** — name the observable behavior; exercise it end-to-end.
+- **Refactor** — name what should stay unchanged; rely on the existing test suite or a behavior-locking probe.
+- **Review** — name concrete risks, missing tests, or regressions.
+
+## Change Integrity
+
+Treat tests, fixtures, snapshots, CI workflows, package wiring, dependencies, core algorithms, and generated baselines as part of the specification. Changing them requires an explicit user request or a clear product reason, and the final report must call it out.
+
+For mechanical ports, migrations, or broad rewrites, preserve the existing algorithm and public behavior in reviewable slices. Prefer a concrete exemplar over abstract instructions, and inspect the diff before trusting a green test run.

--- a/.codex/skills/documentation/SKILL.md
+++ b/.codex/skills/documentation/SKILL.md
@@ -1,0 +1,13 @@
+# Documentation
+
+## READMEs
+
+README files are for the final reader of that package or directory. Start with what it is, when to use it, installation, the smallest working setup, and the common path.
+
+Keep README language direct and practical. Avoid compiler theory, protocol details, internal architecture, and edge cases unless the reader must know them to use the package. Move deep explanations into the website guides and link them only as the next step.
+
+## Guide Documents
+
+Guide documents live under `website/src/content/docs/` as MDX, served by Nextra at https://ttsc.dev. They are the detailed layer. Each guide must name its reader: consumer, package user, bundler user, runtime user, plugin author, or maintainer.
+
+The tree is organized by audience: top-level pages (`setup.mdx`, `why.mdx`, `faq.mdx`, `troubleshooting.mdx`) for cross-cutting tasks, per-package folders (`ttsc/`, `lint/`, `plugins/`, `wasm/`) for package guides, and `development/` for plugin-author guides. Package guides may go deeper than README with full options, recipes, troubleshooting, compatibility notes, and migration details. Plugin-author guides may cover protocol, Go APIs, testing, publishing, and internals. Keep one audience and task per page, and update the matching `_meta.ts` when adding, renaming, or moving a guide.

--- a/.codex/skills/multi-agent/SKILL.md
+++ b/.codex/skills/multi-agent/SKILL.md
@@ -1,0 +1,46 @@
+# Multi-Agent Workflows
+
+Use only when the user explicitly asks for one of the named modes — Review Cycle, Discussion, or Research Review Round. Each mode composes the shared building blocks below; do not invent unnamed combinations.
+
+## Building Blocks
+
+### Six-agent team
+Form a team of six agents. For looped modes, replace the team with six different agents at the start of each round or cycle.
+
+### Lead role
+The lead agent coordinates the team. In modes that produce proposals, the lead rechecks every proposal against the codebase and applies only changes that are technically sound and relevant. In modes that produce transcripts, the lead moderates and scribes — writing each statement in speaking order, recording the live discussion (not a retrospective summary), and not narrowing the topic unless the user did.
+
+### Topic directory
+Create `.discussions/<topic>/` with a short filesystem-safe topic name. Do not delete or overwrite existing discussion directories unless the user explicitly requests it.
+
+### Per-agent knowledge base
+Each agent creates a personal subdirectory under the topic directory and continuously maintains its own wiki-style knowledge base there. Between turns, agents read the updated transcript and each other's statements, keep researching, revise their knowledge bases, and prepare notes.
+
+### Three transcript rounds
+Run three unrestricted rounds recorded as `round1.md`, `round2.md`, and `round3.md`. Each round has a one-hour budget.
+
+### Stop condition for looped modes
+Continue while at least one verified proposal is accepted. Stop when no agent proposes an improvement, or when no proposal survives lead-agent validation.
+
+## Modes
+
+### Review Cycle
+Direct review of changed source, docs, and tests. No topic directory, no transcripts.
+
+1. Form the team. Each agent reads the changed source/docs/tests in full and proposes improvements.
+2. Lead validates and applies surviving proposals.
+3. Start the next cycle with a fresh team. Apply the stop condition.
+
+### Discussion
+Open-ended topic exploration without changing code. No proposals, no validation.
+
+1. Create the topic directory. Form the team; each builds its knowledge base.
+2. Run the three transcript rounds directly under the topic directory.
+3. After `round3.md`, the lead writes agreed conclusions and major open points into `summary.md`, reports to the user, and waits.
+
+### Research Review Round
+Review that needs shared research before individual proposals — discussion KB workflow plus the validation loop.
+
+1. Create the topic directory. Each round lives in its own `review-round-N/` subdirectory containing fresh agents' KB folders, `round1.md`, `round2.md`, `round3.md`, `proposals.md`, and `lead-validation.md`.
+2. In each round: agents build KBs from changed source/docs/tests plus relevant research → three transcript rounds → each agent submits its own concrete proposals (no consensus required) → lead validates and applies surviving ones.
+3. Fresh team next round; apply the stop condition.

--- a/.codex/skills/project/SKILL.md
+++ b/.codex/skills/project/SKILL.md
@@ -1,0 +1,39 @@
+# Project Outline
+
+## Product Contract
+
+`ttsc` is a standalone TypeScript-Go compiler, runtime, plugin host, and LSP host. It ships three CLIs and a plugin protocol:
+
+- `ttsc` — build, check, watch, and source-to-source transform on top of `@typescript/native-preview`.
+- `ttsx` — run a TypeScript entrypoint after a real type-check (a typed `tsx`/`ts-node`).
+- `ttscserver` — LSP host wrapping `tsgo --lsp --stdio` and proxying JSON-RPC so ttsc plugin diagnostics, code actions, and `workspace/executeCommand` handlers reach the editor through one stream.
+- Plugins — Go source packages that share TypeScript-Go's AST/Checker. Executable `package main` sources build as sidecars; non-`main` transform packages link into a native host. `ttsc` builds plugin source on demand and caches the binary.
+
+The contract is general-purpose. Downstream projects like `typia` and `nestia` are compatibility fixtures, not the product definition.
+
+## Layout
+
+- `packages/ttsc`: JS launcher/API plus Go host (`cmd/*`, `driver`, `internal`, `utility`, `shim/`). `driver.PluginSource` is the public seam embedders implement; `NativePluginSource` adapts `capabilities.lsp` sidecars. `internal/lspserver` is the byte-level LSP proxy ttscserver uses.
+- `packages/{banner,paths,strip}`: utility transform plugins with package-owned `driver/` logic linked into a generic native host.
+- `packages/lint`: `@ttsc/lint` with its own native engine, exposing LSP verbs from `linthost/lsp.go` so ttscserver and `packages/vscode` call them through the language client. Rules may consult the TypeScript-Go Checker directly via `ctx.Checker`; third-party rules ship through the public `rule` package and may use the `rule/astutil` helpers.
+- `packages/wasm`: `@ttsc/wasm` — Go `host` helper plus JS boot scaffolding for in-browser ttsc playgrounds. `host.Expose` binds `globalThis[apiName]` with the standard verbs (`build/check/transform/plugin/plugins/version`) plus fountain verbs (`snapshot/getDiagnostics/getNodeAtPosition/...`) over a snapshot handle table.
+- `packages/playground`: `@ttsc/playground` — reusable Web Worker + React shell built on `@ttsc/wasm`. Exports `createWorkerCompiler` (worker-side `ICompilerService` factory), `PlaygroundShell` (Tailwind 4 React component), runtime npm dependency installer, typia source/runtime pack helpers, and Monaco editor wrappers. Consumed by `website/` and `typia/website/`.
+- `packages/unplugin`: bundler adapters.
+- `packages/vscode`: VS Code extension that wires `vscode-languageclient` to ttscserver, exposes the built-in lint/format command bridge, and lets other plugin command ids execute through the language client with editor-applied `WorkspaceEdit`s.
+- `packages/ttsc-*`: per-platform packages (native helper + bundled Go SDK). Each ships both the `ttsc` helper and the `ttscserver` binary.
+- `tests/projects`: project-shaped fixtures copied into temp dirs by `TestProject.copyProject`.
+- `tests/test-*`: feature-test packages (run via `pnpm test:features`).
+- `tests/utils`: shared helpers (`@ttsc/testing`).
+- `tests/<plugin-name>`: workspace packages that need to be `require.resolve`-able from a fixture's `node_modules` (e.g. `tests/lint-contributor-demo`). Built by `scripts/build-current.cjs` before tests run.
+- `website`: Nextra-based docs site (`src/content/docs/**/*.mdx`) that is the canonical home for guides — shipped to https://ttsc.dev.
+- `config`, `scripts`: shared tsconfig and workspace scripts.
+
+## Commands
+
+```bash
+pnpm install
+pnpm format
+pnpm build
+pnpm test:go
+pnpm test
+```

--- a/.codex/skills/pull-request/SKILL.md
+++ b/.codex/skills/pull-request/SKILL.md
@@ -1,0 +1,23 @@
+# Pull Request Submission
+
+When the user explicitly asks for a pull request, follow this flow.
+
+## Branch from the target
+
+Branch from the PR target (`master` unless stated otherwise); never commit to the target directly. Name the branch to reflect the change: `feat/<scope>`, `fix/<scope>`, `ci/<scope>`.
+
+## Group changes into logical commits
+
+Group changes into logical commits — one per coherent unit, not a single mega-commit when the diff is large. Use the repository's existing `<type>(<scope>): <subject>` message style.
+
+## Write the PR body at open
+
+Write the PR body at open: intent, scope, deferred items, test plan. Treat it as the PR's historical intent statement. Do not rewrite the body on every follow-up push — subsequent CI fixes, newly-found design issues, and deferred-item promotions go in `gh pr comment` instead. The comment thread is the PR's chronology.
+
+## Watch checks after every push
+
+After every push, watch `gh pr checks <PR>` with the Monitor tool until each check settles. Do not poll manually; the notification arrives when transitions complete. On failure, fetch the job log via `gh api repos/<owner>/<repo>/actions/jobs/<job-id>/logs` (returns the full log when `gh run view --log-failed` is empty), diagnose, fix in place, push as a new commit, and let the monitor resume.
+
+## Hand back without merging
+
+The agent does not merge, squash-merge, or rebase the target branch. Hand back to the user when all checks pass — or when the user has acknowledged a known-failing check.

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ coverage/
 
 # AI assistant data
 .claude/
-.codex/
 .discussions/
 
 # Local Go workspace overlays

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,163 +1,52 @@
-## 1. Project
+## Skills
 
-### 1.1. Product Contract
+All conventions and workflows live as skills under `.codex/skills/`. Read the linked file when its topic applies.
 
-`ttsc` is a standalone TypeScript-Go compiler, runtime, plugin host, and LSP host. It ships three CLIs and a plugin protocol:
+### Project Outline
 
-- `ttsc` — build, check, watch, and source-to-source transform on top of `@typescript/native-preview`.
-- `ttsx` — run a TypeScript entrypoint after a real type-check (a typed `tsx`/`ts-node`).
-- `ttscserver` — Language Server Protocol host: wraps the project-selected `tsgo --lsp --stdio` process and proxies JSON-RPC traffic so ttsc plugin diagnostics, code actions, and `workspace/executeCommand` handlers merge into the same stream the editor consumes.
-- Plugins — Go source packages that share TypeScript-Go's AST/Checker. Executable `package main` sources build as sidecars; non-`main` transform packages link into a native host. `ttsc` builds plugin source on demand and caches the binary.
+What `ttsc` is, the workspace layout, and the canonical commands — `.codex/skills/project/SKILL.md`.
 
-The contract is general-purpose. Downstream projects like `typia` and `nestia` are compatibility fixtures, not the product definition.
+### Development
 
-### 1.2. Layout
+Work rules, testing, validation, change integrity — `.codex/skills/development/SKILL.md`. Read before writing or modifying code.
 
-- `packages/ttsc`: JS launcher/API plus Go host (`cmd/*`, `driver`, `internal`, `utility`) and `shim/` over TypeScript-Go internals; `internal/lspserver` is the byte-level LSP proxy used by ttscserver, and `driver.PluginSource` is the public seam embedders implement. `NativePluginSource` adapts `capabilities.lsp` sidecars; `@ttsc/lint` exposes those verbs from `packages/lint/linthost/lsp.go`; `packages/vscode` is the reference client and built-in lint/format command bridge, while custom plugin command ids are still advertised through `vscode-languageclient`.
-- `packages/{banner,paths,strip}`: utility transform plugins with package-owned `driver/` logic linked into a generic native host.
-- `packages/lint`: `@ttsc/lint` with its own native engine. Rules may consult the TypeScript-Go Checker directly via `ctx.Checker`; third-party rules ship through the public `rule` package and may use the `rule/astutil` helpers.
-- `packages/wasm`: `@ttsc/wasm` — Go `host` helper plus JS boot scaffolding for in-browser ttsc playgrounds. `host.Expose` binds `globalThis[apiName]` with the standard verbs (`build/check/transform/plugin/plugins/version`) plus fountain verbs (`snapshot/getDiagnostics/getNodeAtPosition/...`) over a snapshot handle table.
-- `packages/playground`: `@ttsc/playground` — reusable Web Worker + React shell built on `@ttsc/wasm`. Exports `createWorkerCompiler` (worker-side `ICompilerService` factory), `PlaygroundShell` (Tailwind 4 React component), runtime npm dependency installer, typia source/runtime pack helpers, and Monaco editor wrappers. Consumed by `website/` and `typia/website/`.
-- `packages/unplugin`: bundler adapters.
-- `packages/vscode`: VS Code extension that wires `vscode-languageclient` to ttscserver, exposes the built-in lint/format command bridge, and lets other plugin command ids execute through the language client with editor-applied `WorkspaceEdit`s.
-- `packages/ttsc-*`: per-platform packages (native helper + bundled Go SDK). Each ships both the `ttsc` helper and the `ttscserver` binary.
-- `tests/projects`: project-shaped fixtures copied into temp dirs by `TestProject.copyProject`.
-- `tests/test-*`: feature-test packages (run via `pnpm test:features`).
-- `tests/utils`: shared helpers (`@ttsc/testing`).
-- `tests/<plugin-name>`: workspace packages that need to be `require.resolve`-able from a fixture's `node_modules` (e.g. `tests/lint-contributor-demo`). Built by `scripts/build-current.cjs` before tests run.
-- `website`: Nextra-based docs site (`src/content/docs/**/*.mdx`) that is the canonical home for guides — shipped to https://ttsc.dev.
-- `config`, `scripts`: shared tsconfig and workspace scripts.
+### Documentation
 
-### 1.3. Commands
+READMEs and website guides — `.codex/skills/documentation/SKILL.md`. Read before writing or modifying docs.
 
-```bash
-pnpm install
-pnpm format
-pnpm build
-pnpm test:go
-pnpm test
-```
+### Multi-Agent Workflows
 
-## 2. Development
+Review Cycle, Discussion, Research Review Round — `.codex/skills/multi-agent/SKILL.md`. Read only when the user explicitly asks for a named mode.
 
-### 2.1. Work Rules
+### Pull Request Submission
 
-- Match existing conventions. Before adding a file, function, or test, open a nearby peer and mirror its naming, location, and code style — don't create parallel structures.
-- Respect existing package boundaries. Don't hardcode consumer-specific behavior into the compiler host.
-- Plugin descriptors are JS; transform logic is Go. JS transform functions (e.g. `transformSource`, `transformOutput`) are not part of the public contract.
-- First-party plugin configuration lives in dedicated `*.config.{ts,cts,mts,js,cjs,mjs,json}` files, auto-discovered by upward walk; shipped ttsc packages accept only `configFile` (an explicit path) beyond host-owned entry keys. Don't reintroduce inline option keys for `@ttsc/banner`, `@ttsc/paths`, `@ttsc/strip`, or `@ttsc/lint` — they were withdrawn so package config has one typed, discoverable home.
-- `shim.go` files marked `gen_shims:hand-maintained` are not regenerated.
-- When code behavior changes, update the matching page under `website/src/content/docs/` in the same change.
+PR submission flow — `.codex/skills/pull-request/SKILL.md`. Read when the user asks for a pull request.
 
-### 2.2. Testing
+### Benchmark
 
-**One test case per file, named after what it asserts.** Applies to both layers.
+Benchmark runner, fixture repos, publication — `.codex/skills/benchmark/SKILL.md`. Read before running, modifying, or publishing benchmark results.
 
-- **Go unit tests** live in `packages/*/test/`; one `Test*` per file. Run the real command entrypoint (e.g. `go run ./plugin`) so wrapper branches stay covered.
-- **TypeScript e2e tests** live in `tests/test-*/src/features/`. Each file exports exactly one `test_<snake_case>` function with a matching file name; `DynamicExecutor` discovers them by prefix. Materialize a temp project, spawn the real binary, and assert on observable output.
+## Maintenance
 
-Open every case with a doc comment in the same three-part shape: a one-line `Verifies …` headline, a short paragraph stating the non-obvious _why_ (which branch or regression is being pinned), and a 2–4-step numbered list summarizing the scenario.
+### Writing style
 
-```ts
-/**
- * Verifies plugin corpus: composes rejects cycle between two plugins.
- *
- * Locks the cycle-detection branch in
- * `loadProjectPlugins.ts::composePluginSources`. Composition is one hop only;
- * reciprocal `composes` arrays would silently reswap the binaries of both
- * plugins, so ttsc throws an explicit error instead of routing to the wrong
- * binary.
- *
- * 1. Two plugin descriptors each list the other in `composes`.
- * 2. Run ttsc.
- * 3. Assert non-zero exit and `composes cycle detected` in stderr.
- */
-export const test_plugin_corpus_composes_rejects_cycle_between_two_plugins =
-  () => {
-    /* ... */
-  };
-```
+AGENTS.md and SKILL.md files are read by humans as well as agents.
 
-Use the shared helpers in `tests/utils` and the per-suite `internal/` modules; do not reach into another suite's internals. Regressions that need a real directory layout (not just a synthetic temp file map) go under `tests/projects`.
+- **Concise means no redundancy, no padding** — not the same as cramming long sentences into one dense paragraph.
+- **Concise does not mean gutted.** Drop repetition; keep the rule and the rationale that makes it usable.
+- **Match structure to content.** Bullets for parallel items, a short paragraph for a single idea, a code block for a command.
+- **State the rule first, then the reason.** Use negative phrasing only for named failure modes the affirmative does not already cover.
+- **Skills point, not paraphrase.** Don't restate what the website, READMEs, or source comments already say — link to them. Skills are for cross-cutting rules and conventions, not a second copy of project docs.
 
-### 2.3. Validation
+### AGENTS.md
 
-Run the narrowest command that proves the change first, then a broader command when shared behavior or packaging changed. Report any command that could not be run.
+The single shared entry point for both Claude Code (via `CLAUDE.md → @AGENTS.md`) and Codex CLI — table of contents, not content. The only H2s are `## Skills` and `## Maintenance`.
 
-### 2.4. Change Integrity
+Update only for repository-contract changes: a new skill area, a renamed or merged skill, a workflow that no longer fits an existing skill, a release-process change, or a coding-agent rule that applies globally before any skill loads.
 
-Treat tests, fixtures, snapshots, CI workflows, package wiring, dependencies, core algorithms, and generated baselines as part of the specification. Changing them requires an explicit user request or a clear product reason, and the final report must call it out.
+### Skills
 
-For mechanical ports, migrations, or broad rewrites, preserve the existing algorithm and public behavior in reviewable slices. Prefer a concrete exemplar over abstract instructions, and inspect the diff before trusting a green test run.
-
-## 3. Documentation
-
-### 3.1. READMEs
-
-README files are for the final reader of that package or directory. Start with what it is, when to use it, installation, the smallest working setup, and the common path.
-
-Keep README language direct and practical. Avoid compiler theory, protocol details, internal architecture, and edge cases unless the reader must know them to use the package. Move deep explanations into the website guides and link them only as the next step.
-
-### 3.2. Guide Documents
-
-Guide documents live under `website/src/content/docs/` as MDX, served by Nextra at https://ttsc.dev. They are the detailed layer. Each guide must name its reader: consumer, package user, bundler user, runtime user, plugin author, or maintainer.
-
-The tree is organized by audience: top-level pages (`setup.mdx`, `why.mdx`, `faq.mdx`, `troubleshooting.mdx`) for cross-cutting tasks, per-package folders (`ttsc/`, `lint/`, `plugins/`, `wasm/`) for package guides, and `development/` for plugin-author guides. Package guides may go deeper than README with full options, recipes, troubleshooting, compatibility notes, and migration details. Plugin-author guides may cover protocol, Go APIs, testing, publishing, and internals. Keep one audience and task per page, and update the matching `_meta.ts` when adding, renaming, or moving a guide.
-
-### 3.3. AGENTS.md Maintenance
-
-Update `AGENTS.md` when the repository contract changes: new package families, moved directories, new commands, testing conventions, documentation policy, release flow, or coding-agent workflow rules.
-
-Keep `AGENTS.md` systematic, natural to read, and concise. Preserve the numbered H2/H3 structure, place new guidance in the smallest fitting section, and prefer direct rules over long rationale.
-
-When adding agent-facing rules, state the desired workflow first. Use negative constraints only for named failure modes, and include the reason so the rule points back to the intended behavior.
-
-## 4. Multi-Agent Workflows
-
-Use these workflows only when the user explicitly asks for the named workflow, a multi-agent review, or a multi-agent discussion. Use Review Cycles for direct review of changed source, docs, and tests; Discussions for open-ended topic exploration; and Research Review Rounds when review needs shared research before individual proposals.
-
-### 4.1. Review Cycles
-
-For an explicitly requested review cycle, form a team of six agents. Each agent must read the changed source, docs, and tests in full, then propose concrete improvements.
-
-The lead agent rechecks every proposal, verifies it against the codebase, and applies only changes that are technically sound and relevant.
-
-That is one cycle. For the next cycle, form a fresh team of six different agents and repeat. Continue while at least one verified proposal is accepted. Stop when no agent proposes an improvement, or when no proposal survives lead-agent validation.
-
-### 4.2. Discussions
-
-For a discussion task, create a new topic directory under `.discussions/<topic>/`. Use a short filesystem-safe topic name. Do not delete or overwrite existing discussion directories unless the user explicitly requests it.
-
-Form a team of six agents. Each agent researches the topic, creates a personal subdirectory under the topic directory, and continuously maintains its own wiki-style knowledge base there.
-
-When all agents are ready, run three unrestricted discussion rounds recorded as `round1.md`, `round2.md`, and `round3.md` in the topic directory. Each round has a one-hour budget. The lead agent moderates, acts as scribe, and does not narrow the topic unless the user did.
-
-The transcript files must record the live discussion, not a retrospective summary. The lead agent writes each statement in speaking order. Team agents read the updated transcript before speaking again and continue researching, revising their own knowledge bases, and preparing notes while waiting for their next turn.
-
-After `round3.md` is complete, the lead agent writes the agreed conclusions and major open points into `summary.md` in the topic directory, reports them to the user, and waits for the next instruction.
-
-### 4.3. Research Review Rounds
-
-For an explicitly requested research review, combine the `.discussions` knowledge-base workflow with the review validation loop.
-
-Create a new topic directory under `.discussions/<topic>/`. Each research review round gets its own `review-round-N/` subdirectory with six fresh agents, agent knowledge-base folders, `round1.md`, `round2.md`, `round3.md`, `proposals.md`, and `lead-validation.md`.
-
-In each round, agents build their own knowledge bases from the changed source, docs, tests, and any relevant research. Run the three live discussion transcripts as in Discussions: the lead agent records statements in speaking order while team agents read each other's statements, keep researching between turns, and refine their notes.
-
-At the end of a round, each agent submits its own concrete improvement proposals. Do not require consensus; discussion is for shared understanding, not voting. The lead agent verifies every proposal and applies only changes that are technically sound and relevant.
-
-For the next round, replace the team with six different agents and repeat. Continue while at least one verified proposal is accepted. Stop when no meaningful proposal remains, or when no proposal survives lead-agent validation.
-
-## 5. Pull Request Submission
-
-When the user explicitly asks for a pull request, follow this flow.
-
-1. Branch from the PR target (`master` unless stated otherwise); never commit to the target directly. Name the branch to reflect the change: `feat/<scope>`, `fix/<scope>`, `ci/<scope>`.
-
-2. Group changes into logical commits — one per coherent unit, not a single mega-commit when the diff is large. Use the repository's existing `<type>(<scope>): <subject>` message style.
-
-3. Write the PR body at open: intent, scope, deferred items, test plan. Treat it as the PR's historical intent statement. Do not rewrite the body on every follow-up push — subsequent CI fixes, newly-found design issues, and deferred-item promotions go in `gh pr comment` instead. The comment thread is the PR's chronology.
-
-4. After every push, watch `gh pr checks <PR>` with the Monitor tool until each check settles. Do not poll manually; the notification arrives when transitions complete. On failure, fetch the job log via `gh api repos/<owner>/<repo>/actions/jobs/<job-id>/logs` (returns the full log when `gh run view --log-failed` is empty), diagnose, fix in place, push as a new commit, and let the monitor resume.
-
-5. The agent does not merge, squash-merge, or rebase the target branch. Hand back to the user when all checks pass — or when the user has acknowledged a known-failing check.
+- **Location.** `.codex/skills/<kebab-name>/SKILL.md`. No numeric prefix, no frontmatter — Claude Code only auto-discovers `.claude/skills/` and Codex has no native skills system, so SKILL.md is plain markdown.
+- **AGENTS.md pointer.** Each skill gets a `### Title` entry under `## Skills` in AGENTS.md with a one-paragraph pointer to the SKILL.md path.
+- **Create or merge.** Add a new skill when a substantial repository concern would otherwise inflate AGENTS.md beyond an index. Merge sibling concerns into one multi-section skill when they share most of their structure (`multi-agent/` is the precedent).
+- **Headings are plain.** No chapter numbers in skill or AGENTS.md headings — use descriptive titles.


### PR DESCRIPTION
## Summary

- Split AGENTS.md into a two-section index: `## Skills` (pointers to per-topic SKILL.md files) and `## Maintenance` (writing style + skill conventions).
- Created `.codex/skills/` with six SKILL.md files: `project/`, `development/`, `documentation/`, `multi-agent/`, `pull-request/`, `benchmark/`.
- Single source of truth shared between Claude Code (via `CLAUDE.md → @AGENTS.md`) and Codex CLI (reads AGENTS.md directly).
- Removed `.codex/` from `.gitignore` so the skill files are tracked.

The Maintenance section spells out the contract for future skill work: file naming (`.codex/skills/<kebab>/SKILL.md`, no numeric prefix, no frontmatter), the AGENTS.md-pointer convention, when to create vs. merge a skill, and the writing-style rules (concise, non-redundant, lists for parallel items, skills point not paraphrase).

## Test plan

- [ ] Tree resolves: `.codex/skills/{benchmark,development,documentation,multi-agent,project,pull-request}/SKILL.md`
- [ ] AGENTS.md links point at the six existing SKILL.md paths
- [ ] No automated CI test exercises this directly; verified by inspection