### PR TITLE
fix(lint): align no-await-in-loop execution positions

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -231,7 +231,7 @@ Source: [ESLint core rules](https://eslint.org/docs/latest/rules/).
 - [`no-alert`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-alert.ts): rejects `alert`, `confirm`, and `prompt`.
 - [`no-array-constructor`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-array-constructor.ts): rejects `Array` constructor calls.
 - [`no-async-promise-executor`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-async-promise-executor.ts): rejects async Promise executors.
-- [`no-await-in-loop`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-await-in-loop.ts): reject `await` expressions evaluated inside a loop body.
+- [`no-await-in-loop`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-await-in-loop.ts): reject explicit and implicit awaits evaluated in repeated loop positions.
 - [`no-bitwise`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-bitwise.ts): rejects bitwise operators.
 - [`no-caller`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-caller.ts): rejects `arguments.caller` and `arguments.callee`.
 - [`no-case-declarations`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-case-declarations.ts): rejects lexical declarations directly inside `case` clauses.

--- a/packages/lint/linthost/rules_core_extra.go
+++ b/packages/lint/linthost/rules_core_extra.go
@@ -14,75 +14,85 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
 
-// noAwaitInLoop reports an `await` expression evaluated inside the body
-// of a sequential loop (for / while / do-while / for-in / for-of). Each
-// iteration of the loop blocks on the previous one's microtask hop, so
-// the loop body runs strictly serially even when the underlying
-// operations are independent and could overlap with Promise.all.
+// noAwaitInLoop reports explicit and implicit awaits evaluated in a repeated
+// loop position. Initializers and iterable expressions run only once per loop,
+// while tests, updates, bodies, nested for-await statements, and await-using
+// declarations in repeated positions serialize iterations.
 // https://eslint.org/docs/latest/rules/no-await-in-loop
-//
-// `for await … of` loops are exempt — the for-await iterator protocol
-// is the whole reason the loop exists, and rejecting its `await` would
-// just suggest the developer abandon the iterator.
 type noAwaitInLoop struct{}
 
 func (noAwaitInLoop) Name() string { return "no-await-in-loop" }
 func (noAwaitInLoop) Visits() []shimast.Kind {
-  return []shimast.Kind{shimast.KindAwaitExpression}
+  return []shimast.Kind{
+    shimast.KindAwaitExpression,
+    shimast.KindForOfStatement,
+    shimast.KindVariableDeclarationList,
+  }
 }
 func (noAwaitInLoop) Check(ctx *Context, node *shimast.Node) {
-  for cur := node.Parent; cur != nil; cur = cur.Parent {
-    if isFunctionLikeKind(cur) {
-      return
-    }
-    switch cur.Kind {
-    case shimast.KindForStatement,
-      shimast.KindWhileStatement,
-      shimast.KindDoStatement,
-      shimast.KindForInStatement:
-      ctx.Report(node, "Unexpected `await` inside a loop — iterations run sequentially; prefer `Promise.all` when independent.")
-      return
-    case shimast.KindForOfStatement:
-      // `for await … of` loops are exempt by design — the await
-      // is the iteration itself, not a sequential block.
-      if isForAwaitOfStatement(ctx.File, cur) {
-        return
-      }
+  if node == nil || !isAwaitInLoopCandidate(node) {
+    return
+  }
+  child := node
+  for parent := node.Parent; parent != nil && !isAwaitInLoopBoundary(parent); parent = parent.Parent {
+    if isRepeatedLoopPosition(child, parent) {
       ctx.Report(node, "Unexpected `await` inside a loop — iterations run sequentially; prefer `Promise.all` when independent.")
       return
     }
+    child = parent
   }
 }
 
-// isForAwaitOfStatement reports whether the for-of statement at `node`
-// is a `for await … of` (rather than a plain `for … of`). The shim AST
-// does not expose `AwaitModifier` as a typed field, so the check is
-// textual: locate the `for` keyword and look for the `await` keyword
-// in the small window before the opening parenthesis. The width 24
-// covers any reasonable spacing/comment-free header.
-func isForAwaitOfStatement(file *shimast.SourceFile, node *shimast.Node) bool {
-  if file == nil || node == nil {
+func isAwaitInLoopCandidate(node *shimast.Node) bool {
+  switch node.Kind {
+  case shimast.KindAwaitExpression:
+    return true
+  case shimast.KindForOfStatement:
+    statement := node.AsForInOrOfStatement()
+    return statement != nil && statement.AwaitModifier != nil
+  case shimast.KindVariableDeclarationList:
+    return isAwaitUsingDeclarationList(node)
+  default:
     return false
   }
-  forPos := keywordStart(file, node, "for")
-  if forPos < 0 {
+}
+
+func isAwaitInLoopBoundary(node *shimast.Node) bool {
+  if isFunctionLikeKind(node) {
+    return true
+  }
+  if node == nil || node.Kind != shimast.KindForOfStatement {
     return false
   }
-  src := file.Text()
-  limit := forPos + 24
-  if limit > len(src) {
-    limit = len(src)
+  statement := node.AsForInOrOfStatement()
+  return statement != nil && statement.AwaitModifier != nil
+}
+
+func isRepeatedLoopPosition(child, parent *shimast.Node) bool {
+  switch parent.Kind {
+  case shimast.KindForStatement:
+    statement := parent.AsForStatement()
+    return statement != nil &&
+      (child == statement.Condition || child == statement.Incrementor || child == statement.Statement)
+  case shimast.KindForInStatement, shimast.KindForOfStatement:
+    statement := parent.AsForInOrOfStatement()
+    return statement != nil &&
+      (child == statement.Statement ||
+        (child == statement.Initializer && isAwaitUsingDeclarationList(child)))
+  case shimast.KindWhileStatement:
+    statement := parent.AsWhileStatement()
+    return statement != nil && (child == statement.Expression || child == statement.Statement)
+  case shimast.KindDoStatement:
+    statement := parent.AsDoStatement()
+    return statement != nil && (child == statement.Expression || child == statement.Statement)
+  default:
+    return false
   }
-  if node.End() < limit {
-    limit = node.End()
-  }
-  for i := forPos + 3; i < limit; i++ {
-    if src[i] == '(' {
-      limit = i
-      break
-    }
-  }
-  return findKeyword(file, forPos+3, limit, "await") >= 0
+}
+
+func isAwaitUsingDeclarationList(node *shimast.Node) bool {
+  return node != nil && node.Kind == shimast.KindVariableDeclarationList &&
+    shimast.GetCombinedNodeFlags(node)&shimast.NodeFlagsBlockScoped == shimast.NodeFlagsAwaitUsing
 }
 
 // noDupeClassMembers reports two declarations of the same member on a

--- a/packages/lint/linthost/rules_core_extra.go
+++ b/packages/lint/linthost/rules_core_extra.go
@@ -3,7 +3,7 @@
 // hadn't migrated yet.
 //
 // Implemented here:
-//   - no-await-in-loop: await inside a loop body iterates sequentially
+//   - no-await-in-loop: explicit or implicit await in a repeated loop position
 //   - no-dupe-class-members: duplicate class member declarations
 //   - no-this-before-super: `this` (or `super.x`) before `super()` in
 //     derived constructors

--- a/packages/lint/test/rules/control-flow/no_await_in_loop_complete_semantics_test.go
+++ b/packages/lint/test/rules/control-flow/no_await_in_loop_complete_semantics_test.go
@@ -1,0 +1,197 @@
+package linthost
+
+import (
+  "fmt"
+  "sort"
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+const noAwaitInLoopCompleteSource = `declare function initializerValue(): Promise<number>;
+declare function repeatedCondition(): Promise<boolean>;
+declare function repeatedUpdate(): Promise<number>;
+declare function repeatedBody(): Promise<void>;
+declare function objectOnce(): Promise<Record<string, number>>;
+declare function valuesOnce(): Promise<number[]>;
+declare function forInBody(): Promise<void>;
+declare function forOfBody(): Promise<void>;
+declare function whileCondition(): Promise<boolean>;
+declare function doBody(): Promise<void>;
+declare function doCondition(): Promise<boolean>;
+declare function outerCondition(): boolean;
+declare function stream(): AsyncIterable<number>;
+declare function consume(value: unknown): void;
+declare function consumeAsync(value: unknown): Promise<void>;
+declare function makeResource(): any;
+declare function resources(): any[];
+declare function nestedAwait(): Promise<void>;
+declare function arrowAwait(): Promise<void>;
+declare function methodAwait(): Promise<void>;
+
+async function forPositions(): Promise<void> {
+  for (
+    let index = await initializerValue();
+    await repeatedCondition();
+    index = await repeatedUpdate()
+  ) {
+    await repeatedBody();
+    break;
+  }
+}
+
+async function iterablePositions(): Promise<void> {
+  for (const key in await objectOnce()) {
+    consume(key);
+    await forInBody();
+  }
+  for (const value of await valuesOnce()) {
+    consume(value);
+    await forOfBody();
+  }
+}
+
+async function conditionPositions(): Promise<void> {
+  while (await whileCondition()) {
+    break;
+  }
+  do {
+    await doBody();
+  } while (
+    await doCondition()
+  );
+}
+
+async function nestedForAwait(): Promise<void> {
+  while (outerCondition()) {
+    for /* a comment deliberately longer than the former source window */ await (const value of stream()) {
+      consume(value);
+    }
+    break;
+  }
+}
+
+async function intentionalAsyncIteration(): Promise<void> {
+  for /* spacing and comments must not affect typed detection */ await (const value of stream()) {
+    await consumeAsync(value);
+  }
+}
+
+async function resourcePositions(): Promise<void> {
+  for (await using initialResource = makeResource(); false; ) {
+    consume(initialResource);
+  }
+  while (outerCondition()) {
+    await using bodyResource = makeResource();
+    consume(bodyResource);
+    break;
+  }
+  for (await using item of resources()) {
+    consume(item);
+  }
+}
+
+async function scopedBoundaries(): Promise<void> {
+  while (outerCondition()) {
+    async function nested(): Promise<void> {
+      await nestedAwait();
+    }
+    const arrow = async (): Promise<void> => {
+      await arrowAwait();
+    };
+    class Holder {
+      static async load(): Promise<void> {
+        await methodAwait();
+      }
+    }
+    consume(nested);
+    consume(arrow);
+    consume(Holder);
+    break;
+  }
+}
+
+consume({ forPositions, iterablePositions, conditionPositions, nestedForAwait, intentionalAsyncIteration, resourcePositions, scopedBoundaries });
+`
+
+// TestNoAwaitInLoopMatchesExecutionPositionsAndImplicitAwaits verifies the complete ESLint traversal contract.
+//
+// A loop ancestor alone is insufficient: initializers and iterable operands run
+// once, while tests, updates, bodies, nested for-await statements, and await-using
+// declarations in repeated positions are implicit or explicit serialization.
+// Typed AST fields must also recognize for-await through arbitrary comments.
+//
+//  1. Exercise every loop position plus function, method, and for-await boundaries.
+//  2. Assert the native engine reports the exact candidate-node ranges once.
+//  3. Run the real check command and require the same diagnostic count and lines.
+func TestNoAwaitInLoopMatchesExecutionPositionsAndImplicitAwaits(t *testing.T) {
+  nestedForAwaitTarget := `for /* a comment deliberately longer than the former source window */ await (const value of stream()) {
+      consume(value);
+    }`
+  targets := []string{
+    "await repeatedCondition()",
+    "await repeatedUpdate()",
+    "await repeatedBody()",
+    "await forInBody()",
+    "await forOfBody()",
+    "await whileCondition()",
+    "await doBody()",
+    "await doCondition()",
+    nestedForAwaitTarget,
+    "await using bodyResource = makeResource()",
+    "await using item",
+  }
+  type expectedRange struct {
+    pos    int
+    end    int
+    target string
+  }
+  expected := make([]expectedRange, 0, len(targets))
+  for _, target := range targets {
+    if count := strings.Count(noAwaitInLoopCompleteSource, target); count != 1 {
+      t.Fatalf("target %q occurs %d times", target, count)
+    }
+    pos := strings.Index(noAwaitInLoopCompleteSource, target)
+    expected = append(expected, expectedRange{pos: pos, end: pos + len(target), target: target})
+  }
+  sort.Slice(expected, func(i, j int) bool { return expected[i].pos < expected[j].pos })
+
+  file := parseTS(t, noAwaitInLoopCompleteSource)
+  findings := NewEngine(RuleConfig{"no-await-in-loop": SeverityError}).Run([]*shimast.SourceFile{file}, nil)
+  sort.Slice(findings, func(i, j int) bool { return findings[i].Pos < findings[j].Pos })
+  if len(findings) != len(expected) {
+    t.Fatalf("want %d findings, got %d: %+v", len(expected), len(findings), findings)
+  }
+  const message = "Unexpected `await` inside a loop — iterations run sequentially; prefer `Promise.all` when independent."
+  for index, finding := range findings {
+    want := expected[index]
+    if finding.Pos != want.pos || finding.End != want.end || finding.Message != message {
+      target := ""
+      if finding.Pos >= 0 && finding.End >= finding.Pos && finding.End <= len(noAwaitInLoopCompleteSource) {
+        target = noAwaitInLoopCompleteSource[finding.Pos:finding.End]
+      }
+      t.Fatalf("finding %d: want [%d,%d) %q, got [%d,%d) %q message=%q",
+        index, want.pos, want.end, want.target, finding.Pos, finding.End, target, finding.Message)
+    }
+  }
+
+  root := seedLintProject(t, noAwaitInLoopCompleteSource)
+  seedLintRules(t, root, map[string]string{"no-await-in-loop": "error"})
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{"check", "--cwd", root, "--plugins-json", lintManifest(t)})
+  })
+  if code != 2 || stdout != "" {
+    t.Fatalf("command result mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  if count := strings.Count(stderr, "[no-await-in-loop]"); count != len(expected) {
+    t.Fatalf("want %d command diagnostics, got %d: %s", len(expected), count, stderr)
+  }
+  for _, want := range expected {
+    line := strings.Count(noAwaitInLoopCompleteSource[:want.pos], "\n") + 1
+    location := fmt.Sprintf("main.ts:%d:", line)
+    if !diagnosticOutputContains(stderr, location) {
+      t.Fatalf("missing command diagnostic at %s for %q: %s", location, want.target, stderr)
+    }
+  }
+}

--- a/packages/lint/test/rules/control-flow/no_await_in_loop_complete_semantics_test.go
+++ b/packages/lint/test/rules/control-flow/no_await_in_loop_complete_semantics_test.go
@@ -66,7 +66,7 @@ async function conditionPositions(): Promise<void> {
 async function nestedForAwait(): Promise<void> {
   while (outerCondition()) {
     for /* a comment deliberately longer than the former source window */ await (const value of stream()) {
-      consume(value);
+      await consumeAsync(value);
     }
     break;
   }
@@ -127,7 +127,7 @@ consume({ forPositions, iterablePositions, conditionPositions, nestedForAwait, i
 //  3. Run the real check command and require the same diagnostic count and lines.
 func TestNoAwaitInLoopMatchesExecutionPositionsAndImplicitAwaits(t *testing.T) {
   nestedForAwaitTarget := `for /* a comment deliberately longer than the former source window */ await (const value of stream()) {
-      consume(value);
+      await consumeAsync(value);
     }`
   targets := []string{
     "await repeatedCondition()",

--- a/packages/lint/test/rules/control-flow/no_await_in_loop_test.go
+++ b/packages/lint/test/rules/control-flow/no_await_in_loop_test.go
@@ -5,9 +5,8 @@ import "testing"
 // TestRuleCorpusNoAwaitInLoop verifies the lint rule corpus fixture
 // no-await-in-loop.ts.
 //
-// The rule walks up from an `await` expression to find the nearest
-// enclosing loop, stopping at function-like boundaries. `for await … of`
-// loops are exempt by design — the awaited iterator IS the loop.
+// The rule walks from each explicit or implicit await through repeated loop
+// positions, stopping at function-like and intentional for-await boundaries.
 //
 // 1. Load the annotated TypeScript source embedded below.
 // 2. Enable the rule severity declared by its `// expect:` comment.

--- a/tests/test-lint/src/cases/no-await-in-loop.ts
+++ b/tests/test-lint/src/cases/no-await-in-loop.ts
@@ -1,5 +1,10 @@
 declare function getPromise(): Promise<number>;
 declare function getAsyncIterator(): AsyncIterableIterator<number>;
+declare function getObject(): Promise<Record<string, number>>;
+declare function getValues(): Promise<number[]>;
+declare function getResource(): any;
+declare function getResources(): any[];
+declare function shouldContinue(): boolean;
 
 // Positive: await inside `for` loop body.
 async function inForLoop(): Promise<number> {
@@ -59,6 +64,85 @@ async function nestedClosureInsideLoop(): Promise<void> {
   }
 }
 
+// A `for` initializer runs once, while its test, update, and body repeat.
+async function inForPositions(): Promise<void> {
+  for (
+    let index = await getPromise();
+    // expect: no-await-in-loop error
+    await getPromise();
+    // expect: no-await-in-loop error
+    index = await getPromise()
+  ) {
+    // expect: no-await-in-loop error
+    await getPromise();
+    break;
+  }
+}
+
+// The enumerable/iterable operand runs once; only the bodies repeat.
+async function inIterablePositions(): Promise<void> {
+  for (const key in await getObject()) {
+    JSON.stringify(key);
+    // expect: no-await-in-loop error
+    await getPromise();
+  }
+  for (const value of await getValues()) {
+    JSON.stringify(value);
+    // expect: no-await-in-loop error
+    await getPromise();
+  }
+}
+
+// A nested for-await statement is an implicit await of every outer iteration.
+async function nestedForAwait(): Promise<void> {
+  while (shouldContinue()) {
+    // expect: no-await-in-loop error
+    for /* comments can exceed the former source-text window */ await (const value of getAsyncIterator()) {
+      JSON.stringify(value);
+    }
+    break;
+  }
+}
+
+// The same spelling at a function boundary is intentional async iteration.
+async function typedForAwaitBoundary(): Promise<void> {
+  for /* comments and spacing do not affect the typed modifier */ await (const value of getAsyncIterator()) {
+    await Promise.resolve(value);
+  }
+}
+
+// Await-using is implicit await. A for initializer is single-shot, while a
+// loop body and an await-using for-of binding repeat.
+async function awaitUsingPositions(): Promise<void> {
+  for (await using initialResource = getResource(); false; ) {
+    JSON.stringify(initialResource);
+  }
+  while (shouldContinue()) {
+    // expect: no-await-in-loop error
+    await using bodyResource = getResource();
+    JSON.stringify(bodyResource);
+    break;
+  }
+  // expect: no-await-in-loop error
+  for (await using resource of getResources()) {
+    JSON.stringify(resource);
+  }
+}
+
+// Function and static method bodies establish independent execution scopes.
+async function functionAndClassBoundaries(): Promise<void> {
+  while (shouldContinue()) {
+    const nested = async (): Promise<number> => await getPromise();
+    class Holder {
+      static async load(): Promise<number> {
+        return await getPromise();
+      }
+    }
+    JSON.stringify({ nested, Holder });
+    break;
+  }
+}
+
 JSON.stringify({
   inForLoop,
   inWhileLoop,
@@ -66,4 +150,10 @@ JSON.stringify({
   inForAwaitOfLoop,
   awaitNotInLoop,
   nestedClosureInsideLoop,
+  inForPositions,
+  inIterablePositions,
+  nestedForAwait,
+  typedForAwaitBoundary,
+  awaitUsingPositions,
+  functionAndClassBoundaries,
 });

--- a/tests/test-lint/src/cases/no-await-in-loop.ts
+++ b/tests/test-lint/src/cases/no-await-in-loop.ts
@@ -98,7 +98,7 @@ async function nestedForAwait(): Promise<void> {
   while (shouldContinue()) {
     // expect: no-await-in-loop error
     for /* comments can exceed the former source-text window */ await (const value of getAsyncIterator()) {
-      JSON.stringify(value);
+      await Promise.resolve(value);
     }
     break;
   }

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -23,7 +23,7 @@ Examples come from the checked [lint corpus](https://github.com/samchon/ttsc/tre
 - [`no-alert`](#rule-no-alert): Reject calls to `alert`, `confirm`, and `prompt`.
 - [`no-array-constructor`](#rule-no-array-constructor): Reject `Array(...)` and `new Array(...)` constructor calls.
 - [`no-async-promise-executor`](#rule-no-async-promise-executor): Reject `new Promise(async (resolve, reject) => { ... })`.
-- [`no-await-in-loop`](#rule-no-await-in-loop): Reject `await` expressions evaluated inside a loop body.
+- [`no-await-in-loop`](#rule-no-await-in-loop): Reject explicit and implicit awaits evaluated in repeated loop positions.
 - [`no-bitwise`](#rule-no-bitwise): Reject bitwise operators.
 - [`no-caller`](#rule-no-caller): Reject `arguments.caller` and `arguments.callee`, both deprecated properties forbidden in strict mode.
 - [`no-case-declarations`](#rule-no-case-declarations): Reject lexical declarations inside `case` or `default` clauses.
@@ -755,11 +755,11 @@ new Promise(async (resolve) => {
 
 ### `no-await-in-loop`
 
-Reject `await` expressions evaluated inside a loop body.
+Reject explicit `await` expressions and implicit awaits from `for await ... of` or `await using` when they execute in a repeated loop position. A `for` initializer and the right-hand side of `for...in` or `for...of` run once and are allowed; loop tests, updates, and bodies repeat and are checked.
 
 The loop runs strictly serially because each iteration blocks on the previous one's microtask hop; when the operations are independent the equivalent `Promise.all([...])` is dramatically faster.
 
-The rule intentionally exempts `for await ... of` because the awaitable iterator is the loop's whole reason for existing.
+The rule treats a `for await ... of` as a boundary for its own body because asynchronous iteration is intentional. The same statement is reported when nested in an ordinary loop, where creating and consuming the async iterator becomes part of each outer iteration.
 
 Example:
 


### PR DESCRIPTION
## Intent

Align `no-await-in-loop` with ESLint's execution-position model so single-shot loop operands remain clean while every explicit or implicit await repeated by a loop is reported.

## Scope

- replace the ancestor-only scan with the upstream candidate, boundary, and repeated-position traversal
- use typed TypeScript-Go `AwaitModifier` and `NodeFlagsAwaitUsing` surfaces instead of source-text keyword windows
- visit explicit await expressions, async for-of statements, and await-using declaration lists
- preserve function, method, and intentional for-await boundaries
- add exact-range and real check-command coverage for all loop positions, implicit awaits, comments/spacing, and negative twins
- expand the public corpus and correct README/website behavior descriptions

## Test plan

Per the delivery workflow, local runtime validation follows three sequential exhaustive exact-HEAD reviews. Planned verification: focused native Go regression, real TypeScript lint corpus, `@ttsc/lint` build, and diff integrity. No formatter will be run.

Closes #475