### PR TITLE
fix(factory): parenthesize new target with a call in the member chain

### DIFF
--- a/packages/factory/src/TsPrinter.ts
+++ b/packages/factory/src/TsPrinter.ts
@@ -1618,13 +1618,30 @@ export class TsPrinter {
   }
 
   private newExpressionTarget(expression: Expression): Doc {
-    return expression.kind !== "CallExpression" &&
-      expression.kind !== "CallChain" &&
-      (expression.kind !== "NewExpression" ||
-        expression.arguments !== undefined) &&
-      this.isLeftHandSideExpression(expression)
-      ? this.emit(expression)
-      : this.parenthesizedExpression(expression);
+    return this.newExpressionTargetNeedsParentheses(expression)
+      ? this.parenthesizedExpression(expression)
+      : this.emit(expression);
+  }
+
+  /**
+   * Whether a `new` target must be parenthesized to keep its call arguments
+   * from re-binding to the `new` — mirroring the legacy printer's
+   * `parenthesizeExpressionOfNew`. A `new` target is grammatically a
+   * `MemberExpression`, so a call anywhere on the target's left spine (not just
+   * a direct one: `new (f().bar)()`, `new (a.b().c)()`) would otherwise
+   * re-parse with the call's arguments consumed by the `new` — a different
+   * program. Argument-less `new` on the spine is kept parenthesized for
+   * continuity with the direct case, though this printer always prints an
+   * argument list, which already disambiguates it.
+   */
+  private newExpressionTargetNeedsParentheses(expression: Expression): boolean {
+    if (!this.isLeftHandSideExpression(expression)) return true;
+    const leftmost: Expression = this.leftmostExpression(expression, true);
+    return (
+      leftmost.kind === "CallExpression" ||
+      leftmost.kind === "CallChain" ||
+      (leftmost.kind === "NewExpression" && leftmost.arguments === undefined)
+    );
   }
 
   private prefixUnaryOperand(operand: Expression, operator?: SyntaxKind): Doc {
@@ -1974,11 +1991,22 @@ export class TsPrinter {
     );
   }
 
-  private leftmostExpression(expression: Expression): Expression {
+  /**
+   * Walk to the expression's leftmost node — the one that starts its printed
+   * text. With `stopAtCall`, calls terminate the walk instead of being walked
+   * through, matching the legacy `getLeftmostExpression`'s
+   * `stopAtCallExpressions` mode used by the `new`-target parenthesizer.
+   */
+  private leftmostExpression(
+    expression: Expression,
+    stopAtCall: boolean = false,
+  ): Expression {
     switch (expression.kind) {
-      case "AsExpression":
       case "CallExpression":
       case "CallChain":
+        if (stopAtCall) return expression;
+        return this.leftmostExpression(expression.expression, stopAtCall);
+      case "AsExpression":
       case "ElementAccessExpression":
       case "ElementAccessChain":
       case "NonNullExpression":
@@ -1986,13 +2014,13 @@ export class TsPrinter {
       case "PropertyAccessExpression":
       case "PropertyAccessChain":
       case "SatisfiesExpression":
-        return this.leftmostExpression(expression.expression);
+        return this.leftmostExpression(expression.expression, stopAtCall);
       case "BinaryExpression":
-        return this.leftmostExpression(expression.left);
+        return this.leftmostExpression(expression.left, stopAtCall);
       case "ConditionalExpression":
-        return this.leftmostExpression(expression.condition);
+        return this.leftmostExpression(expression.condition, stopAtCall);
       case "TaggedTemplateExpression":
-        return this.leftmostExpression(expression.tag);
+        return this.leftmostExpression(expression.tag, stopAtCall);
       default:
         return expression;
     }

--- a/tests/test-factory/src/features/expressions/test_new_expression_target_argumentless_new_parentheses.ts
+++ b/tests/test-factory/src/features/expressions/test_new_expression_target_argumentless_new_parentheses.ts
@@ -1,0 +1,61 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression } from "@ttsc/factory";
+import ts from "ts-legacy";
+
+import { id, print, reparse } from "../../internal/helpers";
+
+const construct = (target: Expression): Expression =>
+  factory.createNewExpression(target, undefined, []);
+
+/** An argument-less `new F` node (`arguments` is `undefined`, not `[]`). */
+const argumentlessNew = (): Expression =>
+  factory.createNewExpression(id("F"), undefined, undefined);
+
+/**
+ * Verifies new-expression parenthesizer: keeps parentheses around an
+ * argument-less inner `new`, directly and deeper in the chain.
+ *
+ * Locks the `NewExpression`-without-`arguments` branch of
+ * `TsPrinter.newExpressionTargetNeedsParentheses` across the stop-at-call walk.
+ * The walk must not recurse through an inner `new` (its target is not on the
+ * printed left edge), and an argument-less inner `new` keeps the parentheses
+ * the direct case always had — before the fix the deeper shape bypassed the
+ * direct-kind check and printed bare. This printer normalizes argument-less
+ * `new F` to `new F()`, so the wrap is belt-and-suspenders rather than
+ * load-bearing, but it keeps direct and deep shapes consistent (the legacy
+ * factory instead parenthesizes at the access level: `new (new F).bar()`; both
+ * round-trip to the same program).
+ *
+ * 1. Print `new` expressions targeting an argument-less `new F` directly and
+ *    behind a member access (`new F.bar` would re-parse as `new (F.bar)`).
+ * 2. Assert both print parenthesized: `new (new F())()` and `new (new F().bar)()`.
+ * 3. Re-parse each output with the legacy compiler and assert the top-level
+ *    expression is still a `NewExpression`.
+ */
+export const test_new_expression_target_argumentless_new_parentheses =
+  (): void => {
+    const printed = {
+      "direct argument-less new": print(construct(argumentlessNew())),
+      "member access over argument-less new": print(
+        construct(
+          factory.createPropertyAccessExpression(argumentlessNew(), "bar"),
+        ),
+      ),
+    };
+    TestValidator.equals(
+      "direct argument-less new",
+      printed["direct argument-less new"],
+      "new (new F())()",
+    );
+    TestValidator.equals(
+      "member access over argument-less new",
+      printed["member access over argument-less new"],
+      "new (new F().bar)()",
+    );
+    for (const [title, source] of Object.entries(printed))
+      TestValidator.equals(
+        `${title} re-parses as new`,
+        reparse(source).kind,
+        ts.SyntaxKind.NewExpression,
+      );
+  };

--- a/tests/test-factory/src/features/expressions/test_new_expression_target_call_in_chain_parentheses.ts
+++ b/tests/test-factory/src/features/expressions/test_new_expression_target_call_in_chain_parentheses.ts
@@ -1,0 +1,69 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression } from "@ttsc/factory";
+import ts from "ts-legacy";
+
+import { id, print, reparse } from "../../internal/helpers";
+
+const call = (expression: Expression): Expression =>
+  factory.createCallExpression(expression, undefined, []);
+const construct = (target: Expression): Expression =>
+  factory.createNewExpression(target, undefined, []);
+
+/**
+ * Verifies new-expression parenthesizer: wraps a target whose member chain
+ * contains a call.
+ *
+ * Locks the stop-at-call leftmost walk in `TsPrinter.newExpressionTarget`. The
+ * old check looked only at the target's direct kind, so a call deeper in the
+ * chain printed bare: `new (f().bar)()` became `new f().bar()`, which re-parses
+ * as `(new f()).bar()` — the call's arguments re-bind to the `new` and the
+ * program changes. The target's leftmost node decides, wherever the call sits
+ * in the chain.
+ *
+ * 1. Print `new` expressions whose targets are `f().bar` (call at the chain head),
+ *    `a.b().c` (call mid-chain), and `f()[0]` (element access over a call).
+ * 2. Assert every target is parenthesized, matching the legacy `ts.Printer`.
+ * 3. Re-parse each output with the legacy compiler and assert the top-level
+ *    expression is still a `NewExpression` (the bug shape re-parses as a
+ *    top-level `CallExpression` instead).
+ */
+export const test_new_expression_target_call_in_chain_parentheses =
+  (): void => {
+    const printed = {
+      "call at chain head": print(
+        construct(factory.createPropertyAccessExpression(call(id("f")), "bar")),
+      ),
+      "call mid-chain": print(
+        construct(
+          factory.createPropertyAccessExpression(
+            call(factory.createPropertyAccessExpression(id("a"), "b")),
+            "c",
+          ),
+        ),
+      ),
+      "element access over call": print(
+        construct(factory.createElementAccessExpression(call(id("f")), 0)),
+      ),
+    };
+    TestValidator.equals(
+      "call at chain head",
+      printed["call at chain head"],
+      "new (f().bar)()",
+    );
+    TestValidator.equals(
+      "call mid-chain",
+      printed["call mid-chain"],
+      "new (a.b().c)()",
+    );
+    TestValidator.equals(
+      "element access over call",
+      printed["element access over call"],
+      "new (f()[0])()",
+    );
+    for (const [title, source] of Object.entries(printed))
+      TestValidator.equals(
+        `${title} re-parses as new`,
+        reparse(source).kind,
+        ts.SyntaxKind.NewExpression,
+      );
+  };

--- a/tests/test-factory/src/features/expressions/test_new_expression_target_member_chain_without_parentheses.ts
+++ b/tests/test-factory/src/features/expressions/test_new_expression_target_member_chain_without_parentheses.ts
@@ -1,0 +1,77 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression } from "@ttsc/factory";
+import ts from "ts-legacy";
+
+import { id, print, reparse } from "../../internal/helpers";
+
+const construct = (target: Expression): Expression =>
+  factory.createNewExpression(target, undefined, []);
+
+/**
+ * Verifies new-expression parenthesizer: leaves call-free targets bare.
+ *
+ * Negative twin of the stop-at-call leftmost walk in
+ * `TsPrinter.newExpressionTarget`. An over-match would wrap the everyday
+ * targets generators emit constantly — plain identifiers, pure member chains,
+ * and inner `new` expressions with argument lists (whose printed `()` already
+ * binds their arguments) — and bloat every generated file with useless
+ * parentheses.
+ *
+ * 1. Print `new` expressions targeting `C`, `a.b.C`, `new F()` (inner `new` with
+ *    an argument list), and `new F().bar` (member access over it).
+ * 2. Assert none of the targets are parenthesized, matching the legacy
+ *    `ts.Printer`.
+ * 3. Re-parse each output with the legacy compiler and assert the top-level
+ *    expression is still a `NewExpression`.
+ */
+export const test_new_expression_target_member_chain_without_parentheses =
+  (): void => {
+    const printed = {
+      "bare identifier": print(construct(id("C"))),
+      "pure member chain": print(
+        construct(
+          factory.createPropertyAccessExpression(
+            factory.createPropertyAccessExpression(id("a"), "b"),
+            "C",
+          ),
+        ),
+      ),
+      "inner new with arguments": print(
+        construct(factory.createNewExpression(id("F"), undefined, [])),
+      ),
+      "member access over inner new": print(
+        construct(
+          factory.createPropertyAccessExpression(
+            factory.createNewExpression(id("F"), undefined, []),
+            "bar",
+          ),
+        ),
+      ),
+    };
+    TestValidator.equals(
+      "bare identifier",
+      printed["bare identifier"],
+      "new C()",
+    );
+    TestValidator.equals(
+      "pure member chain",
+      printed["pure member chain"],
+      "new a.b.C()",
+    );
+    TestValidator.equals(
+      "inner new with arguments",
+      printed["inner new with arguments"],
+      "new new F()()",
+    );
+    TestValidator.equals(
+      "member access over inner new",
+      printed["member access over inner new"],
+      "new new F().bar()",
+    );
+    for (const [title, source] of Object.entries(printed))
+      TestValidator.equals(
+        `${title} re-parses as new`,
+        reparse(source).kind,
+        ts.SyntaxKind.NewExpression,
+      );
+  };

--- a/tests/test-factory/src/features/expressions/test_new_expression_target_spine_operator_parentheses.ts
+++ b/tests/test-factory/src/features/expressions/test_new_expression_target_spine_operator_parentheses.ts
@@ -1,0 +1,97 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression, SyntaxKind } from "@ttsc/factory";
+import ts from "ts-legacy";
+
+import { id, print, reparse } from "../../internal/helpers";
+
+const call = (expression: Expression): Expression =>
+  factory.createCallExpression(expression, undefined, []);
+const construct = (target: Expression): Expression =>
+  factory.createNewExpression(target, undefined, []);
+
+/**
+ * Verifies new-expression parenthesizer: sees a call through non-null
+ * assertions, template tags, and optional chains on the target's spine.
+ *
+ * Boundary cases of the stop-at-call walk in `TsPrinter.newExpressionTarget`:
+ * the walk must traverse every construct that keeps the call on the printed
+ * left edge, not just plain accesses. `new f()!.bar()`, `new f()`x`()`, and the
+ * illegal `new f()?.bar()` would each re-bind (or reject) the arguments; the
+ * tag-over-identifier twin guards against wrapping every tagged template used
+ * as a target.
+ *
+ * 1. Print `new` expressions targeting `f()!.bar` (non-null in the chain), `f()`x`
+ *    ` (tagged template whose tag is a call), and `f()?.bar` (optional chain
+ *    over a call — a runtime `TypeError` shape, but the printed text must still
+ *    parse back to the same AST).
+ * 2. Assert each target is parenthesized, and the tag-over-identifier twin `tag`x`
+ *    ` stays bare.
+ * 3. Re-parse each output with the legacy compiler and assert the top-level
+ *    expression is still a `NewExpression`.
+ */
+export const test_new_expression_target_spine_operator_parentheses =
+  (): void => {
+    const printed = {
+      "non-null in the chain": print(
+        construct(
+          factory.createPropertyAccessExpression(
+            factory.createNonNullExpression(call(id("f"))),
+            "bar",
+          ),
+        ),
+      ),
+      "template tag is a call": print(
+        construct(
+          factory.createTaggedTemplateExpression(
+            call(id("f")),
+            undefined,
+            factory.createNoSubstitutionTemplateLiteral("x"),
+          ),
+        ),
+      ),
+      "optional chain over a call": print(
+        construct(
+          factory.createPropertyAccessChain(
+            call(id("f")),
+            factory.createToken(SyntaxKind.QuestionDotToken),
+            id("bar"),
+          ),
+        ),
+      ),
+      "template tag is an identifier": print(
+        construct(
+          factory.createTaggedTemplateExpression(
+            id("tag"),
+            undefined,
+            factory.createNoSubstitutionTemplateLiteral("x"),
+          ),
+        ),
+      ),
+    };
+    TestValidator.equals(
+      "non-null in the chain",
+      printed["non-null in the chain"],
+      "new (f()!.bar)()",
+    );
+    TestValidator.equals(
+      "template tag is a call",
+      printed["template tag is a call"],
+      "new (f()`x`)()",
+    );
+    TestValidator.equals(
+      "optional chain over a call",
+      printed["optional chain over a call"],
+      "new (f()?.bar)()",
+    );
+    TestValidator.equals(
+      "template tag is an identifier",
+      printed["template tag is an identifier"],
+      "new tag`x`()",
+    );
+    for (const [title, source] of Object.entries(printed))
+      TestValidator.equals(
+        `${title} re-parses as new`,
+        reparse(source).kind,
+        ts.SyntaxKind.NewExpression,
+      );
+  };

--- a/tests/test-factory/src/features/expressions/test_new_expression_target_spine_operator_parentheses.ts
+++ b/tests/test-factory/src/features/expressions/test_new_expression_target_spine_operator_parentheses.ts
@@ -11,21 +11,25 @@ const construct = (target: Expression): Expression =>
 
 /**
  * Verifies new-expression parenthesizer: sees a call through non-null
- * assertions, template tags, and optional chains on the target's spine.
+ * assertions, template tags, and optional calls on the target's spine.
  *
- * Boundary cases of the stop-at-call walk in `TsPrinter.newExpressionTarget`:
- * the walk must traverse every construct that keeps the call on the printed
- * left edge, not just plain accesses. `new f()!.bar()`, `new f()`x`()`, and the
- * illegal `new f()?.bar()` would each re-bind (or reject) the arguments; the
- * tag-over-identifier twin guards against wrapping every tagged template used
- * as a target.
+ * Boundary cases of the stop-at-call walk in `TsPrinter.newExpressionTarget`.
+ * The walk must traverse every construct that keeps the call on the printed
+ * left edge — not just plain property accesses — and must stop at both a
+ * `CallExpression` and a `CallChain`. A non-null assertion over a call, a
+ * tagged template whose tag is a call, an optional call at the chain head, and
+ * an optional property access over a call would each re-bind the arguments to
+ * the `new` (or, for the optional access, produce the illegal `new f()?.bar()`)
+ * once printed bare. The tag-over-identifier twin guards against wrapping every
+ * tagged template used as a target.
  *
- * 1. Print `new` expressions targeting `f()!.bar` (non-null in the chain), `f()`x`
- *    ` (tagged template whose tag is a call), and `f()?.bar` (optional chain
- *    over a call — a runtime `TypeError` shape, but the printed text must still
- *    parse back to the same AST).
- * 2. Assert each target is parenthesized, and the tag-over-identifier twin `tag`x`
- *    ` stays bare.
+ * 1. Print `new` expressions targeting a non-null assertion, a call-tagged
+ *    template, an optional call at the chain head (leftmost node is a
+ *    `CallChain`), and an optional property access over a call (a runtime
+ *    `TypeError` shape, but the printed text must still parse back to the same
+ *    AST).
+ * 2. Assert each target is parenthesized, and the identifier-tagged twin stays
+ *    bare.
  * 3. Re-parse each output with the legacy compiler and assert the top-level
  *    expression is still a `NewExpression`.
  */
@@ -46,6 +50,19 @@ export const test_new_expression_target_spine_operator_parentheses =
             call(id("f")),
             undefined,
             factory.createNoSubstitutionTemplateLiteral("x"),
+          ),
+        ),
+      ),
+      "optional call at chain head": print(
+        construct(
+          factory.createPropertyAccessExpression(
+            factory.createCallChain(
+              id("f"),
+              factory.createToken(SyntaxKind.QuestionDotToken),
+              undefined,
+              [],
+            ),
+            "bar",
           ),
         ),
       ),
@@ -77,6 +94,11 @@ export const test_new_expression_target_spine_operator_parentheses =
       "template tag is a call",
       printed["template tag is a call"],
       "new (f()`x`)()",
+    );
+    TestValidator.equals(
+      "optional call at chain head",
+      printed["optional call at chain head"],
+      "new (f?.().bar)()",
     );
     TestValidator.equals(
       "optional chain over a call",

--- a/tests/test-factory/src/internal/helpers.ts
+++ b/tests/test-factory/src/internal/helpers.ts
@@ -5,6 +5,7 @@ import type {
   ParameterDeclaration,
   TypeNode,
 } from "@ttsc/factory";
+import ts from "ts-legacy";
 
 /** Shared default printer (80 columns, two-space indent). */
 export const printer = new TsPrinter();
@@ -15,6 +16,37 @@ export const print = (node: Node): string => printer.print(node);
 /** Parse printed expression source back and return its runtime value. */
 export const cook = (source: string): string =>
   new Function(`return (${source});`)() as string;
+
+/**
+ * Parse printed expression source back with the legacy compiler and return the
+ * top-level expression, throwing when the source does not parse cleanly as a
+ * single expression statement. Round-trip oracle for parenthesizer tests: the
+ * returned node's kind proves how the printed text re-binds.
+ */
+export const reparse = (source: string): ts.Expression => {
+  const file: ts.SourceFile = ts.createSourceFile(
+    "reparse.ts",
+    `${source};`,
+    ts.ScriptTarget.Latest,
+  );
+  const diagnostics: readonly ts.Diagnostic[] =
+    (file as unknown as { parseDiagnostics?: readonly ts.Diagnostic[] })
+      .parseDiagnostics ?? [];
+  if (diagnostics.length !== 0)
+    throw new Error(
+      `reparse: printed source does not parse: ${JSON.stringify(source)}`,
+    );
+  const statement: ts.Statement | undefined = file.statements[0];
+  if (
+    file.statements.length !== 1 ||
+    statement === undefined ||
+    !ts.isExpressionStatement(statement)
+  )
+    throw new Error(
+      `reparse: printed source is not a single expression statement: ${JSON.stringify(source)}`,
+    );
+  return statement.expression;
+};
 
 /** Shorthand for {@link factory.createIdentifier}. */
 export const id = (text: string) => factory.createIdentifier(text);


### PR DESCRIPTION
## Intent

`TsPrinter.newExpressionTarget` parenthesized a `new` target only when the target was *directly* a `CallExpression`/`CallChain` (or an argument-less `NewExpression`). A call **deeper** in the target's member chain printed bare, silently changing the program:

```ts
// AST: new (f().bar)()
// observed: "new f().bar()"   → re-parses as (new f()).bar()  ❌ different program
// expected: "new (f().bar)()"                                  ✅
```

`new f().bar()` constructs `f`, then calls `.bar()` on the instance; `new (f().bar)()` calls `f()`, takes `.bar`, and constructs *that*. Sibling of #354 — a separate code path.

## Scope

- **`packages/factory/src/TsPrinter.ts`** — confined to the new-target logic:
  - `newExpressionTarget` now delegates to a new `newExpressionTargetNeedsParentheses` predicate.
  - The predicate walks the target's left spine and wraps when the leftmost node is a `CallExpression`/`CallChain` (or an argument-less inner `NewExpression`), mirroring legacy `parenthesizeExpressionOfNew`.
  - Rather than a second walker, `leftmostExpression` gained a `stopAtCall` flag (default `false`, so every existing caller is unchanged) that terminates the walk at a call — matching legacy `getLeftmostExpression`'s `stopAtCallExpressions` mode.
- **`tests/test-factory/src/internal/helpers.ts`** — added a `reparse` helper (legacy `ts-legacy` compiler) that returns the top-level expression of printed source, throwing on parse diagnostics or a non-single-expression-statement. Round-trip oracle.

## Legacy-parity note

Verified empirically against `ts-legacy` (`ts.createPrinter`). All positive shapes match legacy exactly (`new (f().bar)()`, `new (a.b().c)()`, `new (f()[0])()`, `new (f()!.bar)()`, ``new (f()`x`)()``, `new (f()?.bar)()`). One benign divergence, documented in the argument-less-new test: for a member access over an argument-less inner `new`, this printer emits `new (new F().bar)()` (wrapping the whole access) while legacy emits `new (new F).bar()` (wrapping only the inner `new`). Both round-trip to the same AST — this printer always prints an argument list on `new`, so its form is internally consistent with the direct case.

## Test plan

Four e2e files under `tests/test-factory/src/features/expressions/`, each one `test_<snake_case>` with the three-part doc comment, all asserting the printed text **and** a legacy parse-back round-trip (`reparse(...).kind === NewExpression`):

- `..._call_in_chain_parentheses` — `new (f().bar)()`, `new (a.b().c)()`, `new (f()[0])()`.
- `..._member_chain_without_parentheses` — negative twins `new C()`, `new a.b.C()`, `new new F()()`, `new new F().bar()` stay bare.
- `..._argumentless_new_parentheses` — `new (new F())()` and `new (new F().bar)()` keep parens.
- `..._spine_operator_parentheses` — boundary: non-null `new (f()!.bar)()`, tagged-template tag ``new (f()`x`)()``, optional chain `new (f()?.bar)()` (a runtime `TypeError` shape but must still round-trip), and the negative twin ``new tag`x`()``.

Verified locally (outside the suite runner) that all four fixtures pass with the fix and the three positive files fail without it; `tsc --noEmit` is clean for `@ttsc/factory` and `@ttsc/test-factory`.

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB