### PR TITLE
feat(ttsx): run raw-TypeScript dependencies across the graph via Node hooks

### DIFF
--- a/.github/workflows/nestia.yml
+++ b/.github/workflows/nestia.yml
@@ -17,12 +17,13 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  Ubuntu:
+  # Pack the current-platform ttsc tarballs once and share them with every
+  # matrix job below, instead of rebuilding them six times.
+  tarballs:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
     env:
       # Only build + pack the current platform (ttsc-linux-x64) — nestia's
-      # overrides below pull in ttsc.tgz + ttsc-linux-x64.tgz only. The full
+      # overrides pull in ttsc.tgz + ttsc-linux-x64.tgz only. The full
       # cross-platform matrix takes ~20 min for tarballs we never consume.
       TTSC_TARBALLS_CURRENT: "1"
     steps:
@@ -50,6 +51,58 @@ jobs:
 
       - name: Build ttsc tarballs (current platform only)
         run: pnpm package:tgz
+
+      - name: Upload tarballs
+        uses: actions/upload-artifact@v4
+        with:
+          name: ttsc-tarballs
+          path: experimental/tarballs/*.tgz
+          if-no-files-found: error
+          retention-days: 1
+
+  # Mirror nestia (next)'s own test.yml matrix so each suite runs in parallel,
+  # but against the local ttsc tarballs instead of the published release.
+  nestia:
+    needs: tarballs
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: go, run: "pnpm test:go" }
+          - { name: sdk, run: "pnpm --filter ./tests/test-sdk start" }
+          - { name: migrate, run: "pnpm --filter ./tests/test-migrate start" }
+          - {
+              name: transform-options,
+              run: "pnpm --filter ./tests/test-transform-options start",
+            }
+          - { name: e2e, run: "pnpm --filter ./tests/test-e2e start" }
+          - { name: benchmark, run: "pnpm --filter ./tests/test-benchmark start" }
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/ttsc/go.mod
+          cache-dependency-path: |
+            packages/ttsc/go.sum
+            tests/go-transformer/go.mod
+
+      - name: Download ttsc tarballs
+        uses: actions/download-artifact@v4
+        with:
+          name: ttsc-tarballs
+          path: experimental/tarballs
 
       - name: Clone nestia next
         run: |
@@ -79,13 +132,23 @@ jobs:
           fs.writeFileSync(file, merged);
           '
 
-      - name: Test nestia next
+      - name: Install nestia dependencies
+        working-directory: experimental/nestia
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Use System Go For Source Plugin Build
+        run: echo "TTSC_GO_BINARY=$(go env GOROOT)/bin/go" >> "$GITHUB_ENV"
+
+      - name: Build nestia
         working-directory: experimental/nestia
         env:
-          # nestia's run-with-ttsc-env.cjs resolves the Go toolchain installed
-          # by setup-go above; --no-experimental-detect-module mirrors nestia's
-          # own test.yml so ESM/CJS detection stays off during the e2e run.
+          # Mirror nestia's own test.yml: keep Node's native TS strip / module
+          # detection off so the e2e run matches nestia's CI environment.
           NODE_OPTIONS: --no-experimental-strip-types --no-experimental-detect-module
-        run: |
-          pnpm install --no-frozen-lockfile
-          pnpm run test
+        run: pnpm build
+
+      - name: Run ${{ matrix.name }}
+        working-directory: experimental/nestia
+        env:
+          NODE_OPTIONS: --no-experimental-strip-types --no-experimental-detect-module
+        run: ${{ matrix.run }}

--- a/.github/workflows/nestia.yml
+++ b/.github/workflows/nestia.yml
@@ -59,12 +59,25 @@ jobs:
       - name: Use local ttsc tarballs
         working-directory: experimental/nestia
         run: |
-          cat >> pnpm-workspace.yaml <<'YAML'
-
-          overrides:
-            ttsc: file:../tarballs/ttsc.tgz
-            '@ttsc/linux-x64': file:../tarballs/ttsc-linux-x64.tgz
-          YAML
+          # nestia (next) resolves ttsc through a catalog and may grow its own
+          # top-level `overrides:` block, in which case appending a second one
+          # makes pnpm fail with a duplicated-mapping-key YAML error (see the
+          # typia workflow). Merge the local-tarball overrides into the existing
+          # block instead, creating it only when absent, and no-op on re-run.
+          node -e '
+          const fs = require("fs");
+          const file = "pnpm-workspace.yaml";
+          const text = fs.readFileSync(file, "utf8");
+          if (text.includes("file:../tarballs/ttsc.tgz")) process.exit(0);
+          const entries = [
+            "  ttsc: file:../tarballs/ttsc.tgz",
+            "  \"@ttsc/linux-x64\": file:../tarballs/ttsc-linux-x64.tgz",
+          ].join("\n");
+          const merged = /^overrides:[ \t]*$/m.test(text)
+            ? text.replace(/^overrides:[ \t]*$/m, (line) => line + "\n" + entries)
+            : text.replace(/\s*$/, "") + "\n\noverrides:\n" + entries + "\n";
+          fs.writeFileSync(file, merged);
+          '
 
       - name: Test nestia next
         working-directory: experimental/nestia

--- a/.github/workflows/typia.yml
+++ b/.github/workflows/typia.yml
@@ -72,6 +72,7 @@ jobs:
             "  \"@ttsc/linux-x64\": file:../tarballs/ttsc-linux-x64.tgz",
           ].join("\n");
           const text = fs.readFileSync(file, "utf8");
+          if (text.includes("file:../tarballs/ttsc.tgz")) process.exit(0);
           const merged = /^overrides:[ \t]*$/m.test(text)
             ? text.replace(/^overrides:[ \t]*$/m, (line) => line + "\n" + entries)
             : text.replace(/\s*$/, "") + "\n\noverrides:\n" + entries + "\n";

--- a/.github/workflows/typia.yml
+++ b/.github/workflows/typia.yml
@@ -59,12 +59,24 @@ jobs:
       - name: Use local ttsc tarballs
         working-directory: experimental/typia
         run: |
-          cat >> pnpm-workspace.yaml <<'YAML'
-
-          overrides:
-            ttsc: file:../tarballs/ttsc.tgz
-            '@ttsc/linux-x64': file:../tarballs/ttsc-linux-x64.tgz
-          YAML
+          # typia's pnpm-workspace.yaml already declares its own `overrides:`
+          # block (and resolves ttsc through a catalog), so appending a second
+          # `overrides:` key makes pnpm fail with a duplicated-mapping-key YAML
+          # error. Merge the local-tarball overrides into the existing block
+          # instead, creating the block only when typia drops it.
+          node -e '
+          const fs = require("fs");
+          const file = "pnpm-workspace.yaml";
+          const entries = [
+            "  ttsc: file:../tarballs/ttsc.tgz",
+            "  \"@ttsc/linux-x64\": file:../tarballs/ttsc-linux-x64.tgz",
+          ].join("\n");
+          const text = fs.readFileSync(file, "utf8");
+          const merged = /^overrides:[ \t]*$/m.test(text)
+            ? text.replace(/^overrides:[ \t]*$/m, (line) => line + "\n" + entries)
+            : text.replace(/\s*$/, "") + "\n\noverrides:\n" + entries + "\n";
+          fs.writeFileSync(file, merged);
+          '
 
       - name: Test typia next
         working-directory: experimental/typia

--- a/packages/ttsc/src/launcher/internal/registerRuntimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/registerRuntimeHooks.ts
@@ -1,0 +1,14 @@
+import { register } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * `--import` entry point that installs `ttsx`'s runtime module hooks in the
+ * child process. Run before the compiled entry so the `resolve`/`load` hooks in
+ * `runtimeHooks` are active for the whole dependency graph.
+ *
+ * Kept as a dedicated, dependency-free module: it must load in the child's
+ * plain Node runtime (not ttsc's), so it pulls in nothing beyond Node builtins
+ * and the sibling hooks file.
+ */
+register(pathToFileURL(path.join(__dirname, "runtimeHooks.js")).href);

--- a/packages/ttsc/src/launcher/internal/runTtsx.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsx.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import {
   getBoolean,
@@ -213,6 +214,24 @@ function printHelp(): void {
   process.stdout.write("\n");
 }
 
+/**
+ * Node flags that install ttsx's runtime module hooks in the child process.
+ * `--import` loads the registrar before the compiled entry, giving the
+ * `resolve`/`load` hooks whole-graph reach (extensionless relative imports and
+ * raw `.ts` dependencies under `node_modules`) without weakening the up-front
+ * compile gate. `--disable-warning` silences the `ExperimentalWarning` that the
+ * `load` hook's internal `stripTypeScriptTypes` call would otherwise print, the
+ * same flag this repository's own TypeScript runner uses.
+ */
+function runtimeHookArgs(): string[] {
+  const registrar = path.join(__dirname, "registerRuntimeHooks.js");
+  return [
+    "--disable-warning=ExperimentalWarning",
+    "--import",
+    pathToFileURL(registrar).href,
+  ];
+}
+
 function resolvePreload(cwd: string, preload: string): string {
   if (path.isAbsolute(preload) || isRelativeSpecifier(preload)) {
     return path.resolve(cwd, preload);
@@ -247,6 +266,7 @@ function runPreparedEntry(
       );
     }
     const args = [
+      ...runtimeHookArgs(),
       ...parsed.preload.flatMap((preload) => [
         "-r",
         resolvePreload(cwd, preload),

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -1,0 +1,287 @@
+import fs from "node:fs";
+import { stripTypeScriptTypes } from "node:module";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+/**
+ * Node.js module-customization hooks registered inside the child process that
+ * `ttsx` spawns. They give the runtime the same whole-graph reach `tsx` has,
+ * without weakening the compile gate: type-checking still happens up front in
+ * `prepareExecution`'s tsgo build, and these hooks only affect how dependencies
+ * are _loaded_ at runtime.
+ *
+ * - `resolve` rescues extensionless relative imports anywhere in the graph (e.g.
+ *   a workspace dependency exporting raw `.ts` whose own sources use `import
+ *   "./foo"`), which Node's ESM resolver rejects.
+ * - `load` transpiles raw `.ts` dependencies that live under `node_modules`,
+ *   where Node refuses to strip types at all.
+ *
+ * Workspace neighbours (realpath outside `node_modules`) keep Node's native
+ * type-stripping path, so they stay covered by the up-front compile gate.
+ */
+
+/** Source/JS extensions probed when an extensionless relative import fails. */
+const RESOLVABLE_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".mjs",
+  ".cjs",
+] as const;
+
+/** TypeScript source extensions the `load` hook transpiles under node_modules. */
+const TYPESCRIPT_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"] as const;
+
+interface ResolveContext {
+  readonly parentURL?: string;
+  readonly conditions?: readonly string[];
+  readonly importAttributes?: Record<string, string>;
+}
+
+interface ResolveResult {
+  readonly url: string;
+  readonly format?: string | null;
+  readonly shortCircuit?: boolean;
+}
+
+interface LoadContext {
+  readonly format?: string | null;
+  readonly conditions?: readonly string[];
+  readonly importAttributes?: Record<string, string>;
+}
+
+interface LoadResult {
+  readonly format: string;
+  readonly source?: string | Uint8Array;
+  readonly shortCircuit?: boolean;
+}
+
+type NextResolve = (
+  specifier: string,
+  context: ResolveContext,
+) => Promise<ResolveResult>;
+
+type NextLoad = (url: string, context: LoadContext) => Promise<LoadResult>;
+
+/**
+ * Rescue an extensionless relative specifier that Node's ESM resolver rejected.
+ *
+ * Node resolves the common cases itself; this hook only runs after
+ * `nextResolve` throws, so a successful resolution is never perturbed. When the
+ * throwing specifier is relative, the candidate extensions are probed against
+ * the parent's directory and the first existing file (or directory index) wins.
+ * A genuinely missing module finds no candidate and the original error is
+ * rethrown, preserving `ERR_MODULE_NOT_FOUND`.
+ */
+export async function resolve(
+  specifier: string,
+  context: ResolveContext,
+  nextResolve: NextResolve,
+): Promise<ResolveResult> {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (error) {
+    const rescued = probeRelativeSpecifier(specifier, context.parentURL);
+    if (rescued === null) {
+      throw error;
+    }
+    return { shortCircuit: true, url: rescued };
+  }
+}
+
+/**
+ * Transpile a raw `.ts` dependency that lives under `node_modules`.
+ *
+ * Node strips types for first-party `.ts` automatically but refuses to do so
+ * under `node_modules` (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`). This
+ * hook performs the same type-strip transform for those files, scoped strictly
+ * to `node_modules` so workspace neighbours keep Node's native path.
+ */
+export async function load(
+  url: string,
+  context: LoadContext,
+  nextLoad: NextLoad,
+): Promise<LoadResult> {
+  const filename = transpilableNodeModulesPath(url);
+  if (filename === null) {
+    return nextLoad(url, context);
+  }
+  const source = transpile(filename);
+  return {
+    format: moduleFormat(filename, source),
+    shortCircuit: true,
+    source,
+  };
+}
+
+/**
+ * Probe candidate extensions for a relative `specifier` whose bare form failed
+ * to resolve. Returns a `file:` URL string for the first match, or `null` when
+ * the specifier is non-relative, has no usable parent, or matches nothing.
+ */
+function probeRelativeSpecifier(
+  specifier: string,
+  parentURL: string | undefined,
+): string | null {
+  if (!isRelativeSpecifier(specifier)) {
+    return null;
+  }
+  if (parentURL === undefined || !parentURL.startsWith("file:")) {
+    return null;
+  }
+  if (hasConcreteExtension(specifier)) {
+    return null;
+  }
+  const parentDir = path.dirname(fileURLToPath(parentURL));
+  const base = path.resolve(parentDir, specifier);
+  for (const extension of RESOLVABLE_EXTENSIONS) {
+    const candidate = base + extension;
+    if (isFile(candidate)) {
+      return pathToFileURL(candidate).href;
+    }
+  }
+  for (const extension of RESOLVABLE_EXTENSIONS) {
+    const candidate = path.join(base, `index${extension}`);
+    if (isFile(candidate)) {
+      return pathToFileURL(candidate).href;
+    }
+  }
+  return null;
+}
+
+/**
+ * Return the filesystem path of a `file:` URL when it points at a TypeScript
+ * source under `node_modules`, otherwise `null`. Both conditions must hold for
+ * the `load` hook to take over: workspace `.ts` (outside `node_modules`) and
+ * already-JavaScript files fall through to Node.
+ */
+function transpilableNodeModulesPath(url: string): string | null {
+  if (!url.startsWith("file:")) {
+    return null;
+  }
+  const filename = fileURLToPath(url);
+  if (!isTypeScriptSource(filename) || !isUnderNodeModules(filename)) {
+    return null;
+  }
+  return filename;
+}
+
+/**
+ * Strip TypeScript types from `filename`, transforming TS-only constructs
+ * (enums, namespaces, parameter properties) so the result is runnable
+ * JavaScript. No transpile cache is kept: Node caches every module by resolved
+ * URL, so each dependency file reaches this hook at most once per run.
+ */
+function transpile(filename: string): string {
+  return stripTypeScriptTypes(fs.readFileSync(filename, "utf8"), {
+    mode: "transform",
+    sourceUrl: pathToFileURL(filename).href,
+  });
+}
+
+/**
+ * Decide the module format for a transpiled `node_modules` TypeScript file.
+ *
+ * Type-stripping never rewrites module syntax, so the emitted `source` keeps
+ * whatever `import`/`export` or `require` form the author wrote. The format
+ * must match that syntax or Node mis-parses the module. The extension is
+ * authoritative for `.mts`/`.cts`; otherwise the nearest `package.json` `type`
+ * sets the baseline, but unambiguous ESM syntax overrides a CommonJS baseline
+ * exactly as Node's own module-syntax detection does.
+ */
+function moduleFormat(filename: string, source: string): string {
+  if (filename.endsWith(".mts")) {
+    return "module";
+  }
+  if (filename.endsWith(".cts")) {
+    return "commonjs";
+  }
+  if (nearestPackageType(filename) === "module") {
+    return "module";
+  }
+  return hasEsmSyntax(source) ? "module" : "commonjs";
+}
+
+/** True when `source` carries a top-level `import`/`export` statement. */
+function hasEsmSyntax(source: string): boolean {
+  return /(?:^|[\n;])\s*(?:import|export)\b/.test(source);
+}
+
+/** Package-type cache keyed by directory, mirroring Node's own lookup walk. */
+const packageTypeCache = new Map<string, "module" | "commonjs">();
+
+function nearestPackageType(filename: string): "module" | "commonjs" {
+  let directory = path.dirname(filename);
+  const chain: string[] = [];
+  while (true) {
+    const cached = packageTypeCache.get(directory);
+    if (cached !== undefined) {
+      return rememberPackageType(chain, cached);
+    }
+    chain.push(directory);
+    const type = readPackageType(directory);
+    if (type !== null) {
+      return rememberPackageType(chain, type);
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) {
+      return rememberPackageType(chain, "commonjs");
+    }
+    directory = parent;
+  }
+}
+
+function rememberPackageType(
+  directories: readonly string[],
+  type: "module" | "commonjs",
+): "module" | "commonjs" {
+  for (const directory of directories) {
+    packageTypeCache.set(directory, type);
+  }
+  return type;
+}
+
+/** Read a directory's `package.json` `type`, or `null` when absent/invalid. */
+function readPackageType(directory: string): "module" | "commonjs" | null {
+  const manifest = path.join(directory, "package.json");
+  if (!isFile(manifest)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(manifest, "utf8")) as {
+      type?: unknown;
+    };
+    return parsed.type === "module" ? "module" : "commonjs";
+  } catch {
+    return "commonjs";
+  }
+}
+
+function isRelativeSpecifier(specifier: string): boolean {
+  return specifier.startsWith("./") || specifier.startsWith("../");
+}
+
+/** True when `specifier` already carries an extension Node can load directly. */
+function hasConcreteExtension(specifier: string): boolean {
+  return /\.(?:[cm]?jsx?|json|node|[cm]?tsx?)$/i.test(specifier);
+}
+
+function isTypeScriptSource(filename: string): boolean {
+  return TYPESCRIPT_EXTENSIONS.some((extension) =>
+    filename.endsWith(extension),
+  );
+}
+
+function isUnderNodeModules(filename: string): boolean {
+  return filename.split(path.sep).includes("node_modules");
+}
+
+function isFile(candidate: string): boolean {
+  try {
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -204,9 +204,18 @@ function moduleFormat(filename: string, source: string): string {
   return hasEsmSyntax(source) ? "module" : "commonjs";
 }
 
-/** True when `source` carries a top-level `import`/`export` statement. */
+/**
+ * True when `source` carries unambiguous ESM syntax: a top-level
+ * `import`/`export` statement, or an `import.meta` reference (which is a syntax
+ * error outside a module). Mirrors the markers Node's own detection keys on.
+ * `stripTypeScriptTypes` has already removed comments, so a keyword inside a
+ * stripped comment cannot produce a false positive.
+ */
 function hasEsmSyntax(source: string): boolean {
-  return /(?:^|[\n;])\s*(?:import|export)\b/.test(source);
+  return (
+    /(?:^|[\n;])\s*(?:import|export)\b/.test(source) ||
+    /\bimport\s*\.\s*meta\b/.test(source)
+  );
 }
 
 /** Package-type cache keyed by directory, mirroring Node's own lookup walk. */
@@ -260,7 +269,12 @@ function readPackageType(directory: string): "module" | "commonjs" | null {
 }
 
 function isRelativeSpecifier(specifier: string): boolean {
-  return specifier.startsWith("./") || specifier.startsWith("../");
+  return (
+    specifier === "." ||
+    specifier === ".." ||
+    specifier.startsWith("./") ||
+    specifier.startsWith("../")
+  );
 }
 
 /** True when `specifier` already carries an extension Node can load directly. */

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -288,8 +288,25 @@ function isTypeScriptSource(filename: string): boolean {
   );
 }
 
+/**
+ * True when `filename` lives inside a real `node_modules` package. A
+ * `node_modules/.cache` segment does not count: `ttsx` mirrors the project into
+ * `<root>/node_modules/.cache/ttsc/ttsx/.../fs/...`, so the user's own sources
+ * appear under that cache prefix at runtime. Treating them as dependencies
+ * would type-strip a project file (which `stripTypeScriptTypes` cannot do as
+ * faithfully as the compile gate, e.g. it cannot elide type-only imports) and
+ * steal it from a host loader. A genuine dependency still has a deeper
+ * `node_modules/<pkg>` segment, so it is detected; `.cache` (never a package
+ * name) is the only thing skipped.
+ */
 function isUnderNodeModules(filename: string): boolean {
-  return filename.split(path.sep).includes("node_modules");
+  const segments = filename.split(path.sep);
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    if (segments[i] === "node_modules" && segments[i + 1] !== ".cache") {
+      return true;
+    }
+  }
+  return false;
 }
 
 function isFile(candidate: string): boolean {

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_fails_at_the_compile_gate_on_a_type_error_in_an_imported_workspace_package.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_fails_at_the_compile_gate_on_a_type_error_in_an_imported_workspace_package.ts
@@ -1,0 +1,60 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Verifies ttsx still fails at the compile gate on a type error inside an
+ * imported workspace package.
+ *
+ * The runtime hooks are deliberately runtime-only: they must not weaken the
+ * up-front type-check. ttsx's tsgo build deep-checks the whole program,
+ * including workspace neighbours reached through imports, so a type error in a
+ * symlinked workspace dependency must abort before the entry ever runs.
+ *
+ * 1. Create an ESM project plus a symlinked `ws-dep` whose source contains a type
+ *    error, imported by the entry.
+ * 2. Run ttsx against the entry.
+ * 3. Assert it exits non-zero, names the dependency file, and prints no output.
+ */
+export const test_ttsx_fails_at_the_compile_gate_on_a_type_error_in_an_imported_workspace_package =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ type: "module", private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "packages/ws-dep/package.json": JSON.stringify({
+        name: "ws-dep",
+        version: "1.0.0",
+        type: "module",
+        exports: { ".": "./src/index.ts" },
+      }),
+      "packages/ws-dep/src/index.ts": `const bad: number = "not a number";\nexport const hello = (): string => \`value-\${bad}\`;\n`,
+      "src/main.ts": `import { hello } from "ws-dep";\nconsole.log(hello());\n`,
+    });
+    fs.mkdirSync(path.join(root, "node_modules"), { recursive: true });
+    fs.symlinkSync(
+      path.join(root, "packages", "ws-dep"),
+      path.join(root, "node_modules", "ws-dep"),
+      "junction",
+    );
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /ws-dep[\\/]src[\\/]index\.ts/);
+    assert.equal(result.stdout.trim(), "");
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_preserves_module_not_found_for_a_missing_extensionless_relative_import.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_preserves_module_not_found_for_a_missing_extensionless_relative_import.ts
@@ -1,0 +1,44 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx preserves `ERR_MODULE_NOT_FOUND` for a missing extensionless
+ * relative import.
+ *
+ * The `resolve` hook only rescues specifiers it can map to a real file; when no
+ * candidate extension matches it must rethrow Node's original error rather than
+ * masking it. A computed dynamic import bypasses the up-front compile gate so
+ * the failure surfaces at runtime, exactly where the hook runs.
+ *
+ * 1. Create an ESM entry that dynamically imports a computed `"./missing"`
+ *    specifier with no matching file.
+ * 2. Run ttsx against the entry.
+ * 3. Assert it exits non-zero with `ERR_MODULE_NOT_FOUND`.
+ */
+export const test_ttsx_preserves_module_not_found_for_a_missing_extensionless_relative_import =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ type: "module", private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "src/main.ts": `export {};\nconst specifier: string = "./mis" + "sing";\nawait import(specifier);\n`,
+    });
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /ERR_MODULE_NOT_FOUND/);
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_preserves_module_not_found_for_a_missing_package_import.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_preserves_module_not_found_for_a_missing_package_import.ts
@@ -1,0 +1,44 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx preserves `ERR_MODULE_NOT_FOUND` for a missing bare package
+ * import.
+ *
+ * The `resolve` hook's extension probing is scoped to relative specifiers; a
+ * bare package specifier is none of its business, so it must rethrow Node's
+ * original resolution error untouched. This pins the non-relative branch of the
+ * rescue logic.
+ *
+ * 1. Create an ESM entry that dynamically imports a computed bare specifier for a
+ *    package that is not installed.
+ * 2. Run ttsx against the entry.
+ * 3. Assert it exits non-zero with `ERR_MODULE_NOT_FOUND`.
+ */
+export const test_ttsx_preserves_module_not_found_for_a_missing_package_import =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ type: "module", private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "src/main.ts": `export {};\nconst specifier: string = "no-such-" + "package-xyz";\nawait import(specifier);\n`,
+    });
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /ERR_MODULE_NOT_FOUND/);
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_preserves_module_not_found_for_a_missing_relative_import_with_extension.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_preserves_module_not_found_for_a_missing_relative_import_with_extension.ts
@@ -1,0 +1,44 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx preserves `ERR_MODULE_NOT_FOUND` for a missing relative import
+ * that already carries an extension.
+ *
+ * A specifier that already names a concrete extension needs no probing, so the
+ * `resolve` hook must not interfere: it rethrows Node's original error instead
+ * of appending more extensions. This pins the concrete-extension branch as
+ * distinct from the extensionless rescue path.
+ *
+ * 1. Create an ESM entry that dynamically imports a computed `"./missing.ts"`
+ *    specifier with no matching file.
+ * 2. Run ttsx against the entry.
+ * 3. Assert it exits non-zero with `ERR_MODULE_NOT_FOUND`.
+ */
+export const test_ttsx_preserves_module_not_found_for_a_missing_relative_import_with_extension =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ type: "module", private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "src/main.ts": `export {};\nconst specifier: string = "./mis" + "sing.ts";\nawait import(specifier);\n`,
+    });
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /ERR_MODULE_NOT_FOUND/);
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_resolves_directory_index_imports_in_a_node_modules_raw_ts_dependency.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_resolves_directory_index_imports_in_a_node_modules_raw_ts_dependency.ts
@@ -1,0 +1,52 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx resolves directory-index imports inside a published raw `.ts`
+ * dependency.
+ *
+ * When a `node_modules` dependency's own source does `import "./sub"` and `sub`
+ * is a directory, Node's ESM resolver does not fall back to `sub/index.ts`. The
+ * `resolve` hook must probe the directory-index candidates, and the `load` hook
+ * must then transpile the nested file (whose immediate directory has no
+ * `package.json`, exercising the package-type walk to the package root).
+ *
+ * 1. Install `idx-dep` whose `index.ts` imports `"./sub"` (a directory).
+ * 2. Run ttsx against an entry importing the dependency.
+ * 3. Assert the nested `sub/index.ts` resolved and executed.
+ */
+export const test_ttsx_resolves_directory_index_imports_in_a_node_modules_raw_ts_dependency =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ type: "module", private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/idx-dep/package.json": JSON.stringify({
+        name: "idx-dep",
+        version: "1.0.0",
+        type: "module",
+        exports: { ".": "./index.ts" },
+      }),
+      "node_modules/idx-dep/index.ts": `import { deep } from "./sub";\nexport const fromIdx = (): string => deep();\n`,
+      "node_modules/idx-dep/sub/index.ts": `export const deep = (): string => "directory-index-ok";\n`,
+      "src/main.ts": `import { fromIdx } from "idx-dep";\nconsole.log(fromIdx());\n`,
+    });
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "directory-index-ok");
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_resolves_extensionless_imports_in_a_symlinked_workspace_raw_ts_dependency.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_resolves_extensionless_imports_in_a_symlinked_workspace_raw_ts_dependency.ts
@@ -1,0 +1,61 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Verifies ttsx resolves extensionless imports inside a symlinked workspace raw
+ * `.ts` dependency.
+ *
+ * A pnpm-style workspace dependency is a `node_modules` symlink whose realpath
+ * lives outside `node_modules`, so Node strips its types natively but rejects
+ * the source's extensionless relative imports with `ERR_MODULE_NOT_FOUND`.
+ * ttsx's runtime `resolve` hook must probe the candidate extensions and rescue
+ * the import without any change to the dependency.
+ *
+ * 1. Create an ESM project plus a `ws-dep` package whose `index.ts` does `import
+ *    "./util"` (no extension), symlinked into `node_modules`.
+ * 2. Run ttsx against an entry importing the dependency.
+ * 3. Assert the dependency executed and produced its greeting.
+ */
+export const test_ttsx_resolves_extensionless_imports_in_a_symlinked_workspace_raw_ts_dependency =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ type: "module", private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "packages/ws-dep/package.json": JSON.stringify({
+        name: "ws-dep",
+        version: "1.0.0",
+        type: "module",
+        exports: { ".": "./src/index.ts" },
+      }),
+      "packages/ws-dep/src/index.ts": `import { greet } from "./util";\nexport const hello = (): string => greet("workspace");\n`,
+      "packages/ws-dep/src/util.ts": `export const greet = (who: string): string => \`hello-\${who}\`;\n`,
+      "src/main.ts": `import { hello } from "ws-dep";\nconsole.log(hello());\n`,
+    });
+    fs.mkdirSync(path.join(root, "node_modules"), { recursive: true });
+    fs.symlinkSync(
+      path.join(root, "packages", "ws-dep"),
+      path.join(root, "node_modules", "ws-dep"),
+      "junction",
+    );
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "hello-workspace");
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_commonjs_package_raw_ts_dependency_that_uses_import_meta_as_a_module.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_commonjs_package_raw_ts_dependency_that_uses_import_meta_as_a_module.ts
@@ -1,0 +1,51 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx loads a CommonJS-package raw `.ts` dependency that uses
+ * `import.meta` as a module.
+ *
+ * `import.meta` is a syntax error outside an ES module, yet a `.ts` file can
+ * use it without any top-level `import`/`export` statement. The `load` hook's
+ * format decision must treat `import.meta` as an ESM marker (as Node's own
+ * module detection does); otherwise the file is mislabeled `commonjs` and
+ * crashes with "Cannot use 'import.meta' outside a module".
+ *
+ * 1. Install a published `meta-dep` with no `type` field whose `.ts` entry uses
+ *    `import.meta.url` and no `import`/`export` statement.
+ * 2. Run ttsx against an entry that imports it for side effect.
+ * 3. Assert the dependency ran as a module and saw a real `import.meta.url`.
+ */
+export const test_ttsx_runs_a_commonjs_package_raw_ts_dependency_that_uses_import_meta_as_a_module =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ type: "module", private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/meta-dep/package.json": JSON.stringify({
+        name: "meta-dep",
+        version: "1.0.0",
+        exports: { ".": "./effect.ts" },
+      }),
+      "node_modules/meta-dep/effect.ts": `const here: string = import.meta.url;\n(globalThis as Record<string, unknown>).__metaDep = here.startsWith("file:")\n  ? "meta-ok"\n  : "meta-bad";\n`,
+      "src/main.ts": `import "meta-dep";\nconsole.log((globalThis as Record<string, unknown>).__metaDep);\n`,
+    });
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "meta-ok");
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_commonjs_package_raw_ts_dependency_with_esm_syntax_as_a_module.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_commonjs_package_raw_ts_dependency_with_esm_syntax_as_a_module.ts
@@ -1,0 +1,51 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx loads a CommonJS-package raw `.ts` dependency that uses ESM
+ * syntax as a module.
+ *
+ * Type-stripping never rewrites module syntax, so a `.ts` file authored with
+ * `import`/`export` stays ESM even when its package omits `type: module`.
+ * Labelling it CommonJS (the package baseline) would make Node reject its named
+ * exports, so the `load` hook's format decision lets unambiguous ESM syntax
+ * override the CommonJS baseline, matching Node's own module-syntax detection.
+ *
+ * 1. Install a published `pub-dep` with no `type` field whose `.ts` source uses
+ *    ESM `export`.
+ * 2. Run ttsx against an entry that imports a named export from it.
+ * 3. Assert the named export resolved and executed.
+ */
+export const test_ttsx_runs_a_commonjs_package_raw_ts_dependency_with_esm_syntax_as_a_module =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ type: "module", private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/pub-dep/package.json": JSON.stringify({
+        name: "pub-dep",
+        version: "1.0.0",
+        exports: { ".": "./index.ts" },
+      }),
+      "node_modules/pub-dep/index.ts": `export const detect = (): string => "detected-as-module";\n`,
+      "src/main.ts": `import { detect } from "pub-dep";\nconsole.log(detect());\n`,
+    });
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "detected-as-module");
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_commonjs_package_raw_ts_dependency_with_no_module_syntax_as_commonjs.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_commonjs_package_raw_ts_dependency_with_no_module_syntax_as_commonjs.ts
@@ -1,0 +1,51 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx loads a CommonJS-package raw `.ts` dependency that has no
+ * module syntax as CommonJS.
+ *
+ * When a `node_modules` `.ts` file declares no `import`/`export` and its
+ * package omits `type: module`, there is no ESM syntax to override the CommonJS
+ * baseline, so the `load` hook must label it `commonjs`. This is the negative
+ * twin of the ESM-syntax detection case: the format decision must fall through
+ * to CommonJS rather than defaulting to a module.
+ *
+ * 1. Install a published `se-dep` with no `type` field whose `.ts` entry only runs
+ *    a side effect (no `import`/`export`).
+ * 2. Run ttsx against an entry that imports it for side effect.
+ * 3. Assert the side effect ran.
+ */
+export const test_ttsx_runs_a_commonjs_package_raw_ts_dependency_with_no_module_syntax_as_commonjs =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ type: "module", private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/se-dep/package.json": JSON.stringify({
+        name: "se-dep",
+        version: "1.0.0",
+        exports: { ".": "./effect.ts" },
+      }),
+      "node_modules/se-dep/effect.ts": `const tag: string = "side-effect-ran";\n(globalThis as Record<string, unknown>).__seDep = tag;\n`,
+      "src/main.ts": `import "se-dep";\nconsole.log((globalThis as Record<string, unknown>).__seDep);\n`,
+    });
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "side-effect-ran");
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_published_cts_dependency_as_commonjs.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_published_cts_dependency_as_commonjs.ts
@@ -1,0 +1,48 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx loads a published raw `.cts` dependency as CommonJS.
+ *
+ * The `load` hook treats `.cts` as authoritatively CommonJS, the counterpart to
+ * the `.mts` rule, and `transform` mode lowers a TypeScript `export =`
+ * assignment into a CommonJS `module.exports`. This pins that an ESM consumer
+ * can still import a published `.cts` source through Node's CommonJS interop.
+ *
+ * 1. Install a published `cts-dep` whose entry is `index.cts` using `export =`.
+ * 2. Run ttsx against an ESM entry importing its default export.
+ * 3. Assert the CommonJS dependency executed.
+ */
+export const test_ttsx_runs_a_published_cts_dependency_as_commonjs = () => {
+  const root = TestProject.createProject({
+    "package.json": JSON.stringify({ type: "module", private: true }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ES2022",
+        moduleResolution: "bundler",
+        strict: true,
+        esModuleInterop: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "node_modules/cts-dep/package.json": JSON.stringify({
+      name: "cts-dep",
+      version: "1.0.0",
+      exports: { ".": "./index.cts" },
+    }),
+    "node_modules/cts-dep/index.cts": `const value: string = "cts-commonjs";\nexport = value;\n`,
+    "src/main.ts": `import value from "cts-dep";\nconsole.log(value);\n`,
+  });
+
+  const result = TestProject.spawn(
+    TestProject.TTSX_BIN,
+    ["--cwd", root, "src/main.ts"],
+    { cwd: root },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "cts-commonjs");
+};

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_published_esm_raw_ts_dependency_with_enums_under_node_modules.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_published_esm_raw_ts_dependency_with_enums_under_node_modules.ts
@@ -1,0 +1,53 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx runs a published ESM raw `.ts` dependency that ships under
+ * `node_modules`.
+ *
+ * Node refuses to strip types from any `.ts` under `node_modules`
+ * (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`), so an ESM-only package that
+ * publishes raw TypeScript cannot load. ttsx's runtime `load` hook transpiles
+ * such files in `transform` mode, which also lowers TypeScript-only constructs
+ * like `enum`, and labels the result as a module from the package `type`.
+ *
+ * 1. Install a published `pub-dep` (`type: module`) whose source uses an `enum`
+ *    and an extensionless relative import.
+ * 2. Run ttsx against an entry importing the dependency.
+ * 3. Assert the transpiled dependency executed, enum value included.
+ */
+export const test_ttsx_runs_a_published_esm_raw_ts_dependency_with_enums_under_node_modules =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ type: "module", private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/pub-dep/package.json": JSON.stringify({
+        name: "pub-dep",
+        version: "1.0.0",
+        type: "module",
+        exports: { ".": "./src/index.ts" },
+      }),
+      "node_modules/pub-dep/src/index.ts": `import { Color } from "./color";\nexport const paint = (): string => \`painted-\${Color.Red}\`;\n`,
+      "node_modules/pub-dep/src/color.ts": `export enum Color {\n  Red = "red",\n  Blue = "blue",\n}\n`,
+      "src/main.ts": `import { paint } from "pub-dep";\nconsole.log(paint());\n`,
+    });
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "painted-red");
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_published_mts_dependency_as_a_module.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_published_mts_dependency_as_a_module.ts
@@ -1,0 +1,47 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx loads a published raw `.mts` dependency as a module.
+ *
+ * The `load` hook treats the file extension as authoritative ahead of any
+ * `package.json` lookup: `.mts` is always an ES module regardless of the
+ * package `type`. This pins that the extension branch wins for a `.mts` source
+ * shipped under `node_modules` with no `type` field.
+ *
+ * 1. Install a published `mts-dep` (no `type` field) whose entry is `index.mts`.
+ * 2. Run ttsx against an entry importing it.
+ * 3. Assert the `.mts` dependency executed as ESM.
+ */
+export const test_ttsx_runs_a_published_mts_dependency_as_a_module = () => {
+  const root = TestProject.createProject({
+    "package.json": JSON.stringify({ type: "module", private: true }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ES2022",
+        moduleResolution: "bundler",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "node_modules/mts-dep/package.json": JSON.stringify({
+      name: "mts-dep",
+      version: "1.0.0",
+      exports: { ".": "./index.mts" },
+    }),
+    "node_modules/mts-dep/index.mts": `export const fromMts = (): string => "mts-module";\n`,
+    "src/main.ts": `import { fromMts } from "mts-dep";\nconsole.log(fromMts());\n`,
+  });
+
+  const result = TestProject.spawn(
+    TestProject.TTSX_BIN,
+    ["--cwd", root, "src/main.ts"],
+    { cwd: root },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "mts-module");
+};

--- a/website/src/content/docs/ttsc/execute.mdx
+++ b/website/src/content/docs/ttsc/execute.mdx
@@ -18,6 +18,20 @@ Type errors stop execution. So do `@ttsc/lint` errors (warnings don't).
 
 Projects that enable `allowImportingTsExtensions` are supported. During the runtime emit, `ttsx` rewrites relative `.ts`, `.tsx`, `.mts`, and `.cts` import specifiers to the matching JavaScript extensions so Node can execute the output. The emitted JavaScript lives in a per-run cache directory and is removed after the script exits.
 
+## Raw-TypeScript dependencies
+
+The type-check covers your whole program, but at runtime your dependencies are loaded by Node directly. When part of the graph is ESM, Node trips over dependencies that ship raw TypeScript:
+
+- A workspace dependency (a `node_modules` symlink whose real files live outside `node_modules`) gets its types stripped by Node, but its own extensionless relative imports (`import "./util"`) are rejected with `ERR_MODULE_NOT_FOUND`.
+- A published dependency that ships `.ts` inside `node_modules` cannot be loaded at all, because Node refuses to strip types under `node_modules` (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`).
+
+`ttsx` installs Node module hooks in the run, the same approach `tsx` uses, so both cases just work without touching the dependency's `exports`, sources, or `tsconfig`:
+
+- a `resolve` hook probes the candidate extensions (and directory `index` files) for an extensionless relative import anywhere in the graph;
+- a `load` hook transpiles raw `.ts` files under `node_modules`, scoped so workspace neighbours keep Node's native type-stripping path.
+
+These hooks are runtime-only and never weaken the compile gate: the up-front tsgo build still deep-checks the whole program, imported workspace neighbours included, so a type error in a dependency's source fails the run before anything executes. A genuinely missing module still throws `ERR_MODULE_NOT_FOUND`. This makes `ttsx` strictly stronger than `tsx`: a full type-check plus the same runtime reach.
+
 ## Pass arguments to the script
 
 Use `--` to separate `ttsx` flags from the script's own args:


### PR DESCRIPTION
## Intent

Closes #193. `ttsx` only rewrote its own emitted entry, so dependencies that ship raw `.ts` failed once any part of an ESM graph loaded them:

- a **workspace** dependency (a `node_modules` symlink whose realpath is outside `node_modules`) had its types stripped by Node, but its own extensionless relative imports were rejected (`ERR_MODULE_NOT_FOUND`);
- a **published** dependency shipping `.ts` under `node_modules` could not load at all, because Node refuses to strip types there (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`).

This blocked `typia` from dropping its last `ts-node` usage.

## Scope

Register Node module-customization hooks in the child `ttsx` spawns (`--import` a registrar that `module.register`s the hooks), the way `tsx` does:

- **`resolve` hook** — after Node's resolver throws on a relative specifier, probe `.ts/.tsx/.mts/.cts/.js/.mjs/.cjs` then `index.*`, across the whole graph. Closes the workspace wall.
- **`load` hook** — type-strip raw `.ts` under `node_modules` only, so workspace neighbours keep Node's native path. Module format follows the extension (`.mts`/`.cts`), then the nearest `package.json` `type`, with ESM-syntax detection overriding a CommonJS baseline exactly as Node's own module-syntax detection does.

The hooks are runtime-only and never weaken the compile gate: the up-front tsgo build still deep-checks the whole program including imported workspace neighbours. So `ttsx` stays strictly stronger than `tsx` (full compile gate + `tsx`-style runtime reach).

## Acceptance (all verified by new e2e tests)

- ✅ a workspace dep exporting raw `.ts` with extensionless imports runs green (resolve hook);
- ✅ a published dep shipping raw `.ts` runs green (load hook);
- ✅ a genuinely missing module still throws `ERR_MODULE_NOT_FOUND` (relative-extensionless, relative-with-extension, and bare-package variants);
- ✅ a type error inside an imported workspace package still fails at the compile gate before anything runs.

## Deviations from the issue's suggested mechanism

Two implementation choices differ from the request text; both keep the issue's stated *intent* ("transpile-only, no type-checking, no per-dependency tsconfig") and satisfy every acceptance criterion:

1. **Transpiler.** The issue suggested tsgo's transpile / `api-transform` path. Every tsgo entry point in this repo (`api-compile`, `api-transform`, `runSingleFileEmit`) builds a *whole, checked* program against a `tsconfig`; there is no single-file, no-check transpile primitive, and the child is a plain Node process. So the `load` hook uses Node's own `module.stripTypeScriptTypes` in `transform` mode — the same type-strip Node applies to first-party `.ts`, just reached past the `node_modules` policy refusal. This is transpile-only, needs no tsconfig, and matches what `tsx`/Node do.
2. **Cache.** The issue asked to cache by path + mtime. Node already caches every module by resolved URL, and the compile gate rejects the query-string aliasing that would re-trigger a load, so a per-file transpile cache can never hit in a single run. Dropped to keep the load path clean and fully covered. (The `package.json` `type` lookup *is* cached, since multiple files in one package legitimately hit it.)

The `ExperimentalWarning` that `stripTypeScriptTypes` would print is silenced with `--disable-warning=ExperimentalWarning` on the child, the same flag this repo's own TypeScript runner uses.

## Test plan

- New e2e suite under `tests/test-ttsc/src/features/ttsx-runtime/` (10 cases) — full `ttsx` feature suite green.
- `tsgo --noEmit` on `tests/test-ttsc` clean; `packages/ttsc` build (type-check + emit) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)