### PR TITLE
fix(lint): enumerate comments with parser lexical context

### DIFF
--- a/packages/lint/linthost/comment_scan.go
+++ b/packages/lint/linthost/comment_scan.go
@@ -1,68 +1,147 @@
-// Shared raw comment-token scan used by every rule or pass that needs the
-// exact byte range of each comment in a file (inline-disable directives,
-// typescript/ban-ts-comment). Centralizing the loop keeps the template
-// rescanning subtlety below in one place.
+// Shared parser-aware comment enumeration for every rule or pass that needs
+// exact comment byte ranges (inline directives, ban-ts-comment, and switch
+// default markers).
 package linthost
 
 import (
+  "sort"
+
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
 
-// forEachCommentToken re-lexes `text` with the raw TypeScript scanner and
-// invokes `visit` for every comment token with its kind and byte range.
+type commentToken struct {
+  kind shimast.Kind
+  pos  int
+  end  int
+}
+
+type sourceSpan struct {
+  pos int
+  end int
+}
+
+// forEachCommentToken visits every real comment in `file` in source order.
 //
-// The raw scanner does not split `KindTemplateExpression` on its own:
-// after returning `KindTemplateHead`/`KindTemplateMiddle`, it resumes
-// lexing the substitution as ordinary code, and a later `}` is reported
-// as `KindCloseBraceToken` instead of re-entering the template body.
-// Without intervention the next backtick would open a fresh template
-// scan that swallows the rest of the file (including every comment) as
-// one runaway unterminated literal. The loop avoids this by calling
-// `ReScanTemplateToken` on the matching `}`, tracked with a brace-depth
-// stack so comment positions stay aligned with the source bytes past any
-// template substitution.
-func forEachCommentToken(text string, visit func(kind shimast.Kind, pos, end int)) {
+// TypeScript's parser, rather than a context-free scanner, owns the lexical
+// goal for regular expressions, templates, and JSX. The parsed AST retains
+// those context-sensitive tokens as exact spans. We treat those spans as
+// opaque and scan only the gaps between them, where slash-shaped bytes are
+// ordinary JavaScript trivia or punctuation. This preserves the scanner's
+// complete comment and line-terminator behavior without guessing whether a
+// slash is division, manually tracking template braces, or special-casing JSX
+// strings. Exact ranges are deduplicated before the callback runs because a
+// recovery AST can expose overlapping token nodes for malformed source.
+func forEachCommentToken(file *shimast.SourceFile, visit func(kind shimast.Kind, pos, end int)) {
+  if file == nil || visit == nil {
+    return
+  }
+  text := file.Text()
+  opaque := parserTokenSpans(file)
+  comments := make([]commentToken, 0)
+  seen := make(map[sourceSpan]struct{})
+  collect := func(kind shimast.Kind, pos, end int) {
+    if pos < 0 || end <= pos || end > len(text) {
+      return
+    }
+    span := sourceSpan{pos: pos, end: end}
+    if _, ok := seen[span]; ok {
+      return
+    }
+    seen[span] = struct{}{}
+    comments = append(comments, commentToken{kind: kind, pos: pos, end: end})
+  }
+
+  cursor := 0
+  for _, span := range opaque {
+    if cursor < span.pos {
+      scanCommentGap(text, cursor, span.pos, collect)
+    }
+    if span.end > cursor {
+      cursor = span.end
+    }
+  }
+  if cursor < len(text) {
+    scanCommentGap(text, cursor, len(text), collect)
+  }
+
+  sort.Slice(comments, func(i, j int) bool {
+    if comments[i].pos != comments[j].pos {
+      return comments[i].pos < comments[j].pos
+    }
+    return comments[i].end < comments[j].end
+  })
+  for _, comment := range comments {
+    visit(comment.kind, comment.pos, comment.end)
+  }
+}
+
+// parserTokenSpans returns merged source ranges for every parser-owned token.
+// These are the lexical-goal boundaries a raw scanner cannot infer: string and
+// regex literals, template heads/middles/tails, and JSX text are all token
+// nodes, as are their TS/JS counterparts under the selected ScriptKind.
+func parserTokenSpans(file *shimast.SourceFile) []sourceSpan {
+  spans := make([]sourceSpan, 0)
+  var walk func(*shimast.Node)
+  walk = func(node *shimast.Node) {
+    if node == nil {
+      return
+    }
+    if node.Kind >= shimast.KindFirstToken && node.Kind <= shimast.KindLastToken {
+      pos := shimscanner.GetTokenPosOfNode(node, file, false /*includeJSDoc*/)
+      if pos >= 0 && node.End() > pos && node.End() <= len(file.Text()) {
+        spans = append(spans, sourceSpan{pos: pos, end: node.End()})
+      }
+      return
+    }
+    node.ForEachChild(func(child *shimast.Node) bool {
+      walk(child)
+      return false
+    })
+  }
+  walk(file.AsNode())
+  sort.Slice(spans, func(i, j int) bool {
+    if spans[i].pos != spans[j].pos {
+      return spans[i].pos < spans[j].pos
+    }
+    return spans[i].end < spans[j].end
+  })
+  if len(spans) < 2 {
+    return spans
+  }
+  merged := spans[:1]
+  for _, span := range spans[1:] {
+    last := &merged[len(merged)-1]
+    if span.pos <= last.end {
+      if span.end > last.end {
+        last.end = span.end
+      }
+      continue
+    }
+    merged = append(merged, span)
+  }
+  return merged
+}
+
+// scanCommentGap scans one parser-classified non-token gap. Context-sensitive
+// token bodies never enter this function, so every comment trivia token it
+// returns is a real source comment. Scanning the isolated gap also preserves
+// CRLF and Unicode line-terminator behavior without range arithmetic in a
+// second comment parser.
+func scanCommentGap(text string, from, to int, visit func(kind shimast.Kind, pos, end int)) {
+  if from < 0 || to <= from || to > len(text) {
+    return
+  }
   scanner := shimscanner.NewScanner()
-  scanner.SetText(text)
+  scanner.SetText(text[from:to])
   scanner.SetSkipTrivia(false)
-
-  // templateBraceDepth tracks `{` nesting inside each open template
-  // substitution. A zero on top means the next `}` matches the original
-  // `${` and must be re-scanned as a template middle/tail token.
-  var templateBraceDepth []int
-
   for {
     kind := scanner.Scan()
     switch kind {
     case shimast.KindEndOfFile:
       return
-    case shimast.KindTemplateHead, shimast.KindTemplateMiddle:
-      // Entering a `${...}` substitution; account for its closing `}`.
-      templateBraceDepth = append(templateBraceDepth, 0)
-    case shimast.KindOpenBraceToken:
-      if n := len(templateBraceDepth); n > 0 {
-        templateBraceDepth[n-1]++
-      }
-    case shimast.KindCloseBraceToken:
-      n := len(templateBraceDepth)
-      if n == 0 {
-        continue
-      }
-      if templateBraceDepth[n-1] > 0 {
-        templateBraceDepth[n-1]--
-        continue
-      }
-      // Matching `}` for the original `${`. Pop the substitution and
-      // rescan as template; a `KindTemplateMiddle` reopens a new
-      // substitution, a `KindTemplateTail` closes the template literal.
-      templateBraceDepth = templateBraceDepth[:n-1]
-      rescanned := scanner.ReScanTemplateToken(false /*isTaggedTemplate*/)
-      if rescanned == shimast.KindTemplateMiddle {
-        templateBraceDepth = append(templateBraceDepth, 0)
-      }
     case shimast.KindSingleLineCommentTrivia, shimast.KindMultiLineCommentTrivia:
-      visit(kind, scanner.TokenStart(), scanner.TokenEnd())
+      visit(kind, from+scanner.TokenStart(), from+scanner.TokenEnd())
     }
   }
 }

--- a/packages/lint/linthost/comment_scan.go
+++ b/packages/lint/linthost/comment_scan.go
@@ -37,9 +37,10 @@ func forEachCommentToken(file *shimast.SourceFile, visit func(kind shimast.Kind,
     return
   }
   text := file.Text()
-  opaque := parserTokenSpans(file)
+  opaque := parserOpaqueTokenSpans(file)
   comments := make([]commentToken, 0)
   seen := make(map[sourceSpan]struct{})
+  gapScanner := shimscanner.NewScanner()
   collect := func(kind shimast.Kind, pos, end int) {
     if pos < 0 || end <= pos || end > len(text) {
       return
@@ -55,14 +56,14 @@ func forEachCommentToken(file *shimast.SourceFile, visit func(kind shimast.Kind,
   cursor := 0
   for _, span := range opaque {
     if cursor < span.pos {
-      scanCommentGap(text, cursor, span.pos, collect)
+      scanCommentGap(gapScanner, text, cursor, span.pos, collect)
     }
     if span.end > cursor {
       cursor = span.end
     }
   }
   if cursor < len(text) {
-    scanCommentGap(text, cursor, len(text), collect)
+    scanCommentGap(gapScanner, text, cursor, len(text), collect)
   }
 
   sort.Slice(comments, func(i, j int) bool {
@@ -76,18 +77,20 @@ func forEachCommentToken(file *shimast.SourceFile, visit func(kind shimast.Kind,
   }
 }
 
-// parserTokenSpans returns merged source ranges for every parser-owned token.
-// These are the lexical-goal boundaries a raw scanner cannot infer: string and
-// regex literals, template heads/middles/tails, and JSX text are all token
-// nodes, as are their TS/JS counterparts under the selected ScriptKind.
-func parserTokenSpans(file *shimast.SourceFile) []sourceSpan {
+// parserOpaqueTokenSpans returns merged source ranges for the parser-owned
+// tokens whose contents a context-free scanner cannot classify: strings,
+// regex literals, template heads/middles/tails, and JSX text. Numeric literals,
+// identifiers, keywords, and punctuation remain in the scanned gaps because
+// they cannot contain comment-shaped source bytes; keeping them there avoids a
+// scanner reset for every ordinary token.
+func parserOpaqueTokenSpans(file *shimast.SourceFile) []sourceSpan {
   spans := make([]sourceSpan, 0)
   var walk func(*shimast.Node)
   walk = func(node *shimast.Node) {
     if node == nil {
       return
     }
-    if node.Kind >= shimast.KindFirstToken && node.Kind <= shimast.KindLastToken {
+    if parserOpaqueTokenKind(node.Kind) {
       pos := shimscanner.GetTokenPosOfNode(node, file, false /*includeJSDoc*/)
       if pos >= 0 && node.End() > pos && node.End() <= len(file.Text()) {
         spans = append(spans, sourceSpan{pos: pos, end: node.End()})
@@ -123,16 +126,20 @@ func parserTokenSpans(file *shimast.SourceFile) []sourceSpan {
   return merged
 }
 
+func parserOpaqueTokenKind(kind shimast.Kind) bool {
+  return kind >= shimast.KindStringLiteral && kind <= shimast.KindLastLiteralToken ||
+    kind >= shimast.KindFirstTemplateToken && kind <= shimast.KindLastTemplateToken
+}
+
 // scanCommentGap scans one parser-classified non-token gap. Context-sensitive
 // token bodies never enter this function, so every comment trivia token it
 // returns is a real source comment. Scanning the isolated gap also preserves
 // CRLF and Unicode line-terminator behavior without range arithmetic in a
 // second comment parser.
-func scanCommentGap(text string, from, to int, visit func(kind shimast.Kind, pos, end int)) {
-  if from < 0 || to <= from || to > len(text) {
+func scanCommentGap(scanner *shimscanner.Scanner, text string, from, to int, visit func(kind shimast.Kind, pos, end int)) {
+  if scanner == nil || from < 0 || to <= from || to > len(text) {
     return
   }
-  scanner := shimscanner.NewScanner()
   scanner.SetText(text[from:to])
   scanner.SetSkipTrivia(false)
   for {

--- a/packages/lint/linthost/directives.go
+++ b/packages/lint/linthost/directives.go
@@ -105,8 +105,8 @@ func filterInlineDisabledFindingsWithDirectives(file *shimast.SourceFile, findin
   return filtered
 }
 
-// parseLintInlineDirectives scans all comment tokens in `file` (via the
-// shared `forEachCommentToken` raw-scanner loop) for recognized directive
+// parseLintInlineDirectives scans all parser-classified comment tokens in
+// `file` (via the shared `forEachCommentToken` loop) for recognized directive
 // markers and returns a structured summary of the per-line and range-style
 // suppressions found.
 func parseLintInlineDirectives(file *shimast.SourceFile) *lintInlineDirectives {
@@ -124,7 +124,7 @@ func parseLintInlineDirectives(file *shimast.SourceFile) *lintInlineDirectives {
   if !strings.Contains(text, "-disable") && !strings.Contains(text, "-enable") {
     return directives
   }
-  forEachCommentToken(text, func(_ shimast.Kind, start, end int) {
+  forEachCommentToken(file, func(_ shimast.Kind, start, end int) {
     directive, ok := parseLintDirectiveComment(text[start:end])
     if !ok {
       return

--- a/packages/lint/linthost/rules_ban_ts_comment.go
+++ b/packages/lint/linthost/rules_ban_ts_comment.go
@@ -2,7 +2,8 @@
 // ban-ts-comment rule, including its recommended defaults, per-directive
 // options, description thresholds, and description-format matching.
 //
-// The rule scans every comment token itself (via forEachCommentToken)
+// The rule scans every parser-classified comment token (via
+// forEachCommentToken)
 // instead of reading `SourceFile.CommentDirectives`: the compiler-side
 // list only carries the error-suppression directives (`@ts-expect-error`,
 // `@ts-ignore`) and would miss `@ts-nocheck` / `@ts-check` entirely.
@@ -240,7 +241,7 @@ func (banTsComment) Check(ctx *Context, node *shimast.Node) {
     firstStatementLine = shimscanner.GetECMALineOfPosition(ctx.File, pos)
   }
 
-  forEachCommentToken(text, func(kind shimast.Kind, pos, end int) {
+  forEachCommentToken(ctx.File, func(kind shimast.Kind, pos, end int) {
     matched := findTsDirectiveInComment(kind, text[pos:end])
     if matched == nil {
       return

--- a/packages/lint/linthost/rules_ts_switch_exhaustiveness_check.go
+++ b/packages/lint/linthost/rules_ts_switch_exhaustiveness_check.go
@@ -569,10 +569,13 @@ func switchExhaustivenessCheckCommentDefaultCase(
   candidateKind := shimast.KindUnknown
   candidatePos := -1
   candidateEnd := -1
-  forEachCommentToken(text[from:to], func(kind shimast.Kind, pos, end int) {
+  forEachCommentToken(ctx.File, func(kind shimast.Kind, pos, end int) {
+    if pos < from || end > to {
+      return
+    }
     candidateKind = kind
-    candidatePos = from + pos
-    candidateEnd = from + end
+    candidatePos = pos
+    candidateEnd = end
   })
   if candidatePos < 0 || candidateEnd <= candidatePos {
     return nil

--- a/packages/lint/linthost/rules_ts_switch_exhaustiveness_check.go
+++ b/packages/lint/linthost/rules_ts_switch_exhaustiveness_check.go
@@ -573,7 +573,7 @@ func switchExhaustivenessCheckCommentDefaultCase(
   // last clause and ends before the case block's closing-brace token. Scan the
   // bounded gap directly so a file with many switches does not re-enumerate
   // the whole AST for every switch node.
-  scanCommentGap(text, from, to, func(kind shimast.Kind, pos, end int) {
+  scanCommentGap(shimscanner.NewScanner(), text, from, to, func(kind shimast.Kind, pos, end int) {
     candidateKind = kind
     candidatePos = pos
     candidateEnd = end

--- a/packages/lint/linthost/rules_ts_switch_exhaustiveness_check.go
+++ b/packages/lint/linthost/rules_ts_switch_exhaustiveness_check.go
@@ -569,10 +569,11 @@ func switchExhaustivenessCheckCommentDefaultCase(
   candidateKind := shimast.KindUnknown
   candidatePos := -1
   candidateEnd := -1
-  forEachCommentToken(ctx.File, func(kind shimast.Kind, pos, end int) {
-    if pos < from || end > to {
-      return
-    }
+  // `from:to` is itself a parser-classified trivia gap: it begins after the
+  // last clause and ends before the case block's closing-brace token. Scan the
+  // bounded gap directly so a file with many switches does not re-enumerate
+  // the whole AST for every switch node.
+  scanCommentGap(text, from, to, func(kind shimast.Kind, pos, end int) {
     candidateKind = kind
     candidatePos = pos
     candidateEnd = end

--- a/packages/lint/test/command/command_check_uses_parser_context_for_comment_consumers_test.go
+++ b/packages/lint/test/command/command_check_uses_parser_context_for_comment_consumers_test.go
@@ -1,0 +1,55 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestCommandCheckUsesParserContextForCommentConsumers verifies the check
+// front door shares parser-aware comments across ban and inline-disable paths.
+//
+// Comment-shaped JSX text must not suppress a diagnostic, a real JSX
+// expression comment must suppress its next line, and regex braces inside a
+// nested template must not hide a later TypeScript directive. Exercising the
+// project command locks parser, engine, filter, and renderer integration.
+//
+//  1. Materialize a TSX project with fake and real JSX disable markers.
+//  2. Follow nested template regexes with one genuine `@ts-ignore` comment.
+//  3. Assert exact command diagnostics for the unsuppressed debugger and directive.
+func TestCommandCheckUsesParserContextForCommentConsumers(t *testing.T) {
+  source := "declare namespace JSX { interface IntrinsicElements { div: any; } }\n" +
+    "const visible = <div>/* eslint-disable-next-line no-debugger */</div>;\n" +
+    "debugger;\n" +
+    "const active = <div>{/* eslint-disable-next-line no-debugger */}</div>;\n" +
+    "debugger;\n" +
+    "const value = `${`${1}`} ${/[}]/.test(\"}\")} ${/a\\/b/.test(\"a/b\")} ${/[{]/.test(\"{\")}`;\n" +
+    "// @ts-ignore\n" +
+    "const answer: number = 1;\n" +
+    "JSON.stringify([visible, active, value, answer]);\n"
+  root := seedLintProjectFile(t, "main.tsx", source)
+  seedLintRules(t, root, map[string]string{
+    "no-debugger": "error",
+    "typescript/ban-ts-comment": "error",
+  })
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "check",
+      "--cwd", root,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  if code != 2 || stdout != "" {
+    t.Fatalf("check result mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  if got := strings.Count(stderr, "[no-debugger]"); got != 1 {
+    t.Fatalf("want 1 no-debugger diagnostic, got %d: %s", got, stderr)
+  }
+  if got := strings.Count(stderr, "[typescript/ban-ts-comment]"); got != 1 {
+    t.Fatalf("want 1 ban-ts-comment diagnostic, got %d: %s", got, stderr)
+  }
+  if !diagnosticOutputContains(stderr, "main.tsx:3:1") ||
+    !diagnosticOutputContains(stderr, "main.tsx:7:1") ||
+    diagnosticOutputContains(stderr, "main.tsx:5:1") {
+    t.Fatalf("unexpected parser-context diagnostic ranges: %s", stderr)
+  }
+}

--- a/packages/lint/test/command/command_check_uses_parser_context_for_comment_consumers_test.go
+++ b/packages/lint/test/command/command_check_uses_parser_context_for_comment_consumers_test.go
@@ -8,17 +8,18 @@ import (
 // TestCommandCheckUsesParserContextForCommentConsumers verifies the check
 // front door shares parser-aware comments across ban and inline-disable paths.
 //
-// Comment-shaped JSX text must not suppress a diagnostic, a real JSX
-// expression comment must suppress its next line, and regex braces inside a
-// nested template must not hide a later TypeScript directive. Exercising the
-// project command locks parser, engine, filter, and renderer integration.
+// Comment-shaped JSX text must neither suppress a diagnostic nor fabricate a
+// banned TypeScript directive, a real JSX expression comment must suppress its
+// next line, and regex braces inside a nested template must not hide a later
+// TypeScript directive. Exercising the project command locks parser, engine,
+// filter, and renderer integration.
 //
-//  1. Materialize a TSX project with fake and real JSX disable markers.
+//  1. Materialize a TSX project with fake lint and TypeScript markers in JSX text.
 //  2. Follow nested template regexes with one genuine `@ts-ignore` comment.
 //  3. Assert exact command diagnostics for the unsuppressed debugger and directive.
 func TestCommandCheckUsesParserContextForCommentConsumers(t *testing.T) {
   source := "declare namespace JSX { interface IntrinsicElements { div: any; } }\n" +
-    "const visible = <div>/* eslint-disable-next-line no-debugger */</div>;\n" +
+    "const visible = <div>/* eslint-disable-next-line no-debugger *//* @ts-ignore */</div>;\n" +
     "debugger;\n" +
     "const active = <div>{/* eslint-disable-next-line no-debugger */}</div>;\n" +
     "debugger;\n" +

--- a/packages/lint/test/engine/engine_ignores_jsx_text_inline_disable_markers_test.go
+++ b/packages/lint/test/engine/engine_ignores_jsx_text_inline_disable_markers_test.go
@@ -1,0 +1,32 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestEngineIgnoresJsxTextInlineDisableMarkers verifies JSX text cannot create
+// an inline lint directive while an expression-container comment still can.
+//
+// JSX text has a parser-owned lexical goal in which slash-shaped bytes are
+// ordinary text. Treating those bytes as a block comment silently suppressed a
+// real diagnostic, whereas `{/* ... */}` is genuine JavaScript comment trivia.
+//
+//  1. Put a disable-next-line-shaped string directly in JSX text before `debugger`.
+//  2. Put the same marker in a JSX expression comment before another `debugger`.
+//  3. Assert only the first statement is reported at its exact source range.
+func TestEngineIgnoresJsxTextInlineDisableMarkers(t *testing.T) {
+  const ruleName = "no-debugger"
+  source := "const visible = <div>/* eslint-disable-next-line no-debugger */</div>;\ndebugger;\nconst active = <div>{/* eslint-disable-next-line no-debugger */}</div>;\ndebugger;\nJSON.stringify([visible, active]);\n"
+  file := parseTSXFile(t, "/virtual/test.tsx", source)
+  findings := NewEngine(RuleConfig{ruleName: SeverityError}).Run([]*shimast.SourceFile{file}, nil)
+  if len(findings) != 1 {
+    t.Fatalf("want 1 finding, got %d (%+v)", len(findings), findings)
+  }
+  start := strings.Index(source, "debugger;")
+  if findings[0].Pos != start || findings[0].End != start+len("debugger") {
+    t.Fatalf("want first debugger range [%d,%d), got [%d,%d)", start, start+len("debugger"), findings[0].Pos, findings[0].End)
+  }
+}

--- a/packages/lint/test/engine/engine_ignores_jsx_text_inline_disable_markers_test.go
+++ b/packages/lint/test/engine/engine_ignores_jsx_text_inline_disable_markers_test.go
@@ -26,7 +26,8 @@ func TestEngineIgnoresJsxTextInlineDisableMarkers(t *testing.T) {
     t.Fatalf("want 1 finding, got %d (%+v)", len(findings), findings)
   }
   start := strings.Index(source, "debugger;")
-  if findings[0].Pos != start || findings[0].End != start+len("debugger") {
-    t.Fatalf("want first debugger range [%d,%d), got [%d,%d)", start, start+len("debugger"), findings[0].Pos, findings[0].End)
+  end := start + len("debugger;")
+  if findings[0].Pos != start || findings[0].End != end {
+    t.Fatalf("want first debugger range [%d,%d), got [%d,%d)", start, end, findings[0].Pos, findings[0].End)
   }
 }

--- a/packages/lint/test/engine/engine_ignores_jsx_text_inline_disable_markers_test.go
+++ b/packages/lint/test/engine/engine_ignores_jsx_text_inline_disable_markers_test.go
@@ -8,26 +8,39 @@ import (
 )
 
 // TestEngineIgnoresJsxTextInlineDisableMarkers verifies JSX text cannot create
-// an inline lint directive while an expression-container comment still can.
+// or close an inline lint range while expression-container comments still can.
 //
 // JSX text has a parser-owned lexical goal in which slash-shaped bytes are
 // ordinary text. Treating those bytes as a block comment silently suppressed a
 // real diagnostic, whereas `{/* ... */}` is genuine JavaScript comment trivia.
 //
-//  1. Put a disable-next-line-shaped string directly in JSX text before `debugger`.
-//  2. Put the same marker in a JSX expression comment before another `debugger`.
-//  3. Assert only the first statement is reported at its exact source range.
+//  1. Put fake and real range-disable markers before separate `debugger` statements.
+//  2. Put fake and real range-enable markers around two more statements.
+//  3. Assert only the statements outside the genuine range are reported exactly.
 func TestEngineIgnoresJsxTextInlineDisableMarkers(t *testing.T) {
   const ruleName = "no-debugger"
-  source := "const visible = <div>/* eslint-disable-next-line no-debugger */</div>;\ndebugger;\nconst active = <div>{/* eslint-disable-next-line no-debugger */}</div>;\ndebugger;\nJSON.stringify([visible, active]);\n"
+  source := "const fakeDisable = <div>/* eslint-disable no-debugger */</div>;\n" +
+    "debugger;\n" +
+    "const realDisable = <div>{/* eslint-disable no-debugger */}</div>;\n" +
+    "debugger;\n" +
+    "const fakeEnable = <div>/* eslint-enable no-debugger */</div>;\n" +
+    "debugger;\n" +
+    "const realEnable = <div>{/* eslint-enable no-debugger */}</div>;\n" +
+    "debugger;\n" +
+    "JSON.stringify([fakeDisable, realDisable, fakeEnable, realEnable]);\n"
   file := parseTSXFile(t, "/virtual/test.tsx", source)
   findings := NewEngine(RuleConfig{ruleName: SeverityError}).Run([]*shimast.SourceFile{file}, nil)
-  if len(findings) != 1 {
-    t.Fatalf("want 1 finding, got %d (%+v)", len(findings), findings)
+  if len(findings) != 2 {
+    t.Fatalf("want 2 findings, got %d (%+v)", len(findings), findings)
   }
-  start := strings.Index(source, "debugger;")
-  end := start + len("debugger;")
-  if findings[0].Pos != start || findings[0].End != end {
-    t.Fatalf("want first debugger range [%d,%d), got [%d,%d)", start, end, findings[0].Pos, findings[0].End)
+  starts := []int{
+    strings.Index(source, "debugger;"),
+    strings.LastIndex(source, "debugger;"),
+  }
+  for i, start := range starts {
+    end := start + len("debugger;")
+    if findings[i].Pos != start || findings[i].End != end {
+      t.Fatalf("finding %d: want debugger range [%d,%d), got [%d,%d)", i, start, end, findings[i].Pos, findings[i].End)
+    }
   }
 }

--- a/packages/lint/test/rules/comments-directives/ban_ts_comment_follows_regex_in_nested_template_test.go
+++ b/packages/lint/test/rules/comments-directives/ban_ts_comment_follows_regex_in_nested_template_test.go
@@ -1,0 +1,34 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestBanTsCommentFollowsRegexInNestedTemplate verifies a real directive after
+// nested template substitutions remains visible when a regex contains braces.
+//
+// The parser assigns the regular-expression lexical goal, so braces and an
+// escaped slash inside the literal cannot alter template-substitution state in
+// the shared comment enumerator. A context-free scanner used to lose the real
+// trailing directive after interpreting the regex brace as JavaScript syntax.
+//
+//  1. Parse nested substitutions containing brace, character-class, and slash regexes.
+//  2. Place a genuine `@ts-ignore` comment after the completed template.
+//  3. Assert the ban diagnostic covers exactly that comment and no literal bytes.
+func TestBanTsCommentFollowsRegexInNestedTemplate(t *testing.T) {
+  const ruleName = "typescript/ban-ts-comment"
+  source := "const value = `${`${1}`} ${/[}]/.test(\"}\")} ${/a\\/b/.test(\"a/b\")} ${/[{]/.test(\"{\")}`;\n// @ts-ignore\nconst answer: number = 1;\nJSON.stringify([value, answer]);\n"
+  file := parseTS(t, source)
+  findings := NewEngine(RuleConfig{ruleName: SeverityError}).Run([]*shimast.SourceFile{file}, nil)
+  if len(findings) != 1 {
+    t.Fatalf("want 1 finding, got %d (%+v)", len(findings), findings)
+  }
+  start := strings.Index(source, "// @ts-ignore")
+  end := start + len("// @ts-ignore")
+  if findings[0].Pos != start || findings[0].End != end {
+    t.Fatalf("want exact range [%d,%d), got [%d,%d)", start, end, findings[0].Pos, findings[0].End)
+  }
+}

--- a/packages/lint/test/rules/typescript/switch_exhaustiveness_check_parser_comment_ranges_test.go
+++ b/packages/lint/test/rules/typescript/switch_exhaustiveness_check_parser_comment_ranges_test.go
@@ -5,10 +5,10 @@ import "testing"
 // TestSwitchExhaustivenessCheckParserCommentRanges verifies the real command
 // path recognizes only a trailing parser-classified default marker.
 //
-// The shared enumerator now scans a whole SourceFile and filters the switch's
-// eligible trailing range. A Unicode-separated real comment must suppress the
-// open-switch diagnostic, while identical bytes inside a template in the last
-// clause must not escape their parser-owned token span.
+// The switch's AST-bounded trailing trivia gap is scanned independently. A
+// Unicode-separated real comment must suppress the open-switch diagnostic,
+// while identical bytes inside a template in the last clause remain outside
+// that eligible gap.
 //
 //  1. Put a template-shaped marker in one open switch and expect a diagnostic.
 //  2. Put a U+2028-separated real marker after another switch's last clause.

--- a/packages/lint/test/rules/typescript/switch_exhaustiveness_check_parser_comment_ranges_test.go
+++ b/packages/lint/test/rules/typescript/switch_exhaustiveness_check_parser_comment_ranges_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import "testing"
+
+// TestSwitchExhaustivenessCheckParserCommentRanges verifies the real command
+// path recognizes only a trailing parser-classified default marker.
+//
+// The shared enumerator now scans a whole SourceFile and filters the switch's
+// eligible trailing range. A Unicode-separated real comment must suppress the
+// open-switch diagnostic, while identical bytes inside a template in the last
+// clause must not escape their parser-owned token span.
+//
+//  1. Put a template-shaped marker in one open switch and expect a diagnostic.
+//  2. Put a U+2028-separated real marker after another switch's last clause.
+//  3. Assert the negative twin reports once and the real marker suppresses.
+func TestSwitchExhaustivenessCheckParserCommentRanges(t *testing.T) {
+  assertSwitchExhaustivenessCheckForTest(t, `
+declare const value: string;
+switch (value) {
+  case "known":
+    `${"// No Default"}`;
+    break;
+}
+`, map[string]any{
+    "requireDefaultForNonUnion": true,
+  }, 1, map[string]int{"Cases not matched: default": 1})
+
+  assertSwitchExhaustivenessCheckForTest(t, "\ndeclare const value: string;\nswitch (value) {\n  case \"known\": break;\u2028// No Default\u2029}\n", map[string]any{
+    "requireDefaultForNonUnion": true,
+  }, 0, nil)
+}

--- a/packages/lint/test/rules/typescript/switch_exhaustiveness_check_parser_comment_ranges_test.go
+++ b/packages/lint/test/rules/typescript/switch_exhaustiveness_check_parser_comment_ranges_test.go
@@ -1,6 +1,9 @@
 package linthost
 
-import "testing"
+import (
+  "strings"
+  "testing"
+)
 
 // TestSwitchExhaustivenessCheckParserCommentRanges verifies the real command
 // path recognizes only a trailing parser-classified default marker.
@@ -25,7 +28,33 @@ switch (value) {
     "requireDefaultForNonUnion": true,
   }, 1, map[string]int{"Cases not matched: default": 1})
 
-  assertSwitchExhaustivenessCheckForTest(t, "\ndeclare const value: string;\nswitch (value) {\n  case \"known\": break;\u2028// No Default\u2029}\n", map[string]any{
+  markerSource := "\ndeclare const value: string;\nswitch (value) {\n  case \"known\": break;\u2028// No Default\u2029}\n"
+  assertSwitchExhaustivenessCheckForTest(t, markerSource, map[string]any{
     "requireDefaultForNonUnion": true,
   }, 0, nil)
+
+  file := parseTS(t, markerSource)
+  if file.Statements == nil || len(file.Statements.Nodes) != 2 {
+    t.Fatalf("want declaration and switch statements, got %+v", file.Statements)
+  }
+  switchNode := file.Statements.Nodes[1]
+  sw := switchNode.AsSwitchStatement()
+  if sw == nil || sw.CaseBlock == nil {
+    t.Fatalf("parser did not retain switch case block: %+v", switchNode)
+  }
+  block := sw.CaseBlock.AsCaseBlock()
+  if block == nil || block.Clauses == nil || len(block.Clauses.Nodes) != 1 {
+    t.Fatalf("parser did not retain the switch clause: %+v", sw.CaseBlock)
+  }
+  marker := switchExhaustivenessCheckCommentDefaultCase(
+    &Context{File: file},
+    sw.CaseBlock,
+    block.Clauses.Nodes[0],
+    switchExhaustivenessCheckDefaultCommentPattern,
+  )
+  start := strings.Index(markerSource, "// No Default")
+  end := start + len("// No Default")
+  if marker == nil || marker.pos != start || marker.end != end {
+    t.Fatalf("want exact marker range [%d,%d), got %+v", start, end, marker)
+  }
 }

--- a/packages/lint/test/rules/typescript/switch_exhaustiveness_check_parser_comment_ranges_test.go
+++ b/packages/lint/test/rules/typescript/switch_exhaustiveness_check_parser_comment_ranges_test.go
@@ -17,14 +17,13 @@ import (
 //  2. Put a U+2028-separated real marker after another switch's last clause.
 //  3. Assert the negative twin reports once and the real marker suppresses.
 func TestSwitchExhaustivenessCheckParserCommentRanges(t *testing.T) {
-  assertSwitchExhaustivenessCheckForTest(t, `
-declare const value: string;
-switch (value) {
-  case "known":
-    `${"// No Default"}`;
-    break;
-}
-`, map[string]any{
+  templateSource := "\ndeclare const value: string;\n" +
+    "switch (value) {\n" +
+    "  case \"known\":\n" +
+    "    `${\"// No Default\"}`;\n" +
+    "    break;\n" +
+    "}\n"
+  assertSwitchExhaustivenessCheckForTest(t, templateSource, map[string]any{
     "requireDefaultForNonUnion": true,
   }, 1, map[string]int{"Cases not matched: default": 1})
 

--- a/packages/lint/test/shared/comment_scan_handles_malformed_parser_recovery_test.go
+++ b/packages/lint/test/shared/comment_scan_handles_malformed_parser_recovery_test.go
@@ -1,0 +1,54 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimcore "github.com/microsoft/typescript-go/shim/core"
+  shimparser "github.com/microsoft/typescript-go/shim/parser"
+)
+
+// TestCommentScanHandlesMalformedParserRecovery verifies incomplete source is
+// enumerated without panic or comment-like literal leakage.
+//
+// Editors lint parser-recovery trees continuously. Unterminated templates and
+// JSX elements still expose real expression comments, but their raw template
+// and JSX text remain parser-classified token spans even when closing syntax is
+// absent.
+//
+//  1. Parse an unterminated template with one real substitution comment.
+//  2. Parse an unclosed JSX element with text and expression comment twins.
+//  3. Assert only the real leading and expression comments are enumerated.
+func TestCommentScanHandlesMalformedParserRecovery(t *testing.T) {
+  cases := []struct {
+    name     string
+    fileName string
+    kind     shimcore.ScriptKind
+    source   string
+    comments []string
+  }{
+    {
+      name: "template",
+      fileName: "/virtual/broken.ts",
+      kind: shimcore.ScriptKindTS,
+      source: "/* leading-real */\nconst broken = `// fake-template ${/[{]/.test(\"{\") /* expression-real */}\n// fake-tail",
+      comments: []string{"/* leading-real */", "/* expression-real */"},
+    },
+    {
+      name: "jsx",
+      fileName: "/virtual/broken.tsx",
+      kind: shimcore.ScriptKindTSX,
+      source: "/* leading-real */\nconst view = <div>/* fake-jsx */{/* expression-real */}",
+      comments: []string{"/* leading-real */", "/* expression-real */"},
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      file := shimparser.ParseSourceFile(shimast.SourceFileParseOptions{FileName: test.fileName}, test.source, test.kind)
+      if file == nil {
+        t.Fatal("parser returned nil source file")
+      }
+      assertExactCommentTokens(t, file, test.source, test.comments)
+    })
+  }
+}

--- a/packages/lint/test/shared/comment_scan_uses_parser_lexical_ranges_across_source_modes_test.go
+++ b/packages/lint/test/shared/comment_scan_uses_parser_lexical_ranges_across_source_modes_test.go
@@ -1,0 +1,104 @@
+package linthost
+
+import (
+  "fmt"
+  "sort"
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimcore "github.com/microsoft/typescript-go/shim/core"
+  shimparser "github.com/microsoft/typescript-go/shim/parser"
+)
+
+// TestCommentScanUsesParserLexicalRangesAcrossSourceModes verifies exact,
+// deduplicated comment ranges under every TypeScript and JavaScript source mode.
+//
+// Regex, template, string, and JSX-text bodies are parser-owned tokens rather
+// than trivia. Real comments at file edges, in empty containers, in template
+// substitutions, and after division must remain visible across CRLF and Unicode
+// line terminators, while comment-shaped literal bytes remain invisible.
+//
+//  1. Parse equivalent TS/JS sources with nested templates, regexes, and division.
+//  2. Parse equivalent TSX/JSX sources with JSX text and expression comments.
+//  3. Assert every real comment's kind and exact range once, in source order.
+func TestCommentScanUsesParserLexicalRangesAcrossSourceModes(t *testing.T) {
+  scriptSource := "/* file-leading-real */\r\n" +
+    "const quoted = \"// fake-string\"; // trailing-real\r\n" +
+    "const divided = `${8 / 2 /* division-real */}`;\u2028" +
+    "const matched = `${/[{]/.test(\"{\") /* regex-real */}`;\u2029" +
+    "const nested = `/* fake-template */ ${`${1 /* nested-real */}`}`;\n" +
+    "const empty = { /* empty-object-real */ };\n" +
+    "function noop() { /* empty-block-real */ }\n" +
+    "/* file-trailing-real */"
+  scriptComments := []string{
+    "/* file-leading-real */",
+    "// trailing-real",
+    "/* division-real */",
+    "/* regex-real */",
+    "/* nested-real */",
+    "/* empty-object-real */",
+    "/* empty-block-real */",
+    "/* file-trailing-real */",
+  }
+  jsxSource := "/* jsx-leading-real */\n" +
+    "const view = <div>// fake-jsx-line\n/* fake-jsx-block */" +
+    "{/* jsx-expression-real */}<span title=\"// fake-attribute\">text</span></div>;\n" +
+    "// jsx-trailing-real"
+  jsxComments := []string{
+    "/* jsx-leading-real */",
+    "/* jsx-expression-real */",
+    "// jsx-trailing-real",
+  }
+
+  cases := []struct {
+    name       string
+    fileName   string
+    kind       shimcore.ScriptKind
+    source     string
+    comments   []string
+  }{
+    {name: "ts", fileName: "/virtual/comments.ts", kind: shimcore.ScriptKindTS, source: scriptSource, comments: scriptComments},
+    {name: "js", fileName: "/virtual/comments.js", kind: shimcore.ScriptKindJS, source: scriptSource, comments: scriptComments},
+    {name: "tsx", fileName: "/virtual/comments.tsx", kind: shimcore.ScriptKindTSX, source: jsxSource, comments: jsxComments},
+    {name: "jsx", fileName: "/virtual/comments.jsx", kind: shimcore.ScriptKindJSX, source: jsxSource, comments: jsxComments},
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      file := shimparser.ParseSourceFile(shimast.SourceFileParseOptions{FileName: test.fileName}, test.source, test.kind)
+      if file == nil {
+        t.Fatal("parser returned nil source file")
+      }
+      assertExactCommentTokens(t, file, test.source, test.comments)
+    })
+  }
+}
+
+func assertExactCommentTokens(t *testing.T, file *shimast.SourceFile, source string, expectedText []string) {
+  t.Helper()
+  expected := make([]commentToken, 0, len(expectedText))
+  for _, text := range expectedText {
+    pos := strings.Index(source, text)
+    if pos < 0 {
+      t.Fatalf("expected comment %q is absent from fixture", text)
+    }
+    kind := shimast.KindMultiLineCommentTrivia
+    if strings.HasPrefix(text, "//") {
+      kind = shimast.KindSingleLineCommentTrivia
+    }
+    expected = append(expected, commentToken{kind: kind, pos: pos, end: pos + len(text)})
+  }
+  sort.Slice(expected, func(i, j int) bool { return expected[i].pos < expected[j].pos })
+
+  actual := make([]commentToken, 0)
+  forEachCommentToken(file, func(kind shimast.Kind, pos, end int) {
+    actual = append(actual, commentToken{kind: kind, pos: pos, end: end})
+  })
+  if fmt.Sprint(actual) != fmt.Sprint(expected) {
+    actualText := make([]string, 0, len(actual))
+    for _, token := range actual {
+      actualText = append(actualText, source[token.pos:token.end])
+    }
+    t.Fatalf("want tokens %+v, got %+v (%q)", expected, actual, actualText)
+  }
+}

--- a/packages/lint/test/shared/comment_scan_uses_parser_lexical_ranges_across_source_modes_test.go
+++ b/packages/lint/test/shared/comment_scan_uses_parser_lexical_ranges_across_source_modes_test.go
@@ -1,7 +1,7 @@
 package linthost
 
 import (
-  "fmt"
+  "slices"
   "sort"
   "strings"
   "testing"
@@ -94,7 +94,7 @@ func assertExactCommentTokens(t *testing.T, file *shimast.SourceFile, source str
   forEachCommentToken(file, func(kind shimast.Kind, pos, end int) {
     actual = append(actual, commentToken{kind: kind, pos: pos, end: end})
   })
-  if fmt.Sprint(actual) != fmt.Sprint(expected) {
+  if !slices.Equal(actual, expected) {
     actualText := make([]string, 0, len(actual))
     for _, token := range actual {
       actualText = append(actualText, source[token.pos:token.end])


### PR DESCRIPTION
## Intent

Make every lint comment consumer respect TypeScript's parser-selected lexical goals so regex literals, templates, and JSX text cannot hide or fabricate directives.

Closes #453.

## Scope

- derive opaque lexical spans from parser-owned AST tokens
- enumerate and deduplicate exact comment trivia ranges only between those spans
- route inline disables, `typescript/ban-ts-comment`, and switch default-comment recognition through parser-classified ranges
- add TS/TSX/JS/JSX, nested-template regex, JSX-text, malformed-source, line-terminator, exact-range, and real command-path regression coverage

## Deferred

None.

## Test plan

- baseline reproduction: nested-template regex case loses the real trailing directive before this change
- baseline reproduction: JSX text falsely suppresses a real `no-debugger` finding before this change
- after three clean exhaustive review rounds, run the focused comment, directive, and switch command-path tests locally

Formatting was intentionally not run per maintainer instruction.