### PR TITLE
fix(lint): honor safe calls inside composite expressions

### DIFF
--- a/packages/lint/linthost/rules_promise.go
+++ b/packages/lint/linthost/rules_promise.go
@@ -709,9 +709,6 @@ func (noFloatingPromises) Check(ctx *Context, node *shimast.Node) {
   if options.IgnoreIIFE && isImmediatelyInvokedFunctionExpression(expr) {
     return
   }
-  if isKnownSafePromiseCall(ctx, expr, options.AllowForKnownSafeCalls) {
-    return
-  }
   result := analyzeFloatingPromise(ctx, expr, options)
   if !result.unhandled {
     return
@@ -745,6 +742,14 @@ func analyzeFloatingPromise(
 ) floatingPromiseResult {
   node = unwrapFloatingPromiseExpression(node)
   if node == nil {
+    return floatingPromiseResult{}
+  }
+
+  // A configured safe call stays safe wherever recursive expression analysis
+  // reaches it. The callee's symbol/source identity is unchanged by a comma,
+  // logical, conditional, or void parent, so the allowlist decision belongs
+  // at the call node rather than only at the root expression statement.
+  if isKnownSafePromiseCall(ctx, node, options.AllowForKnownSafeCalls) {
     return floatingPromiseResult{}
   }
 

--- a/packages/lint/test/rules/typescript/no_floating_promises_safe_calls_in_composites_specifiers_test.go
+++ b/packages/lint/test/rules/typescript/no_floating_promises_safe_calls_in_composites_specifiers_test.go
@@ -1,0 +1,37 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestNoFloatingPromisesSafeCallsInCompositesHonorStructuredSpecifiers proves
+// nested matching retains file, package, and TypeScript-lib source boundaries.
+func TestNoFloatingPromisesSafeCallsInCompositesHonorStructuredSpecifiers(t *testing.T) {
+  source := `import { localSafeCall } from "./safe";
+import { packageSafeCall } from "safe-package";
+declare const condition: boolean;
+condition && localSafeCall();
+condition ? packageSafeCall() : Promise.resolve();
+// expect only the unlisted native call
+condition && Promise.reject(new Error("unsafe"));
+`
+  extras := map[string]string{
+    "src/safe.ts": `export declare function localSafeCall(): Promise<void>;
+`,
+    "node_modules/safe-package/package.json": `{"name":"safe-package","types":"index.d.ts"}`,
+    "node_modules/safe-package/index.d.ts": `export declare function packageSafeCall(): Promise<void>;
+`,
+  }
+  code, stdout, stderr := runNoFloatingPromisesProjectCase(t, source, map[string]any{
+    "allowForKnownSafeCalls": []any{
+      map[string]any{"from": "file", "name": "localSafeCall", "path": "src/safe.ts"},
+      map[string]any{"from": "package", "name": "packageSafeCall", "package": "safe-package"},
+      map[string]any{"from": "lib", "name": "resolve"},
+    },
+  }, extras)
+  if code != 2 || stdout != "" || strings.Count(stderr, "[typescript/no-floating-promises]") != 1 ||
+    !diagnosticOutputContains(stderr, "main.ts:7:") {
+    t.Fatalf("structured nested safe-call mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}

--- a/packages/lint/test/rules/typescript/no_floating_promises_safe_calls_in_composites_test.go
+++ b/packages/lint/test/rules/typescript/no_floating_promises_safe_calls_in_composites_test.go
@@ -1,0 +1,82 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestNoFloatingPromisesSafeCallsInComposites verifies a safe-call specifier
+// applies to the call itself without suppressing unlisted sibling branches.
+//
+// The matrix covers every recursive composite family, an explicit void walk,
+// a structural thenable under checkThenables, and the existing IIFE escape.
+func TestNoFloatingPromisesSafeCallsInComposites(t *testing.T) {
+  code, stdout, stderr := runNoFloatingPromisesCase(t, `interface CatchableThenable {
+  then(onFulfilled: () => void, onRejected: () => void): CatchableThenable;
+}
+declare const condition: boolean;
+declare const maybe: boolean | null;
+declare function safe(): Promise<void>;
+declare function unsafe(): Promise<void>;
+declare function safeThenable(): CatchableThenable;
+declare function unsafeThenable(): CatchableThenable;
+safe();
+(safe(), 0);
+condition && safe();
+condition || safe();
+maybe ?? safe();
+condition ? safe() : safe();
+// unsafe controls
+unsafe();
+(safe(), unsafe());
+condition && unsafe();
+condition || unsafe();
+maybe ?? unsafe();
+condition ? safe() : unsafe();
+condition ? unsafe() : safe();
+void (safe(), unsafe());
+condition && safeThenable();
+condition && unsafeThenable();
+(async () => { safe(); })();
+`, map[string]any{
+    "allowForKnownSafeCalls": []any{"safe", "safeThenable"},
+    "checkThenables":         true,
+    "ignoreIIFE":             true,
+    "ignoreVoid":             false,
+  })
+  if code != 2 || stdout != "" {
+    t.Fatalf("safe-call composite run mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  if got := strings.Count(stderr, "[typescript/no-floating-promises]"); got != 9 {
+    t.Fatalf("expected 9 unsafe composite findings, got %d:\n%s", got, stderr)
+  }
+  for _, line := range []string{
+    "main.ts:17:",
+    "main.ts:18:",
+    "main.ts:19:",
+    "main.ts:20:",
+    "main.ts:21:",
+    "main.ts:22:",
+    "main.ts:23:",
+    "main.ts:24:",
+    "main.ts:26:",
+  } {
+    if !diagnosticOutputContains(stderr, line) {
+      t.Fatalf("missing unsafe composite finding at %s\n%s", line, stderr)
+    }
+  }
+  for _, line := range []string{
+    "main.ts:10:",
+    "main.ts:11:",
+    "main.ts:12:",
+    "main.ts:13:",
+    "main.ts:14:",
+    "main.ts:15:",
+    "main.ts:25:",
+    "main.ts:27:",
+  } {
+    if diagnosticOutputContains(stderr, line) {
+      t.Fatalf("configured safe/IIFE expression reported at %s\n%s", line, stderr)
+    }
+  }
+}


### PR DESCRIPTION
## Intent

Keep allowForKnownSafeCalls attached to the configured call even when recursive no-floating-promises analysis reaches it through a composite expression.

## Scope

- evaluate the existing symbol/source-aware safe-call matcher at every analyzed call node
- preserve direct, comma, logical, nullish, conditional, and explicit-void behavior
- keep unlisted sibling branches independently reportable
- cover universal, file, package, and TypeScript-lib specifiers
- preserve checkThenables, ignoreVoid, and ignoreIIFE option boundaries

Closes #461.

## Validation

- three sequential exhaustive whole-PR reviews at 7ae1d7cadc7b6996d5f0933236e51633f213f502: clean
- focused materialized lint-host tests: 6/6 passed
- new composite/specifier shields plus existing default, handler, options, and structured-specifier controls passed
- diff check and local/remote HEAD integrity: clean

## Constraints

- no syntax-specific parent skip
- no textual callee matching
- no monkeypatching or test-only production path
- no formatting pass