### PR TITLE
fix(ttsc): name the CJS-globals pitfall when a plugin source is missing

### DIFF
--- a/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
+++ b/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
@@ -844,7 +844,19 @@ function resolveNativeSourceKind(
 
 function resolveGoPackageDir(source: string, label: string): string {
   if (!fs.existsSync(source)) {
-    throw new Error(`ttsc: plugin "${label}" source does not exist: ${source}`);
+    // A descriptor factory runs without CommonJS globals when ttsc loads it
+    // through ttsx or as ESM — `__dirname`/`__filename`/`require` are undefined,
+    // so a `source` derived from them mis-resolves (often against cwd) and lands
+    // here. Name that failure mode explicitly instead of leaving a bare
+    // not-found path: the breakage is otherwise silent. (See #248.)
+    throw new Error(
+      `ttsc: plugin "${label}" source does not exist: ${source}\n` +
+        `  Plugin descriptors run without CommonJS globals: __dirname, __filename, ` +
+        `and require are undefined when ttsc loads a descriptor through ttsx or as ESM. ` +
+        `If this path was derived from one of them, resolve it from context.projectRoot ` +
+        `instead, e.g. createRequire(path.join(context.projectRoot, "package.json"))` +
+        `.resolve("<your-package>/package.json").`,
+    );
   }
   const stat = fs.statSync(source);
   if (stat.isFile() && path.basename(source) === "go.mod") {

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_missing_source_error_names_the_cjs_globals_pitfall.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_missing_source_error_names_the_cjs_globals_pitfall.ts
@@ -1,0 +1,48 @@
+import {
+  assert,
+  goPath,
+  pluginProject,
+  spawn,
+  ttscBin,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: a missing plugin source names the CJS-globals
+ * pitfall.
+ *
+ * Pins the diagnostic added for #248. When a descriptor's `source` does not
+ * exist, the bare not-found path hid the most common cause: a descriptor loaded
+ * through ttsx or as ESM runs without `__dirname`/`__filename`/`require`, so a
+ * path derived from them silently mis-resolves. The error now spells that out
+ * and points at `context.projectRoot`, turning a baffling wrong-path failure
+ * into actionable guidance.
+ *
+ * 1. Write a descriptor returning a `source` that does not exist on disk.
+ * 2. Run ttsc with `--emit` against the fixture project.
+ * 3. Assert non-zero exit and that stderr names the CJS-globals pitfall and
+ *    `context.projectRoot`.
+ */
+export const test_plugin_corpus_missing_source_error_names_the_cjs_globals_pitfall =
+  () => {
+    const root = pluginProject(
+      [{ transform: "./plugins/missing.cjs", name: "missing" }],
+      {
+        "plugins/missing.cjs": `
+        const path = require("node:path");
+        exports.createTtscPlugin = () => ({
+          name: "missing",
+          source: path.resolve(__dirname, "definitely-not-a-go-package"),
+        });
+      `,
+      },
+    );
+
+    const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+      cwd: root,
+      env: { PATH: goPath() },
+    });
+    assert.notEqual(result.status, 0, result.stderr);
+    assert.match(result.stderr, /source does not exist/);
+    assert.match(result.stderr, /without CommonJS globals/);
+    assert.match(result.stderr, /context\.projectRoot/);
+  };

--- a/website/src/content/docs/development/concepts/protocol.mdx
+++ b/website/src/content/docs/development/concepts/protocol.mdx
@@ -46,6 +46,17 @@ module.exports = (context) => ({
 
 `context.binary` is the absolute `ttsc` native helper selected for this invocation. It is not the plugin sidecar binary and not the JavaScript launcher. Most descriptors do not need it; it exists for advanced factories that need to inspect the active native host.
 
+**Descriptors must be ESM-safe.** A descriptor compiled to CommonJS and loaded by `ttsc`'s direct `require()` keeps `__dirname`/`__filename`/`require`. But when `ttsc` loads a descriptor shipped as `.ts` source — through `ttsx` — or as ESM, those ambient globals are **undefined**, so a `source` derived from `__dirname` silently mis-resolves. To locate your own package independently of the load mode, anchor a `node:module` resolver on `context.projectRoot`, which works in both CommonJS and ESM:
+
+```ts
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const requireFrom = createRequire(path.join(context.projectRoot, "package.json"));
+const pkgRoot = path.dirname(requireFrom.resolve("my-plugin/package.json"));
+// source: path.resolve(pkgRoot, "go-plugin")
+```
+
 ```ts
 import * as path from "node:path";
 import type { ITtscPluginFactoryContext } from "ttsc";
@@ -92,7 +103,7 @@ interface ITtscPluginContributor {
 Field rules:
 
 - `name`: optional display label for diagnostics and build messages. Routing is not based on package identity.
-- `source`: Go package directory or `go.mod` file. A `package main` source builds as an executable sidecar. A non-`main` transform source is linked into the selected native host and must register itself through `driver.RegisterPlugin`. Relative paths are resolved from the consumer project root; package descriptors should usually return an absolute path based on `__dirname`.
+- `source`: Go package directory or `go.mod` file. A `package main` source builds as an executable sidecar. A non-`main` transform source is linked into the selected native host and must register itself through `driver.RegisterPlugin`. Relative paths are resolved from the consumer project root; package descriptors should usually return an absolute path. A compiled-CommonJS descriptor can base it on `__dirname`, but a `.ts`-source or ESM descriptor must resolve from `context.projectRoot` instead (see [ESM-safety](#manifest) above), since `__dirname` is undefined there.
 - `composes`: optional list of other plugin names (or original `transform` specifiers) whose source build should be redirected to this descriptor's `source`. Composition is **one hop only**: `A.composes = ["B"]` sends B to A's binary, but if `B.composes = ["C"]` then C is sent to B's original binary, not A's. Reciprocal entries (`A.composes = ["B"]` and `B.composes = ["A"]`) are rejected as a cycle.
 - `stage`: plugin kind. Omit for `"transform"`.
 - `capabilities`: optional host behaviors a strict sidecar would otherwise reject or not understand. Set `threadingArgs` only when the sidecar accepts `--singleThreaded` and `--checkers`; set `diagnosticsTiming` only when it accepts `--diagnostics`/`--extendedDiagnostics` and may print timing detail to stdout. Set `lsp` only when the sidecar implements the `ttscserver` LSP verbs below.


### PR DESCRIPTION
## Intent

Resolves the actionable part of #248 **without adding a context field.**

The original report's self-location need is already met by the existing `context.projectRoot`: `createRequire(path.join(context.projectRoot, "package.json")).resolve("<pkg>/package.json")` locates the plugin's own package in both CommonJS and ESM (this is exactly typia's working workaround). A dedicated `context.dirname`/`filename` would have been redundant (withdrawn in #250).

What #248 actually exposed and projectRoot does **not** fix is the **silent failure**: a descriptor loaded through ttsx or as ESM runs without `__dirname`/`__filename`/`require`, so a `source` derived from them mis-resolves and surfaces as a bare `plugin source does not exist: <baffling path>`.

## Scope

- **Diagnostic** — the not-found error now names the CJS-globals pitfall and points at `context.projectRoot`, turning a silent wrong-path failure into actionable guidance.
- **Docs** — the Plugin Protocol Reference now states descriptors must be ESM-safe and shows the `createRequire(context.projectRoot)` pattern; the `source` field rule notes `__dirname` only works for compiled-CommonJS descriptors.
- No new context fields, no loader changes.

## Deferred

- A deeper fix would make `loadDescriptorViaTtsx` load CJS-classified descriptors via `require()` so `__dirname` works again (even a `.cts` currently loses it through the `import()` shim). High-effort/low-payoff — the one affected ecosystem (typia) already self-locates via `context.projectRoot` — so it's left as a follow-up, not done here.

## Test plan

- New regression test `test_plugin_corpus_missing_source_error_names_the_cjs_globals_pitfall` — drives the real `ttsc` binary; a descriptor returning a non-existent `source` must exit non-zero with stderr naming the pitfall and `context.projectRoot`. Verified locally.
- `pnpm --filter ttsc build` clean. Full suite on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
