### PR TITLE
fix(lint): initialize contributor registries once

### DIFF
--- a/packages/lint/linthost/contrib_adapter.go
+++ b/packages/lint/linthost/contrib_adapter.go
@@ -10,20 +10,31 @@
 // `package main` init functions and the relative order across files in
 // the same package is alphabetical — so we cannot blindly run the
 // contributor wiring from a file-level `init()` and expect built-in
-// registration to have already completed. Instead, `registerContributors`
-// is invoked explicitly from `main.run` after all built-in `init` calls
-// have settled, which makes the collision check meaningful.
+// registration to have already completed. Instead, `registerContributorsOnce`
+// is invoked explicitly from `run` after all built-in `init` calls have
+// settled, which makes the collision check meaningful.
 package linthost
 
 import (
   "fmt"
   "os"
   "sort"
+  "sync"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
 
   "github.com/samchon/ttsc/packages/lint/rule"
 )
+
+var contributorBootstrap sync.Once
+
+// registerContributorsOnce installs the immutable init-time contributor
+// registries exactly once. Main is a reusable library entry and may be called
+// concurrently, so every caller must wait for the same completed bootstrap
+// before constructing an Engine that reads the global rule maps.
+func registerContributorsOnce() {
+  contributorBootstrap.Do(registerContributors)
+}
 
 // registerContributors wraps every contributor rule registered through
 // the public `rule` package into the engine's internal `Rule` interface

--- a/packages/lint/linthost/dispatch.go
+++ b/packages/lint/linthost/dispatch.go
@@ -47,9 +47,9 @@ func run(args []string) int {
     fmt.Fprintf(os.Stderr, "@ttsc/lint: unknown command %q\n", args[0])
     return 2
   }
-  // Wire contributor rules into the engine's dispatch table after every
-  // package init has settled. See contrib_adapter.go for the rationale.
-  registerContributors()
+  // Wire init-time contributor rules into the engine's dispatch table once,
+  // after every package init has settled. See contrib_adapter.go.
+  registerContributorsOnce()
   switch args[0] {
   case "check":
     return RunCheck(args[1:])

--- a/packages/lint/test/command/lsp_apply_suggestion_resolves_logical_project_link_test.go
+++ b/packages/lint/test/command/lsp_apply_suggestion_resolves_logical_project_link_test.go
@@ -107,7 +107,7 @@ func TestLSPApplySuggestionResolvesLogicalProjectLink(t *testing.T) {
     t.Fatal("linked dependency target hid its node_modules boundary")
   }
   code, stdout, stderr = runLSPApplySuggestionForTest(t, physicalRoot, dependencyArguments)
-  if code != 0 || strings.TrimSpace(stdout) != "null" || !isBenignContributorCollisionWarning(stderr) {
+  if code != 0 || strings.TrimSpace(stdout) != "null" || stderr != "" {
     t.Fatalf("node_modules suggestion boundary: code=%d stdout=%q stderr=%q", code, stdout, stderr)
   }
 }

--- a/packages/lint/test/command/lsp_code_actions_short_circuits_unowned_context_only_test.go
+++ b/packages/lint/test/command/lsp_code_actions_short_circuits_unowned_context_only_test.go
@@ -35,7 +35,7 @@ func TestLSPCodeActionsShortCircuitsUnownedContextOnly(t *testing.T) {
       "--context-json", `{"only":["quickfix.other"]}`,
     })
   })
-  if code != 0 || stdout != "[]\n" || !isBenignContributorCollisionWarning(stderr) {
+  if code != 0 || stdout != "[]\n" || stderr != "" {
     t.Fatalf("lsp-code-actions mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
   }
 }

--- a/packages/lint/test/command/lsp_code_actions_split_lint_and_format_commands_test.go
+++ b/packages/lint/test/command/lsp_code_actions_split_lint_and_format_commands_test.go
@@ -65,7 +65,7 @@ func runLSPCodeActionsForRangeForTest(
       "--context-json", contextJSON,
     })
   })
-  if code != 0 || !isBenignContributorCollisionWarning(stderr) {
+  if code != 0 || stderr != "" {
     t.Fatalf("lsp-code-actions mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
   }
   var actions []lspCodeAction

--- a/packages/lint/test/command/lsp_command_discovery_reports_owned_commands_and_kinds_test.go
+++ b/packages/lint/test/command/lsp_command_discovery_reports_owned_commands_and_kinds_test.go
@@ -19,7 +19,7 @@ func TestLSPCommandDiscoveryReportsOwnedCommandsAndKinds(t *testing.T) {
   code, stdout, stderr := captureCommandOutput(t, func() int {
     return run([]string{"lsp-command-ids"})
   })
-  if code != 0 || !isBenignContributorCollisionWarning(stderr) {
+  if code != 0 || stderr != "" {
     t.Fatalf("lsp-command-ids mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
   }
   var commands []string
@@ -37,7 +37,7 @@ func TestLSPCommandDiscoveryReportsOwnedCommandsAndKinds(t *testing.T) {
   code, stdout, stderr = captureCommandOutput(t, func() int {
     return run([]string{"lsp-code-action-kinds"})
   })
-  if code != 0 || !isBenignContributorCollisionWarning(stderr) {
+  if code != 0 || stderr != "" {
     t.Fatalf("lsp-code-action-kinds mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
   }
   var kinds []string

--- a/packages/lint/test/command/lsp_execute_command_returns_null_for_node_modules_target_test.go
+++ b/packages/lint/test/command/lsp_execute_command_returns_null_for_node_modules_target_test.go
@@ -44,7 +44,7 @@ func TestLSPExecuteCommandReturnsNullForNodeModulesTarget(t *testing.T) {
       "--arguments-json", argsJSON,
     })
   })
-  if code != 0 || !isBenignContributorCollisionWarning(stderr) {
+  if code != 0 || stderr != "" {
     t.Fatalf("lsp-execute-command mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
   }
   if strings.TrimSpace(stdout) != "null" {

--- a/packages/lint/test/command/lsp_execute_command_returns_null_when_no_edits_test.go
+++ b/packages/lint/test/command/lsp_execute_command_returns_null_when_no_edits_test.go
@@ -37,7 +37,7 @@ func TestLSPExecuteCommandReturnsNullWhenNoEdits(t *testing.T) {
     })
   })
 
-  if code != 0 || !isBenignContributorCollisionWarning(stderr) {
+  if code != 0 || stderr != "" {
     t.Fatalf("lsp-execute-command mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
   }
   if strings.TrimSpace(stdout) != "null" {

--- a/packages/lint/test/command/lsp_execute_command_splits_lint_and_format_edits_test.go
+++ b/packages/lint/test/command/lsp_execute_command_splits_lint_and_format_edits_test.go
@@ -81,7 +81,7 @@ func executeLSPCommandEditWithArgumentsForTest(
       "--arguments-json", string(argsJSON),
     })
   })
-  if code != 0 || !isBenignContributorCollisionWarning(stderr) {
+  if code != 0 || stderr != "" {
     t.Fatalf("lsp-execute-command mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
   }
   if strings.TrimSpace(stdout) == "null" {

--- a/packages/lint/test/command/lsp_format_buffer_in_memory_test.go
+++ b/packages/lint/test/command/lsp_format_buffer_in_memory_test.go
@@ -125,7 +125,7 @@ func executeLSPFormatBufferEditForTest(t *testing.T, root string, uri string, st
       "--content-stdin",
     })
   })
-  if code != 0 || !isBenignContributorCollisionWarning(stderr) {
+  if code != 0 || stderr != "" {
     t.Fatalf("lsp-execute-command --content-stdin mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
   }
   var edit lspWorkspaceEdit

--- a/packages/lint/test/command/lsp_format_buffer_real_binary_e2e_test.go
+++ b/packages/lint/test/command/lsp_format_buffer_real_binary_e2e_test.go
@@ -64,7 +64,7 @@ func TestLSPFormatBufferRealBinaryE2E(t *testing.T) {
     if code != 0 {
       t.Fatalf("sidecar exit code = %d, want 0; stdout=%q stderr=%q", code, stdout, stderr)
     }
-    if !isBenignContributorCollisionWarning(stderr) {
+    if stderr != "" {
       t.Fatalf("unexpected sidecar stderr: %q", stderr)
     }
 
@@ -94,7 +94,7 @@ func TestLSPFormatBufferRealBinaryE2E(t *testing.T) {
     if code != 0 {
       t.Fatalf("sidecar exit code = %d, want 0; stdout=%q stderr=%q", code, stdout, stderr)
     }
-    if !isBenignContributorCollisionWarning(stderr) {
+    if stderr != "" {
       t.Fatalf("unexpected sidecar stderr: %q", stderr)
     }
     if got := strings.TrimSpace(stdout); got != "null" {

--- a/packages/lint/test/command/lsp_switch_exhaustiveness_suggestions_preserve_default_anchors_test.go
+++ b/packages/lint/test/command/lsp_switch_exhaustiveness_suggestions_preserve_default_anchors_test.go
@@ -195,7 +195,7 @@ func assertSwitchExhaustivenessSuggestedSourceForTest(t *testing.T, root string,
       "--plugins-json", lintManifest(t),
     })
   })
-  if code != 0 || stdout != "" || !isBenignContributorCollisionWarning(stderr) {
+  if code != 0 || stdout != "" || stderr != "" {
     t.Fatalf("suggested source did not re-check cleanly: code=%d stdout=%q stderr=%q\n%s", code, stdout, stderr, source)
   }
 }

--- a/packages/lint/test/plugin/contributor_bootstrap_is_single_owner_for_reusable_main_test.go
+++ b/packages/lint/test/plugin/contributor_bootstrap_is_single_owner_for_reusable_main_test.go
@@ -1,0 +1,342 @@
+package linthost
+
+import (
+  "fmt"
+  "os"
+  "strings"
+  "sync"
+  "sync/atomic"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+type bootstrapFileRuleCounts struct {
+  name                  atomic.Int32
+  visits                atomic.Int32
+  isFormat              atomic.Int32
+  visitsDeclarationFile atomic.Int32
+}
+
+type bootstrapCountingFileRule struct {
+  name   string
+  counts bootstrapFileRuleCounts
+}
+
+func (r *bootstrapCountingFileRule) Name() string {
+  r.counts.name.Add(1)
+  return r.name
+}
+func (r *bootstrapCountingFileRule) Visits() []shimast.Kind {
+  r.counts.visits.Add(1)
+  return []shimast.Kind{shimast.KindSourceFile}
+}
+func (*bootstrapCountingFileRule) Check(*publicrule.Context, *shimast.Node) {}
+
+type bootstrapPanickingFileRule struct {
+  method string
+  counts bootstrapFileRuleCounts
+}
+
+func (r *bootstrapPanickingFileRule) Name() string {
+  r.counts.name.Add(1)
+  if r.method == "Name" {
+    panic("bootstrap Name boom")
+  }
+  return "test/bootstrap-metadata-panic-" + strings.ToLower(r.method)
+}
+func (r *bootstrapPanickingFileRule) Visits() []shimast.Kind {
+  r.counts.visits.Add(1)
+  if r.method == "Visits" {
+    panic("bootstrap Visits boom")
+  }
+  return []shimast.Kind{shimast.KindSourceFile}
+}
+func (*bootstrapPanickingFileRule) Check(*publicrule.Context, *shimast.Node) {}
+func (r *bootstrapPanickingFileRule) IsFormat() bool {
+  r.counts.isFormat.Add(1)
+  if r.method == "IsFormat" {
+    panic("bootstrap IsFormat boom")
+  }
+  return false
+}
+func (r *bootstrapPanickingFileRule) VisitsDeclarationFiles() bool {
+  r.counts.visitsDeclarationFile.Add(1)
+  if r.method == "VisitsDeclarationFiles" {
+    panic("bootstrap VisitsDeclarationFiles boom")
+  }
+  return true
+}
+
+type bootstrapProjectRuleCounts struct {
+  name atomic.Int32
+}
+
+type bootstrapCountingProjectRule struct {
+  name   string
+  counts bootstrapProjectRuleCounts
+}
+
+func (r *bootstrapCountingProjectRule) Name() string {
+  r.counts.name.Add(1)
+  return r.name
+}
+func (*bootstrapCountingProjectRule) Check(*publicrule.ProjectContext) {}
+
+type bootstrapPanickingProjectRule struct {
+  counts bootstrapProjectRuleCounts
+}
+
+func (r *bootstrapPanickingProjectRule) Name() string {
+  r.counts.name.Add(1)
+  panic("bootstrap project Name boom")
+}
+func (*bootstrapPanickingProjectRule) Check(*publicrule.ProjectContext) {}
+
+var bootstrapFileRules = []*bootstrapCountingFileRule{
+  {name: "test/bootstrap-file-file"},
+  {name: "test/bootstrap-file-file"},
+  {name: "test/bootstrap-file-project"},
+}
+
+var bootstrapPanickingFileRules = []*bootstrapPanickingFileRule{
+  {method: "Name"},
+  {method: "Visits"},
+  {method: "IsFormat"},
+  {method: "VisitsDeclarationFiles"},
+}
+
+var bootstrapProjectRules = []*bootstrapCountingProjectRule{
+  {name: "test/bootstrap-project-project"},
+  {name: "test/bootstrap-project-project"},
+  {name: "test/bootstrap-file-project"},
+}
+
+var bootstrapPanickingProjectRuleInstance = &bootstrapPanickingProjectRule{}
+
+func init() {
+  for _, fileRule := range bootstrapFileRules {
+    publicrule.Register(fileRule)
+  }
+  for _, fileRule := range bootstrapPanickingFileRules {
+    publicrule.Register(fileRule)
+  }
+  for _, projectRule := range bootstrapProjectRules {
+    publicrule.RegisterProject(projectRule)
+  }
+  publicrule.RegisterProject(bootstrapPanickingProjectRuleInstance)
+}
+
+// TestMain exercises the only fresh-process bootstrap before ordinary tests
+// reuse Main. The init-time contributors above deliberately cover every
+// collision class and metadata panic boundary; racing real entry calls proves
+// one owner inspects them and publishes the immutable registries to all peers.
+//
+//  1. Release concurrent Main calls against the uninitialized host.
+//  2. Assert every initial collision/panic warning appears exactly once and
+//     every metadata method was evaluated by one bootstrap owner.
+//  3. Reuse two different Main commands sequentially without another warning,
+//     then run the ordinary package suite against the initialized host.
+func TestMain(m *testing.M) {
+  if err := verifyInitialContributorBootstrap(); err != nil {
+    fmt.Fprintf(os.Stderr, "contributor bootstrap lifecycle: %v\n", err)
+    os.Exit(1)
+  }
+  os.Exit(m.Run())
+}
+
+func verifyInitialContributorBootstrap() error {
+  const concurrentCalls = 16
+  commands := make([][]string, concurrentCalls)
+  for index := range commands {
+    if index%2 == 0 {
+      commands[index] = []string{"lsp-command-ids"}
+    } else {
+      commands[index] = []string{"lsp-code-action-kinds"}
+    }
+  }
+  codes, stderr, err := captureBootstrapMainCommands(commands)
+  if err != nil {
+    return err
+  }
+  for index, code := range codes {
+    if code != 0 {
+      return fmt.Errorf("concurrent Main call %d returned %d", index, code)
+    }
+  }
+
+  expectedWarnings := []string{
+    "metadata panicked: bootstrap Name boom; dropping contributor entry",
+    "metadata panicked: bootstrap Visits boom; dropping contributor entry",
+    "metadata panicked: bootstrap IsFormat boom; dropping contributor entry",
+    "metadata panicked: bootstrap VisitsDeclarationFiles boom; dropping contributor entry",
+    `contributor rule "test/bootstrap-file-file" collides with an existing rule; dropping contributor entry`,
+    "metadata panicked: bootstrap project Name boom; dropping project contributor entry",
+    `contributor project rule "test/bootstrap-file-project" collides with a file rule; dropping project contributor entry`,
+    `contributor project rule "test/bootstrap-project-project" collides with an existing project rule; dropping contributor entry`,
+  }
+  normalized := strings.ReplaceAll(strings.TrimSpace(stderr), "\r\n", "\n")
+  lines := strings.Split(normalized, "\n")
+  if len(lines) != len(expectedWarnings) {
+    return fmt.Errorf("initial warning count = %d, want %d: %q", len(lines), len(expectedWarnings), stderr)
+  }
+  for _, warning := range expectedWarnings {
+    if count := strings.Count(stderr, warning); count != 1 {
+      return fmt.Errorf("warning %q appeared %d times in %q", warning, count, stderr)
+    }
+  }
+  if err := verifyContributorMetadataCounts(); err != nil {
+    return err
+  }
+  if err := verifyContributorCollisionSurvivors(); err != nil {
+    return err
+  }
+
+  for _, command := range [][]string{{"lsp-command-ids"}, {"lsp-code-action-kinds"}} {
+    codes, stderr, err := captureBootstrapMainCommands([][]string{command})
+    if err != nil {
+      return err
+    }
+    if codes[0] != 0 || stderr != "" {
+      return fmt.Errorf("reused Main(%q): code=%d stderr=%q", command[0], codes[0], stderr)
+    }
+  }
+  return nil
+}
+
+func verifyContributorMetadataCounts() error {
+  for index, fileRule := range bootstrapFileRules {
+    if names, visits := fileRule.counts.name.Load(), fileRule.counts.visits.Load(); names != 1 || visits != 1 {
+      return fmt.Errorf("file contributor %d metadata calls: Name=%d Visits=%d, want 1 each", index, names, visits)
+    }
+  }
+  expectedPanics := []struct {
+    name                  int32
+    visits                int32
+    isFormat              int32
+    visitsDeclarationFile int32
+  }{
+    {name: 1},
+    {name: 1, visits: 1},
+    {name: 1, visits: 1, isFormat: 1},
+    {name: 1, visits: 1, isFormat: 1, visitsDeclarationFile: 1},
+  }
+  for index, fileRule := range bootstrapPanickingFileRules {
+    expected := expectedPanics[index]
+    actual := &fileRule.counts
+    if actual.name.Load() != expected.name ||
+      actual.visits.Load() != expected.visits ||
+      actual.isFormat.Load() != expected.isFormat ||
+      actual.visitsDeclarationFile.Load() != expected.visitsDeclarationFile {
+      return fmt.Errorf(
+        "panicking file contributor %d metadata calls = (%d,%d,%d,%d), want (%d,%d,%d,%d)",
+        index,
+        actual.name.Load(),
+        actual.visits.Load(),
+        actual.isFormat.Load(),
+        actual.visitsDeclarationFile.Load(),
+        expected.name,
+        expected.visits,
+        expected.isFormat,
+        expected.visitsDeclarationFile,
+      )
+    }
+  }
+  for index, projectRule := range bootstrapProjectRules {
+    if names := projectRule.counts.name.Load(); names != 1 {
+      return fmt.Errorf("project contributor %d Name calls = %d, want 1", index, names)
+    }
+  }
+  if names := bootstrapPanickingProjectRuleInstance.counts.name.Load(); names != 1 {
+    return fmt.Errorf("panicking project contributor Name calls = %d, want 1", names)
+  }
+  return nil
+}
+
+func verifyContributorCollisionSurvivors() error {
+  fileFile, ok := registered.rules["test/bootstrap-file-file"].(contributorAdapter)
+  if !ok || fileFile.inner != bootstrapFileRules[0] {
+    return fmt.Errorf("file/file collision did not preserve the first contributor: %#v", registered.rules["test/bootstrap-file-file"])
+  }
+
+  fileProject, ok := registered.rules["test/bootstrap-file-project"].(contributorAdapter)
+  if !ok || fileProject.inner != bootstrapFileRules[2] {
+    return fmt.Errorf("file/project collision did not preserve the file contributor: %#v", registered.rules["test/bootstrap-file-project"])
+  }
+  if _, exists := registeredProjectRules["test/bootstrap-file-project"]; exists {
+    return fmt.Errorf("file/project collision also installed the project contributor")
+  }
+
+  projectProject, ok := registeredProjectRules["test/bootstrap-project-project"]
+  if !ok || projectProject.inner != bootstrapProjectRules[0] {
+    return fmt.Errorf("project/project collision did not preserve the first contributor: %#v", projectProject)
+  }
+  return nil
+}
+
+func captureBootstrapMainCommands(commands [][]string) ([]int, string, error) {
+  stdout, err := os.CreateTemp("", "ttsc-bootstrap-stdout-*")
+  if err != nil {
+    return nil, "", err
+  }
+  stdoutName := stdout.Name()
+  defer os.Remove(stdoutName)
+  stderr, err := os.CreateTemp("", "ttsc-bootstrap-stderr-*")
+  if err != nil {
+    _ = stdout.Close()
+    return nil, "", err
+  }
+  stderrName := stderr.Name()
+  defer os.Remove(stderrName)
+
+  previousStdout, previousStderr := os.Stdout, os.Stderr
+  os.Stdout, os.Stderr = stdout, stderr
+  codes := make([]int, len(commands))
+  start := make(chan struct{})
+  var wait sync.WaitGroup
+  wait.Add(len(commands))
+  for index, command := range commands {
+    go func() {
+      defer wait.Done()
+      <-start
+      codes[index] = Main(command)
+    }()
+  }
+  close(start)
+  wait.Wait()
+  os.Stdout, os.Stderr = previousStdout, previousStderr
+
+  if err := stdout.Close(); err != nil {
+    _ = stderr.Close()
+    return nil, "", err
+  }
+  if err := stderr.Close(); err != nil {
+    return nil, "", err
+  }
+  content, err := os.ReadFile(stderrName)
+  if err != nil {
+    return nil, "", err
+  }
+  return codes, string(content), nil
+}
+
+// TestContributorBootstrapIsSingleOwnerForReusableMain verifies commands keep
+// reusing the registry state established by the fresh-process race above.
+//
+// The initial bootstrap already asserted collision and panic behavior. This
+// guard keeps the public sequential-host contract explicit: distinct valid
+// Main calls must not reinterpret the same init-time contributor declarations.
+//
+//  1. Invoke the command-id entry after bootstrap.
+//  2. Invoke the code-action-kind entry in the same process.
+//  3. Assert both succeed without contributor stderr.
+func TestContributorBootstrapIsSingleOwnerForReusableMain(t *testing.T) {
+  for _, command := range [][]string{{"lsp-command-ids"}, {"lsp-code-action-kinds"}} {
+    code, _, stderr := captureCommandOutput(t, func() int { return Main(command) })
+    if code != 0 || stderr != "" {
+      t.Fatalf("Main(%q): code=%d stderr=%q", command[0], code, stderr)
+    }
+  }
+}

--- a/packages/lint/test/plugin/contributor_rule_decodes_options_through_public_context_test.go
+++ b/packages/lint/test/plugin/contributor_rule_decodes_options_through_public_context_test.go
@@ -21,18 +21,20 @@ import (
 // internal Context into the public Context — otherwise contributor
 // rules silently see nil options and fall back to defaults.
 //
-//  1. Register a synthetic contributor rule that decodes a `Mode` option
-//     and asserts the decoded value.
+//  1. Inspect and install a synthetic contributor adapter that decodes a
+//     `Mode` option and asserts the decoded value.
 //  2. Run the engine with an InlineRuleResolver that supplies the
 //     options blob the contributor expects.
 //  3. Confirm the rule observed the user's option, not the zero value.
 func TestContributorRuleDecodesOptionsThroughPublicContext(t *testing.T) {
   recorder := &optionRecorder{}
-  rule.Register(&optionConsumingContributor{recorder: recorder})
-  registerContributors()
-  defer func() {
-    delete(registered.rules, "demo/option-consumer")
-  }()
+  contributor := &optionConsumingContributor{recorder: recorder}
+  metadata, err := inspectContributor(contributor)
+  if err != nil {
+    t.Fatalf("inspect contributor: %v", err)
+  }
+  registered.rules[metadata.name] = newContributorAdapter(metadata)
+  t.Cleanup(func() { delete(registered.rules, metadata.name) })
 
   file := parseTS(t, "const x = 1;\n")
   resolver := InlineRuleResolver{

--- a/packages/lint/test/shared/helpers_test.go
+++ b/packages/lint/test/shared/helpers_test.go
@@ -417,12 +417,6 @@ func lintTestFileURI(t *testing.T, file string) string {
   return (&url.URL{Scheme: "file", Path: uriPath}).String()
 }
 
-func isBenignContributorCollisionWarning(stderr string) bool {
-  trimmed := strings.TrimSpace(stderr)
-  return trimmed == "" ||
-    trimmed == `@ttsc/lint: contributor rule "demo/option-consumer" collides with an existing rule; dropping contributor entry`
-}
-
 // assertFixSnapshot runs one rule's findings through the native fix applier.
 //
 // Fixer tests need the real file-writing path, not just in-memory edit

--- a/website/src/content/docs/development/walkthroughs/lint.mdx
+++ b/website/src/content/docs/development/walkthroughs/lint.mdx
@@ -132,7 +132,7 @@ func run(args []string) int {
     fmt.Fprintf(os.Stderr, "@ttsc/lint: unknown command %q\n", args[0])
     return 2
   }
-  registerContributors()
+  registerContributorsOnce()
   switch args[0] {
   case "check":     return RunCheck(args[1:])
   case "fix":       return RunFix(args[1:])
@@ -152,7 +152,7 @@ func run(args []string) int {
 The two-switch shape is intentional:
 
 - The **first switch** validates the subcommand. Unknown commands and `version` exit before any side-effect (the `version` banner does not need to register rules, parse configs, or load a Program).
-- `registerContributors()` walks the public `rule.Registered()` slice and adapts every contributor rule onto the engine's internal `Rule` interface. See [Contributor adapter](#contributor-adapter) below.
+- `registerContributorsOnce()` uses `sync.Once` to inspect the public contributor registries and adapt every contributor rule onto the engine's internal maps during the first valid command. Concurrent callers wait for that bootstrap to finish, and later calls reuse the published maps. See [Contributor adapter](#contributor-adapter) below.
 - The **second switch** dispatches to the actual implementation in `compile.go` / `fix.go` / `format.go`.
 
 `Version` is a package-level `var Version = "dev"` overridden at link time by `-ldflags "-X github.com/samchon/ttsc/packages/lint/linthost.Version=…"`. The release pipeline sets it; local `go build` calls leave it as `"dev"`.
@@ -281,7 +281,7 @@ func Register(rule Rule) {
 }
 ```
 
-Every built-in rule registers from its file's `init()`. By the time `main.run` calls `RunCheck`, the registry holds every rule the binary will ever see. Contributors register the same way but go through `rule.Register` instead; `registerContributors` adapts them onto the internal `Rule` interface after every `init()` has fired.
+Every built-in rule registers from its file's `init()`. Contributors register the same way but go through `rule.Register` instead. After every `init()` has fired, `registerContributorsOnce` adapts them onto the internal `Rule` interface exactly once before the first valid command dispatch, so every later `run` call reads the same registry state.
 
 ### Dispatch table
 


### PR DESCRIPTION
## Intent

Make the reusable lint library entry initialize immutable contributor declarations exactly once, including under concurrent first use.

## Scope

- gate file and project contributor installation with one synchronized bootstrap
- preserve first-bootstrap collision and metadata-panic diagnostics
- remove the test suite's repeated-collision warning allowance
- add fresh-process coverage for concurrent initialization and sequential Main reuse
- align the maintainer walkthrough with the reusable one-time lifecycle

## Deferred

- The Go race detector is unavailable on this Windows host because CGO is disabled.
- The full lint suite is not green locally: three AsyncDisposable failures reproduce on latest master, and four TypeScript-config tests require the built ttsx launcher missing from the dedicated worktree. Repository CI remains GitHub-owned.

## Test plan

- targeted and expanded contributor lifecycle Go tests
- full @ttsc/lint Go suite with latest-master baseline comparison
- three independent exhaustive reviews of the complete PR diff, callers, tests, CI, and docs

Closes #456