### PR TITLE
docs(graph): add the @ttsc/graph launch post and expand the README

### DIFF
--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -4,17 +4,11 @@
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/ttsc/blob/master/LICENSE) [![NPM Version](https://img.shields.io/npm/v/@ttsc/graph.svg)](https://www.npmjs.com/package/@ttsc/graph) [![NPM Downloads](https://img.shields.io/npm/dm/@ttsc/graph.svg)](https://www.npmjs.com/package/@ttsc/graph) [![Build Status](https://github.com/samchon/ttsc/workflows/test/badge.svg)](https://github.com/samchon/ttsc/actions?query=workflow%3Atest) [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://ttsc.dev/docs/graph) [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)
 
-Gives your AI coding agent a **map of your TypeScript codebase**, over MCP, so it answers "how does this work?" without opening file after file.
+Ask your coding agent how a TypeScript project works and you know what happens: it opens a file, follows an import, opens another, and a dozen files later it answers. The crawl is slow, token-hungry, and every relationship is a guess read off the text.
 
-Ask an agent like Claude Code or Codex about your project and it works file by file: open one, follow an import, open the next, until it has pieced the picture together by hand. Slow, token-hungry, and every relationship is a guess from reading text.
+`@ttsc/graph` gives the agent a **graph of your codebase** instead, over MCP: what calls what, what depends on what, where each piece lives. It is drawn by the real TypeScript compiler, so it is exact, not skimmed. The agent answers from the graph, and every claim is anchored to a file and line the compiler resolved, so you can open the spot and check it.
 
-`@ttsc/graph` hands it the map up front: what calls what, what depends on what, where each piece lives. Drawn by the real TypeScript compiler, so it is exact, not skimmed.
-
-On a public benchmark, an agent answered while reading **zero files**, cutting tokens by **77% to 86%** and tool calls by **94% to 95%** (see the [benchmark](https://ttsc.dev/docs/benchmark/graph)).
-
-You can also browse the whole map. This is TypeORM in 3D, colored by kind ([live viewer](https://ttsc.dev/docs/graph/viewer)):
-
-[![The TypeORM code graph rendered in 3D](https://ttsc.dev/graph/typeorm.png)](https://ttsc.dev/docs/graph/viewer)
+Plenty of tools replace that crawl. Cutting the agent's tool calls is the easy part; cutting its tokens too is harder, and cutting them without the answer getting any worse is harder still. That last problem is the one `@ttsc/graph` is built for: on a public benchmark it cuts an agent's tokens by roughly 10x on open-ended "how does this work?" questions. See the [Benchmark](#benchmark) section below.
 
 ## Setup
 
@@ -24,7 +18,7 @@ You can also browse the whole map. This is TypeORM in 3D, colored by kind ([live
 npm install -D ttsc @ttsc/graph typescript@rc
 ```
 
-`@ttsc/graph` reads the map from the program `ttsc` already type-checked, so install the two together.
+`@ttsc/graph` reads the graph from the program `ttsc` type-checked, so install the two together. `ttsc` runs on the TypeScript-Go (TypeScript v7) runtime, which is still a release candidate, so the install pins `typescript@rc`. It does not run on stable TypeScript v6.x yet.
 
 ### Connect your agent
 
@@ -43,23 +37,98 @@ For Claude Code, that is a `.mcp.json` in your project root:
 }
 ```
 
-Start your agent from your project root so the server finds your `tsconfig.json`. The agent queries the map on its own; you never call it by hand.
+Start your agent from your project root so the server finds your `tsconfig.json`. The agent queries the graph on its own; you never call it by hand. The example says Claude Code, but any MCP-capable agent works (Codex, Cursor, and others).
 
 ### Browse it in 3D
 
-Run this in your own project to open that 3D map in your browser, served from a local port:
+Run this in your own project to open the graph in your browser, served from a local port:
 
 ```bash
 npx @ttsc/graph view
 ```
 
+This is TypeORM in 3D, colored by kind ([live viewer](https://ttsc.dev/docs/graph/viewer)):
+
+[![The TypeORM code graph rendered in 3D](https://ttsc.dev/graph/typeorm.png)](https://ttsc.dev/docs/graph/viewer)
+
+## Why I Built It
+
+I did not invent this. [`codegraph`](https://github.com/colbymchenry/codegraph) put a code graph in front of an agent over MCP first; [`codebase-memory-mcp`](https://github.com/DeusData/codebase-memory-mcp) does the same across 158 languages, headlining "120x fewer tokens." Their core claim is legit: the enemy is the agent's grep, find, and Read crawl loop, and replacing it with one graph query is a real win. So I installed them.
+
+It did not go well. Tokens did not drop. On some repositories the agent spent more than it did with no MCP at all. Claude Code and Codex did not get smarter, and kept missing the intent. Useless tool calls fired constantly and blocked the work I wanted done. And I could not just ask in plain language: `codebase-memory-mcp` wants a Cypher query with an exact `qualified_name`, and `codegraph` wants you to name the symbols for a flow.
+
+So I went digging. Two things explained it.
+
+### What the tool returns
+
+A query has to come back as something. `codegraph` returns whole source bodies, "the Read, done for you." That is fine for editing, but for a broad "how does this work?" the body is the token bomb, and past a dozen files it truncates and asks you to call again. `codebase-memory-mcp` is the more interesting case. Under the hood it has a real relation graph, much like the one here: call chains, dependencies, cross-service links. But the capability is spread across fourteen MCP tools, and the useful ones want a Cypher query or an exact `qualified_name`. In the benchmark the agent never reached it: it called the MCP zero times and went to the shell instead. The graph was there; the surface buried it.
+
+Two different failures: one hands back too much, the other keeps the right thing behind a door the agent never opens. Neither lets it answer cheaply.
+
+![What each tool hands back](https://ttsc.dev/blog/response-shapes.svg)
+
+### Whether it forces itself
+
+The other half is the instructions, and the two go opposite ways. `codegraph` forces its tool: its MCP instructions tell the agent to use it instead of reading files, to call it before any Read, and to reach for it on almost any question. So calls fire even when the graph is not the answer, for a config, a small edit, or a question it cannot answer, and those calls block real work. `codebase-memory-mcp` does the reverse: its MCP initialize sends no instructions at all, so with fourteen tools and little to say which to use when, the agent mostly never engaged it. One over-directs, one under-directs.
+
+To their credit, both are upfront about the limits: `codegraph` notes its token savings are scale-dependent and that it is overhead unless queried directly, and `codebase-memory-mcp` reports its biggest numbers on structural queries, not open-ended ones. Those limits grow the more general the use, which is the case `@ttsc/graph` was built for. These two are the pioneers that put a code graph in front of an agent at all; this one just learns from where they ran into a wall.
+
+For the full version of this story, read the [launch post](https://ttsc.dev/blog/graph).
+
+## How It Works
+
+`@ttsc/graph` is built to avoid each of those.
+
+### Built on the real TypeScript compiler
+
+`@ttsc/graph` reads the graph from the program `ttsc` already type-checked. Because the compiler finished module resolution, the graph is exact: `tsconfig` path aliases (`@app/*`), pnpm monorepo cross-package references, symlinks, and re-export chains all resolve correctly. A parser that only reads text, such as tree-sitter, has to infer these, and a guessed edge is where an agent stops trusting the result and goes back to reading files.
+
+The graph falls out of the type-check that already runs, so there is no separate index step, no file watcher, and no stale index to manage.
+
+### An index, not source bodies
+
+A query returns names, edges, signatures, and source spans, and never inlines source bodies. The edges and signatures are the relationships themselves, so the agent assembles the answer without opening a file.
+
+Two things follow. The response is bounded independent of repo size, so the token cost stays flat whether the project is ten thousand lines or a million. And every span is a citation: a file and line the compiler resolved, which you can open to verify.
+
+### One tool, asked in plain language
+
+The whole MCP surface is a single tool. A capable graph is no use if the agent cannot reach it, which is the failure that buried `codebase-memory-mcp`'s, so one tool removes that choice entirely. You ask in plain language ("how does this project work?"), and a guided request inside the tool turns that into the right graph operation. There are no symbol names, query languages, or schemas for you to learn.
+
+![The guided request inside one tool call](https://ttsc.dev/blog/cot-pipeline.svg)
+
+The request carries a short, required chain of thought (`question`, `draft`, `review`) before it runs, so the model plans the smallest query and can correct or bail out first. It is built with [typia](https://typia.io), whose function-calling harness compiles the TypeScript type into the tool schema and validator. The single source of truth for the whole surface, including the descriptions the model reads, is [`ITtscGraphApplication.ts`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphApplication.ts).
+
+The request resolves to one of these operations. You do not pick them by hand; the guided request does.
+
+- [`tour`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphTour.ts): a broad code tour. Answers "new project, how does it work?" in one response.
+- [`entrypoints`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphEntrypoints.ts): where to start reading.
+- [`lookup`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphLookup.ts): find a symbol by name.
+- [`trace`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphTrace.ts): trace a call or data flow, forward or by impact radius.
+- [`details`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphDetails.ts): a symbol's signature, members, and neighbors.
+- [`overview`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphOverview.ts): a repo-level overview.
+- [`escape`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphEscape.ts): a no-op exit when the graph is not the right source.
+
+### It does not force itself on the agent
+
+`@ttsc/graph` never tells the agent to call it instead of reading files. It states when the graph is the right source (questions about TypeScript symbols, calls, and types) and offers a first-class `escape` for everything else (configs, docs, exact-text search). The one firm rule is that a returned fact is compiler truth and does not need re-checking by reading files. Calls fire when the graph helps, and not otherwise.
+
+### Compile errors and lint findings, in the same graph
+
+The graph also carries `tsc` compile errors plus `@ttsc/lint` and plugin (typia, nestia) lint findings, each fused onto the symbol that owns it. So "what is broken here?" and "what breaks if I change this?" come from the same index as the structure.
+
 ## Benchmark
 
-On the current GPT 5.4 Mini snapshot, the published median token cost is lowest with `@ttsc/graph`. The chart below is generated from `website/public/benchmark/graph.json`.
+On the current GPT 5.4 Mini snapshot, the published median token cost is lowest with `@ttsc/graph`.
 
 ![Common prompt median token use on Codex GPT-5.4 Mini](https://ttsc.dev/benchmark/graph-common-codex-gpt-5.4-mini.svg)
 
-See the [full benchmark page](https://ttsc.dev/docs/benchmark/graph) for the raw rows and method.
+The benchmark runs two prompt families across eight real repositories: a common onboarding question, and the per-repo questions from `codegraph`, whose benchmark this ports. `codebase-memory-mcp`'s own prompts would have made a third, but it ships no reproducible method, so they are not included. `@ttsc/graph` holds a flat, low token cost, while the other tools swing with repo size and sometimes land above the no-MCP baseline. See the [full benchmark page](https://ttsc.dev/docs/benchmark/graph) for the raw rows and method.
+
+## Requirements
+
+- A TypeScript project with a `tsconfig.json`. `@ttsc/graph` is TypeScript only. On a project without a TypeScript program there is no graph to serve, and the agent will not lean on the tool.
+- `ttsc` and `typescript@rc`, the TypeScript-Go (v7) release candidate. It does not run on stable TypeScript v6.x yet.
 
 ## Sponsors
 
@@ -71,6 +140,8 @@ Your [donation](https://github.com/sponsors/samchon) encourages `ttsc` developme
 
 ## References
 
-`@ttsc/graph` is inspired by [codegraph](https://github.com/colbymchenry/codegraph), which first put a code graph in front of an agent over MCP. The [benchmark](https://ttsc.dev/docs/benchmark/graph) here is a faithful port of codegraph's.
+`@ttsc/graph` is inspired by [`codegraph`](https://github.com/colbymchenry/codegraph), which first put a code graph in front of an agent over MCP. The [benchmark](https://ttsc.dev/docs/benchmark/graph) here is a faithful port of `codegraph`'s.
 
-The difference is where the map comes from. codegraph parses the shape of your code and infers how the pieces connect, while `@ttsc/graph` asks the real TypeScript compiler, which has already resolved every import and reference, so the map is exact rather than inferred.
+The difference is where the graph comes from. `codegraph` parses the shape of your code and infers how the pieces connect, while `@ttsc/graph` asks the real TypeScript compiler, which has already resolved every import and reference, so the graph is exact rather than inferred.
+
+See also [`codebase-memory-mcp`](https://github.com/DeusData/codebase-memory-mcp), which explores the same idea across 158 languages.

--- a/website/public/blog/cot-pipeline.svg
+++ b/website/public/blog/cot-pipeline.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="512" viewBox="0 0 1200 512" font-family="'Segoe UI', system-ui, -apple-system, Helvetica, Arial, sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1117"/>
+      <stop offset="1" stop-color="#1b2330"/>
+    </linearGradient>
+    <marker id="arrow" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto">
+      <path d="M0 0 L6 3 L0 6 z" fill="#7d93b0"/>
+    </marker>
+    <marker id="arrowG" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto">
+      <path d="M0 0 L6 3 L0 6 z" fill="#3fb950"/>
+    </marker>
+  </defs>
+  <rect width="1200" height="512" fill="url(#bg)"/>
+
+  <!-- title -->
+  <text x="60" y="56" font-size="30" font-weight="700" fill="#e6edf3">One tool, a forced checklist</text>
+  <text x="60" y="86" font-size="17" font-weight="500" fill="#8b949e">Every call walks the same chain of thought before it can act</text>
+
+  <!-- ===================== chain of 4 boxes ===================== -->
+  <!-- arrows between boxes -->
+  <g stroke="#3a4656" stroke-width="2.5" fill="none">
+    <line x1="312" y1="154" x2="366" y2="154" marker-end="url(#arrow)"/>
+    <line x1="572" y1="154" x2="626" y2="154" marker-end="url(#arrow)"/>
+    <line x1="832" y1="154" x2="886" y2="154" marker-end="url(#arrow)"/>
+  </g>
+
+  <!-- box 1: question -->
+  <rect x="115" y="120" width="190" height="68" rx="12" fill="#161d28" stroke="#3178c6" stroke-width="1.8"/>
+  <text x="210" y="151" font-size="20" font-weight="700" fill="#e6edf3" text-anchor="middle">question</text>
+  <text x="210" y="172" font-size="12.5" font-weight="500" fill="#8b949e" text-anchor="middle">the broad ask</text>
+
+  <!-- box 2: draft -->
+  <rect x="375" y="120" width="190" height="68" rx="12" fill="#161d28" stroke="#3178c6" stroke-width="1.8"/>
+  <text x="470" y="151" font-size="20" font-weight="700" fill="#e6edf3" text-anchor="middle">draft</text>
+  <text x="470" y="172" font-size="12.5" font-weight="500" fill="#8b949e" text-anchor="middle">first attempt</text>
+
+  <!-- box 3: review -->
+  <rect x="635" y="120" width="190" height="68" rx="12" fill="#161d28" stroke="#3178c6" stroke-width="1.8"/>
+  <text x="730" y="151" font-size="20" font-weight="700" fill="#e6edf3" text-anchor="middle">review</text>
+  <text x="730" y="172" font-size="12.5" font-weight="500" fill="#8b949e" text-anchor="middle">does it fit?</text>
+
+  <!-- box 4: request -->
+  <rect x="895" y="120" width="190" height="68" rx="12" fill="#161d28" stroke="#3178c6" stroke-width="1.8"/>
+  <text x="990" y="151" font-size="20" font-weight="700" fill="#e6edf3" text-anchor="middle">request</text>
+  <text x="990" y="172" font-size="12.5" font-weight="500" fill="#8b949e" text-anchor="middle">pick an operation</text>
+
+  <!-- note under chain -->
+  <text x="115" y="222" font-size="15.5" font-weight="500" fill="#9fb4cc"><tspan fill="#cfe0f5" font-weight="700">typia</tspan> validates the arguments &#8212; the model can&#8217;t skip a step</text>
+
+  <!-- ===================== escape branch from review ===================== -->
+  <g stroke="#3a4656" stroke-width="2.5" fill="none">
+    <path d="M730 188 L730 248 Q730 256 722 256 L513 256 Q505 256 505 264 L505 296" marker-end="url(#arrow)"/>
+  </g>
+  <text x="612" y="248" font-size="12.5" font-weight="600" fill="#8b949e" text-anchor="middle">if off-topic</text>
+  <rect x="380" y="302" width="250" height="74" rx="12" fill="#1e1518" stroke="#a85544" stroke-width="1.6"/>
+  <text x="505" y="332" font-size="18" font-weight="700" fill="#e6a08f" text-anchor="middle">escape</text>
+  <text x="505" y="356" font-size="13" font-weight="500" fill="#b08379" text-anchor="middle">not a graph question &#183; bail out</text>
+
+  <!-- ===================== fan-out from request to 7 ops ===================== -->
+  <!-- fan lines into panel top -->
+  <g stroke="#2f5d3a" stroke-width="1.6" fill="none" opacity="0.85">
+    <line x1="990" y1="190" x2="720" y2="300"/>
+    <line x1="990" y1="190" x2="800" y2="300"/>
+    <line x1="990" y1="190" x2="880" y2="300"/>
+    <line x1="990" y1="190" x2="960" y2="300"/>
+    <line x1="990" y1="190" x2="1010" y2="300"/>
+    <line x1="990" y1="190" x2="1060" y2="300"/>
+    <line x1="990" y1="190" x2="1110" y2="300"/>
+  </g>
+
+  <!-- operations panel -->
+  <rect x="660" y="300" width="470" height="180" rx="14" fill="#0f1620" stroke="#2a3340" stroke-width="1.5"/>
+  <text x="684" y="328" font-size="14" font-weight="700" fill="#8b949e">7 operations</text>
+  <text x="1106" y="328" font-size="12.5" font-weight="600" fill="#3fb950" text-anchor="end">tour = the usual pick</text>
+
+  <!-- row 1 -->
+  <g font-size="14" font-weight="600">
+    <!-- tour (highlighted) -->
+    <rect x="698" y="346" width="70" height="32" rx="16" fill="#3fb950" opacity="0.16"/>
+    <rect x="698" y="346" width="70" height="32" rx="16" fill="none" stroke="#3fb950" stroke-width="1.6"/>
+    <text x="733" y="367" fill="#7ee08c" text-anchor="middle">tour</text>
+
+    <rect x="784" y="346" width="118" height="32" rx="16" fill="#1a222e" stroke="#39455a" stroke-width="1.3"/>
+    <text x="843" y="367" fill="#cfe0f5" text-anchor="middle">entrypoints</text>
+
+    <rect x="918" y="346" width="86" height="32" rx="16" fill="#1a222e" stroke="#39455a" stroke-width="1.3"/>
+    <text x="961" y="367" fill="#cfe0f5" text-anchor="middle">lookup</text>
+
+    <rect x="1020" y="346" width="76" height="32" rx="16" fill="#1a222e" stroke="#39455a" stroke-width="1.3"/>
+    <text x="1058" y="367" fill="#cfe0f5" text-anchor="middle">trace</text>
+  </g>
+
+  <!-- row 2 -->
+  <g font-size="14" font-weight="600">
+    <rect x="744" y="406" width="84" height="32" rx="16" fill="#1a222e" stroke="#39455a" stroke-width="1.3"/>
+    <text x="786" y="427" fill="#cfe0f5" text-anchor="middle">details</text>
+
+    <rect x="844" y="406" width="96" height="32" rx="16" fill="#1a222e" stroke="#39455a" stroke-width="1.3"/>
+    <text x="892" y="427" fill="#cfe0f5" text-anchor="middle">overview</text>
+
+    <rect x="956" y="406" width="84" height="32" rx="16" fill="#1a222e" stroke="#39455a" stroke-width="1.3"/>
+    <text x="998" y="427" fill="#cfe0f5" text-anchor="middle">escape</text>
+  </g>
+</svg>

--- a/website/public/blog/graph-og.svg
+++ b/website/public/blog/graph-og.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" font-family="'Segoe UI', system-ui, -apple-system, Helvetica, Arial, sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1117"/>
+      <stop offset="1" stop-color="#1b2330"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- faint code-graph motif, right side -->
+  <g opacity="0.16">
+    <g stroke="#3178c6" stroke-width="3" fill="none">
+      <line x1="930" y1="180" x2="1065" y2="140"/>
+      <line x1="930" y1="180" x2="985" y2="335"/>
+      <line x1="1065" y1="140" x2="1110" y2="300"/>
+      <line x1="1110" y1="300" x2="985" y2="335"/>
+      <line x1="985" y1="335" x2="905" y2="450"/>
+      <line x1="985" y1="335" x2="1060" y2="475"/>
+      <line x1="1060" y1="475" x2="1110" y2="300"/>
+    </g>
+    <g fill="#3178c6">
+      <circle cx="930" cy="180" r="16"/>
+      <circle cx="1065" cy="140" r="16"/>
+      <circle cx="1110" cy="300" r="16"/>
+      <circle cx="905" cy="450" r="16"/>
+      <circle cx="1060" cy="475" r="16"/>
+    </g>
+    <g fill="#3fb950">
+      <circle cx="985" cy="335" r="22"/>
+    </g>
+  </g>
+
+  <!-- wordmark -->
+  <text x="80" y="120" font-size="44" font-weight="700" fill="#8b949e">@ttsc<tspan fill="#3fb950">/graph</tspan></text>
+
+  <!-- headline -->
+  <text x="76" y="322" font-size="172" font-weight="800" letter-spacing="-5">
+    <tspan fill="#3fb950">10×</tspan><tspan fill="#e6edf3"> fewer</tspan>
+  </text>
+  <text x="80" y="474" font-size="172" font-weight="800" letter-spacing="-5" fill="#e6edf3">tokens.</text>
+
+  <!-- subtitle -->
+  <text x="84" y="556" font-size="42" font-weight="600" fill="#aebfd4">A TypeScript code-graph over MCP, for Claude Code.</text>
+
+  <!-- footer -->
+  <text x="84" y="600" font-size="30" font-weight="500" fill="#6e7d90">Built on the real TypeScript compiler  ·  ttsc.dev</text>
+</svg>

--- a/website/public/blog/response-shapes.svg
+++ b/website/public/blog/response-shapes.svg
@@ -1,0 +1,155 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" font-family="'Segoe UI', system-ui, -apple-system, Helvetica, Arial, sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1117"/>
+      <stop offset="1" stop-color="#1b2330"/>
+    </linearGradient>
+    <linearGradient id="fade" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0b0f16" stop-opacity="0"/>
+      <stop offset="1" stop-color="#0b0f16" stop-opacity="1"/>
+    </linearGradient>
+    <clipPath id="clipCol1"><rect x="60" y="150" width="320" height="318" rx="12"/></clipPath>
+  </defs>
+  <rect width="1200" height="620" fill="url(#bg)"/>
+
+  <!-- title -->
+  <text x="60" y="56" font-size="30" font-weight="700" fill="#e6edf3">What each tool hands back</text>
+  <text x="60" y="86" font-size="17" font-weight="500" fill="#8b949e">Response to a broad &#8220;how does this work?&#8221; question &#8212; box size = token cost</text>
+
+  <!-- ===================== Column 1: codegraph ===================== -->
+  <g>
+    <rect x="60" y="115" width="320" height="26" rx="13" fill="#3178c6" opacity="0.18"/>
+    <circle cx="80" cy="128" r="5" fill="#3178c6"/>
+    <text x="94" y="133" font-size="16" font-weight="700" fill="#cfe0f5">codegraph</text>
+    <text x="237" y="133" font-size="13" font-weight="600" fill="#7d93b0">source bodies</text>
+
+    <!-- code viewport box, content overflows -->
+    <rect x="60" y="150" width="320" height="318" rx="12" fill="#0b0f16" stroke="#2a3340" stroke-width="1.5"/>
+    <g clip-path="url(#clipCol1)">
+      <g>
+        <!-- many code-line bars, indented like source, spilling -->
+        <g fill="#3178c6">
+          <rect x="78" y="164" width="120" height="8" rx="4" opacity="0.9"/>
+          <rect x="98" y="182" width="180" height="8" rx="4" opacity="0.55"/>
+          <rect x="98" y="200" width="140" height="8" rx="4" opacity="0.7"/>
+          <rect x="118" y="218" width="160" height="8" rx="4" opacity="0.5"/>
+          <rect x="118" y="236" width="96" height="8" rx="4" opacity="0.8"/>
+          <rect x="98" y="254" width="200" height="8" rx="4" opacity="0.5"/>
+          <rect x="78" y="272" width="150" height="8" rx="4" opacity="0.85"/>
+          <rect x="98" y="290" width="170" height="8" rx="4" opacity="0.55"/>
+          <rect x="118" y="308" width="130" height="8" rx="4" opacity="0.7"/>
+          <rect x="118" y="326" width="190" height="8" rx="4" opacity="0.5"/>
+          <rect x="98" y="344" width="110" height="8" rx="4" opacity="0.8"/>
+          <rect x="78" y="362" width="165" height="8" rx="4" opacity="0.6"/>
+          <rect x="98" y="380" width="205" height="8" rx="4" opacity="0.5"/>
+          <rect x="118" y="398" width="140" height="8" rx="4" opacity="0.7"/>
+          <rect x="98" y="416" width="175" height="8" rx="4" opacity="0.55"/>
+          <rect x="78" y="434" width="125" height="8" rx="4" opacity="0.8"/>
+          <rect x="98" y="452" width="195" height="8" rx="4" opacity="0.5"/>
+        </g>
+      </g>
+    </g>
+    <!-- fade to imply it keeps going -->
+    <rect x="61" y="408" width="318" height="59" rx="12" fill="url(#fade)"/>
+    <text x="220" y="455" font-size="13" font-weight="700" fill="#9fb4cc" text-anchor="middle">&#8230; and it keeps going</text>
+
+    <!-- caption -->
+    <text x="220" y="512" font-size="17" font-weight="700" fill="#e6edf3" text-anchor="middle">verbatim source</text>
+    <text x="220" y="540" font-size="15" font-weight="500" fill="#8b949e" text-anchor="middle">tokens explode on broad questions</text>
+  </g>
+
+  <!-- ===================== Column 2: codebase-memory ===================== -->
+  <g>
+    <rect x="440" y="115" width="320" height="26" rx="13" fill="#3178c6" opacity="0.18"/>
+    <circle cx="460" cy="128" r="5" fill="#3178c6"/>
+    <text x="474" y="133" font-size="16" font-weight="700" fill="#cfe0f5">codebase-memory</text>
+    <text x="748" y="133" font-size="13" font-weight="600" fill="#7d93b0" text-anchor="end">graph, buried</text>
+
+    <!-- buried relation graph (faint, peeking behind the wall of tools) -->
+    <g opacity="0.34">
+      <g stroke="#3178c6" stroke-width="3" fill="none">
+        <line x1="456" y1="162" x2="600" y2="150"/>
+        <line x1="600" y1="150" x2="746" y2="168"/>
+        <line x1="456" y1="162" x2="450" y2="298"/>
+        <line x1="746" y1="168" x2="752" y2="292"/>
+        <line x1="450" y1="298" x2="600" y2="306"/>
+        <line x1="600" y1="306" x2="752" y2="292"/>
+        <line x1="456" y1="162" x2="600" y2="306"/>
+        <line x1="746" y1="168" x2="600" y2="306"/>
+      </g>
+      <g fill="#3178c6">
+        <circle cx="456" cy="162" r="8"/>
+        <circle cx="600" cy="150" r="8"/>
+        <circle cx="746" cy="168" r="8"/>
+        <circle cx="450" cy="298" r="8"/>
+        <circle cx="752" cy="292" r="8"/>
+      </g>
+      <circle cx="600" cy="306" r="11" fill="#3fb950"/>
+    </g>
+
+    <!-- the wall: 14 MCP tool chips covering the graph -->
+    <g>
+      <!-- row 1 -->
+      <rect x="460" y="168" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="472" y="181" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <rect x="518" y="168" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="530" y="181" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <rect x="576" y="168" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="588" y="181" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <rect x="634" y="168" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="646" y="181" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <rect x="692" y="168" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="704" y="181" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <!-- row 2 -->
+      <rect x="460" y="210" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="472" y="223" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <rect x="518" y="210" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="530" y="223" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <rect x="576" y="210" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="588" y="223" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <rect x="634" y="210" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="646" y="223" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <rect x="692" y="210" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="704" y="223" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <!-- row 3 (4 chips, centered) -->
+      <rect x="489" y="252" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="501" y="265" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <rect x="547" y="252" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="559" y="265" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <rect x="605" y="252" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="617" y="265" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+      <rect x="663" y="252" width="48" height="30" rx="7" fill="#1a2230" stroke="#3a4656" stroke-width="1.2"/><rect x="675" y="265" width="24" height="4" rx="2" fill="#3178c6" opacity="0.7"/>
+    </g>
+    <text x="600" y="303" font-size="13" font-weight="600" fill="#8b949e" text-anchor="middle">14 MCP tools &#183; graph never reached</text>
+
+    <!-- arrow down -->
+    <g stroke="#566273" stroke-width="2" fill="none">
+      <line x1="600" y1="314" x2="600" y2="334"/>
+    </g>
+    <path d="M600 342 l-7 -11 l14 0 z" fill="#566273"/>
+
+    <!-- gives up -> shell box -->
+    <rect x="470" y="348" width="260" height="58" rx="12" fill="#171f2b" stroke="#3a4656" stroke-width="1.5"/>
+    <text x="600" y="374" font-size="17" font-weight="700" fill="#e6edf3" text-anchor="middle">gives up &#8594; shell</text>
+    <text x="600" y="394" font-size="13" font-weight="500" fill="#8b949e" text-anchor="middle">grep &#183; Read</text>
+
+    <!-- caption -->
+    <text x="600" y="512" font-size="17" font-weight="700" fill="#e6edf3" text-anchor="middle">a real graph</text>
+    <text x="600" y="535" font-size="14" font-weight="500" fill="#8b949e" text-anchor="middle">buried under 14 tools &#183; 0 MCP calls</text>
+    <text x="600" y="556" font-size="14" font-weight="500" fill="#8b949e" text-anchor="middle">fell back to grep</text>
+  </g>
+
+  <!-- ===================== Column 3: @ttsc/graph ===================== -->
+  <g>
+    <rect x="820" y="115" width="320" height="26" rx="13" fill="#3fb950" opacity="0.18"/>
+    <circle cx="840" cy="128" r="5" fill="#3fb950"/>
+    <text x="854" y="133" font-size="16" font-weight="700" fill="#d3f0d8">@ttsc/graph</text>
+    <text x="1058" y="133" font-size="13" font-weight="600" fill="#6fae7c">compact index</text>
+
+    <!-- tidy compact card -->
+    <rect x="855" y="170" width="250" height="150" rx="12" fill="#0e1a13" stroke="#2c5236" stroke-width="1.5"/>
+    <text x="875" y="200" font-size="13" font-weight="700" fill="#8b949e">names</text>
+    <rect x="945" y="190" width="142" height="9" rx="4" fill="#3fb950" opacity="0.85"/>
+    <text x="875" y="230" font-size="13" font-weight="700" fill="#8b949e">edges</text>
+    <rect x="945" y="220" width="120" height="9" rx="4" fill="#3fb950" opacity="0.65"/>
+    <rect x="945" y="234" width="142" height="9" rx="4" fill="#3fb950" opacity="0.65"/>
+    <text x="875" y="266" font-size="13" font-weight="700" fill="#8b949e">spans</text>
+    <text x="945" y="266" font-size="12.5" font-weight="600" fill="#7ee08c">emit.ts:17</text>
+    <text x="875" y="298" font-size="13" font-weight="600" fill="#6fae7c">each span = a file:line anchor</text>
+
+    <!-- green check -->
+    <circle cx="980" cy="362" r="22" fill="#3fb950"/>
+    <path d="M969 362 l8 8 l15 -16" stroke="#0d1117" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <!-- caption -->
+    <text x="980" y="512" font-size="17" font-weight="700" fill="#e6edf3" text-anchor="middle">answer</text>
+    <text x="980" y="540" font-size="15" font-weight="500" fill="#3fb950" text-anchor="middle">grounded &#183; cites exact spans</text>
+  </g>
+</svg>

--- a/website/src/content/blog/graph.mdx
+++ b/website/src/content/blog/graph.mdx
@@ -1,0 +1,279 @@
+---
+title: "I Made a TypeScript Compiler Graph MCP for Claude Code: 10x Fewer Tokens, Even for General-Purpose Questions"
+description: "It's built on the TypeScript compiler's own APIs — it reads the graph the compiler already resolved instead of guessing it — so it stays exact and cuts tokens 10x even on open-ended 'how does this work?' questions, not just targeted ones. A compiler-exact index handed to your coding agent over MCP, with every claim anchored to a verifiable file:line span. Plus why the other code-graph tools, for all their strengths, don't move the token bill on a real question."
+date: "2026-06-30"
+author: "Jeongho Nam"
+ogImage: "/blog/graph-og.svg"
+tags:
+  - typescript
+  - ai
+  - mcp
+  - llm
+  - opensource
+---
+
+> ## TL;DR
+>
+> `codegraph` and `codebase-memory-mcp` had the idea first: hand a coding agent a code graph over MCP. But on my own open-ended questions the token bill didn't budge, so I built [`@ttsc/graph`](https://github.com/samchon/ttsc/tree/master/packages/graph).
+>
+> It hands the agent an **index** the TypeScript compiler already resolved (never source bodies), through one tool with a forced chain-of-thought. The result on "how does this work?" questions: **~10× fewer tokens**, answers no worse. A measured, conservative median.
+>
+> - Repository: https://github.com/samchon/ttsc
+> - Benchmark: https://ttsc.dev/docs/benchmark/graph
+> - Issues: https://github.com/samchon/ttsc/issues
+
+---
+
+## 1. Preface
+
+### 1.1. What @ttsc/graph Is
+
+Ask a coding agent "how does this project actually work?" and you know what comes next. It opens a file. Follows an import, opens another. Opens another. Dozens of files later, it answers.
+
+`@ttsc/graph` kills that crawl. It hands your agent a **graph of your TypeScript codebase — drawn by the compiler itself** — over MCP: what calls what, what depends on what, where each piece lives. The agent answers structural questions from the graph instead of spelunking through files — and every claim comes anchored to an exact file:line the compiler pointed at. Not invented; something you can open and check.
+
+How big is the difference? Here's the chart.
+
+![Median token use, common prompts, Codex GPT-5.4 Mini](https://ttsc.dev/benchmark/graph-common-codex-gpt-5.4-mini.svg)
+
+Same question, same agent. Only `@ttsc/graph` stays flat at ~42k tokens across every repo. The others swing wildly — and some even spend _more_ than the baseline (no MCP at all). Full numbers and method are on the [benchmark page](https://ttsc.dev/docs/benchmark/graph).
+
+### 1.2. What a Code Graph Is
+
+First, what a "code graph" even is. Land in a city you've never visited and you don't read every street sign in order — you glance at a subway map. It throws away the buildings, the trees, the real distances, and keeps the one thing you need: what connects to what. Readable in five seconds.
+
+Code has the same structure. Nodes are functions, classes, files; edges are calls, imports, extends, depends-on. Draw them all and you get a code graph — an **index** of "what calls what." The agent queries that index once instead of walking every street.
+
+### 1.3. Index, Not Source Inlining
+
+Here's the first fork in the road. `@ttsc/graph` **doesn't return source bodies.** Names, edges, signatures, spans — an index, nothing more.
+
+And the span is the point. Every range it cites is a coordinate the compiler vouched for, so if you doubt an answer you just open that spot and check. The reassuring part isn't "it read no files" — it's that **a place to verify always comes attached.**
+
+Tokens stay flat because the response size is **bounded independent of repo size.** A 100k-line project or a 10k-line one — one question returns a similarly sized chunk of index. Why the other tools spill source instead is the autopsy in §2.
+
+### 1.4. How It Works, in One Breath
+
+In one sentence: **it reads an index from the program the TypeScript compiler already resolved, and feeds a single MCP tool a forced chain-of-thought so the agent doesn't wander.** That's the whole thing. Details in §3. First — why I built it at all.
+
+## 2. Why I Built It
+
+### 2.1. The Promise
+
+Honestly, not my idea. [`codegraph`](https://github.com/colbymchenry/codegraph) put a code graph in front of an agent over MCP first, and [`codebase-memory-mcp`](https://github.com/DeusData/codebase-memory-mcp) does the same across 158 languages. This post's benchmark is a faithful port of `codegraph`'s, run on two prompt families: a common onboarding question, and `codegraph`'s own per-repo questions. (`codebase-memory-mcp`'s would have made a third, but it ships no reproducible method.)
+
+And their core claim is legit. The enemy is the agent's **grep · find · Read crawl loop.** Every "where is this?" turns into a grep, a file open, an import chased, another grep — dozens of round-trips burning tokens and time. `codegraph`'s pitch is clean: replace that loop with one graph query — "58% fewer tool calls, file reads to ~zero." `codebase-memory-mcp` goes further, headlining "**120× fewer tokens**" (a 99.2% cut).
+
+Sounded great. So I installed them.
+
+One thing up front, though. Cutting an agent's tool calls is the **easy** part. Cutting its tokens at the same time is harder. And cutting tokens _without the answer getting any worse_ is the real problem. Those are three different things, not one.
+
+### 2.2. So I Tried Them
+
+Here's what actually happened.
+
+- **Tokens didn't drop at all.** The tool-call _count_ may have fallen, but the thing you pay for — tokens — didn't budge. On some cells it was even _worse than the baseline_ (`codegraph` spent up to 47% more, `codebase-memory-mcp` up to 96% more).
+- Claude Code and Codex got **worse**, not smarter. They kept missing the intent.
+- Useless MCP calls fired constantly, **blocking or delaying** the work I actually wanted done.
+- I couldn't just ask in plain language. Every query had to be hand-shaped — `codebase-memory-mcp` wants a Cypher query with an exact `qualified_name`; `codegraph` wants you to name the symbols for a flow. That **babysitting** alone ate the productivity.
+
+In short: for my kind of question, worse than before I installed them. So I went digging.
+
+### 2.3. Bodies, and a Buried Graph
+
+The first cause was what each tool does with what it has.
+
+`codegraph` returns **whole source bodies** — by its own description, "the Read, done for you." Fine for editing. But for a broad "how does this work?", the body _is_ the token bomb. Past a dozen files it truncates and says "call again for more." So you call again. More bodies.
+
+`codebase-memory-mcp` is the more interesting one, because under the hood it has the right idea. It builds a real **relation graph**, a lot like the one I ended up with: not just where things are, but how they call and depend on each other. The trouble is the surface. That capability is spread across **fourteen MCP tools**, and the useful ones want precise input, a Cypher query or an exact `qualified_name`. Handed fourteen tools and a query language, the agent mostly never reached the relation data at all. Measured, it called the MCP **0** times in every run and fell back to the shell: it gave up and grepped. The graph was right there; the surface buried it.
+
+So one hands back too much, and the other keeps the right thing behind a door the agent cannot find. Neither moves the token bill.
+
+![What each tool hands back](https://ttsc.dev/blog/response-shapes.svg)
+
+### 2.4. The Instructions
+
+The second cause is the instructions, and here the two tools go in opposite directions.
+
+`codegraph` forces its tool, hard. Its MCP instructions tell the agent to "use it instead of reading files," "call it before you Read," "don't grep or Read first," and reach for it on "almost any question." So calls fire even when the graph isn't the answer — a config, a small edit, a question it can't answer at all — and those wasted calls block the real work. `codegraph`'s README is candid about why: the tool only helps when queried directly and is overhead otherwise, so the instructions push hard to keep it from being overhead.
+
+`codebase-memory-mcp` does the reverse. Its MCP `initialize` sends no instructions at all, and most of its tools ship with no usage guidance (a couple of descriptions say "use instead of grep" for specific operations; auto-indexing exists but is off by default). Fourteen tools, and almost nothing telling the agent which to reach for or when — so it mostly didn't, and fell back to the shell, as we just saw.
+
+So one over-directs and the other under-directs. Neither lands on the thing you actually want: use the graph when it helps, and stop when it doesn't.
+
+And to their credit, none of the limits are hidden. `codegraph`'s README says its token savings are scale-dependent and small on a normal codebase. `codebase-memory-mcp` reports its biggest numbers on a handful of structural queries, not open-ended ones. They tell you, plainly, that the wins are measured on targeted scenarios.
+
+That is the whole point. Those limits get bigger the more general your use is, and general use is where I live. So I took these two for what they are, the pioneers that put a code graph in front of an agent at all, learned from where each one ran into a wall, and built for the case they were not aimed at: the open-ended question, with the tokens down and the answer still good.
+
+## 3. How It Works
+
+`@ttsc/graph` is designed to cure those four pains one at a time. The order below is the prescription.
+
+| Pain (§2) | Antidote (§3) |
+| --- | --- |
+| 2.4 — over-forced, or no guidance at all | **3.1** — guides without forcing (`escape` + stop) |
+| 2.3 — a real graph buried under 14 tools | **3.2** — one tool, asked in plain language |
+| 2.3 — source bodies blow up tokens | **3.3** — returns `index` only |
+| (only works if trustworthy) | **3.4** — the real compiler |
+
+### 3.1. It Never Forces You
+
+First, **it never forces.** Not one line of the instruction says "use this instead of Read." It states a condition instead: "use it when the answer depends on TypeScript symbols, calls, or types." And it makes `escape` a first-class choice for when the evidence lives outside the graph.
+
+The only strong rule is a single one: "once you've used it, that's compiler-issued truth — don't re-doubt it by reading files." When enough evidence is in, the result _tells_ the agent "answer now and stop" — it points at a stopping line, it doesn't demand more calls.
+
+So the useless forced calls that used to block work simply don't happen. The agent uses the graph when it should and skips it when it shouldn't. (Antidote to §2.4.)
+
+### 3.2. One Tool, with an Escape Hatch
+
+Second, Claude Code won't always pick the **right tool at the right moment.** The more options, the more misfires, and that is exactly what buried `codebase-memory-mcp`'s relation graph: **14** MCP tools, and the agent never found its way to the right one. (`codegraph` avoids the tool-count trap with a single default tool; it just pushes that one tool too hard — the §3.1 problem.)
+
+`@ttsc/graph` has **exactly one** tool. Inside it, _what_ to do is split by a CoT-fed union type. And the safeguards stack: a `review` step mid-CoT can switch the request type, and if it's still wrong, `escape` bails. Safety first.
+
+![The forced chain-of-thought inside one tool call: question → draft → review → one request, or escape out](https://ttsc.dev/blog/cot-pipeline.svg)
+
+Here's the entire surface — one type, with the comments trimmed to one line each:
+
+```typescript
+// TOOL DESCRIPTION: inspect the compiler-built TypeScript code graph over MCP.
+export interface ITtscGraphApplication {
+  inspect_typescript_graph(
+    props: ITtscGraphApplication.IProps,
+  ): ITtscGraphApplication.IResult;
+}
+
+export namespace ITtscGraphApplication {
+  // The forced chain-of-thought, then exactly one graph request.
+  export interface IProps {
+    question: string; // restate the code question being asked
+    draft: string;    // intended request type + why it is the smallest
+    review: string;   // self-correct a wrong/broad draft; pick `escape` if off-graph
+    request:          // the final operation, chosen after review
+      | ITtscGraphEntrypoints.IRequest // orientation: where to start reading
+      | ITtscGraphLookup.IRequest      // find a symbol by name
+      | ITtscGraphTrace.IRequest       // trace call / data flow
+      | ITtscGraphDetails.IRequest     // a symbol's signature, members, neighbors
+      | ITtscGraphOverview.IRequest    // repo-level overview
+      | ITtscGraphTour.IRequest        // broad code tour, answered in one call
+      | ITtscGraphEscape.IRequest;     // not a graph question -> bail out
+  }
+
+  // The selected request's result; `result.type` mirrors `request.type`.
+  export interface IResult {
+    result:
+      | ITtscGraphEntrypoints
+      | ITtscGraphLookup
+      | ITtscGraphTrace
+      | ITtscGraphDetails
+      | ITtscGraphOverview
+      | ITtscGraphTour
+      | ITtscGraphEscape;
+  }
+}
+```
+
+As you can see, `question → draft → review` are **forced function arguments.** typia compiles this type into the tool's JSON schema and validator, so an unfilled CoT is rejected at the call boundary. In typia's words: _"free prose can hide a skipped step; a typed submission cannot."_ (Deeper: [CoT compliance](https://typia.io/blog/function-calling-harness-2-cot-compliance/), [function-calling harness](https://typia.io/blog/function-calling-harness-qwen-meetup-korea/).)
+
+Those one-line comments are condensed; in the source, the fuller JSDoc on each member is what typia compiles into the MCP instruction and the schema descriptions the model reads. Want the details? Read [`ITtscGraphApplication.ts`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphApplication.ts).
+
+This is also the antidote to that babysitting. **You just ask in plain English** — "just figure it out." Translating that vague ask into the precise request type, and self-correcting, is the CoT's job. No symbol names, no Cypher, no query syntax to memorize.
+
+Each request branch is one graph operation — its own request (`.IRequest`) and result type. Dig in:
+
+- [`ITtscGraphTour`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphTour.ts) — a broad code tour. Answers "new project, how does it work?" in one index.
+- [`ITtscGraphEntrypoints`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphEntrypoints.ts) — find the entry points. Where to start reading.
+- [`ITtscGraphLookup`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphLookup.ts) — find a symbol by name.
+- [`ITtscGraphTrace`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphTrace.ts) — trace call / data flow (forward, or impact radius).
+- [`ITtscGraphDetails`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphDetails.ts) — a chosen symbol's signature, members, neighbors.
+- [`ITtscGraphOverview`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphOverview.ts) — a repo-level overview.
+- [`ITtscGraphEscape`](https://github.com/samchon/ttsc/blob/master/packages/graph/src/structures/ITtscGraphEscape.ts) — a no-op bail-out, out of the graph.
+
+### 3.3. Index Only, So Nothing Explodes
+
+Third, it returns **index only.** Names, edges, signatures, spans — the **relationships themselves**, not just where things sit. The edges and signatures carry "what calls what, and how," so the agent assembles the answer right there without opening a file. Source bodies are never inlined, and a span is a citation to verify, not a command to go read.
+
+Two effects. No token explosion from spilled bodies, and no compounding mess where that explosion plus a misfired MCP call clouds the agent's judgment. The response is bounded independent of repo size, so tokens stay flat.
+
+The source-body blowup from §2.3 and the "agent got worse" from §2.2 both ease in this one decision.
+
+And the thesis I opened in §2.1 closes here. `@ttsc/graph` kills the grep crawl loop too — that's table stakes. The difference is it does so _without_ the tokens blowing up, and without the answer getting any worse.
+
+### 3.4. Only the Compiler Makes This Possible
+
+Fourth. All three above only hold if the results are **trustworthy** — and that trust comes only from a real compiler.
+
+A heuristic parser like tree-sitter sees text. So there are things it can't resolve — `tsconfig` `paths` aliases (`@app/*` → the real file), cross-package references in a pnpm monorepo, symlinks, re-export chains. Only a compiler that actually finished module resolution can wire those up correctly.
+
+`@ttsc/graph` reads the program `ttsc` already type-checked and resolved. So aliases and monorepos just line up. And because it rides the toolchain, the graph falls out as a near-**free byproduct** of the type-check that's already running — no separate index step (`codegraph init`, `codebase-memory-mcp`'s `index_repository`), no file watcher, no stale-index problem.
+
+There's a bonus the compiler throws in, too. The graph doesn't just hold structure — it also carries **every tsc compile error and `@ttsc/lint`/plugin (typia, nestia) lint violation, each fused onto the symbol that owns it.** So "what's broken here?" and "what breaks if I change this?" come from the same index. Not just the shape of the code, but what's wrong with it right now — in one graph.
+
+Exact, so you can trust it; trusted, so you can stop. **exact = trust = stop.** That's the root of all of it.
+
+## 4. Try It
+
+### 4.1. What It Can't Do
+
+Bragging only would be a scam. Limits first.
+
+`@ttsc/graph` is **TypeScript-only.** It traded breadth for depth — the opposite bet from the 158-language tools.
+
+But that's not a footgun. On a non-TypeScript project there's simply **no graph to hand over, so the agent never leans on it.** Even inside a TS project, things outside the typed graph — configs, docs, exact-text search — `escape` cleanly out. Step outside its scope and it doesn't _break_; it just **quietly steps aside.** It's strong on exactly the questions a graph can answer, and no further.
+
+And here's the most important prerequisite. `@ttsc/graph` rides `ttsc`, and `ttsc` runs on the **TypeScript-Go (TypeScript v7)** runtime. v7 isn't released yet — it's at **RC**. That's why the install pins `typescript@rc`. It runs fine on the RC, but to be clear: this is **not something you drop onto your current stable TypeScript (v6.x).** Once v7 ships, that caveat dissolves on its own.
+
+### 4.2. It Might Break
+
+I built this because I couldn't stand using `codegraph`. So I worked hard to make it hold up across general situations — no "I installed it and Codex got dumber." At least on my machine, it was solid.
+
+But the world is wide, and there could be failure modes I haven't seen. It's open source. If something's awkward, or you find something I got wrong, [file an issue](https://github.com/samchon/ttsc/issues). That's the fastest way to make this thing solid.
+
+### 4.3. Add It in Four Lines
+
+Setup is four lines.
+
+```bash
+npm install -D ttsc @ttsc/graph typescript@rc
+```
+
+```json
+{
+  "mcpServers": {
+    "ttsc-graph": {
+      "command": "npx",
+      "args": ["-y", "@ttsc/graph"]
+    }
+  }
+}
+```
+
+The agent queries the graph on its own — you never call it by hand. The title says Claude Code, but any MCP-capable agent works — Codex, Cursor, and the rest.
+
+### 4.4. See It in 3D
+
+Bonus. Run it in your own project and you can spin your code graph in 3D in the browser.
+
+```bash
+npx @ttsc/graph view
+```
+
+This is TypeORM, colored by kind:
+
+[![The TypeORM code graph rendered in 3D](https://ttsc.dev/graph/typeorm.png)](https://ttsc.dev/docs/graph/viewer)
+
+And — to those of you on other languages. This approach isn't TypeScript's alone. Truly conquering the code graph takes **each language's real compiler** — heuristics can't resolve aliases, monorepos, or types. I picked TypeScript. Someone in Go, Rust, Python, Java, C# should ride their language's compiler or LSP and **conquer theirs.** One language at compiler depth beats 158 skimmed off the top — far more valuable to an agent. I'd love to see it.
+
+One last thing. **Don't make your agent read the whole codebase. Hand it the index the compiler drew.**
+
+## 5. References
+
+![@ttsc/graph](https://ttsc.dev/og.jpg)
+
+- Repository: https://github.com/samchon/ttsc
+- Benchmark: https://ttsc.dev/docs/benchmark/graph
+- Issues: https://github.com/samchon/ttsc/issues
+
+The pioneers this builds on:
+
+- `codegraph`: https://github.com/colbymchenry/codegraph
+- `codebase-memory-mcp`: https://github.com/DeusData/codebase-memory-mcp


### PR DESCRIPTION
Splits the @ttsc/graph documentation out of the benchmark branch into its own PR.

## What

- New launch blog post at `website/src/content/blog/graph.mdx`, with its OG thumbnail and two explanatory diagrams under `website/public/blog/`.
- Rewrites `packages/graph/README.md` to carry the same substance.

## Notes

- Fair to both pioneer projects (codegraph, codebase-memory-mcp); the competitor claims were fact-checked against their repositories.
- Docs only: no source or benchmark changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)