### PR TITLE
fix(lint): no-dupe-keys computed-key parity + no-extend-native defineProperty/computed shapes

### DIFF
--- a/packages/lint/linthost/rules_dupes.go
+++ b/packages/lint/linthost/rules_dupes.go
@@ -99,11 +99,11 @@ func (noDupeArgs) Check(ctx *Context, node *shimast.Node) {
   }
 }
 
-// propertyKey returns a stable key for a property in an object literal.
-// Computed names without a literal payload return "" so the dedupe pass
-// can skip them safely (a typed field is fine — duplicate identical
-// expressions still won't cause false positives because the same expr
-// produces the same source text).
+// propertyKey returns a stable dedupe key for a property in an object literal,
+// mirroring ESLint's getStaticPropertyName. A property whose name is not
+// statically known — a computed name built from a non-constant expression —
+// returns "" so the dedupe pass skips it and never treats two distinct dynamic
+// keys as duplicates.
 func propertyKey(file *shimast.SourceFile, prop *shimast.Node) string {
   if prop == nil {
     return ""
@@ -152,11 +152,15 @@ func propertyKey(file *shimast.SourceFile, prop *shimast.Node) string {
   return ""
 }
 
-// staticPropertyKey extracts a comparable string key from a property name node.
-// Identifiers, string/numeric literals, and computed names with a literal
-// payload all produce a stable string. Other computed names (dynamic
-// expressions) return "" so the caller skips them without false positives.
-func staticPropertyKey(file *shimast.SourceFile, name *shimast.Node) string {
+// staticPropertyKey extracts a comparable string key from a property name node,
+// mirroring ESLint's getStaticPropertyName. A bare identifier yields its name,
+// and string / numeric / bigint literals yield their text. A computed name
+// yields a key only when its bracketed expression is itself a constant literal
+// (resolved like getStaticStringValue): `["a"]` resolves to `a` so it collides
+// with the identifier key `a`, while a non-constant computed name such as
+// `[f()]` or `[x]` resolves to "" and the caller skips it. The file argument is
+// unused here but kept so the whole property-key family shares one signature.
+func staticPropertyKey(_ *shimast.SourceFile, name *shimast.Node) string {
   if name == nil {
     return ""
   }
@@ -168,9 +172,30 @@ func staticPropertyKey(file *shimast.SourceFile, name *shimast.Node) string {
   case shimast.KindNumericLiteral, shimast.KindBigIntLiteral:
     return numericLiteralText(name)
   case shimast.KindComputedPropertyName:
-    // fall back to source text so a computed `[`foo`]` still compares
-    // against the literal `foo` form when both appear together.
-    return nodeText(file, name)
+    computed := name.AsComputedPropertyName()
+    if computed == nil {
+      return ""
+    }
+    return staticComputedKey(computed.Expression)
+  }
+  return ""
+}
+
+// staticComputedKey resolves the expression inside a `[...]` computed property
+// name to a static key, mirroring ESLint's getStaticStringValue: only a
+// constant literal (string, template without substitutions, numeric, or bigint)
+// contributes a key. Parentheses are transparent, matching ESTree, which has no
+// parenthesized-expression node. Any other expression contributes "".
+func staticComputedKey(expr *shimast.Node) string {
+  expr = stripParens(expr)
+  if expr == nil {
+    return ""
+  }
+  switch expr.Kind {
+  case shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral:
+    return stringLiteralText(expr)
+  case shimast.KindNumericLiteral, shimast.KindBigIntLiteral:
+    return numericLiteralText(expr)
   }
   return ""
 }

--- a/packages/lint/linthost/rules_no_extend_native.go
+++ b/packages/lint/linthost/rules_no_extend_native.go
@@ -2,38 +2,134 @@ package linthost
 
 import shimast "github.com/microsoft/typescript-go/shim/ast"
 
-// noExtendNative: forbid assignments to `<Builtin>.prototype.<key>`,
-// which mutate a shared global and leak across the entire realm.
+// noExtendNative forbids extending a native builtin's prototype, which mutates a
+// shared global and leaks across the entire realm. Mirroring ESLint's
+// no-extend-native, it flags every shape that adds to `<Builtin>.prototype`:
+// direct member assignment (`X.prototype.y = …` and `X.prototype["y"] = …`) and
+// `Object.defineProperty` / `Object.defineProperties` calls whose target is a
+// native prototype. The `exceptions` option removes builtins from the set.
 // https://eslint.org/docs/latest/rules/no-extend-native
 type noExtendNative struct{}
 
-func (noExtendNative) Name() string           { return "no-extend-native" }
-func (noExtendNative) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindBinaryExpression} }
+type noExtendNativeOptions struct {
+  Exceptions []string `json:"exceptions"`
+}
+
+func (noExtendNative) Name() string { return "no-extend-native" }
+func (noExtendNative) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindBinaryExpression, shimast.KindCallExpression}
+}
 func (noExtendNative) Check(ctx *Context, node *shimast.Node) {
+  switch node.Kind {
+  case shimast.KindBinaryExpression:
+    checkExtendNativeAssignment(ctx, node)
+  case shimast.KindCallExpression:
+    checkExtendNativeDefineProperty(ctx, node)
+  }
+}
+
+// checkExtendNativeAssignment reports `<Builtin>.prototype.<key> = …` and
+// `<Builtin>.prototype["<key>"] = …`. Mirroring upstream's isAssigningToPropertyOf,
+// the assigned member key itself is not inspected: any write to a member of the
+// prototype extends it.
+func checkExtendNativeAssignment(ctx *Context, node *shimast.Node) {
   expr := node.AsBinaryExpression()
-  if expr == nil || expr.OperatorToken == nil {
+  if expr == nil || expr.OperatorToken == nil || expr.OperatorToken.Kind != shimast.KindEqualsToken {
     return
   }
-  if expr.OperatorToken.Kind != shimast.KindEqualsToken {
+  target := stripParens(expr.Left)
+  if target == nil {
     return
   }
-  outer := stripParens(expr.Left)
-  if outer == nil || outer.Kind != shimast.KindPropertyAccessExpression {
+  var object *shimast.Node
+  switch target.Kind {
+  case shimast.KindPropertyAccessExpression:
+    if access := target.AsPropertyAccessExpression(); access != nil {
+      object = access.Expression
+    }
+  case shimast.KindElementAccessExpression:
+    if access := target.AsElementAccessExpression(); access != nil {
+      object = access.Expression
+    }
+  default:
     return
   }
-  receiver := stripParens(outer.AsPropertyAccessExpression().Expression)
-  if receiver == nil || receiver.Kind != shimast.KindPropertyAccessExpression {
+  if builtin := extendNativePrototypeBuiltin(ctx, object); builtin != "" {
+    ctx.Report(node, builtin+" prototype is read only, properties should not be added.")
+  }
+}
+
+// checkExtendNativeDefineProperty reports
+// `Object.defineProperty(<Builtin>.prototype, …)` and the `defineProperties`
+// variant, mirroring upstream's isInDefinePropertyCall: the extended prototype
+// is the call's first argument.
+func checkExtendNativeDefineProperty(ctx *Context, node *shimast.Node) {
+  call := node.AsCallExpression()
+  if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
     return
   }
-  inner := receiver.AsPropertyAccessExpression()
-  if identifierText(inner.Name()) != "prototype" {
+  callee := stripParens(call.Expression)
+  if !isMatchingPropertyAccess(callee, "Object", "defineProperty") &&
+    !isMatchingPropertyAccess(callee, "Object", "defineProperties") {
     return
   }
-  builtin := identifierText(stripParens(inner.Expression))
-  if !isExtendNativeBuiltin(builtin) {
-    return
+  if builtin := extendNativePrototypeBuiltin(ctx, call.Arguments.Nodes[0]); builtin != "" {
+    ctx.Report(node, builtin+" prototype is read only, properties should not be added.")
   }
-  ctx.Report(node, builtin+" prototype is read only, properties should not be added.")
+}
+
+// extendNativePrototypeBuiltin returns the native builtin name when `node` reads
+// `<Builtin>.prototype` — through `.prototype` property access or a static
+// `["prototype"]` element access — and the builtin is protected (a known native
+// not listed in the rule's `exceptions` option). Otherwise it returns "".
+// Mirrors upstream's isPrototypePropertyAccessed, which resolves the accessed
+// key with getStaticPropertyName, combined with the exceptions filter.
+func extendNativePrototypeBuiltin(ctx *Context, node *shimast.Node) string {
+  node = stripParens(node)
+  if node == nil {
+    return ""
+  }
+  var object *shimast.Node
+  var key string
+  switch node.Kind {
+  case shimast.KindPropertyAccessExpression:
+    access := node.AsPropertyAccessExpression()
+    if access == nil {
+      return ""
+    }
+    object = access.Expression
+    key = identifierText(access.Name())
+  case shimast.KindElementAccessExpression:
+    access := node.AsElementAccessExpression()
+    if access == nil {
+      return ""
+    }
+    object = access.Expression
+    key = stringLiteralText(access.ArgumentExpression)
+  default:
+    return ""
+  }
+  if key != "prototype" {
+    return ""
+  }
+  builtin := identifierText(stripParens(object))
+  if !isExtendNativeBuiltin(builtin) || extendNativeExcepted(ctx, builtin) {
+    return ""
+  }
+  return builtin
+}
+
+// extendNativeExcepted reports whether the rule's `exceptions` option opts the
+// given builtin out of the protected set.
+func extendNativeExcepted(ctx *Context, builtin string) bool {
+  var options noExtendNativeOptions
+  _ = ctx.DecodeOptions(&options)
+  for _, name := range options.Exceptions {
+    if name == builtin {
+      return true
+    }
+  }
+  return false
 }
 
 func isExtendNativeBuiltin(name string) bool {

--- a/packages/lint/test/rules/runtime-safety/no_dupe_keys_computed_key_static_resolution_test.go
+++ b/packages/lint/test/rules/runtime-safety/no_dupe_keys_computed_key_static_resolution_test.go
@@ -1,0 +1,67 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestNoDupeKeysComputedKeyStaticResolution pins no-dupe-keys to ESLint's
+// getStaticPropertyName semantics for computed keys.
+//
+// A computed key contributes the static value of its literal argument, so
+// `["a"]` collides with the identifier key `a`; a non-constant computed key
+// (`[f()]`, `[x]`) contributes no key and can never collide. This guards the
+// regression where computed keys were compared by their raw `[expr]` source
+// text, which both missed a literal duplicate (`{ a: 1, ["a"]: 2 }` went
+// unreported) and falsely flagged two distinct dynamic keys as identical
+// (`{ [f()]: 1, [f()]: 2 }` reported a bogus duplicate).
+//
+//  1. Parse each object-literal fixture with no type checker (AST-only rule).
+//  2. Run the engine with only no-dupe-keys enabled.
+//  3. Assert the reported duplicate-key messages match the oracle exactly.
+func TestNoDupeKeysComputedKeyStaticResolution(t *testing.T) {
+  tests := []struct {
+    name         string
+    source       string
+    wantMessages []string
+  }{
+    {
+      name:         "computed string literal duplicates identifier key",
+      source:       "const o = {\n  a: 1,\n  [\"a\"]: 2,\n};\n",
+      wantMessages: []string{"Duplicate key 'a'."},
+    },
+    {
+      name:         "computed numeric literal duplicates numeric key",
+      source:       "const o = {\n  1: 1,\n  [1]: 2,\n};\n",
+      wantMessages: []string{"Duplicate key '1'."},
+    },
+    {
+      name:   "distinct calls in computed keys are not duplicates",
+      source: "const o = {\n  [f()]: 1,\n  [f()]: 2,\n};\n",
+    },
+    {
+      name:   "distinct identifier computed keys are not duplicates",
+      source: "const o = {\n  [a]: 1,\n  [b]: 2,\n};\n",
+    },
+  }
+  for _, test := range tests {
+    t.Run(test.name, func(t *testing.T) {
+      file := parseTS(t, test.source)
+      findings := NewEngine(RuleConfig{"no-dupe-keys": SeverityError}).
+        Run([]*shimast.SourceFile{file}, nil)
+      got := make([]string, 0, len(findings))
+      for _, finding := range findings {
+        got = append(got, finding.Message)
+      }
+      if len(got) != len(test.wantMessages) {
+        t.Fatalf("messages = %v, want %v", got, test.wantMessages)
+      }
+      for i := range got {
+        if got[i] != test.wantMessages[i] {
+          t.Fatalf("messages = %v, want %v", got, test.wantMessages)
+        }
+      }
+    })
+  }
+}

--- a/packages/lint/test/rules/runtime-safety/no_dupe_keys_test.go
+++ b/packages/lint/test/rules/runtime-safety/no_dupe_keys_test.go
@@ -9,12 +9,32 @@ import "testing"
 // Check methods are measured by go test instead of only by the TypeScript feature runner.
 //
 // This case enables the rule annotations declared in no-dupe-keys.ts and compares normalized
-// rule, severity, and line triples. The source text stays embedded in the generated Go file so
-// the test remains package-local and deterministic.
+// rule, severity, and line triples. It pairs a literal-key duplicate with a computed one that
+// resolves to the same static key (`["a"]` duplicates `a`) and two distinct dynamic computed
+// keys (`[key()]`) that must stay silent. The source below is byte-identical to
+// tests/test-lint/src/cases/no-dupe-keys.ts, which the TypeScript corpus runner drives through
+// the real ttsc command path.
 //
 // 1. Load the annotated TypeScript fixture source embedded below.
 // 2. Enable the rule severities declared by its // expect: comments.
 // 3. Assert the native Engine reports exactly the annotated diagnostics.
 func TestRuleCorpusNoDupeKeys(t *testing.T) {
-  assertRuleCorpusCase(t, "no-dupe-keys.ts", "const o = {\n  a: 1,\n  // expect: no-dupe-keys error\n  a: 2,\n};\nJSON.stringify(o);\n")
+  assertRuleCorpusCase(t, "no-dupe-keys.ts", `const o = {
+  a: 1,
+  // expect: no-dupe-keys error
+  a: 2,
+};
+JSON.stringify(o);
+
+declare function key(): string;
+
+const computed = {
+  a: 1,
+  // expect: no-dupe-keys error
+  ["a"]: 2,
+  [key()]: 3,
+  [key()]: 4,
+};
+JSON.stringify(computed);
+`)
 }

--- a/packages/lint/test/rules/runtime-safety/no_extend_native_define_property_and_computed_test.go
+++ b/packages/lint/test/rules/runtime-safety/no_extend_native_define_property_and_computed_test.go
@@ -1,0 +1,72 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestNoExtendNativeDefinePropertyAndComputed covers the three prototype-
+// extension shapes beyond the plain `X.prototype.y = …` assignment that the
+// rule originally missed, mirroring ESLint's no-extend-native.
+//
+// Upstream flags any member write to a native `<Builtin>.prototype` plus
+// `Object.defineProperty` / `Object.defineProperties` calls whose first
+// argument is such a prototype. The negatives pin the boundary: a non-native
+// receiver and a define-property target that is not a prototype must stay
+// silent.
+//
+//  1. Parse each fixture with no type checker (AST-only rule).
+//  2. Run the engine with only no-extend-native enabled.
+//  3. Assert the finding count and, for the positives, the builtin in the message.
+func TestNoExtendNativeDefinePropertyAndComputed(t *testing.T) {
+  tests := []struct {
+    name        string
+    source      string
+    wantBuiltin string // "" means no finding is expected
+  }{
+    {
+      name:        "Object.defineProperty on a native prototype",
+      source:      `Object.defineProperty(Array.prototype, "foo", { value: 1 });`,
+      wantBuiltin: "Array",
+    },
+    {
+      name:        "Object.defineProperties on a native prototype",
+      source:      `Object.defineProperties(Array.prototype, { foo: { value: 1 } });`,
+      wantBuiltin: "Array",
+    },
+    {
+      name:        "computed string assignment to a native prototype",
+      source:      `Array.prototype["baz"] = 1;`,
+      wantBuiltin: "Array",
+    },
+    {
+      name:   "assignment to a non-native prototype stays silent",
+      source: `Foo.prototype.bar = 1;`,
+    },
+    {
+      name:   "defineProperty on a non-prototype target stays silent",
+      source: `Object.defineProperty(target, "x", { value: 1 });`,
+    },
+  }
+  for _, test := range tests {
+    t.Run(test.name, func(t *testing.T) {
+      file := parseTS(t, test.source)
+      findings := NewEngine(RuleConfig{"no-extend-native": SeverityError}).
+        Run([]*shimast.SourceFile{file}, nil)
+      if test.wantBuiltin == "" {
+        if len(findings) != 0 {
+          t.Fatalf("expected no findings, got %d: %+v", len(findings), findings)
+        }
+        return
+      }
+      if len(findings) != 1 {
+        t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+      }
+      want := test.wantBuiltin + " prototype is read only, properties should not be added."
+      if findings[0].Message != want {
+        t.Fatalf("message = %q, want %q", findings[0].Message, want)
+      }
+    })
+  }
+}

--- a/packages/lint/test/rules/runtime-safety/no_extend_native_exceptions_option_test.go
+++ b/packages/lint/test/rules/runtime-safety/no_extend_native_exceptions_option_test.go
@@ -1,0 +1,21 @@
+package linthost
+
+import "testing"
+
+// TestNoExtendNativeExceptionsOption verifies the `exceptions` option removes
+// a builtin from the protected set, mirroring ESLint's no-extend-native.
+//
+// With `String` excepted, extending `String.prototype` is allowed while every
+// other native prototype (here `Array`) still reports. This pins the option
+// plumbing end-to-end through the corpus resolver.
+//
+//  1. Supply `{ exceptions: ["String"] }` via the corpus options directive.
+//  2. Run the engine on both an excepted and a non-excepted prototype write.
+//  3. Assert only the non-excepted write reports.
+func TestNoExtendNativeExceptionsOption(t *testing.T) {
+  assertRuleCorpusCase(t, "no-extend-native-exceptions.ts", `// @ttsc-corpus-options: no-extend-native {"exceptions":["String"]}
+// expect: no-extend-native error
+Array.prototype.foo = 1;
+String.prototype.bar = 1;
+`)
+}

--- a/packages/lint/test/rules/runtime-safety/no_extend_native_test.go
+++ b/packages/lint/test/rules/runtime-safety/no_extend_native_test.go
@@ -5,12 +5,26 @@ import "testing"
 // TestRuleCorpusNoExtendNative verifies the lint rule corpus fixture no-extend-native.ts.
 //
 // Rule corpus tests mirror tests/test-lint/src/cases inside Go unit coverage. The fixture
-// pairs two prototype-mutation assignments — one numeric, one function — with a static
-// assignment to `Object.foo` that must stay quiet because it doesn't touch `.prototype.<key>`.
+// exercises all four prototype-extension shapes — dotted and computed member assignment plus
+// `Object.defineProperty` / `Object.defineProperties` on a native prototype — against a static
+// assignment to `Object.foo` that must stay quiet because it doesn't touch a `.prototype`. The
+// source below is byte-identical to tests/test-lint/src/cases/no-extend-native.ts, which the
+// TypeScript corpus runner drives through the real ttsc command path.
 //
 // 1. Load the annotated TypeScript fixture source embedded below.
 // 2. Enable the rule severities declared by its // expect: comments.
 // 3. Assert the native Engine reports exactly the annotated diagnostics.
 func TestRuleCorpusNoExtendNative(t *testing.T) {
-  assertRuleCorpusCase(t, "no-extend-native.ts", "// expect: no-extend-native error\nArray.prototype.foo = 1;\n// expect: no-extend-native error\nString.prototype.upper = function (): void {};\nObject.foo = 1;\n")
+  assertRuleCorpusCase(t, "no-extend-native.ts", `// expect: no-extend-native error
+Array.prototype.foo = 1;
+// expect: no-extend-native error
+String.prototype.upper = function (): void {};
+// expect: no-extend-native error
+Array.prototype["baz"] = 2;
+// expect: no-extend-native error
+Object.defineProperty(Number.prototype, "half", { value: 3 });
+// expect: no-extend-native error
+Object.defineProperties(Boolean.prototype, { flip: { value: 4 } });
+Object.foo = 1;
+`)
 }

--- a/tests/test-lint/src/cases/no-dupe-keys.ts
+++ b/tests/test-lint/src/cases/no-dupe-keys.ts
@@ -4,3 +4,14 @@ const o = {
   a: 2,
 };
 JSON.stringify(o);
+
+declare function key(): string;
+
+const computed = {
+  a: 1,
+  // expect: no-dupe-keys error
+  ["a"]: 2,
+  [key()]: 3,
+  [key()]: 4,
+};
+JSON.stringify(computed);

--- a/tests/test-lint/src/cases/no-extend-native.ts
+++ b/tests/test-lint/src/cases/no-extend-native.ts
@@ -2,4 +2,10 @@
 Array.prototype.foo = 1;
 // expect: no-extend-native error
 String.prototype.upper = function (): void {};
+// expect: no-extend-native error
+Array.prototype["baz"] = 2;
+// expect: no-extend-native error
+Object.defineProperty(Number.prototype, "half", { value: 3 });
+// expect: no-extend-native error
+Object.defineProperties(Boolean.prototype, { flip: { value: 4 } });
 Object.foo = 1;

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -1068,7 +1068,7 @@ function chooseCacheMode(isReady: boolean, isCached: boolean) {
 
 ### `no-dupe-keys`
 
-Reject `{ a: 1, a: 2 }`, duplicate property keys in an object literal silently overwrite earlier values.
+Reject `{ a: 1, a: 2 }`, duplicate property keys in an object literal silently overwrite earlier values. A computed key is resolved to its static literal value, so `["a"]` duplicates the identifier key `a`; a non-constant computed key such as `[f()]` or `[x]` is not statically known and is never treated as a duplicate.
 
 Example:
 
@@ -1077,6 +1077,8 @@ const o = {
   a: 1,
   // reports: no-dupe-keys (error)
   a: 2,
+  // reports: no-dupe-keys (error)
+  ["a"]: 3,
 };
 ```
 

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -1344,7 +1344,7 @@ try {
 
 ### `no-extend-native`
 
-Reject assignments to a built-in prototype such as `Array.prototype.foo = bar`. Only `<Builtin>.prototype.<key> = ...` is flagged; assigning to `Object.foo = ...` (a static property) is left alone.
+Reject extending a built-in prototype such as `Array.prototype.foo = bar`. Every shape that adds to a native prototype is flagged: dotted (`X.prototype.y = ...`) and computed (`X.prototype["y"] = ...`) member assignment, plus `Object.defineProperty` / `Object.defineProperties` whose target is a native prototype. Assigning to `Object.foo = ...` (a static property) is left alone. The `exceptions` option lists builtins to allow.
 
 Example:
 
@@ -1353,7 +1353,17 @@ Example:
 Array.prototype.firstItem = 1;
 // reports: no-extend-native (error)
 String.prototype.upper = function (): void {};
+// reports: no-extend-native (error)
+Array.prototype["lastItem"] = 2;
+// reports: no-extend-native (error)
+Object.defineProperty(Number.prototype, "half", { value: 3 });
 Object.debugLabel = 1;
+```
+
+Allow specific builtins with the `exceptions` option:
+
+```json
+{ "rules": { "no-extend-native": ["error", { "exceptions": ["Array"] }] } }
 ```
 
 <a id="rule-no-extra-bind"></a>


### PR DESCRIPTION
Harvested from a session-limited agent's committed work (verified by main agent; core logic reviewed, final gate pending).

Fixes #612 — `no-dupe-keys` now resolves computed keys via a getStaticPropertyName mirror (`["a"]`→`a`; non-constant computed → no key), fixing the FP on `{[f()]:1,[f()]:2}` and the FN vs `{a:1,["a"]:2}`.
Fixes #613 — `no-extend-native` now also flags `Object.defineProperty`/`defineProperties` on a native prototype and computed `X.prototype["y"]=…`, and honors `exceptions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)