### PR TITLE
fix(lint): require matching receivers in unicorn/prefer-at

### DIFF
--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -183,6 +183,184 @@ func stripParens(node *shimast.Node) *shimast.Node {
   return node
 }
 
+// sameReferenceExpression reports whether two expressions denote the same
+// repeatable runtime reference. Parentheses and TypeScript's type-only
+// expression wrappers are transparent; identifiers, primitive literals,
+// `this` / `super`, and property or element-access chains are compared
+// recursively. Calls and other effectful expressions are deliberately rejected
+// even when their source text is identical because evaluating them twice need
+// not produce the same value.
+//
+// Static member keys are normalized to their runtime property key, so `x.y`
+// and `x["y"]` compare equal. Optional and non-optional member accesses remain
+// distinct because optional chaining changes evaluation semantics.
+func sameReferenceExpression(left, right *shimast.Node) bool {
+  left = unwrapReferenceExpression(left)
+  right = unwrapReferenceExpression(right)
+  if left == nil || right == nil {
+    return false
+  }
+
+  switch left.Kind {
+  case shimast.KindIdentifier, shimast.KindPrivateIdentifier:
+    return left.Kind == right.Kind && shimast.NodeText(left) == shimast.NodeText(right)
+  case shimast.KindThisKeyword, shimast.KindSuperKeyword:
+    return left.Kind == right.Kind
+  case shimast.KindPropertyAccessExpression, shimast.KindElementAccessExpression:
+    leftMember, ok := referenceMemberParts(left)
+    if !ok {
+      return false
+    }
+    rightMember, ok := referenceMemberParts(right)
+    if !ok || leftMember.optional != rightMember.optional ||
+      !sameReferenceExpression(leftMember.object, rightMember.object) {
+      return false
+    }
+    if leftMember.staticKey != nil || rightMember.staticKey != nil {
+      return leftMember.staticKey != nil && rightMember.staticKey != nil &&
+        *leftMember.staticKey == *rightMember.staticKey &&
+        leftMember.private == rightMember.private
+    }
+    return sameReferenceExpression(leftMember.dynamicKey, rightMember.dynamicKey)
+  default:
+    leftValue, leftKind, leftOK := referencePrimitiveValue(left)
+    rightValue, rightKind, rightOK := referencePrimitiveValue(right)
+    return leftOK && rightOK && leftKind == rightKind && leftValue == rightValue
+  }
+}
+
+// unwrapReferenceExpression removes syntax that has no runtime evaluation of
+// its own. Keep this list explicit: optional chains, calls, and instantiation
+// expressions are not harmless wrappers and must remain visible to callers.
+func unwrapReferenceExpression(node *shimast.Node) *shimast.Node {
+  for node != nil {
+    switch node.Kind {
+    case shimast.KindParenthesizedExpression,
+      shimast.KindAsExpression,
+      shimast.KindSatisfiesExpression,
+      shimast.KindNonNullExpression,
+      shimast.KindTypeAssertionExpression:
+      next := node.Expression()
+      if next == nil {
+        return node
+      }
+      node = next
+    default:
+      return node
+    }
+  }
+  return nil
+}
+
+type referenceMember struct {
+  object     *shimast.Node
+  staticKey  *string
+  dynamicKey *shimast.Node
+  optional   bool
+  private    bool
+}
+
+func referenceMemberParts(node *shimast.Node) (referenceMember, bool) {
+  switch node.Kind {
+  case shimast.KindPropertyAccessExpression:
+    access := node.AsPropertyAccessExpression()
+    if access == nil || access.Expression == nil || access.Name() == nil {
+      return referenceMember{}, false
+    }
+    name := access.Name()
+    if name.Kind != shimast.KindIdentifier && name.Kind != shimast.KindPrivateIdentifier {
+      return referenceMember{}, false
+    }
+    key := shimast.NodeText(name)
+    return referenceMember{
+      object:    access.Expression,
+      staticKey: &key,
+      optional:  access.QuestionDotToken != nil,
+      private:   name.Kind == shimast.KindPrivateIdentifier,
+    }, true
+  case shimast.KindElementAccessExpression:
+    access := node.AsElementAccessExpression()
+    if access == nil || access.Expression == nil || access.ArgumentExpression == nil {
+      return referenceMember{}, false
+    }
+    member := referenceMember{
+      object:     access.Expression,
+      dynamicKey: access.ArgumentExpression,
+      optional:   access.QuestionDotToken != nil,
+    }
+    if key, ok := referenceStaticPropertyKey(access.ArgumentExpression); ok {
+      member.staticKey = &key
+      member.dynamicKey = nil
+    }
+    return member, true
+  default:
+    return referenceMember{}, false
+  }
+}
+
+func referenceStaticPropertyKey(node *shimast.Node) (string, bool) {
+  node = unwrapReferenceExpression(node)
+  if node == nil {
+    return "", false
+  }
+  value, kind, ok := referencePrimitiveValue(node)
+  if ok {
+    if kind == "bigint" {
+      value = strings.TrimSuffix(value, "n")
+    }
+    return value, true
+  }
+  if node.Kind != shimast.KindPrefixUnaryExpression {
+    return "", false
+  }
+  prefix := node.AsPrefixUnaryExpression()
+  if prefix == nil || prefix.Operand == nil {
+    return "", false
+  }
+  value, kind, ok = referencePrimitiveValue(prefix.Operand)
+  if !ok || (kind != "number" && kind != "bigint") {
+    return "", false
+  }
+  value = strings.TrimSuffix(value, "n")
+  switch prefix.Operator {
+  case shimast.KindPlusToken:
+    return value, kind == "number"
+  case shimast.KindMinusToken:
+    if strings.Trim(value, "0.") == "" {
+      return "0", true
+    }
+    return "-" + value, true
+  default:
+    return "", false
+  }
+}
+
+// referencePrimitiveValue returns a normalized value plus a runtime-kind tag.
+// The tag keeps numerically similar values such as `1` and `1n` distinct when
+// they are receivers; referenceStaticPropertyKey intentionally collapses them
+// later because JavaScript converts both to the same string property key.
+func referencePrimitiveValue(node *shimast.Node) (value, kind string, ok bool) {
+  if node == nil {
+    return "", "", false
+  }
+  switch node.Kind {
+  case shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral:
+    return stringLiteralText(node), "string", true
+  case shimast.KindNumericLiteral:
+    return numericLiteralText(node), "number", true
+  case shimast.KindBigIntLiteral:
+    return numericLiteralText(node), "bigint", true
+  case shimast.KindTrueKeyword:
+    return "true", "boolean", true
+  case shimast.KindFalseKeyword:
+    return "false", "boolean", true
+  case shimast.KindNullKeyword:
+    return "null", "null", true
+  default:
+    return "", "", false
+  }
+}
+
 // isMatchingPropertyAccess reports whether `node` reads the chain
 // `head.tail[0].tail[1]…`. Useful for detecting `obj.__proto__` or
 // `console.log` shapes regardless of nesting.

--- a/packages/lint/linthost/rules_unicorn_prefer_at.go
+++ b/packages/lint/linthost/rules_unicorn_prefer_at.go
@@ -7,9 +7,10 @@
 // AST-only: visit each `ElementAccessExpression`. The index expression
 // must be a `BinaryExpression` whose operator is `-`, whose left side is
 // `PropertyAccess(_, length)`, and whose right side is a positive
-// numeric literal. The receiver of the `.length` access does not need
-// to match the element-access receiver textually; mismatches are
-// uncommon enough that the AST-only check stays useful in practice.
+// numeric literal. The `.length` receiver must be structurally equivalent to
+// the indexed receiver; otherwise recommending `.at(-N)` would change which
+// index is selected. The shared reference comparator ignores runtime-neutral
+// TypeScript wrappers while rejecting effectful repeated expressions.
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-at.md
 package linthost
 
@@ -41,6 +42,9 @@ func (unicornPreferAt) Check(ctx *Context, node *shimast.Node) {
   }
   prop := left.AsPropertyAccessExpression()
   if prop == nil || identifierText(prop.Name()) != "length" {
+    return
+  }
+  if !sameReferenceExpression(access.Expression, prop.Expression) {
     return
   }
   right := stripParens(bin.Right)

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_at_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_at_test.go
@@ -2,17 +2,74 @@ package linthost
 
 import "testing"
 
-// TestRuleCorpusUnicornPreferAt verifies unicorn/prefer-at reports the
-// `arr[arr.length - N]` shape.
+// TestRuleCorpusUnicornPreferAt verifies unicorn/prefer-at reports negative
+// indexing only when the indexed and `.length` receivers are equivalent.
 //
-// The rule walks the element-access expression and requires the index to be a
-// `length - positive-integer` subtraction. This fixture pins the most common
-// arm — the last-element pattern with N=1 — so regressions in the positive-int
-// validator surface here before exotic literal forms are tested.
+// Replacing `items[limits.length - 1]` with `items.at(-1)` changes behavior.
+// This matrix therefore locks identifier, property, element, private-field,
+// wrapper, optional-chain, and repeated-call boundaries through the public
+// diagnostic surface instead of testing the comparator in isolation.
 //
-// 1. Enable unicorn/prefer-at via an expect annotation.
-// 2. Index `xs[xs.length - 1]`.
-// 3. Assert the element access is reported.
+// 1. Exercise equivalent receivers through runtime-neutral TypeScript wrappers.
+// 2. Exercise adjacent mismatches and effectful repeated calls without expects.
+// 3. Assert findings occur only on semantics-preserving `.at(-N)` candidates.
 func TestRuleCorpusUnicornPreferAt(t *testing.T) {
-  assertRuleCorpusCase(t, "unicorn/prefer-at.ts", "const xs = [1, 2, 3];\n// expect: unicorn/prefer-at error\nconst last = xs[xs.length - 1];\n")
+  assertRuleCorpusCase(t, "unicorn/prefer-at.ts", `const xs = [1, 2, 3];
+// expect: unicorn/prefer-at error
+const last = xs[xs.length - 1];
+
+const limits = [0, 1];
+const mismatchedIdentifier = xs[limits.length - 1];
+
+// expect: unicorn/prefer-at error
+const lastCharacter = "abc"["abc".length - 1];
+const mismatchedString = "abc"["ab".length - 1];
+
+// expect: unicorn/prefer-at error
+const parenthesized = ((xs))[((xs)).length - 2];
+// expect: unicorn/prefer-at error
+const asserted = (xs as readonly number[])[(xs satisfies readonly number[]).length - 1];
+// expect: unicorn/prefer-at error
+const nonNull = xs![(<readonly number[]>xs!).length - 1];
+
+declare const holder: {
+  items: number[];
+  limits: number[];
+};
+// expect: unicorn/prefer-at error
+const propertyReceiver = holder.items[holder.items.length - 1];
+// expect: unicorn/prefer-at error
+const staticElementReceiver = holder["items"][holder.items.length - 1];
+const mismatchedProperty = holder.items[holder.limits.length - 1];
+
+declare const matrix: number[][];
+declare const index: number;
+// expect: unicorn/prefer-at error
+const elementReceiver = matrix[index][matrix[index].length - 1];
+// expect: unicorn/prefer-at error
+const equivalentStaticKey = matrix[0][matrix["0"].length - 1];
+const mismatchedElement = matrix[0][matrix[1].length - 1];
+
+declare function make(): number[];
+const repeatedCall = make()[make().length - 1];
+
+declare const parent: { children: number[] };
+// expect: unicorn/prefer-at error
+const optionalMatch = parent?.children[parent?.children.length - 1];
+const optionalMismatch = parent?.children[parent.children.length - 1];
+
+class Holder {
+  #items = [1, 2, 3];
+  #limits = [0, 1];
+
+  last(): number {
+    // expect: unicorn/prefer-at error
+    return this.#items[this.#items.length - 1];
+  }
+
+  mismatched(): number {
+    return this.#items[this.#limits.length - 1];
+  }
+}
+`)
 }

--- a/tests/test-lint/src/cases/unicorn-prefer-at.ts
+++ b/tests/test-lint/src/cases/unicorn-prefer-at.ts
@@ -1,3 +1,57 @@
 const xs = [1, 2, 3];
 // expect: unicorn/prefer-at error
 const last = xs[xs.length - 1];
+
+const limits = [0, 1];
+const mismatchedIdentifier = xs[limits.length - 1];
+
+// expect: unicorn/prefer-at error
+const lastCharacter = "abc"["abc".length - 1];
+const mismatchedString = "abc"["ab".length - 1];
+
+// expect: unicorn/prefer-at error
+const parenthesized = ((xs))[((xs)).length - 2];
+// expect: unicorn/prefer-at error
+const asserted = (xs as readonly number[])[(xs satisfies readonly number[]).length - 1];
+// expect: unicorn/prefer-at error
+const nonNull = xs![(<readonly number[]>xs!).length - 1];
+
+declare const holder: {
+  items: number[];
+  limits: number[];
+};
+// expect: unicorn/prefer-at error
+const propertyReceiver = holder.items[holder.items.length - 1];
+// expect: unicorn/prefer-at error
+const staticElementReceiver = holder["items"][holder.items.length - 1];
+const mismatchedProperty = holder.items[holder.limits.length - 1];
+
+declare const matrix: number[][];
+declare const index: number;
+// expect: unicorn/prefer-at error
+const elementReceiver = matrix[index][matrix[index].length - 1];
+// expect: unicorn/prefer-at error
+const equivalentStaticKey = matrix[0][matrix["0"].length - 1];
+const mismatchedElement = matrix[0][matrix[1].length - 1];
+
+declare function make(): number[];
+const repeatedCall = make()[make().length - 1];
+
+declare const parent: { children: number[] };
+// expect: unicorn/prefer-at error
+const optionalMatch = parent?.children[parent?.children.length - 1];
+const optionalMismatch = parent?.children[parent.children.length - 1];
+
+class Holder {
+  #items = [1, 2, 3];
+  #limits = [0, 1];
+
+  last(): number {
+    // expect: unicorn/prefer-at error
+    return this.#items[this.#items.length - 1];
+  }
+
+  mismatched(): number {
+    return this.#items[this.#limits.length - 1];
+  }
+}

--- a/website/src/content/docs/lint/rules/unicorn.mdx
+++ b/website/src/content/docs/lint/rules/unicorn.mdx
@@ -1373,7 +1373,10 @@ const hasLarge = xs.filter((x) => x > 1).length > 0;
 
 ### `unicorn/prefer-at`
 
-Prefer `Array#at` / `String#at` over index arithmetic and `charAt`.
+Prefer `Array#at` / `String#at` over negative index arithmetic when the
+indexed value and the `.length` receiver are the same runtime reference.
+Receiver mismatches are left unchanged because `.at(-N)` would select a
+different element.
 
 Example:
 
@@ -1381,6 +1384,9 @@ Example:
 const xs = [1, 2, 3];
 // reports: unicorn/prefer-at (error)
 const last = xs[xs.length - 1];
+
+const limits = [0, 1];
+const unchanged = xs[limits.length - 1];
 ```
 
 <a id="rule-unicorn-prefer-bigint-literals"></a>


### PR DESCRIPTION
## Intent
Prevent `unicorn/prefer-at` from recommending `.at(-N)` when the indexed receiver and the `.length` receiver select different values.

## Scope
- compare repeatable receiver expressions structurally through runtime-neutral TypeScript wrappers
- normalize static member keys while rejecting calls and optional-chain mismatches
- add positive and negative regression coverage to the Go rule corpus and TypeScript feature corpus
- document the matching-receiver contract

## Deferred
- broader `unicorn/prefer-at` parity such as additional upstream expression forms and options is outside this receiver-safety fix

## Test plan
After the mandated three clean full-change reviews, run the focused native lint test harness for the prefer-at regression and the matching TypeScript feature test. Formatting is intentionally not run per task instruction.

Closes #522