### PR TITLE
fix(website): order the cold-time chart alphabetically

### DIFF
--- a/website/build/graph-benchmark-svg.cjs
+++ b/website/build/graph-benchmark-svg.cjs
@@ -600,7 +600,7 @@ function renderTime(index, cells, options = {}) {
       }).filter((value) => value.answerMs > 0),
     }))
     .filter((row) => row.values.length > 0)
-    .sort((a, b) => a.scale.lines - b.scale.lines);
+    .sort((a, b) => a.label.localeCompare(b.label));
 
   // Banded blocks like the grouped chart: repo header + one row per tool, the
   // two-tone bar (faded index build + solid LLM answer) inside a full-width

--- a/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphTime.tsx
+++ b/website/src/components/benchmark/graph/TtscWebsiteBenchmarkGraphTime.tsx
@@ -110,7 +110,7 @@ function buildRows(report: Report, only?: string): TimeRow[] {
       };
     })
     .filter((row) => row.bars.length > 0)
-    .sort((a, b) => a.lines - b.lines);
+    .sort((a, b) => a.label.localeCompare(b.label));
 }
 
 /**


### PR DESCRIPTION
## Intent
The cold-time chart was still ordered by program size while the other graph benchmark charts are alphabetical. Make it consistent.

## Scope
- Sort **Cold time to a first answer** rows by repo label (`localeCompare`) instead of program size — both the React chart (`TtscWebsiteBenchmarkGraphTime`) and the generated SVG (`renderTime`).

## Context
Supersedes the alphabetical-ordering intent of #584's predecessor #572 (closed); the Shopping label + Common/Dedicated ordering already landed in #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)