### PR TITLE
fix(compiler): preserve diagnostics across plugin failures

### DIFF
--- a/packages/lint/linthost/contrib_adapter.go
+++ b/packages/lint/linthost/contrib_adapter.go
@@ -61,13 +61,7 @@ func registerContributors() {
         name)
       continue
     }
-    adapter := contributorAdapter{
-      inner:                  contributor.inner,
-      metadataCached:         true,
-      name:                   contributor.name,
-      visits:                 contributor.visits,
-      visitsDeclarationFiles: contributor.visitsDeclarationFiles,
-    }
+    adapter := newContributorAdapter(contributor)
     if contributor.isFormat {
       Register(formatContributorAdapter{adapter})
       continue
@@ -114,6 +108,19 @@ func inspectContributor(contributor rule.Rule) (metadata contributorMetadata, er
   return metadata, nil
 }
 
+// newContributorAdapter builds the engine-facing adapter from metadata already
+// evaluated by inspectContributor, so no adapter method re-enters contributor
+// code after startup. This is the only construction path; a zero-value
+// contributorAdapter carries no usable metadata.
+func newContributorAdapter(metadata contributorMetadata) contributorAdapter {
+  return contributorAdapter{
+    inner:                  metadata.inner,
+    name:                   metadata.name,
+    visits:                 metadata.visits,
+    visitsDeclarationFiles: metadata.visitsDeclarationFiles,
+  }
+}
+
 // contributorAdapter wraps a public `rule.Rule` so the engine's
 // `Register` accepts it. Name, Visits, and declaration-file policy are
 // cached by inspectContributor; Check bridges through a `rule.Context`
@@ -123,7 +130,6 @@ func inspectContributor(contributor rule.Rule) (metadata contributorMetadata, er
 // same shim AST types, so no wrapping / unwrapping of nodes is needed.
 type contributorAdapter struct {
   inner                  rule.Rule
-  metadataCached         bool
   name                   string
   visits                 []shimast.Kind
   visitsDeclarationFiles bool
@@ -140,14 +146,9 @@ func (a contributorAdapter) NeedsTypeChecker() bool {
 // files unless the contributor opts out through the public
 // `rule.DeclarationFileRule` marker. Same conservative-default reasoning
 // as NeedsTypeChecker: the host cannot infer a third-party rule's grammar
-// shape, and a wrong skip silently loses findings.
+// shape, and a wrong skip silently loses findings. The default-true /
+// marker-override policy is applied once in inspectContributor.
 func (a contributorAdapter) VisitsDeclarationFiles() bool {
-  if !a.metadataCached {
-    if declarationRule, ok := a.inner.(rule.DeclarationFileRule); ok {
-      return declarationRule.VisitsDeclarationFiles()
-    }
-    return true
-  }
   return a.visitsDeclarationFiles
 }
 
@@ -162,18 +163,8 @@ type formatContributorAdapter struct {
 
 func (formatContributorAdapter) IsFormat() bool { return true }
 
-func (a contributorAdapter) Name() string {
-  if !a.metadataCached {
-    return a.inner.Name()
-  }
-  return a.name
-}
-func (a contributorAdapter) Visits() []shimast.Kind {
-  if !a.metadataCached {
-    return a.inner.Visits()
-  }
-  return a.visits
-}
+func (a contributorAdapter) Name() string           { return a.name }
+func (a contributorAdapter) Visits() []shimast.Kind { return a.visits }
 func (a contributorAdapter) Check(ctx *Context, node *shimast.Node) {
   if ctx == nil {
     return

--- a/packages/lint/linthost/contrib_adapter.go
+++ b/packages/lint/linthost/contrib_adapter.go
@@ -63,6 +63,7 @@ func registerContributors() {
     }
     adapter := contributorAdapter{
       inner:                  contributor.inner,
+      metadataCached:         true,
       name:                   contributor.name,
       visits:                 contributor.visits,
       visitsDeclarationFiles: contributor.visitsDeclarationFiles,
@@ -122,6 +123,7 @@ func inspectContributor(contributor rule.Rule) (metadata contributorMetadata, er
 // same shim AST types, so no wrapping / unwrapping of nodes is needed.
 type contributorAdapter struct {
   inner                  rule.Rule
+  metadataCached         bool
   name                   string
   visits                 []shimast.Kind
   visitsDeclarationFiles bool
@@ -140,6 +142,12 @@ func (a contributorAdapter) NeedsTypeChecker() bool {
 // as NeedsTypeChecker: the host cannot infer a third-party rule's grammar
 // shape, and a wrong skip silently loses findings.
 func (a contributorAdapter) VisitsDeclarationFiles() bool {
+  if !a.metadataCached {
+    if declarationRule, ok := a.inner.(rule.DeclarationFileRule); ok {
+      return declarationRule.VisitsDeclarationFiles()
+    }
+    return true
+  }
   return a.visitsDeclarationFiles
 }
 
@@ -154,8 +162,18 @@ type formatContributorAdapter struct {
 
 func (formatContributorAdapter) IsFormat() bool { return true }
 
-func (a contributorAdapter) Name() string           { return a.name }
-func (a contributorAdapter) Visits() []shimast.Kind { return a.visits }
+func (a contributorAdapter) Name() string {
+  if !a.metadataCached {
+    return a.inner.Name()
+  }
+  return a.name
+}
+func (a contributorAdapter) Visits() []shimast.Kind {
+  if !a.metadataCached {
+    return a.inner.Visits()
+  }
+  return a.visits
+}
 func (a contributorAdapter) Check(ctx *Context, node *shimast.Node) {
   if ctx == nil {
     return

--- a/packages/lint/linthost/contrib_adapter.go
+++ b/packages/lint/linthost/contrib_adapter.go
@@ -34,12 +34,23 @@ import (
 // with a stderr warning. The host prefers a deterministic, debuggable
 // outcome over panicking inside startup.
 func registerContributors() {
-  contributors := rule.Registered()
+  registered := rule.Registered()
+  contributors := make([]contributorMetadata, 0, len(registered))
+  for _, contributor := range registered {
+    metadata, err := inspectContributor(contributor)
+    if err != nil {
+      fmt.Fprintf(os.Stderr,
+        "@ttsc/lint: %v; dropping contributor entry\n",
+        err)
+      continue
+    }
+    contributors = append(contributors, metadata)
+  }
   sort.SliceStable(contributors, func(i, j int) bool {
-    return contributors[i].Name() < contributors[j].Name()
+    return contributors[i].name < contributors[j].name
   })
   for _, contributor := range contributors {
-    name := contributor.Name()
+    name := contributor.name
     if name == "" {
       fmt.Fprintln(os.Stderr, "@ttsc/lint: contributor rule with empty name ignored")
       continue
@@ -50,22 +61,70 @@ func registerContributors() {
         name)
       continue
     }
-    if fr, ok := contributor.(rule.FormatRule); ok && fr.IsFormat() {
-      Register(formatContributorAdapter{contributorAdapter{inner: contributor}})
+    adapter := contributorAdapter{
+      inner:                  contributor.inner,
+      name:                   contributor.name,
+      visits:                 contributor.visits,
+      visitsDeclarationFiles: contributor.visitsDeclarationFiles,
+    }
+    if contributor.isFormat {
+      Register(formatContributorAdapter{adapter})
       continue
     }
-    Register(contributorAdapter{inner: contributor})
+    Register(adapter)
   }
 }
 
+// contributorMetadata is the immutable host-side view of a public contributor
+// rule. Every contributor-defined metadata method is evaluated exactly once
+// behind inspectContributor's recover barrier so a broken declaration cannot
+// panic later during registry sorting or engine construction.
+type contributorMetadata struct {
+  inner                  rule.Rule
+  isFormat               bool
+  name                   string
+  visits                 []shimast.Kind
+  visitsDeclarationFiles bool
+}
+
+// inspectContributor evaluates the public rule metadata behind a recover
+// barrier. Check itself is protected separately by runRuleCheck; this function
+// covers the startup methods the engine must call before it can dispatch a
+// node. A panicking contributor is rejected as one entry while the rest of the
+// lint registry remains usable.
+func inspectContributor(contributor rule.Rule) (metadata contributorMetadata, err error) {
+  defer func() {
+    if recovered := recover(); recovered != nil {
+      err = fmt.Errorf("contributor %T metadata panicked: %v", contributor, recovered)
+    }
+  }()
+  metadata = contributorMetadata{
+    inner:                  contributor,
+    name:                   contributor.Name(),
+    visits:                 append([]shimast.Kind(nil), contributor.Visits()...),
+    visitsDeclarationFiles: true,
+  }
+  if formatRule, ok := contributor.(rule.FormatRule); ok {
+    metadata.isFormat = formatRule.IsFormat()
+  }
+  if declarationRule, ok := contributor.(rule.DeclarationFileRule); ok {
+    metadata.visitsDeclarationFiles = declarationRule.VisitsDeclarationFiles()
+  }
+  return metadata, nil
+}
+
 // contributorAdapter wraps a public `rule.Rule` so the engine's
-// `Register` accepts it. Forward `Name` and `Visits` directly; bridge
-// `Check` by constructing a `rule.Context` whose `Reporter` calls back
-// into the engine's existing `Context.Report` / `ReportRange`. The
+// `Register` accepts it. Name, Visits, and declaration-file policy are
+// cached by inspectContributor; Check bridges through a `rule.Context`
+// whose `Reporter` calls back into the engine's existing Context.Report /
+// ReportRange. The
 // public `rule.Context` and the engine's internal `Context` share the
 // same shim AST types, so no wrapping / unwrapping of nodes is needed.
 type contributorAdapter struct {
-  inner rule.Rule
+  inner                  rule.Rule
+  name                   string
+  visits                 []shimast.Kind
+  visitsDeclarationFiles bool
 }
 
 // NeedsTypeChecker keeps contributor rules on the historical checker path.
@@ -81,10 +140,7 @@ func (a contributorAdapter) NeedsTypeChecker() bool {
 // as NeedsTypeChecker: the host cannot infer a third-party rule's grammar
 // shape, and a wrong skip silently loses findings.
 func (a contributorAdapter) VisitsDeclarationFiles() bool {
-  if dr, ok := a.inner.(rule.DeclarationFileRule); ok {
-    return dr.VisitsDeclarationFiles()
-  }
-  return true
+  return a.visitsDeclarationFiles
 }
 
 // formatContributorAdapter is the FormatRule-tagged variant of
@@ -98,8 +154,8 @@ type formatContributorAdapter struct {
 
 func (formatContributorAdapter) IsFormat() bool { return true }
 
-func (a contributorAdapter) Name() string           { return a.inner.Name() }
-func (a contributorAdapter) Visits() []shimast.Kind { return a.inner.Visits() }
+func (a contributorAdapter) Name() string           { return a.name }
+func (a contributorAdapter) Visits() []shimast.Kind { return a.visits }
 func (a contributorAdapter) Check(ctx *Context, node *shimast.Node) {
   if ctx == nil {
     return

--- a/packages/lint/test/engine/contributor_rule_opt_out_skips_declaration_files_test.go
+++ b/packages/lint/test/engine/contributor_rule_opt_out_skips_declaration_files_test.go
@@ -24,15 +24,21 @@ func (declarationOptOutContributor) VisitsDeclarationFiles() bool { return false
 // adapter honors the public `rule.DeclarationFileRule` marker.
 //
 // A value-level contributor rule can return `false` to get the same
-// declaration-file dispatch skip built-in value rules enjoy; the adapter
-// must forward that answer instead of forcing the conservative default,
-// or the public marker would be dead API.
+// declaration-file dispatch skip built-in value rules enjoy; the marker
+// answer is captured by inspectContributor and must reach the adapter
+// through the production construction path, or the public marker would be
+// dead API.
 //
-// 1. Wrap a contributor rule whose marker returns false.
-// 2. Ask the engine's declaration-file predicate.
-// 3. Assert the adapter reports the skip.
+//  1. Inspect a contributor rule whose marker returns false and wrap the
+//     metadata.
+//  2. Ask the engine's declaration-file predicate.
+//  3. Assert the adapter reports the skip.
 func TestContributorRuleOptOutSkipsDeclarationFiles(t *testing.T) {
-  adapter := contributorAdapter{inner: declarationOptOutContributor{}}
+  metadata, err := inspectContributor(declarationOptOutContributor{})
+  if err != nil {
+    t.Fatalf("unexpected contributor inspection error: %v", err)
+  }
+  adapter := newContributorAdapter(metadata)
   if ruleVisitsDeclarationFiles(adapter) {
     t.Fatalf("contributor opt-out marker was ignored by the declaration-file predicate")
   }

--- a/packages/lint/test/engine/contributor_rules_visit_declaration_files_by_default_test.go
+++ b/packages/lint/test/engine/contributor_rules_visit_declaration_files_by_default_test.go
@@ -25,14 +25,20 @@ func (declarationDefaultContributor) Check(ctx *rule.Context, node *shimast.Node
 //
 // The host cannot infer a third-party rule's grammar shape, so the adapter
 // defaults conservatively — the same reasoning that keeps contributor rules
-// on the checker path via `NeedsTypeChecker`. A skip-by-default here would
-// silently change existing contributor behavior on `.d.ts` inputs.
+// on the checker path via `NeedsTypeChecker`. The policy is applied once in
+// inspectContributor, so the test builds the adapter through the production
+// construction path. A skip-by-default here would silently change existing
+// contributor behavior on `.d.ts` inputs.
 //
-// 1. Wrap a contributor rule without the marker in the adapter.
+// 1. Inspect a contributor rule without the marker and wrap the metadata.
 // 2. Ask the engine's declaration-file predicate.
 // 3. Assert the adapter reports it visits declaration files.
 func TestContributorRulesVisitDeclarationFilesByDefault(t *testing.T) {
-  adapter := contributorAdapter{inner: declarationDefaultContributor{}}
+  metadata, err := inspectContributor(declarationDefaultContributor{})
+  if err != nil {
+    t.Fatalf("unexpected contributor inspection error: %v", err)
+  }
+  adapter := newContributorAdapter(metadata)
   if !ruleVisitsDeclarationFiles(adapter) {
     t.Fatalf("contributor rule without the marker must keep visiting declaration files")
   }

--- a/packages/lint/test/plugin/contributor_metadata_panic_is_rejected_test.go
+++ b/packages/lint/test/plugin/contributor_metadata_panic_is_rejected_test.go
@@ -1,0 +1,38 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestContributorMetadataPanicIsRejected verifies contributor metadata panics
+// are converted to one rejected registration instead of escaping startup.
+//
+// Contributor methods run before the engine can dispatch Check, so the normal
+// per-node panic barrier cannot protect Name or Visits. inspectContributor owns
+// that earlier boundary and must return an actionable error without panicking.
+//
+//  1. Construct a public contributor whose Name method panics.
+//  2. Inspect its metadata through the host adapter.
+//  3. Assert the panic becomes an error naming the contributor failure.
+func TestContributorMetadataPanicIsRejected(t *testing.T) {
+  _, err := inspectContributor(metadataPanickingContributor{})
+  if err == nil {
+    t.Fatal("expected contributor metadata panic to be rejected")
+  }
+  if !strings.Contains(err.Error(), "metadata panicked: metadata boom") {
+    t.Fatalf("unexpected contributor metadata error: %v", err)
+  }
+}
+
+type metadataPanickingContributor struct{}
+
+func (metadataPanickingContributor) Name() string { panic("metadata boom") }
+func (metadataPanickingContributor) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindSourceFile}
+}
+func (metadataPanickingContributor) Check(_ *publicrule.Context, _ *shimast.Node) {}

--- a/packages/lint/test/plugin/contributor_metadata_panic_is_rejected_test.go
+++ b/packages/lint/test/plugin/contributor_metadata_panic_is_rejected_test.go
@@ -20,19 +20,48 @@ import (
 //  2. Inspect its metadata through the host adapter.
 //  3. Assert the panic becomes an error naming the contributor failure.
 func TestContributorMetadataPanicIsRejected(t *testing.T) {
-  _, err := inspectContributor(metadataPanickingContributor{})
-  if err == nil {
-    t.Fatal("expected contributor metadata panic to be rejected")
-  }
-  if !strings.Contains(err.Error(), "metadata panicked: metadata boom") {
-    t.Fatalf("unexpected contributor metadata error: %v", err)
+  for _, method := range []string{
+    "Name",
+    "Visits",
+    "IsFormat",
+    "VisitsDeclarationFiles",
+  } {
+    t.Run(method, func(t *testing.T) {
+      _, err := inspectContributor(metadataPanickingContributor{method: method})
+      if err == nil {
+        t.Fatal("expected contributor metadata panic to be rejected")
+      }
+      if !strings.Contains(err.Error(), "metadata panicked: "+method+" boom") {
+        t.Fatalf("unexpected contributor metadata error: %v", err)
+      }
+    })
   }
 }
 
-type metadataPanickingContributor struct{}
+type metadataPanickingContributor struct{ method string }
 
-func (metadataPanickingContributor) Name() string { panic("metadata boom") }
-func (metadataPanickingContributor) Visits() []shimast.Kind {
+func (r metadataPanickingContributor) Name() string {
+  if r.method == "Name" {
+    panic("Name boom")
+  }
+  return "test/metadata-panic"
+}
+func (r metadataPanickingContributor) Visits() []shimast.Kind {
+  if r.method == "Visits" {
+    panic("Visits boom")
+  }
   return []shimast.Kind{shimast.KindSourceFile}
 }
 func (metadataPanickingContributor) Check(_ *publicrule.Context, _ *shimast.Node) {}
+func (r metadataPanickingContributor) IsFormat() bool {
+  if r.method == "IsFormat" {
+    panic("IsFormat boom")
+  }
+  return false
+}
+func (r metadataPanickingContributor) VisitsDeclarationFiles() bool {
+  if r.method == "VisitsDeclarationFiles" {
+    panic("VisitsDeclarationFiles boom")
+  }
+  return true
+}

--- a/packages/lint/test/plugin/engine_requires_type_checker_for_contributor_rule_test.go
+++ b/packages/lint/test/plugin/engine_requires_type_checker_for_contributor_rule_test.go
@@ -15,11 +15,15 @@ import (
 // AST-only marker. Treating them as checker-free would be a correctness risk
 // for third-party rules that already read ctx.Checker.
 //
-// 1. Wrap a synthetic public contributor rule in contributorAdapter.
+// 1. Inspect a synthetic public contributor rule and wrap the metadata.
 // 2. Ask the internal checker gate about that wrapped rule.
 // 3. Assert the rule is treated as type-aware.
 func TestEngineRequiresTypeCheckerForContributorRule(t *testing.T) {
-  adapter := contributorAdapter{inner: contributorCheckerGateRule{}}
+  metadata, err := inspectContributor(contributorCheckerGateRule{})
+  if err != nil {
+    t.Fatalf("unexpected contributor inspection error: %v", err)
+  }
+  adapter := newContributorAdapter(metadata)
   if !ruleNeedsTypeChecker(adapter) {
     t.Fatal("contributor adapter did not request a type checker")
   }

--- a/packages/ttsc/src/TtscCompiler.ts
+++ b/packages/ttsc/src/TtscCompiler.ts
@@ -132,8 +132,9 @@ export class TtscCompiler {
    * directory before returning.
    *
    * The result uses an `embed-typescript`-style discriminated union: `success`
-   * for clean compiles, `failure` for normal compiler diagnostics, and
-   * `exception` for host setup or process failures.
+   * for clean compiles, `failure` for compiler diagnostics or plugin failures
+   * that reached the build pipeline, and `exception` for host failures that
+   * prevent any project check from running.
    *
    * @returns Structured compilation result containing diagnostics or output.
    */

--- a/packages/ttsc/src/TtscCompiler.ts
+++ b/packages/ttsc/src/TtscCompiler.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { compileProjectInMemory } from "./compiler/internal/compileProjectInMemory";
 import { resolveProjectConfig } from "./compiler/internal/project/resolveProjectConfig";
 import { resolveBinary } from "./compiler/internal/resolveBinary";
+import { createProcessDiagnostic } from "./compiler/internal/runBuild";
 import { transformProjectInMemory } from "./compiler/internal/transformProjectInMemory";
 import { resolveCleanTargets } from "./plugin/internal/buildSourcePlugin";
 import { loadProjectPlugins } from "./plugin/internal/loadProjectPlugins";
@@ -345,20 +346,6 @@ function toCompilerResult(project: ProjectResult): ITtscCompilerResult {
         : result.diagnostics,
     output,
     type: "failure",
-  };
-}
-
-function createProcessDiagnostic(
-  result: TtscBuildResult,
-): ITtscCompilerDiagnostic {
-  const messageText =
-    (result.stderr || result.stdout).trim() ||
-    `ttsc exited with status ${result.status}`;
-  return {
-    category: "error",
-    code: "TTSC_PROCESS",
-    file: null,
-    messageText,
   };
 }
 

--- a/packages/ttsc/src/compiler/internal/compileProjectInMemory.ts
+++ b/packages/ttsc/src/compiler/internal/compileProjectInMemory.ts
@@ -36,7 +36,7 @@ export function compileProjectInMemory(options: ITtscCompilerContext): {
     projectRoot: options.projectRoot,
     tsconfig: options.tsconfig,
   });
-  if (hasConfiguredPlugins(options, project)) {
+  if (shouldUsePluginBuild(options, project)) {
     return compileProjectWithPlugins(options, cwd, project);
   }
   const tsconfig = project.path;
@@ -80,6 +80,22 @@ function hasConfiguredPlugins(
   project: ITtscParsedProjectConfig,
 ): boolean {
   return hasProjectPluginEntries(project, options.plugins);
+}
+
+/**
+ * Route plugin discovery failures through runBuild's recoverable setup path.
+ * The fast native-host lane cannot surface the plugin error or run the
+ * post-failure TypeScript check, while the plugin-backed lane can do both.
+ */
+function shouldUsePluginBuild(
+  options: ITtscCompilerContext,
+  project: ITtscParsedProjectConfig,
+): boolean {
+  try {
+    return hasConfiguredPlugins(options, project);
+  } catch {
+    return true;
+  }
 }
 
 /**

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -170,7 +170,11 @@ function runBuildTimed(
     );
     const checked = runNativeCheckPlugins(buildOptions, execution, timing);
     if (checked.status !== 0) {
-      return checked;
+      return appendTypeScriptDiagnosticsAfterPluginFailure(
+        checked,
+        buildOptions,
+        execution,
+      );
     }
 
     if (buildOptions.emit === false) {
@@ -191,15 +195,20 @@ function runBuildTimed(
       }
       if (compilers.length !== 0) {
         assertSharedHostCompatibility(compilers, "emit");
-        return appendBuildOutput(
-          checked,
-          buildWithNativeCompilerPlugins(
-            buildOptions,
-            execution,
-            compilers,
-            timing,
-          ),
+        const compiled = buildWithNativeCompilerPlugins(
+          buildOptions,
+          execution,
+          compilers,
+          timing,
         );
+        const result = appendBuildOutput(checked, compiled);
+        return compiled.status === 0
+          ? result
+          : appendTypeScriptDiagnosticsAfterPluginFailure(
+              result,
+              buildOptions,
+              execution,
+            );
       }
       if (checkPluginsReportTypeScriptDiagnostics(execution.nativePlugins)) {
         return checked;
@@ -213,15 +222,20 @@ function runBuildTimed(
     let result: TtscBuildResult;
     if (compilers.length !== 0) {
       assertSharedHostCompatibility(compilers, "emit");
-      result = appendBuildOutput(
-        checked,
-        buildWithNativeCompilerPlugins(
+      const compiled = buildWithNativeCompilerPlugins(
+        buildOptions,
+        execution,
+        compilers,
+        timing,
+      );
+      result = appendBuildOutput(checked, compiled);
+      if (compiled.status !== 0) {
+        result = appendTypeScriptDiagnosticsAfterPluginFailure(
+          result,
           buildOptions,
           execution,
-          compilers,
-          timing,
-        ),
-      );
+        );
+      }
     } else {
       if (
         buildOptions.skipDiagnosticsCheck !== true &&
@@ -293,6 +307,87 @@ function checkPluginsReportTypeScriptDiagnostics(
     (plugin) =>
       plugin.stage === "check" && plugin.reportsTypeScriptDiagnostics === true,
   );
+}
+
+/**
+ * Preserve a failed plugin's output and status while collecting TypeScript
+ * diagnostics through an independent no-emit pass.
+ *
+ * A sidecar can fail before it loads the project Program, including when a Go
+ * panic or another runtime error terminates the process. The plugin failure
+ * must still block emit, but it must not hide unrelated errors in the user's
+ * TypeScript source. The fallback runs only after a plugin failure, skips modes
+ * whose contract intentionally omits diagnostics, and avoids appending a batch
+ * the plugin already reported itself.
+ */
+function appendTypeScriptDiagnosticsAfterPluginFailure(
+  failure: TtscBuildResult,
+  options: RunBuildOptions,
+  execution: ReturnType<typeof resolveExecutionContext>,
+): TtscBuildResult {
+  if (
+    options.format === true ||
+    options.skipDiagnosticsCheck === true ||
+    forwardsTerminalTsgoFlag(options)
+  ) {
+    return failure;
+  }
+  const typechecked = runTsgo(execution, ["--noEmit"], options);
+  if (!hasMissingTypeScriptDiagnostics(failure, typechecked)) {
+    return failure;
+  }
+  const status = failure.status;
+  return {
+    ...appendBuildOutput(failure, typechecked),
+    status,
+  };
+}
+
+/** Return true when the fallback check contributes diagnostics or raw failure. */
+function hasMissingTypeScriptDiagnostics(
+  failure: TtscBuildResult,
+  typechecked: TtscBuildResult,
+): boolean {
+  if (typechecked.diagnostics.length === 0) {
+    return typechecked.status !== 0;
+  }
+  return typechecked.diagnostics.some(
+    (diagnostic) =>
+      !failure.diagnostics.some((existing) =>
+        compilerDiagnosticsEqual(existing, diagnostic),
+      ),
+  );
+}
+
+/** Compare normalized compiler diagnostics before appending fallback output. */
+function compilerDiagnosticsEqual(
+  left: ITtscCompilerDiagnostic,
+  right: ITtscCompilerDiagnostic,
+): boolean {
+  return (
+    left.category === right.category &&
+    left.code === right.code &&
+    left.file === right.file &&
+    diagnosticPositionsEqual(left, right) &&
+    diagnosticHeadline(left.messageText) ===
+      diagnosticHeadline(right.messageText)
+  );
+}
+
+/** Compare offsets when available, otherwise compare rendered line/column. */
+function diagnosticPositionsEqual(
+  left: ITtscCompilerDiagnostic,
+  right: ITtscCompilerDiagnostic,
+): boolean {
+  if (left.start !== undefined && right.start !== undefined) {
+    return left.start === right.start;
+  }
+  return left.line === right.line && left.character === right.character;
+}
+
+/** Remove pretty-rendered source context from a diagnostic message. */
+function diagnosticHeadline(message: string): string {
+  return message.split(/\r?\n/, 1)[0]!.trim();
 }
 
 /**

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -355,9 +355,18 @@ function appendTypeScriptDiagnosticsAfterPluginFailure(
   if (fallback === null) {
     return failure;
   }
+  // Structured consumers (the public API's `IFailure.diagnostics`) never see
+  // stdout/stderr, so a plugin failure that reported no parsable diagnostics
+  // must be seeded as one before recovered TypeScript diagnostics are appended
+  // — otherwise the recovery would replace the plugin error with unrelated
+  // type errors instead of surfacing both.
+  const seeded =
+    failure.diagnostics.length === 0
+      ? { ...failure, diagnostics: [createProcessDiagnostic(failure)] }
+      : failure;
   const status = failure.status;
   return {
-    ...appendBuildOutput(failure, fallback),
+    ...appendBuildOutput(seeded, fallback),
     status,
   };
 }
@@ -1022,6 +1031,26 @@ export function appendBuildOutput(
     stdout: left.stdout + right.stdout,
     stderr: left.stderr + right.stderr,
   });
+}
+
+/**
+ * Synthesize one structured diagnostic from a non-zero process result that
+ * produced no parsable diagnostics, carrying the captured stderr/stdout as the
+ * message. Shared by the public API result mapping and the plugin-failure
+ * recovery pass so the failure text is never dropped from structured output.
+ */
+export function createProcessDiagnostic(
+  result: TtscBuildResult,
+): ITtscCompilerDiagnostic {
+  const messageText =
+    (result.stderr || result.stdout).trim() ||
+    `ttsc exited with status ${result.status}`;
+  return {
+    category: "error",
+    code: "TTSC_PROCESS",
+    file: null,
+    messageText,
+  };
 }
 
 /**

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -332,31 +332,100 @@ function appendTypeScriptDiagnosticsAfterPluginFailure(
   ) {
     return failure;
   }
-  const typechecked = runTsgo(execution, ["--noEmit"], options);
-  if (!hasMissingTypeScriptDiagnostics(failure, typechecked)) {
+  const typechecked = runTsgo(
+    execution,
+    ["--noEmit"],
+    createPluginFailureTypecheckOptions(options),
+  );
+  const fallback = filterReportedTypeScriptDiagnostics(
+    failure,
+    typechecked,
+    execution.projectRoot,
+  );
+  if (fallback === null) {
     return failure;
   }
   const status = failure.status;
   return {
-    ...appendBuildOutput(failure, typechecked),
+    ...appendBuildOutput(failure, fallback),
     status,
   };
 }
 
-/** Return true when the fallback check contributes diagnostics or raw failure. */
-function hasMissingTypeScriptDiagnostics(
+/**
+ * Make the recovery pass parseable regardless of the user's display flags. This
+ * is an internal second pass, so plain output is required to remove only
+ * diagnostics that the failed plugin already printed.
+ */
+function createPluginFailureTypecheckOptions(
+  options: RunBuildOptions,
+): RunBuildOptions {
+  const passthrough: string[] = [];
+  for (let i = 0; i < (options.passthrough?.length ?? 0); i++) {
+    const token = options.passthrough![i]!;
+    if (token === "--pretty") {
+      if (isBooleanLiteral(options.passthrough![i + 1] ?? "")) i++;
+      continue;
+    }
+    if (token.startsWith("--pretty=")) continue;
+    passthrough.push(token);
+  }
+  return {
+    ...options,
+    passthrough,
+    structuredDiagnostics: true,
+  };
+}
+
+/** Return only fallback diagnostics the failed plugin did not already report. */
+function filterReportedTypeScriptDiagnostics(
   failure: TtscBuildResult,
   typechecked: TtscBuildResult,
-): boolean {
+  cwd: string,
+): TtscBuildResult | null {
   if (typechecked.diagnostics.length === 0) {
-    return typechecked.status !== 0;
+    return typechecked.status === 0 ? null : typechecked;
   }
-  return typechecked.diagnostics.some(
+  const diagnostics = typechecked.diagnostics.filter(
     (diagnostic) =>
       !failure.diagnostics.some((existing) =>
         compilerDiagnosticsEqual(existing, diagnostic),
       ),
   );
+  if (diagnostics.length === 0) return null;
+  if (diagnostics.length === typechecked.diagnostics.length) return typechecked;
+  return {
+    ...typechecked,
+    diagnostics,
+    stderr: filterCompilerDiagnosticText(typechecked.stderr, diagnostics, cwd),
+    stdout: filterCompilerDiagnosticText(typechecked.stdout, diagnostics, cwd),
+  };
+}
+
+/** Remove diagnostic lines absent from the selected structured result. */
+function filterCompilerDiagnosticText(
+  text: string,
+  diagnostics: readonly ITtscCompilerDiagnostic[],
+  cwd: string,
+): string {
+  const out: string[] = [];
+  let keepContinuation = true;
+  for (const line of text.split(/\r?\n/)) {
+    const plain = stripAnsi(line);
+    const diagnostic = parseDiagnosticLine(plain, cwd);
+    if (diagnostic !== null) {
+      keepContinuation = diagnostics.some((selected) =>
+        compilerDiagnosticsEqual(selected, diagnostic),
+      );
+      if (keepContinuation) out.push(line);
+      continue;
+    }
+    if (/^Found\s+\d+\s+errors?/i.test(plain)) continue;
+    if (!keepContinuation && /^\s+/.test(line)) continue;
+    keepContinuation = true;
+    out.push(line);
+  }
+  return out.join("\n");
 }
 
 /** Compare normalized compiler diagnostics before appending fallback output. */

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -160,10 +160,20 @@ function runBuildTimed(
 ): TtscBuildResult {
   const setupStartedAt = process.hrtime.bigint();
   const execution = resolveExecutionContext(options);
-  if (execution.nativePlugins.length > 0) {
+  if (
+    execution.nativePlugins.length > 0 ||
+    execution.pluginSetupFailure !== undefined
+  ) {
     recordTiming(timing, "ttsc plugin setup time", setupStartedAt);
   }
   const buildOptions = applyProjectNoEmit(options, execution);
+  if (execution.pluginSetupFailure !== undefined) {
+    return appendTypeScriptDiagnosticsAfterPluginFailure(
+      execution.pluginSetupFailure,
+      buildOptions,
+      execution,
+    );
+  }
   if (execution.nativePlugins.length > 0) {
     const compilers = execution.nativePlugins.filter(
       (plugin) => plugin.stage === "transform",
@@ -1031,20 +1041,31 @@ function resolveExecutionContext(
   const tsconfig = project.path;
   const projectRoot = project.root;
   const tsgo = resolveTsgo({ ...options, cwd: projectRoot });
-  const hasPlugins = hasProjectPluginEntries(project, options.plugins);
-  const loaded = hasPlugins
-    ? loadProjectPlugins({
+  let pluginSetupFailure: TtscBuildResult | undefined;
+  let nativePlugins: ITtscLoadedNativePlugin[] = [];
+  try {
+    if (hasProjectPluginEntries(project, options.plugins)) {
+      nativePlugins = loadProjectPlugins({
         binary: resolveBinary(options) ?? "",
         cacheDir: options.cacheDir ?? options.env?.TTSC_CACHE_DIR,
         cwd,
         entries: options.plugins,
         projectRoot,
         tsconfig,
-      })
-    : { nativePlugins: [] };
+      }).nativePlugins;
+    }
+  } catch (error) {
+    pluginSetupFailure = {
+      diagnostics: [],
+      status: 2,
+      stdout: "",
+      stderr: `${error instanceof Error ? error.message : String(error)}\n`,
+    };
+  }
   return {
     cwd,
-    nativePlugins: loaded.nativePlugins,
+    nativePlugins,
+    pluginSetupFailure,
     projectNoEmit: project.compilerOptions.noEmit === true,
     projectRoot,
     rewriteRelativeImportExtensionsForEmit:

--- a/packages/ttsc/src/structures/ITtscCompilerResult.ts
+++ b/packages/ttsc/src/structures/ITtscCompilerResult.ts
@@ -47,12 +47,14 @@ export namespace ITtscCompilerResult {
   }
 
   /**
-   * Represents a ttsc compilation that completed but had diagnostics.
+   * Represents a ttsc compilation that completed with diagnostics or a
+   * recoverable plugin failure.
    *
    * This interface is returned when the compiler reports errors, warnings, or
-   * other diagnostics during normal compilation. It contains both structured
-   * diagnostic information and any output that was still generated despite the
-   * diagnostics.
+   * other diagnostics during normal compilation, or when a plugin failure can
+   * be retained as a build result while an independent TypeScript check runs.
+   * It contains both structured diagnostic information and any output that was
+   * still generated despite the failure.
    */
   export interface IFailure {
     /** Indicates that compilation completed with diagnostics. */
@@ -86,7 +88,8 @@ export namespace ITtscCompilerResult {
      * pattern-matching error messages. Omitted when ttsc cannot determine the
      * origin. Treat as `"unknown"` when missing.
      *
-     * - `"plugin"`: a native plugin sidecar crashed or exited non-zero.
+     * - `"plugin"`: plugin preparation failed before a build result could be
+     *   recovered.
      * - `"host"`: the TypeScript-Go host could not start (missing binary, cache
      *   lock, invalid config).
      * - `"unknown"`: any other host-level failure.

--- a/tests/test-lint/src/native-plugins/config/test_lint_contributor_panics_do_not_abort_other_rules.ts
+++ b/tests/test-lint/src/native-plugins/config/test_lint_contributor_panics_do_not_abort_other_rules.ts
@@ -1,0 +1,89 @@
+import {
+  assert,
+  createLintProject,
+  runLintProject,
+} from "../../internal/config-file";
+
+/**
+ * Verifies lint contributor panics do not abort other rules.
+ *
+ * Third-party contributors are statically linked into the @ttsc/lint binary, so
+ * both their startup metadata and Check callbacks execute inside the host
+ * process. Recoverable panics must disable only the broken registration or
+ * become a rule diagnostic while healthy contributor and built-in rules keep
+ * running.
+ *
+ * 1. Register one metadata-panicking, one Check-panicking, and one healthy rule.
+ * 2. Enable the two runnable contributor rules together with built-in no-var.
+ * 3. Run ttsc and assert every recoverable failure is isolated.
+ * 4. Assert the healthy contributor and built-in rule still report findings.
+ */
+export const test_lint_contributor_panics_do_not_abort_other_rules = () => {
+  const project = createLintProject({
+    name: "contributor-panic-isolation",
+    source: "var legacy = 1;\nvoid legacy;\n",
+    pluginConfig: { configFile: "./lint.config.cjs" },
+    extraSources: {
+      "lint.config.cjs": `const path = require("node:path");
+module.exports = {
+  plugins: {
+    broken: { source: path.resolve(__dirname, "contributor") },
+  },
+  rules: {
+    "broken/check-panic": "error",
+    "broken/healthy": "error",
+    "no-var": "error",
+  },
+};
+`,
+      "contributor/rules.go": [
+        "package broken",
+        "",
+        "import (",
+        '\tshimast "github.com/microsoft/typescript-go/shim/ast"',
+        '\t"github.com/samchon/ttsc/packages/lint/rule"',
+        ")",
+        "",
+        "func init() {",
+        "\trule.Register(metadataPanicRule{})",
+        "\trule.Register(checkPanicRule{})",
+        "\trule.Register(healthyRule{})",
+        "}",
+        "",
+        "type metadataPanicRule struct{}",
+        'func (metadataPanicRule) Name() string { panic("metadata boom") }',
+        "func (metadataPanicRule) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindVariableStatement} }",
+        "func (metadataPanicRule) Check(*rule.Context, *shimast.Node) {}",
+        "",
+        "type checkPanicRule struct{}",
+        'func (checkPanicRule) Name() string { return "broken/check-panic" }',
+        "func (checkPanicRule) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindVariableStatement} }",
+        'func (checkPanicRule) Check(*rule.Context, *shimast.Node) { panic("check boom") }',
+        "",
+        "type healthyRule struct{}",
+        'func (healthyRule) Name() string { return "broken/healthy" }',
+        "func (healthyRule) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindVariableStatement} }",
+        'func (healthyRule) Check(ctx *rule.Context, node *shimast.Node) { ctx.Report(node, "healthy contributor ran") }',
+        "",
+      ].join("\n"),
+    },
+  });
+  try {
+    const result = runLintProject(project.tmpdir);
+    assert.notEqual(result.status, 0, result.stderr);
+    assert.match(
+      result.stderr,
+      /contributor .*metadata panicked: metadata boom; dropping contributor entry/,
+    );
+    assert.doesNotMatch(result.stderr, /panic: metadata boom/);
+
+    const rules = new Set(
+      result.diagnostics.map((diagnostic) => diagnostic.rule),
+    );
+    assert.equal(rules.has("broken/check-panic"), true, result.stderr);
+    assert.equal(rules.has("broken/healthy"), true, result.stderr);
+    assert.equal(rules.has("no-var"), true, result.stderr);
+  } finally {
+    project.cleanup();
+  }
+};

--- a/tests/test-ttsc/src/features/api/test_ttsccompiler_compile_recovers_typescript_diagnostics_from_plugin_setup_failure.ts
+++ b/tests/test-ttsc/src/features/api/test_ttsccompiler_compile_recovers_typescript_diagnostics_from_plugin_setup_failure.ts
@@ -15,11 +15,15 @@ import {
  * Plugin presence is probed before the API selects its native-host or
  * plugin-backed path. A descriptor/source-build failure must still reach the
  * recoverable runBuild path, otherwise compile returns an exception before the
- * independent TypeScript check can expose source errors.
+ * independent TypeScript check can expose source errors. The plugin failure
+ * itself must stay visible as a `TTSC_PROCESS` diagnostic: embedders read
+ * `IFailure.diagnostics`, not stderr, so recovered type errors must not replace
+ * the plugin error.
  *
  * 1. Create a project with a TS2322 error and a source plugin.
  * 2. Corrupt the plugin's Go source so setup fails before its sidecar runs.
  * 3. Assert compile returns failure with the pure TypeScript diagnostic.
+ * 4. Assert the plugin build failure is retained as a TTSC_PROCESS diagnostic.
  */
 export const test_ttsccompiler_compile_recovers_typescript_diagnostics_from_plugin_setup_failure =
   () => {
@@ -42,6 +46,14 @@ export const test_ttsccompiler_compile_recovers_typescript_diagnostics_from_plug
     assert.equal(result.type, "failure");
     assert.equal(
       result.diagnostics.some((diagnostic) => diagnostic.code === 2322),
+      true,
+    );
+    assert.equal(
+      result.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.code === "TTSC_PROCESS" &&
+          /building plugin/.test(diagnostic.messageText),
+      ),
       true,
     );
   };

--- a/tests/test-ttsc/src/features/api/test_ttsccompiler_compile_recovers_typescript_diagnostics_from_plugin_setup_failure.ts
+++ b/tests/test-ttsc/src/features/api/test_ttsccompiler_compile_recovers_typescript_diagnostics_from_plugin_setup_failure.ts
@@ -1,0 +1,47 @@
+import {
+  TtscCompiler,
+  assert,
+  createProject,
+  fs,
+  path,
+  tsgo,
+  writeSourcePlugin,
+} from "../../internal/compiler";
+
+/**
+ * Verifies TtscCompiler.compile recovers TypeScript diagnostics from plugin
+ * setup failure.
+ *
+ * Plugin presence is probed before the API selects its native-host or
+ * plugin-backed path. A descriptor/source-build failure must still reach the
+ * recoverable runBuild path, otherwise compile returns an exception before the
+ * independent TypeScript check can expose source errors.
+ *
+ * 1. Create a project with a TS2322 error and a source plugin.
+ * 2. Corrupt the plugin's Go source so setup fails before its sidecar runs.
+ * 3. Assert compile returns failure with the pure TypeScript diagnostic.
+ */
+export const test_ttsccompiler_compile_recovers_typescript_diagnostics_from_plugin_setup_failure =
+  () => {
+    const root = createProject({
+      plugins: [{ transform: "./plugin.cjs" }],
+      source: 'const wrong: number = "type-error";\nvoid wrong;\n',
+    });
+    writeSourcePlugin(root);
+    const goFile = path.join(root, "plugin-go", "main.go");
+    fs.writeFileSync(
+      goFile,
+      fs
+        .readFileSync(goFile, "utf8")
+        .replace("package main", "package main\nthis is not valid go;"),
+      "utf8",
+    );
+
+    const result = new TtscCompiler({ binary: tsgo, cwd: root }).compile();
+
+    assert.equal(result.type, "failure");
+    assert.equal(
+      result.diagnostics.some((diagnostic) => diagnostic.code === 2322),
+      true,
+    );
+  };

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_check_plugin_runtime_failure_preserves_typescript_diagnostics.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_check_plugin_runtime_failure_preserves_typescript_diagnostics.ts
@@ -16,10 +16,10 @@ import {
  * independent no-emit TypeScript check, otherwise an internal plugin bug hides
  * unrelated errors in the user's source code.
  *
- * 1. Write a source file with a genuine TS2322 type error.
- * 2. Register a check-stage Go plugin that exits 3 with a runtime error.
+ * 1. Write a source file with two genuine TS2322 type errors.
+ * 2. Register a check-stage Go plugin that reports one error, then exits 3.
  * 3. Run ttsc with `--noEmit`.
- * 4. Assert the plugin failure, original status, and TS2322 all surface.
+ * 4. Assert the failure/status survive and both TS errors occur exactly once.
  */
 export const test_plugin_corpus_check_plugin_runtime_failure_preserves_typescript_diagnostics =
   () => {
@@ -42,13 +42,19 @@ export const test_plugin_corpus_check_plugin_runtime_failure_preserves_typescrip
           "",
           "func main() {",
           '\tif len(os.Args) > 1 && os.Args[1] == "check" {',
+          "\t\tfmt.Fprintln(os.Stderr, \"src/main.ts:1:7 - error TS2322: Type 'string' is not assignable to type 'number'.\")",
           '\t\tfmt.Fprintln(os.Stderr, "check plugin crashed")',
           "\t\tos.Exit(3)",
           "\t}",
           "}",
           "",
         ].join("\n"),
-        "src/main.ts": `const value: number = "type-error";\nconsole.log(value);\n`,
+        "src/main.ts": [
+          `const first: number = "first-error";`,
+          `const second: number = "second-error";`,
+          "console.log(first, second);",
+          "",
+        ].join("\n"),
       },
       {
         compilerOptions: {
@@ -66,5 +72,5 @@ export const test_plugin_corpus_check_plugin_runtime_failure_preserves_typescrip
 
     assert.equal(result.status, 3);
     assert.match(result.stderr, /check plugin crashed/);
-    assert.match(result.stderr, /TS2322/);
+    assert.equal(result.stderr.match(/TS2322/g)?.length, 2, result.stderr);
   };

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_check_plugin_runtime_failure_preserves_typescript_diagnostics.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_check_plugin_runtime_failure_preserves_typescript_diagnostics.ts
@@ -1,0 +1,70 @@
+import { SHARED_PLUGIN_CACHE_DIR } from "../../internal/plugin-cache";
+import {
+  assert,
+  commonJsProject,
+  goPath,
+  spawn,
+  ttscBin,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: check plugin runtime failure preserves TypeScript
+ * diagnostics.
+ *
+ * A check-stage sidecar can fail before it has loaded the project Program. The
+ * host must keep the sidecar's failure output and status while still running an
+ * independent no-emit TypeScript check, otherwise an internal plugin bug hides
+ * unrelated errors in the user's source code.
+ *
+ * 1. Write a source file with a genuine TS2322 type error.
+ * 2. Register a check-stage Go plugin that exits 3 with a runtime error.
+ * 3. Run ttsc with `--noEmit`.
+ * 4. Assert the plugin failure, original status, and TS2322 all surface.
+ */
+export const test_plugin_corpus_check_plugin_runtime_failure_preserves_typescript_diagnostics =
+  () => {
+    const root = commonJsProject(
+      {
+        "plugins/check.cjs": `module.exports = (context) => ({
+        name: "failing-check",
+        source: require("node:path").resolve(context.dirname, "check-go"),
+        stage: "check",
+      });\n`,
+        "plugins/check-go/go.mod":
+          "module example.com/failingcheck\n\ngo 1.26\n",
+        "plugins/check-go/main.go": [
+          "package main",
+          "",
+          "import (",
+          '\t"fmt"',
+          '\t"os"',
+          ")",
+          "",
+          "func main() {",
+          '\tif len(os.Args) > 1 && os.Args[1] == "check" {',
+          '\t\tfmt.Fprintln(os.Stderr, "check plugin crashed")',
+          "\t\tos.Exit(3)",
+          "\t}",
+          "}",
+          "",
+        ].join("\n"),
+        "src/main.ts": `const value: number = "type-error";\nconsole.log(value);\n`,
+      },
+      {
+        compilerOptions: {
+          plugins: [{ transform: "./plugins/check.cjs" }],
+        },
+      },
+    );
+    const result = spawn(ttscBin, ["--cwd", root, "--noEmit"], {
+      cwd: root,
+      env: {
+        PATH: goPath(),
+        TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
+      },
+    });
+
+    assert.equal(result.status, 3);
+    assert.match(result.stderr, /check plugin crashed/);
+    assert.match(result.stderr, /TS2322/);
+  };

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_transform_plugin_runtime_failure_preserves_typescript_diagnostics.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_transform_plugin_runtime_failure_preserves_typescript_diagnostics.ts
@@ -1,0 +1,67 @@
+import { SHARED_PLUGIN_CACHE_DIR } from "../../internal/plugin-cache";
+import {
+  assert,
+  commonJsProject,
+  goPath,
+  spawn,
+  ttscBin,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: transform plugin runtime failure preserves TypeScript
+ * diagnostics.
+ *
+ * A transform-stage sidecar owns the compiler process and can terminate before
+ * its normal Program diagnostics run. ttsc must retain that runtime failure but
+ * perform an independent no-emit check so the broken plugin cannot conceal
+ * errors in the project it was asked to compile.
+ *
+ * 1. Write a source file with a genuine TS2322 type error.
+ * 2. Register a transform-stage Go plugin that exits 3 from every command.
+ * 3. Run a normal emitting ttsc build.
+ * 4. Assert the plugin failure, original status, and TS2322 all surface.
+ */
+export const test_plugin_corpus_transform_plugin_runtime_failure_preserves_typescript_diagnostics =
+  () => {
+    const root = commonJsProject(
+      {
+        "plugins/transform.cjs": `module.exports = (context) => ({
+        name: "failing-transform",
+        source: require("node:path").resolve(context.dirname, "transform-go"),
+      });\n`,
+        "plugins/transform-go/go.mod":
+          "module example.com/failingtransform\n\ngo 1.26\n",
+        "plugins/transform-go/main.go": [
+          "package main",
+          "",
+          "import (",
+          '\t"fmt"',
+          '\t"os"',
+          ")",
+          "",
+          "func main() {",
+          '\tfmt.Fprintln(os.Stderr, "transform plugin crashed")',
+          "\tos.Exit(3)",
+          "}",
+          "",
+        ].join("\n"),
+        "src/main.ts": `const value: number = "type-error";\nconsole.log(value);\n`,
+      },
+      {
+        compilerOptions: {
+          plugins: [{ transform: "./plugins/transform.cjs" }],
+        },
+      },
+    );
+    const result = spawn(ttscBin, ["--cwd", root], {
+      cwd: root,
+      env: {
+        PATH: goPath(),
+        TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
+      },
+    });
+
+    assert.equal(result.status, 3);
+    assert.match(result.stderr, /transform plugin crashed/);
+    assert.match(result.stderr, /TS2322/);
+  };

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_transform_plugin_runtime_failure_preserves_typescript_diagnostics.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_transform_plugin_runtime_failure_preserves_typescript_diagnostics.ts
@@ -18,8 +18,8 @@ import {
  *
  * 1. Write a source file with a genuine TS2322 type error.
  * 2. Register a transform-stage Go plugin that exits 3 from every command.
- * 3. Run a normal emitting ttsc build.
- * 4. Assert the plugin failure, original status, and TS2322 all surface.
+ * 3. Run both normal emitting and explicit no-emit ttsc builds.
+ * 4. Assert the plugin failure, original status, and TS2322 always surface.
  */
 export const test_plugin_corpus_transform_plugin_runtime_failure_preserves_typescript_diagnostics =
   () => {
@@ -53,15 +53,20 @@ export const test_plugin_corpus_transform_plugin_runtime_failure_preserves_types
         },
       },
     );
-    const result = spawn(ttscBin, ["--cwd", root], {
-      cwd: root,
-      env: {
-        PATH: goPath(),
-        TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
-      },
-    });
+    for (const args of [
+      ["--cwd", root],
+      ["--cwd", root, "--noEmit"],
+    ]) {
+      const result = spawn(ttscBin, args, {
+        cwd: root,
+        env: {
+          PATH: goPath(),
+          TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
+        },
+      });
 
-    assert.equal(result.status, 3);
-    assert.match(result.stderr, /transform plugin crashed/);
-    assert.match(result.stderr, /TS2322/);
+      assert.equal(result.status, 3);
+      assert.match(result.stderr, /transform plugin crashed/);
+      assert.match(result.stderr, /TS2322/);
+    }
   };

--- a/tests/test-ttsc/src/native-plugins/corpus-source/test_plugin_corpus_source_plugin_build_failure_reports_go_compiler_stderr.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-source/test_plugin_corpus_source_plugin_build_failure_reports_go_compiler_stderr.ts
@@ -20,11 +20,9 @@ import {
  * silent failure would leave users with only a non-zero exit code and no
  * actionable information.
  *
- * 1. Copy the `go-source-plugin` fixture and inject a Go syntax error into
- *    `go-plugin/main.go`.
+ * 1. Copy the fixture, inject a Go syntax error, and add a TS2322 source error.
  * 2. Run ttsc with `--emit`.
- * 3. Assert non-zero exit and a message containing `building plugin
- *    "go-source-plugin" via "go build" failed` in stderr.
+ * 3. Assert both the plugin build failure and TS2322 remain visible.
  */
 export const test_plugin_corpus_source_plugin_build_failure_reports_go_compiler_stderr =
   () => {
@@ -35,6 +33,11 @@ export const test_plugin_corpus_source_plugin_build_failure_reports_go_compiler_
     fs.writeFileSync(
       goFile,
       original.replace("package main", "package main\nthis is not valid go;"),
+    );
+    fs.appendFileSync(
+      path.join(root, "src", "main.ts"),
+      '\nconst wrong: number = "type-error";\nvoid wrong;\n',
+      "utf8",
     );
     const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
       cwd: root,
@@ -48,4 +51,5 @@ export const test_plugin_corpus_source_plugin_build_failure_reports_go_compiler_
       result.stderr,
       /building plugin "go-source-plugin" via "go build" failed/,
     );
+    assert.match(result.stderr, /TS2322/);
   };

--- a/tests/test-ttsc/src/native-plugins/corpus-ttsc/test_plugin_corpus_ttsc_lint_failure_does_not_duplicate_typescript_diagnostics.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-ttsc/test_plugin_corpus_ttsc_lint_failure_does_not_duplicate_typescript_diagnostics.ts
@@ -1,0 +1,44 @@
+import { SHARED_PLUGIN_CACHE_DIR } from "../../internal/plugin-cache";
+import {
+  assert,
+  fs,
+  goPath,
+  path,
+  setupLintProject,
+  spawn,
+  ttscBin,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies plugin corpus: @ttsc/lint failure does not duplicate TypeScript
+ * diagnostics.
+ *
+ * `@ttsc/lint` reports normal Program diagnostics together with its own rule
+ * findings. The post-failure TypeScript guard must recognize that TS2322 is
+ * already present and avoid appending the same diagnostic a second time while
+ * preserving the lint failures in the shared stream.
+ *
+ * 1. Copy the lint-violations fixture and add a genuine TS2322 assignment.
+ * 2. Run ttsc with `--noEmit` so @ttsc/lint reports both diagnostic families.
+ * 3. Assert lint output remains present and TS2322 occurs exactly once.
+ */
+export const test_plugin_corpus_ttsc_lint_failure_does_not_duplicate_typescript_diagnostics =
+  () => {
+    const root = setupLintProject("lint-violations");
+    fs.appendFileSync(
+      path.join(root, "src", "main.ts"),
+      '\nconst wrong: number = "type-error";\nvoid wrong;\n',
+      "utf8",
+    );
+    const result = spawn(ttscBin, ["--cwd", root, "--noEmit"], {
+      cwd: root,
+      env: {
+        PATH: goPath(),
+        TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
+      },
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /\[no-var\]/);
+    assert.equal(result.stderr.match(/TS2322/g)?.length, 1, result.stderr);
+  };

--- a/website/src/content/docs/development/concepts/protocol.mdx
+++ b/website/src/content/docs/development/concepts/protocol.mdx
@@ -415,7 +415,7 @@ When multiple entries resolve to the same binary, `ttsc` sends them together. Se
 - `transform` stdout must be the JSON shape above.
 - `build` writes project outputs through TypeScript-Go emit.
 
-**Unrecovered Go panics in a plugin process surface as a normal exit-2 with the panic stack on stderr.** The host does not catch or symbolize the panic, but it preserves the plugin's stderr and exit code. After plugin discovery/build fails or a check/build sidecar exits unsuccessfully, `ttsc` also runs an independent `tsc --noEmit` pass and appends TypeScript diagnostics the plugin did not already report, so a plugin failure cannot hide unrelated source errors. Format and internal emit-only modes keep their diagnostics-free contracts. Wrap rule bodies in `recover()` when you need graceful per-rule reporting. See `packages/lint/linthost/engine.go` for the reference pattern.
+**Unrecovered Go panics in a plugin process surface as a normal exit-2 with the panic stack on stderr.** The host does not catch or symbolize the panic, but it preserves the plugin's stderr and exit code. After plugin discovery/build fails or a check/build sidecar exits unsuccessfully, `ttsc` also runs an independent `tsgo --noEmit` pass and appends TypeScript diagnostics the plugin did not already report, so a plugin failure cannot hide unrelated source errors. Format and internal emit-only modes keep their diagnostics-free contracts. Wrap rule bodies in `recover()` when you need graceful per-rule reporting. See `packages/lint/linthost/engine.go` for the reference pattern.
 
 ## Compatibility Rules
 

--- a/website/src/content/docs/development/concepts/protocol.mdx
+++ b/website/src/content/docs/development/concepts/protocol.mdx
@@ -415,7 +415,7 @@ When multiple entries resolve to the same binary, `ttsc` sends them together. Se
 - `transform` stdout must be the JSON shape above.
 - `build` writes project outputs through TypeScript-Go emit.
 
-**Unrecovered Go panics in a plugin process surface as a normal exit-2 with the panic stack on stderr.** The host prints stderr verbatim and propagates exit code 2 as ttsc's own exit code; it does not catch, symbolize, or aggregate plugin panics. Wrap rule bodies in `recover()` if you need graceful per-rule reporting. See `packages/lint/linthost/engine.go` for the reference pattern.
+**Unrecovered Go panics in a plugin process surface as a normal exit-2 with the panic stack on stderr.** The host does not catch or symbolize the panic, but it preserves the plugin's stderr and exit code. After a failed check or build sidecar, `ttsc` also runs an independent `tsc --noEmit` pass and appends TypeScript diagnostics the plugin did not already report, so a plugin failure cannot hide unrelated source errors. Format and internal emit-only modes keep their diagnostics-free contracts. Wrap rule bodies in `recover()` when you need graceful per-rule reporting. See `packages/lint/linthost/engine.go` for the reference pattern.
 
 ## Compatibility Rules
 

--- a/website/src/content/docs/development/concepts/protocol.mdx
+++ b/website/src/content/docs/development/concepts/protocol.mdx
@@ -415,7 +415,7 @@ When multiple entries resolve to the same binary, `ttsc` sends them together. Se
 - `transform` stdout must be the JSON shape above.
 - `build` writes project outputs through TypeScript-Go emit.
 
-**Unrecovered Go panics in a plugin process surface as a normal exit-2 with the panic stack on stderr.** The host does not catch or symbolize the panic, but it preserves the plugin's stderr and exit code. After a failed check or build sidecar, `ttsc` also runs an independent `tsc --noEmit` pass and appends TypeScript diagnostics the plugin did not already report, so a plugin failure cannot hide unrelated source errors. Format and internal emit-only modes keep their diagnostics-free contracts. Wrap rule bodies in `recover()` when you need graceful per-rule reporting. See `packages/lint/linthost/engine.go` for the reference pattern.
+**Unrecovered Go panics in a plugin process surface as a normal exit-2 with the panic stack on stderr.** The host does not catch or symbolize the panic, but it preserves the plugin's stderr and exit code. After plugin discovery/build fails or a check/build sidecar exits unsuccessfully, `ttsc` also runs an independent `tsc --noEmit` pass and appends TypeScript diagnostics the plugin did not already report, so a plugin failure cannot hide unrelated source errors. Format and internal emit-only modes keep their diagnostics-free contracts. Wrap rule bodies in `recover()` when you need graceful per-rule reporting. See `packages/lint/linthost/engine.go` for the reference pattern.
 
 ## Compatibility Rules
 

--- a/website/src/content/docs/development/walkthroughs/lint.mdx
+++ b/website/src/content/docs/development/walkthroughs/lint.mdx
@@ -489,11 +489,14 @@ The adapter layer lives in `linthost/contrib_adapter.go`. Third-party rule contr
 
 ```go
 type contributorAdapter struct {
-  inner rule.Rule
+  inner                   rule.Rule
+  name                    string
+  visits                  []shimast.Kind
+  visitsDeclarationFiles bool
 }
 
-func (a contributorAdapter) Name() string           { return a.inner.Name() }
-func (a contributorAdapter) Visits() []shimast.Kind { return a.inner.Visits() }
+func (a contributorAdapter) Name() string           { return a.name }
+func (a contributorAdapter) Visits() []shimast.Kind { return a.visits }
 func (a contributorAdapter) Check(ctx *Context, node *shimast.Node) {
   pubCtx := rule.NewContext(
     ctx.File, ctx.Checker, rule.Severity(ctx.Severity), ctx.Options,
@@ -507,7 +510,11 @@ Two adapters, not one, `contributorAdapter` for lint-class rules, `formatContrib
 
 **Why two parallel interfaces?** The engine's internal `Rule` is allowed to evolve freely; the public `rule.Rule` is the stability boundary contributors compile against. By separating the two and bridging through an adapter, we can refactor the internal engine without breaking every published contributor.
 
-The collision policy in `registerContributors` is "later wins is dangerous; prefer determinism." A contributor whose `Name()` collides with an existing rule is dropped with a stderr warning, not panicked-on. This is the same trade-off `@ttsc/lint` makes for the panic barrier: keep the build going whenever possible, surface the problem clearly.
+`registerContributors` evaluates `Name`, `Visits`, `IsFormat`, and `VisitsDeclarationFiles` once behind a recover barrier and stores the results in the adapter. A panic in those startup methods drops only that contributor entry with a stderr warning. A panic in `Check` becomes an error finding for that rule, and the engine continues running the remaining contributor and built-in rules.
+
+The collision policy is "later wins is dangerous; prefer determinism." A contributor whose cached name collides with an existing rule is dropped with a stderr warning, not panicked-on. This is the same trade-off `@ttsc/lint` makes for the panic barrier: keep the build going whenever possible, surface the problem clearly.
+
+Contributor packages are statically linked into the lint binary. Recovery can isolate ordinary Go panics after package initialization, but it cannot survive a panic in `init()`, `os.Exit`, a fatal runtime fault, or a non-returning rule. Those failures require process isolation and are outside the in-process contributor contract.
 
 ## How a contributor package ships
 

--- a/website/src/content/docs/development/walkthroughs/lint.mdx
+++ b/website/src/content/docs/development/walkthroughs/lint.mdx
@@ -514,7 +514,7 @@ Two adapters, not one, `contributorAdapter` for lint-class rules, `formatContrib
 
 The collision policy is "later wins is dangerous; prefer determinism." A contributor whose cached name collides with an existing rule is dropped with a stderr warning, not panicked-on. This is the same trade-off `@ttsc/lint` makes for the panic barrier: keep the build going whenever possible, surface the problem clearly.
 
-Contributor packages are statically linked into the lint binary. Recovery can isolate ordinary Go panics after package initialization, but it cannot survive a panic in `init()`, `os.Exit`, a fatal runtime fault, or a non-returning rule. Those failures require process isolation and are outside the in-process contributor contract.
+Contributor packages are statically linked into the lint binary. Recovery can isolate ordinary Go panics raised synchronously by metadata or `Check`, but it cannot survive a panic in `init()` or a contributor-started goroutine, `os.Exit`, a fatal runtime fault, or a non-returning rule. Those failures require process isolation and are outside the in-process contributor contract.
 
 ## How a contributor package ships
 

--- a/website/src/content/docs/development/walkthroughs/lint.mdx
+++ b/website/src/content/docs/development/walkthroughs/lint.mdx
@@ -489,10 +489,10 @@ The adapter layer lives in `linthost/contrib_adapter.go`. Third-party rule contr
 
 ```go
 type contributorAdapter struct {
-  inner                   rule.Rule
-  metadataCached          bool
-  name                    string
-  visits                  []shimast.Kind
+  inner                  rule.Rule
+  metadataCached         bool
+  name                   string
+  visits                 []shimast.Kind
   visitsDeclarationFiles bool
 }
 

--- a/website/src/content/docs/development/walkthroughs/lint.mdx
+++ b/website/src/content/docs/development/walkthroughs/lint.mdx
@@ -490,7 +490,6 @@ The adapter layer lives in `linthost/contrib_adapter.go`. Third-party rule contr
 ```go
 type contributorAdapter struct {
   inner                  rule.Rule
-  metadataCached         bool
   name                   string
   visits                 []shimast.Kind
   visitsDeclarationFiles bool

--- a/website/src/content/docs/development/walkthroughs/lint.mdx
+++ b/website/src/content/docs/development/walkthroughs/lint.mdx
@@ -490,6 +490,7 @@ The adapter layer lives in `linthost/contrib_adapter.go`. Third-party rule contr
 ```go
 type contributorAdapter struct {
   inner                   rule.Rule
+  metadataCached          bool
   name                    string
   visits                  []shimast.Kind
   visitsDeclarationFiles bool

--- a/website/src/content/docs/ttsc/api.mdx
+++ b/website/src/content/docs/ttsc/api.mdx
@@ -85,8 +85,8 @@ type ITtscCompilerResult =
 ```
 
 - `success`: TypeScript-Go completed with no error-class diagnostics. The `output` map contains every text artifact (JS, `.d.ts`, source maps, declaration maps). `diagnostics` is omitted when empty; warnings appear here when present.
-- `failure`: Compilation ran but produced error-class diagnostics. `output` may still be partial, TypeScript-Go can emit before erroring.
-- `exception`: The host could not run normally (cache lockup, missing binary, plugin sidecar crash, etc.). Treat the `error` field as opaque diagnostic material; do not assume it's an `Error` instance.
+- `failure`: Compilation produced error-class diagnostics or a plugin failed after ttsc could establish a build result. Before returning a plugin-backed failure, ttsc runs an independent no-emit TypeScript check so pure TypeScript errors remain in `diagnostics`; `output` may still be partial.
+- `exception`: The host or plugin setup failed before ttsc could establish a build result (cache lockup, missing binary, invalid project setup, etc.). Treat the `error` field as opaque diagnostic material; do not assume it's an `Error` instance.
 
 ### `transform()`
 

--- a/website/src/content/docs/ttsc/api.mdx
+++ b/website/src/content/docs/ttsc/api.mdx
@@ -191,7 +191,7 @@ interface ITtscCompilerDiagnostic {
 }
 ```
 
-When the host process exits non-zero but produced no parsable diagnostics, ttsc synthesizes a `{ code: "TTSC_PROCESS", category: "error" }` entry that carries the captured stderr/stdout. Embedders can branch on `code` to detect this synthesized case.
+When the host process exits non-zero but produced no parsable diagnostics, ttsc synthesizes a `{ code: "TTSC_PROCESS", category: "error" }` entry that carries the captured stderr/stdout. The same entry is seeded when a plugin fails without reporting structured diagnostics and ttsc recovers pure TypeScript errors through its independent no-emit check, so the recovered type errors never displace the plugin failure. Embedders can branch on `code` to detect this synthesized case.
 
 ## Plugins
 


### PR DESCRIPTION
## Summary
- preserve failed plugin setup/check/transform output and status while independently collecting pure TypeScript diagnostics
- append only TypeScript diagnostics the failed plugin did not already report, including partial-report-before-crash cases
- isolate recoverable `@ttsc/lint` contributor metadata/check panics so healthy contributor and built-in rules continue

## Scope
- plugin discovery, descriptor/source build, check sidecar, and transform/build sidecar failures recover a separate no-emit TypeScript check
- both emitting and no-emit compiler paths retain the original plugin failure status
- contributor `Name`, `Visits`, `IsFormat`, and `VisitsDeclarationFiles` are cached behind a panic barrier; `Check` panics use the existing per-rule diagnostic barrier

## In-process boundary
- contributor `init()` or contributor-started goroutine panics, `os.Exit`, fatal runtime faults, and non-returning rules cannot be recovered in-process and require contributor process isolation

## Test plan
- GitHub Actions CI only, per request; no local tests after the request
