### PR TITLE
perf/fix(lint): contributor checker-pool opt-out (#618) + polyfills targets option type (#626)

### DIFF
--- a/packages/lint/linthost/contrib_adapter.go
+++ b/packages/lint/linthost/contrib_adapter.go
@@ -92,6 +92,7 @@ type contributorMetadata struct {
   name                   string
   visits                 []shimast.Kind
   visitsDeclarationFiles bool
+  needsTypeChecker       bool
 }
 
 // inspectContributor evaluates the public rule metadata behind a recover
@@ -110,12 +111,16 @@ func inspectContributor(contributor rule.Rule) (metadata contributorMetadata, er
     name:                   contributor.Name(),
     visits:                 append([]shimast.Kind(nil), contributor.Visits()...),
     visitsDeclarationFiles: true,
+    needsTypeChecker:       true,
   }
   if formatRule, ok := contributor.(rule.FormatRule); ok {
     metadata.isFormat = formatRule.IsFormat()
   }
   if declarationRule, ok := contributor.(rule.DeclarationFileRule); ok {
     metadata.visitsDeclarationFiles = declarationRule.VisitsDeclarationFiles()
+  }
+  if typeAware, ok := contributor.(rule.TypeAwareRule); ok {
+    metadata.needsTypeChecker = typeAware.NeedsTypeChecker()
   }
   return metadata, nil
 }
@@ -130,6 +135,7 @@ func newContributorAdapter(metadata contributorMetadata) contributorAdapter {
     name:                   metadata.name,
     visits:                 metadata.visits,
     visitsDeclarationFiles: metadata.visitsDeclarationFiles,
+    needsTypeChecker:       metadata.needsTypeChecker,
   }
 }
 
@@ -145,13 +151,18 @@ type contributorAdapter struct {
   name                   string
   visits                 []shimast.Kind
   visitsDeclarationFiles bool
+  needsTypeChecker       bool
 }
 
-// NeedsTypeChecker keeps contributor rules on the historical checker path.
-// The public rule.Context exposes Checker and has no mandatory marker, so the
-// host cannot safely infer that a third-party rule is AST-only.
+// NeedsTypeChecker keeps contributor rules on the conservative checker path
+// unless the contributor opts out through the public `rule.TypeAwareRule`
+// marker. The public rule.Context exposes Checker, so the host cannot infer a
+// third-party rule is AST-only — the default is type-aware, and only a rule
+// that explicitly returns false stays off the checker path (and no longer
+// pins TypeScript-Go's checker pool). The default-true / marker-override
+// policy is applied once in inspectContributor.
 func (a contributorAdapter) NeedsTypeChecker() bool {
-  return true
+  return a.needsTypeChecker
 }
 
 // VisitsDeclarationFiles keeps contributor rules running on declaration

--- a/packages/lint/rule/rule.go
+++ b/packages/lint/rule/rule.go
@@ -112,6 +112,28 @@ type DeclarationFileRule interface {
   VisitsDeclarationFiles() bool
 }
 
+// TypeAwareRule is an optional marker contributors implement to declare
+// whether their rule reads `Context.Checker`. The host cannot infer a
+// third-party rule's shape, so a contributor that does not implement this
+// marker keeps the conservative default: it is treated as type-aware and
+// receives a live checker.
+//
+// Being treated as type-aware is not free. To hand a rule types drawn from
+// every source file on one checker, the host pins TypeScript-Go's checker
+// pool to a single checker, which serializes the whole program's semantic
+// typecheck (normally spread across the pool). A purely syntactic rule that
+// never touches `Context.Checker` pays that whole-program cost for nothing.
+//
+// A contributor whose rule is AST-only can implement this with
+// `NeedsTypeChecker() bool { return false }` to opt out of the checker path,
+// so its presence no longer pins the checker pool. Returning `true` is
+// equivalent to not implementing the interface at all. A rule that returns
+// `false` must not read `Context.Checker`: the host is free to leave it nil.
+type TypeAwareRule interface {
+  Rule
+  NeedsTypeChecker() bool
+}
+
 // Reporter is the engine-supplied callback that records a finding. The
 // host implements this and passes it to `NewContext` when invoking a
 // contributor rule.

--- a/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
+++ b/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
@@ -50,6 +50,7 @@ import type {
   ITtscLintUnicornFilenameCaseRuleOptions,
   ITtscLintUnicornImportStyleRuleOptions,
   ITtscLintUnicornIsolatedFunctionsRuleOptions,
+  ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions,
   ITtscLintUnicornPreventAbbreviationsRuleOptions,
   ITtscLintUnicornStringContentRuleOptions,
   ITtscLintUnicornTemplateIndentRuleOptions,
@@ -134,4 +135,5 @@ export interface ITtscLintRuleOptionsMap {
   "unicorn/filename-case": ITtscLintUnicornFilenameCaseRuleOptions;
   "unicorn/string-content": ITtscLintUnicornStringContentRuleOptions;
   "unicorn/isolated-functions": ITtscLintUnicornIsolatedFunctionsRuleOptions;
+  "unicorn/no-unnecessary-polyfills": ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions;
 }

--- a/packages/lint/src/structures/rules/ITtscLintUnicornRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintUnicornRuleOptions.ts
@@ -298,3 +298,32 @@ export interface ITtscLintUnicornStringContentRuleOptions {
   /** AST selectors that replace the default Literal/TemplateElement targets. */
   selectors?: readonly string[];
 }
+
+/**
+ * Explicit target runtimes for `unicorn/no-unnecessary-polyfills`.
+ *
+ * A Browserslist query string, an array of such queries, or a
+ * core-js-compat targets object (engine name to a version string or number,
+ * plus the special `browsers` / `esmodules` keys). Resolved with the
+ * `production` environment against the linted file's directory, exactly as
+ * upstream passes the value to core-js-compat.
+ */
+export type TtscLintUnicornNoUnnecessaryPolyfillsTargets =
+  | string
+  | readonly string[]
+  | Readonly<Record<string, string | number | boolean | readonly string[]>>;
+
+/**
+ * Options for `unicorn/no-unnecessary-polyfills`.
+ *
+ * Without this option the rule resolves targets from Browserslist config
+ * discovery and, as a last resort, the nearest `package.json` `engines`
+ * field. Set `targets` to pin the baseline explicitly; it mirrors upstream's
+ * required `targets` schema property.
+ *
+ * @reference https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unnecessary-polyfills.md
+ */
+export interface ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions {
+  /** Browserslist query, array of queries, or a core-js-compat targets object. */
+  targets: TtscLintUnicornNoUnnecessaryPolyfillsTargets;
+}

--- a/packages/lint/src/structures/rules/ITtscLintUnicornRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintUnicornRules.ts
@@ -8,6 +8,7 @@ import type {
   ITtscLintUnicornFilenameCaseRuleOptions,
   ITtscLintUnicornImportStyleRuleOptions,
   ITtscLintUnicornIsolatedFunctionsRuleOptions,
+  ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions,
   ITtscLintUnicornPreventAbbreviationsRuleOptions,
   ITtscLintUnicornStringContentRuleOptions,
   ITtscLintUnicornTemplateIndentRuleOptions,
@@ -490,7 +491,7 @@ export interface ITtscLintUnicornRules {
    *
    * @reference https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unnecessary-polyfills.md
    */
-  "unicorn/no-unnecessary-polyfills"?: TtscLintRuleSetting;
+  "unicorn/no-unnecessary-polyfills"?: TtscLintRuleOptionsSetting<ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions>;
 
   /**
    * Reject `.length` / `Infinity` as the end argument to `slice`; omit it to

--- a/packages/lint/test/plugin/contributor_ast_only_marker_leaves_checker_pool_unpinned_test.go
+++ b/packages/lint/test/plugin/contributor_ast_only_marker_leaves_checker_pool_unpinned_test.go
@@ -1,0 +1,49 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestContributorAstOnlyMarkerLeavesCheckerPoolUnpinned verifies a syntactic
+// contributor rule can opt out of the checker path through the public
+// `rule.TypeAwareRule` marker, so its presence no longer pins TypeScript-Go's
+// checker pool to a single checker (which serializes semantic diagnostics —
+// samchon/ttsc#618).
+//
+// Contributor rules default to type-aware because the host cannot infer a
+// third-party rule's shape. A contributor that never reads `ctx.Checker` can
+// implement `NeedsTypeChecker() bool { return false }` to stay off the checker
+// path; the engine's `ruleNeedsTypeChecker` gate — which decides whether
+// loadProgram is asked to pin the pool — must then report false.
+//
+// 1. Inspect an AST-only contributor whose marker returns false and wrap it.
+// 2. Ask the internal checker gate about the wrapped rule.
+// 3. Assert the rule is treated as AST-only (no checker requested).
+func TestContributorAstOnlyMarkerLeavesCheckerPoolUnpinned(t *testing.T) {
+  metadata, err := inspectContributor(contributorAstOnlyMarkerRule{})
+  if err != nil {
+    t.Fatalf("unexpected contributor inspection error: %v", err)
+  }
+  adapter := newContributorAdapter(metadata)
+  if adapter.NeedsTypeChecker() {
+    t.Fatal("AST-only contributor adapter still reports NeedsTypeChecker() == true")
+  }
+  if ruleNeedsTypeChecker(adapter) {
+    t.Fatal("AST-only contributor pinned the checker pool; the engine gate must report false")
+  }
+}
+
+// contributorAstOnlyMarkerRule is a syntactic contributor that opts out of the
+// checker path through the public marker.
+type contributorAstOnlyMarkerRule struct{}
+
+func (contributorAstOnlyMarkerRule) Name() string { return "demo/ast-only-marker" }
+func (contributorAstOnlyMarkerRule) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindSourceFile}
+}
+func (contributorAstOnlyMarkerRule) Check(*publicrule.Context, *shimast.Node) {}
+func (contributorAstOnlyMarkerRule) NeedsTypeChecker() bool                   { return false }

--- a/packages/lint/test/plugin/contributor_type_aware_marker_keeps_checker_test.go
+++ b/packages/lint/test/plugin/contributor_type_aware_marker_keeps_checker_test.go
@@ -1,0 +1,44 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestContributorTypeAwareMarkerKeepsChecker is the negative twin of
+// TestContributorAstOnlyMarkerLeavesCheckerPoolUnpinned: a contributor whose
+// `rule.TypeAwareRule` marker returns true must stay on the checker path,
+// exactly as if it had not implemented the marker at all. This pins the
+// documented "returning true is equivalent to not implementing" boundary so an
+// explicit true can never be misread as an opt-out.
+//
+// 1. Inspect a contributor whose marker returns true and wrap it.
+// 2. Ask the internal checker gate about the wrapped rule.
+// 3. Assert the rule is still treated as type-aware.
+func TestContributorTypeAwareMarkerKeepsChecker(t *testing.T) {
+  metadata, err := inspectContributor(contributorTypeAwareMarkerRule{})
+  if err != nil {
+    t.Fatalf("unexpected contributor inspection error: %v", err)
+  }
+  adapter := newContributorAdapter(metadata)
+  if !adapter.NeedsTypeChecker() {
+    t.Fatal("contributor with NeedsTypeChecker() == true was treated as AST-only")
+  }
+  if !ruleNeedsTypeChecker(adapter) {
+    t.Fatal("contributor with an explicit type-aware marker did not request a checker")
+  }
+}
+
+// contributorTypeAwareMarkerRule implements the marker but returns true, which
+// must behave identically to omitting the marker.
+type contributorTypeAwareMarkerRule struct{}
+
+func (contributorTypeAwareMarkerRule) Name() string { return "demo/type-aware-marker" }
+func (contributorTypeAwareMarkerRule) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindSourceFile}
+}
+func (contributorTypeAwareMarkerRule) Check(*publicrule.Context, *shimast.Node) {}
+func (contributorTypeAwareMarkerRule) NeedsTypeChecker() bool                   { return true }

--- a/packages/lint/test/registry/unicorn_no_unnecessary_polyfills_has_typed_options_key_test.go
+++ b/packages/lint/test/registry/unicorn_no_unnecessary_polyfills_has_typed_options_key_test.go
@@ -1,0 +1,84 @@
+package linthost
+
+import (
+  "os"
+  "path/filepath"
+  "regexp"
+  "runtime"
+  "strings"
+  "testing"
+)
+
+// TestUnicornNoUnnecessaryPolyfillsHasTypedOptionsKey pins the typed surface for
+// `unicorn/no-unnecessary-polyfills` against its Go runtime.
+//
+// The Go rule accepts and honors a `targets` option (validated in
+// `unicornNoUnnecessaryPolyfillsDecodeOptions`, consumed in Check), but the
+// published TypeScript key was severity-only (`TtscLintRuleSetting`), so a
+// type-checked `lint.config.ts` passing `{ targets: "node 18" }` was a TS error
+// even though the runtime needs it (samchon/ttsc#626). This test locks the
+// three-part wiring — the rules key, the options map, and the options interface —
+// so the typed surface can never silently regress back to severity-only.
+//
+// A general options-parity sweep (every ValidateOptions/DecodeOptions rule owns
+// an options-typed key) is intentionally NOT asserted here: several unrelated
+// rules still carry severity-only keys on master and are being corrected in
+// separate parity PRs, so a broad assertion would fail on rules outside this
+// change. This test is scoped to the rule this change fixes.
+//
+//  1. Read the three structures/rules TS sources next to this scratch test.
+//  2. Assert the rules key references TtscLintRuleOptionsSetting with the
+//     dedicated options interface, the options map carries the entry, and the
+//     options interface declares a `targets` property.
+func TestUnicornNoUnnecessaryPolyfillsHasTypedOptionsKey(t *testing.T) {
+  rulesDir := structuresRulesDir(t)
+
+  unicornRules := readStructuresRuleFile(t, rulesDir, "ITtscLintUnicornRules.ts")
+  keyPattern := regexp.MustCompile(
+    `"unicorn/no-unnecessary-polyfills"\?\s*:\s*TtscLintRuleOptionsSetting<\s*ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions\s*>`,
+  )
+  if !keyPattern.MatchString(unicornRules) {
+    t.Fatalf(
+      "unicorn/no-unnecessary-polyfills must be typed as " +
+        "TtscLintRuleOptionsSetting<ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions> " +
+        "so a config passing { targets } type-checks; the runtime honors that option")
+  }
+
+  optionsMap := readStructuresRuleFile(t, rulesDir, "ITtscLintRuleOptionsMap.ts")
+  if !strings.Contains(
+    optionsMap,
+    `"unicorn/no-unnecessary-polyfills": ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions;`,
+  ) {
+    t.Fatal("ITtscLintRuleOptionsMap is missing the unicorn/no-unnecessary-polyfills entry")
+  }
+
+  optionsIface := readStructuresRuleFile(t, rulesDir, "ITtscLintUnicornRuleOptions.ts")
+  ifacePattern := regexp.MustCompile(
+    `interface ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions\s*\{[^}]*\btargets\b`,
+  )
+  if !ifacePattern.MatchString(optionsIface) {
+    t.Fatal("ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions must declare a `targets` property")
+  }
+}
+
+// structuresRulesDir resolves packages/lint/src/structures/rules relative to the
+// running test file. scripts/test-go-lint.cjs flattens the Go tests into
+// linthost/ alongside the verbatim src/ tree, so the rules directory sits one
+// level up — the same layout the name-parity test relies on.
+func structuresRulesDir(t *testing.T) string {
+  t.Helper()
+  _, thisFile, _, ok := runtime.Caller(0)
+  if !ok {
+    t.Fatal("runtime.Caller(0) returned ok=false; cannot locate structures/rules/")
+  }
+  return filepath.Join(filepath.Dir(thisFile), "..", "src", "structures", "rules")
+}
+
+func readStructuresRuleFile(t *testing.T, rulesDir, name string) string {
+  t.Helper()
+  body, err := os.ReadFile(filepath.Join(rulesDir, name))
+  if err != nil {
+    t.Fatalf("read %s: %v", name, err)
+  }
+  return string(body)
+}


### PR DESCRIPTION
Addresses two `@ttsc/lint` audit issues. Scoped to the safe, correct subset of each; deferred items are enumerated below with evidence (per the issues' explicit authority to scope down when the full fix is too invasive or would regress).

## #618 — checker-pool pin serializes the typecheck

A rule that reports `NeedsTypeChecker() == true` makes the host pin TypeScript-Go's checker pool to a single checker, which serializes the whole program's semantic typecheck (+1.7s / 2.15x on typeorm). Two consumers pay this: every contributor rule, and `unicorn/consistent-existence-index-check`.

**Implemented:** an optional `rule.TypeAwareRule` marker in the public `rule` API (mirroring the existing `rule.DeclarationFileRule`). `contrib_adapter.go` previously returned `NeedsTypeChecker() == true` unconditionally, so any third-party rule — even a purely syntactic one — pinned the pool. Now a contributor whose rule never reads `Context.Checker` returns `NeedsTypeChecker() bool { return false }` and stays off the checker path, leaving the pool unpinned. The default stays conservative: a contributor without the marker is still treated as type-aware. This fixes the larger of the two named victims ("every contributor rule").

**Deferred, with evidence:**

- *Decoupling the lint checker from the pool size* (the issue's "Preferred" fix, which would also help built-in type-aware rules). The correct-and-safe form needs a **standalone** lint checker (pool stays N for parallel semantic diagnostics; a dedicated checker resolves lint queries), but `checker.NewChecker` is **not exposed** in `packages/ttsc/shim/checker/shim.go`, and the shim files are outside this change's allowed edit set. The only in-surface single checker, `Program.GetTypeChecker(nil)`, returns a **pool member** (`checkers[0]`); with the pool unpinned that member is subject to the documented "a cross-file circular type resolves to `any` on the borrowed checker" constraint (see `host.go` and `packages/ttsc/driver/program.go` `forceSingleChecker`). Separately, even a standalone lint checker re-resolves types lazily on one thread, which can *regress* heavy type-aware rules (parallel diagnostics + serial lint re-resolution can exceed today's serial diagnostics + cached lint). Shipping the borrowed-checker version would be a forced/broken design.
- *Converting `consistent-existence-index-check` to pure-AST scope resolution.* The AST shim exposes no scope-table (`Locals`) surface, and all binding-identity resolution routes through `ctx.Checker` (`canonicalValueSymbol`). A bespoke eslint-scope reimplementation for one rule is high-risk for shadowing correctness and would need new shim surface — out of scope here.

## #626 — options handling

**Implemented (typed `targets` for `unicorn/no-unnecessary-polyfills`).** The Go rule accepts and honors a `targets` option (Browserslist query, array of queries, or a core-js-compat targets object), but the published TypeScript key was severity-only (`TtscLintRuleSetting`), so a type-checked `lint.config.ts` passing `{ targets: "node 18" }` was a TS error even though the runtime needs it. Added `ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions` (with `targets`), wired it into `ITtscLintRuleOptionsMap.ts`, and changed the rules key to `TtscLintRuleOptionsSetting<…>`.

**Deferred, with evidence:**

- *Engine-side rejection of an options payload for a genuinely optionless rule.* A correct rejection needs a complete runtime "accepts options" signal on every option-consuming rule. Today only ~16 rules implement `ValidateOptions`; ~22 more consume real user options through `ctx.DecodeOptions` with **no** runtime marker (`no-else-return`'s `allowElseIf`, `default-case`'s `commentPattern`, `prefer-const`, `no-typeof-undefined`, `prefer-number-properties`, `ban-ts-comment`, …). Rejecting off the incomplete `ValidateOptions` signal would regress those valid configs; adding a marker to each rule is outside this change's allowed edit set, and a hardcoded rule list is disallowed.
- *A broad options-parity test* (every option-consuming rule owns an options-typed key). It is currently red on master for rules outside this change: `no-typeof-undefined` and `prefer-number-properties` (schema-validated but severity-only-keyed, being corrected in separate parity PRs), plus severity-only-keyed `default-case` / `no-else-return` / `no-extend-native`. Instead this PR adds a focused regression test locking the polyfills key/map/interface wiring, which stays green.

## Tests

- `contributor_ast_only_marker_leaves_checker_pool_unpinned_test.go` — an AST-only contributor (marker → false) leaves the checker gate off.
- `contributor_type_aware_marker_keeps_checker_test.go` — negative twin: an explicit `true` marker behaves exactly like omitting it.
- `unicorn_no_unnecessary_polyfills_has_typed_options_key_test.go` — locks the polyfills rules-key / options-map / options-interface wiring.

Validated: full `node scripts/test-go-lint.cjs` green; `tsc --noEmit` clean on the changed structures.

Fixes #618
Fixes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Giu15S7hyRxpupc1XwXe89
