### PR TITLE
feat(website): show cost, time, and baseline deltas in graph benchmark tooltips

### DIFF
--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphChart.tsx
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphChart.tsx
@@ -214,18 +214,19 @@ function tooltipMetricRows(
       delta: pctDelta(baseline.dur, metrics.dur),
     },
   ];
-  // The cost row only exists on harnesses that report run cost (Claude Code);
-  // Codex lanes carry no cost, so the row is omitted rather than shown empty.
+  // Cost is measured on harnesses that report it (Claude Code) and estimated
+  // from tokens at API list prices otherwise (Codex); an estimate carries a
+  // leading ~. The row is omitted only when neither value exists.
   if (baseline.cost !== undefined || metrics.cost !== undefined)
     rows.push({
       label: "cost",
       base:
         baseline.cost !== undefined
-          ? TtscWebsiteBenchmarkGraphData.fmtCost(baseline.cost)
+          ? `${baseline.costEstimated ? "~" : ""}${TtscWebsiteBenchmarkGraphData.fmtCost(baseline.cost)}`
           : "n/a",
       value:
         metrics.cost !== undefined
-          ? TtscWebsiteBenchmarkGraphData.fmtCost(metrics.cost)
+          ? `${metrics.costEstimated ? "~" : ""}${TtscWebsiteBenchmarkGraphData.fmtCost(metrics.cost)}`
           : "n/a",
       delta:
         baseline.cost !== undefined && metrics.cost !== undefined
@@ -314,6 +315,12 @@ function ReductionTooltip({
           </div>
         ))}
       </div>
+      {row.baseline.costEstimated || tool.metrics.costEstimated ? (
+        <p className="mt-2 font-mono text-[10px] text-neutral-500">
+          ~ cost estimated from tokens at API list prices (Codex reports no
+          cost)
+        </p>
+      ) : null}
       {tool.setupMs !== undefined ? (
         <p className="mt-2 font-mono text-[10px] text-neutral-500">
           index setup: {TtscWebsiteBenchmarkGraphData.fmtSecs(tool.setupMs)}

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphChart.tsx
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphChart.tsx
@@ -168,6 +168,73 @@ function lowestTokenSeries(row: ReductionRow): ReductionSeriesKey {
   ).key;
 }
 
+/**
+ * Signed percentage change of a tool value against its baseline, for the
+ * parenthesized annotation next to each non-baseline metric: negative is a
+ * reduction, positive is over baseline. Null when the baseline is missing.
+ */
+function pctDelta(base: number, value: number): number | null {
+  if (base <= 0) return null;
+  return Math.round((value / base - 1) * 100);
+}
+
+function deltaText(delta: number | null): string | null {
+  if (delta === null) return null;
+  return `(${delta > 0 ? "+" : ""}${delta}%)`;
+}
+
+interface TooltipMetricRow {
+  label: string;
+  base: string;
+  value: string;
+  delta: number | null;
+}
+
+function tooltipMetricRows(
+  baseline: Metrics,
+  metrics: Metrics,
+): TooltipMetricRow[] {
+  const rows: TooltipMetricRow[] = [
+    {
+      label: "tokens",
+      base: TtscWebsiteBenchmarkGraphData.fmt(Math.round(baseline.tokens)),
+      value: TtscWebsiteBenchmarkGraphData.fmt(Math.round(metrics.tokens)),
+      delta: pctDelta(baseline.tokens, metrics.tokens),
+    },
+    {
+      label: "calls",
+      base: TtscWebsiteBenchmarkGraphData.fmt(Math.round(baseline.tools)),
+      value: TtscWebsiteBenchmarkGraphData.fmt(Math.round(metrics.tools)),
+      delta: pctDelta(baseline.tools, metrics.tools),
+    },
+    {
+      label: "time",
+      base: TtscWebsiteBenchmarkGraphData.fmtSecs(baseline.dur),
+      value: TtscWebsiteBenchmarkGraphData.fmtSecs(metrics.dur),
+      delta: pctDelta(baseline.dur, metrics.dur),
+    },
+  ];
+  // The cost row only exists on harnesses that report run cost (Claude Code);
+  // Codex lanes carry no cost, so the row is omitted rather than shown empty.
+  if (baseline.cost !== undefined || metrics.cost !== undefined)
+    rows.push({
+      label: "cost",
+      base:
+        baseline.cost !== undefined
+          ? TtscWebsiteBenchmarkGraphData.fmtCost(baseline.cost)
+          : "n/a",
+      value:
+        metrics.cost !== undefined
+          ? TtscWebsiteBenchmarkGraphData.fmtCost(metrics.cost)
+          : "n/a",
+      delta:
+        baseline.cost !== undefined && metrics.cost !== undefined
+          ? pctDelta(baseline.cost, metrics.cost)
+          : null,
+    });
+  return rows;
+}
+
 function ReductionTooltip({
   row,
   tool,
@@ -189,7 +256,7 @@ function ReductionTooltip({
     );
 
   return (
-    <div className="pointer-events-none absolute bottom-full left-0 z-30 mb-2 hidden w-72 rounded-md border border-[#2a313e] bg-[#090b10] p-3 text-left shadow-[0_18px_45px_rgba(0,0,0,0.45)] group-hover:block">
+    <div className="pointer-events-none absolute bottom-full left-0 z-30 mb-2 hidden w-80 rounded-md border border-[#2a313e] bg-[#090b10] p-3 text-left shadow-[0_18px_45px_rgba(0,0,0,0.45)] group-hover:block">
       <div
         className="pointer-events-none absolute inset-x-0 top-0 h-px"
         style={{
@@ -213,33 +280,39 @@ function ReductionTooltip({
         </span>
       </div>
 
-      <div className="mt-3 grid grid-cols-2 gap-2 font-mono text-[10px]">
-        <div className="rounded border border-[#1c2230] bg-[#0e1117] p-2">
-          <p className="uppercase tracking-[0.12em] text-neutral-600">
-            baseline
-          </p>
-          <p className="mt-1 tabular-nums text-neutral-200">
-            {TtscWebsiteBenchmarkGraphData.fmt(Math.round(row.baseline.tokens))}
-          </p>
+      <div className="mt-3 rounded border border-[#1c2230] bg-[#0e1117] p-2 font-mono text-[10px]">
+        <div className="grid grid-cols-[3.25rem_1fr_1fr] gap-x-2 uppercase tracking-[0.12em] text-neutral-600">
+          <span />
+          <span className="text-right">baseline</span>
+          <span className="text-right">tool</span>
         </div>
-        <div className="rounded border border-[#1c2230] bg-[#0e1117] p-2">
-          <p className="uppercase tracking-[0.12em] text-neutral-600">tool</p>
-          <p className="mt-1 tabular-nums text-neutral-200">
-            {TtscWebsiteBenchmarkGraphData.fmt(Math.round(tool.metrics.tokens))}
-          </p>
-        </div>
-        <div className="rounded border border-[#1c2230] bg-[#0e1117] p-2">
-          <p className="uppercase tracking-[0.12em] text-neutral-600">calls</p>
-          <p className="mt-1 tabular-nums text-neutral-200">
-            {TtscWebsiteBenchmarkGraphData.fmt(Math.round(tool.metrics.tools))}
-          </p>
-        </div>
-        <div className="rounded border border-[#1c2230] bg-[#0e1117] p-2">
-          <p className="uppercase tracking-[0.12em] text-neutral-600">time</p>
-          <p className="mt-1 tabular-nums text-neutral-200">
-            {TtscWebsiteBenchmarkGraphData.fmtSecs(tool.metrics.dur)}
-          </p>
-        </div>
+        {tooltipMetricRows(row.baseline, tool.metrics).map((metric) => (
+          <div
+            key={metric.label}
+            className="mt-1 grid grid-cols-[3.25rem_1fr_1fr] items-baseline gap-x-2"
+          >
+            <span className="uppercase tracking-[0.12em] text-neutral-600">
+              {metric.label}
+            </span>
+            <span className="text-right tabular-nums text-neutral-400">
+              {metric.base}
+            </span>
+            <span className="text-right tabular-nums text-neutral-200">
+              {metric.value}
+              {deltaText(metric.delta) ? (
+                <span
+                  className={`ml-1 ${
+                    metric.delta !== null && metric.delta > 0
+                      ? "text-rose-400"
+                      : "text-[#36e2ee]"
+                  }`}
+                >
+                  {deltaText(metric.delta)}
+                </span>
+              ) : null}
+            </span>
+          </div>
+        ))}
       </div>
       {tool.setupMs !== undefined ? (
         <p className="mt-2 font-mono text-[10px] text-neutral-500">

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphData.ts
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphData.ts
@@ -1,4 +1,5 @@
 import type { ITtscWebsiteBenchmarkGraph } from "../../../structures/ITtscWebsiteBenchmarkGraph";
+import pricing from "./TtscWebsiteBenchmarkGraphPricing.json";
 
 type AgentCell = ITtscWebsiteBenchmarkGraph.AgentCell;
 type AgentSample = ITtscWebsiteBenchmarkGraph.AgentSample;
@@ -176,20 +177,65 @@ function parseKey(key: string): string[] {
   return key.split("|").map((part) => decodeURIComponent(part));
 }
 
-function medianMetricsFromValid(valid: AgentSample[]): Metrics {
-  const costs = valid
+/** API list price in USD per 1M tokens for one model. */
+interface PriceRates {
+  input: number;
+  cachedInput: number;
+  output: number;
+}
+
+/** The list-price table for cost estimation, keyed by `modelVersion`. */
+function priceRates(modelVersion: string | undefined): PriceRates | undefined {
+  if (!modelVersion) return undefined;
+  const table: Record<string, PriceRates> = pricing.usdPerMillion;
+  return table[modelVersion];
+}
+
+/**
+ * Estimate one run's USD cost from its token counts and the model's list
+ * prices, for harnesses that report usage but no cost (Codex). `tokens` is the
+ * summed input+output; `cached` (a subset of the input) moves to the
+ * cached-input rate and `reasoning` is billed as output. The non-reasoning
+ * output slice inside `tokens` cannot be split out, so it is priced at the
+ * input rate: a slight underestimate on agent runs, where input dominates.
+ */
+function estimateSampleCost(sample: AgentSample, rates: PriceRates): number {
+  const cached = sample.cached ?? 0;
+  const reasoning = sample.reasoning ?? 0;
+  return (
+    (Math.max(0, sample.tokens - cached) * rates.input +
+      cached * rates.cachedInput +
+      reasoning * rates.output) /
+    1_000_000
+  );
+}
+
+function medianMetricsFromValid(
+  valid: AgentSample[],
+  rates?: PriceRates,
+): Metrics {
+  const measured = valid
     .map((s) => s.cost)
     .filter((cost): cost is number => typeof cost === "number");
+  const cost =
+    measured.length > 0
+      ? { cost: median(measured) }
+      : rates && valid.length > 0
+        ? {
+            cost: median(valid.map((s) => estimateSampleCost(s, rates))),
+            costEstimated: true,
+          }
+        : {};
   return {
     tokens: median(valid.map((s) => s.tokens)),
     tools: median(valid.map((s) => s.tools)),
     dur: median(valid.map((s) => s.durMs ?? 0)),
-    ...(costs.length > 0 ? { cost: median(costs) } : {}),
+    ...cost,
   };
 }
 
-function medianMetrics(samples: AgentSample[]): Metrics {
-  return medianMetricsFromValid(metricSamples(samples));
+function medianMetrics(samples: AgentSample[], rates?: PriceRates): Metrics {
+  return medianMetricsFromValid(metricSamples(samples), rates);
 }
 
 function metricSamples(samples: AgentSample[]): AgentSample[] {
@@ -319,6 +365,7 @@ function buildProjectGroups(cells: AgentCell[]): ProjectGroup[] {
             ? dedicatedBaselineSamples
             : embeddedBaselineSamples;
         const head = modelCells[0]!;
+        const rates = priceRates(head.modelVersion);
         const ttscValid = ttscCell ? metricSamples(ttscCell.samples.graph) : [];
         const codegraphValid = codegraphCell
           ? metricSamples(codegraphCell.samples.graph)
@@ -355,22 +402,22 @@ function buildProjectGroups(cells: AgentCell[]): ProjectGroup[] {
           codegraphSetupMs: codegraphCell?.toolSetupMs,
           codebaseMemorySetupMs: codebaseMemoryCell?.toolSetupMs,
           serenaSetupMs: serenaCell?.toolSetupMs,
-          baseline: medianMetrics(baselineSamples),
+          baseline: medianMetrics(baselineSamples, rates),
           ttsc:
             ttscValid.length > 0
-              ? medianMetricsFromValid(ttscValid)
+              ? medianMetricsFromValid(ttscValid, rates)
               : undefined,
           codegraph:
             codegraphValid.length > 0
-              ? medianMetricsFromValid(codegraphValid)
+              ? medianMetricsFromValid(codegraphValid, rates)
               : undefined,
           codebaseMemory:
             codebaseMemoryValid.length > 0
-              ? medianMetricsFromValid(codebaseMemoryValid)
+              ? medianMetricsFromValid(codebaseMemoryValid, rates)
               : undefined,
           serena:
             serenaValid.length > 0
-              ? medianMetricsFromValid(serenaValid)
+              ? medianMetricsFromValid(serenaValid, rates)
               : undefined,
         };
       })

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphData.ts
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphData.ts
@@ -29,6 +29,10 @@ function fmtSecs(ms: number): string {
   return `${Math.round(ms / 1000)}s`;
 }
 
+function fmtCost(usd: number): string {
+  return `$${usd.toFixed(2)}`;
+}
+
 /**
  * Map a harness-qualified, version-agnostic `model` to a "Harness / Model"
  * display string. The harness is the AI coding agent (Claude Code vs Codex);
@@ -173,10 +177,14 @@ function parseKey(key: string): string[] {
 }
 
 function medianMetricsFromValid(valid: AgentSample[]): Metrics {
+  const costs = valid
+    .map((s) => s.cost)
+    .filter((cost): cost is number => typeof cost === "number");
   return {
     tokens: median(valid.map((s) => s.tokens)),
     tools: median(valid.map((s) => s.tools)),
     dur: median(valid.map((s) => s.durMs ?? 0)),
+    ...(costs.length > 0 ? { cost: median(costs) } : {}),
   };
 }
 
@@ -396,6 +404,7 @@ const TtscWebsiteBenchmarkGraphData = {
   buildPromptModeGroups,
   cellTool,
   fmt,
+  fmtCost,
   fmtSecs,
   groupBy,
   median,

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphPricing.json
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphPricing.json
@@ -1,0 +1,9 @@
+{
+  "$comment": "API list price in USD per 1M tokens, keyed by the benchmark cell's modelVersion. Used to estimate run cost for harnesses that report token usage but no cost (Codex). Claude Code lanes report measured cost per run, so they never consult this table.",
+  "source": "https://developers.openai.com/api/docs/pricing",
+  "fetched": "2026-07-02",
+  "usdPerMillion": {
+    "gpt-5.5": { "input": 5.0, "cachedInput": 0.5, "output": 30.0 },
+    "gpt-5.4-mini": { "input": 0.75, "cachedInput": 0.075, "output": 4.5 }
+  }
+}

--- a/website/src/structures/ITtscWebsiteBenchmarkGraph.ts
+++ b/website/src/structures/ITtscWebsiteBenchmarkGraph.ts
@@ -7,6 +7,13 @@ export namespace ITtscWebsiteBenchmarkGraph {
     durMs?: number;
     /** Run cost in USD; absent on harnesses that do not report it (Codex). */
     cost?: number;
+    /**
+     * Cached-input tokens (a subset of `tokens`), when the harness reports
+     * them.
+     */
+    cached?: number;
+    /** Reasoning output tokens, counted separately from `tokens`. */
+    reasoning?: number;
     [key: string]: unknown;
   }
 
@@ -58,8 +65,13 @@ export namespace ITtscWebsiteBenchmarkGraph {
     tokens: number;
     tools: number;
     dur: number;
-    /** Median run cost in USD; undefined when no sample reported cost. */
+    /** Median run cost in USD; undefined when neither measured nor estimable. */
     cost?: number;
+    /**
+     * True when `cost` is estimated from tokens and API list prices, not
+     * measured.
+     */
+    costEstimated?: boolean;
   }
 
   export interface ModelGroup {

--- a/website/src/structures/ITtscWebsiteBenchmarkGraph.ts
+++ b/website/src/structures/ITtscWebsiteBenchmarkGraph.ts
@@ -5,6 +5,8 @@ export namespace ITtscWebsiteBenchmarkGraph {
     graph?: number;
     shell?: number;
     durMs?: number;
+    /** Run cost in USD; absent on harnesses that do not report it (Codex). */
+    cost?: number;
     [key: string]: unknown;
   }
 
@@ -56,6 +58,8 @@ export namespace ITtscWebsiteBenchmarkGraph {
     tokens: number;
     tools: number;
     dur: number;
+    /** Median run cost in USD; undefined when no sample reported cost. */
+    cost?: number;
   }
 
   export interface ModelGroup {


### PR DESCRIPTION
## Intent

The graph-benchmark hover tooltips showed baseline/tool tokens, calls, and tool time only. Make each cell answer the full question: tokens, calls, time, and cost, each next to its baseline value, with the change against baseline in parentheses on every non-baseline value.

## Scope

- **Tooltip rework** (`TtscWebsiteBenchmarkGraphChart.tsx`): metric table (tokens / calls / time / cost) with baseline and tool columns; signed deltas in parentheses, cyan for a reduction and rose for over baseline.
- **Cost data** (`TtscWebsiteBenchmarkGraphData.ts`, `ITtscWebsiteBenchmarkGraph.ts`): `Metrics.cost` as the median of per-run `cost` samples (USD) where the harness reports it (Claude Code lanes).
- **Codex cost estimation** (`TtscWebsiteBenchmarkGraphPricing.json`): Codex CLI reports no cost, so estimate it from an API list-price table (USD per 1M tokens, keyed by `modelVersion`, sourced from the OpenAI pricing page with source and fetch date recorded): non-cached tokens at the input rate, cached input at the cached rate, reasoning at the output rate. Estimated values render with a leading `~` and a tooltip footnote.

## Deferred

- The Codex samples store input+output summed, so the non-reasoning output slice is priced at the input rate (slight underestimate on agent runs, where input dominates). Exact pricing needs the parser to record the input/output split and a benchmark re-run.

## Test plan

- `tsc --noEmit` passes in `website`.
- Estimator replayed against the published `graph.json`: VS Code common prompt gives baseline ~$1.27 vs `@ttsc/graph` ~$0.15 on GPT-5.5, with codegraph landing below baseline despite more tokens due to its higher cached share, consistent with expected cache economics.
- Measured Claude Code costs are untouched; Codex-only lanes gain the `~` estimated cost row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3Cn3zmu1uUVkYJfwyPFeJ