### PR TITLE
fix(lint): make no-unnecessary-qualifier type-aware

### DIFF
--- a/packages/lint/linthost/rules_ts_no_unnecessary_qualifier.go
+++ b/packages/lint/linthost/rules_ts_no_unnecessary_qualifier.go
@@ -1,8 +1,8 @@
 // typescript/no-unnecessary-qualifier: a qualified reference like
 // `Foo.Bar` written inside `namespace Foo { ... }` (or `enum Foo { ...,
-// X = Foo.Y, ... }`) names the same scope the reference is already in.
-// The qualifier adds no information; dropping `Foo.` leaves the
-// identical binding lookup. typescript-eslint:
+// X = Foo.Y, ... }`) is redundant only when the unqualified name `Bar`
+// resolves, from the same location, to the exact same binding the
+// qualifier reaches. typescript-eslint:
 // https://typescript-eslint.io/rules/no-unnecessary-qualifier/
 package linthost
 
@@ -13,17 +13,36 @@ import (
 // noUnnecessaryQualifier inspects every two-segment qualified reference
 // whose head is a plain identifier — `QualifiedName` shows up in type
 // position (`Foo.Bar` inside a type annotation) and
-// `PropertyAccessExpression` shows up in value position. The check is
-// AST-only: it walks the ancestor chain for an enclosing `namespace
-// <head> { ... }` or `enum <head> { ... }` declaration and reports when
-// one is found. The rule deliberately does not consult the Checker
-// because the upstream rule operates on lexical scope identity, which
-// the AST already encodes via declaration ancestry.
+// `PropertyAccessExpression` shows up in value position.
+//
+// The check is type-aware, mirroring the upstream rule's
+// `qualifierIsUnnecessary`: text identity alone is not enough because a
+// qualifier can be load-bearing. `Foo.` is redundant only when
+//
+//  1. the head identifier resolves to a namespace/enum symbol that is
+//     declared by one of the declarations enclosing the access
+//     (`symbolIsNamespaceInScope`), and
+//  2. the member name, looked up unqualified from the head's location,
+//     resolves to the same symbol the qualified access reaches
+//     (`getSymbolsInScope` + export-symbol equality).
+//
+// The second clause is what keeps a shadowed member (`const bar` hiding
+// `Foo.bar`) or a shadowed namespace name (`const Foo = { bar }`) from
+// being reported — dropping such a qualifier would silently change which
+// binding the code reads.
 type noUnnecessaryQualifier struct{}
 
 func (noUnnecessaryQualifier) Name() string {
   return "typescript/no-unnecessary-qualifier"
 }
+
+// NeedsTypeChecker marks the rule type-aware: it resolves the head and
+// member symbols and enumerates the in-scope bindings through
+// Context.Checker, so the engine must acquire a checker for it.
+func (noUnnecessaryQualifier) NeedsTypeChecker() bool {
+  return true
+}
+
 func (noUnnecessaryQualifier) Visits() []shimast.Kind {
   return []shimast.Kind{
     shimast.KindQualifiedName,
@@ -31,86 +50,144 @@ func (noUnnecessaryQualifier) Visits() []shimast.Kind {
   }
 }
 func (noUnnecessaryQualifier) Check(ctx *Context, node *shimast.Node) {
-  head := noUnnecessaryQualifierHead(node)
-  if head == "" {
+  head, name := noUnnecessaryQualifierParts(node)
+  if head == nil || name == nil {
     return
   }
-  if !noUnnecessaryQualifierHasEnclosingScope(node, head) {
+  if !noUnnecessaryQualifierIsUnnecessary(ctx, node, head, name) {
     return
   }
-  ctx.Report(node, "Qualifier `"+head+"` is the enclosing namespace or enum — drop the qualifier.")
+  ctx.Report(node, "Qualifier `"+identifierText(head)+"` is the enclosing namespace or enum — drop the qualifier.")
 }
 
-// noUnnecessaryQualifierHead returns the LHS identifier text when the
-// node is a two-segment qualified reference (`A.B`) whose head is a
-// plain identifier. Returns "" for nested chains (`A.B.C`), computed
-// accesses, or non-identifier heads — those shapes don't match the
-// "qualifier names the enclosing scope" pattern.
-func noUnnecessaryQualifierHead(node *shimast.Node) string {
+// noUnnecessaryQualifierParts returns the head (qualifier) and member
+// name nodes of a two-segment qualified reference (`A.B`) whose head is a
+// plain identifier. Returns (nil, nil) for nested chains (`A.B.C`),
+// computed accesses, or non-identifier heads — those shapes don't match
+// the "qualifier names the enclosing scope" pattern.
+func noUnnecessaryQualifierParts(node *shimast.Node) (head *shimast.Node, name *shimast.Node) {
   if node == nil {
-    return ""
+    return nil, nil
   }
   switch node.Kind {
   case shimast.KindQualifiedName:
     qn := node.AsQualifiedName()
-    if qn == nil || qn.Left == nil {
-      return ""
+    if qn == nil || qn.Left == nil || qn.Right == nil {
+      return nil, nil
     }
     if qn.Left.Kind != shimast.KindIdentifier {
-      return ""
+      return nil, nil
     }
-    return identifierText(qn.Left)
+    return qn.Left, qn.Right
   case shimast.KindPropertyAccessExpression:
     pa := node.AsPropertyAccessExpression()
     if pa == nil || pa.Expression == nil || pa.Name() == nil {
-      return ""
+      return nil, nil
     }
     // Optional chains (`Foo?.Bar`) aren't redundant in the same
     // sense — the `?.` changes runtime behavior, so leave them be.
     if pa.QuestionDotToken != nil {
-      return ""
+      return nil, nil
     }
     if pa.Expression.Kind != shimast.KindIdentifier {
-      return ""
+      return nil, nil
     }
-    return identifierText(pa.Expression)
+    return pa.Expression, pa.Name()
   }
-  return ""
+  return nil, nil
 }
 
-// noUnnecessaryQualifierHasEnclosingScope reports whether `node`
-// appears inside a `namespace <head> { ... }` or `enum <head> { ... }`
-// declaration body. The walk climbs `Parent` links until it finds a
-// matching block or hits the SourceFile root.
-func noUnnecessaryQualifierHasEnclosingScope(node *shimast.Node, head string) bool {
+// noUnnecessaryQualifierIsUnnecessary is the Go port of upstream
+// `qualifierIsUnnecessary`. It reports whether dropping the `head.`
+// qualifier leaves the identical binding lookup.
+func noUnnecessaryQualifierIsUnnecessary(ctx *Context, node *shimast.Node, head *shimast.Node, name *shimast.Node) bool {
+  if ctx == nil || ctx.Checker == nil {
+    return false
+  }
+  // The cheap AST walk short-circuits before any checker call: the vast
+  // majority of qualified references in a program sit outside every
+  // namespace/enum, so an empty enclosing set rules them out without
+  // resolving a symbol.
+  enclosing := noUnnecessaryQualifierEnclosingNamespaces(node)
+  if len(enclosing) == 0 {
+    return false
+  }
+  namespaceSymbol := ctx.Checker.GetSymbolAtLocation(head)
+  if namespaceSymbol == nil {
+    return false
+  }
+  if !noUnnecessaryQualifierSymbolIsNamespaceInScope(ctx, enclosing, namespaceSymbol, 0) {
+    return false
+  }
+  accessedSymbol := ctx.Checker.GetSymbolAtLocation(name)
+  if accessedSymbol == nil {
+    return false
+  }
+  fromScope := noUnnecessaryQualifierSymbolInScope(ctx, head, accessedSymbol.Flags, identifierText(name))
+  if fromScope == nil {
+    return false
+  }
+  // Upstream `symbolsAreEqual`: the unqualified lookup must reach the
+  // same symbol as the qualified access. Normalizing the in-scope
+  // symbol to its export symbol collapses the local/export duality that
+  // a namespace or enum member carries.
+  return accessedSymbol == ctx.Checker.GetExportSymbolOfSymbol(fromScope)
+}
+
+// noUnnecessaryQualifierEnclosingNamespaces collects the `namespace`
+// (`ModuleDeclaration`) and `enum` (`EnumDeclaration`) declaration nodes
+// that enclose `node`, mirroring the upstream `namespacesInScope` stack.
+// The walk climbs `Parent` links until it hits the SourceFile root.
+func noUnnecessaryQualifierEnclosingNamespaces(node *shimast.Node) []*shimast.Node {
+  var enclosing []*shimast.Node
   for cur := node.Parent; cur != nil; cur = cur.Parent {
     switch cur.Kind {
-    case shimast.KindModuleDeclaration:
-      decl := cur.AsModuleDeclaration()
-      if decl == nil || decl.Name() == nil {
-        continue
-      }
-      // `declare module "fs"` carries a string-literal name and
-      // does not bind an identifier in the surrounding scope —
-      // skip those entirely. The rule only fires when the head
-      // matches the enclosing namespace's identifier name.
-      if decl.Name().Kind != shimast.KindIdentifier {
-        continue
-      }
-      if identifierText(decl.Name()) == head {
+    case shimast.KindModuleDeclaration, shimast.KindEnumDeclaration:
+      enclosing = append(enclosing, cur)
+    }
+  }
+  return enclosing
+}
+
+// noUnnecessaryQualifierSymbolIsNamespaceInScope is the Go port of
+// upstream `symbolIsNamespaceInScope`: it reports whether `symbol` is one
+// of the namespaces/enums currently in scope by checking its declarations
+// against `enclosing`, following aliases when the direct declarations
+// don't match. The depth guard bounds pathological alias cycles.
+func noUnnecessaryQualifierSymbolIsNamespaceInScope(ctx *Context, enclosing []*shimast.Node, symbol *shimast.Symbol, depth int) bool {
+  if symbol == nil || depth > 16 {
+    return false
+  }
+  for _, decl := range symbol.Declarations {
+    for _, ns := range enclosing {
+      if decl == ns {
         return true
       }
-    case shimast.KindEnumDeclaration:
-      decl := cur.AsEnumDeclaration()
-      if decl == nil || decl.Name() == nil {
-        continue
-      }
-      if identifierText(decl.Name()) == head {
-        return true
-      }
+    }
+  }
+  if symbol.Flags&shimast.SymbolFlagsAlias != 0 {
+    alias := ctx.Checker.GetAliasedSymbol(symbol)
+    if alias != nil && alias != symbol {
+      return noUnnecessaryQualifierSymbolIsNamespaceInScope(ctx, enclosing, alias, depth+1)
     }
   }
   return false
+}
+
+// noUnnecessaryQualifierSymbolInScope is the Go port of upstream
+// `getSymbolInScope`: it returns the first symbol named `name` that the
+// checker reports as visible (with the given meaning `flags`) from the
+// `head` location, or nil when the name is not in scope.
+func noUnnecessaryQualifierSymbolInScope(ctx *Context, head *shimast.Node, flags shimast.SymbolFlags, name string) *shimast.Symbol {
+  if name == "" {
+    return nil
+  }
+  for _, symbol := range ctx.Checker.GetSymbolsInScope(head, flags) {
+    if symbol != nil && symbol.Name == name {
+      return symbol
+    }
+  }
+  return nil
 }
 
 func init() {

--- a/packages/lint/test/rules/typescript/no_unnecessary_qualifier_test.go
+++ b/packages/lint/test/rules/typescript/no_unnecessary_qualifier_test.go
@@ -2,50 +2,113 @@ package linthost
 
 import "testing"
 
-// TestRuleCorpusTypescriptNoUnnecessaryQualifier verifies the lint rule
-// corpus fixture typescript-no-unnecessary-qualifier.ts.
+// TestRuleTypescriptNoUnnecessaryQualifier verifies the type-aware
+// `typescript/no-unnecessary-qualifier` rule fires only when the qualifier
+// is genuinely redundant.
 //
-// The rule is AST-only: `Foo.Bar` written inside `namespace Foo { ... }`
-// or `enum Foo { ..., X = Foo.Y, ... }` references the same lexical
-// scope the access lives in, so dropping the `Foo.` qualifier leaves
-// the identical binding lookup. The check climbs `Parent` links to find
-// a matching enclosing declaration.
+// The rule was previously AST-only and fired on text identity alone, so it
+// flagged load-bearing qualifiers (issue #600): a member shadowed by a
+// local binding, or a namespace name shadowed by a local object. Following
+// that advice silently changed which binding the code read. The port now
+// mirrors upstream `qualifierIsUnnecessary` — the head must resolve to an
+// enclosing namespace/enum symbol AND the unqualified member name must
+// resolve, from the same location, to the same symbol the qualified access
+// reaches. These cases pin both the positive fire and each shadowing arm
+// that must stay silent, with expectations taken from the upstream rule.
 //
-// 1. Load the annotated TypeScript fixture source embedded below.
-// 2. Enable the rule severities declared by its `// expect:` comments.
-// 3. Assert the native Engine reports exactly the annotated diagnostics.
-func TestRuleCorpusTypescriptNoUnnecessaryQualifier(t *testing.T) {
-  assertRuleCorpusCase(t, "typescript-no-unnecessary-qualifier.ts",
-    "// Positive: `Foo.Bar` referenced from inside `namespace Foo` — the\n"+
-      "// `Foo.` qualifier names the enclosing scope and is redundant.\n"+
-      "namespace Foo {\n"+
-      "  export const Bar = 1;\n"+
-      "  // expect: typescript/no-unnecessary-qualifier error\n"+
-      "  export const alias = Foo.Bar;\n"+
-      "}\n"+
-      "\n"+
-      "// Positive: enum member referenced from inside the same `enum` body\n"+
-      "// via `enum E { X, Y = E.X }`.\n"+
-      "enum Color {\n"+
-      "  Red = 1,\n"+
-      "  // expect: typescript/no-unnecessary-qualifier error\n"+
-      "  Crimson = Color.Red,\n"+
-      "}\n"+
-      "\n"+
-      "// Negative: `Foo.Bar` referenced from outside `namespace Foo` — the\n"+
-      "// qualifier is the only way to reach the member.\n"+
-      "const outside = Foo.Bar;\n"+
-      "\n"+
-      "// Negative: an unrelated qualified access whose head does not name\n"+
-      "// any enclosing scope.\n"+
-      "namespace Outer {\n"+
-      "  export namespace Inner {\n"+
-      "    export const value = 1;\n"+
-      "  }\n"+
-      "  // The qualifier `Inner` is the path into the inner namespace — the\n"+
-      "  // enclosing scope is `Outer`, not `Inner`, so this is fine.\n"+
-      "  export const fine = Inner.value;\n"+
-      "}\n"+
-      "\n"+
-      "JSON.stringify({ outside, outer: Outer.Inner.value, alias: Foo.alias });\n")
+//  1. Report `Foo.Bar` inside `namespace Foo` and `Color.Red` inside
+//     `enum Color`, each at its exact byte range.
+//  2. Skip both shadowing arms (local `bar` hiding `Foo.bar`; local `Foo`
+//     object hiding the namespace) where dropping the qualifier would
+//     change behavior.
+//  3. Skip an access from outside the namespace and a path into an inner
+//     namespace, where the qualifier is not the enclosing scope.
+func TestRuleTypescriptNoUnnecessaryQualifier(t *testing.T) {
+  const ruleName = "typescript/no-unnecessary-qualifier"
+  cases := []struct {
+    name    string
+    source  string
+    markers []string
+  }{
+    {
+      name: "namespace member qualifier is redundant",
+      source: "namespace Foo {\n" +
+        "  export const Bar = 1;\n" +
+        "  export const alias = Foo.Bar;\n" +
+        "}\n",
+      markers: []string{"Foo.Bar"},
+    },
+    {
+      name: "enum member qualifier is redundant",
+      source: "enum Color {\n" +
+        "  Red = 1,\n" +
+        "  Crimson = Color.Red,\n" +
+        "}\n",
+      markers: []string{"Color.Red"},
+    },
+    {
+      // Type position: `NS.Item` is a QualifiedName, the other branch of
+      // the rule. The qualifier names the enclosing namespace, so the
+      // type reference resolves to the same interface unqualified.
+      name: "namespace type qualifier is redundant",
+      source: "namespace NS {\n" +
+        "  export interface Item {\n" +
+        "    id: number;\n" +
+        "  }\n" +
+        "  export type Alias = NS.Item;\n" +
+        "}\n",
+      markers: []string{"NS.Item"},
+    },
+    {
+      // Upstream: valid. `const bar` shadows `Foo.bar`, so the unqualified
+      // `bar` resolves to the local `2`, not the member `1`. Dropping
+      // `Foo.` would change the value read.
+      name: "shadowed member keeps its qualifier",
+      source: "namespace Foo {\n" +
+        "  export const bar = 1;\n" +
+        "  export function f() {\n" +
+        "    const bar = 2;\n" +
+        "    return Foo.bar + bar;\n" +
+        "  }\n" +
+        "}\n",
+    },
+    {
+      // Upstream: valid. `Foo` here is a local object, not the namespace,
+      // so its symbol is not a namespace in scope. Dropping `Foo.` would
+      // read the namespace member instead of the local object property.
+      name: "local object shadowing the namespace keeps its qualifier",
+      source: "namespace Foo {\n" +
+        "  export const bar = 1;\n" +
+        "  export function g() {\n" +
+        "    const Foo = { bar: 2 };\n" +
+        "    return Foo.bar;\n" +
+        "  }\n" +
+        "}\n",
+    },
+    {
+      // The access lives outside `namespace Foo`, so the qualifier is the
+      // only way to reach the member.
+      name: "reference from outside the namespace keeps its qualifier",
+      source: "namespace Foo {\n" +
+        "  export const Bar = 1;\n" +
+        "}\n" +
+        "export const outside = Foo.Bar;\n",
+    },
+    {
+      // The enclosing scope is `Outer`, not `Inner`; `Inner.value` is the
+      // path into the inner namespace, so the qualifier is necessary.
+      name: "path into an inner namespace keeps its qualifier",
+      source: "namespace Outer {\n" +
+        "  export namespace Inner {\n" +
+        "    export const value = 1;\n" +
+        "  }\n" +
+        "  export const fine = Inner.value;\n" +
+        "}\n",
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertRuleFindingRanges(t, ruleName, test.source, test.markers...)
+    })
+  }
 }

--- a/tests/test-lint/src/cases/typescript-no-unnecessary-qualifier.ts
+++ b/tests/test-lint/src/cases/typescript-no-unnecessary-qualifier.ts
@@ -14,6 +14,39 @@ enum Color {
   Crimson = Color.Red,
 }
 
+// Positive (type position): `NS.Item` is a `QualifiedName`, the other
+// branch of the rule. The qualifier names the enclosing namespace.
+namespace NS {
+  export interface Item {
+    id: number;
+  }
+  // expect: typescript/no-unnecessary-qualifier error
+  export type Alias = NS.Item;
+}
+
+// Negative: a local `const bar` shadows `MemberShadow.bar`, so the
+// unqualified name would resolve to the local `2`, not the member `1`.
+// The `MemberShadow.` qualifier is load-bearing — dropping it changes
+// the value read, so the type-aware rule must stay silent (issue #600).
+namespace MemberShadow {
+  export const bar = 1;
+  export function f() {
+    const bar = 2;
+    return MemberShadow.bar + bar;
+  }
+}
+
+// Negative: `LocalShadow` here is a local object, not the namespace, so
+// its symbol is not a namespace in scope. Dropping the qualifier would
+// read the namespace member instead of the local object property.
+namespace LocalShadow {
+  export const bar = 1;
+  export function g() {
+    const LocalShadow = { bar: 2 };
+    return LocalShadow.bar;
+  }
+}
+
 // Negative: `Foo.Bar` referenced from outside `namespace Foo` — the
 // qualifier is the only way to reach the member.
 const outside = Foo.Bar;

--- a/website/src/content/docs/lint/rules/typescript.mdx
+++ b/website/src/content/docs/lint/rules/typescript.mdx
@@ -1083,13 +1083,11 @@ class Repeated {
 
 ### `typescript/no-unnecessary-qualifier`
 
-Reject `Foo.Bar` references written inside `namespace Foo { ... }` or `enum Foo { ..., X = Foo.Y, ... }` where the `Foo.` qualifier names the same lexical scope the access lives in.
+Reject `Foo.Bar` references written inside `namespace Foo { ... }` or `enum Foo { ..., X = Foo.Y, ... }` where the `Foo.` qualifier is redundant — the unqualified name already resolves to the same binding.
 
-Dropping the qualifier leaves the identical binding lookup.
+Type-aware via the Checker. The qualifier is flagged only when the head resolves to a namespace or enum symbol declared by one of the enclosing declarations, and the member name — looked up unqualified from the same location — resolves to that same symbol.
 
-AST-only: walks `Parent` links for an enclosing namespace or enum declaration whose identifier matches the qualifier's head.
-
-The Checker is not required because the upstream rule operates on lexical scope identity, which the AST already encodes via declaration ancestry.
+A shadowed member (a local `bar` hiding `Foo.bar`) or a shadowed namespace name (a local `Foo` object) keeps its qualifier: dropping it would silently change which binding the code reads.
 
 Example:
 


### PR DESCRIPTION
## Intent

Fixes #600. `typescript/no-unnecessary-qualifier` had no symbol resolution — it fired on **text identity alone** (any `Foo.Bar` lexically inside `namespace`/`enum Foo`), so it flagged **load-bearing** qualifiers. Following the advice silently changed program behavior:

```ts
namespace Foo {
  export const bar = 1;
  export function f() {
    const bar = 2;          // shadows Foo.bar
    return Foo.bar + bar;   // qualifier is NECESSARY — before: 1 (wrong) finding
  }
}
```

```ts
namespace Foo {
  export const bar = 1;
  export function g() {
    const Foo = { bar: 2 };  // local object, not the namespace
    return Foo.bar;          // before: 1 (wrong) finding; dropping it reads 1 not 2
  }
}
```

## Scope

- **Rule** (`packages/lint/linthost/rules_ts_no_unnecessary_qualifier.go`): port the upstream type-aware `qualifierIsUnnecessary` via `ctx.Checker`. `Foo.` is redundant only when:
  1. the head resolves to a namespace/enum symbol whose declaration is one of the enclosing declarations (`symbolIsNamespaceInScope`, with alias following), and
  2. the member name, looked up unqualified from the head's location (`getSymbolsInScope` restricted to the accessed symbol's meaning), resolves to the same symbol the qualified access reaches (export-symbol equality, upstream `symbolsAreEqual`).

  The rule now declares `NeedsTypeChecker()`. A cheap AST enclosing-namespace walk short-circuits before any checker call, so the overwhelming majority of qualified references (outside every namespace/enum) never touch the checker.
- **Go tests**: the checker-less corpus case is replaced with a real-checker findings suite (`assertRuleFindingRanges`, which builds a Program + checker for type-aware rules). Positives: namespace value member, enum member, and a type-position `QualifiedName`. Negatives: both shadowing arms from the issue, plus the outside-namespace and inner-namespace-path cases.
- **E2E corpus fixture** (`tests/test-lint/src/cases/typescript-no-unnecessary-qualifier.ts`): the two shadowing arms and a type-position positive added.
- **Website** (`lint/rules/typescript.mdx`): the rule section rewritten from "AST-only" to describe the type-aware contract and the shadowing exclusions.

## Side effects considered

- The rule stays in the `.d.ts` allowlist (`declaration_rules.go`) — enum self-qualification still occurs in declaration files, now resolved with a checker.
- The AST-only-vs-checker classification (`load_program_*checker_pool*` tests, `engine_*_type_checker_*` tests) is unaffected — those tests are rule-agnostic and pass; no test hardcoded this rule as AST-only.
- The behavioral-witness audit now records a `checker`-kind positive witness for the rule instead of `engine`; the aggregate audit is unaffected (engine kind is still supplied by hundreds of AST-only rules).

## Test plan

- Before/after repro (targeted): with the master rule, the two shadowing cases wrongly produce 1 finding each; with the fix, all seven cases behave correctly (3 positives fire, 4 negatives silent).
- Blast-radius Go tests green locally: the qualifier suite, `TestLoadProgram*CheckerPool*`, `TestEngine*TypeChecker*`, the full `TestBehavioralWitness*` audit machinery, and `TestTypedKeysMatchRegisteredRules`.
- Full `node scripts/test-go-lint.cjs` is deferred to CI: locally it fails only on pre-existing environment issues (the `ttsx.js` launcher build artifact is absent — rollup needs Node 24, this host has Node 22 — so the TypeScript-config-loading tests can't run, plus the suite exceeds the 10-minute default timeout). None of those touch this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND
