### PR TITLE
feat(ttsc): restore binder symbols on rebuilt plugin-emit containers

### DIFF
--- a/.github/workflows/typia.yml
+++ b/.github/workflows/typia.yml
@@ -54,9 +54,7 @@ jobs:
       - name: Clone typia next
         run: |
           rm -rf experimental/typia
-          # TEMP: clone the native-ttsx integration branch while it is in flight.
-          # Switch back to master (drop --branch) at final merge.
-          git clone --depth=1 --branch feat/native-ttsx-integration https://github.com/samchon/typia experimental/typia
+          git clone --depth=1 https://github.com/samchon/typia experimental/typia
 
       - name: Use local ttsc tarballs
         working-directory: experimental/typia

--- a/packages/ttsc/driver/emit_plugin.go
+++ b/packages/ttsc/driver/emit_plugin.go
@@ -25,8 +25,8 @@ func (h *pluginEmitHost) SourceFiles() []*shimast.SourceFile { return h.program.
 func (h *pluginEmitHost) UseCaseSensitiveFileNames() bool {
   return h.program.UseCaseSensitiveFileNames()
 }
-func (h *pluginEmitHost) GetCurrentDirectory() string   { return h.program.GetCurrentDirectory() }
-func (h *pluginEmitHost) CommonSourceDirectory() string { return h.program.CommonSourceDirectory() }
+func (h *pluginEmitHost) GetCurrentDirectory() string    { return h.program.GetCurrentDirectory() }
+func (h *pluginEmitHost) CommonSourceDirectory() string  { return h.program.CommonSourceDirectory() }
 func (h *pluginEmitHost) IsEmitBlocked(file string) bool { return h.program.IsEmitBlocked(file) }
 func (h *pluginEmitHost) WriteFile(fileName string, text string) error {
   return h.program.Host().FS().WriteFile(fileName, text)
@@ -92,6 +92,39 @@ func (p *Program) EmitLinkedTransforms(writeFile shimcompiler.WriteFile) ([]Diag
   return p.EmitWithPluginTransformers(transforms, writeFile)
 }
 
+// restoreOriginalDeclarationSymbols copies the binder symbol from each original
+// parse-tree node onto the synthetic node a plugin transform recreated in its
+// place. A plugin that rewrites a node nested inside a class/interface/enum (for
+// example a decorator call on a controller method) forces the visitor to rebuild
+// every ancestor container to hold the changed child; those rebuilt containers
+// carry an `original` link (set by the emit context) but NOT the binder symbol,
+// because the emit context's update hook only records the original, it does not
+// copy `DeclarationBase.Symbol`.
+//
+// tsgo's emit resolver then walks the transformed tree in
+// MarkLinkedReferencesRecursively and, when it resolves an identifier whose
+// scope chain passes through one of those rebuilt containers, calls
+// getSymbolOfDeclaration(container) — which reads container.Symbol() and nil-
+// panics on a rebuilt class/interface/enum. Restoring the symbol from the
+// original (the symbol object is shared and node-independent for lookup) lets
+// the resolver mark references the same way it would on the parse tree.
+func restoreOriginalDeclarationSymbols(ec *shimprinter.EmitContext, node *shimast.Node) {
+  if node == nil {
+    return
+  }
+  if data := node.DeclarationData(); data != nil && data.Symbol == nil {
+    if original := ec.MostOriginal(node); original != nil {
+      if originalData := original.DeclarationData(); originalData != nil {
+        data.Symbol = originalData.Symbol
+      }
+    }
+  }
+  node.ForEachChild(func(child *shimast.Node) bool {
+    restoreOriginalDeclarationSymbols(ec, child)
+    return false
+  })
+}
+
 // EmitWithPluginTransformers emits every source file by assembling tsgo's emit
 // pipeline from shim parts and running the plugin transformers FIRST (in order)
 // in the same EmitContext as the builtin chain (type-erase, import-elision,
@@ -116,6 +149,7 @@ func (p *Program) EmitWithPluginTransformers(transforms []PluginTransform, write
       }
     }
     shimast.SetParentInChildrenUnset(out.AsNode())
+    restoreOriginalDeclarationSymbols(ec, out.AsNode())
     for _, tr := range shimcompiler.GetScriptTransformers(ec, host, out) {
       out = tr.TransformSourceFile(out)
     }


### PR DESCRIPTION
## Problem

The AST-integration emit path (`EmitWithPluginTransformers`, the replacement for the old text-splice path) runs plugin transformers in the same `EmitContext` as tsgo's builtin chain. When a plugin rewrites a node **nested inside a declaration container** (a class, interface, or enum), the emit visitor must rebuild every ancestor container so it can hold the changed child.

Those rebuilt containers carry an `original` link (set by `EmitContext.onUpdate` → `SetOriginal`) but **not** the binder symbol: `onUpdate` only records the original node, it never copies `DeclarationBase.Symbol`. tsgo's emit resolver later walks the transformed tree in `MarkLinkedReferencesRecursively`, and when it resolves an identifier whose scope chain passes through one of those rebuilt containers it calls `getSymbolOfDeclaration(container)` — which reads `container.Symbol()` and **nil-panics** on the rebuilt class/interface/enum.

## Why nestia requires this

This is not hypothetical — it is nestia's core code path, and nestia reports it as a hard requirement.

nestia's transformers (`@nestia/core`, `@nestia/sdk`) rewrite the **decorator calls on controller methods** — `@TypedRoute.Get`, `@TypedBody`, `@TypedQuery`, etc. — to inject the generated validation/serialization and SDK glue. A controller method is, by definition, nested inside the controller **class**:

```ts
@Controller("users")
class UsersController {
  @TypedRoute.Get(":id")          // <- plugin rewrites this decorator call
  async at(@TypedParam("id") id: string): Promise<IUser> { ... }
}
```

Rewriting that decorator call forces the visitor to rebuild the method, and then the enclosing `UsersController` class container, to hold it. The rebuilt class loses its binder symbol, and the moment the emit resolver resolves any identifier whose scope passes through that class, it nil-panics. Because every nestia controller follows exactly this shape, nestia cannot emit at all through the plugin path without this fix — hence "무조건 필요".

## Fix

After the plugin pass (and after `SetParentInChildrenUnset`), walk the emitted tree and, for every declaration node missing its symbol, restore it from the most-original parse-tree node. The symbol object is shared and node-independent for lookup, so the resolver then marks references exactly as it would on the parse tree.

`MostOriginal` (not single-step `Original`) is used deliberately: when multiple registered plugins rebuild the same container in sequence, the `original` chain is more than one hop deep, and only walking it to the parse-tree node lands on the node that actually carries the symbol.

## Test plan

- `go build ./driver/` — passes.
- Full Go suite (`node scripts/test-go-lint.cjs`) — green.
- nestia controller emit through the AST-integration plugin path no longer nil-panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)