### PR TITLE
lint: honor top-level `ignores` globally and fall back to cwd for lint-config discovery

### DIFF
--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -567,6 +567,24 @@ func collectConfigObject(store *ConfigStore, raw any, baseDir, path string, chai
     return err
   }
 
+  // An `ignores` list without a `files` filter is a GLOBAL ignore: a config
+  // file is a single ITtscLintConfig object, so its top-level `ignores` is
+  // the only way an author can say "never lint these files". It must
+  // therefore exclude the matched files from every entry of the resolved
+  // chain — including entries folded in via `extends`, which otherwise
+  // carry no ignores of their own and would keep linting the excluded
+  // files (samchon/ttsc: `extends` + `ignores` + `rules` leaked the base
+  // config's rules onto ignored paths). When `files` IS present the
+  // ignores only refine that entry's selection, matching ESLint's
+  // entry-scoped semantics, and no global entry is added.
+  if len(files) == 0 && len(ignores) > 0 {
+    store.entries = append(store.entries, ConfigEntry{
+      BaseDir:    baseDir,
+      Ignores:    ignores,
+      IgnoreOnly: true,
+    })
+  }
+
   rulesValue, hasRules := obj["rules"]
   formatValue, hasFormat := obj["format"]
   if hasRules || hasFormat {
@@ -619,15 +637,6 @@ func collectConfigObject(store *ConfigStore, raw any, baseDir, path string, chai
         Rules:   parsed,
       })
     }
-    return nil
-  }
-
-  if len(files) == 0 && len(ignores) > 0 {
-    store.entries = append(store.entries, ConfigEntry{
-      BaseDir:    baseDir,
-      Ignores:    ignores,
-      IgnoreOnly: true,
-    })
   }
   return nil
 }
@@ -774,7 +783,11 @@ func LoadConfigResolver(entry *PluginEntry, cwd, tsconfigPath string) (RuleResol
     return nil, err
   }
   if discovered == "" {
-    return nil, fmt.Errorf("%w (searched upward from %s); create one or set \"configFile\" on the tsconfig plugin entry", errNoLintConfigFile, cwd)
+    return nil, fmt.Errorf(
+      "%w (searched upward from %s); create one or set \"configFile\" on the tsconfig plugin entry",
+      errNoLintConfigFile,
+      strings.Join(discoveryConfigBaseDirs(cwd, tsconfigPath), ", then from "),
+    )
   }
   return loadConfigResolver(discovered)
 }
@@ -794,7 +807,23 @@ func loadConfigResolver(location string) (RuleResolver, error) {
 }
 
 func findLintConfigFile(cwd, tsconfigPath string) (string, error) {
-  dir := discoveryConfigBaseDir(cwd, tsconfigPath)
+  for _, origin := range discoveryConfigBaseDirs(cwd, tsconfigPath) {
+    discovered, err := findLintConfigFileFrom(origin)
+    if err != nil {
+      return "", err
+    }
+    if discovered != "" {
+      return discovered, nil
+    }
+  }
+  return "", nil
+}
+
+// findLintConfigFileFrom walks upward from `dir` and returns the first
+// directory level holding exactly one lint config file. Two or more candidates
+// in the same directory is ambiguous and a hard error; an exhausted walk
+// returns "" so the caller can try the next discovery origin.
+func findLintConfigFileFrom(dir string) (string, error) {
   for {
     matches := make([]string, 0, 1)
     for _, name := range []string{
@@ -846,19 +875,43 @@ func resolveConfigFilePath(configPath, cwd, tsconfigPath string) string {
   return filepath.Join(tsconfigBaseDir(cwd, tsconfigPath), configPath)
 }
 
-// discoveryConfigBaseDir returns the directory from which auto-discovery walks
-// upward when no explicit config path is provided. Prefer the tsconfig
-// directory over cwd so that nested package configs are found relative to the
-// tsconfig that triggered the lint run.
-func discoveryConfigBaseDir(cwd, tsconfigPath string) string {
+// discoveryConfigBaseDirs returns the ordered directories from which
+// auto-discovery walks upward when no explicit config path is provided. The
+// tsconfig directory comes first so that nested package configs are found
+// relative to the tsconfig that triggered the lint run; the working directory
+// follows as a fallback so a caller that points at an out-of-tree tsconfig
+// (e.g. a TtscCompiler invocation whose wrapper tsconfig lives in the system
+// temp dir but whose cwd/projectRoot is the real project) still discovers the
+// project's lint config instead of failing on the temp dir's empty ancestry.
+func discoveryConfigBaseDirs(cwd, tsconfigPath string) []string {
+  origins := make([]string, 0, 2)
   if tsconfigPath != "" {
     resolvedTsconfig := tsconfigPath
     if !filepath.IsAbs(resolvedTsconfig) {
       resolvedTsconfig = filepath.Join(cwd, resolvedTsconfig)
     }
-    return filepath.Dir(resolvedTsconfig)
+    origins = append(origins, filepath.Dir(resolvedTsconfig))
   }
-  return cwd
+  if cwd != "" && !containsPath(origins, cwd) {
+    origins = append(origins, filepath.Clean(cwd))
+  }
+  return origins
+}
+
+// containsPath reports whether `paths` already holds `candidate` after
+// cleaning, comparing case-insensitively on Windows (where two spellings of
+// the same directory differ only by drive-letter or path case).
+func containsPath(paths []string, candidate string) bool {
+  cleaned := filepath.Clean(candidate)
+  for _, existing := range paths {
+    if existing == cleaned {
+      return true
+    }
+    if runtime.GOOS == "windows" && strings.EqualFold(existing, cleaned) {
+      return true
+    }
+  }
+  return false
 }
 
 // tsconfigBaseDir returns the directory that contains the tsconfig file, or

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -260,14 +260,35 @@ function readConfigFileOption(
 function findLintConfigFile(
   context: TtscPluginFactoryContext<ITtscLintPluginConfig>,
 ): string | undefined {
-  // Mirror the Go-side discovery loop: walk from the tsconfig directory
-  // upward, returning the first directory that has exactly one of the
-  // candidate filenames. Multiple files in the same directory is treated
-  // as ambiguous and skipped (the Go side raises a hard error on the
-  // duplicate; here we leave it to the binary's own discovery to surface
-  // the issue once with one canonical message).
+  // Mirror the Go-side discovery origins: walk upward from the tsconfig
+  // directory first, then fall back to the working directory. The fallback
+  // covers callers that point at an out-of-tree tsconfig (e.g. a
+  // TtscCompiler invocation whose wrapper tsconfig lives in the system temp
+  // dir while cwd/projectRoot is the real project) — without it the walk
+  // dead-ends in the temp dir's ancestry and the project's config (and its
+  // contributor plugins) are silently missed.
+  const tsconfigDir = tsconfigBaseDir(context);
+  const cwd = path.resolve(context.cwd ?? context.projectRoot);
+  for (const origin of tsconfigDir === cwd
+    ? [tsconfigDir]
+    : [tsconfigDir, cwd]) {
+    const discovered = findLintConfigFileFrom(origin);
+    if (discovered !== undefined) {
+      return discovered;
+    }
+  }
+  return undefined;
+}
+
+function findLintConfigFileFrom(origin: string): string | undefined {
+  // Mirror the Go-side discovery loop: walk from `origin` upward, returning
+  // the first directory that has exactly one of the candidate filenames.
+  // Multiple files in the same directory is treated as ambiguous and skipped
+  // (the Go side raises a hard error on the duplicate; here we leave it to
+  // the binary's own discovery to surface the issue once with one canonical
+  // message).
   const candidateSet = new Set<string>(LINT_CONFIG_FILENAMES);
-  let dir = tsconfigBaseDir(context);
+  let dir = origin;
   while (true) {
     // One `readdirSync` per directory level beats 14 `existsSync`+
     // `statSync` pairs (= 28 stat syscalls) per level; intersect the

--- a/packages/lint/src/structures/ITtscLintConfig.ts
+++ b/packages/lint/src/structures/ITtscLintConfig.ts
@@ -12,7 +12,14 @@ export interface ITtscLintConfig {
   /** Globs that select the files this entry applies to. */
   files?: string | readonly string[];
 
-  /** Globs that exclude files this entry would otherwise match. */
+  /**
+   * Globs that exclude files from linting.
+   *
+   * When `files` is also set, the ignores only refine that selection (the
+   * entry's rules skip the matched files). Without `files`, the ignores are
+   * global: the matched files are excluded from every rule in the resolved
+   * config, including rules inherited through `extends`.
+   */
   ignores?: string | readonly string[];
 
   /**

--- a/packages/lint/test/config/external/match_any_pattern_accepts_native_and_slash_separators_test.go
+++ b/packages/lint/test/config/external/match_any_pattern_accepts_native_and_slash_separators_test.go
@@ -1,0 +1,42 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestMatchAnyPatternAcceptsNativeAndSlashSeparators verifies that a file
+// name spelled with the OS-native separator and one spelled with forward
+// slashes both match the same slash-normalized ignore glob.
+//
+// The engine hands ResolveRules absolute paths whose separator depends on the
+// producer: tsgo file names arrive slash-normalized while config discovery
+// and LSP conversions produce `filepath.Join`-built native paths (backslashes
+// on Windows). matchAnyPattern normalizes both sides via `filepath.ToSlash`
+// before matching; a regression that compared raw separators would silently
+// disable every ignore on exactly one platform.
+//
+//  1. Build the same ignored file path once with filepath.Join (native) and
+//     once with forward slashes.
+//  2. Match both spellings, plus a non-ignored sibling in both spellings.
+//  3. Assert the ignored file matches in either spelling and the sibling
+//     matches in neither.
+func TestMatchAnyPatternAcceptsNativeAndSlashSeparators(t *testing.T) {
+  base := filepath.Join(string(filepath.Separator), "project")
+  patterns := []string{".next/**/*.ts"}
+  ignoredNative := filepath.Join(base, ".next", "types", "validator.ts")
+  ignoredSlash := filepath.ToSlash(ignoredNative)
+  sourceNative := filepath.Join(base, "src", "main.ts")
+  sourceSlash := filepath.ToSlash(sourceNative)
+
+  for _, file := range []string{ignoredNative, ignoredSlash} {
+    if !matchAnyPattern(base, patterns, file) {
+      t.Errorf("matchAnyPattern(%q): ignored file must match", file)
+    }
+  }
+  for _, file := range []string{sourceNative, sourceSlash} {
+    if matchAnyPattern(base, patterns, file) {
+      t.Errorf("matchAnyPattern(%q): source file must not match", file)
+    }
+  }
+}

--- a/packages/lint/test/config/external/match_any_pattern_matches_dot_directory_globs_test.go
+++ b/packages/lint/test/config/external/match_any_pattern_matches_dot_directory_globs_test.go
@@ -1,0 +1,39 @@
+package linthost
+
+import "testing"
+
+// TestMatchAnyPatternMatchesDotDirectoryGlobs verifies that ignore globs
+// rooted in a dot-directory (`.next/**/*.ts`) and bare-basename globs
+// (`next-env.d.ts`) match files under those paths.
+//
+// Next.js projects ignore their generated output with exactly these two
+// pattern shapes. The segment matcher must treat a leading `.next` segment as
+// a literal directory name (no special dot-file semantics) and must prepend
+// `**/` to a slash-less pattern so `next-env.d.ts` matches at the base
+// directory root. A near-miss sibling (`.next-cache/`) pins the boundary: the
+// dot-directory segment is a whole-segment literal, not a prefix.
+//
+//  1. Define the two Next.js-shaped ignore globs.
+//  2. Match generated files under `.next/`, the root `next-env.d.ts`, a
+//     `.next-cache/` near-miss, and an ordinary source file.
+//  3. Assert only the genuinely ignored files match.
+func TestMatchAnyPatternMatchesDotDirectoryGlobs(t *testing.T) {
+  patterns := []string{".next/**/*.ts", ".next/**/*.tsx", "next-env.d.ts"}
+  cases := []struct {
+    file string
+    want bool
+  }{
+    {"/project/.next/types/validator.ts", true},
+    {"/project/.next/types/app/page.tsx", true},
+    {"/project/.next/dev/types/routes.d.ts", true},
+    {"/project/next-env.d.ts", true},
+    {"/project/.next-cache/types/validator.ts", false},
+    {"/project/src/main.ts", false},
+  }
+  for _, tc := range cases {
+    got := matchAnyPattern("/project", patterns, tc.file)
+    if got != tc.want {
+      t.Errorf("matchAnyPattern(%q): want %v, got %v", tc.file, tc.want, got)
+    }
+  }
+}

--- a/packages/lint/test/config/external/parse_config_store_keeps_ignores_entry_scoped_when_files_present_test.go
+++ b/packages/lint/test/config/external/parse_config_store_keeps_ignores_entry_scoped_when_files_present_test.go
@@ -1,0 +1,51 @@
+package linthost
+
+import (
+  "testing"
+)
+
+// TestParseConfigStoreKeepsIgnoresEntryScopedWhenFilesPresent verifies that
+// `ignores` alongside a `files` filter stays entry-scoped: it refines that
+// entry's selection instead of becoming a global ignore.
+//
+// The global-ignore promotion (top-level `ignores` with no `files` excludes a
+// file from the whole resolved chain) must not over-reach. When the author
+// paired `ignores` with `files`, the ESLint-compatible reading is "apply these
+// rules to `files` except `ignores`" — the excluded files are still linted by
+// every other entry.
+//
+//  1. Parse a config whose object has `files`, `ignores`, and `rules`, and
+//     whose `extends` target contributes a base rule.
+//  2. Resolve rules for a file matched by `files` but excluded by `ignores`.
+//  3. Assert the file is NOT globally ignored and still receives the base
+//     rule, while the entry's own rule does not apply.
+func TestParseConfigStoreKeepsIgnoresEntryScopedWhenFilesPresent(t *testing.T) {
+  store, err := parseExternalConfigStore(map[string]any{
+    "files":   []any{"src/**/*.ts"},
+    "ignores": []any{"src/generated/**"},
+    "rules":   map[string]any{"no-console": "error"},
+  }, "/project")
+  if err != nil {
+    t.Fatalf("parseExternalConfigStore: %v", err)
+  }
+  store.entries = append([]ConfigEntry{{
+    BaseDir: "/project",
+    Rules:   RuleConfig{"no-var": SeverityError},
+  }}, store.entries...)
+
+  excluded := store.ResolveRules("/project/src/generated/schema.ts")
+  if excluded.Ignored {
+    t.Fatalf("files-scoped ignores must not become a global ignore, got %+v", excluded)
+  }
+  if excluded.Rules.Severity("no-var") != SeverityError {
+    t.Fatalf("base rule must still apply outside the scoped entry, got %v", excluded.Rules.Severity("no-var"))
+  }
+  if excluded.Rules.Severity("no-console") != SeverityOff {
+    t.Fatalf("scoped entry's rule must not apply to its ignored file, got %v", excluded.Rules.Severity("no-console"))
+  }
+
+  selected := store.ResolveRules("/project/src/main.ts")
+  if selected.Rules.Severity("no-console") != SeverityError {
+    t.Fatalf("scoped entry's rule must apply to selected files, got %v", selected.Rules.Severity("no-console"))
+  }
+}

--- a/packages/lint/test/config/external/parse_config_store_promotes_global_ignores_alongside_rules_test.go
+++ b/packages/lint/test/config/external/parse_config_store_promotes_global_ignores_alongside_rules_test.go
@@ -1,0 +1,48 @@
+package linthost
+
+import "testing"
+
+// TestParseConfigStorePromotesGlobalIgnoresAlongsideRules verifies that a
+// single config object carrying both `rules` and a top-level `ignores` (no
+// `files`) still promotes the ignores to a global ignore entry.
+//
+// This is the root cause of the Next.js `.next/**` leak: collectConfigObject
+// used to `return` from the rules branch before reaching the global-ignore
+// promotion, so `ignores` was only attached (entry-scoped) to the object's
+// own rules entry. The object shape here has no `extends` at all — the
+// promotion must not depend on an extends chain being present.
+//
+//  1. Parse one object with `rules` plus `ignores` and no `files`.
+//  2. Resolve an ignored path and an ordinary path.
+//  3. Assert the ignored path resolves Ignored=true with no rules, and the
+//     ordinary path still receives the object's rules.
+func TestParseConfigStorePromotesGlobalIgnoresAlongsideRules(t *testing.T) {
+  store, err := parseExternalConfigStore(map[string]any{
+    "ignores": []any{".next/**/*.ts", "next-env.d.ts"},
+    "rules":   map[string]any{"no-var": "error"},
+  }, "/project")
+  if err != nil {
+    t.Fatalf("parseExternalConfigStore: %v", err)
+  }
+
+  for _, ignored := range []string{
+    "/project/.next/types/validator.ts",
+    "/project/next-env.d.ts",
+  } {
+    resolved := store.ResolveRules(ignored)
+    if !resolved.Ignored {
+      t.Fatalf("%s: want Ignored=true from the global ignores, got %+v", ignored, resolved)
+    }
+    if resolved.Rules.Severity("no-var") != SeverityOff {
+      t.Fatalf("%s: rules leaked onto an ignored file: %v", ignored, resolved.Rules.Severity("no-var"))
+    }
+  }
+
+  main := store.ResolveRules("/project/src/main.ts")
+  if main.Ignored {
+    t.Fatal("src/main.ts must not be ignored")
+  }
+  if main.Rules.Severity("no-var") != SeverityError {
+    t.Fatalf("src/main.ts no-var: want error, got %v", main.Rules.Severity("no-var"))
+  }
+}

--- a/packages/lint/test/config/external/parse_config_store_promotes_global_ignores_with_format_block_test.go
+++ b/packages/lint/test/config/external/parse_config_store_promotes_global_ignores_with_format_block_test.go
@@ -1,0 +1,45 @@
+package linthost
+
+import "testing"
+
+// TestParseConfigStorePromotesGlobalIgnoresWithFormatBlock verifies that a
+// config object whose only rule surface is a `format` block still promotes a
+// top-level `ignores` (no `files`) to a global ignore.
+//
+// The rules-branch early return that swallowed the promotion triggered on
+// `hasRules || hasFormat`, so a format-only config (`format: {...}` plus
+// `ignores`, common for "format everything except generated output") leaked
+// its expanded `format/*` rules onto the ignored paths exactly like a `rules`
+// config did. The fix must cover both halves of that condition, not just the
+// `rules` one.
+//
+//  1. Parse one object with a `format` block (severity warning, so format
+//     rules are active) plus `ignores` and no `files`.
+//  2. Resolve an ignored path and an ordinary path.
+//  3. Assert the ignored path is globally ignored while the ordinary path
+//     keeps the expanded format rules.
+func TestParseConfigStorePromotesGlobalIgnoresWithFormatBlock(t *testing.T) {
+  store, err := parseExternalConfigStore(map[string]any{
+    "ignores": []any{"generated/**"},
+    "format":  map[string]any{"severity": "warning"},
+  }, "/project")
+  if err != nil {
+    t.Fatalf("parseExternalConfigStore: %v", err)
+  }
+
+  ignored := store.ResolveRules("/project/generated/schema.ts")
+  if !ignored.Ignored {
+    t.Fatalf("generated/schema.ts: want Ignored=true, got %+v", ignored)
+  }
+  if len(ignored.Rules) != 0 {
+    t.Fatalf("generated/schema.ts: format rules leaked onto an ignored file: %v", ignored.Rules)
+  }
+
+  main := store.ResolveRules("/project/src/main.ts")
+  if main.Ignored {
+    t.Fatal("src/main.ts must not be ignored")
+  }
+  if len(main.Rules) == 0 {
+    t.Fatal("src/main.ts: expected the expanded format rules to apply")
+  }
+}

--- a/packages/lint/test/config/files/find_lint_config_file_falls_back_to_cwd_for_out_of_tree_tsconfig_test.go
+++ b/packages/lint/test/config/files/find_lint_config_file_falls_back_to_cwd_for_out_of_tree_tsconfig_test.go
@@ -1,0 +1,39 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestFindLintConfigFileFallsBackToCwdForOutOfTreeTsconfig verifies that when
+// the tsconfig directory's upward walk finds no lint config, discovery retries
+// from cwd before giving up.
+//
+// Build integrations hand ttsc a wrapper tsconfig written into the system temp
+// dir (a rollup config that `extends` the real project tsconfig, then calls
+// TtscCompiler with cwd/projectRoot pointing at the project). The temp dir's
+// ancestry holds no lint config, so a tsconfig-dir-only walk failed the build
+// with "no lint.config.* found" even though the project passed as cwd has one
+// sitting right there.
+//
+// 1. Put a lint.config.json in the cwd directory and only a tsconfig.json in a
+//    separate wrapper directory.
+// 2. Call findLintConfigFile with cwd=dir and tsconfig=wrapperDir/tsconfig.json.
+// 3. Assert the config next to cwd is discovered via the fallback origin.
+func TestFindLintConfigFileFallsBackToCwdForOutOfTreeTsconfig(t *testing.T) {
+  dir := t.TempDir()
+  wrapperDir := t.TempDir()
+  wrapper := filepath.Join(wrapperDir, "tsconfig.json")
+  writeFile(t, wrapper, "{}")
+  writeFile(t, filepath.Join(dir, "lint.config.json"), `{
+    "rules": { "no-console": "error" }
+  }`)
+
+  discovered, err := findLintConfigFile(dir, wrapper)
+  if err != nil {
+    t.Fatalf("findLintConfigFile: %v", err)
+  }
+  if discovered != filepath.Join(dir, "lint.config.json") {
+    t.Fatalf("want cwd fallback discovery of %s, got %q", filepath.Join(dir, "lint.config.json"), discovered)
+  }
+}

--- a/packages/lint/test/config/files/load_rule_config_discovers_cwd_config_for_out_of_tree_tsconfig_test.go
+++ b/packages/lint/test/config/files/load_rule_config_discovers_cwd_config_for_out_of_tree_tsconfig_test.go
@@ -1,0 +1,41 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestLoadRuleConfigDiscoversCwdConfigForOutOfTreeTsconfig verifies the full
+// LoadRuleConfig path resolves a project's lint config when the tsconfig lives
+// outside the project tree.
+//
+// This is the TtscCompiler embedding shape: a rollup config writes a wrapper
+// tsconfig into the system temp dir that `extends` the real project tsconfig,
+// then compiles with cwd/projectRoot set to the project. The lint sidecar
+// receives the wrapper path as --tsconfig and the project as --cwd; discovery
+// must land on the project's config via the cwd fallback instead of failing
+// with a missing-config error.
+//
+// 1. Seed a project dir with lint.config.json and a separate wrapper dir with
+//    only a tsconfig.json.
+// 2. Call LoadRuleConfig with cwd=project and tsconfigPath=wrapper.
+// 3. Assert the project's rules are loaded.
+func TestLoadRuleConfigDiscoversCwdConfigForOutOfTreeTsconfig(t *testing.T) {
+  dir := t.TempDir()
+  wrapperDir := t.TempDir()
+  wrapper := filepath.Join(wrapperDir, "tsconfig.json")
+  writeFile(t, wrapper, "{}")
+  writeFile(t, filepath.Join(dir, "lint.config.json"), `{
+    "rules": { "no-var": "error" }
+  }`)
+
+  cfg, err := LoadRuleConfig(&PluginEntry{
+    Config: map[string]any{},
+  }, dir, wrapper)
+  if err != nil {
+    t.Fatalf("LoadRuleConfig: %v", err)
+  }
+  if cfg.Severity("no-var") != SeverityError {
+    t.Fatalf("no-var: want error from the cwd project's config, got %v", cfg.Severity("no-var"))
+  }
+}

--- a/packages/lint/test/config/files/load_rule_config_extends_with_ignores_and_rules_ignores_globally_test.go
+++ b/packages/lint/test/config/files/load_rule_config_extends_with_ignores_and_rules_ignores_globally_test.go
@@ -1,0 +1,67 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestLoadRuleConfigExtendsWithIgnoresAndRulesIgnoresGlobally verifies that a
+// config carrying `extends` + `ignores` + `rules` excludes the ignored files
+// from the INHERITED rules too, not just from its own rules entry.
+//
+// A config file is a single ITtscLintConfig object, so its top-level `ignores`
+// (with no `files` filter) is the only way to say "never lint these files".
+// Before the fix, the `extends` target produced a separate ConfigEntry with no
+// ignores of its own, so the base config's rules kept firing on the ignored
+// paths — exactly the shape of a Next.js package whose lint.config.ts extends
+// a shared config and ignores `.next/**` and `next-env.d.ts`, yet still saw
+// `typescript/triple-slash-reference` errors reported for those files.
+//
+//  1. Write a base config with rules and a package config that extends it,
+//     ignores "generated/**/*.ts" plus "env.d.ts", and adds its own rules.
+//  2. Resolve rules for an ordinary source file and for both ignored shapes.
+//  3. Assert the source file gets base + local rules while the ignored files
+//     resolve to Ignored=true with no rules at all.
+func TestLoadRuleConfigExtendsWithIgnoresAndRulesIgnoresGlobally(t *testing.T) {
+  dir := t.TempDir()
+  writeFile(t, filepath.Join(dir, "tsconfig.json"), "{}")
+  writeFile(t, filepath.Join(dir, "base.config.json"), `{
+    "rules": { "no-var": "error" }
+  }`)
+  writeFile(t, filepath.Join(dir, "lint.config.json"), `{
+    "extends": "./base.config.json",
+    "ignores": ["generated/**/*.ts", "env.d.ts"],
+    "rules": { "no-console": "error" }
+  }`)
+
+  resolver, err := LoadConfigResolver(&PluginEntry{
+    Config: map[string]any{},
+  }, dir, "tsconfig.json")
+  if err != nil {
+    t.Fatalf("LoadConfigResolver: %v", err)
+  }
+
+  main := resolver.ResolveRules(filepath.Join(dir, "src", "main.ts"))
+  if main.Ignored {
+    t.Fatal("src/main.ts must not be ignored")
+  }
+  if main.Rules.Severity("no-var") != SeverityError {
+    t.Fatalf("src/main.ts no-var: want error inherited from base, got %v", main.Rules.Severity("no-var"))
+  }
+  if main.Rules.Severity("no-console") != SeverityError {
+    t.Fatalf("src/main.ts no-console: want error from local rules, got %v", main.Rules.Severity("no-console"))
+  }
+
+  for _, ignored := range []string{
+    filepath.Join(dir, "generated", "types", "validator.ts"),
+    filepath.Join(dir, "env.d.ts"),
+  } {
+    resolved := resolver.ResolveRules(ignored)
+    if !resolved.Ignored {
+      t.Fatalf("%s: want Ignored=true from top-level ignores, got %+v", ignored, resolved)
+    }
+    if resolved.Rules.Severity("no-var") != SeverityOff {
+      t.Fatalf("%s no-var: base config rules leaked onto an ignored file: %v", ignored, resolved.Rules.Severity("no-var"))
+    }
+  }
+}

--- a/packages/lint/test/config/files/load_rule_config_missing_config_error_names_search_origins_test.go
+++ b/packages/lint/test/config/files/load_rule_config_missing_config_error_names_search_origins_test.go
@@ -1,0 +1,39 @@
+package linthost
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestLoadRuleConfigMissingConfigErrorNamesSearchOrigins verifies that the
+// missing-config error reports the directories discovery actually walked.
+//
+// The error used to print cwd as the search origin even though discovery
+// walked upward from the tsconfig's directory — for an out-of-tree wrapper
+// tsconfig the message named a directory that DID contain a lint.config.ts,
+// sending users hunting for a phantom filesystem problem. The message must
+// name the tsconfig directory (primary origin) and the cwd (fallback origin).
+//
+// 1. Create separate cwd and wrapper-tsconfig temp dirs with no lint config.
+// 2. Call LoadRuleConfig with an empty Config map to trigger discovery.
+// 3. Assert the error names both search origins.
+func TestLoadRuleConfigMissingConfigErrorNamesSearchOrigins(t *testing.T) {
+  dir := t.TempDir()
+  wrapperDir := t.TempDir()
+  wrapper := filepath.Join(wrapperDir, "tsconfig.json")
+  writeFile(t, wrapper, "{}")
+
+  _, err := LoadRuleConfig(&PluginEntry{
+    Config: map[string]any{},
+  }, dir, wrapper)
+  if err == nil {
+    t.Fatal("expected missing lint config to fail")
+  }
+  if !strings.Contains(err.Error(), wrapperDir) {
+    t.Fatalf("error must name the tsconfig directory %s it searched from, got %v", wrapperDir, err)
+  }
+  if !strings.Contains(err.Error(), dir) {
+    t.Fatalf("error must name the cwd fallback %s it searched from, got %v", dir, err)
+  }
+}

--- a/tests/test-lint/src/features/config/test_lint_config_file_top_level_ignores_exclude_files_from_extended_rules.ts
+++ b/tests/test-lint/src/features/config/test_lint_config_file_top_level_ignores_exclude_files_from_extended_rules.ts
@@ -1,0 +1,85 @@
+import {
+  assert,
+  createLintProject,
+  runLintProject,
+} from "../../internal/config-file";
+
+/**
+ * Verifies that a config file's top-level `ignores` (no `files` filter)
+ * excludes the matched files from rules inherited through `extends`, not just
+ * from the file's own `rules` entry.
+ *
+ * Pins the global-ignore promotion in `linthost/config.go`
+ * (`collectConfigObject`). A config file is a single ITtscLintConfig object, so
+ * its top-level `ignores` is the only way to say "never lint these files"; it
+ * must silence the whole resolved chain. Before the fix the promotion only ran
+ * when the config had no `rules`/`format` of its own, so a Next.js-shaped
+ * package whose lint.config extends a shared config, ignores `.next/**` plus
+ * `next-env.d.ts`, and adds framework rules still saw the base config's rules
+ * (e.g. `typescript/triple-slash-reference`, `no-var`) fire on the ignored
+ * generated files.
+ *
+ * 1. Materialize a fixture whose tsconfig includes a dot-directory
+ *    (`.next/types/**`) and a root-level `next-env.d.ts`, mirroring Next.js.
+ * 2. `lint.config.json` extends `base.config.json` (enables `no-var` and
+ *    `typescript/triple-slash-reference`), ignores the generated files, and
+ *    enables `no-console` locally.
+ * 3. Run ttsc; assert only `src/main.ts` reports (inherited `no-var` + local
+ *    `no-console`) and no diagnostic names an ignored file.
+ */
+export const test_lint_config_file_top_level_ignores_exclude_files_from_extended_rules =
+  () => {
+    const source = "var value = 1;\nconsole.log(value);\n";
+    const project = createLintProject({
+      name: "config-file-top-level-ignores",
+      source,
+      extraSources: {
+        "tsconfig.json": JSON.stringify({
+          compilerOptions: {
+            target: "ES2022",
+            module: "commonjs",
+            strict: true,
+            noEmit: true,
+            plugins: [{ transform: "@ttsc/lint" }],
+          },
+          include: ["next-env.d.ts", ".next/types/**/*.ts", "src"],
+        }),
+        "lint.config.json": JSON.stringify({
+          extends: "./base.config.json",
+          ignores: [".next/**/*.ts", "next-env.d.ts"],
+          rules: { "no-console": "error" },
+        }),
+        "base.config.json": JSON.stringify({
+          rules: {
+            "no-var": "error",
+            "typescript/triple-slash-reference": "error",
+          },
+        }),
+        ".next/types/validator.ts":
+          "var generated = 1;\nexport const gen = generated;\n",
+        "next-env.d.ts": '/// <reference path="./src/main.ts" />\n',
+      },
+    });
+    try {
+      const result = runLintProject(project.tmpdir);
+      assert.notEqual(result.status, 0, result.stderr);
+      const leaked = result.diagnostics.filter(
+        (d) => d.file.includes(".next") || d.file.includes("next-env"),
+      );
+      assert.deepEqual(
+        leaked,
+        [],
+        `ignored files must not be linted:\n${result.stderr}`,
+      );
+      assert.deepEqual(
+        result.diagnostics.map((d) => [d.rule, d.severity]),
+        [
+          ["no-var", "error"],
+          ["no-console", "error"],
+        ],
+        result.stderr,
+      );
+    } finally {
+      project.cleanup();
+    }
+  };

--- a/tests/test-lint/src/native-plugins/config/test_lint_config_file_out_of_tree_tsconfig_honors_project_ignores_via_cwd_discovery.ts
+++ b/tests/test-lint/src/native-plugins/config/test_lint_config_file_out_of_tree_tsconfig_honors_project_ignores_via_cwd_discovery.ts
@@ -1,0 +1,118 @@
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TtscCompiler } from "../../../../../packages/ttsc/lib/index.js";
+import {
+  TSGO_BINARY,
+  TTSX_BIN,
+  assert,
+  createLintProject,
+  lintGoPath,
+} from "../../internal/config-file";
+
+/**
+ * Verifies that a `TtscCompiler` invocation whose tsconfig lives outside the
+ * project tree still discovers the project's lint config from `cwd` and honors
+ * its top-level `ignores` — including for extends-inherited rules.
+ *
+ * This is the `@ttsc/unplugin` invocation shape: the bundler adapter writes a
+ * wrapper tsconfig into the system temp dir (extending the real project
+ * tsconfig) and compiles with cwd/projectRoot pointing at the project. The
+ * wrapper's ancestry holds no lint config, so discovery must fall back to the
+ * cwd origin; and the discovered config's `extends` + `ignores` + `rules` shape
+ * must exclude the ignored generated files from the inherited base rules, not
+ * only from its own rules entry.
+ *
+ * 1. Materialize a Next.js-shaped project: tsconfig includes `.next/types/**` plus
+ *    `next-env.d.ts`, and `lint.config.json` extends a base config (`no-var`,
+ *    `typescript/triple-slash-reference`) while ignoring the generated files
+ *    and enabling `no-console` locally.
+ * 2. Write a wrapper tsconfig into a separate temp dir and compile via
+ *    `TtscCompiler` with cwd/projectRoot = the project.
+ * 3. Assert the failure diagnostics all point at `src/main.ts` (inherited `no-var`
+ *    + local `no-console`) and none reference the ignored files.
+ */
+export const test_lint_config_file_out_of_tree_tsconfig_honors_project_ignores_via_cwd_discovery =
+  () => {
+    const source = "var value = 1;\nconsole.log(value);\n";
+    const project = createLintProject({
+      name: "config-file-out-of-tree-ignores",
+      source,
+      pluginConfig: {},
+      extraSources: {
+        "tsconfig.json": JSON.stringify({
+          compilerOptions: {
+            target: "ES2022",
+            module: "commonjs",
+            strict: true,
+            noEmit: true,
+            plugins: [{ transform: "@ttsc/lint" }],
+          },
+          include: ["next-env.d.ts", ".next/types/**/*.ts", "src"],
+        }),
+        "lint.config.json": JSON.stringify({
+          extends: "./base.config.json",
+          ignores: [".next/**/*.ts", "next-env.d.ts"],
+          rules: { "no-console": "error" },
+        }),
+        "base.config.json": JSON.stringify({
+          rules: {
+            "no-var": "error",
+            "typescript/triple-slash-reference": "error",
+          },
+        }),
+        ".next/types/validator.ts":
+          "var generated = 1;\nexport const gen = generated;\n",
+        "next-env.d.ts": '/// <reference path="./src/main.ts" />\n',
+      },
+    });
+    const wrapper = TestProject.tmpdir("ttsc-lint-out-of-tree-");
+    try {
+      const tsconfig = path.join(wrapper, "tsconfig.json");
+      fs.writeFileSync(
+        tsconfig,
+        JSON.stringify({ extends: path.join(project.tmpdir, "tsconfig.json") }),
+        "utf8",
+      );
+      const compiler = new TtscCompiler({
+        cacheDir: path.join(project.tmpdir, ".cache", "ttsc"),
+        cwd: project.tmpdir,
+        env: {
+          PATH: lintGoPath(),
+          TTSC_TSGO_BINARY: TSGO_BINARY,
+          TTSC_TTSX_BINARY: TTSX_BIN,
+        },
+        projectRoot: project.tmpdir,
+        tsconfig,
+      });
+      const result = compiler.compile();
+
+      assert.equal(result.type, "failure");
+      const leaked = result.diagnostics.filter(
+        (d) =>
+          d.file !== null &&
+          (d.file.includes(".next") || d.file.includes("next-env")),
+      );
+      assert.deepEqual(
+        leaked,
+        [],
+        `ignored files must not be linted:\n${JSON.stringify(result.diagnostics, null, 2)}`,
+      );
+      assert.deepEqual(
+        result.diagnostics.map((d) => [
+          d.file === null ? null : path.basename(d.file),
+          d.messageText.slice(0, d.messageText.indexOf("]") + 1),
+          d.category,
+        ]),
+        [
+          ["main.ts", "[no-var]", "error"],
+          ["main.ts", "[no-console]", "error"],
+        ],
+        JSON.stringify(result.diagnostics, null, 2),
+      );
+    } finally {
+      fs.rmSync(wrapper, { recursive: true, force: true });
+      project.cleanup();
+    }
+  };

--- a/website/src/content/docs/development/walkthroughs/lint.mdx
+++ b/website/src/content/docs/development/walkthroughs/lint.mdx
@@ -633,7 +633,7 @@ export default {
 } satisfies ITtscLintConfig;
 ```
 
-`files` and `ignores` scope the object when the resolver (`linthost/config.go`) builds the rule severity map for each `FileName()`. `extends` points at one base config file (path relative to this file's directory): the base is loaded first, then this object's `plugins`, `rules`, and `format` fields override it.
+`files` and `ignores` scope the object when the resolver (`linthost/config.go`) builds the rule severity map for each `FileName()`. When `files` is present, `ignores` only refines that selection — the excluded files are still linted by other entries. Without `files`, a top-level `ignores` is a **global ignore**: a config file is a single object, so this is the only way to say "never lint these files", and the matched paths are excluded from every rule in the resolved chain, including rules inherited through `extends`. `extends` points at one base config file (path relative to this file's directory): the base is loaded first, then this object's `plugins`, `rules`, and `format` fields override it.
 
 ## What to copy, what to ignore for your own plugin
 

--- a/website/src/content/docs/lint/setup.mdx
+++ b/website/src/content/docs/lint/setup.mdx
@@ -33,11 +33,13 @@ export default {
 
 `"error"` fails the build. `"warning"` prints. `"off"` disables the rule.
 
+To exclude generated files from linting entirely, add a top-level `ignores` list (e.g. `ignores: [".next/**/*.ts", "next-env.d.ts"]`). Without a `files` filter it is a global ignore: the matched paths are skipped by every rule, including rules inherited through `extends`.
+
 The `format` block configures the formatter, keys mirror `.prettierrc`. Presence of the block (even empty `format: {}`) enables `ttsc format` at Prettier defaults. It does not make `ttsc check` fail on formatting unless you set `format.severity`.
 
 A `lint.config.{ts,js,mjs}` file is evaluated once and the result is cached, keyed by the file's contents, so a monorepo build that runs `ttsc` once per package does not re-evaluate the config each time. Editing the config invalidates the cache automatically. The one case it does not cover is a config that `import`s a separate file: change that imported file without touching the config itself, and set `TTSC_LINT_DISABLE_CONFIG_CACHE=1` to force a fresh evaluation.
 
-By default `@ttsc/lint` discovers `lint.config.{ts,cts,mts,js,cjs,mjs,json}` by walking upward from the tsconfig directory. To override that discovery with an explicit path, pass `configFile` on the plugin entry in `tsconfig.json`:
+By default `@ttsc/lint` discovers `lint.config.{ts,cts,mts,js,cjs,mjs,json}` by walking upward from the tsconfig directory, then — when that walk finds nothing — upward from the working directory (this covers build integrations that hand ttsc a wrapper tsconfig in a temp directory while the project itself is the cwd). To override that discovery with an explicit path, pass `configFile` on the plugin entry in `tsconfig.json`:
 
 ```jsonc
 // tsconfig.json


### PR DESCRIPTION
Fixes #346.

## Intent

Make a lint config file's top-level `ignores` reliable: it must exclude the matched files from **every** rule in the resolved chain — including rules inherited through `extends` — for the CLI, the `TtscCompiler` API, and `@ttsc/unplugin` invocations, with absolute and relative inputs, Windows and POSIX separators, and dot-directories such as `.next`.

## Root cause and fix

**Global-ignore promotion swallowed by the rules branch** (`packages/lint/linthost/config.go`, `collectConfigObject`): the promotion of a `files`-less `ignores` list to a global `IgnoreOnly` entry sat after the `rules`/`format` branch, which ended with `return nil`. Any config carrying `rules` or `format` therefore kept its `ignores` entry-scoped, and the `extends` target's entries (with no ignores of their own) kept linting the excluded paths — 1068 diagnostics on `.next/**` + `next-env.d.ts` in the reporting Next.js project. The promotion now runs whenever `files` is absent; `ignores` alongside `files` stays entry-scoped (ESLint flat-config semantics).

**Discovery dead-ended for out-of-tree tsconfigs** (same file, `findLintConfigFile` / `discoveryConfigBaseDirs`): `@ttsc/unplugin` and other `TtscCompiler` embedders write a wrapper tsconfig into the system temp dir while `cwd`/`projectRoot` point at the real project; a tsconfig-dir-only upward walk never found the project's lint config. Discovery now walks from the tsconfig directory first (the wrapper-config precedence pinned by the existing native-plugins test is preserved) and falls back to `cwd`; the missing-config error names every origin searched. The JS-side factory (`packages/lint/src/index.ts`) mirrors the same origins.

Docs updated: `website/src/content/docs/development/walkthroughs/lint.mdx` (global vs entry-scoped `ignores` semantics), `website/src/content/docs/lint/setup.mdx` (ignores note + discovery origins), and the `ITtscLintConfig.ignores` doc comment.

## Scope

- `packages/lint/linthost/config.go` — global-ignore promotion, discovery origins, error message.
- `packages/lint/src/index.ts`, `packages/lint/src/structures/ITtscLintConfig.ts` — mirrored discovery + docs.
- Regression tests (one case per file, per repo convention).
- Website docs.

No behavior change for `files`-scoped ignores or for wrapper tsconfigs that carry their own lint config.

## Test plan

Go unit tests (`packages/lint/test/config/`):
- `load_rule_config_extends_with_ignores_and_rules_ignores_globally` — extends + ignores + rules excludes ignored files from inherited rules.
- `parse_config_store_promotes_global_ignores_alongside_rules` — promotion without an extends chain.
- `parse_config_store_promotes_global_ignores_with_format_block` — promotion for the `format`-only half of the swallowed branch.
- `parse_config_store_keeps_ignores_entry_scoped_when_files_present` — negative twin: `files` + `ignores` must not become global.
- `match_any_pattern_matches_dot_directory_globs` — `.next/**/*.ts`, `next-env.d.ts`, `.next-cache` near-miss.
- `match_any_pattern_accepts_native_and_slash_separators` — same path in native and forward-slash spellings.
- `find_lint_config_file_falls_back_to_cwd_for_out_of_tree_tsconfig`, `load_rule_config_discovers_cwd_config_for_out_of_tree_tsconfig`, `load_rule_config_missing_config_error_names_search_origins` — discovery fallback and error text.

E2E (`tests/test-lint`):
- `features/config/test_lint_config_file_top_level_ignores_exclude_files_from_extended_rules` — CLI path, Next.js-shaped fixture (dot-directory + root d.ts + extends chain). Verified fail-before/pass-after locally.
- `native-plugins/config/test_lint_config_file_out_of_tree_tsconfig_honors_project_ignores_via_cwd_discovery` — `TtscCompiler` with a temp-dir wrapper tsconfig (the unplugin invocation shape).

Local evidence: the lint Go suite (`node scripts/test-go-lint.cjs`) is green with all new tests; the CLI e2e was run before/after the fix (fails on v0.18.1 behavior, passes with the fix). Against the reporting real-world project (read-only), v0.18.1 reproduces exactly 1068 ignored-file diagnostics (1066 under `.next/**`, 2 in `next-env.d.ts`); full validation of this branch is delegated to CI per maintainer direction.

## Deferred

- No `--project-root` CLI flag exists, so a CLI run whose `-p` points at an out-of-tree wrapper tsconfig still derives both discovery origins from the wrapper's directory; embedders set `projectRoot` via the API, which is the affected shape today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZemZPBFGjdEySJct22Scr
