### PR TITLE
fix(factory): give ArrowFunction assignment-level precedence in TsPrinter

### DIFF
--- a/packages/factory/src/TsPrinter.ts
+++ b/packages/factory/src/TsPrinter.ts
@@ -1724,12 +1724,6 @@ export class TsPrinter {
       this.binaryOperatorPrecedence(operator);
     const operandPrecedence: ExpressionPrecedence =
       this.expressionPrecedence(operand);
-    if (
-      !isLeftSide &&
-      operand.kind === "ArrowFunction" &&
-      operatorPrecedence > ExpressionPrecedence.Assignment
-    )
-      return true;
     if (operandPrecedence < operatorPrecedence) return true;
     if (operandPrecedence > operatorPrecedence) return false;
 
@@ -1755,6 +1749,8 @@ export class TsPrinter {
         return ExpressionPrecedence.Comma;
       case "YieldExpression":
         return ExpressionPrecedence.Yield;
+      case "ArrowFunction":
+        return ExpressionPrecedence.Assignment;
       case "ConditionalExpression":
         return ExpressionPrecedence.Conditional;
       case "BinaryExpression":
@@ -1802,6 +1798,7 @@ export class TsPrinter {
       case "AwaitExpression":
       case "ConditionalExpression":
       case "YieldExpression":
+      case "ArrowFunction":
         return Associativity.Right;
       case "BinaryExpression":
         return this.binaryOperatorAssociativity(expression.operator);

--- a/tests/test-factory/src/features/expressions/test_arrow_function_assertion_operand_parentheses.ts
+++ b/tests/test-factory/src/features/expressions/test_arrow_function_assertion_operand_parentheses.ts
@@ -1,0 +1,60 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression, SyntaxKind } from "@ttsc/factory";
+
+import { id, print, ref } from "../../internal/helpers";
+
+const arrow = (): Expression =>
+  factory.createArrowFunction(
+    undefined,
+    undefined,
+    [],
+    undefined,
+    undefined,
+    id("x"),
+  );
+
+/**
+ * Verifies assertion expression parenthesizer: wraps arrow function operands of
+ * `as` and `satisfies`.
+ *
+ * Locks `TsPrinter.assertionExpressionOperand` against the assignment-level
+ * `ArrowFunction` precedence. With primary precedence the operand printed bare,
+ * so `(() => x) as T` re-parsed as an arrow whose body is `x as T` and the
+ * assertion silently moved inside the body. The parentheses also stop the arrow
+ * from swallowing anything after the assertion when the assertion itself sits
+ * bare in a wider expression, while a plain identifier operand must stay
+ * unwrapped.
+ *
+ * 1. Print `as` and `satisfies` expressions whose operand is an arrow function.
+ * 2. Print the assertion as a bare left binary operand and an identifier operand
+ *    as the negative twin.
+ * 3. Assert only the arrow operand is parenthesized.
+ */
+export const test_arrow_function_assertion_operand_parentheses = (): void => {
+  TestValidator.equals(
+    "as operand",
+    print(factory.createAsExpression(arrow(), ref("T"))),
+    "(() => x) as T",
+  );
+  TestValidator.equals(
+    "satisfies operand",
+    print(factory.createSatisfiesExpression(arrow(), ref("T"))),
+    "(() => x) satisfies T",
+  );
+  TestValidator.equals(
+    "asserted arrow as left binary operand",
+    print(
+      factory.createBinaryExpression(
+        factory.createAsExpression(arrow(), ref("T")),
+        SyntaxKind.BarBarToken,
+        id("y"),
+      ),
+    ),
+    "(() => x) as T || y",
+  );
+  TestValidator.equals(
+    "identifier operand stays bare",
+    print(factory.createAsExpression(id("x"), ref("T"))),
+    "x as T",
+  );
+};

--- a/tests/test-factory/src/features/expressions/test_arrow_function_binary_operand_parentheses.ts
+++ b/tests/test-factory/src/features/expressions/test_arrow_function_binary_operand_parentheses.ts
@@ -1,0 +1,76 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression, SyntaxKind } from "@ttsc/factory";
+
+import { id, print } from "../../internal/helpers";
+
+const arrow = (): Expression =>
+  factory.createArrowFunction(
+    undefined,
+    undefined,
+    [],
+    undefined,
+    undefined,
+    id("x"),
+  );
+
+/**
+ * Verifies expression binary parenthesizer: wraps arrow function operands on
+ * both sides.
+ *
+ * Locks the `ArrowFunction` entry in `TsPrinter.expressionPrecedence` at the
+ * assignment level. With primary precedence a left arrow operand printed bare,
+ * so `(() => x) || y` re-parsed as an arrow whose body is `x || y` and the
+ * right operand silently became unreachable. The right side must keep its
+ * parentheses through the same general rule that previously needed a
+ * right-side-only special case, while the comma operator stays below the
+ * arrow's precedence and both comma sides stay bare.
+ *
+ * 1. Print binary expressions with an arrow function as the left operand of `||`,
+ *    `+`, and `**`.
+ * 2. Print the right-operand twin `y || (() => x)` and both comma-operator sides.
+ * 3. Assert the operator sides are parenthesized and the comma sides are not.
+ */
+export const test_arrow_function_binary_operand_parentheses = (): void => {
+  TestValidator.equals(
+    "left logical or",
+    print(
+      factory.createBinaryExpression(arrow(), SyntaxKind.BarBarToken, id("y")),
+    ),
+    "(() => x) || y",
+  );
+  TestValidator.equals(
+    "left additive",
+    print(
+      factory.createBinaryExpression(arrow(), SyntaxKind.PlusToken, id("y")),
+    ),
+    "(() => x) + y",
+  );
+  TestValidator.equals(
+    "left exponentiation",
+    print(
+      factory.createBinaryExpression(
+        arrow(),
+        SyntaxKind.AsteriskAsteriskToken,
+        id("y"),
+      ),
+    ),
+    "(() => x) ** y",
+  );
+  TestValidator.equals(
+    "right logical or",
+    print(
+      factory.createBinaryExpression(id("y"), SyntaxKind.BarBarToken, arrow()),
+    ),
+    "y || (() => x)",
+  );
+  TestValidator.equals(
+    "left comma stays bare",
+    print(factory.createComma(arrow(), id("y"))),
+    "() => x , y",
+  );
+  TestValidator.equals(
+    "right comma stays bare",
+    print(factory.createComma(id("y"), arrow())),
+    "y , () => x",
+  );
+};

--- a/tests/test-factory/src/features/expressions/test_arrow_function_conditional_condition_parentheses.ts
+++ b/tests/test-factory/src/features/expressions/test_arrow_function_conditional_condition_parentheses.ts
@@ -1,0 +1,59 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression } from "@ttsc/factory";
+
+import { id, print } from "../../internal/helpers";
+
+const arrow = (body: string): Expression =>
+  factory.createArrowFunction(
+    undefined,
+    undefined,
+    [],
+    undefined,
+    undefined,
+    id(body),
+  );
+
+/**
+ * Verifies conditional expression parenthesizer: wraps an arrow function
+ * condition but not arrow branches.
+ *
+ * Locks `TsPrinter.conditionalCondition` against the assignment-level
+ * `ArrowFunction` precedence. With primary precedence the condition printed
+ * bare, so `(() => x) ? a : b` re-parsed as an arrow whose body is the whole
+ * conditional and the always-truthy-condition program disappeared. The branches
+ * sit in disallowed-comma positions above the arrow's precedence, so they must
+ * stay bare.
+ *
+ * 1. Print a conditional expression whose condition is an arrow function.
+ * 2. Print a conditional expression whose branches are arrow functions.
+ * 3. Assert the condition is parenthesized and the branches are not.
+ */
+export const test_arrow_function_conditional_condition_parentheses =
+  (): void => {
+    TestValidator.equals(
+      "arrow condition",
+      print(
+        factory.createConditionalExpression(
+          arrow("x"),
+          undefined,
+          id("a"),
+          undefined,
+          id("b"),
+        ),
+      ),
+      "(() => x) ? a : b",
+    );
+    TestValidator.equals(
+      "arrow branches stay bare",
+      print(
+        factory.createConditionalExpression(
+          id("cond"),
+          undefined,
+          arrow("a"),
+          undefined,
+          arrow("b"),
+        ),
+      ),
+      "cond ? () => a : () => b",
+    );
+  };

--- a/tests/test-factory/src/features/expressions/test_arrow_function_operand_without_parentheses.ts
+++ b/tests/test-factory/src/features/expressions/test_arrow_function_operand_without_parentheses.ts
@@ -1,0 +1,83 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression, SyntaxKind } from "@ttsc/factory";
+
+import { id, print } from "../../internal/helpers";
+
+const arrow = (): Expression =>
+  factory.createArrowFunction(
+    undefined,
+    undefined,
+    [],
+    undefined,
+    undefined,
+    id("x"),
+  );
+
+/**
+ * Verifies arrow function printing: stays bare in assignment and
+ * disallowed-comma contexts.
+ *
+ * Negative twin of the arrow parenthesizer fixes. The assignment-level
+ * `ArrowFunction` precedence must wrap only the positions the grammar rejects;
+ * an over-match would wrap the everyday shapes generators emit constantly —
+ * assignment right-hand sides, call arguments, array elements, property values,
+ * and nested arrow bodies — and bloat every generated file.
+ *
+ * 1. Print an arrow function as the right-hand side of `=` and `??=`.
+ * 2. Print an arrow function as a call argument, array element, property value,
+ *    and concise arrow body.
+ * 3. Assert none of the outputs are parenthesized.
+ */
+export const test_arrow_function_operand_without_parentheses = (): void => {
+  TestValidator.equals(
+    "assignment right-hand side",
+    print(
+      factory.createBinaryExpression(id("a"), SyntaxKind.EqualsToken, arrow()),
+    ),
+    "a = () => x",
+  );
+  TestValidator.equals(
+    "nullish assignment right-hand side",
+    print(
+      factory.createBinaryExpression(
+        id("a"),
+        SyntaxKind.QuestionQuestionEqualsToken,
+        arrow(),
+      ),
+    ),
+    "a ??= () => x",
+  );
+  TestValidator.equals(
+    "call argument",
+    print(factory.createCallExpression(id("fn"), undefined, [arrow()])),
+    "fn(() => x)",
+  );
+  TestValidator.equals(
+    "array element",
+    print(factory.createArrayLiteralExpression([arrow()])),
+    "[() => x]",
+  );
+  TestValidator.equals(
+    "property value",
+    print(
+      factory.createObjectLiteralExpression([
+        factory.createPropertyAssignment(id("p"), arrow()),
+      ]),
+    ),
+    "{ p: () => x }",
+  );
+  TestValidator.equals(
+    "concise arrow body",
+    print(
+      factory.createArrowFunction(
+        undefined,
+        undefined,
+        [],
+        undefined,
+        undefined,
+        arrow(),
+      ),
+    ),
+    "() => () => x",
+  );
+};

--- a/tests/test-factory/src/features/expressions/test_arrow_function_unary_operand_parentheses.ts
+++ b/tests/test-factory/src/features/expressions/test_arrow_function_unary_operand_parentheses.ts
@@ -1,0 +1,79 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression, SyntaxKind } from "@ttsc/factory";
+
+import { id, print } from "../../internal/helpers";
+
+const arrow = (): Expression =>
+  factory.createArrowFunction(
+    undefined,
+    undefined,
+    [],
+    undefined,
+    undefined,
+    id("x"),
+  );
+
+/**
+ * Verifies unary operator parenthesizer: wraps arrow function operands of
+ * prefix unary and unary keyword expressions.
+ *
+ * Locks `TsPrinter.isUnaryExpression` against the assignment-level
+ * `ArrowFunction` precedence. With primary precedence the arrow was accepted as
+ * a UnaryExpression operand, but the grammar disallows it there, so `!() => x`,
+ * `await () => x`, and `void () => x` were emitted as outright syntax errors. A
+ * function expression really is a valid unary operand and must stay bare.
+ *
+ * 1. Print `!`, `await`, `void`, `typeof`, `delete`, and unary minus with an arrow
+ *    function operand.
+ * 2. Print `!` with a function expression operand as the negative twin.
+ * 3. Assert only the arrow operands are parenthesized.
+ */
+export const test_arrow_function_unary_operand_parentheses = (): void => {
+  TestValidator.equals(
+    "logical not",
+    print(factory.createLogicalNot(arrow())),
+    "!(() => x)",
+  );
+  TestValidator.equals(
+    "await",
+    print(factory.createAwaitExpression(arrow())),
+    "await (() => x)",
+  );
+  TestValidator.equals(
+    "void",
+    print(factory.createVoidExpression(arrow())),
+    "void (() => x)",
+  );
+  TestValidator.equals(
+    "typeof",
+    print(factory.createTypeOfExpression(arrow())),
+    "typeof (() => x)",
+  );
+  TestValidator.equals(
+    "delete",
+    print(factory.createDeleteExpression(arrow())),
+    "delete (() => x)",
+  );
+  TestValidator.equals(
+    "unary minus",
+    print(factory.createPrefixUnaryExpression(SyntaxKind.MinusToken, arrow())),
+    "-(() => x)",
+  );
+  TestValidator.equals(
+    "function expression operand stays bare",
+    print(
+      factory.createLogicalNot(
+        factory.createFunctionExpression(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          [],
+          undefined,
+          factory.createBlock([]),
+        ),
+      ),
+    ),
+    "!function () {}",
+  );
+};


### PR DESCRIPTION
## Intent

`TsPrinter.expressionPrecedence` had no `ArrowFunction` case, so arrows fell through to `default: Primary` (20) even though the grammar places them at the *AssignmentExpression* level. Every precedence-consulting guard therefore skipped parentheses:

- **left binary operand** — `(() => x) || y` printed as `() => x || y`, an arrow whose body is `x || y`; the right operand became silently unreachable
- **conditional condition** — `(() => x) ? a : b` printed as `() => x ? a : b`
- **`as` / `satisfies` operand** — `(() => x) as T` printed as `() => x as T`
- **unary operands** — `!() => x`, `await () => x`, `void () => x`, … are outright syntax errors

The only compensation was a right-side-only special case in `binaryOperandNeedsParentheses`, which is also the only shape the suite covered.

## Scope

`packages/factory/src/TsPrinter.ts`, precedence/parenthesization layer only (kept clear of the delimiter/params and template regions sibling PRs touch):

1. `expressionPrecedence`: `case "ArrowFunction": return ExpressionPrecedence.Assignment;`
2. `expressionAssociativity`: `ArrowFunction` → `Right`, so an arrow on the right of an equal-precedence assignment operator stays bare (`a = () => x`, `a ??= () => x`)
3. Removed the now-redundant right-side arrow special case in `binaryOperandNeedsParentheses`: `Assignment (3)` already forces parens on both sides of every operator above the assignment tier through the general rule. Comma-operator edge: precedence 0 < 3 keeps both comma sides bare — matching legacy, and safe because a concise arrow body cannot contain a bare comma.

`FunctionExpression` / `ClassExpression` / `ObjectLiteralExpression` are genuinely PrimaryExpressions and are untouched; their statement-start/callable hazards remain covered by the existing dedicated guards.

Note on the oracle: legacy `ts.factory` + `ts.Printer` (verified on 5.8.3) parenthesizes the unary and right-binary shapes but itself emits the corrupted output for left-binary, conditional-condition, and `as` (it also gives arrows Primary precedence and patches only the right side). The issue's table is the correctness spec here; this fix intentionally exceeds legacy where legacy's output re-parses as a different program.

## Test plan

Five new e2e cases under `tests/test-factory/src/features/expressions/`, expectations derived from the issue's table and cross-checked against legacy where legacy is correct:

- `test_arrow_function_binary_operand_parentheses` — left `||` / `+` / `**` wrapped; right `||` twin keeps printing identically through the general rule; both comma-operator sides stay bare
- `test_arrow_function_conditional_condition_parentheses` — condition wrapped; arrow branches stay bare
- `test_arrow_function_assertion_operand_parentheses` — `as` / `satisfies` operands wrapped, including the transitive `(() => x) as T || y` shape; identifier operand stays bare
- `test_arrow_function_unary_operand_parentheses` — `!`, `await`, `void`, `typeof`, `delete`, unary `-` wrapped; function-expression operand stays bare
- `test_arrow_function_operand_without_parentheses` — assignment RHS (`=`, `??=`), call argument, array element, property value, concise arrow body all stay bare

All 30 shapes (positives, negative twins, boundaries) verified against the patched printer via a scratch harness before commit; existing `test_binary_expression_parentheses` (right-arrow) and `test_expression_context_parentheses` (`(() => x)()`) lock the previously-correct behavior.

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB