### PR TITLE
fix(test): close CI Go lane gaps and guard the lint test overlay

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: test
 
 on:
+  # Validate master after every merge so a red lane cannot persist unnoticed;
+  # pull_request only guards the change, never the post-merge trunk (issue #622).
+  push:
+    branches:
+      - master
   pull_request:
     paths:
       - ".github/workflows/test.yml"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "pnpm run check:flags && pnpm run build:current && pnpm run test:go && pnpm run test:typecheck && pnpm run test:features",
     "coverage:go": "node scripts/test-go-coverage.cjs",
     "test:features": "pnpm --filter \"./tests/test-*\" -r --workspace-concurrency=1 start",
-    "test:go": "node scripts/test-go-driver.cjs && node scripts/test-go-transformer.cjs && node scripts/test-go-utility-plugins.cjs && node scripts/test-go-lint.cjs && node scripts/test-go-graph.cjs",
+    "test:go": "node scripts/test-go.cjs",
     "test:typecheck": "node scripts/test-typecheck.cjs"
   },
   "repository": {

--- a/packages/ttsc/cmd/ttsc/build_branches_test.go
+++ b/packages/ttsc/cmd/ttsc/build_branches_test.go
@@ -84,7 +84,11 @@ export { value };
   code, _, errText = captureCommand(t, func() int {
     return runBuild([]string{"--cwd", root, "--tsconfig", "tsconfig.json", "--emit", "--outDir", "blocked"})
   })
-  if code != 2 || !strings.Contains(errText, "not a directory") {
+  // The write fails because outDir is a regular file. Assert on the exit code
+  // and the platform-agnostic TS5033 "Could not write file" diagnostic prefix,
+  // not the OS errno, which differs by platform (POSIX ENOTDIR "not a
+  // directory" vs Windows "The system cannot find the path specified").
+  if code != 2 || !strings.Contains(errText, "Could not write file") {
     t.Fatalf("emit failure mismatch: code=%d stderr=%q", code, errText)
   }
 

--- a/packages/ttsc/test/utility/command_failures_cover_host_edges_test.go
+++ b/packages/ttsc/test/utility/command_failures_cover_host_edges_test.go
@@ -3,6 +3,7 @@ package ttsc_test
 import (
   "os"
   "path/filepath"
+  "runtime"
   "strings"
   "testing"
 
@@ -127,7 +128,11 @@ func TestUtilityCommandFailuresCoverHostEdges(t *testing.T) {
       "--outDir", "blocked",
     })
   })
-  if code != 2 || !strings.Contains(errOut, "not a directory") {
+  // The write fails because outDir is a regular file. Assert on the exit code
+  // and the platform-agnostic TS5033 "Could not write file" diagnostic prefix,
+  // not the OS errno, which differs by platform (POSIX ENOTDIR "not a
+  // directory" vs Windows "The system cannot find the path specified").
+  if code != 2 || !strings.Contains(errOut, "Could not write file") {
     t.Fatalf("emit failure mismatch: code=%d stderr=%q", code, errOut)
   }
 
@@ -135,25 +140,31 @@ func TestUtilityCommandFailuresCoverHostEdges(t *testing.T) {
   if err != nil {
     t.Fatal(err)
   }
-  deleted := t.TempDir()
-  if err := os.Chdir(deleted); err != nil {
-    t.Fatal(err)
-  }
-  if err := os.Remove(deleted); err != nil {
-    t.Fatal(err)
-  }
   defer os.Chdir(previous)
-  code, _, errOut = captureUtilityOutput(t, func() int {
-    return utility.RunCheck(nil)
-  })
-  if code != 2 || !strings.Contains(errOut, "cwd") {
-    t.Fatalf("deleted cwd mismatch: code=%d stderr=%q", code, errOut)
-  }
-  code, _, errOut = captureUtilityOutput(t, func() int {
-    return utility.RunCheck([]string{"--cwd", filepath.Base(root)})
-  })
-  if code != 2 || !strings.Contains(errOut, "cwd") {
-    t.Fatalf("relative cwd mismatch: code=%d stderr=%q", code, errOut)
+  // Removing the process's own working directory is a POSIX-only capability;
+  // Windows locks the cwd against deletion ("The process cannot access the file
+  // because it is being used by another process"), so the deleted-cwd
+  // getwd-failure branch is only reachable off Windows.
+  if runtime.GOOS != "windows" {
+    deleted := t.TempDir()
+    if err := os.Chdir(deleted); err != nil {
+      t.Fatal(err)
+    }
+    if err := os.Remove(deleted); err != nil {
+      t.Fatal(err)
+    }
+    code, _, errOut = captureUtilityOutput(t, func() int {
+      return utility.RunCheck(nil)
+    })
+    if code != 2 || !strings.Contains(errOut, "cwd") {
+      t.Fatalf("deleted cwd mismatch: code=%d stderr=%q", code, errOut)
+    }
+    code, _, errOut = captureUtilityOutput(t, func() int {
+      return utility.RunCheck([]string{"--cwd", filepath.Base(root)})
+    })
+    if code != 2 || !strings.Contains(errOut, "cwd") {
+      t.Fatalf("relative cwd mismatch: code=%d stderr=%q", code, errOut)
+    }
   }
 
   relativeParent := t.TempDir()

--- a/scripts/bench-go-lint.cjs
+++ b/scripts/bench-go-lint.cjs
@@ -20,6 +20,8 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
+const { copyGoTestsFlat } = require("./ci/go-test-overlay.cjs");
+
 const root = path.resolve(__dirname, "..");
 const lintPkgDir = path.join(root, "packages", "lint");
 const lintTestsDir = path.join(lintPkgDir, "test");
@@ -73,33 +75,6 @@ try {
   process.exit(result.status ?? 1);
 } finally {
   fs.rmSync(scratch, { recursive: true, force: true });
-}
-
-function copyGoTestsFlat(sourceDir, targetDir) {
-  fs.mkdirSync(targetDir, { recursive: true });
-  const seen = new Set();
-  for (const file of walkForGoFiles(sourceDir)) {
-    const basename = path.basename(file);
-    if (seen.has(basename)) {
-      throw new Error(`duplicate lint Go test filename: ${basename}`);
-    }
-    seen.add(basename);
-    fs.copyFileSync(file, path.join(targetDir, basename));
-  }
-}
-
-function walkForGoFiles(dir) {
-  const out = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const p = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (entry.name === "node_modules") continue;
-      out.push(...walkForGoFiles(p));
-    } else if (entry.isFile() && entry.name.endsWith(".go")) {
-      out.push(p);
-    }
-  }
-  return out;
 }
 
 function walkForGoMod(dir, out) {

--- a/scripts/ci/go-test-overlay.cjs
+++ b/scripts/ci/go-test-overlay.cjs
@@ -1,0 +1,65 @@
+// Shared scratch-overlay helpers for the lint Go runners (test-go-lint.cjs,
+// test-go-coverage.cjs, bench-go-lint.cjs).
+//
+// Each runner copies `packages/lint/` into a scratch dir, then flattens every
+// Go test file under `packages/lint/test/` next to the linthost library sources
+// so the tests can reach unexported linthost-package internals. Keeping the
+// flatten logic here means the collision guard lives in one place instead of
+// three copies that can silently drift apart (issues #622/#624).
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// copyGoTestsFlat flattens every `.go` file under sourceDir into targetDir.
+//
+// targetDir already holds the linthost library sources (the caller cpSync'd
+// `packages/lint` into scratch first), so a test file whose basename matches a
+// library source — `engine.go`, `config.go`, `lsp.go`, … — would silently
+// overwrite it and produce an inexplicable compile error. Seeding `seen` with
+// the basenames already present in targetDir turns that collision, and any
+// test-vs-test basename clash, into a loud named error instead of a silent
+// overwrite (issue #624).
+function copyGoTestsFlat(sourceDir, targetDir) {
+  fs.mkdirSync(targetDir, { recursive: true });
+  const seen = new Set(existingGoBasenames(targetDir));
+  for (const file of walkForGoFiles(sourceDir)) {
+    const basename = path.basename(file);
+    if (seen.has(basename)) {
+      throw new Error(
+        `lint Go test overlay collision: ${basename} (from ${file}) would ` +
+          `overwrite a same-named file already in ${targetDir} (a linthost ` +
+          `library source or another test file). Rename the test file.`,
+      );
+    }
+    seen.add(basename);
+    fs.copyFileSync(file, path.join(targetDir, basename));
+  }
+}
+
+// existingGoBasenames lists the `.go` filenames already materialized in dir.
+// Only direct children matter: the library sources sit at the linthost package
+// root, which is exactly where the flattened test files land.
+function existingGoBasenames(dir) {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".go"))
+    .map((entry) => entry.name);
+}
+
+// walkForGoFiles returns every `.go` file under dir, sorted for a deterministic
+// copy order so a collision is reported against a stable "first writer".
+function walkForGoFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const file = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules") continue;
+      out.push(...walkForGoFiles(file));
+    } else if (entry.isFile() && entry.name.endsWith(".go")) {
+      out.push(file);
+    }
+  }
+  return out.sort();
+}
+
+module.exports = { copyGoTestsFlat, walkForGoFiles };

--- a/scripts/ci/go-test-runners.test.cjs
+++ b/scripts/ci/go-test-runners.test.cjs
@@ -1,0 +1,103 @@
+// Unit tests for the Go test runner harness behind `pnpm test:go`.
+//
+// Covers the two latent hazards fixed in issues #622/#624:
+//   1. copyGoTestsFlat silently overwriting a linthost library source with a
+//      same-named test file (the flatten collision guard).
+//   2. the runner chain short-circuiting on the first failure, so a later
+//      runner (test-go-graph) never ran (the aggregation contract).
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { copyGoTestsFlat } = require("./go-test-overlay.cjs");
+const { runAll, runners } = require("../test-go.cjs");
+
+function tmpdir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-runner-harness-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function writeFile(root, rel, contents) {
+  const file = path.join(root, rel);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents, "utf8");
+  return file;
+}
+
+test("copyGoTestsFlat throws instead of overwriting a library source", (t) => {
+  const source = tmpdir(t);
+  const target = tmpdir(t);
+  // A linthost library source already materialized in the scratch linthost dir.
+  const library = writeFile(target, "engine.go", "package linthost\n// library\n");
+  // A test tree that plants a same-basename `engine.go` (issue #624 auditor probe).
+  writeFile(source, "rules/engine.go", "package linthost\n// planted\n");
+
+  assert.throws(
+    () => copyGoTestsFlat(source, target),
+    (err) => err instanceof Error && err.message.includes("engine.go"),
+  );
+  // The library source must be untouched — no silent 45-byte shrink.
+  assert.equal(
+    fs.readFileSync(library, "utf8"),
+    "package linthost\n// library\n",
+  );
+});
+
+test("copyGoTestsFlat copies non-colliding test files", (t) => {
+  const source = tmpdir(t);
+  const target = tmpdir(t);
+  writeFile(target, "engine.go", "package linthost\n// library\n");
+  writeFile(source, "engine_behavior_test.go", "package linthost\n// test\n");
+
+  copyGoTestsFlat(source, target);
+
+  assert.equal(
+    fs.readFileSync(path.join(target, "engine_behavior_test.go"), "utf8"),
+    "package linthost\n// test\n",
+  );
+  // The pre-existing library source is preserved.
+  assert.equal(
+    fs.readFileSync(path.join(target, "engine.go"), "utf8"),
+    "package linthost\n// library\n",
+  );
+});
+
+test("copyGoTestsFlat throws on a test-vs-test basename collision", (t) => {
+  const source = tmpdir(t);
+  const target = tmpdir(t);
+  writeFile(source, "a/dispatch_test.go", "package linthost\n");
+  writeFile(source, "b/dispatch_test.go", "package linthost\n");
+
+  assert.throws(
+    () => copyGoTestsFlat(source, target),
+    (err) => err instanceof Error && err.message.includes("dispatch_test.go"),
+  );
+});
+
+test("runAll invokes every runner even after an earlier one fails", () => {
+  const invoked = [];
+  const failed = runAll(["a", "b", "c"], (runner) => {
+    invoked.push(runner);
+    return runner === "a" ? 1 : 0; // the first runner fails
+  });
+
+  // The short-circuit bug stopped at the first failure; every runner must run.
+  assert.deepEqual(invoked, ["a", "b", "c"]);
+  assert.deepEqual(failed, ["a"]);
+});
+
+test("runAll reports every failing runner, not just the first", () => {
+  const failed = runAll(["a", "b", "c"], (runner) => (runner === "b" ? 0 : 1));
+  assert.deepEqual(failed, ["a", "c"]);
+});
+
+test("the orchestrator still lists the graph runner that used to be skipped", () => {
+  assert.ok(
+    runners.includes("test-go-graph.cjs"),
+    "test-go-graph.cjs must stay in the aggregated runner list",
+  );
+});

--- a/scripts/test-go-coverage.cjs
+++ b/scripts/test-go-coverage.cjs
@@ -5,6 +5,8 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
+const { copyGoTestsFlat } = require("./ci/go-test-overlay.cjs");
+
 const root = path.resolve(__dirname, "..");
 const goRoot = path.join(os.homedir(), "go-sdk", "go", "bin");
 const ttscDir = path.join(root, "packages", "ttsc");
@@ -385,32 +387,6 @@ function writeGoWork(location, packageDir) {
     ].join("\n"),
     "utf8",
   );
-}
-
-function copyGoTestsFlat(sourceDir, targetDir) {
-  fs.mkdirSync(targetDir, { recursive: true });
-  const seen = new Set();
-  for (const file of walkForGoFiles(sourceDir)) {
-    const basename = path.basename(file);
-    if (seen.has(basename)) {
-      throw new Error(`duplicate lint Go test filename: ${basename}`);
-    }
-    seen.add(basename);
-    fs.copyFileSync(file, path.join(targetDir, basename));
-  }
-}
-
-function walkForGoFiles(dir) {
-  const out = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const file = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      out.push(...walkForGoFiles(file));
-    } else if (entry.isFile() && entry.name.endsWith(".go")) {
-      out.push(file);
-    }
-  }
-  return out.sort();
 }
 
 function walkForGoMod(dir, out) {

--- a/scripts/test-go-lint.cjs
+++ b/scripts/test-go-lint.cjs
@@ -25,12 +25,26 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
+const { copyGoTestsFlat } = require("./ci/go-test-overlay.cjs");
+
 const root = path.resolve(__dirname, "..");
 const lintPkgDir = path.join(root, "packages", "lint");
 const lintTestsDir = path.join(lintPkgDir, "test");
 const ttscDir = path.join(root, "packages", "ttsc");
 const goRoot = path.join(os.homedir(), "go-sdk", "go", "bin");
-const ttsxBinary = path.join(ttscDir, "lib", "launcher", "ttsx.js");
+const ttsxBinary =
+  process.env.TTSC_TTSX_BINARY ??
+  path.join(ttscDir, "lib", "launcher", "ttsx.js");
+// Fail loudly in an unbuilt tree instead of letting the config-loader tests
+// fail deep inside `go test` with an opaque `Cannot find module '…/ttsx.js'`
+// (issue #622). test-go-lint drives the real ttsx launcher, which only exists
+// after the ttsc package is built.
+if (!fs.existsSync(ttsxBinary)) {
+  throw new Error(
+    `ttsc lint Go tests need the ttsx launcher at ${ttsxBinary}, which does not exist.\n` +
+      "Build it first with `pnpm --filter ttsc build`, or set TTSC_TTSX_BINARY to an existing launcher.",
+  );
+}
 const tsgoBinary = resolveTsgoBinary();
 
 const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-lint-go-test-"));
@@ -73,7 +87,7 @@ try {
         ? `${goRoot}${path.delimiter}${process.env.PATH ?? ""}`
         : process.env.PATH,
       TTSC_TSGO_BINARY: process.env.TTSC_TSGO_BINARY ?? tsgoBinary,
-      TTSC_TTSX_BINARY: process.env.TTSC_TTSX_BINARY ?? ttsxBinary,
+      TTSC_TTSX_BINARY: ttsxBinary,
     },
     stdio: "inherit",
     windowsHide: true,
@@ -99,32 +113,6 @@ function resolveTsgoBinary() {
     "lib",
     process.platform === "win32" ? "tsc.exe" : "tsc",
   );
-}
-
-function copyGoTestsFlat(sourceDir, targetDir) {
-  fs.mkdirSync(targetDir, { recursive: true });
-  const seen = new Set();
-  for (const file of walkForGoFiles(sourceDir)) {
-    const basename = path.basename(file);
-    if (seen.has(basename)) {
-      throw new Error(`duplicate lint Go test filename: ${basename}`);
-    }
-    seen.add(basename);
-    fs.copyFileSync(file, path.join(targetDir, basename));
-  }
-}
-
-function walkForGoFiles(dir) {
-  const out = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const file = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      out.push(...walkForGoFiles(file));
-    } else if (entry.isFile() && entry.name.endsWith(".go")) {
-      out.push(file);
-    }
-  }
-  return out.sort();
 }
 
 function walkForGoMod(dir, out) {

--- a/scripts/test-go-ttsc.cjs
+++ b/scripts/test-go-ttsc.cjs
@@ -1,0 +1,42 @@
+// Run the ttsc command and integration Go test packages.
+//
+// These six packages exercise the CLI front doors and platform host behind
+// ttsc: `test/cli`, `test/ttscserver`, `test/platform`, `test/utility`,
+// `cmd/ttsc`, and `cmd/ttscserver`. They were never in `pnpm test:go`, so 79
+// test functions had no CI signal (issue #622). The compiler is linked through
+// `shim/bundled`, so — like `test-go-driver.cjs` — they need only Go on PATH,
+// not a resolved tsgo/ttsx binary.
+
+const cp = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const goRoot = path.join(os.homedir(), "go-sdk", "go", "bin");
+
+const packages = [
+  "./test/cli",
+  "./test/ttscserver",
+  "./test/platform",
+  "./test/utility",
+  "./cmd/ttsc",
+  "./cmd/ttscserver",
+];
+
+const result = cp.spawnSync("go", ["test", "-count=1", ...packages], {
+  cwd: path.join(root, "packages", "ttsc"),
+  env: {
+    ...process.env,
+    PATH: fs.existsSync(goRoot)
+      ? `${goRoot}${path.delimiter}${process.env.PATH ?? ""}`
+      : process.env.PATH,
+  },
+  stdio: "inherit",
+  windowsHide: true,
+});
+
+if (result.error) {
+  throw result.error;
+}
+process.exit(result.status ?? 1);

--- a/scripts/test-go.cjs
+++ b/scripts/test-go.cjs
@@ -1,0 +1,64 @@
+// Orchestrate every Go test runner behind `pnpm test:go`.
+//
+// package.json previously chained the runners with `&&`, so the first failing
+// runner short-circuited the rest — test-go-graph.cjs never ran once an earlier
+// suite failed, leaving it with no CI signal (issue #622). This orchestrator
+// runs each runner regardless of earlier failures and exits non-zero if any of
+// them did, naming the failures so no red suite hides behind another.
+
+const cp = require("node:child_process");
+const path = require("node:path");
+
+const runners = [
+  "test-go-driver.cjs",
+  "test-go-ttsc.cjs",
+  "test-go-transformer.cjs",
+  "test-go-utility-plugins.cjs",
+  "test-go-lint.cjs",
+  "test-go-graph.cjs",
+];
+
+// Unit tests for the runner harness itself (the flatten collision guard and
+// this aggregation). Run first so a broken harness is reported before the long
+// Go suites execute, and so both CI Go lanes (ubuntu + windows) cover them.
+const harnessTest = path.join(__dirname, "ci", "go-test-runners.test.cjs");
+
+// runAll invokes every entry through `spawn` and returns the list that failed.
+// `spawn` is injected so the meta-test can assert each runner is invoked even
+// when an earlier one fails — the exact regression the `&&` chain hid.
+function runAll(list, spawn) {
+  const failed = [];
+  for (const entry of list) {
+    if (spawn(entry) !== 0) failed.push(entry);
+  }
+  return failed;
+}
+
+function spawnNode(args) {
+  const result = cp.spawnSync(process.execPath, args, {
+    stdio: "inherit",
+    windowsHide: true,
+  });
+  if (result.error) throw result.error;
+  return result.status ?? 1;
+}
+
+function spawnRunner(runner) {
+  return spawnNode([path.join(__dirname, runner)]);
+}
+
+if (require.main === module) {
+  const failed = [];
+  if (spawnNode(["--test", harnessTest]) !== 0) {
+    failed.push("ci/go-test-runners.test.cjs");
+  }
+  failed.push(...runAll(runners, spawnRunner));
+  if (failed.length > 0) {
+    console.error(
+      `\ntest:go: ${failed.length} step(s) failed: ${failed.join(", ")}`,
+    );
+    process.exit(1);
+  }
+}
+
+module.exports = { runAll, runners };


### PR DESCRIPTION
Closes the Go CI lane gaps in #622 and the flatten-overwrite hazard in #624. Both edit the `pnpm test:go` runner harness, so they ship together.

## #622 — CI Go lane gaps
- **No more short-circuit.** `test:go` was a `node A && node B && …` chain, so the first failing runner skipped the rest — `test-go-graph.cjs` had zero signal behind a red `test-go-lint`. Replaced with `scripts/test-go.cjs`, which runs every runner unconditionally and aggregates exit codes.
- **Six unrun packages now run.** `scripts/test-go-ttsc.cjs` runs `test/cli`, `test/ttscserver`, `test/platform`, `test/utility`, `cmd/ttsc`, `cmd/ttscserver` (79 test functions) on both the `go` and `windows-go` lanes.
- **Two POSIX-only assertions made platform-agnostic.** `TestBuildBranches` and `TestUtilityCommandFailuresCoverHostEdges` asserted the POSIX errno `"not a directory"`; they now assert exit 2 + the TS5033 `"Could not write file"` prefix, which is stable across platforms.
- **push-to-master trigger** added to `test.yml` so the trunk is validated after every merge.
- **`test-go-lint.cjs` fails loudly** when the `ttsx` launcher is missing (`fs.existsSync` guard), instead of an opaque `Cannot find module '…/ttsx.js'` deep in `go test`.

## #624 — lint test overlay collision
`copyGoTestsFlat` flattened every `.go` under `test/` into the scratch `linthost` dir (already filled with library sources), and `seen` only guarded test-vs-test clashes — so a `test/…/engine.go` silently overwrote `linthost/engine.go`. Extracted into `scripts/ci/go-test-overlay.cjs` (shared by the lint/coverage/bench runners) and seeded `seen` with the library basenames already in the target dir, so a collision throws a named error.

## Finding beyond the stated scope
Fixing the `"not a directory"` assertion let `TestUtilityCommandFailuresCoverHostEdges` run past its first `Fatalf` and reveal a **second** Windows-only failure the issue never saw: `os.Remove(deleted)` on the process's own cwd fails on Windows ("being used by another process"). The deleted-cwd getwd-failure branch is now guarded behind `runtime.GOOS != "windows"` (POSIX keeps full coverage; the cwd restore stays unconditional).

Two helper scripts (`scripts/test-go.cjs` orchestrator, `scripts/test-go-ttsc.cjs` runner) are new files — the cross-platform "run-all + aggregate" contract and the six-package lane need a runner each, mirroring the existing `scripts/test-go-*.cjs` pattern.

## Regression shield
`scripts/ci/go-test-runners.test.cjs` (`node --test`, run first inside `test:go` on both lanes) covers:
- the flatten guard — a planted `engine.go` throws and the library source is untouched;
- the aggregation contract — every runner is invoked after an earlier one fails, and `test-go-graph.cjs` stays in the list.

## Test plan (run on Windows)
- `node --check` on all 7 touched/new `.cjs` — clean.
- `node --test scripts/ci/go-test-runners.test.cjs` — 6/6 pass.
- `go test ./test/cli ./test/ttscserver ./test/platform ./test/utility ./cmd/ttsc ./cmd/ttscserver` — all six **ok** (both previously-failing assertions green); `go vet ./test/utility` clean.
- `node scripts/test-go-lint.cjs` in an unbuilt tree — throws the clear ttsx-guard error (exit 1).
- Not runnable in this bare worktree (no `node_modules`/built `ttsx`): the full orchestrator and the lint/coverage/bench end-to-end runners, plus the POSIX path of the utility-test restructure — left to the CI `go` (ubuntu) and `windows-go` lanes.

**Do not merge** — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND