### PR TITLE
feat(website): clarify graph benchmark axes

### DIFF
--- a/tests/test-graph/src/features/test_ttscgraph_dump_keeps_node_modules_as_external_leaves.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_dump_keeps_node_modules_as_external_leaves.ts
@@ -1,0 +1,114 @@
+import { TestProject } from "@ttsc/testing";
+
+import { dumpGraph, findEdge, findNode } from "../internal/graphDump";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies graph dump reaches node_modules declarations only as external
+ * leaves.
+ *
+ * Dependency type definitions matter as endpoints: a local API can extend an
+ * imported class, call an imported function, or expose an imported type. The
+ * graph should keep those direct targets so an agent sees the dependency
+ * boundary, but it must not index every declaration in node_modules because
+ * that would turn the project graph into a dependency graph and bury authored
+ * code.
+ *
+ * 1. Materialize a package with a node_modules `.d.ts` dependency.
+ * 2. Reference three exported dependency symbols from local source.
+ * 3. Assert those targets are external leaves and an unreferenced dependency
+ *    declaration is absent.
+ */
+export const test_ttscgraph_dump_keeps_node_modules_as_external_leaves = () => {
+  const root = TestProject.createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        moduleResolution: "node",
+        strict: true,
+        skipLibCheck: true,
+      },
+      include: ["src"],
+    }),
+    "node_modules/external-lib/package.json": JSON.stringify({
+      name: "external-lib",
+      version: "1.0.0",
+      types: "index.d.ts",
+    }),
+    "node_modules/external-lib/index.d.ts": [
+      "export interface ExternalPayload {",
+      "  value: string;",
+      "}",
+      "export declare function externalHelper(input: ExternalPayload): string;",
+      "export declare class ExternalService {",
+      "  run(input: ExternalPayload): string;",
+      "}",
+      "export declare class UnusedDependencyDetail {",
+      "  value: string;",
+      "}",
+      "",
+    ].join("\n"),
+    "src/main.ts": [
+      'import { ExternalService, externalHelper, type ExternalPayload } from "external-lib";',
+      "export function run(input: ExternalPayload): string {",
+      "  return externalHelper(input);",
+      "}",
+      "export class LocalService extends ExternalService {}",
+      "",
+    ].join("\n"),
+  });
+
+  const dump = dumpGraph(root, "tsconfig.json");
+  const run = findNode(dump, {
+    file: "src/main.ts",
+    name: "run",
+    kind: "function",
+  });
+  const localService = findNode(dump, {
+    file: "src/main.ts",
+    name: "LocalService",
+    kind: "class",
+  });
+  const externalHelper = findNode(dump, {
+    file: "node_modules/external-lib/index.d.ts",
+    name: "externalHelper",
+    kind: "function",
+  });
+  const externalPayload = findNode(dump, {
+    file: "node_modules/external-lib/index.d.ts",
+    name: "ExternalPayload",
+    kind: "interface",
+  });
+  const externalService = findNode(dump, {
+    file: "node_modules/external-lib/index.d.ts",
+    name: "ExternalService",
+    kind: "class",
+  });
+
+  assert.ok(run, "local function is present");
+  assert.ok(localService, "local class is present");
+  assert.ok(externalHelper, "referenced external function is kept");
+  assert.ok(externalPayload, "referenced external interface is kept");
+  assert.ok(externalService, "referenced external class is kept");
+  assert.equal(externalHelper.external, true);
+  assert.equal(externalPayload.external, true);
+  assert.equal(externalService.external, true);
+  assert.ok(
+    findEdge(dump, run, externalHelper, "calls"),
+    "local call reaches the external function leaf",
+  );
+  assert.ok(
+    findEdge(dump, run, externalPayload, "type_ref"),
+    "local type annotation reaches the external type leaf",
+  );
+  assert.ok(
+    findEdge(dump, localService, externalService, "extends"),
+    "local heritage reaches the external class leaf",
+  );
+  assert.equal(
+    dump.nodes.some((node) => node.name === "UnusedDependencyDetail"),
+    false,
+    "unreferenced node_modules declarations are not indexed",
+  );
+};

--- a/tests/test-graph/src/features/test_ttscgraph_dump_resolves_pnpm_workspace_edges.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_dump_resolves_pnpm_workspace_edges.ts
@@ -1,0 +1,147 @@
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+
+import { dumpGraph, findEdge, findNode } from "../internal/graphDump";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies graph dump resolves pnpm workspace package links to sibling source.
+ *
+ * A pnpm monorepo presents workspace packages through node_modules links, but
+ * the graph must follow the TypeScript checker to the real sibling declaration
+ * instead of stopping at the package import string or treating the sibling as
+ * an opaque dependency. This locks the monorepo shape used by projects such as
+ * autobe: one package tsconfig can still produce edges into another workspace
+ * package when the checker resolves that package to source.
+ *
+ * 1. Materialize an app package that imports a linked workspace package.
+ * 2. Build a dump from the workspace root with the app package tsconfig.
+ * 3. Assert calls, type refs, and heritage edges target sibling package nodes.
+ */
+export const test_ttscgraph_dump_resolves_pnpm_workspace_edges = () => {
+  const root = TestProject.tmpdir("ttsc-graph-workspace-");
+  TestProject.writeFiles(root, {
+    "package.json": JSON.stringify({
+      private: true,
+      name: "workspace-root",
+    }),
+    "pnpm-workspace.yaml": "packages:\n  - packages/*\n",
+    "packages/shared/package.json": JSON.stringify({
+      name: "@scope/shared",
+      version: "1.0.0",
+      main: "src/index.ts",
+      types: "src/index.ts",
+    }),
+    "packages/shared/src/index.ts": [
+      "export interface SharedInput {",
+      "  value: string;",
+      "}",
+      "export function sharedHelper(input: SharedInput): string {",
+      "  return input.value;",
+      "}",
+      "export class SharedService {",
+      "  run(input: SharedInput): string {",
+      "    return sharedHelper(input);",
+      "  }",
+      "}",
+      "",
+    ].join("\n"),
+    "packages/app/package.json": JSON.stringify({
+      name: "@scope/app",
+      version: "1.0.0",
+      dependencies: { "@scope/shared": "workspace:*" },
+    }),
+    "packages/app/tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        moduleResolution: "node",
+        strict: true,
+        skipLibCheck: true,
+      },
+      include: ["src"],
+    }),
+    "packages/app/src/main.ts": [
+      'import { SharedService, sharedHelper, type SharedInput } from "@scope/shared";',
+      "export function run(input: SharedInput): string {",
+      "  return sharedHelper(input);",
+      "}",
+      "export class AppService extends SharedService {",
+      "  override run(input: SharedInput): string {",
+      "    return super.run(input);",
+      "  }",
+      "}",
+      "",
+    ].join("\n"),
+  });
+  linkWorkspacePackage(
+    path.join(root, "packages", "shared"),
+    path.join(root, "node_modules", "@scope", "shared"),
+  );
+
+  const dump = dumpGraph(root, "packages/app/tsconfig.json");
+  const run = findNode(dump, {
+    file: "packages/app/src/main.ts",
+    name: "run",
+    kind: "function",
+  });
+  const appService = findNode(dump, {
+    file: "packages/app/src/main.ts",
+    name: "AppService",
+    kind: "class",
+  });
+  const sharedHelper = findNode(dump, {
+    file: "packages/shared/src/index.ts",
+    name: "sharedHelper",
+    kind: "function",
+  });
+  const sharedInput = findNode(dump, {
+    file: "packages/shared/src/index.ts",
+    name: "SharedInput",
+    kind: "interface",
+  });
+  const sharedService = findNode(dump, {
+    file: "packages/shared/src/index.ts",
+    name: "SharedService",
+    kind: "class",
+  });
+
+  assert.ok(run, "workspace app function is present in the dump");
+  assert.ok(appService, "workspace app class is present in the dump");
+  assert.ok(sharedHelper, "sibling package function is present in the dump");
+  assert.ok(sharedInput, "sibling package interface is present in the dump");
+  assert.ok(sharedService, "sibling package class is present in the dump");
+  assert.equal(sharedHelper.external, false, "sibling source is not external");
+  assert.equal(
+    sharedInput.external,
+    false,
+    "sibling type source is not external",
+  );
+  assert.equal(
+    dump.nodes.some((node) => node.file.includes("node_modules/@scope/shared")),
+    false,
+    "pnpm package link resolves to real sibling source paths",
+  );
+  assert.ok(
+    findEdge(dump, run, sharedHelper, "calls"),
+    "app function call resolves to the sibling package function",
+  );
+  assert.ok(
+    findEdge(dump, run, sharedInput, "type_ref"),
+    "app parameter type resolves to the sibling package interface",
+  );
+  assert.ok(
+    findEdge(dump, appService, sharedService, "extends"),
+    "app class heritage resolves to the sibling package class",
+  );
+};
+
+function linkWorkspacePackage(target: string, link: string): void {
+  fs.mkdirSync(path.dirname(link), { recursive: true });
+  fs.symlinkSync(
+    target,
+    link,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+}

--- a/tests/test-graph/src/features/test_ttscgraph_dump_resolves_tsconfig_path_aliases.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_dump_resolves_tsconfig_path_aliases.ts
@@ -1,0 +1,84 @@
+import { TestProject } from "@ttsc/testing";
+
+import { dumpGraph, findEdge, findNode } from "../internal/graphDump";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies graph dump resolves tsconfig path aliases through the checker.
+ *
+ * Path aliases are a TypeScript compiler concern, not a graph string-matching
+ * concern. The graph must follow the symbol that the configured tsconfig binds,
+ * so an alias import records edges to the real source declaration instead of to
+ * the alias text.
+ *
+ * 1. Materialize a project with `baseUrl` and two `paths` aliases.
+ * 2. Import a function and a type through those aliases.
+ * 3. Assert the dump records call and type edges to the real source files.
+ */
+export const test_ttscgraph_dump_resolves_tsconfig_path_aliases = () => {
+  const root = TestProject.createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        moduleResolution: "node",
+        strict: true,
+        baseUrl: ".",
+        paths: {
+          "@core/*": ["src/core/*"],
+          "@models": ["src/models/index.ts"],
+        },
+      },
+      include: ["src"],
+    }),
+    "src/core/helper.ts": [
+      "export function helper(value: string): string {",
+      "  return value.toUpperCase();",
+      "}",
+      "",
+    ].join("\n"),
+    "src/models/index.ts": [
+      "export interface Payload {",
+      "  value: string;",
+      "}",
+      "",
+    ].join("\n"),
+    "src/main.ts": [
+      'import { helper } from "@core/helper";',
+      'import type { Payload } from "@models";',
+      "export function run(input: Payload): string {",
+      "  return helper(input.value);",
+      "}",
+      "",
+    ].join("\n"),
+  });
+
+  const dump = dumpGraph(root, "tsconfig.json");
+  const run = findNode(dump, {
+    file: "src/main.ts",
+    name: "run",
+    kind: "function",
+  });
+  const helper = findNode(dump, {
+    file: "src/core/helper.ts",
+    name: "helper",
+    kind: "function",
+  });
+  const payload = findNode(dump, {
+    file: "src/models/index.ts",
+    name: "Payload",
+    kind: "interface",
+  });
+
+  assert.ok(run, "caller imported through aliases is present");
+  assert.ok(helper, "aliased function declaration is present");
+  assert.ok(payload, "aliased type declaration is present");
+  assert.ok(
+    findEdge(dump, run, helper, "calls"),
+    "alias function import resolves to a real call edge",
+  );
+  assert.ok(
+    findEdge(dump, run, payload, "type_ref"),
+    "alias type import resolves to a real type edge",
+  );
+};

--- a/tests/test-graph/src/internal/graphDump.ts
+++ b/tests/test-graph/src/internal/graphDump.ts
@@ -1,0 +1,64 @@
+import { TestProject } from "@ttsc/testing";
+
+import { resolveGraphLauncher, resolveTtscgraphBinary } from "./ttsgraph";
+
+export interface GraphDump {
+  project: string;
+  tsconfig: string;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export interface GraphNode {
+  id: string;
+  kind: string;
+  name: string;
+  file: string;
+  external: boolean;
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+  kind: string;
+  evidence?: { file?: string; startLine?: number };
+}
+
+export function dumpGraph(cwd: string, tsconfig: string): GraphDump {
+  const result = TestProject.spawn(
+    process.execPath,
+    [resolveGraphLauncher(), "dump", "--cwd", cwd, "--tsconfig", tsconfig],
+    {
+      env: { TTSC_GRAPH_BINARY: resolveTtscgraphBinary() },
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `@ttsc/graph dump failed with ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+  return JSON.parse(result.stdout) as GraphDump;
+}
+
+export function findNode(
+  dump: GraphDump,
+  props: { file: string; name: string; kind: string },
+): GraphNode | undefined {
+  return dump.nodes.find(
+    (node) =>
+      node.file === props.file &&
+      node.name === props.name &&
+      node.kind === props.kind,
+  );
+}
+
+export function findEdge(
+  dump: GraphDump,
+  from: GraphNode,
+  to: GraphNode,
+  kind: string,
+): GraphEdge | undefined {
+  return dump.edges.find(
+    (edge) => edge.from === from.id && edge.to === to.id && edge.kind === kind,
+  );
+}

--- a/website/src/components/benchmark/GraphBenchmark.tsx
+++ b/website/src/components/benchmark/GraphBenchmark.tsx
@@ -248,6 +248,12 @@ interface ProjectGroup {
   models: ModelGroup[];
 }
 
+interface PromptModeGroup {
+  id: string;
+  promptFamily: string;
+  projects: ProjectGroup[];
+}
+
 function medianMetrics(samples: AgentSample[]): Metrics {
   const valid = validSamples(samples);
   return {
@@ -281,6 +287,69 @@ function projectGroupKey(cell: AgentCell): string {
     cell.promptFamily ?? "project-specific",
     cell.repo,
   ].join("\0");
+}
+
+function promptModeKey(promptFamily: string): string {
+  switch (promptFamily) {
+    case "dedicated":
+    case "project-specific":
+      return "dedicated";
+    case "common":
+    case "shared-onboarding":
+      return "common";
+    default:
+      return promptFamily;
+  }
+}
+
+function promptModeOrder(mode: PromptModeGroup): number {
+  const order = ["dedicated", "common", "overview", "custom"];
+  const index = order.indexOf(mode.id);
+  return index === -1 ? order.length : index;
+}
+
+function hasGraphMeasurement(model: ModelGroup): boolean {
+  return Boolean(model.ttsc || model.codegraph);
+}
+
+function hasCodegraphMeasurement(model: ModelGroup): boolean {
+  return Boolean(model.codegraph);
+}
+
+function defaultProjectGroup(
+  projects: ProjectGroup[],
+): ProjectGroup | undefined {
+  return (
+    projects.find((g) => g.models.some(hasCodegraphMeasurement)) ??
+    projects.find((g) => g.models.some(hasGraphMeasurement)) ??
+    projects[0]
+  );
+}
+
+function defaultModelGroup(models: ModelGroup[]): ModelGroup | undefined {
+  return (
+    models.find(hasCodegraphMeasurement) ??
+    models.find(hasGraphMeasurement) ??
+    models[0]
+  );
+}
+
+function buildPromptModeGroups(projects: ProjectGroup[]): PromptModeGroup[] {
+  return groupBy(projects, (project) => promptModeKey(project.promptFamily))
+    .map(
+      ({ key, items }): PromptModeGroup => ({
+        id: key,
+        promptFamily: items[0]?.promptFamily ?? key,
+        projects: items,
+      }),
+    )
+    .sort(
+      (a, b) =>
+        promptModeOrder(a) - promptModeOrder(b) ||
+        promptFamilyLabel(a.promptFamily).localeCompare(
+          promptFamilyLabel(b.promptFamily),
+        ),
+    );
 }
 
 /**
@@ -567,6 +636,13 @@ function modelMeta(model: ModelGroup): string {
   return parts.join(" - ");
 }
 
+function modelTabMeta(model: ModelGroup): string | undefined {
+  const parts: string[] = [];
+  if (model.effort) parts.push(model.effort);
+  parts.push(model.daemon ? "daemon" : "one-shot");
+  return parts.join(" / ");
+}
+
 /** One model row: its identity on the left, the metric groups on the right. */
 function ModelBlock({ model }: { model: ModelGroup }) {
   const metrics = METRICS.filter(
@@ -616,13 +692,15 @@ function LegendDot({ fill, label }: { fill: string; label: string }) {
 
 function ProjectPanel({
   group,
+  models = group.models,
   aside,
 }: {
   group: ProjectGroup;
+  models?: ModelGroup[];
   aside?: string;
 }) {
-  const hasTtsc = group.models.some((model) => model.ttsc);
-  const hasCodegraph = group.models.some((model) => model.codegraph);
+  const hasTtsc = models.some((model) => model.ttsc);
+  const hasCodegraph = models.some((model) => model.codegraph);
   const hasComparator = hasTtsc || hasCodegraph;
 
   return (
@@ -640,7 +718,7 @@ function ProjectPanel({
       />
 
       <div className="divide-y divide-[#1a1f29]">
-        {group.models.map((model) => (
+        {models.map((model) => (
           <ModelBlock key={model.id} model={model} />
         ))}
       </div>
@@ -661,42 +739,116 @@ function ProjectPanel({
   );
 }
 
-/** Project tab strip; mirrors the BenchmarkDashboard nav voice. */
-function ProjectTabs({
-  groups,
+interface TabChoice {
+  id: string;
+  label: string;
+  meta?: string;
+}
+
+function AxisTabs({
+  label,
+  ariaLabel,
+  items,
   active,
   onSelect,
 }: {
-  groups: ProjectGroup[];
+  label: string;
+  ariaLabel: string;
+  items: TabChoice[];
   active: string;
   onSelect: (id: string) => void;
 }) {
   return (
-    <nav
-      aria-label="Graph benchmark projects"
-      className="flex gap-1 overflow-x-auto rounded-lg border border-[#222834] bg-[#0c0e13] p-1"
-    >
-      {groups.map((group) => {
-        const isActive = group.id === active;
-        return (
-          <button
-            key={group.id}
-            type="button"
-            className={`shrink-0 rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors ${
-              isActive
-                ? "bg-[#1b212c] text-neutral-50 shadow-sm"
-                : "text-neutral-400 hover:bg-[#13171f] hover:text-neutral-100"
-            }`}
-            onClick={() => onSelect(group.id)}
-          >
-            {repoLabel(group.repo)}
-            <span className="ml-1 text-neutral-500">
-              {promptFamilyLabel(group.promptFamily)}
-            </span>
-          </button>
-        );
-      })}
-    </nav>
+    <div className="grid gap-2 sm:grid-cols-[6.5rem_minmax(0,1fr)] sm:items-center">
+      <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-neutral-500">
+        {label}
+      </div>
+      <nav
+        aria-label={ariaLabel}
+        className="flex min-w-0 gap-1 overflow-x-auto"
+      >
+        {items.map((item) => {
+          const isActive = item.id === active;
+          return (
+            <button
+              key={item.id}
+              type="button"
+              aria-pressed={isActive}
+              className={`shrink-0 rounded-md px-3 py-1.5 text-left text-[12px] font-medium transition-colors ${
+                isActive
+                  ? "bg-[#1b212c] text-neutral-50 shadow-sm"
+                  : "text-neutral-400 hover:bg-[#13171f] hover:text-neutral-100"
+              }`}
+              onClick={() => onSelect(item.id)}
+            >
+              <span className="block max-w-[13rem] truncate">{item.label}</span>
+              {item.meta ? (
+                <span className="mt-0.5 block font-mono text-[10px] text-neutral-500">
+                  {item.meta}
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}
+
+function GraphBenchmarkTabs({
+  modes,
+  activeMode,
+  activeProject,
+  activeModel,
+  onModeSelect,
+  onProjectSelect,
+  onModelSelect,
+}: {
+  modes: PromptModeGroup[];
+  activeMode: PromptModeGroup;
+  activeProject: ProjectGroup;
+  activeModel: ModelGroup;
+  onModeSelect: (id: string) => void;
+  onProjectSelect: (id: string) => void;
+  onModelSelect: (id: string) => void;
+}) {
+  return (
+    <div className="space-y-2 rounded-lg border border-[#222834] bg-[#0c0e13] p-2.5">
+      <AxisTabs
+        label="Question"
+        ariaLabel="Graph benchmark question modes"
+        items={modes.map((mode) => ({
+          id: mode.id,
+          label: promptFamilyLabel(mode.promptFamily),
+          meta: `${mode.projects.length} project${
+            mode.projects.length !== 1 ? "s" : ""
+          }`,
+        }))}
+        active={activeMode.id}
+        onSelect={onModeSelect}
+      />
+      <AxisTabs
+        label="Project"
+        ariaLabel="Graph benchmark projects"
+        items={activeMode.projects.map((project) => ({
+          id: project.id,
+          label: repoLabel(project.repo),
+        }))}
+        active={activeProject.id}
+        onSelect={onProjectSelect}
+      />
+      <AxisTabs
+        label="Model"
+        ariaLabel="Graph benchmark models"
+        items={activeProject.models.map((model) => ({
+          id: model.id,
+          label: model.label,
+          meta: modelTabMeta(model),
+        }))}
+        active={activeModel.id}
+        onSelect={onModelSelect}
+      />
+    </div>
   );
 }
 
@@ -872,7 +1024,9 @@ export default function GraphBenchmark({
 }: GraphBenchmarkProps) {
   const [report, setReport] = useState<GraphReport | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [activeGroupId, setActiveGroupId] = useState<string | null>(null);
+  const [activeModeId, setActiveModeId] = useState<string | null>(null);
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
+  const [activeModelId, setActiveModelId] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -899,6 +1053,7 @@ export default function GraphBenchmark({
   if (!report) return <Notice>Loading graph benchmark results...</Notice>;
 
   const groups = buildProjectGroups(report.agent?.cells ?? []);
+  const modes = buildPromptModeGroups(groups);
 
   // The landing summary shows only the hero project (vscode) without tabs,
   // matching the index prose; the full page tabs across every project.
@@ -919,34 +1074,65 @@ export default function GraphBenchmark({
     );
   }
 
-  // Default to the first project that carries a full comparison when one exists.
-  const defaultGroup =
-    groups.find((g) => g.models.some((m) => m.codegraph)) ??
-    groups.find((g) => g.models.some((m) => m.ttsc)) ??
-    groups[0];
-  const active =
-    activeGroupId && groups.some((g) => g.id === activeGroupId)
-      ? activeGroupId
-      : defaultGroup?.id;
-  const activeGroup = groups.find((g) => g.id === active);
+  const defaultMode =
+    modes.find((mode) =>
+      mode.projects.some((project) =>
+        project.models.some(hasCodegraphMeasurement),
+      ),
+    ) ??
+    modes.find((mode) =>
+      mode.projects.some((project) => project.models.some(hasGraphMeasurement)),
+    ) ??
+    modes[0];
+  const activeMode =
+    activeModeId && modes.some((mode) => mode.id === activeModeId)
+      ? modes.find((mode) => mode.id === activeModeId)
+      : defaultMode;
+  const activeProject =
+    activeMode && activeProjectId
+      ? (activeMode.projects.find(
+          (project) => project.id === activeProjectId,
+        ) ?? defaultProjectGroup(activeMode.projects))
+      : activeMode
+        ? defaultProjectGroup(activeMode.projects)
+        : undefined;
+  const activeModel =
+    activeProject && activeModelId
+      ? (activeProject.models.find((model) => model.id === activeModelId) ??
+        defaultModelGroup(activeProject.models))
+      : activeProject
+        ? defaultModelGroup(activeProject.models)
+        : undefined;
 
   return (
     <div className="not-prose my-6 space-y-5">
-      {groups.length > 0 && active ? (
+      {modes.length > 0 && activeMode && activeProject && activeModel ? (
         <>
-          <ProjectTabs
-            groups={groups}
-            active={active}
-            onSelect={setActiveGroupId}
+          <GraphBenchmarkTabs
+            modes={modes}
+            activeMode={activeMode}
+            activeProject={activeProject}
+            activeModel={activeModel}
+            onModeSelect={(id) => {
+              setActiveModeId(id);
+              setActiveProjectId(null);
+              setActiveModelId(null);
+            }}
+            onProjectSelect={(id) => {
+              setActiveProjectId(id);
+              setActiveModelId(null);
+            }}
+            onModelSelect={setActiveModelId}
           />
-          {activeGroup ? (
-            <ProjectPanel
-              group={activeGroup}
-              aside={`${activeGroup.models.length} model${
-                activeGroup.models.length !== 1 ? "s" : ""
-              }`}
-            />
-          ) : null}
+          <ProjectPanel
+            group={activeProject}
+            models={[activeModel]}
+            aside={
+              activeProject.models.length === 1
+                ? "1 model"
+                : `1 of ${activeProject.models.length} models`
+            }
+          />
         </>
       ) : null}
       {report.structural ? (

--- a/website/src/content/docs/benchmark/graph.mdx
+++ b/website/src/content/docs/benchmark/graph.mdx
@@ -6,7 +6,7 @@ import GraphBenchmark from "../../../components/benchmark/GraphBenchmark";
 
 It asks two questions: how completely the graph resolves a real TypeScript codebase, and whether an agent spends fewer tokens and tool calls when a graph MCP server is available. The agent-cost runner can measure `@ttsc/graph` and the `codegraph` comparator against the same empty-MCP baseline.
 
-Prompt families are stored in `graph.json`. The `dedicated` family uses project-specific mechanism questions. The `common` family asks the same onboarding-style question across projects.
+The dashboard separates the agent-cost data by question mode, project, then agent model. `dedicated` uses project-specific mechanism questions; `common` asks the same onboarding-style question across projects.
 
 The graph fuses static structure and live diagnostics into one checker-resolved ontology. An agent can see a change's reach over what is currently broken before it edits. See [Code Graph](/docs/graph).
 
@@ -16,7 +16,7 @@ The graph fuses static structure and live diagnostics into one checker-resolved 
 
 The agent-cost benchmark runs an AI coding agent headless against prepared fixtures in `experimental/benchmark/.work`. A baseline run uses an empty MCP config. A graph run uses the same prompt and model, but adds exactly one MCP server: either `@ttsc/graph` or `codegraph`. A graph-arm run that completes without any MCP tool call, or that falls back to shell source reads/searches, is invalid for graph measurement and is retried or left failed rather than used in the median; a cell with no valid sample is not published.
 
-Baseline cells can be measured first with `--arm=baseline --tools=baseline`. Later comparator runs can use `--arm=graph --tools=ttsc-graph,codegraph`; the website groups those graph samples with the existing baseline by repository, prompt id or family, model tier, effort, fixture branch, and daemon mode.
+Baseline cells can be measured first with `--arm=baseline --tools=baseline`. Later comparator runs can use `--arm=graph --tools=ttsc-graph,codegraph`; the website groups those graph samples with the existing baseline by question mode, repository, model tier, effort, fixture branch, and daemon mode.
 
 The stored metrics are the raw per-run samples: total tokens, reasoning token counts when the harness exposes them, tool-call count, and wall time. Medians and saved percentages are derived by the website component from `website/public/benchmark/graph.json`.
 

--- a/website/src/content/docs/benchmark/index.mdx
+++ b/website/src/content/docs/benchmark/index.mdx
@@ -3,20 +3,18 @@ import PerformanceSummary from "../../../components/benchmark/PerformanceSummary
 
 # Benchmark
 
-`ttsc` publishes two separate benchmarks, each measuring a different question.
+`ttsc` publishes two benchmark tracks.
 
 ## Code Graph (MCP)
 
-[The Code Graph benchmark](/docs/benchmark/graph) measures whether an agent spends fewer tokens and tool calls when it has the `@ttsc/graph` code map available. It also covers structural coverage: how completely the graph resolves a real codebase's cross-file relationships.
+[The Code Graph benchmark](/docs/benchmark/graph) measures whether an agent spends fewer tokens and tool calls when `@ttsc/graph` is available. It also checks structural coverage: how completely the graph resolves cross-file relationships in a real TypeScript project.
 
-The agent-cost slice reports prompt families separately. `dedicated` prompts are project-specific mechanism questions. `common` prompts ask the same onboarding-style question across projects.
-
-The current graph refresh starts with Codex / GPT-5.4 mini empty-MCP baselines. Comparator measurements for `@ttsc/graph` and `codegraph` are added as separate graph arms after the baseline exists.
+The detailed page reads the agent-cost results by question mode, project, then agent model. `dedicated` prompts are project-specific mechanism questions; `common` prompts ask the same onboarding-style question across projects.
 
 <GraphBenchmark variant="summary" />
 
 ## Compiler Performance
 
-[The compiler-performance benchmark](/docs/benchmark/performance) measures how much wall-clock time changes when a real TypeScript project moves from the legacy `tsc` + `eslint` path to TypeScript-Go backed builds, checks, and linting. The dashboard covers build, type-check, lint, and format across real open-source repositories, single-threaded and multi-threaded.
+[The compiler-performance benchmark](/docs/benchmark/performance) measures wall-clock time when a real TypeScript project moves from the legacy `tsc` + `eslint` path to TypeScript-Go backed builds, checks, and linting. The dashboard covers build, type-check, lint, and format across real open-source repositories, single-threaded and multi-threaded.
 
 vscode, 6,093 TypeScript files across a large application monorepo, is the flagship example. At 8 checker workers, `ttsc` builds vscode in around 8 s versus roughly 94 s for legacy `tsc`, and type-checks it in around 6.5 s versus roughly 73 s. The full dashboard covers nestjs, vue, zod, typeorm, rxjs, and shopping-backend as well.


### PR DESCRIPTION
## Intent

Move the graph-resolution coverage that briefly landed on `master` into a normal PR, and make the graph benchmark website easier to read as benchmark dimensions expand.

## Scope

- Adds e2e dump coverage for pnpm workspace links, tsconfig path aliases, and node_modules declaration leaves.
- Splits the graph benchmark UI into Question -> Project -> Model axes instead of combining project and prompt family in one tab strip.
- Tightens benchmark overview copy so it matches the new reading order.

## Deferred

- No benchmark JSON changes in this PR.
- No graph runtime behavior changes beyond the tests already covered by the existing implementation.

## Test Plan

- `pnpm format`
- `pnpm --filter @ttsc/test-graph exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @ttsc/website build`