### PR TITLE
refactor(graph): register the MCP server via @typia/mcp

### DIFF
--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
+    "@typia/mcp": "catalog:samchon",
     "typia": "catalog:samchon"
   },
   "keywords": [

--- a/packages/graph/src/TtscGraphApplication.ts
+++ b/packages/graph/src/TtscGraphApplication.ts
@@ -15,10 +15,11 @@ export type TtscGraphSource = TtscGraphMemory | (() => TtscGraphMemory);
  * The MCP tool surface as a plain class over the resident
  * {@link TtscGraphMemory}.
  *
- * Its public method is the MCP tool: `typia.llm.controller` reflects
+ * Its public method is the MCP tool: `typia.llm.application` reflects
  * {@link ITtscGraphApplication} to generate the tool's JSON schema and argument
- * validator from the signature and JSDoc, with no hand-written schema. The
- * method delegates to the pure graph functions in `./server`, which are
+ * validator from the signature and JSDoc, with no hand-written schema, and
+ * `@typia/mcp`'s `createMcpServer` registers it (see `./server/createServer`).
+ * The method delegates to the pure graph functions in `./server`, which are
  * unit-testable without a transport; this class only binds them to the graph.
  *
  * Every method answers from the resident graph; none recompiles. Output is kept
@@ -70,6 +71,7 @@ export class TtscGraphApplication implements ITtscGraphApplication {
           result: runTour(this.graph(), props.request),
         };
       default:
+        props.request satisfies never;
         throw new Error("Unknown graph request type");
     }
   }

--- a/packages/graph/src/server/createServer.ts
+++ b/packages/graph/src/server/createServer.ts
@@ -1,106 +1,31 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
-import typia from "typia";
+import { createMcpServer } from "@typia/mcp";
+import typia, { type ILlmController } from "typia";
 
 import { TtscGraphApplication, TtscGraphSource } from "../TtscGraphApplication";
-import { TtscGraphMemory } from "../model/TtscGraphMemory";
 import { ITtscGraphApplication } from "../structures/ITtscGraphApplication";
 
 /**
- * Build the MCP server for a graph. `typia.llm.controller` reflects
- * {@link ITtscGraphApplication} into a validated tool application. Every tool's
- * JSON schema and argument validator is generated from the method's TypeScript
- * types and JSDoc, so there is no hand-written schema. The list/call handlers
- * below are the minimal standalone registration: list the generated functions,
- * and on a call validate the arguments (returning typia's errors for the model
- * to self-correct) before invoking the method.
+ * Build the MCP server for a graph. `typia.llm.application` reflects
+ * {@link ITtscGraphApplication} into the tool schema and validator (no
+ * hand-written schema), and `createMcpServer` from `@typia/mcp` handles the
+ * list/call registration, argument validation, and structured output.
  *
- * Registration is inlined rather than pulled from `@typia/mcp` to keep the
- * dependency surface to `typia` plus the MCP SDK and avoid version-pinning the
- * wider typia ecosystem; the shape it relies on is `typia.llm.controller`'s
- * public output.
+ * We assemble the `ILlmController` (`{ protocol, name, application, execute }`)
+ * directly rather than via `typia.llm.controller` so the server is named
+ * "ttsc-graph" on our terms, not coupled to a reflected class name. Handshake
+ * instructions come from the class JSDoc; the single tool is named from its
+ * method, `inspect_typescript_graph`.
  */
 export function createServer(
   graph: TtscGraphSource,
   version: string,
 ): McpServer {
-  const controller = typia.llm.controller<ITtscGraphApplication>(
-    "graph",
-    new TtscGraphApplication(graph),
-  );
-  const functions = controller.application.functions;
-  const execute = controller.execute as unknown as Record<
-    string,
-    (input: unknown) => unknown
-  >;
-
-  const server = new McpServer(
-    { name: "ttsc-graph", version },
-    {
-      capabilities: { tools: {} },
-      // The MCP `instructions` are the interface's JSDoc, which
-      // `typia.llm.controller` reflects onto `application.description`. See
-      // {@link ITtscGraphApplication}.
-      instructions: controller.application.description,
-    },
-  );
-  const raw = server.server;
-
-  raw.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: functions.map((func) => ({
-      name: func.name,
-      description: func.description,
-      inputSchema: {
-        type: "object" as const,
-        properties: func.parameters.properties,
-        required: func.parameters.required,
-        additionalProperties: false,
-        $defs: func.parameters.$defs,
-      },
-    })),
-  }));
-
-  raw.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const func = functions.find((f) => f.name === request.params.name);
-    const method = execute[request.params.name];
-    if (func === undefined || method === undefined) {
-      return error(`Unknown tool: ${request.params.name}`);
-    }
-    // Validate an empty object when a client omits `arguments`, so typia can
-    // return field-level errors instead of a generic "expected object".
-    const validation = func.validate(request.params.arguments ?? {});
-    if (!validation.success) {
-      // Hand typia's validation errors back so the model can correct its call.
-      return error(JSON.stringify(validation.errors, null, 2));
-    }
-    try {
-      const result = await method.call(execute, validation.data);
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: result === undefined ? "Success" : JSON.stringify(result),
-          },
-        ],
-      };
-    } catch (exception) {
-      return error(
-        exception instanceof Error
-          ? `${exception.name}: ${exception.message}`
-          : String(exception),
-      );
-    }
-  });
-
-  return server;
-}
-
-function error(text: string): {
-  isError: true;
-  content: { type: "text"; text: string }[];
-} {
-  return { isError: true, content: [{ type: "text", text }] };
+  const controller: ILlmController<ITtscGraphApplication> = {
+    protocol: "class",
+    name: "ttsc-graph",
+    application: typia.llm.application<ITtscGraphApplication>(),
+    execute: new TtscGraphApplication(graph),
+  };
+  return createMcpServer(controller, version);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,14 +23,17 @@ catalogs:
       version: 8.1.2
   samchon:
     '@typia/interface':
-      specifier: 13.0.0-dev.20260701.1
-      version: 13.0.0-dev.20260701.1
+      specifier: 13.0.0-rc.1
+      version: 13.0.0-rc.1
+    '@typia/mcp':
+      specifier: 13.0.0-rc.1
+      version: 13.0.0-rc.1
     '@typia/utils':
-      specifier: 13.0.0-dev.20260701.1
-      version: 13.0.0-dev.20260701.1
+      specifier: 13.0.0-rc.1
+      version: 13.0.0-rc.1
     typia:
-      specifier: 13.0.0-dev.20260701.1
-      version: 13.0.0-dev.20260701.1
+      specifier: 13.0.0-rc.1
+      version: 13.0.0-rc.1
   typescript:
     ts-legacy:
       specifier: npm:typescript@~6.0.3
@@ -137,9 +140,12 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
         version: 1.29.0(zod@3.25.76)
+      '@typia/mcp':
+        specifier: catalog:samchon
+        version: 13.0.0-rc.1(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
       typia:
         specifier: catalog:samchon
-        version: 13.0.0-dev.20260701.1(@types/node@25.9.1)
+        version: 13.0.0-rc.1(@types/node@25.9.1)
     devDependencies:
       '@types/node':
         specifier: catalog:utils
@@ -636,10 +642,10 @@ importers:
         version: link:../packages/wasm
       '@typia/interface':
         specifier: catalog:samchon
-        version: 13.0.0-dev.20260701.1
+        version: 13.0.0-rc.1
       '@typia/utils':
         specifier: catalog:samchon
-        version: 13.0.0-dev.20260701.1
+        version: 13.0.0-rc.1
       lz-string:
         specifier: ^1.5.0
         version: 1.5.0
@@ -690,7 +696,7 @@ importers:
         version: 5.9.3
       typia:
         specifier: catalog:samchon
-        version: 13.0.0-dev.20260701.1(@types/node@20.19.41)
+        version: 13.0.0-rc.1(@types/node@20.19.41)
     devDependencies:
       '@resvg/resvg-js':
         specifier: ^2.6.2
@@ -3234,11 +3240,16 @@ packages:
     resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
 
-  '@typia/interface@13.0.0-dev.20260701.1':
-    resolution: {integrity: sha512-KEUceXD+8NWeZJLE9sqI5wcNEZVJ6aSJP8Yg0q+XhyAmTyTx31ZwPeNpHQK1K1nQnY23PKRLXatCfIgbBEXe9w==}
+  '@typia/interface@13.0.0-rc.1':
+    resolution: {integrity: sha512-zZEmDL+GRRGRhmFeWG/N9hQhV8zMdEm0cK3u4iFT9ry1dZU7bNE8TzFXRpu89LNVHLnttEkj5nkEWbgoeRYldQ==}
 
-  '@typia/utils@13.0.0-dev.20260701.1':
-    resolution: {integrity: sha512-joiy+FW0+IrcVRpejouUh9Mx1Np65uJqJAmfyqBFtleFSSvWncn7x2Th2G9mMW8tc92aW96sPgyTKauxr5P+Fw==}
+  '@typia/mcp@13.0.0-rc.1':
+    resolution: {integrity: sha512-5O+gDDWTkPnIdmeYjtpxiGVUFJGlcmcJzc65HmFsuEIVwJOTD2CEXc6BEwIa/9fGhYx6Eine4fZMUZ6fxhuYOQ==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.12.0'
+
+  '@typia/utils@13.0.0-rc.1':
+    resolution: {integrity: sha512-UQZHcSLSOV0UEy4FfP1Eo5u6K81OEPirEnNUw4g3ALkC5W9tm0l+NGoyMtm3mZ5zMTKlLzui2TWfgg651qJ72A==}
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -6847,8 +6858,8 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
-  typia@13.0.0-dev.20260701.1:
-    resolution: {integrity: sha512-5IR5j5a1O+ZzXEWy1wqo7sYHPk4IEHvOZAy1Yvy3qPNtAzZTqmQYODd6maMODWN9kyfDL1AcOOhMcHHdZrHS6Q==}
+  typia@13.0.0-rc.1:
+    resolution: {integrity: sha512-eS+Xp7OvMbv2mqQiok1SmPPmEEqEe3oJhaoWpiUiOOvRSTQ2bIcufZpRydnNX+MDPqL/qRM7R4kkDUymjCpffg==}
     hasBin: true
 
   uc.micro@2.1.0:
@@ -9817,11 +9828,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typia/interface@13.0.0-dev.20260701.1': {}
+  '@typia/interface@13.0.0-rc.1': {}
 
-  '@typia/utils@13.0.0-dev.20260701.1':
+  '@typia/mcp@13.0.0-rc.1(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
     dependencies:
-      '@typia/interface': 13.0.0-dev.20260701.1
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@typia/interface': 13.0.0-rc.1
+      '@typia/utils': 13.0.0-rc.1
+
+  '@typia/utils@13.0.0-rc.1':
+    dependencies:
+      '@typia/interface': 13.0.0-rc.1
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -14466,11 +14483,11 @@ snapshots:
       '@typescript/typescript-win32-arm64': 7.0.1-rc
       '@typescript/typescript-win32-x64': 7.0.1-rc
 
-  typia@13.0.0-dev.20260701.1(@types/node@20.19.41):
+  typia@13.0.0-rc.1(@types/node@20.19.41):
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@typia/interface': 13.0.0-dev.20260701.1
-      '@typia/utils': 13.0.0-dev.20260701.1
+      '@typia/interface': 13.0.0-rc.1
+      '@typia/utils': 13.0.0-rc.1
       commander: 10.0.1
       inquirer: 8.2.7(@types/node@20.19.41)
       randexp: 0.5.3
@@ -14478,11 +14495,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  typia@13.0.0-dev.20260701.1(@types/node@25.9.1):
+  typia@13.0.0-rc.1(@types/node@25.9.1):
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@typia/interface': 13.0.0-dev.20260701.1
-      '@typia/utils': 13.0.0-dev.20260701.1
+      '@typia/interface': 13.0.0-rc.1
+      '@typia/utils': 13.0.0-rc.1
       commander: 10.0.1
       inquirer: 8.2.7(@types/node@25.9.1)
       randexp: 0.5.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,9 +18,10 @@ catalogs:
     rollup-plugin-auto-external: ^2.0.0
     rollup-plugin-node-externals: ^8.1.2
   samchon:
-    '@typia/interface': 13.0.0-dev.20260701.1
-    '@typia/utils': 13.0.0-dev.20260701.1
-    typia: 13.0.0-dev.20260701.1
+    '@typia/interface': 13.0.0-rc.1
+    '@typia/mcp': 13.0.0-rc.1
+    '@typia/utils': 13.0.0-rc.1
+    typia: 13.0.0-rc.1
   utils:
     '@nestia/e2e': ^11.2.0
     '@types/node': ^25.3.0


### PR DESCRIPTION
## Intent

Now that `@typia/mcp` ships a stable entry point, replace the hand-inlined MCP
list/call registration in `@ttsc/graph`'s `createServer` with its
`createMcpServer`, and move the typia toolchain onto the `13.0.0-rc.1` line.

## Scope

- **`packages/graph/src/server/createServer.ts`** — drop the inlined
  `ListTools`/`CallTool` handlers; build the `ILlmController`
  (`{ protocol, name, application, execute }`) directly from
  `typia.llm.application` and hand it to `createMcpServer`. Building the
  controller by hand (rather than `typia.llm.controller`) keeps the server named
  `ttsc-graph` on our terms instead of a reflected class name. Net: −124/+? lines,
  and the server now also emits reflected `outputSchema` / `structuredContent`.
- **`packages/graph/package.json`** — `@typia/mcp` becomes a runtime dependency.
- **`packages/graph/src/TtscGraphApplication.ts`** — doc + exhaustiveness touch-up.
- **`pnpm-workspace.yaml`** — `samchon` catalog → `13.0.0-rc.1`, add `@typia/mcp`.

## Why rc.1

The `-dev` builds carry `-N`-suffixed prerelease tags (e.g. `20260502-2`) that
semver ranks **above** later dated builds, because a suffixed identifier is
alphanumeric and outranks a plain numeric one. `@typia/mcp`'s
`^13.0.0-dev.…` range therefore resolved a stale `@typia/utils` missing
`LlmJson.validateArguments` (runtime crash). The rc line supersedes every
`13.0.0-dev.*`, so the resolution is consistent without a `pnpm.overrides`
band-aid.

Catalog blast radius: `packages/graph` and `website` (the only `catalog:samchon`
consumers).

## Test plan

- `pnpm --filter @ttsc/graph build` — clean (types check the hand-built controller).
- MCP server over stdio: `initialize` returns name `ttsc-graph` + instructions,
  `tools/list` = single `inspect_typescript_graph` (with `outputSchema`),
  `tools/call` escape branch returns structured JSON, invalid args return typia's
  self-correction feedback, clean exit.
- `graph.mjs --project=typeorm --prompt-family=common --models=gpt-5.4-mini
  --arm=graph --tools=ttsc-graph --runs=1` — one **valid** MCP call, 0 shell
  reads, 41.7k tokens, 70s.
- Full graph MCP e2e (`test_ttscgraph_serves_graph_tools_over_mcp`, which needs
  the native `ttscgraph` binary) runs on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rb5dahyTZEfMCmDGFSbEQC
