### PR TITLE
ci(experimental): build only ttsc platform helper

### DIFF
--- a/experimental/install/src/index.ts
+++ b/experimental/install/src/index.ts
@@ -52,21 +52,20 @@ function packPackage(packageDirName, tarballName) {
   const packageDir = path.join(root, "packages", packageDirName);
   assert(fs.existsSync(packageDir), `${packageDirName} package must exist`);
 
-  for (const entry of fs.readdirSync(packageDir)) {
-    if (entry.endsWith(".tgz")) {
-      fs.rmSync(path.join(packageDir, entry), { force: true });
-    }
-  }
-
-  run("pnpm pack", packageDir);
-  const packed = fs
-    .readdirSync(packageDir)
-    .find((entry) => entry.endsWith(".tgz"));
-  assert(packed, `${packageDirName} package tarball must be created`);
-  fs.copyFileSync(
-    path.join(packageDir, packed),
-    path.join(tarballs, `${tarballName}.tgz`),
+  const output = path.join(tarballs, `${tarballName}.tgz`);
+  fs.rmSync(output, { force: true });
+  const result = run(
+    `pnpm pack --json --out ${JSON.stringify(output)}`,
+    packageDir,
+    {},
+    { echoOutput: false },
   );
+  const summary = parsePackSummary(result.stdout, packageDirName);
+  const fileCount = Array.isArray(summary.files) ? summary.files.length : 0;
+  console.log(
+    `packed ${packageDirName} -> ${path.relative(root, output)} (${fileCount} files)`,
+  );
+  assert(fs.existsSync(output), `${packageDirName} package tarball must exist`);
 }
 
 function prepareWorkspace() {
@@ -408,24 +407,43 @@ function tarball(name) {
   return file;
 }
 
-function run(command, cwd, extraEnv = {}) {
+function run(command, cwd, extraEnv = {}, options = {}) {
   console.log(`$ ${command}`);
-  const result = cp.execSync(command, {
-    cwd,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      ...extraEnv,
-      npm_config_cache: path.join(os.tmpdir(), "ttsc-npm-cache"),
-    },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (result) process.stdout.write(result);
-  return { stdout: result };
+  const started = Date.now();
+  try {
+    const result = cp.execSync(command, {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...extraEnv,
+        npm_config_cache: path.join(os.tmpdir(), "ttsc-npm-cache"),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (result && options.echoOutput !== false) {
+      process.stdout.write(result);
+    }
+    return { stdout: result };
+  } finally {
+    console.log(
+      `$ ${command} finished in ${formatDuration(Date.now() - started)}`,
+    );
+  }
+}
+
+function parsePackSummary(stdout, packageDirName) {
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    throw new Error(`${packageDirName} package pack summary must be JSON`);
+  }
 }
 
 function runNode(args, cwd, label) {
-  console.log(`$ ${label ?? [process.execPath, ...args].join(" ")}`);
+  const command = label ?? [process.execPath, ...args].join(" ");
+  console.log(`$ ${command}`);
+  const started = Date.now();
   const result = cp.spawnSync(process.execPath, args, {
     cwd,
     encoding: "utf8",
@@ -435,6 +453,9 @@ function runNode(args, cwd, label) {
   });
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);
+  console.log(
+    `$ ${command} finished in ${formatDuration(Date.now() - started)}`,
+  );
   assert(result.status === 0, `node ${args.join(" ")} failed`);
   return result;
 }
@@ -479,7 +500,9 @@ function spawnInstalledTtsc(args, cwd, extraEnv = {}) {
   );
   assert(fs.existsSync(ttsx), "installed ttsx launcher must exist");
 
-  console.log(`$ node ${path.relative(cwd, launcher)} ${args.join(" ")}`);
+  const command = `node ${path.relative(cwd, launcher)} ${args.join(" ")}`;
+  console.log(`$ ${command}`);
+  const started = Date.now();
   const result = cp.spawnSync(process.execPath, [launcher, ...args], {
     cwd,
     encoding: "utf8",
@@ -494,7 +517,17 @@ function spawnInstalledTtsc(args, cwd, extraEnv = {}) {
   });
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);
+  console.log(
+    `$ ${command} finished in ${formatDuration(Date.now() - started)}`,
+  );
   return result;
+}
+
+function formatDuration(milliseconds) {
+  if (milliseconds < 1000) {
+    return `${milliseconds}ms`;
+  }
+  return `${(milliseconds / 1000).toFixed(1)}s`;
 }
 
 function assert(condition, message) {

--- a/scripts/assert-platform-package.cjs
+++ b/scripts/assert-platform-package.cjs
@@ -14,6 +14,11 @@ const baseExecutablePaths = [
   "bin/go/bin/go",
   "bin/go/bin/gofmt",
 ];
+const minimumExecutablePaths = [
+  "bin/ttsc",
+  "bin/go/bin/go",
+  "bin/go/bin/gofmt",
+];
 const requiredExecutableConfigPaths = baseExecutablePaths.map(
   (rel) => `./${rel}`,
 );
@@ -89,7 +94,7 @@ function inspectTarball(file) {
   const platform = platformFromPackageName(manifest.name);
   if (platform === null || platform.os === "win32") return;
 
-  for (const rel of requiredExecutablePathsFromEntries(entries)) {
+  for (const rel of requiredExecutablePathsFromEntries(entries, manifest)) {
     const name = `package/${rel}`;
     const entry = entries.get(name);
     if (!entry) {
@@ -141,18 +146,33 @@ function requiredExecutablePaths(packageDir) {
   return paths;
 }
 
-function requiredExecutablePathsFromEntries(entries) {
-  const paths = [...baseExecutablePaths];
+function requiredExecutablePathsFromEntries(entries, manifest) {
+  const configured = configuredExecutablePaths(manifest);
+  const paths = configured ?? [...baseExecutablePaths];
+  for (const rel of minimumExecutablePaths) {
+    if (!paths.includes(rel)) paths.push(rel);
+  }
   for (const [name, entry] of entries) {
     if (
       entry.file &&
       name.startsWith("package/bin/go/pkg/tool/") &&
       !name.endsWith("/")
     ) {
-      paths.push(name.slice("package/".length));
+      const rel = name.slice("package/".length);
+      if (!paths.includes(rel)) paths.push(rel);
     }
   }
   return paths;
+}
+
+function configuredExecutablePaths(manifest) {
+  if (!Array.isArray(manifest.publishConfig?.executableFiles)) {
+    return undefined;
+  }
+  return manifest.publishConfig.executableFiles
+    .filter((rel) => typeof rel === "string")
+    .map((rel) => rel.replace(/^\.\//, ""))
+    .filter((rel) => rel.startsWith("bin/"));
 }
 
 function hasExecutableMode(mode) {

--- a/scripts/build-current.cjs
+++ b/scripts/build-current.cjs
@@ -66,13 +66,23 @@ if (plan === undefined) {
 }
 
 for (const target of plan) {
-  if (target === PLATFORM) run(["--dir", platformDir, "build"]);
-  else run(["--filter", target, "build"]);
+  if (target === PLATFORM) {
+    run(
+      ["--dir", platformDir, "build"],
+      scope === "experimental" ? { TTSC_PLATFORM_BUILD_TARGETS: "ttsc" } : {},
+    );
+  } else {
+    run(["--filter", target, "build"]);
+  }
 }
 
-function run(args) {
+function run(args, extraEnv = {}) {
   const result = cp.spawnSync(...pnpmCommand(args), {
     cwd: root,
+    env: {
+      ...process.env,
+      ...extraEnv,
+    },
     stdio: "inherit",
     windowsHide: true,
   });

--- a/scripts/build-platform-package.cjs
+++ b/scripts/build-platform-package.cjs
@@ -33,6 +33,7 @@ const graphFile = path.join(
   npmOs === "win32" ? "ttscgraph.exe" : "ttscgraph",
 );
 const bundledGoDir = path.join(outDir, "go");
+const buildTargets = parseBuildTargets();
 
 fs.rmSync(outDir, { recursive: true, force: true });
 fs.mkdirSync(outDir, { recursive: true });
@@ -55,64 +56,64 @@ const goBuildFlags = [
   ].join(" "),
 ];
 
-console.log(`Building ${manifest.name} -> ${path.relative(root, outFile)}`);
-cp.execFileSync(
-  buildGo,
-  ["build", ...goBuildFlags, "-o", outFile, "./cmd/platform"],
-  {
-    cwd: source,
-    env: {
-      ...process.env,
-      CGO_ENABLED: "0",
-      GOARCH: goarch,
-      GOOS: goos,
-      PATH: pathValue,
-    },
-    stdio: "inherit",
-  },
-);
-
-console.log(`Building ${manifest.name} -> ${path.relative(root, serverFile)}`);
-cp.execFileSync(
-  buildGo,
-  ["build", ...goBuildFlags, "-o", serverFile, "./cmd/ttscserver"],
-  {
-    cwd: source,
-    env: {
-      ...process.env,
-      CGO_ENABLED: "0",
-      GOARCH: goarch,
-      GOOS: goos,
-      PATH: pathValue,
-    },
-    stdio: "inherit",
-  },
-);
-
-console.log(`Building ${manifest.name} -> ${path.relative(root, graphFile)}`);
-cp.execFileSync(
-  buildGo,
-  ["build", ...goBuildFlags, "-o", graphFile, "./cmd/ttscgraph"],
-  {
-    cwd: source,
-    env: {
-      ...process.env,
-      CGO_ENABLED: "0",
-      GOARCH: goarch,
-      GOOS: goos,
-      PATH: pathValue,
-    },
-    stdio: "inherit",
-  },
-);
+buildGoTarget("ttsc", outFile, "./cmd/platform");
+buildGoTarget("ttscserver", serverFile, "./cmd/ttscserver");
+buildGoTarget("ttscgraph", graphFile, "./cmd/ttscgraph");
 
 embedGoToolchain();
 
 if (npmOs !== "win32") {
-  fs.chmodSync(outFile, 0o755);
-  fs.chmodSync(serverFile, 0o755);
-  fs.chmodSync(graphFile, 0o755);
+  chmodIfBuilt("ttsc", outFile);
+  chmodIfBuilt("ttscserver", serverFile);
+  chmodIfBuilt("ttscgraph", graphFile);
   syncExecutablePublishConfig();
+}
+
+function parseBuildTargets() {
+  const raw = process.env.TTSC_PLATFORM_BUILD_TARGETS;
+  if (!raw) {
+    return new Set(["ttsc", "ttscserver", "ttscgraph"]);
+  }
+  const targets = new Set(
+    raw
+      .split(",")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0),
+  );
+  const allowed = new Set(["ttsc", "ttscserver", "ttscgraph"]);
+  for (const target of targets) {
+    if (!allowed.has(target)) {
+      throw new Error(
+        `build-platform-package: unsupported TTSC_PLATFORM_BUILD_TARGETS entry ${JSON.stringify(target)}`,
+      );
+    }
+  }
+  if (targets.size === 0) {
+    throw new Error(
+      "build-platform-package: TTSC_PLATFORM_BUILD_TARGETS must select at least one target",
+    );
+  }
+  return targets;
+}
+
+function buildGoTarget(name, output, pkg) {
+  if (!buildTargets.has(name)) return;
+  console.log(`Building ${manifest.name} -> ${path.relative(root, output)}`);
+  cp.execFileSync(buildGo, ["build", ...goBuildFlags, "-o", output, pkg], {
+    cwd: source,
+    env: {
+      ...process.env,
+      CGO_ENABLED: "0",
+      GOARCH: goarch,
+      GOOS: goos,
+      PATH: pathValue,
+    },
+    stdio: "inherit",
+  });
+}
+
+function chmodIfBuilt(name, file) {
+  if (buildTargets.has(name)) fs.chmodSync(file, 0o755);
 }
 
 function resolveBuildGo() {
@@ -411,13 +412,11 @@ function chmodGoExecutables(rootDir) {
 function syncExecutablePublishConfig() {
   const manifestPath = path.join(cwd, "package.json");
   const current = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-  const executableFiles = [
-    "./bin/ttsc",
-    "./bin/ttscserver",
-    "./bin/ttscgraph",
-    "./bin/go/bin/go",
-    "./bin/go/bin/gofmt",
-  ];
+  const executableFiles = [];
+  if (buildTargets.has("ttsc")) executableFiles.push("./bin/ttsc");
+  if (buildTargets.has("ttscserver")) executableFiles.push("./bin/ttscserver");
+  if (buildTargets.has("ttscgraph")) executableFiles.push("./bin/ttscgraph");
+  executableFiles.push("./bin/go/bin/go", "./bin/go/bin/gofmt");
   const toolFiles = [];
   const toolDir = path.join(bundledGoDir, "pkg", "tool");
   if (fs.existsSync(toolDir)) {

--- a/tests/test-ttsc/src/features/platform/test_platform_package_tarball_requires_posix_executable_modes.ts
+++ b/tests/test-ttsc/src/features/platform/test_platform_package_tarball_requires_posix_executable_modes.ts
@@ -18,9 +18,11 @@ import {
  *
  * 1. Write a synthetic @ttsc/linux-x64 tarball with every executable at 0755.
  * 2. Write a second tarball with ttscgraph at 0644.
- * 3. Write a source package whose manifest omits pnpm executable-file metadata.
- * 4. Write a source package whose manifest omits the bundled Go tool metadata.
- * 5. Assert the platform-package verifier accepts the good tarball, rejects the
+ * 3. Write a partial tarball whose manifest declares only the executables it
+ *    carries.
+ * 4. Write a source package whose manifest omits pnpm executable-file metadata.
+ * 5. Write a source package whose manifest omits the bundled Go tool metadata.
+ * 6. Assert the platform-package verifier accepts the good tarballs, rejects the
  *    bad tarball with the offending path in stderr, and rejects unsafe source
  *    manifests before publish.
  */
@@ -32,8 +34,21 @@ export const test_platform_package_tarball_requires_posix_executable_modes =
     try {
       const good = path.join(root, "good.tgz");
       const bad = path.join(root, "bad.tgz");
+      const partial = path.join(root, "partial.tgz");
       writePlatformTarball(good, {});
       writePlatformTarball(bad, { "package/bin/ttscgraph": 0o644 });
+      writePlatformTarball(
+        partial,
+        {},
+        {
+          executableFiles: [
+            "bin/ttsc",
+            "bin/go/bin/go",
+            "bin/go/bin/gofmt",
+            "bin/go/pkg/tool/linux_amd64/compile",
+          ],
+        },
+      );
 
       const script = path.join(
         workspaceRoot,
@@ -46,6 +61,17 @@ export const test_platform_package_tarball_requires_posix_executable_modes =
         windowsHide: true,
       });
       assert.equal(ok.status, 0, ok.stderr);
+
+      const partialOk = child_process.spawnSync(
+        process.execPath,
+        [script, partial],
+        {
+          cwd: workspaceRoot,
+          encoding: "utf8",
+          windowsHide: true,
+        },
+      );
+      assert.equal(partialOk.status, 0, partialOk.stderr);
 
       const rejected = child_process.spawnSync(
         process.execPath,
@@ -133,24 +159,42 @@ function writePlatformSourcePackage(
   }
 }
 
-function writePlatformTarball(file: string, modes: Record<string, number>) {
+function writePlatformTarball(
+  file: string,
+  modes: Record<string, number>,
+  options: { executableFiles?: string[] } = {},
+) {
+  const executableFiles = options.executableFiles ?? [
+    "bin/ttsc",
+    "bin/ttscserver",
+    "bin/ttscgraph",
+    "bin/go/bin/go",
+    "bin/go/bin/gofmt",
+    "bin/go/pkg/tool/linux_amd64/compile",
+  ];
+  const manifest: {
+    name: string;
+    publishConfig?: { executableFiles: string[] };
+    version: string;
+  } = {
+    name: "@ttsc/linux-x64",
+    version: "0.0.0",
+  };
+  if (options.executableFiles !== undefined) {
+    manifest.publishConfig = {
+      executableFiles: executableFiles.map((rel) => `./${rel}`),
+    };
+  }
   const entries: TarEntry[] = [
     {
-      content: JSON.stringify({ name: "@ttsc/linux-x64", version: "0.0.0" }),
+      content: JSON.stringify(manifest),
       mode: 0o644,
       name: "package/package.json",
     },
-    ...[
-      "package/bin/ttsc",
-      "package/bin/ttscserver",
-      "package/bin/ttscgraph",
-      "package/bin/go/bin/go",
-      "package/bin/go/bin/gofmt",
-      "package/bin/go/pkg/tool/linux_amd64/compile",
-    ].map((name) => ({
+    ...executableFiles.map((rel) => ({
       content: "x",
-      mode: modes[name] ?? 0o755,
-      name,
+      mode: modes[`package/${rel}`] ?? 0o755,
+      name: `package/${rel}`,
     })),
   ];
   fs.writeFileSync(


### PR DESCRIPTION
## Intent

Reduce `experimental.yml` variance by avoiding unused native platform binaries in the current-platform tarball build. The experimental smoke tests execute the platform `ttsc` helper and bundled Go toolchain, but do not call `ttscserver` or `ttscgraph`.

## Scope

- Adds `TTSC_PLATFORM_BUILD_TARGETS` to `scripts/build-platform-package.cjs`, defaulting to the existing full set: `ttsc`, `ttscserver`, `ttscgraph`.
- Makes `scripts/build-current.cjs` pass `TTSC_PLATFORM_BUILD_TARGETS=ttsc` only for `TTSC_BUILD_SCOPE=experimental` platform builds.
- Keeps full/release builds unchanged when the new env var is unset.

## Test Plan

- `pnpm format`
- `node --check scripts/build-current.cjs`
- `node --check scripts/build-platform-package.cjs`
- Stubbed `build-current` probe: experimental scope passes `TTSC_PLATFORM_BUILD_TARGETS=ttsc` only to the platform build.
- Stubbed platform package probe: `TTSC_PLATFORM_BUILD_TARGETS=ttsc` builds only `./cmd/platform` and skips `ttscserver`/`ttscgraph`.
- Stubbed default platform package probe: env unset builds `./cmd/platform`, `./cmd/ttscserver`, and `./cmd/ttscgraph`.
- Stubbed linux partial probe: `publishConfig.executableFiles` includes only existing selected native binaries plus bundled Go executables.
- `git diff --check -- scripts/build-current.cjs scripts/build-platform-package.cjs`