### PR TITLE
Make graph MCP calls CoT-directed

### DIFF
--- a/experimental/benchmark/graph/agent-ab-codex.mjs
+++ b/experimental/benchmark/graph/agent-ab-codex.mjs
@@ -523,6 +523,8 @@ async function runCodex(question, codexHome, armName, runNumber) {
     [
       "exec",
       "--json",
+      "-c",
+      "tools.web_search=false",
       "--disable",
       "browser_use",
       "--disable",
@@ -679,15 +681,15 @@ function validateArmSample(sample, armName) {
     sample.invalid = "graph-web-used";
     sample.error = "graph arm used web search instead of graph tools";
   }
-  if (armName === "graph" && sample.ok && sample.graph === 0) {
-    sample.ok = false;
-    sample.invalid = "graph-mcp-not-used";
-    sample.error = "graph arm completed without MCP tool calls";
-  }
   if (armName === "graph" && sample.ok && sample.shell > 0) {
     sample.ok = false;
     sample.invalid = "graph-shell-used";
     sample.error = "graph arm used shell commands instead of graph tools";
+  }
+  if (armName === "graph" && sample.ok && sample.graph === 0) {
+    sample.ok = false;
+    sample.invalid = "graph-mcp-not-used";
+    sample.error = "graph arm completed without MCP tool calls";
   }
   return sample;
 }

--- a/experimental/benchmark/graph/agent-ab-codex.mjs
+++ b/experimental/benchmark/graph/agent-ab-codex.mjs
@@ -12,8 +12,7 @@
 //
 // The MCP server is the @ttsc/graph TypeScript launcher (packages/graph/lib/bin.js),
 // which runs `ttscgraph dump` once for the project (the Go binary is dump-only now)
-// and serves graph_index / graph_overview / graph_query / graph_trace /
-// graph_expand over stdio.
+// and serves one planned graph-inspection tool over stdio.
 // Tool guidance comes from the server's MCP descriptions; the user prompt is the
 // manifest question verbatim, tool-neutral, so the token comparison stays honest —
 // no graph-specific instruction is prepended.

--- a/experimental/benchmark/graph/agent-ab-codex.mjs
+++ b/experimental/benchmark/graph/agent-ab-codex.mjs
@@ -366,7 +366,7 @@ const thunks = arms.flatMap((arm) =>
       `  ${arm.name.padEnd(8)} run ${r + 1}: ${m.tokens} tok` +
         (m.reasoning ? ` (+${m.reasoning} reasoning)` : "") +
         `, ${m.tools} tools ` +
-        `(shell ${m.shell}, graph ${m.graph}), ${(m.durMs / 1000).toFixed(0)}s` +
+        `(shell ${m.shell}, graph ${m.graph}, web ${m.web ?? 0}), ${(m.durMs / 1000).toFixed(0)}s` +
         (m.ok ? "" : `  [FAILED${m.error ? `: ${m.error}` : ""}]`),
     );
   }),
@@ -523,6 +523,16 @@ async function runCodex(question, codexHome, armName, runNumber) {
     [
       "exec",
       "--json",
+      "--disable",
+      "browser_use",
+      "--disable",
+      "browser_use_external",
+      "--disable",
+      "standalone_web_search",
+      "--disable",
+      "web_search_request",
+      "--disable",
+      "web_search_cached",
       "--dangerously-bypass-approvals-and-sandbox",
       "--skip-git-repo-check",
       "--ephemeral",
@@ -591,6 +601,7 @@ function parseStream(text, durMs) {
     tools = 0,
     shell = 0,
     graph = 0,
+    web = 0,
     completed = false,
     answered = false,
     answer = "";
@@ -628,6 +639,9 @@ function parseStream(text, durMs) {
       } else if (t === "command_execution") {
         tools++;
         shell++;
+      } else if (t === "web_search") {
+        tools++;
+        web++;
       } else if (t === "agent_message") {
         answered = true;
         // codex emits intermediate agent_message items; the last one carrying
@@ -646,6 +660,7 @@ function parseStream(text, durMs) {
     tools,
     shell,
     graph,
+    web,
     types,
     durMs,
     ok: completed && answered,
@@ -659,6 +674,11 @@ function parseStream(text, durMs) {
 }
 
 function validateArmSample(sample, armName) {
+  if (armName === "graph" && sample.ok && sample.web > 0) {
+    sample.ok = false;
+    sample.invalid = "graph-web-used";
+    sample.error = "graph arm used web search instead of graph tools";
+  }
   if (armName === "graph" && sample.ok && sample.graph === 0) {
     sample.ok = false;
     sample.invalid = "graph-mcp-not-used";

--- a/experimental/benchmark/graph/audit-codex-traces.mjs
+++ b/experimental/benchmark/graph/audit-codex-traces.mjs
@@ -30,6 +30,7 @@ const singleGraphToolNames = new Set([
   "inspect_typescript_graph_before_shell_reading",
   "inspect_typescript_code_evidence_without_shell_search",
   "inspect_typescript_code_graph_evidence",
+  "inspect_typescript_project_graph_before_answering",
 ]);
 
 if (truthy(args["self-test"])) {
@@ -427,9 +428,8 @@ function summarizeRuns(runs) {
     graphArmRuns: graphArmRuns.length,
     graphArmRunsWithoutMcp: graphArmRuns.filter((run) => run.tools.mcp === 0)
       .length,
-    graphArmRunsWithShell: graphArmRuns.filter(
-      (run) => run.tools.command > 0,
-    ).length,
+    graphArmRunsWithShell: graphArmRuns.filter((run) => run.tools.command > 0)
+      .length,
     medianTokens: median(runs.map((run) => run.usage.tokens)),
     medianCachedInputTokens: median(
       runs.map((run) => run.usage.cachedInputTokens),
@@ -1844,11 +1844,17 @@ function graphPayloadResult(name, parsed) {
         payload: parsed.entrypoints,
       };
     case "lookup_symbols":
-      return { kind: graphToolKind(name, parsed.type), payload: parsed.symbols };
+      return {
+        kind: graphToolKind(name, parsed.type),
+        payload: parsed.symbols,
+      };
     case "trace_dependency_path":
       return { kind: graphToolKind(name, parsed.type), payload: parsed.trace };
     case "inspect_symbol_details":
-      return { kind: graphToolKind(name, parsed.type), payload: parsed.details };
+      return {
+        kind: graphToolKind(name, parsed.type),
+        payload: parsed.details,
+      };
     case "summarize_project":
       return {
         kind: graphToolKind(name, parsed.type),

--- a/experimental/benchmark/graph/audit-codex-traces.mjs
+++ b/experimental/benchmark/graph/audit-codex-traces.mjs
@@ -25,6 +25,10 @@ const baselinePath =
     ? null
     : path.resolve(args.baseline ?? "website/public/benchmark/graph.json");
 const compareInputs = args.compare ? listArg(args.compare) : [];
+const singleGraphToolNames = new Set([
+  "query_typescript_graph",
+  "inspect_typescript_graph_before_shell_reading",
+]);
 
 if (truthy(args["self-test"])) {
   runSelfTest();
@@ -1573,7 +1577,7 @@ function formatHotspotArgs(args) {
 }
 
 function graphToolKind(name, requestType) {
-  if (name === "query_typescript_graph") {
+  if (singleGraphToolNames.has(name)) {
     switch (requestType) {
       case "find_question_entrypoints":
         return "entrypoints";
@@ -1647,12 +1651,12 @@ function summarizeMcpArgs(name, input) {
 
 function mcpRequestArgs(name, input) {
   const args = input && typeof input === "object" ? input : {};
-  if (name !== "query_typescript_graph") return args;
+  if (!singleGraphToolNames.has(name)) return args;
   return args.request && typeof args.request === "object" ? args.request : {};
 }
 
 function mcpInputKey(name, input) {
-  return name === "query_typescript_graph" ? mcpRequestArgs(name, input) : input;
+  return singleGraphToolNames.has(name) ? mcpRequestArgs(name, input) : input;
 }
 
 function isReasoningItem(type) {
@@ -1828,7 +1832,7 @@ function analyzeGraphPayload(name, text) {
 }
 
 function graphPayloadResult(name, parsed) {
-  if (name !== "query_typescript_graph") {
+  if (!singleGraphToolNames.has(name)) {
     return { kind: graphToolKind(name), payload: parsed };
   }
   switch (parsed.type) {

--- a/experimental/benchmark/graph/audit-codex-traces.mjs
+++ b/experimental/benchmark/graph/audit-codex-traces.mjs
@@ -29,6 +29,7 @@ const singleGraphToolNames = new Set([
   "query_typescript_graph",
   "inspect_typescript_graph_before_shell_reading",
   "inspect_typescript_code_evidence_without_shell_search",
+  "inspect_typescript_code_graph_evidence",
 ]);
 
 if (truthy(args["self-test"])) {

--- a/experimental/benchmark/graph/audit-codex-traces.mjs
+++ b/experimental/benchmark/graph/audit-codex-traces.mjs
@@ -263,6 +263,7 @@ function parseTrace(text) {
       const payload = item.result ?? item.output ?? item.content ?? "";
       const output = stringifyPayload(payload);
       const contentText = extractMcpText(payload);
+      const args = summarizeMcpArgs(name, input);
       const call = {
         index: calls.length + 1,
         eventIndex,
@@ -271,9 +272,9 @@ function parseTrace(text) {
         kind: "mcp",
         class: "graph",
         name,
-        args: summarizeMcpArgs(name, input),
+        args,
         arguments: input,
-        inputKey: `${name}:${stableStringify(input)}`,
+        inputKey: `${name}:${stableStringify(mcpInputKey(name, input))}`,
         inputChars: JSON.stringify(input).length,
         contentTextChars: contentText.length,
         estimatedContentTextTokens: estimateTokens(contentText),
@@ -1571,7 +1572,23 @@ function formatHotspotArgs(args) {
   return text.length > 120 ? `${text.slice(0, 117)}...` : text;
 }
 
-function graphToolKind(name) {
+function graphToolKind(name, requestType) {
+  if (name === "query_typescript_graph") {
+    switch (requestType) {
+      case "find_question_entrypoints":
+        return "entrypoints";
+      case "lookup_symbols":
+        return "lookup";
+      case "trace_dependency_path":
+        return "path";
+      case "inspect_symbol_details":
+        return "details";
+      case "summarize_project":
+        return "overview";
+      default:
+        return undefined;
+    }
+  }
   switch (name) {
     case "graph_expand":
     case "symbol_details":
@@ -1594,10 +1611,11 @@ function graphToolKind(name) {
 }
 
 function summarizeMcpArgs(name, input) {
-  const args = input && typeof input === "object" ? input : {};
-  const kind = graphToolKind(name);
+  const args = mcpRequestArgs(name, input);
+  const kind = graphToolKind(name, args.type);
   if (kind === "details") {
     return {
+      type: args.type,
       handles: Array.isArray(args.handles) ? args.handles.length : 0,
       source: args.source === true,
       neighbors: args.neighbors === true,
@@ -1606,6 +1624,7 @@ function summarizeMcpArgs(name, input) {
   }
   if (kind === "path") {
     return {
+      type: args.type,
       direction: args.direction ?? "forward",
       focus: args.focus ?? "all",
       path: typeof args.to === "string" && args.to.length > 0,
@@ -1615,14 +1634,25 @@ function summarizeMcpArgs(name, input) {
   }
   if (kind === "lookup" || kind === "entrypoints") {
     return {
+      type: args.type,
       limit: number(args.limit),
       queryChars: typeof args.query === "string" ? args.query.length : 0,
     };
   }
   if (kind === "overview") {
-    return { aspect: args.aspect ?? "all" };
+    return { type: args.type, aspect: args.aspect ?? "all" };
   }
   return {};
+}
+
+function mcpRequestArgs(name, input) {
+  const args = input && typeof input === "object" ? input : {};
+  if (name !== "query_typescript_graph") return args;
+  return args.request && typeof args.request === "object" ? args.request : {};
+}
+
+function mcpInputKey(name, input) {
+  return name === "query_typescript_graph" ? mcpRequestArgs(name, input) : input;
 }
 
 function isReasoningItem(type) {
@@ -1684,9 +1714,11 @@ function extractMcpText(payload) {
 function analyzeGraphPayload(name, text) {
   const parsed = parseJsonObject(text);
   if (parsed === undefined) return undefined;
-  const kind = graphToolKind(name);
+  const normalized = graphPayloadResult(name, parsed);
+  const kind = normalized.kind;
+  const payload = normalized.payload;
   if (kind === "details") {
-    const nodes = Array.isArray(parsed.nodes) ? parsed.nodes : [];
+    const nodes = Array.isArray(payload?.nodes) ? payload.nodes : [];
     const sourceChars = sum(
       nodes.map((node) =>
         typeof node.source === "string" ? node.source.length : 0,
@@ -1718,12 +1750,12 @@ function analyzeGraphPayload(name, text) {
           (Array.isArray(node.dependedOnBy) ? node.dependedOnBy.length : 0),
       ),
     );
-    const coveredEvidenceTextChars = coveredSourceEvidenceTextChars(parsed);
+    const coveredEvidenceTextChars = coveredSourceEvidenceTextChars(payload);
     const truncated = nodes.filter((node) => node.truncated === true).length;
     return {
       kind: "expand",
       nodes: nodes.length,
-      unknown: Array.isArray(parsed.unknown) ? parsed.unknown.length : 0,
+      unknown: Array.isArray(payload?.unknown) ? payload.unknown.length : 0,
       members: members.length,
       dependencyRefs,
       sourceChars,
@@ -1743,9 +1775,9 @@ function analyzeGraphPayload(name, text) {
     };
   }
   if (kind === "path") {
-    const hops = Array.isArray(parsed.hops) ? parsed.hops : [];
-    const reached = Array.isArray(parsed.reached) ? parsed.reached : [];
-    const path = Array.isArray(parsed.path) ? parsed.path : [];
+    const hops = Array.isArray(payload?.hops) ? payload.hops : [];
+    const reached = Array.isArray(payload?.reached) ? payload.reached : [];
+    const path = Array.isArray(payload?.path) ? payload.path : [];
     const evidenceChars = sum(hops.map((hop) => jsonChars(hop.evidence)));
     const pathSignatureChars = sum(
       path.map((node) =>
@@ -1754,22 +1786,22 @@ function analyzeGraphPayload(name, text) {
     );
     return {
       kind: "trace",
-      direction: parsed.direction ?? null,
+      direction: payload?.direction ?? null,
       hops: hops.length,
       reached: reached.length,
       path: path.length,
-      candidates: Array.isArray(parsed.candidates)
-        ? parsed.candidates.length
+      candidates: Array.isArray(payload?.candidates)
+        ? payload.candidates.length
         : 0,
       evidenceChars,
       estimatedEvidenceTokens: estimateTokensFromChars(evidenceChars),
       pathSignatureChars,
       estimatedPathSignatureTokens: estimateTokensFromChars(pathSignatureChars),
-      truncated: parsed.truncated === true,
+      truncated: payload?.truncated === true,
     };
   }
   if (kind === "lookup" || kind === "entrypoints") {
-    const hits = Array.isArray(parsed.hits) ? parsed.hits : [];
+    const hits = Array.isArray(payload?.hits) ? payload.hits : [];
     const signatureChars = sum(
       hits.map((hit) =>
         typeof hit.signature === "string" ? hit.signature.length : 0,
@@ -1785,16 +1817,44 @@ function analyzeGraphPayload(name, text) {
   if (kind === "overview") {
     return {
       kind: "overview",
-      publicApi: Array.isArray(parsed.publicApi) ? parsed.publicApi.length : 0,
-      hotspots: Array.isArray(parsed.hotspots) ? parsed.hotspots.length : 0,
-      layers: Array.isArray(parsed.layers) ? parsed.layers.length : 0,
+      publicApi: Array.isArray(payload?.publicApi)
+        ? payload.publicApi.length
+        : 0,
+      hotspots: Array.isArray(payload?.hotspots) ? payload.hotspots.length : 0,
+      layers: Array.isArray(payload?.layers) ? payload.layers.length : 0,
     };
   }
   return { kind: name };
 }
 
+function graphPayloadResult(name, parsed) {
+  if (name !== "query_typescript_graph") {
+    return { kind: graphToolKind(name), payload: parsed };
+  }
+  switch (parsed.type) {
+    case "find_question_entrypoints":
+      return {
+        kind: graphToolKind(name, parsed.type),
+        payload: parsed.entrypoints,
+      };
+    case "lookup_symbols":
+      return { kind: graphToolKind(name, parsed.type), payload: parsed.symbols };
+    case "trace_dependency_path":
+      return { kind: graphToolKind(name, parsed.type), payload: parsed.trace };
+    case "inspect_symbol_details":
+      return { kind: graphToolKind(name, parsed.type), payload: parsed.details };
+    case "summarize_project":
+      return {
+        kind: graphToolKind(name, parsed.type),
+        payload: parsed.overview,
+      };
+    default:
+      return { kind: undefined, payload: parsed };
+  }
+}
+
 function coveredSourceEvidenceTextChars(payload) {
-  const nodes = Array.isArray(payload.nodes) ? payload.nodes : [];
+  const nodes = Array.isArray(payload?.nodes) ? payload.nodes : [];
   const before = JSON.stringify(payload).length;
   const copy = JSON.parse(JSON.stringify(payload));
   let removed = 0;
@@ -1936,7 +1996,7 @@ function analyzeMcpOverfetch(calls) {
       }
     }
 
-    const kind = graphToolKind(call.name);
+    const kind = graphToolKind(call.name, call.args.type);
     if (kind === "details") {
       if (call.args.source && call.args.neighbors && call.args.handles >= 2) {
         add(

--- a/experimental/benchmark/graph/audit-codex-traces.mjs
+++ b/experimental/benchmark/graph/audit-codex-traces.mjs
@@ -28,6 +28,7 @@ const compareInputs = args.compare ? listArg(args.compare) : [];
 const singleGraphToolNames = new Set([
   "query_typescript_graph",
   "inspect_typescript_graph_before_shell_reading",
+  "inspect_typescript_code_evidence_without_shell_search",
 ]);
 
 if (truthy(args["self-test"])) {

--- a/packages/graph/src/TtscGraphApplication.ts
+++ b/packages/graph/src/TtscGraphApplication.ts
@@ -29,7 +29,7 @@ export class TtscGraphApplication implements ITtscGraphApplication {
     this.graph = typeof source === "function" ? source : () => source;
   }
 
-  public inspect_typescript_code_graph_evidence(
+  public inspect_typescript_project_graph_before_answering(
     props: ITtscGraphApplication.IProps,
   ): ITtscGraphApplication.IResult {
     const graph = this.graph();

--- a/packages/graph/src/TtscGraphApplication.ts
+++ b/packages/graph/src/TtscGraphApplication.ts
@@ -29,7 +29,7 @@ export class TtscGraphApplication implements ITtscGraphApplication {
     this.graph = typeof source === "function" ? source : () => source;
   }
 
-  public query_typescript_graph(
+  public inspect_typescript_graph_before_shell_reading(
     props: ITtscGraphApplication.IProps,
   ): ITtscGraphApplication.IResult {
     const graph = this.graph();

--- a/packages/graph/src/TtscGraphApplication.ts
+++ b/packages/graph/src/TtscGraphApplication.ts
@@ -29,7 +29,7 @@ export class TtscGraphApplication implements ITtscGraphApplication {
     this.graph = typeof source === "function" ? source : () => source;
   }
 
-  public inspect_typescript_code_evidence_without_shell_search(
+  public inspect_typescript_code_graph_evidence(
     props: ITtscGraphApplication.IProps,
   ): ITtscGraphApplication.IResult {
     const graph = this.graph();

--- a/packages/graph/src/TtscGraphApplication.ts
+++ b/packages/graph/src/TtscGraphApplication.ts
@@ -29,7 +29,7 @@ export class TtscGraphApplication implements ITtscGraphApplication {
     this.graph = typeof source === "function" ? source : () => source;
   }
 
-  public inspect_typescript_graph_before_shell_reading(
+  public inspect_typescript_code_evidence_without_shell_search(
     props: ITtscGraphApplication.IProps,
   ): ITtscGraphApplication.IResult {
     const graph = this.graph();

--- a/packages/graph/src/TtscGraphApplication.ts
+++ b/packages/graph/src/TtscGraphApplication.ts
@@ -5,11 +5,6 @@ import { runOverview } from "./server/runOverview";
 import { runQuery } from "./server/runQuery";
 import { runTrace } from "./server/runTrace";
 import { ITtscGraphApplication } from "./structures/ITtscGraphApplication";
-import { ITtscGraphExpand } from "./structures/ITtscGraphExpand";
-import { ITtscGraphIndex } from "./structures/ITtscGraphIndex";
-import { ITtscGraphOverview } from "./structures/ITtscGraphOverview";
-import { ITtscGraphQuery } from "./structures/ITtscGraphQuery";
-import { ITtscGraphTrace } from "./structures/ITtscGraphTrace";
 
 export type TtscGraphSource = TtscGraphMemory | (() => TtscGraphMemory);
 
@@ -17,12 +12,11 @@ export type TtscGraphSource = TtscGraphMemory | (() => TtscGraphMemory);
  * The MCP tool surface as a plain class over the resident
  * {@link TtscGraphMemory}.
  *
- * Each public method is one MCP tool: `typia.llm.controller` reflects
- * {@link ITtscGraphApplication} to generate every tool's JSON schema and
- * argument validator from these signatures and their JSDoc, with no
- * hand-written schema. The methods delegate to the pure tool functions in
- * `./server`, which are unit-testable without a transport; this class only
- * binds them to the graph.
+ * Its public method is the MCP tool: `typia.llm.controller` reflects
+ * {@link ITtscGraphApplication} to generate the tool's JSON schema and argument
+ * validator from the signature and JSDoc, with no hand-written schema. The
+ * method delegates to the pure graph functions in `./server`, which are
+ * unit-testable without a transport; this class only binds them to the graph.
  *
  * Every method answers from the resident graph; none recompiles. Output is kept
  * compact and bounded so a model can read structure without a file read, which
@@ -35,31 +29,48 @@ export class TtscGraphApplication implements ITtscGraphApplication {
     this.graph = typeof source === "function" ? source : () => source;
   }
 
-  public question_entrypoints(
-    props: ITtscGraphIndex.IProps,
-  ): ITtscGraphIndex {
-    return runIndex(this.graph(), props);
-  }
-
-  public symbol_lookup(props: ITtscGraphQuery.IProps): ITtscGraphQuery {
-    return runQuery(this.graph(), props);
-  }
-
-  public dependency_path(
-    props: ITtscGraphTrace.IProps,
-  ): ITtscGraphTrace {
-    return runTrace(this.graph(), props);
-  }
-
-  public symbol_details(
-    props: ITtscGraphExpand.IProps,
-  ): ITtscGraphExpand {
-    return runExpand(this.graph(), props);
-  }
-
-  public project_overview(
-    props: ITtscGraphOverview.IProps,
-  ): ITtscGraphOverview {
-    return runOverview(this.graph(), props);
+  public query_typescript_graph(
+    props: ITtscGraphApplication.IProps,
+  ): ITtscGraphApplication.IResult {
+    const graph = this.graph();
+    switch (props.request.type) {
+      case "find_question_entrypoints": {
+        const { type: _type, purpose: _purpose, ...request } = props.request;
+        return {
+          type: props.request.type,
+          entrypoints: runIndex(graph, request),
+        };
+      }
+      case "lookup_symbols": {
+        const { type: _type, purpose: _purpose, ...request } = props.request;
+        return {
+          type: props.request.type,
+          symbols: runQuery(graph, request),
+        };
+      }
+      case "trace_dependency_path": {
+        const { type: _type, purpose: _purpose, ...request } = props.request;
+        return {
+          type: props.request.type,
+          trace: runTrace(graph, request),
+        };
+      }
+      case "inspect_symbol_details": {
+        const { type: _type, purpose: _purpose, ...request } = props.request;
+        return {
+          type: props.request.type,
+          details: runExpand(graph, request),
+        };
+      }
+      case "summarize_project": {
+        const { type: _type, purpose: _purpose, ...request } = props.request;
+        return {
+          type: props.request.type,
+          overview: runOverview(graph, request),
+        };
+      }
+      default:
+        throw new Error("Unknown graph request type");
+    }
   }
 }

--- a/packages/graph/src/server/instructions.ts
+++ b/packages/graph/src/server/instructions.ts
@@ -4,21 +4,22 @@
  * files. Keep it short; the per-tool descriptions carry the detail.
  */
 export const instructions = `
-For TypeScript code questions, call
-inspect_typescript_code_evidence_without_shell_search. Do not use ls, rg, cat,
-or Get-Content to locate TypeScript files, symbols, dependencies, source
-bodies, or line anchors. Ask the graph, then answer from graph evidence and
-sourceSpan citations.
+For TypeScript code questions, call inspect_typescript_code_graph_evidence
+first. It finds symbols, dependency paths, sourceSpan line anchors, and narrow
+source bodies from the resident TypeScript graph. Do not use ls, rg, cat, or
+Get-Content for TypeScript code evidence unless the user directly asks for a
+non-code file or raw file text.
 
 The graph is a TypeScript index, not an answer writer. Fill thinking before
-each call, then choose one request.type: find entrypoints, lookup symbols, trace
-dependency paths, inspect selected symbols, or summarize the project. If more
-TypeScript evidence is needed, make another graph request instead of switching
-to shell search.
+each call with the smallest next graph step and its stop condition, then choose
+one request.type: find entrypoints, lookup symbols, trace dependency paths,
+inspect selected symbols, or summarize the project. If more TypeScript evidence
+is needed, make another graph request instead of switching to shell search.
 
 The graph already knows resolved symbols, dependency edges, evidence spans,
 decorators, stable handles, source bodies, and sourceSpan line anchors. If you
-need exact code or line numbers, use inspect_symbol_details with source: true.
+need exact code or line numbers, use inspect_symbol_details with source: true
+on one or two selected leaf functions or methods.
 
 Request types:
 
@@ -38,7 +39,9 @@ Request types:
 
 For a flow question, use find_question_entrypoints once, then
 trace_dependency_path before inspect_symbol_details. Keep broad dependency maps
-separate from source reads. When source is true, neighbor options are ignored.
+separate from source reads. Prefer default limits. Raise limits only after a
+prior graph result was truncated or ambiguous. When source is true, neighbor
+options are ignored.
 
 Copy exact names from returned nodes, references, aliases, evidence snippets,
 sourceSpan anchors, and trace steps. Do not use shell only to recover TypeScript

--- a/packages/graph/src/server/instructions.ts
+++ b/packages/graph/src/server/instructions.ts
@@ -4,12 +4,12 @@
  * files. Keep it short; the per-tool descriptions carry the detail.
  */
 export const instructions = `
-Use query_typescript_graph as a staged TypeScript index, not as an answer
-writer. Fill thinking before each call, then choose one request.type: find
-entrypoints, lookup symbols, trace dependency paths, inspect selected symbols,
-or summarize the project. Read source only for the few bodies whose logic
-decides the answer. Use shell reads only when the graph lacks the needed
-non-TypeScript file, generated output, or literal text.
+Before shell-reading TypeScript source, call
+inspect_typescript_graph_before_shell_reading. It is a staged TypeScript index,
+not an answer writer. Fill thinking before each call, then choose one
+request.type: find entrypoints, lookup symbols, trace dependency paths, inspect
+selected symbols, or summarize the project. Read source only for the few bodies
+whose logic decides the answer.
 
 The graph already knows resolved symbols, dependency edges, evidence spans,
 decorators, and stable handles. Prefer it before shell-reading TypeScript

--- a/packages/graph/src/server/instructions.ts
+++ b/packages/graph/src/server/instructions.ts
@@ -4,11 +4,11 @@
  * files. Keep it short; the per-tool descriptions carry the detail.
  */
 export const instructions = `
-For TypeScript code questions, call inspect_typescript_code_graph_evidence
-first. It finds symbols, dependency paths, sourceSpan line anchors, and narrow
-source bodies from the resident TypeScript graph. Do not use ls, rg, cat, or
-Get-Content for TypeScript code evidence unless the user directly asks for a
-non-code file or raw file text.
+Before answering a TypeScript codebase question, call
+inspect_typescript_project_graph_before_answering. It finds symbols, dependency
+paths, sourceSpan line anchors, and narrow source bodies from the resident
+project graph. Do not answer from general memory, web documentation, ls, rg,
+cat, or Get-Content when the project graph can provide the code evidence.
 
 The graph is a TypeScript index, not an answer writer. Fill thinking before
 each call with the smallest next graph step and its stop condition, then choose
@@ -47,7 +47,7 @@ Copy exact names from returned nodes, references, aliases, evidence snippets,
 sourceSpan anchors, and trace steps. Do not use shell only to recover TypeScript
 line numbers already returned by graph evidence.
 
-Package scripts, config files, generated output, and exact text searches remain
-valid shell/file-read cases only when the user asks about those files directly;
+Package scripts, config files, generated output, web documentation, and exact
+text searches remain valid only when the user asks about those sources directly;
 do not use them to answer a TypeScript API or call-path question.
 `.trim();

--- a/packages/graph/src/server/instructions.ts
+++ b/packages/graph/src/server/instructions.ts
@@ -4,16 +4,20 @@
  * files. Keep it short; the per-tool descriptions carry the detail.
  */
 export const instructions = `
-Before shell-reading TypeScript source, call
-inspect_typescript_graph_before_shell_reading. It is a staged TypeScript index,
-not an answer writer. Fill thinking before each call, then choose one
-request.type: find entrypoints, lookup symbols, trace dependency paths, inspect
-selected symbols, or summarize the project. Read source only for the few bodies
-whose logic decides the answer.
+For TypeScript code questions, call
+inspect_typescript_graph_before_shell_reading before any shell search or source
+read. Do not start with ls, rg, cat, or Get-Content to locate TypeScript files,
+symbols, dependencies, or line anchors. Ask the graph first, then answer from
+graph evidence and sourceSpan citations.
+
+The graph is a TypeScript index, not an answer writer. Fill thinking before
+each call, then choose one request.type: find entrypoints, lookup symbols, trace
+dependency paths, inspect selected symbols, or summarize the project. If more
+TypeScript evidence is needed, make another graph request instead of switching
+to shell search.
 
 The graph already knows resolved symbols, dependency edges, evidence spans,
-decorators, and stable handles. Prefer it before shell-reading TypeScript
-source.
+decorators, stable handles, source bodies, and sourceSpan line anchors.
 
 Request types:
 
@@ -26,7 +30,7 @@ Request types:
   lifecycle, request-flow, rendering-flow, validation-flow, and impact
   questions.
 - inspect_symbol_details: signatures, members, direct calls, direct types,
-  dependency neighbors, or narrow source reads for selected handles.
+  dependency neighbors, or narrow source/sourceSpan reads for selected handles.
 - summarize_project: source-free architecture map for layers, hotspots, counts,
   and public API.
 
@@ -35,8 +39,8 @@ trace_dependency_path before inspect_symbol_details. Keep broad dependency maps
 separate from source reads. When source is true, neighbor options are ignored.
 
 Copy exact names from returned nodes, references, aliases, evidence snippets,
-and trace steps. Prefer graph evidence and sourceSpan line anchors over shell
-reads for citations.
+sourceSpan anchors, and trace steps. Do not use shell only to recover TypeScript
+line numbers already returned by graph evidence.
 
 Package scripts, config files, generated output, and exact text searches remain
 valid shell/file-read cases because they are outside the symbol graph.

--- a/packages/graph/src/server/instructions.ts
+++ b/packages/graph/src/server/instructions.ts
@@ -17,6 +17,11 @@ entrypoints, lookup symbols, trace dependency paths, inspect selected symbols,
 or summarize the project. If more TypeScript evidence is needed, make another
 graph request instead of switching to shell search.
 
+For central public API or entrypoint questions, first use summarize_project with
+aspect: "publicApi". Choose one exported TypeScript symbol from that result,
+then trace_dependency_path or inspect_symbol_details for its concrete path. Do
+not start broad public API questions with a large entrypoint search.
+
 The graph already knows resolved symbols, dependency edges, evidence spans,
 decorators, stable handles, source bodies, and sourceSpan line anchors. If you
 need exact code or line numbers, use inspect_symbol_details with source: true
@@ -29,9 +34,10 @@ edge evidence and line anchors for the call expression.
 
 Request types:
 
-- find_question_entrypoints: first call for a natural-language code question.
-  It returns ranked symbols, direct mentions, and small dependency orientation
-  without source bodies.
+- find_question_entrypoints: compact shortlist for behavior-specific code
+  questions. It returns ranked symbols, direct mentions, and small dependency
+  orientation without source bodies. Do not use it as the first broad public API
+  map.
 - lookup_symbols: targeted symbol search for a class, method, function,
   property, or type when you do not already have its handle.
 - trace_dependency_path: call/type/dependency flow for "how A reaches B",
@@ -45,9 +51,10 @@ Request types:
 
 For a flow question, use find_question_entrypoints once, then
 trace_dependency_path before inspect_symbol_details. Keep broad dependency maps
-separate from source reads. Prefer default limits. Raise limits only after a
-prior graph result was truncated or ambiguous. When source is true, neighbor
-options are ignored.
+separate from source reads. Prefer compact defaults: small candidate lists,
+minimal neighbors, and no source bodies until a symbol is selected. Raise limits
+only after a prior graph result was truncated or ambiguous. When source is true,
+neighbor options are ignored.
 
 Copy exact names from returned nodes, references, aliases, evidence snippets,
 sourceSpan anchors, and trace steps. Do not use shell only to recover TypeScript

--- a/packages/graph/src/server/instructions.ts
+++ b/packages/graph/src/server/instructions.ts
@@ -4,36 +4,35 @@
  * files. Keep it short; the per-tool descriptions carry the detail.
  */
 export const instructions = `
-Use the graph tools as a staged TypeScript index, not as an answer writer. Get
-handles with question_entrypoints or symbol_lookup, trace relationships with
-dependency_path, inspect selected symbols with symbol_details, and read source
-only for the few bodies whose logic decides the answer. Keep source reads
-separate from dependency maps. Use shell reads only when the graph lacks the
-needed non-TypeScript file, generated output, or literal text.
+Use query_typescript_graph as a staged TypeScript index, not as an answer
+writer. Fill thinking before each call, then choose one request.type: find
+entrypoints, lookup symbols, trace dependency paths, inspect selected symbols,
+or summarize the project. Read source only for the few bodies whose logic
+decides the answer. Use shell reads only when the graph lacks the needed
+non-TypeScript file, generated output, or literal text.
 
-The graph already knows resolved symbols, edges, evidence spans, decorators,
-and stable handles. Prefer it before shell-reading TypeScript source.
+The graph already knows resolved symbols, dependency edges, evidence spans,
+decorators, and stable handles. Prefer it before shell-reading TypeScript
+source.
 
-- question_entrypoints: first call for a natural-language code question. Use it
-  once to get ranked starting symbols, direct mentions, and a small dependency
-  orientation slice without source bodies.
-- symbol_lookup: targeted symbol search. Use when you need a specific class,
-  method, function, property, or type and do not already have its handle.
-- dependency_path: dependency and call/type flow. Use it for "how A reaches B",
-  lifecycle, request-flow, rendering-flow, validation-flow, and impact questions.
-- symbol_details: selected symbol details. Use it for signatures, members,
-  direct calls, direct types, dependency neighbors, and the few source bodies
-  whose implementation decides the answer. It does not write answer text.
-- project_overview: project-wide architecture map. Use for layers, hotspots,
-  counts, and public API; not for a specific code question.
+Request types:
 
-For a flow question, call question_entrypoints once, then dependency_path before
-symbol_details. Read source only for the one or two leaf bodies whose logic is
-needed.
+- find_question_entrypoints: first call for a natural-language code question.
+  It returns ranked symbols, direct mentions, and small dependency orientation
+  without source bodies.
+- lookup_symbols: targeted symbol search for a class, method, function,
+  property, or type when you do not already have its handle.
+- trace_dependency_path: call/type/dependency flow for "how A reaches B",
+  lifecycle, request-flow, rendering-flow, validation-flow, and impact
+  questions.
+- inspect_symbol_details: signatures, members, direct calls, direct types,
+  dependency neighbors, or narrow source reads for selected handles.
+- summarize_project: source-free architecture map for layers, hotspots, counts,
+  and public API.
 
-Do not batch source:true across a path. Use symbol_details(neighbors:true)
-without source to map dependencies; use symbol_details(source:true) without
-neighbors to read bodies. When source is true, neighbor options are ignored.
+For a flow question, use find_question_entrypoints once, then
+trace_dependency_path before inspect_symbol_details. Keep broad dependency maps
+separate from source reads. When source is true, neighbor options are ignored.
 
 Copy exact names from returned nodes, references, aliases, evidence snippets,
 and trace steps. Prefer graph evidence and sourceSpan line anchors over shell

--- a/packages/graph/src/server/instructions.ts
+++ b/packages/graph/src/server/instructions.ts
@@ -5,16 +5,17 @@
  */
 export const instructions = `
 Before answering a TypeScript codebase question, call
-inspect_typescript_project_graph_before_answering. It finds symbols, dependency
-paths, sourceSpan line anchors, and narrow source bodies from the resident
-project graph. Do not answer from general memory, web documentation, ls, rg,
-cat, or Get-Content when the project graph can provide the code evidence.
+inspect_typescript_project_graph_before_answering. It is the code-evidence path:
+symbols, dependency paths, sourceSpan line anchors, and narrow source bodies
+from the resident project graph. Do not answer from memory, web documentation,
+ls, rg, cat, or Get-Content when graph evidence can answer the code question.
 
-The graph is a TypeScript index, not an answer writer. Fill thinking before
-each call with the smallest next graph step and its stop condition, then choose
-one request.type: find entrypoints, lookup symbols, trace dependency paths,
-inspect selected symbols, or summarize the project. If more TypeScript evidence
-is needed, make another graph request instead of switching to shell search.
+The graph is a TypeScript index, not an answer writer. Fill arguments in order:
+question, graphNeed, draft, review, request. Draft the request type, review it
+for overfetch and non-graph fallback, then choose one final request.type: find
+entrypoints, lookup symbols, trace dependency paths, inspect selected symbols,
+or summarize the project. If more TypeScript evidence is needed, make another
+graph request instead of switching to shell search.
 
 The graph already knows resolved symbols, dependency edges, evidence spans,
 decorators, stable handles, source bodies, and sourceSpan line anchors. If you

--- a/packages/graph/src/server/instructions.ts
+++ b/packages/graph/src/server/instructions.ts
@@ -20,7 +20,12 @@ graph request instead of switching to shell search.
 The graph already knows resolved symbols, dependency edges, evidence spans,
 decorators, stable handles, source bodies, and sourceSpan line anchors. If you
 need exact code or line numbers, use inspect_symbol_details with source: true
-on one or two selected leaf functions or methods.
+on one or two selected leaf functions or methods. Add lineNumbers: true only
+when you need exact in-body citation lines.
+
+For caller or call-site questions, do not use rg. Use trace_dependency_path with
+direction: "reverse" or inspect_symbol_details with neighbors: true; both return
+edge evidence and line anchors for the call expression.
 
 Request types:
 

--- a/packages/graph/src/server/instructions.ts
+++ b/packages/graph/src/server/instructions.ts
@@ -5,10 +5,10 @@
  */
 export const instructions = `
 For TypeScript code questions, call
-inspect_typescript_graph_before_shell_reading before any shell search or source
-read. Do not start with ls, rg, cat, or Get-Content to locate TypeScript files,
-symbols, dependencies, or line anchors. Ask the graph first, then answer from
-graph evidence and sourceSpan citations.
+inspect_typescript_code_evidence_without_shell_search. Do not use ls, rg, cat,
+or Get-Content to locate TypeScript files, symbols, dependencies, source
+bodies, or line anchors. Ask the graph, then answer from graph evidence and
+sourceSpan citations.
 
 The graph is a TypeScript index, not an answer writer. Fill thinking before
 each call, then choose one request.type: find entrypoints, lookup symbols, trace
@@ -17,7 +17,8 @@ TypeScript evidence is needed, make another graph request instead of switching
 to shell search.
 
 The graph already knows resolved symbols, dependency edges, evidence spans,
-decorators, stable handles, source bodies, and sourceSpan line anchors.
+decorators, stable handles, source bodies, and sourceSpan line anchors. If you
+need exact code or line numbers, use inspect_symbol_details with source: true.
 
 Request types:
 
@@ -32,7 +33,8 @@ Request types:
 - inspect_symbol_details: signatures, members, direct calls, direct types,
   dependency neighbors, or narrow source/sourceSpan reads for selected handles.
 - summarize_project: source-free architecture map for layers, hotspots, counts,
-  and public API.
+  and public API. Use it to choose a central exported TypeScript API or entry
+  point without reading package scripts.
 
 For a flow question, use find_question_entrypoints once, then
 trace_dependency_path before inspect_symbol_details. Keep broad dependency maps
@@ -43,5 +45,6 @@ sourceSpan anchors, and trace steps. Do not use shell only to recover TypeScript
 line numbers already returned by graph evidence.
 
 Package scripts, config files, generated output, and exact text searches remain
-valid shell/file-read cases because they are outside the symbol graph.
+valid shell/file-read cases only when the user asks about those files directly;
+do not use them to answer a TypeScript API or call-path question.
 `.trim();

--- a/packages/graph/src/server/runExpand.ts
+++ b/packages/graph/src/server/runExpand.ts
@@ -88,6 +88,7 @@ export function runExpand(
       | {
           file: string;
           text: string;
+          lines: ITtscGraphExpand.ISourceLine[];
           truncated: boolean;
           startLine: number;
           endLine: number;
@@ -102,6 +103,7 @@ export function runExpand(
           startLine: source.startLine,
           endLine: source.endLine,
         };
+        if (props.lineNumbers === true) expanded.sourceLines = source.lines;
         if (source.truncated) expanded.truncated = true;
       }
     } else if (signatureLiterals.length > 0) {
@@ -187,12 +189,7 @@ function refs(
 }
 
 const executionKinds = new Set(["calls", "instantiates", "renders"]);
-const typeKinds = new Set([
-  "type_ref",
-  "extends",
-  "implements",
-  "overrides",
-]);
+const typeKinds = new Set(["type_ref", "extends", "implements", "overrides"]);
 
 function dependencySummaries(
   graph: TtscGraphMemory,
@@ -375,6 +372,7 @@ function readSource(
   | {
       file: string;
       text: string;
+      lines: ITtscGraphExpand.ISourceLine[];
       truncated: boolean;
       startLine: number;
       endLine: number;
@@ -395,6 +393,10 @@ function readSource(
   return {
     file: evidence.file,
     text: slice.join("\n"),
+    lines: slice.map((text, index) => ({
+      line: start + index + 1,
+      text,
+    })),
     truncated,
     startLine: start + 1,
     endLine: start + slice.length,

--- a/packages/graph/src/server/runIndex.ts
+++ b/packages/graph/src/server/runIndex.ts
@@ -6,11 +6,11 @@ import { resolveGraphHandle } from "./resolveHandle";
 import { decoratorsOf, edgeEvidenceOf, signatureOf } from "./runExpand";
 import { runQuery } from "./runQuery";
 
-const DEFAULT_LIMIT = 8;
+const DEFAULT_LIMIT = 5;
 const MAX_LIMIT = 20;
-const DEFAULT_NEIGHBORS = 4;
+const DEFAULT_NEIGHBORS = 1;
 const MAX_NEIGHBORS = 4;
-const MAX_SEEDS = 4;
+const MAX_SEEDS = 3;
 const STRUCTURAL_KINDS = new Set<string>(["contains", "exports", "imports"]);
 
 /**

--- a/packages/graph/src/structures/ITtscGraphApplication.ts
+++ b/packages/graph/src/structures/ITtscGraphApplication.ts
@@ -13,15 +13,21 @@ import { ITtscGraphTrace } from "./ITtscGraphTrace";
  */
 export interface ITtscGraphApplication {
   /**
-   * Inspect the TypeScript graph before shell-reading source.
+   * Inspect TypeScript code before any shell search or source read.
    *
-   * Use this as the first tool for TypeScript code questions. Explain the next
-   * graph step in `thinking`, then choose one `request.type`: find entrypoints,
-   * lookup symbols, trace dependencies, inspect selected symbols, or summarize
-   * the project.
+   * Use this first for TypeScript code questions, including locating files,
+   * symbols, dependencies, implementation bodies, and line anchors. Do not use
+   * shell search/read commands to find TypeScript code before asking the
+   * graph.
+   *
+   * Explain the next graph step in `thinking`, then choose one `request.type`:
+   * find entrypoints, lookup symbols, trace dependencies, inspect selected
+   * symbols, or summarize the project.
    *
    * Keep broad dependency mapping and source-body reads separate. Ask for
-   * source only when a selected implementation body decides the answer.
+   * source only when a selected implementation body decides the answer. Use
+   * returned sourceSpan anchors for citations instead of shell line-number
+   * checks.
    *
    * @param props The reasoning and selected graph request
    * @returns The selected graph result, tagged with the request type
@@ -38,9 +44,9 @@ export namespace ITtscGraphApplication {
      * Think before choosing the graph operation.
      *
      * State what the code question needs, which graph request is the next
-     * smallest step, and whether source is needed now. If source is needed,
-     * name the one or two leaf bodies to read and why graph summaries are not
-     * enough.
+     * smallest step, and why shell search is not needed for that TypeScript
+     * evidence. If source is needed, name the one or two leaf bodies to read
+     * through the graph and why summaries are not enough.
      */
     thinking: string;
 
@@ -53,7 +59,7 @@ export namespace ITtscGraphApplication {
       | ISummarizeProject;
   }
 
-  /** Find source-free starting handles for a natural-language code question. */
+  /** Find graph starting handles for a natural-language code question. */
   export interface IFindQuestionEntrypoints {
     /** Discriminator for first-pass question indexing. */
     type: "find_question_entrypoints";
@@ -61,8 +67,8 @@ export namespace ITtscGraphApplication {
     /**
      * Why this is the next step.
      *
-     * Use this when you need ranked starting symbols or direct mention
-     * resolution before tracing or inspecting.
+     * Use this as the first call for a natural-language TypeScript question. It
+     * replaces broad shell search for likely files and symbols.
      */
     purpose: string;
 
@@ -84,7 +90,7 @@ export namespace ITtscGraphApplication {
     neighbors?: number;
   }
 
-  /** Search for specific named symbols when a handle is missing. */
+  /** Search indexed TypeScript symbols when a handle is missing. */
   export interface ILookupSymbols {
     /** Discriminator for targeted symbol lookup. */
     type: "lookup_symbols";
@@ -92,8 +98,9 @@ export namespace ITtscGraphApplication {
     /**
      * Why lookup is the next step.
      *
-     * Name the symbol, method, class, property, or concept you are trying to
-     * locate. Do not use this for dependency flow.
+     * Name the symbol, method, class, property, file concept, or framework term
+     * you are trying to locate. Use this when you would otherwise reach for rg
+     * to find TypeScript code. Do not use it for dependency flow.
      */
     purpose: string;
 
@@ -108,7 +115,7 @@ export namespace ITtscGraphApplication {
     limit?: number;
   }
 
-  /** Trace call/type/dependency flow from one symbol, optionally to a target. */
+  /** Trace TypeScript call/type/dependency flow between graph handles. */
   export interface ITraceDependencyPath {
     /** Discriminator for dependency tracing. */
     type: "trace_dependency_path";
@@ -116,8 +123,8 @@ export namespace ITtscGraphApplication {
     /**
      * Why tracing is the next step.
      *
-     * State the relationship being tested, such as "how A reaches B" or "which
-     * callers depend on A".
+     * State the relationship being tested, such as request flow, render flow,
+     * validation flow, "how A reaches B", or "which callers depend on A".
      */
     purpose: string;
 
@@ -156,7 +163,7 @@ export namespace ITtscGraphApplication {
     maxNodes?: number;
   }
 
-  /** Inspect selected handles, with source bodies only when necessary. */
+  /** Inspect selected handles, including sourceSpan bodies when necessary. */
   export interface IInspectSymbolDetails {
     /** Discriminator for selected symbol inspection. */
     type: "inspect_symbol_details";
@@ -165,7 +172,9 @@ export namespace ITtscGraphApplication {
      * Why inspection is the next step.
      *
      * Say whether this is shape-only expansion, neighbor mapping, or a narrow
-     * source read. Source reads should be limited to decisive leaf bodies.
+     * graph source read. Source reads should be limited to decisive leaf
+     * bodies. Use returned sourceSpan anchors for citations instead of shell
+     * reads.
      */
     purpose: string;
 

--- a/packages/graph/src/structures/ITtscGraphApplication.ts
+++ b/packages/graph/src/structures/ITtscGraphApplication.ts
@@ -13,12 +13,13 @@ import { ITtscGraphTrace } from "./ITtscGraphTrace";
  */
 export interface ITtscGraphApplication {
   /**
-   * Find, trace, and inspect TypeScript code evidence from the graph.
+   * Inspect the TypeScript project graph before answering code questions.
    *
-   * Use this first for TypeScript code questions. It locates files, symbols,
-   * dependency paths, implementation bodies, and sourceSpan line anchors from
-   * the resident TypeScript graph, so shell search or file reads are usually
-   * unnecessary for code evidence.
+   * Use this before answering TypeScript codebase questions. It locates files,
+   * symbols, dependency paths, implementation bodies, and sourceSpan line
+   * anchors from the resident project graph, so answers do not need general
+   * framework memory, web documentation, shell search, or file reads for code
+   * evidence.
    *
    * In `thinking`, decide the smallest next graph step and the evidence needed
    * to stop. Then choose one `request.type`: find entrypoints, lookup symbols,
@@ -33,7 +34,7 @@ export interface ITtscGraphApplication {
    * @param props The reasoning and selected graph request
    * @returns The selected graph result, tagged with the request type
    */
-  inspect_typescript_code_graph_evidence(
+  inspect_typescript_project_graph_before_answering(
     props: ITtscGraphApplication.IProps,
   ): ITtscGraphApplication.IResult;
 }

--- a/packages/graph/src/structures/ITtscGraphApplication.ts
+++ b/packages/graph/src/structures/ITtscGraphApplication.ts
@@ -13,9 +13,9 @@ import { ITtscGraphTrace } from "./ITtscGraphTrace";
  */
 export interface ITtscGraphApplication {
   /**
-   * Plan and run one TypeScript graph operation.
+   * Inspect the TypeScript graph before shell-reading source.
    *
-   * Use this before shell-reading TypeScript source. First explain the next
+   * Use this as the first tool for TypeScript code questions. Explain the next
    * graph step in `thinking`, then choose one `request.type`: find entrypoints,
    * lookup symbols, trace dependencies, inspect selected symbols, or summarize
    * the project.
@@ -26,7 +26,7 @@ export interface ITtscGraphApplication {
    * @param props The reasoning and selected graph request
    * @returns The selected graph result, tagged with the request type
    */
-  query_typescript_graph(
+  inspect_typescript_graph_before_shell_reading(
     props: ITtscGraphApplication.IProps,
   ): ITtscGraphApplication.IResult;
 }

--- a/packages/graph/src/structures/ITtscGraphApplication.ts
+++ b/packages/graph/src/structures/ITtscGraphApplication.ts
@@ -13,26 +13,27 @@ import { ITtscGraphTrace } from "./ITtscGraphTrace";
  */
 export interface ITtscGraphApplication {
   /**
-   * Resolve TypeScript code evidence without shell search.
+   * Find, trace, and inspect TypeScript code evidence from the graph.
    *
-   * Use this for TypeScript code questions, including locating files, symbols,
-   * dependencies, implementation bodies, and line anchors. Do not use shell
-   * search/read commands to find or verify TypeScript code while this graph can
-   * answer with symbols, source bodies, and sourceSpan anchors.
+   * Use this first for TypeScript code questions. It locates files, symbols,
+   * dependency paths, implementation bodies, and sourceSpan line anchors from
+   * the resident TypeScript graph, so shell search or file reads are usually
+   * unnecessary for code evidence.
    *
-   * Explain the next graph step in `thinking`, then choose one `request.type`:
-   * find entrypoints, lookup symbols, trace dependencies, inspect selected
-   * symbols, or summarize the project.
+   * In `thinking`, decide the smallest next graph step and the evidence needed
+   * to stop. Then choose one `request.type`: find entrypoints, lookup symbols,
+   * trace dependencies, inspect selected symbols, or summarize the project.
    *
-   * Keep broad dependency mapping and source-body reads separate. Ask for
-   * source only when a selected implementation body decides the answer. Use
-   * returned sourceSpan anchors for citations instead of shell line-number
-   * checks.
+   * Keep result slices small. Prefer defaults, and raise `limit`,
+   * `neighborLimit`, or `maxNodes` only after a previous graph result was
+   * truncated or ambiguous. Keep broad dependency maps and source-body reads in
+   * separate calls; ask for `source: true` only for decisive leaf bodies. Use
+   * returned sourceSpan anchors instead of shell line-number checks.
    *
    * @param props The reasoning and selected graph request
    * @returns The selected graph result, tagged with the request type
    */
-  inspect_typescript_code_evidence_without_shell_search(
+  inspect_typescript_code_graph_evidence(
     props: ITtscGraphApplication.IProps,
   ): ITtscGraphApplication.IResult;
 }
@@ -43,12 +44,13 @@ export namespace ITtscGraphApplication {
     /**
      * Think before choosing the graph operation.
      *
-     * State what the code question needs, which graph request is the next
-     * smallest step, and why shell search is not needed for that TypeScript
-     * evidence. If source is needed, name the one or two leaf bodies to read
-     * through the graph and why summaries are not enough. If a package script,
-     * config file, or generated artifact is tempting, say why it is outside or
-     * inside the user's TypeScript code question.
+     * State the user's code question, the smallest graph request that advances
+     * it, the stop condition for this call, and why shell search is not needed
+     * for this TypeScript evidence. If source is needed, name the one or two
+     * leaf bodies to read through the graph and why signatures, trace steps, or
+     * dependency summaries are not enough. If a package script, config file, or
+     * generated artifact is tempting, say why it is outside or inside the
+     * user's TypeScript code question.
      */
     thinking: string;
 
@@ -80,12 +82,18 @@ export namespace ITtscGraphApplication {
     /**
      * Maximum ranked hits to return.
      *
+     * Keep the default for the first pass. Raise it only when the prior result
+     * was truncated or did not contain enough distinct candidates.
+     *
      * @default 8
      */
     limit?: number;
 
     /**
      * Maximum direct dependencies and dependents to return per indexed symbol.
+     *
+     * This is orientation, not a dump. Keep the default unless the answer needs
+     * more direct neighbors from an already chosen symbol.
      *
      * @default 4
      */
@@ -112,6 +120,9 @@ export namespace ITtscGraphApplication {
 
     /**
      * Maximum hits to return.
+     *
+     * Keep the default for broad or natural-language lookup. Raise it only
+     * after a too-small or ambiguous prior result.
      *
      * @default 12
      */
@@ -161,6 +172,9 @@ export namespace ITtscGraphApplication {
     /**
      * Maximum reached nodes before truncation.
      *
+     * Prefer the default for open traces. For "how does A reach B" questions,
+     * pass `to` instead of raising this cap.
+     *
      * @default 30
      */
     maxNodes?: number;
@@ -187,6 +201,9 @@ export namespace ITtscGraphApplication {
     /**
      * Return direct dependencies and dependents.
      *
+     * Use this for a selected symbol's immediate graph context. Do not combine
+     * it with `source: true`; source reads intentionally ignore neighbors.
+     *
      * @default false
      */
     neighbors?: boolean;
@@ -194,12 +211,18 @@ export namespace ITtscGraphApplication {
     /**
      * Maximum dependencies and dependents per side.
      *
+     * Keep the default unless a prior neighbor slice was truncated or too
+     * ambiguous.
+     *
      * @default 6
      */
     neighborLimit?: number;
 
     /**
      * Return the declaration or implementation source body.
+     *
+     * Use only after a handle is selected and the implementation body is needed
+     * to answer. Prefer one or two method/function handles, not containers.
      *
      * @default false
      */

--- a/packages/graph/src/structures/ITtscGraphApplication.ts
+++ b/packages/graph/src/structures/ITtscGraphApplication.ts
@@ -7,81 +7,237 @@ import { ITtscGraphTrace } from "./ITtscGraphTrace";
 /**
  * The MCP tool surface of `@ttsc/graph`, as a typed application.
  *
- * Each method is one MCP tool; its name is the tool name and its parameter
- * object becomes the tool's JSON schema once `typia.llm.controller` reflects
- * this interface. `TtscGraphApplication` implements it over the resident
- * graph.
+ * The single method is the single MCP tool. Its parameter object becomes the
+ * JSON schema once `typia.llm.controller` reflects this interface.
+ * `TtscGraphApplication` implements it over the resident graph.
  */
 export interface ITtscGraphApplication {
   /**
-   * Locate the best starting symbols for a natural-language code question.
+   * Plan and run one TypeScript graph operation.
    *
-   * Use this once at the start of a source-flow question. It returns ranked
-   * symbols, directly mentioned handles, signatures, decorators, and a small
-   * dependency orientation slice without source bodies.
+   * Use this before shell-reading TypeScript source. First explain the next
+   * graph step in `thinking`, then choose one `request.type`: find entrypoints,
+   * lookup symbols, trace dependencies, inspect selected symbols, or summarize
+   * the project.
    *
-   * Follow with `symbol_lookup` when a specific named symbol is missing,
-   * `dependency_path` for call/type flow, or `symbol_details` for selected
-   * declarations.
+   * Keep broad dependency mapping and source-body reads separate. Ask for
+   * source only when a selected implementation body decides the answer.
    *
-   * @param props The natural code question or search phrase
-   * @returns Compact graph coordinates and dependency context
+   * @param props The reasoning and selected graph request
+   * @returns The selected graph result, tagged with the request type
    */
-  question_entrypoints(props: ITtscGraphIndex.IProps): ITtscGraphIndex;
+  query_typescript_graph(
+    props: ITtscGraphApplication.IProps,
+  ): ITtscGraphApplication.IResult;
+}
 
-  /**
-   * Find specific symbols by name or description.
-   *
-   * Use this when you need a class, function, method, property, or type and do
-   * not already have its handle. It is targeted lookup, not flow tracing.
-   *
-   * Follow with `dependency_path` for relationships or `symbol_details` for
-   * declarations and source bodies.
-   *
-   * @param props The query and result cap
-   * @returns Ranked hits with handles
-   */
-  symbol_lookup(props: ITtscGraphQuery.IProps): ITtscGraphQuery;
+export namespace ITtscGraphApplication {
+  /** Reason first, then submit exactly one graph request. */
+  export interface IProps {
+    /**
+     * Think before choosing the graph operation.
+     *
+     * State what the code question needs, which graph request is the next
+     * smallest step, and whether source is needed now. If source is needed,
+     * name the one or two leaf bodies to read and why graph summaries are not
+     * enough.
+     */
+    thinking: string;
 
-  /**
-   * Trace dependency flow between or away from symbols.
-   *
-   * Use `from` and optional `to` for call paths such as "how A reaches B".
-   * `focus:"execution"` follows runtime edges; `focus:"types"` follows type
-   * and inheritance edges.
-   *
-   * Hops carry evidence and aliases. Path results include compact `steps`, so
-   * many flow questions do not need source expansion.
-   *
-   * @param props The start, optional target, direction, and bounds
-   * @returns The ordered hops and reached nodes, or candidates for an ambiguous
-   *   start
-   */
-  dependency_path(props: ITtscGraphTrace.IProps): ITtscGraphTrace;
+    /** The graph operation chosen from the reasoning above. */
+    request:
+      | IFindQuestionEntrypoints
+      | ILookupSymbols
+      | ITraceDependencyPath
+      | IInspectSymbolDetails
+      | ISummarizeProject;
+  }
 
-  /**
-   * Inspect selected symbols and optionally read their bodies.
-   *
-   * Use multiple handles for shape-only expansion: signatures, members,
-   * decorators, direct calls, direct types, and bounded dependency neighbors.
-   *
-   * Use `source:true` only for the one or two leaf bodies whose implementation
-   * decides the answer. Use `neighbors:true` without source for dependency
-   * mapping; source mode ignores neighbor expansion.
-   *
-   * @param props The handles to expand
-   * @returns The resolved nodes, and any handles that did not resolve
-   */
-  symbol_details(props: ITtscGraphExpand.IProps): ITtscGraphExpand;
+  /** Find source-free starting handles for a natural-language code question. */
+  export interface IFindQuestionEntrypoints {
+    /** Discriminator for first-pass question indexing. */
+    type: "find_question_entrypoints";
 
-  /**
-   * Summarize the project-wide graph shape.
-   *
-   * Use this for architecture orientation: folder layers, dependency hotspots,
-   * and public API handles. It is not a symbol search or source reader.
-   *
-   * @param props Which facet to project
-   * @returns The requested architecture facets
-   */
-  project_overview(props: ITtscGraphOverview.IProps): ITtscGraphOverview;
+    /**
+     * Why this is the next step.
+     *
+     * Use this when you need ranked starting symbols or direct mention
+     * resolution before tracing or inspecting.
+     */
+    purpose: string;
+
+    /** Natural code question or search phrase. */
+    query: string;
+
+    /**
+     * Maximum ranked hits to return.
+     *
+     * @default 8
+     */
+    limit?: number;
+
+    /**
+     * Maximum direct dependencies and dependents to return per indexed symbol.
+     *
+     * @default 4
+     */
+    neighbors?: number;
+  }
+
+  /** Search for specific named symbols when a handle is missing. */
+  export interface ILookupSymbols {
+    /** Discriminator for targeted symbol lookup. */
+    type: "lookup_symbols";
+
+    /**
+     * Why lookup is the next step.
+     *
+     * Name the symbol, method, class, property, or concept you are trying to
+     * locate. Do not use this for dependency flow.
+     */
+    purpose: string;
+
+    /** Symbol name, dotted member, or natural-language symbol phrase. */
+    query: string;
+
+    /**
+     * Maximum hits to return.
+     *
+     * @default 12
+     */
+    limit?: number;
+  }
+
+  /** Trace call/type/dependency flow from one symbol, optionally to a target. */
+  export interface ITraceDependencyPath {
+    /** Discriminator for dependency tracing. */
+    type: "trace_dependency_path";
+
+    /**
+     * Why tracing is the next step.
+     *
+     * State the relationship being tested, such as "how A reaches B" or "which
+     * callers depend on A".
+     */
+    purpose: string;
+
+    /** Start node id, simple symbol name, or dotted member name. */
+    from: string;
+
+    /** Optional target node id, simple symbol name, or dotted member name. */
+    to?: string;
+
+    /**
+     * Trace direction.
+     *
+     * @default "forward"
+     */
+    direction?: "forward" | "reverse" | "impact";
+
+    /**
+     * Edge family to follow.
+     *
+     * @default "all"
+     */
+    focus?: "all" | "execution" | "types";
+
+    /**
+     * Maximum hop depth.
+     *
+     * @default 6
+     */
+    maxDepth?: number;
+
+    /**
+     * Maximum reached nodes before truncation.
+     *
+     * @default 30
+     */
+    maxNodes?: number;
+  }
+
+  /** Inspect selected handles, with source bodies only when necessary. */
+  export interface IInspectSymbolDetails {
+    /** Discriminator for selected symbol inspection. */
+    type: "inspect_symbol_details";
+
+    /**
+     * Why inspection is the next step.
+     *
+     * Say whether this is shape-only expansion, neighbor mapping, or a narrow
+     * source read. Source reads should be limited to decisive leaf bodies.
+     */
+    purpose: string;
+
+    /** Handles to expand: node ids or dotted symbol handles. */
+    handles: string[];
+
+    /**
+     * Return direct dependencies and dependents.
+     *
+     * @default false
+     */
+    neighbors?: boolean;
+
+    /**
+     * Maximum dependencies and dependents per side.
+     *
+     * @default 6
+     */
+    neighborLimit?: number;
+
+    /**
+     * Return the declaration or implementation source body.
+     *
+     * @default false
+     */
+    source?: boolean;
+  }
+
+  /** Summarize project-wide graph shape without reading source bodies. */
+  export interface ISummarizeProject {
+    /** Discriminator for architecture overview. */
+    type: "summarize_project";
+
+    /**
+     * Why overview is the next step.
+     *
+     * Use this for architecture orientation, public API, layers, and hotspots;
+     * not for a specific symbol relationship.
+     */
+    purpose: string;
+
+    /**
+     * Which project-wide graph facet to return.
+     *
+     * @default "all"
+     */
+    aspect?: "all" | "layers" | "hotspots" | "publicApi";
+  }
+
+  /** The selected request's output. Exactly one result field is populated. */
+  export interface IResult {
+    /** Mirrors `request.type` so the caller can read the matching field. */
+    type:
+      | "find_question_entrypoints"
+      | "lookup_symbols"
+      | "trace_dependency_path"
+      | "inspect_symbol_details"
+      | "summarize_project";
+
+    /** Result for `find_question_entrypoints`. */
+    entrypoints?: ITtscGraphIndex;
+
+    /** Result for `lookup_symbols`. */
+    symbols?: ITtscGraphQuery;
+
+    /** Result for `trace_dependency_path`. */
+    trace?: ITtscGraphTrace;
+
+    /** Result for `inspect_symbol_details`. */
+    details?: ITtscGraphExpand;
+
+    /** Result for `summarize_project`. */
+    overview?: ITtscGraphOverview;
+  }
 }

--- a/packages/graph/src/structures/ITtscGraphApplication.ts
+++ b/packages/graph/src/structures/ITtscGraphApplication.ts
@@ -75,8 +75,11 @@ export namespace ITtscGraphApplication {
      * Critical review of the draft request.
      *
      * Check whether the draft avoids overfetch, shell fallback, web lookup,
-     * broad source reads, and unnecessary neighbor/source combinations. If the
-     * draft is wrong, choose the corrected type in `request`.
+     * broad source reads, and unnecessary neighbor/source combinations. For
+     * caller or call-site questions, prefer reverse trace or
+     * `inspect_symbol_details` with `neighbors:true`. For exact in-body line
+     * anchors, request graph source line numbers. If the draft is wrong, choose
+     * the corrected type in `request`.
      */
     review: string;
 
@@ -231,7 +234,8 @@ export namespace ITtscGraphApplication {
      * Say whether this is shape-only expansion, neighbor mapping, or a narrow
      * graph source read. Source reads should be limited to decisive leaf
      * bodies. Use returned source and sourceSpan anchors for citations instead
-     * of shell reads or line-number checks.
+     * of shell reads or line-number checks. For caller discovery, use
+     * `neighbors:true`; for exact in-body citations, use `lineNumbers:true`.
      */
     purpose: string;
 
@@ -267,6 +271,17 @@ export namespace ITtscGraphApplication {
      * @default false
      */
     source?: boolean;
+
+    /**
+     * Return numbered source lines with a source read.
+     *
+     * Use with `source: true` when exact in-body line anchors are needed. This
+     * replaces shell `rg`, `cat`, and `Get-Content` line checks. Leave false
+     * when the declaration-level sourceSpan is enough.
+     *
+     * @default false
+     */
+    lineNumbers?: boolean;
   }
 
   /** Summarize project-wide graph shape without reading source bodies. */

--- a/packages/graph/src/structures/ITtscGraphApplication.ts
+++ b/packages/graph/src/structures/ITtscGraphApplication.ts
@@ -128,7 +128,7 @@ export namespace ITtscGraphApplication {
      * Keep the default for the first pass. Raise it only when the prior result
      * was truncated or did not contain enough distinct candidates.
      *
-     * @default 8
+     * @default 5
      */
     limit?: number;
 
@@ -138,7 +138,7 @@ export namespace ITtscGraphApplication {
      * This is orientation, not a dump. Keep the default unless the answer needs
      * more direct neighbors from an already chosen symbol.
      *
-     * @default 4
+     * @default 1
      */
     neighbors?: number;
   }

--- a/packages/graph/src/structures/ITtscGraphApplication.ts
+++ b/packages/graph/src/structures/ITtscGraphApplication.ts
@@ -21,8 +21,9 @@ export interface ITtscGraphApplication {
    * framework memory, web documentation, shell search, or file reads for code
    * evidence.
    *
-   * In `thinking`, decide the smallest next graph step and the evidence needed
-   * to stop. Then choose one `request.type`: find entrypoints, lookup symbols,
+   * Fill the properties in order: restate the question, explain why graph
+   * evidence is required, draft the next request type, review that draft, and
+   * only then choose one `request.type`: find entrypoints, lookup symbols,
    * trace dependencies, inspect selected symbols, or summarize the project.
    *
    * Keep result slices small. Prefer defaults, and raise `limit`,
@@ -40,20 +41,44 @@ export interface ITtscGraphApplication {
 }
 
 export namespace ITtscGraphApplication {
-  /** Reason first, then submit exactly one graph request. */
+  /** Think, review, then submit exactly one graph request. */
   export interface IProps {
     /**
-     * Think before choosing the graph operation.
+     * User's TypeScript code question.
      *
-     * State the user's code question, the smallest graph request that advances
-     * it, the stop condition for this call, and why shell search is not needed
-     * for this TypeScript evidence. If source is needed, name the one or two
-     * leaf bodies to read through the graph and why signatures, trace steps, or
-     * dependency summaries are not enough. If a package script, config file, or
-     * generated artifact is tempting, say why it is outside or inside the
-     * user's TypeScript code question.
+     * Restate the codebase question being answered. Keep this about TypeScript
+     * source, symbols, call flow, type flow, or architecture. If the user is
+     * asking about scripts, config, generated output, or documentation instead,
+     * say that boundary here.
      */
-    thinking: string;
+    question: string;
+
+    /**
+     * Why the resident graph is the next evidence source.
+     *
+     * State what graph evidence is needed and why memory, web documentation,
+     * shell search, or source file reads are not the next step for this call.
+     * Name the smallest evidence that would let the agent stop.
+     */
+    graphNeed: string;
+
+    /**
+     * First request-type decision before arguments are filled.
+     *
+     * Choose the operation class and explain why it is smaller than the
+     * alternatives. This is only the draft; the final arguments are in
+     * `request` after `review`.
+     */
+    draft: IRequestDraft;
+
+    /**
+     * Critical review of the draft request.
+     *
+     * Check whether the draft avoids overfetch, shell fallback, web lookup,
+     * broad source reads, and unnecessary neighbor/source combinations. If the
+     * draft is wrong, choose the corrected type in `request`.
+     */
+    review: string;
 
     /** The graph operation chosen from the reasoning above. */
     request:
@@ -62,6 +87,20 @@ export namespace ITtscGraphApplication {
       | ITraceDependencyPath
       | IInspectSymbolDetails
       | ISummarizeProject;
+  }
+
+  /** First-pass operation choice before final request arguments. */
+  export interface IRequestDraft {
+    /** Draft discriminator for the intended graph operation. */
+    type:
+      | "find_question_entrypoints"
+      | "lookup_symbols"
+      | "trace_dependency_path"
+      | "inspect_symbol_details"
+      | "summarize_project";
+
+    /** Why this operation type is the smallest useful next step. */
+    reason: string;
   }
 
   /** Find graph starting handles for a natural-language code question. */

--- a/packages/graph/src/structures/ITtscGraphApplication.ts
+++ b/packages/graph/src/structures/ITtscGraphApplication.ts
@@ -13,12 +13,12 @@ import { ITtscGraphTrace } from "./ITtscGraphTrace";
  */
 export interface ITtscGraphApplication {
   /**
-   * Inspect TypeScript code before any shell search or source read.
+   * Resolve TypeScript code evidence without shell search.
    *
-   * Use this first for TypeScript code questions, including locating files,
-   * symbols, dependencies, implementation bodies, and line anchors. Do not use
-   * shell search/read commands to find TypeScript code before asking the
-   * graph.
+   * Use this for TypeScript code questions, including locating files, symbols,
+   * dependencies, implementation bodies, and line anchors. Do not use shell
+   * search/read commands to find or verify TypeScript code while this graph can
+   * answer with symbols, source bodies, and sourceSpan anchors.
    *
    * Explain the next graph step in `thinking`, then choose one `request.type`:
    * find entrypoints, lookup symbols, trace dependencies, inspect selected
@@ -32,7 +32,7 @@ export interface ITtscGraphApplication {
    * @param props The reasoning and selected graph request
    * @returns The selected graph result, tagged with the request type
    */
-  inspect_typescript_graph_before_shell_reading(
+  inspect_typescript_code_evidence_without_shell_search(
     props: ITtscGraphApplication.IProps,
   ): ITtscGraphApplication.IResult;
 }
@@ -46,7 +46,9 @@ export namespace ITtscGraphApplication {
      * State what the code question needs, which graph request is the next
      * smallest step, and why shell search is not needed for that TypeScript
      * evidence. If source is needed, name the one or two leaf bodies to read
-     * through the graph and why summaries are not enough.
+     * through the graph and why summaries are not enough. If a package script,
+     * config file, or generated artifact is tempting, say why it is outside or
+     * inside the user's TypeScript code question.
      */
     thinking: string;
 
@@ -68,7 +70,7 @@ export namespace ITtscGraphApplication {
      * Why this is the next step.
      *
      * Use this as the first call for a natural-language TypeScript question. It
-     * replaces broad shell search for likely files and symbols.
+     * replaces broad shell search for likely files, symbols, and line anchors.
      */
     purpose: string;
 
@@ -100,7 +102,8 @@ export namespace ITtscGraphApplication {
      *
      * Name the symbol, method, class, property, file concept, or framework term
      * you are trying to locate. Use this when you would otherwise reach for rg
-     * to find TypeScript code. Do not use it for dependency flow.
+     * to find TypeScript code or exact line anchors. Do not use it for
+     * dependency flow.
      */
     purpose: string;
 
@@ -173,8 +176,8 @@ export namespace ITtscGraphApplication {
      *
      * Say whether this is shape-only expansion, neighbor mapping, or a narrow
      * graph source read. Source reads should be limited to decisive leaf
-     * bodies. Use returned sourceSpan anchors for citations instead of shell
-     * reads.
+     * bodies. Use returned source and sourceSpan anchors for citations instead
+     * of shell reads or line-number checks.
      */
     purpose: string;
 
@@ -211,8 +214,10 @@ export namespace ITtscGraphApplication {
     /**
      * Why overview is the next step.
      *
-     * Use this for architecture orientation, public API, layers, and hotspots;
-     * not for a specific symbol relationship.
+     * Use this for architecture orientation, public TypeScript API, layers, and
+     * hotspots; not for a specific symbol relationship. For code walk-throughs,
+     * choose an exported TypeScript symbol from this result instead of reading
+     * package scripts.
      */
     purpose: string;
 

--- a/packages/graph/src/structures/ITtscGraphExpand.ts
+++ b/packages/graph/src/structures/ITtscGraphExpand.ts
@@ -54,6 +54,17 @@ export namespace ITtscGraphExpand {
      * @default false
      */
     source?: boolean;
+
+    /**
+     * Include numbered source lines beside `source`.
+     *
+     * Use this with `source:true` only when the answer needs exact in-body line
+     * anchors. It replaces shell reads for "what line contains this call?"
+     * checks. Omitted unless requested.
+     *
+     * @default false
+     */
+    lineNumbers?: boolean;
   }
 
   /** One expanded node: its declared shape, and on request its source. */
@@ -87,11 +98,10 @@ export namespace ITtscGraphExpand {
      * `implementation` is present, only when `source` was requested.
      */
     source?: string;
+    /** Numbered source lines for citation, only when requested. */
+    sourceLines?: ISourceLine[];
     /** The file and line range covered by `source`, when it was returned. */
-    sourceSpan?: Pick<
-      ITtscGraphEvidence,
-      "file" | "startLine" | "endLine"
-    >;
+    sourceSpan?: Pick<ITtscGraphEvidence, "file" | "startLine" | "endLine">;
     /** True when `source` was cut at the line cap. */
     truncated?: boolean;
     /** Symbols this node uses (outgoing dependency edges). */
@@ -136,5 +146,11 @@ export namespace ITtscGraphExpand {
      * the source access path.
      */
     aliases?: string[];
+  }
+
+  /** One source line with its original 1-based file line number. */
+  export interface ISourceLine {
+    line: number;
+    text: string;
   }
 }

--- a/packages/graph/src/structures/ITtscGraphIndex.ts
+++ b/packages/graph/src/structures/ITtscGraphIndex.ts
@@ -39,7 +39,7 @@ export namespace ITtscGraphIndex {
     /**
      * Maximum ranked hits to return.
      *
-     * @default 8
+     * @default 5
      */
     limit?: number;
 
@@ -49,7 +49,7 @@ export namespace ITtscGraphIndex {
      * `dependency_path` or `symbol_details(neighbors:true)` after choosing the
      * specific handles.
      *
-     * @default 4
+     * @default 1
      */
     neighbors?: number;
   }

--- a/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
@@ -42,8 +42,8 @@ const callGraphJson = <T>(result: ToolResult): T => {
  * shipped pipeline works: the Node launcher spawns, runs `ttscgraph dump` once
  * for a real project, builds the resident graph, and answers
  * initialize/tools-list/tools-call for the single
- * inspect_typescript_code_graph_evidence tool, then exits cleanly when stdin
- * closes.
+ * inspect_typescript_project_graph_before_answering tool, then exits cleanly
+ * when stdin closes.
  *
  * 1. Materialize a project with a Service.run -> helper call chain, then spawn the
  *    launcher against it.
@@ -115,7 +115,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     const names = list.tools.map((tool) => tool.name);
     assert.deepEqual(
       names,
-      ["inspect_typescript_code_graph_evidence"],
+      ["inspect_typescript_project_graph_before_answering"],
       `tools/list advertises the single graph tool, got ${names.join(", ")}`,
     );
 
@@ -139,7 +139,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next: { traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_graph_evidence",
+        name: "inspect_typescript_project_graph_before_answering",
         arguments: {
           thinking:
             "Find source-free starting handles before tracing Service.run to helper.",
@@ -204,7 +204,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       publicApi?: { id: string; name: string; line?: number }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_graph_evidence",
+        name: "inspect_typescript_project_graph_before_answering",
         arguments: {
           thinking: "Summarize project shape without reading source bodies.",
           request: {
@@ -238,7 +238,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next: { expand: string[]; traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_graph_evidence",
+        name: "inspect_typescript_project_graph_before_answering",
         arguments: {
           thinking: "Look up Service by exact symbol name.",
           request: {
@@ -263,7 +263,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       hits: { name: string; kind: string }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_graph_evidence",
+        name: "inspect_typescript_project_graph_before_answering",
         arguments: {
           thinking:
             "Look up the explicit run method before dependency tracing.",
@@ -294,7 +294,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       steps?: string[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_graph_evidence",
+        name: "inspect_typescript_project_graph_before_answering",
         arguments: {
           thinking:
             "Trace execution dependencies from run to confirm the helper call.",
@@ -328,7 +328,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next?: { traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_graph_evidence",
+        name: "inspect_typescript_project_graph_before_answering",
         arguments: {
           thinking: "Ask for the direct path from Service.run to helper.",
           request: {
@@ -368,7 +368,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       unknown: string[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_graph_evidence",
+        name: "inspect_typescript_project_graph_before_answering",
         arguments: {
           thinking:
             "Read only the Service.run body because the implementation contains the decisive helper call.",
@@ -413,7 +413,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_graph_evidence",
+        name: "inspect_typescript_project_graph_before_answering",
         arguments: {
           thinking: "Inspect Service.run shape without reading source.",
           request: {
@@ -445,7 +445,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_graph_evidence",
+        name: "inspect_typescript_project_graph_before_answering",
         arguments: {
           thinking:
             "Map immediate Service.run dependencies without source bodies.",
@@ -484,7 +484,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_graph_evidence",
+        name: "inspect_typescript_project_graph_before_answering",
         arguments: {
           thinking:
             "Read Service.run source and verify neighbor options stay ignored in source mode.",

--- a/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
@@ -42,8 +42,8 @@ const callGraphJson = <T>(result: ToolResult): T => {
  * shipped pipeline works: the Node launcher spawns, runs `ttscgraph dump` once
  * for a real project, builds the resident graph, and answers
  * initialize/tools-list/tools-call for the single
- * inspect_typescript_code_evidence_without_shell_search tool, then exits
- * cleanly when stdin closes.
+ * inspect_typescript_code_graph_evidence tool, then exits cleanly when stdin
+ * closes.
  *
  * 1. Materialize a project with a Service.run -> helper call chain, then spawn the
  *    launcher against it.
@@ -115,7 +115,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     const names = list.tools.map((tool) => tool.name);
     assert.deepEqual(
       names,
-      ["inspect_typescript_code_evidence_without_shell_search"],
+      ["inspect_typescript_code_graph_evidence"],
       `tools/list advertises the single graph tool, got ${names.join(", ")}`,
     );
 
@@ -139,7 +139,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next: { traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_evidence_without_shell_search",
+        name: "inspect_typescript_code_graph_evidence",
         arguments: {
           thinking:
             "Find source-free starting handles before tracing Service.run to helper.",
@@ -204,7 +204,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       publicApi?: { id: string; name: string; line?: number }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_evidence_without_shell_search",
+        name: "inspect_typescript_code_graph_evidence",
         arguments: {
           thinking: "Summarize project shape without reading source bodies.",
           request: {
@@ -238,7 +238,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next: { expand: string[]; traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_evidence_without_shell_search",
+        name: "inspect_typescript_code_graph_evidence",
         arguments: {
           thinking: "Look up Service by exact symbol name.",
           request: {
@@ -263,7 +263,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       hits: { name: string; kind: string }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_evidence_without_shell_search",
+        name: "inspect_typescript_code_graph_evidence",
         arguments: {
           thinking:
             "Look up the explicit run method before dependency tracing.",
@@ -294,7 +294,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       steps?: string[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_evidence_without_shell_search",
+        name: "inspect_typescript_code_graph_evidence",
         arguments: {
           thinking:
             "Trace execution dependencies from run to confirm the helper call.",
@@ -328,7 +328,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next?: { traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_evidence_without_shell_search",
+        name: "inspect_typescript_code_graph_evidence",
         arguments: {
           thinking: "Ask for the direct path from Service.run to helper.",
           request: {
@@ -368,7 +368,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       unknown: string[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_evidence_without_shell_search",
+        name: "inspect_typescript_code_graph_evidence",
         arguments: {
           thinking:
             "Read only the Service.run body because the implementation contains the decisive helper call.",
@@ -413,7 +413,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_evidence_without_shell_search",
+        name: "inspect_typescript_code_graph_evidence",
         arguments: {
           thinking: "Inspect Service.run shape without reading source.",
           request: {
@@ -445,7 +445,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_evidence_without_shell_search",
+        name: "inspect_typescript_code_graph_evidence",
         arguments: {
           thinking:
             "Map immediate Service.run dependencies without source bodies.",
@@ -484,7 +484,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_code_evidence_without_shell_search",
+        name: "inspect_typescript_code_graph_evidence",
         arguments: {
           thinking:
             "Read Service.run source and verify neighbor options stay ignored in source mode.",

--- a/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
@@ -41,8 +41,9 @@ const callGraphJson = <T>(result: ToolResult): T => {
  * The TypeScript engine is unit-smoked in isolation; this case proves the
  * shipped pipeline works: the Node launcher spawns, runs `ttscgraph dump` once
  * for a real project, builds the resident graph, and answers
- * initialize/tools-list/tools-call for the single query_typescript_graph tool,
- * then exits cleanly when stdin closes.
+ * initialize/tools-list/tools-call for the single
+ * inspect_typescript_graph_before_shell_reading tool, then exits cleanly when
+ * stdin closes.
  *
  * 1. Materialize a project with a Service.run -> helper call chain, then spawn the
  *    launcher against it.
@@ -114,7 +115,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     const names = list.tools.map((tool) => tool.name);
     assert.deepEqual(
       names,
-      ["query_typescript_graph"],
+      ["inspect_typescript_graph_before_shell_reading"],
       `tools/list advertises the single graph tool, got ${names.join(", ")}`,
     );
 
@@ -138,7 +139,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next: { traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "query_typescript_graph",
+        name: "inspect_typescript_graph_before_shell_reading",
         arguments: {
           thinking:
             "Find source-free starting handles before tracing Service.run to helper.",
@@ -203,7 +204,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       publicApi?: { id: string; name: string; line?: number }[];
     }>(
       (await client.request("tools/call", {
-        name: "query_typescript_graph",
+        name: "inspect_typescript_graph_before_shell_reading",
         arguments: {
           thinking: "Summarize project shape without reading source bodies.",
           request: {
@@ -237,7 +238,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next: { expand: string[]; traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "query_typescript_graph",
+        name: "inspect_typescript_graph_before_shell_reading",
         arguments: {
           thinking: "Look up Service by exact symbol name.",
           request: {
@@ -262,7 +263,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       hits: { name: string; kind: string }[];
     }>(
       (await client.request("tools/call", {
-        name: "query_typescript_graph",
+        name: "inspect_typescript_graph_before_shell_reading",
         arguments: {
           thinking:
             "Look up the explicit run method before dependency tracing.",
@@ -293,7 +294,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       steps?: string[];
     }>(
       (await client.request("tools/call", {
-        name: "query_typescript_graph",
+        name: "inspect_typescript_graph_before_shell_reading",
         arguments: {
           thinking:
             "Trace execution dependencies from run to confirm the helper call.",
@@ -327,7 +328,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next?: { traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "query_typescript_graph",
+        name: "inspect_typescript_graph_before_shell_reading",
         arguments: {
           thinking: "Ask for the direct path from Service.run to helper.",
           request: {
@@ -367,7 +368,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       unknown: string[];
     }>(
       (await client.request("tools/call", {
-        name: "query_typescript_graph",
+        name: "inspect_typescript_graph_before_shell_reading",
         arguments: {
           thinking:
             "Read only the Service.run body because the implementation contains the decisive helper call.",
@@ -412,7 +413,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "query_typescript_graph",
+        name: "inspect_typescript_graph_before_shell_reading",
         arguments: {
           thinking: "Inspect Service.run shape without reading source.",
           request: {
@@ -444,7 +445,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "query_typescript_graph",
+        name: "inspect_typescript_graph_before_shell_reading",
         arguments: {
           thinking:
             "Map immediate Service.run dependencies without source bodies.",
@@ -483,7 +484,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "query_typescript_graph",
+        name: "inspect_typescript_graph_before_shell_reading",
         arguments: {
           thinking:
             "Read Service.run source and verify neighbor options stay ignored in source mode.",

--- a/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
@@ -42,8 +42,8 @@ const callGraphJson = <T>(result: ToolResult): T => {
  * shipped pipeline works: the Node launcher spawns, runs `ttscgraph dump` once
  * for a real project, builds the resident graph, and answers
  * initialize/tools-list/tools-call for the single
- * inspect_typescript_graph_before_shell_reading tool, then exits cleanly when
- * stdin closes.
+ * inspect_typescript_code_evidence_without_shell_search tool, then exits
+ * cleanly when stdin closes.
  *
  * 1. Materialize a project with a Service.run -> helper call chain, then spawn the
  *    launcher against it.
@@ -115,7 +115,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     const names = list.tools.map((tool) => tool.name);
     assert.deepEqual(
       names,
-      ["inspect_typescript_graph_before_shell_reading"],
+      ["inspect_typescript_code_evidence_without_shell_search"],
       `tools/list advertises the single graph tool, got ${names.join(", ")}`,
     );
 
@@ -139,7 +139,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next: { traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_graph_before_shell_reading",
+        name: "inspect_typescript_code_evidence_without_shell_search",
         arguments: {
           thinking:
             "Find source-free starting handles before tracing Service.run to helper.",
@@ -204,7 +204,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       publicApi?: { id: string; name: string; line?: number }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_graph_before_shell_reading",
+        name: "inspect_typescript_code_evidence_without_shell_search",
         arguments: {
           thinking: "Summarize project shape without reading source bodies.",
           request: {
@@ -238,7 +238,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next: { expand: string[]; traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_graph_before_shell_reading",
+        name: "inspect_typescript_code_evidence_without_shell_search",
         arguments: {
           thinking: "Look up Service by exact symbol name.",
           request: {
@@ -263,7 +263,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       hits: { name: string; kind: string }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_graph_before_shell_reading",
+        name: "inspect_typescript_code_evidence_without_shell_search",
         arguments: {
           thinking:
             "Look up the explicit run method before dependency tracing.",
@@ -294,7 +294,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       steps?: string[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_graph_before_shell_reading",
+        name: "inspect_typescript_code_evidence_without_shell_search",
         arguments: {
           thinking:
             "Trace execution dependencies from run to confirm the helper call.",
@@ -328,7 +328,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next?: { traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_graph_before_shell_reading",
+        name: "inspect_typescript_code_evidence_without_shell_search",
         arguments: {
           thinking: "Ask for the direct path from Service.run to helper.",
           request: {
@@ -368,7 +368,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       unknown: string[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_graph_before_shell_reading",
+        name: "inspect_typescript_code_evidence_without_shell_search",
         arguments: {
           thinking:
             "Read only the Service.run body because the implementation contains the decisive helper call.",
@@ -413,7 +413,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_graph_before_shell_reading",
+        name: "inspect_typescript_code_evidence_without_shell_search",
         arguments: {
           thinking: "Inspect Service.run shape without reading source.",
           request: {
@@ -445,7 +445,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_graph_before_shell_reading",
+        name: "inspect_typescript_code_evidence_without_shell_search",
         arguments: {
           thinking:
             "Map immediate Service.run dependencies without source bodies.",
@@ -484,7 +484,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "inspect_typescript_graph_before_shell_reading",
+        name: "inspect_typescript_code_evidence_without_shell_search",
         arguments: {
           thinking:
             "Read Service.run source and verify neighbor options stay ignored in source mode.",

--- a/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
@@ -9,6 +9,31 @@ interface ToolResult {
 const callJson = <T>(result: ToolResult): T =>
   JSON.parse(result.content[0]?.text ?? "{}") as T;
 
+const callGraphJson = <T>(result: ToolResult): T => {
+  const value = callJson<{
+    type?: string;
+    entrypoints?: unknown;
+    symbols?: unknown;
+    trace?: unknown;
+    details?: unknown;
+    overview?: unknown;
+  }>(result);
+  switch (value.type) {
+    case "find_question_entrypoints":
+      return value.entrypoints as T;
+    case "lookup_symbols":
+      return value.symbols as T;
+    case "trace_dependency_path":
+      return value.trace as T;
+    case "inspect_symbol_details":
+      return value.details as T;
+    case "summarize_project":
+      return value.overview as T;
+    default:
+      throw new Error(`Unexpected graph result: ${JSON.stringify(value)}`);
+  }
+};
+
 /**
  * Verifies the @ttsc/graph launcher serves the redesigned graph tools to an MCP
  * client end to end over stdio.
@@ -16,9 +41,8 @@ const callJson = <T>(result: ToolResult): T =>
  * The TypeScript engine is unit-smoked in isolation; this case proves the
  * shipped pipeline works: the Node launcher spawns, runs `ttscgraph dump` once
  * for a real project, builds the resident graph, and answers
- * initialize/tools-list/tools-call for question_entrypoints, dependency_path,
- * symbol_details, symbol_lookup, and project_overview, then exits cleanly when
- * stdin closes.
+ * initialize/tools-list/tools-call for the single query_typescript_graph tool,
+ * then exits cleanly when stdin closes.
  *
  * 1. Materialize a project with a Service.run -> helper call chain, then spawn the
  *    launcher against it.
@@ -90,19 +114,13 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     const names = list.tools.map((tool) => tool.name);
     assert.deepEqual(
       names,
-      [
-        "question_entrypoints",
-        "symbol_lookup",
-        "dependency_path",
-        "symbol_details",
-        "project_overview",
-      ],
-      `tools/list advertises the five graph tools, got ${names.join(", ")}`,
+      ["query_typescript_graph"],
+      `tools/list advertises the single graph tool, got ${names.join(", ")}`,
     );
 
     // question_entrypoints: the first source-free index resolves direct handles and
     // nearby dependency context.
-    const index = callJson<{
+    const index = callGraphJson<{
       hits: {
         id: string;
         name: string;
@@ -120,8 +138,16 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       next: { traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "question_entrypoints",
-        arguments: { query: "how Service.run reaches helper" },
+        name: "query_typescript_graph",
+        arguments: {
+          thinking:
+            "Find source-free starting handles before tracing Service.run to helper.",
+          request: {
+            type: "find_question_entrypoints",
+            purpose: "Resolve the starting method and nearby dependency edge.",
+            query: "how Service.run reaches helper",
+          },
+        },
       })) as ToolResult,
     );
     assert.ok(
@@ -172,13 +198,20 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     );
 
     // project_overview: a compact architecture map with real counts.
-    const overview = callJson<{
+    const overview = callGraphJson<{
       counts: { nodes: number; byKind: Record<string, number> };
       publicApi?: { id: string; name: string; line?: number }[];
     }>(
       (await client.request("tools/call", {
-        name: "project_overview",
-        arguments: { aspect: "all" },
+        name: "query_typescript_graph",
+        arguments: {
+          thinking: "Summarize project shape without reading source bodies.",
+          request: {
+            type: "summarize_project",
+            purpose: "Verify the architecture overview request branch.",
+            aspect: "all",
+          },
+        },
       })) as ToolResult,
     );
     const byKind = overview.counts.byKind;
@@ -199,13 +232,20 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     );
 
     // symbol_lookup: finds Service by name and ranks explicit method queries.
-    const query = callJson<{
+    const query = callGraphJson<{
       hits: { id: string; name: string; kind: string }[];
       next: { expand: string[]; traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "symbol_lookup",
-        arguments: { query: "Service" },
+        name: "query_typescript_graph",
+        arguments: {
+          thinking: "Look up Service by exact symbol name.",
+          request: {
+            type: "lookup_symbols",
+            purpose: "Resolve a specific class handle.",
+            query: "Service",
+          },
+        },
       })) as ToolResult,
     );
     const service = query.hits.find((hit) => hit.name === "Service");
@@ -218,14 +258,20 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
         query.next.traceFrom.includes(service.id),
       `symbol_lookup returns follow-up handles: ${JSON.stringify(query.next)}`,
     );
-    const methodQuery = callJson<{
+    const methodQuery = callGraphJson<{
       hits: { name: string; kind: string }[];
     }>(
       (await client.request("tools/call", {
-        name: "symbol_lookup",
+        name: "query_typescript_graph",
         arguments: {
-          query: "How does the `run` method reach helper?",
-          limit: 3,
+          thinking:
+            "Look up the explicit run method before dependency tracing.",
+          request: {
+            type: "lookup_symbols",
+            purpose: "Rank the method target ahead of the class.",
+            query: "How does the `run` method reach helper?",
+            limit: 3,
+          },
         },
       })) as ToolResult,
     );
@@ -241,14 +287,24 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     );
 
     // dependency_path: forward from Service.run reaches the helper it calls.
-    const trace = callJson<{
+    const trace = callGraphJson<{
       reached: { name: string }[];
       hops: { evidence?: { text?: string } }[];
       steps?: string[];
     }>(
       (await client.request("tools/call", {
-        name: "dependency_path",
-        arguments: { from: "run", direction: "forward", focus: "execution" },
+        name: "query_typescript_graph",
+        arguments: {
+          thinking:
+            "Trace execution dependencies from run to confirm the helper call.",
+          request: {
+            type: "trace_dependency_path",
+            purpose: "Follow outgoing runtime calls from Service.run.",
+            from: "run",
+            direction: "forward",
+            focus: "execution",
+          },
+        },
       })) as ToolResult,
     );
     assert.ok(
@@ -265,14 +321,22 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     );
 
     // dependency_path path mode: dotted from handles can be used directly.
-    const pathTrace = callJson<{
+    const pathTrace = callGraphJson<{
       path?: { name: string; signature?: string }[];
       steps?: string[];
       next?: { traceFrom: string[] };
     }>(
       (await client.request("tools/call", {
-        name: "dependency_path",
-        arguments: { from: "Service.run", to: "helper" },
+        name: "query_typescript_graph",
+        arguments: {
+          thinking: "Ask for the direct path from Service.run to helper.",
+          request: {
+            type: "trace_dependency_path",
+            purpose: "Verify dotted handles work in path mode.",
+            from: "Service.run",
+            to: "helper",
+          },
+        },
       })) as ToolResult,
     );
     assert.ok(
@@ -292,7 +356,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     );
 
     // symbol_details: reads the declaration source the graph located.
-    const expand = callJson<{
+    const expand = callGraphJson<{
       nodes: {
         id: string;
         name: string;
@@ -303,8 +367,17 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       unknown: string[];
     }>(
       (await client.request("tools/call", {
-        name: "symbol_details",
-        arguments: { handles: ["Service.run"], source: true },
+        name: "query_typescript_graph",
+        arguments: {
+          thinking:
+            "Read only the Service.run body because the implementation contains the decisive helper call.",
+          request: {
+            type: "inspect_symbol_details",
+            purpose: "Narrow source read for the selected method.",
+            handles: ["Service.run"],
+            source: true,
+          },
+        },
       })) as ToolResult,
     );
     assert.ok(
@@ -330,7 +403,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       `symbol_details returns decorator facts: ${JSON.stringify(expand.nodes)}`,
     );
 
-    const expandShape = callJson<{
+    const expandShape = callGraphJson<{
       nodes: {
         name: string;
         calls?: string[];
@@ -339,8 +412,15 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "symbol_details",
-        arguments: { handles: ["Service.run"] },
+        name: "query_typescript_graph",
+        arguments: {
+          thinking: "Inspect Service.run shape without reading source.",
+          request: {
+            type: "inspect_symbol_details",
+            purpose: "Verify source-free direct call summaries.",
+            handles: ["Service.run"],
+          },
+        },
       })) as ToolResult,
     );
     assert.ok(
@@ -357,18 +437,24 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       `symbol_details leaves execution paths to dependency_path: ${JSON.stringify(expandShape.nodes)}`,
     );
 
-    const expandDeps = callJson<{
+    const expandDeps = callGraphJson<{
       nodes: {
         dependsOn?: { name: string; evidence?: { text?: string } }[];
         dependedOnBy?: unknown[];
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "symbol_details",
+        name: "query_typescript_graph",
         arguments: {
-          handles: ["Service.run"],
-          neighbors: true,
-          neighborLimit: 1,
+          thinking:
+            "Map immediate Service.run dependencies without source bodies.",
+          request: {
+            type: "inspect_symbol_details",
+            purpose: "Verify bounded neighbor mapping.",
+            handles: ["Service.run"],
+            neighbors: true,
+            neighborLimit: 1,
+          },
         },
       })) as ToolResult,
     );
@@ -386,7 +472,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       `symbol_details returns dependency neighbors: ${JSON.stringify(expandDeps.nodes)}`,
     );
 
-    const expandSourceDeps = callJson<{
+    const expandSourceDeps = callGraphJson<{
       nodes: {
         source?: string;
         dependsOn?: {
@@ -397,12 +483,18 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
       }[];
     }>(
       (await client.request("tools/call", {
-        name: "symbol_details",
+        name: "query_typescript_graph",
         arguments: {
-          handles: ["Service.run"],
-          source: true,
-          neighbors: true,
-          neighborLimit: 10,
+          thinking:
+            "Read Service.run source and verify neighbor options stay ignored in source mode.",
+          request: {
+            type: "inspect_symbol_details",
+            purpose: "Source reads must stay separate from dependency maps.",
+            handles: ["Service.run"],
+            source: true,
+            neighbors: true,
+            neighborLimit: 10,
+          },
         },
       })) as ToolResult,
     );
@@ -430,4 +522,3 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     `the launcher should exit cleanly on stdin close\nstderr: ${client.stderrText()}`,
   );
 };
-

--- a/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
@@ -34,6 +34,34 @@ const callGraphJson = <T>(result: ToolResult): T => {
   }
 };
 
+type GraphRequestType =
+  | "find_question_entrypoints"
+  | "lookup_symbols"
+  | "trace_dependency_path"
+  | "inspect_symbol_details"
+  | "summarize_project";
+
+interface GraphRequest {
+  type: GraphRequestType;
+  [key: string]: unknown;
+}
+
+const graphArguments = (props: {
+  thinking: string;
+  request: GraphRequest;
+}) => ({
+  question: props.thinking,
+  graphNeed:
+    "Use resident TypeScript graph evidence and avoid shell or web lookup.",
+  draft: {
+    type: props.request.type,
+    reason: props.thinking,
+  },
+  review:
+    "The draft is bounded to one graph request; follow-up evidence should use another graph call.",
+  request: props.request,
+});
+
 /**
  * Verifies the @ttsc/graph launcher serves the redesigned graph tools to an MCP
  * client end to end over stdio.
@@ -140,7 +168,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     }>(
       (await client.request("tools/call", {
         name: "inspect_typescript_project_graph_before_answering",
-        arguments: {
+        arguments: graphArguments({
           thinking:
             "Find source-free starting handles before tracing Service.run to helper.",
           request: {
@@ -148,7 +176,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
             purpose: "Resolve the starting method and nearby dependency edge.",
             query: "how Service.run reaches helper",
           },
-        },
+        }),
       })) as ToolResult,
     );
     assert.ok(
@@ -205,14 +233,14 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     }>(
       (await client.request("tools/call", {
         name: "inspect_typescript_project_graph_before_answering",
-        arguments: {
+        arguments: graphArguments({
           thinking: "Summarize project shape without reading source bodies.",
           request: {
             type: "summarize_project",
             purpose: "Verify the architecture overview request branch.",
             aspect: "all",
           },
-        },
+        }),
       })) as ToolResult,
     );
     const byKind = overview.counts.byKind;
@@ -239,14 +267,14 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     }>(
       (await client.request("tools/call", {
         name: "inspect_typescript_project_graph_before_answering",
-        arguments: {
+        arguments: graphArguments({
           thinking: "Look up Service by exact symbol name.",
           request: {
             type: "lookup_symbols",
             purpose: "Resolve a specific class handle.",
             query: "Service",
           },
-        },
+        }),
       })) as ToolResult,
     );
     const service = query.hits.find((hit) => hit.name === "Service");
@@ -264,7 +292,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     }>(
       (await client.request("tools/call", {
         name: "inspect_typescript_project_graph_before_answering",
-        arguments: {
+        arguments: graphArguments({
           thinking:
             "Look up the explicit run method before dependency tracing.",
           request: {
@@ -273,7 +301,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
             query: "How does the `run` method reach helper?",
             limit: 3,
           },
-        },
+        }),
       })) as ToolResult,
     );
     assert.equal(
@@ -295,7 +323,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     }>(
       (await client.request("tools/call", {
         name: "inspect_typescript_project_graph_before_answering",
-        arguments: {
+        arguments: graphArguments({
           thinking:
             "Trace execution dependencies from run to confirm the helper call.",
           request: {
@@ -305,7 +333,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
             direction: "forward",
             focus: "execution",
           },
-        },
+        }),
       })) as ToolResult,
     );
     assert.ok(
@@ -329,7 +357,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     }>(
       (await client.request("tools/call", {
         name: "inspect_typescript_project_graph_before_answering",
-        arguments: {
+        arguments: graphArguments({
           thinking: "Ask for the direct path from Service.run to helper.",
           request: {
             type: "trace_dependency_path",
@@ -337,7 +365,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
             from: "Service.run",
             to: "helper",
           },
-        },
+        }),
       })) as ToolResult,
     );
     assert.ok(
@@ -369,7 +397,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     }>(
       (await client.request("tools/call", {
         name: "inspect_typescript_project_graph_before_answering",
-        arguments: {
+        arguments: graphArguments({
           thinking:
             "Read only the Service.run body because the implementation contains the decisive helper call.",
           request: {
@@ -378,7 +406,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
             handles: ["Service.run"],
             source: true,
           },
-        },
+        }),
       })) as ToolResult,
     );
     assert.ok(
@@ -414,14 +442,14 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     }>(
       (await client.request("tools/call", {
         name: "inspect_typescript_project_graph_before_answering",
-        arguments: {
+        arguments: graphArguments({
           thinking: "Inspect Service.run shape without reading source.",
           request: {
             type: "inspect_symbol_details",
             purpose: "Verify source-free direct call summaries.",
             handles: ["Service.run"],
           },
-        },
+        }),
       })) as ToolResult,
     );
     assert.ok(
@@ -446,7 +474,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     }>(
       (await client.request("tools/call", {
         name: "inspect_typescript_project_graph_before_answering",
-        arguments: {
+        arguments: graphArguments({
           thinking:
             "Map immediate Service.run dependencies without source bodies.",
           request: {
@@ -456,7 +484,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
             neighbors: true,
             neighborLimit: 1,
           },
-        },
+        }),
       })) as ToolResult,
     );
     assert.ok(
@@ -485,7 +513,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     }>(
       (await client.request("tools/call", {
         name: "inspect_typescript_project_graph_before_answering",
-        arguments: {
+        arguments: graphArguments({
           thinking:
             "Read Service.run source and verify neighbor options stay ignored in source mode.",
           request: {
@@ -496,7 +524,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
             neighbors: true,
             neighborLimit: 10,
           },
-        },
+        }),
       })) as ToolResult,
     );
     assert.ok(

--- a/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_serves_graph_tools_over_mcp.ts
@@ -390,6 +390,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
         id: string;
         name: string;
         source?: string;
+        sourceLines?: { line: number; text: string }[];
         sourceSpan?: { file: string; startLine: number; endLine?: number };
         decorators?: { name: string; arguments: { literal?: unknown }[] }[];
       }[];
@@ -405,6 +406,7 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
             purpose: "Narrow source read for the selected method.",
             handles: ["Service.run"],
             source: true,
+            lineNumbers: true,
           },
         }),
       })) as ToolResult,
@@ -412,6 +414,15 @@ export const test_ttscgraph_serves_graph_tools_over_mcp = async () => {
     assert.ok(
       expand.nodes.some((node) => (node.source ?? "").includes("helper(")),
       `symbol_details returns the run body: ${JSON.stringify(expand.nodes)}`,
+    );
+    assert.ok(
+      expand.nodes.some((node) =>
+        node.sourceLines?.some(
+          (line) =>
+            typeof line.line === "number" && line.text.includes("helper();"),
+        ),
+      ),
+      `symbol_details returns numbered source lines: ${JSON.stringify(expand.nodes)}`,
     );
     assert.ok(
       expand.nodes.some(


### PR DESCRIPTION
## Intent

This is the follow-up experiment branch after #283. It changes @ttsc/graph from five exposed MCP functions to one query_typescript_graph function whose input forces a short 	hinking field before a discriminated equest.type branch.

## Scope

- Replaces the public graph MCP application interface with one planned request function.
- Keeps the underlying graph operations general: entrypoint search, symbol lookup, dependency tracing, symbol details, and overview still delegate to the existing runners.
- Updates the MCP instruction first screen for the single-tool shape.
- Teaches the Codex trace audit to unwrap query_typescript_graph request/result payloads and to ignore 	hinking when detecting duplicate graph requests.
- Updates the MCP e2e test expectations for the single tool.

## Deferred

- N=1 eight-attempt smoke results will be posted in the sticky benchmark comment after this PR exists.
- This PR is dependent on #283 until that PR is merged or this branch is retargeted.

## Test Plan

- pnpm --filter @ttsc/graph build
- pnpm exec tsc -p tests/test-graph/tsconfig.json --noEmit
- 
ode experimental/benchmark/graph/audit-codex-traces.mjs --self-test
- git diff --check

## Known Gap

- pnpm --filter @ttsc/test-graph start is still blocked on Windows before test execution by Node ESM loader handling of absolute d: URLs.