### PR TITLE
fix(lint): per-finding-atomic fix selection and correct LSP commands through symlinks/junctions

### DIFF
--- a/packages/lint/linthost/fix.go
+++ b/packages/lint/linthost/fix.go
@@ -160,13 +160,14 @@ func reloadFixProgram(current *program, opts *subcommandOpts, needsRuleChecker b
   return loadFixProgram(opts, needsRuleChecker)
 }
 
-// fileFixes groups all pending automatic TextEdit fixes for a single file.
-// `text` is the source content at the time the findings were collected;
-// byte offsets in `edits` are relative to this snapshot.
+// fileFixes groups all pending automatic TextEdit fixes for a single file,
+// one edit group per finding so a multi-edit atomic fix stays all-or-nothing
+// during selection. `text` is the source content at the time the findings were
+// collected; byte offsets in `groups` are relative to this snapshot.
 type fileFixes struct {
-  path  string
-  text  string
-  edits []TextEdit
+  path   string
+  text   string
+  groups [][]TextEdit
 }
 
 // applyFindingFixes groups all fixable findings by file, resolves each
@@ -194,7 +195,7 @@ func applyFindingFixes(cwd string, findings []*Finding) (int, error) {
       bucket = &fileFixes{path: path, text: finding.File.Text()}
       byFile[path] = bucket
     }
-    bucket.edits = append(bucket.edits, finding.Fix...)
+    bucket.groups = append(bucket.groups, finding.Fix)
   }
 
   paths := make([]string, 0, len(byFile))
@@ -205,7 +206,7 @@ func applyFindingFixes(cwd string, findings []*Finding) (int, error) {
   total := 0
   for _, p := range paths {
     bucket := byFile[p]
-    fixed, err := applyTextEditsToFile(bucket.path, bucket.text, bucket.edits)
+    fixed, err := applyTextEditsToFile(bucket.path, bucket.text, bucket.groups)
     if err != nil {
       return total, err
     }
@@ -214,12 +215,13 @@ func applyFindingFixes(cwd string, findings []*Finding) (int, error) {
   return total, nil
 }
 
-// applyTextEditsToFile selects the non-overlapping edits from `edits`, applies
-// them to `source` in reverse order (right-to-left) to preserve earlier
-// offsets, and writes the result to `path`. Returns the number of edits
-// applied, or 0 when no edits survive selection.
-func applyTextEditsToFile(path, source string, edits []TextEdit) (int, error) {
-  selected := selectTextEdits(len(source), edits)
+// applyTextEditsToFile selects a non-overlapping, per-finding-atomic set of
+// edits from `groups` (one group per finding), applies them to `source` in
+// reverse order (right-to-left) to preserve earlier offsets, and writes the
+// result to `path`. Returns the number of edits applied, or 0 when no edits
+// survive selection.
+func applyTextEditsToFile(path, source string, groups [][]TextEdit) (int, error) {
+  selected := selectTextEditGroups(len(source), groups)
   if len(selected) == 0 {
     return 0, nil
   }
@@ -296,4 +298,101 @@ func selectTextEdits(sourceLen int, edits []TextEdit) []TextEdit {
     }
   }
   return selected
+}
+
+// selectTextEditGroups selects a non-overlapping application sequence from
+// per-finding edit GROUPS, applying each group all-or-nothing. Unlike
+// selectTextEdits, which resolves conflicts edit-by-edit, this keeps a
+// finding's multi-edit fix atomic: a fix such as noImportTypeSideEffects emits
+// an `import type` insert paired with an inline `type` deletion, and applying
+// only one member emits invalid code (`import type { type A }`). Groups are
+// considered earliest-edit-first, and a group is accepted only when every one
+// of its edits coexists — under the same disjointness rules as selectTextEdits
+// — with the edits already accepted from earlier groups. If any member would be
+// dropped (it overlaps an already-selected group, duplicates an already-
+// selected edit, is a coincident zero-width insert, or is out of bounds), the
+// WHOLE group is skipped so the owning finding re-fires on the next cascade
+// pass rather than half-applying (samchon/ttsc#605).
+func selectTextEditGroups(sourceLen int, groups [][]TextEdit) []TextEdit {
+  order := make([]int, 0, len(groups))
+  for i := range groups {
+    if len(groups[i]) > 0 {
+      order = append(order, i)
+    }
+  }
+  sort.SliceStable(order, func(a, b int) bool {
+    return textEditGroupLess(groups[order[a]], groups[order[b]])
+  })
+  selected := make([]TextEdit, 0)
+  for _, index := range order {
+    group := dedupeTextEdits(groups[index])
+    candidate := make([]TextEdit, 0, len(selected)+len(group))
+    candidate = append(candidate, selected...)
+    candidate = append(candidate, group...)
+    kept := selectTextEdits(sourceLen, candidate)
+    // Accept the group only if nothing was dropped: a shorter result means one
+    // of its edits collided with an already-selected edit (or a sibling edit of
+    // its own group), so the group cannot apply atomically here.
+    if len(kept) == len(candidate) {
+      selected = kept
+    }
+  }
+  return selected
+}
+
+// dedupeTextEdits removes exact-duplicate edits while preserving order. A
+// finding that emits the same edit twice still applies its distinct edits;
+// deduping here keeps such a finding from being rejected as "internally
+// inconsistent" by selectTextEditGroups, since an exact duplicate is not a
+// conflict the way an overlap is.
+func dedupeTextEdits(edits []TextEdit) []TextEdit {
+  if len(edits) == 0 {
+    return nil
+  }
+  seen := make(map[TextEdit]struct{}, len(edits))
+  out := make([]TextEdit, 0, len(edits))
+  for _, edit := range edits {
+    if _, ok := seen[edit]; ok {
+      continue
+    }
+    seen[edit] = struct{}{}
+    out = append(out, edit)
+  }
+  return out
+}
+
+// textEditGroupLess orders edit groups by their earliest member under the same
+// (Pos, End, Text) key selectTextEdits sorts by, so selection is deterministic
+// and the earliest-starting finding wins a contested range.
+func textEditGroupLess(a, b []TextEdit) bool {
+  ea, eb := minTextEdit(a), minTextEdit(b)
+  if ea.Pos != eb.Pos {
+    return ea.Pos < eb.Pos
+  }
+  if ea.End != eb.End {
+    return ea.End < eb.End
+  }
+  return ea.Text < eb.Text
+}
+
+// minTextEdit returns the least edit of a non-empty group under the
+// (Pos, End, Text) order. Panics on an empty slice; callers filter empties out.
+func minTextEdit(edits []TextEdit) TextEdit {
+  least := edits[0]
+  for _, edit := range edits[1:] {
+    if textEditLess(edit, least) {
+      least = edit
+    }
+  }
+  return least
+}
+
+func textEditLess(a, b TextEdit) bool {
+  if a.Pos != b.Pos {
+    return a.Pos < b.Pos
+  }
+  if a.End != b.End {
+    return a.End < b.End
+  }
+  return a.Text < b.Text
 }

--- a/packages/lint/linthost/lsp.go
+++ b/packages/lint/linthost/lsp.go
@@ -704,10 +704,17 @@ func lspWorkspaceEditForCommand(opts *lspCommandOptions) (*lspWorkspaceEdit, int
   if lspProjectTargetHasSegment(opts, "node_modules") {
     return nil, 0
   }
+  // Containment is the only physical guard: resolve both sides so a symlinked
+  // or short-name spelling of either cannot smuggle the target outside cwd.
+  // `target` itself stays in its LOGICAL (URI) spelling for everything that
+  // indexes into the temp workspace below — the temp tree materializes a
+  // project-internal symlink/junction under its logical name, so resolving the
+  // target to its physical destination here would address a path the temp tree
+  // never created (samchon/ttsc#614).
   physicalCwd := realProjectPath(opts.cwd)
-  target = realProjectPath(target)
-  if _, ok := projectRelativePath(physicalCwd, target); !ok {
-    fmt.Fprintf(os.Stderr, "@ttsc/lint: LSP command target %s is outside cwd %s\n", target, physicalCwd)
+  physicalTarget := realProjectPath(target)
+  if _, ok := projectRelativePath(physicalCwd, physicalTarget); !ok {
+    fmt.Fprintf(os.Stderr, "@ttsc/lint: LSP command target %s is outside cwd %s\n", physicalTarget, physicalCwd)
     return nil, 2
   }
   original, err := os.ReadFile(target)
@@ -715,7 +722,6 @@ func lspWorkspaceEditForCommand(opts *lspCommandOptions) (*lspWorkspaceEdit, int
     fmt.Fprintf(os.Stderr, "@ttsc/lint: read %s: %v\n", target, err)
     return nil, 2
   }
-
   return lspWorkspaceEditForSeededCommand(opts, target, string(original), nil)
 }
 
@@ -733,8 +739,11 @@ func lspWorkspaceEditForSeededCommand(
   original string,
   sourceOverlay *string,
 ) (*lspWorkspaceEdit, int) {
-  physicalCwd := realProjectPath(opts.cwd)
-  tempRoot, tempTarget, tempTsconfig, cleanup, err := prepareLSPCommandWorkspace(physicalCwd, opts.tsconfig, target)
+  // Pass the LOGICAL cwd/target so the temp workspace is indexed by the
+  // project's logical layout (a project-internal symlink or junction keeps its
+  // logical name). Physical resolution stays inside prepareLSPCommandWorkspace
+  // for the copy source and inside tempPathFor's boundary-alias fallback.
+  tempRoot, tempTarget, tempTsconfig, cleanup, err := prepareLSPCommandWorkspace(opts.cwd, opts.tsconfig, target)
   if err != nil {
     fmt.Fprintln(os.Stderr, err)
     return nil, 2
@@ -752,7 +761,7 @@ func lspWorkspaceEditForSeededCommand(
     }
   }
 
-  pluginsJSON := remapLSPPluginsJSONForTempWorkspace(opts.pluginsJSON, physicalCwd, tempRoot)
+  pluginsJSON := remapLSPPluginsJSONForTempWorkspace(opts.pluginsJSON, opts.cwd, tempRoot)
   rules, err := loadLSPCommandRules(
     pluginsJSON,
     tempRoot,
@@ -789,13 +798,25 @@ func lspWorkspaceEditForSeededCommand(
       prog.close()
       return nil, 0
     }
-    if sourceOverlay != nil {
-      targetFile := prog.findSourceFile(tempTarget)
-      if targetFile == nil ||
-        len(prog.tsProgram.GetSyntacticDiagnostics(context.Background(), targetFile)) > 0 {
-        prog.close()
-        return nil, 0
-      }
+    // The command target must resolve to a source file the temp program loaded.
+    // A nil here means the temp workspace did not materialize the target under
+    // the spelling the tsconfig references — the signature of the symlink/
+    // junction copy regression. Fail loud (exit 2) instead of returning a silent
+    // nil edit the editor cannot distinguish from an already-clean document.
+    targetFile := prog.findSourceFile(tempTarget)
+    if targetFile == nil {
+      prog.close()
+      fmt.Fprintf(os.Stderr,
+        "@ttsc/lint: LSP %s: target source file %s is not in the program\n",
+        opts.command, tempTarget)
+      return nil, 2
+    }
+    if sourceOverlay != nil &&
+      len(prog.tsProgram.GetSyntacticDiagnostics(context.Background(), targetFile)) > 0 {
+      // A dirty overlay buffer with syntax errors is a benign no-op: don't fight
+      // the editor's own diagnostics on the dirty document with a partial fix.
+      prog.close()
+      return nil, 0
     }
     findings := filterFindingsForPath(prog.runLintCycle(engine), tempTarget)
     prog.close()
@@ -879,10 +900,13 @@ func lspFormatBuffer(content string, opts *lspCommandOptions) (*lspWorkspaceEdit
     // dirty text into the temporary project so the checker, findings, fix
     // ranges, and final WorkspaceEdit all describe the same editor document.
     // Built-in AST-only format rules keep the fast single-file path below.
+    // Pass the LOGICAL target: the seeded command indexes it into the temp
+    // workspace (which mirrors the project's logical layout), so a
+    // project-internal symlink/junction must keep its logical name here too.
     sourceOverlay := content
     return lspWorkspaceEditForSeededCommand(
       opts,
-      physicalTarget,
+      target,
       content,
       &sourceOverlay,
     )
@@ -935,21 +959,23 @@ func scriptKindForPath(path string) shimcore.ScriptKind {
 }
 
 // applyFindingFixesToText is the in-memory counterpart of
-// applyFindingFixes/applyTextEditsToFile (fix.go): it collects every fixable
-// finding's TextEdit, selects a non-overlapping set with the same
-// selectTextEdits logic, applies them right-to-left to `text`, and returns the
-// new string plus the number of edits applied. It never writes to disk and
-// never reloads a Program. Findings carry byte offsets into the same `text`
-// that was just parsed, so no per-file grouping is needed.
+// applyFindingFixes/applyTextEditsToFile (fix.go): it groups every fixable
+// finding's edits, selects a non-overlapping, per-finding-atomic set with the
+// same selectTextEditGroups logic, applies them right-to-left to `text`, and
+// returns the new string plus the number of edits applied. It never writes to
+// disk and never reloads a Program. Findings carry byte offsets into the same
+// `text` that was just parsed, so no per-file grouping is needed — but each
+// finding still forms its own atomic edit group so a partially-overlapped
+// multi-edit fix is dropped whole rather than half-applied (samchon/ttsc#605).
 func applyFindingFixesToText(text string, findings []*Finding) (string, int) {
-  edits := make([]TextEdit, 0, len(findings))
+  groups := make([][]TextEdit, 0, len(findings))
   for _, finding := range findings {
     if finding == nil || len(finding.Fix) == 0 {
       continue
     }
-    edits = append(edits, finding.Fix...)
+    groups = append(groups, finding.Fix)
   }
-  selected := selectTextEdits(len(text), edits)
+  selected := selectTextEditGroups(len(text), groups)
   if len(selected) == 0 {
     return text, 0
   }
@@ -987,11 +1013,15 @@ func prepareLSPCommandWorkspace(cwd string, tsconfig string, target string) (str
     cleanup()
     return "", "", "", nil, fmt.Errorf("@ttsc/lint: LSP command target %s is outside cwd %s", target, cwd)
   }
-  if err := copyLSPCommandWorkspace(cwd, tempRoot); err != nil {
+  // Copy from the resolved (physical) cwd so a symlinked or short-name project
+  // root still descends into the real tree; the copy reproduces the project's
+  // LOGICAL layout, which tempPathFor above indexes into by the logical cwd.
+  physicalCwd := realProjectPath(cwd)
+  if err := copyLSPCommandWorkspace(physicalCwd, tempRoot); err != nil {
     cleanup()
     return "", "", "", nil, err
   }
-  if err := linkNearestNodeModules(tempRoot, cwd); err != nil {
+  if err := linkNearestNodeModules(tempRoot, physicalCwd); err != nil {
     cleanup()
     return "", "", "", nil, err
   }
@@ -1022,7 +1052,11 @@ func copyLSPCommandWorkspace(src string, dst string) error {
       if entry.IsDir() {
         return filepath.SkipDir
       }
-      if entry.Type()&fs.ModeSymlink != 0 {
+      // A skipped directory that is a reparse point (a symlinked or junctioned
+      // node_modules/.git) is dropped without materializing its contents. A
+      // junction reports ModeSymlink on current toolchains and ModeIrregular on
+      // older ones, so check both bits.
+      if entry.Type()&(fs.ModeSymlink|fs.ModeIrregular) != 0 {
         return nil
       }
     }
@@ -1041,28 +1075,34 @@ func copyLSPCommandWorkspaceEntry(src string, dst string, seenDirs map[string]st
     if err != nil {
       return err
     }
-    isSymlink := linkInfo.Mode()&os.ModeSymlink != 0
-    if isSymlink {
-      realDir, err := filepath.EvalSymlinks(src)
-      if err == nil {
-        if _, ok := seenDirs[realDir]; ok {
-          return nil
-        }
-        // Track the real path only for the active recursion branch.
-        // Releasing it on return lets sibling aliases pointing at the
-        // same real directory (e.g. `src-a -> real-src` and
-        // `src-b -> real-src` in different tsconfig entries) each get
-        // materialized; the test
-        // `TestLSPExecuteCommandMaterializesDuplicateSymlinkedDirectories`
-        // pins this contract.
-        seenDirs[realDir] = struct{}{}
-        defer delete(seenDirs, realDir)
+    // A directory that is itself a reparse point — a symlink OR an NTFS
+    // junction — is not descended into by filepath.WalkDir, so its contents
+    // must be materialized here under the LOGICAL name. Go reports a junction as
+    // ModeSymlink on current toolchains but as ModeIrregular on older ones;
+    // treat either bit as a link so the copy is correct regardless of version.
+    // A plain directory (neither bit) is created empty and left for WalkDir to
+    // descend (samchon/ttsc#614).
+    isLink := linkInfo.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0
+    if isLink {
+      // resolveDirLink chases the symlink/junction via os.Readlink, which
+      // resolves junctions that neither ModeSymlink nor EvalSymlinks expose on
+      // older toolchains. The real path keys the cycle guard, scoped to the
+      // active recursion branch (defer delete) so sibling aliases pointing at
+      // one real directory (e.g. `src-a -> real-src` and `src-b -> real-src` in
+      // different tsconfig entries) each get materialized; the test
+      // `TestLSPExecuteCommandMaterializesDuplicateSymlinkedDirectories` pins
+      // this contract.
+      realDir := resolveDirLink(src)
+      if _, ok := seenDirs[realDir]; ok {
+        return nil
       }
+      seenDirs[realDir] = struct{}{}
+      defer delete(seenDirs, realDir)
     }
     if err := os.MkdirAll(dst, mode.Perm()); err != nil {
       return err
     }
-    if !isSymlink {
+    if !isLink {
       return nil
     }
     entries, err := os.ReadDir(src)
@@ -1184,7 +1224,21 @@ func remapLSPPluginsJSONForTempWorkspace(raw string, cwd string, tempRoot string
   return string(next)
 }
 
+// tempPathFor maps a project `file` to its location inside the temp workspace,
+// which mirrors the project's LOGICAL layout. It therefore prefers the logical
+// relative path: a project-internal symlink or junction (src -> real-src),
+// materialized by copyLSPCommandWorkspace under its logical name, must be
+// addressed the same way here — resolving `file` physically would point at a
+// spelling (real-src/main.ts) the temp tree never created (samchon/ttsc#614).
+// Only when cwd and file don't share a logical prefix — an incidental boundary
+// alias such as a Windows 8.3 short cwd or macOS /tmp -> /private/tmp, where the
+// two spellings can independently pick either alias — does it fall back to
+// realProjectPath to reconcile them. Containment guards resolve physically and
+// live at the call sites, not here.
 func tempPathFor(cwd string, tempRoot string, file string) (string, bool) {
+  if rel, ok := projectRelativePath(cwd, file); ok {
+    return filepath.Join(tempRoot, rel), true
+  }
   rel, ok := projectRelativePath(realProjectPath(cwd), realProjectPath(file))
   if !ok {
     return "", false

--- a/packages/lint/test/command/lsp_execute_command_materializes_junctioned_directory_without_mutating_original_test.go
+++ b/packages/lint/test/command/lsp_execute_command_materializes_junctioned_directory_without_mutating_original_test.go
@@ -1,0 +1,58 @@
+package linthost
+
+import (
+  "os/exec"
+  "path/filepath"
+  "runtime"
+  "testing"
+)
+
+// TestLSPExecuteCommandMaterializesJunctionedDirectoryWithoutMutatingOriginal
+// verifies an NTFS junction source directory still yields a fix-all edit.
+//
+// A Windows junction (`mklink /J`) is the privilege-free directory link used by
+// pnpm/nx/Docker mounts, so it runs on every Windows machine rather than only an
+// elevated symlink runner. The command target arrives under the junction's
+// LOGICAL name (`src`), which the temp workspace must materialize under that
+// same name and index by it — resolving the target to the junction's physical
+// destination (`real-src`) would match zero findings and silently return no
+// edit.
+//
+//  1. Seed a project whose `src` directory is a junction to `real-src`.
+//  2. Execute `ttsc.lint.fixAll` against the visible junction path.
+//  3. Assert the returned WorkspaceEdit fixes the document.
+//  4. Assert both the junction path and backing file still contain source text.
+func TestLSPExecuteCommandMaterializesJunctionedDirectoryWithoutMutatingOriginal(t *testing.T) {
+  if runtime.GOOS != "windows" {
+    t.Skip("junctions are a Windows-only reparse point")
+  }
+  root := t.TempDir()
+  source := "var legacy = 1;\nJSON.stringify(legacy);\n"
+  writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true
+  },
+  "files": ["src/main.ts"]
+}
+`)
+  seedLintRules(t, root, map[string]string{"no-var": "error"})
+  realDir := filepath.Join(root, "real-src")
+  realFile := filepath.Join(realDir, "main.ts")
+  writeFile(t, realFile, source)
+  linkDir := filepath.Join(root, "src")
+  if out, err := exec.Command("cmd", "/c", "mklink", "/J", linkDir, realDir).CombinedOutput(); err != nil {
+    t.Skipf("mklink /J unavailable: %v: %s", err, out)
+  }
+  linkFile := filepath.Join(linkDir, "main.ts")
+  uri := lintTestFileURI(t, linkFile)
+
+  got := executeLSPCommandAppliedTextForTest(t, root, uri, commandLintFixAll, source)
+  want := "let legacy = 1;\nJSON.stringify(legacy);\n"
+  if got != want {
+    t.Fatalf("junctioned directory LSP fix text mismatch:\nwant %q\ngot  %q", want, got)
+  }
+  assertFileText(t, realFile, source)
+  assertFileText(t, linkFile, source)
+}

--- a/packages/lint/test/fix/fix_interleaved_import_type_and_bracket_spacing_stays_valid_test.go
+++ b/packages/lint/test/fix/fix_interleaved_import_type_and_bracket_spacing_stays_valid_test.go
@@ -1,0 +1,104 @@
+package linthost
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestFixInterleavedImportTypeAndBracketSpacingStaysValid verifies two rules
+// whose fixes interleave never emit invalid code through the shared disk
+// applier.
+//
+// samchon/ttsc#605: `no-import-type-side-effects` emits an atomic pair (insert
+// `type ` at the clause + delete the inline `type ` before the specifier), and
+// `format/bracket-spacing` replaces the WHOLE brace interior — which contains
+// that inline `type`. The old flat applier kept the insert but dropped the
+// paired delete when it collided with the interior replace, producing the
+// TS2206-invalid `import type { type A }`. With per-finding-atomic selection one
+// finding wins the contested range wholly, so every intermediate and final
+// state is valid TypeScript.
+//
+//  1. Seed a project importing `{  type A }` from a resolvable module.
+//  2. Cascade both rules on disk exactly like `ttsc fix`.
+//  3. Assert no pass ever writes the half-applied `import type { type A }`.
+//  4. Assert the cascade converges to `import type { A } from "./m";`.
+func TestFixInterleavedImportTypeAndBracketSpacingStaysValid(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true
+  },
+  "files": ["src/main.ts", "src/m.ts"]
+}
+`)
+  writeFile(t, filepath.Join(root, "src", "m.ts"), "export interface A {}\n")
+  mainPath := filepath.Join(root, "src", "main.ts")
+  source := "import {  type A } from \"./m\";\nconst x: A | null = null;\nJSON.stringify(x);\n"
+  writeFile(t, mainPath, source)
+
+  resolver := InlineRuleResolver{
+    Rules: RuleConfig{
+      "typescript/no-import-type-side-effects": SeverityError,
+      "format/bracket-spacing":                 SeverityError,
+    },
+    Options: RuleOptionsMap{
+      "format/bracket-spacing": json.RawMessage(`{"spacing":true}`),
+    },
+  }
+  engine := NewEngineWithResolver(resolver)
+  if err := engine.ConfigError(); err != nil {
+    t.Fatalf("config error: %v", err)
+  }
+  needsChecker := engine.NeedsTypeChecker()
+
+  converged := false
+  for pass := 0; pass < maxFixPasses; pass++ {
+    prog, diags, err := loadProgram(root, "tsconfig.json", loadProgramOptions{
+      forceNoEmit:      true,
+      needsRuleChecker: needsChecker,
+    })
+    if err != nil {
+      t.Fatalf("pass %d loadProgram: %v", pass, err)
+    }
+    if len(diags) != 0 {
+      prog.close()
+      t.Fatalf("pass %d loadProgram diagnostics: %+v", pass, diags)
+    }
+    findings := prog.runLintCycle(engine)
+    fixed, err := applyFindingFixes(root, findings)
+    prog.close()
+    if err != nil {
+      t.Fatalf("pass %d applyFindingFixes: %v", pass, err)
+    }
+    got, err := os.ReadFile(mainPath)
+    if err != nil {
+      t.Fatalf("pass %d read main.ts: %v", pass, err)
+    }
+    for _, invalid := range []string{"import type { type", "import type {  type"} {
+      if strings.Contains(string(got), invalid) {
+        t.Fatalf("pass %d produced half-applied invalid import %q:\n%s", pass, invalid, got)
+      }
+    }
+    if fixed == 0 {
+      converged = true
+      break
+    }
+  }
+  if !converged {
+    t.Fatalf("cascade did not converge within %d passes", maxFixPasses)
+  }
+
+  got, err := os.ReadFile(mainPath)
+  if err != nil {
+    t.Fatalf("read main.ts: %v", err)
+  }
+  want := "import type { A } from \"./m\";\nconst x: A | null = null;\nJSON.stringify(x);\n"
+  if string(got) != want {
+    t.Fatalf("cascade result mismatch:\nwant %q\ngot  %q", want, string(got))
+  }
+}

--- a/packages/lint/test/fix/fix_select_text_edit_groups_drops_partially_overlapped_finding_whole_test.go
+++ b/packages/lint/test/fix/fix_select_text_edit_groups_drops_partially_overlapped_finding_whole_test.go
@@ -1,0 +1,38 @@
+package linthost
+
+import "testing"
+
+// TestSelectTextEditGroupsDropsPartiallyOverlappedFindingWhole verifies the
+// per-finding-atomic applier drops an entire multi-edit finding when only one
+// of its edits overlaps an already-selected finding.
+//
+// This is the core of samchon/ttsc#605: the old flat selector kept a finding's
+// non-overlapping edits while silently dropping the one that collided, emitting
+// a half-applied fix (e.g. `import type { type A }`). selectTextEditGroups must
+// instead reject the whole group so the finding re-fires on the next cascade
+// pass.
+//
+//  1. Group A is a single interior replace that is selected first (earlier start).
+//  2. Group B is a two-edit finding: one edit overlaps A, one is far away and
+//     disjoint from everything.
+//  3. Assert only A survives and NEITHER member of B is applied — proving the
+//     drop is whole-group, not per-edit.
+func TestSelectTextEditGroupsDropsPartiallyOverlappedFindingWhole(t *testing.T) {
+  groupA := []TextEdit{{Pos: 2, End: 4, Text: "AA"}}
+  groupB := []TextEdit{
+    {Pos: 3, End: 6, Text: "OVERLAP"},    // overlaps groupA's [2,4)
+    {Pos: 12, End: 12, Text: "DISJOINT"}, // disjoint zero-width insert
+  }
+  selected := selectTextEditGroups(20, [][]TextEdit{groupA, groupB})
+  if len(selected) != 1 {
+    t.Fatalf("expected only group A to survive, got %d edits: %+v", len(selected), selected)
+  }
+  if selected[0] != (TextEdit{Pos: 2, End: 4, Text: "AA"}) {
+    t.Fatalf("unexpected surviving edit: %+v", selected[0])
+  }
+  for _, edit := range selected {
+    if edit == groupB[1] {
+      t.Fatalf("group B's disjoint edit leaked despite its sibling overlapping: %+v", edit)
+    }
+  }
+}

--- a/packages/lint/test/fix/fix_select_text_edit_groups_keeps_disjoint_multi_edit_finding_whole_test.go
+++ b/packages/lint/test/fix/fix_select_text_edit_groups_keeps_disjoint_multi_edit_finding_whole_test.go
@@ -1,0 +1,37 @@
+package linthost
+
+import "testing"
+
+// TestSelectTextEditGroupsKeepsDisjointMultiEditFindingWhole is the positive
+// twin of the drop-whole test: a multi-edit finding whose every edit is disjoint
+// from the already-selected findings must apply in full, in one pass.
+//
+// Without this arm, selectTextEditGroups could regress into rejecting every
+// multi-edit group (making noImportTypeSideEffects, trailing-comma batches, and
+// the like never converge). Pinning the accept path proves the group gate only
+// fires on a genuine collision.
+//
+//  1. Group A is a single interior replace selected first.
+//  2. Group B is a two-edit finding, both edits disjoint from A and each other.
+//  3. Assert all three edits survive, sorted by position.
+func TestSelectTextEditGroupsKeepsDisjointMultiEditFindingWhole(t *testing.T) {
+  groupA := []TextEdit{{Pos: 2, End: 4, Text: "AA"}}
+  groupB := []TextEdit{
+    {Pos: 6, End: 8, Text: "BB"},
+    {Pos: 12, End: 12, Text: "INS"},
+  }
+  selected := selectTextEditGroups(20, [][]TextEdit{groupA, groupB})
+  want := []TextEdit{
+    {Pos: 2, End: 4, Text: "AA"},
+    {Pos: 6, End: 8, Text: "BB"},
+    {Pos: 12, End: 12, Text: "INS"},
+  }
+  if len(selected) != len(want) {
+    t.Fatalf("expected all %d edits to survive, got %d: %+v", len(want), len(selected), selected)
+  }
+  for i, edit := range selected {
+    if edit != want[i] {
+      t.Fatalf("edit %d = %+v, want %+v (selected=%+v)", i, edit, want[i], selected)
+    }
+  }
+}


### PR DESCRIPTION
## Intent

Fix two bugs in `@ttsc/lint`'s shared fix applier and LSP command paths. They were grouped because both live in `packages/lint/linthost/lsp.go`.

### #605 — half-applied multi-edit atomic fixes

`selectTextEdits` flattened every finding's edits into one list and greedily dropped any edit overlapping an already-selected one, with **no notion of which finding owned an edit**. When one rule's edit overlapped a single member of another rule's multi-edit atomic fix, the remaining members still applied — a half-applied fix that emits invalid code.

Concrete repro (`import {  type A } from "./m";` with `no-import-type-side-effects` + `format/bracket-spacing`): the old applier kept the `import type` insert but dropped the paired inline-`type` deletion when it collided with bracket-spacing's whole-interior replace, producing the TS2206-invalid `import type { type A }`.

Fix: new `selectTextEditGroups` selects **per-finding edit groups all-or-nothing** — a group is accepted only when every one of its edits coexists with the edits already accepted from earlier groups, else the whole group is skipped and the finding re-fires on the next cascade pass. Both the disk applier (`ttsc fix` + LSP fix-all cascade) and the in-memory applier route through it.

### #614 — no edit for symlinked/junctioned project paths

`ttsc.lint.fixAll` / `ttsc.format.document` silently produced **no edit** for any file whose project path went through a symlink or a Windows junction — the root cause of the red `windows-go`/`ubuntu` symlink tests.

Two independent bugs:

1. **Target/copy divergence (all platforms).** The command target was resolved to its physical path while the temp workspace materialized the linked directory under its **logical** (tsconfig) name, so `filterFindingsForPath` matched zero findings → no fix. The LSP target now keeps its **logical (URI) spelling** for everything indexing into the temp workspace (`prepareLSPCommandWorkspace` / `tempPathFor` / the seeded command); `realProjectPath` is used only for the containment guards. `tempPathFor` prefers the logical relative path and falls back to physical resolution only for an incidental boundary alias (Windows 8.3 short cwd, macOS `/tmp`).
2. **Junctions lost their contents (Windows).** `copyLSPCommandWorkspaceEntry` detected a linked directory only via `ModeSymlink`; Go reports an NTFS junction as `ModeIrregular` on older toolchains, so it created an empty directory. It now treats either bit as a link and chases it with `resolveDirLink` (which resolves junctions via `os.Readlink`).

Also **fail loud (exit 2)** when the target source file is not in the program, instead of returning a silent nil edit the editor cannot distinguish from an already-clean document.

## Scope

- `packages/lint/linthost/fix.go` — `selectTextEditGroups` + per-finding grouping.
- `packages/lint/linthost/lsp.go` — logical-target indexing, junction handling, fail-loud, in-memory grouping.
- No `config.go` change was needed: the existing `resolveDirLink` there is reused.
- No website docs affected (internal applier/LSP behavior).

## Test plan

- **#605**: a two-rule interleave test that cascades both rules on disk and asserts no pass ever writes `import type { type A }` and the cascade converges to `import type { A }`; plus two `selectTextEditGroups` unit tests (a partially-overlapped multi-edit finding is dropped whole; a disjoint multi-edit finding is kept whole). Before/after verified: on master the interleave test fails at pass 0 with `import type { type A }`.
- **#614**: the three existing `TestLSPExecuteCommandMaterializes…Symlink…` tests now pass (they were red), plus a new Windows-junction test (`mklink /J`, gated on `runtime.GOOS=="windows"`). Before/after verified locally with the junction test ("returned no edit" → fixed).
- Full `node scripts/test-go-lint.cjs` scope green locally: 1256 pass, 0 fail, 5 skips (privilege/OS-gated: the 3 symlink tests skip only on non-elevated local Windows and run+pass on CI; two chmod tests always skip on Windows).

**The CI `windows-go`/`ubuntu` symlink tests now pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX9EHGJepvvBeNbUEDXXND