### PR TITLE
fix(lint): lock the ban-ts-comment package-discovery contract

### DIFF
--- a/packages/lint/src/structures/rules/ITtscLintTypeScriptRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintTypeScriptRuleOptions.ts
@@ -24,7 +24,7 @@ export type TtscLintTypeScriptBanTsCommentDirectiveConfig =
        * against the raw text following the directive, including its leading
        * whitespace, so anchored patterns usually start with `^: `.
        */
-      descriptionFormat?: string;
+      descriptionFormat: string;
     };
 
 /**

--- a/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
+++ b/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
@@ -31,6 +31,8 @@ import assert from "node:assert/strict";
  * - Cross-rule option leakage (`testIdPattern` on
  *   `cypress/unsafe-to-chain-command`) is rejected.
  * - A typo in a switch-exhaustiveness option is rejected.
+ * - An empty object policy for `typescript/ban-ts-comment` is rejected because
+ *   the object form requires `descriptionFormat`.
  * - A lint-only rule (`no-var`) cannot carry an options object.
  * - An identifier-form built-in name without the canonical slash (`reactJsxKey`)
  *   is rejected.
@@ -175,6 +177,17 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
       ],
     },
   };
+  const banTsCommentMissingDescriptionFormat: ITtscLintConfig = {
+    rules: {
+      "typescript/ban-ts-comment": [
+        "error",
+        {
+          // @ts-expect-error — the object policy requires descriptionFormat.
+          "ts-expect-error": {},
+        },
+      ],
+    },
+  };
   const camelBuiltinName: ITtscLintConfig = {
     rules: {
       // @ts-expect-error — built-in rules use kebab/slash names such as `react/jsx-key`; camelCase identifiers are not in the typed surface.
@@ -193,5 +206,6 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
   assert.ok(crossRuleShape);
   assert.ok(lintRuleWithOptions);
   assert.ok(switchOptionTypo);
+  assert.ok(banTsCommentMissingDescriptionFormat);
   assert.ok(camelBuiltinName);
 };

--- a/tests/test-lint/src/native-plugins/config/test_lint_ban_ts_comment_covers_defaults_and_options_without_plugins_entry.ts
+++ b/tests/test-lint/src/native-plugins/config/test_lint_ban_ts_comment_covers_defaults_and_options_without_plugins_entry.ts
@@ -1,0 +1,108 @@
+import { assert, runLint } from "../../internal/config-file";
+
+const NO_PLUGIN_TSCONFIG = JSON.stringify({
+  compilerOptions: {
+    target: "ES2022",
+    module: "NodeNext",
+    moduleResolution: "NodeNext",
+    strict: true,
+    noEmit: true,
+    rootDir: "src",
+  },
+  include: ["src"],
+});
+
+const PACKAGE_JSON = JSON.stringify({
+  private: true,
+  type: "module",
+  dependencies: { "@ttsc/lint": "*" },
+});
+
+/**
+ * Verifies `typescript/ban-ts-comment` reaches the real CLI through package
+ * discovery, with no `compilerOptions.plugins` entry.
+ *
+ * The ordinary rule corpus uses `TestLint`, whose synthesized tsconfig names
+ * `@ttsc/lint` explicitly. These two projects overwrite that tsconfig and add
+ * only a direct package dependency, closing the consumer path required by
+ * issue #415 while exercising both recommended defaults and every option arm.
+ *
+ * 1. Assert the scalar rule reports only default-forbidden `@ts-nocheck` while
+ *    allowing a described `@ts-expect-error`.
+ * 2. Assert the object form reports configured `@ts-check`, a description
+ *    shorter than the configured minimum, and a format mismatch while allowing
+ *    the matching and disabled directive arms.
+ */
+export const test_lint_ban_ts_comment_covers_defaults_and_options_without_plugins_entry =
+  () => {
+    const defaults = runLint({
+      name: "ban-ts-comment-no-plugin-defaults",
+      source: [
+        "// @ts-nocheck",
+        "const unchecked: string = 1;",
+        "// @ts-expect-error: intentional mismatch",
+        "const described: string = 1;",
+        "",
+      ].join("\n"),
+      rules: { "typescript/ban-ts-comment": "error" },
+      extraSources: {
+        "tsconfig.json": NO_PLUGIN_TSCONFIG,
+        "package.json": PACKAGE_JSON,
+      },
+    });
+
+    assert.notEqual(defaults.status, 0, defaults.stderr);
+    assert.deepEqual(
+      defaults.diagnostics.map((d) => [d.rule, d.severity, d.line]),
+      [["typescript/ban-ts-comment", "error", 1]],
+      defaults.stderr,
+    );
+
+    const options = runLint({
+      name: "ban-ts-comment-no-plugin-options",
+      source: [
+        "// @ts-check",
+        "// @ts-nocheck: short",
+        "const marker = 1;",
+        "// @ts-expect-error: TS2322 because assignment is intentionally invalid",
+        "const described: string = 1;",
+        "// @ts-expect-error: wrong format but long enough",
+        "const malformed: string = 1;",
+        "// @ts-ignore",
+        "const ignored: string = 1;",
+        "void marker;",
+        "",
+      ].join("\n"),
+      extraSources: {
+        "lint.config.json": JSON.stringify({
+          rules: {
+            "typescript/ban-ts-comment": [
+              "error",
+              {
+                minimumDescriptionLength: 10,
+                "ts-check": true,
+                "ts-nocheck": "allow-with-description",
+                "ts-ignore": false,
+                "ts-expect-error": {
+                  descriptionFormat: "^: TS\\d+ because .+$",
+                },
+              },
+            ],
+          },
+        }),
+        "tsconfig.json": NO_PLUGIN_TSCONFIG,
+        "package.json": PACKAGE_JSON,
+      },
+    });
+
+    assert.notEqual(options.status, 0, options.stderr);
+    assert.deepEqual(
+      options.diagnostics.map((d) => [d.rule, d.severity, d.line]),
+      [
+        ["typescript/ban-ts-comment", "error", 1],
+        ["typescript/ban-ts-comment", "error", 2],
+        ["typescript/ban-ts-comment", "error", 6],
+      ],
+      options.stderr,
+    );
+  };

--- a/website/src/content/docs/lint/rules/typescript.mdx
+++ b/website/src/content/docs/lint/rules/typescript.mdx
@@ -214,7 +214,7 @@ Options:
 
   Minimum description length (counted in grapheme clusters, so one emoji is one character) for directives configured as `"allow-with-description"` or `{ descriptionFormat }`. Default: `3`.
 
-- `"ts-check"?`, `"ts-expect-error"?`, `"ts-ignore"?`, `"ts-nocheck"?: boolean | "allow-with-description" | { descriptionFormat?: string }`
+- `"ts-check"?`, `"ts-expect-error"?`, `"ts-ignore"?`, `"ts-nocheck"?: boolean | "allow-with-description" | { descriptionFormat: string }`
 
   Per-directive policy: `true` reports every use, `false` allows the directive, `"allow-with-description"` allows it with a long-enough description, and `{ descriptionFormat }` additionally requires the description to match the given regular expression. Defaults: `"ts-check": false`, `"ts-expect-error": "allow-with-description"`, `"ts-ignore": true`, `"ts-nocheck": true`.
 


### PR DESCRIPTION
Closes the two contract gaps found in the post-merge audit of #429.

- Make the public `{ descriptionFormat }` object match the upstream required-property type.
- Add a real CLI regression that discovers `@ttsc/lint` from a direct dependency with no `compilerOptions.plugins` entry.
- Cover recommended defaults plus the `true`, `false`, `allow-with-description`, regex-object, and minimum-description-length option paths through that consumer-real route.

Local verification:
- `TTSC_BUILD_SCOPE=test-lint pnpm run build:current`
- `GOFLAGS=-run=BanTsComment node scripts/test-go-lint.cjs`
- `pnpm exec tsc --noEmit -p tests/test-lint/tsconfig.json`
- `pnpm --filter @ttsc/test-lint start --include=ban_ts_comment_covers_defaults_and_options_without_plugins_entry`

Closes #415