### PR TITLE
fix(ttsc): distinguish released source-plugin locks from abandoned locks

### DIFF
--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -291,10 +291,18 @@ function compileSourcePlugin(opts: {
  *
  * The lock is an atomic `mkdir` on `<cacheDir>.lock`. The winner builds and
  * publishes the binary; every loser polls for that binary to appear and reuses
- * it. A loser that waits past `PLUGIN_BUILD_LOCK_STEAL_MS` (the builder crashed
- * without publishing) steals the abandoned lock and retries. This is the same
- * shape as `withBuildLock` in the runtime hooks, keyed on the plugin binary's
- * existence instead of a JSON meta marker.
+ * it. A loser distinguishes two ways the lock can stop blocking it:
+ *
+ * - `released`: the holder removed the lock itself — it published, or its build
+ *   threw and its `finally` freed the key. The loser simply retries the
+ *   ordinary acquisition; nothing is stale and nothing is reported.
+ * - `abandoned`: the lock still exists but its owner is provably dead, it is an
+ *   old metadata-less legacy lock, or the wait budget
+ *   (`PLUGIN_BUILD_LOCK_STEAL_MS`) expired. Only then does the loser report and
+ *   steal the lock before retrying.
+ *
+ * This is the same shape as `withBuildLock` in the runtime hooks, keyed on the
+ * plugin binary's existence instead of a JSON meta marker.
  *
  * Correctness still rests on `publishBuiltBinary`'s atomic rename: the lock is
  * an optimisation to avoid duplicate work, not the only guard against a corrupt
@@ -337,13 +345,19 @@ function buildUnderPluginLock(
         lockInfo,
         timeoutMs: PLUGIN_BUILD_LOCK_STEAL_MS,
       });
-      if (waited.published) {
+      if (waited.outcome === "published") {
         touchCacheEntry(cacheDir);
         return binaryPath;
       }
-      reportPluginLockSteal(lockDir, binaryPath, lockInfo, waited.reason);
-      // Builder appears to have crashed: steal the abandoned lock and retry.
-      fs.rmSync(lockDir, { force: true, recursive: true });
+      if (waited.outcome === "abandoned") {
+        // Builder appears to have crashed: steal the abandoned lock and retry.
+        reportPluginLockSteal(lockDir, binaryPath, lockInfo, waited.reason);
+        fs.rmSync(lockDir, { force: true, recursive: true });
+      }
+      // "released" needs no repair: the holder freed the key normally (its
+      // build published or failed), so retry the ordinary atomic acquisition.
+      // Reporting a steal or force-removing the path here would misclassify a
+      // routine handoff as abandonment (issue #421).
       continue;
     }
     try {
@@ -359,8 +373,30 @@ function buildUnderPluginLock(
   }
 }
 
-/** Poll for the locked builder to publish its binary, up to `timeoutMs`. */
-function waitForPluginBinary(opts: {
+/**
+ * Outcome of one waiting session on another process's plugin build lock.
+ *
+ * - `published`: the binary exists and can be reused.
+ * - `released`: the observed lock no longer exists and no binary appeared — the
+ *   holder freed the key normally, so the caller should retry the ordinary
+ *   atomic acquisition without reporting or removing anything.
+ * - `abandoned`: the lock still exists but is provably stale (dead owner, old
+ *   legacy lock) or the wait budget expired; the caller may report and steal
+ *   it.
+ *
+ * Exported for unit tests.
+ */
+export type PluginBinaryWaitResult =
+  | { outcome: "published" }
+  | { outcome: "released" }
+  | { outcome: "abandoned"; reason: string };
+
+/**
+ * Poll for the locked builder to publish its binary, up to `timeoutMs`.
+ *
+ * Exported for unit tests.
+ */
+export function waitForPluginBinary(opts: {
   binaryPath: string;
   lockDir: string;
   lockInfo: {
@@ -369,24 +405,30 @@ function waitForPluginBinary(opts: {
     quiet: boolean;
   };
   timeoutMs: number;
-}): { published: boolean; reason?: string } {
+}): PluginBinaryWaitResult {
   const startedAt = Date.now();
   let nextStatusAt = startedAt + PLUGIN_BUILD_LOCK_STATUS_MS;
   for (;;) {
     if (fs.existsSync(opts.binaryPath)) {
-      return { published: true };
+      return { outcome: "published" };
     }
     const now = Date.now();
-    const lockStatus = inspectPluginBuildLock(opts.lockDir, now);
-    if (lockStatus.abandoned) {
-      return {
-        published: false,
-        reason: lockStatus.reason,
-      };
+    const lock = inspectPluginBuildLock(opts.lockDir, now);
+    if (lock.state === "released") {
+      // The holder removed the lock between the binary check above and this
+      // observation. That is a normal release, not abandonment: prefer the
+      // binary when it landed inside that window, otherwise hand the free key
+      // back to the caller.
+      return fs.existsSync(opts.binaryPath)
+        ? { outcome: "published" }
+        : { outcome: "released" };
+    }
+    if (lock.state === "abandoned") {
+      return { outcome: "abandoned", reason: lock.reason };
     }
     if (now - startedAt > opts.timeoutMs) {
       return {
-        published: false,
+        outcome: "abandoned",
         reason: `timed out after ${formatDuration(now - startedAt)}`,
       };
     }
@@ -396,7 +438,7 @@ function waitForPluginBinary(opts: {
         elapsedMs: now - startedAt,
         lockDir: opts.lockDir,
         lockInfo: opts.lockInfo,
-        owner: lockStatus.owner,
+        owner: lock.owner,
       });
       nextStatusAt = now + PLUGIN_BUILD_LOCK_STATUS_MS;
     }
@@ -424,42 +466,63 @@ function writePluginBuildLockOwner(lockDir: string): void {
   }
 }
 
-function inspectPluginBuildLock(
+/**
+ * One observation of a plugin build lock directory's state.
+ *
+ * - `active`: the lock exists and its owner is alive (or cannot be disproven:
+ *   another host, no metadata but young). Keep waiting.
+ * - `abandoned`: the lock still exists and the evidence says nobody will ever
+ *   release it — a same-host owner that is no longer running, or an old
+ *   metadata-less legacy lock. Stealing is justified.
+ * - `released`: the lock directory no longer exists. The holder released it
+ *   normally (its build published or failed), so this is a routine handoff —
+ *   never an infinitely old abandoned lock (issue #421).
+ *
+ * Exported for unit tests.
+ */
+export type PluginBuildLockObservation =
+  | { state: "active"; owner: string }
+  | { state: "abandoned"; reason: string }
+  | { state: "released" };
+
+/**
+ * Classify the current state of a plugin build lock directory.
+ *
+ * Exported for unit tests.
+ */
+export function inspectPluginBuildLock(
   lockDir: string,
   now: number,
-): {
-  abandoned: boolean;
-  owner: string;
-  reason?: string;
-} {
+): PluginBuildLockObservation {
   const owner = readPluginBuildLockOwner(lockDir);
   if (owner !== null) {
     const label = describePluginBuildLockOwner(owner);
     if (isLocalHostName(owner.hostname) && !isProcessAlive(owner.pid)) {
       return {
-        abandoned: true,
-        owner: label,
+        state: "abandoned",
         reason: `${label} is no longer running`,
       };
     }
     return {
-      abandoned: false,
+      state: "active",
       owner: label,
     };
   }
 
   const ageMs = pluginBuildLockAgeMs(lockDir, now);
+  if (ageMs === null) {
+    return { state: "released" };
+  }
   if (ageMs > PLUGIN_BUILD_LOCK_LEGACY_STALE_MS) {
     return {
-      abandoned: true,
-      owner: `legacy lock with no ${PLUGIN_BUILD_LOCK_OWNER_FILE}`,
+      state: "abandoned",
       reason:
         `legacy lock has no ${PLUGIN_BUILD_LOCK_OWNER_FILE} and is ` +
         `${formatDuration(ageMs)} old`,
     };
   }
   return {
-    abandoned: false,
+    state: "active",
     owner: `legacy lock with no ${PLUGIN_BUILD_LOCK_OWNER_FILE}`,
   };
 }
@@ -490,11 +553,23 @@ function readPluginBuildLockOwner(
   }
 }
 
-function pluginBuildLockAgeMs(lockDir: string, now: number): number {
+/**
+ * Age of the lock directory, or `null` when it no longer exists (the holder
+ * released it between the caller's checks). "Missing" is a first-class
+ * observation, never encoded as a numeric age: the previous
+ * `Number.POSITIVE_INFINITY` encoding made a just-released lock look like an
+ * infinitely old abandoned legacy lock (issue #421).
+ *
+ * A stat failure that does not prove absence (e.g. `EPERM`) clamps to age 0:
+ * the lock is treated as fresh so a waiter never steals on ambiguous evidence,
+ * while the caller's wait budget still bounds the stall.
+ */
+function pluginBuildLockAgeMs(lockDir: string, now: number): number | null {
   try {
     return Math.max(0, now - fs.statSync(lockDir).mtimeMs);
-  } catch {
-    return Number.POSITIVE_INFINITY;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === "ENOENT" || code === "ENOTDIR" ? null : 0;
   }
 }
 
@@ -547,17 +622,29 @@ function reportPluginLockSteal(
     pluginName: string;
     quiet: boolean;
   },
-  reason: string | undefined,
+  reason: string,
 ): void {
   if (lockInfo.quiet) return;
-  const suffix = reason === undefined ? "" : ` (${reason})`;
   process.stderr.write(
     `ttsc: reclaiming abandoned ${lockInfo.label} "${lockInfo.pluginName}" ` +
-      `cache lock at ${lockDir}; binary=${binaryPath}${suffix}\n`,
+      `cache lock at ${lockDir}; binary=${binaryPath} (${reason})\n`,
   );
 }
 
-function formatDuration(ms: number): string {
+/**
+ * Render a millisecond duration for lock diagnostics (`137ms`, `42s`, `9m 3s`).
+ *
+ * Total over every number: no caller produces a non-finite duration anymore
+ * (the lock state machine reports "released" instead of an Infinity age), but
+ * as defense in depth a non-finite input renders as `an unknown time` so no
+ * public diagnostic can ever print `Infinitym NaNs` again (issue #421).
+ *
+ * Exported for unit tests.
+ */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms)) {
+    return "an unknown time";
+  }
   if (ms < 1_000) {
     return `${Math.max(0, Math.round(ms))}ms`;
   }

--- a/tests/test-ttsc/src/internal/source-build.ts
+++ b/tests/test-ttsc/src/internal/source-build.ts
@@ -5,7 +5,9 @@
  * executable that satisfies the commands ttsc issues during plugin compilation
  * without running a real Go toolchain.
  */
+import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
+import child_process from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -14,9 +16,12 @@ import {
   autoQuoteGoModToken,
   buildSourcePlugin,
   computeCacheKey,
+  formatDuration,
   formatGoWorkPath,
+  inspectPluginBuildLock,
   resolvePluginCacheRoot,
   resolveSourceBuildCachePaths,
+  waitForPluginBinary,
 } from "../../../../packages/ttsc/lib/plugin/internal/buildSourcePlugin.js";
 
 /**
@@ -29,6 +34,19 @@ import {
  * Pass `{ executable: false }` to produce a non-executable POSIX file, which
  * lets tests verify that `buildSourcePlugin` fixes permissions before running
  * the toolchain.
+ *
+ * Environment hooks let lock-coordination tests sequence concurrent builders
+ * with explicit barriers instead of sleeps:
+ *
+ * - `FAKE_GO_INVOCATION_LOG`: append each invocation's arguments as one line to
+ *   this file.
+ * - `FAKE_GO_BUILD_BARRIER_FILE`: write this file when `go build` starts, so an
+ *   orchestrator can observe that the builder holds the lock and is inside its
+ *   build.
+ * - `FAKE_GO_BUILD_RELEASE_FILE`: block `go build` until this file exists
+ *   (bounded by a two-minute safety deadline).
+ * - `FAKE_GO_BUILD_EXIT_CODE`: exit `go build` with this status instead of
+ *   writing the output binary, simulating a failed compile.
  */
 function createFakeGoBinary(
   root: string,
@@ -41,6 +59,13 @@ function createFakeGoBinary(
       'const fs = require("node:fs");',
       'const path = require("node:path");',
       "const args = process.argv.slice(2);",
+      "if (process.env.FAKE_GO_INVOCATION_LOG) {",
+      "  fs.appendFileSync(",
+      "    process.env.FAKE_GO_INVOCATION_LOG,",
+      '    args.join(" ") + "\\n",',
+      '    "utf8",',
+      "  );",
+      "}",
       'if (args[0] === "version") {',
       '  console.log("go version fake");',
       "  process.exit(0);",
@@ -63,6 +88,27 @@ function createFakeGoBinary(
       'if (args[0] !== "build") {',
       '  console.error(`unexpected go command: ${args.join(" ")}`);',
       "  process.exit(1);",
+      "}",
+      "if (process.env.FAKE_GO_BUILD_BARRIER_FILE) {",
+      "  fs.writeFileSync(",
+      "    process.env.FAKE_GO_BUILD_BARRIER_FILE,",
+      '    "building\\n",',
+      '    "utf8",',
+      "  );",
+      "}",
+      "if (process.env.FAKE_GO_BUILD_RELEASE_FILE) {",
+      "  const releaseDeadline = Date.now() + 120000;",
+      "  while (!fs.existsSync(process.env.FAKE_GO_BUILD_RELEASE_FILE)) {",
+      "    if (Date.now() > releaseDeadline) {",
+      '      console.error("fake go: FAKE_GO_BUILD_RELEASE_FILE never appeared");',
+      "      process.exit(1);",
+      "    }",
+      "    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);",
+      "  }",
+      "}",
+      "if (process.env.FAKE_GO_BUILD_EXIT_CODE) {",
+      '  console.error("fake go: build failed as directed by FAKE_GO_BUILD_EXIT_CODE");',
+      "  process.exit(Number(process.env.FAKE_GO_BUILD_EXIT_CODE));",
       "}",
       "const required = [",
       '  "vendor/local/value.go",',
@@ -150,17 +196,142 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
+/** Captured output of one `buildSourcePlugin` child-process worker. */
+interface ISourcePluginWorkerResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Writes a CommonJS runner script that calls the workspace-built
+ * `buildSourcePlugin` with the given fixed inputs and returns the script's
+ * path. Lock-coordination tests spawn this script as a real holder and a real
+ * waiter process for the same cache key; per-role behavior is injected only
+ * through the `FAKE_GO_BUILD_*` environment hooks of `createFakeGoBinary`.
+ *
+ * The runner prints the built (or reused) binary path on stdout and exits 0; a
+ * build failure prints the error message on stderr and exits 1.
+ */
+function createSourcePluginWorkerScript(opts: {
+  cacheDir: string;
+  pluginName: string;
+  root: string;
+  source: string;
+}): string {
+  const libraryPath = path.join(
+    TestProject.WORKSPACE_ROOT,
+    "packages",
+    "ttsc",
+    "lib",
+    "plugin",
+    "internal",
+    "buildSourcePlugin.js",
+  );
+  const script = path.join(opts.root, "build-source-plugin-worker.cjs");
+  fs.writeFileSync(
+    script,
+    [
+      `const { buildSourcePlugin } = require(${JSON.stringify(libraryPath)});`,
+      "try {",
+      "  const binary = buildSourcePlugin({",
+      `    baseDir: ${JSON.stringify(opts.root)},`,
+      `    cacheDir: ${JSON.stringify(opts.cacheDir)},`,
+      "    overlayDirs: [],",
+      `    pluginName: ${JSON.stringify(opts.pluginName)},`,
+      "    quiet: false,",
+      `    source: ${JSON.stringify(opts.source)},`,
+      '    ttscVersion: "1.0.0",',
+      '    tsgoVersion: "7.0.0-dev",',
+      "  });",
+      '  process.stdout.write(binary + "\\n");',
+      "} catch (error) {",
+      "  process.stderr.write(",
+      '    String((error && error.message) || error) + "\\n",',
+      "  );",
+      "  process.exitCode = 1;",
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  return script;
+}
+
+/**
+ * Spawns one `buildSourcePlugin` worker (see
+ * {@link createSourcePluginWorkerScript}) and resolves when it exits. `env`
+ * entries overlay the inherited environment — pass the `FAKE_GO_BUILD_*` hooks
+ * there to script the worker's fake toolchain. A two-minute kill timeout bounds
+ * a wedged worker so a broken lock never hangs the suite.
+ */
+function spawnSourcePluginWorker(opts: {
+  env?: Record<string, string>;
+  goBinary: string;
+  script: string;
+}): Promise<ISourcePluginWorkerResult> {
+  return new Promise((resolve, reject) => {
+    const child = child_process.spawn(process.execPath, [opts.script], {
+      env: {
+        ...process.env,
+        TTSC_GO_BINARY: opts.goBinary,
+        ...opts.env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 120_000,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+/**
+ * Polls `predicate` every 25 ms until it holds, failing with `description`
+ * after `timeoutMs` (default one minute). This is observation of an explicit
+ * barrier another process definitely produces, not a timing assumption: the
+ * caller's correctness never depends on how long the wait took.
+ */
+async function waitForCondition(
+  predicate: () => boolean,
+  description: string,
+  timeoutMs = 60_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
 export {
   assert,
   autoQuoteGoModToken,
   buildSourcePlugin,
+  child_process,
   computeCacheKey,
   createFakeGoBinary,
+  createSourcePluginWorkerScript,
+  formatDuration,
   formatGoWorkPath,
   fs,
+  inspectPluginBuildLock,
   os,
   path,
   resolvePluginCacheRoot,
   resolveSourceBuildCachePaths,
   shellQuote,
+  spawnSourcePluginWorker,
+  waitForCondition,
+  waitForPluginBinary,
 };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_waiter_recovers_when_holder_fails_and_releases.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_waiter_recovers_when_holder_fails_and_releases.ts
@@ -1,0 +1,110 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  createFakeGoBinary,
+  createSourcePluginWorkerScript,
+  fs,
+  path,
+  spawnSourcePluginWorker,
+  waitForCondition,
+} from "../../internal/source-build";
+
+/**
+ * Verifies buildSourcePlugin waiter recovers when the holder fails and
+ * releases.
+ *
+ * End-to-end pin for issue #421: a holder whose `go build` throws releases the
+ * lock in its `finally`, and the waiting process then observes a lock that no
+ * longer exists. The old inspector classified that released lock as an
+ * infinitely old abandoned legacy lock and printed `reclaiming abandoned ...
+ * Infinitym NaNs old`. The waiter must instead treat the free key as a routine
+ * handoff: reacquire it, run the build itself, and publish the one usable
+ * binary. Sequencing uses explicit file barriers produced by the fake
+ * toolchain, never sleeps — every interleaving must satisfy the assertions.
+ *
+ * 1. Start a holder worker whose fake `go build` writes a barrier file, then
+ *    blocks until released, then exits non-zero.
+ * 2. After the barrier exists, start a waiter worker on the same cache key and
+ *    release the holder once the waiter's fake-go invocation log shows it
+ *    passed its pre-lock toolchain probes.
+ * 3. Assert the holder exits 1 without publishing while the waiter exits 0, runs
+ *    its own `go build`, and publishes the binary.
+ * 4. Assert the waiter's stderr never reports reclaiming an abandoned lock and
+ *    never contains the `Infinitym NaNs` malformation.
+ */
+export const test_buildsourceplugin_waiter_recovers_when_holder_fails_and_releases =
+  async () => {
+    const root = TestProject.tmpdir("ttsc-lock-handoff-");
+    const plugin = path.join(root, "plugin");
+    writePluginSource(plugin);
+    const fakeGo = createFakeGoBinary(root);
+    const script = createSourcePluginWorkerScript({
+      cacheDir: path.join(root, "cache"),
+      pluginName: "lock-release-race",
+      root,
+      source: plugin,
+    });
+
+    const holderBarrier = path.join(root, "holder-building.txt");
+    const holderRelease = path.join(root, "holder-release.txt");
+    const waiterLog = path.join(root, "waiter-go.log");
+
+    const holder = spawnSourcePluginWorker({
+      env: {
+        FAKE_GO_BUILD_BARRIER_FILE: holderBarrier,
+        FAKE_GO_BUILD_EXIT_CODE: "1",
+        FAKE_GO_BUILD_RELEASE_FILE: holderRelease,
+      },
+      goBinary: fakeGo,
+      script,
+    });
+    await waitForCondition(
+      () => fs.existsSync(holderBarrier),
+      "the holder to enter its go build while owning the lock",
+    );
+
+    const waiter = spawnSourcePluginWorker({
+      env: { FAKE_GO_INVOCATION_LOG: waiterLog },
+      goBinary: fakeGo,
+      script,
+    });
+    await waitForCondition(
+      () =>
+        fs.existsSync(waiterLog) &&
+        fs.readFileSync(waiterLog, "utf8").includes("env -json"),
+      "the waiter to finish its pre-lock toolchain probes",
+    );
+    fs.writeFileSync(holderRelease, "release\n", "utf8");
+
+    const [holderResult, waiterResult] = await Promise.all([holder, waiter]);
+
+    assert.equal(holderResult.status, 1, holderResult.stderr);
+    assert.match(holderResult.stderr, /go build" failed/);
+    assert.equal(waiterResult.status, 0, waiterResult.stderr);
+    const binary = waiterResult.stdout.trim();
+    assert.equal(fs.readFileSync(binary, "utf8"), "fake plugin binary\n");
+    assert.match(waiterResult.stderr, /building source plugin/);
+    assert.match(fs.readFileSync(waiterLog, "utf8"), /^build /m);
+    assert.doesNotMatch(waiterResult.stderr, /reclaiming abandoned/);
+    assert.doesNotMatch(waiterResult.stderr, /Infinitym|NaNs/);
+  };
+
+function writePluginSource(root: string): void {
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "go.mod"),
+    "module example.com/plugin\n\ngo 1.26\n",
+    "utf8",
+  );
+  fs.writeFileSync(path.join(root, "main.go"), "package main\n", "utf8");
+  for (const file of [
+    "vendor/local/value.go",
+    "lib/helper.go",
+    "dist/generated.go",
+    "build/generated.go",
+  ]) {
+    fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+    fs.writeFileSync(path.join(root, file), "package main\n", "utf8");
+  }
+}

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_waiter_reuses_binary_published_during_release.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_waiter_reuses_binary_published_during_release.ts
@@ -1,0 +1,106 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  createFakeGoBinary,
+  createSourcePluginWorkerScript,
+  fs,
+  path,
+  spawnSourcePluginWorker,
+  waitForCondition,
+} from "../../internal/source-build";
+
+/**
+ * Verifies buildSourcePlugin waiter reuses the binary a holder publishes as it
+ * releases.
+ *
+ * Companion pin for issue #421's success-side race: the holder publishes the
+ * binary and removes its lock while the waiter is between two observations.
+ * Whatever the interleaving — the waiter sees the binary directly, or first
+ * sees the released lock and re-checks — it must reuse the published binary,
+ * never rebuild it and never report the routine release as reclaiming an
+ * abandoned lock.
+ *
+ * 1. Start a holder worker whose fake `go build` writes a barrier file and blocks;
+ *    start a waiter on the same cache key once the barrier exists.
+ * 2. Release the holder after the waiter's fake-go invocation log shows it passed
+ *    its pre-lock toolchain probes; the holder publishes and exits 0.
+ * 3. Assert both workers exit 0 and print the same binary path.
+ * 4. Assert the waiter never ran `go build`, never printed the cold-build banner,
+ *    and never reported an abandoned lock.
+ */
+export const test_buildsourceplugin_waiter_reuses_binary_published_during_release =
+  async () => {
+    const root = TestProject.tmpdir("ttsc-lock-publish-");
+    const plugin = path.join(root, "plugin");
+    writePluginSource(plugin);
+    const fakeGo = createFakeGoBinary(root);
+    const script = createSourcePluginWorkerScript({
+      cacheDir: path.join(root, "cache"),
+      pluginName: "lock-publish-race",
+      root,
+      source: plugin,
+    });
+
+    const holderBarrier = path.join(root, "holder-building.txt");
+    const holderRelease = path.join(root, "holder-release.txt");
+    const waiterLog = path.join(root, "waiter-go.log");
+
+    const holder = spawnSourcePluginWorker({
+      env: {
+        FAKE_GO_BUILD_BARRIER_FILE: holderBarrier,
+        FAKE_GO_BUILD_RELEASE_FILE: holderRelease,
+      },
+      goBinary: fakeGo,
+      script,
+    });
+    await waitForCondition(
+      () => fs.existsSync(holderBarrier),
+      "the holder to enter its go build while owning the lock",
+    );
+
+    const waiter = spawnSourcePluginWorker({
+      env: { FAKE_GO_INVOCATION_LOG: waiterLog },
+      goBinary: fakeGo,
+      script,
+    });
+    await waitForCondition(
+      () =>
+        fs.existsSync(waiterLog) &&
+        fs.readFileSync(waiterLog, "utf8").includes("env -json"),
+      "the waiter to finish its pre-lock toolchain probes",
+    );
+    fs.writeFileSync(holderRelease, "release\n", "utf8");
+
+    const [holderResult, waiterResult] = await Promise.all([holder, waiter]);
+
+    assert.equal(holderResult.status, 0, holderResult.stderr);
+    assert.equal(waiterResult.status, 0, waiterResult.stderr);
+    const holderBinary = holderResult.stdout.trim();
+    const waiterBinary = waiterResult.stdout.trim();
+    assert.equal(waiterBinary, holderBinary);
+    assert.equal(fs.readFileSync(waiterBinary, "utf8"), "fake plugin binary\n");
+    assert.doesNotMatch(fs.readFileSync(waiterLog, "utf8"), /^build /m);
+    assert.doesNotMatch(waiterResult.stderr, /building source plugin/);
+    assert.doesNotMatch(waiterResult.stderr, /reclaiming abandoned/);
+    assert.doesNotMatch(waiterResult.stderr, /Infinitym|NaNs/);
+  };
+
+function writePluginSource(root: string): void {
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "go.mod"),
+    "module example.com/plugin\n\ngo 1.26\n",
+    "utf8",
+  );
+  fs.writeFileSync(path.join(root, "main.go"), "package main\n", "utf8");
+  for (const file of [
+    "vendor/local/value.go",
+    "lib/helper.go",
+    "dist/generated.go",
+    "build/generated.go",
+  ]) {
+    fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+    fs.writeFileSync(path.join(root, file), "package main\n", "utf8");
+  }
+}

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_formatduration_renders_nonfinite_input_without_nan_tokens.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_formatduration_renders_nonfinite_input_without_nan_tokens.ts
@@ -1,0 +1,37 @@
+import { assert, formatDuration } from "../../internal/source-build";
+
+/**
+ * Verifies formatDuration renders non-finite input without NaN tokens.
+ *
+ * Defense-in-depth twin of the #421 state-machine fix: the lock inspector no
+ * longer encodes "lock missing" as an Infinity age, but the formatter itself
+ * must also be total so no future caller can ever print the `Infinitym NaNs`
+ * malformation into a user-facing diagnostic again. The finite boundary cases
+ * pin the existing rendering so the guard cannot regress it.
+ *
+ * 1. Format `Infinity`, `-Infinity`, and `NaN`.
+ * 2. Assert each renders as the fixed "an unknown time" phrase with no
+ *    `Infinity`/`NaN` substring.
+ * 3. Assert the finite boundaries (0, sub-second, second, minute, negative) still
+ *    render exactly as before.
+ */
+export const test_formatduration_renders_nonfinite_input_without_nan_tokens =
+  () => {
+    for (const value of [
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      const rendered = formatDuration(value);
+      assert.equal(rendered, "an unknown time");
+      assert.doesNotMatch(rendered, /Infinity|NaN/);
+    }
+
+    assert.equal(formatDuration(0), "0ms");
+    assert.equal(formatDuration(-5), "0ms");
+    assert.equal(formatDuration(999), "999ms");
+    assert.equal(formatDuration(1_000), "1s");
+    assert.equal(formatDuration(59_999), "59s");
+    assert.equal(formatDuration(60_000), "1m 0s");
+    assert.equal(formatDuration(123_456), "2m 3s");
+  };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_keeps_fresh_legacy_lock_active.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_keeps_fresh_legacy_lock_active.ts
@@ -1,0 +1,36 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  inspectPluginBuildLock,
+  path,
+} from "../../internal/source-build";
+
+/**
+ * Verifies inspectPluginBuildLock keeps a fresh metadata-less lock active.
+ *
+ * Negative twin of both the `released` and the abandoned-legacy classifications
+ * in `buildSourcePlugin.ts::inspectPluginBuildLock`. A lock directory that
+ * exists but has no `owner.json` yet is the normal instant between a holder's
+ * `mkdir` and its owner write — treating it as released would race waiters into
+ * duplicate acquisition, and treating it as abandoned would steal a healthy
+ * holder's lock.
+ *
+ * 1. Create a lock directory with a current mtime and no `owner.json`.
+ * 2. Inspect it.
+ * 3. Assert the state is `active` with the legacy-lock owner label.
+ */
+export const test_inspectpluginbuildlock_keeps_fresh_legacy_lock_active =
+  () => {
+    const root = TestProject.tmpdir("ttsc-lock-observe-");
+    const lockDir = path.join(root, "entry.lock");
+    fs.mkdirSync(lockDir);
+
+    const observation = inspectPluginBuildLock(lockDir, Date.now());
+
+    assert.deepEqual(observation, {
+      state: "active",
+      owner: "legacy lock with no owner.json",
+    });
+  };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_keeps_live_local_owner_active.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_keeps_live_local_owner_active.ts
@@ -1,0 +1,43 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  inspectPluginBuildLock,
+  os,
+  path,
+} from "../../internal/source-build";
+
+/**
+ * Verifies inspectPluginBuildLock keeps a live same-host owner active.
+ *
+ * Negative twin of the dead-owner abandonment: a lock whose `owner.json` names
+ * a pid that is still running is a healthy builder mid-`go build`. Classifying
+ * it as abandoned (or released) would steal the lock out from under a live
+ * holder and launch a duplicate build of the same cache key.
+ *
+ * 1. Write a lock directory whose `owner.json` names this test process's own
+ *    (definitely live) pid on this host.
+ * 2. Inspect it.
+ * 3. Assert the state is `active` and the owner label names the pid.
+ */
+export const test_inspectpluginbuildlock_keeps_live_local_owner_active = () => {
+  const root = TestProject.tmpdir("ttsc-lock-observe-");
+  const lockDir = path.join(root, "entry.lock");
+  fs.mkdirSync(lockDir);
+  fs.writeFileSync(
+    path.join(lockDir, "owner.json"),
+    `${JSON.stringify({
+      hostname: os.hostname(),
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    })}\n`,
+    "utf8",
+  );
+
+  const observation = inspectPluginBuildLock(lockDir, Date.now());
+
+  assert.equal(observation.state, "active");
+  const owner = observation.state === "active" ? observation.owner : "";
+  assert.match(owner, new RegExp(`pid ${process.pid} on `));
+};

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_keeps_other_host_owner_active.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_keeps_other_host_owner_active.ts
@@ -1,0 +1,49 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  child_process,
+  fs,
+  inspectPluginBuildLock,
+  os,
+  path,
+} from "../../internal/source-build";
+
+/**
+ * Verifies inspectPluginBuildLock keeps an owner from another host active.
+ *
+ * Negative twin of the dead-owner abandonment along the hostname axis: pid
+ * liveness can only be probed on the local machine, so a lock owned by a
+ * different host must stay `active` even when that pid happens to be dead
+ * locally (a shared cache on a network filesystem). Only the wait budget may
+ * end that wait.
+ *
+ * 1. Take a locally dead pid from a completed child process.
+ * 2. Write a lock directory whose `owner.json` names that pid on a hostname that
+ *    is not this machine's.
+ * 3. Assert inspection reports `active`, not `abandoned`.
+ */
+export const test_inspectpluginbuildlock_keeps_other_host_owner_active = () => {
+  const root = TestProject.tmpdir("ttsc-lock-observe-");
+  const lockDir = path.join(root, "entry.lock");
+  fs.mkdirSync(lockDir);
+  const exited = child_process.spawnSync(process.execPath, ["-e", ""], {
+    windowsHide: true,
+  });
+  assert.equal(exited.status, 0);
+  fs.writeFileSync(
+    path.join(lockDir, "owner.json"),
+    `${JSON.stringify({
+      hostname: `${os.hostname()}-elsewhere`,
+      pid: exited.pid,
+      startedAt: new Date().toISOString(),
+    })}\n`,
+    "utf8",
+  );
+
+  const observation = inspectPluginBuildLock(lockDir, Date.now());
+
+  assert.equal(observation.state, "active");
+  const owner = observation.state === "active" ? observation.owner : "";
+  assert.match(owner, /-elsewhere/);
+};

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_reports_dead_local_owner_as_abandoned.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_reports_dead_local_owner_as_abandoned.ts
@@ -1,0 +1,52 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  child_process,
+  fs,
+  inspectPluginBuildLock,
+  os,
+  path,
+} from "../../internal/source-build";
+
+/**
+ * Verifies inspectPluginBuildLock reports a dead same-host owner as abandoned.
+ *
+ * Keeps the #341 dead-owner guarantee intact under the #421 rework: a lock
+ * whose `owner.json` names a same-host pid that is no longer running will never
+ * be released, so waiters must be allowed to steal it instead of stalling for
+ * the full wait budget.
+ *
+ * 1. Run a short-lived child process to completion and take its now-dead pid.
+ * 2. Write a lock directory whose `owner.json` names that pid on this host.
+ * 3. Assert inspection reports `abandoned` with a "no longer running" reason.
+ */
+export const test_inspectpluginbuildlock_reports_dead_local_owner_as_abandoned =
+  () => {
+    const root = TestProject.tmpdir("ttsc-lock-observe-");
+    const lockDir = path.join(root, "entry.lock");
+    fs.mkdirSync(lockDir);
+    const exited = child_process.spawnSync(process.execPath, ["-e", ""], {
+      windowsHide: true,
+    });
+    assert.equal(exited.status, 0);
+    const deadPid = exited.pid;
+    fs.writeFileSync(
+      path.join(lockDir, "owner.json"),
+      `${JSON.stringify({
+        hostname: os.hostname(),
+        pid: deadPid,
+        startedAt: new Date().toISOString(),
+      })}\n`,
+      "utf8",
+    );
+
+    const observation = inspectPluginBuildLock(lockDir, Date.now());
+
+    assert.equal(observation.state, "abandoned");
+    const reason = observation.state === "abandoned" ? observation.reason : "";
+    assert.match(
+      reason,
+      new RegExp(`pid ${deadPid} on .+ is no longer running`),
+    );
+  };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_reports_missing_lock_as_released.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_reports_missing_lock_as_released.ts
@@ -1,0 +1,32 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  inspectPluginBuildLock,
+  path,
+} from "../../internal/source-build";
+
+/**
+ * Verifies inspectPluginBuildLock reports a missing lock directory as released.
+ *
+ * Pins the issue #421 regression in
+ * `buildSourcePlugin.ts::inspectPluginBuildLock`. A holder's `finally` removes
+ * the lock the moment its build publishes or throws, so a waiter routinely
+ * observes the directory vanishing between two polls. The old code encoded the
+ * failed `statSync` as an Infinity age, classified the released lock as an
+ * infinitely old abandoned legacy lock, and printed `Infinitym NaNs old`.
+ * "Missing" must be the first-class `released` state, never an age.
+ *
+ * 1. Point inspection at a lock path that does not exist.
+ * 2. Assert the observation is exactly `{ state: "released" }` — not abandoned,
+ *    and carrying no fabricated owner or age.
+ */
+export const test_inspectpluginbuildlock_reports_missing_lock_as_released =
+  () => {
+    const root = TestProject.tmpdir("ttsc-lock-observe-");
+    const lockDir = path.join(root, "entry.lock");
+
+    const observation = inspectPluginBuildLock(lockDir, Date.now());
+
+    assert.deepEqual(observation, { state: "released" });
+  };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_reports_old_legacy_lock_abandoned_with_finite_age.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_reports_old_legacy_lock_abandoned_with_finite_age.ts
@@ -1,0 +1,39 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  inspectPluginBuildLock,
+  path,
+} from "../../internal/source-build";
+
+/**
+ * Verifies inspectPluginBuildLock reports an old legacy lock as abandoned with
+ * a finite age.
+ *
+ * Keeps the #341 stale-lock guarantee intact under the #421 rework: a lock
+ * directory that still exists, has no `owner.json`, and is older than the
+ * legacy staleness window must remain reclaimable, and its diagnostic must
+ * carry the real measured age — the `Infinitym NaNs` spelling belonged to the
+ * misclassified released lock, never to this branch.
+ *
+ * 1. Create a metadata-less lock directory and backdate its mtime by two minutes.
+ * 2. Inspect it.
+ * 3. Assert the state is `abandoned` and the reason names the legacy lock with a
+ *    finite `Nm Ns old` age containing no `Infinity`/`NaN` token.
+ */
+export const test_inspectpluginbuildlock_reports_old_legacy_lock_abandoned_with_finite_age =
+  () => {
+    const root = TestProject.tmpdir("ttsc-lock-observe-");
+    const lockDir = path.join(root, "entry.lock");
+    fs.mkdirSync(lockDir);
+    const old = new Date(Date.now() - 120_000);
+    fs.utimesSync(lockDir, old, old);
+
+    const observation = inspectPluginBuildLock(lockDir, Date.now());
+
+    assert.equal(observation.state, "abandoned");
+    const reason = observation.state === "abandoned" ? observation.reason : "";
+    assert.match(reason, /legacy lock has no owner\.json and is \dm \d+s old/);
+    assert.doesNotMatch(reason, /Infinity|NaN/);
+  };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_treats_corrupt_owner_as_legacy_lock.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_treats_corrupt_owner_as_legacy_lock.ts
@@ -1,0 +1,40 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  inspectPluginBuildLock,
+  path,
+} from "../../internal/source-build";
+
+/**
+ * Verifies inspectPluginBuildLock treats a corrupt owner file as a legacy lock,
+ * not a released one.
+ *
+ * Pins the boundary of the #421 `released` state: `released` requires the lock
+ * DIRECTORY to be gone, not merely the owner metadata to be unreadable. A
+ * present directory with an unparsable `owner.json` (a torn write, a crash
+ * mid-write) must fall back to the age-based legacy classification, so a
+ * still-held lock is never handed back to waiters as a free key.
+ *
+ * 1. Create a lock directory whose `owner.json` contains invalid JSON and backdate
+ *    the directory past the legacy staleness window.
+ * 2. Inspect it.
+ * 3. Assert the state is `abandoned` via the legacy-age reason — proving the
+ *    corrupt-owner path routed to the age check instead of `released`.
+ */
+export const test_inspectpluginbuildlock_treats_corrupt_owner_as_legacy_lock =
+  () => {
+    const root = TestProject.tmpdir("ttsc-lock-observe-");
+    const lockDir = path.join(root, "entry.lock");
+    fs.mkdirSync(lockDir);
+    fs.writeFileSync(path.join(lockDir, "owner.json"), "{not json", "utf8");
+    const old = new Date(Date.now() - 120_000);
+    fs.utimesSync(lockDir, old, old);
+
+    const observation = inspectPluginBuildLock(lockDir, Date.now());
+
+    assert.equal(observation.state, "abandoned");
+    const reason = observation.state === "abandoned" ? observation.reason : "";
+    assert.match(reason, /legacy lock has no owner\.json/);
+  };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_waitforpluginbinary_prefers_published_binary_over_released_lock.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_waitforpluginbinary_prefers_published_binary_over_released_lock.ts
@@ -1,0 +1,42 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  path,
+  waitForPluginBinary,
+} from "../../internal/source-build";
+
+/**
+ * Verifies waitForPluginBinary prefers a published binary over a released lock.
+ *
+ * Negative twin of the bare `released` outcome: when the holder published its
+ * binary and then removed the lock, the waiter must come back with `published`
+ * so the caller reuses the binary instead of looping into a redundant
+ * acquisition. `released` is reserved for the key being free AND unpublished.
+ *
+ * 1. Publish a binary file and leave no lock directory.
+ * 2. Call the wait loop.
+ * 3. Assert it returns `{ outcome: "published" }`.
+ */
+export const test_waitforpluginbinary_prefers_published_binary_over_released_lock =
+  () => {
+    const root = TestProject.tmpdir("ttsc-lock-wait-");
+    const cacheEntry = path.join(root, "entry");
+    fs.mkdirSync(cacheEntry, { recursive: true });
+    const binaryPath = path.join(cacheEntry, "plugin.exe");
+    fs.writeFileSync(binaryPath, "fake plugin binary\n", "utf8");
+
+    const result = waitForPluginBinary({
+      binaryPath,
+      lockDir: path.join(root, "entry.lock"),
+      lockInfo: {
+        label: "source plugin",
+        pluginName: "wait-test",
+        quiet: true,
+      },
+      timeoutMs: 600_000,
+    });
+
+    assert.deepEqual(result, { outcome: "published" });
+  };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_waitforpluginbinary_returns_released_when_lock_is_gone.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_waitforpluginbinary_returns_released_when_lock_is_gone.ts
@@ -1,0 +1,35 @@
+import { TestProject } from "@ttsc/testing";
+
+import { assert, path, waitForPluginBinary } from "../../internal/source-build";
+
+/**
+ * Verifies waitForPluginBinary returns `released` when the lock is gone and no
+ * binary exists.
+ *
+ * Pins the wait loop's dispatch for the issue #421 race: a waiter that lost the
+ * `mkdir` race inspects a lock the holder has since removed without publishing
+ * (its build failed). The loop must hand the free key back as `released`
+ * immediately — not report abandonment, not fabricate an Infinity age, and not
+ * burn the wait budget polling a lock that no longer exists.
+ *
+ * 1. Call the wait loop with a lock path and binary path that both do not exist.
+ * 2. Assert it returns `{ outcome: "released" }` without consuming the generous
+ *    timeout.
+ */
+export const test_waitforpluginbinary_returns_released_when_lock_is_gone =
+  () => {
+    const root = TestProject.tmpdir("ttsc-lock-wait-");
+
+    const result = waitForPluginBinary({
+      binaryPath: path.join(root, "entry", "plugin.exe"),
+      lockDir: path.join(root, "entry.lock"),
+      lockInfo: {
+        label: "source plugin",
+        pluginName: "wait-test",
+        quiet: true,
+      },
+      timeoutMs: 600_000,
+    });
+
+    assert.deepEqual(result, { outcome: "released" });
+  };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_waitforpluginbinary_times_out_on_live_owner_with_finite_duration.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_waitforpluginbinary_times_out_on_live_owner_with_finite_duration.ts
@@ -1,0 +1,58 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  os,
+  path,
+  waitForPluginBinary,
+} from "../../internal/source-build";
+
+/**
+ * Verifies waitForPluginBinary times out on a live owner with a finite
+ * duration.
+ *
+ * Pins the wait-budget escape hatch that survives the #421 rework: a lock held
+ * by a live process that never publishes must eventually surface as `abandoned`
+ * via the timeout, and the timeout reason must print a real measured duration —
+ * the release/abandon distinction may never disable the bound, or a wedged
+ * holder would hang every waiter forever.
+ *
+ * 1. Create a lock owned by this (live) process so inspection stays `active`.
+ * 2. Call the wait loop with a zero timeout budget.
+ * 3. Assert it returns `abandoned` with a `timed out after <finite>` reason
+ *    containing no `Infinity`/`NaN` token.
+ */
+export const test_waitforpluginbinary_times_out_on_live_owner_with_finite_duration =
+  () => {
+    const root = TestProject.tmpdir("ttsc-lock-wait-");
+    const lockDir = path.join(root, "entry.lock");
+    fs.mkdirSync(lockDir);
+    fs.writeFileSync(
+      path.join(lockDir, "owner.json"),
+      `${JSON.stringify({
+        hostname: os.hostname(),
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+      })}\n`,
+      "utf8",
+    );
+
+    const result = waitForPluginBinary({
+      binaryPath: path.join(root, "entry", "plugin.exe"),
+      lockDir,
+      lockInfo: {
+        label: "source plugin",
+        pluginName: "wait-test",
+        quiet: true,
+      },
+      timeoutMs: 0,
+    });
+
+    assert.equal(result.outcome, "abandoned");
+    const reason = result.outcome === "abandoned" ? result.reason : "";
+    // The elapsed poll normally reads ~50ms, but a loaded CI runner can stall
+    // past the 1s/1m formatting boundaries, so accept any finite rendering.
+    assert.match(reason, /^timed out after (\d+ms|\d+s|\d+m \d+s)$/);
+    assert.doesNotMatch(reason, /Infinity|NaN/);
+  };


### PR DESCRIPTION
## Intent

Fix the issue #421 lock-lifecycle defect: a source-plugin cache lock that a live holder has just **released** (its build published, or threw and its `finally` freed the key) could be classified as an infinitely old **abandoned** legacy lock, producing the false and malformed diagnostic

```text
ttsc: reclaiming abandoned source plugin "..." cache lock at ...; binary=... (legacy lock has no owner.json and is Infinitym NaNs old)
```

I verified every claim in the issue against `packages/ttsc/src/plugin/internal/buildSourcePlugin.ts` on current `master` before designing: `pluginBuildLockAgeMs()` encoded a failed `statSync` as `Number.POSITIVE_INFINITY`, `inspectPluginBuildLock()` compared that against the 30s legacy-staleness window, and `formatDuration(Infinity)` rendered `Infinitym NaNs`. The report is accurate, and the fix follows the issue's recommended shape.

## Lock-lifecycle semantics shipped

`inspectPluginBuildLock()` now returns a discriminated observation instead of encoding "stat failed" as a numeric age:

- `active` — owner alive, owner on another host, or metadata-less but younger than the legacy window: keep waiting.
- `abandoned` — the lock **still exists** and a same-host owner is dead, or a metadata-less lock is older than the legacy window: report and steal (unchanged #341 behavior).
- `released` — the lock directory **no longer exists** (`ENOENT`/`ENOTDIR`): a routine handoff.

`waitForPluginBinary()` maps that to `published` / `released` / `abandoned` (the wait-budget timeout stays in the `abandoned` bucket). On `released` it re-checks the binary — a holder that published-then-released is reused — and otherwise `buildUnderPluginLock()` retries the ordinary atomic `mkdir` acquisition with **no** steal report and **no** force-remove of a path that is not there.

Details:

- A stat failure that does not prove absence (e.g. `EPERM` on a Windows delete-pending directory) clamps to age 0: the waiter never steals on ambiguous evidence, and the wait budget still bounds the stall. The old code stole instantly on such errors.
- `formatDuration()` is now total: non-finite input renders as `an unknown time` (defense in depth — no caller can produce a non-finite duration anymore).
- Holder crash reclamation, dead-owner detection, legacy-lock reclamation, wait-budget timeout, atomic publication, and the one-builder-per-key coordination are all unchanged; `reportPluginLockSteal()`'s `reason` became required since every abandonment now carries one.

## Scope and deviations

- The issue suggested the wait loop re-check the binary after a `released` observation. Implemented inside `waitForPluginBinary()`; the caller's loop top re-checks again before re-acquiring, so both windows are covered.
- The sibling dependency-build lock in `runtimeHooks.ts::withBuildLock` does **not** share this defect (it has no owner metadata, no age inspection, and no diagnostics — a released lock there just makes the waiter re-read the meta marker), so it is deliberately untouched.
- No website docs change: no page documents the lock diagnostics or the wait/steal mechanism, and the user-visible contract (one builder per key, waiters reuse) is unchanged.

## Test plan

All tests live beside the existing stale-lock coverage in `tests/test-ttsc/src/native-plugins/source-plugin/` (one case per file), and none uses a sleep as synchronization — cross-process ordering is driven by explicit file barriers implemented in the shared fake Go toolchain.

Deterministic unit pins on the exported-for-tests internals:

- `inspectPluginBuildLock`: missing lock → `released` (the regression pin); fresh metadata-less lock → `active` (negative twin); old metadata-less lock → `abandoned` with a finite age; dead same-host owner → `abandoned`; live same-host owner → `active` (negative twin); dead pid on another host → `active` (hostname-axis negative twin); corrupt `owner.json` with the directory still present → legacy classification, not `released` (pins that `released` requires directory absence).
- `waitForPluginBinary`: lock gone + no binary → `released` immediately; lock gone + binary present → `published` (binary preference); live owner + zero budget → `abandoned` via `timed out after <finite>`.
- `formatDuration`: `Infinity`/`-Infinity`/`NaN` → `an unknown time`, plus the finite boundary renderings (0, 999ms, 1s, 59s, 1m 0s, 2m 3s).

Cross-process e2e (real `buildSourcePlugin` holder + waiter child processes, fake Go toolchain, barrier files):

- **Holder fails and releases**: holder blocks inside `go build`, waiter starts and passes its pre-lock toolchain probes, holder is released and exits 1; assert the waiter takes over, runs exactly one build, publishes the one usable binary, and its stderr never contains `reclaiming abandoned` or the `Infinitym NaNs` malformation. On pre-fix master this run prints both.
- **Holder publishes and releases**: same barriers, holder succeeds; assert both workers exit 0 with the same binary path and the waiter never ran `go build`, never printed the cold-build banner, and never reported abandonment. The assertions hold under every interleaving of the release with the waiter's observations.

Existing stale-legacy-lock tests (`test_buildsourceplugin_reclaims_stale_legacy_plugin_lock`, `test_ttsc_reclaims_stale_legacy_source_plugin_lock_e2e`) continue to pin the #341 reclamation behavior.

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EbHEnVZ3wSozmQ639Uz99
