### PR TITLE
fix(lint): analyze prefer-const by lexical binding

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -325,7 +325,7 @@ Source: [ESLint core rules](https://eslint.org/docs/latest/rules/).
 - [`object-shorthand`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/object-shorthand.ts): requires object property shorthand where possible.
 - [`operator-assignment`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/operator-assignment.ts): prefers compound assignment operators.
 - [`prefer-arrow-callback`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/prefer-arrow-callback.ts): reject `function() { ... }` expressions passed as callback arguments. Prefer the arrow form.
-- [`prefer-const`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/prefer-const.ts): prefers `const` for `let` bindings that are never reassigned.
+- [`prefer-const`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/prefer-const.ts): prefers `const` for lexical `let` bindings that are never reassigned, including declaration-only and destructured bindings with ESLint-compatible options.
 - [`prefer-destructuring`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/prefer-destructuring.ts): reject single-property and single-index variable declarations (`const a = obj.a`, `const x = arr[0]`) that destructuring would replace verbatim.
 - [`prefer-exponentiation-operator`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/prefer-exponentiation-operator.ts): prefers `**` over `Math.pow`.
 - [`prefer-for-of`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/prefer-for-of.ts): prefers `for...of` for simple array iteration.

--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -336,8 +336,8 @@ func (w *descendantsWalker) visitChild(child *shimast.Node) bool {
   return false
 }
 
-// assignmentTargetNames collects the identifier names written by an
-// assignment's left-hand side. A bare Identifier yields one name. A
+// assignmentTargetIdentifiers collects the Identifier nodes written by an
+// assignment's left-hand side. A bare Identifier yields one node. A
 // destructuring-assignment target — parsed as an ArrayLiteralExpression
 // (`[a, b] = …`) or ObjectLiteralExpression (`({a} = …)`) rather than a
 // binding pattern — is walked so every nested write position is counted:
@@ -347,70 +347,84 @@ func (w *descendantsWalker) visitChild(child *shimast.Node) bool {
 // Property names in `{key: target}` are read positions, not writes, so
 // only the property value contributes; member-access targets (`obj.x`)
 // declare no local binding and are skipped. Returns nil for other shapes.
-func assignmentTargetNames(node *shimast.Node) []string {
+func assignmentTargetIdentifiers(node *shimast.Node) []*shimast.Node {
   if node == nil {
     return nil
   }
-  if name := identifierText(node); name != "" {
-    return []string{name}
+  if node.Kind == shimast.KindIdentifier {
+    return []*shimast.Node{node}
   }
-  var names []string
-  collectAssignmentTargetNames(node, &names)
+  var identifiers []*shimast.Node
+  collectAssignmentTargetIdentifiers(node, &identifiers)
+  return identifiers
+}
+
+// assignmentTargetNames is the text-only projection used by rules that do not
+// need binding identity.
+func assignmentTargetNames(node *shimast.Node) []string {
+  identifiers := assignmentTargetIdentifiers(node)
+  if len(identifiers) == 0 {
+    return nil
+  }
+  names := make([]string, 0, len(identifiers))
+  for _, identifier := range identifiers {
+    if name := identifierText(identifier); name != "" {
+      names = append(names, name)
+    }
+  }
   return names
 }
 
-// collectAssignmentTargetNames appends to `names` every identifier in a
+// collectAssignmentTargetIdentifiers appends to `identifiers` every identifier in a
 // destructuring-assignment target. It descends only through write-target
 // positions so reads (object property keys, computed-member expressions)
 // never count as reassignments.
-func collectAssignmentTargetNames(node *shimast.Node, names *[]string) {
+func collectAssignmentTargetIdentifiers(node *shimast.Node, identifiers *[]*shimast.Node) {
   if node == nil {
     return
   }
   switch node.Kind {
   case shimast.KindIdentifier:
-    if name := identifierText(node); name != "" {
-      *names = append(*names, name)
-    }
+    *identifiers = append(*identifiers, node)
   case shimast.KindParenthesizedExpression:
-    collectAssignmentTargetNames(stripParens(node), names)
+    collectAssignmentTargetIdentifiers(stripParens(node), identifiers)
   case shimast.KindArrayLiteralExpression:
     if arr := node.AsArrayLiteralExpression(); arr != nil && arr.Elements != nil {
       for _, el := range arr.Elements.Nodes {
-        collectAssignmentTargetNames(el, names)
+        collectAssignmentTargetIdentifiers(el, identifiers)
       }
     }
   case shimast.KindObjectLiteralExpression:
     if obj := node.AsObjectLiteralExpression(); obj != nil && obj.Properties != nil {
       for _, prop := range obj.Properties.Nodes {
-        collectAssignmentTargetNames(prop, names)
+        collectAssignmentTargetIdentifiers(prop, identifiers)
       }
     }
   case shimast.KindSpreadElement:
     if spread := node.AsSpreadElement(); spread != nil {
-      collectAssignmentTargetNames(spread.Expression, names)
+      collectAssignmentTargetIdentifiers(spread.Expression, identifiers)
     }
   case shimast.KindSpreadAssignment:
     if spread := node.AsSpreadAssignment(); spread != nil {
-      collectAssignmentTargetNames(spread.Expression, names)
+      collectAssignmentTargetIdentifiers(spread.Expression, identifiers)
     }
   case shimast.KindShorthandPropertyAssignment:
     // `{a}` and `{a = 1}` — the property name is the write target; any
     // ObjectAssignmentInitializer is a default value, not a target.
     if short := node.AsShorthandPropertyAssignment(); short != nil {
-      collectAssignmentTargetNames(short.Name(), names)
+      collectAssignmentTargetIdentifiers(short.Name(), identifiers)
     }
   case shimast.KindPropertyAssignment:
     // `{key: target}` — only the value (initializer) is written to.
     if assignment := node.AsPropertyAssignment(); assignment != nil {
-      collectAssignmentTargetNames(assignment.Initializer, names)
+      collectAssignmentTargetIdentifiers(assignment.Initializer, identifiers)
     }
   case shimast.KindBinaryExpression:
     // A default inside a pattern (`[a = 1]`, `{key: a = 1}`) parses as an
     // `=` BinaryExpression; only its left side is the write target.
     if expr := node.AsBinaryExpression(); expr != nil &&
       expr.OperatorToken != nil && expr.OperatorToken.Kind == shimast.KindEqualsToken {
-      collectAssignmentTargetNames(expr.Left, names)
+      collectAssignmentTargetIdentifiers(expr.Left, identifiers)
     }
   }
 }

--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -388,6 +388,10 @@ func collectAssignmentTargetIdentifiers(node *shimast.Node, identifiers *[]*shim
     *identifiers = append(*identifiers, node)
   case shimast.KindParenthesizedExpression:
     collectAssignmentTargetIdentifiers(stripParens(node), identifiers)
+  case shimast.KindNonNullExpression:
+    if expression := node.AsNonNullExpression(); expression != nil {
+      collectAssignmentTargetIdentifiers(expression.Expression, identifiers)
+    }
   case shimast.KindArrayLiteralExpression:
     if arr := node.AsArrayLiteralExpression(); arr != nil && arr.Elements != nil {
       for _, el := range arr.Elements.Nodes {

--- a/packages/lint/linthost/rules_var.go
+++ b/packages/lint/linthost/rules_var.go
@@ -562,142 +562,561 @@ func isValueReferenceIdentifier(node *shimast.Node) bool {
   return true
 }
 
-// preferConst: flag `let` declarations whose binding is never reassigned.
-// This follows ESLint's core rule for the common AST-local cases. It is
-// intentionally conservative: destructuring and declaration-only `let`
-// variables (those without an initializer and not in a for-of/for-in
-// header) are skipped until the lint host grows full scope/data-flow state.
-// ESLint canonical: https://eslint.org/docs/latest/rules/prefer-const
+// preferConst follows ESLint's binding semantics rather than comparing
+// identifier text. TypeScript's checker resolves every declaration and write
+// target to its lexical symbol, so same-spelled bindings in sibling, nested,
+// and shadowing scopes remain independent. The rule records the declaration's
+// initialization plus subsequent writes, then reports bindings with exactly
+// one effective initialization.
+//
+// Declaration-only bindings are diagnostic-only. Rewriting `let value;` plus
+// a later `value = expression` requires moving comments and changing statement
+// structure, so the existing keyword edit stays limited to an initialized,
+// single-declarator list. ESLint canonical:
+// https://eslint.org/docs/latest/rules/prefer-const
 type preferConst struct{}
 
-func (preferConst) Name() string           { return "prefer-const" }
+type preferConstOptions struct {
+  Destructuring          string `json:"destructuring"`
+  IgnoreReadBeforeAssign bool   `json:"ignoreReadBeforeAssign"`
+}
+
+type preferConstWriteKind uint8
+
+const (
+  preferConstSimpleAssignment preferConstWriteKind = iota
+  preferConstReassignment
+)
+
+type preferConstWrite struct {
+  target     *shimast.Node
+  assignment *shimast.Node
+  kind       preferConstWriteKind
+}
+
+type preferConstCandidate struct {
+  symbol           *shimast.Symbol
+  nameNode         *shimast.Node
+  declaration      *shimast.Node
+  listNode         *shimast.Node
+  scope            *shimast.Node
+  declarationGroup *shimast.Node
+  initialized      bool
+  readBeforeAssign bool
+  invalid          bool
+  writes           []preferConstWrite
+}
+
+func (preferConst) Name() string { return "prefer-const" }
+func (preferConst) NeedsTypeChecker() bool {
+  return true
+}
 func (preferConst) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSourceFile} }
 func (preferConst) Check(ctx *Context, node *shimast.Node) {
-  type candidate struct {
-    name     string
-    node     *shimast.Node
-    listNode *shimast.Node
+  if ctx.Checker == nil {
+    return
   }
-  var candidates []candidate
-  assigned := map[string]bool{}
+
+  options := preferConstOptions{Destructuring: "any"}
+  _ = ctx.DecodeOptions(&options)
+  if options.Destructuring != "all" {
+    options.Destructuring = "any"
+  }
+
+  candidates := make([]*preferConstCandidate, 0)
+  bySymbol := make(map[*shimast.Symbol]*preferConstCandidate)
+  declarationNames := make(map[*shimast.Node]struct{})
+  candidateNames := make(map[string]struct{})
+  groups := make(map[*shimast.Node][]*preferConstCandidate)
 
   walkDescendants(node, func(child *shimast.Node) {
+    if child.Kind != shimast.KindVariableDeclaration {
+      return
+    }
+    decl := child.AsVariableDeclaration()
+    if decl == nil || child.Parent == nil || child.Parent.Kind != shimast.KindVariableDeclarationList {
+      return
+    }
+    listNode := child.Parent
+    if !shimast.IsLet(listNode) || preferConstIsForStatementInitializer(listNode) {
+      return
+    }
+
+    names := bindingIdentifierNodes(decl.Name())
+    if len(names) == 0 {
+      return
+    }
+    initialized := decl.Initializer != nil || preferConstIsForInOrOfInitializer(listNode)
+    destructuring := decl.Name() != nil && decl.Name().Kind != shimast.KindIdentifier
+    for _, nameNode := range names {
+      symbol := ctx.Checker.GetSymbolAtLocation(nameNode)
+      candidate := &preferConstCandidate{
+        symbol:      symbol,
+        nameNode:    nameNode,
+        declaration: child,
+        listNode:    listNode,
+        scope:       preferConstLexicalScope(nameNode),
+        initialized: initialized,
+      }
+      if destructuring {
+        candidate.declarationGroup = child
+        groups[child] = append(groups[child], candidate)
+      }
+      candidates = append(candidates, candidate)
+      declarationNames[nameNode] = struct{}{}
+      if name := identifierText(nameNode); name != "" {
+        candidateNames[name] = struct{}{}
+      }
+      if symbol == nil {
+        candidate.invalid = true
+        continue
+      }
+      if prior := bySymbol[symbol]; prior != nil {
+        // Duplicate lexical declarations are already a TypeScript error. Do
+        // not add a secondary const suggestion to either declaration.
+        prior.invalid = true
+        candidate.invalid = true
+        continue
+      }
+      bySymbol[symbol] = candidate
+    }
+  })
+
+  writeTargets := make(map[*shimast.Node]struct{})
+  walkDescendants(node, func(child *shimast.Node) {
     switch child.Kind {
-    case shimast.KindVariableDeclaration:
-      decl := child.AsVariableDeclaration()
-      if decl == nil || child.Parent == nil || child.Parent.Kind != shimast.KindVariableDeclarationList {
-        return
-      }
-      listNode := child.Parent
-      if !shimast.IsLet(listNode) {
-        return
-      }
-      name := identifierText(decl.Name())
-      if name == "" {
-        return
-      }
-      if !isConstEligibleLetDeclaration(child, decl) {
-        return
-      }
-      candidates = append(candidates, candidate{name: name, node: child, listNode: listNode})
     case shimast.KindBinaryExpression:
       expr := child.AsBinaryExpression()
-      if expr == nil || expr.OperatorToken == nil || !isAssignmentOperator(expr.OperatorToken.Kind) {
+      if expr == nil || expr.OperatorToken == nil || !isAssignmentOperator(expr.OperatorToken.Kind) ||
+        preferConstIsDestructuringDefaultAssignment(child) {
         return
       }
-      for _, name := range assignmentTargetNames(expr.Left) {
-        assigned[name] = true
+      kind := preferConstReassignment
+      if expr.OperatorToken.Kind == shimast.KindEqualsToken {
+        kind = preferConstSimpleAssignment
+      }
+      targets := assignmentTargetIdentifiers(expr.Left)
+      for _, target := range targets {
+        preferConstRecordWrite(ctx, bySymbol, writeTargets, target, child, kind)
+      }
+      if kind == preferConstSimpleAssignment && len(targets) > 1 {
+        for _, target := range targets {
+          symbol := ctx.Checker.GetSymbolAtLocation(target)
+          if candidate := bySymbol[symbol]; candidate != nil {
+            groups[child] = appendPreferConstCandidate(groups[child], candidate)
+          }
+        }
       }
     case shimast.KindPrefixUnaryExpression:
       expr := child.AsPrefixUnaryExpression()
-      if expr == nil {
-        return
-      }
-      if expr.Operator == shimast.KindPlusPlusToken || expr.Operator == shimast.KindMinusMinusToken {
-        if name := identifierText(expr.Operand); name != "" {
-          assigned[name] = true
-        }
+      if expr != nil && (expr.Operator == shimast.KindPlusPlusToken || expr.Operator == shimast.KindMinusMinusToken) {
+        preferConstRecordWrite(ctx, bySymbol, writeTargets, expr.Operand, nil, preferConstReassignment)
       }
     case shimast.KindPostfixUnaryExpression:
       expr := child.AsPostfixUnaryExpression()
-      if expr == nil {
-        return
-      }
-      if expr.Operator == shimast.KindPlusPlusToken || expr.Operator == shimast.KindMinusMinusToken {
-        if name := identifierText(expr.Operand); name != "" {
-          assigned[name] = true
-        }
+      if expr != nil && (expr.Operator == shimast.KindPlusPlusToken || expr.Operator == shimast.KindMinusMinusToken) {
+        preferConstRecordWrite(ctx, bySymbol, writeTargets, expr.Operand, nil, preferConstReassignment)
       }
     case shimast.KindForOfStatement, shimast.KindForInStatement:
-      // `for (x of …)` / `for (x in …)` reassigns the existing binding `x`
-      // on every iteration. When the initializer IS a
-      // VariableDeclarationList (`for (const y of …)`) it declares a fresh
-      // binding instead, so only a non-declaration initializer counts as a
-      // reassignment target. Missing this lets a pre-existing `let` be
-      // rewritten to `const` that the loop then assigns to — a TS error and
-      // runtime TypeError.
       stmt := child.AsForInOrOfStatement()
-      if stmt == nil || stmt.Initializer == nil {
+      if stmt == nil || stmt.Initializer == nil || stmt.Initializer.Kind == shimast.KindVariableDeclarationList {
         return
       }
-      if stmt.Initializer.Kind == shimast.KindVariableDeclarationList {
-        return
-      }
-      for _, name := range assignmentTargetNames(stmt.Initializer) {
-        assigned[name] = true
+      for _, target := range assignmentTargetIdentifiers(stmt.Initializer) {
+        preferConstRecordWrite(ctx, bySymbol, writeTargets, target, nil, preferConstReassignment)
       }
     }
   })
 
-  for _, c := range candidates {
-    if !assigned[c.name] {
-      start := -1
-      if isSingleDeclarationList(c.listNode) {
-        start = keywordStart(ctx.File, c.listNode, "let")
+  // Only declaration-only candidates need read history. A read preceding the
+  // sole assignment changes the diagnostic location under the default option,
+  // and suppresses the diagnostic when ignoreReadBeforeAssign is enabled.
+  walkDescendants(node, func(child *shimast.Node) {
+    if child.Kind != shimast.KindIdentifier {
+      return
+    }
+    if _, ok := declarationNames[child]; ok {
+      return
+    }
+    if _, ok := writeTargets[child]; ok {
+      return
+    }
+    if _, ok := candidateNames[identifierText(child)]; !ok {
+      return
+    }
+    symbol := ctx.Checker.GetSymbolAtLocation(child)
+    candidate := bySymbol[symbol]
+    if candidate == nil || candidate.initialized || len(candidate.writes) != 1 {
+      return
+    }
+    if child.Pos() < candidate.writes[0].target.Pos() {
+      candidate.readBeforeAssign = true
+    }
+  })
+
+  eligible := make(map[*preferConstCandidate]bool, len(candidates))
+  for _, candidate := range candidates {
+    eligible[candidate] = preferConstCandidateIsEligible(ctx, candidate, bySymbol, options)
+  }
+
+  for _, candidate := range candidates {
+    if !eligible[candidate] {
+      continue
+    }
+    group := candidate.declarationGroup
+    if group == nil && !candidate.initialized && len(candidate.writes) == 1 {
+      assignment := candidate.writes[0].assignment
+      if len(groups[assignment]) > 1 {
+        group = assignment
       }
-      if start >= 0 {
-        ctx.ReportFix(
-          c.node,
-          "Use const instead of let.",
-          TextEdit{Pos: start, End: start + len("let"), Text: "const"},
-        )
-      } else {
-        ctx.Report(c.node, "Use const instead of let.")
+    }
+    if options.Destructuring == "all" && group != nil && !preferConstGroupIsEligible(groups[group], eligible) {
+      continue
+    }
+
+    reportNode := candidate.nameNode
+    if !candidate.initialized && !candidate.readBeforeAssign && len(candidate.writes) == 1 {
+      reportNode = candidate.writes[0].target
+    }
+
+    start := -1
+    if candidate.initialized && isSingleDeclarationList(candidate.listNode) {
+      declarationGroup := groups[candidate.declaration]
+      if len(declarationGroup) == 0 || preferConstGroupIsEligible(declarationGroup, eligible) {
+        start = keywordStart(ctx.File, candidate.listNode, "let")
       }
+    }
+    if start >= 0 {
+      ctx.ReportFix(
+        reportNode,
+        "Use const instead of let.",
+        TextEdit{Pos: start, End: start + len("let"), Text: "const"},
+      )
+    } else {
+      ctx.Report(reportNode, "Use const instead of let.")
     }
   }
 }
 
-// isSingleDeclarationList reports whether the VariableDeclarationList node
-// declares exactly one binding, which is required before the `let` keyword
-// can safely be rewritten to `const` (a multi-binding list shares a single
-// keyword, so replacing just one binding's keyword is not valid).
+func preferConstRecordWrite(
+  ctx *Context,
+  bySymbol map[*shimast.Symbol]*preferConstCandidate,
+  writeTargets map[*shimast.Node]struct{},
+  target *shimast.Node,
+  assignment *shimast.Node,
+  kind preferConstWriteKind,
+) {
+  if target == nil || target.Kind != shimast.KindIdentifier {
+    return
+  }
+  symbol := ctx.Checker.GetSymbolAtLocation(target)
+  candidate := bySymbol[symbol]
+  if candidate == nil {
+    return
+  }
+  candidate.writes = append(candidate.writes, preferConstWrite{
+    target:     target,
+    assignment: assignment,
+    kind:       kind,
+  })
+  writeTargets[target] = struct{}{}
+}
+
+func preferConstCandidateIsEligible(
+  ctx *Context,
+  candidate *preferConstCandidate,
+  bySymbol map[*shimast.Symbol]*preferConstCandidate,
+  options preferConstOptions,
+) bool {
+  if candidate == nil || candidate.invalid || candidate.symbol == nil {
+    return false
+  }
+  if candidate.initialized {
+    return len(candidate.writes) == 0
+  }
+  if len(candidate.writes) != 1 || candidate.writes[0].kind != preferConstSimpleAssignment {
+    return false
+  }
+  if options.IgnoreReadBeforeAssign && candidate.readBeforeAssign {
+    return false
+  }
+  return preferConstAssignmentCanInitialize(ctx, candidate, candidate.writes[0], bySymbol)
+}
+
+func preferConstAssignmentCanInitialize(
+  ctx *Context,
+  candidate *preferConstCandidate,
+  write preferConstWrite,
+  bySymbol map[*shimast.Symbol]*preferConstCandidate,
+) bool {
+  assignment := write.assignment
+  if assignment == nil || assignment.Kind != shimast.KindBinaryExpression ||
+    candidate.scope == nil || candidate.scope != preferConstLexicalScope(write.target) {
+    return false
+  }
+  expr := assignment.AsBinaryExpression()
+  if expr == nil || expr.OperatorToken == nil || expr.OperatorToken.Kind != shimast.KindEqualsToken {
+    return false
+  }
+
+  statementOwner := assignment
+  for statementOwner.Parent != nil && statementOwner.Parent.Kind == shimast.KindParenthesizedExpression {
+    statementOwner = statementOwner.Parent
+  }
+  if statementOwner.Parent == nil || statementOwner.Parent.Kind != shimast.KindExpressionStatement {
+    return false
+  }
+  container := statementOwner.Parent.Parent
+  if container == nil {
+    return false
+  }
+  switch container.Kind {
+  case shimast.KindSourceFile,
+    shimast.KindBlock,
+    shimast.KindModuleBlock,
+    shimast.KindCaseClause,
+    shimast.KindDefaultClause:
+  default:
+    return false
+  }
+
+  if preferConstAssignmentTargetHasMember(expr.Left) {
+    return false
+  }
+  targets := assignmentTargetIdentifiers(expr.Left)
+  if len(targets) == 0 {
+    return false
+  }
+  for _, target := range targets {
+    symbol := ctx.Checker.GetSymbolAtLocation(target)
+    grouped := bySymbol[symbol]
+    if symbol == nil || !preferConstSymbolIsLocalToScope(symbol, candidate.scope) ||
+      (grouped != nil && grouped.invalid) {
+      return false
+    }
+  }
+  return true
+}
+
+func preferConstSymbolIsLocalToScope(symbol *shimast.Symbol, scope *shimast.Node) bool {
+  if symbol == nil || scope == nil {
+    return false
+  }
+  for _, declaration := range symbol.Declarations {
+    if preferConstDeclarationScope(declaration) == scope {
+      return true
+    }
+  }
+  return false
+}
+
+// preferConstDeclarationScope returns the scope that owns a sibling target in
+// a destructuring assignment. Parameters cannot be folded into a declaration,
+// and `var` declarations hoist past ordinary blocks to their function-like
+// owner; every other declaration uses lexical scope.
+func preferConstDeclarationScope(declaration *shimast.Node) *shimast.Node {
+  if declaration == nil {
+    return nil
+  }
+  for ancestor := declaration; ancestor != nil; ancestor = ancestor.Parent {
+    if ancestor.Kind == shimast.KindParameter {
+      return nil
+    }
+    if isFunctionLikeKind(ancestor) {
+      break
+    }
+  }
+  for ancestor := declaration.Parent; ancestor != nil; ancestor = ancestor.Parent {
+    if ancestor.Kind != shimast.KindVariableDeclarationList {
+      continue
+    }
+    if !shimast.IsVar(ancestor) {
+      break
+    }
+    for scope := ancestor.Parent; scope != nil; scope = scope.Parent {
+      if scope.Kind == shimast.KindSourceFile || scope.Kind == shimast.KindModuleBlock ||
+        scope.Kind == shimast.KindClassStaticBlockDeclaration || isFunctionLikeKind(scope) {
+        return scope
+      }
+    }
+    return nil
+  }
+  return preferConstLexicalScope(declaration)
+}
+
+func preferConstAssignmentTargetHasMember(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  switch node.Kind {
+  case shimast.KindPropertyAccessExpression, shimast.KindElementAccessExpression:
+    return true
+  case shimast.KindParenthesizedExpression:
+    return preferConstAssignmentTargetHasMember(stripParens(node))
+  case shimast.KindArrayLiteralExpression:
+    if array := node.AsArrayLiteralExpression(); array != nil && array.Elements != nil {
+      for _, element := range array.Elements.Nodes {
+        if preferConstAssignmentTargetHasMember(element) {
+          return true
+        }
+      }
+    }
+  case shimast.KindObjectLiteralExpression:
+    if object := node.AsObjectLiteralExpression(); object != nil && object.Properties != nil {
+      for _, property := range object.Properties.Nodes {
+        if preferConstAssignmentTargetHasMember(property) {
+          return true
+        }
+      }
+    }
+  case shimast.KindSpreadElement:
+    if spread := node.AsSpreadElement(); spread != nil {
+      return preferConstAssignmentTargetHasMember(spread.Expression)
+    }
+  case shimast.KindSpreadAssignment:
+    if spread := node.AsSpreadAssignment(); spread != nil {
+      return preferConstAssignmentTargetHasMember(spread.Expression)
+    }
+  case shimast.KindPropertyAssignment:
+    if property := node.AsPropertyAssignment(); property != nil {
+      return preferConstAssignmentTargetHasMember(property.Initializer)
+    }
+  case shimast.KindBinaryExpression:
+    if expression := node.AsBinaryExpression(); expression != nil && expression.OperatorToken != nil &&
+      expression.OperatorToken.Kind == shimast.KindEqualsToken {
+      return preferConstAssignmentTargetHasMember(expression.Left)
+    }
+  // A shorthand property assignment writes its name. Its optional object
+  // assignment initializer is a default-value read, so member access there
+  // does not make the destructuring target unsafe.
+  case shimast.KindShorthandPropertyAssignment, shimast.KindIdentifier:
+    return false
+  }
+  return false
+}
+
+func preferConstGroupIsEligible(group []*preferConstCandidate, eligible map[*preferConstCandidate]bool) bool {
+  if len(group) == 0 {
+    return false
+  }
+  for _, candidate := range group {
+    if !eligible[candidate] {
+      return false
+    }
+  }
+  return true
+}
+
+func appendPreferConstCandidate(group []*preferConstCandidate, candidate *preferConstCandidate) []*preferConstCandidate {
+  for _, existing := range group {
+    if existing == candidate {
+      return group
+    }
+  }
+  return append(group, candidate)
+}
+
+func bindingIdentifierNodes(node *shimast.Node) []*shimast.Node {
+  if node == nil {
+    return nil
+  }
+  if node.Kind == shimast.KindIdentifier {
+    return []*shimast.Node{node}
+  }
+  pattern := node.AsBindingPattern()
+  if pattern == nil || pattern.Elements == nil {
+    return nil
+  }
+  var identifiers []*shimast.Node
+  for _, elementNode := range pattern.Elements.Nodes {
+    element := elementNode.AsBindingElement()
+    if element != nil {
+      identifiers = append(identifiers, bindingIdentifierNodes(element.Name())...)
+    }
+  }
+  return identifiers
+}
+
+func preferConstIsForStatementInitializer(listNode *shimast.Node) bool {
+  return listNode != nil && listNode.Parent != nil && listNode.Parent.Kind == shimast.KindForStatement
+}
+
+func preferConstIsForInOrOfInitializer(listNode *shimast.Node) bool {
+  if listNode == nil || listNode.Parent == nil {
+    return false
+  }
+  return listNode.Parent.Kind == shimast.KindForInStatement || listNode.Parent.Kind == shimast.KindForOfStatement
+}
+
+// preferConstIsDestructuringDefaultAssignment distinguishes the `a = 1`
+// syntax inside `[a = 1]` or `{a = 1}` from a second assignment. The default
+// node sits on the outer assignment's left-hand pattern path. A real assignment
+// inside the default expression's right side leaves that path and is counted.
+func preferConstIsDestructuringDefaultAssignment(node *shimast.Node) bool {
+  current := node
+  for parent := node.Parent; parent != nil; parent = parent.Parent {
+    switch parent.Kind {
+    case shimast.KindParenthesizedExpression,
+      shimast.KindArrayLiteralExpression,
+      shimast.KindObjectLiteralExpression,
+      shimast.KindPropertyAssignment,
+      shimast.KindShorthandPropertyAssignment,
+      shimast.KindSpreadElement,
+      shimast.KindSpreadAssignment:
+      current = parent
+      continue
+    case shimast.KindBinaryExpression:
+      expr := parent.AsBinaryExpression()
+      return expr != nil && expr.OperatorToken != nil && isAssignmentOperator(expr.OperatorToken.Kind) &&
+        current.Pos() >= expr.Left.Pos() && current.End() <= expr.Left.End()
+    default:
+      return false
+    }
+  }
+  return false
+}
+
+func preferConstLexicalScope(node *shimast.Node) *shimast.Node {
+  if node == nil {
+    return nil
+  }
+  for ancestor := node.Parent; ancestor != nil; ancestor = ancestor.Parent {
+    if isFunctionLikeKind(ancestor) {
+      return ancestor
+    }
+    switch ancestor.Kind {
+    case shimast.KindSourceFile,
+      shimast.KindModuleBlock,
+      shimast.KindCaseBlock,
+      shimast.KindForStatement,
+      shimast.KindForInStatement,
+      shimast.KindForOfStatement,
+      shimast.KindCatchClause,
+      shimast.KindClassStaticBlockDeclaration,
+      shimast.KindPropertyDeclaration:
+      return ancestor
+    case shimast.KindBlock:
+      if ancestor.Parent != nil && (isFunctionLikeKind(ancestor.Parent) ||
+        ancestor.Parent.Kind == shimast.KindClassStaticBlockDeclaration) {
+        return ancestor.Parent
+      }
+      return ancestor
+    }
+  }
+  return nil
+}
+
+// isSingleDeclarationList reports whether the VariableDeclarationList contains
+// exactly one declarator. Multiple comma-separated declarators share one
+// keyword, so replacing it for only one declarator is not valid. One
+// destructuring declarator may still contain several bindings; preferConst
+// separately requires every affected binding to be eligible before fixing it.
 func isSingleDeclarationList(node *shimast.Node) bool {
   if node == nil {
     return false
   }
   list := node.AsVariableDeclarationList()
   return list != nil && list.Declarations != nil && len(list.Declarations.Nodes) == 1
-}
-
-// isConstEligibleLetDeclaration reports whether a `let` VariableDeclaration
-// node is eligible for preferConst analysis. A declaration is eligible when:
-//   - it has an initializer (the value is set immediately), or
-//   - it is the loop variable of a for-in or for-of statement (e.g. `for (let k of m)`).
-//
-// For-statement initializers (`for (let i = 0; …)`) are eligible only when
-// the declaration list is a single binding; the loop index is a well-known
-// reassignment target so multi-binding for-statement lists are excluded.
-func isConstEligibleLetDeclaration(node *shimast.Node, decl *shimast.VariableDeclaration) bool {
-  if decl.Initializer != nil {
-    if node.Parent != nil && node.Parent.Parent != nil && node.Parent.Parent.Kind == shimast.KindForStatement {
-      list := node.Parent.AsVariableDeclarationList()
-      return list == nil || list.Declarations == nil || len(list.Declarations.Nodes) == 1
-    }
-    return true
-  }
-  return node.Parent != nil && node.Parent.Parent != nil &&
-    (node.Parent.Parent.Kind == shimast.KindForInStatement || node.Parent.Parent.Kind == shimast.KindForOfStatement)
 }
 
 // noUndefInit: forbid `let x = undefined` and `var x = undefined`.

--- a/packages/lint/linthost/rules_var.go
+++ b/packages/lint/linthost/rules_var.go
@@ -701,7 +701,7 @@ func (preferConst) Check(ctx *Context, node *shimast.Node) {
       }
       if kind == preferConstSimpleAssignment && len(targets) > 1 {
         for _, target := range targets {
-          symbol := ctx.Checker.GetSymbolAtLocation(target)
+          symbol := preferConstValueSymbol(ctx, target)
           if candidate := bySymbol[symbol]; candidate != nil {
             groups[child] = appendPreferConstCandidate(groups[child], candidate)
           }
@@ -710,12 +710,16 @@ func (preferConst) Check(ctx *Context, node *shimast.Node) {
     case shimast.KindPrefixUnaryExpression:
       expr := child.AsPrefixUnaryExpression()
       if expr != nil && (expr.Operator == shimast.KindPlusPlusToken || expr.Operator == shimast.KindMinusMinusToken) {
-        preferConstRecordWrite(ctx, bySymbol, writeTargets, expr.Operand, nil, preferConstReassignment)
+        for _, target := range assignmentTargetIdentifiers(expr.Operand) {
+          preferConstRecordWrite(ctx, bySymbol, writeTargets, target, nil, preferConstReassignment)
+        }
       }
     case shimast.KindPostfixUnaryExpression:
       expr := child.AsPostfixUnaryExpression()
       if expr != nil && (expr.Operator == shimast.KindPlusPlusToken || expr.Operator == shimast.KindMinusMinusToken) {
-        preferConstRecordWrite(ctx, bySymbol, writeTargets, expr.Operand, nil, preferConstReassignment)
+        for _, target := range assignmentTargetIdentifiers(expr.Operand) {
+          preferConstRecordWrite(ctx, bySymbol, writeTargets, target, nil, preferConstReassignment)
+        }
       }
     case shimast.KindForOfStatement, shimast.KindForInStatement:
       stmt := child.AsForInOrOfStatement()
@@ -744,7 +748,7 @@ func (preferConst) Check(ctx *Context, node *shimast.Node) {
     if _, ok := candidateNames[identifierText(child)]; !ok {
       return
     }
-    symbol := ctx.Checker.GetSymbolAtLocation(child)
+    symbol := preferConstValueSymbol(ctx, child)
     candidate := bySymbol[symbol]
     if candidate == nil || candidate.initialized || len(candidate.writes) != 1 {
       return
@@ -809,7 +813,7 @@ func preferConstRecordWrite(
   if target == nil || target.Kind != shimast.KindIdentifier {
     return
   }
-  symbol := ctx.Checker.GetSymbolAtLocation(target)
+  symbol := preferConstValueSymbol(ctx, target)
   candidate := bySymbol[symbol]
   if candidate == nil {
     return
@@ -820,6 +824,18 @@ func preferConstRecordWrite(
     kind:       kind,
   })
   writeTargets[target] = struct{}{}
+}
+
+func preferConstValueSymbol(ctx *Context, identifier *shimast.Node) *shimast.Symbol {
+  if ctx == nil || ctx.Checker == nil || identifier == nil {
+    return nil
+  }
+  if parent := identifier.Parent; parent != nil && parent.Kind == shimast.KindShorthandPropertyAssignment {
+    if shorthand := parent.AsShorthandPropertyAssignment(); shorthand != nil && shorthand.Name() == identifier {
+      return ctx.Checker.GetShorthandAssignmentValueSymbol(parent)
+    }
+  }
+  return ctx.Checker.GetSymbolAtLocation(identifier)
 }
 
 func preferConstCandidateIsEligible(
@@ -888,7 +904,7 @@ func preferConstAssignmentCanInitialize(
     return false
   }
   for _, target := range targets {
-    symbol := ctx.Checker.GetSymbolAtLocation(target)
+    symbol := preferConstValueSymbol(ctx, target)
     grouped := bySymbol[symbol]
     if symbol == nil || !preferConstSymbolIsLocalToScope(symbol, candidate.scope) ||
       (grouped != nil && grouped.invalid) {
@@ -953,6 +969,10 @@ func preferConstAssignmentTargetHasMember(node *shimast.Node) bool {
     return true
   case shimast.KindParenthesizedExpression:
     return preferConstAssignmentTargetHasMember(stripParens(node))
+  case shimast.KindNonNullExpression:
+    if expression := node.AsNonNullExpression(); expression != nil {
+      return preferConstAssignmentTargetHasMember(expression.Expression)
+    }
   case shimast.KindArrayLiteralExpression:
     if array := node.AsArrayLiteralExpression(); array != nil && array.Elements != nil {
       for _, element := range array.Elements.Nodes {
@@ -1060,11 +1080,15 @@ func preferConstIsDestructuringDefaultAssignment(node *shimast.Node) bool {
       shimast.KindArrayLiteralExpression,
       shimast.KindObjectLiteralExpression,
       shimast.KindPropertyAssignment,
-      shimast.KindShorthandPropertyAssignment,
       shimast.KindSpreadElement,
       shimast.KindSpreadAssignment:
       current = parent
       continue
+    case shimast.KindShorthandPropertyAssignment:
+      // A shorthand's optional initializer is a read expression rather than
+      // part of the assignment target. Any binary expression nested there is
+      // a real write and must not inherit the outer destructuring assignment.
+      return false
     case shimast.KindBinaryExpression:
       expr := parent.AsBinaryExpression()
       return expr != nil && expr.OperatorToken != nil && isAssignmentOperator(expr.OperatorToken.Kind) &&

--- a/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
@@ -117,3 +117,23 @@ export interface ITtscLintNoFallthroughRuleOptions {
   */
   reportUnusedFallthroughComment?: boolean;
 }
+
+/** `prefer-const` rule options. */
+export interface ITtscLintCorePreferConstRuleOptions {
+  /**
+   * Report each const-eligible binding in a destructuring pattern (`"any"`), or
+   * report the pattern only when every binding is const-eligible (`"all"`).
+   *
+   * @default "any"
+   */
+  destructuring?: "any" | "all";
+
+  /**
+   * Ignore a declaration-only binding when it is read before its first
+   * assignment. This avoids a conflict with `no-use-before-define` policies
+   * that require the declaration to stay at its original location.
+   *
+   * @default false
+  */
+  ignoreReadBeforeAssign?: boolean;
+}

--- a/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
@@ -6,6 +6,7 @@ import type {
   ITtscLintCoreNoDuplicateImportsRuleOptions,
   ITtscLintCoreNoUnusedExpressionsRuleOptions,
   ITtscLintNoFallthroughRuleOptions,
+  ITtscLintCorePreferConstRuleOptions,
 } from "./ITtscLintCoreRuleOptions";
 
 /**
@@ -1242,12 +1243,15 @@ export interface ITtscLintCoreRules {
   "prefer-arrow-callback"?: TtscLintRuleSetting;
 
   /**
-   * Require `const` for variables that are never reassigned after declaration.
-   * Autofixable for single-declaration `let`s.
+   * Require `const` for lexical bindings that are never reassigned after their
+   * initial value is established. Declaration-only and destructured bindings
+   * follow ESLint's `ignoreReadBeforeAssign` and `destructuring` options.
+   * Autofixable when one initialized declaration can safely change its shared
+   * `let` keyword.
    *
    * @reference https://eslint.org/docs/latest/rules/prefer-const
    */
-  "prefer-const"?: TtscLintRuleSetting;
+  "prefer-const"?: TtscLintRuleOptionsSetting<ITtscLintCorePreferConstRuleOptions>;
 
   /**
    * Reject single-property and single-index variable declarations (`const a =

--- a/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
+++ b/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
@@ -10,6 +10,7 @@ import type {
   ITtscLintCoreNoDuplicateImportsRuleOptions,
   ITtscLintCoreNoUnusedExpressionsRuleOptions,
   ITtscLintNoFallthroughRuleOptions,
+  ITtscLintCorePreferConstRuleOptions,
 } from "./ITtscLintCoreRuleOptions";
 import type { ITtscLintCypressUnsafeToChainCommandRuleOptions } from "./ITtscLintCypressRuleOptions";
 import type {
@@ -59,6 +60,7 @@ export interface ITtscLintRuleOptionsMap {
   "no-duplicate-imports": ITtscLintCoreNoDuplicateImportsRuleOptions;
   "no-unused-expressions": ITtscLintCoreNoUnusedExpressionsRuleOptions;
   "no-fallthrough": ITtscLintNoFallthroughRuleOptions;
+  "prefer-const": ITtscLintCorePreferConstRuleOptions;
   "testing-library/consistent-data-testid": ITtscLintTestingLibraryConsistentDataTestIdRuleOptions;
   "functional/functional-parameters": ITtscLintFunctionalParametersRuleOptions;
   "functional/immutable-data": ITtscLintFunctionalImmutableDataRuleOptions;

--- a/packages/lint/test/engine/engine_requires_type_checker_for_prefer_const_test.go
+++ b/packages/lint/test/engine/engine_requires_type_checker_for_prefer_const_test.go
@@ -1,0 +1,19 @@
+package linthost
+
+import "testing"
+
+// TestEngineRequiresTypeCheckerForPreferConst verifies binding analysis requests a checker.
+//
+// `prefer-const` resolves declaration and write identifiers to TypeScript
+// symbols. The engine must therefore acquire one checker and use the serial
+// type-aware path whenever the rule is active.
+//
+//  1. Build an engine with only prefer-const enabled.
+//  2. Query its checker requirement.
+//  3. Assert the loader-facing flag is true.
+func TestEngineRequiresTypeCheckerForPreferConst(t *testing.T) {
+  engine := NewEngine(RuleConfig{"prefer-const": SeverityError})
+  if !engine.NeedsTypeChecker() {
+    t.Fatal("preferConst did not request a type checker")
+  }
+}

--- a/packages/lint/test/engine/engine_run_bench_test.go
+++ b/packages/lint/test/engine/engine_run_bench_test.go
@@ -29,7 +29,6 @@ func BenchmarkEngineRun(b *testing.B) {
   file := parseBenchTSFile(b, "/virtual/bench.ts", source)
   rules := RuleConfig{
     "no-var":                              SeverityError,
-    "prefer-const":                        SeverityError,
     "eqeqeq":                              SeverityError,
     "object-shorthand":                    SeverityError,
     "no-unneeded-ternary":                 SeverityError,

--- a/packages/lint/test/engine/engine_run_declaration_bench_test.go
+++ b/packages/lint/test/engine/engine_run_declaration_bench_test.go
@@ -13,7 +13,6 @@ import (
 func declarationBenchRules() RuleConfig {
   return RuleConfig{
     "no-var":                SeverityError,
-    "prefer-const":          SeverityError,
     "eqeqeq":                SeverityError,
     "object-shorthand":      SeverityError,
     "no-unneeded-ternary":   SeverityError,

--- a/packages/lint/test/fix/fix_prefer_const_counts_nested_write_in_shorthand_default_test.go
+++ b/packages/lint/test/fix/fix_prefer_const_counts_nested_write_in_shorthand_default_test.go
@@ -1,0 +1,20 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferConstCountsNestedWriteInShorthandDefault verifies default expressions keep their writes.
+//
+// A shorthand destructuring default is a read expression inside the outer
+// assignment target. A binary assignment nested in that expression is still a
+// real reassignment and must prevent an initialized let from becoming const.
+//
+//  1. Initialize a mutable binding and declare a destructuring target.
+//  2. Reassign the mutable binding inside the target's shorthand default.
+//  3. Assert prefer-const offers no automatic edit for either declaration.
+func TestFixPreferConstCountsNestedWriteInShorthandDefault(t *testing.T) {
+  assertNoFixSnapshot(t, "prefer-const", `let mutable = 0;
+let target: number;
+({ target = (mutable = 1) } = {});
+console.log(mutable, target);
+`)
+}

--- a/packages/lint/test/fix/fix_prefer_const_keeps_nonlocal_rewrites_diagnostic_only_test.go
+++ b/packages/lint/test/fix/fix_prefer_const_keeps_nonlocal_rewrites_diagnostic_only_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferConstKeepsNonlocalRewritesDiagnosticOnly verifies unsafe rewrites stay disabled.
+//
+// A declaration-only binding would require moving its assignment, while one
+// stable leaf in a mixed destructuring declaration would require splitting the
+// shared `let`. Both remain valid findings, but neither can carry a text edit.
+//
+//  1. Create one declaration-then-assignment and one partially mutable destructuring.
+//  2. Run prefer-const through the disk-backed fix selector.
+//  3. Assert no edit is applied and the source remains byte-for-byte unchanged.
+func TestFixPreferConstKeepsNonlocalRewritesDiagnosticOnly(t *testing.T) {
+  assertNoFixSnapshot(t, "prefer-const", `let assignedLater: number;
+assignedLater = 1;
+
+const input = { stable: 1, mutable: 2 };
+let { stable, mutable } = input;
+mutable += 1;
+
+console.log(assignedLater, stable, mutable);
+`)
+}

--- a/packages/lint/test/fix/fix_prefer_const_replaces_wholly_stable_destructuring_keyword_test.go
+++ b/packages/lint/test/fix/fix_prefer_const_replaces_wholly_stable_destructuring_keyword_test.go
@@ -1,0 +1,21 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferConstReplacesWhollyStableDestructuringKeyword verifies shared-keyword fixing.
+//
+// Each binding in one initialized destructuring declaration is const-eligible,
+// so their identical findings may safely share one deduplicated `let` edit.
+// The pattern, initializer, and references must otherwise remain untouched.
+//
+//  1. Declare and read two stable leaves in one destructuring declaration.
+//  2. Apply all prefer-const findings through the disk-backed fix selector.
+//  3. Assert the shared keyword changes exactly once from `let` to `const`.
+func TestFixPreferConstReplacesWhollyStableDestructuringKeyword(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "prefer-const",
+    "let { left, right } = { left: 1, right: 2 };\nconsole.log(left, right);\n",
+    "const { left, right } = { left: 1, right: 2 };\nconsole.log(left, right);\n",
+  )
+}

--- a/packages/lint/test/rules/variables-assignments/prefer_const_allows_reads_in_destructuring_pattern_test.go
+++ b/packages/lint/test/rules/variables-assignments/prefer_const_allows_reads_in_destructuring_pattern_test.go
@@ -1,0 +1,37 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestPreferConstAllowsReadsInDestructuringPattern verifies only write targets constrain conversion.
+//
+// Member access in a computed property key or default expression is a read,
+// not a non-identifier assignment target. Both declaration-only bindings can
+// therefore still establish their sole value through the destructuring.
+//
+//  1. Assign two declaration-only bindings through computed-key and default patterns.
+//  2. Put member access in the read-only portion of each pattern.
+//  3. Assert both bindings are reported and no read is mistaken for a target.
+func TestPreferConstAllowsReadsInDestructuringPattern(t *testing.T) {
+  root := seedLintProject(t, `const input = { first: 1, second: 2 };
+const keys = { current: "first" as const };
+
+let computed: number;
+({ [keys.current]: computed } = input);
+
+let defaulted: number;
+({ second: defaulted = input.second } = {} as Partial<typeof input>);
+
+console.log(computed, defaulted);
+`)
+  seedLintRules(t, root, map[string]string{"prefer-const": "error"})
+
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{"check", "--cwd", root, "--plugins-json", lintManifest(t)})
+  })
+  if code != 2 || stdout != "" || strings.Count(stderr, "[prefer-const]") != 2 {
+    t.Fatalf("prefer-const destructuring-read diagnostics mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}

--- a/packages/lint/test/rules/variables-assignments/prefer_const_counts_non_null_assignment_target_by_symbol_test.go
+++ b/packages/lint/test/rules/variables-assignments/prefer_const_counts_non_null_assignment_target_by_symbol_test.go
@@ -1,0 +1,19 @@
+package linthost
+
+import "testing"
+
+// TestPreferConstCountsNonNullAssignmentTargetBySymbol verifies asserted writes remain mutable.
+//
+// TypeScript wraps `value!` in a NonNullExpression even when it appears on an
+// assignment's left side. The target walker must unwrap that node so a later
+// asserted write prevents prefer-const from offering an invalid keyword fix.
+//
+//  1. Initialize a nullable let binding.
+//  2. Reassign it through a non-null assertion target.
+//  3. Assert prefer-const emits no finding for the mutable binding.
+func TestPreferConstCountsNonNullAssignmentTargetBySymbol(t *testing.T) {
+  assertRuleSkipsSource(t, "prefer-const", `let value: number | undefined = undefined;
+value! = 2;
+console.log(value);
+`)
+}

--- a/packages/lint/test/rules/variables-assignments/prefer_const_counts_parenthesized_update_target_by_symbol_test.go
+++ b/packages/lint/test/rules/variables-assignments/prefer_const_counts_parenthesized_update_target_by_symbol_test.go
@@ -1,0 +1,21 @@
+package linthost
+
+import "testing"
+
+// TestPreferConstCountsParenthesizedUpdateTargetBySymbol verifies wrapped updates remain mutable.
+//
+// Prefix and postfix update operands may be parenthesized even though the
+// underlying binding is the write target. Normalizing those operands through
+// the shared target walker prevents prefer-const from missing either update.
+//
+//  1. Initialize separate prefix and postfix update bindings.
+//  2. Update each binding through a parenthesized operand.
+//  3. Assert prefer-const emits no finding for either mutable binding.
+func TestPreferConstCountsParenthesizedUpdateTargetBySymbol(t *testing.T) {
+  assertRuleSkipsSource(t, "prefer-const", `let prefix = 0;
+++(prefix);
+let postfix = 0;
+(postfix)++;
+console.log(prefix, postfix);
+`)
+}

--- a/packages/lint/test/rules/variables-assignments/prefer_const_counts_write_forms_by_symbol_test.go
+++ b/packages/lint/test/rules/variables-assignments/prefer_const_counts_write_forms_by_symbol_test.go
@@ -1,0 +1,51 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestPreferConstCountsWriteFormsBySymbol verifies every reassignment surface.
+//
+// Compound and update expressions, destructuring targets, loop targets, and
+// closure writes must all disqualify only the symbol they resolve to. A stable
+// sibling remains the positive control for over-suppression.
+//
+//  1. Reassign separate `let` bindings through each supported write shape.
+//  2. Keep one initialized binding unchanged beside the negative controls.
+//  3. Assert the unchanged binding produces the sole finding.
+func TestPreferConstCountsWriteFormsBySymbol(t *testing.T) {
+  root := seedLintProject(t, `let stable = 1;
+
+let compound = 0;
+compound += 1;
+
+let updated = 0;
+updated++;
+
+let arrayLeft = 1;
+let arrayRight = 2;
+[arrayLeft, arrayRight] = [arrayRight, arrayLeft];
+
+let objectTarget = 0;
+({ objectTarget } = { objectTarget: 1 });
+
+let loopTarget = 0;
+for (loopTarget of [1, 2]) {
+  console.log(loopTarget);
+}
+
+let captured = 0;
+const increment = (): number => ++captured;
+
+console.log(stable, compound, updated, arrayLeft, arrayRight, objectTarget, increment());
+`)
+  seedLintRules(t, root, map[string]string{"prefer-const": "error"})
+
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{"check", "--cwd", root, "--plugins-json", lintManifest(t)})
+  })
+  if code != 2 || stdout != "" || strings.Count(stderr, "[prefer-const]") != 1 {
+    t.Fatalf("prefer-const write-form diagnostics mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}

--- a/packages/lint/test/rules/variables-assignments/prefer_const_honors_destructuring_option_test.go
+++ b/packages/lint/test/rules/variables-assignments/prefer_const_honors_destructuring_option_test.go
@@ -1,0 +1,70 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestPreferConstHonorsDestructuringOption verifies partial-pattern policy.
+//
+// The default `any` policy reports stable leaves even when a sibling is
+// reassigned. The `all` policy suppresses that partial pattern while still
+// reporting every leaf of a wholly stable destructuring declaration.
+//
+//  1. Create partial declaration and assignment patterns plus one wholly stable pattern.
+//  2. Run prefer-const under the default and `destructuring: "all"` policies.
+//  3. Assert the finding counts are five and two respectively.
+func TestPreferConstHonorsDestructuringOption(t *testing.T) {
+  source := `const input = { first: 1, second: 2 };
+let { first, second } = input;
+first += 1;
+
+let { first: stableFirst, second: stableSecond } = input;
+
+let assignedFirst: number, assignedSecond: number;
+({ first: assignedFirst, second: assignedSecond } = input);
+assignedFirst += 1;
+
+let mixedAssigned: number;
+let mixedMutable = 0;
+[mixedAssigned, mixedMutable] = [1, 2];
+
+{
+  let nestedAssigned: number;
+  var outerMutable = 0;
+  [nestedAssigned, outerMutable] = [1, 2];
+  console.log(nestedAssigned, outerMutable);
+}
+
+function keepParameter(parameter: number): void {
+  let parameterSibling: number;
+  [parameterSibling, parameter] = [1, 2];
+  console.log(parameterSibling, parameter);
+}
+
+console.log(first, second, stableFirst, stableSecond, assignedFirst, assignedSecond, mixedAssigned, mixedMutable);
+keepParameter(0);
+`
+
+  defaultRoot := seedLintProject(t, source)
+  seedLintRules(t, defaultRoot, map[string]string{"prefer-const": "error"})
+  defaultCode, defaultStdout, defaultStderr := captureCommandOutput(t, func() int {
+    return run([]string{"check", "--cwd", defaultRoot, "--plugins-json", lintManifest(t)})
+  })
+  if defaultCode != 2 || defaultStdout != "" || strings.Count(defaultStderr, "[prefer-const]") != 5 {
+    t.Fatalf("prefer-const destructuring any mismatch: code=%d stdout=%q stderr=%q", defaultCode, defaultStdout, defaultStderr)
+  }
+
+  allRoot := seedLintProject(t, source)
+  seedLintConfig(t, allRoot, map[string]any{
+    "rules": map[string]any{
+      "prefer-const": []any{"error", map[string]any{"destructuring": "all"}},
+    },
+  })
+  allCode, allStdout, allStderr := captureCommandOutput(t, func() int {
+    return run([]string{"check", "--cwd", allRoot, "--plugins-json", lintManifest(t)})
+  })
+  if allCode != 2 || allStdout != "" || strings.Count(allStderr, "[prefer-const]") != 2 {
+    t.Fatalf("prefer-const destructuring all mismatch: code=%d stdout=%q stderr=%q", allCode, allStdout, allStderr)
+  }
+}

--- a/packages/lint/test/rules/variables-assignments/prefer_const_honors_ignore_read_before_assign_for_shorthand_read_test.go
+++ b/packages/lint/test/rules/variables-assignments/prefer_const_honors_ignore_read_before_assign_for_shorthand_read_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestPreferConstHonorsIgnoreReadBeforeAssignForShorthandRead verifies shorthand reads resolve to values.
+//
+// The checker exposes a property symbol for a shorthand property name unless
+// callers request its value symbol. Resolving that value binding ensures an
+// object-literal read before assignment activates ignoreReadBeforeAssign.
+//
+//  1. Read a declaration-only binding through an object-literal shorthand.
+//  2. Assign the binding once and enable ignoreReadBeforeAssign.
+//  3. Assert prefer-const suppresses the read-before-assignment binding.
+func TestPreferConstHonorsIgnoreReadBeforeAssignForShorthandRead(t *testing.T) {
+  assertRuleSkipsSourceWithOptions(
+    t,
+    "prefer-const",
+    `let value: number;
+console.log({ value });
+value = 1;
+console.log(value);
+`,
+    `{"ignoreReadBeforeAssign":true}`,
+  )
+}

--- a/packages/lint/test/rules/variables-assignments/prefer_const_honors_ignore_read_before_assign_test.go
+++ b/packages/lint/test/rules/variables-assignments/prefer_const_honors_ignore_read_before_assign_test.go
@@ -1,0 +1,51 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestPreferConstHonorsIgnoreReadBeforeAssign verifies first-assignment option semantics.
+//
+// A declaration followed by one same-scope assignment is const-eligible. A
+// prior closure read is still reported by default, but the explicit option
+// suppresses that binding while leaving an unread sibling eligible.
+//
+//  1. Declare two uninitialized bindings and assign each exactly once.
+//  2. Read one binding in a function written before its assignment.
+//  3. Compare the default two findings with the option-enabled single finding.
+func TestPreferConstHonorsIgnoreReadBeforeAssign(t *testing.T) {
+  source := `let assignedLater: number;
+assignedLater = 1;
+
+let readBeforeAssign: number;
+function read(): number {
+  return readBeforeAssign;
+}
+readBeforeAssign = 2;
+
+console.log(assignedLater, read());
+`
+
+  defaultRoot := seedLintProject(t, source)
+  seedLintRules(t, defaultRoot, map[string]string{"prefer-const": "error"})
+  defaultCode, defaultStdout, defaultStderr := captureCommandOutput(t, func() int {
+    return run([]string{"check", "--cwd", defaultRoot, "--plugins-json", lintManifest(t)})
+  })
+  if defaultCode != 2 || defaultStdout != "" || strings.Count(defaultStderr, "[prefer-const]") != 2 {
+    t.Fatalf("prefer-const default read-before diagnostics mismatch: code=%d stdout=%q stderr=%q", defaultCode, defaultStdout, defaultStderr)
+  }
+
+  ignoredRoot := seedLintProject(t, source)
+  seedLintConfig(t, ignoredRoot, map[string]any{
+    "rules": map[string]any{
+      "prefer-const": []any{"error", map[string]any{"ignoreReadBeforeAssign": true}},
+    },
+  })
+  ignoredCode, ignoredStdout, ignoredStderr := captureCommandOutput(t, func() int {
+    return run([]string{"check", "--cwd", ignoredRoot, "--plugins-json", lintManifest(t)})
+  })
+  if ignoredCode != 2 || ignoredStdout != "" || strings.Count(ignoredStderr, "[prefer-const]") != 1 {
+    t.Fatalf("prefer-const ignored read-before diagnostics mismatch: code=%d stdout=%q stderr=%q", ignoredCode, ignoredStdout, ignoredStderr)
+  }
+}

--- a/packages/lint/test/rules/variables-assignments/prefer_const_test.go
+++ b/packages/lint/test/rules/variables-assignments/prefer_const_test.go
@@ -1,20 +1,51 @@
 package linthost
 
-import "testing"
+import (
+  "strings"
+  "testing"
+)
 
-// TestRuleCorpusPreferConst verifies the lint rule corpus fixture prefer-const.ts.
+// TestRuleCorpusPreferConst verifies the prefer-const corpus through a real Program.
 //
-// Rule corpus tests mirror tests/test-lint/src/cases inside Go unit coverage. Each generated
-// scenario keeps one annotated TypeScript fixture tied to the native Engine so individual rule
-// Check methods are measured by go test instead of only by the TypeScript feature runner.
+// Binding identity comes from TypeScript's checker, so the parser-only corpus
+// helper cannot exercise this rule. The command path supplies the checker and
+// preserves the existing positive and reassignment controls.
 //
-// This case enables the rule annotations declared in prefer-const.ts and compares normalized
-// rule, severity, and line triples. The source text stays embedded in the generated Go file so
-// the test remains package-local and deterministic.
-//
-// 1. Load the annotated TypeScript fixture source embedded below.
-// 2. Enable the rule severities declared by its // expect: comments.
-// 3. Assert the native Engine reports exactly the annotated diagnostics.
+//  1. Seed initialized, updated, loop, and destructuring-assignment bindings.
+//  2. Run check with only prefer-const enabled.
+//  3. Assert only the stable declaration and fresh for-of binding are reported.
 func TestRuleCorpusPreferConst(t *testing.T) {
-  assertRuleCorpusCase(t, "prefer-const.ts", "// expect: prefer-const error\nlet stable = 1;\nlet changing = 1;\nchanging = 2;\n\nfor (let i = 0; i < 2; i++) {\n  JSON.stringify(i);\n}\n\n// expect: prefer-const error\nfor (let item of [1, 2]) {\n  JSON.stringify(item);\n}\n\n// Destructuring-assignment targets reassign their identifiers, so neither\n// `swapLeft` nor `swapRight` is const-able and must stay unflagged.\nlet swapLeft = 1;\nlet swapRight = 2;\n[swapLeft, swapRight] = [swapRight, swapLeft];\n\n// Object-destructuring assignment reassigns `picked` through a property value.\nlet picked = 0;\n({ picked } = { picked: 9 });\n\nJSON.stringify([stable, changing, swapLeft, swapRight, picked]);\n")
+  root := seedLintProject(t, `let stable = 1;
+let changing = 1;
+changing = 2;
+
+for (let i = 0; i < 2; i++) {
+  JSON.stringify(i);
+}
+
+for (let item of [1, 2]) {
+  JSON.stringify(item);
+}
+
+let swapLeft = 1;
+let swapRight = 2;
+[swapLeft, swapRight] = [swapRight, swapLeft];
+
+let picked = 0;
+({ picked } = { picked: 9 });
+
+JSON.stringify([stable, changing, swapLeft, swapRight, picked]);
+`)
+  seedLintRules(t, root, map[string]string{"prefer-const": "error"})
+
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "check",
+      "--cwd", root,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  if code != 2 || stdout != "" || strings.Count(stderr, "[prefer-const]") != 2 {
+    t.Fatalf("prefer-const diagnostics mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
 }

--- a/packages/lint/test/rules/variables-assignments/prefer_const_tracks_lexical_binding_identity_test.go
+++ b/packages/lint/test/rules/variables-assignments/prefer_const_tracks_lexical_binding_identity_test.go
@@ -1,0 +1,54 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestPreferConstTracksLexicalBindingIdentity verifies same-spelled bindings stay independent.
+//
+// The former file-global name map let a write in one function suppress stable
+// bindings in sibling and shadowing scopes. Checker symbols must associate each
+// write with only the declaration it resolves to, including closure writes.
+//
+//  1. Declare stable and reassigned `value` bindings in sibling functions.
+//  2. Add a stable outer shadow plus mutable inner and closure-captured controls.
+//  3. Assert only the two stable lexical bindings are reported.
+func TestPreferConstTracksLexicalBindingIdentity(t *testing.T) {
+  root := seedLintProject(t, `function stableSibling(): number {
+  let value = 1;
+  return value;
+}
+
+function mutableSibling(): number {
+  let value = 1;
+  value += 1;
+  return value;
+}
+
+function shadowed(): number {
+  let value = 1;
+  {
+    let value = 2;
+    value++;
+    console.log(value);
+  }
+  return value;
+}
+
+function closureWrite(): () => number {
+  let captured = 0;
+  return () => ++captured;
+}
+
+console.log(stableSibling(), mutableSibling(), shadowed(), closureWrite()());
+`)
+  seedLintRules(t, root, map[string]string{"prefer-const": "error"})
+
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{"check", "--cwd", root, "--plugins-json", lintManifest(t)})
+  })
+  if code != 2 || stdout != "" || strings.Count(stderr, "[prefer-const]") != 2 {
+    t.Fatalf("prefer-const lexical diagnostics mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}

--- a/packages/lint/test/shared/helpers_test.go
+++ b/packages/lint/test/shared/helpers_test.go
@@ -399,7 +399,7 @@ func isBenignContributorCollisionWarning(stderr string) bool {
 // Fixer tests need the real file-writing path, not just in-memory edit
 // selection, because RunFix reloads a fresh Program from disk after every pass.
 //
-// 1. Materialize a real source file and parse it through the shim parser.
+// 1. Materialize a real source file and load the AST or checker path the rule requires.
 // 2. Run one enabled rule and apply collected text edits to disk.
 // 3. Compare the rewritten source exactly.
 func assertFixSnapshot(t *testing.T, ruleName, source, expected string) {
@@ -432,11 +432,7 @@ func assertNoFixSnapshot(t *testing.T, ruleName, source string) {
 // that previously fired on the wrong shape and corrupted source.
 func assertRuleSkipsSource(t *testing.T, ruleName, source string) {
   t.Helper()
-  root := t.TempDir()
-  filePath := filepath.Join(root, "src", "main.ts")
-  writeFile(t, filePath, source)
-  file := parseTSFile(t, filePath, source)
-  findings := NewEngine(RuleConfig{ruleName: SeverityError}).Run([]*shimast.SourceFile{file}, nil)
+  _, _, findings := runRuleFindingsSnapshot(t, ruleName, source, nil)
   if len(findings) != 0 {
     t.Fatalf("%s: expected zero findings, got %d (%+v)", ruleName, len(findings), findings)
   }
@@ -447,18 +443,10 @@ func assertRuleSkipsSource(t *testing.T, ruleName, source string) {
 // Mirrors `assertFixSnapshot`; option-gated sibling of
 // `assertRuleSkipsSourceWithOptions`. Cannot delegate to `runFixSnapshot`
 // because that path uses the default `NewEngine` rather than
-// `NewEngineWithResolver`, so the resolver wiring is inlined here.
+// `NewEngineWithResolver`; the shared findings loader selects the resolver.
 func assertFixSnapshotWithOptions(t *testing.T, ruleName, source, optsJSON, expected string) {
   t.Helper()
-  root := t.TempDir()
-  filePath := filepath.Join(root, "src", "main.ts")
-  writeFile(t, filePath, source)
-  file := parseTSFile(t, filePath, source)
-  resolver := InlineRuleResolver{
-    Rules:   RuleConfig{ruleName: SeverityError},
-    Options: RuleOptionsMap{ruleName: json.RawMessage(optsJSON)},
-  }
-  findings := NewEngineWithResolver(resolver).Run([]*shimast.SourceFile{file}, nil)
+  root, filePath, findings := runRuleFindingsSnapshot(t, ruleName, source, json.RawMessage(optsJSON))
   if len(findings) == 0 {
     t.Fatalf("%s: expected at least one finding", ruleName)
   }
@@ -485,15 +473,7 @@ func assertFixSnapshotWithOptions(t *testing.T, ruleName, source, optsJSON, expe
 // to inline `InlineRuleResolver` + `NewEngineWithResolver` boilerplate.
 func assertRuleSkipsSourceWithOptions(t *testing.T, ruleName, source, optsJSON string) {
   t.Helper()
-  root := t.TempDir()
-  filePath := filepath.Join(root, "src", "main.ts")
-  writeFile(t, filePath, source)
-  file := parseTSFile(t, filePath, source)
-  resolver := InlineRuleResolver{
-    Rules:   RuleConfig{ruleName: SeverityError},
-    Options: RuleOptionsMap{ruleName: json.RawMessage(optsJSON)},
-  }
-  findings := NewEngineWithResolver(resolver).Run([]*shimast.SourceFile{file}, nil)
+  _, _, findings := runRuleFindingsSnapshot(t, ruleName, source, json.RawMessage(optsJSON))
   if len(findings) != 0 {
     t.Fatalf("%s: expected zero findings, got %d (%+v)", ruleName, len(findings), findings)
   }
@@ -501,11 +481,7 @@ func assertRuleSkipsSourceWithOptions(t *testing.T, ruleName, source, optsJSON s
 
 func runFixSnapshot(t *testing.T, ruleName, source string) (string, int) {
   t.Helper()
-  root := t.TempDir()
-  filePath := filepath.Join(root, "src", "main.ts")
-  writeFile(t, filePath, source)
-  file := parseTSFile(t, filePath, source)
-  findings := NewEngine(RuleConfig{ruleName: SeverityError}).Run([]*shimast.SourceFile{file}, nil)
+  root, filePath, findings := runRuleFindingsSnapshot(t, ruleName, source, nil)
   if len(findings) == 0 {
     t.Fatalf("%s: expected at least one finding", ruleName)
   }
@@ -518,4 +494,49 @@ func runFixSnapshot(t *testing.T, ruleName, source string) (string, int) {
     t.Fatalf("%s: ReadFile: %v", ruleName, err)
   }
   return string(got), fixed
+}
+
+// runRuleFindingsSnapshot runs one rule against a disk-backed source file.
+// AST-only rules keep the parser-only fast path; type-aware rules receive a
+// real Program and checker so fixer tests exercise the same binding identity
+// as command, LSP, and CLI execution.
+func runRuleFindingsSnapshot(
+  t *testing.T,
+  ruleName string,
+  source string,
+  options json.RawMessage,
+) (string, string, []*Finding) {
+  t.Helper()
+  var engine *Engine
+  if len(options) == 0 {
+    engine = NewEngine(RuleConfig{ruleName: SeverityError})
+  } else {
+    engine = NewEngineWithResolver(InlineRuleResolver{
+      Rules:   RuleConfig{ruleName: SeverityError},
+      Options: RuleOptionsMap{ruleName: options},
+    })
+  }
+
+  if !engine.NeedsTypeChecker() {
+    root := t.TempDir()
+    filePath := filepath.Join(root, "src", "main.ts")
+    writeFile(t, filePath, source)
+    file := parseTSFile(t, filePath, source)
+    return root, filePath, engine.Run([]*shimast.SourceFile{file}, nil)
+  }
+
+  root := seedLintProject(t, source)
+  filePath := filepath.Join(root, "src", "main.ts")
+  program, diagnostics, err := loadProgram(root, "tsconfig.json", loadProgramOptions{
+    forceNoEmit:      true,
+    needsRuleChecker: true,
+  })
+  if err != nil {
+    t.Fatalf("%s: loadProgram: %v", ruleName, err)
+  }
+  if program == nil {
+    t.Fatalf("%s: loadProgram returned no program (%+v)", ruleName, diagnostics)
+  }
+  defer program.close()
+  return root, filePath, engine.Run(program.userSourceFiles(), program.checker)
 }

--- a/tests/projects/lint-prefer-const-lexical/lint.config.json
+++ b/tests/projects/lint-prefer-const-lexical/lint.config.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "prefer-const": "error"
+  }
+}

--- a/tests/projects/lint-prefer-const-lexical/package.json
+++ b/tests/projects/lint-prefer-const-lexical/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "devDependencies": {
+    "@ttsc/lint": "*"
+  }
+}

--- a/tests/projects/lint-prefer-const-lexical/src/case.ts
+++ b/tests/projects/lint-prefer-const-lexical/src/case.ts
@@ -1,0 +1,28 @@
+function shouldReport(): number {
+  // expect: prefer-const error
+  let value = 1;
+  return value;
+}
+
+function sameNameButReassigned(): number {
+  let value = 1;
+  value += 1;
+  return value;
+}
+
+let assignedLater: number;
+// expect: prefer-const error
+assignedLater = 1;
+
+const input = { first: 1, second: 2 };
+// expect: prefer-const error
+let { first, second } = input;
+first += 1;
+
+console.log(
+  shouldReport(),
+  sameNameButReassigned(),
+  assignedLater,
+  first,
+  second,
+);

--- a/tests/projects/lint-prefer-const-lexical/tsconfig.json
+++ b/tests/projects/lint-prefer-const-lexical/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "rootDir": "src"
+  },
+  "files": ["src/case.ts"]
+}

--- a/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
+++ b/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
@@ -27,6 +27,7 @@ import assert from "node:assert/strict";
  *   on `no-duplicate-imports`) is rejected.
  * - Typo'd option key on another options-bearing core rule (`allowTernery` for
  *   `allowTernary` on `no-unused-expressions`) is rejected.
+ * - An unsupported `prefer-const` destructuring policy is rejected.
  * - Cross-rule option leakage (`testIdPattern` on
  *   `cypress/unsafe-to-chain-command`) is rejected.
  * - A lint-only rule (`no-var`) cannot carry an options object.
@@ -54,6 +55,10 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
       "no-unused-expressions": [
         "error",
         { allowShortCircuit: true, allowTaggedTemplates: true },
+      ],
+      "prefer-const": [
+        "error",
+        { destructuring: "all", ignoreReadBeforeAssign: true },
       ],
       "cypress/unsafe-to-chain-command": [
         "warning",
@@ -121,6 +126,12 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
       "no-unused-expressions": ["error", { allowTernery: true }],
     },
   };
+  const preferConstOptionValue: ITtscLintConfig = {
+    rules: {
+      // @ts-expect-error — prefer-const accepts only the official `any` and `all` destructuring policies.
+      "prefer-const": ["error", { destructuring: "some" }],
+    },
+  };
   const crossRuleShape: ITtscLintConfig = {
     rules: {
       // @ts-expect-error — `testIdPattern` belongs to testing-library/consistent-data-testid; cypress/unsafe-to-chain-command's option shape rejects it.
@@ -147,6 +158,7 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
   assert.ok(noDuplicateImportsOptionKeyTypo);
   assert.ok(noDuplicateImportsOptionValueShape);
   assert.ok(noUnusedExpressionsOptionKeyTypo);
+  assert.ok(preferConstOptionValue);
   assert.ok(crossRuleShape);
   assert.ok(lintRuleWithOptions);
   assert.ok(camelBuiltinName);

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_auto_discovered_lint_prefer_const_tracks_lexical_bindings.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_auto_discovered_lint_prefer_const_tracks_lexical_bindings.ts
@@ -1,0 +1,43 @@
+import { SHARED_PLUGIN_CACHE_DIR } from "../../internal/plugin-cache";
+import {
+  assert,
+  goPath,
+  parseDiagnostics,
+  parseExpectations,
+  path,
+  setupLintProject,
+  spawn,
+  ttscBin,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies auto-discovered lint prefer-const tracks lexical bindings.
+ *
+ * The issue reproduction intentionally has no tsconfig `plugins` entry. The
+ * package-level auto-plugin path must still run the native rule and produce the
+ * three ESLint-default findings without suppressing same-spelled siblings.
+ *
+ * 1. Copy the strict NodeNext fixture with @ttsc/lint as a dev dependency.
+ * 2. Run the real ttsc CLI with no explicit transform plugin configuration.
+ * 3. Compare all prefer-const diagnostics with the annotated three findings.
+ */
+export const test_plugin_corpus_auto_discovered_lint_prefer_const_tracks_lexical_bindings =
+  () => {
+    const root = setupLintProject("lint-prefer-const-lexical");
+    const source = path.join(root, "src", "case.ts");
+
+    const result = spawn(ttscBin, ["--cwd", root, "--noEmit"], {
+      cwd: root,
+      env: {
+        PATH: goPath(),
+        TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
+      },
+    });
+
+    assert.notEqual(result.status, 0, "expected prefer-const diagnostics");
+    assert.deepEqual(
+      parseDiagnostics(result.stderr, source),
+      parseExpectations(source),
+      result.stderr,
+    );
+  };

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -2555,7 +2555,20 @@ list.map(
 
 ### `prefer-const`
 
-Require `const` for variables that are never reassigned after declaration. Autofixable for single-declaration `let`s.
+Require `const` for lexical bindings that are never reassigned after their initial value is established. Same-spelled bindings in sibling, nested, and shadowing scopes are analyzed independently. A declaration followed by one assignment in the same scope is reported without an automatic rewrite.
+
+The default options match ESLint:
+
+```json
+{
+  "destructuring": "any",
+  "ignoreReadBeforeAssign": false
+}
+```
+
+`destructuring: "any"` reports each const-eligible leaf of a destructuring pattern. Set it to `"all"` to report the pattern only when every leaf is const-eligible. Set `ignoreReadBeforeAssign` to `true` to keep declaration-only bindings that are read before their first assignment out of the findings.
+
+The fixer changes the shared `let` keyword only for a single initialized declaration when every binding affected by that keyword is const-eligible. Findings that would require moving an assignment, splitting a declaration, or preserving comments across statements are diagnostic-only.
 
 Example:
 
@@ -2564,6 +2577,14 @@ Example:
 let stable = 1;
 let changing = 1;
 changing = 2;
+
+let assignedLater: number;
+// reports: prefer-const (error, diagnostic-only)
+assignedLater = 1;
+
+const input = { first: 1, second: 2 };
+let { first, second } = input; // reports `second`
+first += 1;
 ```
 
 <a id="rule-prefer-destructuring"></a>


### PR DESCRIPTION
## Summary

- resolve `prefer-const` declarations and writes by TypeScript checker symbol, so sibling, nested, shadowed, and closure-captured bindings stay independent
- implement ESLint-compatible declaration-only, `ignoreReadBeforeAssign`, and `destructuring: any | all` behavior while keeping unsafe nonlocal rewrites diagnostic-only
- add checker-backed native coverage, fixer boundaries, typed configuration coverage, a real no-plugin CLI fixture, and rule documentation

## Root cause

The rule stored writes in a file-global `map[string]bool`, which conflated unrelated same-spelled bindings. It also excluded declaration-only and destructured bindings before write-history analysis.

## Validation

GitHub CI is the source of build, test, typecheck, lint, static-analysis, and reproduction evidence for this change. Per the task contract, those commands were not run locally.

Closes #410