### PR TITLE
fix(driver): keep plugin transform builds complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "pnpm run check:flags && pnpm run build:current && pnpm run test:go && pnpm run test:typecheck && pnpm run test:features",
     "coverage:go": "node scripts/test-go-coverage.cjs",
     "test:features": "pnpm --filter \"./tests/test-*\" -r --workspace-concurrency=1 start",
-    "test:go": "node scripts/test-go-transformer.cjs && node scripts/test-go-utility-plugins.cjs && node scripts/test-go-lint.cjs && node scripts/test-go-graph.cjs",
+    "test:go": "node scripts/test-go-driver.cjs && node scripts/test-go-transformer.cjs && node scripts/test-go-utility-plugins.cjs && node scripts/test-go-lint.cjs && node scripts/test-go-graph.cjs",
     "test:typecheck": "node scripts/test-typecheck.cjs"
   },
   "repository": {

--- a/packages/ttsc/driver/emit_plugin.go
+++ b/packages/ttsc/driver/emit_plugin.go
@@ -1,8 +1,10 @@
 package driver
 
 import (
+  "context"
   "errors"
   "strings"
+  "sync"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
@@ -126,16 +128,20 @@ func restoreOriginalDeclarationSymbols(ec *shimprinter.EmitContext, node *shimas
   })
 }
 
-// EmitWithPluginTransformers emits every source file by assembling tsgo's emit
-// pipeline from shim parts and running the plugin transformers FIRST (in order)
-// in the same EmitContext as the builtin chain (type-erase, import-elision,
-// module-transform, ...). No text-splice and no hand-rolled import aliasing:
-// tsgo's module-transform aliases the plugins' injected imports itself.
+// EmitWithPluginTransformers emits every source file by assembling tsgo's
+// JavaScript emit pipeline from shim parts and running the plugin transformers
+// FIRST (in order) in the same EmitContext as the builtin chain (type-erase,
+// import-elision, module-transform, ...). No text-splice and no hand-rolled
+// import aliasing: tsgo's module-transform aliases the plugins' injected
+// imports itself.
 //
-// Because this bypasses tsgo's own emitter, it reproduces the emitter's
-// source-map step via PrintFileWithSourceMap: a `sourceMap` / `inlineSourceMap`
-// build emits a `.js.map` (and `//# sourceMappingURL=` trailer) just like a
-// plain build, even when a transform expanded one source line into many.
+// Because the JavaScript side bypasses tsgo's own emitter, it reproduces the
+// emitter's source-map step via PrintFileWithSourceMap: a `sourceMap` /
+// `inlineSourceMap` build emits a `.js.map` (and `//# sourceMappingURL=`
+// trailer) just like a plain build, even when a transform expanded one source
+// line into many. All non-JavaScript outputs stay delegated to tsgo's normal
+// dts-only emitter so declaration files, declaration maps, and any future
+// declaration-lane outputs are not silently lost by the hand-assembled JS path.
 func (p *Program) EmitWithPluginTransformers(transforms []PluginTransform, writeFile shimcompiler.WriteFile) ([]Diagnostic, error) {
   if p == nil || p.TSProgram == nil {
     return nil, errors.New("driver: nil program")
@@ -144,54 +150,87 @@ func (p *Program) EmitWithPluginTransformers(transforms []PluginTransform, write
   options := p.TSProgram.Options()
   for _, sf := range shimcompiler.GetSourceFilesToEmit(host, nil, false) {
     paths := shimcompiler.GetOutputPathsFor(sf, options, host, false)
-    if p.outputEscapesOutDir(paths.JsFilePath()) {
-      continue
-    }
-    ec := shimprinter.NewEmitContext()
-    out := sf
-    for _, transform := range transforms {
-      if transform == nil {
-        continue
-      }
-      if next := transform(ec, out); next != nil {
-        out = next
-      }
-    }
-    shimast.SetParentInChildrenUnset(out.AsNode())
-    restoreOriginalDeclarationSymbols(ec, out.AsNode())
-    for _, tr := range shimcompiler.GetScriptTransformers(ec, host, out) {
-      out = tr.TransformSourceFile(out)
-    }
-    // Print through the source-map-aware helper so a `sourceMap` /
-    // `inlineSourceMap` build still gets its `.js.map` and sourceMappingURL
-    // trailer: the hand-assembled emit pipeline does not run tsgo's emitter, so
-    // the source-map step printSourceFile would otherwise perform has to happen
-    // here. With maps off this is the same bare-printer output as before.
-    printed := shimcompiler.PrintFileWithSourceMap(ec, out.AsNode(), out, options, host, paths.JsFilePath(), paths.SourceMapFilePath())
-    // A source-level preamble (e.g. @ttsc/banner linked into a typia host) shifts
-    // the map's source coordinates; correct them here too, so the
-    // preamble-plus-transform combination is not left uncorrected the way it
-    // would be if only the utility host's WriteFile patched maps. Covers both the
-    // external `.js.map` and an inline base64 map embedded in the JS.
-    if p.SourcePreamble != "" {
-      dropLines := strings.Count(p.SourcePreamble, "\n")
-      if adjusted, ok := AdjustEmittedSourceMap(paths.JsFilePath(), printed.JS, dropLines); ok {
-        printed.JS = adjusted
-      }
-      if printed.MapPath != "" {
-        if adjusted, ok := AdjustEmittedSourceMap(printed.MapPath, printed.MapText, dropLines); ok {
-          printed.MapText = adjusted
+    if paths.JsFilePath() != "" && !p.outputEscapesOutDir(paths.JsFilePath()) {
+      ec := shimprinter.NewEmitContext()
+      out := sf
+      for _, transform := range transforms {
+        if transform == nil {
+          continue
+        }
+        if next := transform(ec, out); next != nil {
+          out = next
         }
       }
-    }
-    if err := writeFile(paths.JsFilePath(), printed.JS, nil); err != nil {
-      return nil, err
-    }
-    if printed.MapPath != "" {
-      if err := writeFile(printed.MapPath, printed.MapText, nil); err != nil {
+      shimast.SetParentInChildrenUnset(out.AsNode())
+      restoreOriginalDeclarationSymbols(ec, out.AsNode())
+      for _, tr := range shimcompiler.GetScriptTransformers(ec, host, out) {
+        out = tr.TransformSourceFile(out)
+      }
+      // Print through the source-map-aware helper so a `sourceMap` /
+      // `inlineSourceMap` build still gets its `.js.map` and sourceMappingURL
+      // trailer: the hand-assembled emit pipeline does not run tsgo's emitter,
+      // so the source-map step printSourceFile would otherwise perform has to
+      // happen here. With maps off this is the same bare-printer output as
+      // before.
+      printed := shimcompiler.PrintFileWithSourceMap(ec, out.AsNode(), out, options, host, paths.JsFilePath(), paths.SourceMapFilePath())
+      // A source-level preamble (e.g. @ttsc/banner linked into a typia host)
+      // shifts the map's source coordinates; correct them here too, so the
+      // preamble-plus-transform combination is not left uncorrected the way it
+      // would be if only the utility host's WriteFile patched maps. Covers both
+      // the external `.js.map` and an inline base64 map embedded in the JS.
+      if p.SourcePreamble != "" {
+        dropLines := strings.Count(p.SourcePreamble, "\n")
+        if adjusted, ok := AdjustEmittedSourceMap(paths.JsFilePath(), printed.JS, dropLines); ok {
+          printed.JS = adjusted
+        }
+        if printed.MapPath != "" {
+          if adjusted, ok := AdjustEmittedSourceMap(printed.MapPath, printed.MapText, dropLines); ok {
+            printed.MapText = adjusted
+          }
+        }
+      }
+      if err := p.writePluginEmitOutput(paths.JsFilePath(), printed.JS, writeFile); err != nil {
+        return nil, err
+      }
+      if err := p.writePluginEmitOutput(printed.MapPath, printed.MapText, writeFile); err != nil {
         return nil, err
       }
     }
   }
+  if !options.GetEmitDeclarations() {
+    return nil, nil
+  }
+
+  var wfMu sync.Mutex
+  result := p.TSProgram.Emit(context.Background(), shimcompiler.EmitOptions{
+    EmitOnly: shimcompiler.EmitOnlyDts,
+    WriteFile: func(fileName string, text string, data *shimcompiler.WriteFileData) error {
+      wfMu.Lock()
+      defer wfMu.Unlock()
+      if p.outputEscapesOutDir(fileName) {
+        if data != nil {
+          data.SkippedDtsWrite = true
+        }
+        return nil
+      }
+      if writeFile != nil {
+        return writeFile(fileName, text, data)
+      }
+      return DefaultWriteFile(fileName, text)
+    },
+  })
+  if result != nil && len(result.Diagnostics) != 0 {
+    return convertDiagnostics(result.Diagnostics), nil
+  }
   return nil, nil
+}
+
+func (p *Program) writePluginEmitOutput(fileName, text string, writeFile shimcompiler.WriteFile) error {
+  if fileName == "" || p.outputEscapesOutDir(fileName) {
+    return nil
+  }
+  if writeFile != nil {
+    return writeFile(fileName, text, nil)
+  }
+  return DefaultWriteFile(fileName, text)
 }

--- a/packages/ttsc/scripts/check-flags.cjs
+++ b/packages/ttsc/scripts/check-flags.cjs
@@ -36,11 +36,13 @@ if (result.status !== 0) {
 // skipping this step here would surface as drift on any local edit.
 for (const target of targets) {
   if (!target.endsWith(".go")) continue;
-  const gofmt = child.spawnSync(
-    path.join(repoRoot, ".vscode/gofmt-2spaces.sh"),
-    ["-w", target],
-    { stdio: "inherit" },
-  );
+  const script = path.join(repoRoot, ".vscode/gofmt-2spaces.sh");
+  const gofmt = child.spawnSync(...shellScriptCommand(script, ["-w", target]), {
+    stdio: "inherit",
+  });
+  if (gofmt.error) {
+    throw gofmt.error;
+  }
   if (gofmt.status !== 0) {
     process.exit(gofmt.status ?? 1);
   }
@@ -76,4 +78,11 @@ function snapshot(files) {
       : "";
   }
   return out;
+}
+
+function shellScriptCommand(script, args) {
+  if (process.platform === "win32") {
+    return ["bash", [script, ...args]];
+  }
+  return [script, args];
 }

--- a/packages/ttsc/scripts/gen-flags.mts
+++ b/packages/ttsc/scripts/gen-flags.mts
@@ -206,8 +206,20 @@ function writeFile(target: string, contents: string): void {
   if (target.endsWith(".go")) {
     const formatter = path.join(repoRoot, ".vscode", "gofmt-2spaces.sh");
     if (fs.existsSync(formatter)) {
-      spawnSync(formatter, ["-w", target], { stdio: "ignore" });
+      spawnSync(...shellScriptCommand(formatter, ["-w", target]), {
+        stdio: "ignore",
+      });
     }
   }
   process.stdout.write(`generated ${path.relative(repoRoot, target)}\n`);
+}
+
+function shellScriptCommand(
+  script: string,
+  args: string[],
+): [string, string[]] {
+  if (process.platform === "win32") {
+    return ["bash", [script, ...args]];
+  }
+  return [script, args];
 }

--- a/packages/ttsc/test/driver/emit_plugin_transform_emits_declaration_outputs_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_transform_emits_declaration_outputs_test.go
@@ -1,0 +1,361 @@
+package driver_test
+
+import (
+  "encoding/json"
+  "fmt"
+  "path/filepath"
+  "reflect"
+  "sort"
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+  shimprinter "github.com/microsoft/typescript-go/shim/printer"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestEmitWithPluginTransformerEmitsDeclarationOutputs pins the complete output
+// set for the plugin-transform emit lane.
+//
+// EmitWithPluginTransformers owns the transformed JavaScript path, but it must
+// not narrow tsgo's output set to only `.js` and `.js.map`. A declaration build
+// must still emit the same declaration artifacts as raw tsgo emit: `.d.ts` and
+// `.d.ts.map`, including the declaration map trailer inside the `.d.ts`.
+func TestEmitWithPluginTransformerEmitsDeclarationOutputs(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "incremental": true,
+    "sourceMap": true,
+    "strict": true,
+    "tsBuildInfoFile": "dist/index.tsbuildinfo"
+  },
+  "include": ["src"]
+}
+`)
+  writeProjectFile(t, root, "src/index.ts", strings.Join([]string{
+    "export interface Payload {",
+    "  readonly label: string;",
+    "}",
+    "export const value: number = 1;",
+    "",
+  }, "\n"))
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  raw := map[string]string{}
+  if _, emitDiags, err := prog.EmitAllRaw(func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    raw[filepath.Base(fileName)] = text
+    return nil
+  }); err != nil || len(emitDiags) != 0 {
+    t.Fatalf("raw emit mismatch: diags=%#v err=%v", emitDiags, err)
+  }
+
+  transform := func(ec *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
+    var visitor *shimast.NodeVisitor
+    visit := func(node *shimast.Node) *shimast.Node {
+      if node == nil {
+        return node
+      }
+      if node.Kind == shimast.KindNumericLiteral && node.Text() == "1" {
+        return ec.Factory.NewNumericLiteral("2", 0)
+      }
+      return visitor.VisitEachChild(node)
+    }
+    visitor = ec.NewNodeVisitor(visit)
+    return visitor.VisitSourceFile(sf)
+  }
+
+  plugin := map[string]string{}
+  if emitDiags, err := prog.EmitWithPluginTransformer(transform, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    plugin[filepath.Base(fileName)] = text
+    return nil
+  }); err != nil || len(emitDiags) != 0 {
+    t.Fatalf("plugin emit mismatch: diags=%#v err=%v", emitDiags, err)
+  }
+
+  if got, want := sortedStringKeys(plugin), sortedStringKeys(raw); !reflect.DeepEqual(got, want) {
+    t.Fatalf("plugin emit output set mismatch:\n  got  %v\n  want %v", got, want)
+  }
+  for _, name := range []string{"index.js", "index.js.map", "index.d.ts", "index.d.ts.map"} {
+    if plugin[name] == "" {
+      t.Fatalf("%s was not emitted; got keys %v", name, sortedStringKeys(plugin))
+    }
+  }
+  if !strings.Contains(plugin["index.js"], "exports.value = 2;") {
+    t.Fatalf("plugin transform did not affect JavaScript:\n%s", plugin["index.js"])
+  }
+  if plugin["index.d.ts"] != raw["index.d.ts"] {
+    t.Fatalf("declaration output diverged from raw tsgo emit:\nplugin:\n%s\nraw:\n%s", plugin["index.d.ts"], raw["index.d.ts"])
+  }
+  if plugin["index.d.ts.map"] != raw["index.d.ts.map"] {
+    t.Fatalf("declaration map output diverged from raw tsgo emit:\nplugin:\n%s\nraw:\n%s", plugin["index.d.ts.map"], raw["index.d.ts.map"])
+  }
+  if !strings.Contains(plugin["index.d.ts"], "//# sourceMappingURL=index.d.ts.map") {
+    t.Fatalf("declaration output missing declaration map trailer:\n%s", plugin["index.d.ts"])
+  }
+
+  var parsed struct {
+    Version  int      `json:"version"`
+    Sources  []string `json:"sources"`
+    Mappings string   `json:"mappings"`
+  }
+  if err := json.Unmarshal([]byte(plugin["index.d.ts.map"]), &parsed); err != nil {
+    t.Fatalf("index.d.ts.map is not valid JSON: %v\n%s", err, plugin["index.d.ts.map"])
+  }
+  if parsed.Version != 3 || parsed.Mappings == "" {
+    t.Fatalf("index.d.ts.map is not a populated v3 source map: %#v", parsed)
+  }
+  foundSource := false
+  for _, source := range parsed.Sources {
+    if strings.HasSuffix(filepath.ToSlash(source), "src/index.ts") {
+      foundSource = true
+    }
+  }
+  if !foundSource {
+    t.Fatalf("declaration map sources do not reference src/index.ts: %v", parsed.Sources)
+  }
+}
+
+// TestEmitWithPluginTransformerEmitDeclarationOnlyOutputs covers the
+// declaration-only branch: the plugin-transform lane has no JavaScript output to
+// own, but it must still pass through the declaration outputs TypeScript-Go
+// would have emitted.
+func TestEmitWithPluginTransformerEmitDeclarationOnlyOutputs(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "strict": true
+  },
+  "include": ["src"]
+}
+`)
+  writeProjectFile(t, root, "src/index.ts", strings.Join([]string{
+    "export interface Payload {",
+    "  readonly label: string;",
+    "}",
+    "export declare const payload: Payload;",
+    "",
+  }, "\n"))
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  raw := map[string]string{}
+  if _, emitDiags, err := prog.EmitAllRaw(func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    raw[filepath.Base(fileName)] = text
+    return nil
+  }); err != nil || len(emitDiags) != 0 {
+    t.Fatalf("raw emit mismatch: diags=%#v err=%v", emitDiags, err)
+  }
+
+  transformCalled := false
+  plugin := map[string]string{}
+  transform := func(_ *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
+    transformCalled = true
+    return sf
+  }
+  if emitDiags, err := prog.EmitWithPluginTransformer(transform, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    plugin[filepath.Base(fileName)] = text
+    return nil
+  }); err != nil || len(emitDiags) != 0 {
+    t.Fatalf("plugin emit mismatch: diags=%#v err=%v", emitDiags, err)
+  }
+
+  if transformCalled {
+    t.Fatal("JavaScript transform ran during emitDeclarationOnly")
+  }
+  if got, want := sortedStringKeys(plugin), sortedStringKeys(raw); !reflect.DeepEqual(got, want) {
+    t.Fatalf("plugin emit output set mismatch:\n  got  %v\n  want %v", got, want)
+  }
+  if _, ok := plugin["index.js"]; ok {
+    t.Fatalf("emitDeclarationOnly unexpectedly emitted JavaScript: %v", sortedStringKeys(plugin))
+  }
+  for _, name := range []string{"index.d.ts", "index.d.ts.map"} {
+    if plugin[name] == "" {
+      t.Fatalf("%s was not emitted; got keys %v", name, sortedStringKeys(plugin))
+    }
+  }
+}
+
+// TestEmitWithPluginTransformerDeclarationWriteCallbackSerialized locks the
+// declaration-lane WriteFile callback contract for plugin-transform emit.
+//
+// TypeScript-Go emits one source file per goroutine. The JavaScript side of
+// EmitWithPluginTransformers is hand-assembled and serial, but the delegated dts
+// emit is still parallel. A plugin writer may be a plain output map, so ttsc
+// must serialize that callback just like EmitAllRaw does.
+func TestEmitWithPluginTransformerDeclarationWriteCallbackSerialized(t *testing.T) {
+  root := t.TempDir()
+
+  const sources = 24
+  names := make([]string, sources)
+  for i := range names {
+    names[i] = fmt.Sprintf("mod%02d", i)
+  }
+  writeProjectFile(t, root, "tsconfig.json", fmt.Sprintf(`{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "dist",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "strict": true
+  },
+  "files": [%s]
+}
+`, `"`+strings.Join(filesList(names), `", "`)+`"`))
+  for _, name := range names {
+    writeProjectFile(t, root, name+".ts", fmt.Sprintf("export const value = %q;\n", name))
+  }
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  const iterations = 100
+  for iter := 0; iter < iterations; iter++ {
+    emitted := map[string]int{}
+    emitDiags, err := prog.EmitWithPluginTransformers(nil, func(fileName, _ string, _ *shimcompiler.WriteFileData) error {
+      _ = len(emitted)
+      emitted[filepath.Base(fileName)]++
+      return nil
+    })
+    if err != nil {
+      t.Fatalf("iteration %d: %v", iter, err)
+    }
+    if len(emitDiags) != 0 {
+      t.Fatalf("iteration %d: unexpected emit diagnostics: %#v", iter, emitDiags)
+    }
+    if len(emitted) != len(names) {
+      t.Fatalf("iteration %d: expected %d declaration outputs, got %d: %#v", iter, len(names), len(emitted), emitted)
+    }
+    for _, name := range names {
+      if count := emitted[name+".d.ts"]; count != 1 {
+        t.Fatalf("iteration %d: %s.d.ts written %d times", iter, name, count)
+      }
+    }
+  }
+}
+
+// TestEmitPluginTransformersDeclarationDirOutputsSurviveOutDirContainment pins
+// the declarationDir branch for the plugin-transform emit lane.
+//
+// The JS output for a dependency source may be skipped by the forced-emit
+// outDir guard, but that decision must be per emitted path. A legitimate
+// project declaration written under declarationDir must still survive.
+func TestEmitPluginTransformersDeclarationDirOutputsSurviveOutDirContainment(t *testing.T) {
+  root := t.TempDir()
+  project := writeSelfReferencedDependencyProject(t, root)
+  writeProjectFile(t, root, "proj/tsconfig.json", `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "types",
+    "sourceMap": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+`)
+  prog, diags, err := driver.LoadProgram(project, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  written := map[string]bool{}
+  emitDiags, err := prog.EmitWithPluginTransformers(nil, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    written[filepath.ToSlash(fileName)] = true
+    return nil
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+
+  outDir := filepath.ToSlash(filepath.Join(project, "dist")) + "/"
+  declarationDir := filepath.ToSlash(filepath.Join(project, "types")) + "/"
+  saw := map[string]bool{}
+  for file := range written {
+    if !strings.HasPrefix(file, outDir) && !strings.HasPrefix(file, declarationDir) {
+      t.Fatalf("emit escaped outDir and declarationDir: %s (all writes: %v)", file, sortedBoolKeys(written))
+    }
+    switch {
+    case strings.HasSuffix(file, "/main.js"):
+      saw["main.js"] = true
+    case strings.HasSuffix(file, "/main.js.map"):
+      saw["main.js.map"] = true
+    case strings.HasSuffix(file, "/main.d.ts"):
+      saw["main.d.ts"] = true
+    case strings.HasSuffix(file, "/main.d.ts.map"):
+      saw["main.d.ts.map"] = true
+    }
+  }
+  for _, name := range []string{"main.js", "main.js.map", "main.d.ts", "main.d.ts.map"} {
+    if !saw[name] {
+      t.Fatalf("%s was not emitted; wrote %v", name, sortedBoolKeys(written))
+    }
+  }
+}
+
+func sortedStringKeys(m map[string]string) []string {
+  out := make([]string, 0, len(m))
+  for key := range m {
+    out = append(out, key)
+  }
+  sort.Strings(out)
+  return out
+}
+
+func sortedBoolKeys(m map[string]bool) []string {
+  out := make([]string, 0, len(m))
+  for key := range m {
+    out = append(out, key)
+  }
+  sort.Strings(out)
+  return out
+}

--- a/packages/ttsc/test/driver/emit_plugin_transformers_skip_outputs_outside_outdir_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_transformers_skip_outputs_outside_outdir_test.go
@@ -19,12 +19,12 @@ import (
 // self-referenced dependency's compiled `.js` into that dependency's source
 // tree on every build.
 //
-// 1. Materialize the same self-referenced dependency layout as the EmitAllRaw
-//    regression, with the project nested inside the package directory.
-// 2. Load the project with ForceEmit and emit through
-//    EmitWithPluginTransformers (no transforms).
-// 3. Assert the project's main.js is written under outDir and no write
-//    targets the dependency's source tree.
+//  1. Materialize the same self-referenced dependency layout as the EmitAllRaw
+//     regression, with the project nested inside the package directory.
+//  2. Load the project with ForceEmit and emit through
+//     EmitWithPluginTransformers (no transforms).
+//  3. Assert the project's main.js is written under outDir and no write
+//     targets the dependency's source tree.
 func TestEmitPluginTransformersSkipOutputsOutsideOutDir(t *testing.T) {
   root := t.TempDir()
   project := writeSelfReferencedDependencyProject(t, root)

--- a/packages/ttsc/test/driver/emit_raw_skips_outputs_outside_outdir_for_self_referenced_dependency_test.go
+++ b/packages/ttsc/test/driver/emit_raw_skips_outputs_outside_outdir_for_self_referenced_dependency_test.go
@@ -22,11 +22,11 @@ import (
 // dependency's own sources, outside the project entirely. The guard must skip
 // those writes while the project's own file still emits under outDir.
 //
-// 1. Materialize a dependency package whose `exports` points at raw `.ts`,
-//    with the consuming project nested inside the package directory.
-// 2. Load the project with ForceEmit and run EmitAllRaw.
-// 3. Assert the project's main.js is written under outDir and no write
-//    targets the dependency's source tree.
+//  1. Materialize a dependency package whose `exports` points at raw `.ts`,
+//     with the consuming project nested inside the package directory.
+//  2. Load the project with ForceEmit and run EmitAllRaw.
+//  3. Assert the project's main.js is written under outDir and no write
+//     targets the dependency's source tree.
 func TestEmitRawSkipsOutputsOutsideOutDirForSelfReferencedDependency(t *testing.T) {
   root := t.TempDir()
   project := writeSelfReferencedDependencyProject(t, root)

--- a/packages/ttsc/test/driver/linked_plugins_registers_and_applies_program_test.go
+++ b/packages/ttsc/test/driver/linked_plugins_registers_and_applies_program_test.go
@@ -1,6 +1,7 @@
 package driver_test
 
 import (
+  "path/filepath"
   "testing"
 
   "github.com/samchon/ttsc/packages/ttsc/driver"
@@ -65,8 +66,9 @@ func TestDriverLinkedPluginsRegistersAndAppliesProgram(t *testing.T) {
   if probe.applied != 1 || len(probe.contexts) != 2 {
     t.Fatalf("plugin hooks were not called: applied=%d contexts=%#v", probe.applied, probe.contexts)
   }
+  rootSlash := filepath.ToSlash(root)
   for _, ctx := range probe.contexts {
-    if ctx.Cwd != root || ctx.Tsconfig != "tsconfig.json" {
+    if filepath.ToSlash(ctx.Cwd) != rootSlash || ctx.Tsconfig != "tsconfig.json" {
       t.Fatalf("context paths mismatch: %#v", ctx)
     }
     if ctx.Entry.Name != "whatever" || ctx.Entry.Config["answer"] != float64(42) {

--- a/scripts/extensionless-ts-loader.mjs
+++ b/scripts/extensionless-ts-loader.mjs
@@ -5,8 +5,11 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const extensions = [".ts", ".js", ".mjs", ".cjs"];
 
 export async function resolve(specifier, context, nextResolve) {
+  const nextSpecifier = isWindowsAbsoluteFileSpecifier(specifier)
+    ? pathToFileURL(specifier).href
+    : specifier;
   try {
-    return await nextResolve(specifier, context);
+    return await nextResolve(nextSpecifier, context);
   } catch (error) {
     if (isExtensionlessFileSpecifier(specifier) === false) throw error;
 
@@ -19,7 +22,14 @@ export async function resolve(specifier, context, nextResolve) {
   }
 }
 
+function isWindowsAbsoluteFileSpecifier(specifier) {
+  return process.platform === "win32" && /^[a-zA-Z]:[\\/]/.test(specifier);
+}
+
 function isExtensionlessFileSpecifier(specifier) {
+  if (isWindowsAbsoluteFileSpecifier(specifier)) {
+    return path.extname(specifier) === "";
+  }
   if (specifier.startsWith(".") || specifier.startsWith("/")) {
     return path.extname(specifier) === "";
   }

--- a/scripts/test-go-driver.cjs
+++ b/scripts/test-go-driver.cjs
@@ -1,0 +1,28 @@
+// Run the Go unit tests for the ttsc driver package.
+//
+// The driver tests exercise the public emit and plugin-transform API directly,
+// including regressions that do not pass through utility plugin packages.
+
+const cp = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const goRoot = path.join(os.homedir(), "go-sdk", "go", "bin");
+const result = cp.spawnSync("go", ["test", "-count=1", "./test/driver"], {
+  cwd: path.join(root, "packages", "ttsc"),
+  env: {
+    ...process.env,
+    PATH: fs.existsSync(goRoot)
+      ? `${goRoot}${path.delimiter}${process.env.PATH ?? ""}`
+      : process.env.PATH,
+  },
+  stdio: "inherit",
+  windowsHide: true,
+});
+
+if (result.error) {
+  throw result.error;
+}
+process.exit(result.status ?? 1);

--- a/tests/projects/go-driver-emit-plugin/go-plugin/go.mod
+++ b/tests/projects/go-driver-emit-plugin/go-plugin/go.mod
@@ -1,0 +1,10 @@
+module go-driver-emit-plugin
+
+go 1.26
+
+require (
+	github.com/microsoft/typescript-go/shim/ast v0.0.0
+	github.com/microsoft/typescript-go/shim/compiler v0.0.0
+	github.com/microsoft/typescript-go/shim/printer v0.0.0
+	github.com/samchon/ttsc/packages/ttsc v0.0.0
+)

--- a/tests/projects/go-driver-emit-plugin/go-plugin/main.go
+++ b/tests/projects/go-driver-emit-plugin/go-plugin/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+  "flag"
+  "fmt"
+  "os"
+  "path/filepath"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+  shimprinter "github.com/microsoft/typescript-go/shim/printer"
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+func main() {
+  os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+  if len(args) == 0 {
+    fmt.Fprintln(os.Stderr, "go-driver-emit-plugin: command required")
+    return 2
+  }
+  switch args[0] {
+  case "version", "-v", "--version":
+    fmt.Fprintln(os.Stdout, "go-driver-emit-plugin 0.0.0")
+    return 0
+  case "check":
+    return 0
+  case "build":
+    return runBuild(args[1:])
+  default:
+    fmt.Fprintf(os.Stderr, "go-driver-emit-plugin: unknown command %q\n", args[0])
+    return 2
+  }
+}
+
+func runBuild(args []string) int {
+  fs := flag.NewFlagSet("build", flag.ContinueOnError)
+  fs.SetOutput(os.Stderr)
+  cwd := fs.String("cwd", "", "")
+  tsconfig := fs.String("tsconfig", "", "")
+  _ = fs.String("plugins-json", "", "")
+  _ = fs.Bool("emit", false, "")
+  _ = fs.Bool("noEmit", false, "")
+  _ = fs.Bool("quiet", false, "")
+  _ = fs.Bool("verbose", false, "")
+  _ = fs.String("outDir", "", "")
+  if err := fs.Parse(args); err != nil {
+    return 2
+  }
+  root := *cwd
+  if root == "" {
+    var err error
+    root, err = os.Getwd()
+    if err != nil {
+      fmt.Fprintln(os.Stderr, err)
+      return 2
+    }
+  }
+  tsconfigPath := *tsconfig
+  if tsconfigPath == "" {
+    tsconfigPath = filepath.Join(root, "tsconfig.json")
+  }
+
+  prog, diags, err := driver.LoadProgram(root, tsconfigPath, driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    return 2
+  }
+  if len(diags) != 0 {
+    driver.WritePrettyDiagnostics(os.Stderr, diags, root)
+    return 2
+  }
+  defer prog.Close()
+
+  emitDiags, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{replaceBeforeLiteral}, writeFile)
+  if err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    return 2
+  }
+  if len(emitDiags) != 0 {
+    driver.WritePrettyDiagnostics(os.Stderr, emitDiags, root)
+    return 2
+  }
+  return 0
+}
+
+func replaceBeforeLiteral(ec *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
+  var visitor *shimast.NodeVisitor
+  visit := func(node *shimast.Node) *shimast.Node {
+    if node == nil {
+      return node
+    }
+    if node.Kind == shimast.KindStringLiteral && node.Text() == "before" {
+      return ec.Factory.NewStringLiteral("GO DRIVER EMIT PLUGIN", 0)
+    }
+    return visitor.VisitEachChild(node)
+  }
+  visitor = ec.NewNodeVisitor(visit)
+  return visitor.VisitSourceFile(sf)
+}
+
+func writeFile(fileName, text string, _ *shimcompiler.WriteFileData) error {
+  if err := os.MkdirAll(filepath.Dir(fileName), 0o755); err != nil {
+    return err
+  }
+  return os.WriteFile(fileName, []byte(text), 0o644)
+}

--- a/tests/projects/go-driver-emit-plugin/plugin.cjs
+++ b/tests/projects/go-driver-emit-plugin/plugin.cjs
@@ -1,0 +1,6 @@
+const path = require("node:path");
+
+module.exports = (context) => ({
+  name: "go-driver-emit-plugin",
+  source: path.resolve(context.dirname, "go-plugin"),
+});

--- a/tests/projects/go-driver-emit-plugin/src/main.ts
+++ b/tests/projects/go-driver-emit-plugin/src/main.ts
@@ -1,0 +1,7 @@
+export interface Payload {
+  readonly value: string;
+}
+
+export const payload: Payload = { value: "before" };
+
+console.log(payload.value);

--- a/tests/projects/go-driver-emit-plugin/tsconfig.json
+++ b/tests/projects/go-driver-emit-plugin/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "plugins": [
+      {
+        "transform": "./plugin.cjs"
+      }
+    ]
+  },
+  "include": ["src"]
+}

--- a/tests/test-ttsc/src/features/plugin/test_plugin_corpus_driver_emit_transform_preserves_declaration_outputs.ts
+++ b/tests/test-ttsc/src/features/plugin/test_plugin_corpus_driver_emit_transform_preserves_declaration_outputs.ts
@@ -1,0 +1,81 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  copyProject,
+  fs,
+  goPath,
+  path,
+  spawn,
+  ttscBin,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: a Go source plugin that delegates project emit back
+ * through driver.EmitWithPluginTransformers preserves every tsgo output lane.
+ *
+ * This is the typia-shaped path: ttsc discovers and builds a native Go source
+ * plugin, the plugin loads the consumer project with the driver API, then emits
+ * via EmitWithPluginTransformers. The transformed JavaScript must not come at
+ * the cost of dropping declaration artifacts.
+ *
+ * 1. Copy the `go-driver-emit-plugin` fixture, which enables declaration,
+ *    declarationMap, and sourceMap.
+ * 2. Run `ttsc --emit` so the source plugin is built and executes its own
+ *    driver.EmitWithPluginTransformers build.
+ * 3. Assert `.js`, `.js.map`, `.d.ts`, and `.d.ts.map` all exist, the JS is
+ *    transformed, and the declaration map points back at `src/main.ts`.
+ */
+export const test_plugin_corpus_driver_emit_transform_preserves_declaration_outputs =
+  () => {
+    const root = copyProject("go-driver-emit-plugin");
+    const cacheDir = TestProject.tmpdir("ttsc-driver-emit-plugin-cache-");
+    const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+      cwd: root,
+      env: {
+        PATH: goPath(),
+        TTSC_CACHE_DIR: cacheDir,
+      },
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(
+      result.stderr,
+      /building source plugin "go-driver-emit-plugin"/,
+    );
+
+    for (const rel of [
+      "dist/main.js",
+      "dist/main.js.map",
+      "dist/main.d.ts",
+      "dist/main.d.ts.map",
+    ]) {
+      assert.ok(fs.existsSync(path.join(root, rel)), `${rel} was not emitted`);
+    }
+
+    const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+    assert.match(js, /GO DRIVER EMIT PLUGIN/);
+    assert.match(js, /\/\/# sourceMappingURL=main\.js\.map/);
+
+    const dts = fs.readFileSync(path.join(root, "dist", "main.d.ts"), "utf8");
+    assert.match(dts, /export interface Payload/);
+    assert.match(dts, /export declare const payload: Payload;/);
+    assert.match(dts, /\/\/# sourceMappingURL=main\.d\.ts\.map/);
+
+    const dtsMap = JSON.parse(
+      fs.readFileSync(path.join(root, "dist", "main.d.ts.map"), "utf8"),
+    ) as {
+      version?: number;
+      sources?: string[];
+      mappings?: string;
+    };
+    assert.equal(dtsMap.version, 3);
+    assert.ok(dtsMap.mappings && dtsMap.mappings.length > 0);
+    assert.ok(
+      (dtsMap.sources ?? []).some((source) =>
+        source.replace(/\\/g, "/").endsWith("src/main.ts"),
+      ),
+      `declaration map sources did not include src/main.ts: ${JSON.stringify(
+        dtsMap.sources,
+      )}`,
+    );
+  };


### PR DESCRIPTION
## Intent
Restore complete emitted output when native transform hosts, including typia-shaped hosts, build through `driver.EmitWithPluginTransformers`. The plugin path should transform JavaScript without dropping declaration files, declaration maps, or later TypeScript-Go declaration-lane outputs.

## Scope
- Keep the existing hand-assembled transformed JavaScript and JavaScript source-map emit path.
- Delegate the non-JavaScript declaration lane back to TypeScript-Go with `EmitOnlyDts` so `.d.ts` and `.d.ts.map` survive.
- Add Go driver regression tests comparing plugin-transform output sets against raw TypeScript-Go emit, including declaration maps, `emitDeclarationOnly`, declaration callback serialization, and `declarationDir` containment.
- Add a real `tests/test-ttsc` source-plugin fixture that invokes `driver.EmitWithPluginTransformers` through the CLI.
- Wire driver Go tests into `pnpm test:go`, and fix Windows-local generated-flag/extensionless-loader execution needed by those checks.

## Deferred
- Full `pnpm test` was not run locally; targeted Go, typecheck, formatting, flag, vet, and e2e coverage passed locally. I will continue reviewing while GitHub CI covers the full matrix.
- Local `pnpm build:current` currently fails on Windows in `@ttsc/unplugin` rollup `node-externals`; this is outside the declaration emit change and the Linux CI build path should decide it.

## Test Plan
- `pnpm format`
- `pnpm check:flags`
- `go test ./test/driver` from `packages/ttsc`
- `go test -count=10 ./test/driver -run TestEmitWithPluginTransformerEmitsDeclarationOutputs|TestEmitWithPluginTransformerEmitDeclarationOnlyOutputs|TestEmitWithPluginTransformerDeclarationWriteCallbackSerialized|TestEmitPluginTransformersDeclarationDirOutputsSurviveOutDirContainment` from `packages/ttsc`
- `pnpm test:go`
- `pnpm test:typecheck`
- `pnpm --filter @ttsc/test-ttsc start -- --include=driver_emit_transform_preserves_declaration_outputs`
- `pnpm --filter ttsc go:vet`

Closes #323