### PR TITLE
Honor configured no-restricted-imports options

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -291,7 +291,7 @@ Source: [ESLint core rules](https://eslint.org/docs/latest/rules/).
 - [`no-prototype-builtins`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-prototype-builtins.ts): rejects direct `Object.prototype` method calls.
 - [`no-redeclare`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-redeclare.ts): rejects redeclaring a binding in the same scope.
 - [`no-regex-spaces`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-regex-spaces.ts): rejects repeated literal spaces in regexes.
-- [`no-restricted-imports`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-restricted-imports.ts): reject `import` declarations targeting any module specifier in the project denylist.
+- [`no-restricted-imports`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-restricted-imports.ts): reject static imports and re-exports selected by user-configured exact paths, gitignore-style groups, or regular expressions.
 - [`no-restricted-syntax`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-restricted-syntax.ts): reject AST node kinds listed in the project denylist.
 - [`no-return-assign`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-return-assign.ts): rejects assignments in `return`.
 - [`no-script-url`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-script-url.ts): rejects `javascript:` URLs.

--- a/packages/lint/linthost/rules_no_restricted_imports.go
+++ b/packages/lint/linthost/rules_no_restricted_imports.go
@@ -1,103 +1,1059 @@
-// noRestrictedImports reports an `import` (or `export … from`) whose
-// module specifier matches a project-configured deny list. The rule is
-// the policy hammer for forcing a module boundary: a package that has
-// been renamed, a workspace internal that should not leak, or a heavy
-// dependency that the project wants to discourage all share the same
-// shape — flag the import at its source so the offending line is the
-// one the developer fixes.
+// noRestrictedImports enforces the exact paths and path patterns supplied by
+// the user. With no options it is a no-op: the rule contains no project policy
+// of its own.
 //
-// Configuration shape: a `paths` array of bare module specifiers to
-// flag, exact-match only. An empty (or missing) list is a no-op — the
-// rule contributes no findings until the project lists something to
-// restrict. The native engine's RuleConfig path does not carry options
-// to the rule, so the Go unit test exercises the rule via a hard-coded
-// default deny list (`lodash`, `underscore`) that fires whenever the
-// rule is enabled with no options blob.
+// The option surface mirrors ESLint's current core rule, including positional
+// path entries, the {paths, patterns} object form, import-name restrictions,
+// custom messages, case sensitivity, regular-expression patterns, and
+// type-only exemptions.
 // https://eslint.org/docs/latest/rules/no-restricted-imports
 package linthost
 
 import (
+  "bytes"
   "encoding/json"
+  "fmt"
+  "regexp"
+  "sort"
+  "strings"
+  "unicode"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
 
 type noRestrictedImports struct{}
 
-// noRestrictedImportsOptions decodes the `paths` array from a user
-// `[severity, options]` tuple. Anything else on the blob is ignored so
-// future ESLint-compatible keys (e.g. `patterns`) can be layered in
-// without changing existing configs.
 type noRestrictedImportsOptions struct {
-  Paths []string `json:"paths"`
+  paths    []noRestrictedImportsPath
+  patterns []noRestrictedImportsPattern
 }
 
-// hardCodedRestrictedImports is the default deny list used when the
-// rule is enabled without an options blob. The Go-side test harness
-// exercises the rule through `RuleConfig` (severity-only, no options),
-// so the rule needs a deterministic non-empty default to be testable
-// at the AST layer at all. The choice mirrors a common "don't lean on
-// utility-belt libraries" lint setup in real projects.
-var hardCodedRestrictedImports = []string{"lodash", "underscore"}
+type noRestrictedImportsNameControl struct {
+  importNames            []string
+  hasImportNames         bool
+  allowImportNames       []string
+  hasAllowImportNames    bool
+  importNamePattern      *regexp.Regexp
+  importNamePatternText  string
+  allowImportNamePattern *regexp.Regexp
+  allowImportNameText    string
+}
+
+type noRestrictedImportsPath struct {
+  name             string
+  message          string
+  allowTypeImports bool
+  names            noRestrictedImportsNameControl
+}
+
+type noRestrictedImportsPattern struct {
+  group            []noRestrictedImportsGlob
+  expression       *regexp.Regexp
+  message          string
+  allowTypeImports bool
+  names            noRestrictedImportsNameControl
+}
+
+type noRestrictedImportsGlob struct {
+  expression    *regexp.Regexp
+  negated       bool
+  directoryOnly bool
+}
+
+type noRestrictedImportsReference struct {
+  source        string
+  sourceNode    *shimast.Node
+  names         []noRestrictedImportsImportedName
+  wholeTypeOnly bool
+}
+
+type noRestrictedImportsImportedName struct {
+  name     string
+  node     *shimast.Node
+  pos      int
+  end      int
+  typeOnly bool
+}
 
 func (noRestrictedImports) Name() string { return "no-restricted-imports" }
 func (noRestrictedImports) Visits() []shimast.Kind {
   return []shimast.Kind{
     shimast.KindImportDeclaration,
     shimast.KindExportDeclaration,
+    shimast.KindImportEqualsDeclaration,
   }
 }
+
+func (noRestrictedImports) ValidateOptions(raw json.RawMessage) error {
+  _, err := parseNoRestrictedImportsOptions(raw)
+  return err
+}
+
 func (noRestrictedImports) Check(ctx *Context, node *shimast.Node) {
-  specifierNode := moduleSpecifierOf(node)
-  if specifierNode == nil {
+  if ctx == nil || node == nil {
     return
   }
-  specifier := stringLiteralText(specifierNode)
-  if specifier == "" {
+  options, err := parseNoRestrictedImportsOptions(ctx.Options)
+  if err != nil || (len(options.paths) == 0 && len(options.patterns) == 0) {
     return
   }
-  denied := resolveNoRestrictedImportsPaths(ctx)
-  for _, target := range denied {
-    if specifier == target {
-      ctx.Report(specifierNode, "'"+specifier+"' import is restricted from being used.")
-      return
+  reference, ok := noRestrictedImportsReferenceOf(ctx.File, node)
+  if !ok {
+    return
+  }
+
+  for _, restricted := range options.paths {
+    if reference.source == restricted.name {
+      reportNoRestrictedImportsPath(ctx, reference, restricted)
+    }
+  }
+  for _, restricted := range options.patterns {
+    if restricted.matches(reference.source) {
+      reportNoRestrictedImportsPattern(ctx, reference, restricted)
     }
   }
 }
 
-// moduleSpecifierOf returns the `from "…"` string-literal node of the
-// import / re-export declaration. `export { x }` (no `from`) and
-// every other shape returns nil so the caller short-circuits.
-func moduleSpecifierOf(node *shimast.Node) *shimast.Node {
-  if node == nil {
-    return nil
+func parseNoRestrictedImportsOptions(raw json.RawMessage) (noRestrictedImportsOptions, error) {
+  var options noRestrictedImportsOptions
+  raw = bytes.TrimSpace(raw)
+  if len(raw) == 0 {
+    return options, nil
   }
-  switch node.Kind {
-  case shimast.KindImportDeclaration:
-    if imp := node.AsImportDeclaration(); imp != nil {
-      return imp.ModuleSpecifier
+
+  switch raw[0] {
+  case '"':
+    name, err := noRestrictedImportsDecodeString(raw, "path")
+    if err != nil {
+      return options, err
     }
-  case shimast.KindExportDeclaration:
-    if exp := node.AsExportDeclaration(); exp != nil {
-      return exp.ModuleSpecifier
+    options.paths = append(options.paths, noRestrictedImportsPath{name: name})
+    return options, nil
+  case '{':
+    object, err := noRestrictedImportsDecodeObject(raw, "options")
+    if err != nil {
+      return options, err
     }
+    _, hasPaths := object["paths"]
+    _, hasPatterns := object["patterns"]
+    if len(object) == 0 || hasPaths || hasPatterns {
+      return parseNoRestrictedImportsObjectOptions(object)
+    }
+    path, err := parseNoRestrictedImportsPathObject(object)
+    if err != nil {
+      return options, err
+    }
+    options.paths = append(options.paths, path)
+    return options, nil
+  case '[':
+    entries, err := noRestrictedImportsDecodeArray(raw, "paths")
+    if err != nil {
+      return options, err
+    }
+    if err := noRestrictedImportsRequireUnique(entries, "paths"); err != nil {
+      return options, err
+    }
+    options.paths, err = parseNoRestrictedImportsPaths(entries)
+    return options, err
+  default:
+    return options, fmt.Errorf("options must be path entries or an object with %q and/or %q", "paths", "patterns")
+  }
+}
+
+func parseNoRestrictedImportsObjectOptions(object map[string]json.RawMessage) (noRestrictedImportsOptions, error) {
+  var options noRestrictedImportsOptions
+  if err := noRestrictedImportsRejectUnknown(object, "paths", "patterns"); err != nil {
+    return options, err
+  }
+  if raw, present := object["paths"]; present {
+    entries, err := noRestrictedImportsDecodeArray(raw, "paths")
+    if err != nil {
+      return options, err
+    }
+    if err := noRestrictedImportsRequireUnique(entries, "paths"); err != nil {
+      return options, err
+    }
+    options.paths, err = parseNoRestrictedImportsPaths(entries)
+    if err != nil {
+      return options, err
+    }
+  }
+  if raw, present := object["patterns"]; present {
+    entries, err := noRestrictedImportsDecodeArray(raw, "patterns")
+    if err != nil {
+      return options, err
+    }
+    if err := noRestrictedImportsRequireUnique(entries, "patterns"); err != nil {
+      return options, err
+    }
+    options.patterns, err = parseNoRestrictedImportsPatterns(entries)
+    if err != nil {
+      return options, err
+    }
+  }
+  return options, nil
+}
+
+func parseNoRestrictedImportsPaths(entries []json.RawMessage) ([]noRestrictedImportsPath, error) {
+  paths := make([]noRestrictedImportsPath, 0, len(entries))
+  for index, raw := range entries {
+    raw = bytes.TrimSpace(raw)
+    if len(raw) == 0 {
+      return nil, fmt.Errorf("paths[%d] must be a string or object", index)
+    }
+    switch raw[0] {
+    case '"':
+      name, err := noRestrictedImportsDecodeString(raw, fmt.Sprintf("paths[%d]", index))
+      if err != nil {
+        return nil, err
+      }
+      paths = append(paths, noRestrictedImportsPath{name: name})
+    case '{':
+      object, err := noRestrictedImportsDecodeObject(raw, fmt.Sprintf("paths[%d]", index))
+      if err != nil {
+        return nil, err
+      }
+      path, err := parseNoRestrictedImportsPathObject(object)
+      if err != nil {
+        return nil, fmt.Errorf("paths[%d]: %w", index, err)
+      }
+      paths = append(paths, path)
+    default:
+      return nil, fmt.Errorf("paths[%d] must be a string or object", index)
+    }
+  }
+  return paths, nil
+}
+
+func parseNoRestrictedImportsPathObject(object map[string]json.RawMessage) (noRestrictedImportsPath, error) {
+  var path noRestrictedImportsPath
+  if err := noRestrictedImportsRejectUnknown(
+    object,
+    "name",
+    "message",
+    "importNames",
+    "allowImportNames",
+    "allowTypeImports",
+  ); err != nil {
+    return path, err
+  }
+  rawName, present := object["name"]
+  if !present {
+    return path, fmt.Errorf("path object requires %q", "name")
+  }
+  var err error
+  if path.name, err = noRestrictedImportsDecodeString(rawName, "name"); err != nil {
+    return path, err
+  }
+  if raw, present := object["message"]; present {
+    path.message, err = noRestrictedImportsDecodeString(raw, "message")
+    if err != nil {
+      return path, err
+    }
+    if path.message == "" {
+      return path, fmt.Errorf("option %q must not be empty", "message")
+    }
+  }
+  if raw, present := object["allowTypeImports"]; present {
+    path.allowTypeImports, err = noRestrictedImportsDecodeBool(raw, "allowTypeImports")
+    if err != nil {
+      return path, err
+    }
+  }
+  if raw, present := object["importNames"]; present {
+    path.names.importNames, err = noRestrictedImportsStringList(raw, "importNames", false, false)
+    if err != nil {
+      return path, err
+    }
+    path.names.hasImportNames = true
+  }
+  if raw, present := object["allowImportNames"]; present {
+    path.names.allowImportNames, err = noRestrictedImportsStringList(raw, "allowImportNames", false, false)
+    if err != nil {
+      return path, err
+    }
+    path.names.hasAllowImportNames = true
+  }
+  if path.names.hasImportNames && path.names.hasAllowImportNames {
+    return path, fmt.Errorf("options %q and %q cannot be combined", "importNames", "allowImportNames")
+  }
+  return path, nil
+}
+
+func parseNoRestrictedImportsPatterns(entries []json.RawMessage) ([]noRestrictedImportsPattern, error) {
+  if len(entries) == 0 {
+    return nil, nil
+  }
+  first := bytes.TrimSpace(entries[0])
+  if len(first) == 0 {
+    return nil, fmt.Errorf("patterns[0] must be a string or object")
+  }
+
+  if first[0] == '"' {
+    group := make([]string, 0, len(entries))
+    for index, raw := range entries {
+      text, err := noRestrictedImportsDecodeString(raw, fmt.Sprintf("patterns[%d]", index))
+      if err != nil {
+        return nil, fmt.Errorf("patterns must contain only strings or only objects: %w", err)
+      }
+      group = append(group, text)
+    }
+    compiled, err := noRestrictedImportsCompileGlobGroup(group, false)
+    if err != nil {
+      return nil, err
+    }
+    return []noRestrictedImportsPattern{{group: compiled}}, nil
+  }
+  if first[0] != '{' {
+    return nil, fmt.Errorf("patterns[0] must be a string or object")
+  }
+
+  patterns := make([]noRestrictedImportsPattern, 0, len(entries))
+  for index, raw := range entries {
+    object, err := noRestrictedImportsDecodeObject(raw, fmt.Sprintf("patterns[%d]", index))
+    if err != nil {
+      return nil, fmt.Errorf("patterns must contain only strings or only objects: %w", err)
+    }
+    pattern, err := parseNoRestrictedImportsPatternObject(object)
+    if err != nil {
+      return nil, fmt.Errorf("patterns[%d]: %w", index, err)
+    }
+    patterns = append(patterns, pattern)
+  }
+  return patterns, nil
+}
+
+func parseNoRestrictedImportsPatternObject(object map[string]json.RawMessage) (noRestrictedImportsPattern, error) {
+  var pattern noRestrictedImportsPattern
+  if err := noRestrictedImportsRejectUnknown(
+    object,
+    "group",
+    "regex",
+    "message",
+    "caseSensitive",
+    "importNames",
+    "allowImportNames",
+    "importNamePattern",
+    "allowImportNamePattern",
+    "allowTypeImports",
+  ); err != nil {
+    return pattern, err
+  }
+  rawGroup, hasGroup := object["group"]
+  rawRegex, hasRegex := object["regex"]
+  if hasGroup == hasRegex {
+    return pattern, fmt.Errorf("pattern object must contain exactly one of %q or %q", "group", "regex")
+  }
+
+  var err error
+  caseSensitive := false
+  if raw, present := object["caseSensitive"]; present {
+    caseSensitive, err = noRestrictedImportsDecodeBool(raw, "caseSensitive")
+    if err != nil {
+      return pattern, err
+    }
+  }
+  if raw, present := object["allowTypeImports"]; present {
+    pattern.allowTypeImports, err = noRestrictedImportsDecodeBool(raw, "allowTypeImports")
+    if err != nil {
+      return pattern, err
+    }
+  }
+
+  if hasGroup {
+    group, err := noRestrictedImportsStringList(rawGroup, "group", true, true)
+    if err != nil {
+      return pattern, err
+    }
+    pattern.group, err = noRestrictedImportsCompileGlobGroup(group, caseSensitive)
+    if err != nil {
+      return pattern, err
+    }
+  } else {
+    expression, err := noRestrictedImportsDecodeString(rawRegex, "regex")
+    if err != nil {
+      return pattern, err
+    }
+    pattern.expression, err = noRestrictedImportsCompileRegexp(expression, caseSensitive)
+    if err != nil {
+      return pattern, fmt.Errorf("option %q must be a valid regular expression: %w", "regex", err)
+    }
+  }
+  if raw, present := object["message"]; present {
+    pattern.message, err = noRestrictedImportsDecodeString(raw, "message")
+    if err != nil {
+      return pattern, err
+    }
+    if pattern.message == "" {
+      return pattern, fmt.Errorf("option %q must not be empty", "message")
+    }
+  }
+  if raw, present := object["importNames"]; present {
+    pattern.names.importNames, err = noRestrictedImportsStringList(raw, "importNames", true, true)
+    if err != nil {
+      return pattern, err
+    }
+    pattern.names.hasImportNames = true
+  }
+  if raw, present := object["allowImportNames"]; present {
+    pattern.names.allowImportNames, err = noRestrictedImportsStringList(raw, "allowImportNames", true, true)
+    if err != nil {
+      return pattern, err
+    }
+    pattern.names.hasAllowImportNames = true
+  }
+  if raw, present := object["importNamePattern"]; present {
+    pattern.names.importNamePatternText, err = noRestrictedImportsDecodeString(raw, "importNamePattern")
+    if err != nil {
+      return pattern, err
+    }
+    pattern.names.importNamePattern, err = noRestrictedImportsCompileRegexp(pattern.names.importNamePatternText, true)
+    if err != nil {
+      return pattern, fmt.Errorf("option %q must be a valid regular expression: %w", "importNamePattern", err)
+    }
+  }
+  if raw, present := object["allowImportNamePattern"]; present {
+    pattern.names.allowImportNameText, err = noRestrictedImportsDecodeString(raw, "allowImportNamePattern")
+    if err != nil {
+      return pattern, err
+    }
+    pattern.names.allowImportNamePattern, err = noRestrictedImportsCompileRegexp(pattern.names.allowImportNameText, true)
+    if err != nil {
+      return pattern, fmt.Errorf("option %q must be a valid regular expression: %w", "allowImportNamePattern", err)
+    }
+  }
+  if err := pattern.names.validatePatternCombinations(); err != nil {
+    return pattern, err
+  }
+  return pattern, nil
+}
+
+func (control noRestrictedImportsNameControl) validatePatternCombinations() error {
+  if control.hasImportNames && control.hasAllowImportNames {
+    return fmt.Errorf("options %q and %q cannot be combined", "importNames", "allowImportNames")
+  }
+  if control.importNamePattern != nil && control.allowImportNamePattern != nil {
+    return fmt.Errorf("options %q and %q cannot be combined", "importNamePattern", "allowImportNamePattern")
+  }
+  if control.hasImportNames && control.allowImportNamePattern != nil {
+    return fmt.Errorf("options %q and %q cannot be combined", "importNames", "allowImportNamePattern")
+  }
+  if control.importNamePattern != nil && control.hasAllowImportNames {
+    return fmt.Errorf("options %q and %q cannot be combined", "importNamePattern", "allowImportNames")
+  }
+  if control.hasAllowImportNames && control.allowImportNamePattern != nil {
+    return fmt.Errorf("options %q and %q cannot be combined", "allowImportNames", "allowImportNamePattern")
   }
   return nil
 }
 
-// resolveNoRestrictedImportsPaths returns the active deny list for the
-// firing context. A `paths` array on the user's options blob wins; an
-// empty / missing blob falls back to `hardCodedRestrictedImports` so
-// the AST-layer test fires deterministically.
-func resolveNoRestrictedImportsPaths(ctx *Context) []string {
-  if ctx == nil || len(ctx.Options) == 0 {
-    return hardCodedRestrictedImports
+func noRestrictedImportsDecodeObject(raw json.RawMessage, name string) (map[string]json.RawMessage, error) {
+  var object map[string]json.RawMessage
+  if err := json.Unmarshal(raw, &object); err != nil || object == nil {
+    return nil, fmt.Errorf("%s must be an object", name)
   }
-  var opts noRestrictedImportsOptions
-  if err := json.Unmarshal(ctx.Options, &opts); err != nil || len(opts.Paths) == 0 {
-    return hardCodedRestrictedImports
+  return object, nil
+}
+
+func noRestrictedImportsDecodeArray(raw json.RawMessage, name string) ([]json.RawMessage, error) {
+  var entries []json.RawMessage
+  if err := json.Unmarshal(raw, &entries); err != nil || entries == nil {
+    return nil, fmt.Errorf("option %q must be an array", name)
   }
-  return opts.Paths
+  return entries, nil
+}
+
+func noRestrictedImportsDecodeString(raw json.RawMessage, name string) (string, error) {
+  var decoded any
+  if err := json.Unmarshal(raw, &decoded); err != nil {
+    return "", fmt.Errorf("option %q must be a string", name)
+  }
+  value, ok := decoded.(string)
+  if !ok {
+    return "", fmt.Errorf("option %q must be a string", name)
+  }
+  return value, nil
+}
+
+func noRestrictedImportsDecodeBool(raw json.RawMessage, name string) (bool, error) {
+  var decoded any
+  if err := json.Unmarshal(raw, &decoded); err != nil {
+    return false, fmt.Errorf("option %q must be a boolean", name)
+  }
+  value, ok := decoded.(bool)
+  if !ok {
+    return false, fmt.Errorf("option %q must be a boolean", name)
+  }
+  return value, nil
+}
+
+func noRestrictedImportsStringList(raw json.RawMessage, name string, nonEmpty, unique bool) ([]string, error) {
+  entries, err := noRestrictedImportsDecodeArray(raw, name)
+  if err != nil {
+    return nil, err
+  }
+  if nonEmpty && len(entries) == 0 {
+    return nil, fmt.Errorf("option %q must contain at least one string", name)
+  }
+  values := make([]string, 0, len(entries))
+  seen := make(map[string]struct{}, len(entries))
+  for index, rawEntry := range entries {
+    value, err := noRestrictedImportsDecodeString(rawEntry, fmt.Sprintf("%s[%d]", name, index))
+    if err != nil {
+      return nil, err
+    }
+    if unique {
+      if _, duplicate := seen[value]; duplicate {
+        return nil, fmt.Errorf("option %q contains duplicate value %q", name, value)
+      }
+      seen[value] = struct{}{}
+    }
+    values = append(values, value)
+  }
+  return values, nil
+}
+
+func noRestrictedImportsRejectUnknown(object map[string]json.RawMessage, allowed ...string) error {
+  known := make(map[string]struct{}, len(allowed))
+  for _, name := range allowed {
+    known[name] = struct{}{}
+  }
+  unknown := make([]string, 0)
+  for name := range object {
+    if _, ok := known[name]; !ok {
+      unknown = append(unknown, name)
+    }
+  }
+  if len(unknown) == 0 {
+    return nil
+  }
+  sort.Strings(unknown)
+  return fmt.Errorf("unknown option %q", unknown[0])
+}
+
+func noRestrictedImportsRequireUnique(entries []json.RawMessage, name string) error {
+  seen := make(map[string]struct{}, len(entries))
+  for index, raw := range entries {
+    var value any
+    if err := json.Unmarshal(raw, &value); err != nil {
+      return fmt.Errorf("%s[%d] must be valid JSON: %w", name, index, err)
+    }
+    canonical, err := json.Marshal(value)
+    if err != nil {
+      return fmt.Errorf("%s[%d] cannot be normalized: %w", name, index, err)
+    }
+    key := string(canonical)
+    if _, duplicate := seen[key]; duplicate {
+      return fmt.Errorf("option %q contains a duplicate entry at index %d", name, index)
+    }
+    seen[key] = struct{}{}
+  }
+  return nil
+}
+
+func noRestrictedImportsCompileRegexp(expression string, caseSensitive bool) (*regexp.Regexp, error) {
+  if !caseSensitive {
+    expression = "(?i:" + expression + ")"
+  }
+  return regexp.Compile(expression)
+}
+
+func noRestrictedImportsCompileGlobGroup(patterns []string, caseSensitive bool) ([]noRestrictedImportsGlob, error) {
+  group := make([]noRestrictedImportsGlob, 0, len(patterns))
+  for index, pattern := range patterns {
+    compiled, active, err := noRestrictedImportsCompileGlob(pattern, caseSensitive)
+    if err != nil {
+      return nil, fmt.Errorf("option %q[%d] is not a valid pattern: %w", "group", index, err)
+    }
+    if active {
+      group = append(group, compiled)
+    }
+  }
+  return group, nil
+}
+
+func noRestrictedImportsCompileGlob(raw string, caseSensitive bool) (noRestrictedImportsGlob, bool, error) {
+  var glob noRestrictedImportsGlob
+  pattern := strings.TrimPrefix(raw, "\uFEFF")
+  pattern = noRestrictedImportsTrimPattern(pattern)
+  if pattern == "" || strings.HasPrefix(pattern, "#") {
+    return glob, false, nil
+  }
+  if strings.HasPrefix(pattern, `\#`) || strings.HasPrefix(pattern, `\!`) {
+    pattern = pattern[1:]
+  } else if strings.HasPrefix(pattern, "!") {
+    glob.negated = true
+    pattern = pattern[1:]
+  }
+  if pattern == "" {
+    return glob, false, nil
+  }
+  glob.directoryOnly = strings.HasSuffix(pattern, "/")
+  pattern = strings.TrimSuffix(pattern, "/")
+  rooted := strings.HasPrefix(pattern, "/")
+  pattern = strings.TrimPrefix(pattern, "/")
+  if pattern == "" {
+    return glob, false, nil
+  }
+
+  body, err := noRestrictedImportsGlobRegexp(pattern, rooted)
+  if err != nil {
+    return glob, false, err
+  }
+  if !rooted && !strings.Contains(pattern, "/") {
+    body = `(^|/)` + body
+  } else {
+    body = `^` + body
+  }
+  body += `$`
+  glob.expression, err = noRestrictedImportsCompileRegexp(body, caseSensitive)
+  if err != nil {
+    return glob, false, err
+  }
+  return glob, true, nil
+}
+
+func noRestrictedImportsTrimPattern(pattern string) string {
+  runes := []rune(pattern)
+  for len(runes) > 0 && unicode.IsSpace(runes[len(runes)-1]) {
+    slashCount := 0
+    for index := len(runes) - 2; index >= 0 && runes[index] == '\\'; index-- {
+      slashCount++
+    }
+    if slashCount%2 == 1 {
+      runes = append(runes[:len(runes)-2], runes[len(runes)-1])
+      break
+    }
+    runes = runes[:len(runes)-1]
+  }
+  return string(runes)
+}
+
+func noRestrictedImportsGlobRegexp(pattern string, rooted bool) (string, error) {
+  runes := []rune(pattern)
+  var expression strings.Builder
+  for index := 0; index < len(runes); index++ {
+    current := runes[index]
+    switch current {
+    case '\\':
+      if index+1 < len(runes) {
+        index++
+        expression.WriteString(regexp.QuoteMeta(string(runes[index])))
+      } else {
+        expression.WriteString(`\\`)
+      }
+    case '*':
+      start := index
+      for index+1 < len(runes) && runes[index+1] == '*' {
+        index++
+      }
+      count := index - start + 1
+      previousSlash := start > 0 && runes[start-1] == '/'
+      nextSlash := index+1 < len(runes) && runes[index+1] == '/'
+      if count == 2 && nextSlash && (start == 0 || previousSlash) {
+        index++
+        expression.WriteString(`(?:[^/]+/)*`)
+      } else if count == 2 && previousSlash && index == len(runes)-1 {
+        expression.WriteString(`.+`)
+      } else if count == 1 && index == len(runes)-1 && (previousSlash || (rooted && start == 0)) {
+        expression.WriteString(`[^/]+`)
+      } else {
+        expression.WriteString(`[^/]*`)
+      }
+    case '?':
+      expression.WriteString(`[^/]`)
+    case '[':
+      closeIndex := index + 1
+      for closeIndex < len(runes) && runes[closeIndex] != ']' {
+        closeIndex++
+      }
+      if closeIndex == len(runes) {
+        expression.WriteString(`\[`)
+        continue
+      }
+      class := string(runes[index+1 : closeIndex])
+      if strings.HasPrefix(class, "!") {
+        class = "^/" + class[1:]
+      } else if strings.HasPrefix(class, "^") {
+        class = `\^` + class[1:]
+      }
+      characterClass := "[" + class + "]"
+      if _, err := regexp.Compile(characterClass); err != nil {
+        // Gitignore accepts malformed or descending ranges as patterns and
+        // treats an unusable range as non-matching instead of rejecting the
+        // entire configuration.
+        expression.WriteString(`(?:\b\B)`)
+      } else {
+        expression.WriteString(characterClass)
+      }
+      index = closeIndex
+    default:
+      expression.WriteString(regexp.QuoteMeta(string(current)))
+    }
+  }
+  return expression.String(), nil
+}
+
+func (pattern noRestrictedImportsPattern) matches(source string) bool {
+  if pattern.expression != nil {
+    return pattern.expression.MatchString(source)
+  }
+  if len(pattern.group) == 0 {
+    return false
+  }
+  parts := strings.Split(source, "/")
+  for index := range parts {
+    candidate := strings.Join(parts[:index+1], "/")
+    directory := index < len(parts)-1
+    ignored := false
+    for _, glob := range pattern.group {
+      if glob.directoryOnly && !directory {
+        continue
+      }
+      if glob.expression.MatchString(candidate) {
+        ignored = !glob.negated
+      }
+    }
+    if ignored {
+      return true
+    }
+  }
+  return false
+}
+
+func noRestrictedImportsReferenceOf(file *shimast.SourceFile, node *shimast.Node) (noRestrictedImportsReference, bool) {
+  var reference noRestrictedImportsReference
+  if node == nil {
+    return reference, false
+  }
+  switch node.Kind {
+  case shimast.KindImportDeclaration:
+    declaration := node.AsImportDeclaration()
+    if declaration == nil || declaration.ModuleSpecifier == nil {
+      return reference, false
+    }
+    reference.sourceNode = declaration.ModuleSpecifier
+    reference.names, reference.wholeTypeOnly = noRestrictedImportsImportNames(declaration)
+  case shimast.KindExportDeclaration:
+    declaration := node.AsExportDeclaration()
+    if declaration == nil || declaration.ModuleSpecifier == nil {
+      return reference, false
+    }
+    reference.sourceNode = declaration.ModuleSpecifier
+    reference.names, reference.wholeTypeOnly = noRestrictedImportsExportNames(file, node, declaration)
+  case shimast.KindImportEqualsDeclaration:
+    declaration := node.AsImportEqualsDeclaration()
+    if declaration == nil || declaration.ModuleReference == nil ||
+      declaration.ModuleReference.Kind != shimast.KindExternalModuleReference {
+      return reference, false
+    }
+    module := declaration.ModuleReference.AsExternalModuleReference()
+    if module == nil || module.Expression == nil {
+      return reference, false
+    }
+    reference.sourceNode = module.Expression
+    reference.wholeTypeOnly = declaration.IsTypeOnly
+  default:
+    return reference, false
+  }
+  reference.source = stringLiteralText(reference.sourceNode)
+  return reference, true
+}
+
+func noRestrictedImportsImportNames(declaration *shimast.ImportDeclaration) ([]noRestrictedImportsImportedName, bool) {
+  if declaration == nil || declaration.ImportClause == nil {
+    return nil, false
+  }
+  clauseNode := declaration.ImportClause
+  clause := clauseNode.AsImportClause()
+  if clause == nil {
+    return nil, false
+  }
+  clauseTypeOnly := clauseNode.IsTypeOnly()
+  names := make([]noRestrictedImportsImportedName, 0)
+  if name := clause.Name(); name != nil {
+    names = append(names, noRestrictedImportsImportedName{name: "default", node: name, typeOnly: clauseTypeOnly})
+  }
+  if bindings := clause.NamedBindings; bindings != nil {
+    switch bindings.Kind {
+    case shimast.KindNamespaceImport:
+      names = append(names, noRestrictedImportsImportedName{name: "*", node: bindings, typeOnly: clauseTypeOnly})
+    case shimast.KindNamedImports:
+      named := bindings.AsNamedImports()
+      if named != nil && named.Elements != nil {
+        for _, element := range named.Elements.Nodes {
+          specifier := element.AsImportSpecifier()
+          if specifier == nil {
+            continue
+          }
+          imported := specifier.PropertyName
+          if imported == nil {
+            imported = specifier.Name()
+          }
+          names = append(names, noRestrictedImportsImportedName{
+            name:     noRestrictedImportsModuleExportName(imported),
+            node:     element,
+            typeOnly: clauseTypeOnly || specifier.IsTypeOnly,
+          })
+        }
+      }
+    }
+  }
+  return names, clauseTypeOnly || noRestrictedImportsAllNamesTypeOnly(names)
+}
+
+func noRestrictedImportsExportNames(
+  file *shimast.SourceFile,
+  node *shimast.Node,
+  declaration *shimast.ExportDeclaration,
+) ([]noRestrictedImportsImportedName, bool) {
+  if declaration == nil {
+    return nil, false
+  }
+  declarationTypeOnly := declaration.IsTypeOnly
+  clause := declaration.ExportClause
+  if clause == nil {
+    pos, end := noRestrictedImportsExportStarRange(file, node, declaration.ModuleSpecifier)
+    return []noRestrictedImportsImportedName{{name: "*", pos: pos, end: end, typeOnly: declarationTypeOnly}}, declarationTypeOnly
+  }
+  if clause.Kind == shimast.KindNamespaceExport {
+    pos, end := noRestrictedImportsExportStarRange(file, node, declaration.ModuleSpecifier)
+    return []noRestrictedImportsImportedName{{name: "*", pos: pos, end: end, typeOnly: declarationTypeOnly}}, declarationTypeOnly
+  }
+  if clause.Kind != shimast.KindNamedExports {
+    return nil, declarationTypeOnly
+  }
+  named := clause.AsNamedExports()
+  if named == nil || named.Elements == nil {
+    return nil, declarationTypeOnly
+  }
+  names := make([]noRestrictedImportsImportedName, 0, len(named.Elements.Nodes))
+  for _, element := range named.Elements.Nodes {
+    specifier := element.AsExportSpecifier()
+    if specifier == nil {
+      continue
+    }
+    imported := specifier.PropertyName
+    if imported == nil {
+      imported = specifier.Name()
+    }
+    names = append(names, noRestrictedImportsImportedName{
+      name:     noRestrictedImportsModuleExportName(imported),
+      node:     element,
+      typeOnly: declarationTypeOnly || specifier.IsTypeOnly,
+    })
+  }
+  return names, declarationTypeOnly || noRestrictedImportsAllNamesTypeOnly(names)
+}
+
+func noRestrictedImportsModuleExportName(node *shimast.Node) string {
+  if name := identifierText(node); name != "" {
+    return name
+  }
+  return stringLiteralText(node)
+}
+
+func noRestrictedImportsAllNamesTypeOnly(names []noRestrictedImportsImportedName) bool {
+  if len(names) == 0 {
+    return false
+  }
+  for _, name := range names {
+    if !name.typeOnly {
+      return false
+    }
+  }
+  return true
+}
+
+func noRestrictedImportsExportStarRange(
+  file *shimast.SourceFile,
+  declaration *shimast.Node,
+  moduleSpecifier *shimast.Node,
+) (int, int) {
+  if file == nil || declaration == nil {
+    return -1, -1
+  }
+  source := file.Text()
+  start, _ := tokenRange(file, declaration)
+  limit, _ := tokenRange(file, moduleSpecifier)
+  if start < 0 || limit < start || limit > len(source) {
+    return -1, -1
+  }
+  scanner := shimscanner.NewScanner()
+  scanner.SetText(source[start:limit])
+  scanner.SetSkipTrivia(true)
+  for {
+    switch scanner.Scan() {
+    case shimast.KindAsteriskToken:
+      return start + scanner.TokenStart(), start + scanner.TokenEnd()
+    case shimast.KindEndOfFile:
+      return -1, -1
+    }
+  }
+}
+
+func reportNoRestrictedImportsPath(ctx *Context, reference noRestrictedImportsReference, restricted noRestrictedImportsPath) {
+  if restricted.allowTypeImports && reference.wholeTypeOnly {
+    return
+  }
+  if !restricted.names.hasRestrictions() {
+    message := fmt.Sprintf("'%s' import is restricted from being used.", reference.source)
+    ctx.Report(reference.sourceNode, noRestrictedImportsCustomMessage(message, restricted.message))
+    return
+  }
+  reportNoRestrictedImportsNames(ctx, reference, restricted.names, restricted.message, false, restricted.allowTypeImports)
+}
+
+func reportNoRestrictedImportsPattern(ctx *Context, reference noRestrictedImportsReference, restricted noRestrictedImportsPattern) {
+  if restricted.allowTypeImports && reference.wholeTypeOnly {
+    return
+  }
+  if !restricted.names.hasRestrictions() {
+    message := fmt.Sprintf("'%s' import is restricted from being used by a pattern.", reference.source)
+    ctx.Report(reference.sourceNode, noRestrictedImportsCustomMessage(message, restricted.message))
+    return
+  }
+  reportNoRestrictedImportsNames(ctx, reference, restricted.names, restricted.message, true, restricted.allowTypeImports)
+}
+
+func (control noRestrictedImportsNameControl) hasRestrictions() bool {
+  return control.hasImportNames || control.hasAllowImportNames ||
+    control.importNamePattern != nil || control.allowImportNamePattern != nil
+}
+
+func reportNoRestrictedImportsNames(
+  ctx *Context,
+  reference noRestrictedImportsReference,
+  control noRestrictedImportsNameControl,
+  customMessage string,
+  pattern bool,
+  allowTypeImports bool,
+) {
+  for _, imported := range reference.names {
+    if allowTypeImports && imported.typeOnly {
+      continue
+    }
+    if imported.name == "*" {
+      message := noRestrictedImportsNamespaceMessage(reference.source, control, pattern)
+      imported.report(ctx, noRestrictedImportsCustomMessage(message, customMessage))
+      continue
+    }
+    restricted := control.hasImportNames && noRestrictedImportsContains(control.importNames, imported.name)
+    restricted = restricted || (control.importNamePattern != nil && control.importNamePattern.MatchString(imported.name))
+    if restricted {
+      message := fmt.Sprintf("'%s' import from '%s' is restricted.", imported.name, reference.source)
+      if pattern {
+        message = fmt.Sprintf("'%s' import from '%s' is restricted from being used by a pattern.", imported.name, reference.source)
+      }
+      imported.report(ctx, noRestrictedImportsCustomMessage(message, customMessage))
+    }
+    if control.hasAllowImportNames && !noRestrictedImportsContains(control.allowImportNames, imported.name) {
+      message := fmt.Sprintf(
+        "'%s' import from '%s' is restricted because only %s %s allowed.",
+        imported.name,
+        reference.source,
+        noRestrictedImportsFormatNames(control.allowImportNames),
+        noRestrictedImportsIsOrAre(control.allowImportNames),
+      )
+      imported.report(ctx, noRestrictedImportsCustomMessage(message, customMessage))
+    } else if control.allowImportNamePattern != nil && !control.allowImportNamePattern.MatchString(imported.name) {
+      message := fmt.Sprintf(
+        "'%s' import from '%s' is restricted because only imports that match the pattern '%s' are allowed from '%s'.",
+        imported.name,
+        reference.source,
+        control.allowImportNameText,
+        reference.source,
+      )
+      imported.report(ctx, noRestrictedImportsCustomMessage(message, customMessage))
+    }
+  }
+}
+
+func noRestrictedImportsNamespaceMessage(source string, control noRestrictedImportsNameControl, pattern bool) string {
+  if control.hasImportNames {
+    suffix := "restricted"
+    if pattern {
+      suffix = "restricted from being used by a pattern"
+    }
+    return fmt.Sprintf(
+      "* import is invalid because %s from '%s' %s %s.",
+      noRestrictedImportsFormatNames(control.importNames),
+      source,
+      noRestrictedImportsIsOrAre(control.importNames),
+      suffix,
+    )
+  }
+  if control.hasAllowImportNames {
+    return fmt.Sprintf(
+      "* import is invalid because only %s from '%s' %s allowed.",
+      noRestrictedImportsFormatNames(control.allowImportNames),
+      source,
+      noRestrictedImportsIsOrAre(control.allowImportNames),
+    )
+  }
+  if control.allowImportNamePattern != nil {
+    return fmt.Sprintf(
+      "* import is invalid because only imports that match the pattern '%s' from '%s' are allowed.",
+      control.allowImportNameText,
+      source,
+    )
+  }
+  return fmt.Sprintf(
+    "* import is invalid because import name matching '%s' pattern from '%s' is restricted from being used.",
+    control.importNamePatternText,
+    source,
+  )
+}
+
+func (imported noRestrictedImportsImportedName) report(ctx *Context, message string) {
+  if imported.node != nil {
+    ctx.Report(imported.node, message)
+    return
+  }
+  if imported.pos >= 0 && imported.end > imported.pos {
+    ctx.ReportRange(imported.pos, imported.end, message)
+  }
+}
+
+func noRestrictedImportsContains(values []string, value string) bool {
+  for _, candidate := range values {
+    if candidate == value {
+      return true
+    }
+  }
+  return false
+}
+
+func noRestrictedImportsFormatNames(names []string) string {
+  quoted := make([]string, len(names))
+  for index, name := range names {
+    quoted[index] = "'" + name + "'"
+  }
+  switch len(quoted) {
+  case 0:
+    return ""
+  case 1:
+    return quoted[0]
+  case 2:
+    return quoted[0] + " and " + quoted[1]
+  default:
+    return strings.Join(quoted[:len(quoted)-1], ", ") + ", and " + quoted[len(quoted)-1]
+  }
+}
+
+func noRestrictedImportsIsOrAre(names []string) string {
+  if len(names) == 1 {
+    return "is"
+  }
+  return "are"
+}
+
+func noRestrictedImportsCustomMessage(message, custom string) string {
+  if custom == "" {
+    return message
+  }
+  return message + " " + custom
 }
 
 func init() {

--- a/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
@@ -237,6 +237,113 @@ export type ITtscLintCoreNoParamReassignRuleOptions =
       ignorePropertyModificationsForRegex?: string[];
     };
 
+/** Shared message and type-import switches for one restricted import entry. */
+interface ITtscLintCoreNoRestrictedImportsEntryBase {
+  /** Text appended to the standard diagnostic. */
+  message?: string;
+
+  /** Permit whole type-only declarations and type-only named specifiers. */
+  allowTypeImports?: boolean;
+}
+
+/** Non-empty string collection required by structured pattern controls. */
+type TtscLintCoreNoRestrictedImportsNonEmptyStrings = readonly [
+  string,
+  ...string[],
+];
+
+/** Mutually exclusive imported-name controls accepted for an exact path. */
+type TtscLintCoreNoRestrictedImportsPathNames =
+  | {
+      /** Imported names to reject; aliases are matched by their source name. */
+      importNames?: string[];
+      allowImportNames?: never;
+    }
+  | {
+      importNames?: never;
+      /** Reject every imported name outside this allowlist. */
+      allowImportNames: string[];
+    };
+
+/** One exact path restriction in `no-restricted-imports`. */
+export type TtscLintCoreNoRestrictedImportsPath =
+  | string
+  | (ITtscLintCoreNoRestrictedImportsEntryBase &
+      TtscLintCoreNoRestrictedImportsPathNames & {
+        /** Module specifier matched exactly. */
+        name: string;
+      });
+
+/** Mutually exclusive imported-name controls accepted for a path pattern. */
+type TtscLintCoreNoRestrictedImportsPatternNames =
+  | {
+      /** Imported names rejected by exact match. */
+      importNames?: TtscLintCoreNoRestrictedImportsNonEmptyStrings;
+      /** Imported names rejected by a regular expression. */
+      importNamePattern?: string;
+      allowImportNames?: never;
+      allowImportNamePattern?: never;
+    }
+  | {
+      importNames?: never;
+      importNamePattern?: never;
+      /** Reject every imported name outside this allowlist. */
+      allowImportNames: TtscLintCoreNoRestrictedImportsNonEmptyStrings;
+      allowImportNamePattern?: never;
+    }
+  | {
+      importNames?: never;
+      importNamePattern?: never;
+      allowImportNames?: never;
+      /** Reject every imported name that does not match this expression. */
+      allowImportNamePattern: string;
+    };
+
+/** One gitignore-style group or regular-expression path restriction. */
+export type ITtscLintCoreNoRestrictedImportsPattern =
+  ITtscLintCoreNoRestrictedImportsEntryBase &
+    TtscLintCoreNoRestrictedImportsPatternNames & {
+      /** Match module specifiers case-sensitively instead of the default fold. */
+      caseSensitive?: boolean;
+    } &
+    (
+      | {
+          /** Ordered gitignore-style path patterns, including `!` negation. */
+          group: TtscLintCoreNoRestrictedImportsNonEmptyStrings;
+          regex?: never;
+        }
+      | {
+          group?: never;
+          /** Regular expression tested against the module specifier. */
+          regex: string;
+        }
+    );
+
+/** Object form of the current ESLint `no-restricted-imports` options. */
+export interface ITtscLintCoreNoRestrictedImportsRuleOptions {
+  /** Exact module specifiers to restrict. */
+  paths?: TtscLintCoreNoRestrictedImportsPath[];
+
+  /** Gitignore-style strings or structured pattern entries. */
+  patterns?: string[] | ITtscLintCoreNoRestrictedImportsPattern[];
+}
+
+/**
+ * Canonical setting for `no-restricted-imports`.
+ *
+ * ESLint accepts either positional path entries or one `{ paths, patterns }`
+ * object. Both forms remain available so existing configurations need no
+ * ttsc-specific reshaping.
+ */
+export type TtscLintCoreNoRestrictedImportsRuleSetting =
+  | TtscLintRuleSetting
+  | readonly [TtscLintSeverity, ITtscLintCoreNoRestrictedImportsRuleOptions]
+  | readonly [
+      TtscLintSeverity,
+      TtscLintCoreNoRestrictedImportsPath,
+      ...TtscLintCoreNoRestrictedImportsPath[],
+    ];
+
 /** `prefer-const` rule options. */
 export interface ITtscLintCorePreferConstRuleOptions {
   /**

--- a/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
@@ -12,6 +12,7 @@ import type {
   ITtscLintCorePreferConstRuleOptions,
   ITtscLintNoFallthroughRuleOptions,
   TtscLintCoreNoInnerDeclarationsRuleSetting,
+  TtscLintCoreNoRestrictedImportsRuleSetting,
 } from "./ITtscLintCoreRuleOptions";
 
 /**
@@ -930,12 +931,12 @@ export interface ITtscLintCoreRules {
   "no-regex-spaces"?: TtscLintRuleSetting;
 
   /**
-   * Reject `import` declarations targeting any module specifier in the project
-   * denylist.
+   * Reject static imports and re-exports selected by exact paths or patterns.
+   * Missing or empty restrictions are a no-op.
    *
    * @reference https://eslint.org/docs/latest/rules/no-restricted-imports
    */
-  "no-restricted-imports"?: TtscLintRuleSetting;
+  "no-restricted-imports"?: TtscLintCoreNoRestrictedImportsRuleSetting;
 
   /**
    * Reject AST node kinds listed in the project denylist.

--- a/packages/lint/test/rules/control-flow/no_restricted_imports_test.go
+++ b/packages/lint/test/rules/control-flow/no_restricted_imports_test.go
@@ -2,19 +2,8 @@ package linthost
 
 import "testing"
 
-// TestRuleCorpusNoRestrictedImports verifies the lint rule corpus fixture no-restricted-imports.ts.
-//
-// Rule corpus tests mirror tests/test-lint/src/cases inside Go unit coverage. Each generated
-// scenario keeps one annotated TypeScript fixture tied to the native Engine so individual rule
-// Check methods are measured by go test instead of only by the TypeScript feature runner.
-//
-// This case enables the rule annotations declared in no-restricted-imports.ts and compares
-// normalized rule, severity, and line triples. The source text stays embedded in the
-// generated Go file so the test remains package-local and deterministic.
-//
-// 1. Load the annotated TypeScript fixture source embedded below.
-// 2. Enable the rule severities declared by its // expect: comments.
-// 3. Assert the native Engine reports exactly the annotated diagnostics.
+// TestRuleCorpusNoRestrictedImports verifies that enabling no-restricted-imports without
+// options does not infer a project policy from the corpus fixture.
 func TestRuleCorpusNoRestrictedImports(t *testing.T) {
-  assertRuleCorpusCase(t, "no-restricted-imports.ts", "// Positive: hard-coded deny list flags `lodash` at the specifier.\n// expect: no-restricted-imports error\nimport _ from \"lodash\";\n\n// Positive: a `from` re-export hits the same deny list.\n// expect: no-restricted-imports error\nexport { isArray } from \"underscore\";\n\n// Negative: any specifier outside the deny list passes through.\nimport * as fs from \"node:fs\";\n\nvoid _;\nvoid fs;\n")
+  assertRuleSkipsSource(t, "no-restricted-imports", "// No options means no project policy is inferred.\nimport _ from \"lodash\";\n\n// Re-exports are likewise unrestricted until paths or patterns are supplied.\nexport { isArray } from \"underscore\";\n\n// Arbitrary imports remain accepted.\nimport * as fs from \"node:fs\";\n\nvoid _;\nvoid fs;\n")
 }

--- a/packages/lint/test/rules/imports-modules/no_restricted_imports_options_test.go
+++ b/packages/lint/test/rules/imports-modules/no_restricted_imports_options_test.go
@@ -1,0 +1,473 @@
+package linthost
+
+import (
+  "encoding/json"
+  "sort"
+  "strings"
+  "testing"
+)
+
+type noRestrictedImportsFinding struct {
+  target  string
+  message string
+  pos     int
+}
+
+func runNoRestrictedImports(
+  t *testing.T,
+  source string,
+  options json.RawMessage,
+) []noRestrictedImportsFinding {
+  t.Helper()
+  _, _, findings := runRuleFindingsSnapshot(t, "no-restricted-imports", source, options)
+  normalized := make([]noRestrictedImportsFinding, 0, len(findings))
+  for _, finding := range findings {
+    if finding.Rule != "no-restricted-imports" {
+      t.Fatalf("unexpected rule in no-restricted-imports findings: %+v", finding)
+    }
+    if len(finding.Fix) != 0 || len(finding.Suggestions) != 0 {
+      t.Fatalf("no-restricted-imports must not offer edits: %+v", finding)
+    }
+    if finding.Pos < 0 || finding.End <= finding.Pos || finding.End > len(source) {
+      t.Fatalf("no-restricted-imports returned an invalid source range: %+v", finding)
+    }
+    normalized = append(normalized, noRestrictedImportsFinding{
+      target:  source[finding.Pos:finding.End],
+      message: finding.Message,
+      pos:     finding.Pos,
+    })
+  }
+  sort.SliceStable(normalized, func(i, j int) bool {
+    if normalized[i].pos != normalized[j].pos {
+      return normalized[i].pos < normalized[j].pos
+    }
+    return normalized[i].message < normalized[j].message
+  })
+  return normalized
+}
+
+func noRestrictedImportsTargets(findings []noRestrictedImportsFinding) []string {
+  targets := make([]string, len(findings))
+  for index, finding := range findings {
+    targets[index] = finding.target
+  }
+  return targets
+}
+
+func assertNoRestrictedImportsTargets(t *testing.T, findings []noRestrictedImportsFinding, want ...string) {
+  t.Helper()
+  got := noRestrictedImportsTargets(findings)
+  if len(got) != len(want) {
+    t.Fatalf("no-restricted-imports target count mismatch: want=%q got=%q findings=%+v", want, got, findings)
+  }
+  for index := range want {
+    if got[index] != want[index] {
+      t.Fatalf("no-restricted-imports target[%d] mismatch: want=%q got=%q all=%q", index, want[index], got[index], got)
+    }
+  }
+}
+
+func TestNoRestrictedImportsMissingAndEmptyRestrictionsAreNoOp(t *testing.T) {
+  source := `import lodash from "lodash";
+export { map } from "underscore";
+import * as fs from "node:fs";
+void lodash;
+void fs;
+`
+  options := []json.RawMessage{
+    nil,
+    json.RawMessage(`{}`),
+    json.RawMessage(`[]`),
+    json.RawMessage(`{"paths":[]}`),
+    json.RawMessage(`{"patterns":[]}`),
+    json.RawMessage(`{"paths":[],"patterns":[]}`),
+  }
+  for _, option := range options {
+    if findings := runNoRestrictedImports(t, source, option); len(findings) != 0 {
+      t.Fatalf("empty options %s inferred a restriction: %+v", option, findings)
+    }
+  }
+}
+
+func TestNoRestrictedImportsExactPathsCoverEveryStaticModuleForm(t *testing.T) {
+  source := `import Default from "blocked";
+import { source as alias } from "blocked";
+import * as namespace from "blocked";
+import "blocked";
+export { source as renamed } from "blocked";
+export * from "blocked";
+export * as exportedNamespace from "blocked";
+import legacy = require("blocked");
+import allowed from "allowed";
+void Default;
+void namespace;
+void legacy;
+void allowed;
+`
+  findings := runNoRestrictedImports(
+    t,
+    source,
+    json.RawMessage(`{"paths":[{"name":"blocked","message":"Use the supported boundary instead."}]}`),
+  )
+  assertNoRestrictedImportsTargets(
+    t,
+    findings,
+    `"blocked"`,
+    `"blocked"`,
+    `"blocked"`,
+    `"blocked"`,
+    `"blocked"`,
+    `"blocked"`,
+    `"blocked"`,
+    `"blocked"`,
+  )
+  for _, finding := range findings {
+    if finding.message != "'blocked' import is restricted from being used. Use the supported boundary instead." {
+      t.Fatalf("unexpected exact-path message: %+v", finding)
+    }
+  }
+}
+
+func TestNoRestrictedImportsPositionalPathsDoNotReachDynamicImports(t *testing.T) {
+  source := `import direct from "blocked";
+const dynamic = import("blocked");
+const commonJS = require("blocked");
+JSON.stringify([direct, dynamic, commonJS]);
+`
+  findings := runNoRestrictedImports(t, source, json.RawMessage(`"blocked"`))
+  assertNoRestrictedImportsTargets(t, findings, `"blocked"`)
+}
+
+func TestNoRestrictedImportsExactPathsPreserveModuleSpecifierWhitespace(t *testing.T) {
+  source := `import exact from "pkg";
+import spaced from " pkg ";
+JSON.stringify([exact, spaced]);
+`
+  exact := runNoRestrictedImports(t, source, json.RawMessage(`"pkg"`))
+  assertNoRestrictedImportsTargets(t, exact, `"pkg"`)
+
+  spaced := runNoRestrictedImports(t, source, json.RawMessage(`" pkg "`))
+  assertNoRestrictedImportsTargets(t, spaced, `" pkg "`)
+}
+
+func TestNoRestrictedImportsMatchesSourceNamesAndReportsExactSpecifierRanges(t *testing.T) {
+  source := `import Default, { source as alias, allowed } from "pkg";
+import * as namespace from "pkg";
+export { source as renamed, allowed } from "pkg";
+export { default as exportedDefault } from "pkg";
+export * from "pkg";
+export * as exportedNamespace from "pkg";
+import "pkg";
+void Default;
+void namespace;
+`
+  findings := runNoRestrictedImports(
+    t,
+    source,
+    json.RawMessage(`{"paths":[{"name":"pkg","importNames":["default","source"]}]}`),
+  )
+  assertNoRestrictedImportsTargets(
+    t,
+    findings,
+    "Default",
+    "source as alias",
+    "* as namespace",
+    "source as renamed",
+    "default as exportedDefault",
+    "*",
+    "*",
+  )
+  if !strings.Contains(findings[0].message, "'default' import from 'pkg' is restricted") ||
+    !strings.Contains(findings[1].message, "'source' import from 'pkg' is restricted") {
+    t.Fatalf("aliases were matched by local rather than source names: %+v", findings)
+  }
+  for _, index := range []int{2, 5, 6} {
+    if !strings.Contains(findings[index].message, "* import is invalid because 'default' and 'source' from 'pkg' are restricted") {
+      t.Fatalf("namespace diagnostic mismatch: %+v", findings[index])
+    }
+  }
+}
+
+func TestNoRestrictedImportsPatternsHonorNegationCaseRegexAndNamePatterns(t *testing.T) {
+  source := `import "LIB/private";
+import "LIB/pick";
+import { secret, unsafeThing, safe } from "@internal/pkg";
+import { secret as allowedByCase } from "@Internal/pkg";
+`
+  findings := runNoRestrictedImports(
+    t,
+    source,
+    json.RawMessage(`{"patterns":[{"group":["lib/*","!lib/pick"],"message":"Grouped restriction."},{"regex":"^@internal/","caseSensitive":true,"importNames":["secret"],"importNamePattern":"^unsafe","message":"Internal name."}]}`),
+  )
+  assertNoRestrictedImportsTargets(t, findings, `"LIB/private"`, "secret", "unsafeThing")
+  if findings[0].message != "'LIB/private' import is restricted from being used by a pattern. Grouped restriction." {
+    t.Fatalf("group message mismatch: %+v", findings[0])
+  }
+  for _, finding := range findings[1:] {
+    if !strings.HasSuffix(finding.message, "Internal name.") {
+      t.Fatalf("pattern custom message was not appended: %+v", finding)
+    }
+  }
+}
+
+func TestNoRestrictedImportsStringPatternsKeepGitignoreParentNegationSemantics(t *testing.T) {
+  source := `import "lib/private/value";
+import "lib/public/value";
+import "other/value";
+`
+  findings := runNoRestrictedImports(
+    t,
+    source,
+    json.RawMessage(`{"patterns":["lib/*","!lib/public"]}`),
+  )
+  assertNoRestrictedImportsTargets(t, findings, `"lib/private/value"`)
+}
+
+func TestNoRestrictedImportsGroupsKeepGitignoreAnchorsGlobstarsAndUnicode(t *testing.T) {
+  anchoredSource := `import "root";
+import "nested/root";
+`
+  anchored := runNoRestrictedImports(
+    t,
+    anchoredSource,
+    json.RawMessage(`{"patterns":[{"group":["/root"]}]}`),
+  )
+  assertNoRestrictedImportsTargets(t, anchored, `"root"`)
+
+  ordinaryStarsSource := `import "fooxbar";
+import "foo/deep/bar";
+`
+  ordinaryStars := runNoRestrictedImports(
+    t,
+    ordinaryStarsSource,
+    json.RawMessage(`{"patterns":[{"group":["foo**bar"]}]}`),
+  )
+  assertNoRestrictedImportsTargets(t, ordinaryStars, `"fooxbar"`)
+
+  trailingSource := `import "foo/";
+import "foo/value";
+`
+  trailingStar := runNoRestrictedImports(
+    t,
+    trailingSource,
+    json.RawMessage(`{"patterns":[{"group":["foo/*"]}]}`),
+  )
+  assertNoRestrictedImportsTargets(t, trailingStar, `"foo/value"`)
+  trailingGlobstar := runNoRestrictedImports(
+    t,
+    trailingSource,
+    json.RawMessage(`{"patterns":[{"group":["foo/**"]}]}`),
+  )
+  assertNoRestrictedImportsTargets(t, trailingGlobstar, `"foo/value"`)
+
+  unicodeSource := `import "패키지/내부";
+import "패키지/공개";
+`
+  unicodeGroup := runNoRestrictedImports(
+    t,
+    unicodeSource,
+    json.RawMessage(`{"patterns":[{"group":["패키지/*","!패키지/공개"]}]}`),
+  )
+  assertNoRestrictedImportsTargets(t, unicodeGroup, `"패키지/내부"`)
+
+  invalidRange := runNoRestrictedImports(
+    t,
+    `import "range-target";`,
+    json.RawMessage(`{"patterns":[{"group":["[z-a]"]}]}`),
+  )
+  if len(invalidRange) != 0 {
+    t.Fatalf("an unusable gitignore range must not reject configuration or match imports: %+v", invalidRange)
+  }
+}
+
+func TestNoRestrictedImportsAllowedNamesRejectOnlyTheComplement(t *testing.T) {
+  source := `import Default, { safe, unsafe } from "pkg/module";
+import * as namespace from "pkg/module";
+export { safe, unsafe as renamed } from "pkg/module";
+void Default;
+void namespace;
+`
+  findings := runNoRestrictedImports(
+    t,
+    source,
+    json.RawMessage(`{"patterns":[{"group":["pkg/*"],"allowImportNames":["safe"],"message":"Use the public name."}]}`),
+  )
+  assertNoRestrictedImportsTargets(t, findings, "Default", "unsafe", "* as namespace", "unsafe as renamed")
+  for _, finding := range findings {
+    if !strings.Contains(finding.message, "only 'safe'") || !strings.HasSuffix(finding.message, "Use the public name.") {
+      t.Fatalf("allow-list diagnostic mismatch: %+v", finding)
+    }
+  }
+}
+
+func TestNoRestrictedImportsAllowedNamePatternCoversImportsAndReexports(t *testing.T) {
+  source := `import { publicValue, privateValue } from "pkg/names";
+export { publicType, privateType } from "pkg/names";
+`
+  findings := runNoRestrictedImports(
+    t,
+    source,
+    json.RawMessage(`{"patterns":[{"regex":"^pkg/","allowImportNamePattern":"^public"}]}`),
+  )
+  assertNoRestrictedImportsTargets(t, findings, "privateValue", "privateType")
+}
+
+func TestNoRestrictedImportsAllowTypeImportsHandlesWholeAndInlineTypeSyntax(t *testing.T) {
+  source := `import type { Foo } from "types";
+import { type Foo } from "types";
+import { type Foo, Bar } from "types";
+export type { Foo } from "types";
+export { type Foo } from "types";
+export type * from "types";
+import type Legacy = require("types");
+import { type Foo, Bar } from "names";
+export { type Foo, Bar } from "names";
+import Value from "types";
+void Bar;
+void Value;
+`
+  findings := runNoRestrictedImports(
+    t,
+    source,
+    json.RawMessage(`{"paths":[{"name":"types","allowTypeImports":true},{"name":"names","importNames":["Foo","Bar"],"allowTypeImports":true}]}`),
+  )
+  assertNoRestrictedImportsTargets(t, findings, `"types"`, "Bar", "Bar", `"types"`)
+}
+
+func noRestrictedImportsValidationEngine(options json.RawMessage) *Engine {
+  return NewEngineWithResolver(InlineRuleResolver{
+    Rules: RuleConfig{"no-restricted-imports": SeverityError},
+    Options: RuleOptionsMap{
+      "no-restricted-imports": options,
+    },
+  })
+}
+
+func TestNoRestrictedImportsValidatorAcceptsEveryOfficialOptionBranch(t *testing.T) {
+  valid := []json.RawMessage{
+    nil,
+    json.RawMessage(`"fs"`),
+    json.RawMessage(`["fs",{"name":"pkg","message":"Use another module.","importNames":[],"allowTypeImports":true}]`),
+    json.RawMessage(`{}`),
+    json.RawMessage(`{"paths":[],"patterns":[]}`),
+    json.RawMessage(`{"paths":["fs",{"name":"pkg","allowImportNames":[]}],"patterns":["pkg/*","!pkg/public"]}`),
+    json.RawMessage(`{"patterns":[{"group":["pkg/*"],"importNames":["one"],"importNamePattern":"^unsafe","caseSensitive":true,"allowTypeImports":true}]}`),
+    json.RawMessage(`{"patterns":[{"regex":"^pkg/","allowImportNames":["safe"]},{"regex":"^other/","allowImportNamePattern":"^public"}]}`),
+  }
+  for _, options := range valid {
+    engine := noRestrictedImportsValidationEngine(options)
+    if err := engine.ConfigError(); err != nil {
+      t.Fatalf("valid no-restricted-imports options %s were rejected: %v", options, err)
+    }
+    if engine.EnabledRules()["no-restricted-imports"] != SeverityError {
+      t.Fatalf("valid no-restricted-imports options did not activate the rule: %v", engine.EnabledRules())
+    }
+    if engine.NeedsTypeChecker() {
+      t.Fatal("no-restricted-imports unexpectedly requested a type checker")
+    }
+  }
+}
+
+func TestNoRestrictedImportsValidatorRejectsMalformedConfigurationAtTheBoundary(t *testing.T) {
+  cases := []struct {
+    options json.RawMessage
+    want    string
+  }{
+    {options: json.RawMessage(`null`), want: "options must be path entries"},
+    {options: json.RawMessage(`{"paths":`), want: "options must be an object"},
+    {options: json.RawMessage(`{"paths":[],"unexpected":true}`), want: `unknown option "unexpected"`},
+    {options: json.RawMessage(`{"paths":"fs"}`), want: `option "paths" must be an array`},
+    {options: json.RawMessage(`{"name":1}`), want: `option "name" must be a string`},
+    {options: json.RawMessage(`{"message":"missing name"}`), want: `requires "name"`},
+    {options: json.RawMessage(`{"name":"pkg","message":""}`), want: `option "message" must not be empty`},
+    {options: json.RawMessage(`{"name":"pkg","allowTypeImports":null}`), want: `option "allowTypeImports" must be a boolean`},
+    {options: json.RawMessage(`{"name":"pkg","importNames":[],"allowImportNames":[]}`), want: "cannot be combined"},
+    {options: json.RawMessage(`["fs","fs"]`), want: `option "paths" contains a duplicate entry`},
+    {options: json.RawMessage(`{"patterns":["pkg/*",{"group":["other/*"]}]}`), want: "only strings or only objects"},
+    {options: json.RawMessage(`{"patterns":[{}]}`), want: "exactly one"},
+    {options: json.RawMessage(`{"patterns":[{"group":["pkg/*"],"regex":"pkg"}]}`), want: "exactly one"},
+    {options: json.RawMessage(`{"patterns":[{"group":[]}]}`), want: "at least one string"},
+    {options: json.RawMessage(`{"patterns":[{"group":["pkg/*","pkg/*"]}]}`), want: "duplicate value"},
+    {options: json.RawMessage(`{"patterns":[{"regex":"["}]}`), want: "valid regular expression"},
+    {options: json.RawMessage(`{"patterns":[{"regex":"pkg","importNames":[]}]}`), want: "at least one string"},
+    {options: json.RawMessage(`{"patterns":[{"regex":"pkg","allowImportNames":["safe"],"allowImportNamePattern":"^safe"}]}`), want: "cannot be combined"},
+    {options: json.RawMessage(`{"patterns":[{"regex":"pkg","unknown":true}]}`), want: `unknown option "unknown"`},
+    {options: json.RawMessage(`{"patterns":[{"regex":"pkg","caseSensitive":null}]}`), want: `option "caseSensitive" must be a boolean`},
+    {options: json.RawMessage(`{"patterns":[{"regex":"pkg","message":""}]}`), want: `option "message" must not be empty`},
+    {options: json.RawMessage(`{"patterns":[{"regex":"pkg","message":"x"},{"message":"x","regex":"pkg"}]}`), want: `option "patterns" contains a duplicate entry`},
+  }
+  for _, tc := range cases {
+    engine := noRestrictedImportsValidationEngine(tc.options)
+    err := engine.ConfigError()
+    if err == nil || !strings.Contains(err.Error(), tc.want) {
+      t.Fatalf("invalid options %s mismatch: want=%q got=%v", tc.options, tc.want, err)
+    }
+    if _, active := engine.EnabledRules()["no-restricted-imports"]; active {
+      t.Fatalf("invalid options entered the dispatch table: %v", engine.EnabledRules())
+    }
+  }
+}
+
+func TestCommandCheckNoRestrictedImportsUsesRealConfigOptions(t *testing.T) {
+  root := seedLintProject(t, `import { unsafe, safe } from "pkg/private";
+JSON.stringify([unsafe, safe]);
+`)
+  seedLintConfig(t, root, map[string]any{
+    "rules": map[string]any{
+      "no-restricted-imports": []any{
+        "error",
+        map[string]any{
+          "patterns": []any{
+            map[string]any{
+              "group":       []string{"pkg/*"},
+              "importNames": []string{"unsafe"},
+              "message":     "Import from the public module.",
+            },
+          },
+        },
+      },
+    },
+  })
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "check",
+      "--cwd", root,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  const message = "[no-restricted-imports] 'unsafe' import from 'pkg/private' is restricted from being used by a pattern. Import from the public module."
+  if code != 2 || stdout != "" || strings.Count(stderr, message) != 1 || strings.Contains(stderr, "'safe' import") {
+    t.Fatalf("no-restricted-imports command mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}
+
+func TestCommandCheckRejectsInvalidNoRestrictedImportsOptionsBeforeLinting(t *testing.T) {
+  root := seedLintProject(t, `import value from "pkg";
+JSON.stringify(value);
+`)
+  seedLintConfig(t, root, map[string]any{
+    "rules": map[string]any{
+      "no-restricted-imports": []any{
+        "error",
+        map[string]any{
+          "patterns": []any{
+            map[string]any{"regex": "["},
+          },
+        },
+      },
+    },
+  })
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "check",
+      "--cwd", root,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  if code != 2 || stdout != "" ||
+    !strings.Contains(stderr, `@ttsc/lint: invalid options for rule "no-restricted-imports"`) ||
+    !strings.Contains(stderr, `option "regex" must be a valid regular expression`) ||
+    strings.Contains(stderr, "[no-restricted-imports]") {
+    t.Fatalf("invalid no-restricted-imports command mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}

--- a/tests/test-lint/src/cases/no-restricted-imports.ts
+++ b/tests/test-lint/src/cases/no-restricted-imports.ts
@@ -1,12 +1,10 @@
-// Positive: hard-coded deny list flags `lodash` at the specifier.
-// expect: no-restricted-imports error
+// No options means no project policy is inferred.
 import _ from "lodash";
 
-// Positive: a `from` re-export hits the same deny list.
-// expect: no-restricted-imports error
+// Re-exports are likewise unrestricted until paths or patterns are supplied.
 export { isArray } from "underscore";
 
-// Negative: any specifier outside the deny list passes through.
+// Arbitrary imports remain accepted.
 import * as fs from "node:fs";
 
 void _;

--- a/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
+++ b/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
@@ -75,6 +75,27 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
           ignorePropertyModificationsForRegex: ["^mutable"],
         },
       ],
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            "node:fs",
+            {
+              name: "legacy-package",
+              importNames: ["default", "unsafe"],
+              message: "Use the supported package.",
+              allowTypeImports: true,
+            },
+          ],
+          patterns: [
+            {
+              group: ["internal/*", "!internal/public"],
+              allowImportNamePattern: "^public",
+              caseSensitive: true,
+            },
+          ],
+        },
+      ],
       "prefer-const": [
         "error",
         { destructuring: "all", ignoreReadBeforeAssign: true },
@@ -231,6 +252,75 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
       ],
     },
   };
+  const noRestrictedImportsPositionalPaths: ITtscLintConfig = {
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        "node:fs",
+        { name: "legacy-package", allowImportNames: ["safe"] },
+      ],
+    },
+  };
+  const noRestrictedImportsConflictingPathNames: ITtscLintConfig = {
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "legacy-package",
+              importNames: ["unsafe"],
+              // @ts-expect-error — exact path entries cannot combine a denylist with an allowlist.
+              allowImportNames: ["safe"],
+            },
+          ],
+        },
+      ],
+    },
+  };
+  const noRestrictedImportsPatternModeConflict: ITtscLintConfig = {
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            // @ts-expect-error — a structured pattern selects exactly one of gitignore-style `group` or `regex`.
+            { group: ["internal/*"], regex: "^internal/" },
+          ],
+        },
+      ],
+    },
+  };
+  const noRestrictedImportsPatternNameConflict: ITtscLintConfig = {
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            // @ts-expect-error — deny-name controls cannot be combined with an allow-name pattern.
+            {
+              regex: "^internal/",
+              importNames: ["unsafe"],
+              allowImportNamePattern: "^public",
+            },
+          ],
+        },
+      ],
+    },
+  };
+  const noRestrictedImportsEmptyStructuredPatternList: ITtscLintConfig = {
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            // @ts-expect-error — structured pattern groups must contain at least one string.
+            { group: [] },
+          ],
+        },
+      ],
+    },
+  };
   const crossRuleShape: ITtscLintConfig = {
     rules: {
       // @ts-expect-error — `testIdPattern` belongs to testing-library/consistent-data-testid; cypress/unsafe-to-chain-command's option shape rejects it.
@@ -285,6 +375,11 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
   assert.ok(noParamReassignIgnoreWithoutProps);
   assert.ok(noParamReassignInvalidIgnoreEntry);
   assert.ok(noParamReassignOptionKeyTypo);
+  assert.ok(noRestrictedImportsPositionalPaths);
+  assert.ok(noRestrictedImportsConflictingPathNames);
+  assert.ok(noRestrictedImportsPatternModeConflict);
+  assert.ok(noRestrictedImportsPatternNameConflict);
+  assert.ok(noRestrictedImportsEmptyStructuredPatternList);
   assert.ok(preferConstOptionValue);
   assert.ok(crossRuleShape);
   assert.ok(lintRuleWithOptions);

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -91,7 +91,7 @@ Examples come from the checked [lint corpus](https://github.com/samchon/ttsc/tre
 - [`no-prototype-builtins`](#rule-no-prototype-builtins): Reject `obj.hasOwnProperty(key)` and other direct `Object.prototype` builtins on user objects.
 - [`no-redeclare`](#rule-no-redeclare): Reject declaring the same binding more than once in the same scope.
 - [`no-regex-spaces`](#rule-no-regex-spaces): Reject more than one consecutive literal space in a regex.
-- [`no-restricted-imports`](#rule-no-restricted-imports): Reject `import` declarations targeting any module specifier in the project denylist.
+- [`no-restricted-imports`](#rule-no-restricted-imports): Reject static imports and re-exports selected by configured exact paths, gitignore-style groups, or regular expressions.
 - [`no-restricted-syntax`](#rule-no-restricted-syntax): Reject AST node kinds listed in the project denylist.
 - [`no-return-assign`](#rule-no-return-assign): Reject assignment expressions used as the operand of `return` , almost always a typo for `===`.
 - [`no-script-url`](#rule-no-script-url): Reject `javascript:` URLs in string literals, they execute their body as code on browser navigation.
@@ -2026,13 +2026,62 @@ const r = /a  b/;
 
 ### `no-restricted-imports`
 
-Reject `import` declarations targeting any module specifier in the project denylist.
+Reject static imports and re-exports selected by user-configured exact paths,
+gitignore-style groups, or regular expressions. A severity-only setting, an
+empty `paths` list, and an empty `patterns` list are all no-ops; the rule never
+infers a project denylist.
+
+Exact-path and structured-pattern entries can restrict or allow selected source
+names, append a custom message, and permit type-only imports and re-exports.
+Pattern entries also support case-sensitive matching and source-name regular
+expressions.
+
+Options:
+
+- `paths?: (string | { name, message?, importNames?, allowImportNames?, allowTypeImports? })[]`
+- `patterns?: string[] | ({ group } | { regex })[]`
+
+  Structured pattern entries also accept `message`, `caseSensitive`,
+  `importNames`, `allowImportNames`, `importNamePattern`,
+  `allowImportNamePattern`, and `allowTypeImports`. Each entry uses either
+  deny-name controls or allow-name controls, not both.
 
 Example:
 
 ```ts
 // reports: no-restricted-imports (error)
-import _ from "lodash";
+import legacy from "legacy-package";
+
+// reports: no-restricted-imports (error)
+export { privateApi } from "internal/private";
+```
+
+```ts filename="ttsc.lint.config.ts"
+import type { ITtscLintConfig } from "@ttsc/lint";
+
+export default {
+  rules: {
+    "no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          {
+            name: "legacy-package",
+            importNames: ["default"],
+            message: "Use the supported package.",
+            allowTypeImports: true,
+          },
+        ],
+        patterns: [
+          {
+            group: ["internal/*", "!internal/public"],
+            allowImportNames: ["publicApi"],
+          },
+        ],
+      },
+    ],
+  },
+} satisfies ITtscLintConfig;
 ```
 
 <a id="rule-no-restricted-syntax"></a>


### PR DESCRIPTION
## Summary

- remove the production fallback denylist so missing and empty restrictions are a no-op
- implement the current ESLint exact-path, gitignore-group, regular-expression, imported-name, message, case, and type-only option branches
- validate malformed options before dispatch and expose the canonical positional/object TypeScript settings
- cover every static import/re-export form, exact ranges, config boundaries, public types, and gitignore edge cases

## Validation

Three exhaustive whole-change reviews and focused local validation are in progress on the pushed HEAD. Results will be recorded on this PR before merge.

Fixes #497