### PR TITLE
bench(graph): sharpen the MCP's own pitch and nudge every tool arm alike

### DIFF
--- a/experimental/benchmark/graph/agent-ab-codex.mjs
+++ b/experimental/benchmark/graph/agent-ab-codex.mjs
@@ -38,7 +38,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { GROUNDING } from "./prompt.mjs";
+import { GROUNDING, TOOL_NUDGE } from "./prompt.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..", "..", "..");
@@ -561,11 +561,19 @@ function promptForArm(baseQuestion, armName) {
   // is not a baseline (see GROUNDING). An arm whose facts come from this
   // checkout's compiler needs no such warning.
   if (armName === "baseline") return `${baseQuestion}\n\n${GROUNDING}`;
-  // The tool arm gets a neutral reminder that MCP tools exist, because
-  // tool-search models (e.g. gpt-5.6) do not surface MCP server tools from the
-  // server `instructions` alone. It names no tool and forces nothing; it only
-  // nudges appropriate use when a tool fits.
-  return `${baseQuestion}\n\nThis repository has a graph MCP tool available; make appropriate use of it when it fits the question.`;
+  // Every tool arm — this one's graph, codegraph, serena, codebase-memory — gets
+  // the same line, and the baseline gets none, because it has no tools to be told
+  // about.
+  //
+  // A model that never opens the tool list cannot be judged on its tools. Asked
+  // to tour NestJS with no line, gpt-5.6 spent eleven shell commands and 502k
+  // tokens and never mentioned the MCP; with the line it called the graph twice
+  // and spent 75k. The tools were mounted and visible in both runs — it simply
+  // never went looking, and a benchmark that says nothing measures that instead
+  // of the tool.
+  //
+  // It names no tool and forces nothing.
+  return `${baseQuestion}\n\n${TOOL_NUDGE}`;
 }
 
 function ensureInstalled(targetRepoDir) {

--- a/experimental/benchmark/graph/agent-ab.mjs
+++ b/experimental/benchmark/graph/agent-ab.mjs
@@ -34,7 +34,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { GROUNDING } from "./prompt.mjs";
+import { GROUNDING, TOOL_NUDGE } from "./prompt.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..", "..", "..");
@@ -576,14 +576,11 @@ function promptForArm(baseQuestion, armName) {
   // facts from this checkout's compiler needs no such warning, and giving it one
   // is an order to go verify what the compiler already resolved.
   if (armName === "baseline") return `${baseQuestion}\n\n${GROUNDING}`;
-  // The tool arm gets a neutral reminder that an MCP tool exists, the same one
-  // the codex harness sends. Claude Code defers MCP tool schemas behind
-  // ToolSearch, so the model shell-explores the repo first and only then
-  // discovers the server: every graph cell but one opened with two Bash calls
-  // before its first graph call. The sentence names no tool and forces nothing;
-  // it only tells the model a tool is there, which an operator who installed the
-  // server already knows.
-  return `${baseQuestion}\n\nThis repository has a graph MCP tool available; make appropriate use of it when it fits the question.`;
+  // Every tool arm carries the same line, and the baseline none: see TOOL_NUDGE.
+  // Claude Code defers MCP tool schemas behind ToolSearch, so a model told nothing
+  // shell-explores the repo before it discovers the server at all — every graph
+  // cell but one opened with two Bash calls before its first graph call.
+  return `${baseQuestion}\n\n${TOOL_NUDGE}`;
 }
 
 // spawnAsync runs a child to completion and resolves its captured stdout/stderr,

--- a/experimental/benchmark/graph/prompt.mjs
+++ b/experimental/benchmark/graph/prompt.mjs
@@ -22,3 +22,18 @@ export const GROUNDING =
   "Answer from this checkout's own code, not from what you may already know " +
   "about this project: every claim must trace to a symbol that exists here, " +
   "and cite the files and symbols it rests on.";
+
+// The line every tool arm carries, and the baseline does not — it has no tools to
+// be told about.
+//
+// A model that never opens the tool list cannot be judged on its tools. Asked to
+// tour NestJS with no line at all, gpt-5.6 ran eleven shell commands, spent 502k
+// tokens, and never mentioned the MCP; with this line it called the graph twice
+// and spent 75k. The tools were mounted and visible in both runs. It simply never
+// went looking, and a benchmark that says nothing measures that rather than the
+// tool.
+//
+// The same line goes to every tool arm — ttsc-graph, codegraph, serena,
+// codebase-memory — so no arm is pointed at more precisely than another. It names
+// nothing and asks for nothing.
+export const TOOL_NUDGE = "> code graph tools are provided";

--- a/packages/graph/src/structures/ITtscGraphApplication.ts
+++ b/packages/graph/src/structures/ITtscGraphApplication.ts
@@ -8,7 +8,7 @@ import { ITtscGraphTour } from "./ITtscGraphTour";
 import { ITtscGraphTrace } from "./ITtscGraphTrace";
 
 /**
- * ## What This MCP Is
+ * ## Code Graph MCP
  *
  * `inspect_typescript_graph` returns a compiler-built TypeScript graph contract
  * for the current on-disk source snapshot.
@@ -74,11 +74,25 @@ import { ITtscGraphTrace } from "./ITtscGraphTrace";
  */
 export interface ITtscGraphApplication {
   /**
-   * Inspect the TypeScript compiler graph before searching the repo, for any
-   * answer about symbols, calls, types, references, or flow.
+   * Answer a TypeScript question from the compiler's own index of this
+   * repository.
    *
-   * Use `tour` for architecture and broad flow: one call carries the whole
-   * orientation answer.
+   * The graph holds every symbol, call, type, decorator and test, each with its
+   * file and line, resolved from the source on disk now. Submit exactly one
+   * request:
+   *
+   * - `tour`: architecture, the runtime flow from the public API to the code that
+   *   does the work, nearby paths, and the tests to read — a whole orientation in
+   *   one call
+   * - `trace`: what a symbol calls, what calls it, or the path from A to B
+   * - `details`: signatures, members, and what implements an interface
+   * - `lookup`: where a named symbol is declared
+   * - `entrypoints`: where execution starts, when the entry is unknown
+   * - `overview`: the project's layers and folder structure
+   *
+   * Every result is the checker's own resolution, audited before it is returned,
+   * so nothing in it needs verifying. Read a file for what the graph does not
+   * carry: a function's body, the text inside a span.
    *
    * @param props Reasoning plus one graph request
    * @returns Matching `result` union member


### PR DESCRIPTION
## Intent

gpt-5.6 never opens the tool list unless the prompt mentions a tool. Asked for a NestJS tour with the graph MCP mounted and unmentioned, it ran eleven shell commands, spent 502k tokens, and never touched the server; told in one line that code graph tools exist, it called the graph twice and spent 75k. Both runs had the same tools exposed and visible. A benchmark that says nothing is therefore measuring the model's tool-discovery habit, not the tool.

So the benchmark now says the same thing to every tool arm, and the server's own texts carry the rest of the argument — which is where a model actually decides whether an MCP is worth calling.

## Scope

- **`TOOL_NUDGE`** (`experimental/benchmark/graph/prompt.mjs`): the line `> code graph tools are provided`, appended to every tool arm — ttsc-graph, codegraph, serena, codebase-memory — and to none of the baseline (which keeps `GROUNDING`, having no tools to be told about). It names no tool and asks for nothing, so no arm is pointed at more precisely than another. Both harnesses (`agent-ab.mjs`, `agent-ab-codex.mjs`) import it; the Claude harness previously sent a longer, graph-specific sentence to comparator arms too, which was a mislabel.
- **Server instructions** (`ITtscGraphApplication.ts`): the first section — the 512 characters Codex weighs when it decides how to use a server — now states what the tool is and what it answers, before the contract language.
- **Tool description**: carries the request menu (`tour`, `trace`, `details`, `lookup`, `entrypoints`, `overview`), so the choice is legible before the call rather than after it. Neither text demonizes grep or file reads: those are how you get a function's body, and the description says so.

## Measured (N=1 per cell, all 32 cells valid)

| model | family | baseline | ttsc-graph | saved |
|---|---|---|---|---|
| gpt-5.6-terra | common | 5,416,733 | 630,857 | **88%** |
| gpt-5.6-terra | dedicated | 4,627,850 | 545,528 | **88%** |
| gpt-5.6-sol | common | 15,551,143 | 667,381 | **96%** |
| gpt-5.6-sol | dedicated | 8,431,095 | 689,838 | **92%** |

Every graph cell answered from the graph: no cell answered without calling the MCP, and the arm read source in exactly one cell (typeorm dedicated, one `rg`). The 409 file:line anchors across the 32 answers all resolve to a real file and an in-range line. The baseline arm spent 9–67 shell calls per cell touching actual source, so it is a working developer, not a recital from memory.

## Deferred

No benchmark data is published here. The website deploys on every master push, and terra/sol tabs would render with their comparator arms missing. The follow-up PR re-measures every non-baseline arm under this nudge policy — terra/sol against codegraph/serena/codebase-memory, and Sonnet/Opus re-run — then publishes and drops the gpt-5.4-mini and gpt-5.5 axes.

## Test plan

- `packages/graph` builds; typia accepts the tool description (912 chars, under its 1,024 limit).
- 32 benchmark cells across two models and two prompt families ran green with the new texts, summarized above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YXiVdMRPRCTse2qyx9VQH