### PR TITLE
feat(vscode): Marketplace readiness, plus the native-Windows install fix

### DIFF
--- a/packages/vscode/bin/install.js
+++ b/packages/vscode/bin/install.js
@@ -23,9 +23,16 @@ function createCodeCommand(
     return {
       command: env.ComSpec || "cmd.exe",
       args: ["/d", "/s", "/c", quoteWindowsCommand(["code", ...args])],
+      // The `/c` payload is ALREADY fully quoted. Node's Windows spawn escapes
+      // each arg again unless told not to, turning `""code" …"` into
+      // `"\"\"code\" …\""`, which cmd.exe sees as one un-runnable token (the
+      // CVE-2024-27980 argument-escaping change, Node 18.20.2+/20.12.2+). Pass
+      // the payload verbatim so cmd's `/s` strips the outer quotes and runs
+      // `code …`.
+      options: { windowsVerbatimArguments: true },
     };
   }
-  return { command: "code", args };
+  return { command: "code", args, options: {} };
 }
 
 function quoteWindowsCommand(args) {
@@ -38,7 +45,10 @@ function quoteWindowsArg(arg) {
 
 function spawnCode(args, vsixForFallback) {
   const command = createCodeCommand(args);
-  const r = cp.spawnSync(command.command, command.args, { stdio: "inherit" });
+  const r = cp.spawnSync(command.command, command.args, {
+    stdio: "inherit",
+    ...command.options,
+  });
   if (r.error && r.error.code === "ENOENT") {
     printCodeNotFound(vsixForFallback);
     process.exit(1);

--- a/tests/test-ttsc/src/features/ttscserver/test_vscode_install_script_uses_windows_command_shim.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_vscode_install_script_uses_windows_command_shim.ts
@@ -25,14 +25,22 @@ export const test_vscode_install_script_uses_windows_command_shim = () => {
       args: string[],
       platform?: NodeJS.Platform,
       env?: NodeJS.ProcessEnv,
-    ) => { args: string[]; command: string };
+    ) => {
+      args: string[];
+      command: string;
+      options: { windowsVerbatimArguments?: boolean };
+    };
   };
 
   const args = ["--install-extension", "C:\\tmp & 100%\\ttsc.vsix", "--force"];
   assert.deepEqual(mod.createCodeCommand(args, "linux"), {
     command: "code",
     args,
+    options: {},
   });
+  // The /c payload is already fully quoted; the spawn must pass it verbatim, or
+  // Node re-escapes the quotes (\"\"code\" …) and cmd.exe cannot run it. This is
+  // the native-Windows install failure WSL never hit.
   assert.deepEqual(mod.createCodeCommand(args, "win32", { ComSpec: "cmd" }), {
     command: "cmd",
     args: [
@@ -41,5 +49,6 @@ export const test_vscode_install_script_uses_windows_command_shim = () => {
       "/c",
       '""code" "--install-extension" "C:\\tmp & 100%%\\ttsc.vsix" "--force""',
     ],
+    options: { windowsVerbatimArguments: true },
   });
 };


### PR DESCRIPTION
Readies `@ttsc/vscode` for the VS Code Marketplace, with one real install-blocking fix.

- **fix: native-Windows install.** `npx @ttsc/vscode` failed on Windows (it worked on WSL, which takes the POSIX `code` path): the fully-quoted `cmd /c` payload was escaped again by spawnSync, so cmd.exe saw one un-runnable token. Pass it verbatim (`windowsVerbatimArguments: true`, Node CVE-2024-27980 escaping).
- **feat: tsgo resolution future-proofs the rename.** `resolveTsgoBinary` now tries `@typescript/native-preview` then `typescript`, so when typescript-go graduates to the official package the extension keeps injecting `TTSC_TSGO_BINARY` without a code change. Degrades gracefully if neither resolves.
- **docs: Marketplace-ready README.** Value overview, Features, Marketplace install (npx fallback kept), command and settings reference tables, a How-it-works note, and expanded troubleshooting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
