### PR TITLE
fix(lint): no-useless-escape tagged-template nesting (#604) and v-flag class escapes (#607)

### DIFF
--- a/packages/lint/linthost/ast_helpers.go
+++ b/packages/lint/linthost/ast_helpers.go
@@ -184,6 +184,32 @@ func isTaggedTemplateElement(node *shimast.Node) bool {
   return tagged != nil && tagged.Template == template
 }
 
+// isInsideTaggedTemplate reports whether a whole-template node — a
+// `KindNoSubstitutionTemplateLiteral` or a `KindTemplateExpression` — sits
+// anywhere inside a TaggedTemplateExpression, walking up to three ancestors so
+// a template reached through a substitution span also answers true. Unlike the
+// precise `isTaggedTemplateElement`, which asks only whether a template token's
+// OWN enclosing template is tagged, this treats any enclosing tag as tainting.
+// Used by `typescript/no-unnecessary-template-expression`.
+func isInsideTaggedTemplate(node *shimast.Node) bool {
+  if node == nil || node.Parent == nil {
+    return false
+  }
+  parent := node.Parent
+  if parent.Kind == shimast.KindTaggedTemplateExpression {
+    return true
+  }
+  // Walk up at most two more hops to reach the TaggedTemplateExpression
+  // for the spans family.
+  for i := 0; i < 2 && parent.Parent != nil; i++ {
+    parent = parent.Parent
+    if parent.Kind == shimast.KindTaggedTemplateExpression {
+      return true
+    }
+  }
+  return false
+}
+
 // hasCommentBetween reports whether a comment begins anywhere in the source
 // range [from, to). Fixers whose TextEdit keeps only part of the replaced
 // span use it on the discarded sub-ranges: a comment there would be silently

--- a/packages/lint/linthost/rules_escape.go
+++ b/packages/lint/linthost/rules_escape.go
@@ -86,6 +86,16 @@ const templateValidEscapes = "`'\"\\bfnrtv0xuU$\n\r"
 const regexNonClassValidEscapes = "^$\\.*+?()[]{}|/-\n\r"
 const regexClassValidEscapes = "\\]-^\n\r"
 
+// regexClassSetValidEscapes is the in-class allowlist for a `v`-flag
+// (unicodeSets) regex. There the ClassSetSyntaxCharacters `( ) [ ] { } / | -`
+// stay meaningful inside `[...]`, so a backslash before them is load-bearing:
+// stripping it (e.g. `/[\(]/v` → `/[(]/v`) turns valid source into a
+// `SyntaxError: Invalid character in character class`. Mirrors ESLint's
+// REGEX_CLASSSET_CHARACTER_ESCAPES; its `q` (from `\q{…}`) is handled with the
+// other shorthand letters in `isUselessRegexEscape`. `]` and `-` already sit
+// in the base set above.
+const regexClassSetValidEscapes = regexClassValidEscapes + "()[{}|/"
+
 // reportStringEscapes walks the raw source bytes of a string or template
 // literal and reports each backslash whose following character is not in
 // `whitelist`. `base` is the source offset of `raw[0]` so reported ranges
@@ -152,7 +162,9 @@ func reportStringEscapes(ctx *Context, raw string, base int, whitelist string, i
 
 // reportRegexEscapes walks the pattern body of a regex literal and reports
 // backslashes that escape non-special characters. `base` is the source offset
-// of `raw[0]`. Character-class context (`[…]`) widens the legal set slightly.
+// of `raw[0]`. Character-class context (`[…]`) widens the legal set slightly,
+// and the trailing `v` (unicodeSets) flag widens it further because more
+// punctuation is meaningful inside a class in that mode.
 func reportRegexEscapes(ctx *Context, raw string, base int) {
   if len(raw) < 3 || raw[0] != '/' {
     return
@@ -164,6 +176,12 @@ func reportRegexEscapes(ctx *Context, raw string, base int) {
     return
   }
   body := raw[1:closing]
+  // Flags follow the closing slash. The `v` (unicodeSets) flag promotes the
+  // ClassSetSyntaxCharacters to meaningful members of a character class, so
+  // their escapes must be preserved there; deleting one corrupts the source.
+  // Mirrors ESLint selecting REGEX_CLASSSET_CHARACTER_ESCAPES over
+  // REGEX_GENERAL_ESCAPES on that flag.
+  unicodeSets := strings.IndexByte(raw[closing+1:], 'v') >= 0
   inClass := false
   for i := 0; i < len(body); i++ {
     ch := body[i]
@@ -179,7 +197,7 @@ func reportRegexEscapes(ctx *Context, raw string, base int) {
       continue
     }
     next := body[i+1]
-    if isUselessRegexEscape(next, inClass) {
+    if isUselessRegexEscape(next, inClass, unicodeSets) {
       // base + 1 (for the leading `/`) + i is the byte offset of the
       // backslash in the source.
       pos := base + 1 + i
@@ -241,12 +259,18 @@ func isUselessStringEscape(ch byte, whitelist string) bool {
 // character class, which narrows the set of meaningful meta-char escapes:
 // most regex meta-chars (`.`, `*`, `+`, `?`, `(`, `)`, `{`, `}`, `|`, `^`,
 // `$`, `/`) are literal inside a class, so escaping them there is noise.
-func isUselessRegexEscape(ch byte, inClass bool) bool {
+// `unicodeSets` is true for a `v`-flag regex, where the ClassSetSyntaxCharacters
+// regain meaning inside a class and their escapes are therefore required.
+func isUselessRegexEscape(ch byte, inClass, unicodeSets bool) bool {
   if ch < 0x20 {
     return false
   }
   if inClass {
-    if strings.IndexByte(regexClassValidEscapes, ch) >= 0 {
+    classEscapes := regexClassValidEscapes
+    if unicodeSets {
+      classEscapes = regexClassSetValidEscapes
+    }
+    if strings.IndexByte(classEscapes, ch) >= 0 {
       return false
     }
   } else if strings.IndexByte(regexNonClassValidEscapes, ch) >= 0 {

--- a/packages/lint/linthost/rules_escape.go
+++ b/packages/lint/linthost/rules_escape.go
@@ -38,8 +38,11 @@ func (noUselessEscape) Check(ctx *Context, node *shimast.Node) {
   // Tagged templates expose the raw bytes of the template to the tag
   // function (`String.raw`, `dedent`, `gql`, `css`, …), so a backslash
   // that looks redundant to the JS lexer is meaningful at the tag
-  // boundary. ESLint canonical skips tagged templates entirely.
-  if isInsideTaggedTemplate(node) {
+  // boundary. ESLint canonical skips a tagged template's own quasis, but a
+  // literal merely nested inside a tag's substitution is not itself tagged
+  // and stays checked — so this consults the literal's OWN enclosing
+  // template, not any ancestor tag.
+  if isTaggedTemplateElement(node) {
     return
   }
   // tsgo's `node.Pos()` points at the start of leading trivia; the regex
@@ -270,33 +273,6 @@ func isUselessRegexEscape(ch byte, inClass bool) bool {
     }
   }
   return true
-}
-
-// isInsideTaggedTemplate reports whether `node` is the template payload of
-// a TaggedTemplateExpression. Two AST shapes reach here:
-//
-//   - `KindNoSubstitutionTemplateLiteral` — the direct child of a
-//     TaggedTemplateExpression's Template slot.
-//   - `KindTemplateHead/Middle/Tail` — wrapped in TemplateSpan and
-//     TemplateExpression nodes; the TemplateExpression's parent is the
-//     TaggedTemplateExpression.
-func isInsideTaggedTemplate(node *shimast.Node) bool {
-  if node == nil || node.Parent == nil {
-    return false
-  }
-  parent := node.Parent
-  if parent.Kind == shimast.KindTaggedTemplateExpression {
-    return true
-  }
-  // Walk up at most two more hops to reach the TaggedTemplateExpression
-  // for the spans family.
-  for i := 0; i < 2 && parent.Parent != nil; i++ {
-    parent = parent.Parent
-    if parent.Kind == shimast.KindTaggedTemplateExpression {
-      return true
-    }
-  }
-  return false
 }
 
 func init() {

--- a/packages/lint/test/rules/strings-regex/no_useless_escape_nested_untagged_template_in_tagged_substitution_test.go
+++ b/packages/lint/test/rules/strings-regex/no_useless_escape_nested_untagged_template_in_tagged_substitution_test.go
@@ -1,0 +1,62 @@
+package linthost
+
+import "testing"
+
+// TestNoUselessEscapeNestedUntaggedTemplateInTaggedSubstitution verifies the
+// rule reports a useless escape in an untagged literal nested inside a tagged
+// template's substitution.
+//
+// Pins issue #604: the tagged-template guard used to walk up to three ancestors
+// for ANY TaggedTemplateExpression, so a literal nested in a tag's substitution
+// was wrongly treated as tagged. The guard must instead consult the literal's
+// OWN enclosing template (`isTaggedTemplateElement`). A tag only observes the
+// raw bytes of its own quasis; a literal inside `${…}` is an ordinary
+// expression the tag never sees raw, so its escapes are still noise.
+//
+//  1. Lint the issue's five-row matrix plus a nested string-literal control.
+//  2. Assert each untagged literal (rows a, b, d, e, plus the string control)
+//     reports exactly the backslash byte, while the directly-tagged row f
+//     stays silent.
+func TestNoUselessEscapeNestedUntaggedTemplateInTaggedSubstitution(t *testing.T) {
+  backslash := []string{"\\"}
+  cases := []struct {
+    name    string
+    source  string
+    markers []string
+  }{
+    {
+      name:    "a: plain string literal",
+      source:  "const a = \"\\a\";\n",
+      markers: backslash,
+    },
+    {
+      name:    "b: untagged no-substitution template",
+      source:  "const b = `\\a`;\n",
+      markers: backslash,
+    },
+    {
+      name:    "d: untagged inner template in an untagged outer template",
+      source:  "const d = `x${`\\a`}y`;\n",
+      markers: backslash,
+    },
+    {
+      name:    "e: untagged inner template in a tagged outer template",
+      source:  "const e = String.raw`x${`\\a`}y`;\n",
+      markers: backslash,
+    },
+    {
+      name:   "f: tagged no-substitution template stays silent",
+      source: "const f = String.raw`\\a`;\n",
+    },
+    {
+      name:    "string literal nested in a tagged substitution",
+      source:  "const g = String.raw`${\"\\a\"}`;\n",
+      markers: backslash,
+    },
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      assertRuleFindingRanges(t, "no-useless-escape", test.source, test.markers...)
+    })
+  }
+}

--- a/packages/lint/test/rules/strings-regex/no_useless_escape_v_flag_class_preserves_syntax_char_escapes_test.go
+++ b/packages/lint/test/rules/strings-regex/no_useless_escape_v_flag_class_preserves_syntax_char_escapes_test.go
@@ -1,0 +1,53 @@
+package linthost
+
+import "testing"
+
+// TestNoUselessEscapeVFlagClassPreservesSyntaxCharEscapes verifies the rule
+// leaves ClassSetSyntaxCharacter escapes inside a `v`-flag regex character
+// class untouched.
+//
+// Pins issue #607: the in-class allowlist was flag-blind, so the autofix
+// deleted the load-bearing backslash in `/[\(]/v`, producing `/[(]/v` — a
+// `SyntaxError: Invalid character in character class`. In `v` (unicodeSets)
+// mode `( ) [ ] { } / | -` stay meaningful inside `[...]`, so their escapes are
+// required; ESLint switches to REGEX_CLASSSET_CHARACTER_ESCAPES on that flag.
+// The negative twins prove the fix stayed narrow: a `u`-flag class still strips
+// `\(` (a bare `(` is legal there), and a genuinely useless `v`-mode escape
+// (`\a`) is still reported and removed rather than blanket-skipped.
+//
+//  1. Assert every ClassSetSyntaxCharacter escape in a `v`-flag class reports
+//     nothing (no finding, no corrupting fix).
+//  2. Assert the `u`-flag twin still fixes `/[\(]/u` to `/[(]/u`.
+//  3. Assert a useless `v`-mode escape `/[\a]/v` still fixes to `/[a]/v`.
+func TestNoUselessEscapeVFlagClassPreservesSyntaxCharEscapes(t *testing.T) {
+  // `( ) [ { } | /` gain meaning only through the `v` flag; `]` and `-` are
+  // meaningful in any character class and are covered by the base allowlist.
+  for _, ch := range []string{"(", ")", "[", "{", "}", "|", "/"} {
+    source := "const re = /[\\" + ch + "]/v;\n"
+    t.Run("v-flag keeps \\"+ch, func(t *testing.T) {
+      assertRuleSkipsSource(t, "no-useless-escape", source)
+    })
+  }
+
+  // u-mode: `(` in a character class is legal, so the escape is still useless
+  // and the fix must still strip it.
+  t.Run("u-flag class still strips redundant paren escape", func(t *testing.T) {
+    assertFixSnapshot(
+      t,
+      "no-useless-escape",
+      "const re = /[\\(]/u;\n",
+      "const re = /[(]/u;\n",
+    )
+  })
+
+  // v-mode is not a blanket skip: an escape that is useless even under
+  // unicodeSets (`\a`) is still reported and removed.
+  t.Run("v-flag class still strips a genuinely useless escape", func(t *testing.T) {
+    assertFixSnapshot(
+      t,
+      "no-useless-escape",
+      "const re = /[\\a]/v;\n",
+      "const re = /[a]/v;\n",
+    )
+  })
+}

--- a/tests/test-lint/src/cases/no-useless-escape.ts
+++ b/tests/test-lint/src/cases/no-useless-escape.ts
@@ -1,3 +1,19 @@
 // expect: no-useless-escape error
 const value = "ab\cdef";
 JSON.stringify(value);
+
+/**
+ * Verifies no-useless-escape reports a useless escape in an untagged template
+ * nested inside a tagged template's substitution (issue #604).
+ *
+ * `String.raw` only observes its own quasis raw; the inner no-substitution
+ * template is an ordinary expression the tag never sees raw, so its redundant
+ * escape is still flagged rather than skipped as if it were tagged.
+ *
+ * 1. Nest an untagged template carrying a `\a` escape inside a `String.raw`
+ *    substitution.
+ * 2. Assert the inner escape is flagged.
+ */
+// expect: no-useless-escape error
+const nested = String.raw`x${`\a`}y`;
+JSON.stringify(nested);

--- a/tests/test-lint/src/cases/regexp-no-useless-escape.ts
+++ b/tests/test-lint/src/cases/regexp-no-useless-escape.ts
@@ -11,4 +11,23 @@
 // expect: regexp/no-useless-escape error
 const escape = /\a/;
 
-JSON.stringify(escape);
+/**
+ * Verifies regexp/no-useless-escape leaves a `v`-flag character-class escape
+ * intact (issue #607).
+ *
+ * Under the `v` (unicodeSets) flag `(` is a ClassSetSyntaxCharacter, so `\(`
+ * inside `[...]` is load-bearing; stripping it would rewrite the source to
+ * `/[(]/v`, a `SyntaxError: Invalid character in character class`. No
+ * diagnostic is expected on this line.
+ */
+const unicodeSetsClass = /[\(]/v;
+
+/**
+ * The `u`-flag twin still reports: a bare `(` in a character class is legal in
+ * `u` mode, so `\(` there is a genuinely useless escape and the autofix must
+ * still strip it.
+ */
+// expect: regexp/no-useless-escape error
+const unicodeClass = /[\(]/u;
+
+JSON.stringify([escape, unicodeSetsClass, unicodeClass]);


### PR DESCRIPTION
Two grouped `no-useless-escape` bug fixes; both rewrite `packages/lint/linthost/rules_escape.go`, so they ship on one branch as one PR (one commit per issue).

## #604 — misses a useless escape in an untagged template nested in a tagged template's substitution

The rule's tagged-template guard (`isInsideTaggedTemplate`) walked up to three ancestors for **any** `TaggedTemplateExpression`, so a literal nested inside a tag's substitution — e.g. the inner `` `\a` `` in `` String.raw`x${`\a`}y` `` — was wrongly treated as tagged and skipped. A tag only observes the raw bytes of its own quasis; a literal inside `${…}` is an ordinary expression the tag never sees raw, so its redundant escapes are still noise.

Consolidated onto the precise `isTaggedTemplateElement` (asks only whether the literal's own enclosing template is tagged) and moved the broad `isInsideTaggedTemplate` into `ast_helpers.go` beside the other tagged-template helpers. `isInsideTaggedTemplate` is unchanged and still backs `typescript/no-unnecessary-template-expression`, so no other rule's behavior moves. The fix also seals the same root cause for string/regex literals nested in a tag's substitution.

## #607 — autofix deletes required escapes inside a `v`-flag character class (source corruption)

`reportRegexEscapes` read the regex body but never the trailing flags, and its in-class allowlist was flag-blind. Inside a `v` (unicodeSets) character class the ClassSetSyntaxCharacters `( ) [ ] { } / | -` stay meaningful, so deleting a backslash there corrupts the source: `/[\(]/v` became `/[(]/v`, a `SyntaxError: Invalid character in character class`. The shared `reportRegexEscapes` backs both `no-useless-escape` and `regexp/no-useless-escape`, so the fix flows to both.

Threaded the literal's flags into `reportRegexEscapes` and, in `v` mode, select a classSet allowlist that keeps those characters escaped — mirroring ESLint's `REGEX_CLASSSET_CHARACTER_ESCAPES`. `u`-mode and non-unicode classes are unchanged, so a genuinely useless escape like `/[\(]/u` is still stripped.

## Oracle
Verified against ESLint core `no-useless-escape` (`REGEX_GENERAL_ESCAPES` / `REGEX_CLASSSET_CHARACTER_ESCAPES`; in-class allowlist selected by the `v` flag). Neither issue's claim was invalidated.

## Test plan
- New Go unit tests under `packages/lint/test/rules/strings-regex/`:
  - `TestNoUselessEscapeNestedUntaggedTemplateInTaggedSubstitution` pins the 5-row matrix (case `e` reports, case `f` silent) plus a nested string-literal control.
  - `TestNoUselessEscapeVFlagClassPreservesSyntaxCharEscapes` asserts the 7 v-flag ClassSetSyntaxCharacter escapes are preserved, the `u`-flag twin still fixes `/[\(]/u`→`/[(]/u`, and a useless v-flag escape `/[\a]/v`→`/[a]/v` still fixes (not a blanket skip).
- Before/after repro confirmed for each issue: both tests fail on the pre-fix code and pass after.
- e2e corpus updated: `tests/test-lint/src/cases/no-useless-escape.ts` (nested tagged case) and `regexp-no-useless-escape.ts` (v-flag preserved + u-flag reported).
- Full `node scripts/test-go-lint.cjs` is green except 5 pre-existing environment failures (`TypeScript config file … Cannot find module …/packages/ttsc/lib/launcher/ttsx.js`) that require the built `ttsx.js` launcher (`pnpm build`, Node 24), unrelated to these rules — CI builds it.

## Notes
- `website/src/content/docs/lint/rules/core.mdx` left unchanged: the one-line rule contract ("reject unnecessary escape sequences … Autofixable") still holds; both changes are correctness fixes toward that same described behavior.
- Pre-existing (out of scope): in a non-`v` character class `\q` is under-reported (ESLint flags it); left as-is to keep the change scoped to the corruption class.

Do not merge — merges are sequenced by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Giu15S7hyRxpupc1XwXe89