### PR TITLE
fix(graph): make the question the user's words, not the model's

### DIFF
--- a/packages/graph/src/structures/ITtscGraphApplication.ts
+++ b/packages/graph/src/structures/ITtscGraphApplication.ts
@@ -82,17 +82,17 @@ export interface ITtscGraphApplication {
    * request:
    *
    * - `tour`: architecture, the runtime flow from the public API to the code that
-   *   does the work, nearby paths, and the tests to read — a whole orientation in
-   *   one call
+   *   does the work, nearby paths, and the tests to read — a whole orientation
+   *   in one call
    * - `trace`: what a symbol calls, what calls it, or the path from A to B
    * - `details`: signatures, members, and what implements an interface
    * - `lookup`: where a named symbol is declared
    * - `entrypoints`: where execution starts, when the entry is unknown
    * - `overview`: the project's layers and folder structure
    *
-   * Every result is the checker's own resolution, audited before it is returned,
-   * so nothing in it needs verifying. Read a file for what the graph does not
-   * carry: a function's body, the text inside a span.
+   * Every result is the checker's own resolution, audited before it is
+   * returned, so nothing in it needs verifying. Read a file for what the graph
+   * does not carry: a function's body, the text inside a span.
    *
    * @param props Reasoning plus one graph request
    * @returns Matching `result` union member
@@ -105,7 +105,13 @@ export interface ITtscGraphApplication {
 export namespace ITtscGraphApplication {
   /** Draft, review, then submit exactly one graph request or escape. */
   export interface IProps {
-    /** The code question being considered. */
+    /**
+     * The code question, in the user's own words.
+     *
+     * Cut a long message down to the sentences that state the ask, but keep
+     * their terms: the graph ranks against these words, so a rewrite ranks a
+     * different answer.
+     */
     question: string;
 
     /** The smallest request that could answer, and why. */

--- a/packages/graph/src/structures/ITtscGraphTour.ts
+++ b/packages/graph/src/structures/ITtscGraphTour.ts
@@ -36,7 +36,13 @@ export namespace ITtscGraphTour {
     /** Discriminator for code-tour indexing. */
     type: "tour";
 
-    /** The user's natural code-tour question. */
+    /**
+     * The tour question, in the user's own words — the same ask as `question`.
+     *
+     * Its terms rank the tour: a name sharing one is promoted, a name sharing
+     * none demoted. Trim what the user wrote, but neither reword it nor add
+     * terms of your own.
+     */
     query: string;
 
     /**


### PR DESCRIPTION
## Why

The tour ranks its seeds against the query string: a symbol whose name shares a word with the query is promoted, one that shares none is demoted — a 3.2× swing. So the words in `question` / `query` choose the tour.

The schema asked for "the code question being considered", and the models answered that with their own paraphrase. Caught in a live trace (Opus, vue, common):

```
mcp__ttsc-graph__inspect_typescript_graph
  {"question":"I'm new to this Vue 3 core TypeScript monorepo. What is the central runtime flow from ..."}
```

That is the model's rewrite, not the user's question — and a different rewrite ranks a different tour, which is why the Sonnet cells moved run to run on an unchanged build.

## What

Say what the field is for, in two lines, and say why — the ranking is the reason:

- `IProps.question` — the code question in the user's own words. Cut a long message down to the sentences that state the ask, but keep their terms: the graph ranks against these words, so a rewrite ranks a different answer.
- `ITtscGraphTour.IRequest.query` — the same ask, verbatim. Its terms rank the tour, so neither reword it nor add terms of your own.

Trimming a long message is allowed and necessary; rewriting it is not. Both descriptions ship in the tool schema (typia reflects the JSDoc), so the model reads them when it fills the call.

## Measurement

The graph arm is re-measured on the four models and both prompt families before this is trusted, and the numbers go on the site — a schema change is a text change, and a text change means the whole `ttsc-graph` arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YXiVdMRPRCTse2qyx9VQH