### PR TITLE
fix(lint): complete empty rule semantics

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -244,12 +244,12 @@ Source: [ESLint core rules](https://eslint.org/docs/latest/rules/).
 - [`no-duplicate-case`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-duplicate-case.ts): rejects duplicate `switch` case labels.
 - [`no-duplicate-imports`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-duplicate-imports.ts): reject a repeated module specifier when the import declarations could be merged into one; `allowSeparateTypeImports` and `includeExports` match the ESLint options.
 - [`no-else-return`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-else-return.ts): reject an `else` block whose preceding `if` branch already terminates with `return`, `throw`, `break`, or `continue`.
-- [`no-empty`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty.ts): rejects empty blocks.
+- [`no-empty`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty.ts): rejects uncommented empty blocks and switches; `allowEmptyCatch` accepts empty catches.
 - [`no-empty-character-class`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty-character-class.ts): rejects empty regex character classes.
-- [`no-empty-function`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty-function.ts): rejects empty functions.
+- [`no-empty-function`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty-function.ts): rejects uncommented empty functions unless their category is allowed.
 - [`no-empty-named-blocks`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty-named-blocks.ts): rejects empty named import/export clauses (`import {} from "x"`, `export {}`).
 - [`no-empty-pattern`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty-pattern.ts): rejects empty destructuring patterns.
-- [`no-empty-static-block`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty-static-block.ts): rejects empty class static blocks.
+- [`no-empty-static-block`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty-static-block.ts): rejects uncommented empty class static blocks.
 - [`no-eq-null`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-eq-null.ts): rejects loose null comparisons.
 - [`no-eval`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-eval.ts): rejects `eval`.
 - [`no-ex-assign`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-ex-assign.ts): rejects reassignment of caught exceptions.

--- a/packages/lint/linthost/rules_empty.go
+++ b/packages/lint/linthost/rules_empty.go
@@ -1,35 +1,67 @@
 package linthost
 
-import shimast "github.com/microsoft/typescript-go/shim/ast"
+import (
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+)
 
-// noEmpty: empty block statements (`{}`), but allow empty catch
-// clauses since they're idiomatic for "ignore the error".
+// noEmpty rejects empty block and switch statements unless an interior
+// comment documents the intentional no-op.
 // https://eslint.org/docs/latest/rules/no-empty
 type noEmpty struct{}
 
+type noEmptyOptions struct {
+  AllowEmptyCatch bool `json:"allowEmptyCatch"`
+}
+
 func (noEmpty) Name() string           { return "no-empty" }
-func (noEmpty) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindBlock} }
+func (noEmpty) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindBlock, shimast.KindSwitchStatement}
+}
 func (noEmpty) Check(ctx *Context, node *shimast.Node) {
-  block := node.AsBlock()
-  if block == nil || block.Statements == nil {
+  if node.Kind == shimast.KindSwitchStatement {
+    statement := node.AsSwitchStatement()
+    if statement == nil || statement.CaseBlock == nil {
+      return
+    }
+    caseBlock := statement.CaseBlock.AsCaseBlock()
+    if caseBlock == nil || caseBlock.Clauses != nil && len(caseBlock.Clauses.Nodes) != 0 {
+      return
+    }
+    if !emptyBracedBodyHasComment(ctx.File, statement.CaseBlock) {
+      ctx.Report(statement.CaseBlock, "Empty switch statement.")
+    }
     return
   }
-  if len(block.Statements.Nodes) > 0 {
+
+  block := node.AsBlock()
+  if block == nil || block.Statements != nil && len(block.Statements.Nodes) != 0 {
     return
   }
   parent := node.Parent
-  if parent != nil && parent.Kind == shimast.KindCatchClause {
-    return // tolerated — see ESLint default options
-  }
   if isFunctionLikeKind(parent) {
     return // empty function body is `no-empty-function`'s job
   }
-  ctx.Report(node, "Empty block statement.")
+  if parent != nil && parent.Kind == shimast.KindClassStaticBlockDeclaration {
+    return // static blocks have their own rule and are not BlockStatement in ESTree
+  }
+  var options noEmptyOptions
+  _ = ctx.DecodeOptions(&options)
+  if options.AllowEmptyCatch && parent != nil && parent.Kind == shimast.KindCatchClause {
+    return
+  }
+  if !emptyBracedBodyHasComment(ctx.File, node) {
+    ctx.Report(node, "Empty block statement.")
+  }
 }
 
 // noEmptyFunction: empty function / method / arrow / accessor bodies.
 // https://eslint.org/docs/latest/rules/no-empty-function
 type noEmptyFunction struct{}
+
+type noEmptyFunctionOptions struct {
+  Allow []string `json:"allow"`
+}
 
 func (noEmptyFunction) Name() string { return "no-empty-function" }
 func (noEmptyFunction) Visits() []shimast.Kind {
@@ -45,19 +77,155 @@ func (noEmptyFunction) Visits() []shimast.Kind {
 }
 func (noEmptyFunction) Check(ctx *Context, node *shimast.Node) {
   body := node.Body()
-  if body == nil {
-    return
-  }
-  if body.Kind != shimast.KindBlock {
+  if body == nil || body.Kind != shimast.KindBlock {
     return
   }
   block := body.AsBlock()
-  if block == nil || block.Statements == nil {
+  if block == nil || block.Statements != nil && len(block.Statements.Nodes) != 0 {
     return
   }
-  if len(block.Statements.Nodes) == 0 {
-    ctx.Report(node, "Unexpected empty function.")
+  var options noEmptyFunctionOptions
+  _ = ctx.DecodeOptions(&options)
+  kind := noEmptyFunctionKind(node)
+  if kind == "" || noEmptyFunctionAllowed(node, kind, options.Allow) || emptyBracedBodyHasComment(ctx.File, body) {
+    return
   }
+  ctx.Report(body, "Unexpected empty "+noEmptyFunctionLabel(kind)+".")
+}
+
+func noEmptyFunctionKind(node *shimast.Node) string {
+  if node == nil {
+    return ""
+  }
+  switch node.Kind {
+  case shimast.KindArrowFunction:
+    return "arrowFunctions"
+  case shimast.KindConstructor:
+    return "constructors"
+  case shimast.KindGetAccessor:
+    return "getters"
+  case shimast.KindSetAccessor:
+    return "setters"
+  case shimast.KindMethodDeclaration:
+    if noEmptyFunctionIsGenerator(node) {
+      return "generatorMethods"
+    }
+    if node.ModifierFlags()&shimast.ModifierFlagsAsync != 0 {
+      return "asyncMethods"
+    }
+    return "methods"
+  case shimast.KindFunctionDeclaration, shimast.KindFunctionExpression:
+    if noEmptyFunctionIsGenerator(node) {
+      return "generatorFunctions"
+    }
+    if node.ModifierFlags()&shimast.ModifierFlagsAsync != 0 {
+      return "asyncFunctions"
+    }
+    return "functions"
+  default:
+    return ""
+  }
+}
+
+func noEmptyFunctionIsGenerator(node *shimast.Node) bool {
+  switch node.Kind {
+  case shimast.KindFunctionDeclaration:
+    declaration := node.AsFunctionDeclaration()
+    return declaration != nil && declaration.AsteriskToken != nil
+  case shimast.KindFunctionExpression:
+    expression := node.AsFunctionExpression()
+    return expression != nil && expression.AsteriskToken != nil
+  case shimast.KindMethodDeclaration:
+    declaration := node.AsMethodDeclaration()
+    return declaration != nil && declaration.AsteriskToken != nil
+  default:
+    return false
+  }
+}
+
+func noEmptyFunctionAllowed(node *shimast.Node, kind string, allow []string) bool {
+  if noEmptyFunctionOptionIncludes(allow, kind) {
+    return true
+  }
+  if kind == "constructors" {
+    if hasParameterProperty(node) {
+      return true
+    }
+    modifiers := node.ModifierFlags()
+    if modifiers&shimast.ModifierFlagsPrivate != 0 && noEmptyFunctionOptionIncludes(allow, "privateConstructors") {
+      return true
+    }
+    if modifiers&shimast.ModifierFlagsProtected != 0 && noEmptyFunctionOptionIncludes(allow, "protectedConstructors") {
+      return true
+    }
+  }
+  switch kind {
+  case "methods", "generatorMethods", "asyncMethods", "getters", "setters":
+    if len(node.Decorators()) != 0 && noEmptyFunctionOptionIncludes(allow, "decoratedFunctions") {
+      return true
+    }
+    if node.ModifierFlags()&shimast.ModifierFlagsOverride != 0 && noEmptyFunctionOptionIncludes(allow, "overrideMethods") {
+      return true
+    }
+  }
+  return false
+}
+
+func noEmptyFunctionOptionIncludes(allow []string, candidate string) bool {
+  for _, option := range allow {
+    if option == candidate {
+      return true
+    }
+  }
+  return false
+}
+
+func noEmptyFunctionLabel(kind string) string {
+  switch kind {
+  case "arrowFunctions":
+    return "arrow function"
+  case "generatorFunctions":
+    return "generator function"
+  case "methods":
+    return "method"
+  case "generatorMethods":
+    return "generator method"
+  case "getters":
+    return "getter"
+  case "setters":
+    return "setter"
+  case "constructors":
+    return "constructor"
+  case "asyncFunctions":
+    return "async function"
+  case "asyncMethods":
+    return "async method"
+  default:
+    return "function"
+  }
+}
+
+// emptyBracedBodyHasComment scans only the trivia between the parser-owned
+// opening and closing brace tokens of an already-proven empty body. Exterior
+// comments cannot enter this range, and context-sensitive expression tokens
+// cannot occur because the body has no statements or switch clauses.
+func emptyBracedBodyHasComment(file *shimast.SourceFile, body *shimast.Node) bool {
+  if file == nil || body == nil {
+    return false
+  }
+  opening := shimscanner.GetScannerForSourceFile(file, body.Pos())
+  if opening.Token() != shimast.KindOpenBraceToken || opening.TokenEnd() > body.End() {
+    return false
+  }
+  closing := shimscanner.GetScannerForSourceFile(file, opening.TokenEnd())
+  if closing.Token() != shimast.KindCloseBraceToken || closing.TokenEnd() > body.End() {
+    return false
+  }
+  found := false
+  scanCommentGap(shimscanner.NewScanner(), file.Text(), opening.TokenEnd(), closing.TokenStart(), func(_ shimast.Kind, _, _ int) {
+    found = true
+  })
+  return found
 }
 
 // noEmptyPattern: `({}) => x` or `function ({}) {}` — destructuring

--- a/packages/lint/linthost/rules_gap.go
+++ b/packages/lint/linthost/rules_gap.go
@@ -31,8 +31,11 @@ func (noEmptyStaticBlock) Check(ctx *Context, node *shimast.Node) {
     return
   }
   body := block.Body.AsBlock()
-  if body == nil || body.Statements == nil || len(body.Statements.Nodes) == 0 {
-    ctx.Report(node, "Unexpected empty static block.")
+  if body == nil || body.Statements != nil && len(body.Statements.Nodes) != 0 {
+    return
+  }
+  if !emptyBracedBodyHasComment(ctx.File, block.Body) {
+    ctx.Report(block.Body, "Unexpected empty static block.")
   }
 }
 

--- a/packages/lint/linthost/rules_no_useless_constructor.go
+++ b/packages/lint/linthost/rules_no_useless_constructor.go
@@ -73,9 +73,8 @@ func (noUselessConstructor) Check(ctx *Context, node *shimast.Node) {
 }
 
 // hasParameterProperty reports whether any constructor parameter carries
-// TypeScript's canonical parameter-property modifier flag. Such a parameter
-// declares an instance
-// field, so the constructor is doing real work even if its body is
+// TypeScript's canonical parameter-property modifier flag. Such parameters
+// declare instance fields, so the constructor is doing real work even if its body is
 // empty — removing it would drop the field.
 func hasParameterProperty(node *shimast.Node) bool {
   for _, p := range node.Parameters() {

--- a/packages/lint/linthost/rules_no_useless_constructor.go
+++ b/packages/lint/linthost/rules_no_useless_constructor.go
@@ -73,8 +73,8 @@ func (noUselessConstructor) Check(ctx *Context, node *shimast.Node) {
 }
 
 // hasParameterProperty reports whether any constructor parameter carries
-// a TypeScript parameter-property modifier (`public`, `private`,
-// `protected`, or `readonly`). Such a parameter declares an instance
+// TypeScript's canonical parameter-property modifier flag. Such a parameter
+// declares an instance
 // field, so the constructor is doing real work even if its body is
 // empty — removing it would drop the field.
 func hasParameterProperty(node *shimast.Node) bool {
@@ -82,33 +82,7 @@ func hasParameterProperty(node *shimast.Node) bool {
     if p == nil {
       continue
     }
-    if p.ModifierFlags()&(shimast.ModifierFlagsPrivate|shimast.ModifierFlagsProtected|shimast.ModifierFlagsReadonly) != 0 {
-      return true
-    }
-    // `public` is not represented by any of the above flags but does
-    // still create a parameter property. Inspect the raw modifier
-    // list for a PublicKeyword.
-    decl := p.AsParameterDeclaration()
-    if decl == nil {
-      continue
-    }
-    if hasPublicModifier(decl.Modifiers()) {
-      return true
-    }
-  }
-  return false
-}
-
-// hasPublicModifier reports whether `mods` includes a `public` keyword.
-// `public` is a parameter-property qualifier that does not set any of
-// the Private/Protected/Readonly modifier flags, so we walk the raw
-// modifier list to detect it.
-func hasPublicModifier(mods *shimast.ModifierList) bool {
-  if mods == nil {
-    return false
-  }
-  for _, m := range mods.Nodes {
-    if m != nil && m.Kind == shimast.KindPublicKeyword {
+    if p.ModifierFlags()&shimast.ModifierFlagsParameterPropertyModifier != 0 {
       return true
     }
   }
@@ -194,12 +168,9 @@ func plainParamIdentifier(param *shimast.Node) (string, bool, bool) {
   if decl.Initializer != nil || decl.QuestionToken != nil {
     return "", false, false
   }
-  // Accessibility modifier on the parameter would already have been
-  // caught by hasParameterProperty above, but guard locally too.
-  if param.ModifierFlags()&(shimast.ModifierFlagsPrivate|shimast.ModifierFlagsProtected|shimast.ModifierFlagsReadonly) != 0 {
-    return "", false, false
-  }
-  if hasPublicModifier(decl.Modifiers()) {
+  // A parameter-property modifier would already have been caught by
+  // hasParameterProperty above, but guard locally too.
+  if param.ModifierFlags()&shimast.ModifierFlagsParameterPropertyModifier != 0 {
     return "", false, false
   }
   name := identifierText(decl.Name())

--- a/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
@@ -26,6 +26,46 @@ export interface ITtscLintCoreNoDuplicateImportsRuleOptions {
   includeExports?: boolean;
 }
 
+/** `no-empty` rule options. */
+export interface ITtscLintCoreNoEmptyRuleOptions {
+  /**
+   * Allow a catch clause with no statements or interior comment. Other empty
+   * blocks remain reportable.
+   *
+   * @default false
+   */
+  allowEmptyCatch?: boolean;
+}
+
+/** Function categories accepted by `no-empty-function`. */
+export type TtscLintCoreNoEmptyFunctionAllow =
+  | "functions"
+  | "arrowFunctions"
+  | "generatorFunctions"
+  | "methods"
+  | "generatorMethods"
+  | "getters"
+  | "setters"
+  | "constructors"
+  | "asyncFunctions"
+  | "asyncMethods"
+  | "privateConstructors"
+  | "protectedConstructors"
+  | "decoratedFunctions"
+  | "overrideMethods";
+
+/** `no-empty-function` rule options. */
+export interface ITtscLintCoreNoEmptyFunctionRuleOptions {
+  /**
+   * Function categories that may have an empty, uncommented block body.
+   * TypeScript parameter-property constructors are always accepted because
+   * their parameters initialize fields even when the block has no statements.
+   *
+   * @default []
+   */
+  allow?: TtscLintCoreNoEmptyFunctionAllow[];
+}
+
 /**
  * `no-unused-expressions` rule options.
  *

--- a/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
@@ -4,6 +4,8 @@ import type {
 } from "../TtscLintRuleSetting";
 import type {
   ITtscLintCoreNoDuplicateImportsRuleOptions,
+  ITtscLintCoreNoEmptyFunctionRuleOptions,
+  ITtscLintCoreNoEmptyRuleOptions,
   ITtscLintCoreNoPromiseExecutorReturnRuleOptions,
   ITtscLintCoreNoUnusedExpressionsRuleOptions,
   ITtscLintCorePreferConstRuleOptions,
@@ -478,12 +480,12 @@ export interface ITtscLintCoreRules {
   "no-else-return"?: TtscLintRuleSetting;
 
   /**
-   * Reject empty blocks (`if (x) {}`, `while (x) {}`, `try {} catch (e) {}`
-   * etc.) that almost always indicate forgotten code.
+   * Reject empty, uncommented blocks and switches. Set `allowEmptyCatch` to
+   * accept an uncommented empty catch clause; its default is `false`.
    *
    * @reference https://eslint.org/docs/latest/rules/no-empty
    */
-  "no-empty"?: TtscLintRuleSetting;
+  "no-empty"?: TtscLintRuleOptionsSetting<ITtscLintCoreNoEmptyRuleOptions>;
 
   /**
    * Reject empty regex character classes (`[]`).
@@ -496,14 +498,13 @@ export interface ITtscLintCoreRules {
   "no-empty-character-class"?: TtscLintRuleSetting;
 
   /**
-   * Reject empty function and method bodies (`function f() {}`, `() => {}`).
-   *
-   * Use `() => undefined` or a leading TODO comment when the empty body is
-   * intentional.
+   * Reject empty, uncommented function bodies. The `allow` option accepts
+   * canonical function, method, accessor, constructor, async, generator,
+   * decorator, and override categories.
    *
    * @reference https://eslint.org/docs/latest/rules/no-empty-function
    */
-  "no-empty-function"?: TtscLintRuleSetting;
+  "no-empty-function"?: TtscLintRuleOptionsSetting<ITtscLintCoreNoEmptyFunctionRuleOptions>;
 
   /**
    * Reject empty named import or export clauses — `import {} from "x"`, `import

--- a/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
+++ b/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
@@ -8,6 +8,8 @@ import type {
 } from "./ITtscLintBoundariesRuleOptions";
 import type {
   ITtscLintCoreNoDuplicateImportsRuleOptions,
+  ITtscLintCoreNoEmptyFunctionRuleOptions,
+  ITtscLintCoreNoEmptyRuleOptions,
   ITtscLintCoreNoPromiseExecutorReturnRuleOptions,
   ITtscLintCoreNoUnusedExpressionsRuleOptions,
   ITtscLintCorePreferConstRuleOptions,
@@ -66,6 +68,8 @@ import type {
 export interface ITtscLintRuleOptionsMap {
   "typescript/no-floating-promises": ITtscLintTypeScriptNoFloatingPromisesRuleOptions;
   "no-duplicate-imports": ITtscLintCoreNoDuplicateImportsRuleOptions;
+  "no-empty": ITtscLintCoreNoEmptyRuleOptions;
+  "no-empty-function": ITtscLintCoreNoEmptyFunctionRuleOptions;
   "no-promise-executor-return": ITtscLintCoreNoPromiseExecutorReturnRuleOptions;
   "no-unused-expressions": ITtscLintCoreNoUnusedExpressionsRuleOptions;
   "no-fallthrough": ITtscLintNoFallthroughRuleOptions;

--- a/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
+++ b/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
@@ -179,6 +179,66 @@ class Example extends Base {
       source: `const object = { method() {} };`,
       allow:  []string{"methods"},
     },
+    {
+      name: "decorated method family reports by default",
+      source: `declare function decorate(...args: unknown[]): unknown;
+class Example {
+  @decorate method() {}
+  @decorate *generatorMethod() {}
+  @decorate async asyncMethod() {}
+  @decorate get first() {}
+  @decorate set second(_value: unknown) {}
+}`,
+      want: 5,
+    },
+    {
+      name: "decorated option includes methods and accessors",
+      source: `declare function decorate(...args: unknown[]): unknown;
+class Example {
+  @decorate method() {}
+  @decorate *generatorMethod() {}
+  @decorate async asyncMethod() {}
+  @decorate get first() {}
+  @decorate set second(_value: unknown) {}
+}`,
+      allow: []string{"decoratedFunctions"},
+    },
+    {
+      name: "override method family reports by default",
+      source: `class Base {
+  method() { return; }
+  *generatorMethod() { yield 1; }
+  async asyncMethod() { return; }
+  get first() { return 1; }
+  set second(_value: unknown) { return; }
+}
+class Example extends Base {
+  override method() {}
+  override *generatorMethod() {}
+  override async asyncMethod() {}
+  override get first() {}
+  override set second(_value: unknown) {}
+}`,
+      want: 5,
+    },
+    {
+      name: "override option includes methods and accessors",
+      source: `class Base {
+  method() { return; }
+  *generatorMethod() { yield 1; }
+  async asyncMethod() { return; }
+  get first() { return 1; }
+  set second(_value: unknown) { return; }
+}
+class Example extends Base {
+  override method() {}
+  override *generatorMethod() {}
+  override async asyncMethod() {}
+  override get first() {}
+  override set second(_value: unknown) {}
+}`,
+      allow: []string{"overrideMethods"},
+    },
   }
 
   for _, test := range tests {

--- a/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
+++ b/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
@@ -150,6 +150,11 @@ class Example extends Base {
       want:   1,
     },
     {
+      name:   "async function expression reports by default",
+      source: `const empty = async function () {};`,
+      want:   1,
+    },
+    {
       name:   "async function expressions use async function category",
       source: `const empty = async function () {};`,
       allow:  []string{"asyncFunctions"},

--- a/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
+++ b/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
@@ -92,8 +92,13 @@ func TestNoEmptyFunctionTypeScriptExceptionsAndCategoryBoundaries(t *testing.T) 
     want    int
   }{
     {
-      name:   "parameter property constructor always has work",
-      source: `class Example { constructor(public value: number) {} }`,
+      name: "every parameter property constructor always has work",
+      source: `class PublicExample { constructor(public value: number) {} }
+class PrivateExample { constructor(private value: number) {} }
+class ProtectedExample { constructor(protected value: number) {} }
+class ReadonlyExample { constructor(readonly value: number) {} }
+class Base { value = 0; }
+class OverrideExample extends Base { constructor(override value: number) {} }`,
     },
     {
       name: "private constructor option stays private",

--- a/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
+++ b/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
@@ -58,9 +58,13 @@ class Example extends Base { override method() {} }`,
 // inside each function body's braces and works for every primary function kind.
 func TestNoEmptyFunctionCommentsPreserveEveryKind(t *testing.T) {
   source := `function ordinary() { /* intentional */ }
+const expression = function () { /* intentional */ };
 const arrow = () => { /* intentional */ };
 function* generator() { /* intentional */ }
+const generatorExpression = function* () { /* intentional */ };
 async function asynchronous() { /* intentional */ }
+const asyncExpression = async function () { /* intentional */ };
+const asyncGeneratorExpression = async function* () { /* intentional */ };
 class Example {
   constructor() { /* intentional */ }
   method() { /* intentional */ }
@@ -69,7 +73,8 @@ class Example {
   get value() { /* intentional */ }
   set value(_value: unknown) { /* intentional */ }
 }
-void [ordinary, arrow, generator, asynchronous, Example];`
+void [ordinary, expression, arrow, generator, generatorExpression,
+  asynchronous, asyncExpression, asyncGeneratorExpression, Example];`
   _, _, findings := runRuleFindingsSnapshot(t, "no-empty-function", source, nil)
   if len(findings) != 0 {
     t.Fatalf("commented function bodies produced findings: %+v", findings)
@@ -138,6 +143,30 @@ class Example extends Base {
       source: `class Example { async *method() {} }`,
       allow:  []string{"asyncMethods"},
       want:   1,
+    },
+    {
+      name:   "async function expressions use async function category",
+      source: `const empty = async function () {};`,
+      allow:  []string{"asyncFunctions"},
+    },
+    {
+      name:   "async generator functions use generator category",
+      source: `const empty = async function* () {};`,
+      allow:  []string{"generatorFunctions"},
+    },
+    {
+      name:   "async function category excludes async generators",
+      source: `const empty = async function* () {};`,
+      allow:  []string{"asyncFunctions"},
+      want:   1,
+    },
+    {
+      name:   "concise arrows have no empty block body",
+      source: `const identity = (value: unknown) => value;`,
+    },
+    {
+      name:   "nonempty functions remain accepted",
+      source: `function work() { return; }`,
     },
     {
       name:   "exterior comments do not preserve function",

--- a/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
+++ b/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
@@ -179,6 +179,11 @@ class Example extends Base {
       want:   1,
     },
     {
+      name:   "comment before function opening brace stays exterior",
+      source: `function empty() /* before brace */ {}`,
+      want:   1,
+    },
+    {
       name:   "object property function remains a function",
       source: `const object = { value: function () {} };`,
       allow:  []string{"functions"},

--- a/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
+++ b/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
@@ -1,0 +1,170 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+)
+
+// TestNoEmptyFunctionAllowCategories verifies every canonical allow value maps
+// to exactly the corresponding TypeScript AST function kind.
+func TestNoEmptyFunctionAllowCategories(t *testing.T) {
+  tests := []struct {
+    option string
+    source string
+  }{
+    {option: "functions", source: `function empty() {}`},
+    {option: "arrowFunctions", source: `const empty = () => {};`},
+    {option: "generatorFunctions", source: `function* empty() {}`},
+    {option: "methods", source: `class Example { method() {} }`},
+    {option: "generatorMethods", source: `class Example { *method() {} }`},
+    {option: "getters", source: `class Example { get value() {} }`},
+    {option: "setters", source: `class Example { set value(_value: unknown) {} }`},
+    {option: "constructors", source: `class Example { constructor() {} }`},
+    {option: "asyncFunctions", source: `async function empty() {}`},
+    {option: "asyncMethods", source: `class Example { async method() {} }`},
+    {option: "privateConstructors", source: `class Example { private constructor() {} }`},
+    {option: "protectedConstructors", source: `class Example { protected constructor() {} }`},
+    {
+      option: "decoratedFunctions",
+      source: `declare function decorate(...args: unknown[]): unknown;
+class Example { @decorate method() {} }`,
+    },
+    {
+      option: "overrideMethods",
+      source: `class Base { method() { return; } }
+class Example extends Base { override method() {} }`,
+    },
+  }
+
+  for _, test := range tests {
+    t.Run(test.option, func(t *testing.T) {
+      _, _, defaultFindings := runRuleFindingsSnapshot(t, "no-empty-function", test.source, nil)
+      if len(defaultFindings) != 1 {
+        t.Fatalf("default finding count = %d, want 1; findings=%+v", len(defaultFindings), defaultFindings)
+      }
+      options, err := json.Marshal(noEmptyFunctionOptions{Allow: []string{test.option}})
+      if err != nil {
+        t.Fatal(err)
+      }
+      _, _, allowedFindings := runRuleFindingsSnapshot(t, "no-empty-function", test.source, options)
+      if len(allowedFindings) != 0 {
+        t.Fatalf("finding count with allow %q = %d, want 0; findings=%+v", test.option, len(allowedFindings), allowedFindings)
+      }
+    })
+  }
+}
+
+// TestNoEmptyFunctionCommentsPreserveEveryKind ensures a comment must be
+// inside each function body's braces and works for every primary function kind.
+func TestNoEmptyFunctionCommentsPreserveEveryKind(t *testing.T) {
+  source := `function ordinary() { /* intentional */ }
+const arrow = () => { /* intentional */ };
+function* generator() { /* intentional */ }
+async function asynchronous() { /* intentional */ }
+class Example {
+  constructor() { /* intentional */ }
+  method() { /* intentional */ }
+  *generatorMethod() { /* intentional */ }
+  async asyncMethod() { /* intentional */ }
+  get value() { /* intentional */ }
+  set value(_value: unknown) { /* intentional */ }
+}
+void [ordinary, arrow, generator, asynchronous, Example];`
+  _, _, findings := runRuleFindingsSnapshot(t, "no-empty-function", source, nil)
+  if len(findings) != 0 {
+    t.Fatalf("commented function bodies produced findings: %+v", findings)
+  }
+}
+
+// TestNoEmptyFunctionTypeScriptExceptionsAndCategoryBoundaries protects the
+// parameter-property exception and categories that deliberately do not widen
+// to nearby function shapes.
+func TestNoEmptyFunctionTypeScriptExceptionsAndCategoryBoundaries(t *testing.T) {
+  tests := []struct {
+    name    string
+    source  string
+    allow   []string
+    want    int
+  }{
+    {
+      name:   "parameter property constructor always has work",
+      source: `class Example { constructor(public value: number) {} }`,
+    },
+    {
+      name: "private constructor option stays private",
+      source: `class PrivateExample { private constructor() {} }
+class PublicExample { constructor() {} }`,
+      allow: []string{"privateConstructors"},
+      want:  1,
+    },
+    {
+      name: "decorated option stays decorated",
+      source: `declare function decorate(...args: unknown[]): unknown;
+class Example {
+  @decorate decorated() {}
+  ordinary() {}
+}`,
+      allow: []string{"decoratedFunctions"},
+      want:  1,
+    },
+    {
+      name: "override option stays override",
+      source: `class Base { method() { return; } }
+class Example extends Base {
+  override method() {}
+  ordinary() {}
+}`,
+      allow: []string{"overrideMethods"},
+      want:  1,
+    },
+    {
+      name:   "async function option does not include async arrows",
+      source: `const empty = async () => {};`,
+      allow:  []string{"asyncFunctions"},
+      want:   1,
+    },
+    {
+      name:   "arrow option includes async arrows",
+      source: `const empty = async () => {};`,
+      allow:  []string{"arrowFunctions"},
+    },
+    {
+      name:   "async generator method uses generator category",
+      source: `class Example { async *method() {} }`,
+      allow:  []string{"generatorMethods"},
+    },
+    {
+      name:   "async method category excludes async generators",
+      source: `class Example { async *method() {} }`,
+      allow:  []string{"asyncMethods"},
+      want:   1,
+    },
+    {
+      name:   "exterior comments do not preserve function",
+      source: `/* before */ function empty() {} /* after */`,
+      want:   1,
+    },
+    {
+      name:   "object property function remains a function",
+      source: `const object = { value: function () {} };`,
+      allow:  []string{"functions"},
+    },
+  }
+
+  for _, test := range tests {
+    t.Run(test.name, func(t *testing.T) {
+      var options json.RawMessage
+      if len(test.allow) != 0 {
+        encoded, err := json.Marshal(noEmptyFunctionOptions{Allow: test.allow})
+        if err != nil {
+          t.Fatal(err)
+        }
+        options = encoded
+      }
+      _, _, findings := runRuleFindingsSnapshot(t, "no-empty-function", test.source, options)
+      if len(findings) != test.want {
+        t.Fatalf("finding count = %d, want %d; findings=%+v", len(findings), test.want, findings)
+      }
+    })
+  }
+}

--- a/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
+++ b/packages/lint/test/rules/functions-classes/no_empty_function_options_test.go
@@ -149,6 +149,36 @@ class Example extends Base {
       source: `const object = { value: function () {} };`,
       allow:  []string{"functions"},
     },
+    {
+      name:   "function expression reports by default",
+      source: `const empty = function () {};`,
+      want:   1,
+    },
+    {
+      name:   "functions includes function expressions",
+      source: `const empty = function () {};`,
+      allow:  []string{"functions"},
+    },
+    {
+      name:   "generator expression reports by default",
+      source: `const empty = function* () {};`,
+      want:   1,
+    },
+    {
+      name:   "generator functions includes expressions",
+      source: `const empty = function* () {};`,
+      allow:  []string{"generatorFunctions"},
+    },
+    {
+      name:   "object method reports by default",
+      source: `const object = { method() {} };`,
+      want:   1,
+    },
+    {
+      name:   "methods includes object methods",
+      source: `const object = { method() {} };`,
+      allow:  []string{"methods"},
+    },
   }
 
   for _, test := range tests {

--- a/packages/lint/test/rules/style-suggestions/no_empty_complete_semantics_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_empty_complete_semantics_test.go
@@ -25,8 +25,13 @@ func TestNoEmptyCompleteSemantics(t *testing.T) {
     {name: "try catch finally blocks", source: `try {} catch {} finally {}`, want: 3},
     {name: "catch is rejected by default", source: `try { work(); } catch {}`, want: 1},
     {
-      name:    "allowEmptyCatch accepts only catch",
-      source:  `try {} catch {}`,
+      name:    "allowEmptyCatch accepts catch",
+      source:  `try { work(); } catch {}`,
+      options: json.RawMessage(`{"allowEmptyCatch":true}`),
+    },
+    {
+      name:    "allowEmptyCatch does not accept other blocks",
+      source:  `declare const value: boolean; if (value) {}`,
       options: json.RawMessage(`{"allowEmptyCatch":true}`),
       want:    1,
     },

--- a/packages/lint/test/rules/style-suggestions/no_empty_complete_semantics_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_empty_complete_semantics_test.go
@@ -53,8 +53,18 @@ try { /* intentional */ } catch { /* intentional */ } finally { /* intentional *
       want:   1,
     },
     {
+      name:   "comment before block opening brace stays exterior",
+      source: `declare const value: boolean; if (value) /* before brace */ {}`,
+      want:   1,
+    },
+    {
       name:   "comments outside switch braces do not preserve switch",
       source: `declare const value: boolean; /* before */ switch (value) {} /* after */`,
+      want:   1,
+    },
+    {
+      name:   "comment before switch opening brace stays exterior",
+      source: `declare const value: boolean; switch (value) /* before brace */ {}`,
       want:   1,
     },
     {name: "function body belongs to sibling rule", source: `function empty() {}`},
@@ -85,6 +95,7 @@ func TestNoEmptyStaticBlockCommentBoundaries(t *testing.T) {
     {name: "interior block comment", source: `class Example { static { /* intentional */ } }`},
     {name: "interior line comment", source: "class Example { static { // intentional\n} }"},
     {name: "leading exterior comment", source: `class Example { /* before */ static {} }`, want: 1},
+    {name: "comment before opening brace", source: `class Example { static /* before brace */ {} }`, want: 1},
     {name: "trailing exterior comment", source: `class Example { static {} /* after */ }`, want: 1},
     {name: "nonempty", source: `class Example { static { initialize(); } }`},
   }

--- a/packages/lint/test/rules/style-suggestions/no_empty_complete_semantics_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_empty_complete_semantics_test.go
@@ -1,0 +1,91 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+)
+
+// TestNoEmptyCompleteSemantics protects every empty control-flow body, switch
+// handling, the catch option, and exact interior-comment boundaries.
+func TestNoEmptyCompleteSemantics(t *testing.T) {
+  tests := []struct {
+    name    string
+    source  string
+    options json.RawMessage
+    want    int
+  }{
+    {name: "if block", source: `declare const value: boolean; if (value) {}`, want: 1},
+    {name: "while block", source: `declare const value: boolean; while (value) {}`, want: 1},
+    {name: "do block", source: `declare const value: boolean; do {} while (value);`, want: 1},
+    {name: "for block", source: `declare const value: boolean; for (; value;) {}`, want: 1},
+    {name: "standalone block", source: `{}`, want: 1},
+    {name: "empty switch", source: `declare const value: boolean; switch (value) {}`, want: 1},
+    {name: "try catch finally blocks", source: `try {} catch {} finally {}`, want: 3},
+    {name: "catch is rejected by default", source: `try { work(); } catch {}`, want: 1},
+    {
+      name:    "allowEmptyCatch accepts only catch",
+      source:  `try {} catch {}`,
+      options: json.RawMessage(`{"allowEmptyCatch":true}`),
+      want:    1,
+    },
+    {
+      name: "interior comments preserve all control blocks",
+      source: `declare const value: boolean;
+if (value) { /* intentional */ }
+while (value) { /* intentional */ }
+do { /* intentional */ } while (value);
+for (; value;) { /* intentional */ }
+switch (value) { /* intentional */ }
+try { /* intentional */ } catch { /* intentional */ } finally { /* intentional */ }`,
+    },
+    {
+      name:   "comments outside braces do not preserve block",
+      source: `declare const value: boolean; /* before */ if (value) {} /* after */`,
+      want:   1,
+    },
+    {
+      name:   "comments outside switch braces do not preserve switch",
+      source: `declare const value: boolean; /* before */ switch (value) {} /* after */`,
+      want:   1,
+    },
+    {name: "function body belongs to sibling rule", source: `function empty() {}`},
+    {name: "static body belongs to sibling rule", source: `class Example { static {} }`},
+    {name: "nonempty block", source: `declare const value: boolean; if (value) { work(); }`},
+    {name: "nonempty switch", source: `declare const value: boolean; switch (value) { default: break; }`},
+  }
+
+  for _, test := range tests {
+    t.Run(test.name, func(t *testing.T) {
+      _, _, findings := runRuleFindingsSnapshot(t, "no-empty", test.source, test.options)
+      if len(findings) != test.want {
+        t.Fatalf("finding count = %d, want %d; findings=%+v", len(findings), test.want, findings)
+      }
+    })
+  }
+}
+
+// TestNoEmptyStaticBlockCommentBoundaries ensures only comments between the
+// static block's own braces make the empty block intentional.
+func TestNoEmptyStaticBlockCommentBoundaries(t *testing.T) {
+  tests := []struct {
+    name   string
+    source string
+    want   int
+  }{
+    {name: "empty", source: `class Example { static {} }`, want: 1},
+    {name: "interior block comment", source: `class Example { static { /* intentional */ } }`},
+    {name: "interior line comment", source: "class Example { static { // intentional\n} }"},
+    {name: "leading exterior comment", source: `class Example { /* before */ static {} }`, want: 1},
+    {name: "trailing exterior comment", source: `class Example { static {} /* after */ }`, want: 1},
+    {name: "nonempty", source: `class Example { static { initialize(); } }`},
+  }
+
+  for _, test := range tests {
+    t.Run(test.name, func(t *testing.T) {
+      _, _, findings := runRuleFindingsSnapshot(t, "no-empty-static-block", test.source, nil)
+      if len(findings) != test.want {
+        t.Fatalf("finding count = %d, want %d; findings=%+v", len(findings), test.want, findings)
+      }
+    })
+  }
+}

--- a/packages/lint/test/rules/style-suggestions/no_empty_complete_semantics_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_empty_complete_semantics_test.go
@@ -18,6 +18,8 @@ func TestNoEmptyCompleteSemantics(t *testing.T) {
     {name: "while block", source: `declare const value: boolean; while (value) {}`, want: 1},
     {name: "do block", source: `declare const value: boolean; do {} while (value);`, want: 1},
     {name: "for block", source: `declare const value: boolean; for (; value;) {}`, want: 1},
+    {name: "for in block", source: `declare const object: object; for (const key in object) {}`, want: 1},
+    {name: "for of block", source: `declare const values: unknown[]; for (const value of values) {}`, want: 1},
     {name: "standalone block", source: `{}`, want: 1},
     {name: "empty switch", source: `declare const value: boolean; switch (value) {}`, want: 1},
     {name: "try catch finally blocks", source: `try {} catch {} finally {}`, want: 3},
@@ -35,6 +37,8 @@ if (value) { /* intentional */ }
 while (value) { /* intentional */ }
 do { /* intentional */ } while (value);
 for (; value;) { /* intentional */ }
+for (const key in { value }) { /* intentional */ }
+for (const item of [value]) { /* intentional */ }
 switch (value) { /* intentional */ }
 try { /* intentional */ } catch { /* intentional */ } finally { /* intentional */ }`,
     },

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -1156,6 +1156,13 @@ Reject empty blocks and switches that have no interior comment. Empty catch
 clauses are reported by default; set `allowEmptyCatch` to `true` when silently
 ignoring caught errors is an established project convention.
 
+Options:
+
+- `allowEmptyCatch?: boolean`
+
+  Accept uncommented empty catch clauses while continuing to report every
+  other uncommented empty block. Default: `false`.
+
 Example:
 
 ```ts
@@ -1200,6 +1207,16 @@ Reject empty function bodies that have no interior comment. The `allow` option
 accepts the same function, arrow, generator, method, accessor, constructor,
 async, decorator, and override categories as ESLint. TypeScript parameter-property
 constructors are always accepted because their parameters initialize fields.
+
+Options:
+
+- `allow?: TtscLintCoreNoEmptyFunctionAllow[]`
+
+  Accept the selected categories: `functions`, `arrowFunctions`,
+  `generatorFunctions`, `methods`, `generatorMethods`, `getters`, `setters`,
+  `constructors`, `asyncFunctions`, `asyncMethods`, `privateConstructors`,
+  `protectedConstructors`, `decoratedFunctions`, and `overrideMethods`.
+  Default: `[]`.
 
 Example:
 

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -44,12 +44,12 @@ Examples come from the checked [lint corpus](https://github.com/samchon/ttsc/tre
 - [`no-duplicate-case`](#rule-no-duplicate-case): Reject the same `case` label appearing twice in a `switch`, later duplicates are unreachable.
 - [`no-duplicate-imports`](#rule-no-duplicate-imports): Reject a repeated module specifier when the import declarations could be merged into one legal declaration.
 - [`no-else-return`](#rule-no-else-return): Reject an `else` block whose preceding `if` branch already terminates control flow with `return`, `throw`, `break`.
-- [`no-empty`](#rule-no-empty): Reject empty blocks that almost always indicate forgotten code.
+- [`no-empty`](#rule-no-empty): Reject uncommented empty blocks and switches.
 - [`no-empty-character-class`](#rule-no-empty-character-class): Reject empty regex character classes.
-- [`no-empty-function`](#rule-no-empty-function): Reject empty function and method bodies.
+- [`no-empty-function`](#rule-no-empty-function): Reject uncommented empty function and method bodies unless their category is allowed.
 - [`no-empty-named-blocks`](#rule-no-empty-named-blocks): Reject empty named import or export clauses, `import {} from "x"`, `import name, {} from "x"`, and `export {}`.
 - [`no-empty-pattern`](#rule-no-empty-pattern): Reject empty destructuring patterns.
-- [`no-empty-static-block`](#rule-no-empty-static-block): Reject empty `static {}` class initialization blocks.
+- [`no-empty-static-block`](#rule-no-empty-static-block): Reject uncommented empty `static {}` class initialization blocks.
 - [`no-eq-null`](#rule-no-eq-null): Reject loose null comparisons.
 - [`no-eval`](#rule-no-eval): Reject `eval(...)` and indirect `eval` calls, almost always a security or correctness bug.
 - [`no-ex-assign`](#rule-no-ex-assign): Reject reassigning the parameter of a `catch` clause.
@@ -1152,7 +1152,9 @@ function describe(kind: string): string {
 
 ### `no-empty`
 
-Reject empty blocks (`if (x) {}`, `while (x) {}`, `try {} catch (e) {}` etc.) that almost always indicate forgotten code.
+Reject empty blocks and switches that have no interior comment. Empty catch
+clauses are reported by default; set `allowEmptyCatch` to `true` when silently
+ignoring caught errors is an established project convention.
 
 Example:
 
@@ -1162,6 +1164,16 @@ function f(x: number) {
   if (x === 0) {
   }
 }
+```
+
+```ts filename="ttsc.lint.config.ts"
+import type { ITtscLintConfig } from "@ttsc/lint";
+
+export default {
+  rules: {
+    "no-empty": ["error", { allowEmptyCatch: true }],
+  },
+} satisfies ITtscLintConfig;
 ```
 
 <a id="rule-no-empty-character-class"></a>
@@ -1184,9 +1196,10 @@ const r = /[]/;
 
 ### `no-empty-function`
 
-Reject empty function and method bodies (`function f() {}`, `() => {}`).
-
-Use `() => undefined` or a leading TODO comment when the empty body is intentional.
+Reject empty function bodies that have no interior comment. The `allow` option
+accepts the same function, arrow, generator, method, accessor, constructor,
+async, decorator, and override categories as ESLint. TypeScript parameter-property
+constructors are always accepted because their parameters initialize fields.
 
 Example:
 
@@ -1194,6 +1207,19 @@ Example:
 // reports: no-empty-function (error)
 function f(): void {}
 f();
+```
+
+```ts filename="ttsc.lint.config.ts"
+import type { ITtscLintConfig } from "@ttsc/lint";
+
+export default {
+  rules: {
+    "no-empty-function": [
+      "error",
+      { allow: ["constructors", "overrideMethods"] },
+    ],
+  },
+} satisfies ITtscLintConfig;
 ```
 
 <a id="rule-no-empty-named-blocks"></a>
@@ -1233,7 +1259,8 @@ f({ a: 1 });
 
 ### `no-empty-static-block`
 
-Reject empty `static {}` class initialization blocks.
+Reject empty `static {}` class initialization blocks unless an interior comment
+documents why the block is intentionally empty.
 
 Example:
 


### PR DESCRIPTION
## Summary
- preserve empty blocks, functions, switches, and static blocks only when their own brace range contains a comment
- make empty catches report by default and expose allowEmptyCatch
- implement and type every canonical no-empty-function allow category, including TypeScript constructor, decorator, and override cases
- add positive and negative shields for every control-flow and function shape

## Validation
- implementation, public types, documentation, and shield matrices are committed
- focused local validation intentionally follows three clean exhaustive whole-PR review rounds
- formatter was not run

Closes #509