### PR TITLE
fix(lint): track no-func-assign writes by binding

### DIFF
--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -540,6 +540,22 @@ func assignmentTargetIdentifiers(node *shimast.Node) []*shimast.Node {
   return identifiers
 }
 
+// valueSymbolAtIdentifier resolves an identifier in value position. A
+// shorthand property assignment needs the checker's dedicated value-symbol
+// lookup because GetSymbolAtLocation otherwise resolves the object property
+// rather than the binding written by `({name} = value)`.
+func valueSymbolAtIdentifier(ctx *Context, identifier *shimast.Node) *shimast.Symbol {
+  if ctx == nil || ctx.Checker == nil || identifier == nil {
+    return nil
+  }
+  if parent := identifier.Parent; parent != nil && parent.Kind == shimast.KindShorthandPropertyAssignment {
+    if shorthand := parent.AsShorthandPropertyAssignment(); shorthand != nil && shorthand.Name() == identifier {
+      return ctx.Checker.GetShorthandAssignmentValueSymbol(parent)
+    }
+  }
+  return ctx.Checker.GetSymbolAtLocation(identifier)
+}
+
 // assignmentTargetNames is the text-only projection used by rules that do not
 // need binding identity.
 func assignmentTargetNames(node *shimast.Node) []string {

--- a/packages/lint/linthost/rules_no_func_assign.go
+++ b/packages/lint/linthost/rules_no_func_assign.go
@@ -1,0 +1,117 @@
+// noFuncAssign rejects writes to bindings introduced by function declarations
+// and named function expressions. It follows checker symbols instead of names,
+// so hoisted references resolve correctly while parameter, catch, block, and
+// sibling-scope shadows remain independent.
+// https://eslint.org/docs/latest/rules/no-func-assign
+package linthost
+
+import shimast "github.com/microsoft/typescript-go/shim/ast"
+
+type noFuncAssign struct{}
+
+func (noFuncAssign) Name() string           { return "no-func-assign" }
+func (noFuncAssign) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSourceFile} }
+func (noFuncAssign) NeedsTypeChecker() bool { return true }
+func (noFuncAssign) Check(ctx *Context, node *shimast.Node) {
+  if ctx == nil || ctx.Checker == nil || node == nil {
+    return
+  }
+
+  functionSymbols := make(map[*shimast.Symbol]struct{})
+  walkDescendants(node, func(child *shimast.Node) {
+    name := noFuncAssignDeclarationName(child)
+    symbol := noFuncAssignCanonicalSymbol(ctx, name)
+    if symbol != nil {
+      functionSymbols[symbol] = struct{}{}
+    }
+  })
+  if len(functionSymbols) == 0 {
+    return
+  }
+
+  reported := make(map[*shimast.Node]struct{})
+  walkDescendants(node, func(child *shimast.Node) {
+    for _, target := range noFuncAssignWriteTargets(child) {
+      if _, duplicate := reported[target]; duplicate {
+        continue
+      }
+      symbol := noFuncAssignCanonicalSymbol(ctx, target)
+      if _, isFunction := functionSymbols[symbol]; !isFunction {
+        continue
+      }
+      reported[target] = struct{}{}
+      ctx.Report(target, "'"+identifierText(target)+"' is a function.")
+    }
+  })
+}
+
+// noFuncAssignDeclarationName returns the value-binding name introduced by a
+// function declaration or named function expression. Anonymous expressions do
+// not introduce a function-name binding.
+func noFuncAssignDeclarationName(node *shimast.Node) *shimast.Node {
+  if node == nil {
+    return nil
+  }
+  switch node.Kind {
+  case shimast.KindFunctionDeclaration:
+    if declaration := node.AsFunctionDeclaration(); declaration != nil {
+      return declaration.Name()
+    }
+  case shimast.KindFunctionExpression:
+    if expression := node.AsFunctionExpression(); expression != nil {
+      return expression.Name()
+    }
+  }
+  return nil
+}
+
+// noFuncAssignWriteTargets returns every identifier written by one official
+// reference-writing form. Walking all nodes can encounter a destructuring
+// default both as part of its outer pattern and as a nested binary expression;
+// the caller deduplicates the shared identifier node before reporting it.
+func noFuncAssignWriteTargets(node *shimast.Node) []*shimast.Node {
+  if node == nil {
+    return nil
+  }
+  switch node.Kind {
+  case shimast.KindBinaryExpression:
+    expression := node.AsBinaryExpression()
+    if expression != nil && expression.OperatorToken != nil &&
+      isAssignmentOperator(expression.OperatorToken.Kind) {
+      return assignmentTargetIdentifiers(expression.Left)
+    }
+  case shimast.KindPrefixUnaryExpression:
+    expression := node.AsPrefixUnaryExpression()
+    if expression != nil &&
+      (expression.Operator == shimast.KindPlusPlusToken || expression.Operator == shimast.KindMinusMinusToken) {
+      return assignmentTargetIdentifiers(expression.Operand)
+    }
+  case shimast.KindPostfixUnaryExpression:
+    expression := node.AsPostfixUnaryExpression()
+    if expression != nil &&
+      (expression.Operator == shimast.KindPlusPlusToken || expression.Operator == shimast.KindMinusMinusToken) {
+      return assignmentTargetIdentifiers(expression.Operand)
+    }
+  case shimast.KindForInStatement, shimast.KindForOfStatement:
+    statement := node.AsForInOrOfStatement()
+    if statement != nil && statement.Initializer != nil &&
+      statement.Initializer.Kind != shimast.KindVariableDeclarationList {
+      return assignmentTargetIdentifiers(statement.Initializer)
+    }
+  }
+  return nil
+}
+
+// noFuncAssignCanonicalSymbol normalizes merged declarations, including the
+// TypeScript function-plus-namespace pattern, to one value-binding identity.
+func noFuncAssignCanonicalSymbol(ctx *Context, identifier *shimast.Node) *shimast.Symbol {
+  symbol := valueSymbolAtIdentifier(ctx, identifier)
+  if symbol == nil {
+    return nil
+  }
+  return ctx.Checker.GetMergedSymbol(symbol)
+}
+
+func init() {
+  Register(noFuncAssign{})
+}

--- a/packages/lint/linthost/rules_problems.go
+++ b/packages/lint/linthost/rules_problems.go
@@ -198,9 +198,10 @@ func (noExAssign) Check(ctx *Context, node *shimast.Node) {
 }
 
 // walkAssignments invokes `report` on every `<name> = ...` shape inside
-// `root`. Used by noExAssign to scan a single catch block; the
-// file-wide noFuncAssign / noClassAssign scans go through
-// reportAssignmentsToDeclarations instead.
+// `root`. Used by noExAssign to scan a single catch block; the file-wide
+// noClassAssign scan goes through
+// reportAssignmentsToDeclarations instead. noFuncAssign requires checker
+// binding identity and lives in rules_no_func_assign.go.
 func walkAssignments(root *shimast.Node, name string, report func(*shimast.Node)) {
   if root == nil {
     return
@@ -307,15 +308,6 @@ func (noClassAssign) Check(ctx *Context, node *shimast.Node) {
   reportAssignmentsToDeclarations(ctx, node, shimast.KindClassDeclaration, "is a class.")
 }
 
-// noFuncAssign: same idea, but for function declarations.
-type noFuncAssign struct{}
-
-func (noFuncAssign) Name() string           { return "no-func-assign" }
-func (noFuncAssign) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSourceFile} }
-func (noFuncAssign) Check(ctx *Context, node *shimast.Node) {
-  reportAssignmentsToDeclarations(ctx, node, shimast.KindFunctionDeclaration, "is a function.")
-}
-
 // reportAssignmentsToDeclarations flags every `<name> = …` assignment whose
 // target identifier names a `declKind` declaration found anywhere in the
 // file. It walks the file exactly once — gathering declared names and
@@ -323,8 +315,8 @@ func (noFuncAssign) Check(ctx *Context, node *shimast.Node) {
 //
 // The earlier shape registered for `declKind` directly and, on every
 // declaration, re-scanned the whole file for assignments: O(declarations ×
-// file size), which blows up quadratically on a file with many top-level
-// functions. Visiting `KindSourceFile` once and cross-referencing afterward
+// file size), which blows up quadratically on a file with many declarations.
+// Visiting `KindSourceFile` once and cross-referencing afterward
 // keeps the same findings without the repeated scans.
 func reportAssignmentsToDeclarations(
   ctx *Context,
@@ -585,7 +577,6 @@ func init() {
   Register(noMisleadingCharacterClass{})
   Register(noLossOfPrecision{})
   Register(noClassAssign{})
-  Register(noFuncAssign{})
   Register(noPrototypeBuiltins{})
   Register(noAsyncPromiseExecutor{})
   Register(noControlRegex{})

--- a/packages/lint/linthost/rules_var.go
+++ b/packages/lint/linthost/rules_var.go
@@ -701,7 +701,7 @@ func (preferConst) Check(ctx *Context, node *shimast.Node) {
       }
       if kind == preferConstSimpleAssignment && len(targets) > 1 {
         for _, target := range targets {
-          symbol := preferConstValueSymbol(ctx, target)
+          symbol := valueSymbolAtIdentifier(ctx, target)
           if candidate := bySymbol[symbol]; candidate != nil {
             groups[child] = appendPreferConstCandidate(groups[child], candidate)
           }
@@ -748,7 +748,7 @@ func (preferConst) Check(ctx *Context, node *shimast.Node) {
     if _, ok := candidateNames[identifierText(child)]; !ok {
       return
     }
-    symbol := preferConstValueSymbol(ctx, child)
+    symbol := valueSymbolAtIdentifier(ctx, child)
     candidate := bySymbol[symbol]
     if candidate == nil || candidate.initialized || len(candidate.writes) != 1 {
       return
@@ -813,7 +813,7 @@ func preferConstRecordWrite(
   if target == nil || target.Kind != shimast.KindIdentifier {
     return
   }
-  symbol := preferConstValueSymbol(ctx, target)
+  symbol := valueSymbolAtIdentifier(ctx, target)
   candidate := bySymbol[symbol]
   if candidate == nil {
     return
@@ -824,18 +824,6 @@ func preferConstRecordWrite(
     kind:       kind,
   })
   writeTargets[target] = struct{}{}
-}
-
-func preferConstValueSymbol(ctx *Context, identifier *shimast.Node) *shimast.Symbol {
-  if ctx == nil || ctx.Checker == nil || identifier == nil {
-    return nil
-  }
-  if parent := identifier.Parent; parent != nil && parent.Kind == shimast.KindShorthandPropertyAssignment {
-    if shorthand := parent.AsShorthandPropertyAssignment(); shorthand != nil && shorthand.Name() == identifier {
-      return ctx.Checker.GetShorthandAssignmentValueSymbol(parent)
-    }
-  }
-  return ctx.Checker.GetSymbolAtLocation(identifier)
 }
 
 func preferConstCandidateIsEligible(
@@ -904,7 +892,7 @@ func preferConstAssignmentCanInitialize(
     return false
   }
   for _, target := range targets {
-    symbol := preferConstValueSymbol(ctx, target)
+    symbol := valueSymbolAtIdentifier(ctx, target)
     grouped := bySymbol[symbol]
     if symbol == nil || !preferConstSymbolIsLocalToScope(symbol, candidate.scope) ||
       (grouped != nil && grouped.invalid) {

--- a/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
@@ -607,10 +607,12 @@ export interface ITtscLintCoreRules {
   "no-fallthrough"?: TtscLintRuleOptionsSetting<ITtscLintNoFallthroughRuleOptions>;
 
   /**
-   * Reject reassignment of function declarations (`function f() {}; f = 0;`).
+   * Reject writes to bindings introduced by function declarations and named
+   * function expressions. Lexical binding identity keeps same-spelled shadows
+   * independent across parameters, blocks, catches, and sibling scopes.
    *
-   * The hoisted binding looks final to most readers; overwriting it makes the
-   * original implementation unreachable from other references.
+   * Direct and compound assignment, updates, destructuring, and for-in/of
+   * targets are all modifying references to the function binding.
    *
    * @reference https://eslint.org/docs/latest/rules/no-func-assign
    */

--- a/packages/lint/test/rules/functions-classes/no_func_assign_test.go
+++ b/packages/lint/test/rules/functions-classes/no_func_assign_test.go
@@ -92,10 +92,10 @@ const writeCaptured = (): void => {
   /* report */captured = replacement;
 };
 
-const expression = function namedExpression() {
+let expression = function namedExpression() {
   /* report */namedExpression = replacement;
 };
-void expression;
+expression = replacement;
 
 function overloaded(value: string): string;
 function overloaded(value: number): number;

--- a/packages/lint/test/rules/functions-classes/no_func_assign_test.go
+++ b/packages/lint/test/rules/functions-classes/no_func_assign_test.go
@@ -1,20 +1,212 @@
 package linthost
 
-import "testing"
+import (
+  "fmt"
+  "strings"
+  "testing"
+)
 
-// TestRuleCorpusNoFuncAssign verifies the lint rule corpus fixture no-func-assign.ts.
+// TestRuleCorpusNoFuncAssign verifies function binding identity and every write surface.
 //
-// Rule corpus tests mirror tests/test-lint/src/cases inside Go unit coverage. Each generated
-// scenario keeps one annotated TypeScript fixture tied to the native Engine so individual rule
-// Check methods are measured by go test instead of only by the TypeScript feature runner.
+// A file-wide name set conflates unrelated shadows and only sees bare binary
+// assignments. The real checker must instead connect each modifying reference
+// to the function declaration or named-expression binding it actually resolves
+// to, including hoisted, overloaded, and namespace-merged TypeScript forms.
 //
-// This case enables the rule annotations declared in no-func-assign.ts and compares normalized
-// rule, severity, and line triples. The source text stays embedded in the generated Go file so
-// the test remains package-local and deterministic.
-//
-// 1. Load the annotated TypeScript fixture source embedded below.
-// 2. Enable the rule severities declared by its // expect: comments.
-// 3. Assert the native Engine reports exactly the annotated diagnostics.
+//  1. Write function bindings through assignment, update, destructuring, loop, and TypeScript wrapper forms.
+//  2. Place same-spelled parameter, function-local, block, catch, loop, and sibling shadows beside them.
+//  3. Assert exactly the marked identifier ranges are reported once with the canonical message.
 func TestRuleCorpusNoFuncAssign(t *testing.T) {
-  assertRuleCorpusCase(t, "no-func-assign.ts", "function g() {\n  return 1;\n}\n// expect: no-func-assign error\ng = function () {\n  return 2;\n};\n")
+  engine := NewEngine(RuleConfig{"no-func-assign": SeverityError})
+  if !engine.NeedsTypeChecker() {
+    t.Fatal("no-func-assign did not request a type checker")
+  }
+
+  source := `declare const replacement: any;
+declare const sequence: any[];
+declare const record: Record<string, any>;
+
+function direct() {}
+/* report */direct = replacement;
+
+function compound() {}
+/* report */compound += replacement;
+
+function logical() {}
+/* report */logical ||= replacement;
+
+function prefixUpdate() {}
+++/* report */prefixUpdate;
+
+function postfixUpdate() {}
+/* report */postfixUpdate--;
+
+function arrayTarget() {}
+[/* report */arrayTarget] = sequence;
+
+function objectTarget() {}
+({ value: /* report */objectTarget } = record);
+
+function shorthandTarget() {}
+({ /* report */shorthandTarget } = record);
+
+function defaultTarget() {}
+({ value: /* report */defaultTarget = replacement } = record);
+
+function restTarget() {}
+[.../* report */restTarget] = sequence;
+
+function nestedTarget() {}
+[[/* report */nestedTarget]] = [sequence];
+
+function inTarget() {}
+for (/* report */inTarget in record) {}
+
+function ofTarget() {}
+for (/* report */ofTarget of sequence) {}
+for (let ofTarget of sequence) {
+  void ofTarget;
+}
+
+function asTarget() {}
+(/* report */asTarget as any) = replacement;
+
+function angleTarget() {}
+(<any>/* report */angleTarget) = replacement;
+
+function nonNullTarget() {}
+(/* report */nonNullTarget!) = replacement;
+
+function satisfiesTarget() {}
+(/* report */satisfiesTarget satisfies any) = replacement;
+
+/* report */hoisted = replacement;
+function hoisted() {}
+
+function selfWrite() {
+  /* report */selfWrite = replacement;
+}
+
+function captured() {}
+const writeCaptured = (): void => {
+  /* report */captured = replacement;
+};
+
+const expression = function namedExpression() {
+  /* report */namedExpression = replacement;
+};
+void expression;
+
+function overloaded(value: string): string;
+function overloaded(value: number): number;
+function overloaded(value: string | number): string | number {
+  return value;
+}
+/* report */overloaded = replacement;
+
+declare function ambient(value: string): string;
+/* report */ambient = replacement;
+
+function merged() {}
+namespace merged {
+  export const member = 1;
+}
+/* report */merged = replacement;
+
+function leftScope() {
+  function same() {}
+  /* report */same = replacement;
+}
+
+function rightScope() {
+  function same() {}
+  /* report */same = replacement;
+}
+
+let anonymous = function () {};
+anonymous = replacement;
+
+function parameterShadow(parameterShadow: any) {
+  parameterShadow = replacement;
+}
+
+function functionScopeShadow() {
+  var functionScopeShadow: any;
+  functionScopeShadow = replacement;
+}
+
+function blockShadow() {}
+{
+  let blockShadow: any;
+  blockShadow = replacement;
+}
+
+function catchShadow() {}
+try {
+  throw replacement;
+} catch (catchShadow) {
+  catchShadow = replacement;
+}
+
+function siblingShadow() {}
+function localSiblingShadow() {
+  let siblingShadow: any;
+  siblingShadow = replacement;
+}
+
+namespace namespaceOnly {
+  export const member = 1;
+}
+namespaceOnly = replacement;
+
+const holder = { method() {} };
+holder.method = replacement;
+`
+
+  _, _, findings := runRuleFindingsSnapshot(t, "no-func-assign", source, nil)
+  expected := noFuncAssignMarkedRanges(t, source)
+  if len(findings) != len(expected) {
+    t.Fatalf("expected %d no-func-assign findings, got %d: %#v", len(expected), len(findings), findings)
+  }
+  for index, finding := range findings {
+    want := expected[index]
+    if finding.Rule != "no-func-assign" || finding.Severity != SeverityError ||
+      finding.Pos != want[0] || finding.End != want[1] {
+      t.Fatalf("finding %d range mismatch: got=%+v want=%v", index, finding, want)
+    }
+    name := source[want[0]:want[1]]
+    if expectedMessage := fmt.Sprintf("'%s' is a function.", name); finding.Message != expectedMessage {
+      t.Fatalf("finding %d message mismatch: got=%q want=%q", index, finding.Message, expectedMessage)
+    }
+    if len(finding.Fix) != 0 || len(finding.Suggestions) != 0 {
+      t.Fatalf("finding %d unexpectedly offered edits: %+v", index, finding)
+    }
+  }
+}
+
+func noFuncAssignMarkedRanges(t *testing.T, source string) [][2]int {
+  t.Helper()
+  const marker = "/* report */"
+  ranges := make([][2]int, 0)
+  remaining := source
+  consumed := 0
+  for {
+    markerOffset := strings.Index(remaining, marker)
+    if markerOffset < 0 {
+      return ranges
+    }
+    start := consumed + markerOffset + len(marker)
+    end := start
+    for end < len(source) && (source[end] == '_' || source[end] == '$' ||
+      source[end] >= 'a' && source[end] <= 'z' || source[end] >= 'A' && source[end] <= 'Z' ||
+      end > start && source[end] >= '0' && source[end] <= '9') {
+      end++
+    }
+    if end == start {
+      t.Fatalf("marker at byte %d is not followed by an identifier", start-len(marker))
+    }
+    ranges = append(ranges, [2]int{start, end})
+    consumed = end
+    remaining = source[end:]
+  }
 }

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -1438,9 +1438,9 @@ Options:
 
 ### `no-func-assign`
 
-Reject reassignment of function declarations (`function f() {}; f = 0;`).
+Reject writes to bindings introduced by function declarations and named function expressions.
 
-The hoisted binding looks final to most readers; overwriting it makes the original implementation unreachable from other references.
+The rule follows lexical binding identity, so same-spelled parameters, block variables, catch variables, and sibling bindings remain independent. Direct and compound assignments, updates, destructuring targets, and for-in/of targets all count as writes.
 
 Example:
 


### PR DESCRIPTION
## Intent
Make `no-func-assign` follow the function binding that a write actually resolves to instead of matching same-spelled identifiers across the file.

## Root cause
The previous implementation collected function declaration names in a file-wide string set and inspected only bare binary assignment targets. That conflated lexical shadows and missed updates, destructuring, loop targets, named function expressions, overloads, and TypeScript declaration merging.

## Scope
- Resolve function declaration and named function-expression bindings through the TypeScript checker.
- Canonicalize merged symbols for overload, ambient, and function-plus-namespace forms.
- Recognize direct/compound assignments, prefix/postfix updates, nested destructuring targets, and for-in/of targets.
- Preserve parameter, function-local, block, catch, loop, and sibling-scope shadows.
- Assert exact identifier ranges and no duplicate reports across every write surface.
- Document the complete public rule semantics.

## Deferred items
- `no-class-assign` remains outside this issue.
- Repository-wide formatting is intentionally excluded.

## Test plan
Focused local Go regression and lint package build will run only after three clean exhaustive whole-PR reviews, per the issue workflow. GitHub CI remains additional evidence.

Closes #502