### PR TITLE
fix(lint): complete prefer-as-const suggestion parity

### DIFF
--- a/packages/lint/linthost/rules_ts.go
+++ b/packages/lint/linthost/rules_ts.go
@@ -4,7 +4,12 @@
 // Each rule is registered in the package init function at the bottom.
 package linthost
 
-import shimast "github.com/microsoft/typescript-go/shim/ast"
+import (
+  "strings"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+)
 
 // noExplicitAny: ban `: any` annotations. Loud equivalent of
 // `@typescript-eslint/no-explicit-any`.
@@ -188,7 +193,7 @@ func (preferAsConst) Check(ctx *Context, node *shimast.Node) {
     }
   case shimast.KindVariableDeclaration:
     if decl := node.AsVariableDeclaration(); decl != nil {
-      preferAsConstCheckAnnotation(ctx, decl.Initializer, decl.Type)
+      preferAsConstCheckAnnotation(ctx, node, decl.Initializer, decl.Type)
     }
   case shimast.KindPropertyDeclaration:
     decl := node.AsPropertyDeclaration()
@@ -201,41 +206,151 @@ func (preferAsConst) Check(ctx *Context, node *shimast.Node) {
     if node.ModifierFlags()&shimast.ModifierFlagsAccessor != 0 {
       return
     }
-    preferAsConstCheckAnnotation(ctx, decl.Initializer, decl.Type)
+    preferAsConstCheckAnnotation(ctx, node, decl.Initializer, decl.Type)
   }
 }
 
 // preferAsConstCheckAssertion handles the `expr as T` / `<T>expr` assertion
-// forms. These are directly autofixable: the literal type is replaced by the
-// `const` keyword in place, so no other source text moves.
+// forms. These are directly autofixable: the literal type becomes `const`, and
+// any type-only parentheses are removed without disturbing their comments.
 func preferAsConstCheckAssertion(ctx *Context, expr, typeNode *shimast.Node) {
   if !preferAsConstLiteralsMatch(ctx.File, expr, typeNode) {
     return
   }
   message := "Expected `as const` instead of `as` literal type."
-  pos, end := tokenRange(ctx.File, typeNode)
-  if pos < 0 {
+  edits := preferAsConstAssertionEdits(ctx.File, typeNode)
+  if len(edits) == 0 {
     ctx.Report(typeNode, message)
     return
   }
-  ctx.ReportFix(
-    typeNode,
-    message,
-    TextEdit{Pos: pos, End: end, Text: "const"},
-  )
+  ctx.ReportFix(typeNode, message, edits...)
+}
+
+// preferAsConstAssertionEdits replaces the innermost literal type and removes
+// only the syntactic parentheses around it. Keeping the trivia between those
+// tokens preserves comments while producing valid `as const` / `<const>`
+// syntax instead of the invalid `as (const)` shape.
+func preferAsConstAssertionEdits(file *shimast.SourceFile, typeNode *shimast.Node) []TextEdit {
+  if file == nil || typeNode == nil {
+    return nil
+  }
+  edits := []TextEdit{}
+  for typeNode.Kind == shimast.KindParenthesizedType {
+    parenthesized := typeNode.AsParenthesizedTypeNode()
+    if parenthesized == nil || parenthesized.Type == nil {
+      return nil
+    }
+    openScanner := shimscanner.GetScannerForSourceFile(file, typeNode.Pos())
+    if openScanner.Token() != shimast.KindOpenParenToken {
+      return nil
+    }
+    closeScanner := shimscanner.GetScannerForSourceFile(file, parenthesized.Type.End())
+    if closeScanner.Token() != shimast.KindCloseParenToken || closeScanner.TokenEnd() > typeNode.End() {
+      return nil
+    }
+    edits = append(edits,
+      TextEdit{Pos: openScanner.TokenStart(), End: openScanner.TokenEnd()},
+      TextEdit{Pos: closeScanner.TokenStart(), End: closeScanner.TokenEnd()},
+    )
+    typeNode = parenthesized.Type
+  }
+  pos, end := tokenRange(file, typeNode)
+  if pos < 0 {
+    return nil
+  }
+  return append(edits, TextEdit{Pos: pos, End: end, Text: "const"})
 }
 
 // preferAsConstCheckAnnotation handles variable declarators and class
 // property declarations whose literal type annotation repeats the
-// initializer literal. The upstream rule pairs this report with a
-// suggestion, not an autofix — `eslint --fix` never rewrites these
-// declarations — and `ttsc fix` applies every emitted TextEdit
-// unconditionally, so the finding carries none.
-func preferAsConstCheckAnnotation(ctx *Context, init, typeNode *shimast.Node) {
+// initializer literal. The upstream rule pairs this report with a manual
+// suggestion, not an autofix: it removes the annotation and appends `as const`
+// after the initializer while `eslint --fix` leaves the declaration alone.
+func preferAsConstCheckAnnotation(ctx *Context, declaration, init, typeNode *shimast.Node) {
   if init == nil || !preferAsConstLiteralsMatch(ctx.File, init, typeNode) {
     return
   }
-  ctx.Report(typeNode, "Expected a `const` assertion instead of a literal type annotation.")
+  annotationStart := preferAsConstAnnotationStart(ctx.File, declaration, typeNode)
+  _, annotationEnd := tokenRange(ctx.File, typeNode)
+  message := "Expected a `const` assertion instead of a literal type annotation."
+  if annotationStart < 0 || annotationEnd < annotationStart || init.End() < annotationEnd {
+    ctx.Report(typeNode, message)
+    return
+  }
+  ctx.ReportSuggestion(
+    typeNode,
+    message,
+    "Replace the literal type annotation with `as const`.",
+    TextEdit{
+      Pos:  annotationStart,
+      End:  annotationEnd,
+      Text: preferAsConstPreservedAnnotationComments(ctx.File, annotationStart, annotationEnd),
+    },
+    TextEdit{
+      Pos:  init.End(),
+      End:  init.End(),
+      Text: " as const",
+    },
+  )
+}
+
+// preferAsConstPreservedAnnotationComments keeps comments embedded in the
+// removed annotation. Multiline comments remain space-separated; line comments
+// retain their line ending so the following initializer cannot be commented
+// out. Syntax tokens and whitespace are intentionally discarded.
+func preferAsConstPreservedAnnotationComments(file *shimast.SourceFile, start, end int) string {
+  if file == nil || start < 0 || end <= start || end > len(file.Text()) {
+    return ""
+  }
+  src := file.Text()
+  scanner := shimscanner.GetScannerForSourceFile(file, start)
+  scanner.SetSkipTrivia(false)
+  var preserved strings.Builder
+  lineEnded := false
+  for scanner.TokenStart() < end && scanner.Token() != shimast.KindEndOfFile {
+    kind := scanner.Token()
+    if kind == shimast.KindSingleLineCommentTrivia || kind == shimast.KindMultiLineCommentTrivia {
+      if preserved.Len() == 0 || !lineEnded {
+        preserved.WriteByte(' ')
+      }
+      preserved.WriteString(scanner.TokenText())
+      lineEnded = false
+      if kind == shimast.KindSingleLineCommentTrivia {
+        switch tokenEnd := scanner.TokenEnd(); {
+        case tokenEnd+1 < len(src) && src[tokenEnd:tokenEnd+2] == "\r\n":
+          preserved.WriteString("\r\n")
+        case tokenEnd < len(src) && (src[tokenEnd] == '\r' || src[tokenEnd] == '\n'):
+          preserved.WriteByte(src[tokenEnd])
+        default:
+          preserved.WriteByte('\n')
+        }
+        lineEnded = true
+      }
+    }
+    scanner.Scan()
+  }
+  return preserved.String()
+}
+
+// preferAsConstAnnotationStart locates the annotation's colon by tokenizing
+// only the declaration segment between its name and type. This preserves
+// modifiers, computed names, and postfix `?` / `!` markers without relying on
+// source-text regular expressions.
+func preferAsConstAnnotationStart(file *shimast.SourceFile, declaration, typeNode *shimast.Node) int {
+  if file == nil || declaration == nil || typeNode == nil || declaration.Name() == nil {
+    return -1
+  }
+  scanner := shimscanner.GetScannerForSourceFile(file, declaration.Name().End())
+  for {
+    kind := scanner.Token()
+    if kind == shimast.KindColonToken {
+      return scanner.TokenStart()
+    }
+    if kind == shimast.KindEndOfFile || scanner.TokenStart() >= typeNode.End() {
+      return -1
+    }
+    scanner.Scan()
+  }
 }
 
 // preferAsConstLiteralsMatch reports whether typeNode is a literal type
@@ -248,7 +363,13 @@ func preferAsConstCheckAnnotation(ctx *Context, init, typeNode *shimast.Node) {
 // identically spelled template literal type and `null as null` stay clean
 // exactly like the upstream fixtures.
 func preferAsConstLiteralsMatch(file *shimast.SourceFile, expr, typeNode *shimast.Node) bool {
-  if expr == nil || typeNode == nil || typeNode.Kind != shimast.KindLiteralType {
+  if expr == nil || typeNode == nil {
+    return false
+  }
+  // typescript-estree erases both expression and type parentheses, so tsgo's
+  // ParenthesizedType wrappers must not affect the upstream raw-literal check.
+  typeNode = preferAsConstUnwrapType(typeNode)
+  if typeNode == nil || typeNode.Kind != shimast.KindLiteralType {
     return false
   }
   literalType := typeNode.AsLiteralTypeNode()
@@ -257,13 +378,23 @@ func preferAsConstLiteralsMatch(file *shimast.SourceFile, expr, typeNode *shimas
   }
   // ESTree does not represent expression parentheses, so upstream sees the
   // bare literal in `('a') as 'a'` and reports it; descend to the same
-  // canonical node. Type-side parentheses stay significant: tsgo keeps a
-  // ParenthesizedType node, which is not a literal type.
+  // canonical node.
   expr = stripParens(expr)
   if !isPreferAsConstLiteral(expr) || !isPreferAsConstLiteral(literalType.Literal) {
     return false
   }
   return nodeText(file, expr) == nodeText(file, literalType.Literal)
+}
+
+func preferAsConstUnwrapType(typeNode *shimast.Node) *shimast.Node {
+  for typeNode != nil && typeNode.Kind == shimast.KindParenthesizedType {
+    parenthesized := typeNode.AsParenthesizedTypeNode()
+    if parenthesized == nil || parenthesized.Type == nil {
+      return nil
+    }
+    typeNode = parenthesized.Type
+  }
+  return typeNode
 }
 
 // isPreferAsConstLiteral reports whether node is one of the literal token

--- a/packages/lint/src/structures/rules/ITtscLintTypeScriptRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintTypeScriptRules.ts
@@ -815,8 +815,9 @@ export interface ITtscLintTypeScriptRules {
    * Prefer `as const` over literal type assertions (`as "literal"`,
    * `<"literal">`) and matching literal type annotations on variable and
    * class-property declarations. Literals are compared by raw source spelling.
-   * Assertions are autofixable; annotation findings are detection-only
-   * (upstream offers only a suggestion, never a fix).
+   * Assertions are autofixable. Annotation findings expose an editor quick fix
+   * that removes the annotation and appends `as const`; `ttsc fix` never applies
+   * that suggestion automatically.
    *
    * @reference https://typescript-eslint.io/rules/prefer-as-const
    */

--- a/packages/lint/test/command/lsp_prefer_as_const_suggestion_executes_selected_range_test.go
+++ b/packages/lint/test/command/lsp_prefer_as_const_suggestion_executes_selected_range_test.go
@@ -1,0 +1,43 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestLSPPreferAsConstSuggestionExecutesSelectedRange verifies the editor path
+// exposes a range-scoped manual quick fix and executes only its stored target.
+func TestLSPPreferAsConstSuggestionExecutesSelectedRange(t *testing.T) {
+  source := "let first: (\"one\") = \"one\";\nlet second: (\"two\") = \"two\";\nJSON.stringify(first, second);\n"
+  root := seedLintProject(t, source)
+  seedLintConfig(t, root, map[string]any{
+    "rules": map[string]any{"typescript/prefer-as-const": "error"},
+  })
+  uri := lintTestFileURI(t, filepath.Join(root, "src", "main.ts"))
+  actions := runLSPCodeActionsForRangeForTest(
+    t,
+    root,
+    uri,
+    `{"start":{"line":1,"character":0},"end":{"line":1,"character":40}}`,
+    `{"only":["quickfix"]}`,
+  )
+  if len(actions) != 1 || actions[0].Command == nil {
+    t.Fatalf("quick-fix actions = %#v", actions)
+  }
+  action := actions[0]
+  if action.Kind != "quickfix.ttsc" || action.Command.Command != commandLintApplySuggestion {
+    t.Fatalf("unexpected quick fix = %#v", action)
+  }
+  edit := executeLSPCommandEditWithArgumentsForTest(
+    t,
+    root,
+    action.Command.Command,
+    action.Command.Arguments,
+    lintManifest(t),
+  )
+  rewritten := applyLSPWorkspaceEditForTest(t, source, edit.Changes[uri])
+  expected := "let first: (\"one\") = \"one\";\nlet second = \"two\" as const;\nJSON.stringify(first, second);\n"
+  if rewritten != expected {
+    t.Fatalf("quick-fix source mismatch:\nwant %q\ngot  %q", expected, rewritten)
+  }
+}

--- a/packages/lint/test/fix/fix_prefer_as_const_replaces_parenthesized_literal_type_test.go
+++ b/packages/lint/test/fix/fix_prefer_as_const_replaces_parenthesized_literal_type_test.go
@@ -1,0 +1,19 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferAsConstReplacesParenthesizedLiteralType verifies type-side
+// parentheses follow typescript-estree's erased-parentheses semantics.
+//
+// The fixer removes only the parenthesis tokens and replaces the inner literal,
+// preserving comments that sit inside the parenthesized type. Replacing only
+// the literal would produce invalid `as (const)` syntax; replacing the whole
+// wrapper would silently discard those comments.
+func TestFixPreferAsConstReplacesParenthesizedLiteralType(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "typescript/prefer-as-const",
+    "const value = \"literal\" as (/* keep */ \"literal\" /* tail */);\nJSON.stringify(value);\n",
+    "const value = \"literal\" as /* keep */ const /* tail */;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_prefer_as_const_skips_property_annotation_rewrite_test.go
+++ b/packages/lint/test/fix/fix_prefer_as_const_skips_property_annotation_rewrite_test.go
@@ -6,8 +6,9 @@ import "testing"
 //
 // Class property annotations follow the same suggestion-only upstream
 // contract as variable annotations: the declaration keeps its modifiers and
-// annotation untouched under `ttsc fix`, and only the diagnostic surfaces.
-// A TextEdit here would let the fix cascade silently rewrite class shapes.
+// annotation untouched under `ttsc fix`, while the manual suggestion remains
+// available to editors. A Finding.Fix edit here would let the fix cascade
+// silently rewrite class shapes.
 //
 // 1. Parse a class with `public value: "literal" = "literal";`.
 // 2. Run preferAsConst and apply any offered text edits.

--- a/packages/lint/test/fix/fix_prefer_as_const_skips_variable_annotation_rewrite_test.go
+++ b/packages/lint/test/fix/fix_prefer_as_const_skips_variable_annotation_rewrite_test.go
@@ -6,9 +6,9 @@ import "testing"
 //
 // Upstream pairs the variable-annotation report with a suggestion, never an
 // autofix: `eslint --fix` leaves `let x: 'a' = 'a'` untouched because the
-// rewrite moves the type out of the annotation. `ttsc fix` applies every
-// emitted TextEdit unconditionally, so the finding must carry none or the
-// fix command would apply what upstream reserves for a manual action.
+// rewrite moves the type out of the annotation. The finding carries that
+// rewrite only in Suggestions, leaving Fix empty so `ttsc fix` cannot apply
+// what upstream reserves for a manual action.
 //
 // 1. Parse a source file with `let value: "literal" = "literal";`.
 // 2. Run preferAsConst and apply any offered text edits.

--- a/packages/lint/test/fix/prefer_as_const_property_annotation_offers_exact_suggestion_test.go
+++ b/packages/lint/test/fix/prefer_as_const_property_annotation_offers_exact_suggestion_test.go
@@ -1,0 +1,36 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestPreferAsConstPropertyAnnotationOffersExactSuggestion verifies a manual
+// property rewrite preserves modifiers and source outside the annotation.
+func TestPreferAsConstPropertyAnnotationOffersExactSuggestion(t *testing.T) {
+  source := "class Holder {\n  public readonly /* keep */ value: /* annotation */ (\"literal\" /* tail */) = \"literal\" /* after */;\n}\nJSON.stringify(new Holder());\n"
+  file := parseTS(t, source)
+  findings := NewEngine(RuleConfig{"typescript/prefer-as-const": SeverityError}).Run(
+    []*shimast.SourceFile{file},
+    nil,
+  )
+  if len(findings) != 1 {
+    t.Fatalf("findings = %d, want 1", len(findings))
+  }
+  finding := findings[0]
+  if len(finding.Fix) != 0 || len(finding.Suggestions) != 1 {
+    t.Fatalf("fixes = %d, suggestions = %d", len(finding.Fix), len(finding.Suggestions))
+  }
+  rewritten, applied := applyFindingFixesToText(
+    source,
+    []*Finding{{Fix: finding.Suggestions[0].Edits}},
+  )
+  if applied != 2 {
+    t.Fatalf("applied edits = %d, want 2", applied)
+  }
+  expected := "class Holder {\n  public readonly /* keep */ value /* annotation */ /* tail */ = \"literal\" as const /* after */;\n}\nJSON.stringify(new Holder());\n"
+  if rewritten != expected {
+    t.Fatalf("suggested source mismatch:\nwant %q\ngot  %q", expected, rewritten)
+  }
+}

--- a/packages/lint/test/fix/prefer_as_const_variable_annotation_offers_exact_suggestion_test.go
+++ b/packages/lint/test/fix/prefer_as_const_variable_annotation_offers_exact_suggestion_test.go
@@ -1,0 +1,36 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestPreferAsConstVariableAnnotationOffersExactSuggestion verifies the
+// declaration rewrite is manual, complete, and trivia-safe.
+func TestPreferAsConstVariableAnnotationOffersExactSuggestion(t *testing.T) {
+  source := "let /* before */ value /* marker */: (\"literal\") = \"literal\" /* after */;\nJSON.stringify(value);\n"
+  file := parseTS(t, source)
+  findings := NewEngine(RuleConfig{"typescript/prefer-as-const": SeverityError}).Run(
+    []*shimast.SourceFile{file},
+    nil,
+  )
+  if len(findings) != 1 {
+    t.Fatalf("findings = %d, want 1", len(findings))
+  }
+  finding := findings[0]
+  if len(finding.Fix) != 0 || len(finding.Suggestions) != 1 {
+    t.Fatalf("fixes = %d, suggestions = %d", len(finding.Fix), len(finding.Suggestions))
+  }
+  rewritten, applied := applyFindingFixesToText(
+    source,
+    []*Finding{{Fix: finding.Suggestions[0].Edits}},
+  )
+  if applied != 2 {
+    t.Fatalf("applied edits = %d, want 2", applied)
+  }
+  expected := "let /* before */ value /* marker */ = \"literal\" as const /* after */;\nJSON.stringify(value);\n"
+  if rewritten != expected {
+    t.Fatalf("suggested source mismatch:\nwant %q\ngot  %q", expected, rewritten)
+  }
+}

--- a/tests/test-lint/src/native-plugins/config/test_lint_prefer_as_const_covers_all_rule_families_without_plugins_entry.ts
+++ b/tests/test-lint/src/native-plugins/config/test_lint_prefer_as_const_covers_all_rule_families_without_plugins_entry.ts
@@ -1,0 +1,71 @@
+import { assert, runLint } from "../../internal/config-file";
+
+/**
+ * Verifies prefer-as-const reaches all four upstream visitor families through
+ * package auto-discovery, including type parentheses erased by ts-estree.
+ *
+ * The fixture intentionally omits `compilerOptions.plugins`. Its package.json
+ * dependency and discovered lint.config.json are the only activation path.
+ * Raw-spelling and accessor negatives keep the rule from broadening beyond the
+ * upstream contract while the exact diagnostic set pins every visitor family.
+ */
+export const test_lint_prefer_as_const_covers_all_rule_families_without_plugins_entry =
+  () => {
+    const result = runLint({
+      name: "prefer-as-const-no-plugins-entry",
+      source: `const asserted = "asserted" as ("asserted");
+const angled = <("angled")>"angled";
+let variable: ("variable") = "variable";
+class Holder {
+  public readonly property: ("property") = "property";
+  accessor tracked: ("tracked") = "tracked";
+}
+const differentQuotes = 'different' as ("different");
+let differentNumeric: (10) = 0xa;
+
+JSON.stringify(asserted, angled, variable, new Holder(), differentQuotes, differentNumeric);
+`,
+      rules: { "typescript/prefer-as-const": "error" },
+      extraSources: {
+        "tsconfig.json": JSON.stringify(
+          {
+            compilerOptions: {
+              noEmit: true,
+              strict: true,
+              target: "ES2022",
+              module: "NodeNext",
+              moduleResolution: "NodeNext",
+            },
+            files: ["src/main.ts"],
+          },
+          null,
+          2,
+        ),
+        "package.json": JSON.stringify(
+          {
+            name: "prefer-as-const-no-plugins-entry-fixture",
+            private: true,
+            dependencies: { "@ttsc/lint": "*" },
+          },
+          null,
+          2,
+        ),
+      },
+    });
+
+    assert.notEqual(result.status, 0, result.stderr);
+    assert.deepEqual(
+      result.diagnostics.map(({ rule, severity, line }) => ({
+        rule,
+        severity,
+        line,
+      })),
+      [
+        { rule: "typescript/prefer-as-const", severity: "error", line: 1 },
+        { rule: "typescript/prefer-as-const", severity: "error", line: 2 },
+        { rule: "typescript/prefer-as-const", severity: "error", line: 3 },
+        { rule: "typescript/prefer-as-const", severity: "error", line: 5 },
+      ],
+      result.stderr,
+    );
+  };

--- a/website/src/content/docs/lint/rules/index.mdx
+++ b/website/src/content/docs/lint/rules/index.mdx
@@ -119,7 +119,7 @@ Formatter behavior is configured separately through the top-level `format` block
 
 - `no-var`, single-declaration `prefer-const`, ESLint-safe `eqeqeq`
 - `typescript/no-wrapper-object-types` (primitives only; `Object` is detection-only)
-- `typescript/prefer-as-const` (assertions only; annotation findings are detection-only), `no-useless-rename`, `object-shorthand`, `typescript/no-extra-non-null-assertion`
+- `typescript/prefer-as-const` (assertions only; annotation rewrites are editor suggestions), `no-useless-rename`, `object-shorthand`, `typescript/no-extra-non-null-assertion`
 - `typescript/no-unnecessary-type-constraint`, `typescript/prefer-namespace-keyword`, `no-useless-escape`
 - `typescript/no-import-type-side-effects` (hoists inline `type` modifiers)
 - `typescript/await-thenable` (type-aware: drops `await` only for its ordinary non-thenable operand finding)

--- a/website/src/content/docs/lint/rules/typescript.mdx
+++ b/website/src/content/docs/lint/rules/typescript.mdx
@@ -1431,7 +1431,7 @@ class ParameterShorthand {
 
 Prefer `as const` over a literal type that repeats the literal it describes: `as "literal"` / `<"literal">` assertions, plus variable and class-property annotations such as `let x: "literal" = "literal"`. Literals are compared by raw source spelling, so `'value' as "value"` and `let n: 10 = 0xa` stay clean.
 
-Assertions are autofixable (the literal type becomes `const` in place). Annotation findings are detection-only: the rewrite moves the type out of the annotation, which the upstream rule offers only as a suggestion, never under `--fix`.
+Assertions are autofixable (the literal type becomes `const` in place). Annotation findings offer an editor quick fix that removes the annotation and appends `as const` after the initializer. That larger rewrite remains suggestion-only and is never applied by `ttsc fix`.
 
 Example:
 


### PR DESCRIPTION
## Intent
Complete the reopened prefer-as-const parity contract after #426 by handling parenthesized literal types, preserving manual-only annotation rewrites, and proving real package auto-discovery.

## Scope
- unwrap type-side parentheses and keep assertion fixes syntactically valid while preserving comments
- expose declaration/property rewrites as range-scoped editor suggestions, never ttsc fix edits
- add exact native and no-plugin CLI regression coverage plus user-facing rule docs

## Verification
- focused prefer-as-const and LSP Go tests: passed
- scoped test-lint build: passed
- exact native-plugins/config no-plugin CLI fixture: passed
- git diff --check: passed

Closes #417