### PR TITLE
fix(lint): bound plugin diagnostic ranges

### DIFF
--- a/packages/lint/linthost/engine.go
+++ b/packages/lint/linthost/engine.go
@@ -27,6 +27,7 @@ import (
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimchecker "github.com/microsoft/typescript-go/shim/checker"
+  shimdw "github.com/microsoft/typescript-go/shim/diagnosticwriter"
   shimscanner "github.com/microsoft/typescript-go/shim/scanner"
   publicrule "github.com/samchon/ttsc/packages/lint/rule"
 )
@@ -173,12 +174,13 @@ func (c *Context) ReportFix(node *shimast.Node, message string, edits ...TextEdi
   if c.File != nil {
     pos = shimscanner.SkipTrivia(c.File.Text(), pos)
   }
+  pos, end := shimdw.NormalizeLintRange(c.File, pos, node.End())
   c.collect(&Finding{
     Rule:     c.rule.Name(),
     Severity: c.Severity,
     File:     c.File,
     Pos:      pos,
-    End:      node.End(),
+    End:      end,
     Message:  message,
     Fix:      cloneTextEdits(edits),
     IsFormat: c.isFormat,
@@ -196,12 +198,13 @@ func (c *Context) ReportSuggestion(node *shimast.Node, message string, title str
   if c.File != nil {
     pos = shimscanner.SkipTrivia(c.File.Text(), pos)
   }
+  pos, end := shimdw.NormalizeLintRange(c.File, pos, node.End())
   c.collect(&Finding{
     Rule:        c.rule.Name(),
     Severity:    c.Severity,
     File:        c.File,
     Pos:         pos,
-    End:         node.End(),
+    End:         end,
     Message:     message,
     Suggestions: newSuggestions(title, edits),
     IsFormat:    c.isFormat,
@@ -220,9 +223,7 @@ func (c *Context) ReportRangeFix(pos, end int, message string, edits ...TextEdit
   if c.Severity == SeverityOff || c.File == nil {
     return
   }
-  if end <= pos {
-    end = pos + 1
-  }
+  pos, end = shimdw.NormalizeLintRange(c.File, pos, end)
   c.collect(&Finding{
     Rule:     c.rule.Name(),
     Severity: c.Severity,
@@ -242,9 +243,7 @@ func (c *Context) ReportRangeSuggestion(pos, end int, message string, title stri
   if c.Severity == SeverityOff || c.File == nil {
     return
   }
-  if end <= pos {
-    end = pos + 1
-  }
+  pos, end = shimdw.NormalizeLintRange(c.File, pos, end)
   c.collect(&Finding{
     Rule:        c.rule.Name(),
     Severity:    c.Severity,
@@ -792,6 +791,7 @@ func runRuleCheck(rule Rule, ctx *Context, node *shimast.Node, collect func(*Fin
     if end <= pos {
       end = pos + 1
     }
+    pos, end = shimdw.NormalizeLintRange(ctx.File, pos, end)
     collect(&Finding{
       Rule:     rule.Name(),
       Severity: SeverityError,

--- a/packages/lint/linthost/engine.go
+++ b/packages/lint/linthost/engine.go
@@ -170,11 +170,7 @@ func (c *Context) ReportFix(node *shimast.Node, message string, edits ...TextEdi
   if c.Severity == SeverityOff || node == nil {
     return
   }
-  pos := node.Pos()
-  if c.File != nil {
-    pos = shimscanner.SkipTrivia(c.File.Text(), pos)
-  }
-  pos, end := shimdw.NormalizeLintRange(c.File, pos, node.End())
+  pos, end := c.nodeFindingRange(node)
   c.collect(&Finding{
     Rule:     c.rule.Name(),
     Severity: c.Severity,
@@ -194,11 +190,7 @@ func (c *Context) ReportSuggestion(node *shimast.Node, message string, title str
   if c.Severity == SeverityOff || node == nil {
     return
   }
-  pos := node.Pos()
-  if c.File != nil {
-    pos = shimscanner.SkipTrivia(c.File.Text(), pos)
-  }
-  pos, end := shimdw.NormalizeLintRange(c.File, pos, node.End())
+  pos, end := c.nodeFindingRange(node)
   c.collect(&Finding{
     Rule:        c.rule.Name(),
     Severity:    c.Severity,
@@ -209,6 +201,20 @@ func (c *Context) ReportSuggestion(node *shimast.Node, message string, title str
     Suggestions: newSuggestions(title, edits),
     IsFormat:    c.isFormat,
   })
+}
+
+// nodeFindingRange bounds an arbitrary rule-supplied node before reading the
+// current file's source text. Contributors can accidentally report a node from
+// another file, whose otherwise valid Pos may exceed this Context's source.
+func (c *Context) nodeFindingRange(node *shimast.Node) (int, int) {
+  if node == nil {
+    return shimdw.NormalizeLintRange(c.File, 0, 0)
+  }
+  pos, end := shimdw.NormalizeLintRange(c.File, node.Pos(), node.End())
+  if c.File != nil {
+    pos = shimscanner.SkipTrivia(c.File.Text(), pos)
+  }
+  return shimdw.NormalizeLintRange(c.File, pos, end)
 }
 
 // ReportRange records a finding at an explicit byte range inside the

--- a/packages/lint/test/plugin/contributor_diagnostic_ranges_are_bounded_test.go
+++ b/packages/lint/test/plugin/contributor_diagnostic_ranges_are_bounded_test.go
@@ -113,6 +113,38 @@ const value = 1;
   }
 }
 
+// TestContributorRangeFixBoundsDiagnosticIndependentlyFromEdit pins the
+// public fix-reporting adapter. A malformed diagnostic span must be bounded
+// without shifting or discarding an otherwise valid candidate edit; the two
+// ranges have separate contracts and consumers.
+func TestContributorRangeFixBoundsDiagnosticIndependentlyFromEdit(t *testing.T) {
+  file := parseTSFile(t, "/virtual/range-fix.ts", "const value = 1;\n")
+  contributor := &boundedDiagnosticRangeContributor{
+    spans:   map[string][2]int{file.FileName(): {999, -5}},
+    fixFile: file.FileName(),
+  }
+  metadata, err := inspectContributor(contributor)
+  if err != nil {
+    t.Fatal(err)
+  }
+  Register(newContributorAdapter(metadata))
+  t.Cleanup(func() { delete(registered.rules, contributor.Name()) })
+
+  findings := NewEngine(RuleConfig{contributor.Name(): SeverityError}).
+    Run([]*shimast.SourceFile{file}, nil)
+  if got, want := len(findings), 1; got != want {
+    t.Fatalf("findings = %d, want %d: %+v", got, want, findings)
+  }
+  finding := findings[0]
+  sourceLen := len(file.Text())
+  if got, want := [2]int{finding.Pos, finding.End}, [2]int{sourceLen, sourceLen}; got != want {
+    t.Fatalf("diagnostic range = %v, want EOF %v", got, want)
+  }
+  if got, want := finding.Fix, []TextEdit{{Pos: 0, End: 5, Text: "let"}}; len(got) != len(want) || got[0] != want[0] {
+    t.Fatalf("candidate edit = %+v, want %+v", got, want)
+  }
+}
+
 // TestRangeSuggestionFindingUsesCanonicalBounds covers the internal
 // suggestion-only reporting surface, which does not pass through the public
 // contributor ReportRange method but feeds the same LSP diagnostic pipeline.
@@ -171,7 +203,8 @@ func TestNodeReportBoundsBeforeSkippingTrivia(t *testing.T) {
 }
 
 type boundedDiagnosticRangeContributor struct {
-  spans map[string][2]int
+  spans   map[string][2]int
+  fixFile string
 }
 
 func (*boundedDiagnosticRangeContributor) Name() string {
@@ -182,6 +215,14 @@ func (*boundedDiagnosticRangeContributor) Visits() []shimast.Kind {
 }
 func (r *boundedDiagnosticRangeContributor) Check(ctx *publicrule.Context, _ *shimast.Node) {
   span := r.spans[ctx.File.FileName()]
+  if ctx.File.FileName() == r.fixFile {
+    ctx.ReportRangeFix(span[0], span[1], "explicit contributor range", publicrule.TextEdit{
+      Pos:  0,
+      End:  5,
+      Text: "let",
+    })
+    return
+  }
   ctx.ReportRange(span[0], span[1], "explicit contributor range")
 }
 

--- a/packages/lint/test/plugin/contributor_diagnostic_ranges_are_bounded_test.go
+++ b/packages/lint/test/plugin/contributor_diagnostic_ranges_are_bounded_test.go
@@ -143,6 +143,33 @@ func TestRangeSuggestionFindingUsesCanonicalBounds(t *testing.T) {
   }
 }
 
+// TestNodeReportBoundsBeforeSkippingTrivia proves a contributor cannot make
+// the host slice the current source at another file's otherwise-valid node
+// position. Normalization must happen before SkipTrivia, not only afterward.
+func TestNodeReportBoundsBeforeSkippingTrivia(t *testing.T) {
+  current := parseTSFile(t, "/virtual/current.ts", "x;\n")
+  foreign := parseTSFile(t, "/virtual/foreign.ts", strings.Repeat("const padding = 0;\n", 8)+"target;\n")
+  foreignNode := foreign.Statements.Nodes[len(foreign.Statements.Nodes)-1]
+  if foreignNode.Pos() <= len(current.Text()) {
+    t.Fatalf("fixture node position %d must exceed current source length %d", foreignNode.Pos(), len(current.Text()))
+  }
+
+  var finding *Finding
+  ctx := &Context{
+    File:     current,
+    Severity: SeverityError,
+    rule:     boundedDiagnosticRangeHostRule{},
+    collect:  func(got *Finding) { finding = got },
+  }
+  ctx.Report(foreignNode, "foreign node")
+  if finding == nil {
+    t.Fatal("foreign node diagnostic was not reported")
+  }
+  if got, want := [2]int{finding.Pos, finding.End}, [2]int{len(current.Text()), len(current.Text())}; got != want {
+    t.Fatalf("foreign node range = %v, want EOF %v", got, want)
+  }
+}
+
 type boundedDiagnosticRangeContributor struct {
   spans map[string][2]int
 }

--- a/packages/lint/test/plugin/contributor_diagnostic_ranges_are_bounded_test.go
+++ b/packages/lint/test/plugin/contributor_diagnostic_ranges_are_bounded_test.go
@@ -20,6 +20,7 @@ func TestContributorDiagnosticRangesAreBounded(t *testing.T) {
     parseTSFile(t, "/virtual/beyond.ts", "const beyond = 1;\n"),
     parseTSFile(t, "/virtual/eof.ts", "const eof = 1;\n"),
     parseTSFile(t, "/virtual/empty.ts", ""),
+    parseTSFile(t, "/virtual/valid.ts", "const valid = 1;\n"),
   }
   contributor := &boundedDiagnosticRangeContributor{
     spans: map[string][2]int{
@@ -28,6 +29,7 @@ func TestContributorDiagnosticRangesAreBounded(t *testing.T) {
       files[2].FileName(): {999, 1200},
       files[3].FileName(): {len(files[3].Text()), len(files[3].Text())},
       files[4].FileName(): {-4, 12},
+      files[5].FileName(): {6, 11},
     },
   }
   metadata, err := inspectContributor(contributor)
@@ -49,6 +51,7 @@ func TestContributorDiagnosticRangesAreBounded(t *testing.T) {
     files[2].FileName(): {len(files[2].Text()), len(files[2].Text())},
     files[3].FileName(): {len(files[3].Text()), len(files[3].Text())},
     files[4].FileName(): {0, 0},
+    files[5].FileName(): {6, 11},
   }
   for _, finding := range findings {
     want, ok := expected[finding.File.FileName()]

--- a/packages/lint/test/plugin/contributor_diagnostic_ranges_are_bounded_test.go
+++ b/packages/lint/test/plugin/contributor_diagnostic_ranges_are_bounded_test.go
@@ -1,0 +1,164 @@
+package linthost
+
+import (
+  "bytes"
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimdw "github.com/microsoft/typescript-go/shim/diagnosticwriter"
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestContributorDiagnosticRangesAreBounded verifies the public contributor
+// trust boundary normalizes every explicit source span before inline
+// directives, LSP conversion, or native diagnostic rendering can consume it.
+func TestContributorDiagnosticRangesAreBounded(t *testing.T) {
+  files := []*shimast.SourceFile{
+    parseTSFile(t, "/virtual/negative.ts", "const negative = 1;\n"),
+    parseTSFile(t, "/virtual/reversed.ts", "const reversed = 1;\n"),
+    parseTSFile(t, "/virtual/beyond.ts", "const beyond = 1;\n"),
+    parseTSFile(t, "/virtual/eof.ts", "const eof = 1;\n"),
+    parseTSFile(t, "/virtual/empty.ts", ""),
+  }
+  contributor := &boundedDiagnosticRangeContributor{
+    spans: map[string][2]int{
+      files[0].FileName(): {-7, 5},
+      files[1].FileName(): {8, 3},
+      files[2].FileName(): {999, 1200},
+      files[3].FileName(): {len(files[3].Text()), len(files[3].Text())},
+      files[4].FileName(): {-4, 12},
+    },
+  }
+  metadata, err := inspectContributor(contributor)
+  if err != nil {
+    t.Fatal(err)
+  }
+  adapter := newContributorAdapter(metadata)
+  Register(adapter)
+  t.Cleanup(func() { delete(registered.rules, contributor.Name()) })
+
+  findings := NewEngine(RuleConfig{contributor.Name(): SeverityError}).
+    Run(files, nil)
+  if got, want := len(findings), len(files); got != want {
+    t.Fatalf("findings = %d, want %d: %+v", got, want, findings)
+  }
+  expected := map[string][2]int{
+    files[0].FileName(): {0, 5},
+    files[1].FileName(): {8, 9},
+    files[2].FileName(): {len(files[2].Text()), len(files[2].Text())},
+    files[3].FileName(): {len(files[3].Text()), len(files[3].Text())},
+    files[4].FileName(): {0, 0},
+  }
+  for _, finding := range findings {
+    want, ok := expected[finding.File.FileName()]
+    if !ok {
+      t.Fatalf("unexpected finding file: %+v", finding)
+    }
+    if finding.Pos != want[0] || finding.End != want[1] {
+      t.Fatalf("range for %s = [%d,%d), want [%d,%d)",
+        finding.File.FileName(), finding.Pos, finding.End, want[0], want[1])
+    }
+
+    lspRange := lspRangeForFinding(finding)
+    if lspRange.Start.Line < 0 || lspRange.Start.Character < 0 ||
+      lspRange.End.Line < 0 || lspRange.End.Character < 0 {
+      t.Fatalf("negative LSP range for %s: %+v", finding.File.FileName(), lspRange)
+    }
+
+    diagnostic := shimdw.NewLintDiagnostic(
+      finding.File,
+      contributor.spans[finding.File.FileName()][0],
+      contributor.spans[finding.File.FileName()][1],
+      9501,
+      shimdw.LintCategoryError,
+      "bounded contributor diagnostic",
+    )
+    if diagnostic.Pos() != want[0] || diagnostic.End() != want[1] {
+      t.Fatalf("native range for %s = [%d,%d), want [%d,%d)",
+        finding.File.FileName(), diagnostic.Pos(), diagnostic.End(), want[0], want[1])
+    }
+    var rendered bytes.Buffer
+    shimdw.FormatMixedDiagnostics(&rendered, nil, []*shimdw.LintDiagnostic{diagnostic}, "/virtual")
+    if !strings.Contains(rendered.String(), "bounded contributor diagnostic") {
+      t.Fatalf("native diagnostic was not rendered for %s: %q", finding.File.FileName(), rendered.String())
+    }
+  }
+}
+
+// TestInvalidContributorRangeCannotPanicInlineDirectiveFiltering pins the
+// pre-render path: directive matching must receive the normalized EOF span,
+// suppress it normally, and never pass an out-of-bounds offset to the scanner.
+func TestInvalidContributorRangeCannotPanicInlineDirectiveFiltering(t *testing.T) {
+  file := parseTSFile(t, "/virtual/directive.ts", `// eslint-disable test/bounded-diagnostic-range
+const value = 1;
+`)
+  contributor := &boundedDiagnosticRangeContributor{
+    spans: map[string][2]int{file.FileName(): {999, 1200}},
+  }
+  metadata, err := inspectContributor(contributor)
+  if err != nil {
+    t.Fatal(err)
+  }
+  Register(newContributorAdapter(metadata))
+  t.Cleanup(func() { delete(registered.rules, contributor.Name()) })
+
+  findings := NewEngine(RuleConfig{contributor.Name(): SeverityError}).
+    Run([]*shimast.SourceFile{file}, nil)
+  if len(findings) != 0 {
+    t.Fatalf("normalized EOF finding should be inline-disabled, got %+v", findings)
+  }
+}
+
+// TestRangeSuggestionFindingUsesCanonicalBounds covers the internal
+// suggestion-only reporting surface, which does not pass through the public
+// contributor ReportRange method but feeds the same LSP diagnostic pipeline.
+func TestRangeSuggestionFindingUsesCanonicalBounds(t *testing.T) {
+  file := parseTSFile(t, "/virtual/suggestion.ts", "const value = 1;\n")
+  var finding *Finding
+  ctx := &Context{
+    File:     file,
+    Severity: SeverityError,
+    rule:     boundedDiagnosticRangeHostRule{},
+    collect:  func(got *Finding) { finding = got },
+  }
+  ctx.ReportRangeSuggestion(
+    len(file.Text())+20,
+    -5,
+    "bounded suggestion finding",
+    "Keep the edit separate",
+    TextEdit{Pos: 0, End: 5, Text: "let"},
+  )
+  if finding == nil {
+    t.Fatal("range suggestion was not reported")
+  }
+  if got, want := [2]int{finding.Pos, finding.End}, [2]int{len(file.Text()), len(file.Text())}; got != want {
+    t.Fatalf("suggestion finding range = %v, want %v", got, want)
+  }
+  if got, want := len(finding.Suggestions), 1; got != want {
+    t.Fatalf("suggestions = %d, want %d: %+v", got, want, finding.Suggestions)
+  }
+}
+
+type boundedDiagnosticRangeContributor struct {
+  spans map[string][2]int
+}
+
+func (*boundedDiagnosticRangeContributor) Name() string {
+  return "test/bounded-diagnostic-range"
+}
+func (*boundedDiagnosticRangeContributor) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindSourceFile}
+}
+func (r *boundedDiagnosticRangeContributor) Check(ctx *publicrule.Context, _ *shimast.Node) {
+  span := r.spans[ctx.File.FileName()]
+  ctx.ReportRange(span[0], span[1], "explicit contributor range")
+}
+
+type boundedDiagnosticRangeHostRule struct{}
+
+func (boundedDiagnosticRangeHostRule) Name() string { return "test/bounded-host-range" }
+func (boundedDiagnosticRangeHostRule) Visits() []shimast.Kind {
+  return nil
+}
+func (boundedDiagnosticRangeHostRule) Check(*Context, *shimast.Node) {}

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -81,15 +81,14 @@ func NewLintDiagnostic(
     lint:     lint,
   }
   if file != nil {
+    pos = lint.Pos()
     d.File = file.FileName()
-    if pos >= 0 {
-      length := lint.Len()
-      d.Start = &pos
-      d.Length = &length
-      line, col := shimscanner.GetECMALineAndByteOffsetOfPosition(file, pos)
-      d.Line = line + 1
-      d.Column = col + 1
-    }
+    length := lint.Len()
+    d.Start = &pos
+    d.Length = &length
+    line, col := shimscanner.GetECMALineAndByteOffsetOfPosition(file, pos)
+    d.Line = line + 1
+    d.Column = col + 1
   }
   return d
 }

--- a/packages/ttsc/shim/diagnosticwriter/lint.go
+++ b/packages/ttsc/shim/diagnosticwriter/lint.go
@@ -30,6 +30,35 @@ const (
   LintCategoryError
 )
 
+// NormalizeLintRange returns a renderer-safe half-open source span. Diagnostic
+// producers are a plugin trust boundary, so offsets are clamped even when the
+// caller's contract says they point inside the current file. Reversed and
+// zero-width ranges select one byte when one exists at pos; EOF and empty-file
+// ranges remain zero-width instead of manufacturing a byte past the source.
+func NormalizeLintRange(file *ast.SourceFile, pos, end int) (int, int) {
+  if file == nil {
+    return 0, 0
+  }
+  sourceLen := len(file.Text())
+  if pos < 0 {
+    pos = 0
+  } else if pos > sourceLen {
+    pos = sourceLen
+  }
+  if end < 0 {
+    end = 0
+  } else if end > sourceLen {
+    end = sourceLen
+  }
+  if end <= pos {
+    end = pos
+    if pos < sourceLen {
+      end++
+    }
+  }
+  return pos, end
+}
+
 // LintDiagnostic is a public, plugin-emittable diagnostic shaped like the
 // `internal/diagnosticwriter.Diagnostic` interface. The internal type is
 // unexported, so this is the only way to mix lint output with tsgo's own
@@ -47,9 +76,7 @@ type LintDiagnostic struct {
 // supplied source file. `code` shows up in the rendered banner — the
 // convention is to give each rule its own stable integer.
 func NewLintDiagnostic(file *ast.SourceFile, pos, end int, code int32, category LintCategory, message string) *LintDiagnostic {
-  if end <= pos {
-    end = pos + 1
-  }
+  pos, end = NormalizeLintRange(file, pos, end)
   return &LintDiagnostic{
     file:     file,
     pos:      pos,

--- a/packages/ttsc/test/driver/new_lint_diagnostic_bounds_source_ranges_test.go
+++ b/packages/ttsc/test/driver/new_lint_diagnostic_bounds_source_ranges_test.go
@@ -41,6 +41,7 @@ func TestDriverNewLintDiagnosticBoundsSourceRanges(t *testing.T) {
     {name: "reversed", pos: 8, end: 2, wantStart: 8, wantLength: 1},
     {name: "beyond EOF", pos: sourceLen + 10, end: sourceLen + 20, wantStart: sourceLen, wantLength: 0},
     {name: "zero-width EOF", pos: sourceLen, end: sourceLen, wantStart: sourceLen, wantLength: 0},
+    {name: "valid unchanged", pos: 7, end: 12, wantStart: 7, wantLength: 5},
   }
   for _, tc := range cases {
     t.Run(tc.name, func(t *testing.T) {

--- a/packages/ttsc/test/driver/new_lint_diagnostic_bounds_source_ranges_test.go
+++ b/packages/ttsc/test/driver/new_lint_diagnostic_bounds_source_ranges_test.go
@@ -1,0 +1,60 @@
+package driver_test
+
+import (
+  "bytes"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverNewLintDiagnosticBoundsSourceRanges verifies the public driver
+// exposes and renders the diagnosticwriter shim's normalized source span,
+// rather than retaining the caller's malformed offsets in its DTO.
+func TestDriverNewLintDiagnosticBoundsSourceRanges(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": { "module": "commonjs", "target": "es2020" },
+  "files": ["index.ts"]
+}
+`)
+  writeProjectFile(t, root, "index.ts", "export const value = 1;\n")
+  prog, diagnostics, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceNoEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diagnostics) != 0 {
+    t.Fatalf("unexpected diagnostics: %#v", diagnostics)
+  }
+  defer prog.Close()
+  source := prog.SourceFiles()[0]
+  sourceLen := len(source.Text())
+
+  cases := []struct {
+    name       string
+    pos        int
+    end        int
+    wantStart  int
+    wantLength int
+  }{
+    {name: "negative", pos: -8, end: 4, wantStart: 0, wantLength: 4},
+    {name: "reversed", pos: 8, end: 2, wantStart: 8, wantLength: 1},
+    {name: "beyond EOF", pos: sourceLen + 10, end: sourceLen + 20, wantStart: sourceLen, wantLength: 0},
+    {name: "zero-width EOF", pos: sourceLen, end: sourceLen, wantStart: sourceLen, wantLength: 0},
+  }
+  for _, tc := range cases {
+    t.Run(tc.name, func(t *testing.T) {
+      diagnostic := driver.NewLintDiagnostic(source, tc.pos, tc.end, 9501, driver.SeverityError, tc.name)
+      if diagnostic.Start == nil || *diagnostic.Start != tc.wantStart ||
+        diagnostic.Length == nil || *diagnostic.Length != tc.wantLength {
+        t.Fatalf("diagnostic span = start %v length %v, want %d/%d: %#v",
+          diagnostic.Start, diagnostic.Length, tc.wantStart, tc.wantLength, diagnostic)
+      }
+      var rendered bytes.Buffer
+      driver.WritePrettyDiagnostics(&rendered, []driver.Diagnostic{diagnostic}, root)
+      if !strings.Contains(rendered.String(), tc.name) {
+        t.Fatalf("diagnostic did not render: %q", rendered.String())
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Summary

- normalize every source-anchored lint diagnostic through one canonical shim boundary
- keep malformed contributor spans away from inline directives, LSP conversion, the public driver DTO, and typescript-go rendering
- preserve zero-width EOF and empty-file diagnostics without manufacturing out-of-bounds bytes
- shield negative, reversed, beyond-EOF, contributor, suggestion, driver, and native-renderer paths

## Review and validation

Three sequential exhaustive reviews of one exact HEAD and focused local validation will be recorded before merge.

Closes #521