### PR TITLE
fix(lint): require a crossed newline before stripping statement semicolons

### DIFF
--- a/packages/lint/linthost/rules_format_semi.go
+++ b/packages/lint/linthost/rules_format_semi.go
@@ -135,12 +135,22 @@ func (formatSemi) Check(ctx *Context, node *shimast.Node) {
   )
 }
 
-// nextStatementHasASIHazard reports whether the next non-trivia byte
-// after `end` starts a token that would re-associate with the prior
-// expression if the trailing `;` is removed. Prettier handles this by
-// inserting a defensive leading `;` on the next line; this rule's
-// fixer is single-node, so the safer move is to keep the explicit
-// terminator.
+// nextStatementHasASIHazard reports whether removing the trailing `;`
+// at `end-1` could change the parse, judged by the next significant
+// byte after `end` and the line structure between them.
+//
+// ASI only inserts a semicolon at a line terminator, end of input, or
+// before `}`. So the `;` is removable in exactly two shapes:
+//
+//   - end of input or a same-line `}` follows (ASI's closing-brace and
+//     end-of-input rules apply), or
+//   - a line terminator separates the statement from the next token AND
+//     that token is not a continuation hazard.
+//
+// Any other same-line successor (`else`, `while` of a do-loop, another
+// statement after a gap comment) makes the `;` a REQUIRED separator:
+// no line terminator means ASI cannot fire, so stripping would be a
+// syntax error, not a style change.
 //
 // Hazard tokens per the ASI spec:
 //
@@ -149,18 +159,72 @@ func (formatSemi) Check(ctx *Context, node *shimast.Node) {
 //   - “ ` “: tagged template literal continues
 //   - `+`, `-`, `*`: binary operator continues
 //   - `,`: comma operator continues
-//   - `/`: division operator or regex literal continues; handled by
-//     the comment-or-regex branch below (a leading `//` or `/*` is not a
-//     hazard, a bare `/` is), so it is absent from the token switch.
+//   - `/`: division operator or regex literal continues (a leading `//`
+//     or `/*` is trivia consumed by scanPastTrivia; a bare `/` is a
+//     hazard).
 func nextStatementHasASIHazard(src string, end int) bool {
-  for i := end; i < len(src); i++ {
+  i, sawNewline := scanPastTrivia(src, end)
+  if i >= len(src) {
+    return false
+  }
+  c := src[i]
+  if c == '}' {
+    // ASI applies before a closing brace regardless of line
+    // structure: `{ a(); }` → `{ a() }` stays valid.
+    return false
+  }
+  if !sawNewline {
+    // Next token on the same line: ASI cannot fire without a line
+    // terminator, so the `;` separates the two constructs
+    // (`if (a) b(); else c();`, `do f(); while (x);`,
+    // `a = 1; /* note */ b = 2`). Keep it.
+    return true
+  }
+  if c == '/' {
+    // bare `/` starts a regex literal or division, hazard.
+    return true
+  }
+  switch c {
+  // If the next significant byte is one of these, dropping the terminator
+  // could let the following line re-associate with the prior expression.
+  // `( [`, a unary `+ -`, and a tagged-template backtick are the cases
+  // actually reachable from a valid statement start; `<` matters in .tsx
+  // (a leading `<` opens a JSX element). The remaining infix bytes cannot
+  // begin a valid statement on their own, but are listed defensively so
+  // the strip always cedes rather than risk a parse-changing edit.
+  case '[', '(', '`', '+', '-', '*', ',', '.', '<', '>', '=', '?', '%', '&', '|', '^':
+    return true
+  }
+  return false
+}
+
+// scanPastTrivia advances from `pos` past whitespace and comments,
+// returning the index of the next significant byte (len(src) at end of
+// input) and whether a line terminator was crossed on the way. Both
+// semicolon scanners (statement and member) share it so the ASI line
+// rules cannot drift apart.
+//
+// A block comment that spans lines counts as a crossed line: per
+// ECMA-262 (Comments), a multi-line comment containing a line
+// terminator is treated as a line terminator for ASI, so the decision
+// keys on comment content, not comment kind. `\r` counts as a line
+// terminator on its own, which also covers CRLF sources.
+func scanPastTrivia(src string, pos int) (next int, sawNewline bool) {
+  i := pos
+  for i < len(src) {
     c := src[i]
-    if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
+    if c == '\n' || c == '\r' {
+      sawNewline = true
+      i++
+      continue
+    }
+    if c == ' ' || c == '\t' {
+      i++
       continue
     }
     if c == '/' && i+1 < len(src) {
       if src[i+1] == '/' {
-        for i < len(src) && src[i] != '\n' {
+        for i < len(src) && src[i] != '\n' && src[i] != '\r' {
           i++
         }
         continue
@@ -168,30 +232,22 @@ func nextStatementHasASIHazard(src string, end int) bool {
       if src[i+1] == '*' {
         i += 2
         for i+1 < len(src) && !(src[i] == '*' && src[i+1] == '/') {
+          if src[i] == '\n' || src[i] == '\r' {
+            sawNewline = true
+          }
           i++
         }
         if i+1 < len(src) {
-          i++ // step past '*/'
+          i += 2 // step past '*/'
+        } else {
+          i = len(src) // unterminated block comment swallows the rest
         }
         continue
       }
-      // bare `/` starts a regex literal or division, hazard.
-      return true
     }
-    switch c {
-    // If the next significant byte is one of these, dropping the terminator
-    // could let the following line re-associate with the prior expression.
-    // `( [`, a unary `+ -`, and a tagged-template backtick are the cases
-    // actually reachable from a valid statement start; `<` matters in .tsx
-    // (a leading `<` opens a JSX element). The remaining infix bytes cannot
-    // begin a valid statement on their own, but are listed defensively so
-    // the strip always cedes rather than risk a parse-changing edit.
-    case '[', '(', '`', '+', '-', '*', ',', '.', '<', '>', '=', '?', '%', '&', '|', '^':
-      return true
-    }
-    return false
+    return i, sawNewline
   }
-  return false
+  return len(src), sawNewline
 }
 
 // preferNeverSafeKind reports whether stripping the trailing semicolon
@@ -291,8 +347,9 @@ func stripMemberSemicolon(ctx *Context, src string, node *shimast.Node, isClassF
 
 // memberSemicolonRedundant reports whether the member terminator `;`
 // whose following byte is at `after` can be dropped without changing the
-// parse. It scans past trivia (whitespace + comments) to the next
-// significant byte and applies Prettier's semi:false member rules:
+// parse. It scans past trivia (whitespace + comments, via
+// scanPastTrivia) to the next significant byte and applies Prettier's
+// semi:false member rules:
 //
 //   - The closing `}` (or end of file) always makes the `;` redundant.
 //   - A next member on the SAME line (no newline crossed) keeps the `;`
@@ -305,57 +362,27 @@ func stripMemberSemicolon(ctx *Context, src string, node *shimast.Node, isClassF
 //     call/construct/generic signature (`(` / `<`) for type members
 //     (a leading `[` is an index signature there, not a continuation).
 func memberSemicolonRedundant(src string, after int, isClassField bool) bool {
-  sawNewline := false
-  for i := after; i < len(src); {
-    c := src[i]
-    if c == '\n' {
-      sawNewline = true
-      i++
-      continue
-    }
-    if c == ' ' || c == '\t' || c == '\r' {
-      i++
-      continue
-    }
-    if c == '/' && i+1 < len(src) {
-      if src[i+1] == '/' {
-        for i < len(src) && src[i] != '\n' {
-          i++
-        }
-        continue
-      }
-      if src[i+1] == '*' {
-        i += 2
-        for i+1 < len(src) && !(src[i] == '*' && src[i+1] == '/') {
-          if src[i] == '\n' {
-            sawNewline = true
-          }
-          i++
-        }
-        if i+1 < len(src) {
-          i += 2
-        }
-        continue
-      }
-    }
-    if c == '}' {
-      return true
-    }
-    if !sawNewline {
+  i, sawNewline := scanPastTrivia(src, after)
+  if i >= len(src) {
+    return true
+  }
+  c := src[i]
+  if c == '}' {
+    return true
+  }
+  if !sawNewline {
+    return false
+  }
+  if isClassField {
+    switch c {
+    case '[', '(', '`', '+', '-', '*', '/', ',':
       return false
     }
-    if isClassField {
-      switch c {
-      case '[', '(', '`', '+', '-', '*', '/', ',':
-        return false
-      }
-    } else {
-      switch c {
-      case '(', '<':
-        return false
-      }
+  } else {
+    switch c {
+    case '(', '<':
+      return false
     }
-    return true
   }
   return true
 }

--- a/packages/lint/test/format/format_semi_prefer_never_keeps_do_while_separator_test.go
+++ b/packages/lint/test/format/format_semi_prefer_never_keeps_do_while_separator_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestFormatSemiPreferNeverKeepsDoWhileSeparator verifies the `;` between
+// a single-statement do-body and its same-line `while` is kept under
+// semi:false.
+//
+// In `do f(); while (x);` the first `;` terminates the body expression
+// statement; without a line terminator before `while`, ASI cannot
+// replace it, so stripping yields the SyntaxError `do f() while (x)`.
+// The statement's own trailing `;` at end of file stays strippable —
+// this is the positive/negative pair inside one fixture.
+//
+//  1. Parse `do f(); while (x);` (single line).
+//  2. Apply format/semi with prefer:"never".
+//  3. Assert the body separator survives and only the do-statement's
+//     final `;` is stripped.
+func TestFormatSemiPreferNeverKeepsDoWhileSeparator(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/semi",
+    "do f(); while (x);\n",
+    `{"prefer":"never"}`,
+    "do f(); while (x)\n",
+  )
+}

--- a/packages/lint/test/format/format_semi_prefer_never_keeps_same_line_else_separator_test.go
+++ b/packages/lint/test/format/format_semi_prefer_never_keeps_same_line_else_separator_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestFormatSemiPreferNeverKeepsSameLineElseSeparator verifies the `;`
+// between `if (a) b();` and a same-line `else` is kept under semi:false.
+//
+// ASI only fires at a line terminator, end of input, or before `}`.
+// With `else` on the same line nothing can re-terminate the then-branch
+// once the `;` is gone, so `if (a) b() else c()` is a SyntaxError. The
+// hazard scan used to treat `\n` as skippable whitespace and never
+// required one, so it judged `else` safe and corrupted the source; this
+// pins the sawNewline discipline in nextStatementHasASIHazard.
+//
+//  1. Parse `if (a) b(); else c();` (single line).
+//  2. Apply format/semi with prefer:"never".
+//  3. Assert only the trailing EOF-adjacent `;` is stripped and the
+//     required separator before `else` survives.
+func TestFormatSemiPreferNeverKeepsSameLineElseSeparator(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/semi",
+    "if (a) b(); else c();\n",
+    `{"prefer":"never"}`,
+    "if (a) b(); else c()\n",
+  )
+}

--- a/packages/lint/test/format/format_semi_prefer_never_keeps_same_line_statement_separator_test.go
+++ b/packages/lint/test/format/format_semi_prefer_never_keeps_same_line_statement_separator_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestFormatSemiPreferNeverKeepsSameLineStatementSeparator verifies the
+// `;` between two statements on the SAME line is kept under semi:false.
+//
+// `a = 1; b = 2` needs its separator: with no line terminator in the
+// gap, ASI cannot fire and `a = 1 b = 2` is a SyntaxError. In the full
+// `ttsc format` cascade, format/statement-split later moves `b = 2` to
+// its own line and the next pass strips the then-redundant `;` — the
+// semi rule must defer to that ordering rather than corrupt the source
+// in a single pass. Negative twin of the newline-separated strip pinned
+// by TestFormatSemiHonorsPreferNeverOption.
+//
+//  1. Parse `a = 1; b = 2` (single line).
+//  2. Run format/semi with prefer:"never".
+//  3. Assert zero findings: the same-line successor keeps the `;`.
+func TestFormatSemiPreferNeverKeepsSameLineStatementSeparator(t *testing.T) {
+  assertRuleSkipsSourceWithOptions(
+    t,
+    "format/semi",
+    "a = 1; b = 2\n",
+    `{"prefer":"never"}`,
+  )
+}

--- a/packages/lint/test/format/format_semi_prefer_never_keeps_semi_before_same_line_comment_gap_test.go
+++ b/packages/lint/test/format/format_semi_prefer_never_keeps_semi_before_same_line_comment_gap_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestFormatSemiPreferNeverKeepsSemiBeforeSameLineCommentGap verifies a
+// `;` followed by a single-line block comment and then a second
+// statement on the SAME line is kept under semi:false.
+//
+// `a = 1; /* note */ b = 2` stays on one line because
+// format/statement-split deliberately abstains when a block comment
+// sits in the inter-statement gap, so nothing rescues the line before
+// the stripper runs. A comment without a line terminator is not a line
+// terminator for ASI (ECMA-262, Comments), so stripping would produce
+// the SyntaxError `a = 1 /* note */ b = 2`. The scan must classify the
+// comment by content — no newline inside means no newline crossed.
+//
+//  1. Parse two same-line statements separated by `; /* note */`.
+//  2. Run format/semi with prefer:"never".
+//  3. Assert zero findings: the `;` is a required separator.
+func TestFormatSemiPreferNeverKeepsSemiBeforeSameLineCommentGap(t *testing.T) {
+  assertRuleSkipsSourceWithOptions(
+    t,
+    "format/semi",
+    "a = 1; /* note */ b = 2\n",
+    `{"prefer":"never"}`,
+  )
+}

--- a/packages/lint/test/format/format_semi_prefer_never_strips_across_crlf_test.go
+++ b/packages/lint/test/format/format_semi_prefer_never_strips_across_crlf_test.go
@@ -1,0 +1,28 @@
+package linthost
+
+import "testing"
+
+// TestFormatSemiPreferNeverStripsAcrossCrlf verifies newline detection in
+// the hazard scan counts CRLF line endings, so newline-separated
+// statements in a CRLF source still lose their terminators under
+// semi:false.
+//
+// The sawNewline discipline keeps same-line separators; if it only
+// recognized bare `\n` after skipping `\r` as plain whitespace, a CRLF
+// file would still strip correctly — but a scan that treated `\r\n` as
+// no line break would wrongly keep every terminator. This pins the
+// carriage-return branch of the trivia scanner in both directions:
+// stripping fires, and the CRLF bytes survive the edit untouched.
+//
+//  1. Parse two CRLF-separated statements, the first ending in `;`.
+//  2. Apply format/semi with prefer:"never".
+//  3. Assert the `;` is stripped and the `\r\n` endings are preserved.
+func TestFormatSemiPreferNeverStripsAcrossCrlf(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/semi",
+    "a = 1;\r\nb = 2\r\n",
+    `{"prefer":"never"}`,
+    "a = 1\r\nb = 2\r\n",
+  )
+}

--- a/packages/lint/test/format/format_semi_prefer_never_strips_across_multiline_comment_gap_test.go
+++ b/packages/lint/test/format/format_semi_prefer_never_strips_across_multiline_comment_gap_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestFormatSemiPreferNeverStripsAcrossMultilineCommentGap verifies a `;`
+// followed by a block comment that SPANS lines is strippable under
+// semi:false.
+//
+// Per ECMA-262 (Comments), a multi-line comment containing a line
+// terminator is treated as a line terminator for ASI, so
+// `a = 1 /* note\nnote */ b = 2` parses as two statements. This is the
+// negative twin of the same-line comment-gap case: the decision keys on
+// the comment's content (does it contain a newline?), not on its token
+// kind, so a spanning comment must count as a crossed line.
+//
+//  1. Parse two statements separated by `;` and a two-line block comment.
+//  2. Apply format/semi with prefer:"never".
+//  3. Assert the `;` is stripped and the comment survives intact.
+func TestFormatSemiPreferNeverStripsAcrossMultilineCommentGap(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/semi",
+    "a = 1; /* note\nnote */ b = 2\n",
+    `{"prefer":"never"}`,
+    "a = 1 /* note\nnote */ b = 2\n",
+  )
+}

--- a/packages/lint/test/format/format_semi_prefer_never_strips_before_same_line_close_brace_test.go
+++ b/packages/lint/test/format/format_semi_prefer_never_strips_before_same_line_close_brace_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestFormatSemiPreferNeverStripsBeforeSameLineCloseBrace verifies a `;`
+// whose next significant token is a same-line `}` is still stripped
+// under semi:false.
+//
+// The same-line hazard guard must not over-reach: ASI's closing-brace
+// rule applies regardless of line structure, so `{ a() }` is valid and
+// Prettier prints it without the terminator. This is the negative twin
+// of the same-line `else` / `do…while` cases — `}` is the one same-line
+// successor that keeps the strip safe.
+//
+//  1. Parse `if (x) { a(); }` (single line).
+//  2. Apply format/semi with prefer:"never".
+//  3. Assert the `;` before the same-line `}` is stripped.
+func TestFormatSemiPreferNeverStripsBeforeSameLineCloseBrace(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/semi",
+    "if (x) { a(); }\n",
+    `{"prefer":"never"}`,
+    "if (x) { a() }\n",
+  )
+}


### PR DESCRIPTION
## Intent

Under `semi: false`, `format/semi`'s statement-level stripper decided "safe to strip" by scanning ahead for a blacklisted continuation token while treating newlines as skippable whitespace — it never required that a line terminator actually separate the statement from what follows. ASI only fires at a line terminator, end of input, or before `}`, so any other same-line successor made the stripped `;` a syntax error:

```js
if (a) b(); else c();      // → if (a) b() else c();      SyntaxError
do f(); while (x);         // → do f() while (x);         SyntaxError
a = 1; /* note */ b = 2    // → a = 1 /* note */ b = 2    SyntaxError
```

The member-level twin (`memberSemicolonRedundant`) already tracked `sawNewline`; the statement scanner never got the check.

## Scope

- `packages/lint/linthost/rules_format_semi.go`
  - `nextStatementHasASIHazard` now strips only at end of input, before `}` (ASI's closing-brace rule holds regardless of line structure), or after a crossed line terminator whose next token is not a continuation hazard. Any other same-line successor keeps the `;` as a required separator.
  - Extracted `scanPastTrivia`, now shared by the statement and member scanners so the ASI line rules cannot drift apart. A block comment counts as a crossed line only when it contains a line terminator (per ECMA-262, Comments, it then acts as one for ASI); `\r` counts on its own, which also covers CRLF sources.
- No website change: the docs describe `semi` at the option level and never documented the internal hazard scan.

Cascade note: for plain `a = 1; b = 2`, `format/statement-split` owns the line break; `format/semi` now defers (keeps the `;`) and strips on the pass after the split instead of corrupting the source in the same pass.

## Test plan

New Go regression tests in `packages/lint/test/format/` (all strip expectations oracle-checked against Prettier `semi: false` semantics):

- `…keeps_same_line_else_separator`: `if (a) b(); else c();` keeps the body `;`, strips only the EOF one (fails before the fix).
- `…keeps_do_while_separator`: `do f(); while (x);` keeps the body `;` (fails before the fix).
- `…keeps_semi_before_same_line_comment_gap`: `a = 1; /* note */ b = 2` — zero findings (fails before the fix).
- `…keeps_same_line_statement_separator`: `a = 1; b = 2` — zero findings; negative twin of the newline-separated strip.
- `…strips_across_multiline_comment_gap`: a block comment spanning lines counts as a crossed line, `;` strips.
- `…strips_before_same_line_close_brace`: `if (x) { a(); }` → `if (x) { a() }` — the same-line guard must not over-reach.
- `…strips_across_crlf`: CRLF-separated statements still strip, `\r\n` preserved.

Existing coverage (newline-separated strips, EOF strip, `[`/regex hazards, line/block comment trivia, member-scanner cases) pins the unchanged behavior; the member scanner refactor is behavior-preserving. CI runs the full suite.

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB