### PR TITLE
fix(paths): terminate rootDir inference at volume roots and mirror tsc pattern precedence

### DIFF
--- a/packages/paths/README.md
+++ b/packages/paths/README.md
@@ -42,7 +42,7 @@ Configure those fields under `compilerOptions`:
 
 An import such as `import { value } from "@lib/value"` becomes a relative JavaScript import such as `import { value } from "./modules/value.js"`. Declaration output follows the same source rewrite.
 
-`outDir` must be set for the rewrite to run. Without it, `@ttsc/paths` cannot map a source path to its emitted location and makes no changes. `rootDir` is optional: when omitted it is derived from the common source directory.
+`outDir` must be set for the rewrite to run. Without it, `@ttsc/paths` cannot map a source path to its emitted location and makes no changes. `rootDir` is optional: when omitted it defaults to the tsconfig's directory, matching where TypeScript-Go anchors emitted output.
 
 ## Sponsors
 

--- a/packages/paths/driver/paths.go
+++ b/packages/paths/driver/paths.go
@@ -122,40 +122,49 @@ func (r *rewriter) apply(file *shimast.SourceFile) {
 // visit for every string-literal module specifier it finds. Covered nodes
 // include import/export declarations, require() calls, dynamic import()
 // expressions, import-equals declarations, and import-type nodes.
+//
+// The recursion runs through one closure created per walk, not one per node:
+// handing ForEachChild a fresh closure at every node would allocate once per
+// AST node across the whole program on every apply pass.
 func visitModuleSpecifiers(node *shimast.Node, visit func(*shimast.Node)) {
   if node == nil {
     return
   }
-  switch node.Kind {
-  case shimast.KindImportDeclaration:
-    visit(node.AsImportDeclaration().ModuleSpecifier)
-  case shimast.KindExportDeclaration:
-    visit(node.AsExportDeclaration().ModuleSpecifier)
-  case shimast.KindImportEqualsDeclaration:
-    ref := node.AsImportEqualsDeclaration().ModuleReference
-    if ref != nil && ref.Kind == shimast.KindExternalModuleReference {
-      visit(ref.AsExternalModuleReference().Expression)
+  var walk func(node *shimast.Node) bool
+  walk = func(node *shimast.Node) bool {
+    if node == nil {
+      return false
     }
-  case shimast.KindImportType:
-    arg := node.AsImportTypeNode().Argument
-    if arg != nil && arg.Kind == shimast.KindLiteralType {
-      visit(arg.AsLiteralTypeNode().Literal)
+    switch node.Kind {
+    case shimast.KindImportDeclaration:
+      visit(node.AsImportDeclaration().ModuleSpecifier)
+    case shimast.KindExportDeclaration:
+      visit(node.AsExportDeclaration().ModuleSpecifier)
+    case shimast.KindImportEqualsDeclaration:
+      ref := node.AsImportEqualsDeclaration().ModuleReference
+      if ref != nil && ref.Kind == shimast.KindExternalModuleReference {
+        visit(ref.AsExternalModuleReference().Expression)
+      }
+    case shimast.KindImportType:
+      arg := node.AsImportTypeNode().Argument
+      if arg != nil && arg.Kind == shimast.KindLiteralType {
+        visit(arg.AsLiteralTypeNode().Literal)
+      }
+    case shimast.KindModuleDeclaration:
+      decl := node.AsModuleDeclaration()
+      if decl != nil {
+        visit(decl.Name())
+      }
+    case shimast.KindCallExpression:
+      call := node.AsCallExpression()
+      if isModuleSpecifierCall(call) && call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+        visit(call.Arguments.Nodes[0])
+      }
     }
-  case shimast.KindModuleDeclaration:
-    decl := node.AsModuleDeclaration()
-    if decl != nil {
-      visit(decl.Name())
-    }
-  case shimast.KindCallExpression:
-    call := node.AsCallExpression()
-    if isModuleSpecifierCall(call) && call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
-      visit(call.Arguments.Nodes[0])
-    }
-  }
-  node.ForEachChild(func(child *shimast.Node) bool {
-    visitModuleSpecifiers(child, visit)
+    node.ForEachChild(walk)
     return false
-  })
+  }
+  walk(node)
 }
 
 // isModuleSpecifierCall reports whether call is a dynamic import() or a
@@ -198,9 +207,13 @@ func (r *rewriter) rewrite(fromSource string, specifier string) (string, bool) {
   return rel, true
 }
 
-// resolveSource finds the source file that a tsconfig paths specifier resolves to.
-// It iterates over sorted patterns and, for each match, tries all substitution
-// targets (with and without known extensions) including index files.
+// resolveSource finds the source file that a tsconfig paths specifier
+// resolves to. Patterns are pre-sorted into tsc's precedence order, and like
+// tsc's tryLoadModuleUsingPaths the resolution commits to the first (best)
+// matching pattern: only that pattern's substitution targets are tried, in
+// order, with extension and index fallbacks. When none of them names a
+// program source the specifier stays unrewritten — falling through to a
+// weaker pattern would rewrite at a module the type checker never resolved.
 func (r *rewriter) resolveSource(specifier string) (string, bool) {
   for _, pattern := range r.patterns {
     star, ok := matchPattern(pattern.pattern, specifier)
@@ -214,6 +227,7 @@ func (r *rewriter) resolveSource(specifier string) (string, bool) {
         return source, true
       }
     }
+    return "", false
   }
   return "", false
 }

--- a/packages/paths/driver/paths.go
+++ b/packages/paths/driver/paths.go
@@ -7,6 +7,7 @@ import (
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimcore "github.com/microsoft/typescript-go/shim/core"
+  shimtspath "github.com/microsoft/typescript-go/shim/tspath"
 
   "github.com/samchon/ttsc/packages/ttsc/driver"
 )
@@ -60,16 +61,20 @@ func newRewriter(prog *driver.Program) *rewriter {
     return out
   }
   options := prog.ParsedConfig.ParsedConfig.CompilerOptions
-  out.basePath = filepath.Clean(options.GetPathsBasePath(prog.Host.GetCurrentDirectory()))
+  cwd := prog.Host.GetCurrentDirectory()
+  out.basePath = filepath.Clean(options.GetPathsBasePath(cwd))
   out.jsxPreserve = options.Jsx == shimcore.JsxEmitPreserve
-  out.outDir = optionalPath(options.OutDir, prog.Host.GetCurrentDirectory())
-  out.rootDir = optionalPath(options.RootDir, prog.Host.GetCurrentDirectory())
+  out.outDir = optionalPath(options.OutDir, cwd)
+  out.rootDir = optionalPath(options.RootDir, cwd)
   files := prog.SourceFiles()
-  if out.rootDir == "" {
-    out.rootDir = commonSourceDir(files)
-  }
+  fileNames := make([]string, 0, len(files))
   for _, file := range files {
-    name := normalizePath(file.FileName())
+    fileNames = append(fileNames, normalizePath(file.FileName()))
+  }
+  if out.rootDir == "" {
+    out.rootDir = inferredRootDir(options.ConfigFilePath, fileNames, cwd, useCaseSensitiveFileNames(prog))
+  }
+  for _, name := range fileNames {
     out.sourceFiles[name] = name
   }
   if options.Paths != nil {
@@ -80,10 +85,18 @@ func newRewriter(prog *driver.Program) *rewriter {
       })
     }
   }
-  sort.SliceStable(out.patterns, func(i, j int) bool {
-    return patternRank(out.patterns[i].pattern) > patternRank(out.patterns[j].pattern)
-  })
+  orderPatterns(out.patterns)
   return out
+}
+
+// useCaseSensitiveFileNames reports the host filesystem's case sensitivity,
+// defaulting to case-sensitive when the program carries no filesystem (bare
+// rewriters built by unit tests).
+func useCaseSensitiveFileNames(prog *driver.Program) bool {
+  if prog == nil || prog.FS == nil {
+    return true
+  }
+  return prog.FS.UseCaseSensitiveFileNames()
 }
 
 // apply rewrites all module specifiers in file that match a tsconfig paths pattern.
@@ -261,23 +274,53 @@ func emittedJavaScriptExtension(source string, jsxPreserve bool) string {
 // matchPattern matches specifier against a tsconfig paths pattern (which may
 // contain at most one "*" wildcard). Returns the captured wildcard segment and
 // true on a match, or ("", false) otherwise. Exact patterns are matched with
-// simple equality.
+// simple equality. The length guard mirrors tsc's isPatternMatch: a specifier
+// shorter than the pattern's literal halves combined can still satisfy both
+// the prefix and suffix probes ("@lib/x" against "@lib/x*x"), and slicing the
+// star capture out of it would panic on inverted bounds.
 func matchPattern(pattern string, specifier string) (string, bool) {
   if !strings.Contains(pattern, "*") {
     return "", pattern == specifier
   }
   parts := strings.SplitN(pattern, "*", 2)
-  if !strings.HasPrefix(specifier, parts[0]) || !strings.HasSuffix(specifier, parts[1]) {
+  if strings.Contains(parts[1], "*") {
+    // More than one wildcard is not a pattern at all in tsc
+    // (TryParsePattern discards it), so it must never match here either.
+    return "", false
+  }
+  if len(specifier) < len(parts[0])+len(parts[1]) ||
+    !strings.HasPrefix(specifier, parts[0]) ||
+    !strings.HasSuffix(specifier, parts[1]) {
     return "", false
   }
   return specifier[len(parts[0]) : len(specifier)-len(parts[1])], true
 }
 
-// patternRank returns the length of a tsconfig paths pattern after removing its
-// wildcard character. Patterns with a higher rank (longer literal content) are
-// preferred when multiple patterns match the same specifier.
-func patternRank(pattern string) int {
-  return len(strings.ReplaceAll(pattern, "*", ""))
+// orderPatterns sorts patterns in place into tsc's matchPatternOrExact
+// precedence: exact patterns (no wildcard) first, then wildcard patterns by
+// decreasing literal-prefix length. Ranking by total literal length instead
+// would steer a specifier at a long-suffix pattern ("*-styles") even though
+// tsc resolves it through the longer prefix ("@app/*"), making the rewriter
+// disagree with the type checker's own module resolution. Ties keep the
+// tsconfig's declaration order, matching tsc's first-longest-prefix-wins scan.
+func orderPatterns(patterns []pathPattern) {
+  sort.SliceStable(patterns, func(i, j int) bool {
+    a, b := patterns[i].pattern, patterns[j].pattern
+    aExact, bExact := !strings.Contains(a, "*"), !strings.Contains(b, "*")
+    if aExact != bExact {
+      return aExact
+    }
+    return patternPrefixLength(a) > patternPrefixLength(b)
+  })
+}
+
+// patternPrefixLength returns the length of the literal text before the "*"
+// wildcard, or the whole pattern length for exact patterns.
+func patternPrefixLength(pattern string) int {
+  if i := strings.IndexByte(pattern, '*'); i >= 0 {
+    return i
+  }
+  return len(pattern)
 }
 
 // optionalPath resolves value as a path relative to cwd when it is non-empty
@@ -292,25 +335,55 @@ func optionalPath(value string, cwd string) string {
   return normalizePath(filepath.Join(cwd, value))
 }
 
-// commonSourceDir returns the longest common directory prefix of all file paths
-// in files. It is used as rootDir when the tsconfig does not specify one.
-// Returns "" when files is empty.
-func commonSourceDir(files []*shimast.SourceFile) string {
-  if len(files) == 0 {
+// inferredRootDir mirrors TypeScript-Go's GetCommonSourceDirectory fallback
+// chain for a project without an explicit rootDir: the tsconfig's directory
+// when the program was loaded from one, else the deepest directory shared by
+// every input file. The rewriter must anchor output paths exactly where tsgo
+// anchors its own emit, or the rewritten specifiers drift from the real
+// output layout.
+func inferredRootDir(configFilePath string, fileNames []string, currentDirectory string, useCaseSensitiveFileNames bool) string {
+  if configFilePath != "" {
+    return normalizePath(filepath.Dir(configFilePath))
+  }
+  return commonSourceDir(fileNames, currentDirectory, useCaseSensitiveFileNames)
+}
+
+// commonSourceDir mirrors TypeScript-Go's
+// computeCommonSourceDirectoryOfFilenames: the deepest directory shared by
+// every file, intersected per normalized path component under the host's case
+// sensitivity. Returns "" when the files share no root at all — on Windows, a
+// `files` list spanning two volumes — so the caller skips output mapping
+// instead of guessing. The previous byte-oriented walk hung there (#310):
+// once the shared prefix shrank to a volume root, filepath.Dir handed back
+// the backslash form ("C:\") while the termination guard compared it against
+// the slash-normalized cursor ("C:/"), re-normalizing the same directory
+// forever.
+func commonSourceDir(fileNames []string, currentDirectory string, useCaseSensitiveFileNames bool) string {
+  var common []string
+  for _, fileName := range fileNames {
+    components := shimtspath.GetNormalizedPathComponents(fileName, currentDirectory)
+    // The base file name is not part of the common directory path.
+    components = components[:len(components)-1]
+    if common == nil {
+      common = components
+      continue
+    }
+    shared := 0
+    limit := min(len(common), len(components))
+    for shared < limit &&
+      shimtspath.GetCanonicalFileName(common[shared], useCaseSensitiveFileNames) ==
+        shimtspath.GetCanonicalFileName(components[shared], useCaseSensitiveFileNames) {
+      shared++
+    }
+    if shared == 0 {
+      return ""
+    }
+    common = common[:shared]
+  }
+  if len(common) == 0 {
     return ""
   }
-  common := normalizePath(filepath.Dir(files[0].FileName()))
-  for _, file := range files[1:] {
-    dir := normalizePath(filepath.Dir(file.FileName()))
-    for common != "" && !strings.HasPrefix(dir+"/", common+"/") {
-      next := filepath.Dir(common)
-      if next == common {
-        return common
-      }
-      common = normalizePath(next)
-    }
-  }
-  return common
+  return shimtspath.GetPathFromPathComponents(common)
 }
 
 // normalizePath cleans and converts a file path to forward-slash form.

--- a/packages/paths/test/command_check_completes_on_cross_volume_files_list_test.go
+++ b/packages/paths/test/command_check_completes_on_cross_volume_files_list_test.go
@@ -1,0 +1,67 @@
+package paths_test
+
+import (
+  "context"
+  "os"
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+  "time"
+)
+
+// TestCommandCheckCompletesOnCrossVolumeFilesList verifies the sidecar never hangs on two-volume inputs.
+//
+// Locks the termination fix for #310. A tsconfig `files` list mixing inputs
+// from two Windows volumes sent `paths.go::commonSourceDir` into an infinite
+// spin at the volume root, so `check` ran until the 10-minute go test timeout
+// and left orphaned plugin processes behind. Windows dev boxes and
+// windows-latest runners split the repo (D:) and TEMP (C:), which is exactly
+// the layout this fixture recreates: the project seeds in the system temp
+// dir, the external file next to the repository. Same-volume machines cannot
+// express the shape, so they skip.
+//
+// 1. Seed a no-rootDir project in the temp dir and one `files` entry on the repo volume.
+// 2. Run `check` through the real sidecar under a hard 2-minute deadline.
+// 3. Assert it exits 0 with no output instead of being killed by the deadline.
+func TestCommandCheckCompletesOnCrossVolumeFilesList(t *testing.T) {
+  cacheDir := filepath.Join(packageRoot(t), "..", "..", "node_modules", ".cache")
+  if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+    t.Fatal(err)
+  }
+  externalDir, err := os.MkdirTemp(cacheDir, "paths-cross-volume-")
+  if err != nil {
+    t.Fatal(err)
+  }
+  t.Cleanup(func() { _ = os.RemoveAll(externalDir) })
+  externalFile := filepath.Join(externalDir, "external.ts")
+  writeFile(t, externalFile, `export const external = "ok";`+"\n")
+
+  root := seedProject(t, map[string]string{
+    "tsconfig.json":      `{"compilerOptions":{"target":"ES2022","module":"commonjs","strict":true,"paths":{"@lib/*":["./src/lib/*"]}},"files":["src/main.ts","src/lib/message.ts",` + mustJSON(t, externalFile) + `]}`,
+    "src/lib/message.ts": `export const message = "ok";` + "\n",
+    "src/main.ts":        `import { message } from "@lib/message";` + "\n" + `export const value = message;` + "\n",
+  })
+  if filepath.VolumeName(root) == filepath.VolumeName(externalFile) {
+    t.Skipf("requires two volumes, got %q for both fixtures", filepath.VolumeName(root))
+  }
+
+  // The deadline turns a regression into a 2-minute failure instead of a
+  // suite-wide 10-minute timeout. `go run` itself is prewarmed by the suite
+  // runner, so a healthy check completes in seconds.
+  ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+  defer cancel()
+  cmd := exec.CommandContext(ctx, "go", "run", "./plugin", "check", "--cwd="+root, "--tsconfig="+filepath.Join(root, "tsconfig.json"), "--plugins-json="+pathsManifest(t), "--quiet")
+  cmd.Dir = packageRoot(t)
+  out, err := cmd.Output()
+  if ctx.Err() != nil {
+    t.Fatalf("cross-volume check hung until the deadline: %v", ctx.Err())
+  }
+  stderr := ""
+  if exit, ok := err.(*exec.ExitError); ok {
+    stderr = string(exit.Stderr)
+  }
+  if err != nil || strings.TrimSpace(string(out)) != "" || strings.TrimSpace(stderr) != "" {
+    t.Fatalf("cross-volume check mismatch: err=%v stdout=%q stderr=%q", err, out, stderr)
+  }
+}

--- a/packages/paths/test/command_rewrites_all_module_specifier_forms_test.go
+++ b/packages/paths/test/command_rewrites_all_module_specifier_forms_test.go
@@ -79,11 +79,10 @@ void load;
     t.Fatalf("local no-rootDir check mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
   }
 
-  // A sibling temp dir keeps the file outside the tsconfig directory without
-  // crossing onto another volume: project loading hangs on a `files` list
-  // that spans volumes (Windows dev boxes and windows-latest runners keep
-  // the repo and the temp dir on different drives), and a fixture inside the
-  // package directory leaks into the tree when the test dies mid-run.
+  // A sibling temp dir keeps the file outside the tsconfig directory: a
+  // fixture inside the package directory leaks into the tree when the test
+  // dies mid-run. The cross-volume shape this fixture once accidentally hit
+  // (#310) is pinned by TestCommandCheckCompletesOnCrossVolumeFilesList.
   externalDir := t.TempDir()
   externalFile := filepath.Join(externalDir, "external.ts")
   writeFile(t, externalFile, `export const external = "ok";`+"\n")

--- a/packages/paths/test/linkname_helpers_test.go
+++ b/packages/paths/test/linkname_helpers_test.go
@@ -53,14 +53,20 @@ func pathsOutputPathForSource(r *pathsRewriter, source string) string
 //go:linkname pathsMatchPattern github.com/samchon/ttsc/packages/paths/driver.matchPattern
 func pathsMatchPattern(pattern string, specifier string) (string, bool)
 
-//go:linkname pathsPatternRank github.com/samchon/ttsc/packages/paths/driver.patternRank
-func pathsPatternRank(pattern string) int
+//go:linkname pathsOrderPatterns github.com/samchon/ttsc/packages/paths/driver.orderPatterns
+func pathsOrderPatterns(patterns []pathsPathPattern)
+
+//go:linkname pathsPatternPrefixLength github.com/samchon/ttsc/packages/paths/driver.patternPrefixLength
+func pathsPatternPrefixLength(pattern string) int
 
 //go:linkname pathsOptionalPath github.com/samchon/ttsc/packages/paths/driver.optionalPath
 func pathsOptionalPath(value string, cwd string) string
 
+//go:linkname pathsInferredRootDir github.com/samchon/ttsc/packages/paths/driver.inferredRootDir
+func pathsInferredRootDir(configFilePath string, fileNames []string, currentDirectory string, useCaseSensitiveFileNames bool) string
+
 //go:linkname pathsCommonSourceDir github.com/samchon/ttsc/packages/paths/driver.commonSourceDir
-func pathsCommonSourceDir(files []*shimast.SourceFile) string
+func pathsCommonSourceDir(fileNames []string, currentDirectory string, useCaseSensitiveFileNames bool) string
 
 //go:linkname pathsNormalizePath github.com/samchon/ttsc/packages/paths/driver.normalizePath
 func pathsNormalizePath(value string) string

--- a/packages/paths/test/rewriter_common_source_dir_terminates_at_volume_roots_test.go
+++ b/packages/paths/test/rewriter_common_source_dir_terminates_at_volume_roots_test.go
@@ -1,0 +1,48 @@
+package paths_test
+
+import (
+  "testing"
+  "time"
+)
+
+// TestRewriterCommonSourceDirTerminatesAtVolumeRoots verifies rootDir inference never spins at a root.
+//
+// Locks the termination contract of `paths.go::commonSourceDir` (#310). The
+// previous byte-oriented walk compared `filepath.Dir`'s native result against
+// a slash-normalized cursor, so once the shared prefix shrank to a Windows
+// volume root ("C:\" vs "C:/") the loop re-normalized the same directory
+// forever — a `files` list spanning two volumes hung the sidecar until the
+// 10-minute test timeout. The component intersection must instead mirror
+// TypeScript-Go's computeCommonSourceDirectoryOfFilenames: stop at the volume
+// root, and report "no common root" for cross-volume inputs.
+//
+// 1. Intersect files that share only a volume root, and files on two volumes.
+// 2. Assert the volume root (with separator) and "" respectively.
+// 3. Assert POSIX roots and case-only differences keep the same contract.
+func TestRewriterCommonSourceDirTerminatesAtVolumeRoots(t *testing.T) {
+  cases := []struct {
+    name     string
+    files    []string
+    expected string
+  }{
+    {"windows volume root", []string{"C:/alpha/main.ts", "C:/beta/util.ts"}, "C:/"},
+    {"windows cross volume", []string{"C:/alpha/main.ts", "D:/beta/util.ts"}, ""},
+    {"windows drive letter case", []string{"c:/alpha/main.ts", "C:/alpha/util.ts"}, "c:/alpha"},
+    {"posix root", []string{"/alpha/main.ts", "/beta/util.ts"}, "/"},
+    {"posix nested", []string{"/repo/src/main.ts", "/repo/src/lib/util.ts"}, "/repo/src"},
+    {"single file", []string{"/repo/src/main.ts"}, "/repo/src"},
+    {"empty", nil, ""},
+  }
+  for _, c := range cases {
+    done := make(chan string, 1)
+    go func() { done <- pathsCommonSourceDir(c.files, "/", false) }()
+    select {
+    case got := <-done:
+      if got != c.expected {
+        t.Fatalf("%s: commonSourceDir mismatch: got %q, expected %q", c.name, got, c.expected)
+      }
+    case <-time.After(30 * time.Second):
+      t.Fatalf("%s: commonSourceDir did not terminate", c.name)
+    }
+  }
+}

--- a/packages/paths/test/rewriter_helpers_cover_resolution_edges_test.go
+++ b/packages/paths/test/rewriter_helpers_cover_resolution_edges_test.go
@@ -125,8 +125,11 @@ func TestRewriterHelpersCoverResolutionEdges(t *testing.T) {
   if _, ok := pathsMatchPattern("@exact", "@other"); ok {
     t.Fatal("unexpected exact pattern match")
   }
-  if rank := pathsPatternRank("@lib/*/test"); rank != len("@lib//test") {
-    t.Fatalf("pattern rank mismatch: %d", rank)
+  if got := pathsPatternPrefixLength("@lib/*/test"); got != len("@lib/") {
+    t.Fatalf("wildcard pattern prefix length mismatch: %d", got)
+  }
+  if got := pathsPatternPrefixLength("@exact"); got != len("@exact") {
+    t.Fatalf("exact pattern prefix length mismatch: %d", got)
   }
 
   if got := pathsOptionalPath("", root); got != "" {
@@ -138,8 +141,14 @@ func TestRewriterHelpersCoverResolutionEdges(t *testing.T) {
   if got := pathsOptionalPath("src", root); got != src {
     t.Fatalf("relative optional path mismatch: %q", got)
   }
-  if got := pathsCommonSourceDir(nil); got != "" {
+  if got := pathsCommonSourceDir(nil, "/", true); got != "" {
     t.Fatalf("empty common source dir mismatch: %q", got)
+  }
+  if got := pathsInferredRootDir(root+"/tsconfig.json", nil, root, true); got != root {
+    t.Fatalf("config-anchored root dir mismatch: %q", got)
+  }
+  if got := pathsInferredRootDir("", []string{src + "/main.ts", src + "/lib/message.ts"}, root, true); got != src {
+    t.Fatalf("computed root dir mismatch: %q", got)
   }
   if got := pathsNormalizePath(""); got != "" {
     t.Fatalf("empty normalize mismatch: %q", got)

--- a/packages/paths/test/rewriter_match_pattern_rejects_overlapping_prefix_suffix_test.go
+++ b/packages/paths/test/rewriter_match_pattern_rejects_overlapping_prefix_suffix_test.go
@@ -1,0 +1,33 @@
+package paths_test
+
+import "testing"
+
+// TestRewriterMatchPatternRejectsOverlappingPrefixSuffix verifies wildcard matching never slices out of bounds.
+//
+// Locks the length guard in `paths.go::matchPattern`. A specifier can satisfy
+// both the HasPrefix and HasSuffix probes while being shorter than the
+// pattern's literal halves combined ("@lib/x" against "@lib/x*x"): the star
+// capture `specifier[len(prefix):len(specifier)-len(suffix)]` then panics with
+// inverted slice bounds and takes the whole sidecar down. tsc's isPatternMatch
+// requires candidate.length >= prefix.length + suffix.length, so these
+// specifiers must simply not match.
+//
+// 1. Match specifiers whose prefix and suffix probes overlap.
+// 2. Assert no match (and no panic) for each.
+// 3. Assert the boundary case with zero overlap still matches with an empty star.
+func TestRewriterMatchPatternRejectsOverlappingPrefixSuffix(t *testing.T) {
+  for _, specifier := range []string{"@lib/x", "@lib/"} {
+    if star, ok := pathsMatchPattern("@lib/x*x", specifier); ok {
+      t.Fatalf("overlapping specifier %q unexpectedly matched with star %q", specifier, star)
+    }
+  }
+  if star, ok := pathsMatchPattern("@lib/x*x", "@lib/xx"); !ok || star != "" {
+    t.Fatalf("zero-overlap boundary mismatch: star=%q ok=%v", star, ok)
+  }
+  if star, ok := pathsMatchPattern("@lib/x*x", "@lib/xyx"); !ok || star != "y" {
+    t.Fatalf("regular match mismatch: star=%q ok=%v", star, ok)
+  }
+  if star, ok := pathsMatchPattern("@lib/*sub/*", "@lib/sub/thing"); ok {
+    t.Fatalf("two-wildcard pattern unexpectedly matched with star %q", star)
+  }
+}

--- a/packages/paths/test/rewriter_order_patterns_keeps_declaration_order_on_prefix_ties_test.go
+++ b/packages/paths/test/rewriter_order_patterns_keeps_declaration_order_on_prefix_ties_test.go
@@ -1,0 +1,41 @@
+package paths_test
+
+import "testing"
+
+// TestRewriterOrderPatternsKeepsDeclarationOrderOnPrefixTies verifies tie-breaking matches tsc's scan.
+//
+// Locks the SliceStable choice in `paths.go::orderPatterns`. tsc's
+// FindBestPatternMatch takes a strictly-greater prefix to displace the
+// current best, so between wildcards with equal literal prefixes the first
+// declared pattern wins. An unstable sort (or a >= comparison) would resolve
+// such specifiers through whichever pattern happened to land first,
+// disagreeing with the type checker on order-sensitive configs.
+//
+// 1. Declare two wildcard patterns with identical literal prefixes, both matching one specifier.
+// 2. Resolve it under both declaration orders.
+// 3. Assert the first-declared pattern wins each time.
+func TestRewriterOrderPatternsKeepsDeclarationOrderOnPrefixTies(t *testing.T) {
+  root := "/repo"
+  sources := map[string]string{
+    root + "/src/tie/x/z.ts":    root + "/src/tie/x/z.ts",
+    root + "/src/tie/all/zx.ts": root + "/src/tie/all/zx.ts",
+  }
+  suffixed := pathsPathPattern{pattern: "@a/*x", targets: []string{"src/tie/x/*"}}
+  open := pathsPathPattern{pattern: "@a/*", targets: []string{"src/tie/all/*"}}
+
+  for _, c := range []struct {
+    name     string
+    patterns []pathsPathPattern
+    expected string
+  }{
+    {"suffixed declared first", []pathsPathPattern{suffixed, open}, root + "/src/tie/x/z.ts"},
+    {"open declared first", []pathsPathPattern{open, suffixed}, root + "/src/tie/all/zx.ts"},
+  } {
+    patterns := append([]pathsPathPattern(nil), c.patterns...)
+    pathsOrderPatterns(patterns)
+    rewriter := &pathsRewriter{basePath: root, patterns: patterns, sourceFiles: sources}
+    if source, ok := pathsResolveSource(rewriter, "@a/zx"); !ok || source != c.expected {
+      t.Fatalf("%s: tie resolution mismatch: source=%q ok=%v expected=%q", c.name, source, ok, c.expected)
+    }
+  }
+}

--- a/packages/paths/test/rewriter_resolve_source_commits_to_best_pattern_test.go
+++ b/packages/paths/test/rewriter_resolve_source_commits_to_best_pattern_test.go
@@ -1,0 +1,38 @@
+package paths_test
+
+import "testing"
+
+// TestRewriterResolveSourceCommitsToBestPattern verifies no fall-through past the matched pattern.
+//
+// Locks `paths.go::resolveSource` to tsc's tryLoadModuleUsingPaths contract:
+// resolution commits to the single best-precedence matching pattern and tries
+// only that pattern's substitution targets. When none of them names a program
+// source, tsc's paths lookup fails — it never consults a weaker pattern — so
+// falling through here would rewrite the import at a module the type checker
+// never resolved.
+//
+// 1. Configure a long-prefix pattern whose target is missing and a catch-all whose target exists.
+// 2. Resolve a specifier that matches both.
+// 3. Assert resolution fails instead of landing on the catch-all's source.
+func TestRewriterResolveSourceCommitsToBestPattern(t *testing.T) {
+  root := "/repo"
+  patterns := []pathsPathPattern{
+    {pattern: "*", targets: []string{"src/anywhere/*"}},
+    {pattern: "@app/*", targets: []string{"src/app/*"}},
+  }
+  pathsOrderPatterns(patterns)
+  rewriter := &pathsRewriter{
+    basePath: root,
+    patterns: patterns,
+    sourceFiles: map[string]string{
+      root + "/src/anywhere/@app/widget.ts": root + "/src/anywhere/@app/widget.ts",
+      root + "/src/anywhere/other.ts":       root + "/src/anywhere/other.ts",
+    },
+  }
+  if source, ok := pathsResolveSource(rewriter, "@app/widget"); ok {
+    t.Fatalf("resolution fell through past the best pattern to %q", source)
+  }
+  if source, ok := pathsResolveSource(rewriter, "other"); !ok || source != root+"/src/anywhere/other.ts" {
+    t.Fatalf("catch-all pattern mismatch: source=%q ok=%v", source, ok)
+  }
+}

--- a/packages/paths/test/rewriter_resolve_source_prefers_longest_prefix_pattern_test.go
+++ b/packages/paths/test/rewriter_resolve_source_prefers_longest_prefix_pattern_test.go
@@ -1,0 +1,46 @@
+package paths_test
+
+import "testing"
+
+// TestRewriterResolveSourcePrefersLongestPrefixPattern verifies tsc's paths precedence order.
+//
+// Locks the pattern ordering in `paths.go::newRewriter` to tsc's
+// matchPatternOrExact contract: an exact pattern always beats a wildcard, and
+// among matching wildcards the longest literal prefix wins. The previous rank
+// (total literal length, prefix plus suffix) steered "@app/foo-styles" at the
+// "*-styles" pattern even though tsc resolves it through "@app/*", so the
+// rewriter pointed imports at a different module than the type checker had
+// resolved.
+//
+// 1. Configure overlapping exact, long-prefix, and long-suffix patterns.
+// 2. Resolve specifiers that match more than one of them.
+// 3. Assert each resolution follows the exact-first, longest-prefix order.
+func TestRewriterResolveSourcePrefersLongestPrefixPattern(t *testing.T) {
+  root := "/repo"
+  patterns := []pathsPathPattern{
+    {pattern: "*-styles", targets: []string{"src/styles/*"}},
+    {pattern: "@app/*", targets: []string{"src/app/*"}},
+    {pattern: "@app/main", targets: []string{"src/entry.ts"}},
+  }
+  pathsOrderPatterns(patterns)
+  rewriter := &pathsRewriter{
+    basePath: root,
+    patterns: patterns,
+    sourceFiles: map[string]string{
+      root + "/src/styles/@app/foo.ts": root + "/src/styles/@app/foo.ts",
+      root + "/src/styles/bar.ts":      root + "/src/styles/bar.ts",
+      root + "/src/app/foo-styles.ts":  root + "/src/app/foo-styles.ts",
+      root + "/src/app/main.ts":        root + "/src/app/main.ts",
+      root + "/src/entry.ts":           root + "/src/entry.ts",
+    },
+  }
+  if source, ok := pathsResolveSource(rewriter, "@app/foo-styles"); !ok || source != root+"/src/app/foo-styles.ts" {
+    t.Fatalf("longest-prefix pattern mismatch: source=%q ok=%v", source, ok)
+  }
+  if source, ok := pathsResolveSource(rewriter, "@app/main"); !ok || source != root+"/src/entry.ts" {
+    t.Fatalf("exact-over-wildcard mismatch: source=%q ok=%v", source, ok)
+  }
+  if source, ok := pathsResolveSource(rewriter, "bar-styles"); !ok || source != root+"/src/styles/bar.ts" {
+    t.Fatalf("suffix pattern fallback mismatch: source=%q ok=%v", source, ok)
+  }
+}

--- a/website/src/content/docs/development/walkthroughs/paths.mdx
+++ b/website/src/content/docs/development/walkthroughs/paths.mdx
@@ -107,16 +107,20 @@ func newRewriter(prog *driver.Program) *rewriter {
     return out
   }
   options := prog.ParsedConfig.ParsedConfig.CompilerOptions
-  out.basePath = filepath.Clean(options.GetPathsBasePath(prog.Host.GetCurrentDirectory()))
+  cwd := prog.Host.GetCurrentDirectory()
+  out.basePath = filepath.Clean(options.GetPathsBasePath(cwd))
   out.jsxPreserve = options.Jsx == shimcore.JsxEmitPreserve
-  out.outDir = optionalPath(options.OutDir, prog.Host.GetCurrentDirectory())
-  out.rootDir = optionalPath(options.RootDir, prog.Host.GetCurrentDirectory())
+  out.outDir = optionalPath(options.OutDir, cwd)
+  out.rootDir = optionalPath(options.RootDir, cwd)
   files := prog.SourceFiles()
-  if out.rootDir == "" {
-    out.rootDir = commonSourceDir(files)
-  }
+  fileNames := make([]string, 0, len(files))
   for _, file := range files {
-    name := normalizePath(file.FileName())
+    fileNames = append(fileNames, normalizePath(file.FileName()))
+  }
+  if out.rootDir == "" {
+    out.rootDir = inferredRootDir(options.ConfigFilePath, fileNames, cwd, useCaseSensitiveFileNames(prog))
+  }
+  for _, name := range fileNames {
     out.sourceFiles[name] = name
   }
   if options.Paths != nil {
@@ -127,9 +131,7 @@ func newRewriter(prog *driver.Program) *rewriter {
       })
     }
   }
-  sort.SliceStable(out.patterns, func(i, j int) bool {
-    return patternRank(out.patterns[i].pattern) > patternRank(out.patterns[j].pattern)
-  })
+  orderPatterns(out.patterns)
   return out
 }
 ```
@@ -138,7 +140,7 @@ The constructor pulls four facts out of the Program and caches them as an in-mem
 
 **`basePath`**, the directory that paths in `compilerOptions.paths` resolve relative to. Tsgo's `GetPathsBasePath` handles the `baseUrl` vs no-`baseUrl` logic.
 
-**`outDir`** and **`rootDir`**, where emitted JavaScript lands and which subtree owns the source. If `rootDir` is empty, paths falls back to "longest common ancestor of every source file" via `commonSourceDir`. This matches `tsc`'s behavior when `rootDir` is unspecified.
+**`outDir`** and **`rootDir`**, where emitted JavaScript lands and which subtree owns the source. If `rootDir` is empty, `inferredRootDir` mirrors TypeScript-Go's own `GetCommonSourceDirectory` fallback chain: the tsconfig's directory when the program was loaded from one, else the deepest directory shared by every input file (`commonSourceDir`, a per-component intersection that reports "no common root" for inputs that span two Windows volumes instead of walking forever — the #310 hang). Anchoring exactly where tsgo anchors emit keeps the rewritten specifiers in agreement with the real output layout.
 
 **`sourceFiles`**, a string → string map of every user source file, keyed by its exact normalized path:
 
@@ -155,15 +157,7 @@ Extensionless targets such as `src/modules/greet` are resolved later by `lookupS
 
 ### Sidebar: Go map iteration order is randomised
 
-Notice the explicit sort on `out.patterns` at the end:
-
-```go
-sort.SliceStable(out.patterns, func(i, j int) bool {
-  return patternRank(out.patterns[i].pattern) > patternRank(out.patterns[j].pattern)
-})
-```
-
-Without sorting, the order of patterns would depend on Go's map iteration, which is intentionally randomised, different runs of the same plugin would resolve `@lib/foo/bar` against either `@lib/*` or `@lib/foo/*` non-deterministically. The sort makes the resolution stable and biases toward specificity (more literal characters in the pattern wins). `SliceStable` preserves the relative order of equal-rank patterns so the final tie-break is "whichever entry tsgo gave us first."
+Notice the explicit `orderPatterns(out.patterns)` at the end. Without sorting, the order of patterns would depend on Go's map iteration, which is intentionally randomised, different runs of the same plugin would resolve `@lib/foo/bar` against either `@lib/*` or `@lib/foo/*` non-deterministically. The sort makes the resolution stable and follows tsc's own precedence (next section). `SliceStable` preserves the relative order of equal-rank patterns so the final tie-break is "whichever entry tsgo gave us first."
 
 ### Sidebar: `filepath.ToSlash` and the Windows path discipline
 
@@ -172,12 +166,26 @@ Notice the helper `normalizePath` (`filepath.ToSlash(filepath.Clean(value))`) th
 ### 2. Sort patterns by specificity
 
 ```go
-func patternRank(pattern string) int {
-  return len(strings.ReplaceAll(pattern, "*", ""))
+func orderPatterns(patterns []pathPattern) {
+  sort.SliceStable(patterns, func(i, j int) bool {
+    a, b := patterns[i].pattern, patterns[j].pattern
+    aExact, bExact := !strings.Contains(a, "*"), !strings.Contains(b, "*")
+    if aExact != bExact {
+      return aExact
+    }
+    return patternPrefixLength(a) > patternPrefixLength(b)
+  })
+}
+
+func patternPrefixLength(pattern string) int {
+  if i := strings.IndexByte(pattern, '*'); i >= 0 {
+    return i
+  }
+  return len(pattern)
 }
 ```
 
-A pattern's rank is the count of non-wildcard characters: `@lib/foo/*` (rank 9) beats `@lib/*` (rank 5). Same idea as `tsc`'s own internal pattern matching.
+The order is tsc's `matchPatternOrExact` contract: an exact pattern (no `*`) always wins, and among wildcards the longest literal _prefix_ wins — `@lib/foo/*` (prefix 9) beats `@lib/*` (prefix 5). Ranking by total literal length instead would let a long-suffix pattern like `*-styles` capture a specifier that tsc's module resolution routes through `@app/*`, and the rewrite would then disagree with the type checker.
 
 ### 3. Walk every node that could hold a module specifier
 
@@ -349,7 +357,12 @@ func matchPattern(pattern string, specifier string) (string, bool) {
     return "", pattern == specifier
   }
   parts := strings.SplitN(pattern, "*", 2)
-  if !strings.HasPrefix(specifier, parts[0]) || !strings.HasSuffix(specifier, parts[1]) {
+  if strings.Contains(parts[1], "*") {
+    return "", false
+  }
+  if len(specifier) < len(parts[0])+len(parts[1]) ||
+    !strings.HasPrefix(specifier, parts[0]) ||
+    !strings.HasSuffix(specifier, parts[1]) {
     return "", false
   }
   return specifier[len(parts[0]) : len(specifier)-len(parts[1])], true
@@ -361,6 +374,8 @@ For pattern `@lib/*` and specifier `@lib/greet`:
 - `parts = ["@lib/", ""]`
 - `specifier` has the prefix `@lib/` and the suffix `""`: match.
 - Return `specifier[5 : 10-0] = "greet"` (length 10 minus suffix length 0).
+
+The two guards mirror tsc: a pattern with more than one `*` is not a pattern at all (`TryParsePattern` discards it), and a specifier shorter than the literal halves combined must not match — it can still satisfy both the prefix and suffix probes (`"@lib/x"` against `"@lib/x*x"`), and slicing the star capture out of it would panic on inverted bounds.
 
 The captured `*` substitutes into each target: `./src/modules/*` → `./src/modules/greet`. The candidate is then joined against `basePath` (the tsconfig directory) and looked up in `r.sourceFiles`.
 
@@ -457,7 +472,7 @@ The pattern generalizes to any plugin that needs to query _project-level_ inform
 **Copy:**
 
 - The pattern of caching tsconfig facts on a constructor-built struct (`rewriter`). Avoids re-querying for every node.
-- The pattern-rank sort. Whenever you read a user-supplied map keyed on globs or patterns, copy this idiom: pull entries into a slice, then `sort.SliceStable` by specificity rank. This makes resolution deterministic across runs.
+- The pattern-precedence sort. Whenever you read a user-supplied map keyed on globs or patterns, copy this idiom: pull entries into a slice, then `sort.SliceStable` into the upstream tool's own precedence order. This makes resolution deterministic across runs and keeps it in agreement with the resolver you are mirroring.
 - The visitor that enumerates every module-specifier kind. If your plugin cares about module specifiers, this is the exhaustive list as of TypeScript 5.x.
 - The synthesize-flag invariant. Read it once; tattoo it.
 

--- a/website/src/content/docs/development/walkthroughs/paths.mdx
+++ b/website/src/content/docs/development/walkthroughs/paths.mdx
@@ -218,36 +218,41 @@ func visitModuleSpecifiers(node *shimast.Node, visit func(*shimast.Node)) {
   if node == nil {
     return
   }
-  switch node.Kind {
-  case shimast.KindImportDeclaration:
-    visit(node.AsImportDeclaration().ModuleSpecifier)
-  case shimast.KindExportDeclaration:
-    visit(node.AsExportDeclaration().ModuleSpecifier)
-  case shimast.KindImportEqualsDeclaration:
-    ref := node.AsImportEqualsDeclaration().ModuleReference
-    if ref != nil && ref.Kind == shimast.KindExternalModuleReference {
-      visit(ref.AsExternalModuleReference().Expression)
+  var walk func(node *shimast.Node) bool
+  walk = func(node *shimast.Node) bool {
+    if node == nil {
+      return false
     }
-  case shimast.KindImportType:
-    arg := node.AsImportTypeNode().Argument
-    if arg != nil && arg.Kind == shimast.KindLiteralType {
-      visit(arg.AsLiteralTypeNode().Literal)
+    switch node.Kind {
+    case shimast.KindImportDeclaration:
+      visit(node.AsImportDeclaration().ModuleSpecifier)
+    case shimast.KindExportDeclaration:
+      visit(node.AsExportDeclaration().ModuleSpecifier)
+    case shimast.KindImportEqualsDeclaration:
+      ref := node.AsImportEqualsDeclaration().ModuleReference
+      if ref != nil && ref.Kind == shimast.KindExternalModuleReference {
+        visit(ref.AsExternalModuleReference().Expression)
+      }
+    case shimast.KindImportType:
+      arg := node.AsImportTypeNode().Argument
+      if arg != nil && arg.Kind == shimast.KindLiteralType {
+        visit(arg.AsLiteralTypeNode().Literal)
+      }
+    case shimast.KindModuleDeclaration:
+      decl := node.AsModuleDeclaration()
+      if decl != nil {
+        visit(decl.Name())
+      }
+    case shimast.KindCallExpression:
+      call := node.AsCallExpression()
+      if isModuleSpecifierCall(call) && call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+        visit(call.Arguments.Nodes[0])
+      }
     }
-  case shimast.KindModuleDeclaration:
-    decl := node.AsModuleDeclaration()
-    if decl != nil {
-      visit(decl.Name())
-    }
-  case shimast.KindCallExpression:
-    call := node.AsCallExpression()
-    if isModuleSpecifierCall(call) && call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
-      visit(call.Arguments.Nodes[0])
-    }
-  }
-  node.ForEachChild(func(child *shimast.Node) bool {
-    visitModuleSpecifiers(child, visit)
+    node.ForEachChild(walk)
     return false
-  })
+  }
+  walk(node)
 }
 
 func isModuleSpecifierCall(call *shimast.CallExpression) bool {
@@ -283,17 +288,17 @@ After the switch, `node.ForEachChild` recurses into every child. This is what ma
 The closure-based visitor is the simplest way to walk an AST in Go without an explicit interface. The shape:
 
 ```go
-func walk(node *X, visit func(*X)) {
-  if node == nil { return }
+var walk func(node *X) bool
+walk = func(node *X) bool {
+  if node == nil { return false }
   visit(node)
-  node.ForEachChild(func(child *X) bool {
-    walk(child, visit)
-    return false
-  })
+  node.ForEachChild(walk)
+  return false
 }
+walk(root)
 ```
 
-returning `false` keeps the iteration alive. Returning `true` would short-circuit, useful for "find the first node matching predicate," not useful when you want to visit every node.
+returning `false` keeps the iteration alive. Returning `true` would short-circuit, useful for "find the first node matching predicate," not useful when you want to visit every node. Declare the recursion closure once per walk and hand the same value to every `ForEachChild` call — building a fresh closure at each node allocates once per AST node, which a program-wide pass pays millions of times.
 
 ### 4. Resolving a specifier
 
@@ -348,6 +353,7 @@ func (r *rewriter) resolveSource(specifier string) (string, bool) {
         return source, true
       }
     }
+    return "", false
   }
   return "", false
 }
@@ -376,6 +382,8 @@ For pattern `@lib/*` and specifier `@lib/greet`:
 - Return `specifier[5 : 10-0] = "greet"` (length 10 minus suffix length 0).
 
 The two guards mirror tsc: a pattern with more than one `*` is not a pattern at all (`TryParsePattern` discards it), and a specifier shorter than the literal halves combined must not match — it can still satisfy both the prefix and suffix probes (`"@lib/x"` against `"@lib/x*x"`), and slicing the star capture out of it would panic on inverted bounds.
+
+Resolution also _commits_ to the first (best-precedence) matching pattern, exactly like tsc's `tryLoadModuleUsingPaths`: only that pattern's targets are tried, and when none of them names a program source the specifier stays unrewritten. Falling through to a weaker pattern would rewrite the import at a module the type checker never resolved.
 
 The captured `*` substitutes into each target: `./src/modules/*` → `./src/modules/greet`. The candidate is then joined against `basePath` (the tsconfig directory) and looked up in `r.sourceFiles`.
 

--- a/website/src/content/docs/plugins/paths.mdx
+++ b/website/src/content/docs/plugins/paths.mdx
@@ -46,7 +46,8 @@ import { value } from "./modules/value.js";
 
 ## What it does and doesn't do
 
-- Reads the same `compilerOptions.paths`, `rootDir`, and `outDir` that `ttsc` already uses.
+- Reads the same `compilerOptions.paths`, `rootDir`, and `outDir` that `ttsc` already uses. When `rootDir` is omitted, output paths anchor at the tsconfig's directory — exactly where TypeScript-Go anchors its own emit.
+- When several patterns match one specifier, an exact pattern wins, then the longest literal prefix: the same order tsc uses to resolve the import.
 - Rewrites JavaScript-family emit (`.js`, `.mjs`, `.cjs`, `.jsx`) and `.d.ts` declarations.
 - Resolves extensionless path targets against `.ts`, `.tsx`, `.mts`, `.cts`, then `.js`, `.jsx`, `.mjs`, and `.cjs` source files.
 - No separate plugin config.


### PR DESCRIPTION
## Intent

Resolve #310 at the root, and sweep the same driver for every adjacent defect the audit surfaced, per request, all in one PR.

## Root cause of #310

The hang was never in project loading. `paths.go::commonSourceDir` (the no-`rootDir` fallback) walked the shared prefix upward byte-by-byte and compared `filepath.Dir`'s **native** result against a **slash-normalized** cursor to decide termination. At a Windows volume root, `filepath.Dir("C:/")` returns `"C:\"`, which never equals `"C:/"`, so the loop re-normalized the same directory forever — a pure CPU spin, which is also why orphaned `plugin.exe` processes kept burning CPU after their parents died. A `files` list spanning two volumes always shrinks the shared prefix to a root, so the repro hung deterministically; same-volume lists that share only the drive root (e.g. `C:\a\x.ts` + `C:\b\y.ts`) hung the same way.

Verified on this machine (repo on D:, TEMP on C:): the issue repro hung for the full 45s kill deadline before the fix and exits 0 in ~1s after; the same fixture with all files on one volume was unaffected (~1s before and after).

## Scope

All in `packages/paths` (the audit found no other non-terminating walk in the tree; the banner/strip/lint upward walks compare in native form and terminate):

1. **Termination + tsgo parity for rootDir inference.** `commonSourceDir` is now the same per-component intersection as TypeScript-Go's `computeCommonSourceDirectoryOfFilenames` (canonical comparison under host case sensitivity, `""` when inputs share no root), and the fallback follows tsgo's full `GetCommonSourceDirectory` chain — tsconfig directory first, computed common directory only for config-less programs. Output mapping now anchors exactly where tsgo anchors emit. Note: tsc itself exits 0 on the issue's exact repro config (no `outDir`), and so does the fixed sidecar; the TS5009/TS6059-class errors remain tsgo's to raise, and they now surface instead of the hang eating them.
2. **Wildcard-match panic guard.** `"@lib/x"` against pattern `"@lib/x*x"` satisfied both prefix and suffix probes and panicked on inverted slice bounds. tsc's `isPatternMatch` length guard applies now, and two-wildcard patterns are rejected the way tsc's `TryParsePattern` discards them.
3. **tsc pattern precedence.** Ranking by total literal length steered `"@app/foo-styles"` at `"*-styles"` while the type checker resolved it through `"@app/*"`. `orderPatterns` now follows `matchPatternOrExact`: exact first, then longest literal prefix, stable on ties.

Docs updated in the same change: `@ttsc/paths` README, `plugins/paths.mdx`, and the `walkthroughs/paths.mdx` code listings/prose that quoted the old implementation.

## Out of reach (documented, not fixed here)

- **Upstream tsgo overlap panic.** typescript-go's own `core.Pattern.MatchedText` has the identical inverted-bounds panic (`internal/core/pattern.go:38`; `Matches` checks `len(candidate) >= StarIndex` instead of prefix+suffix). An overlapping paths pattern plus a short specifier crashes module resolution inside the checker pool — reproduced through the sidecar with a panic stack straight into `module.(*resolutionState)`. It fires in tsgo goroutines ttsc cannot recover from and needs an upstream fix; the driver-level guard in this PR covers the positions tsgo's resolver never touches (e.g. ambient `declare module` names).
- **Orphaned sidecars when a parent is killed** (the issue's zombie comment) is a property of `go run`/process trees, not of this bug; with the spin gone, the observed leak vector is closed.

## Test plan

- `rewriter_common_source_dir_terminates_at_volume_roots_test.go` — pure intersection contract: volume-root stop, cross-volume `""`, POSIX roots, case folding, plus a 30s watchdog so a regression fails instead of spinning.
- `command_check_completes_on_cross_volume_files_list_test.go` — the real #310 repro through the sidecar under a 2-minute deadline; skips on single-volume machines, runs for real on windows-latest (repo D:, TEMP C:) and on this dev box.
- `rewriter_match_pattern_rejects_overlapping_prefix_suffix_test.go` — overlap and two-wildcard guards (the overlap case panicked before the fix).
- `rewriter_resolve_source_prefers_longest_prefix_pattern_test.go` — exact-over-wildcard and longest-prefix-over-longest-suffix resolution.
- Updated `rewriter_helpers_cover_resolution_edges_test.go` / `linkname_helpers_test.go` for the new helper surface (existing `patternRank` pin replaced by the tsc-precedence helpers — deliberate, called out here).
- Full `packages/paths` suite green locally on Windows (21s), including all pre-existing command tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AivFfPoUxoU26Dko5Jbm21
