### PR TITLE
fix(ttsc): decode preceding rune in plugin-call boundary guard

### DIFF
--- a/packages/ttsc/driver/rewrite.go
+++ b/packages/ttsc/driver/rewrite.go
@@ -23,6 +23,7 @@ import (
   "strings"
   "sync"
   "unicode"
+  "unicode/utf8"
 
   "github.com/microsoft/typescript-go/shim/ast"
   shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
@@ -427,7 +428,13 @@ func findCallMatch(text string, pattern *regexp.Regexp, searchFrom int) (int, in
     }
     matchStart := start + loc[0]
     parenStart := start + loc[2]
-    if matchStart > 0 && isIdentifierPart(rune(text[matchStart-1])) {
+    // Decode the whole preceding rune rather than widening the single byte at
+    // text[matchStart-1]: for a multi-byte identifier char (e.g. `й`, `한`, an
+    // astral letter) that byte is a UTF-8 continuation/lead byte, not the
+    // character, so the boundary guard would be bypassed and the rewriter would
+    // splice into the middle of a larger identifier.
+    prev, _ := utf8.DecodeLastRuneInString(text[:matchStart])
+    if matchStart > 0 && isIdentifierPart(prev) {
       start = matchStart + 1
       continue
     }

--- a/packages/ttsc/test/driver/rewrite_skips_non_ascii_identifier_prefix_test.go
+++ b/packages/ttsc/test/driver/rewrite_skips_non_ascii_identifier_prefix_test.go
@@ -1,0 +1,58 @@
+package driver_test
+
+import (
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverRewriteSkipsNonASCIIIdentifierPrefix verifies the call-boundary
+// guard rejects a match that begins mid-identifier after a non-ASCII character.
+//
+// findCallMatch used to widen the single byte at text[matchStart-1] into a rune.
+// For a multi-byte identifier character that byte is a UTF-8 continuation/lead
+// byte, not the character, so isIdentifierPart returned false, the boundary
+// guard was bypassed, and `étypia.assert(` matched as the tail `typia.assert(`
+// of a larger identifier — splicing the replacement into the middle of a
+// distinct name and silently corrupting the emitted JS. Decoding the whole
+// preceding rune restores the guard for BMP and astral prefixes alike, while
+// the ASCII `mytypia` negative and a bare positive call pin both sides.
+//
+//  1. Splice `typia.assert(` against inputs whose call head is the trailing
+//     substring of a longer identifier ending in `typia`.
+//  2. Cover an ASCII prefix, BMP (`é`, `한`), and astral (`𝒜`) prefixes.
+//  3. Assert none match, and that a boundary-clean `typia.assert(` still does.
+func TestDriverRewriteSkipsNonASCIIIdentifierPrefix(t *testing.T) {
+  rewrite := driver.Rewrite{
+    RootName:      "typia",
+    Method:        "assert",
+    Replacement:   "__REPLACED__",
+    ConsumeParens: true,
+  }
+  for _, prefix := range []string{"my", "é", "한", "𝒜"} {
+    text := "const x = " + prefix + "typia.assert(input);"
+    got, _, ok, err := spliceCall(text, rewrite, 0)
+    if err != nil {
+      t.Fatalf("prefix %q: unexpected error: %v", prefix, err)
+    }
+    if ok {
+      t.Fatalf("prefix %q: guard bypassed, spliced mid-identifier:\n%s", prefix, got)
+    }
+    if got != text {
+      t.Fatalf("prefix %q: no-match must leave text untouched:\n%s", prefix, got)
+    }
+  }
+
+  positive := "const x = typia.assert(input);"
+  got, _, ok, err := spliceCall(positive, rewrite, 0)
+  if err != nil {
+    t.Fatalf("positive control: unexpected error: %v", err)
+  }
+  if !ok {
+    t.Fatal("positive control: boundary-clean typia.assert( did not match")
+  }
+  if !strings.Contains(got, "__REPLACED__") || strings.Contains(got, "typia.assert") {
+    t.Fatalf("positive control: call was not replaced:\n%s", got)
+  }
+}


### PR DESCRIPTION
## Intent

Fixes #617. The emit-time plugin-call rewriter (`typia.assert(` -> transformed call, etc.) defeated its own identifier-boundary guard whenever the character immediately before a match was non-ASCII, silently corrupting the emitted `.js`.

## Root cause

`packages/ttsc/driver/rewrite.go` `findCallMatch` guarded the match with `isIdentifierPart(rune(text[matchStart-1]))`. `text[matchStart-1]` is a single byte; `rune(byte)` widens that lone byte. When the preceding identifier character is multi-byte UTF-8, that byte is a continuation/lead byte, not the character, so `isIdentifierPart` returned false, the boundary guard was bypassed, and a call head like `étypia.assert(` matched as the tail `typia.assert(` of a larger identifier. The rewriter then spliced the replacement into the middle of a distinct name (`const x = é__REPLACED__;`) and consumed the rewrite budget on the decoy. Same lone-byte class as #582.

## Scope

- `packages/ttsc/driver/rewrite.go`: decode the whole preceding rune with `utf8.DecodeLastRuneInString(text[:matchStart])` before the `isIdentifierPart` check. The ASCII path is unchanged; only the multi-byte case is repaired. The `matchStart > 0` guard still short-circuits at start-of-text (empty slice decodes to `RuneError`, which is not an identifier part).
- `packages/ttsc/test/driver/rewrite_skips_non_ascii_identifier_prefix_test.go`: new regression test asserting `spliceCall` returns no match for `<non-ASCII-letter>typia.assert(` across BMP (`é`, `한`) and astral (`𝒜`) prefixes, paired with the ASCII `mytypia` negative and a positive boundary-clean control that must still match.

## Test plan

- Before/after repro: with the buggy guard the new test fails with `const x = é__REPLACED__;` (the exact issue corruption); with the fix it passes.
- `node scripts/test-go-driver.cjs` — full driver suite green.
- `go vet ./driver/... ./test/driver/...` — clean.
- `gofmt-2spaces.sh -w` applied to both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND