### PR TITLE
feat(lint): implement boundaries/dependencies policy enforcement

### DIFF
--- a/packages/lint/linthost/rules_boundaries.go
+++ b/packages/lint/linthost/rules_boundaries.go
@@ -18,17 +18,6 @@ type boundariesEntryPoint struct{}
 type boundariesNoPrivate struct{}
 type boundariesNoUnknown struct{}
 
-// boundariesDependencies is a v1 stub for the upstream unified
-// `boundaries/dependencies` rule, which replaces the legacy
-// `element-types` / `entry-point` / `external` / `no-private` /
-// `no-unknown` rules with a single direction-aware policy block.
-//
-// The native engine accepts the same `elements` + `rules` config shape so
-// projects can claim the rule id today, but the full direction
-// validation is deferred. Until then this rule registers, decodes
-// options without crashing, and emits no diagnostics.
-type boundariesDependencies struct{}
-
 func (boundariesElementTypes) Name() string { return "boundaries/element-types" }
 func (boundariesExternal) Name() string     { return "boundaries/external" }
 func (boundariesEntryPoint) Name() string   { return "boundaries/entry-point" }
@@ -42,15 +31,6 @@ func (boundariesEntryPoint) Visits() []shimast.Kind   { return []shimast.Kind{sh
 func (boundariesNoPrivate) Visits() []shimast.Kind    { return []shimast.Kind{shimast.KindSourceFile} }
 func (boundariesNoUnknown) Visits() []shimast.Kind    { return []shimast.Kind{shimast.KindSourceFile} }
 func (boundariesDependencies) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSourceFile} }
-
-// Check is intentionally a no-op for the v1 stub. The rule accepts the
-// upstream config shape via the shared `boundariesOptions` decoder so
-// downstream configs type-check and load, then exits without reporting
-// findings. Replace this body when the unified direction validation
-// lands.
-func (boundariesDependencies) Check(ctx *Context, node *shimast.Node) {
-  _ = decodeBoundariesOptions(ctx)
-}
 
 func (boundariesElementTypes) Check(ctx *Context, node *shimast.Node) {
   opts := decodeBoundariesOptions(ctx)
@@ -239,6 +219,9 @@ type boundaryDependency struct {
   node      *shimast.Node
   specifier string
   relative  bool
+  kind      string
+  nodeKind  string
+  specifiers []string
 }
 
 func decodeBoundariesOptions(ctx *Context) boundariesOptions {
@@ -251,6 +234,19 @@ func decodeBoundariesOptions(ctx *Context) boundariesOptions {
 
 func collectBoundaryDependencies(node *shimast.Node) []boundaryDependency {
   out := []boundaryDependency{}
+  appendDependency := func(sourceNode *shimast.Node, specifier, kind, nodeKind string, specifiers []string) {
+    if sourceNode == nil || specifier == "" {
+      return
+    }
+    out = append(out, boundaryDependency{
+      node:       sourceNode,
+      specifier:  specifier,
+      relative:   isRelativeBoundarySpecifier(specifier),
+      kind:       kind,
+      nodeKind:   nodeKind,
+      specifiers: specifiers,
+    })
+  }
   var walk func(*shimast.Node)
   walk = func(n *shimast.Node) {
     if n == nil {
@@ -260,25 +256,73 @@ func collectBoundaryDependencies(node *shimast.Node) []boundaryDependency {
     case shimast.KindImportDeclaration:
       if imp := n.AsImportDeclaration(); imp != nil && imp.ModuleSpecifier != nil {
         specifier := stringLiteralText(imp.ModuleSpecifier)
-        if specifier != "" {
-          out = append(out, boundaryDependency{
-            node:      imp.ModuleSpecifier,
-            specifier: specifier,
-            relative:  isRelativeBoundarySpecifier(specifier),
-          })
-        }
+        names, typeOnly := noRestrictedImportsImportNames(imp)
+        appendDependency(
+          imp.ModuleSpecifier,
+          specifier,
+          boundaryDependencyKind(typeOnly, false),
+          "ImportDeclaration",
+          boundaryImportedNames(names),
+        )
       }
     case shimast.KindExportDeclaration:
       if exp := n.AsExportDeclaration(); exp != nil && exp.ModuleSpecifier != nil {
         specifier := stringLiteralText(exp.ModuleSpecifier)
-        if specifier != "" {
-          out = append(out, boundaryDependency{
-            node:      exp.ModuleSpecifier,
-            specifier: specifier,
-            relative:  isRelativeBoundarySpecifier(specifier),
-          })
+        names, typeOnly := noRestrictedImportsExportNames(nil, n, exp)
+        appendDependency(
+          exp.ModuleSpecifier,
+          specifier,
+          boundaryDependencyKind(typeOnly, false),
+          "ExportDeclaration",
+          boundaryImportedNames(names),
+        )
+      }
+    case shimast.KindImportEqualsDeclaration:
+      declaration := n.AsImportEqualsDeclaration()
+      if declaration != nil && declaration.ModuleReference != nil &&
+        declaration.ModuleReference.Kind == shimast.KindExternalModuleReference {
+        module := declaration.ModuleReference.AsExternalModuleReference()
+        if module != nil && module.Expression != nil {
+          appendDependency(
+            module.Expression,
+            stringLiteralText(module.Expression),
+            boundaryDependencyKind(declaration.IsTypeOnly, false),
+            "ImportEqualsDeclaration",
+            nil,
+          )
         }
       }
+    case shimast.KindCallExpression:
+      call := n.AsCallExpression()
+      if call == nil || call.Expression == nil || call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
+        break
+      }
+      argument := call.Arguments.Nodes[0]
+      if argument == nil {
+        break
+      }
+      switch {
+      case call.Expression.Kind == shimast.KindImportKeyword:
+        appendDependency(argument, stringLiteralText(argument), "value", "ImportCall", nil)
+      case identifierText(call.Expression) == "require":
+        appendDependency(argument, stringLiteralText(argument), "value", "RequireCall", nil)
+      }
+    case shimast.KindImportType:
+      imported := n.AsImportTypeNode()
+      if imported == nil || imported.Argument == nil || imported.Argument.Kind != shimast.KindLiteralType {
+        break
+      }
+      literalType := imported.Argument.AsLiteralTypeNode()
+      if literalType == nil || literalType.Literal == nil {
+        break
+      }
+      appendDependency(
+        literalType.Literal,
+        stringLiteralText(literalType.Literal),
+        boundaryDependencyKind(false, imported.IsTypeOf),
+        "ImportType",
+        nil,
+      )
     }
     n.ForEachChild(func(child *shimast.Node) bool {
       walk(child)
@@ -287,6 +331,26 @@ func collectBoundaryDependencies(node *shimast.Node) []boundaryDependency {
   }
   walk(node)
   return out
+}
+
+func boundaryDependencyKind(typeOnly, typeOf bool) string {
+  if typeOf {
+    return "typeof"
+  }
+  if typeOnly {
+    return "type"
+  }
+  return "value"
+}
+
+func boundaryImportedNames(names []noRestrictedImportsImportedName) []string {
+  out := make([]string, 0, len(names))
+  for _, name := range names {
+    if name.name != "" {
+      out = append(out, name.name)
+    }
+  }
+  return uniqueBoundaryStrings(out)
 }
 
 func classifyBoundaryFile(fileName string, elements []boundaryElement) *boundaryFile {
@@ -357,10 +421,10 @@ func resolveBoundaryImport(sourceFileName, specifier string) (string, bool) {
   target := filepath.Clean(filepath.Join(base, filepath.FromSlash(specifier)))
   candidates := []string{target}
   if filepath.Ext(target) == "" {
-    for _, ext := range []string{".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"} {
+    for _, ext := range []string{".ts", ".tsx", ".mts", ".cts", ".d.ts", ".d.mts", ".d.cts", ".js", ".jsx", ".mjs", ".cjs"} {
       candidates = append(candidates, target+ext)
     }
-    for _, ext := range []string{".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"} {
+    for _, ext := range []string{".ts", ".tsx", ".mts", ".cts", ".d.ts", ".d.mts", ".d.cts", ".js", ".jsx", ".mjs", ".cjs"} {
       candidates = append(candidates, filepath.Join(target, "index"+ext))
     }
   }
@@ -499,6 +563,7 @@ func boundaryDisplayPath(path string) string {
 }
 
 func normalizeBoundaryPath(path string) string {
+  path = strings.ReplaceAll(path, `\`, "/")
   return filepath.ToSlash(filepath.Clean(path))
 }
 

--- a/packages/lint/linthost/rules_boundaries.go
+++ b/packages/lint/linthost/rules_boundaries.go
@@ -216,11 +216,11 @@ type boundaryFile struct {
 }
 
 type boundaryDependency struct {
-  node      *shimast.Node
-  specifier string
-  relative  bool
-  kind      string
-  nodeKind  string
+  node       *shimast.Node
+  specifier  string
+  relative   bool
+  kind       string
+  nodeKind   string
   specifiers []string
 }
 
@@ -233,6 +233,14 @@ func decodeBoundariesOptions(ctx *Context) boundariesOptions {
 }
 
 func collectBoundaryDependencies(node *shimast.Node) []boundaryDependency {
+  return collectBoundaryDependenciesWithSyntax(node, false)
+}
+
+func collectBoundaryPolicyDependencies(node *shimast.Node) []boundaryDependency {
+  return collectBoundaryDependenciesWithSyntax(node, true)
+}
+
+func collectBoundaryDependenciesWithSyntax(node *shimast.Node, extended bool) []boundaryDependency {
   out := []boundaryDependency{}
   appendDependency := func(sourceNode *shimast.Node, specifier, kind, nodeKind string, specifiers []string) {
     if sourceNode == nil || specifier == "" {
@@ -278,6 +286,9 @@ func collectBoundaryDependencies(node *shimast.Node) []boundaryDependency {
         )
       }
     case shimast.KindImportEqualsDeclaration:
+      if !extended {
+        break
+      }
       declaration := n.AsImportEqualsDeclaration()
       if declaration != nil && declaration.ModuleReference != nil &&
         declaration.ModuleReference.Kind == shimast.KindExternalModuleReference {
@@ -293,6 +304,9 @@ func collectBoundaryDependencies(node *shimast.Node) []boundaryDependency {
         }
       }
     case shimast.KindCallExpression:
+      if !extended {
+        break
+      }
       call := n.AsCallExpression()
       if call == nil || call.Expression == nil || call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
         break
@@ -308,6 +322,9 @@ func collectBoundaryDependencies(node *shimast.Node) []boundaryDependency {
         appendDependency(argument, stringLiteralText(argument), "value", "RequireCall", nil)
       }
     case shimast.KindImportType:
+      if !extended {
+        break
+      }
       imported := n.AsImportTypeNode()
       if imported == nil || imported.Argument == nil || imported.Argument.Kind != shimast.KindLiteralType {
         break
@@ -319,7 +336,10 @@ func collectBoundaryDependencies(node *shimast.Node) []boundaryDependency {
       appendDependency(
         literalType.Literal,
         stringLiteralText(literalType.Literal),
-        boundaryDependencyKind(false, imported.IsTypeOf),
+        // An `import("m")` node in type position resolves types only, so it
+        // is a `type` dependency; the `typeof import("m")` flavor queries the
+        // module's value shape and keeps the dedicated `typeof` kind.
+        boundaryDependencyKind(true, imported.IsTypeOf),
         "ImportType",
         nil,
       )

--- a/packages/lint/linthost/rules_boundaries_dependencies.go
+++ b/packages/lint/linthost/rules_boundaries_dependencies.go
@@ -47,13 +47,13 @@ type boundaryDependenciesPolicy struct {
 }
 
 type boundaryDependenciesEntitySelector struct {
-  Types    boundaryStringList
-  Origins  boundaryStringList
-  Sources  boundaryStringList
-  Paths    boundaryStringList
-  Entry    *bool
-  Private  *bool
-  Unknown  *bool
+  Types   boundaryStringList
+  Origins boundaryStringList
+  Sources boundaryStringList
+  Paths   boundaryStringList
+  Entry   *bool
+  Private *bool
+  Unknown *bool
 }
 
 type boundaryDependenciesInfoSelector struct {
@@ -70,14 +70,13 @@ type boundaryDependenciesSelector struct {
 }
 
 type boundaryDependenciesEntity struct {
-  Type       string
-  Origin     string
-  Source     string
-  Path       string
-  Entry      bool
-  Private    bool
-  Unknown    bool
-  boundary   *boundaryFile
+  Type    string
+  Origin  string
+  Source  string
+  Path    string
+  Entry   bool
+  Private bool
+  Unknown bool
 }
 
 type boundaryDependenciesDescription struct {
@@ -113,7 +112,7 @@ func (boundariesDependencies) Check(ctx *Context, node *shimast.Node) {
     return
   }
 
-  for _, dependency := range collectBoundaryDependencies(node) {
+  for _, dependency := range collectBoundaryPolicyDependencies(node) {
     if boundaryDependenciesShadowedRequire(ctx, dependency) {
       continue
     }
@@ -206,11 +205,13 @@ func parseBoundaryDependenciesOptions(raw json.RawMessage) (boundaryDependencies
   if hasPolicies && hasRules {
     return options, fmt.Errorf("options %q and %q cannot be combined", "policies", "rules")
   }
+  policiesKey := "policies"
   if !hasPolicies {
     policiesRaw = rulesRaw
+    policiesKey = "rules"
   }
   if hasPolicies || hasRules {
-    options.Policies, err = parseBoundaryDependenciesPolicies(policiesRaw)
+    options.Policies, err = parseBoundaryDependenciesPolicies(policiesRaw, policiesKey)
     if err != nil {
       return options, err
     }
@@ -265,14 +266,14 @@ func parseBoundaryDependenciesElements(raw json.RawMessage) ([]boundaryElement, 
   return elements, nil
 }
 
-func parseBoundaryDependenciesPolicies(raw json.RawMessage) ([]boundaryDependenciesPolicy, error) {
-  entries, err := boundaryDependenciesArray(raw, "policies")
+func parseBoundaryDependenciesPolicies(raw json.RawMessage, key string) ([]boundaryDependenciesPolicy, error) {
+  entries, err := boundaryDependenciesArray(raw, key)
   if err != nil {
     return nil, err
   }
   policies := make([]boundaryDependenciesPolicy, 0, len(entries))
   for index, entry := range entries {
-    policy, err := parseBoundaryDependenciesPolicy(entry, index)
+    policy, err := parseBoundaryDependenciesPolicy(entry, fmt.Sprintf("%s[%d]", key, index))
     if err != nil {
       return nil, err
     }
@@ -281,9 +282,8 @@ func parseBoundaryDependenciesPolicies(raw json.RawMessage) ([]boundaryDependenc
   return policies, nil
 }
 
-func parseBoundaryDependenciesPolicy(raw json.RawMessage, index int) (boundaryDependenciesPolicy, error) {
+func parseBoundaryDependenciesPolicy(raw json.RawMessage, path string) (boundaryDependenciesPolicy, error) {
   var policy boundaryDependenciesPolicy
-  path := fmt.Sprintf("policies[%d]", index)
   fields, err := boundaryDependenciesObject(raw, path)
   if err != nil {
     return policy, err
@@ -318,14 +318,15 @@ func parseBoundaryDependenciesPolicy(raw json.RawMessage, index int) (boundaryDe
       return policy, err
     }
   }
+  _, hasFrom := fields["from"]
   if value, present := fields["allow"]; present {
-    policy.Allow, err = parseBoundaryDependenciesEffect(value, path+".allow")
+    policy.Allow, err = parseBoundaryDependenciesEffect(value, path+".allow", hasFrom)
     if err != nil {
       return policy, err
     }
   }
   if value, present := fields["disallow"]; present {
-    policy.Disallow, err = parseBoundaryDependenciesEffect(value, path+".disallow")
+    policy.Disallow, err = parseBoundaryDependenciesEffect(value, path+".disallow", hasFrom)
     if err != nil {
       return policy, err
     }
@@ -514,7 +515,7 @@ func parseBoundaryDependenciesInfoSelectors(raw json.RawMessage, path string) ([
   return []boundaryDependenciesInfoSelector{selector}, nil
 }
 
-func parseBoundaryDependenciesEffect(raw json.RawMessage, path string) ([]boundaryDependenciesSelector, error) {
+func parseBoundaryDependenciesEffect(raw json.RawMessage, path string, targetsDestination bool) ([]boundaryDependenciesSelector, error) {
   raw = bytes.TrimSpace(raw)
   if len(raw) == 0 {
     return nil, fmt.Errorf("%s must be a selector", path)
@@ -529,7 +530,7 @@ func parseBoundaryDependenciesEffect(raw json.RawMessage, path string) ([]bounda
     }
     selectors := make([]boundaryDependenciesSelector, 0, len(entries))
     for index, entry := range entries {
-      parsed, err := parseBoundaryDependenciesEffect(entry, fmt.Sprintf("%s[%d]", path, index))
+      parsed, err := parseBoundaryDependenciesEffect(entry, fmt.Sprintf("%s[%d]", path, index), targetsDestination)
       if err != nil {
         return nil, err
       }
@@ -577,7 +578,13 @@ func parseBoundaryDependenciesEffect(raw json.RawMessage, path string) ([]bounda
   }
   selectors := make([]boundaryDependenciesSelector, 0, len(entities))
   for _, entity := range entities {
-    selectors = append(selectors, boundaryDependenciesSelector{To: []boundaryDependenciesEntitySelector{entity}})
+    selector := boundaryDependenciesSelector{}
+    if targetsDestination {
+      selector.To = []boundaryDependenciesEntitySelector{entity}
+    } else {
+      selector.From = []boundaryDependenciesEntitySelector{entity}
+    }
+    selectors = append(selectors, selector)
   }
   return selectors, nil
 }
@@ -607,10 +614,7 @@ func describeBoundaryDependency(
     }
   }
 
-  origin := "external"
-  if strings.HasPrefix(dependency.specifier, "node:") {
-    origin = "core"
-  }
+  origin := boundaryDependenciesOrigin(dependency.specifier)
   return boundaryDependenciesDescription{
     From: from,
     To: boundaryDependenciesEntity{
@@ -627,7 +631,6 @@ func boundaryDependenciesEntityFromFile(file *boundaryFile, path, origin string)
     Origin: origin,
     Source: normalizeBoundaryPath(path),
     Path:   boundaryDisplayPath(path),
-    boundary: file,
   }
   if file == nil {
     return entity
@@ -685,9 +688,19 @@ func boundaryDependenciesProjectLocalPath(root, path string) bool {
 }
 
 func boundaryDependenciesPathHasSegment(path, segment string) bool {
-  normalized := strings.ToLower(filepath.ToSlash(filepath.Clean(path)))
+  normalized := strings.ToLower(normalizeBoundaryPath(path))
   segment = "/" + strings.ToLower(strings.Trim(segment, "/")) + "/"
   return strings.Contains("/"+strings.Trim(normalized, "/")+"/", segment)
+}
+
+func boundaryDependenciesOrigin(specifier string) string {
+  if strings.HasPrefix(specifier, "node:") {
+    return "core"
+  }
+  if _, ok := unicornPreferNodeProtocolBuiltins[specifier]; ok {
+    return "core"
+  }
+  return "external"
 }
 
 func boundaryDependenciesShadowedRequire(ctx *Context, dependency boundaryDependency) bool {

--- a/packages/lint/linthost/rules_boundaries_dependencies.go
+++ b/packages/lint/linthost/rules_boundaries_dependencies.go
@@ -1,0 +1,1000 @@
+// boundaries/dependencies is the unified, direction-aware boundary policy.
+// It keeps the repository's project-local element declarations while following
+// upstream's policy order: the last matching policy wins, and a disallow match
+// takes precedence over allow within one policy. String selectors remain the
+// shorthand for element types; object selectors add origin, source, path,
+// entry/private/unknown state, and dependency metadata without coupling the
+// rule to a particular repository layout.
+//
+// Module targets come from the TypeScript checker when available. That makes
+// tsconfig path aliases and re-exports classify by their resolved source file,
+// while the filesystem resolver remains the AST-only fallback used by the
+// legacy boundary rules and focused tests.
+// https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/packages/website/docs/rules/dependencies.md
+package linthost
+
+import (
+  "bytes"
+  "encoding/json"
+  "fmt"
+  "path/filepath"
+  "sort"
+  "strings"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+type boundariesDependencies struct{}
+
+type boundaryDependenciesOptions struct {
+  Elements           []boundaryElement
+  Policies           []boundaryDependenciesPolicy
+  Default            string
+  Message            string
+  CheckAllOrigins    bool
+  CheckUnknownLocals bool
+  CheckInternals     bool
+}
+
+type boundaryDependenciesPolicy struct {
+  From       []boundaryDependenciesEntitySelector
+  To         []boundaryDependenciesEntitySelector
+  Dependency []boundaryDependenciesInfoSelector
+  Allow      []boundaryDependenciesSelector
+  Disallow   []boundaryDependenciesSelector
+  ImportKind string
+  Message    string
+}
+
+type boundaryDependenciesEntitySelector struct {
+  Types    boundaryStringList
+  Origins  boundaryStringList
+  Sources  boundaryStringList
+  Paths    boundaryStringList
+  Entry    *bool
+  Private  *bool
+  Unknown  *bool
+}
+
+type boundaryDependenciesInfoSelector struct {
+  Kinds      boundaryStringList
+  Sources    boundaryStringList
+  NodeKinds  boundaryStringList
+  Specifiers boundaryStringList
+}
+
+type boundaryDependenciesSelector struct {
+  From       []boundaryDependenciesEntitySelector
+  To         []boundaryDependenciesEntitySelector
+  Dependency []boundaryDependenciesInfoSelector
+}
+
+type boundaryDependenciesEntity struct {
+  Type       string
+  Origin     string
+  Source     string
+  Path       string
+  Entry      bool
+  Private    bool
+  Unknown    bool
+  boundary   *boundaryFile
+}
+
+type boundaryDependenciesDescription struct {
+  From       boundaryDependenciesEntity
+  To         boundaryDependenciesEntity
+  Dependency boundaryDependency
+  Internal   bool
+}
+
+type boundaryDependenciesEvaluation struct {
+  allowed     bool
+  policyIndex int
+  policy      *boundaryDependenciesPolicy
+}
+
+func (boundariesDependencies) NeedsTypeChecker() bool { return true }
+
+func (boundariesDependencies) ValidateOptions(raw json.RawMessage) error {
+  _, err := parseBoundaryDependenciesOptions(raw)
+  return err
+}
+
+func (boundariesDependencies) Check(ctx *Context, node *shimast.Node) {
+  if ctx == nil || ctx.File == nil || node == nil {
+    return
+  }
+  options, err := parseBoundaryDependenciesOptions(ctx.Options)
+  if err != nil {
+    return
+  }
+  source := classifyBoundaryFile(ctx.File.FileName(), options.Elements)
+  if source == nil {
+    return
+  }
+
+  for _, dependency := range collectBoundaryDependencies(node) {
+    if boundaryDependenciesShadowedRequire(ctx, dependency) {
+      continue
+    }
+    description := describeBoundaryDependency(ctx, options, source, dependency)
+    if description.To.Origin != "local" && !options.CheckAllOrigins {
+      continue
+    }
+    if description.To.Origin == "local" && description.To.Unknown && !options.CheckUnknownLocals {
+      continue
+    }
+    if description.Internal && !options.CheckInternals {
+      continue
+    }
+
+    evaluation := evaluateBoundaryDependencies(options, description)
+    if evaluation.allowed {
+      continue
+    }
+    message := boundaryDependenciesMessage(options, description, evaluation)
+    reportBoundaryDependency(ctx, dependency, message)
+  }
+}
+
+func parseBoundaryDependenciesOptions(raw json.RawMessage) (boundaryDependenciesOptions, error) {
+  options := boundaryDependenciesOptions{Default: "disallow"}
+  raw = bytes.TrimSpace(raw)
+  if len(raw) == 0 {
+    return options, nil
+  }
+  fields, err := boundaryDependenciesObject(raw, "options")
+  if err != nil {
+    return options, err
+  }
+  if err := boundaryDependenciesRejectUnknown(
+    fields,
+    "elements",
+    "policies",
+    "rules",
+    "default",
+    "message",
+    "checkAllOrigins",
+    "checkUnknownLocals",
+    "checkInternals",
+  ); err != nil {
+    return options, err
+  }
+
+  if value, present := fields["default"]; present {
+    options.Default, err = boundaryDependenciesString(value, "default")
+    if err != nil {
+      return options, err
+    }
+    if options.Default != "allow" && options.Default != "disallow" {
+      return options, fmt.Errorf("option %q must be %q or %q", "default", "allow", "disallow")
+    }
+  }
+  if value, present := fields["message"]; present {
+    options.Message, err = boundaryDependenciesString(value, "message")
+    if err != nil {
+      return options, err
+    }
+  }
+  if value, present := fields["checkAllOrigins"]; present {
+    options.CheckAllOrigins, err = boundaryDependenciesBool(value, "checkAllOrigins")
+    if err != nil {
+      return options, err
+    }
+  }
+  if value, present := fields["checkUnknownLocals"]; present {
+    options.CheckUnknownLocals, err = boundaryDependenciesBool(value, "checkUnknownLocals")
+    if err != nil {
+      return options, err
+    }
+  }
+  if value, present := fields["checkInternals"]; present {
+    options.CheckInternals, err = boundaryDependenciesBool(value, "checkInternals")
+    if err != nil {
+      return options, err
+    }
+  }
+  if value, present := fields["elements"]; present {
+    options.Elements, err = parseBoundaryDependenciesElements(value)
+    if err != nil {
+      return options, err
+    }
+  }
+
+  policiesRaw, hasPolicies := fields["policies"]
+  rulesRaw, hasRules := fields["rules"]
+  if hasPolicies && hasRules {
+    return options, fmt.Errorf("options %q and %q cannot be combined", "policies", "rules")
+  }
+  if !hasPolicies {
+    policiesRaw = rulesRaw
+  }
+  if hasPolicies || hasRules {
+    options.Policies, err = parseBoundaryDependenciesPolicies(policiesRaw)
+    if err != nil {
+      return options, err
+    }
+  }
+  return options, nil
+}
+
+func parseBoundaryDependenciesElements(raw json.RawMessage) ([]boundaryElement, error) {
+  entries, err := boundaryDependenciesArray(raw, "elements")
+  if err != nil {
+    return nil, err
+  }
+  elements := make([]boundaryElement, 0, len(entries))
+  for index, entry := range entries {
+    path := fmt.Sprintf("elements[%d]", index)
+    fields, err := boundaryDependenciesObject(entry, path)
+    if err != nil {
+      return nil, err
+    }
+    if err := boundaryDependenciesRejectUnknown(fields, "type", "pattern", "entry", "private"); err != nil {
+      return nil, fmt.Errorf("%s: %w", path, err)
+    }
+    typeRaw, hasType := fields["type"]
+    patternRaw, hasPattern := fields["pattern"]
+    if !hasType || !hasPattern {
+      return nil, fmt.Errorf("%s requires non-empty %q and %q", path, "type", "pattern")
+    }
+    element := boundaryElement{}
+    if element.Type, err = boundaryDependenciesString(typeRaw, path+".type"); err != nil {
+      return nil, err
+    }
+    if element.Pattern, err = boundaryDependenciesString(patternRaw, path+".pattern"); err != nil {
+      return nil, err
+    }
+    if element.Type == "" || element.Pattern == "" {
+      return nil, fmt.Errorf("%s requires non-empty %q and %q", path, "type", "pattern")
+    }
+    if value, present := fields["entry"]; present {
+      element.Entry, err = boundaryDependenciesStringList(value, path+".entry")
+      if err != nil {
+        return nil, err
+      }
+    }
+    if value, present := fields["private"]; present {
+      element.Private, err = boundaryDependenciesStringList(value, path+".private")
+      if err != nil {
+        return nil, err
+      }
+    }
+    elements = append(elements, element)
+  }
+  return elements, nil
+}
+
+func parseBoundaryDependenciesPolicies(raw json.RawMessage) ([]boundaryDependenciesPolicy, error) {
+  entries, err := boundaryDependenciesArray(raw, "policies")
+  if err != nil {
+    return nil, err
+  }
+  policies := make([]boundaryDependenciesPolicy, 0, len(entries))
+  for index, entry := range entries {
+    policy, err := parseBoundaryDependenciesPolicy(entry, index)
+    if err != nil {
+      return nil, err
+    }
+    policies = append(policies, policy)
+  }
+  return policies, nil
+}
+
+func parseBoundaryDependenciesPolicy(raw json.RawMessage, index int) (boundaryDependenciesPolicy, error) {
+  var policy boundaryDependenciesPolicy
+  path := fmt.Sprintf("policies[%d]", index)
+  fields, err := boundaryDependenciesObject(raw, path)
+  if err != nil {
+    return policy, err
+  }
+  if err := boundaryDependenciesRejectUnknown(
+    fields,
+    "from",
+    "to",
+    "dependency",
+    "allow",
+    "disallow",
+    "importKind",
+    "message",
+  ); err != nil {
+    return policy, fmt.Errorf("%s: %w", path, err)
+  }
+  if value, present := fields["from"]; present {
+    policy.From, err = parseBoundaryDependenciesEntitySelectors(value, path+".from")
+    if err != nil {
+      return policy, err
+    }
+  }
+  if value, present := fields["to"]; present {
+    policy.To, err = parseBoundaryDependenciesEntitySelectors(value, path+".to")
+    if err != nil {
+      return policy, err
+    }
+  }
+  if value, present := fields["dependency"]; present {
+    policy.Dependency, err = parseBoundaryDependenciesInfoSelectors(value, path+".dependency")
+    if err != nil {
+      return policy, err
+    }
+  }
+  if value, present := fields["allow"]; present {
+    policy.Allow, err = parseBoundaryDependenciesEffect(value, path+".allow")
+    if err != nil {
+      return policy, err
+    }
+  }
+  if value, present := fields["disallow"]; present {
+    policy.Disallow, err = parseBoundaryDependenciesEffect(value, path+".disallow")
+    if err != nil {
+      return policy, err
+    }
+  }
+  if len(policy.Allow) == 0 && len(policy.Disallow) == 0 {
+    return policy, fmt.Errorf("%s requires at least one of %q or %q", path, "allow", "disallow")
+  }
+  if value, present := fields["importKind"]; present {
+    policy.ImportKind, err = boundaryDependenciesString(value, path+".importKind")
+    if err != nil {
+      return policy, err
+    }
+    if !boundaryDependenciesValidKind(policy.ImportKind) {
+      return policy, fmt.Errorf("%s.importKind must be %q, %q, or %q", path, "value", "type", "typeof")
+    }
+  }
+  if value, present := fields["message"]; present {
+    policy.Message, err = boundaryDependenciesString(value, path+".message")
+    if err != nil {
+      return policy, err
+    }
+  }
+  return policy, nil
+}
+
+func parseBoundaryDependenciesEntitySelectors(raw json.RawMessage, path string) ([]boundaryDependenciesEntitySelector, error) {
+  raw = bytes.TrimSpace(raw)
+  if len(raw) == 0 {
+    return nil, fmt.Errorf("%s must be an entity selector", path)
+  }
+  switch raw[0] {
+  case '"':
+    value, err := boundaryDependenciesString(raw, path)
+    if err != nil {
+      return nil, err
+    }
+    if value == "" {
+      return nil, fmt.Errorf("%s must not be empty", path)
+    }
+    return []boundaryDependenciesEntitySelector{{Types: boundaryStringList{value}}}, nil
+  case '[':
+    entries, err := boundaryDependenciesArray(raw, path)
+    if err != nil {
+      return nil, err
+    }
+    if len(entries) == 0 {
+      return nil, fmt.Errorf("%s must not be empty", path)
+    }
+    selectors := make([]boundaryDependenciesEntitySelector, 0, len(entries))
+    for index, entry := range entries {
+      parsed, err := parseBoundaryDependenciesEntitySelectors(entry, fmt.Sprintf("%s[%d]", path, index))
+      if err != nil {
+        return nil, err
+      }
+      selectors = append(selectors, parsed...)
+    }
+    return selectors, nil
+  case '{':
+    selector, err := parseBoundaryDependenciesEntitySelectorObject(raw, path)
+    if err != nil {
+      return nil, err
+    }
+    return []boundaryDependenciesEntitySelector{selector}, nil
+  default:
+    return nil, fmt.Errorf("%s must be a string, object, or array of selectors", path)
+  }
+}
+
+func parseBoundaryDependenciesEntitySelectorObject(raw json.RawMessage, path string) (boundaryDependenciesEntitySelector, error) {
+  var selector boundaryDependenciesEntitySelector
+  fields, err := boundaryDependenciesObject(raw, path)
+  if err != nil {
+    return selector, err
+  }
+  if err := boundaryDependenciesRejectUnknown(fields, "type", "origin", "source", "path", "entry", "private", "unknown"); err != nil {
+    return selector, fmt.Errorf("%s: %w", path, err)
+  }
+  if value, present := fields["type"]; present {
+    selector.Types, err = boundaryDependenciesStringList(value, path+".type")
+    if err != nil {
+      return selector, err
+    }
+  }
+  if value, present := fields["origin"]; present {
+    selector.Origins, err = boundaryDependenciesStringList(value, path+".origin")
+    if err != nil {
+      return selector, err
+    }
+  }
+  if value, present := fields["source"]; present {
+    selector.Sources, err = boundaryDependenciesStringList(value, path+".source")
+    if err != nil {
+      return selector, err
+    }
+  }
+  if value, present := fields["path"]; present {
+    selector.Paths, err = boundaryDependenciesStringList(value, path+".path")
+    if err != nil {
+      return selector, err
+    }
+  }
+  if value, present := fields["entry"]; present {
+    selected, err := boundaryDependenciesBool(value, path+".entry")
+    if err != nil {
+      return selector, err
+    }
+    selector.Entry = &selected
+  }
+  if value, present := fields["private"]; present {
+    selected, err := boundaryDependenciesBool(value, path+".private")
+    if err != nil {
+      return selector, err
+    }
+    selector.Private = &selected
+  }
+  if value, present := fields["unknown"]; present {
+    selected, err := boundaryDependenciesBool(value, path+".unknown")
+    if err != nil {
+      return selector, err
+    }
+    selector.Unknown = &selected
+  }
+  return selector, nil
+}
+
+func parseBoundaryDependenciesInfoSelectors(raw json.RawMessage, path string) ([]boundaryDependenciesInfoSelector, error) {
+  raw = bytes.TrimSpace(raw)
+  if len(raw) == 0 {
+    return nil, fmt.Errorf("%s must be a dependency selector", path)
+  }
+  if raw[0] == '[' {
+    entries, err := boundaryDependenciesArray(raw, path)
+    if err != nil {
+      return nil, err
+    }
+    if len(entries) == 0 {
+      return nil, fmt.Errorf("%s must not be empty", path)
+    }
+    selectors := make([]boundaryDependenciesInfoSelector, 0, len(entries))
+    for index, entry := range entries {
+      parsed, err := parseBoundaryDependenciesInfoSelectors(entry, fmt.Sprintf("%s[%d]", path, index))
+      if err != nil {
+        return nil, err
+      }
+      selectors = append(selectors, parsed...)
+    }
+    return selectors, nil
+  }
+  fields, err := boundaryDependenciesObject(raw, path)
+  if err != nil {
+    return nil, err
+  }
+  if err := boundaryDependenciesRejectUnknown(fields, "kind", "source", "nodeKind", "specifiers"); err != nil {
+    return nil, fmt.Errorf("%s: %w", path, err)
+  }
+  selector := boundaryDependenciesInfoSelector{}
+  if value, present := fields["kind"]; present {
+    selector.Kinds, err = boundaryDependenciesStringList(value, path+".kind")
+    if err != nil {
+      return nil, err
+    }
+    for _, kind := range selector.Kinds {
+      if kind != "*" && !boundaryDependenciesValidKind(kind) {
+        return nil, fmt.Errorf("%s.kind contains unsupported value %q", path, kind)
+      }
+    }
+  }
+  if value, present := fields["source"]; present {
+    selector.Sources, err = boundaryDependenciesStringList(value, path+".source")
+    if err != nil {
+      return nil, err
+    }
+  }
+  if value, present := fields["nodeKind"]; present {
+    selector.NodeKinds, err = boundaryDependenciesStringList(value, path+".nodeKind")
+    if err != nil {
+      return nil, err
+    }
+  }
+  if value, present := fields["specifiers"]; present {
+    selector.Specifiers, err = boundaryDependenciesStringList(value, path+".specifiers")
+    if err != nil {
+      return nil, err
+    }
+  }
+  return []boundaryDependenciesInfoSelector{selector}, nil
+}
+
+func parseBoundaryDependenciesEffect(raw json.RawMessage, path string) ([]boundaryDependenciesSelector, error) {
+  raw = bytes.TrimSpace(raw)
+  if len(raw) == 0 {
+    return nil, fmt.Errorf("%s must be a selector", path)
+  }
+  if raw[0] == '[' {
+    entries, err := boundaryDependenciesArray(raw, path)
+    if err != nil {
+      return nil, err
+    }
+    if len(entries) == 0 {
+      return nil, fmt.Errorf("%s must not be empty", path)
+    }
+    selectors := make([]boundaryDependenciesSelector, 0, len(entries))
+    for index, entry := range entries {
+      parsed, err := parseBoundaryDependenciesEffect(entry, fmt.Sprintf("%s[%d]", path, index))
+      if err != nil {
+        return nil, err
+      }
+      selectors = append(selectors, parsed...)
+    }
+    return selectors, nil
+  }
+  if raw[0] == '{' {
+    fields, err := boundaryDependenciesObject(raw, path)
+    if err != nil {
+      return nil, err
+    }
+    _, hasFrom := fields["from"]
+    _, hasTo := fields["to"]
+    _, hasDependency := fields["dependency"]
+    if hasFrom || hasTo || hasDependency {
+      if err := boundaryDependenciesRejectUnknown(fields, "from", "to", "dependency"); err != nil {
+        return nil, fmt.Errorf("%s: %w", path, err)
+      }
+      selector := boundaryDependenciesSelector{}
+      if hasFrom {
+        selector.From, err = parseBoundaryDependenciesEntitySelectors(fields["from"], path+".from")
+        if err != nil {
+          return nil, err
+        }
+      }
+      if hasTo {
+        selector.To, err = parseBoundaryDependenciesEntitySelectors(fields["to"], path+".to")
+        if err != nil {
+          return nil, err
+        }
+      }
+      if hasDependency {
+        selector.Dependency, err = parseBoundaryDependenciesInfoSelectors(fields["dependency"], path+".dependency")
+        if err != nil {
+          return nil, err
+        }
+      }
+      return []boundaryDependenciesSelector{selector}, nil
+    }
+  }
+  entities, err := parseBoundaryDependenciesEntitySelectors(raw, path)
+  if err != nil {
+    return nil, err
+  }
+  selectors := make([]boundaryDependenciesSelector, 0, len(entities))
+  for _, entity := range entities {
+    selectors = append(selectors, boundaryDependenciesSelector{To: []boundaryDependenciesEntitySelector{entity}})
+  }
+  return selectors, nil
+}
+
+func describeBoundaryDependency(
+  ctx *Context,
+  options boundaryDependenciesOptions,
+  source *boundaryFile,
+  dependency boundaryDependency,
+) boundaryDependenciesDescription {
+  from := boundaryDependenciesEntityFromFile(source, ctx.File.FileName(), "local")
+  resolvedPath, resolved := resolveBoundaryDependencyPath(ctx, dependency)
+  local := dependency.relative || (resolved && boundaryDependenciesProjectLocalPath(ctx.CurrentDirectory, resolvedPath))
+  if local {
+    if !resolved && dependency.relative {
+      resolvedPath = filepath.Clean(filepath.Join(filepath.Dir(ctx.File.FileName()), filepath.FromSlash(dependency.specifier)))
+    }
+    target := classifyBoundaryFile(resolvedPath, options.Elements)
+    to := boundaryDependenciesEntityFromFile(target, resolvedPath, "local")
+    to.Source = dependency.specifier
+    to.Unknown = target == nil
+    return boundaryDependenciesDescription{
+      From:       from,
+      To:         to,
+      Dependency: dependency,
+      Internal:   target != nil && source.RootPath != "" && source.RootPath == target.RootPath,
+    }
+  }
+
+  origin := "external"
+  if strings.HasPrefix(dependency.specifier, "node:") {
+    origin = "core"
+  }
+  return boundaryDependenciesDescription{
+    From: from,
+    To: boundaryDependenciesEntity{
+      Origin: origin,
+      Source: dependency.specifier,
+      Path:   dependency.specifier,
+    },
+    Dependency: dependency,
+  }
+}
+
+func boundaryDependenciesEntityFromFile(file *boundaryFile, path, origin string) boundaryDependenciesEntity {
+  entity := boundaryDependenciesEntity{
+    Origin: origin,
+    Source: normalizeBoundaryPath(path),
+    Path:   boundaryDisplayPath(path),
+    boundary: file,
+  }
+  if file == nil {
+    return entity
+  }
+  entity.Type = file.Type
+  entity.Path = file.LocalPath
+  if entity.Path == "" {
+    entity.Path = file.RelativePath
+  }
+  entity.Entry = matchBoundaryElementLocalPattern(file.Entry, file)
+  entity.Private = matchBoundaryElementLocalPattern(file.Private, file)
+  return entity
+}
+
+func resolveBoundaryDependencyPath(ctx *Context, dependency boundaryDependency) (string, bool) {
+  if ctx != nil && ctx.Checker != nil && dependency.node != nil {
+    symbol := ctx.Checker.GetSymbolAtLocation(dependency.node)
+    if symbol != nil && symbol.Flags&shimast.SymbolFlagsAlias != 0 {
+      symbol = ctx.Checker.GetAliasedSymbol(symbol)
+    }
+    if symbol != nil {
+      for _, declaration := range symbol.Declarations {
+        source := sourceFileForBoundaryDeclaration(declaration)
+        if source == nil || source.FileName() == "" {
+          continue
+        }
+        return filepath.Clean(source.FileName()), true
+      }
+    }
+  }
+  if ctx != nil && ctx.File != nil {
+    return resolveBoundaryImport(ctx.File.FileName(), dependency.specifier)
+  }
+  return "", false
+}
+
+func sourceFileForBoundaryDeclaration(node *shimast.Node) *shimast.SourceFile {
+  for current := node; current != nil; current = current.Parent {
+    if current.Kind == shimast.KindSourceFile {
+      return current.AsSourceFile()
+    }
+  }
+  return nil
+}
+
+func boundaryDependenciesProjectLocalPath(root, path string) bool {
+  if root == "" || path == "" || boundaryDependenciesPathHasSegment(path, "node_modules") {
+    return false
+  }
+  relative, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+  if err != nil || filepath.IsAbs(relative) {
+    return false
+  }
+  return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func boundaryDependenciesPathHasSegment(path, segment string) bool {
+  normalized := strings.ToLower(filepath.ToSlash(filepath.Clean(path)))
+  segment = "/" + strings.ToLower(strings.Trim(segment, "/")) + "/"
+  return strings.Contains("/"+strings.Trim(normalized, "/")+"/", segment)
+}
+
+func boundaryDependenciesShadowedRequire(ctx *Context, dependency boundaryDependency) bool {
+  if ctx == nil || ctx.Checker == nil || dependency.nodeKind != "RequireCall" || dependency.node == nil || dependency.node.Parent == nil {
+    return false
+  }
+  call := dependency.node.Parent.AsCallExpression()
+  if call == nil || call.Expression == nil {
+    return false
+  }
+  symbol := ctx.Checker.GetSymbolAtLocation(call.Expression)
+  if symbol == nil {
+    return false
+  }
+  for _, declaration := range symbol.Declarations {
+    source := sourceFileForBoundaryDeclaration(declaration)
+    if source != nil && boundaryDependenciesProjectLocalPath(ctx.CurrentDirectory, source.FileName()) {
+      return true
+    }
+  }
+  return false
+}
+
+func evaluateBoundaryDependencies(
+  options boundaryDependenciesOptions,
+  description boundaryDependenciesDescription,
+) boundaryDependenciesEvaluation {
+  evaluation := boundaryDependenciesEvaluation{
+    allowed:     options.Default == "allow",
+    policyIndex: -1,
+  }
+  for index := range options.Policies {
+    policy := &options.Policies[index]
+    if !boundaryDependenciesEntitiesMatch(policy.From, description.From) ||
+      !boundaryDependenciesEntitiesMatch(policy.To, description.To) ||
+      !boundaryDependenciesInfoMatches(policy.Dependency, description.Dependency) {
+      continue
+    }
+    if boundaryDependenciesEffectsMatch(policy, policy.Disallow, description) {
+      evaluation.allowed = false
+      evaluation.policyIndex = index
+      evaluation.policy = policy
+      continue
+    }
+    if boundaryDependenciesEffectsMatch(policy, policy.Allow, description) {
+      evaluation.allowed = true
+      evaluation.policyIndex = index
+      evaluation.policy = policy
+    }
+  }
+  return evaluation
+}
+
+func boundaryDependenciesEffectsMatch(
+  policy *boundaryDependenciesPolicy,
+  selectors []boundaryDependenciesSelector,
+  description boundaryDependenciesDescription,
+) bool {
+  for _, selector := range selectors {
+    if !boundaryDependenciesEntitiesMatch(selector.From, description.From) ||
+      !boundaryDependenciesEntitiesMatch(selector.To, description.To) ||
+      !boundaryDependenciesInfoMatches(selector.Dependency, description.Dependency) {
+      continue
+    }
+    if policy.ImportKind != "" &&
+      !boundaryDependenciesInfoHasKind(policy.Dependency) &&
+      !boundaryDependenciesInfoHasKind(selector.Dependency) &&
+      policy.ImportKind != description.Dependency.kind {
+      continue
+    }
+    return true
+  }
+  return false
+}
+
+func boundaryDependenciesEntitiesMatch(selectors []boundaryDependenciesEntitySelector, entity boundaryDependenciesEntity) bool {
+  if len(selectors) == 0 {
+    return true
+  }
+  for _, selector := range selectors {
+    if boundaryDependenciesEntityMatches(selector, entity) {
+      return true
+    }
+  }
+  return false
+}
+
+func boundaryDependenciesEntityMatches(selector boundaryDependenciesEntitySelector, entity boundaryDependenciesEntity) bool {
+  if len(selector.Types) > 0 && !matchAnyBoundaryPattern(selector.Types, entity.Type) {
+    return false
+  }
+  if len(selector.Origins) > 0 && !matchAnyBoundaryPattern(selector.Origins, entity.Origin) {
+    return false
+  }
+  if len(selector.Sources) > 0 && !matchAnyBoundaryPattern(
+    selector.Sources,
+    entity.Source,
+    boundaryPackageName(entity.Source),
+  ) {
+    return false
+  }
+  if len(selector.Paths) > 0 && !matchAnyBoundaryPattern(
+    selector.Paths,
+    entity.Path,
+    filepath.Base(entity.Path),
+  ) {
+    return false
+  }
+  if selector.Entry != nil && *selector.Entry != entity.Entry {
+    return false
+  }
+  if selector.Private != nil && *selector.Private != entity.Private {
+    return false
+  }
+  if selector.Unknown != nil && *selector.Unknown != entity.Unknown {
+    return false
+  }
+  return true
+}
+
+func boundaryDependenciesInfoMatches(selectors []boundaryDependenciesInfoSelector, dependency boundaryDependency) bool {
+  if len(selectors) == 0 {
+    return true
+  }
+  for _, selector := range selectors {
+    if len(selector.Kinds) > 0 && !matchAnyBoundaryPattern(selector.Kinds, dependency.kind) {
+      continue
+    }
+    if len(selector.Sources) > 0 && !matchAnyBoundaryPattern(
+      selector.Sources,
+      dependency.specifier,
+      boundaryPackageName(dependency.specifier),
+    ) {
+      continue
+    }
+    if len(selector.NodeKinds) > 0 && !matchAnyBoundaryPattern(selector.NodeKinds, dependency.nodeKind) {
+      continue
+    }
+    if len(selector.Specifiers) > 0 && !matchAnyBoundaryPattern(selector.Specifiers, dependency.specifiers...) {
+      continue
+    }
+    return true
+  }
+  return false
+}
+
+func boundaryDependenciesInfoHasKind(selectors []boundaryDependenciesInfoSelector) bool {
+  for _, selector := range selectors {
+    if len(selector.Kinds) > 0 {
+      return true
+    }
+  }
+  return false
+}
+
+func boundaryDependenciesMessage(
+  options boundaryDependenciesOptions,
+  description boundaryDependenciesDescription,
+  evaluation boundaryDependenciesEvaluation,
+) string {
+  custom := options.Message
+  if evaluation.policy != nil && evaluation.policy.Message != "" {
+    custom = evaluation.policy.Message
+  }
+  if custom != "" {
+    return boundaryDependenciesRenderMessage(custom, description, evaluation.policyIndex)
+  }
+  from := boundaryDependenciesEntityLabel(description.From)
+  to := boundaryDependenciesEntityLabel(description.To)
+  if evaluation.policyIndex >= 0 {
+    return fmt.Sprintf("Dependency from %s to %s is not allowed by policy at index %d.", from, to, evaluation.policyIndex)
+  }
+  return fmt.Sprintf("There is no policy allowing dependencies from %s to %s.", from, to)
+}
+
+func boundaryDependenciesEntityLabel(entity boundaryDependenciesEntity) string {
+  switch entity.Origin {
+  case "external", "core":
+    return fmt.Sprintf("%s module %q", entity.Origin, entity.Source)
+  }
+  if entity.Unknown {
+    return fmt.Sprintf("unknown local target %q", entity.Source)
+  }
+  return fmt.Sprintf("boundary element %q", entity.Type)
+}
+
+func boundaryDependenciesRenderMessage(
+  message string,
+  description boundaryDependenciesDescription,
+  policyIndex int,
+) string {
+  return strings.NewReplacer(
+    "{{from.type}}", description.From.Type,
+    "{{from.path}}", description.From.Path,
+    "{{from.origin}}", description.From.Origin,
+    "{{to.type}}", description.To.Type,
+    "{{to.path}}", description.To.Path,
+    "{{to.origin}}", description.To.Origin,
+    "{{dependency.source}}", description.Dependency.specifier,
+    "{{dependency.kind}}", description.Dependency.kind,
+    "{{dependency.nodeKind}}", description.Dependency.nodeKind,
+    "{{policy.index}}", fmt.Sprintf("%d", policyIndex),
+  ).Replace(message)
+}
+
+func boundaryDependenciesObject(raw json.RawMessage, path string) (map[string]json.RawMessage, error) {
+  raw = bytes.TrimSpace(raw)
+  if len(raw) == 0 || raw[0] != '{' {
+    return nil, fmt.Errorf("%s must be an object", path)
+  }
+  var fields map[string]json.RawMessage
+  if err := json.Unmarshal(raw, &fields); err != nil {
+    return nil, fmt.Errorf("%s must be an object: %w", path, err)
+  }
+  if fields == nil {
+    return nil, fmt.Errorf("%s must be an object", path)
+  }
+  return fields, nil
+}
+
+func boundaryDependenciesArray(raw json.RawMessage, path string) ([]json.RawMessage, error) {
+  raw = bytes.TrimSpace(raw)
+  if len(raw) == 0 || raw[0] != '[' {
+    return nil, fmt.Errorf("%s must be an array", path)
+  }
+  var values []json.RawMessage
+  if err := json.Unmarshal(raw, &values); err != nil {
+    return nil, fmt.Errorf("%s must be an array: %w", path, err)
+  }
+  return values, nil
+}
+
+func boundaryDependenciesString(raw json.RawMessage, path string) (string, error) {
+  var value string
+  if err := json.Unmarshal(raw, &value); err != nil {
+    return "", fmt.Errorf("%s must be a string", path)
+  }
+  return value, nil
+}
+
+func boundaryDependenciesStringList(raw json.RawMessage, path string) (boundaryStringList, error) {
+  raw = bytes.TrimSpace(raw)
+  if len(raw) == 0 {
+    return nil, fmt.Errorf("%s must be a string or array of strings", path)
+  }
+  if raw[0] == '"' {
+    value, err := boundaryDependenciesString(raw, path)
+    if err != nil {
+      return nil, err
+    }
+    if value == "" {
+      return nil, fmt.Errorf("%s must not be empty", path)
+    }
+    return boundaryStringList{value}, nil
+  }
+  entries, err := boundaryDependenciesArray(raw, path)
+  if err != nil {
+    return nil, fmt.Errorf("%s must be a string or array of strings", path)
+  }
+  if len(entries) == 0 {
+    return nil, fmt.Errorf("%s must not be empty", path)
+  }
+  values := make(boundaryStringList, 0, len(entries))
+  seen := make(map[string]struct{}, len(entries))
+  for index, entry := range entries {
+    value, err := boundaryDependenciesString(entry, fmt.Sprintf("%s[%d]", path, index))
+    if err != nil {
+      return nil, err
+    }
+    if value == "" {
+      return nil, fmt.Errorf("%s[%d] must not be empty", path, index)
+    }
+    if _, duplicate := seen[value]; duplicate {
+      return nil, fmt.Errorf("%s contains duplicate value %q", path, value)
+    }
+    seen[value] = struct{}{}
+    values = append(values, value)
+  }
+  return values, nil
+}
+
+func boundaryDependenciesBool(raw json.RawMessage, path string) (bool, error) {
+  var value bool
+  if err := json.Unmarshal(raw, &value); err != nil {
+    return false, fmt.Errorf("%s must be a boolean", path)
+  }
+  return value, nil
+}
+
+func boundaryDependenciesRejectUnknown(fields map[string]json.RawMessage, allowed ...string) error {
+  known := make(map[string]struct{}, len(allowed))
+  for _, name := range allowed {
+    known[name] = struct{}{}
+  }
+  unknown := make([]string, 0)
+  for name := range fields {
+    if _, ok := known[name]; !ok {
+      unknown = append(unknown, name)
+    }
+  }
+  if len(unknown) == 0 {
+    return nil
+  }
+  sort.Strings(unknown)
+  return fmt.Errorf("unknown option %q", unknown[0])
+}
+
+func boundaryDependenciesValidKind(kind string) bool {
+  return kind == "value" || kind == "type" || kind == "typeof"
+}

--- a/packages/lint/src/structures/rules/ITtscLintBoundariesRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintBoundariesRuleOptions.ts
@@ -95,23 +95,143 @@ export type ITtscLintBoundariesNoPrivateRuleOptions =
 export type ITtscLintBoundariesNoUnknownRuleOptions =
   ITtscLintBoundariesElementsOptions;
 
+/** One entity selector in a `boundaries/dependencies` policy. */
+export interface ITtscLintBoundariesDependenciesEntitySelectorObject {
+  /** Element type glob(s). */
+  type?: string | readonly string[];
+
+  /** Dependency origin glob(s). */
+  origin?: "local" | "external" | "core" | readonly string[];
+
+  /** Import specifier or source-file glob(s). */
+  source?: string | readonly string[];
+
+  /** Element-local path glob(s). */
+  path?: string | readonly string[];
+
+  /** Whether the selected file is a configured entry file. */
+  entry?: boolean;
+
+  /** Whether the selected file is a configured private file. */
+  private?: boolean;
+
+  /** Whether the local target matched no configured element. */
+  unknown?: boolean;
+}
+
+/** Entity selector or legacy element-type shorthand. */
+export type ITtscLintBoundariesDependenciesEntitySelector =
+  | string
+  | ITtscLintBoundariesDependenciesEntitySelectorObject
+  | readonly (
+      | string
+      | ITtscLintBoundariesDependenciesEntitySelectorObject
+    )[];
+
+/** Metadata selector for the import or re-export itself. */
+export interface ITtscLintBoundariesDependenciesInfoSelector {
+  /** TypeScript dependency kind. */
+  kind?: "value" | "type" | "typeof" | readonly (
+    | "value"
+    | "type"
+    | "typeof"
+  )[];
+
+  /** Import specifier glob(s). */
+  source?: string | readonly string[];
+
+  /** AST dependency kind glob(s), such as `ImportDeclaration`. */
+  nodeKind?: string | readonly string[];
+
+  /** Imported or re-exported name glob(s). */
+  specifiers?: string | readonly string[];
+}
+
+/** Complete dependency selector used by an allow/disallow effect. */
+export interface ITtscLintBoundariesDependenciesSelector {
+  /** Importing entity selector. */
+  from?: ITtscLintBoundariesDependenciesEntitySelector;
+
+  /** Imported entity selector. */
+  to?: ITtscLintBoundariesDependenciesEntitySelector;
+
+  /** Dependency metadata selector. */
+  dependency?:
+    | ITtscLintBoundariesDependenciesInfoSelector
+    | readonly ITtscLintBoundariesDependenciesInfoSelector[];
+}
+
+/** One allow/disallow effect selector. */
+export type ITtscLintBoundariesDependenciesEffect =
+  | ITtscLintBoundariesDependenciesEntitySelector
+  | ITtscLintBoundariesDependenciesSelector
+  | readonly (
+      | string
+      | ITtscLintBoundariesDependenciesEntitySelectorObject
+      | ITtscLintBoundariesDependenciesSelector
+    )[];
+
+/** One ordered `boundaries/dependencies` policy. */
+export interface ITtscLintBoundariesDependenciesPolicy {
+  /** Importing entity selector. Omit to match every configured source. */
+  from?: ITtscLintBoundariesDependenciesEntitySelector;
+
+  /** Imported entity selector. Omit to match every target. */
+  to?: ITtscLintBoundariesDependenciesEntitySelector;
+
+  /** Dependency metadata selector. */
+  dependency?:
+    | ITtscLintBoundariesDependenciesInfoSelector
+    | readonly ITtscLintBoundariesDependenciesInfoSelector[];
+
+  /** Selectors whose matching dependencies are allowed. */
+  allow?: ITtscLintBoundariesDependenciesEffect;
+
+  /** Selectors whose matching dependencies are rejected. */
+  disallow?: ITtscLintBoundariesDependenciesEffect;
+
+  /** Legacy dependency-kind filter; `dependency.kind` takes precedence. */
+  importKind?: "value" | "type" | "typeof";
+
+  /** Optional diagnostic override for this policy. */
+  message?: string;
+}
+
 /**
  * `boundaries/dependencies` rule options.
  *
- * The upstream unified rule subsumes `element-types`, `entry-point`,
- * `external`, `no-private`, and `no-unknown` behind a single direction-aware
- * policy block. The v1 native port registers the rule name and decodes this
- * config shape but does not yet emit diagnostics (`v1 stub; full validation
- * deferred` — see `rules_boundaries.go`).
+ * Policies are evaluated in order and the last matching effect wins. Within
+ * one policy, `disallow` takes precedence over `allow`.
  */
-export interface ITtscLintBoundariesDependenciesRuleOptions extends ITtscLintBoundariesElementsOptions {
+export interface ITtscLintBoundariesDependenciesRuleOptions
+  extends ITtscLintBoundariesElementsOptions {
   /**
    * Fallback policy when no rule matches.
    *
-   * @default "allow"
+   * @default "disallow"
    */
   default?: "allow" | "disallow";
 
-  /** Ordered dependency policies. First matching policy wins. */
-  rules?: readonly ITtscLintBoundariesElementTypesRule[];
+  /** Ordered dependency policies. Prefer this current upstream name. */
+  policies?: readonly ITtscLintBoundariesDependenciesPolicy[];
+
+  /** Ordered dependency policies; compatibility alias for `policies`. */
+  rules?: readonly ITtscLintBoundariesDependenciesPolicy[];
+
+  /** Evaluate external and `node:` dependencies as well as local targets. */
+  checkAllOrigins?: boolean;
+
+  /** Evaluate local targets that match no configured element. */
+  checkUnknownLocals?: boolean;
+
+  /** Evaluate dependencies within the same configured element root. */
+  checkInternals?: boolean;
+
+  /**
+   * Global diagnostic override.
+   *
+   * Supports `{{from.type}}`, `{{to.type}}`, `{{dependency.source}}`,
+   * `{{dependency.kind}}`, and `{{policy.index}}` placeholders.
+   */
+  message?: string;
 }

--- a/packages/lint/src/structures/rules/ITtscLintBoundariesRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintBoundariesRuleOptions.ts
@@ -123,19 +123,12 @@ export interface ITtscLintBoundariesDependenciesEntitySelectorObject {
 export type ITtscLintBoundariesDependenciesEntitySelector =
   | string
   | ITtscLintBoundariesDependenciesEntitySelectorObject
-  | readonly (
-      | string
-      | ITtscLintBoundariesDependenciesEntitySelectorObject
-    )[];
+  | readonly (string | ITtscLintBoundariesDependenciesEntitySelectorObject)[];
 
 /** Metadata selector for the import or re-export itself. */
 export interface ITtscLintBoundariesDependenciesInfoSelector {
   /** TypeScript dependency kind. */
-  kind?: "value" | "type" | "typeof" | readonly (
-    | "value"
-    | "type"
-    | "typeof"
-  )[];
+  kind?: "value" | "type" | "typeof" | readonly ("value" | "type" | "typeof")[];
 
   /** Import specifier glob(s). */
   source?: string | readonly string[];
@@ -200,11 +193,10 @@ export interface ITtscLintBoundariesDependenciesPolicy {
 /**
  * `boundaries/dependencies` rule options.
  *
- * Policies are evaluated in order and the last matching effect wins. Within
- * one policy, `disallow` takes precedence over `allow`.
+ * Policies are evaluated in order and the last matching effect wins. Within one
+ * policy, `disallow` takes precedence over `allow`.
  */
-export interface ITtscLintBoundariesDependenciesRuleOptions
-  extends ITtscLintBoundariesElementsOptions {
+export interface ITtscLintBoundariesDependenciesRuleOptions extends ITtscLintBoundariesElementsOptions {
   /**
    * Fallback policy when no rule matches.
    *
@@ -230,8 +222,10 @@ export interface ITtscLintBoundariesDependenciesRuleOptions
   /**
    * Global diagnostic override.
    *
-   * Supports `{{from.type}}`, `{{to.type}}`, `{{dependency.source}}`,
-   * `{{dependency.kind}}`, and `{{policy.index}}` placeholders.
+   * Supports `{{from.type}}`, `{{from.path}}`, `{{from.origin}}`,
+   * `{{to.type}}`, `{{to.path}}`, `{{to.origin}}`, `{{dependency.source}}`,
+   * `{{dependency.kind}}`, `{{dependency.nodeKind}}`, and `{{policy.index}}`
+   * placeholders.
    */
   message?: string;
 }

--- a/packages/lint/src/structures/rules/ITtscLintBoundariesRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintBoundariesRules.ts
@@ -76,16 +76,14 @@ export interface ITtscLintBoundariesRules {
   "boundaries/no-unknown"?: TtscLintRuleOptionsSetting<ITtscLintBoundariesNoUnknownRuleOptions>;
 
   /**
-   * Unified dependency-direction rule from upstream `eslint-plugin-boundaries`,
-   * intended to replace `element-types` / `entry-point` / `external` /
-   * `no-private` / `no-unknown` with a single policy block.
+   * Enforce unified, direction-aware dependency policies.
    *
-   * The native port registers the rule name and accepts the same `elements` +
-   * `rules` config shape as `element-types`, but does not emit diagnostics yet
-   * (v1 stub; full direction validation deferred). Configure it today to claim
-   * the upstream rule id; the legacy split rules continue to enforce policy.
+   * Policies can select the importing and imported element, dependency origin,
+   * resolved path, entry/private/unknown state, import kind, syntax kind, and
+   * imported names. TypeScript path aliases are classified by their resolved
+   * source file rather than by the written specifier.
    *
-   * @reference https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/docs/rules/dependencies.md
+   * @reference https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/packages/website/docs/rules/dependencies.md
    */
   "boundaries/dependencies"?: TtscLintRuleOptionsSetting<ITtscLintBoundariesDependenciesRuleOptions>;
 }

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_alias_resolution_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_alias_resolution_test.go
@@ -7,7 +7,10 @@ import "testing"
 //
 // TypeScript `paths` aliases omit the relative prefix used by the filesystem
 // fallback. The checker must resolve ordinary imports, re-exports, and dynamic
-// imports to the same domain source file before element classification.
+// imports to the same domain source file before element classification. The
+// fixture uses bundler resolution because that is the module mode in which an
+// extensionless alias is legal for every one of those syntaxes; NodeNext
+// rejects it for ESM-mode dynamic imports before lint ever runs.
 //
 // 1. Configure an `@domain/*` tsconfig path alias to a domain element.
 // 2. Import, re-export, and dynamically import the aliased module from app.
@@ -36,7 +39,9 @@ void model;
       "src/domain/model.ts": "export const model = 1;",
     },
     map[string]any{
-      "paths": map[string]any{"@domain/*": []string{"src/domain/*"}},
+      "module":           "ESNext",
+      "moduleResolution": "Bundler",
+      "paths":            map[string]any{"@domain/*": []string{"src/domain/*"}},
     },
   )
   assertBoundaryFindingTexts(

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_alias_resolution_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_alias_resolution_test.go
@@ -1,0 +1,50 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesClassifiesResolvedAliases verifies written module
+// spelling does not decide whether a dependency is local.
+//
+// TypeScript `paths` aliases omit the relative prefix used by the filesystem
+// fallback. The checker must resolve ordinary imports, re-exports, and dynamic
+// imports to the same domain source file before element classification.
+//
+// 1. Configure an `@domain/*` tsconfig path alias to a domain element.
+// 2. Import, re-export, and dynamically import the aliased module from app.
+// 3. Assert all three alias literals are rejected by the app-to-domain policy.
+func TestBoundariesDependenciesClassifiesResolvedAliases(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := `import { model } from "@domain/model";
+export { model as exportedModel } from "@domain/model";
+void import("@domain/model");
+void model;
+`
+  findings := runBoundaryRuleProgram(
+    t,
+    ruleName,
+    "src/app/main.ts",
+    source,
+    `{
+      "elements": [
+        {"type":"app","pattern":"src/app/**"},
+        {"type":"domain","pattern":"src/domain/**"}
+      ],
+      "default":"allow",
+      "policies":[{"from":"app","disallow":"domain"}]
+    }`,
+    map[string]string{
+      "src/domain/model.ts": "export const model = 1;",
+    },
+    map[string]any{
+      "paths": map[string]any{"@domain/*": []string{"src/domain/*"}},
+    },
+  )
+  assertBoundaryFindingTexts(
+    t,
+    source,
+    findings,
+    `"@domain/model"`,
+    `"@domain/model"`,
+    `"@domain/model"`,
+  )
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_bare_core_builtin_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_bare_core_builtin_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesClassifiesBareBuiltinsAsCore verifies Node
+// built-ins keep the `core` origin without the `node:` scheme.
+//
+// Upstream derives origin from the platform module list, not from the
+// specifier spelling. Classifying bare `fs` as external would let
+// external-origin policies capture platform modules and leave core-origin
+// policies silently unenforced for the unprefixed spelling.
+//
+// 1. Import the bare `fs` built-in and an external package with all origins on.
+// 2. Deny external origins, then deny core origins.
+// 3. Assert the built-in reports only under the core policy and the package only under external.
+func TestBoundariesDependenciesClassifiesBareBuiltinsAsCore(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := "import \"fs\";\nimport \"react\";\n"
+  base := `"elements":[{"type":"app","pattern":"src/app/**"}],
+    "default":"allow","checkAllOrigins":true`
+
+  external := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+base+`,
+    "policies":[{"from":"app","disallow":{"to":{"origin":"external"}}}]
+  }`, nil)
+  assertBoundaryFindingTexts(t, source, external, `"react"`)
+
+  core := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+base+`,
+    "policies":[{"from":"app","disallow":{"to":{"origin":"core"}}}]
+  }`, nil)
+  assertBoundaryFindingTexts(t, source, core, `"fs"`)
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_command_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_command_test.go
@@ -1,0 +1,62 @@
+package linthost
+
+import (
+  "encoding/json"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestBoundariesDependenciesReportsThroughCheckCommand verifies the production
+// command front door surfaces unified policy diagnostics.
+//
+// Direct engine tests cannot catch config loading, checker provisioning,
+// declaration routing, or diagnostic rendering regressions. This witness uses
+// the same manifest and `lint.config.json` path as a consuming ttsc project.
+//
+// 1. Materialize an app-to-domain project and lint configuration.
+// 2. Invoke the real `check` command through the package command router.
+// 3. Assert one rendered rule diagnostic and a failing lint exit code.
+func TestBoundariesDependenciesReportsThroughCheckCommand(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "src", "app", "main.ts"), `import "../domain/model";`)
+  writeFile(t, filepath.Join(root, "src", "domain", "model.ts"), `export {};`)
+  tsconfig, err := json.Marshal(map[string]any{
+    "compilerOptions": map[string]any{
+      "target":   "ES2022",
+      "module":   "NodeNext",
+      "strict":   true,
+      "noEmit":   true,
+      "rootDir":  "src",
+    },
+    "files": []string{"src/app/main.ts", "src/domain/model.ts"},
+  })
+  if err != nil {
+    t.Fatalf("marshal tsconfig: %v", err)
+  }
+  writeFile(t, filepath.Join(root, "tsconfig.json"), string(tsconfig))
+  seedLintConfig(t, root, map[string]any{
+    "rules": map[string]any{
+      "boundaries/dependencies": []any{"error", map[string]any{
+        "elements": []any{
+          map[string]any{"type": "app", "pattern": "src/app/**"},
+          map[string]any{"type": "domain", "pattern": "src/domain/**"},
+        },
+        "default": "allow",
+        "policies": []any{
+          map[string]any{"from": "app", "disallow": "domain"},
+        },
+      }},
+    },
+  })
+
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{"check", "--cwd", root, "--plugins-json", lintManifest(t)})
+  })
+  if code != 2 || stdout != "" || strings.Count(stderr, "[boundaries/dependencies]") != 1 {
+    t.Fatalf("command result: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  if !strings.Contains(stderr, `boundary element "app"`) || !strings.Contains(stderr, `boundary element "domain"`) {
+    t.Fatalf("command diagnostic lost direction context: %q", stderr)
+  }
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_command_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_command_test.go
@@ -23,11 +23,11 @@ func TestBoundariesDependenciesReportsThroughCheckCommand(t *testing.T) {
   writeFile(t, filepath.Join(root, "src", "domain", "model.ts"), `export {};`)
   tsconfig, err := json.Marshal(map[string]any{
     "compilerOptions": map[string]any{
-      "target":   "ES2022",
-      "module":   "NodeNext",
-      "strict":   true,
-      "noEmit":   true,
-      "rootDir":  "src",
+      "target":  "ES2022",
+      "module":  "NodeNext",
+      "strict":  true,
+      "noEmit":  true,
+      "rootDir": "src",
     },
     "files": []string{"src/app/main.ts", "src/domain/model.ts"},
   })

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_declaration_file_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_declaration_file_test.go
@@ -1,0 +1,45 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesChecksDeclarationFileDependencies verifies the
+// declaration-file dispatch contract remains functional after implementation.
+//
+// Hand-written `.d.ts` files create architecture edges through type re-exports
+// and import-type nodes. The engine allowlist already admits the rule; this
+// witness ensures the checker-backed collector and `.d.ts` resolver do too.
+//
+// 1. Materialize app and domain declaration files.
+// 2. Re-export and import the domain type from the app declaration.
+// 3. Assert both exact declaration dependency literals are rejected.
+func TestBoundariesDependenciesChecksDeclarationFileDependencies(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := `export type { Domain } from "../domain/types";
+export type LazyDomain = import("../domain/types").Domain;
+`
+  findings := runBoundaryRuleProgram(
+    t,
+    ruleName,
+    "src/app/index.d.ts",
+    source,
+    `{
+      "elements": [
+        {"type":"app","pattern":"src/app/**"},
+        {"type":"domain","pattern":"src/domain/**"}
+      ],
+      "default":"allow",
+      "policies":[{"from":"app","disallow":"domain"}]
+    }`,
+    map[string]string{
+      "src/domain/types.d.ts": "export interface Domain { readonly id: string; }",
+    },
+    nil,
+  )
+  assertBoundaryFindingTexts(
+    t,
+    source,
+    findings,
+    `"../domain/types"`,
+    `"../domain/types"`,
+  )
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_default_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_default_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesDefaultsToDisallow verifies the current upstream
+// fallback and its explicit allow inverse.
+//
+// A missing `default` is intentionally restrictive. Pinning the allow twin
+// prevents the implementation from reporting every dependency unconditionally
+// while also guarding against the former port's documented allow default.
+//
+// 1. Run the same app-to-domain dependency with no matching policies.
+// 2. Compare omitted and explicit-allow default settings.
+// 3. Assert the omitted default reports once and explicit allow reports none.
+func TestBoundariesDependenciesDefaultsToDisallow(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := "import \"../domain/model\";\n"
+  files := map[string]string{"src/domain/model.ts": "export {};"}
+  elements := `"elements":[
+    {"type":"app","pattern":"src/app/**"},
+    {"type":"domain","pattern":"src/domain/**"}
+  ]`
+
+  denied := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+elements+`}`, files)
+  assertSingleBoundaryFinding(t, ruleName, denied, `no policy allowing`)
+
+  allowed := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+elements+`,"default":"allow"}`, files)
+  if len(allowed) != 0 {
+    t.Fatalf("explicit allow default: want no findings, got %+v", allowed)
+  }
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_from_to_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_from_to_test.go
@@ -1,0 +1,37 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesAppliesBothPolicyDirections verifies outer `from`
+// and `to` selectors constrain an effect together.
+//
+// Treating `to` as another allow-list or ignoring it would make a policy meant
+// for one edge affect every dependency from the source. The shared import is
+// the one-property negative twin for the target direction.
+//
+// 1. Import domain and shared elements from the same app file.
+// 2. Scope a source-pattern denial to the app-to-domain edge.
+// 3. Assert only the domain import reports.
+func TestBoundariesDependenciesAppliesBothPolicyDirections(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := "import \"../domain/model\";\nimport \"../shared/value\";\n"
+  findings := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{
+    "elements": [
+      {"type":"app","pattern":"src/app/**"},
+      {"type":"domain","pattern":"src/domain/**"},
+      {"type":"shared","pattern":"src/shared/**"}
+    ],
+    "default":"allow",
+    "policies": [
+      {
+        "from":{"type":"app"},
+        "to":{"type":"domain"},
+        "disallow":{"dependency":{"source":"../domain/**"}}
+      }
+    ]
+  }`, map[string]string{
+    "src/domain/model.ts": "export {};",
+    "src/shared/value.ts": "export {};",
+  })
+  assertBoundaryFindingTexts(t, source, findings, `"../domain/model"`)
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_import_kind_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_import_kind_test.go
@@ -1,0 +1,41 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesFiltersPoliciesByLegacyImportKind verifies the
+// deprecated policy-level `importKind` filter and its selector precedence.
+//
+// Upstream keeps `importKind` as a policy-wide dependency-kind gate that a
+// selector-level `dependency.kind` overrides. Dropping the gate would deny
+// value imports under type-only policies; inverting the precedence would make
+// explicit selector kinds unreachable.
+//
+// 1. Import one type-only and one value dependency from an app file.
+// 2. Deny domain under `importKind: "type"`, then with a `kind: "value"` selector.
+// 3. Assert the first run reports only the type import and the second only the value import.
+func TestBoundariesDependenciesFiltersPoliciesByLegacyImportKind(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := "import type { Foo } from \"../domain/types\";\nimport { value } from \"../domain/value\";\nvoid value;\n"
+  files := map[string]string{
+    "src/domain/types.ts": "export interface Foo {}",
+    "src/domain/value.ts": "export const value = 1;",
+  }
+  elements := `"elements":[
+    {"type":"app","pattern":"src/app/**"},
+    {"type":"domain","pattern":"src/domain/**"}
+  ],"default":"allow"`
+
+  typeOnly := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+elements+`,
+    "policies":[{"from":"app","importKind":"type","disallow":"domain"}]
+  }`, files)
+  assertBoundaryFindingTexts(t, source, typeOnly, `"../domain/types"`)
+
+  selectorWins := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+elements+`,
+    "policies":[{
+      "from":"app",
+      "importKind":"type",
+      "disallow":{"to":"domain","dependency":{"kind":"value"}}
+    }]
+  }`, files)
+  assertBoundaryFindingTexts(t, source, selectorWins, `"../domain/value"`)
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_import_type_kinds_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_import_type_kinds_test.go
@@ -1,0 +1,51 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestBoundariesDependenciesClassifiesImportTypeNodeKinds verifies `import()`
+// type nodes carry the `type` dependency kind and keep `typeof` distinct.
+//
+// An `import("m")` reference in type position is erased at runtime, so a
+// `kind: "value"` policy must never capture it. Classifying it as `value`
+// would let value-only denials block pure type plumbing, while collapsing
+// `typeof import("m")` into `type` would erase the documented third kind.
+//
+// 1. Reference a domain module through plain and typeof import-type nodes.
+// 2. Deny kind `type`, then kind `typeof`, then kind `value` on the edge.
+// 3. Assert each denial reports exactly its own import-type flavor.
+func TestBoundariesDependenciesClassifiesImportTypeNodeKinds(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := "type Shape = import(\"../domain/model\").Shape;\ntype Module = typeof import(\"../domain/model\");\n"
+  firstLineEnd := strings.Index(source, "\n")
+  files := map[string]string{"src/domain/model.ts": "export interface Shape {}\nexport const model = 1;\n"}
+  base := `"elements":[
+    {"type":"app","pattern":"src/app/**"},
+    {"type":"domain","pattern":"src/domain/**"}
+  ],"default":"allow"`
+
+  typeOnly := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+base+`,
+    "policies":[{"from":"app","disallow":{"to":"domain","dependency":{"kind":"type"}}}]
+  }`, files)
+  assertBoundaryFindingTexts(t, source, typeOnly, `"../domain/model"`)
+  if typeOnly[0].End > firstLineEnd {
+    t.Fatalf("type denial must report the plain import-type node, got %+v", typeOnly)
+  }
+
+  typeofOnly := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+base+`,
+    "policies":[{"from":"app","disallow":{"to":"domain","dependency":{"kind":"typeof"}}}]
+  }`, files)
+  assertBoundaryFindingTexts(t, source, typeofOnly, `"../domain/model"`)
+  if typeofOnly[0].Pos < firstLineEnd {
+    t.Fatalf("typeof denial must report the typeof import-type node, got %+v", typeofOnly)
+  }
+
+  valueOnly := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+base+`,
+    "policies":[{"from":"app","disallow":{"to":"domain","dependency":{"kind":"value"}}}]
+  }`, files)
+  if len(valueOnly) != 0 {
+    t.Fatalf("value denial must ignore type-position imports, got %+v", valueOnly)
+  }
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_legacy_to_direction_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_legacy_to_direction_test.go
@@ -1,0 +1,38 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesTreatsLegacyEntryAsSourceForToPolicies verifies a
+// legacy string effect selects the importer when the policy declares only `to`.
+//
+// Upstream maps string entries to the direction the policy leaves open: with
+// `from` present they select targets, without it they select sources. Wiring
+// both cases to targets would make `{"to":..., "disallow":...}` unsatisfiable
+// and silently disable every target-rooted legacy policy.
+//
+// 1. Deny app sources on the domain target with a string `disallow` entry.
+// 2. Import the domain model from an app file and from a shared file.
+// 3. Assert only the app-origin dependency reports, at its exact range.
+func TestBoundariesDependenciesTreatsLegacyEntryAsSourceForToPolicies(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := "import \"../domain/model\";\n"
+  files := map[string]string{"src/domain/model.ts": "export {};"}
+  options := `{
+    "elements": [
+      {"type":"app","pattern":"src/app/**"},
+      {"type":"domain","pattern":"src/domain/**"},
+      {"type":"shared","pattern":"src/shared/**"}
+    ],
+    "default":"allow",
+    "policies":[{"to":"domain","disallow":"app"}]
+  }`
+
+  denied := runBoundaryRule(t, ruleName, "src/app/main.ts", source, options, files)
+  assertSingleBoundaryFinding(t, ruleName, denied, `policy at index 0`)
+  assertBoundaryFindingTexts(t, source, denied, `"../domain/model"`)
+
+  allowed := runBoundaryRule(t, ruleName, "src/shared/main.ts", source, options, files)
+  if len(allowed) != 0 {
+    t.Fatalf("shared source must not match the legacy app entry, got %+v", allowed)
+  }
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_local_gates_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_local_gates_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesGatesInternalAndUnknownTargets verifies the two
+// local-dependency opt-in boundaries.
+//
+// Same-element imports and unclassified local targets are skipped by default,
+// even under a disallow fallback. Enabling the corresponding flags must expose
+// both to the same policy engine without changing known cross-element behavior.
+//
+// 1. Import one app-local file and one unclassified shared file.
+// 2. Run the disallow fallback with both gates disabled and enabled.
+// 3. Assert the enabled run reports both exact module literals.
+func TestBoundariesDependenciesGatesInternalAndUnknownTargets(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := "import \"./local\";\nimport \"../shared/util\";\n"
+  files := map[string]string{
+    "src/app/local.ts":   "export {};",
+    "src/shared/util.ts": "export {};",
+  }
+  base := `"elements":[{"type":"app","pattern":"src/app/**"}]`
+
+  skipped := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+base+`}`, files)
+  if len(skipped) != 0 {
+    t.Fatalf("default local gates: want no findings, got %+v", skipped)
+  }
+
+  checked := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+base+`,"checkInternals":true,"checkUnknownLocals":true}`, files)
+  assertBoundaryFindingTexts(t, source, checked, `"./local"`, `"../shared/util"`)
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_messages_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_messages_test.go
@@ -1,0 +1,53 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesRendersPolicyAndGlobalMessages verifies custom
+// diagnostic precedence and stable template data.
+//
+// A policy-specific message must override the global fallback only for its own
+// denial. The source, target, dependency kind, and policy index placeholders
+// are derived from the evaluated edge rather than from fixture-specific text.
+//
+// 1. Deny domain with a policy message and shared with the global message.
+// 2. Import one value from each target element.
+// 3. Assert both fully rendered messages and their precedence.
+func TestBoundariesDependenciesRendersPolicyAndGlobalMessages(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  findings := runBoundaryRule(t, ruleName, "src/app/main.ts", `
+    import "../domain/model";
+    import "../shared/value";
+  `, `{
+    "elements": [
+      {"type":"app","pattern":"src/app/**"},
+      {"type":"domain","pattern":"src/domain/**"},
+      {"type":"shared","pattern":"src/shared/**"}
+    ],
+    "default":"allow",
+    "message":"global {{from.type}} -> {{to.type}}: {{dependency.source}}",
+    "policies": [
+      {
+        "from":"app",
+        "disallow":"domain",
+        "message":"policy {{policy.index}} blocks {{dependency.kind}} {{from.type}} -> {{to.type}}"
+      },
+      {"from":"app","disallow":"shared"}
+    ]
+  }`, map[string]string{
+    "src/domain/model.ts": "export {};",
+    "src/shared/value.ts": "export {};",
+  })
+  if len(findings) != 2 {
+    t.Fatalf("want two findings, got %+v", findings)
+  }
+  messages := map[string]bool{}
+  for _, finding := range findings {
+    messages[finding.Message] = true
+  }
+  if !messages["policy 0 blocks value app -> domain"] {
+    t.Fatalf("missing policy message: %+v", findings)
+  }
+  if !messages["global app -> shared: ../shared/value"] {
+    t.Fatalf("missing global message: %+v", findings)
+  }
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_options_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_options_test.go
@@ -33,9 +33,12 @@ func TestBoundariesDependenciesValidatesCompleteOptionShape(t *testing.T) {
     {`{"elements":[{"type":"app"}]}`, `requires non-empty "type" and "pattern"`},
     {`{"elements":[{"type":"app","pattern":"src/**","entry":1}]}`, `entry must be a string or array of strings`},
     {`{"policies":{}}`, `policies must be an array`},
+    {`{"rules":{}}`, `rules must be an array`},
+    {`{"rules":[{"from":"app"}]}`, `rules[0] requires at least one of "allow" or "disallow"`},
     {`{"policies":[{"from":"app"}]}`, `requires at least one of "allow" or "disallow"`},
     {`{"policies":[{"disallow":{"unexpected":true}}]}`, `unknown option "unexpected"`},
     {`{"policies":[{"disallow":{"dependency":{"kind":"runtime"}}}]}`, `unsupported value "runtime"`},
+    {`{"policies":[{"importKind":"runtime","disallow":"app"}]}`, `importKind must be "value", "type", or "typeof"`},
     {`{"checkAllOrigins":"yes"}`, `checkAllOrigins must be a boolean`},
   }
   for _, test := range invalid {

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_options_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_options_test.go
@@ -1,0 +1,57 @@
+package linthost
+
+import (
+  "encoding/json"
+  "strings"
+  "testing"
+)
+
+// TestBoundariesDependenciesValidatesCompleteOptionShape verifies malformed
+// policy configuration fails before rule dispatch.
+//
+// Silent decoding was the stub's production behavior. This matrix pins the
+// object boundary, known keys, element descriptors, policy effects, selector
+// fields, dependency kinds, and boolean gates while retaining legacy strings.
+//
+// 1. Validate representative malformed options at every nesting level.
+// 2. Validate one legacy and one direction-aware object-selector configuration.
+// 3. Assert each invalid payload names its actionable contract failure.
+func TestBoundariesDependenciesValidatesCompleteOptionShape(t *testing.T) {
+  rule := LookupRule("boundaries/dependencies")
+  validator, ok := rule.(ruleOptionsValidator)
+  if !ok {
+    t.Fatal("boundaries/dependencies must validate options")
+  }
+  invalid := []struct {
+    options string
+    want    string
+  }{
+    {`[]`, `options must be an object`},
+    {`{"unexpected":true}`, `unknown option "unexpected"`},
+    {`{"default":"deny"}`, `must be "allow" or "disallow"`},
+    {`{"policies":[],"rules":[]}`, `cannot be combined`},
+    {`{"elements":[{"type":"app"}]}`, `requires non-empty "type" and "pattern"`},
+    {`{"elements":[{"type":"app","pattern":"src/**","entry":1}]}`, `entry must be a string or array of strings`},
+    {`{"policies":{}}`, `policies must be an array`},
+    {`{"policies":[{"from":"app"}]}`, `requires at least one of "allow" or "disallow"`},
+    {`{"policies":[{"disallow":{"unexpected":true}}]}`, `unknown option "unexpected"`},
+    {`{"policies":[{"disallow":{"dependency":{"kind":"runtime"}}}]}`, `unsupported value "runtime"`},
+    {`{"checkAllOrigins":"yes"}`, `checkAllOrigins must be a boolean`},
+  }
+  for _, test := range invalid {
+    err := validator.ValidateOptions(json.RawMessage(test.options))
+    if err == nil || !strings.Contains(err.Error(), test.want) {
+      t.Fatalf("ValidateOptions(%s) = %v, want error containing %q", test.options, err, test.want)
+    }
+  }
+
+  valid := []string{
+    `{"elements":[{"type":"app","pattern":"src/app/**"}],"rules":[{"from":"app","allow":"app"}]}`,
+    `{"elements":[{"type":"app","pattern":"src/app/**"}],"default":"allow","checkAllOrigins":true,"checkUnknownLocals":true,"checkInternals":true,"policies":[{"from":{"type":"app","entry":false},"dependency":{"kind":"type"},"disallow":{"to":{"origin":"external","source":"pkg"}},"message":"blocked"}]}`,
+  }
+  for _, options := range valid {
+    if err := validator.ValidateOptions(json.RawMessage(options)); err != nil {
+      t.Fatalf("ValidateOptions(%s) = %v", options, err)
+    }
+  }
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_origins_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_origins_test.go
@@ -1,0 +1,33 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesGatesAndSelectsNonLocalOrigins verifies external
+// and core dependencies participate only when explicitly requested.
+//
+// The package-name candidate must match a subpath without overmatching an
+// unrelated external import, and `node:` must remain distinguishable as core.
+// This is the negative twin for accidental all-origin evaluation.
+//
+// 1. Import a blocked package subpath, an allowed package, and a core module.
+// 2. Run with and without `checkAllOrigins` using origin/source selectors.
+// 3. Assert the enabled run reports exactly the blocked package and core module.
+func TestBoundariesDependenciesGatesAndSelectsNonLocalOrigins(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := "import \"@legacy/sdk/client\";\nimport \"react\";\nimport \"node:fs\";\n"
+  base := `
+    "elements":[{"type":"app","pattern":"src/app/**"}],
+    "default":"allow",
+    "policies":[
+      {"from":"app","disallow":{"to":{"origin":"external","source":"@legacy/sdk"}}},
+      {"from":"app","disallow":{"to":{"origin":"core"}}}
+    ]`
+
+  skipped := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+base+`}`, nil)
+  if len(skipped) != 0 {
+    t.Fatalf("default origin gate: want no findings, got %+v", skipped)
+  }
+
+  checked := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{`+base+`,"checkAllOrigins":true}`, nil)
+  assertBoundaryFindingTexts(t, source, checked, `"@legacy/sdk/client"`, `"node:fs"`)
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_path_separators_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_path_separators_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesNormalizesWindowsAndPosixPaths verifies element and
+// local-path selectors are host-independent.
+//
+// LSP, CLI, and project identity paths can cross separator conventions even on
+// one host. Classification must normalize literal backslashes before applying
+// glob semantics rather than relying on the current operating system alone.
+//
+// 1. Classify synthetic Windows and POSIX absolute paths with slash globs.
+// 2. Match a backslash selector against the resulting element-local path.
+// 3. Assert both elements and the private-path glob match identically.
+func TestBoundariesDependenciesNormalizesWindowsAndPosixPaths(t *testing.T) {
+  elements := []boundaryElement{
+    {Type: "app", Pattern: "src/app/**"},
+    {Type: "domain", Pattern: "src/domain/**", Private: boundaryStringList{`internal\**`}},
+  }
+  app := classifyBoundaryFile(`C:\repo\src\app\main.ts`, elements)
+  domain := classifyBoundaryFile(`/repo/src/domain/internal/model.ts`, elements)
+  if app == nil || app.Type != "app" || app.LocalPath != "main.ts" {
+    t.Fatalf("Windows app classification = %+v", app)
+  }
+  if domain == nil || domain.Type != "domain" || domain.LocalPath != "internal/model.ts" {
+    t.Fatalf("POSIX domain classification = %+v", domain)
+  }
+  if !matchBoundaryElementLocalPattern(domain.Private, domain) {
+    t.Fatalf("backslash private selector did not match %+v", domain)
+  }
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_policy_order_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_policy_order_test.go
@@ -1,0 +1,36 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesUsesLastPolicyAndDisallowPrecedence verifies the
+// upstream policy ordering contract in both dimensions.
+//
+// A later allow must override an earlier disallow, while `disallow` must win
+// over `allow` when both effects in the same policy match. Reversing either
+// precedence silently changes architecture policy during migration.
+//
+// 1. Import one domain and one shared element from an app file.
+// 2. Override domain to allowed, but match both effects for shared.
+// 3. Assert only the shared import is rejected.
+func TestBoundariesDependenciesUsesLastPolicyAndDisallowPrecedence(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := "import \"../domain/model\";\nimport \"../shared/value\";\n"
+  findings := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{
+    "elements": [
+      { "type": "app", "pattern": "src/app/**" },
+      { "type": "domain", "pattern": "src/domain/**" },
+      { "type": "shared", "pattern": "src/shared/**" }
+    ],
+    "default": "allow",
+    "policies": [
+      { "from": "app", "disallow": "domain" },
+      { "from": "app", "allow": "domain" },
+      { "from": "app", "allow": "shared", "disallow": "shared" }
+    ]
+  }`, map[string]string{
+    "src/domain/model.ts": "export {};",
+    "src/shared/value.ts": "export {};",
+  })
+  assertSingleBoundaryFinding(t, ruleName, findings, `policy at index 2`)
+  assertBoundaryFindingTexts(t, source, findings, `"../shared/value"`)
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_syntax_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_syntax_test.go
@@ -1,0 +1,64 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesCollectsModuleSyntaxAndMetadata verifies every
+// supported dependency-producing syntax reaches the unified policy engine.
+//
+// The selector checks node kind, dependency kind, and imported specifier name;
+// a collector that only recognizes ordinary imports or erases type metadata
+// cannot satisfy the complete exact-range oracle.
+//
+// 1. Parse static import/export, dynamic import, require, and import-type forms.
+// 2. Select each form through dependency metadata under app-to-domain policy.
+// 3. Assert all six module literals report, including type and typeof imports.
+func TestBoundariesDependenciesCollectsModuleSyntaxAndMetadata(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := `import type { Foo } from "../domain/types";
+export { value } from "../domain/value";
+void import("../domain/dynamic");
+const required = require("../domain/required");
+type Imported = import("../domain/types").Foo;
+type Namespace = typeof import("../domain/value");
+void required;
+`
+  findings := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{
+    "elements": [
+      {"type":"app","pattern":"src/app/**"},
+      {"type":"domain","pattern":"src/domain/**"}
+    ],
+    "default":"allow",
+    "policies": [
+      {
+        "from":"app",
+        "disallow":{
+          "to":"domain",
+          "dependency":{"nodeKind":["ExportDeclaration","ImportCall","RequireCall","ImportType"]}
+        }
+      },
+      {
+        "from":"app",
+        "disallow":{
+          "to":"domain",
+          "dependency":{"kind":"type","nodeKind":"ImportDeclaration","specifiers":"Foo"}
+        }
+      }
+    ]
+  }`, map[string]string{
+    "src/domain/types.ts":    "export interface Foo {}",
+    "src/domain/value.ts":    "export const value = 1;",
+    "src/domain/dynamic.ts":  "export {};",
+    "src/domain/required.ts": "export {};",
+  })
+  assertBoundaryFindingTexts(
+    t,
+    source,
+    findings,
+    `"../domain/types"`,
+    `"../domain/value"`,
+    `"../domain/dynamic"`,
+    `"../domain/required"`,
+    `"../domain/types"`,
+    `"../domain/value"`,
+  )
+}

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_syntax_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_syntax_test.go
@@ -9,18 +9,21 @@ import "testing"
 // a collector that only recognizes ordinary imports or erases type metadata
 // cannot satisfy the complete exact-range oracle.
 //
-// 1. Parse static import/export, dynamic import, require, and import-type forms.
-// 2. Select each form through dependency metadata under app-to-domain policy.
-// 3. Assert all six module literals report, including type and typeof imports.
+//  1. Parse static import/export, import-equals, dynamic import, require, and
+//     import-type forms.
+//  2. Select each form through dependency metadata under app-to-domain policy.
+//  3. Assert all seven module literals report, including type and typeof imports.
 func TestBoundariesDependenciesCollectsModuleSyntaxAndMetadata(t *testing.T) {
   const ruleName = "boundaries/dependencies"
   source := `import type { Foo } from "../domain/types";
 export { value } from "../domain/value";
+import legacy = require("../domain/required");
 void import("../domain/dynamic");
 const required = require("../domain/required");
 type Imported = import("../domain/types").Foo;
 type Namespace = typeof import("../domain/value");
 void required;
+void legacy;
 `
   findings := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{
     "elements": [
@@ -33,7 +36,7 @@ void required;
         "from":"app",
         "disallow":{
           "to":"domain",
-          "dependency":{"nodeKind":["ExportDeclaration","ImportCall","RequireCall","ImportType"]}
+          "dependency":{"nodeKind":["ExportDeclaration","ImportEqualsDeclaration","ImportCall","RequireCall","ImportType"]}
         }
       },
       {
@@ -57,6 +60,7 @@ void required;
     `"../domain/types"`,
     `"../domain/value"`,
     `"../domain/dynamic"`,
+    `"../domain/required"`,
     `"../domain/required"`,
     `"../domain/types"`,
     `"../domain/value"`,

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_test.go
@@ -2,33 +2,25 @@ package linthost
 
 import "testing"
 
-// TestBoundariesDependenciesLoadsWithoutDiagnostics verifies the
-// `boundaries/dependencies` rule registers, accepts the upstream
-// `elements` + `rules` config shape, and silently passes for any file
-// in the v1 stub release.
+// TestBoundariesDependenciesRejectsDisallowedDirection verifies the unified
+// rule enforces a configured source-to-target dependency policy.
 //
-// The unified rule will eventually subsume `element-types`,
-// `entry-point`, `external`, `no-private`, and `no-unknown`. Until that
-// port lands, this test pins the contract: configs may claim the rule
-// id today without breaking lint runs, and no diagnostic appears for
-// files the legacy split rules would have flagged.
+// This replaces the former zero-diagnostic stub witness with an observable
+// direction check. The adjacent same-element import is the negative twin: it
+// remains outside evaluation unless `checkInternals` is enabled.
 //
-// 1. Materialize an app/domain project that `element-types` would flag.
-// 2. Configure `boundaries/dependencies` with the equivalent policy.
-// 3. Assert zero findings (stub behavior).
-func TestBoundariesDependenciesLoadsWithoutDiagnostics(t *testing.T) {
+// 1. Materialize app, domain, and app-local source files.
+// 2. Disallow app-to-domain dependencies with an allow fallback.
+// 3. Assert only the domain module literal is reported at its exact range.
+func TestBoundariesDependenciesRejectsDisallowedDirection(t *testing.T) {
   const ruleName = "boundaries/dependencies"
-  if LookupRule(ruleName) == nil {
-    t.Fatalf("missing %s rule registration", ruleName)
-  }
-  findings := runBoundaryRule(t, ruleName, "src/app/main.ts", `
-    import "../domain/internal";
-    import "./local";
-  `, `{
+  source := "import \"../domain/internal\";\nimport \"./local\";\n"
+  findings := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{
     "elements": [
       { "type": "app", "pattern": "src/app/**" },
       { "type": "domain", "pattern": "src/domain/**" }
     ],
+    "default": "allow",
     "rules": [
       { "from": "app", "disallow": "domain" }
     ]
@@ -36,7 +28,6 @@ func TestBoundariesDependenciesLoadsWithoutDiagnostics(t *testing.T) {
     "src/app/local.ts":       "export {};",
     "src/domain/internal.ts": "export {};",
   })
-  if len(findings) != 0 {
-    t.Fatalf("%s v1 stub must not emit diagnostics yet, got %d (%+v)", ruleName, len(findings), findings)
-  }
+  assertSingleBoundaryFinding(t, ruleName, findings, `domain`)
+  assertBoundaryFindingTexts(t, source, findings, `"../domain/internal"`)
 }

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_visibility_selectors_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_visibility_selectors_test.go
@@ -31,7 +31,7 @@ func TestBoundariesDependenciesSelectsEntryAndPrivateTargets(t *testing.T) {
       {"from":"app","disallow":{"to":{"type":"domain","entry":false,"path":"public/**"}}}
     ]
   }`, map[string]string{
-    "src/domain/index.ts":          "export {};",
+    "src/domain/index.ts":           "export {};",
     "src/domain/internal/secret.ts": "export {};",
     "src/domain/public/detail.ts":   "export {};",
   })

--- a/packages/lint/test/rules/boundaries/boundaries_dependencies_visibility_selectors_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_dependencies_visibility_selectors_test.go
@@ -1,0 +1,45 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesDependenciesSelectsEntryAndPrivateTargets verifies visibility
+// metadata participates in unified dependency policies.
+//
+// Entry and private classification reuse the legacy element-local glob logic.
+// Pairing an allowed entry with private and non-entry targets guards against
+// treating every file in an element as having the same visibility.
+//
+// 1. Import a domain entry, private implementation, and non-entry public file.
+// 2. Disallow private files and selected non-entry public paths.
+// 3. Assert the entry passes while both restricted targets report.
+func TestBoundariesDependenciesSelectsEntryAndPrivateTargets(t *testing.T) {
+  const ruleName = "boundaries/dependencies"
+  source := "import \"../domain\";\nimport \"../domain/internal/secret\";\nimport \"../domain/public/detail\";\n"
+  findings := runBoundaryRule(t, ruleName, "src/app/main.ts", source, `{
+    "elements": [
+      {"type":"app","pattern":"src/app/**"},
+      {
+        "type":"domain",
+        "pattern":"src/domain/**",
+        "entry":"index.ts",
+        "private":"internal/**"
+      }
+    ],
+    "default":"allow",
+    "policies": [
+      {"from":"app","disallow":{"to":{"type":"domain","private":true}}},
+      {"from":"app","disallow":{"to":{"type":"domain","entry":false,"path":"public/**"}}}
+    ]
+  }`, map[string]string{
+    "src/domain/index.ts":          "export {};",
+    "src/domain/internal/secret.ts": "export {};",
+    "src/domain/public/detail.ts":   "export {};",
+  })
+  assertBoundaryFindingTexts(
+    t,
+    source,
+    findings,
+    `"../domain/internal/secret"`,
+    `"../domain/public/detail"`,
+  )
+}

--- a/packages/lint/test/rules/boundaries/boundaries_element_types_ignores_dynamic_syntax_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_element_types_ignores_dynamic_syntax_test.go
@@ -1,0 +1,39 @@
+package linthost
+
+import "testing"
+
+// TestBoundariesElementTypesIgnoresDynamicSyntax verifies the legacy split
+// rules keep their static import/export dependency surface.
+//
+// The unified `boundaries/dependencies` collector also gathers `import()`,
+// `require()`, `import =`, and import-type nodes. Legacy rules ship a narrower
+// shipped contract, so sharing the extended collector would silently widen
+// `element-types` (and its siblings) in the same release that implements the
+// unified rule.
+//
+// 1. Load a disallowed domain target through dynamic import and require only.
+// 2. Run the legacy `element-types` policy that rejects static domain imports.
+// 3. Assert the legacy rule stays silent while `dependencies` reports both.
+func TestBoundariesElementTypesIgnoresDynamicSyntax(t *testing.T) {
+  source := "void import(\"../domain/dynamic\");\nconst required = require(\"../domain/required\");\nvoid required;\n"
+  files := map[string]string{
+    "src/domain/dynamic.ts":  "export {};",
+    "src/domain/required.ts": "export {};",
+  }
+  options := `{
+    "elements": [
+      {"type":"app","pattern":"src/app/**"},
+      {"type":"domain","pattern":"src/domain/**"}
+    ],
+    "default":"allow",
+    "rules":[{"from":"app","disallow":"domain"}]
+  }`
+
+  legacy := runBoundaryRule(t, "boundaries/element-types", "src/app/main.ts", source, options, files)
+  if len(legacy) != 0 {
+    t.Fatalf("element-types must ignore dynamic dependency syntax, got %+v", legacy)
+  }
+
+  unified := runBoundaryRule(t, "boundaries/dependencies", "src/app/main.ts", source, options, files)
+  assertBoundaryFindingTexts(t, source, unified, `"../domain/dynamic"`, `"../domain/required"`)
+}

--- a/packages/lint/test/rules/boundaries/boundaries_helpers_test.go
+++ b/packages/lint/test/rules/boundaries/boundaries_helpers_test.go
@@ -3,6 +3,7 @@ package linthost
 import (
   "encoding/json"
   "path/filepath"
+  "sort"
   "strings"
   "testing"
 
@@ -38,5 +39,94 @@ func assertSingleBoundaryFinding(t *testing.T, ruleName string, findings []*Find
   }
   if len(findings[0].Fix) != 0 {
     t.Fatalf("%s: boundaries diagnostics must not offer autofixes", ruleName)
+  }
+}
+
+func runBoundaryRuleProgram(
+  t *testing.T,
+  ruleName string,
+  sourcePath string,
+  source string,
+  optsJSON string,
+  extraFiles map[string]string,
+  compilerOptions map[string]any,
+) []*Finding {
+  t.Helper()
+  root := t.TempDir()
+  files := make([]string, 0, len(extraFiles)+1)
+  files = append(files, filepath.ToSlash(sourcePath))
+  writeFile(t, filepath.Join(root, filepath.FromSlash(sourcePath)), source)
+  for relative, text := range extraFiles {
+    files = append(files, filepath.ToSlash(relative))
+    writeFile(t, filepath.Join(root, filepath.FromSlash(relative)), text)
+  }
+  sort.Strings(files)
+
+  options := map[string]any{
+    "target":           "ES2022",
+    "module":           "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict":           true,
+    "noEmit":           true,
+    "baseUrl":          ".",
+  }
+  for name, value := range compilerOptions {
+    options[name] = value
+  }
+  config, err := json.Marshal(map[string]any{
+    "compilerOptions": options,
+    "files":           files,
+  })
+  if err != nil {
+    t.Fatalf("marshal tsconfig: %v", err)
+  }
+  writeFile(t, filepath.Join(root, "tsconfig.json"), string(config))
+
+  resolver := InlineRuleResolver{
+    Rules:   RuleConfig{ruleName: SeverityError},
+    Options: RuleOptionsMap{ruleName: json.RawMessage(optsJSON)},
+  }
+  engine := NewEngineWithResolver(resolver)
+  if err := engine.ConfigError(); err != nil {
+    t.Fatalf("%s config: %v", ruleName, err)
+  }
+  engine.SetCurrentDirectory(root)
+  program, diagnostics, err := loadProgram(root, "tsconfig.json", loadProgramOptions{
+    forceNoEmit:      true,
+    needsRuleChecker: engine.NeedsTypeChecker(),
+  })
+  if program != nil {
+    defer program.close()
+  }
+  if err != nil {
+    t.Fatalf("%s loadProgram: %v", ruleName, err)
+  }
+  if len(diagnostics) != 0 {
+    t.Fatalf("%s loadProgram diagnostics: %+v", ruleName, diagnostics)
+  }
+  if program == nil || program.checker == nil {
+    t.Fatalf("%s requires a checker-backed Program", ruleName)
+  }
+  return program.runLintCycle(engine)
+}
+
+func assertBoundaryFindingTexts(t *testing.T, source string, findings []*Finding, expected ...string) {
+  t.Helper()
+  if len(findings) != len(expected) {
+    t.Fatalf("want %d findings, got %d (%+v)", len(expected), len(findings), findings)
+  }
+  actual := make([]string, 0, len(findings))
+  for _, finding := range findings {
+    if finding.Pos < 0 || finding.End < finding.Pos || finding.End > len(source) {
+      t.Fatalf("invalid finding range %d..%d for %d-byte source", finding.Pos, finding.End, len(source))
+    }
+    actual = append(actual, source[finding.Pos:finding.End])
+  }
+  sort.Strings(actual)
+  sort.Strings(expected)
+  for index := range expected {
+    if actual[index] != expected[index] {
+      t.Fatalf("finding texts mismatch: want %q, got %q", expected, actual)
+    }
   }
 }

--- a/tests/test-lint/src/cases/boundaries-dependencies.ts
+++ b/tests/test-lint/src/cases/boundaries-dependencies.ts
@@ -3,16 +3,14 @@
  *
  * The unified upstream rule replaces `element-types` / `entry-point` /
  * `external` / `no-private` / `no-unknown` with one direction-aware
- * policy block. The native port currently ships as a v1 stub: it
- * registers the rule name, accepts the upstream `elements` + `rules`
- * config shape, and emits no diagnostics. The Go test under
- * `packages/lint/test/rules/boundaries/boundaries_dependencies_test.go`
- * pins that contract.
+ * policy block. The native port resolves local targets through TypeScript,
+ * classifies aliases and relative imports against `elements`, and evaluates
+ * ordered allow/disallow effects across entity and dependency metadata.
  *
  * This fixture exists to document the rule id in the consumer corpus
  * tree. It declares no `// expect:` annotations, so the corpus runner
- * skips it; once the rule grows real diagnostics, replace this body
- * with annotated positive/negative cases.
+ * skips it; package-level tests materialize the multi-file layouts and real
+ * command runs needed to exercise the rule.
  *
  * Example config:
  *

--- a/website/src/content/docs/lint/rules/boundaries.mdx
+++ b/website/src/content/docs/lint/rules/boundaries.mdx
@@ -185,26 +185,74 @@ import "../shared/util";
 
 ### `boundaries/dependencies`
 
-Unified dependency-direction rule from upstream `eslint-plugin-boundaries`, intended to replace `element-types` / `entry-point` / `external` / `no-private` / `no-unknown` with a single policy block.
+Unified, direction-aware dependency policy from upstream `eslint-plugin-boundaries`.
 
-The native port registers the rule name and accepts the same `elements` + `rules` config shape as `element-types`, but does not emit diagnostics yet (v1 stub; full direction validation deferred).
+The rule classifies TypeScript-resolved targets, including `paths` aliases and re-exports, before evaluating policy. It recognizes static imports, exports, `import = require`, dynamic `import()`, static `require()`, and `import()` type nodes. Declaration files use the same policy.
 
-Configure it today to claim the upstream rule id; the legacy split rules continue to enforce policy.
+Policies are processed in order and the last matching effect wins. Within one policy, `disallow` is checked before `allow`. String selectors remain shorthand for element types; object selectors can also match `origin`, `source`, element-local `path`, and `entry` / `private` / `unknown` classification.
 
 Options:
 
 - `default?: "allow" | "disallow"`
 
-  Fallback policy when no rule matches. Default: `"allow"`.
+  Fallback policy when no effect matches. Default: `"disallow"`.
 
-- `rules?: readonly ITtscLintBoundariesElementTypesRule[]`
+- `policies?: readonly ITtscLintBoundariesDependenciesPolicy[]`
 
-  Ordered dependency policies. First matching policy wins.
+  Ordered dependency policies. This is the preferred current name.
+
+- `rules?: readonly ITtscLintBoundariesDependenciesPolicy[]`
+
+  Compatibility alias for `policies`; do not configure both.
+
+- `checkAllOrigins?: boolean`
+
+  Check external and `node:` dependencies as well as local targets. Default: `false`.
+
+- `checkUnknownLocals?: boolean`
+
+  Check resolved or unresolved local targets that match no configured element. Default: `false`.
+
+- `checkInternals?: boolean`
+
+  Check dependencies within the same configured element root. Default: `false`.
+
+- `message?: string`
+
+  Global diagnostic override. Policy messages take precedence. Messages can use `{{from.type}}`, `{{to.type}}`, `{{dependency.source}}`, `{{dependency.kind}}`, and `{{policy.index}}`.
 
 Example:
 
 ```ts
 // src/app/main.ts
+// reports: boundaries/dependencies (error)
 import "../domain/internal";
 import "./local";
+
+// lint.config.ts
+export default {
+  rules: {
+    "boundaries/dependencies": [
+      "error",
+      {
+        elements: [
+          { type: "app", pattern: "src/app/**" },
+          {
+            type: "domain",
+            pattern: "src/domain/**",
+            entry: "index.ts",
+            private: "internal/**",
+          },
+        ],
+        default: "allow",
+        policies: [
+          {
+            from: "app",
+            disallow: { to: { type: "domain", private: true } },
+          },
+        ],
+      },
+    ],
+  },
+} satisfies ITtscLintConfig;
 ```

--- a/website/src/content/docs/lint/rules/boundaries.mdx
+++ b/website/src/content/docs/lint/rules/boundaries.mdx
@@ -219,14 +219,14 @@ Options:
 
 - `message?: string`
 
-  Global diagnostic override. Policy messages take precedence. Messages can use `{{from.type}}`, `{{to.type}}`, `{{dependency.source}}`, `{{dependency.kind}}`, and `{{policy.index}}`.
+  Global diagnostic override. Policy messages take precedence. Messages can use `{{from.type}}`, `{{from.path}}`, `{{from.origin}}`, `{{to.type}}`, `{{to.path}}`, `{{to.origin}}`, `{{dependency.source}}`, `{{dependency.kind}}`, `{{dependency.nodeKind}}`, and `{{policy.index}}`.
 
 Example:
 
 ```ts
 // src/app/main.ts
 // reports: boundaries/dependencies (error)
-import "../domain/internal";
+import "../domain/internal/secret";
 import "./local";
 
 // lint.config.ts


### PR DESCRIPTION
## Intent

Make the published `boundaries/dependencies` rule enforce architecture contracts instead of silently accepting every dependency.

## Scope

- implement ordered direction-aware policies with current upstream precedence
- preserve legacy string selectors while adding entity and dependency metadata selectors
- resolve TypeScript path aliases through the checker and retain relative-path fallback
- collect imports, re-exports, import-equals, dynamic imports, static requires, and import-type nodes
- gate external/core, unknown-local, and internal dependencies explicitly
- validate malformed options before dispatch
- update public types, rule documentation, and the consumer corpus note
- replace the no-op witness with exact-range, command-path, declaration, alias, visibility, path, message, and option regressions

## Test plan

- complete three sequential exhaustive whole-PR reviews on one exact head
- run the focused boundaries Go regression set through the package test harness
- build `@ttsc/lint` and type-check the public option surface
- leave the full matrix to GitHub Actions after the focused local proof

## Deferred

None within the repository's documented `elements`-based selector model.

Closes #476