### PR TITLE
fix(lint): keep non-string sub-chains whole in prefer-template autofix

### DIFF
--- a/packages/lint/linthost/rules_suggestions.go
+++ b/packages/lint/linthost/rules_suggestions.go
@@ -1226,13 +1226,20 @@ func flattenConcatOperands(node *shimast.Node) []*shimast.Node {
 
 // concatChainContainsString reports whether a `+` chain (or a single
 // operand) contains a string-like operand: a string literal, a template
-// literal (with or without substitutions), or a nested `+` chain that
-// itself contains one. This is the flattening gate for
-// flattenConcatOperands. Once a string-like operand appears in a
-// left-associative chain, every later `+` is string concatenation, so
-// splitting the chain into template segments preserves the value; a
-// chain with none may be numeric addition and must stay whole.
+// literal (with or without substitutions), or a nested `+` chain —
+// parenthesized or not — that itself contains one. This is the
+// flattening gate for flattenConcatOperands. Once a string-like operand
+// appears in a left-associative chain, every later `+` is string
+// concatenation, so splitting the chain into template segments preserves
+// the value; a chain with none may be numeric addition and must stay
+// whole. Parentheses are transparent to the DECISION (`("a" + b) + c`
+// is a string chain, so `c` still gets its own slot) even though the
+// flattener keeps the parenthesized operand itself as one slot. A
+// string-like node under any other operator (e.g. `a * "x"`) does NOT
+// qualify: that subexpression coerces away from string, so its chain
+// may still be numeric addition.
 func concatChainContainsString(node *shimast.Node) bool {
+  node = stripParens(node)
   if node == nil {
     return false
   }
@@ -1242,11 +1249,7 @@ func concatChainContainsString(node *shimast.Node) bool {
       return concatChainContainsString(bin.Left) || concatChainContainsString(bin.Right)
     }
   }
-  inner := stripParens(node)
-  if inner == nil {
-    return false
-  }
-  return isStringLikeLiteral(inner) || inner.Kind == shimast.KindTemplateExpression
+  return isStringLikeLiteral(node) || node.Kind == shimast.KindTemplateExpression
 }
 
 // renderConcatAsTemplate renders the flattened concat operands as a single

--- a/packages/lint/linthost/rules_suggestions.go
+++ b/packages/lint/linthost/rules_suggestions.go
@@ -1198,17 +1198,24 @@ func concatChainShape(node *shimast.Node) (hasString bool, hasOther bool) {
 }
 
 // flattenConcatOperands walks a `+` chain left-to-right and returns each
-// leaf operand in source order. Parenthesized sub-expressions are kept as
-// a single operand so the rendered template literal does not lose their
-// grouping. Mirrors ESLint's behavior of treating `("a" + b)` as one
-// expression slot when it appears inside a larger chain.
+// leaf operand in source order. It only descends into a `+` subtree that
+// itself contains a string-like operand (see
+// concatChainContainsString): a subtree without one — the `a + b` in
+// `a + b + " items"` — evaluates BEFORE any string concatenation, so
+// splitting it into separate `${a}${b}` slots would change the runtime
+// value (numeric 3 becomes the digits "12"). Such a subtree stays one
+// operand and renders as a single `${a + b}` slot, mirroring upstream
+// ESLint prefer-template, which embeds non-string sub-chains as one
+// expression. Parenthesized sub-expressions are likewise kept as a
+// single operand so the rendered template literal does not lose their
+// grouping.
 func flattenConcatOperands(node *shimast.Node) []*shimast.Node {
   if node == nil {
     return nil
   }
   if node.Kind == shimast.KindBinaryExpression {
     bin := node.AsBinaryExpression()
-    if bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == shimast.KindPlusToken {
+    if bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == shimast.KindPlusToken && concatChainContainsString(node) {
       out := flattenConcatOperands(bin.Left)
       out = append(out, flattenConcatOperands(bin.Right)...)
       return out
@@ -1217,17 +1224,58 @@ func flattenConcatOperands(node *shimast.Node) []*shimast.Node {
   return []*shimast.Node{node}
 }
 
+// concatChainContainsString reports whether a `+` chain (or a single
+// operand) contains a string-like operand: a string literal, a template
+// literal (with or without substitutions), or a nested `+` chain that
+// itself contains one. This is the flattening gate for
+// flattenConcatOperands. Once a string-like operand appears in a
+// left-associative chain, every later `+` is string concatenation, so
+// splitting the chain into template segments preserves the value; a
+// chain with none may be numeric addition and must stay whole.
+func concatChainContainsString(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  if node.Kind == shimast.KindBinaryExpression {
+    bin := node.AsBinaryExpression()
+    if bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == shimast.KindPlusToken {
+      return concatChainContainsString(bin.Left) || concatChainContainsString(bin.Right)
+    }
+  }
+  inner := stripParens(node)
+  if inner == nil {
+    return false
+  }
+  return isStringLikeLiteral(inner) || inner.Kind == shimast.KindTemplateExpression
+}
+
 // renderConcatAsTemplate renders the flattened concat operands as a single
 // backtick template literal. String-like literals contribute their value
 // directly (with template-specific escaping); any other expression becomes
 // a `${…}` placeholder copied verbatim from the source text. Returns ok=false
 // when an operand cannot be rendered (typically because its source range is
 // unavailable), so the caller falls back to detection-only.
+//
+// Adjacent literal operands are merged into one cooked run BEFORE
+// escaping. Escaping each literal on its own cannot see across the seam,
+// so `"$" + "{"` would emit `$` then `{` — fusing into a live `${`
+// interpolation opener in the rendered template. Escaping the merged run
+// makes escapeTemplateLiteralBody's `${` lookahead total over the body.
+// The only other seam, a literal's trailing `$` followed by an emitted
+// `${…}` placeholder, is safe: `$${expr}` parses as a literal `$` plus
+// the interpolation, which matches the original `"$" + expr` value.
 func renderConcatAsTemplate(src string, operands []*shimast.Node) (string, bool) {
   if len(operands) == 0 {
     return "", false
   }
   var sb strings.Builder
+  var literal strings.Builder
+  flushLiteral := func() {
+    if literal.Len() > 0 {
+      sb.WriteString(escapeTemplateLiteralBody(literal.String()))
+      literal.Reset()
+    }
+  }
   sb.WriteByte('`')
   for _, operand := range operands {
     if operand == nil {
@@ -1235,7 +1283,7 @@ func renderConcatAsTemplate(src string, operands []*shimast.Node) (string, bool)
     }
     inner := stripParens(operand)
     if isStringLikeLiteral(inner) {
-      sb.WriteString(escapeTemplateLiteralBody(stringLiteralText(inner)))
+      literal.WriteString(stringLiteralText(inner))
       continue
     }
     pos := shimscanner.SkipTrivia(src, operand.Pos())
@@ -1243,10 +1291,12 @@ func renderConcatAsTemplate(src string, operands []*shimast.Node) (string, bool)
     if pos < 0 || pos >= end || end > len(src) {
       return "", false
     }
+    flushLiteral()
     sb.WriteString("${")
     sb.WriteString(src[pos:end])
     sb.WriteByte('}')
   }
+  flushLiteral()
   sb.WriteByte('`')
   return sb.String(), true
 }

--- a/packages/lint/test/rules/strings-regex/prefer_template_fix_embeds_numeric_subchain_as_single_slot_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_fix_embeds_numeric_subchain_as_single_slot_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferTemplateEmbedsNumericSubchainAsSingleSlot verifies that a
+// `+` subtree with no string-like operand stays one `${…}` slot:
+// `a + b + " items"` → “ `${a + b} items` “.
+//
+// Left-associativity makes the chain `(a + b) + " items"`, so `a + b`
+// evaluates BEFORE the string concatenation — numeric addition for
+// numbers. Flattening it into `${a}${b}` silently changes the runtime
+// value (3 becomes "12" for a=1, b=2). Upstream ESLint prefer-template
+// embeds the non-string sub-chain as a single expression; this pins the
+// flattening gate in `flattenConcatOperands`.
+//
+// 1. Snapshot a chain whose left sub-chain contains no string literal.
+// 2. Apply `prefer-template` fix.
+// 3. Assert the sub-chain renders as one `${a + b}` slot.
+func TestFixPreferTemplateEmbedsNumericSubchainAsSingleSlot(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "prefer-template",
+    "const a: any = 1;\nconst b: any = 2;\nconst s = a + b + \" items\";\nJSON.stringify(s);\n",
+    "const a: any = 1;\nconst b: any = 2;\nconst s = `${a + b} items`;\nJSON.stringify(s);\n",
+  )
+}

--- a/packages/lint/test/rules/strings-regex/prefer_template_fix_escapes_dollar_brace_seam_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_fix_escapes_dollar_brace_seam_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferTemplateEscapesDollarBraceSeam verifies that a `$` ending
+// one literal operand and a `{` starting the next cannot fuse into a
+// live `${` interpolation: `"$" + "{" + n` → “ `\${${n}` “.
+//
+// Escaping each literal segment on its own cannot see across the seam —
+// `escapeTemplateLiteralBody("$")` leaves the `$` bare because the `{`
+// lives in the NEXT segment, so the joined body would open a real
+// interpolation and the fix output would not even re-parse. The
+// renderer must merge adjacent literal operands into one cooked run
+// before escaping, producing `\${` whose cooked value stays "${".
+//
+// 1. Snapshot a chain whose literals spell `$` then `{` back to back.
+// 2. Apply `prefer-template` fix.
+// 3. Assert the seam is escaped and the cooked value is preserved.
+func TestFixPreferTemplateEscapesDollarBraceSeam(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "prefer-template",
+    "const n: any = 1;\nconst s = \"$\" + \"{\" + n;\nJSON.stringify(s);\n",
+    "const n: any = 1;\nconst s = `\\${${n}`;\nJSON.stringify(s);\n",
+  )
+}

--- a/packages/lint/test/rules/strings-regex/prefer_template_fix_flattens_operands_after_leading_string_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_fix_flattens_operands_after_leading_string_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferTemplateFlattensOperandsAfterLeadingString verifies the
+// negative twin of the numeric-subchain gate: `"count: " + a + b` →
+// “ `count: ${a}${b}` “.
+//
+// Here the string literal is the FIRST operand, so every later `+` in
+// the left-associative chain is string concatenation and flattening
+// each operand into its own slot preserves the value. The gate in
+// `flattenConcatOperands` must keep descending into sub-chains that
+// contain a string-like operand — over-correcting to `${a + b}` here
+// would itself change the value ("count: 12" is correct, not
+// "count: 3").
+//
+// 1. Snapshot a chain whose leftmost operand is a string literal.
+// 2. Apply `prefer-template` fix.
+// 3. Assert each trailing operand keeps its own `${…}` slot.
+func TestFixPreferTemplateFlattensOperandsAfterLeadingString(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "prefer-template",
+    "const a: any = 1;\nconst b: any = 2;\nconst s = \"count: \" + a + b;\nJSON.stringify(s);\n",
+    "const a: any = 1;\nconst b: any = 2;\nconst s = `count: ${a}${b}`;\nJSON.stringify(s);\n",
+  )
+}

--- a/packages/lint/test/rules/strings-regex/prefer_template_fix_flattens_template_expression_subchain_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_fix_flattens_template_expression_subchain_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferTemplateFlattensTemplateExpressionSubchain verifies that
+// a template literal WITH substitutions marks its sub-chain string-like:
+// “ a + `x${y}` + "s" “ → “ `${a}${`x${y}`}s` “.
+//
+// The containment gate must treat `KindTemplateExpression` the same as
+// a plain string literal — upstream ESLint's `isStringLiteral` covers
+// template literals — because a template operand forces every `+` in
+// its sub-chain to be string concatenation, making per-operand slots
+// value-preserving. Only counting `KindStringLiteral` would demote the
+// sub-chain to one `${a + `x${y}`}` slot.
+//
+// 1. Snapshot a chain whose only left-side string-like operand is a
+//    substitution template.
+// 2. Apply `prefer-template` fix.
+// 3. Assert the sub-chain flattens into per-operand slots.
+func TestFixPreferTemplateFlattensTemplateExpressionSubchain(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "prefer-template",
+    "const a: any = 1;\nconst y: any = 2;\nconst s = a + `x${y}` + \"s\";\nJSON.stringify(s);\n",
+    "const a: any = 1;\nconst y: any = 2;\nconst s = `${a}${`x${y}`}s`;\nJSON.stringify(s);\n",
+  )
+}

--- a/packages/lint/test/rules/strings-regex/prefer_template_fix_ignores_string_under_other_operator_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_fix_ignores_string_under_other_operator_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferTemplateIgnoresStringUnderOtherOperator verifies a
+// string literal under a NON-`+` operator does not mark its chain
+// string-like: `a * "x" + c + " s"` → “ `${a * "x" + c} s` “.
+//
+// `a * "x"` coerces the string to a number, so `(a * "x") + c` may be
+// numeric addition and must stay one `${…}` slot. The containment gate
+// only recurses through `+` (and parentheses); treating any descendant
+// string literal as evidence would reintroduce the value corruption
+// the gate exists to prevent, just one operator deeper.
+//
+// 1. Snapshot a chain whose only inner string sits under `*`.
+// 2. Apply `prefer-template` fix.
+// 3. Assert the non-string sub-chain stays a single slot.
+func TestFixPreferTemplateIgnoresStringUnderOtherOperator(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "prefer-template",
+    "const a: any = 1;\nconst c: any = 2;\nconst s = a * \"x\" + c + \" s\";\nJSON.stringify(s);\n",
+    "const a: any = 1;\nconst c: any = 2;\nconst s = `${a * \"x\" + c} s`;\nJSON.stringify(s);\n",
+  )
+}

--- a/packages/lint/test/rules/strings-regex/prefer_template_fix_keeps_parenthesized_subchain_single_slot_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_fix_keeps_parenthesized_subchain_single_slot_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferTemplateKeepsParenthesizedSubchainSingleSlot verifies
+// that an explicitly parenthesized sub-chain stays one `${…}` slot:
+// `(a + b) + " s"` → “ `${(a + b)} s` “.
+//
+// The author's grouping is semantically load-bearing — `(a + b)` may be
+// numeric addition — and the flattener must not descend through a
+// ParenthesizedExpression even though the inner node is a `+` chain.
+// This pins the paren-leaf branch alongside the new containment gate so
+// neither regresses the other.
+//
+// 1. Snapshot a chain whose left operand is a parenthesized `+` chain.
+// 2. Apply `prefer-template` fix.
+// 3. Assert the parenthesized sub-chain renders as one slot, verbatim.
+func TestFixPreferTemplateKeepsParenthesizedSubchainSingleSlot(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "prefer-template",
+    "const a: any = 1;\nconst b: any = 2;\nconst s = (a + b) + \" s\";\nJSON.stringify(s);\n",
+    "const a: any = 1;\nconst b: any = 2;\nconst s = `${(a + b)} s`;\nJSON.stringify(s);\n",
+  )
+}

--- a/packages/lint/test/rules/strings-regex/prefer_template_fix_renders_empty_string_operand_as_bare_placeholder_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_fix_renders_empty_string_operand_as_bare_placeholder_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferTemplateRendersEmptyStringOperandAsBarePlaceholder
+// verifies the empty-literal boundary: `"" + a` → “ `${a}` “.
+//
+// The empty string contributes zero cooked characters, so the merged
+// literal run is empty and the renderer's flush must emit nothing —
+// the template collapses to a single placeholder. This pins the
+// `literal.Len() > 0` guard in `renderConcatAsTemplate`; an
+// unconditional flush would still work here, so the case doubles as
+// the smallest single-expression template output the fixer produces.
+//
+// 1. Snapshot a concat whose only literal is the empty string.
+// 2. Apply `prefer-template` fix.
+// 3. Assert the output is a bare `${a}` template.
+func TestFixPreferTemplateRendersEmptyStringOperandAsBarePlaceholder(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "prefer-template",
+    "const a: any = 1;\nconst s = \"\" + a;\nJSON.stringify(s);\n",
+    "const a: any = 1;\nconst s = `${a}`;\nJSON.stringify(s);\n",
+  )
+}

--- a/packages/lint/test/rules/strings-regex/prefer_template_fix_sees_string_through_parens_when_flattening_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_fix_sees_string_through_parens_when_flattening_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferTemplateSeesStringThroughParensWhenFlattening verifies
+// parentheses are transparent to the flattening DECISION:
+// `("a" + b) + c + " s"` → “ `${("a" + b)}${c} s` “.
+//
+// The parenthesized operand itself stays one slot, but its string
+// literal still marks the enclosing chain as string concatenation —
+// `("a" + b)` evaluates to a string, so `+ c` appends and `c` can keep
+// its own `${c}` slot. Were the containment gate opaque to parens it
+// would demote the whole left side to `${("a" + b) + c}` — still
+// value-correct, but a needless behavior regression from the pre-gate
+// fixer and from upstream ESLint, which flattens here.
+//
+// 1. Snapshot a chain whose only string literal hides inside parens.
+// 2. Apply `prefer-template` fix.
+// 3. Assert `c` still flattens into its own slot.
+func TestFixPreferTemplateSeesStringThroughParensWhenFlattening(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "prefer-template",
+    "const b: any = 1;\nconst c: any = 2;\nconst s = (\"a\" + b) + c + \" s\";\nJSON.stringify(s);\n",
+    "const b: any = 1;\nconst c: any = 2;\nconst s = `${(\"a\" + b)}${c} s`;\nJSON.stringify(s);\n",
+  )
+}

--- a/packages/lint/test/rules/strings-regex/prefer_template_skips_all_literal_chain_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_skips_all_literal_chain_test.go
@@ -1,0 +1,22 @@
+package linthost
+
+import "testing"
+
+// TestPreferTemplateSkipsAllLiteralChain verifies the rule stays silent
+// on a chain of nothing but string literals: `"a" + "b"`.
+//
+// All-literal concatenation is `no-useless-concat` territory — upstream
+// prefer-template only fires when a non-literal operand is mixed in, so
+// this chain must produce zero findings rather than an `` `ab` ``
+// rewrite. Pins the `hasOther` half of the detection gate against the
+// flattening changes in the fixer.
+//
+// 1. Feed an all-string-literal `+` chain to the rule.
+// 2. Assert prefer-template reports no findings at all.
+func TestPreferTemplateSkipsAllLiteralChain(t *testing.T) {
+  assertRuleSkipsSource(
+    t,
+    "prefer-template",
+    "const s = \"a\" + \"b\";\nJSON.stringify(s);\n",
+  )
+}

--- a/packages/lint/test/rules/strings-regex/prefer_template_skips_numeric_only_chain_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_skips_numeric_only_chain_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestPreferTemplateSkipsNumericOnlyChain verifies the rule stays
+// silent on a `+` chain with no string-like operand: `1 + 2 + n`.
+//
+// Without a string literal anywhere in the chain the addition may be
+// numeric, so there is nothing to convert to a template literal —
+// firing here (or worse, fixing) would wrap arithmetic in `${…}` for
+// no reason. Pins the `hasString && hasOther` detection gate that the
+// new flattening gate leans on: the fixer only ever sees chains that
+// contain at least one string-like operand.
+//
+// 1. Feed a numeric-only `+` chain to the rule.
+// 2. Assert prefer-template reports no findings at all.
+func TestPreferTemplateSkipsNumericOnlyChain(t *testing.T) {
+  assertRuleSkipsSource(
+    t,
+    "prefer-template",
+    "const n: any = 3;\nconst s = 1 + 2 + n;\nJSON.stringify(s);\n",
+  )
+}


### PR DESCRIPTION
## Intent

Fix two independent value-corruption defects in the `prefer-template` autofix (#363):

1. **Numeric sub-chain flattening.** `flattenConcatOperands` recursed into every `+` subtree, so the left-associative `a + b + " items"` became `` `${a}${b} items` ``. Since `(a + b)` evaluates before the string concatenation, the rewrite silently changed the runtime value (with `a = 1, b = 2`: `"3 items"` → `"12 items"`).
2. **`$`+`{` seam fusion.** Each literal segment was escaped in isolation, so `"$" + "{" + n` joined into a live `${` interpolation opener — the fixed output didn't even re-parse.

## Scope

`packages/lint/linthost/rules_suggestions.go` only:

- New containment predicate `concatChainContainsString`: a `+` subtree is flattened only when it contains a string-like operand (string literal, template literal with or without substitutions, or a nested chain containing one). A subtree with none stays a single `${a + b}` slot — the upstream ESLint `prefer-template` oracle behavior. This is a general containment gate, not a node-kind blacklist.
- `renderConcatAsTemplate` now merges adjacent literal operands into one cooked run before calling `escapeTemplateLiteralBody`, making the `${` lookahead total across former segment seams. The remaining seam class (literal trailing `$` before an emitted `${…}` placeholder, `$${expr}`) parses as a literal `$` plus the interpolation and preserves the original value, so it needs no escaping.

Detection behavior is unchanged; the website rule page documents detection only, so no docs change.

## Test plan

Go tests under `packages/lint/test/rules/strings-regex/`, one case per file. Verified locally via the scratch-module targeted runner (full suites run in CI):

- `a + b + " items"` → `` `${a + b} items` `` — **fails before the fix** (`` `${a}${b} items` ``), passes after.
- `"$" + "{" + n` → `` `\${${n}` `` — **fails before the fix** (live `${` fusion), passes after; cooked value validated by evaluation.
- Negative twin: `"count: " + a + b` → `` `count: ${a}${b}` `` — string-first flattening is correct and must not be over-corrected.
- `(a + b) + " s"` → `` `${(a + b)} s` `` — parenthesized sub-chain stays one slot.
- `` a + `x${y}` + "s" `` → `` `${a}${`x${y}`}s` `` — substitution template marks its sub-chain string-like (containment branch).
- `"" + a` → `` `${a}` `` — empty-literal flush boundary.
- Numeric-only chain `1 + 2 + n` and all-literal chain `"a" + "b"` — rule stays silent.
- All six pre-existing prefer-template tests (3-part chain, leading identifier, backtick escape, CR/LF preservation, corpus) still pass.

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB