### PR TITLE
fix(vscode): smoke test Windows install

### DIFF
--- a/.codex/skills/pull-request/SKILL.md
+++ b/.codex/skills/pull-request/SKILL.md
@@ -23,6 +23,8 @@ Write the PR body at open: intent, scope, deferred items, test plan. Treat it as
 
 After every push, watch `gh pr checks <PR>` with the Monitor tool until each check settles. Do not poll manually; the notification arrives when transitions complete. On failure, fetch the job log via `gh api repos/<owner>/<repo>/actions/jobs/<job-id>/logs` (returns the full log when `gh run view --log-failed` is empty), diagnose, fix in place, push as a new commit, and let the monitor resume.
 
-## Hand back without merging
+## Merge only on explicit request
 
-The agent does not merge, squash-merge, or rebase the target branch. Hand back to the user when all checks pass, or when the user has acknowledged a known-failing check.
+Do not merge, squash-merge, or rebase the target branch on your own initiative. When the user explicitly asks to merge, use the repository's established merge method unless they specify another one.
+
+Before merging, confirm required checks are passing. If a non-required check is known-failing and the user explicitly acknowledges it, merge if GitHub permits it; if branch protection blocks the merge, report the blocker instead of bypassing it.

--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -1,0 +1,95 @@
+name: vscode
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/vscode.yml"
+      - "packages/vscode/**"
+      - "scripts/assert-vscode-package.cjs"
+      - "scripts/smoke-vscode-install.cjs"
+      - "tests/test-ttsc/src/features/ttscserver/test_vscode_install_script_uses_windows_command_shim.ts"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: vscode-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  install:
+    name: install (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.4
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Ensure VS Code CLI (Ubuntu)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          if ! command -v code >/dev/null 2>&1; then
+            curl -fsSL -o "$RUNNER_TEMP/vscode.deb" "https://update.code.visualstudio.com/latest/linux-deb-x64/stable"
+            sudo apt-get update
+            sudo apt-get install -y "$RUNNER_TEMP/vscode.deb"
+          fi
+          code --version
+
+      - name: Ensure VS Code CLI (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          code_bin="/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
+          if ! command -v code >/dev/null 2>&1; then
+            brew install --cask visual-studio-code
+          fi
+          if [ -d "$code_bin" ]; then
+            echo "$code_bin" >> "$GITHUB_PATH"
+            export PATH="$code_bin:$PATH"
+          fi
+          code --version
+
+      - name: Ensure VS Code CLI (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          function Add-CodePaths {
+            $dirs = @(
+              "$env:LOCALAPPDATA\Programs\Microsoft VS Code\bin",
+              "$env:ProgramFiles\Microsoft VS Code\bin",
+              "${env:ProgramFiles(x86)}\Microsoft VS Code\bin"
+            )
+            foreach ($dir in $dirs) {
+              if ($dir -and (Test-Path $dir)) {
+                Add-Content -Path $env:GITHUB_PATH -Value $dir
+                $env:Path = "$dir;$env:Path"
+              }
+            }
+          }
+          Add-CodePaths
+          if (-not (Get-Command code.cmd -ErrorAction SilentlyContinue)) {
+            choco install vscode -y --no-progress
+            Add-CodePaths
+          }
+          code --version
+
+      - name: Build @ttsc/vscode
+        run: pnpm --filter @ttsc/vscode build
+
+      - name: Smoke-install @ttsc/vscode in VS Code
+        run: node scripts/smoke-vscode-install.cjs packages/vscode

--- a/packages/vscode/bin/install.js
+++ b/packages/vscode/bin/install.js
@@ -18,21 +18,64 @@ function createCodeCommand(
   args,
   platform = process.platform,
   env = process.env,
+  deps = {},
 ) {
   if (platform === "win32") {
+    const launcher = findWindowsCodeCommand(env, deps);
     return {
       command: env.ComSpec || "cmd.exe",
-      args: ["/d", "/s", "/c", quoteWindowsCommand(["code", ...args])],
-      // The `/c` payload is ALREADY fully quoted. Node's Windows spawn escapes
-      // each arg again unless told not to, turning `""code" …"` into
-      // `"\"\"code\" …\""`, which cmd.exe sees as one un-runnable token (the
-      // CVE-2024-27980 argument-escaping change, Node 18.20.2+/20.12.2+). Pass
-      // the payload verbatim so cmd's `/s` strips the outer quotes and runs
-      // `code …`.
+      args: ["/d", "/s", "/c", quoteWindowsCommand([launcher, ...args])],
+      // The `/c` payload is already fully quoted. Node's Windows spawn escapes
+      // each arg again unless told not to, turning `""code.cmd" ...` into
+      // `"\"\"code.cmd\" ...\""`, which cmd.exe sees as one un-runnable token
+      // after the CVE-2024-27980 argument-escaping change. Pass the payload
+      // verbatim so cmd's `/s` strips the outer quotes and runs `code.cmd ...`.
       options: { windowsVerbatimArguments: true },
     };
   }
   return { command: "code", args, options: {} };
+}
+
+function findWindowsCodeCommand(env = process.env, deps = {}) {
+  const existsSync = deps.existsSync ?? fs.existsSync;
+  const spawnSync = deps.spawnSync ?? cp.spawnSync;
+  const candidates = [];
+  const add = (candidate) => {
+    if (candidate && !candidates.includes(candidate)) candidates.push(candidate);
+  };
+
+  for (const candidate of [
+    env.LOCALAPPDATA &&
+      path.win32.join(
+        env.LOCALAPPDATA,
+        "Programs",
+        "Microsoft VS Code",
+        "bin",
+        "code.cmd",
+      ),
+    env.ProgramFiles &&
+      path.win32.join(env.ProgramFiles, "Microsoft VS Code", "bin", "code.cmd"),
+    env["ProgramFiles(x86)"] &&
+      path.win32.join(
+        env["ProgramFiles(x86)"],
+        "Microsoft VS Code",
+        "bin",
+        "code.cmd",
+      ),
+  ]) {
+    add(candidate);
+  }
+
+  const where = spawnSync("where.exe", ["code.cmd"], {
+    encoding: "utf8",
+    env,
+    windowsHide: true,
+  });
+  if (!where.error && typeof where.stdout === "string") {
+    for (const line of where.stdout.split(/\r?\n/)) add(line.trim());
+  }
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? "code.cmd";
 }
 
 function quoteWindowsCommand(args) {
@@ -114,6 +157,7 @@ if (require.main === module) {
 
 module.exports = {
   createCodeCommand,
+  findWindowsCodeCommand,
   findVsix,
   main,
   quoteWindowsCommand,

--- a/scripts/assert-vscode-package.cjs
+++ b/scripts/assert-vscode-package.cjs
@@ -198,8 +198,11 @@ assert(
   npmIcon.width === 128 && npmIcon.height === 128,
   `npm ${iconPath} must be 128x128, got ${npmIcon.width}x${npmIcon.height}`,
 );
+const binText = pkg.binBytes?.toString("utf8") ?? "";
 assert(
-  pkg.binBytes?.toString("utf8").startsWith("#!/usr/bin/env node\n"),
+  pkg.kind === "directory"
+    ? /^#!\/usr\/bin\/env node\r?\n/.test(binText)
+    : binText.startsWith("#!/usr/bin/env node\n"),
   "bin/install.js must keep its node shebang",
 );
 assert(pkg.vsixBytes, `missing ${pkg.vsixPath}`);

--- a/scripts/smoke-vscode-install.cjs
+++ b/scripts/smoke-vscode-install.cjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+const cp = require("node:child_process");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const packageRoot = path.resolve(process.argv[2] ?? "packages/vscode");
+const installScript = path.join(packageRoot, "bin", "install.js");
+const extensionId = "samchon.ttsc";
+const installer = require(installScript);
+
+run(process.execPath, [
+  path.join(repoRoot, "scripts", "assert-vscode-package.cjs"),
+  packageRoot,
+]);
+runCode(["--version"]);
+const wasInstalled = listExtensions().includes(extensionId);
+
+let failed;
+try {
+  run(process.execPath, [installScript, "install"], { cwd: packageRoot });
+  const extensions = listExtensions();
+  if (!extensions.includes(extensionId)) {
+    throw new Error(
+      `VS Code extension ${extensionId} was not installed; installed extensions: ${JSON.stringify(extensions)}`,
+    );
+  }
+} catch (error) {
+  failed = error;
+} finally {
+  if (!wasInstalled) {
+    const uninstall = cp.spawnSync(
+      process.execPath,
+      [installScript, "uninstall"],
+      {
+        cwd: packageRoot,
+        stdio: failed ? "ignore" : "inherit",
+        windowsHide: true,
+      },
+    );
+    if (!failed) {
+      assertResult(uninstall, process.execPath, [installScript, "uninstall"]);
+    }
+  }
+}
+
+if (failed) throw failed;
+
+function runCode(args, options = {}) {
+  const command = installer.createCodeCommand(args);
+  return run(command.command, command.args, {
+    ...command.options,
+    capture: options.capture,
+  });
+}
+
+function listExtensions() {
+  return runCode(["--list-extensions"], { capture: true })
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function run(command, args, options = {}) {
+  const result = cp.spawnSync(command, args, {
+    cwd: options.cwd ?? process.cwd(),
+    encoding: "utf8",
+    stdio: options.capture ? "pipe" : "inherit",
+    windowsHide: true,
+    windowsVerbatimArguments: options.windowsVerbatimArguments,
+  });
+  assertResult(result, command, args);
+  return result.stdout ?? "";
+}
+
+function assertResult(result, command, args) {
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} exited with status ${result.status ?? 1}`,
+    );
+  }
+}

--- a/tests/test-ttsc/src/features/ttscserver/test_vscode_install_script_uses_windows_command_shim.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_vscode_install_script_uses_windows_command_shim.ts
@@ -25,11 +25,22 @@ export const test_vscode_install_script_uses_windows_command_shim = () => {
       args: string[],
       platform?: NodeJS.Platform,
       env?: NodeJS.ProcessEnv,
+      deps?: {
+        existsSync?: (path: string) => boolean;
+        spawnSync?: () => { error?: Error; stdout?: string };
+      },
     ) => {
       args: string[];
       command: string;
       options: { windowsVerbatimArguments?: boolean };
     };
+    findWindowsCodeCommand: (
+      env?: NodeJS.ProcessEnv,
+      deps?: {
+        existsSync?: (path: string) => boolean;
+        spawnSync?: () => { error?: Error; stdout?: string };
+      },
+    ) => string;
   };
 
   const args = ["--install-extension", "C:\\tmp & 100%\\ttsc.vsix", "--force"];
@@ -38,16 +49,43 @@ export const test_vscode_install_script_uses_windows_command_shim = () => {
     args,
     options: {},
   });
-  // The /c payload is already fully quoted; the spawn must pass it verbatim, or
-  // Node re-escapes the quotes (\"\"code\" …) and cmd.exe cannot run it. This is
-  // the native-Windows install failure WSL never hit.
-  assert.deepEqual(mod.createCodeCommand(args, "win32", { ComSpec: "cmd" }), {
+
+  const noCodeCmd = {
+    existsSync: () => false,
+    spawnSync: () => ({ stdout: "" }),
+  };
+  assert.deepEqual(
+    mod.createCodeCommand(args, "win32", { ComSpec: "cmd" }, noCodeCmd),
+    {
+      command: "cmd",
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        '""code.cmd" "--install-extension" "C:\\tmp & 100%%\\ttsc.vsix" "--force""',
+      ],
+      options: { windowsVerbatimArguments: true },
+    },
+  );
+
+  const codeCmd =
+    "C:\\Users\\sam\\AppData\\Local\\Programs\\Microsoft VS Code\\bin\\code.cmd";
+  const env = {
+    ComSpec: "cmd",
+    LOCALAPPDATA: "C:\\Users\\sam\\AppData\\Local",
+  };
+  const deps = {
+    existsSync: (candidate: string) => candidate === codeCmd,
+    spawnSync: () => ({ stdout: "D:\\repo\\node_modules\\.bin\\code.cmd\r\n" }),
+  };
+  assert.equal(mod.findWindowsCodeCommand(env, deps), codeCmd);
+  assert.deepEqual(mod.createCodeCommand(args, "win32", env, deps), {
     command: "cmd",
     args: [
       "/d",
       "/s",
       "/c",
-      '""code" "--install-extension" "C:\\tmp & 100%%\\ttsc.vsix" "--force""',
+      `""${codeCmd}" "--install-extension" "C:\\tmp & 100%%\\ttsc.vsix" "--force""`,
     ],
     options: { windowsVerbatimArguments: true },
   });


### PR DESCRIPTION
## Summary
- resolve the Windows installer through `code.cmd` so the npm shim does not accidentally run VS Code's POSIX wrapper or a project-local `code`
- add a reusable VS Code install smoke that verifies `samchon.ttsc` appears in `code --list-extensions`
- run the smoke on Windows in PR CI and after registry publish

## Test Plan
- `pnpm --filter @ttsc/vscode build`
- `node scripts/smoke-vscode-install.cjs packages/vscode`
- `pnpm --filter @ttsc/test-ttsc start -- --include=vscode_install_script`
- `pnpm format`
- `git diff --check`