### PR TITLE
Fix BOM-prefixed tsconfig parsing

### DIFF
--- a/packages/ttsc/src/compiler/internal/project/readProjectConfig.ts
+++ b/packages/ttsc/src/compiler/internal/project/readProjectConfig.ts
@@ -299,7 +299,11 @@ function isRelativeSpecifier(specifier: string): boolean {
  * commas before handing off to `JSON.parse`.
  */
 function parseJsonc(input: string): unknown {
-  return JSON.parse(stripTrailingCommas(stripComments(input)));
+  return JSON.parse(stripTrailingCommas(stripComments(stripLeadingBom(input))));
+}
+
+function stripLeadingBom(input: string): string {
+  return input.charCodeAt(0) === 0xfeff ? input.slice(1) : input;
 }
 
 /**

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_accepts_utf8_bom_at_tsconfig_start.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_accepts_utf8_bom_at_tsconfig_start.ts
@@ -1,0 +1,40 @@
+import { TestProject } from "@ttsc/testing";
+
+import { assert, fs, path, readProjectConfig } from "../../internal/project";
+
+/**
+ * Verifies readProjectConfig accepts a UTF-8 BOM at the start of tsconfig.
+ *
+ * TypeScript accepts UTF-8 BOM-prefixed config files. `readProjectConfig` must
+ * do the same before applying its JSONC comment/trailing-comma parser so ttsc
+ * does not reject projects that the native compiler accepts.
+ *
+ * 1. Write a BOM-prefixed `tsconfig.json` that also uses JSONC syntax.
+ * 2. Invoke `readProjectConfig`.
+ * 3. Assert the compiler options parse normally.
+ */
+export const test_readprojectconfig_accepts_utf8_bom_at_tsconfig_start = () => {
+  const root = TestProject.tmpdir("ttsc-project-");
+  fs.writeFileSync(
+    path.join(root, "tsconfig.json"),
+    `\uFEFF{
+      // BOM-prefixed JSONC should parse like TypeScript's config reader.
+      "compilerOptions": {
+        "baseUrl": ".",
+        "plugins": [
+          { "transform": "./plugins/bom.cjs" },
+        ],
+      },
+    }\n`,
+    "utf8",
+  );
+
+  const parsed = readProjectConfig({
+    tsconfig: path.join(root, "tsconfig.json"),
+  });
+
+  assert.equal(parsed.compilerOptions.baseUrl, root);
+  assert.deepEqual(parsed.compilerOptions.plugins, [
+    { transform: "./plugins/bom.cjs" },
+  ]);
+};

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_accepts_utf8_bom_in_extended_tsconfig.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_accepts_utf8_bom_in_extended_tsconfig.ts
@@ -1,0 +1,43 @@
+import { TestProject } from "@ttsc/testing";
+
+import { assert, fs, path, readProjectConfig } from "../../internal/project";
+
+/**
+ * Verifies readProjectConfig accepts a UTF-8 BOM in an extended tsconfig.
+ *
+ * The parser is used for every file in an `extends` chain, not just the entry
+ * tsconfig. A shared config saved with a BOM must therefore resolve inherited
+ * compiler options without making each child project fail during config load.
+ *
+ * 1. Write a BOM-prefixed shared config that declares `rootDir`.
+ * 2. Write a child config that extends it.
+ * 3. Assert the inherited path option resolves from the shared config.
+ */
+export const test_readprojectconfig_accepts_utf8_bom_in_extended_tsconfig =
+  () => {
+    const root = TestProject.tmpdir("ttsc-project-");
+    const shared = path.join(root, "shared");
+    const project = path.join(root, "project");
+    fs.mkdirSync(shared, { recursive: true });
+    fs.mkdirSync(project, { recursive: true });
+    fs.writeFileSync(
+      path.join(shared, "tsconfig.json"),
+      `\uFEFF{
+        "compilerOptions": {
+          "rootDir": "../src",
+        },
+      }\n`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(project, "tsconfig.json"),
+      JSON.stringify({ extends: "../shared/tsconfig.json" }, null, 2),
+      "utf8",
+    );
+
+    const parsed = readProjectConfig({
+      tsconfig: path.join(project, "tsconfig.json"),
+    });
+
+    assert.equal(parsed.compilerOptions.rootDir, path.join(root, "src"));
+  };

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_rejects_utf8_bom_after_leading_whitespace.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_rejects_utf8_bom_after_leading_whitespace.ts
@@ -1,0 +1,29 @@
+import { TestProject } from "@ttsc/testing";
+
+import { assert, fs, path, readProjectConfig } from "../../internal/project";
+
+/**
+ * Verifies readProjectConfig only strips a BOM at the start of the file.
+ *
+ * A UTF-8 BOM is valid as the first decoded code point. Stripping it from any
+ * later position would hide malformed config content, so this negative twin
+ * keeps invalid whitespace-before-BOM input rejected.
+ *
+ * 1. Write a `tsconfig.json` whose BOM appears after a leading space.
+ * 2. Invoke `readProjectConfig`.
+ * 3. Assert the config still throws a JSON parse error.
+ */
+export const test_readprojectconfig_rejects_utf8_bom_after_leading_whitespace =
+  () => {
+    const root = TestProject.tmpdir("ttsc-project-");
+    fs.writeFileSync(
+      path.join(root, "tsconfig.json"),
+      ` \uFEFF${JSON.stringify({ compilerOptions: { strict: true } })}`,
+      "utf8",
+    );
+
+    assert.throws(
+      () => readProjectConfig({ tsconfig: path.join(root, "tsconfig.json") }),
+      /Unexpected token/,
+    );
+  };


### PR DESCRIPTION
## Summary

- Strip a leading UTF-8 BOM before `readProjectConfig` parses JSONC tsconfig content.
- Cover BOM-prefixed entry tsconfigs, BOM-prefixed extended tsconfigs, and the invalid whitespace-before-BOM boundary.

## Verification

- Reproduced the pre-fix failure with a BOM-prefixed `tsconfig.json` throwing `Unexpected token` from `readProjectConfig`.
- `pnpm format`
- `$env:PATH='C:\Program Files\Git\usr\bin;' + $env:PATH; pnpm --dir packages/ttsc build`
- Direct scratch runner for the three new `readProjectConfig` BOM tests.
- Direct scratch runner for existing JSONC and circular-extends project-config tests.
- Adversarial scratch check that malformed BOM-prefixed JSON is still rejected.

## Deferred

- Unplugin BOM e2e can be added after this core fix is merged and the related unplugin PR queue is rebased.

Closes #216