### PR TITLE
fix(lint): resolve unicorn/prefer-optional-catch-binding via checker scope

### DIFF
--- a/packages/lint/linthost/rules_unicorn_prefer_optional_catch_binding.go
+++ b/packages/lint/linthost/rules_unicorn_prefer_optional_catch_binding.go
@@ -5,39 +5,31 @@
 // and signals that the catch body still cares about the error when in
 // fact it doesn't.
 //
-// AST-only: visit each `CatchClause`, restrict to the common-case
-// binding names `e` and `error` (true scope analysis would require a
-// resolver), and confirm the body's source text does not contain the
-// binding name as a word-bounded identifier. The previous substring
-// scan was load-bearing-wrong: `strings.Contains(body, "e")` matches
-// nearly any English identifier, hiding the rule entirely; word
-// boundaries (`\bname\b`) correctly distinguish `e` from `error`,
-// `error` from `errorMessage`, etc. False positives on `name` inside
-// string literals or comments are acceptable because the rule is
-// conservative by design.
+// Report any identifier catch binding whose declared variable is never
+// referenced, matching upstream's `getDeclaredVariables(node).some(v =>
+// v.references.length > 0)` check. Binding identity comes from the
+// TypeScript checker: the block is walked for identifiers that resolve to
+// the binding's symbol, so a comment or string literal that merely spells
+// the name is not a use, a reference from a nested closure still is, and a
+// nested shadow that rebinds the name leaves the catch binding unused.
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-optional-catch-binding.md
 package linthost
 
-import (
-  "regexp"
-
-  shimast "github.com/microsoft/typescript-go/shim/ast"
-)
-
-var unicornPreferOptionalCatchBindingNamePattern = map[string]*regexp.Regexp{
-  "e":     regexp.MustCompile(`\be\b`),
-  "error": regexp.MustCompile(`\berror\b`),
-}
+import shimast "github.com/microsoft/typescript-go/shim/ast"
 
 type unicornPreferOptionalCatchBinding struct{}
 
 func (unicornPreferOptionalCatchBinding) Name() string {
   return "unicorn/prefer-optional-catch-binding"
 }
+func (unicornPreferOptionalCatchBinding) NeedsTypeChecker() bool { return true }
 func (unicornPreferOptionalCatchBinding) Visits() []shimast.Kind {
   return []shimast.Kind{shimast.KindCatchClause}
 }
 func (unicornPreferOptionalCatchBinding) Check(ctx *Context, node *shimast.Node) {
+  if ctx == nil || ctx.Checker == nil || node == nil {
+    return
+  }
   catch := node.AsCatchClause()
   if catch == nil || catch.VariableDeclaration == nil || catch.Block == nil {
     return
@@ -46,12 +38,20 @@ func (unicornPreferOptionalCatchBinding) Check(ctx *Context, node *shimast.Node)
   if binding == nil || binding.Kind != shimast.KindIdentifier {
     return
   }
-  name := identifierText(binding)
-  pattern, ok := unicornPreferOptionalCatchBindingNamePattern[name]
-  if !ok {
+  symbol := ctx.Checker.GetSymbolAtLocation(binding)
+  if symbol == nil {
     return
   }
-  if pattern.MatchString(nodeText(ctx.File, catch.Block)) {
+  used := false
+  walkDescendants(catch.Block, func(child *shimast.Node) {
+    if used || child.Kind != shimast.KindIdentifier {
+      return
+    }
+    if valueSymbolAtIdentifier(ctx, child) == symbol {
+      used = true
+    }
+  })
+  if used {
     return
   }
   ctx.Report(binding, "Prefer optional catch binding `catch { ... }` when the error is unused.")

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_optional_catch_binding_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_optional_catch_binding_test.go
@@ -3,17 +3,46 @@ package linthost
 import "testing"
 
 // TestRuleCorpusUnicornPreferOptionalCatchBinding verifies
-// unicorn/prefer-optional-catch-binding reports a `catch (e)` whose body
-// never references the binding.
+// unicorn/prefer-optional-catch-binding reports every identifier catch
+// binding whose declared variable is never referenced, regardless of name.
 //
-// The rule matches catch bindings named `e` or `error` and uses a text
-// scan of the catch block as a loose "binding unused" proxy. This
-// fixture pins the canonical positive case: binding `e`, body does not
-// mention `e`, so the binding identifier is reported.
+// The rule resolves binding usage through the TypeScript checker, so this
+// fixture pins the four cases the old name-allow-list plus raw-text scan
+// missed — bindings named `err` and `exception`, a comment that spells the
+// name, and a string literal that spells the name — alongside the canonical
+// `e` case and a nested shadow that leaves the catch binding unused. Its
+// negative twin (`log(err)`) is a genuine reference that must not report.
 //
-// 1. Enable unicorn/prefer-optional-catch-binding via an expect annotation.
-// 2. Write a `catch (e)` block that never reads `e`.
-// 3. Assert the binding identifier is reported on the catch line.
+// 1. Load the annotated fixture and enable the rule from its expect comments.
+// 2. Run the rule through the real Program/checker snapshot path.
+// 3. Assert exactly the six annotated catch bindings are reported.
 func TestRuleCorpusUnicornPreferOptionalCatchBinding(t *testing.T) {
-  assertRuleCorpusCase(t, "unicorn/prefer-optional-catch-binding.ts", "try {\n  throw new Error(\"x\");\n  // expect: unicorn/prefer-optional-catch-binding error\n} catch (e) {\n  void 0;\n}\n")
+  source := "declare function f(): void;\ndeclare function g(): void;\ndeclare function log(value: unknown): void;\n\n// A binding named `err` is unused: the dropped two-name allow-list used to\n// miss every name other than `e`/`error`.\ntry {\n  f();\n  // expect: unicorn/prefer-optional-catch-binding error\n} catch (err) {\n  g();\n}\n\n// A binding named `exception` is also outside the old allow-list.\ntry {\n  f();\n  // expect: unicorn/prefer-optional-catch-binding error\n} catch (exception) {\n  g();\n}\n\n// A comment that spells the binding name is not a reference; the old raw-text\n// scan treated it as a use and stayed silent.\ntry {\n  f();\n  // expect: unicorn/prefer-optional-catch-binding error\n} catch (error) {\n  // swallow the error\n  g();\n}\n\n// A string literal containing the binding name is not a reference either.\ntry {\n  f();\n  // expect: unicorn/prefer-optional-catch-binding error\n} catch (error) {\n  g();\n  log(\"error\");\n}\n\n// The canonical `e` case from the original fixture still reports.\ntry {\n  f();\n  // expect: unicorn/prefer-optional-catch-binding error\n} catch (e) {\n  g();\n}\n\n// A nested shadow rebinds `error`; the inner references resolve to the inner\n// declaration, so the catch binding itself stays unused and is reported.\ntry {\n  f();\n  // expect: unicorn/prefer-optional-catch-binding error\n} catch (error) {\n  {\n    const error = 1;\n    log(error);\n  }\n}\n\n// Genuine use: `log(err)` references the binding, so nothing is reported.\ntry {\n  f();\n} catch (err) {\n  log(err);\n}\n"
+
+  expected := parseRuleExpectations(t, source)
+  if len(expected) == 0 {
+    t.Fatal("unicorn-prefer-optional-catch-binding.ts has no rule expectations")
+  }
+  _, _, findings := runRuleFindingsSnapshotFile(
+    t,
+    "unicorn/prefer-optional-catch-binding",
+    "unicorn-prefer-optional-catch-binding.ts",
+    source,
+    nil,
+  )
+  if len(findings) != len(expected) {
+    t.Fatalf("want %v, got %+v", expected, findings)
+  }
+  actual := normalizeRuleFindings(findings[0].File, findings)
+  for index := range expected {
+    if actual[index] != expected[index] {
+      t.Fatalf(
+        "[%d]: want %+v, got %+v; all findings=%+v",
+        index,
+        expected[index],
+        actual[index],
+        actual,
+      )
+    }
+  }
 }

--- a/tests/test-lint/src/cases/unicorn-prefer-optional-catch-binding.ts
+++ b/tests/test-lint/src/cases/unicorn-prefer-optional-catch-binding.ts
@@ -1,6 +1,66 @@
+declare function f(): void;
+declare function g(): void;
+declare function log(value: unknown): void;
+
+// A binding named `err` is unused: the dropped two-name allow-list used to
+// miss every name other than `e`/`error`.
 try {
-  throw new Error("x");
+  f();
+  // expect: unicorn/prefer-optional-catch-binding error
+} catch (err) {
+  g();
+}
+
+// A binding named `exception` is also outside the old allow-list.
+try {
+  f();
+  // expect: unicorn/prefer-optional-catch-binding error
+} catch (exception) {
+  g();
+}
+
+// A comment that spells the binding name is not a reference; the old raw-text
+// scan treated it as a use and stayed silent.
+try {
+  f();
+  // expect: unicorn/prefer-optional-catch-binding error
+} catch (error) {
+  // swallow the error
+  g();
+}
+
+// A string literal containing the binding name is not a reference either.
+try {
+  f();
+  // expect: unicorn/prefer-optional-catch-binding error
+} catch (error) {
+  g();
+  log("error");
+}
+
+// The canonical `e` case from the original fixture still reports.
+try {
+  f();
   // expect: unicorn/prefer-optional-catch-binding error
 } catch (e) {
-  void 0;
+  g();
+}
+
+// A nested shadow rebinds `error`; the inner references resolve to the inner
+// declaration, so the catch binding itself stays unused and is reported.
+try {
+  f();
+  // expect: unicorn/prefer-optional-catch-binding error
+} catch (error) {
+  {
+    const error = 1;
+    log(error);
+  }
+}
+
+// Genuine use: `log(err)` references the binding, so nothing is reported.
+try {
+  f();
+} catch (err) {
+  log(err);
 }

--- a/website/src/content/docs/lint/rules/unicorn.mdx
+++ b/website/src/content/docs/lint/rules/unicorn.mdx
@@ -1904,7 +1904,7 @@ const obj = entries.reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {});
 
 ### `unicorn/prefer-optional-catch-binding`
 
-Prefer `catch { ... }` over `catch (e) { ... }` when `e` is unused.
+Prefer `catch { ... }` over `catch (binding) { ... }` when the caught error is never referenced. The binding is resolved through the type checker, so any unused name reports and a name that only appears in a comment or string literal still counts as unused.
 
 Example:
 


### PR DESCRIPTION
## Intent

Fixes #603. `unicorn/prefer-optional-catch-binding` was inert on real code: it only recognized the binding names `e`/`error`, and decided whether the binding was "used" by regex-scanning the catch block's **raw source text** (including comments and string literals). Any other binding name was ignored, and a comment or string that merely spelled the name suppressed the report.

## Change

- **Rule** (`rules_unicorn_prefer_optional_catch_binding.go`): drop the two-name allow-list and the raw-text scan. Resolve the binding's symbol through `ctx.Checker` and walk the block's identifier **nodes**, counting a use only when an identifier resolves to the binding's symbol. This mirrors upstream's `getDeclaredVariables(node).some(v => v.references.length > 0)`:
  - any identifier catch binding with no references reports, regardless of name;
  - a comment or string literal spelling the name is **not** a use;
  - a reference from a nested closure **is** a use;
  - a nested shadow that rebinds the name leaves the catch binding unused.
- The rule is now **type-aware** (`NeedsTypeChecker() == true`). Classification side effect: its behavioral-witness kind moves from `engine` to `checker`, and a config enabling only this rule now builds a Program/checker instead of staying on the AST-only fast path. Verified against the engine checker-gate and behavioral-witness audits.

## Scope

Identifier catch bindings only. Destructuring-pattern bindings (`catch ({ message }) {}`) keep the prior behavior of not reporting — that is a separate, pre-existing gap with different upstream messaging and is out of scope for this issue.

## Test plan

- Rewrote the Go corpus test and the `tests/test-lint` fixture (upstream-oracle) to cover the four previously-missed rows as invalid arms — bindings `err` and `exception`, a comment-only occurrence, and a string-literal occurrence — plus the canonical `e` case, a nested shadow, and the genuine-use negative twin `log(err)` (valid, no report).
- Before/after repro: against the old rule the new fixture yields 1 finding (only `e`); after the fix it yields all 6.
- `unicorn.mdx` rule section reworded to drop the `e`-only phrasing.
- Validated locally: the targeted Go test plus the engine classification and behavioral-witness suites are green. The full `node scripts/test-go-lint.cjs` and the `tests/test-lint` corpus are exercised in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND