### PR TITLE
fix(lint): align no-duplicate-imports with ESLint mergeability and options

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -239,7 +239,7 @@ Source: [ESLint core rules](https://eslint.org/docs/latest/rules/).
 - [`no-dupe-else-if`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-dupe-else-if.ts): rejects repeated `else if` conditions.
 - [`no-dupe-keys`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-dupe-keys.ts): rejects duplicate object keys.
 - [`no-duplicate-case`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-duplicate-case.ts): rejects duplicate `switch` case labels.
-- [`no-duplicate-imports`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-duplicate-imports.ts): reject two import declarations that resolve to the same module specifier.
+- [`no-duplicate-imports`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-duplicate-imports.ts): reject a repeated module specifier when the import declarations could be merged into one; `allowSeparateTypeImports` and `includeExports` match the ESLint options.
 - [`no-else-return`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-else-return.ts): reject an `else` block whose preceding `if` branch already terminates with `return`, `throw`, `break`, or `continue`.
 - [`no-empty`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty.ts): rejects empty blocks.
 - [`no-empty-character-class`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty-character-class.ts): rejects empty regex character classes.

--- a/packages/lint/linthost/rules_core_extra.go
+++ b/packages/lint/linthost/rules_core_extra.go
@@ -377,45 +377,6 @@ func objectLiteralIsEmpty(node *shimast.Node) bool {
   return len(lit.Properties.Nodes) == 0
 }
 
-// noDuplicateImports reports two import declarations that resolve to
-// the same module specifier. Consolidating them into one import keeps
-// the dependency graph at the head of the file readable and avoids
-// surprising load-order interactions when the import has side effects.
-// https://eslint.org/docs/latest/rules/no-duplicate-imports
-//
-// The check is textual on the module specifier string — two imports
-// with the same exact string literal collide. `import type { … } from`
-// is folded together with value imports because the runtime sees only
-// one module load.
-type noDuplicateImports struct{}
-
-func (noDuplicateImports) Name() string { return "no-duplicate-imports" }
-func (noDuplicateImports) Visits() []shimast.Kind {
-  return []shimast.Kind{shimast.KindSourceFile}
-}
-func (noDuplicateImports) Check(ctx *Context, node *shimast.Node) {
-  seen := map[string]bool{}
-  node.ForEachChild(func(child *shimast.Node) bool {
-    if child == nil || child.Kind != shimast.KindImportDeclaration {
-      return false
-    }
-    decl := child.AsImportDeclaration()
-    if decl == nil || decl.ModuleSpecifier == nil {
-      return false
-    }
-    spec := stringLiteralText(decl.ModuleSpecifier)
-    if spec == "" {
-      return false
-    }
-    if seen[spec] {
-      ctx.Report(child, "Module `"+spec+"` is already imported above; consolidate the imports.")
-      return false
-    }
-    seen[spec] = true
-    return false
-  })
-}
-
 // getterReturn reports a `get` accessor whose body completes without
 // returning a value. The runtime returns `undefined` from such a
 // getter; in practice that is always a bug — the caller expects the
@@ -728,7 +689,6 @@ func init() {
   Register(noAwaitInLoop{})
   Register(noConstructorReturn{})
   Register(noDupeClassMembers{})
-  Register(noDuplicateImports{})
   Register(noImplicitCoercion{})
   Register(noNewSymbol{})
   Register(noThisBeforeSuper{})

--- a/packages/lint/linthost/rules_no_duplicate_imports.go
+++ b/packages/lint/linthost/rules_no_duplicate_imports.go
@@ -1,0 +1,266 @@
+// noDuplicateImports reports an import (and, with `includeExports`, a
+// re-export) declaration whose module specifier already appeared above,
+// but only when the two declarations could be consolidated into one
+// legal declaration. Same-module declarations TypeScript cannot merge —
+// named next to namespace bindings, or (since ESLint 9.30.1) a
+// type-only default next to type-only named bindings — are not
+// duplicates, and `allowSeparateTypeImports` additionally keeps one
+// clause-level `import type` declaration apart from value-bearing
+// declarations.
+// https://eslint.org/docs/latest/rules/no-duplicate-imports
+package linthost
+
+import (
+  "strings"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// noDuplicateImportsOptions mirrors the official rule's options object.
+// Both keys default to false, matching ESLint's `defaultOptions`.
+type noDuplicateImportsOptions struct {
+  // AllowSeparateTypeImports keeps clause-level `import type` / `export
+  // type` declarations out of the duplicate comparison with
+  // value-bearing declarations of the same module. Inline type
+  // specifiers (`import { type Foo }`) stay on the value side because
+  // their import clause is not type-only.
+  AllowSeparateTypeImports bool `json:"allowSeparateTypeImports"`
+
+  // IncludeExports folds `export … from` declarations into the same
+  // duplicate/mergeability analysis, adding the official
+  // duplicated-as-export / duplicated-as-import pairings.
+  IncludeExports bool `json:"includeExports"`
+}
+
+// importExportCategory mirrors the specifier categories the official
+// implementation derives from ESTree specifier types
+// (`getImportExportType`).
+type importExportCategory int
+
+const (
+  // `import def from "m"` — ImportDefaultSpecifier.
+  importExportDefault importExportCategory = iota
+  // `import { a } from "m"` / `export { a } from "m"` —
+  // ImportSpecifier / ExportSpecifier.
+  importExportNamed
+  // `import * as ns from "m"` / `export * as ns from "m"` —
+  // ImportNamespaceSpecifier / ExportNamespaceSpecifier.
+  importExportNamespace
+  // `export * from "m"` — ExportAllDeclaration without an alias.
+  importExportAll
+  // `import "m"` and specifier-less clauses such as `import {} from
+  // "m"` / `export {} from "m"` — SideEffectImport.
+  importExportSideEffect
+)
+
+// importExportEntry retains the shape of one earlier import/re-export
+// declaration so later declarations of the same module can answer the
+// mergeability question against it.
+type importExportEntry struct {
+  node     *shimast.Node
+  category importExportCategory
+  typeOnly bool
+  isExport bool
+}
+
+type noDuplicateImports struct{}
+
+func (noDuplicateImports) Name() string { return "no-duplicate-imports" }
+func (noDuplicateImports) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindSourceFile}
+}
+func (noDuplicateImports) Check(ctx *Context, node *shimast.Node) {
+  var opts noDuplicateImportsOptions
+  _ = ctx.DecodeOptions(&opts)
+  modules := map[string][]importExportEntry{}
+  node.ForEachChild(func(child *shimast.Node) bool {
+    if child == nil {
+      return false
+    }
+    switch child.Kind {
+    case shimast.KindImportDeclaration:
+      decl := child.AsImportDeclaration()
+      if decl == nil {
+        return false
+      }
+      module := duplicateImportsModule(decl.ModuleSpecifier)
+      if module == "" {
+        return false
+      }
+      entry := duplicateImportsImportEntry(child, decl)
+      reportDuplicateImports(ctx, opts, modules[module], entry, module)
+      modules[module] = append(modules[module], entry)
+    case shimast.KindExportDeclaration:
+      // Without `includeExports` the official rule does not even
+      // record re-exports, so they can neither be reported nor make
+      // a later import count as duplicated-as-export.
+      if !opts.IncludeExports {
+        return false
+      }
+      decl := child.AsExportDeclaration()
+      if decl == nil {
+        return false
+      }
+      module := duplicateImportsModule(decl.ModuleSpecifier)
+      if module == "" {
+        return false
+      }
+      entry := duplicateImportsExportEntry(child, decl)
+      reportDuplicateImports(ctx, opts, modules[module], entry, module)
+      modules[module] = append(modules[module], entry)
+    }
+    return false
+  })
+}
+
+// duplicateImportsModule returns the trimmed module specifier text, or
+// "" when the declaration has no usable string specifier (`export { x
+// }` without `from`, an empty string module). Trimming mirrors the
+// official implementation, which compares `source.value.trim()`.
+func duplicateImportsModule(spec *shimast.Node) string {
+  return strings.TrimSpace(stringLiteralText(spec))
+}
+
+// duplicateImportsImportEntry categorizes one `import` declaration the
+// way the official rule reads ESTree specifiers: the first named or
+// namespace specifier decides the category, a lone default binding is
+// the default category, and a clause-less or specifier-less import is a
+// side-effect import.
+func duplicateImportsImportEntry(node *shimast.Node, decl *shimast.ImportDeclaration) importExportEntry {
+  entry := importExportEntry{node: node, category: importExportSideEffect}
+  clause := decl.ImportClause
+  if clause == nil {
+    return entry
+  }
+  entry.typeOnly = clause.IsTypeOnly()
+  clauseData := clause.AsImportClause()
+  if clauseData == nil {
+    return entry
+  }
+  if bindings := clauseData.NamedBindings; bindings != nil {
+    switch bindings.Kind {
+    case shimast.KindNamespaceImport:
+      entry.category = importExportNamespace
+      return entry
+    case shimast.KindNamedImports:
+      // `import def, {} from "m"` has no named specifier in ESTree;
+      // the empty block falls through to the default binding below.
+      if named := bindings.AsNamedImports(); named != nil && named.Elements != nil && len(named.Elements.Nodes) > 0 {
+        entry.category = importExportNamed
+        return entry
+      }
+    }
+  }
+  if clauseData.Name() != nil {
+    entry.category = importExportDefault
+  }
+  return entry
+}
+
+// duplicateImportsExportEntry categorizes one `export … from`
+// declaration. `export * from` is the export-all category, `export * as
+// ns from` is a namespace specifier, non-empty `export { … } from` is
+// named, and the degenerate `export {} from "m"` matches the official
+// specifier-less SideEffectImport category.
+func duplicateImportsExportEntry(node *shimast.Node, decl *shimast.ExportDeclaration) importExportEntry {
+  entry := importExportEntry{
+    node:     node,
+    category: importExportSideEffect,
+    typeOnly: decl.IsTypeOnly,
+    isExport: true,
+  }
+  clause := decl.ExportClause
+  if clause == nil {
+    entry.category = importExportAll
+    return entry
+  }
+  switch clause.Kind {
+  case shimast.KindNamespaceExport:
+    entry.category = importExportNamespace
+  case shimast.KindNamedExports:
+    if named := clause.AsNamedExports(); named != nil && named.Elements != nil && len(named.Elements.Nodes) > 0 {
+      entry.category = importExportNamed
+    }
+  }
+  return entry
+}
+
+// reportDuplicateImports mirrors the official checkAndReport: an import
+// is reported once against earlier imports and once more against
+// earlier re-exports, a re-export against earlier re-exports and
+// earlier imports, each pairing with its own message. Earlier
+// re-exports only exist when `includeExports` recorded them.
+func reportDuplicateImports(ctx *Context, opts noDuplicateImportsOptions, previous []importExportEntry, entry importExportEntry, module string) {
+  if len(previous) == 0 {
+    return
+  }
+  if entry.isExport {
+    if duplicateImportsShouldReport(entry, previous, true, opts.AllowSeparateTypeImports) {
+      ctx.Report(entry.node, "`"+module+"` export is duplicated.")
+    }
+    if duplicateImportsShouldReport(entry, previous, false, opts.AllowSeparateTypeImports) {
+      ctx.Report(entry.node, "`"+module+"` export is duplicated as import.")
+    }
+    return
+  }
+  if duplicateImportsShouldReport(entry, previous, false, opts.AllowSeparateTypeImports) {
+    ctx.Report(entry.node, "`"+module+"` import is duplicated.")
+  }
+  if duplicateImportsShouldReport(entry, previous, true, opts.AllowSeparateTypeImports) {
+    ctx.Report(entry.node, "`"+module+"` import is duplicated as export.")
+  }
+}
+
+// duplicateImportsShouldReport mirrors the official
+// shouldReportImportExport: the new declaration is a duplicate when at
+// least one earlier declaration of the requested kind could legally
+// absorb it. With `allowSeparateTypeImports`, earlier declarations
+// whose clause-level type-ness differs from the new declaration's are
+// exempt from the comparison.
+func duplicateImportsShouldReport(entry importExportEntry, previous []importExportEntry, wantExport bool, allowSeparateTypeImports bool) bool {
+  for _, prev := range previous {
+    if prev.isExport != wantExport {
+      continue
+    }
+    if allowSeparateTypeImports && entry.typeOnly != prev.typeOnly {
+      continue
+    }
+    if duplicateImportsCanMerge(entry, prev) {
+      return true
+    }
+  }
+  return false
+}
+
+// duplicateImportsCanMerge mirrors the official
+// isImportExportCanBeMerged: two same-module declarations are duplicates
+// only when one legal declaration could carry both clauses.
+func duplicateImportsCanMerge(a, b importExportEntry) bool {
+  // ESLint 9.30.1 correction: a type-only default and type-only named
+  // bindings cannot be merged, because `import type Def, { Named }` is
+  // not legal TypeScript.
+  if a.typeOnly && b.typeOnly {
+    if (a.category == importExportDefault && b.category == importExportNamed) ||
+      (b.category == importExportDefault && a.category == importExportNamed) {
+      return false
+    }
+  }
+  // `export * from` merges only with another export-all or with a bare
+  // side-effect import; default, named, and namespace forms all need a
+  // different declaration shape.
+  if (a.category == importExportAll && b.category != importExportAll && b.category != importExportSideEffect) ||
+    (b.category == importExportAll && a.category != importExportAll && a.category != importExportSideEffect) {
+    return false
+  }
+  // A namespace binding and named bindings cannot share one
+  // declaration.
+  if (a.category == importExportNamespace && b.category == importExportNamed) ||
+    (b.category == importExportNamespace && a.category == importExportNamed) {
+    return false
+  }
+  return true
+}
+
+func init() {
+  Register(noDuplicateImports{})
+}

--- a/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
@@ -1,0 +1,29 @@
+/**
+ * Options shapes for the configurable rules in {@link ITtscLintCoreRules}.
+ *
+ * Currently only `no-duplicate-imports` accepts options.
+ *
+ * @reference https://eslint.org/docs/latest/rules/
+ */
+
+/** `no-duplicate-imports` rule options. */
+export interface ITtscLintCoreNoDuplicateImportsRuleOptions {
+  /**
+   * Keep clause-level `import type` declarations out of the duplicate
+   * comparison with value-bearing declarations of the same module, so one
+   * runtime import plus one type-only import may coexist. Inline type
+   * specifiers such as `import { type Foo }` stay on the value side because the
+   * whole import clause is not type-only.
+   *
+   * @default false
+   */
+  allowSeparateTypeImports?: boolean;
+
+  /**
+   * Also treat `export … from` declarations of an already imported (or
+   * re-exported) module as duplicates when the declarations could be merged.
+   *
+   * @default false
+   */
+  includeExports?: boolean;
+}

--- a/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
@@ -1,4 +1,8 @@
-import type { TtscLintRuleSetting } from "../TtscLintRuleSetting";
+import type {
+  TtscLintRuleOptionsSetting,
+  TtscLintRuleSetting,
+} from "../TtscLintRuleSetting";
+import type { ITtscLintCoreNoDuplicateImportsRuleOptions } from "./ITtscLintCoreRuleOptions";
 
 /**
  * Generic ESLint-compatible rules that apply to both JavaScript and TypeScript
@@ -446,13 +450,17 @@ export interface ITtscLintCoreRules {
   "no-duplicate-case"?: TtscLintRuleSetting;
 
   /**
-   * Reject two import declarations that resolve to the same module specifier.
-   * The runtime sees one module load either way; the duplicated declaration is
-   * purely noise at the head of the file and obscures the dependency graph.
+   * Reject an import declaration whose module specifier already appeared above
+   * when the two declarations could be merged into one legal declaration.
+   * Same-module pairs TypeScript cannot consolidate — named next to namespace
+   * bindings, or a type-only default next to type-only named bindings — are not
+   * duplicates. `allowSeparateTypeImports` additionally keeps clause-level
+   * `import type` declarations apart from value imports, and `includeExports`
+   * folds `export … from` declarations into the same analysis.
    *
    * @reference https://eslint.org/docs/latest/rules/no-duplicate-imports
    */
-  "no-duplicate-imports"?: TtscLintRuleSetting;
+  "no-duplicate-imports"?: TtscLintRuleOptionsSetting<ITtscLintCoreNoDuplicateImportsRuleOptions>;
 
   /**
    * Reject an `else` block whose preceding `if` branch already terminates

--- a/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
+++ b/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
@@ -6,6 +6,7 @@ import type {
   ITtscLintBoundariesNoPrivateRuleOptions,
   ITtscLintBoundariesNoUnknownRuleOptions,
 } from "./ITtscLintBoundariesRuleOptions";
+import type { ITtscLintCoreNoDuplicateImportsRuleOptions } from "./ITtscLintCoreRuleOptions";
 import type { ITtscLintCypressUnsafeToChainCommandRuleOptions } from "./ITtscLintCypressRuleOptions";
 import type {
   ITtscLintFunctionalEmptyRuleOptions,
@@ -51,6 +52,7 @@ import type { ITtscLintTestingLibraryConsistentDataTestIdRuleOptions } from "./I
  * surface.
  */
 export interface ITtscLintRuleOptionsMap {
+  "no-duplicate-imports": ITtscLintCoreNoDuplicateImportsRuleOptions;
   "testing-library/consistent-data-testid": ITtscLintTestingLibraryConsistentDataTestIdRuleOptions;
   "functional/functional-parameters": ITtscLintFunctionalParametersRuleOptions;
   "functional/immutable-data": ITtscLintFunctionalImmutableDataRuleOptions;

--- a/packages/lint/src/structures/rules/index.ts
+++ b/packages/lint/src/structures/rules/index.ts
@@ -1,6 +1,7 @@
 export * from "./ITtscLintBoundariesRuleOptions";
 export * from "./ITtscLintBoundariesRules";
 export * from "./ITtscLintContributorRules";
+export * from "./ITtscLintCoreRuleOptions";
 export * from "./ITtscLintCoreRules";
 export * from "./ITtscLintCypressRuleOptions";
 export * from "./ITtscLintCypressRules";

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_allow_separate_type_imports_allows_value_plus_type_import_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_allow_separate_type_imports_allows_value_plus_type_import_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsAllowSeparateTypeImportsAllowsValuePlusTypeImport
+// verifies `allowSeparateTypeImports: true` accepts one value import
+// plus one clause-level type import of the same module, in both orders.
+//
+// Locks the option's skip branch in `duplicateImportsShouldReport`: when
+// the new and the earlier declaration differ in clause-level type-ness,
+// the pair is exempt from the mergeability comparison. Both orders
+// exercise the comparison from the value side and from the type side.
+//
+//  1. Import a default value binding then clause-level type bindings from
+//     "m", and type bindings then a value binding from "n".
+//  2. Run the rule with `allowSeparateTypeImports: true`.
+//  3. Assert zero findings.
+func TestNoDuplicateImportsAllowSeparateTypeImportsAllowsValuePlusTypeImport(t *testing.T) {
+  got := runNoDuplicateImports(t, `import api from "m";
+import type { IEntity } from "m";
+import type { IOther } from "n";
+import { other } from "n";
+`, `{"allowSeparateTypeImports":true}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_allow_separate_type_imports_still_reports_type_pairs_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_allow_separate_type_imports_still_reports_type_pairs_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsAllowSeparateTypeImportsStillReportsTypePairs
+// verifies `allowSeparateTypeImports: true` keeps reporting two
+// mergeable clause-level type imports of the same module.
+//
+// Negative twin on the type side: the option separates the type category
+// from the value category but does not exempt duplicates inside the type
+// category — two named `import type` declarations merge into one. An
+// implementation that skipped every type-only declaration under the
+// option would fail here.
+//
+// 1. Import clause-level named type bindings from the same module twice.
+// 2. Run the rule with `allowSeparateTypeImports: true`.
+// 3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsAllowSeparateTypeImportsStillReportsTypePairs(t *testing.T) {
+  got := runNoDuplicateImports(t, `import type { First } from "m";
+import type { Second } from "m";
+`, `{"allowSeparateTypeImports":true}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_allow_separate_type_imports_still_reports_value_pairs_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_allow_separate_type_imports_still_reports_value_pairs_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsAllowSeparateTypeImportsStillReportsValuePairs
+// verifies `allowSeparateTypeImports: true` keeps reporting two
+// mergeable value imports of the same module.
+//
+// Negative twin of the option's acceptance case: the option only exempts
+// pairs whose clause-level type-ness differs. Two value declarations
+// remain in the ordinary comparison, so an over-broad option
+// implementation that mutes every duplicate would fail here.
+//
+// 1. Import named value bindings from the same module twice.
+// 2. Run the rule with `allowSeparateTypeImports: true`.
+// 3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsAllowSeparateTypeImportsStillReportsValuePairs(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { first } from "m";
+import { second } from "m";
+`, `{"allowSeparateTypeImports":true}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_allows_inline_type_specifier_beside_type_import_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_allows_inline_type_specifier_beside_type_import_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsAllowsInlineTypeSpecifierBesideTypeImport
+// verifies `allowSeparateTypeImports: true` accepts a clause-level type
+// import next to an inline-type-specifier import of the same module.
+//
+// Companion of the inline-classification case: because `import { type B
+// }` is a value declaration, the option's type/value separation exempts
+// it from comparison with the clause-level `import type { A }` above.
+// Together the two cases pin the inline form to exactly the value side —
+// compared against value imports, separated from type imports.
+//
+//  1. Import clause-level type bindings, then an inline-type specifier,
+//     from one module.
+//  2. Run the rule with `allowSeparateTypeImports: true`.
+//  3. Assert zero findings.
+func TestNoDuplicateImportsAllowsInlineTypeSpecifierBesideTypeImport(t *testing.T) {
+  got := runNoDuplicateImports(t, `import type { Alpha } from "m";
+import { type Beta } from "m";
+`, `{"allowSeparateTypeImports":true}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_allows_named_and_namespace_value_imports_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_allows_named_and_namespace_value_imports_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsAllowsNamedAndNamespaceValueImports verifies
+// no-duplicate-imports accepts a named and a namespace import of the
+// same module, in both declaration orders.
+//
+// Locks the namespace/named exclusion in `duplicateImportsCanMerge`:
+// TypeScript has no declaration form carrying both `* as ns` and named
+// bindings, so the pair is not consolidatable and must not be reported.
+// Both orders exercise both operand sides of the symmetric guard; the
+// old specifier-string implementation reported both, so this is the
+// regression pin for issue #401's second consequence.
+//
+// 1. Import named-then-namespace from "m" and namespace-then-named from "n".
+// 2. Run the rule with default options.
+// 3. Assert zero findings.
+func TestNoDuplicateImportsAllowsNamedAndNamespaceValueImports(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { named } from "m";
+import * as namespace from "m";
+import * as other from "n";
+import { thing } from "n";
+`, `{}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_allows_type_default_and_type_named_imports_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_allows_type_default_and_type_named_imports_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsAllowsTypeDefaultAndTypeNamedImports verifies a
+// type-only default import and a type-only named import of the same
+// module are accepted, in both declaration orders.
+//
+// Locks parity with the ESLint 9.30.1 correction: `import type Def, {
+// Named } from "m"` is not legal TypeScript, so the pair cannot be
+// consolidated and is not a duplicate — under the default options, with
+// no `allowSeparateTypeImports` involved. Both orders exercise both
+// operand sides of the guard in `duplicateImportsCanMerge`.
+//
+//  1. Import a type-only default then type-only named bindings from "m",
+//     and the reverse order from "n".
+//  2. Run the rule with default options.
+//  3. Assert zero findings.
+func TestNoDuplicateImportsAllowsTypeDefaultAndTypeNamedImports(t *testing.T) {
+  got := runNoDuplicateImports(t, `import type DefaultType from "m";
+import type { NamedType } from "m";
+import type { OtherNamed } from "n";
+import type OtherDefault from "n";
+`, `{}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_allows_type_namespace_and_type_named_imports_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_allows_type_namespace_and_type_named_imports_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsAllowsTypeNamespaceAndTypeNamedImports verifies
+// a type-only namespace import and a type-only named import of the same
+// module are accepted.
+//
+// Locks the interaction of the two exclusions in
+// `duplicateImportsCanMerge`: the type-only default/named guard does not
+// match this pair (neither side is a default), so acceptance must come
+// from the general namespace/named exclusion — which applies to
+// type-only declarations exactly as it does to value declarations.
+//
+// 1. Import `type * as ns` and then `type { Named }` from one module.
+// 2. Run the rule with default options.
+// 3. Assert zero findings.
+func TestNoDuplicateImportsAllowsTypeNamespaceAndTypeNamedImports(t *testing.T) {
+  got := runNoDuplicateImports(t, `import type * as namespace from "m";
+import type { NamedType } from "m";
+`, `{}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_classifies_inline_type_specifier_as_value_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_classifies_inline_type_specifier_as_value_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsClassifiesInlineTypeSpecifierAsValue verifies
+// `import { type Foo } from "m"` counts as a value declaration under
+// `allowSeparateTypeImports: true`, not as a clause-level type import.
+//
+// Locks the clause-level reading of type-ness in
+// `duplicateImportsImportEntry`: only `ImportClause.IsTypeOnly()`
+// (`import type …`) makes a declaration type-only; an inline `type`
+// modifier on a specifier leaves the import clause value-bearing. If the
+// inline modifier leaked into the declaration's type-ness, the option
+// would wrongly exempt this pair and the finding would disappear.
+//
+// 1. Import named value bindings, then an inline-type specifier, from "m".
+// 2. Run the rule with `allowSeparateTypeImports: true`.
+// 3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsClassifiesInlineTypeSpecifierAsValue(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { value } from "m";
+import { type Foo } from "m";
+`, `{"allowSeparateTypeImports":true}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_helpers_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_helpers_test.go
@@ -1,0 +1,78 @@
+package linthost
+
+import (
+  "encoding/json"
+  "sort"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+)
+
+// duplicateImportsFinding is the normalized (line, message) pair the
+// no-duplicate-imports unit cases assert on. Messages are part of the
+// contract because the rule distinguishes the four official pairings
+// (import/import, import/export, export/export, export/import), and a
+// line-only assertion could not tell them apart.
+type duplicateImportsFinding struct {
+  Line    int
+  Message string
+}
+
+// runNoDuplicateImports runs the no-duplicate-imports rule over one
+// virtual TypeScript source with the given options JSON and returns
+// normalized findings sorted by (line, message) so assertions do not
+// depend on engine emission order.
+func runNoDuplicateImports(t *testing.T, source, optsJSON string) []duplicateImportsFinding {
+  t.Helper()
+  const ruleName = "no-duplicate-imports"
+  file := parseTSFile(t, "/virtual/no-duplicate-imports.ts", source)
+  resolver := InlineRuleResolver{
+    Rules:   RuleConfig{ruleName: SeverityError},
+    Options: RuleOptionsMap{ruleName: json.RawMessage(optsJSON)},
+  }
+  findings := NewEngineWithResolver(resolver).Run([]*shimast.SourceFile{file}, nil)
+  out := make([]duplicateImportsFinding, 0, len(findings))
+  for _, finding := range findings {
+    if finding.Rule != ruleName {
+      t.Fatalf("unexpected rule %q in findings: %+v", finding.Rule, finding)
+    }
+    if len(finding.Fix) != 0 {
+      t.Fatalf("no-duplicate-imports must not offer autofixes, got %+v", finding.Fix)
+    }
+    out = append(out, duplicateImportsFinding{
+      Line:    shimscanner.GetECMALineOfPosition(file, finding.Pos) + 1,
+      Message: finding.Message,
+    })
+  }
+  sort.Slice(out, func(i, j int) bool {
+    if out[i].Line != out[j].Line {
+      return out[i].Line < out[j].Line
+    }
+    return out[i].Message < out[j].Message
+  })
+  return out
+}
+
+// assertDuplicateImportsFindings compares normalized findings against the
+// expected (line, message) list. `want` must be pre-sorted by (line,
+// message), matching runNoDuplicateImports output order.
+func assertDuplicateImportsFindings(t *testing.T, got, want []duplicateImportsFinding) {
+  t.Helper()
+  if len(got) != len(want) {
+    t.Fatalf("want %d findings %+v, got %d findings %+v", len(want), want, len(got), got)
+  }
+  for i := range want {
+    if got[i] != want[i] {
+      t.Fatalf("finding[%d]: want %+v, got %+v; all=%+v", i, want[i], got[i], got)
+    }
+  }
+}
+
+// assertNoDuplicateImportsFindings asserts the rule stayed silent.
+func assertNoDuplicateImportsFindings(t *testing.T, got []duplicateImportsFinding) {
+  t.Helper()
+  if len(got) != 0 {
+    t.Fatalf("expected zero findings, got %+v", got)
+  }
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_ignores_misspelled_option_keys_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_ignores_misspelled_option_keys_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIgnoresMisspelledOptionKeys verifies a
+// misspelled option key leaves the rule on its official defaults
+// instead of disabling it or panicking.
+//
+// Locks the options decode path: `DecodeOptions` ignores unknown JSON
+// keys, so `allowSeparateTypeImport` (missing the trailing `s`) must not
+// activate the type/value separation. The Go layer mirrors the
+// compile-time typo rejection asserted in the TypeScript typing test —
+// the native engine is the runtime backstop for untyped config files
+// such as lint.config.json.
+//
+// 1. Import a value binding and a clause-level type binding from one module.
+// 2. Run the rule with a misspelled `allowSeparateTypeImport` key.
+// 3. Assert the default behavior still reports the second declaration.
+func TestNoDuplicateImportsIgnoresMisspelledOptionKeys(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { value } from "m";
+import type { Entity } from "m";
+`, `{"allowSeparateTypeImport":true}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_ignores_reexports_by_default_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_ignores_reexports_by_default_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIgnoresReexportsByDefault verifies the official
+// default `includeExports: false` leaves `export … from` declarations
+// out of the analysis entirely.
+//
+// Locks the option gate in the rule's statement walk: without
+// `includeExports`, re-exports are neither reported nor recorded, so a
+// re-export of an imported module and even two identical re-exports stay
+// silent. This is the negative twin of every include-exports case.
+//
+// 1. Import from "m", then re-export from "m" twice.
+// 2. Run the rule with default options.
+// 3. Assert zero findings.
+func TestNoDuplicateImportsIgnoresReexportsByDefault(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { value } from "m";
+export { first } from "m";
+export { second } from "m";
+`, `{}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_allows_export_star_beside_named_import_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_allows_export_star_beside_named_import_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsAllowsExportStarBesideNamedImport
+// verifies `includeExports: true` accepts `export * from "m"` next to a
+// named import of "m", in both declaration orders.
+//
+// Locks the export-all exclusion in `duplicateImportsCanMerge`: `export
+// *` re-exports every binding and cannot be folded into a named import
+// (or vice versa) — only another `export *` or a bare side-effect import
+// merges with it. Both orders exercise both operand sides of the
+// symmetric guard.
+//
+//  1. Import named bindings then `export *` for "m"; `export *` then a
+//     named import for "n".
+//  2. Run the rule with `includeExports: true`.
+//  3. Assert zero findings.
+func TestNoDuplicateImportsIncludeExportsAllowsExportStarBesideNamedImport(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { value } from "m";
+export * from "m";
+export * from "n";
+import { other } from "n";
+`, `{"includeExports":true}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_allows_export_star_beside_namespace_reexport_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_allows_export_star_beside_namespace_reexport_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsAllowsExportStarBesideNamespaceReexport
+// verifies `includeExports: true` accepts `export * as ns from "m"`
+// next to a bare `export * from "m"`.
+//
+// Discriminates the namespace-export category from export-all in
+// `duplicateImportsExportEntry`: the two star forms cannot merge (the
+// export-all exclusion blocks export-all against namespace bindings),
+// but if the aliased form were miscategorized as export-all the pair
+// would look like two mergeable `export *` declarations and produce a
+// false finding.
+//
+// 1. Write `export * as ns from "m"` and then `export * from "m"`.
+// 2. Run the rule with `includeExports: true`.
+// 3. Assert zero findings.
+func TestNoDuplicateImportsIncludeExportsAllowsExportStarBesideNamespaceReexport(t *testing.T) {
+  got := runNoDuplicateImports(t, `export * as namespace from "m";
+export * from "m";
+`, `{"includeExports":true}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_allows_namespace_reexport_beside_named_import_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_allows_namespace_reexport_beside_named_import_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsAllowsNamespaceReexportBesideNamedImport
+// verifies `includeExports: true` accepts `export * as ns from "m"`
+// next to a named import of "m".
+//
+// Locks the namespace categorization of aliased star re-exports in
+// `duplicateImportsExportEntry`: `export * as ns` is a namespace
+// specifier, so the namespace/named exclusion applies across declaration
+// kinds. Miscategorizing it as export-all would also pass here, which is
+// why the export-star-beside-namespace-reexport case exists as the
+// discriminating twin.
+//
+// 1. Re-export `* as ns` from "m", then import named bindings from "m".
+// 2. Run the rule with `includeExports: true`.
+// 3. Assert zero findings.
+func TestNoDuplicateImportsIncludeExportsAllowsNamespaceReexportBesideNamedImport(t *testing.T) {
+  got := runNoDuplicateImports(t, `export * as namespace from "m";
+import { value } from "m";
+`, `{"includeExports":true}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_both_pairings_on_one_declaration_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_both_pairings_on_one_declaration_test.go
@@ -1,0 +1,29 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsReportsBothPairingsOnOneDeclaration
+// verifies a re-export mergeable with an earlier re-export AND an
+// earlier import produces both findings on the same declaration.
+//
+// Locks the two independent report arms in `reportDuplicateImports`: the
+// official rule pushes one message per pairing kind, so the third
+// declaration below carries the plain export duplicate and the
+// duplicated-as-import finding simultaneously. Collapsing the arms into
+// a single first-match report would drop one of them.
+//
+//  1. Import from "m", re-export from "m", then re-export from "m" again.
+//  2. Run the rule with `includeExports: true`.
+//  3. Assert the middle line reports duplicated-as-import and the last
+//     line reports both pairings.
+func TestNoDuplicateImportsIncludeExportsReportsBothPairingsOnOneDeclaration(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { value } from "m";
+export { first } from "m";
+export { second } from "m";
+`, `{"includeExports":true}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` export is duplicated as import."},
+    {Line: 3, Message: "`m` export is duplicated as import."},
+    {Line: 3, Message: "`m` export is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_export_star_beside_side_effect_import_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_export_star_beside_side_effect_import_test.go
@@ -1,0 +1,30 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsReportsExportStarBesideSideEffectImport
+// verifies `includeExports: true` pairs `export * from "m"` with a bare
+// side-effect import of "m" as duplicates, in both declaration orders.
+//
+// Locks the side-effect carve-out inside the export-all exclusion: the
+// official guard blocks export-all only against binding forms, and a
+// bare `import "m"` is subsumed by the module load `export *` already
+// performs. The first order yields the export message pair, the reverse
+// order the import message pair, pinning both report arms.
+//
+//  1. `import "m"` then `export * from "m"`; `export * from "n"` then
+//     `import "n"`.
+//  2. Run the rule with `includeExports: true`.
+//  3. Assert one duplicated-as-import finding on line 2 and one
+//     duplicated-as-export finding on line 4.
+func TestNoDuplicateImportsIncludeExportsReportsExportStarBesideSideEffectImport(t *testing.T) {
+  got := runNoDuplicateImports(t, `import "m";
+export * from "m";
+export * from "n";
+import "n";
+`, `{"includeExports":true}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` export is duplicated as import."},
+    {Line: 4, Message: "`n` import is duplicated as export."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_import_after_reexport_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_import_after_reexport_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsReportsImportAfterReexport
+// verifies `includeExports: true` reports an import of a module that was
+// already re-exported above.
+//
+// Locks the import-versus-exports pairing (the official `importAs`
+// message): the import handler additionally compares against recorded
+// re-exports when the option is on, and the finding carries the
+// duplicated-as-export message. With the option off, the earlier
+// re-export would never have been recorded and this import would pass.
+//
+// 1. Re-export named bindings from "m", then import from "m".
+// 2. Run the rule with `includeExports: true`.
+// 3. Assert exactly one duplicated-as-export finding on the second line.
+func TestNoDuplicateImportsIncludeExportsReportsImportAfterReexport(t *testing.T) {
+  got := runNoDuplicateImports(t, `export { thing } from "m";
+import { value } from "m";
+`, `{"includeExports":true}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated as export."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_reexport_after_import_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_reexport_after_import_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsReportsReexportAfterImport
+// verifies `includeExports: true` reports a named re-export of a module
+// that already has a mergeable import above.
+//
+// Locks the export-versus-imports pairing (the official `exportAs`
+// message): the re-export could be folded into the existing import plus
+// a local `export`, so the pair is a duplicate across declaration kinds
+// and carries the duplicated-as-import message rather than the plain
+// export message.
+//
+// 1. Import named bindings from "m", then `export { … } from "m"`.
+// 2. Run the rule with `includeExports: true`.
+// 3. Assert exactly one duplicated-as-import finding on the second line.
+func TestNoDuplicateImportsIncludeExportsReportsReexportAfterImport(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { value } from "m";
+export { value } from "m";
+`, `{"includeExports":true}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` export is duplicated as import."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_repeated_export_star_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_repeated_export_star_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsReportsRepeatedExportStar verifies
+// `includeExports: true` reports the second of two `export * from "m"`
+// declarations.
+//
+// Positive twin of the export-all exclusion: the guard in
+// `duplicateImportsCanMerge` only blocks export-all against binding
+// forms; two identical `export *` declarations reduce to one and remain
+// a duplicate. An over-broad exclusion that isolates export-all from
+// everything would fail here.
+//
+// 1. Write `export * from "m"` twice.
+// 2. Run the rule with `includeExports: true`.
+// 3. Assert exactly one duplicated-export finding on the second line.
+func TestNoDuplicateImportsIncludeExportsReportsRepeatedExportStar(t *testing.T) {
+  got := runNoDuplicateImports(t, `export * from "m";
+export * from "m";
+`, `{"includeExports":true}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` export is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_second_reexport_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_second_reexport_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsReportsSecondReexport verifies
+// `includeExports: true` reports the second of two mergeable named
+// re-exports of the same module.
+//
+// Locks the export-versus-exports pairing (the official `export`
+// message): two `export { … } from "m"` declarations consolidate into
+// one, making the second a plain export duplicate with its own message
+// distinct from the cross-kind duplicated-as-import case.
+//
+// 1. Re-export named bindings from the same module twice.
+// 2. Run the rule with `includeExports: true`.
+// 3. Assert exactly one duplicated-export finding on the second line.
+func TestNoDuplicateImportsIncludeExportsReportsSecondReexport(t *testing.T) {
+  got := runNoDuplicateImports(t, `export { first } from "m";
+export { second } from "m";
+`, `{"includeExports":true}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` export is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_type_reexport_after_value_import_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_reports_type_reexport_after_value_import_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsReportsTypeReexportAfterValueImport
+// verifies `includeExports: true` alone still reports a clause-level
+// `export type` re-export of a module with a value import above.
+//
+// Locks the default type handling on the export arm: without
+// `allowSeparateTypeImports`, an `export type { … } from` declaration
+// joins the ordinary comparison, and named type bindings merge with the
+// named value import. This is the negative twin of the case that adds
+// `allowSeparateTypeImports: true` and expects silence.
+//
+// 1. Import named value bindings from "m", then `export type { … } from "m"`.
+// 2. Run the rule with `includeExports: true` only.
+// 3. Assert exactly one duplicated-as-import finding on the second line.
+func TestNoDuplicateImportsIncludeExportsReportsTypeReexportAfterValueImport(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { value } from "m";
+export type { IEntity } from "m";
+`, `{"includeExports":true}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` export is duplicated as import."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_skips_local_export_without_module_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_skips_local_export_without_module_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsSkipsLocalExportWithoutModule
+// verifies `includeExports: true` ignores `export { … }` statements that
+// have no `from` clause.
+//
+// Locks the missing-module guard on the export arm: a local export
+// re-exports nothing and names no module, so it must not join the
+// module-keyed comparison. If the nil `ModuleSpecifier` were keyed under
+// the empty string, two local exports would falsely collide with each
+// other.
+//
+// 1. Import from "m", declare locals, and export them twice without `from`.
+// 2. Run the rule with `includeExports: true`.
+// 3. Assert zero findings.
+func TestNoDuplicateImportsIncludeExportsSkipsLocalExportWithoutModule(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { value } from "m";
+const first = value;
+const second = value;
+export { first };
+export { second };
+`, `{"includeExports":true}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_treats_empty_reexport_clause_as_side_effect_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_treats_empty_reexport_clause_as_side_effect_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsTreatsEmptyReexportClauseAsSideEffect
+// verifies `export {} from "m"` is categorized as a specifier-less
+// side-effect declaration, not as named bindings.
+//
+// Locks the empty-`NamedExports` branch in
+// `duplicateImportsExportEntry`, mirroring the ESTree reading where an
+// empty block contributes no specifiers. The discriminating pairing is a
+// preceding `export * from "m"`: the side-effect category merges with
+// export-all (finding), while miscategorized named bindings would hit
+// the export-all exclusion and stay silent.
+//
+// 1. Write `export * from "m"` and then `export {} from "m"`.
+// 2. Run the rule with `includeExports: true`.
+// 3. Assert exactly one duplicated-export finding on the second line.
+func TestNoDuplicateImportsIncludeExportsTreatsEmptyReexportClauseAsSideEffect(t *testing.T) {
+  got := runNoDuplicateImports(t, `export * from "m";
+export {} from "m";
+`, `{"includeExports":true}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` export is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_with_allow_separate_allows_type_reexport_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_include_exports_with_allow_separate_allows_type_reexport_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsIncludeExportsWithAllowSeparateAllowsTypeReexport
+// verifies combining `includeExports` with `allowSeparateTypeImports`
+// accepts a clause-level `export type` re-export next to a value import
+// of the same module.
+//
+// Locks the clause-level type-ness reading on the export arm
+// (`ExportDeclaration.IsTypeOnly`): the type/value separation must apply
+// to re-exports exactly as it does to imports, so the type-only
+// re-export is exempt from comparison with the value import. If export
+// type-ness were dropped, this pair would report as its
+// includeExports-only twin does.
+//
+// 1. Import named value bindings from "m", then `export type { … } from "m"`.
+// 2. Run the rule with both options enabled.
+// 3. Assert zero findings.
+func TestNoDuplicateImportsIncludeExportsWithAllowSeparateAllowsTypeReexport(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { value } from "m";
+export type { IEntity } from "m";
+`, `{"includeExports":true,"allowSeparateTypeImports":true}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_default_then_named_value_imports_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_default_then_named_value_imports_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsReportsDefaultThenNamedValueImports verifies
+// no-duplicate-imports reports a named value import following a default
+// value import of the same module.
+//
+// Locks the mergeable cross-category pairing in
+// `duplicateImportsCanMerge`: a default binding and named bindings share
+// one legal declaration (`import def, { a } from "m"`), so the pair is a
+// duplicate even though the categories differ. This is the value-kind
+// negative twin of the type-only default/named exemption, which must not
+// leak into value declarations.
+//
+// 1. Import a default binding and then named bindings from one module.
+// 2. Run the rule with default options.
+// 3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsReportsDefaultThenNamedValueImports(t *testing.T) {
+  got := runNoDuplicateImports(t, `import def from "m";
+import { named } from "m";
+`, `{}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_default_then_namespace_value_imports_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_default_then_namespace_value_imports_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsReportsDefaultThenNamespaceValueImports verifies
+// no-duplicate-imports reports a namespace import following a default
+// import of the same module.
+//
+// Locks the mergeable default/namespace pairing: `import def, * as ns
+// from "m"` is legal TypeScript, so the two declarations consolidate and
+// the second one is a duplicate. Guards against widening the
+// namespace/named exclusion in `duplicateImportsCanMerge` to every
+// namespace pairing.
+//
+// 1. Import a default binding and then a namespace binding from one module.
+// 2. Run the rule with default options.
+// 3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsReportsDefaultThenNamespaceValueImports(t *testing.T) {
+  got := runNoDuplicateImports(t, `import def from "m";
+import * as namespace from "m";
+`, `{}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_each_later_duplicate_import_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_each_later_duplicate_import_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsReportsEachLaterDuplicateImport verifies three
+// mergeable imports of one module produce a finding on the second AND
+// the third declaration.
+//
+// Locks the recording rule: a declaration is appended to the module's
+// entry list even after being reported, so every later occurrence still
+// finds a mergeable predecessor. Dropping reported declarations from the
+// bookkeeping would silence the third import.
+//
+// 1. Import named bindings from the same module three times.
+// 2. Run the rule with default options.
+// 3. Assert duplicate-import findings on lines two and three.
+func TestNoDuplicateImportsReportsEachLaterDuplicateImport(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { first } from "m";
+import { second } from "m";
+import { third } from "m";
+`, `{}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+    {Line: 3, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_nonadjacent_duplicate_value_imports_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_nonadjacent_duplicate_value_imports_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsReportsNonadjacentDuplicateValueImports verifies
+// no-duplicate-imports reports a duplicate even when an unrelated import
+// sits between the two same-module declarations.
+//
+// Locks the per-module bookkeeping in the rule's `modules` map: the
+// duplicate comparison keys on the module specifier, not on adjacency,
+// so an intervening import of a different module must neither reset the
+// tracking nor produce a finding of its own.
+//
+// 1. Import from "m", then from an unrelated module, then from "m" again.
+// 2. Run the rule with default options.
+// 3. Assert exactly one duplicate-import finding on the third line.
+func TestNoDuplicateImportsReportsNonadjacentDuplicateValueImports(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { first } from "m";
+import { other } from "other";
+import { second } from "m";
+`, `{}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 3, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_repeated_side_effect_imports_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_repeated_side_effect_imports_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsReportsRepeatedSideEffectImports verifies
+// no-duplicate-imports reports a second bare side-effect import of the
+// same module.
+//
+// Locks the SideEffectImport category from `duplicateImportsImportEntry`
+// on the clause-less shape: two `import "m"` declarations trivially
+// consolidate into one, and the official implementation treats the
+// side-effect category as mergeable with every import category.
+//
+// 1. Write the same bare `import "m"` twice.
+// 2. Run the rule with default options.
+// 3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsReportsRepeatedSideEffectImports(t *testing.T) {
+  got := runNoDuplicateImports(t, `import "m";
+import "m";
+`, `{}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_side_effect_import_after_named_import_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_side_effect_import_after_named_import_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsReportsSideEffectImportAfterNamedImport verifies
+// no-duplicate-imports reports a bare side-effect import of a module
+// that already has a named import above.
+//
+// Locks the cross-category mergeability of the side-effect shape: the
+// module already loads through the named declaration, so the bare
+// `import "m"` folds into it. The official mergeability table exempts
+// the side-effect category from every exclusion, and this pins that the
+// port did not accidentally isolate it.
+//
+// 1. Import named bindings from "m", then a bare `import "m"`.
+// 2. Run the rule with default options.
+// 3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsReportsSideEffectImportAfterNamedImport(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { named } from "m";
+import "m";
+`, `{}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_two_namespace_value_imports_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_two_namespace_value_imports_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsReportsTwoNamespaceValueImports verifies
+// no-duplicate-imports reports two namespace imports of the same module.
+//
+// Positive twin of the namespace/named exclusion: the guard in
+// `duplicateImportsCanMerge` only excludes namespace-beside-named pairs,
+// while two namespace bindings of one module remain an ordinary
+// duplicate (one binding can serve both call sites). An over-broad
+// namespace exemption would silently stop reporting this shape.
+//
+// 1. Import `* as a` and `* as b` from the same module.
+// 2. Run the rule with default options.
+// 3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsReportsTwoNamespaceValueImports(t *testing.T) {
+  got := runNoDuplicateImports(t, `import * as first from "m";
+import * as second from "m";
+`, `{}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_two_type_default_imports_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_two_type_default_imports_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsReportsTwoTypeDefaultImports verifies two
+// type-only default imports of the same module are still reported.
+//
+// Positive twin of the ESLint 9.30.1 exemption: the type-only guard in
+// `duplicateImportsCanMerge` excludes only the default/named pairing.
+// Two type-only defaults reference the same export and reduce to one
+// declaration, so widening the guard to every type-only pair would be a
+// regression this case catches.
+//
+// 1. Import two type-only default bindings from the same module.
+// 2. Run the rule with default options.
+// 3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsReportsTwoTypeDefaultImports(t *testing.T) {
+  got := runNoDuplicateImports(t, `import type First from "m";
+import type Second from "m";
+`, `{}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_value_default_then_type_named_import_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_value_default_then_type_named_import_test.go
@@ -1,0 +1,28 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsReportsValueDefaultThenTypeNamedImport verifies
+// the default configuration reports a clause-level type named import
+// after a value default import of the same module.
+//
+// Pins the both-type precondition of the ESLint 9.30.1 guard in
+// `duplicateImportsCanMerge`: the default/named exemption applies only
+// when BOTH declarations are type-only. This pair has the exempted
+// category shape (default beside named) but only one type-only side, so
+// it merges into `import def, { type Named } from "m"` and must report.
+// A guard loosened to exempt the pair when either side is type-only
+// would go silent here.
+//
+//  1. Import a value default binding, then clause-level named type
+//     bindings, from one module.
+//  2. Run the rule with default options.
+//  3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsReportsValueDefaultThenTypeNamedImport(t *testing.T) {
+  got := runNoDuplicateImports(t, `import def from "m";
+import type { Named } from "m";
+`, `{}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_value_then_type_named_import_by_default_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_reports_value_then_type_named_import_by_default_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsReportsValueThenTypeNamedImportByDefault
+// verifies the default configuration reports a clause-level `import
+// type` declaration whose module already has a value import above.
+//
+// Locks the official default `allowSeparateTypeImports: false`: without
+// the option, clause-level type declarations join the ordinary duplicate
+// comparison, and named value bindings merge with named type bindings
+// into `import { a, type B } from "m"`. This is the negative twin of the
+// option-enabled acceptance case.
+//
+// 1. Import named value bindings and then clause-level type bindings from "m".
+// 2. Run the rule with default options.
+// 3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsReportsValueThenTypeNamedImportByDefault(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { value } from "m";
+import type { Entity } from "m";
+`, `{}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_skips_empty_module_specifiers_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_skips_empty_module_specifiers_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsSkipsEmptyModuleSpecifiers verifies imports with
+// an empty (or whitespace-only) module string never participate in the
+// duplicate comparison.
+//
+// Locks the empty-module guard: the official `handleImportsExports`
+// skips declarations whose trimmed module name is falsy, so even two
+// identical empty-specifier imports are not duplicates of each other.
+// Removing the guard would key both under "" and report the second.
+//
+//  1. Write two `import { … } from ""` declarations and one whitespace-only
+//     specifier.
+//  2. Run the rule with default options.
+//  3. Assert zero findings.
+func TestNoDuplicateImportsSkipsEmptyModuleSpecifiers(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { first } from "";
+import { second } from "";
+import { third } from "  ";
+`, `{}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_test.go
@@ -5,13 +5,15 @@ import "testing"
 // TestRuleCorpusNoDuplicateImports verifies the lint rule corpus
 // fixture no-duplicate-imports.ts.
 //
-// The rule collects every `import … from "…"` declaration at the
-// source-file root and reports the second occurrence of a previously
-// seen module specifier.
+// The rule reports a repeated module specifier only when the two
+// declarations could be merged into one legal declaration. The fixture
+// pins the official defaults: mergeable value pairs and value-plus-type
+// pairs report, while named-beside-namespace and type-only
+// default-beside-named pairs (ESLint 9.30.1 parity) do not.
 //
 // 1. Load the annotated TypeScript source embedded below.
-// 2. Enable the rule severity declared by its `// expect:` comment.
-// 3. Assert the native Engine reports exactly the annotated diagnostic.
+// 2. Enable the rule severity declared by its `// expect:` comments.
+// 3. Assert the native Engine reports exactly the annotated diagnostics.
 func TestRuleCorpusNoDuplicateImports(t *testing.T) {
-  assertRuleCorpusCase(t, "no-duplicate-imports.ts", "import { stringify } from \"node:querystring\";\n// expect: no-duplicate-imports error\nimport { parse } from \"node:querystring\";\nJSON.stringify({ stringify, parse });\n")
+  assertRuleCorpusCase(t, "no-duplicate-imports.ts", "// Positive: two mergeable named value imports of the same module.\nimport { first } from \"some-module\";\n// expect: no-duplicate-imports error\nimport { second } from \"some-module\";\n\n// Positive: under the official default (allowSeparateTypeImports: false),\n// a clause-level type import joins the comparison with the value import\n// above, and named type bindings merge with named value bindings.\nimport { runtime } from \"type-and-value\";\n// expect: no-duplicate-imports error\nimport type { IEntity } from \"type-and-value\";\n\n// Negative: named and namespace imports cannot be merged into one\n// declaration, so the repeated module specifier is not a duplicate.\nimport { named } from \"unmergeable-namespace\";\nimport * as namespace from \"unmergeable-namespace\";\n\n// Negative: a type-only default import and a type-only named import\n// cannot be merged into one declaration (ESLint 9.30.1 parity).\nimport type DefaultType from \"unmergeable-type-forms\";\nimport type { NamedType } from \"unmergeable-type-forms\";\n\n// Negative: imports from different modules.\nimport { alpha } from \"other-module-a\";\nimport { beta } from \"other-module-b\";\n\nJSON.stringify({ first, second, runtime, named, namespace, alpha, beta });\n")
 }

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_treats_default_with_empty_named_clause_as_default_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_treats_default_with_empty_named_clause_as_default_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsTreatsDefaultWithEmptyNamedClauseAsDefault
+// verifies `import def, {} from "m"` is categorized as a default import,
+// not as a side-effect import.
+//
+// Locks the fall-through order in `duplicateImportsImportEntry`: an
+// empty named block contributes no specifiers, so the default binding
+// decides the category — mirroring the official specifier scan that
+// falls back to `specifiers[0]`. The discriminating pairing is an
+// earlier `export * from "m"`: a default binding cannot merge with
+// export-all (silence), while a miscategorized side-effect import would
+// merge and report.
+//
+// 1. Write `export * from "m"`, then `import def, {} from "m"`.
+// 2. Run the rule with `includeExports: true`.
+// 3. Assert zero findings.
+func TestNoDuplicateImportsTreatsDefaultWithEmptyNamedClauseAsDefault(t *testing.T) {
+  got := runNoDuplicateImports(t, `export * from "m";
+import def, {} from "m";
+`, `{"includeExports":true}`)
+  assertNoDuplicateImportsFindings(t, got)
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_treats_empty_named_import_clause_as_side_effect_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_treats_empty_named_import_clause_as_side_effect_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsTreatsEmptyNamedImportClauseAsSideEffect
+// verifies `import {} from "m"` is categorized as a side-effect import,
+// not as named bindings.
+//
+// Locks the empty-`NamedImports` branch in
+// `duplicateImportsImportEntry`. In ESTree an empty block contributes no
+// specifiers, so the official rule categorizes the declaration as
+// SideEffectImport. The discriminating pairing is a preceding namespace
+// import: side-effect merges with namespace (finding), while a
+// miscategorized named clause would hit the namespace/named exclusion
+// and stay silent.
+//
+// 1. Import `* as ns` from "m", then `import {} from "m"`.
+// 2. Run the rule with default options.
+// 3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsTreatsEmptyNamedImportClauseAsSideEffect(t *testing.T) {
+  got := runNoDuplicateImports(t, `import * as namespace from "m";
+import {} from "m";
+`, `{}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/packages/lint/test/rules/imports-modules/no_duplicate_imports_trims_module_specifier_whitespace_test.go
+++ b/packages/lint/test/rules/imports-modules/no_duplicate_imports_trims_module_specifier_whitespace_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestNoDuplicateImportsTrimsModuleSpecifierWhitespace verifies module
+// specifiers are compared after trimming surrounding whitespace.
+//
+// Locks `duplicateImportsModule` parity with the official `getModule`,
+// which compares `source.value.trim()`. Without trimming, `" m "` and
+// `"m"` would silently count as different modules and the pair would
+// escape the duplicate comparison.
+//
+// 1. Import from `"m"` and then from `" m "`.
+// 2. Run the rule with default options.
+// 3. Assert exactly one duplicate-import finding on the second line.
+func TestNoDuplicateImportsTrimsModuleSpecifierWhitespace(t *testing.T) {
+  got := runNoDuplicateImports(t, `import { first } from "m";
+import { second } from " m ";
+`, `{}`)
+  assertDuplicateImportsFindings(t, got, []duplicateImportsFinding{
+    {Line: 2, Message: "`m` import is duplicated."},
+  })
+}

--- a/tests/test-lint/src/cases/no-duplicate-imports.ts
+++ b/tests/test-lint/src/cases/no-duplicate-imports.ts
@@ -1,10 +1,27 @@
-// Positive: two imports of the same module specifier.
-import { stringify } from "node:querystring";
+// Positive: two mergeable named value imports of the same module.
+import { first } from "some-module";
 // expect: no-duplicate-imports error
-import { parse } from "node:querystring";
+import { second } from "some-module";
+
+// Positive: under the official default (allowSeparateTypeImports: false),
+// a clause-level type import joins the comparison with the value import
+// above, and named type bindings merge with named value bindings.
+import { runtime } from "type-and-value";
+// expect: no-duplicate-imports error
+import type { IEntity } from "type-and-value";
+
+// Negative: named and namespace imports cannot be merged into one
+// declaration, so the repeated module specifier is not a duplicate.
+import { named } from "unmergeable-namespace";
+import * as namespace from "unmergeable-namespace";
+
+// Negative: a type-only default import and a type-only named import
+// cannot be merged into one declaration (ESLint 9.30.1 parity).
+import type DefaultType from "unmergeable-type-forms";
+import type { NamedType } from "unmergeable-type-forms";
 
 // Negative: imports from different modules.
-import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { alpha } from "other-module-a";
+import { beta } from "other-module-b";
 
-JSON.stringify({ stringify, parse, join, tmpdir });
+JSON.stringify({ first, second, runtime, named, namespace, alpha, beta });

--- a/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
+++ b/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
@@ -21,6 +21,10 @@ import assert from "node:assert/strict";
  * - Typo'd built-in rule name (`noVra`) is rejected.
  * - Typo'd option key (`metohds` for `methods` on
  *   `cypress/unsafe-to-chain-command`) is rejected.
+ * - Typo'd option key on a bare-name core rule (`allowSeparateTypeImport` for
+ *   `allowSeparateTypeImports` on `no-duplicate-imports`) is rejected.
+ * - A non-boolean value for a boolean core-rule option (`includeExports: "yes"`
+ *   on `no-duplicate-imports`) is rejected.
  * - Cross-rule option leakage (`testIdPattern` on
  *   `cypress/unsafe-to-chain-command`) is rejected.
  * - A lint-only rule (`no-var`) cannot carry an options object.
@@ -41,6 +45,10 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
   const config: ITtscLintConfig = {
     rules: {
       "no-var": "error",
+      "no-duplicate-imports": [
+        "error",
+        { allowSeparateTypeImports: true, includeExports: true },
+      ],
       "cypress/unsafe-to-chain-command": [
         "warning",
         { methods: ["customClick"] },
@@ -89,6 +97,18 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
       "cypress/unsafe-to-chain-command": ["error", { metohds: ["click"] }],
     },
   };
+  const coreOptionKeyTypo: ITtscLintConfig = {
+    rules: {
+      // @ts-expect-error — `allowSeparateTypeImport` is a typo of `allowSeparateTypeImports`; excess property check on the tuple's options slot fires.
+      "no-duplicate-imports": ["error", { allowSeparateTypeImport: true }],
+    },
+  };
+  const coreOptionValueShape: ITtscLintConfig = {
+    rules: {
+      // @ts-expect-error — `includeExports` is a boolean option; a string value is rejected.
+      "no-duplicate-imports": ["error", { includeExports: "yes" }],
+    },
+  };
   const crossRuleShape: ITtscLintConfig = {
     rules: {
       // @ts-expect-error — `testIdPattern` belongs to testing-library/consistent-data-testid; cypress/unsafe-to-chain-command's option shape rejects it.
@@ -112,6 +132,8 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
   assert.ok(bareTuple);
   assert.ok(ruleNameTypo);
   assert.ok(optionKeyTypo);
+  assert.ok(coreOptionKeyTypo);
+  assert.ok(coreOptionValueShape);
   assert.ok(crossRuleShape);
   assert.ok(lintRuleWithOptions);
   assert.ok(camelBuiltinName);

--- a/tests/test-lint/src/native-plugins/config/test_lint_config_file_builtin_rule_options_tuple_reaches_native_rule.ts
+++ b/tests/test-lint/src/native-plugins/config/test_lint_config_file_builtin_rule_options_tuple_reaches_native_rule.ts
@@ -1,0 +1,52 @@
+import { assert, runLint } from "../../internal/config-file";
+
+/**
+ * Verifies a built-in rule's `[severity, options]` tuple in lint.config.json
+ * reaches the native rule.
+ *
+ * `no-duplicate-imports` is the first bare-name core rule with typed options.
+ * The contributor wire-chain test pins options delivery for contributor rules
+ * and the Go unit layer pins the decoded semantics, but a release-only
+ * declaration that advertises an option the native rule never enforces (the
+ * forbidden shortcut named in issue #401) would still pass both. Spawning the
+ * real binary closes that gap: the option must suppress the value/type pairing
+ * while leaving the rule active for a mergeable pair in the same file, so
+ * silence cannot be mistaken for a disabled rule.
+ *
+ * 1. Write a `lint.config.json` configuring `no-duplicate-imports` as `["error", {
+ *    allowSeparateTypeImports: true }]`.
+ * 2. Lint a file with one value import plus one clause-level type import of a
+ *    module, and two mergeable named imports of another module.
+ * 3. Assert exactly one diagnostic: the mergeable named pair.
+ */
+export const test_lint_config_file_builtin_rule_options_tuple_reaches_native_rule =
+  () => {
+    const result = runLint({
+      name: "config-builtin-rule-options-tuple",
+      source: [
+        `import api from "separate-type-module";`,
+        `import type { IEntity } from "separate-type-module";`,
+        `import { alpha } from "duplicate-module";`,
+        `import { beta } from "duplicate-module";`,
+        `JSON.stringify({ api, alpha, beta });`,
+        ``,
+      ].join("\n"),
+      extraSources: {
+        "lint.config.json": JSON.stringify({
+          rules: {
+            "no-duplicate-imports": [
+              "error",
+              { allowSeparateTypeImports: true },
+            ],
+          },
+        }),
+      },
+    });
+
+    assert.notEqual(result.status, 0, result.stderr);
+    assert.deepEqual(
+      result.diagnostics.map((d) => [d.rule, d.severity, d.line]),
+      [["no-duplicate-imports", "error", 4]],
+      result.stderr,
+    );
+  };

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -42,7 +42,7 @@ Examples come from the checked [lint corpus](https://github.com/samchon/ttsc/tre
 - [`no-dupe-else-if`](#rule-no-dupe-else-if): Reject `if (a) {} else if (a) {}`, the second branch is unreachable.
 - [`no-dupe-keys`](#rule-no-dupe-keys): Reject `{ a: 1, a: 2 }`, duplicate property keys in an object literal silently overwrite earlier values.
 - [`no-duplicate-case`](#rule-no-duplicate-case): Reject the same `case` label appearing twice in a `switch`, later duplicates are unreachable.
-- [`no-duplicate-imports`](#rule-no-duplicate-imports): Reject two import declarations that resolve to the same module specifier.
+- [`no-duplicate-imports`](#rule-no-duplicate-imports): Reject a repeated module specifier when the import declarations could be merged into one legal declaration.
 - [`no-else-return`](#rule-no-else-return): Reject an `else` block whose preceding `if` branch already terminates control flow with `return`, `throw`, `break`.
 - [`no-empty`](#rule-no-empty): Reject empty blocks that almost always indicate forgotten code.
 - [`no-empty-character-class`](#rule-no-empty-character-class): Reject empty regex character classes.
@@ -1105,14 +1105,28 @@ function f(x: number) {
 
 ### `no-duplicate-imports`
 
-Reject two import declarations that resolve to the same module specifier. The runtime sees one module load either way; the duplicated declaration is purely noise at the head of the file and obscures the dependency graph.
+Reject an import declaration whose module specifier already appeared above when the two declarations could be merged into one legal declaration. Same-module pairs TypeScript cannot consolidate, such as named next to namespace bindings or a type-only default next to type-only named bindings, are not duplicates.
+
+Options:
+
+- `allowSeparateTypeImports?: boolean`
+
+  Keep clause-level `import type` declarations out of the comparison with value imports of the same module, so one runtime import plus one type-only import may coexist. Inline type specifiers such as `import { type Foo }` stay on the value side because the whole import clause is not type-only. Default: `false`.
+
+- `includeExports?: boolean`
+
+  Also treat `export … from` declarations of an already imported or re-exported module as duplicates when the declarations could be merged. Default: `false`.
 
 Example:
 
 ```ts
-import { stringify } from "node:querystring";
+import { first } from "some-module";
 // reports: no-duplicate-imports (error)
-import { parse } from "node:querystring";
+import { second } from "some-module";
+
+// Not duplicates: named and namespace bindings cannot share one declaration.
+import { named } from "other-module";
+import * as namespace from "other-module";
 ```
 
 <a id="rule-no-else-return"></a>

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -1125,8 +1125,8 @@ import { first } from "some-module";
 import { second } from "some-module";
 
 // Not duplicates: named and namespace bindings cannot share one declaration.
-import { named } from "other-module";
-import * as namespace from "other-module";
+import { named } from "unmergeable-namespace";
+import * as namespace from "unmergeable-namespace";
 ```
 
 <a id="rule-no-else-return"></a>


### PR DESCRIPTION
## Intent

`no-duplicate-imports` reported every second import declaration whose module string matched an earlier one. The official ESLint rule reports a repeated module only when the two declarations could be merged into one legal declaration, and exposes `allowSeparateTypeImports` and `includeExports`. This PR ports the official categorization/mergeability analysis and both options through the existing typed rule-options transport, per #401.

Closes #401

## Scope

- **Go rule** (`packages/lint/linthost/rules_no_duplicate_imports.go`, extracted from `rules_core_extra.go`): declarations are categorized as default / named / namespace / export-all / side-effect the way the official `getImportExportType` reads ESTree specifiers (first named-or-namespace specifier wins, empty clauses are side-effect). Mergeability mirrors `isImportExportCanBeMerged`, including the ESLint 9.30.1 correction that a type-only default cannot merge with type-only named bindings. `allowSeparateTypeImports` exempts pairs whose clause-level type-ness differs (inline `import { type Foo }` stays a value declaration); `includeExports` records and reports `export … from` declarations with the four official message pairings (import / import-as-export / export / export-as-import). Module names are compared trimmed, mirroring `source.value.trim()`; specifier-less exports and empty module strings are skipped. Options decode via the existing `Context.DecodeOptions`.
- **Typed options surface**: new `ITtscLintCoreNoDuplicateImportsRuleOptions` (`ITtscLintCoreRuleOptions.ts`), the rule key upgraded to `TtscLintRuleOptionsSetting<…>` in `ITtscLintCoreRules`, registered in `ITtscLintRuleOptionsMap`, exported from the structures index. No transport changes.
- **Tests**: 27 focused Go cases under `packages/lint/test/rules/imports-modules/` (one case per file) covering every categorization branch with a discriminating pairing, both operand orders of each mergeability guard, option on/off twins, all four includeExports messages (including two findings on one declaration), module trimming, empty specifiers, local exports, and a misspelled option key at the engine layer. The corpus fixture `tests/test-lint/src/cases/no-duplicate-imports.ts` now pins the default-option contract (mergeable value pair and value+type pair report; named-vs-namespace and type-default-vs-type-named do not), with the Go corpus twin kept in sync. `test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts` gains the happy-path tuple plus `@ts-expect-error` rejection of a typo'd option key and a non-boolean option value.
- **Docs**: `packages/lint/README.md` bullet and `website/src/content/docs/lint/rules/core.mdx` section now state the mergeability contract and document both options with defaults, instead of claiming every repeated module string is a duplicate.

## Deviations from the issue

None semantically. Two mechanical notes:

- The rule moved from `rules_core_extra.go` into its own `rules_no_duplicate_imports.go`, matching the single-rule-file precedent (`rules_no_restricted_imports.go`) now that it carries options and ~250 lines.
- Diagnostic messages adopt the official wording shape (`` `m` import is duplicated. `` etc.) so the four pairings are distinguishable; the previous single message could not express them.

## Deferred

The issue's release requirement (ship in the next `@ttsc/lint` patch and verify from the packed package) is a maintainer release step outside this PR.

## Test plan

CI: `pnpm test:go` runs the new Go rule cases and the synced corpus twin; `pnpm test:features` (lint suite) re-runs the corpus fixture end-to-end through the native engine; `test:typecheck` enforces the `@ts-expect-error` typing branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EbHEnVZ3wSozmQ639Uz99