### PR TITLE
fix(lint): keep trailing comma off rest in destructuring assignment targets

### DIFF
--- a/packages/lint/linthost/print_nodes_array.go
+++ b/packages/lint/linthost/print_nodes_array.go
@@ -53,12 +53,18 @@ func printArrayLiteral(ctx *PrintContext, node *shimast.Node) (Doc, bool) {
   // suppresses. Hardcoding `true` would oscillate against Prettier on
   // every `none` project (the trailing-comma rule wouldn't insert one
   // and the printer would put one back).
+  //
+  // A destructuring assignment target ending in a rest
+  // (`[a, ...rest] = arr`) is the one exception: a trailing comma after
+  // its `AssignmentRestElement` is a syntax error, so the reflow must not
+  // emit one even under "all"/"es5". Matches the same suppression in
+  // `format/trailing-comma`; see isRestAssignmentTargetLiteral.
   return printList(ctx, listShape{
     OpenTok:     "[",
     CloseTok:    "]",
     Items:       items,
     Space:       false,
-    AddComma:    ctx.allowsEs5TrailingComma(),
+    AddComma:    ctx.allowsEs5TrailingComma() && !isRestAssignmentTargetLiteral(node),
     Fill:        isConciselyPrintedArray(arr.Elements.Nodes),
     ForceBreak:  arrayShouldForceBreak(arr.Elements.Nodes),
     BlankBefore: blankBeforeItems(ctx.Source, arr.Elements.Nodes),

--- a/packages/lint/linthost/print_nodes_object.go
+++ b/packages/lint/linthost/print_nodes_object.go
@@ -66,12 +66,18 @@ func printObjectLiteral(ctx *PrintContext, node *shimast.Node) (Doc, bool) {
   // trailing commas in ES5 so both "all" and "es5" keep them; only
   // "none" suppresses. Pairs with the call/array branches so the printer
   // never disagrees with the trailing-comma rule on the same setting.
+  //
+  // A destructuring assignment target ending in a rest
+  // (`({ a, ...rest } = obj)`) is the one exception: a trailing comma
+  // after its `AssignmentRestProperty` is a syntax error, so the reflow
+  // must not emit one even under "all"/"es5". Matches the same suppression
+  // in `format/trailing-comma`; see isRestAssignmentTargetLiteral.
   return printList(ctx, listShape{
     OpenTok:     "{",
     CloseTok:    "}",
     Items:       items,
     Space:       true,
-    AddComma:    ctx.allowsEs5TrailingComma(),
+    AddComma:    ctx.allowsEs5TrailingComma() && !isRestAssignmentTargetLiteral(node),
     ForceBreak:  forceBreak,
     BlankBefore: blankBeforeItems(ctx.Source, obj.Properties.Nodes),
   }), covered

--- a/packages/lint/linthost/rules_format_trailing_comma.go
+++ b/packages/lint/linthost/rules_format_trailing_comma.go
@@ -35,6 +35,16 @@ import (
 // element. The same restriction applies to rest binding patterns, which
 // the rule does not visit at all.
 //
+// Destructuring assignment TARGETS are the one array/object-literal shape
+// where the same rest restriction bites: `({ a, ...rest } = obj)` and
+// `[a, ...rest] = arr` parse as ObjectLiteralExpression /
+// ArrayLiteralExpression (not binding patterns) and are therefore visited,
+// yet a trailing comma after their `AssignmentRestProperty` /
+// `AssignmentRestElement` is a syntax error. `isRestAssignmentTargetLiteral`
+// suppresses the insert for exactly those; a real value literal with a
+// trailing spread (`{ a, ...o }`) and a non-rest target (`{ a, b } = obj`)
+// both legally keep the comma.
+//
 // Unparenthesized arrow parameters (`a => …`) are also skipped: there is
 // no parameter-list paren to anchor the comma against, and ECMAScript has
 // no place to insert one. `findCloseTokenAfter` bails on the first
@@ -94,10 +104,16 @@ func (formatTrailingComma) Check(ctx *Context, node *shimast.Node) {
     if arr == nil {
       return
     }
+    if isRestAssignmentTargetLiteral(node) {
+      return
+    }
     considerTrailingComma(ctx, arr.Elements, node.End()-1)
   case shimast.KindObjectLiteralExpression:
     obj := node.AsObjectLiteralExpression()
     if obj == nil {
+      return
+    }
+    if isRestAssignmentTargetLiteral(node) {
       return
     }
     considerTrailingComma(ctx, obj.Properties, node.End()-1)
@@ -349,6 +365,53 @@ func considerFunctionParameterComma(ctx *Context, list *shimast.NodeList) {
     return
   }
   considerTrailingComma(ctx, list, closePos)
+}
+
+// isRestAssignmentTargetLiteral reports whether node is an object- or
+// array-literal used as a destructuring ASSIGNMENT TARGET whose last
+// element is a rest (`...x`). ECMAScript forbids a trailing comma after an
+// `AssignmentRestElement` / `AssignmentRestProperty`, so neither this rule
+// nor the print-width printer (which shares this helper) may add one there.
+//
+// The two-pronged guard is what keeps it from over-suppressing. Only a
+// destructuring assignment target that ENDS in a rest is illegal:
+//
+//   - A real value literal with a trailing spread (`{ a, ...o }`,
+//     `[a, ...rest]`) is not a target, so isDestructuringAssignmentTarget
+//     returns false and the comma stays legal.
+//   - A non-rest assignment target (`{ a, b } = obj`) fails the
+//     last-element-is-rest check and keeps its comma.
+//
+// It handles nested targets (`[{ a, ...rest }] = arr`,
+// `({ x: [a, ...rest] } = obj)`) and for-of/for-in assignment initializers
+// through isDestructuringAssignmentTarget's ancestor walk.
+func isRestAssignmentTargetLiteral(node *shimast.Node) bool {
+  if node == nil {
+    return false
+  }
+  switch node.Kind {
+  case shimast.KindArrayLiteralExpression:
+    arr := node.AsArrayLiteralExpression()
+    if arr == nil || arr.Elements == nil || len(arr.Elements.Nodes) == 0 {
+      return false
+    }
+    last := arr.Elements.Nodes[len(arr.Elements.Nodes)-1]
+    if last == nil || last.Kind != shimast.KindSpreadElement {
+      return false
+    }
+  case shimast.KindObjectLiteralExpression:
+    obj := node.AsObjectLiteralExpression()
+    if obj == nil || obj.Properties == nil || len(obj.Properties.Nodes) == 0 {
+      return false
+    }
+    last := obj.Properties.Nodes[len(obj.Properties.Nodes)-1]
+    if last == nil || last.Kind != shimast.KindSpreadAssignment {
+      return false
+    }
+  default:
+    return false
+  }
+  return isDestructuringAssignmentTarget(node)
 }
 
 // lastParameterIsRest reports whether the parameter list ends with a

--- a/packages/lint/test/format/format_print_width_breaks_array_rest_assignment_target_without_comma_test.go
+++ b/packages/lint/test/format/format_print_width_breaks_array_rest_assignment_target_without_comma_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestFormatPrintWidthBreaksArrayRestAssignmentTargetWithoutComma verifies
+// the reflow breaks an overflowing array destructuring assignment target
+// ending in a rest (`[a, ...rest] = arr`) WITHOUT appending a trailing comma.
+//
+// Arrays have no objectWrap:"preserve", so the suppression must be exercised
+// through a genuine width-driven break: the flat form overflows printWidth,
+// the reflow explodes it one element per line, and the printer's AddComma
+// would otherwise put a comma after the AssignmentRestElement (a syntax
+// error). The rest-target guard keeps the exploded shape valid.
+//
+// 1. Configure printWidth=20 and feed a single-line array rest target that overflows.
+// 2. Run formatPrintWidth so the array breaks one element per line.
+// 3. Assert the broken output has no trailing comma after the rest element.
+func TestFormatPrintWidthBreaksArrayRestAssignmentTargetWithoutComma(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/print-width",
+    "[alpha, ...restItems] = sourceArray;\n",
+    `{"printWidth": 20}`,
+    "[\n  alpha,\n  ...restItems\n] = sourceArray;\n",
+  )
+}

--- a/packages/lint/test/format/format_print_width_inserts_after_non_rest_object_assignment_target_test.go
+++ b/packages/lint/test/format/format_print_width_inserts_after_non_rest_object_assignment_target_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFormatPrintWidthInsertsAfterNonRestObjectAssignmentTarget is the
+// target-axis over-suppression twin for the reflow: a preserved multi-line
+// object assignment target WITHOUT a trailing rest (`({ a, b } = obj)`) must
+// still gain its trailing comma.
+//
+// The printer must suppress the comma only when the target ends in a rest,
+// not on every destructuring target. This pins that a plain `{ a, b } = obj`
+// reflow still appends the comma so the guard does not disable trailing
+// commas across all assignment targets.
+//
+// 1. Feed an already-broken object assignment target whose last member is not a rest.
+// 2. Run formatPrintWidth at the default width (objectWrap keeps it expanded).
+// 3. Assert the reflow adds the trailing comma after the last member.
+func TestFormatPrintWidthInsertsAfterNonRestObjectAssignmentTarget(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "format/print-width",
+    "({\n  a,\n  b\n} = obj);\n",
+    "({\n  a,\n  b,\n} = obj);\n",
+  )
+}

--- a/packages/lint/test/format/format_print_width_inserts_after_object_spread_in_value_literal_test.go
+++ b/packages/lint/test/format/format_print_width_inserts_after_object_spread_in_value_literal_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFormatPrintWidthInsertsAfterObjectSpreadInValueLiteral is the
+// over-suppression twin for the reflow: a preserved multi-line object VALUE
+// literal ending in a spread (`{ a, ...o }`) must still gain its trailing
+// comma when reflowed.
+//
+// The printer's rest-target suppression keys on assignment-target position,
+// not on a trailing spread. A value-position spread is not a target, so the
+// reflow honors trailingComma:"all" and appends the comma — proving the
+// printer guard does not over-reach.
+//
+// 1. Feed an already-broken object value literal whose last member is a spread, no trailing comma.
+// 2. Run formatPrintWidth at the default width (objectWrap keeps it expanded).
+// 3. Assert the reflow adds the trailing comma after the spread.
+func TestFormatPrintWidthInsertsAfterObjectSpreadInValueLiteral(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "format/print-width",
+    "const merged = {\n  a,\n  ...o\n};\n",
+    "const merged = {\n  a,\n  ...o,\n};\n",
+  )
+}

--- a/packages/lint/test/format/format_print_width_keeps_object_rest_assignment_target_without_comma_test.go
+++ b/packages/lint/test/format/format_print_width_keeps_object_rest_assignment_target_without_comma_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFormatPrintWidthKeepsObjectRestAssignmentTargetWithoutComma verifies
+// the reflow does not add a trailing comma when it keeps a multi-line object
+// destructuring assignment target expanded (`({ a, ...rest } = obj)`).
+//
+// objectWrap:"preserve" keeps the newline-after-`{` object broken, and the
+// printer's AddComma would append a comma after the rest under
+// trailingComma:"all" — a syntax error. The printer must mirror the
+// trailing-comma rule's rest-target suppression, so the already-valid,
+// already-canonical source renders byte-identical and produces no finding.
+//
+// 1. Feed an already-broken object rest assignment target with no trailing comma.
+// 2. Run formatPrintWidth at the default width.
+// 3. Assert zero findings: the reflow leaves it untouched instead of adding a comma.
+func TestFormatPrintWidthKeepsObjectRestAssignmentTargetWithoutComma(t *testing.T) {
+  assertRuleSkipsSource(
+    t,
+    "format/print-width",
+    "({\n  ra,\n  ...rrest\n} = obj);\n",
+  )
+}

--- a/packages/lint/test/format/format_trailing_comma_inserts_after_array_spread_in_value_literal_test.go
+++ b/packages/lint/test/format/format_trailing_comma_inserts_after_array_spread_in_value_literal_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFormatTrailingCommaInsertsAfterArraySpreadInValueLiteral is the
+// over-suppression twin of the array rest-target skip: a real array VALUE
+// literal ending in a spread (`[a, ...rest]`) legally takes a trailing comma.
+//
+// Mirrors the object value-spread twin for arrays. The suppression must key
+// on assignment-target position, not on a trailing SpreadElement, so this
+// value-position spread still gains its comma.
+//
+// 1. Parse a multi-line array value literal whose last element is a spread.
+// 2. Apply the rule's finding through the disk-backed fixer.
+// 3. Assert the trailing comma lands after the spread.
+func TestFormatTrailingCommaInsertsAfterArraySpreadInValueLiteral(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "format/trailing-comma",
+    "const combined = [\n  aa,\n  ...rest\n];\n",
+    "const combined = [\n  aa,\n  ...rest,\n];\n",
+  )
+}

--- a/packages/lint/test/format/format_trailing_comma_inserts_after_non_rest_array_assignment_target_test.go
+++ b/packages/lint/test/format/format_trailing_comma_inserts_after_non_rest_array_assignment_target_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFormatTrailingCommaInsertsAfterNonRestArrayAssignmentTarget is the
+// array twin of the non-rest target over-suppression check: a destructuring
+// array assignment target without a trailing rest (`[a, b] = arr`) legally
+// takes a trailing comma (`[a, b,] = arr` parses).
+//
+// Guards the array branch of the same target-position mechanism: suppression
+// keys on the last element being a SpreadElement, so a non-rest array target
+// must still gain its comma.
+//
+// 1. Parse a multi-line array assignment target whose last element is not a rest.
+// 2. Apply the rule's finding through the disk-backed fixer.
+// 3. Assert the trailing comma lands after the last element.
+func TestFormatTrailingCommaInsertsAfterNonRestArrayAssignmentTarget(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "format/trailing-comma",
+    "[\n  a,\n  b\n] = arr;\n",
+    "[\n  a,\n  b,\n] = arr;\n",
+  )
+}

--- a/packages/lint/test/format/format_trailing_comma_inserts_after_non_rest_object_assignment_target_test.go
+++ b/packages/lint/test/format/format_trailing_comma_inserts_after_non_rest_object_assignment_target_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFormatTrailingCommaInsertsAfterNonRestObjectAssignmentTarget is the
+// over-suppression twin on the target axis: a destructuring assignment
+// target WITHOUT a trailing rest (`({ a, b } = obj)`) legally takes a
+// trailing comma (Node `--check` exits 0 on `({ a, b, } = obj)`).
+//
+// The suppression must fire only when the target ends in a rest; an
+// assignment target alone is not enough. This pins that a plain
+// `{ a, b } = obj` still gains its comma so the fix does not over-reach and
+// disable the rule on every destructuring target.
+//
+// 1. Parse a multi-line object assignment target whose last member is not a rest.
+// 2. Apply the rule's finding through the disk-backed fixer.
+// 3. Assert the trailing comma lands after the last member.
+func TestFormatTrailingCommaInsertsAfterNonRestObjectAssignmentTarget(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "format/trailing-comma",
+    "({\n  a,\n  b\n} = obj);\n",
+    "({\n  a,\n  b,\n} = obj);\n",
+  )
+}

--- a/packages/lint/test/format/format_trailing_comma_inserts_after_object_spread_in_value_literal_test.go
+++ b/packages/lint/test/format/format_trailing_comma_inserts_after_object_spread_in_value_literal_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFormatTrailingCommaInsertsAfterObjectSpreadInValueLiteral is the
+// over-suppression twin of the object rest-target skip: a real object VALUE
+// literal ending in a spread (`{ a, ...o }`) legally takes a trailing comma.
+//
+// The rest-target suppression keys on assignment-target position, not on the
+// mere presence of a trailing spread. A value-position spread is not a
+// destructuring target, so the rule must still add the comma; a guard that
+// suppressed on "last element is a spread" alone would silently regress this.
+//
+// 1. Parse a multi-line object value literal whose last member is a spread.
+// 2. Apply the rule's finding through the disk-backed fixer.
+// 3. Assert the trailing comma lands after the spread.
+func TestFormatTrailingCommaInsertsAfterObjectSpreadInValueLiteral(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "format/trailing-comma",
+    "const merged = {\n  a,\n  ...o\n};\n",
+    "const merged = {\n  a,\n  ...o,\n};\n",
+  )
+}

--- a/packages/lint/test/format/format_trailing_comma_skips_array_rest_assignment_target_test.go
+++ b/packages/lint/test/format/format_trailing_comma_skips_array_rest_assignment_target_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFormatTrailingCommaSkipsArrayRestAssignmentTarget verifies the rule
+// adds no trailing comma to a multi-line array destructuring assignment
+// target ending in a rest (`[a, ...rest] = arr`).
+//
+// The array analogue of the object rest-target hazard: it parses as an
+// ArrayLiteralExpression with a trailing SpreadElement, which the rule
+// visits, yet a comma after the AssignmentRestElement is a syntax error.
+// isRestAssignmentTargetLiteral suppresses the insert; the valid source
+// must survive unchanged.
+//
+// 1. Parse a multi-line array destructuring assignment target with a rest.
+// 2. Run the rule.
+// 3. Assert zero findings, so no fix corrupts the source.
+func TestFormatTrailingCommaSkipsArrayRestAssignmentTarget(t *testing.T) {
+  assertRuleSkipsSource(
+    t,
+    "format/trailing-comma",
+    "[\n  aa,\n  ...arest\n] = arr;\n",
+  )
+}

--- a/packages/lint/test/format/format_trailing_comma_skips_object_rest_assignment_target_test.go
+++ b/packages/lint/test/format/format_trailing_comma_skips_object_rest_assignment_target_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFormatTrailingCommaSkipsObjectRestAssignmentTarget verifies the rule
+// adds no trailing comma to a multi-line object destructuring assignment
+// target ending in a rest (`({ a, ...rest } = obj)`).
+//
+// Such a target parses as an ObjectLiteralExpression with a trailing
+// SpreadAssignment, so the rule visits it — but a comma after the
+// AssignmentRestProperty is a syntax error (Node `--check` exits 1). The
+// parameter-list rest guard did not reach this shape; isRestAssignmentTargetLiteral
+// now suppresses it. The source is already valid and must be left untouched.
+//
+// 1. Parse a multi-line object destructuring assignment target with a rest.
+// 2. Run the rule.
+// 3. Assert zero findings, so no fix rewrites the source into invalid syntax.
+func TestFormatTrailingCommaSkipsObjectRestAssignmentTarget(t *testing.T) {
+  assertRuleSkipsSource(
+    t,
+    "format/trailing-comma",
+    "({\n  ra,\n  ...rrest\n} = obj);\n",
+  )
+}

--- a/tests/test-lint/fixtures/format-projects/format-trailing-comma/expected/main.ts
+++ b/tests/test-lint/fixtures/format-projects/format-trailing-comma/expected/main.ts
@@ -21,3 +21,10 @@ JSON.stringify({
   settings,
   sample: describe("a", { name: "x", value: 1 }),
 });
+
+let received: number;
+let others: { timeout: number };
+({
+  received,
+  ...others
+} = { received: 1, timeout: 2 });

--- a/tests/test-lint/fixtures/format-projects/format-trailing-comma/src/main.ts
+++ b/tests/test-lint/fixtures/format-projects/format-trailing-comma/src/main.ts
@@ -21,3 +21,10 @@ JSON.stringify({
   settings,
   sample: describe("a", { name: "x", value: 1 }),
 });
+
+let received: number;
+let others: { timeout: number };
+({
+  received,
+  ...others
+} = { received: 1, timeout: 2 });

--- a/tests/test-lint/src/native-plugins/format/test_lint_format_trailing_comma_rewrites_multi_line_lists.ts
+++ b/tests/test-lint/src/native-plugins/format/test_lint_format_trailing_comma_rewrites_multi_line_lists.ts
@@ -10,12 +10,16 @@ import { SHARED_PLUGIN_CACHE_DIR } from "../../internal/plugin-cache";
  * Verifies lint format trailing-comma: rewrites multi-line lists end-to-end.
  *
  * The fixture mixes a single-line array, a multi-line object, a multi-line
- * nested call inside a function declaration, and a multi-line `JSON.stringify`
- * whose closing `}` and `)` collapse onto a single line. The single-line array
- * is the negative anchor for the no-newlines short-circuit; the
- * `JSON.stringify({...})` call is the close-paren-shares-line regression anchor
- * — its `}` and `)` end up on the same line as the rule's would-be insertion
- * point, so the rule must abstain.
+ * nested call inside a function declaration, a multi-line `JSON.stringify`
+ * whose closing `}` and `)` collapse onto a single line, and a multi-line
+ * object destructuring assignment target ending in a rest
+ * (`({ received, ...others } = …)`). The single-line array is the negative
+ * anchor for the no-newlines short-circuit; the `JSON.stringify({...})` call is
+ * the close-paren-shares-line regression anchor — its `}` and `)` end up on the
+ * same line as the rule's would-be insertion point, so the rule must abstain;
+ * the rest assignment target is the issue #608 anchor — a trailing comma after
+ * its `AssignmentRestProperty` is a syntax error, so the format cascade must
+ * leave it comma-free.
  *
  * 1. Copy `fixtures/format-projects/format-trailing-comma` into a temp project.
  * 2. Run `ttsc format` through the real launcher with `@ttsc/lint` linked.

--- a/website/src/content/docs/lint/format.mdx
+++ b/website/src/content/docs/lint/format.mdx
@@ -86,6 +86,8 @@ Quoting of object-literal property keys. `"as-needed"` (default) unquotes keys t
 
 Enforce trailing commas in **multiline** literals, object literals, array literals, function parameter lists, function call arguments, and import/export specifier lists. Single-line literals are untouched. Driven by `format.trailingComma`.
 
+A trailing comma is never inserted after a rest element (`...rest`), where the grammar forbids one: rest parameters, and destructuring **assignment targets** that end in a rest such as `({ a, ...rest } = obj)` or `[a, ...rest] = arr`. A real value literal with a trailing spread (`{ a, ...o }`, `[a, ...rest]`) and a non-rest assignment target (`{ a, b } = obj`) still receive one. The `printWidth` reflow honors the same rule.
+
 ### `sortImports`
 
 **Opt-in.** Sort named specifiers and erased type-only imports. Set `format.sortImports` to `true` for safe defaults, or to an object to customize.


### PR DESCRIPTION
## Intent

Fixes #608. `format/trailing-comma` **and** `format/print-width` appended a trailing comma after the rest element of a destructuring **assignment target** (`({ a, ...rest } = obj)` / `[a, ...rest] = arr`), producing a **syntax error** — the grammar forbids a comma after `AssignmentRestProperty` / `AssignmentRestElement` (verified with Node `--check`).

## Root cause

A destructuring assignment target parses as an `ObjectLiteralExpression` / `ArrayLiteralExpression` with a trailing `SpreadAssignment` / `SpreadElement` (not a binding pattern), so both the rule and the width-aware printer visited it. The existing rest guard (`lastParameterIsRest`) only covered *parameter* lists; the printer's `AddComma` was unconditional on the last-element kind. Patching only the rule would leave `format/print-width` reintroducing the comma, so **both sites** had to change.

## Fix

New shared helper `isRestAssignmentTargetLiteral` fires only when the last element is a rest **and** the literal sits in an assignment-target position (reusing the existing `isDestructuringAssignmentTarget` ancestor walk, which already handles nested targets and `for-of`/`for-in` initializers). It is consulted in:

- `rules_format_trailing_comma.go` — the array/object literal branches of `Check`.
- `print_nodes_object.go` / `print_nodes_array.go` — `AddComma`.

The two-pronged guard does **not** over-suppress: a real value literal with a trailing spread (`{ a, ...o }`) and a non-rest target (`{ a, b } = obj`) both legally keep their comma.

## Scope

Edited only the three files named in the issue plus tests, the e2e fixture, and docs. No other format-rule files touched; the assignment-target detection reuses the existing `ast_helpers.go` helper unchanged.

## Test plan

- **Before/after repro (local):** with the shared guard neutered, exactly the 4 rest-target suppression tests fail — the printer emits `...restItems,` and the two rules add a comma finding; the 6 positive-twin tests still pass. Restoring the guard turns all 10 green.
- **Oracle (Node `--check`):** suppressed shapes parse; the comma-after-rest output the bug produced is a `SyntaxError`; all positive twins parse.
- **Go unit tests** (one `Test*` per file under `packages/lint/test/format/`):
  - Skip: object + array rest assignment targets, for both `format/trailing-comma` (no finding) and `format/print-width` (object kept comma-free via objectWrap-preserve; array broken by width overflow, comma-free).
  - Positive twins (comma IS legal, must not over-suppress): value-position trailing spread (object + array) and non-rest assignment target (object + array), across both rules.
- **e2e:** added an object rest assignment target to the `format-trailing-comma` fixture (src == expected) so the whole `ttsc format` cascade is shielded end-to-end.
- Ran the full `TestFormat*` + `TestPrint*` families locally (green, 20s). The complete `node scripts/test-go-lint.cjs` suite exceeds Go's default 10-minute test timeout locally (each type-aware test spawns a tsgo Program); left to CI.

## Notes

- Per task instruction, `pnpm format` was **not** run; touched Go files were formatted with `.vscode/gofmt-2spaces.sh -w`, and the `.ts`/`.mdx` edits follow the surrounding Prettier style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND