### PR TITLE
fix(driver): honor linked plugins on the host emit and single-file lanes

### DIFF
--- a/packages/ttsc/driver/emit_plugin.go
+++ b/packages/ttsc/driver/emit_plugin.go
@@ -85,9 +85,6 @@ func (p *Program) EmitWithPluginTransformer(transform PluginTransform, writeFile
 // EmitWithPluginTransformers, which honors linked plugins on every emit it
 // runs.
 func (p *Program) EmitLinkedTransforms(writeFile shimcompiler.WriteFile) ([]Diagnostic, error) {
-  if p == nil || p.TSProgram == nil {
-    return nil, errors.New("driver: nil program")
-  }
   return p.EmitWithPluginTransformers(nil, writeFile)
 }
 

--- a/packages/ttsc/driver/emit_plugin.go
+++ b/packages/ttsc/driver/emit_plugin.go
@@ -80,19 +80,15 @@ func (p *Program) EmitWithPluginTransformer(transform PluginTransform, writeFile
   return p.EmitWithPluginTransformers([]PluginTransform{transform}, writeFile)
 }
 
-// EmitLinkedTransforms emits using the emit-phase transformers contributed by
-// every registered EmitTransformPlugin (in registration order). This is the
-// AST-integration emit path that replaces the ProgramPlugin + RewriteSet
-// text-splice path.
+// EmitLinkedTransforms emits using only the linked plugins' hooks, with no
+// host-owned transformer. It is the no-transform convenience form of
+// EmitWithPluginTransformers, which honors linked plugins on every emit it
+// runs.
 func (p *Program) EmitLinkedTransforms(writeFile shimcompiler.WriteFile) ([]Diagnostic, error) {
   if p == nil || p.TSProgram == nil {
     return nil, errors.New("driver: nil program")
   }
-  transforms, err := p.plugins.emitTransforms()
-  if err != nil {
-    return nil, err
-  }
-  return p.EmitWithPluginTransformers(transforms, writeFile)
+  return p.EmitWithPluginTransformers(nil, writeFile)
 }
 
 // restoreOriginalDeclarationSymbols copies the binder symbol from each original
@@ -135,6 +131,11 @@ func restoreOriginalDeclarationSymbols(ec *shimprinter.EmitContext, node *shimas
 // import aliasing: tsgo's module-transform aliases the plugins' injected
 // imports itself.
 //
+// Linked plugins are honored on every call: registered ProgramPlugins apply
+// to the program before emit (once per Program), and registered
+// EmitTransformPlugins are chained after the caller's transforms in
+// registration order.
+//
 // Because the JavaScript side bypasses tsgo's own emitter, it reproduces the
 // emitter's source-map step via PrintFileWithSourceMap: a `sourceMap` /
 // `inlineSourceMap` build emits a `.js.map` (and `//# sourceMappingURL=`
@@ -145,6 +146,23 @@ func restoreOriginalDeclarationSymbols(ec *shimprinter.EmitContext, node *shimas
 func (p *Program) EmitWithPluginTransformers(transforms []PluginTransform, writeFile shimcompiler.WriteFile) ([]Diagnostic, error) {
   if p == nil || p.TSProgram == nil {
     return nil, errors.New("driver: nil program")
+  }
+  // Linked plugins ride inside whichever host binary owns the emit pass, and
+  // the host does not know which linked packages ttsc compiled into it. Honor
+  // them at the funnel every host emits through: linked ProgramPlugins mutate
+  // the program before the per-file loop below, and linked EmitTransformPlugins
+  // join the per-file chain after the host's own transforms. A host that only
+  // passes its own transform would otherwise link, register, and silently never
+  // run the linked hooks.
+  if err := p.ApplyLinkedPlugins(); err != nil {
+    return nil, err
+  }
+  linked, err := p.plugins.emitTransforms()
+  if err != nil {
+    return nil, err
+  }
+  if len(linked) != 0 {
+    transforms = append(append([]PluginTransform{}, transforms...), linked...)
   }
   host := &pluginEmitHost{program: p.TSProgram, emitResolver: p.Checker.GetEmitResolver()}
   options := p.TSProgram.Options()

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -94,11 +94,15 @@ func NewLintDiagnostic(
   return d
 }
 
-// SourceFile returns the program source file matching filename.
+// SourceFile returns the program source file matching filename. Like
+// SourceFiles, it applies linked ProgramPlugins first so a single-file
+// consumer (e.g. a host's --file transform lane) sees the same mutated tree
+// as a whole-project walk.
 func (p *Program) SourceFile(filename string) *ast.SourceFile {
   if p == nil || p.TSProgram == nil {
     return nil
   }
+  _ = p.ApplyLinkedPlugins()
   normalized := filepath.ToSlash(filename)
   for _, file := range p.TSProgram.SourceFiles() {
     if filepath.ToSlash(file.FileName()) == normalized {

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -189,15 +189,16 @@ func CountErrors(diagnostics []Diagnostic) int {
 
 // Program is the shim-agnostic facade the rest of the engine sees.
 type Program struct {
-  TSProgram      *shimcompiler.Program
-  ParsedConfig   *tsoptions.ParsedCommandLine
-  Checker        *shimchecker.Checker
-  checkerRelease func()
-  Host           shimcompiler.CompilerHost
-  FS             vfs.FS
-  SourcePreamble string
-  plugins        linkedPluginState
-  pluginsApplied bool
+  TSProgram       *shimcompiler.Program
+  ParsedConfig    *tsoptions.ParsedCommandLine
+  Checker         *shimchecker.Checker
+  checkerRelease  func()
+  Host            shimcompiler.CompilerHost
+  FS              vfs.FS
+  SourcePreamble  string
+  plugins         linkedPluginState
+  pluginsApplied  bool
+  pluginsApplyErr error
 }
 
 // LoadProgramOptions controls tsconfig overrides applied before tsgo creates
@@ -525,12 +526,20 @@ func (p *Program) sourceFilesRaw() []*ast.SourceFile {
 }
 
 // ApplyLinkedPlugins runs registered linked ProgramPlugin hooks exactly once.
+// A hook failure is latched and returned on every subsequent call: SourceFiles
+// swallows the error by contract, so without the latch a lookup that happened
+// to run first would consume the only report and let a later emit proceed over
+// the half-applied program as if nothing failed.
 func (p *Program) ApplyLinkedPlugins() error {
-  if p == nil || p.pluginsApplied {
+  if p == nil {
     return nil
   }
+  if p.pluginsApplied {
+    return p.pluginsApplyErr
+  }
   p.pluginsApplied = true
-  return p.plugins.apply(p)
+  p.pluginsApplyErr = p.plugins.apply(p)
+  return p.pluginsApplyErr
 }
 
 // Diagnostics returns project diagnostics that must block compilation or

--- a/packages/ttsc/test/driver/emit_plugin_transformers_apply_linked_program_plugins_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_transformers_apply_linked_program_plugins_test.go
@@ -1,0 +1,148 @@
+package driver_test
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+  shimcore "github.com/microsoft/typescript-go/shim/core"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// stringRewriteProgramPlugin is a synthetic ProgramPlugin shaped like
+// @ttsc/paths: ApplyProgram mutates matching string literals in place across
+// every program source file, so its effect is only visible in emitted output
+// when the emit path actually runs linked ProgramPlugin hooks.
+type stringRewriteProgramPlugin struct {
+  from string
+  to   string
+}
+
+func (p *stringRewriteProgramPlugin) ApplyProgram(prog *driver.Program, _ driver.PluginContext) error {
+  for _, sf := range prog.SourceFiles() {
+    rewriteStringLiterals(sf.AsNode(), p.from, p.to)
+  }
+  return nil
+}
+
+func rewriteStringLiterals(node *shimast.Node, from, to string) {
+  if node == nil {
+    return
+  }
+  if node.Kind == shimast.KindStringLiteral && node.Text() == from {
+    node.AsStringLiteral().Text = to
+    node.Flags |= shimast.NodeFlagsSynthesized
+    node.Loc = shimcore.UndefinedTextRange()
+  }
+  node.ForEachChild(func(child *shimast.Node) bool {
+    rewriteStringLiterals(child, from, to)
+    return false
+  })
+}
+
+// TestEmitWithPluginTransformersAppliesLinkedProgramPlugins verifies that a
+// host emitting through EmitWithPluginTransformers with only its own
+// transform still runs linked ProgramPlugin hooks.
+//
+// Locks the regression where a third-party transform host (typia's
+// `ttsc-typia build`) passed its own PluginTransform to
+// EmitWithPluginTransformers and a linked plugin (@ttsc/paths) compiled into
+// the same binary registered via init() but its ApplyProgram never ran, so
+// tsconfig paths aliases survived into the emitted JavaScript. The linked
+// hooks must fire at the emit funnel itself, not only on the utility-host
+// code path that calls ApplyLinkedPlugins by hand.
+//
+//  1. Register a linked ProgramPlugin that rewrites "linked-pending" into
+//     "linked-applied" and pair it with one manifest entry.
+//  2. Emit through EmitWithPluginTransformers passing only a host-owned
+//     transform (numeric 0 -> 100).
+//  3. Assert the emitted JS carries BOTH the host transform's rewrite and the
+//     linked plugin's rewrite.
+func TestEmitWithPluginTransformersAppliesLinkedProgramPlugins(t *testing.T) {
+  resetLinkedPluginRegistry()
+  t.Setenv(driver.LinkedPluginsEnv, `[{"name":"rewrite","stage":"transform","config":{}}]`)
+  driver.RegisterPlugin(&stringRewriteProgramPlugin{from: "linked-pending", to: "linked-applied"})
+
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": { "module": "commonjs", "target": "es2020", "outDir": "bin", "strict": true },
+  "files": ["index.ts"]
+}
+`)
+  writeProjectFile(t, root, "index.ts", "export const spec = \"linked-pending\";\nexport const a = 0;\n")
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  hostTransform, err := (&numericRewritePlugin{from: "0", to: "100"}).EmitTransform(driver.PluginContext{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  emitted := map[string]string{}
+  if _, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{hostTransform}, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    emitted[filepath.Base(fileName)] = text
+    return nil
+  }); err != nil {
+    t.Fatal(err)
+  }
+  js := emitted["index.js"]
+  t.Logf("index.js:\n%s", js)
+
+  if !strings.Contains(js, "linked-applied") {
+    t.Fatalf("linked ProgramPlugin did not apply on the host emit path:\n%s", js)
+  }
+  if !strings.Contains(js, "exports.a = 100;") {
+    t.Fatalf("host-owned transform was lost:\n%s", js)
+  }
+}
+
+// TestEmitWithPluginTransformersWithoutManifestLeavesLinkedHooksIdle is the
+// negative companion: a registered plugin with NO manifest entry must not run.
+// The manifest, not registration alone, gates linked hook execution — without
+// this guard the fix above could regress into always-on registry side effects.
+func TestEmitWithPluginTransformersWithoutManifestLeavesLinkedHooksIdle(t *testing.T) {
+  resetLinkedPluginRegistry()
+  t.Setenv(driver.LinkedPluginsEnv, "")
+  driver.RegisterPlugin(&stringRewriteProgramPlugin{from: "linked-pending", to: "linked-applied"})
+
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": { "module": "commonjs", "target": "es2020", "outDir": "bin", "strict": true },
+  "files": ["index.ts"]
+}
+`)
+  writeProjectFile(t, root, "index.ts", "export const spec = \"linked-pending\";\n")
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  emitted := map[string]string{}
+  if _, err := prog.EmitWithPluginTransformers(nil, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    emitted[filepath.Base(fileName)] = text
+    return nil
+  }); err != nil {
+    t.Fatal(err)
+  }
+  js := emitted["index.js"]
+  t.Logf("index.js:\n%s", js)
+
+  if !strings.Contains(js, "linked-pending") {
+    t.Fatalf("expected untouched literal without a manifest entry:\n%s", js)
+  }
+  if strings.Contains(js, "linked-applied") {
+    t.Fatalf("linked hook ran without a manifest entry:\n%s", js)
+  }
+}

--- a/packages/ttsc/test/driver/emit_plugin_transformers_chain_linked_transforms_after_host_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_transformers_chain_linked_transforms_after_host_test.go
@@ -1,0 +1,68 @@
+package driver_test
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestEmitWithPluginTransformersChainLinkedTransformsAfterHost verifies that
+// linked EmitTransformPlugins join the per-file chain AFTER the transforms the
+// host passed explicitly.
+//
+// Locks the merge position introduced when EmitWithPluginTransformers started
+// honoring linked plugins itself: the host's own transform keeps its current
+// first slot (existing hosts were built against that timing) and linked
+// transforms ride behind it. The probe is order-sensitive: the host rewrites
+// 100 -> 200 and the linked plugin rewrites 0 -> 100, so host-then-linked
+// stalls at 100 while linked-then-host would reach 200.
+//
+// 1. Register a linked EmitTransformPlugin (0 -> 100) with one manifest entry.
+// 2. Emit through EmitWithPluginTransformers with a host transform (100 -> 200).
+// 3. Assert the output stalls at `exports.a = 100;`, proving host-then-linked.
+func TestEmitWithPluginTransformersChainLinkedTransformsAfterHost(t *testing.T) {
+  resetLinkedPluginRegistry()
+  t.Setenv(driver.LinkedPluginsEnv, `[{"name":"linked","stage":"transform","config":{}}]`)
+  driver.RegisterPlugin(&numericRewritePlugin{from: "0", to: "100"})
+
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": { "module": "commonjs", "target": "es2020", "outDir": "bin", "strict": true },
+  "files": ["index.ts"]
+}
+`)
+  writeProjectFile(t, root, "index.ts", "export const a = 0;\n")
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  hostTransform, err := (&numericRewritePlugin{from: "100", to: "200"}).EmitTransform(driver.PluginContext{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  emitted := map[string]string{}
+  if _, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{hostTransform}, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    emitted[filepath.Base(fileName)] = text
+    return nil
+  }); err != nil {
+    t.Fatal(err)
+  }
+  js := emitted["index.js"]
+  t.Logf("index.js:\n%s", js)
+
+  if !strings.Contains(js, "exports.a = 100;") {
+    t.Fatalf("expected host-then-linked chaining to stall at 100:\n%s", js)
+  }
+  if strings.Contains(js, "exports.a = 200;") {
+    t.Fatalf("linked transform ran before the host's own transform:\n%s", js)
+  }
+}

--- a/packages/ttsc/test/driver/emit_plugin_transformers_propagate_linked_apply_errors_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_transformers_propagate_linked_apply_errors_test.go
@@ -65,3 +65,49 @@ func TestEmitWithPluginTransformersPropagateLinkedApplyErrors(t *testing.T) {
     t.Fatalf("emit produced output despite linked apply failure: %#v", emitted)
   }
 }
+
+// TestEmitWithPluginTransformersReportLatchedLinkedApplyErrors is the
+// swallowed-first-report companion: SourceFiles ignores the apply error by
+// contract, and before the error latch that first call also consumed the
+// once-only apply, so the emit that followed saw a clean no-op and wrote
+// output over the half-applied program.
+//
+// 1. Register a linked ProgramPlugin whose ApplyProgram always errors.
+// 2. Call SourceFiles first (the swallowing lane).
+// 3. Assert the emit still fails with the latched error and writes nothing.
+func TestEmitWithPluginTransformersReportLatchedLinkedApplyErrors(t *testing.T) {
+  resetLinkedPluginRegistry()
+  t.Setenv(driver.LinkedPluginsEnv, `[{"name":"boom","stage":"transform","config":{}}]`)
+  driver.RegisterPlugin(applyErrorProgramPlugin{})
+
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": { "module": "commonjs", "target": "es2020", "outDir": "bin", "strict": true },
+  "files": ["index.ts"]
+}
+`)
+  writeProjectFile(t, root, "index.ts", "export const a = 0;\n")
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  if files := prog.SourceFiles(); len(files) == 0 {
+    t.Fatal("expected program sources despite the swallowed apply failure")
+  }
+  emitted := map[string]string{}
+  _, err = prog.EmitWithPluginTransformers(nil, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    emitted[fileName] = text
+    return nil
+  })
+  if err == nil || !strings.Contains(err.Error(), "linked apply boom") {
+    t.Fatalf("expected latched apply error to abort emit, got err=%v", err)
+  }
+  if len(emitted) != 0 {
+    t.Fatalf("emit produced output despite latched apply failure: %#v", emitted)
+  }
+}

--- a/packages/ttsc/test/driver/emit_plugin_transformers_propagate_linked_apply_errors_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_transformers_propagate_linked_apply_errors_test.go
@@ -1,0 +1,67 @@
+package driver_test
+
+import (
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+type applyErrorProgramPlugin struct{}
+
+func (applyErrorProgramPlugin) ApplyProgram(*driver.Program, driver.PluginContext) error {
+  return errLinkedApplyBoom
+}
+
+var errLinkedApplyBoom = &linkedApplyError{}
+
+type linkedApplyError struct{}
+
+func (*linkedApplyError) Error() string { return "linked apply boom" }
+
+// TestEmitWithPluginTransformersPropagateLinkedApplyErrors verifies that a
+// linked ProgramPlugin failure aborts the emit instead of being swallowed.
+//
+// EmitWithPluginTransformers is the first emit lane that runs linked
+// ProgramPlugins itself, so its error path is new: a hook that fails must
+// surface to the host (which reports emit failure) and must not let a
+// half-mutated program emit as if nothing happened.
+//
+// 1. Register a linked ProgramPlugin whose ApplyProgram always errors.
+// 2. Emit through EmitWithPluginTransformers.
+// 3. Assert the emit returns that error and writes no output.
+func TestEmitWithPluginTransformersPropagateLinkedApplyErrors(t *testing.T) {
+  resetLinkedPluginRegistry()
+  t.Setenv(driver.LinkedPluginsEnv, `[{"name":"boom","stage":"transform","config":{}}]`)
+  driver.RegisterPlugin(applyErrorProgramPlugin{})
+
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": { "module": "commonjs", "target": "es2020", "outDir": "bin", "strict": true },
+  "files": ["index.ts"]
+}
+`)
+  writeProjectFile(t, root, "index.ts", "export const a = 0;\n")
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  emitted := map[string]string{}
+  _, err = prog.EmitWithPluginTransformers(nil, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+    emitted[fileName] = text
+    return nil
+  })
+  if err == nil || !strings.Contains(err.Error(), "linked apply boom") {
+    t.Fatalf("expected linked apply error to abort emit, got err=%v", err)
+  }
+  if len(emitted) != 0 {
+    t.Fatalf("emit produced output despite linked apply failure: %#v", emitted)
+  }
+}

--- a/packages/ttsc/test/driver/source_file_applies_linked_program_plugins_test.go
+++ b/packages/ttsc/test/driver/source_file_applies_linked_program_plugins_test.go
@@ -1,0 +1,60 @@
+package driver_test
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimprinter "github.com/microsoft/typescript-go/shim/printer"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestSourceFileAppliesLinkedProgramPlugins verifies that Program.SourceFile
+// runs linked ProgramPlugin hooks before handing out the single file.
+//
+// Locks the single-file lane of the same class as the emit-funnel regression:
+// a host's `--file` transform mode fetches one source through SourceFile and
+// prints it, so if only SourceFiles applied linked plugins, a whole-project
+// run and a single-file run of the same host would disagree about the tree.
+//
+//  1. Register a linked ProgramPlugin that rewrites "linked-pending" into
+//     "linked-applied" and pair it with one manifest entry.
+//  2. Fetch index.ts via Program.SourceFile (never calling SourceFiles).
+//  3. Print the returned file and assert the linked rewrite is present.
+func TestSourceFileAppliesLinkedProgramPlugins(t *testing.T) {
+  resetLinkedPluginRegistry()
+  t.Setenv(driver.LinkedPluginsEnv, `[{"name":"rewrite","stage":"transform","config":{}}]`)
+  driver.RegisterPlugin(&stringRewriteProgramPlugin{from: "linked-pending", to: "linked-applied"})
+
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": { "module": "commonjs", "target": "es2020" },
+  "files": ["index.ts"]
+}
+`)
+  writeProjectFile(t, root, "index.ts", "export const spec = \"linked-pending\";\n")
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  file := prog.SourceFile(filepath.Join(root, "index.ts"))
+  if file == nil {
+    t.Fatal("index.ts not found in program")
+  }
+  printer := shimprinter.NewPrinter(shimprinter.PrinterOptions{}, shimprinter.PrintHandlers{}, nil)
+  text := shimprinter.EmitSourceFile(printer, file)
+  t.Logf("index.ts:\n%s", text)
+
+  if !strings.Contains(text, "linked-applied") {
+    t.Fatalf("linked ProgramPlugin did not apply on the SourceFile lane:\n%s", text)
+  }
+  if strings.Contains(text, "linked-pending") {
+    t.Fatalf("stale literal survived the linked rewrite:\n%s", text)
+  }
+}

--- a/tests/test-ttsc/src/native-plugins/utility-host/test_ttsc_utility_plugins_paths_applies_when_host_emits_with_own_transformers.ts
+++ b/tests/test-ttsc/src/native-plugins/utility-host/test_ttsc_utility_plugins_paths_applies_when_host_emits_with_own_transformers.ts
@@ -1,0 +1,198 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TestUtilityPlugins } from "../../internal/TestUtilityPlugins";
+import { SHARED_PLUGIN_CACHE_DIR } from "../../internal/plugin-cache";
+
+/**
+ * Verifies ttsc linked plugins: paths applies when the host emits through
+ * EmitWithPluginTransformers with only its own transform.
+ *
+ * Locks the regression where a third-party transform host shaped like typia's
+ * `ttsc-typia build` — LoadProgram, Diagnostics, then
+ * `EmitWithPluginTransformers([own transform])` — never ran the linked plugins
+ * compiled into its binary: `@ttsc/paths` registered via init() but its
+ * ApplyProgram never fired, so tsconfig paths aliases survived into the emitted
+ * JavaScript. The driver must honor linked hooks at the emit funnel itself;
+ * hosts do not know which linked packages ttsc merged into them.
+ *
+ * 1. Configure `@ttsc/paths` alongside a custom executable host whose build
+ *    command emits via EmitWithPluginTransformers with its own transform
+ *    (numeric 0 -> 100), never calling ApplyLinkedPlugins by hand.
+ * 2. Run ttsc with --emit.
+ * 3. Assert the emitted main.js carries BOTH the host transform's rewrite and the
+ *    paths alias rewrite.
+ */
+export const test_ttsc_utility_plugins_paths_applies_when_host_emits_with_own_transformers =
+  () => {
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          strict: true,
+          paths: {
+            "@lib/*": ["./src/lib/*"],
+          },
+          outDir: "dist",
+          rootDir: "src",
+          plugins: [
+            { transform: "@ttsc/paths" },
+            { transform: "./plugins/emit-host.cjs" },
+          ],
+        },
+        include: ["src"],
+      }),
+      "plugins/emit-host.cjs": `
+        module.exports = (context) => ({
+          name: "emit-host",
+          source: require("node:path").resolve(
+            context.dirname,
+            "..",
+            "go-host",
+            "cmd",
+            "emit-host"
+          ),
+        });
+      `,
+      "go-host/go.mod": [
+        "module example.com/emithost",
+        "",
+        "go 1.26",
+        "",
+        "require (",
+        "\tgithub.com/microsoft/typescript-go/shim/ast v0.0.0",
+        "\tgithub.com/microsoft/typescript-go/shim/printer v0.0.0",
+        "\tgithub.com/samchon/ttsc/packages/ttsc v0.0.0",
+        ")",
+        "",
+      ].join("\n"),
+      "go-host/cmd/emit-host/main.go": `
+        package main
+
+        import (
+          "flag"
+          "fmt"
+          "os"
+
+          shimast "github.com/microsoft/typescript-go/shim/ast"
+          shimprinter "github.com/microsoft/typescript-go/shim/printer"
+          "github.com/samchon/ttsc/packages/ttsc/driver"
+        )
+
+        func main() {
+          os.Exit(run(os.Args[1:]))
+        }
+
+        func run(args []string) int {
+          if len(args) == 0 {
+            fmt.Fprintln(os.Stderr, "emit-host: command required")
+            return 2
+          }
+          switch args[0] {
+          case "build":
+            return runBuild(args[1:])
+          case "check":
+            return 0
+          case "-v", "--version", "version":
+            fmt.Fprintln(os.Stdout, "emit-host 0.1.0")
+            return 0
+          default:
+            fmt.Fprintf(os.Stderr, "emit-host: unknown command %q\\n", args[0])
+            return 2
+          }
+        }
+
+        func runBuild(args []string) int {
+          fs := flag.NewFlagSet("emit-host", flag.ContinueOnError)
+          fs.SetOutput(os.Stderr)
+          cwd := fs.String("cwd", "", "project directory")
+          tsconfig := fs.String("tsconfig", "tsconfig.json", "tsconfig")
+          _ = fs.String("plugins-json", "", "ordered plugin descriptors")
+          emit := fs.Bool("emit", false, "force emit")
+          _ = fs.Bool("noEmit", false, "force no emit")
+          outDir := fs.String("outDir", "", "out dir")
+          _ = fs.Bool("quiet", false, "quiet")
+          _ = fs.Bool("verbose", false, "verbose")
+          if err := fs.Parse(args); err != nil {
+            return 2
+          }
+          root := *cwd
+          if root == "" {
+            var err error
+            root, err = os.Getwd()
+            if err != nil {
+              fmt.Fprintf(os.Stderr, "emit-host: cwd: %v\\n", err)
+              return 2
+            }
+          }
+          prog, diags, err := driver.LoadProgram(root, *tsconfig, driver.LoadProgramOptions{
+            ForceEmit: *emit,
+            OutDir:    *outDir,
+          })
+          if err != nil {
+            fmt.Fprintf(os.Stderr, "emit-host: %v\\n", err)
+            return 2
+          }
+          if len(diags) > 0 {
+            for _, diag := range diags {
+              fmt.Fprintln(os.Stderr, diag.String())
+            }
+            return 2
+          }
+          defer prog.Close()
+          if diags := prog.Diagnostics(); len(diags) > 0 {
+            for _, diag := range diags {
+              fmt.Fprintln(os.Stderr, diag.String())
+            }
+            return 2
+          }
+          // The typia-host shape under regression test: only the host's own
+          // transform is passed; linked plugins must still be honored by the
+          // driver's emit funnel.
+          hostTransform := func(ec *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
+            var v *shimast.NodeVisitor
+            visit := func(n *shimast.Node) *shimast.Node {
+              if n != nil && n.Kind == shimast.KindNumericLiteral && n.Text() == "0" {
+                return ec.Factory.NewNumericLiteral("100", 0)
+              }
+              return v.VisitEachChild(n)
+            }
+            v = ec.NewNodeVisitor(visit)
+            return v.VisitSourceFile(sf)
+          }
+          if _, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{hostTransform}, nil); err != nil {
+            fmt.Fprintf(os.Stderr, "emit-host: emit: %v\\n", err)
+            return 3
+          }
+          return 0
+        }
+      `,
+      "src/lib/value.ts": `export const value = "ok";\n`,
+      "src/main.ts": [
+        `import { value } from "@lib/value";`,
+        `export const result = value;`,
+        `export const marker = 0;`,
+        ``,
+      ].join("\n"),
+    });
+    TestUtilityPlugins.seedPackages(root, ["paths"]);
+    const result = TestProject.spawn(
+      TestProject.TTSC_BIN,
+      ["--cwd", root, "--emit"],
+      {
+        cwd: root,
+        env: {
+          PATH: TestUtilityPlugins.goPath(),
+          TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const main = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+    assert.match(main, /from "\.\/lib\/value\.js"/);
+    assert.match(main, /marker = 100/);
+  };

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -127,6 +127,8 @@ func (plugin) ApplyProgram(prog *driver.Program, ctx driver.PluginContext) error
 
 Implement `SourcePreamble(ctx)` when the plugin needs text before parsing, and `ApplyProgram(prog, ctx)` when it mutates the loaded Program. `ctx.Entry.Config` is the original `compilerOptions.plugins[]` object for this linked entry.
 
+The driver runs these hooks itself; a host binary never has to know which linked packages ttsc compiled into it. `SourcePreamble` applies inside `LoadProgram`. `ApplyProgram` runs once per Program, triggered by the first call to `SourceFiles()` / `SourceFile()` or by any driver emit lane — including `EmitWithPluginTransformers`, so a host that emits with only its own transforms (the typia shape) still honors linked plugins. `EmitTransform` transforms join the per-file chain after the host's own transforms, in registration order. Calling `ApplyLinkedPlugins()` by hand remains valid and idempotent.
+
 ## Hosting `ttscserver`
 
 These symbols are for embedders of `ttscserver`, **not for plugin authors**. Skip this section unless you are building a `ttsc`-aware editor extension.


### PR DESCRIPTION
## Intent

A third-party transform host that emits through `EmitWithPluginTransformers` with only its own transform — typia's `ttsc-typia build` shape — never ran the linked plugins ttsc compiled into its binary. `@ttsc/paths` in a typia project built, registered via `init()`, and was then silently never invoked, so tsconfig `paths` aliases survived into the emitted JavaScript.

Diagnosis chain (verified against a real typia + `@ttsc/paths` project):

1. Discovery, linked classification, contributor merge, and the `TTSC_LINKED_PLUGINS_JSON` spawn env are all correct — the paths driver was present in the host binary as `contrib/linked_000001`.
2. `driver.LoadProgram` reads and validates the manifest.
3. But linked `ProgramPlugin.ApplyProgram` only fired via `Program.SourceFiles()` / `ApplyLinkedPlugins()`, and linked `EmitTransformPlugin` transforms only via `EmitLinkedTransforms` — none of which a typia-shaped host calls. The ttsc-owned utility host calls `ApplyLinkedPlugins()` by hand, which is why the bug only bit third-party hosts.

## Scope

- `EmitWithPluginTransformers` now honors linked plugins itself: it applies linked ProgramPlugins before the per-file loop (idempotent — once per Program) and chains linked EmitTransformPlugins after the caller's transforms in registration order. `EmitLinkedTransforms` becomes the nil-transform convenience form, so nothing double-applies.
- `Program.SourceFile` applies linked ProgramPlugins like `SourceFiles` already did, sealing the single-file (`--file`) transform lane of the same failure class.
- Driver unit tests: linked ProgramPlugin applies on the host emit path (fails before the fix), negative twin proving the manifest gates execution, chain-order lock (host-then-linked), and the SourceFile lane (fails before the fix).
- E2E: a synthetic executable host mirroring typia's build lane (own transform passed to `EmitWithPluginTransformers`, no manual `ApplyLinkedPlugins`) plus `@ttsc/paths`, asserting both the host transform and the paths rewrite land in emitted JS.
- Docs: driver API page states the linked hook timing contract.

No host changes required: hosts compile the driver from the installed ttsc package, so existing typia/nestia binaries pick the fix up on their next cache-key rebuild (ttsc version is part of the key).

## Test plan

- `go test ./test/driver/` (packages/ttsc) — new tests fail before the fix, pass after; existing `EmitLinkedTransforms` order tests still pass through the delegation.
- CI runs the new `native-plugins/utility-host` e2e alongside the existing linked-plugin corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178b8D6rnwfrv6cXotV7hrk