### PR TITLE
fix(lint): accept UTF-8 BOM in VS Code formatter settings

### DIFF
--- a/packages/lint/linthost/format_editor_settings.go
+++ b/packages/lint/linthost/format_editor_settings.go
@@ -1,6 +1,7 @@
 package linthost
 
 import (
+  "bytes"
   "encoding/json"
   "errors"
   "os"
@@ -153,6 +154,7 @@ func loadNearestVSCodeSettings(startDir string) (map[string]any, bool) {
   for {
     candidate := filepath.Join(dir, ".vscode", "settings.json")
     if data, err := os.ReadFile(candidate); err == nil {
+      data = bytes.TrimPrefix(data, []byte{0xEF, 0xBB, 0xBF})
       var parsed map[string]any
       if json.Unmarshal(stripJSONC(data), &parsed) == nil {
         return parsed, true

--- a/packages/lint/test/format/editor_format_overrides_accepts_utf8_bom_test.go
+++ b/packages/lint/test/format/editor_format_overrides_accepts_utf8_bom_test.go
@@ -1,0 +1,142 @@
+package linthost
+
+import (
+  "os"
+  "path/filepath"
+  "reflect"
+  "testing"
+)
+
+// TestEditorFormatOverridesAcceptsUTF8BOM verifies VS Code formatter settings
+// saved with a leading UTF-8 BOM retain the same JSONC and formatting behavior
+// as settings saved without one.
+//
+// The loader previously passed the BOM through to encoding/json, which silently
+// discarded every editor override. These cases pin the document boundary,
+// malformed-input fallback, ancestor discovery, and command-level output.
+//
+//  1. Load BOM-prefixed JSONC and boundary cases through the real ancestor walk.
+//  2. Compare valid BOM and no-BOM settings while preserving an embedded BOM.
+//  3. Run the format command and assert the editor indentation reaches the file.
+func TestEditorFormatOverridesAcceptsUTF8BOM(t *testing.T) {
+  bom := []byte{0xEF, 0xBB, 0xBF}
+  writeSettings := func(t *testing.T, root string, body []byte) {
+    t.Helper()
+    location := filepath.Join(root, ".vscode", "settings.json")
+    if err := os.MkdirAll(filepath.Dir(location), 0o755); err != nil {
+      t.Fatalf("mkdir .vscode: %v", err)
+    }
+    if err := os.WriteFile(location, body, 0o644); err != nil {
+      t.Fatalf("write settings: %v", err)
+    }
+  }
+  withBOM := func(body string) []byte {
+    return append(append([]byte{}, bom...), []byte(body)...)
+  }
+
+  t.Run("JSONC from nearest ancestor", func(t *testing.T) {
+    root := t.TempDir()
+    nested := filepath.Join(root, "packages", "app", "src")
+    if err := os.MkdirAll(nested, 0o755); err != nil {
+      t.Fatalf("mkdir nested source: %v", err)
+    }
+    writeSettings(t, root, withBOM(`{
+  // VS Code permits comments and trailing commas.
+  "editor.tabSize": 4,
+  "editor.insertSpaces": false,
+  "files.eol": "\r\n",
+}`))
+
+    got := editorFormatOverrides(nested, "typescript")
+    want := map[string]any{
+      "tabWidth":  float64(4),
+      "useTabs":   true,
+      "endOfLine": "crlf",
+    }
+    if !reflect.DeepEqual(got, want) {
+      t.Fatalf("BOM JSONC overrides mismatch: want %#v, got %#v", want, got)
+    }
+  })
+
+  t.Run("minimal and no-BOM parity", func(t *testing.T) {
+    minimalRoot := t.TempDir()
+    writeSettings(t, minimalRoot, withBOM(`{}`))
+    minimal, ok := loadNearestVSCodeSettings(minimalRoot)
+    if !ok || len(minimal) != 0 {
+      t.Fatalf("BOM minimal object: want empty parsed object, got %#v, ok=%v", minimal, ok)
+    }
+
+    text := `{"editor.tabSize":3,"editor.insertSpaces":true}`
+    bomRoot := t.TempDir()
+    plainRoot := t.TempDir()
+    writeSettings(t, bomRoot, withBOM(text))
+    writeSettings(t, plainRoot, []byte(text))
+    bomOverrides := editorFormatOverrides(bomRoot, "typescript")
+    plainOverrides := editorFormatOverrides(plainRoot, "typescript")
+    if !reflect.DeepEqual(bomOverrides, plainOverrides) {
+      t.Fatalf("BOM parity mismatch: BOM %#v, plain %#v", bomOverrides, plainOverrides)
+    }
+  })
+
+  t.Run("embedded BOM remains data", func(t *testing.T) {
+    root := t.TempDir()
+    body := withBOM(`{"marker":"`)
+    body = append(body, bom...)
+    body = append(body, []byte(`"}`)...)
+    writeSettings(t, root, body)
+
+    settings, ok := loadNearestVSCodeSettings(root)
+    if !ok {
+      t.Fatal("settings with an embedded BOM should parse")
+    }
+    if got := settings["marker"]; got != "\uFEFF" {
+      t.Fatalf("embedded BOM: want %q, got %#v", "\uFEFF", got)
+    }
+  })
+
+  t.Run("malformed input still falls back", func(t *testing.T) {
+    for name, body := range map[string][]byte{
+      "BOM only":       append([]byte{}, bom...),
+      "malformed JSONC": withBOM(`{"editor.tabSize":}`),
+    } {
+      t.Run(name, func(t *testing.T) {
+        root := t.TempDir()
+        writeSettings(t, root, body)
+        if settings, ok := loadNearestVSCodeSettings(root); ok || settings != nil {
+          t.Fatalf("malformed settings: want nil, false; got %#v, %v", settings, ok)
+        }
+        if got := editorFormatOverrides(root, "typescript"); len(got) != 0 {
+          t.Fatalf("malformed settings should fall back to defaults, got %#v", got)
+        }
+      })
+    }
+  })
+
+  t.Run("format command uses BOM settings", func(t *testing.T) {
+    root := seedLintProject(t, "function f() {\nreturn 1;\n}\n")
+    writeSettings(t, root, withBOM(`{
+  // Exercise the same JSONC boundary through the command front door.
+  "editor.tabSize": 4,
+  "editor.insertSpaces": true,
+}`))
+
+    code, stdout, stderr := captureCommandOutput(t, func() int {
+      return run([]string{
+        "format",
+        "--cwd", root,
+        "--plugins-json", lintManifest(t),
+      })
+    })
+    if code != 0 || stdout != "" || stderr != "" {
+      t.Fatalf("format command mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+    }
+    output, err := os.ReadFile(filepath.Join(root, "src", "main.ts"))
+    if err != nil {
+      t.Fatalf("read formatted source: %v", err)
+    }
+    want := "function f() {\n    return 1;\n}\n"
+    if string(output) != want {
+      t.Fatalf("formatted output mismatch:\nwant %q\ngot  %q", want, string(output))
+    }
+  })
+}


### PR DESCRIPTION
## Summary

- accept a single leading UTF-8 BOM in the nearest `.vscode/settings.json`
- preserve existing JSONC comments, trailing commas, malformed-file fallback, and embedded BOM data
- cover ancestor discovery, BOM/no-BOM parity, malformed boundaries, and command-level formatted output

## Review

Three sequential exhaustive reviews completed cleanly on exact head `d3cd04bb27cb210fd2c4919fd35f98acbb80107b`. Each round re-reviewed the complete PR diff and adjacent loader, JSONC, CLI/LSP, cross-platform, data-integrity, test-hygiene, and compatibility risks.

## Testing

- `node scripts/test-go-lint.cjs` — pass (`ok github.com/samchon/ttsc/packages/lint/linthost 187.676s`)

Closes #505