### PR TITLE
fix(lint): load TS configs through file URLs

### DIFF
--- a/.github/workflows/nestia.yml
+++ b/.github/workflows/nestia.yml
@@ -60,26 +60,12 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Mirror nestia (next)'s own test.yml matrix so each suite runs in parallel,
-  # but against the local ttsc tarballs instead of the published release.
+  # Run nestia (next)'s standard test suite against the local ttsc tarballs
+  # instead of the published release.
   nestia:
     needs: tarballs
-    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { name: go, run: "pnpm test:go" }
-          - { name: sdk, run: "pnpm --filter ./tests/test-sdk start" }
-          - { name: migrate, run: "pnpm --filter ./tests/test-migrate start" }
-          - {
-              name: transform-options,
-              run: "pnpm --filter ./tests/test-transform-options start",
-            }
-          - { name: e2e, run: "pnpm --filter ./tests/test-e2e start" }
-          - { name: benchmark, run: "pnpm --filter ./tests/test-benchmark start" }
     steps:
       - uses: actions/checkout@v4
 
@@ -147,8 +133,8 @@ jobs:
           NODE_OPTIONS: --no-experimental-strip-types --no-experimental-detect-module
         run: pnpm build
 
-      - name: Run ${{ matrix.name }}
+      - name: Test nestia
         working-directory: experimental/nestia
         env:
           NODE_OPTIONS: --no-experimental-strip-types --no-experimental-detect-module
-        run: ${{ matrix.run }}
+        run: pnpm test

--- a/experimental/install/src/index.ts
+++ b/experimental/install/src/index.ts
@@ -29,6 +29,7 @@ function main() {
   verifyInstalledPackages();
   verifyTtscBuild();
   verifyTtsxRun();
+  verifyLintConfigLoaderWithRealpathTemp();
   console.log("Success");
 }
 
@@ -286,6 +287,92 @@ function verifyTtsxRun() {
   );
 }
 
+function verifyLintConfigLoaderWithRealpathTemp() {
+  const base = path.join(experimentRoot, ".tmp", "realpath-temp");
+  const realTemp = path.join(base, "private", "var");
+  const linkTemp = path.join(base, "var");
+  const project = path.join(base, "Users", "project");
+
+  fs.rmSync(base, { recursive: true, force: true });
+  fs.mkdirSync(realTemp, { recursive: true });
+  fs.mkdirSync(path.join(project, "src"), { recursive: true });
+  fs.symlinkSync(
+    realTemp,
+    linkTemp,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+  fs.symlinkSync(
+    path.join(workspace, "node_modules"),
+    path.join(project, "node_modules"),
+    process.platform === "win32" ? "junction" : "dir",
+  );
+  fs.writeFileSync(
+    path.join(project, "package.json"),
+    JSON.stringify(
+      {
+        private: true,
+        name: "@ttsc/experiment-lint-realpath-temp",
+        version: "0.0.0",
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(
+    path.join(project, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          noEmit: true,
+          rootDir: "src",
+          plugins: [
+            {
+              transform: "@ttsc/lint",
+              configFile: "./lint.config.ts",
+            },
+          ],
+        },
+        include: ["src"],
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(
+    path.join(project, "lint.config.ts"),
+    [
+      "export default {",
+      "  rules: {",
+      '    "no-var": "error",',
+      "  },",
+      "};",
+      "",
+    ].join("\n"),
+  );
+  fs.writeFileSync(path.join(project, "src", "main.ts"), "var value = 1;\n");
+
+  const result = spawnInstalledTtsc(["--cwd", ".", "--noEmit"], project, {
+    TMPDIR: linkTemp,
+    TMP: linkTemp,
+    TEMP: linkTemp,
+  });
+  assert(
+    result.status !== 0,
+    "installed ttsc lint realpath-temp check must report the configured rule",
+  );
+  assert(
+    result.stderr.includes("[no-var]"),
+    `installed ttsc lint realpath-temp check must load lint.config.ts and report no-var, got:\n${result.stderr}`,
+  );
+  assert(
+    !result.stderr.includes("ERR_MODULE_NOT_FOUND"),
+    `installed ttsc lint realpath-temp check must not lose lint.config.ts through loader realpath drift:\n${result.stderr}`,
+  );
+}
+
 function assertConsoleOutput(command, stdout, expected) {
   const actual = stdout.trim();
   assert(
@@ -352,6 +439,15 @@ function runNode(args, cwd, label) {
 }
 
 function runInstalledTtsc(args, cwd) {
+  const result = spawnInstalledTtsc(args, cwd);
+  assert(
+    result.status === 0,
+    `installed ttsc failed with status ${result.status}`,
+  );
+  return result;
+}
+
+function spawnInstalledTtsc(args, cwd, extraEnv = {}) {
   const launcher = path.join(
     cwd,
     "node_modules",
@@ -372,6 +468,15 @@ function runInstalledTtsc(args, cwd) {
   );
   assert(fs.existsSync(launcher), "installed ttsc launcher must exist");
   assert(fs.existsSync(embeddedGo), "embedded Go compiler must exist");
+  const ttsx = path.join(
+    cwd,
+    "node_modules",
+    "ttsc",
+    "lib",
+    "launcher",
+    "ttsx.js",
+  );
+  assert(fs.existsSync(ttsx), "installed ttsx launcher must exist");
 
   console.log(`$ node ${path.relative(cwd, launcher)} ${args.join(" ")}`);
   const result = cp.spawnSync(process.execPath, [launcher, ...args], {
@@ -379,17 +484,15 @@ function runInstalledTtsc(args, cwd) {
     encoding: "utf8",
     env: {
       ...process.env,
+      ...extraEnv,
       TTSC_GO_BINARY: embeddedGo,
+      TTSC_TTSX_BINARY: ttsx,
     },
     maxBuffer: 1024 * 1024 * 64,
     windowsHide: true,
   });
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);
-  assert(
-    result.status === 0,
-    `installed ttsc failed with status ${result.status}`,
-  );
   return result;
 }
 

--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -1268,11 +1268,12 @@ func fileURL(location string) string {
 
 // typeScriptConfigLoaderSource returns the TypeScript source of the ephemeral
 // loader script that ttsx executes to evaluate a TypeScript lint config file.
-// `importLiteral` is a JSON-encoded relative import path (e.g. `"./lint.config.ts"`)
-// that is spliced directly into the `import * as` statement, so it must
-// already be a valid JSON string (produced by json.Marshal).
+// `importLiteral` is a JSON-encoded file URL (produced by json.Marshal). It is
+// assigned to a variable before `import(configUrl)` so tsgo does not try to
+// statically resolve the file URL during the loader build.
 func typeScriptConfigLoaderSource(importLiteral string) string {
-  return fmt.Sprintf(`const importedConfig = await import(%s);
+  return fmt.Sprintf(`const configUrl = %s;
+const importedConfig = await import(configUrl);
 
 declare const process: {
   stdout: { write(value: string): void };

--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -1242,28 +1242,46 @@ func isConfigObject(value any) bool {
   return ok
 }
 
-// relativeImportSpecifier computes the ESM import specifier for `location`
-// relative to `fromDir`. The result always starts with "./" or "../" so it is
-// treated as a relative path by the ESM loader rather than as a bare package
-// name.
-func relativeImportSpecifier(fromDir, location string) (string, error) {
-  relative, err := filepath.Rel(fromDir, location)
-  if err != nil {
-    return "", fmt.Errorf("@ttsc/lint: resolve relative config import %s: %w", location, err)
-  }
-  relative = filepath.ToSlash(relative)
-  if strings.HasPrefix(relative, "../") || strings.HasPrefix(relative, "./") {
-    return relative, nil
-  }
-  return "./" + relative, nil
-}
-
 func fileURL(location string) string {
+  volume := filepath.VolumeName(location)
+  if volume != "" {
+    volumePath := filepath.ToSlash(volume)
+    rest := strings.TrimPrefix(filepath.ToSlash(location[len(volume):]), "/")
+    if strings.HasPrefix(volumePath, "//?/UNC") {
+      return uncFileURL(rest)
+    }
+    if strings.HasPrefix(volumePath, "//?/") {
+      pathname := "/" + strings.TrimPrefix(volumePath, "//?/")
+      if rest != "" {
+        pathname += "/" + rest
+      }
+      return (&url.URL{Scheme: "file", Path: pathname}).String()
+    }
+    if strings.HasPrefix(volumePath, "//") {
+      return uncFileURL(strings.TrimPrefix(volumePath, "//") + "/" + rest)
+    }
+  }
   pathname := filepath.ToSlash(location)
-  if filepath.VolumeName(location) != "" && !strings.HasPrefix(pathname, "/") {
+  if volume != "" && !strings.HasPrefix(pathname, "/") {
     pathname = "/" + pathname
   }
   return (&url.URL{Scheme: "file", Path: pathname}).String()
+}
+
+func uncFileURL(pathname string) string {
+  server, remainder, ok := strings.Cut(pathname, "/")
+  if !ok || server == "" {
+    return (&url.URL{Scheme: "file", Path: "/" + strings.TrimPrefix(pathname, "/")}).String()
+  }
+  share, tail, _ := strings.Cut(remainder, "/")
+  if share == "" {
+    return (&url.URL{Scheme: "file", Path: "/" + strings.TrimPrefix(pathname, "/")}).String()
+  }
+  urlPath := "/" + share
+  if tail != "" {
+    urlPath += "/" + tail
+  }
+  return (&url.URL{Scheme: "file", Host: server, Path: urlPath}).String()
 }
 
 // typeScriptConfigLoaderSource returns the TypeScript source of the ephemeral

--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -7,6 +7,7 @@ import (
   "encoding/hex"
   "encoding/json"
   "fmt"
+  "net/url"
   "os"
   "os/exec"
   "path/filepath"
@@ -1186,6 +1187,7 @@ func loadTypeScriptConfigFile(location string) (any, error) {
   if err != nil {
     return nil, fmt.Errorf("@ttsc/lint: create config loader tempdir: %w", err)
   }
+  tempDir = realpathIfPossible(tempDir)
   defer os.RemoveAll(tempDir)
 
   if err := linkNearestNodeModules(tempDir, filepath.Dir(location)); err != nil {
@@ -1194,11 +1196,7 @@ func loadTypeScriptConfigFile(location string) (any, error) {
 
   loader := filepath.Join(tempDir, "loader.mts")
   tsconfig := filepath.Join(tempDir, "tsconfig.json")
-  importSpecifier, err := relativeImportSpecifier(tempDir, location)
-  if err != nil {
-    return nil, err
-  }
-  importLiteral, err := json.Marshal(importSpecifier)
+  importLiteral, err := json.Marshal(fileURL(location))
   if err != nil {
     return nil, fmt.Errorf("@ttsc/lint: encode config import %s: %w", location, err)
   }
@@ -1260,13 +1258,21 @@ func relativeImportSpecifier(fromDir, location string) (string, error) {
   return "./" + relative, nil
 }
 
+func fileURL(location string) string {
+  pathname := filepath.ToSlash(location)
+  if filepath.VolumeName(location) != "" && !strings.HasPrefix(pathname, "/") {
+    pathname = "/" + pathname
+  }
+  return (&url.URL{Scheme: "file", Path: pathname}).String()
+}
+
 // typeScriptConfigLoaderSource returns the TypeScript source of the ephemeral
 // loader script that ttsx executes to evaluate a TypeScript lint config file.
 // `importLiteral` is a JSON-encoded relative import path (e.g. `"./lint.config.ts"`)
 // that is spliced directly into the `import * as` statement, so it must
 // already be a valid JSON string (produced by json.Marshal).
 func typeScriptConfigLoaderSource(importLiteral string) string {
-  return fmt.Sprintf(`import * as importedConfig from %s;
+  return fmt.Sprintf(`const importedConfig = await import(%s);
 
 declare const process: {
   stdout: { write(value: string): void };
@@ -1420,6 +1426,14 @@ func loaderTempBase(location, systemTemp string) string {
   real, err := filepath.EvalSymlinks(base)
   if err != nil || !strings.EqualFold(filepath.VolumeName(real), filepath.VolumeName(location)) {
     return filepath.Dir(location)
+  }
+  return real
+}
+
+func realpathIfPossible(location string) string {
+  real, err := filepath.EvalSymlinks(location)
+  if err != nil {
+    return location
   }
   return real
 }

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -394,7 +394,9 @@ function readCjsConfigPlugins(configPath: string): ConfigPluginEntry[] {
 // collects every `plugins` map, and serialises each plugin's `source` field
 // as a JSON array for the parent process to parse — avoiding the need to
 // serialise arbitrary in-memory plugin objects across the process boundary.
-const TTSX_EXTRACTOR_SCRIPT = `const importedConfig = await import(%CONFIG_IMPORT%);
+// The URL lives in a variable so tsgo does not statically resolve it.
+const TTSX_EXTRACTOR_SCRIPT = `const configUrl = %CONFIG_IMPORT%;
+const importedConfig = await import(configUrl);
 
 declare const process: {
   cwd(): string;

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import type { ITtscLintPlugin, ITtscLintPluginConfig } from "./structures";
 
@@ -388,12 +389,12 @@ function readCjsConfigPlugins(configPath: string): ConfigPluginEntry[] {
 }
 
 // TypeScript source written to a temp file and executed via ttsx. The
-// %CONFIG_IMPORT% placeholder is replaced with a JSON-quoted relative path
+// %CONFIG_IMPORT% placeholder is replaced with a JSON-quoted file URL
 // before the file hits disk. The script walks the exported config object,
 // collects every `plugins` map, and serialises each plugin's `source` field
 // as a JSON array for the parent process to parse — avoiding the need to
 // serialise arbitrary in-memory plugin objects across the process boundary.
-const TTSX_EXTRACTOR_SCRIPT = `import * as importedConfig from %CONFIG_IMPORT%;
+const TTSX_EXTRACTOR_SCRIPT = `const importedConfig = await import(%CONFIG_IMPORT%);
 
 declare const process: {
   cwd(): string;
@@ -535,17 +536,16 @@ function evaluateTtsxConfigPlugins(
   configPath: string,
   _context: TtscPluginFactoryContext<ITtscLintPluginConfig>,
 ): ConfigPluginEntry[] {
-  const tempDir = fs.mkdtempSync(
-    path.join(loaderTempBase(configPath), "ttsc-lint-cfg-"),
+  const tempDir = realpathIfPossible(
+    fs.mkdtempSync(path.join(loaderTempBase(configPath), "ttsc-lint-cfg-")),
   );
   try {
     linkNearestNodeModules(tempDir, path.dirname(configPath));
     const loaderPath = path.join(tempDir, "loader.mts");
     const tsconfigPath = path.join(tempDir, "tsconfig.json");
-    const importSpecifier = relativeImportSpecifier(tempDir, configPath);
     const loaderSource = TTSX_EXTRACTOR_SCRIPT.replace(
       "%CONFIG_IMPORT%",
-      JSON.stringify(importSpecifier),
+      JSON.stringify(pathToFileURL(configPath).href),
     );
     fs.writeFileSync(loaderPath, loaderSource, "utf8");
     fs.writeFileSync(
@@ -967,12 +967,12 @@ function loaderTempBase(configPath: string): string {
   return path.dirname(configPath);
 }
 
-function relativeImportSpecifier(fromDir: string, target: string): string {
-  let rel = path.relative(fromDir, target).replace(/\\/g, "/");
-  if (!rel.startsWith("./") && !rel.startsWith("../")) {
-    rel = "./" + rel;
+function realpathIfPossible(location: string): string {
+  try {
+    return fs.realpathSync(location);
+  } catch {
+    return location;
   }
-  return rel;
 }
 
 function nodeConfigLoaderEnv(configPath: string): NodeJS.ProcessEnv {

--- a/packages/lint/test/config/file_url_matches_node_shape_test.go
+++ b/packages/lint/test/config/file_url_matches_node_shape_test.go
@@ -1,0 +1,59 @@
+package linthost
+
+import (
+  "runtime"
+  "testing"
+)
+
+// TestFileURLMatchesNodeShape pins the file URL strings generated for the
+// ephemeral TypeScript config loader. Node consumes these with dynamic import,
+// so the Go side must match Node's pathToFileURL shape for Windows drive and
+// UNC paths, including characters that require URL escaping.
+func TestFileURLMatchesNodeShape(t *testing.T) {
+  type testCase struct {
+    name     string
+    location string
+    want     string
+  }
+
+  cases := []testCase{
+    {
+      name:     "posix escapes path characters",
+      location: "/tmp/a b/#lint%.config.ts",
+      want:     "file:///tmp/a%20b/%23lint%25.config.ts",
+    },
+  }
+
+  if runtime.GOOS == "windows" {
+    cases = append(cases,
+      testCase{
+        name:     "windows drive path",
+        location: `C:\a b\#lint%.config.ts`,
+        want:     "file:///C:/a%20b/%23lint%25.config.ts",
+      },
+      testCase{
+        name:     "windows unc path",
+        location: `\\server\share\a b\lint.config.ts`,
+        want:     "file://server/share/a%20b/lint.config.ts",
+      },
+      testCase{
+        name:     "windows extended drive path",
+        location: `\\?\C:\a b\lint.config.ts`,
+        want:     "file:///C:/a%20b/lint.config.ts",
+      },
+      testCase{
+        name:     "windows extended unc path",
+        location: `\\?\UNC\server\share\a b\lint.config.ts`,
+        want:     "file://server/share/a%20b/lint.config.ts",
+      },
+    )
+  }
+
+  for _, c := range cases {
+    t.Run(c.name, func(t *testing.T) {
+      if got := fileURL(c.location); got != c.want {
+        t.Fatalf("fileURL(%q) = %q, want %q", c.location, got, c.want)
+      }
+    })
+  }
+}

--- a/tests/test-lint/src/features/config/test_lint_config_file_typescript_config_loads_when_temp_dir_realpath_differs.ts
+++ b/tests/test-lint/src/features/config/test_lint_config_file_typescript_config_loads_when_temp_dir_realpath_differs.ts
@@ -1,0 +1,74 @@
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  assert,
+  createLintProject,
+  runLintProject,
+} from "../../internal/config-file";
+
+/**
+ * Verifies that a `.ts` lint config loads when the loader temp dir realpaths
+ * differently from the path returned by the OS temp API.
+ *
+ * Reproduces the macOS `/var -> /private/var` shape with a test-local symlink:
+ * the config project lives beside the symlink, while `TMPDIR` points through
+ * it. Before the loader realpathed its temp dir, ttsx compiled `lint.config.ts`
+ * imports to `lint.config.js`, Node resolved them from the real loader path,
+ * and the import drifted to a non-existent sibling.
+ *
+ * 1. Create `var -> private/var` and a project under `Users/project` in the same
+ *    synthetic root.
+ * 2. Run real ttsc with `TMPDIR`, `TMP`, and `TEMP` pointing at the symlinked temp
+ *    root.
+ * 3. Assert the TypeScript lint config is evaluated and its `no-var` rule fires
+ *    instead of failing with `ERR_MODULE_NOT_FOUND`.
+ */
+export const test_lint_config_file_typescript_config_loads_when_temp_dir_realpath_differs =
+  () => {
+    const base = TestProject.tmpdir("ttsc-lint-realpath-base-");
+    const realTemp = path.join(base, "private", "var");
+    const linkTemp = path.join(base, "var");
+    const projectRoot = path.join(base, "Users", "project");
+
+    fs.mkdirSync(realTemp, { recursive: true });
+    fs.symlinkSync(
+      realTemp,
+      linkTemp,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    const project = createLintProject({
+      name: "config-file-ts-realpath-temp",
+      projectRoot,
+      source: "var value = 1;\n",
+      pluginConfig: {
+        configFile: "./lint.config.ts",
+      },
+      extraSources: {
+        "lint.config.ts": `export default {
+  rules: {
+    "no-var": "error",
+  },
+};\n`,
+      },
+    });
+    try {
+      const result = runLintProject(project.tmpdir, [], {
+        TMPDIR: linkTemp,
+        TMP: linkTemp,
+        TEMP: linkTemp,
+      });
+
+      assert.notEqual(result.status, 0);
+      assert.deepEqual(
+        result.diagnostics.map((d) => [d.rule, d.severity]),
+        [["no-var", "error"]],
+        result.stderr,
+      );
+      assert(!result.stderr.includes("ERR_MODULE_NOT_FOUND"), result.stderr);
+    } finally {
+      project.cleanup();
+    }
+  };

--- a/tests/test-lint/src/internal/config-file.ts
+++ b/tests/test-lint/src/internal/config-file.ts
@@ -40,8 +40,9 @@ function createLintProject(options: IRunLintOptions): TestLint.IRunLintProject {
 function runLintProject(
   tmpdir: string,
   args: string[] = [],
+  env: NodeJS.ProcessEnv = {},
 ): TestLint.IRunLintResult {
-  return TestLint.runProject(tmpdir, args);
+  return TestLint.runProject(tmpdir, args, env);
 }
 
 /**

--- a/tests/utils/src/lint/TestLint.ts
+++ b/tests/utils/src/lint/TestLint.ts
@@ -280,16 +280,38 @@ export namespace TestLint {
   function assertDisposableProjectRoot(projectRoot: string): void {
     const tempRoot = path.resolve(os.tmpdir());
     const resolved = path.resolve(projectRoot);
-    const relative = path.relative(tempRoot, resolved);
+    const tempRoots = new Set([tempRoot, realpathIfPossible(tempRoot)]);
     if (
-      relative === "" ||
-      (!relative.startsWith("..") && !path.isAbsolute(relative))
+      [...tempRoots].some(
+        (candidate) =>
+          isSameOrChildPath(candidate, resolved) ||
+          isSameOrChildPath(candidate, realpathIfPossible(resolved)),
+      )
     ) {
       return;
     }
     throw new Error(
       `TestLint projectRoot must be a disposable directory under ${tempRoot}: ${projectRoot}`,
     );
+  }
+
+  function isSameOrChildPath(parent: string, child: string): boolean {
+    const relative = path.relative(parent, child);
+    if (
+      relative === "" ||
+      (!relative.startsWith("..") && !path.isAbsolute(relative))
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  function realpathIfPossible(location: string): string {
+    try {
+      return fs.realpathSync(location);
+    } catch {
+      return location;
+    }
   }
 
   /** Link the workspace @ttsc/lint package as if the fixture had installed it. */

--- a/tests/utils/src/lint/TestLint.ts
+++ b/tests/utils/src/lint/TestLint.ts
@@ -114,6 +114,7 @@ export namespace TestLint {
   export interface IRunLintOptions {
     name: string;
     source: string;
+    /** Optional disposable root under the OS temp dir; cleanup removes it. */
     projectRoot?: string;
     rules?: Record<string, LintRuleConfigSeverity>;
     pluginConfig?: Record<string, unknown>;
@@ -168,6 +169,9 @@ export namespace TestLint {
     const tmpdir =
       projectRoot ??
       TestProject.tmpdir(`ttsc-lint-case-${sanitizeForFsName(name)}-`);
+    if (projectRoot !== undefined) {
+      assertDisposableProjectRoot(projectRoot);
+    }
     try {
       // The tsconfig plugin entry never carries rules: it is empty, or
       // optionally names a config file via `configFile`. When a test uses the
@@ -270,6 +274,21 @@ export namespace TestLint {
         2,
       ),
       "utf8",
+    );
+  }
+
+  function assertDisposableProjectRoot(projectRoot: string): void {
+    const tempRoot = path.resolve(os.tmpdir());
+    const resolved = path.resolve(projectRoot);
+    const relative = path.relative(tempRoot, resolved);
+    if (
+      relative === "" ||
+      (!relative.startsWith("..") && !path.isAbsolute(relative))
+    ) {
+      return;
+    }
+    throw new Error(
+      `TestLint projectRoot must be a disposable directory under ${tempRoot}: ${projectRoot}`,
     );
   }
 

--- a/tests/utils/src/lint/TestLint.ts
+++ b/tests/utils/src/lint/TestLint.ts
@@ -114,6 +114,7 @@ export namespace TestLint {
   export interface IRunLintOptions {
     name: string;
     source: string;
+    projectRoot?: string;
     rules?: Record<string, LintRuleConfigSeverity>;
     pluginConfig?: Record<string, unknown>;
     extraSources?: Record<string, string>;
@@ -155,11 +156,18 @@ export namespace TestLint {
    * immediately.
    */
   export function createProject(options: IRunLintOptions): IRunLintProject {
-    const { name, source, rules, pluginConfig, extraSources, linkNodeModules } =
-      options;
-    const tmpdir = TestProject.tmpdir(
-      `ttsc-lint-case-${sanitizeForFsName(name)}-`,
-    );
+    const {
+      name,
+      source,
+      projectRoot,
+      rules,
+      pluginConfig,
+      extraSources,
+      linkNodeModules,
+    } = options;
+    const tmpdir =
+      projectRoot ??
+      TestProject.tmpdir(`ttsc-lint-case-${sanitizeForFsName(name)}-`);
     try {
       // The tsconfig plugin entry never carries rules: it is empty, or
       // optionally names a config file via `configFile`. When a test uses the
@@ -202,6 +210,7 @@ export namespace TestLint {
   export function runProject(
     tmpdir: string,
     args: string[] = [],
+    env: NodeJS.ProcessEnv = {},
   ): IRunLintResult {
     const result = spawnSync(
       process.execPath,
@@ -210,6 +219,7 @@ export namespace TestLint {
         cwd: tmpdir,
         env: {
           ...process.env,
+          ...env,
           TTSC_CACHE_DIR: SHARED_CACHE_DIR,
           TTSC_TTSX_BINARY: TTSX_BIN,
           TTSC_TSGO_BINARY: TSGO_BINARY,


### PR DESCRIPTION
## Summary

Fixes TypeScript lint config evaluation when the temporary loader directory is reached through a path whose realpath differs from the path used to compute relative imports, such as macOS `/var` resolving to `/private/var`.

The lint config loaders now import user TypeScript config files through absolute `file://` URLs instead of static relative imports that TypeScript-Go can rewrite to `.js` and Node can resolve from a realpathed loader path.

## Scope

- Use dynamic `file://` imports in the JS factory plugin extractor.
- Use dynamic `file://` imports in the Go sidecar config loader.
- Add a synthetic realpath-drift e2e case for `lint.config.ts`.
- Add the same installed-tarball check to `experimental/install`, so the OS matrix covers macOS, Linux, and Windows.

## Validation

- `pnpm --filter @ttsc/lint build`
- `git diff --check`
- `pnpm format`

Longer e2e/experimental validation is intentionally left to CI.
