### PR TITLE
Finalize TypeScript backend meetup deck

### DIFF
--- a/website/public/presentations/.gitignore
+++ b/website/public/presentations/.gitignore
@@ -1,0 +1,3 @@
+*.html
+*.pdf
+*.pptx

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -1,0 +1,344 @@
+---
+marp: true
+theme: default
+paginate: true
+size: 4:3
+title: "TTSC: Transformer Survival in the TypeScript 7 Era"
+description: "TypeScript Backend Meetup, 2026-06-26"
+footer: "TTSC | TypeScript Backend Meetup | 2026-06-26"
+style: |
+  section {
+    font-family: "Inter", "Segoe UI", "Pretendard", sans-serif;
+    color: #111827;
+    padding: 72px 84px;
+  }
+  section.lead {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  h1 {
+    color: #0f172a;
+    font-size: 58px;
+  }
+  h2 {
+    color: #0f172a;
+    font-size: 44px;
+  }
+  h3 {
+    color: #2563eb;
+    font-size: 32px;
+  }
+  strong {
+    color: #2563eb;
+  }
+  code {
+    font-family: "Cascadia Code", monospace;
+  }
+  table {
+    font-size: 24px;
+  }
+  blockquote {
+    border-left: 8px solid #2563eb;
+    color: #1f2937;
+    font-size: 34px;
+    padding-left: 28px;
+  }
+  section.split h1 {
+    margin-bottom: 28px;
+  }
+  section.split .cols {
+    align-items: stretch;
+    display: grid;
+    gap: 36px;
+    grid-template-columns: 0.95fr 1.05fr;
+  }
+  section.split .cols.equal {
+    grid-template-columns: 1fr 1fr;
+  }
+  section.split .col {
+    min-width: 0;
+  }
+  section.split .panel,
+  section.split .code-card,
+  section.split .diagram {
+    background: #f8fafc;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    padding: 22px;
+  }
+  section.split .label {
+    color: #2563eb;
+    font-size: 22px;
+    font-weight: 700;
+    margin-bottom: 14px;
+    text-transform: uppercase;
+  }
+  section.split .caption {
+    color: #475569;
+    font-size: 24px;
+    margin-top: 16px;
+  }
+  section.split pre {
+    background: #0f172a;
+    border-radius: 8px;
+    color: #e5e7eb;
+    font-size: 20px;
+    line-height: 1.35;
+    margin: 0;
+    padding: 18px;
+  }
+  section.split .node,
+  section.split .hub,
+  section.split .metric {
+    background: #ffffff;
+    border: 1px solid #94a3b8;
+    border-radius: 8px;
+    padding: 14px 18px;
+  }
+  section.split .node {
+    font-size: 24px;
+    font-weight: 700;
+    text-align: center;
+  }
+  section.split .arrow {
+    color: #64748b;
+    font-size: 28px;
+    font-weight: 800;
+    margin: 10px 0;
+    text-align: center;
+  }
+  section.split .flow-grid {
+    display: grid;
+    gap: 12px;
+  }
+  section.split .hub {
+    border-color: #2563eb;
+    color: #0f172a;
+    font-size: 28px;
+    font-weight: 800;
+    margin: 16px 0;
+    text-align: center;
+  }
+  section.split .spokes {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: 1fr 1fr;
+  }
+  section.split .mini {
+    color: #334155;
+    font-size: 22px;
+  }
+  section.split .metric {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    justify-content: center;
+    min-height: 280px;
+  }
+  section.split .metric strong {
+    color: #16a34a;
+    font-size: 96px;
+    line-height: 1;
+  }
+  section.split .bar {
+    align-items: center;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: 110px 1fr 110px;
+    margin: 12px 0;
+  }
+  section.split .bar-fill {
+    background: #2563eb;
+    border-radius: 8px;
+    height: 18px;
+  }
+  section.split .bar-fill.green {
+    background: #16a34a;
+  }
+---
+
+<!-- _class: lead -->
+
+# TTSC
+
+### TypeScript-Go ToolChain
+
+Samchon
+
+2026-06-26
+
+---
+
+# Preface
+
+![](https://ttsc.dev/og.jpg)
+
+---
+
+# 1.1. TypeScript-Go
+
+대충 TypeScript-Go 곧 출시한다는 이야기.
+
+대충 성능 10배 빠르다는 이야기.
+
+대충 Go 언어 기반이라 생태계 다 뒤집힌다는 이야기.
+
+---
+
+# 1.2. Transformer
+
+대충 트랜스포머가 뭔지 설명
+
+---
+
+# 1.2. Transformer
+
+### Generic function call with `IMember` type
+
+```typescript
+import typia, { tags } from "typia";
+
+interface IMember {
+  id: string & tags.Format<"uuid">;
+  email: string & tags.Format<"email">;
+  age: number &
+    tags.Type<"uint32"> &
+    tags.ExclusiveMinimum<19> &
+    tags.Maximum<100>;
+}
+typia.createIs<IMember>();
+```
+
+---
+
+# 1.2. Transformer
+
+### Becomes transformed JS code
+
+```javascript
+import * as _b from "typia/lib/internal/_isFormatEmail";
+import * as _a from "typia/lib/internal/_isFormatUuid";
+import * as _c from "typia/lib/internal/_isTypeUint32";
+
+(() => {
+  const _io0 = (input) =>
+    "string" === typeof input.id &&
+    _a._isFormatUuid(input.id) &&
+    "string" === typeof input.email &&
+    _b._isFormatEmail(input.email) &&
+    "number" === typeof input.age &&
+    _c._isTypeUint32(input.age) &&
+    19 < input.age &&
+    input.age <= 100;
+  return (input) => "object" === typeof input && null !== input && _io0(input);
+})();
+```
+
+---
+
+# 1.2. Transformer
+
+```typescript
+import { TypedBody, TypedRoute } from "@nestia/core";
+import { Controller } from "@nestjs/common";
+
+@Controller()
+export class ShoppingSaleController {
+  @TypedRoute.Post()
+  public async create(
+    @TypedBody() body: IShoppingSale.ICreate
+  ): Promise<IShoppingSale> { ... }
+}
+```
+
+---
+
+# 1.2. Transformer
+
+### Required "ts-patch"
+
+```json
+{
+  "scripts": {
+    "prepare": "ts-patch install"
+  },
+  "devDependencies": {
+    "ts-patch": "^3.2.1"
+  }
+}
+```
+
+---
+
+# 1.2. Transformer
+
+### Required tsconfig.json configuration
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "plugins": [
+      { "transform": "typia/lib/transform" },
+      { "transform": "@nestia/core/lib/transform" },
+      { "transform": "@nestia/sdk/lib/transform" },
+    ]
+  }
+}
+```
+
+---
+
+# 1.2. Transformer
+
+대충 TypeScript-Go 에서 통하지 않는다는 이야기
+
+그래서 좆되었다는 이야기
+
+---
+
+# 2. TTSC
+
+대충 좆되서 본인이 직접 만들었단 이야기
+
+---
+
+# 2.1. Transformer
+
+대충 go 언어 기반의 트랜스포머 생태계 다시 만들었다는 이야기
+
+tsconfig.json 설정 안해도 된다는 이야기
+
+`ttsc` 명령어로 컴파일하면 된다는 이야기
+
+---
+
+# 2.2. Runtime
+
+`ttsx src/index.ts` 로 실행할 수 있단 이야기
+
+대충 `ts-node`보다 10배 빠른데 타입 체킹한다는 이야기
+
+---
+
+# 2.3. Linter
+
+대충 Transformer 플러그인의 형태로 개발했다는 이야기
+
+ttsc 명령어 한 방에 컴파일 에러와 린트 규칙 위반이 한번에 잡힌다는 이야기
+
+이론상 비용이 0에 수렴해, 실제 800배 성능차를 보인다는 이야기
+
+---
+
+# 2.4. Graph
+
+클로드 코드나 코덱스에게 컴파일러 AST 정보 기반 그래프 정보를 준다는 이야기
+
+그래서 grep와 과도한 파일 리드를 막아준다는 이야기
+
+토큰 소모량이 100배로 준다는 이야기
+
+---

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -320,7 +320,7 @@ Compiler plugins lived inside the old compiler shape.
 - Emit pipeline hooks
 
 <!--
-Say: transformer users were not only compiling. They were extending the compiler.
+Say: transformer users were extending the compiler, not just compiling source.
 -->
 
 ---
@@ -390,6 +390,8 @@ Common backend uses:
 - OpenAPI generation
 
 - SDK generation
+
+- SDK call signatures
 
 <!--
 Say: typia and nestia are concrete examples, not edge cases.
@@ -470,25 +472,68 @@ Say: this is not reflection. It is ahead-of-time compilation.
 
 # 1.3. Transformer
 
-### Nestia: route generator
+### Nestia: backend controller
 
 ```typescript
-import { TypedBody, TypedRoute } from "@nestia/core";
+import { TypedBody, TypedParam, TypedRoute } from "@nestia/core";
 import { Controller } from "@nestjs/common";
 
-@Controller()
-export class ShoppingSaleController {
+@Controller("bbs/:section/articles")
+export class BbsArticlesController {
   @TypedRoute.Post()
-  public async create(
-    @TypedBody() body: IShoppingSale.ICreate,
-  ): Promise<IShoppingSale> {
-    // business logic
+  async create(
+    @TypedParam("section") section: string,
+    @TypedBody() input: IBbsArticle.ICreate,
+  ): Promise<IBbsArticle> {
+    return this.service.create(section, input);
   }
 }
 ```
 
 <!--
-Say: controller code becomes route metadata, validation, and SDK material.
+Say: backend code is still normal NestJS. The important part is the TypeScript type on input and output.
+-->
+
+---
+
+# 1.3. Transformer
+
+### Nestia: frontend SDK
+
+```typescript
+import api from "@my/api";
+
+const connection: api.IConnection = {
+  host: "http://localhost:3000",
+};
+
+const article: IBbsArticle =
+  await api.functional.bbs.articles.create(connection, "general", {
+    title: "Hello World",
+    body: "My first article",
+  } satisfies IBbsArticle.ICreate);
+```
+
+<!--
+Say: the frontend receives a generated function with the same route path, parameter order, request type, and response type.
+-->
+
+---
+
+# 1.3. Transformer
+
+Backend type became frontend function.
+
+- Controller path -> SDK namespace
+
+- Route method -> SDK function
+
+- `@TypedBody()` -> request type
+
+- `Promise<IBbsArticle>` -> response type
+
+<!--
+Say: this is the nestia transformer story. Backend TypeScript becomes frontend API surface.
 -->
 
 ---

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -177,23 +177,43 @@ Samchon
 
 ---
 
-# 1.1. TypeScript-Go
+# 1. TypeScript-Go
 
-대충 TypeScript-Go 곧 출시한다는 이야기.
+대충 TypeScript-Go 발표 뉴스 보여주는 이야기.
 
-대충 성능 10배 빠르다는 이야기.
+대충 Microsoft가 TypeScript compiler를 Go로 다시 만들고 있다는 이야기.
 
-대충 Go 언어 기반이라 생태계 다 뒤집힌다는 이야기.
+대충 TypeScript 7부터 이걸 기본 엔진으로 가져오려 한다는 이야기.
+
+대충 `tsc`, editor, LSP가 10배쯤 빨라진다는 좋은 뉴스라는 이야기.
+
+---
+
+# 1.1. Bad News
+
+대충 근데 transformer 사용자 입장에서는 다 좆되었다는 이야기.
+
+대충 기존 transformer 생태계가 JavaScript TypeScript compiler 내부 hook에 기대고 있었다는 이야기.
+
+대충 compiler가 Go로 바뀌면 그 hook에 patch 붙이던 방식이 그대로 안 통한다는 이야기.
+
+대충 typia, nestia 같은 백엔드 TypeScript 도구가 이 문제를 정면으로 맞는다는 이야기.
 
 ---
 
 # 1.2. Transformer
 
-대충 트랜스포머가 뭔지 설명
+대충 transformer가 TypeScript 타입 정보를 읽어 코드를 자동 생성하거나 바꾸는 기술이라는 이야기.
+
+대충 런타임 validation, serialization, SDK generation 같은 일을 컴파일 타임에 끝낸다는 이야기.
+
+대충 typia와 nestia가 이 방식으로 백엔드 보일러플레이트를 없애왔다는 이야기.
 
 ---
 
 # 1.2. Transformer
+
+### typia validation generator
 
 ### Generic function call with `IMember` type
 
@@ -239,6 +259,8 @@ import * as _c from "typia/lib/internal/_isTypeUint32";
 ---
 
 # 1.2. Transformer
+
+### nestia route generator
 
 ```typescript
 import { TypedBody, TypedRoute } from "@nestia/core";
@@ -291,54 +313,110 @@ export class ShoppingSaleController {
 
 ---
 
-# 1.2. Transformer
+# 1.3. The Compatibility Gap
 
-대충 TypeScript-Go 에서 통하지 않는다는 이야기
+대충 기존 transformer 생태계는 JavaScript TypeScript compiler를 patch해서 살아왔다는 이야기.
 
-그래서 좆되었다는 이야기
+대충 `ts-patch`가 compiler 내부 hook을 열어주고, `tsconfig.json`이 transformer를 꽂아주던 구조라는 이야기.
+
+대충 TypeScript-Go는 compiler 내부가 Go라서 이 방식이 그대로 통하지 않는다는 이야기.
+
+---
+
+# 1.3. The Compatibility Gap
+
+대충 TypeScript 7로 가면 사용자 코드가 문제가 아니라 빌드 파이프라인이 막힌다는 이야기.
+
+대충 typia와 nestia API는 그대로 있어도, 뒤에서 코드를 만들어주던 engine이 사라진다는 이야기.
+
+대충 "TypeScript가 빨라졌다"가 transformer 사용자에겐 "기존 생태계가 끊겼다"가 될 수 있다는 이야기.
 
 ---
 
 # 2. TTSC
 
-대충 좆되서 본인이 직접 만들었단 이야기
+대충 그래서 TypeScript-Go 위에서 transformer 생태계를 다시 만들었다는 이야기.
+
+대충 목표는 새 compiler로 갈아타도 typia와 nestia의 사용 경험이 유지되는 것이라는 이야기.
+
+대충 `ttsc`, `ttsx`, `ttscserver`로 compiler, runtime, editor 쪽을 같이 잡는다는 이야기.
 
 ---
 
 # 2.1. Transformer
 
-대충 go 언어 기반의 트랜스포머 생태계 다시 만들었다는 이야기
+대충 Go 기반 compiler AST와 Checker 위에서 동작하는 transformer plugin 생태계를 다시 만들었다는 이야기.
 
-tsconfig.json 설정 안해도 된다는 이야기
+대충 `ts-patch install`이 아니라 `ttsc`가 plugin source를 빌드하고 캐시하고 실행한다는 이야기.
 
-`ttsc` 명령어로 컴파일하면 된다는 이야기
+대충 `ttsc` 명령어로 컴파일하면 기존 transformer 사용자 경험을 TypeScript-Go 위로 가져온다는 이야기.
 
 ---
 
 # 2.2. Runtime
 
-`ttsx src/index.ts` 로 실행할 수 있단 이야기
+대충 `ttsx src/index.ts`로 TypeScript entrypoint를 바로 실행할 수 있다는 이야기.
 
-대충 `ts-node`보다 10배 빠른데 타입 체킹한다는 이야기
+대충 `tsx`나 `ts-node`처럼 쓰지만 먼저 진짜 type-check를 한다는 이야기.
+
+대충 TypeScript-Go 속도 덕분에 개발 runtime에서 type safety를 포기하지 않아도 된다는 이야기.
 
 ---
 
 # 2.3. Linter
 
-대충 Transformer 플러그인의 형태로 개발했다는 이야기
+대충 linter도 transformer plugin처럼 compiler AST와 Checker 위에서 실행한다는 이야기.
 
-ttsc 명령어 한 방에 컴파일 에러와 린트 규칙 위반이 한번에 잡힌다는 이야기
+대충 `ttsc` 명령어 한 방에 compile error와 lint violation을 같이 잡는다는 이야기.
 
-이론상 비용이 0에 수렴해, 실제 800배 성능차를 보인다는 이야기
+대충 이미 compile하면서 만든 AST와 type information을 재사용하니 lint 비용이 0에 수렴한다는 이야기.
+
+대충 VS Code급 프로젝트에서 ESLint 대비 800~900배 성능차를 보인다는 이야기.
+
+---
+
+# 3. TTSC Graph
+
+대충 여기부터는 compiler 정보를 사람뿐 아니라 AI coding agent에게도 주겠다는 이야기.
+
+대충 Claude Code나 Codex가 파일을 마구 읽는 대신 compiler graph를 질의하게 만든다는 이야기.
+
+대충 transformer, linter 다음 단계로 codebase understanding을 compiler 기반으로 가져간다는 이야기.
 
 ---
 
-# 2.4. Graph
+# 3.1. Compiler-Aware Context
 
-클로드 코드나 코덱스에게 컴파일러 AST 정보 기반 그래프 정보를 준다는 이야기
+대충 exports, imports, symbol, references, call path 같은 정보를 AST 기반 graph로 제공한다는 이야기.
 
-그래서 grep와 과도한 파일 리드를 막아준다는 이야기
+대충 grep은 문자열을 찾지만, graph는 코드 구조와 의미를 따라간다는 이야기.
 
-토큰 소모량이 100배로 준다는 이야기
+대충 "이 함수 어디서 쓰임?" 같은 질문을 compiler가 아는 정보로 답하게 한다는 이야기.
 
 ---
+
+# 3.2. For Coding Agents
+
+대충 클로드 코드나 코덱스에게 "일단 파일 다 읽어"가 아니라 "이 symbol 주변만 봐"를 시킨다는 이야기.
+
+대충 과도한 파일 리드와 잘못된 grep 탐색을 줄인다는 이야기.
+
+대충 토큰 소모량이 100배쯤 줄어드는 방향의 이야기.
+
+---
+
+# 3.3. Compiler Platform
+
+대충 TTSC는 `tsc` wrapper가 아니라 TypeScript-Go 기반 compiler platform이 되려 한다는 이야기.
+
+대충 transformer, runtime, linter, graph가 전부 같은 compiler substrate 위에 있다는 이야기.
+
+대충 백엔드 TypeScript 개발 도구가 다음 세대로 넘어가는 길을 보여준다는 이야기.
+
+---
+
+# Q & A
+
+2026-06-26
+
+Samchon

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -193,7 +193,7 @@ One beat for the logo.
 
 - TTSC keeps compile-time code generation alive
 
-- Linter and Graph reuse the same compiler state
+- Linter and Graph turn compiler state into toolchain state
 
 <!--
 Say: this talk is not "Go is faster". It is "the compiler substrate changed".
@@ -211,7 +211,7 @@ TypeScript 7 changes the foundation under TypeScript tools.
 
 - About **10x** faster on many projects
 
-- Compiler API and plugin ecosystem must adapt
+- Plugin ecosystem must adapt
 
 <!--
 Source is Microsoft's TypeScript 7 RC and native port posts.
@@ -291,7 +291,7 @@ Say: for normal users, compatibility is the headline. For tool authors, runtime 
 
 # 1.1. Good News
 
-Backend teams feel compiler latency every day.
+Backend teams pay compiler latency every day.
 
 - Monorepo type check
 
@@ -456,13 +456,13 @@ Say: one generic type call became UUID, email, integer, and range checks.
 
 Type information became runtime code.
 
-- `tags.Format<"uuid">` → UUID check
+- `tags.Format<"uuid">` -> UUID check
 
-- `tags.Format<"email">` → email check
+- `tags.Format<"email">` -> email check
 
-- `tags.Type<"uint32">` → integer range
+- `tags.Type<"uint32">` -> integer range
 
-- `tags.Maximum<100>` → boundary check
+- `tags.Maximum<100>` -> boundary check
 
 <!--
 Say: this is not reflection. It is ahead-of-time compilation.
@@ -592,7 +592,7 @@ The new compiler substrate breaks that assumption.
 
 - New compiler: Go process
 
-- Old hook: no longer the center
+- Old hook: unavailable
 
 <!--
 Say: TypeScript 7 can preserve language semantics while still breaking plugin hosting.
@@ -652,7 +652,7 @@ npx ttsc --watch
 
 - Watch
 
-- Host plugins
+- Host transformers
 
 <!--
 Say: command shape stays familiar. Compiler host changes.
@@ -720,9 +720,9 @@ Say: plugins join the TTSC host instead of mutating the compiler installation.
 
 Old model vs TTSC model:
 
-- `ts-patch` → hook into JavaScript compiler
+- `ts-patch` -> hook into JavaScript compiler
 
-- `ttsc` → host plugins on TypeScript-Go
+- `ttsc` -> host plugins on TypeScript-Go
 
 - User API stays TypeScript
 
@@ -869,7 +869,6 @@ The normal TypeScript check lane repeats work.
 ```bash
 npx tsc --noEmit
 npx eslint .
-npx prettier --check .
 ```
 
 - Same source tree
@@ -1055,7 +1054,7 @@ Linter is a separate TTSC chapter because it proves reuse.
 
 - Lint state
 
-- same substrate
+- Same substrate
 
 <!--
 Say: after transformer survival, linter is the first productivity dividend.
@@ -1111,7 +1110,7 @@ Grep does not know compiler facts.
 
 - Type vs value
 
-- call path
+- Call path
 
 <!--
 Say: the compiler already knows these relationships.
@@ -1129,7 +1128,7 @@ File search is a weak substitute for semantic context.
 
 - Generic call hides concrete type
 
-- dynamic import hides path
+- Dynamic import hides path
 
 <!--
 Say: agents need the graph before they need the file.

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -187,13 +187,13 @@ One beat for the logo.
 
 # TL;DR
 
-• TypeScript compiler is moving to Go
+- TypeScript compiler is moving to Go
 
-• Transformers lose the old JavaScript patch point
+- Transformers lose the old JavaScript patch point
 
-• TTSC keeps compile-time code generation alive
+- TTSC keeps compile-time code generation alive
 
-• Linter and Graph reuse the same compiler state
+- Linter and Graph reuse the same compiler state
 
 <!--
 Say: this talk is not "Go is faster". It is "the compiler substrate changed".
@@ -205,13 +205,13 @@ Say: this talk is not "Go is faster". It is "the compiler substrate changed".
 
 TypeScript 7 changes the foundation under TypeScript tools.
 
-• Native Go compiler
+- Native Go compiler
 
-• TypeScript 6 semantic parity
+- TypeScript 6 semantic parity
 
-• About **10x** faster on many projects
+- About **10x** faster on many projects
 
-• Compiler API and plugin ecosystem must adapt
+- Compiler API and plugin ecosystem must adapt
 
 <!--
 Source is Microsoft's TypeScript 7 RC and native port posts.
@@ -239,13 +239,13 @@ Four chapters. Problem first, TTSC after.
 
 # 1. TypeScript-Go
 
-• Good News
+- Good News
 
-• Bad News
+- Bad News
 
-• Transformer
+- Transformer
 
-• Compatibility Gap
+- Compatibility Gap
 
 <!--
 Chapter start is only the local table of contents.
@@ -257,13 +257,13 @@ Chapter start is only the local table of contents.
 
 TypeScript compiler is moving from JavaScript to Go.
 
-• TypeScript 7.0 RC
+- TypeScript 7.0 RC
 
-• Native compiler and language service
+- Native compiler and language service
 
-• Shared-memory parallelism
+- Shared-memory parallelism
 
-• About **10x** faster than TypeScript 6.0
+- About **10x** faster than TypeScript 6.0
 
 <!--
 Say: most users hear this as a simple speed story.
@@ -275,13 +275,13 @@ Say: most users hear this as a simple speed story.
 
 The port is not a rewrite of the language.
 
-• Existing codebase ported to Go
+- Existing codebase ported to Go
 
-• Type-checking logic kept structurally identical
+- Type-checking logic kept structurally identical
 
-• Same TypeScript semantics
+- Same TypeScript semantics
 
-• New runtime foundation
+- New runtime foundation
 
 <!--
 Say: for normal users, compatibility is the headline. For tool authors, runtime foundation is the issue.
@@ -293,13 +293,13 @@ Say: for normal users, compatibility is the headline. For tool authors, runtime 
 
 Backend teams feel compiler latency every day.
 
-• Monorepo type check
+- Monorepo type check
 
-• Watch mode
+- Watch mode
 
-• Editor startup
+- Editor startup
 
-• CI feedback loop
+- CI feedback loop
 
 <!--
 Say: 10x is not an abstract benchmark. It changes the development loop.
@@ -311,13 +311,13 @@ Say: 10x is not an abstract benchmark. It changes the development loop.
 
 Compiler plugins lived inside the old compiler shape.
 
-• JavaScript runtime
+- JavaScript runtime
 
-• TypeScript compiler API
+- TypeScript compiler API
 
-• AST and Checker objects
+- AST and Checker objects
 
-• Emit pipeline hooks
+- Emit pipeline hooks
 
 <!--
 Say: transformer users were not only compiling. They were extending the compiler.
@@ -329,13 +329,13 @@ Say: transformer users were not only compiling. They were extending the compiler
 
 The old ecosystem patched TypeScript itself.
 
-• `ttypescript`
+- `ttypescript`
 
-• `ts-patch`
+- `ts-patch`
 
-• `tsconfig.plugins`
+- `tsconfig.plugins`
 
-• custom transformers
+- custom transformers
 
 <!--
 Say: the plugin contract was informal, but it worked because everything was JavaScript.
@@ -347,13 +347,13 @@ Say: the plugin contract was informal, but it worked because everything was Java
 
 APIs can survive while engines break.
 
-• `typia`
+- `typia`
 
-• `nestia`
+- `nestia`
 
-• custom SDK generators
+- custom SDK generators
 
-• generated runtime validators
+- generated runtime validators
 
 <!--
 Say: user-facing code can remain the same, but the generation engine must move.
@@ -365,13 +365,13 @@ Say: user-facing code can remain the same, but the generation engine must move.
 
 Transformer = compile-time code generation from TypeScript types.
 
-• Read source code
+- Read source code
 
-• Inspect AST
+- Inspect AST
 
-• Ask the Checker
+- Ask the Checker
 
-• Emit JavaScript
+- Emit JavaScript
 
 <!--
 Minimal definition. The next slides show why it matters.
@@ -383,13 +383,13 @@ Minimal definition. The next slides show why it matters.
 
 Common backend uses:
 
-• Runtime validation
+- Runtime validation
 
-• Serialization
+- Serialization
 
-• OpenAPI generation
+- OpenAPI generation
 
-• SDK generation
+- SDK generation
 
 <!--
 Say: typia and nestia are concrete examples, not edge cases.
@@ -454,13 +454,13 @@ Say: one generic type call became UUID, email, integer, and range checks.
 
 Type information became runtime code.
 
-• `tags.Format<"uuid">` → UUID check
+- `tags.Format<"uuid">` → UUID check
 
-• `tags.Format<"email">` → email check
+- `tags.Format<"email">` → email check
 
-• `tags.Type<"uint32">` → integer range
+- `tags.Type<"uint32">` → integer range
 
-• `tags.Maximum<100>` → boundary check
+- `tags.Maximum<100>` → boundary check
 
 <!--
 Say: this is not reflection. It is ahead-of-time compilation.
@@ -541,13 +541,13 @@ Say: this assumes the compiler can load JavaScript plugins into its own process.
 
 The new compiler substrate breaks that assumption.
 
-• Old compiler: JavaScript process
+- Old compiler: JavaScript process
 
-• Old transformer: JavaScript module
+- Old transformer: JavaScript module
 
-• New compiler: Go process
+- New compiler: Go process
 
-• Old hook: no longer the center
+- Old hook: no longer the center
 
 <!--
 Say: TypeScript 7 can preserve language semantics while still breaking plugin hosting.
@@ -559,13 +559,13 @@ Say: TypeScript 7 can preserve language semantics while still breaking plugin ho
 
 Transformer users need a toolchain, not a patch.
 
-• Compiler front door
+- Compiler front door
 
-• Plugin host
+- Plugin host
 
-• Runtime execution path
+- Runtime execution path
 
-• Editor integration
+- Editor integration
 
 <!--
 Say: this is the bridge from TypeScript-Go to TTSC.
@@ -577,13 +577,13 @@ Say: this is the bridge from TypeScript-Go to TTSC.
 
 # 2. TTSC
 
-• Compiler
+- Compiler
 
-• Transformer
+- Transformer
 
-• Runtime
+- Runtime
 
-• Language Server
+- Language Server
 
 <!--
 Chapter start is only the local table of contents.
@@ -601,13 +601,13 @@ npx ttsc --noEmit
 npx ttsc --watch
 ```
 
-• Build
+- Build
 
-• Check
+- Check
 
-• Watch
+- Watch
 
-• Host plugins
+- Host plugins
 
 <!--
 Say: command shape stays familiar. Compiler host changes.
@@ -619,15 +619,15 @@ Say: command shape stays familiar. Compiler host changes.
 
 TTSC keeps the compiler state as the shared substrate.
 
-• Program
+- Program
 
-• AST
+- AST
 
-• Checker
+- Checker
 
-• Diagnostics
+- Diagnostics
 
-• Emit
+- Emit
 
 <!--
 Say: every later feature hangs off this state.
@@ -639,13 +639,13 @@ Say: every later feature hangs off this state.
 
 The core contract:
 
-• Load project once
+- Load project once
 
-• Build semantic graph once
+- Build semantic graph once
 
-• Let tools reuse it
+- Let tools reuse it
 
-• Report through compiler diagnostics
+- Report through compiler diagnostics
 
 <!--
 Say: this is the opposite of spawning many tools that rediscover the same project.
@@ -657,13 +657,13 @@ Say: this is the opposite of spawning many tools that rediscover the same projec
 
 TTSC hosts transformers without patching TypeScript itself.
 
-• Plugin package
+- Plugin package
 
-• Native sidecar
+- Native sidecar
 
-• Cached artifacts
+- Cached artifacts
 
-• TypeScript-Go bridge
+- TypeScript-Go bridge
 
 <!--
 Say: plugins join the TTSC host instead of mutating the compiler installation.
@@ -675,13 +675,13 @@ Say: plugins join the TTSC host instead of mutating the compiler installation.
 
 Old model vs TTSC model:
 
-• `ts-patch` → hook into JavaScript compiler
+- `ts-patch` → hook into JavaScript compiler
 
-• `ttsc` → host plugins on TypeScript-Go
+- `ttsc` → host plugins on TypeScript-Go
 
-• User API stays TypeScript
+- User API stays TypeScript
 
-• Generation engine moves behind it
+- Generation engine moves behind it
 
 <!--
 Say: preserve the developer surface, replace the compiler integration.
@@ -693,13 +693,13 @@ Say: preserve the developer surface, replace the compiler integration.
 
 Transformer lifecycle:
 
-• Read type declaration
+- Read type declaration
 
-• Ask compiler for semantic facts
+- Ask compiler for semantic facts
 
-• Generate optimized JavaScript
+- Generate optimized JavaScript
 
-• Feed result back into emit
+- Feed result back into emit
 
 <!--
 Say: the lifecycle is the same story as typia, but the host is new.
@@ -715,11 +715,11 @@ Say: the lifecycle is the same story as typia, but the host is new.
 npx ttsx src/index.ts
 ```
 
-• Direct execution
+- Direct execution
 
-• Real type check
+- Real type check
 
-• Plugin-aware path
+- Plugin-aware path
 
 <!--
 Say: the runtime command should not bypass the compiler guarantees.
@@ -731,13 +731,13 @@ Say: the runtime command should not bypass the compiler guarantees.
 
 Runtime target:
 
-• `tsx` convenience
+- `tsx` convenience
 
-• `ts-node` use case
+- `ts-node` use case
 
-• TypeScript-Go speed
+- TypeScript-Go speed
 
-• no transpile-only compromise
+- no transpile-only compromise
 
 <!--
 Say: backend execution can be convenient without becoming blind.
@@ -749,13 +749,13 @@ Say: backend execution can be convenient without becoming blind.
 
 `ttscserver` brings plugin results into the editor.
 
-• Diagnostics
+- Diagnostics
 
-• Code actions
+- Code actions
 
-• Plugin commands
+- Plugin commands
 
-• VS Code extension path
+- VS Code extension path
 
 <!--
 Say: transformer errors must appear before CI.
@@ -767,13 +767,13 @@ Say: transformer errors must appear before CI.
 
 Editor integration is part of the toolchain.
 
-• Compiler sees the project
+- Compiler sees the project
 
-• Plugin sees the same project
+- Plugin sees the same project
 
-• Developer sees diagnostics early
+- Developer sees diagnostics early
 
-• CI becomes confirmation, not discovery
+- CI becomes confirmation, not discovery
 
 <!--
 Say: if plugin work only happens at build time, the feedback loop is too late.
@@ -785,13 +785,13 @@ Say: if plugin work only happens at build time, the feedback loop is too late.
 
 TTSC is not one wrapper command.
 
-• `ttsc`
+- `ttsc`
 
-• `ttsx`
+- `ttsx`
 
-• `ttscserver`
+- `ttscserver`
 
-• shared plugin substrate
+- shared plugin substrate
 
 <!--
 Say: compiler, runtime, and editor must move together.
@@ -803,13 +803,13 @@ Say: compiler, runtime, and editor must move together.
 
 # 3. TTSC Linter
 
-• Why Lint Again
+- Why Lint Again
 
-• Compiler-Aware Rules
+- Compiler-Aware Rules
 
-• Zero-Cost Linting
+- Zero-Cost Linting
 
-• VS Code Benchmark
+- VS Code Benchmark
 
 <!--
 Chapter start is only the local table of contents.
@@ -827,11 +827,11 @@ npx eslint .
 npx prettier --check .
 ```
 
-• Same source tree
+- Same source tree
 
-• Same imports
+- Same imports
 
-• Same types
+- Same types
 
 <!--
 Say: the expensive part is rediscovery.
@@ -843,13 +843,13 @@ Say: the expensive part is rediscovery.
 
 Repeated costs:
 
-• Parse
+- Parse
 
-• Walk
+- Walk
 
-• Type services
+- Type services
 
-• Diagnostics output
+- Diagnostics output
 
 <!--
 Say: type-aware linting asks questions the compiler already answered.
@@ -861,13 +861,13 @@ Say: type-aware linting asks questions the compiler already answered.
 
 `@ttsc/lint` runs where the Program already exists.
 
-• TypeScript diagnostics
+- TypeScript diagnostics
 
-• Lint diagnostics
+- Lint diagnostics
 
-• Same check lane
+- Same check lane
 
-• Same compiler view
+- Same compiler view
 
 <!--
 Say: one project load, one semantic view.
@@ -879,13 +879,13 @@ Say: one project load, one semantic view.
 
 Compiler-aware rules can ask semantic questions directly.
 
-• Symbol owner
+- Symbol owner
 
-• Type relationship
+- Type relationship
 
-• Import target
+- Import target
 
-• Declaration site
+- Declaration site
 
 <!--
 Say: this is the part ESLint recreates with parser services.
@@ -897,13 +897,13 @@ Say: this is the part ESLint recreates with parser services.
 
 Compiler-style output:
 
-• `TS2322`
+- `TS2322`
 
-• `[prefer-const]`
+- `[prefer-const]`
 
-• `[no-var]`
+- `[no-var]`
 
-• one diagnostics stream
+- one diagnostics stream
 
 <!--
 Say: the developer reads one compiler report, not two disconnected reports.
@@ -915,13 +915,13 @@ Say: the developer reads one compiler report, not two disconnected reports.
 
 Zero-cost means marginal cost.
 
-• Program already loaded
+- Program already loaded
 
-• AST already built
+- AST already built
 
-• Checker already available
+- Checker already available
 
-• Rule walk remains
+- Rule walk remains
 
 <!--
 Say: not literally zero milliseconds. It means no second TypeScript world.
@@ -933,13 +933,13 @@ Say: not literally zero milliseconds. It means no second TypeScript world.
 
 Mental model:
 
-• Legacy: compiler + linter pipeline
+- Legacy: compiler + linter pipeline
 
-• TTSC: compiler check + lint pass
+- TTSC: compiler check + lint pass
 
-• Formatting stays a separate write path
+- Formatting stays a separate write path
 
-• Type-aware linting stops duplicating analysis
+- Type-aware linting stops duplicating analysis
 
 <!--
 Say: formatting is still a different concern.
@@ -951,13 +951,13 @@ Say: formatting is still a different concern.
 
 The compiler is already the source of truth.
 
-• One parse
+- One parse
 
-• One module graph
+- One module graph
 
-• One checker
+- One checker
 
-• Many diagnostics
+- Many diagnostics
 
 <!--
 Say: this is the same design principle as transformers.
@@ -986,13 +986,13 @@ Say: lint pass comparison, not a claim that the whole project build is 901x fast
 
 Interpretation:
 
-• Not "Go is magic"
+- Not "Go is magic"
 
-• Reuse the Program
+- Reuse the Program
 
-• Avoid second analysis
+- Avoid second analysis
 
-• About **900x** lint pass gap
+- About **900x** lint pass gap
 
 <!--
 Say: the benchmark proves the architecture point.
@@ -1004,13 +1004,13 @@ Say: the benchmark proves the architecture point.
 
 Linter is a separate TTSC chapter because it proves reuse.
 
-• Compiler state
+- Compiler state
 
-• Transformer state
+- Transformer state
 
-• Lint state
+- Lint state
 
-• same substrate
+- same substrate
 
 <!--
 Say: after transformer survival, linter is the first productivity dividend.
@@ -1022,13 +1022,13 @@ Say: after transformer survival, linter is the first productivity dividend.
 
 # 4. TTSC Graph
 
-• Why grep Fails
+- Why grep Fails
 
-• Compiler-Aware Context
+- Compiler-Aware Context
 
-• For Coding Agents
+- For Coding Agents
 
-• Token Economy
+- Token Economy
 
 <!--
 Chapter start is only the local table of contents.
@@ -1040,13 +1040,13 @@ Chapter start is only the local table of contents.
 
 Agents often rebuild context manually.
 
-• grep
+- grep
 
-• open file
+- open file
 
-• follow import
+- follow import
 
-• repeat
+- repeat
 
 <!--
 Say: this is expensive, lossy, and easy to derail.
@@ -1058,15 +1058,15 @@ Say: this is expensive, lossy, and easy to derail.
 
 Grep does not know compiler facts.
 
-• Alias
+- Alias
 
-• Symbol owner
+- Symbol owner
 
-• References
+- References
 
-• Type vs value
+- Type vs value
 
-• call path
+- call path
 
 <!--
 Say: the compiler already knows these relationships.
@@ -1078,13 +1078,13 @@ Say: the compiler already knows these relationships.
 
 File search is a weak substitute for semantic context.
 
-• Same name, different symbol
+- Same name, different symbol
 
-• Barrel export hides owner
+- Barrel export hides owner
 
-• Generic call hides concrete type
+- Generic call hides concrete type
 
-• dynamic import hides path
+- dynamic import hides path
 
 <!--
 Say: agents need the graph before they need the file.
@@ -1096,15 +1096,15 @@ Say: agents need the graph before they need the file.
 
 `@ttsc/graph` exposes compiler structure.
 
-• Declarations
+- Declarations
 
-• Exports
+- Exports
 
-• Imports
+- Imports
 
-• References
+- References
 
-• Diagnostics
+- Diagnostics
 
 <!--
 Say: graph comes from compiler resolution, not regex.
@@ -1116,13 +1116,13 @@ Say: graph comes from compiler resolution, not regex.
 
 Example path:
 
-• `Repository.find`
+- `Repository.find`
 
-• `FindOptionsUtils`
+- `FindOptionsUtils`
 
-• `SelectQueryBuilder`
+- `SelectQueryBuilder`
 
-• `RelationMetadata`
+- `RelationMetadata`
 
 <!--
 Say: TypeORM relation options example. The point is path discovery, not reading every file.
@@ -1134,13 +1134,13 @@ Say: TypeORM relation options example. The point is path discovery, not reading 
 
 Graph answers a different first question.
 
-• grep: "which files mention this text?"
+- grep: "which files mention this text?"
 
-• graph: "which symbols matter?"
+- graph: "which symbols matter?"
 
-• grep: file-first
+- grep: file-first
 
-• graph: compiler-first
+- graph: compiler-first
 
 <!--
 Say: file reading still happens, but after narrowing.
@@ -1173,13 +1173,13 @@ Say: the agent asks the compiler graph before opening source files.
 
 Workflow:
 
-• Map first
+- Map first
 
-• Source second
+- Source second
 
-• Fewer files
+- Fewer files
 
-• Better edit target
+- Better edit target
 
 <!--
 Say: not source-free. Source-selective.
@@ -1191,13 +1191,13 @@ Say: not source-free. Source-selective.
 
 Agent context becomes compiler-guided.
 
-• Resolve symbol
+- Resolve symbol
 
-• Follow references
+- Follow references
 
-• Inspect diagnostics
+- Inspect diagnostics
 
-• Open only relevant source
+- Open only relevant source
 
 <!--
 Say: this is what a human maintainer does mentally.
@@ -1225,13 +1225,13 @@ Say: about 10x token reduction, not 100x.
 
 Interpretation:
 
-• About **10x** fewer tokens
+- About **10x** fewer tokens
 
-• No blind file reading
+- No blind file reading
 
-• Fewer tool calls
+- Fewer tool calls
 
-• Same target found faster
+- Same target found faster
 
 <!--
 Say: the number matters because agents pay for exploration.
@@ -1243,15 +1243,15 @@ Say: the number matters because agents pay for exploration.
 
 Same pattern across TTSC:
 
-• Compiler state
+- Compiler state
 
-• No duplicate discovery
+- No duplicate discovery
 
-• Linter uses it
+- Linter uses it
 
-• Graph uses it
+- Graph uses it
 
-• Agents use it
+- Agents use it
 
 <!--
 Say: this is the unifying TTSC story.
@@ -1263,13 +1263,13 @@ Say: this is the unifying TTSC story.
 
 One TypeScript-Go substrate:
 
-• `ttsc`
+- `ttsc`
 
-• `ttsx`
+- `ttsx`
 
-• `@ttsc/lint`
+- `@ttsc/lint`
 
-• `@ttsc/graph`
+- `@ttsc/graph`
 
 <!--
 Say: TTSC is a toolchain, not a single wrapper command.
@@ -1283,13 +1283,13 @@ The compiler became faster.
 
 Transformer users need more than speed.
 
-• keep type-driven code generation
+- keep type-driven code generation
 
-• keep diagnostics in the editor
+- keep diagnostics in the editor
 
-• reuse compiler state for lint and graph
+- reuse compiler state for lint and graph
 
-• make TypeScript-Go usable for backend tooling
+- make TypeScript-Go usable for backend tooling
 
 <!--
 Say: TypeScript-Go is good news only if the tool ecosystem survives it.

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -515,7 +515,7 @@ const article: IBbsArticle =
 ```
 
 <!--
-Say: the frontend receives a generated function with the same route path, parameter order, request type, and response type.
+Say: this follows the Nestia homepage contrast: backend controller in, frontend SDK function out.
 -->
 
 ---
@@ -1348,3 +1348,7 @@ TypeScript Backend Meetup
 2026-06-26
 
 Samchon
+
+<!--
+End.
+-->

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -3,159 +3,487 @@ marp: true
 theme: default
 paginate: true
 size: 4:3
-title: "TTSC: Transformer Survival in the TypeScript 7 Era"
+title: "TTSC: From Transformer Crisis to TypeScript-Go Toolchain"
 description: "TypeScript Backend Meetup, 2026-06-26"
-footer: "TTSC | TypeScript Backend Meetup | 2026-06-26"
+footer: "https://ttsc.dev | 2026-06-26"
 style: |
   section {
+    background: #f7fbff;
+    box-shadow: inset 0 8px 0 #3178c6;
     font-family: "Inter", "Segoe UI", "Pretendard", sans-serif;
-    color: #111827;
-    padding: 72px 84px;
+    color: #0f172a;
+    overflow: hidden;
+    padding: 68px 78px;
+    position: relative;
   }
   section.lead {
+    background: #3178c6;
+    box-shadow: none;
+    color: #ffffff;
     display: flex;
     flex-direction: column;
     justify-content: center;
   }
+  section.lead::before {
+    bottom: -42px;
+    color: rgba(255, 255, 255, 0.1);
+    content: "TS";
+    font-size: 230px;
+    font-weight: 900;
+    letter-spacing: 0;
+    line-height: 0.8;
+    position: absolute;
+    right: 28px;
+  }
+  section.lead h1,
+  section.lead h2,
+  section.lead h3,
+  section.lead p,
+  section.lead li {
+    color: #ffffff;
+    position: relative;
+  }
+  section footer {
+    color: rgba(49, 120, 198, 0.78);
+  }
+  section.lead footer,
+  section.lead::after {
+    color: rgba(255, 255, 255, 0.86) !important;
+  }
   h1 {
-    color: #0f172a;
-    font-size: 58px;
+    color: #102a43;
+    font-size: 54px;
+    letter-spacing: 0;
+    margin-bottom: 28px;
   }
   h2 {
-    color: #0f172a;
-    font-size: 44px;
+    color: #102a43;
+    font-size: 42px;
   }
   h3 {
-    color: #2563eb;
-    font-size: 32px;
+    color: #3178c6;
+    font-size: 30px;
+  }
+  p,
+  li {
+    font-size: 28px;
+    line-height: 1.34;
+  }
+  ul ul,
+  ol ul {
+    margin-top: 4px;
+  }
+  ul ul li,
+  ol ul li {
+    color: #334155;
+    font-size: 23px;
+    line-height: 1.25;
   }
   strong {
-    color: #2563eb;
+    color: #3178c6;
   }
   code {
     font-family: "Cascadia Code", monospace;
   }
+  pre {
+    background: #111827;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    color: #e5e7eb;
+    margin: 0;
+    overflow: visible;
+    padding: 18px;
+  }
+  pre code {
+    background: transparent;
+    color: #e5e7eb;
+    font-size: inherit;
+    padding: 0;
+  }
+  pre code.hljs {
+    background: transparent;
+    color: #e5e7eb;
+    overflow: visible;
+    padding: 0;
+  }
+  pre .hljs-keyword,
+  pre .hljs-built_in,
+  pre .hljs-selector-tag {
+    color: #c084fc !important;
+  }
+  pre .hljs-string,
+  pre .hljs-regexp {
+    color: #86efac !important;
+  }
+  pre .hljs-title,
+  pre .hljs-title.class_,
+  pre .hljs-title.function_ {
+    color: #93c5fd !important;
+  }
+  pre .hljs-attr,
+  pre .hljs-property,
+  pre .hljs-attribute {
+    color: #facc15 !important;
+  }
+  pre .hljs-number,
+  pre .hljs-literal {
+    color: #fb923c !important;
+  }
+  pre .hljs-type,
+  pre .hljs-symbol {
+    color: #67e8f9 !important;
+  }
+  pre .hljs-comment {
+    color: #94a3b8 !important;
+    font-style: italic;
+  }
+  pre .hljs-meta {
+    color: #f472b6 !important;
+  }
   table {
     font-size: 24px;
   }
+  th {
+    background: #dbeafe;
+    color: #102a43;
+  }
+  td,
+  th {
+    border-color: #93c5fd !important;
+  }
   blockquote {
-    border-left: 8px solid #2563eb;
+    border-left: 8px solid #3178c6;
     color: #1f2937;
-    font-size: 34px;
+    font-size: 32px;
     padding-left: 28px;
   }
-  section.split h1 {
-    margin-bottom: 28px;
-  }
-  section.split .cols {
-    align-items: stretch;
+  section.split {
+    column-gap: 28px;
     display: grid;
-    gap: 36px;
-    grid-template-columns: 0.95fr 1.05fr;
+    grid-template-columns: 0.64fr 1.36fr;
+    grid-template-rows: auto minmax(0, 1fr);
+    padding: 56px 58px;
   }
-  section.split .cols.equal {
-    grid-template-columns: 1fr 1fr;
+  section.split h1 {
+    font-size: 46px;
+    grid-column: 1 / -1;
+    margin-bottom: 22px;
   }
-  section.split .col {
-    min-width: 0;
-  }
-  section.split .panel,
-  section.split .code-card,
-  section.split .diagram {
+  section.split > ul {
+    align-self: start;
     background: #f8fafc;
     border: 1px solid #cbd5e1;
     border-radius: 8px;
-    padding: 22px;
+    grid-column: 1;
+    margin: 0;
+    padding: 18px 20px 18px 36px;
   }
-  section.split .label {
-    color: #2563eb;
-    font-size: 22px;
-    font-weight: 700;
-    margin-bottom: 14px;
-    text-transform: uppercase;
+  section.split > ul > li {
+    font-size: 23px;
+    line-height: 1.24;
+  }
+  section.split > ul li li {
+    font-size: 19px;
+    line-height: 1.2;
   }
   section.split .caption {
     color: #475569;
-    font-size: 24px;
-    margin-top: 16px;
-  }
-  section.split pre {
-    background: #0f172a;
-    border-radius: 8px;
-    color: #e5e7eb;
-    font-size: 20px;
-    line-height: 1.35;
-    margin: 0;
-    padding: 18px;
-  }
-  section.split .node,
-  section.split .hub,
-  section.split .metric {
-    background: #ffffff;
-    border: 1px solid #94a3b8;
-    border-radius: 8px;
-    padding: 14px 18px;
-  }
-  section.split .node {
-    font-size: 24px;
-    font-weight: 700;
-    text-align: center;
-  }
-  section.split .arrow {
-    color: #64748b;
-    font-size: 28px;
-    font-weight: 800;
-    margin: 10px 0;
-    text-align: center;
-  }
-  section.split .flow-grid {
-    display: grid;
-    gap: 12px;
-  }
-  section.split .hub {
-    border-color: #2563eb;
-    color: #0f172a;
-    font-size: 28px;
-    font-weight: 800;
-    margin: 16px 0;
-    text-align: center;
-  }
-  section.split .spokes {
-    display: grid;
-    gap: 12px;
-    grid-template-columns: 1fr 1fr;
-  }
-  section.split .mini {
-    color: #334155;
     font-size: 22px;
+    margin-top: 12px;
   }
-  section.split .metric {
-    align-items: center;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    justify-content: center;
-    min-height: 280px;
+  section.code-split {
+    column-gap: 28px;
+    display: grid;
+    grid-template-columns: 0.58fr 1.42fr;
+    grid-template-rows: auto minmax(0, 1fr);
+    padding: 48px 56px;
   }
-  section.split .metric strong {
-    color: #16a34a;
-    font-size: 96px;
-    line-height: 1;
+  section.code-split h1 {
+    font-size: 44px;
+    grid-column: 1 / -1;
+    margin-bottom: 18px;
   }
-  section.split .bar {
-    align-items: center;
+  section.code-split > ul {
+    align-self: start;
+    background: #f8fafc;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    grid-column: 1;
+    margin: 0;
+    padding: 16px 18px 16px 34px;
+  }
+  section.code-split > ul > li {
+    font-size: 21px;
+    line-height: 1.22;
+  }
+  section.code-split > ul li li {
+    font-size: 17px;
+    line-height: 1.18;
+  }
+  section.code-split > pre {
+    align-self: start;
+    grid-column: 2;
+    min-width: 0;
+  }
+  section.code-split pre {
+    font-size: 20px;
+    line-height: 1.26;
+    padding: 14px;
+  }
+  section.benchmark {
+    column-gap: 30px;
+    display: grid;
+    grid-template-columns: 0.7fr 1.3fr;
+    grid-template-rows: auto minmax(0, 1fr);
+    padding: 56px 58px;
+  }
+  section.benchmark h1 {
+    font-size: 46px;
+    grid-column: 1 / -1;
+    margin-bottom: 22px;
+  }
+  section.benchmark > ul {
+    align-self: start;
+    background: #f8fafc;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    grid-column: 1;
+    margin: 0;
+    padding: 18px 20px 18px 36px;
+  }
+  section.benchmark > ul > li {
+    font-size: 23px;
+    line-height: 1.24;
+  }
+  section.benchmark > ul li li {
+    font-size: 19px;
+    line-height: 1.2;
+  }
+  section.benchmark .benchmarks {
     display: grid;
     gap: 12px;
-    grid-template-columns: 110px 1fr 110px;
-    margin: 12px 0;
+    grid-column: 2;
   }
-  section.split .bar-fill {
-    background: #2563eb;
+  section.benchmark .bench-card {
+    background: #ffffff;
+    border: 1px solid #cbd5e1;
     border-radius: 8px;
-    height: 18px;
+    padding: 14px;
   }
-  section.split .bar-fill.green {
-    background: #16a34a;
+  section.benchmark .bench-title {
+    color: #2563eb;
+    font-size: 22px;
+    font-weight: 800;
+    margin-bottom: 10px;
+  }
+  section.benchmark .bench-row {
+    align-items: center;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 150px minmax(0, 1fr) 104px;
+    margin-top: 7px;
+  }
+  section.benchmark .bench-name {
+    color: #334155;
+    font-size: 17px;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+  section.benchmark .bench-value {
+    color: #0f172a;
+    font-size: 21px;
+    font-weight: 900;
+    line-height: 1;
+    text-align: right;
+    white-space: nowrap;
+  }
+  section.benchmark .bench-track {
+    background: #e2e8f0;
+    border-radius: 999px;
+    height: 22px;
+    overflow: hidden;
+  }
+  section.benchmark .bench-fill {
+    background: #2563eb;
+    border-radius: 999px;
+    height: 100%;
+  }
+  section.benchmark .bench-fill.base {
+    background: #94a3b8;
+  }
+  section.benchmark .w-base {
+    width: 8%;
+  }
+  section.benchmark .w-10 {
+    width: 36%;
+  }
+  section.benchmark .w-30 {
+    width: 48%;
+  }
+  section.benchmark .w-200 {
+    width: 64%;
+  }
+  section.benchmark .w-20000 {
+    width: 100%;
+  }
+  section.benchmark .bench-note {
+    color: #64748b;
+    font-size: 17px;
+    margin-top: 10px;
+  }
+  section.cards > ul {
+    display: grid;
+    gap: 18px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  section.cards > ul > li {
+    background: #ffffff;
+    border: 1px solid #93c5fd;
+    border-left: 8px solid #3178c6;
+    border-radius: 8px;
+    box-shadow: 0 12px 28px rgba(49, 120, 198, 0.12);
+    color: #102a43;
+    font-size: 26px;
+    font-weight: 800;
+    line-height: 1.15;
+    padding: 18px 20px;
+  }
+  section.cards > ul > li > ul {
+    list-style: disc;
+    margin-top: 12px;
+    padding-left: 24px;
+  }
+  section.cards > ul > li li {
+    color: #334155;
+    font-size: 20px;
+    font-weight: 500;
+    line-height: 1.25;
+  }
+  section.cards.three > ul {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  section.cards.three > ul > li {
+    font-size: 23px;
+    padding: 16px 18px;
+  }
+  section.cards.three > ul > li li {
+    font-size: 18px;
+  }
+  section.cards.choice > ul > li:last-child {
+    background: #3178c6;
+    border-color: #1d4ed8;
+    color: #ffffff;
+  }
+  section.cards.choice > ul > li:last-child li,
+  section.cards.choice > ul > li:last-child strong {
+    color: #dbeafe;
+  }
+  section.compare table {
+    background: #ffffff;
+    border: 1px solid #93c5fd;
+    border-radius: 8px;
+    box-shadow: 0 12px 28px rgba(49, 120, 198, 0.12);
+    display: table;
+    font-size: 23px;
+    overflow: hidden;
+    width: 100%;
+  }
+  section.compare td,
+  section.compare th {
+    padding: 16px 18px;
+    vertical-align: top;
+  }
+  section.compare td:nth-child(2),
+  section.compare th:nth-child(2) {
+    background: #eff6ff;
+  }
+  section.metric table {
+    background: #ffffff;
+    border: 1px solid #93c5fd;
+    border-radius: 8px;
+    box-shadow: 0 12px 28px rgba(49, 120, 198, 0.12);
+    display: table;
+    font-size: 28px;
+    overflow: hidden;
+    width: 100%;
+  }
+  section.metric td,
+  section.metric th {
+    padding: 18px 22px;
+  }
+  section.metric strong {
+    display: block;
+    font-size: 64px;
+    line-height: 1;
+    margin-top: 28px;
+    text-align: center;
+  }
+  section.flow > ul {
+    align-items: stretch;
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  section.flow > ul > li {
+    background: #ffffff;
+    border: 1px solid #93c5fd;
+    border-radius: 8px;
+    box-shadow: 0 12px 28px rgba(49, 120, 198, 0.12);
+    color: #102a43;
+    font-size: 24px;
+    font-weight: 800;
+    line-height: 1.15;
+    min-height: 220px;
+    padding: 18px;
+    position: relative;
+  }
+  section.flow > ul > li:not(:last-child)::after {
+    color: #3178c6;
+    content: ">";
+    font-size: 34px;
+    font-weight: 900;
+    position: absolute;
+    right: -19px;
+    top: 88px;
+  }
+  section.flow > ul > li > ul {
+    margin-top: 12px;
+    padding-left: 22px;
+  }
+  section.flow > ul > li li {
+    color: #334155;
+    font-size: 19px;
+    font-weight: 500;
+    line-height: 1.25;
+  }
+  section.blueprint {
+    background: #0f172a;
+    box-shadow: inset 0 8px 0 #3178c6;
+    color: #e5f0ff;
+  }
+  section.blueprint h1,
+  section.blueprint h2,
+  section.blueprint h3,
+  section.blueprint li,
+  section.blueprint p {
+    color: #e5f0ff;
+  }
+  section.blueprint strong {
+    color: #93c5fd;
+  }
+  section.blueprint > ul > li {
+    background: #102a43;
+    border-color: #3178c6;
+    color: #ffffff;
+  }
+  section.blueprint > ul > li li {
+    color: #dbeafe;
   }
 ---
 
@@ -163,245 +491,66 @@ style: |
 
 # TTSC
 
-### TypeScript-Go ToolChain
+### From Transformer Crisis to TypeScript-Go Toolchain
 
 TypeScript Backend Meetup
 
 Samchon, 2026-06-26
 
-<!--
-Opening: TypeScript-Go is the trigger. TTSC is the survival layer for transformer users.
--->
-
 ---
 
-# TTSC
+![TTSC logo](https://ttsc.dev/og.jpg)
 
-![TTSC logo](../og.jpg)
-
-<!--
-One beat for the logo.
--->
+- https://ttsc.dev
+- https://github.com/samchon/ttsc
 
 ---
 
 # TL;DR
 
-- TypeScript compiler is moving to Go
-
-- Transformers lose the old JavaScript patch point
-
-- TTSC keeps compile-time code generation alive
-
-- Linter and Graph turn compiler state into toolchain state
-
-<!--
-Say: this talk is not "Go is faster". It is "the compiler substrate changed".
--->
-
----
-
-# Preface
-
-TypeScript 7 changes the foundation under TypeScript tools.
-
-- Native Go compiler
-
-- TypeScript 6 semantic parity
-
-- About **10x** faster on many projects
-
-- Plugin ecosystem must adapt
-
-<!--
-Source is Microsoft's TypeScript 7 RC and native port posts.
--->
+- typia and nestia
+  - pure TypeScript input
+  - generated runtime/tooling output
+- TypeScript-Go
+  - faster compiler
+  - missing JavaScript patch point
+- TTSC
+  - transformer host
+  - compiler-state toolchain
 
 ---
 
 # Index
 
-1. TypeScript-Go
-
-2. TTSC
-
-3. TTSC Linter
-
-4. TTSC Graph
-
-<!--
-Four chapters. Problem first, TTSC after.
--->
+1. typia and nestia
+2. TypeScript-Go Shock
+3. TTSC: Transformer Survival
+4. TTSC: Toolchain Opportunity
 
 ---
 
 <!-- _class: lead -->
 
-# 1. TypeScript-Go
+# 1. typia and nestia
 
-- Good News
-
-- Bad News
-
-- Transformer
-
-- Compatibility Gap
-
-<!--
-Chapter start is only the local table of contents.
--->
+- Show the code
+- Show the output
+- Then name the engine
 
 ---
 
-# 1.1. Good News
-
-TypeScript compiler is moving from JavaScript to Go.
-
-- TypeScript 7.0 RC
-
-- Native compiler and language service
-
-- Shared-memory parallelism
-
-- About **10x** faster than TypeScript 6.0
-
-<!--
-Say: most users hear this as a simple speed story.
--->
-
----
-
-# 1.1. Good News
-
-The port is not a rewrite of the language.
-
-- Existing codebase ported to Go
-
-- Type-checking logic kept structurally identical
-
-- Same TypeScript semantics
-
-- New runtime foundation
-
-<!--
-Say: for normal users, compatibility is the headline. For tool authors, runtime foundation is the issue.
--->
-
----
-
-# 1.1. Good News
-
-Backend teams pay compiler latency every day.
-
-- Monorepo type check
-
-- Watch mode
-
-- Editor startup
-
-- CI feedback loop
-
-<!--
-Say: 10x is not an abstract benchmark. It changes the development loop.
--->
-
----
-
-# 1.2. Bad News
-
-Compiler plugins lived inside the old compiler shape.
-
-- JavaScript runtime
-
-- TypeScript compiler API
-
-- AST and Checker objects
-
-- Emit pipeline hooks
-
-<!--
-Say: transformer users were extending the compiler, not just compiling source.
--->
-
----
-
-# 1.2. Bad News
-
-The old ecosystem patched TypeScript itself.
-
-- `ttypescript`
-
-- `ts-patch`
-
-- `tsconfig.plugins`
-
-- custom transformers
-
-<!--
-Say: the plugin contract was informal, but it worked because everything was JavaScript.
--->
-
----
-
-# 1.2. Bad News
-
-APIs can survive while engines break.
-
-- `typia`
-
-- `nestia`
-
-- custom SDK generators
-
-- generated runtime validators
-
-<!--
-Say: user-facing code can remain the same, but the generation engine must move.
--->
-
----
-
-# 1.3. Transformer
-
-Transformer = compile-time code generation from TypeScript types.
-
-- Read source code
-
-- Inspect AST
-
-- Ask the Checker
-
-- Emit JavaScript
-
-<!--
-Minimal definition. The next slides show why it matters.
--->
-
----
-
-# 1.3. Transformer
-
-Common backend uses:
-
-- Runtime validation
-
-- Serialization
-
-- OpenAPI generation
-
-- SDK generation
-
-- SDK call signatures
-
-<!--
-Say: typia and nestia are concrete examples, not edge cases.
--->
-
----
-
-# 1.3. Transformer
-
-### Typia: TypeScript input
+<!-- _class: code-split -->
+
+# 1.1. typia Source
+
+- User writes
+  - TS type
+  - tags
+  - generic call
+- No duplicate
+  - no schema
+  - no decorator
+  - no DTO class
 
 ```typescript
 import typia, { tags } from "typia";
@@ -414,74 +563,109 @@ interface IMember {
     tags.ExclusiveMinimum<19> &
     tags.Maximum<100>;
 }
-typia.createIs<IMember>();
-```
 
-<!--
-Say: IMember is a type. It disappears at runtime unless a transformer catches it before erasure.
--->
+const isMember =
+  typia.createIs<IMember>();
+```
 
 ---
 
-# 1.3. Transformer
+<!-- _class: code-split -->
 
-### Typia: JavaScript output
+# 1.1. typia Output
+
+- Compiler emits
+  - UUID check
+  - email check
+  - uint32 check
+  - range check
+- Erased type
+  - JS
+  - no interpreter
 
 ```javascript
-import * as _b from "typia/lib/internal/_isFormatEmail";
-import * as _a from "typia/lib/internal/_isFormatUuid";
-import * as _c from "typia/lib/internal/_isTypeUint32";
-
-(() => {
-  const _io0 = (input) =>
-    "string" === typeof input.id &&
-    _a._isFormatUuid(input.id) &&
-    "string" === typeof input.email &&
-    _b._isFormatEmail(input.email) &&
-    "number" === typeof input.age &&
-    _c._isTypeUint32(input.age) &&
-    19 < input.age &&
-    input.age <= 100;
-  return (input) => "object" === typeof input && null !== input && _io0(input);
-})();
+const isMember = (input) =>
+  "object" === typeof input &&
+  null !== input &&
+  "string" === typeof input.id &&
+  _isFormatUuid(input.id) &&
+  "string" === typeof input.email &&
+  _isFormatEmail(input.email) &&
+  "number" === typeof input.age &&
+  _isTypeUint32(input.age) &&
+  19 < input.age &&
+  input.age <= 100;
 ```
 
-<!--
-Say: one generic type call became UUID, email, integer, and range checks.
--->
+---
+
+<!-- _class: benchmark -->
+
+# 1.1. typia Impact
+
+- Runtime validation
+  - **20,000x**
+  - `class-validator`
+  - detailed failure paths
+- JSON serialization
+  - **200x**
+  - `class-transformer`
+  - type-specialized stringifier
+- Same source
+  - TypeScript type
+  - JSDoc
+  - tags
+
+<div class="benchmarks">
+  <div class="bench-card">
+    <div class="bench-title">Runtime validation</div>
+    <div class="bench-row">
+      <div class="bench-name">class-validator</div>
+      <div class="bench-track"><div class="bench-fill base w-base"></div></div>
+      <div class="bench-value">1x</div>
+    </div>
+    <div class="bench-row">
+      <div class="bench-name">typia</div>
+      <div class="bench-track"><div class="bench-fill w-20000"></div></div>
+      <div class="bench-value">20,000x</div>
+    </div>
+  </div>
+  <div class="bench-card">
+    <div class="bench-title">JSON serialization</div>
+    <div class="bench-row">
+      <div class="bench-name">class-transformer</div>
+      <div class="bench-track"><div class="bench-fill base w-base"></div></div>
+      <div class="bench-value">1x</div>
+    </div>
+    <div class="bench-row">
+      <div class="bench-name">typia</div>
+      <div class="bench-track"><div class="bench-fill w-200"></div></div>
+      <div class="bench-value">200x</div>
+    </div>
+  </div>
+  <div class="bench-note">Log-scaled visual, comparison target = 1x.</div>
+</div>
 
 ---
 
-# 1.3. Transformer
+<!-- _class: code-split -->
 
-Type information became runtime code.
+# 1.2. nestia Source
 
-- `tags.Format<"uuid">` -> UUID check
-
-- `tags.Format<"email">` -> email check
-
-- `tags.Type<"uint32">` -> integer range
-
-- `tags.Maximum<100>` -> boundary check
-
-<!--
-Say: this is not reflection. It is ahead-of-time compilation.
--->
-
----
-
-# 1.3. Transformer
-
-### Nestia: backend controller
+- Backend code
+  - path
+  - method
+  - parameter
+  - body type
+  - return
+- Contract source
+  - controller
 
 ```typescript
-import { TypedBody, TypedParam, TypedRoute } from "@nestia/core";
-import { Controller } from "@nestjs/common";
-
 @Controller("bbs/:section/articles")
 export class BbsArticlesController {
   @TypedRoute.Post()
-  async create(
+  public async create(
     @TypedParam("section") section: string,
     @TypedBody() input: IBbsArticle.ICreate,
   ): Promise<IBbsArticle> {
@@ -490,83 +674,248 @@ export class BbsArticlesController {
 }
 ```
 
-<!--
-Say: backend code is still normal NestJS. The important part is the TypeScript type on input and output.
--->
-
 ---
 
-# 1.3. Transformer
+<!-- _class: code-split -->
 
-### Nestia: frontend SDK
+# 1.2. nestia Output
+
+- Generated SDK
+  - typed fetch
+  - DTO
+  - checks
+- Backend
+  - no interface copy
+  - FE API
 
 ```typescript
-import api from "@my/api";
-
-const connection: api.IConnection = {
-  host: "http://localhost:3000",
-};
-
 const article: IBbsArticle =
-  await api.functional.bbs.articles.create(connection, "general", {
-    title: "Hello World",
-    body: "My first article",
-  } satisfies IBbsArticle.ICreate);
+  await api.functional.bbs.articles.create(
+    connection,
+    "general",
+    {
+      title: "Hello World",
+      body: "My first article",
+    } satisfies IBbsArticle.ICreate,
+  );
 ```
 
-<!--
-Say: this follows the Nestia homepage contrast: backend controller in, frontend SDK function out.
--->
+---
+
+<!-- _class: benchmark -->
+
+# 1.2. nestia Impact
+
+- Server performance
+  - **10x+** total path
+  - **30x** Fastify path
+  - validation **20,000x**
+  - serialization **200x**
+- SDK generation
+  - typed fetch functions
+  - DTO structures
+  - npm distribution
+- Tooling
+  - OpenAPI
+  - mockup simulator
+  - E2E test functions
+  - Swagger editor
+
+<div class="benchmarks">
+  <div class="bench-card">
+    <div class="bench-title">Server path</div>
+    <div class="bench-row">
+      <div class="bench-name">NestJS base</div>
+      <div class="bench-track"><div class="bench-fill base w-base"></div></div>
+      <div class="bench-value">1x</div>
+    </div>
+    <div class="bench-row">
+      <div class="bench-name">nestia</div>
+      <div class="bench-track"><div class="bench-fill w-10"></div></div>
+      <div class="bench-value">10x+</div>
+    </div>
+  </div>
+  <div class="bench-card">
+    <div class="bench-title">Validation</div>
+    <div class="bench-row">
+      <div class="bench-name">class-validator</div>
+      <div class="bench-track"><div class="bench-fill base w-base"></div></div>
+      <div class="bench-value">1x</div>
+    </div>
+    <div class="bench-row">
+      <div class="bench-name">typia core</div>
+      <div class="bench-track"><div class="bench-fill w-20000"></div></div>
+      <div class="bench-value">20,000x</div>
+    </div>
+  </div>
+  <div class="bench-card">
+    <div class="bench-title">Serialization</div>
+    <div class="bench-row">
+      <div class="bench-name">class-transformer</div>
+      <div class="bench-track"><div class="bench-fill base w-base"></div></div>
+      <div class="bench-value">1x</div>
+    </div>
+    <div class="bench-row">
+      <div class="bench-name">typia core</div>
+      <div class="bench-track"><div class="bench-fill w-200"></div></div>
+      <div class="bench-value">200x</div>
+    </div>
+  </div>
+</div>
 
 ---
 
-# 1.3. Transformer
+# 1.3. What You Just Saw
 
-Backend type became frontend function.
-
-- Controller path -> SDK namespace
-
-- Route method -> SDK function
-
-- `@TypedBody()` -> request type
-
-- `Promise<IBbsArticle>` -> response type
-
-<!--
-Say: this is the nestia transformer story. Backend TypeScript becomes frontend API surface.
--->
-
----
-
-# 1.4. Compatibility Gap
-
-Old transformer setup installed a compiler patch.
-
-```json
-{
-  "scripts": {
-    "prepare": "ts-patch install"
-  },
-  "devDependencies": {
-    "ts-patch": "^3.2.1"
-  }
-}
-```
-
-<!--
-Say: this was the old survival strategy.
--->
+- typia
+  - TypeScript type
+  - runtime validator
+  - JSON serializer
+  - LLM schema
+- nestia
+  - NestJS controller
+  - runtime boundary
+  - client SDK
+  - OpenAPI document
+- Same shape
+  - compiler analysis
+  - generated artifacts
 
 ---
 
-# 1.4. Compatibility Gap
+# 1.3. The Common Engine
 
-Old transformer setup registered plugins in `tsconfig.json`.
+- Input
+  - TypeScript source
+  - types
+  - decorators
+  - JSDoc
+- Compiler facts
+  - AST
+  - Checker
+  - symbols
+  - diagnostics
+- Output
+  - JavaScript
+  - schemas
+  - SDK
+  - OpenAPI
+
+---
+
+# 1.4. Now: Transformer
+
+- Transformer
+  - compile-time code generation
+  - from TypeScript compiler facts
+- Reads
+  - source file
+  - AST
+  - Checker
+- Rewrites
+  - JavaScript emit
+  - diagnostics
+  - generated artifacts
+
+---
+
+# 1.4. Hidden Dependency
+
+- Public API
+  - still TypeScript
+  - still npm package
+  - still framework-friendly
+- Private engine
+  - JavaScript compiler process
+  - transformer host
+  - emit pipeline
+- Key split
+  - language compatibility
+  - plugin compatibility
+
+---
+
+<!-- _class: lead -->
+
+# 2. TypeScript-Go Shock
+
+- Native compiler arrives
+- Faster is good
+- Patch point dies
+- My projects are at risk
+
+---
+
+<!-- _class: cards -->
+
+# 2.1. Native Compiler
+
+- TypeScript 7.0 RC
+  - JavaScript compiler to Go compiler
+  - native compiler and language service
+- Performance
+  - shared-memory parallelism
+  - about **10x** faster than TypeScript 6.0
+- User story
+  - same language
+  - faster loop
+
+---
+
+<!-- _class: cards -->
+
+# 2.1. Backend Upside
+
+- Daily compiler cost
+  - monorepo type check
+  - watch mode
+  - editor startup
+  - CI feedback
+- Result
+  - shorter local loop
+  - shorter review loop
+  - shorter release loop
+
+---
+
+<!-- _class: cards three -->
+
+# 2.2. Old Assumption
+
+- Old compiler
+  - JavaScript package
+  - JavaScript process
+  - JavaScript objects
+- Old transformers
+  - JavaScript modules
+  - compiler API access
+  - emit hook access
+- Old strategy
+  - patch TypeScript
+
+---
+
+<!-- _class: cards -->
+
+# 2.2. Patch Model
+
+- `ttypescript`
+  - custom compiler wrapper
+- `ts-patch`
+  - mutate installed TypeScript
+- `tsconfig.plugins`
+  - transformer module path
+- Works because
+  - compiler is JavaScript
+  - transformer is JavaScript
+
+---
+
+# 2.3. Old Setup
 
 ```json
 {
   "compilerOptions": {
-    "strict": true,
     "plugins": [
       { "transform": "typia/lib/transform" },
       { "transform": "@nestia/core/lib/transform" },
@@ -576,69 +925,72 @@ Old transformer setup registered plugins in `tsconfig.json`.
 }
 ```
 
-<!--
-Say: this assumes the compiler can load JavaScript plugins into its own process.
--->
+---
+
+<!-- _class: compare -->
+
+# 2.3. Broken Assumption
+
+| Old world | TypeScript-Go world |
+| --- | --- |
+| compiler: JavaScript process | compiler: Go process |
+| transformer: JavaScript module | transformer: JavaScript ecosystem |
+| hook: patchable | hook: missing |
+| language OK | transformer host broken |
 
 ---
 
-# 1.4. Compatibility Gap
+<!-- _class: cards three -->
 
-The new compiler substrate breaks that assumption.
+# 2.4. Project Risk
 
-- Old compiler: JavaScript process
-
-- Old transformer: JavaScript module
-
-- New compiler: Go process
-
-- Old hook: unavailable
-
-<!--
-Say: TypeScript 7 can preserve language semantics while still breaking plugin hosting.
--->
+- typia risk
+  - erased types unseen
+  - validators not generated
+  - serializers not generated
+- nestia risk
+  - controllers not extracted
+  - SDK not generated
+  - OpenAPI not generated
+- Business risk
+  - public APIs survive
+  - engine disappears
 
 ---
 
-# 1.4. Compatibility Gap
+<!-- _class: cards choice -->
 
-Transformer users need a toolchain, not a patch.
+# 2.4. Options
 
-- Compiler front door
-
-- Plugin host
-
-- Runtime execution path
-
-- Editor integration
-
-<!--
-Say: this is the bridge from TypeScript-Go to TTSC.
--->
+- Wait
+  - upstream plugin model
+  - unknown timeline
+- Retreat
+  - runtime schemas
+  - weaker compiler magic
+- Drop features
+  - no transformer path
+  - no generated boundary
+- Build
+  - new host
+  - TypeScript-Go base
 
 ---
 
 <!-- _class: lead -->
 
-# 2. TTSC
+# 3. TTSC: Transformer Survival
 
-- Compiler
-
-- Transformer
-
-- Runtime
-
-- Language Server
-
-<!--
-Chapter start is only the local table of contents.
--->
+- Compiler front door
+- Plugin host
+- Transformer lifecycle
+- Runtime and editor path
 
 ---
 
-# 2.1. Compiler
+<!-- _class: cards -->
 
-`ttsc` is a TypeScript-Go compiler front door.
+# 3.1. Compiler Front Door
 
 ```bash
 npx ttsc
@@ -646,610 +998,254 @@ npx ttsc --noEmit
 npx ttsc --watch
 ```
 
-- Build
-
-- Check
-
-- Watch
-
-- Host transformers
-
-<!--
-Say: command shape stays familiar. Compiler host changes.
--->
+- Familiar command shape
+  - build
+  - check
+  - watch
+- New responsibility
+  - own project load
+  - host transformers
+  - route compiler facts
 
 ---
 
-# 2.1. Compiler
+<!-- _class: cards -->
 
-TTSC keeps the compiler state as the shared substrate.
+# 3.1. Not a Bypass
 
-- Program
-
-- AST
-
-- Checker
-
-- Diagnostics
-
-- Emit
-
-<!--
-Say: every later feature hangs off this state.
--->
+- Keep TypeScript-Go
+  - native compiler base
+  - semantic analysis
+  - diagnostics
+- Add missing layer
+  - transformer host
+  - plugin execution path
+  - emit integration
+- Goal
+  - survive on the new compiler
 
 ---
 
-# 2.1. Compiler
+<!-- _class: compare -->
 
-The core contract:
+# 3.2. Old Host vs TTSC Host
 
-- Load project once
-
-- Build semantic graph once
-
-- Let tools reuse it
-
-- Report through compiler diagnostics
-
-<!--
-Say: this is the opposite of spawning many tools that rediscover the same project.
--->
+| Old | TTSC |
+| --- | --- |
+| Patch TypeScript install | Explicit compiler front door |
+| JS compiler process | TypeScript-Go base |
+| JS transformer loaded directly | Plugin host bridge |
+| Build-time only | Build, runtime, editor |
 
 ---
 
-# 2.2. Transformer
+<!-- _class: flow -->
 
-TTSC hosts transformers without patching TypeScript itself.
+# 3.2. Plugin Host
 
+- Project owner
+  - load project once
+  - keep Program state
 - Plugin package
-
-- Native sidecar
-
-- Cached artifacts
-
-- TypeScript-Go bridge
-
-<!--
-Say: plugins join the TTSC host instead of mutating the compiler installation.
--->
+  - discovered
+  - built
+  - cached
+- Bridge
+  - TypeScript-Go facts
+  - transformer execution
+  - emit output
 
 ---
 
-# 2.2. Transformer
+<!-- _class: flow -->
 
-Old model vs TTSC model:
+# 3.3. Transformer Lifecycle
 
-- `ts-patch` -> hook into JavaScript compiler
-
-- `ttsc` -> host plugins on TypeScript-Go
-
-- User API stays TypeScript
-
-- Generation engine moves behind it
-
-<!--
-Say: preserve the developer surface, replace the compiler integration.
--->
-
----
-
-# 2.2. Transformer
-
-Transformer lifecycle:
-
-- Read type declaration
-
-- Ask compiler for semantic facts
-
-- Generate optimized JavaScript
-
-- Feed result back into emit
-
-<!--
-Say: the lifecycle is the same story as typia, but the host is new.
--->
+- Input
+  - source files
+  - declarations
+  - compiler options
+- Compiler facts
+  - AST
+  - Checker
+  - diagnostics
+- Output
+  - generated JavaScript
+  - rewritten emit
+  - plugin diagnostics
 
 ---
 
-# 2.3. Runtime
+<!-- _class: cards three -->
 
-`ttsx` runs TypeScript after type checking.
+# 3.3. User API Stays
+
+- typia user
+  - `typia.createIs<T>()`
+  - no runtime schema
+- nestia user
+  - `@TypedRoute`
+  - generated SDK
+- Internal shift
+  - old patch removed
+  - TTSC host added
+
+---
+
+<!-- _class: cards -->
+
+# 3.4. Runtime Path
 
 ```bash
 npx ttsx src/index.ts
 ```
 
-- Direct execution
-
-- Real type check
-
-- Plugin-aware path
-
-<!--
-Say: the runtime command should not bypass the compiler guarantees.
--->
-
----
-
-# 2.3. Runtime
-
-Runtime target:
-
 - `tsx` convenience
-
-- `ts-node` use case
-
-- TypeScript-Go speed
-
-- no transpile-only compromise
-
-<!--
-Say: backend execution can be convenient without becoming blind.
--->
+  - direct TypeScript execution
+- Type safety
+  - real check
+  - plugin-aware path
+- Avoid
+  - transpile-only blind spot
 
 ---
 
-# 2.4. Language Server
+<!-- _class: cards -->
 
-`ttscserver` brings plugin results into the editor.
-
-- Diagnostics
-
-- Code actions
-
-- Plugin commands
-
-- VS Code extension path
-
-<!--
-Say: transformer errors must appear before CI.
--->
-
----
-
-# 2.4. Language Server
-
-Editor integration is part of the toolchain.
-
-- Compiler sees the project
-
-- Plugin sees the same project
-
-- Developer sees diagnostics early
-
-- CI becomes confirmation, not discovery
-
-<!--
-Say: if plugin work only happens at build time, the feedback loop is too late.
--->
-
----
-
-# 2.4. Language Server
-
-TTSC is not one wrapper command.
-
-- `ttsc`
-
-- `ttsx`
+# 3.4. Editor Path
 
 - `ttscserver`
+  - plugin diagnostics
+  - code actions
+  - plugin commands
+- VS Code path
+  - project view
+  - early feedback
+- Goal
+  - CI confirms
+  - editor discovers
 
-- shared plugin substrate
+---
 
-<!--
-Say: compiler, runtime, and editor must move together.
--->
+<!-- _class: cards -->
+
+# 3.4. Whole Loop
+
+- Build
+  - `ttsc`
+  - transformer emit
+- Runtime
+  - `ttsx`
+  - checked execution
+- Editor
+  - `ttscserver`
+  - plugin diagnostics
+- One toolchain
+  - not one wrapper
 
 ---
 
 <!-- _class: lead -->
 
-# 3. TTSC Linter
+# 4. TTSC: Toolchain Opportunity
 
-- Why Lint Again
-
-- Compiler-Aware Rules
-
-- Zero-Cost Linting
-
-- VS Code Benchmark
-
-<!--
-Chapter start is only the local table of contents.
--->
+- One Program and Checker
+- Linter without rebuild
+- Graph instead of grep
+- Patch to toolchain
 
 ---
 
-# 3.1. Why Lint Again
+<!-- _class: cards three -->
 
-The normal TypeScript check lane repeats work.
+# 4.1. Compiler State
+
+- Already loaded
+  - Program
+  - AST
+  - Checker
+  - diagnostics
+- Expensive to rebuild
+  - parse
+  - module graph
+  - type services
+- Reusable by tools
+  - transformers
+  - linter
+  - graph
+
+---
+
+<!-- _class: flow -->
+
+# 4.1. Core Contract
+
+- Load once
+  - project
+  - options
+  - dependencies
+- Analyze once
+  - semantic graph
+  - diagnostics
+  - type relations
+- Reuse many times
+  - emit
+  - lint
+  - graph
+
+---
+
+<!-- _class: cards -->
+
+# 4.2. Linter Without Rebuild
 
 ```bash
 npx tsc --noEmit
 npx eslint .
 ```
 
-- Same source tree
-
-- Same imports
-
-- Same types
-
-<!--
-Say: the expensive part is rediscovery.
--->
-
----
-
-# 3.1. Why Lint Again
-
-Repeated costs:
-
-- Parse
-
-- Walk
-
-- Type services
-
-- Diagnostics output
-
-<!--
-Say: type-aware linting asks questions the compiler already answered.
--->
+- Legacy cost
+  - compiler pass
+  - linter pass
+  - second type world
+- TTSC lint
+  - same Program
+  - same Checker
+  - same diagnostics stream
 
 ---
 
-# 3.2. Compiler-Aware Rules
+<!-- _class: metric -->
 
-`@ttsc/lint` runs where the Program already exists.
+# 4.2. VS Code Benchmark
 
-- TypeScript diagnostics
-
-- Lint diagnostics
-
-- Same check lane
-
-- Same compiler view
-
-<!--
-Say: one project load, one semantic view.
--->
-
----
-
-# 3.2. Compiler-Aware Rules
-
-Compiler-aware rules can ask semantic questions directly.
-
-- Symbol owner
-
-- Type relationship
-
-- Import target
-
-- Declaration site
-
-<!--
-Say: this is the part ESLint recreates with parser services.
--->
-
----
-
-# 3.2. Compiler-Aware Rules
-
-Compiler-style output:
-
-- `TS2322`
-
-- `[prefer-const]`
-
-- `[no-var]`
-
-- one diagnostics stream
-
-<!--
-Say: the developer reads one compiler report, not two disconnected reports.
--->
-
----
-
-# 3.3. Zero-Cost Linting
-
-Zero-cost means marginal cost.
-
-- Program already loaded
-
-- AST already built
-
-- Checker already available
-
-- Rule walk remains
-
-<!--
-Say: not literally zero milliseconds. It means no second TypeScript world.
--->
-
----
-
-# 3.3. Zero-Cost Linting
-
-Mental model:
-
-- Legacy: compiler + linter pipeline
-
-- TTSC: compiler check + lint pass
-
-- Formatting stays a separate write path
-
-- Type-aware linting stops duplicating analysis
-
-<!--
-Say: formatting is still a different concern.
--->
-
----
-
-# 3.3. Zero-Cost Linting
-
-The compiler is already the source of truth.
-
-- One parse
-
-- One module graph
-
-- One checker
-
-- Many diagnostics
-
-<!--
-Say: this is the same design principle as transformers.
--->
-
----
-
-# 3.4. VS Code Benchmark
-
-VS Code fixture:
+Lint pass comparison:
 
 | Tool         |       Time |
 | ------------ | ---------: |
-| ESLint       | 66,700.2ms |
-| `@ttsc/lint` |       74ms |
+| ESLint       |  66,700 ms |
+| `@ttsc/lint` |      74 ms |
 
 **901.4x**
 
-<!--
-Say: lint pass comparison, not a claim that the whole project build is 901x faster.
--->
+---
+
+<!-- _class: compare -->
+
+# 4.3. Graph Instead of Grep
+
+| Grep-first agent | Compiler-first agent |
+| --- | --- |
+| search text | resolve symbol |
+| open file | follow references |
+| follow import | inspect diagnostics |
+| repeat | open selected source |
 
 ---
 
-# 3.4. VS Code Benchmark
+<!-- _class: metric -->
 
-Interpretation:
-
-- Not "Go is magic"
-
-- Reuse the Program
-
-- Avoid second analysis
-
-- About **900x** lint pass gap
-
-<!--
-Say: the benchmark proves the architecture point.
--->
-
----
-
-# 3.4. VS Code Benchmark
-
-Linter is a separate TTSC chapter because it proves reuse.
-
-- Compiler state
-
-- Transformer state
-
-- Lint state
-
-- Same substrate
-
-<!--
-Say: after transformer survival, linter is the first productivity dividend.
--->
-
----
-
-<!-- _class: lead -->
-
-# 4. TTSC Graph
-
-- Why grep Fails
-
-- Compiler-Aware Context
-
-- For Coding Agents
-
-- Token Economy
-
-<!--
-Chapter start is only the local table of contents.
--->
-
----
-
-# 4.1. Why grep Fails
-
-Agents often rebuild context manually.
-
-- grep
-
-- open file
-
-- follow import
-
-- repeat
-
-<!--
-Say: this is expensive, lossy, and easy to derail.
--->
-
----
-
-# 4.1. Why grep Fails
-
-Grep does not know compiler facts.
-
-- Alias
-
-- Symbol owner
-
-- References
-
-- Type vs value
-
-- Call path
-
-<!--
-Say: the compiler already knows these relationships.
--->
-
----
-
-# 4.1. Why grep Fails
-
-File search is a weak substitute for semantic context.
-
-- Same name, different symbol
-
-- Barrel export hides owner
-
-- Generic call hides concrete type
-
-- Dynamic import hides path
-
-<!--
-Say: agents need the graph before they need the file.
--->
-
----
-
-# 4.2. Compiler-Aware Context
-
-`@ttsc/graph` exposes compiler structure.
-
-- Declarations
-
-- Exports
-
-- Imports
-
-- References
-
-- Diagnostics
-
-<!--
-Say: graph comes from compiler resolution, not regex.
--->
-
----
-
-# 4.2. Compiler-Aware Context
-
-Example path:
-
-- `Repository.find`
-
-- `FindOptionsUtils`
-
-- `SelectQueryBuilder`
-
-- `RelationMetadata`
-
-<!--
-Say: TypeORM relation options example. The point is path discovery, not reading every file.
--->
-
----
-
-# 4.2. Compiler-Aware Context
-
-Graph answers a different first question.
-
-- grep: "which files mention this text?"
-
-- graph: "which symbols matter?"
-
-- grep: file-first
-
-- graph: compiler-first
-
-<!--
-Say: file reading still happens, but after narrowing.
--->
-
----
-
-# 4.3. For Coding Agents
-
-MCP server:
-
-```json
-{
-  "mcpServers": {
-    "ttsc-graph": {
-      "command": "npx",
-      "args": ["-y", "@ttsc/graph"]
-    }
-  }
-}
-```
-
-<!--
-Say: the agent asks the compiler graph before opening source files.
--->
-
----
-
-# 4.3. For Coding Agents
-
-Workflow:
-
-- Map first
-
-- Source second
-
-- Fewer files
-
-- Better edit target
-
-<!--
-Say: not source-free. Source-selective.
--->
-
----
-
-# 4.3. For Coding Agents
-
-Agent context becomes compiler-guided.
-
-- Resolve symbol
-
-- Follow references
-
-- Inspect diagnostics
-
-- Open only relevant source
-
-<!--
-Say: this is what a human maintainer does mentally.
--->
-
----
-
-# 4.4. Token Economy
+# 4.3. Token Economy
 
 TypeORM benchmark cell:
 
@@ -1259,85 +1255,60 @@ TypeORM benchmark cell:
 | file reads |        16 |       0 |
 | tool calls |        38 |       1 |
 
-<!--
-Say: about 10x token reduction, not 100x.
--->
+**9.2x fewer tokens**
 
 ---
 
-# 4.4. Token Economy
+<!-- _class: flow -->
 
-Interpretation:
+# 4.4. From Patch to Toolchain
 
-- About **10x** fewer tokens
+- Started as survival
+  - keep typia alive
+  - keep nestia alive
+  - keep transformers alive
+- Became infrastructure
+  - compiler front door
+  - plugin host
+  - shared compiler state
+- Opened new tools
+  - lint
+  - graph
 
-- No blind file reading
+---
 
-- Fewer tool calls
+<!-- _class: cards -->
 
-- Same target found faster
+# 4.4. TTSC Surface
 
-<!--
-Say: the number matters because agents pay for exploration.
--->
+- Compiler
+  - `ttsc`
+- Runtime
+  - `ttsx`
+- Editor
+  - `ttscserver`
+- Reuse
+  - `@ttsc/lint`
+  - `@ttsc/graph`
 
 ---
 
-# 4.4. Token Economy
-
-Same pattern across TTSC:
-
-- Compiler state
-
-- No duplicate discovery
-
-- Linter uses it
-
-- Graph uses it
-
-- Agents use it
-
-<!--
-Say: this is the unifying TTSC story.
--->
-
----
+<!-- _class: cards -->
 
 # Closing
 
-One TypeScript-Go substrate:
-
-- `ttsc`
-
-- `ttsx`
-
-- `@ttsc/lint`
-
-- `@ttsc/graph`
-
-<!--
-Say: TTSC is a toolchain, not a single wrapper command.
--->
-
----
-
-# Closing
-
-The compiler became faster.
-
-Transformer users need more than speed.
-
-- keep type-driven code generation
-
-- keep diagnostics in the editor
-
-- reuse compiler state for lint and graph
-
-- make TypeScript-Go usable for backend tooling
-
-<!--
-Say: TypeScript-Go is good news only if the tool ecosystem survives it.
--->
+- TypeScript-Go
+  - faster compiler
+  - new runtime substrate
+- Transformers
+  - old patch point gone
+  - host required
+- TTSC
+  - transformer survival
+  - compiler-state toolchain
+- Outcome
+  - user API stays TypeScript
+  - backend tooling moves forward
 
 ---
 
@@ -1348,7 +1319,3 @@ TypeScript Backend Meetup
 2026-06-26
 
 Samchon
-
-<!--
-End.
--->

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -165,64 +165,241 @@ style: |
 
 ### TypeScript-Go ToolChain
 
-Samchon
+TypeScript Backend Meetup
 
-2026-06-26
+Samchon, 2026-06-26
+
+<!--
+Opening: TypeScript-Go is the trigger. TTSC is the survival layer for transformer users.
+-->
+
+---
+
+# TTSC
+
+![TTSC logo](../og.jpg)
+
+<!--
+One beat for the logo.
+-->
+
+---
+
+# TL;DR
+
+• TypeScript compiler is moving to Go
+
+• Transformers lose the old JavaScript patch point
+
+• TTSC keeps compile-time code generation alive
+
+• Linter and Graph reuse the same compiler state
+
+<!--
+Say: this talk is not "Go is faster". It is "the compiler substrate changed".
+-->
 
 ---
 
 # Preface
 
-![](https://ttsc.dev/og.jpg)
+TypeScript 7 changes the foundation under TypeScript tools.
+
+• Native Go compiler
+
+• TypeScript 6 semantic parity
+
+• About **10x** faster on many projects
+
+• Compiler API and plugin ecosystem must adapt
+
+<!--
+Source is Microsoft's TypeScript 7 RC and native port posts.
+-->
 
 ---
 
+# Index
+
+1. TypeScript-Go
+
+2. TTSC
+
+3. TTSC Linter
+
+4. TTSC Graph
+
+<!--
+Four chapters. Problem first, TTSC after.
+-->
+
+---
+
+<!-- _class: lead -->
+
 # 1. TypeScript-Go
 
-- 1.1. Good News
-- 1.2. Bad News
-- 1.3. Transformer
-- 1.4. Compatibility Gap
+• Good News
+
+• Bad News
+
+• Transformer
+
+• Compatibility Gap
+
+<!--
+Chapter start is only the local table of contents.
+-->
 
 ---
 
 # 1.1. Good News
 
-대충 Microsoft가 TypeScript compiler를 Go로 다시 만들고 있다는 이야기.
+TypeScript compiler is moving from JavaScript to Go.
 
-대충 TypeScript 7부터 이걸 기본 엔진으로 가져오려 한다는 이야기.
+• TypeScript 7.0 RC
 
-대충 `tsc`, editor, LSP가 10배쯤 빨라진다는 좋은 뉴스라는 이야기.
+• Native compiler and language service
+
+• Shared-memory parallelism
+
+• About **10x** faster than TypeScript 6.0
+
+<!--
+Say: most users hear this as a simple speed story.
+-->
+
+---
+
+# 1.1. Good News
+
+The port is not a rewrite of the language.
+
+• Existing codebase ported to Go
+
+• Type-checking logic kept structurally identical
+
+• Same TypeScript semantics
+
+• New runtime foundation
+
+<!--
+Say: for normal users, compatibility is the headline. For tool authors, runtime foundation is the issue.
+-->
+
+---
+
+# 1.1. Good News
+
+Backend teams feel compiler latency every day.
+
+• Monorepo type check
+
+• Watch mode
+
+• Editor startup
+
+• CI feedback loop
+
+<!--
+Say: 10x is not an abstract benchmark. It changes the development loop.
+-->
 
 ---
 
 # 1.2. Bad News
 
-대충 근데 transformer 사용자 입장에서는 다 좆되었다는 이야기.
+Compiler plugins lived inside the old compiler shape.
 
-대충 기존 transformer 생태계가 JavaScript TypeScript compiler 내부 hook에 기대고 있었다는 이야기.
+• JavaScript runtime
 
-대충 compiler가 Go로 바뀌면 그 hook에 patch 붙이던 방식이 그대로 안 통한다는 이야기.
+• TypeScript compiler API
 
-대충 typia, nestia 같은 백엔드 TypeScript 도구가 이 문제를 정면으로 맞는다는 이야기.
+• AST and Checker objects
+
+• Emit pipeline hooks
+
+<!--
+Say: transformer users were not only compiling. They were extending the compiler.
+-->
+
+---
+
+# 1.2. Bad News
+
+The old ecosystem patched TypeScript itself.
+
+• `ttypescript`
+
+• `ts-patch`
+
+• `tsconfig.plugins`
+
+• custom transformers
+
+<!--
+Say: the plugin contract was informal, but it worked because everything was JavaScript.
+-->
+
+---
+
+# 1.2. Bad News
+
+APIs can survive while engines break.
+
+• `typia`
+
+• `nestia`
+
+• custom SDK generators
+
+• generated runtime validators
+
+<!--
+Say: user-facing code can remain the same, but the generation engine must move.
+-->
 
 ---
 
 # 1.3. Transformer
 
-대충 transformer가 TypeScript 타입 정보를 읽어 코드를 자동 생성하거나 바꾸는 기술이라는 이야기.
+Transformer = compile-time code generation from TypeScript types.
 
-대충 런타임 validation, serialization, SDK generation 같은 일을 컴파일 타임에 끝낸다는 이야기.
+• Read source code
 
-대충 typia와 nestia가 이 방식으로 백엔드 보일러플레이트를 없애왔다는 이야기.
+• Inspect AST
+
+• Ask the Checker
+
+• Emit JavaScript
+
+<!--
+Minimal definition. The next slides show why it matters.
+-->
 
 ---
 
 # 1.3. Transformer
 
-### typia validation generator
+Common backend uses:
 
-### Generic function call with `IMember` type
+• Runtime validation
+
+• Serialization
+
+• OpenAPI generation
+
+• SDK generation
+
+<!--
+Say: typia and nestia are concrete examples, not edge cases.
+-->
+
+---
+
+# 1.3. Transformer
+
+### Typia: TypeScript input
 
 ```typescript
 import typia, { tags } from "typia";
@@ -238,11 +415,15 @@ interface IMember {
 typia.createIs<IMember>();
 ```
 
+<!--
+Say: IMember is a type. It disappears at runtime unless a transformer catches it before erasure.
+-->
+
 ---
 
 # 1.3. Transformer
 
-### Becomes transformed JS code
+### Typia: JavaScript output
 
 ```javascript
 import * as _b from "typia/lib/internal/_isFormatEmail";
@@ -263,11 +444,33 @@ import * as _c from "typia/lib/internal/_isTypeUint32";
 })();
 ```
 
+<!--
+Say: one generic type call became UUID, email, integer, and range checks.
+-->
+
 ---
 
 # 1.3. Transformer
 
-### nestia route generator
+Type information became runtime code.
+
+• `tags.Format<"uuid">` → UUID check
+
+• `tags.Format<"email">` → email check
+
+• `tags.Type<"uint32">` → integer range
+
+• `tags.Maximum<100>` → boundary check
+
+<!--
+Say: this is not reflection. It is ahead-of-time compilation.
+-->
+
+---
+
+# 1.3. Transformer
+
+### Nestia: route generator
 
 ```typescript
 import { TypedBody, TypedRoute } from "@nestia/core";
@@ -277,26 +480,22 @@ import { Controller } from "@nestjs/common";
 export class ShoppingSaleController {
   @TypedRoute.Post()
   public async create(
-    @TypedBody() body: IShoppingSale.ICreate
-  ): Promise<IShoppingSale> { ... }
+    @TypedBody() body: IShoppingSale.ICreate,
+  ): Promise<IShoppingSale> {
+    // business logic
+  }
 }
 ```
 
----
-
-# 1.4. Compatibility Gap
-
-대충 기존 transformer는 TypeScript compiler를 patch해서 들어갔다는 이야기.
-
-대충 JavaScript compiler에서는 억지로라도 hook을 만들 수 있었다는 이야기.
-
-대충 Go compiler로 넘어가면 그 방식이 그대로 이어지지 않는다는 이야기.
+<!--
+Say: controller code becomes route metadata, validation, and SDK material.
+-->
 
 ---
 
 # 1.4. Compatibility Gap
 
-### Required "ts-patch"
+Old transformer setup installed a compiler patch.
 
 ```json
 {
@@ -309,11 +508,15 @@ export class ShoppingSaleController {
 }
 ```
 
+<!--
+Say: this was the old survival strategy.
+-->
+
 ---
 
 # 1.4. Compatibility Gap
 
-### Required tsconfig.json configuration
+Old transformer setup registered plugins in `tsconfig.json`.
 
 ```json
 {
@@ -322,172 +525,781 @@ export class ShoppingSaleController {
     "plugins": [
       { "transform": "typia/lib/transform" },
       { "transform": "@nestia/core/lib/transform" },
-      { "transform": "@nestia/sdk/lib/transform" },
+      { "transform": "@nestia/sdk/lib/transform" }
     ]
   }
 }
 ```
 
+<!--
+Say: this assumes the compiler can load JavaScript plugins into its own process.
+-->
+
 ---
 
 # 1.4. Compatibility Gap
 
-대충 typia와 nestia API는 그대로 있어도, 뒤에서 코드를 만들어주던 engine이 사라진다는 이야기.
+The new compiler substrate breaks that assumption.
 
-대충 "TypeScript가 빨라졌다"가 transformer 사용자에겐 "기존 생태계가 끊겼다"가 될 수 있다는 이야기.
+• Old compiler: JavaScript process
 
-대충 그래서 TypeScript-Go 위에서 transformer 생태계를 다시 만들어야 한다는 이야기.
+• Old transformer: JavaScript module
+
+• New compiler: Go process
+
+• Old hook: no longer the center
+
+<!--
+Say: TypeScript 7 can preserve language semantics while still breaking plugin hosting.
+-->
 
 ---
 
+# 1.4. Compatibility Gap
+
+Transformer users need a toolchain, not a patch.
+
+• Compiler front door
+
+• Plugin host
+
+• Runtime execution path
+
+• Editor integration
+
+<!--
+Say: this is the bridge from TypeScript-Go to TTSC.
+-->
+
+---
+
+<!-- _class: lead -->
+
 # 2. TTSC
 
-- 2.1. Compiler
-- 2.2. Transformer
-- 2.3. Runtime
-- 2.4. Language Server
+• Compiler
+
+• Transformer
+
+• Runtime
+
+• Language Server
+
+<!--
+Chapter start is only the local table of contents.
+-->
 
 ---
 
 # 2.1. Compiler
 
-대충 `ttsc`는 TypeScript-Go 기반 compiler CLI라는 이야기.
+`ttsc` is a TypeScript-Go compiler front door.
 
-대충 `tsc`처럼 build, check, watch를 하되 plugin host까지 같이 가진다는 이야기.
+```bash
+npx ttsc
+npx ttsc --noEmit
+npx ttsc --watch
+```
 
-대충 TypeScript-Go를 그냥 빠른 compiler가 아니라 확장 가능한 compiler platform으로 쓰겠다는 이야기.
+• Build
+
+• Check
+
+• Watch
+
+• Host plugins
+
+<!--
+Say: command shape stays familiar. Compiler host changes.
+-->
+
+---
+
+# 2.1. Compiler
+
+TTSC keeps the compiler state as the shared substrate.
+
+• Program
+
+• AST
+
+• Checker
+
+• Diagnostics
+
+• Emit
+
+<!--
+Say: every later feature hangs off this state.
+-->
+
+---
+
+# 2.1. Compiler
+
+The core contract:
+
+• Load project once
+
+• Build semantic graph once
+
+• Let tools reuse it
+
+• Report through compiler diagnostics
+
+<!--
+Say: this is the opposite of spawning many tools that rediscover the same project.
+-->
 
 ---
 
 # 2.2. Transformer
 
-대충 Go 기반 compiler AST와 Checker 위에서 동작하는 transformer plugin 생태계를 다시 만들었다는 이야기.
+TTSC hosts transformers without patching TypeScript itself.
 
-대충 `ts-patch install`이 아니라 `ttsc`가 plugin source를 빌드하고 캐시하고 실행한다는 이야기.
+• Plugin package
 
-대충 `ttsc` 명령어로 컴파일하면 기존 transformer 사용자 경험을 TypeScript-Go 위로 가져온다는 이야기.
+• Native sidecar
+
+• Cached artifacts
+
+• TypeScript-Go bridge
+
+<!--
+Say: plugins join the TTSC host instead of mutating the compiler installation.
+-->
+
+---
+
+# 2.2. Transformer
+
+Old model vs TTSC model:
+
+• `ts-patch` → hook into JavaScript compiler
+
+• `ttsc` → host plugins on TypeScript-Go
+
+• User API stays TypeScript
+
+• Generation engine moves behind it
+
+<!--
+Say: preserve the developer surface, replace the compiler integration.
+-->
+
+---
+
+# 2.2. Transformer
+
+Transformer lifecycle:
+
+• Read type declaration
+
+• Ask compiler for semantic facts
+
+• Generate optimized JavaScript
+
+• Feed result back into emit
+
+<!--
+Say: the lifecycle is the same story as typia, but the host is new.
+-->
 
 ---
 
 # 2.3. Runtime
 
-대충 `ttsx src/index.ts`로 TypeScript entrypoint를 바로 실행할 수 있다는 이야기.
+`ttsx` runs TypeScript after type checking.
 
-대충 `tsx`나 `ts-node`처럼 쓰지만 먼저 진짜 type-check를 한다는 이야기.
+```bash
+npx ttsx src/index.ts
+```
 
-대충 TypeScript-Go 속도 덕분에 개발 runtime에서 type safety를 포기하지 않아도 된다는 이야기.
+• Direct execution
+
+• Real type check
+
+• Plugin-aware path
+
+<!--
+Say: the runtime command should not bypass the compiler guarantees.
+-->
+
+---
+
+# 2.3. Runtime
+
+Runtime target:
+
+• `tsx` convenience
+
+• `ts-node` use case
+
+• TypeScript-Go speed
+
+• no transpile-only compromise
+
+<!--
+Say: backend execution can be convenient without becoming blind.
+-->
 
 ---
 
 # 2.4. Language Server
 
-대충 `ttscserver`로 editor와 compiler plugin을 연결한다는 이야기.
+`ttscserver` brings plugin results into the editor.
 
-대충 LSP 위에서 plugin diagnostics, code actions, commands를 editor까지 올린다는 이야기.
+• Diagnostics
 
-대충 compiler plugin 생태계가 CLI에서 끝나지 않고 VS Code 경험까지 이어진다는 이야기.
+• Code actions
+
+• Plugin commands
+
+• VS Code extension path
+
+<!--
+Say: transformer errors must appear before CI.
+-->
 
 ---
 
+# 2.4. Language Server
+
+Editor integration is part of the toolchain.
+
+• Compiler sees the project
+
+• Plugin sees the same project
+
+• Developer sees diagnostics early
+
+• CI becomes confirmation, not discovery
+
+<!--
+Say: if plugin work only happens at build time, the feedback loop is too late.
+-->
+
+---
+
+# 2.4. Language Server
+
+TTSC is not one wrapper command.
+
+• `ttsc`
+
+• `ttsx`
+
+• `ttscserver`
+
+• shared plugin substrate
+
+<!--
+Say: compiler, runtime, and editor must move together.
+-->
+
+---
+
+<!-- _class: lead -->
+
 # 3. TTSC Linter
 
-- 3.1. Why Lint Again
-- 3.2. Compiler-Aware Rules
-- 3.3. Zero-Cost Linting
-- 3.4. VS Code Benchmark
+• Why Lint Again
+
+• Compiler-Aware Rules
+
+• Zero-Cost Linting
+
+• VS Code Benchmark
+
+<!--
+Chapter start is only the local table of contents.
+-->
 
 ---
 
 # 3.1. Why Lint Again
 
-대충 이미 ESLint가 있는데 왜 또 linter를 만들었냐는 이야기.
+The normal TypeScript check lane repeats work.
 
-대충 TypeScript rule은 결국 AST와 type information이 필요한데, compiler가 이미 그걸 만들고 있다는 이야기.
+```bash
+npx tsc --noEmit
+npx eslint .
+npx prettier --check .
+```
 
-대충 같은 정보를 두 번 계산하는 게 낭비라는 이야기.
+• Same source tree
+
+• Same imports
+
+• Same types
+
+<!--
+Say: the expensive part is rediscovery.
+-->
+
+---
+
+# 3.1. Why Lint Again
+
+Repeated costs:
+
+• Parse
+
+• Walk
+
+• Type services
+
+• Diagnostics output
+
+<!--
+Say: type-aware linting asks questions the compiler already answered.
+-->
 
 ---
 
 # 3.2. Compiler-Aware Rules
 
-대충 linter도 transformer plugin처럼 compiler AST와 Checker 위에서 실행한다는 이야기.
+`@ttsc/lint` runs where the Program already exists.
 
-대충 `ttsc` 명령어 한 방에 compile error와 lint violation을 같이 잡는다는 이야기.
+• TypeScript diagnostics
 
-대충 third-party rule도 compiler-aware하게 만들 수 있다는 이야기.
+• Lint diagnostics
+
+• Same check lane
+
+• Same compiler view
+
+<!--
+Say: one project load, one semantic view.
+-->
+
+---
+
+# 3.2. Compiler-Aware Rules
+
+Compiler-aware rules can ask semantic questions directly.
+
+• Symbol owner
+
+• Type relationship
+
+• Import target
+
+• Declaration site
+
+<!--
+Say: this is the part ESLint recreates with parser services.
+-->
+
+---
+
+# 3.2. Compiler-Aware Rules
+
+Compiler-style output:
+
+• `TS2322`
+
+• `[prefer-const]`
+
+• `[no-var]`
+
+• one diagnostics stream
+
+<!--
+Say: the developer reads one compiler report, not two disconnected reports.
+-->
 
 ---
 
 # 3.3. Zero-Cost Linting
 
-대충 이미 compile하면서 만든 AST와 type information을 재사용하니 lint 비용이 0에 수렴한다는 이야기.
+Zero-cost means marginal cost.
 
-대충 compile과 lint가 따로 도는 게 아니라 같은 pass 위에 올라간다는 이야기.
+• Program already loaded
 
-대충 그래서 큰 프로젝트일수록 차이가 커진다는 이야기.
+• AST already built
+
+• Checker already available
+
+• Rule walk remains
+
+<!--
+Say: not literally zero milliseconds. It means no second TypeScript world.
+-->
+
+---
+
+# 3.3. Zero-Cost Linting
+
+Mental model:
+
+• Legacy: compiler + linter pipeline
+
+• TTSC: compiler check + lint pass
+
+• Formatting stays a separate write path
+
+• Type-aware linting stops duplicating analysis
+
+<!--
+Say: formatting is still a different concern.
+-->
+
+---
+
+# 3.3. Zero-Cost Linting
+
+The compiler is already the source of truth.
+
+• One parse
+
+• One module graph
+
+• One checker
+
+• Many diagnostics
+
+<!--
+Say: this is the same design principle as transformers.
+-->
 
 ---
 
 # 3.4. VS Code Benchmark
 
-대충 VS Code급 프로젝트에서 ESLint 대비 800~900배 성능차를 보인다는 이야기.
+VS Code fixture:
 
-대충 Microsoft가 TypeScript-Go 성능 기준으로 썼던 VS Code fixture를 같이 기준으로 삼는다는 이야기.
+| Tool         |       Time |
+| ------------ | ---------: |
+| ESLint       | 66,700.2ms |
+| `@ttsc/lint` |       74ms |
 
-대충 benchmark 숫자를 통해 "빠르다"가 아니라 "다시 돌릴 필요가 없다"를 보여준다는 이야기.
+**901.4x**
+
+<!--
+Say: lint pass comparison, not a claim that the whole project build is 901x faster.
+-->
 
 ---
 
+# 3.4. VS Code Benchmark
+
+Interpretation:
+
+• Not "Go is magic"
+
+• Reuse the Program
+
+• Avoid second analysis
+
+• About **900x** lint pass gap
+
+<!--
+Say: the benchmark proves the architecture point.
+-->
+
+---
+
+# 3.4. VS Code Benchmark
+
+Linter is a separate TTSC chapter because it proves reuse.
+
+• Compiler state
+
+• Transformer state
+
+• Lint state
+
+• same substrate
+
+<!--
+Say: after transformer survival, linter is the first productivity dividend.
+-->
+
+---
+
+<!-- _class: lead -->
+
 # 4. TTSC Graph
 
-- 4.1. Why grep Fails
-- 4.2. Compiler-Aware Context
-- 4.3. For Coding Agents
-- 4.4. Token Economy
+• Why grep Fails
+
+• Compiler-Aware Context
+
+• For Coding Agents
+
+• Token Economy
+
+<!--
+Chapter start is only the local table of contents.
+-->
 
 ---
 
 # 4.1. Why grep Fails
 
-대충 grep은 문자열을 찾지만 코드 의미를 모른다는 이야기.
+Agents often rebuild context manually.
 
-대충 export 이름, import alias, symbol reference, call path는 문자열 검색만으로 틀리기 쉽다는 이야기.
+• grep
 
-대충 agent가 grep만 믿으면 필요 없는 파일을 많이 읽고도 핵심을 놓친다는 이야기.
+• open file
+
+• follow import
+
+• repeat
+
+<!--
+Say: this is expensive, lossy, and easy to derail.
+-->
+
+---
+
+# 4.1. Why grep Fails
+
+Grep does not know compiler facts.
+
+• Alias
+
+• Symbol owner
+
+• References
+
+• Type vs value
+
+• call path
+
+<!--
+Say: the compiler already knows these relationships.
+-->
+
+---
+
+# 4.1. Why grep Fails
+
+File search is a weak substitute for semantic context.
+
+• Same name, different symbol
+
+• Barrel export hides owner
+
+• Generic call hides concrete type
+
+• dynamic import hides path
+
+<!--
+Say: agents need the graph before they need the file.
+-->
 
 ---
 
 # 4.2. Compiler-Aware Context
 
-대충 exports, imports, symbol, references, call path 같은 정보를 AST 기반 graph로 제공한다는 이야기.
+`@ttsc/graph` exposes compiler structure.
 
-대충 grep은 문자열을 찾지만, graph는 코드 구조와 의미를 따라간다는 이야기.
+• Declarations
 
-대충 "이 함수 어디서 쓰임?" 같은 질문을 compiler가 아는 정보로 답하게 한다는 이야기.
+• Exports
+
+• Imports
+
+• References
+
+• Diagnostics
+
+<!--
+Say: graph comes from compiler resolution, not regex.
+-->
+
+---
+
+# 4.2. Compiler-Aware Context
+
+Example path:
+
+• `Repository.find`
+
+• `FindOptionsUtils`
+
+• `SelectQueryBuilder`
+
+• `RelationMetadata`
+
+<!--
+Say: TypeORM relation options example. The point is path discovery, not reading every file.
+-->
+
+---
+
+# 4.2. Compiler-Aware Context
+
+Graph answers a different first question.
+
+• grep: "which files mention this text?"
+
+• graph: "which symbols matter?"
+
+• grep: file-first
+
+• graph: compiler-first
+
+<!--
+Say: file reading still happens, but after narrowing.
+-->
 
 ---
 
 # 4.3. For Coding Agents
 
-대충 클로드 코드나 코덱스에게 "일단 파일 다 읽어"가 아니라 "이 symbol 주변만 봐"를 시킨다는 이야기.
+MCP server:
 
-대충 과도한 파일 리드와 잘못된 grep 탐색을 줄인다는 이야기.
+```json
+{
+  "mcpServers": {
+    "ttsc-graph": {
+      "command": "npx",
+      "args": ["-y", "@ttsc/graph"]
+    }
+  }
+}
+```
 
-대충 agent가 compiler graph를 먼저 보고 필요한 파일만 읽게 만든다는 이야기.
+<!--
+Say: the agent asks the compiler graph before opening source files.
+-->
+
+---
+
+# 4.3. For Coding Agents
+
+Workflow:
+
+• Map first
+
+• Source second
+
+• Fewer files
+
+• Better edit target
+
+<!--
+Say: not source-free. Source-selective.
+-->
+
+---
+
+# 4.3. For Coding Agents
+
+Agent context becomes compiler-guided.
+
+• Resolve symbol
+
+• Follow references
+
+• Inspect diagnostics
+
+• Open only relevant source
+
+<!--
+Say: this is what a human maintainer does mentally.
+-->
 
 ---
 
 # 4.4. Token Economy
 
-대충 과도한 파일 리드를 줄이면 토큰 소모량이 100배쯤 줄어드는 방향의 이야기.
+TypeORM benchmark cell:
 
-대충 더 적은 context로 더 정확한 수정 지점을 찾게 한다는 이야기.
+| Metric     |  Baseline |   Graph |
+| ---------- | --------: | ------: |
+| tokens     | 1,357,346 | 148,231 |
+| file reads |        16 |       0 |
+| tool calls |        38 |       1 |
 
-대충 TTSC가 compiler platform에서 AI coding substrate까지 확장된다는 이야기.
+<!--
+Say: about 10x token reduction, not 100x.
+-->
 
 ---
 
-# Q & A
+# 4.4. Token Economy
+
+Interpretation:
+
+• About **10x** fewer tokens
+
+• No blind file reading
+
+• Fewer tool calls
+
+• Same target found faster
+
+<!--
+Say: the number matters because agents pay for exploration.
+-->
+
+---
+
+# 4.4. Token Economy
+
+Same pattern across TTSC:
+
+• Compiler state
+
+• No duplicate discovery
+
+• Linter uses it
+
+• Graph uses it
+
+• Agents use it
+
+<!--
+Say: this is the unifying TTSC story.
+-->
+
+---
+
+# Closing
+
+One TypeScript-Go substrate:
+
+• `ttsc`
+
+• `ttsx`
+
+• `@ttsc/lint`
+
+• `@ttsc/graph`
+
+<!--
+Say: TTSC is a toolchain, not a single wrapper command.
+-->
+
+---
+
+# Closing
+
+The compiler became faster.
+
+Transformer users need more than speed.
+
+• keep type-driven code generation
+
+• keep diagnostics in the editor
+
+• reuse compiler state for lint and graph
+
+• make TypeScript-Go usable for backend tooling
+
+<!--
+Say: TypeScript-Go is good news only if the tool ecosystem survives it.
+-->
+
+---
+
+# Q&A
+
+TypeScript Backend Meetup
 
 2026-06-26
 

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -179,7 +179,14 @@ Samchon
 
 # 1. TypeScript-Go
 
-대충 TypeScript-Go 발표 뉴스 보여주는 이야기.
+- 1.1. Good News
+- 1.2. Bad News
+- 1.3. Transformer
+- 1.4. Compatibility Gap
+
+---
+
+# 1.1. Good News
 
 대충 Microsoft가 TypeScript compiler를 Go로 다시 만들고 있다는 이야기.
 
@@ -189,7 +196,7 @@ Samchon
 
 ---
 
-# 1.1. Bad News
+# 1.2. Bad News
 
 대충 근데 transformer 사용자 입장에서는 다 좆되었다는 이야기.
 
@@ -201,7 +208,7 @@ Samchon
 
 ---
 
-# 1.2. Transformer
+# 1.3. Transformer
 
 대충 transformer가 TypeScript 타입 정보를 읽어 코드를 자동 생성하거나 바꾸는 기술이라는 이야기.
 
@@ -211,7 +218,7 @@ Samchon
 
 ---
 
-# 1.2. Transformer
+# 1.3. Transformer
 
 ### typia validation generator
 
@@ -233,7 +240,7 @@ typia.createIs<IMember>();
 
 ---
 
-# 1.2. Transformer
+# 1.3. Transformer
 
 ### Becomes transformed JS code
 
@@ -258,7 +265,7 @@ import * as _c from "typia/lib/internal/_isTypeUint32";
 
 ---
 
-# 1.2. Transformer
+# 1.3. Transformer
 
 ### nestia route generator
 
@@ -277,7 +284,17 @@ export class ShoppingSaleController {
 
 ---
 
-# 1.2. Transformer
+# 1.4. Compatibility Gap
+
+대충 기존 transformer는 TypeScript compiler를 patch해서 들어갔다는 이야기.
+
+대충 JavaScript compiler에서는 억지로라도 hook을 만들 수 있었다는 이야기.
+
+대충 Go compiler로 넘어가면 그 방식이 그대로 이어지지 않는다는 이야기.
+
+---
+
+# 1.4. Compatibility Gap
 
 ### Required "ts-patch"
 
@@ -294,7 +311,7 @@ export class ShoppingSaleController {
 
 ---
 
-# 1.2. Transformer
+# 1.4. Compatibility Gap
 
 ### Required tsconfig.json configuration
 
@@ -313,37 +330,36 @@ export class ShoppingSaleController {
 
 ---
 
-# 1.3. The Compatibility Gap
-
-대충 기존 transformer 생태계는 JavaScript TypeScript compiler를 patch해서 살아왔다는 이야기.
-
-대충 `ts-patch`가 compiler 내부 hook을 열어주고, `tsconfig.json`이 transformer를 꽂아주던 구조라는 이야기.
-
-대충 TypeScript-Go는 compiler 내부가 Go라서 이 방식이 그대로 통하지 않는다는 이야기.
-
----
-
-# 1.3. The Compatibility Gap
-
-대충 TypeScript 7로 가면 사용자 코드가 문제가 아니라 빌드 파이프라인이 막힌다는 이야기.
+# 1.4. Compatibility Gap
 
 대충 typia와 nestia API는 그대로 있어도, 뒤에서 코드를 만들어주던 engine이 사라진다는 이야기.
 
 대충 "TypeScript가 빨라졌다"가 transformer 사용자에겐 "기존 생태계가 끊겼다"가 될 수 있다는 이야기.
 
+대충 그래서 TypeScript-Go 위에서 transformer 생태계를 다시 만들어야 한다는 이야기.
+
 ---
 
 # 2. TTSC
 
-대충 그래서 TypeScript-Go 위에서 transformer 생태계를 다시 만들었다는 이야기.
-
-대충 목표는 새 compiler로 갈아타도 typia와 nestia의 사용 경험이 유지되는 것이라는 이야기.
-
-대충 `ttsc`, `ttsx`, `ttscserver`로 compiler, runtime, editor 쪽을 같이 잡는다는 이야기.
+- 2.1. Compiler
+- 2.2. Transformer
+- 2.3. Runtime
+- 2.4. Language Server
 
 ---
 
-# 2.1. Transformer
+# 2.1. Compiler
+
+대충 `ttsc`는 TypeScript-Go 기반 compiler CLI라는 이야기.
+
+대충 `tsc`처럼 build, check, watch를 하되 plugin host까지 같이 가진다는 이야기.
+
+대충 TypeScript-Go를 그냥 빠른 compiler가 아니라 확장 가능한 compiler platform으로 쓰겠다는 이야기.
+
+---
+
+# 2.2. Transformer
 
 대충 Go 기반 compiler AST와 Checker 위에서 동작하는 transformer plugin 생태계를 다시 만들었다는 이야기.
 
@@ -353,7 +369,7 @@ export class ShoppingSaleController {
 
 ---
 
-# 2.2. Runtime
+# 2.3. Runtime
 
 대충 `ttsx src/index.ts`로 TypeScript entrypoint를 바로 실행할 수 있다는 이야기.
 
@@ -363,29 +379,85 @@ export class ShoppingSaleController {
 
 ---
 
-# 2.3. Linter
+# 2.4. Language Server
+
+대충 `ttscserver`로 editor와 compiler plugin을 연결한다는 이야기.
+
+대충 LSP 위에서 plugin diagnostics, code actions, commands를 editor까지 올린다는 이야기.
+
+대충 compiler plugin 생태계가 CLI에서 끝나지 않고 VS Code 경험까지 이어진다는 이야기.
+
+---
+
+# 3. TTSC Linter
+
+- 3.1. Why Lint Again
+- 3.2. Compiler-Aware Rules
+- 3.3. Zero-Cost Linting
+- 3.4. VS Code Benchmark
+
+---
+
+# 3.1. Why Lint Again
+
+대충 이미 ESLint가 있는데 왜 또 linter를 만들었냐는 이야기.
+
+대충 TypeScript rule은 결국 AST와 type information이 필요한데, compiler가 이미 그걸 만들고 있다는 이야기.
+
+대충 같은 정보를 두 번 계산하는 게 낭비라는 이야기.
+
+---
+
+# 3.2. Compiler-Aware Rules
 
 대충 linter도 transformer plugin처럼 compiler AST와 Checker 위에서 실행한다는 이야기.
 
 대충 `ttsc` 명령어 한 방에 compile error와 lint violation을 같이 잡는다는 이야기.
 
+대충 third-party rule도 compiler-aware하게 만들 수 있다는 이야기.
+
+---
+
+# 3.3. Zero-Cost Linting
+
 대충 이미 compile하면서 만든 AST와 type information을 재사용하니 lint 비용이 0에 수렴한다는 이야기.
+
+대충 compile과 lint가 따로 도는 게 아니라 같은 pass 위에 올라간다는 이야기.
+
+대충 그래서 큰 프로젝트일수록 차이가 커진다는 이야기.
+
+---
+
+# 3.4. VS Code Benchmark
 
 대충 VS Code급 프로젝트에서 ESLint 대비 800~900배 성능차를 보인다는 이야기.
 
----
+대충 Microsoft가 TypeScript-Go 성능 기준으로 썼던 VS Code fixture를 같이 기준으로 삼는다는 이야기.
 
-# 3. TTSC Graph
-
-대충 여기부터는 compiler 정보를 사람뿐 아니라 AI coding agent에게도 주겠다는 이야기.
-
-대충 Claude Code나 Codex가 파일을 마구 읽는 대신 compiler graph를 질의하게 만든다는 이야기.
-
-대충 transformer, linter 다음 단계로 codebase understanding을 compiler 기반으로 가져간다는 이야기.
+대충 benchmark 숫자를 통해 "빠르다"가 아니라 "다시 돌릴 필요가 없다"를 보여준다는 이야기.
 
 ---
 
-# 3.1. Compiler-Aware Context
+# 4. TTSC Graph
+
+- 4.1. Why grep Fails
+- 4.2. Compiler-Aware Context
+- 4.3. For Coding Agents
+- 4.4. Token Economy
+
+---
+
+# 4.1. Why grep Fails
+
+대충 grep은 문자열을 찾지만 코드 의미를 모른다는 이야기.
+
+대충 export 이름, import alias, symbol reference, call path는 문자열 검색만으로 틀리기 쉽다는 이야기.
+
+대충 agent가 grep만 믿으면 필요 없는 파일을 많이 읽고도 핵심을 놓친다는 이야기.
+
+---
+
+# 4.2. Compiler-Aware Context
 
 대충 exports, imports, symbol, references, call path 같은 정보를 AST 기반 graph로 제공한다는 이야기.
 
@@ -395,23 +467,23 @@ export class ShoppingSaleController {
 
 ---
 
-# 3.2. For Coding Agents
+# 4.3. For Coding Agents
 
 대충 클로드 코드나 코덱스에게 "일단 파일 다 읽어"가 아니라 "이 symbol 주변만 봐"를 시킨다는 이야기.
 
 대충 과도한 파일 리드와 잘못된 grep 탐색을 줄인다는 이야기.
 
-대충 토큰 소모량이 100배쯤 줄어드는 방향의 이야기.
+대충 agent가 compiler graph를 먼저 보고 필요한 파일만 읽게 만든다는 이야기.
 
 ---
 
-# 3.3. Compiler Platform
+# 4.4. Token Economy
 
-대충 TTSC는 `tsc` wrapper가 아니라 TypeScript-Go 기반 compiler platform이 되려 한다는 이야기.
+대충 과도한 파일 리드를 줄이면 토큰 소모량이 100배쯤 줄어드는 방향의 이야기.
 
-대충 transformer, runtime, linter, graph가 전부 같은 compiler substrate 위에 있다는 이야기.
+대충 더 적은 context로 더 정확한 수정 지점을 찾게 한다는 이야기.
 
-대충 백엔드 TypeScript 개발 도구가 다음 세대로 넘어가는 길을 보여준다는 이야기.
+대충 TTSC가 compiler platform에서 AI coding substrate까지 확장된다는 이야기.
 
 ---
 


### PR DESCRIPTION
## Intent
Replace the meetup presentation source with the finalized TTSC narrative deck.

## Scope
- Promote the reviewed alternate deck into website/public/presentations/20260626-ts-backend-meetup.md
- Use TypeScript-blue presentation styling
- Keep the typia/nestia to TypeScript-Go to TTSC narrative in one canonical file

## Test plan
- git diff --check -- website/public/presentations/20260626-ts-backend-meetup.md
- list-gap scan for adjacent Markdown list blank lines
- Marp PNG render of 45 slides

## Deferred
- Full website build not run.