### PR TITLE
feat(lint): implement unicorn/no-unused-properties

### DIFF
--- a/packages/lint/linthost/rules_unicorn_no_unused_properties.go
+++ b/packages/lint/linthost/rules_unicorn_no_unused_properties.go
@@ -1,28 +1,765 @@
-// unicorn/no-unused-properties: flags object-literal properties that
-// are never read after the object is constructed. The signal is "this
-// key sits in a literal that nothing reaches into" — analogous to
-// `no-unused-vars` but for one level deeper inside object data.
+// unicorn/no-unused-properties: report properties of object literals and
+// inline type literals that no reference ever reads.
 //
-// Escape-hatch / no-op port: implementing this faithfully requires
-// per-object reachability and read tracking across the file (and across
-// destructuring patterns, spread, computed access, and exports). That
-// is a scope-and-flow problem the AST-only engine in this package
-// cannot yet model without false positives every time a property is
-// read through dynamic access. Registered so the typed-key/Go-registry
-// parity check passes and so users can configure the rule, but it
-// intentionally reports nothing until the analysis lands in a
-// follow-up.
-// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unused-properties.md
+// Port of the current upstream analysis: for every single-definition
+// variable that binds an object literal (or carries an inline `{...}` type
+// annotation, including annotated parameters), walk the variable's
+// references and keep only the ones that can reach each property — a member
+// access with the same key, a dynamic/computed access, a member call or
+// assignment, a destructuring that names the key or uses rest, or any
+// escape (alias, argument, return, export, spread). A property whose
+// reference list filters down to nothing is dead data and gets reported;
+// references that survive drive the same analysis one level deeper into
+// nested object/type literals.
+//
+// Escape analysis stays conservative exactly where upstream is: one
+// unpredictable use (passed, returned, aliased, exported, computed access,
+// mutated) marks every property as used. Variables in a script file's
+// global scope are skipped, mirroring upstream's global-scope exclusion.
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-unused-properties.js
 package linthost
 
-import shimast "github.com/microsoft/typescript-go/shim/ast"
+import (
+  "math/big"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
 
 type unicornNoUnusedProperties struct{}
 
-func (unicornNoUnusedProperties) Name() string           { return "unicorn/no-unused-properties" }
-func (unicornNoUnusedProperties) Visits() []shimast.Kind { return nil }
-func (unicornNoUnusedProperties) Check(_ *Context, _ *shimast.Node) {
-  // Intentionally empty — see file header for the escape-hatch rationale.
+func (unicornNoUnusedProperties) Name() string { return "unicorn/no-unused-properties" }
+func (unicornNoUnusedProperties) NeedsTypeChecker() bool {
+  return true
+}
+func (unicornNoUnusedProperties) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindSourceFile}
+}
+
+// unusedPropertiesReference is one use of the analyzed variable. At the top
+// level `node` is the referencing Identifier; recursion into nested
+// containers replaces it with the syntax that consumed the previous key
+// (member expression, matched destructuring, exported declaration) so the
+// next level can inspect that node's parent. `init` marks the write at the
+// variable's own declarator.
+type unusedPropertiesReference struct {
+  node *shimast.Node
+  init bool
+}
+
+// unusedPropertiesCandidate is one analyzable variable: a binding identifier
+// plus the property container its declaration supplies.
+type unusedPropertiesCandidate struct {
+  nameNode    *shimast.Node
+  container   *shimast.Node
+  declaration *shimast.Node
+  references  []unusedPropertiesReference
+}
+
+// unusedPropertiesKey is the comparable identity of a property key or member
+// access. `class` separates runtime value kinds (string names and string
+// literals share one class; numbers, bigints, booleans and null each keep
+// their own) so `foo[0]` matches `{0: 1}` but not `{"0": 1}`, mirroring the
+// strict-equality comparison upstream performs on key values.
+type unusedPropertiesKey struct {
+  class string
+  text  string
+  ok    bool
+}
+
+func (unicornNoUnusedProperties) Check(ctx *Context, node *shimast.Node) {
+  if ctx == nil || ctx.Checker == nil || ctx.File == nil ||
+    node == nil || node.Kind != shimast.KindSourceFile {
+    return
+  }
+  candidates := unusedPropertiesCollectCandidates(ctx, node)
+  if len(candidates) == 0 {
+    return
+  }
+  unusedPropertiesCollectReferences(ctx, node, candidates)
+  pureWrites := unusedPropertiesCollectPureWriteTargets(node)
+  for _, candidate := range candidates {
+    if !unusedPropertiesHasReadReference(candidate, pureWrites) {
+      continue
+    }
+    unusedPropertiesReportContainer(ctx, candidate.container, candidate.references)
+  }
+}
+
+// unusedPropertiesCollectCandidates walks the file for variables the rule can
+// analyze: variable declarations whose initializer (through TS assertion
+// wrappers) is an object literal or whose annotated type is an inline type
+// literal, and identifier parameters annotated with an inline type literal.
+// Mirroring upstream's scope walk, script-file globals are excluded; only a
+// module's top level is analyzable.
+func unusedPropertiesCollectCandidates(
+  ctx *Context,
+  root *shimast.Node,
+) []*unusedPropertiesCandidate {
+  var candidates []*unusedPropertiesCandidate
+  walkDescendants(root, func(child *shimast.Node) {
+    switch child.Kind {
+    case shimast.KindVariableDeclaration:
+      declaration := child.AsVariableDeclaration()
+      if declaration == nil || declaration.Initializer == nil {
+        return
+      }
+      container := unusedPropertiesDeclarationContainer(declaration)
+      if container == nil || unusedPropertiesDeclaredInGlobalScope(ctx.File, child) {
+        return
+      }
+      for _, nameNode := range bindingIdentifierNodes(declaration.Name()) {
+        candidates = append(candidates, &unusedPropertiesCandidate{
+          nameNode:    nameNode,
+          container:   container,
+          declaration: child,
+        })
+      }
+    case shimast.KindParameter:
+      parameter := child.AsParameterDeclaration()
+      if parameter == nil || parameter.Type == nil ||
+        parameter.Type.Kind != shimast.KindTypeLiteral {
+        return
+      }
+      nameNode := parameter.Name()
+      if nameNode == nil || nameNode.Kind != shimast.KindIdentifier {
+        return
+      }
+      candidates = append(candidates, &unusedPropertiesCandidate{
+        nameNode:    nameNode,
+        container:   parameter.Type,
+        declaration: child,
+      })
+    }
+  })
+  return candidates
+}
+
+// unusedPropertiesDeclarationContainer resolves the property container a
+// variable declaration supplies: the object literal it is initialized with
+// (TS assertion wrappers are transparent), else the inline type literal it
+// is annotated with. Upstream only consults the annotation when an
+// initializer exists (`declare const x: {...}` stays out of scope); the
+// caller has already required one.
+func unusedPropertiesDeclarationContainer(
+  declaration *shimast.VariableDeclaration,
+) *shimast.Node {
+  initializer := unwrapReferenceExpression(declaration.Initializer)
+  if initializer != nil && initializer.Kind == shimast.KindObjectLiteralExpression {
+    return initializer
+  }
+  if declaration.Type != nil && declaration.Type.Kind == shimast.KindTypeLiteral {
+    return declaration.Type
+  }
+  return nil
+}
+
+// unusedPropertiesDeclaredInGlobalScope reports whether a variable
+// declaration lands in the global scope, which only exists at the top level
+// of a script file (no import/export). `var` hoists past blocks, so it is
+// global unless a function-like body, class static block, or namespace body
+// intervenes; `let`/`const`/`using` are global only as a direct top-level
+// statement.
+func unusedPropertiesDeclaredInGlobalScope(
+  file *shimast.SourceFile,
+  declaration *shimast.Node,
+) bool {
+  if file == nil || file.ExternalModuleIndicator != nil {
+    return false
+  }
+  if shimast.GetCombinedNodeFlags(declaration)&shimast.NodeFlagsBlockScoped != 0 {
+    list := declaration.Parent
+    if list == nil || list.Parent == nil ||
+      list.Parent.Kind != shimast.KindVariableStatement {
+      return false
+    }
+    statement := list.Parent
+    return statement.Parent != nil && statement.Parent.Kind == shimast.KindSourceFile
+  }
+  for ancestor := declaration.Parent; ancestor != nil; ancestor = ancestor.Parent {
+    if isFunctionLikeKind(ancestor) {
+      return false
+    }
+    switch ancestor.Kind {
+    case shimast.KindClassStaticBlockDeclaration,
+      shimast.KindModuleBlock,
+      shimast.KindModuleDeclaration:
+      return false
+    case shimast.KindSourceFile:
+      return true
+    }
+  }
+  return false
+}
+
+// unusedPropertiesCollectReferences fills each candidate's reference list by
+// resolving every same-named identifier in the file to its checker symbol.
+// The candidate's own binding identifier becomes the `init` reference when
+// the declarator has an initializer; parameters bind without one. Candidates
+// whose symbol cannot be resolved to exactly one declaration lose their
+// container, which excludes them from analysis.
+func unusedPropertiesCollectReferences(
+  ctx *Context,
+  root *shimast.Node,
+  candidates []*unusedPropertiesCandidate,
+) {
+  bySymbol := make(map[*shimast.Symbol]*unusedPropertiesCandidate, len(candidates))
+  names := make(map[string]struct{}, len(candidates))
+  for _, candidate := range candidates {
+    symbol := unusedPropertiesDeclaredSymbol(ctx, candidate)
+    if symbol == nil || len(symbol.Declarations) != 1 || bySymbol[symbol] != nil {
+      candidate.container = nil
+      continue
+    }
+    bySymbol[symbol] = candidate
+    names[identifierText(candidate.nameNode)] = struct{}{}
+  }
+  if len(bySymbol) == 0 {
+    return
+  }
+  walkDescendants(root, func(child *shimast.Node) {
+    if child.Kind != shimast.KindIdentifier {
+      return
+    }
+    if _, possible := names[identifierText(child)]; !possible {
+      return
+    }
+    candidate, ok := bySymbol[unusedPropertiesSymbolAtIdentifier(ctx, child)]
+    if !ok {
+      return
+    }
+    if child == candidate.nameNode {
+      if candidate.declaration.Kind == shimast.KindVariableDeclaration {
+        candidate.references = append(candidate.references, unusedPropertiesReference{
+          node: child,
+          init: true,
+        })
+      }
+      return
+    }
+    candidate.references = append(candidate.references, unusedPropertiesReference{node: child})
+  })
+}
+
+// unusedPropertiesDeclaredSymbol resolves a candidate's binding identifier to
+// its canonical symbol. A TypeScript parameter property carries two symbols
+// at one declaration name — the class member and the constructor-local
+// parameter; body references bind to the latter, so the constructor's locals
+// table is the canonical lookup (mirrors noParamReassignParameterSymbol).
+func unusedPropertiesDeclaredSymbol(
+  ctx *Context,
+  candidate *unusedPropertiesCandidate,
+) *shimast.Symbol {
+  declaration := candidate.declaration
+  if declaration.Kind == shimast.KindParameter && declaration.Parent != nil &&
+    declaration.Parent.Kind == shimast.KindConstructor && isParameterProperty(declaration) {
+    symbol := declaration.Parent.Locals()[identifierText(candidate.nameNode)]
+    if symbol == nil {
+      return nil
+    }
+    return ctx.Checker.GetMergedSymbol(symbol)
+  }
+  return unusedPropertiesSymbolAtIdentifier(ctx, candidate.nameNode)
+}
+
+// unusedPropertiesSymbolAtIdentifier resolves an identifier in value position
+// to its canonical binding symbol. Shorthand property values and export
+// specifiers need their dedicated checker queries: `({foo} = x)` resolves the
+// written binding and `export { foo }` resolves the aliased local rather than
+// the specifier's own alias symbol, matching how the checker's own
+// reference-finding treats those positions.
+func unusedPropertiesSymbolAtIdentifier(
+  ctx *Context,
+  identifier *shimast.Node,
+) *shimast.Symbol {
+  if identifier == nil || identifier.Kind != shimast.KindIdentifier {
+    return nil
+  }
+  symbol := valueSymbolAtIdentifier(ctx, identifier)
+  if parent := identifier.Parent; parent != nil && parent.Kind == shimast.KindExportSpecifier {
+    if specifier := parent.AsExportSpecifier(); specifier != nil &&
+      unusedPropertiesIsExportSpecifierAlias(identifier, specifier) {
+      if local := ctx.Checker.GetExportSpecifierLocalTargetSymbol(parent); local != nil {
+        symbol = local
+      }
+    }
+  }
+  if symbol == nil {
+    return nil
+  }
+  if symbol.Flags&shimast.SymbolFlagsExportValue != 0 && symbol.ExportSymbol != nil {
+    symbol = symbol.ExportSymbol
+  }
+  return ctx.Checker.GetMergedSymbol(symbol)
+}
+
+// unusedPropertiesIsExportSpecifierAlias reports whether the identifier is
+// the side of an export specifier that references a local binding: the
+// property name of `export { foo as bar }`, or the single name of a
+// non-re-export `export { foo }`.
+func unusedPropertiesIsExportSpecifierAlias(
+  identifier *shimast.Node,
+  specifier *shimast.ExportSpecifier,
+) bool {
+  if specifier.PropertyName != nil {
+    return specifier.PropertyName == identifier
+  }
+  declaration := specifier.AsNode().Parent
+  if declaration != nil {
+    declaration = declaration.Parent
+  }
+  return declaration == nil || declaration.ModuleSpecifier() == nil
+}
+
+// unusedPropertiesCollectPureWriteTargets gathers every identifier written by
+// a plain `=` assignment (including destructuring targets) or a for-in/of
+// head. Those references never read the variable, so a variable whose uses
+// are all pure writes is left to no-unused-vars, exactly like upstream's
+// read-reference check. Compound assignments and updates read before writing
+// and are intentionally absent.
+func unusedPropertiesCollectPureWriteTargets(
+  root *shimast.Node,
+) map[*shimast.Node]struct{} {
+  targets := make(map[*shimast.Node]struct{})
+  walkDescendants(root, func(child *shimast.Node) {
+    switch child.Kind {
+    case shimast.KindBinaryExpression:
+      expression := child.AsBinaryExpression()
+      if expression == nil || expression.OperatorToken == nil ||
+        expression.OperatorToken.Kind != shimast.KindEqualsToken ||
+        isDestructuringDefaultAssignment(child) {
+        return
+      }
+      for _, target := range assignmentTargetIdentifiers(expression.Left) {
+        targets[target] = struct{}{}
+      }
+    case shimast.KindForInStatement, shimast.KindForOfStatement:
+      statement := child.AsForInOrOfStatement()
+      if statement == nil || statement.Initializer == nil ||
+        statement.Initializer.Kind == shimast.KindVariableDeclarationList {
+        return
+      }
+      for _, target := range assignmentTargetIdentifiers(statement.Initializer) {
+        targets[target] = struct{}{}
+      }
+    }
+  })
+  return targets
+}
+
+// unusedPropertiesHasReadReference reports whether the candidate is read at
+// least once. A candidate stripped of its container (unresolvable symbol) or
+// with write-only references is skipped entirely.
+func unusedPropertiesHasReadReference(
+  candidate *unusedPropertiesCandidate,
+  pureWrites map[*shimast.Node]struct{},
+) bool {
+  if candidate.container == nil {
+    return false
+  }
+  for _, reference := range candidate.references {
+    if reference.init {
+      continue
+    }
+    if _, writeOnly := pureWrites[reference.node]; writeOnly {
+      continue
+    }
+    return true
+  }
+  return false
+}
+
+// unusedPropertiesReportContainer checks every named property of an object or
+// type literal against the reference list, reporting the ones nothing can
+// read and recursing into nested containers with the references that reached
+// their property.
+func unusedPropertiesReportContainer(
+  ctx *Context,
+  container *shimast.Node,
+  references []unusedPropertiesReference,
+) {
+  for _, property := range unusedPropertiesContainerProperties(container) {
+    keyNode := property.Name()
+    if keyNode == nil {
+      continue
+    }
+    key := unusedPropertiesKeyOf(keyNode)
+    if key.ok && key.class == "string" && key.text == "__proto__" {
+      continue
+    }
+    next := unusedPropertiesFilterReferences(references, key)
+    if len(next) == 0 {
+      ctx.Report(
+        property,
+        "Property `"+unusedPropertiesDisplayName(ctx.File, keyNode, key)+"` is defined but never used.",
+      )
+      continue
+    }
+    if nested := unusedPropertiesPropertyContainer(property); nested != nil {
+      unusedPropertiesReportContainer(ctx, nested, next)
+    }
+  }
+}
+
+// unusedPropertiesContainerProperties returns the analyzable members of a
+// property container: every keyed property of an object literal (spreads
+// have no key and are skipped by the caller's nil check), or the property
+// signatures of a type literal. Index, call, construct, method, and accessor
+// signatures carry no analyzable data slot, matching upstream's
+// TSPropertySignature filter.
+func unusedPropertiesContainerProperties(container *shimast.Node) []*shimast.Node {
+  switch container.Kind {
+  case shimast.KindObjectLiteralExpression:
+    literal := container.AsObjectLiteralExpression()
+    if literal == nil || literal.Properties == nil {
+      return nil
+    }
+    properties := make([]*shimast.Node, 0, len(literal.Properties.Nodes))
+    for _, property := range literal.Properties.Nodes {
+      if property == nil || property.Kind == shimast.KindSpreadAssignment {
+        continue
+      }
+      properties = append(properties, property)
+    }
+    return properties
+  case shimast.KindTypeLiteral:
+    literal := container.AsTypeLiteralNode()
+    if literal == nil || literal.Members == nil {
+      return nil
+    }
+    var members []*shimast.Node
+    for _, member := range literal.Members.Nodes {
+      if member != nil && member.Kind == shimast.KindPropertySignature {
+        members = append(members, member)
+      }
+    }
+    return members
+  }
+  return nil
+}
+
+// unusedPropertiesPropertyContainer resolves the nested container a surviving
+// property recurses into: an object-literal initializer (through TS
+// assertion wrappers) or a property signature's inline type literal.
+func unusedPropertiesPropertyContainer(property *shimast.Node) *shimast.Node {
+  switch property.Kind {
+  case shimast.KindPropertyAssignment:
+    assignment := property.AsPropertyAssignment()
+    if assignment == nil {
+      return nil
+    }
+    value := unwrapReferenceExpression(assignment.Initializer)
+    if value != nil && value.Kind == shimast.KindObjectLiteralExpression {
+      return value
+    }
+  case shimast.KindPropertySignature:
+    signature := property.AsPropertySignatureDeclaration()
+    if signature != nil && signature.Type != nil &&
+      signature.Type.Kind == shimast.KindTypeLiteral {
+      return signature.Type
+    }
+  }
+  return nil
+}
+
+// unusedPropertiesFilterReferences maps the reference list for one property
+// key, mirroring upstream's per-key reference walk:
+//
+//   - the declarator's own init write only survives for `export const`,
+//     where it stands in for the unseen importers;
+//   - a member access survives when it is assigned, called, dynamically
+//     computed, or names this key — and is dropped when it names a
+//     different known key;
+//   - destructuring (declaration or assignment form) survives when the
+//     pattern names this key or uses a rest element;
+//   - anything else — call argument, return, alias, spread, export — is an
+//     escape and survives untouched.
+func unusedPropertiesFilterReferences(
+  references []unusedPropertiesReference,
+  key unusedPropertiesKey,
+) []unusedPropertiesReference {
+  var next []unusedPropertiesReference
+  for _, reference := range references {
+    parent := unusedPropertiesReferenceParent(reference.node)
+    if parent == nil {
+      next = append(next, reference)
+      continue
+    }
+    if reference.init {
+      if parent.Kind == shimast.KindVariableDeclaration &&
+        unusedPropertiesDeclarationIsExported(parent) {
+        next = append(next, unusedPropertiesReference{node: parent})
+      }
+      continue
+    }
+    switch parent.Kind {
+    case shimast.KindPropertyAccessExpression, shimast.KindElementAccessExpression:
+      if unusedPropertiesMemberAccessKeeps(parent, key) {
+        next = append(next, unusedPropertiesReference{node: parent})
+      }
+      continue
+    case shimast.KindVariableDeclaration:
+      declaration := parent.AsVariableDeclaration()
+      if declaration != nil && declaration.Name() != nil &&
+        declaration.Name().Kind == shimast.KindObjectBindingPattern {
+        if unusedPropertiesBindingPatternMatches(declaration.Name(), key) {
+          next = append(next, unusedPropertiesReference{node: parent})
+        }
+        continue
+      }
+    case shimast.KindBinaryExpression:
+      expression := parent.AsBinaryExpression()
+      if expression != nil && expression.OperatorToken != nil &&
+        isAssignmentOperator(expression.OperatorToken.Kind) &&
+        expression.Left != nil &&
+        expression.Left.Kind == shimast.KindObjectLiteralExpression &&
+        !isDestructuringDefaultAssignment(parent) {
+        if unusedPropertiesAssignmentPatternMatches(expression.Left, key) {
+          next = append(next, unusedPropertiesReference{node: parent})
+        }
+        continue
+      }
+    }
+    next = append(next, reference)
+  }
+  return next
+}
+
+// unusedPropertiesReferenceParent returns the node that consumes a reference,
+// looking through parentheses and TypeScript assertion wrappers (`as`,
+// `satisfies`, `!`, angle-bracket assertions) whenever the reference is the
+// wrapped expression, so `(foo as Foo).a` behaves like `foo.a`.
+func unusedPropertiesReferenceParent(node *shimast.Node) *shimast.Node {
+  for node != nil && node.Parent != nil {
+    parent := node.Parent
+    switch parent.Kind {
+    case shimast.KindParenthesizedExpression,
+      shimast.KindAsExpression,
+      shimast.KindSatisfiesExpression,
+      shimast.KindNonNullExpression,
+      shimast.KindTypeAssertionExpression:
+      if parent.Expression() == node {
+        node = parent
+        continue
+      }
+    }
+    return parent
+  }
+  return nil
+}
+
+// unusedPropertiesDeclarationIsExported reports whether a variable
+// declaration belongs to an `export const/let/var` statement.
+func unusedPropertiesDeclarationIsExported(declaration *shimast.Node) bool {
+  list := declaration.Parent
+  if list == nil || list.Parent == nil ||
+    list.Parent.Kind != shimast.KindVariableStatement {
+    return false
+  }
+  return hasModifier(list.Parent, shimast.KindExportKeyword)
+}
+
+// unusedPropertiesMemberAccessKeeps decides whether a member access on the
+// analyzed value can reach the property key. Assignments (either side, like
+// upstream), calls through the member, and dynamic indexes are conservative
+// keeps; a static access survives only when its key equals the property's.
+//
+// The consumer of the member is found through parentheses only — `(foo.a)()`
+// is a member call, exactly as in upstream's paren-free ESTree — while
+// TypeScript wrappers stay opaque: upstream inspects the member's direct
+// parent, so `(foo.a as any)()` is not treated as a call.
+func unusedPropertiesMemberAccessKeeps(member *shimast.Node, key unusedPropertiesKey) bool {
+  wrapped := member
+  for wrapped.Parent != nil && wrapped.Parent.Kind == shimast.KindParenthesizedExpression &&
+    wrapped.Parent.Expression() == wrapped {
+    wrapped = wrapped.Parent
+  }
+  if grand := wrapped.Parent; grand != nil {
+    if grand.Kind == shimast.KindBinaryExpression {
+      expression := grand.AsBinaryExpression()
+      if expression != nil && expression.OperatorToken != nil &&
+        isAssignmentOperator(expression.OperatorToken.Kind) &&
+        !isDestructuringDefaultAssignment(grand) {
+        return true
+      }
+    }
+    if grand.Kind == shimast.KindCallExpression {
+      call := grand.AsCallExpression()
+      if call != nil && call.Expression == wrapped {
+        return true
+      }
+    }
+  }
+  if member.Kind == shimast.KindElementAccessExpression {
+    access := member.AsElementAccessExpression()
+    if access == nil {
+      return false
+    }
+    index := stripParens(access.ArgumentExpression)
+    if !unusedPropertiesPredictableIndex(index) {
+      return true
+    }
+    return unusedPropertiesKeysEqual(unusedPropertiesKeyOf(index), key)
+  }
+  access := member.AsPropertyAccessExpression()
+  if access == nil {
+    return false
+  }
+  return unusedPropertiesKeysEqual(unusedPropertiesKeyOf(access.Name()), key)
+}
+
+// unusedPropertiesPredictableIndex reports whether an element-access index is
+// a literal whose value is knowable without evaluation. Everything else —
+// identifiers, templates, expressions — is a dynamic access that could reach
+// any property.
+func unusedPropertiesPredictableIndex(index *shimast.Node) bool {
+  if index == nil {
+    return false
+  }
+  switch index.Kind {
+  case shimast.KindStringLiteral,
+    shimast.KindNumericLiteral,
+    shimast.KindBigIntLiteral,
+    shimast.KindTrueKeyword,
+    shimast.KindFalseKeyword,
+    shimast.KindNullKeyword,
+    shimast.KindRegularExpressionLiteral:
+    return true
+  }
+  return false
+}
+
+// unusedPropertiesBindingPatternMatches reports whether an object binding
+// pattern (`const {a, ...rest} = value`) can extract the property key.
+func unusedPropertiesBindingPatternMatches(pattern *shimast.Node, key unusedPropertiesKey) bool {
+  binding := pattern.AsBindingPattern()
+  if binding == nil || binding.Elements == nil {
+    return false
+  }
+  for _, elementNode := range binding.Elements.Nodes {
+    element := elementNode.AsBindingElement()
+    if element == nil {
+      continue
+    }
+    if element.DotDotDotToken != nil {
+      return true
+    }
+    keyNode := element.PropertyName
+    if keyNode == nil {
+      keyNode = element.Name()
+    }
+    if unusedPropertiesKeysEqual(unusedPropertiesKeyOf(keyNode), key) {
+      return true
+    }
+  }
+  return false
+}
+
+// unusedPropertiesAssignmentPatternMatches reports whether the object pattern
+// of a destructuring assignment (`({a, ...rest} = value)`) can extract the
+// property key. The pattern parses as an object literal in TS-go's AST.
+func unusedPropertiesAssignmentPatternMatches(pattern *shimast.Node, key unusedPropertiesKey) bool {
+  literal := pattern.AsObjectLiteralExpression()
+  if literal == nil || literal.Properties == nil {
+    return false
+  }
+  for _, property := range literal.Properties.Nodes {
+    if property == nil {
+      continue
+    }
+    if property.Kind == shimast.KindSpreadAssignment {
+      return true
+    }
+    switch property.Kind {
+    case shimast.KindPropertyAssignment, shimast.KindShorthandPropertyAssignment:
+      if unusedPropertiesKeysEqual(unusedPropertiesKeyOf(property.Name()), key) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+// unusedPropertiesKeyOf normalizes a property name or index expression to a
+// comparable key. Identifiers compare as strings (so a computed `[a]` key
+// matches `.a` access, as upstream's name-based comparison does), string
+// literals by value, numeric literals by their canonical numeric text (the
+// parser already normalizes `0xFF`/`1e2`/`1_000`), bigint literals by their
+// canonical decimal value, and boolean/null literals within their own
+// classes. Parentheses inside a computed name are transparent because
+// ESTree has no parenthesized-expression node. Anything else has no
+// predictable name.
+func unusedPropertiesKeyOf(node *shimast.Node) unusedPropertiesKey {
+  if node == nil {
+    return unusedPropertiesKey{}
+  }
+  switch node.Kind {
+  case shimast.KindIdentifier:
+    return unusedPropertiesKey{class: "string", text: identifierText(node), ok: true}
+  case shimast.KindStringLiteral:
+    return unusedPropertiesKey{class: "string", text: stringLiteralText(node), ok: true}
+  case shimast.KindNumericLiteral:
+    return unusedPropertiesKey{class: "number", text: numericLiteralText(node), ok: true}
+  case shimast.KindBigIntLiteral:
+    return unusedPropertiesKey{
+      class: "bigint",
+      text:  unusedPropertiesBigIntText(numericLiteralText(node)),
+      ok:    true,
+    }
+  case shimast.KindTrueKeyword:
+    return unusedPropertiesKey{class: "boolean", text: "true", ok: true}
+  case shimast.KindFalseKeyword:
+    return unusedPropertiesKey{class: "boolean", text: "false", ok: true}
+  case shimast.KindNullKeyword:
+    return unusedPropertiesKey{class: "null", text: "null", ok: true}
+  case shimast.KindComputedPropertyName:
+    computed := node.AsComputedPropertyName()
+    if computed == nil || computed.Expression == nil {
+      return unusedPropertiesKey{}
+    }
+    return unusedPropertiesKeyOf(stripParens(computed.Expression))
+  }
+  return unusedPropertiesKey{}
+}
+
+// unusedPropertiesBigIntText converts a bigint literal's source text (which
+// the parser keeps verbatim, unlike normalized number literals) into its
+// canonical decimal digits, so `0x10n` and `16n` compare equal the way
+// upstream's BigInt value comparison does. Legacy octal (`0123n`) is a
+// syntax error in JavaScript, so base auto-detection over the `0x`/`0o`/`0b`
+// prefixes is unambiguous; unparsable text falls back to itself.
+func unusedPropertiesBigIntText(text string) string {
+  digits := text
+  if len(digits) > 0 && digits[len(digits)-1] == 'n' {
+    digits = digits[:len(digits)-1]
+  }
+  value, ok := new(big.Int).SetString(digits, 0)
+  if !ok {
+    return digits
+  }
+  return value.String()
+}
+
+func unusedPropertiesKeysEqual(a, b unusedPropertiesKey) bool {
+  return a.ok && b.ok && a.class == b.class && a.text == b.text
+}
+
+// unusedPropertiesDisplayName renders the property key for the diagnostic
+// message: resolved key text when the key is predictable, otherwise the
+// source text of the (computed) key expression.
+func unusedPropertiesDisplayName(
+  file *shimast.SourceFile,
+  keyNode *shimast.Node,
+  key unusedPropertiesKey,
+) string {
+  if key.ok {
+    return key.text
+  }
+  if keyNode.Kind == shimast.KindComputedPropertyName {
+    if computed := keyNode.AsComputedPropertyName(); computed != nil && computed.Expression != nil {
+      return nodeText(file, computed.Expression)
+    }
+  }
+  return nodeText(file, keyNode)
 }
 
 func init() {

--- a/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_corpus_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_corpus_test.go
@@ -1,0 +1,78 @@
+package linthost
+
+import (
+  "testing"
+
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+)
+
+// TestRuleCorpusUnicornNoUnusedProperties verifies the lint rule corpus
+// fixture unicorn-no-unused-properties.ts through the type-aware engine path.
+//
+// The rule resolves references with the TypeScript checker, so the plain
+// assertRuleCorpusCase helper (which runs without a Program) can never see
+// its findings. This twin runs the exact corpus source through the real
+// Program/checker lifecycle and pins the same three diagnostics the
+// TypeScript feature runner asserts end-to-end: an unused object property,
+// an unused property of a nested object, and an unused member of an inline
+// parameter type literal.
+//
+//  1. Materialize the corpus fixture source in a strict project.
+//  2. Run unicorn/no-unused-properties through loadProgram + runLintCycle.
+//  3. Assert the reported lines match the fixture's `// expect:` targets.
+func TestRuleCorpusUnicornNoUnusedProperties(t *testing.T) {
+  engine := NewEngine(RuleConfig{"unicorn/no-unused-properties": SeverityError})
+  if !engine.NeedsTypeChecker() {
+    t.Fatal("unicorn/no-unused-properties did not request a type checker")
+  }
+
+  source := `export {};
+
+const settings = {
+  timeout: 1_000,
+  // expect: unicorn/no-unused-properties error
+  retries: 3,
+  limits: {
+    depth: 4,
+    // expect: unicorn/no-unused-properties error
+    breadth: 5,
+  },
+};
+console.log(settings.timeout, settings.limits.depth);
+
+// Negative twin: every property is read, so nothing is reported.
+const used = { first: 1, second: 2 };
+console.log(used.first, used["second"]);
+
+// Negative: a dynamic key access can reach any property.
+declare const anyKey: keyof { alpha: 1; beta: 2 };
+const dynamic = { alpha: 1, beta: 2 };
+console.log(dynamic[anyKey]);
+
+// Negative: the object escapes as a call argument.
+const escaped = { gamma: 1, delta: 2 };
+console.log(escaped);
+
+function report(args: {
+  wanted: number;
+  // expect: unicorn/no-unused-properties error
+  ignored: number;
+}): number {
+  return args.wanted;
+}
+void report({ wanted: 1, ignored: 2 });
+`
+
+  _, _, findings := runRuleFindingsSnapshot(t, "unicorn/no-unused-properties", source, nil)
+  expectedLines := []int{6, 10, 31}
+  if len(findings) != len(expectedLines) {
+    t.Fatalf("want %d findings, got %d: %+v", len(expectedLines), len(findings), findings)
+  }
+  for index, finding := range findings {
+    line := shimscanner.GetECMALineOfPosition(finding.File, finding.Pos) + 1
+    if finding.Rule != "unicorn/no-unused-properties" || finding.Severity != SeverityError ||
+      line != expectedLines[index] {
+      t.Fatalf("finding %d: want line %d, got line %d (%+v)", index, expectedLines[index], line, finding)
+    }
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_key_matching_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_key_matching_test.go
@@ -1,0 +1,78 @@
+package linthost
+
+import "testing"
+
+// TestUnicornNoUnusedPropertiesKeyMatching verifies the strict key identity
+// upstream applies between property names and access expressions.
+//
+// Upstream compares JavaScript key VALUES with strict equality: identifier
+// and string keys share one class, numbers normalize (`0x10` reaches
+// `foo[16]`) but never match strings (`foo["1"]` cannot reach `{1: ...}`),
+// bigints compare by value, boolean/null literal indexes stay distinct from
+// the identifier property names they resolve to at runtime, computed
+// identifier keys match by NAME (not runtime value), and parentheses are
+// transparent on both sides because ESTree has no parenthesized-expression
+// node. Any relaxation or tightening of one class flips a case here.
+//
+//  1. Declare one object per key class with a matching and a mismatching
+//     access, plus `__proto__` skips and unpredictable-key reports.
+//  2. Run the rule through the real Program/checker lifecycle.
+//  3. Assert exactly the `/* unused:NAME */`-marked properties are reported.
+func TestUnicornNoUnusedPropertiesKeyMatching(t *testing.T) {
+  source := `export {};
+declare function consume(...values: unknown[]): void;
+declare const outside: { tag: string };
+
+const numeric = { 255: "a", /* unused:256 */ 256: "b" };
+consume(numeric[0xff]);
+
+const normalized = { 0x10: "a", /* unused:17 */ 17: "b", 1e2: "c", 1.5: "d", 1_000: "e" };
+consume(normalized[16], normalized[100], normalized[1.5], normalized[1000]);
+
+const stringVsNumber = { /* unused:1 */ 1: "a", /* unused:2 */ 2: "b" };
+consume(stringVsNumber["1"]);
+
+const numberVsString = { /* unused:3 */ "3": "a", four: "b" };
+consume(numberVsString[3], numberVsString.four);
+
+const big = { 0x10n: "a", /* unused:17 */ 17n: "b" };
+consume(big[16n]);
+
+const bigVsNumber = { /* unused:5 */ 5n: "a", other: "b" };
+consume(bigVsNumber[5], bigVsNumber.other);
+
+const keyword = { /* unused:true */ true: "a", /* unused:null */ null: "b", done: "c" };
+consume(keyword[true], keyword[null], keyword.done);
+
+const keywordByName = { true: "a", null: "b" };
+consume(keywordByName["true"], keywordByName["null"]);
+
+const label = "runtime";
+const byIdentifier = { [label]: "a", direct: "b" };
+consume(byIdentifier.label, byIdentifier.direct);
+
+const byIdentifierMiss = { /* unused:label */ [label]: "a", kept: "b" };
+consume(byIdentifierMiss.kept, byIdentifierMiss["runtime"]);
+
+const unpredictable = { /* unused:outside.tag */ [outside.tag]: "a", steady: "b" };
+consume(unpredictable.steady);
+
+const parenKey = { [("wrapped")]: "a", /* unused:bare */ bare: "b" };
+consume(parenKey.wrapped);
+
+const parenIndex = { reached: "a", /* unused:missed */ missed: "b" };
+consume(parenIndex[("reached")]);
+
+const negated = { [-1]: "a", alsoNegated: "b" };
+consume(negated[-1]);
+
+const protoSkip = {
+  __proto__: { hidden: 1 },
+  ["__proto__"]: 2,
+  /* unused:visibleDrop */ visibleDrop: 3,
+  read: 4,
+};
+consume(protoSkip.read);
+`
+  assertUnusedPropertiesFindings(t, source)
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_object_literal_semantics_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_object_literal_semantics_test.go
@@ -1,0 +1,206 @@
+package linthost
+
+import (
+  "fmt"
+  "regexp"
+  "sort"
+  "strings"
+  "testing"
+
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+)
+
+// unusedPropertiesMarkerPattern extracts `/* unused:NAME */` expectation
+// markers placed on the same line as the property they pin.
+var unusedPropertiesMarkerPattern = regexp.MustCompile(`/\* unused:([^*]+) \*/`)
+
+// unusedPropertiesMessagePattern parses the reported property name out of the
+// rule's canonical upstream message.
+var unusedPropertiesMessagePattern = regexp.MustCompile("^Property `(.+)` is defined but never used\\.$")
+
+// unusedPropertiesExpectedKeys returns the sorted `NAME@line` set declared by
+// `/* unused:NAME */` markers in the source.
+func unusedPropertiesExpectedKeys(t *testing.T, source string) []string {
+  t.Helper()
+  keys := []string{}
+  for _, match := range unusedPropertiesMarkerPattern.FindAllStringSubmatchIndex(source, -1) {
+    name := source[match[2]:match[3]]
+    line := 1 + strings.Count(source[:match[0]], "\n")
+    keys = append(keys, fmt.Sprintf("%s@%d", name, line))
+  }
+  sort.Strings(keys)
+  return keys
+}
+
+// unusedPropertiesFindingKeys converts findings into the same sorted
+// `NAME@line` shape, failing on any unexpected message or leftover fix.
+func unusedPropertiesFindingKeys(t *testing.T, findings []*Finding) []string {
+  t.Helper()
+  keys := []string{}
+  for _, finding := range findings {
+    if finding.Rule != "unicorn/no-unused-properties" || finding.Severity != SeverityError {
+      t.Fatalf("unexpected finding identity: %+v", finding)
+    }
+    if len(finding.Fix) != 0 || len(finding.Suggestions) != 0 {
+      t.Fatalf("finding unexpectedly offers edits: %+v", finding)
+    }
+    match := unusedPropertiesMessagePattern.FindStringSubmatch(finding.Message)
+    if match == nil {
+      t.Fatalf("unexpected message shape: %q", finding.Message)
+    }
+    line := shimscanner.GetECMALineOfPosition(finding.File, finding.Pos) + 1
+    keys = append(keys, fmt.Sprintf("%s@%d", match[1], line))
+  }
+  sort.Strings(keys)
+  return keys
+}
+
+// assertUnusedPropertiesFindings runs the rule over one disk-backed module
+// and compares the reported `NAME@line` set against the source's markers.
+func assertUnusedPropertiesFindings(t *testing.T, source string) {
+  t.Helper()
+  _, _, findings := runRuleFindingsSnapshot(t, "unicorn/no-unused-properties", source, nil)
+  expected := unusedPropertiesExpectedKeys(t, source)
+  actual := unusedPropertiesFindingKeys(t, findings)
+  if strings.Join(expected, "|") != strings.Join(actual, "|") {
+    t.Fatalf("finding mismatch:\nwant %v\ngot  %v", expected, actual)
+  }
+}
+
+// TestUnicornNoUnusedPropertiesObjectLiteralSemantics verifies every
+// object-literal read, escape, and mutation branch of the upstream analysis.
+//
+// The rule filters a variable's references per property key: static accesses
+// must name the key, destructuring must bind it, and any escape (alias,
+// argument, spread, export, dynamic index, mutation, member call) keeps every
+// property alive. Each positive here has a negative twin one property away so
+// an over- or under-match in any branch flips the expectation set.
+//
+//  1. Declare one module-scope object per branch: direct/quoted/element/
+//     computed reads, nested recursion, destructuring forms, rest, method
+//     calls and assignments, accessors, shorthand, exports, and escapes.
+//  2. Run the rule through the real Program/checker lifecycle.
+//  3. Assert exactly the `/* unused:NAME */`-marked properties are reported.
+func TestUnicornNoUnusedPropertiesObjectLiteralSemantics(t *testing.T) {
+  source := `export {};
+declare function consume(...values: unknown[]): void;
+declare const record: Record<string, number>;
+
+const direct = { kept: 1, /* unused:directDrop */ directDrop: 2 };
+consume(direct.kept);
+
+const quoted = { "kept": 1, /* unused:quotedDrop */ "quotedDrop": 2 };
+consume(quoted.kept);
+
+const element = { kept: 1, /* unused:elementDrop */ elementDrop: 2 };
+consume(element["kept"]);
+
+const computed = { ["kept"]: 1, /* unused:computedDrop */ ["computedDrop"]: 2 };
+consume(computed["kept"]);
+
+const nested = {
+  outer: {
+    inner: 1,
+    /* unused:nestedDrop */ nestedDrop: 2,
+  },
+  /* unused:branchDrop */ branchDrop: { hidden: 3 },
+};
+consume(nested.outer.inner);
+
+const destructured = { taken: 1, /* unused:destructuredDrop */ destructuredDrop: 2 };
+const { taken } = destructured;
+consume(taken);
+
+let assigned = 0;
+const reassignedPattern = { fetched: 1, /* unused:patternDrop */ patternDrop: 2 };
+({ fetched: assigned } = reassignedPattern);
+consume(assigned);
+
+const rested = { firstRest: 1, alsoRest: 2 };
+const { firstRest, ...rest } = rested;
+consume(firstRest, rest);
+
+const aliased = { viaAlias: 1, alsoViaAlias: 2 };
+const alias = aliased;
+consume(alias);
+
+const spread = { viaSpread: 1, alsoViaSpread: 2 };
+consume({ ...spread });
+
+const whole = { viaWhole: 1, alsoViaWhole: 2 };
+consume(whole);
+
+const untouched = { neverRead: 1, alsoNeverRead: 2 };
+
+let writeOnly = { onlyWritten: 1 };
+writeOnly = { onlyWritten: 2 };
+
+let rewritten = { survives: 1, alsoSurvives: 2 };
+rewritten = { survives: 3, alsoSurvives: 4 };
+consume(rewritten.survives);
+
+const mutated = { seed: 1, other: 2 };
+mutated.seed = 3;
+consume(mutated.other);
+
+const called = { helper() {}, extra: 1 };
+called.helper();
+
+const idle = { /* unused:act */ act() {}, usedNext: 1 };
+consume(idle.usedNext);
+
+const accessors = {
+  get readable() {
+    return 1;
+  },
+  /* unused:writable */ set writable(value: number) {},
+  plain: 2,
+};
+consume(accessors.readable, accessors.plain);
+
+const one = 1;
+const two = 2;
+const short = { one, /* unused:two */ two };
+consume(short.one);
+
+export const published = { openly: 1, alsoOpenly: 2 };
+consume(published.openly);
+
+const specified = { byName: 1, alsoByName: 2 };
+consume(specified.byName);
+export { specified };
+
+const defaulted = { byDefault: 1 };
+export default defaulted;
+
+const optional = { maybeRead: 1, /* unused:optionalDrop */ optionalDrop: 2 };
+consume(optional?.maybeRead);
+
+const guarded = { shielded: 1, alsoShielded: 2 };
+consume(Object.prototype.hasOwnProperty.call(guarded, "shielded"));
+
+const probed = { inLeft: 1, inRight: 2 };
+consume("inLeft" in probed);
+
+const growing = { started: 1, follower: 2 };
+growing.started += 1;
+consume(growing.follower);
+
+const looped = { item: 1, nextItem: 2 };
+for (const key in looped) {
+  consume(key);
+}
+
+const proto = {
+  __proto__: { fromProto: 1 },
+  "__proto__x": 2,
+  /* unused:protoDrop */ protoDrop: 3,
+  visible: 4,
+};
+consume(proto.visible, proto["__proto__x"]);
+
+const dynamic = { anyOf: 1, allOf: 2 };
+consume(record[String(dynamic.anyOf)], dynamic[("allOf" as keyof typeof dynamic)]);
+`
+  assertUnusedPropertiesFindings(t, source)
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_reference_identity_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_reference_identity_test.go
@@ -1,0 +1,67 @@
+package linthost
+
+import "testing"
+
+// TestUnicornNoUnusedPropertiesReferenceIdentity verifies checker-driven
+// binding identity and the exact wrapper transparency of reference chains.
+//
+// References resolve through the TypeScript checker, so shadows and
+// redeclarations must not leak between bindings, `export { x as y }` must
+// resolve to the local variable, and a `typeof x` query is a real (escaping)
+// reference. Wrapper handling is asymmetric by upstream's ESTree shape:
+// parentheses are invisible everywhere, but a TS assertion around a member
+// blocks call/assignment detection because upstream inspects the member's
+// direct parent. Each arm pins one of those identity decisions.
+//
+//  1. Declare shadowed, redeclared, exported, type-queried, and
+//     wrapper-consumed objects with used/unused twins.
+//  2. Run the rule through the real Program/checker lifecycle.
+//  3. Assert exactly the `/* unused:NAME */`-marked properties are reported.
+func TestUnicornNoUnusedPropertiesReferenceIdentity(t *testing.T) {
+  source := `export {};
+declare function consume(...values: unknown[]): void;
+
+const shadowed = { outerUsed: 1, /* unused:outerDrop */ outerDrop: 2 };
+consume(shadowed.outerUsed);
+function shade(): void {
+  const shadowed = { innerUsed: 1, /* unused:innerDrop */ innerDrop: 2 };
+  consume(shadowed.innerUsed);
+}
+consume(shade);
+
+var redeclared = { onceUsed: 1, neverUsed: 2 };
+var redeclared;
+consume(redeclared.onceUsed);
+
+const renamed = { openUsed: 1, openSpare: 2 };
+consume(renamed.openUsed);
+export { renamed as published };
+
+const queried = { viaType: 1, alsoViaType: 2 };
+type Queried = typeof queried;
+consume(queried.viaType, null as unknown as Queried);
+
+const parenCalled = { run() {}, tail: 1 };
+(parenCalled.run)();
+
+const wrapperCalled = { go() {}, /* unused:wrapperTail */ wrapperTail: 1 };
+(wrapperCalled.go as () => void)();
+consume(wrapperCalled.go);
+
+const parenAssigned = { slot: 1, follower: 2 };
+(parenAssigned.slot) = 3;
+
+const wrapperAssigned = { cell: 1, /* unused:cellMate */ cellMate: 2 };
+(wrapperAssigned.cell as number) = 3;
+consume(wrapperAssigned.cell);
+
+const defaultTarget = { fallback: 1, /* unused:beside */ beside: 2 };
+declare const cells: number[];
+[defaultTarget.fallback = 1] = cells;
+
+const removed = { cut: 1, kept: 2 } as { cut?: number; kept?: number };
+delete removed.cut;
+consume(removed.kept);
+`
+  assertUnusedPropertiesFindings(t, source)
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_reporting_shape_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_reporting_shape_test.go
@@ -1,0 +1,85 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestUnicornNoUnusedPropertiesReportingShape verifies the exact diagnostic
+// surface: the reported range covers the whole property node, the message
+// interpolates the resolved key (or the computed key's source text), and no
+// autofix or suggestion is offered, mirroring upstream's fix-free rule.
+//
+// Range checks pin the node choice itself — upstream reports the property,
+// not just its key — including a type-literal member whose trailing
+// semicolon belongs to the member node, exactly as in typescript-eslint.
+//
+//  1. Declare one unused property per member kind: assignment, shorthand,
+//     method, computed key, and an inline parameter type member.
+//  2. Run the rule through the real Program/checker lifecycle.
+//  3. Assert each finding's [Pos, End) range, message, and empty edit set.
+func TestUnicornNoUnusedPropertiesReportingShape(t *testing.T) {
+  // The raw literal below picks up CRLF on autocrlf checkouts while the
+  // expectation needles spell "\n"; normalize so both use one representation.
+  source := `export {};
+declare function consume(...values: unknown[]): void;
+declare const outer: { key: string };
+
+const short = 1;
+const subject = {
+  used: 1,
+  droppedValue: 2,
+  short,
+  droppedMethod() {
+    return 3;
+  },
+  [outer.key]: 4,
+};
+consume(subject.used);
+
+function typed(args: { wanted: number; ignored: number; }): number {
+  return args.wanted;
+}
+consume(typed);
+`
+  source = strings.ReplaceAll(source, "\r\n", "\n")
+  _, _, findings := runRuleFindingsSnapshot(t, "unicorn/no-unused-properties", source, nil)
+  type expectation struct {
+    text    string
+    message string
+  }
+  expectations := []expectation{
+    {"droppedValue: 2", "Property `droppedValue` is defined but never used."},
+    {"short,", "Property `short` is defined but never used."},
+    {"droppedMethod() {\n    return 3;\n  }", "Property `droppedMethod` is defined but never used."},
+    {"[outer.key]: 4", "Property `outer.key` is defined but never used."},
+    {"ignored: number;", "Property `ignored` is defined but never used."},
+  }
+  if len(findings) != len(expectations) {
+    t.Fatalf("want %d findings, got %d: %+v", len(expectations), len(findings), findings)
+  }
+  for index, finding := range findings {
+    want := expectations[index]
+    text := want.text
+    if strings.HasSuffix(text, ",") {
+      text = strings.TrimSuffix(text, ",")
+    }
+    start := strings.Index(source, want.text)
+    if start < 0 {
+      t.Fatalf("expectation %d text %q not in source", index, want.text)
+    }
+    if finding.Pos != start || finding.End != start+len(text) {
+      t.Fatalf(
+        "finding %d range: want [%d,%d) for %q, got [%d,%d) covering %q",
+        index, start, start+len(text), text, finding.Pos, finding.End,
+        source[finding.Pos:finding.End],
+      )
+    }
+    if finding.Message != want.message {
+      t.Fatalf("finding %d message: want %q, got %q", index, want.message, finding.Message)
+    }
+    if len(finding.Fix) != 0 || len(finding.Suggestions) != 0 {
+      t.Fatalf("finding %d must not offer edits: %+v", index, finding)
+    }
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_script_global_scope_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_script_global_scope_test.go
@@ -1,0 +1,57 @@
+package linthost
+
+import "testing"
+
+// TestUnicornNoUnusedPropertiesScriptGlobalScopeExclusion verifies the
+// upstream global-scope exclusion for script files.
+//
+// Upstream walks every scope except `global`. In a script (no import or
+// export), top-level `const`/`let` and every hoisted `var` land in the
+// global scope and must be skipped even with obviously unused properties,
+// while block-scoped and function-scoped variables in the same file are
+// still analyzed. A module file has no global variables, which the module
+// test files cover; this fixture intentionally has no export statement.
+//
+//  1. Declare unused-property objects at the script top level (const and
+//     var), inside a bare block (let and hoisted var), inside a function,
+//     and in for-statement heads (initializer-free for-of, initialized for).
+//  2. Run the rule through the real Program/checker lifecycle.
+//  3. Assert only block-, function-, and for-scoped objects report.
+func TestUnicornNoUnusedPropertiesScriptGlobalScopeExclusion(t *testing.T) {
+  source := `const topLevel = { read: 1, skippedConst: 2 };
+console.log(topLevel.read);
+
+var hoisted = { seen: 1, skippedVar: 2 };
+console.log(hoisted.seen);
+
+{
+  let blockScoped = { kept: 1, /* unused:blockDrop */ blockDrop: 2 };
+  console.log(blockScoped.kept);
+
+  var hoistedInBlock = { taken: 1, skippedHoisted: 2 };
+  console.log(hoistedInBlock.taken);
+}
+
+function scoped(): void {
+  const inner = { held: 1, /* unused:innerDrop */ innerDrop: 2 };
+  console.log(inner.held);
+
+  var innerVar = { got: 1, /* unused:innerVarDrop */ innerVarDrop: 2 };
+  console.log(innerVar.got);
+}
+scoped();
+
+// A for-of binding has no initializer of its own, so its object stays
+// unanalyzed even though loopSkipped is never read.
+for (const iterated of [{ once: 1, loopSkipped: 2 }]) {
+  console.log(iterated.once);
+}
+
+// A for-statement head declaration carries a real initializer and lives in
+// the for scope, not the global scope, so it is analyzed even in a script.
+for (let step = { move: 1, /* unused:stayDrop */ stayDrop: 2 }; step.move < 3; step.move++) {
+  console.log(step.move);
+}
+`
+  assertUnusedPropertiesFindings(t, source)
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_template_keys_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_template_keys_test.go
@@ -1,0 +1,32 @@
+package linthost
+
+import "testing"
+
+// TestUnicornNoUnusedPropertiesTemplateKeys verifies that template literals
+// never participate in key matching, on either side of an access.
+//
+// Upstream classifies keys through ESTree `Literal` nodes only. A template
+// literal index (`foo[`+"`a`"+`]`) is not a Literal, so it counts as an
+// unpredictable access that keeps every property alive; a template literal
+// computed KEY has no extractable name, so no static access can ever reach
+// it and it reports with its source text as the display name. Treating
+// templates like plain strings would silently flip both halves.
+//
+//  1. Access one object through a template index, and give another object a
+//     template computed key beside a plain used property.
+//  2. Run the rule through the real Program/checker lifecycle.
+//  3. Assert only the template-keyed property reports, with backticks
+//     preserved in its message.
+func TestUnicornNoUnusedPropertiesTemplateKeys(t *testing.T) {
+  tick := "`"
+  source := `export {};
+declare function consume(...values: unknown[]): void;
+
+const templateIndex = { plain: "a", alsoPlain: "b" };
+consume(templateIndex[` + tick + `plain` + tick + `]);
+
+const templateKey = { /* unused:` + tick + `literal` + tick + ` */ [` + tick + `literal` + tick + `]: "a", spare: "b" };
+consume(templateKey.literal, templateKey.spare);
+`
+  assertUnusedPropertiesFindings(t, source)
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_type_literal_semantics_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_unused_properties_type_literal_semantics_test.go
@@ -1,0 +1,150 @@
+package linthost
+
+import "testing"
+
+// TestUnicornNoUnusedPropertiesTypeLiteralSemantics verifies the TypeScript
+// half of the upstream analysis: inline type-literal containers on parameters
+// and variable declarations.
+//
+// Upstream only analyzes an annotation when it is a literal `{...}` type on
+// an identifier (named aliases and interfaces are opaque), prefers an
+// object-literal initializer over the annotation, filters non-property
+// members (methods, index/call signatures), and sees through TypeScript
+// expression wrappers when following reference chains. Each arm below pins
+// one of those decisions with a used/unused pair.
+//
+//  1. Declare parameters and variables covering annotation containers,
+//     initializer priority, assertion wrappers, and signature filtering.
+//  2. Run the rule through the real Program/checker lifecycle.
+//  3. Assert exactly the `/* unused:NAME */`-marked members are reported.
+func TestUnicornNoUnusedPropertiesTypeLiteralSemantics(t *testing.T) {
+  source := `export {};
+declare function consume(...values: unknown[]): void;
+declare function getArgs(): { x: number; y: number };
+
+function partial(args: { x: number; /* unused:y */ y: number }): number {
+  return args.x * 2;
+}
+consume(partial);
+
+function wholeEscape(args: { x: number; y: number }): void {
+  consume(args);
+}
+consume(wholeEscape);
+
+function dynamicKey(args: { x: number; y: number }, key: "x" | "y"): number {
+  return args[key];
+}
+consume(dynamicKey);
+
+function written(args: { x: number; y: number }): void {
+  args.x = 1;
+}
+consume(written);
+
+function calledMember(args: { x: () => void; y: number }): void {
+  args.x();
+}
+consume(calledMember);
+
+type Named = { x: number; y: number };
+function namedAlias(args: Named): number {
+  return args.x;
+}
+consume(namedAlias);
+
+interface Shaped {
+  x: number;
+  y: number;
+}
+function viaInterface(args: Shaped): number {
+  return args.x;
+}
+consume(viaInterface);
+
+function destructuredParam({ x }: { x: number; y: number }): number {
+  return x;
+}
+consume(destructuredParam);
+
+function filteredMembers(args: {
+  x: number;
+  method(): void;
+  [key: string]: unknown;
+}): unknown {
+  return args.x;
+}
+consume(filteredMembers);
+
+function nestedSignature(args: {
+  options: {
+    enabled: boolean;
+    /* unused:disabledFlag */ disabledFlag: boolean;
+  };
+  label: string;
+}): boolean {
+  return args.options.enabled && args.label.length > 0;
+}
+consume(nestedSignature);
+
+function nonNullChain(args: {
+  x: {
+    a: number;
+    /* unused:b */ b: number;
+  };
+  /* unused:tail */ tail: number;
+}): number {
+  return args.x!.a;
+}
+consume(nonNullChain);
+
+function castChain(args: {
+  x: {
+    a: number;
+    /* unused:castB */ castB: number;
+  };
+  /* unused:castTail */ castTail: number;
+}): number {
+  return (args.x as { a: number; castB: number }).a;
+}
+consume(castChain);
+
+const annotated: { x: number; /* unused:annotatedY */ annotatedY: number } = getArgs() as never;
+consume(annotated.x);
+
+const initWins: { x: number; initY: number } = { x: 1, /* unused:initY */ initY: 2 };
+consume(initWins.x);
+
+const asConst = { x: 1, /* unused:constY */ constY: 2 } as const;
+consume(asConst.x);
+
+const satisfied = { x: 1, /* unused:satisfiedY */ satisfiedY: 2 } satisfies {
+  x: number;
+  satisfiedY: number;
+};
+consume(satisfied.x);
+
+declare const ambient: { x: number; y: number };
+consume(ambient.x);
+
+let uninitialized: { x: number; y: number };
+uninitialized = getArgs();
+consume(uninitialized.x);
+
+class Holder {
+  constructor(private args: { x: number; /* unused:holderY */ holderY: number }) {
+    consume(args.x);
+  }
+}
+consume(new Holder({ x: 1, holderY: 2 }));
+
+class ThisOnly {
+  constructor(private args: { x: number; y: number }) {}
+  read(): number {
+    return this.args.x;
+  }
+}
+consume(new ThisOnly({ x: 1, y: 2 }).read());
+`
+  assertUnusedPropertiesFindings(t, source)
+}

--- a/tests/test-lint/src/cases/unicorn-no-unused-properties.ts
+++ b/tests/test-lint/src/cases/unicorn-no-unused-properties.ts
@@ -1,1 +1,35 @@
-// @ttsc-corpus-skip: unicorn/no-unused-properties not yet implemented; fixture exists as the link target referenced from packages/lint/README.md and website/src/content/docs/lint/rules/unicorn.mdx. The skip directive is removed and replaced with a `// expect:` annotation once the rule lands in this PR (feat/lint-unicorn-rules).
+export {};
+
+const settings = {
+  timeout: 1_000,
+  // expect: unicorn/no-unused-properties error
+  retries: 3,
+  limits: {
+    depth: 4,
+    // expect: unicorn/no-unused-properties error
+    breadth: 5,
+  },
+};
+console.log(settings.timeout, settings.limits.depth);
+
+// Negative twin: every property is read, so nothing is reported.
+const used = { first: 1, second: 2 };
+console.log(used.first, used["second"]);
+
+// Negative: a dynamic key access can reach any property.
+declare const anyKey: keyof { alpha: 1; beta: 2 };
+const dynamic = { alpha: 1, beta: 2 };
+console.log(dynamic[anyKey]);
+
+// Negative: the object escapes as a call argument.
+const escaped = { gamma: 1, delta: 2 };
+console.log(escaped);
+
+function report(args: {
+  wanted: number;
+  // expect: unicorn/no-unused-properties error
+  ignored: number;
+}): number {
+  return args.wanted;
+}
+void report({ wanted: 1, ignored: 2 });

--- a/website/src/content/docs/lint/rules/unicorn.mdx
+++ b/website/src/content/docs/lint/rules/unicorn.mdx
@@ -1143,11 +1143,19 @@ const r = (() => Math.random())();
 
 Reject object properties that are never read after definition.
 
-Illustrative shape:
+The rule follows every reference to a variable bound to an object literal (or
+annotated with an inline `{...}` type, including function parameters) and
+reports the properties no reference can reach. Static accesses must name the
+key, destructuring must bind it, and matching references recurse into nested
+objects. Any escape — aliasing, passing, returning, spreading, exporting,
+mutating, or a dynamic key access — conservatively keeps every property.
+
+Example:
 
 ```ts
 const user = {
   id: "u_1",
+  // reports: unicorn/no-unused-properties (error)
   debugLabel: "local-only",
 };
 


### PR DESCRIPTION
Closes #484

## Intent

`unicorn/no-unused-properties` was registered as a silent stub: the rule existed in the registry but `Visits()` was `nil` and `Check` was empty, so an enabled rule could never report. This PR replaces the stub with a faithful port of the current `eslint-plugin-unicorn` analysis.

For every single-definition variable bound to an object literal (or annotated with an inline `{...}` type, including annotated parameters), the rule walks the variable's references and keeps only the ones that can reach each property; a property whose reference list filters to nothing is reported. Escape analysis stays conservative exactly where upstream is: one unpredictable use (alias, argument, return, export, spread, mutation, member call, dynamic/computed access) marks every property used. Matching references recurse one level deeper into nested object/type literals. Variables in a script file's global scope are skipped, mirroring upstream.

## What landed

- `packages/lint/linthost/rules_unicorn_no_unused_properties.go` — the rule: reference walk, key identity/matching (string, numeric, bigint, boolean, null classes, computed and template keys), object-literal and type-literal containers, destructuring (declaration and assignment forms, rest), escape analysis, TS wrapper transparency, parameter-property symbol resolution, and the script-global-scope exclusion.
- `packages/lint/test/rules/unicorn/unicorn_no_unused_properties_*_test.go` — eight Go test files (corpus, key matching, object-literal semantics, reference identity, reporting shape, script global scope, template keys, type-literal semantics), each a used/unused twin matrix with oracle-derived expectations.
- `tests/test-lint/src/cases/unicorn-no-unused-properties.ts` — corpus fixture: `@ttsc-corpus-skip` removed, real behavioral case with positive `// expect:` annotations and negative twins (dynamic key, escape, fully-read object).
- `website/src/content/docs/lint/rules/unicorn.mdx` — real behavioral description and example.

## Validation

- `unicorn/no-unused-properties` Go tests + corpus twin: all 8 pass via the real `scripts/test-go-lint.cjs` scratch runner.
- Full `./linthost` Go suite: `ok` in 477s, no regressions.
- Semantics cross-checked case-by-case against the upstream oracle (`rules/no-unused-properties.js` and `test/no-unused-properties.js`).

`pnpm format` was intentionally not run (it triggers a repo-wide line-ending rewrite on this machine); formatting/lint is left to CI.
