### PR TITLE
test(ci): shard go-binary suites + fix clean() for explicit cacheDir

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,19 +31,100 @@ jobs:
           # the e2e runner, which is POSIX-only. Only the ttsx launcher build
           # is needed (test-go-lint drives real ttsx), so the full
           # build:current is skipped.
-          - { name: windows-go, os: windows-latest, build: "pnpm --filter ttsc build", run: "pnpm run test:go" }
-          - { name: shim-audit, run: "pnpm --filter ttsc shim:audit:test && pnpm --filter ttsc shim:audit" }
-          - { name: typecheck, run: "pnpm run check:flags && pnpm run test:typecheck" }
+          - {
+              name: windows-go,
+              os: windows-latest,
+              build: "pnpm --filter ttsc build",
+              run: "pnpm run test:go",
+            }
+          - {
+              name: shim-audit,
+              run: "pnpm --filter ttsc shim:audit:test && pnpm --filter ttsc shim:audit",
+            }
+          - {
+              name: typecheck,
+              run: "pnpm run check:flags && pnpm run test:typecheck",
+            }
           - { name: banner, run: "pnpm --filter @ttsc/test-banner start" }
           - { name: factory, run: "pnpm --filter @ttsc/test-factory start" }
-          - { name: lint, run: "pnpm --filter @ttsc/test-lint start" }
           - { name: paths, run: "pnpm --filter @ttsc/test-paths start" }
           - { name: strip, run: "pnpm --filter @ttsc/test-strip start" }
-          - { name: ttsc, run: "pnpm --filter @ttsc/test-ttsc start" }
+          # test-lint and test-ttsc build real Go plugin binaries; those
+          # scenarios dominate wall time, so both suites fan out across parallel
+          # shards (balanced by the weights/spanning hints in each src/index.ts)
+          # instead of grinding cold builds serially on one lane.
+          - {
+              name: "lint 1/5",
+              run: "pnpm --filter @ttsc/test-lint start",
+              shard: "1/5",
+            }
+          - {
+              name: "lint 2/5",
+              run: "pnpm --filter @ttsc/test-lint start",
+              shard: "2/5",
+            }
+          - {
+              name: "lint 3/5",
+              run: "pnpm --filter @ttsc/test-lint start",
+              shard: "3/5",
+            }
+          - {
+              name: "lint 4/5",
+              run: "pnpm --filter @ttsc/test-lint start",
+              shard: "4/5",
+            }
+          - {
+              name: "lint 5/5",
+              run: "pnpm --filter @ttsc/test-lint start",
+              shard: "5/5",
+            }
+          - {
+              name: "ttsc 1/8",
+              run: "pnpm --filter @ttsc/test-ttsc start",
+              shard: "1/8",
+            }
+          - {
+              name: "ttsc 2/8",
+              run: "pnpm --filter @ttsc/test-ttsc start",
+              shard: "2/8",
+            }
+          - {
+              name: "ttsc 3/8",
+              run: "pnpm --filter @ttsc/test-ttsc start",
+              shard: "3/8",
+            }
+          - {
+              name: "ttsc 4/8",
+              run: "pnpm --filter @ttsc/test-ttsc start",
+              shard: "4/8",
+            }
+          - {
+              name: "ttsc 5/8",
+              run: "pnpm --filter @ttsc/test-ttsc start",
+              shard: "5/8",
+            }
+          - {
+              name: "ttsc 6/8",
+              run: "pnpm --filter @ttsc/test-ttsc start",
+              shard: "6/8",
+            }
+          - {
+              name: "ttsc 7/8",
+              run: "pnpm --filter @ttsc/test-ttsc start",
+              shard: "7/8",
+            }
+          - {
+              name: "ttsc 8/8",
+              run: "pnpm --filter @ttsc/test-ttsc start",
+              shard: "8/8",
+            }
           - { name: unplugin, run: "pnpm --filter @ttsc/test-unplugin start" }
           - { name: metro, run: "pnpm --filter @ttsc/test-metro start" }
           - { name: graph, run: "pnpm --filter @ttsc/test-graph start" }
-          - { name: graph-bench, run: "node experimental/benchmark/graph/bench.mjs --runs=3" }
+          - {
+              name: graph-bench,
+              run: "node experimental/benchmark/graph/bench.mjs --runs=3",
+            }
     steps:
       - uses: actions/checkout@v4
 
@@ -75,3 +156,6 @@ jobs:
 
       - name: Run ${{ matrix.name }}
         run: ${{ matrix.run }}
+        env:
+          # Empty for unsharded lanes → the runner executes the whole suite.
+          TTSC_TEST_SHARD: ${{ matrix.shard }}

--- a/packages/ttsc/src/TtscCompiler.ts
+++ b/packages/ttsc/src/TtscCompiler.ts
@@ -94,11 +94,24 @@ export class TtscCompiler {
    */
   public clean(): string[] {
     const projectRoot = this.resolveCleanProjectRoot();
-    // Resolve the cache root exactly as prepare() does (`cacheDir`, else
-    // `context.env.TTSC_CACHE_DIR`), and resolve the Go build cache from the
-    // ambient process env — the same source `go build` reads via goBuildEnv —
-    // so clean removes exactly what a build wrote and never a directory it did
-    // not.
+    const legacyTargets = [
+      path.join(projectRoot, "node_modules", ".ttsc"),
+      path.join(projectRoot, ".ttsc"),
+    ];
+    const explicitCacheDir = this.resolveCacheDir();
+    if (explicitCacheDir !== undefined) {
+      // An explicit constructor `cacheDir` names the cache directory for this
+      // instance — exactly like `ttsc clean --cache-dir X` on the CLI — so
+      // remove it wholesale plus the legacy project-local caches. This keeps
+      // the programmatic and CLI clean contracts identical for an explicit
+      // cache dir.
+      return removeExistingDirectories([explicitCacheDir, ...legacyTargets]);
+    }
+    // Default / `context.env.TTSC_CACHE_DIR`: resolve the cache root exactly as
+    // prepare() does (`context.env.TTSC_CACHE_DIR`) and the Go build cache from
+    // the ambient process env — the same source `go build` reads via
+    // goBuildEnv — then remove only the ttsc-owned subdirectories, so a
+    // possibly-shared root is never deleted.
     return removeExistingDirectories(
       resolveCleanTargets(
         projectRoot,

--- a/tests/test-lint/src/helpers/assertLintCase.ts
+++ b/tests/test-lint/src/helpers/assertLintCase.ts
@@ -17,13 +17,31 @@ const casesRoot = path.join(process.cwd(), "src", "cases");
  * the first non-blank line. The reason is required and acts as the inline
  * docstring for the exclusion. Skipped fixtures are still required to live in
  * the tree (their Go-side rule corpus test stays the source of truth).
+ *
+ * Under a sharded CI run (`TTSC_TEST_SHARD_ACTIVE=<i>/<N>`) this test executes
+ * in every shard but runs only its `index % N === i - 1` slice of the (evenly
+ * costed) fixtures, so the corpus fans out across the parallel lint lanes
+ * instead of pinning a single one. The empty-corpus guard still checks the full
+ * discovered tree in every shard.
  */
 export function assertAllLintCases(): void {
   const cases = listLintCases();
   assert.notEqual(cases.length, 0, "expected at least one lint fixture");
-  for (const file of cases) {
+  for (const file of shardCases(cases)) {
     assertLintCase(file);
   }
+}
+
+/** Keep only this shard's slice of the corpus, or all of it when unsharded. */
+function shardCases(cases: string[]): string[] {
+  const active = process.env.TTSC_TEST_SHARD_ACTIVE;
+  if (!active) return cases;
+  const parts = active.split("/");
+  const index = Number(parts[0]);
+  const total = Number(parts[1]);
+  if (!Number.isFinite(index) || !Number.isFinite(total) || total < 1)
+    return cases;
+  return cases.filter((_, i) => i % total === index - 1);
 }
 
 /**

--- a/tests/test-lint/src/index.ts
+++ b/tests/test-lint/src/index.ts
@@ -3,6 +3,17 @@ import path from "node:path";
 
 TestExecutor.main({
   location: path.join(process.cwd(), "src", "features"),
+  // The 600+ fixture corpus dominates wall time; it runs in every shard and
+  // slices its own case list by `TTSC_TEST_SHARD_ACTIVE`, so it must not pin a
+  // whole lane. The remaining heavy tests each rebuild the native lint engine.
+  spanning: ["test_lint_rules_corpus_matches_expected_diagnostics"],
+  weights: {
+    test_lint_fix_contributor_rule_single_edit_applies_through_native_engine: 116000,
+    test_lint_config_file_wrapper_tsconfig_outside_cwd_discovers_wrapper_config: 114000,
+    test_lint_config_discovered_lint_config_file_applies_without_tsconfig_key: 113000,
+    test_lint_contributor_plugin_discovered_from_lint_config_ts: 13000,
+    test_lint_fix_native_project_rewrites_temp_copy_only: 12000,
+  },
 }).catch((error) => {
   console.error(error);
   process.exit(1);

--- a/tests/test-ttsc/src/index.ts
+++ b/tests/test-ttsc/src/index.ts
@@ -3,6 +3,29 @@ import path from "node:path";
 
 TestExecutor.main({
   location: path.join(process.cwd(), "src", "features"),
+  // Balancing hints for `--shard`: the go-binary-building scenarios (native
+  // plugin + source-plugin compiles) that dominate wall time, so a sharded CI
+  // run spreads them evenly instead of stacking cold builds on one lane.
+  // Approximate milliseconds from a profiling run; refresh when the ordering
+  // drifts. Every unlisted test is cheap and spread by a name hash.
+  weights: {
+    test_ttsc_go_package_tests_pass: 160000,
+    test_ttscservice_transforms_a_file_through_the_resident_host: 144000,
+    test_ttscservice_rejects_when_the_project_does_not_compile: 143000,
+    test_ttscservice_reflects_a_file_update_through_the_resident_host: 141000,
+    test_ttsc_utility_plugins_lint_banner_paths_and_strip_run_together_in_ttsc_build: 139000,
+    test_ttsc_utility_plugins_shared_transform_host_works_when_paths_is_first: 115000,
+    test_ttsx_builds_a_dependency_with_its_own_transform_plugin: 113000,
+    test_ttsccompiler_can_disable_project_plugin_loading: 113000,
+    test_plugin_corpus_ttsc_lint_option_changes_reuse_the_source_plugin_binary_cache: 113000,
+    test_plugin_corpus_auto_discovered_ttsc_lint_fails_when_no_config_file_exists: 112000,
+    test_plugin_corpus_driver_emit_transform_preserves_declaration_outputs: 110000,
+    test_plugin_corpus_source_plugin_walks_ast_uses_checker_to_enumerate_interface_properties: 100000,
+    test_plugin_corpus_source_plugin_bootstraps_a_program_and_checker_against_the_consumer_tsconfig: 99000,
+    test_plugin_corpus_source_plugin_can_import_tsgo_shim_modules_via_go_work_overlay: 52000,
+    test_ttsc_utility_plugins_forced_emit_confines_output_to_outdir: 22000,
+    test_ttsc_utility_plugins_paths_side_loads_into_driver_host: 14000,
+  },
 }).catch((error) => {
   console.error(error);
   process.exit(1);

--- a/tests/utils/src/TestExecutor.ts
+++ b/tests/utils/src/TestExecutor.ts
@@ -4,13 +4,35 @@ import { DynamicExecutor } from "@nestia/e2e";
  * Shared feature-test runner used by the package-shaped test projects.
  *
  * Test packages expose each scenario as a `test_*` function; this wrapper keeps
- * discovery, include/exclude filtering, and console reporting identical across
- * compiler, runner, lint, and plugin suites.
+ * discovery, include/exclude filtering, sharding, and console reporting
+ * identical across compiler, runner, lint, and plugin suites.
  */
 export namespace TestExecutor {
   /** Location of the feature module tree that DynamicExecutor scans. */
   export interface IProps {
     location: string;
+    /**
+     * Approximate per-test cost (milliseconds) for the heavy,
+     * go-binary-building scenarios. When a `--shard` is requested these are
+     * Longest-Processing-Time bin-packed across shards so each parallel lane
+     * carries a balanced slice of the expensive native builds; every other
+     * (cheap) test is spread by a stable name hash. Only the heavy tests need
+     * an entry — the map is a balancing hint, not an allow-list.
+     */
+    weights?: Record<string, number>;
+    /**
+     * Test-name substrings for scenarios that run in **every** shard and slice
+     * their own workload internally (via `TTSC_TEST_SHARD_ACTIVE`). Use this
+     * for a single data-driven corpus test that would otherwise pin a whole
+     * shard; such a test must read the env and run only its slice.
+     */
+    spanning?: string[];
+  }
+
+  /** One shard's position within the parallel matrix (0-based index). */
+  interface IShard {
+    index: number;
+    total: number;
   }
 
   /**
@@ -18,11 +40,15 @@ export namespace TestExecutor {
    *
    * Command-line filters intentionally match by substring so a failing scenario
    * can be rerun from any package with `--include=<case-name>` without adding
-   * package-specific runner switches.
+   * package-specific runner switches. `--shard=<i>/<N>` (1-based) — or the
+   * `TTSC_TEST_SHARD` env — restricts a run to one balanced slice of the suite
+   * so CI can fan the go-binary-building suites across parallel lanes.
    */
   export const main = async (props: IProps): Promise<void> => {
     const include = getArguments("include");
     const exclude = getArguments("exclude");
+    const shard = resolveShard();
+    const shardFilter = buildShardFilter(props, shard);
     const started = Date.now();
     const report: DynamicExecutor.IReport = await DynamicExecutor.validate({
       prefix: "test_",
@@ -48,13 +74,16 @@ export namespace TestExecutor {
       },
       filter: (name) =>
         (include.length ? include.some((str) => name.includes(str)) : true) &&
-        (exclude.length ? exclude.every((str) => !name.includes(str)) : true),
+        (exclude.length ? exclude.every((str) => !name.includes(str)) : true) &&
+        shardFilter(name),
     });
 
     if (report.executions.length === 0) {
       const reason = include.length
         ? `No tests matched --include=${include.join(",")}`
-        : `No tests were discovered under ${props.location}`;
+        : shard
+          ? `No tests fell into shard ${shard.index + 1}/${shard.total} under ${props.location}`
+          : `No tests were discovered under ${props.location}`;
       console.error(reason);
       process.exit(1);
     }
@@ -63,6 +92,12 @@ export namespace TestExecutor {
       .filter((exec) => exec.error !== null)
       .map((exec) => exec.error!);
     for (const error of exceptions) console.error(error);
+    if (shard)
+      console.log(
+        `Shard ${shard.index + 1}/${shard.total}:`,
+        report.executions.length,
+        "tests",
+      );
     console.log(exceptions.length ? "Failed" : "Success");
     console.log(
       "Elapsed time",
@@ -81,5 +116,84 @@ export namespace TestExecutor {
       .flatMap((arg) => arg.slice(prefix.length).split(","))
       .map((arg) => arg.trim())
       .filter(Boolean);
+  }
+
+  /**
+   * Parse `--shard=<i>/<N>` (1-based) from argv, else the `TTSC_TEST_SHARD`
+   * env.
+   */
+  function resolveShard(): IShard | null {
+    const raw =
+      getArguments("shard").at(-1) ?? process.env.TTSC_TEST_SHARD ?? "";
+    if (!raw) return null;
+    const match = /^(\d+)\/(\d+)$/.exec(raw.trim());
+    if (!match)
+      throw new Error(
+        `Invalid --shard "${raw}"; expected "<i>/<N>" (1-based).`,
+      );
+    const index = Number(match[1]) - 1;
+    const total = Number(match[2]);
+    if (total < 1 || index < 0 || index >= total)
+      throw new Error(`Invalid --shard "${raw}"; need 1 <= i <= N.`);
+    return { index, total };
+  }
+
+  /**
+   * Build the shard membership predicate. Heavy (weighted) tests are LPT
+   * bin-packed for balance, spanning tests join every shard (and self-slice via
+   * `TTSC_TEST_SHARD_ACTIVE`), and everything else is spread by a stable hash.
+   */
+  function buildShardFilter(
+    props: IProps,
+    shard: IShard | null,
+  ): (name: string) => boolean {
+    if (shard === null) return () => true;
+    // Publish the active shard so a spanning corpus test can run its own slice.
+    process.env.TTSC_TEST_SHARD_ACTIVE = `${shard.index + 1}/${shard.total}`;
+    const spanning = props.spanning ?? [];
+    const pinned = packWeighted(props.weights ?? {}, shard.total);
+    return (name) => {
+      if (spanning.some((needle) => name.includes(needle))) return true;
+      const bin = pinned.get(name) ?? hash(name) % shard.total;
+      return bin === shard.index;
+    };
+  }
+
+  /**
+   * Longest-Processing-Time bin-packing: assign each weighted test (heaviest
+   * first) to the currently lightest shard, minimizing the busiest shard.
+   */
+  function packWeighted(
+    weights: Record<string, number>,
+    total: number,
+  ): Map<string, number> {
+    const load = new Array<number>(total).fill(0);
+    const pinned = new Map<string, number>();
+    for (const [name, weight] of Object.entries(weights).sort(
+      (a, b) => b[1] - a[1],
+    )) {
+      let lightest = 0;
+      let lightestLoad = load[0] ?? 0;
+      for (let i = 1; i < total; i++) {
+        const current = load[i] ?? 0;
+        if (current < lightestLoad) {
+          lightest = i;
+          lightestLoad = current;
+        }
+      }
+      load[lightest] = lightestLoad + weight;
+      pinned.set(name, lightest);
+    }
+    return pinned;
+  }
+
+  /** FNV-1a: deterministic, well-distributed name hash for cheap-test spread. */
+  function hash(text: string): number {
+    let value = 2166136261;
+    for (let i = 0; i < text.length; i++) {
+      value ^= text.charCodeAt(i);
+      value = Math.imul(value, 16777619);
+    }
+    return value >>> 0;
   }
 }

--- a/website/src/content/docs/ttsc/api.mdx
+++ b/website/src/content/docs/ttsc/api.mdx
@@ -119,13 +119,15 @@ Removes the cache directories owned by this compiler's context. Returns the list
 compiler.clean();
 ```
 
-`clean()` resolves the cache root from this context — `cacheDir`/`TTSC_CACHE_DIR` when set, otherwise the default workspace-local `node_modules/.cache/ttsc` — and removes only the ttsc-owned pieces:
+When the context sets an explicit `cacheDir`, `clean()` removes that directory **wholesale** (plus the legacy `node_modules/.ttsc` and `.ttsc` caches) — the same contract as `ttsc clean --cache-dir <dir>` on the CLI. An explicit `cacheDir` names a directory dedicated to ttsc, so nothing is left behind.
+
+Otherwise — the default workspace-local `node_modules/.cache/ttsc`, or a root resolved from `TTSC_CACHE_DIR` — it removes only the ttsc-owned pieces:
 
 1. the compiled plugin binaries (`<cache-root>/plugins`);
 2. the ttsc-owned Go object cache (`<cache-root>/go-build`, plus an explicit `TTSC_GO_CACHE_DIR` when it points elsewhere);
 3. the legacy project-local caches (`node_modules/.ttsc`, `.ttsc`).
 
-The parent cache root itself is never removed (it may be shared with other tools), and a user-provided `GOCACHE` is treated as external and left untouched.
+In that case the parent cache root itself is never removed (it may be shared with other tools), and a user-provided `GOCACHE` is treated as external and left untouched.
 
 ## Resident transform service (`TtscService`)
 


### PR DESCRIPTION
Follow-up to #327. Unbreaks the `ttsc` test lane it left red and cuts the two slowest CI lanes down with parallel sharding, so 0.17.0 ships green.

## 1. Fix: `clean()` regression from #327 (master is currently red)

#327's project-local cache reshaped `TtscCompiler.clean()` to remove only the ttsc-owned `plugins/` + `go-build/` subdirectories. That is right for the default / `TTSC_CACHE_DIR` root (possibly shared), but for an **explicit constructor `cacheDir`** it left the now-empty directory behind and diverged from the CLI, where `ttsc clean --cache-dir X` removes `X` wholesale — breaking the merged api test `test_ttsccompiler_prepare_builds_source_plugins_and_clean_removes_context_cache` (the `ttsc` lane failed *after* the squash-merge landed).

An explicit `cacheDir` names a directory dedicated to ttsc, so `clean()` now removes it wholesale (plus the legacy `.ttsc` caches), matching the CLI. The default / `TTSC_CACHE_DIR` path is unchanged. Docs (`api.mdx`) updated.

## 2. Split + parallelize the go-binary test suites

Profiling the merged run: `ttsc` **34.5 min**, `lint` **16.8 min** — both dominated by the scenarios that cold-build real Go plugin binaries (native `@ttsc/lint`/`banner`/`paths`/`strip` + source-plugin corpus), run serially in a single job.

`TestExecutor` gains `--shard=<i>/<N>` (or `TTSC_TEST_SHARD`):
- heavy tests listed in each suite's `weights` map are **LPT bin-packed** across shards for balance;
- a `spanning` corpus test runs in **every** shard and slices its own workload via `TTSC_TEST_SHARD_ACTIVE` (the 620-fixture lint corpus; `walk()` already sorts deterministically, so slices are disjoint and cover the whole corpus);
- every other cheap test is spread by a stable FNV-1a name hash.

Each test therefore runs in exactly one shard (verified: 0 coverage violations over the 264 test-ttsc + 41 test-lint names). Unsharded lanes pass an empty `TTSC_TEST_SHARD` and run the whole suite unchanged — fully backward compatible for `banner`/`paths`/`strip`/`graph`/`metro`/`unplugin`/`factory`.

`test.yml`: `ttsc` → 8 shards (heaviest ~4.3 min of tests), `lint` → 5 shards (corpus self-slices ~5-way, heaviest ~3.2 min).

### Expected wall-clock
Per-job fixed overhead (checkout + install + `build:current`) is ~4 min (ttsc) / ~6 min (lint), which is the remaining floor. Slowest lane drops **34.5 → ~8 min** (ttsc) and **16.8 → ~9 min** (lint) — a ~4× cut on the critical path.

### Notes
- This adds 11 matrix jobs (25 total). If the org's concurrent-job cap is below that, some shards queue; raise the cap or lower `N` to tune. Trimming the fixed overhead (pnpm-store cache, sharing the native builds) is a good future follow-up.
- `weights` are approximate ms from a profiling run and are balancing hints only — a stale entry costs balance, never correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)