### PR TITLE
fix(lint): honor endOfLine in declaration-header, parameter-properties, and sort-imports reflow (CRLF corruption)

### DIFF
--- a/packages/lint/linthost/config_format.go
+++ b/packages/lint/linthost/config_format.go
@@ -221,12 +221,20 @@ func expandFormatBlock(raw map[string]any) (map[string]any, error) {
   out["format/whitespace"] = ruleEntry(wsOpts)
 
   // formatSortImports, opt-in by `sortImports` (a boolean or options object).
+  // The top-level `endOfLine` is threaded in (like the other layout rules)
+  // so the rebuilt import block joins declarations with the file's line
+  // ending instead of a hard-coded LF. `endOfLine` is not a sortImports
+  // sub-key, so it is injected here rather than validated by
+  // expandSortImportsBlock.
   if v, ok := raw["sortImports"]; ok && v != nil {
     siOpts, enabled, err := expandSortImportsBlock(v)
     if err != nil {
       return nil, err
     }
     if enabled {
+      if eol, ok := layoutOpts["endOfLine"]; ok {
+        siOpts["endOfLine"] = eol
+      }
       out["format/sort-imports"] = ruleEntry(siOpts)
     }
   }

--- a/packages/lint/linthost/rules_format_declaration_header.go
+++ b/packages/lint/linthost/rules_format_declaration_header.go
@@ -172,7 +172,7 @@ func (formatDeclarationHeader) Check(ctx *Context, node *shimast.Node) {
     // with a non-empty body; an interface (any body) and an empty body
     // keep `{` glued to the last header line (so an empty body reads
     // `… {}`). isClass && !emptyBody captures that.
-    brace := headerBrace(isClass, emptyBody, base)
+    brace := headerBrace(isClass, emptyBody, base, layout.eol)
     target, ok = brokenDeclarationHeader(src, base, prefix, typeParams, paramTexts, clauses, layout, brace, emptyBody, isClass)
     if !ok {
       return // unverified combination: abstain
@@ -194,6 +194,11 @@ type declarationHeaderLayout struct {
   printWidth int
   tabWidth   int
   oneLevel   string
+  // eol is the newline the reflow builders synthesize. It mirrors
+  // loadFormatLayout: `"\n"` by default, `"\r\n"` under endOfLine:"crlf",
+  // so a reflowed CRLF header stays consistently CRLF instead of gaining
+  // lone LFs.
+  eol string
 }
 
 func (l declarationHeaderLayout) indent(base string, depth int) string {
@@ -203,7 +208,7 @@ func (l declarationHeaderLayout) indent(base string, depth int) string {
 func loadDeclarationHeaderLayout(ctx *Context) declarationHeaderLayout {
   var opts formatDeclarationHeaderOptions
   _ = ctx.DecodeOptions(&opts)
-  l := declarationHeaderLayout{printWidth: 80, tabWidth: 2, oneLevel: "  "}
+  l := declarationHeaderLayout{printWidth: 80, tabWidth: 2, oneLevel: "  ", eol: "\n"}
   if opts.PrintWidth != nil && *opts.PrintWidth > 0 {
     l.printWidth = *opts.PrintWidth
   }
@@ -214,6 +219,9 @@ func loadDeclarationHeaderLayout(ctx *Context) declarationHeaderLayout {
     l.oneLevel = "\t"
   } else if opts.TabWidth != nil && *opts.TabWidth > 0 {
     l.oneLevel = strings.Repeat(" ", *opts.TabWidth)
+  }
+  if opts.EndOfLine != nil && *opts.EndOfLine == "crlf" {
+    l.eol = "\r\n"
   }
   return l
 }
@@ -392,11 +400,11 @@ func multiClauseHeader(prefix string, clauses []heritageClauseText, layout decla
   indent1 := layout.indent(base, 1)
   indent2 := layout.indent(base, 2)
   for ci, c := range clauses {
-    b.WriteString("\n")
+    b.WriteString(layout.eol)
     b.WriteString(indent1)
     b.WriteString(c.keyword)
     inlineWidth := visualWidth(indent1+c.keyword+" "+strings.Join(c.types, ", "), layout.tabWidth)
-    if ci == len(clauses)-1 && !strings.HasPrefix(brace, "\n") {
+    if ci == len(clauses)-1 && !strings.HasPrefix(brace, layout.eol) {
       inlineWidth += visualWidth(brace, layout.tabWidth)
     }
     if inlineWidth <= layout.printWidth {
@@ -405,7 +413,7 @@ func multiClauseHeader(prefix string, clauses []heritageClauseText, layout decla
       continue
     }
     for i, t := range c.types {
-      b.WriteString("\n")
+      b.WriteString(layout.eol)
       b.WriteString(indent2)
       b.WriteString(t)
       if i < len(c.types)-1 {
@@ -427,7 +435,7 @@ func multiTypeHeader(prefix string, clause heritageClauseText, layout declaratio
   indent1 := layout.indent(base, 1)
   inline := indent1 + clause.keyword + " " + strings.Join(clause.types, ", ")
   inlineWidth := visualWidth(inline, layout.tabWidth)
-  if !strings.HasPrefix(brace, "\n") {
+  if !strings.HasPrefix(brace, layout.eol) {
     inlineWidth += visualWidth(brace, layout.tabWidth)
   }
   if emptyBody {
@@ -437,16 +445,16 @@ func multiTypeHeader(prefix string, clause heritageClauseText, layout declaratio
     inlineWidth++
   }
   if inlineWidth <= layout.printWidth {
-    return prefix + "\n" + inline + brace
+    return prefix + layout.eol + inline + brace
   }
 
   var b strings.Builder
   b.WriteString(prefix)
-  b.WriteString("\n")
+  b.WriteString(layout.eol)
   b.WriteString(indent1)
   b.WriteString(clause.keyword)
   for i, t := range clause.types {
-    b.WriteString("\n")
+    b.WriteString(layout.eol)
     b.WriteString(layout.indent(base, 2))
     b.WriteString(t)
     if i < len(clause.types)-1 {
@@ -524,14 +532,15 @@ func singleGenericHeritageHeader(src, base, prefix string, typeParams, heritage 
   b.WriteString(keyword)
   b.WriteString(" ")
   b.WriteString(typeName)
-  b.WriteString("<\n")
+  b.WriteString("<")
+  b.WriteString(layout.eol)
   for i, a := range args {
     b.WriteString(layout.indent(base, 1))
     b.WriteString(a)
     if i < len(args)-1 {
       b.WriteString(",")
     }
-    b.WriteString("\n")
+    b.WriteString(layout.eol)
   }
   b.WriteString(base)
   b.WriteString("> {")
@@ -541,10 +550,11 @@ func singleGenericHeritageHeader(src, base, prefix string, typeParams, heritage 
 // headerBrace returns the opening-brace fragment that closes a broken
 // header. Prettier puts `{` on its own line only for a class with a
 // non-empty body; an interface and any empty body keep it glued to the
-// last header line.
-func headerBrace(isClass, emptyBody bool, base string) string {
+// last header line. `eol` is the synthesized newline (LF or CRLF) so the
+// own-line brace matches the file's line endings.
+func headerBrace(isClass, emptyBody bool, base, eol string) string {
   if isClass && !emptyBody {
-    return "\n" + base + "{"
+    return eol + base + "{"
   }
   return " {"
 }
@@ -579,11 +589,13 @@ func typeParamExplodeHeader(
 ) string {
   var b strings.Builder
   b.WriteString(prefix)
-  b.WriteString("<\n")
+  b.WriteString("<")
+  b.WriteString(layout.eol)
   paramIndent := layout.indent(base, 1)
   for _, p := range typeParams.Nodes {
     b.WriteString(renderExplodedTypeParam(src, p, layout, paramIndent))
-    b.WriteString(",\n")
+    b.WriteString(",")
+    b.WriteString(layout.eol)
   }
   b.WriteString(base)
   b.WriteString(">")
@@ -594,7 +606,7 @@ func typeParamExplodeHeader(
     //   >
     //     extends IPage.IRequest {
     c := clauses[0]
-    b.WriteString("\n")
+    b.WriteString(layout.eol)
     b.WriteString(layout.indent(base, 1))
     b.WriteString(c.keyword)
     b.WriteString(" ")
@@ -628,7 +640,7 @@ func renderExplodedTypeParam(src string, p *shimast.Node, layout declarationHead
         head := strings.TrimRight(src[start:defStart], " \t") // ends in `=`
         def := strings.TrimSpace(src[defStart:end])
         if head != "" && def != "" {
-          return paramIndent + head + "\n" + paramIndent + layout.oneLevel + def
+          return paramIndent + head + layout.eol + paramIndent + layout.oneLevel + def
         }
       }
     }

--- a/packages/lint/linthost/rules_format_parameter_properties.go
+++ b/packages/lint/linthost/rules_format_parameter_properties.go
@@ -27,11 +27,13 @@ import (
 // an already-broken list contains a newline and is skipped.
 type formatParameterProperties struct{}
 
-// formatParameterPropertiesOptions carries the indentation settings the
-// rewrite needs. The config layer mirrors format.tabWidth/useTabs in.
+// formatParameterPropertiesOptions carries the indentation + EOL settings
+// the rewrite needs. The config layer mirrors
+// format.tabWidth/useTabs/endOfLine in.
 type formatParameterPropertiesOptions struct {
-  TabWidth *int  `json:"tabWidth"`
-  UseTabs  *bool `json:"useTabs"`
+  TabWidth  *int    `json:"tabWidth"`
+  UseTabs   *bool   `json:"useTabs"`
+  EndOfLine *string `json:"endOfLine"`
 }
 
 func (formatParameterProperties) Name() string   { return "format/parameter-properties" }
@@ -111,10 +113,18 @@ func (formatParameterProperties) Check(ctx *Context, node *shimast.Node) {
   } else if opts.TabWidth != nil && *opts.TabWidth > 0 {
     oneLevel = strings.Repeat(" ", *opts.TabWidth)
   }
+  // The synthesized break mirrors loadFormatLayout: `"\n"` by default,
+  // `"\r\n"` under endOfLine:"crlf", so a broken CRLF constructor keeps
+  // consistent line endings instead of gaining lone LFs.
+  eol := "\n"
+  if opts.EndOfLine != nil && *opts.EndOfLine == "crlf" {
+    eol = "\r\n"
+  }
   inner := indent + oneLevel
 
   var b strings.Builder
-  b.WriteString("(\n")
+  b.WriteString("(")
+  b.WriteString(eol)
   for i, p := range params {
     if p == nil {
       return
@@ -129,7 +139,7 @@ func (formatParameterProperties) Check(ctx *Context, node *shimast.Node) {
     if i < len(params)-1 {
       b.WriteByte(',')
     }
-    b.WriteByte('\n')
+    b.WriteString(eol)
   }
   b.WriteString(indent)
   b.WriteByte(')')

--- a/packages/lint/linthost/rules_format_sort_imports.go
+++ b/packages/lint/linthost/rules_format_sort_imports.go
@@ -27,12 +27,15 @@ const (
   separatorPlaceholder = ""
 )
 
-// formatSortImportsOptions mirrors `ITtscLintFormatSortImports`.
+// formatSortImportsOptions mirrors `ITtscLintFormatSortImports`, plus the
+// top-level `endOfLine` the config layer threads in so the rebuilt block
+// joins declarations with the file's line ending.
 type formatSortImportsOptions struct {
   Order                    []string `json:"order"`
   CaseSensitive            bool     `json:"caseSensitive"`
   CombineTypeAndValue      bool     `json:"combineTypeAndValue"`
   UnsafeSortRuntimeImports bool     `json:"unsafeSortRuntimeImports"`
+  EndOfLine                *string  `json:"endOfLine"`
 }
 
 // defaultImportOrder is used when the user supplies no `order`: Node built-ins,
@@ -120,6 +123,10 @@ type resolvedSortImportsOptions struct {
   caseSensitive            bool
   combineTypeAndValue      bool
   unsafeSortRuntimeImports bool
+  // eol is the newline joined between rebuilt declarations: `"\n"` by
+  // default, `"\r\n"` under endOfLine:"crlf". Verbatim declaration text is
+  // preserved as-is; only the synthesized inter-declaration joins use it.
+  eol string
 }
 
 // sortImportsGroup is one resolved entry of the `order` array. A separator
@@ -142,11 +149,16 @@ func loadSortImportsOptions(ctx *Context) resolvedSortImportsOptions {
     order = defaultImportOrder
   }
   groups := parseImportOrder(order)
+  eol := "\n"
+  if raw.EndOfLine != nil && *raw.EndOfLine == "crlf" {
+    eol = "\r\n"
+  }
   return resolvedSortImportsOptions{
     groups:                   groups,
     caseSensitive:            raw.CaseSensitive,
     combineTypeAndValue:      raw.CombineTypeAndValue,
     unsafeSortRuntimeImports: raw.UnsafeSortRuntimeImports,
+    eol:                      eol,
   }
 }
 
@@ -421,9 +433,11 @@ func buildSortedImportBlock(src string, imports []*shimast.Node, opts resolvedSo
   for i, e := range entries {
     if i > 0 {
       if e.group != prevGroup && separatorBetween(opts.groups, prevGroup, e.group) {
-        b.WriteString("\n\n")
+        // A blank line between groups is two line endings.
+        b.WriteString(opts.eol)
+        b.WriteString(opts.eol)
       } else {
-        b.WriteString("\n")
+        b.WriteString(opts.eol)
       }
     }
     b.WriteString(e.text)

--- a/packages/lint/test/config/format_block_threads_end_of_line_into_sort_imports_test.go
+++ b/packages/lint/test/config/format_block_threads_end_of_line_into_sort_imports_test.go
@@ -1,0 +1,50 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+)
+
+// TestFormatBlockThreadsEndOfLineIntoSortImports verifies the top-level
+// `format.endOfLine` is injected into the format/sort-imports rule entry.
+//
+// `endOfLine` is not a `sortImports` sub-key, so expandSortImportsBlock never
+// sees it; config_format.go threads it in from the shared layout options. This
+// pins that plumbing so the rebuilt import block joins declarations with the
+// file's line ending instead of a hard-coded LF (issue #616). The absence twin
+// (no endOfLine key -> rule defaults to LF) is covered by the LF sort-imports
+// snapshot tests, which set no endOfLine and produce LF output.
+//
+//  1. Build a format block with endOfLine:"crlf" and sortImports enabled.
+//  2. Call expandFormatBlock.
+//  3. Assert the sort-imports rule entry carries endOfLine:"crlf".
+func TestFormatBlockThreadsEndOfLineIntoSortImports(t *testing.T) {
+  out, err := expandFormatBlock(map[string]any{
+    "endOfLine":   "crlf",
+    "sortImports": true,
+  })
+  if err != nil {
+    t.Fatalf("expandFormatBlock: unexpected error: %v", err)
+  }
+  entry, ok := out["format/sort-imports"]
+  if !ok {
+    t.Fatal("format/sort-imports not present in output")
+  }
+  raw, err := json.Marshal(entry)
+  if err != nil {
+    t.Fatalf("marshal entry: %v", err)
+  }
+  var tuple []json.RawMessage
+  if err := json.Unmarshal(raw, &tuple); err != nil || len(tuple) < 2 {
+    t.Fatalf("entry not a [severity, opts] tuple: %v", err)
+  }
+  var o struct {
+    EndOfLine string `json:"endOfLine"`
+  }
+  if err := json.Unmarshal(tuple[1], &o); err != nil {
+    t.Fatalf("decode sort-imports opts: %v", err)
+  }
+  if o.EndOfLine != "crlf" {
+    t.Errorf("endOfLine mismatch: want %q, got %q", "crlf", o.EndOfLine)
+  }
+}

--- a/packages/lint/test/format/command_format_preserves_crlf_across_reflow_rules_test.go
+++ b/packages/lint/test/format/command_format_preserves_crlf_across_reflow_rules_test.go
@@ -1,0 +1,60 @@
+package linthost
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestCommandFormatPreservesCRLFAcrossReflowRules is the end-to-end regression
+// guard for issue #616: `ttsc format` on a CRLF file with
+// `format: { endOfLine: "crlf" }` must never persist a lone LF.
+//
+// Before the fix, format/declaration-header and format/parameter-properties
+// synthesized their breaks with a hard-coded "\n", and format/whitespace under
+// CRLF does not repair an injected lone LF, so the command wrote a mixed-EOL
+// file to disk at exit 0. This drives the whole config -> expansion -> engine
+// -> fixer -> disk path and asserts the written file stays uniformly CRLF.
+//
+//  1. Seed a CRLF class whose header overflows AND whose constructor declares
+//     parameter properties, plus a lint config with endOfLine:"crlf".
+//  2. Run the format subcommand.
+//  3. Assert clean exit, the file changed, both reflows fired with CRLF, and
+//     every "\n" belongs to a "\r\n" (zero lone LFs).
+func TestCommandFormatPreservesCRLFAcrossReflowRules(t *testing.T) {
+  input := "class Repository implements First, Second, Third, Fourth, Fifth, Sixth {\r\n" +
+    "  constructor(private readonly a: Foo, private readonly b: Bar) {}\r\n" +
+    "}\r\n"
+  root := seedLintProject(t, input)
+  seedLintConfig(t, root, map[string]any{
+    "format": map[string]any{"endOfLine": "crlf", "printWidth": 50},
+  })
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "format",
+      "--cwd", root,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  if code != 0 || stdout != "" || stderr != "" {
+    t.Fatalf("format command mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  raw, err := os.ReadFile(filepath.Join(root, "src", "main.ts"))
+  if err != nil {
+    t.Fatalf("ReadFile: %v", err)
+  }
+  got := string(raw)
+  if got == input {
+    t.Fatalf("expected the file to be reflowed, but it was unchanged:\n%q", got)
+  }
+  if lf, crlf := strings.Count(got, "\n"), strings.Count(got, "\r\n"); lf != crlf {
+    t.Fatalf("output has lone LFs (%d LF, %d CRLF): %q", lf, crlf, got)
+  }
+  if !strings.Contains(got, "class Repository\r\n") {
+    t.Fatalf("declaration-header did not break onto a CRLF line:\n%q", got)
+  }
+  if !strings.Contains(got, "constructor(\r\n") {
+    t.Fatalf("parameter-properties did not break onto a CRLF line:\n%q", got)
+  }
+}

--- a/packages/lint/test/format/format_declaration_header_generic_heritage_honors_crlf_end_of_line_test.go
+++ b/packages/lint/test/format/format_declaration_header_generic_heritage_honors_crlf_end_of_line_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestFormatDeclarationHeaderGenericHeritageHonorsCRLFEndOfLine verifies the
+// single-generic-heritage type-argument explode reflow synthesizes CRLF breaks
+// under endOfLine:"crlf".
+//
+// Regression shield for issue #616 on the singleGenericHeritageHeader builder:
+// it emitted a literal "\n" after `<` and per type argument, injecting lone LFs
+// into a CRLF file. Bound to the CRLF oracle (LF twin: format_declaration_
+// header_breaks_generic_heritage_type_args_test.go); the helper asserts zero
+// lone LFs.
+//
+//  1. Parse a CRLF class implementing one generic type with two type arguments
+//     that overflows width 80.
+//  2. Apply format/declaration-header with {"endOfLine":"crlf"}.
+//  3. Assert the type-argument list breaks with "\r\n" and no lone LF remains.
+func TestFormatDeclarationHeaderGenericHeritageHonorsCRLFEndOfLine(t *testing.T) {
+  assertFixCRLFConsistentWithOptions(
+    t,
+    "format/declaration-header",
+    "export class KafkaRequestSerializer implements Serializer<any, KafkaRequest | Promise<KafkaRequest>> {\r\n  serialize() {}\r\n}\r\n",
+    `{"printWidth":80,"tabWidth":2,"endOfLine":"crlf"}`,
+    "export class KafkaRequestSerializer implements Serializer<\r\n  any,\r\n  KafkaRequest | Promise<KafkaRequest>\r\n> {\r\n  serialize() {}\r\n}\r\n",
+  )
+}

--- a/packages/lint/test/format/format_declaration_header_multi_clause_honors_crlf_end_of_line_test.go
+++ b/packages/lint/test/format/format_declaration_header_multi_clause_honors_crlf_end_of_line_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFormatDeclarationHeaderMultiClauseHonorsCRLFEndOfLine verifies the
+// multi-clause header reflow synthesizes CRLF breaks under endOfLine:"crlf".
+//
+// Regression shield for issue #616: the reflow builder hard-coded "\n", so a
+// broken class header on an otherwise-CRLF file gained lone LFs and persisted
+// mixed line endings. Bound to the CRLF oracle (the LF twin lives in
+// format_declaration_header_breaks_multiple_clauses_test.go), and the helper
+// additionally asserts every "\n" belongs to a "\r\n".
+//
+//  1. Parse a CRLF class whose extends+implements header overflows width 50.
+//  2. Apply format/declaration-header with {"endOfLine":"crlf"}.
+//  3. Assert each synthesized break is "\r\n" and no lone LF remains.
+func TestFormatDeclarationHeaderMultiClauseHonorsCRLFEndOfLine(t *testing.T) {
+  assertFixCRLFConsistentWithOptions(
+    t,
+    "format/declaration-header",
+    "class C extends Base implements First, Second, Third, Fourth {\r\n  a = 1;\r\n}\r\n",
+    `{"printWidth":50,"tabWidth":2,"endOfLine":"crlf"}`,
+    "class C\r\n  extends Base\r\n  implements First, Second, Third, Fourth\r\n{\r\n  a = 1;\r\n}\r\n",
+  )
+}

--- a/packages/lint/test/format/format_declaration_header_multi_type_honors_crlf_end_of_line_test.go
+++ b/packages/lint/test/format/format_declaration_header_multi_type_honors_crlf_end_of_line_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFormatDeclarationHeaderMultiTypeHonorsCRLFEndOfLine verifies the
+// single-clause multi-type explode reflow synthesizes CRLF breaks under
+// endOfLine:"crlf".
+//
+// Regression shield for issue #616 on the multiTypeHeader builder: it emitted
+// a literal "\n" per exploded type, injecting lone LFs into a CRLF file. Bound
+// to the CRLF oracle (LF twin: format_declaration_header_breaks_multi_type_
+// interface_test.go); the helper asserts zero lone LFs.
+//
+//  1. Parse a CRLF interface whose extends list overflows width 50.
+//  2. Apply format/declaration-header with {"endOfLine":"crlf"}.
+//  3. Assert the keyword and each type break with "\r\n" and no lone LF remains.
+func TestFormatDeclarationHeaderMultiTypeHonorsCRLFEndOfLine(t *testing.T) {
+  assertFixCRLFConsistentWithOptions(
+    t,
+    "format/declaration-header",
+    "interface B extends First, Second, Third, Fourth, Fifth, Sixth {\r\n  a: number;\r\n}\r\n",
+    `{"printWidth":50,"tabWidth":2,"endOfLine":"crlf"}`,
+    "interface B\r\n  extends\r\n    First,\r\n    Second,\r\n    Third,\r\n    Fourth,\r\n    Fifth,\r\n    Sixth {\r\n  a: number;\r\n}\r\n",
+  )
+}

--- a/packages/lint/test/format/format_declaration_header_type_param_explode_honors_crlf_end_of_line_test.go
+++ b/packages/lint/test/format/format_declaration_header_type_param_explode_honors_crlf_end_of_line_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestFormatDeclarationHeaderTypeParamExplodeHonorsCRLFEndOfLine verifies the
+// type-parameter explode reflow (including the break-after-`=` default hang)
+// synthesizes CRLF breaks under endOfLine:"crlf".
+//
+// Regression shield for issue #616 on the typeParamExplodeHeader and
+// renderExplodedTypeParam builders: both emitted literal "\n" for the `<`, the
+// per-parameter comma, and the default-hang split, injecting lone LFs into a
+// CRLF file. Bound to the CRLF oracle (LF twin: format_declaration_header_
+// breaks_type_param_default_after_equals_test.go); the helper asserts zero
+// lone LFs.
+//
+//  1. Parse a CRLF class with one long defaulted type parameter (width 50).
+//  2. Apply format/declaration-header with {"endOfLine":"crlf"}.
+//  3. Assert the list explodes and the default hangs with "\r\n", no lone LF.
+func TestFormatDeclarationHeaderTypeParamExplodeHonorsCRLFEndOfLine(t *testing.T) {
+  assertFixCRLFConsistentWithOptions(
+    t,
+    "format/declaration-header",
+    "class E<TVeryLongTypeParam extends SomeConstraint = DefaultType> {\r\n  a = 1;\r\n}\r\n",
+    `{"printWidth":50,"tabWidth":2,"endOfLine":"crlf"}`,
+    "class E<\r\n  TVeryLongTypeParam extends SomeConstraint =\r\n    DefaultType,\r\n> {\r\n  a = 1;\r\n}\r\n",
+  )
+}

--- a/packages/lint/test/format/format_parameter_properties_honors_crlf_end_of_line_test.go
+++ b/packages/lint/test/format/format_parameter_properties_honors_crlf_end_of_line_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFormatParameterPropertiesHonorsCRLFEndOfLine verifies the constructor
+// parameter-property break synthesizes CRLF breaks under endOfLine:"crlf".
+//
+// Regression shield for issue #616: the builder emitted literal "(\n" and '\n'
+// and ignored endOfLine entirely (its options struct had no such field), so a
+// broken constructor on an otherwise-CRLF file gained lone LFs. Bound to the
+// CRLF oracle (LF twin: format_parameter_properties_breaks_multi_param_
+// constructor_test.go); the helper asserts zero lone LFs.
+//
+//  1. Parse a CRLF class with a two-parameter-property constructor.
+//  2. Apply format/parameter-properties with {"endOfLine":"crlf"}.
+//  3. Assert each parameter breaks with "\r\n" and no lone LF remains.
+func TestFormatParameterPropertiesHonorsCRLFEndOfLine(t *testing.T) {
+  assertFixCRLFConsistentWithOptions(
+    t,
+    "format/parameter-properties",
+    "class A {\r\n  constructor(private x: Foo, public y: Bar) {}\r\n}\r\n",
+    `{"tabWidth":2,"endOfLine":"crlf"}`,
+    "class A {\r\n  constructor(\r\n    private x: Foo,\r\n    public y: Bar\r\n  ) {}\r\n}\r\n",
+  )
+}

--- a/packages/lint/test/format/format_sort_imports_group_separator_honors_crlf_end_of_line_test.go
+++ b/packages/lint/test/format/format_sort_imports_group_separator_honors_crlf_end_of_line_test.go
@@ -1,0 +1,36 @@
+package linthost
+
+import "testing"
+
+// TestFormatSortImportsGroupSeparatorHonorsCRLFEndOfLine verifies the blank
+// line between import groups is two CRLF terminators under endOfLine:"crlf".
+//
+// Regression shield for issue #616 on the group-separator path: the block
+// builder emitted a hard-coded "\n\n" between groups, so the blank line dropped
+// two lone LFs into an otherwise-CRLF file. Bound to the CRLF oracle (LF twin:
+// format_sort_imports_separator_spans_empty_group_test.go); the helper asserts
+// zero lone LFs, which specifically pins that BOTH newlines of the blank line
+// are "\r\n".
+//
+//  1. Parse a CRLF file with one third-party and one relative import.
+//  2. Apply an order that separates the two populated groups with a blank line
+//     under {"endOfLine":"crlf"}.
+//  3. Assert the blank line is "\r\n\r\n" and no lone LF remains.
+func TestFormatSortImportsGroupSeparatorHonorsCRLFEndOfLine(t *testing.T) {
+  source := "import { a } from \"alpha\";\r\n" +
+    "import { b } from \"./local\";\r\n" +
+    "a;\r\n" +
+    "b;\r\n"
+  expected := "import { a } from \"alpha\";\r\n" +
+    "\r\n" +
+    "import { b } from \"./local\";\r\n" +
+    "a;\r\n" +
+    "b;\r\n"
+  assertFixCRLFConsistentWithOptions(
+    t,
+    "format/sort-imports",
+    source,
+    `{"order":["<THIRD_PARTY_MODULES>","","@api/(.*)","","^[.]"],"unsafeSortRuntimeImports":true,"endOfLine":"crlf"}`,
+    expected,
+  )
+}

--- a/packages/lint/test/format/format_sort_imports_honors_crlf_end_of_line_test.go
+++ b/packages/lint/test/format/format_sort_imports_honors_crlf_end_of_line_test.go
@@ -1,0 +1,36 @@
+package linthost
+
+import "testing"
+
+// TestFormatSortImportsHonorsCRLFEndOfLine verifies the rebuilt import block
+// joins declarations with CRLF under endOfLine:"crlf".
+//
+// Regression shield for issue #616: buildSortedImportBlock joined declarations
+// with a hard-coded "\n", so re-sorting an otherwise-CRLF import block injected
+// lone LFs. The rule now accepts endOfLine (threaded from the top-level format
+// key by config_format.go). Bound to the CRLF oracle (LF twin: format_sort_
+// imports_groups_external_before_relative_test.go); the helper asserts zero
+// lone LFs.
+//
+//  1. Parse a CRLF file with shuffled third-party and relative imports.
+//  2. Apply format/sort-imports with {"endOfLine":"crlf"}.
+//  3. Assert the declarations join with "\r\n" and no lone LF remains.
+func TestFormatSortImportsHonorsCRLFEndOfLine(t *testing.T) {
+  source := "import { reduce } from \"./local-b\";\r\n" +
+    "import zebra from \"zebra\";\r\n" +
+    "import { x } from \"./local-a\";\r\n" +
+    "import alpha from \"alpha\";\r\n" +
+    "JSON.stringify({ reduce, zebra, x, alpha });\r\n"
+  expected := "import alpha from \"alpha\";\r\n" +
+    "import zebra from \"zebra\";\r\n" +
+    "import { x } from \"./local-a\";\r\n" +
+    "import { reduce } from \"./local-b\";\r\n" +
+    "JSON.stringify({ reduce, zebra, x, alpha });\r\n"
+  assertFixCRLFConsistentWithOptions(
+    t,
+    "format/sort-imports",
+    source,
+    `{"unsafeSortRuntimeImports":true,"endOfLine":"crlf"}`,
+    expected,
+  )
+}

--- a/packages/lint/test/shared/helpers_test.go
+++ b/packages/lint/test/shared/helpers_test.go
@@ -635,6 +635,40 @@ func assertFixSnapshotWithOptions(t *testing.T, ruleName, source, optsJSON, expe
   }
 }
 
+// assertFixCRLFConsistentWithOptions runs one rule (configured with optsJSON,
+// which must set endOfLine:"crlf") through the fixer, asserts the rewritten
+// source equals `expected`, and additionally asserts the output carries zero
+// lone LFs — every "\n" belongs to a "\r\n". The lone-LF invariant is the
+// direct regression shield for issue #616: a reflow builder that hard-codes
+// "\n" injects a bare LF into an otherwise-CRLF file, so this check fails on a
+// reintroduced literal independently of the exact snapshot. It is checked on
+// the real applied output, not on the oracle literal.
+func assertFixCRLFConsistentWithOptions(t *testing.T, ruleName, source, optsJSON, expected string) {
+  t.Helper()
+  root, filePath, findings := runRuleFindingsSnapshot(t, ruleName, source, json.RawMessage(optsJSON))
+  if len(findings) == 0 {
+    t.Fatalf("%s: expected at least one finding", ruleName)
+  }
+  fixed, err := applyFindingFixes(root, findings)
+  if err != nil {
+    t.Fatalf("%s: applyFindingFixes: %v", ruleName, err)
+  }
+  if fixed == 0 {
+    t.Fatalf("%s: expected at least one applied fix", ruleName)
+  }
+  raw, err := os.ReadFile(filePath)
+  if err != nil {
+    t.Fatalf("%s: ReadFile: %v", ruleName, err)
+  }
+  got := string(raw)
+  if got != expected {
+    t.Fatalf("%s fixed source mismatch:\nwant %q\ngot  %q", ruleName, expected, got)
+  }
+  if lf, crlf := strings.Count(got, "\n"), strings.Count(got, "\r\n"); lf != crlf {
+    t.Fatalf("%s: output has lone LFs (%d LF, %d CRLF): %q", ruleName, lf, crlf, got)
+  }
+}
+
 // assertRuleSkipsSourceWithOptions asserts the rule emits zero findings for
 // the input when configured with the given options JSON. Mirrors
 // `assertRuleSkipsSource`; used for option-gated skip arms (e.g.

--- a/website/src/content/docs/lint/format.mdx
+++ b/website/src/content/docs/lint/format.mdx
@@ -44,6 +44,8 @@ Presence of the block (even empty `format: {}`) configures the format rules at P
 
 `sortImports` is **opt-in**: it only runs when you set it. Every other format behavior — including JSDoc normalization (set `jsDoc: false` to opt out) — runs as soon as a `format` block is present, along with the keyless layout passes (statement splitting, indentation, whitespace, clause joining, declaration headers, ternary and nullish parens, orphan semicolons, and parameter properties).
 
+`format.endOfLine` (`"lf"` by default, or `"crlf"`) sets the newline every pass synthesizes — `printWidth` reflow, statement splitting, indentation, whitespace, declaration headers, parameter properties, and import sorting all emit it — so reformatting a CRLF file never leaves mixed line endings.
+
 ### `format.severity`
 
 `format.severity` (default `"off"`) sets the diagnostic level for every format rule in `ttsc check`. It is a property of the `format` block, not an external escape hatch:


### PR DESCRIPTION
## Intent

Fixes #616. Three `format/*` rules synthesized line breaks with a hard-coded `"\n"`, ignoring the `endOfLine` option. Reformatting a CRLF file with `{"format":{"endOfLine":"crlf"}}` injected **lone LFs** into an otherwise-CRLF file, and `format/whitespace` under `crlf` never repairs an interior lone LF, so `ttsc format` silently persisted mixed line endings to disk (exit 0, no diagnostics).

## Root cause

- `rules_format_declaration_header.go` — `EndOfLine` was declared in the options struct but never read; every reflow builder emitted a literal `"\n"`.
- `rules_format_parameter_properties.go` — its options struct had no `endOfLine` field at all; the constructor break emitted `"(\n"` / `'\n'`.
- `rules_format_sort_imports.go` — `buildSortedImportBlock` joined declarations with `"\n"`/`"\n\n"`; the rule never received `endOfLine`.

The printer-based rules (`format/print-width`, `format/statement-split`) already thread `layout.eol` correctly; these three string-builder rules did not.

## Scope

- `declarationHeaderLayout` and `formatParameterProperties` gain an `eol` field (default `"\n"`, `"\r\n"` under `endOfLine:"crlf"`, exactly as `loadFormatLayout`/statement-split do). Every synthesized newline — and the own-line-brace `HasPrefix` fit checks — now use `eol`.
- `format/sort-imports` accepts `endOfLine` and threads it into `buildSortedImportBlock`. `config_format.go` injects the top-level `format.endOfLine` into the opt-in sort-imports rule entry (it is not a `sortImports` sub-key). `declaration-header` and `parameter-properties` already received `endOfLine` via the shared layout options.
- Verbatim source text is preserved as-is; only synthesized breaks use `eol`. The LF default is unchanged.
- Docs: `website/src/content/docs/lint/format.mdx` notes that `endOfLine` governs every synthesized break.

## Test plan

New regression coverage (all **fail on master, pass on the fix**):

- Per declaration-header builder: multi-clause (own-line brace), single-clause multi-type explode, type-parameter explode with break-after-`=`, single-generic heritage type args.
- `parameter-properties`; `sort-imports` block join; `sort-imports` blank-line group separator (pins both newlines of the separator as CRLF).
- Config: `format.endOfLine` threads into the opt-in sort-imports entry.
- End-to-end: `ttsc format` on a CRLF file with `endOfLine:"crlf"` keeps the file uniformly CRLF through the full config → engine → fixer → disk path.

A shared helper asserts the exact CRLF oracle **and** that every `\n` belongs to a `\r\n` (zero lone LFs), so a reintroduced literal `"\n"` fails on the invariant. Existing LF snapshots are the negative twins.

Locally: 1032 go-lint tests pass with 0 failures (every format-rule test plus all 9 new tests). The one test that did not run, `TestLSPFormatBufferRealBinaryE2E`, requires a built binary/`node_modules` not present in a git worktree — deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND