### PR TITLE
fix(lint): treat a trailing-comma arrow parameter as parenthesized

### DIFF
--- a/packages/lint/linthost/rules_format_arrow_parens.go
+++ b/packages/lint/linthost/rules_format_arrow_parens.go
@@ -17,7 +17,10 @@ import (
 // other shape (`(x: T)`, `({ x })`, `(...x)`, `(x = 1)`, `(x?)`, `(x, y)`,
 // `()`) keeps its parentheses in both modes, exactly as Prettier does.
 // `async x => x` is handled too: the modifier sits before the parameter, so
-// the parameter-name span is unaffected.
+// the parameter-name span is unaffected. A legal trailing comma (`(x,) => x`)
+// counts as already parenthesized — a trailing comma can only exist inside a
+// parameter-list paren pair — so "always" leaves it alone and "avoid" deletes
+// the comma together with the parens (`x => x`, matching Prettier).
 //
 // The rule rewrites only the parameter span (`x` <-> `(x)`), never the body
 // or the `=>`, so a chained arrow `a => b => …` has each eligible arm
@@ -90,9 +93,13 @@ func (formatArrowParens) Check(ctx *Context, node *shimast.Node) {
 
   // Is the parameter already wrapped in `(` … `)`? Scan over whitespace on
   // each side; the sole parameter of an arrow is delimited by the
-  // parameter-list parens when present.
+  // parameter-list parens when present. The forward scan starts at the
+  // parameter *list*'s end, not the name's: the list span covers a legal
+  // trailing comma (`(x,)` — that is how the AST records HasTrailingComma),
+  // so a trailing-comma list is classified as wrapped instead of the `,`
+  // byte aborting the scan and mis-reporting a bare name.
   openParen := scanBackForByte(src, nameStart, '(')
-  closeParen := scanForwardForByte(src, nameEnd, ')')
+  closeParen := scanForwardForByte(src, arrow.Parameters.End(), ')')
   wrapped := openParen >= 0 && closeParen >= 0
 
   switch prefer {
@@ -189,7 +196,10 @@ func arrowParamRegionHasComment(src string, paramPos, nameStart, nameEnd int) bo
   // paren so a comment between `)` and `=>` (`(x) /* c */ => x`) — which in
   // "avoid" mode would otherwise be stranded when the parens are stripped — is
   // also detected (Prettier keeps the parens of an arrow with such a dangling
-  // comment).
+  // comment). Likewise tolerate one trailing comma before the paren so a
+  // comment on either side of it (`(x /* c */,) => x`, `(x, /* c */) => x`) —
+  // which the "avoid" deletion would destroy — is also detected.
+  sawComma := false
   sawParen := false
   for i := nameEnd; i+1 < len(src); i++ {
     c := src[i]
@@ -198,6 +208,10 @@ func arrowParamRegionHasComment(src string, paramPos, nameStart, nameEnd int) bo
     }
     if c == '/' && (src[i+1] == '*' || src[i+1] == '/') {
       return true
+    }
+    if c == ',' && !sawComma && !sawParen {
+      sawComma = true
+      continue
     }
     if c == ')' && !sawParen {
       sawParen = true

--- a/packages/lint/test/format/format_arrow_parens_abstains_on_comment_near_trailing_comma_test.go
+++ b/packages/lint/test/format/format_arrow_parens_abstains_on_comment_near_trailing_comma_test.go
@@ -1,0 +1,63 @@
+package linthost
+
+import "testing"
+
+// TestFormatArrowParensAbstainsOnCommentNearTrailingComma pins the data-safety
+// guard around a trailing-comma parameter list that also carries a comment: on
+// either side of the comma (`(x /* c */,)`, `(x, /* c */)`) the rule must
+// report nothing in both modes. "avoid" would otherwise delete the comment
+// with the `( … )` span, and "always" would mis-read `(x, /* c */)` as a bare
+// parameter (the comment byte aborts the forward paren scan) and double-wrap
+// it. Prettier declines to drop parens on a commented parameter
+// (canPrintParamsWithoutParens requires `!hasComment(parameters[0])`), so
+// abstaining is oracle-safe.
+//
+//  1. Parse trailing-comma arrows with a comment before/after the comma, plus
+//     the comma-free `(x /* c */) => x` twin under "avoid".
+//  2. Run format/arrow-parens in each mode.
+//  3. Assert the rule reports nothing.
+func TestFormatArrowParensAbstainsOnCommentNearTrailingComma(t *testing.T) {
+  t.Run("comment_before_comma_always", func(t *testing.T) {
+    assertRuleSkipsSourceWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = (x /* c */,) => x;\n",
+      `{"prefer":"always"}`,
+    )
+  })
+  t.Run("comment_before_comma_avoid", func(t *testing.T) {
+    assertRuleSkipsSourceWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = (x /* c */,) => x;\n",
+      `{"prefer":"avoid"}`,
+    )
+  })
+  t.Run("comment_after_comma_always", func(t *testing.T) {
+    assertRuleSkipsSourceWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = (x, /* c */) => x;\n",
+      `{"prefer":"always"}`,
+    )
+  })
+  t.Run("comment_after_comma_avoid", func(t *testing.T) {
+    assertRuleSkipsSourceWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = (x, /* c */) => x;\n",
+      `{"prefer":"avoid"}`,
+    )
+  })
+  // Comma-free negative twin: the trailing-comment guard must keep firing for
+  // `(x /* c */) => x` under "avoid" (the "always" twin lives in
+  // format_arrow_parens_abstains_on_param_comment_test.go).
+  t.Run("comment_no_comma_avoid", func(t *testing.T) {
+    assertRuleSkipsSourceWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = (x /* c */) => x;\n",
+      `{"prefer":"avoid"}`,
+    )
+  })
+}

--- a/packages/lint/test/format/format_arrow_parens_keeps_ineligible_trailing_comma_params_test.go
+++ b/packages/lint/test/format/format_arrow_parens_keeps_ineligible_trailing_comma_params_test.go
@@ -1,0 +1,52 @@
+package linthost
+
+import "testing"
+
+// TestFormatArrowParensKeepsIneligibleTrailingCommaParams verifies
+// prefer:"avoid" still leaves every ineligible single-parameter shape alone
+// when a legal trailing comma follows it: typed `(x: T,)`, defaulted
+// `(x = 1,)`, destructured `({ x },)`, and a generic arrow `<T>(x,)`.
+//
+// These shapes are excluded by `isBareIdentifierParam` (or the
+// type-parameter guard) *before* the trailing-comma-aware wrappedness scan
+// runs, so making `(x,)` strippable must not have widened "avoid" onto
+// parameters whose parens are mandatory — a bare `x: T =>` or `{ x } =>` is
+// not valid syntax.
+//
+//  1. Parse each ineligible trailing-comma arrow.
+//  2. Run format/arrow-parens with prefer:"avoid".
+//  3. Assert the rule reports nothing.
+func TestFormatArrowParensKeepsIneligibleTrailingCommaParams(t *testing.T) {
+  t.Run("typed", func(t *testing.T) {
+    assertRuleSkipsSourceWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = (x: number,) => x;\n",
+      `{"prefer":"avoid"}`,
+    )
+  })
+  t.Run("defaulted", func(t *testing.T) {
+    assertRuleSkipsSourceWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = (x = 1,) => x;\n",
+      `{"prefer":"avoid"}`,
+    )
+  })
+  t.Run("destructured", func(t *testing.T) {
+    assertRuleSkipsSourceWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = ({ x },) => x;\n",
+      `{"prefer":"avoid"}`,
+    )
+  })
+  t.Run("generic", func(t *testing.T) {
+    assertRuleSkipsSourceWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = <T>(x: T,) => x;\n",
+      `{"prefer":"avoid"}`,
+    )
+  })
+}

--- a/packages/lint/test/format/format_arrow_parens_keeps_trailing_comma_param_under_always_test.go
+++ b/packages/lint/test/format/format_arrow_parens_keeps_trailing_comma_param_under_always_test.go
@@ -1,0 +1,46 @@
+package linthost
+
+import "testing"
+
+// TestFormatArrowParensKeepsTrailingCommaParamUnderAlways verifies
+// prefer:"always" treats a single parameter followed by a legal trailing comma
+// (`(x,) => x`) as already parenthesized.
+//
+// Pins the wrappedness detection in
+// `rules_format_arrow_parens.go::formatArrowParens.Check`: the forward paren
+// scan used to start at the parameter *name*'s end, where the `,` byte aborted
+// the whitespace-only scan, misclassified the parameter as bare, and wrapped
+// the name a second time into invalid `((x),) => x` (a parenthesized pattern
+// is not a valid parameter). Scanning from the parameter list's end — whose
+// span covers the trailing comma — classifies it as wrapped.
+//
+//  1. Parse a trailing-comma single-parameter arrow (plain, async, and
+//     multiline variants).
+//  2. Run format/arrow-parens with prefer:"always".
+//  3. Assert the rule reports nothing.
+func TestFormatArrowParensKeepsTrailingCommaParamUnderAlways(t *testing.T) {
+  t.Run("single_line", func(t *testing.T) {
+    assertRuleSkipsSourceWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = (x,) => x;\n",
+      `{"prefer":"always"}`,
+    )
+  })
+  t.Run("async", func(t *testing.T) {
+    assertRuleSkipsSourceWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = async (x,) => x;\n",
+      `{"prefer":"always"}`,
+    )
+  })
+  t.Run("multiline", func(t *testing.T) {
+    assertRuleSkipsSourceWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = (\n  x,\n) => x;\n",
+      `{"prefer":"always"}`,
+    )
+  })
+}

--- a/packages/lint/test/format/format_arrow_parens_strips_trailing_comma_param_under_avoid_test.go
+++ b/packages/lint/test/format/format_arrow_parens_strips_trailing_comma_param_under_avoid_test.go
@@ -1,0 +1,48 @@
+package linthost
+
+import "testing"
+
+// TestFormatArrowParensStripsTrailingCommaParamUnderAvoid verifies
+// prefer:"avoid" removes the parentheses *and* the legal trailing comma of a
+// single bare-identifier parameter: `(x,) => x` becomes `x => x`, matching
+// Prettier.
+//
+// Before the trailing-comma-aware wrappedness detection this input was
+// silently skipped (the `,` byte aborted the forward paren scan, so the
+// parameter looked bare and "avoid" had nothing to strip). The fix must delete
+// the comma together with the parens — replacing only `(x)` would leave the
+// invalid `x, => x`.
+//
+//  1. Parse a trailing-comma single-parameter arrow (plain, async, and
+//     multiline variants).
+//  2. Apply format/arrow-parens with prefer:"avoid".
+//  3. Assert parens and comma are gone: `x => x`.
+func TestFormatArrowParensStripsTrailingCommaParamUnderAvoid(t *testing.T) {
+  t.Run("single_line", func(t *testing.T) {
+    assertFixSnapshotWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = (x,) => x;\n",
+      `{"prefer":"avoid"}`,
+      "const a = x => x;\n",
+    )
+  })
+  t.Run("async", func(t *testing.T) {
+    assertFixSnapshotWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = async (x,) => x;\n",
+      `{"prefer":"avoid"}`,
+      "const a = async x => x;\n",
+    )
+  })
+  t.Run("multiline", func(t *testing.T) {
+    assertFixSnapshotWithOptions(
+      t,
+      "format/arrow-parens",
+      "const a = (\n  x,\n) => x;\n",
+      `{"prefer":"avoid"}`,
+      "const a = x => x;\n",
+    )
+  })
+}

--- a/packages/lint/test/format/format_arrow_parens_strips_wrapped_param_before_list_comma_test.go
+++ b/packages/lint/test/format/format_arrow_parens_strips_wrapped_param_before_list_comma_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestFormatArrowParensStripsWrappedParamBeforeListComma verifies
+// prefer:"avoid" still strips `(x) => x` when the arrow is an array element
+// followed by a comma and a comment: `[(x) => x, /* c */ 1]` becomes
+// `[x => x, /* c */ 1]`.
+//
+// Negative twin for the trailing-comma tolerance in
+// `arrowParamRegionHasComment`: a comma is only skipped *before* the closing
+// paren (a parameter-list trailing comma). A comma after the `)` belongs to
+// the enclosing list, so a comment beyond it is not a parameter comment and
+// must not make the rule abstain.
+//
+//  1. Parse `const a = [(x) => x, /* c */ 1];`.
+//  2. Apply format/arrow-parens with prefer:"avoid".
+//  3. Assert only the arrow changes: `const a = [x => x, /* c */ 1];`.
+func TestFormatArrowParensStripsWrappedParamBeforeListComma(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/arrow-parens",
+    "const a = [(x) => x, /* c */ 1];\n",
+    `{"prefer":"avoid"}`,
+    "const a = [x => x, /* c */ 1];\n",
+  )
+}

--- a/website/src/content/docs/lint/format.mdx
+++ b/website/src/content/docs/lint/format.mdx
@@ -69,7 +69,7 @@ One quote style throughout. Pick `"double"` (default) or `"single"`. Backticks a
 
 ### `arrowParens`
 
-Parentheses around a single arrow-function parameter. `"always"` (default) keeps `(x) => x`; `"avoid"` strips the parens of a single bare-identifier parameter, giving `x => x`. A typed, destructured, rest, optional, defaulted, or multi-parameter list keeps its parentheses in both modes. Driven by `format.arrowParens`.
+Parentheses around a single arrow-function parameter. `"always"` (default) keeps `(x) => x`; `"avoid"` strips the parens of a single bare-identifier parameter, giving `x => x`. A legal trailing comma counts as parenthesized: `"always"` leaves `(x,) => x` untouched, while `"avoid"` removes the comma together with the parens (`x => x`, matching Prettier). A typed, destructured, rest, optional, defaulted, or multi-parameter list keeps its parentheses in both modes, and a parameter carrying a comment is left alone. Driven by `format.arrowParens`.
 
 ### `bracketSpacing`
 


### PR DESCRIPTION
## Intent

`format/arrow-parens` misclassifies a single parameter followed by a legal trailing comma — `(x,) => y` — as **bare**, because wrappedness is detected by whitespace-only byte scans around the parameter *name* and the `,` aborts the forward scan (`rules_format_arrow_parens.go`). The default `"always"` mode then wraps the name a second time, shipping invalid `((x),) => y` (a parenthesized pattern is not a valid parameter → SyntaxError); `"avoid"` silently skips instead of printing `x => y` like Prettier.

Closes #367

## Scope

- `packages/lint/linthost/rules_format_arrow_parens.go`
  - The forward paren scan now starts at the parameter **list**'s AST end position instead of the name's end. The list span covers a trailing comma (that is exactly how the AST records `HasTrailingComma`: `last.End() < list.End()`), so a trailing-comma list is classified as wrapped with no byte special-casing. Bare arrows are unaffected (`Parameters.End() == param.End()` there).
  - `"always"` now leaves `(x,) => y` untouched; `"avoid"` deletes the comma together with the parens (the existing `[openParen, closeParen+1) → name` edit already spans it), yielding `x => y` — Prettier parity.
  - The comment data-safety guard (`arrowParamRegionHasComment`) tolerates one comma in the trailing trivia (only before the `)`), so `(x /* c */,) => y` and `(x, /* c */) => y` abstain in both modes instead of double-wrapping or deleting the comment.
- `website/src/content/docs/lint/format.mdx` — documents the trailing-comma and comment behavior under `arrowParens`.

Ineligible shapes (typed, defaulted, destructured, rest, optional, generic arrows) are excluded by `isBareIdentifierParam`/the type-parameter guard *before* the scan, so their behavior is unchanged — with or without a trailing comma.

## Test plan

New Go tests in `packages/lint/test/format/` (run by `scripts/test-go-lint.cjs` in CI):

- `…keeps_trailing_comma_param_under_always_test.go` — `(x,) => x` unchanged under "always" (the double-wrap regression), plus async and multiline variants.
- `…strips_trailing_comma_param_under_avoid_test.go` — `(x,) => x` → `x => x` under "avoid" (comma deleted with the parens), plus async (`async x => x`) and multiline variants.
- `…abstains_on_comment_near_trailing_comma_test.go` — comment before/after the comma abstains in both modes; comma-free `(x /* c */) => x` "avoid" twin.
- `…keeps_ineligible_trailing_comma_params_test.go` — typed `(x: number,)`, defaulted `(x = 1,)`, destructured `({ x },)`, generic `<T>(x: T,)` all keep parens under "avoid".

Negative twins for the base behavior are already pinned by the existing `wraps_bare_single_param` / `strips_single_param_under_avoid` / `idempotent_on_wrapped` tests. Verified locally that the package plus all test files compile (`go vet` via a scratch workspace mirroring the CI runner); test execution is left to CI per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB