### PR TITLE
fix(lint): detect covered else-if branches

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -239,7 +239,7 @@ Source: [ESLint core rules](https://eslint.org/docs/latest/rules/).
 - [`no-delete-var`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-delete-var.ts): rejects deleting variables.
 - [`no-dupe-args`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-dupe-args.ts): rejects duplicate function parameters.
 - [`no-dupe-class-members`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-dupe-class-members.ts): reject two declarations of the same member on a single class.
-- [`no-dupe-else-if`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-dupe-else-if.ts): rejects repeated `else if` conditions.
+- [`no-dupe-else-if`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-dupe-else-if.ts): rejects duplicate or logically covered `else if` conditions.
 - [`no-dupe-keys`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-dupe-keys.ts): rejects duplicate object keys.
 - [`no-duplicate-case`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-duplicate-case.ts): rejects duplicate `switch` case labels.
 - [`no-duplicate-imports`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-duplicate-imports.ts): reject a repeated module specifier when the import declarations could be merged into one; `allowSeparateTypeImports` and `includeExports` match the ESLint options.

--- a/packages/lint/linthost/rules_problems.go
+++ b/packages/lint/linthost/rules_problems.go
@@ -11,41 +11,165 @@ import (
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
 
-// noDupeElseIf: `if (a) {} else if (a) {}` — the second branch is
-// unreachable.
+// noDupeElseIf rejects an else-if branch when earlier conditions in the
+// same chain already cover every path that can make its condition true.
 type noDupeElseIf struct{}
 
 func (noDupeElseIf) Name() string           { return "no-dupe-else-if" }
 func (noDupeElseIf) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindIfStatement} }
 func (noDupeElseIf) Check(ctx *Context, node *shimast.Node) {
-  // Only fire on the *outermost* if; the recursion below scans the
-  // chain once.
-  if parent := node.Parent; parent != nil {
-    if parent.Kind == shimast.KindIfStatement {
-      outer := parent.AsIfStatement()
-      if outer != nil && outer.ElseStatement == node {
+  statement := node.AsIfStatement()
+  if statement == nil || statement.Expression == nil {
+    return
+  }
+
+  test := stripParens(statement.Expression)
+  conditionsToCheck := []*shimast.Node{test}
+  if noDupeElseIfLogicalOperator(test) == shimast.KindAmpersandAmpersandToken {
+    conditionsToCheck = append(conditionsToCheck, noDupeElseIfSplit(test, shimast.KindAmpersandAmpersandToken)...)
+  }
+
+  candidates := make([][][]*shimast.Node, 0, len(conditionsToCheck))
+  for _, condition := range conditionsToCheck {
+    orOperands := noDupeElseIfSplit(condition, shimast.KindBarBarToken)
+    conjunctions := make([][]*shimast.Node, 0, len(orOperands))
+    for _, operand := range orOperands {
+      conjunctions = append(conjunctions, noDupeElseIfSplit(operand, shimast.KindAmpersandAmpersandToken))
+    }
+    candidates = append(candidates, conjunctions)
+  }
+
+  current := node
+  for current.Parent != nil && current.Parent.Kind == shimast.KindIfStatement {
+    parent := current.Parent
+    parentStatement := parent.AsIfStatement()
+    if parentStatement == nil || parentStatement.ElseStatement != current || parentStatement.Expression == nil {
+      break
+    }
+
+    earlierOrOperands := noDupeElseIfSplit(stripParens(parentStatement.Expression), shimast.KindBarBarToken)
+    earlierConjunctions := make([][]*shimast.Node, 0, len(earlierOrOperands))
+    for _, operand := range earlierOrOperands {
+      earlierConjunctions = append(earlierConjunctions, noDupeElseIfSplit(operand, shimast.KindAmpersandAmpersandToken))
+    }
+
+    for i, disjunction := range candidates {
+      remaining := disjunction[:0]
+      for _, conjunction := range disjunction {
+        covered := false
+        for _, earlier := range earlierConjunctions {
+          if noDupeElseIfSubset(ctx.File, earlier, conjunction) {
+            covered = true
+            break
+          }
+        }
+        if !covered {
+          remaining = append(remaining, conjunction)
+        }
+      }
+      candidates[i] = remaining
+      if len(remaining) == 0 {
+        ctx.Report(statement.Expression, "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.")
         return
       }
     }
+
+    current = parent
   }
-  seen := map[string]bool{}
-  cur := node
-  for cur != nil && cur.Kind == shimast.KindIfStatement {
-    stmt := cur.AsIfStatement()
-    if stmt == nil || stmt.Expression == nil {
-      break
-    }
-    key := nodeText(ctx.File, stmt.Expression)
-    if key != "" {
-      if seen[key] {
-        ctx.Report(stmt.Expression, "This branch can never execute. Its condition is a duplicate of an earlier branch.")
-      } else {
-        seen[key] = true
+}
+
+func noDupeElseIfLogicalOperator(node *shimast.Node) shimast.Kind {
+  node = stripParens(node)
+  if node == nil || node.Kind != shimast.KindBinaryExpression {
+    return shimast.KindUnknown
+  }
+  expression := node.AsBinaryExpression()
+  if expression == nil || expression.OperatorToken == nil {
+    return shimast.KindUnknown
+  }
+  switch expression.OperatorToken.Kind {
+  case shimast.KindAmpersandAmpersandToken, shimast.KindBarBarToken:
+    return expression.OperatorToken.Kind
+  default:
+    return shimast.KindUnknown
+  }
+}
+
+func noDupeElseIfSplit(node *shimast.Node, operator shimast.Kind) []*shimast.Node {
+  node = stripParens(node)
+  if noDupeElseIfLogicalOperator(node) != operator {
+    return []*shimast.Node{node}
+  }
+  expression := node.AsBinaryExpression()
+  operands := noDupeElseIfSplit(expression.Left, operator)
+  return append(operands, noDupeElseIfSplit(expression.Right, operator)...)
+}
+
+func noDupeElseIfSubset(file *shimast.SourceFile, subset, set []*shimast.Node) bool {
+  for _, candidate := range subset {
+    matched := false
+    for _, element := range set {
+      if noDupeElseIfEqual(file, candidate, element) {
+        matched = true
+        break
       }
     }
-    cur = stmt.ElseStatement
+    if !matched {
+      return false
+    }
+  }
+  return true
+}
+
+// noDupeElseIfEqual compares boolean expressions structurally. Logical AND
+// and OR are commutative in a condition's truth table; every other expression
+// must retain the same token kinds and values.
+func noDupeElseIfEqual(file *shimast.SourceFile, left, right *shimast.Node) bool {
+  left = stripParens(left)
+  right = stripParens(right)
+  if left == nil || right == nil || left.Kind != right.Kind {
+    return false
+  }
+
+  operator := noDupeElseIfLogicalOperator(left)
+  if operator != shimast.KindUnknown && operator == noDupeElseIfLogicalOperator(right) {
+    leftExpression := left.AsBinaryExpression()
+    rightExpression := right.AsBinaryExpression()
+    return noDupeElseIfEqual(file, leftExpression.Left, rightExpression.Left) &&
+      noDupeElseIfEqual(file, leftExpression.Right, rightExpression.Right) ||
+      noDupeElseIfEqual(file, leftExpression.Left, rightExpression.Right) &&
+        noDupeElseIfEqual(file, leftExpression.Right, rightExpression.Left)
+  }
+
+  return noDupeElseIfEqualTokens(file, left, right)
+}
+
+func noDupeElseIfEqualTokens(file *shimast.SourceFile, left, right *shimast.Node) bool {
+  leftText := nodeText(file, left)
+  rightText := nodeText(file, right)
+  if leftText == "" || rightText == "" {
+    return false
+  }
+
+  leftScanner := shimscanner.NewScanner()
+  leftScanner.SetText(leftText)
+  leftScanner.SetSkipTrivia(true)
+  rightScanner := shimscanner.NewScanner()
+  rightScanner.SetText(rightText)
+  rightScanner.SetSkipTrivia(true)
+
+  for {
+    leftKind := leftScanner.Scan()
+    rightKind := rightScanner.Scan()
+    if leftKind != rightKind || leftScanner.TokenText() != rightScanner.TokenText() {
+      return false
+    }
+    if leftKind == shimast.KindEndOfFile {
+      return true
+    }
   }
 }
 

--- a/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
@@ -431,8 +431,8 @@ export interface ITtscLintCoreRules {
   "no-dupe-class-members"?: TtscLintRuleSetting;
 
   /**
-   * Reject `if (a) {} else if (a) {}` — the second branch is unreachable
-   * because the first condition already handled it.
+   * Reject an `else if` branch when duplicate or structurally covered
+   * conditions earlier in the same chain make it unreachable.
    *
    * @reference https://eslint.org/docs/latest/rules/no-dupe-else-if
    */

--- a/packages/lint/test/rules/runtime-safety/no_dupe_else_if_logical_coverage_test.go
+++ b/packages/lint/test/rules/runtime-safety/no_dupe_else_if_logical_coverage_test.go
@@ -1,0 +1,147 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+)
+
+// TestNoDupeElseIfLogicalCoverage protects both sides of the rule's boolean
+// coverage test. Covered branches exercise exact, subset, accumulated, nested,
+// and commuted conditions; executable near-misses ensure shared operands alone
+// never cause a report.
+func TestNoDupeElseIfLogicalCoverage(t *testing.T) {
+  tests := []struct {
+    name      string
+    source    string
+    wantLines []int
+  }{
+    {
+      name: "equal tokens ignore whitespace and comments",
+      source: `if (value === 1) {}
+else if (value===/* comment */1) {}`,
+      wantLines: []int{2},
+    },
+    {
+      name: "whole condition parentheses are transparent",
+      source: `if (value === 1) {}
+else if ((value === 1)) {}`,
+      wantLines: []int{2},
+    },
+    {
+      name: "earlier disjunction covers one operand",
+      source: `if (a || b) {}
+else if (a) {}`,
+      wantLines: []int{2},
+    },
+    {
+      name: "earlier operand covers later conjunction",
+      source: `if (a) {}
+else if (a && b) {}`,
+      wantLines: []int{2},
+    },
+    {
+      name: "separate earlier branches accumulate",
+      source: `if (a) {}
+else if (b) {}
+else if (a || b) {}`,
+      wantLines: []int{3},
+    },
+    {
+      name: "and operands commute",
+      source: `if (a && b) {}
+else if (b && a) {}`,
+      wantLines: []int{2},
+    },
+    {
+      name: "or operands commute",
+      source: `if (a || b) {}
+else if (b || a) {}`,
+      wantLines: []int{2},
+    },
+    {
+      name: "nested logical operands commute and cover",
+      source: `if ((a && (b || c)) || d) {}
+else if ((c || b) && e && a) {}`,
+      wantLines: []int{2},
+    },
+    {
+      name: "one disjunction covers multiple later branches",
+      source: `if (a || b) {}
+else if (a) {}
+else if (b) {}`,
+      wantLines: []int{2, 3},
+    },
+    {
+      name: "nested accumulated alternatives cover conjunction",
+      source: `if (a) {}
+else if (b) {}
+else if (c && (a || d && b)) {}`,
+      wantLines: []int{3},
+    },
+    {
+      name: "overlapping disjunction stays executable",
+      source: `if (a || b) {}
+else if (a || c) {}`,
+    },
+    {
+      name: "broader later disjunction stays executable",
+      source: `if (a) {}
+else if (a || b) {}`,
+    },
+    {
+      name: "stricter earlier conjunction does not cover operand",
+      source: `if (a && b) {}
+else if (a) {}`,
+    },
+    {
+      name: "accumulated disjunction with new operand stays executable",
+      source: `if (a) {}
+else if (b) {}
+else if (a || b || c) {}`,
+    },
+    {
+      name: "different token structure stays executable",
+      source: `if (value === 1) {}
+else if (value === (1)) {}`,
+    },
+    {
+      name: "identifier and call stay distinct",
+      source: `if (fn) {}
+else if (fn()) {}`,
+    },
+    {
+      name: "partially shared nested condition stays executable",
+      source: `if (a) {}
+else if (b && (a || c)) {}`,
+    },
+    {
+      name: "independent nested if is not part of chain",
+      source: `if (a) {}
+if (a) {}`,
+    },
+  }
+
+  for _, test := range tests {
+    t.Run(test.name, func(t *testing.T) {
+      file := parseTS(t, test.source)
+      findings := NewEngine(RuleConfig{"no-dupe-else-if": SeverityError}).Run([]*shimast.SourceFile{file}, nil)
+      gotLines := make([]int, 0, len(findings))
+      for _, finding := range findings {
+        if finding.Message != "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain." {
+          t.Fatalf("unexpected message: %q", finding.Message)
+        }
+        gotLines = append(gotLines, shimscanner.GetECMALineOfPosition(file, finding.Pos)+1)
+      }
+      if len(gotLines) != len(test.wantLines) {
+        t.Fatalf("finding lines = %v, want %v", gotLines, test.wantLines)
+      }
+      for i := range gotLines {
+        if gotLines[i] != test.wantLines[i] {
+          t.Fatalf("finding lines = %v, want %v", gotLines, test.wantLines)
+        }
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- detect else-if conditions covered by earlier logical branches
- compare expression tokens structurally while ignoring comments and whitespace
- cover nested, accumulated, and commuted AND/OR cases with executable near-miss shields

## Validation
- implementation and shield tests committed before review
- focused local test intentionally follows three clean exhaustive review rounds

Closes #512