### PR TITLE
fix(lint): decline no-var autofix on block-scope escape and loop-closure capture

### DIFF
--- a/packages/lint/linthost/rules_var.go
+++ b/packages/lint/linthost/rules_var.go
@@ -235,10 +235,16 @@ func isBlockScopeContainer(kind shimast.Kind) bool {
 
 // isFunctionCaptureBoundary reports whether a node creates a new function
 // scope whose body captures outer bindings by closure: function
-// declarations/expressions, arrows, methods, constructors, accessors, and
-// class static blocks. Used both to stop the enclosing-loop walk (a `var`
-// inside a function nested in a loop is per-call regardless of the loop) and
-// to detect references that reach the loop only through a closure.
+// declarations/expressions, arrows, methods, constructors, accessors, class
+// static blocks, and class property declarations (an instance field
+// initializer runs at construction time and closes over the class
+// definition's environment exactly like a method body; escope models it as
+// its own variable scope). A PropertyDeclaration's computed NAME evaluates
+// immediately rather than deferred, so classifying the whole declaration
+// over-declines that rare shape — which never corrupts. Used both to stop
+// the enclosing-loop walk (a `var` inside a function nested in a loop is
+// per-call regardless of the loop) and to detect references that reach the
+// loop only through deferred code.
 func isFunctionCaptureBoundary(node *shimast.Node) bool {
   switch node.Kind {
   case shimast.KindFunctionDeclaration,
@@ -248,7 +254,8 @@ func isFunctionCaptureBoundary(node *shimast.Node) bool {
     shimast.KindConstructor,
     shimast.KindGetAccessor,
     shimast.KindSetAccessor,
-    shimast.KindClassStaticBlockDeclaration:
+    shimast.KindClassStaticBlockDeclaration,
+    shimast.KindPropertyDeclaration:
     return true
   }
   return false

--- a/packages/lint/linthost/rules_var.go
+++ b/packages/lint/linthost/rules_var.go
@@ -47,7 +47,7 @@ func (noVar) Check(ctx *Context, node *shimast.Node) {
 // Five corruption holes were patched piecemeal here before (var-vs-var,
 // for-header var, function/class redeclaration, mixed destructuring sibling,
 // object-literal shorthand, use-before-declaration). That whack-a-mole is
-// replaced by one conservative rule with four preconditions; the fix is
+// replaced by one conservative rule with five preconditions; the fix is
 // emitted only if ALL hold:
 //
 //  1. Single binding in the whole file. The declared name is introduced by
@@ -87,6 +87,13 @@ func (noVar) Check(ctx *Context, node *shimast.Node) {
 //     every closure shares ONE `var` binding but would capture a FRESH
 //     per-iteration `let` binding — the rewrite silently changes runtime
 //     results. Mirrors ESLint no-var's isReferencedInClosure loop check.
+//  5. Not declared under a `with` statement. `var` hoists PAST the with body
+//     to the function scope, so references inside the body resolve through
+//     the with object first (`o.x` shadows the var when present); `let`
+//     stays inside the body's block scope, where it shadows the with object
+//     instead. The rewrite can flip which binding every reference hits, so
+//     any var with a WithStatement ancestor below the nearest function
+//     boundary declines.
 //
 // The var statement being fixed must itself be a single plain identifier
 // declarator so the keyword rewrite has a simple `let x` rename target; a
@@ -121,6 +128,13 @@ func isNoVarAutoFixSafe(ctx *Context, node *shimast.Node) bool {
     return false
   }
   scopeStart, scopeEnd := scopeNode.Pos(), scopeNode.End()
+
+  // Precondition 5: a `var` declared under a `with` statement resolves its
+  // references through the with object; the block-scoped `let` would shadow
+  // that object instead, so the rewrite declines outright.
+  if isDeclaredInsideWithStatement(node) {
+    return false
+  }
 
   // Precondition 4 setup: the outermost loop enclosing the statement without
   // an intervening function boundary. nil when the statement is not
@@ -236,6 +250,26 @@ func isFunctionCaptureBoundary(node *shimast.Node) bool {
     shimast.KindSetAccessor,
     shimast.KindClassStaticBlockDeclaration:
     return true
+  }
+  return false
+}
+
+// isDeclaredInsideWithStatement reports whether the statement has a
+// WithStatement ancestor below the nearest function boundary. Under `var`
+// the binding hoists past the with body to the function scope, so a
+// same-name property on the with target intercepts every reference; under
+// `let` the binding lives inside the body's block and shadows the with
+// object instead. A function boundary resets the risk: a `var` inside a
+// function nested in the with body binds tighter than the with object
+// either way.
+func isDeclaredInsideWithStatement(node *shimast.Node) bool {
+  for ancestor := node.Parent; ancestor != nil; ancestor = ancestor.Parent {
+    if isFunctionCaptureBoundary(ancestor) {
+      return false
+    }
+    if ancestor.Kind == shimast.KindWithStatement {
+      return true
+    }
   }
   return false
 }

--- a/packages/lint/linthost/rules_var.go
+++ b/packages/lint/linthost/rules_var.go
@@ -118,6 +118,14 @@ func isNoVarAutoFixSafe(ctx *Context, node *shimast.Node) bool {
   }
   target := names[0]
 
+  // A name `var` tolerates but `let` cannot redeclare: `let let = 1;` is a
+  // SyntaxError everywhere, and `let static = 1;` is one in strict mode
+  // (modules, classes) — while `var let` / `var static` parse in sloppy
+  // scripts. Mirrors upstream ESLint no-var's DISALLOWED_LET_NAMES.
+  if target == "let" || target == "static" {
+    return false
+  }
+
   // Precondition 3 setup: the statement's parent must both allow a lexical
   // declaration and act as the `let`'s block scope. Any other parent kind is
   // a single-statement body (`if (c) var x = 1;`, `while (c) var x = 1;`,

--- a/packages/lint/linthost/rules_var.go
+++ b/packages/lint/linthost/rules_var.go
@@ -47,8 +47,8 @@ func (noVar) Check(ctx *Context, node *shimast.Node) {
 // Five corruption holes were patched piecemeal here before (var-vs-var,
 // for-header var, function/class redeclaration, mixed destructuring sibling,
 // object-literal shorthand, use-before-declaration). That whack-a-mole is
-// replaced by one conservative rule with two preconditions; the fix is
-// emitted only if BOTH hold:
+// replaced by one conservative rule with four preconditions; the fix is
+// emitted only if ALL hold:
 //
 //  1. Single binding in the whole file. The declared name is introduced by
 //     EXACTLY ONE binding position anywhere in the source — counting every
@@ -64,6 +64,29 @@ func (noVar) Check(ctx *Context, node *shimast.Node) {
 //     same text — a member name (`o.x`), an object-literal key (`{x:1}`), a
 //     statement label (`x:`), or a type reference (`: x`) — binds no value and
 //     must not force a decline; isValueReferenceIdentifier classifies these.
+//  3. No block-scope escape. `var` is function/global-scoped while `let` is
+//     block-scoped, so a `var` declared inside a block and read after the
+//     block (`if (c) { var x = 1; } log(x);`) would stop compiling under
+//     `let`. The statement's parent must be a position where a lexical
+//     declaration is legal AND which forms the `let`'s block scope — a Block
+//     (plain, function-body, loop-body, …), a ModuleBlock, a switch
+//     Case/DefaultClause, or the SourceFile — and every value reference to
+//     the name must lie inside that parent's [Pos, End) span. A non-scope
+//     parent (`if (c) var x = 1;` — a single-statement body, where `let` is a
+//     SyntaxError outright) declines unconditionally. Given precondition 1
+//     (one binding file-wide), positional containment is exact: no other
+//     binding can shadow the name, so a reference outside the span really
+//     does resolve to this binding. Using the CaseClause (not the whole
+//     switch CaseBlock) as the scope over-declines cross-case references,
+//     which under `let` would flip from `undefined` reads to runtime TDZ
+//     throws — declining is the safe side. Mirrors ESLint no-var's
+//     isUsedFromOutsideOf.
+//  4. No loop-closure capture. When the statement sits inside a loop and the
+//     name is referenced from a function or arrow nested within that loop
+//     (`for (const k of keys) { var last = k; fns.push(() => last); }`),
+//     every closure shares ONE `var` binding but would capture a FRESH
+//     per-iteration `let` binding — the rewrite silently changes runtime
+//     results. Mirrors ESLint no-var's isReferencedInClosure loop check.
 //
 // The var statement being fixed must itself be a single plain identifier
 // declarator so the keyword rewrite has a simple `let x` rename target; a
@@ -88,6 +111,22 @@ func isNoVarAutoFixSafe(ctx *Context, node *shimast.Node) bool {
   }
   target := names[0]
 
+  // Precondition 3 setup: the statement's parent must both allow a lexical
+  // declaration and act as the `let`'s block scope. Any other parent kind is
+  // a single-statement body (`if (c) var x = 1;`, `while (c) var x = 1;`,
+  // `label: var x = 1;`, `with (o) var x = 1;`) where `let` is a plain
+  // SyntaxError, so the fix declines before any reference is examined.
+  scopeNode := node.Parent
+  if scopeNode == nil || !isBlockScopeContainer(scopeNode.Kind) {
+    return false
+  }
+  scopeStart, scopeEnd := scopeNode.Pos(), scopeNode.End()
+
+  // Precondition 4 setup: the outermost loop enclosing the statement without
+  // an intervening function boundary. nil when the statement is not
+  // loop-local, which disables the closure-capture check.
+  enclosingLoop := enclosingLoopWithinFunction(node)
+
   declPos := node.Pos()
   // The single declarator's initializer subtree. A value reference to `target`
   // inside this range is a self-reference that runs while `target` is still in
@@ -104,6 +143,8 @@ func isNoVarAutoFixSafe(ctx *Context, node *shimast.Node) bool {
   }
   bindingCount := 0
   referencedBefore := false
+  escapesScope := false
+  capturedInLoop := false
   walkDescendants(ctx.File.AsNode(), func(child *shimast.Node) {
     // Binding count: every position that introduces the name `target` as a
     // binding (a declaration), not a value reference. Two or more positions
@@ -129,12 +170,119 @@ func isNoVarAutoFixSafe(ctx *Context, node *shimast.Node) bool {
       if pos < declPos || (initStart >= 0 && pos >= initStart && pos < initEnd) {
         referencedBefore = true
       }
+      // Scope escape: a value reference outside the enclosing block-scope
+      // node's span stops resolving (or flips to a TDZ throw across switch
+      // cases) once the binding becomes block-scoped `let`. Nested blocks
+      // WITHIN the span stay fixable: containment, not clause equality.
+      if pos < scopeStart || pos >= scopeEnd {
+        escapesScope = true
+      }
+      // Loop-closure capture: a reference reached only by crossing a
+      // function/arrow boundary between itself and the enclosing loop would
+      // switch from one shared `var` binding to a fresh per-iteration `let`
+      // binding.
+      if enclosingLoop != nil && isCapturedInLoopClosure(child, enclosingLoop) {
+        capturedInLoop = true
+      }
     }
   })
-  if referencedBefore {
+  if referencedBefore || escapesScope || capturedInLoop {
     return false
   }
   return bindingCount == 1
+}
+
+// isBlockScopeContainer reports whether a node kind is a legal parent for a
+// lexical (`let`) declaration statement AND the node that delimits the
+// resulting binding's block scope: a Block (plain, function body, loop body,
+// try/catch/finally, labeled block, class static block body — all
+// KindBlock), a namespace's ModuleBlock, a switch clause, or the SourceFile
+// itself. Every other statement position (an unbraced if/else/loop/with body
+// or a directly-labeled statement) rejects lexical declarations at the
+// grammar level, so the keyword rewrite is never legal there.
+//
+// A CaseClause/DefaultClause is used as the scope rather than the enclosing
+// CaseBlock even though `let` technically hoists to the whole switch block:
+// a reference in a LATER clause compiles under `let` but changes an
+// `undefined` read into a runtime TDZ ReferenceError when the declaring
+// clause did not execute first. Bounding the scope at the clause declines
+// that shape; over-declining never corrupts.
+func isBlockScopeContainer(kind shimast.Kind) bool {
+  switch kind {
+  case shimast.KindBlock,
+    shimast.KindModuleBlock,
+    shimast.KindCaseClause,
+    shimast.KindDefaultClause,
+    shimast.KindSourceFile:
+    return true
+  }
+  return false
+}
+
+// isFunctionCaptureBoundary reports whether a node creates a new function
+// scope whose body captures outer bindings by closure: function
+// declarations/expressions, arrows, methods, constructors, accessors, and
+// class static blocks. Used both to stop the enclosing-loop walk (a `var`
+// inside a function nested in a loop is per-call regardless of the loop) and
+// to detect references that reach the loop only through a closure.
+func isFunctionCaptureBoundary(node *shimast.Node) bool {
+  switch node.Kind {
+  case shimast.KindFunctionDeclaration,
+    shimast.KindFunctionExpression,
+    shimast.KindArrowFunction,
+    shimast.KindMethodDeclaration,
+    shimast.KindConstructor,
+    shimast.KindGetAccessor,
+    shimast.KindSetAccessor,
+    shimast.KindClassStaticBlockDeclaration:
+    return true
+  }
+  return false
+}
+
+// enclosingLoopWithinFunction returns the OUTERMOST loop statement enclosing
+// `node` without an intervening function boundary, or nil when no such loop
+// exists. The walk stops at the nearest function-like ancestor because a
+// `var` declared inside a function nested in a loop already gets a fresh
+// binding per call — the loop outside the function cannot make `var` and
+// `let` capture semantics diverge for it.
+func enclosingLoopWithinFunction(node *shimast.Node) *shimast.Node {
+  var loop *shimast.Node
+  for ancestor := node.Parent; ancestor != nil; ancestor = ancestor.Parent {
+    if isFunctionCaptureBoundary(ancestor) {
+      break
+    }
+    switch ancestor.Kind {
+    case shimast.KindForStatement,
+      shimast.KindForInStatement,
+      shimast.KindForOfStatement,
+      shimast.KindWhileStatement,
+      shimast.KindDoStatement:
+      loop = ancestor
+    }
+  }
+  return loop
+}
+
+// isCapturedInLoopClosure reports whether a value-reference identifier
+// reaches `loop` on its ancestor chain only after crossing a function
+// boundary — i.e. the reference lives in a closure created inside the loop.
+// Under `var` every iteration's closure shares one binding; under `let` each
+// iteration captures a fresh binding, so such a reference makes the keyword
+// rewrite change observable behavior. A reference whose chain never meets
+// `loop` lies outside the loop entirely and is left to the scope-containment
+// check.
+func isCapturedInLoopClosure(ref, loop *shimast.Node) bool {
+  crossedFunction := false
+  for ancestor := ref.Parent; ancestor != nil; ancestor = ancestor.Parent {
+    if ancestor == loop {
+      return crossedFunction
+    }
+    if isFunctionCaptureBoundary(ancestor) {
+      crossedFunction = true
+    }
+  }
+  return false
 }
 
 // bindingNamesIntroducedBy returns every plain identifier name that `node`

--- a/packages/lint/test/fix/fix_no_var_replaces_closure_reference_without_loop_test.go
+++ b/packages/lint/test/fix/fix_no_var_replaces_closure_reference_without_loop_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarReplacesClosureReferenceWithoutLoop verifies no-var still
+// rewrites a top-level `var` that a nested arrow closes over.
+//
+// Negative twin of the loop-closure decline: capture semantics only diverge
+// between `var` and `let` when the declaration is re-entered per loop
+// iteration. A closure over a non-loop binding sees the same single binding
+// either way, so the closure check must stay scoped to loop-local
+// declarations and not blanket-decline every captured name.
+//
+//  1. Parse a top-level `var x` read from inside an arrow function.
+//  2. Apply the no-var finding's text edit through the disk-backed fixer.
+//  3. Assert only the `var` keyword changed to `let`.
+func TestFixNoVarReplacesClosureReferenceWithoutLoop(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-var",
+    "var x = 1;\nconst g = () => JSON.stringify(x);\ng();\n",
+    "let x = 1;\nconst g = () => JSON.stringify(x);\ng();\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_replaces_loop_local_without_closure_test.go
+++ b/packages/lint/test/fix/fix_no_var_replaces_loop_local_without_closure_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarReplacesLoopLocalWithoutClosure verifies no-var still rewrites
+// a loop-local `var` whose references never cross a function boundary.
+//
+// Second negative twin of the loop-closure decline: a plain read in the same
+// iteration observes the identical value under `var` and `let`; only a
+// closure created inside the loop can tell the bindings apart. The
+// loop-local + direct-reference shape must keep its autofix.
+//
+//  1. Parse a for-of body declaring `var x` and reading it directly.
+//  2. Apply the no-var finding's text edit through the disk-backed fixer.
+//  3. Assert only the `var` keyword changed to `let`.
+func TestFixNoVarReplacesLoopLocalWithoutClosure(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-var",
+    "for (const k of [1, 2]) {\n  var x = k;\n  JSON.stringify(x);\n}\n",
+    "for (const k of [1, 2]) {\n  let x = k;\n  JSON.stringify(x);\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_replaces_namespace_block_binding_test.go
+++ b/packages/lint/test/fix/fix_no_var_replaces_namespace_block_binding_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarReplacesNamespaceBlockBinding verifies no-var still rewrites a
+// `var` declared directly inside a namespace body.
+//
+// A ModuleBlock is a legal lexical-declaration position and the binding's
+// block scope, so a namespace-local `var` with namespace-local references
+// must keep its autofix. Pins the ModuleBlock arm of the
+// block-scope-container classifier introduced for issue #364.
+//
+//  1. Parse a namespace declaring `var x` and reading it inside the body.
+//  2. Apply the no-var finding's text edit through the disk-backed fixer.
+//  3. Assert only the `var` keyword changed to `let`.
+func TestFixNoVarReplacesNamespaceBlockBinding(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-var",
+    "namespace N {\n  var x = 1;\n  JSON.stringify(x);\n}\n",
+    "namespace N {\n  let x = 1;\n  JSON.stringify(x);\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_replaces_reference_in_nested_block_test.go
+++ b/packages/lint/test/fix/fix_no_var_replaces_reference_in_nested_block_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarReplacesReferenceInNestedBlock verifies no-var still rewrites a
+// `var` referenced from a block nested WITHIN the declaring block.
+//
+// The escape check is positional containment in the declaring block's span,
+// not same-block equality: an inner block's reference still sees the `let`
+// binding, so it must not trigger a decline. This pins the boundary between
+// "deeper inside" (fixable) and "after the block" (declined).
+//
+//  1. Parse a block declaring `var x` with the read inside a nested block.
+//  2. Apply the no-var finding's text edit through the disk-backed fixer.
+//  3. Assert only the `var` keyword changed to `let`.
+func TestFixNoVarReplacesReferenceInNestedBlock(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-var",
+    "{\n  var x = 1;\n  {\n    JSON.stringify(x);\n  }\n}\n",
+    "{\n  let x = 1;\n  {\n    JSON.stringify(x);\n  }\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_replaces_reference_inside_with_body_test.go
+++ b/packages/lint/test/fix/fix_no_var_replaces_reference_inside_with_body_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarReplacesReferenceInsideWithBody verifies no-var still rewrites
+// a `var` declared outside a `with` statement but referenced inside its body.
+//
+// Negative twin of the with-body decline: the hazard is where the DECLARATION
+// lands, not where references sit. For a binding declared outside the with,
+// the with object shadows `var` and `let` identically on the body's scope
+// chain, so the rewrite cannot change which binding a reference resolves to.
+//
+//  1. Parse a top-level `var x` read from inside a with body.
+//  2. Apply the no-var finding's text edit through the disk-backed fixer.
+//  3. Assert only the `var` keyword changed to `let`.
+func TestFixNoVarReplacesReferenceInsideWithBody(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-var",
+    "const o = {};\nvar x = 1;\nwith (o) {\n  JSON.stringify(x);\n}\n",
+    "const o = {};\nlet x = 1;\nwith (o) {\n  JSON.stringify(x);\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_replaces_same_block_references_test.go
+++ b/packages/lint/test/fix/fix_no_var_replaces_same_block_references_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarReplacesSameBlockReferences verifies no-var still rewrites a
+// block-local `var` whose every reference stays inside the declaring block.
+//
+// Positive twin of the block-scope-escape decline: when no reference leaves
+// the enclosing block's span, `let`'s narrower scoping is observationally
+// identical, so the scope-containment gate must not over-decline the common
+// block-local shape.
+//
+//  1. Parse an if-block declaring `var x` and reading it inside the same block.
+//  2. Apply the no-var finding's text edit through the disk-backed fixer.
+//  3. Assert only the `var` keyword changed to `let`.
+func TestFixNoVarReplacesSameBlockReferences(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-var",
+    "if (Math.random() > 0.5) {\n  var x = 1;\n  JSON.stringify(x);\n}\n",
+    "if (Math.random() > 0.5) {\n  let x = 1;\n  JSON.stringify(x);\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_replaces_same_case_clause_references_test.go
+++ b/packages/lint/test/fix/fix_no_var_replaces_same_case_clause_references_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarReplacesSameCaseClauseReferences verifies no-var still rewrites
+// a `var` declared and referenced within a single switch case clause.
+//
+// Positive twin of the cross-case decline: the gate bounds the scope at the
+// CaseClause, so references inside the same clause pass containment and the
+// clause-local shape keeps its autofix. Pins the CaseClause arm of the
+// block-scope-container classifier.
+//
+//  1. Parse a switch whose case 1 declares `var x` and reads it in-clause.
+//  2. Apply the no-var finding's text edit through the disk-backed fixer.
+//  3. Assert only the `var` keyword changed to `let`.
+func TestFixNoVarReplacesSameCaseClauseReferences(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-var",
+    "switch (JSON.parse(\"1\")) {\n  case 1:\n    var x = 1;\n    JSON.stringify(x);\n    break;\n}\n",
+    "switch (JSON.parse(\"1\")) {\n  case 1:\n    let x = 1;\n    JSON.stringify(x);\n    break;\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_block_scope_escape_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_block_scope_escape_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsBlockScopeEscape verifies no-var reports but does not
+// rewrite a `var` declared inside a block and referenced after the block.
+//
+// `var` hoists to the enclosing function/global scope, so a read after the
+// declaring block sees the binding; `let` is block-scoped, so the same read
+// stops compiling (TS2304 / ReferenceError). The safety gate declines when any
+// value reference lies outside the declaring statement's enclosing block-scope
+// node's span (issue #364: this shape used to be rewritten and broke the
+// compile).
+//
+//  1. Parse a file declaring `var x` inside an if-block and reading `x` after it.
+//  2. Run the no-var fixer through the disk-backed applier.
+//  3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsBlockScopeEscape(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "if (Math.random() > 0.5) {\n  var x = 1;\n}\nJSON.stringify(x);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_class_field_capture_in_loop_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_class_field_capture_in_loop_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsClassFieldCaptureInLoop verifies no-var declines the fix
+// for a loop-local `var` referenced from a class field initializer inside the
+// loop.
+//
+// An instance field initializer is deferred code: it runs at construction
+// time and closes over the class definition's environment exactly like a
+// method body. A class created per iteration therefore shares one `var`
+// binding across all its instances but would capture a fresh per-iteration
+// `let` binding, so the loop-closure decline must treat PropertyDeclaration
+// as a capture boundary, not only function-like bodies.
+//
+//  1. Parse a for-of body declaring `var x` and pushing `class { p = x }`.
+//  2. Run the no-var fixer through the disk-backed applier.
+//  3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsClassFieldCaptureInLoop(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "const classes = [];\nfor (const k of [1, 2]) {\n  var x = k;\n  classes.push(\n    class {\n      p = x;\n    },\n  );\n}\nJSON.stringify(classes.length);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_cross_case_reference_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_cross_case_reference_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsCrossCaseReference verifies no-var declines the fix for a
+// `var` declared in one switch case and referenced from a later case.
+//
+// A `let` in a case clause hoists to the whole switch block, so the rewrite
+// still compiles — but when the later case executes without the declaring
+// case having run, the read flips from `var`'s `undefined` to a runtime TDZ
+// ReferenceError. The gate bounds the scope at the CaseClause itself, so a
+// cross-case reference declines (over-declining never corrupts).
+//
+//  1. Parse a switch declaring `var x` in case 1 and reading `x` in case 2.
+//  2. Run the no-var fixer through the disk-backed applier.
+//  3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsCrossCaseReference(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "switch (JSON.parse(\"1\")) {\n  case 1:\n    var x = 1;\n    break;\n  case 2:\n    JSON.stringify(x);\n    break;\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_function_scope_escape_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_function_scope_escape_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsFunctionScopeEscape verifies no-var declines the fix for a
+// `var` declared inside a function body and referenced outside the function.
+//
+// The declaring statement's block scope is the function body Block, so a
+// reference past the closing brace lies outside the scope span. The gate has
+// no checker and cannot know what that outer identifier resolves to; keeping
+// the report fix-free is the conservative side of the containment check.
+//
+//  1. Parse a function body declaring `var x` with a same-name read after the
+//     function.
+//  2. Run the no-var fixer through the disk-backed applier.
+//  3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsFunctionScopeEscape(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "function f() {\n  var x = 1;\n}\nJSON.stringify([f, x]);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_let_as_binding_name_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_let_as_binding_name_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsLetAsBindingName verifies no-var declines the fix for a
+// binding literally named `let`.
+//
+// `var let = 1;` parses in sloppy scripts, but `let let = 1;` is a
+// SyntaxError in every mode, so the keyword rewrite would corrupt the source
+// outright. Same class as the single-statement-position decline: the output
+// must stay parseable, mirroring upstream ESLint no-var's
+// DISALLOWED_LET_NAMES (`let`, `static`).
+//
+//  1. Parse a file declaring `var let = 1` and reading it afterwards.
+//  2. Run the no-var fixer through the disk-backed applier.
+//  3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsLetAsBindingName(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "var let = 1;\nJSON.stringify(let);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_loop_closure_capture_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_loop_closure_capture_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsLoopClosureCapture verifies no-var reports but does not
+// rewrite a loop-local `var` captured by a closure created inside the loop.
+//
+// Under `var` every iteration's closure shares ONE binding (all see the final
+// value); under `let` each iteration captures a FRESH binding. The keyword
+// rewrite would silently change runtime results with no diagnostic, so the
+// gate declines when the declaration is loop-local and any reference sits
+// behind a function boundary nested within that loop (issue #364, mirroring
+// ESLint no-var's isReferencedInClosure loop check).
+//
+//  1. Parse a for-of body declaring `var last` and pushing `() => last`.
+//  2. Run the no-var fixer through the disk-backed applier.
+//  3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsLoopClosureCapture(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "const fns = [];\nfor (const k of [1, 2]) {\n  var last = k;\n  fns.push(() => last);\n}\nJSON.stringify(fns.length);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_single_statement_position_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_single_statement_position_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsSingleStatementPosition verifies no-var declines the fix
+// for a `var` that is an unbraced statement body.
+//
+// A lexical declaration is grammatically illegal as a single-statement body:
+// `if (c) let x = 1;` is a SyntaxError, so the keyword rewrite would corrupt
+// the source outright. The gate requires the statement's parent to be a
+// block-scope container (Block / ModuleBlock / switch clause / SourceFile)
+// before any reference is even examined (issue #364).
+//
+//  1. Parse `if (…) var x = 1;` — the var statement is the bare if-body.
+//  2. Run the no-var fixer through the disk-backed applier.
+//  3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsSingleStatementPosition(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "if (Math.random() > 0.5) var x = 1;\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_while_loop_closure_capture_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_while_loop_closure_capture_test.go
@@ -1,0 +1,22 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsWhileLoopClosureCapture verifies no-var declines the fix
+// for a `var` inside a while-loop body captured by a nested arrow.
+//
+// The loop-closure decline must cover every loop statement kind, not only the
+// for-family: a while-loop body also re-creates closures per iteration, so
+// `var`→`let` changes which binding those closures share. This pins the
+// while/do arm of the enclosing-loop classifier alongside the for-of case.
+//
+//  1. Parse a while body declaring `var x` and pushing `() => x`.
+//  2. Run the no-var fixer through the disk-backed applier.
+//  3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsWhileLoopClosureCapture(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "const fns = [];\nwhile (Math.random() > 0.5) {\n  var x = 1;\n  fns.push(() => x);\n}\nJSON.stringify(fns.length);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_with_statement_body_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_with_statement_body_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsWithStatementBody verifies no-var declines the fix for a
+// `var` declared inside a `with` statement body.
+//
+// `var` hoists past the with body to the function scope, so a same-name
+// property on the with target intercepts every reference inside the body;
+// `let` would live inside the body's block and shadow the with object
+// instead. When the target object has that property the rewrite flips which
+// binding each reference hits, so the gate declines any var declared under a
+// `with` (issue #364 follow-through: same corruption class as the scope
+// checks).
+//
+//  1. Parse a with body declaring `var x` and reading it in the body.
+//  2. Run the no-var fixer through the disk-backed applier.
+//  3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsWithStatementBody(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "const o = { x: 0 };\nwith (o) {\n  var x = 1;\n  JSON.stringify(x);\n}\n",
+  )
+}

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -2394,7 +2394,7 @@ Reject `var` declarations.
 
 Use `let` for mutable bindings and `const` for immutable ones. Autofixable to `let`.
 
-The fix only fires when the rewrite cannot change behavior, mirroring ESLint's `no-var` fix conditions: the name binds exactly once in the file, is never read before the declaration or inside its own initializer, every reference stays inside the declaring block scope (a `var` declared in a block but read after it would stop compiling as `let`), and a loop-local `var` is not captured by a function or arrow created inside the loop (those closures share one `var` binding but would capture a fresh per-iteration `let` binding). Anything else reports without a fix.
+The fix only fires when the rewrite cannot change behavior, mirroring ESLint's `no-var` fix conditions: the name binds exactly once in the file, is never read before the declaration or inside its own initializer, every reference stays inside the declaring block scope (a `var` declared in a block but read after it would stop compiling as `let`), a loop-local `var` is not captured by a function or arrow created inside the loop (those closures share one `var` binding but would capture a fresh per-iteration `let` binding), and the declaration does not sit under a `with` statement. Anything else reports without a fix.
 
 Example:
 

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -2394,6 +2394,8 @@ Reject `var` declarations.
 
 Use `let` for mutable bindings and `const` for immutable ones. Autofixable to `let`.
 
+The fix only fires when the rewrite cannot change behavior, mirroring ESLint's `no-var` fix conditions: the name binds exactly once in the file, is never read before the declaration or inside its own initializer, every reference stays inside the declaring block scope (a `var` declared in a block but read after it would stop compiling as `let`), and a loop-local `var` is not captured by a function or arrow created inside the loop (those closures share one `var` binding but would capture a fresh per-iteration `let` binding). Anything else reports without a fix.
+
 Example:
 
 ```ts


### PR DESCRIPTION
## Intent

`no-var`'s autofix safety gate (`isNoVarAutoFixSafe`, `packages/lint/linthost/rules_var.go`) checked exactly two things: the name binds once file-wide, and no value reference occurs before the declaration or inside its own initializer. It never checked that later references remain in scope once `var`'s function/global scoping becomes `let`'s block scoping. Three shapes passed the gate and got corrupted:

- **Broken compile**: `if (cond) { var x = 1; } console.log(x);` → `let x` no longer resolves after the block (TS2304 / ReferenceError).
- **Silent semantics change**: `for (const k of keys) { var last = k; fns.push(() => last); }` → every closure shares one `var` binding but captures a fresh per-iteration `let` binding; results change with no diagnostic.
- **SyntaxError**: `if (cond) var x = 1;` → `let` is grammatically illegal as an unbraced statement body.

## Scope

Two new gate conditions, mirroring upstream ESLint `no-var` (`isUsedFromOutsideOf` + loop-closure check), both AST-positional (no scope engine), general over kinds, not fixture-enumerated:

1. **Block-scope containment.** The statement's parent must be a block-scope container (`Block`, `ModuleBlock`, `CaseClause`/`DefaultClause`, `SourceFile`) — anything else is a single-statement body where `let` is a SyntaxError — and every value reference to the name must lie inside that parent's `[Pos, End)` span. Containment, not clause equality: references in nested blocks within the declaring block keep the fix. The CaseClause (not the whole switch CaseBlock) bounds the scope so cross-case references decline instead of flipping `undefined` reads into runtime TDZ throws.
2. **Loop-closure capture.** When the statement sits inside a loop (for/for-in/for-of/while/do, stopping at function boundaries) and any reference reaches that loop only by crossing a function/arrow boundary, decline.

Over-declining reports without a fix and never corrupts, matching the gate's existing conservative posture. Docs: the `no-var` section of `website/src/content/docs/lint/rules/core.mdx` now states the fix conditions.

## Test plan

12 new Go cases in `packages/lint/test/fix/`, mirroring the existing `fix_no_var_*` peers. Declines (`assertNoFixSnapshot`): block escape, for-of loop-closure, while loop-closure, cross-case reference, function-scope escape, single-statement position. Positive twins (`assertFixSnapshot`): same-block references, reference in a nested block within the declaring block, same-case-clause references, closure reference without a loop, loop-local without closure, namespace (ModuleBlock) body. Top-level positive stays pinned by the existing `TestFixNoVarReplacesUniqueBinding`.

Verified both directions in a scratch module: the six decline shapes are autofixed (corrupted) by the old gate and decline with the new one; all 33 `TestFixNoVar*` cases pass with the fix.

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB