### PR TITLE
chore(deps): bump typia to 13.0.0-rc.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,17 +23,17 @@ catalogs:
       version: 8.1.2
   samchon:
     '@typia/interface':
-      specifier: ^13.0.0-rc.1
-      version: 13.0.0-rc.1
+      specifier: ^13.0.0-rc.2
+      version: 13.0.0-rc.2
     '@typia/mcp':
-      specifier: ^13.0.0-rc.1
-      version: 13.0.0-rc.1
+      specifier: ^13.0.0-rc.2
+      version: 13.0.0-rc.2
     '@typia/utils':
-      specifier: ^13.0.0-rc.1
-      version: 13.0.0-rc.1
+      specifier: ^13.0.0-rc.2
+      version: 13.0.0-rc.2
     typia:
-      specifier: ^13.0.0-rc.1
-      version: 13.0.0-rc.1
+      specifier: ^13.0.0-rc.2
+      version: 13.0.0-rc.2
   typescript:
     ts-legacy:
       specifier: npm:typescript@~6.0.3
@@ -142,10 +142,10 @@ importers:
         version: 1.29.0(zod@3.25.76)
       '@typia/mcp':
         specifier: catalog:samchon
-        version: 13.0.0-rc.1(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
+        version: 13.0.0-rc.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
       typia:
         specifier: catalog:samchon
-        version: 13.0.0-rc.1(@types/node@25.9.1)
+        version: 13.0.0-rc.2(@types/node@25.9.1)
     devDependencies:
       '@types/node':
         specifier: catalog:utils
@@ -642,10 +642,10 @@ importers:
         version: link:../packages/wasm
       '@typia/interface':
         specifier: catalog:samchon
-        version: 13.0.0-rc.1
+        version: 13.0.0-rc.2
       '@typia/utils':
         specifier: catalog:samchon
-        version: 13.0.0-rc.1
+        version: 13.0.0-rc.2
       lz-string:
         specifier: ^1.5.0
         version: 1.5.0
@@ -696,7 +696,7 @@ importers:
         version: 5.9.3
       typia:
         specifier: catalog:samchon
-        version: 13.0.0-rc.1(@types/node@20.19.41)
+        version: 13.0.0-rc.2(@types/node@20.19.41)
     devDependencies:
       '@resvg/resvg-js':
         specifier: ^2.6.2
@@ -3240,16 +3240,16 @@ packages:
     resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
 
-  '@typia/interface@13.0.0-rc.1':
-    resolution: {integrity: sha512-zZEmDL+GRRGRhmFeWG/N9hQhV8zMdEm0cK3u4iFT9ry1dZU7bNE8TzFXRpu89LNVHLnttEkj5nkEWbgoeRYldQ==}
+  '@typia/interface@13.0.0-rc.2':
+    resolution: {integrity: sha512-zY87xL/P6HW1LrLeBJjQquIPuNgwoeOj9U15wb2JQfI9uRlXo116irlTQ0upOco5ZVxb4y1A2h+/W/7aX12FBQ==}
 
-  '@typia/mcp@13.0.0-rc.1':
-    resolution: {integrity: sha512-5O+gDDWTkPnIdmeYjtpxiGVUFJGlcmcJzc65HmFsuEIVwJOTD2CEXc6BEwIa/9fGhYx6Eine4fZMUZ6fxhuYOQ==}
+  '@typia/mcp@13.0.0-rc.2':
+    resolution: {integrity: sha512-bI2U1Moj2kFX3Oxq4l+aaAl7SJKeYUXfhOHy/7cYW62ccx8udMCI9z6xOuooUvJXIfJdfZOg4O+hlz+S1prVmA==}
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.12.0'
 
-  '@typia/utils@13.0.0-rc.1':
-    resolution: {integrity: sha512-UQZHcSLSOV0UEy4FfP1Eo5u6K81OEPirEnNUw4g3ALkC5W9tm0l+NGoyMtm3mZ5zMTKlLzui2TWfgg651qJ72A==}
+  '@typia/utils@13.0.0-rc.2':
+    resolution: {integrity: sha512-xHukq8l6eI1y7aBeOS6UNe4ZsfzAb9av0TyihBKBWLJK7Y/38uJZue3qFyVpRtNSErs6VS102UaxjhYtqzJ6qQ==}
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -6858,8 +6858,8 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
-  typia@13.0.0-rc.1:
-    resolution: {integrity: sha512-eS+Xp7OvMbv2mqQiok1SmPPmEEqEe3oJhaoWpiUiOOvRSTQ2bIcufZpRydnNX+MDPqL/qRM7R4kkDUymjCpffg==}
+  typia@13.0.0-rc.2:
+    resolution: {integrity: sha512-O4ylbNFZg7KxWZ8x+mak5/JIHD0PgDZeiv1KT6yMX8i+/XuhAC2lMu9uDamroDckhIBqqNKOUZmata/jRdhlvw==}
     hasBin: true
 
   uc.micro@2.1.0:
@@ -9828,17 +9828,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typia/interface@13.0.0-rc.1': {}
+  '@typia/interface@13.0.0-rc.2': {}
 
-  '@typia/mcp@13.0.0-rc.1(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
+  '@typia/mcp@13.0.0-rc.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-      '@typia/interface': 13.0.0-rc.1
-      '@typia/utils': 13.0.0-rc.1
+      '@typia/interface': 13.0.0-rc.2
+      '@typia/utils': 13.0.0-rc.2
 
-  '@typia/utils@13.0.0-rc.1':
+  '@typia/utils@13.0.0-rc.2':
     dependencies:
-      '@typia/interface': 13.0.0-rc.1
+      '@typia/interface': 13.0.0-rc.2
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -14483,11 +14483,11 @@ snapshots:
       '@typescript/typescript-win32-arm64': 7.0.1-rc
       '@typescript/typescript-win32-x64': 7.0.1-rc
 
-  typia@13.0.0-rc.1(@types/node@20.19.41):
+  typia@13.0.0-rc.2(@types/node@20.19.41):
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@typia/interface': 13.0.0-rc.1
-      '@typia/utils': 13.0.0-rc.1
+      '@typia/interface': 13.0.0-rc.2
+      '@typia/utils': 13.0.0-rc.2
       commander: 10.0.1
       inquirer: 8.2.7(@types/node@20.19.41)
       randexp: 0.5.3
@@ -14495,11 +14495,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  typia@13.0.0-rc.1(@types/node@25.9.1):
+  typia@13.0.0-rc.2(@types/node@25.9.1):
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@typia/interface': 13.0.0-rc.1
-      '@typia/utils': 13.0.0-rc.1
+      '@typia/interface': 13.0.0-rc.2
+      '@typia/utils': 13.0.0-rc.2
       commander: 10.0.1
       inquirer: 8.2.7(@types/node@25.9.1)
       randexp: 0.5.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,10 +18,10 @@ catalogs:
     rollup-plugin-auto-external: ^2.0.0
     rollup-plugin-node-externals: ^8.1.2
   samchon:
-    '@typia/interface': ^13.0.0-rc.1
-    '@typia/mcp': ^13.0.0-rc.1
-    '@typia/utils': ^13.0.0-rc.1
-    typia: ^13.0.0-rc.1
+    '@typia/interface': ^13.0.0-rc.2
+    '@typia/mcp': ^13.0.0-rc.2
+    '@typia/utils': ^13.0.0-rc.2
+    typia: ^13.0.0-rc.2
   utils:
     '@nestia/e2e': ^12.0.0-rc.2
     '@types/node': ^25.3.0


### PR DESCRIPTION
## Intent

Bump the `samchon` dependency catalog from typia `13.0.0-rc.1` to `13.0.0-rc.2`.

## Scope

- `pnpm-workspace.yaml`: catalog specifiers for `typia`, `@typia/interface`, `@typia/mcp`, `@typia/utils` → `^13.0.0-rc.2`.
- `pnpm-lock.yaml`: regenerated to match.

No source changes; this is a dependency-only update.

## Test plan

- CI (build + tests) validates the new typia rc against the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)