### PR TITLE
Fix no-loop-func closure safety analysis

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -267,7 +267,7 @@ Source: [ESLint core rules](https://eslint.org/docs/latest/rules/).
 - [`no-labels`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-labels.ts): rejects labels.
 - [`no-lone-blocks`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-lone-blocks.ts): rejects unnecessary standalone blocks.
 - [`no-lonely-if`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-lonely-if.ts): rejects `if` as the only statement in an `else`.
-- [`no-loop-func`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-loop-func.ts): reject function declarations defined inside the body of a loop.
+- [`no-loop-func`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-loop-func.ts): reject loop-created closures only when they capture bindings that can change between iterations.
 - [`no-loss-of-precision`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-loss-of-precision.ts): rejects number literals that lose precision.
 - [`no-magic-numbers`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-magic-numbers.ts): reject inline numeric literals outside `const` initializer position. `0`, `1`, `-1`, array indices, and enum values are exempt.
 - [`no-misleading-character-class`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-misleading-character-class.ts): rejects misleading regex character classes.

--- a/packages/lint/linthost/rules_no_loop_func.go
+++ b/packages/lint/linthost/rules_no_loop_func.go
@@ -1,83 +1,468 @@
-// noLoopFunc reports a `function` declaration, function expression, or
-// arrow function defined inside the body of a loop. The function value
-// allocated each iteration almost always closes over the loop counter or
-// some other binding that changes between iterations, so a deferred call
-// (timer, microtask, event handler) observes whatever the binding holds
-// at call time — usually the loop's terminal value, never the value the
-// developer reasoned about at the textual position.
+// noLoopFunc reports closures created in loops only when they capture a
+// binding whose value can change between iterations. The analysis mirrors
+// ESLint's reference semantics while using TypeScript-Go symbols to preserve
+// lexical identity through shadowing, destructuring, and TypeScript syntax.
 // https://eslint.org/docs/latest/rules/no-loop-func
-//
-// Conservative baseline: every function-like syntactically inside a loop
-// body is flagged. Capture analysis (the rule's full upstream
-// implementation only fires when the function actually closes over a
-// `let` / `var` / `const` declared outside) is deferred; the false-
-// positive rate is acceptable because the fix — hoist the function out
-// of the loop — is almost always the cleaner code in either case.
-//
-// The walk stops at nested loop boundaries — each enclosing loop visits
-// itself once, so an inner loop reports its own nested function-likes
-// and the outer loop only owns the function-likes directly inside it.
-// Inner function-likes are also boundaries: a closure inside an outer
-// function-likes is that inner scope's problem.
 package linthost
 
 import (
+  "strings"
+
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
 
 type noLoopFunc struct{}
 
-func (noLoopFunc) Name() string { return "no-loop-func" }
-func (noLoopFunc) Visits() []shimast.Kind {
-  return []shimast.Kind{
-    shimast.KindForStatement,
-    shimast.KindForInStatement,
-    shimast.KindForOfStatement,
-    shimast.KindWhileStatement,
-    shimast.KindDoStatement,
-  }
+type noLoopFuncReference struct {
+  node   *shimast.Node
+  symbol *shimast.Symbol
+  scope  *shimast.Node
 }
+
+type noLoopFuncBindingKind uint8
+
+const (
+  noLoopFuncOtherBinding noLoopFuncBindingKind = iota
+  noLoopFuncLetBinding
+  noLoopFuncConstantBinding
+)
+
+type noLoopFuncBinding struct {
+  rangeNode *shimast.Node
+  scope     *shimast.Node
+  kind      noLoopFuncBindingKind
+}
+
+type noLoopFuncAnalysis struct {
+  ctx                    *Context
+  declarationIdentifiers map[*shimast.Node]struct{}
+  writeIdentifiers       map[*shimast.Node]struct{}
+  functionReferences     map[*shimast.Node][]noLoopFuncReference
+  writesBySymbol         map[*shimast.Symbol][]noLoopFuncReference
+  bindings               map[*shimast.Symbol]noLoopFuncBinding
+  skippedIIFEs           map[*shimast.Node]struct{}
+}
+
+func (noLoopFunc) Name() string             { return "no-loop-func" }
+func (noLoopFunc) NeedsTypeChecker() bool   { return true }
+func (noLoopFunc) Visits() []shimast.Kind   { return []shimast.Kind{shimast.KindSourceFile} }
 func (noLoopFunc) Check(ctx *Context, node *shimast.Node) {
-  var walk func(n *shimast.Node)
-  walk = func(n *shimast.Node) {
-    if n == nil {
-      return
-    }
-    if isFunctionLikeKind(n) {
-      ctx.Report(n, "Function declared in a loop closes over the loop's bindings — hoist it out.")
-      return
-    }
-    if n != node && isLoopKind(n) {
-      // Nested loops report their own contents when visited.
-      return
-    }
-    n.ForEachChild(func(child *shimast.Node) bool {
-      walk(child)
-      return false
-    })
+  if ctx.Checker == nil || node == nil {
+    return
   }
-  node.ForEachChild(func(child *shimast.Node) bool {
-    walk(child)
-    return false
+
+  analysis := &noLoopFuncAnalysis{
+    ctx:                    ctx,
+    declarationIdentifiers: make(map[*shimast.Node]struct{}),
+    writeIdentifiers:       make(map[*shimast.Node]struct{}),
+    functionReferences:     make(map[*shimast.Node][]noLoopFuncReference),
+    writesBySymbol:         make(map[*shimast.Symbol][]noLoopFuncReference),
+    bindings:               make(map[*shimast.Symbol]noLoopFuncBinding),
+    skippedIIFEs:           make(map[*shimast.Node]struct{}),
+  }
+  analysis.collectSyntax(node)
+  analysis.collectReferences(node)
+  analysis.checkFunctions(node)
+}
+
+func (a *noLoopFuncAnalysis) collectSyntax(source *shimast.Node) {
+  walkDescendants(source, func(node *shimast.Node) {
+    if node.Kind != shimast.KindShorthandPropertyAssignment {
+      for _, identifier := range noLoopFuncNamedIdentifiers(node.Name()) {
+        a.declarationIdentifiers[identifier] = struct{}{}
+      }
+    }
+
+    for _, identifier := range writeTargetIdentifiers(node) {
+      a.writeIdentifiers[identifier] = struct{}{}
+    }
+
+    if node.Kind != shimast.KindVariableDeclaration {
+      return
+    }
+    declaration := node.AsVariableDeclaration()
+    if declaration == nil {
+      return
+    }
+    initialized := declaration.Initializer != nil
+    if !initialized && node.Parent != nil && node.Parent.Kind == shimast.KindVariableDeclarationList &&
+      node.Parent.Parent != nil &&
+      (node.Parent.Parent.Kind == shimast.KindForInStatement || node.Parent.Parent.Kind == shimast.KindForOfStatement) {
+      statement := node.Parent.Parent.AsForInOrOfStatement()
+      initialized = statement != nil && statement.Initializer == node.Parent
+    }
+    if initialized {
+      for _, identifier := range bindingIdentifierNodes(declaration.Name()) {
+        a.writeIdentifiers[identifier] = struct{}{}
+      }
+    }
   })
 }
 
-// isLoopKind reports whether n is one of the loop statement kinds this
-// rule visits. Used to stop the walk at a nested loop boundary so each
-// loop reports only the function-likes directly inside its own body.
-func isLoopKind(n *shimast.Node) bool {
-  if n == nil {
+// noLoopFuncNamedIdentifiers returns identifier-shaped names without asking
+// the AST to reinterpret arbitrary declaration names as binding patterns.
+// Computed names contain evaluated expressions and must remain available to
+// reference analysis, while ordinary named declarations and members are not
+// runtime references to their own spelling.
+func noLoopFuncNamedIdentifiers(name *shimast.Node) []*shimast.Node {
+  if name == nil {
+    return nil
+  }
+  switch name.Kind {
+  case shimast.KindIdentifier:
+    return []*shimast.Node{name}
+  case shimast.KindObjectBindingPattern, shimast.KindArrayBindingPattern:
+    return bindingIdentifierNodes(name)
+  }
+  return nil
+}
+
+func (a *noLoopFuncAnalysis) collectReferences(source *shimast.Node) {
+  walkDescendants(source, func(node *shimast.Node) {
+    if node.Kind != shimast.KindIdentifier {
+      return
+    }
+
+    if _, written := a.writeIdentifiers[node]; written {
+      if symbol := canonicalValueSymbol(a.ctx, node); symbol != nil {
+        a.writesBySymbol[symbol] = append(a.writesBySymbol[symbol], noLoopFuncReference{
+          node:   node,
+          symbol: symbol,
+          scope:  noLoopFuncVariableScope(node),
+        })
+      }
+    }
+
+    if !a.isRuntimeReference(node) {
+      return
+    }
+    symbol := canonicalValueSymbol(a.ctx, node)
+    if symbol == nil {
+      return
+    }
+    reference := noLoopFuncReference{
+      node:   node,
+      symbol: symbol,
+      scope:  noLoopFuncVariableScope(node),
+    }
+    for ancestor := node.Parent; ancestor != nil; ancestor = ancestor.Parent {
+      if noLoopFuncIsCheckedFunction(ancestor) && noLoopFuncReferenceBelongsToFunction(node, ancestor) {
+        a.functionReferences[ancestor] = append(a.functionReferences[ancestor], reference)
+      }
+    }
+  })
+}
+
+func (a *noLoopFuncAnalysis) isRuntimeReference(node *shimast.Node) bool {
+  if _, declaration := a.declarationIdentifiers[node]; declaration {
     return false
   }
-  switch n.Kind {
-  case shimast.KindForStatement,
-    shimast.KindForInStatement,
-    shimast.KindForOfStatement,
-    shimast.KindWhileStatement,
-    shimast.KindDoStatement:
+  if shimast.IsPartOfTypeNode(node) || noLoopFuncInsideTypeQuery(node) {
+    return false
+  }
+  if !isValueReferenceIdentifier(node) {
+    return false
+  }
+  parent := node.Parent
+  if parent != nil && parent.Kind == shimast.KindBindingElement {
+    binding := parent.AsBindingElement()
+    if binding != nil && binding.PropertyName == node {
+      return false
+    }
+  }
+  return true
+}
+
+func (a *noLoopFuncAnalysis) checkFunctions(source *shimast.Node) {
+  walkDescendants(source, func(function *shimast.Node) {
+    if !noLoopFuncIsCheckedFunction(function) {
+      return
+    }
+    loop := noLoopFuncContainingLoop(function, a.skippedIIFEs)
+    if loop == nil {
+      return
+    }
+    if noLoopFuncIsEligibleIIFE(function) && !a.isReferencedNamedIIFE(function) {
+      a.skippedIIFEs[function] = struct{}{}
+      return
+    }
+
+    unsafeNames := make([]string, 0)
+    seenNames := make(map[string]struct{})
+    safety := make(map[*shimast.Symbol]bool)
+    for _, reference := range a.functionReferences[function] {
+      if a.symbolDeclaredInside(reference.symbol, function) {
+        continue
+      }
+      safe, exists := safety[reference.symbol]
+      if !exists {
+        safe = a.isSafe(loop, reference.symbol)
+        safety[reference.symbol] = safe
+      }
+      if safe {
+        continue
+      }
+      name := identifierText(reference.node)
+      if name == "" {
+        continue
+      }
+      if _, exists := seenNames[name]; exists {
+        continue
+      }
+      seenNames[name] = struct{}{}
+      unsafeNames = append(unsafeNames, name)
+    }
+    if len(unsafeNames) == 0 {
+      return
+    }
+    quoted := make([]string, len(unsafeNames))
+    for index, name := range unsafeNames {
+      quoted[index] = "'" + name + "'"
+    }
+    a.ctx.Report(function, "Function declared in a loop contains unsafe references to variable(s) "+strings.Join(quoted, ", ")+".")
+  })
+}
+
+func (a *noLoopFuncAnalysis) isReferencedNamedIIFE(function *shimast.Node) bool {
+  if function.Kind != shimast.KindFunctionExpression {
+    return false
+  }
+  name := function.Name()
+  if name == nil || name.Kind != shimast.KindIdentifier {
+    return false
+  }
+  symbol := canonicalValueSymbol(a.ctx, name)
+  if symbol == nil {
+    return false
+  }
+  for _, reference := range a.functionReferences[function] {
+    if reference.symbol == symbol {
+      return true
+    }
+  }
+  return false
+}
+
+func (a *noLoopFuncAnalysis) symbolDeclaredInside(symbol *shimast.Symbol, function *shimast.Node) bool {
+  for _, declaration := range symbol.Declarations {
+    if declaration != nil && declaration.Pos() >= function.Pos() && declaration.End() <= function.End() {
+      return true
+    }
+  }
+  return false
+}
+
+func (a *noLoopFuncAnalysis) isSafe(loop *shimast.Node, symbol *shimast.Symbol) bool {
+  binding := a.binding(symbol)
+  if binding.kind == noLoopFuncConstantBinding {
+    return true
+  }
+  if binding.kind == noLoopFuncLetBinding && binding.rangeNode != nil &&
+    binding.rangeNode.Pos() > loop.Pos() && binding.rangeNode.End() < loop.End() {
+    return true
+  }
+
+  var excluded *shimast.Node
+  if binding.kind == noLoopFuncLetBinding {
+    excluded = binding.rangeNode
+  }
+  border := noLoopFuncTopLoop(loop, excluded, a.skippedIIFEs)
+  for _, write := range a.writesBySymbol[symbol] {
+    if write.scope != binding.scope || write.node.Pos() >= border.Pos() {
+      return false
+    }
+  }
+  return true
+}
+
+func (a *noLoopFuncAnalysis) binding(symbol *shimast.Symbol) noLoopFuncBinding {
+  if binding, exists := a.bindings[symbol]; exists {
+    return binding
+  }
+  binding := noLoopFuncBinding{kind: noLoopFuncOtherBinding}
+  declarations := symbol.Declarations
+  if symbol.ValueDeclaration != nil {
+    declarations = append([]*shimast.Node{symbol.ValueDeclaration}, declarations...)
+  }
+  for _, declaration := range declarations {
+    root := noLoopFuncRootVariableDeclaration(declaration)
+    if root == nil || root.Kind != shimast.KindVariableDeclaration {
+      if binding.rangeNode == nil && declaration != nil {
+        binding.rangeNode = declaration
+        binding.scope = noLoopFuncVariableScope(declaration)
+      }
+      continue
+    }
+    binding.rangeNode = root
+    if root.Parent != nil && root.Parent.Kind == shimast.KindVariableDeclarationList {
+      binding.rangeNode = root.Parent
+    }
+    binding.scope = noLoopFuncVariableScope(root)
+    flags := shimast.GetCombinedNodeFlags(root)
+    switch {
+    case flags&shimast.NodeFlagsConstant != 0:
+      binding.kind = noLoopFuncConstantBinding
+    case flags&shimast.NodeFlagsLet != 0:
+      binding.kind = noLoopFuncLetBinding
+    }
+    break
+  }
+  a.bindings[symbol] = binding
+  return binding
+}
+
+func noLoopFuncRootVariableDeclaration(node *shimast.Node) *shimast.Node {
+  for node != nil && node.Kind == shimast.KindBindingElement {
+    if node.Parent == nil {
+      return nil
+    }
+    node = node.Parent.Parent
+  }
+  return node
+}
+
+func noLoopFuncVariableScope(node *shimast.Node) *shimast.Node {
+  for ancestor := node; ancestor != nil; ancestor = ancestor.Parent {
+    if noLoopFuncIsAnyFunction(ancestor) || ancestor.Kind == shimast.KindSourceFile ||
+      ancestor.Kind == shimast.KindClassStaticBlockDeclaration {
+      return ancestor
+    }
+    if ancestor.Kind == shimast.KindPropertyDeclaration {
+      property := ancestor.AsPropertyDeclaration()
+      if property != nil && noLoopFuncNodeContains(property.Initializer, node) {
+        return ancestor
+      }
+    }
+  }
+  return nil
+}
+
+func noLoopFuncContainingLoop(node *shimast.Node, skippedIIFEs map[*shimast.Node]struct{}) *shimast.Node {
+  child := node
+  for parent := node.Parent; parent != nil; parent = parent.Parent {
+    switch parent.Kind {
+    case shimast.KindWhileStatement, shimast.KindDoStatement:
+      return parent
+    case shimast.KindForStatement:
+      statement := parent.AsForStatement()
+      if statement == nil || statement.Initializer != child {
+        return parent
+      }
+    case shimast.KindForInStatement, shimast.KindForOfStatement:
+      statement := parent.AsForInOrOfStatement()
+      if statement == nil || statement.Expression != child {
+        return parent
+      }
+    default:
+      if noLoopFuncIsAnyFunction(parent) {
+        if _, skipped := skippedIIFEs[parent]; !skipped {
+          return nil
+        }
+      }
+    }
+    child = parent
+  }
+  return nil
+}
+
+func noLoopFuncTopLoop(loop, excluded *shimast.Node, skippedIIFEs map[*shimast.Node]struct{}) *shimast.Node {
+  top := loop
+  for {
+    outer := noLoopFuncContainingLoop(top, skippedIIFEs)
+    if outer == nil || (excluded != nil && outer.Pos() < excluded.End()) {
+      return top
+    }
+    top = outer
+  }
+}
+
+func noLoopFuncIsEligibleIIFE(function *shimast.Node) bool {
+  if function.Kind != shimast.KindFunctionExpression && function.Kind != shimast.KindArrowFunction {
+    return false
+  }
+  if function.ModifierFlags()&shimast.ModifierFlagsAsync != 0 || noLoopFuncIsGenerator(function) {
+    return false
+  }
+  expression := function
+  parent := expression.Parent
+  for parent != nil && parent.Kind == shimast.KindParenthesizedExpression && parent.Expression() == expression {
+    expression = parent
+    parent = parent.Parent
+  }
+  if parent == nil || parent.Kind != shimast.KindCallExpression {
+    return false
+  }
+  call := parent.AsCallExpression()
+  return call != nil && stripParens(call.Expression) == function
+}
+
+func noLoopFuncIsGenerator(function *shimast.Node) bool {
+  if function.Kind == shimast.KindFunctionExpression {
+    expression := function.AsFunctionExpression()
+    return expression != nil && expression.AsteriskToken != nil
+  }
+  return false
+}
+
+func noLoopFuncInsideTypeQuery(node *shimast.Node) bool {
+  for ancestor := node.Parent; ancestor != nil; ancestor = ancestor.Parent {
+    if ancestor.Kind == shimast.KindTypeQuery {
+      return true
+    }
+    if noLoopFuncIsAnyFunction(ancestor) || ancestor.Kind == shimast.KindSourceFile {
+      return false
+    }
+  }
+  return false
+}
+
+func noLoopFuncReferenceBelongsToFunction(reference, function *shimast.Node) bool {
+  child := reference
+  for child != nil && child.Parent != function {
+    child = child.Parent
+  }
+  if child == nil {
+    return false
+  }
+  if child == function.Body() {
+    return true
+  }
+  if child.Kind != shimast.KindParameter {
+    return false
+  }
+  parameter := child.AsParameterDeclaration()
+  return parameter != nil &&
+    (noLoopFuncNodeContains(parameter.Name(), reference) || noLoopFuncNodeContains(parameter.Initializer, reference))
+}
+
+func noLoopFuncNodeContains(container, node *shimast.Node) bool {
+  for current := node; current != nil; current = current.Parent {
+    if current == container {
+      return true
+    }
+  }
+  return false
+}
+
+func noLoopFuncIsCheckedFunction(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  switch node.Kind {
+  case shimast.KindArrowFunction,
+    shimast.KindFunctionExpression,
+    shimast.KindFunctionDeclaration,
+    shimast.KindMethodDeclaration,
+    shimast.KindGetAccessor,
+    shimast.KindSetAccessor,
+    shimast.KindConstructor:
     return true
   }
   return false
+}
+
+func noLoopFuncIsAnyFunction(node *shimast.Node) bool {
+  return node != nil && isFunctionLikeKind(node)
 }
 
 func init() {

--- a/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
@@ -711,10 +711,9 @@ export interface ITtscLintCoreRules {
   "no-lonely-if"?: TtscLintRuleSetting;
 
   /**
-   * Reject function declarations defined inside the body of a loop. Each
-   * iteration of the loop allocates a fresh function whose closure captures the
-   * surrounding `let`/`var` binding — a class of bugs where every captured
-   * function reads the iteration's final value instead of its own.
+   * Reject loop-created closures that capture bindings which can change between
+   * iterations. Constants, per-iteration `let` bindings, and unreferenced
+   * synchronous IIFEs are safe.
    *
    * @reference https://eslint.org/docs/latest/rules/no-loop-func
    */

--- a/packages/lint/test/rules/control-flow/no_loop_func_allows_safe_bindings_and_excluded_headers_test.go
+++ b/packages/lint/test/rules/control-flow/no_loop_func_allows_safe_bindings_and_excluded_headers_test.go
@@ -1,0 +1,60 @@
+package linthost
+
+import "testing"
+
+// TestNoLoopFuncAllowsSafeBindingsAndExcludedHeaders verifies the official
+// negative twins for closures that cannot observe a later mutable value.
+//
+// Const bindings, iteration-created lets, no-capture closures, type-only uses,
+// unresolved runtime names, functions in excluded loop-header positions, and
+// computed method names are safe even though each sits beneath a loop node.
+//
+// 1. Exercise each safe binding class plus destructuring and shadowing.
+// 2. Place closures in a for initializer and for-in/of right-hand expressions.
+// 3. Mutate adjacent outer bindings and assert the rule remains silent.
+func TestNoLoopFuncAllowsSafeBindingsAndExcludedHeaders(t *testing.T) {
+  source := `let stable = 0;
+stable = 1;
+let headerOnly = 0;
+let typeOnly = 0;
+let computedNameOnly = 0;
+const fixed = 1;
+for (let iteration = 0; iteration < 2; iteration++) {
+  const noCapture = () => 42;
+  const stableCapture = () => stable;
+  const constCapture = () => fixed;
+  const iterationCapture = () => iteration;
+  const typed = (): typeof typeOnly => 1;
+  // @ts-ignore -- unresolved runtime names belong to no-undef, not no-loop-func.
+  const unresolved = () => missingRuntime;
+  {
+    let shadow = 0;
+    const shadowCapture = () => shadow;
+    shadow++;
+    void shadowCapture;
+  }
+  void [noCapture, stableCapture, constCapture, iterationCapture, typed, unresolved];
+}
+for (let initializer = () => headerOnly; false; ) {
+  void initializer;
+}
+for (const candidate of [() => headerOnly]) {
+  void candidate;
+}
+for (const key in { candidate: () => headerOnly }) {
+  void key;
+}
+for (let [left, right] of [[1, 2]]) {
+  const destructured = () => left + right;
+  void destructured;
+}
+for (let iteration = 0; iteration < 1; iteration++) {
+  const object = { [computedNameOnly]() { return 1; } };
+  void object;
+}
+headerOnly = 1;
+typeOnly = 1;
+computedNameOnly = 1;
+`
+  assertNoLoopFuncFindings(t, runNoLoopFunc(t, source))
+}

--- a/packages/lint/test/rules/control-flow/no_loop_func_allows_using_bindings_test.go
+++ b/packages/lint/test/rules/control-flow/no_loop_func_allows_using_bindings_test.go
@@ -1,0 +1,47 @@
+package linthost
+
+import "testing"
+
+// TestNoLoopFuncAllowsUsingBindings verifies `using` and `await using` share
+// the same immutable-capture exemption as const declarations.
+//
+// TypeScript represents both resource declarations with constant flag bits.
+// Even an ignored illegal reassignment must not make the rule diverge from
+// ESLint's declaration-kind contract.
+//
+// 1. Declare disposable and async-disposable resources inside loops.
+// 2. Capture each resource and include a suppressed reassignment attempt.
+// 3. Assert both closures remain exempt from no-loop-func diagnostics.
+func TestNoLoopFuncAllowsUsingBindings(t *testing.T) {
+  source := `interface SymbolConstructor {
+  readonly dispose: unique symbol;
+  readonly asyncDispose: unique symbol;
+}
+interface Disposable { [Symbol.dispose](): void; }
+interface AsyncDisposable { [Symbol.asyncDispose](): PromiseLike<void>; }
+declare function disposable(): Disposable;
+declare function asyncDisposable(): AsyncDisposable;
+
+function synchronous(): void {
+  for (let iteration = 0; iteration < 1; iteration++) {
+    using resource = disposable();
+    const closure = () => resource;
+    // @ts-ignore -- the rule follows the constant declaration kind even when another diagnostic rejects this write.
+    resource = disposable();
+    void closure;
+  }
+}
+
+async function asynchronous(): Promise<void> {
+  for (let iteration = 0; iteration < 1; iteration++) {
+    await using resource = asyncDisposable();
+    const closure = () => resource;
+    // @ts-ignore -- same constant-binding oracle for await using.
+    resource = asyncDisposable();
+    void closure;
+  }
+}
+void [synchronous, asynchronous];
+`
+  assertNoLoopFuncFindings(t, runNoLoopFunc(t, source))
+}

--- a/packages/lint/test/rules/control-flow/no_loop_func_checks_all_runtime_function_forms_test.go
+++ b/packages/lint/test/rules/control-flow/no_loop_func_checks_all_runtime_function_forms_test.go
@@ -1,0 +1,47 @@
+package linthost
+
+import "testing"
+
+// TestNoLoopFuncChecksAllRuntimeFunctionForms verifies TypeScript AST function
+// kinds that correspond to ESLint function-expression nodes are analyzed.
+//
+// Object methods, class methods, accessors, and constructors use dedicated
+// TypeScript-Go kinds. Treating only arrow and `function` syntax as functions
+// would leave the same unsafe closure reachable through these equivalent forms.
+//
+// 1. Declare every runtime function form inside one loop.
+// 2. Capture an outer binding that is reassigned after the loop.
+// 3. Assert every function-shaped range receives the same unsafe diagnostic.
+func TestNoLoopFuncChecksAllRuntimeFunctionForms(t *testing.T) {
+  source := `let outer = 0;
+for (let iteration = 0; iteration < 1; iteration++) {
+  function declared() { return outer; }
+  const object = {
+    method() { return outer; },
+    get value() { return outer; },
+    set value(next: number) { outer = next; },
+  };
+  class Box {
+    constructor() { void outer; }
+    method() { return outer; }
+    get value() { return outer; }
+    set value(next: number) { outer = next; }
+  }
+  void [declared, object, Box];
+}
+outer = 1;
+`
+  message := "Function declared in a loop contains unsafe references to variable(s) 'outer'."
+  assertNoLoopFuncFindings(
+    t,
+    runNoLoopFunc(t, source),
+    noLoopFuncFinding{line: 3, target: "function declared() { return outer; }", message: message},
+    noLoopFuncFinding{line: 5, target: "method() { return outer; }", message: message},
+    noLoopFuncFinding{line: 6, target: "get value() { return outer; }", message: message},
+    noLoopFuncFinding{line: 7, target: "set value(next: number) { outer = next; }", message: message},
+    noLoopFuncFinding{line: 10, target: "constructor() { void outer; }", message: message},
+    noLoopFuncFinding{line: 11, target: "method() { return outer; }", message: message},
+    noLoopFuncFinding{line: 12, target: "get value() { return outer; }", message: message},
+    noLoopFuncFinding{line: 13, target: "set value(next: number) { outer = next; }", message: message},
+  )
+}

--- a/packages/lint/test/rules/control-flow/no_loop_func_helpers_test.go
+++ b/packages/lint/test/rules/control-flow/no_loop_func_helpers_test.go
@@ -1,0 +1,55 @@
+package linthost
+
+import (
+  "sort"
+  "testing"
+
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+)
+
+type noLoopFuncFinding struct {
+  line    int
+  target  string
+  message string
+}
+
+func runNoLoopFunc(t *testing.T, source string) []noLoopFuncFinding {
+  t.Helper()
+  _, _, findings := runRuleFindingsSnapshot(t, "no-loop-func", source, nil)
+  normalized := make([]noLoopFuncFinding, 0, len(findings))
+  for _, finding := range findings {
+    if finding.Rule != "no-loop-func" {
+      t.Fatalf("unexpected rule in no-loop-func findings: %+v", finding)
+    }
+    if len(finding.Fix) != 0 || len(finding.Suggestions) != 0 {
+      t.Fatalf("no-loop-func must not offer edits: %+v", finding)
+    }
+    if finding.Pos < 0 || finding.End < finding.Pos || finding.End > len(source) {
+      t.Fatalf("no-loop-func returned an invalid source range: %+v", finding)
+    }
+    normalized = append(normalized, noLoopFuncFinding{
+      line:    shimscanner.GetECMALineOfPosition(finding.File, finding.Pos) + 1,
+      target:  source[finding.Pos:finding.End],
+      message: finding.Message,
+    })
+  }
+  sort.Slice(normalized, func(i, j int) bool {
+    if normalized[i].line != normalized[j].line {
+      return normalized[i].line < normalized[j].line
+    }
+    return normalized[i].target < normalized[j].target
+  })
+  return normalized
+}
+
+func assertNoLoopFuncFindings(t *testing.T, got []noLoopFuncFinding, want ...noLoopFuncFinding) {
+  t.Helper()
+  if len(got) != len(want) {
+    t.Fatalf("no-loop-func finding count mismatch: want=%+v got=%+v", want, got)
+  }
+  for index := range want {
+    if got[index] != want[index] {
+      t.Fatalf("no-loop-func finding[%d] mismatch: want=%+v got=%+v all=%+v", index, want[index], got[index], got)
+    }
+  }
+}

--- a/packages/lint/test/rules/control-flow/no_loop_func_iife_boundaries_test.go
+++ b/packages/lint/test/rules/control-flow/no_loop_func_iife_boundaries_test.go
@@ -1,0 +1,36 @@
+package linthost
+
+import "testing"
+
+// TestNoLoopFuncIIFEBoundaries verifies which immediately invoked functions
+// are execution boundaries and which can outlive the current iteration.
+//
+// Only unreferenced synchronous non-generator IIFEs execute completely in the
+// iteration. Returned nested closures, referenced named IIFEs, async functions,
+// and generators retain the ordinary unsafe-capture analysis.
+//
+// 1. Invoke safe arrow and named synchronous functions inside a loop.
+// 2. Add a returned closure, self-reference, async IIFE, and generator IIFE.
+// 3. Assert only the four escaping/deferred function ranges are reported.
+func TestNoLoopFuncIIFEBoundaries(t *testing.T) {
+  source := `let outer = 0;
+for (let iteration = 0; iteration < 1; iteration++) {
+  (() => outer)();
+  (function named() { return outer; })();
+  (() => () => outer)();
+  (function self() { return self && outer; })();
+  (async () => outer)();
+  (function* () { yield outer; })();
+}
+outer = 1;
+`
+  message := "Function declared in a loop contains unsafe references to variable(s) 'outer'."
+  assertNoLoopFuncFindings(
+    t,
+    runNoLoopFunc(t, source),
+    noLoopFuncFinding{line: 5, target: "() => outer", message: message},
+    noLoopFuncFinding{line: 6, target: "function self() { return self && outer; }", message: message},
+    noLoopFuncFinding{line: 7, target: "async () => outer", message: message},
+    noLoopFuncFinding{line: 8, target: "function* () { yield outer; }", message: message},
+  )
+}

--- a/packages/lint/test/rules/control-flow/no_loop_func_reports_only_unsafe_references_test.go
+++ b/packages/lint/test/rules/control-flow/no_loop_func_reports_only_unsafe_references_test.go
@@ -1,0 +1,78 @@
+package linthost
+
+import "testing"
+
+// TestNoLoopFuncReportsOnlyUnsafeReferences verifies mutable captures, exact
+// variable names, symbol identity, nested loop borders, and source ranges.
+//
+// A syntax-only walk cannot distinguish the iteration-local binding from the
+// two bindings whose later writes make the closures unsafe. The oracle expects
+// one diagnostic per closure and names only the mutable upper-scope symbols.
+//
+// 1. Create closures over outer, var-loop, nested-loop, and per-iteration names.
+// 2. Mutate only bindings whose writes cross the applicable loop border.
+// 3. Assert exact function ranges and ESLint-compatible unsafe-name messages.
+func TestNoLoopFuncReportsOnlyUnsafeReferences(t *testing.T) {
+  source := `let first = 0;
+let second = 0;
+for (var index = 0; index < 2; index++) {
+  const closure = () => first + index + second;
+  void closure;
+}
+first = 1;
+second = 1;
+
+function nested(): void {
+  let outer = 0;
+  while (outer < 2) {
+    let between = 0;
+    for (let iteration = 0; iteration < 2; iteration++) {
+      const closure = function named() { return outer + between + iteration; };
+      void closure;
+    }
+    between = 1;
+    outer++;
+  }
+}
+void nested;
+
+let defaulted = 0;
+for (let iteration = 0; iteration < 1; iteration++) {
+  const closure = (value = defaulted) => value;
+  void closure;
+}
+defaulted = 1;
+
+let doValue = 0;
+do {
+  const closure = () => doValue;
+  void closure;
+  doValue++;
+} while (doValue < 1);
+`
+  got := runNoLoopFunc(t, source)
+  assertNoLoopFuncFindings(
+    t,
+    got,
+    noLoopFuncFinding{
+      line:    4,
+      target:  "() => first + index + second",
+      message: "Function declared in a loop contains unsafe references to variable(s) 'first', 'index', 'second'.",
+    },
+    noLoopFuncFinding{
+      line:    15,
+      target:  "function named() { return outer + between + iteration; }",
+      message: "Function declared in a loop contains unsafe references to variable(s) 'outer', 'between'.",
+    },
+    noLoopFuncFinding{
+      line:    26,
+      target:  "(value = defaulted) => value",
+      message: "Function declared in a loop contains unsafe references to variable(s) 'defaulted'.",
+    },
+    noLoopFuncFinding{
+      line:    33,
+      target:  "() => doValue",
+      message: "Function declared in a loop contains unsafe references to variable(s) 'doValue'.",
+    },
+  )
+}

--- a/packages/lint/test/rules/control-flow/no_loop_func_test.go
+++ b/packages/lint/test/rules/control-flow/no_loop_func_test.go
@@ -2,17 +2,62 @@ package linthost
 
 import "testing"
 
-// TestRuleCorpusNoLoopFunc verifies the lint rule corpus fixture no-loop-func.ts.
+// TestRuleCorpusNoLoopFunc verifies the real-command corpus fixture's unsafe
+// reference semantics through the same checker-backed native rule engine.
 //
-// The rule visits every loop kind (for, for-in, for-of, while, do-while)
-// and walks the loop body, reporting any nested function-like
-// declaration. Inner loops and inner function-likes are walk boundaries
-// so each enclosing loop only reports the function-likes directly inside
-// its own body.
+// The corpus is the end-to-end command oracle, while this package-local twin
+// keeps its exact positive and negative cases visible in focused Go coverage.
 //
-// 1. Load the annotated TypeScript fixture source embedded below.
-// 2. Enable the rule severity declared by its `// expect:` comments.
-// 3. Assert the native Engine reports exactly the annotated diagnostics.
+// 1. Run the annotated fixture source with a real Program and checker.
+// 2. Assert the outer mutable/var closure and returned closure are reported.
+// 3. Assert safe lets, consts, no-capture closures, and a direct IIFE are not.
 func TestRuleCorpusNoLoopFunc(t *testing.T) {
-  assertRuleCorpusCase(t, "no-loop-func.ts", "function inForLoop(): void {\n  for (let i = 0; i < 3; i++) {\n    // expect: no-loop-func error\n    function inner() {\n      return i;\n    }\n    inner();\n  }\n}\nfunction inWhileLoop(): void {\n  let i = 0;\n  while (i < 3) {\n    // expect: no-loop-func error\n    const inner = () => i;\n    inner();\n    i++;\n  }\n}\nfunction inForOfLoop(items: number[]): void {\n  for (const item of items) {\n    // expect: no-loop-func error\n    const make = function () {\n      return item;\n    };\n    make();\n  }\n}\nfunction inForInLoop(obj: Record<string, number>): void {\n  for (const key in obj) {\n    // expect: no-loop-func error\n    const grab = () => obj[key];\n    grab();\n  }\n}\nfunction inDoWhileLoop(): void {\n  let i = 0;\n  do {\n    // expect: no-loop-func error\n    const inner = () => i;\n    inner();\n    i++;\n  } while (i < 3);\n}\nJSON.stringify({ inForLoop, inWhileLoop, inForOfLoop, inForInLoop, inDoWhileLoop });\n")
+  source := `// Positive: a closure captures both an outer binding written after the loop
+// begins and a var loop counter shared by every iteration.
+let mutable = 0;
+for (var index = 0; index < 2; index++) {
+  // expect: no-loop-func error
+  const unsafe = () => mutable + index;
+  void unsafe;
+}
+mutable = 1;
+
+// Negative: const and per-iteration let bindings cannot change underneath a
+// closure from a different iteration.
+const fixed = 1;
+for (let iteration = 0; iteration < 2; iteration++) {
+  const safe = () => fixed + iteration;
+  const noCapture = () => 42;
+  void [safe, noCapture];
+}
+
+// Negative: an unreferenced synchronous IIFE completes in this iteration.
+for (let iteration = 0; iteration < 1; iteration++) {
+  (() => mutable)();
+}
+
+// Positive: the nested closure returned by an IIFE can escape the iteration.
+for (let iteration = 0; iteration < 1; iteration++) {
+  // expect: no-loop-func error
+  const escaped = (() => () => mutable)();
+  void escaped;
+}
+mutable = 2;
+
+JSON.stringify({ mutable, fixed });
+`
+  assertNoLoopFuncFindings(
+    t,
+    runNoLoopFunc(t, source),
+    noLoopFuncFinding{
+      line:    6,
+      target:  "() => mutable + index",
+      message: "Function declared in a loop contains unsafe references to variable(s) 'mutable', 'index'.",
+    },
+    noLoopFuncFinding{
+      line:    28,
+      target:  "() => mutable",
+      message: "Function declared in a loop contains unsafe references to variable(s) 'mutable'.",
+    },
+  )
 }

--- a/packages/lint/test/rules/control-flow/no_loop_func_tracks_write_forms_and_symbol_identity_test.go
+++ b/packages/lint/test/rules/control-flow/no_loop_func_tracks_write_forms_and_symbol_identity_test.go
@@ -1,0 +1,42 @@
+package linthost
+
+import "testing"
+
+// TestNoLoopFuncTracksWriteFormsAndSymbolIdentity verifies every modifying
+// reference is matched by checker symbol rather than identifier spelling.
+//
+// Compound, destructuring, for-of, update, and foreign-function writes all
+// make a captured binding unsafe. A same-spelled shadow write must not taint
+// the untouched outer binding beside them.
+//
+// 1. Capture five bindings with distinct write forms plus one stable binding.
+// 2. Write the stable spelling only through a separate local symbol.
+// 3. Assert the diagnostic lists exactly the five truly mutable symbols.
+func TestNoLoopFuncTracksWriteFormsAndSymbolIdentity(t *testing.T) {
+  source := `let assigned = 0;
+let destructured = 0;
+let iterated = 0;
+let updated = 0;
+let foreign = 0;
+let stable = 0;
+function mutateForeign(): void { foreign = 1; }
+function mutateShadow(): void { let stable = 0; stable++; }
+for (let iteration = 0; iteration < 1; iteration++) {
+  const closure = () => assigned + destructured + iterated + updated + foreign + stable;
+  assigned += 1;
+  [destructured] = [1];
+  for (iterated of [] as number[]) {}
+  updated++;
+  void [closure, mutateForeign, mutateShadow];
+}
+`
+  assertNoLoopFuncFindings(
+    t,
+    runNoLoopFunc(t, source),
+    noLoopFuncFinding{
+      line:    10,
+      target:  "() => assigned + destructured + iterated + updated + foreign + stable",
+      message: "Function declared in a loop contains unsafe references to variable(s) 'assigned', 'destructured', 'iterated', 'updated', 'foreign'.",
+    },
+  )
+}

--- a/packages/lint/test/rules/control-flow/no_loop_func_treats_class_field_initializers_as_variable_scopes_test.go
+++ b/packages/lint/test/rules/control-flow/no_loop_func_treats_class_field_initializers_as_variable_scopes_test.go
@@ -1,0 +1,41 @@
+package linthost
+
+import "testing"
+
+// TestNoLoopFuncTreatsClassFieldInitializersAsVariableScopes verifies deferred
+// class field writes cannot be mistaken for harmless source-order writes.
+//
+// ESLint gives each class field initializer its own variable scope because the
+// initializer runs when an instance is created, not when the class is declared.
+// Computed field names still run in the surrounding scope at declaration time.
+//
+// 1. Write outer bindings from a field initializer and a computed field name.
+// 2. Capture both in loop-created closures with no later textual writes.
+// 3. Assert only the deferred initializer write keeps its closure unsafe.
+func TestNoLoopFuncTreatsClassFieldInitializersAsVariableScopes(t *testing.T) {
+  source := `let fieldWritten = 0;
+let computedNameWritten = 0;
+class Writer {
+  value = (fieldWritten = 1);
+}
+class KeyWriter {
+  // @ts-ignore -- the scope behavior is independent of the class-key type restriction.
+  [(computedNameWritten = 1)] = 0;
+}
+for (let iteration = 0; iteration < 1; iteration++) {
+  const closure = () => fieldWritten;
+  const safe = () => computedNameWritten;
+  void [closure, safe];
+}
+void [Writer, KeyWriter];
+`
+  assertNoLoopFuncFindings(
+    t,
+    runNoLoopFunc(t, source),
+    noLoopFuncFinding{
+      line:    11,
+      target:  "() => fieldWritten",
+      message: "Function declared in a loop contains unsafe references to variable(s) 'fieldWritten'.",
+    },
+  )
+}

--- a/packages/ttsc/shim/ast/lint.go
+++ b/packages/ttsc/shim/ast/lint.go
@@ -327,6 +327,11 @@ func GetCombinedNodeFlags(node *Node) NodeFlags {
 // its own contextual type to the asserted expression.
 func IsConstAssertion(node *Node) bool { return innerast.IsConstAssertion(node) }
 
+// IsPartOfTypeNode reports whether node belongs to syntax that is evaluated
+// only by the type system. Lint rules use the upstream classifier so runtime
+// reference analysis stays aligned with TypeScript's AST semantics.
+func IsPartOfTypeNode(node *Node) bool { return innerast.IsPartOfTypeNode(node) }
+
 // IsLet reports whether the declaration was introduced by `let` / `using`.
 func IsLet(node *Node) bool { return GetCombinedNodeFlags(node)&NodeFlagsLet != 0 }
 

--- a/tests/test-lint/src/cases/no-loop-func.ts
+++ b/tests/test-lint/src/cases/no-loop-func.ts
@@ -1,70 +1,33 @@
-// Positive: function declaration inside a `for` loop body.
-function inForLoop(): void {
-  for (let i = 0; i < 3; i++) {
-    // expect: no-loop-func error
-    function inner() {
-      return i;
-    }
-    inner();
-  }
+// Positive: a closure captures both an outer binding written after the loop
+// begins and a var loop counter shared by every iteration.
+let mutable = 0;
+for (var index = 0; index < 2; index++) {
+  // expect: no-loop-func error
+  const unsafe = () => mutable + index;
+  void unsafe;
+}
+mutable = 1;
+
+// Negative: const and per-iteration let bindings cannot change underneath a
+// closure from a different iteration.
+const fixed = 1;
+for (let iteration = 0; iteration < 2; iteration++) {
+  const safe = () => fixed + iteration;
+  const noCapture = () => 42;
+  void [safe, noCapture];
 }
 
-// Positive: arrow function inside a `while` loop body.
-function inWhileLoop(): void {
-  let i = 0;
-  while (i < 3) {
-    // expect: no-loop-func error
-    const inner = () => i;
-    inner();
-    i++;
-  }
+// Negative: an unreferenced synchronous IIFE completes in this iteration.
+for (let iteration = 0; iteration < 1; iteration++) {
+  (() => mutable)();
 }
 
-// Positive: function expression inside a `for ... of` loop body.
-function inForOfLoop(items: number[]): void {
-  for (const item of items) {
-    // expect: no-loop-func error
-    const make = function () {
-      return item;
-    };
-    make();
-  }
+// Positive: the nested closure returned by an IIFE can escape the iteration.
+for (let iteration = 0; iteration < 1; iteration++) {
+  // expect: no-loop-func error
+  const escaped = (() => () => mutable)();
+  void escaped;
 }
+mutable = 2;
 
-// Positive: arrow function inside a `for ... in` loop body.
-function inForInLoop(obj: Record<string, number>): void {
-  for (const key in obj) {
-    // expect: no-loop-func error
-    const grab = () => obj[key];
-    grab();
-  }
-}
-
-// Positive: arrow function inside a `do ... while` loop body.
-function inDoWhileLoop(): void {
-  let i = 0;
-  do {
-    // expect: no-loop-func error
-    const inner = () => i;
-    inner();
-    i++;
-  } while (i < 3);
-}
-
-// Negative: function declared OUTSIDE the loop — the closure captures
-// the binding once, not per iteration.
-function outsideLoop(): void {
-  const make = (x: number) => () => x;
-  for (let i = 0; i < 3; i++) {
-    make(i)();
-  }
-}
-
-JSON.stringify({
-  inForLoop,
-  inWhileLoop,
-  inForOfLoop,
-  inForInLoop,
-  inDoWhileLoop,
-  outsideLoop,
-});
+JSON.stringify({ mutable, fixed });

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -67,7 +67,7 @@ Examples come from the checked [lint corpus](https://github.com/samchon/ttsc/tre
 - [`no-labels`](#rule-no-labels): Reject labeled statements.
 - [`no-lone-blocks`](#rule-no-lone-blocks): Reject standalone `{ ... }` blocks that introduce no lexical scope distinct from the surrounding block.
 - [`no-lonely-if`](#rule-no-lonely-if): Reject `if (cond) { if (...) { ... } }`.
-- [`no-loop-func`](#rule-no-loop-func): Reject function declarations defined inside the body of a loop.
+- [`no-loop-func`](#rule-no-loop-func): Reject loop-created closures that capture bindings which can change between iterations.
 - [`no-loss-of-precision`](#rule-no-loss-of-precision): Reject numeric literals whose source text cannot round-trip through `Number`.
 - [`no-magic-numbers`](#rule-no-magic-numbers): Reject inline numeric literals outside `const` initializer position.
 - [`no-misleading-character-class`](#rule-no-misleading-character-class): Reject regex character classes that contain combined Unicode sequences (e.g. surrogate pairs).
@@ -1629,21 +1629,26 @@ function chooseMode(isPrimary: boolean, isFallback: boolean) {
 
 ### `no-loop-func`
 
-Reject function declarations defined inside the body of a loop.
+Reject loop-created closures that capture bindings which can change between iterations.
 
-Each iteration of the loop allocates a fresh function whose closure captures the surrounding `let`/`var` binding, a class of bugs where every captured function reads the iteration's final value instead of its own.
+The rule follows binding identity and write locations instead of rejecting every function beneath a loop. A shared `var` counter or an outer binding written after the loop starts is unsafe. Constants, per-iteration `let` bindings, functions with no upper-scope references, and unreferenced synchronous IIFEs are safe.
 
 Example:
 
 ```ts
 function inForLoop(): void {
-  for (let i = 0; i < 3; i++) {
+  for (var i = 0; i < 3; i++) {
     // reports: no-loop-func (error)
     function inner() {
       return i;
     }
     inner();
   }
+}
+
+for (let i = 0; i < 3; i++) {
+  const safe = () => i;
+  safe();
 }
 ```
 


### PR DESCRIPTION
## Summary

- replace syntax-only `no-loop-func` reporting with TypeScript checker symbol/reference analysis
- match ESLint binding, write-border, nested loop, function boundary, and eligible IIFE semantics
- add checker-backed oracle coverage for safe and unsafe bindings, write forms, TypeScript function forms, resource bindings, class initializer scopes, and the real command corpus
- align package and website documentation with the corrected rule contract

## Verification

- three sequential exhaustive whole-change reviews at HEAD `efb8725ea29c5090b40ab7de15feb8356e8b34b4`, tree `3085a15beab97d43ff317dcedfb24837760b0d6f`, content snapshot `6379BFD14ADA72855F01222E92B12657BF13A8E06AB7A2C75074A3F197A11D37`
- `node scripts/test-go-lint.cjs`
- `pnpm --filter @ttsc/lint build`
- `pnpm --filter ttsc build`
- focused real command corpus: `assertLintCase(no-loop-func.ts)`
- `pnpm --filter ttsc shim:audit`

No formatter was run.

Fixes #496