### PR TITLE
fix(website): review the graph doc pages and fix the 3D viewer edge-kind mapping

### DIFF
--- a/experimental/benchmark/graph/viewer.mjs
+++ b/experimental/benchmark/graph/viewer.mjs
@@ -74,6 +74,26 @@ function rewriteId(id, root) {
 }
 
 /**
+ * Collapse the fine-grained wire kinds `ttscgraph dump` emits (calls,
+ * instantiates, renders, accesses, type_ref, extends, implements) into the
+ * three display families the viewer colors and its legend name. An unknown kind
+ * passes through and renders with the fallback color.
+ */
+const DISPLAY_KIND = {
+  calls: "value-call",
+  instantiates: "value-call",
+  renders: "value-call",
+  accesses: "value-call",
+  type_ref: "type-ref",
+  extends: "heritage",
+  implements: "heritage",
+};
+
+function displayKind(kind) {
+  return DISPLAY_KIND[kind] ?? kind;
+}
+
+/**
  * Reduce a raw dump to the viewer payload: relativized, external-free, capped
  * to the highest-degree nodes, with orphans pruned. Returns `{ nodes, links }`
  * shaped for react-force-graph (node.id, link.source/target).
@@ -130,7 +150,7 @@ export function reduce(
     .map((e) => ({
       source: rewriteId(e.from, root),
       target: rewriteId(e.to, root),
-      kind: e.kind,
+      kind: displayKind(e.kind),
     }))
     .filter((e) => nodeIds.has(e.source) && nodeIds.has(e.target));
 

--- a/packages/graph/src/reduce.ts
+++ b/packages/graph/src/reduce.ts
@@ -97,6 +97,26 @@ function degreeOf(
   return degree;
 }
 
+/**
+ * Collapse the fine-grained wire kinds `ttscgraph dump` emits (calls,
+ * instantiates, renders, accesses, type_ref, extends, implements) into the
+ * three display families the viewer colors and its legend name. An unknown kind
+ * passes through and renders with the fallback color.
+ */
+const DISPLAY_KIND: Record<string, string> = {
+  calls: "value-call",
+  instantiates: "value-call",
+  renders: "value-call",
+  accesses: "value-call",
+  type_ref: "type-ref",
+  extends: "heritage",
+  implements: "heritage",
+};
+
+function displayKind(kind: string): string {
+  return DISPLAY_KIND[kind] ?? kind;
+}
+
 export function reduce(
   raw: RawDump,
   {
@@ -145,7 +165,7 @@ export function reduce(
     .map((e) => ({
       source: rewriteId(e.from, root),
       target: rewriteId(e.to, root),
-      kind: e.kind,
+      kind: displayKind(e.kind),
     }))
     .filter((e) => nodeIds.has(e.source) && nodeIds.has(e.target));
 

--- a/website/src/components/graph/TtscWebsiteGraphReduce.ts
+++ b/website/src/components/graph/TtscWebsiteGraphReduce.ts
@@ -66,6 +66,26 @@ function degreeOf(
 }
 
 /**
+ * Collapse the fine-grained wire kinds `ttscgraph dump` emits (calls,
+ * instantiates, renders, accesses, type_ref, extends, implements) into the
+ * three display families the viewer colors and its legend name. An unknown kind
+ * passes through and renders with the fallback color.
+ */
+const DISPLAY_KIND: Record<string, string> = {
+  calls: "value-call",
+  instantiates: "value-call",
+  renders: "value-call",
+  accesses: "value-call",
+  type_ref: "type-ref",
+  extends: "heritage",
+  implements: "heritage",
+};
+
+function displayKind(kind: string): string {
+  return DISPLAY_KIND[kind] ?? kind;
+}
+
+/**
  * Reduce a raw dump to the viewer payload: relativized, external-free, capped
  * to the highest-degree nodes, with orphans pruned.
  */
@@ -125,7 +145,7 @@ function reduce(
     .map((e) => ({
       source: rewriteId(e.from, root),
       target: rewriteId(e.to, root),
-      kind: e.kind,
+      kind: displayKind(e.kind),
     }))
     .filter((e) => nodeIds.has(e.source) && nodeIds.has(e.target));
 

--- a/website/src/content/docs/graph/compare.mdx
+++ b/website/src/content/docs/graph/compare.mdx
@@ -76,9 +76,7 @@ A capable graph is no use if the agent never calls it, and the four tools take v
 
 `serena` has the broadest surface, over forty tools documented and around twenty-seven active by default ([tools](https://oraios.github.io/serena/01-about/035_tools.html)), spanning retrieval, symbolic editing, memory, and project management. To get the agent to use them over its own read and edit loop, serena's recommended Claude Code setup goes furthest of the four. It launches Claude Code with a serena-supplied replacement system prompt (`claude --system-prompt="$(serena prompts print-cc-system-prompt-override)"`) and recommends disabling Claude Code's own built-in tools, naming `replace_string_in_file`, `apply_patch`, `list_dir`, `file_search`, and `grep_search` ([Claude Code setup](https://oraios.github.io/serena/02-usage/030_clients.html)). Its reasoning is that Claude Code's built-in tool descriptions run about sixteen thousand tokens and bias the model so strongly toward the built-ins that it is otherwise hard to get it to reach for serena at all. The breadth is deliberate, since serena aims to handle reading and editing, not only orientation.
 
-![CoT compliance turning a bolted-on tool back into a hand that grips it](/blog/images/prosthesis-to-hammer-in-hand.png)
-
-> `@ttsc/graph` reaches adoption from the other direction, by the shape of the tool rather than the loudness of the prompt. That mechanism is the [Design](/docs/graph/design) page.
+`@ttsc/graph` reaches adoption from the other direction: by the shape of the tool, a typed chain of thought inside a single call, rather than the loudness of the prompt. That mechanism is the [Design](/docs/graph/design) page.
 
 ### 2.4. Setup and freshness
 

--- a/website/src/content/docs/graph/design.mdx
+++ b/website/src/content/docs/graph/design.mdx
@@ -111,6 +111,10 @@ The typed chain of thought is an instance of a broader idea worth stating on its
 
 None of this is specific to a code graph. The same shape applies to any function-calling tool whose author keeps making the prompt louder to secure a behavior the schema could enforce directly.
 
+![CoT compliance turning a bolted-on tool back into a hand that grips it](/blog/images/prosthesis-to-hammer-in-hand.png)
+
+> The same tools, made whole. Instead of replacing the agent's hands with its own tools, a typed contract turns the tool into something the agent picks up and uses on its own.
+
 Two write-ups go into the theory, the numbers, and where it breaks down:
 
 - [Function Calling Harness from 6.75% to 100%](https://dev.to/samchon/qwen-meetup-function-calling-harness-from-675-to-100-3830)
@@ -134,7 +138,7 @@ The request branches, their results, and the facts each node and edge carries.
 
 `ITtscGraphDetails.IRequest` inspects selected handles. It returns signatures, members, direct calls, direct types, dependency neighbors, and `sourceSpan` anchors without implementation text.
 
-`ITtscGraphOverview.IRequest` returns a source-free architecture map: counts, layers, hotspots, and public API symbols.
+`ITtscGraphOverview.IRequest` returns a source-free architecture summary: counts, layers, hotspots, and public API symbols.
 
 `ITtscGraphEscape.IRequest` returns a small no-op result when the review finds that no graph operation should run.
 
@@ -142,7 +146,7 @@ The request branches, their results, and the facts each node and edge carries.
 
 The concrete payloads carry node coordinates, edge evidence ranges, citation spans, and stable node ids for follow-up graph calls. A span is an `ITtscGraphEvidence` coordinate (project-relative `file` plus 1-based start and end line and column), a place to open and verify, not inlined source text.
 
-Every result also carries `next`, the follow-up contract. `next.action` is one of `answer` (the evidence is complete, stop and answer, even when a slice is capped), `inspect` (make one more focused request, named by `next.request`), `outside` (the next evidence lives outside the graph, leave and read files or configs), or `clarify`.
+Every result also carries `next`, the follow-up contract. `next.action` is one of `answer` (the evidence is complete, stop and answer, even when a slice is capped), `inspect` (make one more focused request, named by `next.request`), `outside` (the next evidence lives outside the graph, leave and read files or configs), or `clarify` (the graph resolved nothing for the query, so ask for a concrete symbol or a narrower scope instead of spending another call).
 
 ### 2.3. Node kinds
 

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -1,12 +1,11 @@
 import TtscWebsiteBenchmarkGraphCommon from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphCommon";
+import TtscWebsiteGraphViewer3D from "../../../components/graph/TtscWebsiteGraphViewer3D";
 
 # Code Graph (MCP)
 
-`@ttsc/graph` gives a coding agent a map of your TypeScript project, over MCP.
+`@ttsc/graph` gives a coding agent a compiler-resolved graph of your TypeScript project, over MCP.
 
-It runs `ttscgraph`, a native binary that type-checks your project once and keeps it in memory. Every query is answered from that warm checker, not a fresh parse.
-
-So every relationship it reports is the compiler's own answer, not a guess from reading text.
+It runs `ttscgraph`, a native binary that type-checks your project once, and keeps the resulting graph resident in memory. Every query is answered from that resident graph, not a fresh parse, so every relationship it reports is the compiler's own answer, not a guess from reading text.
 
 ## 1. Why an agent needs it
 
@@ -14,7 +13,11 @@ What the graph saves an agent, and what that looks like in tokens.
 
 ### 1.1. The crawl it replaces
 
-Ask an agent how something works and, without a map, it reconstructs the picture by hand: open a file, follow an import, open the next, and repeat. That is slow, it spends tokens, and the relationships it infers are guesses from whatever text it happened to read.
+![A file-by-file source crawl collapsing into a compiler-built graph index](/blog/images/source-crawl-vs-compiler-index.png)
+
+> On the left, the agent is lost in a maze of files, chasing imports dozens deep. On the right, it reads one compiler-built graph of nodes and edges, each with a `file:line` anchor it can open and check.
+
+Ask an agent how something works and, without the graph, it reconstructs the picture by hand: open a file, follow an import, open the next, and repeat. That is slow, it spends tokens, and the relationships it infers are guesses from whatever text it happened to read.
 
 The graph hands it the answer up front through one MCP tool, `inspect_typescript_graph`. The agent chooses one request branch per call: `tour`, `overview`, `entrypoints`, `lookup`, `trace`, `details`, or `escape`. The agent stops fanning out across files.
 
@@ -39,6 +42,7 @@ The graph answers the questions an agent actually asks, all from the same checke
 - **Where should I start?** Ranked code handles for a natural question: `entrypoints` or `lookup`.
 - **What does this reach, and what reaches it?** Forward to callees, reverse to callers, and an impact projection onto the public API and tests: `trace`.
 - **What is this, exactly?** The declaration shape, its range, its dependencies, and its dependents: `details`.
+- **What is broken here?** `tsc` compile errors and `@ttsc/lint` and plugin findings ride the same graph, fused onto the symbol that owns them, so breakage and blast radius answer from one index.
 
 A tree-sitter graph has no types and resolves edges by guessing from text. An editor's language server has types but no architecture projection. Only a graph built on the real checker holds the resolved structure and the affected set in one place. Every node and edge is resolved by the compiler, so an agent never mistakes inference for fact.
 
@@ -85,4 +89,6 @@ Your agent picks the tool up from the MCP handshake and calls it when it needs t
 
 - [Design](/docs/graph/design): the design decisions, the single MCP tool and its request/result branches, and the node and edge kinds.
 - [Comparison](/docs/graph/compare): how it differs from codegraph, codebase-memory-mcp, and serena.
-- [3D Viewer](/docs/graph/viewer): browse the whole graph in your browser, or load your own project.
+- [3D Viewer](/docs/graph/viewer): browse the whole graph in your browser, or load your own project. Here it is live, the benchmark repositories rendered as navigable graphs; the [viewer page](/docs/graph/viewer) explains the colors and the reduction:
+
+<TtscWebsiteGraphViewer3D />

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -1,4 +1,5 @@
 import TtscWebsiteBenchmarkGraphCommon from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphCommon";
+import TtscWebsiteGraphViewer3D from "../../../components/graph/TtscWebsiteGraphViewer3D";
 
 # Code Graph (MCP)
 
@@ -88,6 +89,6 @@ Your agent picks the tool up from the MCP handshake and calls it when it needs t
 
 - [Design](/docs/graph/design): the design decisions, the single MCP tool and its request/result branches, and the node and edge kinds.
 - [Comparison](/docs/graph/compare): how it differs from codegraph, codebase-memory-mcp, and serena.
-- [3D Viewer](/docs/graph/viewer): browse the whole graph in your browser, or load your own project. This is TypeORM's graph, colored by declaration kind:
+- [3D Viewer](/docs/graph/viewer): browse the whole graph in your browser, or load your own project. Here it is live, the benchmark repositories rendered as navigable graphs; the [viewer page](/docs/graph/viewer) explains the colors and the reduction:
 
-[![The TypeORM code graph rendered in 3D](/graph/typeorm.png)](/docs/graph/viewer)
+<TtscWebsiteGraphViewer3D />

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -1,5 +1,4 @@
 import TtscWebsiteBenchmarkGraphCommon from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphCommon";
-import TtscWebsiteGraphViewer3D from "../../../components/graph/TtscWebsiteGraphViewer3D";
 
 # Code Graph (MCP)
 
@@ -89,6 +88,6 @@ Your agent picks the tool up from the MCP handshake and calls it when it needs t
 
 - [Design](/docs/graph/design): the design decisions, the single MCP tool and its request/result branches, and the node and edge kinds.
 - [Comparison](/docs/graph/compare): how it differs from codegraph, codebase-memory-mcp, and serena.
-- [3D Viewer](/docs/graph/viewer): browse the whole graph in your browser, or load your own project. Here it is live, the benchmark repositories rendered as navigable graphs; the [viewer page](/docs/graph/viewer) explains the colors and the reduction:
+- [3D Viewer](/docs/graph/viewer): browse the whole graph in your browser, or load your own project. This is TypeORM's graph, colored by declaration kind:
 
-<TtscWebsiteGraphViewer3D />
+[![The TypeORM code graph rendered in 3D](/graph/typeorm.png)](/docs/graph/viewer)

--- a/website/src/content/docs/graph/viewer.mdx
+++ b/website/src/content/docs/graph/viewer.mdx
@@ -2,9 +2,9 @@ import TtscWebsiteGraphViewer3D from "../../../components/graph/TtscWebsiteGraph
 
 # 3D Graph Viewer
 
-The same checker-resolved graph the MCP tools answer from, rendered as a navigable 3D ontology. Pick a benchmark example, or load a graph from your own project. Every node is a declaration (class, interface, function, method, type, enum, variable); every edge is a resolved relationship the compiler reported.
+The same checker-resolved graph the MCP tools answer from, rendered as a navigable 3D ontology. Every node is a declaration (class, interface, function, method, type, enum, variable); every edge is a resolved relationship the compiler reported.
 
-Drag to orbit, scroll to zoom, hover a node for its name, kind, and file.
+The examples below are the [benchmark](/docs/benchmark/graph) fixture repositories, from VS Code's 6,093 files down to Zod. Pick one, or load a graph from your own project (see the next section). Drag to orbit, scroll to zoom, hover a node for its name, kind, and file.
 
 <TtscWebsiteGraphViewer3D />
 
@@ -22,6 +22,8 @@ npx @ttsc/graph view
 
 `view` builds your project's graph, reduces it, and opens this viewer in your browser from a local port. Nothing leaves your machine.
 
+It resolves the project from the working directory and `tsconfig.json` by default; `--cwd`, `--tsconfig`, `--port`, `--max-nodes`, and `--no-open` override that. Like the MCP server, it needs `ttsc` installed so the native `ttscgraph` binary is present.
+
 ### 1.2. Export the graph as JSON
 
 For the data as a file instead:
@@ -30,7 +32,9 @@ For the data as a file instead:
 npx @ttsc/graph dump --tsconfig tsconfig.json > graph.json
 ```
 
-`dump` prints the whole graph as JSON: every declaration and edge, keyed by absolute path. The viewer reduces it client-side (drops `node_modules`, keeps the highest-degree nodes, relativizes paths) so a large project stays legible. It also takes an already-reduced payload, so a graph you trimmed yourself loads as-is.
+`dump` prints the whole graph as JSON: every node and edge the build resolved, with none of the per-response caps the MCP tool applies. It is the same export the MCP server loads at startup, so what you dump is exactly what the agent queries.
+
+That file is what "Load your own JSON" above accepts. The viewer reduces it client-side before rendering (the exact reduction is in [What is left out](#22-what-is-left-out)) so a large project stays legible. It also takes an already-reduced payload, so a graph you trimmed yourself loads as-is.
 
 ## 2. Reading the graph
 
@@ -38,12 +42,21 @@ What the colors and sizes mean, and what the viewer leaves out.
 
 ### 2.1. What the colors mean
 
-Nodes are colored by declaration kind and sized by how many other declarations connect to them, so the load-bearing symbols stand out. Edges carry their kind:
+Nodes are colored by declaration kind and sized by how many other declarations connect to them, so the load-bearing symbols stand out.
 
-- **value-call**: a runtime use (a call, a `new T()`, a JSX component, a tagged template).
+Edges are colored by family. The graph itself distinguishes finer relationship kinds (the full set is in [Design](/docs/graph/design#24-edge-kinds)); the viewer folds them into three so the picture stays readable:
+
+- **value-call**: a runtime use. Covers `calls`, `instantiates` (`new T()`), `renders` (a JSX component), and `accesses` (a property read or write).
 - **type-ref**: a type-position reference (a parameter, return, property, or alias type).
 - **heritage**: an `extends` or `implements` relationship.
 
 ### 2.2. What is left out
 
-Anything in `node_modules` or a `.d.ts` lib is dropped; it is not your code.
+The viewer is a projection, not the whole graph. Reduction happens before rendering (in the browser for an uploaded dump, in Node for `view`), in this order:
+
+- **External code is dropped.** Anything in `node_modules` or a `.d.ts` lib is not your code; the graph keeps it only as a boundary, and the viewer drops the boundary leaves.
+- **Git-ignored generated code is dropped.** A Prisma client or other codegen emitted as `.ts` would bury the authored graph under thousands of look-alike nodes.
+- **Only the best-connected declarations survive a cap.** A project larger than the node budget (1,200 nodes for an uploaded dump) keeps its highest-degree nodes, so the hubs stay and the leaves go.
+- **Orphans are pruned.** A node left with no surviving edge is removed.
+
+The node and edge count in the panel header is what survived, not the raw graph. For the complete data, use `dump` and read the JSON directly.

--- a/website/src/content/docs/setup.mdx
+++ b/website/src/content/docs/setup.mdx
@@ -191,7 +191,7 @@ Full reference: [`@ttsc/vscode`](https://github.com/samchon/ttsc/tree/master/pac
 
 ## Coding agents (@ttsc/graph)
 
-[`@ttsc/graph`](/docs/graph) gives a coding agent a checker-resolved map of your project, over MCP.
+[`@ttsc/graph`](/docs/graph) gives a coding agent a checker-resolved graph of your project, over MCP.
 
 It answers what relates to a symbol and its blast radius, and it surfaces the project's full diagnostics — type errors, `@ttsc/lint` violations, and transform-plugin findings — so the agent stops grepping and re-reading source.
 


### PR DESCRIPTION
## Intent

A self-contained review pass over the four `/docs/graph` pages (built from the launch post), fixing what read abrupt, thin, or factually stale, plus one real defect the review surfaced in the 3D viewer pipeline.

## Scope

**Viewer edge-kind mapping (fix).** `ttscgraph dump` emits fine-grained wire kinds (`calls`, `instantiates`, `renders`, `accesses`, `type_ref`, `extends`, `implements`), but the 3D viewers color and label edges by the three display families (`value-call`, `type-ref`, `heritage`). No reduce mapped between the two, so a freshly dumped graph uploaded to the viewer rendered every edge with the fallback color and the legend matched nothing (the shipped example payloads predate the fine-grained kinds, which hid it). The mapping is added to all three mirrored reduces: `packages/graph/src/reduce.ts`, `website/src/components/graph/TtscWebsiteGraphReduce.ts`, `experimental/benchmark/graph/viewer.mjs`.

**Docs.**
- Overview: correct the resident-graph claim (the native binary dumps once, the Node server answers from the in-memory graph; there is no warm checker), map -> graph wording, add the source-crawl hero image, a diagnostics bullet, and embed the live 3D viewer component.
- Design: explain the `clarify` follow-up action, move the CoT-compliance image here where the concept is defined.
- Comparison: replace that image (out of context there) with a prose pointer to Design.
- Viewer: correct the dump description (ids and paths are project-relative, not absolute), document the `view` flags, name the example repos, tie the three edge families to the full edge-kind set, and spell out the reduction steps.
- Setup: same map -> graph wording fix.

## Deferred

- The shipped example payloads under `website/public/graph/*.json` still carry the old family kinds; they render correctly (pre-reduced payloads bypass the mapping) and were not regenerated.

## Test plan

- `tsc --noEmit` passes in `packages/graph` and `website`.
- Runtime repro of the mapping: a synthetic dump with `calls`/`type_ref`/`extends`/`accesses` edges reduces to `value-call`/`type-ref`/`heritage`/`value-call` (was: kinds passed through and rendered colorless).
- All changed files formatted with the repo prettier config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3Cn3zmu1uUVkYJfwyPFeJ