### PR TITLE
fix(lint): parenthesize no-extra-boolean-cast splices by precedence and decline comment-lossy fixes

### DIFF
--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -113,6 +113,37 @@ func tokenRange(file *shimast.SourceFile, node *shimast.Node) (int, int) {
   return pos, end
 }
 
+// hasCommentBetween reports whether a comment begins anywhere in the source
+// range [from, to). Fixers whose TextEdit keeps only part of the replaced
+// span use it on the discarded sub-ranges: a comment there would be silently
+// deleted by the edit, so the fix must be declined.
+//
+// The scan alternates SkipTriviaEx (whitespace, with StopAtComments so a
+// comment opener is not consumed) with a two-byte opener check that
+// distinguishes `//` and `/*` from a bare slash token. Non-trivia token
+// bytes are stepped over one at a time, so an opener lookalike inside a
+// string literal within the range would over-detect; callers only ever
+// decline an autofix on a hit, which is the safe direction.
+func hasCommentBetween(src string, from, to int) bool {
+  if from < 0 {
+    return false
+  }
+  if to > len(src) {
+    to = len(src)
+  }
+  for pos := from; pos < to; {
+    next := shimscanner.SkipTriviaEx(src, pos, &shimscanner.SkipTriviaOptions{StopAtComments: true})
+    if next < pos || next >= to {
+      return false
+    }
+    if src[next] == '/' && next+1 < len(src) && (src[next+1] == '/' || src[next+1] == '*') {
+      return true
+    }
+    pos = next + 1
+  }
+  return false
+}
+
 // isIdentifierPart reports whether `ch` can appear inside a JavaScript
 // identifier — used as a word-boundary guard by keyword search helpers.
 // Handles only ASCII; multibyte Unicode identifier parts are treated as

--- a/packages/lint/linthost/rules_logic.go
+++ b/packages/lint/linthost/rules_logic.go
@@ -49,23 +49,7 @@ func (noExtraBooleanCast) Check(ctx *Context, node *shimast.Node) {
       ctx.Report(node, message)
       return
     }
-    src := ctx.File.Text()
-    argStart := shimscanner.SkipTrivia(src, arg.Pos())
-    argEnd := arg.End()
-    if argStart < 0 || argStart >= argEnd || argEnd > len(src) {
-      ctx.Report(node, message)
-      return
-    }
-    editPos := shimscanner.SkipTrivia(src, node.Pos())
-    if editPos < 0 || editPos >= node.End() {
-      ctx.Report(node, message)
-      return
-    }
-    ctx.ReportFix(
-      node,
-      message,
-      TextEdit{Pos: editPos, End: node.End(), Text: src[argStart:argEnd]},
-    )
+    reportBooleanCastFix(ctx, node, arg, message)
   case shimast.KindPrefixUnaryExpression:
     outer := node.AsPrefixUnaryExpression()
     if outer == nil || outer.Operator != shimast.KindExclamationToken {
@@ -83,28 +67,88 @@ func (noExtraBooleanCast) Check(ctx *Context, node *shimast.Node) {
       return
     }
     message := "Redundant double negation."
-    if inner.Operand == nil {
-      ctx.Report(node, message)
-      return
-    }
-    src := ctx.File.Text()
-    inStart := shimscanner.SkipTrivia(src, inner.Operand.Pos())
-    inEnd := inner.Operand.End()
-    if inStart < 0 || inStart >= inEnd || inEnd > len(src) {
-      ctx.Report(node, message)
-      return
-    }
-    editPos := shimscanner.SkipTrivia(src, node.Pos())
-    if editPos < 0 || editPos >= node.End() {
-      ctx.Report(node, message)
-      return
-    }
-    ctx.ReportFix(
-      node,
-      message,
-      TextEdit{Pos: editPos, End: node.End(), Text: src[inStart:inEnd]},
-    )
+    reportBooleanCastFix(ctx, node, inner.Operand, message)
   }
+}
+
+// reportBooleanCastFix reports a redundant boolean cast covering `node` and,
+// when safe, attaches the autofix that splices the inner expression's source
+// text over the whole cast. Two hazards can make the raw splice unsafe, and
+// both mirror upstream ESLint's fixer (#362):
+//
+//   - Precedence. In the two expression-level boolean contexts the rule
+//     accepts — `!` operand and ternary condition — a replacement that binds
+//     no tighter than the context re-associates: `!Boolean(a && b)` spliced
+//     bare becomes `!a && b`, which is `(!a) && b`. The replacement is
+//     wrapped in parentheses when the inner expression's precedence is at or
+//     below the context's floor. Statement conditions (`if`/`while`/`do`/
+//     `for`) need no wrap: the statement's own parentheses contain the
+//     result, as do explicit parentheses around the cast itself.
+//   - Comments. The splice keeps only the inner expression's text, so a
+//     comment anywhere else in the replaced span (`!Boolean(/* why */ ok)`)
+//     would be silently deleted. The fix is declined — report only — when
+//     the replaced span contains a comment outside the kept text.
+func reportBooleanCastFix(ctx *Context, node, inner *shimast.Node, message string) {
+  if inner == nil {
+    ctx.Report(node, message)
+    return
+  }
+  src := ctx.File.Text()
+  keepStart := shimscanner.SkipTrivia(src, inner.Pos())
+  keepEnd := inner.End()
+  if keepStart < 0 || keepStart >= keepEnd || keepEnd > len(src) {
+    ctx.Report(node, message)
+    return
+  }
+  editPos := shimscanner.SkipTrivia(src, node.Pos())
+  if editPos < 0 || editPos >= node.End() || node.End() > len(src) {
+    ctx.Report(node, message)
+    return
+  }
+  if hasCommentBetween(src, editPos, keepStart) ||
+    hasCommentBetween(src, keepEnd, node.End()) {
+    ctx.Report(node, message)
+    return
+  }
+  text := src[keepStart:keepEnd]
+  if floor, bounded := booleanContextPrecedenceFloor(node); bounded &&
+    shimast.GetExpressionPrecedence(inner) <= floor {
+    text = "(" + text + ")"
+  }
+  ctx.ReportFix(node, message, TextEdit{Pos: editPos, End: node.End(), Text: text})
+}
+
+// booleanContextPrecedenceFloor returns the precedence at or below which a
+// replacement spliced over `node` re-associates with its surroundings, and
+// whether such a floor applies at all.
+//
+// Only the two expression-level boolean contexts are bounded: an `!` operand
+// must bind tighter than a unary expression (`!(a && b)`, and the grammar
+// even rejects `!x ** 2` outright), and a ternary condition must bind
+// tighter than the conditional itself (`(x = f()) ? a : b`,
+// `(a ? b : c) ? x : y`). The statement conditions `isInBooleanContext`
+// accepts are unbounded — their mandatory parentheses already contain the
+// replacement — and so is a cast explicitly wrapped in parentheses, because
+// the direct parent is then the ParenthesizedExpression, not the `!` or
+// ternary beyond it.
+func booleanContextPrecedenceFloor(node *shimast.Node) (shimast.OperatorPrecedence, bool) {
+  parent := node.Parent
+  if parent == nil {
+    return shimast.OperatorPrecedenceInvalid, false
+  }
+  switch parent.Kind {
+  case shimast.KindPrefixUnaryExpression:
+    prefix := parent.AsPrefixUnaryExpression()
+    if prefix != nil && prefix.Operator == shimast.KindExclamationToken {
+      return shimast.OperatorPrecedenceUnary, true
+    }
+  case shimast.KindConditionalExpression:
+    cond := parent.AsConditionalExpression()
+    if cond != nil && cond.Condition == node {
+      return shimast.OperatorPrecedenceConditional, true
+    }
+  }
+  return shimast.OperatorPrecedenceInvalid, false
 }
 
 // isInBooleanContext walks up the parent chain to determine whether the

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_declines_fix_for_comment_between_bangs_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_declines_fix_for_comment_between_bangs_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestNoExtraBooleanCastDeclinesFixForCommentBetweenBangs verifies that
+// `if (!/* c */!x)` still reports but offers no autofix — the comment
+// bail-out on the double-bang branch of the rule.
+//
+// Both fixer branches share the same raw-splice construction, so the
+// double-bang rewrite deletes an in-operator comment exactly like the
+// Boolean-call one (#362). This pins the shared bail-out on the second
+// branch rather than only the call branch.
+//
+// 1. Snapshot `if (!/* c */!x)` source.
+// 2. Run `no-extra-boolean-cast` through the fix applier.
+// 3. Assert a finding is reported but zero edits are applied.
+func TestNoExtraBooleanCastDeclinesFixForCommentBetweenBangs(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(x: any) {\n  if (!/* c */!x) {\n    return 1;\n  }\n  return 0;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_declines_fix_for_leading_comment_in_call_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_declines_fix_for_leading_comment_in_call_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestNoExtraBooleanCastDeclinesFixForLeadingCommentInCall verifies that
+// `!Boolean(/* why */ ok)` still reports but offers no autofix — the
+// comment bail-out for a comment between `Boolean(` and the argument.
+//
+// The fix keeps only the argument's own text, so a comment ahead of it
+// inside the call would be silently deleted (#362). Upstream ESLint's fixer
+// bails out on comment loss; the port declines the same way and leaves the
+// finding report-only.
+//
+// 1. Snapshot `const z = !Boolean(/* why */ ok);` source.
+// 2. Run `no-extra-boolean-cast` through the fix applier.
+// 3. Assert a finding is reported but zero edits are applied.
+func TestNoExtraBooleanCastDeclinesFixForLeadingCommentInCall(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(ok: any) {\n  const z = !Boolean(/* why */ ok);\n  return z;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_declines_fix_for_trailing_comment_in_call_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_declines_fix_for_trailing_comment_in_call_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestNoExtraBooleanCastDeclinesFixForTrailingCommentInCall verifies that a
+// line comment between the argument and the closing paren still reports but
+// offers no autofix — the comment bail-out for the trailing gap of the call.
+//
+// The argument's node span ends before its trailing trivia, so a comment
+// after it inside the call sits in the discarded region of the splice and
+// would be deleted (#362). This pins the trailing-gap scan (and the `//`
+// opener) separately from the leading-gap `/* */` case.
+//
+// 1. Snapshot `!Boolean(ok // why` with the `)` on the next line.
+// 2. Run `no-extra-boolean-cast` through the fix applier.
+// 3. Assert a finding is reported but zero edits are applied.
+func TestNoExtraBooleanCastDeclinesFixForTrailingCommentInCall(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(ok: any) {\n  const z = !Boolean(ok // why\n  );\n  return z;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_collapses_nested_boolean_call_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_collapses_nested_boolean_call_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBooleanCastCollapsesNestedBooleanCall verifies the
+// `if (Boolean(Boolean(x)))` → `if (Boolean(x))` rewrite — one cascade pass
+// over a nested redundant cast.
+//
+// Only the outer call sits in a boolean context (the inner one is a call
+// argument), so a single pass peels exactly one layer; the fix cascade
+// re-runs until convergence in the real `ttsc fix` flow. This pins that the
+// nested-call splice stays bare — a CallExpression argument binds far above
+// any context floor, so #362's wrap must not fire on it.
+//
+// 1. Snapshot `if (Boolean(Boolean(x)))` source.
+// 2. Apply one `no-extra-boolean-cast` fix pass.
+// 3. Assert the outer cast collapses to `if (Boolean(x))` without parens.
+func TestFixNoExtraBooleanCastCollapsesNestedBooleanCall(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(x: any) {\n  if (Boolean(Boolean(x))) {\n    return 1;\n  }\n  return 0;\n}\nJSON.stringify(f);\n",
+    "function f(x: any) {\n  if (Boolean(x)) {\n    return 1;\n  }\n  return 0;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_keeps_bare_identifier_under_bang_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_keeps_bare_identifier_under_bang_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBooleanCastKeepsBareIdentifierUnderBang verifies the
+// `!Boolean(x)` → `!x` rewrite gains no parentheses — the negative twin of
+// the precedence-wrap branch in an `!`-operand context.
+//
+// An identifier binds at Primary precedence, far above the Unary floor, so
+// wrapping would be pure noise (`!(x)`). This pins that the #362 fix wraps
+// only when the argument actually re-associates.
+//
+// 1. Snapshot `const y = !Boolean(x);` source.
+// 2. Apply `no-extra-boolean-cast` fix.
+// 3. Assert the bare splice `!x` with no added parentheses.
+func TestFixNoExtraBooleanCastKeepsBareIdentifierUnderBang(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(x: any) {\n  const y = !Boolean(x);\n  return y;\n}\nJSON.stringify(f);\n",
+    "function f(x: any) {\n  const y = !x;\n  return y;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_keeps_parenthesized_argument_without_double_wrap_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_keeps_parenthesized_argument_without_double_wrap_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBooleanCastKeepsParenthesizedArgumentWithoutDoubleWrap
+// verifies the `!Boolean((a && b))` → `!(a && b)` rewrite — the boundary
+// where the argument already carries its own parentheses.
+//
+// A ParenthesizedExpression binds at the highest precedence, so the #362
+// wrap must not fire again; double-wrapping would emit `!((a && b))`. The
+// splice keeps the author's parens verbatim and adds none.
+//
+// 1. Snapshot `const y = !Boolean((a && b));` source.
+// 2. Apply `no-extra-boolean-cast` fix.
+// 3. Assert exactly one paren pair survives: `!(a && b)`.
+func TestFixNoExtraBooleanCastKeepsParenthesizedArgumentWithoutDoubleWrap(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(a: any, b: any) {\n  const y = !Boolean((a && b));\n  return y;\n}\nJSON.stringify(f);\n",
+    "function f(a: any, b: any) {\n  const y = !(a && b);\n  return y;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_parenthesizes_arrow_argument_in_ternary_condition_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_parenthesizes_arrow_argument_in_ternary_condition_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBooleanCastParenthesizesArrowArgumentInTernaryCondition
+// verifies the `Boolean(() => a) ? a : b` → `(() => a) ? a : b` rewrite —
+// the wrap branch for an arrow-function argument in a ternary-condition
+// context.
+//
+// Spliced bare, `() => a ? a : b` swallows the whole ternary into the arrow
+// body (`() => (a ? a : b)`), silently changing the branch into an
+// always-truthy function value. Arrows bind at Assignment precedence, below
+// the Conditional floor, so the wrap must fire.
+//
+// 1. Snapshot `const r = Boolean(() => a) ? a : b;` source.
+// 2. Apply `no-extra-boolean-cast` fix.
+// 3. Assert the wrapped splice `(() => a) ? a : b`.
+func TestFixNoExtraBooleanCastParenthesizesArrowArgumentInTernaryCondition(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(a: any, b: any) {\n  const r = Boolean(() => a) ? a : b;\n  return r;\n}\nJSON.stringify(f);\n",
+    "function f(a: any, b: any) {\n  const r = (() => a) ? a : b;\n  return r;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_parenthesizes_assignment_in_ternary_condition_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_parenthesizes_assignment_in_ternary_condition_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBooleanCastParenthesizesAssignmentInTernaryCondition verifies
+// the `Boolean(x = a) ? a : b` → `(x = a) ? a : b` rewrite — the
+// precedence-wrap branch in a ternary-condition context.
+//
+// The raw splice `x = a ? a : b` re-associates the whole ternary into the
+// assignment's right-hand side (#362). An assignment binds below the
+// Conditional floor, so the replacement must keep its own parentheses.
+//
+// 1. Snapshot `const r = Boolean(x = a) ? a : b;` source.
+// 2. Apply `no-extra-boolean-cast` fix.
+// 3. Assert the condition is spliced with parentheses: `(x = a) ? a : b`.
+func TestFixNoExtraBooleanCastParenthesizesAssignmentInTernaryCondition(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(x: any, a: any, b: any) {\n  const r = Boolean(x = a) ? a : b;\n  return [r, x];\n}\nJSON.stringify(f);\n",
+    "function f(x: any, a: any, b: any) {\n  const r = (x = a) ? a : b;\n  return [r, x];\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_parenthesizes_await_argument_under_bang_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_parenthesizes_await_argument_under_bang_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBooleanCastParenthesizesAwaitArgumentUnderBang verifies the
+// `!Boolean(await p)` → `!(await p)` rewrite — the equal-precedence boundary
+// of the wrap branch in an `!`-operand context.
+//
+// An AwaitExpression sits exactly at the Unary floor; the wrap fires at or
+// below the floor, so the equality case must parenthesize rather than splice
+// bare. This pins the `<=` comparison against off-by-one regressions to `<`.
+//
+// 1. Snapshot `const y = !Boolean(await p);` in an async function.
+// 2. Apply `no-extra-boolean-cast` fix.
+// 3. Assert the wrapped splice `!(await p)`.
+func TestFixNoExtraBooleanCastParenthesizesAwaitArgumentUnderBang(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "async function f(p: Promise<unknown>) {\n  const y = !Boolean(await p);\n  return y;\n}\nJSON.stringify(f);\n",
+    "async function f(p: Promise<unknown>) {\n  const y = !(await p);\n  return y;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_parenthesizes_logical_operand_under_bang_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_parenthesizes_logical_operand_under_bang_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBooleanCastParenthesizesLogicalOperandUnderBang verifies the
+// `!Boolean(a && b)` → `!(a && b)` rewrite — the precedence-wrap branch of
+// the Boolean-call fixer in an `!`-operand context.
+//
+// The raw splice `!a && b` re-associates to `(!a) && b`, a different value
+// (#362). Upstream ESLint's fixer parenthesizes by precedence; this test pins
+// the wrap branch for an argument (LogicalAND) below the Unary floor.
+//
+// 1. Snapshot `const y = !Boolean(a && b);` source.
+// 2. Apply `no-extra-boolean-cast` fix.
+// 3. Assert the argument is spliced with parentheses: `!(a && b)`.
+func TestFixNoExtraBooleanCastParenthesizesLogicalOperandUnderBang(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(a: any, b: any) {\n  const y = !Boolean(a && b);\n  return y;\n}\nJSON.stringify(f);\n",
+    "function f(a: any, b: any) {\n  const y = !(a && b);\n  return y;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_parenthesizes_nested_ternary_condition_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_parenthesizes_nested_ternary_condition_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBooleanCastParenthesizesNestedTernaryCondition verifies the
+// `Boolean(a ? b : c) ? a : b` → `(a ? b : c) ? a : b` rewrite — the
+// equal-precedence boundary of the wrap branch in a ternary-condition
+// context.
+//
+// A conditional argument sits exactly at the Conditional floor; spliced bare
+// it re-associates right (`a ? b : c ? a : b` is `a ? b : (c ? a : b)`), so
+// the equality case must parenthesize. This pins the `<=` comparison in the
+// ternary context the same way the await case pins it under `!`.
+//
+// 1. Snapshot `const r = Boolean(a ? b : c) ? a : b;` source.
+// 2. Apply `no-extra-boolean-cast` fix.
+// 3. Assert the wrapped splice `(a ? b : c) ? a : b`.
+func TestFixNoExtraBooleanCastParenthesizesNestedTernaryCondition(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(a: any, b: any, c: any) {\n  const r = Boolean(a ? b : c) ? a : b;\n  return r;\n}\nJSON.stringify(f);\n",
+    "function f(a: any, b: any, c: any) {\n  const r = (a ? b : c) ? a : b;\n  return r;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_parenthesizes_yield_argument_under_bang_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_parenthesizes_yield_argument_under_bang_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBooleanCastParenthesizesYieldArgumentUnderBang verifies the
+// `!Boolean(yield p)` → `!(yield p)` rewrite — the wrap branch for a yield
+// argument in an `!`-operand context.
+//
+// A bare splice would emit `!yield p`, which is not even parseable: `yield`
+// cannot appear as an unparenthesized unary operand. The YieldExpression's
+// precedence is far below the Unary floor, so the wrap must fire.
+//
+// 1. Snapshot `const y = !Boolean(yield p);` in a generator function.
+// 2. Apply `no-extra-boolean-cast` fix.
+// 3. Assert the wrapped splice `!(yield p)`.
+func TestFixNoExtraBooleanCastParenthesizesYieldArgumentUnderBang(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function* g(p: any) {\n  const y = !Boolean(yield p);\n  return y;\n}\nJSON.stringify(g);\n",
+    "function* g(p: any) {\n  const y = !(yield p);\n  return y;\n}\nJSON.stringify(g);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_preserves_comment_inside_argument_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_preserves_comment_inside_argument_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBooleanCastPreservesCommentInsideArgument verifies the
+// `!Boolean(a && /* mid */ b)` → `!(a && /* mid */ b)` rewrite — the
+// positive twin of the comment bail-out.
+//
+// A comment INSIDE the argument's own span survives the splice verbatim, so
+// declining there would be an over-match that turns a perfectly safe fix
+// report-only. This pins that the #362 bail-out scans only the discarded
+// gaps of the replaced span, not the kept text.
+//
+// 1. Snapshot `const y = !Boolean(a && /* mid */ b);` source.
+// 2. Apply `no-extra-boolean-cast` fix.
+// 3. Assert the fix applies and the comment survives inside the parens.
+func TestFixNoExtraBooleanCastPreservesCommentInsideArgument(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(a: any, b: any) {\n  const y = !Boolean(a && /* mid */ b);\n  return y;\n}\nJSON.stringify(f);\n",
+    "function f(a: any, b: any) {\n  const y = !(a && /* mid */ b);\n  return y;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_skips_wrap_for_logical_ternary_condition_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_skips_wrap_for_logical_ternary_condition_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBooleanCastSkipsWrapForLogicalTernaryCondition verifies the
+// `Boolean(a && b) ? a : b` → `a && b ? a : b` rewrite gains no parentheses —
+// the negative twin of the precedence-wrap branch in a ternary-condition
+// context.
+//
+// LogicalAND binds above the Conditional floor, so the bare splice already
+// parses as `(a && b) ? a : b`. This pins that the #362 wrap fires only at
+// or below the context floor, not on every ternary condition.
+//
+// 1. Snapshot `const r = Boolean(a && b) ? a : b;` source.
+// 2. Apply `no-extra-boolean-cast` fix.
+// 3. Assert the bare splice `a && b ? a : b` with no added parentheses.
+func TestFixNoExtraBooleanCastSkipsWrapForLogicalTernaryCondition(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(a: any, b: any) {\n  const r = Boolean(a && b) ? a : b;\n  return r;\n}\nJSON.stringify(f);\n",
+    "function f(a: any, b: any) {\n  const r = a && b ? a : b;\n  return r;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_skips_wrap_inside_explicit_parens_under_bang_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_fix_skips_wrap_inside_explicit_parens_under_bang_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBooleanCastSkipsWrapInsideExplicitParensUnderBang verifies
+// the `!(Boolean(a && b))` → `!(a && b)` rewrite — a cast explicitly
+// parenthesized by the author needs no added parentheses.
+//
+// The edit replaces only the call inside the author's parens, and those
+// parens already contain the result; the context floor keys off the direct
+// parent (the ParenthesizedExpression), so #362's wrap must not fire and
+// emit `!((a && b))`.
+//
+// 1. Snapshot `const y = !(Boolean(a && b));` source.
+// 2. Apply `no-extra-boolean-cast` fix.
+// 3. Assert the splice lands bare inside the existing parens: `!(a && b)`.
+func TestFixNoExtraBooleanCastSkipsWrapInsideExplicitParensUnderBang(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(a: any, b: any) {\n  const y = !(Boolean(a && b));\n  return y;\n}\nJSON.stringify(f);\n",
+    "function f(a: any, b: any) {\n  const y = !(a && b);\n  return y;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/ttsc/shim/ast/shim.go
+++ b/packages/ttsc/shim/ast/shim.go
@@ -177,6 +177,42 @@ const (
   ModifierFlagsReadonly  = innerast.ModifierFlagsReadonly
 )
 
+// OperatorPrecedence members. The complete family is re-exported by hand so
+// precedence comparisons (e.g. a lint fixer deciding whether a spliced
+// replacement must be parenthesized) can name every level of the
+// OperatorPrecedence type aliased in surface.go; a partial re-export would
+// trip the shim_audit zero-tolerance enum gate.
+const (
+  OperatorPrecedenceComma          = innerast.OperatorPrecedenceComma
+  OperatorPrecedenceSpread         = innerast.OperatorPrecedenceSpread
+  OperatorPrecedenceYield          = innerast.OperatorPrecedenceYield
+  OperatorPrecedenceAssignment     = innerast.OperatorPrecedenceAssignment
+  OperatorPrecedenceConditional    = innerast.OperatorPrecedenceConditional
+  OperatorPrecedenceLogicalOR      = innerast.OperatorPrecedenceLogicalOR
+  OperatorPrecedenceLogicalAND     = innerast.OperatorPrecedenceLogicalAND
+  OperatorPrecedenceBitwiseOR      = innerast.OperatorPrecedenceBitwiseOR
+  OperatorPrecedenceBitwiseXOR     = innerast.OperatorPrecedenceBitwiseXOR
+  OperatorPrecedenceBitwiseAND     = innerast.OperatorPrecedenceBitwiseAND
+  OperatorPrecedenceEquality       = innerast.OperatorPrecedenceEquality
+  OperatorPrecedenceRelational     = innerast.OperatorPrecedenceRelational
+  OperatorPrecedenceShift          = innerast.OperatorPrecedenceShift
+  OperatorPrecedenceAdditive       = innerast.OperatorPrecedenceAdditive
+  OperatorPrecedenceMultiplicative = innerast.OperatorPrecedenceMultiplicative
+  OperatorPrecedenceExponentiation = innerast.OperatorPrecedenceExponentiation
+  OperatorPrecedenceUnary          = innerast.OperatorPrecedenceUnary
+  OperatorPrecedenceUpdate         = innerast.OperatorPrecedenceUpdate
+  OperatorPrecedenceLeftHandSide   = innerast.OperatorPrecedenceLeftHandSide
+  OperatorPrecedenceOptionalChain  = innerast.OperatorPrecedenceOptionalChain
+  OperatorPrecedenceMember         = innerast.OperatorPrecedenceMember
+  OperatorPrecedencePrimary        = innerast.OperatorPrecedencePrimary
+  OperatorPrecedenceParentheses    = innerast.OperatorPrecedenceParentheses
+  OperatorPrecedenceLowest         = innerast.OperatorPrecedenceLowest
+  OperatorPrecedenceHighest        = innerast.OperatorPrecedenceHighest
+  OperatorPrecedenceDisallowComma  = innerast.OperatorPrecedenceDisallowComma
+  OperatorPrecedenceCoalesce       = innerast.OperatorPrecedenceCoalesce
+  OperatorPrecedenceInvalid        = innerast.OperatorPrecedenceInvalid
+)
+
 // NewNodeFactory creates an AST node factory with the supplied creation hooks.
 // Pass a zero-value NodeFactoryHooks to get the default factory behaviour.
 func NewNodeFactory(options NodeFactoryHooks) *NodeFactory {
@@ -193,6 +229,14 @@ func NewNodeVisitor(visit func(node *Node) *Node, factory *NodeFactory, options 
 // such as variable statements and their declaration lists.
 func GetCombinedModifierFlags(node *Node) ModifierFlags {
   return innerast.GetCombinedModifierFlags(node)
+}
+
+// GetExpressionPrecedence returns the operator precedence of an expression
+// node — the level at which it binds relative to a surrounding expression.
+// Callers compare it against an OperatorPrecedence floor to decide whether a
+// textual splice of the expression into a new position needs parentheses.
+func GetExpressionPrecedence(expression *Expression) OperatorPrecedence {
+  return innerast.GetExpressionPrecedence(expression)
 }
 
 // IsFunctionLike reports whether node is any function-like construct


### PR DESCRIPTION
## Intent

`no-extra-boolean-cast`'s autofix replaces the whole `Boolean(arg)` call (and the `!!x` double negation) with the raw source text of the inner expression. In the two expression-level boolean contexts the rule accepts — `!` operand and ternary condition — a low-precedence argument re-associates, changing runtime values:

```js
const y = !Boolean(a && b);       // fixed to: const y = !a && b;   ≡ (!a) && b — wrong value
Boolean(x = f()) ? a : b;         // fixed to: x = f() ? a : b;     ≡ x = (f() ? a : b) — wrong assignment
const z = !Boolean(/* why */ ok); // fixed to: const z = !ok;       comment silently deleted
```

Closes #362.

## Scope

- `packages/lint/linthost/rules_logic.go`: both fixer branches (Boolean call and `!!`) now funnel through a shared `reportBooleanCastFix` helper that
  - wraps the spliced text in parentheses when the inner expression's precedence is **at or below** the context floor (Unary for a `!` operand, Conditional for a ternary condition), mirroring upstream ESLint's precedence-aware fixer. Statement conditions (`if`/`while`/`do`/`for`) and casts the author already parenthesized stay bare; an already-parenthesized argument is never double-wrapped;
  - declines the fix (report-only) when the replaced span contains a comment outside the kept argument text, mirroring upstream's comment bail-out. Detection is general: `hasCommentBetween` (in `ast_helpers.go`) scans the discarded gap ranges for `//` / `/*` openers via the scanner's `SkipTriviaEx`.
- `packages/ttsc/shim/ast/shim.go`: re-export typescript-go's canonical `ast.GetExpressionPrecedence` plus the complete `OperatorPrecedence` constant family (the type alias was already exposed; the shim-audit enum gate requires all-or-nothing member exposure — verified `pnpm --filter ttsc shim:audit` stays green).

Fixer-defect audit of the other fixers in `rules_logic.go`: `eqeqeq` replaces only the operator token in place, so it can neither re-associate nor span a comment — no other fixer in this file shares the raw-splice defect class. The two branches of `no-extra-boolean-cast` that did share it are both fixed here via the shared helper.

Website docs need no change: the rule's entry in `lint/rules/core.mdx` does not document fixer output.

## Test plan

15 new one-case-per-file Go tests under `packages/lint/test/rules/style-suggestions/`, expectations derived from the upstream ESLint fixer oracle:

- transformation direction: `!Boolean(a && b)` → `!(a && b)`; `Boolean(x = a) ? a : b` → `(x = a) ? a : b`; arrow in ternary condition wraps
- equal-precedence boundaries (pin `<=` against `<` regressions): `!Boolean(await p)` → `!(await p)`; `Boolean(a ? b : c) ? a : b` → `(a ? b : c) ? a : b`
- grammar-mandated wrap: `!Boolean(yield p)` → `!(yield p)` (bare splice would not even parse)
- negative twins (no spurious parens): `!Boolean(x)` → `!x`; `Boolean(a && b) ? a : b` → `a && b ? a : b`; `!(Boolean(a && b))` → `!(a && b)`; nested `Boolean(Boolean(x))` splices bare
- boundary: already-parenthesized argument `!Boolean((a && b))` → `!(a && b)`, no double wrap
- comment bail-out: leading `/* */`, trailing `//`, and between-bangs comments decline (report-only, source untouched); comment inside the argument still fixes and survives
- existing `if (Boolean(x))` → `if (x)` and `if (!!x)` → `if (x)` snapshots unchanged

Ran the targeted cases locally (`go test -run NoExtraBooleanCast`): 19/19 pass. Full suites run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB