### PR TITLE
docs(graph): drop the last fused-diagnostics mention from the plugin list

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -253,7 +253,7 @@ console.log(matched); // true
 
 - [`@ttsc/banner`](https://github.com/samchon/ttsc/tree/master/packages/banner): adds `@packageDocumentation` JSDoc banners.
 - [`@ttsc/lint`](https://github.com/samchon/ttsc/tree/master/packages/lint): lints and formats TypeScript source.
-- [`@ttsc/graph`](https://github.com/samchon/ttsc/tree/master/packages/graph): MCP server exposing a checker-resolved code graph and diagnostics to coding agents.
+- [`@ttsc/graph`](https://github.com/samchon/ttsc/tree/master/packages/graph): MCP server exposing a checker-resolved code graph to coding agents.
 - [`@ttsc/paths`](https://github.com/samchon/ttsc/tree/master/packages/paths): rewrites source path aliases so JS and declaration emit receive relative imports.
 - [`@ttsc/strip`](https://github.com/samchon/ttsc/tree/master/packages/strip): removes configured calls and `debugger` statements.
 - [`@ttsc/unplugin`](https://github.com/samchon/ttsc/tree/master/packages/unplugin): runs `ttsc` plugins inside bundlers supported by `unplugin`.


### PR DESCRIPTION
## Intent

Final mirror of the #360/#382 diagnostics retraction. The root README already reads "…code graph to coding agents." (#382), but the general `index.mdx` plugin list kept the stale "and diagnostics" phrasing because it lives outside the `graph/*` subtree #382 scoped to and #384's grep pattern didn't cover this wording. `@ttsc/graph` does not deliver diagnostics; docs must describe the code as it is.

## The edit

`website/src/content/docs/index.mdx`, `@ttsc/graph` plugin-list bullet:

> - MCP server exposing a checker-resolved code graph ~~and diagnostics~~ to coding agents.

Now byte-matches the root README bullet.

## Not touched

`setup.mdx:169` (tsgo language-server LSP features), `tsgo.mdx`, `walkthroughs/index.mdx`, and the blog post are all accurate or owner-scoped, per the issue.

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB