### PR TITLE
feat(website): TSBM (TypeScript Backend Meetup) presentation

### DIFF
--- a/website/public/benchmark/meetup-graph-token-usage.svg
+++ b/website/public/benchmark/meetup-graph-token-usage.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="850" height="450" viewBox="0 0 850 450" role="img" aria-label="@ttsc/graph TypeORM agent token usage">
+  <title>@ttsc/graph TypeORM agent token usage</title>
+  <rect x="1" y="1" width="848" height="448" rx="8" fill="#fff" stroke="#cbd5e1" />
+  <text x="34" y="50" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="30" font-weight="900">TypeORM agent token usage</text>
+  <line x1="34" y1="92" x2="816" y2="92" stroke="#e2e8f0" />
+  <text x="42" y="126" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="24" font-weight="900">Anthropic Opus</text>
+  <text x="800" y="126" text-anchor="end" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="26" font-weight="900">9.9x fewer</text>
+  <text x="58" y="171" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="800">Baseline</text>
+  <rect x="164" y="151" width="560" height="24" rx="12" fill="#e2e8f0" />
+  <rect x="164" y="151" width="560" height="24" rx="12" fill="#ef4444" />
+  <text x="800" y="172" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">1,471,202</text>
+  <text x="58" y="214" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="800">Graph</text>
+  <rect x="164" y="194" width="560" height="24" rx="12" fill="#e2e8f0" />
+  <rect x="164" y="194" width="56" height="24" rx="12" fill="#2563eb" />
+  <text x="800" y="215" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">148,231</text>
+  <line x1="34" y1="250" x2="816" y2="250" stroke="#e2e8f0" />
+  <text x="42" y="284" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="24" font-weight="900">OpenAI GPT</text>
+  <text x="800" y="284" text-anchor="end" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="26" font-weight="900">4.0x fewer</text>
+  <text x="58" y="329" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="800">Baseline</text>
+  <rect x="164" y="309" width="560" height="24" rx="12" fill="#e2e8f0" />
+  <rect x="164" y="309" width="560" height="24" rx="12" fill="#ef4444" />
+  <text x="800" y="330" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">586,338</text>
+  <text x="58" y="372" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="800">Graph</text>
+  <rect x="164" y="352" width="560" height="24" rx="12" fill="#e2e8f0" />
+  <rect x="164" y="352" width="139" height="24" rx="12" fill="#2563eb" />
+  <text x="800" y="373" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">145,493</text>
+</svg>

--- a/website/public/benchmark/meetup-graph-token-usage.svg
+++ b/website/public/benchmark/meetup-graph-token-usage.svg
@@ -1,27 +1,36 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="850" height="450" viewBox="0 0 850 450" role="img" aria-label="@ttsc/graph TypeORM agent token usage">
   <title>@ttsc/graph TypeORM agent token usage</title>
   <rect x="1" y="1" width="848" height="448" rx="8" fill="#fff" stroke="#cbd5e1" />
-  <text x="34" y="50" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="30" font-weight="900">TypeORM agent token usage</text>
-  <line x1="34" y1="92" x2="816" y2="92" stroke="#e2e8f0" />
-  <text x="42" y="126" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="24" font-weight="900">Anthropic Opus</text>
-  <text x="800" y="126" text-anchor="end" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="26" font-weight="900">9.9x fewer</text>
-  <text x="58" y="171" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="800">Baseline</text>
-  <rect x="164" y="151" width="560" height="24" rx="12" fill="#e2e8f0" />
-  <rect x="164" y="151" width="560" height="24" rx="12" fill="#ef4444" />
-  <text x="800" y="172" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">1,471,202</text>
-  <text x="58" y="214" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="800">Graph</text>
-  <rect x="164" y="194" width="560" height="24" rx="12" fill="#e2e8f0" />
-  <rect x="164" y="194" width="56" height="24" rx="12" fill="#2563eb" />
-  <text x="800" y="215" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">148,231</text>
-  <line x1="34" y1="250" x2="816" y2="250" stroke="#e2e8f0" />
-  <text x="42" y="284" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="24" font-weight="900">OpenAI GPT</text>
-  <text x="800" y="284" text-anchor="end" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="26" font-weight="900">4.0x fewer</text>
-  <text x="58" y="329" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="800">Baseline</text>
-  <rect x="164" y="309" width="560" height="24" rx="12" fill="#e2e8f0" />
-  <rect x="164" y="309" width="560" height="24" rx="12" fill="#ef4444" />
-  <text x="800" y="330" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">586,338</text>
-  <text x="58" y="372" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="800">Graph</text>
-  <rect x="164" y="352" width="560" height="24" rx="12" fill="#e2e8f0" />
-  <rect x="164" y="352" width="139" height="24" rx="12" fill="#2563eb" />
-  <text x="800" y="373" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">145,493</text>
+  <text x="36" y="50" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="30" font-weight="900">TypeORM agent token usage</text>
+  <text x="36" y="80" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="16">Common token axis. Graph stays near 145k, baseline changes by model.</text>
+  <line x1="232" y1="111" x2="704" y2="111" stroke="#cbd5e1" />
+  <line x1="232" y1="106" x2="232" y2="116" stroke="#cbd5e1" />
+  <line x1="392" y1="106" x2="392" y2="116" stroke="#cbd5e1" />
+  <line x1="552" y1="106" x2="552" y2="116" stroke="#cbd5e1" />
+  <line x1="704" y1="106" x2="704" y2="116" stroke="#cbd5e1" />
+  <text x="232" y="101" text-anchor="middle" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="12">0</text>
+  <text x="392" y="101" text-anchor="middle" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="12">500k</text>
+  <text x="552" y="101" text-anchor="middle" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="12">1.0M</text>
+  <text x="704" y="101" text-anchor="middle" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="12">1.47M</text>
+  <text x="44" y="145" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">Anthropic Opus</text>
+  <text x="800" y="145" text-anchor="end" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="24" font-weight="900">9.9x fewer</text>
+  <text x="62" y="185" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="800">Baseline</text>
+  <rect x="232" y="166" width="472" height="24" rx="12" fill="#e2e8f0" />
+  <rect x="232" y="166" width="472" height="24" rx="12" fill="#ef4444" />
+  <text x="800" y="187" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">1,471,202</text>
+  <text x="62" y="228" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="800">Graph</text>
+  <rect x="232" y="209" width="472" height="24" rx="12" fill="#e2e8f0" />
+  <rect x="232" y="209" width="48" height="24" rx="12" fill="#2563eb" />
+  <text x="800" y="230" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">148,231</text>
+  <line x1="36" y1="262" x2="814" y2="262" stroke="#e2e8f0" />
+  <text x="44" y="299" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">OpenAI GPT</text>
+  <text x="800" y="299" text-anchor="end" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="24" font-weight="900">4.0x fewer</text>
+  <text x="62" y="339" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="800">Baseline</text>
+  <rect x="232" y="320" width="472" height="24" rx="12" fill="#e2e8f0" />
+  <rect x="232" y="320" width="188" height="24" rx="12" fill="#ef4444" />
+  <text x="800" y="341" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">586,338</text>
+  <text x="62" y="382" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="800">Graph</text>
+  <rect x="232" y="363" width="472" height="24" rx="12" fill="#e2e8f0" />
+  <rect x="232" y="363" width="47" height="24" rx="12" fill="#2563eb" />
+  <text x="800" y="384" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">145,493</text>
 </svg>

--- a/website/public/benchmark/meetup-lint-speedup.svg
+++ b/website/public/benchmark/meetup-lint-speedup.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="850" height="470" viewBox="0 0 850 470" role="img" aria-label="@ttsc/lint isolated lint speedup by project">
+  <title>@ttsc/lint isolated lint speedup by project</title>
+  <defs>
+    <linearGradient id="lint-bar" x1="0" x2="1">
+      <stop offset="0%" stop-color="#16a34a" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+  </defs>
+  <rect x="1" y="1" width="848" height="468" rx="8" fill="#fff" stroke="#cbd5e1" />
+  <text x="34" y="50" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="30" font-weight="900">Isolated lint speedup</text>
+  <text x="34" y="82" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="16">Legacy TypeScript + ESLint baseline versus @ttsc/lint.</text>
+  <text x="42" y="129" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">vscode</text>
+  <rect x="168" y="108" width="560" height="26" rx="13" fill="#e2e8f0" />
+  <rect x="168" y="108" width="273" height="26" rx="13" fill="url(#lint-bar)" />
+  <text x="800" y="130" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">901x</text>
+  <text x="42" y="181" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">nestjs</text>
+  <rect x="168" y="160" width="560" height="26" rx="13" fill="#e2e8f0" />
+  <rect x="168" y="160" width="560" height="26" rx="13" fill="url(#lint-bar)" />
+  <text x="800" y="182" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">1848x</text>
+  <text x="42" y="233" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">vue</text>
+  <rect x="168" y="212" width="560" height="26" rx="13" fill="#e2e8f0" />
+  <rect x="168" y="212" width="229" height="26" rx="13" fill="url(#lint-bar)" />
+  <text x="800" y="234" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">757x</text>
+  <text x="42" y="285" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">zod</text>
+  <rect x="168" y="264" width="560" height="26" rx="13" fill="#e2e8f0" />
+  <rect x="168" y="264" width="348" height="26" rx="13" fill="url(#lint-bar)" />
+  <text x="800" y="286" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">1150x</text>
+  <text x="42" y="337" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">rxjs</text>
+  <rect x="168" y="316" width="560" height="26" rx="13" fill="#e2e8f0" />
+  <rect x="168" y="316" width="198" height="26" rx="13" fill="url(#lint-bar)" />
+  <text x="800" y="338" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">653x</text>
+  <text x="42" y="389" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">shopping</text>
+  <rect x="168" y="368" width="560" height="26" rx="13" fill="#e2e8f0" />
+  <rect x="168" y="368" width="177" height="26" rx="13" fill="url(#lint-bar)" />
+  <text x="800" y="390" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">583x</text>
+</svg>

--- a/website/public/benchmark/meetup-lint-speedup.svg
+++ b/website/public/benchmark/meetup-lint-speedup.svg
@@ -7,30 +7,30 @@
     </linearGradient>
   </defs>
   <rect x="1" y="1" width="848" height="468" rx="8" fill="#fff" stroke="#cbd5e1" />
-  <text x="34" y="50" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="30" font-weight="900">Isolated lint speedup</text>
-  <text x="34" y="82" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="16">Legacy TypeScript + ESLint baseline versus @ttsc/lint.</text>
-  <text x="42" y="129" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">vscode</text>
-  <rect x="168" y="108" width="560" height="26" rx="13" fill="#e2e8f0" />
-  <rect x="168" y="108" width="273" height="26" rx="13" fill="url(#lint-bar)" />
-  <text x="800" y="130" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">901x</text>
-  <text x="42" y="181" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">nestjs</text>
-  <rect x="168" y="160" width="560" height="26" rx="13" fill="#e2e8f0" />
-  <rect x="168" y="160" width="560" height="26" rx="13" fill="url(#lint-bar)" />
-  <text x="800" y="182" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">1848x</text>
-  <text x="42" y="233" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">vue</text>
-  <rect x="168" y="212" width="560" height="26" rx="13" fill="#e2e8f0" />
-  <rect x="168" y="212" width="229" height="26" rx="13" fill="url(#lint-bar)" />
-  <text x="800" y="234" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">757x</text>
-  <text x="42" y="285" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">zod</text>
-  <rect x="168" y="264" width="560" height="26" rx="13" fill="#e2e8f0" />
-  <rect x="168" y="264" width="348" height="26" rx="13" fill="url(#lint-bar)" />
-  <text x="800" y="286" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">1150x</text>
-  <text x="42" y="337" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">rxjs</text>
-  <rect x="168" y="316" width="560" height="26" rx="13" fill="#e2e8f0" />
-  <rect x="168" y="316" width="198" height="26" rx="13" fill="url(#lint-bar)" />
-  <text x="800" y="338" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">653x</text>
-  <text x="42" y="389" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">shopping</text>
-  <rect x="168" y="368" width="560" height="26" rx="13" fill="#e2e8f0" />
-  <rect x="168" y="368" width="177" height="26" rx="13" fill="url(#lint-bar)" />
-  <text x="800" y="390" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">583x</text>
+  <text x="36" y="50" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="30" font-weight="900">Isolated lint speedup</text>
+  <text x="36" y="82" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="16">Legacy TypeScript + ESLint baseline versus @ttsc/lint.</text>
+  <text x="46" y="129" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">vscode</text>
+  <rect x="180" y="108" width="500" height="26" rx="13" fill="#e2e8f0" />
+  <rect x="180" y="108" width="244" height="26" rx="13" fill="url(#lint-bar)" />
+  <text x="795" y="130" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">901x</text>
+  <text x="46" y="181" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">nestjs</text>
+  <rect x="180" y="160" width="500" height="26" rx="13" fill="#e2e8f0" />
+  <rect x="180" y="160" width="500" height="26" rx="13" fill="url(#lint-bar)" />
+  <text x="795" y="182" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">1848x</text>
+  <text x="46" y="233" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">vue</text>
+  <rect x="180" y="212" width="500" height="26" rx="13" fill="#e2e8f0" />
+  <rect x="180" y="212" width="205" height="26" rx="13" fill="url(#lint-bar)" />
+  <text x="795" y="234" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">757x</text>
+  <text x="46" y="285" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">zod</text>
+  <rect x="180" y="264" width="500" height="26" rx="13" fill="#e2e8f0" />
+  <rect x="180" y="264" width="311" height="26" rx="13" fill="url(#lint-bar)" />
+  <text x="795" y="286" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">1150x</text>
+  <text x="46" y="337" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">rxjs</text>
+  <rect x="180" y="316" width="500" height="26" rx="13" fill="#e2e8f0" />
+  <rect x="180" y="316" width="177" height="26" rx="13" fill="url(#lint-bar)" />
+  <text x="795" y="338" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">653x</text>
+  <text x="46" y="389" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">shopping</text>
+  <rect x="180" y="368" width="500" height="26" rx="13" fill="#e2e8f0" />
+  <rect x="180" y="368" width="158" height="26" rx="13" fill="url(#lint-bar)" />
+  <text x="795" y="390" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="27" font-weight="900">583x</text>
 </svg>

--- a/website/public/benchmark/meetup-nestia-speedup.svg
+++ b/website/public/benchmark/meetup-nestia-speedup.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="360" viewBox="0 0 620 360" role="img" aria-label="Nestia benchmark speedup chart">
+  <title>Nestia benchmark speedup chart</title>
+  <defs>
+    <linearGradient id="nestia-bar" x1="0" x2="1">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#0f766e" />
+    </linearGradient>
+  </defs>
+  <rect x="1" y="1" width="618" height="358" rx="8" fill="#fff" stroke="#cbd5e1" />
+  <text x="24" y="38" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="24" font-weight="900">Nestia speedup</text>
+  <text x="24" y="72" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">Server path</text>
+  <text x="38" y="103" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">NestJS base</text>
+  <rect x="198" y="88" width="340" height="17" rx="8.5" fill="#e2e8f0" />
+  <rect x="198" y="88" width="28" height="17" rx="8.5" fill="#94a3b8" />
+  <text x="560" y="103" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">1x</text>
+  <text x="38" y="133" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">nestia</text>
+  <rect x="198" y="118" width="340" height="17" rx="8.5" fill="#e2e8f0" />
+  <rect x="198" y="118" width="122" height="17" rx="8.5" fill="url(#nestia-bar)" />
+  <text x="560" y="133" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">10x+</text>
+  <text x="24" y="171" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">Validation</text>
+  <text x="38" y="202" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">class-validator</text>
+  <rect x="198" y="187" width="340" height="17" rx="8.5" fill="#e2e8f0" />
+  <rect x="198" y="187" width="28" height="17" rx="8.5" fill="#94a3b8" />
+  <text x="560" y="202" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">1x</text>
+  <text x="38" y="232" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">typia core</text>
+  <rect x="198" y="217" width="340" height="17" rx="8.5" fill="#e2e8f0" />
+  <rect x="198" y="217" width="340" height="17" rx="8.5" fill="url(#nestia-bar)" />
+  <text x="560" y="232" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">20,000x</text>
+  <text x="24" y="270" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">Serialization</text>
+  <text x="38" y="301" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">class-transformer</text>
+  <rect x="198" y="286" width="340" height="17" rx="8.5" fill="#e2e8f0" />
+  <rect x="198" y="286" width="28" height="17" rx="8.5" fill="#94a3b8" />
+  <text x="560" y="301" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">1x</text>
+  <text x="38" y="331" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">typia core</text>
+  <rect x="198" y="316" width="340" height="17" rx="8.5" fill="#e2e8f0" />
+  <rect x="198" y="316" width="218" height="17" rx="8.5" fill="url(#nestia-bar)" />
+  <text x="560" y="331" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">200x</text>
+</svg>

--- a/website/public/benchmark/meetup-nestia-speedup.svg
+++ b/website/public/benchmark/meetup-nestia-speedup.svg
@@ -7,32 +7,33 @@
     </linearGradient>
   </defs>
   <rect x="1" y="1" width="618" height="358" rx="8" fill="#fff" stroke="#cbd5e1" />
-  <text x="24" y="38" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="24" font-weight="900">Nestia speedup</text>
-  <text x="24" y="72" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">Server path</text>
-  <text x="38" y="103" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">NestJS base</text>
-  <rect x="198" y="88" width="340" height="17" rx="8.5" fill="#e2e8f0" />
-  <rect x="198" y="88" width="28" height="17" rx="8.5" fill="#94a3b8" />
-  <text x="560" y="103" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">1x</text>
-  <text x="38" y="133" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">nestia</text>
-  <rect x="198" y="118" width="340" height="17" rx="8.5" fill="#e2e8f0" />
-  <rect x="198" y="118" width="122" height="17" rx="8.5" fill="url(#nestia-bar)" />
-  <text x="560" y="133" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">10x+</text>
-  <text x="24" y="171" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">Validation</text>
-  <text x="38" y="202" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">class-validator</text>
-  <rect x="198" y="187" width="340" height="17" rx="8.5" fill="#e2e8f0" />
-  <rect x="198" y="187" width="28" height="17" rx="8.5" fill="#94a3b8" />
-  <text x="560" y="202" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">1x</text>
-  <text x="38" y="232" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">typia core</text>
-  <rect x="198" y="217" width="340" height="17" rx="8.5" fill="#e2e8f0" />
-  <rect x="198" y="217" width="340" height="17" rx="8.5" fill="url(#nestia-bar)" />
-  <text x="560" y="232" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">20,000x</text>
-  <text x="24" y="270" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">Serialization</text>
-  <text x="38" y="301" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">class-transformer</text>
-  <rect x="198" y="286" width="340" height="17" rx="8.5" fill="#e2e8f0" />
-  <rect x="198" y="286" width="28" height="17" rx="8.5" fill="#94a3b8" />
-  <text x="560" y="301" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">1x</text>
-  <text x="38" y="331" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">typia core</text>
-  <rect x="198" y="316" width="340" height="17" rx="8.5" fill="#e2e8f0" />
-  <rect x="198" y="316" width="218" height="17" rx="8.5" fill="url(#nestia-bar)" />
-  <text x="560" y="331" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">200x</text>
+  <text x="28" y="38" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="25" font-weight="900">Nestia speedup</text>
+  <text x="28" y="61" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="14">Same log scale as typia. Baseline target = 1x.</text>
+  <text x="28" y="88" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">Server path</text>
+  <text x="42" y="116" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="15" font-weight="800">NestJS base</text>
+  <rect x="232" y="102" width="252" height="16" rx="8" fill="#e2e8f0" />
+  <rect x="232" y="102" width="22" height="16" rx="8" fill="#94a3b8" />
+  <text x="570" y="116" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">1x</text>
+  <text x="42" y="145" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="15" font-weight="800">nestia</text>
+  <rect x="232" y="131" width="252" height="16" rx="8" fill="#e2e8f0" />
+  <rect x="232" y="131" width="59" height="16" rx="8" fill="url(#nestia-bar)" />
+  <text x="570" y="145" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">10x+</text>
+  <text x="28" y="181" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">Validation</text>
+  <text x="42" y="209" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="15" font-weight="800">class-validator</text>
+  <rect x="232" y="195" width="252" height="16" rx="8" fill="#e2e8f0" />
+  <rect x="232" y="195" width="22" height="16" rx="8" fill="#94a3b8" />
+  <text x="570" y="209" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">1x</text>
+  <text x="42" y="238" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="15" font-weight="800">typia core</text>
+  <rect x="232" y="224" width="252" height="16" rx="8" fill="#e2e8f0" />
+  <rect x="232" y="224" width="252" height="16" rx="8" fill="url(#nestia-bar)" />
+  <text x="570" y="238" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">20,000x</text>
+  <text x="28" y="274" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">Serialization</text>
+  <text x="42" y="302" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="15" font-weight="800">class-transformer</text>
+  <rect x="232" y="288" width="252" height="16" rx="8" fill="#e2e8f0" />
+  <rect x="232" y="288" width="22" height="16" rx="8" fill="#94a3b8" />
+  <text x="570" y="302" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">1x</text>
+  <text x="42" y="331" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="15" font-weight="800">typia core</text>
+  <rect x="232" y="317" width="252" height="16" rx="8" fill="#e2e8f0" />
+  <rect x="232" y="317" width="135" height="16" rx="8" fill="url(#nestia-bar)" />
+  <text x="570" y="331" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">200x</text>
 </svg>

--- a/website/public/benchmark/meetup-tsgo-speedup.svg
+++ b/website/public/benchmark/meetup-tsgo-speedup.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="430" viewBox="0 0 620 430" role="img" aria-label="TypeScript-Go type-check speedup by project">
+  <title>TypeScript-Go type-check speedup by project</title>
+  <defs>
+    <linearGradient id="tsgo-bar" x1="0" x2="1">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#0f766e" />
+    </linearGradient>
+  </defs>
+  <rect x="1" y="1" width="618" height="428" rx="8" fill="#fff" stroke="#cbd5e1" />
+  <text x="26" y="42" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="25" font-weight="900">TypeScript-Go type-check speedup</text>
+  <text x="26" y="72" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="15">Multiplier only, VS Code checkers8: 73.29s to 6.54s.</text>
+  <text x="30" y="112" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">VS Code</text>
+  <rect x="140" y="94" width="370" height="22" rx="11" fill="#e2e8f0" />
+  <rect x="140" y="94" width="370" height="22" rx="11" fill="url(#tsgo-bar)" />
+  <text x="580" y="112" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">11.2x</text>
+  <text x="30" y="158" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">nestjs</text>
+  <rect x="140" y="140" width="370" height="22" rx="11" fill="#e2e8f0" />
+  <rect x="140" y="140" width="149" height="22" rx="11" fill="url(#tsgo-bar)" />
+  <text x="580" y="158" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">4.5x</text>
+  <text x="30" y="204" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">vue</text>
+  <rect x="140" y="186" width="370" height="22" rx="11" fill="#e2e8f0" />
+  <rect x="140" y="186" width="238" height="22" rx="11" fill="url(#tsgo-bar)" />
+  <text x="580" y="204" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">7.2x</text>
+  <text x="30" y="250" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">typeorm</text>
+  <rect x="140" y="232" width="370" height="22" rx="11" fill="#e2e8f0" />
+  <rect x="140" y="232" width="251" height="22" rx="11" fill="url(#tsgo-bar)" />
+  <text x="580" y="250" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">7.6x</text>
+  <text x="30" y="296" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">zod</text>
+  <rect x="140" y="278" width="370" height="22" rx="11" fill="#e2e8f0" />
+  <rect x="140" y="278" width="178" height="22" rx="11" fill="url(#tsgo-bar)" />
+  <text x="580" y="296" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">5.4x</text>
+  <text x="30" y="342" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">rxjs</text>
+  <rect x="140" y="324" width="370" height="22" rx="11" fill="#e2e8f0" />
+  <rect x="140" y="324" width="135" height="22" rx="11" fill="url(#tsgo-bar)" />
+  <text x="580" y="342" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">4.1x</text>
+  <text x="30" y="388" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">shopping</text>
+  <rect x="140" y="370" width="370" height="22" rx="11" fill="#e2e8f0" />
+  <rect x="140" y="370" width="86" height="22" rx="11" fill="url(#tsgo-bar)" />
+  <text x="580" y="388" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">2.6x</text>
+</svg>

--- a/website/public/benchmark/meetup-tsgo-speedup.svg
+++ b/website/public/benchmark/meetup-tsgo-speedup.svg
@@ -7,34 +7,34 @@
     </linearGradient>
   </defs>
   <rect x="1" y="1" width="618" height="428" rx="8" fill="#fff" stroke="#cbd5e1" />
-  <text x="26" y="42" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="25" font-weight="900">TypeScript-Go type-check speedup</text>
-  <text x="26" y="72" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="15">Multiplier only, VS Code checkers8: 73.29s to 6.54s.</text>
-  <text x="30" y="112" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">VS Code</text>
-  <rect x="140" y="94" width="370" height="22" rx="11" fill="#e2e8f0" />
-  <rect x="140" y="94" width="370" height="22" rx="11" fill="url(#tsgo-bar)" />
-  <text x="580" y="112" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">11.2x</text>
-  <text x="30" y="158" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">nestjs</text>
-  <rect x="140" y="140" width="370" height="22" rx="11" fill="#e2e8f0" />
-  <rect x="140" y="140" width="149" height="22" rx="11" fill="url(#tsgo-bar)" />
-  <text x="580" y="158" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">4.5x</text>
-  <text x="30" y="204" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">vue</text>
-  <rect x="140" y="186" width="370" height="22" rx="11" fill="#e2e8f0" />
-  <rect x="140" y="186" width="238" height="22" rx="11" fill="url(#tsgo-bar)" />
-  <text x="580" y="204" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">7.2x</text>
-  <text x="30" y="250" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">typeorm</text>
-  <rect x="140" y="232" width="370" height="22" rx="11" fill="#e2e8f0" />
-  <rect x="140" y="232" width="251" height="22" rx="11" fill="url(#tsgo-bar)" />
-  <text x="580" y="250" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">7.6x</text>
-  <text x="30" y="296" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">zod</text>
-  <rect x="140" y="278" width="370" height="22" rx="11" fill="#e2e8f0" />
-  <rect x="140" y="278" width="178" height="22" rx="11" fill="url(#tsgo-bar)" />
-  <text x="580" y="296" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">5.4x</text>
-  <text x="30" y="342" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">rxjs</text>
-  <rect x="140" y="324" width="370" height="22" rx="11" fill="#e2e8f0" />
-  <rect x="140" y="324" width="135" height="22" rx="11" fill="url(#tsgo-bar)" />
-  <text x="580" y="342" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">4.1x</text>
-  <text x="30" y="388" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="900">shopping</text>
-  <rect x="140" y="370" width="370" height="22" rx="11" fill="#e2e8f0" />
-  <rect x="140" y="370" width="86" height="22" rx="11" fill="url(#tsgo-bar)" />
-  <text x="580" y="388" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">2.6x</text>
+  <text x="28" y="42" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="25" font-weight="900">TypeScript-Go type-check speedup</text>
+  <text x="28" y="70" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="15">Multiplier only. VS Code checkers8: 73.29s to 6.54s.</text>
+  <text x="36" y="111" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="900">VS Code</text>
+  <rect x="150" y="95" width="320" height="20" rx="10" fill="#e2e8f0" />
+  <rect x="150" y="95" width="320" height="20" rx="10" fill="url(#tsgo-bar)" />
+  <text x="560" y="112" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">11.2x</text>
+  <text x="36" y="154" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="900">nestjs</text>
+  <rect x="150" y="138" width="320" height="20" rx="10" fill="#e2e8f0" />
+  <rect x="150" y="138" width="129" height="20" rx="10" fill="url(#tsgo-bar)" />
+  <text x="560" y="155" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">4.5x</text>
+  <text x="36" y="197" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="900">vue</text>
+  <rect x="150" y="181" width="320" height="20" rx="10" fill="#e2e8f0" />
+  <rect x="150" y="181" width="206" height="20" rx="10" fill="url(#tsgo-bar)" />
+  <text x="560" y="198" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">7.2x</text>
+  <text x="36" y="240" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="900">typeorm</text>
+  <rect x="150" y="224" width="320" height="20" rx="10" fill="#e2e8f0" />
+  <rect x="150" y="224" width="217" height="20" rx="10" fill="url(#tsgo-bar)" />
+  <text x="560" y="241" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">7.6x</text>
+  <text x="36" y="283" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="900">zod</text>
+  <rect x="150" y="267" width="320" height="20" rx="10" fill="#e2e8f0" />
+  <rect x="150" y="267" width="154" height="20" rx="10" fill="url(#tsgo-bar)" />
+  <text x="560" y="284" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">5.4x</text>
+  <text x="36" y="326" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="900">rxjs</text>
+  <rect x="150" y="310" width="320" height="20" rx="10" fill="#e2e8f0" />
+  <rect x="150" y="310" width="117" height="20" rx="10" fill="url(#tsgo-bar)" />
+  <text x="560" y="327" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">4.1x</text>
+  <text x="36" y="369" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="900">shopping</text>
+  <rect x="150" y="353" width="320" height="20" rx="10" fill="#e2e8f0" />
+  <rect x="150" y="353" width="74" height="20" rx="10" fill="url(#tsgo-bar)" />
+  <text x="560" y="370" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">2.6x</text>
 </svg>

--- a/website/public/benchmark/meetup-typia-speedup.svg
+++ b/website/public/benchmark/meetup-typia-speedup.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="300" viewBox="0 0 620 300" role="img" aria-label="Typia benchmark speedup chart">
+  <title>Typia benchmark speedup chart</title>
+  <defs>
+    <linearGradient id="typia-bar" x1="0" x2="1">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#0f766e" />
+    </linearGradient>
+  </defs>
+  <rect x="1" y="1" width="618" height="298" rx="8" fill="#fff" stroke="#cbd5e1" />
+  <text x="24" y="38" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="24" font-weight="900">Typia speedup</text>
+  <text x="24" y="75" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">Runtime validation</text>
+  <text x="38" y="110" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="800">class-validator</text>
+  <rect x="198" y="94" width="340" height="18" rx="9" fill="#e2e8f0" />
+  <rect x="198" y="94" width="28" height="18" rx="9" fill="#94a3b8" />
+  <text x="560" y="110" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">1x</text>
+  <text x="38" y="144" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="800">typia</text>
+  <rect x="198" y="128" width="340" height="18" rx="9" fill="#e2e8f0" />
+  <rect x="198" y="128" width="340" height="18" rx="9" fill="url(#typia-bar)" />
+  <text x="560" y="144" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">20,000x</text>
+  <text x="24" y="190" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">JSON serialization</text>
+  <text x="38" y="225" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="800">class-transformer</text>
+  <rect x="198" y="209" width="340" height="18" rx="9" fill="#e2e8f0" />
+  <rect x="198" y="209" width="28" height="18" rx="9" fill="#94a3b8" />
+  <text x="560" y="225" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">1x</text>
+  <text x="38" y="259" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="800">typia</text>
+  <rect x="198" y="243" width="340" height="18" rx="9" fill="#e2e8f0" />
+  <rect x="198" y="243" width="218" height="18" rx="9" fill="url(#typia-bar)" />
+  <text x="560" y="259" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">200x</text>
+  <text x="24" y="286" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="14">Log-scaled visual, comparison target = 1x.</text>
+</svg>

--- a/website/public/benchmark/meetup-typia-speedup.svg
+++ b/website/public/benchmark/meetup-typia-speedup.svg
@@ -7,24 +7,24 @@
     </linearGradient>
   </defs>
   <rect x="1" y="1" width="618" height="298" rx="8" fill="#fff" stroke="#cbd5e1" />
-  <text x="24" y="38" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="24" font-weight="900">Typia speedup</text>
-  <text x="24" y="75" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">Runtime validation</text>
-  <text x="38" y="110" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="800">class-validator</text>
-  <rect x="198" y="94" width="340" height="18" rx="9" fill="#e2e8f0" />
-  <rect x="198" y="94" width="28" height="18" rx="9" fill="#94a3b8" />
-  <text x="560" y="110" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">1x</text>
-  <text x="38" y="144" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="800">typia</text>
-  <rect x="198" y="128" width="340" height="18" rx="9" fill="#e2e8f0" />
-  <rect x="198" y="128" width="340" height="18" rx="9" fill="url(#typia-bar)" />
-  <text x="560" y="144" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">20,000x</text>
-  <text x="24" y="190" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">JSON serialization</text>
-  <text x="38" y="225" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="800">class-transformer</text>
-  <rect x="198" y="209" width="340" height="18" rx="9" fill="#e2e8f0" />
-  <rect x="198" y="209" width="28" height="18" rx="9" fill="#94a3b8" />
-  <text x="560" y="225" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">1x</text>
-  <text x="38" y="259" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="17" font-weight="800">typia</text>
-  <rect x="198" y="243" width="340" height="18" rx="9" fill="#e2e8f0" />
-  <rect x="198" y="243" width="218" height="18" rx="9" fill="url(#typia-bar)" />
-  <text x="560" y="259" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">200x</text>
-  <text x="24" y="286" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="14">Log-scaled visual, comparison target = 1x.</text>
+  <text x="28" y="40" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="25" font-weight="900">Typia speedup</text>
+  <text x="28" y="64" fill="#64748b" font-family="Inter, Segoe UI, sans-serif" font-size="14">Log-scaled by multiplier. Baseline target = 1x.</text>
+  <text x="28" y="96" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">Runtime validation</text>
+  <text x="42" y="128" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">class-validator</text>
+  <rect x="232" y="112" width="252" height="18" rx="9" fill="#e2e8f0" />
+  <rect x="232" y="112" width="22" height="18" rx="9" fill="#94a3b8" />
+  <text x="570" y="128" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">1x</text>
+  <text x="42" y="160" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">typia</text>
+  <rect x="232" y="144" width="252" height="18" rx="9" fill="#e2e8f0" />
+  <rect x="232" y="144" width="252" height="18" rx="9" fill="url(#typia-bar)" />
+  <text x="570" y="160" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">20,000x</text>
+  <text x="28" y="205" fill="#2563eb" font-family="Inter, Segoe UI, sans-serif" font-size="19" font-weight="900">JSON serialization</text>
+  <text x="42" y="237" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">class-transformer</text>
+  <rect x="232" y="221" width="252" height="18" rx="9" fill="#e2e8f0" />
+  <rect x="232" y="221" width="22" height="18" rx="9" fill="#94a3b8" />
+  <text x="570" y="237" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">1x</text>
+  <text x="42" y="269" fill="#334155" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="800">typia</text>
+  <rect x="232" y="253" width="252" height="18" rx="9" fill="#e2e8f0" />
+  <rect x="232" y="253" width="135" height="18" rx="9" fill="url(#typia-bar)" />
+  <text x="570" y="269" text-anchor="end" fill="#0f172a" font-family="Inter, Segoe UI, sans-serif" font-size="20" font-weight="900">200x</text>
 </svg>

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -413,52 +413,6 @@ style: |
     font-size: 17px;
     margin-top: 10px;
   }
-  section.benchmark-grid {
-    display: grid;
-    gap: 14px;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-template-rows: auto repeat(3, minmax(0, 1fr)) auto;
-    padding: 48px 50px;
-  }
-  section.benchmark-grid h1 {
-    font-size: 42px;
-    grid-column: 1 / -1;
-    margin-bottom: 0;
-  }
-  section.benchmark-grid .benchmarks {
-    display: contents;
-    grid-column: 1 / -1;
-  }
-  section.benchmark-grid .bench-card {
-    padding: 12px;
-  }
-  section.benchmark-grid .bench-title {
-    font-size: 18px;
-    margin-bottom: 8px;
-  }
-  section.benchmark-grid .bench-row {
-    grid-template-columns: 126px minmax(0, 1fr) 82px;
-    gap: 8px;
-    margin-top: 6px;
-  }
-  section.benchmark-grid .bench-name {
-    font-size: 14px;
-  }
-  section.benchmark-grid .bench-value {
-    font-size: 16px;
-  }
-  section.benchmark-grid .bench-track {
-    height: 14px;
-  }
-  section.benchmark-grid .bench-note {
-    font-size: 12px;
-    line-height: 1.2;
-    margin-top: 8px;
-  }
-  section.benchmark-grid .bench-summary {
-    grid-column: 1 / -1;
-    margin-top: 0;
-  }
   section.cards > ul {
     display: grid;
     gap: 18px;
@@ -1286,140 +1240,25 @@ That is why the language can be compatible while the transformer ecosystem break
   - compiler moves from JavaScript to Go
   - this is where the speedup shows up
 
-<div class="benchmarks">
-  <div class="bench-card">
-    <div class="bench-title">VS Code type-check</div>
-    <div class="bench-row">
-      <div class="bench-name">legacy TypeScript</div>
-      <div class="bench-track">
-        <div class="bench-fill base" style="width: 100%"></div>
-      </div>
-      <div class="bench-value">1.0x</div>
-    </div>
-    <div class="bench-row">
-      <div class="bench-name">TypeScript-Go (8 checkers)</div>
-      <div class="bench-track">
-        <div class="bench-fill" style="width: 8.9%"></div>
-      </div>
-      <div class="bench-value">11.2x</div>
-    </div>
-    <div class="bench-note">
-      11.2x
-    </div>
-  </div>
+<div class="mermaid">
+xychart-beta
+  title "TypeScript-Go type-check speedup"
+  x-axis [vscode, nestjs, vue, typeorm, zod, rxjs, shopping]
+  y-axis "speedup (x)" 0 --> 12
+  bar [11.2, 4.5, 7.2, 7.6, 5.4, 4.1, 2.6]
 </div>
+
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true });
+</script>
 
 <!--
 This is the upside that has to come first.
 
-The benchmark page shows the practical payoff of TypeScript-Go on a real project. TypeScript still looks like TypeScript from the user's side, but the compiler implementation moves to Go and the wall-clock time drops.
+The benchmark page shows the practical payoff of TypeScript-Go across the fixture set. TypeScript still looks like TypeScript from the user's side, but the compiler implementation moves to Go and the check loop gets faster.
 
-The same benchmark page keeps the raw tsgo row around as a reference. That matters here because the story is not "ttsc is faster than tsc by magic." The story is that the new compiler base changes the cost of the everyday check loop.
--->
-
----
-
-<!-- _class: benchmark-grid -->
-
-# 2.1. Native Compiler
-
-<div class="benchmarks">
-  <div class="bench-card">
-    <div class="bench-title">vscode</div>
-    <div class="bench-row">
-      <div class="bench-name">legacy TypeScript</div>
-      <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
-      <div class="bench-value">1.0x</div>
-    </div>
-    <div class="bench-row">
-      <div class="bench-name">TypeScript-Go (8)</div>
-      <div class="bench-track"><div class="bench-fill" style="width: 8.9%"></div></div>
-      <div class="bench-value">11.2x</div>
-    </div>
-    <div class="bench-note">11.2x</div>
-  </div>
-  <div class="bench-card">
-    <div class="bench-title">nestjs</div>
-    <div class="bench-row">
-      <div class="bench-name">legacy TypeScript</div>
-      <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
-      <div class="bench-value">1.0x</div>
-    </div>
-    <div class="bench-row">
-      <div class="bench-name">TypeScript-Go (8)</div>
-      <div class="bench-track"><div class="bench-fill" style="width: 22.1%"></div></div>
-      <div class="bench-value">4.5x</div>
-    </div>
-    <div class="bench-note">4.5x</div>
-  </div>
-  <div class="bench-card">
-    <div class="bench-title">vue</div>
-    <div class="bench-row">
-      <div class="bench-name">legacy TypeScript</div>
-      <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
-      <div class="bench-value">1.0x</div>
-    </div>
-    <div class="bench-row">
-      <div class="bench-name">TypeScript-Go (8)</div>
-      <div class="bench-track"><div class="bench-fill" style="width: 13.9%"></div></div>
-      <div class="bench-value">7.2x</div>
-    </div>
-    <div class="bench-note">7.2x</div>
-  </div>
-  <div class="bench-card">
-    <div class="bench-title">typeorm</div>
-    <div class="bench-row">
-      <div class="bench-name">legacy TypeScript</div>
-      <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
-      <div class="bench-value">1.0x</div>
-    </div>
-    <div class="bench-row">
-      <div class="bench-name">TypeScript-Go (8)</div>
-      <div class="bench-track"><div class="bench-fill" style="width: 13.1%"></div></div>
-      <div class="bench-value">7.6x</div>
-    </div>
-    <div class="bench-note">7.6x</div>
-  </div>
-  <div class="bench-card">
-    <div class="bench-title">zod</div>
-    <div class="bench-row">
-      <div class="bench-name">legacy TypeScript</div>
-      <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
-      <div class="bench-value">1.0x</div>
-    </div>
-    <div class="bench-row">
-      <div class="bench-name">TypeScript-Go (8)</div>
-      <div class="bench-track"><div class="bench-fill" style="width: 18.5%"></div></div>
-      <div class="bench-value">5.4x</div>
-    </div>
-    <div class="bench-note">5.4x</div>
-  </div>
-  <div class="bench-card">
-    <div class="bench-title">rxjs</div>
-    <div class="bench-row">
-      <div class="bench-name">legacy TypeScript</div>
-      <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
-      <div class="bench-value">1.0x</div>
-    </div>
-    <div class="bench-row">
-      <div class="bench-name">TypeScript-Go (8)</div>
-      <div class="bench-track"><div class="bench-fill" style="width: 24.5%"></div></div>
-      <div class="bench-value">4.1x</div>
-    </div>
-    <div class="bench-note">4.1x</div>
-  </div>
-  <p class="bench-note bench-summary">
-    shopping-backend has no comparable `tsgo` noEmit row in the published snapshot,
-    so it is omitted from this direct type-check comparison.
-  </p>
-</div>
-
-<!--
-This is the same benchmark story stretched across the whole page.
-
-Every card is one project from the public benchmark page. The important thing is that the speedup is not a single VS Code anecdote. It repeats across the benchmark set, with the exact `checkers8` row varying by project but always pointing in the same direction.
-
-The one omission is shopping-backend, because the current snapshot does not carry a direct tsgo noEmit row for it. That is a data limitation, not a design change.
+Most rows use the raw tsgo checkers8 comparison. The shopping-backend snapshot has no raw tsgo noEmit row, so this chart uses the ttsc checkers8 row there because it is still backed by TypeScript-Go.
 -->
 
 ---

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -413,54 +413,82 @@ style: |
     font-size: 17px;
     margin-top: 10px;
   }
-  section.benchmark .speed-chart {
+  section.benchmark .speed-chart,
+  section.lint-benchmark .speed-chart {
     align-self: start;
     background: #ffffff;
     border: 1px solid #cbd5e1;
     border-radius: 8px;
+    box-sizing: border-box;
     display: grid;
     gap: 10px;
-    grid-column: 2;
     padding: 16px 18px 18px;
+    width: 100%;
   }
-  section.benchmark .speed-title {
+  section.benchmark .speed-chart {
+    grid-column: 2;
+  }
+  section.benchmark .speed-title,
+  section.lint-benchmark .speed-title {
     color: #0f172a;
     font-size: 23px;
     font-weight: 900;
     line-height: 1.1;
     margin-bottom: 2px;
   }
-  section.benchmark .speed-row {
+  section.benchmark .speed-row,
+  section.lint-benchmark .speed-row {
     align-items: center;
     display: grid;
     gap: 10px;
     grid-template-columns: 120px minmax(0, 1fr) 64px;
     min-height: 33px;
   }
-  section.benchmark .speed-label {
+  section.lint-benchmark .speed-row {
+    grid-template-columns: 120px minmax(0, 1fr) 86px;
+    min-height: 40px;
+  }
+  section.benchmark .speed-label,
+  section.lint-benchmark .speed-label {
     color: #334155;
     font-size: 17px;
     font-weight: 800;
     white-space: nowrap;
   }
-  section.benchmark .speed-track {
+  section.lint-benchmark .speed-label {
+    font-size: 20px;
+    font-weight: 900;
+  }
+  section.benchmark .speed-track,
+  section.lint-benchmark .speed-track {
     background: #e2e8f0;
     border-radius: 999px;
     height: 18px;
     overflow: hidden;
   }
-  section.benchmark .speed-bar {
+  section.lint-benchmark .speed-track {
+    height: 22px;
+  }
+  section.benchmark .speed-bar,
+  section.lint-benchmark .speed-bar {
     background: linear-gradient(90deg, #2563eb, #0f766e);
     border-radius: 999px;
     height: 100%;
   }
-  section.benchmark .speed-value {
+  section.lint-benchmark .speed-bar {
+    background: linear-gradient(90deg, #16a34a, #2563eb);
+  }
+  section.benchmark .speed-value,
+  section.lint-benchmark .speed-value {
     color: #0f172a;
     font-size: 20px;
     font-weight: 900;
     line-height: 1;
     text-align: right;
     white-space: nowrap;
+  }
+  section.lint-benchmark .speed-value {
+    font-size: 24px;
   }
   section.cards > ul {
     display: grid;
@@ -552,6 +580,15 @@ style: |
     margin-top: 28px;
     text-align: center;
   }
+  section.lint-benchmark {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    padding: 52px 58px;
+  }
+  section.lint-benchmark h1 {
+    font-size: 44px;
+    margin-bottom: 18px;
+  }
   section.flow > ul {
     align-items: stretch;
     display: grid;
@@ -634,6 +671,75 @@ style: |
     max-height: 492px;
     object-fit: contain;
     width: 100%;
+  }
+  section.graph-token {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    padding: 50px 58px;
+  }
+  section.graph-token h1 {
+    font-size: 44px;
+    margin-bottom: 18px;
+  }
+  section.graph-token .token-chart {
+    align-self: start;
+    background: #ffffff;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    box-shadow: 0 12px 28px rgba(49, 120, 198, 0.12);
+    display: grid;
+    gap: 14px;
+    padding: 18px 22px 22px;
+  }
+  section.graph-token .token-title {
+    color: #0f172a;
+    font-size: 26px;
+    font-weight: 900;
+    line-height: 1.1;
+  }
+  section.graph-token .token-group {
+    border-top: 1px solid #e2e8f0;
+    display: grid;
+    gap: 8px;
+    padding-top: 12px;
+  }
+  section.graph-token .token-model {
+    align-items: baseline;
+    color: #0f172a;
+    display: flex;
+    font-size: 21px;
+    font-weight: 900;
+    gap: 14px;
+    justify-content: space-between;
+    line-height: 1;
+  }
+  section.graph-token .token-model strong {
+    color: #2563eb;
+    font-size: 24px;
+  }
+  section.graph-token .token-row {
+    align-items: center;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: 100px minmax(0, 1fr) 112px;
+    min-height: 32px;
+  }
+  section.graph-token .token-label {
+    color: #334155;
+    font-size: 18px;
+    font-weight: 800;
+  }
+  section.graph-token .token-track {
+    background: #e2e8f0;
+    border-radius: 999px;
+    height: 18px;
+  }
+  section.graph-token .token-value {
+    color: #0f172a;
+    font-size: 19px;
+    font-weight: 900;
+    line-height: 1;
+    text-align: right;
   }
   section.blueprint {
     background: #0f172a;
@@ -742,14 +848,14 @@ The fourth chapter is the larger opportunity. If one tool already has the Progra
 
 ---
 
-<!-- _class: lead -->
+<!-- _class: cards -->
 
 # 1. Typia and Nestia
 
-- Typia
-- Nestia
-- Common Engine
-- Transformer
+- 1.1. Typia
+- 1.2. Nestia
+- 1.3. Common Engine
+- 1.4. Transformer
 
 <!--
 I will begin with Typia and Nestia because they are the reason this problem matters to me.
@@ -1230,25 +1336,21 @@ That creates an important split. A new compiler can remain compatible with the T
 
 # 2. TypeScript-Go
 
-- Native compiler
-- Faster benchmark
-- Same language
-- Go implementation
-- Transformer host disappears
-- typia and nestia lose their engine
+- 2.1. Native Compiler
+- 2.2. Patch Model
+- 2.3. Broken Assumption
+- 2.4. Project Risk
 
 <!--
-This chapter starts with the upside.
+Chapter 2 has to start fairly.
 
-TypeScript-Go is exciting because the TypeScript compiler becomes much faster. For most users, that is simply good news. Faster type-checking, faster editor feedback, faster CI, and faster monorepo workflows are all wins.
+TypeScript-Go is not a villain in this story. It is the thing TypeScript users have wanted for years: a much faster compiler and language service. The first point is the upside: type-checking gets faster, editor feedback gets faster, and CI gets a real chance to shrink.
 
-But speed is only half of the story. The TypeScript language stays the same, but the compiler implementation language changes. The old center was a JavaScript package running in a JavaScript process. The new center is a native Go compiler.
+Then the chapter turns on one implementation detail. The source language remains TypeScript, but the compiler implementation language changes from JavaScript to Go.
 
-That implementation change is what matters for the ecosystem. The old patch point was not a formal cross-language plugin system. It was a JavaScript compiler implementation that JavaScript tools could patch and extend.
+That sounds internal, but the transformer ecosystem lived inside the old internal shape. It patched a JavaScript package, loaded JavaScript modules, touched JavaScript compiler objects, and rode the JavaScript emit pipeline.
 
-For typia and nestia, this was not a theoretical compatibility issue. The packages could still be installed. The source code could still look valid. But the generated validators, serializers, SDKs, and documents depended on a transformer host that was disappearing.
-
-That means the visible API could survive while the product engine died. The rest of chapter 2 is the breakdown of that failure.
+So the crisis is not "TypeScript-Go cannot understand TypeScript." The crisis is "the old JavaScript transformer host disappears." For typia and nestia, that means the public API can still look alive while the generated product value dies.
 -->
 
 ---
@@ -1257,23 +1359,25 @@ That means the visible API could survive while the product engine died. The rest
 
 # 2.1. Native Compiler
 
-- What stays
-  - TypeScript language
-  - project source code
-- What changes
-  - compiler implementation language
-  - JavaScript process to Go process
-- Why it matters
-  - old plugins lived in JavaScript
+- User-visible promise
+  - same TypeScript source
+  - same project files
+  - faster check loop
+- Implementation change
+  - compiler rewritten in Go
+  - language service moves native
+  - JavaScript package is no longer the center
+- First reaction
+  - this is excellent news
 
 <!--
-The native compiler story has two sides.
+This slide is deliberately positive.
 
-From the user's side, TypeScript source code remains TypeScript. The type system, syntax, project files, and everyday programming model are supposed to remain familiar.
+For ordinary TypeScript users, the pitch is simple. Keep the same source language, keep the same project model, and get a much faster compiler and language service.
 
-From the tool author's side, the implementation language changes. The old compiler was a JavaScript package running in a JavaScript process. TypeScript-Go moves that center into a native Go compiler and language service.
+That is a real improvement. Backend projects, monorepos, editors, and CI pipelines all pay the TypeScript check cost every day.
 
-That is why the language can be compatible while the transformer ecosystem breaks. The source language is the same, but the process that plugins used to live inside is not the same process anymore.
+The key phrase is "same TypeScript, different compiler implementation." The source language remains familiar, but the runtime that compiler-powered tools used to patch is no longer the same runtime.
 -->
 
 ---
@@ -1282,12 +1386,12 @@ That is why the language can be compatible while the transformer ecosystem break
 
 # 2.1. Native Compiler
 
-- Same language
-  - TypeScript source stays valid
-  - everyday workflow stays familiar
-- Different engine
-  - compiler moves from JavaScript to Go
-  - this is where the speedup shows up
+- Benchmark headline
+  - VS Code: **11.2x**
+  - 73.29s to 6.54s
+- Pattern
+  - fixture set repeats the win
+  - speed comes from the native compiler base
 
 <div class="speed-chart" aria-label="TypeScript-Go type-check speedup by project">
   <div class="speed-title">TypeScript-Go type-check speedup</div>
@@ -1329,38 +1433,43 @@ That is why the language can be compatible while the transformer ecosystem break
 </div>
 
 <!--
-This is the upside that has to come first.
+This is the graph that makes the upside credible.
 
-The benchmark page shows the practical payoff of TypeScript-Go across the fixture set. TypeScript still looks like TypeScript from the user's side, but the compiler implementation moves to Go and the check loop gets faster.
+The VS Code row is the important anchor: legacy TypeScript takes about 73.29 seconds in the published check benchmark, while the TypeScript-Go checkers8 row is about 6.54 seconds. That is 11.2x faster.
 
-Most rows use the raw tsgo checkers8 comparison. The shopping-backend snapshot has no raw tsgo noEmit row, so this chart uses the ttsc checkers8 row there because it is still backed by TypeScript-Go.
+The other fixture rows keep the same pattern. The exact multiplier changes by project, but the direction does not: TypeScript-Go makes the type-check loop materially faster.
+
+Most rows use the raw tsgo checkers8 comparison. The shopping-backend snapshot has no raw tsgo noEmit row, so this chart uses the ttsc checkers8 row there because it is still backed by TypeScript-Go. The slide shows only multipliers because the narrative point is the size of the speedup, not a stopwatch table.
 -->
 
 ---
 
-<!-- _class: cards three -->
+<!-- _class: flow -->
 
 # 2.2. Patch Model
 
-- Old compiler
-  - JavaScript package
-  - JavaScript process
-  - JavaScript objects
-- Old transformers
-  - JavaScript modules
-  - compiler API access
-  - emit hook access
-- Old strategy
-  - patch TypeScript
+- JavaScript compiler
+  - `typescript` from npm
+  - `Program`
+  - `TypeChecker`
+  - `SourceFile`
+- JavaScript patch
+  - `ttypescript`
+  - `ts-patch`
+  - `tsconfig.plugins`
+- JavaScript transformer
+  - load module
+  - inspect types
+  - rewrite emit
 
 <!--
-Before TypeScript-Go, many transformer projects shared a simple assumption.
+This is the old world as a pipeline.
 
-The compiler was an npm package written in JavaScript. When your build ran, the compiler process was a JavaScript process. The AST, SourceFile, TypeChecker, Program, and emit pipeline were JavaScript objects.
+The compiler came from npm as JavaScript. The build process ran JavaScript. The Program, TypeChecker, SourceFile, AST nodes, diagnostics, and emit pipeline were all JavaScript objects.
 
-That meant a transformer could be a JavaScript module loaded into the compiler process. It could call the TypeScript compiler API directly. It could participate in emit by using APIs that already existed inside that runtime.
+That made the transformer model possible. ttypescript and ts-patch did not create a clean official plugin system, but they could patch the JavaScript compiler and load JavaScript transformer modules into the same process.
 
-The strategy was therefore practical, even if it was not beautiful: patch TypeScript or run a wrapper around TypeScript, then load transformer modules from tsconfig.
+That is why the model worked. The compiler and the plugin lived in the same language runtime. The transformer could look at compiler objects, ask the checker questions, and replace emitted code.
 -->
 
 ---
@@ -1369,24 +1478,27 @@ The strategy was therefore practical, even if it was not beautiful: patch TypeSc
 
 # 2.2. Patch Model
 
-- `ttypescript`
-  - custom compiler wrapper
-- `ts-patch`
-  - mutate installed TypeScript
-- `tsconfig.plugins`
-  - transformer module path
-- Works because
-  - compiler is JavaScript
-  - transformer is JavaScript
+- What users configured
+  - `ts-patch install`
+  - `plugins` in `tsconfig.json`
+  - transformer package path
+- What tools assumed
+  - patched TypeScript is executable
+  - JavaScript module can enter emit
+  - compiler API objects are reachable
+- What typia and nestia used
+  - type facts before erasure
+  - controller facts before runtime
+  - generated code during emit
 
 <!--
-This is the old patch model.
+This slide names the hidden contract.
 
-ttypescript provided a custom compiler wrapper. ts-patch mutated the installed TypeScript package. tsconfig plugins gave transformer package paths. Once the patch was active, the compiler could load JavaScript transformer modules.
+The user sees a small setup: install a patch, list plugins in tsconfig, and run the compiler through the patched path. That looks like configuration.
 
-This model had real downsides. It was fragile across compiler versions. It depended on implementation details. It could be difficult for new users to diagnose when a patch was missing.
+Under that setup, the tools assume much more. They assume the TypeScript package can be patched. They assume the compiler can load a JavaScript transformer module. They assume compiler API objects are in process and reachable.
 
-But it worked for one basic reason: the compiler and the transformer lived in the same JavaScript world. The plugin could see the compiler API objects directly, and the compiler's emit path was patchable from JavaScript.
+Typia and nestia used that access to catch facts before they disappear. Typia catches type facts before erasure and emits validators and serializers. Nestia catches controller facts before runtime and emits SDKs, OpenAPI documents, mockups, and test helpers.
 -->
 
 ---
@@ -1406,13 +1518,13 @@ But it worked for one basic reason: the compiler and the transformer lived in th
 ```
 
 <!--
-This is what the user configuration looked like.
+This is where the old model starts to fail.
 
-The tsconfig lists the transformer module paths for Typia and Nestia. In a patched compiler setup, those entries become active during compilation. The user keeps writing TypeScript, and the transformer does the code generation work during emit.
+The tsconfig entry still looks ordinary. The package names are still JavaScript package names. The user can still write the same TypeScript application code.
 
-The configuration looks small, but it hides a major assumption: the compiler must be able to load these JavaScript modules and let them participate in compilation.
+But this configuration only means something if the compiler process can load those JavaScript modules and let them participate in emit.
 
-As long as the compiler is JavaScript, that assumption is natural. When the compiler becomes a Go binary, this exact model cannot be taken for granted.
+That was natural when the compiler process was JavaScript. It is not natural when the compiler implementation becomes a native Go compiler. The source language is still TypeScript, but the plugin host assumed by this JSON no longer exists automatically.
 -->
 
 ---
@@ -1421,21 +1533,22 @@ As long as the compiler is JavaScript, that assumption is natural. When the comp
 
 # 2.3. Broken Assumption
 
-| Old world                      | TypeScript-Go world               |
-| ------------------------------ | --------------------------------- |
-| compiler: JavaScript process   | compiler: Go process              |
-| transformer: JavaScript module | transformer: JavaScript ecosystem |
-| hook: patchable                | hook: missing                     |
-| language OK                    | transformer host broken           |
+| Question | Old TypeScript | TypeScript-Go |
+| --- | --- | --- |
+| source language | TypeScript | TypeScript |
+| compiler implementation | JavaScript | Go |
+| plugin loading | JavaScript module in-process | no old JS host |
+| transformer access | Program, Checker, emit hook | bridge required |
+| result | generated artifacts | typia/nestia engine at risk |
 
 <!--
-This table is the broken assumption.
+This table is the point of chapter 2.
 
-In the old world, the compiler was a JavaScript process and the transformer was a JavaScript module. Patching was possible because the compiler internals were also JavaScript. That gave transformer authors a host, even if the host was unofficial.
+Language compatibility and transformer compatibility are different problems.
 
-In the TypeScript-Go world, the compiler process is native Go, while most of the transformer ecosystem is still JavaScript. The TypeScript language can be supported correctly, but the JavaScript transformer host is gone unless a new bridge exists.
+TypeScript-Go can preserve the source language and still break the old transformer execution model. The reason is simple: the old model was not just TypeScript syntax. It was JavaScript modules running inside a JavaScript compiler process.
 
-This is why I describe the problem as plugin compatibility, not language compatibility. Your TypeScript source may still be valid. Your transformer-powered artifacts may still fail to generate.
+Once the compiler implementation moves to Go, transformer access needs a bridge. Without that bridge, the TypeScript source may still be valid, while generated validators, serializers, SDKs, and OpenAPI documents stop appearing.
 -->
 
 ---
@@ -1444,26 +1557,27 @@ This is why I describe the problem as plugin compatibility, not language compati
 
 # 2.4. Project Risk
 
-- typia risk
-  - type erasure wins
-  - validators disappear
-  - serializers disappear
-- nestia risk
-  - controller facts lost
-  - SDK disappears
-  - OpenAPI disappears
-- Product risk
-  - npm API remains
-  - generated value gone
+- typia
+  - `createIs<T>()` needs erased type facts
+  - no transformer, no specialized predicate
+  - no generated serializer path
+- nestia
+  - controllers need compile-time extraction
+  - no transformer, no SDK contract
+  - no OpenAPI or mockup pipeline
+- Product failure
+  - packages can still install
+  - source can still look valid
+  - generated value disappears
 
 <!--
-For my projects, this was the concrete failure mode.
+This is the crisis in practical terms.
 
-typia depends on seeing erased types before they disappear. If the transformer path dies, type erasure wins. The user still writes typia.createIs<T>(), but the specialized validator and serializer code is not produced.
+Typia is not valuable because it exposes a function name. It is valuable because the transformer sees erased type facts and turns them into specialized runtime code. Without that transformer path, the API can remain on npm while the generated predicate and serializer path disappear.
 
-nestia depends on extracting controller contracts. If that path dies, SDK generation, OpenAPI generation, mockup generation, and E2E helpers lose the source of truth that made them safe.
+Nestia is the same kind of problem at the application boundary. It extracts controller contracts and turns them into SDKs, OpenAPI documents, mockups, and E2E helpers. Without the transformer path, the source of truth is still in the TypeScript code, but the compiler no longer delivers it to the generator.
 
-That is why the risk felt severe. This is not a small regression or a slower implementation. The npm package can remain, the TypeScript code can remain, and the core value can still disappear.
+That is why this is not a minor compatibility issue. The visible package can survive while the product engine is gone.
 -->
 
 ---
@@ -1474,27 +1588,25 @@ That is why the risk felt severe. This is not a small regression or a slower imp
 
 - Wait
   - upstream plugin model
-  - unknown timeline
+  - unknown timing
 - Retreat
   - runtime schemas
-  - give up source of truth
-- Drop features
-  - no transformer path
-  - no generated boundary
+  - duplicate source of truth
+- Shrink
+  - remove generated features
+  - lose the reason users came
 - Build
-  - new host
-  - TypeScript-Go base
+  - new transformer host
+  - survive on TypeScript-Go
 
 <!--
-There were four possible responses.
+This final slide sets up chapter 3.
 
-The first option was to wait for an upstream plugin model. That may eventually happen, but the timeline and shape were unknown. Waiting meant accepting a dead zone for products that needed this path today.
+At this point in the story, the replacement host does not already exist. That is important. The situation is not "TTSC is ready, so let's switch." The situation is "the old host is disappearing, and typia and nestia need a path to stay alive."
 
-The second option was to retreat to runtime schemas. That would avoid the transformer problem, but it would also give up the main value proposition: using TypeScript itself as the source of truth.
+The options were bad. Wait for an upstream model with unknown timing. Retreat to runtime schemas and duplicate the source of truth. Shrink the products and remove the generated features that made users choose them.
 
-The third option was to drop features. That would keep the packages simpler, but it would break the reason many users chose them.
-
-So I chose the fourth option: build the missing host myself, on top of the TypeScript-Go direction. That host is TTSC.
+The remaining option was to build a new transformer host on top of the TypeScript-Go direction. That is where chapter 3 begins: not with a finished toolchain, but with the decision to build the missing host.
 -->
 
 ---
@@ -1503,10 +1615,10 @@ So I chose the fourth option: build the missing host myself, on top of the TypeS
 
 # 3. Transformer Survival
 
-- No ready host
-- I had to build one
-- Keep user APIs alive
-- Replace the compiler path
+- 3.1. Compiler Front Door
+- 3.2. Plugin Host
+- 3.3. Transformer Lifecycle
+- 3.4. Runtime and Editor Path
 
 <!--
 This is the reversal.
@@ -1768,10 +1880,10 @@ That starts as transformer survival, but it leads naturally to the next chapter:
 
 # 4. Toolchain Opportunity
 
-- One Program and Checker
-- Linter without rebuild
-- Graph instead of grep
-- Patch to toolchain
+- 4.1. Compiler State
+- 4.2. @ttsc/lint
+- 4.3. @ttsc/graph
+- 4.4. From Patch to Toolchain
 
 <!--
 The final chapter is about the opportunity beyond survival.
@@ -1842,32 +1954,54 @@ So the toolchain is not just about making one command faster. It is about making
 
 ---
 
-<!-- _class: cards -->
+<!-- _class: lint-benchmark -->
 
 # 4.2. @ttsc/lint
 
-```bash
-npx tsc --noEmit
-npx eslint .
-```
-
-- Legacy cost
-  - compiler pass
-  - linter pass
-  - second type world
-- TTSC lint
-  - same Program
-  - same Checker
-  - same diagnostics stream
+<div style="background:#ffffff;border:1px solid #cbd5e1;border-radius:8px;box-shadow:0 12px 28px rgba(49,120,198,.12);box-sizing:border-box;display:grid;gap:14px;padding:22px 28px;width:100%">
+  <div style="color:#0f172a;font-size:28px;font-weight:900;line-height:1.1">Isolated lint speedup</div>
+  <div style="align-items:center;display:grid;gap:14px;grid-template-columns:130px 500px 90px;min-height:42px">
+    <div style="color:#334155;font-size:21px;font-weight:900">vscode</div>
+    <div style="background:#e2e8f0;border-radius:999px;height:24px;width:500px"><div style="background:linear-gradient(90deg,#16a34a,#2563eb);border-radius:999px;height:24px;width:244px"></div></div>
+    <div style="color:#0f172a;font-size:26px;font-weight:900;text-align:right">901x</div>
+  </div>
+  <div style="align-items:center;display:grid;gap:14px;grid-template-columns:130px 500px 90px;min-height:42px">
+    <div style="color:#334155;font-size:21px;font-weight:900">nestjs</div>
+    <div style="background:#e2e8f0;border-radius:999px;height:24px;width:500px"><div style="background:linear-gradient(90deg,#16a34a,#2563eb);border-radius:999px;height:24px;width:500px"></div></div>
+    <div style="color:#0f172a;font-size:26px;font-weight:900;text-align:right">1848x</div>
+  </div>
+  <div style="align-items:center;display:grid;gap:14px;grid-template-columns:130px 500px 90px;min-height:42px">
+    <div style="color:#334155;font-size:21px;font-weight:900">vue</div>
+    <div style="background:#e2e8f0;border-radius:999px;height:24px;width:500px"><div style="background:linear-gradient(90deg,#16a34a,#2563eb);border-radius:999px;height:24px;width:205px"></div></div>
+    <div style="color:#0f172a;font-size:26px;font-weight:900;text-align:right">757x</div>
+  </div>
+  <div style="align-items:center;display:grid;gap:14px;grid-template-columns:130px 500px 90px;min-height:42px">
+    <div style="color:#334155;font-size:21px;font-weight:900">zod</div>
+    <div style="background:#e2e8f0;border-radius:999px;height:24px;width:500px"><div style="background:linear-gradient(90deg,#16a34a,#2563eb);border-radius:999px;height:24px;width:311px"></div></div>
+    <div style="color:#0f172a;font-size:26px;font-weight:900;text-align:right">1150x</div>
+  </div>
+  <div style="align-items:center;display:grid;gap:14px;grid-template-columns:130px 500px 90px;min-height:42px">
+    <div style="color:#334155;font-size:21px;font-weight:900">rxjs</div>
+    <div style="background:#e2e8f0;border-radius:999px;height:24px;width:500px"><div style="background:linear-gradient(90deg,#16a34a,#2563eb);border-radius:999px;height:24px;width:177px"></div></div>
+    <div style="color:#0f172a;font-size:26px;font-weight:900;text-align:right">653x</div>
+  </div>
+  <div style="align-items:center;display:grid;gap:14px;grid-template-columns:130px 500px 90px;min-height:42px">
+    <div style="color:#334155;font-size:21px;font-weight:900">shopping</div>
+    <div style="background:#e2e8f0;border-radius:999px;height:24px;width:500px"><div style="background:linear-gradient(90deg,#16a34a,#2563eb);border-radius:999px;height:24px;width:158px"></div></div>
+    <div style="color:#0f172a;font-size:26px;font-weight:900;text-align:right">583x</div>
+  </div>
+</div>
 
 <!--
-Linting is the easiest example.
+Linting is the easiest performance example.
 
 In many projects, the normal path is to run tsc --noEmit for type checking and then run ESLint for linting. If ESLint uses type-aware rules, it may construct another TypeScript program or another type world.
 
-That means the repository effectively pays for semantic analysis twice. It also means diagnostics may be split across tools that do not share lifecycle, caching, or project state.
+The performance page splits lint out because the legacy path is tsc plus ESLint, while the TTSC path can report the native @ttsc/lint timing separately. The graph uses the pure lint-to-lint ratio from that split.
 
-TTSC lint takes a different approach. If TTSC already owns the Program and Checker, lint rules can run on the same compiler state and report through the same diagnostics stream. That is the basic reason the benchmark after the diagnostic example is possible.
+VS Code is no longer the only visible example. The ratio repeats across vscode, nestjs, vue, zod, rxjs, and shopping. NestJS is the largest row here at 1848x, while even the smallest row, shopping, is still 583x.
+
+For backend teams, this matters because linting is part of the same feedback loop as type checking. If the linter can ride on the compiler session that is already loaded, it becomes much easier to keep strict checks enabled locally and in CI.
 -->
 
 ---
@@ -1916,31 +2050,6 @@ That makes lint a compiler failure. The same terminal output, same CI gate, and 
 
 ---
 
-<!-- _class: metric -->
-
-# 4.2. @ttsc/lint
-
-VS Code benchmark fixture:
-
-| Tool         |      Time |
-| ------------ | --------: |
-| ESLint       | 66,700 ms |
-| `@ttsc/lint` |     74 ms |
-
-**901.4x**
-
-<!--
-This benchmark compares a lint pass on the VS Code codebase.
-
-The legacy ESLint path took about 66,700 milliseconds in this comparison. The @ttsc/lint path took 74 milliseconds for the measured pass. That produces the 901.4x ratio on the slide.
-
-The point is not that every lint rule in every repository will always be 901x faster. The point is that when a tool can reuse compiler state instead of rebuilding or reinterpreting the project, the upper bound changes dramatically.
-
-For backend teams, this matters because linting is part of the same feedback loop as type checking. If the linter can ride on the compiler session that is already loaded, it becomes much easier to keep strict checks enabled locally and in CI.
--->
-
----
-
 <!-- _class: graph-shot -->
 
 # 4.3. @ttsc/graph
@@ -1970,28 +2079,48 @@ Without this, an agent starts with grep and guesses from text. With this, the fi
 
 ---
 
-<!-- _class: metric -->
+<!-- _class: graph-token -->
 
 # 4.3. @ttsc/graph
 
-TypeORM benchmark cell:
-
-| Metric     |  Baseline |   Graph |
-| ---------- | --------: | ------: |
-| tokens     | 1,357,346 | 148,231 |
-| file reads |        16 |       0 |
-| tool calls |        38 |       1 |
-
-**9.2x fewer tokens**
+<div class="token-chart" aria-label="@ttsc/graph TypeORM agent token usage">
+  <div class="token-title">TypeORM agent token usage</div>
+  <div class="token-group">
+    <div class="token-model">Anthropic Opus <strong>9.9x fewer</strong></div>
+    <div class="token-row">
+      <div class="token-label">Baseline</div>
+      <div class="token-track" style="background: linear-gradient(90deg, #ef4444 0 100%, #e2e8f0 100% 100%)"></div>
+      <div class="token-value">1,471,202</div>
+    </div>
+    <div class="token-row">
+      <div class="token-label">Graph</div>
+      <div class="token-track" style="background: linear-gradient(90deg, #2563eb 0 10%, #e2e8f0 10% 100%)"></div>
+      <div class="token-value">148,231</div>
+    </div>
+  </div>
+  <div class="token-group">
+    <div class="token-model">OpenAI GPT <strong>4.0x fewer</strong></div>
+    <div class="token-row">
+      <div class="token-label">Baseline</div>
+      <div class="token-track" style="background: linear-gradient(90deg, #ef4444 0 100%, #e2e8f0 100% 100%)"></div>
+      <div class="token-value">586,338</div>
+    </div>
+    <div class="token-row">
+      <div class="token-label">Graph</div>
+      <div class="token-track" style="background: linear-gradient(90deg, #2563eb 0 25%, #e2e8f0 25% 100%)"></div>
+      <div class="token-value">145,493</div>
+    </div>
+  </div>
+</div>
 
 <!--
 This benchmark cell shows the practical effect on a TypeORM task.
 
-The baseline path consumed about 1.36 million tokens, performed 16 file reads, and used 38 tool calls. The graph path consumed about 148 thousand tokens, used zero direct file reads in the measured agent workflow, and completed with one graph-oriented tool call.
+The first measurement is Anthropic Opus. The baseline path consumed 1,471,202 tokens, while the graph path consumed 148,231 tokens. That is 9.9x fewer tokens.
 
-The 9.2x token reduction is the headline, but the deeper point is accuracy. When a task depends on symbol relationships, references, or diagnostics, the compiler graph is a better source than repeated text browsing.
+The second measurement is OpenAI GPT. The baseline path consumed 586,338 tokens, while the graph path consumed 145,493 tokens. That is about 4.0x fewer tokens.
 
-For large backend repositories, this changes how tool-assisted development can work. Instead of spending most of the budget discovering structure, the tool can ask the compiler for the structure and spend more effort on the actual change.
+The exact multiplier changes by model and agent behavior, but the direction is the same. When a task depends on symbol relationships, references, or diagnostics, the compiler graph reduces the amount of source browsing needed before the real change can start.
 -->
 
 ---
@@ -2077,6 +2206,30 @@ But transformer-based tools depended on an old patch point. typia, nestia, and s
 TTSC is that host, and it is also becoming more than that host. By owning compiler state, it can support transformer emit, runtime execution, editor diagnostics, linting, and graph queries in one toolchain.
 
 The outcome I want is simple: users keep writing TypeScript as the source of truth, and backend tooling moves forward instead of retreating to duplicated schemas or slower runtime interpretation.
+-->
+
+---
+
+<!-- _class: cards -->
+
+# Closing
+
+- TypeScript v7
+  - official TypeScript-Go era
+- TTSC
+  - released alongside TypeScript v7
+- Goal
+  - transformer compatibility
+  - shared compiler-state toolchain
+
+<!--
+The release target is clear.
+
+When TypeScript v7 is officially released and the TypeScript-Go direction becomes the mainstream compiler path, TTSC should be released with it.
+
+The goal is not to ship a separate experimental side project after the ecosystem has already moved. The goal is to have the transformer host and the compiler-state toolchain ready at the same moment backend teams start evaluating TypeScript v7 seriously.
+
+That is the promise: TypeScript-native APIs should not have to die because the compiler got faster.
 -->
 
 ---

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -671,7 +671,7 @@ Third, TTSC is the recovery path. At minimum, it is a transformer host for the n
 # Index
 
 1. Typia and Nestia
-2. TypeScript-Go Shock
+2. TypeScript-Go
 3. Transformer Survival
 4. Toolchain Opportunity
 
@@ -680,7 +680,11 @@ The talk has four chapters.
 
 The first chapter explains why transformers matter, using Typia and Nestia as concrete backend examples. I want everyone to see the real value before I talk about compiler internals.
 
-The second chapter is the breakage point: TypeScript-Go arrives, performance improves, and the old JavaScript patch model stops being a stable foundation.
+The second chapter starts with the good news: TypeScript-Go makes the compiler much faster, so everyday TypeScript work gets better.
+
+Then the chapter turns: the compiler implementation moves from JavaScript to Go, and the old transformer host model stops being a stable foundation.
+
+That is the breakage point. For typia and nestia, the visible TypeScript API can remain, while the generated runtime artifacts lose their engine.
 
 The third chapter explains TTSC as a survival layer. It gives transformers a new front door on top of the TypeScript-Go compiler.
 
@@ -693,9 +697,10 @@ The fourth chapter is the larger opportunity. If one tool already has the Progra
 
 # 1. Typia and Nestia
 
-- Show the code
-- Show the output
-- Then name the engine
+- Typia
+- Nestia
+- Common Engine
+- Transformer
 
 <!--
 I will begin with Typia and Nestia because they are the reason this problem matters to me.
@@ -1174,26 +1179,27 @@ That creates an important split. A new compiler can remain compatible with the T
 
 <!-- _class: lead -->
 
-# 2. TypeScript-Go Shock
+# 2. TypeScript-Go
 
-- Native compiler arrives
-- Faster is good
-- Compiler language changes
+- TypeScript-Go arrives
+- Faster compiler
+- Same language
+- Go implementation
 - Transformer host disappears
-- Typia and Nestia lose their engine
+- typia and nestia lose their engine
 
 <!--
-This is where the story turns from performance into crisis.
+This chapter starts with the upside.
 
 TypeScript-Go is exciting because the TypeScript compiler becomes much faster. For most users, that is simply good news. Faster type-checking, faster editor feedback, faster CI, and faster monorepo workflows are all wins.
 
 But speed is only half of the story. The TypeScript language stays the same, but the compiler implementation language changes. The old center was a JavaScript package running in a JavaScript process. The new center is a native Go compiler.
 
-For transformer-based projects, that creates a shock. The old patch point was not a formal cross-language plugin system. It was a JavaScript compiler implementation that JavaScript tools could patch and extend.
+That implementation change is what matters for the ecosystem. The old patch point was not a formal cross-language plugin system. It was a JavaScript compiler implementation that JavaScript tools could patch and extend.
 
 For typia and nestia, this was not a theoretical compatibility issue. The packages could still be installed. The source code could still look valid. But the generated validators, serializers, SDKs, and documents depended on a transformer host that was disappearing.
 
-That means the visible API could survive while the product engine died. That is the crisis I had to solve.
+That means the visible API could survive while the product engine died. The rest of chapter 2 is the breakdown of that failure.
 -->
 
 ---
@@ -1223,28 +1229,47 @@ That is why the language can be compatible while the transformer ecosystem break
 
 ---
 
-<!-- _class: cards -->
+<!-- _class: benchmark -->
 
 # 2.1. Native Compiler
 
-- Daily compiler cost
-  - monorepo type check
-  - watch mode
-  - editor startup
-  - CI feedback
-- Result
-  - shorter local loop
-  - shorter review loop
-  - shorter release loop
+- Same language
+  - TypeScript source stays valid
+  - everyday workflow stays familiar
+- Different engine
+  - compiler moves from JavaScript to Go
+  - this is where the speedup shows up
+
+<div class="benchmarks">
+  <div class="bench-card">
+    <div class="bench-title">VS Code type-check</div>
+    <div class="bench-row">
+      <div class="bench-name">legacy TypeScript</div>
+      <div class="bench-track">
+        <div class="bench-fill base" style="width: 100%"></div>
+      </div>
+      <div class="bench-value">73.3 s</div>
+    </div>
+    <div class="bench-row">
+      <div class="bench-name">TypeScript-Go</div>
+      <div class="bench-track">
+        <div class="bench-fill" style="width: 34.4%"></div>
+      </div>
+      <div class="bench-value">25.2 s</div>
+    </div>
+    <div class="bench-note">
+      73,293 ms vs 25,222 ms on the benchmark page. Same project, same check,
+      2.9x faster.
+    </div>
+  </div>
+</div>
 
 <!--
-Backend teams feel compiler cost every day.
+This is the upside that has to come first.
 
-A backend monorepo may type-check many packages, run watch mode while several services are changing, start the editor language service over a large dependency graph, and repeat type-checking in CI for every pull request.
+The benchmark page shows the practical payoff of TypeScript-Go on a real project. TypeScript still looks like TypeScript from the user's side, but the compiler implementation moves to Go and the wall-clock time drops.
 
-When those loops are slow, people change behavior. They run fewer checks locally. They wait longer for CI. They split feedback across multiple tools. They avoid large refactors because the verification loop is painful.
-
-So the TypeScript-Go upside is real. A faster compiler shortens the local loop, the review loop, and the release loop. The problem is not the native compiler itself. The problem is that the old transformer ecosystem was coupled to the old compiler implementation.
+The same benchmark page keeps the raw tsgo row around as a reference. That matters here because the story is not "ttsc is faster than tsc by magic." The story is that the new compiler base changes the cost of the everyday check loop.
 -->
 
 ---
@@ -1420,7 +1445,9 @@ So I chose the fourth option: build the missing host myself, on top of the TypeS
 - Replace the compiler path
 
 <!--
-Now the talk changes from crisis to response.
+This is the reversal.
+
+2장에서는 TypeScript-Go가 기존 transformer 생태계를 무너뜨렸습니다. 여기서는 그 뒤에 무엇을 했는지 보여줍니다.
 
 At this point in the story, TTSC is not a finished toolchain waiting on the shelf. The old host is disappearing, and the replacement does not exist yet.
 

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -341,154 +341,21 @@ style: |
     font-size: 19px;
     line-height: 1.2;
   }
-  section.benchmark .benchmarks {
-    display: grid;
-    gap: 12px;
-    grid-column: 2;
+  section.benchmark > p:has(img[src*="../benchmark/meetup-"]),
+  section.lint-benchmark > p:has(img[src*="../benchmark/meetup-"]),
+  section.graph-token > p:has(img[src*="../benchmark/meetup-"]) {
+    margin: 0;
   }
-  section.benchmark .bench-card {
-    background: #ffffff;
-    border: 1px solid #cbd5e1;
-    border-radius: 8px;
-    padding: 14px;
-  }
-  section.benchmark .bench-title {
-    color: #2563eb;
-    font-size: 22px;
-    font-weight: 800;
-    margin-bottom: 10px;
-  }
-  section.benchmark .bench-row {
-    align-items: center;
-    display: grid;
-    gap: 10px;
-    grid-template-columns: 150px minmax(0, 1fr) 104px;
-    margin-top: 7px;
-  }
-  section.benchmark .bench-name {
-    color: #334155;
-    font-size: 17px;
-    font-weight: 700;
-    white-space: nowrap;
-  }
-  section.benchmark .bench-value {
-    color: #0f172a;
-    font-size: 21px;
-    font-weight: 900;
-    line-height: 1;
-    text-align: right;
-    white-space: nowrap;
-  }
-  section.benchmark .bench-track {
-    background: #e2e8f0;
-    border-radius: 999px;
-    height: 22px;
-    overflow: hidden;
-  }
-  section.benchmark .bench-fill {
-    background: #2563eb;
-    border-radius: 999px;
-    height: 100%;
-  }
-  section.benchmark .bench-fill.base {
-    background: #94a3b8;
-  }
-  section.benchmark .w-base {
-    width: 8%;
-  }
-  section.benchmark .w-10 {
-    width: 36%;
-  }
-  section.benchmark .w-30 {
-    width: 48%;
-  }
-  section.benchmark .w-200 {
-    width: 64%;
-  }
-  section.benchmark .w-20000 {
-    width: 100%;
-  }
-  section.benchmark .bench-note {
-    color: #64748b;
-    font-size: 17px;
-    margin-top: 10px;
-  }
-  section.benchmark .speed-chart,
-  section.lint-benchmark .speed-chart {
+  section.benchmark > p:has(img[src*="../benchmark/meetup-"]) {
     align-self: start;
-    background: #ffffff;
-    border: 1px solid #cbd5e1;
-    border-radius: 8px;
-    box-sizing: border-box;
-    display: grid;
-    gap: 10px;
-    padding: 16px 18px 18px;
-    width: 100%;
-  }
-  section.benchmark .speed-chart {
     grid-column: 2;
   }
-  section.benchmark .speed-title,
-  section.lint-benchmark .speed-title {
-    color: #0f172a;
-    font-size: 23px;
-    font-weight: 900;
-    line-height: 1.1;
-    margin-bottom: 2px;
-  }
-  section.benchmark .speed-row,
-  section.lint-benchmark .speed-row {
-    align-items: center;
-    display: grid;
-    gap: 10px;
-    grid-template-columns: 120px minmax(0, 1fr) 64px;
-    min-height: 33px;
-  }
-  section.lint-benchmark .speed-row {
-    grid-template-columns: 120px minmax(0, 1fr) 86px;
-    min-height: 40px;
-  }
-  section.benchmark .speed-label,
-  section.lint-benchmark .speed-label {
-    color: #334155;
-    font-size: 17px;
-    font-weight: 800;
-    white-space: nowrap;
-  }
-  section.lint-benchmark .speed-label {
-    font-size: 20px;
-    font-weight: 900;
-  }
-  section.benchmark .speed-track,
-  section.lint-benchmark .speed-track {
-    background: #e2e8f0;
-    border-radius: 999px;
-    height: 18px;
-    overflow: hidden;
-  }
-  section.lint-benchmark .speed-track {
-    height: 22px;
-  }
-  section.benchmark .speed-bar,
-  section.lint-benchmark .speed-bar {
-    background: linear-gradient(90deg, #2563eb, #0f766e);
-    border-radius: 999px;
-    height: 100%;
-  }
-  section.lint-benchmark .speed-bar {
-    background: linear-gradient(90deg, #16a34a, #2563eb);
-  }
-  section.benchmark .speed-value,
-  section.lint-benchmark .speed-value {
-    color: #0f172a;
-    font-size: 20px;
-    font-weight: 900;
-    line-height: 1;
-    text-align: right;
-    white-space: nowrap;
-  }
-  section.lint-benchmark .speed-value {
-    font-size: 24px;
+  section.benchmark img[src*="../benchmark/meetup-"],
+  section.lint-benchmark img[src*="../benchmark/meetup-"],
+  section.graph-token img[src*="../benchmark/meetup-"] {
+    display: block;
+    height: auto;
+    width: 100%;
   }
   section.cards > ul {
     display: grid;
@@ -680,66 +547,6 @@ style: |
   section.graph-token h1 {
     font-size: 44px;
     margin-bottom: 18px;
-  }
-  section.graph-token .token-chart {
-    align-self: start;
-    background: #ffffff;
-    border: 1px solid #cbd5e1;
-    border-radius: 8px;
-    box-shadow: 0 12px 28px rgba(49, 120, 198, 0.12);
-    display: grid;
-    gap: 14px;
-    padding: 18px 22px 22px;
-  }
-  section.graph-token .token-title {
-    color: #0f172a;
-    font-size: 26px;
-    font-weight: 900;
-    line-height: 1.1;
-  }
-  section.graph-token .token-group {
-    border-top: 1px solid #e2e8f0;
-    display: grid;
-    gap: 8px;
-    padding-top: 12px;
-  }
-  section.graph-token .token-model {
-    align-items: baseline;
-    color: #0f172a;
-    display: flex;
-    font-size: 21px;
-    font-weight: 900;
-    gap: 14px;
-    justify-content: space-between;
-    line-height: 1;
-  }
-  section.graph-token .token-model strong {
-    color: #2563eb;
-    font-size: 24px;
-  }
-  section.graph-token .token-row {
-    align-items: center;
-    display: grid;
-    gap: 12px;
-    grid-template-columns: 100px minmax(0, 1fr) 112px;
-    min-height: 32px;
-  }
-  section.graph-token .token-label {
-    color: #334155;
-    font-size: 18px;
-    font-weight: 800;
-  }
-  section.graph-token .token-track {
-    background: #e2e8f0;
-    border-radius: 999px;
-    height: 18px;
-  }
-  section.graph-token .token-value {
-    color: #0f172a;
-    font-size: 19px;
-    font-weight: 900;
-    line-height: 1;
-    text-align: right;
   }
   section.blueprint {
     background: #0f172a;
@@ -997,35 +804,7 @@ So the transformer is doing two jobs. It captures type information before erasur
   - JSDoc
   - tags
 
-<div class="benchmarks">
-  <div class="bench-card">
-    <div class="bench-title">Runtime validation</div>
-    <div class="bench-row">
-      <div class="bench-name">class-validator</div>
-      <div class="bench-track"><div class="bench-fill base w-base"></div></div>
-      <div class="bench-value">1x</div>
-    </div>
-    <div class="bench-row">
-      <div class="bench-name">typia</div>
-      <div class="bench-track"><div class="bench-fill w-20000"></div></div>
-      <div class="bench-value">20,000x</div>
-    </div>
-  </div>
-  <div class="bench-card">
-    <div class="bench-title">JSON serialization</div>
-    <div class="bench-row">
-      <div class="bench-name">class-transformer</div>
-      <div class="bench-track"><div class="bench-fill base w-base"></div></div>
-      <div class="bench-value">1x</div>
-    </div>
-    <div class="bench-row">
-      <div class="bench-name">typia</div>
-      <div class="bench-track"><div class="bench-fill w-200"></div></div>
-      <div class="bench-value">200x</div>
-    </div>
-  </div>
-  <div class="bench-note">Log-scaled visual, comparison target = 1x.</div>
-</div>
+![](../benchmark/meetup-typia-speedup.svg)
 
 <!--
 This is why typia has such a large practical impact in backend systems.
@@ -1132,47 +911,7 @@ This is also why the transformer problem is bigger than one function call. Once 
   - E2E test functions
   - Swagger editor
 
-<div class="benchmarks">
-  <div class="bench-card">
-    <div class="bench-title">Server path</div>
-    <div class="bench-row">
-      <div class="bench-name">NestJS base</div>
-      <div class="bench-track"><div class="bench-fill base w-base"></div></div>
-      <div class="bench-value">1x</div>
-    </div>
-    <div class="bench-row">
-      <div class="bench-name">nestia</div>
-      <div class="bench-track"><div class="bench-fill w-10"></div></div>
-      <div class="bench-value">10x+</div>
-    </div>
-  </div>
-  <div class="bench-card">
-    <div class="bench-title">Validation</div>
-    <div class="bench-row">
-      <div class="bench-name">class-validator</div>
-      <div class="bench-track"><div class="bench-fill base w-base"></div></div>
-      <div class="bench-value">1x</div>
-    </div>
-    <div class="bench-row">
-      <div class="bench-name">typia core</div>
-      <div class="bench-track"><div class="bench-fill w-20000"></div></div>
-      <div class="bench-value">20,000x</div>
-    </div>
-  </div>
-  <div class="bench-card">
-    <div class="bench-title">Serialization</div>
-    <div class="bench-row">
-      <div class="bench-name">class-transformer</div>
-      <div class="bench-track"><div class="bench-fill base w-base"></div></div>
-      <div class="bench-value">1x</div>
-    </div>
-    <div class="bench-row">
-      <div class="bench-name">typia core</div>
-      <div class="bench-track"><div class="bench-fill w-200"></div></div>
-      <div class="bench-value">200x</div>
-    </div>
-  </div>
-</div>
+![](../benchmark/meetup-nestia-speedup.svg)
 
 <!--
 nestia takes the same compiler-driven idea and applies it to a larger backend workflow.
@@ -1393,44 +1132,7 @@ The key phrase is "same TypeScript, different compiler implementation." The sour
   - fixture set repeats the win
   - speed comes from the native compiler base
 
-<div class="speed-chart" aria-label="TypeScript-Go type-check speedup by project">
-  <div class="speed-title">TypeScript-Go type-check speedup</div>
-  <div class="speed-row">
-    <div class="speed-label">VS Code</div>
-    <div class="speed-track"><div class="speed-bar" style="width: 100%"></div></div>
-    <div class="speed-value">11.2x</div>
-  </div>
-  <div class="speed-row">
-    <div class="speed-label">nestjs</div>
-    <div class="speed-track"><div class="speed-bar" style="width: 40%"></div></div>
-    <div class="speed-value">4.5x</div>
-  </div>
-  <div class="speed-row">
-    <div class="speed-label">vue</div>
-    <div class="speed-track"><div class="speed-bar" style="width: 64%"></div></div>
-    <div class="speed-value">7.2x</div>
-  </div>
-  <div class="speed-row">
-    <div class="speed-label">typeorm</div>
-    <div class="speed-track"><div class="speed-bar" style="width: 68%"></div></div>
-    <div class="speed-value">7.6x</div>
-  </div>
-  <div class="speed-row">
-    <div class="speed-label">zod</div>
-    <div class="speed-track"><div class="speed-bar" style="width: 48%"></div></div>
-    <div class="speed-value">5.4x</div>
-  </div>
-  <div class="speed-row">
-    <div class="speed-label">rxjs</div>
-    <div class="speed-track"><div class="speed-bar" style="width: 37%"></div></div>
-    <div class="speed-value">4.1x</div>
-  </div>
-  <div class="speed-row">
-    <div class="speed-label">shopping</div>
-    <div class="speed-track"><div class="speed-bar" style="width: 23%"></div></div>
-    <div class="speed-value">2.6x</div>
-  </div>
-</div>
+![](../benchmark/meetup-tsgo-speedup.svg)
 
 <!--
 This is the graph that makes the upside credible.
@@ -1958,39 +1660,7 @@ So the toolchain is not just about making one command faster. It is about making
 
 # 4.2. @ttsc/lint
 
-<div style="background:#ffffff;border:1px solid #cbd5e1;border-radius:8px;box-shadow:0 12px 28px rgba(49,120,198,.12);box-sizing:border-box;display:grid;gap:14px;padding:22px 28px;width:100%">
-  <div style="color:#0f172a;font-size:28px;font-weight:900;line-height:1.1">Isolated lint speedup</div>
-  <div style="align-items:center;display:grid;gap:14px;grid-template-columns:130px 500px 90px;min-height:42px">
-    <div style="color:#334155;font-size:21px;font-weight:900">vscode</div>
-    <div style="background:#e2e8f0;border-radius:999px;height:24px;width:500px"><div style="background:linear-gradient(90deg,#16a34a,#2563eb);border-radius:999px;height:24px;width:244px"></div></div>
-    <div style="color:#0f172a;font-size:26px;font-weight:900;text-align:right">901x</div>
-  </div>
-  <div style="align-items:center;display:grid;gap:14px;grid-template-columns:130px 500px 90px;min-height:42px">
-    <div style="color:#334155;font-size:21px;font-weight:900">nestjs</div>
-    <div style="background:#e2e8f0;border-radius:999px;height:24px;width:500px"><div style="background:linear-gradient(90deg,#16a34a,#2563eb);border-radius:999px;height:24px;width:500px"></div></div>
-    <div style="color:#0f172a;font-size:26px;font-weight:900;text-align:right">1848x</div>
-  </div>
-  <div style="align-items:center;display:grid;gap:14px;grid-template-columns:130px 500px 90px;min-height:42px">
-    <div style="color:#334155;font-size:21px;font-weight:900">vue</div>
-    <div style="background:#e2e8f0;border-radius:999px;height:24px;width:500px"><div style="background:linear-gradient(90deg,#16a34a,#2563eb);border-radius:999px;height:24px;width:205px"></div></div>
-    <div style="color:#0f172a;font-size:26px;font-weight:900;text-align:right">757x</div>
-  </div>
-  <div style="align-items:center;display:grid;gap:14px;grid-template-columns:130px 500px 90px;min-height:42px">
-    <div style="color:#334155;font-size:21px;font-weight:900">zod</div>
-    <div style="background:#e2e8f0;border-radius:999px;height:24px;width:500px"><div style="background:linear-gradient(90deg,#16a34a,#2563eb);border-radius:999px;height:24px;width:311px"></div></div>
-    <div style="color:#0f172a;font-size:26px;font-weight:900;text-align:right">1150x</div>
-  </div>
-  <div style="align-items:center;display:grid;gap:14px;grid-template-columns:130px 500px 90px;min-height:42px">
-    <div style="color:#334155;font-size:21px;font-weight:900">rxjs</div>
-    <div style="background:#e2e8f0;border-radius:999px;height:24px;width:500px"><div style="background:linear-gradient(90deg,#16a34a,#2563eb);border-radius:999px;height:24px;width:177px"></div></div>
-    <div style="color:#0f172a;font-size:26px;font-weight:900;text-align:right">653x</div>
-  </div>
-  <div style="align-items:center;display:grid;gap:14px;grid-template-columns:130px 500px 90px;min-height:42px">
-    <div style="color:#334155;font-size:21px;font-weight:900">shopping</div>
-    <div style="background:#e2e8f0;border-radius:999px;height:24px;width:500px"><div style="background:linear-gradient(90deg,#16a34a,#2563eb);border-radius:999px;height:24px;width:158px"></div></div>
-    <div style="color:#0f172a;font-size:26px;font-weight:900;text-align:right">583x</div>
-  </div>
-</div>
+![](../benchmark/meetup-lint-speedup.svg)
 
 <!--
 Linting is the easiest performance example.
@@ -2083,35 +1753,7 @@ Without this, an agent starts with grep and guesses from text. With this, the fi
 
 # 4.3. @ttsc/graph
 
-<div class="token-chart" aria-label="@ttsc/graph TypeORM agent token usage">
-  <div class="token-title">TypeORM agent token usage</div>
-  <div class="token-group">
-    <div class="token-model">Anthropic Opus <strong>9.9x fewer</strong></div>
-    <div class="token-row">
-      <div class="token-label">Baseline</div>
-      <div class="token-track" style="background: linear-gradient(90deg, #ef4444 0 100%, #e2e8f0 100% 100%)"></div>
-      <div class="token-value">1,471,202</div>
-    </div>
-    <div class="token-row">
-      <div class="token-label">Graph</div>
-      <div class="token-track" style="background: linear-gradient(90deg, #2563eb 0 10%, #e2e8f0 10% 100%)"></div>
-      <div class="token-value">148,231</div>
-    </div>
-  </div>
-  <div class="token-group">
-    <div class="token-model">OpenAI GPT <strong>4.0x fewer</strong></div>
-    <div class="token-row">
-      <div class="token-label">Baseline</div>
-      <div class="token-track" style="background: linear-gradient(90deg, #ef4444 0 100%, #e2e8f0 100% 100%)"></div>
-      <div class="token-value">586,338</div>
-    </div>
-    <div class="token-row">
-      <div class="token-label">Graph</div>
-      <div class="token-track" style="background: linear-gradient(90deg, #2563eb 0 25%, #e2e8f0 25% 100%)"></div>
-      <div class="token-value">145,493</div>
-    </div>
-  </div>
-</div>
+![](../benchmark/meetup-graph-token-usage.svg)
 
 <!--
 This benchmark cell shows the practical effect on a TypeORM task.

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -413,6 +413,55 @@ style: |
     font-size: 17px;
     margin-top: 10px;
   }
+  section.benchmark .speed-chart {
+    align-self: start;
+    background: #ffffff;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    display: grid;
+    gap: 10px;
+    grid-column: 2;
+    padding: 16px 18px 18px;
+  }
+  section.benchmark .speed-title {
+    color: #0f172a;
+    font-size: 23px;
+    font-weight: 900;
+    line-height: 1.1;
+    margin-bottom: 2px;
+  }
+  section.benchmark .speed-row {
+    align-items: center;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 120px minmax(0, 1fr) 64px;
+    min-height: 33px;
+  }
+  section.benchmark .speed-label {
+    color: #334155;
+    font-size: 17px;
+    font-weight: 800;
+    white-space: nowrap;
+  }
+  section.benchmark .speed-track {
+    background: #e2e8f0;
+    border-radius: 999px;
+    height: 18px;
+    overflow: hidden;
+  }
+  section.benchmark .speed-bar {
+    background: linear-gradient(90deg, #2563eb, #0f766e);
+    border-radius: 999px;
+    height: 100%;
+  }
+  section.benchmark .speed-value {
+    color: #0f172a;
+    font-size: 20px;
+    font-weight: 900;
+    line-height: 1;
+    text-align: right;
+    white-space: nowrap;
+  }
   section.cards > ul {
     display: grid;
     gap: 18px;
@@ -1240,18 +1289,44 @@ That is why the language can be compatible while the transformer ecosystem break
   - compiler moves from JavaScript to Go
   - this is where the speedup shows up
 
-<div class="mermaid">
-xychart-beta
-  title "TypeScript-Go type-check speedup"
-  x-axis [vscode, nestjs, vue, typeorm, zod, rxjs, shopping]
-  y-axis "speedup (x)" 0 --> 12
-  bar [11.2, 4.5, 7.2, 7.6, 5.4, 4.1, 2.6]
+<div class="speed-chart" aria-label="TypeScript-Go type-check speedup by project">
+  <div class="speed-title">TypeScript-Go type-check speedup</div>
+  <div class="speed-row">
+    <div class="speed-label">VS Code</div>
+    <div class="speed-track"><div class="speed-bar" style="width: 100%"></div></div>
+    <div class="speed-value">11.2x</div>
+  </div>
+  <div class="speed-row">
+    <div class="speed-label">nestjs</div>
+    <div class="speed-track"><div class="speed-bar" style="width: 40%"></div></div>
+    <div class="speed-value">4.5x</div>
+  </div>
+  <div class="speed-row">
+    <div class="speed-label">vue</div>
+    <div class="speed-track"><div class="speed-bar" style="width: 64%"></div></div>
+    <div class="speed-value">7.2x</div>
+  </div>
+  <div class="speed-row">
+    <div class="speed-label">typeorm</div>
+    <div class="speed-track"><div class="speed-bar" style="width: 68%"></div></div>
+    <div class="speed-value">7.6x</div>
+  </div>
+  <div class="speed-row">
+    <div class="speed-label">zod</div>
+    <div class="speed-track"><div class="speed-bar" style="width: 48%"></div></div>
+    <div class="speed-value">5.4x</div>
+  </div>
+  <div class="speed-row">
+    <div class="speed-label">rxjs</div>
+    <div class="speed-track"><div class="speed-bar" style="width: 37%"></div></div>
+    <div class="speed-value">4.1x</div>
+  </div>
+  <div class="speed-row">
+    <div class="speed-label">shopping</div>
+    <div class="speed-track"><div class="speed-bar" style="width: 23%"></div></div>
+    <div class="speed-value">2.6x</div>
+  </div>
 </div>
-
-<script type="module">
-  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
-  mermaid.initialize({ startOnLoad: true });
-</script>
 
 <!--
 This is the upside that has to come first.

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -1780,7 +1780,7 @@ In many projects, the normal path is to run tsc --noEmit for type checking and t
 
 That means the repository effectively pays for semantic analysis twice. It also means diagnostics may be split across tools that do not share lifecycle, caching, or project state.
 
-TTSC lint takes a different approach. If TTSC already owns the Program and Checker, lint rules can run on the same compiler state and report through the same diagnostics stream. That is the basic reason the benchmark on the next slide is possible.
+TTSC lint takes a different approach. If TTSC already owns the Program and Checker, lint rules can run on the same compiler state and report through the same diagnostics stream. That is the basic reason the benchmark after the diagnostic example is possible.
 -->
 
 ---

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -722,15 +722,11 @@ The important point is that the user experience stays TypeScript-native. The use
 //----
 // TypeScript
 //----
-const isBoolean = typia.createIs<boolean>();
-const isNumber = typia.createIs<number>();
 const isString = typia.createIs<string>();
 
 //----
 // JavaScript (Compiled)
 //----
-const isBoolean = (input) => "boolean" === typeof input;
-const isNumber = (input) => "number" === typeof input;
 const isString = (input) => "string" === typeof input;
 ```
 

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -1294,18 +1294,17 @@ That is why the language can be compatible while the transformer ecosystem break
       <div class="bench-track">
         <div class="bench-fill base" style="width: 100%"></div>
       </div>
-      <div class="bench-value">73.3 s</div>
+      <div class="bench-value">1.0x</div>
     </div>
     <div class="bench-row">
       <div class="bench-name">TypeScript-Go (8 checkers)</div>
       <div class="bench-track">
         <div class="bench-fill" style="width: 8.9%"></div>
       </div>
-      <div class="bench-value">6.54 s</div>
+      <div class="bench-value">11.2x</div>
     </div>
     <div class="bench-note">
-      73,293 ms vs 6,544 ms on the benchmark page. Same project, same check,
-      11.2x faster.
+      11.2x
     </div>
   </div>
 </div>
@@ -1330,84 +1329,84 @@ The same benchmark page keeps the raw tsgo row around as a reference. That matte
     <div class="bench-row">
       <div class="bench-name">legacy TypeScript</div>
       <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
-      <div class="bench-value">73.3 s</div>
+      <div class="bench-value">1.0x</div>
     </div>
     <div class="bench-row">
       <div class="bench-name">TypeScript-Go (8)</div>
       <div class="bench-track"><div class="bench-fill" style="width: 8.9%"></div></div>
-      <div class="bench-value">6.54 s</div>
+      <div class="bench-value">11.2x</div>
     </div>
-    <div class="bench-note">11.2x faster</div>
+    <div class="bench-note">11.2x</div>
   </div>
   <div class="bench-card">
     <div class="bench-title">nestjs</div>
     <div class="bench-row">
       <div class="bench-name">legacy TypeScript</div>
       <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
-      <div class="bench-value">19.2 s</div>
+      <div class="bench-value">1.0x</div>
     </div>
     <div class="bench-row">
       <div class="bench-name">TypeScript-Go (8)</div>
       <div class="bench-track"><div class="bench-fill" style="width: 22.1%"></div></div>
-      <div class="bench-value">4.24 s</div>
+      <div class="bench-value">4.5x</div>
     </div>
-    <div class="bench-note">4.5x faster</div>
+    <div class="bench-note">4.5x</div>
   </div>
   <div class="bench-card">
     <div class="bench-title">vue</div>
     <div class="bench-row">
       <div class="bench-name">legacy TypeScript</div>
       <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
-      <div class="bench-value">13.1 s</div>
+      <div class="bench-value">1.0x</div>
     </div>
     <div class="bench-row">
       <div class="bench-name">TypeScript-Go (8)</div>
       <div class="bench-track"><div class="bench-fill" style="width: 13.9%"></div></div>
-      <div class="bench-value">1.82 s</div>
+      <div class="bench-value">7.2x</div>
     </div>
-    <div class="bench-note">7.2x faster</div>
+    <div class="bench-note">7.2x</div>
   </div>
   <div class="bench-card">
     <div class="bench-title">typeorm</div>
     <div class="bench-row">
       <div class="bench-name">legacy TypeScript</div>
       <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
-      <div class="bench-value">11.9 s</div>
+      <div class="bench-value">1.0x</div>
     </div>
     <div class="bench-row">
       <div class="bench-name">TypeScript-Go (8)</div>
       <div class="bench-track"><div class="bench-fill" style="width: 13.1%"></div></div>
-      <div class="bench-value">1.56 s</div>
+      <div class="bench-value">7.6x</div>
     </div>
-    <div class="bench-note">7.6x faster</div>
+    <div class="bench-note">7.6x</div>
   </div>
   <div class="bench-card">
     <div class="bench-title">zod</div>
     <div class="bench-row">
       <div class="bench-name">legacy TypeScript</div>
       <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
-      <div class="bench-value">10.0 s</div>
+      <div class="bench-value">1.0x</div>
     </div>
     <div class="bench-row">
       <div class="bench-name">TypeScript-Go (8)</div>
       <div class="bench-track"><div class="bench-fill" style="width: 18.5%"></div></div>
-      <div class="bench-value">1.85 s</div>
+      <div class="bench-value">5.4x</div>
     </div>
-    <div class="bench-note">5.4x faster</div>
+    <div class="bench-note">5.4x</div>
   </div>
   <div class="bench-card">
     <div class="bench-title">rxjs</div>
     <div class="bench-row">
       <div class="bench-name">legacy TypeScript</div>
       <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
-      <div class="bench-value">8.35 s</div>
+      <div class="bench-value">1.0x</div>
     </div>
     <div class="bench-row">
       <div class="bench-name">TypeScript-Go (8)</div>
       <div class="bench-track"><div class="bench-fill" style="width: 24.5%"></div></div>
-      <div class="bench-value">2.04 s</div>
+      <div class="bench-value">4.1x</div>
     </div>
-    <div class="bench-note">4.1x faster</div>
+    <div class="bench-note">4.1x</div>
   </div>
   <p class="bench-note bench-summary">
     shopping-backend has no comparable `tsgo` noEmit row in the published snapshot,

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -413,6 +413,52 @@ style: |
     font-size: 17px;
     margin-top: 10px;
   }
+  section.benchmark-grid {
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: auto repeat(3, minmax(0, 1fr)) auto;
+    padding: 48px 50px;
+  }
+  section.benchmark-grid h1 {
+    font-size: 42px;
+    grid-column: 1 / -1;
+    margin-bottom: 0;
+  }
+  section.benchmark-grid .benchmarks {
+    display: contents;
+    grid-column: 1 / -1;
+  }
+  section.benchmark-grid .bench-card {
+    padding: 12px;
+  }
+  section.benchmark-grid .bench-title {
+    font-size: 18px;
+    margin-bottom: 8px;
+  }
+  section.benchmark-grid .bench-row {
+    grid-template-columns: 126px minmax(0, 1fr) 82px;
+    gap: 8px;
+    margin-top: 6px;
+  }
+  section.benchmark-grid .bench-name {
+    font-size: 14px;
+  }
+  section.benchmark-grid .bench-value {
+    font-size: 16px;
+  }
+  section.benchmark-grid .bench-track {
+    height: 14px;
+  }
+  section.benchmark-grid .bench-note {
+    font-size: 12px;
+    line-height: 1.2;
+    margin-top: 8px;
+  }
+  section.benchmark-grid .bench-summary {
+    grid-column: 1 / -1;
+    margin-top: 0;
+  }
   section.cards > ul {
     display: grid;
     gap: 18px;
@@ -1181,8 +1227,8 @@ That creates an important split. A new compiler can remain compatible with the T
 
 # 2. TypeScript-Go
 
-- TypeScript-Go arrives
-- Faster compiler
+- Native compiler
+- Faster benchmark
 - Same language
 - Go implementation
 - Transformer host disappears
@@ -1251,15 +1297,15 @@ That is why the language can be compatible while the transformer ecosystem break
       <div class="bench-value">73.3 s</div>
     </div>
     <div class="bench-row">
-      <div class="bench-name">TypeScript-Go</div>
+      <div class="bench-name">TypeScript-Go (8 checkers)</div>
       <div class="bench-track">
-        <div class="bench-fill" style="width: 34.4%"></div>
+        <div class="bench-fill" style="width: 8.9%"></div>
       </div>
-      <div class="bench-value">25.2 s</div>
+      <div class="bench-value">6.54 s</div>
     </div>
     <div class="bench-note">
-      73,293 ms vs 25,222 ms on the benchmark page. Same project, same check,
-      2.9x faster.
+      73,293 ms vs 6,544 ms on the benchmark page. Same project, same check,
+      11.2x faster.
     </div>
   </div>
 </div>
@@ -1270,6 +1316,111 @@ This is the upside that has to come first.
 The benchmark page shows the practical payoff of TypeScript-Go on a real project. TypeScript still looks like TypeScript from the user's side, but the compiler implementation moves to Go and the wall-clock time drops.
 
 The same benchmark page keeps the raw tsgo row around as a reference. That matters here because the story is not "ttsc is faster than tsc by magic." The story is that the new compiler base changes the cost of the everyday check loop.
+-->
+
+---
+
+<!-- _class: benchmark-grid -->
+
+# 2.1. Native Compiler
+
+<div class="benchmarks">
+  <div class="bench-card">
+    <div class="bench-title">vscode</div>
+    <div class="bench-row">
+      <div class="bench-name">legacy TypeScript</div>
+      <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
+      <div class="bench-value">73.3 s</div>
+    </div>
+    <div class="bench-row">
+      <div class="bench-name">TypeScript-Go (8)</div>
+      <div class="bench-track"><div class="bench-fill" style="width: 8.9%"></div></div>
+      <div class="bench-value">6.54 s</div>
+    </div>
+    <div class="bench-note">11.2x faster</div>
+  </div>
+  <div class="bench-card">
+    <div class="bench-title">nestjs</div>
+    <div class="bench-row">
+      <div class="bench-name">legacy TypeScript</div>
+      <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
+      <div class="bench-value">19.2 s</div>
+    </div>
+    <div class="bench-row">
+      <div class="bench-name">TypeScript-Go (8)</div>
+      <div class="bench-track"><div class="bench-fill" style="width: 22.1%"></div></div>
+      <div class="bench-value">4.24 s</div>
+    </div>
+    <div class="bench-note">4.5x faster</div>
+  </div>
+  <div class="bench-card">
+    <div class="bench-title">vue</div>
+    <div class="bench-row">
+      <div class="bench-name">legacy TypeScript</div>
+      <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
+      <div class="bench-value">13.1 s</div>
+    </div>
+    <div class="bench-row">
+      <div class="bench-name">TypeScript-Go (8)</div>
+      <div class="bench-track"><div class="bench-fill" style="width: 13.9%"></div></div>
+      <div class="bench-value">1.82 s</div>
+    </div>
+    <div class="bench-note">7.2x faster</div>
+  </div>
+  <div class="bench-card">
+    <div class="bench-title">typeorm</div>
+    <div class="bench-row">
+      <div class="bench-name">legacy TypeScript</div>
+      <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
+      <div class="bench-value">11.9 s</div>
+    </div>
+    <div class="bench-row">
+      <div class="bench-name">TypeScript-Go (8)</div>
+      <div class="bench-track"><div class="bench-fill" style="width: 13.1%"></div></div>
+      <div class="bench-value">1.56 s</div>
+    </div>
+    <div class="bench-note">7.6x faster</div>
+  </div>
+  <div class="bench-card">
+    <div class="bench-title">zod</div>
+    <div class="bench-row">
+      <div class="bench-name">legacy TypeScript</div>
+      <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
+      <div class="bench-value">10.0 s</div>
+    </div>
+    <div class="bench-row">
+      <div class="bench-name">TypeScript-Go (8)</div>
+      <div class="bench-track"><div class="bench-fill" style="width: 18.5%"></div></div>
+      <div class="bench-value">1.85 s</div>
+    </div>
+    <div class="bench-note">5.4x faster</div>
+  </div>
+  <div class="bench-card">
+    <div class="bench-title">rxjs</div>
+    <div class="bench-row">
+      <div class="bench-name">legacy TypeScript</div>
+      <div class="bench-track"><div class="bench-fill base" style="width: 100%"></div></div>
+      <div class="bench-value">8.35 s</div>
+    </div>
+    <div class="bench-row">
+      <div class="bench-name">TypeScript-Go (8)</div>
+      <div class="bench-track"><div class="bench-fill" style="width: 24.5%"></div></div>
+      <div class="bench-value">2.04 s</div>
+    </div>
+    <div class="bench-note">4.1x faster</div>
+  </div>
+  <p class="bench-note bench-summary">
+    shopping-backend has no comparable `tsgo` noEmit row in the published snapshot,
+    so it is omitted from this direct type-check comparison.
+  </p>
+</div>
+
+<!--
+This is the same benchmark story stretched across the whole page.
+
+Every card is one project from the public benchmark page. The important thing is that the speedup is not a single VS Code anecdote. It repeats across the benchmark set, with the exact `checkers8` row varying by project but always pointing in the same direction.
+
+The one omission is shopping-backend, because the current snapshot does not carry a direct tsgo noEmit row for it. That is a data limitation, not a design change.
 -->
 
 ---

--- a/website/public/presentations/20260626-ts-backend-meetup.md
+++ b/website/public/presentations/20260626-ts-backend-meetup.md
@@ -50,6 +50,10 @@ style: |
   section.lead::after {
     color: rgba(255, 255, 255, 0.86) !important;
   }
+  section.lead a {
+    color: #fde047 !important;
+    font-weight: 400;
+  }
   h1 {
     color: #102a43;
     font-size: 54px;
@@ -229,6 +233,84 @@ style: |
     font-size: 20px;
     line-height: 1.26;
     padding: 14px;
+  }
+  section.lint-example {
+    column-gap: 20px;
+    display: grid;
+    grid-template-columns: 0.7fr 1.3fr;
+    grid-template-rows: auto auto auto minmax(0, 1fr);
+    padding: 38px 48px 46px;
+    row-gap: 12px;
+  }
+  section.lint-example h1 {
+    font-size: 42px;
+    grid-column: 1 / -1;
+    margin-bottom: 0;
+  }
+  section.lint-example .lint-concept {
+    display: grid;
+    gap: 10px;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    grid-template-columns: repeat(3, 1fr);
+  }
+  section.lint-example .lint-concept > div {
+    background: #f8fafc;
+    border: 1px solid #cbd5e1;
+    border-left: 6px solid #3178c6;
+    border-radius: 8px;
+    padding: 10px 12px;
+  }
+  section.lint-example .lint-concept strong {
+    display: block;
+    font-size: 18px;
+    line-height: 1.08;
+    margin-bottom: 4px;
+  }
+  section.lint-example .lint-concept span {
+    color: #334155;
+    display: block;
+    font-size: 15px;
+    line-height: 1.18;
+  }
+  section.lint-example .lint-label {
+    align-self: end;
+    background: #dbeafe;
+    border: 1px solid #93c5fd;
+    border-radius: 8px 8px 0 0;
+    color: #102a43;
+    font-size: 16px;
+    font-weight: 800;
+    grid-row: 3;
+    letter-spacing: 0;
+    line-height: 1;
+    padding: 8px 12px;
+  }
+  section.lint-example .source-label {
+    grid-column: 1;
+  }
+  section.lint-example .terminal-label {
+    grid-column: 2;
+  }
+  section.lint-example > pre {
+    align-self: start;
+    border-radius: 0 0 8px 8px;
+    min-width: 0;
+    overflow: hidden;
+    padding: 14px;
+  }
+  section.lint-example > pre:nth-of-type(1) {
+    font-size: 17px;
+    grid-column: 1;
+    grid-row: 4;
+    line-height: 1.34;
+  }
+  section.lint-example > pre:nth-of-type(2) {
+    font-size: 14px;
+    grid-column: 2;
+    grid-row: 4;
+    line-height: 1.16;
+    white-space: pre-wrap;
   }
   section.benchmark {
     column-gap: 30px;
@@ -462,6 +544,48 @@ style: |
     font-weight: 500;
     line-height: 1.25;
   }
+  section.graph-shot {
+    column-gap: 26px;
+    display: grid;
+    grid-template-columns: 0.52fr 1.48fr;
+    grid-template-rows: auto minmax(0, 1fr);
+    padding: 48px 52px;
+  }
+  section.graph-shot h1 {
+    font-size: 44px;
+    grid-column: 1 / -1;
+    margin-bottom: 18px;
+  }
+  section.graph-shot > ul {
+    align-self: start;
+    background: #f8fafc;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    grid-column: 1;
+    margin: 0;
+    padding: 16px 18px 16px 34px;
+  }
+  section.graph-shot > ul > li {
+    font-size: 21px;
+    font-weight: 800;
+    line-height: 1.22;
+  }
+  section.graph-shot > ul li li {
+    color: #334155;
+    font-size: 17px;
+    font-weight: 500;
+    line-height: 1.18;
+  }
+  section.graph-shot img {
+    align-self: start;
+    border: 1px solid #1e293b;
+    border-radius: 8px;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.22);
+    grid-column: 2;
+    max-height: 492px;
+    object-fit: contain;
+    width: 100%;
+  }
   section.blueprint {
     background: #0f172a;
     box-shadow: inset 0 8px 0 #3178c6;
@@ -585,7 +709,44 @@ The important point is that the user experience stays TypeScript-native. The use
 
 <!-- _class: code-split -->
 
-# 1.1. typia Source
+# 1.1. Typia
+
+- Generic call
+  - type argument
+  - erased later
+- Compiler output
+  - direct predicate
+  - plain JavaScript
+
+```typescript
+//----
+// TypeScript
+//----
+const isBoolean = typia.createIs<boolean>();
+const isNumber = typia.createIs<number>();
+const isString = typia.createIs<string>();
+
+//----
+// JavaScript (Compiled)
+//----
+const isBoolean = (input) => "boolean" === typeof input;
+const isNumber = (input) => "number" === typeof input;
+const isString = (input) => "string" === typeof input;
+```
+
+<!--
+Before the larger IMember example, this is the smallest shape of the idea.
+
+On the TypeScript side, the user writes a generic function call. The type argument is string, and the call sits on the right-hand side of an ordinary assignment.
+
+On the JavaScript side, the generic call is gone. The generated value is a direct predicate. This is the whole point of typia in the smallest possible form: read the type before erasure, then emit plain JavaScript.
+-->
+
+---
+
+<!-- _class: code-split -->
+
+# 1.1. Typia
 
 - User writes
   - TS type
@@ -626,7 +787,7 @@ Then the user calls typia.createIs<IMember>(). At runtime, TypeScript types are 
 
 <!-- _class: code-split -->
 
-# 1.1. typia Output
+# 1.1. Typia
 
 - Compiler emits
   - UUID check
@@ -665,7 +826,7 @@ So the transformer is doing two jobs. It captures type information before erasur
 
 <!-- _class: benchmark -->
 
-# 1.1. typia Impact
+# 1.1. Typia
 
 - Runtime validation
   - **20,000x**
@@ -724,7 +885,7 @@ The numbers on the slide are intentionally simple: validation can reach the 20,0
 
 <!-- _class: code-split -->
 
-# 1.2. nestia Source
+# 1.2. Nestia
 
 - Backend code
   - path
@@ -762,7 +923,7 @@ That is the important design choice. The controller is not merely implementation
 
 <!-- _class: code-split -->
 
-# 1.2. nestia Output
+# 1.2. Nestia
 
 - Generated SDK
   - typed fetch
@@ -798,7 +959,7 @@ This is also why the transformer problem is bigger than one function call. Once 
 
 <!-- _class: benchmark -->
 
-# 1.2. nestia Impact
+# 1.2. Nestia
 
 - Server performance
   - **10x+** total path
@@ -869,21 +1030,19 @@ So the lesson is not "nestia is a faster router." The lesson is that once TypeSc
 
 ---
 
-# 1.3. What You Just Saw
+# 1.3. Common Engine
 
 - typia
   - TypeScript type
-  - runtime validator
+  - Runtime validator
   - JSON serializer
   - LLM schema
 - nestia
   - NestJS controller
-  - runtime boundary
+  - Runtime boundary
   - client SDK
   - OpenAPI document
-- Same shape
-  - compiler analysis
-  - generated artifacts
+- Same shape: compiler analysis, generated artifacts
 
 <!--
 Let us summarize the pattern before going deeper.
@@ -897,7 +1056,7 @@ That common shape is why the compiler host matters. If the compiler cannot expos
 
 ---
 
-# 1.3. The Common Engine
+# 1.3. Common Engine
 
 - Input
   - TypeScript source
@@ -909,11 +1068,6 @@ That common shape is why the compiler host matters. If the compiler cannot expos
   - Checker
   - symbols
   - diagnostics
-- Output
-  - JavaScript
-  - schemas
-  - SDK
-  - OpenAPI
 
 <!--
 The common engine has three layers.
@@ -927,7 +1081,7 @@ The output layer is where product value appears: JavaScript emit, JSON schemas, 
 
 ---
 
-# 1.4. Now: Transformer
+# 1.4. Transformer
 
 - Transformer
   - compile-time code generation
@@ -936,7 +1090,7 @@ The output layer is where product value appears: JavaScript emit, JSON schemas, 
   - source file
   - AST
   - Checker
-- Rewrites
+- Re-writes
   - JavaScript emit
   - diagnostics
   - generated artifacts
@@ -953,7 +1107,50 @@ The critical requirement is timing. The transformer must run while the compiler 
 
 ---
 
-# 1.4. Hidden Dependency
+<!-- _class: code-split -->
+
+# 1.4. Transformer
+
+- Project setup
+  - install `ts-patch`
+  - hack TypeScript
+- Compiler config
+  - transformer path
+
+```jsonc
+// tsconfig.json
+{
+  "compilerOptions": {
+    "plugins": [
+      { "transform": "typia/lib/transform" },
+      { "transform": "@nestia/core/lib/transform" },
+      { "transform": "@nestia/sdk/lib/transform" }
+    ]
+  }
+}
+
+// package.json
+{
+  "scripts": {
+    "prepare": "ts-patch install"
+  },
+  "devDependencies": {
+    "ts-patch": "^3.2.1"
+  }
+}
+```
+
+<!--
+This is the part that must be visible before the TypeScript-Go story.
+
+In the old setup, using a transformer was more than a library import. The project installed ts-patch, registered transformer module paths in tsconfig, and put ts-patch install into the package lifecycle so the local TypeScript package was patched again after install.
+
+That means the working model depended on mutating the installed TypeScript package. It was a practical hack: make TypeScript load transformer modules during compilation, then typia and nestia can run before type erasure.
+-->
+
+---
+
+# 1.4. Transformer
 
 - Public API
   - still TypeScript
@@ -985,17 +1182,22 @@ That creates an important split. A new compiler can remain compatible with the T
 
 - Native compiler arrives
 - Faster is good
-- Patch point dies
-- My projects are at risk
+- Compiler language changes
+- Transformer host disappears
+- Typia and Nestia lose their engine
 
 <!--
-This is the transition point of the talk.
+This is where the story turns from performance into crisis.
 
 TypeScript-Go is exciting because the TypeScript compiler becomes much faster. For most users, that is simply good news. Faster type-checking, faster editor feedback, faster CI, and faster monorepo workflows are all wins.
 
-But for transformer-based projects, the same move creates a shock. The old patch point was not a formal cross-language plugin system. It was a JavaScript compiler implementation that JavaScript tools could patch and extend.
+But speed is only half of the story. The TypeScript language stays the same, but the compiler implementation language changes. The old center was a JavaScript package running in a JavaScript process. The new center is a native Go compiler.
 
-So my reaction was mixed. I wanted the faster compiler, but I also had to protect typia, nestia, and the wider transformer ecosystem that depended on the old host model.
+For transformer-based projects, that creates a shock. The old patch point was not a formal cross-language plugin system. It was a JavaScript compiler implementation that JavaScript tools could patch and extend.
+
+For typia and nestia, this was not a theoretical compatibility issue. The packages could still be installed. The source code could still look valid. But the generated validators, serializers, SDKs, and documents depended on a transformer host that was disappearing.
+
+That means the visible API could survive while the product engine died. That is the crisis I had to solve.
 -->
 
 ---
@@ -1004,31 +1206,30 @@ So my reaction was mixed. I wanted the faster compiler, but I also had to protec
 
 # 2.1. Native Compiler
 
-- TypeScript 7.0 RC
-  - JavaScript compiler to Go compiler
-  - native compiler and language service
-- Performance
-  - shared-memory parallelism
-  - about **10x** faster than TypeScript 6.0
-- User story
-  - same language
-  - faster loop
+- What stays
+  - TypeScript language
+  - project source code
+- What changes
+  - compiler implementation language
+  - JavaScript process to Go process
+- Why it matters
+  - old plugins lived in JavaScript
 
 <!--
-The native compiler story is straightforward from the user's side.
+The native compiler story has two sides.
 
-TypeScript 7.0 moves the compiler and language service direction toward a Go implementation. The public promise is that the same TypeScript language gets a much faster compiler foundation.
+From the user's side, TypeScript source code remains TypeScript. The type system, syntax, project files, and everyday programming model are supposed to remain familiar.
 
-The key performance reason is that the native implementation can use shared-memory parallelism and lower-level runtime behavior more effectively than the old JavaScript implementation. The headline is about a 10x improvement compared with the TypeScript 6.0 era.
+From the tool author's side, the implementation language changes. The old compiler was a JavaScript package running in a JavaScript process. TypeScript-Go moves that center into a native Go compiler and language service.
 
-For a normal developer, there is no complicated story here. The same project should eventually feel much faster. That is exactly why this matters: if the whole ecosystem moves to the faster compiler, transformer tools must find a way to move with it.
+That is why the language can be compatible while the transformer ecosystem breaks. The source language is the same, but the process that plugins used to live inside is not the same process anymore.
 -->
 
 ---
 
 <!-- _class: cards -->
 
-# 2.1. Backend Upside
+# 2.1. Native Compiler
 
 - Daily compiler cost
   - monorepo type check
@@ -1054,7 +1255,7 @@ So the TypeScript-Go upside is real. A faster compiler shortens the local loop, 
 
 <!-- _class: cards three -->
 
-# 2.2. Old Assumption
+# 2.2. Patch Model
 
 - Old compiler
   - JavaScript package
@@ -1105,7 +1306,7 @@ But it worked for one basic reason: the compiler and the transformer lived in th
 
 ---
 
-# 2.3. Old Setup
+# 2.3. Broken Assumption
 
 ```json
 {
@@ -1159,39 +1360,39 @@ This is why I describe the problem as plugin compatibility, not language compati
 # 2.4. Project Risk
 
 - typia risk
-  - erased types unseen
-  - validators not generated
-  - serializers not generated
+  - type erasure wins
+  - validators disappear
+  - serializers disappear
 - nestia risk
-  - controllers not extracted
-  - SDK not generated
-  - OpenAPI not generated
-- Business risk
-  - public APIs survive
-  - engine disappears
+  - controller facts lost
+  - SDK disappears
+  - OpenAPI disappears
+- Product risk
+  - npm API remains
+  - generated value gone
 
 <!--
-For my projects, this was not an abstract ecosystem concern.
+For my projects, this was the concrete failure mode.
 
-typia depends on seeing erased types before they disappear. If the transformer path dies, validators and serializers are not generated. The user still has the same source code, but the runtime code that made it useful is missing.
+typia depends on seeing erased types before they disappear. If the transformer path dies, type erasure wins. The user still writes typia.createIs<T>(), but the specialized validator and serializer code is not produced.
 
-nestia depends on extracting controller contracts. If that path dies, SDK generation, OpenAPI generation, mockup generation, and E2E helpers are at risk. Again, the public API can look alive while the engine underneath is gone.
+nestia depends on extracting controller contracts. If that path dies, SDK generation, OpenAPI generation, mockup generation, and E2E helpers lose the source of truth that made them safe.
 
-That is a real business risk. Users depend on stable package APIs, but those APIs are backed by compiler integration. If the compiler integration is removed, the visible surface becomes misleading.
+That is why the risk felt severe. This is not a small regression or a slower implementation. The npm package can remain, the TypeScript code can remain, and the core value can still disappear.
 -->
 
 ---
 
 <!-- _class: cards choice -->
 
-# 2.4. Options
+# 2.4. Project Risk
 
 - Wait
   - upstream plugin model
   - unknown timeline
 - Retreat
   - runtime schemas
-  - weaker compiler magic
+  - give up source of truth
 - Drop features
   - no transformer path
   - no generated boundary
@@ -1202,13 +1403,13 @@ That is a real business risk. Users depend on stable package APIs, but those API
 <!--
 There were four possible responses.
 
-The first option was to wait for an upstream plugin model. That may eventually happen, but the timeline and shape were unknown. Waiting is risky when your products depend on this path today.
+The first option was to wait for an upstream plugin model. That may eventually happen, but the timeline and shape were unknown. Waiting meant accepting a dead zone for products that needed this path today.
 
 The second option was to retreat to runtime schemas. That would avoid the transformer problem, but it would also give up the main value proposition: using TypeScript itself as the source of truth.
 
 The third option was to drop features. That would keep the packages simpler, but it would break the reason many users chose them.
 
-So I chose the fourth option: build a new host on top of the TypeScript-Go direction. That host is TTSC.
+So I chose the fourth option: build the missing host myself, on top of the TypeScript-Go direction. That host is TTSC.
 -->
 
 ---
@@ -1217,17 +1418,19 @@ So I chose the fourth option: build a new host on top of the TypeScript-Go direc
 
 # 3. Transformer Survival
 
-- Compiler front door
-- Plugin host
-- Transformer lifecycle
-- Runtime and editor path
+- No ready host
+- I had to build one
+- Keep user APIs alive
+- Replace the compiler path
 
 <!--
-Now we move to TTSC as the survival layer.
+Now the talk changes from crisis to response.
 
-The immediate goal is simple: keep transformer-based TypeScript tooling alive in the TypeScript-Go era. That means users need a compiler front door, plugins need a host, transformers need a lifecycle, and the same model must work in build, runtime, and editor paths.
+At this point in the story, TTSC is not a finished toolchain waiting on the shelf. The old host is disappearing, and the replacement does not exist yet.
 
-I will describe TTSC first as infrastructure, not as a package list. The important design idea is that TTSC owns enough of the compiler session to load the project, expose compiler facts, run plugins, and integrate their results.
+The immediate goal was simple: typia and nestia should not die because the compiler implementation moved. Users should not have to rewrite their applications into runtime schemas, and I should not have to remove the features that made these packages useful.
+
+So the first decision was to build the missing host. The later opportunity comes after that. First, the products have to survive.
 -->
 
 ---
@@ -1236,36 +1439,30 @@ I will describe TTSC first as infrastructure, not as a package list. The importa
 
 # 3.1. Compiler Front Door
 
-```bash
-npx ttsc
-npx ttsc --noEmit
-npx ttsc --watch
-```
-
-- Familiar command shape
-  - build
-  - check
-  - watch
-- New responsibility
-  - own project load
-  - host transformers
-  - route compiler facts
+- Missing piece
+  - no patched JavaScript host
+  - no plugin entry point
+- Required host
+  - load the project
+  - expose compiler facts
+  - run transformers
+- Design choice
+  - explicit front door
+  - tsc-shaped command
 
 <!--
-The first user-facing surface is intentionally familiar.
+The first thing I needed was not a new product slogan. It was a compiler front door.
 
-You can run npx ttsc, npx ttsc --noEmit, or npx ttsc --watch. The command shape is close to tsc because the goal is not to teach every user a new build model.
+The old patched JavaScript compiler host could no longer be the assumption. That meant there had to be a new place where the project is loaded, compiler options are understood, compiler facts are exposed, and transformers can run.
 
-But behind that familiar command, TTSC takes on new responsibility. It must load the project, read compiler options, build or reuse the compiler state, discover transformer plugins, execute them, and route compiler facts and emit outputs through the host.
-
-In other words, ttsc is not just a command alias. It is the front door for a compiler session that knows how to host TypeScript transformer tooling in the new world.
+That front door should still feel like tsc to the user. But internally it cannot be a thin alias. It has to be the place where the new compiler world and the old transformer ecosystem meet.
 -->
 
 ---
 
 <!-- _class: cards -->
 
-# 3.1. Not a Bypass
+# 3.1. Compiler Front Door
 
 - Keep TypeScript-Go
   - native compiler base
@@ -1276,23 +1473,24 @@ In other words, ttsc is not just a command alias. It is the front door for a com
   - plugin execution path
   - emit integration
 - Goal
-  - survive on the new compiler
+  - keep products alive
+  - move with the compiler
 
 <!--
-It is important to say what TTSC is not.
+This design has one important constraint.
 
-TTSC is not trying to reject TypeScript-Go and go back to the old JavaScript compiler forever. That would miss the main ecosystem benefit. The native compiler base, semantic analysis, diagnostics, and performance direction are the reason to build this.
+The answer cannot be "reject TypeScript-Go and go back to the old JavaScript compiler forever." That would miss the main ecosystem benefit. The native compiler base, semantic analysis, diagnostics, and performance direction are the reason to build this.
 
-TTSC adds the missing layer around that compiler base. It provides a transformer host, a plugin execution path, and emit integration so that transformer-powered packages can survive while users still benefit from the faster compiler direction.
+The layer I needed to build goes around that compiler base. It provides a transformer host, a plugin execution path, and emit integration so that transformer-powered packages can stay alive while users still benefit from the faster compiler direction.
 
-So the goal is compatibility with the future, not nostalgia for the old patch model.
+That was the design constraint: keep the products alive without asking the ecosystem to reject the faster compiler. The answer could not be nostalgia for the old patch model. It had to be compatibility with the future.
 -->
 
 ---
 
 <!-- _class: compare -->
 
-# 3.2. Old Host vs TTSC Host
+# 3.2. Plugin Host
 
 | Old                            | TTSC                         |
 | ------------------------------ | ---------------------------- |
@@ -1372,7 +1570,7 @@ What changes in TTSC is not the idea of transformation. What changes is who owns
 
 <!-- _class: cards three -->
 
-# 3.3. User API Stays
+# 3.3. Transformer Lifecycle
 
 - typia user
   - `typia.createIs<T>()`
@@ -1398,7 +1596,7 @@ That separation is the whole survival strategy: preserve the surface that users 
 
 <!-- _class: cards -->
 
-# 3.4. Runtime Path
+# 3.4. Runtime and Editor Path
 
 ```bash
 npx ttsx src/index.ts
@@ -1426,13 +1624,13 @@ ttsx is the TTSC answer for that path. The goal is direct TypeScript execution w
 
 <!-- _class: cards -->
 
-# 3.4. Editor Path
+# 3.4. Runtime and Editor Path
 
-- `ttscserver`
+- `@ttsc/vscode`
   - plugin diagnostics
   - code actions
   - plugin commands
-- VS Code path
+- VS Code Plugin
   - project view
   - early feedback
 - Goal
@@ -1444,7 +1642,7 @@ The editor path is just as important as the build path.
 
 If transformer plugins can produce diagnostics, code actions, or plugin commands, developers should see that feedback in the editor. Waiting for CI means the feedback loop is already too late.
 
-ttscserver is the language-service side of the toolchain. The goal is that VS Code can show plugin-aware diagnostics and commands in the project view, using the same compiler understanding that build and runtime paths rely on.
+@ttsc/vscode is the VS Code Plugin side of the toolchain. The goal is that VS Code can show plugin-aware diagnostics and commands in the project view, using the same compiler understanding that build and runtime paths rely on.
 
 The ideal workflow is simple: the editor discovers problems early, local commands verify them, and CI confirms the same behavior.
 -->
@@ -1453,7 +1651,7 @@ The ideal workflow is simple: the editor discovers problems early, local command
 
 <!-- _class: cards -->
 
-# 3.4. Whole Loop
+# 3.4. Runtime and Editor Path
 
 - Build
   - `ttsc`
@@ -1461,8 +1659,8 @@ The ideal workflow is simple: the editor discovers problems early, local command
 - Runtime
   - `ttsx`
   - checked execution
-- Editor
-  - `ttscserver`
+- VS Code Plugin
+  - `@ttsc/vscode`
   - plugin diagnostics
 - One toolchain
   - not one wrapper
@@ -1470,7 +1668,7 @@ The ideal workflow is simple: the editor discovers problems early, local command
 <!--
 This is the whole loop.
 
-ttsc covers build and type-checking. ttsx covers checked runtime execution. ttscserver covers editor diagnostics and actions. Together they form one plugin-aware toolchain.
+ttsc covers build and type-checking. ttsx covers checked runtime execution. @ttsc/vscode covers editor diagnostics and actions in VS Code. Together they form one plugin-aware toolchain.
 
 The phrase "one toolchain" is important. If each surface built a separate TypeScript world, we would pay the compiler cost repeatedly and risk inconsistent behavior. The point of TTSC is to share the same compiler understanding across surfaces.
 
@@ -1530,7 +1728,7 @@ If each tool reloads the project independently, the workflow pays the same cost 
 
 <!-- _class: flow -->
 
-# 4.1. Core Contract
+# 4.1. Compiler State
 
 - Load once
   - project
@@ -1559,7 +1757,7 @@ So the toolchain is not just about making one command faster. It is about making
 
 <!-- _class: cards -->
 
-# 4.2. Linter Without Rebuild
+# 4.2. @ttsc/lint
 
 ```bash
 npx tsc --noEmit
@@ -1587,11 +1785,55 @@ TTSC lint takes a different approach. If TTSC already owns the Program and Check
 
 ---
 
+<!-- _class: lint-example -->
+
+# 4.2. @ttsc/lint
+
+<div class="lint-concept">
+  <div><strong>Compiler gate</strong><span>Lint rules fail the same build path as type errors.</span></div>
+  <div><strong>Diagnostic shape</strong><span>Every finding is rendered as an <code>error TSxxxxx</code>.</span></div>
+  <div><strong>One stream</strong><span>Terminal, CI, and editor consume the same output.</span></div>
+</div>
+
+<div class="lint-label source-label">src/index.ts</div>
+<div class="lint-label terminal-label">npx ttsc --noEmit</div>
+
+```typescript
+var x: number = 3;
+let y: number = 4;
+const z: string = 5;
+
+console.log(x + y + z);
+```
+
+```bash
+$ npx ttsc --noEmit
+
+src/index.ts:3:7 - error TS2322
+Type 'number' is not assignable to type 'string'.
+
+src/index.ts:2:5 - error TS17397 [prefer-const]
+Use const instead of let.
+
+src/index.ts:1:1 - error TS11966 [no-var]
+Unexpected var, use let or const instead.
+```
+
+<!--
+This is the example shape from the ttsc.dev lint pages.
+
+The important part is that one run prints a normal TypeScript error, TS2322, and lint rule failures, TS17397 and TS11966, in the same compiler diagnostic format.
+
+That makes lint a compiler failure. The same terminal output, same CI gate, and same editor underline can handle both type errors and lint violations.
+-->
+
+---
+
 <!-- _class: metric -->
 
-# 4.2. VS Code Benchmark
+# 4.2. @ttsc/lint
 
-Lint pass comparison:
+VS Code benchmark fixture:
 
 | Tool         |      Time |
 | ------------ | --------: |
@@ -1612,32 +1854,38 @@ For backend teams, this matters because linting is part of the same feedback loo
 
 ---
 
-<!-- _class: compare -->
+<!-- _class: graph-shot -->
 
-# 4.3. Graph Instead of Grep
+# 4.3. @ttsc/graph
 
-| Grep-first agent | Compiler-first agent |
-| ---------------- | -------------------- |
-| search text      | resolve symbol       |
-| open file        | follow references    |
-| follow import    | inspect diagnostics  |
-| repeat           | open selected source |
+- Checker facts
+  - declarations
+  - resolved edges
+  - diagnostics
+- Agent queries
+  - overview
+  - query
+  - trace / expand
+- Goal
+  - stop guessing from text
+
+![3D Code Graph viewer](../graph/vscode.png)
 
 <!--
-The same idea applies to code intelligence and agent workflows.
+The same idea applies to code intelligence and agent workflows, but the graph needs a concrete picture.
 
-Without a compiler graph, an agent or tool often starts with grep. It searches text, opens files, follows imports manually, repeats the search, and tries to infer meaning from strings.
+This is the 3D graph viewer from ttsc.dev. The example shown is the VS Code fixture: 724 declaration nodes and 3,002 resolved edges. Every node is a declaration. Every edge is a relationship reported by the compiler.
 
-A compiler-first agent can start from symbols, references, diagnostics, and resolved module relationships. Instead of reading many files to guess what a name means, it can ask the compiler graph directly.
+That matters because the graph is not a screenshot of files. It is checker-resolved structure: declarations, value-call edges, type-reference edges, heritage edges, and diagnostics attached to the same project view.
 
-This is not only about agents. The same distinction applies to any tool that needs to understand a codebase. Text search is useful, but TypeScript programs already contain a semantic graph. TTSC can expose that graph as a first-class tool surface.
+Without this, an agent starts with grep and guesses from text. With this, the first move can be graph_overview, graph_query, graph_trace, or graph_expand. The tool starts from compiler facts, then opens source only when the graph has narrowed the target.
 -->
 
 ---
 
 <!-- _class: metric -->
 
-# 4.3. Token Economy
+# 4.3. @ttsc/graph
 
 TypeORM benchmark cell:
 
@@ -1691,14 +1939,14 @@ That is how survival became toolchain infrastructure. The host that keeps emit a
 
 <!-- _class: cards -->
 
-# 4.4. TTSC Surface
+# 4.4. From Patch to Toolchain
 
 - Compiler
   - `ttsc`
 - Runtime
   - `ttsx`
-- Editor
-  - `ttscserver`
+- VS Code Plugin
+  - `@ttsc/vscode`
 - Reuse
   - `@ttsc/lint`
   - `@ttsc/graph`
@@ -1706,7 +1954,7 @@ That is how survival became toolchain infrastructure. The host that keeps emit a
 <!--
 Here is the surface area in package terms.
 
-ttsc is the compiler command. ttsx is the runtime execution path. ttscserver is the editor and language-service path. @ttsc/lint and @ttsc/graph are examples of tools that reuse the compiler state.
+ttsc is the compiler command. ttsx is the runtime execution path. @ttsc/vscode is the VS Code Plugin path. @ttsc/lint and @ttsc/graph are examples of tools that reuse the compiler state.
 
 This list is also a way to understand the project boundary. TTSC is not just a transformer loader. It is a TypeScript-Go based toolchain where compiler state is a shared asset.
 


### PR DESCRIPTION
## Summary
- Polish the 2026-06-26 TypeScript Backend Meetup Marp deck narrative and section headings.
- Add a clearer @ttsc/lint diagnostic example and @ttsc/graph visual slide.
- Adjust lead-slide link styling and VS Code plugin naming.

## Scope
- Presentation markdown only: `website/public/presentations/20260626-ts-backend-meetup.md`.

## Test plan
- `pnpm exec prettier --check website/public/presentations/20260626-ts-backend-meetup.md`
- `pnpm dlx @marp-team/marp-cli website/public/presentations/20260626-ts-backend-meetup.md --html --allow-local-files --output website/public/presentations/20260626-ts-backend-meetup.check.html`
- `git diff --check -- website/public/presentations/20260626-ts-backend-meetup.md`