### PR TITLE
fix(lint): refuse sort-imports merges that produce invalid import syntax

### DIFF
--- a/packages/lint/linthost/rules_format_sort_imports.go
+++ b/packages/lint/linthost/rules_format_sort_imports.go
@@ -595,7 +595,8 @@ func originalEntry(d siDecl) siEntry {
 // It returns the rendered text, whether the merged result is a type-only import,
 // and an `ok` flag that is false when the declarations cannot be merged
 // (conflicting default names, a type-only default that cannot survive in a
-// mixed value import, or a type-only default alongside named bindings).
+// mixed value import, a type-only default alongside named bindings, or a
+// bucket containing a namespace or comment-bearing declaration).
 func renderMergedDecl(group []siDecl, opts resolvedSortImportsOptions) (string, bool, bool) {
   mergedTypeOnly := true
   for _, d := range group {

--- a/packages/lint/linthost/rules_format_sort_imports.go
+++ b/packages/lint/linthost/rules_format_sort_imports.go
@@ -594,13 +594,23 @@ func originalEntry(d siDecl) siEntry {
 // renderMergedDecl folds a bucket of mergeable declarations into one statement.
 // It returns the rendered text, whether the merged result is a type-only import,
 // and an `ok` flag that is false when the declarations cannot be merged
-// (conflicting default names, or a type-only default that cannot survive in a
-// mixed value import).
+// (conflicting default names, a type-only default that cannot survive in a
+// mixed value import, or a type-only default alongside named bindings).
 func renderMergedDecl(group []siDecl, opts resolvedSortImportsOptions) (string, bool, bool) {
   mergedTypeOnly := true
   for _, d := range group {
     if !d.typeOnly {
       mergedTypeOnly = false
+    }
+    // Namespace bindings and comment-bearing declarations are never mergeable:
+    // the rebuilt statement carries no `* as ns` slot and would drop comment
+    // bytes. mergeKey normally isolates them in per-declaration buckets, but
+    // its key embeds the original text, so byte-identical declarations (a
+    // duplicate-binding error TypeScript reports later, which the parse-level
+    // formatter still sees) collide into one bucket. Refuse here so the
+    // originals are re-emitted verbatim instead of silently losing bindings.
+    if d.namespace || d.hasSpecComment {
+      return "", false, false
     }
   }
   defaultName := ""
@@ -622,6 +632,14 @@ func renderMergedDecl(group []siDecl, opts resolvedSortImportsOptions) (string, 
   }
   specs := collectMergedSpecs(group, mergedTypeOnly, opts.caseSensitive)
   if defaultName == "" && len(specs) == 0 {
+    return "", false, false
+  }
+  // A type-only import cannot carry both a default binding and named bindings:
+  // `import type D, { A } from "m"` is a syntax error (TS1363). Refuse the
+  // merge so the declarations stay separate. (A type-only default with an
+  // empty merged spec list still folds to `import type D from "m"`, which is
+  // legal.)
+  if mergedTypeOnly && defaultName != "" && len(specs) > 0 {
     return "", false, false
   }
 

--- a/packages/lint/test/format/format_sort_imports_keeps_identical_commented_imports_unmerged_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_identical_commented_imports_unmerged_test.go
@@ -1,0 +1,30 @@
+package linthost
+
+import "testing"
+
+// TestFormatSortImportsKeepsIdenticalCommentedImportsUnmerged verifies two
+// byte-identical comment-bearing imports are re-emitted verbatim rather than
+// merged into a comment-less declaration.
+//
+// Like namespace imports, comment-bearing declarations get a per-declaration
+// merge key that embeds the original text, so byte-identical duplicates (a
+// duplicate-binding error TypeScript reports later, which the parse-level
+// formatter still sees) collide into one bucket. Without the guard in
+// `renderMergedDecl` the rebuilt statement would join bare specifier texts
+// and silently drop the comment bytes.
+//
+//  1. Parse two identical named imports carrying a specifier comment plus a
+//     later-sorting third-party import.
+//  2. Apply the rule with default options.
+//  3. Assert both commented declarations survive verbatim, sorted first.
+func TestFormatSortImportsKeepsIdenticalCommentedImportsUnmerged(t *testing.T) {
+  source := "import { z } from \"z\";\n" +
+    "import { a /* keep */ } from \"m\";\n" +
+    "import { a /* keep */ } from \"m\";\n" +
+    "z;\n"
+  expected := "import { a /* keep */ } from \"m\";\n" +
+    "import { a /* keep */ } from \"m\";\n" +
+    "import { z } from \"z\";\n" +
+    "z;\n"
+  assertFixSnapshot(t, "format/sort-imports", source, expected)
+}

--- a/packages/lint/test/format/format_sort_imports_keeps_identical_namespace_imports_unmerged_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_identical_namespace_imports_unmerged_test.go
@@ -1,0 +1,30 @@
+package linthost
+
+import "testing"
+
+// TestFormatSortImportsKeepsIdenticalNamespaceImportsUnmerged verifies two
+// byte-identical `default, * as ns` imports are re-emitted verbatim rather
+// than merged into a namespace-less declaration.
+//
+// mergeKey isolates namespace imports by embedding the original text in the
+// key, so two byte-identical declarations (a duplicate-binding error
+// TypeScript reports later, which the parse-level formatter still sees)
+// collide into one bucket. Without the namespace guard in `renderMergedDecl`
+// the rebuilt statement would keep only the default binding and silently
+// drop `* as N`.
+//
+//  1. Parse two identical `import D, * as N` declarations plus a
+//     later-sorting third-party import.
+//  2. Apply the rule with default options.
+//  3. Assert both namespace declarations survive verbatim, sorted first.
+func TestFormatSortImportsKeepsIdenticalNamespaceImportsUnmerged(t *testing.T) {
+  source := "import { z } from \"z\";\n" +
+    "import D, * as N from \"m\";\n" +
+    "import D, * as N from \"m\";\n" +
+    "z;\n"
+  expected := "import D, * as N from \"m\";\n" +
+    "import D, * as N from \"m\";\n" +
+    "import { z } from \"z\";\n" +
+    "z;\n"
+  assertFixSnapshot(t, "format/sort-imports", source, expected)
+}

--- a/packages/lint/test/format/format_sort_imports_keeps_type_default_and_type_named_separate_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_type_default_and_type_named_separate_test.go
@@ -1,0 +1,29 @@
+package linthost
+
+import "testing"
+
+// TestFormatSortImportsKeepsTypeDefaultAndTypeNamedSeparate verifies a
+// type-only default import and a type-only named import of the same module
+// are not merged into one declaration.
+//
+// Locks the all-type-only guard in `renderMergedDecl`: merging would emit
+// `import type D, { A } from "m"`, which TypeScript rejects with TS1363 ("A
+// type-only import can specify a default import or named bindings, but not
+// both"), breaking the file for every later re-parse. The merge is refused
+// and both declarations survive, still grouped and sorted.
+//
+//  1. Parse a type-only default import and a type-only named import of the
+//     same module plus a later-sorting third-party import.
+//  2. Apply the rule with default options.
+//  3. Assert the two type-only declarations stay separate, sorted first.
+func TestFormatSortImportsKeepsTypeDefaultAndTypeNamedSeparate(t *testing.T) {
+  source := "import { z } from \"z\";\n" +
+    "import type D from \"m\";\n" +
+    "import type { A } from \"m\";\n" +
+    "z;\n"
+  expected := "import type D from \"m\";\n" +
+    "import type { A } from \"m\";\n" +
+    "import { z } from \"z\";\n" +
+    "z;\n"
+  assertFixSnapshot(t, "format/sort-imports", source, expected)
+}

--- a/packages/lint/test/format/format_sort_imports_keeps_type_default_and_type_named_separate_when_combining_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_type_default_and_type_named_separate_when_combining_test.go
@@ -1,0 +1,29 @@
+package linthost
+
+import "testing"
+
+// TestFormatSortImportsKeepsTypeDefaultAndTypeNamedSeparateWhenCombining
+// verifies the TS1363 guard also holds when `combineTypeAndValue` routes the
+// two type-only declarations through the shared value merge key.
+//
+// With `combineTypeAndValue: true` both declarations land in the `v\0m`
+// bucket instead of `t\0m`, but the bucket is still wholly type-only, so a
+// merge would produce the same illegal `import type D, { A } from "m"`
+// shape. The guard keys off the merged type-only state, not the bucket key,
+// so both option settings refuse the merge.
+//
+//  1. Parse a type-only default import and a type-only named import of the
+//     same module plus a later-sorting third-party import.
+//  2. Apply the rule with combineTypeAndValue enabled.
+//  3. Assert the two type-only declarations stay separate, sorted first.
+func TestFormatSortImportsKeepsTypeDefaultAndTypeNamedSeparateWhenCombining(t *testing.T) {
+  source := "import { z } from \"z\";\n" +
+    "import type D from \"m\";\n" +
+    "import type { A } from \"m\";\n" +
+    "z;\n"
+  expected := "import type D from \"m\";\n" +
+    "import type { A } from \"m\";\n" +
+    "import { z } from \"z\";\n" +
+    "z;\n"
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"combineTypeAndValue":true}`, expected)
+}

--- a/packages/lint/test/format/format_sort_imports_merges_type_default_with_empty_named_test.go
+++ b/packages/lint/test/format/format_sort_imports_merges_type_default_with_empty_named_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFormatSortImportsMergesTypeDefaultWithEmptyNamed verifies a type-only
+// default import still merges with an empty type-only named import of the
+// same module.
+//
+// Boundary of the TS1363 guard in `renderMergedDecl`: the guard refuses a
+// type-only default only when merged named specifiers exist. An empty named
+// list contributes none, so the bucket folds to the legal default-only form
+// `import type D from "m"` instead of falling back to two declarations.
+//
+//  1. Parse a type-only default import and an empty type-only named import
+//     of the same module.
+//  2. Apply the rule with default options.
+//  3. Assert one merged default-only `import type` declaration.
+func TestFormatSortImportsMergesTypeDefaultWithEmptyNamed(t *testing.T) {
+  source := "import type D from \"m\";\n" +
+    "import type {} from \"m\";\n"
+  expected := "import type D from \"m\";\n"
+  assertFixSnapshot(t, "format/sort-imports", source, expected)
+}

--- a/website/src/content/docs/lint/format.mdx
+++ b/website/src/content/docs/lint/format.mdx
@@ -94,7 +94,7 @@ The `order` array drives grouping. Each entry is a regular expression matched ag
 - `<TYPES>` — `import type` declarations (optionally scoped, e.g. `<TYPES>^[.]`).
 - `""` — emit one blank line at this position.
 
-The default `order` is `["<BUILTIN_MODULES>", "<THIRD_PARTY_MODULES>", "^[.]"]`, with **no** blank lines between groups (add `""` entries to insert them). Within each group declarations sort by specifier — case-insensitively unless `caseSensitive: true` — and named specifiers always sort. Duplicate imports of the same module are merged; `combineTypeAndValue: true` additionally folds a type-only import into a value import (`import { foo, type Bar } from "m"`). Autofixable.
+The default `order` is `["<BUILTIN_MODULES>", "<THIRD_PARTY_MODULES>", "^[.]"]`, with **no** blank lines between groups (add `""` entries to insert them). Within each group declarations sort by specifier — case-insensitively unless `caseSensitive: true` — and named specifiers always sort. Duplicate imports of the same module are merged; `combineTypeAndValue: true` additionally folds a type-only import into a value import (`import { foo, type Bar } from "m"`). A merge that would produce invalid syntax — such as a type-only default alongside type-only named bindings (`import type D, { A } from "m"` is TS1363) — is skipped, and the declarations stay separate while still grouped and sorted. Autofixable.
 
 ### `jsDoc`
 


### PR DESCRIPTION
## Intent

`format/sort-imports` merges a type-only default import with a type-only named import of the same module into `import type D, { A } from "m";`, which TypeScript rejects with **TS1363** ("A type-only import can specify a default import or named bindings, but not both") — the autofix leaves the file syntax-broken for every later re-parse in the formatter cascade. Reachable with default options. Closes #365.

## Scope

`packages/lint/linthost/rules_format_sort_imports.go`, `renderMergedDecl`:

- **The missing guard (the issue).** The sole default-vs-named guard fired only for mixed-value buckets (`!mergedTypeOnly`). Now, when the merged declaration is wholly type-only and carries both a default binding and at least one merged named specifier, the merge is refused and `mergeBucket` re-emits the per-declaration originals — still grouped and sorted, just not merged. The guard keys off the merged type-only state, not the bucket key, so it holds under both `combineTypeAndValue` settings (with `combineTypeAndValue: true` the same two declarations travel through the `v\0m` key instead of `t\0m` but the bucket is still wholly type-only). A type-only default merging with an *empty* named list still folds to the legal `import type D from "m"`.
- **Same root-cause class, sealed at the renderer.** Namespace (`* as ns`) and comment-bearing declarations are made unmergeable via per-declaration merge keys, but those keys embed the original text, so *byte-identical* declarations (a duplicate-binding error TypeScript reports later — the parse-level formatter still sees them) collide into one bucket, and the rebuilt statement silently dropped the `* as ns` binding (`import D, * as N from "m"` twice → `import D from "m"`) or the comment bytes. `renderMergedDecl` now refuses any bucket containing a namespace or comment-bearing declaration, so the originals are re-emitted verbatim.

Audit of the remaining shapes the renderer can produce — why each is legal or unreachable:

- **Side-effect-only imports** (`import "m"`) never reach the merge path: `containsSideEffectImport` bails the entire block reorder before `buildSortedImportBlock` runs.
- **`import D, * as N from "m"`** is legal input and never shares a bucket (namespace key), so it is only ever re-emitted verbatim; with the new renderer guard this holds even for the identical-text collision.
- **Mixed-value bucket with a type-only default** — already guarded (the pre-existing check).
- **Value default + named (incl. inline `type` specifiers)** → `import D, { type A, b } from "m"` — legal.
- **All-type-only, named only** → `import type { A, B } from "m"` — legal.
- **Conflicting default names** — already guarded.
- **Empty merge (no default, no specs)** — already guarded (`import {} from "m"` pairs stay separate).

Docs: `website/src/content/docs/lint/format.mdx` `sortImports` section now states that merges producing invalid syntax are skipped and the declarations stay separate.

## Test plan

Go unit tests in `packages/lint/test/format/` (one case per file, mirroring the existing sort-imports merge tests):

- `keeps_type_default_and_type_named_separate` — the issue's exact input stays two valid sorted statements (fails before the fix with the TS1363 output, passes after).
- `keeps_type_default_and_type_named_separate_when_combining` — same guard under `combineTypeAndValue: true` (fails before, passes after).
- `merges_type_default_with_empty_named` — boundary: type-only default + `import type {} from "m"` still merges to the legal default-only form (passes before and after; pins the guard's `len(specs) > 0` edge).
- `keeps_identical_namespace_imports_unmerged` — byte-identical `import D, * as N` pair re-emitted verbatim instead of dropping `* as N` (fails before, passes after).
- `keeps_identical_commented_imports_unmerged` — byte-identical commented pair re-emitted verbatim instead of dropping the comment (fails before, passes after).

Negative twins already pinned by existing tests (verified still green alongside the whole sort-imports merge family locally via the CI scratch-workspace runner with a `-run` filter): two named type imports still merge (`merges_duplicate_type_only_imports`), value default + value named still merge (`merges_default_and_named`), plus `combines_type_and_value`, `dedupes_repeated_specifier`, `keeps_conflicting_defaults_separate`, `keeps_empty_named_imports`, `keeps_namespace_imports_separate`, and the comment/attribute unmerged family.

CI validates the full suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB
