### PR TITLE
fix(lint): report valid-typeof only on equality comparisons

### DIFF
--- a/packages/lint/linthost/rules_logic.go
+++ b/packages/lint/linthost/rules_logic.go
@@ -311,7 +311,9 @@ func (useIsNaN) Check(ctx *Context, node *shimast.Node) {
 }
 
 // validTypeof: typeof expressions can only be compared to known type
-// strings. Catches `typeof x === "stirng"`.
+// strings. Catches `typeof x === "stirng"`. Scoped to the four equality
+// operators, like ESLint's own OPERATORS set — a relational comparison such as
+// `typeof x < "m"` orders two strings rather than naming a type.
 // https://eslint.org/docs/latest/rules/valid-typeof
 type validTypeof struct{}
 
@@ -322,7 +324,7 @@ func (validTypeof) Check(ctx *Context, node *shimast.Node) {
   if expr == nil || expr.OperatorToken == nil {
     return
   }
-  if !isComparisonOperator(expr.OperatorToken.Kind) {
+  if !isEqualityOperator(expr.OperatorToken.Kind) {
     return
   }
   left := stripParens(expr.Left)

--- a/packages/lint/linthost/rules_security.go
+++ b/packages/lint/linthost/rules_security.go
@@ -756,17 +756,6 @@ func isFalseLiteral(node *shimast.Node) bool {
   return ok && !value
 }
 
-func isEqualityOperator(kind shimast.Kind) bool {
-  switch kind {
-  case shimast.KindEqualsEqualsToken,
-    shimast.KindEqualsEqualsEqualsToken,
-    shimast.KindExclamationEqualsToken,
-    shimast.KindExclamationEqualsEqualsToken:
-    return true
-  }
-  return false
-}
-
 func containsSecretIdentifier(node *shimast.Node) bool {
   found := false
   walkDescendants(node, func(child *shimast.Node) {

--- a/packages/lint/linthost/rules_self.go
+++ b/packages/lint/linthost/rules_self.go
@@ -72,7 +72,9 @@ func (noSelfCompare) Check(ctx *Context, node *shimast.Node) {
 }
 
 // isComparisonOperator reports whether kind is one of the eight standard
-// comparison operators: ==, ===, !=, !==, <, >, <=, >=.
+// comparison operators: ==, ===, !=, !==, <, >, <=, >=. Rules whose upstream
+// operator set spans both equality and ordering (no-self-compare, use-isnan,
+// no-compare-neg-zero, yoda) gate on this one.
 func isComparisonOperator(kind shimast.Kind) bool {
   switch kind {
   case
@@ -84,6 +86,24 @@ func isComparisonOperator(kind shimast.Kind) bool {
     shimast.KindGreaterThanToken,
     shimast.KindLessThanEqualsToken,
     shimast.KindGreaterThanEqualsToken:
+    return true
+  }
+  return false
+}
+
+// isEqualityOperator reports whether kind is one of the four equality
+// operators: ==, ===, !=, !==. It is the sameness-testing half of
+// isComparisonOperator, for the rules whose upstream operator set stops at
+// equality (valid-typeof, security/detect-possible-timing-attacks): the four
+// relational operators order their operands instead of testing them for
+// identity.
+func isEqualityOperator(kind shimast.Kind) bool {
+  switch kind {
+  case
+    shimast.KindEqualsEqualsToken,
+    shimast.KindEqualsEqualsEqualsToken,
+    shimast.KindExclamationEqualsToken,
+    shimast.KindExclamationEqualsEqualsToken:
     return true
   }
   return false

--- a/packages/lint/test/rules/runtime-safety/valid_typeof_equality_operator_scope_test.go
+++ b/packages/lint/test/rules/runtime-safety/valid_typeof_equality_operator_scope_test.go
@@ -1,0 +1,168 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestValidTypeofEqualityOperatorScope verifies valid-typeof reports only across
+// the four equality operators while its comparison-operator peers keep the
+// relational ones.
+//
+// Upstream valid-typeof gates on OPERATORS = {==, ===, !=, !==}: a relational
+// comparison orders two strings rather than naming a type, so `typeof x < "m"`
+// is not a mistyped type name and ESLint stays silent. This port used to gate on
+// the shared isComparisonOperator, which also admits <, >, <= and >=, and
+// reported there. Both halves of the fix need pinning: the equality arm must
+// still catch every typo shape (either operand order, parentheses, static
+// template literal), and use-isnan, no-self-compare, no-compare-neg-zero and
+// yoda — whose upstream operator sets do span ordering — must still report on
+// relational operators, proving the shared predicate was not narrowed under them.
+//
+//  1. Wrap the comparison under test as the sole expression of a two-parameter
+//     function, so every finding lands on line 2.
+//  2. Run the single rule the case names through the native engine.
+//  3. Compare normalized rule/severity/line findings against the expectation,
+//     requiring zero findings for the arms upstream leaves silent.
+func TestValidTypeofEqualityOperatorScope(t *testing.T) {
+  tests := []struct {
+    name       string
+    rule       string
+    expression string
+    wantReport bool
+  }{
+    {
+      name:       "valid-typeof reports a typo behind strict equality",
+      rule:       "valid-typeof",
+      expression: `typeof x === "stirng"`,
+      wantReport: true,
+    },
+    {
+      name:       "valid-typeof reports a typo behind loose equality",
+      rule:       "valid-typeof",
+      expression: `typeof x == "stirng"`,
+      wantReport: true,
+    },
+    {
+      name:       "valid-typeof reports a typo behind strict inequality",
+      rule:       "valid-typeof",
+      expression: `typeof x !== "stirng"`,
+      wantReport: true,
+    },
+    {
+      name:       "valid-typeof reports a typo behind loose inequality",
+      rule:       "valid-typeof",
+      expression: `typeof x != "stirng"`,
+      wantReport: true,
+    },
+    {
+      name:       "valid-typeof reports a typo with typeof on the right",
+      rule:       "valid-typeof",
+      expression: `"stirng" === typeof x`,
+      wantReport: true,
+    },
+    {
+      name:       "valid-typeof reports a typo through parentheses",
+      rule:       "valid-typeof",
+      expression: `(typeof x) === ("stirng")`,
+      wantReport: true,
+    },
+    {
+      name:       "valid-typeof reports a typo in a static template literal",
+      rule:       "valid-typeof",
+      expression: "typeof x === `stirng`",
+      wantReport: true,
+    },
+    {
+      name:       "valid-typeof accepts a known type string",
+      rule:       "valid-typeof",
+      expression: `typeof x === "string"`,
+    },
+    {
+      name:       "valid-typeof accepts a known type in a static template literal",
+      rule:       "valid-typeof",
+      expression: "typeof x === `string`",
+    },
+    {
+      name:       "valid-typeof ignores a less-than comparison",
+      rule:       "valid-typeof",
+      expression: `typeof x < "m"`,
+    },
+    {
+      name:       "valid-typeof ignores a greater-than-or-equal comparison",
+      rule:       "valid-typeof",
+      expression: `typeof x >= "z"`,
+    },
+    {
+      name:       "valid-typeof ignores a greater-than comparison with typeof on the right",
+      rule:       "valid-typeof",
+      expression: `"m" > typeof x`,
+    },
+    {
+      name:       "valid-typeof ignores a less-than-or-equal comparison",
+      rule:       "valid-typeof",
+      expression: `typeof x <= "stirng"`,
+    },
+    {
+      name:       "valid-typeof ignores a relational comparison against a static template literal",
+      rule:       "valid-typeof",
+      expression: "typeof x < `stirng`",
+    },
+    {
+      name:       "valid-typeof ignores a comparison between two typeof operands",
+      rule:       "valid-typeof",
+      expression: `typeof x === typeof y`,
+    },
+    {
+      name:       "valid-typeof ignores an equality comparison without typeof",
+      rule:       "valid-typeof",
+      expression: `x === "stirng"`,
+    },
+    {
+      name:       "use-isnan still reports a relational NaN comparison",
+      rule:       "use-isnan",
+      expression: `x < NaN`,
+      wantReport: true,
+    },
+    {
+      name:       "no-self-compare still reports a relational self comparison",
+      rule:       "no-self-compare",
+      expression: `x >= x`,
+      wantReport: true,
+    },
+    {
+      name:       "no-compare-neg-zero still reports a relational negative zero comparison",
+      rule:       "no-compare-neg-zero",
+      expression: `x > -0`,
+      wantReport: true,
+    },
+    {
+      name:       "yoda still reports a relational literal-first comparison",
+      rule:       "yoda",
+      expression: `1 <= x`,
+      wantReport: true,
+    },
+  }
+
+  for _, test := range tests {
+    t.Run(test.name, func(t *testing.T) {
+      source := "function f(x: any, y: any) {\n  return " + test.expression + ";\n}\n"
+      file := parseTS(t, source)
+      findings := NewEngine(RuleConfig{test.rule: SeverityError}).Run([]*shimast.SourceFile{file}, nil)
+      want := []ruleExpectation{}
+      if test.wantReport {
+        want = append(want, ruleExpectation{Rule: test.rule, Severity: SeverityError, Line: 2})
+      }
+      got := normalizeRuleFindings(file, findings)
+      if len(got) != len(want) {
+        t.Fatalf("%s on %q: want %+v, got %+v", test.rule, test.expression, want, got)
+      }
+      for index := range want {
+        if got[index] != want[index] {
+          t.Fatalf("%s on %q [%d]: want %+v, got %+v", test.rule, test.expression, index, want[index], got[index])
+        }
+      }
+    })
+  }
+}

--- a/packages/lint/test/rules/runtime-safety/valid_typeof_test.go
+++ b/packages/lint/test/rules/runtime-safety/valid_typeof_test.go
@@ -16,5 +16,5 @@ import "testing"
 // 2. Enable the rule severities declared by its // expect: comments.
 // 3. Assert the native Engine reports exactly the annotated diagnostics.
 func TestRuleCorpusValidTypeof(t *testing.T) {
-  assertRuleCorpusCase(t, "valid-typeof.ts", "function f(x: any) {\n  // expect: valid-typeof error\n  return typeof x === \"stirng\";\n}\nJSON.stringify(f);\n")
+  assertRuleCorpusCase(t, "valid-typeof.ts", "function f(x: any) {\n  // expect: valid-typeof error\n  const typo = typeof x === \"stirng\";\n  const known = typeof x === \"string\";\n  const ordered = typeof x < \"m\";\n  const orderedOrEqual = typeof x >= \"z\";\n  return [typo, known, ordered, orderedOrEqual];\n}\nJSON.stringify(f);\n")
 }

--- a/tests/test-lint/src/cases/valid-typeof.ts
+++ b/tests/test-lint/src/cases/valid-typeof.ts
@@ -1,5 +1,9 @@
 function f(x: any) {
   // expect: valid-typeof error
-  return typeof x === "stirng";
+  const typo = typeof x === "stirng";
+  const known = typeof x === "string";
+  const ordered = typeof x < "m";
+  const orderedOrEqual = typeof x >= "z";
+  return [typo, known, ordered, orderedOrEqual];
 }
 JSON.stringify(f);

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -3034,6 +3034,8 @@ function f(x: number) {
 
 Restrict the right-hand operand of `typeof` to the documented strings (`"number"`, `"object"`, ...) so `typeof x === "undefiend"` typos are caught.
 
+Only equality comparisons (`==`, `===`, `!=`, `!==`) are checked. A relational comparison such as `typeof x < "m"` orders two strings instead of naming a type, so it is left alone.
+
 Example:
 
 ```ts


### PR DESCRIPTION
## Intent

`valid-typeof` reported `Invalid typeof comparison value.` for **relational** comparisons (`<`, `>`, `<=`, `>=`) between a `typeof` expression and a non-type string, e.g. `typeof x < "m"`. ESLint's `valid-typeof` gates on `OPERATORS = {"==", "===", "!=", "!=="}` — a relational comparison orders two strings rather than naming a type, so upstream stays silent. Verified against the ESLint source.

## Scope

- `validTypeof.Check` now gates on the package's equality-only predicate instead of the shared `isComparisonOperator`.
- That predicate (`isEqualityOperator`) already existed in `rules_security.go`; it moves next to its `isComparisonOperator` sibling in `rules_self.go` now that two rule families share it. Pure relocation, no behavior change.
- Both predicates now record which rules gate on them, so the operator-set split is auditable.

`isComparisonOperator` is **unchanged** and keeps all four of its remaining callers. Each was checked against its own upstream oracle and legitimately spans equality *and* ordering:

| rule | upstream operator set | predicate |
| --- | --- | --- |
| `valid-typeof` | `==`, `===`, `!=`, `!==` | `isEqualityOperator` (changed) |
| `security/detect-possible-timing-attacks` | `==`, `===`, `!=`, `!==` | `isEqualityOperator` (unchanged) |
| `use-isnan` | `/^(?:[<>]|[!=]=)=?$/` — all 8 | `isComparisonOperator` |
| `no-self-compare` | all 8 | `isComparisonOperator` |
| `no-compare-neg-zero` | all 8 | `isComparisonOperator` |
| `yoda` | all 8 (`onlyEquality` defaults to `false`) | `isComparisonOperator` |

## Test plan

New `TestValidTypeofEqualityOperatorScope` (`packages/lint/test/rules/runtime-safety/valid_typeof_equality_operator_scope_test.go`), 20 cases:

- **Reports** — all four equality operators; `typeof` on either side; through parentheses; static template literal.
- **Silent** — all four relational tokens (`<`, `<=`, `>`, `>=`) against an invalid type string, plus a relational static template literal. Each of these five fails against `master`'s engine and passes with the fix.
- **Silent** — valid type strings, `typeof x === typeof y`, and equality without `typeof` (value gate unaffected).
- **Shared-helper regression shield** — `use-isnan`, `no-self-compare`, `no-compare-neg-zero` and `yoda` must still report on relational operators, proving `isComparisonOperator` was not narrowed underneath them.

The e2e corpus fixture `tests/test-lint/src/cases/valid-typeof.ts` (and its Go mirror) gains unannotated relational lines, which must now produce no finding.

Expectations are taken from the ESLint rule sources, not from what the engine emits. Full `node scripts/test-go-lint.cjs` suite green.

Fixes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND
