### PR TITLE
fix(lint): preserve shared config composition

### DIFF
--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -898,7 +898,7 @@ func loadConfigFile(location string) (any, error) {
 // configCacheVersion namespaces the on-disk config cache. Bump it whenever
 // the shape of a cached config object changes so that entries written by an
 // older @ttsc/lint binary are treated as a miss rather than silently reused.
-const configCacheVersion = "v1"
+const configCacheVersion = "v2"
 
 // configEvalCache memoizes evaluated .ts/.js lint config objects for the
 // lifetime of one process; the on-disk cache (configCacheDir) extends the
@@ -1115,35 +1115,18 @@ func runConfigLoaderCommand(ctx context.Context, cmd *exec.Cmd, location, label 
 
 // loadScriptConfigFile evaluates a .js/.cjs/.mjs config file by running a
 // Node subprocess that dynamic-imports the file, resolves the exported config
-// through the same 8-hop default/config unwrap used by the TS loader, and
+// through the same 8-hop default/config normalization used by the TS loader, and
 // serializes the result as JSON to stdout. The subprocess has a
 // configLoaderTimeout deadline to prevent user code from hanging indefinitely.
 func loadScriptConfigFile(location string) (any, error) {
   script := fmt.Sprintf(`
 const { pathToFileURL } = require("node:url");
 
+const CONFIG_KEYS = new Set([%s]);
+
 (async () => {
   const mod = await import(pathToFileURL(process.argv[1]).href);
-  let current = mod;
-  let allowNamedConfig = true;
-  // Match the 8-hop walk used by the TypeScript loader at
-  // `+"`"+`typeScriptConfigLoaderSource`+"`"+` so doubly-wrapped CJS/ESM
-  // interop (e.g. `+"`"+`{default:{default:config}}`+"`"+`) is resolved
-  // consistently across .js/.cjs/.mjs and .ts/.cts/.mts loaders.
-  for (let i = 0; i < 8; i++) {
-    if (current !== null && typeof current === "object" && Object.prototype.hasOwnProperty.call(current, "default")) {
-      current = current.default;
-      allowNamedConfig = false;
-      continue;
-    }
-    if (allowNamedConfig && current !== null && typeof current === "object" && Object.prototype.hasOwnProperty.call(current, "config")) {
-      current = current.config;
-      allowNamedConfig = false;
-      continue;
-    }
-    break;
-  }
-  const value = typeof current === "function" ? await current() : current;
+  const value = await resolveConfig(mod, true);
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("config file must export an ITtscLintConfig object");
   }
@@ -1153,13 +1136,70 @@ const { pathToFileURL } = require("node:url");
   process.exit(1);
 });
 
+async function resolveConfig(value, allowNamedConfig) {
+  let current = value;
+  for (let i = 0; i < 8; i++) {
+    if (typeof current === "function") {
+      current = await current();
+      allowNamedConfig = false;
+      continue;
+    }
+    if (current !== null && typeof current === "object" && !Array.isArray(current)) {
+      if (Object.prototype.hasOwnProperty.call(current, "default")) {
+        const defaultValue = current.default;
+        if (isModuleNamespace(current) || !hasConfigKey(current)) {
+          current = defaultValue;
+          allowNamedConfig = false;
+          continue;
+        }
+        const normalizedDefault = await resolveConfig(defaultValue, false);
+        if (normalizedDefault !== null && typeof normalizedDefault === "object" && !Array.isArray(normalizedDefault)) {
+          current = mergeConfigObjects(normalizedDefault, current);
+          allowNamedConfig = false;
+          continue;
+        }
+      }
+      if (allowNamedConfig && Object.prototype.hasOwnProperty.call(current, "config")) {
+        current = current.config;
+        allowNamedConfig = false;
+        continue;
+      }
+    }
+    break;
+  }
+  return current;
+}
+
+function isModuleNamespace(value) {
+  return Object.prototype.toString.call(value) === "[object Module]";
+}
+
+function hasConfigKey(value) {
+  for (const key of CONFIG_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(value, key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function mergeConfigObjects(base, override) {
+  const out = toSerializableConfig(base);
+  for (const key of CONFIG_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(override, key)) {
+      out[key] = override[key];
+    }
+  }
+  return out;
+}
+
 // toSerializableConfig copies every ITtscLintConfig key onto a plain object so
 // it survives the JSON round trip to the Go sidecar. Every key is copied
 // verbatim — files, ignores, extends, plugins, rules, AND format — so a config
 // whose only key is `+"`"+`format`+"`"+` is not silently dropped.
 function toSerializableConfig(value) {
   const out = {};
-  for (const key of [%s]) {
+  for (const key of CONFIG_KEYS) {
     if (Object.prototype.hasOwnProperty.call(value, key)) {
       out[key] = value[key];
     }
@@ -1181,7 +1221,7 @@ function toSerializableConfig(value) {
 // an ephemeral loader script and tsconfig into a temp directory, symlinking the
 // nearest node_modules, then running `ttsx` with a configLoaderTimeout deadline.
 // The loader script imports the config file, resolves it through the same
-// unwrap chain used by loadScriptConfigFile, and writes JSON to stdout.
+// normalization chain used by loadScriptConfigFile, and writes JSON to stdout.
 func loadTypeScriptConfigFile(location string) (any, error) {
   tempDir, err := os.MkdirTemp(loaderTempBase(location, os.TempDir()), "ttsc-lint-config-")
   if err != nil {
@@ -1291,6 +1331,7 @@ func uncFileURL(pathname string) string {
 // statically resolve the file URL during the loader build.
 func typeScriptConfigLoaderSource(importLiteral string) string {
   return fmt.Sprintf(`const configUrl = %s;
+const CONFIG_KEYS = new Set<string>([%s]);
 const importedConfig = await import(configUrl);
 
 declare const process: {
@@ -1313,20 +1354,33 @@ try {
 async function resolveConfig(value: unknown, allowNamedConfig: boolean): Promise<unknown> {
   let current = value;
   for (let i = 0; i < 8; i++) {
-    if (isObject(current) && hasOwn(current, "default")) {
-      current = current.default;
+    if (typeof current === "function") {
+      current = await (current as () => unknown | Promise<unknown>)();
       allowNamedConfig = false;
       continue;
     }
-    if (allowNamedConfig && isObject(current) && hasOwn(current, "config")) {
-      current = current.config;
-      allowNamedConfig = false;
-      continue;
+    if (isObject(current) && !Array.isArray(current)) {
+      if (hasOwn(current, "default")) {
+        const defaultValue = current.default;
+        if (isModuleNamespace(current) || !hasConfigKey(current)) {
+          current = defaultValue;
+          allowNamedConfig = false;
+          continue;
+        }
+        const normalizedDefault = await resolveConfig(defaultValue, false);
+        if (isObject(normalizedDefault) && !Array.isArray(normalizedDefault)) {
+          current = mergeConfigObjects(normalizedDefault, current);
+          allowNamedConfig = false;
+          continue;
+        }
+      }
+      if (allowNamedConfig && hasOwn(current, "config")) {
+        current = current.config;
+        allowNamedConfig = false;
+        continue;
+      }
     }
     break;
-  }
-  if (typeof current === "function") {
-    return await (current as () => unknown | Promise<unknown>)();
   }
   return current;
 }
@@ -1339,13 +1393,39 @@ function hasOwn(value: Record<string, unknown>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(value, key);
 }
 
+function isModuleNamespace(value: Record<string, unknown>): boolean {
+  return Object.prototype.toString.call(value) === "[object Module]";
+}
+
+function hasConfigKey(value: Record<string, unknown>): boolean {
+  for (const key of CONFIG_KEYS) {
+    if (hasOwn(value, key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function mergeConfigObjects(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>,
+): Record<string, unknown> {
+  const out = toSerializableConfig(base);
+  for (const key of CONFIG_KEYS) {
+    if (hasOwn(override, key)) {
+      out[key] = override[key];
+    }
+  }
+  return out;
+}
+
 // toSerializableConfig copies every ITtscLintConfig key onto a plain object so
 // it survives the JSON round trip to the Go sidecar. Every key is copied
 // verbatim — files, ignores, extends, plugins, rules, AND format — so a config
 // whose only key is "format" is not silently dropped.
 function toSerializableConfig(value: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
-  for (const key of [%s]) {
+  for (const key of CONFIG_KEYS) {
     if (hasOwn(value, key)) {
       out[key] = value[key];
     }

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -396,6 +396,14 @@ function readCjsConfigPlugins(configPath: string): ConfigPluginEntry[] {
 // serialise arbitrary in-memory plugin objects across the process boundary.
 // The URL lives in a variable so tsgo does not statically resolve it.
 const TTSX_EXTRACTOR_SCRIPT = `const configUrl = %CONFIG_IMPORT%;
+const CONFIG_KEYS = new Set<string>([
+  "files",
+  "ignores",
+  "extends",
+  "plugins",
+  "rules",
+  "format",
+]);
 const importedConfig = await import(configUrl);
 
 declare const process: {
@@ -406,17 +414,7 @@ declare const process: {
 };
 
 try {
-  let current: unknown = importedConfig;
-  for (let i = 0; i < 8; i++) {
-    if (isObject(current) && hasOwn(current, "default")) {
-      current = (current as Record<string, unknown>).default;
-      continue;
-    }
-    break;
-  }
-  if (typeof current === "function") {
-    current = await (current as () => unknown | Promise<unknown>)();
-  }
+  const current = await resolveConfig(importedConfig, true);
   const pluginMaps = collectPluginObjects(current);
   const entries: Array<{ namespace: string; source: string }> = [];
   for (const map of pluginMaps) {
@@ -438,6 +436,71 @@ function isObject(value: unknown): value is Record<string, unknown> {
 
 function hasOwn(value: Record<string, unknown>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+async function resolveConfig(value: unknown, allowNamedConfig: boolean): Promise<unknown> {
+  let current = value;
+  for (let i = 0; i < 8; i++) {
+    if (typeof current === "function") {
+      current = await (current as () => unknown | Promise<unknown>)();
+      allowNamedConfig = false;
+      continue;
+    }
+    if (isObject(current) && !Array.isArray(current)) {
+      if (hasOwn(current, "default")) {
+        const defaultValue = current.default;
+        if (isModuleNamespace(current) || !hasConfigKey(current)) {
+          current = defaultValue;
+          allowNamedConfig = false;
+          continue;
+        }
+        const normalizedDefault = await resolveConfig(defaultValue, false);
+        if (isObject(normalizedDefault) && !Array.isArray(normalizedDefault)) {
+          current = mergeConfigObjects(normalizedDefault, current);
+          allowNamedConfig = false;
+          continue;
+        }
+      }
+      if (allowNamedConfig && hasOwn(current, "config")) {
+        current = current.config;
+        allowNamedConfig = false;
+        continue;
+      }
+    }
+    break;
+  }
+  return current;
+}
+
+function isModuleNamespace(value: Record<string, unknown>): boolean {
+  return Object.prototype.toString.call(value) === "[object Module]";
+}
+
+function hasConfigKey(value: Record<string, unknown>): boolean {
+  for (const key of CONFIG_KEYS) {
+    if (hasOwn(value, key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function mergeConfigObjects(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of CONFIG_KEYS) {
+    if (hasOwn(base, key)) {
+      out[key] = base[key];
+    }
+  }
+  for (const key of CONFIG_KEYS) {
+    if (hasOwn(override, key)) {
+      out[key] = override[key];
+    }
+  }
+  return out;
 }
 
 function collectPluginObjects(value: unknown): Array<Record<string, unknown>> {
@@ -684,7 +747,7 @@ function evaluateTtsxConfigPlugins(
  * Namespaces the on-disk config cache. Kept in lockstep with the Go sidecar's
  * `configCacheVersion`; bump both when the cached shape changes.
  */
-const CONFIG_CACHE_VERSION = "v1";
+const CONFIG_CACHE_VERSION = "v2";
 
 /**
  * Directory shared by this factory and the Go sidecar for cached lint configs.

--- a/packages/lint/test/config/files/load_rule_config_typescript_config_merges_spread_default_wrapper_test.go
+++ b/packages/lint/test/config/files/load_rule_config_typescript_config_merges_spread_default_wrapper_test.go
@@ -1,0 +1,50 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestLoadRuleConfigTypeScriptConfigMergesSpreadDefaultWrapper verifies shared config composition.
+//
+// A namespace import of another TypeScript config produces the same plain
+// `{ default: config }` shape users hit when CJS/ESM interop wraps a shared
+// config. Spreading that wrapper beside local keys must preserve both sides:
+// inherited rules and local ignores.
+//
+// 1. Write a shared `.ts` config with one rule.
+// 2. Write a package `.ts` config that spreads the module wrapper and adds an ignore.
+// 3. Assert the rule applies to normal files but not to the ignored path.
+func TestLoadRuleConfigTypeScriptConfigMergesSpreadDefaultWrapper(t *testing.T) {
+  dir := t.TempDir()
+  writeFile(t, filepath.Join(dir, "tsconfig.json"), "{}")
+  writeFile(t, filepath.Join(dir, "shared-lint.config.ts"), `export default {
+  rules: {
+    "no-debugger": "error",
+  },
+};`)
+  writeFile(t, filepath.Join(dir, "ttsc-lint.config.ts"), `import * as shared from "./shared-lint.config.ts";
+
+export default {
+  ...shared,
+  ignores: ["src/functional/**/*.ts"],
+};`)
+
+  resolver, err := LoadConfigResolver(&PluginEntry{
+    Config: map[string]any{
+      "configFile": "./ttsc-lint.config.ts",
+    },
+  }, dir, "tsconfig.json")
+  if err != nil {
+    t.Fatalf("LoadConfigResolver: %v", err)
+  }
+
+  main := resolver.ResolveRules(filepath.Join(dir, "src", "main.ts"))
+  if main.Rules.Severity("no-debugger") != SeverityError {
+    t.Fatalf("main no-debugger: want error from shared config, got %v", main.Rules.Severity("no-debugger"))
+  }
+  ignored := resolver.ResolveRules(filepath.Join(dir, "src", "functional", "api.ts"))
+  if ignored.Rules.Severity("no-debugger") != SeverityOff {
+    t.Fatalf("ignored no-debugger: want off from local ignores, got %v", ignored.Rules.Severity("no-debugger"))
+  }
+}

--- a/packages/lint/test/config/files/load_rule_config_typescript_factory_merges_returned_default_wrapper_test.go
+++ b/packages/lint/test/config/files/load_rule_config_typescript_factory_merges_returned_default_wrapper_test.go
@@ -1,0 +1,67 @@
+package linthost
+
+import (
+  "encoding/json"
+  "path/filepath"
+  "testing"
+)
+
+// TestLoadRuleConfigTypeScriptFactoryMergesReturnedDefaultWrapper verifies async factory composition.
+//
+// A `lint.config.ts` factory can dynamically import a shared config and return
+// a spread module wrapper with local keys. The loader must normalize the value
+// after the factory call, otherwise only the local keys survive and inherited
+// rules or format options disappear.
+//
+// 1. Write a shared `.ts` config with rules and format options.
+// 2. Write an async package config that dynamically imports and spreads it.
+// 3. Assert shared rules and format options survive beside the local ignores.
+func TestLoadRuleConfigTypeScriptFactoryMergesReturnedDefaultWrapper(t *testing.T) {
+  dir := t.TempDir()
+  writeFile(t, filepath.Join(dir, "tsconfig.json"), "{}")
+  writeFile(t, filepath.Join(dir, "shared-lint.config.ts"), `export default {
+  format: { semi: false },
+  rules: {
+    "no-debugger": "error",
+  },
+};`)
+  writeFile(t, filepath.Join(dir, "ttsc-lint.config.ts"), `export default async () => {
+  const shared = await import("./shared-lint.config.ts");
+  return {
+    ...shared,
+    ignores: ["src/functional/**/*.ts"],
+  };
+};`)
+
+  resolver, err := LoadConfigResolver(&PluginEntry{
+    Config: map[string]any{
+      "configFile": "./ttsc-lint.config.ts",
+    },
+  }, dir, "tsconfig.json")
+  if err != nil {
+    t.Fatalf("LoadConfigResolver: %v", err)
+  }
+
+  main := resolver.ResolveRules(filepath.Join(dir, "src", "main.ts"))
+  if main.Rules.Severity("no-debugger") != SeverityError {
+    t.Fatalf("main no-debugger: want error from shared config, got %v", main.Rules.Severity("no-debugger"))
+  }
+  ignored := resolver.ResolveRules(filepath.Join(dir, "src", "functional", "api.ts"))
+  if ignored.Rules.Severity("no-debugger") != SeverityOff {
+    t.Fatalf("ignored no-debugger: want off from local ignores, got %v", ignored.Rules.Severity("no-debugger"))
+  }
+
+  raw := resolver.RuleOptions("format/semi")
+  if len(raw) == 0 {
+    t.Fatal("format block was dropped: formatSemi has no options")
+  }
+  var opts struct {
+    Prefer string `json:"prefer"`
+  }
+  if err := json.Unmarshal(raw, &opts); err != nil {
+    t.Fatalf("decode formatSemi options: %v", err)
+  }
+  if opts.Prefer != "never" {
+    t.Fatalf("prefer want \"never\" from shared format, got %q", opts.Prefer)
+  }
+}


### PR DESCRIPTION
## Intent

Fixes #342 by preserving shared `lint.config.ts` keys when CJS/ESM interop or dynamic imports expose a shared config under `default` and the package config spreads that wrapper beside local overrides.

## Scope

- Normalize config exports after factory calls, not only before them.
- Treat real module namespaces and wrapper-only objects as wrappers, but merge wrapper `default` config keys with local lint config keys when both are present.
- Keep the Go sidecar loader and JS contributor extractor in sync.
- Bump the shared lint config cache namespace so stale 0.18.0 evaluated configs are missed.
- Add Go regression tests for static wrapper spread and async factory wrapper spread.

## Test plan

- `pnpm format`
- `pnpm --filter @ttsc/lint build`
- `node scripts/test-go-lint.cjs`
- `pnpm run test:typecheck`
- `TTSC_TEST_DIR=features/config pnpm --dir tests/test-lint start`