### PR TITLE
chore(website): track site visits with Clarity

### DIFF
--- a/website/src/app/layout.jsx
+++ b/website/src/app/layout.jsx
@@ -36,6 +36,14 @@ const footer = (
 const description =
   "A typescript-go toolchain for compiler-powered plugins and type-safe execution.";
 
+const clarityScript = `
+(function(c,l,a,r,i,t,y){
+    c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+    t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+    y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+})(window, document, "clarity", "script", "xgfyndrsk9");
+`;
+
 export default async function RootLayout(props) {
   return (
     <html lang="en" dir="ltr" suppressHydrationWarning>
@@ -57,18 +65,11 @@ export default async function RootLayout(props) {
         <meta name="twitter:image" content="https://ttsc.dev/og.jpg" />
         <meta name="twitter:title" content="ttsc — TypeScript-Go toolchain" />
         <meta name="twitter:description" content={description} />
-        <Script
-          type="text/javascript"
-          dangerouslySetInnerHTML={{
-            __html: `
-(function(c,l,a,r,i,t,y){
-    c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-    t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-    y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-})(window, document, "clarity", "script", "xgfyndrsk9");
-`,
-          }}
-        />
+        {process.env.NODE_ENV === "production" ? (
+          <Script id="microsoft-clarity" type="text/javascript">
+            {clarityScript}
+          </Script>
+        ) : null}
       </Head>
       <body>
         <Layout

--- a/website/src/app/layout.jsx
+++ b/website/src/app/layout.jsx
@@ -1,3 +1,4 @@
+import Script from "next/script";
 import { Footer, Layout, Navbar } from "nextra-theme-docs";
 import { Head } from "nextra/components";
 import { getPageMap } from "nextra/page-map";
@@ -56,6 +57,18 @@ export default async function RootLayout(props) {
         <meta name="twitter:image" content="https://ttsc.dev/og.jpg" />
         <meta name="twitter:title" content="ttsc — TypeScript-Go toolchain" />
         <meta name="twitter:description" content={description} />
+        <Script
+          type="text/javascript"
+          dangerouslySetInnerHTML={{
+            __html: `
+(function(c,l,a,r,i,t,y){
+    c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+    t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+    y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+})(window, document, "clarity", "script", "xgfyndrsk9");
+`,
+          }}
+        />
       </Head>
       <body>
         <Layout


### PR DESCRIPTION
﻿## Intent

Embed Microsoft Clarity on the ttsc website so production pages load the analytics tag requested for the site.

## Scope

- Adds `next/script` to `website/src/app/layout.jsx`.
- Injects the Clarity bootstrap script in the shared root `Head` with project id `xgfyndrsk9`.
- Matches the existing pattern used by `../typia/website`.

## Deferred

- Live Microsoft Clarity dashboard ingestion can only be confirmed after deployment.

## Test Plan

- `pnpm --dir website exec prettier --check src/app/layout.jsx`
- `pnpm --dir website run build:next`
- `pnpm format`
- Verified built HTML contains `xgfyndrsk9`.
