### PR TITLE
fix(lint): make no-var inspect loop-header declaration lists

### DIFF
--- a/packages/lint/linthost/rules_var.go
+++ b/packages/lint/linthost/rules_var.go
@@ -347,8 +347,9 @@ func isFunctionCaptureBoundary(node *shimast.Node) bool {
   return false
 }
 
-// isDeclaredInsideWithStatement reports whether the statement has a
-// WithStatement ancestor below the nearest function boundary. Under `var`
+// isDeclaredInsideWithStatement reports whether the declaration (a
+// statement's or loop header's `var` list) has a WithStatement ancestor
+// below the nearest function boundary. Under `var`
 // the binding hoists past the with body to the function scope, so a
 // same-name property on the with target intercepts every reference; under
 // `let` the binding lives inside the body's block and shadows the with

--- a/packages/lint/linthost/rules_var.go
+++ b/packages/lint/linthost/rules_var.go
@@ -4,42 +4,66 @@ import shimast "github.com/microsoft/typescript-go/shim/ast"
 
 // noVar: ban `var` declarations. ESLint canonical:
 // https://eslint.org/docs/latest/rules/no-var
+//
+// The rule registers KindVariableDeclarationList, not KindVariableStatement:
+// the grammar puts a `var` declaration list either inside a VariableStatement
+// or directly in a `for` / `for...in` / `for...of` header, and only the list
+// node is common to all four shapes. Registering the statement kind alone
+// left every loop-header `var` invisible (issue #409). Each list node occurs
+// exactly once in the tree, so every shape reports exactly once and no shape
+// can double-report.
 type noVar struct{}
 
-func (noVar) Name() string           { return "no-var" }
-func (noVar) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindVariableStatement} }
+func (noVar) Name() string { return "no-var" }
+func (noVar) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindVariableDeclarationList}
+}
 func (noVar) Check(ctx *Context, node *shimast.Node) {
-  stmt := node.AsVariableStatement()
-  if stmt == nil || stmt.DeclarationList == nil {
+  if node.AsVariableDeclarationList() == nil || !shimast.IsVar(node) {
     return
   }
   if ctx.File != nil && ctx.File.IsDeclarationFile {
     return
   }
-  if node.ModifierFlags()&shimast.ModifierFlagsAmbient != 0 {
+  owner := node.Parent
+  ownedByStatement := owner != nil && owner.Kind == shimast.KindVariableStatement
+  // `declare var x` describes an existing binding instead of creating one;
+  // like ESLint, the rule leaves ambient declarations alone. Only a
+  // VariableStatement can carry the modifier — loop headers cannot be
+  // ambient outside declaration files, which returned above.
+  if ownedByStatement && owner.ModifierFlags()&shimast.ModifierFlagsAmbient != 0 {
     return
   }
-  if shimast.IsVar(stmt.DeclarationList) {
-    const message = "Unexpected var, use let or const instead."
-    start := keywordStart(ctx.File, stmt.DeclarationList, "var")
-    if start >= 0 && isNoVarAutoFixSafe(ctx, node) {
-      ctx.ReportRangeFix(
-        start,
-        start+len("var"),
-        message,
-        TextEdit{Pos: start, End: start + len("var"), Text: "let"},
-      )
-      return
-    }
-    ctx.Report(node, message)
+  const message = "Unexpected var, use let or const instead."
+  start := keywordStart(ctx.File, node, "var")
+  if start >= 0 && isNoVarAutoFixSafe(ctx, node) {
+    ctx.ReportRangeFix(
+      start,
+      start+len("var"),
+      message,
+      TextEdit{Pos: start, End: start + len("var"), Text: "let"},
+    )
+    return
   }
+  if ownedByStatement {
+    // Fixless statement reports keep the whole-statement range (through the
+    // terminating semicolon) the rule has always rendered.
+    ctx.Report(owner, message)
+    return
+  }
+  // A loop-header list has no wrapping statement of its own; the list node
+  // (`var i = 0`) is the natural diagnostic range.
+  ctx.Report(node, message)
 }
 
-// isNoVarAutoFixSafe reports whether rewriting a `var` statement's keyword to
-// `let` is safe using only AST-local information (no scope/data-flow engine).
-// It mirrors the conservative posture of isEqeqeqAutoFixSafe: over-declining
-// is fine, corrupting source is not. Blindly turning every `var` into `let`
-// breaks two real shapes that `var` hoisting tolerates but `let` does not:
+// isNoVarAutoFixSafe reports whether rewriting a `var` declaration list's
+// keyword to `let` is safe using only AST-local information (no
+// scope/data-flow engine). `listNode` is the KindVariableDeclarationList the
+// rule visited; its parent is a VariableStatement or a `for` / `for...in` /
+// `for...of` header. It mirrors the conservative posture of
+// isEqeqeqAutoFixSafe: over-declining is fine, corrupting source is not.
+// Blindly turning every `var` into `let` breaks two real shapes that `var`
+// hoisting tolerates but `let` does not:
 //   - redeclaration (`var x=1; var x=2;`) → two `let x` is a SyntaxError;
 //   - use-before-declaration (a binding referenced above its own line) →
 //     `let` makes that reference a TDZ ReferenceError.
@@ -60,33 +84,39 @@ func (noVar) Check(ctx *Context, node *shimast.Node) {
 //     destructure siblings, for-header var, …). It over-declines harmless
 //     cross-scope same-name bindings, which never corrupts.
 //  2. No use-before-declaration / TDZ. The declared name is not referenced as
-//     a VALUE before the statement's Pos(). A non-reference occurrence of the
+//     a VALUE before the list's Pos(). A non-reference occurrence of the
 //     same text — a member name (`o.x`), an object-literal key (`{x:1}`), a
 //     statement label (`x:`), or a type reference (`: x`) — binds no value and
 //     must not force a decline; isValueReferenceIdentifier classifies these.
 //  3. No block-scope escape. `var` is function/global-scoped while `let` is
 //     block-scoped, so a `var` declared inside a block and read after the
 //     block (`if (c) { var x = 1; } log(x);`) would stop compiling under
-//     `let`. The statement's parent must be a position where a lexical
-//     declaration is legal AND which forms the `let`'s block scope — a Block
-//     (plain, function-body, loop-body, …), a ModuleBlock, a switch
-//     Case/DefaultClause, or the SourceFile — and every value reference to
-//     the name must lie inside that parent's [Pos, End) span. A non-scope
-//     parent (`if (c) var x = 1;` — a single-statement body, where `let` is a
-//     SyntaxError outright) declines unconditionally. Given precondition 1
-//     (one binding file-wide), positional containment is exact: no other
-//     binding can shadow the name, so a reference outside the span really
-//     does resolve to this binding. Using the CaseClause (not the whole
-//     switch CaseBlock) as the scope over-declines cross-case references,
-//     which under `let` would flip from `undefined` reads to runtime TDZ
-//     throws — declining is the safe side. Mirrors ESLint no-var's
-//     isUsedFromOutsideOf.
-//  4. No loop-closure capture. When the statement sits inside a loop and the
-//     name is referenced from a function or arrow nested within that loop
-//     (`for (const k of keys) { var last = k; fns.push(() => last); }`),
-//     every closure shares ONE `var` binding but would capture a FRESH
-//     per-iteration `let` binding — the rewrite silently changes runtime
-//     results. Mirrors ESLint no-var's isReferencedInClosure loop check.
+//     `let`. For a statement list the statement's parent must be a position
+//     where a lexical declaration is legal AND which forms the `let`'s block
+//     scope — a Block (plain, function-body, loop-body, …), a ModuleBlock, a
+//     switch Case/DefaultClause, or the SourceFile — and every value
+//     reference to the name must lie inside that parent's [Pos, End) span. A
+//     non-scope parent (`if (c) var x = 1;` — a single-statement body, where
+//     `let` is a SyntaxError outright) declines unconditionally. For a
+//     loop-header list the loop statement itself is the scope: a header
+//     `let` is always grammatically legal and scopes to the whole loop
+//     (header plus body), so references must stay inside the loop's span
+//     (`for (var i = 0; …) {}` followed by `log(i);` declines). Given
+//     precondition 1 (one binding file-wide), positional containment is
+//     exact: no other binding can shadow the name, so a reference outside
+//     the span really does resolve to this binding. Using the CaseClause
+//     (not the whole switch CaseBlock) as the scope over-declines cross-case
+//     references, which under `let` would flip from `undefined` reads to
+//     runtime TDZ throws — declining is the safe side. Mirrors ESLint
+//     no-var's isUsedFromOutsideOf.
+//  4. No loop-closure capture. When the declaration sits inside a loop — a
+//     statement in a loop body OR the loop's own header — and the name is
+//     referenced from a function or arrow nested within that loop
+//     (`for (const k of keys) { var last = k; fns.push(() => last); }`,
+//     `for (var i = 0; i < n; i++) { fns.push(() => i); }`), every closure
+//     shares ONE `var` binding but would capture a FRESH per-iteration `let`
+//     binding — the rewrite silently changes runtime results. Mirrors ESLint
+//     no-var's isReferencedInClosure loop check.
 //  5. Not declared under a `with` statement. `var` hoists PAST the with body
 //     to the function scope, so references inside the body resolve through
 //     the with object first (`o.x` shadows the var when present); `let`
@@ -95,28 +125,43 @@ func (noVar) Check(ctx *Context, node *shimast.Node) {
 //     any var with a WithStatement ancestor below the nearest function
 //     boundary declines.
 //
-// The var statement being fixed must itself be a single plain identifier
+// Two loop-header-only grammar/TDZ hazards also decline:
+//   - a `for...in` / `for...of` declarator with an initializer (Annex B
+//     tolerates `for (var i = 0 in o)`; `for (let i = 0 in o)` is a
+//     SyntaxError), and
+//   - a value reference to the name inside the `for...in` / `for...of` head
+//     expression (`for (var x of x)` reads the hoisted undefined `var`;
+//     under `let` the head expression evaluates inside the binding's TDZ
+//     and throws a ReferenceError).
+//
+// The var list being fixed must itself be a single plain identifier
 // declarator so the keyword rewrite has a simple `let x` rename target; a
-// destructuring var (`var {a}=o`) or a multi-binding list is declined here
-// even though its names might each bind only once.
-func isNoVarAutoFixSafe(ctx *Context, node *shimast.Node) bool {
+// destructuring var (`var {a}=o`, `for (var [a] of …)`) or a multi-binding
+// list is declined here even though its names might each bind only once.
+func isNoVarAutoFixSafe(ctx *Context, listNode *shimast.Node) bool {
   if ctx == nil || ctx.File == nil {
     return false
   }
-  // Precondition: the var being fixed is a single plain identifier declarator.
-  // variableStatementBindingNames returns plain identifier names only, so a
-  // destructuring declarator yields zero names; requiring exactly one name AND
-  // exactly one VariableDeclaration node rejects both multi-binding lists and
-  // any destructured (or destructured-sibling) declarator.
-  names := variableStatementBindingNames(node)
-  if len(names) != 1 {
+  owner := listNode.Parent
+  if owner == nil {
     return false
   }
-  if list := node.AsVariableStatement().DeclarationList.AsVariableDeclarationList(); list == nil ||
-    list.Declarations == nil || len(list.Declarations.Nodes) != 1 {
+  // Precondition: the var being fixed is a single plain identifier
+  // declarator. identifierText returns "" for a destructuring pattern, so
+  // requiring exactly one VariableDeclaration node AND a non-empty plain
+  // name rejects both multi-binding lists and destructured declarators.
+  list := listNode.AsVariableDeclarationList()
+  if list == nil || list.Declarations == nil || len(list.Declarations.Nodes) != 1 {
     return false
   }
-  target := names[0]
+  decl := list.Declarations.Nodes[0].AsVariableDeclaration()
+  if decl == nil {
+    return false
+  }
+  target := identifierText(decl.Name())
+  if target == "" {
+    return false
+  }
 
   // A name `var` tolerates but `let` cannot redeclare: `let let = 1;` is a
   // SyntaxError everywhere, and `let static = 1;` is one in strict mode
@@ -126,13 +171,33 @@ func isNoVarAutoFixSafe(ctx *Context, node *shimast.Node) bool {
     return false
   }
 
-  // Precondition 3 setup: the statement's parent must both allow a lexical
-  // declaration and act as the `let`'s block scope. Any other parent kind is
-  // a single-statement body (`if (c) var x = 1;`, `while (c) var x = 1;`,
-  // `label: var x = 1;`, `with (o) var x = 1;`) where `let` is a plain
-  // SyntaxError, so the fix declines before any reference is examined.
-  scopeNode := node.Parent
-  if scopeNode == nil || !isBlockScopeContainer(scopeNode.Kind) {
+  // Precondition 3 setup: resolve the node that will delimit the rewritten
+  // `let` binding's block scope, per owner shape.
+  var scopeNode *shimast.Node
+  switch owner.Kind {
+  case shimast.KindVariableStatement:
+    // The statement's parent must both allow a lexical declaration and act
+    // as the `let`'s block scope. Any other parent kind is a
+    // single-statement body (`if (c) var x = 1;`, `while (c) var x = 1;`,
+    // `label: var x = 1;`, `with (o) var x = 1;`) where `let` is a plain
+    // SyntaxError, so the fix declines before any reference is examined.
+    scopeNode = owner.Parent
+    if scopeNode == nil || !isBlockScopeContainer(scopeNode.Kind) {
+      return false
+    }
+  case shimast.KindForStatement:
+    scopeNode = owner
+  case shimast.KindForInStatement, shimast.KindForOfStatement:
+    // Annex B parses `for (var i = 0 in o)` in sloppy scripts; the same
+    // header with `let` is a SyntaxError everywhere, so any initializer on
+    // a for-in/for-of declarator declines outright.
+    if decl.Initializer != nil {
+      return false
+    }
+    scopeNode = owner
+  default:
+    // A declaration list can only be owned by the four shapes above; an
+    // unrecognized owner keeps the diagnostic but never offers a rewrite.
     return false
   }
   scopeStart, scopeEnd := scopeNode.Pos(), scopeNode.End()
@@ -140,27 +205,36 @@ func isNoVarAutoFixSafe(ctx *Context, node *shimast.Node) bool {
   // Precondition 5: a `var` declared under a `with` statement resolves its
   // references through the with object; the block-scoped `let` would shadow
   // that object instead, so the rewrite declines outright.
-  if isDeclaredInsideWithStatement(node) {
+  if isDeclaredInsideWithStatement(listNode) {
     return false
   }
 
-  // Precondition 4 setup: the outermost loop enclosing the statement without
-  // an intervening function boundary. nil when the statement is not
-  // loop-local, which disables the closure-capture check.
-  enclosingLoop := enclosingLoopWithinFunction(node)
+  // Precondition 4 setup: the outermost loop enclosing the declaration
+  // without an intervening function boundary. A loop-header list's first
+  // ancestor IS its loop, so header declarations always run the
+  // closure-capture check. nil when the declaration is not loop-local,
+  // which disables the check.
+  enclosingLoop := enclosingLoopWithinFunction(listNode)
 
-  declPos := node.Pos()
+  declPos := listNode.Pos()
   // The single declarator's initializer subtree. A value reference to `target`
   // inside this range is a self-reference that runs while `target` is still in
   // its temporal dead zone under `let` (`var x = typeof x;`, `var x = x;`,
   // `var x = (() => x)();`), so it must also force a decline even though its
-  // Pos() is AFTER the statement's start. initStart/initEnd are -1 when the
+  // Pos() is AFTER the list's start. initStart/initEnd are -1 when the
   // declarator has no initializer, which disables the range check.
   initStart, initEnd := -1, -1
-  if list := node.AsVariableStatement().DeclarationList.AsVariableDeclarationList(); list != nil &&
-    list.Declarations != nil && len(list.Declarations.Nodes) == 1 {
-    if decl := list.Declarations.Nodes[0].AsVariableDeclaration(); decl != nil && decl.Initializer != nil {
-      initStart, initEnd = decl.Initializer.Pos(), decl.Initializer.End()
+  if decl.Initializer != nil {
+    initStart, initEnd = decl.Initializer.Pos(), decl.Initializer.End()
+  }
+  // The for-in/for-of head expression evaluates while a `let` loop binding
+  // is still in its TDZ, so a self-reference there (`for (var x of x)`)
+  // must decline exactly like an initializer self-reference. -1 for the
+  // other owner shapes, which have no head expression.
+  exprStart, exprEnd := -1, -1
+  if owner.Kind == shimast.KindForInStatement || owner.Kind == shimast.KindForOfStatement {
+    if stmt := owner.AsForInOrOfStatement(); stmt != nil && stmt.Expression != nil {
+      exprStart, exprEnd = stmt.Expression.Pos(), stmt.Expression.End()
     }
   }
   bindingCount := 0
@@ -178,18 +252,22 @@ func isNoVarAutoFixSafe(ctx *Context, node *shimast.Node) bool {
     }
     // TDZ: a value reference to `target` turns into a ReferenceError under
     // `let` when it executes while `target` is still in its temporal dead
-    // zone. Two cases decline:
-    //   - a reference BEFORE the var's own position (`log(x); var x = 1;`);
+    // zone. Three cases decline:
+    //   - a reference BEFORE the list's own position (`log(x); var x = 1;`);
     //   - a self-reference WITHIN the declarator's own initializer range
     //     (`var x = typeof x;`). Conservatively, any value reference inside
     //     the initializer declines — including a deferred read in a nested
     //     closure (`var f = () => f;`) that is actually safe — because the
     //     AST-local gate does not track whether that closure runs during
-    //     initialization. Over-declining never corrupts source.
+    //     initialization. Over-declining never corrupts source;
+    //   - a self-reference within a for-in/for-of head expression
+    //     (`for (var x of x)`), which evaluates inside the `let` TDZ.
     if child.Kind == shimast.KindIdentifier && identifierText(child) == target &&
       isValueReferenceIdentifier(child) {
       pos := child.Pos()
-      if pos < declPos || (initStart >= 0 && pos >= initStart && pos < initEnd) {
+      if pos < declPos ||
+        (initStart >= 0 && pos >= initStart && pos < initEnd) ||
+        (exprStart >= 0 && pos >= exprStart && pos < exprEnd) {
         referencedBefore = true
       }
       // Scope escape: a value reference outside the enclosing block-scope

--- a/packages/lint/test/engine/engine_dispatches_only_to_interested_rules_test.go
+++ b/packages/lint/test/engine/engine_dispatches_only_to_interested_rules_test.go
@@ -16,7 +16,7 @@ import (
 // unsupported node cast. This test uses two rules with non-overlapping kind sets on one
 // source file to confirm independent dispatch counts.
 //
-// 1. Build an engine with noVar (KindVariableStatement) and noDebugger (KindDebuggerStatement).
+// 1. Build an engine with noVar (KindVariableDeclarationList) and noDebugger (KindDebuggerStatement).
 // 2. Parse a file with two var declarations and one debugger statement.
 // 3. Assert three total findings split 2 and 1 across the two rules.
 func TestEngineDispatchesOnlyToInterestedRules(t *testing.T) {

--- a/packages/lint/test/fix/fix_no_var_replaces_for_header_binding_test.go
+++ b/packages/lint/test/fix/fix_no_var_replaces_for_header_binding_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarReplacesForHeaderBinding verifies no-var rewrites a safe
+// `for (var i = …)` header to `let`.
+//
+// Loop-header `var` lists reach the rule through KindVariableDeclarationList
+// (issue #409). A header binding that is unique file-wide, referenced only
+// inside the loop's own span, and never captured by a closure behaves
+// identically under `let` (the per-iteration copy carries body mutations
+// forward exactly like the shared `var`), so the keyword rewrite must fire.
+//
+// 1. Parse a `for` statement declaring `var i` and reading it directly.
+// 2. Apply the no-var finding's text edit through the disk-backed fixer.
+// 3. Assert only the `var` keyword changed to `let`.
+func TestFixNoVarReplacesForHeaderBinding(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-var",
+    "for (var i = 0; i < 3; i += 1) {\n  JSON.stringify(i);\n}\n",
+    "for (let i = 0; i < 3; i += 1) {\n  JSON.stringify(i);\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_replaces_for_in_header_binding_test.go
+++ b/packages/lint/test/fix/fix_no_var_replaces_for_in_header_binding_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarReplacesForInHeaderBinding verifies no-var rewrites a safe
+// `for (var key in …)` header to `let`.
+//
+// A `for...in` header `var` with no initializer, no reference in the head
+// expression, and no closure capture assigns each key to a fresh `let`
+// binding with the same observable sequence as the shared `var` binding, so
+// the rewrite must fire (issue #409).
+//
+//  1. Parse a `for...in` statement declaring `var key` and reading it in the
+//     body.
+//  2. Apply the no-var finding's text edit through the disk-backed fixer.
+//  3. Assert only the `var` keyword changed to `let`.
+func TestFixNoVarReplacesForInHeaderBinding(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-var",
+    "for (var key in { a: 1 }) {\n  JSON.stringify(key);\n}\n",
+    "for (let key in { a: 1 }) {\n  JSON.stringify(key);\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_replaces_for_of_header_binding_test.go
+++ b/packages/lint/test/fix/fix_no_var_replaces_for_of_header_binding_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarReplacesForOfHeaderBinding verifies no-var rewrites a safe
+// `for (var item of …)` header to `let`.
+//
+// A `for...of` header `var` with no initializer, no reference in the head
+// expression, and no closure capture receives each element in a fresh `let`
+// binding with the same observable sequence as the shared `var` binding, so
+// the rewrite must fire (issue #409).
+//
+//  1. Parse a `for...of` statement declaring `var item` and reading it in the
+//     body.
+//  2. Apply the no-var finding's text edit through the disk-backed fixer.
+//  3. Assert only the `var` keyword changed to `let`.
+func TestFixNoVarReplacesForOfHeaderBinding(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-var",
+    "for (var item of [1, 2]) {\n  JSON.stringify(item);\n}\n",
+    "for (let item of [1, 2]) {\n  JSON.stringify(item);\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_for_header_closure_capture_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_for_header_closure_capture_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsForHeaderClosureCapture verifies no-var reports but does
+// not rewrite a `for (var i = …)` header captured by a closure created
+// inside the loop.
+//
+// Negative twin of the safe `for`-header rewrite: under `var` every
+// iteration's closure shares ONE binding (all read the final value 2);
+// under `let` each iteration captures a FRESH binding (0, then 1). The
+// classic setTimeout-in-a-loop shape — the keyword rewrite would silently
+// change runtime results, so the gate must decline while the diagnostic
+// still fires (issue #409).
+//
+// 1. Parse a `for` header declaring `var i` whose body pushes `() => i`.
+// 2. Run the no-var fixer through the disk-backed applier.
+// 3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsForHeaderClosureCapture(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "const fns = [];\nfor (var i = 0; i < 2; i += 1) {\n  fns.push(() => i);\n}\nJSON.stringify(fns.length);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_for_header_multi_declarator_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_for_header_multi_declarator_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsForHeaderMultiDeclarator verifies no-var reports once but
+// does not rewrite a multi-declarator `for (var i = 0, limit = 3; …)` header.
+//
+// A declaration list shares one keyword across all of its declarators, so
+// the token-scoped rewrite would re-scope every binding at once; the gate
+// only reasons about a single plain identifier declarator and must decline
+// the compound header while still emitting exactly one diagnostic for the
+// one list (issue #409).
+//
+// 1. Parse a `for` header declaring `var i = 0, limit = 3`.
+// 2. Run the no-var fixer through the disk-backed applier.
+// 3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsForHeaderMultiDeclarator(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "for (var i = 0, limit = 3; i < limit; i += 1) {\n  JSON.stringify(i);\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_for_header_use_after_loop_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_for_header_use_after_loop_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsForHeaderUseAfterLoop verifies no-var reports but does
+// not rewrite a `for (var i = …)` header whose binding is read after the
+// loop.
+//
+// A header `var` hoists to the enclosing function/global scope, so
+// `JSON.stringify(i)` after the loop reads the final counter; a header
+// `let` scopes to the loop statement and the same read stops compiling.
+// The scope-containment gate must treat the loop's own span as the `let`
+// boundary and decline, keeping the fixless diagnostic (issue #409).
+//
+// 1. Parse a `for` header declaring `var i`, then read `i` after the loop.
+// 2. Run the no-var fixer through the disk-backed applier.
+// 3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsForHeaderUseAfterLoop(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "for (var i = 0; i < 3; i += 1) {\n  JSON.stringify(i);\n}\nJSON.stringify(i);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_for_in_annex_b_initializer_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_for_in_annex_b_initializer_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsForInAnnexBInitializer verifies no-var reports but does
+// not rewrite an Annex-B `for (var i = 0 in …)` header.
+//
+// Annex B tolerates an initializer on a `for...in` declarator with `var`;
+// the identical header with `let` is a SyntaxError in every mode. The
+// keyword rewrite would therefore turn parseable (if legacy) source into a
+// file that no longer compiles, so the initializer check must decline while
+// the diagnostic still fires (issue #409).
+//
+// 1. Parse a `for...in` header whose `var i` declarator carries `= 0`.
+// 2. Run the no-var fixer through the disk-backed applier.
+// 3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsForInAnnexBInitializer(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "for (var i = 0 in { a: 1 }) {\n  JSON.stringify(i);\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_for_in_header_expression_self_reference_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_for_in_header_expression_self_reference_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsForInHeaderExpressionSelfReference verifies no-var
+// reports but does not rewrite `for (var looped in looped)`.
+//
+// The `for...in` head expression evaluates before the first key assignment:
+// with `var` it enumerates the hoisted binding's `undefined` (zero
+// iterations, no throw), but a header `let` is still in its temporal dead
+// zone there, so the same read becomes a runtime ReferenceError. The
+// head-expression TDZ range must decline the fix while the diagnostic still
+// fires (issue #409).
+//
+// 1. Parse a `for...in` header declaring `var looped` enumerating `looped`.
+// 2. Run the no-var fixer through the disk-backed applier.
+// 3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsForInHeaderExpressionSelfReference(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "for (var looped in looped) {\n  JSON.stringify(looped);\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_for_of_destructuring_header_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_for_of_destructuring_header_test.go
@@ -1,0 +1,22 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsForOfDestructuringHeader verifies no-var reports but does
+// not rewrite a destructuring `for (var [a, b] of …)` header.
+//
+// The fix gate requires a single plain identifier declarator so the keyword
+// rewrite has a simple `let x` rename target; a destructuring header binds
+// several leaves whose safety the AST-local gate does not model, so it must
+// stay a fixless diagnostic rather than gamble on the rewrite (issue #409).
+//
+// 1. Parse a `for...of` header destructuring `var [a, b]`.
+// 2. Run the no-var fixer through the disk-backed applier.
+// 3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsForOfDestructuringHeader(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "for (var [a, b] of [[1, 2]]) {\n  JSON.stringify(a + b);\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_for_of_header_closure_capture_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_for_of_header_closure_capture_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsForOfHeaderClosureCapture verifies no-var reports but
+// does not rewrite a `for (var item of …)` header captured by a closure
+// created inside the loop.
+//
+// Negative twin of the safe `for...of`-header rewrite: the loop protocol
+// assigns every element to the SAME `var` binding, so closures made inside
+// the loop all read the last element; a `let` header gives each closure its
+// own per-iteration binding. The rewrite would change runtime results, so
+// the gate must decline while the diagnostic still fires (issue #409).
+//
+//  1. Parse a `for...of` header declaring `var item` whose body pushes
+//     `() => item`.
+//  2. Run the no-var fixer through the disk-backed applier.
+//  3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsForOfHeaderClosureCapture(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "const fns = [];\nfor (var item of [1, 2]) {\n  fns.push(() => item);\n}\nJSON.stringify(fns.length);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_for_of_header_expression_self_reference_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_for_of_header_expression_self_reference_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsForOfHeaderExpressionSelfReference verifies no-var
+// reports but does not rewrite `for (var chain of [chain])`.
+//
+// The `for...of` head expression evaluates BEFORE the first assignment to
+// the loop variable: with `var` it reads the hoisted binding's `undefined`,
+// but a header `let` is still in its temporal dead zone there, so the same
+// read becomes a runtime ReferenceError. The head-expression TDZ range must
+// decline the fix while the diagnostic still fires (issue #409).
+//
+// 1. Parse a `for...of` header declaring `var chain` iterating `[chain]`.
+// 2. Run the no-var fixer through the disk-backed applier.
+// 3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsForOfHeaderExpressionSelfReference(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "for (var chain of [chain]) {\n  JSON.stringify(chain);\n}\n",
+  )
+}

--- a/packages/lint/test/fix/fix_no_var_skips_use_before_for_header_test.go
+++ b/packages/lint/test/fix/fix_no_var_skips_use_before_for_header_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFixNoVarSkipsUseBeforeForHeader verifies no-var reports but does not
+// rewrite a `for (var i = …)` header whose binding is read before the loop.
+//
+// The hoisted `var` makes the earlier read a defined `undefined`; a header
+// `let` would turn it into a TDZ ReferenceError (and the read also sits
+// outside the loop span that bounds the `let`). The
+// use-before-declaration gate must decline for headers exactly as it does
+// for statement declarations, keeping the fixless diagnostic (issue #409).
+//
+// 1. Parse a read of `i` followed by a `for` header declaring `var i`.
+// 2. Run the no-var fixer through the disk-backed applier.
+// 3. Assert at least one finding fired but zero fixes were applied.
+func TestFixNoVarSkipsUseBeforeForHeader(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-var",
+    "JSON.stringify(i);\nfor (var i = 0; i < 3; i += 1) {\n  JSON.stringify(i);\n}\n",
+  )
+}

--- a/packages/lint/test/rules/variables-assignments/no_var_loop_headers_test.go
+++ b/packages/lint/test/rules/variables-assignments/no_var_loop_headers_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestRuleCorpusNoVarLoopHeaders verifies the lint rule corpus fixture
+// no-var-loop-headers.ts.
+//
+// Loop-header `var` lists (`for`, `for...in`, `for...of`) are
+// VariableDeclarationList nodes owned by the loop statement, not
+// VariableStatement nodes, so a rule registered on the statement kind alone
+// never saw them (issue #409). This case pins one diagnostic per loop form
+// and — via the corpus helper's exact-match contract — zero diagnostics for
+// the `let`/`const` header negative twins below them.
+//
+// 1. Load the annotated TypeScript fixture source embedded below.
+// 2. Enable the rule severities declared by its // expect: comments.
+// 3. Assert the native Engine reports exactly the annotated diagnostics.
+func TestRuleCorpusNoVarLoopHeaders(t *testing.T) {
+  assertRuleCorpusCase(
+    t,
+    "no-var-loop-headers.ts",
+    "// expect: no-var error\nfor (var index = 0; index < 1; index += 1) {\n  JSON.stringify(index);\n}\n\n// expect: no-var error\nfor (var key in { value: 1 }) {\n  JSON.stringify(key);\n}\n\n// expect: no-var error\nfor (var value of [1]) {\n  JSON.stringify(value);\n}\n\nfor (let safeIndex = 0; safeIndex < 1; safeIndex += 1) {\n  JSON.stringify(safeIndex);\n}\n\nfor (const safeKey in { value: 1 }) {\n  JSON.stringify(safeKey);\n}\n\nfor (const safeValue of [1]) {\n  JSON.stringify(safeValue);\n}\n",
+  )
+}

--- a/packages/lint/test/rules/variables-assignments/no_var_skips_ambient_declare_var_test.go
+++ b/packages/lint/test/rules/variables-assignments/no_var_skips_ambient_declare_var_test.go
@@ -1,0 +1,28 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestNoVarSkipsAmbientDeclareVar verifies `declare var` statements in a
+// regular .ts file do not trip the noVar rule.
+//
+// An ambient `declare var` describes an existing global binding rather than
+// creating one, so ESLint-parity noVar leaves it alone. The guard reads the
+// Ambient modifier off the owning VariableStatement; after the rule moved
+// its dispatch from KindVariableStatement to KindVariableDeclarationList
+// (issue #409) the modifier lives on the list's PARENT, so this pins that
+// the refactored owner lookup still finds it.
+//
+// 1. Parse a non-declaration source containing `declare var`.
+// 2. Run noVar over the file.
+// 3. Assert no finding is emitted.
+func TestNoVarSkipsAmbientDeclareVar(t *testing.T) {
+  file := parseTS(t, "declare var ambient: string;\nJSON.stringify(typeof ambient);\n")
+  findings := NewEngine(RuleConfig{"no-var": SeverityError}).Run([]*shimast.SourceFile{file}, nil)
+  if len(findings) != 0 {
+    t.Fatalf("noVar reported ambient declare var: %d findings", len(findings))
+  }
+}

--- a/packages/lint/test/rules/variables-assignments/no_var_skips_using_declarations_test.go
+++ b/packages/lint/test/rules/variables-assignments/no_var_skips_using_declarations_test.go
@@ -1,0 +1,39 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestNoVarSkipsUsingDeclarations verifies `using` and `await using`
+// declaration lists never trip the noVar rule.
+//
+// noVar decides by GetCombinedNodeFlags: a list is `var` only when every
+// block-scoped flag bit (Let | Const | Using) is clear. Registering
+// KindVariableDeclarationList made the rule see EVERY list — statements and
+// `for...of` headers alike — so this negative twin pins that the new
+// dispatch surface still excludes the resource-management forms instead of
+// reporting everything it now visits.
+//
+//  1. Parse a source with `using` and `await using` statements plus a
+//     `for (using … of …)` header.
+//  2. Run noVar over the file.
+//  3. Assert no finding is emitted.
+func TestNoVarSkipsUsingDeclarations(t *testing.T) {
+  file := parseTS(
+    t,
+    "async function run(): Promise<void> {\n"+
+      "  using handle = { [Symbol.dispose]() {} };\n"+
+      "  await using stream = { async [Symbol.asyncDispose]() {} };\n"+
+      "  for (using item of [{ [Symbol.dispose]() {} }]) {\n"+
+      "    JSON.stringify(item);\n"+
+      "  }\n"+
+      "  JSON.stringify([handle, stream]);\n"+
+      "}\n",
+  )
+  findings := NewEngine(RuleConfig{"no-var": SeverityError}).Run([]*shimast.SourceFile{file}, nil)
+  if len(findings) != 0 {
+    t.Fatalf("noVar reported using declarations: %d findings", len(findings))
+  }
+}

--- a/tests/test-lint/src/cases/no-var-loop-headers.ts
+++ b/tests/test-lint/src/cases/no-var-loop-headers.ts
@@ -1,0 +1,26 @@
+// expect: no-var error
+for (var index = 0; index < 1; index += 1) {
+  JSON.stringify(index);
+}
+
+// expect: no-var error
+for (var key in { value: 1 }) {
+  JSON.stringify(key);
+}
+
+// expect: no-var error
+for (var value of [1]) {
+  JSON.stringify(value);
+}
+
+for (let safeIndex = 0; safeIndex < 1; safeIndex += 1) {
+  JSON.stringify(safeIndex);
+}
+
+for (const safeKey in { value: 1 }) {
+  JSON.stringify(safeKey);
+}
+
+for (const safeValue of [1]) {
+  JSON.stringify(safeValue);
+}

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -2394,13 +2394,20 @@ Reject `var` declarations.
 
 Use `let` for mutable bindings and `const` for immutable ones. Autofixable to `let`.
 
-The fix only fires when the rewrite cannot change behavior, mirroring ESLint's `no-var` fix conditions: the name binds exactly once in the file, is never read before the declaration or inside its own initializer, every reference stays inside the declaring block scope (a `var` declared in a block but read after it would stop compiling as `let`), a loop-local `var` is not captured by a function or arrow created inside the loop (those closures share one `var` binding but would capture a fresh per-iteration `let` binding), and the declaration does not sit under a `with` statement. Anything else reports without a fix.
+Every `var` declaration list reports, whether it appears as a statement or directly in a `for`, `for...in`, or `for...of` header.
+
+The fix only fires when the rewrite cannot change behavior, mirroring ESLint's `no-var` fix conditions: the name binds exactly once in the file, is never read before the declaration or inside its own initializer, every reference stays inside the declaring block scope (a `var` declared in a block but read after it would stop compiling as `let`; a loop-header `var` read after its loop likewise), a loop `var` — declared in the body or in the header itself — is not captured by a function or arrow created inside the loop (those closures share one `var` binding but would capture a fresh per-iteration `let` binding), and the declaration does not sit under a `with` statement. A `for...in`/`for...of` header additionally declines when its declarator carries an Annex-B initializer (`for (var i = 0 in o)`, a SyntaxError under `let`) or when the head expression reads the loop variable (`for (var x of x)`, a TDZ ReferenceError under `let`). Anything else reports without a fix.
 
 Example:
 
 ```ts
 // reports: no-var (error)
 var legacy = 1;
+
+// reports: no-var (error)
+for (var index = 0; index < 1; index += 1) {
+  JSON.stringify(index);
+}
 ```
 
 <a id="rule-no-with"></a>


### PR DESCRIPTION
## Intent

`no-var` registered only `KindVariableStatement`, so `var` declaration lists appearing directly in `for`, `for...in`, and `for...of` headers never reached `Check` — all three forms passed with exit 0 under `"no-var": "error"`. ESLint's `no-var` reports every `var` declaration regardless of position (https://eslint.org/docs/latest/rules/no-var). Closes #409.

## Scope

- **Dispatch**: the rule now registers `KindVariableDeclarationList` — the one node shape common to all four grammar positions (statement, `for`, `for...in`, `for...of` headers). Each list occurs exactly once in the tree, so every shape reports exactly once and duplicates are structurally impossible. No source-text scanning, no per-shape special cases.
- **Detection vs fix stay separate obligations**: every non-ambient runtime `var` list reports; the `let` rewrite is offered only when the existing conservative safety gate proves it behavior-preserving.
- **Safety gate generalized per owner shape**:
  - statement lists keep the exact prior analysis (block-scope-container parent, scope-span containment, file-wide single binding, TDZ/use-before, loop-closure capture, `with` ancestor, `let`/`static` names, single plain-identifier declarator);
  - loop-header lists use the loop statement itself as the `let` scope (header `let` is always grammatically legal; references outside the loop span decline — a header `var` read after its loop hoists, a header `let` does not);
  - a loop-header list's first ancestor is its own loop, so the existing closure-capture check naturally declines the classic `for (var i …) { fns.push(() => i) }` shape — shared `var` binding vs fresh per-iteration `let` bindings;
  - two header-only declines added: an Annex-B `for...in` declarator initializer (`for (var i = 0 in o)` parses; the `let` form is a SyntaxError in every mode) and a head-expression self-reference (`for (var x of x)` reads the hoisted `undefined`; under `let` the head expression evaluates inside the binding's TDZ and throws).
- **Diagnostic anchors preserved**: fixable reports keep the `var`-keyword range; fixless statement reports keep the whole-statement range they always had; fixless header reports anchor on the header list (`var i = 0`).
- **Ambient policy unchanged**: declaration files skip as before (engine-level dispatch policy plus the rule's own guard), and the `declare` modifier is read off the owning `VariableStatement` — the same node the old code checked.

## Deviations from the issue

None of substance. The issue offered "register the loop kinds or `VariableDeclarationList`"; I chose the list kind because it makes single-report-per-list a structural property instead of a bookkeeping discipline across four registration kinds. `using` / `await using` negative controls are pinned at the engine level (parse-only Go test) rather than in the e2e fixture because a real `using` fixture needs disposable values and lib plumbing that would add typecheck noise without adding lint coverage; the `IsVar` check (`NodeFlagsBlockScoped` clear) is what excludes them and that is what the test pins.

## Test plan

- `tests/test-lint/src/cases/no-var-loop-headers.ts` — new corpus fixture: real `ttsc --noEmit` run must exit nonzero with exactly one `no-var` finding per loop form, and the `let`/`const` header negative twins must stay silent (exact-match corpus contract).
- Go corpus twin `no_var_loop_headers_test.go` mirrors the fixture through the native Engine.
- Engine negatives: `no_var_skips_using_declarations_test.go` (`using`, `await using`, `for (using … of …)`), `no_var_skips_ambient_declare_var_test.go` (`declare var` in a `.ts`), existing `.d.ts` skip test.
- Fixer positives: safe `for` / `for...in` / `for...of` header rewrites to `let`.
- Fixer negative twins (report fires, zero edits): header closure capture (`for` and `for...of`), use after loop, use before loop header, destructuring header, multi-declarator header, Annex-B `for...in` initializer, head-expression self-reference (`for...in` and `for...of`).
- All 38 pre-existing `no-var` fix/detection tests exercise the refactored statement path unchanged; `fix_no_var_skips_for_header_redeclaration_test.go` now also exercises the header report path.
- Docs: `website/src/content/docs/lint/rules/core.mdx` `no-var` section updated with the loop-header contract and fix conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EbHEnVZ3wSozmQ639Uz99