### PR TITLE
feat(ttsc): expose context.dirname/filename for ESM-safe plugin self-location

### DIFF
--- a/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
+++ b/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
@@ -570,7 +570,7 @@ function orderNativePlugins(
 
 function loadPluginEntry(
   entry: ITtscProjectPluginConfig,
-  context: ITtscPluginFactoryContext,
+  context: Omit<ITtscPluginFactoryContext, "dirname" | "filename">,
   baseDir: string,
 ): ITtscPlugin {
   return withPluginLoaderEnv(() => {
@@ -582,7 +582,15 @@ function loadPluginEntry(
     }
 
     const request = resolvePluginRequest(specifier, baseDir);
-    const mod = requirePluginEntry(request, context) as {
+    // The descriptor loads through ttsx (`.ts` source) or as ESM (`.mjs`), where
+    // the ambient `__dirname`/`__filename`/`require` are undefined. Hand the
+    // resolved entry's dir/file to the factory so it can self-locate regardless.
+    const factoryContext: ITtscPluginFactoryContext = {
+      ...context,
+      dirname: path.dirname(request),
+      filename: request,
+    };
+    const mod = requirePluginEntry(request, factoryContext) as {
       createTtscPlugin?: TtscPluginFactory;
       default?: ITtscPlugin | TtscPluginFactory;
     } & Partial<Record<"plugin", ITtscPlugin | TtscPluginFactory>>;
@@ -592,7 +600,7 @@ function loadPluginEntry(
       mod.plugin ??
       (mod as unknown as ITtscPlugin | TtscPluginFactory);
     if (typeof candidate === "function") {
-      const plugin = candidate(context);
+      const plugin = candidate(factoryContext);
       if (!isTtscPlugin(plugin)) {
         throw new Error(
           `ttsc: plugin "${specifier}" does not export a valid ttsc plugin`,
@@ -702,6 +710,8 @@ function loadDescriptorViaTtsx(
         TTSC_PLUGIN_CONTEXT: JSON.stringify({
           binary: context.binary,
           cwd: context.cwd,
+          dirname: context.dirname,
+          filename: context.filename,
           plugin: context.plugin,
           projectRoot: context.projectRoot,
           tsconfig: context.tsconfig,

--- a/packages/ttsc/src/structures/ITtscPluginFactoryContext.ts
+++ b/packages/ttsc/src/structures/ITtscPluginFactoryContext.ts
@@ -33,6 +33,28 @@ export interface ITtscPluginFactoryContext<T = ITtscProjectPluginConfig> {
   cwd: string;
 
   /**
+   * Absolute path to the directory holding the resolved descriptor module.
+   *
+   * The ESM-safe analog of `__dirname`, mirroring Node's `import.meta.dirname`.
+   * Use it to locate the plugin's own package without ambient CommonJS globals:
+   * ttsc loads a `.ts`-source descriptor through `ttsx`, and may load a `.mjs`
+   * descriptor as ESM, where the ambient `__dirname`/`__filename`/`require` are
+   * all undefined. Anchor package-relative paths here, e.g.
+   * `path.resolve(context.dirname, "go-plugin")`.
+   */
+  dirname: string;
+
+  /**
+   * Absolute path to the resolved descriptor module file.
+   *
+   * The ESM-safe analog of `__filename`, mirroring Node's
+   * `import.meta.filename` — the file `compilerOptions.plugins[].transform` (or
+   * a package `ttsc` export condition) pointed at. Most descriptors only need
+   * {@link ITtscPluginFactoryContext.dirname}; this is provided for parity.
+   */
+  filename: string;
+
+  /**
    * Original `compilerOptions.plugins[]` entry that loaded this plugin.
    *
    * Ttsc reserves `transform` and `enabled`. Every other property is

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_descriptor_factory_self_locates_via_context_dirname.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_descriptor_factory_self_locates_via_context_dirname.ts
@@ -1,0 +1,66 @@
+import {
+  assert,
+  copyDirectory,
+  fs,
+  goPath,
+  path,
+  pluginProject,
+  spawn,
+  ttscBin,
+  workspaceRoot,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: a factory descriptor self-locates via
+ * `context.dirname` when loaded through ttsx.
+ *
+ * Pins the regression in #248: a `.ts`-source descriptor is evaluated through
+ * ttsx's `import()` shim, where the ambient `__dirname`/`__filename`/`require`
+ * are all undefined, so a descriptor that resolved its own package through them
+ * silently mis-resolved `source` and the build failed. The factory context now
+ * carries `dirname` (the ESM-safe analog of `__dirname`); this descriptor uses
+ * only that field, so it would throw before the fix and resolves after.
+ *
+ * 1. Write a `.ts` descriptor whose `source` is derived purely from
+ *    `context.dirname`, touching no CommonJS global.
+ * 2. Run ttsc with `--emit` against the fixture project.
+ * 3. Assert zero exit and `"PLUGIN"` present in the emitted JS.
+ */
+export const test_plugin_corpus_descriptor_factory_self_locates_via_context_dirname =
+  () => {
+    const root = pluginProject(
+      [{ transform: "./plugins/locate.ts", name: "locate-export" }],
+      {
+        "plugins/locate.ts": `
+        import path from "node:path";
+
+        export function createTtscPlugin(context: any) {
+          return {
+            name: context.plugin.name,
+            source: path.resolve(
+              context.dirname,
+              "..",
+              "go-plugin",
+              "cmd",
+              "ttsc-go-transformer"
+            ),
+          };
+        }
+      `,
+      },
+    );
+    copyDirectory(
+      path.join(workspaceRoot, "tests", "go-transformer"),
+      path.join(root, "go-plugin"),
+    );
+
+    const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+      cwd: root,
+      env: { PATH: goPath() },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+      fs.readFileSync(path.join(root, "dist", "main.js"), "utf8"),
+      /"PLUGIN"/,
+    );
+  };

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_descriptor_factory_self_locates_via_context_filename.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_descriptor_factory_self_locates_via_context_filename.ts
@@ -1,0 +1,64 @@
+import {
+  assert,
+  copyDirectory,
+  fs,
+  goPath,
+  path,
+  pluginProject,
+  spawn,
+  ttscBin,
+  workspaceRoot,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: a factory descriptor self-locates via
+ * `context.filename` on the direct `require` load path.
+ *
+ * Complements the ttsx-path coverage in
+ * `test_plugin_corpus_descriptor_factory_self_locates_via_context_dirname`: a
+ * compiled `.cjs` descriptor loads through ttsc's direct `require()` (no ttsx),
+ * the other branch that must populate the self-location fields. This pins that
+ * `context.filename` is the resolved entry path there too, so #248's fix holds
+ * for both load paths and both fields.
+ *
+ * 1. Write a `.cjs` descriptor whose `source` is derived from
+ *    `path.dirname(context.filename)` rather than the ambient `__dirname`.
+ * 2. Run ttsc with `--emit` against the fixture project.
+ * 3. Assert zero exit and `"PLUGIN"` present in the emitted JS.
+ */
+export const test_plugin_corpus_descriptor_factory_self_locates_via_context_filename =
+  () => {
+    const root = pluginProject(
+      [{ transform: "./plugins/locate.cjs", name: "locate-export" }],
+      {
+        "plugins/locate.cjs": `
+        const path = require("node:path");
+
+        exports.createTtscPlugin = (context) => ({
+          name: context.plugin.name,
+          source: path.resolve(
+            path.dirname(context.filename),
+            "..",
+            "go-plugin",
+            "cmd",
+            "ttsc-go-transformer"
+          ),
+        });
+      `,
+      },
+    );
+    copyDirectory(
+      path.join(workspaceRoot, "tests", "go-transformer"),
+      path.join(root, "go-plugin"),
+    );
+
+    const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+      cwd: root,
+      env: { PATH: goPath() },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+      fs.readFileSync(path.join(root, "dist", "main.js"), "utf8"),
+      /"PLUGIN"/,
+    );
+  };

--- a/website/src/content/docs/development/concepts/protocol.mdx
+++ b/website/src/content/docs/development/concepts/protocol.mdx
@@ -25,7 +25,7 @@ const path = require("node:path");
 
 module.exports = (context) => ({
   name: "my-plugin",
-  source: path.resolve(__dirname, "go-plugin"),
+  source: path.resolve(context.dirname, "go-plugin"),
   stage: "transform",
 });
 ```
@@ -36,6 +36,8 @@ module.exports = (context) => ({
 {
   binary: string;
   cwd: string;
+  dirname: string;
+  filename: string;
   plugin: ITtscProjectPluginConfig;
   projectRoot: string;
   tsconfig: string;
@@ -45,6 +47,8 @@ module.exports = (context) => ({
 `context.plugin` is the original tsconfig plugin entry. If you want stronger typing, specialize the context type in your factory:
 
 `context.binary` is the absolute `ttsc` native helper selected for this invocation. It is not the plugin sidecar binary and not the JavaScript launcher. Most descriptors do not need it; it exists for advanced factories that need to inspect the active native host.
+
+`context.dirname` and `context.filename` are the ESM-safe analogs of `__dirname`/`__filename`, mirroring Node's `import.meta.dirname`/`import.meta.filename`. **Descriptors must be ESM-safe.** ttsc loads a `.ts`-source descriptor through `ttsx` (and may load a `.mjs` descriptor as ESM), where the ambient `__dirname`/`__filename`/`require` are all undefined; a descriptor that locates its own package through them silently mis-resolves. Anchor package-relative paths on `context.dirname` instead — `path.resolve(context.dirname, "go-plugin")`. To resolve sibling packages without ambient `require`, anchor a `node:module` resolver on the project: `createRequire(path.join(context.projectRoot, "package.json"))`.
 
 ```ts
 import * as path from "node:path";
@@ -60,7 +64,7 @@ export function createTtscPlugin(
 ) {
   return {
     name: "my-plugin",
-    source: path.resolve(__dirname, "go-plugin"),
+    source: path.resolve(context.dirname, "go-plugin"),
     stage: "transform",
   };
 }
@@ -92,7 +96,7 @@ interface ITtscPluginContributor {
 Field rules:
 
 - `name`: optional display label for diagnostics and build messages. Routing is not based on package identity.
-- `source`: Go package directory or `go.mod` file. A `package main` source builds as an executable sidecar. A non-`main` transform source is linked into the selected native host and must register itself through `driver.RegisterPlugin`. Relative paths are resolved from the consumer project root; package descriptors should usually return an absolute path based on `__dirname`.
+- `source`: Go package directory or `go.mod` file. A `package main` source builds as an executable sidecar. A non-`main` transform source is linked into the selected native host and must register itself through `driver.RegisterPlugin`. Relative paths are resolved from the consumer project root; package descriptors should usually return an absolute path based on `context.dirname` (the ESM-safe analog of `__dirname` — see [`context.dirname`](#manifest) above).
 - `composes`: optional list of other plugin names (or original `transform` specifiers) whose source build should be redirected to this descriptor's `source`. Composition is **one hop only**: `A.composes = ["B"]` sends B to A's binary, but if `B.composes = ["C"]` then C is sent to B's original binary, not A's. Reciprocal entries (`A.composes = ["B"]` and `B.composes = ["A"]`) are rejected as a cycle.
 - `stage`: plugin kind. Omit for `"transform"`.
 - `capabilities`: optional host behaviors a strict sidecar would otherwise reject or not understand. Set `threadingArgs` only when the sidecar accepts `--singleThreaded` and `--checkers`; set `diagnosticsTiming` only when it accepts `--diagnostics`/`--extendedDiagnostics` and may print timing detail to stdout. Set `lsp` only when the sidecar implements the `ttscserver` LSP verbs below.

--- a/website/src/content/docs/development/walkthroughs/banner.mdx
+++ b/website/src/content/docs/development/walkthroughs/banner.mdx
@@ -98,6 +98,8 @@ type TtscPluginDescriptor = {
 type TtscPluginFactoryContext<TConfig> = {
   binary: string;
   cwd: string;
+  dirname: string;
+  filename: string;
   plugin: TConfig;
   projectRoot: string;
   tsconfig: string;


### PR DESCRIPTION
## Intent

Fixes #248. A plugin **descriptor** loaded from `.ts` source runs through ttsx's `import()` shim, where the ambient `__dirname`/`__filename`/`require` are all undefined — verified empirically that even a `.cts` loses them, so it is the **loader path, not the module format**. A descriptor that self-locates through those globals silently mis-resolves its `source` and the build fails with `plugin source does not exist` (the consumer project's *parent*, from `path.dirname("")`). `typia` hits this because `typia/lib/transform` resolves to `src/transform.ts` in its monorepo.

## Scope

- **`ITtscPluginFactoryContext`** gains `dirname` and `filename` — the ESM-safe analogs of `__dirname`/`__filename`, mirroring Node's `import.meta.dirname`/`import.meta.filename`. Populated in **both** load paths (direct `require` and the ttsx shim's `TTSC_PLUGIN_CONTEXT`), so a descriptor self-locates with no ambient global in any loader.
- **Additive, non-breaking.** Existing descriptors (compiled CJS using `__dirname`, or `createRequire(projectRoot)` workarounds) are untouched.
- **Docs** — the Plugin Protocol Reference and the banner walkthrough now state descriptors must be ESM-safe and recommend `path.resolve(context.dirname, …)` over `__dirname`.

## Deferred / known items

- **`export default` via the ttsx orphan-CJS path** — when a `.ts` descriptor falls to the orphan single-file CJS lowering, the CJS→ESM interop makes `mod.default` a `{ default: fn }` wrapper, so the shim's candidate resolution grabs the object instead of the function. Pre-existing and orthogonal to this PR; named exports (`export function createTtscPlugin`) avoid it. Flagged for a separate fix.
- **`filename`** is included for Node parity; can be dropped if a minimal surface is preferred (`dirname` is the load-bearing field).

## Test plan

- New regression test `test_plugin_corpus_descriptor_factory_self_locates_via_context_dirname` — drives the **real** `ttsc` binary against a `.ts` descriptor (typia's exact ttsx path) that derives `source` purely from `context.dirname`. Verified **fail-before / pass-after** by neutralizing the field in the built lib (reproduces the `#248` mis-resolution).
- `pnpm --filter ttsc build` clean (tsc typecheck of the `Omit<…, "dirname" | "filename">` loader change).
- Full TS e2e suite runs on CI (DynamicExecutor can't start on the Windows dev box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
