### PR TITLE
fix(ttsc): confine forced emit to outDir so dependency sources stay clean

### DIFF
--- a/packages/ttsc/driver/emit_containment.go
+++ b/packages/ttsc/driver/emit_containment.go
@@ -1,0 +1,52 @@
+// Package driver: forced-emit output containment.
+//
+// tsc guards a program whose sources spill outside `rootDir` with TS6059 and,
+// under `--noEmitOnError`, refuses to emit. ttsc's forced-emit lanes
+// (`--emit`, a plugin host's runBuild) intentionally proceed past that guard,
+// and tsgo then computes the output path of an out-of-rootDir source relative
+// to the common source directory — which resolves to a `.js` right next to the
+// dependency's own source (issue #293). The classic trigger is package
+// self-reference: a project nested inside a dependency's directory resolves
+// the dependency's name without a node_modules hop, so its sources are not
+// classified as external-library files and stay in the emit set.
+//
+// The guard here confines every ttsc-owned emit lane to the project's
+// configured `outDir`: an output that would escape it is silently skipped, the
+// same way tsc treats node_modules externals (no emit, no error).
+package driver
+
+import (
+  "strings"
+
+  "github.com/microsoft/typescript-go/shim/tspath"
+)
+
+// outputEscapesOutDir reports whether fileName — an emit output path tsgo
+// computed for this program — would land outside the project's configured
+// `outDir` (and `declarationDir`, when set). Projects without `outDir` emit
+// next to their sources by design, so the guard only applies when `outDir`
+// gives the project an output boundary. `.tsbuildinfo` is exempt because its
+// default location is next to the tsconfig, legitimately outside `outDir`.
+func (p *Program) outputEscapesOutDir(fileName string) bool {
+  if p == nil || p.TSProgram == nil {
+    return false
+  }
+  options := p.TSProgram.Options()
+  if options.OutDir == "" {
+    return false
+  }
+  if strings.HasSuffix(fileName, ".tsbuildinfo") {
+    return false
+  }
+  cmp := tspath.ComparePathsOptions{
+    UseCaseSensitiveFileNames: p.TSProgram.UseCaseSensitiveFileNames(),
+    CurrentDirectory:          p.TSProgram.GetCurrentDirectory(),
+  }
+  if tspath.ContainsPath(options.OutDir, fileName, cmp) {
+    return false
+  }
+  if options.DeclarationDir != "" && tspath.ContainsPath(options.DeclarationDir, fileName, cmp) {
+    return false
+  }
+  return true
+}

--- a/packages/ttsc/driver/emit_plugin.go
+++ b/packages/ttsc/driver/emit_plugin.go
@@ -143,6 +143,10 @@ func (p *Program) EmitWithPluginTransformers(transforms []PluginTransform, write
   host := &pluginEmitHost{program: p.TSProgram, emitResolver: p.Checker.GetEmitResolver()}
   options := p.TSProgram.Options()
   for _, sf := range shimcompiler.GetSourceFilesToEmit(host, nil, false) {
+    paths := shimcompiler.GetOutputPathsFor(sf, options, host, false)
+    if p.outputEscapesOutDir(paths.JsFilePath()) {
+      continue
+    }
     ec := shimprinter.NewEmitContext()
     out := sf
     for _, transform := range transforms {
@@ -158,7 +162,6 @@ func (p *Program) EmitWithPluginTransformers(transforms []PluginTransform, write
     for _, tr := range shimcompiler.GetScriptTransformers(ec, host, out) {
       out = tr.TransformSourceFile(out)
     }
-    paths := shimcompiler.GetOutputPathsFor(sf, options, host, false)
     // Print through the source-map-aware helper so a `sourceMap` /
     // `inlineSourceMap` build still gets its `.js.map` and sourceMappingURL
     // trailer: the hand-assembled emit pipeline does not run tsgo's emitter, so

--- a/packages/ttsc/driver/rewrite.go
+++ b/packages/ttsc/driver/rewrite.go
@@ -110,6 +110,14 @@ func (p *Program) EmitAllRaw(writeFile shimcompiler.WriteFile) (*shimcompiler.Em
   wf := func(fileName, text string, data *shimcompiler.WriteFileData) error {
     wfMu.Lock()
     defer wfMu.Unlock()
+    if p.outputEscapesOutDir(fileName) {
+      // Marking the write skipped keeps the file out of EmitResult.EmittedFiles,
+      // so callers reporting emitted counts don't include phantom outputs.
+      if data != nil {
+        data.SkippedDtsWrite = true
+      }
+      return nil
+    }
     if writeFile != nil {
       return writeFile(fileName, text, data)
     }
@@ -150,6 +158,14 @@ func (p *Program) emit(rs *RewriteSet, target *ast.SourceFile, writeFile shimcom
   wf := func(fileName, text string, data *shimcompiler.WriteFileData) error {
     wfMu.Lock()
     defer wfMu.Unlock()
+    if p.outputEscapesOutDir(fileName) {
+      // See EmitAllRaw: mark the write skipped so EmitResult.EmittedFiles
+      // reflects only files actually written.
+      if data != nil {
+        data.SkippedDtsWrite = true
+      }
+      return nil
+    }
     // A patched file is idempotent: once the sentinel exists, the emitted text
     // is passed through unchanged. This matters for watch/rebuild loops and
     // tests that re-run emit over the same output directory.

--- a/packages/ttsc/test/driver/emit_all_skips_outputs_outside_outdir_test.go
+++ b/packages/ttsc/test/driver/emit_all_skips_outputs_outside_outdir_test.go
@@ -1,0 +1,50 @@
+package driver_test
+
+import (
+  "path/filepath"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestEmitAllSkipsOutputsOutsideOutDir verifies the rewrite-pipeline emit lane
+// confines its output to the project's outDir.
+//
+// Locks the outputEscapesOutDir guard in the emit() WriteFile funnel shared by
+// EmitAll and EmitFile (issue #293). This funnel is a separate code path from
+// EmitAllRaw's — a regression could drop the guard from one funnel while the
+// other keeps it — so the rewrite lane pins its own containment against the
+// same self-referenced dependency layout.
+//
+//  1. Materialize the self-referenced dependency layout with the project
+//     nested inside the package directory.
+//  2. Load the project with ForceEmit and emit through EmitAll with an empty
+//     rewrite set.
+//  3. Assert the project's main.js is written under outDir and no write
+//     targets the dependency's source tree.
+func TestEmitAllSkipsOutputsOutsideOutDir(t *testing.T) {
+  root := t.TempDir()
+  project := writeSelfReferencedDependencyProject(t, root)
+  prog, diags, err := driver.LoadProgram(project, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+  written := []string{}
+  _, emitDiags, err := prog.EmitAll(nil, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    written = append(written, filepath.ToSlash(fileName))
+    return nil
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+  assertOutputsConfinedToOutDir(t, project, written)
+}

--- a/packages/ttsc/test/driver/emit_plugin_transformers_skip_outputs_outside_outdir_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_transformers_skip_outputs_outside_outdir_test.go
@@ -1,0 +1,51 @@
+package driver_test
+
+import (
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestEmitPluginTransformersSkipOutputsOutsideOutDir verifies the
+// AST-integration emit lane confines its output to the project's outDir.
+//
+// Locks the outputEscapesOutDir guard in EmitWithPluginTransformers (issue
+// #293). This lane assembles tsgo's emit pipeline by hand, so it does not
+// inherit any skip the raw Program.Emit path performs — the containment check
+// must run on the per-file output paths it resolves itself. Without it, a
+// plugin host's forced emit (e.g. typia's runBuild --emit) writes the
+// self-referenced dependency's compiled `.js` into that dependency's source
+// tree on every build.
+//
+// 1. Materialize the same self-referenced dependency layout as the EmitAllRaw
+//    regression, with the project nested inside the package directory.
+// 2. Load the project with ForceEmit and emit through
+//    EmitWithPluginTransformers (no transforms).
+// 3. Assert the project's main.js is written under outDir and no write
+//    targets the dependency's source tree.
+func TestEmitPluginTransformersSkipOutputsOutsideOutDir(t *testing.T) {
+  root := t.TempDir()
+  project := writeSelfReferencedDependencyProject(t, root)
+  prog, diags, err := driver.LoadProgram(project, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+  written := []string{}
+  emitDiags, err := prog.EmitWithPluginTransformers(nil, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    written = append(written, fileName)
+    return nil
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+  assertOutputsConfinedToOutDir(t, project, written)
+}

--- a/packages/ttsc/test/driver/emit_raw_declarationdir_outputs_survive_outdir_containment_test.go
+++ b/packages/ttsc/test/driver/emit_raw_declarationdir_outputs_survive_outdir_containment_test.go
@@ -1,0 +1,86 @@
+package driver_test
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestEmitRawDeclarationDirOutputsSurviveOutDirContainment verifies the outDir
+// containment guard exempts declarationDir outputs.
+//
+// Negative twin for the outputEscapesOutDir predicate (issue #293): a
+// `declarationDir` sits outside `outDir` by design, so its `.d.ts` outputs
+// escape `outDir` legitimately. A guard that only whitelisted `outDir` would
+// silently swallow every declaration of a `declaration + declarationDir`
+// project; this pins the DeclarationDir branch while the self-referenced
+// dependency's own outputs (both `.js` and `.d.ts`) still get skipped.
+//
+//  1. Reuse the self-referenced dependency layout with `declaration` and
+//     `declarationDir: "types"` added to the nested project.
+//  2. Load with ForceEmit and run EmitAllRaw.
+//  3. Assert `dist/main.js` and `types/main.d.ts` are written.
+//  4. Assert every write lands under `dist/` or `types/` — nothing beside the
+//     dependency's sources.
+func TestEmitRawDeclarationDirOutputsSurviveOutDirContainment(t *testing.T) {
+  root := t.TempDir()
+  writeSelfReferencedDependencyProject(t, root)
+  writeProjectFile(t, root, "proj/tsconfig.json", `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationDir": "types",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`)
+  project := filepath.Join(root, "proj")
+  prog, diags, err := driver.LoadProgram(project, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+  written := []string{}
+  _, emitDiags, err := prog.EmitAllRaw(func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    written = append(written, filepath.ToSlash(fileName))
+    return nil
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+  outDir := filepath.ToSlash(filepath.Join(project, "dist")) + "/"
+  declarationDir := filepath.ToSlash(filepath.Join(project, "types")) + "/"
+  sawJs, sawDts := false, false
+  for _, file := range written {
+    if !strings.HasPrefix(file, outDir) && !strings.HasPrefix(file, declarationDir) {
+      t.Fatalf("emit escaped outDir and declarationDir: %s (all writes: %v)", file, written)
+    }
+    if strings.HasSuffix(file, "/main.js") {
+      sawJs = true
+    }
+    if strings.HasSuffix(file, "/main.d.ts") {
+      sawDts = true
+    }
+  }
+  if !sawJs {
+    t.Fatalf("project's own main.js was not emitted under outDir: %v", written)
+  }
+  if !sawDts {
+    t.Fatalf("declarationDir output main.d.ts was swallowed by the containment guard: %v", written)
+  }
+}

--- a/packages/ttsc/test/driver/emit_raw_skips_outputs_outside_outdir_for_self_referenced_dependency_test.go
+++ b/packages/ttsc/test/driver/emit_raw_skips_outputs_outside_outdir_for_self_referenced_dependency_test.go
@@ -1,0 +1,107 @@
+package driver_test
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestEmitRawSkipsOutputsOutsideOutDirForSelfReferencedDependency verifies
+// forced emit confines EmitAllRaw output to the project's outDir.
+//
+// Locks the outputEscapesOutDir guard in the EmitAllRaw WriteFile funnel
+// (issue #293). A project nested inside a dependency's directory resolves the
+// dependency's name by package self-reference — no node_modules hop — so the
+// dependency's `.ts` sources are not classified as external-library files and
+// stay in the forced-emit set. tsgo then computes their output paths relative
+// to the common source directory, which lands the compiled `.js` next to the
+// dependency's own sources, outside the project entirely. The guard must skip
+// those writes while the project's own file still emits under outDir.
+//
+// 1. Materialize a dependency package whose `exports` points at raw `.ts`,
+//    with the consuming project nested inside the package directory.
+// 2. Load the project with ForceEmit and run EmitAllRaw.
+// 3. Assert the project's main.js is written under outDir and no write
+//    targets the dependency's source tree.
+func TestEmitRawSkipsOutputsOutsideOutDirForSelfReferencedDependency(t *testing.T) {
+  root := t.TempDir()
+  project := writeSelfReferencedDependencyProject(t, root)
+  prog, diags, err := driver.LoadProgram(project, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+  written := []string{}
+  _, emitDiags, err := prog.EmitAllRaw(func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    written = append(written, filepath.ToSlash(fileName))
+    return nil
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+  assertOutputsConfinedToOutDir(t, project, written)
+}
+
+// writeSelfReferencedDependencyProject materializes the #293 layout: a
+// dependency package exporting raw TypeScript, with the consuming project
+// nested inside the package directory so the import resolves by package
+// self-reference. Returns the project directory.
+func writeSelfReferencedDependencyProject(t *testing.T, root string) string {
+  t.Helper()
+  writeProjectFile(t, root, "package.json", `{
+  "name": "dep",
+  "version": "1.0.0",
+  "exports": { ".": "./src/index.ts" }
+}
+`)
+  writeProjectFile(t, root, "src/index.ts", `export * from "./extra";
+export const dep: number = 1;
+`)
+  writeProjectFile(t, root, "src/extra.ts", `export const extra: string = "x";
+`)
+  writeProjectFile(t, root, "proj/tsconfig.json", `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`)
+  writeProjectFile(t, root, "proj/src/main.ts", `import { dep } from "dep";
+export const x: number = dep;
+`)
+  return filepath.Join(root, "proj")
+}
+
+// assertOutputsConfinedToOutDir asserts the project's own main.js was emitted
+// under <project>/dist and that no recorded write escaped that directory.
+func assertOutputsConfinedToOutDir(t *testing.T, project string, written []string) {
+  t.Helper()
+  outDir := filepath.ToSlash(filepath.Join(project, "dist")) + "/"
+  sawMain := false
+  for _, file := range written {
+    if !strings.HasPrefix(file, outDir) {
+      t.Fatalf("emit escaped outDir: %s (all writes: %v)", file, written)
+    }
+    if strings.HasSuffix(file, "/main.js") {
+      sawMain = true
+    }
+  }
+  if !sawMain {
+    t.Fatalf("project's own main.js was not emitted under outDir: %v", written)
+  }
+}

--- a/tests/test-ttsc/src/features/utility-plugins/test_ttsc_utility_plugins_forced_emit_confines_output_to_outdir.ts
+++ b/tests/test-ttsc/src/features/utility-plugins/test_ttsc_utility_plugins_forced_emit_confines_output_to_outdir.ts
@@ -1,0 +1,89 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TestUtilityPlugins } from "../../internal/TestUtilityPlugins";
+import { SHARED_PLUGIN_CACHE_DIR } from "../../internal/plugin-cache";
+
+/**
+ * Verifies ttsc utility plugins: forced emit confines output to outDir.
+ *
+ * Locks the outputEscapesOutDir guard in the native utility host's emit lane
+ * (issue #293). A project nested inside a dependency package's directory
+ * resolves the dependency's name by package self-reference — no node_modules
+ * hop — so the dependency's raw `.ts` sources are not external-library files
+ * and stay in the forced-emit set. Their output paths resolve outside the
+ * project's `outDir`, right next to the dependency's own sources; without the
+ * guard every plugin `--emit` build pollutes the dependency's source tree with
+ * stray `.js` files.
+ *
+ * 1. Materialize a dependency package whose `exports` points at raw `.ts`, with a
+ *    plugin-configured project nested inside the package directory.
+ * 2. Run `ttsc --emit` so the build routes through the native utility host.
+ * 3. Assert the project's own `dist/main.js` was emitted.
+ * 4. Assert no `.js` was written into the dependency's `src/` tree.
+ */
+export const test_ttsc_utility_plugins_forced_emit_confines_output_to_outdir =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({
+        name: "selfdep",
+        version: "1.0.0",
+        exports: { ".": "./src/index.ts" },
+      }),
+      "src/index.ts": `export const dep: number = 1;\n`,
+      "proj/banner.config.cjs": `module.exports = { text: "confined" };\n`,
+      "proj/tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          module: "CommonJS",
+          moduleResolution: "bundler",
+          target: "ES2022",
+          strict: true,
+          skipLibCheck: true,
+          rootDir: "src",
+          outDir: "dist",
+          plugins: [
+            {
+              transform: "@ttsc/banner",
+              configFile: "banner.config.cjs",
+            },
+          ],
+        },
+        include: ["src"],
+      }),
+      "proj/src/main.ts": [
+        `import { dep } from "selfdep";`,
+        `export const x: number = dep;`,
+        ``,
+      ].join("\n"),
+    });
+    TestUtilityPlugins.seedPackages(root, ["banner"]);
+    const project = path.join(root, "proj");
+    const result = TestProject.spawn(
+      TestProject.TTSC_BIN,
+      ["--cwd", project, "--emit"],
+      {
+        cwd: project,
+        env: {
+          PATH: TestUtilityPlugins.goPath(),
+          TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const mainJs = fs.readFileSync(
+      path.join(project, "dist", "main.js"),
+      "utf8",
+    );
+    assert.match(mainJs, /confined/);
+    const leaked = fs
+      .readdirSync(path.join(root, "src"), { recursive: true })
+      .map(String)
+      .filter((file) => file.endsWith(".js"));
+    assert.deepEqual(
+      leaked,
+      [],
+      `dependency source tree was polluted: ${leaked.join(", ")}`,
+    );
+  };

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -59,6 +59,10 @@ TypeScript-Go emits source files in parallel. One emitter goroutine per source. 
 
 This is the one ttsc-layered phase that observes emit at all; everything else a plugin does (`SourcePreamble`, `ApplyProgram`, rewrite collection against the pooled `Checker`) already runs on ttsc's own serial path.
 
+### Output containment
+
+When the project configures `outDir`, every driver emit lane (`EmitAll`, `EmitAllRaw`, `EmitFile`, `EmitWithPluginTransformers`) skips any output whose computed path would land outside it (outside `declarationDir` too, when set; `.tsbuildinfo` is exempt because its default home is next to the tsconfig). A forced emit past the `TS6059` rootDir check would otherwise resolve an out-of-`rootDir` source — typically a dependency package's raw `.ts` entry reached by package self-reference — to a `.js` right next to the dependency's own source, polluting a sibling package's tree. Skipped files behave exactly like `node_modules` externals: no write, no diagnostic, and your `WriteFile` callback never sees them.
+
 ## Diagnostics
 
 ```go

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -61,7 +61,7 @@ This is the one ttsc-layered phase that observes emit at all; everything else a 
 
 ### Output containment
 
-When the project configures `outDir`, every driver emit lane (`EmitAll`, `EmitAllRaw`, `EmitFile`, `EmitWithPluginTransformers`) skips any output whose computed path would land outside it (outside `declarationDir` too, when set; `.tsbuildinfo` is exempt because its default home is next to the tsconfig). A forced emit past the `TS6059` rootDir check would otherwise resolve an out-of-`rootDir` source — typically a dependency package's raw `.ts` entry reached by package self-reference — to a `.js` right next to the dependency's own source, polluting a sibling package's tree. Skipped files behave exactly like `node_modules` externals: no write, no diagnostic, and your `WriteFile` callback never sees them.
+When the project configures `outDir`, every driver emit lane (`EmitAll`, `EmitAllRaw`, `EmitFile`, `EmitWithPluginTransformers`) skips any output whose computed path would land outside it (outside `declarationDir` too, when set; `.tsbuildinfo` is exempt because its default home is next to the tsconfig). A forced emit past the `TS6059` rootDir check would otherwise resolve an out-of-`rootDir` source (typically a dependency package's raw `.ts` entry reached by package self-reference) to a `.js` right next to the dependency's own source, polluting a sibling package's tree. Skipped files behave exactly like `node_modules` externals: no write, no diagnostic, and your `WriteFile` callback never sees them.
 
 ## Diagnostics
 

--- a/website/src/content/docs/ttsc/compile.mdx
+++ b/website/src/content/docs/ttsc/compile.mdx
@@ -66,7 +66,7 @@ npx ttsc clean                      # drop the plugin cache
 | `--tsconfig <file>` | tsconfig file. |
 | `--cwd <dir>` | Resolve relative paths against this directory. |
 | `--noEmit` | Type-check only, no file writes. |
-| `--emit` | Force emit even when `tsconfig` sets `noEmit: true`. |
+| `--emit` | Force emit even when `tsconfig` sets `noEmit: true`. On a plugin build, output stays confined to `outDir`: a source pulled in from outside `rootDir` (e.g. a dependency package's raw `.ts` entry) whose computed output would escape `outDir` is skipped instead of written next to its own source. |
 | `-w, --watch` | Watch source files and re-check on change. |
 | `--preserveWatchOutput` | Don't clear the screen between watch runs. |
 | `--outDir <dir>` | Override `compilerOptions.outDir`. |


### PR DESCRIPTION
## Intent

Fix #293: a forced emit (`--emit`, plugin `runBuild`) writes a dependency's compiled `.js` into that dependency's own source tree when the dependency's raw `.ts` sources sit outside the project's `rootDir`. In the typia workspace this polluted `packages/typia/src/` with 14 stray `.js` files on every diagnostic-test run.

## Fact-check summary

The issue is real, but its mechanism differs from the report:

- **Trigger is package self-reference, not symlink realpath.** A module resolved through `node_modules` (symlink or junction, realpath'd or not) is classified as an external-library file and is already excluded from emit — the issue's own "minimal repro" does not reproduce, verified in the exact original environment (ttsc 0.16.3, typescript 7.0.1-rc, typia workspace). What does reproduce — exactly the 14 reported files — is a project nested **inside** the dependency package's directory (typia's throwaway test projects under `packages/typia/native/.tmp-ttsc-typia-tests/`): the `"typia"` import then resolves by package self-reference with no `node_modules` hop, so the dependency's sources are not external and stay in the forced-emit set.
- **No tsc divergence upstream.** Plain `tsc` 5.9.3 and `tsgo` 7.0.1-rc both leak identically when emit is forced past the TS6059 check with `--noCheck`. The plugin-free ttsc CLI lane (which spawns tsgo directly) keeps that upstream behavior — without `--noCheck` it already refuses via TS6059 + `--noEmitOnError`.
- **Where ttsc was genuinely at fault:** the driver's forced-emit lanes (`EmitAllRaw`, `EmitWithPluginTransformers`, …) emit past the TS6059 class silently — `Program.Diagnostics()` carries bind/semantic diagnostics only — so plugin hosts leaked with no `--noCheck` anywhere and no diagnostic to see.

## Scope

- `driver/emit_containment.go` (new): `outputEscapesOutDir` — when the project configures `outDir`, an output whose computed path would escape it (and `declarationDir`, when set) is skipped like a `node_modules` external: no write, no diagnostic. `.tsbuildinfo` is exempt (its default home is next to the tsconfig).
- `driver/rewrite.go`: guard wired into the `EmitAll`/`EmitFile` and `EmitAllRaw` WriteFile funnels; skipped writes flagged via `WriteFileData.SkippedDtsWrite` so `EmitResult.EmittedFiles` counts only real writes.
- `driver/emit_plugin.go`: `EmitWithPluginTransformers` resolves output paths before transforming and skips escaping files entirely (no wasted transform/print work).
- Docs: `ttsc/compile.mdx` (`--emit` flag row), `development/reference/driver-api.mdx` (new *Output containment* section).

## Test plan

- Go unit (red→green verified): `test/driver/emit_raw_skips_outputs_outside_outdir_for_self_referenced_dependency_test.go` and `test/driver/emit_plugin_transformers_skip_outputs_outside_outdir_test.go` materialize the self-reference layout and assert output is confined to `outDir` while the project's own `main.js` still emits.
- TS e2e (red→green verified against the real binaries): `test_ttsc_utility_plugins_forced_emit_confines_output_to_outdir` runs `ttsc --emit` on a `@ttsc/banner` project nested inside a dependency package and asserts no `.js` lands in the dependency's `src/`.
- Cross-checked against the live typia workspace: `go test -run TestRandomRecursiveMinItemsDiagnostic` leaked the 14 files before; the driver dry-run harness confirms both lanes emit only `dist/main.js` after.
- Pre-existing Windows-local failures (`TestUtilityCommandFailuresCoverHostEdges`, `TestDriverLinkedPluginsRegistersAndAppliesProgram`) fail identically on master; unrelated.

## Deferred

- The plugin-free CLI lane (`ttsc --emit --noCheck`, tsgo spawned directly) intentionally keeps upstream tsc/tsgo behavior; confining it would mean post-filtering tsgo's own writes. Candidate for an upstream typescript-go issue instead.
- `Program.Diagnostics()` still omits the TS6059 class (config/program diagnostics); surfacing them would flip typia's diagnostic tests from exit 3 to exit 2, so it needs a coordinated change downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9aUTnNS9jaLXEfVZR41bd
