### PR TITLE
fix(lint): make VS Code language override precedence deterministic

### DIFF
--- a/packages/lint/linthost/format_editor_settings.go
+++ b/packages/lint/linthost/format_editor_settings.go
@@ -207,7 +207,9 @@ func loadNearestVSCodeSettings(startDir string) (vscodeSettings, bool) {
 // decodeVSCodeSettings decodes the top-level JSON object without discarding
 // declaration order. encoding/json maps are intentionally unordered, while VS
 // Code merges matching combined language sections in the order they appear in
-// settings.json and applies the exact single-language section afterwards.
+// settings.json and applies the exact single-language section afterwards. A
+// repeated property keeps its first insertion position and final value, as it
+// does in VS Code's parsed settings object.
 func decodeVSCodeSettings(data []byte) (vscodeSettings, error) {
   decoder := json.NewDecoder(bytes.NewReader(data))
   token, err := decoder.Token()
@@ -218,7 +220,8 @@ func decodeVSCodeSettings(data []byte) (vscodeSettings, error) {
     return vscodeSettings{}, errors.New("VS Code settings must be a JSON object")
   }
 
-  settings := vscodeSettings{values: map[string]any{}}
+  orderedKeys := []string{}
+  values := map[string]any{}
   for decoder.More() {
     token, err := decoder.Token()
     if err != nil {
@@ -232,19 +235,10 @@ func decodeVSCodeSettings(data []byte) (vscodeSettings, error) {
     if err := decoder.Decode(&value); err != nil {
       return vscodeSettings{}, err
     }
-    identifiers, isLanguageSection := languageSectionIdentifiers(key)
-    if !isLanguageSection {
-      settings.values[key] = value
-      continue
+    if _, exists := values[key]; !exists {
+      orderedKeys = append(orderedKeys, key)
     }
-    section, ok := value.(map[string]any)
-    if !ok {
-      continue
-    }
-    settings.languageSections = append(settings.languageSections, vscodeLanguageSection{
-      identifiers: identifiers,
-      values:      section,
-    })
+    values[key] = value
   }
   token, err = decoder.Token()
   if err != nil {
@@ -258,6 +252,23 @@ func decodeVSCodeSettings(data []byte) (vscodeSettings, error) {
       return vscodeSettings{}, err
     }
     return vscodeSettings{}, errors.New("VS Code settings contain trailing JSON")
+  }
+  settings := vscodeSettings{values: map[string]any{}}
+  for _, key := range orderedKeys {
+    value := values[key]
+    identifiers, isLanguageSection := languageSectionIdentifiers(key)
+    if !isLanguageSection {
+      settings.values[key] = value
+      continue
+    }
+    section, ok := value.(map[string]any)
+    if !ok {
+      continue
+    }
+    settings.languageSections = append(settings.languageSections, vscodeLanguageSection{
+      identifiers: identifiers,
+      values:      section,
+    })
   }
   return settings, nil
 }

--- a/packages/lint/linthost/format_editor_settings.go
+++ b/packages/lint/linthost/format_editor_settings.go
@@ -115,7 +115,8 @@ func applyEditorSettings(out map[string]any, settings map[string]any) {
 // languageSectionIdentifiers parses a complete VS Code language selector such
 // as "[typescript]" or "[javascript][typescript][json]". Each full selector is
 // one override scope; its identifiers are used only to determine whether that
-// scope applies to the requested language.
+// scope applies to the requested language. Identifiers are trimmed and
+// deduplicated before exact-versus-combined precedence is decided.
 func languageSectionIdentifiers(key string) ([]string, bool) {
   identifiers := []string{}
   for len(key) != 0 {
@@ -126,7 +127,13 @@ func languageSectionIdentifiers(key string) ([]string, bool) {
     if close <= 1 || strings.ContainsRune(key[1:close], '[') {
       return nil, false
     }
-    identifiers = append(identifiers, key[1:close])
+    identifier := strings.TrimSpace(key[1:close])
+    if identifier == "" {
+      return nil, false
+    }
+    if !languageSectionContains(identifiers, identifier) {
+      identifiers = append(identifiers, identifier)
+    }
     key = key[close+1:]
   }
   return identifiers, len(identifiers) != 0

--- a/packages/lint/linthost/format_editor_settings.go
+++ b/packages/lint/linthost/format_editor_settings.go
@@ -116,7 +116,8 @@ func applyEditorSettings(out map[string]any, settings map[string]any) {
 // as "[typescript]" or "[javascript][typescript][json]". Each full selector is
 // one override scope; its identifiers are used only to determine whether that
 // scope applies to the requested language. Identifiers are trimmed and
-// deduplicated before exact-versus-combined precedence is decided.
+// deduplicated, and empty normalized identifiers are discarded, before
+// exact-versus-combined precedence is decided.
 func languageSectionIdentifiers(key string) ([]string, bool) {
   identifiers := []string{}
   for len(key) != 0 {
@@ -124,12 +125,13 @@ func languageSectionIdentifiers(key string) ([]string, bool) {
       return nil, false
     }
     close := strings.IndexByte(key, ']')
-    if close <= 1 || strings.ContainsRune(key[1:close], '[') {
+    if close <= 1 {
       return nil, false
     }
     identifier := strings.TrimSpace(key[1:close])
     if identifier == "" {
-      return nil, false
+      key = key[close+1:]
+      continue
     }
     if !languageSectionContains(identifiers, identifier) {
       identifiers = append(identifiers, identifier)

--- a/packages/lint/linthost/format_editor_settings.go
+++ b/packages/lint/linthost/format_editor_settings.go
@@ -4,6 +4,7 @@ import (
   "bytes"
   "encoding/json"
   "errors"
+  "io"
   "os"
   "path/filepath"
   "strings"
@@ -39,10 +40,10 @@ func loadFormatRules(pluginsJSON, cwd, tsconfigPath string) (RuleResolver, error
 //
 // This is consulted only when lint.config.* configures no `format` block: a
 // configured format block always wins and never reaches this path. Within
-// settings.json a language-specific section matching `language` (e.g.
-// "[typescript]" or a combined "[javascript][typescript][json]") wins over the
-// top-level keys, mirroring VS Code's own resolution. Pass language="" to skip
-// language sections (e.g. the project-wide `ttsc format` CLI path).
+// settings.json, matching combined language sections are applied in source
+// order and an exact single-language section is applied last, mirroring VS
+// Code's own resolution. Pass language="" to skip language sections (e.g. the
+// project-wide `ttsc format` CLI path).
 //
 // Mapping (values use JSON types so they parse identically to a real `format`
 // block, where numbers decode as float64):
@@ -64,17 +65,22 @@ func editorFormatOverrides(startDir string, language string) map[string]any {
   if !ok {
     return out
   }
-  // Top-level keys first, then language-specific sections override them.
-  applyEditorSettings(out, settings)
+  // Top-level keys first, then matching combined language sections in source
+  // order. VS Code holds an exact single-language section aside and applies it
+  // last, regardless of where its full selector appears in settings.json.
+  applyEditorSettings(out, settings.values)
   if language != "" {
-    for key, value := range settings {
-      if !sectionMatchesLanguage(key, language) {
+    var exact map[string]any
+    for _, section := range settings.languageSections {
+      if len(section.identifiers) == 1 && section.identifiers[0] == language {
+        exact = section.values
         continue
       }
-      if section, ok := value.(map[string]any); ok {
-        applyEditorSettings(out, section)
+      if languageSectionContains(section.identifiers, language) {
+        applyEditorSettings(out, section.values)
       }
     }
+    applyEditorSettings(out, exact)
   }
   return out
 }
@@ -106,20 +112,32 @@ func applyEditorSettings(out map[string]any, settings map[string]any) {
   }
 }
 
-// sectionMatchesLanguage reports whether a settings.json key is a
-// language-specific section header (e.g. "[typescript]" or the combined
-// "[javascript][typescript][json]") that applies to language. An empty
-// language never matches.
-func sectionMatchesLanguage(key string, language string) bool {
+// languageSectionIdentifiers parses a complete VS Code language selector such
+// as "[typescript]" or "[javascript][typescript][json]". Each full selector is
+// one override scope; its identifiers are used only to determine whether that
+// scope applies to the requested language.
+func languageSectionIdentifiers(key string) ([]string, bool) {
+  identifiers := []string{}
+  for len(key) != 0 {
+    if key[0] != '[' {
+      return nil, false
+    }
+    close := strings.IndexByte(key, ']')
+    if close <= 1 || strings.ContainsRune(key[1:close], '[') {
+      return nil, false
+    }
+    identifiers = append(identifiers, key[1:close])
+    key = key[close+1:]
+  }
+  return identifiers, len(identifiers) != 0
+}
+
+func languageSectionContains(identifiers []string, language string) bool {
   if language == "" {
     return false
   }
-  if !strings.HasPrefix(key, "[") || !strings.HasSuffix(key, "]") {
-    return false
-  }
-  inner := strings.TrimSuffix(strings.TrimPrefix(key, "["), "]")
-  for _, lang := range strings.Split(inner, "][") {
-    if lang == language {
+  for _, identifier := range identifiers {
+    if identifier == language {
       return true
     }
   }
@@ -144,29 +162,97 @@ func vscodeLanguageID(filePath string) string {
   }
 }
 
+type vscodeSettings struct {
+  values           map[string]any
+  languageSections []vscodeLanguageSection
+}
+
+type vscodeLanguageSection struct {
+  identifiers []string
+  values      map[string]any
+}
+
 // loadNearestVSCodeSettings walks up from startDir looking for a
 // `.vscode/settings.json`, returning the first one found decoded as a JSONC
 // document. It returns ok=false when none exists or the file cannot be parsed,
 // so a broken settings file degrades to the format defaults instead of breaking
 // the formatter.
-func loadNearestVSCodeSettings(startDir string) (map[string]any, bool) {
+func loadNearestVSCodeSettings(startDir string) (vscodeSettings, bool) {
   dir := startDir
   for {
     candidate := filepath.Join(dir, ".vscode", "settings.json")
     if data, err := os.ReadFile(candidate); err == nil {
       data = bytes.TrimPrefix(data, []byte{0xEF, 0xBB, 0xBF})
-      var parsed map[string]any
-      if json.Unmarshal(stripJSONC(data), &parsed) == nil {
+      parsed, err := decodeVSCodeSettings(stripJSONC(data))
+      if err == nil {
         return parsed, true
       }
-      return nil, false
+      return vscodeSettings{}, false
     }
     parent := filepath.Dir(dir)
     if parent == dir {
-      return nil, false
+      return vscodeSettings{}, false
     }
     dir = parent
   }
+}
+
+// decodeVSCodeSettings decodes the top-level JSON object without discarding
+// declaration order. encoding/json maps are intentionally unordered, while VS
+// Code merges matching combined language sections in the order they appear in
+// settings.json and applies the exact single-language section afterwards.
+func decodeVSCodeSettings(data []byte) (vscodeSettings, error) {
+  decoder := json.NewDecoder(bytes.NewReader(data))
+  token, err := decoder.Token()
+  if err != nil {
+    return vscodeSettings{}, err
+  }
+  if token != json.Delim('{') {
+    return vscodeSettings{}, errors.New("VS Code settings must be a JSON object")
+  }
+
+  settings := vscodeSettings{values: map[string]any{}}
+  for decoder.More() {
+    token, err := decoder.Token()
+    if err != nil {
+      return vscodeSettings{}, err
+    }
+    key, ok := token.(string)
+    if !ok {
+      return vscodeSettings{}, errors.New("VS Code setting key must be a string")
+    }
+    var value any
+    if err := decoder.Decode(&value); err != nil {
+      return vscodeSettings{}, err
+    }
+    identifiers, isLanguageSection := languageSectionIdentifiers(key)
+    if !isLanguageSection {
+      settings.values[key] = value
+      continue
+    }
+    section, ok := value.(map[string]any)
+    if !ok {
+      continue
+    }
+    settings.languageSections = append(settings.languageSections, vscodeLanguageSection{
+      identifiers: identifiers,
+      values:      section,
+    })
+  }
+  token, err = decoder.Token()
+  if err != nil {
+    return vscodeSettings{}, err
+  }
+  if token != json.Delim('}') {
+    return vscodeSettings{}, errors.New("VS Code settings object is not closed")
+  }
+  if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+    if err != nil {
+      return vscodeSettings{}, err
+    }
+    return vscodeSettings{}, errors.New("VS Code settings contain trailing JSON")
+  }
+  return settings, nil
 }
 
 // stripJSONC removes `//` line comments, `/* */` block comments, and trailing

--- a/packages/lint/test/format/editor_format_overrides_accepts_utf8_bom_test.go
+++ b/packages/lint/test/format/editor_format_overrides_accepts_utf8_bom_test.go
@@ -62,7 +62,7 @@ func TestEditorFormatOverridesAcceptsUTF8BOM(t *testing.T) {
     minimalRoot := t.TempDir()
     writeSettings(t, minimalRoot, withBOM(`{}`))
     minimal, ok := loadNearestVSCodeSettings(minimalRoot)
-    if !ok || len(minimal) != 0 {
+    if !ok || len(minimal.values) != 0 || len(minimal.languageSections) != 0 {
       t.Fatalf("BOM minimal object: want empty parsed object, got %#v, ok=%v", minimal, ok)
     }
 
@@ -89,7 +89,7 @@ func TestEditorFormatOverridesAcceptsUTF8BOM(t *testing.T) {
     if !ok {
       t.Fatal("settings with an embedded BOM should parse")
     }
-    if got := settings["marker"]; got != "\uFEFF" {
+    if got := settings.values["marker"]; got != "\uFEFF" {
       t.Fatalf("embedded BOM: want %q, got %#v", "\uFEFF", got)
     }
   })
@@ -102,7 +102,8 @@ func TestEditorFormatOverridesAcceptsUTF8BOM(t *testing.T) {
       t.Run(name, func(t *testing.T) {
         root := t.TempDir()
         writeSettings(t, root, body)
-        if settings, ok := loadNearestVSCodeSettings(root); ok || settings != nil {
+        if settings, ok := loadNearestVSCodeSettings(root); ok ||
+          settings.values != nil || len(settings.languageSections) != 0 {
           t.Fatalf("malformed settings: want nil, false; got %#v, %v", settings, ok)
         }
         if got := editorFormatOverrides(root, "typescript"); len(got) != 0 {

--- a/packages/lint/test/format/editor_format_overrides_combined_sections_follow_source_order_test.go
+++ b/packages/lint/test/format/editor_format_overrides_combined_sections_follow_source_order_test.go
@@ -25,13 +25,13 @@ func TestEditorFormatOverridesCombinedSectionsFollowSourceOrder(t *testing.T) {
   "[typescript]": {
     "editor.tabSize": 2
   },
+  "[json][typescript]": {
+    "editor.tabSize": 3,
+    "editor.insertSpaces": false
+  },
   "[javascript][typescript]": {
     "editor.tabSize": 4,
     "editor.insertSpaces": true
-  },
-  "[json][typescript]": {
-    "editor.tabSize": 3,
-    "files.eol": "\n"
   }
 }`
   writeFile(t, filepath.Join(root, ".vscode", "settings.json"), settings)
@@ -41,9 +41,9 @@ func TestEditorFormatOverridesCombinedSectionsFollowSourceOrder(t *testing.T) {
     t.Fatalf("exact language tabWidth should win with 2, got %v", got["tabWidth"])
   }
   if got["useTabs"] != false {
-    t.Fatalf("first combined section should set useTabs=false, got %v", got["useTabs"])
+    t.Fatalf("later combined section should set useTabs=false, got %v", got["useTabs"])
   }
-  if got["endOfLine"] != "lf" {
-    t.Fatalf("later combined section should set endOfLine=lf, got %v", got["endOfLine"])
+  if got["endOfLine"] != "crlf" {
+    t.Fatalf("unshadowed top-level endOfLine should remain crlf, got %v", got["endOfLine"])
   }
 }

--- a/packages/lint/test/format/editor_format_overrides_combined_sections_follow_source_order_test.go
+++ b/packages/lint/test/format/editor_format_overrides_combined_sections_follow_source_order_test.go
@@ -1,0 +1,49 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestEditorFormatOverridesCombinedSectionsFollowSourceOrder verifies matching
+// combined language sections merge in JSON declaration order before the exact
+// language section is applied.
+//
+// VS Code preserves each full language selector as one override scope. Matching
+// combined scopes layer in source order, retain non-conflicting keys, and then
+// yield conflicting keys to the exact single-language scope.
+//
+// 1. Configure top-level, exact, and two matching combined scopes.
+// 2. Give the scopes overlapping and disjoint formatter keys.
+// 3. Assert source-order merging and final exact-language precedence.
+func TestEditorFormatOverridesCombinedSectionsFollowSourceOrder(t *testing.T) {
+  root := t.TempDir()
+  settings := `{
+  "editor.tabSize": 8,
+  "editor.insertSpaces": false,
+  "files.eol": "\r\n",
+  "[typescript]": {
+    "editor.tabSize": 2
+  },
+  "[javascript][typescript]": {
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true
+  },
+  "[json][typescript]": {
+    "editor.tabSize": 3,
+    "files.eol": "\n"
+  }
+}`
+  writeFile(t, filepath.Join(root, ".vscode", "settings.json"), settings)
+
+  got := editorFormatOverrides(root, "typescript")
+  if got["tabWidth"] != float64(2) {
+    t.Fatalf("exact language tabWidth should win with 2, got %v", got["tabWidth"])
+  }
+  if got["useTabs"] != false {
+    t.Fatalf("first combined section should set useTabs=false, got %v", got["useTabs"])
+  }
+  if got["endOfLine"] != "lf" {
+    t.Fatalf("later combined section should set endOfLine=lf, got %v", got["endOfLine"])
+  }
+}

--- a/packages/lint/test/format/editor_format_overrides_combined_sections_follow_source_order_test.go
+++ b/packages/lint/test/format/editor_format_overrides_combined_sections_follow_source_order_test.go
@@ -13,7 +13,7 @@ import (
 // combined scopes layer in source order, retain non-conflicting keys, and then
 // yield conflicting keys to the exact single-language scope.
 //
-// 1. Configure top-level, exact, and two matching combined scopes.
+// 1. Configure top-level, exact, matching, and non-matching combined scopes.
 // 2. Give the scopes overlapping and disjoint formatter keys.
 // 3. Assert source-order merging and final exact-language precedence.
 func TestEditorFormatOverridesCombinedSectionsFollowSourceOrder(t *testing.T) {
@@ -32,6 +32,10 @@ func TestEditorFormatOverridesCombinedSectionsFollowSourceOrder(t *testing.T) {
   "[javascript][typescript]": {
     "editor.tabSize": 4,
     "editor.insertSpaces": true
+  },
+  "[json][markdown]": {
+    "editor.insertSpaces": false,
+    "files.eol": "\n"
   }
 }`
   writeFile(t, filepath.Join(root, ".vscode", "settings.json"), settings)

--- a/packages/lint/test/format/editor_format_overrides_drive_idempotent_output_test.go
+++ b/packages/lint/test/format/editor_format_overrides_drive_idempotent_output_test.go
@@ -1,0 +1,64 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestEditorFormatOverridesDriveIdempotentOutput verifies deterministic
+// language precedence reaches the formatter's observable output and converges.
+//
+// Inspecting the options map alone cannot prove the LSP formatting path consumes
+// the winning value. This scenario runs the default formatting resolver with a
+// conflicting combined scope and exact TypeScript scope, then feeds its output
+// through the same resolver again.
+//
+// 1. Configure four-space combined indentation and two-space TypeScript indentation.
+// 2. Format a four-space-indented TypeScript statement to convergence.
+// 3. Assert exact two-space output and a zero-edit second run.
+func TestEditorFormatOverridesDriveIdempotentOutput(t *testing.T) {
+  root := t.TempDir()
+  settings := `{
+  "[javascript][typescript]": { "editor.tabSize": 4 },
+  "[typescript]": { "editor.tabSize": 2 }
+}`
+  writeFile(t, filepath.Join(root, ".vscode", "settings.json"), settings)
+  resolver, err := newFormatCommandResolver(RuleConfig{}, root, "typescript")
+  if err != nil {
+    t.Fatalf("newFormatCommandResolver: %v", err)
+  }
+  fileName := filepath.Join(root, "src", "main.ts")
+  format := func(source string) (string, int) {
+    t.Helper()
+    total := 0
+    for pass := 0; pass < 10; pass++ {
+      file := parseTSFile(t, fileName, source)
+      findings := filterFormatFindings(
+        NewEngineWithResolver(resolver).Run([]*shimast.SourceFile{file}, nil),
+      )
+      next, applied := applyFindingFixesToText(source, findings)
+      total += applied
+      if applied == 0 {
+        return source, total
+      }
+      source = next
+    }
+    t.Fatalf("formatter did not converge after 10 passes")
+    return "", 0
+  }
+
+  expected := "function f() {\n  const value = 1;\n}\n"
+  first, applied := format("function f() {\n    const value = 1;\n}\n")
+  if applied == 0 {
+    t.Fatalf("expected indentation rewrite")
+  }
+  if first != expected {
+    t.Fatalf("formatted output mismatch:\nwant %q\ngot  %q", expected, first)
+  }
+  second, applied := format(first)
+  if applied != 0 || second != first {
+    t.Fatalf("format should be idempotent: applied=%d first=%q second=%q", applied, first, second)
+  }
+}

--- a/packages/lint/test/format/editor_format_overrides_duplicate_language_section_uses_last_value_test.go
+++ b/packages/lint/test/format/editor_format_overrides_duplicate_language_section_uses_last_value_test.go
@@ -1,0 +1,36 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestEditorFormatOverridesDuplicateLanguageSectionUsesLastValue verifies a
+// repeated JSON property replaces its earlier object instead of merging it.
+//
+// VS Code first parses settings.json into an object, where the final value for
+// a duplicate property wins without moving that property's insertion order.
+// Treating both occurrences as separate override scopes would preserve stale
+// keys that no longer exist in the parsed settings object.
+//
+// 1. Set tab size in the first occurrence of a combined language property.
+// 2. Replace that property with an object that sets only insertSpaces.
+// 3. Assert tab size falls back to the top level while the final object applies.
+func TestEditorFormatOverridesDuplicateLanguageSectionUsesLastValue(t *testing.T) {
+  root := t.TempDir()
+  settings := `{
+  "editor.tabSize": 8,
+  "editor.insertSpaces": false,
+  "[javascript][typescript]": { "editor.tabSize": 4 },
+  "[javascript][typescript]": { "editor.insertSpaces": true }
+}`
+  writeFile(t, filepath.Join(root, ".vscode", "settings.json"), settings)
+
+  got := editorFormatOverrides(root, "typescript")
+  if got["tabWidth"] != float64(8) {
+    t.Fatalf("replaced section must not retain stale tabWidth; want 8, got %v", got["tabWidth"])
+  }
+  if got["useTabs"] != false {
+    t.Fatalf("last section value should set useTabs=false, got %v", got["useTabs"])
+  }
+}

--- a/packages/lint/test/format/editor_format_overrides_duplicate_language_section_uses_last_value_test.go
+++ b/packages/lint/test/format/editor_format_overrides_duplicate_language_section_uses_last_value_test.go
@@ -13,24 +13,38 @@ import (
 // Treating both occurrences as separate override scopes would preserve stale
 // keys that no longer exist in the parsed settings object.
 //
-// 1. Set tab size in the first occurrence of a combined language property.
-// 2. Replace that property with an object that sets only insertSpaces.
-// 3. Assert tab size falls back to the top level while the final object applies.
+// 1. Place a combined language property before another matching property.
+// 2. Repeat the first property later with a disjoint replacement object.
+// 3. Assert its stale value disappears and its original merge position remains.
 func TestEditorFormatOverridesDuplicateLanguageSectionUsesLastValue(t *testing.T) {
   root := t.TempDir()
   settings := `{
   "editor.tabSize": 8,
   "editor.insertSpaces": false,
-  "[javascript][typescript]": { "editor.tabSize": 4 },
-  "[javascript][typescript]": { "editor.insertSpaces": true }
+  "files.eol": "\r\n",
+  "[json][typescript]": { "files.eol": "\n" },
+  "[javascript][typescript]": { "editor.tabSize": 6 },
+  "[json][typescript]": {
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true
+  }
 }`
   writeFile(t, filepath.Join(root, ".vscode", "settings.json"), settings)
 
   got := editorFormatOverrides(root, "typescript")
-  if got["tabWidth"] != float64(8) {
-    t.Fatalf("replaced section must not retain stale tabWidth; want 8, got %v", got["tabWidth"])
+  if got["tabWidth"] != float64(6) {
+    t.Fatalf(
+      "later distinct section should win at the duplicate key's original position, got %v",
+      got["tabWidth"],
+    )
   }
   if got["useTabs"] != false {
     t.Fatalf("last section value should set useTabs=false, got %v", got["useTabs"])
+  }
+  if got["endOfLine"] != "crlf" {
+    t.Fatalf(
+      "replaced section must not retain stale endOfLine; want crlf, got %v",
+      got["endOfLine"],
+    )
   }
 }

--- a/packages/lint/test/format/editor_format_overrides_equivalent_exact_sections_use_last_scope_test.go
+++ b/packages/lint/test/format/editor_format_overrides_equivalent_exact_sections_use_last_scope_test.go
@@ -1,0 +1,47 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestEditorFormatOverridesEquivalentExactSectionsUseLastScope verifies the
+// final exact-language scope replaces earlier exact scopes as a whole.
+//
+// Distinct full selector strings can normalize to the same single language ID.
+// VS Code retains only the final matching exact scope, then merges that scope
+// over the accumulated combined scopes without reviving keys from earlier exact
+// scopes.
+//
+// 1. Configure an early spaced exact scope with tab and EOL values.
+// 2. Follow it with a matching combined scope and a later canonical exact scope.
+// 3. Assert only the later exact scope overlays the combined and top-level keys.
+func TestEditorFormatOverridesEquivalentExactSectionsUseLastScope(t *testing.T) {
+  root := t.TempDir()
+  settings := `{
+  "editor.tabSize": 8,
+  "editor.insertSpaces": false,
+  "files.eol": "\r\n",
+  "[ typescript ]": {
+    "editor.tabSize": 3,
+    "files.eol": "\n"
+  },
+  "[javascript][typescript]": {
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true
+  },
+  "[typescript]": { "editor.tabSize": 2 }
+}`
+  writeFile(t, filepath.Join(root, ".vscode", "settings.json"), settings)
+
+  got := editorFormatOverrides(root, "typescript")
+  if got["tabWidth"] != float64(2) {
+    t.Fatalf("last exact scope should set tabWidth 2, got %v", got["tabWidth"])
+  }
+  if got["useTabs"] != false {
+    t.Fatalf("combined scope should retain useTabs=false, got %v", got["useTabs"])
+  }
+  if got["endOfLine"] != "crlf" {
+    t.Fatalf("superseded exact scope must not leak endOfLine, got %v", got["endOfLine"])
+  }
+}

--- a/packages/lint/test/format/editor_format_overrides_normalize_full_language_selectors_test.go
+++ b/packages/lint/test/format/editor_format_overrides_normalize_full_language_selectors_test.go
@@ -1,0 +1,30 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestEditorFormatOverridesNormalizeFullLanguageSelectors verifies whitespace
+// and duplicate IDs are normalized before exact-scope precedence is decided.
+//
+// VS Code trims each identifier and removes duplicates from a full language
+// selector. `[ typescript ][typescript]` is therefore an exact TypeScript scope,
+// not a combined scope that can be overwritten by a later combined selector.
+//
+// 1. Configure a normalized exact selector before a conflicting combined selector.
+// 2. Resolve formatter settings for TypeScript.
+// 3. Assert the normalized exact selector still wins.
+func TestEditorFormatOverridesNormalizeFullLanguageSelectors(t *testing.T) {
+  root := t.TempDir()
+  settings := `{
+  "[ typescript ][typescript]": { "editor.tabSize": 2 },
+  "[javascript][typescript]": { "editor.tabSize": 4 }
+}`
+  writeFile(t, filepath.Join(root, ".vscode", "settings.json"), settings)
+
+  got := editorFormatOverrides(root, "typescript")
+  if got["tabWidth"] != float64(2) {
+    t.Fatalf("normalized exact language tabWidth should win with 2, got %v", got["tabWidth"])
+  }
+}

--- a/packages/lint/test/format/editor_format_overrides_normalize_full_language_selectors_test.go
+++ b/packages/lint/test/format/editor_format_overrides_normalize_full_language_selectors_test.go
@@ -9,16 +9,19 @@ import (
 // and duplicate IDs are normalized before exact-scope precedence is decided.
 //
 // VS Code trims each identifier and removes duplicates from a full language
-// selector. `[ typescript ][typescript]` is therefore an exact TypeScript scope,
-// not a combined scope that can be overwritten by a later combined selector.
+// selector. `[ ][ typescript ][typescript]` is therefore an exact TypeScript
+// scope, not a combined scope that can be overwritten by a later combined
+// selector.
 //
-// 1. Configure a normalized exact selector before a conflicting combined selector.
+// 1. Configure normalized exact and bracket-containing combined selectors.
 // 2. Resolve formatter settings for TypeScript.
-// 3. Assert the normalized exact selector still wins.
+// 3. Assert the exact value wins while the valid combined selector still applies.
 func TestEditorFormatOverridesNormalizeFullLanguageSelectors(t *testing.T) {
   root := t.TempDir()
   settings := `{
-  "[ typescript ][typescript]": { "editor.tabSize": 2 },
+  "files.eol": "\r\n",
+  "[ ][ typescript ][typescript]": { "editor.tabSize": 2 },
+  "[[custom][typescript]": { "files.eol": "\n" },
   "[javascript][typescript]": { "editor.tabSize": 4 }
 }`
   writeFile(t, filepath.Join(root, ".vscode", "settings.json"), settings)
@@ -26,5 +29,11 @@ func TestEditorFormatOverridesNormalizeFullLanguageSelectors(t *testing.T) {
   got := editorFormatOverrides(root, "typescript")
   if got["tabWidth"] != float64(2) {
     t.Fatalf("normalized exact language tabWidth should win with 2, got %v", got["tabWidth"])
+  }
+  if got["endOfLine"] != "lf" {
+    t.Fatalf(
+      "bracket-containing identifier should preserve combined endOfLine lf, got %v",
+      got["endOfLine"],
+    )
   }
 }

--- a/packages/lint/test/format/editor_format_overrides_reject_malformed_language_selectors_test.go
+++ b/packages/lint/test/format/editor_format_overrides_reject_malformed_language_selectors_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestEditorFormatOverridesRejectMalformedLanguageSelectors verifies only
+// complete non-empty VS Code language selector groups participate in merging.
+//
+// A selector is a full string of adjacent `[language]` groups. Treating an
+// empty group as an independent wildcard would let malformed settings such as
+// `[][typescript]` override valid top-level formatter settings.
+//
+// 1. Configure a top-level tab size and malformed selectors containing empty groups.
+// 2. Resolve the settings for TypeScript.
+// 3. Assert malformed sections are ignored and the top-level value survives.
+func TestEditorFormatOverridesRejectMalformedLanguageSelectors(t *testing.T) {
+  root := t.TempDir()
+  settings := `{
+  "editor.tabSize": 8,
+  "[][typescript]": { "editor.tabSize": 4 },
+  "[typescript][]": { "editor.tabSize": 2 }
+}`
+  writeFile(t, filepath.Join(root, ".vscode", "settings.json"), settings)
+
+  got := editorFormatOverrides(root, "typescript")
+  if got["tabWidth"] != float64(8) {
+    t.Fatalf("malformed selectors must not override top-level tabWidth 8, got %v", got["tabWidth"])
+  }
+}

--- a/packages/lint/test/format/editor_format_overrides_single_language_precedence_is_deterministic_test.go
+++ b/packages/lint/test/format/editor_format_overrides_single_language_precedence_is_deterministic_test.go
@@ -1,0 +1,46 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestEditorFormatOverridesSingleLanguagePrecedenceIsDeterministic verifies an
+// exact language section wins over a matching combined section in either JSON
+// declaration order.
+//
+// VS Code gives `[typescript]` semantic precedence over
+// `[javascript][typescript]`. Iterating a decoded Go map made the winner depend
+// on runtime map order, so repeated resolutions of equivalent settings could
+// disagree even though the source did not change.
+//
+// 1. Write both declaration-order permutations of the conflicting sections.
+// 2. Resolve each settings file repeatedly for TypeScript.
+// 3. Assert the exact section wins every time.
+func TestEditorFormatOverridesSingleLanguagePrecedenceIsDeterministic(t *testing.T) {
+  settingsFiles := []string{
+    `{
+  "[javascript][typescript]": { "editor.tabSize": 4 },
+  "[typescript]": { "editor.tabSize": 2 }
+}`,
+    `{
+  "[typescript]": { "editor.tabSize": 2 },
+  "[javascript][typescript]": { "editor.tabSize": 4 }
+}`,
+  }
+  for caseIndex, settings := range settingsFiles {
+    root := t.TempDir()
+    writeFile(t, filepath.Join(root, ".vscode", "settings.json"), settings)
+    for iteration := 0; iteration < 64; iteration++ {
+      got := editorFormatOverrides(root, "typescript")
+      if got["tabWidth"] != float64(2) {
+        t.Fatalf(
+          "case %d iteration %d: exact language tabWidth should win with 2, got %v",
+          caseIndex,
+          iteration,
+          got["tabWidth"],
+        )
+      }
+    }
+  }
+}

--- a/packages/lint/test/format/editor_format_overrides_supported_language_ids_test.go
+++ b/packages/lint/test/format/editor_format_overrides_supported_language_ids_test.go
@@ -1,0 +1,55 @@
+package linthost
+
+import (
+  "fmt"
+  "path/filepath"
+  "testing"
+)
+
+// TestEditorFormatOverridesSupportedLanguageIDs verifies every JavaScript and
+// TypeScript extension uses its VS Code language ID when resolving overrides.
+//
+// The formatter supports eight JS/TS extensions but four VS Code language IDs.
+// A precedence fix that recognizes only TypeScript would leave JSX, TSX, and
+// module-flavored extensions with the combined-scope value.
+//
+// 1. Map every supported extension to its expected VS Code language ID.
+// 2. Configure a combined fallback and an exact section for that ID.
+// 3. Assert the exact section wins for every extension.
+func TestEditorFormatOverridesSupportedLanguageIDs(t *testing.T) {
+  cases := []struct {
+    fileName string
+    language string
+  }{
+    {fileName: "file.ts", language: "typescript"},
+    {fileName: "file.mts", language: "typescript"},
+    {fileName: "file.cts", language: "typescript"},
+    {fileName: "file.tsx", language: "typescriptreact"},
+    {fileName: "file.js", language: "javascript"},
+    {fileName: "file.mjs", language: "javascript"},
+    {fileName: "file.cjs", language: "javascript"},
+    {fileName: "file.jsx", language: "javascriptreact"},
+  }
+  for _, testCase := range cases {
+    t.Run(testCase.fileName, func(t *testing.T) {
+      language := vscodeLanguageID(testCase.fileName)
+      if language != testCase.language {
+        t.Fatalf("language ID: want %q, got %q", testCase.language, language)
+      }
+      root := t.TempDir()
+      settings := fmt.Sprintf(`{
+  "[javascript][javascriptreact][typescript][typescriptreact]": {
+    "editor.tabSize": 4
+  },
+  "[%s]": {
+    "editor.tabSize": 2
+  }
+}`, testCase.language)
+      writeFile(t, filepath.Join(root, ".vscode", "settings.json"), settings)
+      got := editorFormatOverrides(root, language)
+      if got["tabWidth"] != float64(2) {
+        t.Fatalf("exact language tabWidth should win with 2, got %v", got["tabWidth"])
+      }
+    })
+  }
+}

--- a/website/src/content/docs/lint/format.mdx
+++ b/website/src/content/docs/lint/format.mdx
@@ -57,6 +57,8 @@ format: { severity: "off" }
 
 Formatting is configured **only** through the `format` block. The `rules` map is for lint rules; format settings placed there are ignored. Turn a behavior off through its `format` key (for example `trailingComma: "none"`), not a `rules` entry.
 
+When no `format` block is present, VS Code format-on-save reads `editor.tabSize`, `editor.insertSpaces`, and `files.eol` from the nearest `.vscode/settings.json`. Top-level values apply first, matching combined language sections apply in source order, and an exact single-language section such as `[typescript]` takes precedence over combined sections such as `[javascript][typescript]`. A configured `format` block remains authoritative.
+
 ## Individual format keys
 
 ### `semi`


### PR DESCRIPTION
## Intent

Make formatter settings resolution deterministic and match VS Code when top-level, combined-language, and exact single-language settings overlap.

Closes #504.

## Scope

- decode the top-level JSONC settings object without losing declaration order
- merge matching combined-language scopes in source order, then apply the exact language scope
- retain partial-key inheritance from top-level and earlier matching scopes
- cover all supported JavaScript and TypeScript language IDs, malformed selectors, repeated resolution, and observable idempotent format output
- document the fallback precedence used by VS Code format-on-save

## Deferred items

None.

## Test plan

- confirm the new precedence suite fails against the previous map-iteration implementation
- complete three exhaustive reviews on one exact PR head
- run the focused `TestEditorFormatOverrides*` Go suite after those reviews