### PR TITLE
fix(lint): preserve meaningful bind applications

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -254,7 +254,7 @@ Source: [ESLint core rules](https://eslint.org/docs/latest/rules/).
 - [`no-eval`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-eval.ts): rejects `eval`.
 - [`no-ex-assign`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-ex-assign.ts): rejects reassignment of caught exceptions.
 - [`no-extend-native`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-extend-native.ts): reject assignments to a built-in prototype such as `Array.prototype.foo = bar`.
-- [`no-extra-bind`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-extra-bind.ts): rejects unnecessary `.bind()` calls.
+- [`no-extra-bind`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-extra-bind.ts): rejects `.bind(thisArg)` on arrows and regular functions that never read their own `this`, while preserving partial application.
 - [`no-extra-boolean-cast`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-extra-boolean-cast.ts): rejects redundant boolean casts.
 - [`no-fallthrough`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-fallthrough.ts): rejects `switch` cases whose end is reachable and that lack an intentional `// falls through` comment before the next label.
 - [`no-func-assign`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-func-assign.ts): rejects reassignment of function declarations.

--- a/packages/lint/linthost/rules_suggestions.go
+++ b/packages/lint/linthost/rules_suggestions.go
@@ -166,68 +166,138 @@ func isNullLiteral(node *shimast.Node) bool {
   return node != nil && node.Kind == shimast.KindNullKeyword
 }
 
-// noExtraBind: `(function () {}).bind(this)` where `this` isn't used
-// — only flag the case where the bind target is empty/parameterless,
-// keeping false-positives down.
+// noExtraBind reports `.bind(thisArg)` on arrow functions and regular
+// functions whose own lexical/function scope never reads `this`. Calls that
+// also bind ordinary arguments are partial applications and remain untouched.
+// https://eslint.org/docs/latest/rules/no-extra-bind
 type noExtraBind struct{}
 
 func (noExtraBind) Name() string           { return "no-extra-bind" }
 func (noExtraBind) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindCallExpression} }
 func (noExtraBind) Check(ctx *Context, node *shimast.Node) {
   call := node.AsCallExpression()
-  if call == nil || call.Expression == nil {
+  target, member, receiver, ok := noExtraBindCallParts(call)
+  if !ok {
     return
   }
-  if call.Expression.Kind != shimast.KindPropertyAccessExpression {
+  if target.Kind == shimast.KindFunctionExpression && functionScopeReferencesThis(target) {
     return
   }
-  access := call.Expression.AsPropertyAccessExpression()
-  if access == nil || identifierText(access.Name()) != "bind" {
-    return
-  }
-  target := stripParens(access.Expression)
-  if target == nil {
-    return
-  }
-  if target.Kind != shimast.KindArrowFunction && target.Kind != shimast.KindFunctionExpression {
-    return
-  }
-  // Arrow functions don't have their own `this`; `.bind` is always
-  // useless on them.
-  if target.Kind == shimast.KindArrowFunction {
+
+  edits := noExtraBindFixEdits(ctx, node, call, member, receiver)
+  if len(edits) == 0 {
     ctx.Report(node, "The function binding is unnecessary.")
-    return
-  }
-  body := target.Body()
-  if body != nil && !bodyReferencesThis(body) {
-    ctx.Report(node, "The function binding is unnecessary.")
+  } else {
+    ctx.ReportFix(node, "The function binding is unnecessary.", edits...)
   }
 }
 
-func bodyReferencesThis(node *shimast.Node) bool {
+// noExtraBindCallParts recognizes the complete syntactic bind call. Static
+// computed keys and optional member/call chains are accepted, but a dynamic
+// computed property is not assumed to be Function.prototype.bind. Exactly one
+// non-spread argument is required: zero arguments are not the canonical bind
+// shape, while later arguments perform meaningful partial application.
+func noExtraBindCallParts(call *shimast.CallExpression) (
+  target *shimast.Node,
+  member *shimast.Node,
+  receiver *shimast.Node,
+  ok bool,
+) {
+  if call == nil || call.Expression == nil || call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
+    return nil, nil, nil, false
+  }
+  receiver = call.Arguments.Nodes[0]
+  if receiver == nil || receiver.Kind == shimast.KindSpreadElement {
+    return nil, nil, nil, false
+  }
+
+  member = stripParens(call.Expression)
+  parts, matched := referenceMemberParts(member)
+  if !matched || parts.private || parts.staticKey == nil || *parts.staticKey != "bind" {
+    return nil, nil, nil, false
+  }
+  target = stripParens(parts.object)
+  if target == nil || (target.Kind != shimast.KindArrowFunction && target.Kind != shimast.KindFunctionExpression) {
+    return nil, nil, nil, false
+  }
+  return target, member, receiver, true
+}
+
+// functionScopeReferencesThis searches the bound regular function itself.
+// Nested arrows inherit that function's `this` and remain in the walk; nested
+// regular functions, methods, accessors, and constructors bind their own
+// `this`, so their subtrees are pruned.
+func functionScopeReferencesThis(root *shimast.Node) bool {
+  if root == nil {
+    return false
+  }
+  var visit func(*shimast.Node) bool
+  visit = func(node *shimast.Node) bool {
+    if node == nil {
+      return false
+    }
+    if node.Kind == shimast.KindThisKeyword {
+      return true
+    }
+    if node != root && isFunctionLikeKind(node) && node.Kind != shimast.KindArrowFunction {
+      return false
+    }
+    found := false
+    node.ForEachChild(func(child *shimast.Node) bool {
+      found = visit(child)
+      return found
+    })
+    return found
+  }
+  return visit(root)
+}
+
+// noExtraBindFixEdits removes the member access and its one-argument call as
+// separate ranges. Parentheses and comments before the member operator remain
+// byte-for-byte intact. The fix is withheld when evaluating the receiver may
+// have effects or when any comment lies inside discarded syntax.
+func noExtraBindFixEdits(
+  ctx *Context,
+  callNode *shimast.Node,
+  call *shimast.CallExpression,
+  member *shimast.Node,
+  receiver *shimast.Node,
+) []TextEdit {
+  if ctx == nil || ctx.File == nil || callNode == nil || call == nil || call.Expression == nil || member == nil ||
+    !noExtraBindReceiverIsSideEffectFree(receiver) {
+    return nil
+  }
+  parts, ok := referenceMemberParts(member)
+  if !ok || parts.object == nil {
+    return nil
+  }
+
+  src := ctx.File.Text()
+  memberStart := shimscanner.SkipTrivia(src, parts.object.End())
+  memberEnd := member.End()
+  callStart := shimscanner.SkipTrivia(src, call.Expression.End())
+  callEnd := callNode.End()
+  if memberStart < 0 || memberStart >= memberEnd || memberEnd > callStart || callStart >= callEnd || callEnd > len(src) {
+    return nil
+  }
+  if hasCommentBetween(src, memberStart, callEnd) {
+    return nil
+  }
+  return []TextEdit{
+    {Pos: memberStart, End: memberEnd, Text: ""},
+    {Pos: callStart, End: callEnd, Text: ""},
+  }
+}
+
+func noExtraBindReceiverIsSideEffectFree(node *shimast.Node) bool {
+  node = stripParens(node)
   if node == nil {
     return false
   }
-  if node.Kind == shimast.KindThisKeyword {
-    return true
-  }
-  // Don't descend into nested function-likes — their `this` is
-  // independent.
-  if isFunctionLikeKind(node) && node.Parent != nil {
-    return false
-  }
-  found := false
-  node.ForEachChild(func(child *shimast.Node) bool {
-    if found {
-      return true
-    }
-    if bodyReferencesThis(child) {
-      found = true
-      return true
-    }
-    return false
-  })
-  return found
+  return isLiteralExpression(node) ||
+    node.Kind == shimast.KindIdentifier ||
+    node.Kind == shimast.KindThisKeyword ||
+    node.Kind == shimast.KindFunctionExpression
 }
 
 // noLabels: labels (`outer: for (...) { break outer; }`) are

--- a/packages/lint/linthost/rules_suggestions.go
+++ b/packages/lint/linthost/rules_suggestions.go
@@ -224,9 +224,10 @@ func noExtraBindCallParts(call *shimast.CallExpression) (
 }
 
 // functionScopeReferencesThis searches the bound regular function itself.
-// Nested arrows inherit that function's `this` and remain in the walk; nested
-// regular functions, methods, accessors, and constructors bind their own
-// `this`, so their subtrees are pruned.
+// Nested arrows inherit that function's `this`; nested regular functions and
+// class-owned initializers do not. Computed class/object keys and decorators
+// are evaluated outside their owning method or field, so their `this` still
+// belongs to the enclosing function.
 func functionScopeReferencesThis(root *shimast.Node) bool {
   if root == nil {
     return false
@@ -237,10 +238,7 @@ func functionScopeReferencesThis(root *shimast.Node) bool {
       return false
     }
     if node.Kind == shimast.KindThisKeyword {
-      return true
-    }
-    if node != root && isFunctionLikeKind(node) && node.Kind != shimast.KindArrowFunction {
-      return false
+      return noExtraBindThisBelongsToFunction(node, root)
     }
     found := false
     node.ForEachChild(func(child *shimast.Node) bool {
@@ -250,6 +248,44 @@ func functionScopeReferencesThis(root *shimast.Node) bool {
     return found
   }
   return visit(root)
+}
+
+func noExtraBindThisBelongsToFunction(node, root *shimast.Node) bool {
+  outerEvaluation := false
+  for ancestor := node.Parent; ancestor != nil; ancestor = ancestor.Parent {
+    if ancestor == root {
+      return true
+    }
+    switch ancestor.Kind {
+    case shimast.KindComputedPropertyName, shimast.KindDecorator:
+      outerEvaluation = true
+    case shimast.KindClassStaticBlockDeclaration:
+      return false
+    case shimast.KindPropertyDeclaration:
+      if outerEvaluation {
+        outerEvaluation = false
+        continue
+      }
+      return false
+    case shimast.KindArrowFunction:
+      continue
+    }
+    if !isFunctionLikeKind(ancestor) {
+      continue
+    }
+    switch ancestor.Kind {
+    case shimast.KindMethodDeclaration,
+      shimast.KindGetAccessor,
+      shimast.KindSetAccessor,
+      shimast.KindConstructor:
+      if outerEvaluation {
+        outerEvaluation = false
+        continue
+      }
+    }
+    return false
+  }
+  return false
 }
 
 // noExtraBindFixEdits removes the member access and its one-argument call as

--- a/packages/lint/linthost/rules_suggestions.go
+++ b/packages/lint/linthost/rules_suggestions.go
@@ -259,6 +259,11 @@ func noExtraBindThisBelongsToFunction(node, root *shimast.Node) bool {
     switch ancestor.Kind {
     case shimast.KindComputedPropertyName, shimast.KindDecorator:
       outerEvaluation = true
+    case shimast.KindClassDeclaration, shimast.KindClassExpression:
+      // A class decorator runs outside that class, but still inside any
+      // enclosing method/function. Do not carry its marker across the class
+      // and accidentally skip an unrelated outer method boundary.
+      outerEvaluation = false
     case shimast.KindClassStaticBlockDeclaration:
       return false
     case shimast.KindPropertyDeclaration:

--- a/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
@@ -573,8 +573,9 @@ export interface ITtscLintCoreRules {
   "no-extend-native"?: TtscLintRuleSetting;
 
   /**
-   * Reject unnecessary `Function.prototype.bind()` calls — for example, binding
-   * without arguments or binding an arrow function (which ignores `this`).
+   * Reject `.bind(thisArg)` on an arrow function or on a regular function whose
+   * own scope never reads `this`. Calls that bind later arguments are preserved
+   * as partial applications.
    *
    * @reference https://eslint.org/docs/latest/rules/no-extra-bind
    */

--- a/packages/lint/test/fix/fix_no_extra_bind_removes_safe_member_and_call_syntax_test.go
+++ b/packages/lint/test/fix/fix_no_extra_bind_removes_safe_member_and_call_syntax_test.go
@@ -1,0 +1,38 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBindRemovesSafeMemberAndCallSyntax verifies the autofix
+// preserves grouping and comments outside the discarded bind syntax.
+//
+// Removing the whole call node would also erase comments between the function
+// and member operator. Two precise edits retain those bytes while supporting
+// computed properties and optional member/call forms.
+//
+// 1. Bind side-effect-free receiver expressions through every supported syntax.
+// 2. Keep comments immediately before the member and after the call.
+// 3. Assert only the bind member and its call arguments disappear.
+func TestFixNoExtraBindRemovesSafeMemberAndCallSyntax(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "no-extra-bind",
+    `declare const receiver: unknown;
+const direct = (function () { return 1; }).bind(receiver);
+const computed = (function () { return 2; })["bind"](null);
+const template = (function () { return 3; })[`+"`bind`"+`](true);
+const optionalMember = (function () { return 4; })?.["bind"](this);
+const optionalCall = (function () { return 5; }.bind)?.(receiver);
+const leadingComment = (function () { return 6; })/* keep */.bind(receiver);
+const trailingComment = (function () { return 7; }).bind(receiver)/* keep */;
+`,
+    `declare const receiver: unknown;
+const direct = (function () { return 1; });
+const computed = (function () { return 2; });
+const template = (function () { return 3; });
+const optionalMember = (function () { return 4; });
+const optionalCall = (function () { return 5; });
+const leadingComment = (function () { return 6; })/* keep */;
+const trailingComment = (function () { return 7; })/* keep */;
+`,
+  )
+}

--- a/packages/lint/test/fix/fix_no_extra_bind_removes_safe_member_and_call_syntax_test.go
+++ b/packages/lint/test/fix/fix_no_extra_bind_removes_safe_member_and_call_syntax_test.go
@@ -9,7 +9,7 @@ import "testing"
 // and member operator. Two precise edits retain those bytes while supporting
 // computed properties and optional member/call forms.
 //
-// 1. Bind side-effect-free receiver expressions through every supported syntax.
+// 1. Bind literal, identifier, `this`, and function-expression receivers.
 // 2. Keep comments immediately before the member and after the call.
 // 3. Assert only the bind member and its call arguments disappear.
 func TestFixNoExtraBindRemovesSafeMemberAndCallSyntax(t *testing.T) {
@@ -24,6 +24,7 @@ const optionalMember = (function () { return 4; })?.["bind"](this);
 const optionalCall = (function () { return 5; }.bind)?.(receiver);
 const leadingComment = (function () { return 6; })/* keep */.bind(receiver);
 const trailingComment = (function () { return 7; }).bind(receiver)/* keep */;
+const functionReceiver = (function () { return 8; }).bind(function receiverFunction() {});
 `,
     `declare const receiver: unknown;
 const direct = (function () { return 1; });
@@ -33,6 +34,7 @@ const optionalMember = (function () { return 4; });
 const optionalCall = (function () { return 5; });
 const leadingComment = (function () { return 6; })/* keep */;
 const trailingComment = (function () { return 7; })/* keep */;
+const functionReceiver = (function () { return 8; });
 `,
   )
 }

--- a/packages/lint/test/fix/fix_no_extra_bind_skips_effectful_or_commented_removals_test.go
+++ b/packages/lint/test/fix/fix_no_extra_bind_skips_effectful_or_commented_removals_test.go
@@ -1,0 +1,30 @@
+package linthost
+
+import "testing"
+
+// TestFixNoExtraBindSkipsEffectfulOrCommentedRemovals verifies diagnostics do
+// not become behavior-changing or comment-dropping automatic edits.
+//
+// Evaluating the bound receiver can call code, access a getter, or mutate
+// state. Comments inside the member/call syntax also carry source information
+// that a deletion cannot safely relocate.
+//
+// 1. Bind call, member-access, and update expressions as receivers.
+// 2. Place comments inside dot, computed-key, and argument syntax.
+// 3. Assert all calls report without changing any source byte.
+func TestFixNoExtraBindSkipsEffectfulOrCommentedRemovals(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-extra-bind",
+    `declare function makeReceiver(): unknown;
+declare const receiver: { value: unknown };
+let index = 0;
+const called = (function () { return 1; }).bind(makeReceiver());
+const accessed = (function () { return 2; }).bind(receiver.value);
+const updated = (function () { return 3; }).bind(index++);
+const dotComment = (function () { return 4; })./**/bind(receiver);
+const keyComment = (function () { return 5; })["bind"/**/](receiver);
+const argumentComment = (function () { return 6; }).bind(/**/receiver);
+`,
+  )
+}

--- a/packages/lint/test/rules/functions-classes/no_extra_bind_function_body_test.go
+++ b/packages/lint/test/rules/functions-classes/no_extra_bind_function_body_test.go
@@ -1,23 +1,51 @@
 package linthost
 
-import "testing"
+import (
+  "slices"
+  "sort"
+  "strings"
+  "testing"
+)
 
-// TestRuleNoExtraBindFunctionBody verifies noExtraBind inspects function bodies.
+// TestRuleNoExtraBindFunctionBody verifies argument shape and `this` scope
+// boundaries are both required before reporting a bind call.
 //
-// The generated corpus covers the arrow-function branch of no-extra-bind. This
-// handwritten rule test covers the regular function path where the rule must
-// scan the body and prove it does not reference this.
+// A nested arrow inherits the enclosing regular function's receiver, while a
+// nested regular function owns a different receiver. Bind arguments after the
+// receiver and spread calls are partial-application shapes, even for arrows.
 //
-// This scenario exists specifically for Go unit coverage of bodyReferencesThis,
-// which is not visible through the simpler corpus fixture.
-//
-// 1. Build a TypeScript fixture with a bound regular function.
-// 2. Enable noExtraBind through the same corpus helper.
-// 3. Assert the native Engine reports the annotated diagnostic.
+// 1. Exercise direct, zero-argument, partial, spread, and dynamic-member calls.
+// 2. Place `this` in a parameter default, nested arrow, and nested regular function.
+// 3. Assert only the truly unnecessary regular-function binds are reported.
 func TestRuleNoExtraBindFunctionBody(t *testing.T) {
-  assertRuleCorpusCase(t, "no-extra-bind-function-body.ts", `const obj = {};
-// expect: no-extra-bind error
-const f = function () { return 1; }.bind(obj);
-JSON.stringify(f);
-`)
+  source := `declare const receiver: { value: number };
+declare const bindArguments: [unknown];
+declare const dynamicKey: string;
+
+const direct = function () { return 1; }.bind(receiver); // diagnostic
+const noReceiver = function () { return 2; }.bind();
+const partial = function (value: number) { return value; }.bind(null, 1);
+const arrowPartial = ((value: number) => value).bind(null, 1);
+const spread = function () { return 3; }.bind(...bindArguments);
+const dynamic = function () { return 4; }[dynamicKey](receiver);
+const parameterDefault = function (this: { value: number }, value = this.value) { return value; }.bind(receiver);
+const nestedArrow = function (this: { value: number }) { return () => this.value; }.bind(receiver);
+const nestedRegular = function () { return function (this: { value: number }) { return this.value; }; }.bind(receiver); // diagnostic
+`
+  expectedLines := make([]int, 0)
+  for index, line := range strings.Split(source, "\n") {
+    if strings.Contains(line, "// diagnostic") {
+      expectedLines = append(expectedLines, index+1)
+    }
+  }
+
+  _, _, findings := runRuleFindingsSnapshot(t, "no-extra-bind", source, nil)
+  actualLines := make([]int, 0, len(findings))
+  for _, finding := range findings {
+    actualLines = append(actualLines, strings.Count(source[:finding.Pos], "\n")+1)
+  }
+  sort.Ints(actualLines)
+  if !slices.Equal(actualLines, expectedLines) {
+    t.Fatalf("diagnostic lines mismatch: want %v, got %v", expectedLines, actualLines)
+  }
 }

--- a/packages/lint/test/rules/functions-classes/no_extra_bind_function_body_test.go
+++ b/packages/lint/test/rules/functions-classes/no_extra_bind_function_body_test.go
@@ -10,12 +10,13 @@ import (
 // TestRuleNoExtraBindFunctionBody verifies argument shape and `this` scope
 // boundaries are both required before reporting a bind call.
 //
-// A nested arrow inherits the enclosing regular function's receiver, while a
-// nested regular function owns a different receiver. Bind arguments after the
+// A nested arrow and computed member key inherit the enclosing regular
+// function's receiver, while nested regular functions, method bodies, class
+// fields, and static blocks own a different receiver. Bind arguments after the
 // receiver and spread calls are partial-application shapes, even for arrows.
 //
 // 1. Exercise direct, zero-argument, partial, spread, and dynamic-member calls.
-// 2. Place `this` in a parameter default, nested arrow, and nested regular function.
+// 2. Place `this` across function, method, computed-key, and class-owned scopes.
 // 3. Assert only the truly unnecessary regular-function binds are reported.
 func TestRuleNoExtraBindFunctionBody(t *testing.T) {
   source := `declare const receiver: { value: number };
@@ -31,6 +32,12 @@ const dynamic = function () { return 4; }[dynamicKey](receiver);
 const parameterDefault = function (this: { value: number }, value = this.value) { return value; }.bind(receiver);
 const nestedArrow = function (this: { value: number }) { return () => this.value; }.bind(receiver);
 const nestedRegular = function () { return function (this: { value: number }) { return this.value; }; }.bind(receiver); // diagnostic
+const computedMethodKey = function (this: { value: number }) { return { [this.value]() {} }; }.bind(receiver);
+const nestedMethodBody = function () { return { method() { return this; } }; }.bind(receiver); // diagnostic
+const classComputedKey = function (this: { value: number }) { return class { [this.value]() {} }; }.bind(receiver);
+const methodDecorator = function (this: { value: number }) { return class { @this.value method() {} }; }.bind(receiver);
+const classFieldInitializer = function () { return class { value = this; }; }.bind(receiver); // diagnostic
+const classStaticBlock = function () { return class { static { void this; } }; }.bind(receiver); // diagnostic
 `
   expectedLines := make([]int, 0)
   for index, line := range strings.Split(source, "\n") {

--- a/packages/lint/test/rules/functions-classes/no_extra_bind_function_body_test.go
+++ b/packages/lint/test/rules/functions-classes/no_extra_bind_function_body_test.go
@@ -16,20 +16,24 @@ import (
 // after the receiver and spread calls are partial-application shapes, even for
 // arrows.
 //
-// 1. Exercise direct, zero-argument, partial, spread, and dynamic-member calls.
+// 1. Exercise direct, zero, partial, spread, dynamic, and non-bind call shapes.
 // 2. Place `this` across function, method, computed-key, and class-owned scopes.
 // 3. Assert only the truly unnecessary regular-function binds are reported.
 func TestRuleNoExtraBindFunctionBody(t *testing.T) {
   source := `declare const receiver: { value: number };
 declare const bindArguments: [unknown];
 declare const dynamicKey: string;
+declare function namedTarget(): number;
 
 const direct = function () { return 1; }.bind(receiver); // diagnostic
+const arrowThis = (() => this).bind(receiver); // diagnostic
 const noReceiver = function () { return 2; }.bind();
 const partial = function (value: number) { return value; }.bind(null, 1);
 const arrowPartial = ((value: number) => value).bind(null, 1);
 const spread = function () { return 3; }.bind(...bindArguments);
 const dynamic = function () { return 4; }[dynamicKey](receiver);
+const otherMember = function () { return 5; }.call(receiver);
+const namedFunction = namedTarget.bind(receiver);
 const parameterDefault = function (this: { value: number }, value = this.value) { return value; }.bind(receiver);
 const nestedArrow = function (this: { value: number }) { return () => this.value; }.bind(receiver);
 const nestedRegular = function () { return function (this: { value: number }) { return this.value; }; }.bind(receiver); // diagnostic

--- a/packages/lint/test/rules/functions-classes/no_extra_bind_function_body_test.go
+++ b/packages/lint/test/rules/functions-classes/no_extra_bind_function_body_test.go
@@ -36,6 +36,7 @@ const computedMethodKey = function (this: { value: number }) { return { [this.va
 const nestedMethodBody = function () { return { method() { return this; } }; }.bind(receiver); // diagnostic
 const classComputedKey = function (this: { value: number }) { return class { [this.value]() {} }; }.bind(receiver);
 const methodDecorator = function (this: { value: number }) { return class { @this.value method() {} }; }.bind(receiver);
+const nestedClassDecorator = function () { return { method() { @this.value class Nested {} return Nested; } }; }.bind(receiver); // diagnostic
 const classFieldInitializer = function () { return class { value = this; }; }.bind(receiver); // diagnostic
 const classStaticBlock = function () { return class { static { void this; } }; }.bind(receiver); // diagnostic
 `

--- a/packages/lint/test/rules/functions-classes/no_extra_bind_function_body_test.go
+++ b/packages/lint/test/rules/functions-classes/no_extra_bind_function_body_test.go
@@ -10,10 +10,11 @@ import (
 // TestRuleNoExtraBindFunctionBody verifies argument shape and `this` scope
 // boundaries are both required before reporting a bind call.
 //
-// A nested arrow and computed member key inherit the enclosing regular
-// function's receiver, while nested regular functions, method bodies, class
-// fields, and static blocks own a different receiver. Bind arguments after the
-// receiver and spread calls are partial-application shapes, even for arrows.
+// Nested arrows, computed member keys, and decorators inherit the enclosing
+// regular function's receiver, while nested regular functions, method bodies,
+// class fields, and static blocks own a different receiver. Bind arguments
+// after the receiver and spread calls are partial-application shapes, even for
+// arrows.
 //
 // 1. Exercise direct, zero-argument, partial, spread, and dynamic-member calls.
 // 2. Place `this` across function, method, computed-key, and class-owned scopes.

--- a/packages/lint/test/rules/functions-classes/no_extra_bind_test.go
+++ b/packages/lint/test/rules/functions-classes/no_extra_bind_test.go
@@ -8,13 +8,95 @@ import "testing"
 // scenario keeps one annotated TypeScript fixture tied to the native Engine so individual rule
 // Check methods are measured by go test instead of only by the TypeScript feature runner.
 //
-// This case enables the rule annotations declared in no-extra-bind.ts and compares normalized
-// rule, severity, and line triples. The source text stays embedded in the generated Go file so
-// the test remains package-local and deterministic.
+// The fixture pins regular and arrow targets, computed and optional member
+// forms, partial application, spread arguments, and lexical `this` ownership.
 //
 // 1. Load the annotated TypeScript fixture source embedded below.
 // 2. Enable the rule severities declared by its // expect: comments.
 // 3. Assert the native Engine reports exactly the annotated diagnostics.
 func TestRuleCorpusNoExtraBind(t *testing.T) {
-  assertRuleCorpusCase(t, "no-extra-bind.ts", "// expect: no-extra-bind error\nconst f = (() => 1).bind({});\nJSON.stringify(f);\n")
+  assertRuleCorpusCase(t, "no-extra-bind.ts", `declare const receiver: { value: number };
+const bindArguments = [receiver] as const;
+
+// expect: no-extra-bind error
+const arrow = (() => 1).bind(receiver);
+
+// expect: no-extra-bind error
+const regular = (function () {
+  return 2;
+}).bind(receiver);
+
+// expect: no-extra-bind error
+const computed = (function () {
+  return 3;
+})["bind"](receiver);
+
+// expect: no-extra-bind error
+const template = (function () {
+  return 4;
+})[` + "`bind`" + `](receiver);
+
+// expect: no-extra-bind error
+const optionalMember = (function () {
+  return 5;
+})?.["bind"](receiver);
+
+// expect: no-extra-bind error
+const optionalCall = (function () {
+  return 6;
+}).bind?.(receiver);
+
+// expect: no-extra-bind error
+const parenthesizedMember = ((function () {
+  return 7;
+}).bind)(receiver);
+
+// expect: no-extra-bind error
+const nestedRegular = (function () {
+  return function (this: { value: number }) {
+    return this.value;
+  };
+}).bind(receiver);
+
+const partial = (function (value: number) {
+  return value;
+}).bind(null, 1);
+
+const arrowPartial = ((value: number) => value).bind(null, 1);
+const spread = (function () {
+  return 8;
+}).bind(...bindArguments);
+
+const ownThis = (function (this: { value: number }) {
+  return this.value;
+}).bind(receiver);
+
+const inheritedArrowThis = (function (this: { value: number }) {
+  return () => this.value;
+}).bind(receiver);
+
+const parameterDefaultThis = (function (
+  this: { value: number },
+  value = this.value,
+) {
+  return value;
+}).bind(receiver);
+
+JSON.stringify({
+  arrow,
+  regular,
+  computed,
+  template,
+  optionalMember,
+  optionalCall,
+  parenthesizedMember,
+  nestedRegular,
+  partial,
+  arrowPartial,
+  spread,
+  ownThis,
+  inheritedArrowThis,
+  parameterDefaultThis,
+});
+`)
 }

--- a/tests/test-lint/src/cases/no-extra-bind.ts
+++ b/tests/test-lint/src/cases/no-extra-bind.ts
@@ -1,3 +1,83 @@
+declare const receiver: { value: number };
+const bindArguments = [receiver] as const;
+
 // expect: no-extra-bind error
-const f = (() => 1).bind({});
-JSON.stringify(f);
+const arrow = (() => 1).bind(receiver);
+
+// expect: no-extra-bind error
+const regular = (function () {
+  return 2;
+}).bind(receiver);
+
+// expect: no-extra-bind error
+const computed = (function () {
+  return 3;
+})["bind"](receiver);
+
+// expect: no-extra-bind error
+const template = (function () {
+  return 4;
+})[`bind`](receiver);
+
+// expect: no-extra-bind error
+const optionalMember = (function () {
+  return 5;
+})?.["bind"](receiver);
+
+// expect: no-extra-bind error
+const optionalCall = (function () {
+  return 6;
+}).bind?.(receiver);
+
+// expect: no-extra-bind error
+const parenthesizedMember = ((function () {
+  return 7;
+}).bind)(receiver);
+
+// expect: no-extra-bind error
+const nestedRegular = (function () {
+  return function (this: { value: number }) {
+    return this.value;
+  };
+}).bind(receiver);
+
+const partial = (function (value: number) {
+  return value;
+}).bind(null, 1);
+
+const arrowPartial = ((value: number) => value).bind(null, 1);
+const spread = (function () {
+  return 8;
+}).bind(...bindArguments);
+
+const ownThis = (function (this: { value: number }) {
+  return this.value;
+}).bind(receiver);
+
+const inheritedArrowThis = (function (this: { value: number }) {
+  return () => this.value;
+}).bind(receiver);
+
+const parameterDefaultThis = (function (
+  this: { value: number },
+  value = this.value,
+) {
+  return value;
+}).bind(receiver);
+
+JSON.stringify({
+  arrow,
+  regular,
+  computed,
+  template,
+  optionalMember,
+  optionalCall,
+  parenthesizedMember,
+  nestedRegular,
+  partial,
+  arrowPartial,
+  spread,
+  ownThis,
+  inheritedArrowThis,
+  parameterDefaultThis,
+});

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -54,7 +54,7 @@ Examples come from the checked [lint corpus](https://github.com/samchon/ttsc/tre
 - [`no-eval`](#rule-no-eval): Reject `eval(...)` and indirect `eval` calls, almost always a security or correctness bug.
 - [`no-ex-assign`](#rule-no-ex-assign): Reject reassigning the parameter of a `catch` clause.
 - [`no-extend-native`](#rule-no-extend-native): Reject assignments to a built-in prototype such as `Array.prototype.foo = bar`.
-- [`no-extra-bind`](#rule-no-extra-bind): Reject unnecessary `Function.prototype.bind()` calls.
+- [`no-extra-bind`](#rule-no-extra-bind): Reject `.bind(thisArg)` when the function cannot use the bound receiver.
 - [`no-extra-boolean-cast`](#rule-no-extra-boolean-cast): Reject redundant boolean casts such as `!!Boolean(x)`, `if (Boolean(x))`, or `Boolean(!!x)`.
 - [`no-fallthrough`](#rule-no-fallthrough): Reject `switch` cases that can reach the next label without an intentional `// falls through` comment.
 - [`no-func-assign`](#rule-no-func-assign): Reject reassignment of function declarations.
@@ -1314,13 +1314,17 @@ Object.debugLabel = 1;
 
 ### `no-extra-bind`
 
-Reject unnecessary `Function.prototype.bind()` calls, for example, binding without arguments or binding an arrow function (which ignores `this`).
+Reject `.bind(thisArg)` on an arrow function or on a regular function whose own scope never reads `this`. A nested arrow inherits the enclosing regular function's receiver and therefore counts as a use, while a nested regular function owns a separate receiver. Calls with arguments after `thisArg` and calls that spread their arguments remain unchanged because they can perform partial application.
+
+Dot, static computed, and optional member/call forms are recognized. The autofix removes the bind syntax only when evaluating `thisArg` is side-effect-free and no comment lies inside the discarded ranges; other findings remain diagnostic-only.
 
 Example:
 
 ```ts
 // reports: no-extra-bind (error)
 const f = (() => 1).bind({});
+
+const partial = ((value: number) => value).bind(null, 1);
 ```
 
 <a id="rule-no-extra-boolean-cast"></a>


### PR DESCRIPTION
## Summary

- recognize direct, static computed, parenthesized, and optional bind call syntax
- preserve partial applications, spread calls, and regular functions whose lexical this is used through nested arrows
- offer comment-safe fixes only for side-effect-free receiver arguments
- expand rule, fixer, corpus, public type, README, and website shields

## Validation

Local tests are intentionally deferred until three consecutive exhaustive reviews of one exact PR head, per the issue workflow.

Closes #510