### PR TITLE
fix(lint): honor // no default marker and skip empty switches in default-case

### DIFF
--- a/packages/lint/linthost/rules_default_case.go
+++ b/packages/lint/linthost/rules_default_case.go
@@ -1,17 +1,49 @@
 // defaultCase: a `switch` statement that omits the `default` clause
 // silently drops every discriminant value not matched by an explicit
-// `case` label. The rule wants the catch-all path written out so an
-// unhandled discriminant becomes an intentional branch — even if that
-// branch is a `// no default` comment marker.
+// `case` label. The rule wants the catch-all path written out — unless the
+// omission is deliberately marked by a trailing `// no default` comment.
 //
-// AST-only: each visited `SwitchStatement` checks its `CaseBlock`
-// clauses for any node of kind `DefaultClause`. The rule reports on the
-// switch keyword itself rather than the case block so the diagnostic
-// lands at the head of the statement.
+// Behavior mirrors ESLint's `default-case`:
+//
+//   - An empty switch (`switch (x) {}`, zero clauses) is skipped: an empty
+//     case block has no clause to attach the marker comment to, so upstream
+//     bails with `if (!node.cases.length) return;`.
+//   - A `default` clause anywhere in the block satisfies the rule.
+//   - Otherwise the LAST comment trailing the final clause (between its end
+//     and the case block's `}`) is tested against `commentPattern`. When the
+//     comment's trimmed text matches, the omission is intentional and the
+//     switch is left alone; otherwise the rule reports on the `switch`
+//     keyword so the diagnostic lands at the head of the statement.
+//
+// `commentPattern` replaces the default marker pattern `/^no default$/i`
+// (ESLint's DEFAULT_COMMENT_PATTERN). The trailing-comment scan reuses
+// comment_scan.go's parser-aware gap scanner over the trivia-only region
+// after the last clause.
 // https://eslint.org/docs/latest/rules/default-case
 package linthost
 
-import shimast "github.com/microsoft/typescript-go/shim/ast"
+import (
+  "regexp"
+  "strings"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+)
+
+// defaultCaseDefaultCommentPattern is ESLint's DEFAULT_COMMENT_PATTERN
+// (`/^no default$/iu`) in RE2: the trailing comment's trimmed text must be
+// exactly `no default`, in any letter case.
+var defaultCaseDefaultCommentPattern = regexp.MustCompile(`(?i)^no default$`)
+
+// defaultCaseOptions mirrors the upstream rule's single-object schema.
+type defaultCaseOptions struct {
+  // CommentPattern replaces the default `no default` marker pattern when
+  // non-empty. Upstream compiles it with the `u` flag and no `i`, so the
+  // custom pattern is case-sensitive unless it opts in. An uncompilable
+  // pattern falls back to the default marker (matching no-fallthrough) so a
+  // config typo cannot silently turn every marked switch into a finding.
+  CommentPattern string `json:"commentPattern"`
+}
 
 type defaultCase struct{}
 
@@ -19,19 +51,63 @@ func (defaultCase) Name() string           { return "default-case" }
 func (defaultCase) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSwitchStatement} }
 func (defaultCase) Check(ctx *Context, node *shimast.Node) {
   sw := node.AsSwitchStatement()
-  if sw == nil || sw.CaseBlock == nil {
+  if sw == nil || sw.CaseBlock == nil || ctx.File == nil {
     return
   }
   block := sw.CaseBlock.AsCaseBlock()
   if block == nil || block.Clauses == nil {
     return
   }
-  for _, clause := range block.Clauses.Nodes {
+  clauses := block.Clauses.Nodes
+  // Empty switch: upstream skips it because an empty case block offers no
+  // clause to read the marker comment from.
+  if len(clauses) == 0 {
+    return
+  }
+  for _, clause := range clauses {
     if clause != nil && clause.Kind == shimast.KindDefaultClause {
       return
     }
   }
+
+  var opts defaultCaseOptions
+  ctx.DecodeOptions(&opts)
+  pattern := defaultCaseDefaultCommentPattern
+  if opts.CommentPattern != "" {
+    if custom, err := regexp.Compile(opts.CommentPattern); err == nil {
+      pattern = custom
+    }
+  }
+
+  // ESLint's sourceCode.getCommentsAfter(lastCase).at(-1): the LAST comment
+  // between the final clause and the case block's closing brace marks the
+  // omission intentional when its trimmed text matches the pattern. A
+  // trailing non-marker comment after a `// no default` therefore invalidates
+  // the marker.
+  if lastClause := clauses[len(clauses)-1]; lastClause != nil {
+    text := ctx.File.Text()
+    closeBrace := sw.CaseBlock.End() - 1 // exclusive End covers the `}` token
+    if pos, end, ok := defaultCaseLastTrailingComment(text, lastClause.End(), closeBrace); ok &&
+      pattern.MatchString(strings.TrimSpace(commentInnerText(text[pos:end]))) {
+      return
+    }
+  }
+
   ctx.Report(node, "Expected a default case.")
+}
+
+// defaultCaseLastTrailingComment returns the source range of the LAST comment
+// in the trivia region [from, to), reusing comment_scan.go's parser-aware gap
+// scanner. The region between a switch's last clause and its closing brace is
+// trivia-only by construction, so scanning the isolated gap is exact.
+func defaultCaseLastTrailingComment(text string, from, to int) (pos, end int, ok bool) {
+  if from < 0 || to > len(text) || from >= to {
+    return 0, 0, false
+  }
+  scanCommentGap(shimscanner.NewScanner(), text, from, to, func(_ shimast.Kind, p, e int) {
+    pos, end, ok = p, e, true
+  })
+  return pos, end, ok
 }
 
 func init() {

--- a/packages/lint/test/rules/control-flow/default_case_accepts_block_comment_marker_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_accepts_block_comment_marker_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestDefaultCaseAcceptsBlockCommentMarker verifies a block-comment marker is honored.
+//
+// ESLint reads `comment.value` (delimiter-free) and trims it, so `/* no default */`
+// carries the same `no default` value as the line form. Boundary twin of the
+// line-comment marker covering the `/* */` delimiter stripping.
+//
+// 1. Place `/* no default */` as the trailing comment of the last clause.
+// 2. Run the engine with default-case enabled.
+// 3. Assert zero findings.
+func TestDefaultCaseAcceptsBlockCommentMarker(t *testing.T) {
+  assertDefaultCaseClean(t, `declare const foo: number;
+switch (foo) {
+  case 0:
+    console.log(0);
+    break;
+  /* no default */
+}
+`, "")
+}

--- a/packages/lint/test/rules/control-flow/default_case_accepts_case_insensitive_marker_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_accepts_case_insensitive_marker_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestDefaultCaseAcceptsCaseInsensitiveMarker verifies the default marker matches regardless of letter case.
+//
+// DEFAULT_COMMENT_PATTERN carries the `i` flag, so `// NO DEFAULT` is as valid
+// as the lowercase spelling. Locks the case-insensitivity of the ported
+// default pattern.
+//
+// 1. Place `// NO DEFAULT` as the trailing comment.
+// 2. Run the engine with default-case enabled.
+// 3. Assert zero findings.
+func TestDefaultCaseAcceptsCaseInsensitiveMarker(t *testing.T) {
+  assertDefaultCaseClean(t, `declare const foo: number;
+switch (foo) {
+  case 0:
+    console.log(0);
+    break;
+  // NO DEFAULT
+}
+`, "")
+}

--- a/packages/lint/test/rules/control-flow/default_case_accepts_empty_switch_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_accepts_empty_switch_test.go
@@ -1,0 +1,20 @@
+package linthost
+
+import "testing"
+
+// TestDefaultCaseAcceptsEmptySwitch verifies an empty switch produces nothing.
+//
+// Upstream `default-case` bails on `if (!node.cases.length) return;`: an empty
+// case block has no clause to hang a `// no default` marker on, so ESLint
+// leaves it alone. Locks the empty-switch boundary that the pre-fix port
+// wrongly reported.
+//
+// 1. Build `switch (foo) {}` with zero clauses.
+// 2. Run the engine with default-case enabled.
+// 3. Assert zero findings.
+func TestDefaultCaseAcceptsEmptySwitch(t *testing.T) {
+  assertDefaultCaseClean(t, `declare const foo: number;
+switch (foo) {
+}
+`, "")
+}

--- a/packages/lint/test/rules/control-flow/default_case_accepts_existing_default_clause_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_accepts_existing_default_clause_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestDefaultCaseAcceptsExistingDefaultClause verifies a present default clause satisfies the rule.
+//
+// A `switch` that already spells out `default` needs no marker and must never
+// report. Negative twin of the missing-default finding, one property away (the
+// default clause added).
+//
+// 1. Build a switch whose clauses include a `default`.
+// 2. Run the engine with default-case enabled.
+// 3. Assert zero findings.
+func TestDefaultCaseAcceptsExistingDefaultClause(t *testing.T) {
+  assertDefaultCaseClean(t, `declare const foo: number;
+switch (foo) {
+  case 0:
+    console.log(0);
+    break;
+  default:
+    console.log("other");
+}
+`, "")
+}

--- a/packages/lint/test/rules/control-flow/default_case_accepts_no_default_marker_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_accepts_no_default_marker_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestDefaultCaseAcceptsNoDefaultMarker verifies the // no default marker suppresses the finding.
+//
+// ESLint accepts a trailing comment whose trimmed text matches
+// DEFAULT_COMMENT_PATTERN (`/^no default$/iu`) as an explicit statement that
+// the omitted default is intentional. Locks the marker-scan path the pre-fix
+// port never implemented despite its header claim.
+//
+// 1. Place `// no default` as the last comment before the case block's `}`.
+// 2. Run the engine with default-case enabled.
+// 3. Assert zero findings.
+func TestDefaultCaseAcceptsNoDefaultMarker(t *testing.T) {
+  assertDefaultCaseClean(t, `declare const foo: number;
+switch (foo) {
+  case 0:
+    console.log(0);
+    break;
+  // no default
+}
+`, "")
+}

--- a/packages/lint/test/rules/control-flow/default_case_custom_pattern_replaces_default_marker_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_custom_pattern_replaces_default_marker_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestDefaultCaseCustomPatternReplacesDefaultMarker verifies a custom commentPattern disables the default marker.
+//
+// ESLint compiles the custom pattern INSTEAD of the default one, so the
+// standard `// no default` stops being accepted once a project configures its
+// own wording (upstream invalid regression). Negative twin of the
+// custom-pattern acceptance, one property away (the comment kept at the
+// default spelling).
+//
+// 1. Keep the default `// no default` marker under a custom pattern.
+// 2. Run the engine with options {"commentPattern":"^skip default$"}.
+// 3. Assert exactly one finding at the switch statement (line 2).
+func TestDefaultCaseCustomPatternReplacesDefaultMarker(t *testing.T) {
+  assertDefaultCaseReportsAtLines(t, `declare const foo: number;
+switch (foo) {
+  case 0:
+    console.log(0);
+    break;
+  // no default
+}
+`, `{"commentPattern":"^skip default$"}`, 2)
+}

--- a/packages/lint/test/rules/control-flow/default_case_helpers_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_helpers_test.go
@@ -1,0 +1,55 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// lintDefaultCase runs the native Engine over `source` with only the
+// default-case rule enabled (at error severity) and returns the raw findings
+// plus the parsed file for line assertions. A non-empty `options` JSON blob is
+// forwarded through the typed rule-options transport, exactly like a
+// `["error", {...}]` tuple in a lint config.
+//
+// Shared by the default_case_* test files so each scenario stays a single
+// assertion over one annotated source snippet.
+func lintDefaultCase(t *testing.T, source string, options string) (*shimast.SourceFile, []*Finding) {
+  t.Helper()
+  file := parseTSFile(t, "/virtual/default-case.ts", source)
+  rules := RuleConfig{"default-case": SeverityError}
+  var resolver RuleResolver = rules
+  if options != "" {
+    resolver = InlineRuleResolver{
+      Rules:   rules,
+      Options: RuleOptionsMap{"default-case": json.RawMessage(options)},
+    }
+  }
+  return file, NewEngineWithResolver(resolver).Run([]*shimast.SourceFile{file}, nil)
+}
+
+// assertDefaultCaseClean asserts that the scenario produced zero findings.
+func assertDefaultCaseClean(t *testing.T, source string, options string) {
+  t.Helper()
+  file, findings := lintDefaultCase(t, source, options)
+  if len(findings) != 0 {
+    t.Fatalf("expected zero findings, got %+v", normalizeRuleFindings(file, findings))
+  }
+}
+
+// assertDefaultCaseReportsAtLines asserts the scenario produced exactly one
+// finding per expected 1-based line, in order.
+func assertDefaultCaseReportsAtLines(t *testing.T, source string, options string, lines ...int) {
+  t.Helper()
+  file, findings := lintDefaultCase(t, source, options)
+  actual := normalizeRuleFindings(file, findings)
+  if len(actual) != len(lines) {
+    t.Fatalf("expected %d finding(s) at lines %v, got %+v", len(lines), lines, actual)
+  }
+  for i, line := range lines {
+    if actual[i].Rule != "default-case" || actual[i].Line != line {
+      t.Fatalf("finding[%d]: expected default-case at line %d, got %+v", i, line, actual)
+    }
+  }
+}

--- a/packages/lint/test/rules/control-flow/default_case_honors_custom_comment_pattern_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_honors_custom_comment_pattern_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestDefaultCaseHonorsCustomCommentPattern verifies the commentPattern option accepts a matching custom marker.
+//
+// Upstream compiles `new RegExp(options.commentPattern, "u")`, letting a
+// project standardize its own marker wording, delivered through the typed rule
+// options transport. Locks the custom-pattern compilation and matching path.
+//
+// 1. Mark the omission with `// skip default`.
+// 2. Run the engine with options {"commentPattern":"^skip default$"}.
+// 3. Assert zero findings.
+func TestDefaultCaseHonorsCustomCommentPattern(t *testing.T) {
+  assertDefaultCaseClean(t, `declare const foo: number;
+switch (foo) {
+  case 0:
+    console.log(0);
+    break;
+  // skip default
+}
+`, `{"commentPattern":"^skip default$"}`)
+}

--- a/packages/lint/test/rules/control-flow/default_case_invalid_comment_pattern_falls_back_to_default_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_invalid_comment_pattern_falls_back_to_default_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestDefaultCaseInvalidCommentPatternFallsBackToDefault verifies an uncompilable commentPattern degrades to the default marker.
+//
+// ESLint throws at rule creation on a bad regex; this host cannot fail the
+// whole run for one rule's option, so the rule keeps the default marker rather
+// than silently reporting every marked switch (mirrors no-fallthrough).
+//
+// 1. Keep the standard `// no default` marker.
+// 2. Run the engine with the invalid options {"commentPattern":"("}.
+// 3. Assert zero findings (default pattern still honored).
+func TestDefaultCaseInvalidCommentPatternFallsBackToDefault(t *testing.T) {
+  assertDefaultCaseClean(t, `declare const foo: number;
+switch (foo) {
+  case 0:
+    console.log(0);
+    break;
+  // no default
+}
+`, `{"commentPattern":"("}`)
+}

--- a/packages/lint/test/rules/control-flow/default_case_rejects_marker_with_trailing_text_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_rejects_marker_with_trailing_text_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestDefaultCaseRejectsMarkerWithTrailingText verifies the anchored default pattern rejects extra words.
+//
+// DEFAULT_COMMENT_PATTERN is anchored (`^no default$`), so `// no default here`
+// does not match and the omission stays unmarked. Boundary twin locking the
+// anchors against a loose substring match.
+//
+// 1. Place `// no default here` as the trailing comment.
+// 2. Run the engine with default-case enabled.
+// 3. Assert exactly one finding at the switch statement (line 2).
+func TestDefaultCaseRejectsMarkerWithTrailingText(t *testing.T) {
+  assertDefaultCaseReportsAtLines(t, `declare const foo: number;
+switch (foo) {
+  case 0:
+    console.log(0);
+    break;
+  // no default here
+}
+`, "", 2)
+}

--- a/packages/lint/test/rules/control-flow/default_case_rejects_unrelated_trailing_comment_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_rejects_unrelated_trailing_comment_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestDefaultCaseRejectsUnrelatedTrailingComment verifies a non-marker trailing comment does not suppress the finding.
+//
+// Only a comment matching the pattern is a marker; an ordinary `// TODO` after
+// the last clause still leaves the default omitted. Negative twin of the
+// marker acceptance, one property away (the comment text changed).
+//
+// 1. Place `// TODO: handle the rest` as the trailing comment.
+// 2. Run the engine with default-case enabled.
+// 3. Assert exactly one finding at the switch statement (line 2).
+func TestDefaultCaseRejectsUnrelatedTrailingComment(t *testing.T) {
+  assertDefaultCaseReportsAtLines(t, `declare const foo: number;
+switch (foo) {
+  case 0:
+    console.log(0);
+    break;
+  // TODO: handle the rest
+}
+`, "", 2)
+}

--- a/packages/lint/test/rules/control-flow/default_case_reports_switch_without_default_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_reports_switch_without_default_test.go
@@ -1,0 +1,22 @@
+package linthost
+
+import "testing"
+
+// TestDefaultCaseReportsSwitchWithoutDefault verifies a switch lacking a default clause is reported.
+//
+// The core rule: a non-empty switch with no `default` clause and no marker
+// comment silently drops unmatched discriminants, so ESLint reports on the
+// `switch` keyword. Primary positive arm of the fix.
+//
+// 1. Build a switch with only `case` clauses and no marker.
+// 2. Run the engine with default-case enabled.
+// 3. Assert exactly one finding at the switch statement (line 2).
+func TestDefaultCaseReportsSwitchWithoutDefault(t *testing.T) {
+  assertDefaultCaseReportsAtLines(t, `declare const foo: number;
+switch (foo) {
+  case 0:
+    console.log(0);
+    break;
+}
+`, "", 2)
+}

--- a/packages/lint/test/rules/control-flow/default_case_requires_marker_to_be_last_comment_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_requires_marker_to_be_last_comment_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestDefaultCaseRequiresMarkerToBeLastComment verifies only the last trailing comment counts as the marker.
+//
+// ESLint tests getCommentsAfter(lastCase).at(-1): when an unrelated comment
+// follows the marker, the marker no longer speaks for the switch. Locks the
+// last-comment-only selection against an "any comment in range matches"
+// over-match.
+//
+// 1. Place `// no default` followed by `// revisit later` after the last clause.
+// 2. Run the engine with default-case enabled.
+// 3. Assert exactly one finding at the switch statement (line 2).
+func TestDefaultCaseRequiresMarkerToBeLastComment(t *testing.T) {
+  assertDefaultCaseReportsAtLines(t, `declare const foo: number;
+switch (foo) {
+  case 0:
+    console.log(0);
+    break;
+  // no default
+  // revisit later
+}
+`, "", 2)
+}

--- a/packages/lint/test/rules/control-flow/default_case_test.go
+++ b/packages/lint/test/rules/control-flow/default_case_test.go
@@ -8,13 +8,14 @@ import "testing"
 // scenario keeps one annotated TypeScript fixture tied to the native Engine so individual rule
 // Check methods are measured by go test instead of only by the TypeScript feature runner.
 //
-// This case enables the rule annotations declared in default-case.ts and compares
-// normalized rule, severity, and line triples. The source text stays embedded in the
-// generated Go file so the test remains package-local and deterministic.
+// This fixture is the end-to-end regression shield for issue #601: the missing-default switch
+// is the sole finding, while the default-carrying, empty, and `// no default`-marked switches
+// must stay silent. Before the fix the empty and marked switches also reported, so the count
+// mismatch pins the bug.
 //
 // 1. Load the annotated TypeScript fixture source embedded below.
 // 2. Enable the rule severities declared by its // expect: comments.
 // 3. Assert the native Engine reports exactly the annotated diagnostics.
 func TestRuleCorpusDefaultCase(t *testing.T) {
-  assertRuleCorpusCase(t, "default-case.ts", "// Positive: a `switch` without a `default` clause silently lets unhandled\n// discriminants fall through with no value — the rule wants every switch\n// to spell out the catch-all path.\nfunction classify(kind: string): string {\n  // expect: default-case error\n  switch (kind) {\n    case \"a\":\n      return \"letter-a\";\n    case \"b\":\n      return \"letter-b\";\n  }\n  return \"unknown\";\n}\n\n// Negative: a `switch` that already carries a `default` clause is fine.\nfunction describe(kind: string): string {\n  switch (kind) {\n    case \"a\":\n      return \"letter-a\";\n    default:\n      return \"unknown\";\n  }\n}\n\nJSON.stringify({ classify: classify(\"a\"), describe: describe(\"b\") });\n")
+  assertRuleCorpusCase(t, "default-case.ts", "// Positive: a `switch` without a `default` clause and without a marker\n// silently lets unhandled discriminants fall through with no value -- the\n// rule reports.\nfunction classify(kind: string): string {\n  // expect: default-case error\n  switch (kind) {\n    case \"a\":\n      return \"letter-a\";\n    case \"b\":\n      return \"letter-b\";\n  }\n  return \"unknown\";\n}\n\n// Negative: a `switch` that already carries a `default` clause is fine.\nfunction describe(kind: string): string {\n  switch (kind) {\n    case \"a\":\n      return \"letter-a\";\n    default:\n      return \"unknown\";\n  }\n}\n\n// Negative: an empty `switch` has no clause to attach a marker to, so the\n// rule skips it (upstream `if (!node.cases.length) return;`).\nfunction ignoreEmpty(kind: string): void {\n  switch (kind) {\n  }\n}\n\n// Negative: a trailing `// no default` marker declares the omission\n// intentional, so the rule stays silent.\nfunction marked(kind: string): string {\n  switch (kind) {\n    case \"a\":\n      return \"letter-a\";\n    // no default\n  }\n  return \"unknown\";\n}\n\nJSON.stringify({\n  classify: classify(\"a\"),\n  describe: describe(\"b\"),\n  marked: marked(\"a\"),\n});\n")
 }

--- a/tests/test-lint/src/cases/default-case.ts
+++ b/tests/test-lint/src/cases/default-case.ts
@@ -1,6 +1,6 @@
-// Positive: a `switch` without a `default` clause silently lets unhandled
-// discriminants fall through with no value — the rule wants every switch
-// to spell out the catch-all path.
+// Positive: a `switch` without a `default` clause and without a marker
+// silently lets unhandled discriminants fall through with no value -- the
+// rule reports.
 function classify(kind: string): string {
   // expect: default-case error
   switch (kind) {
@@ -22,4 +22,26 @@ function describe(kind: string): string {
   }
 }
 
-JSON.stringify({ classify: classify("a"), describe: describe("b") });
+// Negative: an empty `switch` has no clause to attach a marker to, so the
+// rule skips it (upstream `if (!node.cases.length) return;`).
+function ignoreEmpty(kind: string): void {
+  switch (kind) {
+  }
+}
+
+// Negative: a trailing `// no default` marker declares the omission
+// intentional, so the rule stays silent.
+function marked(kind: string): string {
+  switch (kind) {
+    case "a":
+      return "letter-a";
+    // no default
+  }
+  return "unknown";
+}
+
+JSON.stringify({
+  classify: classify("a"),
+  describe: describe("b"),
+  marked: marked("a"),
+});

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -158,7 +158,7 @@ Examples come from the checked [lint corpus](https://github.com/samchon/ttsc/tre
 ### Other checks
 
 - [`curly`](#rule-curly): Require block statements for every `if`, `else`, `while`, `for`, and `do` body, reject the single-statement shorthand.
-- [`default-case`](#rule-default-case): Require `switch` statements to include a `default` clause.
+- [`default-case`](#rule-default-case): Require `switch` statements to include a `default` clause unless a `// no default` marker comment opts out.
 - [`default-case-last`](#rule-default-case-last): Require the `default` clause of a `switch` statement.
 - [`camelcase`](#rule-camelcase): Reject identifier declarations that aren't camelCase or PascalCase, snake_case bindings are flagged.
 - [`complexity`](#rule-complexity): Reject function bodies whose cyclomatic complexity exceeds twenty (default ESLint threshold).
@@ -209,7 +209,7 @@ Require `switch` statements to include a `default` clause.
 
 A switch without `default` silently drops every discriminant value that no `case` label matched.
 
-The rule forces the catch-all branch to be written out so unhandled cases become an intentional decision instead of a hidden fall-through.
+The rule forces the catch-all branch to be written out so unhandled cases become an intentional decision instead of a hidden fall-through. An empty switch (`switch (x) {}`) is skipped, matching ESLint. A switch may opt out by placing a marker comment whose trimmed text matches `commentPattern` (default `/^no default$/i`, for example `// no default`) as the last comment after its final clause.
 
 Example:
 
@@ -224,7 +224,22 @@ function classify(kind: string): string {
   }
   return "unknown";
 }
+
+function classifyMarked(kind: string): string {
+  switch (kind) {
+    case "a":
+      return "letter-a";
+    // no default
+  }
+  return "unknown";
+}
 ```
+
+Options:
+
+- `commentPattern?: string`
+
+  Regular expression the opt-out marker comment must match. Replaces the default `/^no default$/i` pattern entirely.
 
 <a id="rule-default-case-last"></a>
 


### PR DESCRIPTION
## Summary

Fixes #601. The `default-case` port (`packages/lint/linthost/rules_default_case.go`) diverged from ESLint in two ways verified against the upstream source (`eslint/lib/rules/default-case.js`): it reported empty switches and ignored the `// no default` marker comment (the rule's own header even claimed the marker worked, but no code implemented it). It also exposed no `commentPattern` option.

## Change

- **Bail on a zero-clause switch.** Mirrors upstream `if (!node.cases.length) return;` — an empty case block has no clause to attach a marker to.
- **Scan the trailing marker comment.** The LAST comment between the final clause and the case block's `}` (ESLint's `getCommentsAfter(lastCase).at(-1)`) is tested against `commentPattern`; a trimmed match leaves the switch alone. A non-marker comment after the marker invalidates it. The scan reuses `comment_scan.go`'s parser-aware gap scanner over the trivia-only region, and `commentInnerText` (ESLint's `comment.value`) for delimiter stripping — the same helpers the sibling `no-fallthrough` switch-marker rule uses.
- **Expose the `commentPattern` option** (default `/^no default$/i`, ESLint's `DEFAULT_COMMENT_PATTERN`). An uncompilable pattern falls back to the default marker, mirroring `no-fallthrough`.

## Tests (oracle-derived, upstream-checked)

New per-file Go unit tests under `packages/lint/test/rules/control-flow/` cover the three regression rows and their twins:

- empty switch **VALID**, `// no default` (line + block + case-insensitive) **VALID**, existing `default` **VALID**
- missing-default **INVALID**, non-marker trailing comment **INVALID**, marker-not-last **INVALID**, anchored `no default here` **INVALID**
- `commentPattern`: custom marker accepted, custom pattern replaces the default, invalid pattern falls back to default

The shared corpus fixture (`tests/test-lint/src/cases/default-case.ts`) and its Go mirror are expanded into a three-row end-to-end shield (missing-default reports; empty and `// no default`-marked switches stay silent).

## Verification

Before/after repro via a filtered `go test` on the linthost package:

- **Before:** 7 tests fail — empty switch reported, marker ignored (all forms), option ignored, corpus yields 3 findings instead of 1.
- **After:** all 13 default-case tests pass.

The full `node scripts/test-go-lint.cjs` suite and the `tests/test-lint` feature corpus were left to CI (they need a built worktree/binaries this environment lacks; the Windows go lane is a known-red exemption).

## Scope note

`commentPattern` is honored by the engine at runtime, but the typed `*.config.ts` surface still types `default-case` as a bare setting. Fully exposing the option to config authors would additionally require `packages/lint/src/structures/rules/ITtscLintCoreRules.ts`, `ITtscLintRuleOptionsMap.ts`, and `ITtscLintCoreRuleOptions.ts` — outside this change's permitted edit set, so left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Giu15S7hyRxpupc1XwXe89