### PR TITLE
fix(lint): name the escaped rune in no-useless-escape messages

### DIFF
--- a/packages/lint/linthost/rules_escape.go
+++ b/packages/lint/linthost/rules_escape.go
@@ -2,6 +2,7 @@ package linthost
 
 import (
   "strings"
+  "unicode/utf8"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
@@ -128,21 +129,18 @@ func reportStringEscapes(ctx *Context, raw string, base int, whitelist string, i
       continue
     }
     if isUselessStringEscape(next, whitelist) {
+      message := uselessEscapeMessage(raw[i+1:])
       // Only emit a fix when both surrounding bytes are plain ASCII so
       // deleting one byte cannot corrupt a multi-byte sequence.
       if next < 0x80 {
         ctx.ReportRangeFix(
           base+i,
           base+i+1,
-          "Unnecessary escape character: \\"+string(next)+".",
+          message,
           TextEdit{Pos: base + i, End: base + i + 1, Text: ""},
         )
       } else {
-        ctx.ReportRange(
-          base+i,
-          base+i+1,
-          "Unnecessary escape character: \\"+string(next)+".",
-        )
+        ctx.ReportRange(base+i, base+i+1, message)
       }
     }
     i++ // skip the escaped char so `\\\\` doesn't double-report.
@@ -182,23 +180,33 @@ func reportRegexEscapes(ctx *Context, raw string, base int) {
       // base + 1 (for the leading `/`) + i is the byte offset of the
       // backslash in the source.
       pos := base + 1 + i
+      message := uselessEscapeMessage(body[i+1:])
       if next < 0x80 {
         ctx.ReportRangeFix(
           pos,
           pos+1,
-          "Unnecessary escape character: \\"+string(next)+".",
+          message,
           TextEdit{Pos: pos, End: pos + 1, Text: ""},
         )
       } else {
-        ctx.ReportRange(
-          pos,
-          pos+1,
-          "Unnecessary escape character: \\"+string(next)+".",
-        )
+        ctx.ReportRange(pos, pos+1, message)
       }
     }
     i++ // consume the escaped character.
   }
+}
+
+// uselessEscapeMessage renders the diagnostic for one redundant backslash.
+// `rest` is the raw source starting at the escaped character, of which only
+// the leading UTF-8 rune is named. Decoding is required because the escape
+// target may be multi-byte: converting the lone lead byte would reinterpret it
+// as the code point of the same numeric value, so `\你` (lead byte 0xE4) would
+// accuse `ä` (U+00E4). ESLint canonical names the whole code point as well.
+// A byte that is not valid UTF-8 decodes to U+FFFD, which keeps the message
+// itself well-formed.
+func uselessEscapeMessage(rest string) string {
+  escaped, _ := utf8.DecodeRuneInString(rest)
+  return "Unnecessary escape character: \\" + string(escaped) + "."
 }
 
 // isUselessStringEscape reports whether a backslash before `ch` is redundant

--- a/packages/lint/test/rules/strings-regex/no_useless_escape_invalid_utf8_names_replacement_character_test.go
+++ b/packages/lint/test/rules/strings-regex/no_useless_escape_invalid_utf8_names_replacement_character_test.go
@@ -1,0 +1,53 @@
+package linthost
+
+import (
+  "sort"
+  "strings"
+  "testing"
+  "unicode/utf8"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestNoUselessEscapeInvalidUtf8NamesReplacementCharacter verifies the
+// no-useless-escape message when the escaped byte is not valid UTF-8.
+//
+// Source text reaches the rule as raw bytes, so an escape can target a byte
+// that decodes to nothing — a lone 0xFF from a Latin-1 file saved without
+// conversion. Naming the escaped rune must not smuggle that byte into the
+// message: a Finding is serialized to JSON for the CLI renderer and the LSP,
+// where an invalid sequence would be mangled downstream. Decoding yields
+// U+FFFD, which is also what ESLint sees, because Node replaces undecodable
+// bytes with U+FFFD while reading the file, long before the rule runs.
+//
+//  1. Lint a string and a regex whose escape targets a lone 0xFF byte.
+//  2. Assert both messages name the replacement character.
+//  3. Assert both messages are well-formed UTF-8 and still span one backslash.
+func TestNoUselessEscapeInvalidUtf8NamesReplacementCharacter(t *testing.T) {
+  source := "const bad = \"\\\xff\";\nconst pattern = /\\\xff/;\nJSON.stringify([bad, pattern]);\n"
+  file := parseTS(t, source)
+  findings := NewEngine(RuleConfig{
+    "no-useless-escape": SeverityError,
+  }).Run([]*shimast.SourceFile{file}, nil)
+  sort.Slice(findings, func(i, j int) bool { return findings[i].Pos < findings[j].Pos })
+  if len(findings) != 2 {
+    t.Fatalf("want 2 findings, got %d (%+v)", len(findings), findings)
+  }
+  const message = "Unnecessary escape character: \\�."
+  wanted := []int{
+    strings.Index(source, "\\\xff"),
+    strings.LastIndex(source, "\\\xff"),
+  }
+  for i, finding := range findings {
+    if finding.Message != message {
+      t.Fatalf("[%d]: message mismatch:\nwant %q\ngot  %q", i, message, finding.Message)
+    }
+    if !utf8.ValidString(finding.Message) {
+      t.Fatalf("[%d]: message is not valid UTF-8: %x", i, finding.Message)
+    }
+    if finding.Pos != wanted[i] || finding.End != wanted[i]+1 {
+      t.Fatalf("[%d]: want range [%d,%d), got [%d,%d)",
+        i, wanted[i], wanted[i]+1, finding.Pos, finding.End)
+    }
+  }
+}

--- a/packages/lint/test/rules/strings-regex/no_useless_escape_invalid_utf8_names_replacement_character_test.go
+++ b/packages/lint/test/rules/strings-regex/no_useless_escape_invalid_utf8_names_replacement_character_test.go
@@ -33,17 +33,22 @@ func TestNoUselessEscapeInvalidUtf8NamesReplacementCharacter(t *testing.T) {
   if len(findings) != 2 {
     t.Fatalf("want 2 findings, got %d (%+v)", len(findings), findings)
   }
-  const message = "Unnecessary escape character: \\�."
+  const message = "Unnecessary escape character: \\\uFFFD."
   wanted := []int{
     strings.Index(source, "\\\xff"),
     strings.LastIndex(source, "\\\xff"),
   }
   for i, finding := range findings {
-    if finding.Message != message {
-      t.Fatalf("[%d]: message mismatch:\nwant %q\ngot  %q", i, message, finding.Message)
+    if wanted[i] < 0 {
+      t.Fatalf("[%d]: fixture lost its escape", i)
     }
+    // Checked before the exact match so a regression that leaks the raw byte
+    // back into the message is named as such instead of as a text mismatch.
     if !utf8.ValidString(finding.Message) {
       t.Fatalf("[%d]: message is not valid UTF-8: %x", i, finding.Message)
+    }
+    if finding.Message != message {
+      t.Fatalf("[%d]: message mismatch:\nwant %q\ngot  %q", i, message, finding.Message)
     }
     if finding.Pos != wanted[i] || finding.End != wanted[i]+1 {
       t.Fatalf("[%d]: want range [%d,%d), got [%d,%d)",

--- a/packages/lint/test/rules/strings-regex/no_useless_escape_message_names_decoded_rune_test.go
+++ b/packages/lint/test/rules/strings-regex/no_useless_escape_message_names_decoded_rune_test.go
@@ -17,21 +17,30 @@ import (
 // character that never appeared in the source. ESLint canonical names the whole
 // code point — the string arm reports `match[0].slice(1)` under a `/u` pattern,
 // the regex arm `characterNode.raw.slice(1)` — so an astral rune must survive
-// whole as well. The ASCII arm is the negative twin: its message must stay
-// byte-identical, since a rune below 0x80 decodes to itself.
+// whole, while an escaped ASCII letter carrying a combining mark must still name
+// the letter alone: the unit is one code point, not one grapheme cluster. The
+// ASCII arm is the negative twin — a rune below 0x80 decodes to itself, so its
+// message must stay byte-identical.
 //
-//  1. Lint a source that uselessly escapes a BMP rune, an astral rune, and an
-//     ASCII letter, in both a string literal and a regex literal.
-//  2. Enable only `no-useless-escape`.
-//  3. Assert each message names the exact character that follows the backslash.
+//  1. Lint escapes of a two-byte, three-byte, and astral rune plus an ASCII
+//     letter, in both a string literal and a regex literal.
+//  2. Add an escaped ASCII letter followed by a combining acute accent, whose
+//     message must name the letter and stop there.
+//  3. Enable only `no-useless-escape` and assert each message names the exact
+//     character that follows the backslash.
 func TestNoUselessEscapeMessageNamesDecodedRune(t *testing.T) {
-  source := `const stringWide = "\你";
+  // The combining accent is written as an escape so no editor can silently
+  // normalize the fixture into a precomposed single rune.
+  source := "const stringCombining = \"\\e\u0301\";\n" + `const stringLatin = "\ä";
+const stringWide = "\你";
 const stringAstral = "\😀";
 const stringAscii = "\a";
+const regexLatin = /\ä/;
 const regexWide = /\你/;
 const regexAstral = /\😀/;
 const regexAscii = /\a/;
-JSON.stringify([stringWide, stringAstral, stringAscii, regexWide, regexAstral, regexAscii]);
+JSON.stringify([stringCombining, stringLatin, stringWide, stringAstral, stringAscii]);
+JSON.stringify([regexLatin, regexWide, regexAstral, regexAscii]);
 `
   file := parseTS(t, source)
   findings := NewEngine(RuleConfig{
@@ -39,9 +48,12 @@ JSON.stringify([stringWide, stringAstral, stringAscii, regexWide, regexAstral, r
   }).Run([]*shimast.SourceFile{file}, nil)
   sort.Slice(findings, func(i, j int) bool { return findings[i].Pos < findings[j].Pos })
   expected := []string{
+    "Unnecessary escape character: \\e.",
+    "Unnecessary escape character: \\ä.",
     "Unnecessary escape character: \\你.",
     "Unnecessary escape character: \\😀.",
     "Unnecessary escape character: \\a.",
+    "Unnecessary escape character: \\ä.",
     "Unnecessary escape character: \\你.",
     "Unnecessary escape character: \\😀.",
     "Unnecessary escape character: \\a.",

--- a/packages/lint/test/rules/strings-regex/no_useless_escape_message_names_decoded_rune_test.go
+++ b/packages/lint/test/rules/strings-regex/no_useless_escape_message_names_decoded_rune_test.go
@@ -1,0 +1,57 @@
+package linthost
+
+import (
+  "sort"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestNoUselessEscapeMessageNamesDecodedRune verifies the no-useless-escape
+// message names the escaped character itself, not its UTF-8 lead byte.
+//
+// Pins the issue-582 regression: both report sites built the message from
+// `string(raw[i+1])`, a lone byte. For a multi-byte character that byte is the
+// UTF-8 lead byte (`你` starts with 0xE4), and Go re-encodes it as the code
+// point of the same numeric value (U+00E4 `ä`), so the diagnostic accused a
+// character that never appeared in the source. ESLint canonical names the whole
+// code point — the string arm reports `match[0].slice(1)` under a `/u` pattern,
+// the regex arm `characterNode.raw.slice(1)` — so an astral rune must survive
+// whole as well. The ASCII arm is the negative twin: its message must stay
+// byte-identical, since a rune below 0x80 decodes to itself.
+//
+//  1. Lint a source that uselessly escapes a BMP rune, an astral rune, and an
+//     ASCII letter, in both a string literal and a regex literal.
+//  2. Enable only `no-useless-escape`.
+//  3. Assert each message names the exact character that follows the backslash.
+func TestNoUselessEscapeMessageNamesDecodedRune(t *testing.T) {
+  source := `const stringWide = "\你";
+const stringAstral = "\😀";
+const stringAscii = "\a";
+const regexWide = /\你/;
+const regexAstral = /\😀/;
+const regexAscii = /\a/;
+JSON.stringify([stringWide, stringAstral, stringAscii, regexWide, regexAstral, regexAscii]);
+`
+  file := parseTS(t, source)
+  findings := NewEngine(RuleConfig{
+    "no-useless-escape": SeverityError,
+  }).Run([]*shimast.SourceFile{file}, nil)
+  sort.Slice(findings, func(i, j int) bool { return findings[i].Pos < findings[j].Pos })
+  expected := []string{
+    "Unnecessary escape character: \\你.",
+    "Unnecessary escape character: \\😀.",
+    "Unnecessary escape character: \\a.",
+    "Unnecessary escape character: \\你.",
+    "Unnecessary escape character: \\😀.",
+    "Unnecessary escape character: \\a.",
+  }
+  if len(findings) != len(expected) {
+    t.Fatalf("want %d findings, got %d (%+v)", len(expected), len(findings), findings)
+  }
+  for i, message := range expected {
+    if findings[i].Message != message {
+      t.Fatalf("[%d]: message mismatch:\nwant %q\ngot  %q", i, message, findings[i].Message)
+    }
+  }
+}

--- a/packages/lint/test/rules/strings-regex/no_useless_escape_multibyte_range_covers_backslash_only_test.go
+++ b/packages/lint/test/rules/strings-regex/no_useless_escape_multibyte_range_covers_backslash_only_test.go
@@ -1,0 +1,66 @@
+package linthost
+
+import (
+  "sort"
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestNoUselessEscapeMultibyteRangeCoversBackslashOnly verifies the reported
+// range and the fix channel of a multi-byte no-useless-escape finding.
+//
+// The message for a multi-byte escape is built by decoding the rune that
+// follows the backslash, but the finding itself must keep addressing bytes:
+// ESLint canonical reports `[rangeStart, rangeStart + 1]` — the backslash
+// alone — and the autofix deletes exactly that one byte. This pins the two
+// invariants a rune-aware message could plausibly break: the range must not
+// widen to the rune's byte length, and the multi-byte arm must stay
+// detection-only (deleting the backslash is safe, but the rule declines the
+// fix, so an accidental fix would be a behavior change, not a message change).
+//
+//  1. Lint a string and a regex that uselessly escape a 3-byte rune, plus an
+//     ASCII escape as the twin that does carry a fix.
+//  2. Assert every finding spans exactly the backslash byte.
+//  3. Assert the multi-byte findings carry no fix and the ASCII one deletes
+//     exactly the backslash.
+func TestNoUselessEscapeMultibyteRangeCoversBackslashOnly(t *testing.T) {
+  source := `const wide = "\你";
+const pattern = /\你/;
+const ascii = "\a";
+JSON.stringify([wide, pattern, ascii]);
+`
+  file := parseTS(t, source)
+  findings := NewEngine(RuleConfig{
+    "no-useless-escape": SeverityError,
+  }).Run([]*shimast.SourceFile{file}, nil)
+  sort.Slice(findings, func(i, j int) bool { return findings[i].Pos < findings[j].Pos })
+  if len(findings) != 3 {
+    t.Fatalf("want 3 findings, got %d (%+v)", len(findings), findings)
+  }
+  wanted := []int{
+    strings.Index(source, "\\你"),
+    strings.LastIndex(source, "\\你"),
+    strings.Index(source, "\\a"),
+  }
+  for i, pos := range wanted {
+    if pos < 0 {
+      t.Fatalf("[%d]: fixture lost its escape", i)
+    }
+    if findings[i].Pos != pos || findings[i].End != pos+1 {
+      t.Fatalf("[%d]: want range [%d,%d), got [%d,%d)",
+        i, pos, pos+1, findings[i].Pos, findings[i].End)
+    }
+  }
+  for i := 0; i < 2; i++ {
+    if len(findings[i].Fix) != 0 {
+      t.Fatalf("[%d]: multi-byte escape must stay detection-only, got %+v", i, findings[i].Fix)
+    }
+  }
+  fix := findings[2].Fix
+  if len(fix) != 1 || fix[0].Pos != wanted[2] || fix[0].End != wanted[2]+1 || fix[0].Text != "" {
+    t.Fatalf("ascii fix mismatch: want one deletion of [%d,%d), got %+v",
+      wanted[2], wanted[2]+1, fix)
+  }
+}


### PR DESCRIPTION
## Intent

`no-useless-escape` named the wrong character whenever the escape target was not ASCII. `const s = "\你";` reported

```
[no-useless-escape] Unnecessary escape character: \ä.
```

Both report sites in `packages/lint/linthost/rules_escape.go` built the message with `string(next)`, where `next` is `raw[i+1]` — a single **byte**. For a multi-byte rune that byte is the UTF-8 lead byte (`0xE4` for `你`), and Go's `string(byte)` re-encodes it as the code point of the same numeric value (U+00E4 = `ä`), so the diagnostic accused a character that never appears in the source.

## Scope

- `uselessEscapeMessage` decodes the escape target with `utf8.DecodeRuneInString` and renders the message from the whole rune. Both call sites (string/template literals, regex literals) now go through it, so the lone-byte conversion is gone from the package.
- This is upstream-faithful: ESLint core decides on the first unit (`match[0][1]`) but names the **whole code point** in the message (`match[0].slice(1)` under a `/u` pattern; `characterNode.raw.slice(1)` in the regex arm) with the same `Unnecessary escape character: \{{character}}.` text.
- `regexp/no-useless-escape` (`rules_regexp.go`) delegates to the same `reportRegexEscapes`, so the alias is fixed too.
- Message-only. Detection, the reported byte range (`[backslash, backslash+1)`, matching upstream's `[rangeStart, rangeStart + 1]`), and the ASCII one-byte autofix are unchanged — the range test passes both before and after the fix, and the e2e rule corpus needed no annotation change. `website/.../lint/rules/core.mdx` documents what the rule reports, not the message text, so it is unchanged as well.
- Behavior across the rune classes: 2-byte (`\ä`), 3-byte (`\你`), astral (`\😀`) are each named whole; an escaped ASCII letter carrying a combining mark still names the letter alone (the unit is one code point, not one grapheme cluster); an undecodable byte becomes U+FFFD, which is also what ESLint sees because Node substitutes it while decoding the file, and keeps the message well-formed for JSON/LSP serialization.

Noted but deliberately not touched (behavior change, not a message change): the multi-byte arm declines the autofix, though deleting the backslash byte alone could never corrupt a code point.

## Test plan

`packages/lint/test/rules/strings-regex/`:

- `no_useless_escape_message_names_decoded_rune_test.go` — the two-byte, three-byte, astral, and combining-mark cases in both the string and regex arms, with the ASCII escape as the negative twin whose message must stay byte-identical. Fails before the fix (`\ä` for `\你`), passes after.
- `no_useless_escape_multibyte_range_covers_backslash_only_test.go` — the finding still spans exactly the backslash byte and the multi-byte arm stays detection-only, while the ASCII arm keeps its one-byte deletion.
- `no_useless_escape_invalid_utf8_names_replacement_character_test.go` — an escape targeting a lone `0xFF` names U+FFFD and the message stays valid UTF-8.

Full `node scripts/test-go-lint.cjs` suite green.

Fixes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND
