### PR TITLE
fix(ttsc): quote go.work paths so workspace spaces don't break source builds

### DIFF
--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -821,7 +821,7 @@ function writeGoWork(
       : useDirs;
   const useLines = ["\t."];
   for (const dir of effectiveUseDirs) {
-    useLines.push(`\t${dir.replace(/\\/g, "/")}`);
+    useLines.push(`\t${formatGoWorkPath(dir)}`);
   }
   const replaceLines = sourceBuildWorkspaceReplacements(
     effectiveUseDirs,
@@ -873,8 +873,134 @@ function sourceBuildWorkspaceReplacements(
     return [];
   }
   return [
-    `replace ${TTSC_GO_MODULE_PATH} v0.0.0 => ${ttscRoot.replace(/\\/g, "/")}`,
+    `replace ${TTSC_GO_MODULE_PATH} v0.0.0 => ${formatGoWorkPath(ttscRoot)}`,
   ];
+}
+
+/**
+ * Format an absolute filesystem path as a single `go.work`/`go.mod` token.
+ *
+ * The modfile grammar shared by `go.mod` and `go.work` (parsed by
+ * `golang.org/x/mod/modfile`) is whitespace-tokenized, so a `use`/`replace`
+ * path that contains a space — a home or project directory such as `/Users/John
+ * Smith/...` or `C:\Users\John Smith\...` — must be emitted as a quoted string
+ * or `go` cannot parse the generated `go.work`. Normalize Windows separators to
+ * `/` (the workspace convention) and then delegate to
+ * {@link autoQuoteGoModToken}, which mirrors `modfile.AutoQuote`.
+ *
+ * Exported for unit tests.
+ */
+export function formatGoWorkPath(p: string): string {
+  return autoQuoteGoModToken(p.replace(/\\/g, "/"));
+}
+
+/**
+ * Quote `token` for a `go.mod`/`go.work` line exactly as
+ * `golang.org/x/mod/modfile`'s `AutoQuote` does: return it unchanged when it is
+ * already a clean bare token, otherwise return its Go double-quoted form so the
+ * value round-trips through the modfile lexer. A space-free path is therefore
+ * emitted byte-for-byte as before; only tokens that would otherwise
+ * mis-tokenize are quoted.
+ *
+ * Exported for unit tests.
+ */
+export function autoQuoteGoModToken(token: string): string {
+  return mustQuoteGoModToken(token) ? goQuoteString(token) : token;
+}
+
+// Mirror `modfile.MustQuote`: report whether `s` must be quoted to appear as a
+// single token on a modfile line.
+function mustQuoteGoModToken(s: string): boolean {
+  for (const ch of s) {
+    if (ch === " " || ch === '"' || ch === "'" || ch === "`") {
+      return true;
+    }
+    if (
+      ch === "(" ||
+      ch === ")" ||
+      ch === "[" ||
+      ch === "]" ||
+      ch === "{" ||
+      ch === "}" ||
+      ch === ","
+    ) {
+      // Go tests `len(s) > 1` (byte length): a lone bracket/comma is a legal
+      // bare token, but one embedded in a longer token forces quoting.
+      if (Buffer.byteLength(s, "utf8") > 1) {
+        return true;
+      }
+      continue;
+    }
+    if (!isGoGraphic(ch)) {
+      return true;
+    }
+  }
+  return s === "" || s === "//" || s === "/*";
+}
+
+// Mirror `strconv.Quote`: wrap in double quotes, backslash-escape `"` and `\`,
+// emit Go-printable runes verbatim (including the ASCII space and printable
+// Unicode), and escape everything else with Go's `\a\b\f\n\r\t\v` / `\xNN` /
+// `\uNNNN` / `\UNNNNNNNN` forms so the token round-trips through
+// `strconv.Unquote` in the modfile lexer.
+function goQuoteString(s: string): string {
+  let out = '"';
+  for (const ch of s) {
+    if (ch === '"' || ch === "\\") {
+      out += `\\${ch}`;
+      continue;
+    }
+    if (isGoPrintable(ch)) {
+      out += ch;
+      continue;
+    }
+    out += escapeGoRune(ch);
+  }
+  return `${out}"`;
+}
+
+function escapeGoRune(ch: string): string {
+  switch (ch) {
+    case "\x07":
+      return "\\a";
+    case "\b":
+      return "\\b";
+    case "\f":
+      return "\\f";
+    case "\n":
+      return "\\n";
+    case "\r":
+      return "\\r";
+    case "\t":
+      return "\\t";
+    case "\v":
+      return "\\v";
+    default: {
+      const cp = ch.codePointAt(0) ?? 0;
+      if (cp < 0x20 || cp === 0x7f) {
+        return `\\x${cp.toString(16).padStart(2, "0")}`;
+      }
+      if (cp < 0x10000) {
+        return `\\u${cp.toString(16).padStart(4, "0")}`;
+      }
+      return `\\U${cp.toString(16).padStart(8, "0")}`;
+    }
+  }
+}
+
+// `unicode.IsGraphic`: categories L, M, N, P, S, Zs (all spacing).
+const GO_GRAPHIC_RE = /^[\p{L}\p{M}\p{N}\p{P}\p{S}\p{Zs}]$/u;
+
+function isGoGraphic(ch: string): boolean {
+  return GO_GRAPHIC_RE.test(ch);
+}
+
+// `strconv.IsPrint`: the graphic categories except that the ONLY spacing
+// character is the ASCII space (U+0020); other Unicode spaces are escaped.
+const GO_PRINTABLE_RE = /^[\p{L}\p{M}\p{N}\p{P}\p{S}]$/u;
+
+function isGoPrintable(ch: string): boolean {
+  return ch === " " || GO_PRINTABLE_RE.test(ch);
 }
 
 interface GoModReplacement {

--- a/tests/test-ttsc/src/internal/source-build.ts
+++ b/tests/test-ttsc/src/internal/source-build.ts
@@ -11,8 +11,10 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  autoQuoteGoModToken,
   buildSourcePlugin,
   computeCacheKey,
+  formatGoWorkPath,
   resolvePluginCacheRoot,
   resolveSourceBuildCachePaths,
 } from "../../../../packages/ttsc/lib/plugin/internal/buildSourcePlugin.js";
@@ -150,9 +152,11 @@ function shellQuote(value: string): string {
 
 export {
   assert,
+  autoQuoteGoModToken,
   buildSourcePlugin,
   computeCacheKey,
   createFakeGoBinary,
+  formatGoWorkPath,
   fs,
   os,
   path,

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_gomod_token_quoting_mirrors_go_autoquote.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_gomod_token_quoting_mirrors_go_autoquote.ts
@@ -1,0 +1,95 @@
+import {
+  assert,
+  autoQuoteGoModToken,
+  formatGoWorkPath,
+} from "../../internal/source-build";
+
+/**
+ * Verifies go.work/go.mod token quoting mirrors Go's modfile.AutoQuote.
+ *
+ * `writeGoWork` emits `use`/`replace` paths into a `go.work` whose grammar
+ * (`golang.org/x/mod/modfile`) is whitespace-tokenized, so a path containing a
+ * space — a home directory like `/Users/John Smith/...` — must be quoted or
+ * `go` cannot parse it (#394). `formatGoWorkPath`/`autoQuoteGoModToken`
+ * reproduce `modfile.AutoQuote` + `strconv.Quote`: a clean bare token
+ * round-trips unchanged, and only a token that would otherwise mis-tokenize is
+ * quoted with Go's exact escaping. This pins every branch of that logic.
+ *
+ * 1. Feed `autoQuoteGoModToken` a table spanning clean tokens, the space case,
+ *    every forced-quote trigger, and every escape form.
+ * 2. Feed `formatGoWorkPath` Windows/POSIX paths with and without spaces.
+ * 3. Assert each output equals the value Go would emit for the same token.
+ */
+export const test_gomod_token_quoting_mirrors_go_autoquote = () => {
+  const NBSP = " "; // U+00A0: a Zs (graphic) space that is not ASCII space.
+
+  // [input, expected] where expected is exactly what modfile.AutoQuote emits.
+  const autoQuoteCases: readonly [string, string][] = [
+    // Clean bare tokens: returned unchanged (space-free paths must not churn).
+    ["/home/user/plugin", "/home/user/plugin"],
+    [
+      "github.com/samchon/ttsc/packages/ttsc",
+      "github.com/samchon/ttsc/packages/ttsc",
+    ],
+    [".", "."],
+    ["café", "café"], // lone Unicode letter is graphic → not forced.
+    ["a😀b", "a😀b"], // lone astral symbol is graphic → not forced.
+    [`a${NBSP}b`, `a${NBSP}b`], // NBSP is Zs (graphic) → not forced.
+    ["(", "("], // a lone bracket/comma is a legal bare token.
+    [")", ")"],
+    [",", ","],
+
+    // MustQuote triggers.
+    ["/Users/John Smith/x", '"/Users/John Smith/x"'], // ASCII space.
+    ['a"b', '"a\\"b"'], // double quote.
+    ["a'b", '"a\'b"'], // apostrophe.
+    ["a`b", '"a`b"'], // backtick.
+    ["a(b", '"a(b"'], // bracket embedded in a longer token.
+    ["a,b", '"a,b"'], // comma embedded in a longer token.
+    ["", '""'], // empty string is not a valid bare token.
+    ["//", '"//"'], // a line comment opener must be quoted to be a token.
+    ["/*", '"/*"'], // a block comment opener too.
+
+    // strconv.Quote escape forms (control runes force quoting on their own).
+    ["a\tb", '"a\\tb"'], // \t
+    ["a\nb", '"a\\nb"'], // \n
+    ["a\rb", '"a\\rb"'], // \r
+    ["a\vb", '"a\\vb"'], // \v
+    ["a\fb", '"a\\fb"'], // \f
+    ["a\bb", '"a\\bb"'], // \b (backspace)
+    ["a\x07b", '"a\\ab"'], // \a (bell)
+    ["a\x01b", '"a\\x01b"'], // \xNN for other C0 controls
+    ["a\x7fb", '"a\\x7fb"'], // \x7f for DEL
+    [`a ${NBSP}`, '"a \\u00a0"'], // \uNNNN: NBSP is not printable inside a quote.
+    [String.fromCodePoint(0x10ffff), '"\\U0010ffff"'], // \UNNNNNNNN for astral non-printable.
+
+    // Verbatim emission inside a forced quote (printable runes are not escaped).
+    ["caf é", '"caf é"'], // Unicode letter kept literally.
+    ["a 😀", '"a 😀"'], // astral symbol kept literally.
+    ["a\\b c", '"a\\\\b c"'], // backslash escaped only when quoting is forced.
+  ];
+  for (const [input, expected] of autoQuoteCases) {
+    assert.equal(
+      autoQuoteGoModToken(input),
+      expected,
+      `autoQuoteGoModToken(${JSON.stringify(input)})`,
+    );
+  }
+
+  // formatGoWorkPath normalizes Windows separators before quoting, exactly as
+  // writeGoWork emits `use`/`replace` paths.
+  const formatCases: readonly [string, string][] = [
+    ["C:\\Users\\John Smith\\proj", '"C:/Users/John Smith/proj"'],
+    ["C:\\Users\\jsmith\\proj", "C:/Users/jsmith/proj"],
+    ["/Users/John Smith/x", '"/Users/John Smith/x"'],
+    ["/home/user/x", "/home/user/x"],
+    [".", "."],
+  ];
+  for (const [input, expected] of formatCases) {
+    assert.equal(
+      formatGoWorkPath(input),
+      expected,
+      `formatGoWorkPath(${JSON.stringify(input)})`,
+    );
+  }
+};

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_writegowork_quotes_workspace_paths_with_spaces.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_writegowork_quotes_workspace_paths_with_spaces.ts
@@ -1,0 +1,185 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  buildSourcePlugin,
+  fs,
+  path,
+  shellQuote,
+} from "../../internal/source-build";
+
+/**
+ * Verifies writeGoWork quotes go.work paths that contain spaces (#394).
+ *
+ * `writeGoWork` emitted `use`/`replace` paths unquoted, so an overlay resolved
+ * under a directory with a space — the common `C:\Users\John Smith\...` /
+ * `/Users/John Smith/...` case — produced a `go.work` the modfile lexer splits
+ * into extra tokens, and `go` failed to parse it. The emitter now quotes each
+ * path via `modfile.AutoQuote`. This drives the real build pipeline (fake `go`)
+ * and inspects the generated `go.work` to pin both directives, plus a
+ * space-free twin that must stay unquoted so the fix never over-quotes.
+ *
+ * 1. Build a plugin whose overlays are a ttsc-module dir under a `"space dir"`
+ *    path and a space-free shim dir.
+ * 2. Capture the `go.work` the builder hands to `go build`.
+ * 3. Assert the spaced path is quoted in both `use` and `replace`, and the
+ *    space-free path stays bare.
+ */
+export const test_writegowork_quotes_workspace_paths_with_spaces = () => {
+  const root = TestProject.tmpdir("ttsc-gowork-spaces-");
+  const source = path.join(root, "plugin");
+  const spacedOverlay = path.join(root, "space dir", "ttsc");
+  const bareOverlay = path.join(root, "nospace", "shim");
+
+  writeFile(
+    path.join(source, "go.mod"),
+    "module example.com/plugin\n\ngo 1.26\n",
+  );
+  writeFile(path.join(source, "main.go"), "package main\n\nfunc main() {}\n");
+
+  writeFile(
+    path.join(spacedOverlay, "go.mod"),
+    "module github.com/samchon/ttsc/packages/ttsc\n\ngo 1.26\n",
+  );
+  writeFile(path.join(spacedOverlay, "ttsc.go"), "package ttsc\n");
+  writeFile(
+    path.join(bareOverlay, "go.mod"),
+    "module github.com/microsoft/typescript-go/shim/foo\n\ngo 1.26\n",
+  );
+  writeFile(path.join(bareOverlay, "foo.go"), "package foo\n");
+
+  const capture = path.join(root, "captured-go.work");
+  const fakeGo = createGoWorkCapturingGoBinary(root);
+
+  const previousGo = process.env.TTSC_GO_BINARY;
+  const previousCapture = process.env.FAKE_GO_WORK_CAPTURE;
+  process.env.TTSC_GO_BINARY = fakeGo;
+  process.env.FAKE_GO_WORK_CAPTURE = capture;
+  try {
+    buildSourcePlugin({
+      baseDir: root,
+      overlayDirs: [spacedOverlay, bareOverlay],
+      pluginName: "gowork-spaces",
+      source,
+      quiet: true,
+      ttscVersion: "1.0.0",
+      tsgoVersion: "7.0.0-dev",
+    });
+  } finally {
+    restoreEnv("TTSC_GO_BINARY", previousGo);
+    restoreEnv("FAKE_GO_WORK_CAPTURE", previousCapture);
+  }
+
+  const goWork = fs.readFileSync(capture, "utf8");
+  const spaced = spacedOverlay.replace(/\\/g, "/");
+  const bare = bareOverlay.replace(/\\/g, "/");
+
+  // The spaced overlay must appear quoted in the `use` block and the `replace`
+  // directive, and must never appear as a bare (unquoted) token.
+  assert.ok(
+    goWork.includes(`\n\t"${spaced}"\n`),
+    `go.work should quote the spaced use path:\n${goWork}`,
+  );
+  assert.ok(
+    goWork.includes(
+      `replace github.com/samchon/ttsc/packages/ttsc v0.0.0 => "${spaced}"`,
+    ),
+    `go.work should quote the spaced replace path:\n${goWork}`,
+  );
+  assert.ok(
+    !goWork.includes(`\n\t${spaced}\n`),
+    `go.work must not emit the spaced path unquoted:\n${goWork}`,
+  );
+
+  // The space-free overlay is the negative twin: it must stay bare so the fix
+  // does not over-quote clean tokens.
+  assert.ok(
+    goWork.includes(`\n\t${bare}\n`),
+    `go.work should leave the space-free use path bare:\n${goWork}`,
+  );
+  assert.ok(
+    !goWork.includes(`"${bare}"`),
+    `go.work must not quote the space-free path:\n${goWork}`,
+  );
+};
+
+function writeFile(file: string, contents: string): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents, "utf8");
+}
+
+function restoreEnv(key: string, previous: string | undefined): void {
+  if (previous === undefined) delete process.env[key];
+  else process.env[key] = previous;
+}
+
+/**
+ * Writes a fake `go` that answers the metadata commands ttsc issues while
+ * composing a source build (`version`, `env -json`, `mod edit -json`) and, on
+ * `go build`, copies the workspace's `go.work` to `FAKE_GO_WORK_CAPTURE` before
+ * writing a stub binary — so the test can inspect the exact `go.work` ttsc
+ * generated without a real Go toolchain.
+ */
+function createGoWorkCapturingGoBinary(root: string): string {
+  const script = path.join(root, "fake-go.cjs");
+  fs.writeFileSync(
+    script,
+    [
+      'const fs = require("node:fs");',
+      'const path = require("node:path");',
+      "const args = process.argv.slice(2);",
+      'if (args[0] === "version") {',
+      '  console.log("go version fake");',
+      "  process.exit(0);",
+      "}",
+      'if (args[0] === "env" && args[1] === "-json") {',
+      '  console.log("{}");',
+      "  process.exit(0);",
+      "}",
+      'if (args[0] === "mod" && args[1] === "edit" && args[2] === "-json") {',
+      '  const text = fs.readFileSync(path.join(process.cwd(), "go.mod"), "utf8");',
+      "  const m = text.match(/^\\s*module\\s+(\\S+)/m);",
+      "  console.log(JSON.stringify(m ? { Module: { Path: m[1] } } : {}));",
+      "  process.exit(0);",
+      "}",
+      'if (args[0] === "build") {',
+      "  const capture = process.env.FAKE_GO_WORK_CAPTURE;",
+      "  if (capture) {",
+      '    fs.writeFileSync(capture, fs.readFileSync(path.join(process.cwd(), "go.work"), "utf8"), "utf8");',
+      "  }",
+      '  const outIndex = args.indexOf("-o");',
+      "  const out = outIndex >= 0 ? args[outIndex + 1] : null;",
+      "  if (!out) {",
+      '    console.error("missing -o output path");',
+      "    process.exit(1);",
+      "  }",
+      "  fs.mkdirSync(path.dirname(path.resolve(out)), { recursive: true });",
+      '  fs.writeFileSync(out, "fake plugin binary\\n", "utf8");',
+      "  process.exit(0);",
+      "}",
+      'console.error(`unexpected go command: ${args.join(" ")}`);',
+      "process.exit(1);",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  if (process.platform === "win32") {
+    const command = path.join(root, "fake-go.cmd");
+    fs.writeFileSync(
+      command,
+      `@echo off\r\n"${process.execPath}" "%~dp0fake-go.cjs" %*\r\n`,
+      "utf8",
+    );
+    return command;
+  }
+
+  const command = path.join(root, "fake-go");
+  fs.writeFileSync(
+    command,
+    `#!/bin/sh\nexec ${shellQuote(process.execPath)} ${shellQuote(script)} "$@"\n`,
+    "utf8",
+  );
+  fs.chmodSync(command, 0o755);
+  return command;
+}


### PR DESCRIPTION
Fixes #394.

## Root cause

`writeGoWork` in `packages/ttsc/src/plugin/internal/buildSourcePlugin.ts` builds the entire `go.work` as a string and emitted the `use` and `replace` paths **unquoted** (`\t${dir.replace(/\/g,"/")}` and `... => ${ttscRoot...}`). The `go.mod`/`go.work` modfile grammar (parsed by `golang.org/x/mod/modfile`, which `go`'s workspace loader uses) is **whitespace-tokenized**: a `use` line must be a single token and a `replace` target is a single token. When any workspace directory contains a space, the path splits into multiple tokens and `go` fails to parse the generated `go.work`.

This is not hypothetical: `findTtscOverlayDirs` resolves the overlay directories from the installed package location (`…/node_modules/@ttsc/…`), so a project living under `C:\Users\John Smith\…` or `/Users/John Smith/…` (common on Windows/macOS) makes every overlay path contain a space, and the same path also feeds the `replace` directive. The result is a silent, total break of source-plugin builds for those users.

## The fix (universal, mirrors Go)

Emit every path through a faithful mirror of `modfile.AutoQuote`:

- `mustQuoteGoModToken` reproduces `modfile.MustQuote` (space / `"` / `'` / backtick, embedded brackets & comma, non-graphic runes, and the empty / `//` / `/*` tokens).
- `goQuoteString` reproduces `strconv.Quote` (backslash-escape `"` and `\`, emit Go-printable runes verbatim including the ASCII space, and escape everything else with `\a\b\f\n\r\t\v` / `\xNN` / `\uNNNN` / `\UNNNNNNNN`).
- `formatGoWorkPath` normalizes Windows separators to `/` (the existing convention) and then auto-quotes.

A token is quoted **only when it is not already a clean bare token**, so space-free paths are emitted **byte-for-byte as before** (no churn, no behavior change for the common case), while any special character round-trips through the modfile lexer on any OS. No hardcoded usernames or paths.

## Tests

- `test_gomod_token_quoting_mirrors_go_autoquote` — exhaustive unit table over `autoQuoteGoModToken`/`formatGoWorkPath` covering every `MustQuote` trigger and every `strconv.Quote` escape form, with negative twins proving clean tokens (space-free POSIX/Windows paths, `.`, bare brackets, Unicode letters/emoji, NBSP) stay unquoted.
- `test_writegowork_quotes_workspace_paths_with_spaces` — drives the real build pipeline with a fake `go` that captures the generated `go.work`, asserting a ttsc-module overlay under a `space dir` path is quoted in **both** `use` and `replace`, while a space-free shim overlay stays bare (negative twin against over-quoting).

Both new tests sit alongside the existing `source-plugin` suite and reuse its `internal/source-build` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXWHm6DJ71X8xFjxVYzoEB