### PR TITLE
fix(lint): align unicorn/no-typeof-undefined with upstream

### DIFF
--- a/packages/lint/linthost/rules_unicorn_no_typeof_undefined.go
+++ b/packages/lint/linthost/rules_unicorn_no_typeof_undefined.go
@@ -1,29 +1,78 @@
-// unicorn/no-typeof-undefined: comparing `typeof X` against the string
-// literal `"undefined"` is a leftover guard from pre-strict-mode code,
-// when referencing an undeclared identifier threw a ReferenceError.
-// Modern code can compare the value to `undefined` directly, which is
-// shorter and reads as the intent it actually expresses.
+// unicorn/no-typeof-undefined: comparing `typeof X` against the string literal
+// `"undefined"` is a leftover guard from pre-strict-mode code, when referencing
+// an undeclared identifier threw a ReferenceError. Modern code can compare the
+// value to `undefined` directly, which is shorter and reads as the intent it
+// actually expresses.
 //
-// AST-only: each visited BinaryExpression is rejected when its operator
-// is one of `===`, `==`, `!==`, `!=` and its two operands include
-// exactly one TypeOfExpression and exactly one string-shaped literal
-// (StringLiteral or NoSubstitutionTemplateLiteral) whose text value is
-// `undefined`. Either side may carry the typeof; either side may carry
-// the literal.
+// The match mirrors upstream exactly:
+//
+//   - the `typeof` must be the LEFT operand of `===` / `==` / `!==` / `!=`
+//     (a reversed `"undefined" === typeof x` is left alone),
+//   - the right operand must be a string Literal whose value is `undefined`
+//     (a template literal “ `undefined` “ is a TemplateLiteral, never a
+//     Literal, so it is excluded), and
+//   - a global operand is skipped unless `checkGlobalVariables` is enabled,
+//     because rewriting `typeof window === "undefined"` to `window ===
+//     undefined` throws a ReferenceError when the global is undeclared. A
+//     global is an identifier that resolves to no local binding, which the
+//     checker answers; every other operand (member access, call, `this`,
+//     literal) is never a global identifier and stays checked.
+//
+// The autofix removes the `typeof` keyword, upgrades `==` / `!=` to their
+// strict form, and replaces the `"undefined"` literal with the `undefined`
+// identifier. Removing a leading keyword can create an ASI hazard, so the fix
+// is declined (the diagnostic still reports) when `typeof` and its operand span
+// different lines or the operand begins with a continuation character; upstream
+// inserts a guarding `;` or parentheses there, which this port conservatively
+// avoids emitting rather than risk a wrong edit. When `checkGlobalVariables`
+// surfaces a global, the same edits are offered as an opt-in suggestion instead
+// of an automatic fix, matching upstream.
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-typeof-undefined.md
 package linthost
 
-import shimast "github.com/microsoft/typescript-go/shim/ast"
+import (
+  "bytes"
+  "encoding/json"
+  "errors"
+  "fmt"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+)
 
 type unicornNoTypeofUndefined struct{}
+
+// unicornNoTypeofUndefinedOptions is the decoded option payload. Upstream's
+// only option is `checkGlobalVariables`, defaulting to false.
+type unicornNoTypeofUndefinedOptions struct {
+  checkGlobalVariables bool
+}
 
 func (unicornNoTypeofUndefined) Name() string { return "unicorn/no-typeof-undefined" }
 func (unicornNoTypeofUndefined) Visits() []shimast.Kind {
   return []shimast.Kind{shimast.KindBinaryExpression}
 }
+
+// The global guard is scope analysis, not syntax: resolving the operand to its
+// binding is what separates a shadowing `let window` (checked) from the
+// ambient `window` global (skipped by default).
+func (unicornNoTypeofUndefined) NeedsTypeChecker() bool { return true }
+
+func (unicornNoTypeofUndefined) ValidateOptions(raw json.RawMessage) error {
+  _, err := decodeUnicornNoTypeofUndefinedOptions(raw)
+  return err
+}
+
 func (unicornNoTypeofUndefined) Check(ctx *Context, node *shimast.Node) {
+  if ctx == nil || ctx.File == nil || ctx.Checker == nil || node == nil {
+    return
+  }
+  options, err := decodeUnicornNoTypeofUndefinedOptions(ctx.Options)
+  if err != nil {
+    return
+  }
   expr := node.AsBinaryExpression()
-  if expr == nil || expr.OperatorToken == nil {
+  if expr == nil || expr.OperatorToken == nil || expr.Left == nil || expr.Right == nil {
     return
   }
   switch expr.OperatorToken.Kind {
@@ -34,23 +83,183 @@ func (unicornNoTypeofUndefined) Check(ctx *Context, node *shimast.Node) {
   default:
     return
   }
-  left := stripParens(expr.Left)
-  right := stripParens(expr.Right)
-  if left == nil || right == nil {
+  // Upstream requires `binaryExpression.left` to be the `typeof` unary; the
+  // reversed operand order is one of its explicit valid cases.
+  if expr.Left.Kind != shimast.KindTypeOfExpression {
     return
   }
-  var literal *shimast.Node
-  if left.Kind == shimast.KindTypeOfExpression {
-    literal = right
-  } else if right.Kind == shimast.KindTypeOfExpression {
-    literal = left
-  } else {
+  // `isLiteral(right, 'undefined')` matches an ESTree Literal only. A
+  // NoSubstitutionTemplateLiteral is a TemplateLiteral, so it never matches.
+  if expr.Right.Kind != shimast.KindStringLiteral {
     return
   }
-  if stringLiteralText(literal) != "undefined" {
+  if lit := expr.Right.AsStringLiteral(); lit == nil || lit.Text != "undefined" {
     return
   }
-  ctx.Report(node, "Compare with `undefined` directly instead of using `typeof`.")
+
+  typeofExpr := expr.Left.AsTypeOfExpression()
+  if typeofExpr == nil || typeofExpr.Expression == nil {
+    return
+  }
+  // Parentheses are elided in ESTree, so `typeof (foo)` reads through to `foo`
+  // for the global-identifier test.
+  operand := stripParens(typeofExpr.Expression)
+  isGlobal := unicornNoTypeofUndefinedIsGlobal(ctx, operand)
+  if isGlobal && !options.checkGlobalVariables {
+    return
+  }
+
+  text := ctx.File.Text()
+  typeofStart := shimscanner.SkipTrivia(text, expr.Left.Pos())
+  const typeofKeyword = "typeof"
+  typeofEnd := typeofStart + len(typeofKeyword)
+  if typeofStart < 0 || typeofEnd > len(text) || text[typeofStart:typeofEnd] != typeofKeyword {
+    return
+  }
+
+  const message = "Compare with `undefined` directly instead of using `typeof`."
+  edits, safe := unicornNoTypeofUndefinedFix(text, expr, typeofExpr, typeofStart, typeofEnd)
+  if !safe {
+    ctx.ReportRange(typeofStart, typeofEnd, message)
+    return
+  }
+  if isGlobal {
+    // Reachable only under checkGlobalVariables. Rewriting a global can throw,
+    // so upstream advertises an opt-in suggestion rather than an autofix.
+    ctx.ReportRangeSuggestion(
+      typeofStart,
+      typeofEnd,
+      message,
+      unicornNoTypeofUndefinedSuggestionTitle(expr.OperatorToken.Kind),
+      edits...,
+    )
+    return
+  }
+  ctx.ReportRangeFix(typeofStart, typeofEnd, message, edits...)
+}
+
+// decodeUnicornNoTypeofUndefinedOptions parses the `checkGlobalVariables`
+// option. An absent payload keeps the upstream default (false); an unknown key,
+// a non-object payload, or a non-boolean value is rejected so a malformed
+// config fails loudly instead of silently defaulting.
+func decodeUnicornNoTypeofUndefinedOptions(raw json.RawMessage) (unicornNoTypeofUndefinedOptions, error) {
+  options := unicornNoTypeofUndefinedOptions{}
+  trimmed := bytes.TrimSpace(raw)
+  if len(trimmed) == 0 {
+    return options, nil
+  }
+  if trimmed[0] != '{' {
+    return options, errors.New("options must be an object")
+  }
+  var rawFields map[string]json.RawMessage
+  if err := json.Unmarshal(trimmed, &rawFields); err != nil {
+    return options, fmt.Errorf("options must be an object: %w", err)
+  }
+  for name := range rawFields {
+    if name != "checkGlobalVariables" {
+      return options, fmt.Errorf("unknown option %q", name)
+    }
+  }
+  if value, ok := rawFields["checkGlobalVariables"]; ok {
+    if bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+      return options, errors.New(`option "checkGlobalVariables" must be a boolean`)
+    }
+    if err := json.Unmarshal(value, &options.checkGlobalVariables); err != nil {
+      return options, fmt.Errorf(`option "checkGlobalVariables" must be a boolean: %w`, err)
+    }
+  }
+  return options, nil
+}
+
+// unicornNoTypeofUndefinedIsGlobal ports upstream's `isGlobalIdentifier`: an
+// identifier that resolves to no local binding — either unresolved (an implicit
+// global) or declared only outside this file (a lib/ambient global). Any other
+// operand shape (member access, call, `this`, a literal) is never a global
+// identifier and returns false so it stays checked.
+func unicornNoTypeofUndefinedIsGlobal(ctx *Context, operand *shimast.Node) bool {
+  if operand == nil || operand.Kind != shimast.KindIdentifier {
+    return false
+  }
+  symbol := ctx.Checker.GetSymbolAtLocation(operand)
+  if symbol == nil {
+    return true
+  }
+  for _, declaration := range symbol.Declarations {
+    if declaration == nil {
+      continue
+    }
+    if shimast.GetSourceFileOfNode(declaration) == ctx.File {
+      return false
+    }
+  }
+  return true
+}
+
+// unicornNoTypeofUndefinedFix builds the upstream autofix edits and reports
+// whether they are safe to apply. The three edits — remove `typeof` plus the
+// whitespace after it, upgrade `==`/`!=`, and replace the literal — reproduce
+// upstream's non-hazard rewrite. Removing the leading `typeof` is declined
+// (safe=false) when the operand sits on a different line than `typeof` or
+// begins with an ASI-continuation character, the two shapes where upstream
+// instead emits a guarding `;` or wrapping parentheses.
+func unicornNoTypeofUndefinedFix(
+  text string,
+  expr *shimast.BinaryExpression,
+  typeofExpr *shimast.TypeOfExpression,
+  typeofStart, typeofEnd int,
+) ([]TextEdit, bool) {
+  operandStart := shimscanner.SkipTrivia(text, typeofExpr.Expression.Pos())
+  if operandStart < typeofEnd || operandStart >= len(text) {
+    return nil, false
+  }
+  // (A) A line break between `typeof` and its operand (a newline or a
+  // multi-line comment) risks ASI once `typeof` is gone, notably inside a
+  // `return`/`throw` argument.
+  if bytes.ContainsAny([]byte(text[typeofEnd:operandStart]), "\n\r") {
+    return nil, false
+  }
+  // (B) An operand that begins with a continuation character could merge with a
+  // preceding token: `foo⏎typeof [] === "undefined"` would become `foo⏎[] ===
+  // undefined`, i.e. `foo[]`.
+  switch text[operandStart] {
+  case '[', '(', '`', '+', '-', '*', '/', ',', '.':
+    return nil, false
+  }
+
+  edits := make([]TextEdit, 0, 3)
+  // Drop `typeof` and the whitespace run that follows it, mirroring
+  // `fixer.remove(typeofToken)` + `removeSpacesAfter(typeofToken)`. The run
+  // stops at the operand or an intervening comment, so a same-line comment is
+  // preserved rather than deleted.
+  removeEnd := typeofEnd
+  for removeEnd < len(text) && (text[removeEnd] == ' ' || text[removeEnd] == '\t') {
+    removeEnd++
+  }
+  edits = append(edits, TextEdit{Pos: typeofStart, End: removeEnd, Text: ""})
+
+  if expr.OperatorToken.Kind == shimast.KindEqualsEqualsToken ||
+    expr.OperatorToken.Kind == shimast.KindExclamationEqualsToken {
+    edits = append(edits, TextEdit{
+      Pos:  expr.OperatorToken.End(),
+      End:  expr.OperatorToken.End(),
+      Text: "=",
+    })
+  }
+
+  literalStart := shimscanner.SkipTrivia(text, expr.Right.Pos())
+  edits = append(edits, TextEdit{Pos: literalStart, End: expr.Right.End(), Text: "undefined"})
+  return edits, true
+}
+
+// unicornNoTypeofUndefinedSuggestionTitle renders upstream's suggestion label,
+// whose operator is `!==` for a negated comparison and `===` otherwise.
+func unicornNoTypeofUndefinedSuggestionTitle(operator shimast.Kind) string {
+  replacement := "==="
+  if operator == shimast.KindExclamationEqualsEqualsToken ||
+    operator == shimast.KindExclamationEqualsToken {
+    replacement = "!=="
+  }
+  return "Switch to `… " + replacement + " undefined`."
 }
 
 func init() {

--- a/packages/lint/test/rules/unicorn/unicorn_no_typeof_undefined_check_global_variables_option_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_typeof_undefined_check_global_variables_option_test.go
@@ -1,0 +1,90 @@
+package linthost
+
+import (
+  "encoding/json"
+  "sort"
+  "testing"
+)
+
+// TestUnicornNoTypeofUndefinedCheckGlobalVariablesOption verifies the
+// `checkGlobalVariables` option surfaces globals as opt-in suggestions, leaves
+// local bindings on the autofix path, and rejects malformed payloads.
+//
+// Upstream defaults the option to false and, when it is enabled, reports a
+// global with a suggestion (not an automatic fix) because rewriting an
+// undeclared global throws. The suggestion label carries `!==` for a negated
+// comparison and `===` otherwise. A local binding under the same option keeps
+// the automatic fix, proving the option only changes how globals are handled.
+// The negative twin — the option omitted, so the global is skipped entirely —
+// is the skips-upstream-valid-forms case; here the ValidateOptions branch is
+// pinned so a typo'd or non-boolean option fails loudly rather than silently
+// defaulting.
+//
+//  1. With checkGlobalVariables enabled, assert each global reports a
+//     suggestion (with edits, no fix) and the correct operator label.
+//  2. With the option enabled, assert a local binding still reports an autofix.
+//  3. Assert ValidateOptions accepts the boolean forms and rejects the rest.
+func TestUnicornNoTypeofUndefinedCheckGlobalVariablesOption(t *testing.T) {
+  const ruleName = "unicorn/no-typeof-undefined"
+  const message = "Compare with `undefined` directly instead of using `typeof`."
+  enabled := json.RawMessage(`{"checkGlobalVariables":true}`)
+
+  globalSource := `typeof globalThis === "undefined";
+typeof globalThis !== "undefined";
+`
+  _, _, globalFindings := runRuleFindingsSnapshot(t, ruleName, globalSource, enabled)
+  if len(globalFindings) != 2 {
+    t.Fatalf("expected 2 global findings, got %d: %+v", len(globalFindings), globalFindings)
+  }
+  sort.Slice(globalFindings, func(i, j int) bool { return globalFindings[i].Pos < globalFindings[j].Pos })
+  wantTitles := []string{
+    "Switch to `… === undefined`.",
+    "Switch to `… !== undefined`.",
+  }
+  for index, finding := range globalFindings {
+    if finding.Message != message || finding.Severity != SeverityError {
+      t.Fatalf("global finding %d identity mismatch: %+v", index, finding)
+    }
+    if len(finding.Fix) != 0 {
+      t.Fatalf("global finding %d must not carry an autofix: %+v", index, finding.Fix)
+    }
+    if len(finding.Suggestions) != 1 {
+      t.Fatalf("global finding %d must carry one suggestion: %+v", index, finding.Suggestions)
+    }
+    if finding.Suggestions[0].Title != wantTitles[index] {
+      t.Fatalf("global finding %d suggestion title: got %q want %q", index, finding.Suggestions[0].Title, wantTitles[index])
+    }
+    if len(finding.Suggestions[0].Edits) == 0 {
+      t.Fatalf("global finding %d suggestion must carry edits", index)
+    }
+  }
+
+  localSource := `let binding: unknown;
+typeof binding !== "undefined";
+`
+  _, _, localFindings := runRuleFindingsSnapshot(t, ruleName, localSource, enabled)
+  if len(localFindings) != 1 {
+    t.Fatalf("expected 1 local finding, got %d: %+v", len(localFindings), localFindings)
+  }
+  if len(localFindings[0].Fix) == 0 {
+    t.Fatalf("local finding must carry an autofix under checkGlobalVariables: %+v", localFindings[0])
+  }
+  if len(localFindings[0].Suggestions) != 0 {
+    t.Fatalf("local finding must not carry a suggestion: %+v", localFindings[0].Suggestions)
+  }
+
+  rule := LookupRule(ruleName)
+  if rule == nil {
+    t.Fatal("unicorn/no-typeof-undefined is not registered")
+  }
+  for _, accepted := range []string{"", `{"checkGlobalVariables":true}`, `{"checkGlobalVariables":false}`, `{}`} {
+    if err := validateRuleOptions(rule, json.RawMessage(accepted)); err != nil {
+      t.Fatalf("ValidateOptions rejected a valid payload %q: %v", accepted, err)
+    }
+  }
+  for _, rejected := range []string{`{"nope":true}`, `{"checkGlobalVariables":"yes"}`, `{"checkGlobalVariables":null}`, `[1,2]`, `"error"`} {
+    if err := validateRuleOptions(rule, json.RawMessage(rejected)); err == nil {
+      t.Fatalf("ValidateOptions accepted a malformed payload %q", rejected)
+    }
+  }
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_typeof_undefined_declines_unsafe_fix_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_typeof_undefined_declines_unsafe_fix_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import "testing"
+
+// TestUnicornNoTypeofUndefinedDeclinesUnsafeFix verifies the rule still reports
+// the ASI-hazard shapes but attaches no autofix, so the fix applier leaves the
+// source untouched.
+//
+// Removing the leading `typeof` can trigger Automatic Semicolon Insertion. An
+// operand that begins with a continuation character (`typeof [x] === …` after a
+// prior expression parses as `x[…]`) and an operand split onto a different line
+// from `typeof` (which would let `return` insert a semicolon before it) are the
+// two cases where a naive edit corrupts source. Upstream fixes them by inserting
+// a guarding `;` or wrapping parentheses; this port declines the edit instead,
+// so the diagnostic must still fire while the file stays byte-identical. The
+// safe twin — an identifier operand on the same line — is the fix-rewrites case.
+//
+//  1. Lint a source stacking an array-literal operand and a line-split operand,
+//     both bound so the global guard does not pre-empt the report.
+//  2. Run the disk-backed fix applier.
+//  3. Assert findings exist but nothing was rewritten.
+func TestUnicornNoTypeofUndefinedDeclinesUnsafeFix(t *testing.T) {
+  source := `declare const items: unknown[];
+declare const value: { deep: unknown };
+
+typeof [items] === "undefined";
+typeof
+value.deep === "undefined";
+`
+  assertNoFixSnapshot(t, "unicorn/no-typeof-undefined", source)
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_typeof_undefined_fix_rewrites_comparisons_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_typeof_undefined_fix_rewrites_comparisons_test.go
@@ -1,0 +1,38 @@
+package linthost
+
+import "testing"
+
+// TestUnicornNoTypeofUndefinedFixRewritesComparisons verifies the autofix drops
+// the `typeof`, strengthens loose equality, and rewrites the `"undefined"`
+// literal into the `undefined` identifier — byte for byte against the upstream
+// oracle.
+//
+// The fix is three token-scoped edits (remove `typeof` plus its trailing space,
+// upgrade `==`/`!=`, replace the literal), so any off-by-one corrupts source
+// silently: it would swallow a space, leave the loose operator, or mangle the
+// literal. `===`/`!==` keep the operator untouched while `==`/`!=` gain the
+// third `=`; an identifier operand and a member-access operand both reduce to a
+// bare comparison. The expected output is upstream's fixed source, not this
+// port's own emission.
+//
+//  1. Lint a source stacking `===`, `!==`, `==`, and `!=` over identifier and
+//     member-access operands bound in the same file.
+//  2. Apply the collected fixes through the real disk-backed fix applier.
+//  3. Assert the rewritten file byte for byte.
+func TestUnicornNoTypeofUndefinedFixRewritesComparisons(t *testing.T) {
+  source := `declare const value: { deep: unknown };
+
+typeof value === "undefined";
+typeof value !== "undefined";
+typeof value.deep == "undefined";
+typeof value.deep != "undefined";
+`
+  expected := `declare const value: { deep: unknown };
+
+value === undefined;
+value !== undefined;
+value.deep === undefined;
+value.deep !== undefined;
+`
+  assertFixSnapshot(t, "unicorn/no-typeof-undefined", source, expected)
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_typeof_undefined_skips_upstream_valid_forms_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_typeof_undefined_skips_upstream_valid_forms_test.go
@@ -1,0 +1,52 @@
+package linthost
+
+import "testing"
+
+// TestUnicornNoTypeofUndefinedSkipsUpstreamValidForms verifies the negative
+// twin of every reporting surface: the forms upstream lists as valid must
+// produce zero findings.
+//
+// Each guard has a way to over-match. The `typeof` must be the LEFT operand, so
+// the reversed `"undefined" === typeof a.b` is skipped; the right side must be a
+// string Literal, so a template literal and an identifier are skipped; the value
+// must be `"undefined"`, so `"string"` is skipped; the operator must be an
+// equality, so `>` is skipped; a non-`typeof` left (`void`, unary `+`, `++`,
+// postfix `++`, a bare member) never matches; and a global operand is skipped by
+// default because rewriting `typeof window === "undefined"` to `window ===
+// undefined` throws a ReferenceError when the global is undeclared. `window`,
+// `globalThis`, and an undeclared `foo` cover the resolved-lib-global and
+// unresolved-implicit-global branches of that guard.
+//
+//  1. Enable unicorn/no-typeof-undefined on one source stacking every
+//     upstream-valid shape.
+//  2. Run the checker-backed snapshot path.
+//  3. Assert the rule reports nothing.
+func TestUnicornNoTypeofUndefinedSkipsUpstreamValidForms(t *testing.T) {
+  source := "declare const a: { b: unknown };\n" +
+    "const UNDEFINED = \"undefined\";\n" +
+    "\n" +
+    "// The `typeof` must be the left operand.\n" +
+    "\"undefined\" === typeof a.b;\n" +
+    "// A template literal is a TemplateLiteral, never a string Literal.\n" +
+    "typeof a.b === `undefined`;\n" +
+    "// The right operand is a string, but not \"undefined\".\n" +
+    "typeof a.b === \"string\";\n" +
+    "// The right operand is an identifier, not a literal.\n" +
+    "typeof a.b === UNDEFINED;\n" +
+    "// A relational operator is not an equality comparison.\n" +
+    "typeof a.b > \"undefined\";\n" +
+    "// No `typeof` on the left.\n" +
+    "a.b === \"undefined\";\n" +
+    "void a.b === \"undefined\";\n" +
+    "+a.b === \"undefined\";\n" +
+    "++a.b === \"undefined\";\n" +
+    "a.b++ === \"undefined\";\n" +
+    "foo === undefined;\n" +
+    "// A bare `typeof` with no comparison.\n" +
+    "typeof a.b;\n" +
+    "// Globals are skipped by default: rewriting them can throw.\n" +
+    "typeof foo === \"undefined\";\n" +
+    "typeof window === \"undefined\";\n" +
+    "typeof globalThis === \"undefined\";\n"
+  assertRuleSkipsSource(t, "unicorn/no-typeof-undefined", source)
+}

--- a/packages/lint/test/rules/unicorn/unicorn_no_typeof_undefined_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_no_typeof_undefined_test.go
@@ -1,20 +1,83 @@
 package linthost
 
-import "testing"
+import (
+  "sort"
+  "strings"
+  "testing"
+)
 
-// TestRuleCorpusUnicornNoTypeofUndefined verifies unicorn/no-typeof-undefined
-// reports `typeof x === "undefined"`.
+// TestRuleCorpusUnicornNoTypeofUndefined verifies every upstream-invalid
+// `typeof <local> <op> "undefined"` comparison reports at the `typeof` keyword,
+// with the upstream message and an attached autofix.
 //
-// This fixture pins the strict-equality branch with the typeof on the left and
-// the "undefined" literal on the right — the most common shape and the
-// canonical positive case for the rule. The match is purely structural, so a
-// stand-alone expression statement over `globalThis` is enough to exercise the
-// core detection without dragging in declared bindings that would shift the
-// expect-annotation target line.
+// Upstream matches only when the `typeof` is the left operand of an equality
+// comparison whose right side is the string literal `"undefined"`, and skips
+// globals by default because rewriting them can throw. Pinning all four
+// equality operators over a `let`, a `const`, a `var`, and a member-access
+// operand locks the checker-backed "has a local binding" branch (a name-only
+// match would collude with the skipped global forms) and the diagnostic range,
+// which upstream anchors to the `typeof` keyword rather than the whole
+// comparison. The negative twin — every upstream-valid shape — lives in the
+// skips-upstream-valid-forms case.
 //
-// 1. Enable unicorn/no-typeof-undefined via an expect annotation.
-// 2. Compare `typeof globalThis === "undefined"` against the literal.
-// 3. Assert the binary expression is reported.
+//  1. Enable unicorn/no-typeof-undefined on one source stacking the reporting
+//     shapes, each operand a binding declared in the same file.
+//  2. Run the checker-backed snapshot path.
+//  3. Assert one finding per `typeof`, at the keyword range, with the message,
+//     a non-empty fix, and no suggestion.
 func TestRuleCorpusUnicornNoTypeofUndefined(t *testing.T) {
-  assertRuleCorpusCase(t, "unicorn/no-typeof-undefined.ts", "// expect: unicorn/no-typeof-undefined error\ntypeof globalThis === \"undefined\";\n")
+  const ruleName = "unicorn/no-typeof-undefined"
+  source := `declare const object: { property: unknown };
+let mutableBinding: unknown;
+const constantBinding: unknown = object;
+var hoistedBinding: unknown;
+
+typeof mutableBinding === "undefined";
+typeof constantBinding !== "undefined";
+typeof hoistedBinding == "undefined";
+typeof object.property != "undefined";
+`
+  const keyword = "typeof"
+  starts := make([]int, 0)
+  for offset := 0; ; {
+    index := strings.Index(source[offset:], keyword+" ")
+    if index < 0 {
+      break
+    }
+    starts = append(starts, offset+index)
+    offset = offset + index + len(keyword)
+  }
+  if len(starts) != 4 {
+    t.Fatalf("test wiring: expected 4 typeof operands, found %d", len(starts))
+  }
+
+  _, _, findings := runRuleFindingsSnapshot(t, ruleName, source, nil)
+  if len(findings) != len(starts) {
+    t.Fatalf("expected %d findings, got %d: %+v", len(starts), len(findings), findings)
+  }
+  sort.Slice(findings, func(i, j int) bool { return findings[i].Pos < findings[j].Pos })
+
+  const message = "Compare with `undefined` directly instead of using `typeof`."
+  for index, finding := range findings {
+    start := starts[index]
+    if finding.Rule != ruleName || finding.Severity != SeverityError {
+      t.Fatalf("finding %d identity mismatch: %+v", index, finding)
+    }
+    if finding.Pos != start || finding.End != start+len(keyword) {
+      t.Fatalf(
+        "finding %d range: got=[%d,%d) want=[%d,%d) (%q)",
+        index, finding.Pos, finding.End, start, start+len(keyword),
+        source[start:start+len(keyword)],
+      )
+    }
+    if finding.Message != message {
+      t.Fatalf("finding %d message: got %q want %q", index, finding.Message, message)
+    }
+    if len(finding.Fix) == 0 {
+      t.Fatalf("finding %d must carry an autofix", index)
+    }
+    if len(finding.Suggestions) != 0 {
+      t.Fatalf("finding %d must not carry suggestions: %+v", index, finding.Suggestions)
+    }
+  }
 }

--- a/tests/test-lint/src/cases/unicorn-no-typeof-undefined.ts
+++ b/tests/test-lint/src/cases/unicorn-no-typeof-undefined.ts
@@ -1,2 +1,20 @@
-// expect: unicorn/no-typeof-undefined error
+// Regression corpus for unicorn/no-typeof-undefined. Upstream treats global
+// operands, reversed operands, and template-literal operands as valid; only a
+// `typeof <local> === "undefined"` comparison fires.
+declare const value: { deep: unknown };
+
+// Valid: rewriting a global to `window === undefined` throws a ReferenceError
+// when the global is undeclared, so globals are skipped by default.
+typeof window === "undefined";
 typeof globalThis === "undefined";
+
+// Valid: the `typeof` must be the left operand.
+"undefined" === typeof value.deep;
+
+// Valid: a template literal is a TemplateLiteral, not a string literal.
+typeof value.deep === `undefined`;
+
+// A binding declared in this file is not a global, so it is reported.
+let bar: unknown;
+// expect: unicorn/no-typeof-undefined error
+typeof bar === "undefined";

--- a/website/src/content/docs/lint/rules/unicorn.mdx
+++ b/website/src/content/docs/lint/rules/unicorn.mdx
@@ -1056,11 +1056,16 @@ class C {
 
 Reject `typeof x === "undefined"`; compare against `undefined` directly.
 
+Only a `typeof` on the left of an equality comparison (`===`, `==`, `!==`, `!=`) against the string literal `"undefined"` is reported. A reversed `"undefined" === typeof x`, a template-literal operand (`` typeof x === `undefined` ``), and a global operand are all left alone, matching upstream: rewriting `typeof window === "undefined"` to `window === undefined` throws a `ReferenceError` when the global is undeclared. A global here means an identifier that resolves to no local binding. Enable `checkGlobalVariables` to also check global operands, which are then offered an opt-in suggestion rather than an automatic fix.
+
+The autofix removes the `typeof`, upgrades `==` / `!=` to their strict form, and replaces the literal, but declines rather than risk an incorrect edit when removing `typeof` could trigger Automatic Semicolon Insertion (the operand starts on a different line, or begins with a character that could merge with the preceding token).
+
 Example:
 
 ```ts
+let value: unknown;
 // reports: unicorn/no-typeof-undefined (error)
-typeof globalThis === "undefined";
+typeof value === "undefined";
 ```
 
 <a id="rule-unicorn-no-unnecessary-array-flat-depth"></a>


### PR DESCRIPTION
## Intent

Fixes #595. `unicorn/no-typeof-undefined` fired on three shapes upstream treats as **valid**, making the rule unusable (it flagged `typeof window === "undefined"`, the canonical SSR guard). Its own corpus fixture even pinned an upstream-valid `typeof globalThis` as an expected error.

## Root cause

The old detection accepted the `typeof` on **either** side, accepted a `NoSubstitutionTemplateLiteral` operand (via `stringLiteralText`), and had **no global guard**.

## Scope

Verified against the upstream source (`eslint-plugin-unicorn/rules/no-typeof-undefined.js`). The rule now matches upstream exactly:

- `typeof` must be the **left** operand of `===` / `==` / `!==` / `!=`;
- the right operand must be a string **Literal** valued `undefined` (a template literal is a `TemplateLiteral`, never a `Literal`);
- a **global** operand (an identifier that resolves to no local binding, via `ctx.Checker`) is skipped unless the new `checkGlobalVariables` option is set, because rewriting an undeclared global throws a `ReferenceError`.

The rule is now checker-backed (`NeedsTypeChecker`). The autofix (drop `typeof`, strengthen `==`/`!=`, replace the literal) is ported and anchored at the `typeof` keyword like upstream. Under `checkGlobalVariables`, a global is offered the edits as an opt-in **suggestion** rather than an automatic fix, matching upstream.

## Deferred / deliberate

- **ASI hazards.** Removing the leading `typeof` can trigger Automatic Semicolon Insertion. Where upstream inserts a guarding `;` or wrapping parentheses (operand on a different line than `typeof`, or beginning with a continuation character), this port conservatively **declines the autofix** (the diagnostic still reports) rather than risk a corrupting edit.
- **Typed option surface.** The `checkGlobalVariables` option is decoded and validated at runtime but is not added to the typed `ITtscLint*` structures (out of scope for this change); it is settable through `lint.config.json`.

## Test plan

- Replaced the inverted corpus fixture; added checker-backed Go tests: the reporting positive (ranges/message/fix at the `typeof` keyword), the full upstream **valid** list as its negative twin, the fix oracle (`===`/`==`/`!==`/`!=`), the option gate + `ValidateOptions`, and the ASI-hazard decline.
- `node scripts/test-go-lint.cjs` — full `packages/lint` Go suite green.
- Updated the `tests/test-lint` e2e fixture and the `unicorn.mdx` rule section; e2e validated on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Giu15S7hyRxpupc1XwXe89