### PR TITLE
Fix ttsx symlinked directory mirroring on Windows

### DIFF
--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -220,8 +220,24 @@ function linkVirtualEntry(
     }
     return;
   }
+  if (
+    process.platform === "win32" &&
+    entry.isSymbolicLink() &&
+    isDirectorySymlinkTarget(realEntry)
+  ) {
+    fs.symlinkSync(realEntry, virtualEntry, "junction");
+    return;
+  }
   // Symlinks (and other special entries) are re-symlinked as-is.
   fs.symlinkSync(realEntry, virtualEntry);
+}
+
+function isDirectorySymlinkTarget(realEntry: string): boolean {
+  try {
+    return fs.statSync(realEntry).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_virtual_layout_junctions_symlinked_directory_entries_on_windows.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_virtual_layout_junctions_symlinked_directory_entries_on_windows.ts
@@ -1,0 +1,51 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Verifies ttsx mirrors symlinked directory entries without Windows symlink
+ * privileges.
+ *
+ * `prepareExecution` mirrors project-root entries into a virtual filesystem
+ * layout after build. On Windows, a directory entry that is itself a symlink
+ * needs to be mirrored as a junction; otherwise `fs.symlinkSync` defaults to a
+ * privileged directory symlink and fails with EPERM.
+ *
+ * 1. Create a CJS ttsx project whose `node_modules` entry is a junction.
+ * 2. Run ttsx against the entry.
+ * 3. Assert the virtual-layout mirror completes and the entry executes.
+ */
+export const test_ttsx_virtual_layout_junctions_symlinked_directory_entries_on_windows =
+  () => {
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "src/main.ts": `const message: string = "junction-ok";\nconsole.log(message);\n`,
+    });
+    const linkedModules = TestProject.tmpdir("ttsx-linked-node-modules-");
+    const nodeModules = path.join(root, "node_modules");
+    fs.symlinkSync(
+      linkedModules,
+      nodeModules,
+      process.platform === "win32" ? "junction" : undefined,
+    );
+    assert.equal(fs.lstatSync(nodeModules).isSymbolicLink(), true);
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "junction-ok");
+  };


### PR DESCRIPTION
## Summary

- Mirror symlinked directory entries as junctions on Windows when `ttsx` builds its virtual project layout.
- Keep existing file, plain directory, non-Windows symlink, and non-directory special-entry behavior unchanged.
- Add a ttsx runtime regression that creates a symlinked `node_modules` entry and asserts the entry executes.

## Verification

- Reproduced the pre-fix Windows failure with a minimal `fs.symlinkSync(link, mirror)` directory-symlink fallthrough returning `EPERM`.
- `pnpm format`
- `$env:PATH='C:\Program Files\Git\usr\bin;' + $env:PATH; pnpm --dir packages/ttsc build`
- Direct scratch runner for `test_ttsx_virtual_layout_junctions_symlinked_directory_entries_on_windows`.
- Direct scratch runner for existing `test_ttsx_runs_a_commonjs_typescript_entry_through_ttsc` and `test_ttsx_resolves_extensionless_imports_in_a_symlinked_workspace_raw_ts_dependency`.
- Self-review completed in three passes: staged diff read, contract/consistency, adversarial review.

Closes #218