### PR TITLE
fix(lint): track no-class-assign writes by binding

### DIFF
--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -557,13 +557,20 @@ func valueSymbolAtIdentifier(ctx *Context, identifier *shimast.Node) *shimast.Sy
 }
 
 // canonicalValueSymbol resolves an identifier in value position and
-// normalizes declaration merges to one binding identity. Rules that protect
-// declarations from writes use this for both the declaration name and every
-// modifying reference, including shorthand destructuring targets.
+// normalizes exported local/export pairs and declaration merges to one binding
+// identity. TypeScript binds an exported declaration to both a local symbol
+// (used by references in the declaring module) and its ExportSymbol (returned
+// for the declaration name), so both sides must converge before comparison.
+// Rules that protect declarations from writes use this for both the
+// declaration name and every modifying reference, including shorthand
+// destructuring targets.
 func canonicalValueSymbol(ctx *Context, identifier *shimast.Node) *shimast.Symbol {
   symbol := valueSymbolAtIdentifier(ctx, identifier)
   if symbol == nil {
     return nil
+  }
+  if symbol.Flags&shimast.SymbolFlagsExportValue != 0 && symbol.ExportSymbol != nil {
+    symbol = symbol.ExportSymbol
   }
   return ctx.Checker.GetMergedSymbol(symbol)
 }

--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -556,6 +556,60 @@ func valueSymbolAtIdentifier(ctx *Context, identifier *shimast.Node) *shimast.Sy
   return ctx.Checker.GetSymbolAtLocation(identifier)
 }
 
+// canonicalValueSymbol resolves an identifier in value position and
+// normalizes declaration merges to one binding identity. Rules that protect
+// declarations from writes use this for both the declaration name and every
+// modifying reference, including shorthand destructuring targets.
+func canonicalValueSymbol(ctx *Context, identifier *shimast.Node) *shimast.Symbol {
+  symbol := valueSymbolAtIdentifier(ctx, identifier)
+  if symbol == nil {
+    return nil
+  }
+  return ctx.Checker.GetMergedSymbol(symbol)
+}
+
+// writeTargetIdentifiers returns every identifier written by one reference-
+// modifying syntax node. It recognizes assignment operators, update
+// expressions, and expression initializers of for-in/of statements; nested
+// destructuring and TypeScript assertion wrappers are delegated to the shared
+// assignment-target walker.
+//
+// Walking all nodes can encounter a destructuring default both through its
+// outer pattern and as a nested binary expression. Callers that report a full
+// tree must therefore deduplicate the returned identifier nodes.
+func writeTargetIdentifiers(node *shimast.Node) []*shimast.Node {
+  if node == nil {
+    return nil
+  }
+  switch node.Kind {
+  case shimast.KindBinaryExpression:
+    expression := node.AsBinaryExpression()
+    if expression != nil && expression.OperatorToken != nil &&
+      isAssignmentOperator(expression.OperatorToken.Kind) {
+      return assignmentTargetIdentifiers(expression.Left)
+    }
+  case shimast.KindPrefixUnaryExpression:
+    expression := node.AsPrefixUnaryExpression()
+    if expression != nil &&
+      (expression.Operator == shimast.KindPlusPlusToken || expression.Operator == shimast.KindMinusMinusToken) {
+      return assignmentTargetIdentifiers(expression.Operand)
+    }
+  case shimast.KindPostfixUnaryExpression:
+    expression := node.AsPostfixUnaryExpression()
+    if expression != nil &&
+      (expression.Operator == shimast.KindPlusPlusToken || expression.Operator == shimast.KindMinusMinusToken) {
+      return assignmentTargetIdentifiers(expression.Operand)
+    }
+  case shimast.KindForInStatement, shimast.KindForOfStatement:
+    statement := node.AsForInOrOfStatement()
+    if statement != nil && statement.Initializer != nil &&
+      statement.Initializer.Kind != shimast.KindVariableDeclarationList {
+      return assignmentTargetIdentifiers(statement.Initializer)
+    }
+  }
+  return nil
+}
+
 // assignmentTargetNames is the text-only projection used by rules that do not
 // need binding identity.
 func assignmentTargetNames(node *shimast.Node) []string {

--- a/packages/lint/linthost/rules_no_class_assign.go
+++ b/packages/lint/linthost/rules_no_class_assign.go
@@ -1,0 +1,70 @@
+// noClassAssign rejects writes to bindings introduced by class declarations
+// and named class expressions. It follows checker symbols instead of names,
+// so references inside the class and in its surrounding scope resolve while
+// parameter, catch, block, and sibling-scope shadows remain independent.
+// https://eslint.org/docs/latest/rules/no-class-assign
+package linthost
+
+import shimast "github.com/microsoft/typescript-go/shim/ast"
+
+type noClassAssign struct{}
+
+func (noClassAssign) Name() string           { return "no-class-assign" }
+func (noClassAssign) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSourceFile} }
+func (noClassAssign) NeedsTypeChecker() bool { return true }
+func (noClassAssign) Check(ctx *Context, node *shimast.Node) {
+  if ctx == nil || ctx.Checker == nil || node == nil {
+    return
+  }
+
+  classSymbols := make(map[*shimast.Symbol]struct{})
+  walkDescendants(node, func(child *shimast.Node) {
+    name := noClassAssignDeclarationName(child)
+    symbol := canonicalValueSymbol(ctx, name)
+    if symbol != nil {
+      classSymbols[symbol] = struct{}{}
+    }
+  })
+  if len(classSymbols) == 0 {
+    return
+  }
+
+  reported := make(map[*shimast.Node]struct{})
+  walkDescendants(node, func(child *shimast.Node) {
+    for _, target := range writeTargetIdentifiers(child) {
+      if _, duplicate := reported[target]; duplicate {
+        continue
+      }
+      symbol := canonicalValueSymbol(ctx, target)
+      if _, isClass := classSymbols[symbol]; !isClass {
+        continue
+      }
+      reported[target] = struct{}{}
+      ctx.Report(target, "'"+identifierText(target)+"' is a class.")
+    }
+  })
+}
+
+// noClassAssignDeclarationName returns the value-binding name introduced by a
+// class declaration or named class expression. Anonymous expressions and
+// anonymous default-export declarations introduce no writable local name.
+func noClassAssignDeclarationName(node *shimast.Node) *shimast.Node {
+  if node == nil {
+    return nil
+  }
+  switch node.Kind {
+  case shimast.KindClassDeclaration:
+    if declaration := node.AsClassDeclaration(); declaration != nil {
+      return declaration.Name()
+    }
+  case shimast.KindClassExpression:
+    if expression := node.AsClassExpression(); expression != nil {
+      return expression.Name()
+    }
+  }
+  return nil
+}
+
+func init() {
+  Register(noClassAssign{})
+}

--- a/packages/lint/linthost/rules_no_func_assign.go
+++ b/packages/lint/linthost/rules_no_func_assign.go
@@ -20,7 +20,7 @@ func (noFuncAssign) Check(ctx *Context, node *shimast.Node) {
   functionSymbols := make(map[*shimast.Symbol]struct{})
   walkDescendants(node, func(child *shimast.Node) {
     name := noFuncAssignDeclarationName(child)
-    symbol := noFuncAssignCanonicalSymbol(ctx, name)
+    symbol := canonicalValueSymbol(ctx, name)
     if symbol != nil {
       functionSymbols[symbol] = struct{}{}
     }
@@ -31,11 +31,11 @@ func (noFuncAssign) Check(ctx *Context, node *shimast.Node) {
 
   reported := make(map[*shimast.Node]struct{})
   walkDescendants(node, func(child *shimast.Node) {
-    for _, target := range noFuncAssignWriteTargets(child) {
+    for _, target := range writeTargetIdentifiers(child) {
       if _, duplicate := reported[target]; duplicate {
         continue
       }
-      symbol := noFuncAssignCanonicalSymbol(ctx, target)
+      symbol := canonicalValueSymbol(ctx, target)
       if _, isFunction := functionSymbols[symbol]; !isFunction {
         continue
       }
@@ -63,53 +63,6 @@ func noFuncAssignDeclarationName(node *shimast.Node) *shimast.Node {
     }
   }
   return nil
-}
-
-// noFuncAssignWriteTargets returns every identifier written by one official
-// reference-writing form. Walking all nodes can encounter a destructuring
-// default both as part of its outer pattern and as a nested binary expression;
-// the caller deduplicates the shared identifier node before reporting it.
-func noFuncAssignWriteTargets(node *shimast.Node) []*shimast.Node {
-  if node == nil {
-    return nil
-  }
-  switch node.Kind {
-  case shimast.KindBinaryExpression:
-    expression := node.AsBinaryExpression()
-    if expression != nil && expression.OperatorToken != nil &&
-      isAssignmentOperator(expression.OperatorToken.Kind) {
-      return assignmentTargetIdentifiers(expression.Left)
-    }
-  case shimast.KindPrefixUnaryExpression:
-    expression := node.AsPrefixUnaryExpression()
-    if expression != nil &&
-      (expression.Operator == shimast.KindPlusPlusToken || expression.Operator == shimast.KindMinusMinusToken) {
-      return assignmentTargetIdentifiers(expression.Operand)
-    }
-  case shimast.KindPostfixUnaryExpression:
-    expression := node.AsPostfixUnaryExpression()
-    if expression != nil &&
-      (expression.Operator == shimast.KindPlusPlusToken || expression.Operator == shimast.KindMinusMinusToken) {
-      return assignmentTargetIdentifiers(expression.Operand)
-    }
-  case shimast.KindForInStatement, shimast.KindForOfStatement:
-    statement := node.AsForInOrOfStatement()
-    if statement != nil && statement.Initializer != nil &&
-      statement.Initializer.Kind != shimast.KindVariableDeclarationList {
-      return assignmentTargetIdentifiers(statement.Initializer)
-    }
-  }
-  return nil
-}
-
-// noFuncAssignCanonicalSymbol normalizes merged declarations, including the
-// TypeScript function-plus-namespace pattern, to one value-binding identity.
-func noFuncAssignCanonicalSymbol(ctx *Context, identifier *shimast.Node) *shimast.Symbol {
-  symbol := valueSymbolAtIdentifier(ctx, identifier)
-  if symbol == nil {
-    return nil
-  }
-  return ctx.Checker.GetMergedSymbol(symbol)
 }
 
 func init() {

--- a/packages/lint/linthost/rules_problems.go
+++ b/packages/lint/linthost/rules_problems.go
@@ -198,10 +198,9 @@ func (noExAssign) Check(ctx *Context, node *shimast.Node) {
 }
 
 // walkAssignments invokes `report` on every `<name> = ...` shape inside
-// `root`. Used by noExAssign to scan a single catch block; the file-wide
-// noClassAssign scan goes through
-// reportAssignmentsToDeclarations instead. noFuncAssign requires checker
-// binding identity and lives in rules_no_func_assign.go.
+// `root`. It is retained for noExAssign's catch-block-local scan; class and
+// function assignment rules require checker binding identity and live in
+// their dedicated files.
 func walkAssignments(root *shimast.Node, name string, report func(*shimast.Node)) {
   if root == nil {
     return
@@ -297,77 +296,6 @@ func (noLossOfPrecision) Check(ctx *Context, node *shimast.Node) {
   if numericLiteralLosesPrecision(source) {
     ctx.Report(node, "This number literal will lose precision at runtime.")
   }
-}
-
-// noClassAssign: assigning to a class declaration's name.
-type noClassAssign struct{}
-
-func (noClassAssign) Name() string           { return "no-class-assign" }
-func (noClassAssign) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSourceFile} }
-func (noClassAssign) Check(ctx *Context, node *shimast.Node) {
-  reportAssignmentsToDeclarations(ctx, node, shimast.KindClassDeclaration, "is a class.")
-}
-
-// reportAssignmentsToDeclarations flags every `<name> = …` assignment whose
-// target identifier names a `declKind` declaration found anywhere in the
-// file. It walks the file exactly once — gathering declared names and
-// assignment targets in the same pass — so the cost is linear in file size.
-//
-// The earlier shape registered for `declKind` directly and, on every
-// declaration, re-scanned the whole file for assignments: O(declarations ×
-// file size), which blows up quadratically on a file with many declarations.
-// Visiting `KindSourceFile` once and cross-referencing afterward
-// keeps the same findings without the repeated scans.
-func reportAssignmentsToDeclarations(
-  ctx *Context,
-  file *shimast.Node,
-  declKind shimast.Kind,
-  noun string,
-) {
-  if ctx == nil || file == nil {
-    return
-  }
-  declared := map[string]struct{}{}
-  var targets []*shimast.Node
-  walkDescendants(file, func(n *shimast.Node) {
-    switch n.Kind {
-    case declKind:
-      if name := declarationName(n); name != "" {
-        declared[name] = struct{}{}
-      }
-    case shimast.KindBinaryExpression:
-      if expr := n.AsBinaryExpression(); expr != nil &&
-        expr.OperatorToken != nil && isAssignmentOperator(expr.OperatorToken.Kind) &&
-        expr.Left != nil && expr.Left.Kind == shimast.KindIdentifier {
-        targets = append(targets, expr.Left)
-      }
-    }
-  })
-  if len(declared) == 0 || len(targets) == 0 {
-    return
-  }
-  for _, target := range targets {
-    name := identifierText(target)
-    if _, ok := declared[name]; ok {
-      ctx.Report(target, "'"+name+"' "+noun)
-    }
-  }
-}
-
-// declarationName returns the bound name of a class or function declaration
-// node, or "" when the node is neither (or is anonymous).
-func declarationName(n *shimast.Node) string {
-  switch n.Kind {
-  case shimast.KindFunctionDeclaration:
-    if d := n.AsFunctionDeclaration(); d != nil {
-      return identifierText(d.Name())
-    }
-  case shimast.KindClassDeclaration:
-    if d := n.AsClassDeclaration(); d != nil {
-      return identifierText(d.Name())
-    }
-  }
-  return ""
 }
 
 // noPrototypeBuiltins: `obj.hasOwnProperty(x)` — should be
@@ -576,7 +504,6 @@ func init() {
   Register(noEmptyCharacterClass{})
   Register(noMisleadingCharacterClass{})
   Register(noLossOfPrecision{})
-  Register(noClassAssign{})
   Register(noPrototypeBuiltins{})
   Register(noAsyncPromiseExecutor{})
   Register(noControlRegex{})

--- a/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
@@ -314,10 +314,13 @@ export interface ITtscLintCoreRules {
   "no-case-declarations"?: TtscLintRuleSetting;
 
   /**
-   * Reject reassigning a class binding (`class C {}; C = ...`).
+   * Reject every write to a binding introduced by a class declaration or
+   * named class expression.
    *
-   * The declaration name is effectively final; overwriting it silently leaves
-   * other call sites pointing at the original class.
+   * Binding identity is resolved lexically, so same-spelled parameter, catch,
+   * block, and sibling bindings remain independent. Direct and compound
+   * assignments, updates, destructuring targets, and `for-in`/`for-of` targets
+   * are all covered.
    *
    * @reference https://eslint.org/docs/latest/rules/no-class-assign
    */

--- a/packages/lint/test/rules/functions-classes/no_class_assign_test.go
+++ b/packages/lint/test/rules/functions-classes/no_class_assign_test.go
@@ -133,6 +133,9 @@ interface interfaceMerged {
 export class exported {}
 /* report */exported = replacement;
 
+export default class defaultExported {}
+/* report */defaultExported = replacement;
+
 function leftScope() {
   class same {}
   /* report */same = replacement;

--- a/packages/lint/test/rules/functions-classes/no_class_assign_test.go
+++ b/packages/lint/test/rules/functions-classes/no_class_assign_test.go
@@ -99,9 +99,9 @@ const writeCaptured = (): void => {
   /* report */captured = replacement;
 };
 
-let expression = class namedExpression {
+let expression = class expression {
   static replace(): void {
-    /* report */namedExpression = replacement;
+    /* report */expression = replacement;
   }
 };
 expression = replacement;

--- a/packages/lint/test/rules/functions-classes/no_class_assign_test.go
+++ b/packages/lint/test/rules/functions-classes/no_class_assign_test.go
@@ -1,20 +1,209 @@
 package linthost
 
-import "testing"
+import (
+  "fmt"
+  "testing"
+)
 
-// TestRuleCorpusNoClassAssign verifies the lint rule corpus fixture no-class-assign.ts.
+// TestRuleCorpusNoClassAssign verifies class binding identity and every write surface.
 //
-// Rule corpus tests mirror tests/test-lint/src/cases inside Go unit coverage. Each generated
-// scenario keeps one annotated TypeScript fixture tied to the native Engine so individual rule
-// Check methods are measured by go test instead of only by the TypeScript feature runner.
+// A file-wide name set conflates unrelated shadows and only sees bare binary
+// assignments. The checker must connect each modifying reference to the class
+// declaration or named-expression binding it actually resolves to, including
+// class-body references and TypeScript declaration merges.
 //
-// This case enables the rule annotations declared in no-class-assign.ts and compares normalized
-// rule, severity, and line triples. The source text stays embedded in the generated Go file so
-// the test remains package-local and deterministic.
-//
-// 1. Load the annotated TypeScript fixture source embedded below.
-// 2. Enable the rule severities declared by its // expect: comments.
-// 3. Assert the native Engine reports exactly the annotated diagnostics.
+//  1. Write class bindings through assignment, update, destructuring, loop, and TypeScript wrapper forms.
+//  2. Place official clean twins and same-spelled parameter, local, block, catch, loop, and sibling shadows beside them.
+//  3. Assert exactly the marked identifier ranges are reported once with the canonical message.
 func TestRuleCorpusNoClassAssign(t *testing.T) {
-  assertRuleCorpusCase(t, "no-class-assign.ts", "class A {}\n// expect: no-class-assign error\nA = function () {} as any;\n")
+  engine := NewEngine(RuleConfig{"no-class-assign": SeverityError})
+  if !engine.NeedsTypeChecker() {
+    t.Fatal("no-class-assign did not request a type checker")
+  }
+
+  source := `declare const replacement: any;
+declare const sequence: any[];
+declare const record: Record<string, any>;
+
+class direct {}
+/* report */direct = replacement;
+
+class compound {}
+/* report */compound += replacement;
+
+class logical {}
+/* report */logical ||= replacement;
+
+class prefixUpdate {}
+++/* report */prefixUpdate;
+
+class postfixUpdate {}
+/* report */postfixUpdate--;
+
+class arrayTarget {}
+[/* report */arrayTarget] = sequence;
+
+class objectTarget {}
+({ value: /* report */objectTarget } = record);
+
+class shorthandTarget {}
+({ /* report */shorthandTarget } = record);
+
+class defaultTarget {}
+({ value: /* report */defaultTarget = replacement } = record);
+
+class restTarget {}
+[.../* report */restTarget] = sequence;
+
+class nestedTarget {}
+[[/* report */nestedTarget]] = [sequence];
+
+class inTarget {}
+for (/* report */inTarget in record) {}
+
+class ofTarget {}
+for (/* report */ofTarget of sequence) {}
+for (let ofTarget of sequence) {
+  void ofTarget;
+}
+
+class asTarget {}
+(/* report */asTarget as any) = replacement;
+
+class angleTarget {}
+(<any>/* report */angleTarget) = replacement;
+
+class nonNullTarget {}
+(/* report */nonNullTarget!) = replacement;
+
+class satisfiesTarget {}
+(/* report */satisfiesTarget satisfies any) = replacement;
+
+/* report */hoisted = replacement;
+class hoisted {}
+
+class selfWrite {
+  replace(): void {
+    /* report */selfWrite = replacement;
+  }
+}
+
+class staticBlockWrite {
+  static {
+    /* report */staticBlockWrite = replacement;
+  }
+}
+
+class captured {}
+const writeCaptured = (): void => {
+  /* report */captured = replacement;
+};
+
+let expression = class namedExpression {
+  static replace(): void {
+    /* report */namedExpression = replacement;
+  }
+};
+expression = replacement;
+
+let anonymous = class {};
+anonymous = replacement;
+
+let anonymousOuterWrite = class {
+  static replace(): void {
+    anonymousOuterWrite = replacement;
+  }
+};
+
+declare class ambient {}
+/* report */ambient = replacement;
+
+class merged {}
+namespace merged {
+  export const member = 1;
+}
+/* report */merged = replacement;
+
+class interfaceMerged {}
+interface interfaceMerged {
+  member: number;
+}
+/* report */interfaceMerged = replacement;
+
+export class exported {}
+/* report */exported = replacement;
+
+function leftScope() {
+  class same {}
+  /* report */same = replacement;
+}
+
+function rightScope() {
+  class same {}
+  /* report */same = replacement;
+}
+
+class parameterShadow {
+  replace(parameterShadow: any): void {
+    parameterShadow = replacement;
+  }
+}
+
+class methodLocalShadow {
+  replace(): void {
+    let methodLocalShadow: any;
+    methodLocalShadow = replacement;
+  }
+}
+
+class blockShadow {}
+{
+  let blockShadow: any;
+  blockShadow = replacement;
+}
+
+class catchShadow {}
+try {
+  throw replacement;
+} catch (catchShadow) {
+  catchShadow = replacement;
+}
+
+class siblingShadow {}
+function localSiblingShadow() {
+  let siblingShadow: any;
+  siblingShadow = replacement;
+}
+
+namespace namespaceOnly {
+  export const member = 1;
+}
+namespaceOnly = replacement;
+
+interface interfaceOnly {}
+interfaceOnly = replacement;
+
+const holder = { Class: class {} };
+holder.Class = replacement;
+`
+
+  _, _, findings := runRuleFindingsSnapshot(t, "no-class-assign", source, nil)
+  expected := markedIdentifierRanges(t, source, "/* report */")
+  if len(findings) != len(expected) {
+    t.Fatalf("expected %d no-class-assign findings, got %d: %#v", len(expected), len(findings), findings)
+  }
+  for index, finding := range findings {
+    want := expected[index]
+    if finding.Rule != "no-class-assign" || finding.Severity != SeverityError ||
+      finding.Pos != want[0] || finding.End != want[1] {
+      t.Fatalf("finding %d range mismatch: got=%+v want=%v", index, finding, want)
+    }
+    name := source[want[0]:want[1]]
+    if expectedMessage := fmt.Sprintf("'%s' is a class.", name); finding.Message != expectedMessage {
+      t.Fatalf("finding %d message mismatch: got=%q want=%q", index, finding.Message, expectedMessage)
+    }
+    if len(finding.Fix) != 0 || len(finding.Suggestions) != 0 {
+      t.Fatalf("finding %d unexpectedly offered edits: %+v", index, finding)
+    }
+  }
 }

--- a/packages/lint/test/rules/functions-classes/no_func_assign_test.go
+++ b/packages/lint/test/rules/functions-classes/no_func_assign_test.go
@@ -112,6 +112,12 @@ namespace merged {
 }
 /* report */merged = replacement;
 
+export function exportedFunction() {}
+/* report */exportedFunction = replacement;
+
+export default function defaultExportedFunction() {}
+/* report */defaultExportedFunction = replacement;
+
 function leftScope() {
   function same() {}
   /* report */same = replacement;

--- a/packages/lint/test/rules/functions-classes/no_func_assign_test.go
+++ b/packages/lint/test/rules/functions-classes/no_func_assign_test.go
@@ -91,8 +91,8 @@ const writeCaptured = (): void => {
   /* report */captured = replacement;
 };
 
-let expression = function namedExpression() {
-  /* report */namedExpression = replacement;
+let expression = function expression() {
+  /* report */expression = replacement;
 };
 expression = replacement;
 

--- a/packages/lint/test/rules/functions-classes/no_func_assign_test.go
+++ b/packages/lint/test/rules/functions-classes/no_func_assign_test.go
@@ -2,7 +2,6 @@ package linthost
 
 import (
   "fmt"
-  "strings"
   "testing"
 )
 
@@ -164,7 +163,7 @@ holder.method = replacement;
 `
 
   _, _, findings := runRuleFindingsSnapshot(t, "no-func-assign", source, nil)
-  expected := noFuncAssignMarkedRanges(t, source)
+  expected := markedIdentifierRanges(t, source, "/* report */")
   if len(findings) != len(expected) {
     t.Fatalf("expected %d no-func-assign findings, got %d: %#v", len(expected), len(findings), findings)
   }
@@ -181,32 +180,5 @@ holder.method = replacement;
     if len(finding.Fix) != 0 || len(finding.Suggestions) != 0 {
       t.Fatalf("finding %d unexpectedly offered edits: %+v", index, finding)
     }
-  }
-}
-
-func noFuncAssignMarkedRanges(t *testing.T, source string) [][2]int {
-  t.Helper()
-  const marker = "/* report */"
-  ranges := make([][2]int, 0)
-  remaining := source
-  consumed := 0
-  for {
-    markerOffset := strings.Index(remaining, marker)
-    if markerOffset < 0 {
-      return ranges
-    }
-    start := consumed + markerOffset + len(marker)
-    end := start
-    for end < len(source) && (source[end] == '_' || source[end] == '$' ||
-      source[end] >= 'a' && source[end] <= 'z' || source[end] >= 'A' && source[end] <= 'Z' ||
-      end > start && source[end] >= '0' && source[end] <= '9') {
-      end++
-    }
-    if end == start {
-      t.Fatalf("marker at byte %d is not followed by an identifier", start-len(marker))
-    }
-    ranges = append(ranges, [2]int{start, end})
-    consumed = end
-    remaining = source[end:]
   }
 }

--- a/packages/lint/test/shared/helpers_test.go
+++ b/packages/lint/test/shared/helpers_test.go
@@ -559,6 +559,38 @@ func runRuleFindingsSnapshot(
   return runRuleFindingsSnapshotFile(t, ruleName, "main.ts", source, options)
 }
 
+// markedIdentifierRanges returns the exact identifier ranges immediately
+// following each marker. Rule tests use the marker-free finding set as their
+// oracle, so an extra, missing, duplicate, or over-wide diagnostic fails.
+func markedIdentifierRanges(t *testing.T, source string, marker string) [][2]int {
+  t.Helper()
+  if marker == "" {
+    t.Fatal("markedIdentifierRanges requires a non-empty marker")
+  }
+  ranges := make([][2]int, 0)
+  remaining := source
+  consumed := 0
+  for {
+    markerOffset := strings.Index(remaining, marker)
+    if markerOffset < 0 {
+      return ranges
+    }
+    start := consumed + markerOffset + len(marker)
+    end := start
+    for end < len(source) && (source[end] == '_' || source[end] == '$' ||
+      source[end] >= 'a' && source[end] <= 'z' || source[end] >= 'A' && source[end] <= 'Z' ||
+      end > start && source[end] >= '0' && source[end] <= '9') {
+      end++
+    }
+    if end == start {
+      t.Fatalf("marker at byte %d is not followed by an identifier", start-len(marker))
+    }
+    ranges = append(ranges, [2]int{start, end})
+    consumed = end
+    remaining = source[end:]
+  }
+}
+
 // runRuleFindingsSnapshotFile selects the lightweight parser or the real
 // Program/checker lifecycle from the configured engine's requirements. Both
 // paths materialize the caller's exact filename and project directory so the

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -834,9 +834,9 @@ function f(x: number) {
 
 ### `no-class-assign`
 
-Reject reassigning a class binding (`class C {}; C = ...`).
+Reject every write to a binding introduced by a class declaration or named class expression.
 
-The declaration name is effectively final; overwriting it silently leaves other call sites pointing at the original class.
+The rule follows lexical binding identity rather than matching names. Same-spelled parameter, catch, block, and sibling bindings remain independent, while direct and compound assignments, updates, destructuring targets, and `for-in`/`for-of` targets all report writes to the actual class binding.
 
 Example:
 


### PR DESCRIPTION
## Intent

Make `no-class-assign` report writes to the actual class binding instead of matching class names across an entire file.

## Root cause

The rule collected class declaration names as strings and only inspected bare binary-assignment identifiers. That conflated unrelated lexical shadows and missed updates, destructuring, loop targets, named class expressions, and TypeScript declaration merges.

## Changes

- require a real TypeScript checker and canonicalize merged value symbols
- collect bindings introduced by class declarations and named class expressions
- reuse one shared write-target surface for assignment operators, updates, nested destructuring, `for-in`/`for-of`, shorthand values, and TypeScript assertion wrappers
- preserve exact identifier diagnostic ranges and suppress duplicate visits from destructuring defaults
- remove the obsolete file-wide name-map implementation
- document the full binding/write contract

## Regression shield

The exact finding-set test covers direct, compound, logical, update, destructuring, loop, wrapper, hoisted, class-body, static-block, closure, named-expression, ambient, namespace/interface-merged, exported, and sibling-scope positives. It pins parameter, method-local, block, catch, loop, sibling, anonymous-expression holder, namespace-only, interface-only, and property writes as clean twins.

## Validation plan

Per the requested workflow, focused local tests and the lint build will run only after three sequential exhaustive whole-PR reviews at one exact HEAD. No formatter will be run.

Closes #500