### PR TITLE
fix(lint): preserve dirty buffers for contributor formatting

### DIFF
--- a/packages/lint/linthost/lsp.go
+++ b/packages/lint/linthost/lsp.go
@@ -1,6 +1,7 @@
 package linthost
 
 import (
+  "context"
   "crypto/sha256"
   "encoding/json"
   "errors"
@@ -710,12 +711,42 @@ func lspWorkspaceEditForCommand(opts *lspCommandOptions) (*lspWorkspaceEdit, int
     fmt.Fprintf(os.Stderr, "@ttsc/lint: read %s: %v\n", target, err)
     return nil, 2
   }
+
+  return lspWorkspaceEditForSeededCommand(opts, target, string(original), nil)
+}
+
+// lspWorkspaceEditForSeededCommand runs a command in the ordinary temporary
+// project while optionally replacing the target copy with editor-owned text.
+// original is always the document against which the returned full-document
+// edit is measured. A non-nil sourceOverlay is written only inside the
+// temporary workspace, so type-aware contributor rules receive a real Program
+// and Checker for the dirty document without using or mutating its disk twin as
+// command input. Dirty buffers with syntax errors fail closed before any fix is
+// applied.
+func lspWorkspaceEditForSeededCommand(
+  opts *lspCommandOptions,
+  target string,
+  original string,
+  sourceOverlay *string,
+) (*lspWorkspaceEdit, int) {
+  physicalCwd := realProjectPath(opts.cwd)
   tempRoot, tempTarget, tempTsconfig, cleanup, err := prepareLSPCommandWorkspace(physicalCwd, opts.tsconfig, target)
   if err != nil {
     fmt.Fprintln(os.Stderr, err)
     return nil, 2
   }
   defer cleanup()
+
+  if sourceOverlay != nil {
+    if err := os.MkdirAll(filepath.Dir(tempTarget), 0o755); err != nil {
+      fmt.Fprintf(os.Stderr, "@ttsc/lint: create dirty-buffer directory: %v\n", err)
+      return nil, 2
+    }
+    if err := os.WriteFile(tempTarget, []byte(*sourceOverlay), 0o600); err != nil {
+      fmt.Fprintf(os.Stderr, "@ttsc/lint: seed dirty buffer %s: %v\n", target, err)
+      return nil, 2
+    }
+  }
 
   pluginsJSON := remapLSPPluginsJSONForTempWorkspace(opts.pluginsJSON, physicalCwd, tempRoot)
   rules, err := loadLSPCommandRules(
@@ -750,6 +781,14 @@ func lspWorkspaceEditForCommand(opts *lspCommandOptions) (*lspWorkspaceEdit, int
       prog.close()
       return nil, 0
     }
+    if sourceOverlay != nil {
+      targetFile := prog.findSourceFile(tempTarget)
+      if targetFile == nil ||
+        len(prog.tsProgram.GetSyntacticDiagnostics(context.Background(), targetFile)) > 0 {
+        prog.close()
+        return nil, 0
+      }
+    }
     findings := filterFindingsForPath(prog.runLintCycle(engine), tempTarget)
     prog.close()
     if opts.command == commandFormatDocument {
@@ -778,18 +817,18 @@ func lspWorkspaceEditForCommand(opts *lspCommandOptions) (*lspWorkspaceEdit, int
     fmt.Fprintf(os.Stderr, "@ttsc/lint: read cascaded %s: %v\n", tempTarget, err)
     return nil, 2
   }
-  return workspaceEditForFullDocument(opts.uri, string(original), string(next)), 0
+  return workspaceEditForFullDocument(opts.uri, original, string(next)), 0
 }
 
 // lspFormatBuffer formats an in-memory document buffer using only the
-// format-class rules, with no tsgo Program and no temp-workspace copy. It is
-// the lightweight path behind --content-stdin for ttsc.format.document.
+// format-class rules. It is the path behind --content-stdin for
+// ttsc.format.document.
 //
-// Format rules are AST+source only (`IsFormat() == true`); none implement
-// typeAwareRule, so the engine runs them with a nil checker. The document
-// content comes entirely from `content` — the file on disk at opts.uri is
-// never read — so an editor can format an unsaved buffer without paying the
-// disk-copy + full-program-load cost of lspWorkspaceEditForCommand.
+// Built-in format rules are AST+source only and use the lightweight single-file
+// parser below. Contributor format rules conservatively require a checker, so
+// they use a temporary project seeded with `content`. Both branches derive
+// findings and edits from the supplied buffer; neither uses stale disk content
+// as the document or mutates the original project.
 //
 // Returns the same WorkspaceEdit shape as the disk path, or (nil, 0) on a
 // no-op (no fixable findings, or text unchanged after convergence).
@@ -824,12 +863,17 @@ func lspFormatBuffer(content string, opts *lspCommandOptions) (*lspWorkspaceEdit
   }
   engine := NewEngineWithResolver(resolver)
   if engine.NeedsTypeChecker() {
-    // A format-class contributor rule (formatContributorAdapter) needs the type
-    // checker, which the single-file in-memory parse can't supply. Fall back to
-    // the disk path, which builds a full program with a checker, so the result
-    // matches `ttsc format`; the dirty buffer can't be honored for these rules.
-    // Built-in format rules are AST-only, so they keep the fast in-memory path.
-    return lspWorkspaceEditForCommand(opts)
+    // Contributor format rules conservatively require a checker. Seed the
+    // dirty text into the temporary project so the checker, findings, fix
+    // ranges, and final WorkspaceEdit all describe the same editor document.
+    // Built-in AST-only format rules keep the fast single-file path below.
+    sourceOverlay := content
+    return lspWorkspaceEditForSeededCommand(
+      opts,
+      physicalTarget,
+      content,
+      &sourceOverlay,
+    )
   }
   scriptKind := scriptKindForPath(target)
 

--- a/packages/lint/test/command/lsp_format_buffer_type_aware_contributor_test.go
+++ b/packages/lint/test/command/lsp_format_buffer_type_aware_contributor_test.go
@@ -12,6 +12,13 @@ import (
 
 const dirtyBufferFormatContributorName = "test/dirty-buffer-format"
 
+// Register through the public contributor surface before TestMain performs the
+// package's one-time bootstrap. This mirrors a real blank-imported contributor
+// and avoids any test-only mutation of the internal rule registry.
+func init() {
+  publicrule.Register(dirtyBufferFormatContributor{})
+}
+
 // TestLSPFormatBufferTypeAwareContributorUsesDirtyContent guards the public
 // contributor path that requires a real Program and Checker.
 //
@@ -21,8 +28,6 @@ const dirtyBufferFormatContributorName = "test/dirty-buffer-format"
 // a range measured against the wrong document. A syntactically invalid dirty
 // buffer must also fail closed instead of formatting the valid disk twin.
 func TestLSPFormatBufferTypeAwareContributorUsesDirtyContent(t *testing.T) {
-  registerDirtyBufferFormatContributor(t)
-
   disk := `import { imported } from "./dep";
 const value = imported;
 const diskOnly = "FIRST";
@@ -62,20 +67,6 @@ const bufferOnly = "FIRST";
       t.Fatalf("syntax-error dirty buffer edit = %#v, want no changes", edit)
     }
     assertFileText(t, target, disk)
-  })
-}
-
-func registerDirtyBufferFormatContributor(t *testing.T) {
-  t.Helper()
-  if existing := LookupRule(dirtyBufferFormatContributorName); existing != nil {
-    t.Fatalf("unexpected pre-registered %q rule", dirtyBufferFormatContributorName)
-  }
-  metadata, err := inspectContributor(dirtyBufferFormatContributor{})
-  if err != nil {
-    t.Fatalf("inspect contributor: %v", err)
-  }
-  Register(formatContributorAdapter{
-    contributorAdapter: newContributorAdapter(metadata),
   })
 }
 

--- a/packages/lint/test/command/lsp_format_buffer_type_aware_contributor_test.go
+++ b/packages/lint/test/command/lsp_format_buffer_type_aware_contributor_test.go
@@ -1,0 +1,140 @@
+package linthost
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+const dirtyBufferFormatContributorName = "test/dirty-buffer-format"
+
+// TestLSPFormatBufferTypeAwareContributorUsesDirtyContent guards the public
+// contributor path that requires a real Program and Checker.
+//
+// The synthetic FormatRule consults an imported value's inferred type before
+// applying two cascading edits. Disk and editor contents deliberately differ,
+// so returning a disk-derived edit would either overwrite `bufferOnly` or use
+// a range measured against the wrong document. A syntactically invalid dirty
+// buffer must also fail closed instead of formatting the valid disk twin.
+func TestLSPFormatBufferTypeAwareContributorUsesDirtyContent(t *testing.T) {
+  registerDirtyBufferFormatContributor(t)
+
+  disk := `import { imported } from "./dep";
+const value = imported;
+const diskOnly = "FIRST";
+`
+
+  t.Run("checker-backed multi-pass edits use the buffer", func(t *testing.T) {
+    root := seedDirtyBufferFormatProject(t, disk)
+    target := filepath.Join(root, "src", "main.ts")
+    uri := lintTestFileURI(t, target)
+    buffer := `import { imported } from "./dep";
+const value = imported;
+const bufferOnly = "FIRST";
+`
+    want := `import { imported } from "./dep";
+const value = imported;
+const bufferOnly = "FINAL";
+`
+
+    got := executeLSPFormatBufferAppliedTextForTest(t, root, uri, buffer, buffer)
+    if got != want {
+      t.Fatalf("type-aware dirty-buffer format:\nwant %q\ngot  %q", want, got)
+    }
+    assertFileText(t, target, disk)
+  })
+
+  t.Run("syntax errors do not fall back to disk", func(t *testing.T) {
+    root := seedDirtyBufferFormatProject(t, disk)
+    target := filepath.Join(root, "src", "main.ts")
+    uri := lintTestFileURI(t, target)
+    broken := `import { imported } from "./dep";
+const value: = imported;
+const bufferOnly = "FIRST";
+`
+
+    edit := executeLSPFormatBufferEditForTest(t, root, uri, broken)
+    if len(edit.Changes) != 0 {
+      t.Fatalf("syntax-error dirty buffer edit = %#v, want no changes", edit)
+    }
+    assertFileText(t, target, disk)
+  })
+}
+
+func registerDirtyBufferFormatContributor(t *testing.T) {
+  t.Helper()
+  if existing := LookupRule(dirtyBufferFormatContributorName); existing != nil {
+    t.Fatalf("unexpected pre-registered %q rule", dirtyBufferFormatContributorName)
+  }
+  metadata, err := inspectContributor(dirtyBufferFormatContributor{})
+  if err != nil {
+    t.Fatalf("inspect contributor: %v", err)
+  }
+  Register(formatContributorAdapter{
+    contributorAdapter: newContributorAdapter(metadata),
+  })
+}
+
+func seedDirtyBufferFormatProject(t *testing.T, disk string) string {
+  t.Helper()
+  root := seedLintProject(t, disk)
+  writeFile(t, filepath.Join(root, "src", "dep.ts"), "export let imported = 1;\n")
+  seedLintConfig(t, root, map[string]any{
+    "format": map[string]any{},
+    "rules": map[string]any{
+      dirtyBufferFormatContributorName: "error",
+    },
+  })
+  return root
+}
+
+// dirtyBufferFormatContributor requires the imported `value` binding to be a
+// number before it rewrites the stage marker. This prevents a checker that was
+// built without the dirty target or its dependency graph from satisfying the
+// fixture. FIRST -> SECOND -> FINAL requires two independently rebuilt Program
+// cycles and therefore shields the complete cascade, not only its first pass.
+type dirtyBufferFormatContributor struct{}
+
+func (dirtyBufferFormatContributor) Name() string {
+  return dirtyBufferFormatContributorName
+}
+
+func (dirtyBufferFormatContributor) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindIdentifier}
+}
+
+func (dirtyBufferFormatContributor) IsFormat() bool { return true }
+
+func (dirtyBufferFormatContributor) Check(ctx *publicrule.Context, node *shimast.Node) {
+  if ctx == nil || ctx.Checker == nil || ctx.File == nil || node == nil ||
+    shimast.NodeText(node) != "value" || node.Parent == nil ||
+    node.Parent.Kind != shimast.KindVariableDeclaration {
+    return
+  }
+  valueType := ctx.Checker.GetTypeAtLocation(node)
+  if valueType == nil || ctx.Checker.TypeToString(valueType) != "number" {
+    return
+  }
+
+  source := ctx.File.Text()
+  from, to := "", ""
+  switch {
+  case strings.Contains(source, "FIRST"):
+    from, to = "FIRST", "SECOND"
+  case strings.Contains(source, "SECOND"):
+    from, to = "SECOND", "FINAL"
+  default:
+    return
+  }
+  pos := strings.Index(source, from)
+  ctx.ReportRangeFix(
+    pos,
+    pos+len(from),
+    "advance dirty-buffer format cascade",
+    publicrule.TextEdit{Pos: pos, End: pos + len(from), Text: to},
+  )
+}


### PR DESCRIPTION
## Intent

Keep checker-backed contributor formatting bound to the editor document that requested it, never stale disk text.

## Scope

- seed dirty content into the target file inside the temporary project
- retain the normal Program, Checker, imports, and project/module resolution
- rebuild checker state across every format cascade pass
- measure the final WorkspaceEdit against the original buffer
- fail closed on dirty-buffer syntax errors without touching the real project
- shield divergent disk/buffer content, imported type inference, multi-pass fixes, edit ranges, and disk immutability

## Validation plan

- three sequential exhaustive whole-PR reviews at one exact HEAD
- focused dirty-buffer contributor Go test
- lint package build

No formatter was run. Local execution is deferred until the three clean review rounds complete.

Closes #507