### PR TITLE
fix(ttsc): reclaim stale source-plugin locks

### DIFF
--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -104,6 +104,9 @@ const CONTRIB_DIRNAME = "contrib";
 // runtimeHooks.ts.
 const PLUGIN_BUILD_LOCK_STEAL_MS = 600_000;
 const PLUGIN_BUILD_LOCK_POLL_MS = 50;
+const PLUGIN_BUILD_LOCK_LEGACY_STALE_MS = 30_000;
+const PLUGIN_BUILD_LOCK_STATUS_MS = 30_000;
+const PLUGIN_BUILD_LOCK_OWNER_FILE = "owner.json";
 // The default cache lives INSIDE the workspace, at
 // `<workspaceRoot>/node_modules/.cache/ttsc`, so `rm -rf node_modules` (or
 // deleting the repo) reclaims every compiled plugin binary and Go object file.
@@ -192,22 +195,28 @@ export function buildSourcePlugin(opts: {
     return binaryPath;
   }
   fs.mkdirSync(cacheDir, { recursive: true });
-  return buildUnderPluginLock(cacheDir, binaryPath, () =>
-    compileSourcePlugin({
-      binaryPath,
-      cacheDir,
-      contributors,
-      dir,
-      entry,
-      goBinary,
-      key,
-      label: opts.label ?? "source plugin",
-      goBuildCacheRoot: paths.goBuildRoot,
-      overlayDirs,
-      pluginName: opts.pluginName,
-      quiet: opts.quiet === true,
-      source,
-    }),
+  const label = opts.label ?? "source plugin";
+  const quiet = opts.quiet === true;
+  return buildUnderPluginLock(
+    cacheDir,
+    binaryPath,
+    { label, pluginName: opts.pluginName, quiet },
+    () =>
+      compileSourcePlugin({
+        binaryPath,
+        cacheDir,
+        contributors,
+        dir,
+        entry,
+        goBinary,
+        key,
+        label,
+        goBuildCacheRoot: paths.goBuildRoot,
+        overlayDirs,
+        pluginName: opts.pluginName,
+        quiet,
+        source,
+      }),
   );
 }
 
@@ -235,7 +244,8 @@ function compileSourcePlugin(opts: {
             .map((c) => c.name)
             .join(", ")}`;
     process.stderr.write(
-      `ttsc: building ${opts.label} "${opts.pluginName}" from ${opts.source}${extra} (this runs once per cache key)\n`,
+      `ttsc: building ${opts.label} "${opts.pluginName}" from ${opts.source}${extra} ` +
+        `(this runs once per cache key and can take several minutes on a cold Go cache)\n`,
     );
   }
 
@@ -294,6 +304,11 @@ function compileSourcePlugin(opts: {
 function buildUnderPluginLock(
   cacheDir: string,
   binaryPath: string,
+  lockInfo: {
+    label: string;
+    pluginName: string;
+    quiet: boolean;
+  },
   build: () => string,
 ): string {
   const lockDir = `${cacheDir}.lock`;
@@ -308,6 +323,7 @@ function buildUnderPluginLock(
       // exists, so a single-level mkdir is all that is needed and its EEXIST
       // is exactly the "someone else holds the lock" signal.
       fs.mkdirSync(lockDir);
+      writePluginBuildLockOwner(lockDir);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
         // A lock dir we cannot create for an unexpected reason (e.g. a
@@ -315,14 +331,17 @@ function buildUnderPluginLock(
         // unlocked build — correctness is preserved by the atomic publish.
         return build();
       }
-      const waited = waitForPluginBinary(
+      const waited = waitForPluginBinary({
         binaryPath,
-        PLUGIN_BUILD_LOCK_STEAL_MS,
-      );
-      if (waited) {
+        lockDir,
+        lockInfo,
+        timeoutMs: PLUGIN_BUILD_LOCK_STEAL_MS,
+      });
+      if (waited.published) {
         touchCacheEntry(cacheDir);
         return binaryPath;
       }
+      reportPluginLockSteal(lockDir, binaryPath, lockInfo, waited.reason);
       // Builder appears to have crashed: steal the abandoned lock and retry.
       fs.rmSync(lockDir, { force: true, recursive: true });
       continue;
@@ -341,17 +360,214 @@ function buildUnderPluginLock(
 }
 
 /** Poll for the locked builder to publish its binary, up to `timeoutMs`. */
-function waitForPluginBinary(binaryPath: string, timeoutMs: number): boolean {
+function waitForPluginBinary(opts: {
+  binaryPath: string;
+  lockDir: string;
+  lockInfo: {
+    label: string;
+    pluginName: string;
+    quiet: boolean;
+  };
+  timeoutMs: number;
+}): { published: boolean; reason?: string } {
   const startedAt = Date.now();
+  let nextStatusAt = startedAt + PLUGIN_BUILD_LOCK_STATUS_MS;
   for (;;) {
-    if (fs.existsSync(binaryPath)) {
-      return true;
+    if (fs.existsSync(opts.binaryPath)) {
+      return { published: true };
     }
-    if (Date.now() - startedAt > timeoutMs) {
-      return false;
+    const now = Date.now();
+    const lockStatus = inspectPluginBuildLock(opts.lockDir, now);
+    if (lockStatus.abandoned) {
+      return {
+        published: false,
+        reason: lockStatus.reason,
+      };
+    }
+    if (now - startedAt > opts.timeoutMs) {
+      return {
+        published: false,
+        reason: `timed out after ${formatDuration(now - startedAt)}`,
+      };
+    }
+    if (!opts.lockInfo.quiet && now >= nextStatusAt) {
+      reportPluginLockWait({
+        binaryPath: opts.binaryPath,
+        elapsedMs: now - startedAt,
+        lockDir: opts.lockDir,
+        lockInfo: opts.lockInfo,
+        owner: lockStatus.owner,
+      });
+      nextStatusAt = now + PLUGIN_BUILD_LOCK_STATUS_MS;
     }
     sleepSync(PLUGIN_BUILD_LOCK_POLL_MS);
   }
+}
+
+function writePluginBuildLockOwner(lockDir: string): void {
+  try {
+    fs.writeFileSync(
+      path.join(lockDir, PLUGIN_BUILD_LOCK_OWNER_FILE),
+      `${JSON.stringify(
+        {
+          hostname: os.hostname(),
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+  } catch {
+    // Best-effort metadata: the mkdir lock still serializes the build.
+  }
+}
+
+function inspectPluginBuildLock(
+  lockDir: string,
+  now: number,
+): {
+  abandoned: boolean;
+  owner: string;
+  reason?: string;
+} {
+  const owner = readPluginBuildLockOwner(lockDir);
+  if (owner !== null) {
+    const label = describePluginBuildLockOwner(owner);
+    if (isLocalHostName(owner.hostname) && !isProcessAlive(owner.pid)) {
+      return {
+        abandoned: true,
+        owner: label,
+        reason: `${label} is no longer running`,
+      };
+    }
+    return {
+      abandoned: false,
+      owner: label,
+    };
+  }
+
+  const ageMs = pluginBuildLockAgeMs(lockDir, now);
+  if (ageMs > PLUGIN_BUILD_LOCK_LEGACY_STALE_MS) {
+    return {
+      abandoned: true,
+      owner: `legacy lock with no ${PLUGIN_BUILD_LOCK_OWNER_FILE}`,
+      reason:
+        `legacy lock has no ${PLUGIN_BUILD_LOCK_OWNER_FILE} and is ` +
+        `${formatDuration(ageMs)} old`,
+    };
+  }
+  return {
+    abandoned: false,
+    owner: `legacy lock with no ${PLUGIN_BUILD_LOCK_OWNER_FILE}`,
+  };
+}
+
+function readPluginBuildLockOwner(
+  lockDir: string,
+): { hostname: string; pid: number; startedAt?: string } | null {
+  try {
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(lockDir, PLUGIN_BUILD_LOCK_OWNER_FILE), "utf8"),
+    ) as Record<string, unknown>;
+    if (
+      typeof parsed.hostname !== "string" ||
+      !Number.isInteger(parsed.pid) ||
+      typeof parsed.pid !== "number" ||
+      parsed.pid <= 0
+    ) {
+      return null;
+    }
+    return {
+      hostname: parsed.hostname,
+      pid: parsed.pid,
+      startedAt:
+        typeof parsed.startedAt === "string" ? parsed.startedAt : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function pluginBuildLockAgeMs(lockDir: string, now: number): number {
+  try {
+    return Math.max(0, now - fs.statSync(lockDir).mtimeMs);
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function isLocalHostName(hostname: string): boolean {
+  return hostname.toLowerCase() === os.hostname().toLowerCase();
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function describePluginBuildLockOwner(owner: {
+  hostname: string;
+  pid: number;
+  startedAt?: string;
+}): string {
+  const started =
+    owner.startedAt === undefined ? "" : ` started at ${owner.startedAt}`;
+  return `pid ${owner.pid} on ${owner.hostname}${started}`;
+}
+
+function reportPluginLockWait(opts: {
+  binaryPath: string;
+  elapsedMs: number;
+  lockDir: string;
+  lockInfo: {
+    label: string;
+    pluginName: string;
+    quiet: boolean;
+  };
+  owner: string;
+}): void {
+  process.stderr.write(
+    `ttsc: waiting for ${opts.lockInfo.label} "${opts.lockInfo.pluginName}" ` +
+      `cache lock after ${formatDuration(opts.elapsedMs)}; ` +
+      `lock=${opts.lockDir}; binary=${opts.binaryPath}; owner=${opts.owner}\n`,
+  );
+}
+
+function reportPluginLockSteal(
+  lockDir: string,
+  binaryPath: string,
+  lockInfo: {
+    label: string;
+    pluginName: string;
+    quiet: boolean;
+  },
+  reason: string | undefined,
+): void {
+  if (lockInfo.quiet) return;
+  const suffix = reason === undefined ? "" : ` (${reason})`;
+  process.stderr.write(
+    `ttsc: reclaiming abandoned ${lockInfo.label} "${lockInfo.pluginName}" ` +
+      `cache lock at ${lockDir}; binary=${binaryPath}${suffix}\n`,
+  );
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1_000) {
+    return `${Math.max(0, Math.round(ms))}ms`;
+  }
+  const seconds = Math.floor(ms / 1_000);
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  if (minutes === 0) {
+    return `${seconds}s`;
+  }
+  return `${minutes}m ${remainder}s`;
 }
 
 /** Block the current (synchronous) thread for `ms` without busy-spinning. */

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_reclaims_stale_legacy_plugin_lock.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_reclaims_stale_legacy_plugin_lock.ts
@@ -1,0 +1,103 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  buildSourcePlugin,
+  computeCacheKey,
+  createFakeGoBinary,
+  fs,
+  path,
+  resolveSourceBuildCachePaths,
+} from "../../internal/source-build";
+
+/**
+ * Verifies buildSourcePlugin reclaims stale legacy plugin locks.
+ *
+ * A killed 0.18.0 source-plugin build can leave `<cache-key>.lock` without a
+ * published binary or owner metadata. Waiting ten silent minutes makes the CLI
+ * look wedged, so ttsc must recognize an old metadata-less lock as abandoned
+ * and retry the build under a fresh lock.
+ *
+ * 1. Create a source-plugin cache entry with an old `.lock` directory and no
+ *    binary.
+ * 2. Run `buildSourcePlugin` through the fake Go toolchain.
+ * 3. Assert the plugin binary is published and the stale lock is removed.
+ */
+export const test_buildsourceplugin_reclaims_stale_legacy_plugin_lock = () => {
+  const root = TestProject.tmpdir("ttsc-source-plugin-");
+  const plugin = path.join(root, "plugin");
+  writePluginSource(plugin);
+  const cacheDir = path.join(root, "cache");
+
+  const fakeGo = createFakeGoBinary(root);
+  const saved = {
+    go: process.env.TTSC_GO_BINARY,
+    cache: process.env.TTSC_CACHE_DIR,
+    goCache: process.env.TTSC_GO_CACHE_DIR,
+    gocache: process.env.GOCACHE,
+  };
+  process.env.TTSC_GO_BINARY = fakeGo;
+  delete process.env.TTSC_CACHE_DIR;
+  delete process.env.TTSC_GO_CACHE_DIR;
+  delete process.env.GOCACHE;
+  try {
+    const key = computeCacheKey({
+      dir: plugin,
+      entry: ".",
+      goBinary: fakeGo,
+      overlayDirs: [],
+      ttscVersion: "1.0.0",
+      tsgoVersion: "7.0.0-dev",
+    });
+    const paths = resolveSourceBuildCachePaths(root, cacheDir);
+    const cacheEntry = path.join(paths.pluginRoot, key);
+    const lockDir = `${cacheEntry}.lock`;
+    fs.mkdirSync(cacheEntry, { recursive: true });
+    fs.mkdirSync(lockDir, { recursive: true });
+    const old = new Date(Date.now() - 120_000);
+    fs.utimesSync(lockDir, old, old);
+
+    const binary = buildSourcePlugin({
+      baseDir: root,
+      cacheDir,
+      overlayDirs: [],
+      pluginName: "stale-lock",
+      source: plugin,
+      quiet: true,
+      ttscVersion: "1.0.0",
+      tsgoVersion: "7.0.0-dev",
+    });
+
+    assert.equal(fs.existsSync(binary), true);
+    assert.equal(fs.existsSync(lockDir), false);
+  } finally {
+    restore("TTSC_GO_BINARY", saved.go);
+    restore("TTSC_CACHE_DIR", saved.cache);
+    restore("TTSC_GO_CACHE_DIR", saved.goCache);
+    restore("GOCACHE", saved.gocache);
+  }
+};
+
+function writePluginSource(root: string): void {
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "go.mod"),
+    "module example.com/plugin\n\ngo 1.26\n",
+    "utf8",
+  );
+  fs.writeFileSync(path.join(root, "main.go"), "package main\n", "utf8");
+  for (const file of [
+    "vendor/local/value.go",
+    "lib/helper.go",
+    "dist/generated.go",
+    "build/generated.go",
+  ]) {
+    fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+    fs.writeFileSync(path.join(root, file), "package main\n", "utf8");
+  }
+}
+
+function restore(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_ttsc_reclaims_stale_legacy_source_plugin_lock_e2e.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_ttsc_reclaims_stale_legacy_source_plugin_lock_e2e.ts
@@ -1,0 +1,75 @@
+import { TestProject } from "@ttsc/testing";
+
+import { goPath, spawn, ttscBin } from "../../internal/plugin-corpus";
+import {
+  assert,
+  buildSourcePlugin,
+  fs,
+  path,
+} from "../../internal/source-build";
+
+/**
+ * Verifies ttsc e2e: reclaims stale legacy source-plugin locks.
+ *
+ * The hang report reached the CLI through package plugin discovery and then
+ * stalled in the shared source-plugin cache. The lower-level lock test pins the
+ * helper branch; this e2e keeps the launcher/loadProjectPlugins path honest by
+ * running `ttsc -p tsconfig.json --noEmit` against the same abandoned lock.
+ *
+ * 1. Seed the exact source-plugin cache entry with a binary, then replace it with
+ *    an old metadata-less `.lock` directory.
+ * 2. Run the real local `ttsc` launcher with that cache directory.
+ * 3. Assert the CLI exits successfully and reports reclaiming the abandoned lock
+ *    instead of waiting for the legacy timeout.
+ */
+export const test_ttsc_reclaims_stale_legacy_source_plugin_lock_e2e = () => {
+  const root = TestProject.copyProject("go-source-plugin");
+  const plugin = path.join(root, "go-plugin");
+  const cacheDir = path.join(root, "cache");
+  const savedPath = process.env.PATH;
+  process.env.PATH = goPath();
+  try {
+    const binary = buildSourcePlugin({
+      baseDir: root,
+      cacheDir,
+      pluginName: "go-source-plugin",
+      source: plugin,
+      quiet: true,
+      ttscVersion: readWorkspaceTtscVersion(),
+      tsgoVersion: "unknown",
+    });
+    const lockDir = `${path.dirname(binary)}.lock`;
+    fs.rmSync(binary, { force: true });
+    fs.mkdirSync(lockDir, { recursive: true });
+    const old = new Date(Date.now() - 120_000);
+    fs.utimesSync(lockDir, old, old);
+
+    const result = spawn(ttscBin, ["-p", "tsconfig.json", "--noEmit"], {
+      cwd: root,
+      env: {
+        TTSC_CACHE_DIR: cacheDir,
+        PATH: process.env.PATH,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stderr, /reclaiming abandoned source plugin/);
+    assert.match(result.stderr, /building source plugin "go-source-plugin"/);
+  } finally {
+    if (savedPath === undefined) delete process.env.PATH;
+    else process.env.PATH = savedPath;
+  }
+};
+
+function readWorkspaceTtscVersion(): string {
+  const file = path.join(
+    TestProject.WORKSPACE_ROOT,
+    "packages",
+    "ttsc",
+    "package.json",
+  );
+  const pkg = JSON.parse(fs.readFileSync(file, "utf8")) as {
+    version?: string;
+  };
+  return pkg.version ?? "0.0.0";
+}


### PR DESCRIPTION
## Intent

Fixes #340. A killed cold source-plugin build could leave a cache lock directory without a plugin binary. The next ttsc run then waited silently for the full ten-minute steal timeout, which looked like a permanent hang.

## Scope

- Record source-plugin cache lock owner metadata for new builders.
- Reclaim old metadata-less locks after a short stale window instead of waiting ten minutes.
- Detect dead same-host lock owners by PID.
- Print periodic wait diagnostics with lock and binary paths.
- Clarify cold Go cache build output so a legitimate first build is recognizable.
- Add both direct cache-lock regression coverage and a CLI e2e over 	tsc -p tsconfig.json --noEmit.

## Test Plan

- pnpm format
- pnpm --filter ttsc build
- TTSC_TEST_DIR=native-plugins/source-plugin pnpm --dir tests/test-ttsc start
- pnpm run test:typecheck
- Manual repro in D:/github/samchon/nestia.examples/nestia-start/packages/api with local launcher: cold --noEmit completed in 116s; warm cache completed in 3.7s.

## Notes

pnpm run build:current is not green locally on Windows because @ttsc/unplugin fails in Rollup's ollup-plugin-node-externals with TypeError: undefined is not a function; this is outside the changed source-plugin lock path.