### PR TITLE
docs(graph): rebuild the benchmark story around the time-to-answer chart

### DIFF
--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -57,9 +57,13 @@ Every repository is asked the same onboarding question, a plain code tour. Acros
 
 An index answers nothing until it is built, and a developer waits for it before the agent can ask anything at all. This is the other half of the trade: a tool that cuts the token bill and then spends twelve minutes indexing has moved the cost, not removed it.
 
-The faded head of each bar is the cold index build, the solid tail is the answer, and every bar is labelled `index / answer` in the order you wait for them. The baseline has no index to build.
+The faded head of each bar is the cold index build, the solid tail is the LLM answering, and every bar is labelled `index / LLM` in the order you wait for them. The baseline has no index to build.
 
 ![Cold time to a first answer, per repository](https://ttsc.dev/benchmark/svg/graph-time-to-answer.svg)
+
+At three million lines the index question stops being academic. On VS Code, `@ttsc/graph` builds in 29 seconds — the graph is a byproduct of the type-check the compiler runs anyway — where `codegraph` spends twelve minutes and serena four and a half:
+
+![Cold time to a first answer, VS Code alone](https://ttsc.dev/benchmark/svg/graph-time-to-answer-vscode.svg)
 
 The interactive charts, every model, and the method are on the benchmark page: https://ttsc.dev/docs/benchmark/graph
 

--- a/website/build/graph-benchmark-svg.cjs
+++ b/website/build/graph-benchmark-svg.cjs
@@ -137,6 +137,13 @@ for (const combo of combos.values()) {
 if (report.index && (report.index.cells ?? []).length > 0) {
   writeSvg("graph-index-build-time.svg", renderIndex(report.index));
   writeSvg("graph-time-to-answer.svg", renderTime(report.index, allCells));
+  writeSvg(
+    "graph-time-to-answer-vscode.svg",
+    renderTime(report.index, allCells, {
+      only: "vscode",
+      title: "Cold time to a first answer — VS Code, 3.4M lines (lower is better)",
+    }),
+  );
 }
 
 const pngs = writePngs();
@@ -525,15 +532,16 @@ function renderIndex(index) {
 }
 
 // The wall clock a first answer costs from a cold checkout: build the tool's
-// index once, then ask. The faded head of each bar is the build; the solid tail
-// is the median time the agent spent answering, over every model and both prompt
-// families, so each tool faces the same mix.
+// index once, then ask. The faded head of each bar is the index build; the
+// solid tail is the median time the LLM spent answering, over every model and
+// both prompt families, so each tool faces the same mix.
 //
 // It is the other half of the trade a context-saving tool is making. A tool that
 // cuts an agent's token bill and then spends four minutes indexing and three
 // more re-searching what it indexed has moved the cost, not removed it.
-function renderTime(index, cells) {
+function renderTime(index, cells, options = {}) {
   const rows = [...new Set(index.cells.map((cell) => cell.project))]
+    .filter((project) => !options.only || project === options.only)
     .map((project) => ({
       project,
       label: REPO_LABELS[project] ?? project,
@@ -552,16 +560,18 @@ function renderTime(index, cells) {
     .filter((row) => row.values.length > 0)
     .sort((a, b) => a.scale.lines - b.scale.lines);
 
-  // A group of five bars is 75px tall and the row it sat in was 76, so the
-  // repositories ran together into one wall and the reader had to count bars to
-  // find where Vue ended and NestJS began. The plot is taller now: each project
-  // gets its own band of whitespace, and the eye lands on a repository before it
-  // reads a tool.
+  // One repository per band of whitespace, so a project reads as a block before
+  // the eye starts picking tools out of it. A single-project render (the VS
+  // Code cut) gets thicker bars instead of empty air.
+  const single = rows.length === 1;
+  const barHeight = single ? 26 : 11;
+  const barStep = single ? 38 : 15;
+  const rowHeight = single ? 5 * barStep + 40 : 90;
   const width = 1040;
-  const height = 920;
-  const chart = { left: 160, right: 940, top: 130, bottom: 850 };
+  const chart = { left: 160, right: 900, top: 150 };
+  chart.bottom = chart.top + rows.length * rowHeight;
+  const height = chart.bottom + 80;
   const plotWidth = chart.right - chart.left;
-  const plotHeight = chart.bottom - chart.top;
   const max = niceMax(
     Math.max(
       1,
@@ -571,17 +581,13 @@ function renderTime(index, cells) {
     ),
   );
   const ticks = [0, max * 0.25, max * 0.5, max * 0.75, max];
-  const rowHeight = plotHeight / rows.length;
-  const barHeight = 11;
-  const barStep = 15;
   const bandHeight = rowHeight - 14;
-  const title = "Cold time to a first answer (lower is better)";
+  const title =
+    options.title ?? "Cold time to a first answer (lower is better)";
   const host = index.host
     ? `${index.host.cpu}, ${index.host.cores} cores, ${index.host.ramGB} GB — ${index.host.os}`
     : "";
 
-  // One band per repository, under the grid, so a project reads as a block
-  // before the eye starts picking tools out of it.
   const bands = rows
     .map((row, rowIndex) => {
       const center = chart.top + rowIndex * rowHeight + rowHeight / 2;
@@ -611,6 +617,7 @@ function renderTime(index, cells) {
         const y = groupTop + i * barStep;
         const buildWidth = (value.buildMs / max) * plotWidth;
         const answerWidth = (value.answerMs / max) * plotWidth;
+        const textY = y + barHeight / 2 + 4;
         if (value.buildMs > 0)
           lines.push(
             `  <rect x="${chart.left}" y="${y.toFixed(1)}" width="${buildWidth.toFixed(1)}" height="${barHeight}" fill="${value.color}" fill-opacity="0.35" rx="2"/>`,
@@ -618,42 +625,41 @@ function renderTime(index, cells) {
         lines.push(
           `  <rect x="${(chart.left + buildWidth).toFixed(1)}" y="${y.toFixed(1)}" width="${answerWidth.toFixed(1)}" height="${barHeight}" fill="${value.color}" rx="2"/>`,
         );
-        // Both halves of the wait, in the order they are paid: the index build,
-        // then the answer. A tool with no index to build says so with a zero,
-        // which is the point of putting them side by side.
+        // Both halves of the wait, in the order they are paid: (index / LLM).
+        // A tool with no index to build says so with a zero, which is the point
+        // of putting them side by side.
         lines.push(
-          `  <text x="${(chart.left + buildWidth + answerWidth + 8).toFixed(1)}" y="${(y + barHeight - 1).toFixed(1)}" fill="${value.color}" font-size="11">${escapeXml(`${fmtSeconds(value.buildMs)} / ${fmtSeconds(value.answerMs)}`)}</text>`,
+          `  <text x="${(chart.left + buildWidth + answerWidth + 8).toFixed(1)}" y="${textY.toFixed(1)}" fill="${value.color}" font-size="${single ? 13 : 11}">${escapeXml(`(${fmtCompact(value.buildMs)} / ${fmtCompact(value.answerMs)})`)}</text>`,
         );
       });
       return lines.join("\n");
     })
     .join("\n");
 
-  // Two legends, because the bar carries two facts. The colours say which tool,
-  // and the shades say which half of the wait — and the label beside each bar
-  // reads in that same order, `index / answer`, so a tool with no index to build
-  // shows a zero where the others show a minute.
+  // Two legends, because a bar carries two facts. The colours say which tool;
+  // the worked example says which shade is which wait, using the same two-tone
+  // bar the chart draws, so the reader learns the encoding by seeing it once.
   const legend = TOOLS.map((tool, i) =>
     [
-      `  <rect x="${100 + i * 175}" y="80" width="12" height="12" fill="${tool.color}" rx="2"/>`,
-      `  <text x="${118 + i * 175}" y="90" fill="#cbd5f5" font-size="12">${escapeXml(tool.label)}</text>`,
+      `  <rect x="${40 + i * 175}" y="78" width="12" height="12" fill="${tool.color}" rx="2"/>`,
+      `  <text x="${58 + i * 175}" y="88" fill="#cbd5f5" font-size="12">${escapeXml(tool.label)}</text>`,
     ].join("\n"),
   ).join("\n");
   const shadeLegend = [
-    `  <rect x="100" y="100" width="12" height="12" fill="#94a3b8" fill-opacity="0.35" rx="2"/>`,
-    `  <text x="118" y="110" fill="#94a3b8" font-size="11">index build</text>`,
-    `  <rect x="215" y="100" width="12" height="12" fill="#94a3b8" rx="2"/>`,
-    `  <text x="233" y="110" fill="#94a3b8" font-size="11">answer</text>`,
-    `  <text x="300" y="110" fill="#64748b" font-size="11">— each bar is labelled index / answer, in the order you wait for them</text>`,
+    `  <rect x="40" y="104" width="56" height="15" fill="#22d3ee" fill-opacity="0.35" rx="2"/>`,
+    `  <rect x="96" y="104" width="36" height="15" fill="#22d3ee" rx="2"/>`,
+    `  <text x="68" y="115.5" fill="#e2e8f0" font-size="10" font-weight="bold" text-anchor="middle">index</text>`,
+    `  <text x="114" y="115.5" fill="#0b0f14" font-size="10" font-weight="bold" text-anchor="middle">LLM</text>`,
+    `  <text x="142" y="115.5" fill="#cbd5f5" font-size="12">${escapeXml("faded = index build, solid = LLM answering — every bar is labelled (index / LLM)")}</text>`,
   ].join("\n");
 
   return [
     `<?xml version="1.0" encoding="utf-8" standalone="no"?>`,
     `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" version="1.1" role="img" aria-label="${escapeXml(title)}">`,
     ` <rect width="${width}" height="${height}" fill="#0b0f14"/>`,
-    ` <text x="40" y="46" fill="#f8fafc" font-size="20" font-weight="bold" font-family="DejaVu Sans, Arial, sans-serif">${escapeXml(title)}</text>`,
-    ` <text x="40" y="68" fill="#64748b" font-size="12" font-family="DejaVu Sans, Arial, sans-serif">${escapeXml(host)}</text>`,
-    ` <text x="40" y="${height - 22}" fill="#64748b" font-size="11" font-family="DejaVu Sans, Arial, sans-serif">Cold checkout: build the tool's index once, then ask. The answer is the median wall clock over four models and both prompt families; the baseline has no index to build.</text>`,
+    ` <text x="40" y="42" fill="#f8fafc" font-size="20" font-weight="bold" font-family="DejaVu Sans, Arial, sans-serif">${escapeXml(title)}</text>`,
+    ` <text x="40" y="62" fill="#64748b" font-size="12" font-family="DejaVu Sans, Arial, sans-serif">${escapeXml(host)}</text>`,
+    ` <text x="40" y="${height - 20}" fill="#64748b" font-size="11" font-family="DejaVu Sans, Arial, sans-serif">Cold checkout: build the tool's index once, then ask. LLM time is the median wall clock over four models and both prompt families; the baseline has no index to build.</text>`,
     legend,
     shadeLegend,
     bands,
@@ -661,6 +667,20 @@ function renderTime(index, cells) {
     bars,
     `</svg>`,
   ].join("\n");
+}
+
+/**
+ * Compact seconds for the in-chart labels: "30s", "5s", "0.4s", "732s".
+ *
+ * One unit, no space, because the label carries two of these plus punctuation
+ * and sits beside a bar; "(732s / 41s)" reads in a glance where
+ * "12.2 min / 41 s" makes the reader convert units before comparing.
+ */
+function fmtCompact(ms) {
+  const seconds = ms / 1000;
+  if (seconds === 0) return "0s";
+  if (seconds >= 10) return `${Math.round(seconds).toLocaleString("en-US")}s`;
+  return `${seconds.toFixed(1)}s`;
 }
 
 function medianAnswerMs(cells, project, tool) {

--- a/website/build/graph-benchmark-svg.cjs
+++ b/website/build/graph-benchmark-svg.cjs
@@ -135,7 +135,6 @@ for (const combo of combos.values()) {
 // The index axis: what readiness costs before a tool can answer anything. It
 // is not a token chart, so it renders on its own scale (wall clock).
 if (report.index && (report.index.cells ?? []).length > 0) {
-  writeSvg("graph-index-build-time.svg", renderIndex(report.index));
   writeSvg("graph-time-to-answer.svg", renderTime(report.index, allCells));
   writeSvg(
     "graph-time-to-answer-vscode.svg",
@@ -192,12 +191,12 @@ function buildRows(input) {
 
 function render(rows, title) {
   const width = 1040;
-  const height = 900;
+  const height = 940;
   const chart = {
-    left: 124,
+    left: 136,
     right: 1016,
-    top: 116,
-    bottom: 830,
+    top: 128,
+    bottom: 866,
   };
   const plotWidth = chart.right - chart.left;
   const plotHeight = chart.bottom - chart.top;
@@ -209,8 +208,8 @@ function render(rows, title) {
   );
   const ticks = [0, max * 0.25, max * 0.5, max * 0.75, max];
   const rowHeight = plotHeight / rows.length;
-  const barHeight = 9;
-  const barStep = 13.5;
+  const barHeight = 10.5;
+  const barStep = 15.5;
 
   return `<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" version="1.1" role="img" aria-label="${escapeXml(title)}">
@@ -233,7 +232,7 @@ function render(rows, title) {
        const x = chart.left + (tick / max) * plotWidth;
        return `<g>
     <path d="M ${x.toFixed(3)} ${chart.top} L ${x.toFixed(3)} ${chart.bottom}" style="fill:none;stroke:${COLORS.grid};stroke-width:0.7"/>
-    <text x="${x.toFixed(3)}" y="${chart.bottom + 18}" style="fill:${COLORS.label};font-size:11px;text-anchor:middle">${formatTick(tick)}</text>
+    <text x="${x.toFixed(3)}" y="${chart.bottom + 18}" style="fill:${COLORS.label};font-size:13px;text-anchor:middle">${formatTick(tick)}</text>
    </g>`;
      })
      .join("\n   ")}
@@ -244,31 +243,31 @@ function render(rows, title) {
        const barTop = rowTop + (rowHeight - (TOOLS.length - 1) * barStep) / 2;
        return `<g>
     <path d="M 18 ${(rowTop + rowHeight).toFixed(3)} L ${chart.right} ${(rowTop + rowHeight).toFixed(3)}" style="fill:none;stroke:${COLORS.grid};stroke-width:0.6"/>
-    <text x="${chart.left - 16}" y="${labelY.toFixed(3)}" style="fill:${COLORS.title};font-size:13px;font-weight:600;text-anchor:end">${escapeXml(row.label)}</text>
+    <text x="${chart.left - 16}" y="${labelY.toFixed(3)}" style="fill:${COLORS.title};font-size:15px;font-weight:600;text-anchor:end">${escapeXml(row.label)}</text>
     ${row.values
       .map((value, valueIndex) => {
         if (value.value <= 0) return "";
         const barWidth = Math.max(2, (value.value / max) * plotWidth);
         const label = valueLabel(row, value);
         const best = value.value === minTokens(row);
-        const labelWidth = estimateTextWidth(label, 11, best ? 700 : 400);
+        const labelWidth = estimateTextWidth(label, 13, best ? 700 : 400);
         const textX = Math.min(
           chart.left + barWidth + 5,
           width - labelWidth - 8,
         );
         const y = barTop + valueIndex * barStep;
         return `<rect x="${chart.left}" y="${y.toFixed(3)}" width="${barWidth.toFixed(3)}" height="${barHeight}" style="fill:${value.color}"/>
-    <text x="${textX.toFixed(3)}" y="${(y + barHeight - 0.7).toFixed(3)}" style="fill:${valueLabelColor(row, value)};font-size:11px${best ? ";font-weight:700" : ""}">${escapeXml(label)}</text>`;
+    <text x="${textX.toFixed(3)}" y="${(y + barHeight - 0.7).toFixed(3)}" style="fill:${valueLabelColor(row, value)};font-size:13px${best ? ";font-weight:700" : ""}">${escapeXml(label)}</text>`;
       })
       .filter(Boolean)
       .join("\n    ")}
    </g>`;
      })
      .join("\n   ")}
-   <text x="${(chart.left + plotWidth / 2).toFixed(3)}" y="28" style="fill:${COLORS.title};font-size:20px;font-weight:600;text-anchor:middle">${escapeXml(title)}</text>
-   <text x="${(chart.left + plotWidth / 2).toFixed(3)}" y="${chart.bottom + 44}" style="fill:${COLORS.label};font-size:13px;text-anchor:middle">Tokens</text>
-   ${renderLegend(chart.left, 58)}
-   <text x="${chart.left}" y="80" style="fill:${COLORS.muted};font-size:12px">Lower is better. Percentage is versus the no-MCP baseline.</text>
+   <text x="${(chart.left + plotWidth / 2).toFixed(3)}" y="30" style="fill:${COLORS.title};font-size:22px;font-weight:600;text-anchor:middle">${escapeXml(title)}</text>
+   <text x="${(chart.left + plotWidth / 2).toFixed(3)}" y="${chart.bottom + 46}" style="fill:${COLORS.label};font-size:14px;text-anchor:middle">Tokens</text>
+   ${renderLegend(chart.left, 60)}
+   <text x="${chart.left}" y="86" style="fill:${COLORS.muted};font-size:13px">Lower is better. Percentage is versus the no-MCP baseline.</text>
   </g>
  </g>
 </svg>`;
@@ -279,8 +278,8 @@ function render(rows, title) {
 // read at a glance.
 function renderSingle(row, cfg) {
   const width = 1040;
-  const height = 430;
-  const left = 124;
+  const height = 440;
+  const left = 136;
   const right = 1016;
   const top = 72;
   const bottom = 372;
@@ -299,12 +298,12 @@ function renderSingle(row, cfg) {
       const center = barY + barHeight / 2;
       const barWidth = Math.max(2, (value.value / max) * plotWidth);
       const label = valueLabel(row, value);
-      const labelWidth = estimateTextWidth(label, 12, 400);
+      const labelWidth = estimateTextWidth(label, 14, 400);
       const textX = Math.min(left + barWidth + 8, width - labelWidth - 8);
       return `<g>
-    <text x="${left - 8}" y="${(center + 4).toFixed(3)}" style="fill:${COLORS.title};font-size:13px;font-weight:600;text-anchor:end">${escapeXml(value.label)}</text>
+    <text x="${left - 8}" y="${(center + 4).toFixed(3)}" style="fill:${COLORS.title};font-size:15px;font-weight:600;text-anchor:end">${escapeXml(value.label)}</text>
     <rect x="${left}" y="${barY.toFixed(3)}" width="${barWidth.toFixed(3)}" height="${barHeight}" style="fill:${value.color}"/>
-    <text x="${textX.toFixed(3)}" y="${(center + 4).toFixed(3)}" style="fill:${valueLabelColor(row, value)};font-size:12px">${escapeXml(label)}</text>
+    <text x="${textX.toFixed(3)}" y="${(center + 4).toFixed(3)}" style="fill:${valueLabelColor(row, value)};font-size:14px">${escapeXml(label)}</text>
    </g>`;
     })
     .join("\n   ");
@@ -312,7 +311,7 @@ function renderSingle(row, cfg) {
   const baselineRef =
     row.baseline > 0
       ? `<line x1="${baselineX.toFixed(3)}" y1="${top}" x2="${baselineX.toFixed(3)}" y2="${bottom}" style="stroke:${COLORS.axis};stroke-width:1;stroke-dasharray:4 4"/>
-   <text x="${(baselineX + 4).toFixed(3)}" y="${top + 14}" style="fill:${COLORS.muted};font-size:11px">no-MCP baseline</text>`
+   <text x="${(baselineX + 4).toFixed(3)}" y="${top + 14}" style="fill:${COLORS.muted};font-size:12.5px">no-MCP baseline</text>`
       : "";
 
   return `<?xml version="1.0" encoding="utf-8" standalone="no"?>
@@ -325,21 +324,21 @@ function renderSingle(row, cfg) {
  </defs>
  <g>
   <path d="M 0 ${height} L ${width} ${height} L ${width} 0 L 0 0 z" style="fill:${COLORS.background}"/>
-  <text x="${left}" y="30" style="fill:${COLORS.title};font-size:16px;font-weight:600">${escapeXml(cfg.title)}</text>
-  ${cfg.subtitle ? `<text x="${left}" y="52" style="fill:${COLORS.muted};font-size:12px">${escapeXml(cfg.subtitle)}</text>` : ""}
+  <text x="${left}" y="30" style="fill:${COLORS.title};font-size:19px;font-weight:600">${escapeXml(cfg.title)}</text>
+  ${cfg.subtitle ? `<text x="${left}" y="52" style="fill:${COLORS.muted};font-size:13px">${escapeXml(cfg.subtitle)}</text>` : ""}
   <path d="M ${left} ${top} L ${right} ${top} L ${right} ${bottom} L ${left} ${bottom} z" style="fill:${COLORS.panel}"/>
   ${ticks
     .map((tick) => {
       const x = left + (tick / max) * plotWidth;
       return `<g>
    <path d="M ${x.toFixed(3)} ${top} L ${x.toFixed(3)} ${bottom}" style="fill:none;stroke:${COLORS.grid};stroke-width:0.7"/>
-   <text x="${x.toFixed(3)}" y="${bottom + 18}" style="fill:${COLORS.label};font-size:11px;text-anchor:middle">${formatTick(tick)}</text>
+   <text x="${x.toFixed(3)}" y="${bottom + 18}" style="fill:${COLORS.label};font-size:13px;text-anchor:middle">${formatTick(tick)}</text>
   </g>`;
     })
     .join("\n  ")}
   <path d="M ${left} ${bottom} L ${right} ${bottom}" style="fill:none;stroke:${COLORS.axis};stroke-width:0.8"/>
   <path d="M ${left} ${top} L ${left} ${bottom}" style="fill:none;stroke:${COLORS.axis};stroke-width:0.8"/>
-  <text x="${(left + plotWidth / 2).toFixed(3)}" y="${bottom + 42}" style="fill:${COLORS.label};font-size:13px;text-anchor:middle">Tokens</text>
+  <text x="${(left + plotWidth / 2).toFixed(3)}" y="${bottom + 44}" style="fill:${COLORS.label};font-size:14px;text-anchor:middle">Tokens</text>
   ${baselineRef}
   ${bars}
  </g>
@@ -521,8 +520,8 @@ function renderIndex(index) {
     `<?xml version="1.0" encoding="utf-8" standalone="no"?>`,
     `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" version="1.1" role="img" aria-label="${escapeXml(title)}">`,
     ` <rect width="${width}" height="${height}" fill="#0b0f14"/>`,
-    ` <text x="40" y="46" fill="#f8fafc" font-size="20" font-weight="bold" font-family="DejaVu Sans, Arial, sans-serif">${escapeXml(title)}</text>`,
-    ` <text x="40" y="68" fill="#64748b" font-size="12" font-family="DejaVu Sans, Arial, sans-serif">${escapeXml(host)}</text>`,
+    ` <text x="40" y="46" fill="#f8fafc" font-size="22" font-weight="bold" font-family="DejaVu Sans, Arial, sans-serif">${escapeXml(title)}</text>`,
+    ` <text x="40" y="68" fill="#64748b" font-size="13" font-family="DejaVu Sans, Arial, sans-serif">${escapeXml(host)}</text>`,
     ` <text x="40" y="${height - 22}" fill="#64748b" font-size="11" font-family="DejaVu Sans, Arial, sans-serif">Every tool builds the index its own documentation prescribes; repositories are ordered by the size of the program each was built from.</text>`,
     legend,
     grid,
@@ -564,9 +563,9 @@ function renderTime(index, cells, options = {}) {
   // the eye starts picking tools out of it. A single-project render (the VS
   // Code cut) gets thicker bars instead of empty air.
   const single = rows.length === 1;
-  const barHeight = single ? 26 : 11;
-  const barStep = single ? 38 : 15;
-  const rowHeight = single ? 5 * barStep + 40 : 90;
+  const barHeight = single ? 28 : 12.5;
+  const barStep = single ? 40 : 17;
+  const rowHeight = single ? 5 * barStep + 44 : 100;
   const width = 1040;
   const chart = { left: 160, right: 900, top: 150 };
   chart.bottom = chart.top + rows.length * rowHeight;
@@ -629,7 +628,7 @@ function renderTime(index, cells, options = {}) {
         // A tool with no index to build says so with a zero, which is the point
         // of putting them side by side.
         lines.push(
-          `  <text x="${(chart.left + buildWidth + answerWidth + 8).toFixed(1)}" y="${textY.toFixed(1)}" font-size="${single ? 13 : 11}"><tspan fill="${value.color}" fill-opacity="0.55">${escapeXml(fmtCompact(value.buildMs))}</tspan><tspan fill="#64748b"> / </tspan><tspan fill="${value.color}">${escapeXml(fmtCompact(value.answerMs))}</tspan></text>`,
+          `  <text x="${(chart.left + buildWidth + answerWidth + 8).toFixed(1)}" y="${textY.toFixed(1)}" fill="#cbd5f5" font-size="${single ? 13 : 11}">${escapeXml(`${fmtCompact(value.buildMs)} / ${fmtCompact(value.answerMs)}`)}</text>`,
         );
       });
       return lines.join("\n");
@@ -641,16 +640,16 @@ function renderTime(index, cells, options = {}) {
   // bar the chart draws, so the reader learns the encoding by seeing it once.
   const legend = TOOLS.map((tool, i) =>
     [
-      `  <rect x="${40 + i * 175}" y="78" width="12" height="12" fill="${tool.color}" rx="2"/>`,
-      `  <text x="${58 + i * 175}" y="88" fill="#cbd5f5" font-size="12">${escapeXml(tool.label)}</text>`,
+      `  <rect x="${40 + i * 180}" y="76" width="13" height="13" fill="${tool.color}" rx="2"/>`,
+      `  <text x="${59 + i * 180}" y="87" fill="#cbd5f5" font-size="13.5">${escapeXml(tool.label)}</text>`,
     ].join("\n"),
   ).join("\n");
   const shadeLegend = [
-    `  <rect x="40" y="104" width="56" height="15" fill="#22d3ee" fill-opacity="0.35" rx="2"/>`,
-    `  <rect x="96" y="104" width="36" height="15" fill="#22d3ee" rx="2"/>`,
-    `  <text x="68" y="115.5" fill="#e2e8f0" font-size="10" font-weight="bold" text-anchor="middle">index</text>`,
-    `  <text x="114" y="115.5" fill="#0b0f14" font-size="10" font-weight="bold" text-anchor="middle">LLM</text>`,
-    `  <text x="142" y="115.5" fill="#cbd5f5" font-size="12">${escapeXml("faded = index build, solid = LLM answering — each label reads index / LLM in the same shades")}</text>`,
+    `  <rect x="40" y="102" width="60" height="17" fill="#22d3ee" fill-opacity="0.35" rx="2"/>`,
+    `  <rect x="100" y="102" width="40" height="17" fill="#22d3ee" rx="2"/>`,
+    `  <text x="70" y="115" fill="#e2e8f0" font-size="11" font-weight="bold" text-anchor="middle">index</text>`,
+    `  <text x="120" y="115" fill="#0b0f14" font-size="11" font-weight="bold" text-anchor="middle">LLM</text>`,
+    `  <text x="150" y="115" fill="#cbd5f5" font-size="13">${escapeXml("faded = index build, solid = LLM answering — each bar is labelled index / LLM")}</text>`,
   ].join("\n");
 
   return [
@@ -659,7 +658,7 @@ function renderTime(index, cells, options = {}) {
     ` <rect width="${width}" height="${height}" fill="#0b0f14"/>`,
     ` <text x="40" y="42" fill="#f8fafc" font-size="20" font-weight="bold" font-family="DejaVu Sans, Arial, sans-serif">${escapeXml(title)}</text>`,
     ` <text x="40" y="62" fill="#64748b" font-size="12" font-family="DejaVu Sans, Arial, sans-serif">${escapeXml(host)}</text>`,
-    ` <text x="40" y="${height - 20}" fill="#64748b" font-size="11" font-family="DejaVu Sans, Arial, sans-serif">Cold checkout: build the tool's index once, then ask. LLM time is the median wall clock over four models and both prompt families; the baseline has no index to build.</text>`,
+    ` <text x="40" y="${height - 20}" fill="#64748b" font-size="12.5" font-family="DejaVu Sans, Arial, sans-serif">Cold checkout: build the tool's index once, then ask. LLM time is the median wall clock over four models and both prompt families; the baseline has no index to build.</text>`,
     legend,
     shadeLegend,
     bands,

--- a/website/build/graph-benchmark-svg.cjs
+++ b/website/build/graph-benchmark-svg.cjs
@@ -629,7 +629,7 @@ function renderTime(index, cells, options = {}) {
         // A tool with no index to build says so with a zero, which is the point
         // of putting them side by side.
         lines.push(
-          `  <text x="${(chart.left + buildWidth + answerWidth + 8).toFixed(1)}" y="${textY.toFixed(1)}" fill="${value.color}" font-size="${single ? 13 : 11}">${escapeXml(`(${fmtCompact(value.buildMs)} / ${fmtCompact(value.answerMs)})`)}</text>`,
+          `  <text x="${(chart.left + buildWidth + answerWidth + 8).toFixed(1)}" y="${textY.toFixed(1)}" font-size="${single ? 13 : 11}"><tspan fill="${value.color}" fill-opacity="0.55">${escapeXml(fmtCompact(value.buildMs))}</tspan><tspan fill="#64748b"> / </tspan><tspan fill="${value.color}">${escapeXml(fmtCompact(value.answerMs))}</tspan></text>`,
         );
       });
       return lines.join("\n");
@@ -650,7 +650,7 @@ function renderTime(index, cells, options = {}) {
     `  <rect x="96" y="104" width="36" height="15" fill="#22d3ee" rx="2"/>`,
     `  <text x="68" y="115.5" fill="#e2e8f0" font-size="10" font-weight="bold" text-anchor="middle">index</text>`,
     `  <text x="114" y="115.5" fill="#0b0f14" font-size="10" font-weight="bold" text-anchor="middle">LLM</text>`,
-    `  <text x="142" y="115.5" fill="#cbd5f5" font-size="12">${escapeXml("faded = index build, solid = LLM answering — every bar is labelled (index / LLM)")}</text>`,
+    `  <text x="142" y="115.5" fill="#cbd5f5" font-size="12">${escapeXml("faded = index build, solid = LLM answering — each label reads index / LLM in the same shades")}</text>`,
   ].join("\n");
 
   return [

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphTime.tsx
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphTime.tsx
@@ -50,7 +50,7 @@ interface TimeBar {
   tool: string;
   /** Cold index build, once per checkout; null for a tool that has none. */
   buildMs: number | null;
-  /** Median wall clock the agent spent answering, index already built. */
+  /** Median wall clock the LLM spent answering, index already built. */
   answerMs: number;
 }
 
@@ -69,10 +69,12 @@ interface TimeRow {
  * four models, both prompt families — so the mix of fast and slow models is the
  * same for every tool, and the bars compare the tools rather than the models.
  */
-function buildRows(report: Report): TimeRow[] {
+function buildRows(report: Report, only?: string): TimeRow[] {
   const cells: AgentCell[] = report.agent?.cells ?? [];
   const index = report.index;
-  const projects = [...new Set(cells.map((cell) => cell.repo))];
+  const projects = [...new Set(cells.map((cell) => cell.repo))].filter(
+    (project) => !only || project === only,
+  );
   return projects
     .map((project) => {
       const scale = index?.scale[project];
@@ -111,28 +113,96 @@ function buildRows(report: Report): TimeRow[] {
     .sort((a, b) => a.lines - b.lines);
 }
 
-function fmtDuration(ms: number): string {
-  return ms >= 60_000
-    ? `${(ms / 60_000).toFixed(1)} min`
-    : `${Math.round(ms / 1000)} s`;
+/**
+ * Compact seconds, one unit throughout: "29s", "0.8s", "731s".
+ *
+ * The label carries two of these side by side, and minutes beside seconds make
+ * the reader convert units before the shape appears — and the shape is the
+ * finding.
+ */
+function fmtCompact(ms: number): string {
+  const seconds = ms / 1000;
+  if (seconds === 0) return "0s";
+  if (seconds >= 10) return `${Math.round(seconds).toLocaleString("en-US")}s`;
+  return `${seconds.toFixed(1)}s`;
 }
 
-function Bars({ row, max }: { row: TimeRow; max: number }) {
+/**
+ * On hover, the two waits spelled out: which tool, how long its index build
+ * took, and the median wall clock the LLM spent answering with it.
+ */
+function TimeTooltip({
+  row,
+  bar,
+  tool,
+}: {
+  row: TimeRow;
+  bar: TimeBar;
+  tool: (typeof TOOLS)[number];
+}) {
+  const build = bar.buildMs ?? 0;
   return (
-    <div className="space-y-1">
+    <div className="pointer-events-none absolute bottom-full left-0 z-30 mb-2 hidden w-64 rounded-md border border-[#2a313e] bg-[#090b10] p-3 text-left shadow-[0_18px_45px_rgba(0,0,0,0.45)] group-hover:block">
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-px"
+        style={{
+          background: `linear-gradient(to right, transparent, ${tool.text}99, transparent)`,
+        }}
+      />
+      <p className="truncate font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+        {row.label}
+      </p>
+      <p className="mt-1 text-[12px] font-semibold" style={{ color: tool.text }}>
+        {tool.label}
+      </p>
+      <div className="mt-2 space-y-1 font-mono text-[11px] tabular-nums">
+        <div className="flex justify-between gap-4">
+          <span className="text-neutral-500">index build</span>
+          <span className="text-neutral-300">
+            {build > 0 ? fmtCompact(build) : "none"}
+          </span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="text-neutral-500">LLM answering</span>
+          <span className="text-neutral-300">{fmtCompact(bar.answerMs)}</span>
+        </div>
+        <div className="flex justify-between gap-4 border-t border-[#1c2230] pt-1">
+          <span className="text-neutral-500">first answer</span>
+          <span className="text-neutral-100">
+            {fmtCompact(build + bar.answerMs)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Bars({
+  row,
+  max,
+  thick,
+}: {
+  row: TimeRow;
+  max: number;
+  thick: boolean;
+}) {
+  return (
+    <div className={thick ? "space-y-2" : "space-y-1"}>
       {row.bars.map((bar) => {
         const tool = TOOLS.find((item) => item.id === bar.tool)!;
         const build = bar.buildMs ?? 0;
         const total = build + bar.answerMs;
         return (
-          <div key={bar.tool} className="flex items-center gap-2">
+          <div key={bar.tool} className="group relative flex items-center gap-2">
             <span
               className="w-28 shrink-0 truncate font-mono text-[10px]"
               style={{ color: tool.text }}
             >
               {tool.label}
             </span>
-            <div className="relative h-3 flex-1 overflow-hidden rounded-sm bg-[#0c0e13]">
+            <div
+              className={`relative flex-1 overflow-hidden rounded-sm bg-[#0c0e13] ${thick ? "h-5" : "h-3"}`}
+            >
               <span
                 className="absolute inset-y-0 left-0 flex"
                 style={{ width: `${Math.max(1.5, (total / max) * 100)}%` }}
@@ -152,15 +222,10 @@ function Bars({ row, max }: { row: TimeRow; max: number }) {
                 />
               </span>
             </div>
-            <span className="w-28 shrink-0 text-right font-mono text-[11px] tabular-nums text-neutral-300">
-              {fmtDuration(total)}
-              {build > 0 ? (
-                <span className="text-neutral-500">
-                  {" "}
-                  ({fmtDuration(build)} build)
-                </span>
-              ) : null}
+            <span className="w-24 shrink-0 text-right font-mono text-[11px] tabular-nums text-neutral-300">
+              {fmtCompact(build)} / {fmtCompact(bar.answerMs)}
             </span>
+            <TimeTooltip row={row} bar={bar} tool={tool} />
           </div>
         );
       })}
@@ -168,9 +233,49 @@ function Bars({ row, max }: { row: TimeRow; max: number }) {
   );
 }
 
-export default function TtscWebsiteBenchmarkGraphTime() {
+/**
+ * The legend is a worked example: the same two-tone bar the chart draws, with
+ * the two waits named on their own segments.
+ */
+function ShadeLegend() {
+  return (
+    <div className="flex items-center gap-3 border-b border-[#1c212b] px-5 py-2.5">
+      <span className="flex h-4 overflow-hidden rounded-sm font-mono text-[9px] font-bold leading-4">
+        <span
+          className="px-2 text-center text-neutral-100"
+          style={{
+            background: TtscWebsiteBenchmarkGraphUi.TTSC_FILL as string,
+            opacity: 0.4,
+          }}
+        >
+          index
+        </span>
+        <span
+          className="px-2 text-center text-[#0b0f14]"
+          style={{ background: TtscWebsiteBenchmarkGraphUi.TTSC_FILL as string }}
+        >
+          LLM
+        </span>
+      </span>
+      <span className="text-[11px] text-neutral-400">
+        faded = index build, solid = LLM answering — each bar is labelled index
+        / LLM
+      </span>
+    </div>
+  );
+}
+
+export default function TtscWebsiteBenchmarkGraphTime({
+  project,
+}: {
+  /** Render a single repository with thick bars, e.g. `"vscode"`. */
+  project?: string;
+}) {
   const { report, error, loading } = useTtscWebsiteBenchmarkGraphData();
-  const rows = useMemo(() => (report ? buildRows(report) : []), [report]);
+  const rows = useMemo(
+    () => (report ? buildRows(report, project) : []),
+    [report, project],
+  );
   const max = useMemo(
     () =>
       Math.max(
@@ -207,10 +312,15 @@ export default function TtscWebsiteBenchmarkGraphTime() {
     >
       <TtscWebsiteBenchmarkGraphUi.SectionHeader
         eyebrow="Time"
-        title="Cold time to a first answer"
-        description="Build the tool's index once, then ask: the faded segment is the index build, the solid one the median wall clock the agent spent answering. Repositories are ordered by program size."
-        aside="Answer time is the median across four models and both prompt families, so every tool faces the same mix."
+        title={
+          project
+            ? `Cold time to a first answer — ${rows[0]?.label ?? project}`
+            : "Cold time to a first answer"
+        }
+        description="Build the tool's index once, then ask. The faded segment is the index build, the solid one the median wall clock the LLM spent answering."
+        aside="LLM time is the median across four models and both prompt families, so every tool faces the same mix."
       />
+      <ShadeLegend />
       <div className="space-y-4 px-5 py-4">
         {rows.map((row) => (
           <div key={row.project} className="space-y-1.5">
@@ -224,7 +334,7 @@ export default function TtscWebsiteBenchmarkGraphTime() {
                 </span>
               ) : null}
             </div>
-            <Bars row={row} max={max} />
+            <Bars row={row} max={max} thick={Boolean(project)} />
           </div>
         ))}
       </div>

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphTime.tsx
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphTime.tsx
@@ -195,13 +195,13 @@ function Bars({
         return (
           <div key={bar.tool} className="group relative flex items-center gap-2">
             <span
-              className="w-28 shrink-0 truncate font-mono text-[10px]"
+              className="w-32 shrink-0 truncate font-mono text-[11px]"
               style={{ color: tool.text }}
             >
               {tool.label}
             </span>
             <div
-              className={`relative flex-1 overflow-hidden rounded-sm bg-[#0c0e13] ${thick ? "h-5" : "h-3"}`}
+              className={`relative flex-1 overflow-hidden rounded-sm bg-[#0c0e13] ${thick ? "h-6" : "h-3.5"}`}
             >
               <span
                 className="absolute inset-y-0 left-0 flex"
@@ -222,7 +222,7 @@ function Bars({
                 />
               </span>
             </div>
-            <span className="w-24 shrink-0 text-right font-mono text-[11px] tabular-nums text-neutral-300">
+            <span className="w-28 shrink-0 text-right font-mono text-[12px] tabular-nums text-neutral-200">
               {fmtCompact(build)} / {fmtCompact(bar.answerMs)}
             </span>
             <TimeTooltip row={row} bar={bar} tool={tool} />
@@ -325,11 +325,11 @@ export default function TtscWebsiteBenchmarkGraphTime({
         {rows.map((row) => (
           <div key={row.project} className="space-y-1.5">
             <div className="flex items-baseline justify-between gap-3">
-              <span className="font-mono text-[12px] text-neutral-200">
+              <span className="font-mono text-[13px] font-semibold text-neutral-100">
                 {row.label}
               </span>
               {row.lines > 0 ? (
-                <span className="font-mono text-[10px] tabular-nums text-neutral-500">
+                <span className="font-mono text-[11px] tabular-nums text-neutral-500">
                   {row.lines.toLocaleString()} lines
                 </span>
               ) : null}

--- a/website/src/content/blog/i-made-ts-compiler-graph-mcp.mdx
+++ b/website/src/content/blog/i-made-ts-compiler-graph-mcp.mdx
@@ -149,11 +149,23 @@ What actually happened was a lot less exciting than the pitch.
 - Extra MCP calls fired on their own and delayed the work I wanted done.
 - I couldn't just ask in plain language either. Every query had to be shaped by hand. `codebase-memory-mcp`'s sharpest tools want a Cypher query or an exact `qualified_name`, `codegraph` wants you to name the symbols in a flow, and `serena` wants you to activate the project and then hand it an exact `name_path` you don't have yet. The hand-shaping alone cost more time than the tools gave back.
 
+zod wasn't a lucky pick, so here is the whole corpus on one question. This is the same onboarding prompt on all eight repositories — the one I actually paste when I enter a codebase I don't know — and the shape to look at is not any single bar but the *variance*. The cyan bars sit flat at roughly a quarter-million tokens whether the repository is a 51k-line backend or three-million-line VS Code, because an index answer is the size of the answer, not the size of the code. Every other bar swings with the repository, because bodies and searches grow with what they crawl:
+
+![Median token use across every repository, shared onboarding question, Claude Code Sonnet 5](/benchmark/svg/graph-common-claude-code-claude-sonnet-5.svg)
+
+And because a benchmark that only runs the author's own prompt proves nothing, the second lane borrows the competition's: `codegraph` ships its own per-repository architecture questions, and this chart runs them verbatim, one per project. Same ordering on someone else's questions:
+
+![Median token use, codegraph's own per-repository questions, Claude Code Sonnet 5](/benchmark/svg/graph-dedicated-claude-code-claude-sonnet-5.svg)
+
 And none of that counts the wait before the first question. A code-graph MCP has to index the repository before it can answer anything, and you sit through that build on a cold checkout whether the answer that follows is cheap or not.
 
 ![Cold time to a first answer, per repository](/benchmark/svg/graph-time-to-answer.svg)
 
-> The faded head of each bar is the index build, the solid tail is the answer, and each bar is labelled `index / answer` in the order you wait for them. On VS Code, `@ttsc/graph` builds in 29 seconds; `codegraph` takes 732. A tool that cuts the token bill and then spends twelve minutes indexing has moved the cost, not removed it.
+> The faded head of each bar is the index build, the solid tail is the LLM answering, and each bar is labelled `index / LLM` in the order you wait for them. A tool that cuts the token bill and then spends twelve minutes indexing has moved the cost, not removed it.
+
+The place that trade bites hardest deserves its own frame. VS Code is three million lines, and on it the index builds diverge by a factor of twenty-five: `@ttsc/graph` is ready in 29 seconds because the graph falls out of the type-check the compiler was going to run anyway, while `codegraph` crawls for twelve minutes and serena for four and a half before either can say a word:
+
+![Cold time to a first answer, VS Code alone](/benchmark/svg/graph-time-to-answer-vscode.svg)
 
 So for my kind of question, all three left me worse off than before I installed them. Two things are true at once: they're the strongest tools of their kind, built by people who saw the problem before I did; and on an open question, every one made the agent spend more than nothing would have. That's when I went digging.
 

--- a/website/src/content/docs/benchmark/graph.mdx
+++ b/website/src/content/docs/benchmark/graph.mdx
@@ -1,6 +1,5 @@
 import TtscWebsiteBenchmarkGraphCommon from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphCommon";
 import TtscWebsiteBenchmarkGraphDedicated from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphDedicated";
-import TtscWebsiteBenchmarkGraphIndex from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphIndex";
 import TtscWebsiteBenchmarkGraphStructural from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphStructural";
 import TtscWebsiteBenchmarkGraphTime from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphTime";
 
@@ -30,23 +29,21 @@ Switch projects with the tabs. Each chart row is one measured model.
 
 <TtscWebsiteBenchmarkGraphDedicated />
 
-## Index Build Time
-
-The charts above measure what a _question_ costs once a tool is ready. This one measures the readiness itself: each tool's index is deleted, built once, and timed on a quiet machine.
-
-It is a competitive dimension in its own right, because a developer waits for it before the agent can ask anything — and the wait is not evenly distributed. On VS Code's three million lines, `codegraph` spends **twelve minutes** and `serena` five, where `@ttsc/graph` — which reads the graph the TypeScript compiler has to build anyway — takes under thirty seconds.
-
-Every tool is given the index its own documentation prescribes: `codegraph init`, `codebase-memory-mcp index_repository` in its default `full` mode (the mode the token charts above also ran), and `serena project index`, which serena recommends for larger projects. That last one is a correction: the harness had not been running it, and a benchmark that withholds a tool's own prescribed setup is measuring the withholding.
-
-Repositories are ordered by the size of the program each index was built from, because thirty seconds on VS Code and one second on a small backend are the same tool, not two.
-
-<TtscWebsiteBenchmarkGraphIndex />
-
 ## Time to an Answer
 
-A tool that cuts an agent's token bill and then spends four minutes indexing, and three more re-searching what it indexed, has moved the cost rather than removed it. This chart adds the two waits a developer actually sits through: the cold index build, then the agent answering with that index in hand.
+The charts above measure what a _question_ costs once a tool is ready. This one adds the readiness itself. Each bar is the two waits a developer actually sits through, in the order they are paid: the cold index build (the faded segment), then the LLM answering with that index in hand (the solid one). A tool that cuts an agent's token bill and then spends four minutes indexing, and three more re-searching what it indexed, has moved the cost rather than removed it.
+
+The wait is not evenly distributed. On VS Code's three million lines, `codegraph` spends **twelve minutes** building and `serena` almost five, where `@ttsc/graph` — which reads the graph the TypeScript compiler has to build anyway — takes under thirty seconds.
+
+Every tool is given the index its own documentation prescribes: `codegraph init`, `codebase-memory-mcp index_repository` in its default `full` mode (the mode the token charts above also ran), and `serena project index`, which serena recommends for larger projects. Repositories are ordered by the size of the program each index was built from.
 
 <TtscWebsiteBenchmarkGraphTime />
+
+### VS Code, alone
+
+Three million lines is where the index question stops being academic: it is the difference between a tool that answers while you pour a coffee and one you configure before lunch. The same bars as above, isolated.
+
+<TtscWebsiteBenchmarkGraphTime project="vscode" />
 
 ## Structural Coverage
 


### PR DESCRIPTION
## Intent

The time-to-answer chart is the benchmark's second finding — a tool's index is a wait the developer sits through before the first answer — and everywhere it appears the presentation undersold it: an unlabelled two-value bar label, a grey-chip legend, an index-only chart shown before the better combined one, a blog that dropped most of the charts, and VS Code (where the index gap is a factor of 25) buried as one thin row.

## Scope

- [x] SVG generator: `29s / 41s` compact-second labels, a worked-example legend (the chart's own two-tone bar with "index" on the faded segment and "LLM" on the solid), one typographic size up across every chart, and a VS Code single-repository cut. The index-only chart is retired — nothing referenced it.
- [x] ttsc.dev benchmark page: the index-build section folds into "Time to an Answer", a "VS Code, alone" section follows it, and the React chart gets the same labels, the worked-example legend, a per-bar hover tooltip (index build / LLM answering / first answer), and a `project` prop for the single-repository view.
- [x] `packages/graph/README.md`: the chart fixes flow through the shared SVGs; the VS Code cut lands after the main time chart.
- [x] Blog article: section 2.2 now carries the whole-corpus Common chart and the borrowed Dedicated chart with prose about what to read in them, and the VS Code cut after the time chart — every chart the README carries.

## Test plan

- `node website/build/graph-benchmark-svg.cjs` writes 74 charts.
- Pages verified on the local dev server (full-page headless captures) and charts reviewed as PNG renders.