### PR TITLE
docs(graph): finish retracting the fused-diagnostics claim from landing and setup

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -161,8 +161,6 @@ For bare React Native, wrap `getDefaultConfig` from `@react-native/metro-config`
 
 It answers "what relates to this symbol" or "what does this change affect" straight from the type checker, so the agent stops grepping and re-reading files.
 
-It also carries the project's full diagnostics: type errors, `@ttsc/lint` violations, and plugin findings. They are fused onto the graph, so an agent sees a change's reach over what is already broken before editing.
-
 ```bash
 npm install -D ttsc @ttsc/graph typescript
 ```

--- a/website/src/content/docs/setup.mdx
+++ b/website/src/content/docs/setup.mdx
@@ -193,9 +193,7 @@ Full reference: [`@ttsc/vscode`](https://github.com/samchon/ttsc/tree/master/pac
 
 [`@ttsc/graph`](/docs/graph) gives a coding agent a checker-resolved graph of your project, over MCP.
 
-It answers what relates to a symbol and its blast radius, and it surfaces the project's full diagnostics — type errors, `@ttsc/lint` violations, and transform-plugin findings — so the agent stops grepping and re-reading source.
-
-Because both come from one warm checker, the graph also shows a change's reach over what is currently broken, before the edit.
+It answers what relates to a symbol and its blast radius, so the agent stops grepping and re-reading source.
 
 ### Install
 


### PR DESCRIPTION
Completes the diagnostics retraction from #360/#382 on the two general product-docs pages their `graph/*`-scoped grep missed. The root README and every `graph/*` page already dropped the never-implemented "fused diagnostics" promise; these two pages still both contradicted the README and described a capability the code does not have. The graph delivers declarations, signatures, relationships, decorators, tests, and spans, not diagnostics.

## Removals

- `website/src/content/docs/index.mdx` (landing) — removed the paragraph: "It also carries the project's full diagnostics: type errors, `@ttsc/lint` violations, and plugin findings. They are fused onto the graph, so an agent sees a change's reach over what is already broken before editing." The accurate "what relates / what does this change affect" text above it stays.
- `website/src/content/docs/setup.mdx` — removed the "it surfaces the project's full diagnostics — type errors, `@ttsc/lint` violations, and transform-plugin findings" clause and the follow-on sentence "Because both come from one warm checker, the graph also shows a change's reach over what is currently broken, before the edit." Reflowed the surviving sentence to "It answers what relates to a symbol and its blast radius, so the agent stops grepping and re-reading source."

## Deferred / out of scope

- The launch blog post (`blog/i-made-ts-compiler-graph-mcp.mdx:309`) makes the same claim but is a dated first-person narrative; #382 deliberately left it as an owner decision. Not touched.
- `development/concepts/tsgo.mdx:670` and `development/walkthroughs/index.mdx:12` say "full diagnostics engine" about `@ttsc/lint` the linter, which is accurate. Not touched.

## Test plan

Docs-only, no code change. `grep -rni "full diagnostics|fused onto|what is currently broken|what is already broken|surfaces the project" website/src/content/docs README.md` returns only the accurate `@ttsc/lint`-engine mentions. The website build/deploy lane must stay green.

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB
