### PR TITLE
test(lint): make await-using fixtures compiler-valid

### DIFF
--- a/packages/lint/test/rules/typescript/await_thenable_await_using_async_disposable_allows_test.go
+++ b/packages/lint/test/rules/typescript/await_thenable_await_using_async_disposable_allows_test.go
@@ -19,16 +19,11 @@ import (
 // surfaces here.
 //
 //  1. Seed a project containing all four valid resource-management shapes.
-//  2. Run `check` with typescript/await-thenable enabled as error.
-//  3. Assert a clean exit with no await-thenable finding.
+//  2. Prove the fixture type-checks without a lint plugin entry.
+//  3. Run `check` with typescript/await-thenable enabled as error.
+//  4. Assert a clean exit with no await-thenable finding.
 func TestAwaitThenableAwaitUsingAsyncDisposableAllows(t *testing.T) {
-  root := seedLintProject(t, `export {};
-declare global {
-  interface SymbolConstructor {
-    readonly dispose: unique symbol;
-    readonly asyncDispose: unique symbol;
-  }
-}
+  root := seedAwaitUsingLintProject(t, `export {};
 interface AsyncResource {
   [Symbol.asyncDispose](): Promise<void>;
 }
@@ -48,6 +43,7 @@ async function main(): Promise<void> {
 }
 void main();
 `)
+  assertAwaitUsingProjectTypeChecks(t, root)
   seedLintRules(t, root, map[string]string{"typescript/await-thenable": "error"})
 
   code, stdout, stderr := captureCommandOutput(t, func() int {

--- a/packages/lint/test/rules/typescript/await_thenable_await_using_async_method_under_dispose_symbol_reports_test.go
+++ b/packages/lint/test/rules/typescript/await_thenable_await_using_async_method_under_dispose_symbol_reports_test.go
@@ -18,16 +18,11 @@ import (
 //
 //  1. Seed a project declaring `await using` over an object whose only
 //     member is `async [Symbol.dispose]()`.
-//  2. Run `check` with typescript/await-thenable enabled as error.
-//  3. Assert exactly one finding on the declaration line.
+//  2. Prove the fixture type-checks without a lint plugin entry.
+//  3. Run `check` with typescript/await-thenable enabled as error.
+//  4. Assert exactly one finding on the declaration line.
 func TestAwaitThenableAwaitUsingAsyncMethodUnderDisposeSymbolReports(t *testing.T) {
-  root := seedLintProject(t, `export {};
-declare global {
-  interface SymbolConstructor {
-    readonly dispose: unique symbol;
-    readonly asyncDispose: unique symbol;
-  }
-}
+  root := seedAwaitUsingLintProject(t, `export {};
 async function main(): Promise<void> {
   await using resource = {
     async [Symbol.dispose](): Promise<void> {},
@@ -36,6 +31,7 @@ async function main(): Promise<void> {
 }
 void main();
 `)
+  assertAwaitUsingProjectTypeChecks(t, root)
   seedLintRules(t, root, map[string]string{"typescript/await-thenable": "error"})
 
   code, stdout, stderr := captureCommandOutput(t, func() int {
@@ -51,7 +47,7 @@ void main();
   if got := strings.Count(stderr, "[typescript/await-thenable]"); got != 1 {
     t.Fatalf("expected 1 await-thenable finding, got %d:\n%s", got, stderr)
   }
-  if !diagnosticOutputContains(stderr, "main.ts:9:") {
+  if !diagnosticOutputContains(stderr, "main.ts:3:") {
     t.Fatalf("finding not anchored on the declaration line:\n%s", stderr)
   }
 }

--- a/packages/lint/test/rules/typescript/await_thenable_await_using_helpers_test.go
+++ b/packages/lint/test/rules/typescript/await_thenable_await_using_helpers_test.go
@@ -1,0 +1,44 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// seedAwaitUsingLintProject materializes an await-using fixture with the
+// standard explicit-resource-management declarations supplied by TypeScript.
+// Keeping the protocol library in compiler configuration prevents the fixture
+// from replacing global Disposable contracts with partial local declarations.
+func seedAwaitUsingLintProject(t *testing.T, source string) string {
+  t.Helper()
+  root := seedLintProject(t, source)
+  writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "lib": ["ES2022", "DOM", "ESNext.Disposable"]
+  },
+  "files": ["src/main.ts"]
+}
+`)
+  return root
+}
+
+// assertAwaitUsingProjectTypeChecks proves fixture prerequisites independently
+// of lint by invoking the real check front door with no lint plugin entry.
+func assertAwaitUsingProjectTypeChecks(t *testing.T, root string) {
+  t.Helper()
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "check",
+      "--cwd", root,
+      "--plugins-json", "[]",
+    })
+  })
+  if code != 0 || stdout != "" || stderr != "" {
+    t.Fatalf("await-using fixture does not type-check: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}

--- a/packages/lint/test/rules/typescript/await_thenable_await_using_multi_declarator_reports_only_sync_resource_test.go
+++ b/packages/lint/test/rules/typescript/await_thenable_await_using_multi_declarator_reports_only_sync_resource_test.go
@@ -17,17 +17,12 @@ import (
 // directions.
 //
 //  1. Seed a project with `await using ok = makeAsync(), bad = makeSync();`.
-//  2. Run `check` with typescript/await-thenable enabled as error.
-//  3. Assert exactly one finding, anchored at the second declarator's
+//  2. Prove the fixture type-checks without a lint plugin entry.
+//  3. Run `check` with typescript/await-thenable enabled as error.
+//  4. Assert exactly one finding, anchored at the second declarator's
 //     initializer expression.
 func TestAwaitThenableAwaitUsingMultiDeclaratorReportsOnlySyncResource(t *testing.T) {
-  root := seedLintProject(t, `export {};
-declare global {
-  interface SymbolConstructor {
-    readonly dispose: unique symbol;
-    readonly asyncDispose: unique symbol;
-  }
-}
+  root := seedAwaitUsingLintProject(t, `export {};
 interface AsyncResource {
   [Symbol.asyncDispose](): Promise<void>;
 }
@@ -42,6 +37,7 @@ async function main(): Promise<void> {
 }
 void main();
 `)
+  assertAwaitUsingProjectTypeChecks(t, root)
   seedLintRules(t, root, map[string]string{"typescript/await-thenable": "error"})
 
   code, stdout, stderr := captureCommandOutput(t, func() int {
@@ -57,7 +53,7 @@ void main();
   if got := strings.Count(stderr, "[typescript/await-thenable]"); got != 1 {
     t.Fatalf("expected 1 await-thenable finding, got %d:\n%s", got, stderr)
   }
-  if !diagnosticOutputContains(stderr, "main.ts:17:45") {
+  if !diagnosticOutputContains(stderr, "main.ts:11:45") {
     t.Fatalf("finding not anchored at the sync declarator's initializer:\n%s", stderr)
   }
 }

--- a/packages/lint/test/rules/typescript/await_thenable_await_using_protocol_abstractions_allows_test.go
+++ b/packages/lint/test/rules/typescript/await_thenable_await_using_protocol_abstractions_allows_test.go
@@ -17,16 +17,11 @@ import (
 //
 //  1. Seed a project with `await using` over aliased, inherited,
 //     intersected, and constraint-typed async disposables.
-//  2. Run `check` with typescript/await-thenable enabled as error.
-//  3. Assert a clean exit with no await-thenable finding.
+//  2. Prove the fixture type-checks without a lint plugin entry.
+//  3. Run `check` with typescript/await-thenable enabled as error.
+//  4. Assert a clean exit with no await-thenable finding.
 func TestAwaitThenableAwaitUsingProtocolAbstractionsAllows(t *testing.T) {
-  root := seedLintProject(t, `export {};
-declare global {
-  interface SymbolConstructor {
-    readonly dispose: unique symbol;
-    readonly asyncDispose: unique symbol;
-  }
-}
+  root := seedAwaitUsingLintProject(t, `export {};
 interface AsyncResource {
   [Symbol.asyncDispose](): Promise<void>;
 }
@@ -50,6 +45,7 @@ async function openConstrained<T extends AsyncResource>(factory: () => T): Promi
 void main();
 void openConstrained(() => aliased);
 `)
+  assertAwaitUsingProjectTypeChecks(t, root)
   seedLintRules(t, root, map[string]string{"typescript/await-thenable": "error"})
 
   code, stdout, stderr := captureCommandOutput(t, func() int {

--- a/packages/lint/test/rules/typescript/await_thenable_await_using_protocol_abstractions_reports_test.go
+++ b/packages/lint/test/rules/typescript/await_thenable_await_using_protocol_abstractions_reports_test.go
@@ -17,16 +17,11 @@ import (
 //
 //  1. Seed a project with `await using` over aliased, inherited,
 //     intersected, and constraint-typed SYNC-only disposables.
-//  2. Run `check` with typescript/await-thenable enabled as error.
-//  3. Assert exactly four findings on the four declaration lines.
+//  2. Prove the fixture type-checks without a lint plugin entry.
+//  3. Run `check` with typescript/await-thenable enabled as error.
+//  4. Assert exactly four findings on the four declaration lines.
 func TestAwaitThenableAwaitUsingProtocolAbstractionsReports(t *testing.T) {
-  root := seedLintProject(t, `export {};
-declare global {
-  interface SymbolConstructor {
-    readonly dispose: unique symbol;
-    readonly asyncDispose: unique symbol;
-  }
-}
+  root := seedAwaitUsingLintProject(t, `export {};
 interface SyncResource {
   [Symbol.dispose](): void;
 }
@@ -50,6 +45,7 @@ async function openConstrained<T extends SyncResource>(factory: () => T): Promis
 void main();
 void openConstrained(() => aliased);
 `)
+  assertAwaitUsingProjectTypeChecks(t, root)
   seedLintRules(t, root, map[string]string{"typescript/await-thenable": "error"})
 
   code, stdout, stderr := captureCommandOutput(t, func() int {
@@ -65,7 +61,7 @@ void openConstrained(() => aliased);
   if got := strings.Count(stderr, "[typescript/await-thenable]"); got != 4 {
     t.Fatalf("expected 4 await-thenable findings, got %d:\n%s", got, stderr)
   }
-  for _, anchor := range []string{"main.ts:19:", "main.ts:20:", "main.ts:21:", "main.ts:25:"} {
+  for _, anchor := range []string{"main.ts:13:", "main.ts:14:", "main.ts:15:", "main.ts:19:"} {
     if !diagnosticOutputContains(stderr, anchor) {
       t.Fatalf("missing finding at %s:\n%s", anchor, stderr)
     }

--- a/packages/lint/test/rules/typescript/await_thenable_await_using_sync_disposable_reports_test.go
+++ b/packages/lint/test/rules/typescript/await_thenable_await_using_sync_disposable_reports_test.go
@@ -13,25 +13,19 @@ import (
 // a sync-only disposable never reported (#413). JavaScript permits the
 // fallback (the runtime wraps the sync disposer), which is exactly why only
 // the type-level `[Symbol.asyncDispose]` protocol check can catch the pointless
-// `await`. The disposable symbols come from a `declare global`
-// augmentation, the standard shape for projects without the
-// `ESNext.Disposable` lib, so the well-known-symbol resolution is exercised
-// through the merged SymbolConstructor rather than lib-provided members. The
-// expected column pins the diagnostic to the initializer expression.
+// `await`. The standard `ESNext.Disposable` library supplies both the global
+// protocol types and their well-known symbols, keeping compiler prerequisites
+// distinct from the lint finding. The expected column pins the diagnostic to
+// the initializer expression.
 //
 //  1. Seed a project declaring `await using` over a `[Symbol.dispose]`-only
 //     object literal.
-//  2. Run `check` with typescript/await-thenable enabled as error.
-//  3. Assert exactly one finding anchored at the initializer with the
+//  2. Prove the fixture type-checks without a lint plugin entry.
+//  3. Run `check` with typescript/await-thenable enabled as error.
+//  4. Assert exactly one finding anchored at the initializer with the
 //     upstream message text.
 func TestAwaitThenableAwaitUsingSyncDisposableReports(t *testing.T) {
-  root := seedLintProject(t, `export {};
-declare global {
-  interface SymbolConstructor {
-    readonly dispose: unique symbol;
-    readonly asyncDispose: unique symbol;
-  }
-}
+  root := seedAwaitUsingLintProject(t, `export {};
 async function main(): Promise<void> {
   await using resource = {
     [Symbol.dispose](): void {},
@@ -40,6 +34,7 @@ async function main(): Promise<void> {
 }
 void main();
 `)
+  assertAwaitUsingProjectTypeChecks(t, root)
   seedLintRules(t, root, map[string]string{"typescript/await-thenable": "error"})
 
   code, stdout, stderr := captureCommandOutput(t, func() int {
@@ -58,7 +53,7 @@ void main();
   if !strings.Contains(stderr, "Unexpected `await using` of a value that is not async disposable.") {
     t.Fatalf("missing upstream await-using message:\n%s", stderr)
   }
-  if !diagnosticOutputContains(stderr, "main.ts:9:26") {
+  if !diagnosticOutputContains(stderr, "main.ts:3:26") {
     t.Fatalf("finding not anchored at the initializer expression:\n%s", stderr)
   }
 }

--- a/packages/lint/test/rules/typescript/await_thenable_await_using_sync_only_union_reports_test.go
+++ b/packages/lint/test/rules/typescript/await_thenable_await_using_sync_only_union_reports_test.go
@@ -18,16 +18,11 @@ import (
 //
 //  1. Seed a project declaring `await using` over a
 //     `FileHandle | SocketHandle` value where both sides are sync-only.
-//  2. Run `check` with typescript/await-thenable enabled as error.
-//  3. Assert exactly one finding on the declaration line.
+//  2. Prove the fixture type-checks without a lint plugin entry.
+//  3. Run `check` with typescript/await-thenable enabled as error.
+//  4. Assert exactly one finding on the declaration line.
 func TestAwaitThenableAwaitUsingSyncOnlyUnionReports(t *testing.T) {
-  root := seedLintProject(t, `export {};
-declare global {
-  interface SymbolConstructor {
-    readonly dispose: unique symbol;
-    readonly asyncDispose: unique symbol;
-  }
-}
+  root := seedAwaitUsingLintProject(t, `export {};
 interface FileHandle {
   [Symbol.dispose](): void;
 }
@@ -42,6 +37,7 @@ async function main(): Promise<void> {
 }
 void main();
 `)
+  assertAwaitUsingProjectTypeChecks(t, root)
   seedLintRules(t, root, map[string]string{"typescript/await-thenable": "error"})
 
   code, stdout, stderr := captureCommandOutput(t, func() int {
@@ -57,7 +53,7 @@ void main();
   if got := strings.Count(stderr, "[typescript/await-thenable]"); got != 1 {
     t.Fatalf("expected 1 await-thenable finding, got %d:\n%s", got, stderr)
   }
-  if !diagnosticOutputContains(stderr, "main.ts:17:") {
+  if !diagnosticOutputContains(stderr, "main.ts:11:") {
     t.Fatalf("finding not anchored on the declaration line:\n%s", stderr)
   }
 }

--- a/packages/lint/test/rules/typescript/await_thenable_await_using_union_with_async_disposable_allows_test.go
+++ b/packages/lint/test/rules/typescript/await_thenable_await_using_union_with_async_disposable_allows_test.go
@@ -16,16 +16,11 @@ import (
 //
 //  1. Seed a project declaring `await using` over a
 //     `SyncResource | AsyncResource` value.
-//  2. Run `check` with typescript/await-thenable enabled as error.
-//  3. Assert a clean exit with no await-thenable finding.
+//  2. Prove the fixture type-checks without a lint plugin entry.
+//  3. Run `check` with typescript/await-thenable enabled as error.
+//  4. Assert a clean exit with no await-thenable finding.
 func TestAwaitThenableAwaitUsingUnionWithAsyncDisposableAllows(t *testing.T) {
-  root := seedLintProject(t, `export {};
-declare global {
-  interface SymbolConstructor {
-    readonly dispose: unique symbol;
-    readonly asyncDispose: unique symbol;
-  }
-}
+  root := seedAwaitUsingLintProject(t, `export {};
 interface SyncResource {
   [Symbol.dispose](): void;
 }
@@ -39,6 +34,7 @@ async function main(): Promise<void> {
 }
 void main();
 `)
+  assertAwaitUsingProjectTypeChecks(t, root)
   seedLintRules(t, root, map[string]string{"typescript/await-thenable": "error"})
 
   code, stdout, stderr := captureCommandOutput(t, func() int {


### PR DESCRIPTION
## Intent

Keep await-thenable resource-management regressions behind valid TypeScript compiler prerequisites so a clean lint assertion cannot pass or fail for the wrong reason.

## Scope

- Configure the affected await using fixtures with the canonical ESNext.Disposable library.
- Remove partial local SymbolConstructor declarations from those fixtures.
- Prove every positive and negative fixture type-checks through the real command front door with no lint plugin entry.
- Preserve lint assertions for direct, abstracted, generic, intersection, union, wrong-symbol, and multi-declarator shapes.

## Root cause

The shared ES2022 project fixture did not load the explicit-resource-management declarations. Defining only Symbol.dispose and Symbol.asyncDispose left the required global Disposable and AsyncDisposable types missing, so compiler TS2318 diagnostics preempted the intended lint assertions.

## Deferred

No production rule change is needed.

## Test plan

After three exhaustive whole-PR review rounds, run the focused TestAwaitThenableAwaitUsing Go tests from the materialized lint test module.

Closes #458