### PR TITLE
fix(lint): scope rule options to matching config entries

### DIFF
--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -100,23 +100,46 @@ type ProjectRuleSetting struct {
   Options  json.RawMessage
 }
 
-// ResolvedRuleConfig is the rule map that applies to one source file.
+// ResolvedRuleConfig is the complete rule setting that applies to one source
+// file. Rules and Options are folded from the same matching config entries so
+// an option tuple can never cross a files/ignores boundary independently of
+// its severity.
+//
 // `Ignored` means an `ignores`-only config entry matched the file and the
 // engine should skip linting it entirely.
 type ResolvedRuleConfig struct {
-  Rules   RuleConfig
-  Ignored bool
+  Rules           RuleConfig
+  Options         RuleOptionsMap
+  // OptionsResolved distinguishes an authoritative empty per-file option map
+  // from a legacy custom resolver that still supplies options exclusively via
+  // RuleResolver.RuleOptions.
+  OptionsResolved bool
+  Ignored         bool
+}
+
+// RuleOptions returns the file-resolved option payload for name. Built-in
+// aliases are normalized on lookup so the same key selects both severity and
+// options.
+func (r ResolvedRuleConfig) RuleOptions(name string) json.RawMessage {
+  if raw := r.Options[name]; len(raw) > 0 {
+    return raw
+  }
+  if raw := r.Options[normalizeBuiltinRuleName(name)]; len(raw) > 0 {
+    return raw
+  }
+  return nil
 }
 
 // RuleResolver is the engine-facing view of a resolved lint configuration.
 // Implementations include RuleConfig (severity-only, no options),
 // InlineRuleResolver (a severity map plus per-rule options), and *ConfigStore
-// (a parsed lint config file, with per-file glob resolution and a unified
-// options map).
+// (a parsed lint config file, with per-file glob resolution for both severity
+// and options).
 type RuleResolver interface {
-  // ResolveRules returns the effective severity map for the given source file.
-  // Implementations that support `files`/`ignores` patterns apply them here;
-  // flat RuleConfig always returns all rules unchanged.
+  // ResolveRules returns the effective severities and option payloads for the
+  // given source file. Implementations that support `files`/`ignores`
+  // patterns apply both halves of each rule setting here; flat RuleConfig
+  // always returns all severities unchanged and no options.
   ResolveRules(fileName string) ResolvedRuleConfig
   // ActiveRuleNames returns the sorted names of every rule that is not SeverityOff
   // in at least one config entry. Used to build the engine's dispatch table.
@@ -124,14 +147,36 @@ type RuleResolver interface {
   // EnabledRuleConfig returns the project-wide severity map for rules that are
   // not SeverityOff. Where multiple entries disagree, SeverityError wins.
   EnabledRuleConfig() RuleConfig
-  // RuleOptions returns the raw JSON options for `name`, or nil when the
-  // rule was configured with a severity alone. Returns nil for unknown
-  // rule names too — rules treat that as "use defaults".
+  // RuleOptions is the file-agnostic compatibility lookup used by flat and
+  // metadata-only consumers. Runtime file binding reads
+  // ResolveRules(fileName).RuleOptions(name), which is authoritative for
+  // scoped resolvers. Returns nil for severity-only and unknown rules.
   RuleOptions(name string) json.RawMessage
   // ResolveProjectRules folds global declarations for registered project-rule
   // names. A mention under a files selector is rejected because project state
   // has no file identity.
   ResolveProjectRules(names []string) (map[string]ProjectRuleSetting, error)
+}
+
+// RuleOptionsVariantsResolver is an optional extension for resolvers that can
+// declare more than one option payload for a rule. Engine construction uses
+// it to validate every files/extends variant before any file is visited.
+// Custom resolvers that omit this interface remain compatible through the
+// single RuleResolver.RuleOptions fallback.
+type RuleOptionsVariantsResolver interface {
+  RuleOptionsVariants(name string) []json.RawMessage
+}
+
+// resolvedRuleOptionsVariants returns every option shape a rule may receive.
+// File-scoped resolvers expose all declarations through the internal
+// extension; flat and external resolvers retain the RuleOptions fallback.
+func resolvedRuleOptionsVariants(resolver RuleResolver, name string) []json.RawMessage {
+  if variants, ok := resolver.(RuleOptionsVariantsResolver); ok {
+    if values := variants.RuleOptionsVariants(name); len(values) > 0 {
+      return values
+    }
+  }
+  return []json.RawMessage{append(json.RawMessage(nil), resolver.RuleOptions(name)...)}
 }
 
 // boundProjectRuleResolver retains the one project-wide resolution performed
@@ -163,10 +208,17 @@ func (r boundProjectRuleResolver) ResolveProjectRules(names []string) (map[strin
   return settings, nil
 }
 
+func (r boundProjectRuleResolver) RuleOptionsVariants(name string) []json.RawMessage {
+  return resolvedRuleOptionsVariants(r.RuleResolver, name)
+}
+
 // ResolveRules implements RuleResolver. A flat RuleConfig has no glob scoping,
 // so every file receives the full map unchanged.
 func (c RuleConfig) ResolveRules(string) ResolvedRuleConfig {
-  return ResolvedRuleConfig{Rules: normalizeRuleConfigKeys(c)}
+  return ResolvedRuleConfig{
+    Rules:           normalizeRuleConfigKeys(c),
+    OptionsResolved: true,
+  }
 }
 
 // ActiveRuleNames implements RuleResolver. Returns rule names whose severity
@@ -225,7 +277,22 @@ type InlineRuleResolver struct {
 // ResolveRules implements RuleResolver. Inline rules have no glob scoping;
 // the full map applies to every file.
 func (r InlineRuleResolver) ResolveRules(string) ResolvedRuleConfig {
-  return ResolvedRuleConfig{Rules: normalizeRuleConfigKeys(r.Rules)}
+  return ResolvedRuleConfig{
+    Rules:           normalizeRuleConfigKeys(r.Rules),
+    Options:         normalizeRuleOptionsKeys(r.Options),
+    OptionsResolved: true,
+  }
+}
+
+func normalizeRuleOptionsKeys(options RuleOptionsMap) RuleOptionsMap {
+  if len(options) == 0 {
+    return nil
+  }
+  normalized := make(RuleOptionsMap, len(options))
+  for name, raw := range options {
+    normalized[normalizeBuiltinRuleName(name)] = append(json.RawMessage(nil), raw...)
+  }
+  return normalized
 }
 
 // ActiveRuleNames implements RuleResolver by delegating to the inner RuleConfig.
@@ -269,9 +336,11 @@ func (r InlineRuleResolver) ResolveProjectRules(names []string) (map[string]Proj
 
 // ConfigStore holds the parsed representation of a lint config file. It
 // implements RuleResolver with per-file glob scoping: ResolveRules walks the
-// entries in declaration order and the last matching entry wins. Options are
-// intentionally NOT per-file — one project-wide options map is kept so rule
-// behavior is uniform across the codebase even when severity varies by glob.
+// entries in declaration order and folds each matching rule's severity and
+// options together. A later option tuple replaces the inherited payload; a
+// later severity-only declaration preserves options from an earlier matching
+// entry and cannot borrow them from an entry that did not match the file.
+// https://eslint.org/docs/latest/use/configure/rules#using-configuration-files
 //
 // A config file is a single `ITtscLintConfig` object. Its `extends` field
 // names another config file to fold in first; the extends chain produces one
@@ -279,27 +348,64 @@ func (r InlineRuleResolver) ResolveProjectRules(names []string) (map[string]Proj
 // extending file's own entry so local rules win on collision.
 type ConfigStore struct {
   entries []ConfigEntry
-  // options is a flat rule-name → JSON map. Options are not scoped by
-  // `files` / `ignores`: a rule's behavior is a single project-wide
-  // configuration even when its severity is per-file. The simplification
-  // matches prettier-style options (one setting per project) while
-  // keeping severity layering intact.
-  options RuleOptionsMap
 }
 
-// RuleOptions implements RuleResolver.RuleOptions on ConfigStore.
+// RuleOptions implements the file-agnostic RuleResolver compatibility method.
+// Engine execution does not use this representative value: ResolveRules
+// carries the matching file's options. Callers that only understand the older
+// interface observe the final declared tuple, preserving the former flat
+// resolver behavior without storing a second source of truth.
 func (s *ConfigStore) RuleOptions(name string) json.RawMessage {
   if s == nil {
     return nil
   }
-  if raw := s.options[name]; len(raw) > 0 {
-    return raw
+  canonical := normalizeBuiltinRuleName(name)
+  var selected json.RawMessage
+  for _, entry := range s.entries {
+    if raw := entry.Options[canonical]; len(raw) > 0 {
+      selected = raw
+    }
+  }
+  return append(json.RawMessage(nil), selected...)
+}
+
+// flattenOptions returns the final declared payload for each rule without
+// claiming that it applies to any particular file. Metadata-only consumers
+// use this to enumerate option-bearing rules; execution always uses
+// ResolveRules instead.
+func (s *ConfigStore) flattenOptions() RuleOptionsMap {
+  if s == nil {
+    return nil
+  }
+  options := RuleOptionsMap{}
+  for _, entry := range s.entries {
+    for name, raw := range entry.Options {
+      options[normalizeBuiltinRuleName(name)] = append(json.RawMessage(nil), raw...)
+    }
+  }
+  return options
+}
+
+// RuleOptionsVariants exposes every entry-local payload (including a nil
+// severity-only declaration) so engine construction validates the full
+// files/extends surface rather than whichever tuple happened to be parsed
+// last.
+func (s *ConfigStore) RuleOptionsVariants(name string) []json.RawMessage {
+  if s == nil {
+    return nil
   }
   canonical := normalizeBuiltinRuleName(name)
-  if raw := s.options[canonical]; len(raw) > 0 {
-    return raw
+  variants := make([]json.RawMessage, 0)
+  for _, entry := range s.entries {
+    if entry.IgnoreOnly {
+      continue
+    }
+    if _, declared := entry.Rules[canonical]; !declared {
+      continue
+    }
+    variants = append(variants, append(json.RawMessage(nil), entry.Options[canonical]...))
   }
-  return nil
+  return variants
 }
 
 // ConfigEntry is the parsed form of one config file in the extends chain.
@@ -323,23 +429,28 @@ type ConfigEntry struct {
 // entry wins (later entries shadow earlier ones for the same rule name).
 func (s *ConfigStore) ResolveRules(fileName string) ResolvedRuleConfig {
   if s == nil {
-    return ResolvedRuleConfig{Rules: RuleConfig{}}
+    return ResolvedRuleConfig{Rules: RuleConfig{}, OptionsResolved: true}
   }
   for _, entry := range s.entries {
     if entry.IgnoreOnly && entry.matchesIgnores(fileName) {
-      return ResolvedRuleConfig{Rules: RuleConfig{}, Ignored: true}
+      return ResolvedRuleConfig{Rules: RuleConfig{}, OptionsResolved: true, Ignored: true}
     }
   }
   out := RuleConfig{}
+  options := RuleOptionsMap{}
   for _, entry := range s.entries {
     if entry.IgnoreOnly || !entry.matchesFile(fileName) {
       continue
     }
     for name, sev := range entry.Rules {
-      out[normalizeBuiltinRuleName(name)] = sev
+      canonical := normalizeBuiltinRuleName(name)
+      out[canonical] = sev
+      if raw := entry.Options[canonical]; len(raw) > 0 {
+        options[canonical] = append(json.RawMessage(nil), raw...)
+      }
     }
   }
-  return ResolvedRuleConfig{Rules: out}
+  return ResolvedRuleConfig{Rules: out, Options: options, OptionsResolved: true}
 }
 
 // ActiveRuleNames implements RuleResolver. Returns the sorted union of all rule
@@ -726,7 +837,7 @@ func collectConfigObject(store *ConfigStore, raw any, baseDir, path string, chai
     }
     merged := mergeRuleMaps(formatRulesRaw, rulesMap)
     if len(merged) > 0 {
-      parsed, entryOptions, err := parseExternalRuleMapInto(merged, path+".rules", store)
+      parsed, entryOptions, err := parseExternalRuleMapInto(merged, path+".rules")
       if err != nil {
         return err
       }
@@ -743,20 +854,14 @@ func collectConfigObject(store *ConfigStore, raw any, baseDir, path string, chai
   return nil
 }
 
-// parseExternalRuleMapInto parses the rules map and folds any
-// option blobs into `store.options`. Used by entry-creation paths so
-// the store ends with a unified options map for RuleResolver consumers.
-func parseExternalRuleMapInto(raw any, path string, store *ConfigStore) (RuleConfig, RuleOptionsMap, error) {
+// parseExternalRuleMapInto parses one entry's rules and option tuples. Options
+// stay on the ConfigEntry that owns their files/ignores scope; no project-wide
+// mirror is created.
+func parseExternalRuleMapInto(raw any, path string) (RuleConfig, RuleOptionsMap, error) {
   out := RuleConfig{}
   entryOptions := RuleOptionsMap{}
-  if store.options == nil {
-    store.options = RuleOptionsMap{}
-  }
   if err := collectExternalRuleMapWithOptions(out, entryOptions, raw, path); err != nil {
     return nil, nil, err
-  }
-  for name, raw := range entryOptions {
-    store.options[name] = append(json.RawMessage(nil), raw...)
   }
   return out, entryOptions, nil
 }

--- a/packages/lint/linthost/engine.go
+++ b/packages/lint/linthost/engine.go
@@ -102,10 +102,11 @@ func validateRuleOptions(r Rule, options json.RawMessage) error {
 
 // Context is the per-(file, rule) handle the engine passes to `Check`.
 //
-// `Options` is the raw JSON payload from the rule configuration. One option
-// slot preserves its scalar or object shape; multiple positional options are
-// an array. It is nil for a bare severity. Rules decode the payload according
-// to their public option type and fall back to defaults on nil.
+// `Options` is the raw JSON payload resolved for this source file from the
+// same config entries as Severity. One option slot preserves its scalar or
+// object shape; multiple positional options are an array. It is nil for a
+// bare severity. Rules decode the payload according to their public option
+// type and fall back to defaults on nil.
 type Context struct {
   File             *shimast.SourceFile
   Checker          *shimchecker.Checker
@@ -466,11 +467,23 @@ func NewEngineWithResolver(config RuleResolver) *Engine {
       eng.unknown = append(eng.unknown, name)
       continue
     }
-    if err := validateRuleOptions(rule, config.RuleOptions(name)); err != nil {
-      eng.configError = errors.Join(
-        eng.configError,
-        fmt.Errorf("@ttsc/lint: invalid options for rule %q: %w", name, err),
-      )
+    optionsValid := true
+    seenOptions := make(map[string]struct{})
+    for _, options := range resolvedRuleOptionsVariants(config, name) {
+      key := string(options)
+      if _, duplicate := seenOptions[key]; duplicate {
+        continue
+      }
+      seenOptions[key] = struct{}{}
+      if err := validateRuleOptions(rule, options); err != nil {
+        eng.configError = errors.Join(
+          eng.configError,
+          fmt.Errorf("@ttsc/lint: invalid options for rule %q: %w", name, err),
+        )
+        optionsValid = false
+      }
+    }
+    if !optionsValid {
       continue
     }
     if ruleNeedsTypeChecker(rule) {
@@ -758,12 +771,19 @@ func (e *Engine) runFile(
       ctx, built := ctxByRule[name]
       if !built {
         if severity := fileRules.Severity(name); severity != SeverityOff {
+          options := resolved.RuleOptions(name)
+          if len(options) == 0 && !resolved.OptionsResolved {
+            // Compatibility for custom RuleResolver implementations compiled
+            // against the original contract: until they opt into per-file
+            // options, their file-agnostic RuleOptions method remains active.
+            options = e.config.RuleOptions(name)
+          }
           ctx = &Context{
             File:             file,
             Checker:          checker,
             CurrentDirectory: currentDirectory,
             Severity:         severity,
-            Options:          e.config.RuleOptions(name),
+            Options:          options,
             rule:             rule,
             isFormat:         isFormatRule(rule),
             collect:          collect,

--- a/packages/lint/linthost/format.go
+++ b/packages/lint/linthost/format.go
@@ -250,9 +250,32 @@ func (r formatCommandResolver) ResolveRules(fileName string) ResolvedRuleConfig 
   if resolved.Rules == nil {
     resolved.Rules = RuleConfig{}
   }
+  if resolved.Options == nil {
+    resolved.Options = RuleOptionsMap{}
+  }
   for _, name := range r.formatOptionRuleNames() {
+    _, declaredForFile := resolved.Rules[normalizeBuiltinRuleName(name)]
+    if r.defaultOptions == nil && !declaredForFile {
+      // A configured format block is still a normal config entry: its files
+      // and ignores selectors scope the complete rule setting. Only the
+      // synthetic default set is allowed to introduce an undeclared rule.
+      continue
+    }
     if resolved.Rules.Severity(name) == SeverityOff {
       resolved.Rules[name] = SeverityWarn
+    }
+    if len(resolved.RuleOptions(name)) == 0 {
+      var raw json.RawMessage
+      if resolved.OptionsResolved {
+        raw = r.defaultOptions[name]
+      } else {
+        // Legacy custom resolvers have no authoritative per-file options, so
+        // retain their file-agnostic override before consulting defaults.
+        raw = r.RuleOptions(name)
+      }
+      if len(raw) > 0 {
+        resolved.Options[name] = append(json.RawMessage(nil), raw...)
+      }
     }
   }
   return resolved
@@ -424,6 +447,31 @@ func (r formatCommandResolver) RuleOptions(name string) json.RawMessage {
   return nil
 }
 
+func (r formatCommandResolver) RuleOptionsVariants(name string) []json.RawMessage {
+  variants := resolvedRuleOptionsVariants(r.inner, name)
+  defaultOptions := r.defaultOptions[name]
+  if len(defaultOptions) == 0 {
+    return variants
+  }
+  effective := make([]json.RawMessage, 0, len(variants)+1)
+  defaultIncluded := false
+  for _, raw := range variants {
+    if len(raw) == 0 {
+      raw = defaultOptions
+      defaultIncluded = true
+    } else if string(raw) == string(defaultOptions) {
+      defaultIncluded = true
+    }
+    effective = append(effective, append(json.RawMessage(nil), raw...))
+  }
+  if !defaultIncluded {
+    // A scoped custom resolver may enumerate only its explicit tuples even
+    // though the default remains reachable for every other file.
+    effective = append(effective, append(json.RawMessage(nil), defaultOptions...))
+  }
+  return effective
+}
+
 // ResolveProjectRules forwards project declarations unchanged. Format defaults
 // are file rules and cannot create or scope project-rule state.
 func (r formatCommandResolver) ResolveProjectRules(names []string) (map[string]ProjectRuleSetting, error) {
@@ -482,7 +530,7 @@ func resolverOptions(resolver RuleResolver) RuleOptionsMap {
   case InlineRuleResolver:
     return r.Options
   case *ConfigStore:
-    return r.options
+    return r.flattenOptions()
   default:
     return nil
   }

--- a/packages/lint/test/command/command_check_scopes_extends_rule_options_per_file_test.go
+++ b/packages/lint/test/command/command_check_scopes_extends_rule_options_per_file_test.go
@@ -1,0 +1,65 @@
+package linthost
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestCommandCheckScopesExtendsRuleOptionsPerFile covers the complete command
+// path, including project-rule binding around ConfigStore. Both files contain
+// both selectable nodes; each must report only the option tuple from entries
+// that match its own path.
+func TestCommandCheckScopesExtendsRuleOptionsPerFile(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+    "compilerOptions": {
+      "target": "ES2022",
+      "module": "commonjs",
+      "strict": true,
+      "rootDir": "."
+    },
+    "files": ["src/main.ts", "tests/unit.ts"]
+  }`)
+  source := "export {};\nconst value = 1;\ndebugger;\n"
+  writeFile(t, filepath.Join(root, "src", "main.ts"), source)
+  writeFile(t, filepath.Join(root, "tests", "unit.ts"), source)
+  writeFile(t, filepath.Join(root, "base.json"), `{
+    "rules": {
+      "no-restricted-syntax": ["error", "VariableDeclaration"]
+    }
+  }`)
+  writeFile(t, filepath.Join(root, "lint.config.json"), `{
+    "extends": "./base.json",
+    "files": ["tests/**"],
+    "rules": {
+      "no-restricted-syntax": ["warning", "DebuggerStatement"]
+    }
+  }`)
+
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{"check", "--cwd", root, "--plugins-json", lintManifest(t)})
+  })
+  if code != 2 || stdout != "" || strings.Count(stderr, "[no-restricted-syntax]") != 2 {
+    t.Fatalf("scoped command diagnostics mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  cleanStderr := ansiControlSequencePattern.ReplaceAllString(stderr, "")
+  var mainDiagnostic, unitDiagnostic string
+  for _, line := range strings.Split(cleanStderr, "\n") {
+    if !strings.Contains(line, "[no-restricted-syntax]") {
+      continue
+    }
+    if strings.Contains(line, "main.ts") {
+      mainDiagnostic = line
+    }
+    if strings.Contains(line, "unit.ts") {
+      unitDiagnostic = line
+    }
+  }
+  if !strings.Contains(mainDiagnostic, "error TS") ||
+    !strings.Contains(mainDiagnostic, "Using 'VariableDeclaration' is not allowed.") ||
+    !strings.Contains(unitDiagnostic, "warning TS") ||
+    !strings.Contains(unitDiagnostic, "Using 'DebuggerStatement' is not allowed.") {
+    t.Fatalf("command did not preserve per-file options: %q", stderr)
+  }
+}

--- a/packages/lint/test/config/external/config_store_option_fold_honors_both_entry_orders_test.go
+++ b/packages/lint/test/config/external/config_store_option_fold_honors_both_entry_orders_test.go
@@ -1,0 +1,61 @@
+package linthost
+
+import (
+  "encoding/json"
+  "path/filepath"
+  "testing"
+)
+
+// TestConfigStoreOptionFoldHonorsBothEntryOrders proves declaration order is
+// applied only among entries that match the requested file. Reversing global
+// and scoped tuples reverses the selected-file winner without changing the
+// unselected file's payload.
+func TestConfigStoreOptionFoldHonorsBothEntryOrders(t *testing.T) {
+  root := t.TempDir()
+  global := ConfigEntry{
+    BaseDir: root,
+    Rules:   RuleConfig{"no-restricted-syntax": SeverityError},
+    Options: RuleOptionsMap{"no-restricted-syntax": json.RawMessage(`"VariableDeclaration"`)},
+  }
+  scoped := ConfigEntry{
+    BaseDir: root,
+    Files:   []string{"tests/**"},
+    Rules:   RuleConfig{"no-restricted-syntax": SeverityWarn},
+    Options: RuleOptionsMap{"no-restricted-syntax": json.RawMessage(`"DebuggerStatement"`)},
+  }
+
+  tests := []struct {
+    name         string
+    entries      []ConfigEntry
+    selectedWant string
+    severityWant Severity
+  }{
+    {
+      name:         "scoped tuple declared last",
+      entries:      []ConfigEntry{global, scoped},
+      selectedWant: `"DebuggerStatement"`,
+      severityWant: SeverityWarn,
+    },
+    {
+      name:         "global tuple declared last",
+      entries:      []ConfigEntry{scoped, global},
+      selectedWant: `"VariableDeclaration"`,
+      severityWant: SeverityError,
+    },
+  }
+  for _, test := range tests {
+    t.Run(test.name, func(t *testing.T) {
+      store := &ConfigStore{entries: test.entries}
+      selected := store.ResolveRules(filepath.Join(root, "tests", "unit.ts"))
+      if selected.Rules.Severity("no-restricted-syntax") != test.severityWant ||
+        string(selected.RuleOptions("no-restricted-syntax")) != test.selectedWant {
+        t.Fatalf("selected fold mismatch: %+v options=%s", selected, selected.RuleOptions("no-restricted-syntax"))
+      }
+      unselected := store.ResolveRules(filepath.Join(root, "src", "main.ts"))
+      if unselected.Rules.Severity("no-restricted-syntax") != SeverityError ||
+        string(unselected.RuleOptions("no-restricted-syntax")) != `"VariableDeclaration"` {
+        t.Fatalf("nonmatching tuple leaked into main file: %+v options=%s", unselected, unselected.RuleOptions("no-restricted-syntax"))
+      }
+    })
+  }
+}

--- a/packages/lint/test/config/external/config_store_resolves_options_with_entry_scope_test.go
+++ b/packages/lint/test/config/external/config_store_resolves_options_with_entry_scope_test.go
@@ -1,0 +1,77 @@
+package linthost
+
+import (
+  "encoding/json"
+  "path/filepath"
+  "testing"
+)
+
+// TestConfigStoreResolvesOptionsWithEntryScope pins the severity/options fold
+// to the same matching ConfigEntry sequence. A tuple from a sibling files
+// selector must not become the option payload for an unrelated file.
+func TestConfigStoreResolvesOptionsWithEntryScope(t *testing.T) {
+  root := t.TempDir()
+  store := &ConfigStore{entries: []ConfigEntry{
+    {
+      BaseDir: root,
+      Rules: RuleConfig{
+        "no-restricted-syntax": SeverityError,
+        "custom/rule":         SeverityWarn,
+      },
+      Options: RuleOptionsMap{
+        "no-restricted-syntax": json.RawMessage(`"VariableDeclaration"`),
+        "custom/rule":         json.RawMessage(`{"mode":"base"}`),
+      },
+    },
+    {
+      BaseDir: root,
+      Files:   []string{"tests/**"},
+      Rules:   RuleConfig{"no-restricted-syntax": SeverityWarn},
+      Options: RuleOptionsMap{"no-restricted-syntax": json.RawMessage(`"DebuggerStatement"`)},
+    },
+    {
+      BaseDir: root,
+      Files:   []string{"generated/**"},
+      Rules: RuleConfig{
+        "no-restricted-syntax": SeverityError,
+        "custom/rule":         SeverityError,
+      },
+      Options: RuleOptionsMap{
+        "no-restricted-syntax": json.RawMessage(`"WithStatement"`),
+        "custom/rule":         json.RawMessage(`{"mode":"generated"}`),
+      },
+    },
+    {
+      BaseDir:    root,
+      Ignores:    []string{"vendor/**"},
+      IgnoreOnly: true,
+    },
+  }}
+
+  main := store.ResolveRules(filepath.Join(root, "src", "main.ts"))
+  if main.Ignored || main.Rules.Severity("no-restricted-syntax") != SeverityError ||
+    string(main.RuleOptions("no-restricted-syntax")) != `"VariableDeclaration"` {
+    t.Fatalf("main resolution crossed an entry boundary: %+v options=%s", main, main.RuleOptions("no-restricted-syntax"))
+  }
+  if main.Rules.Severity("custom/rule") != SeverityWarn ||
+    string(main.RuleOptions("custom/rule")) != `{"mode":"base"}` {
+    t.Fatalf("unrelated rule state crossed a nonmatching entry: %+v options=%s", main, main.RuleOptions("custom/rule"))
+  }
+
+  testFile := store.ResolveRules(filepath.Join(root, "tests", "unit.ts"))
+  if testFile.Ignored || testFile.Rules.Severity("no-restricted-syntax") != SeverityWarn ||
+    string(testFile.RuleOptions("no-restricted-syntax")) != `"DebuggerStatement"` {
+    t.Fatalf("test resolution did not select its tuple: %+v options=%s", testFile, testFile.RuleOptions("no-restricted-syntax"))
+  }
+
+  ignored := store.ResolveRules(filepath.Join(root, "vendor", "library.ts"))
+  if !ignored.Ignored || len(ignored.Options) != 0 {
+    t.Fatalf("globally ignored file retained rule state: %+v", ignored)
+  }
+
+  main.Options["no-restricted-syntax"][0] = 'x'
+  again := store.ResolveRules(filepath.Join(root, "src", "main.ts"))
+  if string(again.RuleOptions("no-restricted-syntax")) != `"VariableDeclaration"` {
+    t.Fatalf("resolved option payload aliases config state: %s", again.RuleOptions("no-restricted-syntax"))
+  }
+}

--- a/packages/lint/test/config/external/config_store_severity_only_override_inherits_matching_options_test.go
+++ b/packages/lint/test/config/external/config_store_severity_only_override_inherits_matching_options_test.go
@@ -1,0 +1,44 @@
+package linthost
+
+import (
+  "encoding/json"
+  "path/filepath"
+  "testing"
+)
+
+// TestConfigStoreSeverityOnlyOverrideInheritsMatchingOptions verifies normal
+// rule-setting merge semantics: a later severity-only declaration preserves a
+// tuple from an earlier matching entry, but never one from a nonmatching entry.
+func TestConfigStoreSeverityOnlyOverrideInheritsMatchingOptions(t *testing.T) {
+  root := t.TempDir()
+  store := &ConfigStore{entries: []ConfigEntry{
+    {
+      BaseDir: root,
+      Rules:   RuleConfig{"no-restricted-syntax": SeverityError},
+      Options: RuleOptionsMap{"no-restricted-syntax": json.RawMessage(`"VariableDeclaration"`)},
+    },
+    {
+      BaseDir: root,
+      Files:   []string{"tests/**"},
+      Rules:   RuleConfig{"no-restricted-syntax": SeverityWarn},
+    },
+    {
+      BaseDir: root,
+      Files:   []string{"scripts/**"},
+      Rules:   RuleConfig{"no-restricted-syntax": SeverityWarn},
+      Options: RuleOptionsMap{"no-restricted-syntax": json.RawMessage(`"DebuggerStatement"`)},
+    },
+  }}
+
+  testFile := store.ResolveRules(filepath.Join(root, "tests", "unit.ts"))
+  if testFile.Rules.Severity("no-restricted-syntax") != SeverityWarn ||
+    string(testFile.RuleOptions("no-restricted-syntax")) != `"VariableDeclaration"` {
+    t.Fatalf("severity-only override lost its matching inherited options: %+v options=%s", testFile, testFile.RuleOptions("no-restricted-syntax"))
+  }
+
+  script := store.ResolveRules(filepath.Join(root, "scripts", "build.ts"))
+  if script.Rules.Severity("no-restricted-syntax") != SeverityWarn ||
+    string(script.RuleOptions("no-restricted-syntax")) != `"DebuggerStatement"` {
+    t.Fatalf("explicit option override was not selected: %+v options=%s", script, script.RuleOptions("no-restricted-syntax"))
+  }
+}

--- a/packages/lint/test/config/external/config_store_validates_every_scoped_option_variant_test.go
+++ b/packages/lint/test/config/external/config_store_validates_every_scoped_option_variant_test.go
@@ -1,0 +1,37 @@
+package linthost
+
+import (
+  "encoding/json"
+  "strings"
+  "testing"
+)
+
+// TestConfigStoreValidatesEveryScopedOptionVariant proves engine construction
+// cannot hide an invalid option behind a later valid tuple for a disjoint file
+// selector. The old project-wide map validated only the last parsed payload.
+func TestConfigStoreValidatesEveryScopedOptionVariant(t *testing.T) {
+  store := &ConfigStore{entries: []ConfigEntry{
+    {
+      BaseDir: "/project",
+      Files:   []string{"tests/**"},
+      Rules:   RuleConfig{"no-restricted-syntax": SeverityError},
+      Options: RuleOptionsMap{"no-restricted-syntax": json.RawMessage(`"VariableDeclaration["`)},
+    },
+    {
+      BaseDir: "/project",
+      Files:   []string{"src/**"},
+      Rules:   RuleConfig{"no-restricted-syntax": SeverityError},
+      Options: RuleOptionsMap{"no-restricted-syntax": json.RawMessage(`"VariableDeclaration"`)},
+    },
+  }}
+
+  engine := NewEngineWithResolver(store)
+  err := engine.ConfigError()
+  if err == nil || !strings.Contains(err.Error(), `invalid options for rule "no-restricted-syntax"`) ||
+    !strings.Contains(err.Error(), "invalid selector") {
+    t.Fatalf("scoped invalid options were not rejected: %v", err)
+  }
+  if _, active := engine.EnabledRules()["no-restricted-syntax"]; active {
+    t.Fatalf("rule with an invalid scoped variant entered dispatch: %v", engine.EnabledRules())
+  }
+}

--- a/packages/lint/test/config/files/load_config_resolver_scopes_extends_options_in_engine_test.go
+++ b/packages/lint/test/config/files/load_config_resolver_scopes_extends_options_in_engine_test.go
@@ -1,0 +1,56 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestLoadConfigResolverScopesExtendsOptionsInEngine exercises the real JSON
+// loader, extends ordering, alias normalization, and per-file engine binding.
+// Both files contain both candidate nodes; only their matching selector may
+// report, making an option leak observable as an exact wrong diagnostic.
+func TestLoadConfigResolverScopesExtendsOptionsInEngine(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), `{}`)
+  writeFile(t, filepath.Join(root, "base.json"), `{
+    "rules": {
+      "no-restricted-syntax": ["error", "VariableDeclaration"]
+    }
+  }`)
+  writeFile(t, filepath.Join(root, "lint.config.json"), `{
+    "extends": "./base.json",
+    "files": ["tests/**"],
+    "rules": {
+      "eslint/no-restricted-syntax": ["warning", "DebuggerStatement"]
+    }
+  }`)
+
+  resolver, err := LoadConfigResolver(&PluginEntry{Config: map[string]any{
+    "configFile": "./lint.config.json",
+  }}, root, "tsconfig.json")
+  if err != nil {
+    t.Fatalf("LoadConfigResolver: %v", err)
+  }
+  engine := NewEngineWithResolver(resolver)
+  if err := engine.ConfigError(); err != nil {
+    t.Fatalf("NewEngineWithResolver: %v", err)
+  }
+
+  source := "const value = 1;\ndebugger;\n"
+  main := parseTSFile(t, filepath.Join(root, "src", "main.ts"), source)
+  testFile := parseTSFile(t, filepath.Join(root, "tests", "unit.ts"), source)
+  findings := engine.Run([]*shimast.SourceFile{main, testFile}, nil)
+  if len(findings) != 2 {
+    t.Fatalf("want one scoped finding per file, got %+v", findings)
+  }
+  if findings[0].File != main || findings[0].Severity != SeverityError ||
+    findings[0].Message != "Using 'VariableDeclaration' is not allowed." {
+    t.Fatalf("base file received the wrong rule setting: %+v", findings[0])
+  }
+  if findings[1].File != testFile || findings[1].Severity != SeverityWarn ||
+    findings[1].Message != "Using 'DebuggerStatement' is not allowed." {
+    t.Fatalf("selected file received the wrong rule setting: %+v", findings[1])
+  }
+}

--- a/packages/lint/test/config/inline/inline_resolver_carries_options_in_resolved_config_test.go
+++ b/packages/lint/test/config/inline/inline_resolver_carries_options_in_resolved_config_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+)
+
+// TestInlineResolverCarriesOptionsInResolvedConfig protects the non-scoped
+// compatibility path after Context binding moves to ResolvedRuleConfig.
+func TestInlineResolverCarriesOptionsInResolvedConfig(t *testing.T) {
+  resolver := InlineRuleResolver{
+    Rules: RuleConfig{"eslint/no-restricted-syntax": SeverityError},
+    Options: RuleOptionsMap{
+      "eslint/no-restricted-syntax": json.RawMessage(`"DebuggerStatement"`),
+    },
+  }
+  resolved := resolver.ResolveRules("/virtual/file.ts")
+  if resolved.Rules.Severity("no-restricted-syntax") != SeverityError ||
+    string(resolved.RuleOptions("no-restricted-syntax")) != `"DebuggerStatement"` {
+    t.Fatalf("inline options were not normalized with severity: %+v options=%s", resolved, resolved.RuleOptions("no-restricted-syntax"))
+  }
+
+  resolved.Options["no-restricted-syntax"][0] = 'x'
+  if string(resolver.Options["eslint/no-restricted-syntax"]) != `"DebuggerStatement"` {
+    t.Fatalf("resolved inline options alias caller-owned input: %s", resolver.Options["eslint/no-restricted-syntax"])
+  }
+}

--- a/packages/lint/test/config/inline/legacy_custom_resolver_keeps_rule_options_fallback_test.go
+++ b/packages/lint/test/config/inline/legacy_custom_resolver_keeps_rule_options_fallback_test.go
@@ -1,0 +1,36 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+type legacyCustomRuleOptionsResolver struct {
+  InlineRuleResolver
+}
+
+// ResolveRules deliberately returns the pre-file-options shape. Embedding
+// InlineRuleResolver supplies every other RuleResolver method, including the
+// legacy file-agnostic RuleOptions lookup.
+func (r legacyCustomRuleOptionsResolver) ResolveRules(string) ResolvedRuleConfig {
+  return ResolvedRuleConfig{Rules: normalizeRuleConfigKeys(r.Rules)}
+}
+
+// TestLegacyCustomResolverKeepsRuleOptionsFallback protects external resolver
+// compatibility while built-in scoped resolvers move to authoritative
+// per-file options.
+func TestLegacyCustomResolverKeepsRuleOptionsFallback(t *testing.T) {
+  resolver := legacyCustomRuleOptionsResolver{InlineRuleResolver: InlineRuleResolver{
+    Rules: RuleConfig{"no-restricted-syntax": SeverityError},
+    Options: RuleOptionsMap{
+      "no-restricted-syntax": json.RawMessage(`"DebuggerStatement"`),
+    },
+  }}
+  file := parseTS(t, "debugger;\n")
+  findings := NewEngineWithResolver(resolver).Run([]*shimast.SourceFile{file}, nil)
+  if len(findings) != 1 || findings[0].Message != "Using 'DebuggerStatement' is not allowed." {
+    t.Fatalf("legacy RuleOptions fallback was not preserved: %+v", findings)
+  }
+}

--- a/packages/lint/test/format/format_command_resolver_keeps_configured_options_inside_matching_entry_test.go
+++ b/packages/lint/test/format/format_command_resolver_keeps_configured_options_inside_matching_entry_test.go
@@ -1,0 +1,75 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+)
+
+// TestFormatCommandResolverKeepsConfiguredOptionsInsideMatchingEntry proves a
+// scoped format tuple cannot be promoted into a file merely because that file
+// matches some other config entry. The synthetic default set remains global,
+// but a user-authored format block follows normal files/ignores scoping.
+func TestFormatCommandResolverKeepsConfiguredOptionsInsideMatchingEntry(t *testing.T) {
+  store := &ConfigStore{entries: []ConfigEntry{
+    {
+      BaseDir: "/project",
+      Rules: RuleConfig{
+        "no-var":      SeverityError,
+        "format/semi": SeverityOff,
+      },
+    },
+    {
+      BaseDir: "/project",
+      Files:   []string{"tests/**"},
+      Rules: RuleConfig{
+        "format/semi":   SeverityOff,
+        "format/quotes": SeverityOff,
+      },
+      Options: RuleOptionsMap{
+        "format/semi":   json.RawMessage(`{"prefer":"never"}`),
+        "format/quotes": json.RawMessage(`{"prefer":"single"}`),
+      },
+    },
+  }}
+  resolver := formatCommandResolver{inner: store}
+
+  source := resolver.ResolveRules("/project/src/main.ts")
+  if source.Rules.Severity("format/semi") != SeverityWarn ||
+    len(source.RuleOptions("format/semi")) != 0 {
+    t.Fatalf("severity-only format setting borrowed scoped options: %+v options=%s",
+      source.Rules, source.RuleOptions("format/semi"))
+  }
+  if source.Rules.Severity("format/quotes") != SeverityOff ||
+    len(source.RuleOptions("format/quotes")) != 0 {
+    t.Fatalf("entire scoped format setting leaked into source file: %+v options=%s",
+      source.Rules, source.RuleOptions("format/quotes"))
+  }
+
+  testFile := resolver.ResolveRules("/project/tests/unit.ts")
+  if testFile.Rules.Severity("format/semi") != SeverityWarn ||
+    string(testFile.RuleOptions("format/semi")) != `{"prefer":"never"}` {
+    t.Fatalf("matching format tuple was not promoted intact: %+v options=%s",
+      testFile.Rules, testFile.RuleOptions("format/semi"))
+  }
+  if testFile.Rules.Severity("format/quotes") != SeverityWarn ||
+    string(testFile.RuleOptions("format/quotes")) != `{"prefer":"single"}` {
+    t.Fatalf("matching scoped format rule was not promoted intact: %+v options=%s",
+      testFile.Rules, testFile.RuleOptions("format/quotes"))
+  }
+}
+
+// TestFormatCommandResolverVariantsReplaceBareOptionsWithReachableDefaults
+// keeps eager validation aligned with runtime binding. A nil inner payload is
+// not reachable when the format command supplies a synthetic default.
+func TestFormatCommandResolverVariantsReplaceBareOptionsWithReachableDefaults(t *testing.T) {
+  resolver := formatCommandResolver{
+    inner: RuleConfig{"format/semi": SeverityOff},
+    defaultOptions: RuleOptionsMap{
+      "format/semi": json.RawMessage(`{"prefer":"always"}`),
+    },
+  }
+  variants := resolver.RuleOptionsVariants("format/semi")
+  if len(variants) != 1 || string(variants[0]) != `{"prefer":"always"}` {
+    t.Fatalf("validation variants do not match reachable defaults: %q", variants)
+  }
+}

--- a/packages/lint/test/format/format_command_resolver_skips_upgrade_for_entry_ignored_file_test.go
+++ b/packages/lint/test/format/format_command_resolver_skips_upgrade_for_entry_ignored_file_test.go
@@ -20,7 +20,7 @@ import (
 // resolver-side guard that closes that gap.
 //
 //  1. Build a `*ConfigStore` whose single entry has both `rules` and an
-//     `ignores` list, and whose options map registers a `format/*` rule.
+//     `ignores` list plus a `format/*` option tuple.
 //  2. Resolve rules for an ignored path and for an unrelated path.
 //  3. Assert the ignored path receives no format-rule upgrade and the
 //     unrelated path receives the standard warn-severity upgrade.
@@ -31,12 +31,13 @@ func TestFormatCommandResolverSkipsUpgradeForEntryIgnoredFile(t *testing.T) {
         BaseDir: "/project",
         Ignores: []string{"src/driver/mongodb/typings.ts"},
         Rules: RuleConfig{
-          "no-var": SeverityError,
+          "no-var":      SeverityError,
+          "format/semi": SeverityOff,
+        },
+        Options: RuleOptionsMap{
+          "format/semi": json.RawMessage(`{"prefer":"always"}`),
         },
       },
-    },
-    options: RuleOptionsMap{
-      "format/semi": json.RawMessage(`{"prefer":"always"}`),
     },
   }
   resolver := formatCommandResolver{inner: store}

--- a/packages/lint/test/format/format_command_resolver_skips_upgrade_for_file_outside_entry_files_test.go
+++ b/packages/lint/test/format/format_command_resolver_skips_upgrade_for_file_outside_entry_files_test.go
@@ -21,8 +21,7 @@ import (
 // gap.
 //
 //  1. Build a `*ConfigStore` whose single non-IgnoreOnly entry restricts
-//     `files` to `src/**/*.ts`, and whose options map registers a `format/*`
-//     rule.
+//     `files` to `src/**/*.ts` and declares a `format/*` option tuple.
 //  2. Resolve rules for an in-scope path and for an out-of-scope path.
 //  3. Assert the out-of-scope path receives no format-rule upgrade and the
 //     in-scope path receives the standard warn-severity upgrade.
@@ -33,12 +32,13 @@ func TestFormatCommandResolverSkipsUpgradeForFileOutsideEntryFiles(t *testing.T)
         BaseDir: "/project",
         Files:   []string{"src/**/*.ts"},
         Rules: RuleConfig{
-          "no-var": SeverityError,
+          "no-var":      SeverityError,
+          "format/semi": SeverityOff,
+        },
+        Options: RuleOptionsMap{
+          "format/semi": json.RawMessage(`{"prefer":"always"}`),
         },
       },
-    },
-    options: RuleOptionsMap{
-      "format/semi": json.RawMessage(`{"prefer":"always"}`),
     },
   }
   resolver := formatCommandResolver{inner: store}


### PR DESCRIPTION
## Intent

Resolve each rule's option payload through the same `files`, `ignores`, and `extends` entries as its severity. This prevents an option tuple from a nonmatching config entry from changing another file's lint behavior.

## Root cause

`ConfigStore` retained entry-local options but also overwrote a project-wide options map while parsing. `ResolveRules(file)` scoped only severity, and `Engine.runFile` then bound the project-wide final payload for every file.

## Changes

- Carry severity and options together in `ResolvedRuleConfig`.
- Fold matching entries base-first: later tuples replace options, while severity-only overrides retain options from earlier matching entries, matching ESLint flat-config semantics.
- Bind each file context from its resolved payload rather than the project-wide compatibility lookup.
- Validate every scoped option variant before dispatch, not only the last parsed tuple.
- Preserve flat, inline, project-rule, format-resolver, and legacy custom `RuleResolver` compatibility explicitly.
- Remove the duplicate project-wide option cache; metadata enumeration derives from entry state.

## Regression shield

- matching/nonmatching files with both declaration orders;
- severity-only inheritance and explicit tuple replacement;
- global ignores and defensive payload isolation;
- real JSON config loading through an `extends` chain;
- canonical `eslint/` alias normalization;
- exact per-file engine findings and severities;
- invalid payload validation across disjoint scopes;
- inline and legacy custom resolver compatibility.

Local execution is intentionally deferred until three clean exhaustive reviews of the exact PR head. No formatter was run.

Closes #490
