### PR TITLE
ci(experimental): scope current tarball builds

### DIFF
--- a/experimental/install/src/index.ts
+++ b/experimental/install/src/index.ts
@@ -34,7 +34,7 @@ function main() {
 }
 
 function prepareCurrentTarballs() {
-  run("pnpm run build:current", root);
+  run("pnpm run build:current", root, { TTSC_BUILD_SCOPE: "experimental" });
 
   fs.mkdirSync(tarballs, { recursive: true });
   for (const name of ["ttsc", platformTarball, ...currentPackageTarballs]) {
@@ -408,13 +408,14 @@ function tarball(name) {
   return file;
 }
 
-function run(command, cwd) {
+function run(command, cwd, extraEnv = {}) {
   console.log(`$ ${command}`);
   const result = cp.execSync(command, {
     cwd,
     encoding: "utf8",
     env: {
       ...process.env,
+      ...extraEnv,
       npm_config_cache: path.join(os.tmpdir(), "ttsc-npm-cache"),
     },
     stdio: ["ignore", "pipe", "pipe"],

--- a/experimental/source-map/src/index.ts
+++ b/experimental/source-map/src/index.ts
@@ -57,7 +57,7 @@ function main() {
 }
 
 function prepareCurrentTarballs() {
-  run("pnpm run build:current", root);
+  run("pnpm run build:current", root, { TTSC_BUILD_SCOPE: "experimental" });
 
   fs.mkdirSync(tarballs, { recursive: true });
   for (const name of ["ttsc", platformTarball]) {
@@ -248,13 +248,14 @@ function tarball(name) {
   return file;
 }
 
-function run(command, cwd) {
+function run(command, cwd, extraEnv = {}) {
   console.log(`$ ${command}`);
   const result = cp.execSync(command, {
     cwd,
     encoding: "utf8",
     env: {
       ...process.env,
+      ...extraEnv,
       npm_config_cache: path.join(os.tmpdir(), "ttsc-npm-cache"),
     },
     maxBuffer: 1024 * 1024 * 64,

--- a/experimental/tarballs/index.ts
+++ b/experimental/tarballs/index.ts
@@ -31,6 +31,10 @@ function preparePackages() {
   console.log(`Preparing packages (pnpm run ${script})`);
   cp.execSync(`pnpm run ${script}`, {
     cwd: root,
+    env: {
+      ...process.env,
+      ...(CURRENT_ONLY ? { TTSC_BUILD_SCOPE: "experimental" } : {}),
+    },
     stdio: "inherit",
   });
 }

--- a/experimental/test-unplugin/src/index.ts
+++ b/experimental/test-unplugin/src/index.ts
@@ -92,7 +92,7 @@ function main() {
 }
 
 function prepareCurrentTarballs() {
-  run("pnpm run build:current", root);
+  run("pnpm run build:current", root, { TTSC_BUILD_SCOPE: "experimental" });
 
   fs.mkdirSync(tarballs, { recursive: true });
   for (const name of ["ttsc", platformTarball, "unplugin"]) {
@@ -884,7 +884,7 @@ function tarball(name) {
   return file;
 }
 
-function run(command, cwd) {
+function run(command, cwd, extraEnv = {}) {
   console.log(`$ ${command}`);
   try {
     const result = cp.execSync(command, {
@@ -892,6 +892,7 @@ function run(command, cwd) {
       encoding: "utf8",
       env: {
         ...process.env,
+        ...extraEnv,
         npm_config_cache: path.join(os.tmpdir(), "ttsc-npm-cache"),
         // ttsc resolves the native `tsc` binary from here, so the consumer need
         // not install the native `typescript` package (Next cannot load it).

--- a/scripts/build-current.cjs
+++ b/scripts/build-current.cjs
@@ -15,11 +15,10 @@ if (!fs.existsSync(path.join(platformDir, "package.json"))) {
 // (e.g. @ttsc/graph, lint-contributor-demo).
 const PLATFORM = Symbol("platform");
 
-// `TTSC_BUILD_SCOPE` trims the build to what a given test lane actually
-// exercises. The heavy cost in a full build is @ttsc/graph (its build runs
-// `ttsc` with the typia plugin) plus the native binary; the test suites below
-// reference neither graph, vscode, metro, nor unplugin, so skipping them cuts
-// the per-lane build roughly in half.
+// `TTSC_BUILD_SCOPE` trims the build to what a given test or experiment lane
+// actually exercises. The heavy cost in a full build is @ttsc/graph (its build
+// runs `ttsc` with the typia plugin) plus the native binary; scoped lanes skip
+// packages they never package or execute.
 const SCOPES = {
   // Everything, in dependency-safe order (native binary before graph/demo).
   full: [
@@ -45,6 +44,16 @@ const SCOPES = {
     "@ttsc/lint",
     PLATFORM,
     "lint-contributor-demo",
+  ],
+  // Experimental tarball smoke tests pack only ttsc, the current platform, and
+  // first-party packages consumed by the install/unplugin checks. paths/strip
+  // ship source files directly and have no build script.
+  experimental: [
+    "ttsc",
+    "@ttsc/banner",
+    "@ttsc/lint",
+    "@ttsc/unplugin",
+    PLATFORM,
   ],
 };
 


### PR DESCRIPTION
## Intent

Reduce experimental.yml runtime variance caused by `experimental/* --pack-current` preparing tarballs through the default full `build:current` plan.

## Scope

- Add an `experimental` `TTSC_BUILD_SCOPE` containing only packages needed by current-platform experimental tarballs: `ttsc`, `@ttsc/banner`, `@ttsc/lint`, `@ttsc/unplugin`, and the current platform package.
- Wire `experimental/install`, `experimental/test-unplugin`, `experimental/source-map`, and `experimental/tarballs --current` to use that scope when preparing current tarballs.
- Leave full builds and release/full tarball packaging unchanged.

## Deferred

- Deeper runtime variance work after this PR can split/measure the internal experimental phases if needed.

## Test Plan

- `pnpm format`
- `node --check scripts/build-current.cjs`
- `node --experimental-strip-types --check experimental/install/src/index.ts`
- `node --experimental-strip-types --check experimental/test-unplugin/src/index.ts`
- `node --experimental-strip-types --check experimental/source-map/src/index.ts`
- `node --experimental-strip-types --check experimental/tarballs/index.ts`
- Stubbed `TTSC_BUILD_SCOPE=experimental` build-current plan check, verifying only the five expected build calls are issued.