### PR TITLE
Document ttsc platform package contents

### DIFF
--- a/packages/ttsc-darwin-arm64/README.md
+++ b/packages/ttsc-darwin-arm64/README.md
@@ -5,3 +5,20 @@ macOS arm64 native binaries and bundled Go compiler package for `ttsc`.
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
 It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+
+## Package contents
+
+This package intentionally ships the prebuilt `darwin-arm64` artifacts for `ttsc`:
+
+- `bin/ttsc`: the native command helper.
+- `bin/ttscserver`: the native language-server wrapper.
+- `bin/go/`: a pruned Go SDK used to compile source plugins into cached plugin binaries.
+
+Source and build entrypoint: [`packages/ttsc`](https://github.com/samchon/ttsc/tree/master/packages/ttsc) and [`scripts/build-platform-package.cjs`](https://github.com/samchon/ttsc/blob/master/scripts/build-platform-package.cjs).
+
+There is no `postinstall` download step. Supply-chain scanners may report the native executables or bundled Go SDK as opaque or obfuscated because they are not readable JavaScript source. Review the npm package metadata when triaging that finding:
+
+```bash
+npm view "@ttsc/darwin-arm64@<version>" dist.integrity dist.signatures dist.attestations --json
+npm pack "@ttsc/darwin-arm64@<version>" --dry-run --json
+```

--- a/packages/ttsc-darwin-x64/README.md
+++ b/packages/ttsc-darwin-x64/README.md
@@ -5,3 +5,20 @@ macOS x64 native binaries and bundled Go compiler package for `ttsc`.
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
 It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+
+## Package contents
+
+This package intentionally ships the prebuilt `darwin-x64` artifacts for `ttsc`:
+
+- `bin/ttsc`: the native command helper.
+- `bin/ttscserver`: the native language-server wrapper.
+- `bin/go/`: a pruned Go SDK used to compile source plugins into cached plugin binaries.
+
+Source and build entrypoint: [`packages/ttsc`](https://github.com/samchon/ttsc/tree/master/packages/ttsc) and [`scripts/build-platform-package.cjs`](https://github.com/samchon/ttsc/blob/master/scripts/build-platform-package.cjs).
+
+There is no `postinstall` download step. Supply-chain scanners may report the native executables or bundled Go SDK as opaque or obfuscated because they are not readable JavaScript source. Review the npm package metadata when triaging that finding:
+
+```bash
+npm view "@ttsc/darwin-x64@<version>" dist.integrity dist.signatures dist.attestations --json
+npm pack "@ttsc/darwin-x64@<version>" --dry-run --json
+```

--- a/packages/ttsc-linux-arm/README.md
+++ b/packages/ttsc-linux-arm/README.md
@@ -5,3 +5,20 @@ Linux arm native binaries and bundled Go compiler package for `ttsc`.
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
 It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+
+## Package contents
+
+This package intentionally ships the prebuilt `linux-arm` artifacts for `ttsc`:
+
+- `bin/ttsc`: the native command helper.
+- `bin/ttscserver`: the native language-server wrapper.
+- `bin/go/`: a pruned Go SDK used to compile source plugins into cached plugin binaries.
+
+Source and build entrypoint: [`packages/ttsc`](https://github.com/samchon/ttsc/tree/master/packages/ttsc) and [`scripts/build-platform-package.cjs`](https://github.com/samchon/ttsc/blob/master/scripts/build-platform-package.cjs).
+
+There is no `postinstall` download step. Supply-chain scanners may report the native executables or bundled Go SDK as opaque or obfuscated because they are not readable JavaScript source. Review the npm package metadata when triaging that finding:
+
+```bash
+npm view "@ttsc/linux-arm@<version>" dist.integrity dist.signatures dist.attestations --json
+npm pack "@ttsc/linux-arm@<version>" --dry-run --json
+```

--- a/packages/ttsc-linux-arm64/README.md
+++ b/packages/ttsc-linux-arm64/README.md
@@ -5,3 +5,20 @@ Linux arm64 native binaries and bundled Go compiler package for `ttsc`.
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
 It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+
+## Package contents
+
+This package intentionally ships the prebuilt `linux-arm64` artifacts for `ttsc`:
+
+- `bin/ttsc`: the native command helper.
+- `bin/ttscserver`: the native language-server wrapper.
+- `bin/go/`: a pruned Go SDK used to compile source plugins into cached plugin binaries.
+
+Source and build entrypoint: [`packages/ttsc`](https://github.com/samchon/ttsc/tree/master/packages/ttsc) and [`scripts/build-platform-package.cjs`](https://github.com/samchon/ttsc/blob/master/scripts/build-platform-package.cjs).
+
+There is no `postinstall` download step. Supply-chain scanners may report the native executables or bundled Go SDK as opaque or obfuscated because they are not readable JavaScript source. Review the npm package metadata when triaging that finding:
+
+```bash
+npm view "@ttsc/linux-arm64@<version>" dist.integrity dist.signatures dist.attestations --json
+npm pack "@ttsc/linux-arm64@<version>" --dry-run --json
+```

--- a/packages/ttsc-linux-x64/README.md
+++ b/packages/ttsc-linux-x64/README.md
@@ -5,3 +5,20 @@ Linux x64 native binaries and bundled Go compiler package for `ttsc`.
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
 It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+
+## Package contents
+
+This package intentionally ships the prebuilt `linux-x64` artifacts for `ttsc`:
+
+- `bin/ttsc`: the native command helper.
+- `bin/ttscserver`: the native language-server wrapper.
+- `bin/go/`: a pruned Go SDK used to compile source plugins into cached plugin binaries.
+
+Source and build entrypoint: [`packages/ttsc`](https://github.com/samchon/ttsc/tree/master/packages/ttsc) and [`scripts/build-platform-package.cjs`](https://github.com/samchon/ttsc/blob/master/scripts/build-platform-package.cjs).
+
+There is no `postinstall` download step. Supply-chain scanners may report the native executables or bundled Go SDK as opaque or obfuscated because they are not readable JavaScript source. Review the npm package metadata when triaging that finding:
+
+```bash
+npm view "@ttsc/linux-x64@<version>" dist.integrity dist.signatures dist.attestations --json
+npm pack "@ttsc/linux-x64@<version>" --dry-run --json
+```

--- a/packages/ttsc-win32-arm64/README.md
+++ b/packages/ttsc-win32-arm64/README.md
@@ -5,3 +5,20 @@ Windows arm64 native binaries and bundled Go compiler package for `ttsc`.
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
 It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+
+## Package contents
+
+This package intentionally ships the prebuilt `win32-arm64` artifacts for `ttsc`:
+
+- `bin/ttsc.exe`: the native command helper.
+- `bin/ttscserver.exe`: the native language-server wrapper.
+- `bin/go/`: a pruned Go SDK used to compile source plugins into cached plugin binaries.
+
+Source and build entrypoint: [`packages/ttsc`](https://github.com/samchon/ttsc/tree/master/packages/ttsc) and [`scripts/build-platform-package.cjs`](https://github.com/samchon/ttsc/blob/master/scripts/build-platform-package.cjs).
+
+There is no `postinstall` download step. Supply-chain scanners may report the native executables or bundled Go SDK as opaque or obfuscated because they are not readable JavaScript source. Review the npm package metadata when triaging that finding:
+
+```bash
+npm view "@ttsc/win32-arm64@<version>" dist.integrity dist.signatures dist.attestations --json
+npm pack "@ttsc/win32-arm64@<version>" --dry-run --json
+```

--- a/packages/ttsc-win32-x64/README.md
+++ b/packages/ttsc-win32-x64/README.md
@@ -5,3 +5,20 @@ Windows x64 native binaries and bundled Go compiler package for `ttsc`.
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
 It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
+
+## Package contents
+
+This package intentionally ships the prebuilt `win32-x64` artifacts for `ttsc`:
+
+- `bin/ttsc.exe`: the native command helper.
+- `bin/ttscserver.exe`: the native language-server wrapper.
+- `bin/go/`: a pruned Go SDK used to compile source plugins into cached plugin binaries.
+
+Source and build entrypoint: [`packages/ttsc`](https://github.com/samchon/ttsc/tree/master/packages/ttsc) and [`scripts/build-platform-package.cjs`](https://github.com/samchon/ttsc/blob/master/scripts/build-platform-package.cjs).
+
+There is no `postinstall` download step. Supply-chain scanners may report the native executables or bundled Go SDK as opaque or obfuscated because they are not readable JavaScript source. Review the npm package metadata when triaging that finding:
+
+```bash
+npm view "@ttsc/win32-x64@<version>" dist.integrity dist.signatures dist.attestations --json
+npm pack "@ttsc/win32-x64@<version>" --dry-run --json
+```


### PR DESCRIPTION
## Scope

- Document the intentional contents of each `@ttsc/*` platform package README.
- Note the native helpers, bundled Go SDK, source/build entrypoints, no postinstall download, and npm metadata checks for scanner triage.

## Notes

README-only change; no code tests run.