### PR TITLE
fix(lint): preserve import evaluation order by default

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -105,6 +105,7 @@ export default {
     trailingComma: "all",
     sortImports: {
       order: ["<BUILTIN_MODULES>", "", "<THIRD_PARTY_MODULES>", "", "^[./]"],
+      unsafeSortRuntimeImports: true, // accepts module evaluation reordering
     },
     jsDoc: true,
   },
@@ -126,10 +127,12 @@ Each `format` key controls one behavior:
 | `quoteProps` | Quote or unquote object property keys. |
 | `trailingComma` | Add trailing commas to multi-line lists. |
 | `printWidth`, `tabWidth`, `useTabs`, `endOfLine` | Column-aware line reflow. Object/array literals, call/new arguments, and named import/export clauses break across lines when their flat form overflows the budget. |
-| `sortImports` (opt-in) | Group imports by `order`, alphabetize each group + its specifiers, and merge duplicate modules. |
+| `sortImports` (opt-in) | Sort named specifiers and erased type-only imports. Runtime declaration sorting requires `unsafeSortRuntimeImports`. |
 | `jsDoc` (on by default) | Normalize JSDoc blocks toward [prettier-plugin-jsdoc](https://github.com/hosseinmd/prettier-plugin-jsdoc). |
 
 `sortImports` is **opt-in** — it takes effect only when you set it. Every other key takes effect as soon as the `format` block is present (JSDoc normalization included; set `jsDoc: false` to opt out), which also applies several keyless layout behaviors (statement splitting, indentation, whitespace normalization, clause joining, declaration-header reflow, ternary-nullish parens, leading-semicolon merging, and parameter-property breaking).
+
+The safe default preserves the source order of every runtime-bearing import, including default, namespace, named, and bare imports, because each form can evaluate its dependency module. It still alphabetizes named specifiers within one declaration and can sort or merge a block made entirely of erased `import type` declarations. Set `unsafeSortRuntimeImports: true` only when every dependency in the block is order-independent. `combineTypeAndValue` affects a mixed type/value block only under that unsafe opt-in.
 
 Formatting is configured **only** through the `format` block. The `rules` map is for lint rules; a `format/*` id placed there is ignored. To turn a format behavior off, set its `format` key (for example `trailingComma: "none"`), not a `rules` entry.
 

--- a/packages/lint/linthost/config_format.go
+++ b/packages/lint/linthost/config_format.go
@@ -316,8 +316,14 @@ func expandSortImportsBlock(v any) (map[string]any, bool, error) {
           return nil, false, err
         }
         opts["combineTypeAndValue"] = b
+      case "unsafeSortRuntimeImports":
+        b, err := asBool("format.sortImports.unsafeSortRuntimeImports", val)
+        if err != nil {
+          return nil, false, err
+        }
+        opts["unsafeSortRuntimeImports"] = b
       default:
-        return nil, false, fmt.Errorf("@ttsc/lint: format.sortImports unknown key %q (allowed: order, caseSensitive, combineTypeAndValue)", key)
+        return nil, false, fmt.Errorf("@ttsc/lint: format.sortImports unknown key %q (allowed: order, caseSensitive, combineTypeAndValue, unsafeSortRuntimeImports)", key)
       }
     }
     return opts, true, nil

--- a/packages/lint/linthost/rules_format_sort_imports.go
+++ b/packages/lint/linthost/rules_format_sort_imports.go
@@ -29,9 +29,10 @@ const (
 
 // formatSortImportsOptions mirrors `ITtscLintFormatSortImports`.
 type formatSortImportsOptions struct {
-  Order               []string `json:"order"`
-  CaseSensitive       bool     `json:"caseSensitive"`
-  CombineTypeAndValue bool     `json:"combineTypeAndValue"`
+  Order                    []string `json:"order"`
+  CaseSensitive            bool     `json:"caseSensitive"`
+  CombineTypeAndValue      bool     `json:"combineTypeAndValue"`
+  UnsafeSortRuntimeImports bool     `json:"unsafeSortRuntimeImports"`
 }
 
 // defaultImportOrder is used when the user supplies no `order`: Node built-ins,
@@ -44,12 +45,13 @@ var defaultImportOrder = []string{
   `^[.]`,
 }
 
-// formatSortImports orders the file's top-level import declarations into
-// canonical groups, alphabetizes each group, merges duplicate imports of the
-// same module, and (when `combineTypeAndValue` is on) folds a type-only
-// import into a value import of the same module. Groups are user-configurable
-// via the `order` option; when omitted, the rule falls back to {@link
-// defaultImportOrder}.
+// formatSortImports safely sorts named specifiers and erased type-only import
+// blocks. Runtime-bearing declarations retain source order unless the user
+// explicitly enables `unsafeSortRuntimeImports`; only then are they grouped,
+// alphabetized, and merged. When that unsafe mode and `combineTypeAndValue`
+// are both on, a type-only import may fold into a value import of the same
+// module. Groups are user-configurable via the `order` option; when omitted,
+// the rule falls back to {@link defaultImportOrder}.
 //
 // Within each group, declarations are sorted by their module-specifier text
 // (ASCII order, or case-insensitive unless `caseSensitive: true`). Named
@@ -58,9 +60,9 @@ var defaultImportOrder = []string{
 // Safety policy: if any byte between the contiguous imports is not
 // whitespace, the rule bails. Comments anchored to specific imports would
 // otherwise move with the wrong declaration, which is a strictly worse
-// outcome than declining to sort. Side-effect imports (`import "foo"`) also
-// bail the whole block because their evaluation order can carry meaning the
-// rule cannot reason about.
+// outcome than declining to sort. Every import other than `import type` can
+// evaluate a module, including default, namespace, and named binding imports,
+// so declaration-level rewriting is disabled for those blocks by default.
 type formatSortImports struct{}
 
 func (formatSortImports) Name() string   { return "format/sort-imports" }
@@ -80,19 +82,15 @@ func (formatSortImports) Check(ctx *Context, node *shimast.Node) {
     return
   }
   imports := collectLeadingImports(statements.Nodes)
-  // Block-level reorder runs only when the rule can do it safely:
-  // two or more contiguous imports with no comment trivia between
-  // them (comments anchor to specific imports and moving them would
-  // mis-attach the user's intent), AND no side-effect-only imports
-  // in the block. A side-effect import (`import "./polyfill"`) runs
-  // its module's top-level code for its observable effect; sorting it
-  // across a sibling import that depends on the polyfill being
-  // initialized first would silently change runtime behavior. The
-  // rule conservatively refuses to reorder the entire block in that
-  // case.
+  // Block-level rewriting runs only for erased type-only imports or after the
+  // caller explicitly accepts runtime reordering. Binding imports execute
+  // their dependencies just like bare imports, so preserving only
+  // `import "./polyfill"` is insufficient. Comment trivia remains an
+  // unconditional barrier even in unsafe mode because the rebuilder cannot
+  // preserve a comment's declaration attachment.
   if len(imports) >= 2 &&
     leadingTriviaIsAllWhitespace(src, imports) &&
-    !containsSideEffectImport(imports) {
+    (opts.unsafeSortRuntimeImports || !importsHaveRuntimeEvaluation(imports)) {
     first := imports[0]
     last := imports[len(imports)-1]
     replaceStart := shimscanner.SkipTrivia(src, first.Pos())
@@ -118,9 +116,10 @@ func (formatSortImports) Check(ctx *Context, node *shimast.Node) {
 // during one Check call. All option defaults are applied here so the
 // rest of the rule code does not branch on nil-ness.
 type resolvedSortImportsOptions struct {
-  groups              []sortImportsGroup
-  caseSensitive       bool
-  combineTypeAndValue bool
+  groups                   []sortImportsGroup
+  caseSensitive            bool
+  combineTypeAndValue      bool
+  unsafeSortRuntimeImports bool
 }
 
 // sortImportsGroup is one resolved entry of the `order` array. A separator
@@ -144,9 +143,10 @@ func loadSortImportsOptions(ctx *Context) resolvedSortImportsOptions {
   }
   groups := parseImportOrder(order)
   return resolvedSortImportsOptions{
-    groups:              groups,
-    caseSensitive:       raw.CaseSensitive,
-    combineTypeAndValue: raw.CombineTypeAndValue,
+    groups:                   groups,
+    caseSensitive:            raw.CaseSensitive,
+    combineTypeAndValue:      raw.CombineTypeAndValue,
+    unsafeSortRuntimeImports: raw.UnsafeSortRuntimeImports,
   }
 }
 
@@ -298,21 +298,22 @@ func specifierListHasCommentTrivia(src string, specifiers []*shimast.Node) bool 
   return false
 }
 
-// containsSideEffectImport reports whether any import in the contiguous
-// block has no import clause (i.e. is a side-effect-only `import "x"`).
-// These imports are evaluated for their top-level effect; their order
-// relative to other imports may carry meaning the rule cannot reason
-// about, so the safety policy is to refuse to sort.
-func containsSideEffectImport(imports []*shimast.Node) bool {
+// importsHaveRuntimeEvaluation reports whether a contiguous block contains an
+// import that survives as a module dependency. Bare, default, namespace,
+// named, and deferred imports can all trigger top-level evaluation; only a
+// clause explicitly marked `type` is erased. Unexpected AST shapes are treated
+// as runtime-bearing so a parser change cannot silently weaken the guard.
+func importsHaveRuntimeEvaluation(imports []*shimast.Node) bool {
   for _, decl := range imports {
     if decl == nil {
-      continue
+      return true
     }
     imp := decl.AsImportDeclaration()
-    if imp == nil {
-      continue
+    if imp == nil || imp.ImportClause == nil {
+      return true
     }
-    if imp.ImportClause == nil {
+    clause := imp.ImportClause.AsImportClause()
+    if clause == nil || clause.PhaseModifier != shimast.KindTypeKeyword {
       return true
     }
   }

--- a/packages/lint/src/structures/format/ITtscLintFormat.ts
+++ b/packages/lint/src/structures/format/ITtscLintFormat.ts
@@ -120,8 +120,9 @@ export interface ITtscLintFormat {
   endOfLine?: "lf" | "crlf";
 
   /**
-   * Import sorting & merging. Off unless present; `true` enables it with
-   * defaults, an object customizes.
+   * Import formatting. Off unless present; `true` sorts named specifiers and
+   * erased type-only imports with defaults, and an object customizes behavior.
+   * Runtime declaration reordering requires an explicit unsafe opt-in.
    *
    * @default false
    */

--- a/packages/lint/src/structures/format/ITtscLintFormatSortImports.ts
+++ b/packages/lint/src/structures/format/ITtscLintFormatSortImports.ts
@@ -2,9 +2,9 @@
  * Object form of {@link ITtscLintFormat.sortImports}.
  *
  * The declarative {@link order} array expresses group order, blank-line
- * separation, and special groups all by position. Multiple imports of the same
- * module are always merged into one declaration; merging a value import with a
- * type-only import additionally requires {@link combineTypeAndValue}.
+ * separation, and special groups all by position. By default, declaration-level
+ * sorting and merging are limited to erased `import type` blocks. Runtime
+ * imports retain source order unless {@link unsafeSortRuntimeImports} is set.
  */
 export interface ITtscLintFormatSortImports {
   /**
@@ -54,9 +54,26 @@ export interface ITtscLintFormatSortImports {
    * Merge a value import and a type-only import of the same module into one
    * declaration with inline `type` specifiers: `import { foo } from "m"` plus
    * `import type { Bar } from "m"` collapse to `import { foo, type Bar } from
-   * "m"`.
+   * "m"`. Mixed type/value blocks are left unchanged unless
+   * {@link unsafeSortRuntimeImports} is also enabled.
    *
    * @default false
    */
   combineTypeAndValue?: boolean;
+
+  /**
+   * Permit declaration-level sorting and merging of runtime-bearing imports.
+   *
+   * Every default, namespace, named, and bare import can evaluate its module.
+   * Reordering those declarations can therefore change program behavior. Keep
+   * this disabled unless every imported module in the block is order-independent.
+   * Named specifiers inside a declaration and erased `import type` blocks are
+   * still sorted when this option is disabled.
+   *
+   * {@link combineTypeAndValue} only affects mixed type/value blocks when this
+   * option is enabled.
+   *
+   * @default false
+   */
+  unsafeSortRuntimeImports?: boolean;
 }

--- a/packages/lint/test/config/format_block_propagates_sort_imports_options_test.go
+++ b/packages/lint/test/config/format_block_propagates_sort_imports_options_test.go
@@ -6,15 +6,15 @@ import (
 )
 
 // TestFormatBlockPropagatesSortImportsOptions verifies the `sortImports` object
-// form forwards its `order`, `caseSensitive`, and `combineTypeAndValue` fields
-// into the format/sort-imports rule entry.
+// form forwards its `order`, `caseSensitive`, `combineTypeAndValue`, and
+// `unsafeSortRuntimeImports` fields into the format/sort-imports rule entry.
 //
 // Locks the success arms inside expandSortImportsBlock. The error-path tests
 // prove validation rejects bad values; this proves valid values populate the
 // emitted options blob rather than being silently dropped.
 //
 //  1. Build a format block with sortImports set to an object exercising all
-//     three fields.
+//     four fields.
 //  2. Call expandFormatBlock.
 //  3. Assert no error and the rule entry carries every field verbatim.
 func TestFormatBlockPropagatesSortImportsOptions(t *testing.T) {
@@ -23,6 +23,7 @@ func TestFormatBlockPropagatesSortImportsOptions(t *testing.T) {
       "order":               []any{"<TYPES>", "", "^[./]"},
       "caseSensitive":       true,
       "combineTypeAndValue": true,
+      "unsafeSortRuntimeImports": true,
     },
   })
   if err != nil {
@@ -41,9 +42,10 @@ func TestFormatBlockPropagatesSortImportsOptions(t *testing.T) {
     t.Fatalf("entry not a [severity, opts] tuple: %v", err)
   }
   var o struct {
-    Order               []string `json:"order"`
-    CaseSensitive       bool     `json:"caseSensitive"`
-    CombineTypeAndValue bool     `json:"combineTypeAndValue"`
+    Order                    []string `json:"order"`
+    CaseSensitive            bool     `json:"caseSensitive"`
+    CombineTypeAndValue      bool     `json:"combineTypeAndValue"`
+    UnsafeSortRuntimeImports bool     `json:"unsafeSortRuntimeImports"`
   }
   if err := json.Unmarshal(tuple[1], &o); err != nil {
     t.Fatalf("decode sort-imports opts: %v", err)
@@ -56,5 +58,8 @@ func TestFormatBlockPropagatesSortImportsOptions(t *testing.T) {
   }
   if !o.CombineTypeAndValue {
     t.Error("combineTypeAndValue should be true")
+  }
+  if !o.UnsafeSortRuntimeImports {
+    t.Error("unsafeSortRuntimeImports should be true")
   }
 }

--- a/packages/lint/test/config/format_block_rejects_non_bool_sort_imports_options_test.go
+++ b/packages/lint/test/config/format_block_rejects_non_bool_sort_imports_options_test.go
@@ -8,8 +8,8 @@ import (
 // TestFormatBlockRejectsNonBoolSortImportsOptions verifies the boolean
 // sub-options of sortImports reject non-boolean values.
 //
-// Locks the asBool error paths for caseSensitive and combineTypeAndValue. A
-// non-bool value for either must be surfaced at the format-block boundary
+// Locks the asBool error paths for every boolean option. A non-bool value must
+// be surfaced at the format-block boundary
 // rather than coerced.
 //
 //  1. For each boolean sub-option, build sortImports with a non-bool value.
@@ -23,6 +23,7 @@ func TestFormatBlockRejectsNonBoolSortImportsOptions(t *testing.T) {
   }{
     {"caseSensitive", "yes", "format.sortImports.caseSensitive"},
     {"combineTypeAndValue", 1, "format.sortImports.combineTypeAndValue"},
+    {"unsafeSortRuntimeImports", "yes", "format.sortImports.unsafeSortRuntimeImports"},
   }
   for _, tc := range cases {
     _, err := expandFormatBlock(map[string]any{

--- a/packages/lint/test/format/format_sort_imports_combine_requires_unsafe_runtime_opt_in_test.go
+++ b/packages/lint/test/format/format_sort_imports_combine_requires_unsafe_runtime_opt_in_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFormatSortImportsCombineRequiresUnsafeRuntimeOptIn verifies
+// combineTypeAndValue alone cannot rewrite a runtime-bearing import block.
+//
+// Combining declarations uses the same whole-block rebuilder as grouping and
+// sorting. Letting the apparently narrow option bypass the runtime guard would
+// reintroduce declaration reordering through a less obvious configuration path.
+//
+//  1. Parse same-module value and type-only declarations.
+//  2. Enable combineTypeAndValue without unsafeSortRuntimeImports.
+//  3. Assert the mixed block remains byte-for-byte unchanged.
+func TestFormatSortImportsCombineRequiresUnsafeRuntimeOptIn(t *testing.T) {
+  source := "import { value } from \"m\";\n" +
+    "import type { Value } from \"m\";\n" +
+    "value;\n"
+  assertRuleSkipsSourceWithOptions(
+    t,
+    "format/sort-imports",
+    source,
+    `{"combineTypeAndValue":true}`,
+  )
+}

--- a/packages/lint/test/format/format_sort_imports_combines_type_and_value_test.go
+++ b/packages/lint/test/format/format_sort_imports_combines_type_and_value_test.go
@@ -10,7 +10,7 @@ import "testing"
 // declaration is no longer type-only.
 //
 //  1. Parse a value import and a type-only import of the same module.
-//  2. Apply the rule with combineTypeAndValue enabled.
+//  2. Enable combineTypeAndValue and unsafe runtime sorting.
 //  3. Assert one declaration with the value specifier before the inline `type`.
 func TestFormatSortImportsCombinesTypeAndValue(t *testing.T) {
   source := "import { foo } from \"m\";\n" +
@@ -18,5 +18,5 @@ func TestFormatSortImportsCombinesTypeAndValue(t *testing.T) {
     "foo;\n"
   expected := "import { foo, type Bar } from \"m\";\n" +
     "foo;\n"
-  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"combineTypeAndValue":true}`, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"combineTypeAndValue":true,"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_dedupes_repeated_specifier_test.go
+++ b/packages/lint/test/format/format_sort_imports_dedupes_repeated_specifier_test.go
@@ -9,7 +9,7 @@ import "testing"
 // declarations each importing `{ a }` yield one `{ a }`.
 //
 //  1. Parse two imports of `{ a }` from the same module.
-//  2. Apply the rule with default options.
+//  2. Apply the rule with unsafe runtime sorting enabled.
 //  3. Assert the merged declaration lists `a` once.
 func TestFormatSortImportsDedupesRepeatedSpecifier(t *testing.T) {
   source := "import { a } from \"m\";\n" +
@@ -17,5 +17,5 @@ func TestFormatSortImportsDedupesRepeatedSpecifier(t *testing.T) {
     "a;\n"
   expected := "import { a } from \"m\";\n" +
     "a;\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_groups_builtins_first_test.go
+++ b/packages/lint/test/format/format_sort_imports_groups_builtins_first_test.go
@@ -9,7 +9,7 @@ import "testing"
 // built-in specifier must land there ahead of everything else.
 //
 //  1. Parse a file mixing a built-in, a third-party, and a relative import.
-//  2. Apply the rule with default options.
+//  2. Apply the rule with unsafe runtime sorting enabled.
 //  3. Assert the built-in import sits first.
 func TestFormatSortImportsGroupsBuiltinsFirst(t *testing.T) {
   source := "import { x } from \"./local\";\n" +
@@ -20,5 +20,5 @@ func TestFormatSortImportsGroupsBuiltinsFirst(t *testing.T) {
     "import express from \"express\";\n" +
     "import { x } from \"./local\";\n" +
     "JSON.stringify({ x, express, readFile });\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_groups_external_before_relative_test.go
+++ b/packages/lint/test/format/format_sort_imports_groups_external_before_relative_test.go
@@ -26,5 +26,5 @@ func TestFormatSortImportsGroupsExternalBeforeRelative(t *testing.T) {
     "import { x } from \"./local-a\";\n" +
     "import { reduce } from \"./local-b\";\n" +
     "JSON.stringify({ reduce, zebra, x, alpha });\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_groups_type_only_imports_test.go
+++ b/packages/lint/test/format/format_sort_imports_groups_type_only_imports_test.go
@@ -9,7 +9,7 @@ import "testing"
 // `<TYPES>` group placed first pulls every `import type` to the top.
 //
 //  1. Parse a value import and a type-only import.
-//  2. Apply the rule with order ["<TYPES>", "<THIRD_PARTY_MODULES>"].
+//  2. Apply that order with unsafe runtime sorting enabled.
 //  3. Assert the type-only import sorts first.
 func TestFormatSortImportsGroupsTypeOnlyImports(t *testing.T) {
   source := "import { a } from \"m\";\n" +
@@ -18,5 +18,5 @@ func TestFormatSortImportsGroupsTypeOnlyImports(t *testing.T) {
   expected := "import type { B } from \"n\";\n" +
     "import { a } from \"m\";\n" +
     "a;\n"
-  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"order":["<TYPES>","<THIRD_PARTY_MODULES>"]}`, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"order":["<TYPES>","<THIRD_PARTY_MODULES>"],"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_honors_custom_import_order_test.go
+++ b/packages/lint/test/format/format_sort_imports_honors_custom_import_order_test.go
@@ -21,8 +21,7 @@ import (
 // the engine.
 //
 //  1. Parse a source file with mixed import classes.
-//  2. Apply the rule with a custom `order` (third-party, then `@api/*`, then
-//     relative) separated by blank lines.
+//  2. Apply the custom order and separators with unsafe runtime sorting.
 //  3. Assert the rewritten file has the imports laid out per the spec.
 func TestFormatSortImportsHonorsCustomImportOrder(t *testing.T) {
   root := t.TempDir()
@@ -39,7 +38,7 @@ func TestFormatSortImportsHonorsCustomImportOrder(t *testing.T) {
     Rules: RuleConfig{"format/sort-imports": SeverityError},
     Options: RuleOptionsMap{
       "format/sort-imports": json.RawMessage(
-        `{"order":["<THIRD_PARTY_MODULES>","","@api(.*)$","","^[./]"]}`,
+        `{"order":["<THIRD_PARTY_MODULES>","","@api(.*)$","","^[./]"],"unsafeSortRuntimeImports":true}`,
       ),
     },
   }

--- a/packages/lint/test/format/format_sort_imports_keeps_conflicting_defaults_separate_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_conflicting_defaults_separate_test.go
@@ -10,7 +10,7 @@ import "testing"
 //
 //  1. Parse a file with two different defaults from the same module plus a
 //     later-sorting third-party import.
-//  2. Apply the rule with default options.
+//  2. Apply the rule with unsafe runtime sorting enabled.
 //  3. Assert the conflicting defaults remain two declarations.
 func TestFormatSortImportsKeepsConflictingDefaultsSeparate(t *testing.T) {
   source := "import { z } from \"z\";\n" +
@@ -25,5 +25,5 @@ func TestFormatSortImportsKeepsConflictingDefaultsSeparate(t *testing.T) {
     "z;\n" +
     "a;\n" +
     "b;\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_keeps_empty_named_imports_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_empty_named_imports_test.go
@@ -11,7 +11,7 @@ import "testing"
 //
 //  1. Parse two `import {}` declarations from the same module plus a
 //     later-sorting third-party import.
-//  2. Apply the rule with default options.
+//  2. Apply the rule with unsafe runtime sorting enabled.
 //  3. Assert the empty imports survive as separate declarations.
 func TestFormatSortImportsKeepsEmptyNamedImports(t *testing.T) {
   source := "import { z } from \"z\";\n" +
@@ -22,5 +22,5 @@ func TestFormatSortImportsKeepsEmptyNamedImports(t *testing.T) {
     "import {} from \"m\";\n" +
     "import { z } from \"z\";\n" +
     "z;\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_keeps_identical_commented_imports_unmerged_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_identical_commented_imports_unmerged_test.go
@@ -15,7 +15,7 @@ import "testing"
 //
 //  1. Parse two identical named imports carrying a specifier comment plus a
 //     later-sorting third-party import.
-//  2. Apply the rule with default options.
+//  2. Apply the rule with unsafe runtime sorting enabled.
 //  3. Assert both commented declarations survive verbatim, sorted first.
 func TestFormatSortImportsKeepsIdenticalCommentedImportsUnmerged(t *testing.T) {
   source := "import { z } from \"z\";\n" +
@@ -26,5 +26,5 @@ func TestFormatSortImportsKeepsIdenticalCommentedImportsUnmerged(t *testing.T) {
     "import { a /* keep */ } from \"m\";\n" +
     "import { z } from \"z\";\n" +
     "z;\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_keeps_identical_namespace_imports_unmerged_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_identical_namespace_imports_unmerged_test.go
@@ -15,7 +15,7 @@ import "testing"
 //
 //  1. Parse two identical `import D, * as N` declarations plus a
 //     later-sorting third-party import.
-//  2. Apply the rule with default options.
+//  2. Apply the rule with unsafe runtime sorting enabled.
 //  3. Assert both namespace declarations survive verbatim, sorted first.
 func TestFormatSortImportsKeepsIdenticalNamespaceImportsUnmerged(t *testing.T) {
   source := "import { z } from \"z\";\n" +
@@ -26,5 +26,5 @@ func TestFormatSortImportsKeepsIdenticalNamespaceImportsUnmerged(t *testing.T) {
     "import D, * as N from \"m\";\n" +
     "import { z } from \"z\";\n" +
     "z;\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_keeps_namespace_imports_separate_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_namespace_imports_separate_test.go
@@ -10,7 +10,7 @@ import "testing"
 //
 //  1. Parse a file with a namespace and a named import of the same module plus
 //     a later-sorting third-party import.
-//  2. Apply the rule with default options.
+//  2. Apply the rule with unsafe runtime sorting enabled.
 //  3. Assert the namespace import stays its own declaration.
 func TestFormatSortImportsKeepsNamespaceImportsSeparate(t *testing.T) {
   source := "import { z } from \"z\";\n" +
@@ -25,5 +25,5 @@ func TestFormatSortImportsKeepsNamespaceImportsSeparate(t *testing.T) {
     "z;\n" +
     "ns;\n" +
     "a;\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_keeps_type_and_value_separate_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_type_and_value_separate_test.go
@@ -11,7 +11,7 @@ import "testing"
 //
 //  1. Parse a value import and a type-only import of the same module plus a
 //     later-sorting third-party import.
-//  2. Apply the rule with default options.
+//  2. Apply the rule with unsafe runtime sorting enabled.
 //  3. Assert the value and type-only imports remain separate.
 func TestFormatSortImportsKeepsTypeAndValueSeparate(t *testing.T) {
   source := "import { z } from \"z\";\n" +
@@ -22,5 +22,5 @@ func TestFormatSortImportsKeepsTypeAndValueSeparate(t *testing.T) {
     "import type { Bar } from \"m\";\n" +
     "import { z } from \"z\";\n" +
     "foo;\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_keeps_type_default_and_type_named_separate_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_type_default_and_type_named_separate_test.go
@@ -14,7 +14,7 @@ import "testing"
 //
 //  1. Parse a type-only default import and a type-only named import of the
 //     same module plus a later-sorting third-party import.
-//  2. Apply the rule with default options.
+//  2. Apply the rule with unsafe runtime sorting enabled.
 //  3. Assert the two type-only declarations stay separate, sorted first.
 func TestFormatSortImportsKeepsTypeDefaultAndTypeNamedSeparate(t *testing.T) {
   source := "import { z } from \"z\";\n" +
@@ -25,5 +25,5 @@ func TestFormatSortImportsKeepsTypeDefaultAndTypeNamedSeparate(t *testing.T) {
     "import type { A } from \"m\";\n" +
     "import { z } from \"z\";\n" +
     "z;\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_keeps_type_default_and_type_named_separate_when_combining_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_type_default_and_type_named_separate_when_combining_test.go
@@ -14,7 +14,7 @@ import "testing"
 //
 //  1. Parse a type-only default import and a type-only named import of the
 //     same module plus a later-sorting third-party import.
-//  2. Apply the rule with combineTypeAndValue enabled.
+//  2. Enable combineTypeAndValue and unsafe runtime sorting.
 //  3. Assert the two type-only declarations stay separate, sorted first.
 func TestFormatSortImportsKeepsTypeDefaultAndTypeNamedSeparateWhenCombining(t *testing.T) {
   source := "import { z } from \"z\";\n" +
@@ -25,5 +25,5 @@ func TestFormatSortImportsKeepsTypeDefaultAndTypeNamedSeparateWhenCombining(t *t
     "import type { A } from \"m\";\n" +
     "import { z } from \"z\";\n" +
     "z;\n"
-  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"combineTypeAndValue":true}`, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"combineTypeAndValue":true,"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_keeps_type_default_separate_when_combining_test.go
+++ b/packages/lint/test/format/format_sort_imports_keeps_type_default_separate_when_combining_test.go
@@ -11,7 +11,7 @@ import "testing"
 //
 //  1. Parse a type-only default import and a value import of the same module
 //     plus a later-sorting third-party import.
-//  2. Apply the rule with combineTypeAndValue enabled.
+//  2. Enable combineTypeAndValue and unsafe runtime sorting.
 //  3. Assert the type-only default import stays its own declaration.
 func TestFormatSortImportsKeepsTypeDefaultSeparateWhenCombining(t *testing.T) {
   source := "import { z } from \"z\";\n" +
@@ -22,5 +22,5 @@ func TestFormatSortImportsKeepsTypeDefaultSeparateWhenCombining(t *testing.T) {
     "import { x } from \"m\";\n" +
     "import { z } from \"z\";\n" +
     "x;\n"
-  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"combineTypeAndValue":true}`, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"combineTypeAndValue":true,"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_merges_default_and_named_test.go
+++ b/packages/lint/test/format/format_sort_imports_merges_default_and_named_test.go
@@ -8,7 +8,7 @@ import "testing"
 // The default binding survives alongside the union of named specifiers.
 //
 //  1. Parse a file importing `{ b }` and a default from the same module.
-//  2. Apply the rule with default options.
+//  2. Apply the rule with unsafe runtime sorting enabled.
 //  3. Assert one merged `default, { named }` declaration.
 func TestFormatSortImportsMergesDefaultAndNamed(t *testing.T) {
   source := "import { b } from \"m\";\n" +
@@ -18,5 +18,5 @@ func TestFormatSortImportsMergesDefaultAndNamed(t *testing.T) {
   expected := "import a, { b } from \"m\";\n" +
     "a;\n" +
     "b;\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_merges_duplicate_modules_test.go
+++ b/packages/lint/test/format/format_sort_imports_merges_duplicate_modules_test.go
@@ -5,11 +5,11 @@ import "testing"
 // TestFormatSortImportsMergesDuplicateModules verifies two value imports of the
 // same module collapse into one declaration with the union of named specifiers.
 //
-// Duplicate merging is always on; the merged specifier list is de-duplicated
-// and sorted.
+// Duplicate runtime merging is available only through the explicit unsafe
+// option; once enabled, the merged specifier list is de-duplicated and sorted.
 //
 //  1. Parse a file importing `{ b }` and `{ a }` from the same module.
-//  2. Apply the rule with default options.
+//  2. Apply the rule with unsafe runtime sorting enabled.
 //  3. Assert one merged, sorted declaration.
 func TestFormatSortImportsMergesDuplicateModules(t *testing.T) {
   source := "import { b } from \"m\";\n" +
@@ -19,5 +19,5 @@ func TestFormatSortImportsMergesDuplicateModules(t *testing.T) {
   expected := "import { a, b } from \"m\";\n" +
     "a;\n" +
     "b;\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_merges_type_named_binding_test.go
+++ b/packages/lint/test/format/format_sort_imports_merges_type_named_binding_test.go
@@ -20,5 +20,5 @@ func TestFormatSortImportsMergesTypeNamedBinding(t *testing.T) {
     "foo;\n"
   expected := "import { foo, type type as bar } from \"m\";\n" +
     "foo;\n"
-  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"combineTypeAndValue":true}`, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"combineTypeAndValue":true,"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_orders_case_insensitively_by_default_test.go
+++ b/packages/lint/test/format/format_sort_imports_orders_case_insensitively_by_default_test.go
@@ -9,7 +9,7 @@ import "testing"
 // default lowercases both before comparing, so `apple` precedes `React`.
 //
 //  1. Parse imports of `React` and `apple`.
-//  2. Apply the rule with default options.
+//  2. Enable unsafe runtime sorting with the default comparison mode.
 //  3. Assert `apple` sorts before `React`.
 func TestFormatSortImportsOrdersCaseInsensitivelyByDefault(t *testing.T) {
   source := "import React from \"React\";\n" +
@@ -20,5 +20,5 @@ func TestFormatSortImportsOrdersCaseInsensitivelyByDefault(t *testing.T) {
     "import React from \"React\";\n" +
     "React;\n" +
     "apple;\n"
-  assertFixSnapshot(t, "format/sort-imports", source, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_orders_case_sensitively_when_enabled_test.go
+++ b/packages/lint/test/format/format_sort_imports_orders_case_sensitively_when_enabled_test.go
@@ -9,7 +9,7 @@ import "testing"
 // the case-insensitive default, isolating the caseSensitive branch.
 //
 //  1. Parse imports of `apple` and `React`.
-//  2. Apply the rule with caseSensitive enabled.
+//  2. Enable caseSensitive and unsafe runtime sorting.
 //  3. Assert `React` sorts before `apple`.
 func TestFormatSortImportsOrdersCaseSensitivelyWhenEnabled(t *testing.T) {
   source := "import apple from \"apple\";\n" +
@@ -20,5 +20,5 @@ func TestFormatSortImportsOrdersCaseSensitivelyWhenEnabled(t *testing.T) {
     "import apple from \"apple\";\n" +
     "React;\n" +
     "apple;\n"
-  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"caseSensitive":true}`, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"caseSensitive":true,"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_preserves_binding_import_evaluation_order_test.go
+++ b/packages/lint/test/format/format_sort_imports_preserves_binding_import_evaluation_order_test.go
@@ -1,0 +1,55 @@
+package linthost
+
+import (
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestFormatSortImportsPreservesBindingImportEvaluationOrder verifies default,
+// named, and namespace imports retain their observable module evaluation order.
+//
+// Every binding import evaluates its dependency even though it is not a bare
+// side-effect import. The old bare-import-only guard sorted `b` before `a` into
+// `a` before `b`, so this executable ESM witness locks the runtime semantics,
+// not merely the formatter's source text.
+//
+//  1. Format binding imports whose lexical order differs from source order.
+//  2. Execute dependency modules that append their names to shared state.
+//  3. Assert the formatter emits no declaration edit and Node observes `b,a`.
+func TestFormatSortImportsPreservesBindingImportEvaluationOrder(t *testing.T) {
+  source := `import bDefault, { bNamed } from "./b.mjs";
+import * as aNamespace from "./a.mjs";
+console.log(globalThis.__sortImportsTrace.join(","));
+void bDefault;
+void bNamed;
+void aNamespace;
+`
+  root, filePath, findings := runRuleFindingsSnapshotFile(
+    t,
+    "format/sort-imports",
+    "main.mjs",
+    source,
+    nil,
+  )
+  if len(findings) != 0 {
+    t.Fatalf("format/sort-imports: expected zero findings, got %d (%+v)", len(findings), findings)
+  }
+  writeFile(t, filepath.Join(root, "src", "b.mjs"), `globalThis.__sortImportsTrace ??= [];
+globalThis.__sortImportsTrace.push("b");
+export default 0;
+export const bNamed = 0;
+`)
+  writeFile(t, filepath.Join(root, "src", "a.mjs"), `globalThis.__sortImportsTrace ??= [];
+globalThis.__sortImportsTrace.push("a");
+export const aNamed = 0;
+`)
+  output, err := exec.Command("node", filePath).CombinedOutput()
+  if err != nil {
+    t.Fatalf("node failed: %v\n%s", err, output)
+  }
+  if got := strings.TrimSpace(string(output)); got != "b,a" {
+    t.Fatalf("module evaluation order = %q, want %q", got, "b,a")
+  }
+}

--- a/packages/lint/test/format/format_sort_imports_scopes_type_group_by_regex_test.go
+++ b/packages/lint/test/format/format_sort_imports_scopes_type_group_by_regex_test.go
@@ -10,7 +10,7 @@ import "testing"
 // no-match arm of the type-group test.
 //
 //  1. Parse value + type-only imports across relative and third-party modules.
-//  2. Apply the rule with order ["<TYPES>^[.]", "<THIRD_PARTY_MODULES>", "^[.]"].
+//  2. Apply that order with unsafe runtime sorting enabled.
 //  3. Assert only the type-only relative import is hoisted.
 func TestFormatSortImportsScopesTypeGroupByRegex(t *testing.T) {
   source := "import { v } from \"react\";\n" +
@@ -23,5 +23,5 @@ func TestFormatSortImportsScopesTypeGroupByRegex(t *testing.T) {
     "import type { R } from \"react\";\n" +
     "import { local } from \"./local\";\n" +
     "v;\n"
-  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"order":["<TYPES>^[.]","<THIRD_PARTY_MODULES>","^[.]"]}`, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"order":["<TYPES>^[.]","<THIRD_PARTY_MODULES>","^[.]"],"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_separator_spans_empty_group_test.go
+++ b/packages/lint/test/format/format_sort_imports_separator_spans_empty_group_test.go
@@ -10,7 +10,7 @@ import "testing"
 // single blank line carried by the skipped middle group.
 //
 //  1. Parse a third-party and a relative import (no @api import).
-//  2. Apply the rule with an order whose middle group is empty.
+//  2. Apply that order with unsafe runtime sorting enabled.
 //  3. Assert one blank line separates the two populated groups.
 func TestFormatSortImportsSeparatorSpansEmptyGroup(t *testing.T) {
   source := "import { a } from \"alpha\";\n" +
@@ -22,5 +22,5 @@ func TestFormatSortImportsSeparatorSpansEmptyGroup(t *testing.T) {
     "import { b } from \"./local\";\n" +
     "a;\n" +
     "b;\n"
-  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"order":["<THIRD_PARTY_MODULES>","","@api/(.*)","","^[.]"]}`, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"order":["<THIRD_PARTY_MODULES>","","@api/(.*)","","^[.]"],"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_skips_invalid_regex_group_test.go
+++ b/packages/lint/test/format/format_sort_imports_skips_invalid_regex_group_test.go
@@ -10,7 +10,7 @@ import "testing"
 // unmatched specifier.
 //
 //  1. Parse a third-party and a relative import.
-//  2. Apply the rule with order ["[", "^[.]"] (the first entry is invalid).
+//  2. Apply that order with unsafe runtime sorting (the first entry is invalid).
 //  3. Assert the run continues and groups by the surviving order.
 func TestFormatSortImportsSkipsInvalidRegexGroup(t *testing.T) {
   source := "import { b } from \"./local\";\n" +
@@ -21,5 +21,5 @@ func TestFormatSortImportsSkipsInvalidRegexGroup(t *testing.T) {
     "import { b } from \"./local\";\n" +
     "a;\n" +
     "b;\n"
-  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"order":["[","^[.]"]}`, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"order":["[","^[.]"],"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_skips_invalid_types_regex_group_test.go
+++ b/packages/lint/test/format/format_sort_imports_skips_invalid_types_regex_group_test.go
@@ -9,7 +9,7 @@ import "testing"
 // proceeds with the remaining groups (here merging duplicate modules).
 //
 //  1. Parse two value imports of the same module.
-//  2. Apply the rule with order ["<TYPES>[", "<THIRD_PARTY_MODULES>"].
+//  2. Apply that order with unsafe runtime sorting enabled.
 //  3. Assert the run merges the duplicates without crashing.
 func TestFormatSortImportsSkipsInvalidTypesRegexGroup(t *testing.T) {
   source := "import { b } from \"m\";\n" +
@@ -19,5 +19,5 @@ func TestFormatSortImportsSkipsInvalidTypesRegexGroup(t *testing.T) {
   expected := "import { a, b } from \"m\";\n" +
     "a;\n" +
     "b;\n"
-  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"order":["<TYPES>[","<THIRD_PARTY_MODULES>"]}`, expected)
+  assertFixSnapshotWithOptions(t, "format/sort-imports", source, `{"order":["<TYPES>[","<THIRD_PARTY_MODULES>"],"unsafeSortRuntimeImports":true}`, expected)
 }

--- a/packages/lint/test/format/format_sort_imports_sorts_erased_type_only_block_test.go
+++ b/packages/lint/test/format/format_sort_imports_sorts_erased_type_only_block_test.go
@@ -1,0 +1,21 @@
+package linthost
+
+import "testing"
+
+// TestFormatSortImportsSortsErasedTypeOnlyBlock verifies the safe default still
+// orders declarations when every import is erased before runtime evaluation.
+//
+// Blocking every declaration-level operation would protect runtime semantics
+// but discard safe formatter value. An all-`import type` block has no module
+// evaluation order to preserve, so it remains eligible for grouping and sort.
+//
+//  1. Parse two type-only imports in reverse lexical order.
+//  2. Apply format/sort-imports without unsafe options.
+//  3. Assert the erased declarations sort alphabetically.
+func TestFormatSortImportsSortsErasedTypeOnlyBlock(t *testing.T) {
+  source := "import type { Zebra } from \"zebra\";\n" +
+    "import type { Alpha } from \"alpha\";\n"
+  expected := "import type { Alpha } from \"alpha\";\n" +
+    "import type { Zebra } from \"zebra\";\n"
+  assertFixSnapshot(t, "format/sort-imports", source, expected)
+}

--- a/packages/lint/test/format/format_sort_imports_sorts_named_specifiers_without_reordering_runtime_imports_test.go
+++ b/packages/lint/test/format/format_sort_imports_sorts_named_specifiers_without_reordering_runtime_imports_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFormatSortImportsSortsNamedSpecifiersWithoutReorderingRuntimeImports
+// verifies safe local formatting remains active inside a protected value block.
+//
+// The runtime guard applies only to declaration-level reconstruction. Named
+// specifier order has no effect on dependency evaluation, so the rule should
+// still fix `{ zebra, alpha }` without moving its declaration across a sibling.
+//
+//  1. Parse reverse-lexical runtime declarations and one unsorted named list.
+//  2. Apply format/sort-imports with safe defaults.
+//  3. Assert only the named list changes and declaration order remains intact.
+func TestFormatSortImportsSortsNamedSpecifiersWithoutReorderingRuntimeImports(t *testing.T) {
+  source := "import { zebra, alpha } from \"./b\";\n" +
+    "import value from \"./a\";\n" +
+    "console.log(alpha, zebra, value);\n"
+  expected := "import { alpha, zebra } from \"./b\";\n" +
+    "import value from \"./a\";\n" +
+    "console.log(alpha, zebra, value);\n"
+  assertFixSnapshot(t, "format/sort-imports", source, expected)
+}

--- a/packages/lint/test/format/format_sort_imports_treats_inline_type_bindings_as_runtime_import_test.go
+++ b/packages/lint/test/format/format_sort_imports_treats_inline_type_bindings_as_runtime_import_test.go
@@ -1,0 +1,19 @@
+package linthost
+
+import "testing"
+
+// TestFormatSortImportsTreatsInlineTypeBindingsAsRuntimeImport verifies only a
+// clause-level `import type` declaration enters the erased-block safe path.
+//
+// `import { type T }` still uses a runtime import declaration and can become an
+// evaluating `import {}` under verbatim module syntax. Classifying it from the
+// specifier modifier would therefore weaken the evaluation-order guard.
+//
+//  1. Parse an inline-type binding before a lexically earlier type-only import.
+//  2. Apply format/sort-imports with safe defaults.
+//  3. Assert the mixed runtime/type block remains unchanged.
+func TestFormatSortImportsTreatsInlineTypeBindingsAsRuntimeImport(t *testing.T) {
+  source := "import { type Zebra } from \"./zebra\";\n" +
+    "import type { Alpha } from \"./alpha\";\n"
+  assertRuleSkipsSource(t, "format/sort-imports", source)
+}

--- a/packages/lint/test/format/format_sort_imports_unsafe_option_reorders_runtime_imports_test.go
+++ b/packages/lint/test/format/format_sort_imports_unsafe_option_reorders_runtime_imports_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestFormatSortImportsUnsafeOptionReordersRuntimeImports verifies the explicit
+// unsafe option restores declaration-level sorting for runtime dependencies.
+//
+// The option is deliberately named for its semantic cost. This positive twin
+// proves it controls the runtime guard rather than becoming a documented flag
+// that the implementation silently ignores.
+//
+//  1. Parse two bare runtime imports in reverse lexical order.
+//  2. Enable unsafeSortRuntimeImports.
+//  3. Assert the declarations reorder alphabetically.
+func TestFormatSortImportsUnsafeOptionReordersRuntimeImports(t *testing.T) {
+  source := "import \"./z\";\n" +
+    "import \"./a\";\n"
+  expected := "import \"./a\";\n" +
+    "import \"./z\";\n"
+  assertFixSnapshotWithOptions(
+    t,
+    "format/sort-imports",
+    source,
+    `{"unsafeSortRuntimeImports":true}`,
+    expected,
+  )
+}

--- a/website/src/content/docs/lint/format.mdx
+++ b/website/src/content/docs/lint/format.mdx
@@ -18,6 +18,7 @@ export default {
     trailingComma: "all",
     sortImports: {
       order: ["<BUILTIN_MODULES>", "", "<THIRD_PARTY_MODULES>", "", "^[./]"],
+      unsafeSortRuntimeImports: true, // accepts module evaluation reordering
     },
     jsDoc: true,
   },
@@ -38,7 +39,7 @@ Presence of the block (even empty `format: {}`) configures the format rules at P
 | `quoteProps` | Quote or unquote object property keys. |
 | `trailingComma` | Add trailing commas to multi-line lists. |
 | `printWidth`, `tabWidth`, `useTabs`, `endOfLine` | Prettier-style line reflow. |
-| `sortImports` (opt-in) | Group imports by `order`, alphabetize them, and merge duplicate modules. |
+| `sortImports` (opt-in) | Sort named specifiers and erased type-only imports. Runtime declaration sorting requires `unsafeSortRuntimeImports`. |
 | `jsDoc` (on by default) | Normalize JSDoc blocks toward [prettier-plugin-jsdoc](https://github.com/hosseinmd/prettier-plugin-jsdoc). |
 
 `sortImports` is **opt-in**: it only runs when you set it. Every other format behavior — including JSDoc normalization (set `jsDoc: false` to opt out) — runs as soon as a `format` block is present, along with the keyless layout passes (statement splitting, indentation, whitespace, clause joining, declaration headers, ternary and nullish parens, orphan semicolons, and parameter properties).
@@ -87,7 +88,7 @@ Enforce trailing commas in **multiline** literals, object literals, array litera
 
 ### `sortImports`
 
-**Opt-in.** Reorder, group, and merge imports. Set `format.sortImports` to `true` for defaults, or to an object to customize.
+**Opt-in.** Sort named specifiers and erased type-only imports. Set `format.sortImports` to `true` for safe defaults, or to an object to customize.
 
 The `order` array drives grouping. Each entry is a regular expression matched against a module specifier, or one of these placeholders:
 
@@ -96,7 +97,9 @@ The `order` array drives grouping. Each entry is a regular expression matched ag
 - `<TYPES>` — `import type` declarations (optionally scoped, e.g. `<TYPES>^[.]`).
 - `""` — emit one blank line at this position.
 
-The default `order` is `["<BUILTIN_MODULES>", "<THIRD_PARTY_MODULES>", "^[.]"]`, with **no** blank lines between groups (add `""` entries to insert them). Within each group declarations sort by specifier — case-insensitively unless `caseSensitive: true` — and named specifiers always sort. Duplicate imports of the same module are merged; `combineTypeAndValue: true` additionally folds a type-only import into a value import (`import { foo, type Bar } from "m"`). A merge that would produce invalid syntax — such as a type-only default alongside type-only named bindings (`import type D, { A } from "m"` is TS1363) — is skipped, and the declarations stay separate while still grouped and sorted. Autofixable.
+The default `order` is `["<BUILTIN_MODULES>", "<THIRD_PARTY_MODULES>", "^[.]"]`, with **no** blank lines between groups (add `""` entries to insert them). Named specifiers always sort. A block made entirely of erased `import type` declarations is grouped, sorted, and merged according to these options.
+
+Runtime-bearing declarations keep source order by default. Default, namespace, named, and bare imports can all evaluate their dependency modules, so changing their order can change program behavior. `unsafeSortRuntimeImports: true` explicitly permits grouping, sorting, and merging those declarations when every dependency in the block is order-independent. `combineTypeAndValue: true` folds a type-only import into a value import (`import { foo, type Bar } from "m"`) only under that unsafe opt-in. A merge that would produce invalid syntax, such as a type-only default alongside type-only named bindings (`import type D, { A } from "m"` is TS1363), is skipped. Autofixable.
 
 ### `jsDoc`
 


### PR DESCRIPTION
## Summary

- preserve the source order of every runtime-bearing import by default
- keep named-specifier sorting and all-type-only block sorting on the safe path
- require the explicit \unsafeSortRuntimeImports\ option for runtime declaration grouping, sorting, merging, and mixed type/value combining
- document the semantic boundary and update existing declaration-rewrite tests to opt in
- add an executable Node ESM witness plus positive and negative regression shields

## Deferred items

None.

## Test plan

- complete three sequential exhaustive whole-PR reviews at one exact HEAD
- run focused \ormat/sort-imports\ and format-config Go tests only after those reviews
- run the package lint harness as the broader partial validation

Closes #523