### PR TITLE
fix(lint): suppress value-changing unicorn/prefer-string-raw reports

### DIFF
--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -1,6 +1,7 @@
 package linthost
 
 import (
+  "regexp"
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
@@ -24,6 +25,36 @@ func nodeText(file *shimast.SourceFile, node *shimast.Node) string {
     return ""
   }
   return strings.TrimRight(src[pos:end], " \t\r\n")
+}
+
+// templateRawNewlinePattern is acorn's TemplateElement raw normalization
+// (`raw.replace(/\r\n?/g, "\n")` in parseTemplateElement).
+var templateRawNewlinePattern = regexp.MustCompile(`\r\n?`)
+
+// normalizeTemplateRaw reproduces the raw value ESLint sees for a template
+// quasi: acorn materializes `TemplateElement.value.raw` with CR / CRLF
+// collapsed to LF, so upstream rules both match patterns against and rewrite
+// from the LF-normalized text. TypeScript's scanner performs the same
+// collapse while cooking a template token (ECMA-262 normalizes <CR> and
+// <CRLF> to <LF> in template values), so a raw payload sliced straight out of
+// a CRLF source file must be normalized before it is compared with, or
+// substituted back into, a cooked value.
+func normalizeTemplateRaw(raw string) string {
+  return templateRawNewlinePattern.ReplaceAllString(raw, "\n")
+}
+
+// isTaggedTemplateQuasi reports whether `node` is the template argument of a
+// TaggedTemplateExpression — the position whose RAW text the tag function
+// observes, and therefore the one where escape spelling is meaningful.
+// A literal that merely appears somewhere inside a tagged template (e.g.
+// within a substitution) or that sits in the tag slot is not the quasi and
+// stays checked, mirroring upstream's isTaggedTemplateLiteral.
+func isTaggedTemplateQuasi(node *shimast.Node) bool {
+  if node == nil || node.Parent == nil || node.Parent.Kind != shimast.KindTaggedTemplateExpression {
+    return false
+  }
+  tagged := node.Parent.AsTaggedTemplateExpression()
+  return tagged != nil && tagged.Template == node
 }
 
 // keywordStart returns the source offset of a declaration keyword such as

--- a/packages/lint/linthost/rules_unicorn_consistent_template_literal_escape.go
+++ b/packages/lint/linthost/rules_unicorn_consistent_template_literal_escape.go
@@ -46,12 +46,12 @@ func (unicornConsistentTemplateLiteralEscape) Check(ctx *Context, node *shimast.
   source := ctx.File.Text()
   switch node.Kind {
   case shimast.KindNoSubstitutionTemplateLiteral:
-    if unicornConsistentTemplateLiteralEscapeIsTagged(node) {
+    if isTaggedTemplateQuasi(node) {
       return
     }
     unicornConsistentTemplateLiteralEscapeCheckElement(ctx, source, node)
   case shimast.KindTemplateExpression:
-    if unicornConsistentTemplateLiteralEscapeIsTagged(node) {
+    if isTaggedTemplateQuasi(node) {
       return
     }
     expression := node.AsTemplateExpression()
@@ -80,20 +80,6 @@ func (unicornConsistentTemplateLiteralEscape) Check(ctx *Context, node *shimast.
       unicornConsistentTemplateLiteralEscapeCheckElement(ctx, source, span.Literal)
     }
   }
-}
-
-// unicornConsistentTemplateLiteralEscapeIsTagged reports whether `template`
-// is the quasi of a TaggedTemplateExpression. A template that merely
-// appears somewhere inside a tagged template (e.g. within a substitution)
-// is not tagged itself and stays checked, mirroring upstream's
-// isTaggedTemplateLiteral.
-func unicornConsistentTemplateLiteralEscapeIsTagged(template *shimast.Node) bool {
-  parent := template.Parent
-  if parent == nil || parent.Kind != shimast.KindTaggedTemplateExpression {
-    return false
-  }
-  tagged := parent.AsTaggedTemplateExpression()
-  return tagged != nil && tagged.Template == template
 }
 
 // unicornConsistentTemplateLiteralEscapeCheckElement slices one template

--- a/packages/lint/linthost/rules_unicorn_prefer_string_raw.go
+++ b/packages/lint/linthost/rules_unicorn_prefer_string_raw.go
@@ -39,10 +39,13 @@
 //
 // Not ported: upstream also suppresses the report by POSITION
 // (`isStringRawRestricted` — directive prologues, property keys, module
-// specifiers, JSX attribute values, TypeScript literal types and enum
-// members, …) and inside Jest inline snapshots. Untagged template
-// literals WITH substitutions are out of scope too; this rule only
-// addresses the "single literal of fixed text" case.
+// specifiers, TypeScript literal types and enum members, …) and inside
+// Jest inline snapshots. Of that list only JSX attribute values are
+// covered here, and by value rather than by position: a JSX attribute
+// string has no escape sequences, so its cooked text keeps the doubled
+// backslash that the unescape above drops. Untagged template literals
+// WITH substitutions are out of scope too; this rule only addresses the
+// "single literal of fixed text" case.
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-raw.md
 package linthost
 

--- a/packages/lint/linthost/rules_unicorn_prefer_string_raw.go
+++ b/packages/lint/linthost/rules_unicorn_prefer_string_raw.go
@@ -1,17 +1,48 @@
-// unicorn/prefer-string-raw: a string literal whose source contains
-// `\\` (an escaped backslash) is using the escape syntax to represent a
-// literal backslash. The same value, written through `String.raw` as
-// a template literal, drops every backslash escape and reads as the
-// literal text the author meant — particularly noticeable for Windows
-// paths, regex source strings, and TeX-shaped snippets.
+// unicorn/prefer-string-raw: a string literal whose source spells a
+// backslash as the escape `\\` is using escape syntax to represent a
+// literal backslash. The same value, written through `String.raw` as a
+// template literal, drops every backslash escape and reads as the literal
+// text the author meant — particularly noticeable for Windows paths,
+// regex source strings, and TeX-shaped snippets.
 //
 // AST-only: visit `KindStringLiteral` and
-// `KindNoSubstitutionTemplateLiteral`. The match keys on the raw source
-// bytes of the literal node — `nodeText` returns the as-written source
-// — and fires when those bytes contain the two-character sequence `\\`,
-// i.e. an escaped backslash that `String.raw` would render literally.
-// Untagged template literals with substitutions are out of scope; this
-// rule only addresses the "single literal of fixed text" case.
+// `KindNoSubstitutionTemplateLiteral`. `\\` is invisible in a literal's
+// cooked value, so both branches re-read the raw source bytes of the node
+// and report only when a `String.raw` template would reproduce the value
+// exactly. Upstream's autofix is not ported; the rule is report-only.
+//
+// String literals mirror upstream's `Literal` handler, which returns
+// before reporting when
+//
+//   - the raw payload's last character is a backslash: a template cannot
+//     end in one, it would escape the closing backtick;
+//   - the raw payload holds no `\\` at all: no escape to drop;
+//   - the raw payload holds a backtick or `${`: the template would
+//     terminate early or interpolate;
+//   - the literal spans more than one line;
+//   - unescaping only `\\` and `\<quote>` out of the raw payload does not
+//     reproduce the cooked value: some OTHER escape (`\t`, `\n`, a
+//     unicode escape, an escaped non-delimiter quote, …) is present, and
+//     `String.raw` would emit its source spelling verbatim instead of the
+//     character it stands for, silently changing the value.
+//
+// No-substitution templates mirror upstream's `TemplateLiteral` handler:
+// the quasi of a tagged template is skipped (the tag already observes the
+// raw text), a raw payload equal to its cooked value has no escape to
+// drop, a cooked value ending in a backslash cannot be respelled raw, and
+// the raw payload must unescape — `\\` only, a template has no delimiter
+// quote to escape — back to the cooked value. Multi-line templates stay
+// reportable, unlike multi-line string literals: a template already
+// carries its newlines literally. As in ESLint, the raw payload is read
+// with CR / CRLF collapsed to LF, the same normalization the TypeScript
+// scanner applies when it cooks a template token.
+//
+// Not ported: upstream also suppresses the report by POSITION
+// (`isStringRawRestricted` — directive prologues, property keys, module
+// specifiers, JSX attribute values, TypeScript literal types and enum
+// members, …) and inside Jest inline snapshots. Untagged template
+// literals WITH substitutions are out of scope too; this rule only
+// addresses the "single literal of fixed text" case.
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-raw.md
 package linthost
 
@@ -19,7 +50,10 @@ import (
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
+
+const unicornPreferStringRawMessage = "Prefer `String.raw` for strings with backslash escapes."
 
 type unicornPreferStringRaw struct{}
 
@@ -28,14 +62,108 @@ func (unicornPreferStringRaw) Visits() []shimast.Kind {
   return []shimast.Kind{shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral}
 }
 func (unicornPreferStringRaw) Check(ctx *Context, node *shimast.Node) {
-  raw := nodeText(ctx.File, node)
-  if raw == "" {
+  if ctx == nil || ctx.File == nil || node == nil {
     return
   }
-  if !strings.Contains(raw, `\\`) {
+  switch node.Kind {
+  case shimast.KindStringLiteral:
+    unicornPreferStringRawCheckString(ctx, node)
+  case shimast.KindNoSubstitutionTemplateLiteral:
+    unicornPreferStringRawCheckTemplate(ctx, node)
+  }
+}
+
+// unicornPreferStringRawCheckString reports a single-quoted or
+// double-quoted literal whose `\\` escapes — and nothing else — separate
+// its raw source from its value.
+//
+// A literal without a matching closing quote is an unterminated token the
+// parser recovered from; there is no payload to respell, so it is left
+// alone rather than sliced blindly.
+func unicornPreferStringRawCheckString(ctx *Context, node *shimast.Node) {
+  pos, end := tokenRange(ctx.File, node)
+  if pos < 0 || end-pos < 2 {
     return
   }
-  ctx.Report(node, "Prefer `String.raw` for strings with backslash escapes.")
+  source := ctx.File.Text()
+  quote := source[pos]
+  if (quote != '\'' && quote != '"') || source[end-1] != quote {
+    return
+  }
+  raw := source[pos+1 : end-1]
+  if strings.HasSuffix(raw, `\`) ||
+    !strings.Contains(raw, `\\`) ||
+    strings.Contains(raw, "`") ||
+    strings.Contains(raw, "${") {
+    return
+  }
+  if shimscanner.GetECMALineOfPosition(ctx.File, pos) != shimscanner.GetECMALineOfPosition(ctx.File, end) {
+    return
+  }
+  if unicornPreferStringRawUnescapeBackslash(raw, quote) != stringLiteralText(node) {
+    return
+  }
+  ctx.Report(node, unicornPreferStringRawMessage)
+}
+
+// unicornPreferStringRawCheckTemplate reports an untagged
+// no-substitution template whose `\\` escapes — and nothing else —
+// separate its raw source from its cooked value, so prefixing it with
+// `String.raw` keeps the value and drops the escapes.
+func unicornPreferStringRawCheckTemplate(ctx *Context, node *shimast.Node) {
+  if isTaggedTemplateQuasi(node) {
+    return
+  }
+  pos, end := tokenRange(ctx.File, node)
+  if pos < 0 || end-pos < 2 {
+    return
+  }
+  source := ctx.File.Text()
+  if source[pos] != '`' || source[end-1] != '`' {
+    return
+  }
+  raw := normalizeTemplateRaw(source[pos+1 : end-1])
+  cooked := stringLiteralText(node)
+  if raw == cooked || strings.HasSuffix(cooked, `\`) {
+    return
+  }
+  if unicornPreferStringRawUnescapeBackslash(raw, 0) != cooked {
+    return
+  }
+  ctx.Report(node, unicornPreferStringRawMessage)
+}
+
+// unicornPreferStringRawUnescapeBackslash is upstream's
+// `unescapeBackslash(text, quote)`:
+//
+//  text.replaceAll(new RegExp(String.raw`\\(?<escapedCharacter>[\\${quote}])`, "g"), "$<escapedCharacter>")
+//
+// It drops the backslash from `\\` and from an escaped delimiter quote,
+// and leaves every other escape sequence spelled out exactly as written.
+// The result therefore equals the literal's cooked value only when those
+// two are the only escapes present — which is precisely when `String.raw`
+// can respell the literal without changing it.
+//
+// `quote` is the delimiter byte (`'` or `"`), or 0 for a template, whose
+// only escapable delimiter is the backslash itself. Scanning bytes is
+// UTF-8 safe: `\` is ASCII and never appears inside a multi-byte
+// sequence, so multi-byte and astral runes are copied through untouched.
+// Matches are consumed left to right and never overlap, so a run of
+// backslashes halves exactly as the global regular expression does.
+func unicornPreferStringRawUnescapeBackslash(text string, quote byte) string {
+  var unescaped strings.Builder
+  for index := 0; index < len(text); index++ {
+    character := text[index]
+    if character == '\\' && index+1 < len(text) {
+      if next := text[index+1]; next == '\\' || (quote != 0 && next == quote) {
+        unescaped.WriteByte(next)
+        index++
+        continue
+      }
+    }
+    unescaped.WriteByte(character)
+  }
+  return unescaped.String()
 }
 
 func init() {

--- a/packages/lint/linthost/rules_unicorn_string_content.go
+++ b/packages/lint/linthost/rules_unicorn_string_content.go
@@ -410,6 +410,8 @@ func checkUnicornStringContentNode(
   // Template quasis match on their RAW text so escape spelling and
   // substitution boundaries stay untouched. Foreign-language tags are
   // exempt even when the quasi was reached through a configured selector.
+  // The raw text is LF-normalized like acorn's, so a reported quasi that
+  // contained CRLF comes back LF-only after the fix, exactly like upstream.
   if unicornStringContentHasIgnoredTag(node) {
     return
   }
@@ -417,7 +419,7 @@ func checkUnicornStringContentNode(
   if !ok {
     return
   }
-  raw := unicornStringContentNormalizeTemplateRaw(source[innerPos:innerEnd])
+  raw := normalizeTemplateRaw(source[innerPos:innerEnd])
   if raw == "" {
     return
   }
@@ -428,19 +430,6 @@ func checkUnicornStringContentNode(
   fixed := replacement.regex.ReplaceAllLiteralString(raw, replacement.suggest)
   edits := []TextEdit{{Pos: innerPos, End: innerEnd, Text: unicornStringContentEscapeTemplateRaw(fixed)}}
   reportUnicornStringContent(ctx, node, replacement, edits)
-}
-
-// unicornStringContentTemplateNewlinePattern is acorn's TemplateElement raw
-// normalization (`raw.replace(/\r\n?/g, "\n")` in parseTemplateElement).
-var unicornStringContentTemplateNewlinePattern = regexp.MustCompile(`\r\n?`)
-
-// unicornStringContentNormalizeTemplateRaw reproduces the raw value ESLint
-// sees for a template quasi: acorn materializes `TemplateElement.value.raw`
-// with CR / CRLF collapsed to LF, so upstream both matches patterns against
-// and rewrites from the LF-normalized text. A reported quasi that contained
-// CRLF therefore comes back LF-only after the fix, exactly like upstream.
-func unicornStringContentNormalizeTemplateRaw(raw string) string {
-  return unicornStringContentTemplateNewlinePattern.ReplaceAllString(raw, "\n")
 }
 
 // findUnicornStringContentReplacement returns the FIRST configured pattern

--- a/packages/lint/linthost/rules_unicorn_string_content.go
+++ b/packages/lint/linthost/rules_unicorn_string_content.go
@@ -410,8 +410,6 @@ func checkUnicornStringContentNode(
   // Template quasis match on their RAW text so escape spelling and
   // substitution boundaries stay untouched. Foreign-language tags are
   // exempt even when the quasi was reached through a configured selector.
-  // The raw text is LF-normalized like acorn's, so a reported quasi that
-  // contained CRLF comes back LF-only after the fix, exactly like upstream.
   if unicornStringContentHasIgnoredTag(node) {
     return
   }
@@ -419,6 +417,9 @@ func checkUnicornStringContentNode(
   if !ok {
     return
   }
+  // Matching and rewriting both run on the acorn-normalized raw text, so a
+  // reported quasi that contained CRLF comes back LF-only after the fix,
+  // exactly like upstream.
   raw := normalizeTemplateRaw(source[innerPos:innerEnd])
   if raw == "" {
     return

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_reports_multiline_and_crlf_templates_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_reports_multiline_and_crlf_templates_test.go
@@ -1,0 +1,32 @@
+package linthost
+
+import "testing"
+
+// TestUnicornPreferStringRawReportsMultilineAndCrlfTemplates verifies a
+// no-substitution template keeps reporting across line breaks.
+//
+// Upstream's line check belongs to its `Literal` handler alone: a template
+// already carries its newlines literally, so `String.raw` reproduces them and
+// the multi-line case stays reportable. Applying the string-literal guards
+// wholesale to both node kinds would silence it. The CRLF twin pins the raw
+// payload's LF normalization — the scanner cooks <CRLF> to <LF>, so a raw
+// payload read verbatim out of a CRLF file would never match its own cooked
+// value and the rule would go silent on Windows checkouts.
+//
+//  1. Write a two-line template whose only escapes are `\\` separators.
+//  2. Repeat the fixture with CRLF line endings.
+//  3. Assert both report exactly once, on the template's opening line.
+func TestUnicornPreferStringRawReportsMultilineAndCrlfTemplates(t *testing.T) {
+  assertRuleCorpusCase(
+    t,
+    "unicorn/prefer-string-raw-template-lf.ts",
+    "// expect: unicorn/prefer-string-raw error\n"+
+      "const paths = `C:\\\\Users\nD:\\\\Data`;\n",
+  )
+  assertRuleCorpusCase(
+    t,
+    "unicorn/prefer-string-raw-template-crlf.ts",
+    "// expect: unicorn/prefer-string-raw error\r\n"+
+      "const paths = `C:\\\\Users\r\nD:\\\\Data`;\r\n",
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_jsx_attribute_strings_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_jsx_attribute_strings_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestUnicornPreferStringRawSkipsJsxAttributeStrings verifies the rule stays
+// silent on a JSX attribute value.
+//
+// Upstream exempts JSX attribute values by position, because JSX strings have
+// no escape sequences: `title="C:\\Users"` really does hold two backslashes,
+// and a `String.raw` template would halve them. The value comparison reaches
+// the same verdict from the value side — the scanner cooks a JSX attribute
+// string verbatim, so its cooked text keeps the doubled backslash the unescape
+// drops — which is exactly why the comparison must stay in place for TSX.
+//
+//  1. Parse a TSX fixture whose annotated line is an ordinary string literal.
+//  2. Give a JSX attribute the same backslash-escaped path as its value.
+//  3. Assert only the ordinary literal reports.
+func TestUnicornPreferStringRawSkipsJsxAttributeStrings(t *testing.T) {
+  assertRuleCorpusCaseTSX(
+    t,
+    "unicorn/prefer-string-raw-jsx-attribute.tsx",
+    "// expect: unicorn/prefer-string-raw error\n"+
+      "const path = \"C:\\\\Users\\\\me\";\n"+
+      "const element = <div title=\"C:\\\\Users\\\\me\" />;\n",
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_literals_ending_with_a_backslash_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_literals_ending_with_a_backslash_test.go
@@ -1,0 +1,30 @@
+package linthost
+
+import "testing"
+
+// TestUnicornPreferStringRawSkipsLiteralsEndingWithABackslash verifies the
+// rule stays silent when the value ends with a backslash.
+//
+// Pins upstream's `raw.at(-2) === "\\"` guard for string literals and its
+// `cooked.at(-1) === "\\"` twin for templates. A raw template cannot end in a
+// backslash — it would escape the closing backtick — so `String.raw` has no
+// spelling for these values at all, yet the port reported them because their
+// source contains `\\`. The all-backslashes literal is the boundary: every
+// character is an escape and the last one still blocks the conversion.
+//
+//  1. Enable unicorn/prefer-string-raw on a fixture whose annotated line ends
+//     in a path segment rather than a separator.
+//  2. Add a trailing-separator path, an all-backslashes literal, and a
+//     template whose cooked value ends with a backslash.
+//  3. Assert the annotated line is the ONLY finding.
+func TestUnicornPreferStringRawSkipsLiteralsEndingWithABackslash(t *testing.T) {
+  assertRuleCorpusCase(
+    t,
+    "unicorn/prefer-string-raw-trailing-backslash.ts",
+    "// expect: unicorn/prefer-string-raw error\n"+
+      "const inner = \"C:\\\\Users\\\\me\";\n"+
+      "const trailing = \"C:\\\\Users\\\\\";\n"+
+      "const onlyBackslashes = \"\\\\\\\\\";\n"+
+      "const template = `C:\\\\Users\\\\`;\n",
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_literals_with_backtick_or_substitution_opener_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_literals_with_backtick_or_substitution_opener_test.go
@@ -9,11 +9,15 @@ import "testing"
 // backticks, a literal backtick would close the template early and `${` would
 // start a substitution, so the advised conversion produces different code — or
 // no code at all. A lone `$` is harmless and must still report, which is why
-// the guard keys on the two-character opener rather than the dollar sign.
+// the guard keys on the two-character opener rather than the dollar sign. A
+// template already spells both as escapes, so upstream leaves them to its
+// value comparison rather than a second explicit guard — and so does the port,
+// which is why the same two characters must be exercised through templates.
 //
 //  1. Enable unicorn/prefer-string-raw on a fixture whose annotated line holds
 //     a dollar sign that opens nothing.
-//  2. Add literals carrying a backtick and a `${` substitution opener.
+//  2. Add string literals carrying a backtick and a `${` substitution opener,
+//     then the templates that escape those same two characters.
 //  3. Assert the annotated line is the ONLY finding.
 func TestUnicornPreferStringRawSkipsLiteralsWithBacktickOrSubstitutionOpener(t *testing.T) {
   assertRuleCorpusCase(
@@ -22,6 +26,8 @@ func TestUnicornPreferStringRawSkipsLiteralsWithBacktickOrSubstitutionOpener(t *
     "// expect: unicorn/prefer-string-raw error\n"+
       "const dollar = \"a\\\\b$c\";\n"+
       "const backtick = \"a\\\\b`c\";\n"+
-      "const opener = \"a\\\\b${c}\";\n",
+      "const opener = \"a\\\\b${c}\";\n"+
+      "const templateBacktick = `a\\\\b\\`c`;\n"+
+      "const templateOpener = `a\\\\b\\${c}`;\n",
   )
 }

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_literals_with_backtick_or_substitution_opener_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_literals_with_backtick_or_substitution_opener_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestUnicornPreferStringRawSkipsLiteralsWithBacktickOrSubstitutionOpener
+// verifies the rule stays silent when the value cannot live inside a template.
+//
+// Pins upstream's `raw.includes("`") || raw.includes("${")` guard. Wrapped in
+// backticks, a literal backtick would close the template early and `${` would
+// start a substitution, so the advised conversion produces different code — or
+// no code at all. A lone `$` is harmless and must still report, which is why
+// the guard keys on the two-character opener rather than the dollar sign.
+//
+//  1. Enable unicorn/prefer-string-raw on a fixture whose annotated line holds
+//     a dollar sign that opens nothing.
+//  2. Add literals carrying a backtick and a `${` substitution opener.
+//  3. Assert the annotated line is the ONLY finding.
+func TestUnicornPreferStringRawSkipsLiteralsWithBacktickOrSubstitutionOpener(t *testing.T) {
+  assertRuleCorpusCase(
+    t,
+    "unicorn/prefer-string-raw-template-delimiters.ts",
+    "// expect: unicorn/prefer-string-raw error\n"+
+      "const dollar = \"a\\\\b$c\";\n"+
+      "const backtick = \"a\\\\b`c\";\n"+
+      "const opener = \"a\\\\b${c}\";\n",
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_literals_with_other_escapes_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_literals_with_other_escapes_test.go
@@ -1,0 +1,32 @@
+package linthost
+
+import "testing"
+
+// TestUnicornPreferStringRawSkipsLiteralsWithOtherEscapes verifies the rule
+// stays silent when a literal carries an escape other than `\\`.
+//
+// Pins upstream's `unescapeBackslash(raw) !== node.value` guard. `String.raw`
+// emits every escape by its source spelling, so converting `"\\d\t"` would
+// turn the TAB into the two characters `\t` — a silent value change. The port
+// used to report any literal whose raw source contained `\\`, which advised
+// exactly that corruption (issue #575). The escaped backslash on its own
+// (`"\\n"` — a backslash followed by the letter `n`) must still report, so the
+// guard cannot be implemented as "raw contains a second backslash".
+//
+//  1. Enable unicorn/prefer-string-raw on a fixture whose only annotated line
+//     is a literal escaping nothing but backslashes.
+//  2. Add string and template literals that mix `\\` with a tab, a hex, and a
+//     newline escape.
+//  3. Assert the annotated line is the ONLY finding.
+func TestUnicornPreferStringRawSkipsLiteralsWithOtherEscapes(t *testing.T) {
+  assertRuleCorpusCase(
+    t,
+    "unicorn/prefer-string-raw-other-escapes.ts",
+    "// expect: unicorn/prefer-string-raw error\n"+
+      "const backslashOnly = \"\\\\n\";\n"+
+      "const tab = \"\\\\d\\t\";\n"+
+      "const hex = \"\\\\d\\x41\";\n"+
+      "const newline = \"\\\\d\\n\";\n"+
+      "const template = `\\\\d\\t`;\n",
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_literals_without_escaped_backslashes_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_literals_without_escaped_backslashes_test.go
@@ -1,0 +1,30 @@
+package linthost
+
+import "testing"
+
+// TestUnicornPreferStringRawSkipsLiteralsWithoutEscapedBackslashes verifies
+// the rule stays silent when there is no backslash escape to drop.
+//
+// Pins upstream's `!raw.includes("\\\\")` guard together with its boundary
+// cases: the empty literal, the empty template, and a literal whose lone
+// escape is not a backslash have nothing `String.raw` could simplify, and an
+// astral rune must not be mistaken for one — a byte-wise scan of UTF-8 sees no
+// `\` inside a multi-byte sequence, and the port must keep it that way.
+//
+//  1. Enable unicorn/prefer-string-raw on a fixture whose annotated line pairs
+//     an astral rune with a real `\\` escape.
+//  2. Add the empty string, the empty template, plain text, and a literal
+//     whose only escape is `\n`.
+//  3. Assert the annotated line is the ONLY finding.
+func TestUnicornPreferStringRawSkipsLiteralsWithoutEscapedBackslashes(t *testing.T) {
+  assertRuleCorpusCase(
+    t,
+    "unicorn/prefer-string-raw-no-escapes.ts",
+    "// expect: unicorn/prefer-string-raw error\n"+
+      "const astral = \"🦄\\\\d\";\n"+
+      "const empty = \"\";\n"+
+      "const emptyTemplate = ``;\n"+
+      "const plain = \"C:/Users/me\";\n"+
+      "const newline = \"line\\nbreak\";\n",
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_multiline_string_literals_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_multiline_string_literals_test.go
@@ -1,0 +1,34 @@
+package linthost
+
+import "testing"
+
+// TestUnicornPreferStringRawSkipsMultilineStringLiterals verifies the rule
+// stays silent on a string literal continued onto a second line.
+//
+// Pins upstream's `start.line !== end.line` guard. A string literal reaches a
+// second line only through a line continuation, whose backslash-newline pair
+// the parser swallows; inside a `String.raw` template both characters would
+// survive, so the value gains a backslash and a newline. Both line endings are
+// covered because a CRLF checkout must not decide whether the rule fires.
+//
+//  1. Enable unicorn/prefer-string-raw on a fixture whose annotated line holds
+//     a single-line path.
+//  2. Continue the same path across a line break, once with LF and once with
+//     CRLF.
+//  3. Assert the annotated line is the ONLY finding in either file.
+func TestUnicornPreferStringRawSkipsMultilineStringLiterals(t *testing.T) {
+  assertRuleCorpusCase(
+    t,
+    "unicorn/prefer-string-raw-multiline-lf.ts",
+    "// expect: unicorn/prefer-string-raw error\n"+
+      "const single = \"C:\\\\Users\\\\me\";\n"+
+      "const continued = \"C:\\\\Users\\\\\\\nme\";\n",
+  )
+  assertRuleCorpusCase(
+    t,
+    "unicorn/prefer-string-raw-multiline-crlf.ts",
+    "// expect: unicorn/prefer-string-raw error\r\n"+
+      "const single = \"C:\\\\Users\\\\me\";\r\n"+
+      "const continued = \"C:\\\\Users\\\\\\\r\nme\";\r\n",
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_tagged_template_quasis_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_skips_tagged_template_quasis_test.go
@@ -1,0 +1,36 @@
+package linthost
+
+import "testing"
+
+// TestUnicornPreferStringRawSkipsTaggedTemplateQuasis verifies the rule leaves
+// the quasi of a tagged template alone.
+//
+// A tag function receives the RAW strings, so the escapes carry meaning and no
+// `String.raw` prefix can be added — least of all to a template already tagged
+// with `String.raw`, which the port used to flag against its own advice. The
+// exemption is exactly the quasi: a literal sitting inside a substitution of a
+// tagged template is ordinary code and must still report, so the predicate
+// cannot degrade into "has a tagged template above it".
+//
+//  1. Tag two templates carrying `\\` escapes, one of them with `String.raw`.
+//  2. Nest a template literal and a string literal inside the substitutions of
+//     another tagged template, and annotate both.
+//  3. Assert the tagged quasis report nothing while the two nested literals do.
+func TestUnicornPreferStringRawSkipsTaggedTemplateQuasis(t *testing.T) {
+  assertRuleSkipsSource(
+    t,
+    "unicorn/prefer-string-raw",
+    "declare const dedent: (strings: TemplateStringsArray) => string;\n"+
+      "const raw = String.raw`C:\\\\Users\\\\me`;\n"+
+      "const trimmed = dedent`C:\\\\Users\\\\me`;\n",
+  )
+  assertRuleCorpusCase(
+    t,
+    "unicorn/prefer-string-raw-tagged-substitution.ts",
+    "declare const tag: (strings: TemplateStringsArray, value: string) => string;\n"+
+      "// expect: unicorn/prefer-string-raw error\n"+
+      "const nestedTemplate = tag`${`C:\\\\Users\\\\me`}`;\n"+
+      "// expect: unicorn/prefer-string-raw error\n"+
+      "const nestedString = tag`${\"C:\\\\Users\\\\me\"}`;\n",
+  )
+}

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_survives_unterminated_literals_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_survives_unterminated_literals_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import "testing"
+
+// TestUnicornPreferStringRawSurvivesUnterminatedLiterals verifies the rule
+// reports nothing, and slices nothing out of bounds, on a recovered parse
+// error.
+//
+// The lint engine walks whatever AST the parser recovers, so an unterminated
+// literal reaches the rule as a token with no closing delimiter — in the
+// degenerate case a lone quote or backtick, one byte long. The payload slice
+// `source[pos+1 : end-1]` is invalid for such a token, so the delimiter and
+// length guards must run first; upstream never sees these files at all, and a
+// half-typed path in an editor buffer must not advise a `String.raw`
+// conversion of a literal that does not exist yet.
+//
+//  1. Lint an unterminated string and an unterminated template, both carrying
+//     the `\\` escapes the rule keys on.
+//  2. Lint the degenerate one-byte tokens: a lone quote and a lone backtick at
+//     end of file.
+//  3. Assert every one of them is silent.
+func TestUnicornPreferStringRawSurvivesUnterminatedLiterals(t *testing.T) {
+  for _, source := range []string{
+    "const unterminatedString = \"C:\\\\Users\\\\me\n",
+    "const unterminatedTemplate = `C:\\\\Users\\\\me\n",
+    "const loneQuote = \"",
+    "const loneBacktick = `",
+  } {
+    assertRuleSkipsSource(t, "unicorn/prefer-string-raw", source)
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_test.go
@@ -3,15 +3,15 @@ package linthost
 import "testing"
 
 // TestRuleCorpusUnicornPreferStringRaw verifies the rule reports a
-// string literal whose source contains escaped backslashes.
+// string literal whose escapes are nothing but backslashes.
 //
-// The detection scans the literal's raw source bytes for the two-byte
-// sequence `\\` — the escape form `String.raw` would let the author
-// drop. A Windows-shaped path is the canonical example and the minimal
+// The positive case the suppression guards must never swallow: every escape
+// in the literal is `\\`, so `String.raw` respells the value character for
+// character. A Windows-shaped path is the canonical example and the minimal
 // positive case.
 //
 // 1. Enable unicorn/prefer-string-raw via an expect annotation.
-// 2. Write a string literal with `\\` escapes (`"C:\\Users\\me"`).
+// 2. Write a string literal whose only escapes are `\\` (`"C:\\Users\\me"`).
 // 3. Assert the string literal is reported.
 func TestRuleCorpusUnicornPreferStringRaw(t *testing.T) {
   assertRuleCorpusCase(t, "unicorn/prefer-string-raw.ts", "// expect: unicorn/prefer-string-raw error\nconst p = \"C:\\\\Users\\\\me\";\n")

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_unescapes_only_the_delimiter_quote_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_string_raw_unescapes_only_the_delimiter_quote_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestUnicornPreferStringRawUnescapesOnlyTheDelimiterQuote verifies the value
+// comparison unescapes the literal's OWN quote and no other.
+//
+// Upstream builds its unescape pattern from the literal's delimiter
+// (`[\\${quote}]`), so `\"` cancels out in a double-quoted literal but stays
+// an escape in a single-quoted one — where `String.raw` would emit the
+// backslash and change the value. A port that unescaped both quote characters,
+// or neither, would flip one of these two lines.
+//
+//  1. Double-quote a literal that escapes its own delimiter alongside `\\`.
+//  2. Single-quote a literal escaping the OTHER quote alongside `\\`.
+//  3. Assert only the double-quoted line, whose escapes all cancel, reports.
+func TestUnicornPreferStringRawUnescapesOnlyTheDelimiterQuote(t *testing.T) {
+  assertRuleCorpusCase(
+    t,
+    "unicorn/prefer-string-raw-delimiter-quote.ts",
+    "// expect: unicorn/prefer-string-raw error\n"+
+      "const own = \"a\\\"b\\\\c\";\n"+
+      "const other = 'a\\\"b\\\\c';\n",
+  )
+}

--- a/tests/test-lint/src/cases/unicorn-prefer-string-raw.ts
+++ b/tests/test-lint/src/cases/unicorn-prefer-string-raw.ts
@@ -1,2 +1,27 @@
 // expect: unicorn/prefer-string-raw error
 const p = "C:\\Users\\me";
+// expect: unicorn/prefer-string-raw error
+const backslashThenLetter = "\\n";
+// expect: unicorn/prefer-string-raw error
+const multilineTemplate = `C:\\Users
+D:\\Data`;
+const otherEscape = "\\d\t";
+const trailingBackslash = "C:\\Users\\";
+const backtick = "a\\b`c";
+const substitutionOpener = "a\\b${c}";
+const continuedLine = "C:\\Users\\\
+me";
+const tagged = String.raw`C:\\Users\\me`;
+const noBackslash = "C:/Users/me";
+export default [
+  p,
+  backslashThenLetter,
+  multilineTemplate,
+  otherEscape,
+  trailingBackslash,
+  backtick,
+  substitutionOpener,
+  continuedLine,
+  tagged,
+  noBackslash,
+];

--- a/website/src/content/docs/lint/rules/unicorn.mdx
+++ b/website/src/content/docs/lint/rules/unicorn.mdx
@@ -2075,11 +2075,15 @@ const b = Array.from(a);
 
 Prefer `String.raw` for path literals and other strings that would otherwise need backslash escapes.
 
+The rule only reports when a `String.raw` template would reproduce the value exactly, so a literal is left alone when it carries any escape other than `\\` (`"\\d\t"` would turn its tab into the two characters `\t`), when its value ends with a backslash (a raw template cannot end in one), when it contains a backtick or `${` (the template would close early or interpolate), or when a line continuation spreads it over two lines. A no-substitution template is reported under the same value-preserving condition, except that its newlines are already literal, so a multi-line template stays reportable; the quasi of a tagged template — including `` String.raw`…` `` itself — is never reported. The report carries no autofix.
+
 Example:
 
 ```ts
 // reports: unicorn/prefer-string-raw (error)
 const p = "C:\\Users\\me";
+// not reported: the tab escape would not survive String.raw
+const q = "C:\\Users\tme";
 ```
 
 <a id="rule-unicorn-prefer-string-replace-all"></a>


### PR DESCRIPTION
## Intent

`unicorn/prefer-string-raw` reported **any** string or no-substitution template whose raw source contained `\`, so it advised a `String.raw` conversion that would silently change the string's value — and with the rule at `error` it failed CI on correct code.

Fixes #575.

## Scope

**String literals** now reproduce upstream's `Literal` handler. A report survives only when unescaping `\` and the delimiter quote out of the raw payload reproduces the cooked value, on a single line, with no trailing backslash, backtick, or `${`:

| skipped | why the advice was wrong |
| --- | --- |
| `"\d\t"` (any non-backslash escape) | `String.raw` emits `\t` as two characters — a value change |
| `"C:\Users\\"` (value ends in `\`) | a raw template cannot end in a backslash |
| ``"a\b`c"``, `"a\b${c}"` | the template would close early or interpolate |
| `"C:\Users\` + newline + `me"` | the continuation's backslash-newline would survive |
| `String.raw`…`` / any tagged quasi | the tag already observes the raw text |

**No-substitution templates** reproduce upstream's `TemplateLiteral` handler instead: their newlines are already literal, so multi-line templates stay reportable, and a backtick or `${` is already spelled as an escape and falls out of the same value comparison. Their raw payload is LF-normalized the way acorn materializes `TemplateElement.value.raw`, so a CRLF checkout does not decide whether the rule fires.

The tagged-quasi predicate and the acorn newline normalization moved to `ast_helpers.go` and are now shared with `unicorn/consistent-template-literal-escape` and `unicorn/string-content` rather than duplicated.

## Deferred

Upstream additionally suppresses the report **by position** (`isStringRawRestricted`: directive prologues, property keys, module specifiers, TS literal types and enum members, …) and inside Jest inline snapshots. That axis is out of #575's scope and stays unported — it is called out in the rule's doc comment. JSX attribute values, the one entry of that list that matters in practice, are already silent here through the value comparison (a JSX string has no escape sequences, so its cooked text keeps the doubled backslash). The port also remains report-only; upstream's autofix is still not ported.

## Test plan

`node scripts/test-go-lint.cjs` — full Go lint suite green.

Repro: the six new negative-twin scenarios fail on `master` (e.g. `"\d\t"`, `"C:\Users\\"`, ``"a\b`c"``, the continued literal, and `String.raw`C:\Users\me`` all report) and pass on this branch.

New Go cases under `packages/lint/test/rules/unicorn/`, one guard per file, each pairing a negative with the positive it must not swallow:

- other escapes (tab / hex / newline) vs. `"\n"`, which must still report
- delimiter quote: `"a\"b\c"` reports, `'a\"b\c'` does not
- trailing backslash, including the all-backslashes literal and the template twin
- backtick / `${`, including the template spellings, vs. a lone `$`
- multi-line string literals, LF and CRLF
- multi-line and CRLF templates, which must keep reporting
- tagged quasis vs. literals nested in a tagged template's substitutions
- JSX attribute strings
- unterminated literals (a lone quote or backtick would otherwise slice out of bounds)
- the no-escape boundaries: empty string, empty template, plain text, astral rune

The e2e rule corpus (`tests/test-lint/src/cases/unicorn-prefer-string-raw.ts`) carries the same cases, and the website rule page states when the rule stays silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND