### PR TITLE
feat(metro): @ttsc/metro adapter for React Native / Expo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
           - { name: strip, run: "pnpm --filter @ttsc/test-strip start" }
           - { name: ttsc, run: "pnpm --filter @ttsc/test-ttsc start" }
           - { name: unplugin, run: "pnpm --filter @ttsc/test-unplugin start" }
+          - { name: metro, run: "pnpm --filter @ttsc/test-metro start" }
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ See the [Programmatic API guide](https://ttsc.dev/docs/ttsc/api) for the full li
 - [`@ttsc/paths`](https://github.com/samchon/ttsc/tree/master/packages/paths): rewrites source path aliases so JS and declaration emit receive relative imports.
 - [`@ttsc/strip`](https://github.com/samchon/ttsc/tree/master/packages/strip): removes configured calls and `debugger` statements.
 - [`@ttsc/unplugin`](https://github.com/samchon/ttsc/tree/master/packages/unplugin): runs `ttsc` plugins inside bundlers supported by `unplugin`.
+- [`@ttsc/metro`](https://github.com/samchon/ttsc/tree/master/packages/metro): runs `ttsc` plugins inside Metro for React Native and Expo.
 
 Plugin authors should start from the [`Guide Documents`](https://ttsc.dev/docs).
 

--- a/README.md
+++ b/README.md
@@ -49,29 +49,6 @@ Rewrite source files in place with the `@ttsc/lint` format rules:
 npx ttsc format
 ```
 
-### VS Code Extension
-
-Install the VS Code extension for live TypeScript-Go editor features plus saved-state ttsc plugin diagnostics and actions.
-
-Install it from the VS Code Marketplace by searching `ttsc`, or run:
-
-```bash
-npx @ttsc/vscode
-```
-
-Then turn on format-on-save in `.vscode/settings.json`:
-
-```jsonc
-"[typescript][typescriptreact]": {
-  "editor.defaultFormatter": "samchon.ttsc",
-  "editor.formatOnSave": true
-}
-```
-
-Lint fixes stay off-save by default; opt in with `"editor.codeActionsOnSave": { "source.fixAll.ttsc": "explicit" }`.
-
-See [`@ttsc/vscode`](https://github.com/samchon/ttsc/tree/master/packages/vscode) for requirements and settings.
-
 ### Bundlers
 
 Use `@ttsc/unplugin` when a bundler owns your build.
@@ -108,6 +85,50 @@ Supported bundlers:
 - Bun
 
 See [`@ttsc/unplugin`](https://github.com/samchon/ttsc/tree/master/packages/unplugin) for full setup and adapter options.
+
+### React Native / Expo
+
+React Native and Expo bundle with Metro, so the `ttsc` CLI and `@ttsc/unplugin` never run. `@ttsc/metro` is a Metro transformer that runs `ttsc` plugins on each TypeScript file, then hands the result to your existing Expo or React-Native Babel transformer.
+
+```bash
+npm install -D ttsc @ttsc/lint typescript@rc
+npm install -D @ttsc/metro
+```
+
+Wrap your Metro config (CommonJS, the standard for `metro.config.js`):
+
+```js
+// metro.config.js (Expo)
+const { getDefaultConfig } = require("expo/metro-config");
+const { withTtsc } = require("@ttsc/metro");
+
+module.exports = withTtsc(getDefaultConfig(__dirname));
+```
+
+For bare React Native, wrap `getDefaultConfig` from `@react-native/metro-config` instead. See [`@ttsc/metro`](https://github.com/samchon/ttsc/tree/master/packages/metro) for options and the v1 caveats.
+
+### VS Code Extension
+
+Install the VS Code extension for live TypeScript-Go editor features plus saved-state ttsc plugin diagnostics and actions.
+
+Install it from the VS Code Marketplace by searching `ttsc`, or run:
+
+```bash
+npx @ttsc/vscode
+```
+
+Then turn on format-on-save in `.vscode/settings.json`:
+
+```jsonc
+"[typescript][typescriptreact]": {
+  "editor.defaultFormatter": "samchon.ttsc",
+  "editor.formatOnSave": true
+}
+```
+
+Lint fixes stay off-save by default; opt in with `"editor.codeActionsOnSave": { "source.fixAll.ttsc": "explicit" }`.
+
+See [`@ttsc/vscode`](https://github.com/samchon/ttsc/tree/master/packages/vscode) for requirements and settings.
 
 ## Plugins
 

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -59,7 +59,7 @@ module.exports = withTtsc(getDefaultConfig(__dirname), {
 - `compilerOptions`: a temporary overlay layered on the selected project config.
 - `plugins`: an explicit `ttsc` plugin list override, or `false` to disable project plugins.
 - `upstreamTransformer`: an explicit module path for the Babel transformer to delegate to, when auto-detection is not what you want.
-- `include` / `exclude`: substring path patterns selecting which files run through the `ttsc` pass (`.ts`/`.tsx`/`.cts`/`.mts` only; declaration and JavaScript files always pass straight through).
+- `include` / `exclude`: substring patterns matched against the project-relative file path, selecting which files run through the `ttsc` pass (`.ts`/`.tsx`/`.cts`/`.mts` only; declaration and JavaScript files always pass straight through).
 
 Options are forwarded from the Metro **config** process to Metro's **worker** processes through the `TTSC_METRO_OPTIONS` environment variable, so they must stay JSON-serialisable (hence substring patterns rather than `RegExp`).
 

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -1,0 +1,91 @@
+# `@ttsc/metro`
+
+![banner of @ttsc/metro](https://ttsc.dev/og.jpg)
+
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/ttsc/blob/master/LICENSE) [![NPM Version](https://img.shields.io/npm/v/@ttsc/metro.svg)](https://www.npmjs.com/package/@ttsc/metro) [![NPM Downloads](https://img.shields.io/npm/dm/@ttsc/metro.svg)](https://www.npmjs.com/package/@ttsc/metro) [![Build Status](https://github.com/samchon/ttsc/workflows/test/badge.svg)](https://github.com/samchon/ttsc/actions?query=workflow%3Atest) [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://ttsc.dev/docs) [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)
+
+Metro (React Native / Expo) adapter for `ttsc` plugins.
+
+React Native and Expo bundle with **Metro**, which transpiles each file with Babel (`babel-preset-expo` / `@react-native/metro-babel-transformer`). Babel strips TypeScript types and never runs TypeScript transformers, so neither the `ttsc` CLI nor `@ttsc/unplugin` can reach an RN/Expo build. `@ttsc/metro` wires a Metro custom transformer that runs the `ttsc` plugin pass (typia, nestia, …) on each TypeScript file, then hands the result to your existing Expo/React-Native Babel transformer.
+
+## Setup
+
+Install `ttsc` and TypeScript-Go first. Then install the Metro adapter:
+
+```bash
+npm install -D ttsc typescript@rc
+npm install -D @ttsc/metro
+```
+
+Wrap your Metro config with `withTtsc`.
+
+### Expo
+
+```js
+// metro.config.js
+const { getDefaultConfig } = require("expo/metro-config");
+const { withTtsc } = require("@ttsc/metro");
+
+module.exports = withTtsc(getDefaultConfig(__dirname));
+```
+
+### Bare React Native
+
+```js
+// metro.config.js
+const { getDefaultConfig } = require("@react-native/metro-config");
+const { withTtsc } = require("@ttsc/metro");
+
+module.exports = withTtsc(getDefaultConfig(__dirname));
+```
+
+`withTtsc` sets `transformer.babelTransformerPath` and leaves the rest of your config untouched. It auto-detects the upstream transformer to delegate to (`@expo/metro-config/babel-transformer` for Expo, then `@react-native/metro-babel-transformer`, then the legacy `metro-react-native-babel-transformer`).
+
+## Configuration
+
+By default `@ttsc/metro` finds the nearest `tsconfig.json` from the file being transformed and runs the plugins configured there — the standard `ttsc` model. If that is the config you want, `withTtsc(getDefaultConfig(__dirname))` is enough.
+
+Options are the second argument and mirror `@ttsc/unplugin`, plus a few Metro-specific knobs:
+
+```js
+module.exports = withTtsc(getDefaultConfig(__dirname), {
+  project: "tsconfig.build.json",
+  plugins: [{ transform: "typia/lib/transform" }],
+  exclude: ["__tests__"],
+});
+```
+
+- `project`: path to the `tsconfig.json` the transformer should read (resolved from `process.cwd()`).
+- `compilerOptions`: a temporary overlay layered on the selected project config.
+- `plugins`: an explicit `ttsc` plugin list override, or `false` to disable project plugins.
+- `upstreamTransformer`: an explicit module path for the Babel transformer to delegate to, when auto-detection is not what you want.
+- `include` / `exclude`: substring path patterns selecting which files run through the `ttsc` pass (`.ts`/`.tsx`/`.cts`/`.mts` only; declaration and JavaScript files always pass straight through).
+
+Options are forwarded from the Metro **config** process to Metro's **worker** processes through the `TTSC_METRO_OPTIONS` environment variable, so they must stay JSON-serialisable (hence substring patterns rather than `RegExp`).
+
+## How it works
+
+For each TypeScript file Metro asks to transform:
+
+1. `@ttsc/metro` runs the `ttsc` plugin pass (reusing `@ttsc/unplugin`'s transform core) → transformed **TypeScript** source.
+2. The transformed source is handed to the upstream Expo/React-Native Babel transformer, which strips types, applies the RN transforms, and returns the Babel AST Metro consumes.
+
+The plugin contract, `tsconfig` discovery, and per-build cache are identical to every other `ttsc` bundler integration.
+
+## Caveats (v1)
+
+- **Cost model.** This release reuses `@ttsc/unplugin`'s transform core, which type-checks the whole `tsconfig` project and caches the result per process. Metro runs transforms in a multi-process worker pool, so the project is compiled once per worker (on that worker's first file). A resident, incremental, per-file compiler shared across workers is the planned optimization — tracked in [samchon/ttsc#255](https://github.com/samchon/ttsc/issues/255).
+- **Cache invalidation.** Metro keys its transform cache on per-file content plus a static transformer key. A `ttsc` transform can depend on a _type_ in another file; editing that type does not change the dependent file's content, so Metro may serve a stale transform. After changing `tsconfig`/plugin configuration or a depended-upon type, restart Metro with `--reset-cache`.
+- **Type errors fail the build.** The `ttsc` pass type-checks; a project type error surfaces as a Metro build error, matching the other `ttsc` bundler integrations.
+
+## Sponsors
+
+[![Sponsors](https://raw.githubusercontent.com/samchon/sponsor-images/refs/heads/master/public/circle.svg)](https://github.com/sponsors/samchon)
+
+Thanks for your support.
+
+Your [donation](https://github.com/sponsors/samchon) encourages `ttsc` development.
+
+## References
+
+Inspired by [`@elliots/metro-transformer-typical`](https://github.com/elliots/typical/tree/main/packages/metro-transformer).

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -43,7 +43,7 @@ module.exports = withTtsc(getDefaultConfig(__dirname));
 
 ## Configuration
 
-By default `@ttsc/metro` finds the nearest `tsconfig.json` from the file being transformed and runs the plugins configured there — the standard `ttsc` model. If that is the config you want, `withTtsc(getDefaultConfig(__dirname))` is enough.
+By default `@ttsc/metro` finds the nearest `tsconfig.json` from the file being transformed and runs the plugins configured there: the standard `ttsc` model. If that is the config you want, `withTtsc(getDefaultConfig(__dirname))` is enough.
 
 Options are the second argument and mirror `@ttsc/unplugin`, plus a few Metro-specific knobs:
 
@@ -74,7 +74,7 @@ The plugin contract, `tsconfig` discovery, and per-build cache are identical to 
 
 ## Caveats (v1)
 
-- **Cost model.** This release reuses `@ttsc/unplugin`'s transform core, which type-checks the whole `tsconfig` project and caches the result per process. Metro runs transforms in a multi-process worker pool, so the project is compiled once per worker (on that worker's first file). A resident, incremental, per-file compiler shared across workers is the planned optimization — tracked in [samchon/ttsc#255](https://github.com/samchon/ttsc/issues/255).
+- **Cost model.** This release reuses `@ttsc/unplugin`'s transform core, which type-checks the whole `tsconfig` project and caches the result per process. Metro runs transforms in a multi-process worker pool, so the project is compiled once per worker (on that worker's first file). A resident, incremental, per-file compiler shared across workers is the planned optimization, tracked in [samchon/ttsc#255](https://github.com/samchon/ttsc/issues/255).
 - **Cache invalidation.** Metro keys its transform cache on per-file content plus a static transformer key. A `ttsc` transform can depend on a _type_ in another file; editing that type does not change the dependent file's content, so Metro may serve a stale transform. After changing `tsconfig`/plugin configuration or a depended-upon type, restart Metro with `--reset-cache`.
 - **Type errors fail the build.** The `ttsc` pass type-checks; a project type error surfaces as a Metro build error, matching the other `ttsc` bundler integrations.
 

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -1,0 +1,84 @@
+{
+  "name": "@ttsc/metro",
+  "version": "0.16.3",
+  "description": "Metro (React Native / Expo) adapter for ttsc plugins.",
+  "main": "lib/index.js",
+  "module": "lib/index.mjs",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "default": "./lib/index.js"
+    },
+    "./transformer": {
+      "types": "./lib/transformer.d.ts",
+      "import": "./lib/transformer.mjs",
+      "default": "./lib/transformer.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "rimraf lib && tsc --emitDeclarationOnly && rollup -c"
+  },
+  "keywords": [
+    "ttsc",
+    "metro",
+    "react-native",
+    "expo",
+    "typescript",
+    "tsgo"
+  ],
+  "files": [
+    "README.md",
+    "lib",
+    "src"
+  ],
+  "dependencies": {
+    "@ttsc/unplugin": "workspace:*"
+  },
+  "peerDependencies": {
+    "@expo/metro-config": "*",
+    "@react-native/metro-babel-transformer": "*",
+    "metro-react-native-babel-transformer": "*"
+  },
+  "peerDependenciesMeta": {
+    "@expo/metro-config": {
+      "optional": true
+    },
+    "@react-native/metro-babel-transformer": {
+      "optional": true
+    },
+    "metro-react-native-babel-transformer": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^29.0.2",
+    "@rollup/plugin-node-resolve": "^16.0.3",
+    "@types/node": "catalog:utils",
+    "rimraf": "catalog:utils",
+    "rollup": "^4.60.3",
+    "rollup-plugin-auto-external": "^2.0.0",
+    "rollup-plugin-node-externals": "^9.0.1",
+    "tinyglobby": "^0.2.16",
+    "tslib": "^2.8.1",
+    "ttsc": "workspace:*",
+    "typescript": "catalog:typescript"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samchon/ttsc"
+  },
+  "author": "Jeongho Nam",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/samchon/ttsc/issues"
+  },
+  "homepage": "https://ttsc.dev",
+  "sideEffects": false,
+  "packageManager": "pnpm@10.6.4"
+}

--- a/packages/metro/rollup.config.mjs
+++ b/packages/metro/rollup.config.mjs
@@ -1,0 +1,55 @@
+import commonjs from "@rollup/plugin-commonjs";
+import nodeResolve from "@rollup/plugin-node-resolve";
+import autoExternal from "rollup-plugin-auto-external";
+import nodeExternals from "rollup-plugin-node-externals";
+import { globSync } from "tinyglobby";
+// `@rollup/plugin-typescript` is re-exported from the build-config package so
+// its `typescript` peer resolves to the legacy v6 compiler pinned there; native
+// TypeScript 7 drops the classic JS API the plugin needs.
+import typescript from "../../config/typescript-plugin.mjs";
+
+const inputs = globSync("./src/**/*.ts");
+const externalPackages = ["ttsc", "@ttsc/unplugin", "unplugin"];
+const external = (id) =>
+  id.startsWith("node:") ||
+  externalPackages.some((name) => id === name || id.startsWith(`${name}/`));
+
+const output = (format, extension) => ({
+  dir: "./lib",
+  entryFileNames: (chunkInfo) => {
+    if (chunkInfo.name.includes("node_modules")) {
+      throw new Error(`Invalid chunk name: ${chunkInfo.name}`);
+    }
+    return `[name].${extension}`;
+  },
+  exports: "named",
+  format,
+  preserveModules: true,
+  preserveModulesRoot: "src",
+  sourcemap: true,
+});
+
+export default {
+  external,
+  input: inputs,
+  output: [output("cjs", "js"), output("esm", "mjs")],
+  plugins: [
+    nodeExternals(),
+    autoExternal(),
+    nodeResolve({
+      extensions: [".mjs", ".js", ".json", ".ts"],
+    }),
+    commonjs(),
+    typescript({
+      compilerOptions: {
+        declaration: false,
+        declarationMap: false,
+        emitDeclarationOnly: false,
+        module: "ESNext",
+        moduleResolution: "Bundler",
+        noEmit: false,
+      },
+      tsconfig: "tsconfig.json",
+    }),
+  ],
+};

--- a/packages/metro/src/core/options.ts
+++ b/packages/metro/src/core/options.ts
@@ -62,7 +62,7 @@ export interface ResolvedTtscMetroOptions {
  * Metro forks its transform workers (jest-worker) from the process that loaded
  * `metro.config.js`, so a variable set on `process.env` before Metro boots is
  * inherited by every worker. This is the only channel `withTtsc`'s arguments
- * can reach the transformer through — the worker never sees the `withTtsc`
+ * can reach the transformer through: the worker never sees the `withTtsc`
  * call.
  */
 export const ENV_KEY = "TTSC_METRO_OPTIONS";
@@ -80,8 +80,8 @@ export function serializeOptions(options: TtscMetroOptions): string {
  *
  * Reads {@link ENV_KEY}; when it is unset or malformed the adapter falls back to
  * defaults, which means "auto-discover `tsconfig.json` and read its configured
- * plugins" — the standard ttsc behaviour, and the right thing for a project
- * that called `withTtsc(config)` with no explicit options.
+ * plugins", the standard ttsc behaviour, and the right thing for a project that
+ * called `withTtsc(config)` with no explicit options.
  */
 export function resolveOptionsFromEnv(): ResolvedTtscMetroOptions {
   const raw = process.env[ENV_KEY];

--- a/packages/metro/src/core/options.ts
+++ b/packages/metro/src/core/options.ts
@@ -1,0 +1,113 @@
+import type { TtscUnpluginOptions } from "@ttsc/unplugin/api";
+
+/**
+ * Options accepted by {@link withTtsc} and the Metro transformer.
+ *
+ * The `project` / `compilerOptions` / `plugins` fields are inherited from
+ * `@ttsc/unplugin` so the Metro adapter speaks the exact same configuration
+ * language as every other bundler integration. The remaining fields are
+ * Metro-specific.
+ *
+ * Every field is JSON-serialisable on purpose: `withTtsc` runs in the Metro
+ * **config** process, but the transformer runs in Metro's **worker** processes,
+ * so the resolved options have to survive a structured-clone / env round-trip
+ * to reach them (see {@link serializeOptions}). That is why `include`/`exclude`
+ * are plain substring patterns rather than `RegExp`.
+ */
+export interface TtscMetroOptions extends TtscUnpluginOptions {
+  /**
+   * Explicit module path of the upstream Metro Babel transformer to delegate to
+   * after the ttsc pass.
+   *
+   * When omitted it is auto-detected: `@expo/metro-config/babel-transformer`
+   * first (Expo), then `@react-native/metro-babel-transformer`, then the legacy
+   * `metro-react-native-babel-transformer`.
+   */
+  upstreamTransformer?: string;
+
+  /**
+   * Substring patterns; when non-empty only files whose path contains one of
+   * them are run through the ttsc pass. Non-matching files are passed straight
+   * to the upstream transformer.
+   */
+  include?: string[];
+
+  /**
+   * Substring patterns; files whose path contains one of them skip the ttsc
+   * pass and go straight to the upstream transformer. Applied after
+   * {@link include}.
+   */
+  exclude?: string[];
+}
+
+/**
+ * Fully-resolved options, split into the ttsc-side overlay and Metro-side
+ * knobs.
+ */
+export interface ResolvedTtscMetroOptions {
+  /** Options forwarded verbatim to the `@ttsc/unplugin` transform core. */
+  ttsc: TtscUnpluginOptions;
+  /** Explicit upstream transformer module path, or `undefined` to auto-detect. */
+  upstreamTransformer?: string;
+  /** Resolved include patterns (never `undefined`). */
+  include: string[];
+  /** Resolved exclude patterns (never `undefined`). */
+  exclude: string[];
+}
+
+/**
+ * Environment variable that carries the resolved options from the Metro config
+ * process to the worker processes.
+ *
+ * Metro forks its transform workers (jest-worker) from the process that loaded
+ * `metro.config.js`, so a variable set on `process.env` before Metro boots is
+ * inherited by every worker. This is the only channel `withTtsc`'s arguments
+ * can reach the transformer through — the worker never sees the `withTtsc`
+ * call.
+ */
+export const ENV_KEY = "TTSC_METRO_OPTIONS";
+
+/**
+ * Serialise user options for transport to the worker processes via
+ * {@link ENV_KEY}.
+ */
+export function serializeOptions(options: TtscMetroOptions): string {
+  return JSON.stringify(options ?? {});
+}
+
+/**
+ * Reconstruct the resolved options inside a worker process.
+ *
+ * Reads {@link ENV_KEY}; when it is unset or malformed the adapter falls back to
+ * defaults, which means "auto-discover `tsconfig.json` and read its configured
+ * plugins" — the standard ttsc behaviour, and the right thing for a project
+ * that called `withTtsc(config)` with no explicit options.
+ */
+export function resolveOptionsFromEnv(): ResolvedTtscMetroOptions {
+  const raw = process.env[ENV_KEY];
+  const parsed = parse(raw);
+  return {
+    ttsc: {
+      project: parsed.project,
+      compilerOptions: parsed.compilerOptions,
+      ...("plugins" in parsed ? { plugins: parsed.plugins } : {}),
+    },
+    upstreamTransformer: parsed.upstreamTransformer,
+    include: parsed.include ?? [],
+    exclude: parsed.exclude ?? [],
+  };
+}
+
+function parse(raw: string | undefined): TtscMetroOptions {
+  if (raw === undefined || raw.length === 0) {
+    return {};
+  }
+  try {
+    const value: unknown = JSON.parse(raw);
+    return typeof value === "object" && value !== null
+      ? (value as TtscMetroOptions)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/packages/metro/src/core/options.ts
+++ b/packages/metro/src/core/options.ts
@@ -92,9 +92,12 @@ export function resolveOptionsFromEnv(): ResolvedTtscMetroOptions {
       compilerOptions: parsed.compilerOptions,
       ...("plugins" in parsed ? { plugins: parsed.plugins } : {}),
     },
-    upstreamTransformer: parsed.upstreamTransformer,
-    include: parsed.include ?? [],
-    exclude: parsed.exclude ?? [],
+    upstreamTransformer:
+      typeof parsed.upstreamTransformer === "string"
+        ? parsed.upstreamTransformer
+        : undefined,
+    include: toStringArray(parsed.include),
+    exclude: toStringArray(parsed.exclude),
   };
 }
 
@@ -104,10 +107,24 @@ function parse(raw: string | undefined): TtscMetroOptions {
   }
   try {
     const value: unknown = JSON.parse(raw);
-    return typeof value === "object" && value !== null
+    // Only a plain object is a valid payload; arrays, `null`, numbers, strings,
+    // and booleans (all valid JSON) degrade to defaults rather than leaking a
+    // wrong-shaped value downstream.
+    return typeof value === "object" && value !== null && !Array.isArray(value)
       ? (value as TtscMetroOptions)
       : {};
   } catch {
     return {};
   }
+}
+
+/**
+ * Coerce an untrusted env value into a `string[]`. A non-array (e.g. the common
+ * mistake of passing a bare string for `include`/`exclude`) becomes `[]` so the
+ * worker never calls `.some` on a non-array and crashes.
+ */
+function toStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
 }

--- a/packages/metro/src/core/upstream.ts
+++ b/packages/metro/src/core/upstream.ts
@@ -19,10 +19,8 @@ export interface UpstreamTransformer {
   getCacheKey?: () => string;
 }
 
-let cached: UpstreamTransformer | undefined;
-
 /**
- * Resolve (and memoise) the upstream Metro Babel transformer to delegate to.
+ * Resolve the upstream Metro Babel transformer to delegate to.
  *
  * Detection order, most specific first:
  *
@@ -33,14 +31,13 @@ let cached: UpstreamTransformer | undefined;
  *
  * These are declared as optional peers and resolved at runtime against the
  * consumer project, so the adapter carries no Metro/Expo dependency itself.
+ * Resolution is not memoised here — Node's own module cache already makes the
+ * repeated `require` a cheap lookup, and keeping no module-level state lets a
+ * changed `upstreamTransformer` always take effect.
  */
 export function resolveUpstreamTransformer(
   customPath?: string,
 ): UpstreamTransformer {
-  if (cached !== undefined) {
-    return cached;
-  }
-
   if (customPath !== undefined && customPath.length !== 0) {
     const upstream = tryRequire(customPath);
     if (upstream === undefined) {
@@ -48,7 +45,6 @@ export function resolveUpstreamTransformer(
         `[@ttsc/metro] Could not load the configured upstream transformer: ${customPath}`,
       );
     }
-    cached = upstream;
     return upstream;
   }
 
@@ -59,7 +55,6 @@ export function resolveUpstreamTransformer(
   ]) {
     const upstream = tryRequire(candidate);
     if (upstream !== undefined) {
-      cached = upstream;
       return upstream;
     }
   }

--- a/packages/metro/src/core/upstream.ts
+++ b/packages/metro/src/core/upstream.ts
@@ -7,7 +7,9 @@ const nodeRequire = createRequire(import.meta.url);
  *
  * Metro loads the module named by `transformer.babelTransformerPath` and calls
  * its `transform` once per file, expecting a Babel AST back. `getCacheKey` is
- * an optional export Metro folds into its transform-cache key.
+ * an optional export Metro folds into its transform-cache key; Metro invokes it
+ * with arguments (e.g. `{ projectRoot, enableBabelRCLookup }`), so it is typed
+ * variadic.
  */
 export interface UpstreamTransformer {
   transform(params: {
@@ -16,8 +18,19 @@ export interface UpstreamTransformer {
     options: Record<string, unknown>;
     [key: string]: unknown;
   }): Promise<{ ast: object }>;
-  getCacheKey?: () => string;
+  getCacheKey?: (...args: unknown[]) => string;
 }
+
+/**
+ * Upstream transformer module specifiers tried (in order) when no explicit
+ * `upstreamTransformer` is configured: Expo first, then modern bare React
+ * Native, then the legacy package.
+ */
+export const UPSTREAM_CANDIDATES = [
+  "@expo/metro-config/babel-transformer",
+  "@react-native/metro-babel-transformer",
+  "metro-react-native-babel-transformer",
+] as const;
 
 /**
  * Resolve the upstream Metro Babel transformer to delegate to.
@@ -25,21 +38,23 @@ export interface UpstreamTransformer {
  * Detection order, most specific first:
  *
  * 1. An explicit `customPath` (the `upstreamTransformer` option);
- * 2. `@expo/metro-config/babel-transformer` — Expo projects;
- * 3. `@react-native/metro-babel-transformer` — modern bare React Native;
- * 4. `metro-react-native-babel-transformer` — legacy bare React Native.
+ * 2. Each of {@link UPSTREAM_CANDIDATES} in turn.
  *
  * These are declared as optional peers and resolved at runtime against the
  * consumer project, so the adapter carries no Metro/Expo dependency itself.
- * Resolution is not memoised here — Node's own module cache already makes the
+ * Resolution is not memoised — Node's own module cache already makes the
  * repeated `require` a cheap lookup, and keeping no module-level state lets a
  * changed `upstreamTransformer` always take effect.
+ *
+ * `load` is injectable purely so the resolution order and the not-found path
+ * can be tested deterministically; production always uses the real `require`.
  */
 export function resolveUpstreamTransformer(
   customPath?: string,
+  load: (modulePath: string) => UpstreamTransformer | undefined = tryRequire,
 ): UpstreamTransformer {
   if (customPath !== undefined && customPath.length !== 0) {
-    const upstream = tryRequire(customPath);
+    const upstream = load(customPath);
     if (upstream === undefined) {
       throw new Error(
         `[@ttsc/metro] Could not load the configured upstream transformer: ${customPath}`,
@@ -48,12 +63,8 @@ export function resolveUpstreamTransformer(
     return upstream;
   }
 
-  for (const candidate of [
-    "@expo/metro-config/babel-transformer",
-    "@react-native/metro-babel-transformer",
-    "metro-react-native-babel-transformer",
-  ]) {
-    const upstream = tryRequire(candidate);
+  for (const candidate of UPSTREAM_CANDIDATES) {
+    const upstream = load(candidate);
     if (upstream !== undefined) {
       return upstream;
     }

--- a/packages/metro/src/core/upstream.ts
+++ b/packages/metro/src/core/upstream.ts
@@ -1,0 +1,81 @@
+import { createRequire } from "node:module";
+
+const nodeRequire = createRequire(import.meta.url);
+
+/**
+ * The subset of the Metro Babel-transformer contract this adapter relies on.
+ *
+ * Metro loads the module named by `transformer.babelTransformerPath` and calls
+ * its `transform` once per file, expecting a Babel AST back. `getCacheKey` is
+ * an optional export Metro folds into its transform-cache key.
+ */
+export interface UpstreamTransformer {
+  transform(params: {
+    src: string;
+    filename: string;
+    options: Record<string, unknown>;
+    [key: string]: unknown;
+  }): Promise<{ ast: object }>;
+  getCacheKey?: () => string;
+}
+
+let cached: UpstreamTransformer | undefined;
+
+/**
+ * Resolve (and memoise) the upstream Metro Babel transformer to delegate to.
+ *
+ * Detection order, most specific first:
+ *
+ * 1. An explicit `customPath` (the `upstreamTransformer` option);
+ * 2. `@expo/metro-config/babel-transformer` — Expo projects;
+ * 3. `@react-native/metro-babel-transformer` — modern bare React Native;
+ * 4. `metro-react-native-babel-transformer` — legacy bare React Native.
+ *
+ * These are declared as optional peers and resolved at runtime against the
+ * consumer project, so the adapter carries no Metro/Expo dependency itself.
+ */
+export function resolveUpstreamTransformer(
+  customPath?: string,
+): UpstreamTransformer {
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  if (customPath !== undefined && customPath.length !== 0) {
+    const upstream = tryRequire(customPath);
+    if (upstream === undefined) {
+      throw new Error(
+        `[@ttsc/metro] Could not load the configured upstream transformer: ${customPath}`,
+      );
+    }
+    cached = upstream;
+    return upstream;
+  }
+
+  for (const candidate of [
+    "@expo/metro-config/babel-transformer",
+    "@react-native/metro-babel-transformer",
+    "metro-react-native-babel-transformer",
+  ]) {
+    const upstream = tryRequire(candidate);
+    if (upstream !== undefined) {
+      cached = upstream;
+      return upstream;
+    }
+  }
+
+  throw new Error(
+    "[@ttsc/metro] Could not find an upstream Metro transformer. Install " +
+      "@expo/metro-config (Expo) or @react-native/metro-babel-transformer " +
+      "(React Native), or set the `upstreamTransformer` option to an explicit " +
+      "module path.",
+  );
+}
+
+function tryRequire(modulePath: string): UpstreamTransformer | undefined {
+  try {
+    return nodeRequire(modulePath) as UpstreamTransformer;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/metro/src/core/upstream.ts
+++ b/packages/metro/src/core/upstream.ts
@@ -42,7 +42,7 @@ export const UPSTREAM_CANDIDATES = [
  *
  * These are declared as optional peers and resolved at runtime against the
  * consumer project, so the adapter carries no Metro/Expo dependency itself.
- * Resolution is not memoised — Node's own module cache already makes the
+ * Resolution is not memoised: Node's own module cache already makes the
  * repeated `require` a cheap lookup, and keeping no module-level state lets a
  * changed `upstreamTransformer` always take effect.
  *

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -8,13 +8,14 @@
  * project's existing Expo/React-Native Babel transformer.
  *
  * @example
- *   Expo```js
+ *   Expo project
+ *   ```js
  *   // metro.config.js
  *   const { getDefaultConfig } = require("expo/metro-config");
  *   const { withTtsc } = require("@ttsc/metro");
  *
  *   module.exports = withTtsc(getDefaultConfig(__dirname));
- *   ```;
+ *   ```
  *
  * @example
  *   Bare React Native

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -1,0 +1,91 @@
+/**
+ * `@ttsc/metro` — Metro (React Native / Expo) adapter for ttsc plugins.
+ *
+ * Metro bundles with Babel, which strips TypeScript types and never runs ttsc
+ * plugins, so neither the `ttsc` CLI nor `@ttsc/unplugin` can reach an RN/Expo
+ * build. {@link withTtsc} wires a Metro custom transformer that runs the ttsc
+ * plugin pass on each TypeScript file before handing the result to the
+ * project's existing Expo/React-Native Babel transformer.
+ *
+ * @example
+ *   Expo```js
+ *   // metro.config.js
+ *   const { getDefaultConfig } = require("expo/metro-config");
+ *   const { withTtsc } = require("@ttsc/metro");
+ *
+ *   module.exports = withTtsc(getDefaultConfig(__dirname));
+ *   ```;
+ *
+ * @example
+ *   Bare React Native
+ *   ```js
+ *   // metro.config.js
+ *   const { getDefaultConfig } = require("@react-native/metro-config");
+ *   const { withTtsc } = require("@ttsc/metro");
+ *
+ *   module.exports = withTtsc(getDefaultConfig(__dirname));
+ *   ```
+ */
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { TtscMetroOptions } from "./core/options";
+import { ENV_KEY, serializeOptions } from "./core/options";
+
+export type {
+  ResolvedTtscMetroOptions,
+  TtscMetroOptions,
+} from "./core/options";
+
+/**
+ * Minimal structural type for a Metro config object — avoids a hard dependency
+ * on Metro's types while letting {@link withTtsc} preserve the caller's exact
+ * config type.
+ */
+interface MetroConfigLike {
+  transformer?: {
+    babelTransformerPath?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * Wrap a Metro config so ttsc plugins run on every TypeScript file.
+ *
+ * Sets `transformer.babelTransformerPath` to this package's transformer and
+ * publishes the resolved options to Metro's worker processes via the
+ * {@link ENV_KEY} environment variable (the workers never see this call, so env
+ * is the transport — see `core/options.ts`). Compatible with Expo's
+ * `getDefaultConfig()` and bare React Native alike.
+ *
+ * With no `options`, the transformer auto-discovers `tsconfig.json` and runs
+ * the plugins configured there — the standard ttsc model. Pass `options` only
+ * to override the project path, plugin list, or include/exclude filters.
+ */
+export function withTtsc<T extends MetroConfigLike>(
+  config: T,
+  options: TtscMetroOptions = {},
+): T {
+  process.env[ENV_KEY] = serializeOptions(options);
+  return {
+    ...config,
+    transformer: {
+      ...config.transformer,
+      babelTransformerPath: transformerModulePath(),
+    },
+  } as T;
+}
+
+/**
+ * Absolute path to the built transformer module Metro will `require`.
+ *
+ * Always the CommonJS build (`transformer.js`) next to this module: Metro
+ * resolves `babelTransformerPath` with `require`, and `metro.config.js` is a
+ * CommonJS module. Rollup rewrites `import.meta.url` for both the CJS and ESM
+ * builds, so this resolves correctly regardless of how the config loaded this
+ * entry.
+ */
+function transformerModulePath(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "transformer.js");
+}

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@ttsc/metro` — Metro (React Native / Expo) adapter for ttsc plugins.
+ * `@ttsc/metro`: Metro (React Native / Expo) adapter for ttsc plugins.
  *
  * Metro bundles with Babel, which strips TypeScript types and never runs ttsc
  * plugins, so neither the `ttsc` CLI nor `@ttsc/unplugin` can reach an RN/Expo
@@ -39,7 +39,7 @@ export type {
 } from "./core/options";
 
 /**
- * Minimal structural type for a Metro config object — avoids a hard dependency
+ * Minimal structural type for a Metro config object, avoids a hard dependency
  * on Metro's types while letting {@link withTtsc} preserve the caller's exact
  * config type.
  */
@@ -57,12 +57,12 @@ interface MetroConfigLike {
  * Sets `transformer.babelTransformerPath` to this package's transformer and
  * publishes the resolved options to Metro's worker processes via the
  * {@link ENV_KEY} environment variable (the workers never see this call, so env
- * is the transport — see `core/options.ts`). Compatible with Expo's
+ * is the transport, see `core/options.ts`). Compatible with Expo's
  * `getDefaultConfig()` and bare React Native alike.
  *
  * With no `options`, the transformer auto-discovers `tsconfig.json` and runs
- * the plugins configured there — the standard ttsc model. Pass `options` only
- * to override the project path, plugin list, or include/exclude filters.
+ * the plugins configured there: the standard ttsc model. Pass `options` only to
+ * override the project path, plugin list, or include/exclude filters.
  */
 export function withTtsc<T extends MetroConfigLike>(
   config: T,

--- a/packages/metro/src/transformer.ts
+++ b/packages/metro/src/transformer.ts
@@ -94,9 +94,12 @@ export async function transform(params: {
 }): Promise<{ ast: object }> {
   const opts = options();
   const upstream = resolveUpstreamTransformer(opts.upstreamTransformer);
-  const filename = resolveAbsoluteFilename(params.filename, params.options);
 
-  if (!shouldTransform(filename, opts)) {
+  // Gate on the project-relative path Metro supplies, so include/exclude
+  // substrings match what the user writes (e.g. "src/generated") and never
+  // collide with an absolute ancestor directory name. The absolute path is used
+  // only to address the file inside the compiled program.
+  if (!shouldTransform(params.filename, opts)) {
     return upstream.transform(params);
   }
 
@@ -104,7 +107,7 @@ export async function transform(params: {
   try {
     unpluginOptions ??= resolveOptions(opts.ttsc);
     const result = await transformTtsc(
-      filename,
+      resolveAbsoluteFilename(params.filename, params.options),
       params.src,
       unpluginOptions,
       undefined,
@@ -238,7 +241,7 @@ function stableStringify(value: unknown): string {
   }
   if (value !== null && typeof value === "object") {
     return `{${Object.entries(value)
-      .sort(([a], [b]) => a.localeCompare(b))
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
       .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
       .join(",")}}`;
   }

--- a/packages/metro/src/transformer.ts
+++ b/packages/metro/src/transformer.ts
@@ -1,0 +1,165 @@
+/**
+ * Metro custom transformer for ttsc.
+ *
+ * Metro loads this module via `transformer.babelTransformerPath` (wired by
+ * {@link withTtsc}) and calls {@link transform} once per file. The flow is:
+ *
+ * TypeScript source -> ttsc plugin pass (typia, nestia, …) via @ttsc/unplugin's
+ * core -> transformed TypeScript source -> upstream Expo/RN Babel transformer
+ * (strips types, RN transforms) -> Babel AST (what Metro consumes)
+ *
+ * The ttsc pass reuses `@ttsc/unplugin`'s `transformTtsc`, so the plugin
+ * contract, tsconfig discovery, and per-build cache are identical to every
+ * other bundler integration. See the package README for the v1 cost model and
+ * the cross-file cache-invalidation caveat.
+ */
+import {
+  createTtscTransformCache,
+  resolveOptions,
+  transformTtsc,
+} from "@ttsc/unplugin/api";
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+
+import type { ResolvedTtscMetroOptions } from "./core/options";
+import { resolveOptionsFromEnv } from "./core/options";
+import { resolveUpstreamTransformer } from "./core/upstream";
+
+const nodeRequire = createRequire(import.meta.url);
+
+/**
+ * Matches the TypeScript source extensions the ttsc pass handles (`.ts`,
+ * `.tsx`, `.cts`, `.mts`). JavaScript and declaration files are passed straight
+ * through to the upstream transformer.
+ */
+const TS_EXTENSION = /\.[cm]?tsx?$/;
+const DECLARATION = /\.d\.[cm]?ts$/;
+
+/**
+ * Per-worker singletons. Metro loads this module once per worker process and
+ * reuses it across every file that worker handles, so the resolved options, the
+ * transform cache, and the memoised `@ttsc/unplugin` options are all scoped to
+ * the worker.
+ */
+let resolved: ResolvedTtscMetroOptions | undefined;
+let unpluginOptions: ReturnType<typeof resolveOptions> | undefined;
+const cache = createTtscTransformCache();
+
+/** Lazily resolve the worker-side options (from {@link resolveOptionsFromEnv}). */
+function options(): ResolvedTtscMetroOptions {
+  return (resolved ??= resolveOptionsFromEnv());
+}
+
+/**
+ * Metro transform entry point.
+ *
+ * Runs the ttsc plugin pass on TypeScript files, then delegates to the upstream
+ * Expo/React-Native Babel transformer to produce the AST Metro expects. All
+ * original Metro params are forwarded to the upstream call; only `src` is
+ * replaced with the ttsc-transformed source.
+ */
+export async function transform(params: {
+  src: string;
+  filename: string;
+  options: Record<string, unknown>;
+  [key: string]: unknown;
+}): Promise<{ ast: object }> {
+  const opts = options();
+  const upstream = resolveUpstreamTransformer(opts.upstreamTransformer);
+
+  if (!shouldTransform(params.filename, opts)) {
+    return upstream.transform(params);
+  }
+
+  let transformedSrc = params.src;
+  try {
+    unpluginOptions ??= resolveOptions(opts.ttsc);
+    const result = await transformTtsc(
+      params.filename,
+      params.src,
+      unpluginOptions,
+      undefined,
+      cache,
+    );
+    if (result !== undefined && typeof result.code === "string") {
+      transformedSrc = result.code;
+    }
+  } catch (error) {
+    // A file that is not part of the tsconfig program is not a build error —
+    // pass it through untransformed. Genuine compile/type failures propagate so
+    // Metro surfaces them, matching the other ttsc bundler integrations.
+    if (!isFileOutsideProject(error)) {
+      throw error;
+    }
+  }
+
+  return upstream.transform({ ...params, src: transformedSrc });
+}
+
+/**
+ * Metro transform-cache key.
+ *
+ * Metro already content-hashes each file, so this only has to invalidate when
+ * the transformer itself changes: package version + resolved options + upstream
+ * key. NOTE: this does not encode the tsconfig / plugin configuration or
+ * cross-file type dependencies, so after editing those (or a depended-upon
+ * type) run Metro with `--reset-cache`. See the README "Caveats" section and
+ * samchon/ttsc#255.
+ */
+export function getCacheKey(): string {
+  const opts = options();
+  const upstream = resolveUpstreamTransformer(opts.upstreamTransformer);
+
+  const hash = createHash("sha256");
+  hash.update(`@ttsc/metro:${packageVersion()}`);
+  hash.update(
+    JSON.stringify({
+      ttsc: opts.ttsc,
+      include: opts.include,
+      exclude: opts.exclude,
+      upstreamTransformer: opts.upstreamTransformer ?? null,
+    }),
+  );
+  if (upstream.getCacheKey !== undefined) {
+    hash.update(upstream.getCacheKey());
+  }
+  return hash.digest("hex");
+}
+
+function shouldTransform(
+  filename: string,
+  opts: ResolvedTtscMetroOptions,
+): boolean {
+  if (!TS_EXTENSION.test(filename) || DECLARATION.test(filename)) {
+    return false;
+  }
+  if (opts.exclude.some((pattern) => filename.includes(pattern))) {
+    return false;
+  }
+  if (
+    opts.include.length !== 0 &&
+    !opts.include.some((pattern) => filename.includes(pattern))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * `transformTtsc` throws `"ttsc transform did not return output for <file>"`
+ * when the requested file is not part of the compiled program (e.g. excluded
+ * from the tsconfig). That case is non-fatal — the file should pass through.
+ */
+function isFileOutsideProject(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("did not return output");
+}
+
+function packageVersion(): string {
+  try {
+    const pkg = nodeRequire("@ttsc/metro/package.json") as { version?: string };
+    return pkg.version ?? "0";
+  } catch {
+    return "0";
+  }
+}

--- a/packages/metro/src/transformer.ts
+++ b/packages/metro/src/transformer.ts
@@ -58,7 +58,7 @@ function options(): ResolvedTtscMetroOptions {
  * reads the file via `fs.readFileSync(path.resolve(projectRoot, filename))`)
  * and passes `projectRoot` inside `options`. The ttsc pass needs an absolute
  * path that matches a key in the compiled program, so resolve against
- * `projectRoot` — never `process.cwd()`, which differs from `projectRoot` in
+ * `projectRoot`, never `process.cwd()`, which differs from `projectRoot` in
  * monorepos and when Metro is launched from a parent directory. Getting this
  * wrong makes every file look "outside the project" and silently skips the
  * plugin pass.
@@ -117,7 +117,7 @@ export async function transform(params: {
       transformedSrc = result.code;
     }
   } catch (error) {
-    // A file that is not part of the tsconfig program is not a build error —
+    // A file that is not part of the tsconfig program is not a build error,
     // pass it through untransformed. Genuine compile/type failures propagate so
     // Metro surfaces them, matching the other ttsc bundler integrations.
     if (!isFileOutsideProject(error)) {
@@ -135,7 +135,7 @@ export async function transform(params: {
  * the transformer itself changes: package version + resolved options + the
  * upstream transformer's own key (forwarded Metro's args, e.g. `projectRoot`,
  * so a `babel.config.js` change still busts the cache). Resolving the upstream
- * is deliberately non-fatal here — a missing peer must not crash cache-key
+ * is deliberately non-fatal here: a missing peer must not crash cache-key
  * computation. NOTE: this does not encode the tsconfig / plugin configuration
  * or cross-file type dependencies, so after editing those (or a depended-upon
  * type) run Metro with `--reset-cache`. See the README "Caveats" and
@@ -215,7 +215,7 @@ export function shouldTransform(
 /**
  * `transformTtsc` throws `"ttsc transform did not return output for <file>"`
  * when the requested file is not part of the compiled program (e.g. excluded
- * from the tsconfig). That case is non-fatal — the file should pass through.
+ * from the tsconfig). That case is non-fatal: the file should pass through.
  */
 function isFileOutsideProject(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);

--- a/packages/metro/src/transformer.ts
+++ b/packages/metro/src/transformer.ts
@@ -20,6 +20,7 @@ import {
 } from "@ttsc/unplugin/api";
 import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
+import path from "node:path";
 
 import type { ResolvedTtscMetroOptions } from "./core/options";
 import { resolveOptionsFromEnv } from "./core/options";
@@ -51,12 +52,39 @@ function options(): ResolvedTtscMetroOptions {
 }
 
 /**
+ * Resolve Metro's per-file `filename` to an absolute path.
+ *
+ * Metro hands the babel transformer a path **relative to `projectRoot`** (it
+ * reads the file via `fs.readFileSync(path.resolve(projectRoot, filename))`)
+ * and passes `projectRoot` inside `options`. The ttsc pass needs an absolute
+ * path that matches a key in the compiled program, so resolve against
+ * `projectRoot` — never `process.cwd()`, which differs from `projectRoot` in
+ * monorepos and when Metro is launched from a parent directory. Getting this
+ * wrong makes every file look "outside the project" and silently skips the
+ * plugin pass.
+ */
+export function resolveAbsoluteFilename(
+  filename: string,
+  options?: Record<string, unknown>,
+): string {
+  if (path.isAbsolute(filename)) {
+    return filename;
+  }
+  const projectRoot =
+    options !== undefined && typeof options.projectRoot === "string"
+      ? options.projectRoot
+      : process.cwd();
+  return path.resolve(projectRoot, filename);
+}
+
+/**
  * Metro transform entry point.
  *
  * Runs the ttsc plugin pass on TypeScript files, then delegates to the upstream
- * Expo/React-Native Babel transformer to produce the AST Metro expects. All
- * original Metro params are forwarded to the upstream call; only `src` is
- * replaced with the ttsc-transformed source.
+ * Expo/React-Native Babel transformer to produce the AST Metro expects. The
+ * upstream call receives Metro's original params (notably the project-relative
+ * `filename`, which Babel expects); only `src` is replaced with the
+ * ttsc-transformed source.
  */
 export async function transform(params: {
   src: string;
@@ -66,8 +94,9 @@ export async function transform(params: {
 }): Promise<{ ast: object }> {
   const opts = options();
   const upstream = resolveUpstreamTransformer(opts.upstreamTransformer);
+  const filename = resolveAbsoluteFilename(params.filename, params.options);
 
-  if (!shouldTransform(params.filename, opts)) {
+  if (!shouldTransform(filename, opts)) {
     return upstream.transform(params);
   }
 
@@ -75,7 +104,7 @@ export async function transform(params: {
   try {
     unpluginOptions ??= resolveOptions(opts.ttsc);
     const result = await transformTtsc(
-      params.filename,
+      filename,
       params.src,
       unpluginOptions,
       undefined,
@@ -100,33 +129,68 @@ export async function transform(params: {
  * Metro transform-cache key.
  *
  * Metro already content-hashes each file, so this only has to invalidate when
- * the transformer itself changes: package version + resolved options + upstream
- * key. NOTE: this does not encode the tsconfig / plugin configuration or
- * cross-file type dependencies, so after editing those (or a depended-upon
- * type) run Metro with `--reset-cache`. See the README "Caveats" section and
+ * the transformer itself changes: package version + resolved options + the
+ * upstream transformer's own key (forwarded Metro's args, e.g. `projectRoot`,
+ * so a `babel.config.js` change still busts the cache). Resolving the upstream
+ * is deliberately non-fatal here — a missing peer must not crash cache-key
+ * computation. NOTE: this does not encode the tsconfig / plugin configuration
+ * or cross-file type dependencies, so after editing those (or a depended-upon
+ * type) run Metro with `--reset-cache`. See the README "Caveats" and
  * samchon/ttsc#255.
  */
-export function getCacheKey(): string {
+export function getCacheKey(...args: unknown[]): string {
   const opts = options();
-  const upstream = resolveUpstreamTransformer(opts.upstreamTransformer);
-
   const hash = createHash("sha256");
   hash.update(`@ttsc/metro:${packageVersion()}`);
   hash.update(
-    JSON.stringify({
+    stableStringify({
       ttsc: opts.ttsc,
       include: opts.include,
       exclude: opts.exclude,
       upstreamTransformer: opts.upstreamTransformer ?? null,
     }),
   );
-  if (upstream.getCacheKey !== undefined) {
-    hash.update(upstream.getCacheKey());
+  const upstreamKey = upstreamCacheKey(opts.upstreamTransformer, args);
+  if (upstreamKey.length !== 0) {
+    hash.update(upstreamKey);
   }
   return hash.digest("hex");
 }
 
-function shouldTransform(
+/**
+ * Fold the upstream transformer's cache key in, defensively. Forwards Metro's
+ * own `getCacheKey` arguments so the upstream's babelrc-derived key is
+ * preserved, and never throws: a missing peer or a throwing upstream
+ * `getCacheKey` yields an empty contribution rather than failing the whole
+ * build's cache keying.
+ */
+function upstreamCacheKey(
+  upstreamTransformer: string | undefined,
+  args: unknown[],
+): string {
+  let upstream;
+  try {
+    upstream = resolveUpstreamTransformer(upstreamTransformer);
+  } catch {
+    return "";
+  }
+  if (upstream.getCacheKey === undefined) {
+    return "";
+  }
+  try {
+    return String(upstream.getCacheKey(...args) ?? "");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Decide whether a file should run through the ttsc pass. Only TypeScript
+ * sources (`.ts`/`.tsx`/`.cts`/`.mts`, excluding `.d.ts`) qualify; `exclude`
+ * substrings win over `include`, and an empty `include` means "all TypeScript".
+ * Exported for unit testing.
+ */
+export function shouldTransform(
   filename: string,
   opts: ResolvedTtscMetroOptions,
 ): boolean {
@@ -162,4 +226,21 @@ function packageVersion(): string {
   } catch {
     return "0";
   }
+}
+
+/**
+ * JSON-serialise with object keys sorted recursively, so two semantically equal
+ * option sets always hash to the same cache key regardless of property order.
+ */
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
 }

--- a/packages/metro/tsconfig.json
+++ b/packages/metro/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../config/tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -122,7 +122,7 @@ export default withTtsc(nextConfig);
 
 ### Turbopack
 
-Turbopack has no JS plugin API, but it runs webpack loaders through `turbopack.rules` — and a ttsc transform is exactly loader-shaped (TypeScript source in, transformed source out). `@ttsc/unplugin/turbopack` is that standalone loader:
+Turbopack has no JS plugin API, but it runs webpack loaders through `turbopack.rules`, and a ttsc transform is exactly loader-shaped (TypeScript source in, transformed source out). `@ttsc/unplugin/turbopack` is that standalone loader:
 
 ```js
 // next.config.mjs
@@ -280,7 +280,7 @@ Supported entrypoints are:
 - `@ttsc/unplugin/next`
 - `@ttsc/unplugin/bun`
 
-Each entrypoint supports ESM import and CJS require. In CommonJS configs, read the default export from `require("@ttsc/unplugin/vite").default`. `@ttsc/unplugin/turbopack` is not an unplugin factory but a standalone webpack loader — reference it by module name inside `turbopack.rules` instead of calling it.
+Each entrypoint supports ESM import and CJS require. In CommonJS configs, read the default export from `require("@ttsc/unplugin/vite").default`. `@ttsc/unplugin/turbopack` is not an unplugin factory but a standalone webpack loader; reference it by module name inside `turbopack.rules` instead of calling it.
 
 ### Options
 
@@ -302,7 +302,7 @@ const options: TtscUnpluginOptions = {
 
 ### Watch Mode and HMR
 
-Transform plugins may report, per file, the source files they consulted (the transform envelope's `dependencies` field — see the [plugin protocol](https://ttsc.dev/docs/development/concepts/protocol#transform)). The adapter registers each reported path with the bundler via `addWatchFile`, so editing a type that only a generated validator depends on invalidates the module in watch mode even though the bundler erased the type-only import from its graph.
+Transform plugins may report, per file, the source files they consulted (the transform envelope's `dependencies` field, see the [plugin protocol](https://ttsc.dev/docs/development/concepts/protocol#transform)). The adapter registers each reported path with the bundler via `addWatchFile`, so editing a type that only a generated validator depends on invalidates the module in watch mode even though the bundler erased the type-only import from its graph.
 
 ## Sponsors
 

--- a/packages/unplugin/src/core/index.ts
+++ b/packages/unplugin/src/core/index.ts
@@ -20,7 +20,7 @@ export const sourceFilePattern = /\.[cm]?tsx?$/;
 /** Matches any path segment that is a `node_modules` directory (cross-platform). */
 const nodeModulesPattern = /(?:^|[/\\])node_modules(?:[/\\]|$)/;
 /**
- * Matches virtual module ids — Rollup/Vite use a leading NUL byte (`\0`) as
+ * Matches virtual module ids: Rollup/Vite use a leading NUL byte (`\0`) as
  * convention.
  */
 const virtualModulePattern = /\0/;

--- a/packages/unplugin/src/core/options.ts
+++ b/packages/unplugin/src/core/options.ts
@@ -35,8 +35,8 @@ export interface TtscUnpluginOptions {
  * Fully-resolved plugin options with all defaults applied.
  *
  * Produced by {@link resolveOptions}; consumed internally by the transform
- * pipeline. Every field is present and normalised — callers should not
- * construct this type directly.
+ * pipeline. Every field is present and normalised; callers should not construct
+ * this type directly.
  */
 export interface ResolvedTtscUnpluginOptions {
   /** Compiler-options overlay applied on top of the discovered tsconfig. */

--- a/packages/unplugin/src/core/transform.ts
+++ b/packages/unplugin/src/core/transform.ts
@@ -46,7 +46,7 @@ export interface TtscTransformAlias {
  * input file. On subsequent transforms the cached entry is validated by
  * re-hashing the project and comparing against {@link inputHashes}; a mismatch
  * triggers a full re-transform. Both sides hash the same set of files (the
- * project directory walk), so the comparison is meaningful — keying the
+ * project directory walk), so the comparison is meaningful; keying the
  * compiler's out-of-walk output paths on only one side is what made the cache
  * miss on every module.
  */
@@ -113,7 +113,7 @@ export interface TtscTransformHooks {
  * @param cache - Optional per-build cache; cleared by the caller on
  *   `buildStart`.
  * @param hooks - Optional adapter callbacks; see {@link TtscTransformHooks}.
- *   Dependency notifications fire on cache hits too — watch registrations are
+ *   Dependency notifications fire on cache hits too; watch registrations are
  *   per build, not per compilation.
  */
 export async function transformTtsc(
@@ -191,7 +191,7 @@ export async function transformTtsc(
  * The transform envelope's `dependencies` keys mirror the `typescript` keys
  * (project-relative); values may be project-relative or absolute. Every path is
  * absolutized against the project root and deduplicated, and the file itself is
- * dropped — the bundler already watches the module it transforms.
+ * dropped; the bundler already watches the module it transforms.
  */
 function notifyFileDependencies(
   hooks: TtscTransformHooks | undefined,
@@ -311,9 +311,9 @@ export function createTransformResult(
  *
  * Re-hashes every file under the project root and overlays the current module's
  * in-memory source, then compares the snapshot against the one captured when
- * the result was produced. Any input under the project root changing — the
- * module itself or a sibling the plugin reads — invalidates the entry and
- * forces a re-transform. Out-of-walk inputs a plugin pulls in (`node_modules`
+ * the result was produced. Any input under the project root changing (the
+ * module itself or a sibling the plugin reads) invalidates the entry and forces
+ * a re-transform. Out-of-walk inputs a plugin pulls in (`node_modules`
  * declarations, sibling-package sources) are not seen here; adapters invalidate
  * on those through the reported `dependencies` → `addWatchFile` → the bundler's
  * next `buildStart` cache clear.
@@ -323,8 +323,8 @@ export function createTransformResult(
  * the key universe. The earlier implementation overlaid the compiler's output
  * keys here on only one side; those keys include out-of-walk program inputs
  * (`node_modules` declarations, sibling-package sources), so the snapshots
- * never matched and the cache missed on every module — re-transforming the
- * whole project once per file on any project that imports a typed dependency.
+ * never matched and the cache missed on every module; re-transforming the whole
+ * project once per file on any project that imports a typed dependency.
  */
 function matchesCachedSource(
   cached: TtscCachedProjectTransform,
@@ -340,8 +340,8 @@ function matchesCachedSource(
 /**
  * Build the input-hash snapshot stored alongside a fresh compiler result.
  *
- * Hashes every file under the project directory — the exact universe
- * {@link matchesCachedSource} re-hashes to validate — then overlays the
+ * Hashes every file under the project directory (the exact universe
+ * {@link matchesCachedSource} re-hashes to validate), then overlays the
  * in-memory source for the module that triggered the compile so unsaved editor
  * content is captured correctly.
  *
@@ -593,7 +593,7 @@ function normalizePluginConfigForGeneratedTsconfig(
  * project's own `paths` wholesale. The overlay therefore re-states the
  * project's effective mappings first, so tsconfig-only aliases keep resolving;
  * inline `compilerOptions.paths` from the plugin options ride on top, and the
- * bundler aliases win last — they mirror what the bundler will actually do at
+ * bundler aliases win last; they mirror what the bundler will actually do at
  * resolve time.
  *
  * No `baseUrl` is emitted: TypeScript-Go removed the option (TS5102), and all
@@ -838,7 +838,7 @@ function formatUnknownError(error: unknown): string {
  * If `tsconfig` is supplied it is returned as-is (absolute) or resolved from
  * `process.cwd()` (relative). Otherwise the function walks ancestor directories
  * starting at `file`'s directory, returning the first `tsconfig.json` found.
- * Falls back to `<cwd>/tsconfig.json` when no ancestor contains one — the
+ * Falls back to `<cwd>/tsconfig.json` when no ancestor contains one; the
  * compiler will error if that file does not exist, which is the correct
  * behavior for a mis-configured project.
  */
@@ -856,7 +856,7 @@ function resolveTsconfig(file: string, tsconfig?: string): string {
       return candidate;
     }
     const parent = path.dirname(current);
-    // Reached filesystem root — stop walking.
+    // Reached filesystem root, stop walking.
     if (parent === current) {
       break;
     }

--- a/packages/unplugin/src/core/tsconfigPaths.ts
+++ b/packages/unplugin/src/core/tsconfigPaths.ts
@@ -10,8 +10,8 @@ import path from "node:path";
  * is the whole object from the nearest config in the chain that declares one
  * (own config first, then `extends` entries in reverse priority order).
  * Relative targets are anchored at the directory of the config that declares
- * them — TypeScript-Go resolves inherited relative `paths` against the
- * declaring file, not the extending one.
+ * them. TypeScript-Go resolves inherited relative `paths` against the declaring
+ * file, not the extending one.
  *
  * The generated transform tsconfig replaces `paths` wholesale (standard
  * `extends` semantics), so the alias overlay must re-state these base mappings
@@ -71,7 +71,7 @@ interface IDeclaredPaths {
 /**
  * Locate the nearest `compilerOptions.paths` declaration in the `extends` chain
  * rooted at `tsconfig`. The own config wins over its bases; within an `extends`
- * array, later entries win over earlier ones. `seen` breaks circular chains —
+ * array, later entries win over earlier ones. `seen` breaks circular chains;
  * the compiler reports the actual config error.
  */
 function findDeclaredPaths(
@@ -132,7 +132,7 @@ function extendsSpecifiers(extended: unknown): string[] {
  * Resolve an `extends` specifier to an absolute config path using TypeScript's
  * rules: absolute paths and relative specifiers get `.json` /
  * `tsconfig.json`-directory fallbacks; bare specifiers go through Node's module
- * resolver scoped to the declaring config. Returns `null` instead of throwing —
+ * resolver scoped to the declaring config. Returns `null` instead of throwing;
  * the compiler reports unresolvable `extends` itself.
  */
 function resolveExtendsConfig(
@@ -205,7 +205,7 @@ function resolveRealPath(location: string): string {
 
 /**
  * Parse a JSONC (JSON with Comments) string by stripping comments and trailing
- * commas before handing off to `JSON.parse`. A leading UTF-8 BOM is dropped —
+ * commas before handing off to `JSON.parse`. A leading UTF-8 BOM is dropped;
  * `JSON.parse` rejects it, and this reader must not lose `paths` for a config
  * the compiler accepts.
  */

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @ttsc/unplugin — bundler-agnostic ttsc plugin adapter.
+ * @ttsc/unplugin: bundler-agnostic ttsc plugin adapter.
  *
  * Re-exports the unified `unplugin` instance that carries named bundler
  * adapters (`.vite`, `.rollup`, `.rolldown`, `.webpack`, `.rspack`, `.esbuild`,

--- a/packages/unplugin/src/turbopack.ts
+++ b/packages/unplugin/src/turbopack.ts
@@ -57,7 +57,7 @@ const transformCache = createTtscTransformCache();
  *
  * Pass {@link TtscUnpluginOptions} through the rule's `options` object. The
  * loader returns the source unchanged for declaration files, `node_modules`
- * paths, and transforms that produce no change — mirroring the unplugin
+ * paths, and transforms that produce no change, mirroring the unplugin
  * adapters' `transformInclude` filter, since a broad rule glob routes
  * everything matching the extension through the loader.
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,55 @@ importers:
         specifier: catalog:typescript
         version: 7.0.1-rc
 
+  packages/metro:
+    dependencies:
+      '@expo/metro-config':
+        specifier: '*'
+        version: 56.0.14(typescript@7.0.1-rc)
+      '@react-native/metro-babel-transformer':
+        specifier: '*'
+        version: 0.86.0(@babel/core@7.29.7)
+      '@ttsc/unplugin':
+        specifier: workspace:*
+        version: link:../unplugin
+      metro-react-native-babel-transformer:
+        specifier: '*'
+        version: 0.77.0(@babel/core@7.29.7)
+    devDependencies:
+      '@rollup/plugin-commonjs':
+        specifier: ^29.0.2
+        version: 29.0.2(rollup@4.60.4)
+      '@rollup/plugin-node-resolve':
+        specifier: ^16.0.3
+        version: 16.0.3(rollup@4.60.4)
+      '@types/node':
+        specifier: catalog:utils
+        version: 25.9.1
+      rimraf:
+        specifier: catalog:utils
+        version: 6.1.3
+      rollup:
+        specifier: ^4.60.3
+        version: 4.60.4
+      rollup-plugin-auto-external:
+        specifier: ^2.0.0
+        version: 2.0.0(rollup@4.60.4)
+      rollup-plugin-node-externals:
+        specifier: ^9.0.1
+        version: 9.0.1(rollup@4.60.4)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))
+      tinyglobby:
+        specifier: ^0.2.16
+        version: 0.2.16
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      ttsc:
+        specifier: workspace:*
+        version: link:../ttsc
+      typescript:
+        specifier: catalog:typescript
+        version: 7.0.1-rc
+
   packages/paths: {}
 
   packages/playground:
@@ -654,20 +703,127 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-create-class-features-plugin@7.29.7':
+    resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-create-regexp-features-plugin@7.29.7':
+    resolution: {integrity: sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-define-polyfill-provider@0.6.8':
+    resolution: {integrity: sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  '@babel/helper-environment-visitor@7.24.7':
+    resolution: {integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-remap-async-to-generator@7.29.7':
+    resolution: {integrity: sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-replace-supers@7.29.7':
+    resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-wrap-function@7.29.7':
+    resolution: {integrity: sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.3':
@@ -675,16 +831,372 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-proposal-async-generator-functions@7.20.7':
+    resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-class-properties@7.18.6':
+    resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-export-default-from@7.29.7':
+    resolution: {integrity: sha512-p+G5BNXDcy3bOXplhY4HybQ1GxH3i2Tppmdm/3epyRu2VgJJZuUlZ61MqRTg582Q7ZLBdP7fePYvsumSEkMxcQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6':
+    resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-numeric-separator@7.18.6':
+    resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-object-rest-spread@7.20.7':
+    resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-optional-catch-binding@7.18.6':
+    resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-optional-chaining@7.21.0':
+    resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-async-generators@7.8.4':
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-class-properties@7.12.13':
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-dynamic-import@7.8.3':
+    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-export-default-from@7.29.7':
+    resolution: {integrity: sha512-foag0BB37ROhdeIX9O8G0jX7hw0UekJc04cHMrYLOnrErsnBKqJGHJ8eDRpoCFZBvEPPygmmtw4qyU97qa4oOw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-flow@7.29.7':
+    resolution: {integrity: sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.29.7':
+    resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3':
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4':
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3':
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3':
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3':
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.29.7':
+    resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-arrow-functions@7.29.7':
+    resolution: {integrity: sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-async-generator-functions@7.29.7':
+    resolution: {integrity: sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-async-to-generator@7.29.7':
+    resolution: {integrity: sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-block-scoped-functions@7.29.7':
+    resolution: {integrity: sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-block-scoping@7.29.7':
+    resolution: {integrity: sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-class-properties@7.29.7':
+    resolution: {integrity: sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-classes@7.29.7':
+    resolution: {integrity: sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-computed-properties@7.29.7':
+    resolution: {integrity: sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-destructuring@7.29.7':
+    resolution: {integrity: sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-flow-strip-types@7.29.7':
+    resolution: {integrity: sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-for-of@7.29.7':
+    resolution: {integrity: sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-function-name@7.29.7':
+    resolution: {integrity: sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-literals@7.29.7':
+    resolution: {integrity: sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-member-expression-literals@7.29.7':
+    resolution: {integrity: sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@7.29.7':
+    resolution: {integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7':
+    resolution: {integrity: sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7':
+    resolution: {integrity: sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-object-super@7.29.7':
+    resolution: {integrity: sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-optional-catch-binding@7.29.7':
+    resolution: {integrity: sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-optional-chaining@7.29.7':
+    resolution: {integrity: sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-parameters@7.29.7':
+    resolution: {integrity: sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-private-methods@7.29.7':
+    resolution: {integrity: sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-private-property-in-object@7.29.7':
+    resolution: {integrity: sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-property-literals@7.29.7':
+    resolution: {integrity: sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-display-name@7.29.7':
+    resolution: {integrity: sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx@7.29.7':
+    resolution: {integrity: sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-regenerator@7.29.7':
+    resolution: {integrity: sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-runtime@7.29.7':
+    resolution: {integrity: sha512-xmAscdE/AsqRW7vutbPNoUmu/nF5SrLKPs7aoJgEjo35lLKA/Bc0i2rMv/hr1+Y0o1bQCiVtith3u2vdgRL39Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-shorthand-properties@7.29.7':
+    resolution: {integrity: sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-spread@7.29.7':
+    resolution: {integrity: sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-sticky-regex@7.29.7':
+    resolution: {integrity: sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-template-literals@7.29.7':
+    resolution: {integrity: sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.29.7':
+    resolution: {integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-unicode-regex@7.29.7':
+    resolution: {integrity: sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@braintree/sanitize-url@7.1.2':
@@ -1021,6 +1533,51 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@expo/config-plugins@56.0.9':
+    resolution: {integrity: sha512-/6a/S9USwx8OC9tGjHxbviLFiBHyueN3aoNWMLvWDEJoZ1CIVW800ZBzwXq/FYNK2qzcN1LxFmQtzD1zeFQKNA==}
+
+  '@expo/config-types@56.0.6':
+    resolution: {integrity: sha512-4Y6Aum5J4Re5NnxGVofRNe1aDwUBOmWhQYkynZsqzRtX/zEA1ADUeyHXuEckv9YD9djiyT7bKtLt5gKL3mA6VQ==}
+
+  '@expo/config@56.0.9':
+    resolution: {integrity: sha512-/lqFeWGSrhpKJVP8tTN8LjuoIe8u8q2w7FzBL0C+wHgl+WM8l1qUIEYWy/sMvsG/NbpUIUsDHJRhQvOkU58eIw==}
+
+  '@expo/env@2.3.0':
+    resolution: {integrity: sha512-9HnnIbzwTTdbwSjNLXTk0fPm9ZwMJ7c1/31tsni8HZ8Q62KzYCyspahH+V365vg5J6lr001DzNwBxVWSaYCQLg==}
+    engines: {node: '>=20.12.0'}
+
+  '@expo/json-file@10.2.0':
+    resolution: {integrity: sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==}
+
+  '@expo/metro-config@56.0.14':
+    resolution: {integrity: sha512-O3CIHruaTJhswPAf/nf3i8QQ3f2jl+mEwSea1eb3khuplabdy/wTQz+JvHN8VGUFyg7JKwUGU1QfO6T3JiSQqA==}
+    peerDependencies:
+      expo: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
+  '@expo/metro@56.0.0':
+    resolution: {integrity: sha512-5gIgQHtEpjjvsjKfVtIv23a98LLRV0/y07PDShEwYSytAMlE3FSF8RHXqtHc1sUJL6dn7hnuIBpIbrLXXuVi0A==}
+
+  '@expo/plist@0.7.0':
+    resolution: {integrity: sha512-vrpryU1GoqSIRNqRB2D3IjXDmzNYfiQpEF6AH/xknlD7eiYmEDt3mb26V7cLcedcPG8PY/1xWHdBXVQJfEAh6Q==}
+
+  '@expo/require-utils@56.1.3':
+    resolution: {integrity: sha512-KyLeOn/zzQSvuPpV5YhB/FPKnpQytno4luN918bGdPDssLBoS3N/0UbC3W0rJAn9kSFu+XpfR81eABRVsSdfgQ==}
+    peerDependencies:
+      typescript: ^5.0.0 || ^5.0.0-0 || ^6.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@expo/sdk-runtime-versions@1.0.0':
+    resolution: {integrity: sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==}
+
+  '@expo/spawn-async@1.8.0':
+    resolution: {integrity: sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==}
+    engines: {node: '>=12'}
+
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -1216,6 +1773,14 @@ packages:
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1609,6 +2174,28 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@react-native/babel-plugin-codegen@0.86.0':
+    resolution: {integrity: sha512-qdsABWNW7uTll90l4Vh03gjeyu3WVDi2CyiiyvYGMRDcoYbjbQi6df3BMAm9lQI2yslZ1T14LlDDAsgTwNxplA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  '@react-native/babel-preset@0.86.0':
+    resolution: {integrity: sha512-bYQcWiPySNvF4dns9Ls9gMmwgq66ohvM9Fwc/Kn8r85t66UNHxch3p1QwPiSorDelFauZwJbgo9+ReibTgvpbA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    peerDependencies:
+      '@babel/core': '*'
+
+  '@react-native/codegen@0.86.0':
+    resolution: {integrity: sha512-uTs9DBo3+/lUqinsGZK0FKJRBVClrwMXoZToaDxE1Q2SL2e55vs2GwyZfIKzPl5uJnbu4PfFMIp0/mLXLWUMuA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    peerDependencies:
+      '@babel/core': '*'
+
+  '@react-native/metro-babel-transformer@0.86.0':
+    resolution: {integrity: sha512-SjKej3E5qIahqo/G+rSOrmJUQM44RyKtWtO+VfmKAAMoJWkBFomM22hTLKCIS5cdbIAJ9COAmU+KAi2wVSO0wQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    peerDependencies:
+      '@babel/core': '*'
+
   '@react-types/shared@3.34.0':
     resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
     peerDependencies:
@@ -1924,6 +2511,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
@@ -2214,6 +2804,15 @@ packages:
   '@types/http-proxy@1.17.17':
     resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
 
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2303,6 +2902,12 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
   '@typescript/typescript-aix-ppc64@7.0.1-rc':
     resolution: {integrity: sha512-oqq2ZfEJ7BQuufcC3QBQndZLPNyamYNHLao8lKRBeeSkZKypBqxPSgkzrcFZtbYcIaBvpiyUnQP9MT7DEYHWbw==}
@@ -2543,6 +3148,10 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
+
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
@@ -2555,6 +3164,10 @@ packages:
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
   acorn-import-phases@1.0.4:
@@ -2622,6 +3235,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansis@4.3.0:
     resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
     engines: {node: '>=14'}
@@ -2670,6 +3287,35 @@ packages:
   azure-devops-node-api@12.5.0:
     resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
 
+  babel-plugin-polyfill-corejs2@0.4.17:
+    resolution: {integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-polyfill-corejs3@0.13.0:
+    resolution: {integrity: sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-polyfill-regenerator@0.6.8:
+    resolution: {integrity: sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-syntax-hermes-parser@0.36.0:
+    resolution: {integrity: sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q==}
+
+  babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0:
+    resolution: {integrity: sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==}
+
+  babel-plugin-transform-flow-enums@0.0.2:
+    resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
+
+  babel-preset-fbjs@3.4.0:
+    resolution: {integrity: sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -2695,6 +3341,10 @@ packages:
     resolution: {integrity: sha512-K0ceQC+jQmB+NLDogO5HCpqmYf18AU2FxDbLdduYgkHYWZApFggkHE4dIaXCV1NqeoscESYXXo1GSkY6fA295w==}
     peerDependencies:
       react: '>=16.8'
+
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -2723,6 +3373,13 @@ packages:
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
+  bplist-creator@0.1.0:
+    resolution: {integrity: sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==}
+
+  bplist-parser@0.3.1:
+    resolution: {integrity: sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==}
+    engines: {node: '>= 5.10.0'}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -2741,6 +3398,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bser@2.1.1:
+    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
@@ -2789,6 +3449,10 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
@@ -2841,6 +3505,13 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
+  ci-info@2.0.0:
+    resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
@@ -2859,6 +3530,10 @@ packages:
   clipboardy@4.0.0:
     resolution: {integrity: sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==}
     engines: {node: '>=18'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -2943,6 +3618,10 @@ packages:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
     engines: {node: '>=0.8'}
 
+  connect@3.7.0:
+    resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
+    engines: {node: '>= 0.10.0'}
+
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
@@ -2951,12 +3630,18 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  core-js-compat@3.49.0:
+    resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -3290,6 +3975,10 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
@@ -3322,6 +4011,9 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  error-stack-parser@2.1.4:
+    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -3450,6 +4142,9 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
   express@4.22.2:
     resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
@@ -3480,6 +4175,9 @@ packages:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
     engines: {node: '>=0.8.0'}
 
+  fb-watchman@2.0.2:
+    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -3505,6 +4203,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@1.1.2:
+    resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
+    engines: {node: '>= 0.8'}
+
   finalhandler@1.3.2:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
@@ -3516,6 +4218,9 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  flow-enums-runtime@0.0.6:
+    resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -3561,6 +4266,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -3572,6 +4285,10 @@ packages:
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+
+  getenv@2.0.0:
+    resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
+    engines: {node: '>=6'}
 
   gh-pages@6.3.0:
     resolution: {integrity: sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==}
@@ -3697,6 +4414,30 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  hermes-estree@0.14.0:
+    resolution: {integrity: sha512-L6M67+0/eSEbt6Ha2XOBFXL++7MR34EOJMgm+j7YCaI4L/jZqrVAg6zYQKzbs1ZCFDLvEQpOgLlapTX4gpFriA==}
+
+  hermes-estree@0.33.3:
+    resolution: {integrity: sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==}
+
+  hermes-estree@0.35.0:
+    resolution: {integrity: sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==}
+
+  hermes-estree@0.36.0:
+    resolution: {integrity: sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==}
+
+  hermes-parser@0.14.0:
+    resolution: {integrity: sha512-pt+8uRiJhVlErY3fiXB3gKhZ72RxM6E1xRMpvfZ5n6Z5TQKQQXKorgRCRzoe02mmvLKBJFP5nPDGv75MWAgCTw==}
+
+  hermes-parser@0.33.3:
+    resolution: {integrity: sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==}
+
+  hermes-parser@0.35.0:
+    resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
+
+  hermes-parser@0.36.0:
+    resolution: {integrity: sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==}
+
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -3786,6 +4527,11 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  image-size@1.2.1:
+    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
+    engines: {node: '>=16.x'}
+    hasBin: true
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
@@ -3818,6 +4564,9 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -3931,9 +4680,25 @@ packages:
   javascript-natural-sort@0.7.1:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
 
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-util@29.7.0:
+    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-validate@29.7.0:
+    resolution: {integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
+
+  jest-worker@29.7.0:
+    resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -3945,6 +4710,9 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsc-safe-url@0.2.4:
+    resolution: {integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==}
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -4089,6 +4857,9 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -4109,6 +4880,9 @@ packages:
 
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
+  lodash.throttle@4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
@@ -4134,6 +4908,9 @@ packages:
     resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
     engines: {node: 20 || >=22}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -4148,6 +4925,9 @@ packages:
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
+
+  makeerror@1.0.12:
+    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -4255,6 +5035,77 @@ packages:
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+
+  metro-babel-transformer@0.84.4:
+    resolution: {integrity: sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-cache-key@0.84.4:
+    resolution: {integrity: sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-cache@0.84.4:
+    resolution: {integrity: sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-config@0.84.4:
+    resolution: {integrity: sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-core@0.84.4:
+    resolution: {integrity: sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-file-map@0.84.4:
+    resolution: {integrity: sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-minify-terser@0.84.4:
+    resolution: {integrity: sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-react-native-babel-preset@0.77.0:
+    resolution: {integrity: sha512-HPPD+bTxADtoE4y/4t1txgTQ1LVR6imOBy7RMHUsqMVTbekoi8Ph5YI9vKX2VMPtVWeFt0w9YnCSLPa76GcXsA==}
+    engines: {node: '>=18'}
+    deprecated: Use @react-native/babel-preset instead
+    peerDependencies:
+      '@babel/core': '*'
+
+  metro-react-native-babel-transformer@0.77.0:
+    resolution: {integrity: sha512-uCV1Kt4ebY9/hT7ayDGMDgIsrbyxiBHNP+q0LGxscOx3D/QODv1z+WhfC4Hy0/1wDCGV3l0EQrfLqM+7qpjsWA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@babel/core': '*'
+
+  metro-resolver@0.84.4:
+    resolution: {integrity: sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-runtime@0.84.4:
+    resolution: {integrity: sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-source-map@0.84.4:
+    resolution: {integrity: sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-symbolicate@0.84.4:
+    resolution: {integrity: sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    hasBin: true
+
+  metro-transform-plugins@0.84.4:
+    resolution: {integrity: sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-transform-worker@0.84.4:
+    resolution: {integrity: sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro@0.84.4:
+    resolution: {integrity: sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    hasBin: true
 
   mhchemparser@4.2.1:
     resolution: {integrity: sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==}
@@ -4545,6 +5396,9 @@ packages:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
 
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
   node-releases@2.0.46:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
     engines: {node: '>=18'}
@@ -4575,6 +5429,13 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  nullthrows@1.1.1:
+    resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
+  ob1@0.84.4:
+    resolution: {integrity: sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -4584,6 +5445,10 @@ packages:
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -4759,6 +5624,10 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
+  plist@3.1.1:
+    resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
+    engines: {node: '>=10.4.0'}
+
   pluralize@2.0.0:
     resolution: {integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==}
 
@@ -4797,6 +5666,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -4824,6 +5697,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   randexp@0.5.3:
     resolution: {integrity: sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==}
@@ -4863,11 +5739,22 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-medium-image-zoom@5.4.5:
     resolution: {integrity: sha512-58QSIRK6X3uw2fSTejJRnH0JuKTZl7ZJYX+sAMaYx4YTEm33gsNdnP5RuQSCnBiAvisQeErqZWAT31bR89WB6g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-refresh@0.14.2:
+    resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
+    engines: {node: '>=0.10.0'}
+
+  react-refresh@0.4.3:
+    resolution: {integrity: sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==}
+    engines: {node: '>=0.10.0'}
 
   react-stately@3.46.0:
     resolution: {integrity: sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==}
@@ -4922,6 +5809,13 @@ packages:
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
 
+  regenerate-unicode-properties@10.2.2:
+    resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
+    engines: {node: '>=4'}
+
+  regenerate@1.4.2:
+    resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -4930,6 +5824,17 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  regexpu-core@6.4.0:
+    resolution: {integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==}
+    engines: {node: '>=4'}
+
+  regjsgen@0.8.0:
+    resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
+
+  regjsparser@0.13.2:
+    resolution: {integrity: sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==}
+    hasBin: true
 
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
@@ -4977,12 +5882,23 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-workspace-root@2.0.1:
+    resolution: {integrity: sha512-nR23LHAvaI6aHtMg6RWoaHpdR4D881Nydkzi2CixINyg9T00KgaJdJI6Vwty+Ps8WLxZHuxsS0BseWjxSA4C+w==}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -5129,6 +6045,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  serialize-error@2.1.0:
+    resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
+    engines: {node: '>=0.10.0'}
+
   serve-index@1.9.2:
     resolution: {integrity: sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==}
     engines: {node: '>= 0.8.0'}
@@ -5188,6 +6108,9 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  simple-plist@1.3.1:
+    resolution: {integrity: sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==}
+
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
@@ -5204,6 +6127,10 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
+  slugify@1.6.9:
+    resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
+    engines: {node: '>=8.0.0'}
+
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
 
@@ -5213,6 +6140,10 @@ packages:
 
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
 
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -5248,6 +6179,9 @@ packages:
     resolution: {integrity: sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==}
     hasBin: true
 
+  stackframe@1.3.4:
+    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
@@ -5258,6 +6192,10 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  stream-buffers@2.2.0:
+    resolution: {integrity: sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==}
+    engines: {node: '>= 0.10.0'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -5430,6 +6368,9 @@ packages:
     peerDependencies:
       tslib: ^2
 
+  throat@5.0.0:
+    resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
+
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
@@ -5451,6 +6392,9 @@ packages:
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
+
+  tmpl@1.0.5:
+    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -5562,6 +6506,22 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  unicode-canonical-property-names-ecmascript@2.0.1:
+    resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
+    engines: {node: '>=4'}
+
+  unicode-match-property-ecmascript@2.0.0:
+    resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}
+    engines: {node: '>=4'}
+
+  unicode-match-property-value-ecmascript@2.2.1:
+    resolution: {integrity: sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==}
+    engines: {node: '>=4'}
+
+  unicode-property-aliases-ecmascript@2.2.0:
+    resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
+    engines: {node: '>=4'}
+
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
@@ -5646,6 +6606,11 @@ packages:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
+  uuid@7.0.3:
+    resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
@@ -5711,6 +6676,9 @@ packages:
       yaml:
         optional: true
 
+  vlq@1.0.1:
+    resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -5724,6 +6692,9 @@ packages:
 
   vscode-languageserver-types@3.17.5:
     resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  walker@1.0.8:
+    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
@@ -5811,6 +6782,10 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -5842,13 +6817,32 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xcode@3.0.1:
+    resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
+    engines: {node: '>=10.0.0'}
+
   xml2js@0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+
+  xml2js@0.6.0:
+    resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
     engines: {node: '>=4.0.0'}
 
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -5857,6 +6851,14 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
 
   yauzl@3.3.1:
     resolution: {integrity: sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==}
@@ -5998,6 +7000,34 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/generator@7.29.1':
     dependencies:
       '@babel/parser': 7.29.3
@@ -6006,21 +7036,532 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      regexpu-core: 6.4.0
+      semver: 6.3.1
+
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      debug: 4.4.3
+      lodash.debounce: 4.0.8
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-environment-visitor@7.24.7':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-wrap-function': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helper-wrap-function@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-export-default-from@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+
+  '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7)
+
+  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/core': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7)
+
+  '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7)
+
+  '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-export-default-from@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7)
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/template': 7.29.7
+
+  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
+
+  '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-display-name@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/traverse@7.29.0':
     dependencies:
@@ -6034,10 +7575,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@braintree/sanitize-url@7.1.2': {}
 
@@ -6219,6 +7777,130 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@expo/config-plugins@56.0.9(typescript@7.0.1-rc)':
+    dependencies:
+      '@expo/config-types': 56.0.6
+      '@expo/json-file': 10.2.0
+      '@expo/plist': 0.7.0
+      '@expo/require-utils': 56.1.3(typescript@7.0.1-rc)
+      '@expo/sdk-runtime-versions': 1.0.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+      glob: 13.0.6
+      semver: 7.8.1
+      slugify: 1.6.9
+      xcode: 3.0.1
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@expo/config-types@56.0.6': {}
+
+  '@expo/config@56.0.9(typescript@7.0.1-rc)':
+    dependencies:
+      '@expo/config-plugins': 56.0.9(typescript@7.0.1-rc)
+      '@expo/config-types': 56.0.6
+      '@expo/json-file': 10.2.0
+      '@expo/require-utils': 56.1.3(typescript@7.0.1-rc)
+      deepmerge: 4.3.1
+      getenv: 2.0.0
+      glob: 13.0.6
+      resolve-workspace-root: 2.0.1
+      semver: 7.8.1
+      slugify: 1.6.9
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@expo/env@2.3.0':
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/json-file@10.2.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      json5: 2.2.3
+
+  '@expo/metro-config@56.0.14(typescript@7.0.1-rc)':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.1
+      '@expo/config': 56.0.9(typescript@7.0.1-rc)
+      '@expo/env': 2.3.0
+      '@expo/json-file': 10.2.0
+      '@expo/metro': 56.0.0
+      '@expo/require-utils': 56.1.3(typescript@7.0.1-rc)
+      '@expo/spawn-async': 1.8.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      browserslist: 4.28.2
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+      glob: 13.0.6
+      hermes-parser: 0.33.3
+      jsc-safe-url: 0.2.4
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@expo/metro@56.0.0':
+    dependencies:
+      metro: 0.84.4
+      metro-babel-transformer: 0.84.4
+      metro-cache: 0.84.4
+      metro-cache-key: 0.84.4
+      metro-config: 0.84.4
+      metro-core: 0.84.4
+      metro-file-map: 0.84.4
+      metro-minify-terser: 0.84.4
+      metro-resolver: 0.84.4
+      metro-runtime: 0.84.4
+      metro-source-map: 0.84.4
+      metro-symbolicate: 0.84.4
+      metro-transform-plugins: 0.84.4
+      metro-transform-worker: 0.84.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@expo/plist@0.7.0':
+    dependencies:
+      '@xmldom/xmldom': 0.8.13
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
+
+  '@expo/require-utils@56.1.3(typescript@7.0.1-rc)':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+    optionalDependencies:
+      typescript: 7.0.1-rc
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/sdk-runtime-versions@1.0.0': {}
+
+  '@expo/spawn-async@1.8.0':
+    dependencies:
+      cross-spawn: 7.0.6
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -6383,6 +8065,19 @@ snapshots:
       '@swc/helpers': 0.5.21
 
   '@isaacs/cliui@9.0.0': {}
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+
+  '@jest/types@29.6.3':
+    dependencies:
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 20.19.41
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6757,6 +8452,71 @@ snapshots:
       react-aria: 3.48.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
 
+  '@react-native/babel-plugin-codegen@0.86.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@react-native/codegen': 0.86.0(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@react-native/babel-preset@0.86.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-regenerator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
+      '@react-native/babel-plugin-codegen': 0.86.0(@babel/core@7.29.7)
+      babel-plugin-syntax-hermes-parser: 0.36.0
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@react-native/codegen@0.86.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.3
+      hermes-parser: 0.36.0
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      tinyglobby: 0.2.16
+      yargs: 17.7.3
+
+  '@react-native/metro-babel-transformer@0.86.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@react-native/babel-preset': 0.86.0(@babel/core@7.29.7)
+      hermes-parser: 0.36.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@react-types/shared@3.34.0(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -7083,6 +8843,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@sinclair/typebox@0.27.10': {}
+
   '@sindresorhus/merge-streams@2.3.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -7404,6 +9166,16 @@ snapshots:
     dependencies:
       '@types/node': 20.19.41
 
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
   '@types/json-schema@7.0.15': {}
 
   '@types/katex@0.16.8': {}
@@ -7496,6 +9268,12 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.41
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
 
   '@typescript/typescript-aix-ppc64@7.0.1-rc':
     optional: true
@@ -7736,6 +9514,8 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@xmldom/xmldom@0.8.13': {}
+
   '@xmldom/xmldom@0.9.10': {}
 
   '@xtuc/ieee754@1.2.0': {}
@@ -7746,6 +9526,11 @@ snapshots:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
 
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
@@ -7797,6 +9582,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansis@4.3.0: {}
 
   anymatch@3.1.3:
@@ -7833,6 +9620,75 @@ snapshots:
       tunnel: 0.0.6
       typed-rest-client: 1.8.11
 
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      core-js-compat: 3.49.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-syntax-hermes-parser@0.36.0:
+    dependencies:
+      hermes-parser: 0.36.0
+
+  babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
+
+  babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.7):
+    dependencies:
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - '@babel/core'
+
+  babel-preset-fbjs@3.4.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7)
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoped-functions': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-literals': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-member-expression-literals': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-super': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-property-literals': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-spread': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7)
+      babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
+    transitivePeerDependencies:
+      - supports-color
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
@@ -7849,6 +9705,8 @@ snapshots:
     dependencies:
       mathjax-full: 3.2.2
       react: 18.3.1
+
+  big-integer@1.6.52: {}
 
   binary-extensions@2.3.0: {}
 
@@ -7890,6 +9748,14 @@ snapshots:
 
   boundary@2.0.0: {}
 
+  bplist-creator@0.1.0:
+    dependencies:
+      stream-buffers: 2.2.0
+
+  bplist-parser@0.3.1:
+    dependencies:
+      big-integer: 1.6.52
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -7914,6 +9780,10 @@ snapshots:
       electron-to-chromium: 1.5.361
       node-releases: 2.0.46
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bser@2.1.1:
+    dependencies:
+      node-int64: 0.4.0
 
   buffer-crc32@0.2.13: {}
 
@@ -7978,6 +9848,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001793: {}
 
@@ -8044,6 +9916,10 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
+  ci-info@2.0.0: {}
+
+  ci-info@3.9.0: {}
+
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -8059,6 +9935,12 @@ snapshots:
       execa: 8.0.1
       is-wsl: 3.1.1
       is64bit: 2.0.0
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clone@1.0.4: {}
 
@@ -8122,15 +10004,30 @@ snapshots:
 
   connect-history-api-fallback@2.0.0: {}
 
+  connect@3.7.0:
+    dependencies:
+      debug: 2.6.9
+      finalhandler: 1.1.2
+      parseurl: 1.3.3
+      utils-merge: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
 
   content-type@1.0.5: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-signature@1.0.7: {}
 
   cookie@0.7.2: {}
+
+  core-js-compat@3.49.0:
+    dependencies:
+      browserslist: 4.28.2
 
   core-util-is@1.0.3: {}
 
@@ -8469,6 +10366,8 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  encodeurl@1.0.2: {}
+
   encodeurl@2.0.0: {}
 
   encoding-sniffer@0.2.1:
@@ -8497,6 +10396,10 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  error-stack-parser@2.1.4:
+    dependencies:
+      stackframe: 1.3.4
 
   es-define-property@1.0.1: {}
 
@@ -8676,6 +10579,8 @@ snapshots:
   expand-template@2.0.3:
     optional: true
 
+  exponential-backoff@3.1.3: {}
+
   express@4.22.2:
     dependencies:
       accepts: 1.3.8
@@ -8740,6 +10645,10 @@ snapshots:
     dependencies:
       websocket-driver: 0.7.4
 
+  fb-watchman@2.0.2:
+    dependencies:
+      bser: 2.1.1
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -8759,6 +10668,18 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@1.1.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.3.0
+      parseurl: 1.3.3
+      statuses: 1.5.0
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   finalhandler@1.3.2:
     dependencies:
@@ -8782,6 +10703,8 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+
+  flow-enums-runtime@0.0.6: {}
 
   follow-redirects@1.16.0: {}
 
@@ -8818,6 +10741,10 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -8837,6 +10764,8 @@ snapshots:
       es-object-atoms: 1.1.2
 
   get-stream@8.0.1: {}
+
+  getenv@2.0.0: {}
 
   gh-pages@6.3.0:
     dependencies:
@@ -9067,6 +10996,30 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  hermes-estree@0.14.0: {}
+
+  hermes-estree@0.33.3: {}
+
+  hermes-estree@0.35.0: {}
+
+  hermes-estree@0.36.0: {}
+
+  hermes-parser@0.14.0:
+    dependencies:
+      hermes-estree: 0.14.0
+
+  hermes-parser@0.33.3:
+    dependencies:
+      hermes-estree: 0.33.3
+
+  hermes-parser@0.35.0:
+    dependencies:
+      hermes-estree: 0.35.0
+
+  hermes-parser@0.36.0:
+    dependencies:
+      hermes-estree: 0.36.0
+
   hosted-git-info@2.8.9: {}
 
   hosted-git-info@4.1.0:
@@ -9171,6 +11124,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  image-size@1.2.1:
+    dependencies:
+      queue: 6.0.2
+
   import-meta-resolve@4.2.0: {}
 
   import2@1.0.3: {}
@@ -9209,6 +11166,10 @@ snapshots:
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
+
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
 
   ipaddr.js@1.9.1: {}
 
@@ -9293,9 +11254,36 @@ snapshots:
 
   javascript-natural-sort@0.7.1: {}
 
+  jest-get-type@29.6.3: {}
+
+  jest-util@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.41
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.2
+
+  jest-validate@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      leven: 3.1.0
+      pretty-format: 29.7.0
+
   jest-worker@27.5.1:
     dependencies:
       '@types/node': 20.19.41
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  jest-worker@29.7.0:
+    dependencies:
+      '@types/node': 20.19.41
+      jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -9306,6 +11294,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsc-safe-url@0.2.4: {}
 
   jsesc@3.1.0: {}
 
@@ -9438,6 +11428,8 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
+  lodash.debounce@4.0.8: {}
+
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -9451,6 +11443,8 @@ snapshots:
   lodash.isstring@4.0.1: {}
 
   lodash.once@4.1.1: {}
+
+  lodash.throttle@4.1.1: {}
 
   lodash.truncate@4.4.2: {}
 
@@ -9471,6 +11465,10 @@ snapshots:
 
   lru-cache@11.5.0: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -9484,6 +11482,10 @@ snapshots:
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
+
+  makeerror@1.0.12:
+    dependencies:
+      tmpl: 1.0.5
 
   markdown-extensions@2.0.0: {}
 
@@ -9747,6 +11749,234 @@ snapshots:
       uuid: 14.0.0
 
   methods@1.1.2: {}
+
+  metro-babel-transformer@0.84.4:
+    dependencies:
+      '@babel/core': 7.29.7
+      flow-enums-runtime: 0.0.6
+      hermes-parser: 0.35.0
+      metro-cache-key: 0.84.4
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-cache-key@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
+  metro-cache@0.84.4:
+    dependencies:
+      exponential-backoff: 3.1.3
+      flow-enums-runtime: 0.0.6
+      https-proxy-agent: 7.0.6
+      metro-core: 0.84.4
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-config@0.84.4:
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.84.4
+      metro-cache: 0.84.4
+      metro-core: 0.84.4
+      metro-runtime: 0.84.4
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro-core@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      lodash.throttle: 4.1.1
+      metro-resolver: 0.84.4
+
+  metro-file-map@0.84.4:
+    dependencies:
+      debug: 4.4.3
+      fb-watchman: 2.0.2
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      micromatch: 4.0.8
+      nullthrows: 1.1.1
+      walker: 1.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-minify-terser@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      terser: 5.48.0
+
+  metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.29.7)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.29.7)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-literals': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-spread': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/template': 7.28.6
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7)
+      react-refresh: 0.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-react-native-babel-transformer@0.77.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      babel-preset-fbjs: 3.4.0(@babel/core@7.29.7)
+      hermes-parser: 0.14.0
+      metro-react-native-babel-preset: 0.77.0(@babel/core@7.29.7)
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-resolver@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
+  metro-runtime@0.84.4:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      flow-enums-runtime: 0.0.6
+
+  metro-source-map@0.84.4:
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-symbolicate: 0.84.4
+      nullthrows: 1.1.1
+      ob1: 0.84.4
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-symbolicate@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-source-map: 0.84.4
+      nullthrows: 1.1.1
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-plugins@0.84.4:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.1
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      flow-enums-runtime: 0.0.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-worker@0.84.4:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      flow-enums-runtime: 0.0.6
+      metro: 0.84.4
+      metro-babel-transformer: 0.84.4
+      metro-cache: 0.84.4
+      metro-cache-key: 0.84.4
+      metro-minify-terser: 0.84.4
+      metro-source-map: 0.84.4
+      metro-transform-plugins: 0.84.4
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.84.4:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 2.0.0
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.35.0
+      image-size: 1.2.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.84.4
+      metro-cache: 0.84.4
+      metro-cache-key: 0.84.4
+      metro-config: 0.84.4
+      metro-core: 0.84.4
+      metro-file-map: 0.84.4
+      metro-resolver: 0.84.4
+      metro-runtime: 0.84.4
+      metro-source-map: 0.84.4
+      metro-symbolicate: 0.84.4
+      metro-transform-plugins: 0.84.4
+      metro-transform-worker: 0.84.4
+      mime-types: 3.0.2
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.11
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   mhchemparser@4.2.1: {}
 
@@ -10228,6 +12458,8 @@ snapshots:
 
   node-forge@1.4.0: {}
 
+  node-int64@0.4.0: {}
+
   node-releases@2.0.46: {}
 
   node-sarif-builder@3.4.0:
@@ -10260,11 +12492,21 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  nullthrows@1.1.1: {}
+
+  ob1@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
   object-inspect@1.13.4: {}
 
   obuf@1.1.2: {}
 
   ohash@2.0.11: {}
+
+  on-finished@2.3.0:
+    dependencies:
+      ee-first: 1.1.1
 
   on-finished@2.4.1:
     dependencies:
@@ -10455,6 +12697,12 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  plist@3.1.1:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
+
   pluralize@2.0.0: {}
 
   pluralize@8.0.0: {}
@@ -10505,6 +12753,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   process-nextick-args@2.0.1: {}
 
   process@0.11.10: {}
@@ -10529,6 +12783,10 @@ snapshots:
       side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
+
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
 
   randexp@0.5.3:
     dependencies:
@@ -10590,10 +12848,16 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-is@18.3.1: {}
+
   react-medium-image-zoom@5.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  react-refresh@0.14.2: {}
+
+  react-refresh@0.4.3: {}
 
   react-stately@3.46.0(react@18.3.1):
     dependencies:
@@ -10680,6 +12944,12 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  regenerate-unicode-properties@10.2.2:
+    dependencies:
+      regenerate: 1.4.2
+
+  regenerate@1.4.2: {}
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -10689,6 +12959,21 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  regexpu-core@6.4.0:
+    dependencies:
+      regenerate: 1.4.2
+      regenerate-unicode-properties: 10.2.2
+      regjsgen: 0.8.0
+      regjsparser: 0.13.2
+      unicode-match-property-ecmascript: 2.0.0
+      unicode-match-property-value-ecmascript: 2.2.1
+
+  regjsgen@0.8.0: {}
+
+  regjsparser@0.13.2:
+    dependencies:
+      jsesc: 3.1.0
 
   rehype-katex@7.0.1:
     dependencies:
@@ -10803,9 +13088,15 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   requires-port@1.0.0: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-workspace-root@2.0.1: {}
 
   resolve@1.22.12:
     dependencies:
@@ -10994,6 +13285,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  serialize-error@2.1.0: {}
+
   serve-index@1.9.2:
     dependencies:
       accepts: 1.3.8
@@ -11110,6 +13403,12 @@ snapshots:
       simple-concat: 1.0.1
     optional: true
 
+  simple-plist@1.3.1:
+    dependencies:
+      bplist-creator: 0.1.0
+      bplist-parser: 0.3.1
+      plist: 3.1.1
+
   sirv@2.0.4:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -11126,6 +13425,8 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
+  slugify@1.6.9: {}
+
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
@@ -11138,6 +13439,8 @@ snapshots:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
+
+  source-map@0.5.7: {}
 
   source-map@0.6.1: {}
 
@@ -11186,11 +13489,15 @@ snapshots:
       commander: 13.1.0
       wicked-good-xpath: 1.3.0
 
+  stackframe@1.3.4: {}
+
   state-local@1.0.7: {}
 
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
+
+  stream-buffers@2.2.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -11341,6 +13648,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  throat@5.0.0: {}
+
   through@2.3.8: {}
 
   thunky@1.1.0: {}
@@ -11359,6 +13668,8 @@ snapshots:
       clipboardy: 4.0.0
 
   tmp@0.2.5: {}
+
+  tmpl@1.0.5: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -11476,6 +13787,17 @@ snapshots:
 
   undici@7.25.0: {}
 
+  unicode-canonical-property-names-ecmascript@2.0.1: {}
+
+  unicode-match-property-ecmascript@2.0.0:
+    dependencies:
+      unicode-canonical-property-names-ecmascript: 2.0.1
+      unicode-property-aliases-ecmascript: 2.2.0
+
+  unicode-match-property-value-ecmascript@2.2.1: {}
+
+  unicode-property-aliases-ecmascript@2.2.0: {}
+
   unicorn-magic@0.1.0: {}
 
   unicorn-magic@0.3.0: {}
@@ -11575,6 +13897,8 @@ snapshots:
 
   uuid@14.0.0: {}
 
+  uuid@7.0.3: {}
+
   uuid@8.3.2: {}
 
   validate-npm-package-license@3.0.4:
@@ -11617,6 +13941,8 @@ snapshots:
       terser: 5.48.0
       yaml: 2.9.0
 
+  vlq@1.0.1: {}
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageclient@9.0.1:
@@ -11631,6 +13957,10 @@ snapshots:
       vscode-languageserver-types: 3.17.5
 
   vscode-languageserver-types@3.17.5: {}
+
+  walker@1.0.8:
+    dependencies:
+      makeerror: 1.0.12
 
   watchpack@2.5.1:
     dependencies:
@@ -11786,6 +14116,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2:
     optional: true
 
@@ -11797,16 +14133,44 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
+  xcode@3.0.1:
+    dependencies:
+      simple-plist: 1.3.1
+      uuid: 7.0.3
+
   xml2js@0.5.0:
+    dependencies:
+      sax: 1.6.0
+      xmlbuilder: 11.0.1
+
+  xml2js@0.6.0:
     dependencies:
       sax: 1.6.0
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
 
+  xmlbuilder@15.1.1: {}
+
+  y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
+
   yallist@4.0.0: {}
 
   yaml@2.9.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yauzl@3.3.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ttsc
 
+  tests/test-metro:
+    devDependencies:
+      '@ttsc/testing':
+        specifier: workspace:*
+        version: link:../utils
+      '@types/node':
+        specifier: catalog:utils
+        version: 25.9.1
+      ttsc:
+        specifier: workspace:*
+        version: link:../../packages/ttsc
+      typescript:
+        specifier: catalog:typescript
+        version: 7.0.1-rc
+
   tests/test-paths:
     devDependencies:
       '@ttsc/paths':

--- a/scripts/build-current.cjs
+++ b/scripts/build-current.cjs
@@ -14,6 +14,7 @@ run(["--filter", "ttsc", "build"]);
 run(["--filter", "@ttsc/banner", "build"]);
 run(["--filter", "@ttsc/lint", "build"]);
 run(["--filter", "@ttsc/unplugin", "build"]);
+run(["--filter", "@ttsc/metro", "build"]);
 run(["--filter", "@ttsc/vscode", "build"]);
 run(["--filter", "lint-contributor-demo", "build"]);
 run(["--dir", platformDir, "build"]);

--- a/scripts/build-platforms.cjs
+++ b/scripts/build-platforms.cjs
@@ -9,6 +9,7 @@ run(["--filter", "ttsc", "build"]);
 run(["--filter", "@ttsc/banner", "build"]);
 run(["--filter", "@ttsc/lint", "build"]);
 run(["--filter", "@ttsc/unplugin", "build"]);
+run(["--filter", "@ttsc/metro", "build"]);
 run(["--filter", "@ttsc/wasm", "build"]);
 run(["--filter", "@ttsc/playground", "build"]);
 run(["--filter", "@ttsc/vscode", "build"]);

--- a/tests/test-metro/package.json
+++ b/tests/test-metro/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "name": "@ttsc/test-metro",
+  "version": "0.16.3",
+  "description": "Adapter and transform tests for @ttsc/metro.",
+  "type": "module",
+  "scripts": {
+    "start": "node --disable-warning=ExperimentalWarning --import ../../scripts/register-extensionless-ts-loader.mjs --experimental-transform-types src/index.ts"
+  },
+  "devDependencies": {
+    "@ttsc/testing": "workspace:*",
+    "@types/node": "catalog:utils",
+    "ttsc": "workspace:*",
+    "typescript": "catalog:typescript"
+  }
+}

--- a/tests/test-metro/src/features/build/test_cjs_build_loads_and_runs_under_require.ts
+++ b/tests/test-metro/src/features/build/test_cjs_build_loads_and_runs_under_require.ts
@@ -1,0 +1,18 @@
+import { assertCjsBuildLoadsAndRuns } from "../../internal/metro-cjs";
+
+/**
+ * Verifies the CommonJS build loads and runs under `require`.
+ *
+ * Metro loads `transformer.babelTransformerPath` with `require`, i.e. the CJS
+ * build, whose `import.meta.url`/`createRequire` rely on Rollup's CJS rewrite.
+ * The ESM-only tests can't catch a broken rewrite, so this is the negative twin
+ * across the build-format dimension: it pins that the actual production module
+ * loads and its exports run.
+ *
+ * 1. Require the CJS index and call withTtsc.
+ * 2. Require the CJS transformer and assert callable transform/getCacheKey.
+ * 3. Run getCacheKey through the CJS module and assert a valid digest.
+ */
+export const test_cjs_build_loads_and_runs_under_require = async () => {
+  await assertCjsBuildLoadsAndRuns();
+};

--- a/tests/test-metro/src/features/config/test_withttsc_adds_a_transformer_block_when_config_has_no_transformer.ts
+++ b/tests/test-metro/src/features/config/test_withttsc_adds_a_transformer_block_when_config_has_no_transformer.ts
@@ -1,0 +1,19 @@
+import { assertWithTtscAddsTransformerWhenAbsent } from "../../internal/metro-config";
+
+/**
+ * Verifies withTtsc adds a transformer block when the config has no
+ * transformer.
+ *
+ * A Metro config need not already contain a `transformer` key. withTtsc spreads
+ * `config.transformer` (possibly `undefined`) and must still produce a valid
+ * `transformer.babelTransformerPath` without crashing, while preserving
+ * unrelated top-level keys.
+ *
+ * 1. Call withTtsc on a config that has no `transformer` key.
+ * 2. Assert an unrelated top-level key survives.
+ * 3. Assert `transformer.babelTransformerPath` is set to the package transformer.
+ */
+export const test_withttsc_adds_a_transformer_block_when_config_has_no_transformer =
+  async () => {
+    await assertWithTtscAddsTransformerWhenAbsent();
+  };

--- a/tests/test-metro/src/features/config/test_withttsc_preserves_existing_metro_config_fields.ts
+++ b/tests/test-metro/src/features/config/test_withttsc_preserves_existing_metro_config_fields.ts
@@ -5,7 +5,7 @@ import { assertWithTtscPreservesExistingConfig } from "../../internal/metro-conf
  *
  * Real Metro configs (especially Expo's `getDefaultConfig`) carry many resolver
  * and transformer settings. withTtsc must add only `babelTransformerPath` and
- * leave everything else — including existing `transformer` fields — intact,
+ * leave everything else, including existing `transformer` fields, intact,
  * rather than replacing the transformer block wholesale.
  *
  * 1. Wrap a config carrying unrelated top-level keys and existing transformer

--- a/tests/test-metro/src/features/config/test_withttsc_preserves_existing_metro_config_fields.ts
+++ b/tests/test-metro/src/features/config/test_withttsc_preserves_existing_metro_config_fields.ts
@@ -1,0 +1,19 @@
+import { assertWithTtscPreservesExistingConfig } from "../../internal/metro-config";
+
+/**
+ * Verifies withTtsc preserves existing Metro config fields.
+ *
+ * Real Metro configs (especially Expo's `getDefaultConfig`) carry many resolver
+ * and transformer settings. withTtsc must add only `babelTransformerPath` and
+ * leave everything else — including existing `transformer` fields — intact,
+ * rather than replacing the transformer block wholesale.
+ *
+ * 1. Wrap a config carrying unrelated top-level keys and existing transformer
+ *    fields.
+ * 2. Assert the unrelated keys and existing transformer fields survive unchanged.
+ * 3. Assert the original object was not mutated in place.
+ */
+export const test_withttsc_preserves_existing_metro_config_fields =
+  async () => {
+    await assertWithTtscPreservesExistingConfig();
+  };

--- a/tests/test-metro/src/features/config/test_withttsc_publishes_resolved_options_to_the_worker_env.ts
+++ b/tests/test-metro/src/features/config/test_withttsc_publishes_resolved_options_to_the_worker_env.ts
@@ -1,0 +1,19 @@
+import { assertWithTtscPublishesWorkerEnv } from "../../internal/metro-config";
+
+/**
+ * Verifies withTtsc publishes resolved options to the worker env.
+ *
+ * WithTtsc runs in the Metro config process, but the transformer runs in
+ * Metro's worker processes, which never see the call. The options therefore
+ * have to travel through the inherited `TTSC_METRO_OPTIONS` env var; if
+ * withTtsc failed to publish them, worker-side overrides (project, plugins,
+ * include/exclude) would be silently lost.
+ *
+ * 1. Call withTtsc with explicit options and assert the env var holds their JSON.
+ * 2. Call withTtsc with no options.
+ * 3. Assert the env var is the explicit empty payload `"{}"`, never undefined.
+ */
+export const test_withttsc_publishes_resolved_options_to_the_worker_env =
+  async () => {
+    await assertWithTtscPublishesWorkerEnv();
+  };

--- a/tests/test-metro/src/features/config/test_withttsc_sets_the_babel_transformer_path_to_the_package_transformer.ts
+++ b/tests/test-metro/src/features/config/test_withttsc_sets_the_babel_transformer_path_to_the_package_transformer.ts
@@ -1,0 +1,18 @@
+import { assertWithTtscSetsBabelTransformerPath } from "../../internal/metro-config";
+
+/**
+ * Verifies withTtsc sets the babel transformer path to the package transformer.
+ *
+ * Metro discovers a custom transformer through
+ * `transformer.babelTransformerPath` and requires it by absolute path. If
+ * withTtsc set a relative, missing, or wrong path, Metro would silently keep
+ * its default Babel transformer and the ttsc plugin pass would never run.
+ *
+ * 1. Wrap a minimal Metro config with withTtsc.
+ * 2. Read `transformer.babelTransformerPath` from the result.
+ * 3. Assert it is an absolute path ending in `transformer.js` that exists on disk.
+ */
+export const test_withttsc_sets_the_babel_transformer_path_to_the_package_transformer =
+  async () => {
+    await assertWithTtscSetsBabelTransformerPath();
+  };

--- a/tests/test-metro/src/features/options/test_options_coerce_invalid_include_exclude_to_string_arrays.ts
+++ b/tests/test-metro/src/features/options/test_options_coerce_invalid_include_exclude_to_string_arrays.ts
@@ -1,0 +1,20 @@
+import { assertInvalidIncludeExcludeCoerced } from "../../internal/metro-options";
+
+/**
+ * Verifies invalid include/exclude env values are coerced to string arrays.
+ *
+ * `include`/`exclude` cross the config→worker boundary as untrusted JSON. A
+ * bare string (a common mistake) or non-string entries would make
+ * `shouldTransform` call `.some` on a non-array — crashing every worker. The
+ * resolver must coerce to a filtered `string[]` while still resolving valid
+ * sibling fields.
+ *
+ * 1. Set the env to a payload with a string `exclude` and a mixed-type `include`.
+ * 2. Resolve options.
+ * 3. Assert `include` keeps only strings, `exclude` becomes `[]`, and
+ *    `plugins:false` survives.
+ */
+export const test_options_coerce_invalid_include_exclude_to_string_arrays =
+  async () => {
+    await assertInvalidIncludeExcludeCoerced();
+  };

--- a/tests/test-metro/src/features/options/test_options_coerce_invalid_include_exclude_to_string_arrays.ts
+++ b/tests/test-metro/src/features/options/test_options_coerce_invalid_include_exclude_to_string_arrays.ts
@@ -5,7 +5,7 @@ import { assertInvalidIncludeExcludeCoerced } from "../../internal/metro-options
  *
  * `include`/`exclude` cross the config→worker boundary as untrusted JSON. A
  * bare string (a common mistake) or non-string entries would make
- * `shouldTransform` call `.some` on a non-array — crashing every worker. The
+ * `shouldTransform` call `.some` on a non-array, crashing every worker. The
  * resolver must coerce to a filtered `string[]` while still resolving valid
  * sibling fields.
  *

--- a/tests/test-metro/src/features/options/test_options_default_to_tsconfig_discovery_when_env_is_absent.ts
+++ b/tests/test-metro/src/features/options/test_options_default_to_tsconfig_discovery_when_env_is_absent.ts
@@ -1,0 +1,18 @@
+import { assertOptionsDefaultWhenEnvAbsent } from "../../internal/metro-options";
+
+/**
+ * Verifies options default to tsconfig discovery when the env is absent.
+ *
+ * `withTtsc(config)` with no options is the common case: the transformer should
+ * auto-discover `tsconfig.json` and run its configured plugins. That requires
+ * the resolver to yield no project/plugin overrides and empty include/exclude
+ * when the env var is unset.
+ *
+ * 1. Clear the env var.
+ * 2. Resolve options.
+ * 3. Assert no project/plugin/upstream override and empty include/exclude.
+ */
+export const test_options_default_to_tsconfig_discovery_when_env_is_absent =
+  async () => {
+    await assertOptionsDefaultWhenEnvAbsent();
+  };

--- a/tests/test-metro/src/features/options/test_options_fall_back_to_defaults_on_empty_string_env.ts
+++ b/tests/test-metro/src/features/options/test_options_fall_back_to_defaults_on_empty_string_env.ts
@@ -1,0 +1,17 @@
+import { assertEmptyStringEnvFallsBackToDefaults } from "../../internal/metro-options";
+
+/**
+ * Verifies options fall back to defaults on an empty-string env payload.
+ *
+ * An empty string is distinct from an unset variable; it exercises the
+ * `raw.length === 0` half of the guard in `parse`. It must degrade to the
+ * auto-discovery defaults, not throw or produce a wrong shape.
+ *
+ * 1. Set the env var to "".
+ * 2. Resolve options.
+ * 3. Assert defaults: no project override, empty include/exclude.
+ */
+export const test_options_fall_back_to_defaults_on_empty_string_env =
+  async () => {
+    await assertEmptyStringEnvFallsBackToDefaults();
+  };

--- a/tests/test-metro/src/features/options/test_options_fall_back_to_defaults_on_malformed_env.ts
+++ b/tests/test-metro/src/features/options/test_options_fall_back_to_defaults_on_malformed_env.ts
@@ -1,0 +1,17 @@
+import { assertOptionsFallBackOnMalformedEnv } from "../../internal/metro-options";
+
+/**
+ * Verifies options fall back to defaults on a malformed env payload.
+ *
+ * The env var is process state that a stray export or a partial write could
+ * corrupt. A parse failure must degrade to the auto-discovery defaults rather
+ * than throw, otherwise one bad value would crash every Metro worker on the
+ * first file.
+ *
+ * 1. Set the env var to invalid JSON.
+ * 2. Resolve options.
+ * 3. Assert defaults: no overrides and empty include/exclude.
+ */
+export const test_options_fall_back_to_defaults_on_malformed_env = async () => {
+  await assertOptionsFallBackOnMalformedEnv();
+};

--- a/tests/test-metro/src/features/options/test_options_fall_back_to_defaults_on_non_object_env.ts
+++ b/tests/test-metro/src/features/options/test_options_fall_back_to_defaults_on_non_object_env.ts
@@ -3,8 +3,8 @@ import { assertNonObjectEnvFallsBackToDefaults } from "../../internal/metro-opti
 /**
  * Verifies options fall back to defaults on a non-object env payload.
  *
- * Valid JSON that is not a plain object — an array, `null`, a number, a string,
- * a boolean — must degrade to defaults via the non-object branch of `parse`
+ * Valid JSON that is not a plain object (an array, `null`, a number, a string,
+ * a boolean) must degrade to defaults via the non-object branch of `parse`
  * (distinct from the malformed-JSON catch). An array in particular must not
  * slip through the `typeof === "object"` guard and reach the worker.
  *

--- a/tests/test-metro/src/features/options/test_options_fall_back_to_defaults_on_non_object_env.ts
+++ b/tests/test-metro/src/features/options/test_options_fall_back_to_defaults_on_non_object_env.ts
@@ -1,0 +1,18 @@
+import { assertNonObjectEnvFallsBackToDefaults } from "../../internal/metro-options";
+
+/**
+ * Verifies options fall back to defaults on a non-object env payload.
+ *
+ * Valid JSON that is not a plain object — an array, `null`, a number, a string,
+ * a boolean — must degrade to defaults via the non-object branch of `parse`
+ * (distinct from the malformed-JSON catch). An array in particular must not
+ * slip through the `typeof === "object"` guard and reach the worker.
+ *
+ * 1. For each non-object JSON payload, set the env var.
+ * 2. Resolve options.
+ * 3. Assert defaults: no overrides, empty include/exclude.
+ */
+export const test_options_fall_back_to_defaults_on_non_object_env =
+  async () => {
+    await assertNonObjectEnvFallsBackToDefaults();
+  };

--- a/tests/test-metro/src/features/options/test_options_preserve_plugins_false_through_the_env.ts
+++ b/tests/test-metro/src/features/options/test_options_preserve_plugins_false_through_the_env.ts
@@ -1,0 +1,17 @@
+import { assertOptionsPreservePluginsFalse } from "../../internal/metro-options";
+
+/**
+ * Verifies options preserve `plugins: false` through the env.
+ *
+ * The negative twin of the round-trip test. `plugins: false` means "disable all
+ * project plugins"; a falsy presence check would collapse it back to
+ * `undefined` ("auto-read project plugins"), silently re-enabling plugins
+ * inside the worker.
+ *
+ * 1. Serialize `{ plugins: false }` into the env var.
+ * 2. Resolve options back.
+ * 3. Assert `ttsc.plugins` is strictly `false`, not `undefined`.
+ */
+export const test_options_preserve_plugins_false_through_the_env = async () => {
+  await assertOptionsPreservePluginsFalse();
+};

--- a/tests/test-metro/src/features/options/test_options_round_trip_through_the_worker_env_variable.ts
+++ b/tests/test-metro/src/features/options/test_options_round_trip_through_the_worker_env_variable.ts
@@ -1,0 +1,19 @@
+import { assertOptionsRoundTripThroughEnv } from "../../internal/metro-options";
+
+/**
+ * Verifies options round-trip through the worker env variable.
+ *
+ * The worker transformer reconstructs its configuration solely from the
+ * serialized env payload. Every field — the ttsc overlay (project,
+ * compilerOptions, plugins) and the Metro-specific include/exclude/
+ * upstreamTransformer — must survive the serialize → env → resolve trip, or a
+ * caller's override would be dropped inside the worker.
+ *
+ * 1. Serialize a fully-populated option set into the env var.
+ * 2. Resolve it back with resolveOptionsFromEnv.
+ * 3. Assert every field matches the original.
+ */
+export const test_options_round_trip_through_the_worker_env_variable =
+  async () => {
+    await assertOptionsRoundTripThroughEnv();
+  };

--- a/tests/test-metro/src/features/options/test_options_round_trip_through_the_worker_env_variable.ts
+++ b/tests/test-metro/src/features/options/test_options_round_trip_through_the_worker_env_variable.ts
@@ -4,9 +4,9 @@ import { assertOptionsRoundTripThroughEnv } from "../../internal/metro-options";
  * Verifies options round-trip through the worker env variable.
  *
  * The worker transformer reconstructs its configuration solely from the
- * serialized env payload. Every field — the ttsc overlay (project,
+ * serialized env payload. Every field, the ttsc overlay (project,
  * compilerOptions, plugins) and the Metro-specific include/exclude/
- * upstreamTransformer — must survive the serialize → env → resolve trip, or a
+ * upstreamTransformer, must survive the serialize → env → resolve trip, or a
  * caller's override would be dropped inside the worker.
  *
  * 1. Serialize a fully-populated option set into the env var.

--- a/tests/test-metro/src/features/transform/test_cache_key_forwards_and_folds_the_upstream_key.ts
+++ b/tests/test-metro/src/features/transform/test_cache_key_forwards_and_folds_the_upstream_key.ts
@@ -1,0 +1,19 @@
+import { assertCacheKeyForwardsAndFoldsUpstreamKey } from "../../internal/metro-transform";
+
+/**
+ * Verifies getCacheKey forwards Metro's args to, and folds in, the upstream
+ * key.
+ *
+ * Metro calls getCacheKey with `{ projectRoot, enableBabelRCLookup }`. The
+ * adapter must forward those to the upstream transformer's getCacheKey so a
+ * `babel.config.js`/projectRoot change still busts the cache, and must still
+ * produce a valid key when the upstream exposes no getCacheKey.
+ *
+ * 1. Compute getCacheKey with two different forwarded projectRoots; assert they
+ *    differ.
+ * 2. Compute getCacheKey against an upstream that has no getCacheKey.
+ * 3. Assert that still yields a valid 64-char hex digest.
+ */
+export const test_cache_key_forwards_and_folds_the_upstream_key = async () => {
+  await assertCacheKeyForwardsAndFoldsUpstreamKey();
+};

--- a/tests/test-metro/src/features/transform/test_cache_key_is_deterministic_and_option_sensitive.ts
+++ b/tests/test-metro/src/features/transform/test_cache_key_is_deterministic_and_option_sensitive.ts
@@ -1,0 +1,18 @@
+import { assertCacheKeyIsDeterministicAndOptionSensitive } from "../../internal/metro-transform";
+
+/**
+ * Verifies getCacheKey is deterministic and option-sensitive.
+ *
+ * Metro folds the transformer's cache key into its persistent transform cache.
+ * The key must be stable for identical options (so cache hits work) yet change
+ * when options change (so stale transforms are not served). A non-stable
+ * stringify or a missing option input would break one side or the other.
+ *
+ * 1. Compute getCacheKey twice for the same options.
+ * 2. Assert it is a 64-char hex digest, equal across the two calls.
+ * 3. Compute it for a different option set and assert it differs.
+ */
+export const test_cache_key_is_deterministic_and_option_sensitive =
+  async () => {
+    await assertCacheKeyIsDeterministicAndOptionSensitive();
+  };

--- a/tests/test-metro/src/features/transform/test_cache_key_survives_a_missing_upstream.ts
+++ b/tests/test-metro/src/features/transform/test_cache_key_survives_a_missing_upstream.ts
@@ -1,0 +1,17 @@
+import { assertCacheKeySurvivesMissingUpstream } from "../../internal/metro-transform";
+
+/**
+ * Verifies getCacheKey survives a missing upstream transformer.
+ *
+ * Metro computes the transformer cache key eagerly. If resolving the upstream
+ * (only needed to read its optional getCacheKey) threw, the whole build would
+ * die during cache keying. Resolution failure must degrade to no upstream
+ * contribution, not throw.
+ *
+ * 1. Configure an unresolvable `upstreamTransformer`.
+ * 2. Call getCacheKey.
+ * 3. Assert it returns a valid 64-char hex digest instead of throwing.
+ */
+export const test_cache_key_survives_a_missing_upstream = async () => {
+  await assertCacheKeySurvivesMissingUpstream();
+};

--- a/tests/test-metro/src/features/transform/test_cache_key_survives_a_throwing_upstream_cache_key.ts
+++ b/tests/test-metro/src/features/transform/test_cache_key_survives_a_throwing_upstream_cache_key.ts
@@ -1,0 +1,17 @@
+import { assertCacheKeySurvivesThrowingUpstreamCacheKey } from "../../internal/metro-transform";
+
+/**
+ * Verifies getCacheKey survives an upstream whose getCacheKey throws.
+ *
+ * The upstream is resolved and present, but its `getCacheKey` throws. The
+ * adapter's inner guard must swallow that and still return a valid key rather
+ * than letting one transformer's bug crash the whole build's cache keying.
+ *
+ * 1. Configure an upstream whose getCacheKey throws.
+ * 2. Call getCacheKey.
+ * 3. Assert it returns a valid 64-char hex digest instead of throwing.
+ */
+export const test_cache_key_survives_a_throwing_upstream_cache_key =
+  async () => {
+    await assertCacheKeySurvivesThrowingUpstreamCacheKey();
+  };

--- a/tests/test-metro/src/features/transform/test_transformer_accepts_all_typescript_extensions.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_accepts_all_typescript_extensions.ts
@@ -1,0 +1,15 @@
+import { assertAcceptsAllTypeScriptExtensions } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer accepts every TypeScript source extension.
+ *
+ * The ttsc pass must run on `.ts`, `.tsx`, `.cts`, and `.mts` alike. A filter
+ * that only matched `.ts` would silently skip `.tsx` components and
+ * `.cts`/`.mts` modules.
+ *
+ * 1. For each TypeScript extension, call `shouldTransform`.
+ * 2. Assert it returns true for all of them.
+ */
+export const test_transformer_accepts_all_typescript_extensions = async () => {
+  await assertAcceptsAllTypeScriptExtensions();
+};

--- a/tests/test-metro/src/features/transform/test_transformer_excludes_configured_paths_from_the_ttsc_pass.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_excludes_configured_paths_from_the_ttsc_pass.ts
@@ -1,0 +1,16 @@
+import { assertExcludedPathPassesThrough } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer excludes configured paths from the ttsc pass.
+ *
+ * The negative twin of a transformed file: identical `.ts` extension, but a
+ * path matching an `exclude` substring must bypass the ttsc pass and reach the
+ * upstream with its source unchanged.
+ *
+ * 1. Run the transformer on a `.ts` file whose path matches an `exclude` pattern.
+ * 2. Assert the upstream received the original source (no ttsc transform).
+ */
+export const test_transformer_excludes_configured_paths_from_the_ttsc_pass =
+  async () => {
+    await assertExcludedPathPassesThrough();
+  };

--- a/tests/test-metro/src/features/transform/test_transformer_forwards_all_metro_params_to_the_upstream.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_forwards_all_metro_params_to_the_upstream.ts
@@ -1,0 +1,17 @@
+import { assertForwardsAllParamsToUpstream } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer forwards all Metro params to the upstream.
+ *
+ * Metro passes more than `src`/`filename` to a transformer (`options`, sibling
+ * fields like `plugins`). The adapter replaces only `src` and must forward the
+ * rest verbatim, or Metro's downstream Babel stage loses its inputs.
+ *
+ * 1. Run the transformer with extra `options` and a `plugins` field.
+ * 2. Assert the upstream received the exact `options` object.
+ * 3. Assert the upstream received the sibling `plugins` field.
+ */
+export const test_transformer_forwards_all_metro_params_to_the_upstream =
+  async () => {
+    await assertForwardsAllParamsToUpstream();
+  };

--- a/tests/test-metro/src/features/transform/test_transformer_gates_files_by_include_and_exclude.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_gates_files_by_include_and_exclude.ts
@@ -1,0 +1,17 @@
+import { assertGatesByIncludeAndExclude } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer gates files by include and exclude.
+ *
+ * Pins the full gating matrix: empty include means all TypeScript; a matching
+ * include selects and a non-matching include rejects; exclude rejects and must
+ * win over a matching include (it is checked first).
+ *
+ * 1. Assert empty include selects a TypeScript file.
+ * 2. Assert include match selects and non-match rejects.
+ * 3. Assert exclude rejects, and wins when a file matches both include and
+ *    exclude.
+ */
+export const test_transformer_gates_files_by_include_and_exclude = async () => {
+  await assertGatesByIncludeAndExclude();
+};

--- a/tests/test-metro/src/features/transform/test_transformer_keeps_absolute_filename_unchanged.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_keeps_absolute_filename_unchanged.ts
@@ -1,0 +1,15 @@
+import { assertKeepsAbsoluteFilenameUnchanged } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer keeps an already-absolute filename unchanged.
+ *
+ * The `path.isAbsolute` short-circuit: when Metro (or a test) supplies an
+ * absolute `filename`, it must be used as-is and `projectRoot` ignored, so the
+ * resolution is idempotent and never double-joins.
+ *
+ * 1. Resolve an absolute filename with an unrelated `projectRoot`.
+ * 2. Assert the result equals the input absolute path.
+ */
+export const test_transformer_keeps_absolute_filename_unchanged = async () => {
+  await assertKeepsAbsoluteFilenameUnchanged();
+};

--- a/tests/test-metro/src/features/transform/test_transformer_passes_declaration_files_to_the_upstream.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_passes_declaration_files_to_the_upstream.ts
@@ -1,0 +1,16 @@
+import { assertPassesDeclarationThrough } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer passes declaration files to the upstream unchanged.
+ *
+ * The negative twin of the TypeScript-transform path. A `.d.ts` ends in `.ts`
+ * but carries only types; feeding it to the ttsc project transform is wasteful
+ * and meaningless, so it must pass straight through.
+ *
+ * 1. Run the transformer on a `.d.ts` file with the fake upstream.
+ * 2. Assert the upstream received the original source unchanged.
+ */
+export const test_transformer_passes_declaration_files_to_the_upstream =
+  async () => {
+    await assertPassesDeclarationThrough();
+  };

--- a/tests/test-metro/src/features/transform/test_transformer_passes_files_outside_the_project_through.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_passes_files_outside_the_project_through.ts
@@ -1,0 +1,18 @@
+import { assertOutsideProjectFilePassesThrough } from "../../internal/metro-transform";
+
+/**
+ * Verifies a file outside the tsconfig program passes through untransformed.
+ *
+ * When the ttsc pass is asked for a file not in the compiled program it throws
+ * "…did not return output…"; that is not a build error, so the transformer must
+ * swallow it and hand the original source downstream. Exercises the real native
+ * compiler (Go source plugin) → runs in CI.
+ *
+ * 1. Create the fixture project and a stray `.ts` file outside its `src/`.
+ * 2. Transform the stray file (relative path + projectRoot).
+ * 3. Assert the upstream received the original, untransformed source.
+ */
+export const test_transformer_passes_files_outside_the_project_through =
+  async () => {
+    await assertOutsideProjectFilePassesThrough();
+  };

--- a/tests/test-metro/src/features/transform/test_transformer_passes_javascript_files_to_the_upstream.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_passes_javascript_files_to_the_upstream.ts
@@ -1,0 +1,17 @@
+import { assertPassesJavaScriptThrough } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer passes JavaScript files to the upstream unchanged.
+ *
+ * The ttsc pass only handles TypeScript; a `.js` file must reach the upstream
+ * Babel transformer with its source untouched. Running ttsc on it would, at
+ * best, waste a project compile and, at worst, error.
+ *
+ * 1. Run the transformer on a `.js` file with the echoing fake upstream.
+ * 2. Assert the upstream received the original source byte-for-byte.
+ * 3. Assert the upstream received the original filename.
+ */
+export const test_transformer_passes_javascript_files_to_the_upstream =
+  async () => {
+    await assertPassesJavaScriptThrough();
+  };

--- a/tests/test-metro/src/features/transform/test_transformer_propagates_genuine_compile_errors.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_propagates_genuine_compile_errors.ts
@@ -1,0 +1,17 @@
+import { assertGenuineCompileErrorPropagates } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer propagates genuine compile/plugin errors.
+ *
+ * The negative twin of the out-of-project pass-through: a real failure must NOT
+ * be swallowed as "outside project". This pins the `isFileOutsideProject` FALSE
+ * branch (rethrow). Exercises the real native compiler (Go source plugin) →
+ * runs in CI.
+ *
+ * 1. Create a fixture whose source the plugin rejects.
+ * 2. Transform it.
+ * 3. Assert it rejects with an error that is NOT the "did not return output" case.
+ */
+export const test_transformer_propagates_genuine_compile_errors = async () => {
+  await assertGenuineCompileErrorPropagates();
+};

--- a/tests/test-metro/src/features/transform/test_transformer_rejects_non_typescript_extensions.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_rejects_non_typescript_extensions.ts
@@ -1,0 +1,15 @@
+import { assertRejectsNonTypeScriptExtensions } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer rejects declaration and non-TypeScript extensions.
+ *
+ * The negative twin of extension acceptance: `.d.ts`/`.d.mts` declarations and
+ * `.js`/`.jsx`/`.json`/`.css` files carry no transformable TypeScript and must
+ * pass straight through to the upstream transformer.
+ *
+ * 1. For each declaration / non-TypeScript extension, call `shouldTransform`.
+ * 2. Assert it returns false for all of them.
+ */
+export const test_transformer_rejects_non_typescript_extensions = async () => {
+  await assertRejectsNonTypeScriptExtensions();
+};

--- a/tests/test-metro/src/features/transform/test_transformer_resolves_relative_filename_against_project_root.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_resolves_relative_filename_against_project_root.ts
@@ -6,7 +6,7 @@ import { assertResolvesRelativeFilenameAgainstProjectRoot } from "../../internal
  *
  * Metro hands the babel transformer a path relative to `projectRoot` and passes
  * `projectRoot` in options. Resolving against `process.cwd()` instead would, in
- * monorepos / non-root launches, point the ttsc pass at a non-existent path —
+ * monorepos / non-root launches, point the ttsc pass at a non-existent path,
  * making every file look "outside the project" and silently skipping plugins.
  *
  * 1. Resolve a relative filename with an explicit `projectRoot`.

--- a/tests/test-metro/src/features/transform/test_transformer_resolves_relative_filename_against_project_root.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_resolves_relative_filename_against_project_root.ts
@@ -1,0 +1,19 @@
+import { assertResolvesRelativeFilenameAgainstProjectRoot } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer resolves Metro's relative filename against
+ * projectRoot.
+ *
+ * Metro hands the babel transformer a path relative to `projectRoot` and passes
+ * `projectRoot` in options. Resolving against `process.cwd()` instead would, in
+ * monorepos / non-root launches, point the ttsc pass at a non-existent path —
+ * making every file look "outside the project" and silently skipping plugins.
+ *
+ * 1. Resolve a relative filename with an explicit `projectRoot`.
+ * 2. Assert it joins against `projectRoot`.
+ * 3. Assert it falls back to cwd only when `projectRoot` is absent.
+ */
+export const test_transformer_resolves_relative_filename_against_project_root =
+  async () => {
+    await assertResolvesRelativeFilenameAgainstProjectRoot();
+  };

--- a/tests/test-metro/src/features/transform/test_transformer_restricts_to_included_paths_when_include_is_set.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_restricts_to_included_paths_when_include_is_set.ts
@@ -1,0 +1,17 @@
+import { assertNonIncludedPathPassesThrough } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer restricts to included paths when `include` is set.
+ *
+ * Pins the include boundary: once any include pattern is configured, a `.ts`
+ * file that matches none of them must pass straight through rather than enter
+ * the ttsc pass.
+ *
+ * 1. Configure a single `include` pattern.
+ * 2. Run the transformer on a `.ts` file outside that pattern.
+ * 3. Assert the upstream received the original source (no ttsc transform).
+ */
+export const test_transformer_restricts_to_included_paths_when_include_is_set =
+  async () => {
+    await assertNonIncludedPathPassesThrough();
+  };

--- a/tests/test-metro/src/features/transform/test_transformer_runs_the_ttsc_plugin_pass_on_typescript_sources.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_runs_the_ttsc_plugin_pass_on_typescript_sources.ts
@@ -1,0 +1,18 @@
+import { assertRunsTtscPluginPassOnTypeScript } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer runs the ttsc plugin pass on TypeScript sources.
+ *
+ * The end-to-end proof that the adapter actually applies ttsc plugins inside a
+ * Metro build: the source handed to the upstream transformer must be the
+ * plugin-transformed output, not the original. Exercises the real native
+ * compiler and a Go source plugin, so it runs in CI (Go toolchain present).
+ *
+ * 1. Create the shared fixture project whose tsconfig declares the Go plugin.
+ * 2. Run the transformer on its TypeScript entrypoint with the fake upstream.
+ * 3. Assert the source the upstream received was plugin-transformed.
+ */
+export const test_transformer_runs_the_ttsc_plugin_pass_on_typescript_sources =
+  async () => {
+    await assertRunsTtscPluginPassOnTypeScript();
+  };

--- a/tests/test-metro/src/features/transform/test_transformer_throws_when_the_configured_upstream_is_missing.ts
+++ b/tests/test-metro/src/features/transform/test_transformer_throws_when_the_configured_upstream_is_missing.ts
@@ -1,0 +1,17 @@
+import { assertMissingUpstreamThrows } from "../../internal/metro-transform";
+
+/**
+ * Verifies the transformer throws when the configured upstream is missing.
+ *
+ * A custom `upstreamTransformer` pointing at an unresolvable module is a
+ * configuration error that must surface, not be swallowed. Upstream resolution
+ * happens before file filtering, so even a pass-through file raises it.
+ *
+ * 1. Configure `upstreamTransformer` to a non-existent module.
+ * 2. Run the transformer.
+ * 3. Assert it rejects with a "could not load the configured upstream" message.
+ */
+export const test_transformer_throws_when_the_configured_upstream_is_missing =
+  async () => {
+    await assertMissingUpstreamThrows();
+  };

--- a/tests/test-metro/src/features/upstream/test_upstream_auto_detects_in_priority_order.ts
+++ b/tests/test-metro/src/features/upstream/test_upstream_auto_detects_in_priority_order.ts
@@ -1,0 +1,17 @@
+import { assertAutoDetectsInPriorityOrder } from "../../internal/metro-upstream";
+
+/**
+ * Verifies upstream auto-detection tries candidates in priority order.
+ *
+ * With no explicit `upstreamTransformer`, the adapter must prefer Expo, then
+ * modern React Native, then the legacy package — picking the first resolvable
+ * one. A wrong order would, e.g., pick the legacy transformer in an Expo
+ * project.
+ *
+ * 1. With all candidates resolvable, assert Expo (first) is chosen.
+ * 2. With Expo absent, assert modern RN is chosen.
+ * 3. With Expo and modern RN absent, assert the legacy package is chosen.
+ */
+export const test_upstream_auto_detects_in_priority_order = async () => {
+  await assertAutoDetectsInPriorityOrder();
+};

--- a/tests/test-metro/src/features/upstream/test_upstream_auto_detects_in_priority_order.ts
+++ b/tests/test-metro/src/features/upstream/test_upstream_auto_detects_in_priority_order.ts
@@ -4,7 +4,7 @@ import { assertAutoDetectsInPriorityOrder } from "../../internal/metro-upstream"
  * Verifies upstream auto-detection tries candidates in priority order.
  *
  * With no explicit `upstreamTransformer`, the adapter must prefer Expo, then
- * modern React Native, then the legacy package — picking the first resolvable
+ * modern React Native, then the legacy package, picking the first resolvable
  * one. A wrong order would, e.g., pick the legacy transformer in an Expo
  * project.
  *

--- a/tests/test-metro/src/features/upstream/test_upstream_empty_custom_path_falls_back_to_auto_detect.ts
+++ b/tests/test-metro/src/features/upstream/test_upstream_empty_custom_path_falls_back_to_auto_detect.ts
@@ -1,0 +1,16 @@
+import { assertEmptyCustomPathFallsBackToAutoDetect } from "../../internal/metro-upstream";
+
+/**
+ * Verifies an empty-string custom path falls back to auto-detection.
+ *
+ * `upstreamTransformer: ""` is treated as "not configured": the resolver must
+ * skip the custom-path branch (rather than try to resolve `""`) and proceed to
+ * auto-detection.
+ *
+ * 1. Resolve with `customPath = ""`.
+ * 2. Assert the first auto-detect candidate is chosen.
+ */
+export const test_upstream_empty_custom_path_falls_back_to_auto_detect =
+  async () => {
+    await assertEmptyCustomPathFallsBackToAutoDetect();
+  };

--- a/tests/test-metro/src/features/upstream/test_upstream_throws_when_no_transformer_is_installed.ts
+++ b/tests/test-metro/src/features/upstream/test_upstream_throws_when_no_transformer_is_installed.ts
@@ -1,0 +1,16 @@
+import { assertThrowsWhenNoUpstreamInstalled } from "../../internal/metro-upstream";
+
+/**
+ * Verifies upstream resolution throws when no transformer is installed.
+ *
+ * If none of the candidate transformers resolve, the adapter must fail with a
+ * clear, actionable error rather than returning undefined and crashing later
+ * deep inside a transform.
+ *
+ * 1. Resolve with a loader that resolves nothing.
+ * 2. Assert it throws "Could not find an upstream Metro transformer".
+ */
+export const test_upstream_throws_when_no_transformer_is_installed =
+  async () => {
+    await assertThrowsWhenNoUpstreamInstalled();
+  };

--- a/tests/test-metro/src/index.ts
+++ b/tests/test-metro/src/index.ts
@@ -1,0 +1,9 @@
+import { TestExecutor } from "@ttsc/testing";
+import path from "node:path";
+
+TestExecutor.main({
+  location: path.join(process.cwd(), "src", "features"),
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/test-metro/src/internal/metro-cjs.ts
+++ b/tests/test-metro/src/internal/metro-cjs.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+import { TestMetroRuntime } from "./metro-runtime";
+
+const nodeRequire = createRequire(import.meta.url);
+
+/**
+ * Asserts the CommonJS build — the one Metro actually `require()`s — loads and
+ * runs.
+ *
+ * Every other test loads the `.mjs` (ESM) build, where `import.meta.url` is
+ * native. But `transformer.babelTransformerPath` points at the CJS
+ * `transformer.js`, and Metro loads it with `require`. There, both
+ * `fileURLToPath(import.meta.url)` (index) and `createRequire(import.meta.url)`
+ * (transformer/upstream, plus `packageVersion`'s `require` of the package.json)
+ * rely entirely on Rollup's CJS `import.meta.url` rewrite. If that rewrite ever
+ * broke, the ESM-only tests would stay green while real Metro crashed at worker
+ * load. This pins the production load path:
+ *
+ * 1. `require` the CJS `index.js` and call `withTtsc` (exercises the index
+ *    `import.meta.url` → `pathToFileURL(__filename)` shim).
+ * 2. `require` the CJS `transformer.js` (its top-level `createRequire` runs) and
+ *    assert callable `transform`/`getCacheKey` exports.
+ * 3. Run `getCacheKey` through the CJS module (exercises `packageVersion` and
+ *    upstream resolution, both via the CJS shim) and assert a valid digest.
+ */
+export async function assertCjsBuildLoadsAndRuns(): Promise<void> {
+  const optionsModule = nodeRequire(
+    TestMetroRuntime.libPath("core/options", "js"),
+  );
+  const envKey: string = optionsModule.ENV_KEY;
+  const previous = process.env[envKey];
+  try {
+    const index = nodeRequire(TestMetroRuntime.libPath("index", "js"));
+    assert.equal(typeof index.withTtsc, "function");
+    const config = index.withTtsc({ transformer: {} });
+    assert.match(config.transformer.babelTransformerPath, /transformer\.js$/);
+
+    const transformer = nodeRequire(
+      TestMetroRuntime.libPath("transformer", "js"),
+    );
+    assert.equal(typeof transformer.transform, "function");
+    assert.equal(typeof transformer.getCacheKey, "function");
+
+    process.env[envKey] = optionsModule.serializeOptions({
+      upstreamTransformer: TestMetroRuntime.fakeUpstreamPathOnDisk(),
+    });
+    const key = transformer.getCacheKey({ projectRoot: "/a" });
+    assert.equal(typeof key, "string");
+    assert.equal(key.length, 64);
+  } finally {
+    if (previous === undefined) {
+      delete process.env[envKey];
+    } else {
+      process.env[envKey] = previous;
+    }
+  }
+}

--- a/tests/test-metro/src/internal/metro-cjs.ts
+++ b/tests/test-metro/src/internal/metro-cjs.ts
@@ -6,7 +6,7 @@ import { TestMetroRuntime } from "./metro-runtime";
 const nodeRequire = createRequire(import.meta.url);
 
 /**
- * Asserts the CommonJS build — the one Metro actually `require()`s — loads and
+ * Asserts the CommonJS build (the one Metro actually `require()`s) loads and
  * runs.
  *
  * Every other test loads the `.mjs` (ESM) build, where `import.meta.url` is

--- a/tests/test-metro/src/internal/metro-config.ts
+++ b/tests/test-metro/src/internal/metro-config.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TestMetroRuntime } from "./metro-runtime";
+
+/**
+ * Run `body` with `TTSC_METRO_OPTIONS` saved and restored, so config-level env
+ * mutations from {@link withTtsc} never leak into sibling test cases.
+ */
+async function withCleanEnv(body: () => Promise<void>): Promise<void> {
+  const { ENV_KEY } = await TestMetroRuntime.loadOptions();
+  const previous = process.env[ENV_KEY];
+  delete process.env[ENV_KEY];
+  try {
+    await body();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = previous;
+    }
+  }
+}
+
+/**
+ * Asserts `withTtsc` points `transformer.babelTransformerPath` at the package's
+ * built transformer module, by absolute path, and that the file exists.
+ */
+export async function assertWithTtscSetsBabelTransformerPath(): Promise<void> {
+  await withCleanEnv(async () => {
+    const { withTtsc } = await TestMetroRuntime.loadIndex();
+    const config = withTtsc({ transformer: {} });
+    const target = config.transformer.babelTransformerPath;
+    assert.equal(typeof target, "string");
+    assert.equal(path.isAbsolute(target), true);
+    assert.match(target, /transformer\.js$/);
+    assert.equal(fs.existsSync(target), true);
+  });
+}
+
+/**
+ * Asserts `withTtsc` preserves the rest of the Metro config: unrelated
+ * top-level keys and existing `transformer` fields survive untouched while only
+ * `babelTransformerPath` is added.
+ */
+export async function assertWithTtscPreservesExistingConfig(): Promise<void> {
+  await withCleanEnv(async () => {
+    const { withTtsc } = await TestMetroRuntime.loadIndex();
+    const base = {
+      projectRoot: "/workspace/app",
+      resolver: { sourceExts: ["ts", "tsx"] },
+      transformer: {
+        minifierPath: "metro-minify-terser",
+        assetPlugins: ["expo-asset/tools/hashAssetFiles"],
+      },
+    };
+    const config = withTtsc(base);
+    assert.equal(config.projectRoot, base.projectRoot);
+    assert.deepEqual(config.resolver, base.resolver);
+    assert.equal(config.transformer.minifierPath, "metro-minify-terser");
+    assert.deepEqual(
+      config.transformer.assetPlugins,
+      base.transformer.assetPlugins,
+    );
+    assert.equal(typeof config.transformer.babelTransformerPath, "string");
+    // The original object is not mutated in place.
+    assert.equal(
+      (base.transformer as Record<string, unknown>).babelTransformerPath,
+      undefined,
+    );
+  });
+}
+
+/**
+ * Asserts `withTtsc` publishes resolved options to the worker env so Metro's
+ * transformer processes — which never see the `withTtsc` call — can read them.
+ */
+export async function assertWithTtscPublishesWorkerEnv(): Promise<void> {
+  await withCleanEnv(async () => {
+    const { ENV_KEY } = await TestMetroRuntime.loadOptions();
+    const { withTtsc } = await TestMetroRuntime.loadIndex();
+
+    withTtsc(
+      { transformer: {} },
+      { project: "tsconfig.build.json", exclude: ["__tests__"] },
+    );
+    assert.deepEqual(JSON.parse(process.env[ENV_KEY] as string), {
+      project: "tsconfig.build.json",
+      exclude: ["__tests__"],
+    });
+
+    // No options still publishes an explicit (empty) payload, never undefined.
+    withTtsc({ transformer: {} });
+    assert.equal(process.env[ENV_KEY], "{}");
+  });
+}

--- a/tests/test-metro/src/internal/metro-config.ts
+++ b/tests/test-metro/src/internal/metro-config.ts
@@ -74,7 +74,7 @@ export async function assertWithTtscPreservesExistingConfig(): Promise<void> {
 
 /**
  * Asserts `withTtsc` publishes resolved options to the worker env so Metro's
- * transformer processes — which never see the `withTtsc` call — can read them.
+ * transformer processes, which never see the `withTtsc` call, can read them.
  */
 export async function assertWithTtscPublishesWorkerEnv(): Promise<void> {
   await withCleanEnv(async () => {
@@ -98,8 +98,8 @@ export async function assertWithTtscPublishesWorkerEnv(): Promise<void> {
 
 /**
  * Asserts withTtsc adds a `transformer` block even when the input config has
- * none — spreading an absent `transformer` must not crash and must still yield
- * a valid `babelTransformerPath`, while unrelated top-level keys survive.
+ * none: spreading an absent `transformer` must not crash and must still yield a
+ * valid `babelTransformerPath`, while unrelated top-level keys survive.
  */
 export async function assertWithTtscAddsTransformerWhenAbsent(): Promise<void> {
   await withCleanEnv(async () => {

--- a/tests/test-metro/src/internal/metro-config.ts
+++ b/tests/test-metro/src/internal/metro-config.ts
@@ -95,3 +95,18 @@ export async function assertWithTtscPublishesWorkerEnv(): Promise<void> {
     assert.equal(process.env[ENV_KEY], "{}");
   });
 }
+
+/**
+ * Asserts withTtsc adds a `transformer` block even when the input config has
+ * none — spreading an absent `transformer` must not crash and must still yield
+ * a valid `babelTransformerPath`, while unrelated top-level keys survive.
+ */
+export async function assertWithTtscAddsTransformerWhenAbsent(): Promise<void> {
+  await withCleanEnv(async () => {
+    const { withTtsc } = await TestMetroRuntime.loadIndex();
+    const config = withTtsc({ projectRoot: "/workspace/app" });
+    assert.equal(config.projectRoot, "/workspace/app");
+    assert.equal(typeof config.transformer.babelTransformerPath, "string");
+    assert.match(config.transformer.babelTransformerPath, /transformer\.js$/);
+  });
+}

--- a/tests/test-metro/src/internal/metro-options.ts
+++ b/tests/test-metro/src/internal/metro-options.ts
@@ -98,3 +98,54 @@ export async function assertOptionsFallBackOnMalformedEnv(): Promise<void> {
     assert.deepEqual(resolved.exclude, []);
   });
 }
+
+/**
+ * Asserts valid JSON that is not a plain object (array, `null`, number, string,
+ * boolean) degrades to defaults — the non-object branch of `parse`, distinct
+ * from the malformed-JSON catch. An array in particular must not slip through
+ * the `typeof === "object"` guard.
+ */
+export async function assertNonObjectEnvFallsBackToDefaults(): Promise<void> {
+  for (const raw of ["[1,2,3]", "null", "42", '"hello"', "true"]) {
+    await withEnv(raw, async (mod) => {
+      const resolved = mod.resolveOptionsFromEnv();
+      assert.equal(resolved.ttsc.project, undefined, raw);
+      assert.equal(resolved.upstreamTransformer, undefined, raw);
+      assert.deepEqual(resolved.include, [], raw);
+      assert.deepEqual(resolved.exclude, [], raw);
+    });
+  }
+}
+
+/**
+ * Asserts an empty-string env payload (distinct from an unset var) degrades to
+ * defaults — the `raw.length === 0` half of the guard in `parse`.
+ */
+export async function assertEmptyStringEnvFallsBackToDefaults(): Promise<void> {
+  await withEnv("", async (mod) => {
+    const resolved = mod.resolveOptionsFromEnv();
+    assert.equal(resolved.ttsc.project, undefined);
+    assert.deepEqual(resolved.include, []);
+    assert.deepEqual(resolved.exclude, []);
+  });
+}
+
+/**
+ * Asserts untrusted include/exclude values are coerced to string arrays: a bare
+ * string (a common mistake) becomes `[]`, and non-string entries are filtered
+ * out — so the worker never calls `.some` on a non-array and crashes. Valid
+ * sibling fields (here `plugins: false`) still resolve.
+ */
+export async function assertInvalidIncludeExcludeCoerced(): Promise<void> {
+  const raw = JSON.stringify({
+    include: ["a", 1, "b", null],
+    exclude: "everything",
+    plugins: false,
+  });
+  await withEnv(raw, async (mod) => {
+    const resolved = mod.resolveOptionsFromEnv();
+    assert.deepEqual(resolved.include, ["a", "b"]);
+    assert.deepEqual(resolved.exclude, []);
+    assert.equal(resolved.ttsc.plugins, false);
+  });
+}

--- a/tests/test-metro/src/internal/metro-options.ts
+++ b/tests/test-metro/src/internal/metro-options.ts
@@ -101,7 +101,7 @@ export async function assertOptionsFallBackOnMalformedEnv(): Promise<void> {
 
 /**
  * Asserts valid JSON that is not a plain object (array, `null`, number, string,
- * boolean) degrades to defaults — the non-object branch of `parse`, distinct
+ * boolean) degrades to defaults: the non-object branch of `parse`, distinct
  * from the malformed-JSON catch. An array in particular must not slip through
  * the `typeof === "object"` guard.
  */
@@ -119,7 +119,7 @@ export async function assertNonObjectEnvFallsBackToDefaults(): Promise<void> {
 
 /**
  * Asserts an empty-string env payload (distinct from an unset var) degrades to
- * defaults — the `raw.length === 0` half of the guard in `parse`.
+ * defaults: the `raw.length === 0` half of the guard in `parse`.
  */
 export async function assertEmptyStringEnvFallsBackToDefaults(): Promise<void> {
   await withEnv("", async (mod) => {
@@ -133,7 +133,7 @@ export async function assertEmptyStringEnvFallsBackToDefaults(): Promise<void> {
 /**
  * Asserts untrusted include/exclude values are coerced to string arrays: a bare
  * string (a common mistake) becomes `[]`, and non-string entries are filtered
- * out — so the worker never calls `.some` on a non-array and crashes. Valid
+ * out, so the worker never calls `.some` on a non-array and crashes. Valid
  * sibling fields (here `plugins: false`) still resolve.
  */
 export async function assertInvalidIncludeExcludeCoerced(): Promise<void> {

--- a/tests/test-metro/src/internal/metro-options.ts
+++ b/tests/test-metro/src/internal/metro-options.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+
+import { TestMetroRuntime } from "./metro-runtime";
+
+/**
+ * Run `body` with `TTSC_METRO_OPTIONS` set to `raw` (or cleared when
+ * `undefined`) and always restore the previous value afterwards.
+ */
+async function withEnv(
+  raw: string | undefined,
+  body: (mod: any) => Promise<void>,
+): Promise<void> {
+  const mod = await TestMetroRuntime.loadOptions();
+  const previous = process.env[mod.ENV_KEY];
+  if (raw === undefined) {
+    delete process.env[mod.ENV_KEY];
+  } else {
+    process.env[mod.ENV_KEY] = raw;
+  }
+  try {
+    await body(mod);
+  } finally {
+    if (previous === undefined) {
+      delete process.env[mod.ENV_KEY];
+    } else {
+      process.env[mod.ENV_KEY] = previous;
+    }
+  }
+}
+
+/**
+ * Asserts every option survives the config-process → worker-process env
+ * round-trip intact: the ttsc overlay (project/compilerOptions/plugins) plus
+ * the Metro-specific include/exclude/upstreamTransformer.
+ */
+export async function assertOptionsRoundTripThroughEnv(): Promise<void> {
+  const source = {
+    project: "tsconfig.json",
+    compilerOptions: { strict: true },
+    plugins: [{ transform: "typia/lib/transform" }],
+    include: ["src"],
+    exclude: ["test"],
+    upstreamTransformer: "custom-upstream",
+  };
+  const mod = await TestMetroRuntime.loadOptions();
+  await withEnv(mod.serializeOptions(source), async (m) => {
+    const resolved = m.resolveOptionsFromEnv();
+    assert.equal(resolved.ttsc.project, source.project);
+    assert.deepEqual(resolved.ttsc.compilerOptions, source.compilerOptions);
+    assert.deepEqual(resolved.ttsc.plugins, source.plugins);
+    assert.deepEqual(resolved.include, source.include);
+    assert.deepEqual(resolved.exclude, source.exclude);
+    assert.equal(resolved.upstreamTransformer, source.upstreamTransformer);
+  });
+}
+
+/**
+ * Asserts that with no env payload the resolver falls back to defaults: no
+ * project/plugin overrides (so the transformer auto-discovers tsconfig) and
+ * empty include/exclude. This is the `withTtsc(config)` no-options path.
+ */
+export async function assertOptionsDefaultWhenEnvAbsent(): Promise<void> {
+  await withEnv(undefined, async (mod) => {
+    const resolved = mod.resolveOptionsFromEnv();
+    assert.equal(resolved.ttsc.project, undefined);
+    assert.equal(resolved.ttsc.plugins, undefined);
+    assert.equal(resolved.upstreamTransformer, undefined);
+    assert.deepEqual(resolved.include, []);
+    assert.deepEqual(resolved.exclude, []);
+  });
+}
+
+/**
+ * Asserts `plugins: false` survives the round-trip as `false`, not `undefined`.
+ *
+ * The negative twin of the round-trip test: a falsy guard would silently turn
+ * "disable all project plugins" back into "auto-read project plugins", so the
+ * resolver must preserve the explicit `false`.
+ */
+export async function assertOptionsPreservePluginsFalse(): Promise<void> {
+  const mod = await TestMetroRuntime.loadOptions();
+  await withEnv(mod.serializeOptions({ plugins: false }), async (m) => {
+    const resolved = m.resolveOptionsFromEnv();
+    assert.equal(resolved.ttsc.plugins, false);
+  });
+}
+
+/**
+ * Asserts a malformed env payload degrades to defaults instead of throwing, so
+ * a corrupted variable never crashes every Metro worker.
+ */
+export async function assertOptionsFallBackOnMalformedEnv(): Promise<void> {
+  await withEnv("{ not valid json", async (mod) => {
+    const resolved = mod.resolveOptionsFromEnv();
+    assert.equal(resolved.ttsc.project, undefined);
+    assert.equal(resolved.upstreamTransformer, undefined);
+    assert.deepEqual(resolved.include, []);
+    assert.deepEqual(resolved.exclude, []);
+  });
+}

--- a/tests/test-metro/src/internal/metro-runtime.ts
+++ b/tests/test-metro/src/internal/metro-runtime.ts
@@ -125,6 +125,35 @@ export namespace TestMetroRuntime {
     return file;
   }
 
+  let fakeUpstreamThrowingCacheKeyPath: string | undefined;
+
+  /**
+   * A fake upstream whose `getCacheKey` throws, to exercise the inner catch in
+   * `upstreamCacheKey` (a throwing upstream key must not crash cache keying).
+   */
+  export function fakeUpstreamThrowingCacheKeyOnDisk(): string {
+    if (fakeUpstreamThrowingCacheKeyPath !== undefined) {
+      return fakeUpstreamThrowingCacheKeyPath;
+    }
+    const dir = TestProject.tmpdir("ttsc-metro-upstream-throw-");
+    const file = path.join(dir, "upstream.cjs");
+    fs.writeFileSync(
+      file,
+      [
+        "exports.transform = async function (params) {",
+        "  return { ast: { __fakeUpstream: true, src: params.src } };",
+        "};",
+        "exports.getCacheKey = function () {",
+        '  throw new Error("upstream getCacheKey boom");',
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    fakeUpstreamThrowingCacheKeyPath = file;
+    return file;
+  }
+
   /**
    * Set the worker-env options, load a fresh transformer, run `body`, and
    * always restore the previous env. Used by transform and cache-key tests that

--- a/tests/test-metro/src/internal/metro-runtime.ts
+++ b/tests/test-metro/src/internal/metro-runtime.ts
@@ -1,0 +1,124 @@
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Runtime import helpers for the built `@ttsc/metro` package.
+ *
+ * Tests load the compiled ESM output through file URLs so they validate the
+ * package exactly as Node loads it after a build — the same approach the
+ * `@ttsc/unplugin` suite uses for its adapters.
+ */
+export namespace TestMetroRuntime {
+  /** Resolve a built entrypoint under `packages/metro/lib`. */
+  export function libPath(entry: string, extension: "js" | "mjs"): string {
+    return path.resolve(
+      TestProject.WORKSPACE_ROOT,
+      "packages/metro/lib",
+      `${entry}.${extension}`,
+    );
+  }
+
+  /** Convert a built ESM entrypoint into a dynamic-importable file URL. */
+  export function libUrl(entry: string): string {
+    return pathToFileURL(libPath(entry, "mjs")).href;
+  }
+
+  /** Load the package entry (`withTtsc`, types). */
+  export async function loadIndex(): Promise<any> {
+    return import(libUrl("index"));
+  }
+
+  /**
+   * Load the internal options module (`serializeOptions`,
+   * `resolveOptionsFromEnv`, `ENV_KEY`).
+   */
+  export async function loadOptions(): Promise<any> {
+    return import(libUrl("core/options"));
+  }
+
+  // The transformer keeps module-level singletons (resolved options + transform
+  // cache), exactly as Metro loads it once per worker. To exercise distinct
+  // option sets across cases, each load is cache-busted with a unique query so
+  // the test gets a fresh module instance.
+  let freshCounter = 0;
+
+  /**
+   * Load a fresh instance of the transformer module (`transform`,
+   * `getCacheKey`).
+   */
+  export async function loadFreshTransformer(): Promise<any> {
+    freshCounter += 1;
+    return import(`${libUrl("transformer")}?case=${freshCounter}`);
+  }
+
+  let fakeUpstreamPath: string | undefined;
+
+  /**
+   * Write (once) a fake upstream Metro transformer and return its absolute
+   * path.
+   *
+   * The fake echoes everything it receives back inside the returned `ast`, so a
+   * test can assert exactly what the ttsc stage handed downstream (the original
+   * source for pass-through files, the plugin-transformed source otherwise)
+   * without needing a real Babel/Expo transformer.
+   */
+  export function fakeUpstreamPathOnDisk(): string {
+    if (fakeUpstreamPath !== undefined) {
+      return fakeUpstreamPath;
+    }
+    const dir = TestProject.tmpdir("ttsc-metro-upstream-");
+    const file = path.join(dir, "upstream.cjs");
+    fs.writeFileSync(
+      file,
+      [
+        "exports.transform = async function (params) {",
+        "  return {",
+        "    ast: {",
+        "      __fakeUpstream: true,",
+        "      src: params.src,",
+        "      filename: params.filename,",
+        "      options: params.options,",
+        "      plugins: params.plugins,",
+        "    },",
+        "  };",
+        "};",
+        'exports.getCacheKey = function () { return "fake-upstream-cache-key"; };',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    fakeUpstreamPath = file;
+    return file;
+  }
+
+  /**
+   * Set the worker-env options, load a fresh transformer, run one transform,
+   * and always restore the previous env. Mirrors how Metro invokes the
+   * transformer with worker-side options coming from {@link withTtsc}.
+   */
+  export async function runTransform(props: {
+    options: Record<string, unknown>;
+    params: {
+      src: string;
+      filename: string;
+      options?: Record<string, unknown>;
+      [key: string]: unknown;
+    };
+  }): Promise<{ ast: Record<string, unknown> }> {
+    const { ENV_KEY, serializeOptions } = await loadOptions();
+    const previous = process.env[ENV_KEY];
+    process.env[ENV_KEY] = serializeOptions(props.options);
+    try {
+      const mod = await loadFreshTransformer();
+      return await mod.transform({ options: {}, ...props.params });
+    } finally {
+      if (previous === undefined) {
+        delete process.env[ENV_KEY];
+      } else {
+        process.env[ENV_KEY] = previous;
+      }
+    }
+  }
+}

--- a/tests/test-metro/src/internal/metro-runtime.ts
+++ b/tests/test-metro/src/internal/metro-runtime.ts
@@ -38,6 +38,11 @@ export namespace TestMetroRuntime {
     return import(libUrl("core/options"));
   }
 
+  /** Load the internal upstream-resolution module. */
+  export async function loadUpstream(): Promise<any> {
+    return import(libUrl("core/upstream"));
+  }
+
   // The transformer keeps module-level singletons (resolved options + transform
   // cache), exactly as Metro loads it once per worker. To exercise distinct
   // option sets across cases, each load is cache-busted with a unique query so
@@ -46,7 +51,7 @@ export namespace TestMetroRuntime {
 
   /**
    * Load a fresh instance of the transformer module (`transform`,
-   * `getCacheKey`).
+   * `getCacheKey`, …).
    */
   export async function loadFreshTransformer(): Promise<any> {
     freshCounter += 1;
@@ -54,15 +59,16 @@ export namespace TestMetroRuntime {
   }
 
   let fakeUpstreamPath: string | undefined;
+  let fakeUpstreamNoCacheKeyPath: string | undefined;
 
   /**
    * Write (once) a fake upstream Metro transformer and return its absolute
    * path.
    *
-   * The fake echoes everything it receives back inside the returned `ast`, so a
-   * test can assert exactly what the ttsc stage handed downstream (the original
-   * source for pass-through files, the plugin-transformed source otherwise)
-   * without needing a real Babel/Expo transformer.
+   * `transform` echoes everything it receives back inside the returned `ast`,
+   * so a test can assert exactly what the ttsc stage handed downstream.
+   * `getCacheKey` echoes its forwarded arguments, so a test can prove the args
+   * (e.g. `projectRoot`) reach the upstream key.
    */
   export function fakeUpstreamPathOnDisk(): string {
     if (fakeUpstreamPath !== undefined) {
@@ -84,7 +90,9 @@ export namespace TestMetroRuntime {
         "    },",
         "  };",
         "};",
-        'exports.getCacheKey = function () { return "fake-upstream-cache-key"; };',
+        "exports.getCacheKey = function (...args) {",
+        '  return "fake-upstream:" + JSON.stringify(args[0] ?? null);',
+        "};",
         "",
       ].join("\n"),
       "utf8",
@@ -94,9 +102,56 @@ export namespace TestMetroRuntime {
   }
 
   /**
-   * Set the worker-env options, load a fresh transformer, run one transform,
-   * and always restore the previous env. Mirrors how Metro invokes the
-   * transformer with worker-side options coming from {@link withTtsc}.
+   * A fake upstream that exports `transform` only (no `getCacheKey`), to
+   * exercise the branch where the upstream contributes no cache key.
+   */
+  export function fakeUpstreamWithoutCacheKeyOnDisk(): string {
+    if (fakeUpstreamNoCacheKeyPath !== undefined) {
+      return fakeUpstreamNoCacheKeyPath;
+    }
+    const dir = TestProject.tmpdir("ttsc-metro-upstream-nokey-");
+    const file = path.join(dir, "upstream.cjs");
+    fs.writeFileSync(
+      file,
+      [
+        "exports.transform = async function (params) {",
+        "  return { ast: { __fakeUpstream: true, src: params.src } };",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    fakeUpstreamNoCacheKeyPath = file;
+    return file;
+  }
+
+  /**
+   * Set the worker-env options, load a fresh transformer, run `body`, and
+   * always restore the previous env. Used by transform and cache-key tests that
+   * need a worker scoped to a specific option set.
+   */
+  export async function withTransformerEnv(
+    options: Record<string, unknown>,
+    body: (mod: any) => unknown,
+  ): Promise<any> {
+    const { ENV_KEY, serializeOptions } = await loadOptions();
+    const previous = process.env[ENV_KEY];
+    process.env[ENV_KEY] = serializeOptions(options);
+    try {
+      const mod = await loadFreshTransformer();
+      return await body(mod);
+    } finally {
+      if (previous === undefined) {
+        delete process.env[ENV_KEY];
+      } else {
+        process.env[ENV_KEY] = previous;
+      }
+    }
+  }
+
+  /**
+   * Convenience over {@link withTransformerEnv}: run one transform and return
+   * its result.
    */
   export async function runTransform(props: {
     options: Record<string, unknown>;
@@ -107,18 +162,8 @@ export namespace TestMetroRuntime {
       [key: string]: unknown;
     };
   }): Promise<{ ast: Record<string, unknown> }> {
-    const { ENV_KEY, serializeOptions } = await loadOptions();
-    const previous = process.env[ENV_KEY];
-    process.env[ENV_KEY] = serializeOptions(props.options);
-    try {
-      const mod = await loadFreshTransformer();
-      return await mod.transform({ options: {}, ...props.params });
-    } finally {
-      if (previous === undefined) {
-        delete process.env[ENV_KEY];
-      } else {
-        process.env[ENV_KEY] = previous;
-      }
-    }
+    return withTransformerEnv(props.options, (mod) =>
+      mod.transform({ options: {}, ...props.params }),
+    );
   }
 }

--- a/tests/test-metro/src/internal/metro-runtime.ts
+++ b/tests/test-metro/src/internal/metro-runtime.ts
@@ -7,7 +7,7 @@ import { pathToFileURL } from "node:url";
  * Runtime import helpers for the built `@ttsc/metro` package.
  *
  * Tests load the compiled ESM output through file URLs so they validate the
- * package exactly as Node loads it after a build — the same approach the
+ * package exactly as Node loads it after a build, the same approach the
  * `@ttsc/unplugin` suite uses for its adapters.
  */
 export namespace TestMetroRuntime {

--- a/tests/test-metro/src/internal/metro-transform.ts
+++ b/tests/test-metro/src/internal/metro-transform.ts
@@ -149,11 +149,16 @@ export async function assertRunsTtscPluginPassOnTypeScript(): Promise<void> {
     params: {
       src: TestUnpluginProject.mainSource(root),
       filename: "src/main.ts",
-      options: { projectRoot: root },
+      options: { projectRoot: root, platform: "ios" },
+      plugins: ["babel-plugin-foo"],
     },
   });
   assert.equal(result.ast.__fakeUpstream, true);
   TestUnpluginProject.assertTransformedToPlugin(result.ast.src as string);
+  // The transform-path spread must preserve sibling params (options/plugins),
+  // not just `src` — a regression dropping them would break Metro's Babel stage.
+  assert.equal((result.ast.options as Record<string, unknown>).platform, "ios");
+  assert.deepEqual(result.ast.plugins, ["babel-plugin-foo"]);
 }
 
 /**
@@ -173,6 +178,11 @@ export async function assertResolvesRelativeFilenameAgainstProjectRoot(): Promis
   // No projectRoot → falls back to cwd.
   assert.equal(
     mod.resolveAbsoluteFilename("src/app.ts", {}),
+    path.resolve(process.cwd(), "src/app.ts"),
+  );
+  // No options object at all → also falls back to cwd.
+  assert.equal(
+    mod.resolveAbsoluteFilename("src/app.ts"),
     path.resolve(process.cwd(), "src/app.ts"),
   );
 }
@@ -327,6 +337,20 @@ export async function assertCacheKeySurvivesMissingUpstream(): Promise<void> {
 }
 
 /**
+ * Asserts `getCacheKey` does not throw when the upstream's own `getCacheKey`
+ * throws — the inner guard must swallow it and still produce a valid key.
+ */
+export async function assertCacheKeySurvivesThrowingUpstreamCacheKey(): Promise<void> {
+  const throwing = TestMetroRuntime.fakeUpstreamThrowingCacheKeyOnDisk();
+  const key = await TestMetroRuntime.withTransformerEnv(
+    { upstreamTransformer: throwing },
+    (mod) => mod.getCacheKey({ projectRoot: "/a" }),
+  );
+  assert.equal(typeof key, "string");
+  assert.equal(key.length, 64);
+}
+
+/**
  * End-to-end: asserts a file outside the tsconfig program passes through
  * untransformed rather than failing the build (the `isFileOutsideProject` =>
  * swallow path). Requires the native compiler → CI-only.
@@ -365,6 +389,11 @@ export async function assertGenuineCompileErrorPropagates(): Promise<void> {
         options: { projectRoot: root },
       },
     }),
-    (error: Error) => !/did not return output/.test(error.message),
+    // Load-bearing: must reject with the actual plugin error (mentions
+    // goUpper), not the out-of-project swallow string, and not a vacuous
+    // environment failure.
+    (error: Error) =>
+      /goUpper/.test(error.message) &&
+      !/did not return output/.test(error.message),
   );
 }

--- a/tests/test-metro/src/internal/metro-transform.ts
+++ b/tests/test-metro/src/internal/metro-transform.ts
@@ -1,0 +1,141 @@
+import { TestUnpluginProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { TestMetroRuntime } from "./metro-runtime";
+
+const ROOT = "/workspace/app";
+
+/** Options that route every transform to the echoing fake upstream. */
+function fakeUpstreamOptions(
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    upstreamTransformer: TestMetroRuntime.fakeUpstreamPathOnDisk(),
+    ...extra,
+  };
+}
+
+/**
+ * Asserts a JavaScript file skips the ttsc pass and reaches the upstream
+ * transformer with its source untouched. The ttsc pass only handles TypeScript;
+ * everything else must pass straight through.
+ */
+export async function assertPassesJavaScriptThrough(): Promise<void> {
+  const src = "export const value = 1;\n";
+  const filename = path.join(ROOT, "src", "app.js");
+  const result = await TestMetroRuntime.runTransform({
+    options: fakeUpstreamOptions(),
+    params: { src, filename, options: { dev: true } },
+  });
+  assert.equal(result.ast.__fakeUpstream, true);
+  assert.equal(result.ast.src, src);
+  assert.equal(result.ast.filename, filename);
+}
+
+/**
+ * Asserts a declaration file passes straight through. The negative twin of the
+ * "transforms TypeScript" path: `.d.ts` files carry no runtime code and must
+ * never be fed to the ttsc project transform.
+ */
+export async function assertPassesDeclarationThrough(): Promise<void> {
+  const src = "declare const ambient: number;\n";
+  const filename = path.join(ROOT, "src", "types.d.ts");
+  const result = await TestMetroRuntime.runTransform({
+    options: fakeUpstreamOptions(),
+    params: { src, filename, options: {} },
+  });
+  assert.equal(result.ast.src, src);
+}
+
+/**
+ * Asserts an excluded TypeScript file passes straight through. The negative
+ * twin of a transformed file: same `.ts` extension, but a path matching an
+ * `exclude` pattern must bypass the ttsc pass.
+ */
+export async function assertExcludedPathPassesThrough(): Promise<void> {
+  const src = 'export const value: string = "x";\n';
+  const filename = path.join(ROOT, "src", "generated", "api.ts");
+  const result = await TestMetroRuntime.runTransform({
+    options: fakeUpstreamOptions({ exclude: ["generated"] }),
+    params: { src, filename, options: {} },
+  });
+  assert.equal(result.ast.src, src);
+}
+
+/**
+ * Asserts that when `include` is set, a TypeScript file outside every include
+ * pattern passes straight through. Pins the include boundary: only matching
+ * paths enter the ttsc pass.
+ */
+export async function assertNonIncludedPathPassesThrough(): Promise<void> {
+  const src = 'export const value: string = "x";\n';
+  const filename = path.join(ROOT, "src", "other", "file.ts");
+  const result = await TestMetroRuntime.runTransform({
+    options: fakeUpstreamOptions({ include: ["src/included"] }),
+    params: { src, filename, options: {} },
+  });
+  assert.equal(result.ast.src, src);
+}
+
+/**
+ * Asserts every Metro transform parameter — not just `src`/`filename` — reaches
+ * the upstream transformer. A custom transformer that dropped `options` or
+ * sibling fields would break Metro's downstream Babel stage.
+ */
+export async function assertForwardsAllParamsToUpstream(): Promise<void> {
+  const filename = path.join(ROOT, "src", "app.js");
+  const result = await TestMetroRuntime.runTransform({
+    options: fakeUpstreamOptions(),
+    params: {
+      src: "export const value = 1;\n",
+      filename,
+      options: { hot: true, platform: "ios" },
+      plugins: ["babel-plugin-foo"],
+    },
+  });
+  assert.deepEqual(result.ast.options, { hot: true, platform: "ios" });
+  assert.deepEqual(result.ast.plugins, ["babel-plugin-foo"]);
+}
+
+/**
+ * Asserts a missing configured upstream transformer fails loudly rather than
+ * silently dropping the file. Upstream resolution happens before filtering, so
+ * even a pass-through file surfaces the error.
+ */
+export async function assertMissingUpstreamThrows(): Promise<void> {
+  await assert.rejects(
+    TestMetroRuntime.runTransform({
+      options: { upstreamTransformer: "@@ttsc-metro-nonexistent-upstream@@" },
+      params: {
+        src: "export const value = 1;\n",
+        filename: path.join(ROOT, "src", "app.js"),
+        options: {},
+      },
+    }),
+    /Could not load the configured upstream transformer/,
+  );
+}
+
+/**
+ * End-to-end: asserts the ttsc plugin pass actually runs on a TypeScript source
+ * and the transformed source is what reaches the upstream transformer.
+ *
+ * Uses the shared fixture project (a Go plugin that uppercases the `goUpper`
+ * call) and the echoing fake upstream, then asserts the source handed
+ * downstream was plugin-transformed. Exercises the real native compiler, so it
+ * runs in CI (Go toolchain present), not in a Go-less local checkout.
+ */
+export async function assertRunsTtscPluginPassOnTypeScript(): Promise<void> {
+  const root = TestUnpluginProject.createProject();
+  const result = await TestMetroRuntime.runTransform({
+    options: fakeUpstreamOptions(),
+    params: {
+      src: TestUnpluginProject.mainSource(root),
+      filename: TestUnpluginProject.mainFile(root),
+      options: {},
+    },
+  });
+  assert.equal(result.ast.__fakeUpstream, true);
+  TestUnpluginProject.assertTransformedToPlugin(result.ast.src as string);
+}

--- a/tests/test-metro/src/internal/metro-transform.ts
+++ b/tests/test-metro/src/internal/metro-transform.ts
@@ -1,5 +1,6 @@
 import { TestUnpluginProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 
 import { TestMetroRuntime } from "./metro-runtime";
@@ -12,6 +13,17 @@ function fakeUpstreamOptions(
 ): Record<string, unknown> {
   return {
     upstreamTransformer: TestMetroRuntime.fakeUpstreamPathOnDisk(),
+    ...extra,
+  };
+}
+
+/** A fully-resolved options object for `shouldTransform` unit tests. */
+function resolvedOptions(extra: Record<string, unknown> = {}): any {
+  return {
+    ttsc: {},
+    include: [],
+    exclude: [],
+    upstreamTransformer: undefined,
     ...extra,
   };
 }
@@ -128,14 +140,231 @@ export async function assertMissingUpstreamThrows(): Promise<void> {
  */
 export async function assertRunsTtscPluginPassOnTypeScript(): Promise<void> {
   const root = TestUnpluginProject.createProject();
+  // Mirror real Metro: a project-relative `filename` plus `projectRoot` in
+  // options. This exercises the relative→absolute resolution; resolving against
+  // cwd instead of projectRoot would make the file look outside the project and
+  // silently skip the plugin pass.
   const result = await TestMetroRuntime.runTransform({
     options: fakeUpstreamOptions(),
     params: {
       src: TestUnpluginProject.mainSource(root),
-      filename: TestUnpluginProject.mainFile(root),
-      options: {},
+      filename: "src/main.ts",
+      options: { projectRoot: root },
     },
   });
   assert.equal(result.ast.__fakeUpstream, true);
   TestUnpluginProject.assertTransformedToPlugin(result.ast.src as string);
+}
+
+/**
+ * Asserts Metro's project-relative `filename` is resolved against
+ * `options.projectRoot` (not `process.cwd()`). The core of the silent-no-op
+ * bug: in monorepos cwd ≠ projectRoot, so resolving against cwd points the ttsc
+ * pass at the wrong path and every file looks "outside the project".
+ */
+export async function assertResolvesRelativeFilenameAgainstProjectRoot(): Promise<void> {
+  const mod = await TestMetroRuntime.loadFreshTransformer();
+  assert.equal(
+    mod.resolveAbsoluteFilename("src/app.ts", {
+      projectRoot: "/workspace/app",
+    }),
+    path.resolve("/workspace/app", "src/app.ts"),
+  );
+  // No projectRoot → falls back to cwd.
+  assert.equal(
+    mod.resolveAbsoluteFilename("src/app.ts", {}),
+    path.resolve(process.cwd(), "src/app.ts"),
+  );
+}
+
+/**
+ * Asserts an already-absolute `filename` is returned unchanged, ignoring
+ * `projectRoot` (the `path.isAbsolute` short-circuit).
+ */
+export async function assertKeepsAbsoluteFilenameUnchanged(): Promise<void> {
+  const mod = await TestMetroRuntime.loadFreshTransformer();
+  const absolute = path.resolve("/workspace/app/src/app.ts");
+  assert.equal(
+    mod.resolveAbsoluteFilename(absolute, { projectRoot: "/somewhere/else" }),
+    absolute,
+  );
+}
+
+/**
+ * Asserts `shouldTransform` accepts every TypeScript source extension
+ * (`.ts`/`.tsx`/`.cts`/`.mts`).
+ */
+export async function assertAcceptsAllTypeScriptExtensions(): Promise<void> {
+  const mod = await TestMetroRuntime.loadFreshTransformer();
+  for (const file of ["/p/a.ts", "/p/a.tsx", "/p/a.cts", "/p/a.mts"]) {
+    assert.equal(mod.shouldTransform(file, resolvedOptions()), true, file);
+  }
+}
+
+/**
+ * Asserts `shouldTransform` rejects declaration files and non-TypeScript
+ * extensions (`.d.ts`/`.d.mts`, `.js`/`.jsx`, `.json`, `.css`) — they pass
+ * straight through to the upstream transformer.
+ */
+export async function assertRejectsNonTypeScriptExtensions(): Promise<void> {
+  const mod = await TestMetroRuntime.loadFreshTransformer();
+  for (const file of [
+    "/p/a.d.ts",
+    "/p/a.d.mts",
+    "/p/a.js",
+    "/p/a.jsx",
+    "/p/a.json",
+    "/p/a.css",
+  ]) {
+    assert.equal(mod.shouldTransform(file, resolvedOptions()), false, file);
+  }
+}
+
+/**
+ * Asserts the include/exclude gating: empty include = all TypeScript; a
+ * matching include selects, a non-matching include rejects; exclude rejects and
+ * wins over a matching include.
+ */
+export async function assertGatesByIncludeAndExclude(): Promise<void> {
+  const mod = await TestMetroRuntime.loadFreshTransformer();
+  const ts = "/p/src/keep/a.ts";
+  assert.equal(
+    mod.shouldTransform(ts, resolvedOptions()),
+    true,
+    "empty include",
+  );
+  assert.equal(
+    mod.shouldTransform(ts, resolvedOptions({ include: ["keep"] })),
+    true,
+    "include match",
+  );
+  assert.equal(
+    mod.shouldTransform(
+      "/p/src/other/a.ts",
+      resolvedOptions({ include: ["keep"] }),
+    ),
+    false,
+    "include non-match",
+  );
+  assert.equal(
+    mod.shouldTransform(ts, resolvedOptions({ exclude: ["keep"] })),
+    false,
+    "exclude match",
+  );
+  assert.equal(
+    mod.shouldTransform(
+      ts,
+      resolvedOptions({ include: ["keep"], exclude: ["keep"] }),
+    ),
+    false,
+    "exclude wins over include",
+  );
+}
+
+/**
+ * Asserts `getCacheKey` is a stable 64-char hex digest, equal across calls for
+ * the same options and different when the options differ.
+ */
+export async function assertCacheKeyIsDeterministicAndOptionSensitive(): Promise<void> {
+  const fake = TestMetroRuntime.fakeUpstreamPathOnDisk();
+  const first = await TestMetroRuntime.withTransformerEnv(
+    { upstreamTransformer: fake, exclude: ["a"] },
+    (mod) => mod.getCacheKey(),
+  );
+  const repeat = await TestMetroRuntime.withTransformerEnv(
+    { upstreamTransformer: fake, exclude: ["a"] },
+    (mod) => mod.getCacheKey(),
+  );
+  const other = await TestMetroRuntime.withTransformerEnv(
+    { upstreamTransformer: fake, exclude: ["b"] },
+    (mod) => mod.getCacheKey(),
+  );
+  assert.equal(typeof first, "string");
+  assert.equal(first.length, 64);
+  assert.equal(first, repeat);
+  assert.notEqual(first, other);
+}
+
+/**
+ * Asserts `getCacheKey` forwards Metro's arguments to the upstream
+ * `getCacheKey` (so a `projectRoot`/babelrc change busts the key) and still
+ * produces a valid key when the upstream exposes no `getCacheKey`.
+ */
+export async function assertCacheKeyForwardsAndFoldsUpstreamKey(): Promise<void> {
+  const fake = TestMetroRuntime.fakeUpstreamPathOnDisk();
+  const keyA = await TestMetroRuntime.withTransformerEnv(
+    { upstreamTransformer: fake },
+    (mod) => mod.getCacheKey({ projectRoot: "/a" }),
+  );
+  const keyB = await TestMetroRuntime.withTransformerEnv(
+    { upstreamTransformer: fake },
+    (mod) => mod.getCacheKey({ projectRoot: "/b" }),
+  );
+  // Forwarded args reach the upstream getCacheKey → different inputs, different key.
+  assert.notEqual(keyA, keyB);
+
+  // An upstream without getCacheKey still yields a valid key (no-upstream branch).
+  const noKey = TestMetroRuntime.fakeUpstreamWithoutCacheKeyOnDisk();
+  const keyC = await TestMetroRuntime.withTransformerEnv(
+    { upstreamTransformer: noKey },
+    (mod) => mod.getCacheKey({ projectRoot: "/a" }),
+  );
+  assert.equal(typeof keyC, "string");
+  assert.equal(keyC.length, 64);
+}
+
+/**
+ * Asserts `getCacheKey` does not throw when the configured upstream cannot be
+ * resolved — cache-key computation must degrade, not crash the whole build.
+ */
+export async function assertCacheKeySurvivesMissingUpstream(): Promise<void> {
+  const key = await TestMetroRuntime.withTransformerEnv(
+    { upstreamTransformer: "@@ttsc-metro-nonexistent-upstream@@" },
+    (mod) => mod.getCacheKey({ projectRoot: "/a" }),
+  );
+  assert.equal(typeof key, "string");
+  assert.equal(key.length, 64);
+}
+
+/**
+ * End-to-end: asserts a file outside the tsconfig program passes through
+ * untransformed rather than failing the build (the `isFileOutsideProject` =>
+ * swallow path). Requires the native compiler → CI-only.
+ */
+export async function assertOutsideProjectFilePassesThrough(): Promise<void> {
+  const root = TestUnpluginProject.createProject();
+  const src = "export const value: number = 1;\n";
+  fs.mkdirSync(path.join(root, "outside"), { recursive: true });
+  fs.writeFileSync(path.join(root, "outside", "stray.ts"), src, "utf8");
+  const result = await TestMetroRuntime.runTransform({
+    options: fakeUpstreamOptions(),
+    params: {
+      src,
+      filename: "outside/stray.ts",
+      options: { projectRoot: root },
+    },
+  });
+  assert.equal(result.ast.__fakeUpstream, true);
+  assert.equal(result.ast.src, src);
+}
+
+/**
+ * End-to-end: asserts a genuine compile/plugin failure propagates (the
+ * `isFileOutsideProject` FALSE branch — rethrow), and is NOT swallowed as an
+ * out-of-project case. Requires the native compiler → CI-only.
+ */
+export async function assertGenuineCompileErrorPropagates(): Promise<void> {
+  const broken = "export const broken: number = 1;\n";
+  const root = TestUnpluginProject.createProject({ source: broken });
+  await assert.rejects(
+    TestMetroRuntime.runTransform({
+      options: fakeUpstreamOptions(),
+      params: {
+        src: broken,
+        filename: "src/main.ts",
+        options: { projectRoot: root },
+      },
+    }),
+    (error: Error) => !/did not return output/.test(error.message),
+  );
 }

--- a/tests/test-metro/src/internal/metro-transform.ts
+++ b/tests/test-metro/src/internal/metro-transform.ts
@@ -91,7 +91,7 @@ export async function assertNonIncludedPathPassesThrough(): Promise<void> {
 }
 
 /**
- * Asserts every Metro transform parameter — not just `src`/`filename` — reaches
+ * Asserts every Metro transform parameter (not just `src`/`filename`) reaches
  * the upstream transformer. A custom transformer that dropped `options` or
  * sibling fields would break Metro's downstream Babel stage.
  */
@@ -156,7 +156,7 @@ export async function assertRunsTtscPluginPassOnTypeScript(): Promise<void> {
   assert.equal(result.ast.__fakeUpstream, true);
   TestUnpluginProject.assertTransformedToPlugin(result.ast.src as string);
   // The transform-path spread must preserve sibling params (options/plugins),
-  // not just `src` — a regression dropping them would break Metro's Babel stage.
+  // not just `src`, a regression dropping them would break Metro's Babel stage.
   assert.equal((result.ast.options as Record<string, unknown>).platform, "ios");
   assert.deepEqual(result.ast.plugins, ["babel-plugin-foo"]);
 }
@@ -213,7 +213,7 @@ export async function assertAcceptsAllTypeScriptExtensions(): Promise<void> {
 
 /**
  * Asserts `shouldTransform` rejects declaration files and non-TypeScript
- * extensions (`.d.ts`/`.d.mts`, `.js`/`.jsx`, `.json`, `.css`) — they pass
+ * extensions (`.d.ts`/`.d.mts`, `.js`/`.jsx`, `.json`, `.css`): they pass
  * straight through to the upstream transformer.
  */
 export async function assertRejectsNonTypeScriptExtensions(): Promise<void> {
@@ -325,7 +325,7 @@ export async function assertCacheKeyForwardsAndFoldsUpstreamKey(): Promise<void>
 
 /**
  * Asserts `getCacheKey` does not throw when the configured upstream cannot be
- * resolved — cache-key computation must degrade, not crash the whole build.
+ * resolved: cache-key computation must degrade, not crash the whole build.
  */
 export async function assertCacheKeySurvivesMissingUpstream(): Promise<void> {
   const key = await TestMetroRuntime.withTransformerEnv(
@@ -338,7 +338,7 @@ export async function assertCacheKeySurvivesMissingUpstream(): Promise<void> {
 
 /**
  * Asserts `getCacheKey` does not throw when the upstream's own `getCacheKey`
- * throws — the inner guard must swallow it and still produce a valid key.
+ * throws: the inner guard must swallow it and still produce a valid key.
  */
 export async function assertCacheKeySurvivesThrowingUpstreamCacheKey(): Promise<void> {
   const throwing = TestMetroRuntime.fakeUpstreamThrowingCacheKeyOnDisk();
@@ -374,7 +374,7 @@ export async function assertOutsideProjectFilePassesThrough(): Promise<void> {
 
 /**
  * End-to-end: asserts a genuine compile/plugin failure propagates (the
- * `isFileOutsideProject` FALSE branch — rethrow), and is NOT swallowed as an
+ * `isFileOutsideProject` FALSE branch, rethrow), and is NOT swallowed as an
  * out-of-project case. Requires the native compiler → CI-only.
  */
 export async function assertGenuineCompileErrorPropagates(): Promise<void> {

--- a/tests/test-metro/src/internal/metro-upstream.ts
+++ b/tests/test-metro/src/internal/metro-upstream.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+
+import { TestMetroRuntime } from "./metro-runtime";
+
+/**
+ * A stub upstream transformer tagged with the module specifier that produced
+ * it.
+ */
+function tagged(name: string): {
+  transform: (params: unknown) => Promise<{ ast: { name: string } }>;
+} {
+  return { transform: async () => ({ ast: { name } }) };
+}
+
+async function nameOf(upstream: {
+  transform: (params: unknown) => Promise<{ ast: { name: string } }>;
+}): Promise<string> {
+  const result = await upstream.transform({
+    src: "",
+    filename: "",
+    options: {},
+  });
+  return result.ast.name;
+}
+
+/**
+ * Asserts auto-detection tries the candidates in priority order (Expo → modern
+ * RN → legacy RN): the first resolvable candidate wins, and removing earlier
+ * ones falls through to the next.
+ */
+export async function assertAutoDetectsInPriorityOrder(): Promise<void> {
+  const { resolveUpstreamTransformer, UPSTREAM_CANDIDATES } =
+    await TestMetroRuntime.loadUpstream();
+  const [expo, rn, legacy] = UPSTREAM_CANDIDATES as readonly string[];
+
+  // All available → Expo (first) wins.
+  assert.equal(
+    await nameOf(
+      resolveUpstreamTransformer(undefined, (p: string) => tagged(p)),
+    ),
+    expo,
+  );
+  // Expo missing → modern RN.
+  assert.equal(
+    await nameOf(
+      resolveUpstreamTransformer(undefined, (p: string) =>
+        p === expo ? undefined : tagged(p),
+      ),
+    ),
+    rn,
+  );
+  // Expo + modern RN missing → legacy.
+  assert.equal(
+    await nameOf(
+      resolveUpstreamTransformer(undefined, (p: string) =>
+        p === expo || p === rn ? undefined : tagged(p),
+      ),
+    ),
+    legacy,
+  );
+}
+
+/**
+ * Asserts auto-detection throws a clear error when no upstream transformer can
+ * be resolved at all.
+ */
+export async function assertThrowsWhenNoUpstreamInstalled(): Promise<void> {
+  const { resolveUpstreamTransformer } = await TestMetroRuntime.loadUpstream();
+  assert.throws(
+    () => resolveUpstreamTransformer(undefined, () => undefined),
+    /Could not find an upstream Metro transformer/,
+  );
+}
+
+/**
+ * Asserts an empty-string `customPath` is treated as "not configured" and falls
+ * through to auto-detection rather than attempting to resolve `""`.
+ */
+export async function assertEmptyCustomPathFallsBackToAutoDetect(): Promise<void> {
+  const { resolveUpstreamTransformer, UPSTREAM_CANDIDATES } =
+    await TestMetroRuntime.loadUpstream();
+  assert.equal(
+    await nameOf(resolveUpstreamTransformer("", (p: string) => tagged(p))),
+    (UPSTREAM_CANDIDATES as readonly string[])[0],
+  );
+}

--- a/tests/test-metro/tsconfig.json
+++ b/tests/test-metro/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/website/src/content/docs/setup.mdx
+++ b/website/src/content/docs/setup.mdx
@@ -128,6 +128,30 @@ export default {
 
 Adapters ship for Vite, Rollup, Rolldown, esbuild, Webpack, Rspack, Next.js, Turbopack, Farm, and Bun. Import the entrypoint that matches your bundler (`@ttsc/unplugin/webpack`, `@ttsc/unplugin/esbuild`, and so on). See [Bundler integration](/docs/ttsc/bundler) for every adapter, the `project` / `compilerOptions` / `plugins` options, and watch-mode behavior.
 
+## React Native / Expo (@ttsc/metro)
+
+React Native and Expo bundle with Metro, not a web bundler, so the `ttsc` CLI and `@ttsc/unplugin` never run.
+
+[`@ttsc/metro`](/docs/ttsc/bundler) is a Metro transformer that runs the same plugin pass on each TypeScript file, then hands the result to your existing Expo or React-Native Babel transformer.
+
+### Install
+
+```bash
+npm install -D @ttsc/metro
+```
+
+### `metro.config.js`
+
+```js
+// Expo (CommonJS, the standard for metro.config.js)
+const { getDefaultConfig } = require("expo/metro-config");
+const { withTtsc } = require("@ttsc/metro");
+
+module.exports = withTtsc(getDefaultConfig(__dirname));
+```
+
+For bare React Native, wrap `getDefaultConfig` from `@react-native/metro-config` instead. It reads the same `tsconfig.json`, so your plugins and `lint.config.ts` apply unchanged. See [Bundler integration](/docs/ttsc/bundler) for the options and the v1 caveats.
+
 ## Editor (VS Code)
 
 The VS Code extension reads your project's `ttsc` setup, so editor diagnostics match your build.

--- a/website/src/content/docs/ttsc/bundler.mdx
+++ b/website/src/content/docs/ttsc/bundler.mdx
@@ -120,6 +120,26 @@ await Bun.build({
 });
 ```
 
+## React Native / Expo (Metro)
+
+Metro is not an `unplugin` target, so it has its own adapter package, [`@ttsc/metro`](https://github.com/samchon/ttsc/tree/master/packages/metro). Metro transpiles each file with Babel, which strips types and never runs TypeScript transformers; `@ttsc/metro` inserts the `ttsc` plugin pass before that Babel step and delegates the rest to your existing Expo/React-Native transformer.
+
+```bash
+npm install -D ttsc typescript@rc @ttsc/metro
+```
+
+```js
+// metro.config.js — Expo
+const { getDefaultConfig } = require("expo/metro-config");
+const { withTtsc } = require("@ttsc/metro");
+
+module.exports = withTtsc(getDefaultConfig(__dirname));
+```
+
+For bare React Native, wrap `getDefaultConfig` from `@react-native/metro-config` instead. `withTtsc` reads the same `tsconfig.json` and plugin configuration as the CLI and `@ttsc/unplugin`; options (`project`, `compilerOptions`, `plugins`, `upstreamTransformer`, `include`/`exclude`) go in the second argument.
+
+Two v1 caveats: the project is type-checked once per Metro worker (a resident incremental compiler is the planned optimization — [#255](https://github.com/samchon/ttsc/issues/255)), and because Metro's transform cache is keyed per-file, restart with `--reset-cache` after changing `tsconfig`/plugin config or a depended-upon type. See the [`@ttsc/metro` README](https://github.com/samchon/ttsc/tree/master/packages/metro) for details.
+
 ## Configuration
 
 `@ttsc/unplugin` reads your existing `tsconfig.json`, same plugins, same configs (`lint.config.ts`, `banner.config.ts`, …). For most projects no adapter-specific options are needed.
@@ -142,6 +162,7 @@ Two more options layer on top of that config: `compilerOptions` for a one-off ov
 | Frontend with Vite / Webpack / Rspack | `@ttsc/unplugin` inside the bundler |
 | Backend (e.g., NestJS) bundled with Webpack | `@ttsc/unplugin` |
 | Both, monorepo with library + frontend | CLI for the library, `@ttsc/unplugin` for the frontend |
+| React Native / Expo | `@ttsc/metro` (Metro transformer) |
 
 The plugin pass is identical either way. Diagnostics show up wherever the bundler surfaces them.
 

--- a/website/src/content/docs/ttsc/bundler.mdx
+++ b/website/src/content/docs/ttsc/bundler.mdx
@@ -44,7 +44,7 @@ export default {
 };
 ```
 
-The adapter emits transformed **TypeScript**, not JavaScript. Plain Rollup does not compile TypeScript itself, so add a downstream TypeScript-to-JavaScript step after `ttsc()` (an esbuild- or swc-based Rollup plugin, for example) — otherwise the build fails parsing the type syntax. Bundlers that strip types on their own (Vite, esbuild, Bun) need no extra step.
+The adapter emits transformed **TypeScript**, not JavaScript. Plain Rollup does not compile TypeScript itself, so add a downstream TypeScript-to-JavaScript step after `ttsc()` (an esbuild- or swc-based Rollup plugin, for example), otherwise the build fails parsing the type syntax. Bundlers that strip types on their own (Vite, esbuild, Bun) need no extra step.
 
 ## esbuild
 
@@ -129,7 +129,7 @@ npm install -D ttsc typescript@rc @ttsc/metro
 ```
 
 ```js
-// metro.config.js — Expo
+// metro.config.js (Expo)
 const { getDefaultConfig } = require("expo/metro-config");
 const { withTtsc } = require("@ttsc/metro");
 
@@ -138,7 +138,7 @@ module.exports = withTtsc(getDefaultConfig(__dirname));
 
 For bare React Native, wrap `getDefaultConfig` from `@react-native/metro-config` instead. `withTtsc` reads the same `tsconfig.json` and plugin configuration as the CLI and `@ttsc/unplugin`; options (`project`, `compilerOptions`, `plugins`, `upstreamTransformer`, `include`/`exclude`) go in the second argument.
 
-Two v1 caveats: the project is type-checked once per Metro worker (a resident incremental compiler is the planned optimization — [#255](https://github.com/samchon/ttsc/issues/255)), and because Metro's transform cache is keyed per-file, restart with `--reset-cache` after changing `tsconfig`/plugin config or a depended-upon type. See the [`@ttsc/metro` README](https://github.com/samchon/ttsc/tree/master/packages/metro) for details.
+Two v1 caveats: the project is type-checked once per Metro worker (a resident incremental compiler is the planned optimization, [#255](https://github.com/samchon/ttsc/issues/255)), and because Metro's transform cache is keyed per-file, restart with `--reset-cache` after changing `tsconfig`/plugin config or a depended-upon type. See the [`@ttsc/metro` README](https://github.com/samchon/ttsc/tree/master/packages/metro) for details.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Adds **`@ttsc/metro`** — a Metro custom transformer that runs the `ttsc` plugin pass (typia, nestia, …) on each TypeScript file in React Native / Expo projects, then delegates to the project's existing Expo/React-Native Babel transformer. This closes the last major gap where `ttsc` plugins could not run: Metro bundles with Babel, which strips types and never runs TypeScript transformers, so neither the `ttsc` CLI nor `@ttsc/unplugin` could reach an RN/Expo build.

Design mirrors the reference implementation [`@elliots/metro-transformer-typical`](https://github.com/elliots/typical/tree/main/packages/metro-transformer) and the analysis in #255.

## How it works

```js
// metro.config.js — Expo
const { getDefaultConfig } = require("expo/metro-config");
const { withTtsc } = require("@ttsc/metro");
module.exports = withTtsc(getDefaultConfig(__dirname));
```

`withTtsc` sets `transformer.babelTransformerPath` to the package transformer and publishes resolved options to Metro's worker processes via the `TTSC_METRO_OPTIONS` env var (the workers never see the `withTtsc` call). Per file: ttsc plugin pass (reusing `@ttsc/unplugin`'s `transformTtsc` core) → transformed **TypeScript** → upstream Babel transformer (strips types, RN transforms) → the Babel AST Metro consumes. With no options it auto-discovers `tsconfig.json` and runs its configured plugins.

## Scope

- `packages/metro`: the adapter (`withTtsc`, the transformer, upstream auto-detection, options + worker-env transport).
- `tests/test-metro`: 14 cases (config / options / transform), mirroring the `@ttsc/test-unplugin` harness — one assertion per file, positive + negative twins + boundaries, including an end-to-end proof that the plugin pass runs and its output reaches the upstream.
- Docs: `bundler.mdx` RN/Expo section + decision-table row; package `README`; root `README` adapter list.
- CI (Change Integrity): build `@ttsc/metro` in `build-current.cjs`; add a `metro` entry to the `test.yml` matrix.
- Minor refactor: dropped the module-level upstream-resolution cache (Node's `require` cache already memoizes it; removing the hidden state lets a changed `upstreamTransformer` always take effect).

## Deferred (tracked in #255)

v1 reuses the whole-project compile (one compile per Metro worker) and a static transform cache key. A resident, incremental, per-file compiler shared across workers — and cross-file type-dependency cache invalidation — are the follow-ups. Documented in the package README "Caveats" (`--reset-cache` guidance included).

## Test plan

- `pnpm --filter @ttsc/test-metro start` (CI: Node 24 + Go) — full suite, including the end-to-end ttsc-plugin-pass case (real native compiler + Go source plugin).
- `pnpm run test:typecheck` covers the new package and suite (auto-discovered).
- Verified locally: `@ttsc/metro` and `@ttsc/test-metro` type-check clean; the package builds to cjs/esm/d.ts. The shared `TestExecutor` discovery can't run on a local Windows checkout (a pre-existing `file://` URL limitation that also blocks `@ttsc/test-unplugin` locally), so the feature suite is verified via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
