### PR TITLE
feat(test): cover monorepo edge cases for graph dump and vscode server resolution

### DIFF
--- a/tests/test-graph/src/features/test_ttscgraph_dump_survives_unresolved_workspace_import.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_dump_survives_unresolved_workspace_import.ts
@@ -1,0 +1,87 @@
+import { TestProject } from "@ttsc/testing";
+
+import { dumpGraph, findNode } from "../internal/graphDump";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies graph dump degrades gracefully when a workspace import does not
+ * resolve.
+ *
+ * A pnpm workspace normally links sibling packages through node_modules, but a
+ * Yarn PnP layout (no node_modules), an incomplete install, or a not-yet-linked
+ * package leaves the checker unable to resolve the import. The dump must still
+ * produce a usable graph for the files it can compile — exiting non-zero or
+ * crashing on the unresolved specifier would take down a whole monorepo's graph
+ * for one missing link. The importing package's own declarations stay in the
+ * graph; the unresolved sibling is simply absent, not an external leak.
+ *
+ * 1. Materialize an app package that imports a sibling by its package name.
+ * 2. Omit the node_modules link so the specifier cannot resolve.
+ * 3. Assert the dump still loads, keeps the app node, and drops the sibling.
+ */
+export const test_ttscgraph_dump_survives_unresolved_workspace_import = () => {
+  const root = TestProject.tmpdir("ttsc-graph-unresolved-");
+  TestProject.writeFiles(root, {
+    "package.json": JSON.stringify({
+      private: true,
+      name: "workspace-root",
+    }),
+    "pnpm-workspace.yaml": "packages:\n  - packages/*\n",
+    "packages/shared/package.json": JSON.stringify({
+      name: "@scope/shared",
+      version: "1.0.0",
+      exports: { ".": "./src/index.ts" },
+    }),
+    "packages/shared/src/index.ts": [
+      "export function sharedHelper(value: string): string {",
+      "  return value;",
+      "}",
+      "",
+    ].join("\n"),
+    "packages/app/package.json": JSON.stringify({
+      name: "@scope/app",
+      version: "1.0.0",
+      dependencies: { "@scope/shared": "workspace:*" },
+    }),
+    "packages/app/tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "nodenext",
+        moduleResolution: "nodenext",
+        strict: true,
+        skipLibCheck: true,
+        noEmit: true,
+      },
+      include: ["src"],
+    }),
+    "packages/app/src/main.ts": [
+      'import { sharedHelper } from "@scope/shared";',
+      "export function run(value: string): string {",
+      "  return sharedHelper(value);",
+      "}",
+      "",
+    ].join("\n"),
+  });
+
+  // No linkWorkspacePackage call: the sibling package exists on disk but is
+  // never linked into node_modules, so `@scope/shared` cannot resolve — the
+  // shape a Yarn PnP install or an incomplete install presents to the checker.
+  const dump = dumpGraph(root, "packages/app/tsconfig.json");
+  const run = findNode(dump, {
+    file: "packages/app/src/main.ts",
+    name: "run",
+    kind: "function",
+  });
+
+  assert.ok(run, "importing package node survives the unresolved specifier");
+  assert.equal(
+    dump.nodes.some((node) => node.file.includes("packages/shared")),
+    false,
+    "unresolved sibling package contributes no nodes",
+  );
+  assert.equal(
+    dump.nodes.some((node) => node.file.includes("node_modules")),
+    false,
+    "unresolved sibling does not leak a node_modules path",
+  );
+};

--- a/tests/test-ttsc/src/features/ttscserver/test_vscode_server_resolution_finds_package_ttsc_without_root_install.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_vscode_server_resolution_finds_package_ttsc_without_root_install.ts
@@ -1,0 +1,92 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Verifies VS Code server resolution finds a per-package ttsc when the root has
+ * none.
+ *
+ * A common monorepo shape installs `ttsc` in each `packages/*` package but not
+ * in the root package.json. The extension resolves the launcher by walking up
+ * from the open file's directory, not from the workspace root, so an open
+ * package file still finds `packages/app/node_modules/ttsc`. The root-anchored
+ * candidate must fail to resolve without throwing — the extension drops it and
+ * relies on the file-anchored candidate, so a bare root never blocks a package
+ * that carries its own ttsc.
+ *
+ * 1. Create a workspace whose root has no ttsc but a package installs its own.
+ * 2. Resolve the launcher from the package file's directory and from the root.
+ * 3. Assert the package file finds the nested launcher and the root finds none.
+ */
+export const test_vscode_server_resolution_finds_package_ttsc_without_root_install =
+  () => {
+    const repo = TestProject.WORKSPACE_ROOT;
+    const workspace = TestProject.tmpdir("vscode-nested-ttsc-");
+    const packageDir = path.join(workspace, "packages", "app");
+    const fileDir = path.join(packageDir, "src");
+    const ttscPackage = path.join(packageDir, "node_modules", "ttsc");
+    const launcher = path.join(ttscPackage, "lib", "launcher", "ttscserver.js");
+
+    fs.writeFileSync(
+      path.join(workspace, "package.json"),
+      JSON.stringify({ private: true, name: "workspace-root" }, null, 2),
+    );
+    fs.mkdirSync(fileDir, { recursive: true });
+    fs.writeFileSync(path.join(fileDir, "main.ts"), "export {};\n");
+    fs.mkdirSync(path.dirname(launcher), { recursive: true });
+    fs.writeFileSync(
+      path.join(ttscPackage, "package.json"),
+      JSON.stringify(
+        {
+          name: "ttsc",
+          bin: { ttscserver: "lib/launcher/ttscserver.js" },
+          exports: { "./package.json": "./package.json" },
+        },
+        null,
+        2,
+      ),
+    );
+    fs.writeFileSync(launcher, "module.exports = {};\n");
+
+    const script = `
+      import { pathToFileURL } from "node:url";
+      const mod = await import(pathToFileURL(${JSON.stringify(
+        path.join(repo, "packages", "vscode", "src", "serverResolution.ts"),
+      )}).href);
+      console.log(JSON.stringify({
+        fromFile: mod.resolveTtscServerLauncher(${JSON.stringify(fileDir)}) ?? "",
+        fromRoot: mod.resolveTtscServerLauncher(${JSON.stringify(workspace)}) ?? "",
+      }));
+    `;
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--disable-warning=ExperimentalWarning",
+        "--experimental-transform-types",
+        "--input-type=module",
+        "--eval",
+        script,
+      ],
+      {
+        cwd: workspace,
+        encoding: "utf8",
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const resolved = JSON.parse(result.stdout.trim()) as {
+      fromFile: string;
+      fromRoot: string;
+    };
+    assert.equal(
+      path.normalize(resolved.fromFile),
+      path.normalize(launcher),
+      "package file walks up to its own node_modules ttsc launcher",
+    );
+    assert.equal(
+      resolved.fromRoot,
+      "",
+      "root without ttsc resolves no launcher and is dropped, not thrown",
+    );
+  };


### PR DESCRIPTION
## Intent

Two coverage holes surfaced while auditing how `@ttsc/graph` and the `@ttsc/vscode`/`ttscserver` stack behave in pnpm/yarn monorepos with multiple `tsconfig.json` files. Both behaviors already work; neither was pinned by a test. This adds the missing tests only — no product code changes.

## Scope

- **`test(graph)`** — `test_ttscgraph_dump_survives_unresolved_workspace_import`
  Locks the fail-soft path of `ttscgraph dump` when a workspace specifier cannot resolve (Yarn PnP with no `node_modules`, an incomplete install, or a not-yet-linked sibling). The dump must still load, keep the importing package's nodes, and drop the unresolved sibling without leaking a `node_modules` path — one missing link must not take down a whole monorepo's graph.

- **`test(vscode)`** — `test_vscode_server_resolution_finds_package_ttsc_without_root_install`
  Pins the common shape where `ttsc` is installed in each `packages/*` but not in the root `package.json`. `resolveTtscServerLauncher` walks up from the open file's directory, so a package file finds its own `node_modules/ttsc` while the root-anchored candidate resolves to nothing — without throwing — and is dropped.

Both follow the existing peers: the graph test mirrors `test_ttscgraph_dump_resolves_pnpm_workspace_edges`; the vscode test mirrors `test_vscode_server_resolution_uses_package_json_anchor`. Each is one `test_<snake_case>` per file with the standard three-part doc comment, and both exercise the negative/degrade direction rather than a happy path.

## Deferred

- No end-to-end LSP test that a `ttscserver` launched at package A serves cross-package go-to-definition into package B's symlinked source — that path is delegated to the upstream tsgo LSP and is out of scope here.
- `graphsymbols` "find references" remains scoped to the launched package's program (downstream references in sibling packages are not found); noted as a known limitation, not addressed here.

## Test plan

- `test_vscode_server_resolution_finds_package_ttsc_without_root_install` runs locally and passes; all sibling `test_vscode_server_resolution_*` / `multi_root` tests still pass (they import the real `serverResolution.ts` helpers through Node's TS loader; no native binary needed).
- `test_ttscgraph_dump_survives_unresolved_workspace_import`: the full `test-graph` harness needs a built `@ttsc/graph` + native binary, which could not be built locally (an unrelated `@ttsc/unplugin` rollup build failure blocks `pnpm build:current`). The asserted behavior was verified directly against a locally built `ttscgraph` binary running the identical `dump` code path: exit 0, importing-package node retained, unresolved sibling absent, no `node_modules` leak.
- CI intentionally not driven here (the queue is saturated); please run the graph lane on a free slot before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)