### PR TITLE
fix(ttsx): inline served source maps so coverage and stacks map to source (#353)

### DIFF
--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -24,6 +24,14 @@ import { outputText, spawnNative } from "./spawnNative";
 type RunBuildOptions = TtscBuildOptions & {
   skipDiagnosticsCheck?: boolean;
   forceListEmittedFiles?: boolean;
+  /**
+   * Emit an external source map from the direct tsgo build lane even when the
+   * project configures none. Set by the ttsx runtime builds so a served emit
+   * carries a map to inline under the source URL (issue #353). Applied only to
+   * the plain tsgo emit — never forwarded to a native plugin host, whose own
+   * emit honours the project's `sourceMap` setting.
+   */
+  forceRuntimeSourceMap?: boolean;
 };
 
 type BuildTiming = {
@@ -681,6 +689,12 @@ function createTsgoBuildArgs(
     args.push("--noEmit", "false", "--emitDeclarationOnly", "false");
     if (execution.rewriteRelativeImportExtensionsForEmit) {
       args.push("--rewriteRelativeImportExtensions");
+    }
+    // The ttsx runtime build asks for an external map when the project emits
+    // none, so its served emit carries a map to inline under the source URL.
+    // Pushed before passthrough so an explicit user `--sourceMap` still wins.
+    if (options.forceRuntimeSourceMap === true) {
+      args.push("--sourceMap", "true");
     }
   } else if (options.emit === false) {
     args.push("--noEmit");

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -6,7 +6,6 @@ import { readProjectConfig } from "../../compiler/internal/project/readProjectCo
 import { resolveEmittedJavaScript } from "../../compiler/internal/resolveEmittedJavaScript";
 import { runBuild } from "../../compiler/internal/runBuild";
 import type { TtscCommonOptions } from "../../structures/internal/TtscCommonOptions";
-import { RUNTIME_SOURCE_MAP_TSGO_FLAGS } from "./servedSourceMap";
 
 /** Subdirectory name that isolates concurrent ttsx processes by PID. */
 const PROCESS_CACHE_KEY = String(process.pid);
@@ -103,6 +102,13 @@ function createProjectContext(
       typeof project.compilerOptions.module === "string"
         ? project.compilerOptions.module
         : undefined,
+    // Force a source map on the transient runtime emit only when the project
+    // configures none — when it already emits `sourceMap` or `inlineSourceMap`,
+    // the serve path inlines/absolutizes that map, so no override is needed
+    // (issue #353).
+    forceRuntimeSourceMap:
+      project.compilerOptions.sourceMap !== true &&
+      project.compilerOptions.inlineSourceMap !== true,
     built: false,
     emittedFiles: undefined as string[] | undefined,
   };
@@ -139,14 +145,13 @@ function buildProject(
     forceListEmittedFiles: true,
     cacheDir: context.pluginCacheDir,
     outDir: context.emitDir,
-    // Force an external source map on the transient entry emit so the serve
-    // path can inline it under the source URL (issue #353). This emit lands in
-    // a PID-isolated temp dir, never the consumer's `outDir`, so the override
-    // leaks nowhere; appended last so it wins over any forwarded map flag.
-    passthrough: [
-      ...(options.passthrough ?? []),
-      ...RUNTIME_SOURCE_MAP_TSGO_FLAGS,
-    ],
+    passthrough: options.passthrough,
+    // Emit a source map on the transient entry emit (a PID-isolated temp dir,
+    // never the consumer's `outDir`) so the serve path can inline it under the
+    // source URL. Routed as a dedicated build option, not a forwarded tsgo
+    // flag, so it never reaches a native plugin host's argument parser (issue
+    // #353).
+    forceRuntimeSourceMap: context.forceRuntimeSourceMap,
     plugins: options.plugins,
     quiet: true,
     singleThreaded: options.singleThreaded,

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -6,6 +6,7 @@ import { readProjectConfig } from "../../compiler/internal/project/readProjectCo
 import { resolveEmittedJavaScript } from "../../compiler/internal/resolveEmittedJavaScript";
 import { runBuild } from "../../compiler/internal/runBuild";
 import type { TtscCommonOptions } from "../../structures/internal/TtscCommonOptions";
+import { RUNTIME_SOURCE_MAP_TSGO_FLAGS } from "./servedSourceMap";
 
 /** Subdirectory name that isolates concurrent ttsx processes by PID. */
 const PROCESS_CACHE_KEY = String(process.pid);
@@ -138,7 +139,14 @@ function buildProject(
     forceListEmittedFiles: true,
     cacheDir: context.pluginCacheDir,
     outDir: context.emitDir,
-    passthrough: options.passthrough,
+    // Force an external source map on the transient entry emit so the serve
+    // path can inline it under the source URL (issue #353). This emit lands in
+    // a PID-isolated temp dir, never the consumer's `outDir`, so the override
+    // leaks nowhere; appended last so it wins over any forwarded map flag.
+    passthrough: [
+      ...(options.passthrough ?? []),
+      ...RUNTIME_SOURCE_MAP_TSGO_FLAGS,
+    ],
     plugins: options.plugins,
     quiet: true,
     singleThreaded: options.singleThreaded,

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -10,10 +10,7 @@ import { resolveEmittedJavaScript } from "../../compiler/internal/resolveEmitted
 import { resolveTsgo } from "../../compiler/internal/resolveTsgo";
 import { runBuild } from "../../compiler/internal/runBuild";
 import { outputText, spawnNative } from "../../compiler/internal/spawnNative";
-import {
-  RUNTIME_SOURCE_MAP_TSGO_FLAGS,
-  inlineServedSourceMap,
-} from "./servedSourceMap";
+import { inlineServedSourceMap } from "./servedSourceMap";
 
 /**
  * Synchronous Node module hooks installed (via `module.registerHooks`) in the
@@ -1117,12 +1114,14 @@ function buildDependency(
     emit: true,
     forceListEmittedFiles: true,
     outDir: emitDir,
-    // Force an external source map on the transient dependency emit so the
-    // serve path can inline it under the source URL (issue #353). This emit
-    // never reaches the dependency's published `lib/`, so the override leaks
-    // nowhere. Passthrough wins over any `sourceMap`/`inlineSourceMap` the
-    // dependency's own tsconfig set, so coverage and stacks work regardless.
-    passthrough: [...RUNTIME_SOURCE_MAP_TSGO_FLAGS],
+    // Emit a source map on the transient dependency emit (it never reaches the
+    // dependency's published `lib/`) so the serve path can inline it under the
+    // source URL, but only when the dependency configures none itself. Routed
+    // as a dedicated build option, not a forwarded tsgo flag, so it never
+    // reaches a native plugin host's argument parser (issue #353).
+    forceRuntimeSourceMap:
+      project.compilerOptions.sourceMap !== true &&
+      project.compilerOptions.inlineSourceMap !== true,
     // Honour the dependency's own transform plugins: a source-shipping package
     // can itself depend on a transform (e.g. a fixture whose values are built
     // with `typia.createRandom`), and its runtime behaviour is wrong without it.

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -10,6 +10,10 @@ import { resolveEmittedJavaScript } from "../../compiler/internal/resolveEmitted
 import { resolveTsgo } from "../../compiler/internal/resolveTsgo";
 import { runBuild } from "../../compiler/internal/runBuild";
 import { outputText, spawnNative } from "../../compiler/internal/spawnNative";
+import {
+  RUNTIME_SOURCE_MAP_TSGO_FLAGS,
+  inlineServedSourceMap,
+} from "./servedSourceMap";
 
 /**
  * Synchronous Node module hooks installed (via `module.registerHooks`) in the
@@ -151,6 +155,13 @@ export function installRuntimeHooks(): void {
     return;
   }
   installed = true;
+  // Map error stacks through the source maps the serve path now inlines, so a
+  // thrown frame reports the true `.ts` line:col out of the box (no
+  // `--enable-source-maps` needed). Applied before the entry loads; user code
+  // that later toggles it wins, since this is a plain runtime switch.
+  if (typeof process.setSourceMapsEnabled === "function") {
+    process.setSourceMapsEnabled(true);
+  }
   registerHooks({ load, resolve });
   installCommonJsHook();
 }
@@ -356,17 +367,36 @@ function resolveServedSource(
   const real = realPath(filename);
   const served = serveEntryEmit(real);
   if (served !== null) {
-    return { moduleOption: manifest()?.moduleOption, ...served };
+    return withInlineSourceMap({
+      moduleOption: manifest()?.moduleOption,
+      ...served,
+    });
   }
   const built = serveDependencyEmit(real);
   if (built !== null) {
-    return built;
+    return withInlineSourceMap(built);
   }
   return {
     moduleOption: undefined,
     sourceFile: filename,
     source: transformOrphanSource(filename, url),
   };
+}
+
+/**
+ * Inline a served emit's external source map into its text and absolutize the
+ * map's `sources`, so the JavaScript executed under the `.ts` source URL stays
+ * self-describing after the per-run emit directory is deleted. Applied to both
+ * the entry lane (`serveEntryEmit`) and the dependency lane
+ * (`serveBuiltDependency`); the orphan type-strip lane carries no emitted map.
+ */
+function withInlineSourceMap(served: ServedSource): ServedSource {
+  const source = inlineServedSourceMap(
+    served.source,
+    served.emittedFile,
+    served.sourceFile,
+  );
+  return source === served.source ? served : { ...served, source };
 }
 
 /**
@@ -1087,6 +1117,12 @@ function buildDependency(
     emit: true,
     forceListEmittedFiles: true,
     outDir: emitDir,
+    // Force an external source map on the transient dependency emit so the
+    // serve path can inline it under the source URL (issue #353). This emit
+    // never reaches the dependency's published `lib/`, so the override leaks
+    // nowhere. Passthrough wins over any `sourceMap`/`inlineSourceMap` the
+    // dependency's own tsconfig set, so coverage and stacks work regardless.
+    passthrough: [...RUNTIME_SOURCE_MAP_TSGO_FLAGS],
     // Honour the dependency's own transform plugins: a source-shipping package
     // can itself depend on a transform (e.g. a fixture whose values are built
     // with `typia.createRandom`), and its runtime behaviour is wrong without it.

--- a/packages/ttsc/src/launcher/internal/servedSourceMap.ts
+++ b/packages/ttsc/src/launcher/internal/servedSourceMap.ts
@@ -28,9 +28,13 @@ export const RUNTIME_SOURCE_MAP_TSGO_FLAGS: readonly string[] = [
 /** Rewritten served text keyed by emitted file, so the work runs once per run. */
 const inlineCache = new Map<string, string>();
 
-/** Trailing `//# sourceMappingURL=<url>` (or legacy `//@`) magic comment. */
-const SOURCE_MAPPING_URL =
-  /\/\/[#@] sourceMappingURL=([^\r\n]*)[ \t]*(?:\r?\n)?$/;
+/**
+ * Trailing `//# sourceMappingURL=<url>` (or legacy `//@`) magic comment.
+ * Anchored at end of text through any trailing whitespace, so it matches the
+ * last comment whether tsgo emitted it with a newline, none, or a CRLF line
+ * ending.
+ */
+const SOURCE_MAPPING_URL = /\/\/[#@] sourceMappingURL=([^\r\n]*)[ \t\r\n]*$/;
 
 /**
  * Replace a served emit's trailing external `//# sourceMappingURL=<relative>`

--- a/packages/ttsc/src/launcher/internal/servedSourceMap.ts
+++ b/packages/ttsc/src/launcher/internal/servedSourceMap.ts
@@ -2,29 +2,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-/**
- * Tsgo flags that force the ttsx runtime build to emit an external source map
- * (`<name>.js.map`) beside every `<name>.js`, regardless of the consumer's own
- * tsconfig. They are appended after the user's forwarded flags so they win a
- * conflicting earlier value.
- *
- * The runtime build always emits to a private, transient directory (the entry
- * project's PID-isolated dir, or the shared dependency cache) that is never the
- * consumer's `outDir`, so forcing maps here leaks into nobody's published
- * `lib/`. Forcing an _external_ map (and disabling any inline variant) gives
- * the serve path one uniform shape to rewrite — a trailing `//#
- * sourceMappingURL=<relative>` comment with a sibling `.map` — whether the
- * consumer configured `sourceMap`, `inlineSourceMap`, or no map at all.
- */
-export const RUNTIME_SOURCE_MAP_TSGO_FLAGS: readonly string[] = [
-  "--sourceMap",
-  "true",
-  "--inlineSourceMap",
-  "false",
-  "--inlineSources",
-  "false",
-];
-
 /** Rewritten served text keyed by emitted file, so the work runs once per run. */
 const inlineCache = new Map<string, string>();
 

--- a/packages/ttsc/src/launcher/internal/servedSourceMap.ts
+++ b/packages/ttsc/src/launcher/internal/servedSourceMap.ts
@@ -1,0 +1,202 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Tsgo flags that force the ttsx runtime build to emit an external source map
+ * (`<name>.js.map`) beside every `<name>.js`, regardless of the consumer's own
+ * tsconfig. They are appended after the user's forwarded flags so they win a
+ * conflicting earlier value.
+ *
+ * The runtime build always emits to a private, transient directory (the entry
+ * project's PID-isolated dir, or the shared dependency cache) that is never the
+ * consumer's `outDir`, so forcing maps here leaks into nobody's published
+ * `lib/`. Forcing an _external_ map (and disabling any inline variant) gives
+ * the serve path one uniform shape to rewrite — a trailing `//#
+ * sourceMappingURL=<relative>` comment with a sibling `.map` — whether the
+ * consumer configured `sourceMap`, `inlineSourceMap`, or no map at all.
+ */
+export const RUNTIME_SOURCE_MAP_TSGO_FLAGS: readonly string[] = [
+  "--sourceMap",
+  "true",
+  "--inlineSourceMap",
+  "false",
+  "--inlineSources",
+  "false",
+];
+
+/** Rewritten served text keyed by emitted file, so the work runs once per run. */
+const inlineCache = new Map<string, string>();
+
+/** Trailing `//# sourceMappingURL=<url>` (or legacy `//@`) magic comment. */
+const SOURCE_MAPPING_URL =
+  /\/\/[#@] sourceMappingURL=([^\r\n]*)[ \t]*(?:\r?\n)?$/;
+
+/**
+ * Replace a served emit's trailing external `//# sourceMappingURL=<relative>`
+ * comment with an inline `data:` URL whose `sources` are absolute `file://`
+ * URLs of the true on-disk source files.
+ *
+ * Ttsx runs tsgo-built JavaScript under the ORIGINAL `.ts` source URL. When the
+ * owning tsconfig emits external maps, the served text ends with a relative
+ * `sourceMappingURL` that Node resolves against the `.ts` script URL — where no
+ * `.js.map` exists — and that the per-run emit directory deletes at process
+ * exit anyway. Node's V8 coverage then caches the script with `data: null` and
+ * c8 misattributes lines (false 100%, issue #353); `--enable-source-maps`
+ * cannot map stack frames. Inlining the map into the served text (which V8
+ * captures at compile time) survives both the wrong resolution base and the
+ * post-exit cleanup, and absolutizing `sources` fixes the mis-rooted paths that
+ * mapped stack frames, debuggers, and IDE links would otherwise print.
+ *
+ * Idempotent: re-running it on already-inlined text (whose `sources` are
+ * already absolute `file://` URLs) reproduces the same bytes, which keeps the
+ * shared cross-process dependency cache deterministic.
+ *
+ * @param source - The emitted JavaScript text served under the source URL.
+ * @param emittedFile - On-disk path of the emitted `.js`, beside its `.map`.
+ * @param sourceFile - Real path of the `.ts` source the emit was built from.
+ */
+export function inlineServedSourceMap(
+  source: string,
+  emittedFile: string | undefined,
+  sourceFile: string | undefined,
+): string {
+  if (emittedFile === undefined) {
+    return source;
+  }
+  const cached = inlineCache.get(emittedFile);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const rewritten = rewrite(source, emittedFile, sourceFile);
+  inlineCache.set(emittedFile, rewritten);
+  return rewritten;
+}
+
+function rewrite(
+  source: string,
+  emittedFile: string,
+  sourceFile: string | undefined,
+): string {
+  const match = SOURCE_MAPPING_URL.exec(source);
+  if (match === null) {
+    return source;
+  }
+  const url = match[1]!.trim();
+  if (url.length === 0) {
+    return source;
+  }
+  const json = readMapJson(url, emittedFile);
+  if (json === null) {
+    // The referenced map cannot be read (an external ref whose sibling is
+    // missing). Strip the dangling comment so Node does not cache the script
+    // with `data: null` and misattribute coverage; leave an already-inline
+    // `data:` map untouched since it is self-contained.
+    return url.startsWith("data:")
+      ? source
+      : source.slice(0, match.index).replace(/\r?\n$/, "");
+  }
+  const inlined = inlineComment(json, emittedFile, sourceFile);
+  if (inlined === null) {
+    return source;
+  }
+  return source.slice(0, match.index) + inlined;
+}
+
+/** Read the raw map JSON from a `data:` URI or a sibling map file. */
+function readMapJson(url: string, emittedFile: string): string | null {
+  if (url.startsWith("data:")) {
+    return decodeDataUri(url);
+  }
+  const direct = path.resolve(path.dirname(emittedFile), url);
+  const fromRef = readFileOrNull(direct);
+  if (fromRef !== null) {
+    return fromRef;
+  }
+  // tsgo names the comment after the emit basename; fall back to the canonical
+  // sibling path when the comment's relative form does not resolve on disk.
+  return readFileOrNull(`${emittedFile}.map`);
+}
+
+/** Decode a `data:application/json[;base64],...` source-map URI to its JSON. */
+function decodeDataUri(url: string): string | null {
+  const comma = url.indexOf(",");
+  if (comma === -1) {
+    return null;
+  }
+  const meta = url.slice(0, comma);
+  if (!meta.includes("application/json")) {
+    return null;
+  }
+  const payload = url.slice(comma + 1);
+  try {
+    return meta.includes(";base64")
+      ? Buffer.from(payload, "base64").toString("utf8")
+      : decodeURIComponent(payload);
+  } catch {
+    return null;
+  }
+}
+
+/** Parse the map, absolutize its `sources`, and re-encode it as a `data:` URI. */
+function inlineComment(
+  json: string,
+  emittedFile: string,
+  sourceFile: string | undefined,
+): string | null {
+  let map: {
+    sources?: unknown;
+    sourceRoot?: unknown;
+    [key: string]: unknown;
+  };
+  try {
+    map = JSON.parse(json) as typeof map;
+  } catch {
+    return null;
+  }
+  map.sources = absolutizeSources(map, path.dirname(emittedFile), sourceFile);
+  // `sources` are now absolute `file://` URLs, so any `sourceRoot` prefix would
+  // corrupt them — drop it.
+  delete map.sourceRoot;
+  const encoded = Buffer.from(JSON.stringify(map), "utf8").toString("base64");
+  return `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${encoded}`;
+}
+
+/**
+ * Map each entry of the source map's `sources` to an absolute `file://` URL.
+ *
+ * Tsgo's per-file emit is 1:1, so a single source is the served file itself and
+ * resolves to the real on-disk `sourceFile` the serve path already knows — the
+ * most reliable anchor. A map that somehow carries several sources (or is
+ * consumed without a known source file) has each relative entry resolved
+ * against the map's own directory and `sourceRoot`, exactly where tsgo computed
+ * them from; entries that are already absolute URLs pass through unchanged.
+ */
+function absolutizeSources(
+  map: { sources?: unknown; sourceRoot?: unknown },
+  mapDir: string,
+  sourceFile: string | undefined,
+): string[] {
+  const sources = Array.isArray(map.sources) ? map.sources : [];
+  if (sources.length === 1 && sourceFile !== undefined) {
+    return [pathToFileURL(sourceFile).href];
+  }
+  const sourceRoot = typeof map.sourceRoot === "string" ? map.sourceRoot : "";
+  return sources.map((entry) => {
+    if (typeof entry !== "string") {
+      return String(entry);
+    }
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(entry)) {
+      return entry;
+    }
+    return pathToFileURL(path.resolve(mapDir, sourceRoot, entry)).href;
+  });
+}
+
+function readFileOrNull(file: string): string | null {
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+}

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_coverage_source_map_is_inlined_for_a_built_dependency.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_coverage_source_map_is_inlined_for_a_built_dependency.ts
@@ -1,0 +1,99 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  maxFunctionCount,
+  runTtsxWithCoverage,
+  sourceMapSourcePath,
+  tallCommentLibrarySource,
+} from "../../internal/ttsx-source-map";
+
+/**
+ * Verifies the inlined-map fix also covers the dependency serve lane, which is
+ * a separate code path from the entry lane (issue #353).
+ *
+ * A raw-`.ts` dependency resolved from `node_modules` is built under its own
+ * tsconfig by `serveBuiltDependency`, not `serveEntryEmit`; a fix that only
+ * touched the entry lane would leave dependency coverage broken. The dependency
+ * build forces an external map and the serve path inlines it the same way, so a
+ * never-called dependency export is attributed correctly.
+ *
+ * 1. Install a `built-dep` package (own tsconfig, `sourceMap: true`) whose
+ *    `index.ts` has a called and an uncalled export behind a tall comment.
+ * 2. Run an entry that calls only the called export under `NODE_V8_COVERAGE`.
+ * 3. Assert the dependency script's map `data` is present and real, `unused`
+ *    records zero executions, and `used` at least one.
+ */
+export const test_ttsx_coverage_source_map_is_inlined_for_a_built_dependency =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/built-dep/package.json": JSON.stringify({
+        name: "built-dep",
+        version: "1.0.0",
+        exports: { ".": "./src/index.ts" },
+      }),
+      "node_modules/built-dep/tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          sourceMap: true,
+          outDir: "lib",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/built-dep/src/index.ts": tallCommentLibrarySource(),
+      "src/main.ts": ['import { used } from "built-dep";', "used();", ""].join(
+        "\n",
+      ),
+    });
+
+    const run = runTtsxWithCoverage(root, "src/main.ts");
+    assert.equal(run.status, 0, run.stderr);
+
+    const script = run.scriptEndingWith("index.ts");
+    assert.ok(script, "coverage must record the served dependency script");
+    assert.ok(
+      script.sourceMap !== null,
+      "the dependency's source-map-cache.data must be present, not null",
+    );
+
+    const mapped = sourceMapSourcePath(script);
+    const real = fs.realpathSync(
+      path.join(root, "node_modules", "built-dep", "src", "index.ts"),
+    );
+    assert.ok(mapped, "the inlined map must list a source path");
+    assert.equal(
+      caseFold(path.normalize(mapped)),
+      caseFold(real),
+      "the map's source must be the dependency's real absolute index.ts",
+    );
+
+    assert.equal(
+      maxFunctionCount(script, "unused"),
+      0,
+      "the never-called dependency export must record zero executions",
+    );
+    assert.ok(
+      maxFunctionCount(script, "used") >= 1,
+      "the called dependency export must record at least one execution",
+    );
+  };
+
+function caseFold(value: string): string {
+  return process.platform === "win32" ? value.toLowerCase() : value;
+}

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_coverage_source_map_is_inlined_for_a_built_dependency_without_maps.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_coverage_source_map_is_inlined_for_a_built_dependency_without_maps.ts
@@ -1,0 +1,98 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  maxFunctionCount,
+  runTtsxWithCoverage,
+  sourceMapSourcePath,
+  tallCommentLibrarySource,
+} from "../../internal/ttsx-source-map";
+
+/**
+ * Verifies ttsx forces a map on a dependency build whose own tsconfig emits
+ * none (`sourceMap: false`), so dependency coverage works regardless (issue
+ * #353).
+ *
+ * The dependency build has its own `runBuild` call site (`buildDependency`),
+ * distinct from the entry build, so its forced-map override must be pinned
+ * separately from the entry's. A source-shipping dependency that publishes
+ * without maps must still yield resolvable coverage when run through ttsx.
+ *
+ * 1. Install a `built-dep` package whose tsconfig sets `sourceMap: false`.
+ * 2. Run an entry that calls only its called export under `NODE_V8_COVERAGE`.
+ * 3. Assert the dependency script's map `data` is present and real, `unused`
+ *    records zero executions, and `used` at least one.
+ */
+export const test_ttsx_coverage_source_map_is_inlined_for_a_built_dependency_without_maps =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/built-dep/package.json": JSON.stringify({
+        name: "built-dep",
+        version: "1.0.0",
+        exports: { ".": "./src/index.ts" },
+      }),
+      "node_modules/built-dep/tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          sourceMap: false,
+          outDir: "lib",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/built-dep/src/index.ts": tallCommentLibrarySource(),
+      "src/main.ts": ['import { used } from "built-dep";', "used();", ""].join(
+        "\n",
+      ),
+    });
+
+    const run = runTtsxWithCoverage(root, "src/main.ts");
+    assert.equal(run.status, 0, run.stderr);
+
+    const script = run.scriptEndingWith("index.ts");
+    assert.ok(script, "coverage must record the served dependency script");
+    assert.ok(
+      script.sourceMap !== null,
+      "a forced dependency map must make source-map-cache.data present",
+    );
+
+    const mapped = sourceMapSourcePath(script);
+    const real = fs.realpathSync(
+      path.join(root, "node_modules", "built-dep", "src", "index.ts"),
+    );
+    assert.ok(mapped, "the inlined map must list a source path");
+    assert.equal(
+      caseFold(path.normalize(mapped)),
+      caseFold(real),
+      "the map's source must be the dependency's real absolute index.ts",
+    );
+
+    assert.equal(
+      maxFunctionCount(script, "unused"),
+      0,
+      "the never-called dependency export must record zero executions",
+    );
+    assert.ok(
+      maxFunctionCount(script, "used") >= 1,
+      "the called dependency export must record at least one execution",
+    );
+  };
+
+function caseFold(value: string): string {
+  return process.platform === "win32" ? value.toLowerCase() : value;
+}

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_coverage_source_map_is_inlined_for_the_entry_project.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_coverage_source_map_is_inlined_for_the_entry_project.ts
@@ -1,0 +1,85 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  maxFunctionCount,
+  runTtsxWithCoverage,
+  sourceMapSourcePath,
+  tallCommentLibrarySource,
+} from "../../internal/ttsx-source-map";
+
+/**
+ * Verifies ttsx serves the entry project's emit with an inlined, absolutized
+ * source map, so Node's V8 coverage remaps it correctly (issue #353).
+ *
+ * Ttsx runs tsgo-built JavaScript under the original `.ts` URL. With external
+ * maps (a library's default `sourceMap: true`) the served text ended with a
+ * relative `//# sourceMappingURL` Node could never resolve, so V8 cached the
+ * script with `data: null` and c8 misattributed lines — a never-called function
+ * reported 100% covered. The serve path now inlines the sibling map and
+ * rewrites its `sources` to the real absolute path, so `data` is present and
+ * points at the true source; V8's raw counts (used ran, unused did not) then
+ * attribute to the right lines.
+ *
+ * 1. Build an entry project (`sourceMap: true`) whose `lib.ts` has a called and an
+ *    uncalled export behind a tall comment; run it under `NODE_V8_COVERAGE`.
+ * 2. Assert the `lib.ts` script's `source-map-cache.data` is non-null and its
+ *    `sources[0]` is the real absolute `lib.ts`.
+ * 3. Assert V8 recorded `unused` with count 0 and `used` with count >= 1.
+ */
+export const test_ttsx_coverage_source_map_is_inlined_for_the_entry_project =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          sourceMap: true,
+          outDir: "lib",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "src/lib.ts": tallCommentLibrarySource(),
+      "src/main.ts": ['import { used } from "./lib";', "used();", ""].join(
+        "\n",
+      ),
+    });
+
+    const run = runTtsxWithCoverage(root, "src/main.ts");
+    assert.equal(run.status, 0, run.stderr);
+
+    const script = run.scriptEndingWith("lib.ts");
+    assert.ok(script, "coverage must record the served lib.ts script");
+    assert.ok(
+      script.sourceMap !== null,
+      "source-map-cache.data must be present, not null (the #353 failure)",
+    );
+
+    const mapped = sourceMapSourcePath(script);
+    const real = fs.realpathSync(path.join(root, "src", "lib.ts"));
+    assert.ok(mapped, "the inlined map must list a source path");
+    assert.equal(
+      caseFold(path.normalize(mapped)),
+      caseFold(real),
+      "the map's source must be the real absolute lib.ts, not a mis-rooted path",
+    );
+
+    assert.equal(
+      maxFunctionCount(script, "unused"),
+      0,
+      "the never-called export must record zero executions",
+    );
+    assert.ok(
+      maxFunctionCount(script, "used") >= 1,
+      "the called export must record at least one execution (negative twin)",
+    );
+  };
+
+function caseFold(value: string): string {
+  return process.platform === "win32" ? value.toLowerCase() : value;
+}

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_coverage_source_map_is_inlined_when_the_entry_project_emits_no_map.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_coverage_source_map_is_inlined_when_the_entry_project_emits_no_map.ts
@@ -1,0 +1,83 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  maxFunctionCount,
+  runTtsxWithCoverage,
+  sourceMapSourcePath,
+  tallCommentLibrarySource,
+} from "../../internal/ttsx-source-map";
+
+/**
+ * Verifies ttsx makes coverage work even when the entry tsconfig emits no map
+ * (`sourceMap: false`), by forcing a map on the transient runtime build.
+ *
+ * A consumer that publishes without maps must not lose ttsx coverage fidelity,
+ * and forcing inline maps into everyone's `lib/` is not an acceptable
+ * workaround. ttsx therefore forces an external source map on its own private,
+ * PID-isolated emit (never the consumer's `outDir`) and inlines it at serve
+ * time, so `source-map-cache.data` is present regardless of the owning
+ * tsconfig. This pins the forced-map path in `prepareExecution`.
+ *
+ * 1. Build an entry project with `sourceMap: false`; run it under
+ *    `NODE_V8_COVERAGE`.
+ * 2. Assert the `lib.ts` script's `source-map-cache.data` is non-null and points
+ *    at the real absolute source.
+ * 3. Assert `unused` records zero executions and `used` at least one.
+ */
+export const test_ttsx_coverage_source_map_is_inlined_when_the_entry_project_emits_no_map =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          sourceMap: false,
+          outDir: "lib",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "src/lib.ts": tallCommentLibrarySource(),
+      "src/main.ts": ['import { used } from "./lib";', "used();", ""].join(
+        "\n",
+      ),
+    });
+
+    const run = runTtsxWithCoverage(root, "src/main.ts");
+    assert.equal(run.status, 0, run.stderr);
+
+    const script = run.scriptEndingWith("lib.ts");
+    assert.ok(script, "coverage must record the served lib.ts script");
+    assert.ok(
+      script.sourceMap !== null,
+      "a forced runtime map must make source-map-cache.data present",
+    );
+
+    const mapped = sourceMapSourcePath(script);
+    const real = fs.realpathSync(path.join(root, "src", "lib.ts"));
+    assert.ok(mapped, "the inlined map must list a source path");
+    assert.equal(
+      caseFold(path.normalize(mapped)),
+      caseFold(real),
+      "the map's source must be the real absolute lib.ts",
+    );
+
+    assert.equal(
+      maxFunctionCount(script, "unused"),
+      0,
+      "the never-called export must record zero executions",
+    );
+    assert.ok(
+      maxFunctionCount(script, "used") >= 1,
+      "the called export must record at least one execution (negative twin)",
+    );
+  };
+
+function caseFold(value: string): string {
+  return process.platform === "win32" ? value.toLowerCase() : value;
+}

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dependency_own_type_diagnostics_do_not_fail_the_run_while_inlining_its_map.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dependency_own_type_diagnostics_do_not_fail_the_run_while_inlining_its_map.ts
@@ -1,0 +1,106 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  runTtsxWithCoverage,
+  sourceMapSourcePath,
+} from "../../internal/ttsx-source-map";
+
+/**
+ * Verifies a dependency's OWN type diagnostics never fail a ttsx run, even
+ * while ttsx builds that dependency to obtain a source map to inline (issue
+ * #353).
+ *
+ * A source-shipping dependency is built under its own (possibly stricter)
+ * tsconfig for type-aware emit, but its diagnostics belong to that package, not
+ * the user's program — the dependency build runs emit-only
+ * (`skipDiagnosticsCheck`). This pins that a dependency whose config would trip
+ * `noUnusedLocals`/`noUnusedParameters` still emits, runs, and yields an
+ * inlined map, so the map work added for #353 cannot start gating on foreign
+ * diagnostics.
+ *
+ * 1. Install a `built-dep` whose tsconfig sets `noUnusedLocals` /
+ *    `noUnusedParameters` and whose source carries an unused local and
+ *    parameter (a real TS6133 under that config).
+ * 2. Run an entry that imports and calls it under `NODE_V8_COVERAGE`.
+ * 3. Assert exit 0, the dependency executed, and its map `data` inlined with the
+ *    real source path.
+ */
+export const test_ttsx_dependency_own_type_diagnostics_do_not_fail_the_run_while_inlining_its_map =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/built-dep/package.json": JSON.stringify({
+        name: "built-dep",
+        version: "1.0.0",
+        exports: { ".": "./src/index.ts" },
+      }),
+      "node_modules/built-dep/tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          sourceMap: true,
+          noUnusedLocals: true,
+          noUnusedParameters: true,
+          outDir: "lib",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      // Under the dependency's own `noUnusedLocals`/`noUnusedParameters` this is
+      // a real TS6133 pair — invisible to the user, and it must not fail the run.
+      "node_modules/built-dep/src/index.ts": [
+        "export function greet(unusedParam: number): string {",
+        "  const unusedLocal: number = 1;",
+        '  return "greet ran";',
+        "}",
+        "",
+      ].join("\n"),
+      "src/main.ts": [
+        'import { greet } from "built-dep";',
+        "greet(1);",
+        "",
+      ].join("\n"),
+    });
+
+    const run = runTtsxWithCoverage(root, "src/main.ts");
+    assert.equal(
+      run.status,
+      0,
+      `a dependency's own type diagnostics must not fail the run\n${run.stderr}`,
+    );
+
+    const script = run.scriptEndingWith("index.ts");
+    assert.ok(script, "coverage must record the served dependency script");
+    assert.ok(
+      script.sourceMap !== null,
+      "the dependency's map must still inline (data present)",
+    );
+    const mapped = sourceMapSourcePath(script);
+    const real = fs.realpathSync(
+      path.join(root, "node_modules", "built-dep", "src", "index.ts"),
+    );
+    assert.ok(mapped, "the inlined map must list a source path");
+    assert.equal(
+      caseFold(path.normalize(mapped)),
+      caseFold(real),
+      "the map's source must be the dependency's real absolute index.ts",
+    );
+  };
+
+function caseFold(value: string): string {
+  return process.platform === "win32" ? value.toLowerCase() : value;
+}

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_inline_source_map_handles_absent_inline_and_multi_source_maps.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_inline_source_map_handles_absent_inline_and_multi_source_maps.ts
@@ -1,0 +1,117 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { inlineServedSourceMap } from "../../../../../packages/ttsc/lib/launcher/internal/servedSourceMap.js";
+
+/**
+ * Verifies the source-map inliner's boundary behavior on the map shapes a
+ * served emit can carry beyond the common single-source external case (issue
+ * #353).
+ *
+ * These are the latent-risk edges the spawned runs cannot reach on a platform
+ * whose tsgo always emits an LF, single-source external map: a served emit with
+ * no comment must pass through untouched; an emit whose sibling map is missing
+ * must have its dangling comment stripped (so Node caches no `data: null`
+ * script); an already-inline map must be absolutized without being double-
+ * wrapped; and a multi-source map must have each relative source absolutized
+ * against the map's own directory.
+ *
+ * 1. Assert text without a trailer is returned unchanged.
+ * 2. Assert a missing-sibling external trailer is stripped entirely.
+ * 3. Assert an already-inline `data:` map is rewritten to one trailer with an
+ *    absolute source.
+ * 4. Assert a two-source map absolutizes both entries against the map directory.
+ */
+export const test_ttsx_inline_source_map_handles_absent_inline_and_multi_source_maps =
+  () => {
+    const dir = TestProject.tmpdir("ttsx-inline-map-edges-");
+    const sourceFile = path.join(dir, "src", "lib.ts");
+
+    // 1. No trailer → unchanged.
+    const plain = "exports.x = 1;\n";
+    assert.equal(
+      inlineServedSourceMap(plain, path.join(dir, "plain.js"), sourceFile),
+      plain,
+      "text without a sourceMappingURL trailer must be returned unchanged",
+    );
+
+    // 2. External trailer whose sibling map is missing → comment stripped.
+    const dangling = "exports.x = 1;\n//# sourceMappingURL=missing.js.map";
+    const stripped = inlineServedSourceMap(
+      dangling,
+      path.join(dir, "missing.js"),
+      sourceFile,
+    );
+    assert.equal(
+      stripped,
+      "exports.x = 1;",
+      "a dangling external trailer must be stripped so no data:null is cached",
+    );
+
+    // 3. Already-inline data URI → absolutized, single trailer.
+    const inlineMap = Buffer.from(
+      JSON.stringify({
+        version: 3,
+        file: "a.js",
+        sources: ["../src/lib.ts"],
+        names: [],
+        mappings: "AAAA",
+      }),
+      "utf8",
+    ).toString("base64");
+    const alreadyInline = `exports.x = 1;\n//# sourceMappingURL=data:application/json;base64,${inlineMap}`;
+    const reinlined = inlineServedSourceMap(
+      alreadyInline,
+      path.join(dir, "inline.js"),
+      sourceFile,
+    );
+    assert.equal(
+      (reinlined.match(/sourceMappingURL=data:/g) ?? []).length,
+      1,
+      "an already-inline map must not be double-wrapped",
+    );
+    assert.deepEqual(
+      decodeInlineMap(reinlined).sources,
+      [pathToFileURL(sourceFile).href],
+      "an already-inline single-source map must be absolutized",
+    );
+
+    // 4. Multi-source map → each relative source absolutized against map dir.
+    const multiEmitted = path.join(dir, "multi.js");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      `${multiEmitted}.map`,
+      JSON.stringify({
+        version: 3,
+        file: "multi.js",
+        sourceRoot: "",
+        sources: ["../src/a.ts", "../src/b.ts"],
+        names: [],
+        mappings: "AAAA",
+      }),
+    );
+    const multiOut = inlineServedSourceMap(
+      "exports.x = 1;\n//# sourceMappingURL=multi.js.map",
+      multiEmitted,
+      undefined,
+    );
+    assert.deepEqual(
+      decodeInlineMap(multiOut).sources,
+      [
+        pathToFileURL(path.resolve(dir, "../src/a.ts")).href,
+        pathToFileURL(path.resolve(dir, "../src/b.ts")).href,
+      ],
+      "each source of a multi-source map must be absolutized against the map dir",
+    );
+  };
+
+function decodeInlineMap(text: string): Record<string, unknown> {
+  const match = text.match(
+    /sourceMappingURL=data:application\/json;[^,]*,(.+)$/,
+  );
+  assert.ok(match, "output must carry a base64 data URI");
+  return JSON.parse(Buffer.from(match[1]!, "base64").toString("utf8"));
+}

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_inline_source_map_rewrites_external_maps_and_is_idempotent.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_inline_source_map_rewrites_external_maps_and_is_idempotent.ts
@@ -1,0 +1,106 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { inlineServedSourceMap } from "../../../../../packages/ttsc/lib/launcher/internal/servedSourceMap.js";
+
+/**
+ * Verifies the serve-time source-map inliner rewrites an external map into an
+ * absolutized `data:` URI and is idempotent (issue #353).
+ *
+ * The inliner is the choke point every served emit passes through, so its own
+ * contract is pinned directly here rather than only through spawned runs: it
+ * reads the sibling `.map`, replaces `sources` with the real absolute `file://`
+ * URL, drops `sourceRoot`, and re-encodes — and re-running it on
+ * already-inlined text (as the shared cross-process dependency cache can) must
+ * reproduce the same bytes. A CRLF-terminated emit must rewrite the same way.
+ *
+ * 1. Write a `lib.js` + sibling `lib.js.map` (relative `sources`, a `sourceRoot`)
+ *    and inline it; assert the trailer is a single `data:` URI whose decoded
+ *    map lists the real absolute source and carries no `sourceRoot`.
+ * 2. Feed the output back through a fresh emit key; assert the bytes are equal.
+ * 3. Inline a CRLF-terminated emit; assert it too becomes a `data:` trailer.
+ */
+export const test_ttsx_inline_source_map_rewrites_external_maps_and_is_idempotent =
+  () => {
+    const dir = TestProject.tmpdir("ttsx-inline-map-");
+    const sourceFile = path.join(dir, "src", "lib.ts");
+    fs.mkdirSync(path.dirname(sourceFile), { recursive: true });
+    fs.writeFileSync(sourceFile, "export const x = 1;\n");
+
+    const map = JSON.stringify({
+      version: 3,
+      file: "lib.js",
+      sourceRoot: "",
+      sources: ["../src/lib.ts"],
+      names: [],
+      mappings: "AAAA",
+    });
+    const emittedFile = path.join(dir, "lib.js");
+    fs.writeFileSync(`${emittedFile}.map`, map);
+
+    const served = "exports.x = 1;\n//# sourceMappingURL=lib.js.map";
+    const out = inlineServedSourceMap(served, emittedFile, sourceFile);
+
+    assert.equal(
+      trailerCount(out),
+      1,
+      "the rewrite must leave exactly one sourceMappingURL trailer",
+    );
+    const decoded = decodeInlineMap(out);
+    assert.deepEqual(
+      decoded.sources,
+      [pathToFileURL(sourceFile).href],
+      "sources must become the real absolute file URL",
+    );
+    assert.ok(
+      !("sourceRoot" in decoded),
+      "sourceRoot must be dropped once sources are absolute",
+    );
+    assert.ok(
+      out.startsWith("exports.x = 1;\n//# sourceMappingURL=data:"),
+      "the emitted body must be preserved before the inlined trailer",
+    );
+
+    // Idempotent: a second pass over already-inlined text (fresh cache key)
+    // reproduces the same bytes.
+    const again = inlineServedSourceMap(
+      out,
+      path.join(dir, "lib-again.js"),
+      sourceFile,
+    );
+    assert.equal(
+      again,
+      out,
+      "re-inlining already-inlined text must be a no-op",
+    );
+
+    // CRLF emit: the trailer still matches and rewrites.
+    const crlfEmitted = path.join(dir, "crlf.js");
+    fs.writeFileSync(`${crlfEmitted}.map`, map);
+    const crlfServed = "exports.x = 1;\r\n//# sourceMappingURL=crlf.js.map";
+    const crlfOut = inlineServedSourceMap(crlfServed, crlfEmitted, sourceFile);
+    assert.equal(
+      trailerCount(crlfOut),
+      1,
+      "a CRLF-terminated emit must rewrite to one data: trailer",
+    );
+    assert.ok(
+      crlfOut.startsWith("exports.x = 1;\r\n//# sourceMappingURL=data:"),
+      "the CRLF body and line ending must be preserved",
+    );
+  };
+
+function trailerCount(text: string): number {
+  return (text.match(/sourceMappingURL=data:/g) ?? []).length;
+}
+
+function decodeInlineMap(text: string): Record<string, unknown> {
+  const match = text.match(
+    /sourceMappingURL=data:application\/json;[^,]*,(.+)$/,
+  );
+  assert.ok(match, "output must carry a base64 data URI");
+  return JSON.parse(Buffer.from(match[1]!, "base64").toString("utf8"));
+}

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_stack_trace_maps_to_the_true_source_position_for_a_built_dependency.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_stack_trace_maps_to_the_true_source_position_for_a_built_dependency.ts
@@ -1,0 +1,90 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  THROWER_THROW_COLUMN,
+  THROWER_THROW_LINE,
+  tallCommentThrowerSource,
+} from "../../internal/ttsx-source-map";
+
+/**
+ * Verifies stack frames map to the true source position for a built dependency,
+ * the serve lane separate from the entry project (issue #353).
+ *
+ * A raw-`.ts` dependency from `node_modules` is served by
+ * `serveBuiltDependency`; its emit must also carry an inlined, absolutized map
+ * so a frame thrown inside the dependency reports the dependency's real source
+ * path and line:col, not the emitted-JS line under a mis-rooted path.
+ *
+ * 1. Install a `built-dep` package whose `index.ts` throws behind a tall comment.
+ * 2. Run an entry that calls the dependency through ttsx.
+ * 3. Assert a non-zero exit and a `depBoom (<real index.ts>:12:9)` frame.
+ */
+export const test_ttsx_stack_trace_maps_to_the_true_source_position_for_a_built_dependency =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          outDir: "dist",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/built-dep/package.json": JSON.stringify({
+        name: "built-dep",
+        version: "1.0.0",
+        exports: { ".": "./src/index.ts" },
+      }),
+      "node_modules/built-dep/tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          sourceMap: true,
+          outDir: "lib",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/built-dep/src/index.ts": tallCommentThrowerSource(
+        "depBoom",
+        "dependency boom",
+      ),
+      "src/main.ts": [
+        'import { depBoom } from "built-dep";',
+        "depBoom();",
+        "",
+      ].join("\n"),
+    });
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.notEqual(result.status, 0, "the thrown error must fail the run");
+    const real = fs.realpathSync(
+      path.join(root, "node_modules", "built-dep", "src", "index.ts"),
+    );
+    assertMappedFrame(result.stderr, "depBoom", real);
+  };
+
+function assertMappedFrame(stderr: string, fn: string, file: string): void {
+  const frame = `${fn} (${file}:${THROWER_THROW_LINE}:${THROWER_THROW_COLUMN})`;
+  assert.ok(
+    fold(stderr).includes(fold(frame)),
+    `stderr must contain the mapped frame "${frame}"\n---\n${stderr}`,
+  );
+}
+
+function fold(value: string): string {
+  const slashed = value.replace(/\\/g, "/");
+  return process.platform === "win32" ? slashed.toLowerCase() : slashed;
+}

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_stack_trace_maps_to_the_true_source_position_for_the_entry_project.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_stack_trace_maps_to_the_true_source_position_for_the_entry_project.ts
@@ -1,0 +1,72 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  THROWER_THROW_COLUMN,
+  THROWER_THROW_LINE,
+  tallCommentThrowerSource,
+} from "../../internal/ttsx-source-map";
+
+/**
+ * Verifies a thrown error's stack frame reports the true source line:col and
+ * the real absolute source path for an entry-project file (issue #353).
+ *
+ * Ttsx runs emitted JavaScript under the `.ts` URL, so an unmapped frame
+ * carries the `.ts` filename with emitted-JS line numbers (off by the
+ * comment/prologue shift), and a consumed-but-mis-rooted map prints a
+ * nonexistent path. The serve path now inlines an absolutized map and the
+ * runtime bootstrap enables source maps, so the frame maps back to the exact
+ * source position at the real path — with no `--enable-source-maps` flag from
+ * the user.
+ *
+ * 1. Build an entry project whose `boom.ts` throws behind a tall comment.
+ * 2. Run the entry (which calls `boom`) through ttsx.
+ * 3. Assert a non-zero exit and a `boom (<real boom.ts>:12:9)` frame in stderr.
+ */
+export const test_ttsx_stack_trace_maps_to_the_true_source_position_for_the_entry_project =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          sourceMap: true,
+          outDir: "lib",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "src/boom.ts": tallCommentThrowerSource("boom", "entry boom"),
+      "src/main.ts": ['import { boom } from "./boom";', "boom();", ""].join(
+        "\n",
+      ),
+    });
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.notEqual(result.status, 0, "the thrown error must fail the run");
+    const real = fs.realpathSync(path.join(root, "src", "boom.ts"));
+    assertMappedFrame(result.stderr, "boom", real);
+  };
+
+/** Assert stderr carries a `<fn> (<file>:LINE:COL)` frame at the true position. */
+function assertMappedFrame(stderr: string, fn: string, file: string): void {
+  const frame = `${fn} (${file}:${THROWER_THROW_LINE}:${THROWER_THROW_COLUMN})`;
+  assert.ok(
+    fold(stderr).includes(fold(frame)),
+    `stderr must contain the mapped frame "${frame}"\n---\n${stderr}`,
+  );
+}
+
+function fold(value: string): string {
+  const slashed = value.replace(/\\/g, "/");
+  return process.platform === "win32" ? slashed.toLowerCase() : slashed;
+}

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_stack_trace_maps_to_the_true_source_position_when_the_entry_emits_no_map.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_stack_trace_maps_to_the_true_source_position_when_the_entry_emits_no_map.ts
@@ -1,0 +1,69 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  THROWER_THROW_COLUMN,
+  THROWER_THROW_LINE,
+  tallCommentThrowerSource,
+} from "../../internal/ttsx-source-map";
+
+/**
+ * Verifies stack frames map to the true source position even when the entry
+ * tsconfig emits no map (`sourceMap: false`), via the forced runtime map.
+ *
+ * A project that publishes without maps must still get correct ttsx stacks.
+ * ttsx forces a map on its private runtime emit and enables source maps in the
+ * child, so the frame maps regardless of the owning tsconfig — pinning the
+ * forced-map path together with the stack test that uses it.
+ *
+ * 1. Build an entry project with `sourceMap: false` whose `boom.ts` throws behind
+ *    a tall comment.
+ * 2. Run the entry through ttsx.
+ * 3. Assert a non-zero exit and a `boom (<real boom.ts>:12:9)` frame in stderr.
+ */
+export const test_ttsx_stack_trace_maps_to_the_true_source_position_when_the_entry_emits_no_map =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          sourceMap: false,
+          outDir: "lib",
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "src/boom.ts": tallCommentThrowerSource("boom", "no-map boom"),
+      "src/main.ts": ['import { boom } from "./boom";', "boom();", ""].join(
+        "\n",
+      ),
+    });
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.notEqual(result.status, 0, "the thrown error must fail the run");
+    const real = fs.realpathSync(path.join(root, "src", "boom.ts"));
+    assertMappedFrame(result.stderr, "boom", real);
+  };
+
+function assertMappedFrame(stderr: string, fn: string, file: string): void {
+  const frame = `${fn} (${file}:${THROWER_THROW_LINE}:${THROWER_THROW_COLUMN})`;
+  assert.ok(
+    fold(stderr).includes(fold(frame)),
+    `stderr must contain the mapped frame "${frame}"\n---\n${stderr}`,
+  );
+}
+
+function fold(value: string): string {
+  const slashed = value.replace(/\\/g, "/");
+  return process.platform === "win32" ? slashed.toLowerCase() : slashed;
+}

--- a/tests/test-ttsc/src/internal/ttsx-source-map.ts
+++ b/tests/test-ttsc/src/internal/ttsx-source-map.ts
@@ -1,0 +1,233 @@
+/**
+ * Shared helpers for the ttsx source-map regression tests (issue #353).
+ *
+ * Ttsx runs tsgo-built JavaScript under the original `.ts` source URL. These
+ * helpers drive a real ttsx run with Node's built-in V8 coverage recorder
+ * (`NODE_V8_COVERAGE`) and read back the coverage JSON, so a test can assert on
+ * the two authoritative inputs c8 consumes: the per-script `source-map-cache`
+ * entry (its `data` is `null` when the served map dangles) and V8's raw
+ * function execution counts. Asserting both decomposes the c8 result exactly —
+ * correct counts plus a resolvable map is precisely what turns a false 100%
+ * into a faithful per-line report — without depending on c8 itself.
+ */
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * A source module opened by a tall comment block, so emitted lines diverge
+ * visibly from source lines, then a called export (`used`) and a never-called
+ * export (`unused`). V8 records `unused` with count 0 and `used` with count >
+ * 0; with a resolvable map those counts attribute to the right source lines,
+ * and without one the run reports a false 100%.
+ */
+export function tallCommentLibrarySource(): string {
+  return [
+    "/**",
+    " * A tall comment block whose height shifts every statement's line.",
+    " *",
+    " * padding",
+    " * padding",
+    " * padding",
+    " * padding",
+    " * padding",
+    " * padding",
+    " */",
+    "export function used(): string {",
+    '  return "used ran";',
+    "}",
+    "",
+    "export function unused(): string {",
+    '  return "unused never runs";',
+    "}",
+    "",
+  ].join("\n");
+}
+
+/** 1-based source line of the `throw` in {@link tallCommentThrowerSource}. */
+export const THROWER_THROW_LINE = 12;
+/** 1-based source column of the `new Error(...)` a mapped frame must report. */
+export const THROWER_THROW_COLUMN = 9;
+
+/**
+ * A never-returning export that throws behind the same tall comment, so the
+ * emitted `throw` line differs from the source line. A correctly mapped stack
+ * frame reports `THROWER_THROW_LINE:THROWER_THROW_COLUMN` at the real source
+ * path.
+ */
+export function tallCommentThrowerSource(
+  functionName: string,
+  message: string,
+): string {
+  return [
+    "/**",
+    " * A tall comment block whose height shifts every statement's line.",
+    " *",
+    " * padding",
+    " * padding",
+    " * padding",
+    " * padding",
+    " * padding",
+    " * padding",
+    " */",
+    `export function ${functionName}(): never {`,
+    `  throw new Error(${JSON.stringify(message)});`,
+    "}",
+    "",
+  ].join("\n");
+}
+
+/** One executed script's coverage, joined from the V8 coverage JSON files. */
+export interface ScriptCoverage {
+  /** The `file://` URL V8 recorded the script under (the `.ts` source URL). */
+  url: string;
+  /** Whether a `source-map-cache` entry exists for this script at all. */
+  hasSourceMapCacheEntry: boolean;
+  /**
+   * The parsed source map V8 cached, or `null` when the served
+   * `sourceMappingURL` could not be resolved (the #353 failure).
+   */
+  sourceMap: { sources?: unknown; [key: string]: unknown } | null;
+  /** V8's per-function execution counts for this script. */
+  functions: readonly {
+    functionName: string;
+    ranges: readonly { count: number }[];
+  }[];
+}
+
+/** Result of a coverage-instrumented ttsx run. */
+export interface CoverageRun {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  /** Coverage for the first executed script whose URL ends with `basename`. */
+  scriptEndingWith(basename: string): ScriptCoverage | null;
+}
+
+/**
+ * Run `ttsx <entry>` under `NODE_V8_COVERAGE` and return the run result plus a
+ * reader over the coverage JSON. The coverage directory is a fresh tracked temp
+ * dir, so parallel cases never share one another's recordings.
+ */
+export function runTtsxWithCoverage(
+  root: string,
+  entry: string,
+  env: Record<string, string> = {},
+): CoverageRun {
+  const coverageDir = TestProject.tmpdir("ttsx-v8-coverage-");
+  const result = TestProject.spawn(
+    TestProject.TTSX_BIN,
+    ["--cwd", root, entry],
+    { cwd: root, env: { ...env, NODE_V8_COVERAGE: coverageDir } },
+  );
+  const scripts = readCoverageScripts(coverageDir);
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    scriptEndingWith(basename: string): ScriptCoverage | null {
+      const needle = `/${basename}`;
+      for (const script of scripts) {
+        if (normalizeUrl(script.url).endsWith(needle)) {
+          return script;
+        }
+      }
+      return null;
+    },
+  };
+}
+
+/** Highest execution count recorded for the function named `name`, or -1. */
+export function maxFunctionCount(script: ScriptCoverage, name: string): number {
+  let best = -1;
+  for (const fn of script.functions) {
+    if (fn.functionName !== name) {
+      continue;
+    }
+    for (const range of fn.ranges) {
+      if (range.count > best) {
+        best = range.count;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Resolve a source map `sources` entry (an absolute `file://` URL after the
+ * #353 fix) to a native filesystem path for comparison against the real
+ * source.
+ */
+export function sourceMapSourcePath(script: ScriptCoverage): string | null {
+  const sources = script.sourceMap?.sources;
+  if (!Array.isArray(sources) || typeof sources[0] !== "string") {
+    return null;
+  }
+  const first = sources[0];
+  return first.startsWith("file:")
+    ? path.normalize(fileURLToPath(first))
+    : first;
+}
+
+interface RawCoverageFile {
+  result: readonly {
+    url: string;
+    functions: readonly {
+      functionName: string;
+      ranges: readonly { count: number }[];
+    }[];
+  }[];
+  "source-map-cache"?: Record<
+    string,
+    { data: { sources?: unknown } | null } | undefined
+  >;
+}
+
+function readCoverageScripts(coverageDir: string): ScriptCoverage[] {
+  const byUrl = new Map<string, ScriptCoverage>();
+  for (const file of listJsonFiles(coverageDir)) {
+    let parsed: RawCoverageFile;
+    try {
+      parsed = JSON.parse(fs.readFileSync(file, "utf8")) as RawCoverageFile;
+    } catch {
+      continue;
+    }
+    const smc = parsed["source-map-cache"] ?? {};
+    for (const entry of parsed.result) {
+      if (!entry.url.startsWith("file:")) {
+        continue;
+      }
+      // Prefer a record that carries function counts; a later empty duplicate
+      // (e.g. the parent process's view) must not clobber the child's real one.
+      const existing = byUrl.get(entry.url);
+      if (existing !== undefined && existing.functions.length > 0) {
+        continue;
+      }
+      const cache = smc[entry.url];
+      byUrl.set(entry.url, {
+        url: entry.url,
+        hasSourceMapCacheEntry: cache !== undefined,
+        sourceMap: cache?.data ?? null,
+        functions: entry.functions,
+      });
+    }
+  }
+  return [...byUrl.values()];
+}
+
+function listJsonFiles(dir: string): string[] {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((name) => name.endsWith(".json"))
+    .map((name) => path.join(dir, name));
+}
+
+function normalizeUrl(url: string): string {
+  return url.replace(/\\/g, "/");
+}

--- a/website/src/content/docs/ttsc/execute.mdx
+++ b/website/src/content/docs/ttsc/execute.mdx
@@ -34,6 +34,10 @@ These hooks are runtime-only and never weaken the compile gate: the up-front tsg
 
 When an ESM entry imports named bindings from a CommonJS-classified source package, `ttsx` also exposes names re-exported through nested `export *` barrels. Node's CommonJS interop can miss those names because TypeScript-Go lowers them through dynamic helper calls, so the runtime hook makes the emitted CommonJS names visible without changing the package's CommonJS `require` path.
 
+## Source maps, stack traces, and coverage
+
+`ttsx` runs the tsgo-built JavaScript under your original `.ts` path, so it inlines a source map into every served file and enables Node's source-map support in the run. Error stack traces therefore report the true `.ts` line and column out of the box — no `--enable-source-maps` needed — and V8 coverage (`c8`, `NODE_V8_COVERAGE`) attributes executed lines to the real source, so a coverage gate over a `ttsx` run is trustworthy. This holds regardless of the project's own `sourceMap` setting (the map is forced onto the private runtime emit and never touches your published `outDir`) and for both entry-project files and raw-`.ts` dependencies.
+
 ## Pass arguments to the script
 
 Use `--` to separate `ttsx` flags from the script's own args:


### PR DESCRIPTION
## Intent

`ttsx` executes tsgo-built JavaScript under the original `.ts` source URL. When the owning tsconfig emits external maps (a library's default `sourceMap: true`), the served text ended with a relative `//# sourceMappingURL=<name>.js.map` that **nothing can resolve**: Node resolves it against the `.ts` script URL (no `.js.map` there), and the per-run emit dir is deleted at process exit anyway. The consequences (#353):

1. **V8/c8 coverage is garbage, including false 100%** — Node caches the script with `source-map-cache[url].data = null`, so c8 applies transformed-JS offsets to the original TS text; a never-called function reports covered.
2. **Stack frames point at wrong lines** — the `.ts` filename with emitted-JS line numbers.
3. **Mis-rooted map `sources`** — even when a map is consumed, mapped frames/IDE links print a nonexistent path.

## Mechanism of the fix

At the single serve choke point (`resolveServedSource`, which holds `emittedFile` + `sourceFile`), a shared helper rewrites the served text before it is returned from **both** `serveEntryEmit` (entry lane) and `serveBuiltDependency` (dependency lane — a separate code path):

- read the sibling `${emittedFile}.map`, rewrite its `sources` to absolute `file://` URLs of the true on-disk source (tsgo's per-file emit is 1:1, so the serve path's known `sourceFile` is the anchor), drop `sourceRoot`, re-serialize, and replace the trailing comment with `//# sourceMappingURL=data:application/json;base64,…`.

Because the map now travels **inside** the text V8 captures at compile time, it survives both the wrong resolution base and the post-exit cleanup. This one change fixes coverage (Node caches real `data`), stacks, and the mis-rooted `sources`. The rewrite is cached per emitted file and is idempotent (re-encoding already-absolutized text reproduces the same bytes), keeping the shared cross-process dependency cache deterministic. `pathToFileURL` builds the URLs (Windows-safe).

## No-map tsconfig handling (and justification)

Rather than branch on whether the consumer set `sourceMap`, both runtime builds **force an external map** (`--sourceMap true --inlineSourceMap false --inlineSources false`, appended after the user's forwarded flags so they win). The runtime emit always lands in a private, transient directory — the entry's PID-isolated dir or the shared dependency cache, **never** the consumer's `outDir` — so the override leaks into nobody's published `lib/`. Forcing an *external* map (over the alternative of forcing inline) gives the serve path one uniform shape to rewrite regardless of whether the consumer configured `sourceMap`, `inlineSourceMap`, or no map at all, and routes every case through the same `sources`-absolutizing pass. The entry build (`prepareExecution`) and the dependency build (`buildDependency`) are separate `runBuild` call sites, so each forces maps independently.

## Bootstrap

`installRuntimeHooks` calls `process.setSourceMapsEnabled(true)` so stacks map out of the box (no `--enable-source-maps`); user code that later toggles it still wins. The orphan type-strip path is line-preserving and untouched.

## Test plan

New ttsx e2e tests under `tests/test-ttsc/src/features/ttsx-runtime/`, driving a real run under `NODE_V8_COVERAGE` and reading Node's coverage JSON — no dependency on c8 (it is not in the repo). They assert the exact inputs c8 consumes, which decompose its result per the issue's mechanism:

- **Coverage**: `source-map-cache[lib].data` is non-null (was null) and its `sources[0]` is the real absolute source (defect 3); V8 records the never-called `unused` with count 0 and its called twin `used` with count ≥ 1.
- **Stacks**: a thrown frame reports the true `line:col` at the real absolute source path.
- Both across `sourceMap: true` **and** `sourceMap: false` owning tsconfigs, for the **entry project** and a **built dependency** (the two serve lanes).

Verified fail-before/pass-after against a scratch repro of the issue: coverage `data: null → present`, stack `boom.ts:16:11 → boom.ts:13:9` (true position, real path). Full `ttsx-runtime` suite green except two pre-existing Windows-local failures (file-symlink `EPERM`, a temp-`tsc.exe` spawn `UNKNOWN`) that fail identically on unmodified `master`.

Docs: `website/src/content/docs/ttsc/execute.mdx` gains a short "Source maps, stack traces, and coverage" section.

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB
