### PR TITLE
fix(lint): align async predicates with native array semantics

### DIFF
--- a/packages/lint/linthost/rules_ts_no_misused_promises.go
+++ b/packages/lint/linthost/rules_ts_no_misused_promises.go
@@ -115,11 +115,12 @@ func (noMisusedPromises) Check(ctx *Context, node *shimast.Node) {
   case shimast.KindBinaryExpression:
     noMisusedPromisesCheckBinary(ctx, node, options)
   case shimast.KindCallExpression, shimast.KindNewExpression:
+    var predicateArgument *shimast.Node
     if options.checksConditionals {
-      noMisusedPromisesCheckPredicate(ctx, node)
+      predicateArgument = noMisusedPromisesCheckPredicate(ctx, node)
     }
     if options.arguments {
-      noMisusedPromisesCheckArguments(ctx, node)
+      noMisusedPromisesCheckArguments(ctx, node, predicateArgument)
     }
   case shimast.KindSpreadAssignment:
     if options.checksSpreads {
@@ -334,22 +335,24 @@ func noMisusedPromisesIsAlwaysThenable(checker *shimchecker.Checker, node *shima
   return true
 }
 
-func noMisusedPromisesCheckPredicate(ctx *Context, node *shimast.Node) {
+func noMisusedPromisesCheckPredicate(ctx *Context, node *shimast.Node) *shimast.Node {
   if node.Kind != shimast.KindCallExpression {
-    return
+    return nil
   }
   call := node.AsCallExpression()
   if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
-    return
+    return nil
   }
-  receiver, method, ok := promisePropertyAccessParts(call.Expression)
-  if !ok || !noMisusedPromisesIsArrayPredicate(method) || !noMisusedPromisesIsArrayLike(ctx.Checker, receiver) {
-    return
+  receiver, method, ok := noMisusedPromisesStaticMemberParts(call.Expression)
+  if !ok || !noMisusedPromisesIsArrayPredicate(method) || !noMisusedPromisesHasNativeArrayReceiver(ctx.Checker, receiver) {
+    return nil
   }
   callback := call.Arguments.Nodes[0]
   if noMisusedPromisesReturnsThenable(ctx.Checker, callback) {
     ctx.Report(callback, "Expected a non-Promise value to be returned from this predicate.")
+    return callback
   }
+  return nil
 }
 
 func noMisusedPromisesIsArrayPredicate(method string) bool {
@@ -360,26 +363,85 @@ func noMisusedPromisesIsArrayPredicate(method string) bool {
   return false
 }
 
-func noMisusedPromisesIsArrayLike(checker *shimchecker.Checker, node *shimast.Node) bool {
+func noMisusedPromisesStaticMemberParts(node *shimast.Node) (*shimast.Node, string, bool) {
+  node = stripParens(node)
+  if node == nil {
+    return nil, "", false
+  }
+  switch node.Kind {
+  case shimast.KindPropertyAccessExpression:
+    access := node.AsPropertyAccessExpression()
+    if access == nil {
+      return nil, "", false
+    }
+    method := identifierText(access.Name())
+    return access.Expression, method, method != ""
+  case shimast.KindElementAccessExpression:
+    access := node.AsElementAccessExpression()
+    if access == nil || access.ArgumentExpression == nil {
+      return nil, "", false
+    }
+    switch access.ArgumentExpression.Kind {
+    case shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral:
+      method := stringLiteralText(access.ArgumentExpression)
+      return access.Expression, method, method != ""
+    }
+  }
+  return nil, "", false
+}
+
+func noMisusedPromisesHasNativeArrayReceiver(checker *shimchecker.Checker, node *shimast.Node) bool {
   if checker == nil || node == nil {
     return false
   }
-  valueType := checker.GetApparentType(checker.GetTypeAtLocation(node))
-  for _, part := range promiseUnionParts(valueType) {
-    if part != nil && checker.IsArrayLikeType(part) {
-      return true
-    }
-  }
-  return false
+  return noMisusedPromisesTypeHasNativeArray(
+    checker,
+    checker.GetTypeAtLocation(node),
+    map[*shimchecker.Type]struct{}{},
+  )
 }
 
-func noMisusedPromisesCheckArguments(ctx *Context, node *shimast.Node) {
+func noMisusedPromisesTypeHasNativeArray(
+  checker *shimchecker.Checker,
+  valueType *shimchecker.Type,
+  seen map[*shimchecker.Type]struct{},
+) bool {
+  if checker == nil || valueType == nil {
+    return false
+  }
+  if _, ok := seen[valueType]; ok {
+    return false
+  }
+  seen[valueType] = struct{}{}
+  defer delete(seen, valueType)
+
+  flags := valueType.Flags()
+  if flags&shimchecker.TypeFlagsTypeParameter != 0 {
+    constraint := checker.GetBaseConstraintOfType(valueType)
+    return constraint != nil && constraint != valueType &&
+      noMisusedPromisesTypeHasNativeArray(checker, constraint, seen)
+  }
+  if flags&(shimchecker.TypeFlagsUnion|shimchecker.TypeFlagsIntersection) != 0 {
+    for _, part := range valueType.Types() {
+      if noMisusedPromisesTypeHasNativeArray(checker, part, seen) {
+        return true
+      }
+    }
+    return false
+  }
+  return shimchecker.Checker_isArrayType(checker, valueType) || shimchecker.IsTupleType(valueType)
+}
+
+func noMisusedPromisesCheckArguments(ctx *Context, node, predicateArgument *shimast.Node) {
   expression, arguments, signatureKind := noMisusedPromisesCallParts(node)
   if expression == nil || len(arguments) == 0 || noMisusedPromisesIsPromiseFinally(ctx.Checker, node, expression) {
     return
   }
   calleeType := ctx.Checker.GetApparentType(ctx.Checker.GetTypeAtLocation(expression))
   for index, argument := range arguments {
+    if argument == predicateArgument {
+      continue
+    }
     acceptsThenable := false
     acceptsVoid := false
     classify := func(target *shimchecker.Type) {

--- a/packages/lint/linthost/rules_ts_no_misused_promises.go
+++ b/packages/lint/linthost/rules_ts_no_misused_promises.go
@@ -381,9 +381,13 @@ func noMisusedPromisesStaticMemberParts(node *shimast.Node) (*shimast.Node, stri
     if access == nil || access.ArgumentExpression == nil {
       return nil, "", false
     }
-    switch access.ArgumentExpression.Kind {
+    argument := stripParens(access.ArgumentExpression)
+    if argument == nil {
+      return nil, "", false
+    }
+    switch argument.Kind {
     case shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral:
-      method := stringLiteralText(access.ArgumentExpression)
+      method := stringLiteralText(argument)
       return access.Expression, method, method != ""
     }
   }

--- a/packages/lint/test/rules/typescript/no_misused_promises_native_array_predicates_test.go
+++ b/packages/lint/test/rules/typescript/no_misused_promises_native_array_predicates_test.go
@@ -44,10 +44,21 @@ interface PromiseAwareArrayLike<T> {
 declare const promiseAware: PromiseAwareArrayLike<number>;
 promiseAware.filter(async value => value > 0);
 
-type PromiseAwareReadonlyShape<T> = Omit<ReadonlyArray<T>, "filter"> & {
-  filter(predicate: (value: T) => Promise<boolean>): Promise<readonly T[]>;
-};
-declare const promiseAwareReadonly: PromiseAwareReadonlyShape<number>;
+interface PromiseAwareReadonlyArray<T> extends ReadonlyArray<T> {
+  filter<S extends T>(
+    predicate: (value: T, index: number, array: readonly T[]) => value is S,
+    thisArg?: any,
+  ): S[];
+  filter(
+    predicate: (value: T, index: number, array: readonly T[]) => unknown,
+    thisArg?: any,
+  ): T[];
+  filter(
+    predicate: (value: T, index: number, array: readonly T[]) => Promise<boolean>,
+    thisArg?: any,
+  ): Promise<readonly T[]>;
+}
+declare const promiseAwareReadonly: PromiseAwareReadonlyArray<number>;
 promiseAwareReadonly.filter(async value => value > 0);
 
 declare const union: number[] | readonly number[];

--- a/packages/lint/test/rules/typescript/no_misused_promises_native_array_predicates_test.go
+++ b/packages/lint/test/rules/typescript/no_misused_promises_native_array_predicates_test.go
@@ -1,0 +1,67 @@
+package linthost
+
+import "testing"
+
+// TestNoMisusedPromisesNativeArrayPredicates pins the upstream native-array
+// boundary independently from structurally array-like user APIs.
+//
+//  1. Cover dot, static computed, template, and optional access on mutable,
+//     readonly, tuple, union, intersection, and constrained receivers.
+//  2. Keep dynamic keys and Promise-aware numeric-indexed APIs clean.
+//  3. Require one diagnostic when predicate and void-argument analysis overlap.
+func TestNoMisusedPromisesNativeArrayPredicates(t *testing.T) {
+  assertNoMisusedPromisesCase(t, "main.ts", `const mutable = [1, 2, 3];
+declare const readonlyValues: readonly number[];
+declare const tuple: readonly [number, number];
+declare const maybeValues: number[] | undefined;
+
+// expect: typescript/no-misused-promises error
+mutable.filter(async value => value > 0);
+// expect: typescript/no-misused-promises error
+mutable["find"](async value => value > 0);
+// expect: typescript/no-misused-promises error
+mutable[`some`](async value => value > 0);
+// expect: typescript/no-misused-promises error
+mutable?.["every"](async value => value > 0);
+// expect: typescript/no-misused-promises error
+maybeValues?.findIndex(async value => value > 0);
+// expect: typescript/no-misused-promises error
+readonlyValues["findLast"](async value => value > 0);
+// expect: typescript/no-misused-promises error
+tuple.some(async value => value > 0);
+
+const dynamicMethod: "filter" = "filter";
+mutable[dynamicMethod](async value => value > 0);
+
+interface PromiseAwareArrayLike<T> {
+  readonly length: number;
+  readonly [index: number]: T;
+  filter(predicate: (value: T) => boolean): T[];
+  filter(predicate: (value: T) => Promise<boolean>): Promise<T[]>;
+}
+declare const promiseAware: PromiseAwareArrayLike<number>;
+promiseAware.filter(async value => value > 0);
+
+declare const union: number[] | readonly number[];
+// expect: typescript/no-misused-promises error
+union["filter"](async value => value > 0);
+
+declare const intersection: readonly number[] & { readonly marker: true };
+// expect: typescript/no-misused-promises error
+intersection.find(async value => value > 0);
+
+function checkConstrained<T extends readonly number[]>(values: T): void {
+  // expect: typescript/no-misused-promises error
+  values.every(async value => value > 0);
+}
+
+type ArrayWithVoidFilter = number[] & {
+  filter(predicate: (value: number) => void): number[];
+};
+declare const overlapping: ArrayWithVoidFilter;
+// expect: typescript/no-misused-promises error
+overlapping.filter(async value => { void value; });
+
+void [mutable, readonlyValues, tuple, maybeValues, promiseAware, union, intersection, checkConstrained, overlapping];
+`, nil)
+}

--- a/packages/lint/test/rules/typescript/no_misused_promises_native_array_predicates_test.go
+++ b/packages/lint/test/rules/typescript/no_misused_promises_native_array_predicates_test.go
@@ -22,6 +22,8 @@ mutable["find"](async value => value > 0);
 // expect: typescript/no-misused-promises error
 mutable[`some`](async value => value > 0);
 // expect: typescript/no-misused-promises error
+mutable[("filter")](async value => value > 0);
+// expect: typescript/no-misused-promises error
 mutable?.["every"](async value => value > 0);
 // expect: typescript/no-misused-promises error
 maybeValues?.findIndex(async value => value > 0);

--- a/packages/lint/test/rules/typescript/no_misused_promises_native_array_predicates_test.go
+++ b/packages/lint/test/rules/typescript/no_misused_promises_native_array_predicates_test.go
@@ -50,13 +50,13 @@ interface PromiseAwareReadonlyArray<T> extends ReadonlyArray<T> {
     thisArg?: any,
   ): S[];
   filter(
-    predicate: (value: T, index: number, array: readonly T[]) => unknown,
-    thisArg?: any,
-  ): T[];
-  filter(
     predicate: (value: T, index: number, array: readonly T[]) => Promise<boolean>,
     thisArg?: any,
   ): Promise<readonly T[]>;
+  filter(
+    predicate: (value: T, index: number, array: readonly T[]) => unknown,
+    thisArg?: any,
+  ): T[];
 }
 declare const promiseAwareReadonly: PromiseAwareReadonlyArray<number>;
 promiseAwareReadonly.filter(async value => value > 0);

--- a/packages/lint/test/rules/typescript/no_misused_promises_native_array_predicates_test.go
+++ b/packages/lint/test/rules/typescript/no_misused_promises_native_array_predicates_test.go
@@ -26,7 +26,7 @@ mutable?.["every"](async value => value > 0);
 // expect: typescript/no-misused-promises error
 maybeValues?.findIndex(async value => value > 0);
 // expect: typescript/no-misused-promises error
-readonlyValues["findLast"](async value => value > 0);
+readonlyValues["find"](async value => value > 0);
 // expect: typescript/no-misused-promises error
 tuple.some(async value => value > 0);
 
@@ -41,6 +41,12 @@ interface PromiseAwareArrayLike<T> {
 }
 declare const promiseAware: PromiseAwareArrayLike<number>;
 promiseAware.filter(async value => value > 0);
+
+type PromiseAwareReadonlyShape<T> = Omit<ReadonlyArray<T>, "filter"> & {
+  filter(predicate: (value: T) => Promise<boolean>): Promise<readonly T[]>;
+};
+declare const promiseAwareReadonly: PromiseAwareReadonlyShape<number>;
+promiseAwareReadonly.filter(async value => value > 0);
 
 declare const union: number[] | readonly number[];
 // expect: typescript/no-misused-promises error
@@ -62,6 +68,6 @@ declare const overlapping: ArrayWithVoidFilter;
 // expect: typescript/no-misused-promises error
 overlapping.filter(async value => { void value; });
 
-void [mutable, readonlyValues, tuple, maybeValues, promiseAware, union, intersection, checkConstrained, overlapping];
+void [mutable, readonlyValues, tuple, maybeValues, promiseAware, promiseAwareReadonly, union, intersection, checkConstrained, overlapping];
 `, nil)
 }

--- a/packages/lint/test/rules/typescript/no_misused_promises_native_array_predicates_test.go
+++ b/packages/lint/test/rules/typescript/no_misused_promises_native_array_predicates_test.go
@@ -20,7 +20,7 @@ mutable.filter(async value => value > 0);
 // expect: typescript/no-misused-promises error
 mutable["find"](async value => value > 0);
 // expect: typescript/no-misused-promises error
-mutable[`some`](async value => value > 0);
+mutable[`+"`some`"+`](async value => value > 0);
 // expect: typescript/no-misused-promises error
 mutable[("filter")](async value => value > 0);
 // expect: typescript/no-misused-promises error


### PR DESCRIPTION
## Summary
- recognize dot and statically computed native Array/tuple predicate calls
- follow constrained union and intersection constituents without treating structural ArrayLike APIs as native arrays
- suppress duplicate callback diagnostics when predicate and void-argument analysis overlap
- cover mutable, readonly, tuple, optional, dynamic, custom, union, intersection, generic, and overlap boundaries

## Validation
- implementation and shield tests committed
- exhaustive whole-change review rounds and focused local tests follow on the exact published HEAD
- formatter not run

Closes #447