### PR TITLE
fix(lint): dynamically resolve rootDir for Windows compatibility

### DIFF
--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -1353,7 +1353,13 @@ func typeScriptConfigLoaderTsconfig(loader, location, outDir string) string {
       "noImplicitAny":                   false,
       "outDir":                          filepath.ToSlash(filepath.Join(outDir, "out")),
       "rewriteRelativeImportExtensions": true,
-      "rootDir":                         "/",
+      "rootDir": func() string {
+        vol := filepath.VolumeName(outDir)
+        if vol == "" {
+          return "/"
+        }
+        return filepath.ToSlash(vol + "\\")
+      }(),
       "skipLibCheck":                    true,
       "strict":                          false,
       "target":                          "ES2022",

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -564,7 +564,7 @@ function evaluateTtsxConfigPlugins(
             noImplicitAny: false,
             outDir: path.join(tempDir, "out").replace(/\\/g, "/"),
             rewriteRelativeImportExtensions: true,
-            rootDir: "/",
+            rootDir: path.parse(tempDir).root.replace(/\\/g, "/"),
             skipLibCheck: true,
             strict: false,
             target: "ES2022",


### PR DESCRIPTION
## Overview
Resolves the `TS6059` compilation error when evaluating TypeScript lint configs on Windows by dynamically detecting the system's volume root instead of using the hardcoded `"/"`.

## Changes
- **JS side** (`packages/lint/src/index.ts`): Replaced `"rootDir": "/"` with `rootDir: path.parse(tempDir).root.replace(/\\/g, "/")`.
- **Go side** (`packages/lint/linthost/config.go`): Replaced `"rootDir": "/"` with a volume root dynamic resolver using `filepath.VolumeName()`.

## Related Issue
- Resolves #299 
