### PR TITLE
feat(website): rework the graph benchmark charts

### DIFF
--- a/website/build/graph-benchmark-svg.cjs
+++ b/website/build/graph-benchmark-svg.cjs
@@ -20,7 +20,21 @@ const COLORS = {
   legendBorder: "#334155",
   muted: "#94a3b8",
   worse: "#fb7185",
+  // Winner treatment, mirroring the React chart: a cyan crown glyph left of the
+  // value label, plus a near-white border/halo the length of the winning bar.
+  crown: "#36e2ee",
+  ring: "#d7f9ff",
 };
+
+// The same crown the React chart draws (CrownMark, viewBox 0 0 16 16), scaled
+// to `size` px and translated so (x, y) is its top-left corner.
+function crownMark(x, y, size, color) {
+  const s = size / 16;
+  return `<g transform="translate(${x.toFixed(2)} ${y.toFixed(2)}) scale(${s.toFixed(3)})" style="fill:none;stroke:${color};stroke-width:1.5">
+    <path d="M2.5 5.5 5.4 8l2.6-4 2.6 4 2.9-2.5-.8 6H3.3l-.8-6Z" style="stroke-linejoin:round"/>
+    <path d="M3.5 12.5 h9" style="stroke-linecap:round"/>
+   </g>`;
+}
 
 const TOOLS = [
   { key: "baseline", sample: "baseline", label: "baseline", color: "#94a3b8" },
@@ -48,14 +62,14 @@ const INDEX_TOOLS = [
 ];
 
 const REPO_LABELS = {
-  excalidraw: "excalidraw",
-  nestjs: "nestjs",
-  rxjs: "rxjs",
-  "shopping-backend": "shopping",
-  typeorm: "typeorm",
-  vscode: "vscode",
-  vue: "vue",
-  zod: "zod",
+  excalidraw: "Excalidraw",
+  nestjs: "NestJS",
+  rxjs: "RxJS",
+  "shopping-backend": "Shopping",
+  typeorm: "TypeORM",
+  vscode: "VS Code",
+  vue: "Vue",
+  zod: "Zod",
 };
 
 const HARNESS_LABELS = { codex: "Codex", "claude-code": "Claude Code" };
@@ -189,87 +203,101 @@ function buildRows(input) {
     .sort((a, b) => a.label.localeCompare(b.label));
 }
 
+// Grouped chart, laid out like the website: one banded block per repo with the
+// repo name as a header, then one row per series — tool name on the left, a
+// full-width track with the coloured bar inside, and the value on the right
+// (baseline in tokens, the rest as % vs baseline). Larger type throughout.
 function render(rows, title) {
-  const width = 1040;
-  const height = 940;
-  const chart = {
-    left: 136,
-    right: 1016,
-    top: 128,
-    bottom: 866,
-  };
-  const plotWidth = chart.right - chart.left;
-  const plotHeight = chart.bottom - chart.top;
+  const width = 1240;
+  const margin = 36;
+  const nameX = 60; // tool-name column start (crown sits just left of it)
+  const labelRight = margin + 224;
+  const barLeft = labelRight + 10;
+  const valueRight = width - margin;
+  const barRight = valueRight - 176;
+  const barFull = barRight - barLeft;
+  const barHeight = 20;
+  const rowStep = 30;
+  const headerH = 44;
+  const padBottom = 14;
+  const groupGap = 12;
+  const titleBlock = 100;
+
   const max = niceMax(
-    Math.max(
-      1,
-      ...rows.flatMap((row) => row.values.map((value) => value.value)),
-    ),
+    Math.max(1, ...rows.flatMap((row) => row.values.map((v) => v.value))),
   );
-  const ticks = [0, max * 0.25, max * 0.5, max * 0.75, max];
-  const rowHeight = plotHeight / rows.length;
-  const barHeight = 10.5;
-  const barStep = 15.5;
+
+  let cursor = titleBlock;
+  const groups = rows.map((row, index) => {
+    const height = headerH + row.values.length * rowStep + padBottom;
+    const g = { row, index, y: cursor, height };
+    cursor += height + groupGap;
+    return g;
+  });
+  const height = Math.round(cursor - groupGap + margin);
+
+  const groupsSvg = groups
+    .map(({ row, index, y, height: gh }) => {
+      const lowest = minTokens(row);
+      const band = `<rect x="${margin - 8}" y="${y.toFixed(1)}" width="${(width - 2 * margin + 16).toFixed(1)}" height="${gh.toFixed(1)}" rx="10" style="fill:#111a24;fill-opacity:${index % 2 === 0 ? 0.55 : 0.25}"/>`;
+      const header = `<text x="${nameX}" y="${(y + 30).toFixed(1)}" style="fill:${COLORS.title};font-size:22px;font-weight:700">${escapeXml(row.label)}</text>`;
+      const bars = row.values
+        .map((value, vi) => {
+          const rowTop = y + headerH + vi * rowStep;
+          const cy = rowTop + barHeight / 2;
+          const baseY = (cy + 6).toFixed(1);
+          const isBaseline = value.key === "baseline";
+          const hasData = value.value > 0;
+          const isBest = hasData && value.value === lowest;
+          const dataW = hasData ? Math.max(3, (value.value / max) * barFull) : 0;
+          const rx = (barHeight / 2).toFixed(1);
+          const saved = hasData ? pctSaved(row.baseline, value.value) : 0;
+          const label = isBaseline
+            ? `${formatTick(value.value)} tokens`
+            : !hasData
+              ? "no data"
+              : saved >= 0
+                ? `${saved}% saved`
+                : `${-saved}% over`;
+          const nameColor = isBaseline ? "#9aa3b2" : value.color;
+          const valueColor = isBaseline
+            ? COLORS.label
+            : !hasData
+              ? COLORS.muted
+              : isBest
+                ? COLORS.crown
+                : saved >= 0
+                  ? COLORS.label
+                  : COLORS.worse;
+          const glow = isBest
+            ? `<rect x="${(barLeft - 2).toFixed(1)}" y="${(rowTop - 2).toFixed(1)}" width="${(barFull + 4).toFixed(1)}" height="${(barHeight + 4).toFixed(1)}" rx="${((barHeight + 4) / 2).toFixed(1)}" style="fill:none;stroke:${COLORS.ring};stroke-opacity:0.18;stroke-width:3.5"/>\n    `
+            : "";
+          const trackStroke = isBest
+            ? `stroke:${COLORS.ring};stroke-width:1.6`
+            : `stroke:#ffffff;stroke-opacity:0.05;stroke-width:1`;
+          const track = `<rect x="${barLeft}" y="${rowTop.toFixed(1)}" width="${barFull.toFixed(1)}" height="${barHeight}" rx="${rx}" style="fill:${COLORS.track};${trackStroke}"/>`;
+          const bar = hasData
+            ? `<rect x="${barLeft}" y="${rowTop.toFixed(1)}" width="${dataW.toFixed(1)}" height="${barHeight}" rx="${rx}" style="fill:${value.color}"/>`
+            : "";
+          const crown = isBest ? crownMark(nameX - 22, cy - 8, 16, COLORS.crown) : "";
+          return `${glow}${track}${bar}${crown}
+    <text x="${nameX}" y="${baseY}" style="fill:${nameColor};font-size:17px${isBest ? ";font-weight:700" : ""}">${escapeXml(value.label)}</text>
+    <text x="${valueRight}" y="${baseY}" style="fill:${valueColor};font-size:17px;font-weight:${isBest ? 700 : 500};text-anchor:end">${escapeXml(label)}</text>`;
+        })
+        .join("\n    ");
+      return `${band}
+   ${header}
+   ${bars}`;
+    })
+    .join("\n  ");
 
   return `<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" version="1.1" role="img" aria-label="${escapeXml(title)}">
- <defs>
-  <style type="text/css">
-   *{stroke-linejoin:round;stroke-linecap:butt}
-   text{font-family:DejaVu Sans, Arial, sans-serif}
-  </style>
- </defs>
- <g id="figure_1">
-  <g id="patch_1">
-   <path d="M 0 ${height} L ${width} ${height} L ${width} 0 L 0 0 z" style="fill:${COLORS.background}"/>
-  </g>
-  <g id="axes_1">
-   <path d="M ${chart.left} ${chart.top} L ${chart.right} ${chart.top} L ${chart.right} ${chart.bottom} L ${chart.left} ${chart.bottom} z" style="fill:${COLORS.panel}"/>
-   <path d="M ${chart.left} ${chart.bottom} L ${chart.right} ${chart.bottom}" style="fill:none;stroke:${COLORS.axis};stroke-width:0.8"/>
-   <path d="M ${chart.left} ${chart.top} L ${chart.left} ${chart.bottom}" style="fill:none;stroke:${COLORS.axis};stroke-width:0.8"/>
-   ${ticks
-     .map((tick) => {
-       const x = chart.left + (tick / max) * plotWidth;
-       return `<g>
-    <path d="M ${x.toFixed(3)} ${chart.top} L ${x.toFixed(3)} ${chart.bottom}" style="fill:none;stroke:${COLORS.grid};stroke-width:0.7"/>
-    <text x="${x.toFixed(3)}" y="${chart.bottom + 18}" style="fill:${COLORS.label};font-size:13px;text-anchor:middle">${formatTick(tick)}</text>
-   </g>`;
-     })
-     .join("\n   ")}
-   ${rows
-     .map((row, rowIndex) => {
-       const rowTop = chart.top + rowIndex * rowHeight;
-       const labelY = rowTop + rowHeight / 2 + 3;
-       const barTop = rowTop + (rowHeight - (TOOLS.length - 1) * barStep) / 2;
-       return `<g>
-    <path d="M 18 ${(rowTop + rowHeight).toFixed(3)} L ${chart.right} ${(rowTop + rowHeight).toFixed(3)}" style="fill:none;stroke:${COLORS.grid};stroke-width:0.6"/>
-    <text x="${chart.left - 16}" y="${labelY.toFixed(3)}" style="fill:${COLORS.title};font-size:15px;font-weight:600;text-anchor:end">${escapeXml(row.label)}</text>
-    ${row.values
-      .map((value, valueIndex) => {
-        if (value.value <= 0) return "";
-        const barWidth = Math.max(2, (value.value / max) * plotWidth);
-        const label = valueLabel(row, value);
-        const best = value.value === minTokens(row);
-        const labelWidth = estimateTextWidth(label, 13, best ? 700 : 400);
-        const textX = Math.min(
-          chart.left + barWidth + 5,
-          width - labelWidth - 8,
-        );
-        const y = barTop + valueIndex * barStep;
-        return `<rect x="${chart.left}" y="${y.toFixed(3)}" width="${barWidth.toFixed(3)}" height="${barHeight}" style="fill:${value.color}"/>
-    <text x="${textX.toFixed(3)}" y="${(y + barHeight - 0.7).toFixed(3)}" style="fill:${valueLabelColor(row, value)};font-size:13px${best ? ";font-weight:700" : ""}">${escapeXml(label)}</text>`;
-      })
-      .filter(Boolean)
-      .join("\n    ")}
-   </g>`;
-     })
-     .join("\n   ")}
-   <text x="${(chart.left + plotWidth / 2).toFixed(3)}" y="30" style="fill:${COLORS.title};font-size:22px;font-weight:600;text-anchor:middle">${escapeXml(title)}</text>
-   <text x="${(chart.left + plotWidth / 2).toFixed(3)}" y="${chart.bottom + 46}" style="fill:${COLORS.label};font-size:14px;text-anchor:middle">Tokens</text>
-   ${renderLegend(chart.left, 60)}
-   <text x="${chart.left}" y="86" style="fill:${COLORS.muted};font-size:13px">Lower is better. Percentage is versus the no-MCP baseline.</text>
-  </g>
- </g>
+ <defs><style type="text/css">text{font-family:DejaVu Sans, Arial, sans-serif}</style></defs>
+ <rect width="${width}" height="${height}" style="fill:${COLORS.background}"/>
+ <text x="${margin}" y="48" style="fill:${COLORS.title};font-size:27px;font-weight:700">${escapeXml(title)}</text>
+ <text x="${margin}" y="78" style="fill:${COLORS.muted};font-size:15px">Lower is better</text>
+ ${groupsSvg}
 </svg>`;
 }
 
@@ -298,12 +326,27 @@ function renderSingle(row, cfg) {
       const center = barY + barHeight / 2;
       const barWidth = Math.max(2, (value.value / max) * plotWidth);
       const label = valueLabel(row, value);
+      const best = value.value === minTokens(row);
       const labelWidth = estimateTextWidth(label, 14, 400);
-      const textX = Math.min(left + barWidth + 8, width - labelWidth - 8);
+      const crownSize = 16;
+      const crownX = left + barWidth + 8;
+      const textX = Math.min(
+        crownX + (best ? crownSize + 6 : 0),
+        width - labelWidth - 8,
+      );
+      const rx = (barHeight / 2).toFixed(3);
+      // Winner: a near-white border the exact length of the bar, softly haloed,
+      // with the crown just left of the value label.
+      const ring = best
+        ? `<rect x="${(left - 2).toFixed(3)}" y="${(barY - 2).toFixed(3)}" width="${(barWidth + 4).toFixed(3)}" height="${(barHeight + 4).toFixed(3)}" rx="${((barHeight + 4) / 2).toFixed(3)}" style="fill:none;stroke:${COLORS.ring};stroke-opacity:0.28;stroke-width:3"/>`
+        : "";
+      const crown = best
+        ? crownMark(crownX, center - crownSize / 2, crownSize, COLORS.crown)
+        : "";
       return `<g>
-    <text x="${left - 8}" y="${(center + 4).toFixed(3)}" style="fill:${COLORS.title};font-size:15px;font-weight:600;text-anchor:end">${escapeXml(value.label)}</text>
-    <rect x="${left}" y="${barY.toFixed(3)}" width="${barWidth.toFixed(3)}" height="${barHeight}" style="fill:${value.color}"/>
-    <text x="${textX.toFixed(3)}" y="${(center + 4).toFixed(3)}" style="fill:${valueLabelColor(row, value)};font-size:14px">${escapeXml(label)}</text>
+    <text x="${left - 8}" y="${(center + 4).toFixed(3)}" style="fill:${COLORS.title};font-size:15px;font-weight:${best ? 700 : 600};text-anchor:end">${escapeXml(value.label)}</text>
+    ${ring}<rect x="${left}" y="${barY.toFixed(3)}" width="${barWidth.toFixed(3)}" height="${barHeight}"${best ? ` rx="${rx}"` : ""} style="fill:${value.color}${best ? `;stroke:${COLORS.ring};stroke-width:1.4` : ""}"/>${crown}
+    <text x="${textX.toFixed(3)}" y="${(center + 4).toFixed(3)}" style="fill:${valueLabelColor(row, value)};font-size:14px${best ? ";font-weight:700" : ""}">${escapeXml(label)}</text>
    </g>`;
     })
     .join("\n   ");
@@ -559,18 +602,29 @@ function renderTime(index, cells, options = {}) {
     .filter((row) => row.values.length > 0)
     .sort((a, b) => a.scale.lines - b.scale.lines);
 
-  // One repository per band of whitespace, so a project reads as a block before
-  // the eye starts picking tools out of it. A single-project render (the VS
-  // Code cut) gets thicker bars instead of empty air.
+  // Banded blocks like the grouped chart: repo header + one row per tool, the
+  // two-tone bar (faded index build + solid LLM answer) inside a full-width
+  // track. A single-project render (the VS Code cut) gets thicker bars.
   const single = rows.length === 1;
-  const barHeight = single ? 28 : 12.5;
-  const barStep = single ? 40 : 17;
-  const rowHeight = single ? 5 * barStep + 44 : 100;
-  const width = 1040;
-  const chart = { left: 160, right: 900, top: 150 };
-  chart.bottom = chart.top + rows.length * rowHeight;
-  const height = chart.bottom + 80;
-  const plotWidth = chart.right - chart.left;
+  const width = 1240;
+  const margin = 36;
+  const nameX = 60;
+  const labelRight = margin + 224;
+  const barLeft = labelRight + 10;
+  const valueRight = width - margin;
+  const barRight = valueRight - 176;
+  const barFull = barRight - barLeft;
+  const barHeight = single ? 28 : 20;
+  const rowStep = single ? 40 : 30;
+  const headerH = 46;
+  const padBottom = 16;
+  const groupGap = 12;
+  const titleBlock = 132;
+  const fontSize = single ? 18 : 17;
+  const crownSize = single ? 18 : 16;
+  const title =
+    options.title ?? "Cold time to a first answer (lower is better)";
+
   const max = niceMax(
     Math.max(
       1,
@@ -579,93 +633,79 @@ function renderTime(index, cells, options = {}) {
       ),
     ),
   );
-  const ticks = [0, max * 0.25, max * 0.5, max * 0.75, max];
-  const bandHeight = rowHeight - 14;
-  const title =
-    options.title ?? "Cold time to a first answer (lower is better)";
-  const host = index.host
-    ? `${index.host.cpu}, ${index.host.cores} cores, ${index.host.ramGB} GB — ${index.host.os}`
-    : "";
 
-  const bands = rows
-    .map((row, rowIndex) => {
-      const center = chart.top + rowIndex * rowHeight + rowHeight / 2;
-      return `  <rect x="${chart.left}" y="${(center - bandHeight / 2).toFixed(1)}" width="${plotWidth}" height="${bandHeight.toFixed(1)}" fill="#111a24" fill-opacity="${rowIndex % 2 === 0 ? 0.6 : 0.25}" rx="3"/>`;
+  let cursor = titleBlock;
+  const groups = rows.map((row, gi) => {
+    const gHeight = headerH + row.values.length * rowStep + padBottom;
+    const g = { row, index: gi, y: cursor, height: gHeight };
+    cursor += gHeight + groupGap;
+    return g;
+  });
+  const height = Math.round(cursor - groupGap + margin);
+
+  const groupsSvg = groups
+    .map(({ row, index: gi, y, height: gh }) => {
+      const bestTotal = Math.min(
+        ...row.values.map((value) => value.buildMs + value.answerMs),
+      );
+      const band = `<rect x="${margin - 8}" y="${y.toFixed(1)}" width="${(width - 2 * margin + 16).toFixed(1)}" height="${gh.toFixed(1)}" rx="10" style="fill:#111a24;fill-opacity:${gi % 2 === 0 ? 0.55 : 0.25}"/>`;
+      const header = `<text x="${nameX}" y="${(y + 30).toFixed(1)}" style="fill:${COLORS.title};font-size:22px;font-weight:700">${escapeXml(row.label)}</text>
+   <text x="${valueRight}" y="${(y + 29).toFixed(1)}" style="fill:#94a3b8;font-size:15px;text-anchor:end">${row.scale.lines.toLocaleString()} lines</text>`;
+      const bars = row.values
+        .map((value, vi) => {
+          const rowTop = y + headerH + vi * rowStep;
+          const cy = rowTop + barHeight / 2;
+          const baseY = (cy + 6).toFixed(1);
+          const buildW = (value.buildMs / max) * barFull;
+          const answerW = (value.answerMs / max) * barFull;
+          const isBest = value.buildMs + value.answerMs === bestTotal;
+          const timeLabel = `${fmtCompact(value.buildMs)} / ${fmtCompact(value.answerMs)}`;
+          const nameColor = value.key === "baseline" ? "#9aa3b2" : value.color;
+          // Rectangular track + segments: cold time bars stay square so the
+          // faded index / solid LLM split reads as a clean vertical seam. Pill
+          // rounding would round short segments into blobs and blur the divide.
+          const glow = isBest
+            ? `<rect x="${(barLeft - 2).toFixed(1)}" y="${(rowTop - 2).toFixed(1)}" width="${(barFull + 4).toFixed(1)}" height="${(barHeight + 4).toFixed(1)}" rx="4" style="fill:none;stroke:${COLORS.ring};stroke-opacity:0.18;stroke-width:3.5"/>\n    `
+            : "";
+          const trackStroke = isBest
+            ? `stroke:${COLORS.ring};stroke-width:1.6`
+            : `stroke:#ffffff;stroke-opacity:0.05;stroke-width:1`;
+          const track = `<rect x="${barLeft}" y="${rowTop.toFixed(1)}" width="${barFull.toFixed(1)}" height="${barHeight}" rx="2" style="fill:${COLORS.track};${trackStroke}"/>`;
+          const buildSeg =
+            value.buildMs > 0
+              ? `<rect x="${barLeft}" y="${rowTop.toFixed(1)}" width="${buildW.toFixed(1)}" height="${barHeight}" style="fill:${value.color};fill-opacity:0.5"/>`
+              : "";
+          const answerSeg = `<rect x="${(barLeft + buildW).toFixed(1)}" y="${rowTop.toFixed(1)}" width="${answerW.toFixed(1)}" height="${barHeight}" style="fill:${value.color}"/>`;
+          const crown = isBest
+            ? crownMark(nameX - 22, cy - crownSize / 2, crownSize, COLORS.crown)
+            : "";
+          return `${glow}${track}${buildSeg}${answerSeg}${crown}
+    <text x="${nameX}" y="${baseY}" style="fill:${nameColor};font-size:${fontSize}px${isBest ? ";font-weight:700" : ""}">${escapeXml(value.label)}</text>
+    <text x="${valueRight}" y="${baseY}" style="fill:#e2e8f0;font-size:${fontSize}px;font-weight:${isBest ? 700 : 500};text-anchor:end">${escapeXml(timeLabel)}</text>`;
+        })
+        .join("\n    ");
+      return `${band}
+   ${header}
+   ${bars}`;
     })
-    .join("\n");
+    .join("\n  ");
 
-  const grid = ticks
-    .map((tick) => {
-      const x = chart.left + (tick / max) * plotWidth;
-      return [
-        `  <line x1="${x.toFixed(1)}" y1="${chart.top}" x2="${x.toFixed(1)}" y2="${chart.bottom}" stroke="#1f2937" stroke-width="1"/>`,
-        `  <text x="${x.toFixed(1)}" y="${chart.bottom + 22}" fill="#94a3b8" font-size="12" text-anchor="middle">${escapeXml(fmtSeconds(tick))}</text>`,
-      ].join("\n");
-    })
-    .join("\n");
+  // Worked-example key: the same two-tone bar the chart draws, so the reader
+  // learns which shade is which wait by seeing it once.
+  const shade = `<rect x="${margin}" y="70" width="62" height="24" rx="4" style="fill:#22d3ee;fill-opacity:0.35"/>
+ <text x="${margin + 31}" y="87" style="fill:#e2e8f0;font-size:13px;font-weight:700;text-anchor:middle">index</text>
+ <rect x="${margin + 62}" y="70" width="52" height="24" rx="4" style="fill:#22d3ee"/>
+ <text x="${margin + 88}" y="87" style="fill:#0b0f14;font-size:13px;font-weight:700;text-anchor:middle">LLM</text>
+ <text x="${margin + 128}" y="88" style="fill:${COLORS.muted};font-size:15px">faded = index build, solid = LLM answering — each bar is labelled index / LLM</text>`;
 
-  const bars = rows
-    .map((row, rowIndex) => {
-      const center = chart.top + rowIndex * rowHeight + rowHeight / 2;
-      const groupTop = center - (row.values.length * barStep) / 2;
-      const lines = [
-        `  <text x="${chart.left - 12}" y="${(center - 4).toFixed(1)}" fill="#e2e8f0" font-size="13" text-anchor="end">${escapeXml(row.label)}</text>`,
-        `  <text x="${chart.left - 12}" y="${(center + 12).toFixed(1)}" fill="#64748b" font-size="10" text-anchor="end">${row.scale.lines.toLocaleString()} lines</text>`,
-      ];
-      row.values.forEach((value, i) => {
-        const y = groupTop + i * barStep;
-        const buildWidth = (value.buildMs / max) * plotWidth;
-        const answerWidth = (value.answerMs / max) * plotWidth;
-        const textY = y + barHeight / 2 + 4;
-        if (value.buildMs > 0)
-          lines.push(
-            `  <rect x="${chart.left}" y="${y.toFixed(1)}" width="${buildWidth.toFixed(1)}" height="${barHeight}" fill="${value.color}" fill-opacity="0.35" rx="2"/>`,
-          );
-        lines.push(
-          `  <rect x="${(chart.left + buildWidth).toFixed(1)}" y="${y.toFixed(1)}" width="${answerWidth.toFixed(1)}" height="${barHeight}" fill="${value.color}" rx="2"/>`,
-        );
-        // Both halves of the wait, in the order they are paid: (index / LLM).
-        // A tool with no index to build says so with a zero, which is the point
-        // of putting them side by side.
-        lines.push(
-          `  <text x="${(chart.left + buildWidth + answerWidth + 8).toFixed(1)}" y="${textY.toFixed(1)}" fill="#cbd5f5" font-size="${single ? 13 : 11}">${escapeXml(`${fmtCompact(value.buildMs)} / ${fmtCompact(value.answerMs)}`)}</text>`,
-        );
-      });
-      return lines.join("\n");
-    })
-    .join("\n");
-
-  // Two legends, because a bar carries two facts. The colours say which tool;
-  // the worked example says which shade is which wait, using the same two-tone
-  // bar the chart draws, so the reader learns the encoding by seeing it once.
-  const legend = TOOLS.map((tool, i) =>
-    [
-      `  <rect x="${40 + i * 180}" y="76" width="13" height="13" fill="${tool.color}" rx="2"/>`,
-      `  <text x="${59 + i * 180}" y="87" fill="#cbd5f5" font-size="13.5">${escapeXml(tool.label)}</text>`,
-    ].join("\n"),
-  ).join("\n");
-  const shadeLegend = [
-    `  <rect x="40" y="102" width="60" height="17" fill="#22d3ee" fill-opacity="0.35" rx="2"/>`,
-    `  <rect x="100" y="102" width="40" height="17" fill="#22d3ee" rx="2"/>`,
-    `  <text x="70" y="115" fill="#e2e8f0" font-size="11" font-weight="bold" text-anchor="middle">index</text>`,
-    `  <text x="120" y="115" fill="#0b0f14" font-size="11" font-weight="bold" text-anchor="middle">LLM</text>`,
-    `  <text x="150" y="115" fill="#cbd5f5" font-size="13">${escapeXml("faded = index build, solid = LLM answering — each bar is labelled index / LLM")}</text>`,
-  ].join("\n");
-
-  return [
-    `<?xml version="1.0" encoding="utf-8" standalone="no"?>`,
-    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" version="1.1" role="img" aria-label="${escapeXml(title)}">`,
-    ` <rect width="${width}" height="${height}" fill="#0b0f14"/>`,
-    ` <text x="40" y="42" fill="#f8fafc" font-size="20" font-weight="bold" font-family="DejaVu Sans, Arial, sans-serif">${escapeXml(title)}</text>`,
-    ` <text x="40" y="62" fill="#64748b" font-size="12" font-family="DejaVu Sans, Arial, sans-serif">${escapeXml(host)}</text>`,
-    ` <text x="40" y="${height - 20}" fill="#64748b" font-size="12.5" font-family="DejaVu Sans, Arial, sans-serif">Cold checkout: build the tool's index once, then ask. LLM time is the median wall clock over four models and both prompt families; the baseline has no index to build.</text>`,
-    legend,
-    shadeLegend,
-    bands,
-    grid,
-    bars,
-    `</svg>`,
-  ].join("\n");
+  return `<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" version="1.1" role="img" aria-label="${escapeXml(title)}">
+ <defs><style type="text/css">text{font-family:DejaVu Sans, Arial, sans-serif}</style></defs>
+ <rect width="${width}" height="${height}" style="fill:${COLORS.background}"/>
+ <text x="${margin}" y="48" style="fill:${COLORS.title};font-size:27px;font-weight:700">${escapeXml(title)}</text>
+ ${shade}
+ ${groupsSvg}
+</svg>`;
 }
 
 /**

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphChart.tsx
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphChart.tsx
@@ -12,18 +12,6 @@ type ReductionSeriesKey = ITtscWebsiteBenchmarkGraph.ReductionSeriesKey;
 type ReductionTool = ITtscWebsiteBenchmarkGraph.ReductionTool;
 type ToolKey = ITtscWebsiteBenchmarkGraph.ToolKey;
 
-function LegendDot({ fill, label }: { fill: string; label: string }) {
-  return (
-    <span className="inline-flex items-center gap-1.5">
-      <span
-        className="inline-block h-2.5 w-2.5 rounded-full"
-        style={{ background: fill }}
-      />
-      {label}
-    </span>
-  );
-}
-
 function CrownMark({ active }: { active: boolean }) {
   return (
     <span
@@ -62,32 +50,11 @@ function toolReduction(row: ReductionRow, tool: ReductionTool): number | null {
   );
 }
 
-function reductionLabel(reduction: number | null): string {
-  if (reduction === null) return "n/a";
-  return `${reduction}%`;
-}
-
-function averageReduction(
-  rows: ReductionRow[],
-  toolKey: ToolKey,
-): number | null {
-  const values = rows
-    .map((row) => {
-      const tool = row.tools.find((candidate) => candidate.key === toolKey);
-      return tool ? toolReduction(row, tool) : null;
-    })
-    .filter((value): value is number => value !== null);
-  if (values.length === 0) return null;
-  return Math.round(
-    values.reduce((sum, value) => sum + value, 0) / values.length,
-  );
-}
-
 function reductionText(reduction: number | null): string {
   if (reduction === null) return "No data";
   return reduction >= 0
     ? `${reduction}% saved`
-    : `${-reduction}% over baseline`;
+    : `${-reduction}% over`;
 }
 
 interface TokenDomain {
@@ -118,28 +85,6 @@ function tokenBarStyle(
 ): { width: string } {
   if (tokens === null) return { width: "0%" };
   return { width: `${Math.max(1.2, tokenPosition(tokens, domain))}%` };
-}
-
-function tokenTicks(domain: TokenDomain): number[] {
-  // Clamp the domain first: a non-finite or non-positive max would otherwise
-  // poison the step computation below and hang the render loop.
-  const max =
-    Number.isFinite(domain.maxTokens) && domain.maxTokens > 0
-      ? domain.maxTokens
-      : 1;
-  const rawStep = max / 4;
-  const base = 10 ** Math.floor(Math.log10(rawStep));
-  const candidate =
-    [1, 2, 5, 10].find((factor) => factor * base >= rawStep) ?? 10 * base;
-  // step MUST be a finite positive number, or the for-loop never terminates.
-  const step = Number.isFinite(candidate) && candidate > 0 ? candidate : max;
-  const ticks: number[] = [];
-  // Hard cap on iterations as a final backstop: no data shape can ever spin
-  // this loop forever.
-  for (let tick = 0; tick <= max && ticks.length < 64; tick += step)
-    ticks.push(tick);
-  if (ticks.length <= 1) return [0, max];
-  return ticks;
 }
 
 function fmtTokenShort(tokens: number): string {
@@ -330,37 +275,6 @@ function ReductionTooltip({
   );
 }
 
-function ChartLegend() {
-  return (
-    <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 font-mono text-[10px] text-neutral-500">
-      <LegendDot fill="#6f7787" label="baseline" />
-      <LegendDot
-        fill={TtscWebsiteBenchmarkGraphUi.ACCENT}
-        label="@ttsc/graph"
-      />
-      <LegendDot
-        fill={TtscWebsiteBenchmarkGraphUi.CODEGRAPH_TEXT}
-        label="codegraph"
-      />
-      <LegendDot
-        fill={TtscWebsiteBenchmarkGraphUi.CODEBASE_MEMORY_TEXT}
-        label="codebase-memory"
-      />
-      <LegendDot
-        fill={TtscWebsiteBenchmarkGraphUi.SERENA_TEXT}
-        label="serena"
-      />
-      <span className="text-neutral-400">lower is better</span>
-      <span className="text-neutral-600">
-        bars show token usage; right labels show tokens and baseline reduction
-      </span>
-      <span className="text-neutral-600">
-        crown marks the lowest-token series
-      </span>
-    </div>
-  );
-}
-
 export default function TtscWebsiteBenchmarkGraphChart({
   eyebrow,
   title,
@@ -374,24 +288,10 @@ export default function TtscWebsiteBenchmarkGraphChart({
   rows: ReductionRow[];
   aside?: string;
 }) {
-  const {
-    ttscAverage,
-    codegraphAverage,
-    codebaseMemoryAverage,
-    serenaAverage,
-    domain,
-    ticks,
-  } = useMemo(() => {
-    const d = tokenDomain(rows);
-    return {
-      ttscAverage: averageReduction(rows, "ttsc"),
-      codegraphAverage: averageReduction(rows, "codegraph"),
-      codebaseMemoryAverage: averageReduction(rows, "codebaseMemory"),
-      serenaAverage: averageReduction(rows, "serena"),
-      domain: d,
-      ticks: tokenTicks(d),
-    };
-  }, [rows]);
+  const { domain } = useMemo(
+    () => ({ domain: tokenDomain(rows) }),
+    [rows],
+  );
 
   return (
     <section
@@ -403,189 +303,120 @@ export default function TtscWebsiteBenchmarkGraphChart({
         description={description}
         aside={aside}
       />
-      <div className="space-y-3 px-5 py-4">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <ChartLegend />
-          <div className="flex flex-wrap gap-2 font-mono text-[10px] tabular-nums">
-            {ttscAverage !== null ? (
-              <span className="rounded-full border border-[#1f3e46] bg-[#0d1a1d] px-2 py-1 text-[#36e2ee]">
-                @ttsc/graph avg {reductionLabel(ttscAverage)}
-              </span>
-            ) : null}
-            {codegraphAverage !== null ? (
-              <span className="rounded-full border border-[#49351a] bg-[#1b140b] px-2 py-1 text-[#f5b042]">
-                codegraph avg {reductionLabel(codegraphAverage)}
-              </span>
-            ) : null}
-            {codebaseMemoryAverage !== null ? (
-              <span className="rounded-full border border-[#2f4b28] bg-[#111a10] px-2 py-1 text-[#8bdc65]">
-                codebase-memory avg {reductionLabel(codebaseMemoryAverage)}
-              </span>
-            ) : null}
-            {serenaAverage !== null ? (
-              <span className="rounded-full border border-[#553066] bg-[#1a0f21] px-2 py-1 text-[#e879f9]">
-                serena avg {reductionLabel(serenaAverage)}
-              </span>
-            ) : null}
-          </div>
-        </div>
-
-        <div className="grid grid-cols-[9rem_1fr] items-center gap-3 border-y border-[#1a1f29] py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-600 sm:grid-cols-[12rem_1fr]">
-          <span>case</span>
-          <div className="relative h-4">
-            <span className="sr-only">token usage scale</span>
-            {ticks.map((tick) => {
-              const position = tokenPosition(tick, domain);
-              return (
-                <span
-                  key={tick}
-                  className={`absolute top-0 ${
-                    position <= 1
-                      ? "text-left"
-                      : position >= 99
-                        ? "-translate-x-full text-right"
-                        : "-translate-x-1/2 text-center"
-                  }`}
-                  style={{ left: `${position}%` }}
-                >
-                  {fmtTokenShort(tick)}
+      <p className="border-b border-[#222834] px-5 py-2.5 font-mono text-[11px] text-neutral-400">
+        lower is better
+      </p>
+      <div className="space-y-1.5 px-3 py-3">
+        {rows.map((row, index) => {
+          const bestSeries = lowestTokenSeries(row);
+          const baselineBest = bestSeries === "baseline";
+          return (
+            <div
+              key={row.id}
+              className="space-y-1 rounded-lg px-3.5 py-2.5"
+              style={{
+                // Alternating bands so each case reads as a block, matching the
+                // Time-to-answer chart.
+                backgroundColor:
+                  index % 2 === 0 ? "rgba(17,26,36,0.6)" : "rgba(17,26,36,0.25)",
+              }}
+            >
+              <div className="flex items-baseline justify-between gap-3 pb-0.5">
+                <span className="truncate text-[13px] font-semibold text-neutral-100">
+                  {row.label}
                 </span>
-              );
-            })}
-          </div>
-        </div>
+                {row.meta ? (
+                  <span className="shrink-0 font-mono text-[11px] text-neutral-400">
+                    {row.meta}
+                  </span>
+                ) : null}
+              </div>
 
-        <div className="space-y-4">
-          {rows.map((row) => {
-            const bestSeries = lowestTokenSeries(row);
-            const baselineBest = bestSeries === "baseline";
-            return (
-              <div
-                key={row.id}
-                className="grid gap-2 sm:grid-cols-[12rem_minmax(0,1fr)] sm:items-start"
-              >
-                <div className="min-w-0">
-                  <p className="truncate text-[13px] font-medium text-neutral-100">
-                    {row.label}
-                  </p>
-                  {row.meta ? (
-                    <p className="mt-0.5 truncate font-mono text-[10px] text-neutral-500">
-                      {row.meta}
-                    </p>
-                  ) : null}
+              <div className="flex items-center gap-2.5">
+                <span
+                  className={`inline-flex w-32 shrink-0 items-center gap-1 truncate font-mono text-[11px] ${
+                    baselineBest
+                      ? "font-semibold text-neutral-100"
+                      : "text-neutral-400"
+                  }`}
+                >
+                  <CrownMark active={baselineBest} />
+                  <span className="truncate">baseline</span>
+                </span>
+                <div
+                  className={`relative h-3.5 flex-1 overflow-hidden rounded-full bg-[#161b24] ring-1 ring-inset ${
+                    baselineBest
+                      ? "shadow-[0_0_14px_rgba(54,226,238,0.16)] ring-[#d7f9ff]/70"
+                      : "ring-white/[0.04]"
+                  }`}
+                >
+                  <div
+                    className="absolute top-0 h-full rounded-full bg-[#6f7787]"
+                    style={tokenBarStyle(row.baseline.tokens, domain)}
+                  />
                 </div>
-                <div className="space-y-1.5">
-                  <div className="grid grid-cols-[5.75rem_minmax(0,1fr)_7.5rem] items-center gap-2">
+                <span
+                  className={`w-24 shrink-0 whitespace-nowrap text-right font-mono text-[11px] tabular-nums ${
+                    baselineBest ? "text-neutral-50" : "text-neutral-200"
+                  }`}
+                >
+                  {tokenUsageText(row.baseline.tokens)}
+                </span>
+              </div>
+
+              {row.tools.map((tool) => {
+                const reduction = toolReduction(row, tool);
+                const missing = !tool.metrics;
+                const best = bestSeries === tool.key;
+                return (
+                  <div
+                    key={tool.key}
+                    className="group relative flex items-center gap-2.5"
+                  >
                     <span
-                      className={`inline-flex min-w-0 items-center gap-1 truncate font-mono text-[10px] ${
-                        baselineBest
-                          ? "font-semibold text-neutral-100"
-                          : "text-neutral-500"
+                      className={`inline-flex w-32 shrink-0 items-center gap-1 truncate font-mono text-[11px] ${
+                        best ? "font-semibold" : ""
                       }`}
+                      style={{ color: tool.textColor }}
                     >
-                      <CrownMark active={baselineBest} />
-                      <span className="truncate">baseline</span>
+                      <CrownMark active={best} />
+                      <span className="truncate">{tool.label}</span>
                     </span>
                     <div
-                      className={`relative h-3.5 overflow-hidden rounded-full bg-[#161b24] ring-1 ring-inset ${
-                        baselineBest
+                      className={`relative h-3.5 flex-1 overflow-hidden rounded-full bg-[#161b24] ring-1 ring-inset ${
+                        best
                           ? "shadow-[0_0_14px_rgba(54,226,238,0.16)] ring-[#d7f9ff]/70"
                           : "ring-white/[0.04]"
                       }`}
                     >
                       <div
-                        className="absolute top-0 h-full rounded-full bg-[#6f7787]"
-                        style={tokenBarStyle(row.baseline.tokens, domain)}
+                        className={`absolute top-0 h-full rounded-full ${
+                          missing ? "opacity-25" : ""
+                        }`}
+                        style={{
+                          ...tokenBarStyle(tool.metrics?.tokens ?? null, domain),
+                          background: missing ? "#303644" : tool.fill,
+                        }}
                       />
                     </div>
                     <span
-                      className={`text-right font-mono text-[10px] leading-tight tabular-nums ${
-                        baselineBest ? "text-neutral-50" : "text-neutral-300"
+                      className={`w-24 shrink-0 whitespace-nowrap text-right font-mono text-[11px] font-medium tabular-nums ${
+                        best
+                          ? "text-[#36e2ee]"
+                          : reduction !== null && reduction < 0
+                            ? "text-rose-400"
+                            : "text-neutral-300"
                       }`}
                     >
-                      <span className="block">
-                        {tokenUsageText(row.baseline.tokens)}
-                      </span>
-                      <span
-                        className={`block ${
-                          baselineBest ? "text-[#36e2ee]" : "text-neutral-600"
-                        }`}
-                      >
-                        baseline
-                      </span>
+                      {tool.metrics ? reductionText(reduction) : "no data"}
                     </span>
+                    <ReductionTooltip row={row} tool={tool} />
                   </div>
-                  {row.tools.map((tool) => {
-                    const reduction = toolReduction(row, tool);
-                    const missing = !tool.metrics;
-                    const best = bestSeries === tool.key;
-                    return (
-                      <div
-                        key={tool.key}
-                        className="group relative grid grid-cols-[5.75rem_minmax(0,1fr)_7.5rem] items-center gap-2"
-                      >
-                        <span
-                          className={`inline-flex min-w-0 items-center gap-1 truncate font-mono text-[10px] ${
-                            best ? "font-semibold" : ""
-                          }`}
-                          style={{ color: tool.textColor }}
-                        >
-                          <CrownMark active={best} />
-                          <span className="truncate">{tool.label}</span>
-                        </span>
-                        <div
-                          className={`relative h-3.5 overflow-hidden rounded-full bg-[#161b24] ring-1 ring-inset ${
-                            best
-                              ? "shadow-[0_0_14px_rgba(54,226,238,0.16)] ring-[#d7f9ff]/70"
-                              : "ring-white/[0.04]"
-                          }`}
-                        >
-                          <div
-                            className={`absolute top-0 h-full rounded-full ${
-                              missing ? "opacity-25" : ""
-                            }`}
-                            style={{
-                              ...tokenBarStyle(
-                                tool.metrics?.tokens ?? null,
-                                domain,
-                              ),
-                              background: missing ? "#303644" : tool.fill,
-                            }}
-                          />
-                        </div>
-                        <span
-                          className={`text-right font-mono text-[10px] leading-tight tabular-nums ${
-                            best
-                              ? "text-neutral-50"
-                              : reduction !== null && reduction < 0
-                                ? "text-rose-400"
-                                : "text-neutral-300"
-                          }`}
-                        >
-                          <span className="block">
-                            {tool.metrics
-                              ? tokenUsageText(tool.metrics.tokens)
-                              : "n/a"}
-                          </span>
-                          <span
-                            className={`block ${
-                              best ? "text-[#36e2ee]" : "text-neutral-500"
-                            }`}
-                          >
-                            {tool.metrics
-                              ? reductionText(reduction)
-                              : "no data"}
-                          </span>
-                        </span>
-                        <ReductionTooltip row={row} tool={tool} />
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          })}
-        </div>
+                );
+              })}
+            </div>
+          );
+        })}
       </div>
     </section>
   );

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphCommon.tsx
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphCommon.tsx
@@ -30,7 +30,7 @@ function commonRowsForModel(
       tools: TtscWebsiteBenchmarkGraphReductionTools(model),
     });
   }
-  return rows;
+  return rows.sort((a, b) => a.label.localeCompare(b.label));
 }
 
 function TtscWebsiteBenchmarkGraphCommonChart({

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphData.ts
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphData.ts
@@ -98,6 +98,8 @@ function repoLabel(repo: string): string {
       return "Vue";
     case "zod":
       return "Zod";
+    case "shopping-backend":
+      return "Shopping";
     default:
       return repo;
   }

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphDedicated.tsx
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphDedicated.tsx
@@ -54,19 +54,29 @@ function TtscWebsiteBenchmarkGraphDedicatedGroup({
 }: {
   mode: PromptModeGroup;
 }) {
+  const projects = useMemo(
+    () =>
+      [...mode.projects].sort((a, b) =>
+        TtscWebsiteBenchmarkGraphData.repoLabel(a.repo).localeCompare(
+          TtscWebsiteBenchmarkGraphData.repoLabel(b.repo),
+        ),
+      ),
+    [mode],
+  );
+
   const [activeProjectId, setActiveProjectId] = useState<string | null>(() =>
     TtscWebsiteBenchmarkGraphSearchParam.initial("graphDedicatedProject"),
   );
   const activeProject =
     (activeProjectId
-      ? mode.projects.find((project) => project.id === activeProjectId)
-      : undefined) ?? mode.projects[0];
+      ? projects.find((project) => project.id === activeProjectId)
+      : undefined) ?? projects[0];
 
   return (
     <section className="space-y-3">
       <TtscWebsiteBenchmarkGraphTabs
         label="Project"
-        items={mode.projects.map((project) => ({
+        items={projects.map((project) => ({
           id: project.id,
           label: TtscWebsiteBenchmarkGraphData.repoLabel(project.repo),
         }))}

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphTime.tsx
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphTime.tsx
@@ -177,6 +177,33 @@ function TimeTooltip({
   );
 }
 
+/** Same crown the token chart draws, marking the fastest first answer. */
+function CrownMark({ active }: { active: boolean }) {
+  return (
+    <span
+      className={`inline-flex h-3 w-3 shrink-0 items-center justify-center ${
+        active ? "text-[#36e2ee]" : "text-transparent"
+      }`}
+      aria-hidden="true"
+    >
+      <svg viewBox="0 0 16 16" className="h-3 w-3" fill="none">
+        <path
+          d="M2.5 5.5 5.4 8l2.6-4 2.6 4 2.9-2.5-.8 6H3.3l-.8-6Z"
+          stroke="currentColor"
+          strokeLinejoin="round"
+          strokeWidth="1.35"
+        />
+        <path
+          d="M3.5 12.5h9"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeWidth="1.35"
+        />
+      </svg>
+    </span>
+  );
+}
+
 function Bars({
   row,
   max,
@@ -186,30 +213,46 @@ function Bars({
   max: number;
   thick: boolean;
 }) {
+  // Winner is the fastest first answer: the smallest index-build + LLM total.
+  const bestTotal = Math.min(
+    ...row.bars.map((bar) => (bar.buildMs ?? 0) + bar.answerMs),
+  );
   return (
     <div className={thick ? "space-y-2" : "space-y-1"}>
       {row.bars.map((bar) => {
         const tool = TOOLS.find((item) => item.id === bar.tool)!;
         const build = bar.buildMs ?? 0;
         const total = build + bar.answerMs;
+        const best = total === bestTotal;
         return (
           <div key={bar.tool} className="group relative flex items-center gap-2">
             <span
-              className="w-32 shrink-0 truncate font-mono text-[11px]"
+              className={`inline-flex w-32 shrink-0 items-center gap-1 truncate font-mono text-[12px] ${
+                best ? "font-semibold" : ""
+              }`}
               style={{ color: tool.text }}
             >
-              {tool.label}
+              <CrownMark active={best} />
+              <span className="truncate">{tool.label}</span>
             </span>
             <div
-              className={`relative flex-1 overflow-hidden rounded-sm bg-[#0c0e13] ${thick ? "h-6" : "h-3.5"}`}
+              className={`relative flex-1 overflow-hidden rounded-sm bg-[#0c0e13] ring-1 ring-inset ${
+                thick ? "h-7" : "h-4"
+              } ${
+                best
+                  ? "shadow-[0_0_14px_rgba(54,226,238,0.16)] ring-[#d7f9ff]/70"
+                  : "ring-white/[0.04]"
+              }`}
             >
+              {/* Rectangular two-tone: the faded index / solid LLM split must
+                  read as a clean vertical seam, so no pill rounding here. */}
               <span
                 className="absolute inset-y-0 left-0 flex"
                 style={{ width: `${Math.max(1.5, (total / max) * 100)}%` }}
               >
                 {build > 0 ? (
                   <span
-                    className="h-full rounded-l-sm opacity-40"
+                    className="h-full opacity-[0.55]"
                     style={{
                       width: `${(build / total) * 100}%`,
                       background: tool.fill,
@@ -217,12 +260,16 @@ function Bars({
                   />
                 ) : null}
                 <span
-                  className="h-full flex-1 rounded-r-sm"
+                  className="h-full flex-1"
                   style={{ background: tool.fill }}
                 />
               </span>
             </div>
-            <span className="w-28 shrink-0 text-right font-mono text-[12px] tabular-nums text-neutral-200">
+            <span
+              className={`w-28 shrink-0 text-right font-mono text-[13px] tabular-nums ${
+                best ? "text-neutral-50" : "text-neutral-200"
+              }`}
+            >
               {fmtCompact(build)} / {fmtCompact(bar.answerMs)}
             </span>
             <TimeTooltip row={row} bar={bar} tool={tool} />
@@ -240,24 +287,22 @@ function Bars({
 function ShadeLegend() {
   return (
     <div className="flex items-center gap-3 border-b border-[#1c212b] px-5 py-2.5">
-      <span className="flex h-4 overflow-hidden rounded-sm font-mono text-[9px] font-bold leading-4">
-        <span
-          className="px-2 text-center text-neutral-100"
-          style={{
-            background: TtscWebsiteBenchmarkGraphUi.TTSC_FILL as string,
-            opacity: 0.4,
-          }}
-        >
-          index
+      <span className="flex h-5 overflow-hidden rounded-sm font-mono text-[10px] font-bold leading-5">
+        <span className="relative flex items-center px-2 text-neutral-100">
+          <span
+            className="absolute inset-0 opacity-40"
+            style={{ background: TtscWebsiteBenchmarkGraphUi.TTSC_FILL as string }}
+          />
+          <span className="relative">index</span>
         </span>
         <span
-          className="px-2 text-center text-[#0b0f14]"
+          className="flex items-center px-2 text-[#0b0f14]"
           style={{ background: TtscWebsiteBenchmarkGraphUi.TTSC_FILL as string }}
         >
           LLM
         </span>
       </span>
-      <span className="text-[11px] text-neutral-400">
+      <span className="text-[12px] text-neutral-300">
         faded = index build, solid = LLM answering — each bar is labelled index
         / LLM
       </span>
@@ -318,18 +363,26 @@ export default function TtscWebsiteBenchmarkGraphTime({
             : "Cold time to a first answer"
         }
         description="Build the tool's index once, then ask. The faded segment is the index build, the solid one the median wall clock the LLM spent answering."
-        aside="LLM time is the median across four models and both prompt families, so every tool faces the same mix."
       />
       <ShadeLegend />
-      <div className="space-y-4 px-5 py-4">
-        {rows.map((row) => (
-          <div key={row.project} className="space-y-1.5">
+      <div className="space-y-1.5 px-3 py-3">
+        {rows.map((row, index) => (
+          <div
+            key={row.project}
+            className="space-y-1.5 rounded-lg px-3.5 py-2.5"
+            style={{
+              // Alternating bands, like the SVG chart, so each project reads as
+              // a block before the eye starts picking tools out of it.
+              backgroundColor:
+                index % 2 === 0 ? "rgba(17,26,36,0.6)" : "rgba(17,26,36,0.25)",
+            }}
+          >
             <div className="flex items-baseline justify-between gap-3">
               <span className="font-mono text-[13px] font-semibold text-neutral-100">
                 {row.label}
               </span>
               {row.lines > 0 ? (
-                <span className="font-mono text-[11px] tabular-nums text-neutral-500">
+                <span className="font-mono text-[12px] tabular-nums text-neutral-400">
                   {row.lines.toLocaleString()} lines
                 </span>
               ) : null}

--- a/website/src/content/docs/benchmark/graph.mdx
+++ b/website/src/content/docs/benchmark/graph.mdx
@@ -1,6 +1,5 @@
 import TtscWebsiteBenchmarkGraphCommon from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphCommon";
 import TtscWebsiteBenchmarkGraphDedicated from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphDedicated";
-import TtscWebsiteBenchmarkGraphStructural from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphStructural";
 import TtscWebsiteBenchmarkGraphTime from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphTime";
 
 # Code Graph (MCP)
@@ -38,20 +37,6 @@ The wait is not evenly distributed. On VS Code's three million lines, `codegraph
 Every tool is given the index its own documentation prescribes: `codegraph init`, `codebase-memory-mcp index_repository` in its default `full` mode (the mode the token charts above also ran), and `serena project index`, which serena recommends for larger projects. Repositories are ordered by the size of the program each index was built from.
 
 <TtscWebsiteBenchmarkGraphTime />
-
-### VS Code, alone
-
-Three million lines is where the index question stops being academic: it is the difference between a tool that answers while you pour a coffee and one you configure before lunch. The same bars as above, isolated.
-
-<TtscWebsiteBenchmarkGraphTime project="vscode" />
-
-## Structural Coverage
-
-This panel shows what `@ttsc/graph` resolves before any agent prompt runs.
-
-It is not a Common or Dedicated prompt lane. It reports graph shape, edge coverage, and setup timing so the token charts have a structural baseline.
-
-<TtscWebsiteBenchmarkGraphStructural />
 
 ## How to read it
 

--- a/website/src/content/docs/benchmark/index.mdx
+++ b/website/src/content/docs/benchmark/index.mdx
@@ -1,4 +1,5 @@
 import TtscWebsiteBenchmarkGraphCommon from "../../../components/benchmark/graph/TtscWebsiteBenchmarkGraphCommon";
+import TtscWebsiteBenchmarkPerformanceSummary from "../../../components/benchmark/TtscWebsiteBenchmarkPerformanceSummary";
 
 # Benchmark
 
@@ -17,3 +18,5 @@ The overview below uses the same shared onboarding prompt across every project w
 [The compiler-performance benchmark](/docs/benchmark/performance) measures wall-clock time when a real TypeScript project moves from the legacy `tsc` + `eslint` path to TypeScript-Go backed builds, checks, and linting. The dashboard covers build, type-check, lint, and format across real open-source repositories, single-threaded and multi-threaded.
 
 vscode, 6,093 TypeScript files across a large application monorepo, is the flagship example. At 8 checker workers, `ttsc` builds vscode in around 8 s versus roughly 94 s for legacy `tsc`, and type-checks it in around 6.5 s versus roughly 73 s. The full dashboard covers nestjs, vue, zod, typeorm, rxjs, and shopping-backend as well.
+
+<TtscWebsiteBenchmarkPerformanceSummary />


### PR DESCRIPTION
## Intent
Make the graph benchmark charts readable and consistent between the website (React) and the generated SVG embeds.

## Scope
- **Layout**: unify the token (common/dedicated) and cold-time charts on a banded, per-project layout — project as a group header, one row per tool, alternating zebra bands.
- **Labels**: baseline shows tokens, the rest show `% saved / over`; repos alphabetized with proper casing (`Shopping`, `VS Code`, …); dedicated project tabs alphabetized.
- **Legend**: collapsed the duplicated colour legend + average pills into one vertical key, then dropped the top legend once row labels carry identity (slim `lower is better` caption remains).
- **Readability**: higher contrast + larger type across both charts; fixed the washed-out `index` legend chip; removed a redundant faint aside block.
- **Cold time**: bars kept **rectangular** so the faded-index / solid-LLM split reads as a clean vertical seam (React + SVG).
- **SVG generator**: restyled to match the website (banded groups, bigger type, rectangular time bars).
- **Docs**: trimmed the graph page (removed "VS Code, alone" + "Structural Coverage") and restored the orphaned compiler-performance summary on the benchmark overview.

## Test plan
- Verified every chart variant (common, dedicated, cold time) live via headless render at each step.
- Regenerated all SVG/PNG embeds and inspected them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)