### PR TITLE
fix(ttsc): prevent injected import name collisions

### DIFF
--- a/packages/ttsc/driver/plugins.go
+++ b/packages/ttsc/driver/plugins.go
@@ -42,11 +42,14 @@ type ProgramPlugin interface {
 // EmitTransformPlugin contributes an emit-phase AST transformer. The returned
 // PluginTransform runs first in tsgo's per-file emit chain, sharing the emit
 // EmitContext with the builtin transformers, so a plugin returns AST instead of
-// spliced text: it injects its own imports with ec.Factory and references them
-// via NewGeneratedNameForNode, and tsgo's module-transform emits the require and
-// aliases the references itself. This is the AST-integration replacement for the
-// ProgramPlugin + RewriteSet text-splice model. A plugin whose returned
-// transform is nil contributes nothing.
+// spliced text. For an injected import, allocate its binding once with
+// ec.Factory.NewUniqueNameEx and the Optimistic | FileLevel flags, then reuse
+// that identifier for every reference. NewGeneratedNameForNode on a string
+// literal uses tsgo's temp-name channel and can be shadowed by downlevel temps.
+// Tsgo's module-transform emits the require and aliases the references itself.
+// This is the AST-integration replacement for the ProgramPlugin + RewriteSet
+// text-splice model. A plugin whose returned transform is nil contributes
+// nothing.
 type EmitTransformPlugin interface {
   EmitTransform(PluginContext) (PluginTransform, error)
 }

--- a/packages/ttsc/shim/printer/shim.go
+++ b/packages/ttsc/shim/printer/shim.go
@@ -1,7 +1,6 @@
-// Package printer re-exports the typescript-go internal/printer types and
-// wraps the three functions that the ttsc driver and transform plugins need
-// to emit source text from an AST. The surface is intentionally narrow: only
-// the construction and single-file emit path are exposed.
+// Package printer re-exports the typescript-go internal/printer types that the
+// ttsc driver and transform plugins need to emit source text and allocate
+// collision-safe generated identifiers. The surface is intentionally narrow.
 package printer
 
 import (
@@ -23,6 +22,25 @@ type PrinterOptions = innerprinter.PrinterOptions
 // EmitContext accumulates per-emit metadata (source maps, comment positions)
 // and must be created fresh for each emit round via NewEmitContext.
 type EmitContext = innerprinter.EmitContext
+
+// AutoGenerateOptions configures how NodeFactory allocates generated names.
+type AutoGenerateOptions = innerprinter.AutoGenerateOptions
+
+// GeneratedIdentifierFlags controls generated-name scope and collision checks.
+type GeneratedIdentifierFlags = innerprinter.GeneratedIdentifierFlags
+
+const (
+  GeneratedIdentifierFlagsNone                   = innerprinter.GeneratedIdentifierFlagsNone
+  GeneratedIdentifierFlagsAuto                   = innerprinter.GeneratedIdentifierFlagsAuto
+  GeneratedIdentifierFlagsLoop                   = innerprinter.GeneratedIdentifierFlagsLoop
+  GeneratedIdentifierFlagsUnique                 = innerprinter.GeneratedIdentifierFlagsUnique
+  GeneratedIdentifierFlagsNode                   = innerprinter.GeneratedIdentifierFlagsNode
+  GeneratedIdentifierFlagsKindMask               = innerprinter.GeneratedIdentifierFlagsKindMask
+  GeneratedIdentifierFlagsReservedInNestedScopes = innerprinter.GeneratedIdentifierFlagsReservedInNestedScopes
+  GeneratedIdentifierFlagsOptimistic             = innerprinter.GeneratedIdentifierFlagsOptimistic
+  GeneratedIdentifierFlagsFileLevel              = innerprinter.GeneratedIdentifierFlagsFileLevel
+  GeneratedIdentifierFlagsAllowNameSubstitution  = innerprinter.GeneratedIdentifierFlagsAllowNameSubstitution
+)
 
 // NewPrinter creates an emitter with the supplied options, substitution hooks,
 // and emit context. Callers must pass the same EmitContext to all operations

--- a/packages/ttsc/test/driver/emit_plugin_import_star_helper_with_injected_import_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_import_star_helper_with_injected_import_test.go
@@ -50,7 +50,10 @@ func TestEmitWithPluginTransformerImportStarHelperWithInjectedImport(t *testing.
   // initializer to `<gen>.foo`.
   transform := func(ec *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
     modSpec := ec.Factory.NewStringLiteral("./dep", 0)
-    nsImport := ec.Factory.NewNamespaceImport(ec.Factory.NewGeneratedNameForNode(modSpec))
+    importName := ec.Factory.NewUniqueNameEx("dep", shimprinter.AutoGenerateOptions{
+      Flags: shimprinter.GeneratedIdentifierFlagsOptimistic | shimprinter.GeneratedIdentifierFlagsFileLevel,
+    })
+    nsImport := ec.Factory.NewNamespaceImport(importName)
     clause := ec.Factory.NewImportClause(shimast.KindUnknown, nil, nsImport)
     importDecl := ec.Factory.NewImportDeclaration(nil, clause, modSpec, nil)
 
@@ -60,7 +63,7 @@ func TestEmitWithPluginTransformerImportStarHelperWithInjectedImport(t *testing.
         return node
       }
       if node.Kind == shimast.KindNumericLiteral && node.Text() == "0" {
-        ref := ec.Factory.NewGeneratedNameForNode(modSpec)
+        ref := importName
         return ec.Factory.NewPropertyAccessExpression(ref, nil, ec.Factory.NewIdentifier("foo"), shimast.NodeFlagsNone)
       }
       if node.Kind == shimast.KindSourceFile {

--- a/packages/ttsc/test/driver/emit_plugin_injected_import_esnext_module_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_injected_import_esnext_module_test.go
@@ -3,9 +3,9 @@ package driver_test
 // EC-module-format-esnext: the commonjs injected-import case has an ESM mirror.
 // Under module=esnext, a plugin-injected namespace import must stay an ESM
 // `import * as <gen> from "..."` (NOT lowered to require), and the member
-// reference built with the same NewGeneratedNameForNode must print the same
-// alias. This guards the ESM emit path of tsgo's module-transform for
-// plugin-injected imports.
+// reference built with the same unique identifier must print the same alias.
+// This guards the ESM emit path of tsgo's module-transform for plugin-injected
+// imports.
 
 import (
   "path/filepath"
@@ -41,7 +41,10 @@ func TestEmitWithPluginTransformerInjectedImportEsnextModule(t *testing.T) {
 
   transform := func(ec *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
     modSpec := ec.Factory.NewStringLiteral("./dep", 0)
-    nsImport := ec.Factory.NewNamespaceImport(ec.Factory.NewGeneratedNameForNode(modSpec))
+    importName := ec.Factory.NewUniqueNameEx("dep", shimprinter.AutoGenerateOptions{
+      Flags: shimprinter.GeneratedIdentifierFlagsOptimistic | shimprinter.GeneratedIdentifierFlagsFileLevel,
+    })
+    nsImport := ec.Factory.NewNamespaceImport(importName)
     clause := ec.Factory.NewImportClause(shimast.KindUnknown, nil, nsImport)
     importDecl := ec.Factory.NewImportDeclaration(nil, clause, modSpec, nil)
 
@@ -51,7 +54,7 @@ func TestEmitWithPluginTransformerInjectedImportEsnextModule(t *testing.T) {
         return node
       }
       if node.Kind == shimast.KindNumericLiteral && node.Text() == "0" {
-        ref := ec.Factory.NewGeneratedNameForNode(modSpec)
+        ref := importName
         return ec.Factory.NewPropertyAccessExpression(ref, nil, ec.Factory.NewIdentifier("foo"), shimast.NodeFlagsNone)
       }
       if node.Kind == shimast.KindSourceFile {

--- a/packages/ttsc/test/driver/emit_plugin_mixed_factory_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_mixed_factory_test.go
@@ -15,11 +15,11 @@ import (
 // TestEmitWithPluginTransformerMixedFactory proves the property that bounds the
 // typia port: a plugin may build its big expression tree with its OWN global
 // NodeFactory (typia keeps dozens of module-level factories) and only build the
-// runtime-import REFERENCE with the emit ec.Factory.NewGeneratedNameForNode. The
-// non-import nodes are not import references, so tsgo's module-transform never
-// touches them; only the generated namespace name needs the emit context. The
-// require is still emitted and the alias still lines up, so the port can leave
-// every typia programmer's factory alone and only rewire ImportProgrammer.
+// runtime-import name with the emit ec.Factory.NewUniqueNameEx. The non-import
+// nodes are not import references, so tsgo's module-transform never touches
+// them; only the generated namespace name needs the emit context. The require
+// is still emitted and the alias still lines up, so the port can leave every
+// typia programmer's factory alone and only rewire ImportProgrammer.
 func TestEmitWithPluginTransformerMixedFactory(t *testing.T) {
   root := t.TempDir()
   writeProjectFile(t, root, "tsconfig.json", `{
@@ -40,7 +40,10 @@ func TestEmitWithPluginTransformerMixedFactory(t *testing.T) {
 
   transform := func(ec *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
     modSpec := ec.Factory.NewStringLiteral("./dep", 0)
-    nsImport := ec.Factory.NewNamespaceImport(ec.Factory.NewGeneratedNameForNode(modSpec))
+    importName := ec.Factory.NewUniqueNameEx("dep", shimprinter.AutoGenerateOptions{
+      Flags: shimprinter.GeneratedIdentifierFlagsOptimistic | shimprinter.GeneratedIdentifierFlagsFileLevel,
+    })
+    nsImport := ec.Factory.NewNamespaceImport(importName)
     clause := ec.Factory.NewImportClause(shimast.KindUnknown, nil, nsImport)
     importDecl := ec.Factory.NewImportDeclaration(nil, clause, modSpec, nil)
 
@@ -51,7 +54,7 @@ func TestEmitWithPluginTransformerMixedFactory(t *testing.T) {
       }
       if node.Kind == shimast.KindNumericLiteral && node.Text() == "0" {
         // 검증 트리: 바깥 노드는 indep, namespace 참조만 ec.Factory
-        ref := ec.Factory.NewGeneratedNameForNode(modSpec)                                                       // <-- emit ec
+        ref := importName                                                                                        // <-- emit ec
         access := indep.NewPropertyAccessExpression(ref, nil, indep.NewIdentifier("foo"), shimast.NodeFlagsNone) // <-- indep
         arg := indep.NewNumericLiteral("123", 0)                                                                 // <-- indep
         return indep.NewCallExpression(access, nil, nil, indep.NewNodeList([]*shimast.Node{arg}), shimast.NodeFlagsNone)

--- a/packages/ttsc/test/driver/emit_plugin_type_only_import_elided_synthetic_survives_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_type_only_import_elided_synthetic_survives_test.go
@@ -51,7 +51,10 @@ func TestEmitWithPluginTransformerTypeOnlyImportElidedSyntheticSurvives(t *testi
   // used. The type-only `./types` import is left untouched to be elided.
   transform := func(ec *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
     modSpec := ec.Factory.NewStringLiteral("./dep", 0)
-    nsImport := ec.Factory.NewNamespaceImport(ec.Factory.NewGeneratedNameForNode(modSpec))
+    importName := ec.Factory.NewUniqueNameEx("dep", shimprinter.AutoGenerateOptions{
+      Flags: shimprinter.GeneratedIdentifierFlagsOptimistic | shimprinter.GeneratedIdentifierFlagsFileLevel,
+    })
+    nsImport := ec.Factory.NewNamespaceImport(importName)
     clause := ec.Factory.NewImportClause(shimast.KindUnknown, nil, nsImport)
     importDecl := ec.Factory.NewImportDeclaration(nil, clause, modSpec, nil)
 
@@ -62,7 +65,7 @@ func TestEmitWithPluginTransformerTypeOnlyImportElidedSyntheticSurvives(t *testi
       }
       if node.Kind == shimast.KindSourceFile {
         visited := visitor.VisitEachChild(node).AsSourceFile()
-        ref := ec.Factory.NewGeneratedNameForNode(modSpec)
+        ref := importName
         access := ec.Factory.NewPropertyAccessExpression(ref, nil, ec.Factory.NewIdentifier("foo"), shimast.NodeFlagsNone)
         useStmt := ec.Factory.NewExpressionStatement(access)
         stmts := append([]*shimast.Node{importDecl}, visited.Statements.Nodes...)

--- a/packages/ttsc/test/driver/emit_plugin_unique_import_avoids_downlevel_temp_shadow_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_unique_import_avoids_downlevel_temp_shadow_test.go
@@ -13,23 +13,27 @@ import (
   "github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
-// TestEmitWithPluginTransformerInjectedImport drives the official
-// driver.EmitWithPluginTransformer end-to-end with typia's real pattern: the
-// plugin INJECTS its own namespace import built with ec.Factory and references
-// a member through one file-level unique name. tsgo's builtin module-transform
-// then emits the require unconditionally (a synthetic import has no parse node,
-// so import-elision never drops it) and the generated name lines up between the
-// import and the reference, all without any checker/symbol involvement and
-// without text-splice or hand-rolled aliasing.
-func TestEmitWithPluginTransformerInjectedImport(t *testing.T) {
+// TestEmitPluginUniqueImportAvoidsDownlevelTempShadow verifies emit plugins:
+// unique import bindings survive ES2015 downlevel temps.
+//
+// Locks the generated-name collision between a synthetic namespace import and
+// the function-scoped variables that lower optional chaining and nullish
+// coalescing. Both name families may be referenced inside the same function,
+// so the import binding must use tsgo's unique-name channel.
+//
+// 1. Inject a namespace import and reference it inside a nullish expression.
+// 2. Emit the source at ES2015 so tsgo allocates a function-scoped temp.
+// 3. Assert the downlevel temp does not shadow the injected import binding.
+func TestEmitPluginUniqueImportAvoidsDownlevelTempShadow(t *testing.T) {
   root := t.TempDir()
   writeProjectFile(t, root, "tsconfig.json", `{
-  "compilerOptions": { "module": "commonjs", "target": "es2020", "outDir": "bin", "strict": true },
+  "compilerOptions": { "module": "commonjs", "target": "es2015", "outDir": "bin", "strict": true },
   "files": ["dep.ts", "index.ts"]
 }
 `)
-  writeProjectFile(t, root, "dep.ts", "export const foo: number = 1;\n")
-  writeProjectFile(t, root, "index.ts", "export const a = 0;\n")
+  writeProjectFile(t, root, "dep.ts", "export const foo: number = 42;\n")
+  writeProjectFile(t, root, "index.ts", "export const value = (input?: { nested?: number }): number => input?.nested ?? 0;\n")
+
   prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
   if err != nil {
     t.Fatal(err)
@@ -39,9 +43,6 @@ func TestEmitWithPluginTransformerInjectedImport(t *testing.T) {
   }
   defer prog.Close()
 
-  // Plugin transformer: inject `import * as <gen> from "./dep"` and rewrite the
-  // `0` initializer to `<gen>.foo`, reusing one file-level unique identifier so
-  // both positions print as the same name.
   transform := func(ec *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
     modSpec := ec.Factory.NewStringLiteral("./dep", 0)
     importName := ec.Factory.NewUniqueNameEx("dep", shimprinter.AutoGenerateOptions{
@@ -57,13 +58,12 @@ func TestEmitWithPluginTransformerInjectedImport(t *testing.T) {
         return node
       }
       if node.Kind == shimast.KindNumericLiteral && node.Text() == "0" {
-        ref := importName
-        return ec.Factory.NewPropertyAccessExpression(ref, nil, ec.Factory.NewIdentifier("foo"), shimast.NodeFlagsNone)
+        return ec.Factory.NewPropertyAccessExpression(importName, nil, ec.Factory.NewIdentifier("foo"), shimast.NodeFlagsNone)
       }
       if node.Kind == shimast.KindSourceFile {
         visited := visitor.VisitEachChild(node).AsSourceFile()
-        stmts := append([]*shimast.Node{importDecl}, visited.Statements.Nodes...)
-        return ec.Factory.UpdateSourceFile(visited, ec.Factory.NewNodeList(stmts), visited.EndOfFileToken)
+        statements := append([]*shimast.Node{importDecl}, visited.Statements.Nodes...)
+        return ec.Factory.UpdateSourceFile(visited, ec.Factory.NewNodeList(statements), visited.EndOfFileToken)
       }
       return visitor.VisitEachChild(node)
     }
@@ -78,16 +78,20 @@ func TestEmitWithPluginTransformerInjectedImport(t *testing.T) {
   }); err != nil {
     t.Fatal(err)
   }
+
   js := emitted["index.js"]
-  t.Logf("index.js:\n%s", js)
-  // The namespace alias must be identical between the require binding
-  // (`const X = ...require("./dep")`) and the member reference
-  // (`exports.a = X.foo`) — tsgo's generated-name resolution lines them up.
-  bind := regexp.MustCompile(`const (\w+) = [^\n]*require\("\./dep"\)`).FindStringSubmatch(js)
-  if bind == nil {
+  binding := regexp.MustCompile(`const (\w+) = [^\n]*require\("\./dep"\)`).FindStringSubmatch(js)
+  if binding == nil {
     t.Fatalf("injected import did not emit a require binding:\n%s", js)
   }
-  if !strings.Contains(js, "exports.a = "+bind[1]+".foo;") {
-    t.Fatalf("reference %q.foo not aliased to the require binding %q:\n%s", bind[1], bind[1], js)
+  if !strings.Contains(js, binding[1]+".foo") {
+    t.Fatalf("injected reference does not use import binding %q:\n%s", binding[1], js)
+  }
+  downlevelTemp := regexp.MustCompile(`const value = \(input\) => \{ var (\w+);`).FindStringSubmatch(js)
+  if downlevelTemp == nil {
+    t.Fatalf("ES2015 emit did not allocate the expected function-scoped temp:\n%s", js)
+  }
+  if downlevelTemp[1] == binding[1] {
+    t.Fatalf("downlevel temp shadows injected import %q:\n%s", binding[1], js)
   }
 }

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -129,6 +129,24 @@ Implement `SourcePreamble(ctx)` when the plugin needs text before parsing, and `
 
 The driver runs these hooks itself; a host binary never has to know which linked packages ttsc compiled into it. `SourcePreamble` applies inside `LoadProgram`. `ApplyProgram` runs once per Program, triggered by the first call to `SourceFiles()` / `SourceFile()` or by any driver emit lane — including `EmitWithPluginTransformers`, so a host that emits with only its own transforms (the typia shape) still honors linked plugins. `EmitTransform` transforms join the per-file chain after the host's own transforms, in registration order. Calling `ApplyLinkedPlugins()` by hand remains valid and idempotent.
 
+An `EmitTransform` that injects an import must allocate one file-level unique identifier and reuse that node for the import binding and every reference:
+
+```go
+importName := ec.Factory.NewUniqueNameEx("dep", shimprinter.AutoGenerateOptions{
+    Flags: shimprinter.GeneratedIdentifierFlagsOptimistic |
+        shimprinter.GeneratedIdentifierFlagsFileLevel,
+})
+namespaceImport := ec.Factory.NewNamespaceImport(importName)
+reference := ec.Factory.NewPropertyAccessExpression(
+    importName,
+    nil,
+    ec.Factory.NewIdentifier("foo"),
+    shimast.NodeFlagsNone,
+)
+```
+
+Do not derive an injected import binding with `NewGeneratedNameForNode(moduleSpecifier)` when `moduleSpecifier` is a string literal. Tsgo routes that node kind through its temp-name channel (`_a`, `_b`, and so on). ES2015-ES2019 lowering can allocate the same names inside a nested function for optional chaining or nullish coalescing, shadowing the module-level import at runtime. `NewUniqueNameEx` uses the non-conflicting unique-name channel; `FileLevel` checks source bindings and `Optimistic` keeps the unsuffixed base name when it is available.
+
 ## Hosting `ttscserver`
 
 These symbols are for embedders of `ttscserver`, **not for plugin authors**. Skip this section unless you are building a `ttsc`-aware editor extension.


### PR DESCRIPTION
## Summary

- expose `AutoGenerateOptions` and the complete `GeneratedIdentifierFlags` family through `shim/printer`
- update the `EmitTransformPlugin` contract and plugin-author guide to allocate one file-level `NewUniqueNameEx` binding and reuse it for injected imports
- migrate the injected-import driver tests to the safe pattern and add an ES2015 regression that proves downlevel temps cannot shadow the import

## Scope

This fixes the ttsc SDK and guidance that previously recommended `NewGeneratedNameForNode` with a string-literal module specifier. That tsgo node kind uses the temp-name channel and can collide with nested optional-chain/nullish-coalescing temps.

## Deferred

Consumer plugins that already use the old pattern still need to migrate their import programmer. Ttsc cannot rewrite plugin-owned generated-name identities after the transformer returns its AST, and upstream typescript-go still routes string literals through the temp-name fallback.

## Test plan

- `pnpm format`
- `go test ./test/driver -count=1`
- `go test ./...` from `packages/ttsc/shim/printer`
- `pnpm --filter ttsc shim:audit`
- `pnpm --filter @ttsc/website build:next`

Addresses #349
