### PR TITLE
ci(test): clone `nestia`'s next branch

### DIFF
--- a/.codex/skills/benchmark/SKILL.md
+++ b/.codex/skills/benchmark/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: benchmark
+description: Benchmark runner, fixture repos, and publication. Read before running, modifying, or publishing benchmark results.
+---
+
 # Benchmark
 
 ## What it measures

--- a/.codex/skills/development/SKILL.md
+++ b/.codex/skills/development/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: development
+description: Work rules, testing, validation, and change integrity. Read before writing or modifying code.
+---
+
 # Development
 
 ## Forbidden

--- a/.codex/skills/documentation/SKILL.md
+++ b/.codex/skills/documentation/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: documentation
+description: READMEs and website guides. Read before writing or modifying docs.
+---
+
 # Documentation
 
 ## READMEs

--- a/.codex/skills/multi-agent/SKILL.md
+++ b/.codex/skills/multi-agent/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: multi-agent
+description: Review Cycle, Discussion, and Research Review Round workflows. Read the Briefing subagents rule before delegating to any subagent; read in full when the user asks for a named mode.
+---
+
 # Multi-Agent Workflows
 
 Use only when the user explicitly asks for one of the named modes, Review Cycle, Discussion, or Research Review Round. Each mode composes the shared building blocks below; do not invent unnamed combinations.

--- a/.codex/skills/project/SKILL.md
+++ b/.codex/skills/project/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: project
+description: What ttsc is, the workspace layout, and the canonical commands.
+---
+
 # Project Outline
 
 ## Product Contract

--- a/.codex/skills/pull-request/SKILL.md
+++ b/.codex/skills/pull-request/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: pull-request
+description: Pull request submission flow. Read only when the user explicitly asks for a pull request.
+---
+
 # Pull Request Submission
 
 Only act on this skill when the user explicitly asks for a pull request. Never open, propose, or push a new PR on your own initiative, not as a "helpful" follow-up to a finished change, not because the work looks done. (This bounds PR creation only; it does not change how you commit to a branch.) When the user does ask, follow this flow.

--- a/.codex/skills/typescript-go-sync/SKILL.md
+++ b/.codex/skills/typescript-go-sync/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: typescript-go-sync
+description: Keeping packages/ttsc/shim/* synced with typescript-go and complete for plugin authors. Read before adding a re-export, bumping the pinned typescript-go version, or chasing a missing AST/transform/printer/emit API a plugin needs.
+---
+
 # TypeScript-Go Shim Sync
 
 ## Why the shim exists

--- a/.github/workflows/nestia.yml
+++ b/.github/workflows/nestia.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Clone nestia
         run: |
           rm -rf experimental/nestia
-          git clone --depth=1 --branch master https://github.com/samchon/nestia experimental/nestia
+          git clone --depth=1 --branch next https://github.com/samchon/nestia experimental/nestia
 
       - name: Use local ttsc tarballs
         working-directory: experimental/nestia

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Update only for repository-contract changes: a new skill area, a renamed or merg
 
 ### Skills
 
-- **Location.** `.codex/skills/<kebab-name>/SKILL.md`. No numeric prefix, no frontmatter: Claude Code only auto-discovers `.claude/skills/` and Codex has no native skills system, so SKILL.md is plain markdown.
+- **Location.** `.codex/skills/<kebab-name>/SKILL.md`. No numeric prefix. Each file opens with YAML frontmatter (`name` matching the kebab directory, `description` as a one-line pointer); the body is plain markdown below it.
 - **AGENTS.md pointer.** Each skill gets a `### Title` entry under `## Skills` in AGENTS.md with a one-paragraph pointer to the SKILL.md path.
 - **Create or merge.** Add a new skill when a substantial repository concern would otherwise inflate AGENTS.md beyond an index. Merge sibling concerns into one multi-section skill when they share most of their structure (`multi-agent/` is the precedent).
 - **Headings are plain.** No chapter numbers in skill or AGENTS.md headings. Use descriptive titles.

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -362,8 +362,10 @@ function emitOrphanAsCommonJs(filename: string): string | null {
   }
 }
 
-/** Cache root for lowered orphan sources, shared per run (and across runs when
- * `TTSC_CACHE_DIR` points at a persisted directory). */
+/**
+ * Cache root for lowered orphan sources, shared per run (and across runs when
+ * `TTSC_CACHE_DIR` points at a persisted directory).
+ */
 function orphanCacheRoot(): string {
   const base =
     process.env.TTSC_CACHE_DIR && process.env.TTSC_CACHE_DIR.length !== 0
@@ -372,9 +374,11 @@ function orphanCacheRoot(): string {
   return path.join(base, "ttsx-orphan-cjs");
 }
 
-/** Content-addressed cache path for one orphan file's CommonJS lowering, keyed
- * by source bytes and the tsgo binary so a tsgo bump invalidates it. `null` when
- * the source cannot be read. */
+/**
+ * Content-addressed cache path for one orphan file's CommonJS lowering, keyed
+ * by source bytes and the tsgo binary so a tsgo bump invalidates it. `null`
+ * when the source cannot be read.
+ */
 function orphanCacheFile(filename: string, tsgo: string): string | null {
   let source: Buffer;
   try {
@@ -392,9 +396,11 @@ function orphanCacheFile(filename: string, tsgo: string): string | null {
   return path.join(orphanCacheRoot(), `${key}.js`);
 }
 
-/** Write the lowered source to its cache path atomically (temp + rename), so a
+/**
+ * Write the lowered source to its cache path atomically (temp + rename), so a
  * concurrent reader never sees a half-written file. Best-effort: a failure just
- * means the next process re-lowers. */
+ * means the next process re-lowers.
+ */
 function writeOrphanCache(cacheFile: string, lowered: string): void {
   try {
     fs.mkdirSync(path.dirname(cacheFile), { recursive: true });

--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -240,15 +240,15 @@ function compileSourcePlugin(opts: {
  *
  * The lock is an atomic `mkdir` on `<cacheDir>.lock`. The winner builds and
  * publishes the binary; every loser polls for that binary to appear and reuses
- * it. A loser that waits past `PLUGIN_BUILD_LOCK_STEAL_MS` (the builder
- * crashed without publishing) steals the abandoned lock and retries. This is
- * the same shape as `withBuildLock` in the runtime hooks, keyed on the plugin
- * binary's existence instead of a JSON meta marker.
+ * it. A loser that waits past `PLUGIN_BUILD_LOCK_STEAL_MS` (the builder crashed
+ * without publishing) steals the abandoned lock and retries. This is the same
+ * shape as `withBuildLock` in the runtime hooks, keyed on the plugin binary's
+ * existence instead of a JSON meta marker.
  *
  * Correctness still rests on `publishBuiltBinary`'s atomic rename: the lock is
- * an optimisation to avoid duplicate work, not the only guard against a
- * corrupt binary, so a stolen lock that races a slow builder cannot ship a
- * half-written file.
+ * an optimisation to avoid duplicate work, not the only guard against a corrupt
+ * binary, so a stolen lock that races a slow builder cannot ship a half-written
+ * file.
  */
 function buildUnderPluginLock(
   cacheDir: string,
@@ -274,7 +274,10 @@ function buildUnderPluginLock(
         // unlocked build — correctness is preserved by the atomic publish.
         return build();
       }
-      const waited = waitForPluginBinary(binaryPath, PLUGIN_BUILD_LOCK_STEAL_MS);
+      const waited = waitForPluginBinary(
+        binaryPath,
+        PLUGIN_BUILD_LOCK_STEAL_MS,
+      );
       if (waited) {
         touchCacheEntry(cacheDir);
         return binaryPath;

--- a/packages/ttsc/test/driver/emit_plugin_mixed_factory_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_mixed_factory_test.go
@@ -30,7 +30,9 @@ func TestEmitWithPluginTransformerMixedFactory(t *testing.T) {
   writeProjectFile(t, root, "dep.ts", "export const foo = (x: number): number => x;\n")
   writeProjectFile(t, root, "index.ts", "export const a = 0;\n")
   prog, _, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
-  if err != nil { t.Fatal(err) }
+  if err != nil {
+    t.Fatal(err)
+  }
   defer prog.Close()
 
   // typia 글로벌 factory 대역 (ec와 무관한 독립 factory)
@@ -44,12 +46,14 @@ func TestEmitWithPluginTransformerMixedFactory(t *testing.T) {
 
     var visitor *shimast.NodeVisitor
     visit := func(node *shimast.Node) *shimast.Node {
-      if node == nil { return node }
+      if node == nil {
+        return node
+      }
       if node.Kind == shimast.KindNumericLiteral && node.Text() == "0" {
         // 검증 트리: 바깥 노드는 indep, namespace 참조만 ec.Factory
-        ref := ec.Factory.NewGeneratedNameForNode(modSpec)              // <-- emit ec
+        ref := ec.Factory.NewGeneratedNameForNode(modSpec)                                                       // <-- emit ec
         access := indep.NewPropertyAccessExpression(ref, nil, indep.NewIdentifier("foo"), shimast.NodeFlagsNone) // <-- indep
-        arg := indep.NewNumericLiteral("123", 0)                        // <-- indep
+        arg := indep.NewNumericLiteral("123", 0)                                                                 // <-- indep
         return indep.NewCallExpression(access, nil, nil, indep.NewNodeList([]*shimast.Node{arg}), shimast.NodeFlagsNone)
       }
       if node.Kind == shimast.KindSourceFile {
@@ -67,11 +71,15 @@ func TestEmitWithPluginTransformerMixedFactory(t *testing.T) {
   if _, err := prog.EmitWithPluginTransformer(transform, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
     emitted[filepath.Base(fileName)] = text
     return nil
-  }); err != nil { t.Fatal(err) }
+  }); err != nil {
+    t.Fatal(err)
+  }
   js := emitted["index.js"]
   t.Logf("index.js:\n%s", js)
   bind := regexp.MustCompile(`const (\w+) = [^\n]*require\("\./dep"\)`).FindStringSubmatch(js)
-  if bind == nil { t.Fatalf("no require binding:\n%s", js) }
+  if bind == nil {
+    t.Fatalf("no require binding:\n%s", js)
+  }
   if !strings.Contains(js, "exports.a = "+bind[1]+".foo(123);") {
     t.Fatalf("mixed-factory ref not aliased to %q:\n%s", bind[1], js)
   }

--- a/packages/ttsc/test/driver/emit_plugin_namespace_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_namespace_test.go
@@ -1,11 +1,15 @@
 package driver_test
+
 import (
-  "path/filepath"; "strings"; "testing"
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
   shimprinter "github.com/microsoft/typescript-go/shim/printer"
   "github.com/samchon/ttsc/packages/ttsc/driver"
+  "path/filepath"
+  "strings"
+  "testing"
 )
+
 // TestEmitWithPluginTransformerNamespace guards against a regression where a
 // top-level `export namespace` was dropped from emit when the plugin rebuilt the
 // SourceFile (sibling statements rewritten): SetParentInChildren overwrote the
@@ -19,14 +23,23 @@ func TestEmitWithPluginTransformerNamespace(t *testing.T) {
   transform := func(ec *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
     var v *shimast.NodeVisitor
     visit := func(n *shimast.Node) *shimast.Node {
-      if n != nil && n.Kind == shimast.KindNumericLiteral && n.Text() == "0" { return ec.Factory.NewNumericLiteral("1", 0) }
+      if n != nil && n.Kind == shimast.KindNumericLiteral && n.Text() == "0" {
+        return ec.Factory.NewNumericLiteral("1", 0)
+      }
       return v.VisitEachChild(n)
     }
     v = ec.NewNodeVisitor(visit)
     return v.VisitSourceFile(sf)
   }
   emitted := map[string]string{}
-  prog.EmitWithPluginTransformer(transform, func(fn, text string, _ *shimcompiler.WriteFileData) error { emitted[filepath.Base(fn)] = text; return nil })
+  prog.EmitWithPluginTransformer(transform, func(fn, text string, _ *shimcompiler.WriteFileData) error {
+    emitted[filepath.Base(fn)] = text
+    return nil
+  })
   js := emitted["index.js"]
-  if strings.Contains(js, "exports.Foo = Foo = {}") { t.Logf("OK namespace emitted") } else { t.Errorf("BROKEN namespace:\n%s", js) }
+  if strings.Contains(js, "exports.Foo = Foo = {}") {
+    t.Logf("OK namespace emitted")
+  } else {
+    t.Errorf("BROKEN namespace:\n%s", js)
+  }
 }

--- a/packages/ttsc/test/driver/emit_plugin_type_only_syntax_fully_erased_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_type_only_syntax_fully_erased_test.go
@@ -23,9 +23,9 @@ func TestEmitWithPluginTransformerTypeOnlySyntaxFullyErased(t *testing.T) {
   root := t.TempDir()
   writeProjectFile(t, root, "tsconfig.json", `{"compilerOptions":{"module":"commonjs","target":"es2020","outDir":"bin","strict":true},"files":["index.ts"]}`)
   writeProjectFile(t, root, "index.ts", strings.Join([]string{
-    "type Greeting<T extends string> = `hello ${T}`;",                       // template literal type
-    "type IsString<T> = T extends string ? true : false;",                   // conditional type
-    "type Flags<T> = { [K in keyof T]: boolean };",                          // mapped type
+    "type Greeting<T extends string> = `hello ${T}`;",     // template literal type
+    "type IsString<T> = T extends string ? true : false;", // conditional type
+    "type Flags<T> = { [K in keyof T]: boolean };",        // mapped type
     "interface Shape { readonly id: number; readonly label: Greeting<\"x\">; }",
     "export type Probe = IsString<Flags<Shape>>;",
     "export const runtime: number = 0;",
@@ -73,16 +73,16 @@ func TestEmitWithPluginTransformerTypeOnlySyntaxFullyErased(t *testing.T) {
 
   // Tokens that exist ONLY inside the type-level syntax. None may survive.
   leaks := map[string]string{
-    "Greeting":        "template-literal type alias name leaked",
-    "IsString":        "conditional type alias name leaked",
-    "Flags":           "mapped type alias name leaked",
-    "Shape":           "interface name leaked",
-    "Probe":           "exported type alias name leaked",
-    "hello ${":        "template literal type body leaked",
-    "extends":         "conditional/generic constraint syntax leaked",
-    "keyof":           "mapped type `keyof` leaked",
-    "interface":       "interface declaration leaked",
-    "readonly":        "interface readonly modifier leaked",
+    "Greeting":  "template-literal type alias name leaked",
+    "IsString":  "conditional type alias name leaked",
+    "Flags":     "mapped type alias name leaked",
+    "Shape":     "interface name leaked",
+    "Probe":     "exported type alias name leaked",
+    "hello ${":  "template literal type body leaked",
+    "extends":   "conditional/generic constraint syntax leaked",
+    "keyof":     "mapped type `keyof` leaked",
+    "interface": "interface declaration leaked",
+    "readonly":  "interface readonly modifier leaked",
   }
   for token, msg := range leaks {
     if strings.Contains(js, token) {

--- a/packages/ttsc/test/driver/prototype_assembled_alias_test.go
+++ b/packages/ttsc/test/driver/prototype_assembled_alias_test.go
@@ -28,8 +28,8 @@ func (h *assembledEmitHost) SourceFiles() []*shimast.SourceFile { return h.progr
 func (h *assembledEmitHost) UseCaseSensitiveFileNames() bool {
   return h.program.UseCaseSensitiveFileNames()
 }
-func (h *assembledEmitHost) GetCurrentDirectory() string   { return h.program.GetCurrentDirectory() }
-func (h *assembledEmitHost) CommonSourceDirectory() string { return h.program.CommonSourceDirectory() }
+func (h *assembledEmitHost) GetCurrentDirectory() string    { return h.program.GetCurrentDirectory() }
+func (h *assembledEmitHost) CommonSourceDirectory() string  { return h.program.CommonSourceDirectory() }
 func (h *assembledEmitHost) IsEmitBlocked(file string) bool { return h.program.IsEmitBlocked(file) }
 func (h *assembledEmitHost) WriteFile(fileName string, text string) error {
   return h.program.Host().FS().WriteFile(fileName, text)

--- a/packages/ttsc/test/utility/transform_subcommand_emits_relative_keyed_envelope_test.go
+++ b/packages/ttsc/test/utility/transform_subcommand_emits_relative_keyed_envelope_test.go
@@ -21,11 +21,11 @@ import (
 //
 // Layout:
 //
-//   root/ext.ts          (outside cwd -> absolute slash key)
-//   root/proj/           (== cwd)
-//   root/proj/tsconfig.json  files: ["a.ts","b.ts","../ext.ts"]
-//   root/proj/a.ts
-//   root/proj/b.ts
+//  root/ext.ts          (outside cwd -> absolute slash key)
+//  root/proj/           (== cwd)
+//  root/proj/tsconfig.json  files: ["a.ts","b.ts","../ext.ts"]
+//  root/proj/a.ts
+//  root/proj/b.ts
 //
 // No linked plugin is needed: the transform subcommand prints the project text
 // regardless, and that is exactly the path that must not collapse to empty.

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_builds_a_raw_ts_dependency_that_type_stripping_cannot_elide.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_builds_a_raw_ts_dependency_that_type_stripping_cannot_elide.ts
@@ -9,9 +9,9 @@ import assert from "node:assert/strict";
  * name (`Brand`) where the namespace holds only types, then import that name as
  * a value-shaped binding used solely in type positions. A full tsgo build
  * resolves the type and elides the import entirely; Node's isolated
- * type-stripping cannot, so the ESM named import would dangle
- * (`does not provide an export named 'Brand'`) at link time. ttsx must therefore
- * find the dependency's own `tsconfig.json` and build it.
+ * type-stripping cannot, so the ESM named import would dangle (`does not
+ * provide an export named 'Brand'`) at link time. ttsx must therefore find the
+ * dependency's own `tsconfig.json` and build it.
  *
  * 1. Install an ESM `built-dep` that ships its own `tsconfig.json` and a
  *    `type`+`namespace` merge imported for its type only.

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dirname_points_at_the_source_directory_not_the_outdir.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dirname_points_at_the_source_directory_not_the_outdir.ts
@@ -5,15 +5,15 @@ import assert from "node:assert/strict";
  * Verifies ttsx runs the entry from source, so `__dirname` is the source
  * directory rather than the configured `outDir`.
  *
- * ttsx is a ts-node-style runner: it type-checks and builds the project, then
+ * Ttsx is a ts-node-style runner: it type-checks and builds the project, then
  * executes the entry _at its source path_ with the build served under that URL.
  * A file that exists only in the source tree (never emitted) must therefore be
  * readable relative to `__dirname`. This pins the run-from-source contract that
  * lets `DynamicExecutor`-style harnesses discover sibling `.ts` files by
  * `__dirname`.
  *
- * 1. Create a CommonJS project with `outDir: "dist"` and a `marker.txt` that
- *    lives only under `src/`.
+ * 1. Create a CommonJS project with `outDir: "dist"` and a `marker.txt` that lives
+ *    only under `src/`.
  * 2. Run ttsx against the entry, which reads `__dirname + "/marker.txt"`.
  * 3. Assert the source-only file was found and printed.
  */

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_forks_a_child_whose_entry_path_is_javascript.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_forks_a_child_whose_entry_path_is_javascript.ts
@@ -8,11 +8,11 @@ import assert from "node:assert/strict";
  * Libraries like `tgrid` (used by `@nestia/benchmark`) fork a servant via
  * `child_process.fork(__dirname + "/servant.js")` — a `.js` path. Under
  * run-from-source `__dirname` is the source tree, which ships only the `.ts`,
- * so the child's main module would die with `Cannot find module servant.js`.
- * A tgrid master then waits on the dead child's handshake forever (the
- * benchmark CI job hung until the 60-minute timeout). The resolve hook must map
- * the absolute `.js` main entry — which reaches the hook with no `parentURL` —
- * to its `.ts` source.
+ * so the child's main module would die with `Cannot find module servant.js`. A
+ * tgrid master then waits on the dead child's handshake forever (the benchmark
+ * CI job hung until the 60-minute timeout). The resolve hook must map the
+ * absolute `.js` main entry — which reaches the hook with no `parentURL` — to
+ * its `.ts` source.
  *
  * 1. Create a project whose entry forks `node child.js`, but only `child.ts`
  *    exists on disk.

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_preserves_enum_runtime_object_in_a_built_dependency.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_preserves_enum_runtime_object_in_a_built_dependency.ts
@@ -2,20 +2,20 @@ import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 
 /**
- * Verifies ttsx preserves an `enum`'s *runtime object* when it builds a raw
- * `.ts` source-distribution dependency under that dependency's own tsconfig (the
- * path-2 `runBuild` route).
+ * Verifies ttsx preserves an `enum`'s _runtime object_ when it builds a raw
+ * `.ts` source-distribution dependency under that dependency's own tsconfig
+ * (the path-2 `runBuild` route).
  *
  * The existing enum coverage exercises the published-ESM-under-node_modules
  * transpile path (`load`-hook `transform` mode). This case is the general build
  * path: a package that ships its own `tsconfig.json` and re-exports an `enum`
- * used both as a *type* and as a runtime value (reverse mapping + member access).
- * A full tsgo build must emit the enum IIFE so both directions work at runtime;
- * if ttsx merely type-stripped the dependency, the enum object would be gone and
- * the member access / reverse mapping would be `undefined`.
+ * used both as a _type_ and as a runtime value (reverse mapping + member
+ * access). A full tsgo build must emit the enum IIFE so both directions work at
+ * runtime; if ttsx merely type-stripped the dependency, the enum object would
+ * be gone and the member access / reverse mapping would be `undefined`.
  *
- * 1. Install an ESM `enum-dep` that ships its own `tsconfig.json` and re-exports
- *    a numeric `enum`.
+ * 1. Install an ESM `enum-dep` that ships its own `tsconfig.json` and re-exports a
+ *    numeric `enum`.
  * 2. Run ttsx against an entry that reads an enum member and its reverse mapping.
  * 3. Assert the dependency executed and produced the enum runtime values.
  */

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_preserves_runtime_namespace_value_export_in_a_built_dependency.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_preserves_runtime_namespace_value_export_in_a_built_dependency.ts
@@ -2,19 +2,19 @@ import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 
 /**
- * Verifies ttsx preserves the *runtime values* a namespace exports when it
+ * Verifies ttsx preserves the _runtime values_ a namespace exports when it
  * builds a raw `.ts` source-distribution dependency under that dependency's own
  * tsconfig (the path-2 `runBuild` route).
  *
  * The existing type-strip-cannot-elide test only covers a namespace that holds
- * *types* (so the whole import elides). This case is the complement: a package
+ * _types_ (so the whole import elides). This case is the complement: a package
  * ships a `type` + `namespace` merge under one name (`ArrayRepeatedNullable`)
- * where the namespace carries real *runtime* members (a function and a const),
+ * where the namespace carries real _runtime_ members (a function and a const),
  * imported as a value and actually called at runtime. A full tsgo build must
  * emit the namespace IIFE (`(function (NS) { ... })(NS || ...)`) so the members
  * exist at link time; if ttsx type-stripped the dependency instead of building
- * it, the namespace value export would vanish and the call would throw
- * `is not a function` / `undefined`.
+ * it, the namespace value export would vanish and the call would throw `is not
+ * a function` / `undefined`.
  *
  * 1. Install an ESM `built-dep` that ships its own `tsconfig.json` and a
  *    `type`+`namespace` merge whose namespace exports runtime members.

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_source_file_the_entry_generates_at_runtime.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_a_source_file_the_entry_generates_at_runtime.ts
@@ -17,8 +17,8 @@ import assert from "node:assert/strict";
  * "module"`) and written with ECMAScript module syntax, so a plain type-strip
  * would leave its `export` dangling; the lowering must turn it into CommonJS.
  *
- * 1. The entry writes `src/generated/leaf.ts` (an `export const`) at runtime,
- *    then `require`s it.
+ * 1. The entry writes `src/generated/leaf.ts` (an `export const`) at runtime, then
+ *    `require`s it.
  * 2. Run ttsx against the entry.
  * 3. Assert the generated module loaded and produced its value.
  */


### PR DESCRIPTION
## Intent

Run the ttsc nestia workflow against nestia's `next` branch instead of `master`.

## Scope

- Change `.github/workflows/nestia.yml` to clone `samchon/nestia` with `--branch next`.
- Add YAML frontmatter metadata to repository skills and update `AGENTS.md` to document that contract.
- Include repository formatter output from `pnpm format`.

## Deferred Items

None.

## Test Plan

- `pnpm format` with Git for Windows `usr/bin` on `PATH` so the `xargs`-based Go formatter step runs on Windows.