### PR TITLE
fix(website): "Shopping" label + alphabetical order for graph benchmark charts

### DIFF
--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphData.ts
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphData.ts
@@ -92,6 +92,8 @@ function repoLabel(repo: string): string {
       return "TypeORM";
     case "nestjs":
       return "NestJS";
+    case "shopping-backend":
+      return "Shopping";
     case "excalidraw":
       return "Excalidraw";
     case "vue":
@@ -313,7 +315,11 @@ function buildPromptModeGroups(projects: ProjectGroup[]): PromptModeGroup[] {
       ({ key, items }): PromptModeGroup => ({
         id: key,
         promptFamily: items[0]?.promptFamily ?? key,
-        projects: items,
+        projects: [...items].sort(
+          (a, b) =>
+            repoLabel(a.repo).localeCompare(repoLabel(b.repo)) ||
+            (a.promptId ?? "").localeCompare(b.promptId ?? ""),
+        ),
       }),
     )
     .sort(

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphIndex.tsx
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphIndex.tsx
@@ -51,9 +51,10 @@ interface IndexRow {
 }
 
 /**
- * Rows ordered by the size of the program each index was built from, so a build
- * time is read against the work it had to do: forty seconds on VS Code and one
- * second on a small backend are the same tool, not two.
+ * Rows are listed alphabetically by repository. Each row still carries the
+ * program's file and line counts, so a build time is read against the work it
+ * had to do: forty seconds on VS Code and one second on a small backend are the
+ * same tool, not two.
  */
 function buildRows(data: IndexData): IndexRow[] {
   const projects = [...new Set(data.cells.map((cell) => cell.project))];
@@ -77,7 +78,7 @@ function buildRows(data: IndexData): IndexRow[] {
         }),
       };
     })
-    .sort((a, b) => a.lines - b.lines);
+    .sort((a, b) => a.label.localeCompare(b.label));
 }
 
 function Bars({ row, max }: { row: IndexRow; max: number }) {

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphTime.tsx
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphTime.tsx
@@ -110,7 +110,7 @@ function buildRows(report: Report, only?: string): TimeRow[] {
       };
     })
     .filter((row) => row.bars.length > 0)
-    .sort((a, b) => a.lines - b.lines);
+    .sort((a, b) => a.label.localeCompare(b.label));
 }
 
 /**


### PR DESCRIPTION
## Intent

On the graph benchmark charts the `shopping-backend` fixture rendered with its raw key, and several charts ordered repositories by program size. Per request: label it **Shopping**, and arrange the graph elements alphabetically.

## Scope (display-only — no data/measurement changes)

- **`repoLabel`** (`TtscWebsiteBenchmarkGraphData.ts`): add `shopping-backend → "Shopping"`, matching the proper-cased peers (VS Code, RxJS, TypeORM, NestJS). This propagates to every React chart.
- **Alphabetical element order** by display label, across the charts that list repositories:
  - `buildPromptModeGroups` — the shared per-mode project list feeding **Common** rows and **Dedicated** tabs (was first-appearance order).
  - **Cold time to a first answer** (`GraphTime`) — was sorted by program size.
  - **Cold index build time** (`GraphIndex`) — was sorted by program size; its doc comment and caption are updated. Each row still shows file/line counts, so the size context is preserved.

## Not changed (deliberate)

- Benchmark **data keys**, question files, and measurements are untouched (`shopping-backend` remains the identity key in `graph.json`).
- The generated **SVG** chart (`build/graph-benchmark-svg.cjs`) already drops the `-backend` suffix (labels `shopping`) and already sorts alphabetically; its repo labels are uniformly lowercase (vscode, rxjs, typeorm), so it is left as-is. Say the word if you'd rather it read capital "Shopping" there too.
- The SVG "time to first answer" chart is single-repo (vscode), so ordering doesn't apply.

## Test plan

- `tsc --noEmit` on `website`: no errors in the changed files (only pre-existing unrelated `@ttsc/playground`/`typia-types.json` module-resolution errors from the unbuilt workspace).
- Diff is semantic-only (13 lines); no formatting churn.
- A full `next build` of the site was not run locally (unbuilt workspace deps); the changes are pure sort keys + a label case + caption text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)