### PR TITLE
feat(unplugin): Turbopack support via a standalone loader entrypoint

### DIFF
--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -118,6 +118,28 @@ const nextConfig = {
 export default withTtsc(nextConfig);
 ```
 
+`withTtsc` covers Next.js builds that go through webpack. When Next.js runs on Turbopack (`next dev --turbopack`), wire the Turbopack loader rules below instead.
+
+### Turbopack
+
+Turbopack has no JS plugin API, but it runs webpack loaders through `turbopack.rules` — and a ttsc transform is exactly loader-shaped (TypeScript source in, transformed source out). `@ttsc/unplugin/turbopack` is that standalone loader:
+
+```js
+// next.config.mjs
+/** @type {import("next").NextConfig} */
+const nextConfig = {
+  turbopack: {
+    rules: {
+      "*.ts": { loaders: ["@ttsc/unplugin/turbopack"] },
+      "*.tsx": { loaders: ["@ttsc/unplugin/turbopack"] },
+    },
+  },
+};
+export default nextConfig;
+```
+
+Pass options through the rule's `options` object: `{ loader: "@ttsc/unplugin/turbopack", options: { project: "tsconfig.build.json" } }`. The loader keeps a per-worker compiler cache (Turbopack runs loaders in a worker pool) and returns the source unchanged for declaration files, `node_modules` paths, and transforms that produce no change.
+
 ### Farm
 
 ```ts
@@ -253,11 +275,12 @@ Supported entrypoints are:
 - `@ttsc/unplugin/rolldown`
 - `@ttsc/unplugin/webpack`
 - `@ttsc/unplugin/rspack`
+- `@ttsc/unplugin/turbopack`
 - `@ttsc/unplugin/farm`
 - `@ttsc/unplugin/next`
 - `@ttsc/unplugin/bun`
 
-Each entrypoint supports ESM import and CJS require. In CommonJS configs, read the default export from `require("@ttsc/unplugin/vite").default`.
+Each entrypoint supports ESM import and CJS require. In CommonJS configs, read the default export from `require("@ttsc/unplugin/vite").default`. `@ttsc/unplugin/turbopack` is not an unplugin factory but a standalone webpack loader — reference it by module name inside `turbopack.rules` instead of calling it.
 
 ### Options
 

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -51,6 +51,11 @@
       "import": "./lib/rspack.mjs",
       "default": "./lib/rspack.js"
     },
+    "./turbopack": {
+      "types": "./lib/turbopack.d.ts",
+      "import": "./lib/turbopack.mjs",
+      "default": "./lib/turbopack.js"
+    },
     "./vite": {
       "types": "./lib/vite.d.ts",
       "import": "./lib/vite.mjs",

--- a/packages/unplugin/src/turbopack.ts
+++ b/packages/unplugin/src/turbopack.ts
@@ -1,0 +1,84 @@
+import type { TtscUnpluginOptions } from "./core/options";
+import { resolveOptions } from "./core/options";
+import {
+  createTtscTransformCache,
+  isDeclarationFile,
+  stripQuery,
+  transformTtsc,
+} from "./core/transform";
+
+/**
+ * Subset of the webpack loader context Turbopack provides to loaders wired
+ * through `turbopack.rules`. Turbopack has no JS plugin API, but it runs
+ * webpack-compatible loaders: source string in, source string out, with
+ * `async()` for asynchronous completion and `getOptions()` for the rule's
+ * `options` object.
+ */
+export interface TtscTurbopackLoaderContext {
+  /** Marks the loader asynchronous and returns the completion callback. */
+  async(): (error?: unknown, content?: string) => void;
+  /** Absolute path of the module being loaded. */
+  resourcePath: string;
+  /** The rule's `options` object, when one was configured. */
+  getOptions?(): TtscUnpluginOptions | undefined;
+}
+
+/** Matches any path segment that is a `node_modules` directory (cross-platform). */
+const nodeModulesPattern = /(?:^|[/\\])node_modules(?:[/\\]|$)/;
+
+/**
+ * Per-process transform cache. Turbopack runs loaders in a worker pool and
+ * never signals build boundaries to a loader, so the cache lives for the
+ * worker's lifetime; entries self-invalidate by re-hashing the project's input
+ * files on every request (see `transformTtsc`), which is the same freshness
+ * rule the bundler-plugin adapters rely on between watch rebuilds.
+ */
+const transformCache = createTtscTransformCache();
+
+/**
+ * Standalone webpack-loader entrypoint for Turbopack.
+ *
+ * Turbopack cannot load unplugin-based plugins (no JS plugin API), but its
+ * `turbopack.rules` accept webpack loaders, and a ttsc transform is exactly
+ * loader-shaped: pure TypeScript source in, transformed source out. Wire it per
+ * extension:
+ *
+ * ```js
+ * // next.config.mjs
+ * const nextConfig = {
+ *   turbopack: {
+ *     rules: {
+ *       "*.ts": { loaders: ["@ttsc/unplugin/turbopack"] },
+ *       "*.tsx": { loaders: ["@ttsc/unplugin/turbopack"] },
+ *     },
+ *   },
+ * };
+ * ```
+ *
+ * Pass {@link TtscUnpluginOptions} through the rule's `options` object. The
+ * loader returns the source unchanged for declaration files, `node_modules`
+ * paths, and transforms that produce no change — mirroring the unplugin
+ * adapters' `transformInclude` filter, since a broad rule glob routes
+ * everything matching the extension through the loader.
+ */
+export default function turbopack(
+  this: TtscTurbopackLoaderContext,
+  source: string,
+): void {
+  const callback = this.async();
+  const file = stripQuery(this.resourcePath);
+  if (isDeclarationFile(file) || nodeModulesPattern.test(file)) {
+    callback(undefined, source);
+    return;
+  }
+  transformTtsc(
+    file,
+    source,
+    resolveOptions(this.getOptions?.() ?? {}),
+    undefined,
+    transformCache,
+  ).then(
+    (result) => callback(undefined, result?.code ?? source),
+    (error) => callback(error),
+  );
+}

--- a/tests/test-unplugin/src/features/adapters/test_turbopack_loader_forwards_rule_options_to_the_transform.ts
+++ b/tests/test-unplugin/src/features/adapters/test_turbopack_loader_forwards_rule_options_to_the_transform.ts
@@ -1,0 +1,21 @@
+import { assertTurbopackLoaderForwardsRuleOptions } from "../../internal/adapter-turbopack";
+
+/**
+ * Verifies the turbopack loader forwards the rule's `options` object to the
+ * ttsc transform.
+ *
+ * Turbopack rules pass options as `{ loader, options }`; the loader reads them
+ * via `this.getOptions()` and they must reach `resolveOptions` like any
+ * adapter's constructor options would. Locks the plugin-list override path: if
+ * options were dropped, the loader would silently fall back to tsconfig
+ * discovery and per-rule configuration would be dead.
+ *
+ * 1. Create a fixture project with no tsconfig plugins.
+ * 2. Invoke the loader with `options.plugins` running the fixture's `go-prefix`
+ *    operation.
+ * 3. Assert the prefixed output — only reachable through the options object.
+ */
+export const test_turbopack_loader_forwards_rule_options_to_the_transform =
+  async () => {
+    await assertTurbopackLoaderForwardsRuleOptions();
+  };

--- a/tests/test-unplugin/src/features/adapters/test_turbopack_loader_passes_through_declarations_and_node_modules.ts
+++ b/tests/test-unplugin/src/features/adapters/test_turbopack_loader_passes_through_declarations_and_node_modules.ts
@@ -1,0 +1,20 @@
+import { assertTurbopackLoaderPassesThroughFilteredPaths } from "../../internal/adapter-turbopack";
+
+/**
+ * Verifies the turbopack loader passes declaration files and `node_modules`
+ * paths through unchanged.
+ *
+ * The negative twin of the transform test: unplugin adapters filter these via
+ * `transformInclude`, but a Turbopack rule glob (`*.ts`) routes every match
+ * through the loader, so the loader carries the guard itself. Without it,
+ * `.d.ts` files would be fed to the project transform and vendored sources
+ * would trigger full project compiles.
+ *
+ * 1. Invoke the loader on a `.d.ts` resource path.
+ * 2. Invoke it on a path under `node_modules`.
+ * 3. Assert both return the input source byte-for-byte.
+ */
+export const test_turbopack_loader_passes_through_declarations_and_node_modules =
+  async () => {
+    await assertTurbopackLoaderPassesThroughFilteredPaths();
+  };

--- a/tests/test-unplugin/src/features/adapters/test_turbopack_loader_transforms_source_through_the_webpack_loader_contract.ts
+++ b/tests/test-unplugin/src/features/adapters/test_turbopack_loader_transforms_source_through_the_webpack_loader_contract.ts
@@ -1,0 +1,21 @@
+import { assertTurbopackLoaderTransformsSource } from "../../internal/adapter-turbopack";
+
+/**
+ * Verifies the turbopack loader entrypoint transforms TypeScript source through
+ * the webpack loader contract.
+ *
+ * Implements samchon/ttsc#215: Turbopack has no JS plugin API, so unplugin
+ * adapters cannot reach it — but `turbopack.rules` runs webpack loaders, and a
+ * ttsc transform is loader-shaped. This pins the exact invocation surface
+ * Turbopack uses (`this.async()` + `this.resourcePath`, source string in/out)
+ * against the built `@ttsc/unplugin/turbopack` entrypoint, with plugins
+ * discovered from the project's own tsconfig.
+ *
+ * 1. Create the fixture project whose tsconfig declares the Go plugin.
+ * 2. Invoke the built loader with a minimal webpack loader context.
+ * 3. Assert the callback receives the plugin-transformed source.
+ */
+export const test_turbopack_loader_transforms_source_through_the_webpack_loader_contract =
+  async () => {
+    await assertTurbopackLoaderTransformsSource();
+  };

--- a/tests/test-unplugin/src/internal/adapter-entrypoints.ts
+++ b/tests/test-unplugin/src/internal/adapter-entrypoints.ts
@@ -55,6 +55,7 @@ async function assertAdapterEntrypointsSupportEsmDefaultImport() {
     "rolldown",
     "rollup",
     "rspack",
+    "turbopack",
     "vite",
     "webpack",
   ]) {
@@ -82,6 +83,7 @@ function assertAdapterEntrypointsSupportCjsRequire() {
     "rolldown",
     "rollup",
     "rspack",
+    "turbopack",
     "vite",
     "webpack",
   ]) {

--- a/tests/test-unplugin/src/internal/adapter-turbopack.ts
+++ b/tests/test-unplugin/src/internal/adapter-turbopack.ts
@@ -1,0 +1,92 @@
+import { TestUnpluginProject, TestUnpluginRuntime } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+/**
+ * Invoke the built turbopack loader entrypoint with a minimal fake of the
+ * webpack loader context Turbopack provides (`async()`, `resourcePath`,
+ * `getOptions()`), returning the content the loader hands to the callback.
+ */
+async function runTurbopackLoader(props: {
+  resourcePath: string;
+  source: string;
+  options?: unknown;
+}): Promise<string> {
+  const loader = await TestUnpluginRuntime.loadUnpluginAdapter("turbopack");
+  return new Promise<string>((resolve, reject) => {
+    const context = {
+      resourcePath: props.resourcePath,
+      getOptions: () => props.options,
+      async:
+        () =>
+        (error?: unknown, content?: string): void => {
+          if (error !== undefined && error !== null) {
+            reject(error instanceof Error ? error : new Error(String(error)));
+            return;
+          }
+          resolve(content ?? "");
+        },
+    };
+    loader.call(context, props.source);
+  });
+}
+
+/**
+ * Asserts the loader transforms TypeScript source through the webpack loader
+ * contract using the project's own tsconfig-declared plugins — the exact way
+ * Turbopack invokes loaders registered in `turbopack.rules`.
+ */
+async function assertTurbopackLoaderTransformsSource(): Promise<void> {
+  const root = TestUnpluginProject.createProject();
+  const output = await runTurbopackLoader({
+    resourcePath: TestUnpluginProject.mainFile(root),
+    source: TestUnpluginProject.mainSource(root),
+  });
+  TestUnpluginProject.assertTransformedToPlugin(output);
+}
+
+/**
+ * Asserts the rule's `options` object reaches the transform: a plugin list
+ * passed through loader options must override the tsconfig-declared plugins,
+ * here proven by the fixture's `go-prefix` operation reshaping the output.
+ */
+async function assertTurbopackLoaderForwardsRuleOptions(): Promise<void> {
+  const root = TestUnpluginProject.createProject({ plugins: [] });
+  const output = await runTurbopackLoader({
+    resourcePath: TestUnpluginProject.mainFile(root),
+    source: TestUnpluginProject.mainSource(root),
+    options: {
+      plugins: [{ transform: "./plugin.cjs", name: "prefix", prefix: "A:" }],
+    },
+  });
+  assert.match(output, /"A:plugin"/);
+}
+
+/**
+ * Asserts the loader's own filter: declaration files and `node_modules` paths
+ * pass through byte-for-byte. A broad `*.ts` rule glob routes everything with
+ * the extension through the loader, so the loader must mirror the unplugin
+ * adapters' `transformInclude` guard itself.
+ */
+async function assertTurbopackLoaderPassesThroughFilteredPaths(): Promise<void> {
+  const root = TestUnpluginProject.createProject();
+  const declaration = "declare const ambient: number;\n";
+  const declarationOut = await runTurbopackLoader({
+    resourcePath: path.join(root, "src", "ambient.d.ts"),
+    source: declaration,
+  });
+  assert.equal(declarationOut, declaration);
+
+  const vendored = 'export const value: string = goUpper("plugin");\n';
+  const vendoredOut = await runTurbopackLoader({
+    resourcePath: path.join(root, "node_modules", "pkg", "main.ts"),
+    source: vendored,
+  });
+  assert.equal(vendoredOut, vendored);
+}
+
+export {
+  assertTurbopackLoaderForwardsRuleOptions,
+  assertTurbopackLoaderPassesThroughFilteredPaths,
+  assertTurbopackLoaderTransformsSource,
+};

--- a/website/src/content/docs/ttsc/bundler.mdx
+++ b/website/src/content/docs/ttsc/bundler.mdx
@@ -77,6 +77,26 @@ export default withTtsc({
 });
 ```
 
+`withTtsc` covers the webpack path. On Turbopack (`next dev --turbopack`), use the loader rules below instead.
+
+## Turbopack
+
+Turbopack has no JS plugin API, but it runs webpack loaders through `turbopack.rules`, and a ttsc transform is loader-shaped: TypeScript source in, transformed source out. Reference the standalone loader by module name (do not call it):
+
+```js
+// next.config.mjs
+export default {
+  turbopack: {
+    rules: {
+      "*.ts": { loaders: ["@ttsc/unplugin/turbopack"] },
+      "*.tsx": { loaders: ["@ttsc/unplugin/turbopack"] },
+    },
+  },
+};
+```
+
+Options go through the rule's `options` object (`{ loader: "@ttsc/unplugin/turbopack", options: { project: "tsconfig.build.json" } }`).
+
 ## Farm
 
 ```ts


### PR DESCRIPTION
## Intent

Implement #215: a standalone webpack-loader entrypoint so projects on Turbopack (which has no JS plugin API and therefore cannot load unplugin adapters) can run ttsc plugins — typia included — through the bundler.

Closes #215.

## How

Turbopack's `turbopack.rules` runs webpack loaders: source string in/out, `this.async()`, `this.getOptions()`. A ttsc transform is exactly that shape, so `@ttsc/unplugin/turbopack` exports the loader directly:

```js
// next.config.mjs
export default {
  turbopack: {
    rules: {
      "*.ts": { loaders: ["@ttsc/unplugin/turbopack"] },
      "*.tsx": { loaders: ["@ttsc/unplugin/turbopack"] },
    },
  },
};
```

- **Options** flow through the rule's `options` object into `resolveOptions`, same surface as every adapter (`project`, `compilerOptions`, `plugins`).
- **Caching**: per-worker module-level transform cache (Turbopack pools loader workers and signals no build boundaries). Entries self-invalidate by re-hashing project inputs per request — the same freshness rule the plugin adapters rely on between watch rebuilds, so no new invalidation mechanism.
- **Filtering**: the loader passes declaration files and `node_modules` paths through unchanged. Adapters get this from `transformInclude`, but a broad `*.ts` rule glob routes everything through the loader, so it carries the guard itself.

## Tests

- `test_turbopack_loader_transforms_source_through_the_webpack_loader_contract` — the exact Turbopack invocation surface against the built entrypoint, plugins discovered from tsconfig.
- `test_turbopack_loader_forwards_rule_options_to_the_transform` — rule `options` reach the transform (plugin-list override proven via output reshaping).
- `test_turbopack_loader_passes_through_declarations_and_node_modules` — negative twin for the loader-level filter.
- Entrypoint contract tests (`ESM default import` / `CJS require`) now include `turbopack`.

All green locally on Windows by direct invocation (DynamicExecutor cannot start on Windows — pre-existing; CI runs the suites on Linux).

## Deferred

- Automatic rule injection from `@ttsc/unplugin/next` when Next.js runs `--turbopack`: a webpack hook cannot write `turbopack.rules`, so this needs a config-wrapper design of its own (the issue listed it as optional). Documented setup covers it manually; README and the bundler guide carry the new section.
- A real `next dev --turbopack` e2e is not run in CI; the loader contract test pins the invocation surface Turbopack documents for loaders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
