### PR TITLE
fix(lint): honor negated empty character classes

### DIFF
--- a/packages/lint/linthost/rules_problems.go
+++ b/packages/lint/linthost/rules_problems.go
@@ -107,31 +107,10 @@ func (noEmptyCharacterClass) Visits() []shimast.Kind {
   return []shimast.Kind{shimast.KindRegularExpressionLiteral}
 }
 func (noEmptyCharacterClass) Check(ctx *Context, node *shimast.Node) {
-  src := nodeText(ctx.File, node)
-  if hasEmptyCharClass(src) {
+  parts, ok := parseRegexpLiteralParts(ctx, node)
+  if ok && regexpHasEmptyCharacterClass(parts) {
     ctx.Report(node, "Empty class.")
   }
-}
-
-// hasEmptyCharClass reports whether the regex source text src contains an
-// empty character class (`[]` or `[^]`). Respects backslash escapes.
-func hasEmptyCharClass(src string) bool {
-  // Walk the regex literal source manually, respecting escapes.
-  for i := 0; i < len(src); i++ {
-    switch src[i] {
-    case '\\':
-      i++ // skip escape
-    case '[':
-      j := i + 1
-      if j < len(src) && src[j] == '^' {
-        j++
-      }
-      if j < len(src) && src[j] == ']' {
-        return true
-      }
-    }
-  }
-  return false
 }
 
 // noMisleadingCharacterClass: `/[👍]/` — surrogate pairs in regex.

--- a/packages/lint/linthost/rules_regexp.go
+++ b/packages/lint/linthost/rules_regexp.go
@@ -6,6 +6,7 @@ import (
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
 
 // regexpSourceRule implements the high-confidence, source-text subset of
@@ -143,6 +144,43 @@ func regexpHasEmptyLookaround(parts regexpLiteralParts) bool {
       strings.HasPrefix(pattern[i:], "(?<=)") ||
       strings.HasPrefix(pattern[i:], "(?<!)")
   })
+}
+
+// regexpHasEmptyCharacterClass reports non-negated character classes whose
+// parsed element list is empty. The compiler's regexp parser is the syntax
+// authority; the structural walk runs only after that parser accepts the full
+// literal, so malformed escapes, flags, and class-set expressions cannot
+// create lint findings.
+func regexpHasEmptyCharacterClass(parts regexpLiteralParts) bool {
+  if !shimscanner.IsValidRegularExpressionLiteral(parts.raw) {
+    return false
+  }
+  unicodeSets := strings.Contains(parts.flags, "v")
+  depth := 0
+  for i := 0; i < len(parts.pattern); i++ {
+    switch parts.pattern[i] {
+    case '\\':
+      i++
+    case '[':
+      if depth != 0 && !unicodeSets {
+        continue
+      }
+      depth++
+      content := i + 1
+      negated := content < len(parts.pattern) && parts.pattern[content] == '^'
+      if negated {
+        content++
+      }
+      if !negated && content < len(parts.pattern) && parts.pattern[content] == ']' {
+        return true
+      }
+    case ']':
+      if depth > 0 {
+        depth--
+      }
+    }
+  }
+  return false
 }
 
 func regexpHasZeroQuantifier(parts regexpLiteralParts) bool {
@@ -385,9 +423,7 @@ func init() {
   Register(regexpSourceRule{name: "regexp/no-dupe-characters-character-class", check: regexpHasDuplicateClassCharacter})
   Register(regexpSourceRule{name: "regexp/no-empty-alternative", check: regexpHasEmptyAlternative})
   Register(regexpSourceRule{name: "regexp/no-empty-capturing-group", check: regexpHasEmptyCapturingGroup})
-  Register(regexpSourceRule{name: "regexp/no-empty-character-class", check: func(parts regexpLiteralParts) bool {
-    return hasEmptyCharClass(parts.raw)
-  }})
+  Register(regexpSourceRule{name: "regexp/no-empty-character-class", check: regexpHasEmptyCharacterClass})
   Register(regexpSourceRule{name: "regexp/no-empty-group", check: regexpHasEmptyGroup})
   Register(regexpSourceRule{name: "regexp/no-empty-lookarounds-assertion", check: regexpHasEmptyLookaround})
   Register(regexpSourceRule{name: "regexp/no-misleading-unicode-character", check: func(parts regexpLiteralParts) bool {

--- a/packages/lint/test/rules/strings-regex/no_empty_character_class_semantics_test.go
+++ b/packages/lint/test/rules/strings-regex/no_empty_character_class_semantics_test.go
@@ -1,0 +1,48 @@
+package linthost
+
+import (
+  "reflect"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestNoEmptyCharacterClassUsesParsedClassSemantics keeps the core and regexp
+// rule ids on one canonical predicate. It covers legacy, Unicode, Unicode Sets,
+// nested class-set, escaped delimiter, range, negation, and invalid-syntax
+// boundaries through the public engine surface.
+func TestNoEmptyCharacterClassUsesParsedClassSemantics(t *testing.T) {
+  file := parseTS(t, `const legacyEmpty = /[]/;
+const legacyNegated = /[^]/;
+const escapedBrackets = /[\[\]]/;
+const range = /[a-z]/;
+const unicodeEmpty = /[]/u;
+const unicodeNegated = /[^]/u;
+const setsEmpty = /[]/v;
+const setsNegated = /[^]/v;
+const nestedSetsEmpty = /[[]]/v;
+const nestedSetsNegated = /[[^]]/v;
+const nestedSetsRange = /[[a-z]&&[a-m]]/v;
+const invalidFlags = /[]/uv;
+const invalidNestedSet = /[[]&&]/v;
+const legacyLiteralOpen = /[[]/;
+const unicodeEscapedClose = /[\]]/u;
+const setsEscapedBrackets = /[\[\]]/v;
+const nestedSetsNonEmpty = /[[a-z]]/v;
+`)
+  findings := NewEngine(RuleConfig{
+    "no-empty-character-class":        SeverityError,
+    "regexp/no-empty-character-class": SeverityError,
+  }).Run([]*shimast.SourceFile{file}, nil)
+
+  lines := map[string][]int{}
+  for _, finding := range normalizeRuleFindings(file, findings) {
+    lines[finding.Rule] = append(lines[finding.Rule], finding.Line)
+  }
+  want := []int{1, 5, 7, 9}
+  for _, rule := range []string{"no-empty-character-class", "regexp/no-empty-character-class"} {
+    if !reflect.DeepEqual(lines[rule], want) {
+      t.Fatalf("%s lines = %v, want %v; all=%v", rule, lines[rule], want, lines)
+    }
+  }
+}

--- a/packages/lint/test/rules/strings-regex/no_empty_character_class_semantics_test.go
+++ b/packages/lint/test/rules/strings-regex/no_empty_character_class_semantics_test.go
@@ -29,6 +29,9 @@ const legacyLiteralOpen = /[[]/;
 const unicodeEscapedClose = /[\]]/u;
 const setsEscapedBrackets = /[\[\]]/v;
 const nestedSetsNonEmpty = /[[a-z]]/v;
+const invalidEscape = /\u{110000}[]/u;
+const unknownFlag = /[]/z;
+const duplicateFlag = /[]/uu;
 `)
   findings := NewEngine(RuleConfig{
     "no-empty-character-class":        SeverityError,

--- a/packages/ttsc/shim/scanner/regexp.go
+++ b/packages/ttsc/shim/scanner/regexp.go
@@ -2,7 +2,6 @@ package scanner
 
 import (
   "github.com/microsoft/typescript-go/internal/ast"
-  "github.com/microsoft/typescript-go/internal/core"
   "github.com/microsoft/typescript-go/internal/diagnostics"
 )
 
@@ -16,7 +15,6 @@ func IsValidRegularExpressionLiteral(text string) bool {
   scanner.SetOnError(func(_ *diagnostics.Message, _, _ int, _ ...any) {
     valid = false
   })
-  scanner.SetScriptTarget(core.ScriptTargetLatest)
   scanner.SetText(text)
   token := scanner.Scan()
   if token != ast.KindSlashToken && token != ast.KindSlashEqualsToken {

--- a/packages/ttsc/shim/scanner/regexp.go
+++ b/packages/ttsc/shim/scanner/regexp.go
@@ -1,0 +1,29 @@
+package scanner
+
+import (
+  "github.com/microsoft/typescript-go/internal/ast"
+  "github.com/microsoft/typescript-go/internal/core"
+  "github.com/microsoft/typescript-go/internal/diagnostics"
+)
+
+// IsValidRegularExpressionLiteral reports whether text is one complete,
+// grammar-valid ECMAScript regular-expression literal. It deliberately uses
+// typescript-go's own scanner and regexp parser so callers share the compiler's
+// handling of escapes, flags, Unicode mode, and Unicode Sets syntax.
+func IsValidRegularExpressionLiteral(text string) bool {
+  scanner := NewScanner()
+  valid := true
+  scanner.SetOnError(func(_ *diagnostics.Message, _, _ int, _ ...any) {
+    valid = false
+  })
+  scanner.SetScriptTarget(core.ScriptTargetLatest)
+  scanner.SetText(text)
+  token := scanner.Scan()
+  if token != ast.KindSlashToken && token != ast.KindSlashEqualsToken {
+    return false
+  }
+  if scanner.ReScanSlashToken(true) != ast.KindRegularExpressionLiteral {
+    return false
+  }
+  return valid && scanner.TokenEnd() == len(text)
+}

--- a/tests/test-lint/src/cases/no-empty-character-class.ts
+++ b/tests/test-lint/src/cases/no-empty-character-class.ts
@@ -1,3 +1,21 @@
 // expect: no-empty-character-class error
 const r = /[]/;
 JSON.stringify(r);
+
+const anyLegacyCharacter = /[^]/;
+const escapedBrackets = /[\[\]]/;
+const range = /[a-z]/;
+
+// expect: no-empty-character-class error
+const unicodeEmpty = /[]/u;
+const anyUnicodeCharacter = /[^]/u;
+
+// expect: no-empty-character-class error
+const unicodeSetsEmpty = /[]/v;
+const anyUnicodeSetsCharacter = /[^]/v;
+
+// expect: no-empty-character-class error
+const nestedUnicodeSetsEmpty = /[[]]/v;
+const nestedUnicodeSetsAny = /[[^]]/v;
+const nestedUnicodeSetsNonEmpty = /[[a-z]]/v;
+const escapedUnicodeSetsBrackets = /[\[\]]/v;

--- a/tests/test-lint/src/cases/regexp-no-empty-character-class.ts
+++ b/tests/test-lint/src/cases/regexp-no-empty-character-class.ts
@@ -12,3 +12,21 @@
 const empty = /[]/;
 
 JSON.stringify(empty);
+
+const anyLegacyCharacter = /[^]/;
+const escapedBrackets = /[\[\]]/;
+const range = /[a-z]/;
+
+// expect: regexp/no-empty-character-class error
+const unicodeEmpty = /[]/u;
+const anyUnicodeCharacter = /[^]/u;
+
+// expect: regexp/no-empty-character-class error
+const unicodeSetsEmpty = /[]/v;
+const anyUnicodeSetsCharacter = /[^]/v;
+
+// expect: regexp/no-empty-character-class error
+const nestedUnicodeSetsEmpty = /[[]]/v;
+const nestedUnicodeSetsAny = /[[^]]/v;
+const nestedUnicodeSetsNonEmpty = /[[a-z]]/v;
+const escapedUnicodeSetsBrackets = /[\[\]]/v;

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -1169,9 +1169,9 @@ function f(x: number) {
 ### `no-empty-character-class`
 
 Reject non-negated empty regex character classes (`[]`), including nested
-classes in Unicode Sets (`v`) mode. An empty class never matches anything, so
-the entire pattern can never succeed; the negated form `[^]` matches any
-character and is allowed.
+classes in Unicode Sets (`v`) mode. An empty class never matches a character,
+so its containing alternative cannot match through that class; the negated
+form `[^]` matches any character and is allowed.
 
 Example:
 

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -1168,9 +1168,10 @@ function f(x: number) {
 
 ### `no-empty-character-class`
 
-Reject empty regex character classes (`[]`).
-
-An empty class never matches anything, so the entire pattern can never succeed; the negated form `[^]` (matches any character) is allowed.
+Reject non-negated empty regex character classes (`[]`), including nested
+classes in Unicode Sets (`v`) mode. An empty class never matches anything, so
+the entire pattern can never succeed; the negated form `[^]` matches any
+character and is allowed.
 
 Example:
 

--- a/website/src/content/docs/lint/rules/regexp.mdx
+++ b/website/src/content/docs/lint/rules/regexp.mdx
@@ -97,7 +97,9 @@ const emptyCap = /()/;
 
 ### `regexp/no-empty-character-class`
 
-Reject empty regex character classes (`[]`). Alias of the bare core check.
+Reject non-negated empty regex character classes (`[]`), including nested
+classes in Unicode Sets (`v`) mode. The negated form `[^]` matches any character
+and is allowed. Alias of the bare core check.
 
 Example:
 


### PR DESCRIPTION
## Summary

- validate regular-expression literals through TypeScript-Go's canonical parser before checking empty character classes
- align the core and regexp-prefixed rules on one non-negated empty-class predicate
- cover legacy, Unicode, Unicode Sets, nested, escaped, range, and invalid syntax boundaries

## Rationale

A negated empty class ([^]) matches any character and must not be reported. Raw source scanning also cannot establish whether flag-sensitive Unicode Sets syntax is valid, so malformed literals are now rejected by the compiler parser before structural inspection.

## Validation

Local tests are intentionally deferred until three exhaustive reviews complete on the same exact HEAD.

Closes #514