### PR TITLE
fix(lint): preserve entry-scoped formatting eligibility

### DIFF
--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -106,7 +106,10 @@ type ProjectRuleSetting struct {
 // its severity.
 //
 // `Ignored` means an `ignores`-only config entry matched the file and the
-// engine should skip linting it entirely.
+// engine should skip linting it entirely. `OutOfScope` means the store has at
+// least one rule-bearing entry but none applies to this file. Keeping the two
+// states distinct lets wrappers preserve entry-local ignores: one entry may
+// reject a file while another matching entry still contributes rules.
 type ResolvedRuleConfig struct {
   Rules           RuleConfig
   Options         RuleOptionsMap
@@ -115,6 +118,7 @@ type ResolvedRuleConfig struct {
   // RuleResolver.RuleOptions.
   OptionsResolved bool
   Ignored         bool
+  OutOfScope      bool
 }
 
 // RuleOptions returns the file-resolved option payload for name. Built-in
@@ -438,10 +442,17 @@ func (s *ConfigStore) ResolveRules(fileName string) ResolvedRuleConfig {
   }
   out := RuleConfig{}
   options := RuleOptionsMap{}
+  hasEntries := false
+  matchedEntry := false
   for _, entry := range s.entries {
-    if entry.IgnoreOnly || !entry.matchesFile(fileName) {
+    if entry.IgnoreOnly {
       continue
     }
+    hasEntries = true
+    if !entry.matchesFile(fileName) {
+      continue
+    }
+    matchedEntry = true
     for name, sev := range entry.Rules {
       canonical := normalizeBuiltinRuleName(name)
       out[canonical] = sev
@@ -450,7 +461,12 @@ func (s *ConfigStore) ResolveRules(fileName string) ResolvedRuleConfig {
       }
     }
   }
-  return ResolvedRuleConfig{Rules: out, Options: options, OptionsResolved: true}
+  return ResolvedRuleConfig{
+    Rules:           out,
+    Options:         options,
+    OptionsResolved: true,
+    OutOfScope:      hasEntries && !matchedEntry,
+  }
 }
 
 // ActiveRuleNames implements RuleResolver. Returns the sorted union of all rule

--- a/packages/lint/linthost/format.go
+++ b/packages/lint/linthost/format.go
@@ -119,15 +119,6 @@ type formatCommandResolver struct {
   // around as a value) shares the same underlying cache rather than copying a
   // sync.Once lock.
   ruleNames *formatRuleNamesCache
-  // entryDecisions memoizes the per-fileName ignored/matches decision that
-  // ResolveRules derives from fileIsIgnoredByEntry and fileMatchesAnyEntry.
-  // Both walk store.entries with glob matching and are recomputed identically
-  // for the same fileName on every format pass, so the result is cached once
-  // per file and reused. The field is a pointer (a *sync.Map) so the nil zero
-  // value stays valid for construction sites that omit it, and copying the
-  // resolver by value shares the same underlying map. sync.Map handles the
-  // engine's concurrent per-file ResolveRules calls without an extra lock.
-  entryDecisions *sync.Map
   // defaultOptions holds the always-on format rules' options (from
   // expandFormatBlock) to apply when the project config declares no `format`
   // block — no block in lint.config.*, or no config file at all. nil when a
@@ -146,9 +137,8 @@ type formatCommandResolver struct {
 // defaultOptions nil so the block stays authoritative.
 func newFormatCommandResolver(inner RuleResolver, startDir string, language string) (formatCommandResolver, error) {
   r := formatCommandResolver{
-    inner:          inner,
-    ruleNames:      &formatRuleNamesCache{},
-    entryDecisions: &sync.Map{},
+    inner:     inner,
+    ruleNames: &formatRuleNamesCache{},
   }
   if !hasInnerFormatRules(inner) {
     opts, err := defaultFormatOptions(editorFormatOverrides(startDir, language))
@@ -208,43 +198,18 @@ type formatRuleNamesCache struct {
   names []string
 }
 
-// formatEntryDecision is the cached per-fileName outcome of the two entry-scope
-// checks ResolveRules runs before applying its format-rule upgrade.
-type formatEntryDecision struct {
-  ignoredByEntry bool
-  matchesEntry   bool
-}
-
 // ResolveRules implements RuleResolver. It delegates to the inner resolver
 // and then upgrades format-rule entries from off to warn so they are applied
 // even when the project config omits them.
 //
-// A user-authored entry whose `ignores` list matches `fileName` is honored
-// here even when the entry also carries a `rules` block: the engine already
-// skips that entry's rule contributions via `ConfigEntry.matchesFile`, so the
-// format command must skip its blanket format-rule upgrade as well. Without
-// this guard, `ttsc format` would rewrite files that the user explicitly
-// asked the lint config to ignore — the engine's lint walk would skip the
-// file but the formatter would still touch it.
-//
-// The symmetric guard applies to `files`: if every non-IgnoreOnly entry
-// carries a `files` filter and `fileName` matches none of them, the engine
-// would not run any rules on the file (`ConfigEntry.matchesFile` returns
-// false for every entry). The format command must skip its blanket
-// format-rule upgrade for the same reason — otherwise `ttsc format` would
-// rewrite files that fall outside every entry's scope, e.g. a `.json`
-// resolved into the program via `resolveJsonModule` when the only entry
-// targets `src/**/*.ts`.
+// ConfigStore resolves entry applicability together with rules and options.
+// A global ignore skips the file, while OutOfScope skips only files rejected
+// by every rule-bearing entry. An ignore on one entry therefore cannot erase a
+// separate matching entry's contribution. The flags also survive resolver
+// wrappers, unlike inspecting a concrete ConfigStore from this outer layer.
 func (r formatCommandResolver) ResolveRules(fileName string) ResolvedRuleConfig {
   resolved := r.inner.ResolveRules(fileName)
-  if resolved.Ignored {
-    return resolved
-  }
-  decision := r.entryDecision(fileName)
-  if decision.ignoredByEntry {
-    return resolved
-  }
-  if !decision.matchesEntry {
+  if resolved.Ignored || resolved.OutOfScope {
     return resolved
   }
   if resolved.Rules == nil {
@@ -279,128 +244,6 @@ func (r formatCommandResolver) ResolveRules(fileName string) ResolvedRuleConfig 
     }
   }
   return resolved
-}
-
-// entryDecision returns the per-fileName ignored/matches outcome that
-// ResolveRules needs, computing it from fileIsIgnoredByEntry and
-// fileMatchesAnyEntry on first use and reusing it on later passes. When the
-// memo is absent (a resolver built without entryDecisions, e.g. in tests or
-// lsp) it computes the decision directly so behavior is identical, just
-// uncached.
-func (r formatCommandResolver) entryDecision(fileName string) formatEntryDecision {
-  if r.entryDecisions == nil {
-    return r.computeEntryDecision(fileName)
-  }
-  if cached, ok := r.entryDecisions.Load(fileName); ok {
-    return cached.(formatEntryDecision)
-  }
-  decision := r.computeEntryDecision(fileName)
-  // LoadOrStore keeps the first writer's value so concurrent passes over the
-  // same file agree; the decision is a pure function of fileName, so either
-  // value is correct.
-  actual, _ := r.entryDecisions.LoadOrStore(fileName, decision)
-  return actual.(formatEntryDecision)
-}
-
-// computeEntryDecision runs the two uncached entry-scope checks behind
-// entryDecision.
-func (r formatCommandResolver) computeEntryDecision(fileName string) formatEntryDecision {
-  return formatEntryDecision{
-    ignoredByEntry: r.fileIsIgnoredByEntry(fileName),
-    matchesEntry:   r.fileMatchesAnyEntry(fileName),
-  }
-}
-
-// fileIsIgnoredByEntry reports whether any non-IgnoreOnly entry in the inner
-// ConfigStore has an `ignores` glob that matches `fileName`. IgnoreOnly
-// entries are already handled by ResolvedRuleConfig.Ignored — they are
-// checked first by ConfigStore.ResolveRules and short-circuit the walk. This
-// helper covers the complementary case: an entry that carries both `rules`
-// and `ignores`, where the engine skips the entry's rule contributions via
-// `ConfigEntry.matchesFile` but the format command must learn the same fact
-// independently because its job is to upgrade format rules to `warn`, not to
-// read the engine's resolved severity map.
-func (r formatCommandResolver) fileIsIgnoredByEntry(fileName string) bool {
-  matched, _ := r.anyNonIgnoreEntry(func(entry *ConfigEntry) bool {
-    return entry.matchesIgnores(fileName)
-  })
-  return matched
-}
-
-// anyNonIgnoreEntry resolves the inner resolver to its concrete *ConfigStore
-// once and reports whether any non-IgnoreOnly entry satisfies `pred`. The
-// second return value is false when the inner resolver is not a *ConfigStore
-// (or is a nil one), letting each caller pick its own non-store default. This
-// collapses the shared store-resolution and entry-walk that fileIsIgnoredByEntry
-// and fileMatchesAnyEntry would otherwise duplicate; the per-caller default and
-// the empty-entries base case stay in the callers where they differ.
-func (r formatCommandResolver) anyNonIgnoreEntry(pred func(*ConfigEntry) bool) (matched bool, hasStore bool) {
-  store, ok := r.inner.(*ConfigStore)
-  if !ok || store == nil {
-    return false, false
-  }
-  for i := range store.entries {
-    entry := &store.entries[i]
-    if entry.IgnoreOnly {
-      continue
-    }
-    if pred(entry) {
-      return true, true
-    }
-  }
-  return false, true
-}
-
-// fileMatchesAnyEntry reports whether `fileName` falls inside the `files`
-// scope of at least one non-IgnoreOnly entry. An entry without an explicit
-// `files` list matches every file by definition (eslint flat-config
-// semantics), so a config with any unrestricted non-IgnoreOnly entry returns
-// true for every file. The format command treats a `false` result the same
-// way the engine does: no entry contributes rules, so the blanket
-// format-rule upgrade must be skipped.
-//
-// Base cases:
-//
-//   - Empty entries slice: returns `true`. A store with no entries cannot
-//     skip a file by scope (the engine has nothing to walk), so format
-//     mode must be allowed to apply its default upgrade. Matching engine
-//     behavior at `ConfigStore.ResolveRules` for the same input
-//     (`Ignored = false`, empty rule map).
-//   - All entries are IgnoreOnly: returns `false`. No non-IgnoreOnly
-//     entry contributes a `files` scope, so the file is out-of-scope by
-//     construction.
-//   - Inner resolver is not a *ConfigStore: returns `true` (conservative
-//     default). The `files` concept is store-specific; an in-process
-//     custom resolver that does not surface a scope cannot have its
-//     rule-eligibility reasoned about from the outside, so the format
-//     upgrade applies the same as it does for an entry without `files`.
-func (r formatCommandResolver) fileMatchesAnyEntry(fileName string) bool {
-  matched, hasStore := r.anyNonIgnoreEntry(func(entry *ConfigEntry) bool {
-    return entry.matchesFile(fileName)
-  })
-  if !hasStore {
-    // Not a *ConfigStore: conservative default, see the doc comment above.
-    return true
-  }
-  // A store with no entries (or only IgnoreOnly ones that the walk skipped)
-  // produces matched == false; an empty entries slice must still return true
-  // so format mode applies its default upgrade, matching ConfigStore behavior.
-  // The all-IgnoreOnly case is distinguished by a non-empty entries slice.
-  if !matched && len(r.storeEntries()) == 0 {
-    return true
-  }
-  return matched
-}
-
-// storeEntries returns the inner resolver's config entries, or nil when the
-// inner resolver is not a *ConfigStore. Used by fileMatchesAnyEntry to tell the
-// empty-entries base case (return true) apart from the all-IgnoreOnly case
-// (return false) after anyNonIgnoreEntry reports no match.
-func (r formatCommandResolver) storeEntries() []ConfigEntry {
-  if store, ok := r.inner.(*ConfigStore); ok && store != nil {
-    return store.entries
-  }
-  return nil
 }
 
 // ActiveRuleNames implements RuleResolver. Returns the union of the inner

--- a/packages/lint/test/format/command_format_respects_resolved_entry_applicability_test.go
+++ b/packages/lint/test/format/command_format_respects_resolved_entry_applicability_test.go
@@ -27,6 +27,43 @@ func TestCommandFormatRespectsResolvedEntryApplicability(t *testing.T) {
       "ignores": []string{"src/ignored.ts"},
     })
     assertFormatApplicability(t, root, files)
+
+    ignored := resolveFormatApplicability(t, root, "src/ignored.ts")
+    if !ignored.Ignored || ignored.OutOfScope {
+      t.Fatalf("normal resolution lost global ignore state: %+v", ignored)
+    }
+    included := resolveFormatApplicability(t, root, "src/included.ts")
+    if included.Ignored || included.OutOfScope {
+      t.Fatalf("normal resolution excluded unignored file: %+v", included)
+    }
+    assertLSPFormatApplicability(t, root, files)
+  })
+
+  t.Run("scoped_base_ignore_keeps_global_child_format", func(t *testing.T) {
+    files := []formatApplicabilityFile{
+      {name: "src/generated/model.ts", source: "const generated = 1\n", want: "const generated = 1;\n"},
+    }
+    root := seedFormatApplicabilityProject(t, files)
+    baseConfig := map[string]any{
+      "files":   []string{"src/**"},
+      "ignores": []string{"src/generated/**"},
+      "format":  map[string]any{"semi": true},
+    }
+    encodedBase, err := json.Marshal(baseConfig)
+    if err != nil {
+      t.Fatalf("marshal base config: %v", err)
+    }
+    writeFile(t, filepath.Join(root, "lint.base.json"), string(encodedBase))
+    seedLintConfig(t, root, map[string]any{
+      "extends": "./lint.base.json",
+      "format":  map[string]any{"semi": true},
+    })
+    assertFormatApplicability(t, root, files)
+
+    resolved := resolveFormatApplicability(t, root, files[0].name)
+    if resolved.Ignored || resolved.OutOfScope || len(resolved.RuleOptions("format/semi")) == 0 {
+      t.Fatalf("global child contribution was lost in normal resolution: %+v", resolved)
+    }
   })
 
   t.Run("overlapping_extends_entries_keep_each_others_match", func(t *testing.T) {
@@ -59,6 +96,18 @@ func TestCommandFormatRespectsResolvedEntryApplicability(t *testing.T) {
       "format":  map[string]any{"semi": true},
     })
     assertFormatApplicability(t, root, files)
+
+    for _, file := range files[:2] {
+      resolved := resolveFormatApplicability(t, root, file.name)
+      if resolved.Ignored || resolved.OutOfScope || len(resolved.RuleOptions("format/semi")) == 0 {
+        t.Fatalf("matching entry contribution was lost for %s: %+v", file.name, resolved)
+      }
+    }
+    outside := resolveFormatApplicability(t, root, files[2].name)
+    if outside.Ignored || !outside.OutOfScope || len(outside.Rules) != 0 || len(outside.Options) != 0 {
+      t.Fatalf("normal resolution retained state outside every entry: %+v", outside)
+    }
+    assertLSPFormatApplicability(t, root, files)
   })
 
   for _, scenario := range []struct {
@@ -120,5 +169,32 @@ func assertFormatApplicability(t *testing.T, root string, files []formatApplicab
     for _, file := range files {
       assertFileText(t, filepath.Join(root, filepath.FromSlash(file.name)), file.want)
     }
+  }
+}
+
+func resolveFormatApplicability(t *testing.T, root string, fileName string) ResolvedRuleConfig {
+  t.Helper()
+  resolver, err := loadRules(lintManifest(t), root, "")
+  if err != nil {
+    t.Fatalf("loadRules: %v", err)
+  }
+  return resolver.ResolveRules(filepath.Join(root, filepath.FromSlash(fileName)))
+}
+
+func assertLSPFormatApplicability(t *testing.T, root string, files []formatApplicabilityFile) {
+  t.Helper()
+  for _, file := range files {
+    target := filepath.Join(root, filepath.FromSlash(file.name))
+    got := executeLSPFormatBufferAppliedTextForTest(
+      t,
+      root,
+      lintTestFileURI(t, target),
+      file.source,
+      file.source,
+    )
+    if got != file.want {
+      t.Fatalf("LSP format mismatch for %s:\nwant %q\ngot  %q", file.name, file.want, got)
+    }
+    assertFileText(t, target, file.want)
   }
 }

--- a/packages/lint/test/format/command_format_respects_resolved_entry_applicability_test.go
+++ b/packages/lint/test/format/command_format_respects_resolved_entry_applicability_test.go
@@ -1,0 +1,124 @@
+package linthost
+
+import (
+  "encoding/json"
+  "path/filepath"
+  "testing"
+)
+
+type formatApplicabilityFile struct {
+  name   string
+  source string
+  want   string
+}
+
+// TestCommandFormatRespectsResolvedEntryApplicability exercises entry scope
+// through the real command loader. loadRules wraps ConfigStore before format
+// mode sees it, so these cases also prevent an outer resolver from duplicating
+// glob logic through a concrete-type assertion.
+func TestCommandFormatRespectsResolvedEntryApplicability(t *testing.T) {
+  t.Run("ignore_only_keeps_defaults_for_unignored_files", func(t *testing.T) {
+    files := []formatApplicabilityFile{
+      {name: "src/ignored.ts", source: "const ignored = 1\n", want: "const ignored = 1\n"},
+      {name: "src/included.ts", source: "const included = 2\n", want: "const included = 2;\n"},
+    }
+    root := seedFormatApplicabilityProject(t, files)
+    seedLintConfig(t, root, map[string]any{
+      "ignores": []string{"src/ignored.ts"},
+    })
+    assertFormatApplicability(t, root, files)
+  })
+
+  t.Run("overlapping_extends_entries_keep_each_others_match", func(t *testing.T) {
+    files := []formatApplicabilityFile{
+      {name: "src/base-wins.ts", source: "const baseWins = 1\n", want: "const baseWins = 1;\n"},
+      {name: "src/child-wins.ts", source: "const childWins = 2\n", want: "const childWins = 2;\n"},
+      {name: "src/outside.ts", source: "const outside = 3\n", want: "const outside = 3\n"},
+    }
+    root := seedFormatApplicabilityProject(t, files)
+    baseConfig := map[string]any{
+      "files": []string{
+        filepath.Join("src", "base-wins.ts"),
+        "src/child-wins.ts",
+      },
+      "ignores": []string{filepath.Join("src", "child-wins.ts")},
+      "format":  map[string]any{"semi": true},
+    }
+    encodedBase, err := json.Marshal(baseConfig)
+    if err != nil {
+      t.Fatalf("marshal base config: %v", err)
+    }
+    writeFile(t, filepath.Join(root, "lint.base.json"), string(encodedBase))
+    seedLintConfig(t, root, map[string]any{
+      "extends": "./lint.base.json",
+      "files": []string{
+        "src/base-wins.ts",
+        filepath.Join("src", "child-wins.ts"),
+      },
+      "ignores": []string{"src/base-wins.ts"},
+      "format":  map[string]any{"semi": true},
+    })
+    assertFormatApplicability(t, root, files)
+  })
+
+  for _, scenario := range []struct {
+    name        string
+    writeConfig bool
+  }{
+    {name: "no_config"},
+    {name: "empty_config", writeConfig: true},
+  } {
+    t.Run(scenario.name+"_keeps_format_defaults", func(t *testing.T) {
+      files := []formatApplicabilityFile{
+        {name: "src/main.ts", source: "const value = 1\n", want: "const value = 1;\n"},
+      }
+      root := seedFormatApplicabilityProject(t, files)
+      if scenario.writeConfig {
+        seedLintConfig(t, root, map[string]any{})
+      }
+      assertFormatApplicability(t, root, files)
+    })
+  }
+}
+
+func seedFormatApplicabilityProject(t *testing.T, files []formatApplicabilityFile) string {
+  t.Helper()
+  root := t.TempDir()
+  names := make([]string, 0, len(files))
+  for _, file := range files {
+    names = append(names, filepath.ToSlash(file.name))
+    writeFile(t, filepath.Join(root, filepath.FromSlash(file.name)), file.source)
+  }
+  config, err := json.Marshal(map[string]any{
+    "compilerOptions": map[string]any{
+      "module": "commonjs",
+      "strict": true,
+      "target": "ES2022",
+    },
+    "files": names,
+  })
+  if err != nil {
+    t.Fatalf("marshal tsconfig: %v", err)
+  }
+  writeFile(t, filepath.Join(root, "tsconfig.json"), string(config))
+  return root
+}
+
+func assertFormatApplicability(t *testing.T, root string, files []formatApplicabilityFile) {
+  t.Helper()
+  for pass := 1; pass <= 2; pass++ {
+    code, stdout, stderr := captureCommandOutput(t, func() int {
+      return run([]string{
+        "format",
+        "--cwd", root,
+        "--plugins-json", lintManifest(t),
+      })
+    })
+    if code != 0 || stdout != "" || stderr != "" {
+      t.Fatalf("format pass %d mismatch: code=%d stdout=%q stderr=%q", pass, code, stdout, stderr)
+    }
+    for _, file := range files {
+      assertFileText(t, filepath.Join(root, filepath.FromSlash(file.name)), file.want)
+    }
+  }
+}

--- a/packages/lint/test/format/format_command_resolver_skips_upgrade_for_entry_ignored_file_test.go
+++ b/packages/lint/test/format/format_command_resolver_skips_upgrade_for_entry_ignored_file_test.go
@@ -43,6 +43,9 @@ func TestFormatCommandResolverSkipsUpgradeForEntryIgnoredFile(t *testing.T) {
   resolver := formatCommandResolver{inner: store}
 
   ignored := resolver.ResolveRules("/project/src/driver/mongodb/typings.ts")
+  if !ignored.OutOfScope {
+    t.Fatalf("entry-ignored file was not marked inapplicable: %+v", ignored)
+  }
   if ignored.Rules.Severity("format/semi") != SeverityOff {
     t.Fatalf("ignored file: want formatSemi off, got %v (resolved=%+v)",
       ignored.Rules.Severity("format/semi"), ignored.Rules)

--- a/packages/lint/test/format/format_command_resolver_skips_upgrade_for_file_outside_entry_files_test.go
+++ b/packages/lint/test/format/format_command_resolver_skips_upgrade_for_file_outside_entry_files_test.go
@@ -50,6 +50,9 @@ func TestFormatCommandResolverSkipsUpgradeForFileOutsideEntryFiles(t *testing.T)
   }
 
   outOfScope := resolver.ResolveRules("/project/extensions/theme-defaults/themes/dark_modern.json")
+  if !outOfScope.OutOfScope {
+    t.Fatalf("out-of-scope file was not marked inapplicable: %+v", outOfScope)
+  }
   if outOfScope.Rules.Severity("format/semi") != SeverityOff {
     t.Fatalf("out-of-scope file: want formatSemi off, got %v (resolved=%+v)",
       outOfScope.Rules.Severity("format/semi"), outOfScope.Rules)


### PR DESCRIPTION
## Summary

- resolve per-file applicability in the same config fold as severities and options
- preserve global ignores while allowing another matching extends entry to contribute formatting
- keep default formatting active for empty and ignore-only configs, and skip files outside every scoped entry
- remove duplicate concrete-ConfigStore glob inspection from the format wrapper
- add real CLI, normal resolution, LSP in-memory, mixed-separator, extends, exact-output, and second-pass idempotence shields

## Verification

- three sequential exhaustive whole-PR reviews passed on exact HEAD \4014f87da941c42c0b902374fd079cdb0ee817ff\`n- focused Go selection passed: new CLI/LSP applicability shield plus adjacent format/config regressions (\ok .../linthost 1.022s\)
- \pnpm --filter @ttsc/lint build\ passed
- merge-tree against current master \4a02e14b\ passed
- local/remote HEAD match; diff-check and worktree are clean
- formatter was not run

Closes #491