### PR TITLE
fix(lint): derive Promise inputs from iterator yields

### DIFF
--- a/packages/lint/linthost/rules_promise.go
+++ b/packages/lint/linthost/rules_promise.go
@@ -573,10 +573,11 @@ func isIterablePromiseAggregatorInput(
   return true
 }
 
-// promiseIterableElementTypes extracts the value types exposed by a tuple,
-// array-like type, or generic Iterable reference. It intentionally returns all
-// tuple slots but only the first type argument of a general iterable, matching
-// the collection contract used by the native Promise aggregators.
+// promiseIterableElementTypes extracts the values produced by synchronous
+// iteration. Tuples retain slot-by-slot precision; every other iterable goes
+// through TypeScript-Go's checked `[Symbol.iterator]` traversal so a concrete
+// container's unrelated generic arguments are never mistaken for its yield
+// type.
 func promiseIterableElementTypes(checker *shimchecker.Checker, t *shimchecker.Type) []*shimchecker.Type {
   if checker == nil || t == nil {
     return nil
@@ -584,17 +585,8 @@ func promiseIterableElementTypes(checker *shimchecker.Checker, t *shimchecker.Ty
   if shimchecker.IsTupleType(t) {
     return checker.GetTypeArguments(t)
   }
-  if checker.IsArrayLikeType(t) {
-    if elementType := checker.GetNumberIndexType(t); elementType != nil {
-      return []*shimchecker.Type{elementType}
-    }
-    return nil
-  }
-  if t.ObjectFlags()&shimchecker.ObjectFlagsReference != 0 {
-    arguments := checker.GetTypeArguments(t)
-    if len(arguments) > 0 {
-      return arguments[:1]
-    }
+  if elementType := shimchecker.Checker_getSynchronousIterationYieldType(checker, t); elementType != nil {
+    return []*shimchecker.Type{elementType}
   }
   return nil
 }

--- a/packages/lint/src/structures/rules/ITtscLintTypeScriptRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintTypeScriptRules.ts
@@ -55,7 +55,8 @@ export interface ITtscLintTypeScriptRules {
    *
    * Also reject sync-only `for await...of` and `await using` constructs.
    *
-   * Type-aware. The Checker resolves Promise and well-known-symbol protocols.
+   * Type-aware. The Checker resolves Promise and well-known-symbol protocols,
+   * including each Promise aggregator input's synchronous iterator yield type.
    * Only the ordinary `await` finding is autofixable.
    *
    * @reference https://typescript-eslint.io/rules/await-thenable

--- a/packages/lint/test/rules/typescript/await_thenable_promise_aggregator_iteration_yields_allow_test.go
+++ b/packages/lint/test/rules/typescript/await_thenable_promise_aggregator_iteration_yields_allow_test.go
@@ -1,0 +1,44 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestAwaitThenablePromiseAggregatorIterationYieldsAllow verifies unrelated
+// container parameters do not create false positives when the checked iterator
+// protocol yields only Promises.
+//
+//  1. Seed generic, inherited, and structural iterables that yield Promise values.
+//  2. Instantiate the generic container with a non-Promise type argument and aggregate every value.
+//  3. Assert the real lint command remains clean.
+func TestAwaitThenablePromiseAggregatorIterationYieldsAllow(t *testing.T) {
+  root := seedLintProject(t, `class Box<T> implements Iterable<Promise<number>> {
+  *[Symbol.iterator](): Iterator<Promise<number>> {
+    yield Promise.resolve(1);
+  }
+}
+interface InheritedPromises extends Iterable<Promise<number>> {}
+interface StructuralPromises {
+  [Symbol.iterator](): Iterator<Promise<number>>;
+}
+declare const unrelatedParameter: Box<string>;
+declare const inheritedPromises: InheritedPromises;
+declare const structuralPromises: StructuralPromises;
+Promise.all(unrelatedParameter);
+Promise.allSettled(inheritedPromises);
+Promise.race(structuralPromises);
+`)
+  seedLintRules(t, root, map[string]string{"typescript/await-thenable": "error"})
+
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "check",
+      "--cwd", root,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  if code != 0 || stdout != "" || strings.Contains(stderr, "[typescript/await-thenable]") {
+    t.Fatalf("Promise-yielding custom iterables were reported: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}

--- a/packages/lint/test/rules/typescript/await_thenable_promise_aggregator_iteration_yields_report_test.go
+++ b/packages/lint/test/rules/typescript/await_thenable_promise_aggregator_iteration_yields_report_test.go
@@ -1,0 +1,58 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestAwaitThenablePromiseAggregatorIterationYieldsReport verifies custom
+// iterable diagnostics follow the instantiated iterator yield type instead of
+// a container's own generic arguments.
+//
+//  1. Seed generic, inherited, structural, and primitive-string iterables that yield non-Promise values.
+//  2. Pass each iterable to a native Promise aggregator.
+//  3. Assert exactly one diagnostic on every offending argument.
+func TestAwaitThenablePromiseAggregatorIterationYieldsReport(t *testing.T) {
+  root := seedLintProject(t, `class Box<T> implements Iterable<number> {
+  *[Symbol.iterator](): Iterator<number> {
+    yield 1;
+  }
+}
+interface InheritedNumbers extends Iterable<number> {}
+interface StructuralNumbers {
+  [Symbol.iterator](): Iterator<number>;
+}
+declare const promiseParameterized: Box<Promise<void>>;
+declare const inheritedNumbers: InheritedNumbers;
+declare const structuralNumbers: StructuralNumbers;
+declare const text: string;
+Promise.all(promiseParameterized);
+Promise.allSettled(inheritedNumbers);
+Promise.race(structuralNumbers);
+Promise.any(text);
+`)
+  seedLintRules(t, root, map[string]string{"typescript/await-thenable": "error"})
+
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "check",
+      "--cwd", root,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  if code != 2 || stdout != "" {
+    t.Fatalf("iteration-yield Promise aggregator run mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  const message = "Unexpected iterable of non-Promise (non-\"Thenable\") values passed to promise aggregator."
+  if got := strings.Count(stderr, "[typescript/await-thenable]"); got != 4 {
+    t.Fatalf("expected 4 await-thenable findings, got %d:\n%s", got, stderr)
+  }
+  if got := strings.Count(stderr, message); got != 4 {
+    t.Fatalf("expected the exact aggregator diagnostic 4 times, got %d:\n%s", got, stderr)
+  }
+  for _, anchor := range []string{"main.ts:14:", "main.ts:15:", "main.ts:16:", "main.ts:17:"} {
+    if !diagnosticOutputContains(stderr, anchor) {
+      t.Fatalf("missing iteration-yield finding at %s:\n%s", anchor, stderr)
+    }
+  }
+}

--- a/packages/ttsc/shim/checker/shim.go
+++ b/packages/ttsc/shim/checker/shim.go
@@ -200,6 +200,35 @@ func Checker_getPropertyNameForKnownSymbolName(recv *innerchecker.Checker, symbo
   return checkerGetPropertyNameForKnownSymbolName(recv, symbolName)
 }
 
+//go:linkname checkerGetIterationTypeOfIterable github.com/microsoft/typescript-go/internal/checker.(*Checker).getIterationTypeOfIterable
+func checkerGetIterationTypeOfIterable(
+  recv *innerchecker.Checker,
+  use innerchecker.IterationUse,
+  typeKind innerchecker.IterationTypeKind,
+  inputType *innerchecker.Type,
+  errorNode *innerast.Node,
+) *innerchecker.Type
+
+// Checker_getSynchronousIterationYieldType returns the value type produced by
+// inputType's checked `[Symbol.iterator]` protocol. It delegates to the same
+// TypeScript-Go traversal used for synchronous iteration, including inherited
+// and structural iterables, instantiated iterator returns, intersections, and
+// primitive strings. A nil result means the checker could not derive a valid
+// synchronous iteration type. Diagnostics are intentionally disabled because
+// callers use this as a type query after normal TypeScript checking.
+func Checker_getSynchronousIterationYieldType(recv *innerchecker.Checker, inputType *innerchecker.Type) *innerchecker.Type {
+  if recv == nil || inputType == nil {
+    return nil
+  }
+  return checkerGetIterationTypeOfIterable(
+    recv,
+    innerchecker.IterationUseElement,
+    innerchecker.IterationTypeKindYield,
+    inputType,
+    nil,
+  )
+}
+
 //go:linkname checkerGetAliasSymbolForTypeNode github.com/microsoft/typescript-go/internal/checker.(*Checker).getAliasSymbolForTypeNode
 func checkerGetAliasSymbolForTypeNode(recv *innerchecker.Checker, node *innerast.Node) *innerast.Symbol
 

--- a/website/src/content/docs/lint/rules/typescript.mdx
+++ b/website/src/content/docs/lint/rules/typescript.mdx
@@ -175,7 +175,7 @@ Reject `await` on operands that are not thenable, non-awaitable values passed to
 
 Type-aware.
 
-The Checker classifies awaitability as always, never, or uncertain; resolves aggregator receivers to the default-library `PromiseConstructor`; extracts array, tuple, and `Iterable` element types; and requires callable `[Symbol.asyncIterator]` and `[Symbol.asyncDispose]` members.
+The Checker classifies awaitability as always, never, or uncertain; resolves aggregator receivers to the default-library `PromiseConstructor`; derives custom iterable and primitive-string values from their synchronous iterator protocol while retaining tuple-slot precision; and requires callable `[Symbol.asyncIterator]` and `[Symbol.asyncDispose]` members.
 
 Protocol lookups resolve through unions (any callable async constituent is accepted), intersections, type aliases, inherited members, and generic constraints.
 


### PR DESCRIPTION
## Intent

Make typescript/await-thenable judge native Promise aggregator inputs by the values their checked synchronous iterator protocol produces, not by unrelated generic arguments on concrete container types.

## Scope

- expose a narrow TypeScript-Go checker shim query for synchronous iteration yield types;
- retain tuple slot precision while routing arrays, custom iterables, inherited and structural iterables, and strings through checker semantics;
- add real lint-command positive and negative twins for misleading container generics and protocol shapes;
- clarify the public rule documentation.

## Deferred

None.

## Test plan

- complete three sequential exhaustive whole-PR reviews at one exact HEAD;
- run the focused await-thenable Go command-path tests, including the existing array, tuple, direct Iterable, constraint, union, any/unknown, native identity, and malformed-input shields;
- run git diff --check.

Closes #450