### PR TITLE
fix(graph): refresh resident index after source changes

### DIFF
--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -47,6 +47,7 @@ The whole MCP surface is one tool, `inspect_typescript_graph`. You ask in plain 
 
 - **An index, not source bodies.** It returns names, edges, signatures, and spans, never code, so the response stays flat as the repository grows.
 - **Built on the real compiler.** It reads the program `ttsc` type-checked, so `tsconfig` aliases, pnpm monorepos, symlinks, and re-exports resolve exactly, where a text parser can only guess.
+- **Current within one agent session.** Before each graph operation it checks the config, root-file set, module-resolution inputs, and source contents. Unchanged calls reuse the warm graph; source edits update the resident compiler incrementally; config, file-addition, deletion, and resolution changes reload safely.
 - **It does not force itself.** It states when the graph is the right source and offers a first-class `escape` for everything else.
 - **Errors and lint too.** `tsc` compile errors and `@ttsc/lint` and plugin (typia, nestia) findings ride the same graph, so "what is broken here?" answers from one index.
 

--- a/packages/graph/src/TtscGraphApplication.ts
+++ b/packages/graph/src/TtscGraphApplication.ts
@@ -9,7 +9,9 @@ import { runTrace } from "./server/runTrace";
 import { ITtscGraphApplication } from "./structures/ITtscGraphApplication";
 import { ITtscGraphEscape } from "./structures/ITtscGraphEscape";
 
-export type TtscGraphSource = TtscGraphMemory | (() => TtscGraphMemory);
+export type TtscGraphSource =
+  | TtscGraphMemory
+  | (() => TtscGraphMemory | Promise<TtscGraphMemory>);
 
 /**
  * The MCP tool surface as a plain class over the resident
@@ -22,20 +24,21 @@ export type TtscGraphSource = TtscGraphMemory | (() => TtscGraphMemory);
  * The method delegates to the pure graph functions in `./server`, which are
  * unit-testable without a transport; this class only binds them to the graph.
  *
- * Every method answers from the resident graph; none recompiles. Output is kept
+ * Every method answers from the current resident graph. The source may refresh
+ * that graph before the operation when project files changed. Output is kept
  * compact and bounded so a model can read structure without a file read, which
  * is the token win the redesign exists for.
  */
 export class TtscGraphApplication implements ITtscGraphApplication {
-  private readonly graph: () => TtscGraphMemory;
+  private readonly graph: () => TtscGraphMemory | Promise<TtscGraphMemory>;
 
   public constructor(source: TtscGraphSource) {
     this.graph = typeof source === "function" ? source : () => source;
   }
 
-  public inspect_typescript_graph(
+  public async inspect_typescript_graph(
     props: ITtscGraphApplication.IProps,
-  ): ITtscGraphApplication.IResult {
+  ): Promise<ITtscGraphApplication.IResult> {
     if (props.request.type === "escape") {
       const result = this.escape(props.request.reason);
       if (props.request.nextStep !== undefined) {
@@ -45,30 +48,31 @@ export class TtscGraphApplication implements ITtscGraphApplication {
         result,
       };
     }
+    const graph = await this.graph();
     switch (props.request.type) {
       case "entrypoints":
         return {
-          result: runEntrypoints(this.graph(), props.request),
+          result: runEntrypoints(graph, props.request),
         };
       case "lookup":
         return {
-          result: runLookup(this.graph(), props.request),
+          result: runLookup(graph, props.request),
         };
       case "trace":
         return {
-          result: runTrace(this.graph(), props.request),
+          result: runTrace(graph, props.request),
         };
       case "details":
         return {
-          result: runDetails(this.graph(), props.request),
+          result: runDetails(graph, props.request),
         };
       case "overview":
         return {
-          result: runOverview(this.graph(), props.request),
+          result: runOverview(graph, props.request),
         };
       case "tour":
         return {
-          result: runTour(this.graph(), props.request),
+          result: runTour(graph, props.request),
         };
       default:
         props.request satisfies never;

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -38,10 +38,10 @@ function parseProjectArgs(argv: readonly string[]): {
  * - `view`: JS-orchestrated 3D viewer (dump -> reduce -> serve -> open).
  * - `dump`: pass through to the native `ttscgraph dump`, which prints the whole
  *   graph as JSON for piping or the viewer.
- * - Default: serve the MCP graph over stdio. The TypeScript server runs
- *   `ttscgraph dump` once to build the resident graph, then answers tool calls
- *   from memory; the agent's MCP client speaks JSON-RPC over this process's
- *   stdin/stdout. The process stays alive on the stdio transport.
+ * - Default: serve the MCP graph over stdio. The TypeScript server keeps a native
+ *   incremental compiler session resident, checks the disk snapshot before each
+ *   graph operation, and reuses the in-memory graph when unchanged; the agent's
+ *   MCP client speaks JSON-RPC over this process's stdin/stdout.
  */
 export function runGraph(
   argv: readonly string[] = process.argv.slice(2),

--- a/packages/graph/src/model/TtscGraphSession.ts
+++ b/packages/graph/src/model/TtscGraphSession.ts
@@ -1,0 +1,192 @@
+import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import readline from "node:readline";
+import typia from "typia";
+
+import { ensureExecutable } from "../nativeExecutable";
+import { resolveGraphBinary } from "../resolveGraphBinary";
+import { ITtscGraphDump } from "../structures/ITtscGraphDump";
+import { TtscGraphMemory } from "./TtscGraphMemory";
+
+interface SessionResponse {
+  id: number;
+  changed: boolean;
+  mode?: "initial" | "unchanged" | "incremental" | "rebuild" | "reload";
+  dump?: unknown;
+  error?: string;
+}
+
+interface Pending {
+  resolve: (response: SessionResponse) => void;
+  reject: (error: Error) => void;
+}
+
+/**
+ * Resident bridge to `ttscgraph serve`.
+ *
+ * Every graph request first asks the native session for the current disk
+ * snapshot. Unchanged requests reuse the existing {@link TtscGraphMemory}; an
+ * edited source reuses tsgo's resident Program through `driver.Session`, while
+ * config and root-file-set changes force a safe full reload.
+ */
+export class TtscGraphSession {
+  private readonly cwd: string;
+  private readonly tsconfig: string;
+  private readonly binary: string;
+  private child: ChildProcessWithoutNullStreams | undefined;
+  private stderr = "";
+  private nextId = 0;
+  private readonly pending = new Map<number, Pending>();
+  private queue: Promise<void> = Promise.resolve();
+  private current: TtscGraphMemory | undefined;
+
+  public constructor(options: {
+    cwd: string;
+    tsconfig: string;
+    binary?: string;
+  }) {
+    const binary = options.binary ?? resolveGraphBinary();
+    if (binary === null) {
+      throw new Error(
+        "@ttsc/graph: could not resolve the ttscgraph binary. " +
+          "Install `ttsc` so its platform package is present, " +
+          "or set TTSC_GRAPH_BINARY to an absolute path.",
+      );
+    }
+    ensureExecutable(binary);
+    this.cwd = options.cwd;
+    this.tsconfig = options.tsconfig;
+    this.binary = binary;
+  }
+
+  /** Return a graph for the current disk snapshot, serialized per tool call. */
+  public graph(): Promise<TtscGraphMemory> {
+    let resolve!: (graph: TtscGraphMemory) => void;
+    let reject!: (error: Error) => void;
+    const result = new Promise<TtscGraphMemory>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    this.queue = this.queue
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          resolve(await this.refresh());
+        } catch (error) {
+          reject(asError(error));
+        }
+      });
+    return result;
+  }
+
+  /** Close the native session. Safe to call more than once. */
+  public close(): void {
+    const child = this.child;
+    this.child = undefined;
+    if (child !== undefined && !child.killed) child.stdin.end();
+  }
+
+  private async refresh(): Promise<TtscGraphMemory> {
+    const response = await this.request();
+    if (response.error !== undefined) {
+      throw new Error(`@ttsc/graph: ${response.error}`);
+    }
+    if (response.changed) {
+      if (response.dump === undefined) {
+        throw new Error(
+          `@ttsc/graph: native ${response.mode ?? "changed"} response omitted its dump`,
+        );
+      }
+      const dump = typia.assert<ITtscGraphDump>(response.dump);
+      this.current = TtscGraphMemory.from(dump);
+    }
+    if (this.current === undefined) {
+      throw new Error(
+        "@ttsc/graph: native session returned no initial graph snapshot",
+      );
+    }
+    return this.current;
+  }
+
+  private request(): Promise<SessionResponse> {
+    const child = this.ensureChild();
+    const id = ++this.nextId;
+    return new Promise<SessionResponse>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      child.stdin.write(`${JSON.stringify({ id })}\n`, (error) => {
+        if (error === null || error === undefined) return;
+        this.pending.delete(id);
+        reject(
+          new Error(
+            `@ttsc/graph: could not request native snapshot: ${error.message}`,
+          ),
+        );
+      });
+    });
+  }
+
+  private ensureChild(): ChildProcessWithoutNullStreams {
+    if (this.child !== undefined && this.child.exitCode === null) {
+      return this.child;
+    }
+    this.stderr = "";
+    const child = spawn(
+      this.binary,
+      ["serve", "--cwd", this.cwd, "--tsconfig", this.tsconfig],
+      { stdio: ["pipe", "pipe", "pipe"], windowsHide: true },
+    );
+    this.child = child;
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      this.stderr = (this.stderr + chunk).slice(-64 * 1024);
+    });
+    const lines = readline.createInterface({ input: child.stdout });
+    lines.on("line", (line) => this.onLine(line));
+    child.on("error", (error) => this.failChild(child, error));
+    child.on("exit", (code, signal) => {
+      if (this.child !== child) return;
+      this.child = undefined;
+      this.failPending(
+        new Error(
+          `@ttsc/graph: native session exited (code=${String(code)}, signal=${String(signal)})${
+            this.stderr.trim() === "" ? "" : `: ${this.stderr.trim()}`
+          }`,
+        ),
+      );
+    });
+    return child;
+  }
+
+  private onLine(line: string): void {
+    let response: SessionResponse;
+    try {
+      response = JSON.parse(line) as SessionResponse;
+    } catch (error) {
+      this.failPending(
+        new Error(
+          `@ttsc/graph: native session returned invalid JSON: ${asError(error).message}`,
+        ),
+      );
+      return;
+    }
+    const pending = this.pending.get(response.id);
+    if (pending === undefined) return;
+    this.pending.delete(response.id);
+    pending.resolve(response);
+  }
+
+  private failChild(child: ChildProcessWithoutNullStreams, error: Error): void {
+    if (this.child === child) this.child = undefined;
+    this.failPending(
+      new Error(`@ttsc/graph: native session failed: ${error.message}`),
+    );
+  }
+
+  private failPending(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/graph/src/model/TtscGraphSession.ts
+++ b/packages/graph/src/model/TtscGraphSession.ts
@@ -38,6 +38,7 @@ export class TtscGraphSession {
   private readonly pending = new Map<number, Pending>();
   private queue: Promise<void> = Promise.resolve();
   private current: TtscGraphMemory | undefined;
+  private closed = false;
 
   public constructor(options: {
     cwd: string;
@@ -80,9 +81,11 @@ export class TtscGraphSession {
 
   /** Close the native session. Safe to call more than once. */
   public close(): void {
+    this.closed = true;
     const child = this.child;
     this.child = undefined;
     if (child !== undefined && !child.killed) child.stdin.end();
+    this.failPending(new Error("@ttsc/graph: native session closed"));
   }
 
   private async refresh(): Promise<TtscGraphMemory> {
@@ -125,6 +128,11 @@ export class TtscGraphSession {
   }
 
   private ensureChild(): ChildProcessWithoutNullStreams {
+    if (this.closed) {
+      // A request queued behind the close must not respawn the native
+      // process; an orphaned resident compiler would outlive the MCP server.
+      throw new Error("@ttsc/graph: native session is closed");
+    }
     if (this.child !== undefined && this.child.exitCode === null) {
       return this.child;
     }

--- a/packages/graph/src/model/loadGraph.ts
+++ b/packages/graph/src/model/loadGraph.ts
@@ -13,9 +13,9 @@ const MAX_DUMP_BYTES = 1024 * 1024 * 1024;
 
 /**
  * Build the resident {@link TtscGraphMemory} for a project by running `ttscgraph
- * dump` once and loading its JSON. This is the cold path behind the MCP tool
- * calls: one type-check in Go produces the checker-resolved fact graph, then
- * every later tool call is answered from the in-memory model.
+ * dump` once and loading its JSON. This is the one-shot path for direct callers
+ * and the viewer. The MCP server uses `TtscGraphSession` instead so source
+ * edits refresh a resident compiler session.
  *
  * Throws when the binary cannot be resolved, the dump command fails, or its
  * output is not a readable graph — the server surfaces the failure rather than

--- a/packages/graph/src/server/startServer.ts
+++ b/packages/graph/src/server/startServer.ts
@@ -1,13 +1,13 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
-import { TtscGraphMemory } from "../model/TtscGraphMemory";
-import { loadGraph } from "../model/loadGraph";
+import { TtscGraphSession } from "../model/TtscGraphSession";
 import { createServer } from "./createServer";
 
 /**
  * Serve the graph tools over MCP on stdio. The server answers the MCP handshake
- * immediately and builds the resident graph on the first tool call, so a large
- * project cannot make the client give up before tools are advertised.
+ * immediately and opens the resident incremental graph session on the first
+ * real tool call, so a large project cannot make the client give up before
+ * tools are advertised and an escape request still performs no graph work.
  */
 export async function startServer(options: {
   cwd?: string;
@@ -15,11 +15,16 @@ export async function startServer(options: {
   /** Server version reported in the MCP handshake. */
   version: string;
 }): Promise<void> {
-  let graph: TtscGraphMemory | undefined;
-  const server = createServer(() => {
-    graph ??= loadGraph({ cwd: options.cwd, tsconfig: options.tsconfig });
-    return graph;
+  const cwd = options.cwd ?? process.cwd();
+  const tsconfig = options.tsconfig ?? "tsconfig.json";
+  let session: TtscGraphSession | undefined;
+  const server = createServer(async () => {
+    session ??= new TtscGraphSession({ cwd, tsconfig });
+    return session.graph();
   }, options.version);
   const transport = new StdioServerTransport();
+  const closeSession = () => session?.close();
+  transport.onclose = closeSession;
+  process.stdin.once("end", closeSession);
   await server.connect(transport);
 }

--- a/packages/graph/src/structures/ITtscGraphApplication.ts
+++ b/packages/graph/src/structures/ITtscGraphApplication.ts
@@ -10,14 +10,16 @@ import { ITtscGraphTrace } from "./ITtscGraphTrace";
  * ## What This MCP Is
  *
  * `inspect_typescript_graph` returns a compiler-built TypeScript graph contract
- * for the current source snapshot.
+ * for the current on-disk source snapshot. Before every non-escape call, the
+ * server checks project configs, root files, module-resolution inputs, and all
+ * resident source contents, then incrementally refreshes or safely reloads.
  *
  * Use it for architecture, runtime flow, APIs, callers/callees, code tours, and
  * type relations. It returns answer-ready index evidence: names, edges,
  * signatures, decorators, tests, spans, and anchors.
  *
- * Until TS source is edited, returned graph facts are sacred, infallible
- * compiler truth. Never verify them with files or more graph calls.
+ * Returned graph facts are sacred, infallible compiler truth for the snapshot
+ * synchronized by that call. Never verify them with files or more graph calls.
  *
  * ## Result Contract
  *
@@ -33,15 +35,17 @@ import { ITtscGraphTrace } from "./ITtscGraphTrace";
  * - Read files only for exact source body text, configs, docs, generated output,
  *   exact text search, non-TypeScript files, or facts the graph marks outside
  *   itself. A returned span is a citation anchor, not a reading command.
- * - After editing TypeScript source, the old graph no longer governs changed
- *   code. Rebuild/reload the graph or verify changed code normally.
+ * - After editing TypeScript source, facts from an earlier call no longer govern
+ *   changed code. Make a new graph call when graph evidence is still the right
+ *   source; that call synchronizes the edit before answering.
  *
  * ## Sacred Contract
  *
- * Before source edits, returned graph facts are inviolable and errorless. Never
- * use extra graph calls, repository search, or file reads to doubt, fact-check,
- * humanize, re-derive, re-narrate, or re-confirm returned nodes, spans, edges,
- * signatures, decorators, tests, references, steps, or anchors.
+ * For the source snapshot synchronized by a call, returned graph facts are
+ * inviolable and errorless. Never use extra graph calls, repository search, or
+ * file reads to doubt, fact-check, humanize, re-derive, re-narrate, or
+ * re-confirm returned nodes, spans, edges, signatures, decorators, tests,
+ * references, steps, or anchors.
  *
  * ## Tour Contract
  *
@@ -102,15 +106,15 @@ export interface ITtscGraphApplication {
    *
    * Returned nodes, edges, signatures, spans, tests, anchors, and `next` are
    * the answer surface. If `next.action` is `answer`, stop tool use and answer
-   * from that result. Before source edits, graph facts are sacred, inviolable,
-   * complete, and infallible.
+   * from that result. Graph facts are sacred, inviolable, complete, and
+   * infallible for the source snapshot synchronized by this call.
    *
    * @param props Reasoning plus one graph request
    * @returns Matching `result` union member
    */
   inspect_typescript_graph(
     props: ITtscGraphApplication.IProps,
-  ): ITtscGraphApplication.IResult;
+  ): Promise<ITtscGraphApplication.IResult>;
 }
 
 export namespace ITtscGraphApplication {

--- a/packages/graph/src/structures/ITtscGraphDump.ts
+++ b/packages/graph/src/structures/ITtscGraphDump.ts
@@ -7,9 +7,10 @@ import { ITtscGraphNode } from "./ITtscGraphNode";
  * wire contract between the Go fact-builder and the TypeScript graph engine.
  *
  * It is the complete graph with none of the per-response caps the MCP tools
- * apply: every node and edge the build resolved. The server parses it once at
- * startup (typia-validated) into an in-memory resident graph and answers every
- * tool call from that warm model; the bundled 3D viewer reduces the same dump.
+ * apply: every node and edge the build resolved. The server parses each changed
+ * native snapshot (typia-validated) into an in-memory resident graph and reuses
+ * that warm model while project inputs stay unchanged; the bundled 3D viewer
+ * reduces the same dump.
  *
  * Paths in `project` and `tsconfig` are absolute; `file` fields on nodes,
  * edges, and diagnostics are project-relative.

--- a/packages/ttsc/cmd/ttscgraph/main.go
+++ b/packages/ttsc/cmd/ttscgraph/main.go
@@ -1,9 +1,7 @@
-// Command ttscgraph builds the checker-resolved code graph for a project and
-// prints it as JSON (`ttscgraph dump`). It is the native data provider for
-// @ttsc/graph: the JavaScript launcher runs `ttscgraph dump` once, then serves
-// the Model Context Protocol from the in-memory graph itself. The MCP server,
-// its tools, and their schemas live in @ttsc/graph (TypeScript); nothing here
-// answers tool calls.
+// Command ttscgraph builds the checker-resolved code graph for a project. The
+// one-shot `dump` command prints JSON; the internal `serve` command keeps an
+// incremental compiler session resident for @ttsc/graph. MCP tools and schemas
+// remain in the TypeScript package.
 package main
 
 import (
@@ -35,9 +33,9 @@ func main() {
   os.Exit(run(os.Args[1:]))
 }
 
-// run dispatches the top-level command and returns an exit code. ttscgraph is
-// dump-only; anything that is not help/version/dump prints usage and exits 2,
-// since serving MCP is the launcher's job.
+// run dispatches the top-level command and returns an exit code. Anything that
+// is not help, version, dump, or the internal serve protocol prints usage and
+// exits 2; serving MCP itself remains the launcher's job.
 func run(args []string) int {
   if len(args) > 0 {
     switch args[0] {
@@ -49,6 +47,8 @@ func run(args []string) int {
       return 0
     case "dump":
       return runDump(args[1:])
+    case "serve":
+      return runServe(args[1:])
     }
   }
   printHelp(stderr)
@@ -72,12 +72,12 @@ func printHelp(w io.Writer) {
   fmt.Fprintln(w, strings.TrimSpace(`
 ttscgraph — checker-resolved code graph for ttsc.
 
-Builds the project's code graph and prints it as JSON. The @ttsc/graph launcher
-runs this and serves the Model Context Protocol from the result; the MCP tools
-live in @ttsc/graph, not here.
+Builds the project's code graph as JSON or keeps an incremental compiler session
+for the @ttsc/graph launcher. The MCP tools live in @ttsc/graph, not here.
 
 Usage:
   ttscgraph dump [--cwd <dir>] [--tsconfig <path>] [--pretty] > graph.json
+  ttscgraph serve [--cwd <dir>] [--tsconfig <path>]
   ttscgraph --version
   ttscgraph --help
 
@@ -87,5 +87,11 @@ Dump:
   --cwd <dir>          Project root (defaults to the process working directory).
   --tsconfig <path>    Project tsconfig path (default: tsconfig.json).
   --pretty             Indent the JSON output.
+
+Serve:
+  serve                Internal newline-delimited snapshot protocol used by
+                       @ttsc/graph. Keeps the compiler Program resident, applies
+                       source edits incrementally, and reloads on structural
+                       project changes.
 `))
 }

--- a/packages/ttsc/cmd/ttscgraph/run_help_version_and_bad_flags_exit_codes_test.go
+++ b/packages/ttsc/cmd/ttscgraph/run_help_version_and_bad_flags_exit_codes_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 // TestRunHelpVersionAndBadFlagsExitCodes verifies the top-level run dispatcher
-// returns the documented exit codes for the dump-only command surface: help and
-// version short-circuit to 0, an unknown command prints usage and exits 2, and a
-// dump that cannot resolve its working directory exits 2 with an explanation.
+// returns the documented exit codes for the command surface: help and version
+// short-circuit to 0, an unknown command prints usage and exits 2, and dump or
+// serve invocations that cannot parse flags or resolve their working directory
+// exit 2 with an explanation.
 //
 // These are the non-load paths a user hits with a typo or `--help`; each must
 // resolve to a code without building a Program. The getwd seam stands in for an
@@ -19,8 +20,8 @@ import (
 //
 //  1. run --help and run --version exit 0, printing the command name / version.
 //  2. run --bogus (unknown command) exits 2 and prints usage.
-//  3. run dump --nope exits 2 (dump flag parse failure).
-//  4. With getwd forced to fail, run dump exits 2 and explains why.
+//  3. run dump --nope and run serve --nope exit 2 (flag parse failure).
+//  4. With getwd forced to fail, run dump and run serve exit 2 and explain why.
 func TestRunHelpVersionAndBadFlagsExitCodes(t *testing.T) {
   oldStdout, oldStderr, oldGetwd := stdout, stderr, getwd
   defer func() { stdout, stderr, getwd = oldStdout, oldStderr, oldGetwd }()
@@ -62,6 +63,13 @@ func TestRunHelpVersionAndBadFlagsExitCodes(t *testing.T) {
     t.Fatalf("run dump --nope exit = %d, want 2", code)
   }
 
+  // An unknown serve flag is an invalid invocation: serve's flag.Parse fails -> 2.
+  var serveFlagErr bytes.Buffer
+  stderr = &serveFlagErr
+  if code := run([]string{"serve", "--nope"}); code != 2 {
+    t.Fatalf("run serve --nope exit = %d, want 2", code)
+  }
+
   // A getwd failure (no --cwd given) is an invalid invocation -> 2, explained.
   var wdErr bytes.Buffer
   stderr = &wdErr
@@ -71,5 +79,15 @@ func TestRunHelpVersionAndBadFlagsExitCodes(t *testing.T) {
   }
   if !strings.Contains(wdErr.String(), "could not resolve working directory") {
     t.Fatalf("getwd failure did not explain itself:\n%s", wdErr.String())
+  }
+
+  // serve resolves the working directory the same way before touching stdin.
+  var serveWdErr bytes.Buffer
+  stderr = &serveWdErr
+  if code := run([]string{"serve"}); code != 2 {
+    t.Fatalf("run serve with getwd failure exit = %d, want 2", code)
+  }
+  if !strings.Contains(serveWdErr.String(), "could not resolve working directory") {
+    t.Fatalf("serve getwd failure did not explain itself:\n%s", serveWdErr.String())
   }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve.go
+++ b/packages/ttsc/cmd/ttscgraph/serve.go
@@ -186,11 +186,29 @@ func (s *graphSession) captureState() error {
   if err != nil {
     return err
   }
+  inputs := auxiliaryInputs(program, configs, s.cwd)
+  inputs = append(inputs, missingRootInputs(configs, sourceHashes)...)
   s.configHashes = configHashes
-  s.auxStates = captureDiskStates(auxiliaryInputs(program, configs, s.cwd))
+  s.auxStates = captureDiskStates(compactSortedStrings(inputs))
   s.sourceHashes = sourceHashes
   s.rootFiles = projectRootFilesFromConfigs(configs, false)
   return nil
+}
+
+// missingRootInputs returns config root files absent from the loaded program.
+// A literal `files` entry keeps its name whether or not the file exists, so
+// neither the root-set comparison nor source hashing notices when such a root
+// is created later; tracking the missing path as a freshness input does.
+func missingRootInputs(configs []*shimtsoptions.ParsedCommandLine, sourceHashes map[string][sha256.Size]byte) []string {
+  missing := []string{}
+  for _, parsed := range configs {
+    for _, file := range parsed.FileNames() {
+      if _, tracked := sourceHashes[file]; !tracked {
+        missing = append(missing, file)
+      }
+    }
+  }
+  return missing
 }
 
 func (s *graphSession) buildDump() graph.Dump {
@@ -296,7 +314,22 @@ func invalidProjectError(diags []driver.Diagnostic) error {
 func hashProgramSources(program *driver.Program) (map[string][sha256.Size]byte, error) {
   hashes := make(map[string][sha256.Size]byte)
   for _, source := range program.TSProgram.SourceFiles() {
-    if !fileOnDisk(source) {
+    // Virtual sources (tsgo's `bundled:///` libs) have no on-disk identity;
+    // real project files always carry an absolute path.
+    if source == nil || !filepath.IsAbs(source.FileName()) {
+      continue
+    }
+    info, err := os.Stat(source.FileName())
+    if err != nil {
+      if errors.Is(err, os.ErrNotExist) {
+        // The file vanished while the compiler session was loading. Hash the
+        // resident text so the next snapshot revisits the path, observes the
+        // deletion, and reloads instead of serving the vanished file forever.
+        hashes[source.FileName()] = sha256.Sum256([]byte(source.Text()))
+      }
+      continue
+    }
+    if info.IsDir() {
       continue
     }
     content, err := os.ReadFile(source.FileName())
@@ -314,14 +347,6 @@ func hashProgramSources(program *driver.Program) (map[string][sha256.Size]byte, 
     }
   }
   return hashes, nil
-}
-
-func fileOnDisk(source *shimast.SourceFile) bool {
-  if source == nil || source.FileName() == "" {
-    return false
-  }
-  info, err := os.Stat(source.FileName())
-  return err == nil && !info.IsDir()
 }
 
 func hashFiles(paths []string) (map[string][sha256.Size]byte, error) {
@@ -446,6 +471,17 @@ func auxiliaryInputs(program *driver.Program, configs []*shimtsoptions.ParsedCom
         continue
       }
       inputs = append(inputs, unresolvedModuleCandidates(configs, directory, cwd, specifier.Text())...)
+    }
+  }
+  // Config `types` entries request type packages without any source syntax, so
+  // a missing one (e.g. a generated typeRoots package) must contribute the same
+  // candidates as a triple-slash type directive.
+  for _, parsed := range configs {
+    if parsed == nil || parsed.ParsedConfig == nil || parsed.ParsedConfig.CompilerOptions == nil {
+      continue
+    }
+    for _, name := range parsed.ParsedConfig.CompilerOptions.Types {
+      inputs = append(inputs, typeReferenceCandidates(configs, parsed.GetCurrentDirectory(), cwd, name)...)
     }
   }
   return compactSortedStrings(inputs)

--- a/packages/ttsc/cmd/ttscgraph/serve.go
+++ b/packages/ttsc/cmd/ttscgraph/serve.go
@@ -79,11 +79,7 @@ func (s *graphSession) Snapshot() (*graph.Dump, string, bool, error) {
     return &dump, "reload", true, nil
   }
 
-  auxChanged, err := diskStatesChanged(s.auxStates)
-  if err != nil {
-    return nil, "", false, err
-  }
-  if auxChanged {
+  if diskStatesChanged(s.auxStates) {
     if err := s.reload(); err != nil {
       return nil, "", false, err
     }
@@ -190,12 +186,8 @@ func (s *graphSession) captureState() error {
   if err != nil {
     return err
   }
-  auxStates, err := captureDiskStates(auxiliaryInputs(program, configs, s.cwd))
-  if err != nil {
-    return err
-  }
   s.configHashes = configHashes
-  s.auxStates = auxStates
+  s.auxStates = captureDiskStates(auxiliaryInputs(program, configs, s.cwd))
   s.sourceHashes = sourceHashes
   s.rootFiles = projectRootFilesFromConfigs(configs, false)
   return nil
@@ -387,42 +379,41 @@ type packageTarget struct {
   wildcard string
 }
 
-func captureDiskStates(paths []string) (map[string]diskState, error) {
+// captureDiskStates records the freshness state of speculative resolution
+// candidates. Most candidates do not exist, and a module specifier can name a
+// path the host OS cannot even parse (`./style.css?inline`, a `data:` URL on
+// Windows), so any path that is neither a readable file nor a directory is
+// recorded as absent instead of failing the snapshot: the recorded state only
+// needs to flip when the candidate becomes resolvable.
+func captureDiskStates(paths []string) map[string]diskState {
   states := make(map[string]diskState, len(paths))
   for _, path := range paths {
     content, err := os.ReadFile(path)
     if err != nil {
-      if errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrInvalid) {
-        states[path] = diskState{}
-        continue
-      }
-      info, statErr := os.Stat(path)
-      if statErr == nil && info.IsDir() {
+      if info, statErr := os.Stat(path); statErr == nil && info.IsDir() {
         states[path] = diskState{Exists: true}
-        continue
+      } else {
+        states[path] = diskState{}
       }
-      return nil, fmt.Errorf("ttscgraph: read snapshot input %s: %w", path, err)
+      continue
     }
     states[path] = diskState{Hash: sha256.Sum256(content), Exists: true}
   }
-  return states, nil
+  return states
 }
 
-func diskStatesChanged(previous map[string]diskState) (bool, error) {
+func diskStatesChanged(previous map[string]diskState) bool {
   paths := make([]string, 0, len(previous))
   for path := range previous {
     paths = append(paths, path)
   }
-  current, err := captureDiskStates(paths)
-  if err != nil {
-    return false, err
-  }
+  current := captureDiskStates(paths)
   for path, state := range previous {
     if current[path] != state {
-      return true, nil
+      return true
     }
   }
-  return false, nil
+  return false
 }
 
 func auxiliaryInputs(program *driver.Program, configs []*shimtsoptions.ParsedCommandLine, cwd string) []string {

--- a/packages/ttsc/cmd/ttscgraph/serve.go
+++ b/packages/ttsc/cmd/ttscgraph/serve.go
@@ -1,0 +1,836 @@
+package main
+
+import (
+  "bufio"
+  "crypto/sha256"
+  "encoding/json"
+  "errors"
+  "flag"
+  "fmt"
+  "io"
+  "os"
+  "path/filepath"
+  "slices"
+  "sort"
+  "strings"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimtsoptions "github.com/microsoft/typescript-go/shim/tsoptions"
+  shimtspath "github.com/microsoft/typescript-go/shim/tspath"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+  "github.com/samchon/ttsc/packages/ttsc/internal/graph"
+)
+
+type serveRequest struct {
+  ID int `json:"id"`
+}
+
+type serveResponse struct {
+  Dump    *graph.Dump `json:"dump,omitempty"`
+  Error   string      `json:"error,omitempty"`
+  ID      int         `json:"id"`
+  Mode    string      `json:"mode,omitempty"`
+  Changed bool        `json:"changed"`
+}
+
+type graphSession struct {
+  cwd          string
+  tsconfig     string
+  compiler     *driver.Session
+  configHashes map[string][sha256.Size]byte
+  auxStates    map[string]diskState
+  sourceHashes map[string][sha256.Size]byte
+  rootFiles    []string
+  initialized  bool
+}
+
+func newGraphSession(cwd, tsconfig string) (*graphSession, error) {
+  session := &graphSession{cwd: cwd, tsconfig: tsconfig}
+  if err := session.reload(); err != nil {
+    return nil, err
+  }
+  return session, nil
+}
+
+func (s *graphSession) Close() error {
+  if s.compiler == nil {
+    return nil
+  }
+  return s.compiler.Close()
+}
+
+func (s *graphSession) Snapshot() (*graph.Dump, string, bool, error) {
+  if !s.initialized {
+    dump := s.buildDump()
+    s.initialized = true
+    return &dump, "initial", true, nil
+  }
+
+  configChanged, err := hashesChanged(s.configHashes)
+  if err != nil {
+    return nil, "", false, err
+  }
+  if configChanged {
+    if err := s.reload(); err != nil {
+      return nil, "", false, err
+    }
+    dump := s.buildDump()
+    return &dump, "reload", true, nil
+  }
+
+  auxChanged, err := diskStatesChanged(s.auxStates)
+  if err != nil {
+    return nil, "", false, err
+  }
+  if auxChanged {
+    if err := s.reload(); err != nil {
+      return nil, "", false, err
+    }
+    dump := s.buildDump()
+    return &dump, "reload", true, nil
+  }
+
+  roots, err := projectRootFiles(s.compiler.Program(), true)
+  if err != nil {
+    return nil, "", false, err
+  }
+  if !slices.Equal(s.rootFiles, roots) {
+    if err := s.reload(); err != nil {
+      return nil, "", false, err
+    }
+    dump := s.buildDump()
+    return &dump, "reload", true, nil
+  }
+
+  changed, deleted, err := changedSources(s.sourceHashes)
+  if err != nil {
+    return nil, "", false, err
+  }
+  if deleted {
+    if err := s.reload(); err != nil {
+      return nil, "", false, err
+    }
+    dump := s.buildDump()
+    return &dump, "reload", true, nil
+  }
+  if len(changed) == 0 {
+    return nil, "unchanged", false, nil
+  }
+  if s.compiler.Program().HasLinkedProgramPlugins() {
+    if err := s.reload(); err != nil {
+      return nil, "", false, err
+    }
+    dump := s.buildDump()
+    return &dump, "reload", true, nil
+  }
+
+  mode := "incremental"
+  paths := make([]string, 0, len(changed))
+  for path := range changed {
+    paths = append(paths, path)
+  }
+  sort.Strings(paths)
+  for _, path := range paths {
+    if reused := s.compiler.Apply(path, changed[path]); !reused {
+      mode = "rebuild"
+    }
+    current, exists := s.compiler.SourceText(path)
+    expected := driver.ApplySourcePreambleToFile(path, changed[path], s.compiler.Program().SourcePreamble)
+    if !exists || current != expected {
+      if err := s.reload(); err != nil {
+        return nil, "", false, err
+      }
+      dump := s.buildDump()
+      return &dump, "reload", true, nil
+    }
+  }
+  if err := s.captureState(); err != nil {
+    return nil, "", false, err
+  }
+  dump := s.buildDump()
+  return &dump, mode, true, nil
+}
+
+func (s *graphSession) reload() error {
+  next, diags, err := driver.NewSession(s.cwd, s.tsconfig, driver.LoadProgramOptions{})
+  if err != nil {
+    return err
+  }
+  if next == nil {
+    if len(diags) == 0 {
+      return errors.New("ttscgraph: compiler session was not created")
+    }
+    return invalidProjectError(diags)
+  }
+  previous := s.compiler
+  s.compiler = next
+  if err := s.captureState(); err != nil {
+    _ = next.Close()
+    s.compiler = previous
+    return err
+  }
+  if previous != nil {
+    _ = previous.Close()
+  }
+  return nil
+}
+
+func (s *graphSession) captureState() error {
+  program := s.compiler.Program()
+  configs, err := parsedConfigs(program)
+  if err != nil {
+    return err
+  }
+  configHashes, err := hashFiles(configFiles(configs))
+  if err != nil {
+    return err
+  }
+  sourceHashes, err := hashProgramSources(program)
+  if err != nil {
+    return err
+  }
+  auxStates, err := captureDiskStates(auxiliaryInputs(program, configs, s.cwd))
+  if err != nil {
+    return err
+  }
+  s.configHashes = configHashes
+  s.auxStates = auxStates
+  s.sourceHashes = sourceHashes
+  s.rootFiles = projectRootFilesFromConfigs(configs, false)
+  return nil
+}
+
+func (s *graphSession) buildDump() graph.Dump {
+  program := s.compiler.Program()
+  built := graph.Build(program)
+  return graph.NewDump(
+    built,
+    s.cwd,
+    s.tsconfig,
+    graph.GitIgnoredFiles(s.cwd, built),
+    graph.SourceTexts(program),
+  )
+}
+
+func configFiles(configs []*shimtsoptions.ParsedCommandLine) []string {
+  files := []string{}
+  for _, parsed := range configs {
+    files = append(files, parsed.ConfigName())
+    files = append(files, parsed.ExtendedSourceFiles()...)
+  }
+  return compactSortedStrings(files)
+}
+
+func projectRootFiles(program *driver.Program, reload bool) ([]string, error) {
+  configs, err := parsedConfigs(program)
+  if err != nil {
+    return nil, err
+  }
+  return projectRootFilesFromConfigs(configs, reload), nil
+}
+
+func projectRootFilesFromConfigs(configs []*shimtsoptions.ParsedCommandLine, reload bool) []string {
+  roots := []string{}
+  for _, parsed := range configs {
+    current := parsed
+    if reload {
+      current = parsed.ReloadFileNamesOfParsedCommandLine(driver.DefaultFS())
+    }
+    config := current.ConfigName()
+    for _, file := range current.FileNames() {
+      roots = append(roots, config+"\x00"+file)
+    }
+  }
+  return compactSortedStrings(roots)
+}
+
+func parsedConfigs(program *driver.Program) ([]*shimtsoptions.ParsedCommandLine, error) {
+  if program == nil || program.ParsedConfig == nil {
+    return nil, errors.New("ttscgraph: compiler program omitted its parsed config")
+  }
+  resolved := make(map[string]*shimtsoptions.ParsedCommandLine)
+  for _, parsed := range program.TSProgram.GetResolvedProjectReferences() {
+    if parsed != nil {
+      resolved[shimtspath.ResolvePath(parsed.ConfigName())] = parsed
+    }
+  }
+  configs := []*shimtsoptions.ParsedCommandLine{}
+  pending := []*shimtsoptions.ParsedCommandLine{program.ParsedConfig}
+  seen := make(map[string]struct{})
+  for len(pending) > 0 {
+    parsed := pending[0]
+    pending = pending[1:]
+    config := shimtspath.ResolvePath(parsed.ConfigName())
+    if _, exists := seen[config]; exists {
+      continue
+    }
+    seen[config] = struct{}{}
+    configs = append(configs, parsed)
+    for _, reference := range parsed.ResolvedProjectReferencePaths() {
+      reference = shimtspath.ResolvePath(reference)
+      child := resolved[reference]
+      if child == nil {
+        fs := program.FS
+        cwd := filepath.Dir(reference)
+        var diags []driver.Diagnostic
+        var err error
+        child, diags, err = driver.ParseTSConfig(fs, cwd, reference, driver.DefaultHost(cwd, fs), nil)
+        if err != nil {
+          return nil, err
+        }
+        if child == nil {
+          if len(diags) == 0 {
+            return nil, fmt.Errorf("ttscgraph: project reference was not parsed: %s", reference)
+          }
+          return nil, invalidProjectError(diags)
+        }
+        resolved[reference] = child
+      }
+      pending = append(pending, child)
+    }
+  }
+  return configs, nil
+}
+
+func invalidProjectError(diags []driver.Diagnostic) error {
+  messages := make([]string, len(diags))
+  for i, diag := range diags {
+    messages[i] = diag.String()
+  }
+  return fmt.Errorf("ttscgraph: invalid project: %s", strings.Join(messages, "; "))
+}
+
+func hashProgramSources(program *driver.Program) (map[string][sha256.Size]byte, error) {
+  hashes := make(map[string][sha256.Size]byte)
+  for _, source := range program.TSProgram.SourceFiles() {
+    if !fileOnDisk(source) {
+      continue
+    }
+    content, err := os.ReadFile(source.FileName())
+    if err != nil {
+      return nil, fmt.Errorf("ttscgraph: read %s: %w", source.FileName(), err)
+    }
+    rawHash := sha256.Sum256(content)
+    expected := driver.ApplySourcePreambleToFile(source.FileName(), string(content), program.SourcePreamble)
+    if source.Text() == expected {
+      hashes[source.FileName()] = rawHash
+    } else {
+      // Force the next snapshot to revisit a file that changed while the
+      // compiler session was loading instead of blessing mismatched disk text.
+      hashes[source.FileName()] = sha256.Sum256([]byte(source.Text()))
+    }
+  }
+  return hashes, nil
+}
+
+func fileOnDisk(source *shimast.SourceFile) bool {
+  if source == nil || source.FileName() == "" {
+    return false
+  }
+  info, err := os.Stat(source.FileName())
+  return err == nil && !info.IsDir()
+}
+
+func hashFiles(paths []string) (map[string][sha256.Size]byte, error) {
+  hashes := make(map[string][sha256.Size]byte, len(paths))
+  for _, path := range paths {
+    content, err := os.ReadFile(path)
+    if err != nil {
+      return nil, fmt.Errorf("ttscgraph: read %s: %w", path, err)
+    }
+    hashes[path] = sha256.Sum256(content)
+  }
+  return hashes, nil
+}
+
+func hashesChanged(previous map[string][sha256.Size]byte) (bool, error) {
+  for path, oldHash := range previous {
+    content, err := os.ReadFile(path)
+    if err != nil {
+      if errors.Is(err, os.ErrNotExist) {
+        return true, nil
+      }
+      return false, fmt.Errorf("ttscgraph: read %s: %w", path, err)
+    }
+    if sha256.Sum256(content) != oldHash {
+      return true, nil
+    }
+  }
+  return false, nil
+}
+
+func changedSources(previous map[string][sha256.Size]byte) (map[string]string, bool, error) {
+  changed := map[string]string{}
+  for path, oldHash := range previous {
+    content, err := os.ReadFile(path)
+    if err != nil {
+      if errors.Is(err, os.ErrNotExist) {
+        return nil, true, nil
+      }
+      return nil, false, fmt.Errorf("ttscgraph: read %s: %w", path, err)
+    }
+    if sha256.Sum256(content) != oldHash {
+      changed[path] = string(content)
+    }
+  }
+  return changed, false, nil
+}
+
+type diskState struct {
+  Hash   [sha256.Size]byte
+  Exists bool
+}
+
+type packageTarget struct {
+  path     string
+  wildcard string
+}
+
+func captureDiskStates(paths []string) (map[string]diskState, error) {
+  states := make(map[string]diskState, len(paths))
+  for _, path := range paths {
+    content, err := os.ReadFile(path)
+    if err != nil {
+      if errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrInvalid) {
+        states[path] = diskState{}
+        continue
+      }
+      info, statErr := os.Stat(path)
+      if statErr == nil && info.IsDir() {
+        states[path] = diskState{Exists: true}
+        continue
+      }
+      return nil, fmt.Errorf("ttscgraph: read snapshot input %s: %w", path, err)
+    }
+    states[path] = diskState{Hash: sha256.Sum256(content), Exists: true}
+  }
+  return states, nil
+}
+
+func diskStatesChanged(previous map[string]diskState) (bool, error) {
+  paths := make([]string, 0, len(previous))
+  for path := range previous {
+    paths = append(paths, path)
+  }
+  current, err := captureDiskStates(paths)
+  if err != nil {
+    return false, err
+  }
+  for path, state := range previous {
+    if current[path] != state {
+      return true, nil
+    }
+  }
+  return false, nil
+}
+
+func auxiliaryInputs(program *driver.Program, configs []*shimtsoptions.ParsedCommandLine, cwd string) []string {
+  inputs := []string{
+    filepath.Join(cwd, ".gitignore"),
+    filepath.Join(cwd, ".git", "info", "exclude"),
+    filepath.Join(cwd, "package.json"),
+    filepath.Join(cwd, "package-lock.json"),
+    filepath.Join(cwd, "pnpm-lock.yaml"),
+    filepath.Join(cwd, "yarn.lock"),
+    filepath.Join(cwd, "bun.lock"),
+    filepath.Join(cwd, "bun.lockb"),
+  }
+  for _, source := range program.TSProgram.SourceFiles() {
+    file := source.FileName()
+    if file == "" || strings.HasPrefix(file, "bundled:///") {
+      continue
+    }
+    directory := filepath.Dir(file)
+    inputs = appendAncestorInputs(inputs, directory, cwd)
+    for _, reference := range source.ReferencedFiles {
+      inputs = append(inputs, fileCandidates(filepath.Join(directory, filepath.FromSlash(reference.FileName)))...)
+    }
+    for _, reference := range source.TypeReferenceDirectives {
+      inputs = append(inputs, typeReferenceCandidates(configs, directory, cwd, reference.FileName)...)
+    }
+    for _, specifier := range sourceModuleSpecifiers(source) {
+      resolved := program.TSProgram.GetResolvedModuleFromModuleSpecifier(source, specifier)
+      if resolved != nil && resolved.IsResolved() {
+        continue
+      }
+      inputs = append(inputs, unresolvedModuleCandidates(configs, directory, cwd, specifier.Text())...)
+    }
+  }
+  return compactSortedStrings(inputs)
+}
+
+func typeReferenceCandidates(configs []*shimtsoptions.ParsedCommandLine, directory, cwd, name string) []string {
+  candidates := []string{}
+  for _, parsed := range configs {
+    if parsed == nil || parsed.ParsedConfig == nil || parsed.ParsedConfig.CompilerOptions == nil {
+      continue
+    }
+    for _, root := range parsed.ParsedConfig.CompilerOptions.TypeRoots {
+      candidates = append(candidates, fileCandidates(filepath.Join(root, filepath.FromSlash(name)))...)
+    }
+  }
+  for current := filepath.Clean(directory); ; current = filepath.Dir(current) {
+    candidates = append(candidates, fileCandidates(filepath.Join(current, "node_modules", "@types", filepath.FromSlash(name)))...)
+    if current == filepath.Clean(cwd) || filepath.Dir(current) == current {
+      return candidates
+    }
+  }
+}
+
+func sourceModuleSpecifiers(source *shimast.SourceFile) []*shimast.Node {
+  if source == nil {
+    return nil
+  }
+  specifiers := []*shimast.Node{}
+  var walk func(*shimast.Node) bool
+  walk = func(node *shimast.Node) bool {
+    if node == nil {
+      return false
+    }
+    var specifier *shimast.Node
+    switch node.Kind {
+    case shimast.KindImportDeclaration, shimast.KindJSImportDeclaration:
+      specifier = node.AsImportDeclaration().ModuleSpecifier
+    case shimast.KindExportDeclaration:
+      specifier = node.AsExportDeclaration().ModuleSpecifier
+    case shimast.KindImportEqualsDeclaration:
+      reference := node.AsImportEqualsDeclaration().ModuleReference
+      if reference != nil && reference.Kind == shimast.KindExternalModuleReference {
+        specifier = reference.AsExternalModuleReference().Expression
+      }
+    case shimast.KindImportType:
+      argument := node.AsImportTypeNode().Argument
+      if argument != nil && argument.Kind == shimast.KindLiteralType {
+        specifier = argument.AsLiteralTypeNode().Literal
+      }
+    case shimast.KindCallExpression:
+      call := node.AsCallExpression()
+      if isModuleSpecifierCall(call) && call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+        specifier = call.Arguments.Nodes[0]
+      }
+    }
+    if specifier != nil && (specifier.Kind == shimast.KindStringLiteral || specifier.Kind == shimast.KindNoSubstitutionTemplateLiteral) {
+      specifiers = append(specifiers, specifier)
+    }
+    node.ForEachChild(walk)
+    return false
+  }
+  walk(source.AsNode())
+  return specifiers
+}
+
+func isModuleSpecifierCall(call *shimast.CallExpression) bool {
+  if call == nil || call.Expression == nil {
+    return false
+  }
+  if call.Expression.Kind == shimast.KindImportKeyword {
+    return true
+  }
+  return call.Expression.Kind == shimast.KindIdentifier && call.Expression.Text() == "require"
+}
+
+func appendAncestorInputs(inputs []string, directory, stop string) []string {
+  stop = filepath.Clean(stop)
+  for current := filepath.Clean(directory); ; current = filepath.Dir(current) {
+    inputs = append(inputs, filepath.Join(current, "package.json"), filepath.Join(current, ".gitignore"))
+    if current == stop || filepath.Dir(current) == current {
+      return inputs
+    }
+  }
+}
+
+func unresolvedModuleCandidates(configs []*shimtsoptions.ParsedCommandLine, directory, cwd, specifier string) []string {
+  if specifier == "" {
+    return nil
+  }
+  if strings.HasPrefix(specifier, ".") {
+    candidates := fileCandidates(filepath.Clean(filepath.Join(directory, filepath.FromSlash(specifier))))
+    return append(candidates, rootDirsCandidates(configs, directory, specifier)...)
+  }
+  candidates := compilerOptionCandidates(configs, specifier)
+  if strings.HasPrefix(specifier, "#") {
+    for current := filepath.Clean(directory); ; current = filepath.Dir(current) {
+      candidates = append(candidates, packageManifestCandidates(current, specifier)...)
+      if current == filepath.Clean(cwd) || filepath.Dir(current) == current {
+        return candidates
+      }
+    }
+  }
+  for current := filepath.Clean(directory); ; current = filepath.Dir(current) {
+    base := filepath.Join(current, "node_modules", filepath.FromSlash(specifier))
+    root := packageRoot(base, specifier)
+    candidates = append(candidates, fileCandidates(base)...)
+    candidates = append(candidates, filepath.Join(root, "package.json"))
+    candidates = append(candidates, packageManifestCandidates(root, packageSubpath(specifier))...)
+    if current == filepath.Clean(cwd) || filepath.Dir(current) == current {
+      break
+    }
+  }
+  return candidates
+}
+
+func packageManifestCandidates(root, wildcard string) []string {
+  content, err := os.ReadFile(filepath.Join(root, "package.json"))
+  if err != nil {
+    return nil
+  }
+  var manifest struct {
+    Main          string `json:"main"`
+    Module        string `json:"module"`
+    Types         string `json:"types"`
+    Typings       string `json:"typings"`
+    Exports       any    `json:"exports"`
+    Imports       any    `json:"imports"`
+    TypesVersions any    `json:"typesVersions"`
+  }
+  if json.Unmarshal(content, &manifest) != nil {
+    return nil
+  }
+  defaultWildcard := strings.TrimPrefix(strings.TrimPrefix(wildcard, "./"), "#")
+  targets := []packageTarget{
+    {path: manifest.Main, wildcard: defaultWildcard},
+    {path: manifest.Module, wildcard: defaultWildcard},
+    {path: manifest.Types, wildcard: defaultWildcard},
+    {path: manifest.Typings, wildcard: defaultWildcard},
+  }
+  exportRequest := "."
+  if wildcard != "" && !strings.HasPrefix(wildcard, "#") {
+    exportRequest = "./" + strings.TrimPrefix(wildcard, "./")
+  }
+  collectPackageMappingTargets(manifest.Exports, exportRequest, defaultWildcard, &targets)
+  collectPackageMappingTargets(manifest.Imports, wildcard, defaultWildcard, &targets)
+  collectPackageTargets(manifest.TypesVersions, defaultWildcard, &targets)
+  candidates := []string{}
+  for _, target := range targets {
+    if target.path == "" || filepath.IsAbs(target.path) || strings.Contains(target.path, "://") {
+      continue
+    }
+    path := strings.Replace(target.path, "*", target.wildcard, 1)
+    candidates = append(candidates, fileCandidates(filepath.Join(root, filepath.FromSlash(path)))...)
+  }
+  return candidates
+}
+
+func collectPackageMappingTargets(value any, request, wildcard string, targets *[]packageTarget) {
+  if object, ok := value.(map[string]any); ok {
+    mapping := false
+    for key := range object {
+      if strings.HasPrefix(key, ".") || strings.HasPrefix(key, "#") {
+        mapping = true
+        break
+      }
+    }
+    if mapping {
+      for pattern, child := range object {
+        matched, ok := matchPathPattern(pattern, request)
+        if ok {
+          collectPackageTargets(child, matched, targets)
+        }
+      }
+      return
+    }
+  }
+  collectPackageTargets(value, wildcard, targets)
+}
+
+func collectPackageTargets(value any, wildcard string, targets *[]packageTarget) {
+  switch value := value.(type) {
+  case string:
+    *targets = append(*targets, packageTarget{path: value, wildcard: wildcard})
+  case []any:
+    for _, child := range value {
+      collectPackageTargets(child, wildcard, targets)
+    }
+  case map[string]any:
+    for _, child := range value {
+      collectPackageTargets(child, wildcard, targets)
+    }
+  }
+}
+
+func packageSubpath(specifier string) string {
+  parts := strings.Split(filepath.ToSlash(specifier), "/")
+  count := 1
+  if strings.HasPrefix(specifier, "@") && len(parts) > 1 {
+    count = 2
+  }
+  if len(parts) <= count {
+    return ""
+  }
+  return strings.Join(parts[count:], "/")
+}
+
+func compilerOptionCandidates(configs []*shimtsoptions.ParsedCommandLine, specifier string) []string {
+  candidates := []string{}
+  for _, parsed := range configs {
+    if parsed == nil || parsed.ParsedConfig == nil || parsed.ParsedConfig.CompilerOptions == nil {
+      continue
+    }
+    options := parsed.ParsedConfig.CompilerOptions
+    if options.BaseUrl != "" {
+      candidates = append(candidates, fileCandidates(filepath.Join(options.BaseUrl, filepath.FromSlash(specifier)))...)
+    }
+    if options.Paths == nil {
+      continue
+    }
+    base := options.GetPathsBasePath(parsed.GetCurrentDirectory())
+    for pattern, targets := range options.Paths.Entries() {
+      matched, ok := matchPathPattern(pattern, specifier)
+      if !ok {
+        continue
+      }
+      for _, target := range targets {
+        target = strings.Replace(target, "*", matched, 1)
+        candidates = append(candidates, fileCandidates(filepath.Join(base, filepath.FromSlash(target)))...)
+      }
+    }
+  }
+  return candidates
+}
+
+func rootDirsCandidates(configs []*shimtsoptions.ParsedCommandLine, directory, specifier string) []string {
+  candidates := []string{}
+  for _, parsed := range configs {
+    if parsed == nil || parsed.ParsedConfig == nil || parsed.ParsedConfig.CompilerOptions == nil {
+      continue
+    }
+    roots := parsed.ParsedConfig.CompilerOptions.RootDirs
+    for _, sourceRoot := range roots {
+      relative, err := filepath.Rel(sourceRoot, directory)
+      if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+        continue
+      }
+      suffix := filepath.Join(relative, filepath.FromSlash(specifier))
+      for _, targetRoot := range roots {
+        candidates = append(candidates, fileCandidates(filepath.Join(targetRoot, suffix))...)
+      }
+    }
+  }
+  return candidates
+}
+
+func matchPathPattern(pattern, specifier string) (string, bool) {
+  star := strings.IndexByte(pattern, '*')
+  if star < 0 {
+    return "", pattern == specifier
+  }
+  prefix := pattern[:star]
+  suffix := pattern[star+1:]
+  if len(specifier) < len(prefix)+len(suffix) || !strings.HasPrefix(specifier, prefix) || !strings.HasSuffix(specifier, suffix) {
+    return "", false
+  }
+  return specifier[len(prefix) : len(specifier)-len(suffix)], true
+}
+
+func packageRoot(base, specifier string) string {
+  parts := strings.Split(filepath.ToSlash(specifier), "/")
+  count := 1
+  if strings.HasPrefix(specifier, "@") && len(parts) > 1 {
+    count = 2
+  }
+  suffixCount := len(parts) - count
+  root := base
+  for range suffixCount {
+    root = filepath.Dir(root)
+  }
+  return root
+}
+
+func fileCandidates(base string) []string {
+  candidates := []string{base}
+  extension := strings.ToLower(filepath.Ext(base))
+  if extension == ".js" || extension == ".jsx" || extension == ".mjs" || extension == ".cjs" {
+    base = strings.TrimSuffix(base, filepath.Ext(base))
+  }
+  for _, suffix := range []string{".ts", ".tsx", ".mts", ".cts", ".d.ts", ".d.mts", ".d.cts", ".js", ".jsx", ".mjs", ".cjs", ".json"} {
+    candidates = append(candidates, base+suffix, filepath.Join(base, "index"+suffix))
+  }
+  candidates = append(candidates, filepath.Join(base, "package.json"))
+  return candidates
+}
+
+func compactSortedStrings(input []string) []string {
+  out := make([]string, 0, len(input))
+  for _, value := range input {
+    if strings.TrimSpace(value) != "" {
+      out = append(out, value)
+    }
+  }
+  sort.Strings(out)
+  return slices.Compact(out)
+}
+
+func runServe(args []string) int {
+  fs := flag.NewFlagSet("ttscgraph serve", flag.ContinueOnError)
+  fs.SetOutput(stderr)
+  cwdFlag := fs.String("cwd", "", "project root (defaults to process cwd)")
+  tsconfigFlag := fs.String("tsconfig", "tsconfig.json", "project tsconfig path")
+  if err := fs.Parse(args); err != nil {
+    return 2
+  }
+
+  cwd := strings.TrimSpace(*cwdFlag)
+  if cwd == "" {
+    resolved, err := getwd()
+    if err != nil {
+      fmt.Fprintf(stderr, "ttscgraph: could not resolve working directory: %v\n", err)
+      return 2
+    }
+    cwd = resolved
+  }
+  if abs, err := filepath.Abs(cwd); err == nil {
+    cwd = abs
+  }
+  cwd = shimtspath.ResolvePath(cwd)
+  tsconfig := strings.TrimSpace(*tsconfigFlag)
+
+  return serveSnapshots(os.Stdin, stdout, cwd, tsconfig)
+}
+
+func serveSnapshots(input io.Reader, output io.Writer, cwd, tsconfig string) int {
+  scanner := bufio.NewScanner(input)
+  scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+  encoder := json.NewEncoder(output)
+  var session *graphSession
+  defer func() {
+    if session != nil {
+      _ = session.Close()
+    }
+  }()
+
+  for scanner.Scan() {
+    line := strings.TrimSpace(scanner.Text())
+    if line == "" {
+      continue
+    }
+    var request serveRequest
+    if err := json.Unmarshal([]byte(line), &request); err != nil {
+      _ = encoder.Encode(serveResponse{Error: fmt.Sprintf("invalid request: %v", err)})
+      continue
+    }
+    if session == nil {
+      created, err := newGraphSession(cwd, tsconfig)
+      if err != nil {
+        _ = encoder.Encode(serveResponse{ID: request.ID, Error: err.Error()})
+        continue
+      }
+      session = created
+    }
+    dump, mode, changed, err := session.Snapshot()
+    response := serveResponse{ID: request.ID, Dump: dump, Mode: mode, Changed: changed}
+    if err != nil {
+      response.Error = err.Error()
+      response.Dump = nil
+    }
+    if err := encoder.Encode(response); err != nil {
+      fmt.Fprintf(stderr, "ttscgraph: write serve response: %v\n", err)
+      return 1
+    }
+  }
+  if err := scanner.Err(); err != nil {
+    fmt.Fprintf(stderr, "ttscgraph: read serve request: %v\n", err)
+    return 1
+  }
+  return 0
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_protocol_rejects_invalid_request_line_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_protocol_rejects_invalid_request_line_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+  "bytes"
+  "encoding/json"
+  "strings"
+  "testing"
+)
+
+// TestServeProtocolRejectsInvalidRequestLine verifies a malformed NDJSON line
+// answers with a protocol error and never poisons the following requests.
+//
+// The launcher only ever writes well-formed requests, so a garbage line means
+// a corrupted pipe or a foreign writer; the server must report it (with the
+// zero ID, since none could be parsed) and keep serving instead of exiting.
+//
+//  1. Send a non-JSON line followed by a valid request.
+//  2. Assert the first response carries an error and no dump.
+//  3. Assert the second response is the normal initial snapshot.
+func TestServeProtocolRejectsInvalidRequestLine(t *testing.T) {
+  root := graphSessionFixture(t)
+  input := strings.NewReader("not-json\n{\"id\":1}\n")
+  var output bytes.Buffer
+
+  if code := serveSnapshots(input, &output, root, "tsconfig.json"); code != 0 {
+    t.Fatalf("serveSnapshots exited %d", code)
+  }
+  decoder := json.NewDecoder(&output)
+  var invalid serveResponse
+  var initial serveResponse
+  if err := decoder.Decode(&invalid); err != nil {
+    t.Fatal(err)
+  }
+  if err := decoder.Decode(&initial); err != nil {
+    t.Fatal(err)
+  }
+  if invalid.ID != 0 || invalid.Error == "" || !strings.Contains(invalid.Error, "invalid request") || invalid.Dump != nil || invalid.Changed {
+    t.Fatalf("invalid line response: %#v", invalid)
+  }
+  if initial.ID != 1 || initial.Mode != "initial" || !initial.Changed || initial.Dump == nil || initial.Error != "" {
+    t.Fatalf("follow-up response: %#v", initial)
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_protocol_retries_session_creation_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_protocol_retries_session_creation_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+  "bytes"
+  "encoding/json"
+  "io"
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// stepReader hands the scanner one scripted chunk per Read call, running each
+// step's side effect at the moment the server asks for more input — after the
+// previous request has been fully answered.
+type stepReader struct {
+  steps []func() []byte
+  buf   []byte
+}
+
+func (r *stepReader) Read(p []byte) (int, error) {
+  if len(r.buf) == 0 {
+    if len(r.steps) == 0 {
+      return 0, io.EOF
+    }
+    r.buf = r.steps[0]()
+    r.steps = r.steps[1:]
+  }
+  n := copy(p, r.buf)
+  r.buf = r.buf[n:]
+  return n, nil
+}
+
+// TestServeProtocolRetriesSessionCreation verifies a project that is invalid
+// at startup answers with an error and recovers on a later request.
+//
+// The MCP server starts the native process lazily, so the first request may
+// hit a broken tsconfig. Failing session creation must stay per-request: the
+// server keeps running, and once the config is fixed the same process builds
+// the session and serves the initial dump.
+//
+//  1. Request a snapshot while tsconfig.json is invalid; assert an error.
+//  2. Fix the config between requests, request again.
+//  3. Assert the second response is a normal initial snapshot.
+func TestServeProtocolRetriesSessionCreation(t *testing.T) {
+  root := t.TempDir()
+  config := filepath.Join(root, "tsconfig.json")
+  writeGraphFile(t, config, "{ invalid")
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export class Recovered {}\n")
+
+  valid := `{"compilerOptions":{"target":"ES2022","module":"commonjs","strict":true},"include":["src"]}`
+  input := &stepReader{steps: []func() []byte{
+    func() []byte { return []byte("{\"id\":1}\n") },
+    func() []byte {
+      if err := os.WriteFile(config, []byte(valid), 0o644); err != nil {
+        t.Fatal(err)
+      }
+      return []byte("{\"id\":2}\n")
+    },
+  }}
+  var output bytes.Buffer
+
+  if code := serveSnapshots(input, &output, root, "tsconfig.json"); code != 0 {
+    t.Fatalf("serveSnapshots exited %d", code)
+  }
+  decoder := json.NewDecoder(&output)
+  var failed serveResponse
+  var recovered serveResponse
+  if err := decoder.Decode(&failed); err != nil {
+    t.Fatal(err)
+  }
+  if err := decoder.Decode(&recovered); err != nil {
+    t.Fatal(err)
+  }
+  if failed.ID != 1 || failed.Error == "" || failed.Dump != nil || failed.Changed {
+    t.Fatalf("invalid project response: %#v", failed)
+  }
+  if recovered.ID != 2 || recovered.Mode != "initial" || !recovered.Changed || recovered.Dump == nil || recovered.Error != "" {
+    t.Fatalf("recovered response: %#v", recovered)
+  }
+  if !hasDumpNode(*recovered.Dump, "Recovered") {
+    t.Fatalf("recovered dump omitted the declaration: %#v", recovered.Dump.Nodes)
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_protocol_reuses_session_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_protocol_reuses_session_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+  "bytes"
+  "encoding/json"
+  "strings"
+  "testing"
+)
+
+// TestServeProtocolReusesSession verifies multiple NDJSON requests share one
+// compiler session and unchanged responses omit the full dump.
+func TestServeProtocolReusesSession(t *testing.T) {
+  root := graphSessionFixture(t)
+  input := strings.NewReader("{\"id\":1}\n{\"id\":2}\n")
+  var output bytes.Buffer
+
+  if code := serveSnapshots(input, &output, root, "tsconfig.json"); code != 0 {
+    t.Fatalf("serveSnapshots exited %d", code)
+  }
+  decoder := json.NewDecoder(&output)
+  var initial serveResponse
+  var unchanged serveResponse
+  if err := decoder.Decode(&initial); err != nil {
+    t.Fatal(err)
+  }
+  if err := decoder.Decode(&unchanged); err != nil {
+    t.Fatal(err)
+  }
+  if initial.ID != 1 || initial.Mode != "initial" || !initial.Changed || initial.Dump == nil {
+    t.Fatalf("initial response: %#v", initial)
+  }
+  if unchanged.ID != 2 || unchanged.Mode != "unchanged" || unchanged.Changed || unchanged.Dump != nil {
+    t.Fatalf("unchanged response: %#v", unchanged)
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_applies_source_edit_incrementally_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_applies_source_edit_incrementally_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/samchon/ttsc/packages/ttsc/internal/graph"
+)
+
+// TestServeSessionAppliesSourceEditIncrementally verifies a content-only source
+// edit updates the graph through the resident tsgo Program.
+//
+// A declaration rename changes graph nodes but not imports, so UpdateProgram can
+// reuse every unchanged AST. The new dump must expose the replacement symbol
+// and remove the old one without reopening the project.
+//
+// 1. Build the initial graph containing `BeforeEdit`.
+// 2. Replace it with `AfterEdit` in the same source file.
+// 3. Assert incremental mode and an exact post-edit node set.
+func TestServeSessionAppliesSourceEditIncrementally(t *testing.T) {
+	root := graphSessionFixture(t)
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	if _, _, _, err := session.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	file := filepath.Join(root, "src", "index.ts")
+	if err := os.WriteFile(file, []byte("export class AfterEdit {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "incremental" || !changed {
+		t.Fatalf("edited snapshot = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+	}
+	if !hasDumpNode(*dump, "AfterEdit") || hasDumpNode(*dump, "BeforeEdit") {
+		t.Fatalf("incremental dump kept stale nodes: %#v", dump.Nodes)
+	}
+}
+
+func hasDumpNode(dump graph.Dump, name string) bool {
+	for _, node := range dump.Nodes {
+		if node.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_applies_source_edit_incrementally_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_applies_source_edit_incrementally_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 
-	"github.com/samchon/ttsc/packages/ttsc/internal/graph"
+  "github.com/samchon/ttsc/packages/ttsc/internal/graph"
 )
 
 // TestServeSessionAppliesSourceEditIncrementally verifies a content-only source
@@ -19,37 +19,37 @@ import (
 // 2. Replace it with `AfterEdit` in the same source file.
 // 3. Assert incremental mode and an exact post-edit node set.
 func TestServeSessionAppliesSourceEditIncrementally(t *testing.T) {
-	root := graphSessionFixture(t)
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
-	if _, _, _, err := session.Snapshot(); err != nil {
-		t.Fatal(err)
-	}
+  root := graphSessionFixture(t)
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
 
-	file := filepath.Join(root, "src", "index.ts")
-	if err := os.WriteFile(file, []byte("export class AfterEdit {}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "incremental" || !changed {
-		t.Fatalf("edited snapshot = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
-	}
-	if !hasDumpNode(*dump, "AfterEdit") || hasDumpNode(*dump, "BeforeEdit") {
-		t.Fatalf("incremental dump kept stale nodes: %#v", dump.Nodes)
-	}
+  file := filepath.Join(root, "src", "index.ts")
+  if err := os.WriteFile(file, []byte("export class AfterEdit {}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "incremental" || !changed {
+    t.Fatalf("edited snapshot = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+  if !hasDumpNode(*dump, "AfterEdit") || hasDumpNode(*dump, "BeforeEdit") {
+    t.Fatalf("incremental dump kept stale nodes: %#v", dump.Nodes)
+  }
 }
 
 func hasDumpNode(dump graph.Dump, name string) bool {
-	for _, node := range dump.Nodes {
-		if node.Name == name {
-			return true
-		}
-	}
-	return false
+  for _, node := range dump.Nodes {
+    if node.Name == name {
+      return true
+    }
+  }
+  return false
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_fails_closed_on_deleted_config_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_fails_closed_on_deleted_config_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestServeSessionFailsClosedOnDeletedConfig verifies removing the project
+// config fails the snapshot without poisoning the resident session.
+//
+// The boundary twin of the invalid-config case: deletion takes the
+// hashesChanged ErrNotExist branch and its forced reload fails at session
+// construction rather than config parsing. A byte-identical restore must then
+// report unchanged — the resident graph still matches the disk exactly — and
+// the compiler session must keep serving incremental edits, proving the
+// failed reload episode left no partial state behind.
+//
+//  1. Build a valid initial graph, then delete tsconfig.json.
+//  2. Assert the snapshot fails with no dump.
+//  3. Restore the identical config and assert the snapshot is unchanged.
+//  4. Edit the source and assert an incremental refresh still works.
+func TestServeSessionFailsClosedOnDeletedConfig(t *testing.T) {
+  root := graphSessionFixture(t)
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
+
+  config := filepath.Join(root, "tsconfig.json")
+  saved, err := os.ReadFile(config)
+  if err != nil {
+    t.Fatal(err)
+  }
+  if err := os.Remove(config); err != nil {
+    t.Fatal(err)
+  }
+  dump, _, changed, err := session.Snapshot()
+  if err == nil || dump != nil || changed {
+    t.Fatalf("deleted config must fail closed: dump:%v changed:%v err:%v", dump != nil, changed, err)
+  }
+
+  if err := os.WriteFile(config, saved, 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump != nil || mode != "unchanged" || changed {
+    t.Fatalf("identical restored config must be unchanged: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+
+  if err := os.WriteFile(filepath.Join(root, "src", "index.ts"), []byte("export class AfterEdit {}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err = session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "incremental" || !changed || !hasDumpNode(*dump, "AfterEdit") {
+    t.Fatalf("session did not survive the failed reload: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_fails_closed_on_invalid_config_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_fails_closed_on_invalid_config_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionFailsClosedOnInvalidConfig verifies a broken project config
@@ -17,34 +17,34 @@ import (
 // 2. Assert snapshot fails with no dump instead of serving the cached graph.
 // 3. Restore a valid config and assert the next request reloads successfully.
 func TestServeSessionFailsClosedOnInvalidConfig(t *testing.T) {
-	root := graphSessionFixture(t)
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
-	if _, _, _, err := session.Snapshot(); err != nil {
-		t.Fatal(err)
-	}
+  root := graphSessionFixture(t)
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
 
-	config := filepath.Join(root, "tsconfig.json")
-	if err := os.WriteFile(config, []byte("{ invalid"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, _, changed, err := session.Snapshot()
-	if err == nil || dump != nil || changed {
-		t.Fatalf("invalid config must fail closed: dump:%v changed:%v err:%v", dump != nil, changed, err)
-	}
+  config := filepath.Join(root, "tsconfig.json")
+  if err := os.WriteFile(config, []byte("{ invalid"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, _, changed, err := session.Snapshot()
+  if err == nil || dump != nil || changed {
+    t.Fatalf("invalid config must fail closed: dump:%v changed:%v err:%v", dump != nil, changed, err)
+  }
 
-	valid := `{"compilerOptions":{"target":"ES2022","module":"commonjs","strict":true},"include":["src"]}`
-	if err := os.WriteFile(config, []byte(valid), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "BeforeEdit") {
-		t.Fatalf("fixed config did not recover: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
-	}
+  valid := `{"compilerOptions":{"target":"ES2022","module":"commonjs","strict":true},"include":["src"]}`
+  if err := os.WriteFile(config, []byte(valid), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "BeforeEdit") {
+    t.Fatalf("fixed config did not recover: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_fails_closed_on_invalid_config_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_fails_closed_on_invalid_config_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionFailsClosedOnInvalidConfig verifies a broken project config
+// never falls back to the last valid graph and recovers after the config is fixed.
+//
+// Returning stale compiler facts is worse than returning an MCP error. A config
+// parse failure must therefore suppress the dump while preserving enough
+// session state to retry the reload on the next request.
+//
+// 1. Build a valid initial graph, then replace tsconfig.json with invalid JSON.
+// 2. Assert snapshot fails with no dump instead of serving the cached graph.
+// 3. Restore a valid config and assert the next request reloads successfully.
+func TestServeSessionFailsClosedOnInvalidConfig(t *testing.T) {
+	root := graphSessionFixture(t)
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	if _, _, _, err := session.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	config := filepath.Join(root, "tsconfig.json")
+	if err := os.WriteFile(config, []byte("{ invalid"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, _, changed, err := session.Snapshot()
+	if err == nil || dump != nil || changed {
+		t.Fatalf("invalid config must fail closed: dump:%v changed:%v err:%v", dump != nil, changed, err)
+	}
+
+	valid := `{"compilerOptions":{"target":"ES2022","module":"commonjs","strict":true},"include":["src"]}`
+	if err := os.WriteFile(config, []byte(valid), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "BeforeEdit") {
+		t.Fatalf("fixed config did not recover: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+	}
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_keeps_missing_literal_root_unchanged_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_keeps_missing_literal_root_unchanged_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestServeSessionKeepsMissingLiteralRootUnchanged verifies a permanently
+// absent `files` entry does not churn the session.
+//
+// The negative twin of the created-literal-root reload: tracking a missing
+// root as a freshness input must record a stable absent state. If the stored
+// parse-time root set and the reloaded one disagreed about missing literal
+// entries, or the absent state flapped, every snapshot would degrade into a
+// full reload and silently erase the resident session's entire benefit.
+//
+//  1. Open a session whose tsconfig lists absent `src/generated.ts` in files.
+//  2. Take repeated snapshots without touching the project.
+//  3. Assert each one reports unchanged with no replacement dump.
+func TestServeSessionKeepsMissingLiteralRootUnchanged(t *testing.T) {
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs" },
+  "files": ["src/index.ts", "src/generated.ts"]
+}`)
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export class Present {}\n")
+
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
+
+  for i := 0; i < 2; i++ {
+    dump, mode, changed, err := session.Snapshot()
+    if err != nil {
+      t.Fatal(err)
+    }
+    if dump != nil || mode != "unchanged" || changed {
+      t.Fatalf("iteration %d: missing literal root churned = dump:%v mode:%q changed:%v", i, dump != nil, mode, changed)
+    }
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_rebuilds_import_graph_change_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_rebuilds_import_graph_change_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionRebuildsImportGraphChange verifies an edited import set uses
+// tsgo's safe rebuild path instead of claiming structural reuse.
+//
+// UpdateProgram can replace one AST only while its module references are
+// unchanged. Adding an import must rebuild the Program, refresh the Checker, and
+// emit the newly-resolved call edge in the same resident native process.
+//
+// 1. Start with two exported functions and no edge between them.
+// 2. Edit the first file to import and call the second.
+// 3. Assert rebuild mode and a calls edge from `main` to `helper`.
+func TestServeSessionRebuildsImportGraphChange(t *testing.T) {
+	root := graphSessionFixture(t)
+	helper := filepath.Join(root, "src", "helper.ts")
+	if err := os.WriteFile(helper, []byte("export function helper(): void {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	if _, _, _, err := session.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	index := filepath.Join(root, "src", "index.ts")
+	content := "import { helper } from './helper';\nexport function main(): void { helper(); }\n"
+	if err := os.WriteFile(index, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "rebuild" || !changed {
+		t.Fatalf("import edit = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+	}
+	mainID, helperID := "", ""
+	for _, node := range dump.Nodes {
+		if node.Name == "main" {
+			mainID = node.ID
+		} else if node.Name == "helper" {
+			helperID = node.ID
+		}
+	}
+	for _, edge := range dump.Edges {
+		if edge.From == mainID && edge.To == helperID && edge.Kind == "calls" {
+			return
+		}
+	}
+	t.Fatalf("rebuilt graph omitted main -> helper call: nodes=%#v edges=%#v", dump.Nodes, dump.Edges)
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_rebuilds_import_graph_change_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_rebuilds_import_graph_change_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionRebuildsImportGraphChange verifies an edited import set uses
@@ -17,44 +17,44 @@ import (
 // 2. Edit the first file to import and call the second.
 // 3. Assert rebuild mode and a calls edge from `main` to `helper`.
 func TestServeSessionRebuildsImportGraphChange(t *testing.T) {
-	root := graphSessionFixture(t)
-	helper := filepath.Join(root, "src", "helper.ts")
-	if err := os.WriteFile(helper, []byte("export function helper(): void {}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
-	if _, _, _, err := session.Snapshot(); err != nil {
-		t.Fatal(err)
-	}
+  root := graphSessionFixture(t)
+  helper := filepath.Join(root, "src", "helper.ts")
+  if err := os.WriteFile(helper, []byte("export function helper(): void {}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
 
-	index := filepath.Join(root, "src", "index.ts")
-	content := "import { helper } from './helper';\nexport function main(): void { helper(); }\n"
-	if err := os.WriteFile(index, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "rebuild" || !changed {
-		t.Fatalf("import edit = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
-	}
-	mainID, helperID := "", ""
-	for _, node := range dump.Nodes {
-		if node.Name == "main" {
-			mainID = node.ID
-		} else if node.Name == "helper" {
-			helperID = node.ID
-		}
-	}
-	for _, edge := range dump.Edges {
-		if edge.From == mainID && edge.To == helperID && edge.Kind == "calls" {
-			return
-		}
-	}
-	t.Fatalf("rebuilt graph omitted main -> helper call: nodes=%#v edges=%#v", dump.Nodes, dump.Edges)
+  index := filepath.Join(root, "src", "index.ts")
+  content := "import { helper } from './helper';\nexport function main(): void { helper(); }\n"
+  if err := os.WriteFile(index, []byte(content), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "rebuild" || !changed {
+    t.Fatalf("import edit = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+  mainID, helperID := "", ""
+  for _, node := range dump.Nodes {
+    if node.Name == "main" {
+      mainID = node.ID
+    } else if node.Name == "helper" {
+      helperID = node.ID
+    }
+  }
+  for _, edge := range dump.Edges {
+    if edge.From == mainID && edge.To == helperID && edge.Kind == "calls" {
+      return
+    }
+  }
+  t.Fatalf("rebuilt graph omitted main -> helper call: nodes=%#v edges=%#v", dump.Nodes, dump.Edges)
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_created_literal_root_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_created_literal_root_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestServeSessionReloadsCreatedLiteralRoot verifies a `files`-listed root
+// that does not exist yet joins the graph once it is created.
+//
+// A literal `files` entry survives a root-set reload whether or not the file
+// exists, so the root comparison never flips for it, and a file absent from
+// the program has no source hash and no unresolved-import candidate. The
+// session must track missing literal roots as freshness inputs of their own.
+//
+//  1. Open a session whose tsconfig lists absent `src/generated.ts` in files.
+//  2. Create that file without touching any other project input.
+//  3. Assert the next snapshot reloads and exposes the new declaration.
+func TestServeSessionReloadsCreatedLiteralRoot(t *testing.T) {
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs" },
+  "files": ["src/index.ts", "src/generated.ts"]
+}`)
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export class Present {}\n")
+
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
+
+  writeGraphFile(t, filepath.Join(root, "src", "generated.ts"), "export class Generated {}\n")
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "Generated") {
+    t.Fatalf("created files-listed root was not reloaded: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_extended_config_change_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_extended_config_change_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionReloadsExtendedConfigChange verifies every config in an
@@ -17,29 +17,29 @@ import (
 // 2. Build once, then change a compiler option only in the base config.
 // 3. Assert the next snapshot reports a full reload.
 func TestServeSessionReloadsExtendedConfigChange(t *testing.T) {
-	root := t.TempDir()
-	writeGraphFile(t, filepath.Join(root, "base.json"), `{"compilerOptions":{"strict":true,"target":"ES2022"}}`)
-	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{"extends":"./base.json","include":["src"]}`)
-	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export class Value {}\n")
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "base.json"), `{"compilerOptions":{"strict":true,"target":"ES2022"}}`)
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{"extends":"./base.json","include":["src"]}`)
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export class Value {}\n")
 
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
-	if _, _, _, err := session.Snapshot(); err != nil {
-		t.Fatal(err)
-	}
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
 
-	base := filepath.Join(root, "base.json")
-	if err := os.WriteFile(base, []byte(`{"compilerOptions":{"strict":false,"target":"ES2022"}}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "reload" || !changed {
-		t.Fatalf("extended config edit = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
-	}
+  base := filepath.Join(root, "base.json")
+  if err := os.WriteFile(base, []byte(`{"compilerOptions":{"strict":false,"target":"ES2022"}}`), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed {
+    t.Fatalf("extended config edit = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_extended_config_change_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_extended_config_change_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionReloadsExtendedConfigChange verifies every config in an
+// extends chain participates in snapshot freshness.
+//
+// Watching only the requested tsconfig misses compiler-option changes inherited
+// from a base file. The session records all parsed extended source files and
+// must full-reload before answering after any one changes.
+//
+// 1. Create a project whose tsconfig extends `base.json`.
+// 2. Build once, then change a compiler option only in the base config.
+// 3. Assert the next snapshot reports a full reload.
+func TestServeSessionReloadsExtendedConfigChange(t *testing.T) {
+	root := t.TempDir()
+	writeGraphFile(t, filepath.Join(root, "base.json"), `{"compilerOptions":{"strict":true,"target":"ES2022"}}`)
+	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{"extends":"./base.json","include":["src"]}`)
+	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export class Value {}\n")
+
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	if _, _, _, err := session.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	base := filepath.Join(root, "base.json")
+	if err := os.WriteFile(base, []byte(`{"compilerOptions":{"strict":false,"target":"ES2022"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "reload" || !changed {
+		t.Fatalf("extended config edit = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+	}
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_conditional_export_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_conditional_export_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestServeSessionReloadsNewlyResolvedConditionalExport verifies conditional
+// exports objects and array fallbacks contribute resolution candidates.
+//
+// Real packages rarely map a subpath straight to one string: `exports`
+// commonly nests condition objects (`types`, `default`) and array fallbacks.
+// Every leaf target must be tracked, or a package shipping its compiled
+// output later stays invisible to the resident graph.
+//
+//  1. Import a package subpath whose exports leaf targets do not exist yet.
+//  2. Create the `types` condition's declaration target.
+//  3. Assert the next snapshot reports a full reload.
+func TestServeSessionReloadsNewlyResolvedConditionalExport(t *testing.T) {
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs" },
+  "files": ["src/index.ts"]
+}`)
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { feature } from 'fixture-package/feature';\nexport function main(): void { feature(); }\n")
+  writeGraphFile(t, filepath.Join(root, "node_modules", "fixture-package", "package.json"), `{
+  "name": "fixture-package",
+  "exports": {
+    "./feature": {
+      "types": "./dist/feature.d.ts",
+      "default": ["./dist/feature.js"]
+    }
+  }
+}`)
+
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
+
+  target := filepath.Join(root, "node_modules", "fixture-package", "dist", "feature.d.ts")
+  if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+    t.Fatal(err)
+  }
+  if err := os.WriteFile(target, []byte("export declare function feature(): void;\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed {
+    t.Fatalf("new conditional export target = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_config_types_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_config_types_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestServeSessionReloadsNewlyResolvedConfigTypes verifies compilerOptions
+// `types` entries participate in freshness without any source-level syntax.
+//
+// A `types` package is requested by the config alone, so no triple-slash
+// directive or import exists to contribute resolution candidates. Generated
+// typeRoots packages appear without touching package.json or the lockfile,
+// which would leave the graph permanently blind to them.
+//
+//  1. Open a session whose config lists absent types package `fixture-types`.
+//  2. Create the package under the configured typeRoots directory.
+//  3. Assert the next snapshot reports a full reload.
+func TestServeSessionReloadsNewlyResolvedConfigTypes(t *testing.T) {
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "typeRoots": ["./types"], "types": ["fixture-types"] },
+  "files": ["src/index.ts"]
+}`)
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export const value = 1;\n")
+
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
+
+  writeGraphFile(t, filepath.Join(root, "types", "fixture-types", "index.d.ts"), "interface FixtureType { id: number }\n")
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed {
+    t.Fatalf("new config types package = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_excluded_import_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_excluded_import_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionReloadsNewlyResolvedExcludedImport verifies a previously
+// missing relative import becomes visible even when the new file is not a
+// tsconfig root.
+//
+// Comparing only parsed root file names misses this transition: `files` stays
+// unchanged while module resolution changes from unresolved to resolved. The
+// session snapshots concrete resolution candidates and reloads when one appears.
+//
+// 1. Compile one root that imports missing, excluded `generated.ts`.
+// 2. Create that module without changing the importer or tsconfig roots.
+// 3. Assert reload mode and the newly-resolved declaration and call edge.
+func TestServeSessionReloadsNewlyResolvedExcludedImport(t *testing.T) {
+	root := t.TempDir()
+	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs", "strict": true },
+  "files": ["src/index.ts"]
+}`)
+	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { generated } from './generated';\nexport function main(): void { generated(); }\n")
+
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	if _, _, _, err := session.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	generated := filepath.Join(root, "src", "generated.ts")
+	if err := os.WriteFile(generated, []byte("export function generated(): void {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "generated") {
+		t.Fatalf("new resolution = dump:%v mode:%q changed:%v nodes:%#v", dump != nil, mode, changed, dump)
+	}
+	mainID, generatedID := "", ""
+	for _, node := range dump.Nodes {
+		if node.Name == "main" {
+			mainID = node.ID
+		} else if node.Name == "generated" {
+			generatedID = node.ID
+		}
+	}
+	for _, edge := range dump.Edges {
+		if edge.From == mainID && edge.To == generatedID && edge.Kind == "calls" {
+			return
+		}
+	}
+	t.Fatalf("reloaded graph omitted main -> generated call: %#v", dump.Edges)
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_excluded_import_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_excluded_import_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionReloadsNewlyResolvedExcludedImport verifies a previously
@@ -18,45 +18,45 @@ import (
 // 2. Create that module without changing the importer or tsconfig roots.
 // 3. Assert reload mode and the newly-resolved declaration and call edge.
 func TestServeSessionReloadsNewlyResolvedExcludedImport(t *testing.T) {
-	root := t.TempDir()
-	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
   "compilerOptions": { "target": "ES2022", "module": "commonjs", "strict": true },
   "files": ["src/index.ts"]
 }`)
-	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { generated } from './generated';\nexport function main(): void { generated(); }\n")
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { generated } from './generated';\nexport function main(): void { generated(); }\n")
 
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
-	if _, _, _, err := session.Snapshot(); err != nil {
-		t.Fatal(err)
-	}
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
 
-	generated := filepath.Join(root, "src", "generated.ts")
-	if err := os.WriteFile(generated, []byte("export function generated(): void {}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "generated") {
-		t.Fatalf("new resolution = dump:%v mode:%q changed:%v nodes:%#v", dump != nil, mode, changed, dump)
-	}
-	mainID, generatedID := "", ""
-	for _, node := range dump.Nodes {
-		if node.Name == "main" {
-			mainID = node.ID
-		} else if node.Name == "generated" {
-			generatedID = node.ID
-		}
-	}
-	for _, edge := range dump.Edges {
-		if edge.From == mainID && edge.To == generatedID && edge.Kind == "calls" {
-			return
-		}
-	}
-	t.Fatalf("reloaded graph omitted main -> generated call: %#v", dump.Edges)
+  generated := filepath.Join(root, "src", "generated.ts")
+  if err := os.WriteFile(generated, []byte("export function generated(): void {}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "generated") {
+    t.Fatalf("new resolution = dump:%v mode:%q changed:%v nodes:%#v", dump != nil, mode, changed, dump)
+  }
+  mainID, generatedID := "", ""
+  for _, node := range dump.Nodes {
+    if node.Name == "main" {
+      mainID = node.ID
+    } else if node.Name == "generated" {
+      generatedID = node.ID
+    }
+  }
+  for _, edge := range dump.Edges {
+    if edge.From == mainID && edge.To == generatedID && edge.Kind == "calls" {
+      return
+    }
+  }
+  t.Fatalf("reloaded graph omitted main -> generated call: %#v", dump.Edges)
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_package_export_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_package_export_test.go
@@ -1,46 +1,46 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionReloadsNewlyResolvedPackageExport verifies an exports target
 // appearing under an existing package triggers module-resolution reload.
 func TestServeSessionReloadsNewlyResolvedPackageExport(t *testing.T) {
-	root := t.TempDir()
-	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
   "compilerOptions": { "target": "ES2022", "module": "commonjs" },
   "files": ["src/index.ts"]
 }`)
-	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { feature } from 'fixture-package/feature';\nexport function main(): void { feature(); }\n")
-	writeGraphFile(t, filepath.Join(root, "node_modules", "fixture-package", "package.json"), `{
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { feature } from 'fixture-package/feature';\nexport function main(): void { feature(); }\n")
+  writeGraphFile(t, filepath.Join(root, "node_modules", "fixture-package", "package.json"), `{
   "name": "fixture-package",
   "exports": { "./feature": "./dist/feature.js" }
 }`)
 
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
-	if _, _, _, err := session.Snapshot(); err != nil {
-		t.Fatal(err)
-	}
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
 
-	target := filepath.Join(root, "node_modules", "fixture-package", "dist", "feature.ts")
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(target, []byte("export function feature(): void {}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "reload" || !changed {
-		t.Fatalf("new package export target = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
-	}
+  target := filepath.Join(root, "node_modules", "fixture-package", "dist", "feature.ts")
+  if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+    t.Fatal(err)
+  }
+  if err := os.WriteFile(target, []byte("export function feature(): void {}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed {
+    t.Fatalf("new package export target = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_package_export_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_package_export_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionReloadsNewlyResolvedPackageExport verifies an exports target
+// appearing under an existing package triggers module-resolution reload.
+func TestServeSessionReloadsNewlyResolvedPackageExport(t *testing.T) {
+	root := t.TempDir()
+	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs" },
+  "files": ["src/index.ts"]
+}`)
+	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { feature } from 'fixture-package/feature';\nexport function main(): void { feature(); }\n")
+	writeGraphFile(t, filepath.Join(root, "node_modules", "fixture-package", "package.json"), `{
+  "name": "fixture-package",
+  "exports": { "./feature": "./dist/feature.js" }
+}`)
+
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	if _, _, _, err := session.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	target := filepath.Join(root, "node_modules", "fixture-package", "dist", "feature.ts")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("export function feature(): void {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "reload" || !changed {
+		t.Fatalf("new package export target = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+	}
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_package_import_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_package_import_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionReloadsNewlyResolvedPackageImport verifies wildcard imports
+// targets are tracked with the wildcard text matched from the package key.
+func TestServeSessionReloadsNewlyResolvedPackageImport(t *testing.T) {
+	root := t.TempDir()
+	writeGraphFile(t, filepath.Join(root, "package.json"), `{
+  "name": "fixture-project",
+  "imports": { "#generated/*": "./generated/*.js" }
+}`)
+	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "nodenext", "moduleResolution": "nodenext" },
+  "files": ["src/index.ts"]
+}`)
+	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { generated } from '#generated/value';\nexport function main(): void { generated(); }\n")
+
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	if _, _, _, err := session.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	target := filepath.Join(root, "generated", "value.ts")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("export function generated(): void {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "reload" || !changed {
+		t.Fatalf("new package imports target = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+	}
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_package_import_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_package_import_test.go
@@ -1,46 +1,46 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionReloadsNewlyResolvedPackageImport verifies wildcard imports
 // targets are tracked with the wildcard text matched from the package key.
 func TestServeSessionReloadsNewlyResolvedPackageImport(t *testing.T) {
-	root := t.TempDir()
-	writeGraphFile(t, filepath.Join(root, "package.json"), `{
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "package.json"), `{
   "name": "fixture-project",
   "imports": { "#generated/*": "./generated/*.js" }
 }`)
-	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
   "compilerOptions": { "target": "ES2022", "module": "nodenext", "moduleResolution": "nodenext" },
   "files": ["src/index.ts"]
 }`)
-	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { generated } from '#generated/value';\nexport function main(): void { generated(); }\n")
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { generated } from '#generated/value';\nexport function main(): void { generated(); }\n")
 
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
-	if _, _, _, err := session.Snapshot(); err != nil {
-		t.Fatal(err)
-	}
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
 
-	target := filepath.Join(root, "generated", "value.ts")
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(target, []byte("export function generated(): void {}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "reload" || !changed {
-		t.Fatalf("new package imports target = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
-	}
+  target := filepath.Join(root, "generated", "value.ts")
+  if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+    t.Fatal(err)
+  }
+  if err := os.WriteFile(target, []byte("export function generated(): void {}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed {
+    t.Fatalf("new package imports target = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_path_alias_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_path_alias_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionReloadsNewlyResolvedPathAlias verifies a missing paths target
+// is tracked even when it is excluded from the tsconfig root set.
+func TestServeSessionReloadsNewlyResolvedPathAlias(t *testing.T) {
+	root := t.TempDir()
+	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "baseUrl": ".",
+    "paths": { "@generated/*": ["generated/*"] }
+  },
+  "files": ["src/index.ts"]
+}`)
+	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { generated } from '@generated/value';\nexport function main(): void { generated(); }\n")
+
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	if _, _, _, err := session.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	target := filepath.Join(root, "generated", "value.ts")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("export function generated(): void {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "generated") {
+		t.Fatalf("new paths target = dump:%v mode:%q changed:%v nodes:%#v", dump != nil, mode, changed, dump)
+	}
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_path_alias_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_path_alias_test.go
@@ -1,16 +1,16 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionReloadsNewlyResolvedPathAlias verifies a missing paths target
 // is tracked even when it is excluded from the tsconfig root set.
 func TestServeSessionReloadsNewlyResolvedPathAlias(t *testing.T) {
-	root := t.TempDir()
-	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
   "compilerOptions": {
     "target": "ES2022",
     "module": "commonjs",
@@ -19,29 +19,29 @@ func TestServeSessionReloadsNewlyResolvedPathAlias(t *testing.T) {
   },
   "files": ["src/index.ts"]
 }`)
-	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { generated } from '@generated/value';\nexport function main(): void { generated(); }\n")
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { generated } from '@generated/value';\nexport function main(): void { generated(); }\n")
 
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
-	if _, _, _, err := session.Snapshot(); err != nil {
-		t.Fatal(err)
-	}
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
 
-	target := filepath.Join(root, "generated", "value.ts")
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(target, []byte("export function generated(): void {}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "generated") {
-		t.Fatalf("new paths target = dump:%v mode:%q changed:%v nodes:%#v", dump != nil, mode, changed, dump)
-	}
+  target := filepath.Join(root, "generated", "value.ts")
+  if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+    t.Fatal(err)
+  }
+  if err := os.WriteFile(target, []byte("export function generated(): void {}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "generated") {
+    t.Fatalf("new paths target = dump:%v mode:%q changed:%v nodes:%#v", dump != nil, mode, changed, dump)
+  }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_reference_path_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_reference_path_test.go
@@ -1,42 +1,42 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionReloadsNewlyResolvedReferencePath verifies triple-slash path
 // directives participate in freshness even though they are not AST statements.
 func TestServeSessionReloadsNewlyResolvedReferencePath(t *testing.T) {
-	root := t.TempDir()
-	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
   "compilerOptions": { "target": "ES2022", "module": "commonjs" },
   "files": ["src/index.ts"]
 }`)
-	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "/// <reference path=\"../generated/types.d.ts\" />\nexport const value: Generated = { id: 1 };\n")
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "/// <reference path=\"../generated/types.d.ts\" />\nexport const value: Generated = { id: 1 };\n")
 
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
-	if _, _, _, err := session.Snapshot(); err != nil {
-		t.Fatal(err)
-	}
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
 
-	target := filepath.Join(root, "generated", "types.d.ts")
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(target, []byte("interface Generated { id: number }\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "reload" || !changed {
-		t.Fatalf("new reference path = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
-	}
+  target := filepath.Join(root, "generated", "types.d.ts")
+  if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+    t.Fatal(err)
+  }
+  if err := os.WriteFile(target, []byte("interface Generated { id: number }\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed {
+    t.Fatalf("new reference path = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_reference_path_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_reference_path_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionReloadsNewlyResolvedReferencePath verifies triple-slash path
+// directives participate in freshness even though they are not AST statements.
+func TestServeSessionReloadsNewlyResolvedReferencePath(t *testing.T) {
+	root := t.TempDir()
+	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs" },
+  "files": ["src/index.ts"]
+}`)
+	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "/// <reference path=\"../generated/types.d.ts\" />\nexport const value: Generated = { id: 1 };\n")
+
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	if _, _, _, err := session.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	target := filepath.Join(root, "generated", "types.d.ts")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("interface Generated { id: number }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "reload" || !changed {
+		t.Fatalf("new reference path = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+	}
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_root_dirs_target_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_root_dirs_target_test.go
@@ -1,16 +1,16 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionReloadsNewlyResolvedRootDirsTarget verifies virtual relative
 // paths across rootDirs participate in module-resolution freshness.
 func TestServeSessionReloadsNewlyResolvedRootDirsTarget(t *testing.T) {
-	root := t.TempDir()
-	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
   "compilerOptions": {
     "target": "ES2022",
     "module": "commonjs",
@@ -18,29 +18,29 @@ func TestServeSessionReloadsNewlyResolvedRootDirsTarget(t *testing.T) {
   },
   "files": ["src/views/index.ts"]
 }`)
-	writeGraphFile(t, filepath.Join(root, "src", "views", "index.ts"), "import { template } from './template';\nexport function render(): void { template(); }\n")
+  writeGraphFile(t, filepath.Join(root, "src", "views", "index.ts"), "import { template } from './template';\nexport function render(): void { template(); }\n")
 
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
-	if _, _, _, err := session.Snapshot(); err != nil {
-		t.Fatal(err)
-	}
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
 
-	target := filepath.Join(root, "generated", "views", "template.ts")
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(target, []byte("export function template(): void {}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "template") {
-		t.Fatalf("new rootDirs target = dump:%v mode:%q changed:%v nodes:%#v", dump != nil, mode, changed, dump)
-	}
+  target := filepath.Join(root, "generated", "views", "template.ts")
+  if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+    t.Fatal(err)
+  }
+  if err := os.WriteFile(target, []byte("export function template(): void {}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "template") {
+    t.Fatalf("new rootDirs target = dump:%v mode:%q changed:%v nodes:%#v", dump != nil, mode, changed, dump)
+  }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_root_dirs_target_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_root_dirs_target_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionReloadsNewlyResolvedRootDirsTarget verifies virtual relative
+// paths across rootDirs participate in module-resolution freshness.
+func TestServeSessionReloadsNewlyResolvedRootDirsTarget(t *testing.T) {
+	root := t.TempDir()
+	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "rootDirs": ["src", "generated"]
+  },
+  "files": ["src/views/index.ts"]
+}`)
+	writeGraphFile(t, filepath.Join(root, "src", "views", "index.ts"), "import { template } from './template';\nexport function render(): void { template(); }\n")
+
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	if _, _, _, err := session.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	target := filepath.Join(root, "generated", "views", "template.ts")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("export function template(): void {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "template") {
+		t.Fatalf("new rootDirs target = dump:%v mode:%q changed:%v nodes:%#v", dump != nil, mode, changed, dump)
+	}
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_type_reference_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_newly_resolved_type_reference_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestServeSessionReloadsNewlyResolvedTypeReference verifies triple-slash type
+// directives honor configured typeRoots when a missing package appears.
+func TestServeSessionReloadsNewlyResolvedTypeReference(t *testing.T) {
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "typeRoots": ["./types"] },
+  "files": ["src/index.ts"]
+}`)
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "/// <reference types=\"fixture-types\" />\nexport const value: FixtureType = { id: 1 };\n")
+
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
+
+  target := filepath.Join(root, "types", "fixture-types", "index.d.ts")
+  if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+    t.Fatal(err)
+  }
+  if err := os.WriteFile(target, []byte("interface FixtureType { id: number }\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed {
+    t.Fatalf("new type reference = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_root_file_set_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_root_file_set_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionReloadsRootFileSet verifies include-glob additions and
@@ -17,36 +17,36 @@ import (
 // 2. Delete the original `BeforeEdit` root.
 // 3. Assert another reload removes the deleted declaration.
 func TestServeSessionReloadsRootFileSet(t *testing.T) {
-	root := graphSessionFixture(t)
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
-	if _, _, _, err := session.Snapshot(); err != nil {
-		t.Fatal(err)
-	}
+  root := graphSessionFixture(t)
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
 
-	added := filepath.Join(root, "src", "added.ts")
-	if err := os.WriteFile(added, []byte("export class AddedRoot {}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "AddedRoot") {
-		t.Fatalf("added root was not reloaded: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
-	}
+  added := filepath.Join(root, "src", "added.ts")
+  if err := os.WriteFile(added, []byte("export class AddedRoot {}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "AddedRoot") {
+    t.Fatalf("added root was not reloaded: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
 
-	if err := os.Remove(filepath.Join(root, "src", "index.ts")); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err = session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "reload" || !changed || hasDumpNode(*dump, "BeforeEdit") {
-		t.Fatalf("deleted root remained in graph: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
-	}
+  if err := os.Remove(filepath.Join(root, "src", "index.ts")); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err = session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed || hasDumpNode(*dump, "BeforeEdit") {
+    t.Fatalf("deleted root remained in graph: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_root_file_set_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_root_file_set_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionReloadsRootFileSet verifies include-glob additions and
+// deletions replace the compiler session rather than leaving stale roots.
+//
+// A one-file UpdateProgram cannot add or remove config roots. The session must
+// re-evaluate the tsconfig file set before source hashing and reload whenever
+// that set changes.
+//
+// 1. Add `AddedRoot` under an included directory and assert reload plus presence.
+// 2. Delete the original `BeforeEdit` root.
+// 3. Assert another reload removes the deleted declaration.
+func TestServeSessionReloadsRootFileSet(t *testing.T) {
+	root := graphSessionFixture(t)
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	if _, _, _, err := session.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	added := filepath.Join(root, "src", "added.ts")
+	if err := os.WriteFile(added, []byte("export class AddedRoot {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "AddedRoot") {
+		t.Fatalf("added root was not reloaded: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+	}
+
+	if err := os.Remove(filepath.Join(root, "src", "index.ts")); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err = session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "reload" || !changed || hasDumpNode(*dump, "BeforeEdit") {
+		t.Fatalf("deleted root remained in graph: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+	}
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_source_deleted_during_load_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_source_deleted_during_load_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestServeSessionReloadsSourceDeletedDuringLoad verifies a program source
+// that vanishes between compiler load and state capture is still detected.
+//
+// captureState hashes only sources it can read back from disk, so silently
+// skipping a just-deleted file would drop it from every later freshness check:
+// no root change, no source hash, no resolution candidate. The session must
+// record the resident text instead so the next snapshot observes the deletion
+// and reloads rather than serving the vanished declarations forever.
+//
+//  1. Load a session whose root imports `helper.ts`.
+//  2. Delete `helper.ts` before capturing the freshness state.
+//  3. Assert the next snapshot reloads and drops the deleted declaration.
+func TestServeSessionReloadsSourceDeletedDuringLoad(t *testing.T) {
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs" },
+  "files": ["src/index.ts"]
+}`)
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "import { helper } from './helper';\nexport function main(): void { helper(); }\n")
+  writeGraphFile(t, filepath.Join(root, "src", "helper.ts"), "export function helper(): void {}\n")
+
+  compiler, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if compiler == nil {
+    t.Fatalf("NewSession returned nil session (diagnostics: %v)", diags)
+  }
+  if err := os.Remove(filepath.Join(root, "src", "helper.ts")); err != nil {
+    t.Fatal(err)
+  }
+  session := &graphSession{
+    cwd:         root,
+    tsconfig:    "tsconfig.json",
+    compiler:    compiler,
+    initialized: true,
+  }
+  defer session.Close()
+  if err := session.captureState(); err != nil {
+    t.Fatal(err)
+  }
+
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed || hasDumpNode(*dump, "helper") {
+    t.Fatalf("deleted-during-load source survived: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_transitive_project_reference_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_transitive_project_reference_test.go
@@ -1,55 +1,55 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+  "os"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionReloadsTransitiveProjectReference verifies config and root
 // freshness traverses the complete project-reference graph, not only the
 // root config's direct references.
 func TestServeSessionReloadsTransitiveProjectReference(t *testing.T) {
-	root := t.TempDir()
-	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
   "files": ["src/index.ts"],
   "references": [{ "path": "./middle" }]
 }`)
-	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export const root = 1;\n")
-	writeGraphFile(t, filepath.Join(root, "middle", "tsconfig.json"), `{
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export const root = 1;\n")
+  writeGraphFile(t, filepath.Join(root, "middle", "tsconfig.json"), `{
   "compilerOptions": { "composite": true },
   "files": ["src/index.ts"],
   "references": [{ "path": "../leaf" }]
 }`)
-	writeGraphFile(t, filepath.Join(root, "middle", "src", "index.ts"), "export const middle = 1;\n")
-	writeGraphFile(t, filepath.Join(root, "leaf", "tsconfig.json"), `{
+  writeGraphFile(t, filepath.Join(root, "middle", "src", "index.ts"), "export const middle = 1;\n")
+  writeGraphFile(t, filepath.Join(root, "leaf", "tsconfig.json"), `{
   "compilerOptions": { "composite": true },
   "include": ["src"]
 }`)
-	writeGraphFile(t, filepath.Join(root, "leaf", "src", "index.ts"), "export const leaf = 1;\n")
+  writeGraphFile(t, filepath.Join(root, "leaf", "src", "index.ts"), "export const leaf = 1;\n")
 
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
-	leafConfig := filepath.ToSlash(filepath.Join(root, "leaf", "tsconfig.json"))
-	if _, ok := session.configHashes[leafConfig]; !ok {
-		t.Fatalf("transitive project config was not tracked: %s; got %#v", leafConfig, session.configHashes)
-	}
-	if _, _, _, err := session.Snapshot(); err != nil {
-		t.Fatal(err)
-	}
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  leafConfig := filepath.ToSlash(filepath.Join(root, "leaf", "tsconfig.json"))
+  if _, ok := session.configHashes[leafConfig]; !ok {
+    t.Fatalf("transitive project config was not tracked: %s; got %#v", leafConfig, session.configHashes)
+  }
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
 
-	added := filepath.Join(root, "leaf", "src", "added.ts")
-	if err := os.WriteFile(added, []byte("export const added = 1;\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump == nil || mode != "reload" || !changed {
-		t.Fatalf("transitive root addition = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
-	}
+  added := filepath.Join(root, "leaf", "src", "added.ts")
+  if err := os.WriteFile(added, []byte("export const added = 1;\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed {
+    t.Fatalf("transitive root addition = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_transitive_project_reference_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_transitive_project_reference_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionReloadsTransitiveProjectReference verifies config and root
+// freshness traverses the complete project-reference graph, not only the
+// root config's direct references.
+func TestServeSessionReloadsTransitiveProjectReference(t *testing.T) {
+	root := t.TempDir()
+	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "files": ["src/index.ts"],
+  "references": [{ "path": "./middle" }]
+}`)
+	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export const root = 1;\n")
+	writeGraphFile(t, filepath.Join(root, "middle", "tsconfig.json"), `{
+  "compilerOptions": { "composite": true },
+  "files": ["src/index.ts"],
+  "references": [{ "path": "../leaf" }]
+}`)
+	writeGraphFile(t, filepath.Join(root, "middle", "src", "index.ts"), "export const middle = 1;\n")
+	writeGraphFile(t, filepath.Join(root, "leaf", "tsconfig.json"), `{
+  "compilerOptions": { "composite": true },
+  "include": ["src"]
+}`)
+	writeGraphFile(t, filepath.Join(root, "leaf", "src", "index.ts"), "export const leaf = 1;\n")
+
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	leafConfig := filepath.ToSlash(filepath.Join(root, "leaf", "tsconfig.json"))
+	if _, ok := session.configHashes[leafConfig]; !ok {
+		t.Fatalf("transitive project config was not tracked: %s; got %#v", leafConfig, session.configHashes)
+	}
+	if _, _, _, err := session.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	added := filepath.Join(root, "leaf", "src", "added.ts")
+	if err := os.WriteFile(added, []byte("export const added = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump == nil || mode != "reload" || !changed {
+		t.Fatalf("transitive root addition = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+	}
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_when_program_plugin_linked_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_when_program_plugin_linked_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+type serveProgramPluginProbe struct{}
+
+func (serveProgramPluginProbe) ApplyProgram(*driver.Program, driver.PluginContext) error {
+  return nil
+}
+
+// TestServeSessionReloadsWhenProgramPluginLinked verifies a project with an
+// active linked ProgramPlugin never takes the incremental source path.
+//
+// ProgramPlugin hooks mutate parsed ASTs in place and run exactly once per
+// Program, so an incremental source replacement would leave the new AST
+// without the plugin's mutations while the rest of the graph still carries
+// them. A content-only edit must therefore rebuild through a full reload.
+//
+//  1. Register a linked ProgramPlugin and open a graph session.
+//  2. Apply a content-only edit that would otherwise refresh incrementally.
+//  3. Assert the snapshot reports a full reload with the post-edit node.
+func TestServeSessionReloadsWhenProgramPluginLinked(t *testing.T) {
+  t.Setenv(driver.LinkedPluginsEnv, `[{"name":"probe","stage":"transform"}]`)
+  driver.RegisterPlugin(serveProgramPluginProbe{})
+
+  root := graphSessionFixture(t)
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
+
+  file := filepath.Join(root, "src", "index.ts")
+  if err := os.WriteFile(file, []byte("export class AfterEdit {}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "reload" || !changed || !hasDumpNode(*dump, "AfterEdit") {
+    t.Fatalf("program-plugin edit = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reuses_unchanged_preamble_source_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reuses_unchanged_preamble_source_test.go
@@ -1,45 +1,45 @@
 package main
 
 import (
-	"path/filepath"
-	"testing"
+  "path/filepath"
+  "testing"
 
-	"github.com/samchon/ttsc/packages/ttsc/driver"
+  "github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
 // TestServeSessionReusesUnchangedPreambleSource verifies injected compiler text
 // is compared against the corresponding raw disk source, not mistaken for an
 // edit on every snapshot.
 func TestServeSessionReusesUnchangedPreambleSource(t *testing.T) {
-	root := t.TempDir()
-	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{"compilerOptions":{"strict":true},"files":["index.ts"]}`)
-	writeGraphFile(t, filepath.Join(root, "index.ts"), "export const value = 1;\n")
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{"compilerOptions":{"strict":true},"files":["index.ts"]}`)
+  writeGraphFile(t, filepath.Join(root, "index.ts"), "export const value = 1;\n")
 
-	compiler, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{
-		SourcePreamble: "declare const injected: number;\n",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if compiler == nil {
-		t.Fatalf("NewSession returned nil session (diagnostics: %v)", diags)
-	}
-	session := &graphSession{
-		cwd:         root,
-		tsconfig:    "tsconfig.json",
-		compiler:    compiler,
-		initialized: true,
-	}
-	defer session.Close()
-	if err := session.captureState(); err != nil {
-		t.Fatal(err)
-	}
+  compiler, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{
+    SourcePreamble: "declare const injected: number;\n",
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if compiler == nil {
+    t.Fatalf("NewSession returned nil session (diagnostics: %v)", diags)
+  }
+  session := &graphSession{
+    cwd:         root,
+    tsconfig:    "tsconfig.json",
+    compiler:    compiler,
+    initialized: true,
+  }
+  defer session.Close()
+  if err := session.captureState(); err != nil {
+    t.Fatal(err)
+  }
 
-	dump, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dump != nil || mode != "unchanged" || changed {
-		t.Fatalf("unchanged preamble source = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
-	}
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump != nil || mode != "unchanged" || changed {
+    t.Fatalf("unchanged preamble source = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reuses_unchanged_preamble_source_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reuses_unchanged_preamble_source_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestServeSessionReusesUnchangedPreambleSource verifies injected compiler text
+// is compared against the corresponding raw disk source, not mistaken for an
+// edit on every snapshot.
+func TestServeSessionReusesUnchangedPreambleSource(t *testing.T) {
+	root := t.TempDir()
+	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{"compilerOptions":{"strict":true},"files":["index.ts"]}`)
+	writeGraphFile(t, filepath.Join(root, "index.ts"), "export const value = 1;\n")
+
+	compiler, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{
+		SourcePreamble: "declare const injected: number;\n",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiler == nil {
+		t.Fatalf("NewSession returned nil session (diagnostics: %v)", diags)
+	}
+	session := &graphSession{
+		cwd:         root,
+		tsconfig:    "tsconfig.json",
+		compiler:    compiler,
+		initialized: true,
+	}
+	defer session.Close()
+	if err := session.captureState(); err != nil {
+		t.Fatal(err)
+	}
+
+	dump, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dump != nil || mode != "unchanged" || changed {
+		t.Fatalf("unchanged preamble source = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+	}
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reuses_unchanged_snapshot_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reuses_unchanged_snapshot_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"path/filepath"
-	"testing"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionReusesUnchangedSnapshot verifies repeated graph requests do
@@ -16,37 +16,37 @@ import (
 // 2. Request another snapshot without touching the project.
 // 3. Assert the second response is unchanged and carries no replacement dump.
 func TestServeSessionReusesUnchangedSnapshot(t *testing.T) {
-	root := graphSessionFixture(t)
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
+  root := graphSessionFixture(t)
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
 
-	first, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if first == nil || mode != "initial" || !changed {
-		t.Fatalf("initial snapshot = dump:%v mode:%q changed:%v", first != nil, mode, changed)
-	}
+  first, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if first == nil || mode != "initial" || !changed {
+    t.Fatalf("initial snapshot = dump:%v mode:%q changed:%v", first != nil, mode, changed)
+  }
 
-	second, mode, changed, err := session.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if second != nil || mode != "unchanged" || changed {
-		t.Fatalf("unchanged snapshot = dump:%v mode:%q changed:%v", second != nil, mode, changed)
-	}
+  second, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if second != nil || mode != "unchanged" || changed {
+    t.Fatalf("unchanged snapshot = dump:%v mode:%q changed:%v", second != nil, mode, changed)
+  }
 }
 
 func graphSessionFixture(t *testing.T) string {
-	t.Helper()
-	root := t.TempDir()
-	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  t.Helper()
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
   "compilerOptions": { "target": "ES2022", "module": "commonjs", "strict": true },
   "include": ["src"]
 }`)
-	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export class BeforeEdit {}\n")
-	return root
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export class BeforeEdit {}\n")
+  return root
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reuses_unchanged_snapshot_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reuses_unchanged_snapshot_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionReusesUnchangedSnapshot verifies repeated graph requests do
+// no graph rebuild when every project input is byte-identical.
+//
+// This is the hot MCP path. The native session still checks its config, root
+// file set, and resident source hashes, but it must omit the dump so the Node
+// server can retain its indexed maps without parsing or synthesizing them again.
+//
+// 1. Open a one-file graph session and request its initial dump.
+// 2. Request another snapshot without touching the project.
+// 3. Assert the second response is unchanged and carries no replacement dump.
+func TestServeSessionReusesUnchangedSnapshot(t *testing.T) {
+	root := graphSessionFixture(t)
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	first, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == nil || mode != "initial" || !changed {
+		t.Fatalf("initial snapshot = dump:%v mode:%q changed:%v", first != nil, mode, changed)
+	}
+
+	second, mode, changed, err := session.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second != nil || mode != "unchanged" || changed {
+		t.Fatalf("unchanged snapshot = dump:%v mode:%q changed:%v", second != nil, mode, changed)
+	}
+}
+
+func graphSessionFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs", "strict": true },
+  "include": ["src"]
+}`)
+	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export class BeforeEdit {}\n")
+	return root
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_revisits_source_edited_during_load_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_revisits_source_edited_during_load_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestServeSessionRevisitsSourceEditedDuringLoad verifies a source edited
+// between compiler load and state capture is refreshed on the next snapshot.
+//
+// Hashing the raw disk bytes at capture time would bless content the resident
+// program never parsed: disk and graph would disagree until an unrelated
+// change. The capture must hash the resident text instead, so the next
+// snapshot sees the disk mismatch and applies the missed edit.
+//
+//  1. Load a session, then rewrite the source before capturing state.
+//  2. Take a snapshot and assert it refreshes to the on-disk declaration.
+//  3. Take another snapshot and assert the session has converged (unchanged).
+func TestServeSessionRevisitsSourceEditedDuringLoad(t *testing.T) {
+  root := graphSessionFixture(t)
+  compiler, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if compiler == nil {
+    t.Fatalf("NewSession returned nil session (diagnostics: %v)", diags)
+  }
+  file := filepath.Join(root, "src", "index.ts")
+  if err := os.WriteFile(file, []byte("export class EditedDuringLoad {}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  session := &graphSession{
+    cwd:         root,
+    tsconfig:    "tsconfig.json",
+    compiler:    compiler,
+    initialized: true,
+  }
+  defer session.Close()
+  if err := session.captureState(); err != nil {
+    t.Fatal(err)
+  }
+
+  dump, _, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || !changed || !hasDumpNode(*dump, "EditedDuringLoad") || hasDumpNode(*dump, "BeforeEdit") {
+    t.Fatalf("edited-during-load source was not refreshed: dump:%v changed:%v", dump != nil, changed)
+  }
+
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump != nil || mode != "unchanged" || changed {
+    t.Fatalf("session did not converge after the missed edit: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_tolerates_os_invalid_resolution_candidate_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_tolerates_os_invalid_resolution_candidate_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestServeSessionToleratesOsInvalidResolutionCandidate verifies unresolved
+// module specifiers that name OS-unparseable paths never break the session.
+//
+// Bundler-style specifiers (`./style.css?inline`) and URL imports (`data:`)
+// stay unresolved in tsgo and become freshness candidates. On Windows those
+// candidate paths fail os.ReadFile with ERROR_INVALID_NAME, which is neither
+// ErrNotExist nor ErrInvalid; treating that as a snapshot error would make
+// every graph request fail forever on such a project.
+//
+//  1. Open a session whose only root imports a query-suffixed CSS path and a
+//     data: URL.
+//  2. Assert the session initializes and serves its initial dump.
+//  3. Assert an untouched second snapshot reports unchanged.
+func TestServeSessionToleratesOsInvalidResolutionCandidate(t *testing.T) {
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs" },
+  "files": ["src/index.ts"]
+}`)
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), `
+// @ts-expect-error bundler-only specifier stays unresolved for tsgo
+import styles from "./style.css?inline";
+// @ts-expect-error data: URLs resolve at runtime, not through the compiler
+import remote from "data:text/plain,hello";
+export const value: unknown[] = [styles, remote];
+`)
+
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != "initial" || !changed {
+    t.Fatalf("initial snapshot = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+
+  dump, mode, changed, err = session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump != nil || mode != "unchanged" || changed {
+    t.Fatalf("untouched snapshot = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_tracks_all_module_specifier_forms_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_tracks_all_module_specifier_forms_test.go
@@ -1,20 +1,20 @@
 package main
 
 import (
-	"path/filepath"
-	"testing"
+  "path/filepath"
+  "testing"
 )
 
 // TestServeSessionTracksAllModuleSpecifierForms verifies that every TypeScript
 // syntax which can trigger module resolution contributes missing-file
 // candidates to the freshness snapshot.
 func TestServeSessionTracksAllModuleSpecifierForms(t *testing.T) {
-	root := t.TempDir()
-	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
   "compilerOptions": { "target": "ES2022", "module": "commonjs", "strict": true },
   "files": ["src/index.ts"]
 }`)
-	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), `
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), `
 import legacy = require("./legacy");
 export { exported } from "./exported";
 export type Deferred = import("./types").Deferred;
@@ -23,19 +23,19 @@ export const common = require("./common");
 export const result = legacy();
 `)
 
-	session, err := newGraphSession(root, "tsconfig.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer session.Close()
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
 
-	for _, name := range []string{"legacy.ts", "exported.ts", "types.ts", "lazy.ts", "common.ts"} {
-		candidate := filepath.Join(root, "src", name)
-		state, ok := session.auxStates[candidate]
-		if !ok {
-			t.Errorf("module candidate %s was not tracked", name)
-		} else if state.Exists {
-			t.Errorf("missing module candidate %s unexpectedly exists", name)
-		}
-	}
+  for _, name := range []string{"legacy.ts", "exported.ts", "types.ts", "lazy.ts", "common.ts"} {
+    candidate := filepath.Join(root, "src", name)
+    state, ok := session.auxStates[candidate]
+    if !ok {
+      t.Errorf("module candidate %s was not tracked", name)
+    } else if state.Exists {
+      t.Errorf("missing module candidate %s unexpectedly exists", name)
+    }
+  }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_tracks_all_module_specifier_forms_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_tracks_all_module_specifier_forms_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestServeSessionTracksAllModuleSpecifierForms verifies that every TypeScript
+// syntax which can trigger module resolution contributes missing-file
+// candidates to the freshness snapshot.
+func TestServeSessionTracksAllModuleSpecifierForms(t *testing.T) {
+	root := t.TempDir()
+	writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs", "strict": true },
+  "files": ["src/index.ts"]
+}`)
+	writeGraphFile(t, filepath.Join(root, "src", "index.ts"), `
+import legacy = require("./legacy");
+export { exported } from "./exported";
+export type Deferred = import("./types").Deferred;
+export const lazy = import("./lazy");
+export const common = require("./common");
+export const result = legacy();
+`)
+
+	session, err := newGraphSession(root, "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	for _, name := range []string{"legacy.ts", "exported.ts", "types.ts", "lazy.ts", "common.ts"} {
+		candidate := filepath.Join(root, "src", name)
+		state, ok := session.auxStates[candidate]
+		if !ok {
+			t.Errorf("module candidate %s was not tracked", name)
+		} else if state.Exists {
+			t.Errorf("missing module candidate %s unexpectedly exists", name)
+		}
+	}
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_session_tracks_diamond_project_references_once_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_tracks_diamond_project_references_once_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestServeSessionTracksDiamondProjectReferencesOnce verifies the config
+// traversal terminates and deduplicates when two references share a child.
+//
+// A diamond (root -> left, root -> right, both -> shared) visits the shared
+// config twice; without the seen-set the traversal would duplicate tracked
+// state, and on a reference cycle it would never terminate. The shared leaf
+// must appear in the freshness state exactly once and the session must stay
+// stable across untouched snapshots.
+//
+//  1. Open a session over a diamond of project references.
+//  2. Assert the shared leaf config is hash-tracked.
+//  3. Assert an untouched snapshot reports unchanged.
+func TestServeSessionTracksDiamondProjectReferencesOnce(t *testing.T) {
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "files": ["src/index.ts"],
+  "references": [{ "path": "./left" }, { "path": "./right" }]
+}`)
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), "export const root = 1;\n")
+  for _, side := range []string{"left", "right"} {
+    writeGraphFile(t, filepath.Join(root, side, "tsconfig.json"), `{
+  "compilerOptions": { "composite": true },
+  "files": ["src/index.ts"],
+  "references": [{ "path": "../shared" }]
+}`)
+    writeGraphFile(t, filepath.Join(root, side, "src", "index.ts"), "export const side = 1;\n")
+  }
+  writeGraphFile(t, filepath.Join(root, "shared", "tsconfig.json"), `{
+  "compilerOptions": { "composite": true },
+  "files": ["src/index.ts"]
+}`)
+  writeGraphFile(t, filepath.Join(root, "shared", "src", "index.ts"), "export const shared = 1;\n")
+
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  sharedConfig := filepath.ToSlash(filepath.Join(root, "shared", "tsconfig.json"))
+  if _, ok := session.configHashes[sharedConfig]; !ok {
+    t.Fatalf("shared diamond config was not tracked: %s; got %#v", sharedConfig, session.configHashes)
+  }
+  if _, _, _, err := session.Snapshot(); err != nil {
+    t.Fatal(err)
+  }
+
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump != nil || mode != "unchanged" || changed {
+    t.Fatalf("diamond references churned: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+}

--- a/packages/ttsc/driver/plugins.go
+++ b/packages/ttsc/driver/plugins.go
@@ -130,6 +130,19 @@ func (state linkedPluginState) apply(prog *Program) error {
   return nil
 }
 
+func (state linkedPluginState) hasProgramPlugins() bool {
+  for index := range state.entries {
+    plugin, ok := registeredPlugin(index)
+    if !ok {
+      continue
+    }
+    if _, ok := plugin.(ProgramPlugin); ok {
+      return true
+    }
+  }
+  return false
+}
+
 // emitTransforms collects an emit-phase PluginTransform from every registered
 // EmitTransformPlugin, in registration order. Entries that do not implement
 // EmitTransformPlugin, or whose transform is nil, are skipped.

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -456,10 +456,10 @@ type sourcePreambleFS struct {
 
 func (fs sourcePreambleFS) ReadFile(filePath string) (string, bool) {
   contents, ok := fs.FS.ReadFile(filePath)
-  if !ok || !isSourcePreambleTarget(filePath) {
+  if !ok {
     return contents, ok
   }
-  return ApplySourcePreamble(contents, fs.preamble), true
+  return ApplySourcePreambleToFile(filePath, contents, fs.preamble), true
 }
 
 // isSourcePreambleTarget reports whether the preamble should be injected into
@@ -478,6 +478,15 @@ func isSourcePreambleTarget(filePath string) bool {
     }
   }
   return false
+}
+
+// ApplySourcePreambleToFile applies a generated preamble only when filePath is
+// a non-declaration TypeScript or JavaScript source, matching sourcePreambleFS.
+func ApplySourcePreambleToFile(filePath string, text string, preamble string) string {
+  if !isSourcePreambleTarget(filePath) {
+    return text
+  }
+  return ApplySourcePreamble(text, preamble)
 }
 
 // ApplySourcePreamble inserts a generated source preamble without moving the
@@ -540,6 +549,13 @@ func (p *Program) ApplyLinkedPlugins() error {
   p.pluginsApplied = true
   p.pluginsApplyErr = p.plugins.apply(p)
   return p.pluginsApplyErr
+}
+
+// HasLinkedProgramPlugins reports whether the loaded project has an active
+// ProgramPlugin. Those hooks mutate parsed ASTs in place and therefore require
+// a fresh Program rather than Session's incremental source replacement.
+func (p *Program) HasLinkedProgramPlugins() bool {
+  return p != nil && p.plugins.hasProgramPlugins()
 }
 
 // Diagnostics returns project diagnostics that must block compilation or

--- a/packages/ttsc/driver/session.go
+++ b/packages/ttsc/driver/session.go
@@ -1,13 +1,15 @@
 package driver
 
 import (
+  "context"
+
   shimtspath "github.com/microsoft/typescript-go/shim/tspath"
 )
 
 // Session is a resident compiler host for incremental type-checking: it keeps a
 // loaded program alive and re-parses only the changed file on each edit (reusing
-// the unchanged ASTs and the pinned checker through UpdateProgram), instead of
-// recompiling the whole project per request.
+// the unchanged ASTs and refreshing the checker for the updated Program),
+// instead of recompiling the whole project per request.
 //
 // It is the driver-level incremental type-check primitive. The resident
 // transform path (utility-host `serve`) deliberately does not use it: the
@@ -50,10 +52,16 @@ func (s *Session) Apply(absPath, content string) bool {
     name = file.FileName()
   }
   changed := shimtspath.ToPath(name, s.cwd, s.overlay.caseSensitive)
-  newHost := DefaultHost(s.cwd, s.overlay)
+  newHost := DefaultHost(s.cwd, s.prog.FS)
   newProg, reused := s.prog.TSProgram.UpdateProgram(changed, newHost, nil)
   if newProg != nil {
+    if s.prog.checkerRelease != nil {
+      s.prog.checkerRelease()
+    }
+    checker, release := newProg.GetTypeChecker(context.Background())
     s.prog.TSProgram = newProg
+    s.prog.Checker = checker
+    s.prog.checkerRelease = release
     s.prog.Host = newHost
   }
   return reused

--- a/packages/ttsc/test/driver/session_apply_preserves_source_preamble_test.go
+++ b/packages/ttsc/test/driver/session_apply_preserves_source_preamble_test.go
@@ -1,39 +1,39 @@
 package driver_test
 
 import (
-	"path/filepath"
-	"testing"
+  "path/filepath"
+  "testing"
 
-	"github.com/samchon/ttsc/packages/ttsc/driver"
+  "github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
 // TestDriverSessionApplyPreservesSourcePreamble verifies incremental updates
 // read the overlay through the same preamble filesystem as the initial Program.
 func TestDriverSessionApplyPreservesSourcePreamble(t *testing.T) {
-	root := t.TempDir()
-	writeProjectFile(t, root, "tsconfig.json", `{"compilerOptions":{"strict":true,"noEmit":true},"files":["index.ts"]}`)
-	writeProjectFile(t, root, "index.ts", "export const value = 1;\n")
-	preamble := "declare const injected: number;\n"
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{"compilerOptions":{"strict":true,"noEmit":true},"files":["index.ts"]}`)
+  writeProjectFile(t, root, "index.ts", "export const value = 1;\n")
+  preamble := "declare const injected: number;\n"
 
-	session, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{
-		ForceNoEmit:    true,
-		SourcePreamble: preamble,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if session == nil {
-		t.Fatalf("NewSession returned nil session (diagnostics: %v)", diags)
-	}
-	defer session.Close()
+  session, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{
+    ForceNoEmit:    true,
+    SourcePreamble: preamble,
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if session == nil {
+    t.Fatalf("NewSession returned nil session (diagnostics: %v)", diags)
+  }
+  defer session.Close()
 
-	file := filepath.Join(root, "index.ts")
-	edited := "export const value = 2;\n"
-	if reused := session.Apply(file, edited); !reused {
-		t.Fatal("content-only preamble edit unexpectedly rebuilt the Program")
-	}
-	text, ok := session.SourceText(file)
-	if !ok || text != preamble+edited {
-		t.Fatalf("updated source lost its preamble: ok=%v text=%q", ok, text)
-	}
+  file := filepath.Join(root, "index.ts")
+  edited := "export const value = 2;\n"
+  if reused := session.Apply(file, edited); !reused {
+    t.Fatal("content-only preamble edit unexpectedly rebuilt the Program")
+  }
+  text, ok := session.SourceText(file)
+  if !ok || text != preamble+edited {
+    t.Fatalf("updated source lost its preamble: ok=%v text=%q", ok, text)
+  }
 }

--- a/packages/ttsc/test/driver/session_apply_preserves_source_preamble_test.go
+++ b/packages/ttsc/test/driver/session_apply_preserves_source_preamble_test.go
@@ -1,0 +1,39 @@
+package driver_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverSessionApplyPreservesSourcePreamble verifies incremental updates
+// read the overlay through the same preamble filesystem as the initial Program.
+func TestDriverSessionApplyPreservesSourcePreamble(t *testing.T) {
+	root := t.TempDir()
+	writeProjectFile(t, root, "tsconfig.json", `{"compilerOptions":{"strict":true,"noEmit":true},"files":["index.ts"]}`)
+	writeProjectFile(t, root, "index.ts", "export const value = 1;\n")
+	preamble := "declare const injected: number;\n"
+
+	session, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{
+		ForceNoEmit:    true,
+		SourcePreamble: preamble,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session == nil {
+		t.Fatalf("NewSession returned nil session (diagnostics: %v)", diags)
+	}
+	defer session.Close()
+
+	file := filepath.Join(root, "index.ts")
+	edited := "export const value = 2;\n"
+	if reused := session.Apply(file, edited); !reused {
+		t.Fatal("content-only preamble edit unexpectedly rebuilt the Program")
+	}
+	text, ok := session.SourceText(file)
+	if !ok || text != preamble+edited {
+		t.Fatalf("updated source lost its preamble: ok=%v text=%q", ok, text)
+	}
+}

--- a/packages/ttsc/test/driver/session_apply_refreshes_checker_test.go
+++ b/packages/ttsc/test/driver/session_apply_refreshes_checker_test.go
@@ -1,11 +1,11 @@
 package driver_test
 
 import (
-	"path/filepath"
-	"strings"
-	"testing"
+  "path/filepath"
+  "strings"
+  "testing"
 
-	"github.com/samchon/ttsc/packages/ttsc/driver"
+  "github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
 // TestDriverSessionApplyRefreshesChecker verifies incremental sessions replace
@@ -20,34 +20,34 @@ import (
 // 2. Apply an import-stable edit that assigns a string to a number.
 // 3. Assert the current Program reports the post-edit type error.
 func TestDriverSessionApplyRefreshesChecker(t *testing.T) {
-	root := t.TempDir()
-	writeProjectFile(t, root, "tsconfig.json", `{"compilerOptions":{"strict":true,"noEmit":true},"files":["index.ts"]}`)
-	file := filepath.Join(root, "index.ts")
-	writeProjectFile(t, root, "index.ts", "export const value: number = 1;\n")
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{"compilerOptions":{"strict":true,"noEmit":true},"files":["index.ts"]}`)
+  file := filepath.Join(root, "index.ts")
+  writeProjectFile(t, root, "index.ts", "export const value: number = 1;\n")
 
-	session, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{ForceNoEmit: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if session == nil {
-		t.Fatalf("NewSession returned nil (diagnostics: %v)", diags)
-	}
-	defer session.Close()
+  session, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{ForceNoEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if session == nil {
+    t.Fatalf("NewSession returned nil (diagnostics: %v)", diags)
+  }
+  defer session.Close()
 
-	if reused := session.Apply(file, "export const value: number = 'bad';\n"); !reused {
-		t.Fatal("type-only body edit should reuse the resident program")
-	}
-	current := session.Program().Diagnostics()
-	if !hasDiagnosticText(current, "not assignable to type 'number'") {
-		t.Fatalf("updated checker did not report the post-edit type error: %v", current)
-	}
+  if reused := session.Apply(file, "export const value: number = 'bad';\n"); !reused {
+    t.Fatal("type-only body edit should reuse the resident program")
+  }
+  current := session.Program().Diagnostics()
+  if !hasDiagnosticText(current, "not assignable to type 'number'") {
+    t.Fatalf("updated checker did not report the post-edit type error: %v", current)
+  }
 }
 
 func hasDiagnosticText(diags []driver.Diagnostic, text string) bool {
-	for _, diag := range diags {
-		if strings.Contains(diag.Message, text) {
-			return true
-		}
-	}
-	return false
+  for _, diag := range diags {
+    if strings.Contains(diag.Message, text) {
+      return true
+    }
+  }
+  return false
 }

--- a/packages/ttsc/test/driver/session_apply_refreshes_checker_test.go
+++ b/packages/ttsc/test/driver/session_apply_refreshes_checker_test.go
@@ -1,0 +1,53 @@
+package driver_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverSessionApplyRefreshesChecker verifies incremental sessions replace
+// the Checker lease together with the tsgo Program.
+//
+// UpdateProgram returns a new Program and checker pool even when it reuses all
+// unchanged files. Keeping the wrapper's previous Checker would let consumers
+// observe the new AST with stale types and diagnostics, which is especially
+// dangerous for a checker-resolved graph.
+//
+// 1. Open a valid one-file resident Session.
+// 2. Apply an import-stable edit that assigns a string to a number.
+// 3. Assert the current Program reports the post-edit type error.
+func TestDriverSessionApplyRefreshesChecker(t *testing.T) {
+	root := t.TempDir()
+	writeProjectFile(t, root, "tsconfig.json", `{"compilerOptions":{"strict":true,"noEmit":true},"files":["index.ts"]}`)
+	file := filepath.Join(root, "index.ts")
+	writeProjectFile(t, root, "index.ts", "export const value: number = 1;\n")
+
+	session, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{ForceNoEmit: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session == nil {
+		t.Fatalf("NewSession returned nil (diagnostics: %v)", diags)
+	}
+	defer session.Close()
+
+	if reused := session.Apply(file, "export const value: number = 'bad';\n"); !reused {
+		t.Fatal("type-only body edit should reuse the resident program")
+	}
+	current := session.Program().Diagnostics()
+	if !hasDiagnosticText(current, "not assignable to type 'number'") {
+		t.Fatalf("updated checker did not report the post-edit type error: %v", current)
+	}
+}
+
+func hasDiagnosticText(diags []driver.Diagnostic, text string) bool {
+	for _, diag := range diags {
+		if strings.Contains(diag.Message, text) {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/test-graph/src/features/test_ttscgraph_fails_closed_for_invalid_config_and_recovers.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_fails_closed_for_invalid_config_and_recovers.ts
@@ -1,0 +1,90 @@
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  isError?: boolean;
+  content: { type: string; text: string }[];
+}
+
+const GRAPH_TOOL_NAME = "inspect_typescript_graph";
+
+const lookupArguments = (query: string) => ({
+  question: `Look up ${query} in the synchronized TypeScript graph.`,
+  draft: {
+    reason: "A named lookup is the smallest graph request.",
+    type: "lookup",
+  },
+  review: "Confirmed: use the current graph snapshot.",
+  request: { type: "lookup", query },
+});
+
+/**
+ * Verifies MCP graph calls fail closed on an invalid config and recover later.
+ *
+ * A refresh error must never make the server return its previous valid graph as
+ * if it described the current project. The native session remains retryable so
+ * an agent can fix the config and use the same MCP process afterward.
+ *
+ * 1. Build an initial graph, then corrupt tsconfig.json.
+ * 2. Assert the next tool result is an error rather than stale graph evidence.
+ * 3. Restore the config and assert the same server answers successfully again.
+ */
+export const test_ttscgraph_fails_closed_for_invalid_config_and_recovers =
+  async () => {
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: { target: "ES2022", module: "commonjs", strict: true },
+        include: ["src"],
+      }),
+      "src/index.ts": "export class Recoverable {}\n",
+    });
+    const client = TtsgraphClient.start(root);
+    try {
+      await client.request("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-graph", version: "0.0.0" },
+      });
+      client.notify("notifications/initialized", {});
+
+      const initial = (await client.request("tools/call", {
+        name: GRAPH_TOOL_NAME,
+        arguments: lookupArguments("Recoverable"),
+      })) as ToolResult;
+      assert.equal(initial.isError, undefined, initial.content[0]?.text);
+
+      const config = path.join(root, "tsconfig.json");
+      fs.writeFileSync(config, "{ invalid");
+      const invalid = (await client.request("tools/call", {
+        name: GRAPH_TOOL_NAME,
+        arguments: lookupArguments("Recoverable"),
+      })) as ToolResult;
+      assert.equal(invalid.isError, true, JSON.stringify(invalid));
+      assert.match(invalid.content[0]?.text ?? "", /invalid project/i);
+
+      fs.writeFileSync(
+        config,
+        JSON.stringify({
+          compilerOptions: {
+            target: "ES2022",
+            module: "commonjs",
+            strict: true,
+          },
+          include: ["src"],
+        }),
+      );
+      const recovered = (await client.request("tools/call", {
+        name: GRAPH_TOOL_NAME,
+        arguments: lookupArguments("Recoverable"),
+      })) as ToolResult;
+      assert.equal(recovered.isError, undefined, recovered.content[0]?.text);
+      assert.match(recovered.content[0]?.text ?? "", /Recoverable/);
+    } finally {
+      client.endStdin();
+    }
+
+    assert.equal(await client.waitForExit(), 0, client.stderrText());
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_refreshes_added_and_deleted_roots_in_same_mcp_session.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_refreshes_added_and_deleted_roots_in_same_mcp_session.ts
@@ -1,0 +1,90 @@
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  content: { type: string; text: string }[];
+}
+
+const GRAPH_TOOL_NAME = "inspect_typescript_graph";
+
+const lookup = async (
+  client: ReturnType<typeof TtsgraphClient.start>,
+  query: string,
+): Promise<string[]> => {
+  const result = (await client.request("tools/call", {
+    name: GRAPH_TOOL_NAME,
+    arguments: {
+      question: `Look up ${query} in the current TypeScript project roots.`,
+      draft: {
+        reason: "A named symbol lookup is the smallest graph request.",
+        type: "lookup",
+      },
+      review: "Confirmed: query the synchronized graph once.",
+      request: { type: "lookup", query },
+    },
+  })) as ToolResult;
+  const value = JSON.parse(result.content[0]?.text ?? "{}") as {
+    result?: { type?: string; hits?: { name?: string }[] };
+  };
+  assert.equal(value.result?.type, "lookup", JSON.stringify(value));
+  return (value.result?.hits ?? []).flatMap((hit) =>
+    typeof hit.name === "string" ? [hit.name] : [],
+  );
+};
+
+/**
+ * Verifies one MCP session refreshes tsconfig root additions and deletions.
+ *
+ * Content hashing existing Program files cannot discover a new include-glob
+ * match, and an incremental single-file replacement cannot remove a deleted
+ * root. The resident native session must compare parsed root sets and safely
+ * reload before each affected tool response.
+ *
+ * 1. Start one server over an include-glob project containing `OriginalRoot`.
+ * 2. Add `AddedRoot` in a second file and assert it is immediately searchable.
+ * 3. Delete the original file and assert its declaration disappears.
+ */
+export const test_ttscgraph_refreshes_added_and_deleted_roots_in_same_mcp_session =
+  async () => {
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+        },
+        include: ["src"],
+      }),
+      "src/original.ts": "export class OriginalRoot {}\n",
+    });
+    const client = TtsgraphClient.start(root);
+    try {
+      await client.request("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-graph", version: "0.0.0" },
+      });
+      client.notify("notifications/initialized", {});
+
+      assert.ok(
+        (await lookup(client, "OriginalRoot")).includes("OriginalRoot"),
+      );
+      fs.writeFileSync(
+        path.join(root, "src", "added.ts"),
+        "export class AddedRoot {}\n",
+      );
+      assert.ok((await lookup(client, "AddedRoot")).includes("AddedRoot"));
+
+      fs.rmSync(path.join(root, "src", "original.ts"));
+      assert.ok(
+        !(await lookup(client, "OriginalRoot")).includes("OriginalRoot"),
+      );
+    } finally {
+      client.endStdin();
+    }
+
+    assert.equal(await client.waitForExit(), 0, client.stderrText());
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_refreshes_changed_source_in_same_mcp_session.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_refreshes_changed_source_in_same_mcp_session.ts
@@ -1,0 +1,105 @@
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  content: { type: string; text: string }[];
+}
+
+const GRAPH_TOOL_NAME = "inspect_typescript_graph";
+
+const lookupArguments = (query: string) => ({
+  question: `Look up ${query} in the current TypeScript source snapshot.`,
+  draft: {
+    reason: "A named symbol lookup is the smallest useful graph request.",
+    type: "lookup",
+  },
+  review: "Confirmed: use one lookup against the current source snapshot.",
+  request: {
+    type: "lookup",
+    query,
+  },
+});
+
+const lookupNames = (result: ToolResult): string[] => {
+  const value = JSON.parse(result.content[0]?.text ?? "{}") as {
+    result?: { type?: string; hits?: { name?: string }[] };
+  };
+  assert.equal(value.result?.type, "lookup", JSON.stringify(value));
+  return (value.result?.hits ?? []).flatMap((hit) =>
+    typeof hit.name === "string" ? [hit.name] : [],
+  );
+};
+
+/**
+ * Verifies the MCP graph refreshes a changed source file in the same session.
+ *
+ * Locks the stale resident-index failure in `startServer`: caching the first
+ * dump forever makes every later tool call return declarations from before an
+ * agent edit. The second lookup must observe the current disk snapshot without
+ * restarting the MCP process.
+ *
+ * 1. Start one MCP server and look up an exported `BeforeEdit` class.
+ * 2. Replace that declaration on disk with `AfterEdit` in the same source file.
+ * 3. Look up both names and assert only the post-edit declaration remains.
+ */
+export const test_ttscgraph_refreshes_changed_source_in_same_mcp_session =
+  async () => {
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+        },
+        include: ["src"],
+      }),
+      "src/index.ts": "export class BeforeEdit {}\n",
+    });
+
+    const client = TtsgraphClient.start(root);
+    try {
+      await client.request("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-graph", version: "0.0.0" },
+      });
+      client.notify("notifications/initialized", {});
+
+      const before = lookupNames(
+        (await client.request("tools/call", {
+          name: GRAPH_TOOL_NAME,
+          arguments: lookupArguments("BeforeEdit"),
+        })) as ToolResult,
+      );
+      assert.ok(before.includes("BeforeEdit"), JSON.stringify(before));
+
+      fs.writeFileSync(
+        path.join(root, "src", "index.ts"),
+        "export class AfterEdit {}\n",
+      );
+
+      const after = lookupNames(
+        (await client.request("tools/call", {
+          name: GRAPH_TOOL_NAME,
+          arguments: lookupArguments("AfterEdit"),
+        })) as ToolResult,
+      );
+      assert.ok(after.includes("AfterEdit"), JSON.stringify(after));
+
+      const stale = lookupNames(
+        (await client.request("tools/call", {
+          name: GRAPH_TOOL_NAME,
+          arguments: lookupArguments("BeforeEdit"),
+        })) as ToolResult,
+      );
+      assert.ok(!stale.includes("BeforeEdit"), JSON.stringify(stale));
+    } finally {
+      client.endStdin();
+    }
+
+    const code = await client.waitForExit();
+    assert.equal(code, 0, client.stderrText());
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_skip_request_does_not_load_graph.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_skip_request_does_not_load_graph.ts
@@ -28,7 +28,7 @@ const graphArguments = () => ({
  *
  * The graph launcher builds the TypeScript graph lazily on the first real graph
  * operation. A bad tsconfig would fail that load, so a successful escape proves
- * the escape branch returns before calling the dump binary or any graph
+ * the escape branch returns before starting the native session or any graph
  * traversal.
  *
  * 1. Materialize a project with an intentionally invalid tsconfig.

--- a/tests/test-graph/src/internal/ttsgraph.ts
+++ b/tests/test-graph/src/internal/ttsgraph.ts
@@ -10,8 +10,8 @@ export { default as assert } from "node:assert/strict";
 
 /**
  * Resolve the native `ttscgraph` data binary built next to `ttsc` by `pnpm
- * build:current`. The MCP server runs it once as `ttscgraph dump`; the test
- * points the launcher at it through `TTSC_GRAPH_BINARY`.
+ * build:current`. The MCP server keeps its `ttscgraph serve` compiler session
+ * resident; the test points the launcher at it through `TTSC_GRAPH_BINARY`.
  */
 export function resolveTtscgraphBinary(): string {
   const override = process.env.TTSC_GRAPH_BINARY;
@@ -24,8 +24,8 @@ export function resolveTtscgraphBinary(): string {
 
 /**
  * Resolve the built `@ttsc/graph` launcher (lib/bin.js), the Node entry an MCP
- * client spawns. It serves the graph over stdio after running `ttscgraph dump`
- * once for the project.
+ * client spawns. It serves the graph over stdio and synchronizes the resident
+ * native snapshot before each graph operation.
  */
 export function resolveGraphLauncher(): string {
   const pkg = createRequire(import.meta.url).resolve("@ttsc/graph");
@@ -60,7 +60,7 @@ export class TtsgraphClient {
       [resolveGraphLauncher(), "--cwd", cwd],
       {
         stdio: ["pipe", "pipe", "pipe"],
-        // The launcher resolves the dump binary from TTSC_GRAPH_BINARY, so the
+        // The launcher resolves the native graph binary from TTSC_GRAPH_BINARY, so the
         // test project needs no installed `ttsc` of its own.
         env: { ...process.env, TTSC_GRAPH_BINARY: resolveTtscgraphBinary() },
         windowsHide: true,

--- a/website/src/content/docs/graph/compare.mdx
+++ b/website/src/content/docs/graph/compare.mdx
@@ -80,7 +80,7 @@ A capable graph is no use if the agent never calls it, and the four tools take v
 
 ### 2.4. Setup and freshness
 
-`@ttsc/graph` has no separate index step. The graph falls out of the type-check `ttsc` already runs, so there is no `init` command, no file watcher, and no stale index to manage.
+`@ttsc/graph` has no separate index step or `init` command. Its native compiler session checks the current project snapshot before each graph operation. Unchanged calls reuse the warm in-memory indexes, source edits reuse tsgo's incremental Program when safe, and config, root-file-set, deletion, or module-resolution changes reload before the tool answers. A refresh failure returns an error rather than the previous graph.
 
 The others build an index first. `codegraph` needs `codegraph init` to construct the graph into a local `.codegraph/` directory, `codebase-memory-mcp` needs `index_repository` (and auto-indexing turned on if you want it kept current), and `serena` activates the project and starts a language server, which carries a cold-start before the first answer.
 

--- a/website/src/content/docs/graph/design.mdx
+++ b/website/src/content/docs/graph/design.mdx
@@ -42,7 +42,7 @@ export interface ITtscGraphApplication {
    */
   inspect_typescript_graph(
     props: ITtscGraphApplication.IProps,
-  ): ITtscGraphApplication.IResult;
+  ): Promise<ITtscGraphApplication.IResult>;
 }
 
 export namespace ITtscGraphApplication {
@@ -95,7 +95,7 @@ Every choice above holds up only if the graph is trustworthy, and that trust has
 
 A parser that only reads text, such as tree-sitter, stops where the syntax stops. It cannot follow a `tsconfig` `paths` alias like `@app/*` to the real file, a `workspace:*` dependency into a sibling package, a symlink, or a re-export chain through a barrel `index.ts`. A compiler that has finished module resolution wires all of those up, and a guessed edge is exactly where an agent stops trusting the result and falls back to reading files.
 
-`@ttsc/graph` reads the program `ttsc` already type-checked, so its edges are resolved rather than inferred. Because the graph falls out of the type-check that already runs, there is no separate index step, no file watcher, and no stale index to manage.
+`@ttsc/graph` reads the program `ttsc` already type-checked, so its edges are resolved rather than inferred. The native compiler Program stays resident. Before each graph operation the server hashes the config chain, checks every root set and module-resolution input, and compares the current bytes of every Program source. With no change it returns the existing in-memory indexes. A content-only edit goes through tsgo's incremental `UpdateProgram`; an import-shape, config, addition, deletion, project-reference, or resolution change takes the safe full-reload path. A broken config fails the call instead of returning the previous graph.
 
 ![A file-by-file source crawl collapsing into a compiler-built index](/blog/images/source-crawl-vs-compiler-index.png)
 

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -5,7 +5,7 @@ import TtscWebsiteGraphViewer3D from "../../../components/graph/TtscWebsiteGraph
 
 `@ttsc/graph` gives a coding agent a compiler-resolved graph of your TypeScript project, over MCP.
 
-It runs `ttscgraph`, a native binary that type-checks your project once, and keeps the resulting graph resident in memory. Every query is answered from that resident graph, not a fresh parse, so every relationship it reports is the compiler's own answer, not a guess from reading text.
+It runs `ttscgraph`, a native binary that keeps the type-checked project and resulting graph resident in memory. Before each graph operation it checks the config, root-file set, module-resolution inputs, and source contents. An unchanged project reuses the warm graph, a content-only edit updates the resident compiler incrementally, and config, file-addition, deletion, or resolution changes trigger a safe reload. Every relationship it reports is the current compiler's own answer, not a guess from reading text.
 
 ## 1. Why an agent needs it
 


### PR DESCRIPTION
## Summary

- replace the MCP server's one-time `ttscgraph dump` cache with a resident native snapshot session checked before every non-escape graph call
- apply content-only source edits through TypeScript-Go's incremental `UpdateProgram`, refresh the checker lease, and reuse the in-memory graph when the project is unchanged
- reload safely for config, root-set, deletion, project-reference, module-resolution, and AST-mutating linked-plugin changes; return an error instead of stale graph evidence when refresh fails
- document the freshness contract and add native plus same-process MCP regression coverage

## Correctness and cost model

Freshness is derived from project inputs rather than a watcher, cooldown, fixture name, or prompt/tool heuristic. The native session hashes config chains and source bytes, compares transitive project root sets, and tracks structured TypeScript module specifiers plus `paths`, `baseUrl`, `rootDirs`, package `exports`/`imports`, and triple-slash references.

Unchanged calls retain both the compiler Program and `TtscGraphMemory`. Content-only edits reuse unchanged TypeScript ASTs through `driver.Session`. A changed compiler snapshot rebuilds the graph projection intentionally because a declaration edit can change checker-resolved edges originating in other files; structural changes take a full compiler reload.

This is a backward-compatible bug fix and fits a `0.18.4` patch release.

## Test plan

- `pnpm format`
- `go test ./cmd/ttscgraph ./test/driver -count=1`
- `go vet ./cmd/ttscgraph ./driver`
- `node scripts/test-go-graph.cjs`
- `pnpm --filter @ttsc/graph build`
- `$env:TTSC_PLATFORM_BUILD_TARGETS='ttscgraph'; pnpm --dir packages/ttsc-win32-x64 build`
- `pnpm --filter @ttsc/test-graph start`
- `pnpm test:typecheck`
- `pnpm --filter @ttsc/website build:next`

`pnpm build:current` was also attempted, but the existing `@ttsc/unplugin` Rollup stage fails in `rollup-plugin-node-externals` with `TypeError: undefined is not a function`. The graph package and native `ttscgraph` target were built independently and passed.