### PR TITLE
fix(lint): safe autofixes for dot-notation, comment-eating fixers, no-return-assign parens

### DIFF
--- a/packages/lint/linthost/rules_gap.go
+++ b/packages/lint/linthost/rules_gap.go
@@ -560,8 +560,25 @@ func (dotNotation) Check(ctx *Context, node *shimast.Node) {
   } else {
     replaceFrom = access.Expression.End()
     replacement = "." + key
+    // A bare decimal-integer receiver lexes an immediately following `.` as
+    // the number's own decimal point, so `5["toString"]` → `5.toString` is a
+    // syntax error (TS1351). Emit a separating space (`5 .toString`) exactly
+    // where ESLint's dot-notation does. Parenthesized `(5)`, hex/octal/binary,
+    // float, exponent, and bigint receivers all take `.` as member access
+    // cleanly, so they keep the dot tight.
+    if access.Expression.Kind == shimast.KindNumericLiteral &&
+      isDecimalIntegerLiteralText(nodeText(ctx.File, access.Expression)) {
+      replacement = " " + replacement
+    }
   }
   if replaceFrom < 0 || replaceFrom >= node.End() {
+    ctx.Report(node, message)
+    return
+  }
+  // A comment inside the replaced `[…]` tail (`p1 /* keep */ ["foo"]`) would be
+  // silently deleted by the splice. Decline to a report-only diagnostic,
+  // matching ESLint dot-notation's `commentsExistBetween` guard.
+  if hasCommentBetween(src, replaceFrom, node.End()) {
     ctx.Report(node, message)
     return
   }
@@ -570,6 +587,24 @@ func (dotNotation) Check(ctx *Context, node *shimast.Node) {
     message,
     TextEdit{Pos: replaceFrom, End: node.End(), Text: replacement},
   )
+}
+
+// isDecimalIntegerLiteralText reports whether raw is a numeric literal written
+// as a plain decimal integer — ASCII digits with optional `_` separators and
+// no radix prefix, decimal point, exponent, or bigint `n` suffix. A `.`
+// spliced directly after such a receiver is lexed as the number's own decimal
+// point (`5["x"]` → `5.x` is a SyntaxError), so dot-notation inserts a
+// separating space. Mirrors ESLint astUtils.isDecimalInteger.
+func isDecimalIntegerLiteralText(raw string) bool {
+  if raw == "" {
+    return false
+  }
+  for i := 0; i < len(raw); i++ {
+    if c := raw[i]; (c < '0' || c > '9') && c != '_' {
+      return false
+    }
+  }
+  return true
 }
 
 // isReservedWord reports whether `value` is an ECMAScript reserved word. The

--- a/packages/lint/linthost/rules_suggestions.go
+++ b/packages/lint/linthost/rules_suggestions.go
@@ -4,6 +4,7 @@
 package linthost
 
 import (
+  "encoding/json"
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
@@ -716,13 +717,14 @@ func (noReturnAssign) Visits() []shimast.Kind {
   return []shimast.Kind{shimast.KindReturnStatement, shimast.KindArrowFunction}
 }
 func (noReturnAssign) Check(ctx *Context, node *shimast.Node) {
+  always := noReturnAssignAlways(ctx)
   switch node.Kind {
   case shimast.KindReturnStatement:
     ret := node.AsReturnStatement()
     if ret == nil || ret.Expression == nil {
       return
     }
-    if isAssignmentExpression(stripParens(ret.Expression)) {
+    if noReturnAssignFlags(ret.Expression, always) {
       ctx.Report(node, "Return statement should not contain assignment.")
     }
   case shimast.KindArrowFunction:
@@ -730,10 +732,51 @@ func (noReturnAssign) Check(ctx *Context, node *shimast.Node) {
     if arrow == nil || arrow.Body == nil || arrow.Body.Kind == shimast.KindBlock {
       return
     }
-    if isAssignmentExpression(stripParens(arrow.Body)) {
+    if noReturnAssignFlags(arrow.Body, always) {
       ctx.Report(node, "Arrow function should not return an assignment.")
     }
   }
+}
+
+// noReturnAssignFlags reports whether a return/arrow operand should be flagged.
+// Under the default `except-parens` an explicitly parenthesized assignment
+// (`return (a = 1)`) is allowed, so the operand is tested as written: a
+// wrapping ParenthesizedExpression is not a BinaryExpression and fails the
+// assignment test. Under `always` the parentheses are stripped first so the
+// wrapped assignment is flagged too. This matches ESLint no-return-assign's
+// default and the parenthesis exemption `no-cond-assign` already applies.
+func noReturnAssignFlags(expr *shimast.Node, always bool) bool {
+  if always {
+    return isAssignmentExpression(stripParens(expr))
+  }
+  return isAssignmentExpression(expr)
+}
+
+// noReturnAssignAlways reports whether the rule runs in `always` mode, where a
+// parenthesized assignment is flagged as well. The single positional string
+// option arrives either bare (`"always"`) or as the first slot of an array,
+// mirroring the transport `resolveNoInnerDeclarationsOptions` documents.
+func noReturnAssignAlways(ctx *Context) bool {
+  if ctx == nil || len(ctx.Options) == 0 {
+    return false
+  }
+  raw := strings.TrimSpace(string(ctx.Options))
+  if raw == "" {
+    return false
+  }
+  var slots []json.RawMessage
+  if raw[0] == '[' {
+    if err := json.Unmarshal([]byte(raw), &slots); err != nil {
+      return false
+    }
+  } else {
+    slots = []json.RawMessage{json.RawMessage(raw)}
+  }
+  if len(slots) == 0 {
+    return false
+  }
+  var mode string
+  return json.Unmarshal(slots[0], &mode) == nil && mode == "always"
 }
 
 // noSequences: `(a, b)` — comma operator. Almost always a confusing
@@ -1269,6 +1312,14 @@ func reportUselessRenameFix(ctx *Context, node, propertyName, name *shimast.Node
     ctx.Report(node, message)
     return
   }
+  // A comment between the two names (`{ a as /* c */ a }`) sits inside the
+  // deleted rename tail; dropping it would be silent data loss, so decline to
+  // a report-only diagnostic. Mirrors ESLint no-useless-rename's
+  // `commentsExistBetween` guard.
+  if hasCommentBetween(ctx.File.Text(), propertyName.End(), name.End()) {
+    ctx.Report(node, message)
+    return
+  }
   ctx.ReportFix(
     node,
     message,
@@ -1298,6 +1349,14 @@ func (objectShorthand) Check(ctx *Context, node *shimast.Node) {
   // at the end of the property name and ends at the end of the
   // initializer; any whitespace between `:` and the value is part of
   // that range.
+  //
+  // A comment inside that range (`{ x: /* c */ x }`) would be dropped by the
+  // deletion, so decline to a report-only diagnostic. Mirrors ESLint
+  // object-shorthand's `commentsExistBetween` guard.
+  if hasCommentBetween(ctx.File.Text(), prop.Name().End(), prop.Initializer.End()) {
+    ctx.Report(node, "Expected property shorthand.")
+    return
+  }
   ctx.ReportFix(
     node,
     "Expected property shorthand.",
@@ -1435,11 +1494,42 @@ func (preferTemplate) Check(ctx *Context, node *shimast.Node) {
     ctx.Report(node, message)
     return
   }
+  // A comment in an operator seam (`"a" + /* c */ b`) is dropped by the
+  // template rebuild, so decline to a report-only diagnostic. Mirrors ESLint
+  // prefer-template's `commentsExistBetween` guard. Only the seams are scanned:
+  // operand interiors are copied verbatim (their comments survive) and string
+  // contents are cooked, so scanning the whole span would misread a `//` or
+  // `/*` inside a string literal (`"https://" + host`) as a comment.
+  if concatOperandSeamsHaveComment(src, operands) {
+    ctx.Report(node, message)
+    return
+  }
   ctx.ReportFix(
     node,
     message,
     TextEdit{Pos: editPos, End: node.End(), Text: template},
   )
+}
+
+// concatOperandSeamsHaveComment reports whether a comment sits in any seam
+// between the flattened concat operands — the `+`-operator gaps the template
+// rebuild collapses. A leading comment before an operand is skipped by the
+// renderer (both string and expression operands begin at their trimmed token),
+// so a seam comment would be lost and the fix must decline. Operand interiors
+// are excluded because the renderer copies expression operands verbatim and
+// cooks string operands, so their contents — including a `//`-bearing URL
+// string — never trigger a false positive.
+func concatOperandSeamsHaveComment(src string, operands []*shimast.Node) bool {
+  for i := 0; i+1 < len(operands); i++ {
+    left, right := operands[i], operands[i+1]
+    if left == nil || right == nil {
+      continue
+    }
+    if hasCommentBetween(src, left.End(), shimscanner.SkipTrivia(src, right.Pos())) {
+      return true
+    }
+  }
+  return false
 }
 
 func concatChainShape(node *shimast.Node) (hasString bool, hasOther bool) {

--- a/packages/lint/test/rules/arrays-objects/dot_notation_declines_fix_when_comment_in_bracket_span_test.go
+++ b/packages/lint/test/rules/arrays-objects/dot_notation_declines_fix_when_comment_in_bracket_span_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import "testing"
+
+// TestDotNotationDeclinesFixWhenCommentInBracketSpan verifies the dot-notation
+// autofix is withheld when a comment sits inside the `[…]` span it would splice
+// over, so the comment survives instead of being silently deleted.
+//
+// The fix replaces the range from the receiver's end through the closing
+// bracket, so a comment there (`p1 /* keep */ ["foo"]`) would vanish after
+// `ttsc lint fix`. ESLint's dot-notation declines via `commentsExistBetween`;
+// the port reports the diagnostic but offers no edit. The negative twin — the
+// same access with no comment — must still rewrite, proving the guard is scoped
+// to the comment and not a blanket suppression.
+//
+//  1. Report on a bracket access whose span carries a block comment.
+//  2. Assert no fix is applied and the source is left byte-for-byte intact.
+//  3. Assert the comment-free twin still collapses to dot notation.
+func TestDotNotationDeclinesFixWhenCommentInBracketSpan(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "dot-notation",
+    "const p1: any = {};\nconst v1 = p1 /* keep */ [\"foo\"];\nJSON.stringify(v1);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "dot-notation",
+    "const p2: any = {};\nconst v2 = p2[\"foo\"];\nJSON.stringify(v2);\n",
+    "const p2: any = {};\nconst v2 = p2.foo;\nJSON.stringify(v2);\n",
+  )
+}

--- a/packages/lint/test/rules/arrays-objects/dot_notation_fix_spaces_decimal_integer_receiver_test.go
+++ b/packages/lint/test/rules/arrays-objects/dot_notation_fix_spaces_decimal_integer_receiver_test.go
@@ -1,0 +1,71 @@
+package linthost
+
+import "testing"
+
+// TestFixDotNotationSpacesDecimalIntegerReceiver verifies the dot-notation
+// autofix keeps a bare decimal-integer receiver parseable by inserting a
+// separating space before the dot, while radix-prefixed, float, exponent, and
+// parenthesized receivers keep the dot tight.
+//
+// `5["toString"]` → `5.toString` is a SyntaxError (TS1351): the digit and the
+// dot lex together as the float `5.`. ESLint's dot-notation inserts a space
+// (`5 .toString`) only for a plain decimal integer; a hex/float/exponent
+// literal ends in a non-decimal token and a parenthesized `(5)` ends in `)`,
+// so the spliced dot reads as a clean member access. The receiver kind is
+// inspected directly (not through `stripParens`) so `(5)` keeps the tight dot.
+//
+//  1. Fix bare decimal-integer receivers and assert the space is inserted.
+//  2. Fix hex, float, exponent, and parenthesized receivers with the dot tight.
+//  3. Re-parse every fixed output and assert it carries zero parse diagnostics.
+func TestFixDotNotationSpacesDecimalIntegerReceiver(t *testing.T) {
+  cases := []struct {
+    name     string
+    source   string
+    expected string
+  }{
+    {
+      name:     "bare decimal integer needs a space",
+      source:   "const s = 5[\"toString\"];\n",
+      expected: "const s = 5 .toString;\n",
+    },
+    {
+      name:     "zero needs a space",
+      source:   "const s = 0[\"toString\"];\n",
+      expected: "const s = 0 .toString;\n",
+    },
+    {
+      name:     "numeric separators still need a space",
+      source:   "const s = 1_000[\"toString\"];\n",
+      expected: "const s = 1_000 .toString;\n",
+    },
+    {
+      name:     "parenthesized receiver keeps the dot tight",
+      source:   "const s = (5)[\"toString\"];\n",
+      expected: "const s = (5).toString;\n",
+    },
+    {
+      name:     "hex receiver keeps the dot tight",
+      source:   "const s = 0x10[\"toString\"];\n",
+      expected: "const s = 0x10.toString;\n",
+    },
+    {
+      name:     "float receiver keeps the dot tight",
+      source:   "const s = 5.0[\"toString\"];\n",
+      expected: "const s = 5.0.toString;\n",
+    },
+    {
+      name:     "exponent receiver keeps the dot tight",
+      source:   "const s = 5e3[\"toString\"];\n",
+      expected: "const s = 5e3.toString;\n",
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertFixSnapshot(t, "dot-notation", test.source, test.expected)
+      file := parseTSFile(t, "/virtual/fixed-dot-notation-numeric.ts", test.expected)
+      if diagnostics := file.Diagnostics(); len(diagnostics) != 0 {
+        t.Fatalf("fixed source has parse diagnostics: %+v\n%s", diagnostics, test.expected)
+      }
+    })
+  }
+}

--- a/packages/lint/test/rules/arrays-objects/object_shorthand_declines_fix_when_comment_in_value_span_test.go
+++ b/packages/lint/test/rules/arrays-objects/object_shorthand_declines_fix_when_comment_in_value_span_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import "testing"
+
+// TestObjectShorthandDeclinesFixWhenCommentInValueSpan verifies the
+// object-shorthand autofix is withheld when a comment sits inside the `: value`
+// span it would delete, so the comment survives the collapse to shorthand.
+//
+// The fix deletes from the key name's end through the initializer's end, so a
+// comment there (`{ x: /* keep */ x }`) would be erased. ESLint's
+// object-shorthand declines via `commentsExistBetween`; the port reports the
+// shorthand candidate but offers no edit. The negative twin — the same property
+// with no comment — must still collapse to `{ x }`, proving the guard is scoped
+// to the comment.
+//
+//  1. Report on `{ x: /* keep */ x }` and assert no edit is applied.
+//  2. Assert the source is left byte-for-byte intact.
+//  3. Assert the comment-free twin still collapses to the shorthand `{ x }`.
+func TestObjectShorthandDeclinesFixWhenCommentInValueSpan(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "object-shorthand",
+    "const x = 1;\nconst o = { x: /* keep */ x };\nJSON.stringify(o);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "object-shorthand",
+    "const x = 1;\nconst o = { x: x };\nJSON.stringify(o);\n",
+    "const x = 1;\nconst o = { x };\nJSON.stringify(o);\n",
+  )
+}

--- a/packages/lint/test/rules/control-flow/no_return_assign_allows_parenthesized_assignment_test.go
+++ b/packages/lint/test/rules/control-flow/no_return_assign_allows_parenthesized_assignment_test.go
@@ -1,0 +1,81 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+)
+
+// TestNoReturnAssignAllowsParenthesizedAssignment verifies no-return-assign
+// follows ESLint's default `except-parens`: a bare assignment operand fires,
+// but a parenthesized one is allowed — and the `always` option opts the
+// parenthesized form back in.
+//
+// The port previously stripped parentheses before the assignment test, so
+// `return (a = 1)` was flagged even though the ESLint default treats the
+// explicit parentheses as an intentional assignment. The operand is now tested
+// as written (a wrapping parenthesized expression is not a binary assignment),
+// matching the parenthesis exemption `no-cond-assign` already applies, with
+// `always` restoring the strip-then-test behavior.
+//
+//  1. Assert bare `return a = 1` and `=> a = 1` each report exactly once.
+//  2. Assert their parenthesized twins report nothing under the default.
+//  3. Assert the `"always"` option flags both parenthesized forms.
+func TestNoReturnAssignAllowsParenthesizedAssignment(t *testing.T) {
+  cases := []struct {
+    name    string
+    source  string
+    options string
+    want    int
+  }{
+    {
+      name:   "bare return assignment fires",
+      source: "function f(a: number) {\n  return a = 1;\n}\nJSON.stringify(f);\n",
+      want:   1,
+    },
+    {
+      name:   "parenthesized return assignment is allowed",
+      source: "function f(a: number) {\n  return (a = 1);\n}\nJSON.stringify(f);\n",
+      want:   0,
+    },
+    {
+      name:   "bare arrow assignment fires",
+      source: "const g = (a: number) => a = 1;\nJSON.stringify(g);\n",
+      want:   1,
+    },
+    {
+      name:   "parenthesized arrow assignment is allowed",
+      source: "const g = (a: number) => (a = 1);\nJSON.stringify(g);\n",
+      want:   0,
+    },
+    {
+      name:    "always option flags the parenthesized return",
+      source:  "function f(a: number) {\n  return (a = 1);\n}\nJSON.stringify(f);\n",
+      options: "\"always\"",
+      want:    1,
+    },
+    {
+      name:    "always option flags the parenthesized arrow",
+      source:  "const g = (a: number) => (a = 1);\nJSON.stringify(g);\n",
+      options: "\"always\"",
+      want:    1,
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      var opts json.RawMessage
+      if test.options != "" {
+        opts = json.RawMessage(test.options)
+      }
+      _, _, findings := runRuleFindingsSnapshot(t, "no-return-assign", test.source, opts)
+      if len(findings) != test.want {
+        t.Fatalf(
+          "no-return-assign %q: want %d findings, got %d (%+v)",
+          test.name,
+          test.want,
+          len(findings),
+          findings,
+        )
+      }
+    })
+  }
+}

--- a/packages/lint/test/rules/control-flow/no_return_assign_test.go
+++ b/packages/lint/test/rules/control-flow/no_return_assign_test.go
@@ -16,5 +16,5 @@ import "testing"
 // 2. Enable the rule severities declared by its // expect: comments.
 // 3. Assert the native Engine reports exactly the annotated diagnostics.
 func TestRuleCorpusNoReturnAssign(t *testing.T) {
-  assertRuleCorpusCase(t, "no-return-assign.ts", "function f(a: any) {\n  // expect: no-return-assign error\n  return (a = 1);\n}\nJSON.stringify(f);\n")
+  assertRuleCorpusCase(t, "no-return-assign.ts", "function f(a: any) {\n  // expect: no-return-assign error\n  return a = 1;\n}\nJSON.stringify(f);\n")
 }

--- a/packages/lint/test/rules/strings-regex/prefer_template_declines_fix_when_comment_in_concat_span_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_declines_fix_when_comment_in_concat_span_test.go
@@ -1,0 +1,41 @@
+package linthost
+
+import "testing"
+
+// TestPreferTemplateDeclinesFixWhenCommentInConcatSpan verifies the
+// prefer-template autofix is withheld when a comment sits inside the
+// concatenation it would rewrite as a single template literal, so the comment
+// is preserved instead of dropped.
+//
+// The fix replaces the whole `+` chain span with one template literal, so a
+// comment anywhere inside (`"hi " + /* keep */ who`) would be erased. ESLint's
+// prefer-template declines via `commentsExistBetween`; the port reports the
+// concatenation but offers no edit. The negative twin — the same concatenation
+// with no comment — must still become a template literal, proving the guard is
+// scoped to the comment.
+//
+//  1. Report on `"hi " + /* keep */ who` and assert no edit is applied.
+//  2. Assert the comment-free twin still becomes the template “ `hi ${who}` “.
+//  3. Assert a `//`-bearing string operand (`"https://" + host`) still fixes,
+//     since the seam scan must not misread string content as a comment.
+func TestPreferTemplateDeclinesFixWhenCommentInConcatSpan(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "prefer-template",
+    "const who = \"world\";\nconst s = \"hi \" + /* keep */ who;\nJSON.stringify(s);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "prefer-template",
+    "const who = \"world\";\nconst s = \"hi \" + who;\nJSON.stringify(s);\n",
+    "const who = \"world\";\nconst s = `hi ${who}`;\nJSON.stringify(s);\n",
+  )
+  // A string literal containing `//` must not trip the seam scan into
+  // declining: the slashes are string content, not a comment.
+  assertFixSnapshot(
+    t,
+    "prefer-template",
+    "const host = \"example.com\";\nconst s = \"https://\" + host;\nJSON.stringify(s);\n",
+    "const host = \"example.com\";\nconst s = `https://${host}`;\nJSON.stringify(s);\n",
+  )
+}

--- a/packages/lint/test/rules/variables-assignments/no_useless_rename_declines_fix_when_comment_between_names_test.go
+++ b/packages/lint/test/rules/variables-assignments/no_useless_rename_declines_fix_when_comment_between_names_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import "testing"
+
+// TestNoUselessRenameDeclinesFixWhenCommentBetweenNames verifies the
+// no-useless-rename autofix is withheld when a comment sits between the two
+// names it would delete, so the comment is preserved rather than dropped.
+//
+// The fix deletes the rename tail from the property name's end through the
+// local name's end, so a comment there (`{ a as /* keep */ a }`) would be
+// erased. ESLint's no-useless-rename declines via `commentsExistBetween`; the
+// port reports the redundant rename but offers no edit. The negative twin — the
+// same specifier with no comment — must still collapse, proving the guard fires
+// only on the comment.
+//
+//  1. Report on `import { a as /* keep */ a }` and assert no edit is applied.
+//  2. Assert the source is left byte-for-byte intact.
+//  3. Assert the comment-free twin still collapses to `import { a }`.
+func TestNoUselessRenameDeclinesFixWhenCommentBetweenNames(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "no-useless-rename",
+    "import { a as /* keep */ a } from \"./m\";\nJSON.stringify(a);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "no-useless-rename",
+    "import { a as a } from \"./m\";\nJSON.stringify(a);\n",
+    "import { a } from \"./m\";\nJSON.stringify(a);\n",
+  )
+}

--- a/tests/test-lint/src/cases/no-return-assign.ts
+++ b/tests/test-lint/src/cases/no-return-assign.ts
@@ -1,5 +1,5 @@
 function f(a: any) {
   // expect: no-return-assign error
-  return (a = 1);
+  return a = 1;
 }
 JSON.stringify(f);

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -363,6 +363,8 @@ Prefer dot access (`obj.value`) over bracket access (`obj["value"]`) when the st
 
 Bracket access remains accepted for reserved words, dynamic keys, or keys containing characters that cannot appear in an identifier.
 
+The autofix inserts a space after a bare decimal-integer receiver (`5["toString"]` becomes `5 .toString`) so the dot is not lexed as the number's decimal point, and declines the rewrite when a comment sits inside the bracket span rather than deleting it.
+
 Example:
 
 ```ts
@@ -2173,6 +2175,8 @@ function runWith(target: { value: number }): number {
 
 Reject assignment expressions used as the operand of `return` (`return x = 1`), almost always a typo for `===`.
 
+Follows ESLint's default `except-parens` option: an assignment wrapped in explicit parentheses (`return (count = 1)`) is treated as intentional and left alone. Pass the `"always"` option to flag the parenthesized form as well.
+
 Example:
 
 ```ts
@@ -2180,7 +2184,7 @@ let count = 0;
 
 function f() {
   // reports: no-return-assign (error)
-  return (count = 1);
+  return count = 1;
 }
 ```
 


### PR DESCRIPTION
Fixes three `@ttsc/lint` autofix correctness bugs, all localized to `packages/lint/linthost/rules_gap.go` and `rules_suggestions.go`.

## #606 — dot-notation rewrites `5["toString"]` into a syntax error
A bare decimal-integer receiver lexes an immediately following `.` as its own decimal point, so `5["toString"]` → `5.toString` is a `SyntaxError` (TS1351). The fixer now inserts a separating space (`5 .toString`) exactly where ESLint's `dot-notation` does. Parenthesized `(5)`, hex/octal/binary, float, exponent, and bigint receivers all take `.` as a clean member access, so they keep the dot tight. The regression test asserts the fixed output **re-parses with zero diagnostics**.

## #609 — several fixers silently delete comments in their replacement range
`dot-notation`, `no-useless-rename` (all three rename shapes: import/export/binding), `object-shorthand`, and `prefer-template` each spliced over a delete/replace range that could contain a comment, dropping it silently. Each now declines to a **report-only** diagnostic when a comment sits in that range, via the existing `hasCommentBetween` helper (`ast_helpers.go`), matching ESLint's `commentsExistBetween`.

`prefer-template` scans **only the operator seams** between flattened operands rather than the whole span, so a `//` or `/*` that appears inside a *string literal* (`"https://" + host`) is not misread as a comment and the fix still applies.

## #610 — no-return-assign over-matches parenthesized assignment
The port stripped parentheses before the assignment test, flagging `return (a = 1)` even though ESLint's default `except-parens` allows it. The operand is now tested as written (a wrapping parenthesized expression is not a binary assignment), matching ESLint and the sibling `no-cond-assign`. The `always` option strips parens to opt back in. The fixture `tests/test-lint/src/cases/no-return-assign.ts` and the docs move to the unparenthesized positive.

## Scope / deferred
- The `always` option is honored by the Go engine and documented, but the typed TS surface (`ITtscLintCoreRuleOptions.ts`) was **not** extended, matching how the sibling `no-cond-assign` leaves its `except-parens`/`always` option untyped. Extending the typed config is a separate public-API change out of this fix's scope.

## Test plan
- New Go unit tests (one `Test*` per file, positive + negative twins, upstream-oracle expectations):
  - `dot_notation_fix_spaces_decimal_integer_receiver_test.go` (asserts fixed output re-parses)
  - `dot_notation_declines_fix_when_comment_in_bracket_span_test.go`
  - `no_useless_rename_declines_fix_when_comment_between_names_test.go`
  - `object_shorthand_declines_fix_when_comment_in_value_span_test.go`
  - `prefer_template_declines_fix_when_comment_in_concat_span_test.go` (includes the `"https://"` false-positive shield)
  - `no_return_assign_allows_parenthesized_assignment_test.go` (fires on `return a = 1`, silent on `return (a = 1)`, `always` re-enables)
- Updated corpus mirror `no_return_assign_test.go`.
- Targeted `go test ./linthost` for all five rules + siblings: green. Full `node scripts/test-go-lint.cjs`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Giu15S7hyRxpupc1XwXe89