### PR TITLE
fix(lint): unicorn/prefer-number-properties parity (options, filters, message, fix)

### DIFF
--- a/packages/lint/linthost/rules_unicorn_prefer_number_properties.go
+++ b/packages/lint/linthost/rules_unicorn_prefer_number_properties.go
@@ -5,82 +5,415 @@
 // `false`, while the global `isNaN("abc")` is `true`) and are more
 // discoverable. The rule pushes authors to the namespaced spellings.
 //
-// AST-only: visit each `Identifier`. The text must be one of the six
-// shadowable names. The identifier must be in a value-expression
-// position — not the name part of a property access (`obj.isNaN`),
-// not the key of a property assignment, and not a binding name. Reports
-// on the identifier.
+// Faithful port of eslint-plugin-unicorn `rules/prefer-number-properties.js`.
+// The upstream rule tracks *references to the global binding* through scope
+// analysis; this port reproduces that with the TypeScript-Go checker so a
+// locally shadowed `parseInt` / `isNaN` (a different value) is never flagged,
+// while genuine value-position reads — including an object initializer
+// (`{normalize: parseFloat}`) and a shorthand (`{parseInt}`) — are. Options
+// `checkInfinity` and `checkNaN` both default to `false`, so `Infinity` and
+// `NaN` are only checked when the caller opts in. `parseInt(x)` and
+// `parseInt(x, 10)` already yield what `Number.parseInt` would and are left
+// alone; assignment / update / destructuring / `delete` targets are not reads
+// and are excluded. Diagnostics interpolate the real spellings
+// (`Number.<property>` over `<description>`) and carry an autofix, or a
+// suggestion where the rewrite could change runtime behavior.
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-number-properties.md
 package linthost
 
-import shimast "github.com/microsoft/typescript-go/shim/ast"
+import (
+  "bytes"
+  "encoding/json"
+  "fmt"
+  "strings"
 
-var unicornPreferNumberPropertiesNames = map[string]struct{}{
-  "isNaN":      {},
-  "isFinite":   {},
-  "parseFloat": {},
-  "parseInt":   {},
-  "NaN":        {},
-  "Infinity":   {},
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimchecker "github.com/microsoft/typescript-go/shim/checker"
+)
+
+// unicornPreferNumberPropertiesGlobals maps each shadowable global name to
+// whether replacing it with `Number.<name>` is unconditionally safe (upstream's
+// `globalObjects`). `parseInt`, `parseFloat`, `NaN`, and `Infinity` are pure
+// aliases, so the fix applies automatically; `isNaN` and `isFinite` differ from
+// `Number.isNaN` / `Number.isFinite` on non-number arguments, so they autofix
+// only when the sole argument is provably a number and are otherwise offered as
+// an opt-in suggestion.
+var unicornPreferNumberPropertiesGlobals = map[string]bool{
+  "parseInt":   true,
+  "parseFloat": true,
+  "NaN":        true,
+  "Infinity":   true,
+  "isNaN":      false,
+  "isFinite":   false,
 }
 
 type unicornPreferNumberProperties struct{}
 
+type unicornPreferNumberPropertiesOptions struct {
+  checkInfinity bool
+  checkNaN      bool
+}
+
 func (unicornPreferNumberProperties) Name() string {
   return "unicorn/prefer-number-properties"
 }
+func (unicornPreferNumberProperties) NeedsTypeChecker() bool { return true }
 func (unicornPreferNumberProperties) Visits() []shimast.Kind {
   return []shimast.Kind{shimast.KindIdentifier}
 }
+
+func (unicornPreferNumberProperties) ValidateOptions(raw json.RawMessage) error {
+  _, err := decodeUnicornPreferNumberPropertiesOptions(raw)
+  return err
+}
+
 func (unicornPreferNumberProperties) Check(ctx *Context, node *shimast.Node) {
   name := identifierText(node)
-  if _, ok := unicornPreferNumberPropertiesNames[name]; !ok {
+  isSafeGlobal, tracked := unicornPreferNumberPropertiesGlobals[name]
+  if !tracked {
     return
   }
-  parent := node.Parent
-  if parent == nil {
+  options, err := decodeUnicornPreferNumberPropertiesOptions(ctx.Options)
+  if err != nil {
+    // Malformed options are already surfaced as a configuration error at
+    // engine construction; stay side-effect-free here.
     return
   }
-  switch parent.Kind {
-  case shimast.KindPropertyAccessExpression:
-    // `obj.isNaN` — the identifier is the property name, not a
-    // reference to the global. `Number.isNaN(...)` itself also
-    // reaches here and must not be flagged.
-    access := parent.AsPropertyAccessExpression()
-    if access != nil && access.Name() == node {
+  // `Infinity` and `NaN` leave the tracked set unless the caller opts in;
+  // both options default to false.
+  if name == "Infinity" && !options.checkInfinity {
+    return
+  }
+  if name == "NaN" && !options.checkNaN {
+    return
+  }
+  // Only value-expression reads are candidates. Declaration names, property
+  // keys, member-access right sides, type positions, and import/export
+  // specifiers are name slots, not references to the global; value positions
+  // such as `{key: parseFloat}` and the shorthand `{parseInt}` are kept.
+  if !isUnicornValuePositionIdentifier(node) {
+    return
+  }
+  // Assignment / update / destructuring / delete targets are writes, not reads.
+  if unicornPreferNumberPropertiesIsLeftHandSide(node) {
+    return
+  }
+  if name == "Infinity" && unicornPreferNumberPropertiesIsDeletedNegativeInfinity(node) {
+    return
+  }
+  // `parseInt(x)` (no radix) and `parseInt(x, 10)` (explicit base 10) already
+  // produce what `Number.parseInt` would, so upstream skips them.
+  if name == "parseInt" && unicornPreferNumberPropertiesIsBase10OrNoRadixCall(ctx, node) {
+    return
+  }
+  // Bind the identifier: a locally shadowed name is a different value.
+  if !unicornPreferNumberPropertiesResolvesGlobal(ctx, node, name) {
+    return
+  }
+  unicornPreferNumberPropertiesReport(ctx, node, name, isSafeGlobal)
+}
+
+// unicornPreferNumberPropertiesReport emits the diagnostic with the substituted
+// message plus an autofix or a suggestion, mirroring upstream's
+// getPropertyProblem. `Infinity` maps to `POSITIVE_INFINITY`, or, when negated,
+// to a `NEGATIVE_INFINITY` fix anchored on the whole `-Infinity` unary.
+func unicornPreferNumberPropertiesReport(ctx *Context, node *shimast.Node, name string, isSafeGlobal bool) {
+  property := name
+  description := name
+
+  if name == "Infinity" {
+    if unicornPreferNumberPropertiesIsNegative(node) {
+      unary := node.Parent
+      message := unicornPreferNumberPropertiesMessage("NEGATIVE_INFINITY", "-Infinity")
+      if edits, ok := unicornPreferNumberPropertiesNegativeInfinityFix(ctx, unary); ok {
+        ctx.ReportFix(unary, message, edits...)
+        return
+      }
+      ctx.Report(unary, message)
       return
     }
-  case shimast.KindQualifiedName:
-    // Type-position `A.B` — same rationale as PropertyAccess.
-    return
-  case shimast.KindPropertyAssignment,
-    shimast.KindShorthandPropertyAssignment,
-    shimast.KindMethodDeclaration,
-    shimast.KindPropertyDeclaration,
-    shimast.KindEnumMember,
-    shimast.KindPropertySignature,
-    shimast.KindMethodSignature,
-    shimast.KindGetAccessor,
-    shimast.KindSetAccessor:
-    // Member name slots on object/class shapes.
-    return
-  case shimast.KindParameter,
-    shimast.KindVariableDeclaration,
-    shimast.KindBindingElement,
-    shimast.KindFunctionDeclaration,
-    shimast.KindFunctionExpression,
-    shimast.KindClassDeclaration,
-    shimast.KindClassExpression,
-    shimast.KindImportSpecifier,
-    shimast.KindImportClause,
-    shimast.KindNamespaceImport,
-    shimast.KindExportSpecifier,
-    shimast.KindTypeParameter,
-    shimast.KindLabeledStatement:
-    // Binding / declaration names, not references to the global.
+    property = "POSITIVE_INFINITY"
+  }
+
+  message := unicornPreferNumberPropertiesMessage(property, description)
+  edits, ok := unicornPreferNumberPropertiesReplaceFix(ctx, node, property)
+  if !ok {
+    ctx.Report(node, message)
     return
   }
-  ctx.Report(node, "Prefer `Number.<X>` over the global `<X>` (e.g. `Number.isNaN`, `Number.parseInt`).")
+  if isSafeGlobal || unicornPreferNumberPropertiesIsCallWithNumberArgument(ctx, node) {
+    ctx.ReportFix(node, message, edits...)
+    return
+  }
+  title := fmt.Sprintf("Replace `%s` with `Number.%s`.", description, property)
+  ctx.ReportSuggestion(node, message, title, edits...)
+}
+
+func unicornPreferNumberPropertiesMessage(property, description string) string {
+  return fmt.Sprintf("Prefer `Number.%s` over `%s`.", property, description)
+}
+
+// unicornPreferNumberPropertiesReplaceFix builds the edit that rewrites the
+// identifier to `Number.<property>`. A shorthand property value must expand to
+// `name: Number.<property>` because `{Number.parseInt}` is not valid syntax
+// (upstream's replaceReferenceIdentifier).
+func unicornPreferNumberPropertiesReplaceFix(ctx *Context, node *shimast.Node, property string) ([]TextEdit, bool) {
+  pos, end := tokenRange(ctx.File, node)
+  if pos < 0 {
+    return nil, false
+  }
+  replacement := "Number." + property
+  if parent := node.Parent; parent != nil && parent.Kind == shimast.KindShorthandPropertyAssignment {
+    if shorthand := parent.AsShorthandPropertyAssignment(); shorthand != nil && shorthand.Name() == node {
+      replacement = identifierText(node) + ": " + replacement
+    }
+  }
+  return []TextEdit{{Pos: pos, End: end, Text: replacement}}, true
+}
+
+// unicornPreferNumberPropertiesNegativeInfinityFix rewrites a `-Infinity` unary
+// to `Number.NEGATIVE_INFINITY`, inserting a leading space when the preceding
+// byte is an identifier part so a keyword operand (`return-Infinity`) does not
+// merge with the replacement (upstream's fixSpaceAroundKeyword).
+func unicornPreferNumberPropertiesNegativeInfinityFix(ctx *Context, unary *shimast.Node) ([]TextEdit, bool) {
+  pos, end := tokenRange(ctx.File, unary)
+  if pos < 0 {
+    return nil, false
+  }
+  replacement := "Number.NEGATIVE_INFINITY"
+  if src := ctx.File.Text(); pos > 0 && pos <= len(src) && isIdentifierPart(src[pos-1]) {
+    replacement = " " + replacement
+  }
+  return []TextEdit{{Pos: pos, End: end, Text: replacement}}, true
+}
+
+// unicornPreferNumberPropertiesResolvesGlobal reports whether the identifier is
+// a reference to the program's global binding of `name`, not a local shadow.
+// The same-file value-declaration guard covers script files whose top-level
+// binding merges into the checker global table; module bindings already resolve
+// to a distinct symbol.
+func unicornPreferNumberPropertiesResolvesGlobal(ctx *Context, node *shimast.Node, name string) bool {
+  if ctx == nil || ctx.Checker == nil || ctx.File == nil {
+    return false
+  }
+  resolved := valueSymbolAtIdentifier(ctx, node)
+  global := ctx.Checker.GetGlobalSymbol(name, shimast.SymbolFlagsValue, nil)
+  if resolved == nil || global == nil {
+    return false
+  }
+  resolved = ctx.Checker.GetMergedSymbol(resolved)
+  global = ctx.Checker.GetMergedSymbol(global)
+  if resolved != global {
+    return false
+  }
+  for _, declaration := range resolved.Declarations {
+    if declaration != nil &&
+      shimast.GetSourceFileOfNode(declaration) == ctx.File &&
+      unicornPreferNumberPropertiesDeclarationIntroducesValue(declaration) {
+      return false
+    }
+  }
+  return true
+}
+
+// unicornPreferNumberPropertiesDeclarationIntroducesValue distinguishes a
+// same-file value binding that shadows the built-in from a type-only
+// declaration that legitimately merges with the global's interface.
+func unicornPreferNumberPropertiesDeclarationIntroducesValue(declaration *shimast.Node) bool {
+  switch declaration.Kind {
+  case shimast.KindVariableDeclaration,
+    shimast.KindBindingElement,
+    shimast.KindParameter,
+    shimast.KindFunctionDeclaration,
+    shimast.KindClassDeclaration,
+    shimast.KindEnumDeclaration,
+    shimast.KindModuleDeclaration,
+    shimast.KindImportClause,
+    shimast.KindImportSpecifier,
+    shimast.KindImportEqualsDeclaration,
+    shimast.KindNamespaceImport:
+    return true
+  }
+  return false
+}
+
+// unicornPreferNumberPropertiesIsLeftHandSide reports whether the identifier is
+// written rather than read: an assignment/compound-assignment target, an update
+// operand, a `delete` argument, or a destructuring-assignment target (upstream's
+// isLeftHandSide).
+func unicornPreferNumberPropertiesIsLeftHandSide(node *shimast.Node) bool {
+  parent := node.Parent
+  if parent == nil {
+    return false
+  }
+  switch parent.Kind {
+  case shimast.KindBinaryExpression:
+    binary := parent.AsBinaryExpression()
+    if binary != nil && binary.Left == node && binary.OperatorToken != nil &&
+      isAssignmentOperator(binary.OperatorToken.Kind) {
+      return true
+    }
+  case shimast.KindPrefixUnaryExpression:
+    unary := parent.AsPrefixUnaryExpression()
+    if unary != nil && unary.Operand == node &&
+      (unary.Operator == shimast.KindPlusPlusToken || unary.Operator == shimast.KindMinusMinusToken) {
+      return true
+    }
+  case shimast.KindPostfixUnaryExpression:
+    unary := parent.AsPostfixUnaryExpression()
+    if unary != nil && unary.Operand == node &&
+      (unary.Operator == shimast.KindPlusPlusToken || unary.Operator == shimast.KindMinusMinusToken) {
+      return true
+    }
+  case shimast.KindDeleteExpression:
+    del := parent.AsDeleteExpression()
+    if del != nil && del.Expression == node {
+      return true
+    }
+  }
+  return isDestructuringAssignmentTarget(node)
+}
+
+// unicornPreferNumberPropertiesIsNegative reports whether the identifier is the
+// operand of a unary minus (`-Infinity`).
+func unicornPreferNumberPropertiesIsNegative(node *shimast.Node) bool {
+  parent := node.Parent
+  if parent == nil || parent.Kind != shimast.KindPrefixUnaryExpression {
+    return false
+  }
+  unary := parent.AsPrefixUnaryExpression()
+  return unary != nil && unary.Operator == shimast.KindMinusToken && unary.Operand == node
+}
+
+// unicornPreferNumberPropertiesIsDeletedNegativeInfinity reports whether the
+// identifier is the `Infinity` of a `delete -Infinity` no-op, which upstream
+// leaves untouched.
+func unicornPreferNumberPropertiesIsDeletedNegativeInfinity(node *shimast.Node) bool {
+  if !unicornPreferNumberPropertiesIsNegative(node) {
+    return false
+  }
+  unary := node.Parent
+  if unary == nil || unary.Parent == nil || unary.Parent.Kind != shimast.KindDeleteExpression {
+    return false
+  }
+  del := unary.Parent.AsDeleteExpression()
+  return del != nil && del.Expression == unary
+}
+
+// unicornPreferNumberPropertiesIsBase10OrNoRadixCall reports whether the
+// identifier is a `parseInt` callee with no radix or an explicit base-10 radix.
+// The radix is read statically through the checker so a `const R = 10;
+// parseInt(x, R)` folds the same way upstream's getStaticValue does.
+func unicornPreferNumberPropertiesIsBase10OrNoRadixCall(ctx *Context, node *shimast.Node) bool {
+  parent := node.Parent
+  if parent == nil || parent.Kind != shimast.KindCallExpression {
+    return false
+  }
+  call := parent.AsCallExpression()
+  if call == nil || call.Expression != node || call.Arguments == nil {
+    return false
+  }
+  args := call.Arguments.Nodes
+  if len(args) < 2 {
+    return true
+  }
+  radix := args[1]
+  if radix == nil || radix.Kind == shimast.KindSpreadElement {
+    return false
+  }
+  if ctx.Checker == nil {
+    return false
+  }
+  t := ctx.Checker.GetTypeAtLocation(radix)
+  if t == nil || t.Flags()&shimchecker.TypeFlagsNumberLiteral == 0 {
+    return false
+  }
+  return strings.TrimSpace(ctx.Checker.TypeToString(t)) == "10"
+}
+
+// unicornPreferNumberPropertiesIsCallWithNumberArgument reports whether the
+// identifier is a callee invoked with exactly one argument whose type is
+// provably a number, the condition under which `Number.isNaN` / `Number.isFinite`
+// preserve `isNaN` / `isFinite` behavior and the rewrite is safe to autofix.
+func unicornPreferNumberPropertiesIsCallWithNumberArgument(ctx *Context, node *shimast.Node) bool {
+  parent := node.Parent
+  if parent == nil || parent.Kind != shimast.KindCallExpression || ctx.Checker == nil {
+    return false
+  }
+  call := parent.AsCallExpression()
+  if call == nil || call.Expression != node || call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
+    return false
+  }
+  argument := call.Arguments.Nodes[0]
+  if argument == nil || argument.Kind == shimast.KindSpreadElement {
+    return false
+  }
+  return unicornPreferNumberPropertiesTypeIsNumber(ctx.Checker.GetTypeAtLocation(argument))
+}
+
+// unicornPreferNumberPropertiesTypeIsNumber reports whether every constituent of
+// `t` is number-like. `any` / `unknown` and any non-number member answer false,
+// keeping the autofix conservative — such calls fall back to a suggestion.
+func unicornPreferNumberPropertiesTypeIsNumber(t *shimchecker.Type) bool {
+  if t == nil {
+    return false
+  }
+  flags := t.Flags()
+  if flags&shimchecker.TypeFlagsNumberLike != 0 {
+    return true
+  }
+  if flags&shimchecker.TypeFlagsUnion != 0 {
+    parts := t.Types()
+    if len(parts) == 0 {
+      return false
+    }
+    for _, part := range parts {
+      if !unicornPreferNumberPropertiesTypeIsNumber(part) {
+        return false
+      }
+    }
+    return true
+  }
+  return false
+}
+
+// decodeUnicornPreferNumberPropertiesOptions enforces the upstream schema: an
+// optional object whose only keys are the boolean `checkInfinity` and `checkNaN`
+// (both default false).
+func decodeUnicornPreferNumberPropertiesOptions(raw json.RawMessage) (unicornPreferNumberPropertiesOptions, error) {
+  options := unicornPreferNumberPropertiesOptions{}
+  trimmed := bytes.TrimSpace(raw)
+  if len(trimmed) == 0 {
+    return options, nil
+  }
+  if trimmed[0] != '{' {
+    return options, fmt.Errorf("options must be an object")
+  }
+  var fields map[string]json.RawMessage
+  if err := json.Unmarshal(trimmed, &fields); err != nil || fields == nil {
+    if err == nil {
+      err = fmt.Errorf("null object")
+    }
+    return options, fmt.Errorf("options must be an object: %w", err)
+  }
+  for name := range fields {
+    if name != "checkInfinity" && name != "checkNaN" {
+      return options, fmt.Errorf("unknown option %q", name)
+    }
+  }
+  if value, exists := fields["checkInfinity"]; exists {
+    if bytes.Equal(bytes.TrimSpace(value), []byte("null")) ||
+      json.Unmarshal(value, &options.checkInfinity) != nil {
+      return options, fmt.Errorf("option %q must be a boolean", "checkInfinity")
+    }
+  }
+  if value, exists := fields["checkNaN"]; exists {
+    if bytes.Equal(bytes.TrimSpace(value), []byte("null")) ||
+      json.Unmarshal(value, &options.checkNaN) != nil {
+      return options, fmt.Errorf("option %q must be a boolean", "checkNaN")
+    }
+  }
+  return options, nil
 }
 
 func init() {

--- a/packages/lint/test/rules/unicorn/unicorn_prefer_number_properties_test.go
+++ b/packages/lint/test/rules/unicorn/unicorn_prefer_number_properties_test.go
@@ -1,19 +1,324 @@
 package linthost
 
-import "testing"
+import (
+  "encoding/json"
+  "strings"
+  "testing"
+)
 
-// TestRuleCorpusUnicornPreferNumberProperties verifies
-// unicorn/prefer-number-properties reports a global `isNaN(...)` call.
+const unicornPreferNumberPropertiesRuleName = "unicorn/prefer-number-properties"
+
+// unicornPreferNumberPropertiesCorpusSource mirrors
+// tests/test-lint/src/cases/unicorn-prefer-number-properties.ts so the Go layer
+// and the end-to-end corpus assert the same default-option behavior: base-10 /
+// no-radix parseInt calls and locally shadowed bindings are valid, while a
+// radix-2 parseInt and both value positions of an object literal
+// (`{normalize: parseFloat, parseInt}`) are reported.
+const unicornPreferNumberPropertiesCorpusSource = `export {};
+
+const raw = "10";
+const value: unknown = 0;
+
+// Valid: parseInt without a radix already yields a base-10 integer.
+void parseInt(raw);
+
+// Valid: an explicit base-10 radix is equally redundant.
+void parseInt(raw, 10);
+
+// expect: unicorn/prefer-number-properties error
+void parseInt(raw, 2);
+
+// expect: unicorn/prefer-number-properties error
+// expect: unicorn/prefer-number-properties error
+const options = { normalize: parseFloat, parseInt };
+void options;
+
+// Valid: a locally shadowed isNaN is a different function.
+{
+  const isNaN = (input: unknown): boolean => input !== input;
+  void isNaN(value);
+}
+
+// Valid: parseInt destructured from Number is a local binding.
+{
+  const { parseInt } = Number;
+  void parseInt(raw, 2);
+}
+
+// Valid: -Infinity is left untouched unless checkInfinity is enabled.
+const negative = -Infinity;
+void negative;
+`
+
+// TestRuleCorpusUnicornPreferNumberProperties verifies the shared corpus
+// fixture end-to-end against the native Engine.
 //
-// The rule walks identifiers and matches the six shadowable names, but gates
-// out property-name slots and binding positions so a `Number.isNaN(...)` call
-// or a `{isNaN: 1}` key does not trigger. This fixture pins the bare-call
-// positive case, which is the most common spelling and the one most likely to
-// regress if the parent-position gate is loosened too far.
+// The rule resolves bindings through the checker, so the fixture is loaded with
+// a real Program: locally shadowed `isNaN` / `parseInt`, base-10 and no-radix
+// `parseInt` calls, and default-off `-Infinity` stay silent, while `parseInt(x,
+// 2)` and the value positions of `{normalize: parseFloat, parseInt}` report.
 //
-// 1. Enable unicorn/prefer-number-properties via an expect annotation.
-// 2. Invoke the global `isNaN(0)`.
-// 3. Assert the identifier is reported.
+// 1. Parse the fixture's `// expect:` annotations.
+// 2. Run the rule through the checker-backed snapshot path.
+// 3. Assert the Engine reports exactly the annotated diagnostics.
 func TestRuleCorpusUnicornPreferNumberProperties(t *testing.T) {
-  assertRuleCorpusCase(t, "unicorn/prefer-number-properties.ts", "// expect: unicorn/prefer-number-properties error\nvoid isNaN(0);\n")
+  source := unicornPreferNumberPropertiesCorpusSource
+  expected := parseRuleExpectations(t, source)
+  _, _, findings := runRuleFindingsSnapshot(t, unicornPreferNumberPropertiesRuleName, source, nil)
+  if len(findings) != len(expected) {
+    t.Fatalf("unicorn-prefer-number-properties.ts: want %v, got %+v", expected, findings)
+  }
+  actual := normalizeRuleFindings(findings[0].File, findings)
+  for index := range expected {
+    if actual[index] != expected[index] {
+      t.Fatalf("unicorn-prefer-number-properties.ts[%d]: want %+v, got %+v; all=%+v", index, expected[index], actual[index], actual)
+    }
+  }
+}
+
+// TestUnicornPreferNumberPropertiesInterpolatesMessage pins the regression this
+// fix targets: the message substitutes the real spellings rather than emitting
+// the literal `<X>` placeholders the old port shipped.
+func TestUnicornPreferNumberPropertiesInterpolatesMessage(t *testing.T) {
+  source := "export {};\nconst raw = \"10\";\nvoid parseInt(raw, 2);\n"
+  _, _, findings := runRuleFindingsSnapshot(t, unicornPreferNumberPropertiesRuleName, source, nil)
+  if len(findings) != 1 {
+    t.Fatalf("want one finding, got %+v", findings)
+  }
+  want := "Prefer `Number.parseInt` over `parseInt`."
+  if findings[0].Message != want {
+    t.Fatalf("message not interpolated: want %q, got %q", want, findings[0].Message)
+  }
+  if strings.Contains(findings[0].Message, "<X>") {
+    t.Fatalf("message still carries the literal placeholder: %q", findings[0].Message)
+  }
+}
+
+// TestUnicornPreferNumberPropertiesReportsObjectValuePositions locks the
+// dropped-value-position bug: the initializer of a property (`parseFloat`) and a
+// shorthand (`parseInt`) are both references and must each report.
+func TestUnicornPreferNumberPropertiesReportsObjectValuePositions(t *testing.T) {
+  source := "export {};\nconst options = { normalize: parseFloat, parseInt };\nvoid options;\n"
+  _, _, findings := runRuleFindingsSnapshot(t, unicornPreferNumberPropertiesRuleName, source, nil)
+  if len(findings) != 2 {
+    t.Fatalf("want findings for parseFloat and parseInt, got %+v", findings)
+  }
+  messages := map[string]bool{}
+  for _, finding := range findings {
+    messages[finding.Message] = true
+  }
+  for _, want := range []string{
+    "Prefer `Number.parseFloat` over `parseFloat`.",
+    "Prefer `Number.parseInt` over `parseInt`.",
+  } {
+    if !messages[want] {
+      t.Fatalf("missing %q in %+v", want, findings)
+    }
+  }
+}
+
+// TestUnicornPreferNumberPropertiesSkipsBase10AndMissingRadix keeps the
+// no-radix and base-10 parseInt calls valid while pinning the radix-2 twin so an
+// over-eager relaxation of the filter is caught.
+func TestUnicornPreferNumberPropertiesSkipsBase10AndMissingRadix(t *testing.T) {
+  for _, source := range []string{
+    "export {};\nconst raw = \"10\";\nvoid parseInt(raw);\n",
+    "export {};\nconst raw = \"10\";\nvoid parseInt(raw, 10);\n",
+  } {
+    _, _, findings := runRuleFindingsSnapshot(t, unicornPreferNumberPropertiesRuleName, source, nil)
+    if len(findings) != 0 {
+      t.Fatalf("base-10 / no-radix parseInt must be valid, got %+v for %q", findings, source)
+    }
+  }
+  source := "export {};\nconst raw = \"10\";\nvoid parseInt(raw, 2);\n"
+  _, _, findings := runRuleFindingsSnapshot(t, unicornPreferNumberPropertiesRuleName, source, nil)
+  if len(findings) != 1 {
+    t.Fatalf("radix-2 parseInt must fire, got %+v", findings)
+  }
+}
+
+// TestUnicornPreferNumberPropertiesSkipsShadowedBindings verifies a locally
+// declared or destructured binding of a tracked name is treated as a distinct
+// value, so neither the shadowed `isNaN` call nor the shadowed `parseInt` fires.
+func TestUnicornPreferNumberPropertiesSkipsShadowedBindings(t *testing.T) {
+  source := `export {};
+const value: unknown = 0;
+{
+  const isNaN = (input: unknown): boolean => input !== input;
+  void isNaN(value);
+}
+{
+  const { parseInt } = Number;
+  void parseInt("10", 2);
+}
+`
+  _, _, findings := runRuleFindingsSnapshot(t, unicornPreferNumberPropertiesRuleName, source, nil)
+  if len(findings) != 0 {
+    t.Fatalf("shadowed bindings must not fire, got %+v", findings)
+  }
+}
+
+// TestUnicornPreferNumberPropertiesLeavesInfinityAndNaNUnderDefaults confirms
+// both constants stay unchecked with the default options (both false).
+func TestUnicornPreferNumberPropertiesLeavesInfinityAndNaNUnderDefaults(t *testing.T) {
+  source := "export {};\nconst values = [Infinity, -Infinity, NaN];\nvoid values;\n"
+  _, _, findings := runRuleFindingsSnapshot(t, unicornPreferNumberPropertiesRuleName, source, nil)
+  if len(findings) != 0 {
+    t.Fatalf("Infinity and NaN are off by default, got %+v", findings)
+  }
+}
+
+// TestUnicornPreferNumberPropertiesChecksInfinityWhenEnabled proves the opt-in
+// path maps positive and negated Infinity to their distinct property names and
+// interpolates the negated description.
+func TestUnicornPreferNumberPropertiesChecksInfinityWhenEnabled(t *testing.T) {
+  source := "export {};\nconst positive = Infinity;\nconst negative = -Infinity;\nvoid [positive, negative];\n"
+  _, _, findings := runRuleFindingsSnapshot(
+    t,
+    unicornPreferNumberPropertiesRuleName,
+    source,
+    json.RawMessage(`{"checkInfinity":true}`),
+  )
+  if len(findings) != 2 {
+    t.Fatalf("checkInfinity should report both, got %+v", findings)
+  }
+  messages := map[string]bool{}
+  for _, finding := range findings {
+    messages[finding.Message] = true
+  }
+  for _, want := range []string{
+    "Prefer `Number.POSITIVE_INFINITY` over `Infinity`.",
+    "Prefer `Number.NEGATIVE_INFINITY` over `-Infinity`.",
+  } {
+    if !messages[want] {
+      t.Fatalf("missing %q in %+v", want, findings)
+    }
+  }
+}
+
+// TestUnicornPreferNumberPropertiesChecksNaNWhenEnabled proves the opt-in NaN
+// path reports with the substituted `Number.NaN` message.
+func TestUnicornPreferNumberPropertiesChecksNaNWhenEnabled(t *testing.T) {
+  source := "export {};\nconst value = NaN;\nvoid value;\n"
+  _, _, findings := runRuleFindingsSnapshot(
+    t,
+    unicornPreferNumberPropertiesRuleName,
+    source,
+    json.RawMessage(`{"checkNaN":true}`),
+  )
+  if len(findings) != 1 || findings[0].Message != "Prefer `Number.NaN` over `NaN`." {
+    t.Fatalf("checkNaN mismatch: %+v", findings)
+  }
+}
+
+// TestUnicornPreferNumberPropertiesAutofixesSafeGlobal proves a pure-alias
+// global carries an automatic fix.
+func TestUnicornPreferNumberPropertiesAutofixesSafeGlobal(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    unicornPreferNumberPropertiesRuleName,
+    "export {};\nconst raw = \"10\";\nconst n = parseInt(raw, 2);\nvoid n;\n",
+    "export {};\nconst raw = \"10\";\nconst n = Number.parseInt(raw, 2);\nvoid n;\n",
+  )
+}
+
+// TestUnicornPreferNumberPropertiesExpandsShorthandFix proves the shorthand
+// value is expanded to a full property so the fix stays valid syntax.
+func TestUnicornPreferNumberPropertiesExpandsShorthandFix(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    unicornPreferNumberPropertiesRuleName,
+    "export {};\nconst o = { parseInt };\nvoid o;\n",
+    "export {};\nconst o = { parseInt: Number.parseInt };\nvoid o;\n",
+  )
+}
+
+// TestUnicornPreferNumberPropertiesAutofixesIsNaNWithNumberArgument proves the
+// otherwise suggestion-only isNaN autofixes when its sole argument is a number.
+func TestUnicornPreferNumberPropertiesAutofixesIsNaNWithNumberArgument(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    unicornPreferNumberPropertiesRuleName,
+    "export {};\nvoid isNaN(0);\n",
+    "export {};\nvoid Number.isNaN(0);\n",
+  )
+}
+
+// TestUnicornPreferNumberPropertiesSuggestsUnsafeIsNaN proves that isNaN with a
+// non-number argument reports with a suggestion instead of an unsafe autofix,
+// because Number.isNaN would change the runtime result.
+func TestUnicornPreferNumberPropertiesSuggestsUnsafeIsNaN(t *testing.T) {
+  source := "export {};\ndeclare const input: any;\nvoid isNaN(input);\n"
+  _, _, findings := runRuleFindingsSnapshot(t, unicornPreferNumberPropertiesRuleName, source, nil)
+  if len(findings) != 1 {
+    t.Fatalf("want one finding, got %+v", findings)
+  }
+  if len(findings[0].Fix) != 0 {
+    t.Fatalf("unsafe isNaN must not carry an automatic fix, got %+v", findings[0].Fix)
+  }
+  if len(findings[0].Suggestions) != 1 ||
+    findings[0].Suggestions[0].Title != "Replace `isNaN` with `Number.isNaN`." {
+    t.Fatalf("suggestion mismatch: %+v", findings[0].Suggestions)
+  }
+}
+
+// TestUnicornPreferNumberPropertiesFixesNegativeInfinity proves the negated
+// Infinity fix rewrites the whole unary to Number.NEGATIVE_INFINITY.
+func TestUnicornPreferNumberPropertiesFixesNegativeInfinity(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    unicornPreferNumberPropertiesRuleName,
+    "export {};\nconst negative = -Infinity;\nvoid negative;\n",
+    `{"checkInfinity":true}`,
+    "export {};\nconst negative = Number.NEGATIVE_INFINITY;\nvoid negative;\n",
+  )
+}
+
+// TestUnicornPreferNumberPropertiesValidatesOptions locks the public option
+// schema: only the boolean checkInfinity / checkNaN keys are accepted, and the
+// checker requirement survives every valid shape.
+func TestUnicornPreferNumberPropertiesValidatesOptions(t *testing.T) {
+  valid := []json.RawMessage{
+    nil,
+    json.RawMessage(`{}`),
+    json.RawMessage(`{"checkInfinity":true}`),
+    json.RawMessage(`{"checkNaN":false}`),
+    json.RawMessage(`{"checkInfinity":true,"checkNaN":true}`),
+  }
+  for _, options := range valid {
+    engine := NewEngineWithResolver(InlineRuleResolver{
+      Rules:   RuleConfig{unicornPreferNumberPropertiesRuleName: SeverityError},
+      Options: RuleOptionsMap{unicornPreferNumberPropertiesRuleName: options},
+    })
+    if err := engine.ConfigError(); err != nil {
+      t.Fatalf("valid options %s were rejected: %v", options, err)
+    }
+    if !engine.NeedsTypeChecker() {
+      t.Fatalf("valid options %s lost the checker requirement", options)
+    }
+  }
+
+  invalid := []struct {
+    options json.RawMessage
+    want    string
+  }{
+    {options: json.RawMessage(`null`), want: "options must be an object"},
+    {options: json.RawMessage(`[]`), want: "options must be an object"},
+    {options: json.RawMessage(`{"checkInfinity":null}`), want: `option "checkInfinity" must be a boolean`},
+    {options: json.RawMessage(`{"checkNaN":"yes"}`), want: `option "checkNaN" must be a boolean`},
+    {options: json.RawMessage(`{"unknown":true}`), want: `unknown option "unknown"`},
+  }
+  for _, test := range invalid {
+    engine := NewEngineWithResolver(InlineRuleResolver{
+      Rules:   RuleConfig{unicornPreferNumberPropertiesRuleName: SeverityError},
+      Options: RuleOptionsMap{unicornPreferNumberPropertiesRuleName: test.options},
+    })
+    err := engine.ConfigError()
+    if err == nil || !strings.Contains(err.Error(), test.want) {
+      t.Fatalf("invalid options %s mismatch: want %q, got %v", test.options, test.want, err)
+    }
+    if _, active := engine.EnabledRules()[unicornPreferNumberPropertiesRuleName]; active {
+      t.Fatalf("invalid options entered the dispatch table: %v", engine.EnabledRules())
+    }
+  }
 }

--- a/tests/test-lint/src/cases/unicorn-prefer-number-properties.ts
+++ b/tests/test-lint/src/cases/unicorn-prefer-number-properties.ts
@@ -1,2 +1,34 @@
+export {};
+
+const raw = "10";
+const value: unknown = 0;
+
+// Valid: parseInt without a radix already yields a base-10 integer.
+void parseInt(raw);
+
+// Valid: an explicit base-10 radix is equally redundant.
+void parseInt(raw, 10);
+
 // expect: unicorn/prefer-number-properties error
-void isNaN(0);
+void parseInt(raw, 2);
+
+// expect: unicorn/prefer-number-properties error
+// expect: unicorn/prefer-number-properties error
+const options = { normalize: parseFloat, parseInt };
+void options;
+
+// Valid: a locally shadowed isNaN is a different function.
+{
+  const isNaN = (input: unknown): boolean => input !== input;
+  void isNaN(value);
+}
+
+// Valid: parseInt destructured from Number is a local binding.
+{
+  const { parseInt } = Number;
+  void parseInt(raw, 2);
+}
+
+// Valid: -Infinity is left untouched unless checkInfinity is enabled.
+const negative = -Infinity;
+void negative;

--- a/website/src/content/docs/lint/rules/unicorn.mdx
+++ b/website/src/content/docs/lint/rules/unicorn.mdx
@@ -1877,14 +1877,30 @@ import * as fs from "fs";
 
 ### `unicorn/prefer-number-properties`
 
-Prefer `Number.isNaN` / `Number.parseInt` / `Number.NaN` over their global counterparts.
+Prefer the ES2015 `Number` static members over their global counterparts: `Number.isNaN`, `Number.isFinite`, `Number.parseInt`, `Number.parseFloat`, and, when enabled, `Number.NaN`, `Number.POSITIVE_INFINITY`, and `Number.NEGATIVE_INFINITY`. The namespaced forms coerce more predictably and are easier to discover. Only a reference to the real global is reported, so a locally shadowed `parseInt` or `isNaN` is left alone, and a `parseInt(value)` or `parseInt(value, 10)` call (already base 10) is not flagged.
 
 Example:
 
 ```ts
 // reports: unicorn/prefer-number-properties (error)
 void isNaN(0);
+
+const options = {
+  // reports: unicorn/prefer-number-properties (error)
+  normalize: parseFloat,
+  // reports: unicorn/prefer-number-properties (error)
+  parseInt,
+};
 ```
+
+`NaN` and `Infinity` are unchecked by default. Set `checkNaN: true` to flag `NaN`, and `checkInfinity: true` to flag `Infinity` (a negated `-Infinity` fixes to `Number.NEGATIVE_INFINITY`):
+
+```jsonc
+// lint.config.json rule entry
+"unicorn/prefer-number-properties": ["error", { "checkInfinity": true, "checkNaN": true }]
+```
+
+The pure aliases (`parseInt`, `parseFloat`, `NaN`, `Infinity`) autofix directly. `isNaN` and `isFinite` autofix only when their sole argument is a number, since `Number.isNaN` and `Number.isFinite` skip the coercion the global forms perform; otherwise the rewrite is offered as a suggestion.
 
 <a id="rule-unicorn-prefer-object-from-entries"></a>
 


### PR DESCRIPTION
## Intent

Fix the four independent faults in `unicorn/prefer-number-properties` reported in #599, so the port matches upstream `eslint-plugin-unicorn` `rules/prefer-number-properties.js`.

Before this change the rule:

1. checked `NaN` / `Infinity` unconditionally and swallowed the `checkInfinity` / `checkNaN` options (upstream defaults both `false`);
2. had no radix, left-hand-side, or global-scope filter, so `parseInt("10")`, `parseInt("10", 10)`, and shadowed `parseInt` / `isNaN` were flagged;
3. keyed its declaration exclusion on `parent.Kind` and dropped value positions such as `{normalize: parseFloat, parseInt}`;
4. emitted the literal message ``Prefer `Number.<X>` over the global `<X>` …`` — the `<X>` placeholders were never substituted.

## Scope

- `packages/lint/linthost/rules_unicorn_prefer_number_properties.go` — rewritten as a checker-backed (`NeedsTypeChecker`) port:
  - `checkInfinity` / `checkNaN` options (default `false`) with `ValidateOptions`.
  - Shadowing-aware global resolution via `ctx.Checker` (with a same-file value-declaration guard for script files), the base-10 / no-radix `parseInt` filter, the left-hand-side filter, and the `delete -Infinity` filter.
  - Value-position gating by the name slot, so `{normalize: parseFloat, parseInt}` reports both references.
  - Interpolated message ``Prefer `Number.{{property}}` over `{{description}}` `` and the autofix, with an opt-in suggestion for `isNaN` / `isFinite` unless the sole argument is provably a number, plus the `-Infinity` → `Number.NEGATIVE_INFINITY` rewrite.
- `packages/lint/test/rules/unicorn/unicorn_prefer_number_properties_test.go` — replaced the single AST-only case with 14 checker-backed cases covering the upstream valid/invalid rows, message interpolation, fixes/suggestions, opt-in `Infinity` / `NaN`, and the option schema.
- `tests/test-lint/src/cases/unicorn-prefer-number-properties.ts` — expanded the end-to-end corpus fixture to the same valid/invalid rows.
- `website/src/content/docs/lint/rules/unicorn.mdx` — documented the options and the fix/suggestion behavior.

## Deferred

- The typed config surface (`ITtscLintUnicornRules.ts`) still types this rule as a bare `TtscLintRuleSetting`; the new options are validated by the engine and configurable through the JSON/`lint.config` path but are not yet exposed in the `TtscLintRuleOptionsSetting<…>` TypeScript type. Left out to keep this change scoped to the rule (per issue), and because every left-hand-side form of these globals is a type error in strict TS, the `isLeftHandSide` filter is faithful-port defensive coverage for JavaScript inputs rather than a TS-testable path.

## Test plan

- Before/after repro: the new tests fail against the old rule (literal `<X>` message, dropped `{normalize: parseFloat, parseInt}`, false-positive `parseInt(raw)`, wrong corpus count) and pass against the new rule.
- Full `packages/lint` Go suite green except five pre-existing `ttsx`-config-loader tests that require the `ttsx` binary on `PATH`; those fail identically on unmodified `master` in the same local sandbox (environmental, injected by `scripts/test-go-lint.cjs` in CI). The behavioral-witness audit passes (this rule now records a `checker` witness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Giu15S7hyRxpupc1XwXe89