### PR TITLE
fix(build): derive rollup externals from package.json so unplugin/metro build on Node 22

### DIFF
--- a/config/package.json
+++ b/config/package.json
@@ -8,8 +8,6 @@
     "@rollup/plugin-node-resolve": "catalog:rollup",
     "@rollup/plugin-typescript": "^12.3.0",
     "rollup": "catalog:rollup",
-    "rollup-plugin-auto-external": "catalog:rollup",
-    "rollup-plugin-node-externals": "catalog:rollup",
     "tinyglobby": "^0.2.12",
     "typescript": "~6.0.3"
   }

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -62,8 +62,6 @@
     "@types/node": "catalog:utils",
     "rimraf": "catalog:utils",
     "rollup": "^4.60.3",
-    "rollup-plugin-auto-external": "^2.0.0",
-    "rollup-plugin-node-externals": "^9.0.1",
     "tinyglobby": "^0.2.16",
     "tslib": "^2.8.1",
     "ttsc": "workspace:*",

--- a/packages/metro/rollup.config.mjs
+++ b/packages/metro/rollup.config.mjs
@@ -1,18 +1,35 @@
 import commonjs from "@rollup/plugin-commonjs";
 import nodeResolve from "@rollup/plugin-node-resolve";
-import autoExternal from "rollup-plugin-auto-external";
-import nodeExternals from "rollup-plugin-node-externals";
+import { builtinModules, createRequire } from "node:module";
 import { globSync } from "tinyglobby";
 // `@rollup/plugin-typescript` is re-exported from the build-config package so
 // its `typescript` peer resolves to the legacy v6 compiler pinned there; native
 // TypeScript 7 drops the classic JS API the plugin needs.
 import typescript from "../../config/typescript-plugin.mjs";
 
+const manifest = createRequire(import.meta.url)("./package.json");
 const inputs = globSync("./src/**/*.ts");
-const externalPackages = ["ttsc", "@ttsc/unplugin", "unplugin"];
+
+// Externalise Node builtins, the host `ttsc` (supplied by the consuming project,
+// never bundled), and every declared dependency — including the Metro/Expo peers
+// resolved at runtime — so the published package never inlines a runtime it
+// shares with its consumer. The names come straight from package.json instead of
+// `rollup-plugin-node-externals`: that plugin's v9 calls the ES2025
+// `RegExp.escape`, so it needs Node 24 and crashes the build on Node 22. Deriving
+// the set here covers the same specifiers with no Node-version floor, and folds
+// in the old `rollup-plugin-auto-external` too.
+const externalPackages = new Set([
+  "ttsc",
+  "@ttsc/unplugin",
+  "unplugin",
+  ...Object.keys(manifest.dependencies ?? {}),
+  ...Object.keys(manifest.peerDependencies ?? {}),
+  ...Object.keys(manifest.optionalDependencies ?? {}),
+]);
 const external = (id) =>
   id.startsWith("node:") ||
-  externalPackages.some((name) => id === name || id.startsWith(`${name}/`));
+  builtinModules.includes(id) ||
+  [...externalPackages].some((name) => id === name || id.startsWith(`${name}/`));
 
 const output = (format, extension) => ({
   dir: "./lib",
@@ -34,8 +51,6 @@ export default {
   input: inputs,
   output: [output("cjs", "js"), output("esm", "mjs")],
   plugins: [
-    nodeExternals(),
-    autoExternal(),
     nodeResolve({
       extensions: [".mjs", ".js", ".json", ".ts"],
     }),

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -104,8 +104,6 @@
     "esbuild": "^0.25.12",
     "rimraf": "catalog:utils",
     "rollup": "^4.60.3",
-    "rollup-plugin-auto-external": "^2.0.0",
-    "rollup-plugin-node-externals": "^9.0.1",
     "tinyglobby": "^0.2.16",
     "tslib": "^2.8.1",
     "ttsc": "workspace:*",

--- a/packages/unplugin/rollup.config.mjs
+++ b/packages/unplugin/rollup.config.mjs
@@ -1,18 +1,33 @@
 import commonjs from "@rollup/plugin-commonjs";
 import nodeResolve from "@rollup/plugin-node-resolve";
-import autoExternal from "rollup-plugin-auto-external";
-import nodeExternals from "rollup-plugin-node-externals";
+import { builtinModules, createRequire } from "node:module";
 import { globSync } from "tinyglobby";
 // `@rollup/plugin-typescript` is re-exported from the build-config package so
 // its `typescript` peer resolves to the legacy v6 compiler pinned there; native
 // TypeScript 7 drops the classic JS API the plugin needs.
 import typescript from "../../config/typescript-plugin.mjs";
 
+const manifest = createRequire(import.meta.url)("./package.json");
 const inputs = globSync("./src/**/*.ts");
-const externalPackages = ["ttsc", "unplugin"];
+
+// Externalise Node builtins, the host `ttsc` (supplied by the consuming project,
+// never bundled), and every declared dependency so the published package never
+// inlines a second copy of a runtime it shares with its consumer. The names come
+// straight from package.json instead of `rollup-plugin-node-externals`: that
+// plugin's v9 calls the ES2025 `RegExp.escape`, so it needs Node 24 and crashes
+// the build on Node 22. Deriving the set here covers the same specifiers with no
+// Node-version floor, and folds in the old `rollup-plugin-auto-external` too.
+const externalPackages = new Set([
+  "ttsc",
+  "unplugin",
+  ...Object.keys(manifest.dependencies ?? {}),
+  ...Object.keys(manifest.peerDependencies ?? {}),
+  ...Object.keys(manifest.optionalDependencies ?? {}),
+]);
 const external = (id) =>
   id.startsWith("node:") ||
-  externalPackages.some((name) => id === name || id.startsWith(`${name}/`));
+  builtinModules.includes(id) ||
+  [...externalPackages].some((name) => id === name || id.startsWith(`${name}/`));
 
 const output = (format, extension) => ({
   dir: "./lib",
@@ -34,8 +49,6 @@ export default {
   input: inputs,
   output: [output("cjs", "js"), output("esm", "mjs")],
   plugins: [
-    nodeExternals(),
-    autoExternal(),
     nodeResolve({
       extensions: [".mjs", ".js", ".json", ".ts"],
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,12 +15,6 @@ catalogs:
     rollup:
       specifier: ^4.56.0
       version: 4.60.4
-    rollup-plugin-auto-external:
-      specifier: ^2.0.0
-      version: 2.0.0
-    rollup-plugin-node-externals:
-      specifier: ^8.1.2
-      version: 8.1.2
   samchon:
     '@typia/interface':
       specifier: ^13.1.0
@@ -95,12 +89,6 @@ importers:
       rollup:
         specifier: catalog:rollup
         version: 4.60.4
-      rollup-plugin-auto-external:
-        specifier: catalog:rollup
-        version: 2.0.0(rollup@4.60.4)
-      rollup-plugin-node-externals:
-        specifier: catalog:rollup
-        version: 8.1.2(rollup@4.60.4)
       tinyglobby:
         specifier: ^0.2.12
         version: 0.2.16
@@ -217,12 +205,6 @@ importers:
       rollup:
         specifier: ^4.60.3
         version: 4.60.4
-      rollup-plugin-auto-external:
-        specifier: ^2.0.0
-        version: 2.0.0(rollup@4.60.4)
-      rollup-plugin-node-externals:
-        specifier: ^9.0.1
-        version: 9.0.1(rollup@4.60.4)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))
       tinyglobby:
         specifier: ^0.2.16
         version: 0.2.16
@@ -349,12 +331,6 @@ importers:
       rollup:
         specifier: ^4.60.3
         version: 4.60.4
-      rollup-plugin-auto-external:
-        specifier: ^2.0.0
-        version: 2.0.0(rollup@4.60.4)
-      rollup-plugin-node-externals:
-        specifier: ^9.0.1
-        version: 9.0.1(rollup@4.60.4)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))
       tinyglobby:
         specifier: ^0.2.16
         version: 0.2.16
@@ -3637,9 +3613,6 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  builtins@2.0.1:
-    resolution: {integrity: sha512-XkkVe5QAb6guWPXTzpSrYpSlN3nqEmrrE2TkAr/tp7idSF6+MONh9WvKrAuR3HiKLvoSgmbs8l1U9IPmMrIoLw==}
-
   bumpp@10.4.1:
     resolution: {integrity: sha512-X/bwWs5Gbb/D7rN4aHLB7zdjiA6nGdjckM1sTHhI9oovIbEw2L5pw5S4xzk8ZTeOZ8EnwU/Ze4SoZ6/Vr3pM2Q==}
     engines: {node: '>=18'}
@@ -4262,9 +4235,6 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
-  error-ex@1.3.4:
-    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
-
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
@@ -4724,9 +4694,6 @@ packages:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
-  hosted-git-info@2.8.9:
-    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
-
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -4872,9 +4839,6 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
-  is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
@@ -5015,9 +4979,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  json-parse-better-errors@1.0.2:
-    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
-
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -5144,10 +5105,6 @@ packages:
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
-
-  load-json-file@4.0.0:
-    resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
-    engines: {node: '>=4'}
 
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
@@ -5736,9 +5693,6 @@ packages:
     resolution: {integrity: sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==}
     engines: {node: '>=20'}
 
-  normalize-package-data@2.5.0:
-    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
-
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -5853,10 +5807,6 @@ packages:
   parse-imports-exports@0.2.4:
     resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
 
-  parse-json@4.0.0:
-    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
-    engines: {node: '>=4'}
-
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
@@ -5914,10 +5864,6 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
-  path-type@3.0.0:
-    resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
-    engines: {node: '>=4'}
-
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -5948,10 +5894,6 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
-
-  pify@3.0.0:
-    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
-    engines: {node: '>=4'}
 
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
@@ -6108,10 +6050,6 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
-
-  read-pkg@3.0.0:
-    resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
-    engines: {node: '>=4'}
 
   read-pkg@9.0.1:
     resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
@@ -6285,30 +6223,6 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
-  rollup-plugin-auto-external@2.0.0:
-    resolution: {integrity: sha512-HQM3ZkZYfSam1uoZtAB9sK26EiAsfs1phrkf91c/YX+S07wugyRXSigBxrIwiLr5EPPilKYmoMxsrnlGBsXnuQ==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      rollup: '>=0.45.2'
-
-  rollup-plugin-node-externals@8.1.2:
-    resolution: {integrity: sha512-EuB6/lolkMLK16gvibUjikERq5fCRVIGwD2xue/CrM8D0pz5GXD2V6N8IrgxegwbcUoKkUFI8VYCEEv8MMvgpA==}
-    engines: {node: '>= 21 || ^20.6.0 || ^18.19.0'}
-    peerDependencies:
-      rollup: ^4.0.0
-
-  rollup-plugin-node-externals@9.0.1:
-    resolution: {integrity: sha512-Yp91CX1ebDA8s4+BY7bOOdhF8VRR1XAKnSsHeVhYg4DW4MRXPsF4F2FnSsN9ghJgFhHl3L1uyK7A9NA/SF4Zgw==}
-    engines: {node: '>= 24'}
-    peerDependencies:
-      rollup: ^4.0.0
-      vite: '>=5.0.0'
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-      vite:
-        optional: true
-
   rollup@4.60.4:
     resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -6343,9 +6257,6 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  safe-resolve@1.0.0:
-    resolution: {integrity: sha512-aQpRvfxoi1y0UxKEU0tNO327kb0/LMo8Xrk64M2u172UqOOLCCM0khxN2OTClDiTqTJz5864GMD1X92j4YiHTg==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -6573,10 +6484,6 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
-
-  strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
 
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -10300,10 +10207,6 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  builtins@2.0.1:
-    dependencies:
-      semver: 6.3.1
-
   bumpp@10.4.1:
     dependencies:
       ansis: 4.3.0
@@ -10923,10 +10826,6 @@ snapshots:
   entities@7.0.1: {}
 
   environment@1.1.0: {}
-
-  error-ex@1.3.4:
-    dependencies:
-      is-arrayish: 0.2.1
 
   error-stack-parser@2.1.4:
     dependencies:
@@ -11612,8 +11511,6 @@ snapshots:
 
   hono@4.12.27: {}
 
-  hosted-git-info@2.8.9: {}
-
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -11796,8 +11693,6 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
-  is-arrayish@0.2.1: {}
-
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
@@ -11917,8 +11812,6 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-parse-better-errors@1.0.2: {}
-
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -12036,13 +11929,6 @@ snapshots:
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
-
-  load-json-file@4.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      parse-json: 4.0.0
-      pify: 3.0.0
-      strip-bom: 3.0.0
 
   loader-runner@4.3.2: {}
 
@@ -13113,13 +12999,6 @@ snapshots:
       '@types/sarif': 2.1.7
       fs-extra: 11.3.5
 
-  normalize-package-data@2.5.0:
-    dependencies:
-      hosted-git-info: 2.8.9
-      resolve: 1.22.12
-      semver: 5.7.2
-      validate-npm-package-license: 3.0.4
-
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
@@ -13247,11 +13126,6 @@ snapshots:
     dependencies:
       parse-statements: 1.0.11
 
-  parse-json@4.0.0:
-    dependencies:
-      error-ex: 1.3.4
-      json-parse-better-errors: 1.0.2
-
   parse-json@8.3.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -13309,10 +13183,6 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
-  path-type@3.0.0:
-    dependencies:
-      pify: 3.0.0
-
   path-type@4.0.0: {}
 
   path-type@6.0.0: {}
@@ -13333,8 +13203,6 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
-
-  pify@3.0.0: {}
 
   pkce-challenge@5.0.1: {}
 
@@ -13530,12 +13398,6 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-
-  read-pkg@3.0.0:
-    dependencies:
-      load-json-file: 4.0.0
-      normalize-package-data: 2.5.0
-      path-type: 3.0.0
 
   read-pkg@9.0.1:
     dependencies:
@@ -13806,23 +13668,6 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rollup-plugin-auto-external@2.0.0(rollup@4.60.4):
-    dependencies:
-      builtins: 2.0.1
-      read-pkg: 3.0.0
-      rollup: 4.60.4
-      safe-resolve: 1.0.0
-      semver: 5.7.2
-
-  rollup-plugin-node-externals@8.1.2(rollup@4.60.4):
-    dependencies:
-      rollup: 4.60.4
-
-  rollup-plugin-node-externals@9.0.1(rollup@4.60.4)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)):
-    optionalDependencies:
-      rollup: 4.60.4
-      vite: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
-
   rollup@4.60.4:
     dependencies:
       '@types/estree': 1.0.8
@@ -13888,8 +13733,6 @@ snapshots:
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
-
-  safe-resolve@1.0.0: {}
 
   safer-buffer@2.1.2: {}
 
@@ -14218,8 +14061,6 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
-
-  strip-bom@3.0.0: {}
 
   strip-final-newline@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,8 +15,6 @@ catalogs:
     '@rollup/plugin-commonjs': ^29.0.0
     '@rollup/plugin-node-resolve': ^16.0.3
     rollup: ^4.56.0
-    rollup-plugin-auto-external: ^2.0.0
-    rollup-plugin-node-externals: ^8.1.2
   samchon:
     '@typia/interface': ^13.1.0
     '@typia/mcp': ^13.1.0

--- a/tests/test-metro/src/features/build/test_package_build_keeps_runtime_dependencies_external.ts
+++ b/tests/test-metro/src/features/build/test_package_build_keeps_runtime_dependencies_external.ts
@@ -1,0 +1,21 @@
+import { assertMetroBuildKeepsRuntimeDependenciesExternal } from "../../internal/metro-build";
+
+/**
+ * Verifies the Metro package build keeps `@ttsc/unplugin` external and needs no
+ * Node-24-only rollup tooling.
+ *
+ * Bundling `@ttsc/unplugin` into the Metro output would inflate the artifact
+ * and shadow the version the consuming project installed. Separately, the build
+ * used to externalise dependencies through `rollup-plugin-node-externals`,
+ * whose v9 calls the ES2025 `RegExp.escape` and so requires Node 24 — it
+ * crashed the rollup build on Node 22. The config now derives its external set
+ * straight from package.json. This pins both invariants so neither regresses.
+ *
+ * 1. Read the built CJS and ESM `transformer` outputs and `rollup.config.mjs`.
+ * 2. Assert `@ttsc/unplugin/api` stays a runtime import in both outputs.
+ * 3. Assert the config no longer imports `rollup-plugin-node-externals` /
+ *    `rollup-plugin-auto-external`, and no virtual-module shims are inlined.
+ */
+export const test_package_build_keeps_runtime_dependencies_external = () => {
+  assertMetroBuildKeepsRuntimeDependenciesExternal();
+};

--- a/tests/test-metro/src/internal/metro-build.ts
+++ b/tests/test-metro/src/internal/metro-build.ts
@@ -1,0 +1,61 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TestMetroRuntime } from "./metro-runtime";
+
+/**
+ * Asserts that `@ttsc/unplugin` stays external in the built Metro output and
+ * that the rollup build no longer depends on `rollup-plugin-node-externals` /
+ * `rollup-plugin-auto-external`.
+ *
+ * The externals plugin's v9 calls the ES2025 `RegExp.escape`, so it requires
+ * Node 24 and crashes the rollup build on Node 22; the config now derives its
+ * external set from package.json instead. Pinning the external `@ttsc/unplugin`
+ * import, the absence of those plugin imports, and the absence of
+ * virtual-module shims keeps the Metro build working on Node 22 and blocks the
+ * plugin's return.
+ */
+export function assertMetroBuildKeepsRuntimeDependenciesExternal(): void {
+  const cjs = readLib("transformer", "js");
+  const esm = readLib("transformer", "mjs");
+
+  assert.match(cjs, /require\('@ttsc\/unplugin\/api'\)/);
+  assert.match(esm, /from '@ttsc\/unplugin\/api'/);
+
+  const rollupConfig = fs.readFileSync(
+    path.resolve(
+      TestProject.WORKSPACE_ROOT,
+      "packages/metro/rollup.config.mjs",
+    ),
+    "utf8",
+  );
+  for (const removedPlugin of [
+    "rollup-plugin-node-externals",
+    "rollup-plugin-auto-external",
+  ]) {
+    // Match the import statement, not a bare mention: the config comment names
+    // these plugins to explain why externals come from package.json instead.
+    assert.doesNotMatch(
+      rollupConfig,
+      new RegExp(`from ["']${escapeRegExp(removedPlugin)}["']`),
+      removedPlugin,
+    );
+  }
+
+  for (const output of [cjs, esm]) {
+    assert.doesNotMatch(output, /_virtual/);
+  }
+}
+
+function readLib(entry: string, extension: "js" | "mjs"): string {
+  const file = TestMetroRuntime.libPath(entry, extension);
+  assert.equal(fs.existsSync(file), true, file);
+  return fs.readFileSync(file, "utf8");
+}
+
+/** Escapes all regex meta-characters in `value` for use in `new RegExp(...)`. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/tests/test-unplugin/src/features/adapters/test_package_build_keeps_runtime_dependencies_external.ts
+++ b/tests/test-unplugin/src/features/adapters/test_package_build_keeps_runtime_dependencies_external.ts
@@ -15,8 +15,9 @@ import { assertPackageBuildKeepsRuntimeDependenciesExternal } from "../../intern
  * 2. Read `rollup.config.mjs` from `packages/unplugin`.
  * 3. Assert `ttsc` appears as a runtime import in the CJS and ESM outputs.
  * 4. Assert no virtual-module paths, `__dirname` refs, or workspace-relative paths
- *    are present in any output; assert stale externals are absent from both the
- *    config and all outputs.
+ *    are present in any output; assert stale externals and the removed
+ *    `rollup-plugin-node-externals` / `rollup-plugin-auto-external` (whose v9
+ *    needs Node 24) are absent from the config and all outputs.
  */
 export const test_package_build_keeps_runtime_dependencies_external = () => {
   assertPackageBuildKeepsRuntimeDependenciesExternal();

--- a/tests/test-unplugin/src/features/adapters/test_package_build_keeps_runtime_dependencies_external.ts
+++ b/tests/test-unplugin/src/features/adapters/test_package_build_keeps_runtime_dependencies_external.ts
@@ -15,9 +15,10 @@ import { assertPackageBuildKeepsRuntimeDependenciesExternal } from "../../intern
  * 2. Read `rollup.config.mjs` from `packages/unplugin`.
  * 3. Assert `ttsc` appears as a runtime import in the CJS and ESM outputs.
  * 4. Assert no virtual-module paths, `__dirname` refs, or workspace-relative paths
- *    are present in any output; assert stale externals and the removed
+ *    are present in any output; assert stale externals are absent from the config
+ *    and all outputs; and assert the config no longer imports the removed
  *    `rollup-plugin-node-externals` / `rollup-plugin-auto-external` (whose v9
- *    needs Node 24) are absent from the config and all outputs.
+ *    needs Node 24).
  */
 export const test_package_build_keeps_runtime_dependencies_external = () => {
   assertPackageBuildKeepsRuntimeDependenciesExternal();

--- a/tests/test-unplugin/src/internal/adapter-entrypoints.ts
+++ b/tests/test-unplugin/src/internal/adapter-entrypoints.ts
@@ -100,9 +100,16 @@ function assertAdapterEntrypointsSupportCjsRequire() {
 
 /**
  * Asserts that `ttsc` and `unplugin` are externalised in the built output, that
- * no virtual-module shims or workspace-relative paths are inlined, and that
- * stale dev-time externals (`diff-match-patch-es`, `magic-string`) have been
- * removed from both `rollup.config.mjs` and the built artifacts.
+ * no virtual-module shims or workspace-relative paths are inlined, that stale
+ * dev-time externals (`diff-match-patch-es`, `magic-string`) have been removed
+ * from both `rollup.config.mjs` and the built artifacts, and that the build no
+ * longer depends on `rollup-plugin-node-externals` /
+ * `rollup-plugin-auto-external`.
+ *
+ * The externals plugin's v9 calls the ES2025 `RegExp.escape`, so it requires
+ * Node 24 and crashes the rollup build on Node 22; the config now derives its
+ * external set from package.json instead. Pinning the config free of those
+ * imports keeps the build working on Node 22 and blocks the plugin's return.
  */
 function assertPackageBuildKeepsRuntimeDependenciesExternal() {
   assert.equal(
@@ -164,6 +171,19 @@ function assertPackageBuildKeepsRuntimeDependenciesExternal() {
     for (const output of [cjs, esm, cjsCore, esmCore]) {
       assert.doesNotMatch(output, pattern);
     }
+  }
+
+  for (const removedPlugin of [
+    "rollup-plugin-node-externals",
+    "rollup-plugin-auto-external",
+  ]) {
+    // Match the import statement, not a bare mention: the config comment names
+    // these plugins to explain why externals come from package.json instead.
+    assert.doesNotMatch(
+      rollupConfig,
+      new RegExp(`from ["']${escapeRegExp(removedPlugin)}["']`),
+      removedPlugin,
+    );
   }
 
   for (const output of [cjs, esm, cjsCore, esmCore]) {


### PR DESCRIPTION
## Intent

`pnpm build:current` aborts on Node 22 at the `@ttsc/unplugin` rollup step, which also blocked local verification of graph/vscode work downstream in the build order. Root cause: `@ttsc/unplugin` and `@ttsc/metro` externalise dependencies through `rollup-plugin-node-externals`, pinned **literally** at `^9.0.1` — diverging from the `rollup` catalog's `^8.1.2`. v9 declares `engines.node >= 24` and calls the ES2025 `RegExp.escape`; on Node 22 its `getConfig` runs `names.map(RegExp.escape)` with `RegExp.escape === undefined` → `TypeError: undefined is not a function`, killing the rollup build.

## Scope

- **`packages/unplugin/rollup.config.mjs`, `packages/metro/rollup.config.mjs`** — Remove `rollup-plugin-node-externals` and the redundant `rollup-plugin-auto-external`. Both configs already carried a complete manual `external` list; replace all three overlapping mechanisms with one self-contained predicate that externalises Node builtins plus every name declared in `package.json` (`dependencies` + `peerDependencies` + `optionalDependencies`) alongside the explicit host packages (`ttsc`, and for metro `@ttsc/unplugin`). Same specifiers, no Node-version floor — builds on Node 22 and 24 alike.
- **`packages/{unplugin,metro}/package.json`, `config/package.json`, `pnpm-workspace.yaml`** — Both plugins are now unused repo-wide, so drop them from the two package manifests, from `config/package.json`, and from the `rollup` catalog. `config/rollup.config.mjs` (the shared config used by `@ttsc/factory`) never imported them.
- **Tests** — Extend `test-unplugin`'s externalization test and add a mirror in `test-metro` pinning each `rollup.config.mjs` free of the removed plugin imports (they still document the rationale in a comment, so the assertion matches the `from "…"` import form, not a bare mention).

## Deferred

- No engines pin added. CI runs Node 24; this change makes local dev on Node 22 work too, without mandating either.
- `commonjs()` / `nodeResolve()` left in place in both configs; they resolve extensionless relative `.ts` imports and are unrelated to the crash.

## Test plan (local — CI queue is saturated)

Verified on Node 22.21.0 (`RegExp.escape` absent):

- `pnpm --filter @ttsc/unplugin build`, `pnpm --filter @ttsc/metro build`, `pnpm --filter @ttsc/factory build` — all succeed (previously unplugin/metro crashed).
- Built outputs keep dependencies external, nothing inlined: unplugin lib references only `ttsc` / `unplugin`; metro lib references only `@ttsc/unplugin/api`; no `_virtual` chunks.
- `test-unplugin` — `entrypoints` (ESM `import()` + CJS `require()` of all 11 entrypoints) and `package_build_keeps_runtime_dependencies_external` pass.
- `test-metro` — `cjs_build_loads_and_runs_under_require`, the new `package_build_keeps_runtime_dependencies_external`, and the ESM-load structural suites (`withttsc` / `options` / `upstream` / `cache_key`) pass.
- `tsc --noEmit` clean for both test packages; `pnpm-lock.yaml` diff is scoped to the two removed plugins only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)