### PR TITLE
fix(lint): match every `*Error` callee in unicorn/throw-new-error

### DIFF
--- a/packages/lint/linthost/rules_unicorn_throw_new_error.go
+++ b/packages/lint/linthost/rules_unicorn_throw_new_error.go
@@ -1,31 +1,42 @@
 // unicorn/throw-new-error: `throw Foo(...)` and `throw new Foo(...)` both
-// produce an Error instance because the built-in Error constructors are
+// produce an Error instance for the BUILT-IN Error constructors, which stay
 // callable without `new`, but the call-form is a footgun — readers expect
-// `throw` to be paired with `new`, and some tooling (notably custom Error
-// subclasses) stops working when the call-form is mixed in. The rule
-// requires `throw new` whenever the operand is a direct call to one of the
-// eight built-in Error constructor names.
+// `throw` to be paired with `new`, and a user-defined `class FooError extends
+// Error` cannot be called without `new` at all: the call throws a TypeError
+// instead of the error the author meant to throw. The rule requires
+// `throw new` whenever the operand is a direct call to an error-like
+// constructor.
+//
+// The callee predicate is upstream's: an `Identifier` callee, or a
+// non-computed member callee whose property is an `Identifier`, whose name
+// matches `^(?:[A-Z][\da-z]*)*Error$`. That covers the built-ins
+// (`TypeError`) AND user-defined classes (`ValidationError`,
+// `ns.HttpError`), which are the rule's most common real-world target.
 //
 // AST-only: visit each `ThrowStatement`, peel parentheses off its operand,
 // and fire when the operand is a `CallExpression` (NOT a `NewExpression`)
-// whose callee is an `Identifier` matching the built-in allowlist. Shadowed
-// bindings and type-aware widening are intentionally out of scope — the
-// rule is a syntactic nudge, not a full Error-tracking pass.
+// whose callee matches. Computed access (`lib["Error"]()`) is skipped, and
+// so is any optional-chained callee (`Error?.()`, `lib?.Error()`) because
+// `new` cannot be applied to an optional chain. Shadowed bindings and
+// type-aware widening are intentionally out of scope — the rule is a
+// syntactic nudge, not a full Error-tracking pass. Unlike upstream, which
+// flags every error-constructing call site, this port stays scoped to
+// `throw` operands.
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/throw-new-error.md
 package linthost
 
-import shimast "github.com/microsoft/typescript-go/shim/ast"
+import (
+  "regexp"
 
-var unicornThrowNewErrorBuiltinNames = map[string]struct{}{
-  "Error":          {},
-  "TypeError":      {},
-  "RangeError":     {},
-  "SyntaxError":    {},
-  "ReferenceError": {},
-  "EvalError":      {},
-  "URIError":       {},
-  "AggregateError": {},
-}
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// unicornThrowNewErrorNamePattern is upstream's `customError` regex: any
+// number of capitalized words (each a capital followed by digits/lowercase)
+// closed by a literal `Error`. It accepts `Error`, `TypeError`, `HTTPError`,
+// and `Abc3Error`, and rejects `fooError` (no leading capital), `ERROR` (the
+// suffix is case-sensitive), `getError`, and `Errors`.
+var unicornThrowNewErrorNamePattern = regexp.MustCompile(`^(?:[A-Z][\da-z]*)*Error$`)
 
 type unicornThrowNewError struct{}
 
@@ -35,7 +46,7 @@ func (unicornThrowNewError) Visits() []shimast.Kind {
 }
 func (unicornThrowNewError) Check(ctx *Context, node *shimast.Node) {
   throw := node.AsThrowStatement()
-  if throw == nil {
+  if throw == nil || throw.Expression == nil {
     return
   }
   expr := stripParens(throw.Expression)
@@ -43,17 +54,198 @@ func (unicornThrowNewError) Check(ctx *Context, node *shimast.Node) {
     return
   }
   call := expr.AsCallExpression()
-  if call == nil {
+  if call == nil || call.Expression == nil {
     return
   }
-  name := identifierText(call.Expression)
-  if name == "" {
+  // `new` cannot be applied to an optional chain (`new lib?.Error()` is a
+  // syntax error), so upstream reports neither an optional call nor an
+  // optional-chained callee.
+  if call.QuestionDotToken != nil || unicornThrowNewErrorHasOptionalChain(call.Expression) {
     return
   }
-  if _, ok := unicornThrowNewErrorBuiltinNames[name]; !ok {
+  callee := stripParens(call.Expression)
+  if !unicornThrowNewErrorIsErrorCallee(callee) {
     return
   }
-  ctx.Report(expr, "Use `new` when throwing an error.")
+  ctx.ReportFix(
+    expr,
+    "Use `new` when throwing an error.",
+    unicornThrowNewErrorFix(ctx.File, throw.Expression, expr, call.Expression)...,
+  )
+}
+
+// unicornThrowNewErrorIsErrorCallee reports whether a callee names an error
+// constructor. A bare identifier matches on its own name; a property access
+// matches on its property name, so `ns.FooError()` counts while the computed
+// `ns["FooError"]()` (an element access) never does — computed keys are opaque
+// to upstream's selector too.
+//
+// `Data.TaggedError(...)` is upstream's Effect-library carve-out: the call
+// builds an error CLASS rather than an error instance, so `new` would be wrong.
+// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2654
+func unicornThrowNewErrorIsErrorCallee(callee *shimast.Node) bool {
+  if callee == nil {
+    return false
+  }
+  switch callee.Kind {
+  case shimast.KindIdentifier:
+    return unicornThrowNewErrorNamePattern.MatchString(identifierText(callee))
+  case shimast.KindPropertyAccessExpression:
+    access := callee.AsPropertyAccessExpression()
+    if access == nil {
+      return false
+    }
+    name := identifierText(access.Name())
+    if !unicornThrowNewErrorNamePattern.MatchString(name) {
+      return false
+    }
+    return name != "TaggedError" ||
+      identifierText(stripParens(access.Expression)) != "Data"
+  default:
+    return false
+  }
+}
+
+// unicornThrowNewErrorHasOptionalChain reports whether any element on a
+// callee's left-hand chain uses `?.`, mirroring upstream's
+// `hasOptionalChainElement`. It differs from the shared `containsOptionalChain`
+// by seeing through parentheses and TypeScript's type-only wrappers, so
+// `(lib?.foo)!.Error()` is still recognized as an optional chain; `new` on any
+// such callee is a syntax error, and the rule must stay silent rather than
+// offer a fix that breaks the file.
+func unicornThrowNewErrorHasOptionalChain(node *shimast.Node) bool {
+  node = unwrapReferenceExpression(node)
+  if node == nil {
+    return false
+  }
+  switch node.Kind {
+  case shimast.KindPropertyAccessExpression:
+    access := node.AsPropertyAccessExpression()
+    if access == nil {
+      return false
+    }
+    return access.QuestionDotToken != nil ||
+      unicornThrowNewErrorHasOptionalChain(access.Expression)
+  case shimast.KindElementAccessExpression:
+    access := node.AsElementAccessExpression()
+    if access == nil {
+      return false
+    }
+    return access.QuestionDotToken != nil ||
+      unicornThrowNewErrorHasOptionalChain(access.Expression)
+  case shimast.KindCallExpression:
+    call := node.AsCallExpression()
+    if call == nil {
+      return false
+    }
+    return call.QuestionDotToken != nil ||
+      unicornThrowNewErrorHasOptionalChain(call.Expression)
+  default:
+    return false
+  }
+}
+
+// unicornThrowNewErrorFix builds upstream's autofix: insert `new ` in front of
+// the reported call. Two adjustments keep the rewritten source parseable, both
+// owed to upstream's shared `switchCallExpressionToNewExpression` fixer.
+//
+// A `throw` keyword that abuts its operand (`throw(Error())`,
+// `throw[lib][0].Error()`) needs a separating space, or the inserted keyword
+// welds onto it (`thrownew ...`). The space belongs at the operand's own start
+// — outside any parentheses wrapping it — and merges into the `new ` insert
+// when the two offsets coincide, because two zero-width inserts at one offset
+// cannot both survive edit selection.
+//
+// A callee that still exposes a call needs parentheses, because a `new`
+// expression's callee grammar ends at the first argument list; see
+// unicornThrowNewErrorCalleeNeedsParens.
+func unicornThrowNewErrorFix(
+  file *shimast.SourceFile,
+  operand *shimast.Node,
+  call *shimast.Node,
+  rawCallee *shimast.Node,
+) []TextEdit {
+  if file == nil {
+    return nil
+  }
+  callee := stripParens(rawCallee)
+  operandStart, _ := tokenRange(file, operand)
+  // A callee is its call's first token, so the call and its callee share one
+  // start offset; the opening parenthesis therefore rides along with the `new `
+  // insert instead of being a second zero-width edit at that same offset.
+  callStart, _ := tokenRange(file, call)
+  _, calleeEnd := tokenRange(file, callee)
+  if operandStart < 0 || callStart < 0 || calleeEnd < 0 {
+    return nil
+  }
+  src := file.Text()
+  parenthesize := unicornThrowNewErrorCalleeNeedsParens(rawCallee, callee)
+  insert := "new "
+  if parenthesize {
+    insert += "("
+  }
+  edits := make([]TextEdit, 0, 3)
+  if operandStart > 0 && isIdentifierPart(src[operandStart-1]) {
+    if operandStart == callStart {
+      insert = " " + insert
+    } else {
+      edits = append(edits, TextEdit{Pos: operandStart, End: operandStart, Text: " "})
+    }
+  }
+  edits = append(edits, TextEdit{Pos: callStart, End: callStart, Text: insert})
+  if parenthesize {
+    edits = append(edits, TextEdit{Pos: calleeEnd, End: calleeEnd, Text: ")"})
+  }
+  return edits
+}
+
+// unicornThrowNewErrorCalleeNeedsParens reports whether the fix has to wrap the
+// callee in parentheses: only when the source does not already parenthesize the
+// callee itself and an unshielded call sits on its object chain, whose argument
+// list `new` would otherwise consume as its own.
+//
+// The walk stops at a parenthesized object because parentheses already shield
+// everything inside them — `throw (getGlobalThis()).Error()` fixes to
+// `throw new (getGlobalThis()).Error()`, whose callee parse ends at `.Error`.
+// A non-null assertion shields nothing, so it stays transparent: without that
+// step `throw lib.getError()!.FooError()` would fix to
+// `throw new lib.getError()!.FooError()`, which constructs `lib.getError()` and
+// then reads `.FooError()` off the instance.
+func unicornThrowNewErrorCalleeNeedsParens(rawCallee, callee *shimast.Node) bool {
+  if rawCallee == nil || rawCallee.Kind == shimast.KindParenthesizedExpression {
+    return false
+  }
+  if callee == nil || callee.Kind != shimast.KindPropertyAccessExpression {
+    return false
+  }
+  access := callee.AsPropertyAccessExpression()
+  if access == nil {
+    return false
+  }
+  current := access.Expression
+  for current != nil {
+    switch current.Kind {
+    case shimast.KindCallExpression:
+      return true
+    case shimast.KindPropertyAccessExpression:
+      inner := current.AsPropertyAccessExpression()
+      if inner == nil {
+        return false
+      }
+      current = inner.Expression
+    case shimast.KindElementAccessExpression:
+      inner := current.AsElementAccessExpression()
+      if inner == nil {
+        return false
+      }
+      current = inner.Expression
+    case shimast.KindNonNullExpression:
+      current = current.Expression()
+    default:
+      return false
+    }
+  }
+  return false
 }
 
 func init() {

--- a/packages/lint/test/rules/unicorn/unicorn_throw_new_error_fix_parenthesizes_a_shielded_call_chain_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_throw_new_error_fix_parenthesizes_a_shielded_call_chain_test.go
@@ -1,0 +1,64 @@
+package linthost
+
+import "testing"
+
+// TestUnicornThrowNewErrorFixParenthesizesAShieldedCallChain verifies the callee
+// parenthesization decision on the TypeScript-only chain shapes upstream's
+// ESTree fixer never sees.
+//
+// `new`'s callee grammar ends at the first argument list, so the fix has to
+// parenthesize a callee whose object chain still exposes a call. A non-null
+// assertion does not shield that call — upstream's walk stops at
+// `TSNonNullExpression` and would emit `new lib.getError()!.FooError()`, which
+// constructs `lib.getError()` and reads `.FooError()` off the instance — while
+// real parentheses do shield it, so `(lib.getError() as any).FooError()` must
+// not collect a second pair. Type arguments belong to the call, not the callee,
+// so the closing parenthesis has to land before them.
+//
+//  1. Fix a `!`-pierced chain, two parenthesis-shielded chains, and a generic
+//     call with and without a parenthesized callee.
+//  2. Compare the rewritten file byte-for-byte.
+//  3. Reparse the output and assert the rule no longer fires on it.
+func TestUnicornThrowNewErrorFixParenthesizesAShieldedCallChain(t *testing.T) {
+  cases := []struct {
+    name     string
+    source   string
+    expected string
+  }{
+    {
+      name:     "non-null assertion does not shield the call",
+      source:   "throw lib.getError()!.FooError();\n",
+      expected: "throw new (lib.getError()!.FooError)();\n",
+    },
+    {
+      name:     "parentheses shield the call",
+      source:   "throw (lib.getError() as any).FooError();\n",
+      expected: "throw new (lib.getError() as any).FooError();\n",
+    },
+    {
+      name:     "parenthesized call object shields the call",
+      source:   "throw (getGlobalThis()).Error();\n",
+      expected: "throw new (getGlobalThis()).Error();\n",
+    },
+    {
+      name:     "type arguments stay with the call",
+      source:   "throw ns.FooError<string>(\"x\");\n",
+      expected: "throw new ns.FooError<string>(\"x\");\n",
+    },
+    {
+      name:     "type arguments stay outside a parenthesized callee",
+      source:   "throw getNs().FooError<string>(\"x\");\n",
+      expected: "throw new (getNs().FooError)<string>(\"x\");\n",
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertFixSnapshot(t, "unicorn/throw-new-error", test.source, test.expected)
+      file := parseTSFile(t, "/virtual/shielded-throw-new-error.ts", test.expected)
+      if diagnostics := file.Diagnostics(); len(diagnostics) != 0 {
+        t.Fatalf("fixed source has parse diagnostics: %+v\n%s", diagnostics, test.expected)
+      }
+      assertRuleSkipsSource(t, "unicorn/throw-new-error", test.expected)
+    })
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_throw_new_error_fix_spaces_an_abutting_throw_keyword_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_throw_new_error_fix_spaces_an_abutting_throw_keyword_test.go
@@ -1,0 +1,59 @@
+package linthost
+
+import "testing"
+
+// TestUnicornThrowNewErrorFixSpacesAnAbuttingThrowKeyword verifies the fix keeps
+// the `throw` keyword a separate token when the operand starts right against it.
+//
+// A bare `insertTextBefore(call, "new ")` corrupts any source whose operand
+// needs no space after `throw` — `throw[lib][0].Error()` would become
+// `thrownew [lib][0].Error()`, a different program that no longer parses.
+// Upstream solves it with `fixSpaceAroundKeyword`; the port emits the space at
+// the operand's own start, which is outside any parentheses wrapping it, and
+// folds it into the `new ` insert when both land on the same offset — two
+// zero-width inserts at one offset cannot both survive edit selection.
+//
+//  1. Fix an operand that abuts `throw` directly, one that abuts it and also
+//     needs a parenthesized callee (both inserts land on one offset, so they
+//     have to merge into a single edit), one behind parentheses, and one behind
+//     a comment (trivia is not adjacency).
+//  2. Compare the rewritten file byte-for-byte.
+//  3. Reparse the output and assert the rule no longer fires on it.
+func TestUnicornThrowNewErrorFixSpacesAnAbuttingThrowKeyword(t *testing.T) {
+  cases := []struct {
+    name     string
+    source   string
+    expected string
+  }{
+    {
+      name:     "operand abuts the keyword",
+      source:   "throw[globalThis][0].Error();\n",
+      expected: "throw new [globalThis][0].Error();\n",
+    },
+    {
+      name:     "abutting operand whose callee also needs parentheses",
+      source:   "throw[globalThis][0].getError().FooError();\n",
+      expected: "throw new ([globalThis][0].getError().FooError)();\n",
+    },
+    {
+      name:     "parentheses abut the keyword",
+      source:   "throw(Error());\n",
+      expected: "throw (new Error());\n",
+    },
+    {
+      name:     "comment separates the keyword",
+      source:   "throw/* c */Error();\n",
+      expected: "throw/* c */new Error();\n",
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertFixSnapshot(t, "unicorn/throw-new-error", test.source, test.expected)
+      file := parseTSFile(t, "/virtual/spaced-throw-new-error.ts", test.expected)
+      if diagnostics := file.Diagnostics(); len(diagnostics) != 0 {
+        t.Fatalf("fixed source has parse diagnostics: %+v\n%s", diagnostics, test.expected)
+      }
+      assertRuleSkipsSource(t, "unicorn/throw-new-error", test.expected)
+    })
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_throw_new_error_fixes_every_throw_in_one_pass_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_throw_new_error_fixes_every_throw_in_one_pass_test.go
@@ -1,0 +1,37 @@
+package linthost
+
+import "testing"
+
+// TestUnicornThrowNewErrorFixesEveryThrowInOnePass verifies a file carrying
+// several violations is rewritten completely by a single fix pass.
+//
+// One finding of this rule can carry three text edits (a separating space, the
+// `new ` insert, a closing parenthesis), so a file with several violations hands
+// the applier a mixed batch of zero-width inserts. `selectTextEdits` drops any
+// edit that overlaps an earlier one and any second zero-width insert at an
+// offset already claimed, so a fixer that mis-anchored one of its edits would
+// silently lose edits from a neighboring finding and leave the file broken
+// (a bare `new` with no callee parentheses, say). Fixing every shape at once is
+// what proves the offsets are disjoint.
+//
+//  1. Lint one file holding an identifier callee, a member callee, a callee that
+//     needs parentheses, and an operand that abuts the `throw` keyword.
+//  2. Apply the fixes in a single pass and compare the whole file.
+//  3. Reparse the output and assert the rule no longer fires on it.
+func TestUnicornThrowNewErrorFixesEveryThrowInOnePass(t *testing.T) {
+  source := "function a() {\n  throw ValidationError(\"bad\");\n}\n" +
+    "function b() {\n  throw ns.FooError(\"x\");\n}\n" +
+    "function c() {\n  throw getGlobalThis().Error();\n}\n" +
+    "function d() {\n  throw[globalThis][0].Error();\n}\n"
+  expected := "function a() {\n  throw new ValidationError(\"bad\");\n}\n" +
+    "function b() {\n  throw new ns.FooError(\"x\");\n}\n" +
+    "function c() {\n  throw new (getGlobalThis().Error)();\n}\n" +
+    "function d() {\n  throw new [globalThis][0].Error();\n}\n"
+
+  assertFixSnapshot(t, "unicorn/throw-new-error", source, expected)
+  file := parseTSFile(t, "/virtual/batch-throw-new-error.ts", expected)
+  if diagnostics := file.Diagnostics(); len(diagnostics) != 0 {
+    t.Fatalf("fixed source has parse diagnostics: %+v\n%s", diagnostics, expected)
+  }
+  assertRuleSkipsSource(t, "unicorn/throw-new-error", expected)
+}

--- a/packages/lint/test/rules/unicorn/unicorn_throw_new_error_fixes_upstream_invalid_corpus_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_throw_new_error_fixes_upstream_invalid_corpus_test.go
@@ -1,0 +1,109 @@
+package linthost
+
+import "testing"
+
+// TestUnicornThrowNewErrorFixesUpstreamInvalidCorpus verifies every throw-shaped
+// invalid case of the upstream snapshot rewrites to the upstream fix output
+// through the native fix applier.
+//
+// The expected outputs are transcribed from eslint-plugin-unicorn 71.1.0's
+// test/snapshots/throw-new-error.js.md, so the port cannot lock in its own
+// bugs. The subtle half is the callee grammar: a `new` expression's callee ends
+// at the first argument list, so `throw getGlobalThis().Error()` may not become
+// `throw new getGlobalThis().Error()` — that constructs `getGlobalThis()` and
+// reads `.Error()` off the result. Upstream parenthesizes the callee whenever a
+// call sits on its object chain and the source has not parenthesized it already;
+// both branches are pinned here, along with the parenthesized-callee and
+// parenthesized-operand shapes whose insert offsets differ.
+//
+//  1. Run the fixer over each upstream invalid source.
+//  2. Compare the rewritten file byte-for-byte with the upstream output.
+//  3. Reparse the output and assert the rule no longer fires on it.
+func TestUnicornThrowNewErrorFixesUpstreamInvalidCorpus(t *testing.T) {
+  cases := []struct {
+    name     string
+    source   string
+    expected string
+  }{
+    {
+      name:     "builtin identifier callee",
+      source:   "throw Error();\n",
+      expected: "throw new Error();\n",
+    },
+    {
+      name:     "custom error identifier callee",
+      source:   "throw CustomError('foo');\n",
+      expected: "throw new CustomError('foo');\n",
+    },
+    {
+      name:     "acronym word callee",
+      source:   "throw ABCError('foo');\n",
+      expected: "throw new ABCError('foo');\n",
+    },
+    {
+      name:     "digit inside a word callee",
+      source:   "throw Abc3Error('foo');\n",
+      expected: "throw new Abc3Error('foo');\n",
+    },
+    {
+      name:     "parenthesized callee",
+      source:   "throw (Error)();\n",
+      expected: "throw new (Error)();\n",
+    },
+    {
+      name:     "member callee",
+      source:   "throw lib.Error();\n",
+      expected: "throw new lib.Error();\n",
+    },
+    {
+      name:     "nested member callee",
+      source:   "throw lib.mod.Error();\n",
+      expected: "throw new lib.mod.Error();\n",
+    },
+    {
+      name:     "computed link inside the callee chain",
+      source:   "throw lib[mod].Error();\n",
+      expected: "throw new lib[mod].Error();\n",
+    },
+    {
+      name:     "parenthesized object inside the callee chain",
+      source:   "throw (lib.mod).Error();\n",
+      expected: "throw new (lib.mod).Error();\n",
+    },
+    {
+      name:     "parenthesized operand",
+      source:   "throw (( URIError() ));\n",
+      expected: "throw (( new URIError() ));\n",
+    },
+    {
+      name:     "parenthesized identifier callee",
+      source:   "throw (( URIError ))();\n",
+      expected: "throw new (( URIError ))();\n",
+    },
+    {
+      name:     "call on the callee chain needs parentheses",
+      source:   "throw getGlobalThis().Error();\n",
+      expected: "throw new (getGlobalThis().Error)();\n",
+    },
+    {
+      name:     "deep call on the callee chain needs parentheses",
+      source:   "throw utils.getGlobalThis().Error();\n",
+      expected: "throw new (utils.getGlobalThis().Error)();\n",
+    },
+    {
+      name:     "already parenthesized callee keeps its parentheses",
+      source:   "throw (( getGlobalThis().Error ))();\n",
+      expected: "throw new (( getGlobalThis().Error ))();\n",
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertFixSnapshot(t, "unicorn/throw-new-error", test.source, test.expected)
+      file := parseTSFile(t, "/virtual/fixed-throw-new-error.ts", test.expected)
+      if diagnostics := file.Diagnostics(); len(diagnostics) != 0 {
+        t.Fatalf("fixed source has parse diagnostics: %+v\n%s", diagnostics, test.expected)
+      }
+      assertRuleSkipsSource(t, "unicorn/throw-new-error", test.expected)
+    })
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_throw_new_error_reports_custom_and_member_callees_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_throw_new_error_reports_custom_and_member_callees_test.go
@@ -1,0 +1,57 @@
+package linthost
+
+import "testing"
+
+// TestUnicornThrowNewErrorReportsCustomAndMemberCallees verifies the rule fires
+// for every callee upstream's `^(?:[A-Z][\da-z]*)*Error$` name pattern accepts,
+// through an identifier callee and through a non-computed member callee alike.
+//
+// The port used to carry an eight-entry allowlist of built-in Error names and
+// to read the callee through `identifierText`, which returns "" for anything
+// that is not an Identifier. User-defined classes (`ValidationError`) and
+// namespaced constructors (`ns.FooError()`) — the rule's most common real-world
+// target — were therefore accepted in silence. Each case below pins one part of
+// the ported predicate: a capitalized word chain, an all-caps acronym word, a
+// digit inside a word, `Error` as an interior word, a nested member chain, a
+// computed link inside an otherwise static chain, a parenthesized callee, and a
+// callee whose object is itself a call. `data.TaggedError("x")` is a positive on
+// purpose: upstream's Effect carve-out keys on the exact `Data` object name, so
+// any other receiver stays reportable.
+//
+//  1. Lint `throw <callee>(...);` with only unicorn/throw-new-error enabled.
+//  2. Assert exactly one finding carrying the rule's message.
+//  3. Assert the finding covers the whole call expression, not just the callee.
+func TestUnicornThrowNewErrorReportsCustomAndMemberCallees(t *testing.T) {
+  for _, call := range []string{
+    `Error("oops")`,
+    `TypeError("oops")`,
+    `AggregateError([], "oops")`,
+    `ValidationError("bad")`,
+    `HTTPError()`,
+    `Abc3Error()`,
+    `MyErrorError()`,
+    `ns.FooError("x")`,
+    `ns.Error()`,
+    `a.b.FooError()`,
+    `lib[mod].Error()`,
+    `(Error)()`,
+    `(( URIError ))()`,
+    `getGlobalThis().Error()`,
+    `data.TaggedError("x")`,
+  } {
+    source := "throw " + call + ";\n"
+    _, _, findings := runRuleFindingsSnapshot(t, "unicorn/throw-new-error", source, nil)
+    if len(findings) != 1 {
+      t.Fatalf("%q: want one finding, got %d (%+v)", source, len(findings), findings)
+    }
+    finding := findings[0]
+    if finding.Message != "Use `new` when throwing an error." {
+      t.Fatalf("%q: message = %q", source, finding.Message)
+    }
+    wantPos := len("throw ")
+    wantEnd := wantPos + len(call)
+    if finding.Pos != wantPos || finding.End != wantEnd {
+      t.Fatalf("%q: range = [%d,%d), want [%d,%d)", source, finding.Pos, finding.End, wantPos, wantEnd)
+    }
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_throw_new_error_skips_non_matching_callees_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_throw_new_error_skips_non_matching_callees_test.go
@@ -1,0 +1,62 @@
+package linthost
+
+import "testing"
+
+// TestUnicornThrowNewErrorSkipsNonMatchingCallees verifies the negative twin of
+// every branch the widened callee predicate opened.
+//
+// Matching any `*Error` name instead of eight built-ins is only safe with the
+// counter-examples pinned: the name pattern is anchored and case-sensitive
+// (`fooError`, `ERROR`, `Errors` must stay silent), computed member access is
+// opaque (`lib["Error"]()`), and an optional chain must never be reported
+// because the autofix would emit `new lib?.Error()`, which is a syntax error —
+// the fix, not just the report, is what makes these exclusions load-bearing.
+// `Data.TaggedError()` is upstream's Effect-library carve-out; it builds an
+// error class, so `new` would be wrong.
+//
+//  1. Lint each source with only unicorn/throw-new-error enabled.
+//  2. Assert the engine emits no finding at all.
+func TestUnicornThrowNewErrorSkipsNonMatchingCallees(t *testing.T) {
+  for _, source := range []string{
+    // Already constructed with `new`.
+    "throw new Error(\"oops\");\n",
+    "throw new ValidationError(\"bad\");\n",
+    "throw new ns.FooError();\n",
+    "throw new (getGlobalThis().Error)();\n",
+    // Not an `*Error` name.
+    "throw getError();\n",
+    "throw lib.getError();\n",
+    "throw ns.notAnError();\n",
+    "throw Error2();\n",
+    // The name pattern is anchored, case-sensitive, and word-shaped.
+    "throw fooError();\n",
+    "throw ERROR();\n",
+    "throw Errors();\n",
+    "throw My_Error();\n",
+    "throw $Error();\n",
+    "throw _Error();\n",
+    // Not a call expression.
+    "throw ValidationError;\n",
+    "throw FooError`x`;\n",
+    // The callee is neither an Identifier nor a member access.
+    "throw getErrorConstructor()();\n",
+    // Computed member access.
+    "throw lib[\"Error\"]();\n",
+    "throw lib[Error]();\n",
+    // Optional chains: `new` cannot be applied to one.
+    "throw Error?.();\n",
+    "throw lib.Error?.();\n",
+    "throw lib?.Error();\n",
+    "throw lib?.foo.Error();\n",
+    "throw lib?.[key].Error();\n",
+    "throw lib?.foo!.Error();\n",
+    "throw getGlobalThis?.().Error();\n",
+    "throw (lib?.Error)();\n",
+    // Upstream's Effect-library carve-out.
+    "throw Data.TaggedError(\"x\");\n",
+  } {
+    t.Run(source, func(t *testing.T) {
+      assertRuleSkipsSource(t, "unicorn/throw-new-error", source)
+    })
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_throw_new_error_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_throw_new_error_test.go
@@ -2,18 +2,30 @@ package linthost
 
 import "testing"
 
-// TestRuleCorpusUnicornThrowNewError verifies unicorn/throw-new-error reports
-// `throw Error(...)` without `new`.
+// TestRuleCorpusUnicornThrowNewError verifies unicorn/throw-new-error reports a
+// call-form throw for a built-in, a user-defined, and a namespaced error class.
 //
-// The rule fires only when the throw operand is a CallExpression with an
-// identifier callee matching the built-in Error name list (Error, TypeError,
-// RangeError, SyntaxError, ReferenceError, EvalError, URIError,
-// AggregateError). This fixture exercises the most common `throw Error("msg")`
-// shape and pins the call-vs-new discrimination at the rule's core.
+// The rule fires when the throw operand is a CallExpression whose callee names
+// an error constructor — an identifier or a non-computed property whose name
+// matches upstream's `^(?:[A-Z][\da-z]*)*Error$` pattern. This fixture mirrors
+// the TypeScript corpus case: the three matched callee shapes, plus the
+// unannotated forms that must stay silent (an already-constructed `new`, a
+// computed key, an optional chain, and a non-error name).
 //
-// 1. Enable unicorn/throw-new-error via an expect annotation.
-// 2. Throw `Error("oops")` without `new`.
-// 3. Assert the call expression is reported.
+// 1. Enable unicorn/throw-new-error via expect annotations.
+// 2. Throw `Error(...)`, `ValidationError(...)`, and `ns.CustomError(...)`.
+// 3. Assert exactly those three call expressions are reported.
 func TestRuleCorpusUnicornThrowNewError(t *testing.T) {
-  assertRuleCorpusCase(t, "unicorn/throw-new-error.ts", "// expect: unicorn/throw-new-error error\nthrow Error(\"oops\");\n")
+  assertRuleCorpusCase(
+    t,
+    "unicorn/throw-new-error.ts",
+    "declare const ValidationError: any;\ndeclare const ns: any;\ndeclare const getError: any;\n\n"+
+      "function builtinCallee() {\n  // expect: unicorn/throw-new-error error\n  throw Error(\"oops\");\n}\n\n"+
+      "function customErrorCallee() {\n  // expect: unicorn/throw-new-error error\n  throw ValidationError(\"bad\");\n}\n\n"+
+      "function memberCallee() {\n  // expect: unicorn/throw-new-error error\n  throw ns.CustomError(\"bad\");\n}\n\n"+
+      "function alreadyConstructed() {\n  throw new ValidationError(\"bad\");\n}\n\n"+
+      "function computedCallee() {\n  throw ns[\"CustomError\"](\"bad\");\n}\n\n"+
+      "function optionalCallee() {\n  throw ns?.CustomError(\"bad\");\n}\n\n"+
+      "function nonErrorCallee() {\n  throw getError();\n}\n",
+  )
 }

--- a/tests/test-lint/src/cases/unicorn-throw-new-error.ts
+++ b/tests/test-lint/src/cases/unicorn-throw-new-error.ts
@@ -1,2 +1,34 @@
-// expect: unicorn/throw-new-error error
-throw Error("oops");
+declare const ValidationError: any;
+declare const ns: any;
+declare const getError: any;
+
+function builtinCallee() {
+  // expect: unicorn/throw-new-error error
+  throw Error("oops");
+}
+
+function customErrorCallee() {
+  // expect: unicorn/throw-new-error error
+  throw ValidationError("bad");
+}
+
+function memberCallee() {
+  // expect: unicorn/throw-new-error error
+  throw ns.CustomError("bad");
+}
+
+function alreadyConstructed() {
+  throw new ValidationError("bad");
+}
+
+function computedCallee() {
+  throw ns["CustomError"]("bad");
+}
+
+function optionalCallee() {
+  throw ns?.CustomError("bad");
+}
+
+function nonErrorCallee() {
+  throw getError();
+}

--- a/website/src/content/docs/lint/rules/unicorn.mdx
+++ b/website/src/content/docs/lint/rules/unicorn.mdx
@@ -2441,9 +2441,19 @@ const enc = "UTF-8";
 
 Require `throw new Error(...)` over `throw Error(...)`.
 
+A thrown call is reported when its callee names an error constructor: a plain identifier, or a non-computed property access whose property name matches `^(?:[A-Z][\da-z]*)*Error$` (capitalized words closed by `Error`). That covers the built-ins (`TypeError`) and user-defined classes alike (`ValidationError`, `ns.HttpError`), while `getError()`, `fooError()`, and computed access (`ns["FooError"]()`) stay silent. An optional-chained callee (`Error?.()`, `ns?.FooError()`) is never reported, because `new` cannot be applied to an optional chain.
+
+The autofix inserts `new` in front of the call. It parenthesizes a callee whose object chain still exposes a call, because a `new` expression's callee ends at the first argument list: `throw getGlobalThis().Error()` becomes `throw new (getGlobalThis().Error)()`.
+
 Example:
 
 ```ts
 // reports: unicorn/throw-new-error (error)
 throw Error("oops");
+
+// reports: unicorn/throw-new-error (error)
+throw ValidationError("bad");
+
+// reports: unicorn/throw-new-error (error)
+throw ns.HttpError(404);
 ```


### PR DESCRIPTION
## Intent

`unicorn/throw-new-error` fired only for an eight-entry allowlist of built-in Error names, and read the callee through `identifierText`, which returns `""` for any non-Identifier node. User-defined error classes (`throw ValidationError("x")`) and member callees (`throw ns.FooError("x")`) - the rule's most common real-world target - were reported by upstream and silently accepted here.

Fixes #579.

## Scope

- **Callee predicate** (`packages/lint/linthost/rules_unicorn_throw_new_error.go`): ported from eslint-plugin-unicorn 71.1.0. An `Identifier` callee, or a non-computed member callee whose property is an `Identifier`, whose name matches `^(?:[A-Z][\da-z]*)*Error$`. Optional-chained callees (`Error?.()`, `ns?.FooError()`) stay unreported because `new` cannot be applied to a chain, computed access (`ns["FooError"]()`) stays opaque, and upstream's Effect-library `Data.TaggedError` carve-out is ported with it.
- **Autofix** (new): the port had none while upstream is `fixable: "code"`, and the issue's repro expects one. It inserts `new ` before the call, adds a separating space when the `throw` keyword abuts its operand (`throw[lib][0].Error()` would otherwise weld into `thrownew ...`), and parenthesizes a callee whose object chain still exposes a call, since a `new` expression's callee ends at the first argument list (`throw getGlobalThis().Error()` -> `throw new (getGlobalThis().Error)()`).
- **Docs**: `website/src/content/docs/lint/rules/unicorn.mdx` gains the callee pattern, the exclusions, and the autofix behavior.

Two deliberate deviations, both documented in the rule's doc comment:

- The port stays scoped to `throw` operands. Upstream 71.1.0 flags every error-constructing call site (`const error = Error()`) and words its message accordingly; widening the scope is a separate behavior change, not part of this issue.
- The parenthesization walk sees through a non-null assertion. Upstream's ESTree walk stops at `TSNonNullExpression`, so it would emit `new lib.getError()!.FooError()`, which constructs `lib.getError()` and reads `.FooError()` off the instance. Real parentheses do shield the call, so they end the walk.

This widens what the rule reports. No first-party code or fixture trips it (the repo has no call-form error throw outside this rule's own fixture); downstream projects that enable the rule will see the new findings, which is the point of the issue.

## Test plan

Expectations come from the upstream oracle (rule source plus `test/snapshots/throw-new-error.js.md` at v71.1.0), never from what the port emits.

- `unicorn_throw_new_error_reports_custom_and_member_callees_test.go` - identifier and member callees, acronym and digit words, nested chains, a computed link inside a static chain, parenthesized callees, a callee whose object is a call; exact range and message.
- `unicorn_throw_new_error_skips_non_matching_callees_test.go` - 28 negatives: `getError()`, `fooError()`, `ERROR()`, `Errors()`, `My_Error()`, a bare reference, a tagged template, a call-callee, computed access, every optional-chain shape, `Data.TaggedError()`, and every `throw new X(...)`.
- `unicorn_throw_new_error_fixes_upstream_invalid_corpus_test.go` - the upstream invalid corpus, byte-for-byte.
- `unicorn_throw_new_error_fix_spaces_an_abutting_throw_keyword_test.go` - abutting-keyword shapes, including the one where the space and the callee parenthesis land on the same offset.
- `unicorn_throw_new_error_fix_parenthesizes_a_shielded_call_chain_test.go` - TypeScript chains (`!`, `as`, type arguments).
- `unicorn_throw_new_error_fixes_every_throw_in_one_pass_test.go` - a file whose violations are all fixed in a single applier pass.
- `unicorn_throw_new_error_test.go` + `tests/test-lint/src/cases/unicorn-throw-new-error.ts` - the corpus fixture, extended with the member/custom positives and the silent forms.

Every fixed output is reparsed (no parse diagnostics) and re-linted (zero findings), so a corrupting or non-idempotent edit fails the suite.

Repro: `throw ValidationError("bad")` produced no finding before this change; the new tests fail against the old rule (`expected at least one finding`) and pass after. `node scripts/test-go-lint.cjs` is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND