### PR TITLE
fix(lint): exempt backslash-digit escapes from no-useless-escape in strings and templates

### DIFF
--- a/packages/lint/linthost/rules_escape.go
+++ b/packages/lint/linthost/rules_escape.go
@@ -212,10 +212,16 @@ func isUselessStringEscape(ch byte, whitelist string) bool {
   if strings.IndexByte(whitelist, ch) >= 0 {
     return false
   }
+  // Digits 1-9 are octal-shaped (`no-octal-escape` owns those; `0` is in
+  // the whitelist). Deleting the backslash of `\1`…`\7` changes the cooked
+  // string value, and upstream ESLint skips backslash-digit entirely, so
+  // `\8`/`\9` are exempt too for oracle parity.
+  if ch >= '1' && ch <= '9' {
+    return false
+  }
   // ASCII letters that aren't in the whitelist are user-error escapes
-  // like `\a`, `\m`. Digits 1-9 are octal-shaped (`no-octal-escape`
-  // owns those). `0` is in the whitelist. Punctuation that isn't in the
-  // whitelist (e.g., `\.`) is also redundant.
+  // like `\a`, `\m`. Punctuation that isn't in the whitelist (e.g., `\.`)
+  // is also redundant.
   return true
 }
 

--- a/packages/lint/test/fix/fix_no_useless_escape_drops_nondigit_neighbors_of_octal_exemption_test.go
+++ b/packages/lint/test/fix/fix_no_useless_escape_drops_nondigit_neighbors_of_octal_exemption_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixNoUselessEscapeDropsNondigitNeighborsOfOctalExemption verifies
+// the negative twins of the backslash-digit exemption still autofix.
+//
+// The `\1`…`\9` exemption in `isUselessStringEscape` (issue #361) must
+// not over-reach: a useless letter escape (`\m`) and a useless
+// punctuation escape (`\.`) sit one property away from the exempted
+// digits and must keep being reported and fixed, otherwise the exemption
+// silently disables the rule for whole character classes.
+//
+// 1. Parse string literals containing `\m` and `\.` (no meaningful escape).
+// 2. Apply the findings through the disk-backed fixer.
+// 3. Assert both backslashes are gone and nothing else changed.
+func TestFixNoUselessEscapeDropsNondigitNeighborsOfOctalExemption(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-useless-escape",
+    "const letter = \"a\\mb\";\nconst dot = \"a\\.b\";\nJSON.stringify({letter,dot});\n",
+    "const letter = \"amb\";\nconst dot = \"a.b\";\nJSON.stringify({letter,dot});\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_useless_escape_drops_nondigit_neighbors_of_octal_exemption_test.go
+++ b/packages/lint/test/fix/fix_no_useless_escape_drops_nondigit_neighbors_of_octal_exemption_test.go
@@ -6,19 +6,21 @@ import "testing"
 // the negative twins of the backslash-digit exemption still autofix.
 //
 // The `\1`…`\9` exemption in `isUselessStringEscape` (issue #361) must
-// not over-reach: a useless letter escape (`\m`) and a useless
-// punctuation escape (`\.`) sit one property away from the exempted
-// digits and must keep being reported and fixed, otherwise the exemption
+// not over-reach: a useless letter escape (`\m`), a useless punctuation
+// escape (`\.`), and the ASCII neighbor right above the digit range
+// (`\:`, `':' == '9'+1`, which an off-by-one in the range comparison
+// would wrongly exempt) sit one property away from the exempted digits
+// and must keep being reported and fixed, otherwise the exemption
 // silently disables the rule for whole character classes.
 //
-// 1. Parse string literals containing `\m` and `\.` (no meaningful escape).
+// 1. Parse string literals containing `\m`, `\.`, and `\:` (no meaningful escape).
 // 2. Apply the findings through the disk-backed fixer.
-// 3. Assert both backslashes are gone and nothing else changed.
+// 3. Assert all three backslashes are gone and nothing else changed.
 func TestFixNoUselessEscapeDropsNondigitNeighborsOfOctalExemption(t *testing.T) {
   assertFixSnapshot(
     t,
     "no-useless-escape",
-    "const letter = \"a\\mb\";\nconst dot = \"a\\.b\";\nJSON.stringify({letter,dot});\n",
-    "const letter = \"amb\";\nconst dot = \"a.b\";\nJSON.stringify({letter,dot});\n",
+    "const letter = \"a\\mb\";\nconst dot = \"a\\.b\";\nconst colon = \"a\\:b\";\nJSON.stringify({letter,dot,colon});\n",
+    "const letter = \"amb\";\nconst dot = \"a.b\";\nconst colon = \"a:b\";\nJSON.stringify({letter,dot,colon});\n",
   )
 }

--- a/packages/lint/test/fix/fix_no_useless_escape_skips_backslash_digit_escapes_test.go
+++ b/packages/lint/test/fix/fix_no_useless_escape_skips_backslash_digit_escapes_test.go
@@ -1,0 +1,42 @@
+package linthost
+
+import "testing"
+
+// TestFixNoUselessEscapeSkipsBackslashDigitEscapes verifies the digit
+// exemption of `no-useless-escape` across every literal context.
+//
+// Deleting the backslash of an octal-shaped escape `\1`…`\7` changes the
+// cooked string value (`"a\1b"` is "a\x01b", `"a1b"` is not), and upstream
+// ESLint skips backslash-digit entirely — `no-octal-escape` owns those.
+// This pins the `isUselessStringEscape` exemption for `\1`…`\9` in string
+// and template literals (issue #361: the exemption was documented in a
+// comment but never implemented, so the autofix silently corrupted script
+// -mode strings), the `\0` whitelist boundary right below it — including
+// `\0` followed by a digit, which the JS lexer reads as one octal escape —
+// and the pre-existing regex back-reference exemption so no cleanup of
+// `isUselessRegexEscape` can reintroduce the same class of corruption.
+//
+//  1. Parse string, template (no-substitution and tail), and regex
+//     literals that carry backslash-digit escapes: `\1`/`\7` (value
+//     -changing octals), `\0`/`\01` (whitelist boundary), `\8`/`\9`
+//     (value-preserving but exempt for oracle parity), and a `\1`
+//     back-reference in a regex.
+//  2. Run only `no-useless-escape` and confirm zero findings — the fix
+//     path is never reached.
+//  3. Source stays byte-identical (no autofix applied).
+func TestFixNoUselessEscapeSkipsBackslashDigitEscapes(t *testing.T) {
+  assertRuleSkipsSource(
+    t,
+    "no-useless-escape",
+    "const octalOne = \"a\\1b\";\n"+
+      "const octalSeven = \"a\\7b\";\n"+
+      "const nul = \"\\0\";\n"+
+      "const nulThenDigit = \"\\01\";\n"+
+      "const eight = \"\\8\";\n"+
+      "const nine = \"\\9\";\n"+
+      "const tpl = `a\\1b`;\n"+
+      "const tplTail = `${nul}\\7`;\n"+
+      "const backref = /(a)\\1/;\n"+
+      "JSON.stringify({octalOne,octalSeven,nul,nulThenDigit,eight,nine,tpl,tplTail,backref});\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_useless_escape_skips_backslash_digit_escapes_test.go
+++ b/packages/lint/test/fix/fix_no_useless_escape_skips_backslash_digit_escapes_test.go
@@ -10,15 +10,16 @@ import "testing"
 // ESLint skips backslash-digit entirely — `no-octal-escape` owns those.
 // This pins the `isUselessStringEscape` exemption for `\1`…`\9` in string
 // and template literals (issue #361: the exemption was documented in a
-// comment but never implemented, so the autofix silently corrupted script
-// -mode strings), the `\0` whitelist boundary right below it — including
-// `\0` followed by a digit, which the JS lexer reads as one octal escape —
-// and the pre-existing regex back-reference exemption so no cleanup of
-// `isUselessRegexEscape` can reintroduce the same class of corruption.
+// comment but never implemented, so the autofix silently corrupted
+// script-mode strings), the `\0` whitelist boundary right below it —
+// including `\0` followed by a digit, which the JS lexer reads as one
+// octal escape — and the pre-existing regex back-reference exemption so
+// no cleanup of `isUselessRegexEscape` can reintroduce the same class of
+// corruption.
 //
 //  1. Parse string, template (no-substitution and tail), and regex
-//     literals that carry backslash-digit escapes: `\1`/`\7` (value
-//     -changing octals), `\0`/`\01` (whitelist boundary), `\8`/`\9`
+//     literals that carry backslash-digit escapes: `\1`/`\7`
+//     (value-changing octals), `\0`/`\01` (whitelist boundary), `\8`/`\9`
 //     (value-preserving but exempt for oracle parity), and a `\1`
 //     back-reference in a regex.
 //  2. Run only `no-useless-escape` and confirm zero findings — the fix


### PR DESCRIPTION
## Intent

`no-useless-escape` reported octal-shaped escapes `\1`-`\9` in string and template literals, and its autofix deleted the backslash — silently changing the cooked string value for `\1`-`\7` (`"a\1b"` → `"a1b"`). The code's own comment in `isUselessStringEscape` claimed digits 1-9 were exempt ("`no-octal-escape` owns those"), but the exemption was never implemented. Upstream ESLint's `no-useless-escape` skips backslash-digit entirely.

## Scope

- `packages/lint/linthost/rules_escape.go` — `isUselessStringEscape` now returns `false` for `'1'`-`'9'`, implementing the documented exemption for both consumers (string whitelist and template whitelist). `\8`/`\9` are exempt too: their deletion happens to preserve the cooked value, but upstream skips all backslash-digit escapes, so the full range is exempted for oracle parity. `\0` remains covered by the whitelist.
- **Regex path audited, already correct**: `isUselessRegexEscape` exempts `'1'`-`'9'` as decimal back-references in both class and non-class contexts (the `switch` in `rules_escape.go`), matching upstream. No change needed there; the new skip test pins it so a future cleanup cannot reintroduce the same class of corruption.
- **Docs**: the `no-useless-escape` entry in `website/src/content/docs/lint/rules/core.mdx` describes only the general rule (`"\."`, `/\,/` examples) and never documented the buggy digit behavior, so no doc change is required.

## Test plan

Go unit tests in `packages/lint/test/fix/`, mirroring the existing `fix_no_useless_escape_*` peers:

- `fix_no_useless_escape_skips_backslash_digit_escapes_test.go` — zero findings (and therefore no fix) for:
  - `"a\1b"`, `"a\7b"` — value-changing octals (fails before this fix);
  - `"\0"` and `"\01"` — whitelist boundary, including `\0` followed by a digit which the lexer reads as one octal escape;
  - `"\8"`, `"\9"` — value-preserving but exempt, pinning the oracle-parity decision;
  - `` `a\1b` `` and a `TemplateTail` `\7` — template-literal twin through `templateValidEscapes`;
  - `/(a)\1/` — regex back-reference, pinning the pre-existing regex-path exemption.
- `fix_no_useless_escape_drops_nondigit_neighbors_of_octal_exemption_test.go` — negative twins one property away from the exemption: `"\m"` and `"\."` are still reported and autofixed to `"m"` / `"."`.

CI runs the full Go and TypeScript suites.

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB
