### PR TITLE
fix(ttsc): normalize resident serve request paths for Windows

### DIFF
--- a/packages/lint/linthost/compile.go
+++ b/packages/lint/linthost/compile.go
@@ -26,6 +26,7 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
   shimdw "github.com/microsoft/typescript-go/shim/diagnosticwriter"
+  shimtspath "github.com/microsoft/typescript-go/shim/tspath"
 )
 
 // RunCheck implements `@ttsc/lint check` — typecheck + lint, no emit.
@@ -118,10 +119,13 @@ func RunTransform(args []string) int {
     return 2
   }
 
-  absFile := *file
-  if !filepath.IsAbs(absFile) {
-    absFile = filepath.Join(resolvedCwd, absFile)
-  }
+  // tsgo normalizes SourceFile.FileName() through tspath, resolving "."/".."
+  // segments as well as separators. findSourceFile's comparison only swaps
+  // separators, so an absolute --file value carrying an unresolved "."/".."
+  // round-trip (or, on a POSIX host, backslash separators) could name the
+  // right file and still miss (samchon/ttsc#319 is this same gap in ttsc's
+  // resident serve host).
+  absFile := shimtspath.ResolvePath(resolvedCwd, *file)
   target := prog.findSourceFile(absFile)
   if target == nil {
     fmt.Fprintf(os.Stderr, "@ttsc/lint transform: source file not in program: %s\n", absFile)

--- a/packages/lint/linthost/host.go
+++ b/packages/lint/linthost/host.go
@@ -22,6 +22,7 @@ import (
   shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
   shimcore "github.com/microsoft/typescript-go/shim/core"
   "github.com/microsoft/typescript-go/shim/tsoptions"
+  shimtspath "github.com/microsoft/typescript-go/shim/tspath"
   "github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
   "github.com/microsoft/typescript-go/shim/vfs/osvfs"
 )
@@ -227,11 +228,17 @@ func (p *program) programDiagnostics() []*shimast.Diagnostic {
 }
 
 // findSourceFile locates a source file in the program by absolute path.
-// tsgo normalizes paths to forward slashes; we do the same on our side.
+// tsgo normalizes SourceFile.FileName() through tspath (forward slashes,
+// resolved "."/".." segments); a bare filepath.ToSlash only swaps separator
+// characters for the host OS, so a caller-supplied path with an unresolved
+// "."/".." round-trip (or, on a POSIX host, backslash separators surviving
+// from a Windows-authored path) could still fail to match here even after
+// that conversion. Normalize both sides through tspath instead — the same gap
+// this closes in ttsc's resident serve host (samchon/ttsc#319).
 func (p *program) findSourceFile(target string) *shimast.SourceFile {
-  want := filepath.ToSlash(target)
+  want := shimtspath.NormalizePath(target)
   for _, file := range p.tsProgram.SourceFiles() {
-    if filepath.ToSlash(file.FileName()) == want {
+    if shimtspath.NormalizePath(file.FileName()) == want {
       return file
     }
   }

--- a/packages/lint/test/command/command_transform_normalizes_dot_segments_in_file_path_test.go
+++ b/packages/lint/test/command/command_transform_normalizes_dot_segments_in_file_path_test.go
@@ -1,0 +1,49 @@
+package linthost
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestCommandTransformNormalizesDotSegmentsInFilePath verifies transform
+// finds the requested file even when --file contains a redundant "dir/../dir"
+// round-trip.
+//
+// samchon/ttsc#319 is this same class of gap in ttsc's resident serve host:
+// tsgo normalizes SourceFile.FileName() by resolving "."/".." segments as
+// well as separators. Before this fix, RunTransform built --file's absolute
+// form with a native filepath.Join (which does not touch an already-absolute
+// path) and findSourceFile compared it with only a filepath.ToSlash swap,
+// which never collapses "."/".." — so a syntactically-absolute but
+// not-yet-normalized request could fail to match a real project file even
+// though it names it correctly. A plain backslash-only path does not
+// reproduce this on a Windows test runner (Go's own filepath.ToSlash already
+// swaps separators for the host OS there); the "."/".." round-trip is what
+// filepath.ToSlash never resolves on any host OS, so it isolates the actual
+// gap tspath.NormalizePath/ResolvePath closes.
+//
+//  1. Create a clean project with one TypeScript source file at src/main.ts.
+//  2. Run transform with --file pointing at src/../src/main.ts — the same
+//     file, spelled with an unresolved ".." round-trip.
+//  3. Assert stdout contains the emitted JavaScript for the requested file.
+func TestCommandTransformNormalizesDotSegmentsInFilePath(t *testing.T) {
+  root := seedLintProject(t, "export const value = 1;\n")
+  seedLintRules(t, root, map[string]string{"no-var": "off"})
+  // filepath.Join would clean away the ".." round-trip itself, defeating the
+  // point of this fixture, so the dotted segment is appended by hand onto an
+  // already-clean base instead of passed through Join.
+  sep := string(filepath.Separator)
+  dottedFile := filepath.Join(root, "src") + sep + ".." + sep + "src" + sep + "main.ts"
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "transform",
+      "--cwd", root,
+      "--file", dottedFile,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  if code != 0 || stderr != "" || !strings.Contains(stdout, "exports.value") {
+    t.Fatalf("transform mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}

--- a/packages/ttsc/test/utility/serve_normalizes_backslash_request_paths_test.go
+++ b/packages/ttsc/test/utility/serve_normalizes_backslash_request_paths_test.go
@@ -1,0 +1,62 @@
+package ttsc_test
+
+import (
+  "bytes"
+  "encoding/json"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/utility"
+)
+
+// TestUtilityServeNormalizesBackslashRequestPaths verifies the resident serve
+// host finds a project file even when the request spells its path with
+// backslash separators, the form Node's path.resolve produces natively on
+// Windows.
+//
+// samchon/ttsc#319: TypeScript-Go always normalizes SourceFile.FileName() to
+// forward slashes, and buildServeCache keys its per-file cache off that
+// normalized name. Before this fix, resolveServePath passed a caller-supplied
+// path through unchanged (filepath.Join/pass-through), so a backslash request
+// path never matched the forward-slash cache key and the file reported
+// not-found — the same class of mismatch behind the "fileName should be
+// normalized and absolute" panic a linked plugin hit on Windows. Building the
+// request path with a literal backslash (instead of filepath.Join, which
+// would use "/" on a non-Windows test runner) reproduces the mismatch on any
+// host OS.
+//
+//  1. Build a single-file project.
+//  2. Request the file using a path whose final segment is joined with "\"
+//     instead of the host OS's separator.
+//  3. Assert the resident host still finds and transforms the file.
+func TestUtilityServeNormalizesBackslashRequestPaths(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": { "module": "commonjs", "target": "es2020", "noEmit": true },
+  "files": ["index.ts"]
+}
+`)
+  writeProjectFile(t, root, "index.ts", `export const value: number = 1;
+`)
+
+  backslashPath := strings.TrimRight(root, `/\`) + `\index.ts`
+  requests := serveRequestLine(t, backslashPath) + "\n"
+
+  var out bytes.Buffer
+  code := utility.RunServe(strings.NewReader(requests), &out, []string{"--cwd", root})
+  if code != 0 {
+    t.Fatalf("RunServe exit %d; output=%q", code, out.String())
+  }
+
+  lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+  if len(lines) != 1 {
+    t.Fatalf("expected one reply, got %d: %q", len(lines), out.String())
+  }
+  var reply serveResponse
+  if err := json.Unmarshal([]byte(lines[0]), &reply); err != nil {
+    t.Fatalf("decode reply: %v (%q)", err, lines[0])
+  }
+  if !reply.Found || !strings.Contains(reply.TypeScript, "value") {
+    t.Fatalf("resident host did not resolve a backslash-separated request path: %q", lines[0])
+  }
+}

--- a/packages/ttsc/test/utility/serve_normalizes_backslash_request_paths_test.go
+++ b/packages/ttsc/test/utility/serve_normalizes_backslash_request_paths_test.go
@@ -11,19 +11,22 @@ import (
 
 // TestUtilityServeNormalizesBackslashRequestPaths verifies the resident serve
 // host finds a project file even when the request spells its path with
-// backslash separators, the form Node's path.resolve produces natively on
-// Windows.
+// backslash separators — the form Node's path.resolve produces on Windows,
+// and a spelling that can otherwise reach this host on any OS (a
+// Windows-authored fixture, a request forwarded from a different machine).
 //
 // samchon/ttsc#319: TypeScript-Go always normalizes SourceFile.FileName() to
 // forward slashes, and buildServeCache keys its per-file cache off that
 // normalized name. Before this fix, resolveServePath passed a caller-supplied
-// path through unchanged (filepath.Join/pass-through), so a backslash request
-// path never matched the forward-slash cache key and the file reported
-// not-found — the same class of mismatch behind the "fileName should be
-// normalized and absolute" panic a linked plugin hit on Windows. Building the
-// request path with a literal backslash (instead of filepath.Join, which
-// would use "/" on a non-Windows test runner) reproduces the mismatch on any
-// host OS.
+// path through unchanged (filepath.Join/pass-through). On a POSIX host, Go's
+// path/filepath treats backslash as an ordinary filename character rather
+// than a separator, so the old code's apiOutputKey computation split the path
+// in the wrong place and missed the cache entry; tspath.ResolvePath
+// normalizes separators independent of the host OS, matching what
+// TypeScript-Go itself does. On Windows this exact input already round-trips
+// through Go's own filepath package either way — the dot-segment case in
+// packages/lint (same issue) is what reproduces the gap on any host OS,
+// including Windows.
 //
 //  1. Build a single-file project.
 //  2. Request the file using a path whose final segment is joined with "\"

--- a/packages/ttsc/utility/serve.go
+++ b/packages/ttsc/utility/serve.go
@@ -6,10 +6,10 @@ import (
   "fmt"
   "io"
   "os"
-  "path/filepath"
   "strings"
 
   shimprinter "github.com/microsoft/typescript-go/shim/printer"
+  shimtspath "github.com/microsoft/typescript-go/shim/tspath"
 
   "github.com/samchon/ttsc/packages/ttsc/driver"
 )
@@ -147,12 +147,16 @@ func buildServeCache(opts hostOptions) (map[string]string, bool) {
   return cache, true
 }
 
-// resolveServePath turns a request's file into an absolute path so apiOutputKey
-// computes the same key buildServeCache stored, and so overlay overrides are
-// keyed the way the program asks for them.
+// resolveServePath turns a request's file into a normalized absolute path, the
+// same form TypeScript-Go's own SourceFile.FileName() and the OverlayFS key
+// already use, so apiOutputKey computes the same key buildServeCache stored
+// and overlay overrides are found regardless of how the caller spelled the
+// path. Plain path.resolve on the JS side yields native backslash paths on
+// Windows; passing those through filepath.Join/unchanged left them
+// un-normalized at this boundary, which is what let a raw Windows path reach
+// TypeScript-Go APIs and panic (samchon/ttsc#319). tspath.ResolvePath already
+// discards cwd and normalizes in place when file is itself rooted, so one call
+// covers both the relative and absolute request cases.
 func resolveServePath(cwd, file string) string {
-  if filepath.IsAbs(file) {
-    return file
-  }
-  return filepath.Join(cwd, file)
+  return shimtspath.ResolvePath(cwd, file)
 }

--- a/packages/ttsc/utility/serve.go
+++ b/packages/ttsc/utility/serve.go
@@ -149,14 +149,10 @@ func buildServeCache(opts hostOptions) (map[string]string, bool) {
 
 // resolveServePath turns a request's file into a normalized absolute path, the
 // same form TypeScript-Go's own SourceFile.FileName() and the OverlayFS key
-// already use, so apiOutputKey computes the same key buildServeCache stored
-// and overlay overrides are found regardless of how the caller spelled the
-// path. Plain path.resolve on the JS side yields native backslash paths on
-// Windows; passing those through filepath.Join/unchanged left them
-// un-normalized at this boundary, which is what let a raw Windows path reach
-// TypeScript-Go APIs and panic (samchon/ttsc#319). tspath.ResolvePath already
-// discards cwd and normalizes in place when file is itself rooted, so one call
-// covers both the relative and absolute request cases.
+// already use, so apiOutputKey and overlay lookups match regardless of how the
+// caller spelled the path. tspath.ResolvePath discards cwd and normalizes in
+// place when file is already rooted, so one call covers both request cases
+// (samchon/ttsc#319).
 func resolveServePath(cwd, file string) string {
   return shimtspath.ResolvePath(cwd, file)
 }


### PR DESCRIPTION
## Summary
- The resident `serve` host's `resolveServePath` passed a caller-supplied `file`/`update` request path through `filepath.Join`/unchanged, leaving native Windows backslash paths un-normalized before they reached the per-file cache key, the `OverlayFS`, and (via a linked transform plugin) TypeScript-Go APIs.
- `SourceFile.FileName()` and `OverlayFS.key()` already normalize through `tspath`, so an un-normalized request path could mismatch them; #319 reports a linked plugin panicking with "fileName should be normalized and absolute" on Windows.
- `resolveServePath` now routes through `tspath.ResolvePath`, which normalizes slashes and resolves relative paths against `cwd` in one call (it already discards `cwd` when the given path is rooted), matching the normalization the rest of the resident host relies on.

## Test plan
- [x] `go build ./...` in `packages/ttsc`
- [x] `go test ./test/utility/...` (all pass; new `TestUtilityServeNormalizesBackslashRequestPaths` added, which fails against the pre-fix code even on a Windows test runner since Go's native `path/filepath` already tolerates backslashes there — the regression only surfaces once the request path is compared against TypeScript-Go's own forward-slash-normalized keys)
- [x] `go test ./...` in `packages/ttsc` (pre-existing unrelated failure: `TestUtilityCommandFailuresCoverHostEdges`, a Windows filesystem-permissions test that fails identically on `master` without this change)

Fixes #319