### PR TITLE
feat(lint): implement unicorn/isolated-functions (WIP)

### DIFF
--- a/packages/lint/linthost/rules_unicorn_isolated_functions.go
+++ b/packages/lint/linthost/rules_unicorn_isolated_functions.go
@@ -1,27 +1,938 @@
-// unicorn/isolated-functions: flags function expressions that "escape"
-// their lexical closure unintentionally — e.g. an inner function that
-// references no outer binding but is still placed at the inner scope.
-// Correctly identifying "isolated function" context requires scope
-// analysis tracking what each nested function captures, which is not
-// available in the AST-only slice of this port.
+// unicornIsolatedFunctions ports unicorn/isolated-functions: functions that
+// run outside their defining execution context (workerized callbacks,
+// `page.evaluate` payloads, `@isolated`-tagged functions, selector-matched
+// functions) must not reference bindings from their surrounding scope, `this`,
+// or `super`.
 //
-// Registered as a no-op stub to keep
-// `TestTypedKeysMatchRegisteredRules` aligned with the typed
-// `ITtscLintUnicornRules` surface. The matching fixture under
-// `tests/test-lint/src/cases/unicorn-isolated-functions.ts` keeps its
-// `@ttsc-corpus-skip` directive.
+// Scope escape is decided by the TypeScript-Go checker: a reference inside an
+// isolated function is allowed only when its symbol has a declaration inside
+// the function (parameters, locals, nested declarations). ESLint's
+// language-options globals have no direct equivalent here, so the port maps
+// "configured globals" to ambient global declarations (lib files, `@types`
+// packages, `declare global` blocks): those stay allowed read-only, mirroring
+// upstream's all-readonly ES-globals default, and the `overrideGlobals` option
+// remains the writability/off escape hatch. Everything else — module and
+// script bindings, imports, recursion through the function's own hoisted name,
+// unresolved names — is reported exactly like upstream's `scope.through`
+// analysis.
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/isolated-functions.md
 package linthost
 
-import shimast "github.com/microsoft/typescript-go/shim/ast"
+import (
+  "bytes"
+  "encoding/json"
+  "fmt"
+  "regexp"
+  "sort"
+  "strconv"
+  "strings"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+)
+
+var (
+  unicornIsolatedFunctionsDefaultFunctions = []string{"makeSynchronous", "workerize"}
+  unicornIsolatedFunctionsDefaultComments  = []string{"@isolated"}
+  // JSDoc block comments keep their `*` margin in the raw comment interior;
+  // upstream strips one leading run of `*`-and-whitespace before matching.
+  unicornIsolatedFunctionsCommentMarginPattern = regexp.MustCompile(`^(?:\*\s*)*`)
+)
 
 type unicornIsolatedFunctions struct{}
 
+type unicornIsolatedFunctionsRawOptions struct {
+  Functions       json.RawMessage `json:"functions"`
+  Selectors       json.RawMessage `json:"selectors"`
+  Comments        json.RawMessage `json:"comments"`
+  OverrideGlobals json.RawMessage `json:"overrideGlobals"`
+}
+
+// unicornIsolatedFunctionsGlobalPolicy is one normalized overrideGlobals
+// value. Upstream accepts booleans plus the writability strings; `false` and
+// "readonly" both mean readable-but-not-writable, so the port collapses them.
+type unicornIsolatedFunctionsGlobalPolicy uint8
+
+const (
+  unicornIsolatedFunctionsGlobalReadonly unicornIsolatedFunctionsGlobalPolicy = iota
+  unicornIsolatedFunctionsGlobalWritable
+  unicornIsolatedFunctionsGlobalOff
+)
+
+type unicornIsolatedFunctionsSelector struct {
+  source   string
+  selector *astSelector
+}
+
+type unicornIsolatedFunctionsOptions struct {
+  functions       []string
+  selectors       []unicornIsolatedFunctionsSelector
+  comments        []string
+  overrideGlobals map[string]unicornIsolatedFunctionsGlobalPolicy
+}
+
+type unicornIsolatedFunctionsProblem struct {
+  pos     int
+  node    *shimast.Node
+  message string
+}
+
+type unicornIsolatedFunctionsAnalysis struct {
+  ctx      *Context
+  options  unicornIsolatedFunctionsOptions
+  factory  *shimast.NodeFactory
+  selected []map[*shimast.Node]struct{}
+  problems []unicornIsolatedFunctionsProblem
+  walkCB   func(*shimast.Node) bool
+}
+
 func (unicornIsolatedFunctions) Name() string { return "unicorn/isolated-functions" }
+
+// NeedsTypeChecker: scope escape is decided with checker symbol resolution so
+// shadowing, destructuring, hoisting, and TypeScript declarations keep their
+// real binding identity instead of a name-only approximation.
+func (unicornIsolatedFunctions) NeedsTypeChecker() bool { return true }
+
 func (unicornIsolatedFunctions) Visits() []shimast.Kind {
   return []shimast.Kind{shimast.KindSourceFile}
 }
-func (unicornIsolatedFunctions) Check(_ *Context, _ *shimast.Node) {
+
+// ValidateOptions is consumed by the engine's optional rule-options
+// validation interface. Parsing here makes malformed selectors and
+// overrideGlobals values a project configuration error before any file is
+// linted.
+func (unicornIsolatedFunctions) ValidateOptions(raw json.RawMessage) error {
+  _, err := compileUnicornIsolatedFunctionsOptions(raw)
+  return err
+}
+
+func (unicornIsolatedFunctions) Check(ctx *Context, root *shimast.Node) {
+  if ctx == nil || ctx.File == nil || ctx.Checker == nil || root == nil {
+    return
+  }
+  options, err := compileUnicornIsolatedFunctionsOptions(ctx.Options)
+  if err != nil {
+    // Engine construction already records this as a configuration error.
+    // Check stays side-effect-free for direct contributor calls.
+    return
+  }
+
+  analysis := &unicornIsolatedFunctionsAnalysis{
+    ctx:     ctx,
+    options: options,
+    factory: shimast.NewNodeFactory(shimast.NodeFactoryHooks{}),
+  }
+  analysis.selected = make([]map[*shimast.Node]struct{}, len(options.selectors))
+  for index, entry := range options.selectors {
+    matched := matchASTSelector(root, entry.selector)
+    set := make(map[*shimast.Node]struct{}, len(matched))
+    for _, node := range matched {
+      set[node] = struct{}{}
+    }
+    analysis.selected[index] = set
+  }
+
+  analysis.walkCB = analysis.visit
+  analysis.walk(root)
+
+  // ESLint sorts the final diagnostics by source position. The stable sort
+  // preserves the upstream inner-before-outer report order when nested
+  // isolated functions flag the same identifier.
+  sort.SliceStable(analysis.problems, func(left, right int) bool {
+    return analysis.problems[left].pos < analysis.problems[right].pos
+  })
+  for _, problem := range analysis.problems {
+    ctx.Report(problem.node, problem.message)
+  }
+}
+
+// walk processes functions on exit (children first), matching upstream's
+// `context.onExit` registration: nested isolated functions report before the
+// enclosing one.
+func (a *unicornIsolatedFunctionsAnalysis) walk(node *shimast.Node) {
+  if node == nil {
+    return
+  }
+  node.ForEachChild(a.walkCB)
+  if unicornIsolatedFunctionsIsFunction(node) {
+    if reason := a.isolationReason(node); reason != "" {
+      a.analyzeFunction(node, reason)
+    }
+  }
+}
+
+func (a *unicornIsolatedFunctionsAnalysis) visit(child *shimast.Node) bool {
+  a.walk(child)
+  return false
+}
+
+// unicornIsolatedFunctionsIsFunction lists the function shapes a reason can
+// attach to. Upstream's ESTree function types are declaration, expression, and
+// arrow; TypeScript-Go represents class/object methods, accessors, and
+// constructors as their own function nodes (ESTree wraps a FunctionExpression
+// value), so those participate directly.
+func unicornIsolatedFunctionsIsFunction(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  switch node.Kind {
+  case shimast.KindFunctionDeclaration,
+    shimast.KindFunctionExpression,
+    shimast.KindArrowFunction,
+    shimast.KindMethodDeclaration,
+    shimast.KindGetAccessor,
+    shimast.KindSetAccessor,
+    shimast.KindConstructor:
+    return true
+  }
+  return false
+}
+
+// isolationReason mirrors upstream's reasonForBeingIsolatedFunction plus its
+// selector listeners: comment markers win, then the `functions` option, then
+// the built-in browser.execute/page.evaluate/executeScript shapes, then the
+// configured selectors in option order. The first reason claims the function;
+// upstream's `checked` set never lets a second listener re-report it.
+func (a *unicornIsolatedFunctionsAnalysis) isolationReason(node *shimast.Node) string {
+  if len(a.options.comments) > 0 {
+    if interior, ok := a.findIsolationComment(node); ok {
+      value := unicornIsolatedFunctionsCommentMarginPattern.ReplaceAllString(interior, "")
+      value = strings.ToLower(strings.TrimSpace(value))
+      for _, comment := range a.options.comments {
+        if value == comment ||
+          strings.HasPrefix(value, comment+" - ") ||
+          strings.HasPrefix(value, comment+" -- ") {
+          return "follows comment " + unicornIsolatedFunctionsQuote(comment)
+        }
+      }
+    }
+  }
+  if reason := a.callArgumentReason(node); reason != "" {
+    return reason
+  }
+  for index, entry := range a.options.selectors {
+    if _, ok := a.selected[index][node]; ok {
+      return "matches selector " + unicornIsolatedFunctionsQuote(entry.source)
+    }
+  }
+  return ""
+}
+
+// callArgumentReason covers the call-shaped reasons: any argument of a
+// configured function name, the first argument of `browser.execute` /
+// `page.evaluate`, and the `func` property of an object passed first to
+// `chrome.scripting.executeScript` / `browser.scripting.executeScript`.
+// Parentheses are transparent because ESTree drops them.
+func (a *unicornIsolatedFunctionsAnalysis) callArgumentReason(node *shimast.Node) string {
+  parent := unicornIsolatedFunctionsParent(node)
+  if parent != nil && parent.Kind == shimast.KindCallExpression {
+    call := parent.AsCallExpression()
+    if call != nil && call.Arguments != nil {
+      isArgument := false
+      isFirstArgument := false
+      for index, argument := range call.Arguments.Nodes {
+        if stripParens(argument) == node {
+          isArgument = true
+          isFirstArgument = index == 0
+          break
+        }
+      }
+      if isArgument && len(a.options.functions) > 0 {
+        if name := identifierText(stripParens(call.Expression)); name != "" {
+          for _, function := range a.options.functions {
+            if function == name {
+              return "callee of function named " + unicornIsolatedFunctionsQuote(name)
+            }
+          }
+        }
+      }
+      if isFirstArgument {
+        switch unicornIsolatedFunctionsMethodObjectName(call, "execute") {
+        case "browser":
+          return `callee of method named "browser.execute"`
+        }
+        switch unicornIsolatedFunctionsMethodObjectName(call, "evaluate") {
+        case "page":
+          return `callee of method named "page.evaluate"`
+        }
+      }
+    }
+  }
+  return a.executeScriptFuncReason(node)
+}
+
+// unicornIsolatedFunctionsMethodObjectName returns the simple-identifier
+// receiver of a non-computed `object.method(...)` call, or "" when the callee
+// has any other shape. Optional chaining is accepted, mirroring upstream's
+// unconstrained isMethodCall options.
+func unicornIsolatedFunctionsMethodObjectName(call *shimast.CallExpression, method string) string {
+  if call == nil {
+    return ""
+  }
+  callee := stripParens(call.Expression)
+  if callee == nil || callee.Kind != shimast.KindPropertyAccessExpression {
+    return ""
+  }
+  access := callee.AsPropertyAccessExpression()
+  if access == nil || identifierText(access.Name()) != method {
+    return ""
+  }
+  return identifierText(stripParens(access.Expression))
+}
+
+// executeScriptFuncReason recognizes `func`-valued properties (assignment,
+// string key, computed string key, or method shorthand — upstream Property
+// kind "init") on an object literal passed as the first argument of
+// `<browser|chrome>.scripting.executeScript(...)`. Accessors stay excluded.
+func (a *unicornIsolatedFunctionsAnalysis) executeScriptFuncReason(node *shimast.Node) string {
+  var property *shimast.Node
+  switch node.Kind {
+  case shimast.KindMethodDeclaration:
+    property = node
+  case shimast.KindFunctionExpression, shimast.KindArrowFunction:
+    parent := unicornIsolatedFunctionsParent(node)
+    if parent == nil || parent.Kind != shimast.KindPropertyAssignment {
+      return ""
+    }
+    assignment := parent.AsPropertyAssignment()
+    if assignment == nil || stripParens(assignment.Initializer) != node {
+      return ""
+    }
+    property = parent
+  default:
+    return ""
+  }
+  if unicornIsolatedFunctionsObjectPropertyName(property.Name()) != "func" {
+    return ""
+  }
+  object := property.Parent
+  if object == nil || object.Kind != shimast.KindObjectLiteralExpression {
+    return ""
+  }
+  callNode := unicornIsolatedFunctionsParent(object)
+  if callNode == nil || callNode.Kind != shimast.KindCallExpression {
+    return ""
+  }
+  call := callNode.AsCallExpression()
+  if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) == 0 ||
+    stripParens(call.Arguments.Nodes[0]) != object {
+    return ""
+  }
+  scripting := unicornIsolatedFunctionsMethodObjectAccess(call, "executeScript")
+  if scripting == nil || scripting.Kind != shimast.KindPropertyAccessExpression {
+    return ""
+  }
+  access := scripting.AsPropertyAccessExpression()
+  if access == nil || identifierText(access.Name()) != "scripting" {
+    return ""
+  }
+  base := identifierText(stripParens(access.Expression))
+  if base != "browser" && base != "chrome" {
+    return ""
+  }
+  return `property "func" passed to "` + base + `.scripting.executeScript"`
+}
+
+// unicornIsolatedFunctionsMethodObjectAccess returns the receiver expression
+// of a non-computed `receiver.method(...)` call without constraining the
+// receiver's shape.
+func unicornIsolatedFunctionsMethodObjectAccess(call *shimast.CallExpression, method string) *shimast.Node {
+  if call == nil {
+    return nil
+  }
+  callee := stripParens(call.Expression)
+  if callee == nil || callee.Kind != shimast.KindPropertyAccessExpression {
+    return nil
+  }
+  access := callee.AsPropertyAccessExpression()
+  if access == nil || identifierText(access.Name()) != method {
+    return nil
+  }
+  return stripParens(access.Expression)
+}
+
+// unicornIsolatedFunctionsObjectPropertyName mirrors upstream's
+// getObjectPropertyName: identifier keys and string-literal keys count, and a
+// computed key counts only when it is a string literal.
+func unicornIsolatedFunctionsObjectPropertyName(name *shimast.Node) string {
+  if name == nil {
+    return ""
+  }
+  switch name.Kind {
+  case shimast.KindIdentifier:
+    return identifierText(name)
+  case shimast.KindStringLiteral:
+    return stringLiteralText(name)
+  case shimast.KindComputedPropertyName:
+    computed := name.AsComputedPropertyName()
+    if computed == nil {
+      return ""
+    }
+    expression := stripParens(computed.Expression)
+    if expression != nil && expression.Kind == shimast.KindStringLiteral {
+      return stringLiteralText(expression)
+    }
+  }
+  return ""
+}
+
+// unicornIsolatedFunctionsParent returns the ESTree-equivalent parent:
+// TypeScript-Go keeps ParenthesizedExpression nodes that ESLint's tree drops.
+func unicornIsolatedFunctionsParent(node *shimast.Node) *shimast.Node {
+  if node == nil {
+    return nil
+  }
+  parent := node.Parent
+  for parent != nil && parent.Kind == shimast.KindParenthesizedExpression {
+    parent = parent.Parent
+  }
+  return parent
+}
+
+// findIsolationComment mirrors upstream's findComment: take the comment
+// directly preceding the function, walking up through variable, export, and
+// property declarations while no comment has been found yet. The first
+// comment encountered ends the walk whether or not it matches.
+func (a *unicornIsolatedFunctionsAnalysis) findIsolationComment(node *shimast.Node) (string, bool) {
+  commentable := node
+  for {
+    if interior, ok := a.lastLeadingComment(commentable); ok {
+      return interior, true
+    }
+    next := unicornIsolatedFunctionsCommentParent(commentable)
+    if next == nil {
+      return "", false
+    }
+    commentable = next
+  }
+}
+
+// unicornIsolatedFunctionsCommentParent maps upstream's
+// canCommentApplyToParent chain onto the TypeScript-Go tree. ESTree's
+// VariableDeclarator/VariableDeclaration/ExportNamedDeclaration hops become
+// VariableDeclaration/VariableDeclarationList/VariableStatement (export
+// modifiers live on the statement); ExportDefaultDeclaration is
+// ExportAssignment; Property values hop to their PropertyAssignment. Class
+// and object methods carry their own leading trivia, so they need no hop.
+func unicornIsolatedFunctionsCommentParent(node *shimast.Node) *shimast.Node {
+  if node == nil {
+    return nil
+  }
+  wrapped := node
+  parent := node.Parent
+  for parent != nil && parent.Kind == shimast.KindParenthesizedExpression {
+    wrapped = parent
+    parent = parent.Parent
+  }
+  if parent == nil {
+    return nil
+  }
+  switch parent.Kind {
+  case shimast.KindVariableDeclaration,
+    shimast.KindVariableDeclarationList,
+    shimast.KindVariableStatement:
+    return parent
+  case shimast.KindExportAssignment:
+    assignment := parent.AsExportAssignment()
+    // `export = fn` is TSExportAssignment upstream, which is not in the
+    // comment-walk allowlist; only `export default` hops.
+    if assignment != nil && !assignment.IsExportEquals {
+      return parent
+    }
+  case shimast.KindPropertyAssignment:
+    assignment := parent.AsPropertyAssignment()
+    if assignment != nil && assignment.Initializer == wrapped {
+      return parent
+    }
+  }
+  return nil
+}
+
+// lastLeadingComment returns the interior text of the last comment inside the
+// node's leading trivia. That comment is exactly what ESLint's
+// getTokenBefore(node, {includeComments: true}) yields when the preceding
+// token is a comment: no other token can sit between it and the node.
+func (a *unicornIsolatedFunctionsAnalysis) lastLeadingComment(node *shimast.Node) (string, bool) {
+  if a.ctx.File == nil || node == nil {
+    return "", false
+  }
+  source := a.ctx.File.Text()
+  triviaStart := node.Pos()
+  if triviaStart < 0 || triviaStart > len(source) {
+    return "", false
+  }
+  tokenStart := shimscanner.SkipTrivia(source, triviaStart)
+  if tokenStart <= triviaStart || tokenStart > len(source) {
+    return "", false
+  }
+  var last shimast.CommentRange
+  found := false
+  consider := func(comment shimast.CommentRange) {
+    if comment.Pos() < triviaStart || comment.End() > tokenStart {
+      return
+    }
+    if !found || comment.End() > last.End() {
+      last = comment
+      found = true
+    }
+  }
+  for comment := range shimscanner.GetTrailingCommentRanges(a.factory, source, triviaStart) {
+    consider(comment)
+  }
+  for comment := range shimscanner.GetLeadingCommentRanges(a.factory, source, triviaStart) {
+    consider(comment)
+  }
+  if !found {
+    return "", false
+  }
+  pos, end := last.Pos(), last.End()
+  if pos+2 > end || end > len(source) {
+    return "", false
+  }
+  if last.Kind == shimast.KindMultiLineCommentTrivia {
+    if pos+4 > end {
+      return "", false
+    }
+    return source[pos+2 : end-2], true
+  }
+  return source[pos+2 : end], true
+}
+
+// analyzeFunction reports every scope-escaping reference and every `this` /
+// `super` usage of one isolated function. The walk roots are the function's
+// type parameters, parameters, return type, and body: a method's name
+// (computed key) and decorators evaluate in the enclosing class scope, so
+// they are not part of the isolated scope, mirroring ESTree where they belong
+// to the MethodDefinition wrapper.
+func (a *unicornIsolatedFunctionsAnalysis) analyzeFunction(function *shimast.Node, reason string) {
+  data := function.FunctionLikeData()
+  if data == nil {
+    return
+  }
+  roots := make([]*shimast.Node, 0, 8)
+  if data.TypeParameters != nil {
+    roots = append(roots, data.TypeParameters.Nodes...)
+  }
+  if data.Parameters != nil {
+    roots = append(roots, data.Parameters.Nodes...)
+  }
+  if data.Type != nil {
+    roots = append(roots, data.Type)
+  }
+  if body := function.Body(); body != nil {
+    roots = append(roots, body)
+  }
+
+  declarations := make(map[*shimast.Node]struct{})
+  writes := make(map[*shimast.Node]struct{})
+  for _, root := range roots {
+    walkDescendants(root, func(node *shimast.Node) {
+      if node.Kind != shimast.KindShorthandPropertyAssignment {
+        for _, identifier := range noLoopFuncNamedIdentifiers(node.Name()) {
+          declarations[identifier] = struct{}{}
+        }
+      }
+      for _, identifier := range writeTargetIdentifiers(node) {
+        writes[identifier] = struct{}{}
+      }
+    })
+  }
+  for _, root := range roots {
+    walkDescendants(root, func(node *shimast.Node) {
+      if node.Kind != shimast.KindIdentifier {
+        return
+      }
+      if _, declaration := declarations[node]; declaration {
+        return
+      }
+      if !unicornIsolatedFunctionsIsReference(node) {
+        return
+      }
+      a.checkReference(function, node, reason, writes)
+    })
+  }
+  for _, root := range roots {
+    a.contextWalk(root, reason)
+  }
+}
+
+// unicornIsolatedFunctionsIsReference filters identifiers down to runtime (or
+// upstream-visible type) references. Identifiers directly inside a type
+// reference or type query mirror upstream's TSTypeReference/TSTypeQuery skip;
+// qualified names below them intentionally stay visible, matching upstream.
+func unicornIsolatedFunctionsIsReference(node *shimast.Node) bool {
+  if !isValueReferenceIdentifier(node) {
+    return false
+  }
+  parent := node.Parent
+  if parent == nil {
+    return true
+  }
+  switch parent.Kind {
+  case shimast.KindMetaProperty:
+    // `import.meta` / `new.target` carry no scope reference.
+    return false
+  case shimast.KindTypeReference, shimast.KindTypeQuery:
+    return false
+  case shimast.KindBindingElement:
+    binding := parent.AsBindingElement()
+    if binding != nil && binding.PropertyName == node {
+      return false
+    }
+  }
+  return true
+}
+
+// checkReference decides one reference the way upstream walks
+// `scope.through` + getAllowedGlobalValue: bindings declared inside the
+// function are fine; ambient globals are readable (writable only through
+// overrideGlobals); captured outer bindings and unresolved names are
+// reported. A function's own hoisted name lives in the enclosing scope, so
+// recursion is reported, exactly like upstream.
+func (a *unicornIsolatedFunctionsAnalysis) checkReference(
+  function *shimast.Node,
+  identifier *shimast.Node,
+  reason string,
+  writes map[*shimast.Node]struct{},
+) {
+  name := identifierText(identifier)
+  if name == "" {
+    return
+  }
+
+  var symbol *shimast.Symbol
+  capturedArguments := false
+  if name == "arguments" {
+    // The checker's `arguments` symbol has no declarations, so locate its
+    // owning non-arrow function syntactically: inside the isolated function
+    // it is a local; outside it is a captured binding that overrideGlobals
+    // must not whitelist; without any owner it is an unresolved name.
+    for ancestor := identifier.Parent; ancestor != nil; ancestor = ancestor.Parent {
+      if !isFunctionLikeKind(ancestor) || ancestor.Kind == shimast.KindArrowFunction {
+        continue
+      }
+      if ancestor.Pos() >= function.Pos() && ancestor.End() <= function.End() {
+        return
+      }
+      capturedArguments = true
+      break
+    }
+  } else {
+    symbol = canonicalValueSymbol(a.ctx, identifier)
+    if symbol != nil {
+      for _, declaration := range symbol.Declarations {
+        if declaration != nil && declaration != function &&
+          declaration.Pos() >= function.Pos() && declaration.End() <= function.End() {
+          return
+        }
+      }
+    }
+  }
+
+  global := symbol != nil && unicornIsolatedFunctionsIsAmbientGlobal(a.ctx, name, symbol)
+  captured := capturedArguments || (symbol != nil && !global)
+
+  problemReason := reason
+  policy, hasOverride := a.options.overrideGlobals[name]
+  allowed := false
+  if hasOverride {
+    if policy != unicornIsolatedFunctionsGlobalOff && !captured {
+      allowed = true
+    }
+  } else if global {
+    policy = unicornIsolatedFunctionsGlobalReadonly
+    allowed = true
+  }
+  if allowed {
+    if _, written := writes[identifier]; !written {
+      return
+    }
+    if policy == unicornIsolatedFunctionsGlobalWritable {
+      return
+    }
+    problemReason += " (global variable is not writable)"
+  }
+
+  a.addProblem(identifier,
+    "Variable "+name+" not defined in scope of isolated function. Function is isolated because: "+problemReason+".")
+}
+
+// unicornIsolatedFunctionsIsAmbientGlobal reports whether the symbol is this
+// engine's equivalent of an ESLint configured global: every declaration is
+// ambient (lib/@types declaration files or `declare` contexts) and the name
+// resolves in the checker's global scope. Intrinsics such as `undefined` and
+// `globalThis` have no declarations and count as globals. Script-file
+// top-level bindings resolve globally but are real source declarations, so
+// they stay reported like upstream's script-mode captures.
+func unicornIsolatedFunctionsIsAmbientGlobal(ctx *Context, name string, symbol *shimast.Symbol) bool {
+  if len(symbol.Declarations) == 0 {
+    return true
+  }
+  for _, declaration := range symbol.Declarations {
+    if declaration == nil {
+      return false
+    }
+    if declaration.Flags&shimast.NodeFlagsAmbient != 0 {
+      continue
+    }
+    file := shimast.GetSourceFileOfNode(declaration)
+    if file == nil || !file.IsDeclarationFile {
+      return false
+    }
+  }
+  meaning := shimast.SymbolFlagsValue | shimast.SymbolFlagsType |
+    shimast.SymbolFlagsNamespace | shimast.SymbolFlagsAlias
+  global := ctx.Checker.ResolveName(name, nil, meaning, false /*excludeGlobals*/)
+  if global == nil {
+    return false
+  }
+  return ctx.Checker.GetMergedSymbol(global) == symbol
+}
+
+// contextWalk reports `this` and `super` usage the way upstream's
+// getFunctionContextProblems does: nested non-arrow functions own their
+// context and stop the walk (their computed keys still evaluate outside, so
+// those are walked); nested classes contribute only their `extends`
+// expression and computed member keys. A `typeof this` type query is reported
+// as `this` because the upstream TS tree models it as a ThisExpression.
+func (a *unicornIsolatedFunctionsAnalysis) contextWalk(node *shimast.Node, reason string) {
+  if node == nil {
+    return
+  }
+  switch node.Kind {
+  case shimast.KindThisKeyword:
+    a.addProblem(node, "Unexpected `this` in isolated function. Function is isolated because: "+reason+".")
+    return
+  case shimast.KindSuperKeyword:
+    a.addProblem(node, "Unexpected `super` in isolated function. Function is isolated because: "+reason+".")
+    return
+  case shimast.KindClassDeclaration, shimast.KindClassExpression:
+    a.contextWalk(unicornIsolatedFunctionsExtendsExpression(node), reason)
+    for _, member := range unicornIsolatedFunctionsClassMembers(node) {
+      if name := member.Name(); name != nil && name.Kind == shimast.KindComputedPropertyName {
+        a.contextWalk(name, reason)
+      }
+    }
+    return
+  case shimast.KindTypeQuery:
+    query := node.AsTypeQueryNode()
+    if query != nil {
+      if thisName := unicornIsolatedFunctionsEntityHead(query.ExprName); thisName != nil &&
+        identifierText(thisName) == "this" {
+        a.addProblem(thisName, "Unexpected `this` in isolated function. Function is isolated because: "+reason+".")
+      }
+    }
+  }
+  if isFunctionLikeKind(node) && node.Kind != shimast.KindArrowFunction {
+    if name := node.Name(); name != nil && name.Kind == shimast.KindComputedPropertyName {
+      a.contextWalk(name, reason)
+    }
+    return
+  }
+  node.ForEachChild(func(child *shimast.Node) bool {
+    a.contextWalk(child, reason)
+    return false
+  })
+}
+
+// unicornIsolatedFunctionsExtendsExpression returns the runtime `extends`
+// expression of a class, or nil. Type arguments and `implements` clauses are
+// type-only and stay out of the context walk, mirroring upstream's superClass
+// handling.
+func unicornIsolatedFunctionsExtendsExpression(class *shimast.Node) *shimast.Node {
+  var clauses *shimast.NodeList
+  switch class.Kind {
+  case shimast.KindClassDeclaration:
+    declaration := class.AsClassDeclaration()
+    if declaration != nil {
+      clauses = declaration.HeritageClauses
+    }
+  case shimast.KindClassExpression:
+    expression := class.AsClassExpression()
+    if expression != nil {
+      clauses = expression.HeritageClauses
+    }
+  }
+  if clauses == nil {
+    return nil
+  }
+  for _, clause := range clauses.Nodes {
+    heritage := clause.AsHeritageClause()
+    if heritage == nil || heritage.Token != shimast.KindExtendsKeyword ||
+      heritage.Types == nil || len(heritage.Types.Nodes) == 0 {
+      continue
+    }
+    withArguments := heritage.Types.Nodes[0].AsExpressionWithTypeArguments()
+    if withArguments != nil {
+      return withArguments.Expression
+    }
+  }
+  return nil
+}
+
+func unicornIsolatedFunctionsClassMembers(class *shimast.Node) []*shimast.Node {
+  switch class.Kind {
+  case shimast.KindClassDeclaration:
+    declaration := class.AsClassDeclaration()
+    if declaration != nil && declaration.Members != nil {
+      return declaration.Members.Nodes
+    }
+  case shimast.KindClassExpression:
+    expression := class.AsClassExpression()
+    if expression != nil && expression.Members != nil {
+      return expression.Members.Nodes
+    }
+  }
+  return nil
+}
+
+// unicornIsolatedFunctionsEntityHead returns the leftmost identifier of a
+// type-query entity name (`typeof a.b.c` → `a`).
+func unicornIsolatedFunctionsEntityHead(entity *shimast.Node) *shimast.Node {
+  for entity != nil && entity.Kind == shimast.KindQualifiedName {
+    qualified := entity.AsQualifiedName()
+    if qualified == nil {
+      return nil
+    }
+    entity = qualified.Left
+  }
+  if entity != nil && entity.Kind == shimast.KindIdentifier {
+    return entity
+  }
+  return nil
+}
+
+func (a *unicornIsolatedFunctionsAnalysis) addProblem(node *shimast.Node, message string) {
+  pos := node.Pos()
+  if a.ctx.File != nil {
+    pos = shimscanner.SkipTrivia(a.ctx.File.Text(), pos)
+  }
+  a.problems = append(a.problems, unicornIsolatedFunctionsProblem{
+    pos:     pos,
+    node:    node,
+    message: message,
+  })
+}
+
+// unicornIsolatedFunctionsQuote is JSON.stringify for reason interpolation:
+// like upstream, names, comments, and selectors appear JSON-quoted, and HTML
+// characters (selector combinators like `>`) stay literal.
+func unicornIsolatedFunctionsQuote(value string) string {
+  var buffer bytes.Buffer
+  encoder := json.NewEncoder(&buffer)
+  encoder.SetEscapeHTML(false)
+  if err := encoder.Encode(value); err != nil {
+    return strconv.Quote(value)
+  }
+  return strings.TrimSuffix(buffer.String(), "\n")
+}
+
+func compileUnicornIsolatedFunctionsOptions(raw json.RawMessage) (unicornIsolatedFunctionsOptions, error) {
+  options := unicornIsolatedFunctionsOptions{
+    functions: append([]string(nil), unicornIsolatedFunctionsDefaultFunctions...),
+    comments:  append([]string(nil), unicornIsolatedFunctionsDefaultComments...),
+  }
+  raw = bytes.TrimSpace(raw)
+  if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+    return options, nil
+  }
+  if raw[0] != '{' {
+    return unicornIsolatedFunctionsOptions{}, fmt.Errorf("unicorn/isolated-functions options must be an object")
+  }
+  encoded := unicornIsolatedFunctionsRawOptions{}
+  if err := decodeStrictJSON(raw, &encoded); err != nil {
+    return unicornIsolatedFunctionsOptions{}, fmt.Errorf(
+      "unicorn/isolated-functions options must contain only functions, selectors, comments, and overrideGlobals: %w", err)
+  }
+
+  var err error
+  if options.functions, err = decodeUnicornIsolatedFunctionsStrings(
+    "functions", encoded.Functions, options.functions); err != nil {
+    return unicornIsolatedFunctionsOptions{}, err
+  }
+  if options.comments, err = decodeUnicornIsolatedFunctionsStrings(
+    "comments", encoded.Comments, options.comments); err != nil {
+    return unicornIsolatedFunctionsOptions{}, err
+  }
+  selectorSources, err := decodeUnicornIsolatedFunctionsStrings("selectors", encoded.Selectors, nil)
+  if err != nil {
+    return unicornIsolatedFunctionsOptions{}, err
+  }
+  options.selectors = make([]unicornIsolatedFunctionsSelector, 0, len(selectorSources))
+  for index, source := range selectorSources {
+    selector, err := parseASTSelector(source)
+    if err != nil {
+      return unicornIsolatedFunctionsOptions{}, fmt.Errorf(
+        "unicorn/isolated-functions selector %d %q is invalid: %w", index+1, source, err)
+    }
+    options.selectors = append(options.selectors, unicornIsolatedFunctionsSelector{
+      source:   source,
+      selector: selector,
+    })
+  }
+  for index := range options.comments {
+    options.comments[index] = strings.ToLower(options.comments[index])
+  }
+
+  if trimmed := bytes.TrimSpace(encoded.OverrideGlobals); len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null")) {
+    if trimmed[0] != '{' {
+      return unicornIsolatedFunctionsOptions{}, fmt.Errorf(
+        "unicorn/isolated-functions overrideGlobals must be an object")
+    }
+    entries := map[string]json.RawMessage{}
+    if err := decodeStrictJSON(trimmed, &entries); err != nil {
+      return unicornIsolatedFunctionsOptions{}, fmt.Errorf(
+        "unicorn/isolated-functions overrideGlobals must map names to boolean, \"readonly\", \"writable\", \"writeable\", or \"off\": %w", err)
+    }
+    options.overrideGlobals = make(map[string]unicornIsolatedFunctionsGlobalPolicy, len(entries))
+    for name, value := range entries {
+      policy, err := decodeUnicornIsolatedFunctionsGlobalPolicy(name, value)
+      if err != nil {
+        return unicornIsolatedFunctionsOptions{}, err
+      }
+      options.overrideGlobals[name] = policy
+    }
+  }
+  return options, nil
+}
+
+func decodeUnicornIsolatedFunctionsStrings(name string, raw json.RawMessage, defaults []string) ([]string, error) {
+  raw = bytes.TrimSpace(raw)
+  if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+    return defaults, nil
+  }
+  if raw[0] != '[' {
+    return nil, fmt.Errorf("unicorn/isolated-functions %s must be an array of unique strings", name)
+  }
+  var values []string
+  if err := decodeStrictJSON(raw, &values); err != nil {
+    return nil, fmt.Errorf("unicorn/isolated-functions %s must be an array of unique strings: %w", name, err)
+  }
+  seen := make(map[string]struct{}, len(values))
+  for _, value := range values {
+    if _, duplicate := seen[value]; duplicate {
+      return nil, fmt.Errorf("unicorn/isolated-functions %s must not contain duplicate %q", name, value)
+    }
+    seen[value] = struct{}{}
+  }
+  return values, nil
+}
+
+func decodeUnicornIsolatedFunctionsGlobalPolicy(
+  name string,
+  raw json.RawMessage,
+) (unicornIsolatedFunctionsGlobalPolicy, error) {
+  value := string(bytes.TrimSpace(raw))
+  switch value {
+  case "true", `"writable"`, `"writeable"`:
+    return unicornIsolatedFunctionsGlobalWritable, nil
+  case "false", `"readonly"`:
+    return unicornIsolatedFunctionsGlobalReadonly, nil
+  case `"off"`:
+    return unicornIsolatedFunctionsGlobalOff, nil
+  }
+  return unicornIsolatedFunctionsGlobalReadonly, fmt.Errorf(
+    "unicorn/isolated-functions overrideGlobals[%q] must be a boolean, \"readonly\", \"writable\", \"writeable\", or \"off\"", name)
 }
 
 func init() {

--- a/packages/lint/linthost/rules_unicorn_isolated_functions.go
+++ b/packages/lint/linthost/rules_unicorn_isolated_functions.go
@@ -564,6 +564,15 @@ func unicornIsolatedFunctionsIsReference(node *shimast.Node) bool {
   if !isValueReferenceIdentifier(node) {
     return false
   }
+  // TypeScript-Go models the `this` at the head of a type-query entity name
+  // (`typeof this.foo`) as an identifier named "this"; ESTree models every
+  // `this` as a ThisExpression, which is never a scope reference. `this` is
+  // reserved and can name no binding, so any identifier spelled "this" is that
+  // pseudo-identifier, owned by the `this`/`super` context walk. Leaving it
+  // here would double-report it as an externally-scoped variable.
+  if identifierText(node) == "this" {
+    return false
+  }
   parent := node.Parent
   if parent == nil {
     return true

--- a/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
+++ b/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
@@ -46,8 +46,9 @@ import type {
 } from "./ITtscLintTypeScriptRuleOptions";
 import type {
   ITtscLintUnicornConsistentFunctionScopingRuleOptions,
-  ITtscLintUnicornImportStyleRuleOptions,
   ITtscLintUnicornFilenameCaseRuleOptions,
+  ITtscLintUnicornImportStyleRuleOptions,
+  ITtscLintUnicornIsolatedFunctionsRuleOptions,
   ITtscLintUnicornPreventAbbreviationsRuleOptions,
   ITtscLintUnicornStringContentRuleOptions,
   ITtscLintUnicornTemplateIndentRuleOptions,
@@ -130,4 +131,5 @@ export interface ITtscLintRuleOptionsMap {
   "unicorn/import-style": ITtscLintUnicornImportStyleRuleOptions;
   "unicorn/filename-case": ITtscLintUnicornFilenameCaseRuleOptions;
   "unicorn/string-content": ITtscLintUnicornStringContentRuleOptions;
+  "unicorn/isolated-functions": ITtscLintUnicornIsolatedFunctionsRuleOptions;
 }

--- a/packages/lint/src/structures/rules/ITtscLintUnicornRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintUnicornRuleOptions.ts
@@ -108,6 +108,62 @@ export interface ITtscLintUnicornImportStyleRuleOptions {
   styles?: Readonly<Record<string, TtscLintUnicornImportStyleModuleStyles>>;
 }
 
+/**
+ * Global-variable policy for one `unicorn/isolated-functions` override.
+ *
+ * `true` / `"writable"` / `"writeable"` permit writes, `false` / `"readonly"`
+ * permit reads only, and `"off"` forbids the global entirely inside isolated
+ * scopes.
+ */
+export type TtscLintUnicornIsolatedFunctionsGlobalPolicy =
+  | boolean
+  | "readonly"
+  | "writable"
+  | "writeable"
+  | "off";
+
+/**
+ * Options for `unicorn/isolated-functions`.
+ *
+ * Each list replaces the corresponding default. A function is treated as
+ * isolated when a call to a name in `functions` receives it as an argument,
+ * when it matches one of the `selectors`, or when one of the `comments` markers
+ * precedes it; `overrideGlobals` retunes which global names may be read or
+ * written inside isolated scopes.
+ *
+ * @reference https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/isolated-functions.md
+ */
+export interface ITtscLintUnicornIsolatedFunctionsRuleOptions {
+  /**
+   * Callee names whose call arguments are isolated functions.
+   *
+   * @default ["makeSynchronous", "workerize"]
+   */
+  functions?: readonly string[];
+
+  /**
+   * AST selectors whose matching functions are isolated.
+   *
+   * @default []
+   */
+  selectors?: readonly string[];
+
+  /**
+   * Comment markers that isolate the function they immediately precede.
+   *
+   * @default ["@isolated"]
+   */
+  comments?: readonly string[];
+
+  /**
+   * Per-name overrides for which globals may be read or written inside isolated
+   * scopes.
+   */
+  overrideGlobals?: Readonly<
+    Record<string, TtscLintUnicornIsolatedFunctionsGlobalPolicy>
+  >;
+}
+
 /** Import categories accepted by `unicorn/prevent-abbreviations`. */
 export type TtscLintUnicornPreventAbbreviationsImportMode =
   | boolean

--- a/packages/lint/src/structures/rules/ITtscLintUnicornRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintUnicornRules.ts
@@ -4,8 +4,9 @@ import type {
 } from "../TtscLintRuleSetting";
 import type {
   ITtscLintUnicornConsistentFunctionScopingRuleOptions,
-  ITtscLintUnicornImportStyleRuleOptions,
   ITtscLintUnicornFilenameCaseRuleOptions,
+  ITtscLintUnicornImportStyleRuleOptions,
+  ITtscLintUnicornIsolatedFunctionsRuleOptions,
   ITtscLintUnicornPreventAbbreviationsRuleOptions,
   ITtscLintUnicornStringContentRuleOptions,
   ITtscLintUnicornTemplateIndentRuleOptions,
@@ -159,12 +160,13 @@ export interface ITtscLintUnicornRules {
   "unicorn/import-style"?: TtscLintRuleOptionsSetting<ITtscLintUnicornImportStyleRuleOptions>;
 
   /**
-   * Reject references to outer-scope variables inside functions marked as
-   * isolated (e.g., the body of a web worker).
+   * Reject references to outer-scope variables (and `this` / `super`) inside
+   * functions that run outside their defining context (e.g., the body of a web
+   * worker or a `page.evaluate` payload).
    *
    * @reference https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/isolated-functions.md
    */
-  "unicorn/isolated-functions"?: TtscLintRuleSetting;
+  "unicorn/isolated-functions"?: TtscLintRuleOptionsSetting<ITtscLintUnicornIsolatedFunctionsRuleOptions>;
 
   /**
    * Require `new` when calling builtin constructors like `Error`, `Map`, `Set`,

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_arguments_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_arguments_test.go
@@ -1,0 +1,43 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsArguments verifies the `arguments` special case:
+// the isolated non-arrow function's own `arguments` object is a local, but an
+// `arguments` captured from an enclosing function through an isolated arrow
+// escapes the isolated scope.
+//
+// The checker gives `arguments` no declaration, so the port locates its owning
+// non-arrow function syntactically: owned inside the isolated function it is a
+// local (clean); owned outside it is a captured binding (reported).
+//
+// 1. Assert a makeSynchronous function expression using its own `arguments`
+//    stays clean.
+// 2. Assert an isolated arrow reaching the enclosing function's `arguments`
+//    reports it.
+func TestUnicornIsolatedFunctionsArguments(t *testing.T) {
+  own := `declare function makeSynchronous<T>(fn: T): T;
+
+makeSynchronous(function () {
+  return arguments.length;
+});
+`
+  assertUnicornIsolatedFunctionsFindings(t, runUnicornIsolatedFunctions(t, own, ""))
+
+  captured := `declare function makeSynchronous<T>(fn: T): T;
+
+function outer() {
+  return makeSynchronous(() => arguments.length);
+}
+outer();
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, captured, ""),
+    unicornIsolatedFunctionsFinding{
+      line:    4,
+      target:  "arguments",
+      message: unicornIsolatedFunctionsVariableMessage("arguments", `callee of function named "makeSynchronous"`),
+    },
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_browser_and_page_callees_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_browser_and_page_callees_test.go
@@ -1,0 +1,58 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsBrowserAndPageCallees verifies the built-in
+// `browser.execute` / `page.evaluate` recognition: only the first argument of
+// a non-computed call on those exact identifiers is isolated.
+//
+// These shapes are hardcoded upstream (not part of the `functions` option),
+// so they must keep firing when `functions` is emptied, must accept optional
+// chaining, and must reject computed member access, other receivers, and
+// later argument positions.
+//
+// 1. Assert captures in the first argument of browser.execute and
+//    page.evaluate (plain and optional-chained) are reported.
+// 2. Assert frame.evaluate, computed page["evaluate"], and second arguments
+//    stay clean.
+// 3. Re-run with functions [] and assert the built-in shapes still report.
+func TestUnicornIsolatedFunctionsBrowserAndPageCallees(t *testing.T) {
+  source := `declare const browser: { execute(...args: unknown[]): unknown };
+declare const page: { evaluate(...args: unknown[]): unknown };
+declare const frame: { evaluate(...args: unknown[]): unknown };
+
+const captured = "hi";
+
+browser.execute(() => captured.slice());
+page.evaluate(() => captured.slice());
+page?.evaluate(() => captured.slice());
+page.evaluate(() => "first", () => captured.slice());
+frame.evaluate(() => captured.slice());
+page["evaluate"](() => captured.slice());
+`
+  expected := []unicornIsolatedFunctionsFinding{
+    {
+      line:    7,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", `callee of method named "browser.execute"`),
+    },
+    {
+      line:    8,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", `callee of method named "page.evaluate"`),
+    },
+    {
+      line:    9,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", `callee of method named "page.evaluate"`),
+    },
+  }
+  assertUnicornIsolatedFunctionsFindings(t, runUnicornIsolatedFunctions(t, source, ""), expected...)
+  // The browser/page shapes are hardcoded upstream; emptying `functions`
+  // must not disable them.
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, source, `{"functions": []}`),
+    expected...,
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_comments_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_comments_test.go
@@ -1,0 +1,126 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsComments verifies the comment-marker path of
+// reasonForBeingIsolatedFunction and findComment: the `@isolated` marker is
+// recognized on the function itself and on the variable, export, and property
+// declarations a comment can apply to, across block, JSDoc, and line comment
+// shapes including trailing explanations.
+//
+// Upstream strips one leading `*`-margin run, lowercases, trims, and accepts
+// the bare marker or `marker - ` / `marker -- ` prefixes; the comment must be
+// the token immediately before the (possibly hoisted) declaration.
+//
+// 1. Assert declaration, arrow, inline, block, multiline-JSDoc, explanation,
+//    export const/default, object method, and object property forms report.
+// 2. Assert a non-matching marker and a marker separated by another statement
+//    stay clean.
+func TestUnicornIsolatedFunctionsComments(t *testing.T) {
+  reason := `follows comment "@isolated"`
+  captured := func(line int) unicornIsolatedFunctionsFinding {
+    return unicornIsolatedFunctionsFinding{
+      line:    line,
+      target:  "foo",
+      message: unicornIsolatedFunctionsVariableMessage("foo", reason),
+    }
+  }
+
+  source := `const foo = "hi";
+
+/** @isolated */
+function declaration() {
+  return foo.slice();
+}
+declaration();
+
+/** @isolated */
+const arrow = () => foo.slice();
+
+// @isolated
+const inlineArrow = () => foo.slice();
+
+/* @isolated */
+const blockArrow = () => foo.slice();
+
+/**
+ * @isolated
+ */
+const jsdocArrow = () => foo.slice();
+
+// @isolated - explanation
+const dashArrow = () => foo.slice();
+
+// @isolated -- explanation
+const doubleDashArrow = () => foo.slice();
+
+// @isolated
+export const exportedArrow = () => foo.slice();
+
+// @isolated
+export default () => foo.slice();
+
+const objectMethod = {
+  /** @isolated */
+  method() {
+    return foo.slice();
+  },
+  /** @isolated */
+  propertyArrow: () => foo.slice(),
+  /** @isolated */
+  propertyFunction: function () {
+    return foo.slice();
+  },
+};
+objectMethod.method();
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, source, ""),
+    captured(5),  // declaration
+    captured(10), // arrow
+    captured(13), // inlineArrow
+    captured(16), // blockArrow
+    captured(21), // jsdocArrow
+    captured(24), // dashArrow
+    captured(27), // doubleDashArrow
+    captured(30), // exportedArrow
+    captured(33), // export default
+    captured(38), // object method
+    captured(41), // property arrow
+    captured(44), // property function
+  )
+
+  // Negative twins: a marker the option does not list, and a matching marker
+  // that is not the token immediately before the declaration, isolate nothing.
+  clean := `const foo = "hi";
+
+/** @other */
+const notMarked = () => foo.slice();
+
+// @isolated
+const separated = 1;
+const afterSeparated = () => foo.slice();
+`
+  assertUnicornIsolatedFunctionsFindings(t, runUnicornIsolatedFunctions(t, clean, ""))
+
+  // Custom comments replace the defaults: @remote now isolates, @isolated no
+  // longer does.
+  custom := `const foo = "hi";
+
+// @remote
+const remote = () => foo.slice();
+
+// @isolated
+const isolated = () => foo.slice();
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, custom, `{"comments": ["@remote"]}`),
+    unicornIsolatedFunctionsFinding{
+      line:    4,
+      target:  "foo",
+      message: unicornIsolatedFunctionsVariableMessage("foo", `follows comment "@remote"`),
+    },
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_execute_script_func_property_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_execute_script_func_property_test.go
@@ -1,0 +1,77 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsExecuteScriptFuncProperty verifies the
+// `chrome.scripting.executeScript` / `browser.scripting.executeScript`
+// recognition: a function-valued `func` property (assignment, method
+// shorthand, or computed string key) on the object passed as the first
+// argument is isolated.
+//
+// Upstream requires Property kind "init" with a statically known "func" name
+// on the first argument's object literal, so accessors, computed identifier
+// keys, later arguments, and computed executeScript access must stay silent.
+//
+// 1. Assert arrow, function-expression, method-shorthand, and
+//    computed-string-key `func` members report for both scripting objects.
+// 2. Assert accessors, identifier-computed keys, identifier values, second
+//    arguments, and computed executeScript member access are clean.
+func TestUnicornIsolatedFunctionsExecuteScriptFuncProperty(t *testing.T) {
+  source := `declare const chrome: { scripting: { executeScript(...args: unknown[]): unknown } };
+declare const browser: { scripting: { executeScript(...args: unknown[]): unknown } };
+declare const target: { tabId: number };
+
+const captured = "hi";
+
+chrome.scripting.executeScript({
+  target: { tabId: 1 },
+  func: () => captured.slice(),
+});
+browser.scripting.executeScript({
+  func() {
+    return captured.slice();
+  },
+});
+chrome.scripting.executeScript({
+  ["func"]: function (): string {
+    return captured.slice();
+  },
+});
+chrome.scripting.executeScript(target, {
+  func: () => captured.slice(),
+});
+chrome.scripting.executeScript({
+  get func(): () => string {
+    return () => captured.slice();
+  },
+});
+const dynamicKey = "func";
+chrome.scripting.executeScript({
+  [dynamicKey]: () => captured.slice(),
+});
+const funcValue = (): string => captured.slice();
+chrome.scripting.executeScript({ func: funcValue });
+chrome.scripting["executeScript"]({ func: () => captured.slice() });
+`
+  chromeReason := `property "func" passed to "chrome.scripting.executeScript"`
+  browserReason := `property "func" passed to "browser.scripting.executeScript"`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, source, ""),
+    unicornIsolatedFunctionsFinding{
+      line:    9,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", chromeReason),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    13,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", browserReason),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    18,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", chromeReason),
+    },
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_function_name_callees_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_function_name_callees_test.go
@@ -1,0 +1,96 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsFunctionNameCallees verifies the `functions`
+// option: every function form passed at any argument position of a configured
+// bare-name callee is isolated, and the option replaces (not extends) the
+// defaults.
+//
+// Upstream matches `node.parent.arguments.includes(node)` with an Identifier
+// callee, so member callees and unlisted names must stay silent, parentheses
+// are transparent, and a named function expression's own name — resolved in
+// the function-expression-name scope above the function scope — is reported
+// when used recursively.
+//
+// 1. Pass arrows, async arrows, function expressions, and a parenthesized
+//    arrow to makeSynchronous/workerize and assert each capture is reported.
+// 2. Assert unlisted callees, member callees, and object arguments are clean.
+// 3. Re-run with functions ["myIsolate"] and assert the defaults stop
+//    matching while the custom name reports.
+func TestUnicornIsolatedFunctionsFunctionNameCallees(t *testing.T) {
+  source := `declare function makeSynchronous(...args: unknown[]): unknown;
+declare function workerize(...args: unknown[]): unknown;
+declare function memoize(...args: unknown[]): unknown;
+declare const ns: { makeSynchronous(...args: unknown[]): unknown };
+
+const captured = "hi";
+
+makeSynchronous(() => captured.slice());
+workerize(async () => captured.slice());
+makeSynchronous(async function (): Promise<string> {
+  return captured.slice();
+});
+makeSynchronous(function named(): string {
+  return named.name;
+});
+makeSynchronous(1, () => captured.slice());
+makeSynchronous((((() => captured.slice()))));
+memoize(() => captured.slice());
+ns.makeSynchronous(() => captured.slice());
+makeSynchronous({ method() { return captured.slice(); } });
+`
+  reason := `callee of function named "makeSynchronous"`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, source, ""),
+    unicornIsolatedFunctionsFinding{
+      line:    8,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", reason),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    9,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", `callee of function named "workerize"`),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    11,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", reason),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    14,
+      target:  "named",
+      message: unicornIsolatedFunctionsVariableMessage("named", reason),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    16,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", reason),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    17,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", reason),
+    },
+  )
+
+  replaced := `declare function makeSynchronous(...args: unknown[]): unknown;
+declare function myIsolate(...args: unknown[]): unknown;
+
+const captured = "hi";
+
+makeSynchronous(() => captured.slice());
+myIsolate(() => captured.slice());
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, replaced, `{"functions": ["myIsolate"]}`),
+    unicornIsolatedFunctionsFinding{
+      line:    7,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", `callee of function named "myIsolate"`),
+    },
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_helpers_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_helpers_test.go
@@ -1,0 +1,76 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+)
+
+type unicornIsolatedFunctionsFinding struct {
+  line    int
+  target  string
+  message string
+}
+
+// runUnicornIsolatedFunctions lints one source through the checker-backed
+// snapshot path and normalizes findings to (line, reported text, message).
+// The engine order is preserved: the rule emits position-sorted problems, and
+// equal positions keep the upstream inner-function-first report order.
+func runUnicornIsolatedFunctions(t *testing.T, source string, optionsJSON string) []unicornIsolatedFunctionsFinding {
+  t.Helper()
+  var options json.RawMessage
+  if optionsJSON != "" {
+    options = json.RawMessage(optionsJSON)
+  }
+  _, _, findings := runRuleFindingsSnapshot(t, "unicorn/isolated-functions", source, options)
+  normalized := make([]unicornIsolatedFunctionsFinding, 0, len(findings))
+  for _, finding := range findings {
+    if finding.Rule != "unicorn/isolated-functions" {
+      t.Fatalf("unexpected rule in unicorn/isolated-functions findings: %+v", finding)
+    }
+    if len(finding.Fix) != 0 || len(finding.Suggestions) != 0 {
+      t.Fatalf("unicorn/isolated-functions must not offer edits: %+v", finding)
+    }
+    if finding.Pos < 0 || finding.End < finding.Pos || finding.End > len(source) {
+      t.Fatalf("unicorn/isolated-functions returned an invalid source range: %+v", finding)
+    }
+    normalized = append(normalized, unicornIsolatedFunctionsFinding{
+      line:    shimscanner.GetECMALineOfPosition(finding.File, finding.Pos) + 1,
+      target:  source[finding.Pos:finding.End],
+      message: finding.Message,
+    })
+  }
+  return normalized
+}
+
+func assertUnicornIsolatedFunctionsFindings(
+  t *testing.T,
+  got []unicornIsolatedFunctionsFinding,
+  want ...unicornIsolatedFunctionsFinding,
+) {
+  t.Helper()
+  if len(got) != len(want) {
+    t.Fatalf("unicorn/isolated-functions finding count mismatch:\nwant=%+v\ngot =%+v", want, got)
+  }
+  for index := range want {
+    if got[index] != want[index] {
+      t.Fatalf("unicorn/isolated-functions finding[%d] mismatch:\nwant=%+v\ngot =%+v\nall =%+v",
+        index, want[index], got[index], got)
+    }
+  }
+}
+
+// unicornIsolatedFunctionsVariableMessage builds the externally-scoped
+// diagnostic exactly as upstream interpolates it.
+func unicornIsolatedFunctionsVariableMessage(name, reason string) string {
+  return "Variable " + name + " not defined in scope of isolated function. Function is isolated because: " + reason + "."
+}
+
+func unicornIsolatedFunctionsThisMessage(reason string) string {
+  return "Unexpected `this` in isolated function. Function is isolated because: " + reason + "."
+}
+
+func unicornIsolatedFunctionsSuperMessage(reason string) string {
+  return "Unexpected `super` in isolated function. Function is isolated because: " + reason + "."
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_override_globals_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_override_globals_test.go
@@ -1,0 +1,87 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsOverrideGlobals verifies the overrideGlobals
+// policy matrix over an ambient global (`console`): default readonly allows
+// reads but reports writes as not-writable, "writable" allows writes, "off"
+// disallows the global entirely, and "readonly" restates the default. A
+// captured module binding is never allowed by an override.
+//
+// This mirrors getAllowedGlobalValue: an ambient global maps to ESLint's
+// all-readonly ES-globals default, overrideGlobals is the writability/off
+// escape hatch, and an override on a resolved non-global reference is ignored.
+//
+// 1. Assert the read/write outcome of `console` under no option, "writable",
+//    "off", and "readonly".
+// 2. Assert `overrideGlobals: {foo: true}` still reports a captured module
+//    `foo`.
+func TestUnicornIsolatedFunctionsOverrideGlobals(t *testing.T) {
+  reason := `callee of function named "makeSynchronous"`
+  writeSource := `makeSynchronous(function () {
+  console.log("x");
+  console = undefined;
+});
+`
+
+  // Default: read is allowed, the write to the readonly global is reported.
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, writeSource, ""),
+    unicornIsolatedFunctionsFinding{
+      line:    3,
+      target:  "console",
+      message: unicornIsolatedFunctionsVariableMessage("console", reason+" (global variable is not writable)"),
+    },
+  )
+
+  // "writable" allows the write; nothing is reported.
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, writeSource, `{"overrideGlobals": {"console": "writable"}}`),
+  )
+
+  // "off" disallows the global entirely: both the read and the write report,
+  // neither with the not-writable suffix.
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, writeSource, `{"overrideGlobals": {"console": "off"}}`),
+    unicornIsolatedFunctionsFinding{
+      line:    2,
+      target:  "console",
+      message: unicornIsolatedFunctionsVariableMessage("console", reason),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    3,
+      target:  "console",
+      message: unicornIsolatedFunctionsVariableMessage("console", reason),
+    },
+  )
+
+  // "readonly" restates the default: read allowed, write reported.
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, writeSource, `{"overrideGlobals": {"console": "readonly"}}`),
+    unicornIsolatedFunctionsFinding{
+      line:    3,
+      target:  "console",
+      message: unicornIsolatedFunctionsVariableMessage("console", reason+" (global variable is not writable)"),
+    },
+  )
+
+  // An override cannot whitelist a captured module binding.
+  captured := `const foo = "hi";
+makeSynchronous(function () {
+  return foo.slice();
+});
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, captured, `{"overrideGlobals": {"foo": true}}`),
+    unicornIsolatedFunctionsFinding{
+      line:    3,
+      target:  "foo",
+      message: unicornIsolatedFunctionsVariableMessage("foo", reason),
+    },
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_parameter_default_capture_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_parameter_default_capture_test.go
@@ -1,0 +1,41 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsParameterDefaultCapture verifies that an outer
+// binding referenced from a parameter default value is a scope escape, whether
+// the default is on a plain parameter or a destructuring binding element.
+//
+// Parameter defaults are evaluated in the function's own scope, so upstream's
+// scope.through carries the outer reference; the port walks the parameter list
+// as an analysis root and reports the captured initializer while the parameter
+// names themselves stay declared-in-scope.
+//
+// 1. Capture outer `outer` from a plain parameter default and from a
+//    destructuring element default under makeSynchronous.
+// 2. Assert each reference is reported once, and the parameter names are not.
+func TestUnicornIsolatedFunctionsParameterDefaultCapture(t *testing.T) {
+  reason := `callee of function named "makeSynchronous"`
+  source := `declare function makeSynchronous<T>(fn: T): T;
+
+const outer = "hi";
+
+makeSynchronous((x = outer) => x);
+
+makeSynchronous(({ a = outer }: { a?: string }) => a);
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, source, ""),
+    unicornIsolatedFunctionsFinding{
+      line:    5,
+      target:  "outer",
+      message: unicornIsolatedFunctionsVariableMessage("outer", reason),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    7,
+      target:  "outer",
+      message: unicornIsolatedFunctionsVariableMessage("outer", reason),
+    },
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_scope_internals_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_scope_internals_test.go
@@ -1,0 +1,52 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsScopeInternals verifies that bindings introduced
+// anywhere inside an isolated function — nested closures over its locals,
+// nested function declarations, method parameters and locals, destructuring
+// parameters, and a local that shadows an outer binding — never count as scope
+// escapes.
+//
+// These are the negative twins for the capture reports: upstream's
+// scope.through only carries references that fail to resolve within the
+// isolated scope, so a resolved inner binding (including a shadow of an outer
+// name) must stay silent. An over-match here would fire on ordinary code.
+//
+// 1. Exercise nested closure/function, object-method params+locals+global,
+//    destructuring params, and a shadowing local.
+// 2. Assert nothing is reported.
+func TestUnicornIsolatedFunctionsScopeInternals(t *testing.T) {
+  source := `declare function makeSynchronous<T>(fn: T): T;
+
+const shadowed = "outer";
+
+/** @isolated */
+function withNestedClosure() {
+  const local = "hi";
+  const slice = () => local.slice();
+  function helper() {
+    return slice();
+  }
+  return helper();
+}
+withNestedClosure();
+
+const object = {
+  /** @isolated */
+  method(param: string) {
+    const bar = param.slice();
+    return console.log(bar);
+  },
+};
+object.method("x");
+
+makeSynchronous(({ a, b }: { a: string; b: string }) => a + b);
+
+makeSynchronous(() => {
+  const shadowed = "inner";
+  return shadowed.slice();
+});
+`
+  assertUnicornIsolatedFunctionsFindings(t, runUnicornIsolatedFunctions(t, source, ""))
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_selector_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_selector_test.go
@@ -1,0 +1,38 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsSelector verifies the `selectors` option: a
+// function matching a configured AST selector becomes isolated and reports its
+// captures with a `matches selector ...` reason, while a non-matching sibling
+// stays clean.
+//
+// Upstream registers one onExit listener per selector; the port pre-matches
+// the selector against the tree and attaches the reason in option order. The
+// reason string is the JSON-quoted selector source, combinators included.
+//
+// 1. Isolate `FunctionDeclaration[id.name=/lambdaHandler.*/]` and assert the
+//    matching declaration's captured `foo` is reported.
+// 2. Assert the non-matching declaration's identical capture stays clean.
+func TestUnicornIsolatedFunctionsSelector(t *testing.T) {
+  source := `const foo = "hi";
+
+function lambdaHandlerFoo() {
+  return foo.slice();
+}
+
+function someOtherFunction() {
+  return foo.slice();
+}
+`
+  selector := "FunctionDeclaration[id.name=/lambdaHandler.*/]"
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, source, `{"selectors": ["`+selector+`"]}`),
+    unicornIsolatedFunctionsFinding{
+      line:    4,
+      target:  "foo",
+      message: unicornIsolatedFunctionsVariableMessage("foo", `matches selector "`+selector+`"`),
+    },
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_test.go
@@ -1,0 +1,71 @@
+package linthost
+
+import "testing"
+
+// TestRuleCorpusUnicornIsolatedFunctions verifies the real-command corpus
+// fixture's scope-escape semantics through the checker-backed native engine.
+//
+// The corpus is the end-to-end command oracle; this package-local twin keeps
+// its exact positive and negative cases visible in focused Go coverage,
+// including the recursion-through-hoisted-name report the upstream scope
+// model mandates.
+//
+// 1. Run the annotated fixture source with a real Program and checker.
+// 2. Assert the captured references, the hoisted-name recursion, and the
+//    `this` usage are reported with their isolation reasons.
+// 3. Assert the clean twin using parameters, locals, and ambient globals
+//    stays silent.
+func TestRuleCorpusUnicornIsolatedFunctions(t *testing.T) {
+  source := `declare function makeSynchronous<T>(fn: T): T;
+
+const captured = "hi";
+
+// expect: unicorn/isolated-functions error
+makeSynchronous(() => captured.slice());
+
+/** @isolated */
+function viaComment(): string {
+  // expect: unicorn/isolated-functions error
+  // expect: unicorn/isolated-functions error
+  return captured.slice() + viaComment.name;
+}
+viaComment();
+
+makeSynchronous(function (this: { key: string }) {
+  // expect: unicorn/isolated-functions error
+  return this.key;
+});
+
+// Clean twin: parameters, locals, and ambient globals stay usable inside the
+// isolated function.
+makeSynchronous((prefix: string) => {
+  const local = "ok";
+  console.log(local);
+  return prefix + local + new Array(1).length;
+});
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, source, ""),
+    unicornIsolatedFunctionsFinding{
+      line:    6,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", `callee of function named "makeSynchronous"`),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    12,
+      target:  "captured",
+      message: unicornIsolatedFunctionsVariableMessage("captured", `follows comment "@isolated"`),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    12,
+      target:  "viaComment",
+      message: unicornIsolatedFunctionsVariableMessage("viaComment", `follows comment "@isolated"`),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    18,
+      target:  "this",
+      message: unicornIsolatedFunctionsThisMessage(`callee of function named "makeSynchronous"`),
+    },
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_this_and_super_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_this_and_super_test.go
@@ -1,0 +1,105 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsThisAndSuper verifies the `this` / `super`
+// context walk of getFunctionContextProblems: an isolated function owns its
+// `this`/`super`, a nested arrow shares that context, and a nested non-arrow
+// function or class method owns its own context and stops the walk.
+//
+// Upstream reports every `ThisExpression`/`Super` reachable without crossing a
+// new function context boundary; the arrow chain keeps the isolated context,
+// while a nested regular function or class method introduces a fresh context
+// whose `this` is its own, so those stay clean.
+//
+// 1. Assert direct `this` in an @isolated method, `super` in an @isolated
+//    method, and both through a nested arrow are reported.
+// 2. Assert a nested regular function's `this` and a nested class method's
+//    `this` stay clean.
+func TestUnicornIsolatedFunctionsThisAndSuper(t *testing.T) {
+  comment := `follows comment "@isolated"`
+
+  directThis := `class Base { foo = 1; }
+class Example extends Base {
+  /** @isolated */
+  method() {
+    return this.foo;
+  }
+}
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, directThis, ""),
+    unicornIsolatedFunctionsFinding{
+      line:    5,
+      target:  "this",
+      message: unicornIsolatedFunctionsThisMessage(comment),
+    },
+  )
+
+  directSuper := `class Base { foo = 1; }
+class Example extends Base {
+  /** @isolated */
+  method() {
+    return super.foo;
+  }
+}
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, directSuper, ""),
+    unicornIsolatedFunctionsFinding{
+      line:    5,
+      target:  "super",
+      message: unicornIsolatedFunctionsSuperMessage(comment),
+    },
+  )
+
+  // A nested arrow keeps the isolated function's lexical `this`/`super`, so
+  // both are reported; upstream yields the ThisExpression before the Super in
+  // source order.
+  nestedArrow := `class Base { foo = 1; }
+class Example extends Base {
+  /** @isolated */
+  method() {
+    const getValue = () => this.foo + super.foo;
+    return getValue;
+  }
+}
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, nestedArrow, ""),
+    unicornIsolatedFunctionsFinding{
+      line:    5,
+      target:  "this",
+      message: unicornIsolatedFunctionsThisMessage(comment),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    5,
+      target:  "super",
+      message: unicornIsolatedFunctionsSuperMessage(comment),
+    },
+  )
+
+  // A nested non-arrow function and a nested class method each own their
+  // `this`; the isolated context walk must stop at their boundary, so both
+  // are clean.
+  nestedOwnContext := `/** @isolated */
+function abc() {
+  function getValue() {
+    return this.value;
+  }
+  return class {
+    method() {
+      return this.value;
+    }
+  };
+}
+abc();
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, nestedOwnContext, ""),
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_typeof_this_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_typeof_this_test.go
@@ -1,0 +1,41 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsTypeofThis verifies that a `this` appearing at
+// the head of a type-query entity name is reported exactly once, as a `this`
+// context problem, never as an externally-scoped variable.
+//
+// ESTree models `typeof this` and `typeof this.foo` with a ThisExpression, so
+// upstream yields a single `this` context report. TypeScript-Go instead spells
+// the qualified-name head as an identifier named "this"; the port must route
+// it through the context walk only, or it would double-report a nonsensical
+// "Variable this not defined in scope".
+//
+// 1. Reference `typeof this` and `typeof this.foo` inside an isolated function.
+// 2. Assert one `this` context report per occurrence and no variable report.
+func TestUnicornIsolatedFunctionsTypeofThis(t *testing.T) {
+  reason := `callee of function named "makeSynchronous"`
+  source := `declare function makeSynchronous<T>(fn: T): T;
+
+makeSynchronous(function () {
+  let a: typeof this;
+  let b: typeof this.foo;
+  return [a, b];
+});
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, source, ""),
+    unicornIsolatedFunctionsFinding{
+      line:    4,
+      target:  "this",
+      message: unicornIsolatedFunctionsThisMessage(reason),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    5,
+      target:  "this",
+      message: unicornIsolatedFunctionsThisMessage(reason),
+    },
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_typescript_types_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_typescript_types_test.go
@@ -1,0 +1,34 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsTypeScriptTypes verifies that type-only
+// references to outer bindings never count as scope escapes: an isolated
+// function may name outer types and `typeof` outer values in type positions.
+//
+// Upstream skips identifiers whose parent is a TSTypeReference or TSTypeQuery;
+// the port mirrors that so `typeof a`, generic constraints, `as`, `satisfies`,
+// and conditional types stay silent while their runtime values are declared
+// inside the function.
+//
+// 1. Reference outer `a` (via `typeof`) and outer `MyType` only in type
+//    positions inside a makeSynchronous callback.
+// 2. Assert nothing is reported.
+func TestUnicornIsolatedFunctionsTypeScriptTypes(t *testing.T) {
+  source := `declare function makeSynchronous<T>(fn: T): T;
+
+const a = 1;
+type MyType = { foo: string };
+makeSynchronous(() => {
+  const b: typeof a = 1;
+  const f = <T extends MyType>(t: T) => t;
+  let myType: MyType = { foo: "bar" };
+  myType = { foo: "bar" } as MyType;
+  myType = { foo: "bar" } as const;
+  myType = { foo: "baz" } satisfies MyType;
+  type X = typeof myType extends MyType ? true : false;
+  return [b, f, myType] as X extends true ? unknown[] : never;
+});
+`
+  assertUnicornIsolatedFunctionsFindings(t, runUnicornIsolatedFunctions(t, source, ""))
+}

--- a/packages/lint/test/rules/unicorn/unicorn_isolated_functions_unresolved_reference_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_isolated_functions_unresolved_reference_test.go
@@ -1,0 +1,37 @@
+package linthost
+
+import "testing"
+
+// TestUnicornIsolatedFunctionsUnresolvedReference verifies that a name which
+// resolves to no declaration at all — an inherited prototype property name
+// like `constructor` or any undeclared identifier — is reported, while a real
+// ambient global on the same line is not.
+//
+// Upstream's scope.through carries unresolved references, and
+// getAllowedGlobalValue only whitelists names that are configured globals; an
+// unresolved identifier is neither declared inside the function nor an ambient
+// global, so it escapes.
+//
+// 1. Assert `constructor` and an undeclared `missingGlobal` are reported.
+// 2. Assert the ambient global `Array` on the same callback stays clean.
+func TestUnicornIsolatedFunctionsUnresolvedReference(t *testing.T) {
+  reason := `callee of function named "makeSynchronous"`
+  source := `declare function makeSynchronous<T>(fn: T): T;
+
+makeSynchronous(() => [constructor, missingGlobal, new Array()]);
+`
+  assertUnicornIsolatedFunctionsFindings(
+    t,
+    runUnicornIsolatedFunctions(t, source, ""),
+    unicornIsolatedFunctionsFinding{
+      line:    3,
+      target:  "constructor",
+      message: unicornIsolatedFunctionsVariableMessage("constructor", reason),
+    },
+    unicornIsolatedFunctionsFinding{
+      line:    3,
+      target:  "missingGlobal",
+      message: unicornIsolatedFunctionsVariableMessage("missingGlobal", reason),
+    },
+  )
+}

--- a/tests/test-lint/src/cases/unicorn-isolated-functions.ts
+++ b/tests/test-lint/src/cases/unicorn-isolated-functions.ts
@@ -1,1 +1,27 @@
-// @ttsc-corpus-skip: unicorn/isolated-functions not yet implemented; fixture exists as the link target referenced from packages/lint/README.md and website/src/content/docs/lint/rules/unicorn.mdx. The skip directive is removed and replaced with a `// expect:` annotation once the rule lands in this PR (feat/lint-unicorn-rules).
+declare function makeSynchronous<T>(fn: T): T;
+
+const captured = "hi";
+
+// expect: unicorn/isolated-functions error
+makeSynchronous(() => captured.slice());
+
+/** @isolated */
+function viaComment(): string {
+  // expect: unicorn/isolated-functions error
+  // expect: unicorn/isolated-functions error
+  return captured.slice() + viaComment.name;
+}
+viaComment();
+
+makeSynchronous(function (this: { key: string }) {
+  // expect: unicorn/isolated-functions error
+  return this.key;
+});
+
+// Clean twin: parameters, locals, and ambient globals stay usable inside the
+// isolated function.
+makeSynchronous((prefix: string) => {
+  const local = "ok";
+  console.log(local);
+  return prefix + local + new Array(1).length;
+});

--- a/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
+++ b/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
@@ -42,6 +42,9 @@ import assert from "node:assert/strict";
  * - Unicorn replacement maps and import modes retain their exact public shape.
  * - `unicorn/import-style` accepts per-module style maps and `false` module
  *   entries, and rejects a non-`false` scalar module entry.
+ * - `unicorn/isolated-functions` exposes its function/selector/comment lists and
+ *   per-name `overrideGlobals` policies, rejecting arbitrary keys and
+ *   out-of-enum global policies.
  * - An empty object policy for `typescript/ban-ts-comment` is rejected because
  *   the object form requires `descriptionFormat`.
  * - A lint-only rule (`no-var`) cannot carry an options object.
@@ -213,6 +216,20 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
             },
           },
           selectors: ['VariableDeclarator[id.name="description"] > Literal'],
+        },
+      ],
+      "unicorn/isolated-functions": [
+        "error",
+        {
+          functions: ["makeSynchronous", "runInWorker"],
+          selectors: ["FunctionDeclaration[id.name=/^lambda/]"],
+          comments: ["@isolated", "@remote"],
+          overrideGlobals: {
+            console: "writable",
+            fetch: "readonly",
+            process: "off",
+            document: true,
+          },
         },
       ],
     },
@@ -533,6 +550,21 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
       ],
     },
   };
+  const isolatedFunctionsOptionKeyTypo: ITtscLintConfig = {
+    rules: {
+      // @ts-expect-error — `comment` is a typo of `comments`; the rule exposes no arbitrary option keys.
+      "unicorn/isolated-functions": ["error", { comment: ["@isolated"] }],
+    },
+  };
+  const isolatedFunctionsGlobalPolicyShape: ITtscLintConfig = {
+    rules: {
+      "unicorn/isolated-functions": [
+        "error",
+        // @ts-expect-error — a global policy is a boolean or one of "readonly" | "writable" | "writeable" | "off".
+        { overrideGlobals: { console: "sometimes" } },
+      ],
+    },
+  };
   const banTsCommentMissingDescriptionFormat: ITtscLintConfig = {
     rules: {
       "typescript/ban-ts-comment": [
@@ -583,6 +615,8 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
   assert.ok(unicornReplacementShape);
   assert.ok(importStyleOptionKeyTypo);
   assert.ok(importStyleModuleEntryShape);
+  assert.ok(isolatedFunctionsOptionKeyTypo);
+  assert.ok(isolatedFunctionsGlobalPolicyShape);
   assert.ok(banTsCommentMissingDescriptionFormat);
   assert.ok(camelBuiltinName);
 };

--- a/website/src/content/docs/lint/rules/unicorn.mdx
+++ b/website/src/content/docs/lint/rules/unicorn.mdx
@@ -479,15 +479,17 @@ export default {
 
 ### `unicorn/isolated-functions`
 
-Reject references to outer-scope variables inside functions marked as isolated (e.g., the body of a web worker).
+Reject references to outer-scope variables (and `this` / `super`) inside functions that run outside their defining context. Functions are recognized as isolated when passed to a configured name (`makeSynchronous` and `workerize` by default), to `browser.execute` / `page.evaluate`, as the `func` property of `chrome.scripting.executeScript` / `browser.scripting.executeScript`, or when preceded by an `@isolated` comment; the `functions`, `selectors`, `comments`, and `overrideGlobals` options tune this.
 
-Illustrative shape:
+Example:
 
 ```ts
 const prefix = "user:";
-const isolated = (task: () => string) => task;
 
-const worker = isolated(() => `${prefix}ready`);
+// `makeSynchronous` runs the callback in a separate context, so the captured
+// `prefix` is unavailable there.
+// reports: unicorn/isolated-functions (error)
+const build = makeSynchronous(() => `${prefix}ready`);
 ```
 
 <a id="rule-unicorn-new-for-builtins"></a>


### PR DESCRIPTION
Closes #480

## Intent

Replace the `unicorn/isolated-functions` no-op stub with a faithful port of the upstream eslint-plugin-unicorn rule: functions that run outside their defining execution context — configured-name callees (`makeSynchronous` / `workerize`), `browser.execute` / `page.evaluate`, the `func` property of `chrome|browser.scripting.executeScript`, `@isolated`-commented functions, and selector-matched functions — must not reference bindings from their surrounding scope, `this`, or `super`.

## Scope-analysis mapping

ESLint's `scope.through` + `getAllowedGlobalValue` are mapped onto the TypeScript-Go checker: a reference is allowed when its symbol has a declaration inside the isolated function; ambient globals (lib / `@types` / `declare`) map to ESLint's all-readonly ES-globals default and stay read-only unless `overrideGlobals` grants writability or turns them `off`. Environment-specific writable globals (ESLint `languageOptions.globals`) have no faithful equivalent and are intentionally not modeled; `overrideGlobals` is the escape hatch (documented in the rule source).

## Correctness fix over the WIP

TypeScript-Go spells the `this` at the head of a type-query entity name (`typeof this.foo`) as an identifier named `"this"`, which the reference walk double-reported as a nonsensical `Variable this not defined in scope`. ESTree models every `this` as a `ThisExpression` owned by the context walk, so the reference filter now skips any identifier spelled `"this"` (a reserved word that can name no binding). Locked by `unicorn_isolated_functions_typeof_this_test.go`.

## Coverage (oracle = upstream rule + its test file)

10 new Go test files added on top of the WIP's 5, each with positive/negative twins: this/super context nesting, comment-marker variety (declaration/arrow/export/object/class, block/JSDoc/inline, explanations), the `overrideGlobals` policy matrix including the writability twins, selectors, TypeScript type positions, unresolved references, `arguments` ownership, parameter-default capture, shadowing, and clean scope-internals twins. The corpus fixture's `@ttsc-corpus-skip` is removed and it is a live behavioral case.

## Typed options + docs

Added `ITtscLintUnicornIsolatedFunctionsRuleOptions` (functions / selectors / comments / overrideGlobals) wired through `ITtscLintRuleOptionsMap` so the rule accepts `[severity, options]` in typed config, with positive and `@ts-expect-error` cases in the autocomplete test. The website rule doc now shows a faithful, firing example.

## Validation

- `unicorn/isolated-functions` Go tests (all 15 files) pass via the real scratch runner.
- Full `node scripts/test-go-lint.cjs` exited 0.
- `pnpm format` was **not** run (it triggers a repo-wide CRLF rewrite on the authoring machine); left to CI. The `test:typecheck` lane (which validates the autocomplete d.ts) and the corpus partition lane run in CI.
