### PR TITLE
fix(lint): complete Promise executor return semantics

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -286,7 +286,7 @@ Source: [ESLint core rules](https://eslint.org/docs/latest/rules/).
 - [`no-octal-escape`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-octal-escape.ts): rejects octal escape sequences.
 - [`no-param-reassign`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-param-reassign.ts): reject reassigning a function parameter inside the body of the function it belongs to.
 - [`no-plusplus`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-plusplus.ts): rejects `++` and `--`.
-- [`no-promise-executor-return`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-promise-executor-return.ts): rejects returned values from Promise executors.
+- [`no-promise-executor-return`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-promise-executor-return.ts): rejects values returned by global Promise executors, with an `allowVoid` option for explicit unary `void` returns.
 - [`no-proto`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-proto.ts): rejects `__proto__`.
 - [`no-prototype-builtins`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-prototype-builtins.ts): rejects direct `Object.prototype` method calls.
 - [`no-redeclare`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-redeclare.ts): rejects redeclaring a binding in the same scope.

--- a/packages/lint/linthost/rules_no_promise_executor_return.go
+++ b/packages/lint/linthost/rules_no_promise_executor_return.go
@@ -1,0 +1,156 @@
+// noPromiseExecutorReturn rejects values returned by the callback passed as
+// the first argument to the global Promise constructor. Promise ignores its
+// executor's return value, so a value return almost always reflects a missing
+// resolve/reject call or an accidentally concise arrow body.
+//
+// The rule uses checker binding identity rather than identifier text: a local
+// class, variable, import, or parameter named Promise is a different
+// constructor and remains untouched. It walks every statement nested inside
+// the executor, but stops at nested function-like boundaries so those
+// functions retain their own return scopes.
+// https://eslint.org/docs/latest/rules/no-promise-executor-return
+package linthost
+
+import shimast "github.com/microsoft/typescript-go/shim/ast"
+
+const noPromiseExecutorReturnMessage = "Return values from promise executor functions cannot be read."
+
+type noPromiseExecutorReturn struct{}
+
+type noPromiseExecutorReturnOptions struct {
+  AllowVoid bool `json:"allowVoid"`
+}
+
+func (noPromiseExecutorReturn) Name() string { return "no-promise-executor-return" }
+func (noPromiseExecutorReturn) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindNewExpression}
+}
+func (noPromiseExecutorReturn) NeedsTypeChecker() bool { return true }
+func (noPromiseExecutorReturn) Check(ctx *Context, node *shimast.Node) {
+  expression := node.AsNewExpression()
+  if expression == nil || expression.Arguments == nil || len(expression.Arguments.Nodes) == 0 {
+    return
+  }
+  callee := stripParens(expression.Expression)
+  if !isGlobalPromiseConstructor(ctx, callee) {
+    return
+  }
+
+  executor := stripParens(expression.Arguments.Nodes[0])
+  if executor == nil || (executor.Kind != shimast.KindArrowFunction && executor.Kind != shimast.KindFunctionExpression) {
+    return
+  }
+  body := executor.Body()
+  if body == nil {
+    return
+  }
+
+  var options noPromiseExecutorReturnOptions
+  _ = ctx.DecodeOptions(&options)
+  if executor.Kind == shimast.KindArrowFunction && body.Kind != shimast.KindBlock {
+    reportPromiseExecutorReturn(ctx, body, body, options)
+    return
+  }
+  walkPromiseExecutorReturns(body, func(returnNode, value *shimast.Node) {
+    reportPromiseExecutorReturn(ctx, returnNode, value, options)
+  })
+}
+
+// isGlobalPromiseConstructor proves that callee resolves to the program's
+// global Promise value. The declaration guard handles script files whose
+// top-level value declaration can merge into the checker global table: such a
+// declaration still shadows the built-in for this source file and must not be
+// treated as the standard Promise constructor.
+func isGlobalPromiseConstructor(ctx *Context, callee *shimast.Node) bool {
+  if ctx == nil || ctx.Checker == nil || ctx.File == nil || identifierText(callee) != "Promise" {
+    return false
+  }
+  resolved := ctx.Checker.GetSymbolAtLocation(callee)
+  global := ctx.Checker.GetGlobalSymbol("Promise", shimast.SymbolFlagsValue, nil)
+  if resolved == nil || global == nil {
+    return false
+  }
+  resolved = ctx.Checker.GetMergedSymbol(resolved)
+  global = ctx.Checker.GetMergedSymbol(global)
+  if resolved != global {
+    return false
+  }
+  for _, declaration := range resolved.Declarations {
+    if declaration != nil && shimast.GetSourceFileOfNode(declaration) == ctx.File &&
+      promiseDeclarationIntroducesValue(declaration) {
+      return false
+    }
+  }
+  return true
+}
+
+// promiseDeclarationIntroducesValue distinguishes same-file value bindings
+// from type-only declarations that legitimately merge with the global Promise
+// interface. The checker already resolves nested lexical bindings to a
+// different symbol; this list is only needed for declarations merged into a
+// script's global symbol table.
+func promiseDeclarationIntroducesValue(declaration *shimast.Node) bool {
+  switch declaration.Kind {
+  case
+    shimast.KindVariableDeclaration,
+    shimast.KindBindingElement,
+    shimast.KindFunctionDeclaration,
+    shimast.KindClassDeclaration,
+    shimast.KindEnumDeclaration,
+    shimast.KindModuleDeclaration,
+    shimast.KindImportEqualsDeclaration:
+    return true
+  }
+  return false
+}
+
+// walkPromiseExecutorReturns visits all explicit return statements owned by
+// root. Nested control-flow statements are traversed naturally; nested
+// functions are pruned because their return values belong to another call.
+func walkPromiseExecutorReturns(root *shimast.Node, visit func(returnNode, value *shimast.Node)) {
+  if root == nil {
+    return
+  }
+  var walk func(*shimast.Node)
+  walk = func(node *shimast.Node) {
+    if node == nil {
+      return
+    }
+    if node != root && isFunctionLikeKind(node) {
+      return
+    }
+    if node.Kind == shimast.KindReturnStatement {
+      statement := node.AsReturnStatement()
+      if statement != nil && statement.Expression != nil {
+        visit(node, statement.Expression)
+      }
+      return
+    }
+    node.ForEachChild(func(child *shimast.Node) bool {
+      walk(child)
+      return false
+    })
+  }
+  walk(root)
+}
+
+func reportPromiseExecutorReturn(
+  ctx *Context,
+  reportNode *shimast.Node,
+  value *shimast.Node,
+  options noPromiseExecutorReturnOptions,
+) {
+  if options.AllowVoid && isExplicitVoidExpression(value) {
+    return
+  }
+  ctx.Report(reportNode, noPromiseExecutorReturnMessage)
+}
+
+func isExplicitVoidExpression(node *shimast.Node) bool {
+  node = stripParens(node)
+  return node != nil && node.Kind == shimast.KindVoidExpression
+}
+
+func init() {
+  Register(noPromiseExecutorReturn{})
+}

--- a/packages/lint/linthost/rules_problems.go
+++ b/packages/lint/linthost/rules_problems.go
@@ -371,36 +371,6 @@ func (noAsyncPromiseExecutor) Check(ctx *Context, node *shimast.Node) {
   }
 }
 
-// noPromiseExecutorReturn: `new Promise(() => 1)` — the value is
-// thrown away.
-type noPromiseExecutorReturn struct{}
-
-func (noPromiseExecutorReturn) Name() string { return "no-promise-executor-return" }
-func (noPromiseExecutorReturn) Visits() []shimast.Kind {
-  return []shimast.Kind{shimast.KindNewExpression}
-}
-func (noPromiseExecutorReturn) Check(ctx *Context, node *shimast.Node) {
-  ne := node.AsNewExpression()
-  if ne == nil || identifierText(ne.Expression) != "Promise" {
-    return
-  }
-  if ne.Arguments == nil || len(ne.Arguments.Nodes) == 0 {
-    return
-  }
-  executor := ne.Arguments.Nodes[0]
-  if executor == nil || executor.Kind != shimast.KindArrowFunction {
-    return
-  }
-  arrow := executor.AsArrowFunction()
-  if arrow == nil || arrow.Body == nil {
-    return
-  }
-  // Concise arrow body returns the value implicitly.
-  if arrow.Body.Kind != shimast.KindBlock {
-    ctx.Report(arrow.Body, "Return values from promise executor functions cannot be read.")
-  }
-}
-
 // noControlRegex: `/\x00/` — control characters in regex are usually
 // the result of accidentally typing the escape rather than the printable
 // counterpart.
@@ -602,7 +572,6 @@ func init() {
   Register(noFuncAssign{})
   Register(noPrototypeBuiltins{})
   Register(noAsyncPromiseExecutor{})
-  Register(noPromiseExecutorReturn{})
   Register(noControlRegex{})
   Register(noIrregularWhitespace{})
   Register(noInnerDeclarations{})

--- a/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
@@ -118,6 +118,19 @@ export interface ITtscLintNoFallthroughRuleOptions {
   reportUnusedFallthroughComment?: boolean;
 }
 
+/** `no-promise-executor-return` rule options. */
+export interface ITtscLintCoreNoPromiseExecutorReturnRuleOptions {
+  /**
+   * Allow an executor to explicitly discard a value with the unary `void`
+   * operator, in either a concise arrow body or a `return void expression`
+   * statement. Other expressions that happen to have the `void` type remain
+   * reportable because their explicit return value is still ignored.
+   *
+   * @default false
+   */
+  allowVoid?: boolean;
+}
+
 /** `prefer-const` rule options. */
 export interface ITtscLintCorePreferConstRuleOptions {
   /**

--- a/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
@@ -4,6 +4,7 @@ import type {
 } from "../TtscLintRuleSetting";
 import type {
   ITtscLintCoreNoDuplicateImportsRuleOptions,
+  ITtscLintCoreNoPromiseExecutorReturnRuleOptions,
   ITtscLintCoreNoUnusedExpressionsRuleOptions,
   ITtscLintCorePreferConstRuleOptions,
   ITtscLintNoFallthroughRuleOptions,
@@ -871,12 +872,14 @@ export interface ITtscLintCoreRules {
   "no-plusplus"?: TtscLintRuleSetting;
 
   /**
-   * Reject `return` inside the Promise executor function — the value is
-   * ignored.
+   * Reject values returned by the global Promise constructor's executor. This
+   * covers concise arrows and explicit returns without crossing nested
+   * function boundaries. Set `allowVoid` to accept an explicit unary `void`
+   * return.
    *
    * @reference https://eslint.org/docs/latest/rules/no-promise-executor-return
    */
-  "no-promise-executor-return"?: TtscLintRuleSetting;
+  "no-promise-executor-return"?: TtscLintRuleOptionsSetting<ITtscLintCoreNoPromiseExecutorReturnRuleOptions>;
 
   /**
    * Reject access to `obj.__proto__`; use `Object.getPrototypeOf` /

--- a/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
+++ b/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
@@ -8,6 +8,7 @@ import type {
 } from "./ITtscLintBoundariesRuleOptions";
 import type {
   ITtscLintCoreNoDuplicateImportsRuleOptions,
+  ITtscLintCoreNoPromiseExecutorReturnRuleOptions,
   ITtscLintCoreNoUnusedExpressionsRuleOptions,
   ITtscLintCorePreferConstRuleOptions,
   ITtscLintNoFallthroughRuleOptions,
@@ -65,6 +66,7 @@ import type {
 export interface ITtscLintRuleOptionsMap {
   "typescript/no-floating-promises": ITtscLintTypeScriptNoFloatingPromisesRuleOptions;
   "no-duplicate-imports": ITtscLintCoreNoDuplicateImportsRuleOptions;
+  "no-promise-executor-return": ITtscLintCoreNoPromiseExecutorReturnRuleOptions;
   "no-unused-expressions": ITtscLintCoreNoUnusedExpressionsRuleOptions;
   "no-fallthrough": ITtscLintNoFallthroughRuleOptions;
   "prefer-const": ITtscLintCorePreferConstRuleOptions;

--- a/packages/lint/test/rules/functions-classes/no_promise_executor_return_allow_void_test.go
+++ b/packages/lint/test/rules/functions-classes/no_promise_executor_return_allow_void_test.go
@@ -1,0 +1,72 @@
+package linthost
+
+import (
+  "encoding/json"
+  "slices"
+  "sort"
+  "strings"
+  "testing"
+)
+
+// TestNoPromiseExecutorReturnAllowVoid verifies the allowVoid option accepts
+// only an explicit unary void return.
+//
+// A value can have the TypeScript `void` type without using the `void`
+// operator. The upstream contract deliberately recognizes the syntax, not the
+// inferred type, so `undefined` and sequence expressions remain reportable
+// while parenthesized unary void expressions are accepted.
+//
+// 1. Enable allowVoid and exercise concise and explicit executor returns.
+// 2. Pair unary void positives with undefined and sequence-expression negatives.
+// 3. Assert bare returns and nested-function returns remain silent.
+func TestNoPromiseExecutorReturnAllowVoid(t *testing.T) {
+  source := `declare function consume(value: unknown): void;
+
+new Promise(() => void consume(1));
+new Promise(() => (void consume(2)));
+new Promise(() => {
+  return void consume(3);
+});
+new Promise(function () {
+  return (void consume(4));
+});
+new Promise(() => undefined); // diagnostic
+new Promise(() => {
+  return undefined; // diagnostic
+});
+new Promise(() => {
+  return (0, void consume(5)); // diagnostic
+});
+new Promise(() => {
+  function nested() {
+    return 6;
+  }
+  consume(nested);
+  return;
+});
+`
+  expectedLines := make([]int, 0)
+  for index, line := range strings.Split(source, "\n") {
+    if strings.Contains(line, "// diagnostic") {
+      expectedLines = append(expectedLines, index+1)
+    }
+  }
+
+  _, _, findings := runRuleFindingsSnapshot(
+    t,
+    "no-promise-executor-return",
+    source,
+    json.RawMessage(`{"allowVoid":true}`),
+  )
+  actualLines := make([]int, 0, len(findings))
+  for _, finding := range findings {
+    if finding.Pos < 0 || finding.Pos > len(source) {
+      t.Fatalf("finding position %d is outside source length %d", finding.Pos, len(source))
+    }
+    actualLines = append(actualLines, strings.Count(source[:finding.Pos], "\n")+1)
+  }
+  sort.Ints(actualLines)
+  if !slices.Equal(actualLines, expectedLines) {
+    t.Fatalf("diagnostic lines mismatch: want %v, got %v", expectedLines, actualLines)
+  }
+}

--- a/packages/lint/test/rules/functions-classes/no_promise_executor_return_allow_void_test.go
+++ b/packages/lint/test/rules/functions-classes/no_promise_executor_return_allow_void_test.go
@@ -35,7 +35,7 @@ new Promise(() => {
   return undefined; // diagnostic
 });
 new Promise(() => {
-  return (0, void consume(5)); // diagnostic
+  return (consume(5), void consume(6)); // diagnostic
 });
 new Promise(() => {
   function nested() {

--- a/packages/lint/test/rules/functions-classes/no_promise_executor_return_complete_semantics_test.go
+++ b/packages/lint/test/rules/functions-classes/no_promise_executor_return_complete_semantics_test.go
@@ -17,7 +17,7 @@ import (
 //
 // 1. Run the rule against global Promise executors and collect every marked line.
 // 2. Exercise concise, block, function-expression, and nested control-flow returns.
-// 3. Assert local and script-level Promise bindings plus nested functions stay silent.
+// 3. Assert local and top-level Promise bindings plus nested functions stay silent.
 func TestNoPromiseExecutorReturnCompleteSemantics(t *testing.T) {
   cases := []struct {
     name   string

--- a/packages/lint/test/rules/functions-classes/no_promise_executor_return_complete_semantics_test.go
+++ b/packages/lint/test/rules/functions-classes/no_promise_executor_return_complete_semantics_test.go
@@ -1,0 +1,132 @@
+package linthost
+
+import (
+  "slices"
+  "sort"
+  "strings"
+  "testing"
+)
+
+// TestNoPromiseExecutorReturnCompleteSemantics verifies the rule follows the
+// global Promise binding through every executor return scope.
+//
+// The old implementation only inspected concise arrow bodies and matched the
+// callee by text. These cases pin explicit returns in nested control flow,
+// function-expression executors, global binding identity, and the function
+// boundaries that must prevent an inner closure's return from leaking outward.
+//
+// 1. Run the rule against global Promise executors and collect every marked line.
+// 2. Exercise concise, block, function-expression, and nested control-flow returns.
+// 3. Assert local and script-level Promise bindings plus nested functions stay silent.
+func TestNoPromiseExecutorReturnCompleteSemantics(t *testing.T) {
+  cases := []struct {
+    name   string
+    source string
+  }{
+    {
+      name: "global Promise executor scopes",
+      source: `interface Promise<T> { marker?: T }
+declare const condition: boolean;
+declare function consume(value: unknown): void;
+
+new Promise(() => 1); // diagnostic
+new (Promise)(() => 2); // diagnostic
+new Promise(() => {
+  if (condition) {
+    return 3; // diagnostic
+  }
+  try {
+    return 4; // diagnostic
+  } catch {
+    return 5; // diagnostic
+  }
+});
+new Promise(function executor() {
+  switch (condition) {
+    case true:
+      return 6; // diagnostic
+    default:
+      return 7; // diagnostic
+  }
+});
+new Promise(function Promise() {
+  return 8; // diagnostic
+});
+new Promise(() => {
+  function declared() {
+    return 20;
+  }
+  const arrow = () => 21;
+  const expression = function () {
+    return 22;
+  };
+  class Nested {
+    method() {
+      return 23;
+    }
+  }
+  consume([declared, arrow, expression, Nested]);
+  return;
+});
+new Promise(() => {
+  new Promise(() => 9); // diagnostic
+});
+new Promise(() => void consume(10)); // diagnostic
+new Promise(() => {
+  return void consume(11); // diagnostic
+});
+
+Promise(() => 12);
+new Promise(consume, () => 13);
+new globalThis.Promise(() => 14);
+function parameterShadow(Promise: new (executor: () => unknown) => unknown) {
+  new Promise(() => 15);
+}
+{
+  class Promise {
+    constructor(_executor: () => unknown) {}
+  }
+  new Promise(() => 16);
+}
+consume(parameterShadow);
+`,
+    },
+    {
+      name: "script global table shadow",
+      source: `let Promise = class {
+  constructor(_executor: () => unknown) {}
+};
+new Promise(() => 1);
+`,
+    },
+  }
+
+  for _, testCase := range cases {
+    t.Run(testCase.name, func(t *testing.T) {
+      expectedLines := make([]int, 0)
+      for index, line := range strings.Split(testCase.source, "\n") {
+        if strings.Contains(line, "// diagnostic") {
+          expectedLines = append(expectedLines, index+1)
+        }
+      }
+
+      _, _, findings := runRuleFindingsSnapshot(
+        t,
+        "no-promise-executor-return",
+        testCase.source,
+        nil,
+      )
+      actualLines := make([]int, 0, len(findings))
+      for _, finding := range findings {
+        if finding.Pos < 0 || finding.Pos > len(testCase.source) {
+          t.Fatalf("finding position %d is outside source length %d", finding.Pos, len(testCase.source))
+        }
+        actualLines = append(actualLines, strings.Count(testCase.source[:finding.Pos], "\n")+1)
+      }
+      sort.Ints(actualLines)
+      if !slices.Equal(actualLines, expectedLines) {
+        t.Fatalf("diagnostic lines mismatch: want %v, got %v", expectedLines, actualLines)
+      }
+    })
+  }
+}

--- a/packages/lint/test/rules/functions-classes/no_promise_executor_return_complete_semantics_test.go
+++ b/packages/lint/test/rules/functions-classes/no_promise_executor_return_complete_semantics_test.go
@@ -98,6 +98,12 @@ new Promise(() => 1);
 export {};
 `,
     },
+    {
+      name: "script global value declaration",
+      source: `declare var Promise: PromiseConstructor;
+new Promise(() => 1);
+`,
+    },
   }
 
   for _, testCase := range cases {

--- a/packages/lint/test/rules/functions-classes/no_promise_executor_return_complete_semantics_test.go
+++ b/packages/lint/test/rules/functions-classes/no_promise_executor_return_complete_semantics_test.go
@@ -76,27 +76,26 @@ new Promise(() => {
   return void consume(11); // diagnostic
 });
 
-Promise(() => 12);
-new Promise(consume, () => 13);
-new globalThis.Promise(() => 14);
+new globalThis.Promise(() => 12);
 function parameterShadow(Promise: new (executor: () => unknown) => unknown) {
-  new Promise(() => 15);
+  new Promise(() => 13);
 }
 {
   class Promise {
     constructor(_executor: () => unknown) {}
   }
-  new Promise(() => 16);
+  new Promise(() => 14);
 }
 consume(parameterShadow);
 `,
     },
     {
-      name: "script global table shadow",
+      name: "module top-level shadow",
       source: `let Promise = class {
   constructor(_executor: () => unknown) {}
 };
 new Promise(() => 1);
+export {};
 `,
     },
   }

--- a/packages/lint/test/rules/functions-classes/no_promise_executor_return_test.go
+++ b/packages/lint/test/rules/functions-classes/no_promise_executor_return_test.go
@@ -8,13 +8,12 @@ import "testing"
 // scenario keeps one annotated TypeScript fixture tied to the native Engine so individual rule
 // Check methods are measured by go test instead of only by the TypeScript feature runner.
 //
-// This case enables the rule annotations declared in no-promise-executor-return.ts and compares
-// normalized rule, severity, and line triples. The source text stays embedded in the generated
-// Go file so the test remains package-local and deterministic.
+// The fixture covers concise arrows, block-arrow returns, function-expression executors,
+// bare returns, nested function boundaries, and a locally shadowed Promise constructor.
 //
 // 1. Load the annotated TypeScript fixture source embedded below.
 // 2. Enable the rule severities declared by its // expect: comments.
 // 3. Assert the native Engine reports exactly the annotated diagnostics.
 func TestRuleCorpusNoPromiseExecutorReturn(t *testing.T) {
-  assertRuleCorpusCase(t, "no-promise-executor-return.ts", "// expect: no-promise-executor-return error\nnew Promise((resolve) => resolve(1));\n")
+  assertRuleCorpusCase(t, "no-promise-executor-return.ts", "declare const condition: boolean;\ndeclare function consume(value: unknown): void;\n\n// expect: no-promise-executor-return error\nnew Promise((resolve) => resolve(1));\n\nnew Promise(() => {\n  if (condition) {\n    // expect: no-promise-executor-return error\n    return 1;\n  }\n  return;\n});\n\nnew Promise(function () {\n  // expect: no-promise-executor-return error\n  return 2;\n});\n\nnew Promise(() => {\n  const nested = () => 3;\n  consume(nested);\n  return;\n});\n\nfunction shadowed(Promise: new (executor: () => unknown) => unknown) {\n  new Promise(() => 4);\n}\nconsume(shadowed);\n")
 }

--- a/packages/lint/test/rules/functions-classes/no_promise_executor_return_test.go
+++ b/packages/lint/test/rules/functions-classes/no_promise_executor_return_test.go
@@ -12,8 +12,19 @@ import "testing"
 // bare returns, nested function boundaries, and a locally shadowed Promise constructor.
 //
 // 1. Load the annotated TypeScript fixture source embedded below.
-// 2. Enable the rule severities declared by its // expect: comments.
+// 2. Load a real Program and checker for global Promise binding identity.
 // 3. Assert the native Engine reports exactly the annotated diagnostics.
 func TestRuleCorpusNoPromiseExecutorReturn(t *testing.T) {
-  assertRuleCorpusCase(t, "no-promise-executor-return.ts", "declare const condition: boolean;\ndeclare function consume(value: unknown): void;\n\n// expect: no-promise-executor-return error\nnew Promise((resolve) => resolve(1));\n\nnew Promise(() => {\n  if (condition) {\n    // expect: no-promise-executor-return error\n    return 1;\n  }\n  return;\n});\n\nnew Promise(function () {\n  // expect: no-promise-executor-return error\n  return 2;\n});\n\nnew Promise(() => {\n  const nested = () => 3;\n  consume(nested);\n  return;\n});\n\nfunction shadowed(Promise: new (executor: () => unknown) => unknown) {\n  new Promise(() => 4);\n}\nconsume(shadowed);\n")
+  source := "declare const condition: boolean;\ndeclare function consume(value: unknown): void;\n\n// expect: no-promise-executor-return error\nnew Promise((resolve) => resolve(1));\n\nnew Promise(() => {\n  if (condition) {\n    // expect: no-promise-executor-return error\n    return 1;\n  }\n  return;\n});\n\nnew Promise(function () {\n  // expect: no-promise-executor-return error\n  return 2;\n});\n\nnew Promise(() => {\n  const nested = () => 3;\n  consume(nested);\n  return;\n});\n\nfunction shadowed(Promise: new (executor: () => unknown) => unknown) {\n  new Promise(() => 4);\n}\nconsume(shadowed);\n"
+  expected := parseRuleExpectations(t, source)
+  _, _, findings := runRuleFindingsSnapshot(t, "no-promise-executor-return", source, nil)
+  if len(findings) != len(expected) {
+    t.Fatalf("no-promise-executor-return.ts: want %v, got %+v", expected, findings)
+  }
+  actual := normalizeRuleFindings(findings[0].File, findings)
+  for index := range expected {
+    if actual[index] != expected[index] {
+      t.Fatalf("no-promise-executor-return.ts[%d]: want %+v, got %+v; all findings=%+v", index, expected[index], actual[index], actual)
+    }
+  }
 }

--- a/tests/test-lint/src/cases/no-promise-executor-return.ts
+++ b/tests/test-lint/src/cases/no-promise-executor-return.ts
@@ -1,2 +1,29 @@
+declare const condition: boolean;
+declare function consume(value: unknown): void;
+
 // expect: no-promise-executor-return error
 new Promise((resolve) => resolve(1));
+
+new Promise(() => {
+  if (condition) {
+    // expect: no-promise-executor-return error
+    return 1;
+  }
+  return;
+});
+
+new Promise(function () {
+  // expect: no-promise-executor-return error
+  return 2;
+});
+
+new Promise(() => {
+  const nested = () => 3;
+  consume(nested);
+  return;
+});
+
+function shadowed(Promise: new (executor: () => unknown) => unknown) {
+  new Promise(() => 4);
+}
+consume(shadowed);

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -86,7 +86,7 @@ Examples come from the checked [lint corpus](https://github.com/samchon/ttsc/tre
 - [`no-octal-escape`](#rule-no-octal-escape): Reject octal escape sequences in string literals.
 - [`no-param-reassign`](#rule-no-param-reassign): Reject reassigning a function parameter inside the body of the function it belongs to.
 - [`no-plusplus`](#rule-no-plusplus): Reject `++` and `--` operators.
-- [`no-promise-executor-return`](#rule-no-promise-executor-return): Reject `return` inside the Promise executor function.
+- [`no-promise-executor-return`](#rule-no-promise-executor-return): Reject values returned by global Promise executors.
 - [`no-proto`](#rule-no-proto): Reject access to `obj.__proto__`; use `Object.getPrototypeOf` / `Object.setPrototypeOf`.
 - [`no-prototype-builtins`](#rule-no-prototype-builtins): Reject `obj.hasOwnProperty(key)` and other direct `Object.prototype` builtins on user objects.
 - [`no-redeclare`](#rule-no-redeclare): Reject declaring the same binding more than once in the same scope.

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -1852,13 +1852,30 @@ i++;
 
 ### `no-promise-executor-return`
 
-Reject `return` inside the Promise executor function, the value is ignored.
+Reject values returned by the global `Promise` constructor's executor because the constructor ignores them. The rule checks concise arrow bodies and every explicit value return in block arrows or function expressions without crossing nested function boundaries. A locally shadowed `Promise` constructor is not checked.
+
+Set `allowVoid` to `true` to accept concise `void expression` bodies and explicit `return void expression` statements. It defaults to `false`.
 
 Example:
 
 ```ts
 // reports: no-promise-executor-return (error)
 new Promise((resolve) => resolve(1));
+
+new Promise(() => {
+  // reports: no-promise-executor-return (error)
+  return 1;
+});
+```
+
+```ts filename="ttsc.lint.config.ts"
+import type { ITtscLintConfig } from "@ttsc/lint";
+
+export default {
+  rules: {
+    "no-promise-executor-return": ["error", { allowVoid: true }],
+  },
+} satisfies ITtscLintConfig;
 ```
 
 <a id="rule-no-proto"></a>


### PR DESCRIPTION
## Summary

- recognize only the global `Promise` constructor through TypeScript binding identity
- report concise-arrow values and every executor-owned explicit value return
- stop at nested function boundaries so inner returns keep their own scope
- expose the upstream-compatible `allowVoid` option in runtime and public types
- add positive and negative shields for shadowing, control flow, bare returns, nested functions, and explicit void returns
- document the complete behavior and configuration

## Root cause

The existing implementation matched the callee by identifier text and inspected only concise arrow bodies. It therefore missed block-bodied arrows and function expressions, while reporting locally shadowed constructors.

## Validation plan

Per the required issue lifecycle, focused local validation will run only after three clean exhaustive reviews of this exact PR head. The implementation and shields were compared statically with the current official ESLint rule and corpus before publication.

Closes #513