### PR TITLE
fix(lint): honor configured no-restricted-syntax selectors

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -292,7 +292,7 @@ Source: [ESLint core rules](https://eslint.org/docs/latest/rules/).
 - [`no-redeclare`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-redeclare.ts): rejects redeclaring a binding in the same scope.
 - [`no-regex-spaces`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-regex-spaces.ts): rejects repeated literal spaces in regexes.
 - [`no-restricted-imports`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-restricted-imports.ts): reject static imports and re-exports selected by user-configured exact paths, gitignore-style groups, or regular expressions.
-- [`no-restricted-syntax`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-restricted-syntax.ts): reject AST node kinds listed in the project denylist.
+- [`no-restricted-syntax`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-restricted-syntax.ts): reject only syntax matching the project's configured TypeScript-Go AST selectors; no selectors means no restrictions.
 - [`no-return-assign`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-return-assign.ts): rejects assignments in `return`.
 - [`no-script-url`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-script-url.ts): rejects `javascript:` URLs.
 - [`no-self-assign`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-self-assign.ts): rejects assignments to the same value.

--- a/packages/lint/linthost/ast_selector_matcher.go
+++ b/packages/lint/linthost/ast_selector_matcher.go
@@ -1,12 +1,12 @@
 package linthost
 
 import (
-  "fmt"
   "math"
   "strconv"
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
 
 // matchASTSelector returns every node selected below root. A configured
@@ -275,6 +275,19 @@ func astSelectorMatchesNodeType(node *shimast.Node, requested string) bool {
     }
     expression := node.AsBinaryExpression()
     return expression != nil && expression.OperatorToken != nil && isAssignmentOperator(expression.OperatorToken.Kind)
+  case "logicalexpression":
+    if node.Kind != shimast.KindBinaryExpression {
+      return false
+    }
+    expression := node.AsBinaryExpression()
+    if expression == nil || expression.OperatorToken == nil {
+      return false
+    }
+    switch expression.OperatorToken.Kind {
+    case shimast.KindAmpersandAmpersandToken, shimast.KindBarBarToken, shimast.KindQuestionQuestionToken:
+      return true
+    }
+    return false
   case "updateexpression":
     if node.Kind == shimast.KindPrefixUnaryExpression {
       expression := node.AsPrefixUnaryExpression()
@@ -286,21 +299,31 @@ func astSelectorMatchesNodeType(node *shimast.Node, requested string) bool {
     }
     return false
   case "unaryexpression":
-    return node.Kind == shimast.KindPrefixUnaryExpression ||
-      node.Kind == shimast.KindDeleteExpression ||
+    if node.Kind == shimast.KindPrefixUnaryExpression {
+      expression := node.AsPrefixUnaryExpression()
+      return expression != nil && expression.Operator != shimast.KindPlusPlusToken && expression.Operator != shimast.KindMinusMinusToken
+    }
+    return node.Kind == shimast.KindDeleteExpression ||
       node.Kind == shimast.KindTypeOfExpression ||
       node.Kind == shimast.KindVoidExpression
   case "literal":
     return astSelectorIsLiteral(node)
+  case "thisexpression":
+    return node.Kind == shimast.KindThisKeyword
+  case "super":
+    return node.Kind == shimast.KindSuperKeyword
+  case "templateliteral":
+    return node.Kind == shimast.KindTemplateExpression || node.Kind == shimast.KindNoSubstitutionTemplateLiteral
   case "property":
     switch node.Kind {
     case shimast.KindPropertyAssignment,
       shimast.KindShorthandPropertyAssignment,
-      shimast.KindSpreadAssignment,
-      shimast.KindMethodDeclaration,
+      shimast.KindSpreadAssignment:
+      return true
+    case shimast.KindMethodDeclaration,
       shimast.KindGetAccessor,
       shimast.KindSetAccessor:
-      return true
+      return node.Parent != nil && node.Parent.Kind == shimast.KindObjectLiteralExpression
     }
   case "restelement":
     return node.Kind == shimast.KindSpreadElement || node.Kind == shimast.KindSpreadAssignment ||
@@ -338,7 +361,8 @@ func astSelectorIsLiteral(node *shimast.Node) bool {
 func astSelectorMatchesClass(node *shimast.Node, class string) bool {
   switch strings.ToLower(class) {
   case "statement":
-    return node.Kind >= shimast.KindFirstStatement && node.Kind <= shimast.KindLastStatement
+    native := strings.TrimPrefix(node.Kind.String(), "Kind")
+    return strings.HasSuffix(native, "Statement") || strings.HasSuffix(native, "Declaration")
   case "expression":
     return astSelectorIsExpression(node)
   case "declaration":
@@ -346,7 +370,7 @@ func astSelectorMatchesClass(node *shimast.Node, class string) bool {
   case "function":
     return isFunctionLikeKind(node)
   case "pattern":
-    return astSelectorIsPattern(node)
+    return astSelectorIsPattern(node) || astSelectorIsExpression(node)
   default:
     return false
   }
@@ -356,67 +380,35 @@ func astSelectorIsExpression(node *shimast.Node) bool {
   if node == nil {
     return false
   }
-  if astSelectorIsLiteral(node) {
+  native := strings.TrimPrefix(node.Kind.String(), "Kind")
+  if strings.HasSuffix(native, "Expression") || strings.HasSuffix(native, "Literal") {
     return true
   }
-  if node.Kind == shimast.KindIdentifier || node.Kind == shimast.KindPrivateIdentifier ||
-    node.Kind == shimast.KindThisKeyword || node.Kind == shimast.KindSuperKeyword {
+  switch node.Kind {
+  case shimast.KindIdentifier:
+    return node.Parent == nil || node.Parent.Kind != shimast.KindMetaProperty
+  case shimast.KindPrivateIdentifier,
+    shimast.KindMetaProperty,
+    shimast.KindThisKeyword,
+    shimast.KindSuperKeyword,
+    shimast.KindArrowFunction:
     return true
   }
-  return node.Kind >= shimast.KindArrayLiteralExpression && node.Kind <= shimast.KindSatisfiesExpression
+  return false
 }
 
 func astSelectorIsDeclaration(node *shimast.Node) bool {
   if node == nil {
     return false
   }
-  switch node.Kind {
-  case shimast.KindTypeParameter,
-    shimast.KindParameter,
-    shimast.KindPropertySignature,
-    shimast.KindPropertyDeclaration,
-    shimast.KindMethodSignature,
-    shimast.KindMethodDeclaration,
-    shimast.KindConstructor,
-    shimast.KindGetAccessor,
-    shimast.KindSetAccessor,
-    shimast.KindCallSignature,
-    shimast.KindConstructSignature,
-    shimast.KindIndexSignature,
-    shimast.KindVariableDeclaration,
-    shimast.KindFunctionDeclaration,
-    shimast.KindClassDeclaration,
-    shimast.KindInterfaceDeclaration,
-    shimast.KindTypeAliasDeclaration,
-    shimast.KindEnumDeclaration,
-    shimast.KindModuleDeclaration,
-    shimast.KindImportEqualsDeclaration,
-    shimast.KindImportDeclaration,
-    shimast.KindImportClause,
-    shimast.KindNamespaceImport,
-    shimast.KindImportSpecifier,
-    shimast.KindExportDeclaration,
-    shimast.KindExportSpecifier,
-    shimast.KindEnumMember,
-    shimast.KindBindingElement:
-    return true
-  }
-  return false
+  return strings.HasSuffix(strings.TrimPrefix(node.Kind.String(), "Kind"), "Declaration")
 }
 
 func astSelectorIsPattern(node *shimast.Node) bool {
   if node == nil {
     return false
   }
-  switch node.Kind {
-  case shimast.KindObjectBindingPattern, shimast.KindArrayBindingPattern, shimast.KindBindingElement:
-    return true
-  case shimast.KindIdentifier:
-    parent := node.Parent
-    return parent != nil && (parent.Kind == shimast.KindObjectBindingPattern ||
-      parent.Kind == shimast.KindArrayBindingPattern || parent.Kind == shimast.KindBindingElement)
-  }
-  return false
+  return strings.HasSuffix(strings.TrimPrefix(node.Kind.String(), "Kind"), "Pattern")
 }
 
 type astSelectorRuntimeValueKind uint8
@@ -426,7 +418,9 @@ const (
   astSelectorRuntimeNull
   astSelectorRuntimeString
   astSelectorRuntimeNumber
+  astSelectorRuntimeBigInt
   astSelectorRuntimeBoolean
+  astSelectorRuntimeObject
   astSelectorRuntimeNode
   astSelectorRuntimeNodes
 )
@@ -448,6 +442,9 @@ func astSelectorMatchesAttribute(node *shimast.Node, selector *astSelector) bool
   matched := false
   switch selector.value.kind {
   case astSelectorValueRegexp:
+    if selector.operator == "!=" {
+      return selector.value.regexp == nil || !selector.value.regexp.MatchString(astSelectorRuntimeStringValue(value))
+    }
     matched = value.kind == astSelectorRuntimeString && selector.value.regexp != nil && selector.value.regexp.MatchString(value.text)
   case astSelectorValueType:
     matched = selector.value.literal == astSelectorRuntimeType(value)
@@ -467,6 +464,19 @@ func astSelectorMatchesAttribute(node *shimast.Node, selector *astSelector) bool
 }
 
 func astSelectorCompare(value astSelectorRuntimeValue, expected astSelectorValue, operator string) bool {
+  if value.kind == astSelectorRuntimeString && expected.number == nil {
+    switch operator {
+    case ">":
+      return value.text > expected.literal
+    case ">=":
+      return value.text >= expected.literal
+    case "<":
+      return value.text < expected.literal
+    case "<=":
+      return value.text <= expected.literal
+    }
+    return false
+  }
   left, leftNumber := astSelectorRuntimeNumberValue(value)
   right := 0.0
   rightNumber := false
@@ -499,9 +509,11 @@ func astSelectorRuntimeType(value astSelectorRuntimeValue) string {
     return "string"
   case astSelectorRuntimeNumber:
     return "number"
+  case astSelectorRuntimeBigInt:
+    return "bigint"
   case astSelectorRuntimeBoolean:
     return "boolean"
-  case astSelectorRuntimeNode, astSelectorRuntimeNodes, astSelectorRuntimeNull:
+  case astSelectorRuntimeObject, astSelectorRuntimeNode, astSelectorRuntimeNodes, astSelectorRuntimeNull:
     return "object"
   default:
     return "undefined"
@@ -514,12 +526,19 @@ func astSelectorRuntimeStringValue(value astSelectorRuntimeValue) string {
     return value.text
   case astSelectorRuntimeNumber:
     return strconv.FormatFloat(value.number, 'g', -1, 64)
+  case astSelectorRuntimeBigInt:
+    return value.text
   case astSelectorRuntimeBoolean:
     return strconv.FormatBool(value.boolean)
   case astSelectorRuntimeNull:
     return "null"
   case astSelectorRuntimeMissing:
     return "undefined"
+  case astSelectorRuntimeNodes:
+    if len(value.nodes) == 0 {
+      return ""
+    }
+    return strings.TrimSuffix(strings.Repeat("[object Object],", len(value.nodes)), ",")
   }
   return "[object Object]"
 }
@@ -536,6 +555,8 @@ func astSelectorRuntimeNumberValue(value astSelectorRuntimeValue) (float64, bool
       return 1, true
     }
     return 0, true
+  case astSelectorRuntimeNull:
+    return 0, true
   }
   return 0, false
 }
@@ -547,10 +568,15 @@ func astSelectorPathValue(value astSelectorRuntimeValue, path []string) astSelec
     case astSelectorRuntimeNode:
       current = astSelectorNodeProperty(current.node, field)
     case astSelectorRuntimeNodes:
-      if field != "length" {
+      if field == "length" {
+        current = astSelectorRuntimeValue{kind: astSelectorRuntimeNumber, number: float64(len(current.nodes))}
+        continue
+      }
+      index, err := strconv.Atoi(field)
+      if err != nil || index < 0 || index >= len(current.nodes) {
         return astSelectorRuntimeValue{}
       }
-      current = astSelectorRuntimeValue{kind: astSelectorRuntimeNumber, number: float64(len(current.nodes))}
+      current = astSelectorNode(current.nodes[index])
     case astSelectorRuntimeString:
       if field != "length" {
         return astSelectorRuntimeValue{}
@@ -605,21 +631,36 @@ func astSelectorNodeProperty(node *shimast.Node, field string) astSelectorRuntim
     if name := identifierText(node); name != "" {
       return astSelectorString(name)
     }
-    if name := identifierText(node.Name()); name != "" {
+    if node.Kind == shimast.KindPrivateIdentifier {
+      return astSelectorString(node.AsPrivateIdentifier().Text)
+    }
+    nameNode := node.Name()
+    if name := identifierText(nameNode); name != "" {
       return astSelectorString(name)
     }
-    return astSelectorRuntimeValue{kind: astSelectorRuntimeNull}
-  case "value", "raw":
-    if text := literalText(node); text != "" || node.Kind == shimast.KindStringLiteral || node.Kind == shimast.KindNoSubstitutionTemplateLiteral {
-      return astSelectorString(text)
+    if nameNode != nil && nameNode.Kind == shimast.KindPrivateIdentifier {
+      return astSelectorString(nameNode.AsPrivateIdentifier().Text)
     }
-    switch node.Kind {
-    case shimast.KindTrueKeyword:
-      return astSelectorBoolean(true)
-    case shimast.KindFalseKeyword:
-      return astSelectorBoolean(false)
-    case shimast.KindNullKeyword:
-      return astSelectorRuntimeValue{kind: astSelectorRuntimeNull}
+    if value := astSelectorLiteralValue(nameNode); value.kind != astSelectorRuntimeMissing {
+      return value
+    }
+    return astSelectorRuntimeValue{kind: astSelectorRuntimeNull}
+  case "value":
+    if node.Kind == shimast.KindPropertyAssignment {
+      return astSelectorNode(node.AsPropertyAssignment().Initializer)
+    }
+    if node.Kind == shimast.KindShorthandPropertyAssignment {
+      return astSelectorNode(node.AsShorthandPropertyAssignment().Name())
+    }
+    if node.Kind == shimast.KindBindingElement {
+      return astSelectorNode(node.Name())
+    }
+    return astSelectorLiteralValue(node)
+  case "raw":
+    if astSelectorIsLiteral(node) {
+      if file := shimast.GetSourceFileOfNode(node); file != nil {
+        return astSelectorString(nodeText(file, node))
+      }
     }
     return astSelectorRuntimeValue{}
   case "operator":
@@ -633,28 +674,65 @@ func astSelectorNodeProperty(node *shimast.Node, field string) astSelectorRuntim
     }
     return astSelectorRuntimeValue{}
   case "async":
+    if node.FunctionLikeData() == nil {
+      return astSelectorRuntimeValue{}
+    }
     return astSelectorBoolean(hasModifier(node, shimast.KindAsyncKeyword))
   case "generator":
+    if node.FunctionLikeData() == nil {
+      return astSelectorRuntimeValue{}
+    }
     return astSelectorBoolean(astSelectorIsGenerator(node))
   case "static":
+    if !astSelectorSupportsStatic(node) {
+      return astSelectorRuntimeValue{}
+    }
+    if node.Kind == shimast.KindClassStaticBlockDeclaration {
+      return astSelectorBoolean(true)
+    }
     return astSelectorBoolean(hasModifier(node, shimast.KindStaticKeyword))
   case "readonly":
+    if !astSelectorSupportsReadonly(node) {
+      return astSelectorRuntimeValue{}
+    }
     return astSelectorBoolean(hasModifier(node, shimast.KindReadonlyKeyword))
   case "declare":
+    if !astSelectorIsDeclaration(node) {
+      return astSelectorRuntimeValue{}
+    }
     return astSelectorBoolean(hasModifier(node, shimast.KindDeclareKeyword))
   case "optional":
-    return astSelectorBoolean(astSelectorIsOptional(node))
+    optional, applicable := astSelectorIsOptional(node)
+    if !applicable {
+      return astSelectorRuntimeValue{}
+    }
+    return astSelectorBoolean(optional)
   case "computed":
-    return astSelectorBoolean(node.Kind == shimast.KindElementAccessExpression || node.Kind == shimast.KindComputedPropertyName)
+    computed, applicable := astSelectorIsComputed(node)
+    if !applicable {
+      return astSelectorRuntimeValue{}
+    }
+    return astSelectorBoolean(computed)
+  case "prefix":
+    switch node.Kind {
+    case shimast.KindPrefixUnaryExpression,
+      shimast.KindDeleteExpression,
+      shimast.KindTypeOfExpression,
+      shimast.KindVoidExpression:
+      return astSelectorBoolean(true)
+    case shimast.KindPostfixUnaryExpression:
+      return astSelectorBoolean(false)
+    }
+    return astSelectorRuntimeValue{}
   case "id":
     return astSelectorNode(node.Name())
   case "params":
-    if isFunctionLikeKind(node) {
-      return astSelectorNodes(node.Parameters())
+    if function := node.FunctionLikeData(); function != nil && function.Parameters != nil {
+      return astSelectorNodes(function.Parameters.Nodes)
     }
   case "body":
-    if isFunctionLikeKind(node) {
-      return astSelectorNode(node.Body())
+    if body := node.Body(); body != nil {
+      return astSelectorNode(body)
     }
     return astSelectorStatementBody(node)
   case "callee":
@@ -720,6 +798,12 @@ func astSelectorNodeProperty(node *shimast.Node, field string) astSelectorRuntim
     if node.Kind == shimast.KindConditionalExpression {
       return astSelectorNode(node.AsConditionalExpression().WhenTrue)
     }
+    if node.Kind == shimast.KindCaseClause || node.Kind == shimast.KindDefaultClause {
+      clause := node.AsCaseOrDefaultClause()
+      if clause != nil && clause.Statements != nil {
+        return astSelectorNodes(clause.Statements.Nodes)
+      }
+    }
   case "alternate":
     if node.Kind == shimast.KindIfStatement {
       return astSelectorNode(node.AsIfStatement().ElseStatement)
@@ -774,6 +858,12 @@ func astSelectorNodeProperty(node *shimast.Node, field string) astSelectorRuntim
         return astSelectorNodes(expression.Properties.Nodes)
       }
     }
+    if node.Kind == shimast.KindObjectBindingPattern {
+      pattern := node.AsBindingPattern()
+      if pattern != nil && pattern.Elements != nil {
+        return astSelectorNodes(pattern.Elements.Nodes)
+      }
+    }
   case "key":
     return astSelectorPropertyKey(node)
   case "source":
@@ -795,6 +885,44 @@ func astSelectorString(value string) astSelectorRuntimeValue {
 
 func astSelectorBoolean(value bool) astSelectorRuntimeValue {
   return astSelectorRuntimeValue{kind: astSelectorRuntimeBoolean, boolean: value}
+}
+
+func astSelectorLiteralValue(node *shimast.Node) astSelectorRuntimeValue {
+  if node == nil {
+    return astSelectorRuntimeValue{kind: astSelectorRuntimeNull}
+  }
+  switch node.Kind {
+  case shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral:
+    if data := node.LiteralLikeData(); data != nil {
+      return astSelectorString(data.Text)
+    }
+  case shimast.KindRegularExpressionLiteral:
+    return astSelectorRuntimeValue{kind: astSelectorRuntimeObject}
+  case shimast.KindNumericLiteral:
+    if data := node.LiteralLikeData(); data != nil {
+      text := strings.ReplaceAll(data.Text, "_", "")
+      if number, err := strconv.ParseFloat(text, 64); err == nil {
+        return astSelectorRuntimeValue{kind: astSelectorRuntimeNumber, number: number}
+      }
+      if number, err := strconv.ParseUint(text, 0, 64); err == nil {
+        return astSelectorRuntimeValue{kind: astSelectorRuntimeNumber, number: float64(number)}
+      }
+    }
+  case shimast.KindBigIntLiteral:
+    if data := node.LiteralLikeData(); data != nil {
+      return astSelectorRuntimeValue{
+        kind: astSelectorRuntimeBigInt,
+        text: strings.TrimSuffix(strings.ReplaceAll(data.Text, "_", ""), "n"),
+      }
+    }
+  case shimast.KindTrueKeyword:
+    return astSelectorBoolean(true)
+  case shimast.KindFalseKeyword:
+    return astSelectorBoolean(false)
+  case shimast.KindNullKeyword:
+    return astSelectorRuntimeValue{kind: astSelectorRuntimeNull}
+  }
+  return astSelectorRuntimeValue{}
 }
 
 func astSelectorNode(node *shimast.Node) astSelectorRuntimeValue {
@@ -836,54 +964,7 @@ func astSelectorNodeOperator(node *shimast.Node) string {
 }
 
 func astSelectorOperatorText(kind shimast.Kind) string {
-  operators := map[shimast.Kind]string{
-    shimast.KindEqualsToken:                       "=",
-    shimast.KindPlusToken:                         "+",
-    shimast.KindMinusToken:                        "-",
-    shimast.KindAsteriskToken:                     "*",
-    shimast.KindAsteriskAsteriskToken:             "**",
-    shimast.KindSlashToken:                        "/",
-    shimast.KindPercentToken:                      "%",
-    shimast.KindPlusPlusToken:                     "++",
-    shimast.KindMinusMinusToken:                   "--",
-    shimast.KindLessThanToken:                     "<",
-    shimast.KindLessThanEqualsToken:               "<=",
-    shimast.KindGreaterThanToken:                  ">",
-    shimast.KindGreaterThanEqualsToken:            ">=",
-    shimast.KindEqualsEqualsToken:                 "==",
-    shimast.KindExclamationEqualsToken:            "!=",
-    shimast.KindEqualsEqualsEqualsToken:           "===",
-    shimast.KindExclamationEqualsEqualsToken:      "!==",
-    shimast.KindLessThanLessThanToken:              "<<",
-    shimast.KindGreaterThanGreaterThanToken:        ">>",
-    shimast.KindGreaterThanGreaterThanGreaterThanToken: ">>>",
-    shimast.KindAmpersandToken:                    "&",
-    shimast.KindBarToken:                          "|",
-    shimast.KindCaretToken:                        "^",
-    shimast.KindExclamationToken:                  "!",
-    shimast.KindTildeToken:                        "~",
-    shimast.KindAmpersandAmpersandToken:           "&&",
-    shimast.KindBarBarToken:                       "||",
-    shimast.KindQuestionQuestionToken:             "??",
-    shimast.KindInKeyword:                         "in",
-    shimast.KindInstanceOfKeyword:                 "instanceof",
-    shimast.KindPlusEqualsToken:                   "+=",
-    shimast.KindMinusEqualsToken:                  "-=",
-    shimast.KindAsteriskEqualsToken:               "*=",
-    shimast.KindAsteriskAsteriskEqualsToken:       "**=",
-    shimast.KindSlashEqualsToken:                  "/=",
-    shimast.KindPercentEqualsToken:                "%=",
-    shimast.KindLessThanLessThanEqualsToken:       "<<=",
-    shimast.KindGreaterThanGreaterThanEqualsToken: ">>=",
-    shimast.KindGreaterThanGreaterThanGreaterThanEqualsToken: ">>>=",
-    shimast.KindAmpersandEqualsToken:              "&=",
-    shimast.KindBarEqualsToken:                    "|=",
-    shimast.KindCaretEqualsToken:                  "^=",
-    shimast.KindBarBarEqualsToken:                 "||=",
-    shimast.KindAmpersandAmpersandEqualsToken:     "&&=",
-    shimast.KindQuestionQuestionEqualsToken:       "??=",
-  }
-  return operators[kind]
+  return shimscanner.TokenToString(kind)
 }
 
 func astSelectorVariableKind(node *shimast.Node) string {
@@ -926,19 +1007,91 @@ func astSelectorIsGenerator(node *shimast.Node) bool {
   return body != nil && body.AsteriskToken != nil
 }
 
-func astSelectorIsOptional(node *shimast.Node) bool {
+func astSelectorIsOptional(node *shimast.Node) (bool, bool) {
+  if node == nil {
+    return false, false
+  }
+  switch node.Kind {
+  case shimast.KindPropertyAccessExpression:
+    return node.AsPropertyAccessExpression().QuestionDotToken != nil, true
+  case shimast.KindElementAccessExpression:
+    return node.AsElementAccessExpression().QuestionDotToken != nil, true
+  case shimast.KindCallExpression:
+    return node.AsCallExpression().QuestionDotToken != nil, true
+  case shimast.KindTaggedTemplateExpression:
+    return node.AsTaggedTemplateExpression().QuestionDotToken != nil, true
+  case shimast.KindParameter,
+    shimast.KindNamedTupleMember,
+    shimast.KindMethodDeclaration,
+    shimast.KindShorthandPropertyAssignment,
+    shimast.KindMethodSignature,
+    shimast.KindPropertySignature,
+    shimast.KindPropertyAssignment,
+    shimast.KindPropertyDeclaration,
+    shimast.KindEnumMember,
+    shimast.KindGetAccessor,
+    shimast.KindSetAccessor:
+    return node.QuestionToken() != nil, true
+  }
+  return false, false
+}
+
+func astSelectorSupportsStatic(node *shimast.Node) bool {
   if node == nil {
     return false
   }
   switch node.Kind {
-  case shimast.KindPropertyAccessExpression:
-    return node.AsPropertyAccessExpression().QuestionDotToken != nil
-  case shimast.KindElementAccessExpression:
-    return node.AsElementAccessExpression().QuestionDotToken != nil
-  case shimast.KindCallExpression:
-    return node.AsCallExpression().QuestionDotToken != nil
+  case shimast.KindClassStaticBlockDeclaration:
+    return true
+  case shimast.KindPropertyDeclaration,
+    shimast.KindMethodDeclaration,
+    shimast.KindGetAccessor,
+    shimast.KindSetAccessor:
+    return node.Parent != nil &&
+      (node.Parent.Kind == shimast.KindClassDeclaration || node.Parent.Kind == shimast.KindClassExpression)
   }
   return false
+}
+
+func astSelectorSupportsReadonly(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  switch node.Kind {
+  case shimast.KindParameter,
+    shimast.KindPropertyDeclaration,
+    shimast.KindPropertySignature,
+    shimast.KindIndexSignature:
+    return true
+  }
+  return false
+}
+
+func astSelectorIsComputed(node *shimast.Node) (bool, bool) {
+  if node == nil {
+    return false, false
+  }
+  switch node.Kind {
+  case shimast.KindElementAccessExpression, shimast.KindComputedPropertyName:
+    return true, true
+  case shimast.KindPropertyAccessExpression:
+    return false, true
+  case shimast.KindBindingElement:
+    element := node.AsBindingElement()
+    return element != nil && element.PropertyName != nil && element.PropertyName.Kind == shimast.KindComputedPropertyName, true
+  case shimast.KindPropertyAssignment,
+    shimast.KindShorthandPropertyAssignment,
+    shimast.KindMethodDeclaration,
+    shimast.KindMethodSignature,
+    shimast.KindGetAccessor,
+    shimast.KindSetAccessor,
+    shimast.KindPropertyDeclaration,
+    shimast.KindPropertySignature,
+    shimast.KindEnumMember:
+    name := node.Name()
+    return name != nil && name.Kind == shimast.KindComputedPropertyName, true
+  }
+  return false, false
 }
 
 func astSelectorStatementBody(node *shimast.Node) astSelectorRuntimeValue {
@@ -946,6 +1099,21 @@ func astSelectorStatementBody(node *shimast.Node) astSelectorRuntimeValue {
     return astSelectorRuntimeValue{}
   }
   switch node.Kind {
+  case shimast.KindSourceFile:
+    file := node.AsSourceFile()
+    if file != nil && file.Statements != nil {
+      return astSelectorNodes(file.Statements.Nodes)
+    }
+  case shimast.KindBlock:
+    block := node.AsBlock()
+    if block != nil && block.Statements != nil {
+      return astSelectorNodes(block.Statements.Nodes)
+    }
+  case shimast.KindModuleBlock:
+    block := node.AsModuleBlock()
+    if block != nil && block.Statements != nil {
+      return astSelectorNodes(block.Statements.Nodes)
+    }
   case shimast.KindIfStatement:
     return astSelectorNode(node.AsIfStatement().ThenStatement)
   case shimast.KindWhileStatement:
@@ -973,6 +1141,14 @@ func astSelectorUnaryArgument(node *shimast.Node) astSelectorRuntimeValue {
     return astSelectorNode(node.AsPostfixUnaryExpression().Operand)
   case shimast.KindDeleteExpression:
     return astSelectorNode(node.AsDeleteExpression().Expression)
+  case shimast.KindTypeOfExpression:
+    return astSelectorNode(node.AsTypeOfExpression().Expression)
+  case shimast.KindVoidExpression:
+    return astSelectorNode(node.AsVoidExpression().Expression)
+  case shimast.KindAwaitExpression:
+    return astSelectorNode(node.AsAwaitExpression().Expression)
+  case shimast.KindYieldExpression:
+    return astSelectorNode(node.AsYieldExpression().Expression)
   case shimast.KindReturnStatement:
     return astSelectorNode(node.AsReturnStatement().Expression)
   case shimast.KindThrowStatement:
@@ -981,6 +1157,11 @@ func astSelectorUnaryArgument(node *shimast.Node) astSelectorRuntimeValue {
     return astSelectorNode(node.AsSpreadElement().Expression)
   case shimast.KindSpreadAssignment:
     return astSelectorNode(node.AsSpreadAssignment().Expression)
+  case shimast.KindBindingElement:
+    element := node.AsBindingElement()
+    if element != nil && element.DotDotDotToken != nil {
+      return astSelectorNode(element.Name())
+    }
   }
   return astSelectorRuntimeValue{}
 }
@@ -1075,11 +1256,4 @@ func astSelectorStatements(node *shimast.Node) astSelectorRuntimeValue {
     }
   }
   return astSelectorRuntimeValue{}
-}
-
-func (selector *astSelector) String() string {
-  if selector == nil {
-    return "<nil>"
-  }
-  return fmt.Sprintf("astSelector(kind=%d,name=%q)", selector.kind, selector.name)
 }

--- a/packages/lint/linthost/ast_selector_matcher.go
+++ b/packages/lint/linthost/ast_selector_matcher.go
@@ -1,0 +1,1085 @@
+package linthost
+
+import (
+  "fmt"
+  "math"
+  "strconv"
+  "strings"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// matchASTSelector returns every node selected below root. A configured
+// selector reports each node once even when multiple alternatives or subject
+// paths reach it.
+func matchASTSelector(root *shimast.Node, selector *astSelector) []*shimast.Node {
+  if root == nil || selector == nil {
+    return nil
+  }
+  subjects := astSelectorSubjects(selector, selector)
+  selected := make(map[*shimast.Node]struct{})
+  ordered := make([]*shimast.Node, 0)
+  walkDescendants(root, func(node *shimast.Node) {
+    if !astSelectorMatchesNode(node, selector, nil) {
+      return
+    }
+    if len(subjects) == 0 {
+      if _, duplicate := selected[node]; !duplicate {
+        selected[node] = struct{}{}
+        ordered = append(ordered, node)
+      }
+      return
+    }
+    for candidate := node; candidate != nil; candidate = selectorParent(candidate) {
+      for _, subject := range subjects {
+        if !astSelectorMatchesNode(candidate, subject, nil) {
+          continue
+        }
+        if _, duplicate := selected[candidate]; !duplicate {
+          selected[candidate] = struct{}{}
+          ordered = append(ordered, candidate)
+        }
+        break
+      }
+    }
+  })
+  return ordered
+}
+
+func astSelectorSubjects(selector, ancestor *astSelector) []*astSelector {
+  if selector == nil {
+    return nil
+  }
+  subjects := make([]*astSelector, 0)
+  if selector.subject {
+    subjects = append(subjects, ancestor)
+  }
+  if selector.left != nil {
+    subjects = append(subjects, astSelectorSubjects(selector.left, selector.left)...)
+  }
+  if selector.right != nil {
+    subjects = append(subjects, astSelectorSubjects(selector.right, ancestor)...)
+  }
+  for _, child := range selector.selectors {
+    subjects = append(subjects, astSelectorSubjects(child, ancestor)...)
+  }
+  return subjects
+}
+
+func astSelectorMatchesNode(node *shimast.Node, selector *astSelector, scopeRoot *shimast.Node) bool {
+  if node == nil || selector == nil {
+    return false
+  }
+  switch selector.kind {
+  case astSelectorWildcard:
+    return true
+  case astSelectorNodeType:
+    return astSelectorMatchesNodeType(node, selector.name)
+  case astSelectorExactNode:
+    return scopeRoot != nil && node == scopeRoot
+  case astSelectorAttribute:
+    return astSelectorMatchesAttribute(node, selector)
+  case astSelectorField:
+    return astSelectorMatchesField(node, selector.name)
+  case astSelectorMatches:
+    for _, alternative := range selector.selectors {
+      if astSelectorMatchesNode(node, alternative, scopeRoot) {
+        return true
+      }
+    }
+    return false
+  case astSelectorCompound:
+    for _, part := range selector.selectors {
+      if !astSelectorMatchesNode(node, part, scopeRoot) {
+        return false
+      }
+    }
+    return true
+  case astSelectorNot:
+    for _, excluded := range selector.selectors {
+      if astSelectorMatchesNode(node, excluded, scopeRoot) {
+        return false
+      }
+    }
+    return true
+  case astSelectorHas:
+    found := false
+    walkDescendants(node, func(candidate *shimast.Node) {
+      if found {
+        return
+      }
+      for _, nested := range selector.selectors {
+        if astSelectorMatchesNode(candidate, nested, node) {
+          found = true
+          return
+        }
+      }
+    })
+    return found
+  case astSelectorChild:
+    parent := selectorParent(node)
+    return parent != nil &&
+      astSelectorMatchesNode(node, selector.right, scopeRoot) &&
+      astSelectorMatchesNode(parent, selector.left, scopeRoot)
+  case astSelectorDescendant:
+    if !astSelectorMatchesNode(node, selector.right, scopeRoot) {
+      return false
+    }
+    for parent := selectorParent(node); parent != nil; parent = selectorParent(parent) {
+      if astSelectorMatchesNode(parent, selector.left, scopeRoot) {
+        return true
+      }
+      if scopeRoot != nil && parent == scopeRoot {
+        break
+      }
+    }
+    return false
+  case astSelectorSibling:
+    if astSelectorMatchesNode(node, selector.right, scopeRoot) {
+      for _, sibling := range selectorSiblings(node, false) {
+        if astSelectorMatchesNode(sibling, selector.left, scopeRoot) {
+          return true
+        }
+      }
+    }
+    if selector.left != nil && selector.left.subject && astSelectorMatchesNode(node, selector.left, scopeRoot) {
+      for _, sibling := range selectorSiblings(node, true) {
+        if astSelectorMatchesNode(sibling, selector.right, scopeRoot) {
+          return true
+        }
+      }
+    }
+    return false
+  case astSelectorAdjacent:
+    if astSelectorMatchesNode(node, selector.right, scopeRoot) {
+      if sibling := selectorAdjacent(node, false); sibling != nil {
+        return astSelectorMatchesNode(sibling, selector.left, scopeRoot)
+      }
+    }
+    if selector.left != nil && selector.left.subject && astSelectorMatchesNode(node, selector.left, scopeRoot) {
+      if sibling := selectorAdjacent(node, true); sibling != nil {
+        return astSelectorMatchesNode(sibling, selector.right, scopeRoot)
+      }
+    }
+    return false
+  case astSelectorNthChild:
+    return selectorChildIndex(node, false) == selector.index
+  case astSelectorNthLastChild:
+    return selectorChildIndex(node, true) == selector.index
+  case astSelectorClass:
+    return astSelectorMatchesClass(node, selector.name)
+  }
+  return false
+}
+
+func selectorParent(node *shimast.Node) *shimast.Node {
+  if node == nil {
+    return nil
+  }
+  return node.Parent
+}
+
+func selectorChildren(node *shimast.Node) []*shimast.Node {
+  if node == nil {
+    return nil
+  }
+  children := make([]*shimast.Node, 0)
+  node.ForEachChild(func(child *shimast.Node) bool {
+    if child != nil {
+      children = append(children, child)
+    }
+    return false
+  })
+  return children
+}
+
+func selectorSiblings(node *shimast.Node, following bool) []*shimast.Node {
+  parent := selectorParent(node)
+  if parent == nil {
+    return nil
+  }
+  children := selectorChildren(parent)
+  index := -1
+  for i, child := range children {
+    if child == node {
+      index = i
+      break
+    }
+  }
+  if index < 0 {
+    return nil
+  }
+  if following {
+    return children[index+1:]
+  }
+  return children[:index]
+}
+
+func selectorAdjacent(node *shimast.Node, following bool) *shimast.Node {
+  siblings := selectorSiblings(node, following)
+  if len(siblings) == 0 {
+    return nil
+  }
+  if following {
+    return siblings[0]
+  }
+  return siblings[len(siblings)-1]
+}
+
+func selectorChildIndex(node *shimast.Node, fromEnd bool) int {
+  parent := selectorParent(node)
+  if parent == nil {
+    return 0
+  }
+  children := selectorChildren(parent)
+  for index, child := range children {
+    if child != node {
+      continue
+    }
+    if fromEnd {
+      return len(children) - index
+    }
+    return index + 1
+  }
+  return 0
+}
+
+func astSelectorMatchesNodeType(node *shimast.Node, requested string) bool {
+  if node == nil {
+    return false
+  }
+  native := strings.TrimPrefix(node.Kind.String(), "Kind")
+  if strings.EqualFold(native, requested) {
+    return true
+  }
+  switch strings.ToLower(requested) {
+  case "program":
+    return node.Kind == shimast.KindSourceFile
+  case "arrowfunctionexpression":
+    return node.Kind == shimast.KindArrowFunction
+  case "objectexpression":
+    return node.Kind == shimast.KindObjectLiteralExpression
+  case "arrayexpression":
+    return node.Kind == shimast.KindArrayLiteralExpression
+  case "objectpattern":
+    return node.Kind == shimast.KindObjectBindingPattern
+  case "arraypattern":
+    return node.Kind == shimast.KindArrayBindingPattern
+  case "variabledeclarator":
+    return node.Kind == shimast.KindVariableDeclaration
+  case "memberexpression":
+    return node.Kind == shimast.KindPropertyAccessExpression || node.Kind == shimast.KindElementAccessExpression
+  case "assignmentexpression":
+    if node.Kind != shimast.KindBinaryExpression {
+      return false
+    }
+    expression := node.AsBinaryExpression()
+    return expression != nil && expression.OperatorToken != nil && isAssignmentOperator(expression.OperatorToken.Kind)
+  case "updateexpression":
+    if node.Kind == shimast.KindPrefixUnaryExpression {
+      expression := node.AsPrefixUnaryExpression()
+      return expression != nil && (expression.Operator == shimast.KindPlusPlusToken || expression.Operator == shimast.KindMinusMinusToken)
+    }
+    if node.Kind == shimast.KindPostfixUnaryExpression {
+      expression := node.AsPostfixUnaryExpression()
+      return expression != nil && (expression.Operator == shimast.KindPlusPlusToken || expression.Operator == shimast.KindMinusMinusToken)
+    }
+    return false
+  case "unaryexpression":
+    return node.Kind == shimast.KindPrefixUnaryExpression ||
+      node.Kind == shimast.KindDeleteExpression ||
+      node.Kind == shimast.KindTypeOfExpression ||
+      node.Kind == shimast.KindVoidExpression
+  case "literal":
+    return astSelectorIsLiteral(node)
+  case "property":
+    switch node.Kind {
+    case shimast.KindPropertyAssignment,
+      shimast.KindShorthandPropertyAssignment,
+      shimast.KindSpreadAssignment,
+      shimast.KindMethodDeclaration,
+      shimast.KindGetAccessor,
+      shimast.KindSetAccessor:
+      return true
+    }
+  case "restelement":
+    return node.Kind == shimast.KindSpreadElement || node.Kind == shimast.KindSpreadAssignment ||
+      node.Kind == shimast.KindBindingElement && node.AsBindingElement() != nil && node.AsBindingElement().DotDotDotToken != nil
+  case "tsasexpression":
+    return node.Kind == shimast.KindAsExpression
+  case "tstypeassertion":
+    return node.Kind == shimast.KindTypeAssertionExpression
+  case "tssatisfiesexpression":
+    return node.Kind == shimast.KindSatisfiesExpression
+  case "tsnonnullexpression":
+    return node.Kind == shimast.KindNonNullExpression
+  }
+  return false
+}
+
+func astSelectorIsLiteral(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  switch node.Kind {
+  case shimast.KindNumericLiteral,
+    shimast.KindBigIntLiteral,
+    shimast.KindStringLiteral,
+    shimast.KindRegularExpressionLiteral,
+    shimast.KindNoSubstitutionTemplateLiteral,
+    shimast.KindTrueKeyword,
+    shimast.KindFalseKeyword,
+    shimast.KindNullKeyword:
+    return true
+  }
+  return false
+}
+
+func astSelectorMatchesClass(node *shimast.Node, class string) bool {
+  switch strings.ToLower(class) {
+  case "statement":
+    return node.Kind >= shimast.KindFirstStatement && node.Kind <= shimast.KindLastStatement
+  case "expression":
+    return astSelectorIsExpression(node)
+  case "declaration":
+    return astSelectorIsDeclaration(node)
+  case "function":
+    return isFunctionLikeKind(node)
+  case "pattern":
+    return astSelectorIsPattern(node)
+  default:
+    return false
+  }
+}
+
+func astSelectorIsExpression(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  if astSelectorIsLiteral(node) {
+    return true
+  }
+  if node.Kind == shimast.KindIdentifier || node.Kind == shimast.KindPrivateIdentifier ||
+    node.Kind == shimast.KindThisKeyword || node.Kind == shimast.KindSuperKeyword {
+    return true
+  }
+  return node.Kind >= shimast.KindArrayLiteralExpression && node.Kind <= shimast.KindSatisfiesExpression
+}
+
+func astSelectorIsDeclaration(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  switch node.Kind {
+  case shimast.KindTypeParameter,
+    shimast.KindParameter,
+    shimast.KindPropertySignature,
+    shimast.KindPropertyDeclaration,
+    shimast.KindMethodSignature,
+    shimast.KindMethodDeclaration,
+    shimast.KindConstructor,
+    shimast.KindGetAccessor,
+    shimast.KindSetAccessor,
+    shimast.KindCallSignature,
+    shimast.KindConstructSignature,
+    shimast.KindIndexSignature,
+    shimast.KindVariableDeclaration,
+    shimast.KindFunctionDeclaration,
+    shimast.KindClassDeclaration,
+    shimast.KindInterfaceDeclaration,
+    shimast.KindTypeAliasDeclaration,
+    shimast.KindEnumDeclaration,
+    shimast.KindModuleDeclaration,
+    shimast.KindImportEqualsDeclaration,
+    shimast.KindImportDeclaration,
+    shimast.KindImportClause,
+    shimast.KindNamespaceImport,
+    shimast.KindImportSpecifier,
+    shimast.KindExportDeclaration,
+    shimast.KindExportSpecifier,
+    shimast.KindEnumMember,
+    shimast.KindBindingElement:
+    return true
+  }
+  return false
+}
+
+func astSelectorIsPattern(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  switch node.Kind {
+  case shimast.KindObjectBindingPattern, shimast.KindArrayBindingPattern, shimast.KindBindingElement:
+    return true
+  case shimast.KindIdentifier:
+    parent := node.Parent
+    return parent != nil && (parent.Kind == shimast.KindObjectBindingPattern ||
+      parent.Kind == shimast.KindArrayBindingPattern || parent.Kind == shimast.KindBindingElement)
+  }
+  return false
+}
+
+type astSelectorRuntimeValueKind uint8
+
+const (
+  astSelectorRuntimeMissing astSelectorRuntimeValueKind = iota
+  astSelectorRuntimeNull
+  astSelectorRuntimeString
+  astSelectorRuntimeNumber
+  astSelectorRuntimeBoolean
+  astSelectorRuntimeNode
+  astSelectorRuntimeNodes
+)
+
+type astSelectorRuntimeValue struct {
+  kind    astSelectorRuntimeValueKind
+  text    string
+  number  float64
+  boolean bool
+  node    *shimast.Node
+  nodes   []*shimast.Node
+}
+
+func astSelectorMatchesAttribute(node *shimast.Node, selector *astSelector) bool {
+  value := astSelectorPathValue(astSelectorRuntimeValue{kind: astSelectorRuntimeNode, node: node}, strings.Split(selector.name, "."))
+  if selector.operator == "" {
+    return value.kind != astSelectorRuntimeMissing && value.kind != astSelectorRuntimeNull
+  }
+  matched := false
+  switch selector.value.kind {
+  case astSelectorValueRegexp:
+    matched = value.kind == astSelectorRuntimeString && selector.value.regexp != nil && selector.value.regexp.MatchString(value.text)
+  case astSelectorValueType:
+    matched = selector.value.literal == astSelectorRuntimeType(value)
+  case astSelectorValueLiteral:
+    if selector.operator == "=" || selector.operator == "!=" {
+      matched = astSelectorRuntimeStringValue(value) == selector.value.literal
+    } else {
+      return astSelectorCompare(value, selector.value, selector.operator)
+    }
+  default:
+    return false
+  }
+  if selector.operator == "!=" {
+    return !matched
+  }
+  return matched
+}
+
+func astSelectorCompare(value astSelectorRuntimeValue, expected astSelectorValue, operator string) bool {
+  left, leftNumber := astSelectorRuntimeNumberValue(value)
+  right := 0.0
+  rightNumber := false
+  if expected.number != nil {
+    right = *expected.number
+    rightNumber = true
+  } else if parsed, err := strconv.ParseFloat(expected.literal, 64); err == nil {
+    right = parsed
+    rightNumber = true
+  }
+  if !leftNumber || !rightNumber || math.IsNaN(left) || math.IsNaN(right) {
+    return false
+  }
+  switch operator {
+  case ">":
+    return left > right
+  case ">=":
+    return left >= right
+  case "<":
+    return left < right
+  case "<=":
+    return left <= right
+  }
+  return false
+}
+
+func astSelectorRuntimeType(value astSelectorRuntimeValue) string {
+  switch value.kind {
+  case astSelectorRuntimeString:
+    return "string"
+  case astSelectorRuntimeNumber:
+    return "number"
+  case astSelectorRuntimeBoolean:
+    return "boolean"
+  case astSelectorRuntimeNode, astSelectorRuntimeNodes, astSelectorRuntimeNull:
+    return "object"
+  default:
+    return "undefined"
+  }
+}
+
+func astSelectorRuntimeStringValue(value astSelectorRuntimeValue) string {
+  switch value.kind {
+  case astSelectorRuntimeString:
+    return value.text
+  case astSelectorRuntimeNumber:
+    return strconv.FormatFloat(value.number, 'g', -1, 64)
+  case astSelectorRuntimeBoolean:
+    return strconv.FormatBool(value.boolean)
+  case astSelectorRuntimeNull:
+    return "null"
+  case astSelectorRuntimeMissing:
+    return "undefined"
+  }
+  return "[object Object]"
+}
+
+func astSelectorRuntimeNumberValue(value astSelectorRuntimeValue) (float64, bool) {
+  switch value.kind {
+  case astSelectorRuntimeNumber:
+    return value.number, true
+  case astSelectorRuntimeString:
+    parsed, err := strconv.ParseFloat(value.text, 64)
+    return parsed, err == nil
+  case astSelectorRuntimeBoolean:
+    if value.boolean {
+      return 1, true
+    }
+    return 0, true
+  }
+  return 0, false
+}
+
+func astSelectorPathValue(value astSelectorRuntimeValue, path []string) astSelectorRuntimeValue {
+  current := value
+  for _, field := range path {
+    switch current.kind {
+    case astSelectorRuntimeNode:
+      current = astSelectorNodeProperty(current.node, field)
+    case astSelectorRuntimeNodes:
+      if field != "length" {
+        return astSelectorRuntimeValue{}
+      }
+      current = astSelectorRuntimeValue{kind: astSelectorRuntimeNumber, number: float64(len(current.nodes))}
+    case astSelectorRuntimeString:
+      if field != "length" {
+        return astSelectorRuntimeValue{}
+      }
+      current = astSelectorRuntimeValue{kind: astSelectorRuntimeNumber, number: float64(len([]rune(current.text)))}
+    default:
+      return astSelectorRuntimeValue{}
+    }
+  }
+  return current
+}
+
+func astSelectorMatchesField(node *shimast.Node, name string) bool {
+  path := strings.Split(name, ".")
+  ancestor := node
+  for range path {
+    ancestor = selectorParent(ancestor)
+    if ancestor == nil {
+      return false
+    }
+  }
+  return astSelectorNodeInPath(node, astSelectorRuntimeValue{kind: astSelectorRuntimeNode, node: ancestor}, path)
+}
+
+func astSelectorNodeInPath(node *shimast.Node, value astSelectorRuntimeValue, path []string) bool {
+  if len(path) == 0 {
+    return value.kind == astSelectorRuntimeNode && value.node == node
+  }
+  if value.kind != astSelectorRuntimeNode {
+    return false
+  }
+  next := astSelectorNodeProperty(value.node, path[0])
+  if next.kind == astSelectorRuntimeNodes {
+    for _, child := range next.nodes {
+      if astSelectorNodeInPath(node, astSelectorRuntimeValue{kind: astSelectorRuntimeNode, node: child}, path[1:]) {
+        return true
+      }
+    }
+    return false
+  }
+  return astSelectorNodeInPath(node, next, path[1:])
+}
+
+func astSelectorNodeProperty(node *shimast.Node, field string) astSelectorRuntimeValue {
+  if node == nil {
+    return astSelectorRuntimeValue{kind: astSelectorRuntimeNull}
+  }
+  switch field {
+  case "type":
+    return astSelectorString(strings.TrimPrefix(node.Kind.String(), "Kind"))
+  case "name":
+    if name := identifierText(node); name != "" {
+      return astSelectorString(name)
+    }
+    if name := identifierText(node.Name()); name != "" {
+      return astSelectorString(name)
+    }
+    return astSelectorRuntimeValue{kind: astSelectorRuntimeNull}
+  case "value", "raw":
+    if text := literalText(node); text != "" || node.Kind == shimast.KindStringLiteral || node.Kind == shimast.KindNoSubstitutionTemplateLiteral {
+      return astSelectorString(text)
+    }
+    switch node.Kind {
+    case shimast.KindTrueKeyword:
+      return astSelectorBoolean(true)
+    case shimast.KindFalseKeyword:
+      return astSelectorBoolean(false)
+    case shimast.KindNullKeyword:
+      return astSelectorRuntimeValue{kind: astSelectorRuntimeNull}
+    }
+    return astSelectorRuntimeValue{}
+  case "operator":
+    if operator := astSelectorNodeOperator(node); operator != "" {
+      return astSelectorString(operator)
+    }
+    return astSelectorRuntimeValue{}
+  case "kind":
+    if kind := astSelectorVariableKind(node); kind != "" {
+      return astSelectorString(kind)
+    }
+    return astSelectorRuntimeValue{}
+  case "async":
+    return astSelectorBoolean(hasModifier(node, shimast.KindAsyncKeyword))
+  case "generator":
+    return astSelectorBoolean(astSelectorIsGenerator(node))
+  case "static":
+    return astSelectorBoolean(hasModifier(node, shimast.KindStaticKeyword))
+  case "readonly":
+    return astSelectorBoolean(hasModifier(node, shimast.KindReadonlyKeyword))
+  case "declare":
+    return astSelectorBoolean(hasModifier(node, shimast.KindDeclareKeyword))
+  case "optional":
+    return astSelectorBoolean(astSelectorIsOptional(node))
+  case "computed":
+    return astSelectorBoolean(node.Kind == shimast.KindElementAccessExpression || node.Kind == shimast.KindComputedPropertyName)
+  case "id":
+    return astSelectorNode(node.Name())
+  case "params":
+    if isFunctionLikeKind(node) {
+      return astSelectorNodes(node.Parameters())
+    }
+  case "body":
+    if isFunctionLikeKind(node) {
+      return astSelectorNode(node.Body())
+    }
+    return astSelectorStatementBody(node)
+  case "callee":
+    if node.Kind == shimast.KindCallExpression {
+      if call := node.AsCallExpression(); call != nil {
+        return astSelectorNode(call.Expression)
+      }
+    }
+    if node.Kind == shimast.KindNewExpression {
+      if expression := node.AsNewExpression(); expression != nil {
+        return astSelectorNode(expression.Expression)
+      }
+    }
+  case "arguments":
+    if node.Kind == shimast.KindCallExpression {
+      if call := node.AsCallExpression(); call != nil && call.Arguments != nil {
+        return astSelectorNodes(call.Arguments.Nodes)
+      }
+    }
+    if node.Kind == shimast.KindNewExpression {
+      if expression := node.AsNewExpression(); expression != nil && expression.Arguments != nil {
+        return astSelectorNodes(expression.Arguments.Nodes)
+      }
+    }
+  case "object":
+    if node.Kind == shimast.KindPropertyAccessExpression {
+      return astSelectorNode(node.AsPropertyAccessExpression().Expression)
+    }
+    if node.Kind == shimast.KindElementAccessExpression {
+      return astSelectorNode(node.AsElementAccessExpression().Expression)
+    }
+  case "property":
+    if node.Kind == shimast.KindPropertyAccessExpression {
+      return astSelectorNode(node.AsPropertyAccessExpression().Name())
+    }
+    if node.Kind == shimast.KindElementAccessExpression {
+      return astSelectorNode(node.AsElementAccessExpression().ArgumentExpression)
+    }
+  case "left":
+    if node.Kind == shimast.KindBinaryExpression {
+      return astSelectorNode(node.AsBinaryExpression().Left)
+    }
+    if node.Kind == shimast.KindQualifiedName {
+      return astSelectorNode(node.AsQualifiedName().Left)
+    }
+  case "right":
+    if node.Kind == shimast.KindBinaryExpression {
+      return astSelectorNode(node.AsBinaryExpression().Right)
+    }
+    if node.Kind == shimast.KindQualifiedName {
+      return astSelectorNode(node.AsQualifiedName().Right)
+    }
+  case "argument":
+    return astSelectorUnaryArgument(node)
+  case "expression":
+    return astSelectorExpressionChild(node)
+  case "test":
+    return astSelectorTestChild(node)
+  case "consequent":
+    if node.Kind == shimast.KindIfStatement {
+      return astSelectorNode(node.AsIfStatement().ThenStatement)
+    }
+    if node.Kind == shimast.KindConditionalExpression {
+      return astSelectorNode(node.AsConditionalExpression().WhenTrue)
+    }
+  case "alternate":
+    if node.Kind == shimast.KindIfStatement {
+      return astSelectorNode(node.AsIfStatement().ElseStatement)
+    }
+    if node.Kind == shimast.KindConditionalExpression {
+      return astSelectorNode(node.AsConditionalExpression().WhenFalse)
+    }
+  case "init":
+    if node.Kind == shimast.KindVariableDeclaration {
+      return astSelectorNode(node.AsVariableDeclaration().Initializer)
+    }
+    if node.Kind == shimast.KindForStatement {
+      return astSelectorNode(node.AsForStatement().Initializer)
+    }
+  case "update":
+    if node.Kind == shimast.KindForStatement {
+      return astSelectorNode(node.AsForStatement().Incrementor)
+    }
+  case "declarations":
+    if node.Kind == shimast.KindVariableDeclarationList {
+      list := node.AsVariableDeclarationList()
+      if list != nil && list.Declarations != nil {
+        return astSelectorNodes(list.Declarations.Nodes)
+      }
+    }
+    if node.Kind == shimast.KindVariableStatement {
+      statement := node.AsVariableStatement()
+      if statement != nil && statement.DeclarationList != nil {
+        list := statement.DeclarationList.AsVariableDeclarationList()
+        if list != nil && list.Declarations != nil {
+          return astSelectorNodes(list.Declarations.Nodes)
+        }
+      }
+    }
+  case "elements":
+    if node.Kind == shimast.KindArrayLiteralExpression {
+      expression := node.AsArrayLiteralExpression()
+      if expression != nil && expression.Elements != nil {
+        return astSelectorNodes(expression.Elements.Nodes)
+      }
+    }
+    if node.Kind == shimast.KindObjectBindingPattern || node.Kind == shimast.KindArrayBindingPattern {
+      pattern := node.AsBindingPattern()
+      if pattern != nil && pattern.Elements != nil {
+        return astSelectorNodes(pattern.Elements.Nodes)
+      }
+    }
+  case "properties":
+    if node.Kind == shimast.KindObjectLiteralExpression {
+      expression := node.AsObjectLiteralExpression()
+      if expression != nil && expression.Properties != nil {
+        return astSelectorNodes(expression.Properties.Nodes)
+      }
+    }
+  case "key":
+    return astSelectorPropertyKey(node)
+  case "source":
+    if node.Kind == shimast.KindImportDeclaration {
+      return astSelectorNode(node.AsImportDeclaration().ModuleSpecifier)
+    }
+    if node.Kind == shimast.KindExportDeclaration {
+      return astSelectorNode(node.AsExportDeclaration().ModuleSpecifier)
+    }
+  case "statements":
+    return astSelectorStatements(node)
+  }
+  return astSelectorRuntimeValue{}
+}
+
+func astSelectorString(value string) astSelectorRuntimeValue {
+  return astSelectorRuntimeValue{kind: astSelectorRuntimeString, text: value}
+}
+
+func astSelectorBoolean(value bool) astSelectorRuntimeValue {
+  return astSelectorRuntimeValue{kind: astSelectorRuntimeBoolean, boolean: value}
+}
+
+func astSelectorNode(node *shimast.Node) astSelectorRuntimeValue {
+  if node == nil {
+    return astSelectorRuntimeValue{kind: astSelectorRuntimeNull}
+  }
+  return astSelectorRuntimeValue{kind: astSelectorRuntimeNode, node: node}
+}
+
+func astSelectorNodes(nodes []*shimast.Node) astSelectorRuntimeValue {
+  if nodes == nil {
+    return astSelectorRuntimeValue{kind: astSelectorRuntimeNull}
+  }
+  return astSelectorRuntimeValue{kind: astSelectorRuntimeNodes, nodes: nodes}
+}
+
+func astSelectorNodeOperator(node *shimast.Node) string {
+  if node == nil {
+    return ""
+  }
+  kind := shimast.KindUnknown
+  switch node.Kind {
+  case shimast.KindBinaryExpression:
+    if expression := node.AsBinaryExpression(); expression != nil && expression.OperatorToken != nil {
+      kind = expression.OperatorToken.Kind
+    }
+  case shimast.KindPrefixUnaryExpression:
+    kind = node.AsPrefixUnaryExpression().Operator
+  case shimast.KindPostfixUnaryExpression:
+    kind = node.AsPostfixUnaryExpression().Operator
+  case shimast.KindDeleteExpression:
+    return "delete"
+  case shimast.KindTypeOfExpression:
+    return "typeof"
+  case shimast.KindVoidExpression:
+    return "void"
+  }
+  return astSelectorOperatorText(kind)
+}
+
+func astSelectorOperatorText(kind shimast.Kind) string {
+  operators := map[shimast.Kind]string{
+    shimast.KindEqualsToken:                       "=",
+    shimast.KindPlusToken:                         "+",
+    shimast.KindMinusToken:                        "-",
+    shimast.KindAsteriskToken:                     "*",
+    shimast.KindAsteriskAsteriskToken:             "**",
+    shimast.KindSlashToken:                        "/",
+    shimast.KindPercentToken:                      "%",
+    shimast.KindPlusPlusToken:                     "++",
+    shimast.KindMinusMinusToken:                   "--",
+    shimast.KindLessThanToken:                     "<",
+    shimast.KindLessThanEqualsToken:               "<=",
+    shimast.KindGreaterThanToken:                  ">",
+    shimast.KindGreaterThanEqualsToken:            ">=",
+    shimast.KindEqualsEqualsToken:                 "==",
+    shimast.KindExclamationEqualsToken:            "!=",
+    shimast.KindEqualsEqualsEqualsToken:           "===",
+    shimast.KindExclamationEqualsEqualsToken:      "!==",
+    shimast.KindLessThanLessThanToken:              "<<",
+    shimast.KindGreaterThanGreaterThanToken:        ">>",
+    shimast.KindGreaterThanGreaterThanGreaterThanToken: ">>>",
+    shimast.KindAmpersandToken:                    "&",
+    shimast.KindBarToken:                          "|",
+    shimast.KindCaretToken:                        "^",
+    shimast.KindExclamationToken:                  "!",
+    shimast.KindTildeToken:                        "~",
+    shimast.KindAmpersandAmpersandToken:           "&&",
+    shimast.KindBarBarToken:                       "||",
+    shimast.KindQuestionQuestionToken:             "??",
+    shimast.KindInKeyword:                         "in",
+    shimast.KindInstanceOfKeyword:                 "instanceof",
+    shimast.KindPlusEqualsToken:                   "+=",
+    shimast.KindMinusEqualsToken:                  "-=",
+    shimast.KindAsteriskEqualsToken:               "*=",
+    shimast.KindAsteriskAsteriskEqualsToken:       "**=",
+    shimast.KindSlashEqualsToken:                  "/=",
+    shimast.KindPercentEqualsToken:                "%=",
+    shimast.KindLessThanLessThanEqualsToken:       "<<=",
+    shimast.KindGreaterThanGreaterThanEqualsToken: ">>=",
+    shimast.KindGreaterThanGreaterThanGreaterThanEqualsToken: ">>>=",
+    shimast.KindAmpersandEqualsToken:              "&=",
+    shimast.KindBarEqualsToken:                    "|=",
+    shimast.KindCaretEqualsToken:                  "^=",
+    shimast.KindBarBarEqualsToken:                 "||=",
+    shimast.KindAmpersandAmpersandEqualsToken:     "&&=",
+    shimast.KindQuestionQuestionEqualsToken:       "??=",
+  }
+  return operators[kind]
+}
+
+func astSelectorVariableKind(node *shimast.Node) string {
+  if node == nil {
+    return ""
+  }
+  list := node
+  if node.Kind == shimast.KindVariableStatement {
+    statement := node.AsVariableStatement()
+    if statement == nil {
+      return ""
+    }
+    list = statement.DeclarationList
+  } else if node.Kind == shimast.KindVariableDeclaration {
+    list = node.Parent
+  }
+  if list == nil || list.Kind != shimast.KindVariableDeclarationList {
+    return ""
+  }
+  flags := list.Flags & shimast.NodeFlagsBlockScoped
+  switch flags {
+  case shimast.NodeFlagsLet:
+    return "let"
+  case shimast.NodeFlagsConst:
+    return "const"
+  case shimast.NodeFlagsUsing:
+    return "using"
+  case shimast.NodeFlagsAwaitUsing:
+    return "await using"
+  default:
+    return "var"
+  }
+}
+
+func astSelectorIsGenerator(node *shimast.Node) bool {
+  if node == nil || !isFunctionLikeKind(node) {
+    return false
+  }
+  body := node.BodyData()
+  return body != nil && body.AsteriskToken != nil
+}
+
+func astSelectorIsOptional(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  switch node.Kind {
+  case shimast.KindPropertyAccessExpression:
+    return node.AsPropertyAccessExpression().QuestionDotToken != nil
+  case shimast.KindElementAccessExpression:
+    return node.AsElementAccessExpression().QuestionDotToken != nil
+  case shimast.KindCallExpression:
+    return node.AsCallExpression().QuestionDotToken != nil
+  }
+  return false
+}
+
+func astSelectorStatementBody(node *shimast.Node) astSelectorRuntimeValue {
+  if node == nil {
+    return astSelectorRuntimeValue{}
+  }
+  switch node.Kind {
+  case shimast.KindIfStatement:
+    return astSelectorNode(node.AsIfStatement().ThenStatement)
+  case shimast.KindWhileStatement:
+    return astSelectorNode(node.AsWhileStatement().Statement)
+  case shimast.KindDoStatement:
+    return astSelectorNode(node.AsDoStatement().Statement)
+  case shimast.KindForStatement:
+    return astSelectorNode(node.AsForStatement().Statement)
+  case shimast.KindForInStatement, shimast.KindForOfStatement:
+    return astSelectorNode(node.AsForInOrOfStatement().Statement)
+  case shimast.KindWithStatement:
+    return astSelectorNode(node.AsWithStatement().Statement)
+  }
+  return astSelectorRuntimeValue{}
+}
+
+func astSelectorUnaryArgument(node *shimast.Node) astSelectorRuntimeValue {
+  if node == nil {
+    return astSelectorRuntimeValue{}
+  }
+  switch node.Kind {
+  case shimast.KindPrefixUnaryExpression:
+    return astSelectorNode(node.AsPrefixUnaryExpression().Operand)
+  case shimast.KindPostfixUnaryExpression:
+    return astSelectorNode(node.AsPostfixUnaryExpression().Operand)
+  case shimast.KindDeleteExpression:
+    return astSelectorNode(node.AsDeleteExpression().Expression)
+  case shimast.KindReturnStatement:
+    return astSelectorNode(node.AsReturnStatement().Expression)
+  case shimast.KindThrowStatement:
+    return astSelectorNode(node.AsThrowStatement().Expression)
+  case shimast.KindSpreadElement:
+    return astSelectorNode(node.AsSpreadElement().Expression)
+  case shimast.KindSpreadAssignment:
+    return astSelectorNode(node.AsSpreadAssignment().Expression)
+  }
+  return astSelectorRuntimeValue{}
+}
+
+func astSelectorExpressionChild(node *shimast.Node) astSelectorRuntimeValue {
+  if node == nil {
+    return astSelectorRuntimeValue{}
+  }
+  switch node.Kind {
+  case shimast.KindExpressionStatement:
+    return astSelectorNode(node.AsExpressionStatement().Expression)
+  case shimast.KindParenthesizedExpression:
+    return astSelectorNode(node.AsParenthesizedExpression().Expression)
+  case shimast.KindAsExpression:
+    return astSelectorNode(node.AsAsExpression().Expression)
+  case shimast.KindTypeAssertionExpression:
+    return astSelectorNode(node.AsTypeAssertion().Expression)
+  case shimast.KindSatisfiesExpression:
+    return astSelectorNode(node.AsSatisfiesExpression().Expression)
+  case shimast.KindNonNullExpression:
+    return astSelectorNode(node.AsNonNullExpression().Expression)
+  case shimast.KindAwaitExpression:
+    return astSelectorNode(node.AsAwaitExpression().Expression)
+  case shimast.KindYieldExpression:
+    return astSelectorNode(node.AsYieldExpression().Expression)
+  }
+  return astSelectorRuntimeValue{}
+}
+
+func astSelectorTestChild(node *shimast.Node) astSelectorRuntimeValue {
+  if node == nil {
+    return astSelectorRuntimeValue{}
+  }
+  switch node.Kind {
+  case shimast.KindIfStatement:
+    return astSelectorNode(node.AsIfStatement().Expression)
+  case shimast.KindWhileStatement:
+    return astSelectorNode(node.AsWhileStatement().Expression)
+  case shimast.KindDoStatement:
+    return astSelectorNode(node.AsDoStatement().Expression)
+  case shimast.KindForStatement:
+    return astSelectorNode(node.AsForStatement().Condition)
+  case shimast.KindConditionalExpression:
+    return astSelectorNode(node.AsConditionalExpression().Condition)
+  }
+  return astSelectorRuntimeValue{}
+}
+
+func astSelectorPropertyKey(node *shimast.Node) astSelectorRuntimeValue {
+  if node == nil {
+    return astSelectorRuntimeValue{}
+  }
+  switch node.Kind {
+  case shimast.KindPropertyAssignment:
+    return astSelectorNode(node.AsPropertyAssignment().Name())
+  case shimast.KindShorthandPropertyAssignment:
+    return astSelectorNode(node.AsShorthandPropertyAssignment().Name())
+  case shimast.KindBindingElement:
+    element := node.AsBindingElement()
+    if element.PropertyName != nil {
+      return astSelectorNode(element.PropertyName)
+    }
+    return astSelectorNode(element.Name())
+  }
+  return astSelectorNode(node.Name())
+}
+
+func astSelectorStatements(node *shimast.Node) astSelectorRuntimeValue {
+  if node == nil {
+    return astSelectorRuntimeValue{}
+  }
+  switch node.Kind {
+  case shimast.KindSourceFile:
+    file := node.AsSourceFile()
+    if file != nil && file.Statements != nil {
+      return astSelectorNodes(file.Statements.Nodes)
+    }
+  case shimast.KindBlock:
+    block := node.AsBlock()
+    if block != nil && block.Statements != nil {
+      return astSelectorNodes(block.Statements.Nodes)
+    }
+  case shimast.KindModuleBlock:
+    block := node.AsModuleBlock()
+    if block != nil && block.Statements != nil {
+      return astSelectorNodes(block.Statements.Nodes)
+    }
+  case shimast.KindCaseClause, shimast.KindDefaultClause:
+    clause := node.AsCaseOrDefaultClause()
+    if clause != nil && clause.Statements != nil {
+      return astSelectorNodes(clause.Statements.Nodes)
+    }
+  }
+  return astSelectorRuntimeValue{}
+}
+
+func (selector *astSelector) String() string {
+  if selector == nil {
+    return "<nil>"
+  }
+  return fmt.Sprintf("astSelector(kind=%d,name=%q)", selector.kind, selector.name)
+}

--- a/packages/lint/linthost/ast_selector_matcher.go
+++ b/packages/lint/linthost/ast_selector_matcher.go
@@ -1,9 +1,12 @@
 package linthost
 
 import (
+  "errors"
   "math"
+  "math/big"
   "strconv"
   "strings"
+  "unicode/utf16"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimscanner "github.com/microsoft/typescript-go/shim/scanner"
@@ -179,33 +182,8 @@ func selectorParent(node *shimast.Node) *shimast.Node {
   return node.Parent
 }
 
-func selectorChildren(node *shimast.Node) []*shimast.Node {
-  if node == nil {
-    return nil
-  }
-  children := make([]*shimast.Node, 0)
-  node.ForEachChild(func(child *shimast.Node) bool {
-    if child != nil {
-      children = append(children, child)
-    }
-    return false
-  })
-  return children
-}
-
 func selectorSiblings(node *shimast.Node, following bool) []*shimast.Node {
-  parent := selectorParent(node)
-  if parent == nil {
-    return nil
-  }
-  children := selectorChildren(parent)
-  index := -1
-  for i, child := range children {
-    if child == node {
-      index = i
-      break
-    }
-  }
+  children, index := selectorNodeListPosition(node)
   if index < 0 {
     return nil
   }
@@ -227,21 +205,49 @@ func selectorAdjacent(node *shimast.Node, following bool) *shimast.Node {
 }
 
 func selectorChildIndex(node *shimast.Node, fromEnd bool) int {
-  parent := selectorParent(node)
-  if parent == nil {
+  children, index := selectorNodeListPosition(node)
+  if index < 0 {
     return 0
   }
-  children := selectorChildren(parent)
-  for index, child := range children {
-    if child != node {
+  if fromEnd {
+    return len(children) - index
+  }
+  return index + 1
+}
+
+// esquery defines sibling and child-position selectors only within array-valued
+// visitor fields. Scalar children such as a call's callee are not siblings of
+// entries in its arguments array. TypeScript-Go exposes traversal through
+// ForEachChild, so recover the node-list boundaries from the structural fields
+// supported by this selector adapter instead of flattening every child.
+func selectorNodeListPosition(node *shimast.Node) ([]*shimast.Node, int) {
+  parent := selectorParent(node)
+  if parent == nil {
+    return nil, -1
+  }
+  fields := [...]string{
+    "body",
+    "params",
+    "arguments",
+    "consequent",
+    "declarations",
+    "elements",
+    "members",
+    "properties",
+    "statements",
+  }
+  for _, field := range fields {
+    value := astSelectorNodeProperty(parent, field)
+    if value.kind != astSelectorRuntimeNodes {
       continue
     }
-    if fromEnd {
-      return len(children) - index
+    for index, candidate := range value.nodes {
+      if candidate == node {
+        return value.nodes, index
+      }
     }
-    return index + 1
   }
-  return 0
+  return nil, -1
 }
 
 func astSelectorMatchesNodeType(node *shimast.Node, requested string) bool {
@@ -258,13 +264,15 @@ func astSelectorMatchesNodeType(node *shimast.Node, requested string) bool {
   case "arrowfunctionexpression":
     return node.Kind == shimast.KindArrowFunction
   case "objectexpression":
-    return node.Kind == shimast.KindObjectLiteralExpression
+    return node.Kind == shimast.KindObjectLiteralExpression && !isDestructuringAssignmentTarget(node)
   case "arrayexpression":
-    return node.Kind == shimast.KindArrayLiteralExpression
+    return node.Kind == shimast.KindArrayLiteralExpression && !isDestructuringAssignmentTarget(node)
   case "objectpattern":
-    return node.Kind == shimast.KindObjectBindingPattern
+    return node.Kind == shimast.KindObjectBindingPattern ||
+      node.Kind == shimast.KindObjectLiteralExpression && isDestructuringAssignmentTarget(node)
   case "arraypattern":
-    return node.Kind == shimast.KindArrayBindingPattern
+    return node.Kind == shimast.KindArrayBindingPattern ||
+      node.Kind == shimast.KindArrayLiteralExpression && isDestructuringAssignmentTarget(node)
   case "variabledeclarator":
     return node.Kind == shimast.KindVariableDeclaration
   case "memberexpression":
@@ -274,7 +282,9 @@ func astSelectorMatchesNodeType(node *shimast.Node, requested string) bool {
       return false
     }
     expression := node.AsBinaryExpression()
-    return expression != nil && expression.OperatorToken != nil && isAssignmentOperator(expression.OperatorToken.Kind)
+    return expression != nil && expression.OperatorToken != nil &&
+      isAssignmentOperator(expression.OperatorToken.Kind) &&
+      !isDestructuringAssignmentTarget(node)
   case "logicalexpression":
     if node.Kind != shimast.KindBinaryExpression {
       return false
@@ -317,17 +327,34 @@ func astSelectorMatchesNodeType(node *shimast.Node, requested string) bool {
   case "property":
     switch node.Kind {
     case shimast.KindPropertyAssignment,
-      shimast.KindShorthandPropertyAssignment,
-      shimast.KindSpreadAssignment:
+      shimast.KindShorthandPropertyAssignment:
       return true
+    case shimast.KindBindingElement:
+      element := node.AsBindingElement()
+      return element != nil && element.DotDotDotToken == nil &&
+        node.Parent != nil && node.Parent.Kind == shimast.KindObjectBindingPattern
     case shimast.KindMethodDeclaration,
       shimast.KindGetAccessor,
       shimast.KindSetAccessor:
       return node.Parent != nil && node.Parent.Kind == shimast.KindObjectLiteralExpression
     }
+  case "spreadelement":
+    return (node.Kind == shimast.KindSpreadElement || node.Kind == shimast.KindSpreadAssignment) &&
+      !isDestructuringAssignmentTarget(node)
   case "restelement":
-    return node.Kind == shimast.KindSpreadElement || node.Kind == shimast.KindSpreadAssignment ||
-      node.Kind == shimast.KindBindingElement && node.AsBindingElement() != nil && node.AsBindingElement().DotDotDotToken != nil
+    if (node.Kind == shimast.KindSpreadElement || node.Kind == shimast.KindSpreadAssignment) &&
+      isDestructuringAssignmentTarget(node) {
+      return true
+    }
+    if node.Kind == shimast.KindBindingElement {
+      element := node.AsBindingElement()
+      return element != nil && element.DotDotDotToken != nil
+    }
+    if node.Kind == shimast.KindParameter {
+      parameter := node.AsParameterDeclaration()
+      return parameter != nil && parameter.DotDotDotToken != nil
+    }
+    return false
   case "tsasexpression":
     return node.Kind == shimast.KindAsExpression
   case "tstypeassertion":
@@ -349,7 +376,6 @@ func astSelectorIsLiteral(node *shimast.Node) bool {
     shimast.KindBigIntLiteral,
     shimast.KindStringLiteral,
     shimast.KindRegularExpressionLiteral,
-    shimast.KindNoSubstitutionTemplateLiteral,
     shimast.KindTrueKeyword,
     shimast.KindFalseKeyword,
     shimast.KindNullKeyword:
@@ -379,6 +405,9 @@ func astSelectorMatchesClass(node *shimast.Node, class string) bool {
 func astSelectorIsExpression(node *shimast.Node) bool {
   if node == nil {
     return false
+  }
+  if astSelectorIsLiteral(node) {
+    return true
   }
   native := strings.TrimPrefix(node.Kind.String(), "Kind")
   if strings.HasSuffix(native, "Expression") || strings.HasSuffix(native, "Literal") {
@@ -450,7 +479,11 @@ func astSelectorMatchesAttribute(node *shimast.Node, selector *astSelector) bool
     matched = selector.value.literal == astSelectorRuntimeType(value)
   case astSelectorValueLiteral:
     if selector.operator == "=" || selector.operator == "!=" {
-      matched = astSelectorRuntimeStringValue(value) == selector.value.literal
+      expected := selector.value.literal
+      if selector.value.number != nil {
+        expected = astSelectorNumberString(*selector.value.number)
+      }
+      matched = astSelectorRuntimeStringValue(value) == expected
     } else {
       return astSelectorCompare(value, selector.value, selector.operator)
     }
@@ -464,18 +497,22 @@ func astSelectorMatchesAttribute(node *shimast.Node, selector *astSelector) bool
 }
 
 func astSelectorCompare(value astSelectorRuntimeValue, expected astSelectorValue, operator string) bool {
-  if value.kind == astSelectorRuntimeString && expected.number == nil {
+  if left, stringValue := astSelectorRuntimeRelationalString(value); stringValue && expected.number == nil {
+    comparison := astSelectorCompareUTF16(left, expected.literal)
     switch operator {
     case ">":
-      return value.text > expected.literal
+      return comparison > 0
     case ">=":
-      return value.text >= expected.literal
+      return comparison >= 0
     case "<":
-      return value.text < expected.literal
+      return comparison < 0
     case "<=":
-      return value.text <= expected.literal
+      return comparison <= 0
     }
     return false
+  }
+  if value.kind == astSelectorRuntimeBigInt {
+    return astSelectorCompareBigInt(value.text, expected, operator)
   }
   left, leftNumber := astSelectorRuntimeNumberValue(value)
   right := 0.0
@@ -483,7 +520,7 @@ func astSelectorCompare(value astSelectorRuntimeValue, expected astSelectorValue
   if expected.number != nil {
     right = *expected.number
     rightNumber = true
-  } else if parsed, err := strconv.ParseFloat(expected.literal, 64); err == nil {
+  } else if parsed, ok := astSelectorParseNumberString(expected.literal); ok {
     right = parsed
     rightNumber = true
   }
@@ -501,6 +538,121 @@ func astSelectorCompare(value astSelectorRuntimeValue, expected astSelectorValue
     return left <= right
   }
   return false
+}
+
+func astSelectorCompareUTF16(left, right string) int {
+  leftUnits := utf16.Encode([]rune(left))
+  rightUnits := utf16.Encode([]rune(right))
+  length := len(leftUnits)
+  if len(rightUnits) < length {
+    length = len(rightUnits)
+  }
+  for index := 0; index < length; index++ {
+    if leftUnits[index] < rightUnits[index] {
+      return -1
+    }
+    if leftUnits[index] > rightUnits[index] {
+      return 1
+    }
+  }
+  switch {
+  case len(leftUnits) < len(rightUnits):
+    return -1
+  case len(leftUnits) > len(rightUnits):
+    return 1
+  default:
+    return 0
+  }
+}
+
+func astSelectorRuntimeRelationalString(value astSelectorRuntimeValue) (string, bool) {
+  switch value.kind {
+  case astSelectorRuntimeString,
+    astSelectorRuntimeObject,
+    astSelectorRuntimeNode,
+    astSelectorRuntimeNodes:
+    return astSelectorRuntimeStringValue(value), true
+  }
+  return "", false
+}
+
+func astSelectorCompareBigInt(value string, expected astSelectorValue, operator string) bool {
+  left, ok := new(big.Int).SetString(value, 10)
+  if !ok {
+    return false
+  }
+  right := new(big.Rat)
+  comparison := 0
+  if expected.number != nil {
+    if math.IsNaN(*expected.number) {
+      return false
+    }
+    if math.IsInf(*expected.number, 1) {
+      comparison = -1
+    } else if math.IsInf(*expected.number, -1) {
+      comparison = 1
+    } else {
+      if right.SetFloat64(*expected.number) == nil {
+        return false
+      }
+      comparison = new(big.Rat).SetInt(left).Cmp(right)
+    }
+  } else {
+    integer, ok := astSelectorParseBigIntString(expected.literal)
+    if !ok {
+      return false
+    }
+    right.SetInt(integer)
+    comparison = new(big.Rat).SetInt(left).Cmp(right)
+  }
+  switch operator {
+  case ">":
+    return comparison > 0
+  case ">=":
+    return comparison >= 0
+  case "<":
+    return comparison < 0
+  case "<=":
+    return comparison <= 0
+  }
+  return false
+}
+
+func astSelectorParseBigIntString(value string) (*big.Int, bool) {
+  value = strings.TrimSpace(value)
+  if value == "" {
+    return new(big.Int), true
+  }
+  negative := false
+  if value[0] == '+' || value[0] == '-' {
+    negative = value[0] == '-'
+    value = value[1:]
+    if value == "" {
+      return nil, false
+    }
+    lower := strings.ToLower(value)
+    if strings.HasPrefix(lower, "0x") || strings.HasPrefix(lower, "0o") || strings.HasPrefix(lower, "0b") {
+      return nil, false
+    }
+  }
+  base := 10
+  lower := strings.ToLower(value)
+  switch {
+  case strings.HasPrefix(lower, "0x"):
+    base, value = 16, value[2:]
+  case strings.HasPrefix(lower, "0o"):
+    base, value = 8, value[2:]
+  case strings.HasPrefix(lower, "0b"):
+    base, value = 2, value[2:]
+  }
+  integer, ok := new(big.Int).SetString(value, base)
+  if !ok {
+    return nil, false
+  }
+  if negative {
+    integer.Neg(integer)
+  }
+  return integer, true
 }
 
 func astSelectorRuntimeType(value astSelectorRuntimeValue) string {
@@ -525,7 +677,7 @@ func astSelectorRuntimeStringValue(value astSelectorRuntimeValue) string {
   case astSelectorRuntimeString:
     return value.text
   case astSelectorRuntimeNumber:
-    return strconv.FormatFloat(value.number, 'g', -1, 64)
+    return astSelectorNumberString(value.number)
   case astSelectorRuntimeBigInt:
     return value.text
   case astSelectorRuntimeBoolean:
@@ -539,6 +691,10 @@ func astSelectorRuntimeStringValue(value astSelectorRuntimeValue) string {
       return ""
     }
     return strings.TrimSuffix(strings.Repeat("[object Object],", len(value.nodes)), ",")
+  case astSelectorRuntimeObject:
+    if value.text != "" {
+      return value.text
+    }
   }
   return "[object Object]"
 }
@@ -548,8 +704,7 @@ func astSelectorRuntimeNumberValue(value astSelectorRuntimeValue) (float64, bool
   case astSelectorRuntimeNumber:
     return value.number, true
   case astSelectorRuntimeString:
-    parsed, err := strconv.ParseFloat(value.text, 64)
-    return parsed, err == nil
+    return astSelectorParseNumberString(value.text)
   case astSelectorRuntimeBoolean:
     if value.boolean {
       return 1, true
@@ -557,8 +712,109 @@ func astSelectorRuntimeNumberValue(value astSelectorRuntimeValue) (float64, bool
     return 0, true
   case astSelectorRuntimeNull:
     return 0, true
+  case astSelectorRuntimeObject,
+    astSelectorRuntimeNode,
+    astSelectorRuntimeNodes:
+    return astSelectorParseNumberString(astSelectorRuntimeStringValue(value))
   }
   return 0, false
+}
+
+func astSelectorNumberString(value float64) string {
+  if math.IsInf(value, 1) {
+    return "Infinity"
+  }
+  if math.IsInf(value, -1) {
+    return "-Infinity"
+  }
+  if math.IsNaN(value) {
+    return "NaN"
+  }
+  if value == 0 {
+    return "0"
+  }
+  formatted := strconv.FormatFloat(value, 'g', -1, 64)
+  exponentAt := strings.IndexByte(formatted, 'e')
+  if exponentAt < 0 {
+    return formatted
+  }
+  mantissa := formatted[:exponentAt]
+  exponent, err := strconv.Atoi(formatted[exponentAt+1:])
+  if err != nil {
+    return formatted
+  }
+  sign := ""
+  if strings.HasPrefix(mantissa, "-") {
+    sign = "-"
+    mantissa = mantissa[1:]
+  }
+  if exponent >= -6 && exponent < 21 {
+    digits := strings.ReplaceAll(mantissa, ".", "")
+    decimal := exponent + 1
+    switch {
+    case decimal <= 0:
+      return sign + "0." + strings.Repeat("0", -decimal) + digits
+    case decimal >= len(digits):
+      return sign + digits + strings.Repeat("0", decimal-len(digits))
+    default:
+      return sign + digits[:decimal] + "." + digits[decimal:]
+    }
+  }
+  exponentSign := "+"
+  if exponent < 0 {
+    exponentSign = ""
+  }
+  return sign + mantissa + "e" + exponentSign + strconv.Itoa(exponent)
+}
+
+func astSelectorParseNumberString(value string) (float64, bool) {
+  value = strings.TrimSpace(value)
+  if value == "" {
+    return 0, true
+  }
+  switch value {
+  case "Infinity", "+Infinity":
+    return math.Inf(1), true
+  case "-Infinity":
+    return math.Inf(-1), true
+  }
+  lower := strings.ToLower(value)
+  switch lower {
+  case "inf", "+inf", "-inf", "infinity", "+infinity", "-infinity":
+    return 0, false
+  }
+  if strings.ContainsRune(value, '_') {
+    return 0, false
+  }
+  if len(lower) > 1 && (lower[0] == '+' || lower[0] == '-') {
+    unsigned := lower[1:]
+    if strings.HasPrefix(unsigned, "0x") || strings.HasPrefix(unsigned, "0o") || strings.HasPrefix(unsigned, "0b") {
+      return 0, false
+    }
+  }
+  base := 0
+  switch {
+  case strings.HasPrefix(lower, "0x"):
+    base = 16
+  case strings.HasPrefix(lower, "0o"):
+    base = 8
+  case strings.HasPrefix(lower, "0b"):
+    base = 2
+  }
+  if base != 0 {
+    digits := value[2:]
+    if digits == "" || digits[0] == '+' || digits[0] == '-' || strings.ContainsRune(digits, '_') {
+      return 0, false
+    }
+    integer, ok := new(big.Int).SetString(digits, base)
+    if !ok {
+      return 0, false
+    }
+    number, _ := new(big.Float).SetInt(integer).Float64()
+    return number, true
+  }
+  number, err := strconv.ParseFloat(value, 64)
+  return number, err == nil || errors.Is(err, strconv.ErrRange)
 }
 
 func astSelectorPathValue(value astSelectorRuntimeValue, path []string) astSelectorRuntimeValue {
@@ -573,7 +829,7 @@ func astSelectorPathValue(value astSelectorRuntimeValue, path []string) astSelec
         continue
       }
       index, err := strconv.Atoi(field)
-      if err != nil || index < 0 || index >= len(current.nodes) {
+      if err != nil || index < 0 || strconv.Itoa(index) != field || index >= len(current.nodes) {
         return astSelectorRuntimeValue{}
       }
       current = astSelectorNode(current.nodes[index])
@@ -581,7 +837,12 @@ func astSelectorPathValue(value astSelectorRuntimeValue, path []string) astSelec
       if field != "length" {
         return astSelectorRuntimeValue{}
       }
-      current = astSelectorRuntimeValue{kind: astSelectorRuntimeNumber, number: float64(len([]rune(current.text)))}
+      current = astSelectorRuntimeValue{
+        kind:   astSelectorRuntimeNumber,
+        number: float64(len(utf16.Encode([]rune(current.text)))),
+      }
+    case astSelectorRuntimeNull:
+      return current
     default:
       return astSelectorRuntimeValue{}
     }
@@ -657,7 +918,7 @@ func astSelectorNodeProperty(node *shimast.Node, field string) astSelectorRuntim
     }
     return astSelectorLiteralValue(node)
   case "raw":
-    if astSelectorIsLiteral(node) {
+    if astSelectorIsLiteral(node) || node.Kind == shimast.KindNoSubstitutionTemplateLiteral {
       if file := shimast.GetSourceFileOfNode(node); file != nil {
         return astSelectorString(nodeText(file, node))
       }
@@ -697,10 +958,11 @@ func astSelectorNodeProperty(node *shimast.Node, field string) astSelectorRuntim
     }
     return astSelectorBoolean(hasModifier(node, shimast.KindReadonlyKeyword))
   case "declare":
-    if !astSelectorIsDeclaration(node) {
+    declared, applicable := astSelectorIsDeclared(node)
+    if !applicable {
       return astSelectorRuntimeValue{}
     }
-    return astSelectorBoolean(hasModifier(node, shimast.KindDeclareKeyword))
+    return astSelectorBoolean(declared)
   case "optional":
     optional, applicable := astSelectorIsOptional(node)
     if !applicable {
@@ -864,6 +1126,16 @@ func astSelectorNodeProperty(node *shimast.Node, field string) astSelectorRuntim
         return astSelectorNodes(pattern.Elements.Nodes)
       }
     }
+  case "members":
+    switch node.Kind {
+    case shimast.KindClassDeclaration,
+      shimast.KindClassExpression,
+      shimast.KindInterfaceDeclaration,
+      shimast.KindEnumDeclaration,
+      shimast.KindTypeLiteral,
+      shimast.KindMappedType:
+      return astSelectorNodes(node.Members())
+    }
   case "key":
     return astSelectorPropertyKey(node)
   case "source":
@@ -897,22 +1169,30 @@ func astSelectorLiteralValue(node *shimast.Node) astSelectorRuntimeValue {
       return astSelectorString(data.Text)
     }
   case shimast.KindRegularExpressionLiteral:
+    if file := shimast.GetSourceFileOfNode(node); file != nil {
+      return astSelectorRuntimeValue{kind: astSelectorRuntimeObject, text: astSelectorRegexpString(nodeText(file, node))}
+    }
     return astSelectorRuntimeValue{kind: astSelectorRuntimeObject}
   case shimast.KindNumericLiteral:
     if data := node.LiteralLikeData(); data != nil {
       text := strings.ReplaceAll(data.Text, "_", "")
-      if number, err := strconv.ParseFloat(text, 64); err == nil {
+      if number, err := strconv.ParseFloat(text, 64); err == nil || errors.Is(err, strconv.ErrRange) {
         return astSelectorRuntimeValue{kind: astSelectorRuntimeNumber, number: number}
       }
-      if number, err := strconv.ParseUint(text, 0, 64); err == nil {
-        return astSelectorRuntimeValue{kind: astSelectorRuntimeNumber, number: float64(number)}
+      if integer, ok := new(big.Int).SetString(text, 0); ok {
+        number, _ := new(big.Float).SetInt(integer).Float64()
+        return astSelectorRuntimeValue{kind: astSelectorRuntimeNumber, number: number}
       }
     }
   case shimast.KindBigIntLiteral:
     if data := node.LiteralLikeData(); data != nil {
+      text := strings.TrimSuffix(strings.ReplaceAll(data.Text, "_", ""), "n")
+      if integer, ok := new(big.Int).SetString(text, 0); ok {
+        text = integer.String()
+      }
       return astSelectorRuntimeValue{
         kind: astSelectorRuntimeBigInt,
-        text: strings.TrimSuffix(strings.ReplaceAll(data.Text, "_", ""), "n"),
+        text: text,
       }
     }
   case shimast.KindTrueKeyword:
@@ -923,6 +1203,24 @@ func astSelectorLiteralValue(node *shimast.Node) astSelectorRuntimeValue {
     return astSelectorRuntimeValue{kind: astSelectorRuntimeNull}
   }
   return astSelectorRuntimeValue{}
+}
+
+func astSelectorRegexpString(raw string) string {
+  delimiter := strings.LastIndexByte(raw, '/')
+  if delimiter <= 0 || delimiter == len(raw)-1 {
+    return raw
+  }
+  flags := raw[delimiter+1:]
+  var canonical strings.Builder
+  for _, flag := range "dgimsuvy" {
+    if strings.ContainsRune(flags, flag) {
+      canonical.WriteRune(flag)
+    }
+  }
+  if canonical.Len() != len(flags) {
+    return raw
+  }
+  return raw[:delimiter+1] + canonical.String()
 }
 
 func astSelectorNode(node *shimast.Node) astSelectorRuntimeValue {
@@ -1067,6 +1365,26 @@ func astSelectorSupportsReadonly(node *shimast.Node) bool {
   return false
 }
 
+func astSelectorIsDeclared(node *shimast.Node) (bool, bool) {
+  if node == nil {
+    return false, false
+  }
+  declaration := node
+  if node.Kind == shimast.KindVariableDeclaration {
+    declaration = node.Parent
+  }
+  if declaration != nil && declaration.Kind == shimast.KindVariableDeclarationList {
+    declaration = declaration.Parent
+  }
+  if declaration != nil && declaration.Kind == shimast.KindVariableStatement {
+    return hasModifier(declaration, shimast.KindDeclareKeyword), true
+  }
+  if !astSelectorIsDeclaration(node) {
+    return false, false
+  }
+  return hasModifier(node, shimast.KindDeclareKeyword), true
+}
+
 func astSelectorIsComputed(node *shimast.Node) (bool, bool) {
   if node == nil {
     return false, false
@@ -1113,6 +1431,18 @@ func astSelectorStatementBody(node *shimast.Node) astSelectorRuntimeValue {
     block := node.AsModuleBlock()
     if block != nil && block.Statements != nil {
       return astSelectorNodes(block.Statements.Nodes)
+    }
+  case shimast.KindCatchClause:
+    if clause := node.AsCatchClause(); clause != nil {
+      return astSelectorNode(clause.Block)
+    }
+  case shimast.KindLabeledStatement:
+    if statement := node.AsLabeledStatement(); statement != nil {
+      return astSelectorNode(statement.Statement)
+    }
+  case shimast.KindClassStaticBlockDeclaration:
+    if block := node.AsClassStaticBlockDeclaration(); block != nil {
+      return astSelectorNode(block.Body)
     }
   case shimast.KindIfStatement:
     return astSelectorNode(node.AsIfStatement().ThenStatement)
@@ -1162,6 +1492,11 @@ func astSelectorUnaryArgument(node *shimast.Node) astSelectorRuntimeValue {
     if element != nil && element.DotDotDotToken != nil {
       return astSelectorNode(element.Name())
     }
+  case shimast.KindParameter:
+    parameter := node.AsParameterDeclaration()
+    if parameter != nil && parameter.DotDotDotToken != nil {
+      return astSelectorNode(parameter.Name())
+    }
   }
   return astSelectorRuntimeValue{}
 }
@@ -1171,22 +1506,43 @@ func astSelectorExpressionChild(node *shimast.Node) astSelectorRuntimeValue {
     return astSelectorRuntimeValue{}
   }
   switch node.Kind {
-  case shimast.KindExpressionStatement:
-    return astSelectorNode(node.AsExpressionStatement().Expression)
-  case shimast.KindParenthesizedExpression:
-    return astSelectorNode(node.AsParenthesizedExpression().Expression)
-  case shimast.KindAsExpression:
-    return astSelectorNode(node.AsAsExpression().Expression)
-  case shimast.KindTypeAssertionExpression:
-    return astSelectorNode(node.AsTypeAssertion().Expression)
-  case shimast.KindSatisfiesExpression:
-    return astSelectorNode(node.AsSatisfiesExpression().Expression)
-  case shimast.KindNonNullExpression:
-    return astSelectorNode(node.AsNonNullExpression().Expression)
-  case shimast.KindAwaitExpression:
-    return astSelectorNode(node.AsAwaitExpression().Expression)
-  case shimast.KindYieldExpression:
-    return astSelectorNode(node.AsYieldExpression().Expression)
+  case shimast.KindPropertyAccessExpression,
+    shimast.KindElementAccessExpression,
+    shimast.KindParenthesizedExpression,
+    shimast.KindCallExpression,
+    shimast.KindNewExpression,
+    shimast.KindExpressionWithTypeArguments,
+    shimast.KindComputedPropertyName,
+    shimast.KindNonNullExpression,
+    shimast.KindTypeAssertionExpression,
+    shimast.KindAsExpression,
+    shimast.KindSatisfiesExpression,
+    shimast.KindTypeOfExpression,
+    shimast.KindSpreadAssignment,
+    shimast.KindSpreadElement,
+    shimast.KindTemplateSpan,
+    shimast.KindDeleteExpression,
+    shimast.KindVoidExpression,
+    shimast.KindAwaitExpression,
+    shimast.KindYieldExpression,
+    shimast.KindPartiallyEmittedExpression,
+    shimast.KindIfStatement,
+    shimast.KindDoStatement,
+    shimast.KindWhileStatement,
+    shimast.KindWithStatement,
+    shimast.KindForInStatement,
+    shimast.KindForOfStatement,
+    shimast.KindSwitchStatement,
+    shimast.KindCaseClause,
+    shimast.KindExpressionStatement,
+    shimast.KindReturnStatement,
+    shimast.KindThrowStatement,
+    shimast.KindExternalModuleReference,
+    shimast.KindExportAssignment,
+    shimast.KindDecorator,
+    shimast.KindJsxExpression,
+    shimast.KindJsxSpreadAttribute:
+    return astSelectorNode(node.Expression())
   }
   return astSelectorRuntimeValue{}
 }
@@ -1206,6 +1562,11 @@ func astSelectorTestChild(node *shimast.Node) astSelectorRuntimeValue {
     return astSelectorNode(node.AsForStatement().Condition)
   case shimast.KindConditionalExpression:
     return astSelectorNode(node.AsConditionalExpression().Condition)
+  case shimast.KindCaseClause:
+    clause := node.AsCaseOrDefaultClause()
+    if clause != nil {
+      return astSelectorNode(clause.Expression)
+    }
   }
   return astSelectorRuntimeValue{}
 }

--- a/packages/lint/linthost/ast_selector_parser.go
+++ b/packages/lint/linthost/ast_selector_parser.go
@@ -285,11 +285,6 @@ func (p *astSelectorParser) parseAttributeValue(operator string) (astSelectorVal
       return astSelectorValue{}, p.errorf("invalid type() value")
     }
     p.offset++
-    switch name {
-    case "string", "number", "boolean", "object", "undefined":
-    default:
-      return astSelectorValue{}, p.errorf("unknown type() value %q", name)
-    }
     return astSelectorValue{kind: astSelectorValueType, literal: name}, nil
   }
   start := p.offset
@@ -300,7 +295,8 @@ func (p *astSelectorParser) parseAttributeValue(operator string) (astSelectorVal
   if raw == "" {
     return astSelectorValue{}, p.errorf("expected attribute value")
   }
-  if number, err := strconv.ParseFloat(raw, 64); err == nil {
+  if astSelectorNumberPattern.MatchString(raw) {
+    number, _ := strconv.ParseFloat(raw, 64)
     return astSelectorValue{kind: astSelectorValueLiteral, literal: raw, number: &number}, nil
   }
   return astSelectorValue{kind: astSelectorValueLiteral, literal: raw}, nil
@@ -377,6 +373,9 @@ func (p *astSelectorParser) parseRegexp() (*regexp.Regexp, error) {
   }
   if end < 0 {
     return nil, p.errorf("unterminated regular expression")
+  }
+  if end == start {
+    return nil, p.errorf("regular expression must not be empty")
   }
   seenFlags := map[byte]struct{}{}
   var goFlags strings.Builder
@@ -483,7 +482,7 @@ func (p *astSelectorParser) parsePseudo() (*astSelector, error) {
     }
     return &astSelector{kind: kind, selectors: selectors}, nil
   default:
-    switch name {
+    switch strings.ToLower(name) {
     case "statement", "expression", "declaration", "function", "pattern":
       return &astSelector{kind: astSelectorClass, name: name}, nil
     default:
@@ -593,3 +592,5 @@ func (p *astSelectorParser) errorf(format string, args ...any) error {
 func isASTSelectorSpace(ch byte) bool {
   return ch < unicode.MaxASCII && unicode.IsSpace(rune(ch))
 }
+
+var astSelectorNumberPattern = regexp.MustCompile(`^(?:[0-9]*\.)?[0-9]+$`)

--- a/packages/lint/linthost/ast_selector_parser.go
+++ b/packages/lint/linthost/ast_selector_parser.go
@@ -279,7 +279,11 @@ func (p *astSelectorParser) parseAttributeValue(operator string) (astSelectorVal
     }
     p.offset += len("type(")
     p.skipSpace()
-    name := p.parseIdentifier()
+    start := p.offset
+    for !p.eof() && !isASTSelectorSpace(p.peek()) && p.peek() != ')' {
+      p.offset++
+    }
+    name := p.source[start:p.offset]
     p.skipSpace()
     if name == "" || p.eof() || p.peek() != ')' {
       return astSelectorValue{}, p.errorf("invalid type() value")
@@ -287,11 +291,39 @@ func (p *astSelectorParser) parseAttributeValue(operator string) (astSelectorVal
     p.offset++
     return astSelectorValue{kind: astSelectorValueType, literal: name}, nil
   }
-  start := p.offset
-  for !p.eof() && !isASTSelectorSpace(p.peek()) && p.peek() != ']' {
+  if p.peek() == '.' {
+    start := p.offset
     p.offset++
+    for !p.eof() && p.peek() >= '0' && p.peek() <= '9' {
+      p.offset++
+    }
+    raw := p.source[start:p.offset]
+    if !astSelectorNumberPattern.MatchString(raw) {
+      return astSelectorValue{}, p.errorf("invalid attribute value")
+    }
+    number, _ := strconv.ParseFloat(raw, 64)
+    return astSelectorValue{kind: astSelectorValueLiteral, literal: raw, number: &number}, nil
   }
-  raw := p.source[start:p.offset]
+  if p.peek() >= '0' && p.peek() <= '9' {
+    start := p.offset
+    for !p.eof() && p.peek() >= '0' && p.peek() <= '9' {
+      p.offset++
+    }
+    if !p.eof() && p.peek() == '.' {
+      p.offset++
+      for !p.eof() && p.peek() >= '0' && p.peek() <= '9' {
+        p.offset++
+      }
+      raw := p.source[start:p.offset]
+      if !astSelectorNumberPattern.MatchString(raw) {
+        return astSelectorValue{}, p.errorf("invalid attribute value")
+      }
+      number, _ := strconv.ParseFloat(raw, 64)
+      return astSelectorValue{kind: astSelectorValueLiteral, literal: raw, number: &number}, nil
+    }
+    p.offset = start
+  }
+  raw := p.parseIdentifier()
   if raw == "" {
     return astSelectorValue{}, p.errorf("expected attribute value")
   }
@@ -566,7 +598,7 @@ func (p *astSelectorParser) parseIdentifier() string {
   start := p.offset
   for !p.eof() {
     ch := p.peek()
-    if isASTSelectorSpace(ch) || strings.ContainsRune("[](),:#!=><~+.*'\"/", rune(ch)) {
+    if isASTSelectorSpace(ch) || strings.ContainsRune("[](),:#!=><~+.", rune(ch)) {
       break
     }
     p.offset++

--- a/packages/lint/linthost/ast_selector_parser.go
+++ b/packages/lint/linthost/ast_selector_parser.go
@@ -1,0 +1,595 @@
+package linthost
+
+import (
+  "fmt"
+  "regexp"
+  "strconv"
+  "strings"
+  "unicode"
+)
+
+type astSelectorKind uint8
+
+const (
+  astSelectorWildcard astSelectorKind = iota
+  astSelectorNodeType
+  astSelectorExactNode
+  astSelectorAttribute
+  astSelectorField
+  astSelectorMatches
+  astSelectorCompound
+  astSelectorNot
+  astSelectorHas
+  astSelectorChild
+  astSelectorDescendant
+  astSelectorSibling
+  astSelectorAdjacent
+  astSelectorNthChild
+  astSelectorNthLastChild
+  astSelectorClass
+)
+
+type astSelector struct {
+  kind      astSelectorKind
+  name      string
+  operator  string
+  value     astSelectorValue
+  selectors []*astSelector
+  left      *astSelector
+  right     *astSelector
+  index     int
+  subject   bool
+}
+
+type astSelectorValueKind uint8
+
+const (
+  astSelectorValueMissing astSelectorValueKind = iota
+  astSelectorValueLiteral
+  astSelectorValueType
+  astSelectorValueRegexp
+)
+
+type astSelectorValue struct {
+  kind    astSelectorValueKind
+  literal string
+  number  *float64
+  regexp  *regexp.Regexp
+}
+
+// parseASTSelector parses the selector language documented by esquery. The
+// matcher runs over TypeScript-Go's AST rather than ESTree, but the grammar is
+// intentionally the same: node types, attributes, fields, combinators,
+// :not/:is/:matches/:has, child-position pseudos, classes, and subjects.
+func parseASTSelector(source string) (*astSelector, error) {
+  parser := &astSelectorParser{source: source}
+  parser.skipSpace()
+  if parser.eof() {
+    return nil, fmt.Errorf("selector must not be empty")
+  }
+  selector, err := parser.parseSelectorList(0)
+  if err != nil {
+    return nil, err
+  }
+  parser.skipSpace()
+  if !parser.eof() {
+    return nil, parser.errorf("unexpected %q", parser.peek())
+  }
+  return selector, nil
+}
+
+type astSelectorParser struct {
+  source string
+  offset int
+}
+
+func (p *astSelectorParser) parseSelectorList(stop byte) (*astSelector, error) {
+  selectors := make([]*astSelector, 0, 1)
+  for {
+    p.skipSpace()
+    if p.eof() || stop != 0 && p.peek() == stop {
+      if len(selectors) == 0 {
+        return nil, p.errorf("expected selector")
+      }
+      break
+    }
+    selector, err := p.parseSelector()
+    if err != nil {
+      return nil, err
+    }
+    selectors = append(selectors, selector)
+    p.skipSpace()
+    if p.eof() || stop != 0 && p.peek() == stop {
+      break
+    }
+    if p.peek() != ',' {
+      return nil, p.errorf("expected ','")
+    }
+    p.offset++
+    p.skipSpace()
+    if p.eof() || stop != 0 && p.peek() == stop {
+      return nil, p.errorf("expected selector after ','")
+    }
+  }
+  if len(selectors) == 1 {
+    return selectors[0], nil
+  }
+  return &astSelector{kind: astSelectorMatches, selectors: selectors}, nil
+}
+
+func (p *astSelectorParser) parseSelector() (*astSelector, error) {
+  left, err := p.parseSequence()
+  if err != nil {
+    return nil, err
+  }
+  for {
+    spaced := p.skipSpace()
+    if p.eof() || p.peek() == ',' || p.peek() == ')' {
+      return left, nil
+    }
+    kind := astSelectorDescendant
+    switch p.peek() {
+    case '>':
+      kind = astSelectorChild
+      p.offset++
+      p.skipSpace()
+    case '~':
+      kind = astSelectorSibling
+      p.offset++
+      p.skipSpace()
+    case '+':
+      kind = astSelectorAdjacent
+      p.offset++
+      p.skipSpace()
+    default:
+      if !spaced {
+        return left, nil
+      }
+    }
+    right, err := p.parseSequence()
+    if err != nil {
+      return nil, err
+    }
+    left = &astSelector{kind: kind, left: left, right: right}
+  }
+}
+
+func (p *astSelectorParser) parseSequence() (*astSelector, error) {
+  subject := false
+  if !p.eof() && p.peek() == '!' {
+    subject = true
+    p.offset++
+  }
+  atoms := make([]*astSelector, 0, 2)
+  for !p.eof() {
+    switch p.peek() {
+    case ' ', '\t', '\r', '\n', ',', ')', '>', '~', '+':
+      goto done
+    }
+    atom, err := p.parseAtom()
+    if err != nil {
+      return nil, err
+    }
+    atoms = append(atoms, atom)
+  }
+
+done:
+  if len(atoms) == 0 {
+    return nil, p.errorf("expected selector atom")
+  }
+  var result *astSelector
+  if len(atoms) == 1 {
+    result = atoms[0]
+  } else {
+    result = &astSelector{kind: astSelectorCompound, selectors: atoms}
+  }
+  result.subject = subject
+  return result, nil
+}
+
+func (p *astSelectorParser) parseAtom() (*astSelector, error) {
+  if p.eof() {
+    return nil, p.errorf("expected selector atom")
+  }
+  switch p.peek() {
+  case '*':
+    p.offset++
+    return &astSelector{kind: astSelectorWildcard}, nil
+  case '[':
+    return p.parseAttribute()
+  case '.':
+    return p.parseField()
+  case ':':
+    return p.parsePseudo()
+  case '#':
+    p.offset++
+  }
+  name := p.parseIdentifier()
+  if name == "" {
+    return nil, p.errorf("expected node type")
+  }
+  return &astSelector{kind: astSelectorNodeType, name: name}, nil
+}
+
+func (p *astSelectorParser) parseAttribute() (*astSelector, error) {
+  p.offset++
+  p.skipSpace()
+  name := p.parsePath()
+  if name == "" {
+    return nil, p.errorf("expected attribute name")
+  }
+  p.skipSpace()
+  if p.eof() {
+    return nil, p.errorf("unterminated attribute selector")
+  }
+  if p.peek() == ']' {
+    p.offset++
+    return &astSelector{kind: astSelectorAttribute, name: name}, nil
+  }
+  operator := ""
+  if strings.ContainsRune("!<>", rune(p.peek())) {
+    operator = string(p.peek())
+    p.offset++
+  }
+  if !p.eof() && p.peek() == '=' {
+    operator += "="
+    p.offset++
+  } else if operator == "!" {
+    return nil, p.errorf("expected '=' after '!'")
+  }
+  if operator == "" {
+    return nil, p.errorf("expected attribute operator")
+  }
+  p.skipSpace()
+  value, err := p.parseAttributeValue(operator)
+  if err != nil {
+    return nil, err
+  }
+  p.skipSpace()
+  if p.eof() || p.peek() != ']' {
+    return nil, p.errorf("expected ']'")
+  }
+  p.offset++
+  return &astSelector{
+    kind:     astSelectorAttribute,
+    name:     name,
+    operator: operator,
+    value:    value,
+  }, nil
+}
+
+func (p *astSelectorParser) parseAttributeValue(operator string) (astSelectorValue, error) {
+  if p.eof() {
+    return astSelectorValue{}, p.errorf("expected attribute value")
+  }
+  if p.peek() == '\'' || p.peek() == '"' {
+    value, err := p.parseQuoted()
+    return astSelectorValue{kind: astSelectorValueLiteral, literal: value}, err
+  }
+  if p.peek() == '/' {
+    if operator != "=" && operator != "!=" {
+      return astSelectorValue{}, p.errorf("regular expressions require '=' or '!='")
+    }
+    compiled, err := p.parseRegexp()
+    return astSelectorValue{kind: astSelectorValueRegexp, regexp: compiled}, err
+  }
+  if strings.HasPrefix(p.source[p.offset:], "type(") {
+    if operator != "=" && operator != "!=" {
+      return astSelectorValue{}, p.errorf("type() requires '=' or '!='")
+    }
+    p.offset += len("type(")
+    p.skipSpace()
+    name := p.parseIdentifier()
+    p.skipSpace()
+    if name == "" || p.eof() || p.peek() != ')' {
+      return astSelectorValue{}, p.errorf("invalid type() value")
+    }
+    p.offset++
+    switch name {
+    case "string", "number", "boolean", "object", "undefined":
+    default:
+      return astSelectorValue{}, p.errorf("unknown type() value %q", name)
+    }
+    return astSelectorValue{kind: astSelectorValueType, literal: name}, nil
+  }
+  start := p.offset
+  for !p.eof() && !isASTSelectorSpace(p.peek()) && p.peek() != ']' {
+    p.offset++
+  }
+  raw := p.source[start:p.offset]
+  if raw == "" {
+    return astSelectorValue{}, p.errorf("expected attribute value")
+  }
+  if number, err := strconv.ParseFloat(raw, 64); err == nil {
+    return astSelectorValue{kind: astSelectorValueLiteral, literal: raw, number: &number}, nil
+  }
+  return astSelectorValue{kind: astSelectorValueLiteral, literal: raw}, nil
+}
+
+func (p *astSelectorParser) parseQuoted() (string, error) {
+  quote := p.peek()
+  p.offset++
+  var out strings.Builder
+  for !p.eof() {
+    ch := p.peek()
+    p.offset++
+    if ch == quote {
+      return out.String(), nil
+    }
+    if ch != '\\' {
+      out.WriteByte(ch)
+      continue
+    }
+    if p.eof() {
+      return "", p.errorf("unterminated string escape")
+    }
+    escaped := p.peek()
+    p.offset++
+    switch escaped {
+    case 'b':
+      out.WriteByte('\b')
+    case 'f':
+      out.WriteByte('\f')
+    case 'n':
+      out.WriteByte('\n')
+    case 'r':
+      out.WriteByte('\r')
+    case 't':
+      out.WriteByte('\t')
+    case 'v':
+      out.WriteByte('\v')
+    default:
+      out.WriteByte(escaped)
+    }
+  }
+  return "", p.errorf("unterminated string")
+}
+
+func (p *astSelectorParser) parseRegexp() (*regexp.Regexp, error) {
+  p.offset++
+  start := p.offset
+  inClass := false
+  escaped := false
+  end := -1
+  for !p.eof() {
+    ch := p.peek()
+    p.offset++
+    if escaped {
+      escaped = false
+      continue
+    }
+    if ch == '\\' {
+      escaped = true
+      continue
+    }
+    if ch == '[' {
+      inClass = true
+      continue
+    }
+    if ch == ']' {
+      inClass = false
+      continue
+    }
+    if ch == '/' && !inClass {
+      end = p.offset - 1
+      break
+    }
+  }
+  if end < 0 {
+    return nil, p.errorf("unterminated regular expression")
+  }
+  seenFlags := map[byte]struct{}{}
+  var goFlags strings.Builder
+  for !p.eof() {
+    flag := p.peek()
+    if !strings.ContainsRune("imsu", rune(flag)) {
+      break
+    }
+    p.offset++
+    if _, duplicate := seenFlags[flag]; duplicate {
+      return nil, p.errorf("duplicate regular-expression flag %q", flag)
+    }
+    seenFlags[flag] = struct{}{}
+    if flag != 'u' {
+      goFlags.WriteByte(flag)
+    }
+  }
+  pattern := p.source[start:end]
+  if goFlags.Len() != 0 {
+    pattern = "(?" + goFlags.String() + ":" + pattern + ")"
+  }
+  compiled, err := regexp.Compile(pattern)
+  if err != nil {
+    return nil, p.errorf("invalid regular expression: %v", err)
+  }
+  return compiled, nil
+}
+
+func (p *astSelectorParser) parseField() (*astSelector, error) {
+  p.offset++
+  name := p.parsePath()
+  if name == "" {
+    return nil, p.errorf("expected field name")
+  }
+  return &astSelector{kind: astSelectorField, name: name}, nil
+}
+
+func (p *astSelectorParser) parsePseudo() (*astSelector, error) {
+  p.offset++
+  name := p.parseIdentifier()
+  if name == "" {
+    return nil, p.errorf("expected pseudo-selector name")
+  }
+  switch name {
+  case "first-child":
+    return &astSelector{kind: astSelectorNthChild, index: 1}, nil
+  case "last-child":
+    return &astSelector{kind: astSelectorNthLastChild, index: 1}, nil
+  case "nth-child", "nth-last-child":
+    if p.eof() || p.peek() != '(' {
+      return nil, p.errorf("expected '('")
+    }
+    p.offset++
+    p.skipSpace()
+    start := p.offset
+    for !p.eof() && p.peek() >= '0' && p.peek() <= '9' {
+      p.offset++
+    }
+    if start == p.offset {
+      return nil, p.errorf("expected positive child index")
+    }
+    index, _ := strconv.Atoi(p.source[start:p.offset])
+    p.skipSpace()
+    if p.eof() || p.peek() != ')' {
+      return nil, p.errorf("expected ')'")
+    }
+    p.offset++
+    kind := astSelectorNthChild
+    if name == "nth-last-child" {
+      kind = astSelectorNthLastChild
+    }
+    return &astSelector{kind: kind, index: index}, nil
+  case "not", "matches", "is", "has":
+    if p.eof() || p.peek() != '(' {
+      return nil, p.errorf("expected '('")
+    }
+    p.offset++
+    p.skipSpace()
+    var nested *astSelector
+    var err error
+    if name == "has" {
+      nested, err = p.parseHasSelectorList()
+    } else {
+      nested, err = p.parseSelectorList(')')
+    }
+    if err != nil {
+      return nil, err
+    }
+    p.skipSpace()
+    if p.eof() || p.peek() != ')' {
+      return nil, p.errorf("expected ')'")
+    }
+    p.offset++
+    kind := astSelectorMatches
+    switch name {
+    case "not":
+      kind = astSelectorNot
+    case "has":
+      kind = astSelectorHas
+    }
+    selectors := nested.selectors
+    if nested.kind != astSelectorMatches {
+      selectors = []*astSelector{nested}
+    }
+    return &astSelector{kind: kind, selectors: selectors}, nil
+  default:
+    switch name {
+    case "statement", "expression", "declaration", "function", "pattern":
+      return &astSelector{kind: astSelectorClass, name: name}, nil
+    default:
+      return nil, p.errorf("unknown AST class %q", name)
+    }
+  }
+}
+
+func (p *astSelectorParser) parseHasSelectorList() (*astSelector, error) {
+  selectors := make([]*astSelector, 0, 1)
+  for {
+    p.skipSpace()
+    if p.eof() || p.peek() == ')' {
+      if len(selectors) == 0 {
+        return nil, p.errorf("expected selector")
+      }
+      break
+    }
+    var leading astSelectorKind
+    switch p.peek() {
+    case '>':
+      leading = astSelectorChild
+    case '~':
+      leading = astSelectorSibling
+    case '+':
+      leading = astSelectorAdjacent
+    }
+    if leading != 0 {
+      p.offset++
+      p.skipSpace()
+    }
+    selector, err := p.parseSelector()
+    if err != nil {
+      return nil, err
+    }
+    if leading != 0 {
+      selector = &astSelector{
+        kind:  leading,
+        left:  &astSelector{kind: astSelectorExactNode},
+        right: selector,
+      }
+    }
+    selectors = append(selectors, selector)
+    p.skipSpace()
+    if p.eof() || p.peek() == ')' {
+      break
+    }
+    if p.peek() != ',' {
+      return nil, p.errorf("expected ','")
+    }
+    p.offset++
+  }
+  if len(selectors) == 1 {
+    return selectors[0], nil
+  }
+  return &astSelector{kind: astSelectorMatches, selectors: selectors}, nil
+}
+
+func (p *astSelectorParser) parsePath() string {
+  first := p.parseIdentifier()
+  if first == "" {
+    return ""
+  }
+  var path strings.Builder
+  path.WriteString(first)
+  for !p.eof() && p.peek() == '.' {
+    mark := p.offset
+    p.offset++
+    next := p.parseIdentifier()
+    if next == "" {
+      p.offset = mark
+      break
+    }
+    path.WriteByte('.')
+    path.WriteString(next)
+  }
+  return path.String()
+}
+
+func (p *astSelectorParser) parseIdentifier() string {
+  start := p.offset
+  for !p.eof() {
+    ch := p.peek()
+    if isASTSelectorSpace(ch) || strings.ContainsRune("[](),:#!=><~+.*'\"/", rune(ch)) {
+      break
+    }
+    p.offset++
+  }
+  return p.source[start:p.offset]
+}
+
+func (p *astSelectorParser) skipSpace() bool {
+  start := p.offset
+  for !p.eof() && isASTSelectorSpace(p.peek()) {
+    p.offset++
+  }
+  return p.offset != start
+}
+
+func (p *astSelectorParser) eof() bool { return p.offset >= len(p.source) }
+func (p *astSelectorParser) peek() byte { return p.source[p.offset] }
+
+func (p *astSelectorParser) errorf(format string, args ...any) error {
+  return fmt.Errorf("selector byte %d: %s", p.offset+1, fmt.Sprintf(format, args...))
+}
+
+func isASTSelectorSpace(ch byte) bool {
+  return ch < unicode.MaxASCII && unicode.IsSpace(rune(ch))
+}

--- a/packages/lint/linthost/rules_no_restricted_syntax.go
+++ b/packages/lint/linthost/rules_no_restricted_syntax.go
@@ -29,7 +29,6 @@ type noRestrictedSyntaxOption struct {
 }
 
 type compiledNoRestrictedSyntaxOption struct {
-  source   string
   selector *astSelector
   message  string
 }
@@ -70,6 +69,7 @@ func compileNoRestrictedSyntaxOptions(raw json.RawMessage) ([]compiledNoRestrict
     return nil, err
   }
   compiled := make([]compiledNoRestrictedSyntaxOption, 0, len(options))
+  selectorIndexes := make(map[string]int, len(options))
   for index, option := range options {
     selector, err := parseASTSelector(option.selector)
     if err != nil {
@@ -79,11 +79,18 @@ func compileNoRestrictedSyntaxOptions(raw json.RawMessage) ([]compiledNoRestrict
     if option.messageSet && option.message != "" {
       message = option.message
     }
-    compiled = append(compiled, compiledNoRestrictedSyntaxOption{
-      source:   option.selector,
+    entry := compiledNoRestrictedSyntaxOption{
       selector: selector,
       message:  message,
-    })
+    }
+    if previous, exists := selectorIndexes[option.selector]; exists {
+      // ESLint registers selector listeners in an object. Reusing a selector
+      // therefore replaces its listener/message rather than reporting twice.
+      compiled[previous] = entry
+      continue
+    }
+    selectorIndexes[option.selector] = len(compiled)
+    compiled = append(compiled, entry)
   }
   return compiled, nil
 }

--- a/packages/lint/linthost/rules_no_restricted_syntax.go
+++ b/packages/lint/linthost/rules_no_restricted_syntax.go
@@ -1,47 +1,174 @@
-// noRestrictedSyntax: a project-level escape hatch that lets a team
-// ban specific AST node kinds outright. Upstream ESLint accepts an
-// arbitrary selector list and a per-entry message; without the
-// rule-options plumbing, this baseline ships a fixed default set that
-// covers the two syntactic constructs almost every modern TypeScript
-// project forbids: `with` (replaced by destructuring / explicit access
-// long ago) and labeled statements (used only to bridge complex
-// nested loops, which are themselves better refactored). The full
-// configurable surface is deferred — projects that need a custom
-// denylist can stack additional rules until option decoding lands.
+// noRestrictedSyntax applies only the AST selectors configured by the
+// project. It has no built-in denylist: a severity without selector options is
+// intentionally silent, matching ESLint's official rule contract.
+//
+// Selectors use esquery's grammar over the TypeScript-Go AST. Native kind
+// names (without the Kind prefix) are authoritative; common ESTree aliases are
+// accepted where the two trees have equivalent nodes. Tree combinators follow
+// TypeScript-Go's parent/ForEachChild relationships, so TypeScript-only syntax
+// participates without a parallel or monkeypatched AST.
 // https://eslint.org/docs/latest/rules/no-restricted-syntax
 package linthost
 
 import (
+  "bytes"
+  "encoding/json"
+  "fmt"
+  "io"
+  "strings"
+
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
 
-// noRestrictedSyntaxDefault is the built-in denylist surfaced when no
-// config is supplied. Each entry pairs a banned node kind with the
-// short, actionable message reported at the offending node.
-var noRestrictedSyntaxDefault = map[shimast.Kind]string{
-  shimast.KindWithStatement:    "`with` statements are restricted — use explicit property access instead.",
-  shimast.KindLabeledStatement: "Labeled statements are restricted — refactor the surrounding control flow instead.",
+type noRestrictedSyntax struct{}
+
+type noRestrictedSyntaxOption struct {
+  selector   string
+  message    string
+  messageSet bool
 }
 
-type noRestrictedSyntax struct{}
+type compiledNoRestrictedSyntaxOption struct {
+  source   string
+  selector *astSelector
+  message  string
+}
 
 func (noRestrictedSyntax) Name() string { return "no-restricted-syntax" }
 func (noRestrictedSyntax) Visits() []shimast.Kind {
-  kinds := make([]shimast.Kind, 0, len(noRestrictedSyntaxDefault))
-  for kind := range noRestrictedSyntaxDefault {
-    kinds = append(kinds, kind)
-  }
-  return kinds
+  return []shimast.Kind{shimast.KindSourceFile}
 }
+
+// ValidateOptions is consumed by the engine's optional rule-options
+// validation interface. Parsing here makes malformed selectors/configuration a
+// project configuration error before any file is linted.
+func (noRestrictedSyntax) ValidateOptions(raw json.RawMessage) error {
+  _, err := compileNoRestrictedSyntaxOptions(raw)
+  return err
+}
+
 func (noRestrictedSyntax) Check(ctx *Context, node *shimast.Node) {
-  if node == nil {
+  if ctx == nil || node == nil {
     return
   }
-  message, banned := noRestrictedSyntaxDefault[node.Kind]
-  if !banned {
+  options, err := compileNoRestrictedSyntaxOptions(ctx.Options)
+  if err != nil {
+    // Engine construction already records this as ConfigError. Check stays
+    // side-effect-free for direct contributor calls that bypass validation.
     return
   }
-  ctx.Report(node, message)
+  for _, option := range options {
+    for _, restricted := range matchASTSelector(node, option.selector) {
+      ctx.Report(restricted, option.message)
+    }
+  }
+}
+
+func compileNoRestrictedSyntaxOptions(raw json.RawMessage) ([]compiledNoRestrictedSyntaxOption, error) {
+  options, err := decodeNoRestrictedSyntaxOptions(raw)
+  if err != nil {
+    return nil, err
+  }
+  compiled := make([]compiledNoRestrictedSyntaxOption, 0, len(options))
+  for index, option := range options {
+    selector, err := parseASTSelector(option.selector)
+    if err != nil {
+      return nil, fmt.Errorf("no-restricted-syntax option %d: invalid selector %q: %w", index+1, option.selector, err)
+    }
+    message := "Using '" + option.selector + "' is not allowed."
+    if option.messageSet && option.message != "" {
+      message = option.message
+    }
+    compiled = append(compiled, compiledNoRestrictedSyntaxOption{
+      source:   option.selector,
+      selector: selector,
+      message:  message,
+    })
+  }
+  return compiled, nil
+}
+
+func decodeNoRestrictedSyntaxOptions(raw json.RawMessage) ([]noRestrictedSyntaxOption, error) {
+  raw = bytes.TrimSpace(raw)
+  if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+    return nil, nil
+  }
+  encoded := make([]json.RawMessage, 0, 1)
+  if raw[0] == '[' {
+    if err := decodeStrictJSON(raw, &encoded); err != nil {
+      return nil, fmt.Errorf("no-restricted-syntax options must be selector strings or {selector,message} objects: %w", err)
+    }
+  } else {
+    encoded = append(encoded, append(json.RawMessage(nil), raw...))
+  }
+
+  options := make([]noRestrictedSyntaxOption, 0, len(encoded))
+  seen := make(map[string]struct{}, len(encoded))
+  for index, item := range encoded {
+    item = bytes.TrimSpace(item)
+    if len(item) == 0 {
+      return nil, fmt.Errorf("no-restricted-syntax option %d is empty", index+1)
+    }
+    option := noRestrictedSyntaxOption{}
+    uniquenessKey := ""
+    switch item[0] {
+    case '"':
+      if err := decodeStrictJSON(item, &option.selector); err != nil {
+        return nil, fmt.Errorf("no-restricted-syntax option %d must be a selector string: %w", index+1, err)
+      }
+      uniquenessKey = "string\x00" + option.selector
+    case '{':
+      object := struct {
+        Selector *string `json:"selector"`
+        Message  *string `json:"message"`
+      }{}
+      if err := decodeStrictJSON(item, &object); err != nil {
+        return nil, fmt.Errorf("no-restricted-syntax option %d must contain only selector and message: %w", index+1, err)
+      }
+      if object.Selector == nil {
+        return nil, fmt.Errorf("no-restricted-syntax option %d is missing selector", index+1)
+      }
+      option.selector = *object.Selector
+      if object.Message != nil {
+        option.message = *object.Message
+        option.messageSet = true
+      }
+      uniquenessKey = "object\x00" + option.selector + "\x00" + strconvBool(option.messageSet) + "\x00" + option.message
+    default:
+      return nil, fmt.Errorf("no-restricted-syntax option %d must be a selector string or {selector,message} object", index+1)
+    }
+    if strings.TrimSpace(option.selector) == "" {
+      return nil, fmt.Errorf("no-restricted-syntax option %d selector must not be empty", index+1)
+    }
+    if _, duplicate := seen[uniquenessKey]; duplicate {
+      return nil, fmt.Errorf("no-restricted-syntax option %d duplicates an earlier option", index+1)
+    }
+    seen[uniquenessKey] = struct{}{}
+    options = append(options, option)
+  }
+  return options, nil
+}
+
+func decodeStrictJSON(raw json.RawMessage, out any) error {
+  decoder := json.NewDecoder(bytes.NewReader(raw))
+  decoder.DisallowUnknownFields()
+  if err := decoder.Decode(out); err != nil {
+    return err
+  }
+  if err := decoder.Decode(&struct{}{}); err != io.EOF {
+    if err == nil {
+      return fmt.Errorf("multiple JSON values")
+    }
+    return err
+  }
+  return nil
+}
+
+func strconvBool(value bool) string {
+  if value {
+    return "true"
+  }
+  return "false"
 }
 
 func init() {

--- a/packages/lint/linthost/rules_no_restricted_syntax.go
+++ b/packages/lint/linthost/rules_no_restricted_syntax.go
@@ -15,6 +15,7 @@ import (
   "encoding/json"
   "fmt"
   "io"
+  "sort"
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
@@ -28,9 +29,21 @@ type noRestrictedSyntaxOption struct {
   messageSet bool
 }
 
+type noRestrictedSyntaxOptionKey struct {
+  selector   string
+  message    string
+  messageSet bool
+  structured bool
+}
+
 type compiledNoRestrictedSyntaxOption struct {
   selector *astSelector
   message  string
+}
+
+type noRestrictedSyntaxMatch struct {
+  node    *shimast.Node
+  message string
 }
 
 func (noRestrictedSyntax) Name() string { return "no-restricted-syntax" }
@@ -56,10 +69,17 @@ func (noRestrictedSyntax) Check(ctx *Context, node *shimast.Node) {
     // side-effect-free for direct contributor calls that bypass validation.
     return
   }
+  matches := make([]noRestrictedSyntaxMatch, 0)
   for _, option := range options {
     for _, restricted := range matchASTSelector(node, option.selector) {
-      ctx.Report(restricted, option.message)
+      matches = append(matches, noRestrictedSyntaxMatch{node: restricted, message: option.message})
     }
+  }
+  sort.SliceStable(matches, func(left, right int) bool {
+    return matches[left].node.Pos() < matches[right].node.Pos()
+  })
+  for _, match := range matches {
+    ctx.Report(match.node, match.message)
   }
 }
 
@@ -110,37 +130,46 @@ func decodeNoRestrictedSyntaxOptions(raw json.RawMessage) ([]noRestrictedSyntaxO
   }
 
   options := make([]noRestrictedSyntaxOption, 0, len(encoded))
-  seen := make(map[string]struct{}, len(encoded))
+  seen := make(map[noRestrictedSyntaxOptionKey]struct{}, len(encoded))
   for index, item := range encoded {
     item = bytes.TrimSpace(item)
     if len(item) == 0 {
       return nil, fmt.Errorf("no-restricted-syntax option %d is empty", index+1)
     }
     option := noRestrictedSyntaxOption{}
-    uniquenessKey := ""
+    uniquenessKey := noRestrictedSyntaxOptionKey{}
     switch item[0] {
     case '"':
       if err := decodeStrictJSON(item, &option.selector); err != nil {
         return nil, fmt.Errorf("no-restricted-syntax option %d must be a selector string: %w", index+1, err)
       }
-      uniquenessKey = "string\x00" + option.selector
+      uniquenessKey.selector = option.selector
     case '{':
       object := struct {
-        Selector *string `json:"selector"`
-        Message  *string `json:"message"`
+        Selector json.RawMessage `json:"selector"`
+        Message  json.RawMessage `json:"message"`
       }{}
       if err := decodeStrictJSON(item, &object); err != nil {
         return nil, fmt.Errorf("no-restricted-syntax option %d must contain only selector and message: %w", index+1, err)
       }
-      if object.Selector == nil {
+      if len(object.Selector) == 0 {
         return nil, fmt.Errorf("no-restricted-syntax option %d is missing selector", index+1)
       }
-      option.selector = *object.Selector
-      if object.Message != nil {
-        option.message = *object.Message
+      if err := decodeNoRestrictedSyntaxString(object.Selector, &option.selector); err != nil {
+        return nil, fmt.Errorf("no-restricted-syntax option %d selector must be a string: %w", index+1, err)
+      }
+      if len(object.Message) != 0 {
+        if err := decodeNoRestrictedSyntaxString(object.Message, &option.message); err != nil {
+          return nil, fmt.Errorf("no-restricted-syntax option %d message must be a string: %w", index+1, err)
+        }
         option.messageSet = true
       }
-      uniquenessKey = "object\x00" + option.selector + "\x00" + strconvBool(option.messageSet) + "\x00" + option.message
+      uniquenessKey = noRestrictedSyntaxOptionKey{
+        selector:   option.selector,
+        message:    option.message,
+        messageSet: option.messageSet,
+        structured: true,
+      }
     default:
       return nil, fmt.Errorf("no-restricted-syntax option %d must be a selector string or {selector,message} object", index+1)
     }
@@ -156,6 +185,14 @@ func decodeNoRestrictedSyntaxOptions(raw json.RawMessage) ([]noRestrictedSyntaxO
   return options, nil
 }
 
+func decodeNoRestrictedSyntaxString(raw json.RawMessage, out *string) error {
+  trimmed := bytes.TrimSpace(raw)
+  if len(trimmed) < 2 || trimmed[0] != '"' {
+    return fmt.Errorf("expected JSON string")
+  }
+  return decodeStrictJSON(trimmed, out)
+}
+
 func decodeStrictJSON(raw json.RawMessage, out any) error {
   decoder := json.NewDecoder(bytes.NewReader(raw))
   decoder.DisallowUnknownFields()
@@ -169,13 +206,6 @@ func decodeStrictJSON(raw json.RawMessage, out any) error {
     return err
   }
   return nil
-}
-
-func strconvBool(value bool) string {
-  if value {
-    return "true"
-  }
-  return "false"
 }
 
 func init() {

--- a/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
@@ -150,6 +150,30 @@ export type TtscLintCoreNoInnerDeclarationsRuleSetting =
       ITtscLintCoreNoInnerDeclarationsRuleOptions,
     ];
 
+/** One restriction accepted by ESLint's `no-restricted-syntax` rule. */
+export type TtscLintCoreNoRestrictedSyntaxSelector =
+  | string
+  | {
+      /** esquery selector evaluated against the TypeScript-Go AST. */
+      selector: string;
+
+      /** Diagnostic text replacing the canonical default message. */
+      message?: string;
+    };
+
+/**
+ * Canonical variadic setting for `no-restricted-syntax`.
+ *
+ * Every tuple item after the severity is one independently reported selector.
+ * A bare severity or one-element tuple carries no selectors and is silent.
+ */
+export type TtscLintCoreNoRestrictedSyntaxRuleSetting =
+  | TtscLintRuleSetting
+  | readonly [
+      TtscLintSeverity,
+      ...TtscLintCoreNoRestrictedSyntaxSelector[],
+    ];
+
 /**
  * `no-fallthrough` rule options.
  *

--- a/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
@@ -13,6 +13,7 @@ import type {
   ITtscLintNoFallthroughRuleOptions,
   TtscLintCoreNoInnerDeclarationsRuleSetting,
   TtscLintCoreNoRestrictedImportsRuleSetting,
+  TtscLintCoreNoRestrictedSyntaxRuleSetting,
 } from "./ITtscLintCoreRuleOptions";
 
 /**
@@ -939,11 +940,15 @@ export interface ITtscLintCoreRules {
   "no-restricted-imports"?: TtscLintCoreNoRestrictedImportsRuleSetting;
 
   /**
-   * Reject AST node kinds listed in the project denylist.
+   * Reject syntax matching the configured AST selectors. With no selector
+   * options the rule is silent; it does not impose a built-in denylist.
+   *
+   * Native TypeScript-Go kind names and the documented esquery-compatible
+   * selector forms are supported, including TypeScript-only syntax.
    *
    * @reference https://eslint.org/docs/latest/rules/no-restricted-syntax
    */
-  "no-restricted-syntax"?: TtscLintRuleSetting;
+  "no-restricted-syntax"?: TtscLintCoreNoRestrictedSyntaxRuleSetting;
 
   /**
    * Reject assignment expressions used as the operand of `return` (`return x =

--- a/packages/lint/test/rules/control-flow/no_restricted_syntax_test.go
+++ b/packages/lint/test/rules/control-flow/no_restricted_syntax_test.go
@@ -81,6 +81,22 @@ func TestNoRestrictedSyntaxAppliesEveryConfiguredEntryAndCustomMessage(t *testin
   )
 }
 
+func TestNoRestrictedSyntaxUsesTheLastMessageForARepeatedSelector(t *testing.T) {
+  source := `debugger;
+`
+  options := json.RawMessage(`[
+    {"selector":"DebuggerStatement","message":"Superseded message."},
+    "DebuggerStatement",
+    {"selector":"DebuggerStatement","message":"Final message."}
+  ]`)
+  runNoRestrictedSyntax(
+    t,
+    source,
+    options,
+    noRestrictedSyntaxExpectation{target: "debugger;", message: "Final message."},
+  )
+}
+
 func TestNoRestrictedSyntaxMatchesAttributesNestedPathsRegexTypesAndLengths(t *testing.T) {
   source := `declare function DANGER(first: number, second: number): void;
 const target = { key: true };
@@ -102,6 +118,93 @@ JSON.stringify(present);
     source,
     json.RawMessage(`"`+binarySelector+`"`),
     noRestrictedSyntaxExpectation{target: `"key" in target`, message: noRestrictedDefaultMessage(binarySelector)},
+  )
+}
+
+func TestNoRestrictedSyntaxMatchesIndexedPathsLiteralTypesAndPrefix(t *testing.T) {
+  source := `declare function choose(first: string, second: number): void;
+let count = 0;
+++count;
+count++;
+choose("x", count);
+`
+  indexedSelector := `FunctionDeclaration[params.0.name='first']`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+indexedSelector+`"`),
+    noRestrictedSyntaxExpectation{
+      target:  "declare function choose(first: string, second: number): void;",
+      message: noRestrictedDefaultMessage(indexedSelector),
+    },
+  )
+
+  numberSelector := `NumericLiteral[value=type(number)][value=0]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+numberSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "0", message: noRestrictedDefaultMessage(numberSelector)},
+  )
+
+  prefixSelector := `UpdateExpression[prefix=true]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+prefixSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "++count", message: noRestrictedDefaultMessage(prefixSelector)},
+  )
+
+  bodySelector := `Program[body.length=5]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+bodySelector+`"`),
+    noRestrictedSyntaxExpectation{target: source, message: noRestrictedDefaultMessage(bodySelector)},
+  )
+}
+
+func TestNoRestrictedSyntaxLimitsBooleanPropertiesAndESTreeAliases(t *testing.T) {
+  source := `let count = 0;
+++count;
+void count;
+class Box { classMethod(): number { return 1; } }
+const record = { objectMethod(): number { return 2; } };
+JSON.stringify([Box, record]);
+`
+  runNoRestrictedSyntax(t, source, json.RawMessage(`"Identifier[async=false]"`))
+
+  unarySelector := `UnaryExpression`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+unarySelector+`"`),
+    noRestrictedSyntaxExpectation{target: "void count", message: noRestrictedDefaultMessage(unarySelector)},
+  )
+
+  propertySelector := `Property`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+propertySelector+`"`),
+    noRestrictedSyntaxExpectation{
+      target:  "objectMethod(): number { return 2; }",
+      message: noRestrictedDefaultMessage(propertySelector),
+    },
+  )
+}
+
+func TestNoRestrictedSyntaxExposesComputedKeysAndPropertyValuePaths(t *testing.T) {
+  source := `const key = "answer";
+const record = { [key]: () => 42, plain: () => 0 };
+JSON.stringify(record);
+`
+  selector := `PropertyAssignment[computed=true][value.type='ArrowFunction']`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+selector+`"`),
+    noRestrictedSyntaxExpectation{target: "[key]: () => 42", message: noRestrictedDefaultMessage(selector)},
   )
 }
 
@@ -178,7 +281,7 @@ JSON.stringify([satisfied, returns]);
     noRestrictedSyntaxExpectation{target: "input satisfies unknown", message: noRestrictedDefaultMessage(selector)},
   )
 
-  classSelector := `:function:has(ReturnStatement)`
+  classSelector := `:FUNCTION:has(ReturnStatement)`
   runNoRestrictedSyntax(
     t,
     source,
@@ -210,6 +313,7 @@ func TestNoRestrictedSyntaxRejectsInvalidConfigurationBeforeDispatch(t *testing.
     {name: "duplicate", options: json.RawMessage(`["Identifier","Identifier"]`), want: "duplicates an earlier option"},
     {name: "unterminated attribute", options: json.RawMessage(`"Identifier[name='x'"`), want: "expected ']'"},
     {name: "invalid regexp", options: json.RawMessage(`"Identifier[name=/(/]"`), want: "invalid regular expression"},
+    {name: "empty regexp", options: json.RawMessage(`"Identifier[name=//]"`), want: "regular expression must not be empty"},
     {name: "unknown class", options: json.RawMessage(`":mystery"`), want: "unknown AST class"},
   }
   for _, tc := range cases {

--- a/packages/lint/test/rules/control-flow/no_restricted_syntax_test.go
+++ b/packages/lint/test/rules/control-flow/no_restricted_syntax_test.go
@@ -97,6 +97,33 @@ func TestNoRestrictedSyntaxUsesTheLastMessageForARepeatedSelector(t *testing.T) 
   )
 }
 
+func TestNoRestrictedSyntaxChecksStructuredOptionUniquenessByFields(t *testing.T) {
+  options, err := decodeNoRestrictedSyntaxOptions(json.RawMessage(`[
+    {"selector":"A","message":"B\u0000true\u0000C"},
+    {"selector":"A\u0000true\u0000B","message":"C"}
+  ]`))
+  if err != nil || len(options) != 2 {
+    t.Fatalf("distinct structured options collided: options=%+v err=%v", options, err)
+  }
+}
+
+func TestNoRestrictedSyntaxReportsMatchesInSourceOrder(t *testing.T) {
+  source := `debugger;
+with ({ value: 1 }) { void value; }
+`
+  options := json.RawMessage(`["WithStatement","DebuggerStatement"]`)
+  runNoRestrictedSyntax(
+    t,
+    source,
+    options,
+    noRestrictedSyntaxExpectation{target: "debugger;", message: noRestrictedDefaultMessage("DebuggerStatement")},
+    noRestrictedSyntaxExpectation{
+      target:  "with ({ value: 1 }) { void value; }",
+      message: noRestrictedDefaultMessage("WithStatement"),
+    },
+  )
+}
+
 func TestNoRestrictedSyntaxMatchesAttributesNestedPathsRegexTypesAndLengths(t *testing.T) {
   source := `declare function DANGER(first: number, second: number): void;
 const target = { key: true };
@@ -121,9 +148,72 @@ JSON.stringify(present);
   )
 }
 
+func TestNoRestrictedSyntaxCoercesEmptyNodeListsForNumericComparisons(t *testing.T) {
+  source := `const empty = (): void => {};
+empty();
+`
+  selector := `CallExpression[arguments<1]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+selector+`"`),
+    noRestrictedSyntaxExpectation{target: "empty()", message: noRestrictedDefaultMessage(selector)},
+  )
+  runNoRestrictedSyntax(t, source, json.RawMessage(`"CallExpression[arguments>0]"`))
+}
+
+func TestNoRestrictedSyntaxPreservesNullAcrossNestedPaths(t *testing.T) {
+  source := `declare const flag: boolean;
+if (flag) { void flag; }
+`
+  selector := `IfStatement[alternate.missing=type(object)]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+selector+`"`),
+    noRestrictedSyntaxExpectation{target: "if (flag) { void flag; }", message: noRestrictedDefaultMessage(selector)},
+  )
+  runNoRestrictedSyntax(t, source, json.RawMessage(`"IfStatement[alternate.missing=type(undefined)]"`))
+}
+
+func TestNoRestrictedSyntaxStringifiesRegularExpressionValues(t *testing.T) {
+  source := `const pattern = /danger/mi;
+void pattern;
+`
+  selector := `RegularExpressionLiteral[value='/danger/im'][raw='/danger/mi'][value=type(object)]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+selector+`"`),
+    noRestrictedSyntaxExpectation{target: "/danger/mi", message: noRestrictedDefaultMessage(selector)},
+  )
+}
+
+func TestNoRestrictedSyntaxComparesStringsAsUTF16(t *testing.T) {
+  source := "const value = \"𐀀\";\nvoid value;\n"
+  selector := "StringLiteral[value<'\ue000']"
+  options, err := json.Marshal(selector)
+  if err != nil {
+    t.Fatal(err)
+  }
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(options),
+    noRestrictedSyntaxExpectation{target: "\"𐀀\"", message: noRestrictedDefaultMessage(selector)},
+  )
+}
+
 func TestNoRestrictedSyntaxMatchesIndexedPathsLiteralTypesAndPrefix(t *testing.T) {
   source := `declare function choose(first: string, second: number): void;
 let count = 0;
+const emoji = "😀";
+const amount = 0x10n;
+const precise = 9007199254740993n;
+const huge = 0x10000000000000000;
+const decimal = 100000000000000000000;
+const tiny = 0.000001;
+const infinity = 1e999;
 ++count;
 count++;
 choose("x", count);
@@ -138,13 +228,108 @@ choose("x", count);
       message: noRestrictedDefaultMessage(indexedSelector),
     },
   )
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"FunctionDeclaration[params.01.name='second']"`),
+  )
 
-  numberSelector := `NumericLiteral[value=type(number)][value=0]`
+  numberSelector := `NumericLiteral[value=type(number)][value=.0]`
   runNoRestrictedSyntax(
     t,
     source,
     json.RawMessage(`"`+numberSelector+`"`),
     noRestrictedSyntaxExpectation{target: "0", message: noRestrictedDefaultMessage(numberSelector)},
+  )
+
+  stringSelector := `StringLiteral[raw='"😀"'][value.length=2]`
+  stringOptions, err := json.Marshal(stringSelector)
+  if err != nil {
+    t.Fatal(err)
+  }
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(stringOptions),
+    noRestrictedSyntaxExpectation{target: `"😀"`, message: noRestrictedDefaultMessage(stringSelector)},
+  )
+
+  bigintSelector := `BigIntLiteral[value=16]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+bigintSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "0x10n", message: noRestrictedDefaultMessage(bigintSelector)},
+  )
+
+  preciseBigintSelector := `BigIntLiteral[value>'9007199254740992']`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+preciseBigintSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "9007199254740993n", message: noRestrictedDefaultMessage(preciseBigintSelector)},
+  )
+
+  infiniteNumberSelector := `BigIntLiteral[value>9007199254740992][value<` + strings.Repeat("9", 400) + `]`
+  infiniteNumberOptions, err := json.Marshal(infiniteNumberSelector)
+  if err != nil {
+    t.Fatal(err)
+  }
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(infiniteNumberOptions),
+    noRestrictedSyntaxExpectation{target: "9007199254740993n", message: noRestrictedDefaultMessage(infiniteNumberSelector)},
+  )
+
+  hugeNumberSelector := `NumericLiteral[value=18446744073709551616]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+hugeNumberSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "0x10000000000000000", message: noRestrictedDefaultMessage(hugeNumberSelector)},
+  )
+
+  decimalStringSelector := `NumericLiteral[value='100000000000000000000']`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+decimalStringSelector+`"`),
+    noRestrictedSyntaxExpectation{
+      target:  "100000000000000000000",
+      message: noRestrictedDefaultMessage(decimalStringSelector),
+    },
+  )
+
+  tinyStringSelector := `NumericLiteral[value='0.000001'][value>'0x0']`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+tinyStringSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "0.000001", message: noRestrictedDefaultMessage(tinyStringSelector)},
+  )
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"NumericLiteral[raw='0.000001'][value<'0x1_0']"`),
+  )
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"NumericLiteral[raw='0.000001'][value<'1_0']"`),
+  )
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"NumericLiteral[raw='0.000001'][value<'+0x1p0']"`),
+  )
+
+  infinitySelector := `NumericLiteral[value=Infinity][value=type(number)]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+infinitySelector+`"`),
+    noRestrictedSyntaxExpectation{target: "1e999", message: noRestrictedDefaultMessage(infinitySelector)},
   )
 
   prefixSelector := `UpdateExpression[prefix=true]`
@@ -155,7 +340,7 @@ choose("x", count);
     noRestrictedSyntaxExpectation{target: "++count", message: noRestrictedDefaultMessage(prefixSelector)},
   )
 
-  bodySelector := `Program[body.length=5]`
+  bodySelector := `Program[body.length=12]`
   runNoRestrictedSyntax(
     t,
     source,
@@ -194,12 +379,160 @@ JSON.stringify([Box, record]);
   )
 }
 
+func TestNoRestrictedSyntaxInheritsDeclareFromVariableStatements(t *testing.T) {
+  source := `declare const ambient: number;
+const local = 1;
+void local;
+`
+  declaredSelector := `VariableDeclarator[declare=true]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+declaredSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "ambient: number", message: noRestrictedDefaultMessage(declaredSelector)},
+  )
+
+  localSelector := `VariableDeclarator[declare=false]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+localSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "local = 1", message: noRestrictedDefaultMessage(localSelector)},
+  )
+}
+
+func TestNoRestrictedSyntaxKeepsTemplateAndLiteralAliasesDistinct(t *testing.T) {
+  source := "const text = `value`;\nvoid text;\n"
+  runNoRestrictedSyntax(t, source, json.RawMessage(`"Literal"`))
+  templateSelector := `TemplateLiteral`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+templateSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "`value`", message: noRestrictedDefaultMessage(templateSelector)},
+  )
+}
+
+func TestNoRestrictedSyntaxDistinguishesRestAndSpreadAliases(t *testing.T) {
+  source := `declare const record: Record<string, number>;
+function collect(...items: number[]): number[] { const values = items; return [...values]; }
+const clone = { ...record };
+JSON.stringify([collect, clone]);
+`
+  restSelector := `RestElement`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+restSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "...items: number[]", message: noRestrictedDefaultMessage(restSelector)},
+  )
+
+  restArgumentSelector := `RestElement[argument.name='items']`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+restArgumentSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "...items: number[]", message: noRestrictedDefaultMessage(restArgumentSelector)},
+  )
+
+  spreadSelector := `SpreadElement`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+spreadSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "...values", message: noRestrictedDefaultMessage(spreadSelector)},
+    noRestrictedSyntaxExpectation{target: "...record", message: noRestrictedDefaultMessage(spreadSelector)},
+  )
+  runNoRestrictedSyntax(t, source, json.RawMessage(`"Property"`))
+}
+
+func TestNoRestrictedSyntaxDistinguishesObjectBindingPropertiesFromRest(t *testing.T) {
+  source := `declare const record: { source: number; extra: number };
+const { source: local, ...remaining } = record;
+JSON.stringify([local, remaining]);
+`
+  propertySelector := `ObjectPattern > Property[key.name='source'][value.name='local']`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+propertySelector+`"`),
+    noRestrictedSyntaxExpectation{target: "source: local", message: noRestrictedDefaultMessage(propertySelector)},
+  )
+  runNoRestrictedSyntax(t, source, json.RawMessage(`"ObjectPattern > Property[key.name='remaining']"`))
+
+  restSelector := `ObjectPattern > RestElement[argument.name='remaining']`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+restSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "...remaining", message: noRestrictedDefaultMessage(restSelector)},
+  )
+}
+
+func TestNoRestrictedSyntaxDistinguishesAssignmentPatternsFromLiterals(t *testing.T) {
+  source := `let first = 0;
+let assignedRest: number[] = [];
+const rest: number[] = [];
+let value = 0;
+let assignedOthers: Record<string, number> = {};
+const others: Record<string, number> = {};
+[first = 1, ...assignedRest] = [1, 2];
+({ value, ...assignedOthers } = { value: 1 });
+const array = [...rest];
+const object = { ...others };
+JSON.stringify([first, value, array, object]);
+`
+  arrayPatternSelector := `ArrayPattern > RestElement`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+arrayPatternSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "...assignedRest", message: noRestrictedDefaultMessage(arrayPatternSelector)},
+  )
+
+  objectPatternSelector := `ObjectPattern > RestElement`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+objectPatternSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "...assignedOthers", message: noRestrictedDefaultMessage(objectPatternSelector)},
+  )
+
+  arrayExpressionSelector := `ArrayExpression > SpreadElement`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+arrayExpressionSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "...rest", message: noRestrictedDefaultMessage(arrayExpressionSelector)},
+  )
+
+  objectExpressionSelector := `ObjectExpression > SpreadElement`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+objectExpressionSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "...others", message: noRestrictedDefaultMessage(objectExpressionSelector)},
+  )
+
+  runNoRestrictedSyntax(t, source, json.RawMessage(`"ArrayPattern AssignmentExpression"`))
+  outerAssignmentSelector := `AssignmentExpression > ArrayPattern`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+outerAssignmentSelector+`"`),
+    noRestrictedSyntaxExpectation{
+      target:  "[first = 1, ...assignedRest]",
+      message: noRestrictedDefaultMessage(outerAssignmentSelector),
+    },
+  )
+}
+
 func TestNoRestrictedSyntaxExposesComputedKeysAndPropertyValuePaths(t *testing.T) {
   source := `const key = "answer";
 const record = { [key]: () => 42, plain: () => 0 };
 JSON.stringify(record);
 `
-  selector := `PropertyAssignment[computed=true][value.type='ArrowFunction']`
+  selector := `PropertyAssignment[computed=true][key.expression.name='key'][value.type='ArrowFunction']`
   runNoRestrictedSyntax(
     t,
     source,
@@ -208,9 +541,49 @@ JSON.stringify(record);
   )
 }
 
+func TestNoRestrictedSyntaxExposesSwitchCaseTestAndConsequent(t *testing.T) {
+  source := `let output = 0;
+switch (output) {
+  case 1: output = 1; break;
+  default: break;
+}
+`
+  selector := `CaseClause[test.value=1][consequent.length=2]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+selector+`"`),
+    noRestrictedSyntaxExpectation{target: "case 1: output = 1; break;", message: noRestrictedDefaultMessage(selector)},
+  )
+}
+
+func TestNoRestrictedSyntaxExposesScalarStatementBodies(t *testing.T) {
+  source := `label: { void 1; }
+try { throw 1; } catch (error) { void error; }
+class Box { static { void 2; } }
+void Box;
+`
+  cases := []struct {
+    selector string
+    target   string
+  }{
+    {selector: `LabeledStatement > Block.body`, target: `{ void 1; }`},
+    {selector: `CatchClause > Block.body`, target: `{ void error; }`},
+    {selector: `ClassStaticBlockDeclaration > Block.body`, target: `{ void 2; }`},
+  }
+  for _, tc := range cases {
+    runNoRestrictedSyntax(
+      t,
+      source,
+      json.RawMessage(`"`+tc.selector+`"`),
+      noRestrictedSyntaxExpectation{target: tc.target, message: noRestrictedDefaultMessage(tc.selector)},
+    )
+  }
+}
+
 func TestNoRestrictedSyntaxMatchesCombinatorsFieldsPseudosAndSubjects(t *testing.T) {
   functionSource := `function selected(value: number): number {
-  return value;
+  return arguments.length;
 }
 `
   fieldSelector := `FunctionDeclaration > Identifier.id`
@@ -221,12 +594,12 @@ func TestNoRestrictedSyntaxMatchesCombinatorsFieldsPseudosAndSubjects(t *testing
     noRestrictedSyntaxExpectation{target: "selected", message: noRestrictedDefaultMessage(fieldSelector)},
   )
 
-  descendantSelector := `FunctionDeclaration ReturnStatement > Identifier.expression`
+  descendantSelector := `FunctionDeclaration ReturnStatement > PropertyAccessExpression.argument`
   runNoRestrictedSyntax(
     t,
     functionSource,
     json.RawMessage(`"`+descendantSelector+`"`),
-    noRestrictedSyntaxExpectation{target: "value", message: noRestrictedDefaultMessage(descendantSelector)},
+    noRestrictedSyntaxExpectation{target: "arguments.length", message: noRestrictedDefaultMessage(descendantSelector)},
   )
 
   hasSelector := `FunctionDeclaration:has(> Identifier.id):not([async=true])`
@@ -262,6 +635,36 @@ JSON.stringify([first, second, third]);
     json.RawMessage(`"`+siblingSelector+`"`),
     noRestrictedSyntaxExpectation{target: "third = 3", message: noRestrictedDefaultMessage(siblingSelector)},
   )
+
+  callSource := `declare function combine(first: number, second: number): number;
+const result = combine(1, 2);
+void result;
+`
+  runNoRestrictedSyntax(
+    t,
+    callSource,
+    json.RawMessage(`"CallExpression > Identifier[name='combine']:first-child"`),
+  )
+  argumentSelector := `CallExpression > NumericLiteral[value=1]:first-child + NumericLiteral[value=2]:last-child`
+  runNoRestrictedSyntax(
+    t,
+    callSource,
+    json.RawMessage(`"`+argumentSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "2", message: noRestrictedDefaultMessage(argumentSelector)},
+  )
+
+  classSource := `class Pair {
+  first(): void {}
+  second(): void {}
+}
+`
+  memberSelector := `ClassDeclaration > MethodDeclaration:first-child + MethodDeclaration:last-child`
+  runNoRestrictedSyntax(
+    t,
+    classSource,
+    json.RawMessage(`"`+memberSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "second(): void {}", message: noRestrictedDefaultMessage(memberSelector)},
+  )
 }
 
 func TestNoRestrictedSyntaxMatchesClassesAlternativesAndTypeScriptNodes(t *testing.T) {
@@ -288,6 +691,18 @@ JSON.stringify([satisfied, returns]);
     json.RawMessage(`"`+classSelector+`"`),
     noRestrictedSyntaxExpectation{target: "function returns(): unknown { return asserted; }", message: noRestrictedDefaultMessage(classSelector)},
   )
+
+  literalSource := `const values = [true, null];
+void values;
+`
+  expressionSelector := `Literal:expression`
+  runNoRestrictedSyntax(
+    t,
+    literalSource,
+    json.RawMessage(`"`+expressionSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "true", message: noRestrictedDefaultMessage(expressionSelector)},
+    noRestrictedSyntaxExpectation{target: "null", message: noRestrictedDefaultMessage(expressionSelector)},
+  )
 }
 
 func noRestrictedSyntaxValidationEngine(options json.RawMessage) *Engine {
@@ -308,12 +723,16 @@ func TestNoRestrictedSyntaxRejectsInvalidConfigurationBeforeDispatch(t *testing.
     {name: "malformed JSON", options: json.RawMessage(`{"selector":`), want: "must contain only selector and message"},
     {name: "wrong entry type", options: json.RawMessage(`42`), want: "must be a selector string or {selector,message} object"},
     {name: "missing selector", options: json.RawMessage(`{"message":"missing"}`), want: "is missing selector"},
+    {name: "null selector", options: json.RawMessage(`{"selector":null}`), want: "selector must be a string"},
+    {name: "null message", options: json.RawMessage(`{"selector":"Identifier","message":null}`), want: "message must be a string"},
+    {name: "boolean message", options: json.RawMessage(`{"selector":"Identifier","message":true}`), want: "message must be a string"},
     {name: "unknown key", options: json.RawMessage(`{"selector":"Identifier","extra":true}`), want: "unknown field"},
     {name: "empty selector", options: json.RawMessage(`"  "`), want: "selector must not be empty"},
     {name: "duplicate", options: json.RawMessage(`["Identifier","Identifier"]`), want: "duplicates an earlier option"},
     {name: "unterminated attribute", options: json.RawMessage(`"Identifier[name='x'"`), want: "expected ']'"},
     {name: "invalid regexp", options: json.RawMessage(`"Identifier[name=/(/]"`), want: "invalid regular expression"},
     {name: "empty regexp", options: json.RawMessage(`"Identifier[name=//]"`), want: "regular expression must not be empty"},
+    {name: "invalid unquoted path", options: json.RawMessage(`"Identifier[name==value]"`), want: "expected attribute value"},
     {name: "unknown class", options: json.RawMessage(`":mystery"`), want: "unknown AST class"},
   }
   for _, tc := range cases {

--- a/packages/lint/test/rules/control-flow/no_restricted_syntax_test.go
+++ b/packages/lint/test/rules/control-flow/no_restricted_syntax_test.go
@@ -1,20 +1,268 @@
 package linthost
 
-import "testing"
+import (
+  "encoding/json"
+  "strings"
+  "testing"
+)
 
-// TestRuleCorpusNoRestrictedSyntax verifies the lint rule corpus fixture no-restricted-syntax.ts.
-//
-// Rule corpus tests mirror tests/test-lint/src/cases inside Go unit coverage. Each generated
-// scenario keeps one annotated TypeScript fixture tied to the native Engine so individual rule
-// Check methods are measured by go test instead of only by the TypeScript feature runner.
-//
-// This case enables the rule annotations declared in no-restricted-syntax.ts and compares
-// normalized rule, severity, and line triples. The source text stays embedded in the
-// generated Go file so the test remains package-local and deterministic.
-//
-// 1. Load the annotated TypeScript fixture source embedded below.
-// 2. Enable the rule severities declared by its // expect: comments.
-// 3. Assert the native Engine reports exactly the annotated diagnostics.
-func TestRuleCorpusNoRestrictedSyntax(t *testing.T) {
-  assertRuleCorpusCase(t, "no-restricted-syntax.ts", "function runWith(target: { value: number }): number {\n  let total = 0;\n  // expect: no-restricted-syntax error\n  with (target) {\n    total = value;\n  }\n  return total;\n}\n\nfunction runLabeled(): number {\n  let acc = 0;\n  // expect: no-restricted-syntax error\n  outer: for (let i = 0; i < 3; i += 1) {\n    for (let j = 0; j < 3; j += 1) {\n      if (i + j > 3) break outer;\n      acc += 1;\n    }\n  }\n  return acc;\n}\n\n// Negative: ordinary statements stay silent.\nfunction plain(value: number): number {\n  return value + 1;\n}\n\nJSON.stringify({\n  runWith: runWith({ value: 7 }),\n  runLabeled: runLabeled(),\n  plain: plain(3),\n});\n")
+type noRestrictedSyntaxExpectation struct {
+  target  string
+  message string
+}
+
+func runNoRestrictedSyntax(
+  t *testing.T,
+  source string,
+  options json.RawMessage,
+  expected ...noRestrictedSyntaxExpectation,
+) {
+  t.Helper()
+  _, _, findings := runRuleFindingsSnapshot(t, "no-restricted-syntax", source, options)
+  if len(findings) != len(expected) {
+    t.Fatalf("no-restricted-syntax finding count mismatch: want=%+v got=%+v", expected, findings)
+  }
+  searchFrom := 0
+  for index, want := range expected {
+    relative := strings.Index(source[searchFrom:], want.target)
+    if relative < 0 {
+      t.Fatalf("expectation %d target %q is absent after byte %d", index, want.target, searchFrom)
+    }
+    start := searchFrom + relative
+    end := start + len(want.target)
+    finding := findings[index]
+    if finding.Rule != "no-restricted-syntax" || finding.Severity != SeverityError ||
+      finding.Pos != start || finding.End != end || finding.Message != want.message {
+      t.Fatalf("finding %d mismatch: want=%+v range=[%d,%d) got=%+v", index, want, start, end, finding)
+    }
+    if len(finding.Fix) != 0 || len(finding.Suggestions) != 0 {
+      t.Fatalf("finding %d unexpectedly offered edits: %+v", index, finding)
+    }
+    searchFrom = end
+  }
+}
+
+func noRestrictedDefaultMessage(selector string) string {
+  return "Using '" + selector + "' is not allowed."
+}
+
+func TestNoRestrictedSyntaxHasNoImplicitDenylist(t *testing.T) {
+  source := `function legacy(target: any): void {
+  with (target) { target.value = 1; }
+  outer: for (;;) { break outer; }
+}
+`
+  runNoRestrictedSyntax(t, source, nil)
+  runNoRestrictedSyntax(t, source, json.RawMessage(`[]`))
+}
+
+func TestNoRestrictedSyntaxAppliesEveryConfiguredEntryAndCustomMessage(t *testing.T) {
+  source := `function legacy(target: any): void {
+  with (target) { target.value = 1; }
+  outer: for (;;) { break outer; }
+}
+`
+  options := json.RawMessage(`[
+    "WithStatement",
+    {"selector":"LabeledStatement","message":"Labels obscure control flow."}
+  ]`)
+  runNoRestrictedSyntax(
+    t,
+    source,
+    options,
+    noRestrictedSyntaxExpectation{
+      target:  `with (target) { target.value = 1; }`,
+      message: noRestrictedDefaultMessage("WithStatement"),
+    },
+    noRestrictedSyntaxExpectation{
+      target:  `outer: for (;;) { break outer; }`,
+      message: "Labels obscure control flow.",
+    },
+  )
+}
+
+func TestNoRestrictedSyntaxMatchesAttributesNestedPathsRegexTypesAndLengths(t *testing.T) {
+  source := `declare function DANGER(first: number, second: number): void;
+const target = { key: true };
+const present = "key" in target;
+DANGER(1, 2);
+JSON.stringify(present);
+`
+  selector := `CallExpression[callee.name=/^danger$/iu][callee.name=type(string)][arguments.length>=2]`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`{"selector":"`+selector+`","message":"Dangerous call."}`),
+    noRestrictedSyntaxExpectation{target: "DANGER(1, 2)", message: "Dangerous call."},
+  )
+
+  binarySelector := `BinaryExpression[operator='in']`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+binarySelector+`"`),
+    noRestrictedSyntaxExpectation{target: `"key" in target`, message: noRestrictedDefaultMessage(binarySelector)},
+  )
+}
+
+func TestNoRestrictedSyntaxMatchesCombinatorsFieldsPseudosAndSubjects(t *testing.T) {
+  functionSource := `function selected(value: number): number {
+  return value;
+}
+`
+  fieldSelector := `FunctionDeclaration > Identifier.id`
+  runNoRestrictedSyntax(
+    t,
+    functionSource,
+    json.RawMessage(`"`+fieldSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "selected", message: noRestrictedDefaultMessage(fieldSelector)},
+  )
+
+  descendantSelector := `FunctionDeclaration ReturnStatement > Identifier.expression`
+  runNoRestrictedSyntax(
+    t,
+    functionSource,
+    json.RawMessage(`"`+descendantSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "value", message: noRestrictedDefaultMessage(descendantSelector)},
+  )
+
+  hasSelector := `FunctionDeclaration:has(> Identifier.id):not([async=true])`
+  runNoRestrictedSyntax(
+    t,
+    functionSource,
+    json.RawMessage(`"`+hasSelector+`"`),
+    noRestrictedSyntaxExpectation{target: strings.TrimSpace(functionSource), message: noRestrictedDefaultMessage(hasSelector)},
+  )
+
+  subjectSelector := `!FunctionDeclaration > Identifier.id`
+  runNoRestrictedSyntax(
+    t,
+    functionSource,
+    json.RawMessage(`"`+subjectSelector+`"`),
+    noRestrictedSyntaxExpectation{target: strings.TrimSpace(functionSource), message: noRestrictedDefaultMessage(subjectSelector)},
+  )
+
+  siblingSource := `const first = 1, second = 2, third = 3;
+JSON.stringify([first, second, third]);
+`
+  adjacentSelector := `VariableDeclaration + VariableDeclaration[name='second']:nth-child(2)`
+  runNoRestrictedSyntax(
+    t,
+    siblingSource,
+    json.RawMessage(`"`+adjacentSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "second = 2", message: noRestrictedDefaultMessage(adjacentSelector)},
+  )
+  siblingSelector := `VariableDeclaration ~ VariableDeclaration[name='third']:last-child`
+  runNoRestrictedSyntax(
+    t,
+    siblingSource,
+    json.RawMessage(`"`+siblingSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "third = 3", message: noRestrictedDefaultMessage(siblingSelector)},
+  )
+}
+
+func TestNoRestrictedSyntaxMatchesClassesAlternativesAndTypeScriptNodes(t *testing.T) {
+  source := `type Text = string;
+declare const input: unknown;
+const asserted = input as Text;
+const satisfied = input satisfies unknown;
+function returns(): unknown { return asserted; }
+JSON.stringify([satisfied, returns]);
+`
+  selector := `:matches(TSAsExpression, TSSatisfiesExpression)`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+selector+`"`),
+    noRestrictedSyntaxExpectation{target: "input as Text", message: noRestrictedDefaultMessage(selector)},
+    noRestrictedSyntaxExpectation{target: "input satisfies unknown", message: noRestrictedDefaultMessage(selector)},
+  )
+
+  classSelector := `:function:has(ReturnStatement)`
+  runNoRestrictedSyntax(
+    t,
+    source,
+    json.RawMessage(`"`+classSelector+`"`),
+    noRestrictedSyntaxExpectation{target: "function returns(): unknown { return asserted; }", message: noRestrictedDefaultMessage(classSelector)},
+  )
+}
+
+func noRestrictedSyntaxValidationEngine(options json.RawMessage) *Engine {
+  return NewEngineWithResolver(InlineRuleResolver{
+    Rules: RuleConfig{"no-restricted-syntax": SeverityError},
+    Options: RuleOptionsMap{
+      "no-restricted-syntax": options,
+    },
+  })
+}
+
+func TestNoRestrictedSyntaxRejectsInvalidConfigurationBeforeDispatch(t *testing.T) {
+  cases := []struct {
+    name    string
+    options json.RawMessage
+    want    string
+  }{
+    {name: "malformed JSON", options: json.RawMessage(`{"selector":`), want: "must contain only selector and message"},
+    {name: "wrong entry type", options: json.RawMessage(`42`), want: "must be a selector string or {selector,message} object"},
+    {name: "missing selector", options: json.RawMessage(`{"message":"missing"}`), want: "is missing selector"},
+    {name: "unknown key", options: json.RawMessage(`{"selector":"Identifier","extra":true}`), want: "unknown field"},
+    {name: "empty selector", options: json.RawMessage(`"  "`), want: "selector must not be empty"},
+    {name: "duplicate", options: json.RawMessage(`["Identifier","Identifier"]`), want: "duplicates an earlier option"},
+    {name: "unterminated attribute", options: json.RawMessage(`"Identifier[name='x'"`), want: "expected ']'"},
+    {name: "invalid regexp", options: json.RawMessage(`"Identifier[name=/(/]"`), want: "invalid regular expression"},
+    {name: "unknown class", options: json.RawMessage(`":mystery"`), want: "unknown AST class"},
+  }
+  for _, tc := range cases {
+    t.Run(tc.name, func(t *testing.T) {
+      engine := noRestrictedSyntaxValidationEngine(tc.options)
+      err := engine.ConfigError()
+      if err == nil || !strings.Contains(err.Error(), tc.want) {
+        t.Fatalf("invalid no-restricted-syntax config mismatch: want=%q got=%v", tc.want, err)
+      }
+      if _, active := engine.EnabledRules()["no-restricted-syntax"]; active {
+        t.Fatalf("invalid rule entered dispatch: %v", engine.EnabledRules())
+      }
+    })
+  }
+}
+
+func TestCommandCheckHonorsNoRestrictedSyntaxOptions(t *testing.T) {
+  root := seedLintProject(t, `eval("1");
+const safe = JSON.stringify(1);
+void safe;
+`)
+  seedLintConfig(t, root, map[string]any{
+    "rules": map[string]any{
+      "no-restricted-syntax": []any{
+        "error",
+        map[string]any{
+          "selector": "CallExpression[callee.name='eval']",
+          "message":  "Do not evaluate source text.",
+        },
+      },
+    },
+  })
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{"check", "--cwd", root, "--plugins-json", lintManifest(t)})
+  })
+  if code != 2 || stdout != "" || strings.Count(stderr, "[no-restricted-syntax] Do not evaluate source text.") != 1 {
+    t.Fatalf("valid command path mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}
+
+func TestCommandCheckRejectsInvalidNoRestrictedSyntaxSelector(t *testing.T) {
+  root := seedLintProject(t, `eval("1");
+`)
+  seedLintConfig(t, root, map[string]any{
+    "rules": map[string]any{
+      "no-restricted-syntax": []any{"error", "CallExpression["},
+    },
+  })
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{"check", "--cwd", root, "--plugins-json", lintManifest(t)})
+  })
+  if code != 2 || stdout != "" || !strings.Contains(stderr, `invalid options for rule "no-restricted-syntax"`) ||
+    !strings.Contains(stderr, "invalid selector") || strings.Contains(stderr, "[no-restricted-syntax]") {
+    t.Fatalf("invalid command path mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
 }

--- a/tests/test-lint/src/cases/no-restricted-syntax.ts
+++ b/tests/test-lint/src/cases/no-restricted-syntax.ts
@@ -1,6 +1,5 @@
 function runWith(target: { value: number }): number {
   let total = 0;
-  // expect: no-restricted-syntax error
   with (target) {
     total = value;
   }
@@ -9,7 +8,6 @@ function runWith(target: { value: number }): number {
 
 function runLabeled(): number {
   let acc = 0;
-  // expect: no-restricted-syntax error
   outer: for (let i = 0; i < 3; i += 1) {
     for (let j = 0; j < 3; j += 1) {
       if (i + j > 3) break outer;

--- a/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
+++ b/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
@@ -96,6 +96,15 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
           ],
         },
       ],
+      "no-restricted-syntax": [
+        "error",
+        "WithStatement",
+        {
+          selector: "CallExpression[callee.name='eval']",
+          message: "Do not evaluate source text.",
+        },
+        "TSAsExpression",
+      ],
       "prefer-const": [
         "error",
         { destructuring: "all", ignoreReadBeforeAssign: true },
@@ -321,6 +330,24 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
       ],
     },
   };
+  const noRestrictedSyntaxNonSelector: ITtscLintConfig = {
+    rules: {
+      // @ts-expect-error — selector entries are strings or {selector,message} objects.
+      "no-restricted-syntax": ["error", 42],
+    },
+  };
+  const noRestrictedSyntaxUnknownObjectKey: ITtscLintConfig = {
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "WithStatement",
+          // @ts-expect-error — selector objects expose only selector and message.
+          reason: "legacy scope mutation",
+        },
+      ],
+    },
+  };
   const crossRuleShape: ITtscLintConfig = {
     rules: {
       // @ts-expect-error — `testIdPattern` belongs to testing-library/consistent-data-testid; cypress/unsafe-to-chain-command's option shape rejects it.
@@ -380,6 +407,8 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
   assert.ok(noRestrictedImportsPatternModeConflict);
   assert.ok(noRestrictedImportsPatternNameConflict);
   assert.ok(noRestrictedImportsEmptyStructuredPatternList);
+  assert.ok(noRestrictedSyntaxNonSelector);
+  assert.ok(noRestrictedSyntaxUnknownObjectKey);
   assert.ok(preferConstOptionValue);
   assert.ok(crossRuleShape);
   assert.ok(lintRuleWithOptions);

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -2124,18 +2124,22 @@ The selector grammar follows esquery and supports:
 Native names are case-insensitive. Common ESTree names including `Program`,
 `ArrowFunctionExpression`, `ObjectExpression`, `ArrayExpression`,
 `VariableDeclarator`, `MemberExpression`, `AssignmentExpression`,
-`UpdateExpression`, `UnaryExpression`, `Literal`, `Property`, and the
+`LogicalExpression`, `UpdateExpression`, `UnaryExpression`, `Literal`,
+`Property`, `ThisExpression`, `Super`, `TemplateLiteral`, and the
 `TSAsExpression`/`TSTypeAssertion`/`TSSatisfiesExpression`/
 `TSNonNullExpression` family are aliases for their TypeScript-Go equivalents.
 
 Attribute paths expose `type`, `name`, `value`/`raw`, `operator`, variable
 `kind`, `async`, `generator`, `static`, `readonly`, `declare`, `optional`,
-`computed`, and the usual structural fields (`id`, `params`, `body`, `callee`,
+`computed`, `prefix`, and the usual structural fields (`id`, `params`, `body`, `callee`,
 `arguments`, `object`, `property`, `left`, `right`, `argument`, `expression`,
 `test`, `consequent`, `alternate`, `init`, `update`, `declarations`, `elements`,
 `properties`, `key`, `source`, and `statements`). Regular expressions use Go's
 linear-time RE2 syntax; `i`, `m`, and `s` change matching and `u` is accepted as
-an explicit no-op because Go strings are already UTF-8.
+an explicit no-op because Go strings are already UTF-8. Numeric segments index
+node-list paths, so selectors such as `[params.0.name='value']` are supported.
+Boolean properties are absent on node kinds that do not define them, rather
+than appearing as a synthetic `false` on every node.
 
 Tree relationships intentionally use TypeScript-Go's `Parent` and
 `ForEachChild` order. That makes TypeScript type, modifier, and token nodes

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -92,7 +92,7 @@ Examples come from the checked [lint corpus](https://github.com/samchon/ttsc/tre
 - [`no-redeclare`](#rule-no-redeclare): Reject declaring the same binding more than once in the same scope.
 - [`no-regex-spaces`](#rule-no-regex-spaces): Reject more than one consecutive literal space in a regex.
 - [`no-restricted-imports`](#rule-no-restricted-imports): Reject static imports and re-exports selected by configured exact paths, gitignore-style groups, or regular expressions.
-- [`no-restricted-syntax`](#rule-no-restricted-syntax): Reject AST node kinds listed in the project denylist.
+- [`no-restricted-syntax`](#rule-no-restricted-syntax): Reject only syntax matching configured TypeScript-Go AST selectors.
 - [`no-return-assign`](#rule-no-return-assign): Reject assignment expressions used as the operand of `return` , almost always a typo for `===`.
 - [`no-script-url`](#rule-no-script-url): Reject `javascript:` URLs in string literals, they execute their body as code on browser navigation.
 - [`no-self-assign`](#rule-no-self-assign): Reject `x = x` and destructuring forms.
@@ -2088,7 +2088,60 @@ export default {
 
 ### `no-restricted-syntax`
 
-Reject AST node kinds listed in the project denylist.
+Reject only syntax matching selectors supplied after the severity. The rule has
+no default denylist: `"no-restricted-syntax": "error"` and
+`["error"]` are both silent.
+
+```ts
+export default {
+  rules: {
+    "no-restricted-syntax": [
+      "error",
+      "WithStatement",
+      {
+        selector: "CallExpression[callee.name='eval']",
+        message: "Do not evaluate source text.",
+      },
+      "TSAsExpression > Literal.expression",
+    ],
+  },
+};
+```
+
+The selector grammar follows esquery and supports:
+
+- native TypeScript-Go node kinds without the `Kind` prefix, plus `*`;
+- attribute presence, equality/inequality, numeric comparisons,
+  `type(...)`, nested paths, and `/pattern/imsu` regular expressions;
+- child (`>`), descendant (space), following-sibling (`~`), and adjacent
+  (`+`) combinators;
+- `:not`, `:is`/`:matches`, `:has`, `:first-child`, `:last-child`,
+  `:nth-child(n)`, `:nth-last-child(n)`, and `!` subjects;
+- the `:statement`, `:expression`, `:declaration`, `:function`, and
+  `:pattern` classes; and
+- field selectors such as `FunctionDeclaration > Identifier.id`.
+
+Native names are case-insensitive. Common ESTree names including `Program`,
+`ArrowFunctionExpression`, `ObjectExpression`, `ArrayExpression`,
+`VariableDeclarator`, `MemberExpression`, `AssignmentExpression`,
+`UpdateExpression`, `UnaryExpression`, `Literal`, `Property`, and the
+`TSAsExpression`/`TSTypeAssertion`/`TSSatisfiesExpression`/
+`TSNonNullExpression` family are aliases for their TypeScript-Go equivalents.
+
+Attribute paths expose `type`, `name`, `value`/`raw`, `operator`, variable
+`kind`, `async`, `generator`, `static`, `readonly`, `declare`, `optional`,
+`computed`, and the usual structural fields (`id`, `params`, `body`, `callee`,
+`arguments`, `object`, `property`, `left`, `right`, `argument`, `expression`,
+`test`, `consequent`, `alternate`, `init`, `update`, `declarations`, `elements`,
+`properties`, `key`, `source`, and `statements`). Regular expressions use Go's
+linear-time RE2 syntax; `i`, `m`, and `s` change matching and `u` is accepted as
+an explicit no-op because Go strings are already UTF-8.
+
+Tree relationships intentionally use TypeScript-Go's `Parent` and
+`ForEachChild` order. That makes TypeScript type, modifier, and token nodes
+selectable without constructing or monkeypatching a second ESTree. It also
+means sibling and child-position selectors describe the native tree rather
+than an ESTree projection.
 
 Example:
 

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -2121,31 +2121,33 @@ The selector grammar follows esquery and supports:
   `:pattern` classes; and
 - field selectors such as `FunctionDeclaration > Identifier.id`.
 
-Native names are case-insensitive. Common ESTree names including `Program`,
+Native names are case-insensitive. Supported ESTree aliases are `Program`,
 `ArrowFunctionExpression`, `ObjectExpression`, `ArrayExpression`,
-`VariableDeclarator`, `MemberExpression`, `AssignmentExpression`,
+`ObjectPattern`, `ArrayPattern`, `VariableDeclarator`, `MemberExpression`,
+`AssignmentExpression`,
 `LogicalExpression`, `UpdateExpression`, `UnaryExpression`, `Literal`,
-`Property`, `ThisExpression`, `Super`, `TemplateLiteral`, and the
+`Property`, `SpreadElement`, `RestElement`, `ThisExpression`, `Super`,
+`TemplateLiteral`, and the
 `TSAsExpression`/`TSTypeAssertion`/`TSSatisfiesExpression`/
 `TSNonNullExpression` family are aliases for their TypeScript-Go equivalents.
 
 Attribute paths expose `type`, `name`, `value`/`raw`, `operator`, variable
 `kind`, `async`, `generator`, `static`, `readonly`, `declare`, `optional`,
-`computed`, `prefix`, and the usual structural fields (`id`, `params`, `body`, `callee`,
-`arguments`, `object`, `property`, `left`, `right`, `argument`, `expression`,
+`computed`, `prefix`, and the usual structural fields (`id`, `params`, `body`,
+`callee`, `arguments`, `object`, `property`, `left`, `right`, `argument`, `expression`,
 `test`, `consequent`, `alternate`, `init`, `update`, `declarations`, `elements`,
-`properties`, `key`, `source`, and `statements`). Regular expressions use Go's
+`members`, `properties`, `key`, `source`, and `statements`). Regular expressions use Go's
 linear-time RE2 syntax; `i`, `m`, and `s` change matching and `u` is accepted as
 an explicit no-op because Go strings are already UTF-8. Numeric segments index
 node-list paths, so selectors such as `[params.0.name='value']` are supported.
 Boolean properties are absent on node kinds that do not define them, rather
 than appearing as a synthetic `false` on every node.
 
-Tree relationships intentionally use TypeScript-Go's `Parent` and
-`ForEachChild` order. That makes TypeScript type, modifier, and token nodes
-selectable without constructing or monkeypatching a second ESTree. It also
-means sibling and child-position selectors describe the native tree rather
-than an ESTree projection.
+Tree descent and parent relationships use TypeScript-Go's `ForEachChild` and
+`Parent` surfaces. Sibling and child-position selectors stay within one of the
+exposed node-list fields above, matching esquery's array-field semantics. This
+makes TypeScript-only nodes selectable without constructing or monkeypatching
+a second ESTree.
 
 Example:
 


### PR DESCRIPTION
## Summary
- remove the built-in with/label denylist so an optionless rule is silent
- add a validated esquery-compatible selector parser and matcher over the native TypeScript-Go AST
- expose the official variadic selector/message types and document native TypeScript selector semantics
- add exact-range, combinator, attribute, subject, TypeScript-node, invalid-config, and real-command regression shields

## Validation
- not run yet: per the required delivery sequence, focused local tests follow three clean exhaustive whole-PR reviews of one exact HEAD
- formatter was not run

Closes #499