### PR TITLE
[codex] Add TTSC meetup presentation slides

### DIFF
--- a/website/public/presentations/20260622-tsbm.md
+++ b/website/public/presentations/20260622-tsbm.md
@@ -1,0 +1,1334 @@
+---
+marp: true
+theme: default
+paginate: true
+size: 16:9
+title: "TTSC: Transformer Survival in the TypeScript 7 Era"
+description: "TypeScript Backend Meetup, 2026-06-26"
+footer: "TTSC | TypeScript Backend Meetup | 2026-06-26"
+style: |
+  section {
+    font-family: "Inter", "Segoe UI", "Pretendard", sans-serif;
+    color: #111827;
+    padding: 72px 84px;
+  }
+  section.lead {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  h1 {
+    color: #0f172a;
+    font-size: 58px;
+  }
+  h2 {
+    color: #0f172a;
+    font-size: 44px;
+  }
+  h3 {
+    color: #2563eb;
+    font-size: 32px;
+  }
+  strong {
+    color: #2563eb;
+  }
+  code {
+    font-family: "Cascadia Code", monospace;
+  }
+  table {
+    font-size: 24px;
+  }
+  blockquote {
+    border-left: 8px solid #2563eb;
+    color: #1f2937;
+    font-size: 34px;
+    padding-left: 28px;
+  }
+  section.split h1 {
+    margin-bottom: 28px;
+  }
+  section.split .cols {
+    align-items: stretch;
+    display: grid;
+    gap: 36px;
+    grid-template-columns: 0.95fr 1.05fr;
+  }
+  section.split .cols.equal {
+    grid-template-columns: 1fr 1fr;
+  }
+  section.split .col {
+    min-width: 0;
+  }
+  section.split .panel,
+  section.split .code-card,
+  section.split .diagram {
+    background: #f8fafc;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    padding: 22px;
+  }
+  section.split .label {
+    color: #2563eb;
+    font-size: 22px;
+    font-weight: 700;
+    margin-bottom: 14px;
+    text-transform: uppercase;
+  }
+  section.split .caption {
+    color: #475569;
+    font-size: 24px;
+    margin-top: 16px;
+  }
+  section.split pre {
+    background: #0f172a;
+    border-radius: 8px;
+    color: #e5e7eb;
+    font-size: 20px;
+    line-height: 1.35;
+    margin: 0;
+    padding: 18px;
+  }
+  section.split .node,
+  section.split .hub,
+  section.split .metric {
+    background: #ffffff;
+    border: 1px solid #94a3b8;
+    border-radius: 8px;
+    padding: 14px 18px;
+  }
+  section.split .node {
+    font-size: 24px;
+    font-weight: 700;
+    text-align: center;
+  }
+  section.split .arrow {
+    color: #64748b;
+    font-size: 28px;
+    font-weight: 800;
+    margin: 10px 0;
+    text-align: center;
+  }
+  section.split .flow-grid {
+    display: grid;
+    gap: 12px;
+  }
+  section.split .hub {
+    border-color: #2563eb;
+    color: #0f172a;
+    font-size: 28px;
+    font-weight: 800;
+    margin: 16px 0;
+    text-align: center;
+  }
+  section.split .spokes {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: 1fr 1fr;
+  }
+  section.split .mini {
+    color: #334155;
+    font-size: 22px;
+  }
+  section.split .metric {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    justify-content: center;
+    min-height: 280px;
+  }
+  section.split .metric strong {
+    color: #16a34a;
+    font-size: 96px;
+    line-height: 1;
+  }
+  section.split .bar {
+    align-items: center;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: 110px 1fr 110px;
+    margin: 12px 0;
+  }
+  section.split .bar-fill {
+    background: #2563eb;
+    border-radius: 8px;
+    height: 18px;
+  }
+  section.split .bar-fill.green {
+    background: #16a34a;
+  }
+---
+
+<!-- _class: lead -->
+
+# TTSC
+
+## Transformer Survival in the TypeScript 7 Era
+
+TypeScript Backend Developer Meetup
+
+Samchon, Wrtn Technologies
+
+2026-06-26
+
+<!--
+Notes:
+- Open like the existing PPTX decks: title, subtitle, meetup, speaker, date.
+- The story is personal and practical: transformer libraries made typia and nestia useful, but TypeScript 7 moves the compiler ground.
+- TTSC is the toolchain answer to that survival problem.
+-->
+
+---
+
+# TL;DR;
+
+## typia / nestia
+
+## TypeScript 7
+
+## TTSC
+
+## @ttsc/lint
+
+<!--
+Notes:
+- Keep this as the same four-keyword opening style as the PPTX files.
+- Each keyword gets one preview slide before Preface.
+- Do not explain everything here. This slide is the map.
+-->
+
+---
+
+# TTSC
+
+TypeScript-Go compiler toolchain
+
+- transformer host
+- runtime launcher
+- LSP proxy
+- bundler adapters
+- lint / format
+
+<!--
+Notes:
+- TTSC is not just a command wrapper.
+- It is a compiler, runtime, plugin host, and LSP host built around TypeScript-Go.
+- typia and nestia are the first big consumers, but the contract is general-purpose.
+-->
+
+---
+
+# typia
+
+TypeScript compiler plugin
+
+- analyzes source code at compile time
+- overcomes runtime type erasure
+- generates AOT runtime code
+- validates, serializes, schemas, LLM tools
+
+<!--
+Notes:
+- This mirrors the typia slide in the existing function-calling deck.
+- typia should sound like compiler infrastructure, not a small validator package.
+- Mention that one TypeScript type can become validators, JSON serializers, schemas, LLM tool contracts, protobuf codecs, and random generators.
+-->
+
+---
+
+# TypeScript 7
+
+Native TypeScript compiler
+
+- much faster
+- written in Go
+- new LSP path
+- old patch route breaks
+
+<!--
+Notes:
+- We are not attacking TypeScript 7. It is great for TypeScript users.
+- The problem is that the old transformer hosting route depended on the JavaScript compiler implementation.
+- When the compiler moves, transformer libraries need a new host.
+-->
+
+---
+
+# @ttsc/lint
+
+Compiler-integrated lint
+
+- no second parse
+- checker-aware rules
+- diagnostics in compile path
+- VS Code benchmark: about 900x lint pass gap
+
+<!--
+Notes:
+- This is the later performance punchline.
+- Be precise: the 900x claim is about isolated lint pass cost on the VS Code fixture, comparing ESLint time to @ttsc/lint plugin time.
+- Full command time still includes the TypeScript diagnostics path.
+-->
+
+---
+
+# Preface
+
+## Transformer libraries are real infrastructure.
+
+## TypeScript 7 changes their foundation.
+
+## TTSC rebuilds the foundation.
+
+<!--
+Notes:
+- This is the three-claim Preface slide, matching the PPT style.
+- The talk is not a feature catalog. It is a sequence: value, breakage, replacement.
+- Keep the claim words direct.
+-->
+
+---
+
+# Preface
+
+```text
+TypeScript type
+  -> compiler knowledge
+  -> runtime artifact
+```
+
+That arrow was never official.
+
+<!--
+Notes:
+- This is the broken contract.
+- TypeScript knows the type graph during compilation, but official tsc does not provide a production transformer plugin system.
+- typia and nestia built value on this gap anyway because the backend use case needed it.
+-->
+
+---
+
+<!-- _class: lead -->
+
+# 1. Compiler-Level Libraries
+
+## 1.1. typia
+
+## 1.2. nestia
+
+## 1.3. Unsupported Contract
+
+<!--
+Notes:
+- Big section opener, exactly in the PPT style: section title plus three subtopics.
+- This section proves why transformer support is worth saving before talking about TypeScript 7.
+- Spend the most time on typia because it is the clearest compiler-level example.
+-->
+
+---
+
+# 1.1. Typia
+
+A TypeScript compiler plugin
+
+- source analysis at compile time
+- runtime type erasure bypass
+- AOT validation code
+- one line, no separate schema
+
+```ts
+typia.validate<T>(input);
+```
+
+<!--
+Notes:
+- This mirrors the "What Is Typia" PPT slide.
+- The key sentence: typia is not a runtime reflection library.
+- It asks the compiler for T before T disappears.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 1.1. Typia - TS to JS Transform
+
+<!-- prettier-ignore-start -->
+<div class="cols equal">
+<div class="col code-card">
+<div class="label">Before Compilation</div>
+<pre><code class="language-ts">import typia, { tags } from "typia";<br /><br />interface IMember {<br />&nbsp;&nbsp;email: string & tags.Format&lt;"email"&gt;;<br />&nbsp;&nbsp;age: number & tags.Type&lt;"uint32"&gt;;<br />}<br /><br />typia.is&lt;IMember&gt;(input);</code></pre>
+
+</div>
+<div class="col code-card">
+<div class="label">After Compilation</div>
+<pre><code class="language-js">"object" === typeof input &&
+null !== input &&
+"string" === typeof input.email &&
+_isFormatEmail(input.email) &&
+"number" === typeof input.age &&
+Number.isInteger(input.age);</code></pre>
+<div class="caption">No runtime reflection. Generated from Checker data.</div>
+</div>
+</div>
+<!-- prettier-ignore-end -->
+
+<!--
+Notes:
+- Do not show the full generated validator in Marp. Say it aloud.
+- In the PPT deck this is the visual proof: one TypeScript call expands into ordinary JavaScript checks.
+- The generated code checks UUID, email, integer, range, nesting, unions, and tags without runtime schema discovery.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 1.1. Typia - Type to Schema
+
+<div class="cols equal">
+<div class="col code-card">
+<div class="label">TypeScript Type</div>
+<pre><code class="language-ts">interface IMember {<br />&nbsp;&nbsp;/**<br />&nbsp;&nbsp; * Only adults can register.<br />&nbsp;&nbsp; */<br />&nbsp;&nbsp;age: number<br />&nbsp;&nbsp;&nbsp;&nbsp;& tags.Type&lt;"uint32"&gt;<br />&nbsp;&nbsp;&nbsp;&nbsp;& tags.ExclusiveMinimum&lt;18&gt;;<br /><br />&nbsp;&nbsp;email: string & tags.Format&lt;"email"&gt;;<br />}<br /><br />typia.llm.parameters&lt;IMember&gt;();</code></pre>
+
+</div>
+<div class="col code-card">
+<div class="label">Generated Schema</div>
+<pre><code class="language-json">{
+  "type": "object",
+  "properties": {
+    "age": {
+      "type": "integer",
+      "exclusiveMinimum": 18,
+      "description": "Only adults can register."
+    },
+    "email": {
+      "type": "string",
+      "format": "email"
+    }
+  },
+  "required": ["age", "email"]
+}</code></pre>
+</div>
+</div>
+
+<!--
+Notes:
+- This follows the "Type -> Schema: Automatic Generation" PPT slide.
+- JSDoc becomes descriptions. Type constraints become schema constraints.
+- The point is one source of truth, not another hand-written JSON Schema file.
+-->
+
+---
+
+# 1.1. Typia - API Surface
+
+| Area      | Example                               |
+| --------- | ------------------------------------- |
+| Validator | `typia.validate<T>(input)`            |
+| JSON      | `typia.json.assertStringify<T>(data)` |
+| Schema    | `typia.json.schemas<[T]>()`           |
+| LLM       | `typia.llm.application<App>()`        |
+| Protobuf  | `typia.protobuf.message<T>()`         |
+| Test data | `typia.random<T>()`                   |
+
+<!--
+Notes:
+- typia.io presents this as a broad compiler-backed toolkit.
+- The feature list is wide, but the input is always TypeScript's type graph.
+- Mention the typia headline claims here: validation can be far faster than decorator-based validators, and JSON serialization can be much faster than reflection-style approaches.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 1.1. typia.llm.application
+
+<div class="cols">
+<div class="col code-card">
+<div class="label">Input</div>
+<pre><code class="language-ts">class BookmarkService {
+  create(input: IBookmarkCreate): Promise&lt;IBookmark&gt;;
+  erase(input: IBookmarkErase): Promise&lt;void&gt;;
+}
+
+typia.llm.application&lt;BookmarkService&gt;();</code></pre>
+
+</div>
+<div class="col diagram">
+<div class="label">Generated Harness</div>
+<div class="flow-grid">
+  <div class="node">method schemas</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">parse()</div>
+  <div class="node">coerce()</div>
+  <div class="node">validate()</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">typed execute()</div>
+</div>
+</div>
+</div>
+
+<!--
+Notes:
+- This copies the function-calling harness deck's typia emphasis.
+- A class becomes a set of function-calling schemas.
+- Each method gets schema generation, lenient parsing, type coercion, validation, and execution wiring.
+-->
+
+---
+
+# 1.1. Validation Feedback
+
+```text
+path: $.order.payment.cardNumber
+expected: string
+actual: number
+```
+
+Fix the broken field.
+
+<!--
+Notes:
+- This is why typia matters for backend and AI workflows.
+- The validator reports exact paths and expected types.
+- That turns an invalid value into a targeted correction, not a full blind retry.
+-->
+
+---
+
+# 1.2. nestia
+
+NestJS controller
+
+```text
+controller
+  -> OpenAPI
+  -> typed SDK
+  -> e2e helpers
+```
+
+Type-first backend contracts.
+
+<!--
+Notes:
+- nestia is the backend-facing sibling of the same transformer story.
+- It analyzes NestJS controllers and TypeScript types to generate OpenAPI documents, SDKs, and tests.
+- The audience is TypeScript backend developers, so this slide connects compiler plugins to daily API work.
+-->
+
+---
+
+# 1.2. nestia - Contract Output
+
+- request validation
+- response serialization
+- OpenAPI
+- typed client SDK
+- e2e helpers
+- LLM function schemas
+
+One controller, many artifacts.
+
+<!--
+Notes:
+- This slide mirrors the "one type becomes many artifacts" typia slide.
+- The backend value is lower duplication and a stronger client contract.
+- Tie it back to TTSC: this only works if the compiler can host the analyzer reliably.
+-->
+
+---
+
+# 1.3. Unsupported Contract
+
+Official TypeScript:
+
+```text
+types for compile-time
+JavaScript for runtime
+no production transformer plugin API
+```
+
+typia needs the missing middle.
+
+<!--
+Notes:
+- This is the real problem statement.
+- TypeScript's official model does not promise production transformer plugins.
+- The ecosystem still needed them, so ts-patch became the practical route.
+-->
+
+---
+
+# 1.3. Runtime Type Erasure
+
+```ts
+typia.validate<User>(input);
+```
+
+looks like a runtime function.
+
+```text
+User exists in Checker,
+not in JavaScript.
+```
+
+<!--
+Notes:
+- This explains why a normal library cannot do typia's job.
+- Generic type arguments are erased.
+- The transformer must run while the Program and Checker still know User.
+-->
+
+---
+
+# 1.3. Hidden API
+
+```text
+compiler Program
+  -> Checker
+  -> AST transform
+  -> emitted JavaScript
+```
+
+That path was useful, but unofficial.
+
+<!--
+Notes:
+- The old ecosystem found a route through the JavaScript compiler.
+- It worked well enough for typia and nestia users.
+- But unofficial integration means the host can disappear when the compiler architecture changes.
+-->
+
+---
+
+<!-- _class: lead -->
+
+# 2. TypeScript 7
+
+## 2.1. ts-patch Era
+
+## 2.2. Native Compiler
+
+## 2.3. Survival Problem
+
+<!--
+Notes:
+- Second big section opener.
+- The story now shifts from "why these libraries matter" to "why the old route is gone."
+- Keep the tone balanced: TypeScript 7 is good, but it breaks an unofficial ecosystem path.
+-->
+
+---
+
+# 2.1. ts-patch Era
+
+```text
+npm install -D ts-patch
+ts-patch install
+```
+
+Then transformer libraries could ride `tsc`.
+
+<!--
+Notes:
+- Explain the old production path in one slide.
+- ts-patch patched the JavaScript TypeScript compiler package so custom transformers could run.
+- For typia and nestia, this was the practical way to ship.
+-->
+
+---
+
+# 2.1. Why It Worked
+
+```text
+TypeScript was JavaScript
+node_modules was patchable
+Program and Checker were reachable
+emit pipeline was mutable
+```
+
+Useful, but fragile.
+
+<!--
+Notes:
+- This is the hidden contract behind ts-patch.
+- It depended on implementation details that were never guaranteed as a stable extension point.
+- The next section explains why TypeScript 7 breaks that assumption.
+-->
+
+---
+
+# 2.1. Cost of the Old Route
+
+- install-time patching
+- version-sensitive internals
+- editor mismatch risk
+- source map risk
+- bundler/runtime gaps
+
+The ecosystem tolerated it.
+
+<!--
+Notes:
+- Do not overstate ts-patch as bad. It saved transformer libraries for years.
+- The point is that the old route was a workaround.
+- TTSC should preserve the value while removing the scary parts for users.
+-->
+
+---
+
+# 2.2. Native Compiler
+
+TypeScript 7 introduces the Go-native compiler.
+
+```text
+large codebases
+  -> faster check
+  -> faster editor
+  -> different host
+```
+
+<!--
+Notes:
+- The TypeScript team benchmarked VS Code and other projects to show the native compiler's speed.
+- That is good news for TypeScript itself.
+- But transformer libraries cannot assume the old JavaScript internals exist.
+-->
+
+---
+
+# 2.2. VS Code Benchmark
+
+Microsoft's TypeScript 7 RC numbers:
+
+| Project | JS tsc | Native | Speedup |
+| ------- | -----: | -----: | ------: |
+| VS Code | 77.8 s |  7.5 s |   10.4x |
+
+The compiler moved for a reason.
+
+<!--
+Notes:
+- Use Microsoft's VS Code number because the user explicitly asked for that comparison basis earlier.
+- The message is not "TypeScript 7 is a problem." The speedup is why TypeScript 7 will matter.
+- That makes transformer survival urgent, not optional.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 2.2. Programmatic API Gap
+
+<div class="cols equal">
+<div class="col diagram">
+<div class="label">Old Route</div>
+<div class="flow-grid">
+  <div class="node">require("typescript")</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">patch JS compiler</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">custom transformer</div>
+</div>
+</div>
+<div class="col diagram">
+<div class="label">TypeScript 7 Route</div>
+<div class="flow-grid">
+  <div class="node">native compiler</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">LSP-oriented host</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">new plugin bridge needed</div>
+</div>
+</div>
+</div>
+
+<!--
+Notes:
+- Keep this simple for backend developers.
+- The JavaScript compiler package was patchable.
+- The Go-native compiler path needs a new plugin host and a new bridge to editor/runtime tools.
+-->
+
+---
+
+# 2.3. Survival Problem
+
+```text
+typia depends on compiler transforms
+nestia depends on compiler analysis
+ts-patch depends on the old host
+TypeScript 7 changes the host
+```
+
+That is a cliff.
+
+<!--
+Notes:
+- This is the "we are going to die" slide, but in conference English.
+- The user story belongs here: I built typia and nestia, and the old survival route was closing.
+- The conclusion should feel inevitable: if no host exists, build the host.
+-->
+
+---
+
+# 2.3. No One Else Was Coming
+
+```text
+Need transformer support
+Need TypeScript-Go
+Need editor support
+Need bundlers
+Need source maps
+```
+
+So I built TTSC.
+
+<!--
+Notes:
+- This is the personal pivot.
+- "The one who needs the well digs the well" becomes "I needed the host, so I built it."
+- Keep it direct and a little dry.
+-->
+
+---
+
+# 2.3. Design Constraint
+
+Do not make users learn compiler internals.
+
+```bash
+npm install -D ttsc typescript@rc typia
+npx ttsc --noEmit
+```
+
+The host must feel boring.
+
+<!--
+Notes:
+- This sets up section 3.
+- The replacement cannot be a research prototype.
+- It has to be easier, safer, and more convenient than the workaround it replaces.
+-->
+
+---
+
+<!-- _class: lead -->
+
+# 3. TTSC
+
+## 3.1. Transformer Host
+
+## 3.2. Integrations
+
+## 3.3. Linter
+
+<!--
+Notes:
+- Third big section opener.
+- This follows the PPT convention: one section slide names the three subtopics.
+- The narrative is now constructive: host, integrations, and lint payoff.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 3.1. Transformer Host
+
+<div class="cols">
+<div class="col diagram">
+<div class="label">Compile Path</div>
+<div class="flow-grid">
+  <div class="node">tsconfig.json</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">ttsc</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">TypeScript-Go Program</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">JS / d.ts / diagnostics</div>
+</div>
+</div>
+<div class="col diagram">
+<div class="label">Plugin Layer</div>
+<div class="hub">Program + Checker</div>
+<div class="spokes">
+  <div class="node">typia</div>
+  <div class="node">nestia</div>
+  <div class="node">@ttsc/lint</div>
+  <div class="node">custom plugins</div>
+</div>
+<div class="caption">Same type graph, one compiler pass.</div>
+</div>
+</div>
+
+<!--
+Notes:
+- TTSC hosts plugins against the TypeScript-Go Program and Checker.
+- Plugins can generate transforms and diagnostics from the same type graph the compiler already built.
+- The goal is to preserve typia's compiler-level model in the TypeScript 7 era.
+-->
+
+---
+
+# 3.1. What Ships
+
+- `ttsc`
+- `ttsx`
+- `ttscserver`
+- plugin protocol
+- VS Code extension
+- unplugin adapters
+- Metro adapter
+
+One compiler toolchain.
+
+<!--
+Notes:
+- This uses the project contract from the repo.
+- ttsc builds and checks, ttsx runs a typed entrypoint, and ttscserver proxies the TypeScript-Go LSP.
+- The rest makes the same compiler behavior reachable from the editor and build tools.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 3.1. Plugin Pipeline
+
+<div class="cols">
+<div class="col diagram">
+<div class="label">Author Side</div>
+<div class="flow-grid">
+  <div class="node">Go plugin source</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">package metadata</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">npm package</div>
+</div>
+</div>
+<div class="col diagram">
+<div class="label">User Side</div>
+<div class="flow-grid">
+  <div class="node">install package</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">build on demand</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">cached native sidecar</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">transform / diagnostics / commands</div>
+</div>
+</div>
+</div>
+
+<!--
+Notes:
+- Plugin authors write Go source packages for TypeScript-Go.
+- TTSC builds plugin sources on demand and caches the result.
+- Users should see normal npm installation behavior, not a manual native-plugin workflow.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 3.2. Source Maps
+
+<!-- prettier-ignore-start -->
+<div class="cols">
+<div class="col code-card">
+<div class="label">Source</div>
+<pre><code class="language-ts">// main.ts<br />const ok = typia.is&lt;User&gt;(input);<br /><br />if (!ok) {<br />&nbsp;&nbsp;throw new Error("invalid user");<br />}</code></pre>
+
+<div class="caption">Transformer rewrites the call.</div>
+</div>
+<div class="col diagram">
+<div class="label">Debugger View</div>
+<div class="flow-grid">
+  <div class="node">main.ts</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">generated validator in out.js</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">out.js.map</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">breakpoint still lands on main.ts</div>
+</div>
+</div>
+</div>
+<!-- prettier-ignore-end -->
+
+<!--
+Notes:
+- This is one of the fear points for transformer users.
+- If a transformer rewrites source but the debugger points to nonsense, the toolchain feels unsafe.
+- TTSC treats source-map correctness as a core promise, including real typia transform coverage.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 3.2. VS Code
+
+<div class="cols">
+<div class="col diagram">
+<div class="label">Language Server</div>
+<div class="flow-grid">
+  <div class="node">tsc --lsp --stdio</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">ttscserver</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">VS Code client</div>
+</div>
+</div>
+<div class="col diagram">
+<div class="label">Plugin Features</div>
+<div class="spokes">
+  <div class="node">diagnostics</div>
+  <div class="node">code actions</div>
+  <div class="node">fix all</div>
+  <div class="node">format</div>
+</div>
+<div class="caption">Build and editor report the same plugin facts.</div>
+</div>
+</div>
+
+<!--
+Notes:
+- TypeScript 7's editor path is LSP-oriented.
+- ttscserver wraps that path and forwards plugin diagnostics and commands.
+- The VS Code extension exposes lint diagnostics, fix-all, formatting, and plugin command bridges.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 3.2. unplugin
+
+<!-- prettier-ignore-start -->
+<div class="cols">
+<div class="col code-card">
+<div class="label">Vite Example</div>
+<pre><code class="language-ts">import ttsc from "@ttsc/unplugin/vite";<br /><br />export default defineConfig({<br />&nbsp;&nbsp;plugins: [ttsc()],<br />});</code></pre>
+
+<div class="caption">Same tsconfig, same plugin pass.</div>
+</div>
+<div class="col diagram">
+<div class="label">Adapters</div>
+<div class="spokes">
+  <div class="node">Vite</div>
+  <div class="node">Rollup</div>
+  <div class="node">esbuild</div>
+  <div class="node">Webpack</div>
+  <div class="node">Rspack</div>
+  <div class="node">Next.js</div>
+  <div class="node">Turbopack</div>
+  <div class="node">Bun</div>
+</div>
+</div>
+</div>
+<!-- prettier-ignore-end -->
+
+<!--
+Notes:
+- @ttsc/unplugin is the bundler story.
+- Mention Vite, Rollup, Rolldown, esbuild, Webpack, Rspack, Next.js, Turbopack, Farm, and Bun.
+- Backend teams increasingly bundle server code for deployment, serverless, and monorepo packaging.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 3.2. React Native / Expo
+
+<!-- prettier-ignore-start -->
+<div class="cols">
+<div class="col code-card">
+<div class="label">Metro Config</div>
+<pre><code class="language-js">const { getDefaultConfig } = require("expo/metro-config");<br />const { withTtsc } = require("@ttsc/metro");<br />const projectRoot = process.cwd();<br /><br />module.exports = withTtsc(<br />&nbsp;&nbsp;getDefaultConfig(projectRoot),<br />);</code></pre>
+
+</div>
+<div class="col diagram">
+<div class="label">Metro Stack</div>
+<div class="flow-grid">
+  <div class="node">TypeScript source</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">ttsc plugin pass</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">Expo / RN Babel transformer</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">Metro bundle</div>
+</div>
+</div>
+</div>
+<!-- prettier-ignore-end -->
+
+<!--
+Notes:
+- React Native and Expo are easy to forget in compiler talks.
+- Metro needs its own adapter path.
+- The point is one transformer contract across CLI, editor, bundler, and React Native.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 3.3. Linter
+
+<div class="cols equal">
+<div class="col diagram">
+<div class="label">ESLint Path</div>
+<div class="flow-grid">
+  <div class="node">parse TypeScript</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">rebuild semantic context</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">run lint rules</div>
+</div>
+</div>
+<div class="col diagram">
+<div class="label">TTSC Path</div>
+<div class="flow-grid">
+  <div class="node">compile once</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">reuse Program + Checker</div>
+  <div class="arrow">-&gt;</div>
+  <div class="node">run lint rules</div>
+</div>
+</div>
+</div>
+
+<!--
+Notes:
+- This is where TTSC becomes more than a typia survival tool.
+- Once lint runs inside the compiler, parsing is not duplicated.
+- Rules can use the same AST and Checker the compiler already owns.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 3.3. Zero Parse Cost
+
+<div class="cols">
+<div class="col diagram">
+<div class="label">Already Paid</div>
+<div class="flow-grid">
+  <div class="node">parse</div>
+  <div class="node">bind</div>
+  <div class="node">check</div>
+</div>
+</div>
+<div class="col diagram">
+<div class="label">Lint Starts Here</div>
+<div class="hub">Program + Checker</div>
+<div class="spokes">
+  <div class="node">AST rules</div>
+  <div class="node">type rules</div>
+  <div class="node">diagnostics</div>
+  <div class="node">fixes</div>
+</div>
+<div class="caption">No second TypeScript parse for the lint pass.</div>
+</div>
+</div>
+
+<!--
+Notes:
+- Be careful with the claim: the compile still parses and checks.
+- The lint-specific parsing cost is zero in principle because the compiler already paid it.
+- That is why isolated lint plugin time can be tiny.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 3.3. VS Code Lint
+
+<div class="cols">
+<div class="col panel">
+<div class="label">VS Code Fixture</div>
+<div class="mini">6,093 TypeScript files</div>
+<table>
+  <tr><th>Path</th><th>Time</th></tr>
+  <tr><td>ESLint</td><td>66,700.2 ms</td></tr>
+  <tr><td>@ttsc/lint plugin</td><td>74 ms</td></tr>
+</table>
+<div class="bar">
+  <span>ESLint</span>
+  <div class="bar-fill" style="width: 100%;"></div>
+  <span>66.7 s</span>
+</div>
+<div class="bar">
+  <span>TTSC</span>
+  <div class="bar-fill green" style="width: 1%;"></div>
+  <span>0.074 s</span>
+</div>
+</div>
+<div class="col metric">
+<div class="label">Lint Pass Gap</div>
+<strong>900x</strong>
+<div class="mini">isolated lint pass comparison</div>
+</div>
+</div>
+
+<!--
+Notes:
+- This is from the 2026-06-01 TTSC benchmark snapshot.
+- Use the user's requested comparison basis: VS Code, the same project Microsoft used in TypeScript performance discussions.
+- State the caveat: this compares isolated ESLint time to the best observed pure @ttsc/lint plugin sample, not the full ttsc-lint command.
+-->
+
+---
+
+<!-- _class: split -->
+
+# 3.3. Why 900x Happens
+
+<div class="cols equal">
+<div class="col diagram">
+<div class="label">Duplicated Work</div>
+<div class="flow-grid">
+  <div class="node">tsc parses</div>
+  <div class="node">tsc checks</div>
+  <div class="arrow">then</div>
+  <div class="node">ESLint parses again</div>
+  <div class="node">rules rebuild context</div>
+</div>
+</div>
+<div class="col diagram">
+<div class="label">Shared Compiler Data</div>
+<div class="hub">TypeScript-Go Program</div>
+<div class="arrow">-&gt;</div>
+<div class="node">@ttsc/lint rules</div>
+<div class="arrow">-&gt;</div>
+<div class="node">diagnostics and fixes</div>
+<div class="caption">Architecture, not magic.</div>
+</div>
+</div>
+
+<!--
+Notes:
+- This is the explanation slide after the number.
+- The linter is fast because it lives at the same layer as the compiler.
+- Hundreds to thousands of times faster is plausible only when duplicated work disappears.
+-->
+
+---
+
+# 3.3. Current Limits
+
+- rule coverage is still growing
+- ESLint ecosystem is huge
+- plugin API must stabilize
+- TypeScript-Go is still moving
+
+This is a toolchain, not a fairy tale.
+
+<!--
+Notes:
+- The user's style is direct, so keep the limitations plain.
+- Do not pretend @ttsc/lint replaces every ESLint setup today.
+- The bet is architectural: when rules live in the compiler path, the ceiling is different.
+-->
+
+---
+
+# Conclusion
+
+```text
+typia proved the value
+TypeScript 7 broke the old host
+TTSC rebuilds the host
+@ttsc/lint shows the upside
+```
+
+Transformer libraries can survive.
+
+<!--
+Notes:
+- This is the same "journey summary" pattern as the PPTX decks.
+- Reconnect every section in one slide.
+- Keep it short so the closing ask has room.
+-->
+
+---
+
+# The Ask
+
+I have heard this many times:
+
+> "typia should be part of TypeScript."
+
+TTSC is not the official standard.
+
+But it can become the practical standard.
+
+<!--
+Notes:
+- This directly uses the user's requested closing idea.
+- typia becoming a TypeScript standard is not real today.
+- TTSC aims to make transformer libraries feel close to official in ease of use and reach.
+-->
+
+---
+
+# Please Use It
+
+- try `ttsc`
+- try `typia` on TypeScript-Go
+- try `@ttsc/lint`
+- report missing rules
+- bring transformer use cases
+
+The ecosystem needs real projects.
+
+<!--
+Notes:
+- Close with a concrete call to action.
+- Backend developers can help by trying real CI, editor, bundler, and React Native setups.
+- The fastest way to harden TTSC is usage from projects that actually depend on transformer behavior.
+-->
+
+---
+
+# Q&A
+
+Samchon
+
+Wrtn Technologies
+
+2026-06-26
+
+<!--
+Notes:
+- Keep the closing slide in the same style as the PPTX decks.
+- Switch from prepared talk to discussion.
+-->
+
+---
+
+# References
+
+- TypeScript 7.0 RC: https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-rc/
+- A 10x Faster TypeScript: https://devblogs.microsoft.com/typescript/typescript-native-port/
+- ts-patch README: https://github.com/nonara/ts-patch
+- typia docs: https://typia.io/docs
+- typia API: https://typia.io/api/modules/typia.html
+- typia LLM application: https://typia.io/docs/llm/application/
+- typia JSON Schema: https://typia.io/docs/json/schema/
+- nestia docs: https://nestia.io
+- TTSC docs: https://ttsc.dev/docs
+- TTSC benchmark: https://ttsc.dev/docs/benchmark
+
+<!--
+Notes:
+- Keep this slide for attribution and follow-up reading.
+- The audience can verify TypeScript 7, typia API scope, ts-patch context, and benchmark methodology from these links.
+-->


### PR DESCRIPTION
﻿## Summary

Adds a Marp slide deck for the 2026-06-26 TypeScript Backend Developer Meetup talk about TTSC.

The deck follows the existing presentation style in `website/public/presentations`: TL;DR, preface, numbered major sections, compact slides, speaker notes, split layouts, and diagram-style panels. It covers typia/nestia transformer motivation, the TypeScript 7 and ts-patch breakage story, TTSC integrations, and the @ttsc/lint VS Code benchmark narrative.

## Scope

- Add `website/public/presentations/20260622-tsbm.md`.
- Keep the presentation content in English.
- Preserve the requested talk date as `2026-06-26`.
- Include Marp CSS for split left/right layouts and diagram panels.

## Deferred

None.

## Test Plan

- `pnpm format`
- `pnpm exec prettier --check website/public/presentations/20260622-tsbm.md`
- ASCII/prose hygiene scan for non-ASCII and banned filler phrases
- slide/note count check: `48 slides / 48 notes`
- `pnpm dlx @marp-team/marp-cli website/public/presentations/20260622-tsbm.md --html -o %TEMP%/20260622-tsbm-pr-check.html`
