### PR TITLE
fix(lint): track assertion-wrapped assignment targets

### DIFF
--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -344,9 +344,12 @@ func (w *descendantsWalker) visitChild(child *shimast.Node) bool {
 // array elements, object property values, shorthand properties, defaults
 // (`[a = 1]`, `{a = 1}`), nested patterns, and rest elements.
 //
-// Property names in `{key: target}` are read positions, not writes, so
-// only the property value contributes; member-access targets (`obj.x`)
-// declare no local binding and are skipped. Returns nil for other shapes.
+// TypeScript assertion wrappers are transparent in reference position, so
+// `as`, angle-bracket assertions, `satisfies`, non-null assertions, and
+// parentheses are unwrapped recursively wherever they appear in a target.
+// Property names in `{key: target}` are read positions, not writes, so only
+// the property value contributes; member-access targets (`obj.x`) declare no
+// local binding and are skipped. Returns nil for other shapes.
 func assignmentTargetIdentifiers(node *shimast.Node) []*shimast.Node {
   if node == nil {
     return nil
@@ -390,6 +393,18 @@ func collectAssignmentTargetIdentifiers(node *shimast.Node, identifiers *[]*shim
     collectAssignmentTargetIdentifiers(stripParens(node), identifiers)
   case shimast.KindNonNullExpression:
     if expression := node.AsNonNullExpression(); expression != nil {
+      collectAssignmentTargetIdentifiers(expression.Expression, identifiers)
+    }
+  case shimast.KindAsExpression:
+    if expression := node.AsAsExpression(); expression != nil {
+      collectAssignmentTargetIdentifiers(expression.Expression, identifiers)
+    }
+  case shimast.KindTypeAssertionExpression:
+    if expression := node.AsTypeAssertion(); expression != nil {
+      collectAssignmentTargetIdentifiers(expression.Expression, identifiers)
+    }
+  case shimast.KindSatisfiesExpression:
+    if expression := node.AsSatisfiesExpression(); expression != nil {
       collectAssignmentTargetIdentifiers(expression.Expression, identifiers)
     }
   case shimast.KindArrayLiteralExpression:

--- a/packages/lint/linthost/rules_security.go
+++ b/packages/lint/linthost/rules_security.go
@@ -367,7 +367,7 @@ func collectSecurityAssignedNames(node *shimast.Node) map[string]bool {
         return
       }
       if expr.Operator == shimast.KindPlusPlusToken || expr.Operator == shimast.KindMinusMinusToken {
-        if name := identifierText(expr.Operand); name != "" {
+        for _, name := range assignmentTargetNames(expr.Operand) {
           assigned[name] = true
         }
       }
@@ -377,9 +377,17 @@ func collectSecurityAssignedNames(node *shimast.Node) map[string]bool {
         return
       }
       if expr.Operator == shimast.KindPlusPlusToken || expr.Operator == shimast.KindMinusMinusToken {
-        if name := identifierText(expr.Operand); name != "" {
+        for _, name := range assignmentTargetNames(expr.Operand) {
           assigned[name] = true
         }
+      }
+    case shimast.KindForOfStatement, shimast.KindForInStatement:
+      stmt := child.AsForInOrOfStatement()
+      if stmt == nil || stmt.Initializer == nil || stmt.Initializer.Kind == shimast.KindVariableDeclarationList {
+        return
+      }
+      for _, name := range assignmentTargetNames(stmt.Initializer) {
+        assigned[name] = true
       }
     }
   })

--- a/packages/lint/linthost/rules_var.go
+++ b/packages/lint/linthost/rules_var.go
@@ -973,6 +973,18 @@ func preferConstAssignmentTargetHasMember(node *shimast.Node) bool {
     if expression := node.AsNonNullExpression(); expression != nil {
       return preferConstAssignmentTargetHasMember(expression.Expression)
     }
+  case shimast.KindAsExpression:
+    if expression := node.AsAsExpression(); expression != nil {
+      return preferConstAssignmentTargetHasMember(expression.Expression)
+    }
+  case shimast.KindTypeAssertionExpression:
+    if expression := node.AsTypeAssertion(); expression != nil {
+      return preferConstAssignmentTargetHasMember(expression.Expression)
+    }
+  case shimast.KindSatisfiesExpression:
+    if expression := node.AsSatisfiesExpression(); expression != nil {
+      return preferConstAssignmentTargetHasMember(expression.Expression)
+    }
   case shimast.KindArrayLiteralExpression:
     if array := node.AsArrayLiteralExpression(); array != nil && array.Elements != nil {
       for _, element := range array.Elements.Nodes {

--- a/packages/lint/test/fix/fix_prefer_const_preserves_assertion_wrapped_assignment_targets_test.go
+++ b/packages/lint/test/fix/fix_prefer_const_preserves_assertion_wrapped_assignment_targets_test.go
@@ -1,0 +1,63 @@
+package linthost
+
+import "testing"
+
+// TestFixPreferConstPreservesAssertionWrappedAssignmentTargets verifies every
+// TypeScript reference wrapper remains transparent to write tracking.
+//
+// The mutable bindings cover simple and compound assignments, prefix and
+// postfix updates, for-in/of targets, nested wrappers, and array/object
+// destructuring defaults. The member target is the negative boundary: writing
+// through holder.value does not reassign holder, so holder and the unrelated
+// stable binding must still receive the ordinary let-to-const fix.
+func TestFixPreferConstPreservesAssertionWrappedAssignmentTargets(t *testing.T) {
+  source := `let simple = 0;
+(simple as number) = 1;
+let compound = 0;
+(<number>compound) += 1;
+let postfix = 0;
+(postfix satisfies number)++;
+let prefix = 0;
+++((prefix as number));
+let nested = 0;
+((((nested!) as number) satisfies number)) = 1;
+let fromForOf = 0;
+for ((fromForOf as number) of [1, 2]) {}
+let fromForIn = "";
+for ((fromForIn satisfies string) in { key: true }) {}
+let arrayValue = 0;
+let defaulted = 0;
+[((arrayValue as number)), ((defaulted satisfies number)) = 1] = [2];
+let objectValue = 0;
+({ value: (<number>objectValue) } = { value: 3 });
+let holder = { value: 0 };
+(holder.value as number) = 4;
+let stable = 1;
+console.log(simple, compound, postfix, prefix, nested, fromForOf, fromForIn, arrayValue, defaulted, objectValue, holder, stable);
+`
+  expected := `let simple = 0;
+(simple as number) = 1;
+let compound = 0;
+(<number>compound) += 1;
+let postfix = 0;
+(postfix satisfies number)++;
+let prefix = 0;
+++((prefix as number));
+let nested = 0;
+((((nested!) as number) satisfies number)) = 1;
+let fromForOf = 0;
+for ((fromForOf as number) of [1, 2]) {}
+let fromForIn = "";
+for ((fromForIn satisfies string) in { key: true }) {}
+let arrayValue = 0;
+let defaulted = 0;
+[((arrayValue as number)), ((defaulted satisfies number)) = 1] = [2];
+let objectValue = 0;
+({ value: (<number>objectValue) } = { value: 3 });
+const holder = { value: 0 };
+(holder.value as number) = 4;
+const stable = 1;
+console.log(simple, compound, postfix, prefix, nested, fromForOf, fromForIn, arrayValue, defaulted, objectValue, holder, stable);
+`
+  assertFixSnapshot(t, "prefer-const", source, expected)
+}

--- a/packages/lint/test/rules/security/security_assigned_names_unwrap_assertion_targets_test.go
+++ b/packages/lint/test/rules/security/security_assigned_names_unwrap_assertion_targets_test.go
@@ -1,0 +1,49 @@
+package linthost
+
+import "testing"
+
+// TestSecurityAssignedNamesUnwrapAssertionTargets pins every write context
+// consumed by the security rules while keeping member writes out of the local
+// binding set.
+func TestSecurityAssignedNamesUnwrapAssertionTargets(t *testing.T) {
+  file := parseTS(t, `let simple = 0;
+(simple as number) = input;
+let compound = 0;
+(<number>compound) += input;
+let prefix = 0;
+++((prefix satisfies number));
+let postfix = 0;
+((postfix as number))++;
+let fromForOf = 0;
+for ((fromForOf as number) of values) {}
+let fromForIn = "";
+for ((fromForIn satisfies string) in values) {}
+let arrayValue = 0;
+let objectValue = 0;
+[(arrayValue as number), { value: (<number>objectValue) }] = values;
+let nested = 0;
+((((nested!) as number) satisfies number)) = input;
+let holder = { value: 0 };
+(holder.value as number) = input;
+`)
+
+  assigned := collectSecurityAssignedNames(file.AsNode())
+  for _, name := range []string{
+    "simple",
+    "compound",
+    "prefix",
+    "postfix",
+    "fromForOf",
+    "fromForIn",
+    "arrayValue",
+    "objectValue",
+    "nested",
+  } {
+    if !assigned[name] {
+      t.Errorf("assertion-wrapped write to %q was not collected", name)
+    }
+  }
+  if assigned["holder"] {
+    t.Fatal("member write was misclassified as a write to the holder binding")
+  }
+}

--- a/packages/lint/test/rules/security/security_detect_non_literal_fs_filename_reports_assertion_wrapped_reassignment_test.go
+++ b/packages/lint/test/rules/security/security_detect_non_literal_fs_filename_reports_assertion_wrapped_reassignment_test.go
@@ -1,0 +1,16 @@
+package linthost
+
+import "testing"
+
+// TestSecurityDetectNonLiteralFSFilenameReportsAssertionWrappedReassignment
+// verifies the shared text projection invalidates a previously static binding
+// after a TypeScript assertion-wrapped write.
+func TestSecurityDetectNonLiteralFSFilenameReportsAssertionWrappedReassignment(t *testing.T) {
+  assertRuleCorpusCase(t, "security/detect-non-literal-fs-filename-assertion-write.ts", `
+import fs from "fs";
+let filename = "./safe.json";
+(filename as string) = input;
+// expect: security/detect-non-literal-fs-filename error
+fs.readFileSync(filename);
+`)
+}


### PR DESCRIPTION
## Intent

Preserve binding-write identity through every TypeScript assertion wrapper accepted in assignment reference position.

## Scope

- unwrap as, angle-bracket, satisfies, non-null, and parenthesized targets recursively
- retain the same semantics inside destructuring, defaults, updates, and for-in/of targets
- keep member writes distinct from writes to their holder binding
- invalidate security-rule static bindings after wrapped updates and loop assignments
- add a real prefer-const fixer shield plus shared-security and command-path regressions

Closes #448.

## Validation

- three sequential exhaustive whole-PR reviews at 1b9c8a9217c41f4b5fb5a15de97dff753316d53b: clean
- focused materialized lint-host tests: 8/8 passed
- included new wrapper tests plus non-null, parenthesized update, destructuring, stable-fix, and reassigned-static controls
- diff check and local/remote HEAD integrity: clean

## Constraints

- no source-text target scanning
- no identifier-specific exceptions
- no monkeypatching or test-only production path
- no formatting pass