### PR TITLE
fix(ttsc): exclude persistent plugin lock dirs from corpus cache-entry counts

### DIFF
--- a/tests/test-ttsc/src/internal/plugin-corpus.ts
+++ b/tests/test-ttsc/src/internal/plugin-corpus.ts
@@ -67,6 +67,41 @@ function copyDirectory(from: string, to: string): void {
   fs.cpSync(from, to, { recursive: true });
 }
 
+/**
+ * List the content-keyed plugin-binary directories under a plugin cache root,
+ * excluding the lock-coordination directories `buildSourcePlugin` leaves beside
+ * them.
+ *
+ * A source-plugin build creates the PERSISTENT `<key>.lock.v2` coordination
+ * directory (and can leave `<key>.lock` / `<key>.lock.retired-*` tombstones) as
+ * SIBLINGS of the `<key>` binary directory. ttsc's own cache GC
+ * (`buildSourcePlugin.ts::collectPluginCacheEntries`) skips exactly these when
+ * it enumerates cache entries, so a test that counts cache entries must do the
+ * same. Otherwise the persistent v2 lock directory is miscounted as a second
+ * content-keyed binary and a one-plugin build looks like two.
+ */
+function pluginCacheEntryDirs(pluginCacheRoot: string): string[] {
+  return fs
+    .readdirSync(pluginCacheRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && isPluginCacheEntryDir(entry.name))
+    .map((entry) => entry.name);
+}
+
+/**
+ * Report whether a directory name under the plugin cache root is a
+ * content-keyed binary entry rather than a lock-coordination sibling. Mirrors
+ * the `.lock`-family exclusion in
+ * `buildSourcePlugin.ts::collectPluginCacheEntries`; the `scratch-` guard is a
+ * legacy carry-over from when build scratch dirs lived under the cache root.
+ */
+function isPluginCacheEntryDir(name: string): boolean {
+  return (
+    !name.startsWith("scratch-") &&
+    !name.endsWith(".lock") &&
+    !name.includes(".lock.")
+  );
+}
+
 function writeRelativePackagePlugin(
   root: string,
   name: string,
@@ -227,6 +262,7 @@ export {
   parseDiagnostics,
   parseExpectations,
   path,
+  pluginCacheEntryDirs,
   pluginProject,
   REQUIRE_FROM_TEST as requireFromTest,
   setupLintProject,

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_prepare_builds_source_plugins_without_emitting_project_output.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_prepare_builds_source_plugins_without_emitting_project_output.ts
@@ -7,6 +7,7 @@ import {
   goPath,
   os,
   path,
+  pluginCacheEntryDirs,
   spawn,
   ttscBin,
 } from "../../internal/plugin-corpus";
@@ -44,16 +45,13 @@ export const test_plugin_corpus_prepare_builds_source_plugins_without_emitting_p
     assert.match(prepared.stderr, /building source plugin "go-source-plugin"/);
     assert.equal(fs.existsSync(path.join(root, "dist")), false);
     const pluginCache = path.join(cacheDir, "plugins");
-    const binaries = fs
-      .readdirSync(pluginCache, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) =>
-        path.join(
-          pluginCache,
-          entry.name,
-          process.platform === "win32" ? "plugin.exe" : "plugin",
-        ),
-      );
+    const binaries = pluginCacheEntryDirs(pluginCache).map((name) =>
+      path.join(
+        pluginCache,
+        name,
+        process.platform === "win32" ? "plugin.exe" : "plugin",
+      ),
+    );
     assert.equal(binaries.length, 1);
     const binary = binaries[0];
     assert.ok(binary);

--- a/tests/test-ttsc/src/native-plugins/corpus-source/test_plugin_corpus_source_plugin_default_cache_is_workspace_local_content_cache.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-source/test_plugin_corpus_source_plugin_default_cache_is_workspace_local_content_cache.ts
@@ -4,6 +4,7 @@ import {
   fs,
   goPath,
   path,
+  pluginCacheEntryDirs,
   spawn,
   ttscBin,
 } from "../../internal/plugin-corpus";
@@ -41,11 +42,7 @@ export const test_plugin_corpus_source_plugin_default_cache_is_workspace_local_c
       "ttsc",
       "plugins",
     );
-    const entries = fs
-      .readdirSync(pluginCache, { withFileTypes: true })
-      .filter(
-        (entry) => entry.isDirectory() && !entry.name.startsWith("scratch-"),
-      );
+    const entries = pluginCacheEntryDirs(pluginCache);
     assert.equal(entries.length, 1);
     const entry = entries[0];
     assert.ok(entry);
@@ -53,7 +50,7 @@ export const test_plugin_corpus_source_plugin_default_cache_is_workspace_local_c
       fs.existsSync(
         path.join(
           pluginCache,
-          entry.name,
+          entry,
           process.platform === "win32" ? "plugin.exe" : "plugin",
         ),
       ),

--- a/tests/test-ttsc/src/native-plugins/corpus-ttsc/test_plugin_corpus_ttsc_lint_option_changes_reuse_the_source_plugin_binary_cache.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-ttsc/test_plugin_corpus_ttsc_lint_option_changes_reuse_the_source_plugin_binary_cache.ts
@@ -5,6 +5,7 @@ import {
   fs,
   goPath,
   path,
+  pluginCacheEntryDirs,
   setupLintProject,
   spawn,
   ttscBin,
@@ -78,10 +79,6 @@ export const test_plugin_corpus_ttsc_lint_option_changes_reuse_the_source_plugin
     assert.equal(fs.existsSync(path.join(root, "custom", "main.js")), true);
 
     const pluginCache = path.join(cacheDir, "plugins");
-    const entries = fs
-      .readdirSync(pluginCache, { withFileTypes: true })
-      .filter(
-        (entry) => entry.isDirectory() && !entry.name.startsWith("scratch-"),
-      );
+    const entries = pluginCacheEntryDirs(pluginCache);
     assert.equal(entries.length, 1);
   };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_computecachekey_is_stable_across_source_path_spellings.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_computecachekey_is_stable_across_source_path_spellings.ts
@@ -1,0 +1,64 @@
+import { TestProject } from "@ttsc/testing";
+
+import { assert, computeCacheKey, fs, path } from "../../internal/source-build";
+
+/**
+ * Verifies computeCacheKey is stable across source path spellings.
+ *
+ * The plugin cache key must identify a source by its CONTENT, not by the exact
+ * path string a caller happens to reach it through. `computeCacheKey` hashes
+ * file bytes plus separator-normalized RELATIVE paths and the normalized
+ * `entry`, never the absolute directory string, so the same directory reached
+ * via a trailing separator, forward-slash separators, or a redundant `.`/`..`
+ * segment must produce ONE key — a single source can never split into two cache
+ * entries (issue #625, which suspected — incorrectly — a per-spelling key
+ * split).
+ *
+ * 1. Materialize a Go plugin package with a nested source file.
+ * 2. Compute the key for its directory spelled four equivalent ways.
+ * 3. Assert every spelling yields the canonical key.
+ */
+export const test_computecachekey_is_stable_across_source_path_spellings =
+  () => {
+    const root = TestProject.tmpdir("ttsc-source-plugin-");
+    const plugin = path.join(root, "plugin");
+    fs.mkdirSync(path.join(plugin, "sub"), { recursive: true });
+    fs.writeFileSync(
+      path.join(plugin, "go.mod"),
+      "module example.com/plugin\n\ngo 1.26\n",
+      "utf8",
+    );
+    fs.writeFileSync(path.join(plugin, "main.go"), "package main\n", "utf8");
+    // A nested file so the key covers a relative path that carries a separator.
+    fs.writeFileSync(
+      path.join(plugin, "sub", "helper.go"),
+      "package sub\n\nconst Value = 1\n",
+      "utf8",
+    );
+
+    const keyFor = (dir: string) =>
+      computeCacheKey({
+        dir,
+        entry: ".",
+        ttscVersion: "1.0.0",
+        tsgoVersion: "7.0.0-dev",
+      });
+
+    const canonical = keyFor(plugin);
+    // Every spelling below resolves to the SAME directory on both Windows and
+    // POSIX (forward slashes are accepted on Windows; backslashes are not on
+    // POSIX, so a backslash spelling is deliberately excluded).
+    const spellings = [
+      plugin + path.sep,
+      plugin.replace(/\\/g, "/"),
+      path.join(plugin, "nested", ".."),
+      path.join(path.dirname(plugin), ".", path.basename(plugin)),
+    ];
+    for (const spelling of spellings) {
+      assert.equal(
+        keyFor(spelling),
+        canonical,
+        `path spelling ${JSON.stringify(spelling)} produced a different key`,
+      );
+    }
+  };


### PR DESCRIPTION
## Intent

Fixes #625. Makes the `ttsc native corpus-source`, `corpus-ttsc`, and
`corpus-misc` lanes green again (all three fail with `2 !== 1`).

## Root cause (issue hypothesis corrected)

The issue suspected one `ttsc --emit` mints **two content-keyed cache dirs** for
one source (a path-normalization / hash-input split). That is **not** what
happens:

- `computeCacheKey` is already stable across path spellings — one source yields
  exactly one key (now pinned by a unit test, verified locally against the real
  function).
- A single build creates **one** `<key>/` binary directory plus the
  **persistent** `<key>.lock.v2` coordination directory as a *sibling* under the
  plugin cache root. Before #460 the build lock was an atomic `mkdir` removed on
  release, so only `<key>/` remained; #460 (`72575f5e2`) made the lock a
  persistent, never-removed coordination root (retired via rename into
  `retired/<gen>`).

ttsc's own cache GC (`buildSourcePlugin.ts::collectPluginCacheEntries`) already
skips the `.lock`-family siblings, and
`test_resolveplugincacheroot_prunes_stale_cache_entries` asserts they are
preserved — the persistent `.lock.v2` directory is **intended** product
behavior. The three corpus tests, however, counted cache directories with a
stale filter (`!startsWith("scratch-")`, or none) that did **not** exclude the
lock sibling, so each miscounted `<key>.lock.v2` as a second binary → `2 !== 1`.

Empirically confirmed by exercising the real `acquirePluginBuildLock` /
`releasePluginBuildLock` on a temp cache root: one build leaves `<key>/` +
`<key>.lock.v2/`; the old filter counts 2, a GC-style `.lock`-family filter
counts 1.

## Scope

Test-only. Product code is unchanged (the lock directory layout is intentional
and the cache key is correct).

- Add a shared `pluginCacheEntryDirs` helper to the corpus test support module
  that counts cache entries the way ttsc itself does — excluding `.lock` /
  `.lock.v2` / `.lock.retired-*` siblings. Routes all three failing tests
  through it so the class of failure cannot recur.
- Add `test_computecachekey_is_stable_across_source_path_spellings` pinning the
  path-spelling invariant the issue suspected was broken.

## Test plan

- The three fixed corpus lanes (`corpus-source`, `corpus-ttsc`, `corpus-misc`)
  must go green — verifiable only on CI (the e2e suites build real Go plugins
  and cannot run on the author's local Windows).
- New unit test verified locally against the current source: all path spellings
  of one source produce one identical key.
- Prettier checked clean on all five changed files (LF blobs).

Out of scope for #625: `windows-go` (independently/permanently red) and the
`go` / `lint native corpus-*` jobs seen on unrelated feature-branch runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND
