### PR TITLE
fix(lint): execute suggestions through logical project links

### DIFF
--- a/packages/lint/linthost/host.go
+++ b/packages/lint/linthost/host.go
@@ -198,11 +198,52 @@ func absoluteProjectPath(cwd string, target string) string {
 }
 
 func realProjectPath(target string) string {
-  resolved, err := filepath.EvalSymlinks(target)
-  if err != nil {
-    return filepath.Clean(target)
+  original := filepath.Clean(target)
+  resolved := original
+  seen := make(map[string]struct{})
+  for range 255 {
+    key := filepath.Clean(resolved)
+    if _, exists := seen[key]; exists {
+      return original
+    }
+    seen[key] = struct{}{}
+
+    if evaluated, err := filepath.EvalSymlinks(resolved); err == nil {
+      resolved = filepath.Clean(evaluated)
+    }
+    next, ok := resolveProjectLinkAncestor(resolved)
+    if !ok {
+      return filepath.Clean(resolved)
+    }
+    resolved = next
   }
-  return resolved
+  return original
+}
+
+// resolveProjectLinkAncestor resolves the nearest symlink-like ancestor and
+// reattaches the remaining path. filepath.EvalSymlinks handles ordinary links,
+// but some Windows directory junctions are readable through os.Readlink while
+// EvalSymlinks either leaves the junction unchanged or fails on its children.
+// Walking ancestors keeps physical project identity and LSP containment checks
+// correct for both existing files and not-yet-created paths below such links.
+func resolveProjectLinkAncestor(target string) (string, bool) {
+  probe := filepath.Clean(target)
+  suffix := make([]string, 0)
+  for {
+    if _, err := os.Readlink(probe); err == nil {
+      destination := resolveDirLink(probe)
+      for i := len(suffix) - 1; i >= 0; i-- {
+        destination = filepath.Join(destination, suffix[i])
+      }
+      return filepath.Clean(destination), true
+    }
+    parent := filepath.Dir(probe)
+    if parent == probe {
+      return "", false
+    }
+    suffix = append(suffix, filepath.Base(probe))
+    probe = parent
+  }
 }
 
 func (p *program) runLintCycle(engine *Engine) []*Finding {

--- a/packages/lint/linthost/lsp.go
+++ b/packages/lint/linthost/lsp.go
@@ -579,11 +579,13 @@ func lspWorkspaceEditForSuggestion(opts *lspCommandOptions) (*lspWorkspaceEdit, 
     fmt.Fprintln(os.Stderr, err)
     return nil, 2
   }
-  if _, ok := projectRelativePath(opts.cwd, target); !ok {
-    fmt.Fprintf(os.Stderr, "@ttsc/lint: LSP command target %s is outside cwd %s\n", target, opts.cwd)
+  physicalCwd := realProjectPath(opts.cwd)
+  physicalTarget := realProjectPath(target)
+  if _, ok := projectRelativePath(physicalCwd, physicalTarget); !ok {
+    fmt.Fprintf(os.Stderr, "@ttsc/lint: LSP command target %s is outside cwd %s\n", physicalTarget, physicalCwd)
     return nil, 2
   }
-  if projectPathHasSegment(opts.cwd, target, "node_modules") {
+  if lspProjectTargetHasSegment(opts, "node_modules") {
     return nil, 0
   }
   selection, err := suggestionSelectionArgument(opts.argumentsJSON)
@@ -591,7 +593,7 @@ func lspWorkspaceEditForSuggestion(opts *lspCommandOptions) (*lspWorkspaceEdit, 
     fmt.Fprintln(os.Stderr, err)
     return nil, 2
   }
-  current, err := os.ReadFile(target)
+  current, err := os.ReadFile(physicalTarget)
   if err != nil || lspSourceHash(string(current)) != selection.SourceHash {
     return nil, 0
   }
@@ -602,6 +604,7 @@ func lspWorkspaceEditForSuggestion(opts *lspCommandOptions) (*lspWorkspaceEdit, 
   if code != 0 {
     return nil, code
   }
+  findings = filterFindingsForPath(findings, physicalTarget)
   for _, finding := range findings {
     if finding == nil || finding.Rule != selection.Rule ||
       finding.Message != selection.Message ||
@@ -630,7 +633,7 @@ func lspWorkspaceEditForSuggestion(opts *lspCommandOptions) (*lspWorkspaceEdit, 
         NewText: edit.Text,
       })
     }
-    current, err := os.ReadFile(target)
+    current, err := os.ReadFile(physicalTarget)
     if err != nil || lspSourceHash(string(current)) != selection.SourceHash {
       return nil, 0
     }

--- a/packages/lint/test/command/lsp_apply_suggestion_resolves_logical_project_link_test.go
+++ b/packages/lint/test/command/lsp_apply_suggestion_resolves_logical_project_link_test.go
@@ -1,0 +1,128 @@
+package linthost
+
+import (
+  "encoding/json"
+  "os"
+  "os/exec"
+  "path/filepath"
+  "runtime"
+  "strings"
+  "testing"
+)
+
+// TestLSPApplySuggestionResolvesLogicalProjectLink verifies suggestion
+// discovery and execution use the same physical project boundary while the
+// returned WorkspaceEdit keeps the editor's logical document URI.
+//
+// NativePluginSource runs the lint sidecar from PhysicalProjectRoot but keeps
+// the logical URI supplied by an editor that opened a symlink or junction.
+// Code-action discovery already accepts that pairing after resolving both
+// paths. Execution must not reject the action, read a different path, or relax
+// the outside-project and node_modules guards while doing the same resolution.
+//
+//  1. Expose one physical project through a logical directory link.
+//  2. Discover and execute a manual suggestion for the logical URI.
+//  3. Assert the edit is keyed by that URI and leaves the physical file alone.
+//  4. Reuse the signed selection with outside and node_modules URIs and assert
+//     both command boundaries still fail closed.
+func TestLSPApplySuggestionResolvesLogicalProjectLink(t *testing.T) {
+  source := "let value: (\"one\") = \"one\";\nJSON.stringify(value);\n"
+  physicalRoot := seedLintProject(t, source)
+  seedLintConfig(t, physicalRoot, map[string]any{
+    "rules": map[string]any{"typescript/prefer-as-const": "error"},
+  })
+
+  logicalRoot := filepath.Join(t.TempDir(), "project-link")
+  createLSPDirectoryLinkForTest(t, physicalRoot, logicalRoot)
+  logicalFile := filepath.Join(logicalRoot, "src", "main.ts")
+  logicalURI := lintTestFileURI(t, logicalFile)
+
+  actions := runLSPCodeActionsForRangeForTest(
+    t,
+    physicalRoot,
+    logicalURI,
+    `{"start":{"line":0,"character":0},"end":{"line":0,"character":40}}`,
+    `{"only":["quickfix"]}`,
+  )
+  if len(actions) != 1 || actions[0].Command == nil ||
+    actions[0].Command.Command != commandLintApplySuggestion {
+    t.Fatalf("logical-link quick fixes = %#v", actions)
+  }
+
+  command := actions[0].Command
+  edit := executeLSPCommandEditWithArgumentsForTest(
+    t,
+    physicalRoot,
+    command.Command,
+    command.Arguments,
+    lintManifest(t),
+  )
+  if edit == nil || len(edit.Changes) != 1 || len(edit.Changes[logicalURI]) == 0 {
+    t.Fatalf("logical-link suggestion edit = %#v", edit)
+  }
+  if _, leaked := edit.Changes[lintTestFileURI(t, filepath.Join(physicalRoot, "src", "main.ts"))]; leaked {
+    t.Fatalf("WorkspaceEdit replaced logical URI with physical path: %#v", edit.Changes)
+  }
+  rewritten := applyLSPWorkspaceEditForTest(t, source, edit.Changes[logicalURI])
+  expected := "let value = \"one\" as const;\nJSON.stringify(value);\n"
+  if rewritten != expected {
+    t.Fatalf("logical-link suggestion mismatch:\nwant %q\ngot  %q", expected, rewritten)
+  }
+  assertFileText(t, filepath.Join(physicalRoot, "src", "main.ts"), source)
+
+  outside := filepath.Join(t.TempDir(), "outside.ts")
+  writeFile(t, outside, source)
+  outsideArguments := replaceLSPCommandURIForTest(t, command.Arguments, lintTestFileURI(t, outside))
+  code, stdout, stderr := runLSPApplySuggestionForTest(t, physicalRoot, outsideArguments)
+  if code != 2 || stdout != "" || !strings.Contains(stderr, "outside cwd") {
+    t.Fatalf("outside suggestion boundary: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+
+  dependency := filepath.Join(physicalRoot, "node_modules", "demo", "index.ts")
+  writeFile(t, dependency, source)
+  dependencyArguments := replaceLSPCommandURIForTest(t, command.Arguments, lintTestFileURI(t, dependency))
+  code, stdout, stderr = runLSPApplySuggestionForTest(t, physicalRoot, dependencyArguments)
+  if code != 0 || strings.TrimSpace(stdout) != "null" || !isBenignContributorCollisionWarning(stderr) {
+    t.Fatalf("node_modules suggestion boundary: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}
+
+func createLSPDirectoryLinkForTest(t *testing.T, target string, link string) {
+  t.Helper()
+  if err := os.Symlink(target, link); err == nil {
+    return
+  } else if runtime.GOOS != "windows" {
+    t.Skipf("directory symlink unavailable: %v", err)
+  }
+  if output, err := exec.Command("cmd", "/c", "mklink", "/J", link, target).CombinedOutput(); err != nil {
+    t.Skipf("directory link unavailable: %v: %s", err, output)
+  }
+}
+
+func replaceLSPCommandURIForTest(t *testing.T, arguments []json.RawMessage, uri string) []json.RawMessage {
+  t.Helper()
+  replaced := append([]json.RawMessage(nil), arguments...)
+  raw, err := json.Marshal(uri)
+  if err != nil {
+    t.Fatal(err)
+  }
+  replaced[0] = raw
+  return replaced
+}
+
+func runLSPApplySuggestionForTest(t *testing.T, root string, arguments []json.RawMessage) (int, string, string) {
+  t.Helper()
+  raw, err := json.Marshal(arguments)
+  if err != nil {
+    t.Fatal(err)
+  }
+  return captureCommandOutput(t, func() int {
+    return run([]string{
+      "lsp-execute-command",
+      "--cwd", root,
+      "--plugins-json", lintManifest(t),
+      "--command", commandLintApplySuggestion,
+      "--arguments-json", string(raw),
+    })
+  })
+}

--- a/packages/lint/test/command/lsp_apply_suggestion_resolves_logical_project_link_test.go
+++ b/packages/lint/test/command/lsp_apply_suggestion_resolves_logical_project_link_test.go
@@ -16,9 +16,9 @@ import (
 //
 // NativePluginSource runs the lint sidecar from PhysicalProjectRoot but keeps
 // the logical URI supplied by an editor that opened a symlink or junction.
-// Code-action discovery already accepts that pairing after resolving both
-// paths. Execution must not reject the action, read a different path, or relax
-// the outside-project and node_modules guards while doing the same resolution.
+// Code-action discovery and execution must resolve both paths consistently
+// without rejecting the action, reading a different file, or relaxing the
+// outside-project and node_modules guards.
 //
 //  1. Expose one physical project through a logical directory link.
 //  2. Discover and execute a manual suggestion for the logical URI.
@@ -36,6 +36,10 @@ func TestLSPApplySuggestionResolvesLogicalProjectLink(t *testing.T) {
   createLSPDirectoryLinkForTest(t, physicalRoot, logicalRoot)
   logicalFile := filepath.Join(logicalRoot, "src", "main.ts")
   logicalURI := lintTestFileURI(t, logicalFile)
+  logicalOptions := &lspCommandOptions{cwd: physicalRoot, uri: logicalURI}
+  if lspProjectTargetOutsideCwd(logicalOptions) || lspProjectTargetHasSegment(logicalOptions, "node_modules") {
+    t.Fatalf("logical project link was classified outside the source project")
+  }
 
   actions := runLSPCodeActionsForRangeForTest(
     t,
@@ -70,9 +74,20 @@ func TestLSPApplySuggestionResolvesLogicalProjectLink(t *testing.T) {
   }
   assertFileText(t, filepath.Join(physicalRoot, "src", "main.ts"), source)
 
-  outside := filepath.Join(t.TempDir(), "outside.ts")
+  outsideRoot := t.TempDir()
+  outside := filepath.Join(outsideRoot, "outside.ts")
   writeFile(t, outside, source)
-  outsideArguments := replaceLSPCommandURIForTest(t, command.Arguments, lintTestFileURI(t, outside))
+  outsideLink := filepath.Join(physicalRoot, "outside-link")
+  createLSPDirectoryLinkForTest(t, outsideRoot, outsideLink)
+  outsideURI := lintTestFileURI(t, filepath.Join(outsideLink, "outside.ts"))
+  outsideArguments := replaceLSPCommandURIForTest(
+    t,
+    command.Arguments,
+    outsideURI,
+  )
+  if !lspProjectTargetOutsideCwd(&lspCommandOptions{cwd: physicalRoot, uri: outsideURI}) {
+    t.Fatal("linked outside target was classified inside the source project")
+  }
   code, stdout, stderr := runLSPApplySuggestionForTest(t, physicalRoot, outsideArguments)
   if code != 2 || stdout != "" || !strings.Contains(stderr, "outside cwd") {
     t.Fatalf("outside suggestion boundary: code=%d stdout=%q stderr=%q", code, stdout, stderr)
@@ -80,7 +95,17 @@ func TestLSPApplySuggestionResolvesLogicalProjectLink(t *testing.T) {
 
   dependency := filepath.Join(physicalRoot, "node_modules", "demo", "index.ts")
   writeFile(t, dependency, source)
-  dependencyArguments := replaceLSPCommandURIForTest(t, command.Arguments, lintTestFileURI(t, dependency))
+  dependencyLink := filepath.Join(physicalRoot, "dependency-link")
+  createLSPDirectoryLinkForTest(t, filepath.Dir(dependency), dependencyLink)
+  dependencyURI := lintTestFileURI(t, filepath.Join(dependencyLink, "index.ts"))
+  dependencyArguments := replaceLSPCommandURIForTest(
+    t,
+    command.Arguments,
+    dependencyURI,
+  )
+  if !lspProjectTargetHasSegment(&lspCommandOptions{cwd: physicalRoot, uri: dependencyURI}, "node_modules") {
+    t.Fatal("linked dependency target hid its node_modules boundary")
+  }
   code, stdout, stderr = runLSPApplySuggestionForTest(t, physicalRoot, dependencyArguments)
   if code != 0 || strings.TrimSpace(stdout) != "null" || !isBenignContributorCollisionWarning(stderr) {
     t.Fatalf("node_modules suggestion boundary: code=%d stdout=%q stderr=%q", code, stdout, stderr)


### PR DESCRIPTION
## Summary

- resolve suggestion execution targets through the same physical project boundary used by code-action discovery
- filter findings and revalidate source hashes against the physical file while preserving the editor's logical URI in `WorkspaceEdit`
- cover symlink/junction execution plus forged outside-root and `node_modules` negative twins

## Validation

- three exhaustive whole-PR review passes and targeted local tests will run against this exact head before merge

Closes #449