### PR TITLE
ci(test): parallelize test.yml across matrix jobs per package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,21 @@ on:
       - "pnpm-workspace.yaml"
 
 jobs:
-  Ubuntu:
+  test:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: go, run: "pnpm run test:go && pnpm --filter ttsc go:vet" }
+          - { name: typecheck, run: "pnpm run check:flags && pnpm run test:typecheck" }
+          - { name: banner, run: "pnpm --filter @ttsc/test-banner start" }
+          - { name: lint, run: "pnpm --filter @ttsc/test-lint start" }
+          - { name: paths, run: "pnpm --filter @ttsc/test-paths start" }
+          - { name: strip, run: "pnpm --filter @ttsc/test-strip start" }
+          - { name: ttsc, run: "pnpm --filter @ttsc/test-ttsc start" }
+          - { name: unplugin, run: "pnpm --filter @ttsc/test-unplugin start" }
     steps:
       - uses: actions/checkout@v4
 
@@ -40,8 +53,8 @@ jobs:
       - name: Use System Go For Source Plugin Tests
         run: echo "TTSC_GO_BINARY=$(go env GOROOT)/bin/go" >> "$GITHUB_ENV"
 
-      - name: Run Tests
-        run: pnpm test
+      - name: Build Current Platform
+        run: pnpm run build:current
 
-      - name: Go Vet
-        run: pnpm --filter ttsc go:vet
+      - name: Run ${{ matrix.name }}
+        run: ${{ matrix.run }}


### PR DESCRIPTION
## Why

`test.yml` ran a single Ubuntu job executing `pnpm test` sequentially, taking ~25-31min of CI wall-clock. Nearly all of it was spent in `test:features` (`--workspace-concurrency=1`, strictly sequential). A single GitHub runner is only 2 cores, so raising in-job concurrency is useless — we need multiple runner instances.

## What

Replace the single job with a `matrix.include` of parallel jobs, one slice per test package plus `go` and `typecheck`. Each job repeats the shared setup (checkout/node/go/pnpm/install) and `build:current` (every test needs the built binary + packages), then runs only its slice.

| job | runs | measured |
|---|---|---|
| go | `test:go` + `go:vet` | ~3m |
| typecheck | `check:flags` + `test:typecheck` | fast |
| banner | `@ttsc/test-banner` | ~3m |
| lint | `@ttsc/test-lint` | ~8m (long pole) |
| paths | `@ttsc/test-paths` | ~1m |
| strip | `@ttsc/test-strip` | ~2m |
| ttsc | `@ttsc/test-ttsc` | ~8m (long pole) |
| unplugin | `@ttsc/test-unplugin` | ~7s |

Expected wall-clock: ~25min → longest package (~8m) + setup ≈ 9min.

`fail-fast: false` so one failing slice does not cancel the rest. Root `package.json` scripts are untouched, so local `pnpm test` is unchanged. Splitting the two 8min poles further (sharding / package split / naming unification) is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)