### PR TITLE
fix(ttsc): fence source-plugin lock generations

### DIFF
--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -609,8 +609,8 @@ export function waitForPluginBinary(opts: {
     const now = Date.now();
     const lock = inspectPluginBuildLock(opts.lockDir, now);
     if (lock.state === "released") {
-      // The holder removed the lock between the binary check above and this
-      // observation. That is a normal release, not abandonment: prefer the
+      // The holder retired its generation between the binary check above and
+      // this observation. That is a normal release, not abandonment: prefer the
       // binary when it landed inside that window, otherwise hand the free key
       // back to the caller.
       return fs.existsSync(opts.binaryPath)
@@ -672,7 +672,7 @@ function writePluginBuildLockOwner(
  *   another host, no metadata but young). Keep waiting.
  * - `abandoned`: the lock still exists and the evidence says nobody will ever
  *   release it — a same-host owner that is no longer running, or an old
- *   metadata-less legacy lock. Stealing is justified.
+ *   metadata-less legacy lock. Retiring its fenced generation is justified.
  * - `released`: the observed generation no longer exists. In v2 the persistent
  *   coordination root remains while `current` is absent. This is a routine
  *   handoff, never an infinitely old abandoned lock (issue #421).
@@ -832,10 +832,10 @@ function captureLegacyPluginBuildLockFence(
   let captured = readLegacyPluginBuildLockFence(fenceDir);
   if (captured === null) {
     const generation = crypto.randomBytes(16).toString("hex");
-    const candidateDir = path.join(
-      lockDir,
-      `legacy-candidate-${generation}`,
-    );
+    // Keep candidates beside the legacy lock. Creating one inside `lockDir`
+    // would advance its mtime before a contender publishes the shared fence;
+    // a concurrent contender could then record an old lock as freshly created.
+    const candidateDir = `${lockDir}.legacy-candidate-${generation}`;
     try {
       fs.mkdirSync(candidateDir);
       fs.writeFileSync(

--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -107,6 +107,12 @@ const PLUGIN_BUILD_LOCK_POLL_MS = 50;
 const PLUGIN_BUILD_LOCK_LEGACY_STALE_MS = 30_000;
 const PLUGIN_BUILD_LOCK_STATUS_MS = 30_000;
 const PLUGIN_BUILD_LOCK_OWNER_FILE = "owner.json";
+const PLUGIN_BUILD_LOCK_PROTOCOL_FILE = "protocol-v2";
+const PLUGIN_BUILD_LOCK_GENERATION_FILE = "generation";
+const PLUGIN_BUILD_LOCK_LEGACY_FENCE_FILE = "legacy-generation.json";
+const PLUGIN_BUILD_LOCK_CURRENT_DIR = "current";
+const PLUGIN_BUILD_LOCK_RETIRED_DIR = "retired";
+const PLUGIN_BUILD_LOCK_PROTOCOL = "ttsc-plugin-build-lock-v2\n";
 // The default cache lives INSIDE the workspace, at
 // `<workspaceRoot>/node_modules/.cache/ttsc`, so `rm -rf node_modules` (or
 // deleting the repo) reclaims every compiled plugin binary and Go object file.
@@ -289,25 +295,24 @@ function compileSourcePlugin(opts: {
  * cache key, so concurrent fan-out (parallel suites, a benchmark, a worker
  * pool) runs the `go build` once instead of once per process.
  *
- * The lock is an atomic `mkdir` on `<cacheDir>.lock`. The winner builds and
- * publishes the binary; every loser polls for that binary to appear and reuses
- * it. A loser distinguishes two ways the lock can stop blocking it:
+ * `<cacheDir>.lock` is a persistent coordination directory. A contender writes
+ * a non-empty candidate and atomically renames it to `current`; only one rename
+ * wins. The winner builds and publishes while every loser polls and reuses the
+ * resulting binary. A loser distinguishes two ways a generation stops blocking:
  *
- * - `released`: the holder removed the lock itself — it published, or its build
- *   threw and its `finally` freed the key. The loser simply retries the
+ * - `released`: the holder retired `current` itself — it published, or its
+ *   build threw and its `finally` freed the key. The loser simply retries the
  *   ordinary acquisition; nothing is stale and nothing is reported.
- * - `abandoned`: the lock still exists but its owner is provably dead, it is an
- *   old metadata-less legacy lock, or the wait budget
+ * - `abandoned`: `current` still exists but its owner is provably dead, it is
+ *   an old metadata-less legacy lock, or the wait budget
  *   (`PLUGIN_BUILD_LOCK_STEAL_MS`) expired. Only then does the loser report and
- *   steal the lock before retrying.
+ *   retire precisely that generation before retrying.
  *
- * This is the same shape as `withBuildLock` in the runtime hooks, keyed on the
- * plugin binary's existence instead of a JSON meta marker.
- *
- * Correctness still rests on `publishBuiltBinary`'s atomic rename: the lock is
- * an optimisation to avoid duplicate work, not the only guard against a corrupt
- * binary, so a stolen lock that races a slow builder cannot ship a half-written
- * file.
+ * Retired generations remain as non-empty tombstones. Release and reclaim both
+ * rename `current` to the observed generation's deterministic tombstone path.
+ * Once generation A is retired, a stale observer or old finalizer for A cannot
+ * rename successor B there because replacing the non-empty tombstone fails
+ * atomically. `publishBuiltBinary`'s atomic rename remains defense in depth.
  */
 function buildUnderPluginLock(
   cacheDir: string,
@@ -325,20 +330,15 @@ function buildUnderPluginLock(
       touchCacheEntry(cacheDir);
       return binaryPath;
     }
+    let lease: PluginBuildLockLease | null;
     try {
-      // Plain mkdir (no `recursive`): recursive mode is idempotent and would
-      // not throw EEXIST, defeating the lock. The parent `cacheDir` already
-      // exists, so a single-level mkdir is all that is needed and its EEXIST
-      // is exactly the "someone else holds the lock" signal.
-      fs.mkdirSync(lockDir);
-      writePluginBuildLockOwner(lockDir);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        // A lock dir we cannot create for an unexpected reason (e.g. a
-        // read-only cache) must not silently skip the build. Fall back to an
-        // unlocked build — correctness is preserved by the atomic publish.
-        return build();
-      }
+      lease = acquirePluginBuildLock(lockDir);
+    } catch {
+      // An unusable coordination directory must not silently skip the build.
+      // Atomic publication still preserves binary integrity.
+      return build();
+    }
+    if (lease === null) {
       const waited = waitForPluginBinary({
         binaryPath,
         lockDir,
@@ -350,9 +350,10 @@ function buildUnderPluginLock(
         return binaryPath;
       }
       if (waited.outcome === "abandoned") {
-        // Builder appears to have crashed: steal the abandoned lock and retry.
+        // Retire only the generation that produced this observation. Losing
+        // the rename race means another waiter already made progress.
         reportPluginLockSteal(lockDir, binaryPath, lockInfo, waited.reason);
-        fs.rmSync(lockDir, { force: true, recursive: true });
+        reclaimPluginBuildLock(lockDir, waited.fence);
       }
       // "released" needs no repair: the holder freed the key normally (its
       // build published or failed), so retry the ordinary atomic acquisition.
@@ -368,9 +369,197 @@ function buildUnderPluginLock(
       }
       return build();
     } finally {
-      fs.rmSync(lockDir, { force: true, recursive: true });
+      releasePluginBuildLock(lockDir, lease);
     }
   }
+}
+
+/** Opaque identity of one observed lock generation. */
+export type PluginBuildLockFence = {
+  protocol: "legacy" | "v2";
+  generation: string;
+};
+
+/** Ownership token returned only to the process that acquired `current`. */
+export type PluginBuildLockLease = {
+  protocol: "v2";
+  generation: string;
+};
+
+/**
+ * Atomically acquire the current generation in a v2 coordination directory.
+ *
+ * A non-empty candidate is renamed to `current`. Directory rename cannot
+ * replace a non-empty `current`, so exactly one contender wins without an
+ * empty-owner publication window. `null` means either another v2 holder won or
+ * the path is a legacy lock that must be observed before it can be reclaimed.
+ *
+ * Exported for deterministic multi-process tests.
+ */
+export function acquirePluginBuildLock(
+  lockDir: string,
+): PluginBuildLockLease | null {
+  if (!ensurePluginBuildLockProtocol(lockDir)) {
+    return null;
+  }
+
+  const generation = crypto.randomBytes(16).toString("hex");
+  const candidateDir = path.join(lockDir, `candidate-${generation}`);
+  fs.mkdirSync(candidateDir);
+  try {
+    fs.writeFileSync(
+      path.join(candidateDir, PLUGIN_BUILD_LOCK_GENERATION_FILE),
+      `${generation}\n`,
+      { encoding: "utf8", flag: "wx" },
+    );
+    writePluginBuildLockOwner(candidateDir, generation);
+    try {
+      fs.renameSync(
+        candidateDir,
+        path.join(lockDir, PLUGIN_BUILD_LOCK_CURRENT_DIR),
+      );
+    } catch (error) {
+      if (
+        isMissingPathError(error) ||
+        isRenameDestinationOccupied(
+          error,
+          path.join(lockDir, PLUGIN_BUILD_LOCK_CURRENT_DIR),
+        )
+      ) {
+        return null;
+      }
+      throw error;
+    }
+    return { protocol: "v2", generation };
+  } finally {
+    // The candidate name contains this process's random generation and can
+    // never alias `current` or another contender's candidate.
+    fs.rmSync(candidateDir, { force: true, recursive: true });
+  }
+}
+
+/** Retire a held generation during the holder's `finally`. */
+export function releasePluginBuildLock(
+  lockDir: string,
+  lease: PluginBuildLockLease,
+): boolean {
+  return retireV2PluginBuildLock(lockDir, lease.generation);
+}
+
+/**
+ * Retire exactly the generation carried by an abandoned observation.
+ *
+ * Exported for deterministic multi-process tests.
+ */
+export function reclaimPluginBuildLock(
+  lockDir: string,
+  fence: PluginBuildLockFence,
+): boolean {
+  if (fence.protocol === "v2") {
+    return retireV2PluginBuildLock(lockDir, fence.generation);
+  }
+  return retireLegacyPluginBuildLock(lockDir, fence.generation);
+}
+
+function ensurePluginBuildLockProtocol(lockDir: string): boolean {
+  try {
+    fs.mkdirSync(lockDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw error;
+    }
+    return isPluginBuildLockProtocolV2(lockDir);
+  }
+
+  fs.mkdirSync(path.join(lockDir, PLUGIN_BUILD_LOCK_RETIRED_DIR));
+  fs.writeFileSync(
+    path.join(lockDir, PLUGIN_BUILD_LOCK_PROTOCOL_FILE),
+    PLUGIN_BUILD_LOCK_PROTOCOL,
+    { encoding: "utf8", flag: "wx" },
+  );
+  return true;
+}
+
+function isPluginBuildLockProtocolV2(lockDir: string): boolean {
+  try {
+    return (
+      fs.readFileSync(
+        path.join(lockDir, PLUGIN_BUILD_LOCK_PROTOCOL_FILE),
+        "utf8",
+      ) === PLUGIN_BUILD_LOCK_PROTOCOL
+    );
+  } catch {
+    return false;
+  }
+}
+
+function retireV2PluginBuildLock(
+  lockDir: string,
+  generation: string,
+): boolean {
+  if (!isPluginBuildLockGeneration(generation)) return false;
+  const retiredDir = path.join(lockDir, PLUGIN_BUILD_LOCK_RETIRED_DIR);
+  try {
+    fs.mkdirSync(retiredDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      if (isMissingPathError(error)) return false;
+      throw error;
+    }
+  }
+
+  const destination = path.join(retiredDir, generation);
+  try {
+    fs.renameSync(
+      path.join(lockDir, PLUGIN_BUILD_LOCK_CURRENT_DIR),
+      destination,
+    );
+    return true;
+  } catch (error) {
+    if (
+      isMissingPathError(error) ||
+      isRenameDestinationOccupied(error, destination)
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function retireLegacyPluginBuildLock(
+  lockDir: string,
+  generation: string,
+): boolean {
+  if (!isPluginBuildLockGeneration(generation)) return false;
+  const destination = `${lockDir}.retired-${generation}`;
+  try {
+    fs.renameSync(lockDir, destination);
+    return true;
+  } catch (error) {
+    if (
+      isMissingPathError(error) ||
+      isRenameDestinationOccupied(error, destination)
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function isRenameDestinationOccupied(
+  error: unknown,
+  destination: string,
+): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code === "EEXIST" || code === "ENOTEMPTY") {
+    return true;
+  }
+  return (code === "EACCES" || code === "EPERM") && fs.existsSync(destination);
 }
 
 /**
@@ -389,7 +578,11 @@ function buildUnderPluginLock(
 export type PluginBinaryWaitResult =
   | { outcome: "published" }
   | { outcome: "released" }
-  | { outcome: "abandoned"; reason: string };
+  | {
+      outcome: "abandoned";
+      reason: string;
+      fence: PluginBuildLockFence;
+    };
 
 /**
  * Poll for the locked builder to publish its binary, up to `timeoutMs`.
@@ -424,12 +617,17 @@ export function waitForPluginBinary(opts: {
         : { outcome: "released" };
     }
     if (lock.state === "abandoned") {
-      return { outcome: "abandoned", reason: lock.reason };
+      return {
+        outcome: "abandoned",
+        reason: lock.reason,
+        fence: lock.fence,
+      };
     }
     if (now - startedAt > opts.timeoutMs) {
       return {
         outcome: "abandoned",
         reason: `timed out after ${formatDuration(now - startedAt)}`,
+        fence: lock.fence,
       };
     }
     if (!opts.lockInfo.quiet && now >= nextStatusAt) {
@@ -446,24 +644,24 @@ export function waitForPluginBinary(opts: {
   }
 }
 
-function writePluginBuildLockOwner(lockDir: string): void {
-  try {
-    fs.writeFileSync(
-      path.join(lockDir, PLUGIN_BUILD_LOCK_OWNER_FILE),
-      `${JSON.stringify(
-        {
-          hostname: os.hostname(),
-          pid: process.pid,
-          startedAt: new Date().toISOString(),
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-  } catch {
-    // Best-effort metadata: the mkdir lock still serializes the build.
-  }
+function writePluginBuildLockOwner(
+  generationDir: string,
+  generation: string,
+): void {
+  fs.writeFileSync(
+    path.join(generationDir, PLUGIN_BUILD_LOCK_OWNER_FILE),
+    `${JSON.stringify(
+      {
+        generation,
+        hostname: os.hostname(),
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
 }
 
 /**
@@ -481,8 +679,16 @@ function writePluginBuildLockOwner(lockDir: string): void {
  * Exported for unit tests.
  */
 export type PluginBuildLockObservation =
-  | { state: "active"; owner: string }
-  | { state: "abandoned"; reason: string }
+  | {
+      state: "active";
+      owner: string;
+      fence: PluginBuildLockFence;
+    }
+  | {
+      state: "abandoned";
+      reason: string;
+      fence: PluginBuildLockFence;
+    }
   | { state: "released" };
 
 /**
@@ -494,22 +700,55 @@ export function inspectPluginBuildLock(
   lockDir: string,
   now: number,
 ): PluginBuildLockObservation {
-  const owner = readPluginBuildLockOwner(lockDir);
+  for (;;) {
+    if (isPluginBuildLockProtocolV2(lockDir)) {
+      return inspectV2PluginBuildLock(lockDir, now);
+    }
+    const legacy = captureLegacyPluginBuildLockFence(lockDir);
+    if (legacy !== null) {
+      return inspectLegacyPluginBuildLock(lockDir, now, legacy);
+    }
+    if (pluginBuildLockAgeMs(lockDir, now) === null) {
+      return { state: "released" };
+    }
+    // The path changed while its legacy fence was being captured. Re-observe
+    // the replacement rather than attaching the old state to a new owner.
+  }
+}
+
+function inspectV2PluginBuildLock(
+  lockDir: string,
+  now: number,
+): PluginBuildLockObservation {
+  const generationDir = path.join(lockDir, PLUGIN_BUILD_LOCK_CURRENT_DIR);
+  const generation = readPluginBuildLockGeneration(generationDir);
+  if (generation === null) {
+    if (pluginBuildLockAgeMs(generationDir, now) === null) {
+      return { state: "released" };
+    }
+    throw new Error(
+      `ttsc plugin build lock has no valid ${PLUGIN_BUILD_LOCK_GENERATION_FILE}: ${generationDir}`,
+    );
+  }
+  const fence: PluginBuildLockFence = { protocol: "v2", generation };
+  const owner = readPluginBuildLockOwner(generationDir);
   if (owner !== null) {
     const label = describePluginBuildLockOwner(owner);
     if (isLocalHostName(owner.hostname) && !isProcessAlive(owner.pid)) {
       return {
         state: "abandoned",
         reason: `${label} is no longer running`,
+        fence,
       };
     }
     return {
       state: "active",
       owner: label,
+      fence,
     };
   }
 
-  const ageMs = pluginBuildLockAgeMs(lockDir, now);
+  const ageMs = pluginBuildLockAgeMs(generationDir, now);
   if (ageMs === null) {
     return { state: "released" };
   }
@@ -517,14 +756,159 @@ export function inspectPluginBuildLock(
     return {
       state: "abandoned",
       reason:
+        `lock generation has no ${PLUGIN_BUILD_LOCK_OWNER_FILE} and is ` +
+        `${formatDuration(ageMs)} old`,
+      fence,
+    };
+  }
+  return {
+    state: "active",
+    owner: `lock generation with no ${PLUGIN_BUILD_LOCK_OWNER_FILE}`,
+    fence,
+  };
+}
+
+interface LegacyPluginBuildLockFence {
+  fence: PluginBuildLockFence;
+  legacyMtimeMs: number;
+}
+
+function inspectLegacyPluginBuildLock(
+  lockDir: string,
+  now: number,
+  legacy: LegacyPluginBuildLockFence,
+): PluginBuildLockObservation {
+  const owner = readPluginBuildLockOwner(lockDir);
+  if (owner !== null) {
+    const label = describePluginBuildLockOwner(owner);
+    if (isLocalHostName(owner.hostname) && !isProcessAlive(owner.pid)) {
+      return {
+        state: "abandoned",
+        reason: `${label} is no longer running`,
+        fence: legacy.fence,
+      };
+    }
+    return {
+      state: "active",
+      owner: label,
+      fence: legacy.fence,
+    };
+  }
+
+  const ageMs = Math.max(0, now - legacy.legacyMtimeMs);
+  if (ageMs > PLUGIN_BUILD_LOCK_LEGACY_STALE_MS) {
+    return {
+      state: "abandoned",
+      reason:
         `legacy lock has no ${PLUGIN_BUILD_LOCK_OWNER_FILE} and is ` +
         `${formatDuration(ageMs)} old`,
+      fence: legacy.fence,
     };
   }
   return {
     state: "active",
     owner: `legacy lock with no ${PLUGIN_BUILD_LOCK_OWNER_FILE}`,
+    fence: legacy.fence,
   };
+}
+
+function captureLegacyPluginBuildLockFence(
+  lockDir: string,
+): LegacyPluginBuildLockFence | null {
+  if (isPluginBuildLockProtocolV2(lockDir)) {
+    return null;
+  }
+
+  let legacyMtimeMs: number;
+  try {
+    legacyMtimeMs = fs.statSync(lockDir).mtimeMs;
+  } catch (error) {
+    if (isMissingPathError(error)) return null;
+    throw error;
+  }
+
+  const file = path.join(lockDir, PLUGIN_BUILD_LOCK_LEGACY_FENCE_FILE);
+  let captured = readLegacyPluginBuildLockFence(file);
+  if (captured === null) {
+    const generation = crypto.randomBytes(16).toString("hex");
+    try {
+      fs.writeFileSync(
+        file,
+        `${JSON.stringify({ generation, legacyMtimeMs })}\n`,
+        { encoding: "utf8", flag: "wx" },
+      );
+      captured = {
+        fence: { protocol: "legacy", generation },
+        legacyMtimeMs,
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        captured = readLegacyPluginBuildLockFence(file);
+      } else if (isMissingPathError(error)) {
+        return null;
+      } else {
+        throw error;
+      }
+    }
+  }
+  if (captured === null) {
+    throw new Error(`invalid legacy plugin build lock fence: ${file}`);
+  }
+
+  // A stale observer can resume after another process replaced the legacy
+  // path with a v2 root. Confirm both the layout and token after publication.
+  const confirmed = readLegacyPluginBuildLockFence(file);
+  if (
+    isPluginBuildLockProtocolV2(lockDir) ||
+    confirmed === null ||
+    confirmed.fence.generation !== captured.fence.generation
+  ) {
+    return null;
+  }
+  return captured;
+}
+
+function readLegacyPluginBuildLockFence(
+  file: string,
+): LegacyPluginBuildLockFence | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    if (
+      !isPluginBuildLockGeneration(parsed.generation) ||
+      typeof parsed.legacyMtimeMs !== "number" ||
+      !Number.isFinite(parsed.legacyMtimeMs) ||
+      parsed.legacyMtimeMs < 0
+    ) {
+      return null;
+    }
+    return {
+      fence: { protocol: "legacy", generation: parsed.generation },
+      legacyMtimeMs: parsed.legacyMtimeMs,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readPluginBuildLockGeneration(generationDir: string): string | null {
+  try {
+    const generation = fs
+      .readFileSync(
+        path.join(generationDir, PLUGIN_BUILD_LOCK_GENERATION_FILE),
+        "utf8",
+      )
+      .trim();
+    return isPluginBuildLockGeneration(generation) ? generation : null;
+  } catch {
+    return null;
+  }
+}
+
+function isPluginBuildLockGeneration(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{32}$/.test(value);
 }
 
 function readPluginBuildLockOwner(
@@ -2190,7 +2574,11 @@ function collectPluginCacheEntries(
     return entries;
   }
   for (const dirent of dirents) {
-    if (!dirent.isDirectory()) {
+    if (
+      !dirent.isDirectory() ||
+      dirent.name.endsWith(".lock") ||
+      dirent.name.includes(".lock.retired-")
+    ) {
       continue;
     }
     const dir = path.join(root, dirent.name);

--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -113,6 +113,7 @@ const PLUGIN_BUILD_LOCK_LEGACY_FENCE_DIR = "legacy-generation";
 const PLUGIN_BUILD_LOCK_LEGACY_FENCE_RECORD = "fence.json";
 const PLUGIN_BUILD_LOCK_CURRENT_DIR = "current";
 const PLUGIN_BUILD_LOCK_RETIRED_DIR = "retired";
+const PLUGIN_BUILD_LOCK_V2_SUFFIX = ".v2";
 const PLUGIN_BUILD_LOCK_PROTOCOL = "ttsc-plugin-build-lock-v2\n";
 // The default cache lives INSIDE the workspace, at
 // `<workspaceRoot>/node_modules/.cache/ttsc`, so `rm -rf node_modules` (or
@@ -296,10 +297,14 @@ function compileSourcePlugin(opts: {
  * cache key, so concurrent fan-out (parallel suites, a benchmark, a worker
  * pool) runs the `go build` once instead of once per process.
  *
- * `<cacheDir>.lock` is a persistent coordination directory. A contender writes
- * a non-empty candidate and atomically renames it to `current`; only one rename
- * wins. The winner builds and publishes while every loser polls and reuses the
- * resulting binary. A loser distinguishes two ways a generation stops blocking:
+ * `<cacheDir>.lock.v2` is a persistent coordination directory. The adjacent
+ * `<cacheDir>.lock` path remains reserved for legacy holders and is never
+ * reused for a v2 generation: an old holder or stale legacy reclaimer can
+ * therefore remove only the legacy path, never a v2 successor. A contender
+ * writes a non-empty candidate and atomically renames it to `current`; only one
+ * rename wins. The winner builds and publishes while every loser polls and
+ * reuses the resulting binary. A loser distinguishes two ways a generation
+ * stops blocking:
  *
  * - `released`: the holder retired `current` itself — it published, or its
  *   build threw and its `finally` freed the key. The loser simply retries the
@@ -352,9 +357,12 @@ function buildUnderPluginLock(
       }
       if (waited.outcome === "abandoned") {
         // Retire only the generation that produced this observation. Losing
-        // the rename race means another waiter already made progress.
-        reportPluginLockSteal(lockDir, binaryPath, lockInfo, waited.reason);
-        reclaimPluginBuildLock(lockDir, waited.fence);
+        // the rename race means another waiter (or the holder's normal
+        // finalizer) already made progress, so do not report a stale result as
+        // an abandonment.
+        if (reclaimPluginBuildLock(lockDir, waited.fence)) {
+          reportPluginLockSteal(lockDir, binaryPath, lockInfo, waited.reason);
+        }
       }
       // "released" needs no repair: the holder freed the key normally (its
       // build published or failed), so retry the ordinary atomic acquisition.
@@ -400,12 +408,23 @@ export type PluginBuildLockLease = {
 export function acquirePluginBuildLock(
   lockDir: string,
 ): PluginBuildLockLease | null {
-  if (!ensurePluginBuildLockProtocol(lockDir)) {
+  // A legacy holder owns the old path. Never publish v2 ownership into that
+  // deletable namespace; wait until the legacy generation is released or
+  // reclaimed, then use the orthogonal persistent v2 directory.
+  if (pluginBuildLockPathExists(lockDir)) {
+    return null;
+  }
+  const protocolDir = pluginBuildLockProtocolDir(lockDir);
+  ensurePluginBuildLockProtocol(protocolDir);
+  // Close the initialization window as far as the legacy protocol permits. A
+  // legacy holder that appeared while v2 was initialized still blocks this
+  // acquisition. (A legacy executable cannot provide a true cross-path CAS.)
+  if (pluginBuildLockPathExists(lockDir)) {
     return null;
   }
 
   const generation = crypto.randomBytes(16).toString("hex");
-  const candidateDir = path.join(lockDir, `candidate-${generation}`);
+  const candidateDir = path.join(protocolDir, `candidate-${generation}`);
   fs.mkdirSync(candidateDir);
   try {
     fs.writeFileSync(
@@ -417,14 +436,14 @@ export function acquirePluginBuildLock(
     try {
       fs.renameSync(
         candidateDir,
-        path.join(lockDir, PLUGIN_BUILD_LOCK_CURRENT_DIR),
+        path.join(protocolDir, PLUGIN_BUILD_LOCK_CURRENT_DIR),
       );
     } catch (error) {
       if (
         isMissingPathError(error) ||
         isRenameDestinationOccupied(
           error,
-          path.join(lockDir, PLUGIN_BUILD_LOCK_CURRENT_DIR),
+          path.join(protocolDir, PLUGIN_BUILD_LOCK_CURRENT_DIR),
         )
       ) {
         return null;
@@ -444,7 +463,10 @@ export function releasePluginBuildLock(
   lockDir: string,
   lease: PluginBuildLockLease,
 ): boolean {
-  return retireV2PluginBuildLock(lockDir, lease.generation);
+  return retireV2PluginBuildLock(
+    pluginBuildLockProtocolDir(lockDir),
+    lease.generation,
+  );
 }
 
 /**
@@ -457,28 +479,47 @@ export function reclaimPluginBuildLock(
   fence: PluginBuildLockFence,
 ): boolean {
   if (fence.protocol === "v2") {
-    return retireV2PluginBuildLock(lockDir, fence.generation);
+    return retireV2PluginBuildLock(
+      pluginBuildLockProtocolDir(lockDir),
+      fence.generation,
+    );
   }
   return retireLegacyPluginBuildLock(lockDir, fence.generation);
 }
 
-function ensurePluginBuildLockProtocol(lockDir: string): boolean {
-  try {
-    fs.mkdirSync(lockDir);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-      throw error;
-    }
-    return isPluginBuildLockProtocolV2(lockDir);
+function pluginBuildLockProtocolDir(lockDir: string): string {
+  return `${lockDir}${PLUGIN_BUILD_LOCK_V2_SUFFIX}`;
+}
+
+function ensurePluginBuildLockProtocol(protocolDir: string): void {
+  if (isPluginBuildLockProtocolV2(protocolDir)) {
+    return;
   }
 
-  fs.mkdirSync(path.join(lockDir, PLUGIN_BUILD_LOCK_RETIRED_DIR));
-  fs.writeFileSync(
-    path.join(lockDir, PLUGIN_BUILD_LOCK_PROTOCOL_FILE),
-    PLUGIN_BUILD_LOCK_PROTOCOL,
-    { encoding: "utf8", flag: "wx" },
-  );
-  return true;
+  const generation = crypto.randomBytes(16).toString("hex");
+  const candidateDir = `${protocolDir}.candidate-${generation}`;
+  fs.mkdirSync(candidateDir);
+  try {
+    fs.mkdirSync(path.join(candidateDir, PLUGIN_BUILD_LOCK_RETIRED_DIR));
+    fs.writeFileSync(
+      path.join(candidateDir, PLUGIN_BUILD_LOCK_PROTOCOL_FILE),
+      PLUGIN_BUILD_LOCK_PROTOCOL,
+      { encoding: "utf8", flag: "wx" },
+    );
+    try {
+      fs.renameSync(candidateDir, protocolDir);
+    } catch (error) {
+      if (
+        isRenameDestinationOccupied(error, protocolDir) &&
+        isPluginBuildLockProtocolV2(protocolDir)
+      ) {
+        return;
+      }
+      throw error;
+    }
+  } finally {
+    fs.rmSync(candidateDir, { force: true, recursive: true });
+  }
 }
 
 function isPluginBuildLockProtocolV2(lockDir: string): boolean {
@@ -532,6 +573,12 @@ function retireLegacyPluginBuildLock(
   generation: string,
 ): boolean {
   if (!isPluginBuildLockGeneration(generation)) return false;
+  const captured = readLegacyPluginBuildLockFence(
+    path.join(lockDir, PLUGIN_BUILD_LOCK_LEGACY_FENCE_DIR),
+  );
+  if (captured?.fence.generation !== generation) {
+    return false;
+  }
   const destination = `${lockDir}.retired-${generation}`;
   try {
     fs.renameSync(lockDir, destination);
@@ -701,9 +748,13 @@ export function inspectPluginBuildLock(
   lockDir: string,
   now: number,
 ): PluginBuildLockObservation {
+  const protocolDir = pluginBuildLockProtocolDir(lockDir);
   for (;;) {
-    if (isPluginBuildLockProtocolV2(lockDir)) {
-      return inspectV2PluginBuildLock(lockDir, now);
+    if (isPluginBuildLockProtocolV2(protocolDir)) {
+      const v2 = inspectV2PluginBuildLock(protocolDir, now);
+      if (v2.state !== "released") {
+        return v2;
+      }
     }
     const legacy = captureLegacyPluginBuildLockFence(lockDir);
     if (legacy !== null) {
@@ -871,8 +922,9 @@ function captureLegacyPluginBuildLockFence(
     throw new Error(`invalid legacy plugin build lock fence: ${fenceDir}`);
   }
 
-  // A stale observer can resume after another process replaced the legacy
-  // path with a v2 root. Confirm both the layout and token after publication.
+  // A stale observer can resume after the legacy holder released or another
+  // process retired the path. Confirm both the legacy layout and token after
+  // publication; v2 ownership is kept in the orthogonal sibling directory.
   const confirmed = readLegacyPluginBuildLockFence(fenceDir);
   if (
     isPluginBuildLockProtocolV2(lockDir) ||
@@ -972,6 +1024,16 @@ function pluginBuildLockAgeMs(lockDir: string, now: number): number | null {
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     return code === "ENOENT" || code === "ENOTDIR" ? null : 0;
+  }
+}
+
+function pluginBuildLockPathExists(lockDir: string): boolean {
+  try {
+    fs.statSync(lockDir);
+    return true;
+  } catch (error) {
+    if (isMissingPathError(error)) return false;
+    throw error;
   }
 }
 
@@ -2595,7 +2657,7 @@ function collectPluginCacheEntries(
     if (
       !dirent.isDirectory() ||
       dirent.name.endsWith(".lock") ||
-      dirent.name.includes(".lock.retired-")
+      dirent.name.includes(".lock.")
     ) {
       continue;
     }

--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -109,7 +109,8 @@ const PLUGIN_BUILD_LOCK_STATUS_MS = 30_000;
 const PLUGIN_BUILD_LOCK_OWNER_FILE = "owner.json";
 const PLUGIN_BUILD_LOCK_PROTOCOL_FILE = "protocol-v2";
 const PLUGIN_BUILD_LOCK_GENERATION_FILE = "generation";
-const PLUGIN_BUILD_LOCK_LEGACY_FENCE_FILE = "legacy-generation.json";
+const PLUGIN_BUILD_LOCK_LEGACY_FENCE_DIR = "legacy-generation";
+const PLUGIN_BUILD_LOCK_LEGACY_FENCE_RECORD = "fence.json";
 const PLUGIN_BUILD_LOCK_CURRENT_DIR = "current";
 const PLUGIN_BUILD_LOCK_RETIRED_DIR = "retired";
 const PLUGIN_BUILD_LOCK_PROTOCOL = "ttsc-plugin-build-lock-v2\n";
@@ -566,12 +567,12 @@ function isRenameDestinationOccupied(
  * Outcome of one waiting session on another process's plugin build lock.
  *
  * - `published`: the binary exists and can be reused.
- * - `released`: the observed lock no longer exists and no binary appeared — the
- *   holder freed the key normally, so the caller should retry the ordinary
- *   atomic acquisition without reporting or removing anything.
+ * - `released`: the observed generation no longer exists and no binary
+ *   appeared — the holder freed the key normally, so the caller should retry
+ *   ordinary acquisition without reporting or removing anything.
  * - `abandoned`: the lock still exists but is provably stale (dead owner, old
- *   legacy lock) or the wait budget expired; the caller may report and steal
- *   it.
+ *   legacy lock) or the wait budget expired; the caller may report and retire
+ *   precisely the attached generation.
  *
  * Exported for unit tests.
  */
@@ -672,9 +673,9 @@ function writePluginBuildLockOwner(
  * - `abandoned`: the lock still exists and the evidence says nobody will ever
  *   release it — a same-host owner that is no longer running, or an old
  *   metadata-less legacy lock. Stealing is justified.
- * - `released`: the lock directory no longer exists. The holder released it
- *   normally (its build published or failed), so this is a routine handoff —
- *   never an infinitely old abandoned lock (issue #421).
+ * - `released`: the observed generation no longer exists. In v2 the persistent
+ *   coordination root remains while `current` is absent. This is a routine
+ *   handoff, never an infinitely old abandoned lock (issue #421).
  *
  * Exported for unit tests.
  */
@@ -827,37 +828,52 @@ function captureLegacyPluginBuildLockFence(
     throw error;
   }
 
-  const file = path.join(lockDir, PLUGIN_BUILD_LOCK_LEGACY_FENCE_FILE);
-  let captured = readLegacyPluginBuildLockFence(file);
+  const fenceDir = path.join(lockDir, PLUGIN_BUILD_LOCK_LEGACY_FENCE_DIR);
+  let captured = readLegacyPluginBuildLockFence(fenceDir);
   if (captured === null) {
     const generation = crypto.randomBytes(16).toString("hex");
+    const candidateDir = path.join(
+      lockDir,
+      `legacy-candidate-${generation}`,
+    );
     try {
+      fs.mkdirSync(candidateDir);
       fs.writeFileSync(
-        file,
+        path.join(candidateDir, PLUGIN_BUILD_LOCK_LEGACY_FENCE_RECORD),
         `${JSON.stringify({ generation, legacyMtimeMs })}\n`,
-        { encoding: "utf8", flag: "wx" },
+        "utf8",
       );
-      captured = {
-        fence: { protocol: "legacy", generation },
-        legacyMtimeMs,
-      };
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
-        captured = readLegacyPluginBuildLockFence(file);
-      } else if (isMissingPathError(error)) {
-        return null;
-      } else {
-        throw error;
+      try {
+        fs.renameSync(candidateDir, fenceDir);
+        captured = {
+          fence: { protocol: "legacy", generation },
+          legacyMtimeMs,
+        };
+      } catch (error) {
+        if (isRenameDestinationOccupied(error, fenceDir)) {
+          captured = readLegacyPluginBuildLockFence(fenceDir);
+        } else if (isMissingPathError(error)) {
+          return null;
+        } else {
+          throw error;
+        }
       }
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        return null;
+      }
+      throw error;
+    } finally {
+      fs.rmSync(candidateDir, { force: true, recursive: true });
     }
   }
   if (captured === null) {
-    throw new Error(`invalid legacy plugin build lock fence: ${file}`);
+    throw new Error(`invalid legacy plugin build lock fence: ${fenceDir}`);
   }
 
   // A stale observer can resume after another process replaced the legacy
   // path with a v2 root. Confirm both the layout and token after publication.
-  const confirmed = readLegacyPluginBuildLockFence(file);
+  const confirmed = readLegacyPluginBuildLockFence(fenceDir);
   if (
     isPluginBuildLockProtocolV2(lockDir) ||
     confirmed === null ||
@@ -869,13 +885,15 @@ function captureLegacyPluginBuildLockFence(
 }
 
 function readLegacyPluginBuildLockFence(
-  file: string,
+  fenceDir: string,
 ): LegacyPluginBuildLockFence | null {
   try {
-    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as Record<
-      string,
-      unknown
-    >;
+    const parsed = JSON.parse(
+      fs.readFileSync(
+        path.join(fenceDir, PLUGIN_BUILD_LOCK_LEGACY_FENCE_RECORD),
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
     if (
       !isPluginBuildLockGeneration(parsed.generation) ||
       typeof parsed.legacyMtimeMs !== "number" ||
@@ -938,8 +956,8 @@ function readPluginBuildLockOwner(
 }
 
 /**
- * Age of the lock directory, or `null` when it no longer exists (the holder
- * released it between the caller's checks). "Missing" is a first-class
+ * Age of an observed lock directory, or `null` when it no longer exists. The
+ * holder may have retired it between the caller's checks. "Missing" is a
  * observation, never encoded as a numeric age: the previous
  * `Number.POSITIVE_INFINITY` encoding made a just-released lock look like an
  * infinitely old abandoned legacy lock (issue #421).

--- a/tests/test-ttsc/src/internal/source-build.ts
+++ b/tests/test-ttsc/src/internal/source-build.ts
@@ -13,12 +13,15 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  acquirePluginBuildLock,
   autoQuoteGoModToken,
   buildSourcePlugin,
   computeCacheKey,
   formatDuration,
   formatGoWorkPath,
   inspectPluginBuildLock,
+  reclaimPluginBuildLock,
+  releasePluginBuildLock,
   resolvePluginCacheRoot,
   resolveSourceBuildCachePaths,
   waitForPluginBinary,
@@ -203,6 +206,45 @@ interface ISourcePluginWorkerResult {
   stderr: string;
 }
 
+/** Spawn a Node.js worker script and capture its complete result. */
+function spawnNodeWorker(opts: {
+  env?: Record<string, string>;
+  script: string;
+  timeoutMs?: number;
+}): Promise<ISourcePluginWorkerResult> {
+  return new Promise((resolve, reject) => {
+    const child = child_process.spawn(process.execPath, [opts.script], {
+      env: { ...process.env, ...opts.env },
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: opts.timeoutMs ?? 120_000,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+/** Absolute path to the built source-plugin implementation used by workers. */
+function sourceBuildLibraryPath(): string {
+  return path.join(
+    TestProject.WORKSPACE_ROOT,
+    "packages",
+    "ttsc",
+    "lib",
+    "plugin",
+    "internal",
+    "buildSourcePlugin.js",
+  );
+}
+
 /**
  * Writes a CommonJS runner script that calls the workspace-built
  * `buildSourcePlugin` with the given fixed inputs and returns the script's
@@ -219,15 +261,7 @@ function createSourcePluginWorkerScript(opts: {
   root: string;
   source: string;
 }): string {
-  const libraryPath = path.join(
-    TestProject.WORKSPACE_ROOT,
-    "packages",
-    "ttsc",
-    "lib",
-    "plugin",
-    "internal",
-    "buildSourcePlugin.js",
-  );
+  const libraryPath = sourceBuildLibraryPath();
   const script = path.join(opts.root, "build-source-plugin-worker.cjs");
   fs.writeFileSync(
     script,
@@ -270,27 +304,12 @@ function spawnSourcePluginWorker(opts: {
   goBinary: string;
   script: string;
 }): Promise<ISourcePluginWorkerResult> {
-  return new Promise((resolve, reject) => {
-    const child = child_process.spawn(process.execPath, [opts.script], {
-      env: {
-        ...process.env,
-        TTSC_GO_BINARY: opts.goBinary,
-        ...opts.env,
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 120_000,
-      windowsHide: true,
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
-    });
-    child.on("error", reject);
-    child.on("close", (status) => resolve({ status, stdout, stderr }));
+  return spawnNodeWorker({
+    env: {
+      TTSC_GO_BINARY: opts.goBinary,
+      ...opts.env,
+    },
+    script: opts.script,
   });
 }
 
@@ -315,6 +334,7 @@ async function waitForCondition(
 }
 
 export {
+  acquirePluginBuildLock,
   assert,
   autoQuoteGoModToken,
   buildSourcePlugin,
@@ -328,9 +348,13 @@ export {
   inspectPluginBuildLock,
   os,
   path,
+  reclaimPluginBuildLock,
+  releasePluginBuildLock,
   resolvePluginCacheRoot,
   resolveSourceBuildCachePaths,
   shellQuote,
+  spawnNodeWorker,
+  sourceBuildLibraryPath,
   spawnSourcePluginWorker,
   waitForCondition,
   waitForPluginBinary,

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_reclaims_stale_legacy_plugin_lock.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_reclaims_stale_legacy_plugin_lock.ts
@@ -6,6 +6,7 @@ import {
   computeCacheKey,
   createFakeGoBinary,
   fs,
+  inspectPluginBuildLock,
   path,
   resolveSourceBuildCachePaths,
 } from "../../internal/source-build";
@@ -21,7 +22,7 @@ import {
  * 1. Create a source-plugin cache entry with an old `.lock` directory and no
  *    binary.
  * 2. Run `buildSourcePlugin` through the fake Go toolchain.
- * 3. Assert the plugin binary is published and the stale lock is removed.
+ * 3. Assert the binary is published and the replacement v2 lock is released.
  */
 export const test_buildsourceplugin_reclaims_stale_legacy_plugin_lock = () => {
   const root = TestProject.tmpdir("ttsc-source-plugin-");
@@ -69,7 +70,9 @@ export const test_buildsourceplugin_reclaims_stale_legacy_plugin_lock = () => {
     });
 
     assert.equal(fs.existsSync(binary), true);
-    assert.equal(fs.existsSync(lockDir), false);
+    assert.deepEqual(inspectPluginBuildLock(lockDir, Date.now()), {
+      state: "released",
+    });
   } finally {
     restore("TTSC_GO_BINARY", saved.go);
     restore("TTSC_CACHE_DIR", saved.cache);

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_reclaims_stale_legacy_plugin_lock.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_reclaims_stale_legacy_plugin_lock.ts
@@ -54,9 +54,7 @@ export const test_buildsourceplugin_reclaims_stale_legacy_plugin_lock = () => {
     const lockDir = `${cacheEntry}.lock`;
     fs.mkdirSync(cacheEntry, { recursive: true });
     fs.mkdirSync(lockDir, { recursive: true });
-    fs.mkdirSync(
-      path.join(lockDir, `legacy-candidate-${"0".repeat(32)}`),
-    );
+    fs.mkdirSync(`${lockDir}.legacy-candidate-${"0".repeat(32)}`);
     const old = new Date(Date.now() - 120_000);
     fs.utimesSync(lockDir, old, old);
 

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_reclaims_stale_legacy_plugin_lock.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_reclaims_stale_legacy_plugin_lock.ts
@@ -19,8 +19,7 @@ import {
  * look wedged, so ttsc must recognize an old metadata-less lock as abandoned
  * and retry the build under a fresh lock.
  *
- * 1. Create a source-plugin cache entry with an old `.lock` directory and no
- *    binary.
+ * 1. Create an old `.lock` with no binary and a crashed fence candidate.
  * 2. Run `buildSourcePlugin` through the fake Go toolchain.
  * 3. Assert the binary is published and the replacement v2 lock is released.
  */
@@ -55,6 +54,9 @@ export const test_buildsourceplugin_reclaims_stale_legacy_plugin_lock = () => {
     const lockDir = `${cacheEntry}.lock`;
     fs.mkdirSync(cacheEntry, { recursive: true });
     fs.mkdirSync(lockDir, { recursive: true });
+    fs.mkdirSync(
+      path.join(lockDir, `legacy-candidate-${"0".repeat(32)}`),
+    );
     const old = new Date(Date.now() - 120_000);
     fs.utimesSync(lockDir, old, old);
 

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_waiter_recovers_when_holder_fails_and_releases.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_waiter_recovers_when_holder_fails_and_releases.ts
@@ -15,8 +15,8 @@ import {
  * releases.
  *
  * End-to-end pin for issue #421: a holder whose `go build` throws releases the
- * lock in its `finally`, and the waiting process then observes a lock that no
- * longer exists. The old inspector classified that released lock as an
+ * generation in its `finally`, and the waiting process then observes no
+ * `current` generation. The old inspector classified that release as an
  * infinitely old abandoned legacy lock and printed `reclaiming abandoned ...
  * Infinitym NaNs old`. The waiter must instead treat the free key as a routine
  * handoff: reacquire it, run the build itself, and publish the one usable

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_waiter_reuses_binary_published_during_release.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_buildsourceplugin_waiter_reuses_binary_published_during_release.ts
@@ -15,9 +15,9 @@ import {
  * releases.
  *
  * Companion pin for issue #421's success-side race: the holder publishes the
- * binary and removes its lock while the waiter is between two observations.
+ * binary and retires its generation while the waiter is between observations.
  * Whatever the interleaving — the waiter sees the binary directly, or first
- * sees the released lock and re-checks — it must reuse the published binary,
+ * sees the released generation and re-checks — it must reuse the binary,
  * never rebuild it and never report the routine release as reclaiming an
  * abandoned lock.
  *

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_keeps_fresh_legacy_lock_active.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_inspectpluginbuildlock_keeps_fresh_legacy_lock_active.ts
@@ -29,8 +29,9 @@ export const test_inspectpluginbuildlock_keeps_fresh_legacy_lock_active =
 
     const observation = inspectPluginBuildLock(lockDir, Date.now());
 
-    assert.deepEqual(observation, {
-      state: "active",
-      owner: "legacy lock with no owner.json",
-    });
+    assert.equal(observation.state, "active");
+    if (observation.state !== "active") return;
+    assert.equal(observation.owner, "legacy lock with no owner.json");
+    assert.equal(observation.fence.protocol, "legacy");
+    assert.match(observation.fence.generation, /^[0-9a-f]{32}$/);
   };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_pluginbuildlock_fences_two_stale_observers.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_pluginbuildlock_fences_two_stale_observers.ts
@@ -199,11 +199,13 @@ export const test_pluginbuildlock_fences_two_stale_observers = async () => {
     state: "released",
   });
   assert.equal(
-    fs.existsSync(path.join(lockDir, "retired", seed.generation)),
+    fs.existsSync(path.join(`${lockDir}.v2`, "retired", seed.generation)),
     true,
   );
   assert.equal(
-    fs.existsSync(path.join(lockDir, "retired", successorLease.generation)),
+    fs.existsSync(
+      path.join(`${lockDir}.v2`, "retired", successorLease.generation),
+    ),
     true,
   );
 };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_pluginbuildlock_fences_two_stale_observers.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_pluginbuildlock_fences_two_stale_observers.ts
@@ -1,0 +1,160 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  inspectPluginBuildLock,
+  path,
+  sourceBuildLibraryPath,
+  spawnNodeWorker,
+  waitForCondition,
+} from "../../internal/source-build";
+
+/**
+ * Verifies two stale observers cannot both replace one abandoned generation.
+ *
+ * Both real child processes capture the same dead owner's fence before either
+ * may reclaim it. After a shared barrier opens, exactly one retirement wins,
+ * exactly one successor acquires and publishes, and the other process reuses
+ * that result.
+ *
+ * 1. Let a short-lived child acquire a v2 lock and exit without releasing it.
+ * 2. Hold two observers at a barrier after both report that generation dead.
+ * 3. Release them together and assert one reclaim, one build, and one binary.
+ */
+export const test_pluginbuildlock_fences_two_stale_observers = async () => {
+  const root = TestProject.tmpdir("ttsc-lock-fence-");
+  const lockDir = path.join(root, "entry.lock");
+  const binaryPath = path.join(root, "entry", "plugin.exe");
+  const libraryPath = sourceBuildLibraryPath();
+  const seedFile = path.join(root, "seed.json");
+  const releaseFile = path.join(root, "release");
+  const buildLog = path.join(root, "build.log");
+  const seedScript = path.join(root, "seed.cjs");
+  const observerScript = path.join(root, "observer.cjs");
+
+  fs.writeFileSync(
+    seedScript,
+    [
+      `const fs = require("node:fs");`,
+      `const { acquirePluginBuildLock } = require(${JSON.stringify(libraryPath)});`,
+      `const lease = acquirePluginBuildLock(${JSON.stringify(lockDir)});`,
+      `if (!lease) throw new Error("seed failed to acquire lock");`,
+      `fs.writeFileSync(${JSON.stringify(seedFile)}, JSON.stringify(lease), "utf8");`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  const seeded = await spawnNodeWorker({ script: seedScript });
+  assert.equal(seeded.status, 0, seeded.stderr);
+  const seed = JSON.parse(fs.readFileSync(seedFile, "utf8")) as {
+    generation: string;
+    protocol: "v2";
+  };
+
+  fs.writeFileSync(
+    observerScript,
+    [
+      `const fs = require("node:fs");`,
+      `const path = require("node:path");`,
+      `const { acquirePluginBuildLock, inspectPluginBuildLock, reclaimPluginBuildLock, releasePluginBuildLock } = require(${JSON.stringify(libraryPath)});`,
+      `const lockDir = ${JSON.stringify(lockDir)};`,
+      `const binaryPath = ${JSON.stringify(binaryPath)};`,
+      `const releaseFile = ${JSON.stringify(releaseFile)};`,
+      `const buildLog = ${JSON.stringify(buildLog)};`,
+      `const id = process.env.LOCK_WORKER_ID;`,
+      `const readyFile = process.env.LOCK_WORKER_READY;`,
+      `const observation = inspectPluginBuildLock(lockDir, Date.now());`,
+      `if (observation.state !== "abandoned") throw new Error("expected abandoned lock, got " + observation.state);`,
+      `fs.writeFileSync(readyFile, JSON.stringify(observation.fence), "utf8");`,
+      `waitFor(() => fs.existsSync(releaseFile), "observer release");`,
+      `const reclaimed = reclaimPluginBuildLock(lockDir, observation.fence);`,
+      `let built = false;`,
+      `let generation = null;`,
+      `const deadline = Date.now() + 120000;`,
+      `for (;;) {`,
+      `  if (fs.existsSync(binaryPath)) break;`,
+      `  const lease = acquirePluginBuildLock(lockDir);`,
+      `  if (lease) {`,
+      `    generation = lease.generation;`,
+      `    try {`,
+      `      if (!fs.existsSync(binaryPath)) {`,
+      `        built = true;`,
+      `        fs.appendFileSync(buildLog, id + "\\n", "utf8");`,
+      `        fs.mkdirSync(path.dirname(binaryPath), { recursive: true });`,
+      `        const temporary = binaryPath + "." + id + ".tmp";`,
+      `        fs.writeFileSync(temporary, "plugin\\n", "utf8");`,
+      `        fs.renameSync(temporary, binaryPath);`,
+      `      }`,
+      `    } finally {`,
+      `      releasePluginBuildLock(lockDir, lease);`,
+      `    }`,
+      `    break;`,
+      `  }`,
+      `  if (Date.now() > deadline) throw new Error("timed out acquiring successor");`,
+      `  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);`,
+      `}`,
+      `process.stdout.write(JSON.stringify({ built, generation, reclaimed }) + "\\n");`,
+      `function waitFor(predicate, label) {`,
+      `  const deadline = Date.now() + 120000;`,
+      `  while (!predicate()) {`,
+      `    if (Date.now() > deadline) throw new Error("timed out waiting for " + label);`,
+      `    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);`,
+      `  }`,
+      `}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const readyA = path.join(root, "ready-a.json");
+  const readyB = path.join(root, "ready-b.json");
+  const workerA = spawnNodeWorker({
+    env: { LOCK_WORKER_ID: "a", LOCK_WORKER_READY: readyA },
+    script: observerScript,
+  });
+  const workerB = spawnNodeWorker({
+    env: { LOCK_WORKER_ID: "b", LOCK_WORKER_READY: readyB },
+    script: observerScript,
+  });
+  await waitForCondition(
+    () => fs.existsSync(readyA) && fs.existsSync(readyB),
+    "both stale observers",
+  );
+  assert.deepEqual(JSON.parse(fs.readFileSync(readyA, "utf8")), seed);
+  assert.deepEqual(JSON.parse(fs.readFileSync(readyB, "utf8")), seed);
+
+  fs.writeFileSync(releaseFile, "release\n", "utf8");
+  const results = await Promise.all([workerA, workerB]);
+  for (const result of results) {
+    assert.equal(result.status, 0, result.stderr);
+  }
+  const reports = results.map(
+    (result) =>
+      JSON.parse(result.stdout) as {
+        built: boolean;
+        generation: string | null;
+        reclaimed: boolean;
+      },
+  );
+  assert.equal(reports.filter((report) => report.reclaimed).length, 1);
+  assert.equal(reports.filter((report) => report.built).length, 1);
+  assert.equal(
+    fs.readFileSync(buildLog, "utf8").trim().split(/\r?\n/).length,
+    1,
+  );
+  assert.equal(fs.readFileSync(binaryPath, "utf8"), "plugin\n");
+  assert.deepEqual(inspectPluginBuildLock(lockDir, Date.now()), {
+    state: "released",
+  });
+  assert.equal(
+    fs.existsSync(path.join(lockDir, "retired", seed.generation)),
+    true,
+  );
+  const successor = reports.find((report) => report.built)?.generation;
+  assert.equal(typeof successor, "string");
+  assert.equal(
+    fs.existsSync(path.join(lockDir, "retired", successor!)),
+    true,
+  );
+};

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_pluginbuildlock_fences_two_stale_observers.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_pluginbuildlock_fences_two_stale_observers.ts
@@ -14,13 +14,13 @@ import {
  * Verifies two stale observers cannot both replace one abandoned generation.
  *
  * Both real child processes capture the same dead owner's fence before either
- * may reclaim it. After a shared barrier opens, exactly one retirement wins,
- * exactly one successor acquires and publishes, and the other process reuses
- * that result.
+ * may reclaim it. Observer A first acquires a successor and stops inside its
+ * build. Only then may stale observer B act, so B must leave that visible
+ * successor intact and eventually reuse its binary.
  *
  * 1. Let a short-lived child acquire a v2 lock and exit without releasing it.
  * 2. Hold two observers at a barrier after both report that generation dead.
- * 3. Release them together and assert one reclaim, one build, and one binary.
+ * 3. Hold A's successor, release stale B, then assert one build and one binary.
  */
 export const test_pluginbuildlock_fences_two_stale_observers = async () => {
   const root = TestProject.tmpdir("ttsc-lock-fence-");
@@ -28,7 +28,7 @@ export const test_pluginbuildlock_fences_two_stale_observers = async () => {
   const binaryPath = path.join(root, "entry", "plugin.exe");
   const libraryPath = sourceBuildLibraryPath();
   const seedFile = path.join(root, "seed.json");
-  const releaseFile = path.join(root, "release");
+  const buildReleaseFile = path.join(root, "build-release");
   const buildLog = path.join(root, "build.log");
   const seedScript = path.join(root, "seed.cjs");
   const observerScript = path.join(root, "observer.cjs");
@@ -60,15 +60,19 @@ export const test_pluginbuildlock_fences_two_stale_observers = async () => {
       `const { acquirePluginBuildLock, inspectPluginBuildLock, reclaimPluginBuildLock, releasePluginBuildLock } = require(${JSON.stringify(libraryPath)});`,
       `const lockDir = ${JSON.stringify(lockDir)};`,
       `const binaryPath = ${JSON.stringify(binaryPath)};`,
-      `const releaseFile = ${JSON.stringify(releaseFile)};`,
       `const buildLog = ${JSON.stringify(buildLog)};`,
       `const id = process.env.LOCK_WORKER_ID;`,
       `const readyFile = process.env.LOCK_WORKER_READY;`,
+      `const observerReleaseFile = process.env.LOCK_WORKER_RELEASE;`,
+      `const reclaimResultFile = process.env.LOCK_WORKER_RECLAIMED;`,
+      `const buildingFile = process.env.LOCK_WORKER_BUILDING;`,
+      `const buildReleaseFile = ${JSON.stringify(buildReleaseFile)};`,
       `const observation = inspectPluginBuildLock(lockDir, Date.now());`,
       `if (observation.state !== "abandoned") throw new Error("expected abandoned lock, got " + observation.state);`,
       `fs.writeFileSync(readyFile, JSON.stringify(observation.fence), "utf8");`,
-      `waitFor(() => fs.existsSync(releaseFile), "observer release");`,
+      `waitFor(() => fs.existsSync(observerReleaseFile), "observer release");`,
       `const reclaimed = reclaimPluginBuildLock(lockDir, observation.fence);`,
+      `fs.writeFileSync(reclaimResultFile, JSON.stringify({ reclaimed }), "utf8");`,
       `let built = false;`,
       `let generation = null;`,
       `const deadline = Date.now() + 120000;`,
@@ -80,6 +84,8 @@ export const test_pluginbuildlock_fences_two_stale_observers = async () => {
       `    try {`,
       `      if (!fs.existsSync(binaryPath)) {`,
       `        built = true;`,
+      `        fs.writeFileSync(buildingFile, JSON.stringify(lease), "utf8");`,
+      `        waitFor(() => fs.existsSync(buildReleaseFile), "build release");`,
       `        fs.appendFileSync(buildLog, id + "\\n", "utf8");`,
       `        fs.mkdirSync(path.dirname(binaryPath), { recursive: true });`,
       `        const temporary = binaryPath + "." + id + ".tmp";`,
@@ -109,12 +115,30 @@ export const test_pluginbuildlock_fences_two_stale_observers = async () => {
 
   const readyA = path.join(root, "ready-a.json");
   const readyB = path.join(root, "ready-b.json");
+  const releaseA = path.join(root, "release-a");
+  const releaseB = path.join(root, "release-b");
+  const reclaimedA = path.join(root, "reclaimed-a.json");
+  const reclaimedB = path.join(root, "reclaimed-b.json");
+  const buildingA = path.join(root, "building-a.json");
+  const buildingB = path.join(root, "building-b.json");
   const workerA = spawnNodeWorker({
-    env: { LOCK_WORKER_ID: "a", LOCK_WORKER_READY: readyA },
+    env: {
+      LOCK_WORKER_BUILDING: buildingA,
+      LOCK_WORKER_ID: "a",
+      LOCK_WORKER_READY: readyA,
+      LOCK_WORKER_RECLAIMED: reclaimedA,
+      LOCK_WORKER_RELEASE: releaseA,
+    },
     script: observerScript,
   });
   const workerB = spawnNodeWorker({
-    env: { LOCK_WORKER_ID: "b", LOCK_WORKER_READY: readyB },
+    env: {
+      LOCK_WORKER_BUILDING: buildingB,
+      LOCK_WORKER_ID: "b",
+      LOCK_WORKER_READY: readyB,
+      LOCK_WORKER_RECLAIMED: reclaimedB,
+      LOCK_WORKER_RELEASE: releaseB,
+    },
     script: observerScript,
   });
   await waitForCondition(
@@ -124,7 +148,22 @@ export const test_pluginbuildlock_fences_two_stale_observers = async () => {
   assert.deepEqual(JSON.parse(fs.readFileSync(readyA, "utf8")), seed);
   assert.deepEqual(JSON.parse(fs.readFileSync(readyB, "utf8")), seed);
 
-  fs.writeFileSync(releaseFile, "release\n", "utf8");
+  fs.writeFileSync(releaseA, "release\n", "utf8");
+  await waitForCondition(
+    () => fs.existsSync(reclaimedA) && fs.existsSync(buildingA),
+    "observer A to hold the successor generation",
+  );
+  const successorLease = JSON.parse(
+    fs.readFileSync(buildingA, "utf8"),
+  ) as { generation: string; protocol: "v2" };
+
+  fs.writeFileSync(releaseB, "release\n", "utf8");
+  await waitForCondition(
+    () => fs.existsSync(reclaimedB),
+    "stale observer B to attempt retirement",
+  );
+  const afterStaleReclaim = inspectPluginBuildLock(lockDir, Date.now());
+  fs.writeFileSync(buildReleaseFile, "release\n", "utf8");
   const results = await Promise.all([workerA, workerB]);
   for (const result of results) {
     assert.equal(result.status, 0, result.stderr);
@@ -136,6 +175,18 @@ export const test_pluginbuildlock_fences_two_stale_observers = async () => {
         generation: string | null;
         reclaimed: boolean;
       },
+  );
+  assert.deepEqual(JSON.parse(fs.readFileSync(reclaimedA, "utf8")), {
+    reclaimed: true,
+  });
+  assert.deepEqual(JSON.parse(fs.readFileSync(reclaimedB, "utf8")), {
+    reclaimed: false,
+  });
+  assert.equal(fs.existsSync(buildingB), false);
+  assert.equal(afterStaleReclaim.state, "active");
+  assert.deepEqual(
+    afterStaleReclaim.state === "active" ? afterStaleReclaim.fence : null,
+    successorLease,
   );
   assert.equal(reports.filter((report) => report.reclaimed).length, 1);
   assert.equal(reports.filter((report) => report.built).length, 1);
@@ -151,10 +202,8 @@ export const test_pluginbuildlock_fences_two_stale_observers = async () => {
     fs.existsSync(path.join(lockDir, "retired", seed.generation)),
     true,
   );
-  const successor = reports.find((report) => report.built)?.generation;
-  assert.equal(typeof successor, "string");
   assert.equal(
-    fs.existsSync(path.join(lockDir, "retired", successor!)),
+    fs.existsSync(path.join(lockDir, "retired", successorLease.generation)),
     true,
   );
 };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_pluginbuildlock_legacy_observer_preserves_v2_successor.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_pluginbuildlock_legacy_observer_preserves_v2_successor.ts
@@ -1,0 +1,153 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  inspectPluginBuildLock,
+  path,
+  reclaimPluginBuildLock,
+  sourceBuildLibraryPath,
+  spawnNodeWorker,
+  waitForCondition,
+} from "../../internal/source-build";
+
+/**
+ * Verifies a stale legacy observer cannot retire a v2 successor.
+ *
+ * A legacy holder may normally remove the whole legacy lock path after another
+ * process captured its fence. The successor must live in an ownership namespace
+ * that this delayed legacy reclaim can never rename, even though the observer's
+ * deterministic retirement destination has not previously been populated.
+ *
+ * 1. Observe a live legacy holder, then let it remove its lock normally.
+ * 2. Hold a v2 successor in a second child process.
+ * 3. Apply the stale legacy fence and assert the successor remains current.
+ */
+export const test_pluginbuildlock_legacy_observer_preserves_v2_successor =
+  async () => {
+    const root = TestProject.tmpdir("ttsc-lock-legacy-successor-");
+    const lockDir = path.join(root, "entry.lock");
+    const libraryPath = sourceBuildLibraryPath();
+    const legacyReady = path.join(root, "legacy-ready");
+    const legacyRelease = path.join(root, "legacy-release");
+    const legacyReleased = path.join(root, "legacy-released");
+    const successorLeaseFile = path.join(root, "successor-lease.json");
+    const successorRelease = path.join(root, "successor-release");
+    const successorResult = path.join(root, "successor-result.json");
+    const workerScript = path.join(root, "legacy-successor-worker.cjs");
+
+    fs.writeFileSync(
+      workerScript,
+      [
+        `const fs = require("node:fs");`,
+        `const os = require("node:os");`,
+        `const path = require("node:path");`,
+        `const { acquirePluginBuildLock, releasePluginBuildLock } = require(${JSON.stringify(libraryPath)});`,
+        `const lockDir = ${JSON.stringify(lockDir)};`,
+        `const mode = process.env.LOCK_WORKER_MODE;`,
+        `if (mode === "legacy") {`,
+        `  fs.mkdirSync(lockDir);`,
+        `  fs.writeFileSync(path.join(lockDir, "owner.json"), JSON.stringify({ hostname: os.hostname(), pid: process.pid, startedAt: new Date().toISOString() }), "utf8");`,
+        `  fs.writeFileSync(process.env.LOCK_WORKER_READY, "ready\\n", "utf8");`,
+        `  waitFor(() => fs.existsSync(process.env.LOCK_WORKER_RELEASE), "legacy release");`,
+        `  fs.rmSync(lockDir, { force: true, recursive: true });`,
+        `  fs.writeFileSync(process.env.LOCK_WORKER_RESULT, "released\\n", "utf8");`,
+        `} else if (mode === "successor") {`,
+        `  let lease = null;`,
+        `  const deadline = Date.now() + 120000;`,
+        `  while (lease === null) {`,
+        `    lease = acquirePluginBuildLock(lockDir);`,
+        `    if (Date.now() > deadline) throw new Error("timed out acquiring successor");`,
+        `    if (lease === null) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);`,
+        `  }`,
+        `  fs.writeFileSync(process.env.LOCK_WORKER_READY, JSON.stringify(lease), "utf8");`,
+        `  waitFor(() => fs.existsSync(process.env.LOCK_WORKER_RELEASE), "successor release");`,
+        `  const released = releasePluginBuildLock(lockDir, lease);`,
+        `  fs.writeFileSync(process.env.LOCK_WORKER_RESULT, JSON.stringify({ released }), "utf8");`,
+        `} else {`,
+        `  throw new Error("unknown worker mode: " + mode);`,
+        `}`,
+        `function waitFor(predicate, label) {`,
+        `  const deadline = Date.now() + 120000;`,
+        `  while (!predicate()) {`,
+        `    if (Date.now() > deadline) throw new Error("timed out waiting for " + label);`,
+        `    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);`,
+        `  }`,
+        `}`,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const legacyHolder = spawnNodeWorker({
+      env: {
+        LOCK_WORKER_MODE: "legacy",
+        LOCK_WORKER_READY: legacyReady,
+        LOCK_WORKER_RELEASE: legacyRelease,
+        LOCK_WORKER_RESULT: legacyReleased,
+      },
+      script: workerScript,
+    });
+    await waitForCondition(
+      () => fs.existsSync(legacyReady),
+      "legacy holder acquisition",
+    );
+    const observation = inspectPluginBuildLock(lockDir, Date.now());
+    if (observation.state !== "active") {
+      fs.writeFileSync(legacyRelease, "release\n", "utf8");
+      await legacyHolder;
+      assert.fail(`expected active legacy holder, got ${observation.state}`);
+    }
+    assert.equal(observation.fence.protocol, "legacy");
+
+    fs.writeFileSync(legacyRelease, "release\n", "utf8");
+    await waitForCondition(
+      () => fs.existsSync(legacyReleased),
+      "legacy holder normal release",
+    );
+    const legacyResult = await legacyHolder;
+    assert.equal(legacyResult.status, 0, legacyResult.stderr);
+
+    const successor = spawnNodeWorker({
+      env: {
+        LOCK_WORKER_MODE: "successor",
+        LOCK_WORKER_READY: successorLeaseFile,
+        LOCK_WORKER_RELEASE: successorRelease,
+        LOCK_WORKER_RESULT: successorResult,
+      },
+      script: workerScript,
+    });
+    await waitForCondition(
+      () => fs.existsSync(successorLeaseFile),
+      "v2 successor acquisition",
+    );
+    const successorLease = JSON.parse(
+      fs.readFileSync(successorLeaseFile, "utf8"),
+    ) as { generation: string; protocol: "v2" };
+
+    let reclaimed: boolean;
+    let afterStaleReclaim: ReturnType<typeof inspectPluginBuildLock>;
+    try {
+      reclaimed = reclaimPluginBuildLock(lockDir, observation.fence);
+      afterStaleReclaim = inspectPluginBuildLock(lockDir, Date.now());
+    } finally {
+      fs.writeFileSync(successorRelease, "release\n", "utf8");
+    }
+    const successorWorker = await successor;
+    assert.equal(successorWorker.status, 0, successorWorker.stderr);
+
+    assert.equal(reclaimed, false);
+    assert.equal(afterStaleReclaim.state, "active");
+    assert.deepEqual(
+      afterStaleReclaim.state === "active"
+        ? afterStaleReclaim.fence
+        : null,
+      successorLease,
+    );
+    assert.deepEqual(JSON.parse(fs.readFileSync(successorResult, "utf8")), {
+      released: true,
+    });
+    assert.deepEqual(inspectPluginBuildLock(lockDir, Date.now()), {
+      state: "released",
+    });
+  };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_pluginbuildlock_old_finalizer_preserves_successor.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_pluginbuildlock_old_finalizer_preserves_successor.ts
@@ -133,11 +133,13 @@ export const test_pluginbuildlock_old_finalizer_preserves_successor =
       state: "released",
     });
     assert.equal(
-      fs.existsSync(path.join(lockDir, "retired", oldLease.generation)),
+      fs.existsSync(path.join(`${lockDir}.v2`, "retired", oldLease.generation)),
       true,
     );
     assert.equal(
-      fs.existsSync(path.join(lockDir, "retired", successorLease.generation)),
+      fs.existsSync(
+        path.join(`${lockDir}.v2`, "retired", successorLease.generation),
+      ),
       true,
     );
   };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_pluginbuildlock_old_finalizer_preserves_successor.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_pluginbuildlock_old_finalizer_preserves_successor.ts
@@ -1,0 +1,143 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  inspectPluginBuildLock,
+  path,
+  reclaimPluginBuildLock,
+  sourceBuildLibraryPath,
+  spawnNodeWorker,
+  waitForCondition,
+} from "../../internal/source-build";
+
+/**
+ * Verifies an old holder's delayed finalizer cannot release its successor.
+ *
+ * A first child keeps generation A alive while the parent retires A and lets a
+ * second child acquire B. Only after B is visibly current may A run its normal
+ * `finally`; A's deterministic tombstone already exists, so its rename fails
+ * without touching B.
+ *
+ * 1. Hold generation A in a child and reclaim it from the parent.
+ * 2. Let a second child acquire B, then release A's delayed finalizer.
+ * 3. Assert A reports loss, B remains current, and B later releases normally.
+ */
+export const test_pluginbuildlock_old_finalizer_preserves_successor =
+  async () => {
+    const root = TestProject.tmpdir("ttsc-lock-finalizer-");
+    const lockDir = path.join(root, "entry.lock");
+    const libraryPath = sourceBuildLibraryPath();
+    const oldLeaseFile = path.join(root, "old-lease.json");
+    const oldFinalizeFile = path.join(root, "old-finalize");
+    const oldResultFile = path.join(root, "old-result.json");
+    const successorLeaseFile = path.join(root, "successor-lease.json");
+    const successorReleaseFile = path.join(root, "successor-release");
+    const successorResultFile = path.join(root, "successor-result.json");
+    const workerScript = path.join(root, "holder.cjs");
+
+    fs.writeFileSync(
+      workerScript,
+      [
+        `const fs = require("node:fs");`,
+        `const { acquirePluginBuildLock, releasePluginBuildLock } = require(${JSON.stringify(libraryPath)});`,
+        `const lockDir = ${JSON.stringify(lockDir)};`,
+        `const leaseFile = process.env.LOCK_LEASE_FILE;`,
+        `const releaseFile = process.env.LOCK_RELEASE_FILE;`,
+        `const resultFile = process.env.LOCK_RESULT_FILE;`,
+        `let lease = null;`,
+        `const acquireDeadline = Date.now() + 120000;`,
+        `while (lease === null) {`,
+        `  lease = acquirePluginBuildLock(lockDir);`,
+        `  if (Date.now() > acquireDeadline) throw new Error("timed out acquiring lock");`,
+        `  if (lease === null) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);`,
+        `}`,
+        `fs.writeFileSync(leaseFile, JSON.stringify(lease), "utf8");`,
+        `const releaseDeadline = Date.now() + 120000;`,
+        `while (!fs.existsSync(releaseFile)) {`,
+        `  if (Date.now() > releaseDeadline) throw new Error("timed out waiting to release");`,
+        `  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);`,
+        `}`,
+        `const released = releasePluginBuildLock(lockDir, lease);`,
+        `fs.writeFileSync(resultFile, JSON.stringify({ released }), "utf8");`,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const oldHolder = spawnNodeWorker({
+      env: {
+        LOCK_LEASE_FILE: oldLeaseFile,
+        LOCK_RELEASE_FILE: oldFinalizeFile,
+        LOCK_RESULT_FILE: oldResultFile,
+      },
+      script: workerScript,
+    });
+    await waitForCondition(
+      () => fs.existsSync(oldLeaseFile),
+      "old holder acquisition",
+    );
+    const oldLease = JSON.parse(fs.readFileSync(oldLeaseFile, "utf8")) as {
+      generation: string;
+      protocol: "v2";
+    };
+    assert.equal(
+      reclaimPluginBuildLock(lockDir, oldLease),
+      true,
+      "the parent should retire generation A",
+    );
+
+    const successor = spawnNodeWorker({
+      env: {
+        LOCK_LEASE_FILE: successorLeaseFile,
+        LOCK_RELEASE_FILE: successorReleaseFile,
+        LOCK_RESULT_FILE: successorResultFile,
+      },
+      script: workerScript,
+    });
+    await waitForCondition(
+      () => fs.existsSync(successorLeaseFile),
+      "successor acquisition",
+    );
+    const successorLease = JSON.parse(
+      fs.readFileSync(successorLeaseFile, "utf8"),
+    ) as { generation: string; protocol: "v2" };
+
+    fs.writeFileSync(oldFinalizeFile, "release\n", "utf8");
+    await waitForCondition(
+      () => fs.existsSync(oldResultFile),
+      "old finalizer result",
+    );
+    const oldResult = await oldHolder;
+    assert.equal(oldResult.status, 0, oldResult.stderr);
+    assert.deepEqual(JSON.parse(fs.readFileSync(oldResultFile, "utf8")), {
+      released: false,
+    });
+    const whileSuccessorHeld = inspectPluginBuildLock(lockDir, Date.now());
+    assert.equal(whileSuccessorHeld.state, "active");
+    assert.deepEqual(
+      whileSuccessorHeld.state === "active"
+        ? whileSuccessorHeld.fence
+        : null,
+      successorLease,
+    );
+
+    fs.writeFileSync(successorReleaseFile, "release\n", "utf8");
+    const successorResult = await successor;
+    assert.equal(successorResult.status, 0, successorResult.stderr);
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(successorResultFile, "utf8")),
+      { released: true },
+    );
+    assert.deepEqual(inspectPluginBuildLock(lockDir, Date.now()), {
+      state: "released",
+    });
+    assert.equal(
+      fs.existsSync(path.join(lockDir, "retired", oldLease.generation)),
+      true,
+    );
+    assert.equal(
+      fs.existsSync(path.join(lockDir, "retired", successorLease.generation)),
+      true,
+    );
+  };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_resolveplugincacheroot_prunes_stale_cache_entries.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_resolveplugincacheroot_prunes_stale_cache_entries.ts
@@ -41,10 +41,12 @@ export const test_resolveplugincacheroot_prunes_stale_cache_entries = () => {
     const stale = path.join(pluginCache, "stale");
     const fresh = path.join(pluginCache, "fresh");
     const lock = path.join(pluginCache, "stale.lock");
+    const v2Lock = path.join(pluginCache, "stale.lock.v2");
     const retiredLegacy = path.join(pluginCache, "stale.lock.retired-deadbeef");
     fs.mkdirSync(stale, { recursive: true });
     fs.mkdirSync(fresh, { recursive: true });
     fs.mkdirSync(lock, { recursive: true });
+    fs.mkdirSync(v2Lock, { recursive: true });
     fs.mkdirSync(retiredLegacy, { recursive: true });
     fs.writeFileSync(path.join(stale, "plugin"), "stale\n", "utf8");
     fs.writeFileSync(path.join(fresh, "plugin"), "fresh\n", "utf8");
@@ -60,6 +62,7 @@ export const test_resolveplugincacheroot_prunes_stale_cache_entries = () => {
     assert.equal(fs.existsSync(stale), false);
     assert.equal(fs.existsSync(fresh), true);
     assert.equal(fs.existsSync(lock), true);
+    assert.equal(fs.existsSync(v2Lock), true);
     assert.equal(fs.existsSync(retiredLegacy), true);
   } finally {
     if (saved.cache === undefined) delete process.env.TTSC_CACHE_DIR;

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_resolveplugincacheroot_prunes_stale_cache_entries.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_resolveplugincacheroot_prunes_stale_cache_entries.ts
@@ -16,9 +16,9 @@ import {
  * last-used metadata is older than the 30-day retention window. Scoped to the
  * project cache root only — never a shared/global location.
  *
- * 1. Seed one stale and one fresh entry under the workspace-local plugin cache.
+ * 1. Seed stale/fresh entries plus generation-fencing lock artifacts.
  * 2. Resolve the default plugin cache root (no cacheDir/TTSC_CACHE_DIR override).
- * 3. Assert only the stale entry is removed and the fresh one is kept.
+ * 3. Assert the stale entry is removed while fresh data and fences remain.
  */
 export const test_resolveplugincacheroot_prunes_stale_cache_entries = () => {
   const root = TestProject.tmpdir("ttsc-cache-gc-");
@@ -40,8 +40,12 @@ export const test_resolveplugincacheroot_prunes_stale_cache_entries = () => {
     );
     const stale = path.join(pluginCache, "stale");
     const fresh = path.join(pluginCache, "fresh");
+    const lock = path.join(pluginCache, "stale.lock");
+    const retiredLegacy = path.join(pluginCache, "stale.lock.retired-deadbeef");
     fs.mkdirSync(stale, { recursive: true });
     fs.mkdirSync(fresh, { recursive: true });
+    fs.mkdirSync(lock, { recursive: true });
+    fs.mkdirSync(retiredLegacy, { recursive: true });
     fs.writeFileSync(path.join(stale, "plugin"), "stale\n", "utf8");
     fs.writeFileSync(path.join(fresh, "plugin"), "fresh\n", "utf8");
     const now = Date.now();
@@ -55,6 +59,8 @@ export const test_resolveplugincacheroot_prunes_stale_cache_entries = () => {
     assert.equal(resolvePluginCacheRoot(root), pluginCache);
     assert.equal(fs.existsSync(stale), false);
     assert.equal(fs.existsSync(fresh), true);
+    assert.equal(fs.existsSync(lock), true);
+    assert.equal(fs.existsSync(retiredLegacy), true);
   } finally {
     if (saved.cache === undefined) delete process.env.TTSC_CACHE_DIR;
     else process.env.TTSC_CACHE_DIR = saved.cache;

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_ttsc_reclaims_stale_legacy_source_plugin_lock_e2e.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_ttsc_reclaims_stale_legacy_source_plugin_lock_e2e.ts
@@ -41,6 +41,7 @@ export const test_ttsc_reclaims_stale_legacy_source_plugin_lock_e2e = () => {
     const lockDir = `${path.dirname(binary)}.lock`;
     fs.rmSync(binary, { force: true });
     fs.rmSync(lockDir, { force: true, recursive: true });
+    fs.rmSync(`${lockDir}.v2`, { force: true, recursive: true });
     fs.mkdirSync(lockDir, { recursive: true });
     const old = new Date(Date.now() - 120_000);
     fs.utimesSync(lockDir, old, old);

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_ttsc_reclaims_stale_legacy_source_plugin_lock_e2e.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_ttsc_reclaims_stale_legacy_source_plugin_lock_e2e.ts
@@ -40,6 +40,7 @@ export const test_ttsc_reclaims_stale_legacy_source_plugin_lock_e2e = () => {
     });
     const lockDir = `${path.dirname(binary)}.lock`;
     fs.rmSync(binary, { force: true });
+    fs.rmSync(lockDir, { force: true, recursive: true });
     fs.mkdirSync(lockDir, { recursive: true });
     const old = new Date(Date.now() - 120_000);
     fs.utimesSync(lockDir, old, old);

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_waitforpluginbinary_times_out_on_live_owner_with_finite_duration.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_waitforpluginbinary_times_out_on_live_owner_with_finite_duration.ts
@@ -1,10 +1,10 @@
 import { TestProject } from "@ttsc/testing";
 
 import {
+  acquirePluginBuildLock,
   assert,
-  fs,
-  os,
   path,
+  releasePluginBuildLock,
   waitForPluginBinary,
 } from "../../internal/source-build";
 
@@ -18,7 +18,7 @@ import {
  * the release/abandon distinction may never disable the bound, or a wedged
  * holder would hang every waiter forever.
  *
- * 1. Create a lock owned by this (live) process so inspection stays `active`.
+ * 1. Acquire a v2 lock owned by this process so inspection stays `active`.
  * 2. Call the wait loop with a zero timeout budget.
  * 3. Assert it returns `abandoned` with a `timed out after <finite>` reason
  *    containing no `Infinity`/`NaN` token.
@@ -27,32 +27,33 @@ export const test_waitforpluginbinary_times_out_on_live_owner_with_finite_durati
   () => {
     const root = TestProject.tmpdir("ttsc-lock-wait-");
     const lockDir = path.join(root, "entry.lock");
-    fs.mkdirSync(lockDir);
-    fs.writeFileSync(
-      path.join(lockDir, "owner.json"),
-      `${JSON.stringify({
-        hostname: os.hostname(),
-        pid: process.pid,
-        startedAt: new Date().toISOString(),
-      })}\n`,
-      "utf8",
-    );
+    const lease = acquirePluginBuildLock(lockDir);
+    assert.notEqual(lease, null);
+    if (lease === null) return;
 
-    const result = waitForPluginBinary({
-      binaryPath: path.join(root, "entry", "plugin.exe"),
-      lockDir,
-      lockInfo: {
-        label: "source plugin",
-        pluginName: "wait-test",
-        quiet: true,
-      },
-      timeoutMs: 0,
-    });
+    try {
+      const result = waitForPluginBinary({
+        binaryPath: path.join(root, "entry", "plugin.exe"),
+        lockDir,
+        lockInfo: {
+          label: "source plugin",
+          pluginName: "wait-test",
+          quiet: true,
+        },
+        timeoutMs: 0,
+      });
 
-    assert.equal(result.outcome, "abandoned");
-    const reason = result.outcome === "abandoned" ? result.reason : "";
-    // The elapsed poll normally reads ~50ms, but a loaded CI runner can stall
-    // past the 1s/1m formatting boundaries, so accept any finite rendering.
-    assert.match(reason, /^timed out after (\d+ms|\d+s|\d+m \d+s)$/);
-    assert.doesNotMatch(reason, /Infinity|NaN/);
+      assert.equal(result.outcome, "abandoned");
+      if (result.outcome !== "abandoned") return;
+      // The elapsed poll normally reads ~50ms, but a loaded CI runner can stall
+      // past the 1s/1m formatting boundaries, so accept any finite rendering.
+      assert.match(
+        result.reason,
+        /^timed out after (\d+ms|\d+s|\d+m \d+s)$/,
+      );
+      assert.doesNotMatch(result.reason, /Infinity|NaN/);
+      assert.deepEqual(result.fence, lease);
+    } finally {
+      releasePluginBuildLock(lockDir, lease);
+    }
   };

--- a/website/src/content/docs/development/reference/architecture.mdx
+++ b/website/src/content/docs/development/reference/architecture.mdx
@@ -146,19 +146,21 @@ Check:
 
 ## Concurrency
 
-Concurrent `ttsc` processes serialize a cold build per cache key. The
-`<key>.lock` coordination directory publishes a uniquely generated, non-empty
-`current` directory with an atomic rename. Waiters reuse the published binary;
-when an owner dies or times out, one waiter atomically retires that exact
-generation before acquiring its successor.
+Concurrent `ttsc` processes serialize a cold build per cache key. The persistent
+`<key>.lock.v2` coordination directory publishes a uniquely generated,
+non-empty `current` directory with an atomic rename. Waiters reuse the published
+binary; when an owner dies or times out, one waiter atomically retires that
+exact generation before acquiring its successor.
 
 Retired generations remain as non-empty tombstones inside the lock directory.
 Both reclaim and normal release rename `current` to the generation's fixed
 tombstone path, so a delayed observer or old holder cannot remove a newer
 generation: its destination already exists and a directory rename cannot
-replace it. Legacy pre-generation locks are fenced and retired to an adjacent
-tombstone before the v2 directory is initialized. Scratch directories remain
-unique and binary publication remains atomic as defense in depth.
+replace it. The adjacent `<key>.lock` path is reserved exclusively for legacy
+pre-generation holders. It is fenced and retired before v2 acquisition, but is
+never reused for v2 ownership, so a delayed legacy release or reclaim cannot
+delete a v2 successor. Scratch directories remain unique and binary publication
+remains atomic as defense in depth.
 
 ## See also
 

--- a/website/src/content/docs/development/reference/architecture.mdx
+++ b/website/src/content/docs/development/reference/architecture.mdx
@@ -146,7 +146,19 @@ Check:
 
 ## Concurrency
 
-Concurrent `ttsc` processes may build the same missing key at the same time. Scratch directories are unique, and the final move is atomic. This is wasteful but safe.
+Concurrent `ttsc` processes serialize a cold build per cache key. The
+`<key>.lock` coordination directory publishes a uniquely generated, non-empty
+`current` directory with an atomic rename. Waiters reuse the published binary;
+when an owner dies or times out, one waiter atomically retires that exact
+generation before acquiring its successor.
+
+Retired generations remain as non-empty tombstones inside the lock directory.
+Both reclaim and normal release rename `current` to the generation's fixed
+tombstone path, so a delayed observer or old holder cannot remove a newer
+generation: its destination already exists and a directory rename cannot
+replace it. Legacy pre-generation locks are fenced and retired to an adjacent
+tombstone before the v2 directory is initialized. Scratch directories remain
+unique and binary publication remains atomic as defense in depth.
 
 ## See also
 


### PR DESCRIPTION
## Intent

Prevent stale source-plugin lock observers, delayed holder finalizers, and legacy pathname cleanup from deleting a successor generation.

## Scope

- keep legacy `<key>.lock` separate from persistent v2 ownership at `<key>.lock.v2`
- atomically publish the complete v2 coordination root and each non-empty current generation
- retire releases and abandoned generations to deterministic non-empty tombstones
- revalidate legacy fences before retiring the legacy path
- report abandonment only after successful fenced retirement
- preserve every lock artifact during opportunistic cache GC
- add barrier-driven multi-process regressions for stale v2 observers, old v2 finalizers, and a stale legacy observer acting on a held v2 successor
- document the generation-fencing and legacy-migration protocol

## Verification

- three exhaustive full-change reviews completed after the final structural fix
- `pnpm --filter ttsc build`
- 18 targeted source-plugin lock, handoff, timeout, legacy, GC, and real CLI E2E tests
- real concurrent cold-cache two-process corpus test

Closes #452
