### PR TITLE
fix(lint): rewrite the unicorn escape scan (parity, digit bounds, template segments)

### DIFF
--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -113,6 +113,45 @@ func tokenRange(file *shimast.SourceFile, node *shimast.Node) (int, int) {
   return pos, end
 }
 
+// isTaggedTemplateElement reports whether a template token — a
+// `KindNoSubstitutionTemplateLiteral` or one of the
+// `KindTemplateHead`/`Middle`/`Tail` elements of a `KindTemplateExpression`
+// — belongs to the quasi of a TaggedTemplateExpression. The tag function
+// observes the raw text (`String.raw`, `dedent`, `gql`, `css`, …), so rules
+// that police escape spelling must leave tagged templates alone; this is
+// upstream's `isTaggedTemplateLiteral(node.parent)` guard on its
+// `TemplateElement` handlers.
+//
+// A template that merely appears inside a tagged template — nested in one of
+// its substitutions — is not tagged itself and stays checked, so the walk
+// stops at the element's own enclosing template instead of searching upward
+// for any tag. Template literal *types* can never be tagged and always
+// answer false.
+func isTaggedTemplateElement(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  template := node
+  switch node.Kind {
+  case shimast.KindNoSubstitutionTemplateLiteral:
+  case shimast.KindTemplateHead:
+    template = node.Parent
+  case shimast.KindTemplateMiddle, shimast.KindTemplateTail:
+    if node.Parent == nil {
+      return false
+    }
+    template = node.Parent.Parent
+  default:
+    return false
+  }
+  if template == nil || template.Parent == nil ||
+    template.Parent.Kind != shimast.KindTaggedTemplateExpression {
+    return false
+  }
+  tagged := template.Parent.AsTaggedTemplateExpression()
+  return tagged != nil && tagged.Template == template
+}
+
 // hasCommentBetween reports whether a comment begins anywhere in the source
 // range [from, to). Fixers whose TextEdit keeps only part of the replaced
 // span use it on the discarded sub-ranges: a comment there would be silently

--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -134,6 +134,7 @@ func isTaggedTemplateElement(node *shimast.Node) bool {
   template := node
   switch node.Kind {
   case shimast.KindNoSubstitutionTemplateLiteral:
+    // The literal is the whole template; the tag, if any, is its parent.
   case shimast.KindTemplateHead:
     template = node.Parent
   case shimast.KindTemplateMiddle, shimast.KindTemplateTail:

--- a/packages/lint/linthost/literal_escape_scan.go
+++ b/packages/lint/linthost/literal_escape_scan.go
@@ -1,0 +1,117 @@
+// Raw-source scanning for the numeric escape sequences (`\xHH`, `\uHHHH`,
+// `\u{HEX...}`) that `unicorn/no-hex-escape` and `unicorn/escape-case`
+// police. Both rules read the raw literal source — the parser already
+// decodes escapes into the `.Text` value, so a normal accessor would see
+// `©` instead of `\xA9` — and both therefore need the same two guards a
+// regex port cannot express in RE2:
+//
+//   - Backslash parity: only a backslash preceded by an even-length
+//     backslash run opens an escape. Upstream spells this as the
+//     lookbehind `(?<=(?:^|[^\\])(?:\\\\)*\\)` and, in its byte-scanning
+//     rules, as `isActiveBackslash`. Without it, the second backslash of
+//     an escaped `\\` donates itself to a bogus match and `"\\x64"` (a
+//     backslash followed by the literal text `x64`) reports.
+//   - Fixed-width digit runs: `\x` takes exactly two hex digits and `\u`
+//     exactly four, so an escape never absorbs the literal hex-looking
+//     characters that follow it (`"\x41bcd"` is a canonical `\x41` plus
+//     the letters `bcd`). Only the braced `\u{HEX...}` form is variable
+//     width, and its `}` terminates it.
+//
+// Byte scanning is UTF-8 safe: every byte the scanner tests is ASCII, and
+// a multi-byte sequence contains no ASCII bytes.
+package linthost
+
+// literalEscape is one numeric escape sequence found in raw literal source.
+// `Prefix` is the character introducing it (`x` for `\xHH`, `u` for both
+// `\uHHHH` and `\u{HEX...}`) and `Digits` is its hex payload with the `\u{`
+// / `}` brackets stripped.
+type literalEscape struct {
+  Prefix byte
+  Digits string
+}
+
+// hasActiveLiteralEscape reports whether `text` contains an escape sequence
+// accepted by `match` whose backslash is active — preceded by an even-length
+// run of backslashes.
+//
+// `text` is the raw source of one string literal or template element token,
+// delimiters included. Including them changes nothing: a quote, backtick,
+// `}`, or `${` is never a backslash, so the parity of every run inside the
+// payload is the same as it would be for the delimiter-free raw value
+// upstream reads off `TemplateElement.value.raw`.
+func hasActiveLiteralEscape(text string, match func(escape literalEscape) bool) bool {
+  for index := 0; index < len(text); {
+    if text[index] != '\\' {
+      index++
+      continue
+    }
+    run := 0
+    for index < len(text) && text[index] == '\\' {
+      run++
+      index++
+    }
+    // An even-length run is a sequence of escaped backslashes: each one
+    // consumes the next, none is left over to open an escape, and the text
+    // behind the run is literal. Only the last backslash of an odd-length
+    // run is active, and it opens the escape at `index`.
+    if run%2 == 0 {
+      continue
+    }
+    if escape, ok := literalEscapeAt(text[index:]); ok && match(escape) {
+      return true
+    }
+    // `text[index]` is the escaped character, never a backslash (the run
+    // above consumed every one), so the outer loop may step over it.
+  }
+  return false
+}
+
+// literalEscapeAt parses the escape sequence opened at `text[0]`, the byte
+// right after an active backslash. It recognizes exactly the three numeric
+// forms of upstream's `x[\dA-Fa-f]{2}|u[\dA-Fa-f]{4}|u{[\dA-Fa-f]+}`
+// alternation; any other escape (`\n`, `\\`, `\$`, a line continuation, an
+// identifier escape) is not a numeric escape and fails the parse.
+func literalEscapeAt(text string) (literalEscape, bool) {
+  if text == "" {
+    return literalEscape{}, false
+  }
+  switch text[0] {
+  case 'x':
+    if digits, ok := literalEscapeDigits(text[1:], 2); ok {
+      return literalEscape{Prefix: 'x', Digits: digits}, true
+    }
+  case 'u':
+    // The braced form is the only variable-width escape. `{` is not a hex
+    // digit, so the fixed-width `\uHHHH` form can never match here and the
+    // brace branch owns the decision.
+    if len(text) > 1 && text[1] == '{' {
+      end := 2
+      for end < len(text) && hexDigit(text[end]) >= 0 {
+        end++
+      }
+      if end == 2 || end >= len(text) || text[end] != '}' {
+        return literalEscape{}, false
+      }
+      return literalEscape{Prefix: 'u', Digits: text[2:end]}, true
+    }
+    if digits, ok := literalEscapeDigits(text[1:], 4); ok {
+      return literalEscape{Prefix: 'u', Digits: digits}, true
+    }
+  }
+  return literalEscape{}, false
+}
+
+// literalEscapeDigits returns the first `count` bytes of `text` when every
+// one of them is a hex digit — the fixed-width digit run of a `\xHH` or
+// `\uHHHH` escape.
+func literalEscapeDigits(text string, count int) (string, bool) {
+  if len(text) < count {
+    return "", false
+  }
+  for index := 0; index < count; index++ {
+    if hexDigit(text[index]) < 0 {
+      return "", false
+    }
+  }
+  return text[:count], true
+}

--- a/packages/lint/linthost/rules_unicorn_escape_case.go
+++ b/packages/lint/linthost/rules_unicorn_escape_case.go
@@ -4,12 +4,15 @@
 // mix `\xa9` and `\xA9`. Canonical form uses uppercase hex digits; the
 // rule fires when any hex escape's A-F digits are lowercase.
 //
-// AST-only: visit `KindStringLiteral` and `KindNoSubstitutionTemplateLiteral`,
-// read the raw source text via `nodeText` (the parser already decodes
-// escapes into the `.Text` value), and match against a regex that finds
-// `\xHH`, `\uHHHH`, or `\u{HEX...}` whose hex portion contains an a-f
-// letter. The match is hex-only — `\n` and other identifier escapes are
-// untouched.
+// AST-only: visit `KindStringLiteral`, `KindNoSubstitutionTemplateLiteral`,
+// and the `KindTemplateHead`/`Middle`/`Tail` elements an interpolated
+// template (or a template literal type) is built from, read each token's raw
+// source text via `nodeText` (the parser already decodes escapes into the
+// `.Text` value), and match against a regex that finds `\xHH`, `\uHHHH`, or
+// `\u{HEX...}` whose hex portion contains an a-f letter. The match is
+// hex-only — `\n` and other identifier escapes are untouched — and tagged
+// templates are skipped because their tag observes the raw text, where the
+// two spellings differ.
 //
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/escape-case.md
 package linthost
@@ -34,9 +37,18 @@ type unicornEscapeCase struct{}
 
 func (unicornEscapeCase) Name() string { return "unicorn/escape-case" }
 func (unicornEscapeCase) Visits() []shimast.Kind {
-  return []shimast.Kind{shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral}
+  return []shimast.Kind{
+    shimast.KindStringLiteral,
+    shimast.KindNoSubstitutionTemplateLiteral,
+    shimast.KindTemplateHead,
+    shimast.KindTemplateMiddle,
+    shimast.KindTemplateTail,
+  }
 }
 func (unicornEscapeCase) Check(ctx *Context, node *shimast.Node) {
+  if isTaggedTemplateElement(node) {
+    return
+  }
   source := nodeText(ctx.File, node)
   if source == "" {
     return

--- a/packages/lint/linthost/rules_unicorn_escape_case.go
+++ b/packages/lint/linthost/rules_unicorn_escape_case.go
@@ -8,29 +8,20 @@
 // and the `KindTemplateHead`/`Middle`/`Tail` elements an interpolated
 // template (or a template literal type) is built from, read each token's raw
 // source text via `nodeText` (the parser already decodes escapes into the
-// `.Text` value), and match against a regex that finds `\xHH`, `\uHHHH`, or
-// `\u{HEX...}` whose hex portion contains an a-f letter. The match is
-// hex-only — `\n` and other identifier escapes are untouched — and tagged
-// templates are skipped because their tag observes the raw text, where the
-// two spellings differ.
+// `.Text` value), and fire when an active escape's hex digits contain an a-f
+// letter. The scan is hex-only — `\n` and other identifier escapes are
+// untouched — and tagged templates are skipped because their tag observes
+// the raw text, where the two spellings differ. See
+// `literal_escape_scan.go` for the parity and digit-width rules the scan
+// enforces.
 //
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/escape-case.md
 package linthost
 
 import (
-  "regexp"
+  "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
-)
-
-// unicornEscapeCasePattern matches a hex escape whose hex digits contain
-// at least one lowercase a-f letter. The regex anchors on `\x`, `\u`, or
-// `\u{...}` and rejects matches where every hex digit is already
-// uppercase / 0-9.
-var unicornEscapeCasePattern = regexp.MustCompile(
-  `\\x[0-9A-Fa-f]*[a-f][0-9A-Fa-f]*|` +
-    `\\u\{[0-9A-Fa-f]*[a-f][0-9A-Fa-f]*\}|` +
-    `\\u[0-9A-Fa-f]*[a-f][0-9A-Fa-f]*`,
 )
 
 type unicornEscapeCase struct{}
@@ -53,9 +44,17 @@ func (unicornEscapeCase) Check(ctx *Context, node *shimast.Node) {
   if source == "" {
     return
   }
-  if unicornEscapeCasePattern.MatchString(source) {
+  if hasActiveLiteralEscape(source, unicornEscapeCaseIsLowercase) {
     ctx.Report(node, "Use uppercase letters for escape sequence hex digits (`\\xA9` over `\\xa9`).")
   }
+}
+
+// unicornEscapeCaseIsLowercase selects an escape whose hex digits carry at
+// least one lowercase a-f letter — exactly the escapes upstream's uppercasing
+// replacement would rewrite. Digits `0`-`9` and `A`-`F` are already canonical,
+// and the `\u{...}` brackets are not part of `Digits`.
+func unicornEscapeCaseIsLowercase(escape literalEscape) bool {
+  return strings.ContainsAny(escape.Digits, "abcdef")
 }
 
 func init() {

--- a/packages/lint/linthost/rules_unicorn_no_hex_escape.go
+++ b/packages/lint/linthost/rules_unicorn_no_hex_escape.go
@@ -4,11 +4,14 @@
 // escape, while a hex escape silently widens to a Unicode escape at
 // runtime anyway. The rule nudges authors toward the Unicode form.
 //
-// AST-only: visit `KindStringLiteral` and `KindNoSubstitutionTemplateLiteral`,
-// read the raw source text via `nodeText` (the parser already decodes
-// escapes into the `.Text` value, so a normal accessor would see `©`
-// instead of `\xA9`), and fire when the source contains a `\xHH`
-// occurrence where HH is two hex digits.
+// AST-only: visit `KindStringLiteral`, `KindNoSubstitutionTemplateLiteral`,
+// and the `KindTemplateHead`/`Middle`/`Tail` elements an interpolated
+// template (or a template literal type) is built from, read each token's raw
+// source text via `nodeText` (the parser already decodes escapes into the
+// `.Text` value, so a normal accessor would see `©` instead of `\xA9`), and
+// fire when the text contains a `\xHH` occurrence where HH is two hex digits.
+// Tagged templates are skipped: their tag observes the raw text, where `\xA9`
+// and `©` differ.
 //
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-hex-escape.md
 package linthost
@@ -25,9 +28,18 @@ type unicornNoHexEscape struct{}
 
 func (unicornNoHexEscape) Name() string { return "unicorn/no-hex-escape" }
 func (unicornNoHexEscape) Visits() []shimast.Kind {
-  return []shimast.Kind{shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral}
+  return []shimast.Kind{
+    shimast.KindStringLiteral,
+    shimast.KindNoSubstitutionTemplateLiteral,
+    shimast.KindTemplateHead,
+    shimast.KindTemplateMiddle,
+    shimast.KindTemplateTail,
+  }
 }
 func (unicornNoHexEscape) Check(ctx *Context, node *shimast.Node) {
+  if isTaggedTemplateElement(node) {
+    return
+  }
   source := nodeText(ctx.File, node)
   if source == "" {
     return

--- a/packages/lint/linthost/rules_unicorn_no_hex_escape.go
+++ b/packages/lint/linthost/rules_unicorn_no_hex_escape.go
@@ -9,20 +9,17 @@
 // template (or a template literal type) is built from, read each token's raw
 // source text via `nodeText` (the parser already decodes escapes into the
 // `.Text` value, so a normal accessor would see `©` instead of `\xA9`), and
-// fire when the text contains a `\xHH` occurrence where HH is two hex digits.
-// Tagged templates are skipped: their tag observes the raw text, where `\xA9`
-// and `©` differ.
+// fire when the text carries an active `\xHH` escape. Tagged templates are
+// skipped: their tag observes the raw text, where `\xA9` and `©` differ.
+// See `literal_escape_scan.go` for the parity and digit-width rules the scan
+// enforces.
 //
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-hex-escape.md
 package linthost
 
 import (
-  "regexp"
-
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
-
-var unicornNoHexEscapePattern = regexp.MustCompile(`\\x[0-9A-Fa-f]{2}`)
 
 type unicornNoHexEscape struct{}
 
@@ -44,9 +41,15 @@ func (unicornNoHexEscape) Check(ctx *Context, node *shimast.Node) {
   if source == "" {
     return
   }
-  if unicornNoHexEscapePattern.MatchString(source) {
+  if hasActiveLiteralEscape(source, unicornNoHexEscapeIsHex) {
     ctx.Report(node, "Prefer Unicode escapes (`\\uXXXX`) over hex escapes (`\\xHH`).")
   }
+}
+
+// unicornNoHexEscapeIsHex selects the `\xHH` form. The `\uHHHH` and
+// `\u{HEX...}` forms are the shapes upstream rewrites *to*, so they pass.
+func unicornNoHexEscapeIsHex(escape literalEscape) bool {
+  return escape.Prefix == 'x'
 }
 
 func init() {

--- a/packages/lint/test/rules/unicorn/unicorn_escape_case_bounds_escape_digit_runs_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_escape_case_bounds_escape_digit_runs_test.go
@@ -1,0 +1,91 @@
+package linthost
+
+import "testing"
+
+// TestUnicornEscapeCaseBoundsEscapeDigitRuns verifies an escape's hex digits
+// stop at the escape boundary.
+//
+// Upstream matches `x[\dA-Fa-f]{2}|u[\dA-Fa-f]{4}|u{[\dA-Fa-f]+}`: a `\x`
+// escape is exactly two hex digits and a `\u` escape exactly four, so the
+// literal characters behind an escape are not part of it. The Go port used
+// unbounded `*` quantifiers, which let a match run past the escape and absorb
+// following `a-f` letters, so the canonical `"\x41bcd"` reported as lowercase
+// (issue #577). Only the braced form is variable width, and its `}` ends the
+// digit run — the letters behind it stay literal too. Each over-match
+// candidate is paired with the lowercase escape it would be confused with, so
+// a re-widened quantifier fails here.
+//
+//  1. Lint canonical escapes trailed by literal `a-f` letters.
+//  2. Assert they stay silent while their lowercase twins report at the
+//     literal's exact range.
+//  3. Assert the braced code point escape reports on its digits alone.
+func TestUnicornEscapeCaseBoundsEscapeDigitRuns(t *testing.T) {
+  cases := []struct {
+    name    string
+    source  string
+    markers []string
+  }{
+    {
+      name:   "hex escape trailed by literal hex letters",
+      source: "const s = \"\\x41bcd\";\n",
+    },
+    {
+      name:    "lowercase hex escape",
+      source:  "const s = \"\\xa9\";\n",
+      markers: []string{"\"\\xa9\""},
+    },
+    {
+      name:   "uppercase hex escape",
+      source: "const s = \"\\xA9\";\n",
+    },
+    {
+      name:    "hex escape with one lowercase digit",
+      source:  "const s = \"\\xAb\";\n",
+      markers: []string{"\"\\xAb\""},
+    },
+    {
+      name:   "unicode escape trailed by literal hex letters",
+      source: "const s = \"\\uABCDdef\";\n",
+    },
+    {
+      name:    "lowercase unicode escape",
+      source:  "const s = \"\\uabcd\";\n",
+      markers: []string{"\"\\uabcd\""},
+    },
+    {
+      name:   "uppercase unicode escape",
+      source: "const s = \"\\uABCD\";\n",
+    },
+    {
+      name:   "unicode escape trailed by lowercase letters",
+      source: "const s = \"\\uD83Dabc\";\n",
+    },
+    {
+      name:   "braced code point escape trailed by literal hex letters",
+      source: "const s = \"\\u{1F600}abc\";\n",
+    },
+    {
+      name:    "lowercase braced code point escape",
+      source:  "const s = \"\\u{1f600}\";\n",
+      markers: []string{"\"\\u{1f600}\""},
+    },
+    {
+      name:   "uppercase braced code point escape",
+      source: "const s = \"\\u{1F600}\";\n",
+    },
+    {
+      name:    "single-digit braced code point escape",
+      source:  "const s = \"\\u{a}\";\n",
+      markers: []string{"\"\\u{a}\""},
+    },
+    {
+      name:   "digits-only escapes",
+      source: "const s = \"\\x41\\u0041\\u{41}\";\n",
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertRuleFindingRanges(t, unicornEscapeCaseRuleName, test.source, test.markers...)
+    })
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_escape_case_honors_backslash_parity_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_escape_case_honors_backslash_parity_test.go
@@ -1,0 +1,62 @@
+package linthost
+
+import (
+  "fmt"
+  "strings"
+  "testing"
+)
+
+// TestUnicornEscapeCaseHonorsBackslashParity verifies only an escape opened
+// by an active backslash reports.
+//
+// Upstream anchors its match on a lookbehind RE2 cannot express,
+// `(?<=(?:^|[^\\])(?:\\\\)*\\)`: the escape counts only when its backslash
+// follows an even-length backslash run. The Go port used to match the bare
+// `\xa9` text, so `"\\xa9"` — an escaped backslash followed by the literal
+// characters `xa9` — falsely reported (issue #574). Every odd run is a
+// positive and its even twin one backslash away is a negative, in both a
+// string literal and a template payload, so a parity miscount fires in one
+// direction or the other.
+//
+//  1. Prefix `xa9` with one through six backslashes inside a string literal
+//     and inside a template head.
+//  2. Assert the odd runs report exactly the literal's token range and the
+//     even runs stay silent.
+//  3. Assert a run that starts mid-payload, after a plain character, is
+//     counted from that character and not from the payload start.
+func TestUnicornEscapeCaseHonorsBackslashParity(t *testing.T) {
+  for backslashes := 1; backslashes <= 6; backslashes++ {
+    run := strings.Repeat(`\`, backslashes)
+    active := backslashes%2 == 1
+    t.Run(fmt.Sprintf("string with %d leading backslashes", backslashes), func(t *testing.T) {
+      literal := `"` + run + `xa9"`
+      source := "const s = " + literal + ";\n"
+      if !active {
+        assertRuleFindingRanges(t, unicornEscapeCaseRuleName, source)
+        return
+      }
+      assertRuleFindingRanges(t, unicornEscapeCaseRuleName, source, literal)
+    })
+    t.Run(fmt.Sprintf("template head with %d leading backslashes", backslashes), func(t *testing.T) {
+      head := "`" + run + "xa9${"
+      source := "const s = " + head + "a}`;\n"
+      if !active {
+        assertRuleFindingRanges(t, unicornEscapeCaseRuleName, source)
+        return
+      }
+      assertRuleFindingRanges(t, unicornEscapeCaseRuleName, source, head)
+    })
+  }
+  t.Run("run restarts after a plain character", func(t *testing.T) {
+    literal := `"a\\b\xa9"`
+    assertRuleFindingRanges(
+      t,
+      unicornEscapeCaseRuleName,
+      "const s = "+literal+";\n",
+      literal,
+    )
+  })
+  t.Run("plain character does not revive an even run", func(t *testing.T) {
+    assertRuleFindingRanges(t, unicornEscapeCaseRuleName, "const s = "+`"a\\bxa9"`+";\n")
+  })
+}

--- a/packages/lint/test/rules/unicorn/unicorn_escape_case_reports_interpolated_template_segments_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_escape_case_reports_interpolated_template_segments_test.go
@@ -1,0 +1,84 @@
+package linthost
+
+import "testing"
+
+// TestUnicornEscapeCaseReportsInterpolatedTemplateSegments verifies the rule
+// inspects the head, middle, and tail elements of a substituted template.
+//
+// The engine dispatches strictly by a node's own Kind, and an interpolated
+// template's literal segments parse as separate `KindTemplateHead`,
+// `KindTemplateMiddle`, and `KindTemplateTail` tokens. The rule used to opt
+// into `KindStringLiteral` and `KindNoSubstitutionTemplateLiteral` only, so
+// every lowercase escape in an interpolated segment was silently ignored
+// (issue #578). Each segment is pinned on its own, at its exact token range —
+// opening backtick or `}` through the closing `${` or backtick — because a
+// range that leaks into the substitution would underline live code. The
+// comment arm is the negative twin of the tail arm: a template token's Pos
+// starts at the substitution's trailing trivia, so a lowercase escape typed
+// inside a comment must not be scanned.
+//
+//  1. Lint templates that carry the escape in the head, the middle, and the
+//     tail segment, plus a template literal type and a no-substitution
+//     template.
+//  2. Assert one finding per segment, each spanning exactly its element token.
+//  3. Assert an escape inside a substitution comment reports nothing.
+func TestUnicornEscapeCaseReportsInterpolatedTemplateSegments(t *testing.T) {
+  cases := []struct {
+    name    string
+    source  string
+    markers []string
+  }{
+    {
+      name:    "head segment",
+      source:  "const t = `\\xa9${a}`;\n",
+      markers: []string{"`\\xa9${"},
+    },
+    {
+      name:    "middle segment",
+      source:  "const t = `${a}\\xa9${a}`;\n",
+      markers: []string{"}\\xa9${"},
+    },
+    {
+      name:    "tail segment",
+      source:  "const t = `${a}\\xa9`;\n",
+      markers: []string{"}\\xa9`"},
+    },
+    {
+      name:   "every segment of one template",
+      source: "const t = `\\xa9${a}\\uabcd${a}\\u{1f600}`;\n",
+      markers: []string{
+        "`\\xa9${",
+        "}\\uabcd${",
+        "}\\u{1f600}`",
+      },
+    },
+    {
+      name:    "template literal type",
+      source:  "type T = `\\xa9${string}`;\n",
+      markers: []string{"`\\xa9${"},
+    },
+    {
+      name:    "no-substitution template",
+      source:  "const t = `\\xa9`;\n",
+      markers: []string{"`\\xa9`"},
+    },
+    {
+      name:   "escape inside a substitution comment",
+      source: "const t = `${a /* \\xa9 */}`;\n",
+    },
+    {
+      name:    "string literal inside a substitution",
+      source:  "const t = `${\"\\xa9\"}`;\n",
+      markers: []string{"\"\\xa9\""},
+    },
+    {
+      name:   "canonical segments",
+      source: "const t = `\\xA9${a}\\uABCD${a}\\u{1F600}`;\n",
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertRuleFindingRanges(t, unicornEscapeCaseRuleName, test.source, test.markers...)
+    })
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_escape_case_reports_interpolated_template_segments_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_escape_case_reports_interpolated_template_segments_test.go
@@ -53,9 +53,17 @@ func TestUnicornEscapeCaseReportsInterpolatedTemplateSegments(t *testing.T) {
       },
     },
     {
-      name:    "template literal type",
+      name:    "template literal type head",
       source:  "type T = `\\xa9${string}`;\n",
       markers: []string{"`\\xa9${"},
+    },
+    {
+      name:   "template literal type middle and tail",
+      source: "type T = `${string}\\xa9${string}\\xa9`;\n",
+      markers: []string{
+        "}\\xa9${",
+        "}\\xa9`",
+      },
     },
     {
       name:    "no-substitution template",

--- a/packages/lint/test/rules/unicorn/unicorn_escape_case_skips_tagged_templates_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_escape_case_skips_tagged_templates_test.go
@@ -1,0 +1,57 @@
+package linthost
+
+import "testing"
+
+// TestUnicornEscapeCaseSkipsTaggedTemplates verifies a tagged template's
+// segments are never reported.
+//
+// Upstream guards its `TemplateElement` handler with
+// `isTaggedTemplateLiteral(node.parent)`: the tag function receives the raw
+// text (`String.raw`, `dedent`, `gql`), where `\xa9` is a four-character
+// string and `\xA9` a different one, so uppercasing the digits would change
+// what the tag observes. Opting into the template elements without this guard
+// would have turned every String.raw template carrying a lowercase escape into
+// a fresh false positive. The guard stops at the element's own template: a
+// literal nested inside a tagged template's substitution is not itself tagged
+// and stays checked.
+//
+//  1. Lint tagged templates with and without substitutions.
+//  2. Assert they report nothing while the untagged control does report.
+//  3. Assert an untagged template and a string literal inside a tagged
+//     template's substitution still report.
+func TestUnicornEscapeCaseSkipsTaggedTemplates(t *testing.T) {
+  cases := []struct {
+    name    string
+    source  string
+    markers []string
+  }{
+    {
+      name:   "tagged no-substitution template",
+      source: "const s = String.raw`\\xa9`;\n",
+    },
+    {
+      name:   "tagged template with substitutions",
+      source: "const s = String.raw`\\xa9${a}\\uabcd${a}\\u{1f600}`;\n",
+    },
+    {
+      name:    "untagged control",
+      source:  "const s = `\\xa9${a}`;\n",
+      markers: []string{"`\\xa9${"},
+    },
+    {
+      name:    "untagged template nested in a tagged substitution",
+      source:  "const s = String.raw`${`\\xa9`}`;\n",
+      markers: []string{"`\\xa9`"},
+    },
+    {
+      name:    "string literal nested in a tagged substitution",
+      source:  "const s = String.raw`${\"\\xa9\"}`;\n",
+      markers: []string{"\"\\xa9\""},
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertRuleFindingRanges(t, unicornEscapeCaseRuleName, test.source, test.markers...)
+    })
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_escape_case_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_escape_case_test.go
@@ -2,6 +2,8 @@ package linthost
 
 import "testing"
 
+const unicornEscapeCaseRuleName = "unicorn/escape-case"
+
 // TestRuleCorpusUnicornEscapeCase verifies unicorn/escape-case reports a
 // string literal whose `\xHH` escape uses lowercase hex digits.
 //

--- a/packages/lint/test/rules/unicorn/unicorn_escape_case_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_escape_case_test.go
@@ -4,17 +4,61 @@ import "testing"
 
 const unicornEscapeCaseRuleName = "unicorn/escape-case"
 
-// TestRuleCorpusUnicornEscapeCase verifies unicorn/escape-case reports a
-// string literal whose `\xHH` escape uses lowercase hex digits.
+// TestRuleCorpusUnicornEscapeCase verifies the corpus fixture: every active
+// escape whose hex digits carry an a-f letter reports while canonical
+// escapes, escaped backslashes, and tagged templates stay silent.
 //
-// The parser decodes escape sequences into `.Text`, so the rule reads
-// the raw source via `nodeText` and matches hex-escape patterns whose
-// digits contain a lowercase a-f letter. `\xa9` (the lowercase form of
-// the © glyph escape) pins the regex branch — uppercase `\xA9` passes.
+// The parser decodes escapes into `.Text`, so the rule reads raw source via
+// `nodeText`; this fixture pins that raw-source path across string literals,
+// the head/middle/tail elements of substituted templates, the
+// backslash-parity boundary, and the fixed digit widths that keep a canonical
+// escape from absorbing the literal `a-f` letters typed behind it.
 //
-// 1. Enable unicorn/escape-case via an expect annotation.
-// 2. Declare a const initialized to `"\xa9"`.
-// 3. Assert the literal is reported.
+// 1. Mirror tests/test-lint/src/cases/unicorn-escape-case.ts.
+// 2. Run the native engine with the rule enabled via expect annotations.
+// 3. Assert the reported (rule, severity, line) triples match the annotations.
 func TestRuleCorpusUnicornEscapeCase(t *testing.T) {
-  assertRuleCorpusCase(t, "unicorn/escape-case.ts", "// expect: unicorn/escape-case error\nconst s = \"\\xa9\";\n")
+  assertRuleCorpusCase(
+    t,
+    "unicorn/escape-case.ts",
+    "// expect: unicorn/escape-case error\n"+
+      "const s = \"\\xa9\";\n"+
+      "// expect: unicorn/escape-case error\n"+
+      "const lowercaseUnicode = \"\\uabcd\";\n"+
+      "// expect: unicorn/escape-case error\n"+
+      "const lowercaseCodePoint = \"\\u{1f600}\";\n"+
+      "// expect: unicorn/escape-case error\n"+
+      "const oddBackslashRun = \"\\\\\\xa9\";\n"+
+      "// expect: unicorn/escape-case error\n"+
+      "const head = `\\xa9${s}`;\n"+
+      "// expect: unicorn/escape-case error\n"+
+      "const middle = `${s}\\xa9${s}`;\n"+
+      "// expect: unicorn/escape-case error\n"+
+      "const tail = `${s}\\xa9`;\n"+
+      "const canonicalHex = \"\\xA9\";\n"+
+      "const canonicalUnicode = \"\\uABCD\";\n"+
+      "const canonicalCodePoint = \"\\u{1F600}\";\n"+
+      "const boundedHex = \"\\x41bcd\";\n"+
+      "const boundedUnicode = \"\\uABCDdef\";\n"+
+      "const escapedBackslash = \"\\\\xa9\";\n"+
+      "const evenBackslashRun = \"\\\\\\\\xa9\";\n"+
+      "const tagged = String.raw`\\xa9`;\n"+
+      "export default [\n"+
+      "  s,\n"+
+      "  lowercaseUnicode,\n"+
+      "  lowercaseCodePoint,\n"+
+      "  oddBackslashRun,\n"+
+      "  head,\n"+
+      "  middle,\n"+
+      "  tail,\n"+
+      "  canonicalHex,\n"+
+      "  canonicalUnicode,\n"+
+      "  canonicalCodePoint,\n"+
+      "  boundedHex,\n"+
+      "  boundedUnicode,\n"+
+      "  escapedBackslash,\n"+
+      "  evenBackslashRun,\n"+
+      "  tagged,\n"+
+      "];\n",
+  )
 }

--- a/packages/lint/test/rules/unicorn/unicorn_escape_family_survives_crlf_and_astral_literals_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_escape_family_survives_crlf_and_astral_literals_test.go
@@ -1,0 +1,61 @@
+package linthost
+
+import "testing"
+
+// TestUnicornEscapeFamilySurvivesCrlfAndAstralLiterals verifies the shared
+// raw-source scan behind `unicorn/no-hex-escape` and `unicorn/escape-case`
+// stays byte-exact around line breaks and multi-byte text.
+//
+// Both rules walk the literal's raw bytes rather than its decoded value, so
+// the scan has to be UTF-8 safe (a multi-byte sequence carries no ASCII
+// bytes, and a reported range is a byte range that must still land on the
+// token) and line-ending agnostic (a CRLF template segment is one token
+// spanning two lines). A backslash before a line terminator is a line
+// continuation, not an escape opener, so the characters behind it are
+// literal — the negative twin a parity miscount would report.
+//
+//  1. Lint CRLF sources whose literals carry astral and CJK characters next
+//     to escapes.
+//  2. Assert both rules report exactly the offending token ranges.
+//  3. Assert a line continuation and an escaped backslash behind multi-byte
+//     text keep both rules silent.
+func TestUnicornEscapeFamilySurvivesCrlfAndAstralLiterals(t *testing.T) {
+  cases := []struct {
+    name       string
+    source     string
+    hexEscape  []string
+    escapeCase []string
+  }{
+    {
+      name:       "crlf template segments",
+      source:     "const t = `\\xa9${a}\r\nb\\xa9`;\r\n",
+      hexEscape:  []string{"`\\xa9${", "}\r\nb\\xa9`"},
+      escapeCase: []string{"`\\xa9${", "}\r\nb\\xa9`"},
+    },
+    {
+      name:       "astral character before an escape",
+      source:     "const s = \"😀\\xa9\";\r\n",
+      hexEscape:  []string{"\"😀\\xa9\""},
+      escapeCase: []string{"\"😀\\xa9\""},
+    },
+    {
+      name:       "braced escape for an astral code point",
+      source:     "const s = \"\\u{1f600}\";\r\n",
+      escapeCase: []string{"\"\\u{1f600}\""},
+    },
+    {
+      name:   "line continuation before hex-looking text",
+      source: "const s = \"a\\\r\nxa9\";\r\n",
+    },
+    {
+      name:   "escaped backslash behind multi-byte text",
+      source: "const s = \"日本\\\\xa9\";\r\n",
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertRuleFindingRanges(t, unicornNoHexEscapeRuleName, test.source, test.hexEscape...)
+      assertRuleFindingRanges(t, unicornEscapeCaseRuleName, test.source, test.escapeCase...)
+    })
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_escape_family_survives_crlf_and_astral_literals_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_escape_family_survives_crlf_and_astral_literals_test.go
@@ -10,9 +10,10 @@ import "testing"
 // the scan has to be UTF-8 safe (a multi-byte sequence carries no ASCII
 // bytes, and a reported range is a byte range that must still land on the
 // token) and line-ending agnostic (a CRLF template segment is one token
-// spanning two lines). A backslash before a line terminator is a line
-// continuation, not an escape opener, so the characters behind it are
-// literal — the negative twin a parity miscount would report.
+// spanning two lines). A backslash before a line terminator opens a line
+// continuation: the CR is the escaped character, so the text behind it is
+// literal and a scan that stepped over the line break to find its escape
+// would report the `xa9` that follows.
 //
 //  1. Lint CRLF sources whose literals carry astral and CJK characters next
 //     to escapes.

--- a/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_honors_backslash_parity_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_honors_backslash_parity_test.go
@@ -1,0 +1,61 @@
+package linthost
+
+import (
+  "fmt"
+  "strings"
+  "testing"
+)
+
+// TestUnicornNoHexEscapeHonorsBackslashParity verifies only a `\x` opened by
+// an active backslash reports.
+//
+// Upstream anchors its match on `(?<=(?:^|[^\\])(?:\\\\)*\\)x`, a lookbehind
+// RE2 cannot express: the `x` counts only when its backslash follows an
+// even-length backslash run. The Go port used to match the bare `\xHH` text,
+// so `"\\x64"` — an escaped backslash followed by the literal characters
+// `x64` — falsely reported (issue #574). Every odd run is a positive and its
+// even twin one backslash away is a negative, in both a string literal and a
+// template payload, so a parity miscount fires in one direction or the other.
+//
+//  1. Prefix `x41` with one through six backslashes inside a string literal
+//     and inside a template head.
+//  2. Assert the odd runs report exactly the literal's token range and the
+//     even runs stay silent.
+//  3. Assert a run that starts mid-payload, after a plain character, is
+//     counted from that character and not from the payload start.
+func TestUnicornNoHexEscapeHonorsBackslashParity(t *testing.T) {
+  for backslashes := 1; backslashes <= 6; backslashes++ {
+    run := strings.Repeat(`\`, backslashes)
+    active := backslashes%2 == 1
+    t.Run(fmt.Sprintf("string with %d leading backslashes", backslashes), func(t *testing.T) {
+      literal := `"` + run + `x41"`
+      source := "const s = " + literal + ";\n"
+      if !active {
+        assertRuleFindingRanges(t, unicornNoHexEscapeRuleName, source)
+        return
+      }
+      assertRuleFindingRanges(t, unicornNoHexEscapeRuleName, source, literal)
+    })
+    t.Run(fmt.Sprintf("template head with %d leading backslashes", backslashes), func(t *testing.T) {
+      head := "`" + run + "x41${"
+      source := "const s = " + head + "a}`;\n"
+      if !active {
+        assertRuleFindingRanges(t, unicornNoHexEscapeRuleName, source)
+        return
+      }
+      assertRuleFindingRanges(t, unicornNoHexEscapeRuleName, source, head)
+    })
+  }
+  t.Run("run restarts after a plain character", func(t *testing.T) {
+    literal := `"a\\b\x41"`
+    assertRuleFindingRanges(
+      t,
+      unicornNoHexEscapeRuleName,
+      "const s = "+literal+";\n",
+      literal,
+    )
+  })
+  t.Run("plain character does not revive an even run", func(t *testing.T) {
+    assertRuleFindingRanges(t, unicornNoHexEscapeRuleName, "const s = "+`"a\\bx41"`+";\n")
+  })
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_ignores_non_hex_escapes_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_ignores_non_hex_escapes_test.go
@@ -1,0 +1,70 @@
+package linthost
+
+import "testing"
+
+// TestUnicornNoHexEscapeIgnoresNonHexEscapes verifies only the `\xHH` form
+// reports.
+//
+// The rule exists to move authors from `\xHH` to `\uXXXX`, so the shapes it
+// rewrites *to* — the fixed-width and the braced Unicode escape — are the
+// negative twins that keep the scan from firing on its own canonical output.
+// A scan that looked for the letter `x` alone would report plain text like
+// `x41`, and one that ignored the digit width would swallow the literal
+// characters behind an escape; `"\x41bcd"` is the positive twin of the
+// `escape-case` boundary case, because the escape ends after two hex digits
+// yet is still a hex escape and must report.
+//
+//  1. Lint Unicode escapes, a non-numeric escape, a decoded glyph, and plain
+//     hex-looking text.
+//  2. Assert none of them report.
+//  3. Assert genuine `\xHH` escapes — including one trailed by literal hex
+//     letters and one behind a multi-byte character — report at their exact
+//     byte range.
+func TestUnicornNoHexEscapeIgnoresNonHexEscapes(t *testing.T) {
+  cases := []struct {
+    name    string
+    source  string
+    markers []string
+  }{
+    {
+      name:   "fixed-width unicode escape",
+      source: "const s = \"\\u00A9\";\n",
+    },
+    {
+      name:   "braced code point escape",
+      source: "const s = \"\\u{1F600}\";\n",
+    },
+    {
+      name:   "decoded glyph",
+      source: "const s = \"©\";\n",
+    },
+    {
+      name:   "non-numeric escapes",
+      source: "const s = \"\\n\\t\";\n",
+    },
+    {
+      name:   "plain hex-looking text",
+      source: "const s = \"x41\";\n",
+    },
+    {
+      name:    "hex escape",
+      source:  "const s = \"\\xA9\";\n",
+      markers: []string{"\"\\xA9\""},
+    },
+    {
+      name:    "hex escape trailed by literal hex letters",
+      source:  "const s = \"\\x41bcd\";\n",
+      markers: []string{"\"\\x41bcd\""},
+    },
+    {
+      name:    "hex escape behind a multi-byte character",
+      source:  "const s = \"日本\\xA9\";\n",
+      markers: []string{"\"日本\\xA9\""},
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertRuleFindingRanges(t, unicornNoHexEscapeRuleName, test.source, test.markers...)
+    })
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_reports_interpolated_template_segments_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_reports_interpolated_template_segments_test.go
@@ -1,0 +1,80 @@
+package linthost
+
+import "testing"
+
+// TestUnicornNoHexEscapeReportsInterpolatedTemplateSegments verifies the rule
+// inspects the head, middle, and tail elements of a substituted template.
+//
+// The engine dispatches strictly by a node's own Kind, and an interpolated
+// template's literal segments parse as separate `KindTemplateHead`,
+// `KindTemplateMiddle`, and `KindTemplateTail` tokens. The rule used to opt
+// into `KindStringLiteral` and `KindNoSubstitutionTemplateLiteral` only, so
+// every escape in an interpolated segment was silently ignored (issue
+// #578). Each segment is pinned on its own, at its exact token range —
+// opening backtick or `}` through the closing `${` or backtick — because a
+// range that leaks into the substitution would underline live code. The
+// comment arm is the negative twin of the tail arm: a template token's Pos
+// starts at the substitution's trailing trivia, so a hex escape typed inside
+// a comment must not be scanned.
+//
+//  1. Lint templates that carry the escape in the head, the middle, and the
+//     tail segment, plus a template literal type and a no-substitution
+//     template.
+//  2. Assert one finding per segment, each spanning exactly its element token.
+//  3. Assert a `\xHH` sequence inside a substitution comment reports nothing.
+func TestUnicornNoHexEscapeReportsInterpolatedTemplateSegments(t *testing.T) {
+  cases := []struct {
+    name    string
+    source  string
+    markers []string
+  }{
+    {
+      name:    "head segment",
+      source:  "const t = `\\xA9${a}`;\n",
+      markers: []string{"`\\xA9${"},
+    },
+    {
+      name:    "middle segment",
+      source:  "const t = `${a}\\xA9${a}`;\n",
+      markers: []string{"}\\xA9${"},
+    },
+    {
+      name:    "tail segment",
+      source:  "const t = `${a}\\xA9`;\n",
+      markers: []string{"}\\xA9`"},
+    },
+    {
+      name:   "every segment of one template",
+      source: "const t = `\\xA9${a}\\xA9${a}\\xA9`;\n",
+      markers: []string{
+        "`\\xA9${",
+        "}\\xA9${",
+        "}\\xA9`",
+      },
+    },
+    {
+      name:    "template literal type",
+      source:  "type T = `\\xA9${string}`;\n",
+      markers: []string{"`\\xA9${"},
+    },
+    {
+      name:    "no-substitution template",
+      source:  "const t = `\\xA9`;\n",
+      markers: []string{"`\\xA9`"},
+    },
+    {
+      name:   "escape inside a substitution comment",
+      source: "const t = `${a /* \\xA9 */}`;\n",
+    },
+    {
+      name:    "string literal inside a substitution",
+      source:  "const t = `${\"\\xA9\"}`;\n",
+      markers: []string{"\"\\xA9\""},
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertRuleFindingRanges(t, unicornNoHexEscapeRuleName, test.source, test.markers...)
+    })
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_reports_interpolated_template_segments_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_reports_interpolated_template_segments_test.go
@@ -53,9 +53,17 @@ func TestUnicornNoHexEscapeReportsInterpolatedTemplateSegments(t *testing.T) {
       },
     },
     {
-      name:    "template literal type",
+      name:    "template literal type head",
       source:  "type T = `\\xA9${string}`;\n",
       markers: []string{"`\\xA9${"},
+    },
+    {
+      name:   "template literal type middle and tail",
+      source: "type T = `${string}\\xA9${string}\\xA9`;\n",
+      markers: []string{
+        "}\\xA9${",
+        "}\\xA9`",
+      },
     },
     {
       name:    "no-substitution template",

--- a/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_skips_tagged_templates_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_skips_tagged_templates_test.go
@@ -1,0 +1,57 @@
+package linthost
+
+import "testing"
+
+// TestUnicornNoHexEscapeSkipsTaggedTemplates verifies a tagged template's
+// segments are never reported.
+//
+// Upstream guards its `TemplateElement` handler with
+// `isTaggedTemplateLiteral(node.parent)`: the tag function receives the raw
+// text (`String.raw`, `dedent`, `gql`), where `\xA9` and `©` are
+// different strings, so rewriting the escape would change what the tag
+// observes. Opting into the template elements without this guard would have
+// turned every String.raw template carrying a hex escape into a fresh false
+// positive. The guard stops at the element's own template: a literal nested
+// inside a tagged template's substitution is not itself tagged and stays
+// checked.
+//
+//  1. Lint tagged templates with and without substitutions.
+//  2. Assert they report nothing while the untagged control does report.
+//  3. Assert an untagged template and a string literal inside a tagged
+//     template's substitution still report.
+func TestUnicornNoHexEscapeSkipsTaggedTemplates(t *testing.T) {
+  cases := []struct {
+    name    string
+    source  string
+    markers []string
+  }{
+    {
+      name:   "tagged no-substitution template",
+      source: "const s = String.raw`\\xA9`;\n",
+    },
+    {
+      name:   "tagged template with substitutions",
+      source: "const s = String.raw`\\xA9${a}\\xA9${a}\\xA9`;\n",
+    },
+    {
+      name:    "untagged control",
+      source:  "const s = `\\xA9${a}`;\n",
+      markers: []string{"`\\xA9${"},
+    },
+    {
+      name:    "untagged template nested in a tagged substitution",
+      source:  "const s = String.raw`${`\\xA9`}`;\n",
+      markers: []string{"`\\xA9`"},
+    },
+    {
+      name:    "string literal nested in a tagged substitution",
+      source:  "const s = String.raw`${\"\\xA9\"}`;\n",
+      markers: []string{"\"\\xA9\""},
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertRuleFindingRanges(t, unicornNoHexEscapeRuleName, test.source, test.markers...)
+    })
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_test.go
@@ -2,6 +2,8 @@ package linthost
 
 import "testing"
 
+const unicornNoHexEscapeRuleName = "unicorn/no-hex-escape"
+
 // TestRuleCorpusUnicornNoHexEscape verifies unicorn/no-hex-escape reports a
 // string literal that contains a `\xHH` escape.
 //

--- a/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_hex_escape_test.go
@@ -4,17 +4,49 @@ import "testing"
 
 const unicornNoHexEscapeRuleName = "unicorn/no-hex-escape"
 
-// TestRuleCorpusUnicornNoHexEscape verifies unicorn/no-hex-escape reports a
-// string literal that contains a `\xHH` escape.
+// TestRuleCorpusUnicornNoHexEscape verifies the corpus fixture: every active
+// `\xHH` escape reports while Unicode escapes, escaped backslashes, and
+// tagged templates stay silent.
 //
-// The parser decodes escapes into `.Text`, so the rule reads raw source
-// via `nodeText` and matches `\xHH` against the literal's source span.
-// `\xA9` (the © glyph) is the canonical example and pins the regex
-// branch.
+// The parser decodes escapes into `.Text`, so the rule reads raw source via
+// `nodeText`; this fixture pins that raw-source path across string literals,
+// the head/middle/tail elements of substituted templates, and the
+// backslash-parity boundary that separates a genuine escape from an escaped
+// backslash followed by hex-looking text.
 //
-// 1. Enable unicorn/no-hex-escape via an expect annotation.
-// 2. Declare a const initialized to the literal `"\xA9"`.
-// 3. Assert the literal is reported.
+// 1. Mirror tests/test-lint/src/cases/unicorn-no-hex-escape.ts.
+// 2. Run the native engine with the rule enabled via expect annotations.
+// 3. Assert the reported (rule, severity, line) triples match the annotations.
 func TestRuleCorpusUnicornNoHexEscape(t *testing.T) {
-  assertRuleCorpusCase(t, "unicorn/no-hex-escape.ts", "// expect: unicorn/no-hex-escape error\nconst s = \"\\xA9\";\n")
+  assertRuleCorpusCase(
+    t,
+    "unicorn/no-hex-escape.ts",
+    "// expect: unicorn/no-hex-escape error\n"+
+      "const s = \"\\xA9\";\n"+
+      "// expect: unicorn/no-hex-escape error\n"+
+      "const oddBackslashRun = \"\\\\\\x41\";\n"+
+      "// expect: unicorn/no-hex-escape error\n"+
+      "const head = `\\xA9${s}`;\n"+
+      "// expect: unicorn/no-hex-escape error\n"+
+      "const middle = `${s}\\xA9${s}`;\n"+
+      "// expect: unicorn/no-hex-escape error\n"+
+      "const tail = `${s}\\xA9`;\n"+
+      "const escapedBackslash = \"\\\\x64\";\n"+
+      "const evenBackslashRun = \"\\\\\\\\x64\";\n"+
+      "const unicodeEscape = \"\\u00A9\";\n"+
+      "const codePointEscape = \"\\u{1F600}\";\n"+
+      "const tagged = String.raw`\\xA9`;\n"+
+      "export default [\n"+
+      "  s,\n"+
+      "  oddBackslashRun,\n"+
+      "  head,\n"+
+      "  middle,\n"+
+      "  tail,\n"+
+      "  escapedBackslash,\n"+
+      "  evenBackslashRun,\n"+
+      "  unicodeEscape,\n"+
+      "  codePointEscape,\n"+
+      "  tagged,\n"+
+      "];\n",
+  )
 }

--- a/packages/lint/test/shared/helpers_test.go
+++ b/packages/lint/test/shared/helpers_test.go
@@ -597,6 +597,44 @@ func assertFixSnapshotWithOptions(t *testing.T, ruleName, source, optsJSON, expe
   }
 }
 
+// assertRuleFindingRanges asserts the rule reports exactly one finding per
+// marker, in source order, each spanning that marker's byte range.
+//
+// Markers are literal substrings of `source` and must occur exactly once, so
+// a missing, extra, duplicated, or over-wide diagnostic fails the assertion
+// instead of hiding behind a bare count. Passing no marker asserts the rule
+// stays silent, which keeps a positive arm and its negative twin in the same
+// helper.
+func assertRuleFindingRanges(t *testing.T, ruleName, source string, markers ...string) {
+  t.Helper()
+  _, _, findings := runRuleFindingsSnapshot(t, ruleName, source, nil)
+  if len(findings) != len(markers) {
+    t.Fatalf("%s: want %d findings, got %d (%+v)", ruleName, len(markers), len(findings), findings)
+  }
+  for index, marker := range markers {
+    start := strings.Index(source, marker)
+    if start < 0 {
+      t.Fatalf("%s: marker %q missing from source", ruleName, marker)
+    }
+    if strings.Contains(source[start+1:], marker) {
+      t.Fatalf("%s: marker %q occurs more than once in source", ruleName, marker)
+    }
+    finding := findings[index]
+    if finding.Pos != start || finding.End != start+len(marker) {
+      t.Fatalf(
+        "%s: finding %d range: want [%d,%d) %q, got [%d,%d)",
+        ruleName,
+        index,
+        start,
+        start+len(marker),
+        marker,
+        finding.Pos,
+        finding.End,
+      )
+    }
+  }
+}
+
 // assertRuleSkipsSourceWithOptions asserts the rule emits zero findings for
 // the input when configured with the given options JSON. Mirrors
 // `assertRuleSkipsSource`; used for option-gated skip arms (e.g.

--- a/packages/lint/test/shared/helpers_test.go
+++ b/packages/lint/test/shared/helpers_test.go
@@ -569,41 +569,13 @@ func assertRuleSkipsSource(t *testing.T, ruleName, source string) {
   }
 }
 
-// assertFixSnapshotWithOptions runs one rule (configured with optsJSON)
-// through the native fix applier and snapshots the rewritten source.
-// Mirrors `assertFixSnapshot`; option-gated sibling of
-// `assertRuleSkipsSourceWithOptions`. Cannot delegate to `runFixSnapshot`
-// because that path uses the default `NewEngine` rather than
-// `NewEngineWithResolver`; the shared findings loader selects the resolver.
-func assertFixSnapshotWithOptions(t *testing.T, ruleName, source, optsJSON, expected string) {
-  t.Helper()
-  root, filePath, findings := runRuleFindingsSnapshot(t, ruleName, source, json.RawMessage(optsJSON))
-  if len(findings) == 0 {
-    t.Fatalf("%s: expected at least one finding", ruleName)
-  }
-  fixed, err := applyFindingFixes(root, findings)
-  if err != nil {
-    t.Fatalf("%s: applyFindingFixes: %v", ruleName, err)
-  }
-  if fixed == 0 {
-    t.Fatalf("%s: expected at least one applied fix", ruleName)
-  }
-  got, err := os.ReadFile(filePath)
-  if err != nil {
-    t.Fatalf("%s: ReadFile: %v", ruleName, err)
-  }
-  if string(got) != expected {
-    t.Fatalf("%s fixed source mismatch:\nwant %q\ngot  %q", ruleName, expected, string(got))
-  }
-}
-
 // assertRuleFindingRanges asserts the rule reports exactly one finding per
 // marker, in source order, each spanning that marker's byte range.
 //
 // Markers are literal substrings of `source` and must occur exactly once, so
 // a missing, extra, duplicated, or over-wide diagnostic fails the assertion
 // instead of hiding behind a bare count. Passing no marker asserts the rule
-// stays silent, which keeps a positive arm and its negative twin in the same
+// stays silent, which keeps a positive arm and its negative twin in one
 // helper.
 func assertRuleFindingRanges(t *testing.T, ruleName, source string, markers ...string) {
   t.Helper()
@@ -632,6 +604,34 @@ func assertRuleFindingRanges(t *testing.T, ruleName, source string, markers ...s
         finding.End,
       )
     }
+  }
+}
+
+// assertFixSnapshotWithOptions runs one rule (configured with optsJSON)
+// through the native fix applier and snapshots the rewritten source.
+// Mirrors `assertFixSnapshot`; option-gated sibling of
+// `assertRuleSkipsSourceWithOptions`. Cannot delegate to `runFixSnapshot`
+// because that path uses the default `NewEngine` rather than
+// `NewEngineWithResolver`; the shared findings loader selects the resolver.
+func assertFixSnapshotWithOptions(t *testing.T, ruleName, source, optsJSON, expected string) {
+  t.Helper()
+  root, filePath, findings := runRuleFindingsSnapshot(t, ruleName, source, json.RawMessage(optsJSON))
+  if len(findings) == 0 {
+    t.Fatalf("%s: expected at least one finding", ruleName)
+  }
+  fixed, err := applyFindingFixes(root, findings)
+  if err != nil {
+    t.Fatalf("%s: applyFindingFixes: %v", ruleName, err)
+  }
+  if fixed == 0 {
+    t.Fatalf("%s: expected at least one applied fix", ruleName)
+  }
+  got, err := os.ReadFile(filePath)
+  if err != nil {
+    t.Fatalf("%s: ReadFile: %v", ruleName, err)
+  }
+  if string(got) != expected {
+    t.Fatalf("%s fixed source mismatch:\nwant %q\ngot  %q", ruleName, expected, string(got))
   }
 }
 

--- a/tests/test-lint/src/cases/unicorn-escape-case.ts
+++ b/tests/test-lint/src/cases/unicorn-escape-case.ts
@@ -1,2 +1,39 @@
 // expect: unicorn/escape-case error
 const s = "\xa9";
+// expect: unicorn/escape-case error
+const lowercaseUnicode = "\uabcd";
+// expect: unicorn/escape-case error
+const lowercaseCodePoint = "\u{1f600}";
+// expect: unicorn/escape-case error
+const oddBackslashRun = "\\\xa9";
+// expect: unicorn/escape-case error
+const head = `\xa9${s}`;
+// expect: unicorn/escape-case error
+const middle = `${s}\xa9${s}`;
+// expect: unicorn/escape-case error
+const tail = `${s}\xa9`;
+const canonicalHex = "\xA9";
+const canonicalUnicode = "\uABCD";
+const canonicalCodePoint = "\u{1F600}";
+const boundedHex = "\x41bcd";
+const boundedUnicode = "\uABCDdef";
+const escapedBackslash = "\\xa9";
+const evenBackslashRun = "\\\\xa9";
+const tagged = String.raw`\xa9`;
+export default [
+  s,
+  lowercaseUnicode,
+  lowercaseCodePoint,
+  oddBackslashRun,
+  head,
+  middle,
+  tail,
+  canonicalHex,
+  canonicalUnicode,
+  canonicalCodePoint,
+  boundedHex,
+  boundedUnicode,
+  escapedBackslash,
+  evenBackslashRun,
+  tagged,
+];

--- a/tests/test-lint/src/cases/unicorn-no-hex-escape.ts
+++ b/tests/test-lint/src/cases/unicorn-no-hex-escape.ts
@@ -1,2 +1,27 @@
 // expect: unicorn/no-hex-escape error
 const s = "\xA9";
+// expect: unicorn/no-hex-escape error
+const oddBackslashRun = "\\\x41";
+// expect: unicorn/no-hex-escape error
+const head = `\xA9${s}`;
+// expect: unicorn/no-hex-escape error
+const middle = `${s}\xA9${s}`;
+// expect: unicorn/no-hex-escape error
+const tail = `${s}\xA9`;
+const escapedBackslash = "\\x64";
+const evenBackslashRun = "\\\\x64";
+const unicodeEscape = "\u00A9";
+const codePointEscape = "\u{1F600}";
+const tagged = String.raw`\xA9`;
+export default [
+  s,
+  oddBackslashRun,
+  head,
+  middle,
+  tail,
+  escapedBackslash,
+  evenBackslashRun,
+  unicodeEscape,
+  codePointEscape,
+  tagged,
+];

--- a/website/src/content/docs/lint/rules/unicorn.mdx
+++ b/website/src/content/docs/lint/rules/unicorn.mdx
@@ -382,6 +382,8 @@ throw new Error();
 
 Require consistent case for escape sequences (`\xA9` over `\xa9`, `\u00B5` over `\u00b5`).
 
+Escapes are read from the raw source of string literals and of every template segment, including the segments of an interpolated template. An escaped backslash opens no escape, so `"\\xa9"` is left alone, and an escape ends after its digits, so the canonical `"\x41bcd"` is not read as a lowercase one. Tagged templates are skipped because the tag function observes the raw text.
+
 Example:
 
 ```ts
@@ -742,6 +744,8 @@ for (let i = 0; i < xs.length; i++) {
 ### `unicorn/no-hex-escape`
 
 Prefer Unicode escape (`\u00A9`) over hexadecimal escape (`\xA9`).
+
+Escapes are read from the raw source of string literals and of every template segment, including the segments of an interpolated template. An escaped backslash opens no escape, so `"\\x64"` is left alone. Tagged templates are skipped because the tag function observes the raw text.
 
 Example:
 

--- a/website/src/content/docs/lint/rules/unicorn.mdx
+++ b/website/src/content/docs/lint/rules/unicorn.mdx
@@ -382,7 +382,7 @@ throw new Error();
 
 Require consistent case for escape sequences (`\xA9` over `\xa9`, `\u00B5` over `\u00b5`).
 
-Escapes are read from the raw source of string literals and of every template segment, including the segments of an interpolated template. An escaped backslash opens no escape, so `"\\xa9"` is left alone, and an escape ends after its digits, so the canonical `"\x41bcd"` is not read as a lowercase one. Tagged templates are skipped because the tag function observes the raw text.
+Escapes are read from the raw source of string literals and of every template segment, including the segments of an interpolated template. An escaped backslash opens no escape, so `"\\xa9"` is left alone, and an escape ends after its digits, so the letters trailing the canonical `"\x41bcd"` are not part of it. Tagged templates are skipped because the tag function observes the raw text.
 
 Example:
 


### PR DESCRIPTION
## Intent

`unicorn/no-hex-escape` and `unicorn/escape-case` both scan the **raw literal source** for `\x`/`\u` escapes, and both ports of that scan were wrong in three independent ways. All three land here because they are the same two files and the same scanning path: fixing one in isolation would have left the other two producing wrong findings through the code being rewritten.

| Issue | Defect | Example |
| --- | --- | --- |
| #574 | Dropped upstream's even-backslash lookbehind (RE2 has none) | `"\\x64"` — an escaped backslash plus the literal text `x64` — falsely reported |
| #577 | `escape-case` used unbounded `*` hex quantifiers, so a match ran past the escape boundary | canonical `"\x41bcd"` falsely reported as lowercase |
| #578 | Only `KindStringLiteral` / `KindNoSubstitutionTemplateLiteral` were visited | every escape in an interpolated template segment was silently ignored |

Verified against the upstream oracle: `escape-case.js` at `main`, and `no-hex-escape.js` at its last revision before deprecation (`6b6ab55`). All three reports are valid.

## Scope

- **New** `packages/lint/linthost/literal_escape_scan.go` — one shared scanner, `hasActiveLiteralEscape`, replacing both regexes. It walks raw bytes, counts backslash runs the way upstream's `isActiveBackslash` does (only the last backslash of an odd-length run opens an escape), and parses exactly the three numeric forms at their real widths: `\xHH`, `\uHHHH`, `\u{HEX...}`.
- **Both rules** now visit `KindTemplateHead`/`Middle`/`Tail`, which also brings template literal types under the scan. Findings anchor on the element token (opening backtick or `}` through the closing `${` or backtick) — the same range the sibling `consistent-template-literal-escape` reports.
- **Tagged templates are now skipped** (`isTaggedTemplateElement` in `ast_helpers.go`). This is upstream's `isTaggedTemplateLiteral(node.parent)` guard, and it becomes load-bearing the moment template elements are visited: a tag function observes the raw text, where `\xa9` and `\xA9` are different strings. It also removes a pre-existing false positive on tagged **no-substitution** templates. A template nested inside a tagged template's *substitution* is not itself tagged and stays checked.
- Both rules stay **report-only** (no autofix), as before.

Net behavior change: fewer false positives (escaped backslashes, canonical escapes trailed by hex letters, tagged templates), and new true positives inside interpolated templates and template literal types.

Not in scope (pre-existing, unrelated to these issues): upstream also runs both rules over **regex literals**, and neither rule is on the engine's `declarationFileRuleNames` allowlist, so neither fires on `.d.ts`.

## Test plan

Repro per issue — each fails on `master` and passes here:

- #574 `TestUnicornNoHexEscapeHonorsBackslashParity` / `TestUnicornEscapeCaseHonorsBackslashParity` — one through six leading backslashes, in a string literal and a template payload; every odd run reports, every even twin is silent.
- #577 `TestUnicornEscapeCaseBoundsEscapeDigitRuns` — `"\x41bcd"`, `"\uABCDdef"`, `"\u{1F600}abc"` silent; `"\xa9"`, `"\uabcd"`, `"\u{1f600}"`, `"\u{a}"` report.
- #578 `TestUnicorn{NoHexEscape,EscapeCase}ReportsInterpolatedTemplateSegments` — head, middle, and tail pinned individually at their exact token ranges, plus template literal type head/middle/tail; an escape inside a substitution *comment* must not report.

Plus `TestUnicorn{NoHexEscape,EscapeCase}SkipsTaggedTemplates` (with the untagged-inside-tagged twin), `TestUnicornNoHexEscapeIgnoresNonHexEscapes`, and `TestUnicornEscapeFamilySurvivesCrlfAndAstralLiterals` (CRLF template segments, astral/CJK literals, line continuations). Every positive asserts the exact reported byte range, and every positive has a negative twin one property away. Expectations come from the upstream rule sources, not from what the port emitted.

Both e2e corpora (`tests/test-lint/src/cases/unicorn-{escape-case,no-hex-escape}.ts`) are extended with the same shapes, and their Go mirrors reproduce the fixtures byte-for-byte.

`node scripts/test-go-lint.cjs`: green, except five config-loader tests that shell out to the built `packages/ttsc/lib/launcher/ttsx.js` and fail identically on a clean `master` in this environment (no `pnpm build`).

Fixes #574
Fixes #577
Fixes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND
