### PR TITLE
fix(lint): quarantine panicking rules per file

### DIFF
--- a/packages/lint/linthost/directives.go
+++ b/packages/lint/linthost/directives.go
@@ -98,7 +98,7 @@ func filterInlineDisabledFindingsWithDirectives(file *shimast.SourceFile, findin
   }
   filtered := findings[:0]
   for _, finding := range findings {
-    if finding == nil || !directives.suppresses(file, finding) {
+    if finding == nil || finding.engineFailure || !directives.suppresses(file, finding) {
       filtered = append(filtered, finding)
     }
   }

--- a/packages/lint/linthost/engine.go
+++ b/packages/lint/linthost/engine.go
@@ -96,10 +96,11 @@ type Context struct {
   Severity         Severity
   Options          json.RawMessage
 
-  rule           Rule
-  isFormat       bool
-  collect        func(*Finding)
-  projectResults publicrule.ProjectResultReader
+  rule             Rule
+  isFormat         bool
+  quarantined      bool
+  collect          func(*Finding)
+  projectResults   publicrule.ProjectResultReader
 }
 
 // DecodeOptions unmarshals the rule's options blob into `out`. Returns
@@ -132,6 +133,8 @@ type Finding struct {
   Fix         []TextEdit
   Suggestions []Suggestion
   IsFormat    bool
+
+  engineFailure bool
 }
 
 // TextEdit is one byte-range source replacement used by a fix or suggestion.
@@ -588,6 +591,19 @@ type boundRule struct {
   ctx  *Context
 }
 
+// check invokes one bound rule unless an earlier invocation panicked in this
+// file. Context is shared by every kind bucket for the same file/rule pair, so
+// the quarantine covers later nodes and later registered kinds without leaking
+// into the next source file.
+func (b boundRule) check(node *shimast.Node, collect func(*Finding)) {
+  if b.ctx == nil || b.ctx.quarantined {
+    return
+  }
+  if runRuleCheck(b.rule, b.ctx, node, collect) {
+    b.ctx.quarantined = true
+  }
+}
+
 // lintFileWalker drives the per-file AST traversal. The struct exists so
 // the `ForEachChild` callback can be a method value cached in
 // `childCB`. A naive nested-closure walker re-allocates one callback
@@ -608,7 +624,7 @@ func (w *lintFileWalker) walk(node *shimast.Node) {
   }
   if k := int(node.Kind); k >= 0 && k < len(w.byKind) {
     for _, bound := range w.byKind[k] {
-      runRuleCheck(bound.rule, bound.ctx, node, w.collect)
+      bound.check(node, w.collect)
     }
   }
   node.ForEachChild(w.childCB)
@@ -714,7 +730,7 @@ func (e *Engine) runFile(
     // per SourceFile).
     if k := int(shimast.KindSourceFile); k >= 0 && k < len(byKind) {
       for _, bound := range byKind[k] {
-        runRuleCheck(bound.rule, bound.ctx, file.AsNode(), collect)
+        bound.check(file.AsNode(), collect)
       }
     }
 
@@ -751,13 +767,15 @@ func hasEnabledFileRules(rules RuleConfig) bool {
 // anyone; protecting the engine is the only way to bound the blast
 // radius of one bad rule. The recovered panic is surfaced as a
 // SeverityError finding tagged with the rule's name so the user sees
-// the failure in the normal diagnostic stream.
-func runRuleCheck(rule Rule, ctx *Context, node *shimast.Node, collect func(*Finding)) {
+// the failure in the normal diagnostic stream. The boolean result tells the
+// per-file binding to quarantine the rule after recovery.
+func runRuleCheck(rule Rule, ctx *Context, node *shimast.Node, collect func(*Finding)) (panicked bool) {
   defer func() {
     r := recover()
     if r == nil {
       return
     }
+    panicked = true
     if ctx == nil || ctx.File == nil {
       // Without source context there is nowhere to anchor the
       // diagnostic. Surface to stderr so the panic is at least
@@ -783,8 +801,10 @@ func runRuleCheck(rule Rule, ctx *Context, node *shimast.Node, collect func(*Fin
         "Rule %q panicked while checking this node: %v. Report this to the rule's author; ttsc skipped the rule on this file.",
         rule.Name(), r,
       ),
-      File: ctx.File,
+      File:          ctx.File,
+      engineFailure: true,
     })
   }()
   rule.Check(ctx, node)
+  return false
 }

--- a/packages/lint/test/plugin/engine_quarantines_panicking_rule_per_file_test.go
+++ b/packages/lint/test/plugin/engine_quarantines_panicking_rule_per_file_test.go
@@ -1,0 +1,87 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestEngineQuarantinesPanickingRulePerFile verifies a recovered panic disables
+// only that rule for the rest of the current file. The failure must remain
+// visible even under inline disables, while sibling rules and later files keep
+// running normally.
+func TestEngineQuarantinesPanickingRulePerFile(t *testing.T) {
+  bomb := &fileQuarantinePanickingRule{checks: map[string]int{}}
+  sibling := &fileQuarantineSiblingRule{checks: map[string]int{}}
+  Register(bomb)
+  Register(sibling)
+  t.Cleanup(func() {
+    delete(registered.rules, bomb.Name())
+    delete(registered.rules, sibling.Name())
+  })
+
+  first := parseTSFile(t, "/virtual/panic-first.ts", `// eslint-disable test/quarantine-panic
+const alpha = 1;
+alpha;
+const beta = 2;
+beta;
+`)
+  second := parseTSFile(t, "/virtual/panic-second.ts", `// eslint-disable
+const gamma = 3;
+gamma;
+const delta = 4;
+delta;
+`)
+  engine := NewEngine(RuleConfig{
+    bomb.Name():    SeverityError,
+    sibling.Name(): SeverityError,
+  })
+  engine.SetSerial(true)
+  findings := engine.Run([]*shimast.SourceFile{first, second}, nil)
+
+  if got, want := len(findings), 2; got != want {
+    t.Fatalf("recovered panic findings = %d, want %d: %+v", got, want, findings)
+  }
+  for i, finding := range findings {
+    if finding.Rule != bomb.Name() || finding.Severity != SeverityError ||
+      !strings.Contains(finding.Message, "panicked") {
+      t.Fatalf("finding %d is not the unsuppressed engine failure: %+v", i, finding)
+    }
+  }
+
+  for _, file := range []*shimast.SourceFile{first, second} {
+    name := file.FileName()
+    if got, want := bomb.checks[name], 1; got != want {
+      t.Fatalf("panicking rule checks for %s = %d, want %d", name, got, want)
+    }
+    if got, want := sibling.checks[name], 6; got != want {
+      t.Fatalf("sibling rule checks for %s = %d, want %d", name, got, want)
+    }
+  }
+}
+
+type fileQuarantinePanickingRule struct {
+  checks map[string]int
+}
+
+func (*fileQuarantinePanickingRule) Name() string { return "test/quarantine-panic" }
+func (*fileQuarantinePanickingRule) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindIdentifier, shimast.KindNumericLiteral}
+}
+func (r *fileQuarantinePanickingRule) Check(ctx *Context, _ *shimast.Node) {
+  r.checks[ctx.File.FileName()]++
+  panic("synthetic repeated panic")
+}
+
+type fileQuarantineSiblingRule struct {
+  checks map[string]int
+}
+
+func (*fileQuarantineSiblingRule) Name() string { return "test/quarantine-sibling" }
+func (*fileQuarantineSiblingRule) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindIdentifier, shimast.KindNumericLiteral}
+}
+func (r *fileQuarantineSiblingRule) Check(ctx *Context, _ *shimast.Node) {
+  r.checks[ctx.File.FileName()]++
+}


### PR DESCRIPTION
## Summary

- quarantine a panicking rule for the remainder of its current source file
- share the quarantine across every registered node kind without disabling sibling rules or later files
- keep recovered engine failures visible even under inline lint disables
- shield multi-kind dispatch, per-file reset, sibling progress, and diagnostic cardinality

## Review and validation

Three sequential exhaustive reviews of one exact HEAD and focused local validation will be recorded before merge.

Closes #493
