### PR TITLE
fix(lint): run type-aware fixer snapshots with a checker

### DIFF
--- a/packages/lint/test/fix/fix_snapshot_harness_keeps_ast_only_rule_on_parser_path_test.go
+++ b/packages/lint/test/fix/fix_snapshot_harness_keeps_ast_only_rule_on_parser_path_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestFixSnapshotHarnessKeepsASTOnlyRuleOnParserPath verifies untyped snapshots stay lightweight.
+//
+// The shared lifecycle selector must not make every fixer pay for a TypeScript
+// Program merely because typed rules use one. A TSX filename still needs the
+// JSX parser, but the AST-only no-var rewrite must not advance Program state.
+//
+// 1. Record the Program lifecycle sequence and materialize a TSX no-var case.
+// 2. Apply the AST-only edit through the shared snapshot helper.
+// 3. Assert the exact rewrite succeeded without creating a Program.
+func TestFixSnapshotHarnessKeepsASTOnlyRuleOnParserPath(t *testing.T) {
+  before := programLifecycleSequence.Load()
+  assertFixSnapshotFile(
+    t,
+    "no-var",
+    "component.tsx",
+    "var legacy = 1;\nconst view = <div />;\nJSON.stringify([legacy, view]);\n",
+    "let legacy = 1;\nconst view = <div />;\nJSON.stringify([legacy, view]);\n",
+  )
+  if after := programLifecycleSequence.Load(); after != before {
+    t.Fatalf("AST-only fixer snapshot created a Program: before=%d after=%d", before, after)
+  }
+}

--- a/packages/lint/test/fix/fix_snapshot_harness_runs_type_aware_rule_with_program_checker_test.go
+++ b/packages/lint/test/fix/fix_snapshot_harness_runs_type_aware_rule_with_program_checker_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestFixSnapshotHarnessRunsTypeAwareRuleWithProgramChecker verifies typed fixer snapshots use a real Program.
+//
+// Prefer-const cannot resolve binding identity without Context.Checker. A
+// parser-only snapshot would therefore produce no edit, while a Program-backed
+// TSX snapshot must preserve the caller's grammar and rewrite the stable let.
+//
+// 1. Record the Program lifecycle sequence and materialize a TSX fixer case.
+// 2. Apply the type-aware prefer-const edit through the shared snapshot helper.
+// 3. Assert a Program was created and the exact on-disk rewrite succeeded.
+func TestFixSnapshotHarnessRunsTypeAwareRuleWithProgramChecker(t *testing.T) {
+  before := programLifecycleSequence.Load()
+  assertFixSnapshotFile(
+    t,
+    "prefer-const",
+    "component.tsx",
+    "const view = <div />;\nlet stable = 1;\nJSON.stringify([view, stable]);\n",
+    "const view = <div />;\nconst stable = 1;\nJSON.stringify([view, stable]);\n",
+  )
+  if after := programLifecycleSequence.Load(); after <= before {
+    t.Fatalf("type-aware fixer snapshot did not create a Program: before=%d after=%d", before, after)
+  }
+}

--- a/packages/lint/test/shared/helpers_test.go
+++ b/packages/lint/test/shared/helpers_test.go
@@ -587,7 +587,8 @@ func runRuleFindingsSnapshotFile(
     })
   }
 
-  if !engine.NeedsTypeChecker() {
+  needsRuleChecker := engine.NeedsTypeChecker()
+  if !needsRuleChecker {
     root := t.TempDir()
     engine.SetCurrentDirectory(root)
     filePath := filepath.Join(root, "src", fileName)
@@ -606,8 +607,11 @@ func runRuleFindingsSnapshotFile(
   filePath := filepath.Join(root, "src", fileName)
   program, diagnostics, err := loadProgram(root, "tsconfig.json", loadProgramOptions{
     forceNoEmit:      true,
-    needsRuleChecker: true,
+    needsRuleChecker: needsRuleChecker,
   })
+  if program != nil {
+    defer program.close()
+  }
   if err != nil {
     t.Fatalf("%s: loadProgram: %v", ruleName, err)
   }
@@ -617,7 +621,6 @@ func runRuleFindingsSnapshotFile(
   if program == nil {
     t.Fatalf("%s: loadProgram returned no program", ruleName)
   }
-  defer program.close()
   if program.checker == nil {
     t.Fatalf("%s: loadProgram returned no checker for a type-aware rule", ruleName)
   }

--- a/packages/lint/test/shared/helpers_test.go
+++ b/packages/lint/test/shared/helpers_test.go
@@ -317,19 +317,36 @@ func captureCommandOutput(t *testing.T, fn func() int) (int, string, string) {
 // 3. Return the root path for --cwd command execution.
 func seedLintProject(t *testing.T, source string) string {
   t.Helper()
-  root := t.TempDir()
-  writeFile(t, filepath.Join(root, "tsconfig.json"), `{
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "commonjs",
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist"
-  },
-  "files": ["src/main.ts"]
+  return seedLintProjectFile(t, "main.ts", source)
 }
-`)
-  writeFile(t, filepath.Join(root, "src", "main.ts"), source)
+
+// seedLintProjectFile is seedLintProject with a caller-selected source name.
+// Snapshot tests use it when the filename controls TypeScript's grammar, while
+// command-frontdoor tests keep the main.ts default above.
+func seedLintProjectFile(t *testing.T, fileName, source string) string {
+  t.Helper()
+  root := t.TempDir()
+  compilerOptions := map[string]any{
+    "target":  "ES2022",
+    "module":  "commonjs",
+    "strict":  true,
+    "rootDir": "src",
+    "outDir":  "dist",
+  }
+  if strings.EqualFold(filepath.Ext(fileName), ".tsx") {
+    compilerOptions["jsx"] = "preserve"
+  }
+  config, err := json.MarshalIndent(map[string]any{
+    "compilerOptions": compilerOptions,
+    "files": []string{
+      filepath.ToSlash(filepath.Join("src", fileName)),
+    },
+  }, "", "  ")
+  if err != nil {
+    t.Fatalf("marshal tsconfig: %v", err)
+  }
+  writeFile(t, filepath.Join(root, "tsconfig.json"), string(config)+"\n")
+  writeFile(t, filepath.Join(root, "src", fileName), source)
   return root
 }
 
@@ -513,16 +530,13 @@ func runFixSnapshot(t *testing.T, ruleName, source string) (string, int) {
 
 func runFixSnapshotFile(t *testing.T, ruleName, fileName, source string) (string, int) {
   t.Helper()
-  root := t.TempDir()
-  filePath := filepath.Join(root, "src", fileName)
-  writeFile(t, filePath, source)
-  var file *shimast.SourceFile
-  if strings.EqualFold(filepath.Ext(fileName), ".tsx") {
-    file = parseTSXFile(t, filePath, source)
-  } else {
-    file = parseTSFile(t, filePath, source)
-  }
-  findings := NewEngine(RuleConfig{ruleName: SeverityError}).Run([]*shimast.SourceFile{file}, nil)
+  root, filePath, findings := runRuleFindingsSnapshotFile(
+    t,
+    ruleName,
+    fileName,
+    source,
+    nil,
+  )
   if len(findings) == 0 {
     t.Fatalf("%s: expected at least one finding", ruleName)
   }
@@ -548,6 +562,21 @@ func runRuleFindingsSnapshot(
   options json.RawMessage,
 ) (string, string, []*Finding) {
   t.Helper()
+  return runRuleFindingsSnapshotFile(t, ruleName, "main.ts", source, options)
+}
+
+// runRuleFindingsSnapshotFile selects the lightweight parser or the real
+// Program/checker lifecycle from the configured engine's requirements. Both
+// paths materialize the caller's exact filename and project directory so the
+// returned findings can flow through the same disk-backed edit assertions.
+func runRuleFindingsSnapshotFile(
+  t *testing.T,
+  ruleName string,
+  fileName string,
+  source string,
+  options json.RawMessage,
+) (string, string, []*Finding) {
+  t.Helper()
   var engine *Engine
   if len(options) == 0 {
     engine = NewEngine(RuleConfig{ruleName: SeverityError})
@@ -561,15 +590,20 @@ func runRuleFindingsSnapshot(
   if !engine.NeedsTypeChecker() {
     root := t.TempDir()
     engine.SetCurrentDirectory(root)
-    filePath := filepath.Join(root, "src", "main.ts")
+    filePath := filepath.Join(root, "src", fileName)
     writeFile(t, filePath, source)
-    file := parseTSFile(t, filePath, source)
+    var file *shimast.SourceFile
+    if strings.EqualFold(filepath.Ext(fileName), ".tsx") {
+      file = parseTSXFile(t, filePath, source)
+    } else {
+      file = parseTSFile(t, filePath, source)
+    }
     return root, filePath, engine.Run([]*shimast.SourceFile{file}, nil)
   }
 
-  root := seedLintProject(t, source)
+  root := seedLintProjectFile(t, fileName, source)
   engine.SetCurrentDirectory(root)
-  filePath := filepath.Join(root, "src", "main.ts")
+  filePath := filepath.Join(root, "src", fileName)
   program, diagnostics, err := loadProgram(root, "tsconfig.json", loadProgramOptions{
     forceNoEmit:      true,
     needsRuleChecker: true,
@@ -577,9 +611,15 @@ func runRuleFindingsSnapshot(
   if err != nil {
     t.Fatalf("%s: loadProgram: %v", ruleName, err)
   }
+  if len(diagnostics) != 0 {
+    t.Fatalf("%s: loadProgram diagnostics: %+v", ruleName, diagnostics)
+  }
   if program == nil {
-    t.Fatalf("%s: loadProgram returned no program (%+v)", ruleName, diagnostics)
+    t.Fatalf("%s: loadProgram returned no program", ruleName)
   }
   defer program.close()
-  return root, filePath, engine.Run(program.userSourceFiles(), program.checker)
+  if program.checker == nil {
+    t.Fatalf("%s: loadProgram returned no checker for a type-aware rule", ruleName)
+  }
+  return root, filePath, program.runLintCycle(engine)
 }


### PR DESCRIPTION
## Intent

Make disk-backed lint fixer snapshots execute type-aware rules with the same real TypeScript Program/checker lifecycle used by production instead of silently skipping them.

Fixes #457.

## Scope

- share one filename-aware snapshot runner between finding and fixer assertions
- retain the parser-only fast path for AST-only rules
- run checker-backed fixtures through `program.runLintCycle`
- preserve TS/TSX filenames, project current directory, Program cleanup, loader diagnostic visibility, and exact on-disk edit assertions
- add positive/negative harness twins for Program-backed and parser-only execution

## Deferred

- no production rule behavior changes
- no formatter run, per task constraint
- no CI wait, per task constraint

## Verification

- three clean exhaustive reviews of the complete PR diff, production callers, shared-helper callers, and regression tests
- focused Go lint run passed 32 tests: both harness twins, all prefer-const fixer and checker shields, all filename-sensitive TS/TSX/MTS/CTS fixer snapshots, and the typed current-directory case
- `git diff --check` passed

## Focused command

```powershell
$env:NODE_PATH='D:\github\samchon\ttsc@fix\node_modules'
$env:GOFLAGS='-run=^(TestFixSnapshotHarness|Test.*PreferConst|TestFixNoUnnecessaryTypeConstraint|TestNoFloatingPromisesStructuredSpecifiers) -v'
node scripts/test-go-lint.cjs
```