### PR TITLE
fix(lint): unify LSP formatter defaults

### DIFF
--- a/packages/lint/linthost/lsp.go
+++ b/packages/lint/linthost/lsp.go
@@ -325,18 +325,21 @@ func lspFindings(opts *lspCommandOptions, includeFormatDefaults bool) ([]*Findin
     fmt.Fprintln(os.Stderr, "@ttsc/lint: lsp command requires --uri")
     return nil, nil, nil, 2
   }
-  _, err := filePathFromURI(opts.uri)
+  target, err := filePathFromURI(opts.uri)
   if err != nil {
     fmt.Fprintln(os.Stderr, err)
     return nil, nil, nil, 2
   }
-  rules, err := loadRules(opts.pluginsJSON, opts.cwd, opts.tsconfig)
+  rules, err := loadLSPCommandRules(
+    opts.pluginsJSON,
+    opts.cwd,
+    opts.tsconfig,
+    target,
+    includeFormatDefaults,
+  )
   if err != nil {
     fmt.Fprintln(os.Stderr, err)
     return nil, nil, nil, 2
-  }
-  if includeFormatDefaults {
-    rules = formatCommandResolver{inner: rules}
   }
   engine := NewEngineWithResolver(rules)
   prog, parseDiags, err := loadProgram(opts.cwd, opts.tsconfig, loadProgramOptions{
@@ -354,6 +357,33 @@ func lspFindings(opts *lspCommandOptions, includeFormatDefaults bool) ([]*Findin
   }
   findings := prog.runLintCycle(engine)
   return findings, prog, prog.close, 0
+}
+
+// loadLSPCommandRules constructs the resolver shared by every LSP command
+// path. Format requests use the same missing-config fallback, documented
+// defaults, editor overrides, and language precedence as the CLI formatter and
+// in-memory buffer formatter; lint-only requests retain the strict lint loader.
+// formatTarget is the real editor document even when cwd/tsconfig point at the
+// temporary workspace used by the disk execute-command path.
+func loadLSPCommandRules(
+  pluginsJSON string,
+  cwd string,
+  tsconfigPath string,
+  formatTarget string,
+  includeFormatDefaults bool,
+) (RuleResolver, error) {
+  if !includeFormatDefaults {
+    return loadRules(pluginsJSON, cwd, tsconfigPath)
+  }
+  rules, err := loadFormatRules(pluginsJSON, cwd, tsconfigPath)
+  if err != nil {
+    return nil, err
+  }
+  return newFormatCommandResolver(
+    rules,
+    filepath.Dir(formatTarget),
+    vscodeLanguageID(formatTarget),
+  )
 }
 
 func mustFilePathFromURI(uri string) string {
@@ -688,13 +718,16 @@ func lspWorkspaceEditForCommand(opts *lspCommandOptions) (*lspWorkspaceEdit, int
   defer cleanup()
 
   pluginsJSON := remapLSPPluginsJSONForTempWorkspace(opts.pluginsJSON, physicalCwd, tempRoot)
-  rules, err := loadRules(pluginsJSON, tempRoot, tempTsconfig)
+  rules, err := loadLSPCommandRules(
+    pluginsJSON,
+    tempRoot,
+    tempTsconfig,
+    target,
+    opts.command == commandFormatDocument,
+  )
   if err != nil {
     fmt.Fprintln(os.Stderr, err)
     return nil, 2
-  }
-  if opts.command == commandFormatDocument {
-    rules = formatCommandResolver{inner: rules}
   }
   engine := NewEngineWithResolver(rules)
   needsRuleChecker := engine.NeedsTypeChecker()
@@ -778,12 +811,13 @@ func lspFormatBuffer(content string, opts *lspCommandOptions) (*lspWorkspaceEdit
     return nil, 0
   }
 
-  rules, err := loadFormatRules(opts.pluginsJSON, opts.cwd, opts.tsconfig)
-  if err != nil {
-    fmt.Fprintln(os.Stderr, err)
-    return nil, 2
-  }
-  resolver, err := newFormatCommandResolver(rules, filepath.Dir(target), vscodeLanguageID(target))
+  resolver, err := loadLSPCommandRules(
+    opts.pluginsJSON,
+    opts.cwd,
+    opts.tsconfig,
+    target,
+    true,
+  )
   if err != nil {
     fmt.Fprintln(os.Stderr, err)
     return nil, 2

--- a/packages/lint/test/command/lsp_format_paths_use_canonical_defaults_test.go
+++ b/packages/lint/test/command/lsp_format_paths_use_canonical_defaults_test.go
@@ -43,7 +43,7 @@ func TestLSPFormatPathsUseDefaultsWithoutFormatBlock(t *testing.T) {
 // the project-wide CLI must use only the top-level value. Every value is
 // deliberately non-default so neither path can pass by skipping settings.
 func TestLSPFormatPathsUseEditorLanguageOverrides(t *testing.T) {
-  source := "function outer() {\n    const value = 1\n}\n"
+  source := "function outer() {\n     const value = 1\n}\n"
   root := seedLintProject(t, source)
   writeFile(t, filepath.Join(root, ".vscode", "settings.json"), `{
   "editor.tabSize": 3,

--- a/packages/lint/test/command/lsp_format_paths_use_canonical_defaults_test.go
+++ b/packages/lint/test/command/lsp_format_paths_use_canonical_defaults_test.go
@@ -38,21 +38,21 @@ func TestLSPFormatPathsUseDefaultsWithoutFormatBlock(t *testing.T) {
 // TestLSPFormatPathsUseEditorLanguageOverrides guards the resolver context
 // used by editor-originated format requests.
 //
-// The combined selector intentionally disagrees with both the project-wide
-// value and the exact TypeScript selector. LSP requests must resolve the real
-// document language, while the CLI uses the matching project-wide value. The
-// shared value is deliberately non-default, so omitting editor settings cannot
-// accidentally satisfy the assertion.
+// The project-wide, combined, and exact TypeScript values all disagree. LSP
+// requests must resolve the real document language and select the exact scope;
+// the project-wide CLI must use only the top-level value. Every value is
+// deliberately non-default so neither path can pass by skipping settings.
 func TestLSPFormatPathsUseEditorLanguageOverrides(t *testing.T) {
   source := "function outer() {\n    const value = 1\n}\n"
   root := seedLintProject(t, source)
   writeFile(t, filepath.Join(root, ".vscode", "settings.json"), `{
   "editor.tabSize": 3,
   "[javascript][typescript]": { "editor.tabSize": 6 },
-  "[typescript]": { "editor.tabSize": 3 }
+  "[typescript]": { "editor.tabSize": 4 }
 }`)
 
-  assertCanonicalLSPFormatPaths(t, root, source, "function outer() {\n   const value = 1;\n}\n")
+  assertLSPFormatPaths(t, root, source, "function outer() {\n    const value = 1;\n}\n")
+  assertCLIFormatText(t, root, "function outer() {\n   const value = 1;\n}\n")
 }
 
 // TestLSPFormatPathsHonorEntryIgnores guards scoping parity across every
@@ -83,6 +83,12 @@ func TestLSPFormatPathsHonorEntryIgnores(t *testing.T) {
 
 func assertCanonicalLSPFormatPaths(t *testing.T, root string, source string, want string) {
   t.Helper()
+  assertLSPFormatPaths(t, root, source, want)
+  assertCLIFormatText(t, root, want)
+}
+
+func assertLSPFormatPaths(t *testing.T, root string, source string, want string) {
+  t.Helper()
   uri := lintTestFileURI(t, filepath.Join(root, "src", "main.ts"))
 
   actions := runLSPCodeActionsForTest(t, root, uri, `{"only":["source.format"]}`)
@@ -95,8 +101,6 @@ func assertCanonicalLSPFormatPaths(t *testing.T, root string, source string, wan
   if got := executeLSPFormatBufferAppliedTextForTest(t, root, uri, source, source); got != want {
     t.Fatalf("buffer format text = %q, want %q", got, want)
   }
-
-  assertCLIFormatText(t, root, want)
 }
 
 func assertCLIFormatText(t *testing.T, root string, want string) {

--- a/packages/lint/test/command/lsp_format_paths_use_canonical_defaults_test.go
+++ b/packages/lint/test/command/lsp_format_paths_use_canonical_defaults_test.go
@@ -1,0 +1,120 @@
+package linthost
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestLSPFormatPathsUseDefaultsWithoutLintConfig guards the editor contract
+// for projects that use formatting without configuring lint at all.
+//
+// Code-action discovery, disk execute-command, dirty-buffer formatting, and
+// the CLI must all activate the same always-on formatter defaults. In
+// particular, the LSP front doors must not fail just because lint.config.json
+// is absent.
+func TestLSPFormatPathsUseDefaultsWithoutLintConfig(t *testing.T) {
+  source := "const value = 1\n"
+  root := seedLintProject(t, source)
+
+  assertCanonicalLSPFormatPaths(t, root, source, "const value = 1;\n")
+}
+
+// TestLSPFormatPathsUseDefaultsWithoutFormatBlock guards the distinction
+// between a lint configuration and an explicit formatter configuration.
+//
+// A rules-only lint.config.json must not suppress documented formatter
+// defaults on any LSP path.
+func TestLSPFormatPathsUseDefaultsWithoutFormatBlock(t *testing.T) {
+  source := "const value = 1\n"
+  root := seedLintProject(t, source)
+  seedLintConfig(t, root, map[string]any{
+    "rules": map[string]any{"no-var": "off"},
+  })
+
+  assertCanonicalLSPFormatPaths(t, root, source, "const value = 1;\n")
+}
+
+// TestLSPFormatPathsUseEditorLanguageOverrides guards the resolver context
+// used by editor-originated format requests.
+//
+// The combined selector intentionally disagrees with both the project-wide
+// value and the exact TypeScript selector. LSP requests must resolve the real
+// document language, while the CLI uses the matching project-wide value; all
+// paths therefore converge on the same two-space output for the right reasons.
+func TestLSPFormatPathsUseEditorLanguageOverrides(t *testing.T) {
+  source := "function outer() {\n    const value = 1\n}\n"
+  root := seedLintProject(t, source)
+  writeFile(t, filepath.Join(root, ".vscode", "settings.json"), `{
+  "editor.tabSize": 2,
+  "[javascript][typescript]": { "editor.tabSize": 6 },
+  "[typescript]": { "editor.tabSize": 2 }
+}`)
+
+  assertCanonicalLSPFormatPaths(t, root, source, "function outer() {\n  const value = 1;\n}\n")
+}
+
+// TestLSPFormatPathsHonorEntryIgnores guards scoping parity across every
+// formatting front door. A rules-bearing entry is important here: it proves
+// ignores are preserved even when the config is not an ignore-only entry.
+func TestLSPFormatPathsHonorEntryIgnores(t *testing.T) {
+  source := "const value = 1\n"
+  root := seedLintProject(t, source)
+  seedLintConfig(t, root, map[string]any{
+    "ignores": []string{"src/main.ts"},
+    "rules":   map[string]any{"no-var": "off"},
+  })
+  uri := lintTestFileURI(t, filepath.Join(root, "src", "main.ts"))
+
+  actions := runLSPCodeActionsForTest(t, root, uri, `{"only":["source.format"]}`)
+  if got := actionCommandsForTest(actions); len(got) != 0 {
+    t.Fatalf("ignored format actions = %#v, want none", got)
+  }
+  if edit := executeLSPCommandEditForTest(t, root, uri, commandFormatDocument); edit != nil {
+    t.Fatalf("ignored disk format edit = %#v, want nil", edit)
+  }
+  if edit := executeLSPFormatBufferEditForTest(t, root, uri, source); len(edit.Changes) != 0 {
+    t.Fatalf("ignored buffer format edit = %#v, want no changes", edit)
+  }
+
+  assertCLIFormatText(t, root, source)
+}
+
+func assertCanonicalLSPFormatPaths(t *testing.T, root string, source string, want string) {
+  t.Helper()
+  uri := lintTestFileURI(t, filepath.Join(root, "src", "main.ts"))
+
+  actions := runLSPCodeActionsForTest(t, root, uri, `{"only":["source.format"]}`)
+  if got := actionCommandsForTest(actions); len(got) != 1 || got[0] != commandFormatDocument {
+    t.Fatalf("format actions = %#v, want [%q]", got, commandFormatDocument)
+  }
+  if got := executeLSPCommandAppliedTextForTest(t, root, uri, commandFormatDocument, source); got != want {
+    t.Fatalf("disk format text = %q, want %q", got, want)
+  }
+  if got := executeLSPFormatBufferAppliedTextForTest(t, root, uri, source, source); got != want {
+    t.Fatalf("buffer format text = %q, want %q", got, want)
+  }
+
+  assertCLIFormatText(t, root, want)
+}
+
+func assertCLIFormatText(t *testing.T, root string, want string) {
+  t.Helper()
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "format",
+      "--cwd", root,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  if code != 0 || stdout != "" || stderr != "" {
+    t.Fatalf("format command mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  got, err := os.ReadFile(filepath.Join(root, "src", "main.ts"))
+  if err != nil {
+    t.Fatalf("ReadFile: %v", err)
+  }
+  if string(got) != want {
+    t.Fatalf("CLI format text = %q, want %q", string(got), want)
+  }
+}

--- a/packages/lint/test/command/lsp_format_paths_use_canonical_defaults_test.go
+++ b/packages/lint/test/command/lsp_format_paths_use_canonical_defaults_test.go
@@ -40,18 +40,19 @@ func TestLSPFormatPathsUseDefaultsWithoutFormatBlock(t *testing.T) {
 //
 // The combined selector intentionally disagrees with both the project-wide
 // value and the exact TypeScript selector. LSP requests must resolve the real
-// document language, while the CLI uses the matching project-wide value; all
-// paths therefore converge on the same two-space output for the right reasons.
+// document language, while the CLI uses the matching project-wide value. The
+// shared value is deliberately non-default, so omitting editor settings cannot
+// accidentally satisfy the assertion.
 func TestLSPFormatPathsUseEditorLanguageOverrides(t *testing.T) {
   source := "function outer() {\n    const value = 1\n}\n"
   root := seedLintProject(t, source)
   writeFile(t, filepath.Join(root, ".vscode", "settings.json"), `{
-  "editor.tabSize": 2,
+  "editor.tabSize": 3,
   "[javascript][typescript]": { "editor.tabSize": 6 },
-  "[typescript]": { "editor.tabSize": 2 }
+  "[typescript]": { "editor.tabSize": 3 }
 }`)
 
-  assertCanonicalLSPFormatPaths(t, root, source, "function outer() {\n  const value = 1;\n}\n")
+  assertCanonicalLSPFormatPaths(t, root, source, "function outer() {\n   const value = 1;\n}\n")
 }
 
 // TestLSPFormatPathsHonorEntryIgnores guards scoping parity across every


### PR DESCRIPTION
## Intent

Make every LSP formatting front door honor the same canonical defaults and precedence as \	tsc format\.

## Scope

- centralize LSP resolver construction on the canonical format loader
- preserve temporary-workspace config resolution while reading editor settings from the real document
- apply missing-config fallback, always-on defaults, language overrides, files/ignores, and configured format blocks consistently
- shield parity across code-action discovery, disk execute-command, in-memory buffers, and CLI formatting

## Validation plan

- three sequential exhaustive whole-PR reviews at one exact HEAD
- focused LSP format Go tests
- lint package build

No formatter was run. Local execution is deferred until the three clean review rounds complete.

Closes #508