### PR TITLE
chore(lint): test/CI/docs hygiene (#627)

### DIFF
--- a/packages/lint/linthost/fix.go
+++ b/packages/lint/linthost/fix.go
@@ -43,13 +43,19 @@ func runFix(opts *subcommandOpts) int {
     fmt.Fprintln(os.Stderr, err)
     return 2
   }
-  // `ttsc fix` is the run-everything entry point: lint fixes AND formatter
-  // edits. Formatting is configured solely through the `format` block (a
-  // format/* key in `rules` is dropped), so wrap the resolver the same way
-  // `ttsc format` and the LSP paths do — formatCommandResolver force-
-  // activates the format rules the format block configured. A project with
-  // no format block populates no format options, so nothing extra is enabled
-  // and fix stays a pure lint pass.
+  // `ttsc fix` runs lint autofixes AND format-rule edits in one pass. Formatting
+  // is configured solely through the `format` block (a format/* key in `rules`
+  // is dropped), so wrap the resolver in formatCommandResolver to force-activate
+  // the format rules that block configured — the same promotion `ttsc format`
+  // applies to a configured block.
+  //
+  // Deliberately NOT newFormatCommandResolver: fix supplies no defaultOptions, so
+  // a project with no `format` block enables no format rules and fix stays a pure
+  // lint pass. Loading the always-on default formatter is `ttsc format`'s job;
+  // doing it here would reformat every file during a plain lint fix. This
+  // divergence is the contract pinned by
+  // command_fix_skips_default_formatting_that_format_applies_test.go and the
+  // website lint docs.
   engine := NewEngineWithResolver(formatCommandResolver{inner: rules})
   if err := engine.ConfigError(); err != nil {
     fmt.Fprintln(os.Stderr, err)

--- a/packages/lint/linthost/regexp_cache.go
+++ b/packages/lint/linthost/regexp_cache.go
@@ -1,0 +1,44 @@
+package linthost
+
+import (
+  "regexp"
+  "sync"
+)
+
+// userPatternCache memoizes RE2 compilation of option-supplied regex patterns.
+//
+// Several rules accept a custom regex option — no-fallthrough's and
+// default-case's `commentPattern`, functional's identifier patterns,
+// no-param-reassign's `ignorePropertyModificationsForRegex` — and compile it
+// inside Check. That recompiles the same immutable, config-derived automaton on
+// every invocation: once per visited node, or once per candidate name in an
+// inner loop. The pattern is invariant for a whole run, so compiling it once and
+// reusing the result collapses the per-node cost to a single compile. Distinct
+// option patterns come from configuration and are therefore few and bounded, so
+// the cache cannot grow without bound.
+//
+// The engine walks files in parallel, so access is synchronized. Both the
+// compiled regexp and a compile error are cached so every caller keeps its
+// existing success/failure handling — an invalid custom pattern still surfaces
+// its error, just without recompiling on each visit.
+var userPatternCache sync.Map // map[string]userPatternResult
+
+type userPatternResult struct {
+  re  *regexp.Regexp
+  err error
+}
+
+// compileUserPattern compiles an option-supplied RE2 pattern, memoizing the
+// (regexp, error) result keyed by the pattern text. It is a drop-in replacement
+// for regexp.Compile at option-derived call sites that run during dispatch, with
+// identical return semantics.
+func compileUserPattern(pattern string) (*regexp.Regexp, error) {
+  if cached, ok := userPatternCache.Load(pattern); ok {
+    result := cached.(userPatternResult)
+    return result.re, result.err
+  }
+  re, err := regexp.Compile(pattern)
+  actual, _ := userPatternCache.LoadOrStore(pattern, userPatternResult{re: re, err: err})
+  result := actual.(userPatternResult)
+  return result.re, result.err
+}

--- a/packages/lint/linthost/rules_default_case.go
+++ b/packages/lint/linthost/rules_default_case.go
@@ -74,7 +74,7 @@ func (defaultCase) Check(ctx *Context, node *shimast.Node) {
   ctx.DecodeOptions(&opts)
   pattern := defaultCaseDefaultCommentPattern
   if opts.CommentPattern != "" {
-    if custom, err := regexp.Compile(opts.CommentPattern); err == nil {
+    if custom, err := compileUserPattern(opts.CommentPattern); err == nil {
       pattern = custom
     }
   }

--- a/packages/lint/linthost/rules_functional.go
+++ b/packages/lint/linthost/rules_functional.go
@@ -1,7 +1,6 @@
 package linthost
 
 import (
-  "regexp"
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
@@ -921,7 +920,7 @@ func functionalPatternMatches(pattern, name string) bool {
   if pattern == name {
     return true
   }
-  re, err := regexp.Compile(pattern)
+  re, err := compileUserPattern(pattern)
   return err == nil && re.MatchString(name)
 }
 

--- a/packages/lint/linthost/rules_no_fallthrough.go
+++ b/packages/lint/linthost/rules_no_fallthrough.go
@@ -88,7 +88,7 @@ func (noFallthrough) Check(ctx *Context, node *shimast.Node) {
   ctx.DecodeOptions(&opts)
   pattern := noFallthroughDefaultCommentPattern
   if opts.CommentPattern != "" {
-    if custom, err := regexp.Compile(opts.CommentPattern); err == nil {
+    if custom, err := compileUserPattern(opts.CommentPattern); err == nil {
       pattern = custom
     }
   }

--- a/packages/lint/linthost/rules_no_param_reassign.go
+++ b/packages/lint/linthost/rules_no_param_reassign.go
@@ -237,7 +237,7 @@ func (noParamReassign) Check(ctx *Context, node *shimast.Node) {
   }
   ignoredPatterns := make([]*regexp.Regexp, 0, len(options.IgnorePropertyModificationsForRegex))
   for _, pattern := range options.IgnorePropertyModificationsForRegex {
-    compiled, err := regexp.Compile(pattern)
+    compiled, err := compileUserPattern(pattern)
     if err != nil {
       return
     }

--- a/packages/lint/test/engine/compile_user_pattern_caches_option_regex_test.go
+++ b/packages/lint/test/engine/compile_user_pattern_caches_option_regex_test.go
@@ -1,0 +1,57 @@
+package linthost
+
+import "testing"
+
+// TestCompileUserPatternCachesOptionRegex verifies compileUserPattern compiles
+// an option-supplied pattern once and reuses the result.
+//
+// Option-derived regexes (no-fallthrough / default-case commentPattern,
+// functional identifier patterns, no-param-reassign ignore patterns) used to
+// call regexp.Compile inside Check, rebuilding the same immutable automaton on
+// every visited node. The cache collapses that to a single compile, so a repeat
+// request for the same pattern must return the identical *regexp.Regexp pointer;
+// a distinct pattern must compile independently; and an invalid pattern must
+// keep returning its cached error rather than recompiling.
+//
+//  1. Compile a valid pattern twice and assert pointer identity (compiled once).
+//  2. Compile a different pattern and assert it is a distinct instance.
+//  3. Compile an invalid pattern twice and assert the error is stable and no
+//     regexp is returned.
+func TestCompileUserPatternCachesOptionRegex(t *testing.T) {
+  const pattern = `(?i)custom\s?marker`
+  first, err := compileUserPattern(pattern)
+  if err != nil || first == nil {
+    t.Fatalf("first compile: re=%v err=%v", first, err)
+  }
+  second, err := compileUserPattern(pattern)
+  if err != nil {
+    t.Fatalf("second compile error: %v", err)
+  }
+  if first != second {
+    t.Fatalf("same pattern must reuse one compiled regexp: %p != %p", first, second)
+  }
+  if !first.MatchString("CUSTOM marker") {
+    t.Fatalf("cached regexp lost its behavior")
+  }
+
+  other, err := compileUserPattern(pattern + "-other")
+  if err != nil || other == nil {
+    t.Fatalf("distinct pattern compile: re=%v err=%v", other, err)
+  }
+  if other == first {
+    t.Fatalf("distinct patterns must not share one compiled regexp")
+  }
+
+  const invalid = `([`
+  re1, err1 := compileUserPattern(invalid)
+  re2, err2 := compileUserPattern(invalid)
+  if err1 == nil || err2 == nil {
+    t.Fatalf("invalid pattern must report an error: %v / %v", err1, err2)
+  }
+  if re1 != nil || re2 != nil {
+    t.Fatalf("invalid pattern must not yield a regexp: %v / %v", re1, re2)
+  }
+  if err1.Error() != err2.Error() {
+    t.Fatalf("cached error must be stable: %q != %q", err1, err2)
+  }
+}

--- a/packages/lint/test/format/command_fix_skips_default_formatting_that_format_applies_test.go
+++ b/packages/lint/test/format/command_fix_skips_default_formatting_that_format_applies_test.go
@@ -1,0 +1,78 @@
+package linthost
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestCommandFixSkipsDefaultFormattingThatFormatApplies pins the `ttsc fix` vs
+// `ttsc format` formatting contract on a project with NO `format` block.
+//
+// `ttsc format` loads the always-on default formatter (format/semi here), so it
+// closes a missing statement terminator even without a configured block.
+// `ttsc fix` deliberately does not: it applies lint autofixes and only the
+// format rules a `format` block configured, so with no block the same source
+// keeps its missing semicolons — a pure lint pass. Running both commands on
+// identical input and asserting the two outputs diverge locks that intentional
+// asymmetry (fix.go's resolver choice) against a regression that silently routes
+// fix through the default formatter.
+//
+//  1. Seed two copies of one source — a `no-var` lint violation plus two missing
+//     semicolons — with only a lint rule configured and no `format` block.
+//  2. Run `ttsc fix` on one copy and `ttsc format` on the other.
+//  3. Assert fix applied the lint fix but added no semicolons, while format added
+//     the default semicolons but left the `var` lint violation untouched.
+func TestCommandFixSkipsDefaultFormattingThatFormatApplies(t *testing.T) {
+  const source = "var legacy = 1\nJSON.stringify(legacy)\n"
+
+  fixRoot := seedLintProject(t, source)
+  seedLintRules(t, fixRoot, map[string]string{"no-var": "error"})
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "fix",
+      "--cwd", fixRoot,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  if code != 0 || stdout != "" || stderr != "" {
+    t.Fatalf("fix mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  // no-var rewrote `var`→`let`; the default formatter never ran, so both
+  // missing semicolons stay.
+  assertFileText(
+    t,
+    filepath.Join(fixRoot, "src", "main.ts"),
+    "let legacy = 1\nJSON.stringify(legacy)\n",
+  )
+
+  formatRoot := seedLintProject(t, source)
+  seedLintRules(t, formatRoot, map[string]string{"no-var": "error"})
+  code, stdout, stderr = captureCommandOutput(t, func() int {
+    return run([]string{
+      "format",
+      "--cwd", formatRoot,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  if code != 0 || stdout != "" || stderr != "" {
+    t.Fatalf("format mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  // The default formatter added both semicolons; format is write-only, so the
+  // `no-var` lint violation is left in place (`var`, not `let`).
+  got, err := os.ReadFile(filepath.Join(formatRoot, "src", "main.ts"))
+  if err != nil {
+    t.Fatalf("ReadFile: %v", err)
+  }
+  text := string(got)
+  if !strings.Contains(text, "var legacy = 1;") {
+    t.Fatalf("format must apply the default terminator and keep `var`: %q", text)
+  }
+  if !strings.Contains(text, "JSON.stringify(legacy);") {
+    t.Fatalf("format must apply the trailing default terminator: %q", text)
+  }
+  if strings.Contains(text, "let ") {
+    t.Fatalf("format is write-only and must not apply the no-var lint fix: %q", text)
+  }
+}

--- a/packages/lint/test/registry/behavioral_witness_coverage_test.go
+++ b/packages/lint/test/registry/behavioral_witness_coverage_test.go
@@ -134,12 +134,33 @@ func recordedBehavioralWitnesses() map[string][]behavioralWitness {
   return out
 }
 
+// behavioralWitnessPublicRuleSet is the rule set the witness audit requires a
+// positive production witness for: every user-facing registered rule. It is the
+// typed-key parity set (registeredRuleSetForParity) plus the format/* family.
+// Format rules are user-facing but configured through the `format` block rather
+// than a typed `rules` key, so registeredRuleSetForParity — which must match the
+// typed keys — excludes them. The witness audit asks a different question ("does
+// every user-facing rule fire in production?"), so it must not: the formatter
+// family is precisely the over-match-prone surface the witness doctrine exists
+// to guard. Format rules earn their witnesses through the dedicated fixer
+// harnesses under packages/lint/test/format, the same route other rules that
+// cannot run the flat corpus already use.
+func behavioralWitnessPublicRuleSet() map[string]struct{} {
+  public := registeredRuleSetForParity()
+  for _, name := range AllRuleNames() {
+    if strings.HasPrefix(name, "format/") {
+      public[name] = struct{}{}
+    }
+  }
+  return public
+}
+
 // verifyRecordedBehavioralWitnessCoverage runs after the package test suite.
 // A rule can enter the canonical map only after a positive assertion executed,
 // so registry parity can no longer be satisfied by an inert rule object.
 func verifyRecordedBehavioralWitnessCoverage() error {
   candidates := recordedBehavioralWitnesses()
-  public := registeredRuleSetForParity()
+  public := behavioralWitnessPublicRuleSet()
   _, err := auditBehavioralWitnesses(public, candidates)
   if err != nil {
     return err
@@ -444,9 +465,13 @@ func validBehavioralWitnessSources(sources []string) bool {
     strings.HasSuffix(source, "_test.go")
 }
 
+// isNonPublicRuleName reports whether a recorded witness belongs to a rule that
+// is intentionally outside the public audit set. Only the test/ and demo/
+// families qualify: format/* rules ARE public (see behavioralWitnessPublicRuleSet),
+// so a stray format witness for an unregistered id is now correctly flagged
+// instead of silently tolerated.
 func isNonPublicRuleName(ruleName string) bool {
-  return strings.HasPrefix(ruleName, "format/") ||
-    strings.HasPrefix(ruleName, "test/") ||
+  return strings.HasPrefix(ruleName, "test/") ||
     strings.HasPrefix(ruleName, "demo/")
 }
 

--- a/website/src/content/docs/lint/index.mdx
+++ b/website/src/content/docs/lint/index.mdx
@@ -37,11 +37,13 @@ If you only have five minutes: read [Setup](/docs/lint/setup), copy the `lint.co
 
 ```bash
 npx ttsc                # type-check + lint + format diagnostics
-npx ttsc fix            # autofix everything (lint and format), then re-check
+npx ttsc fix            # autofix lint + configured format rules, then re-check
 npx ttsc format         # rewrite source files with the format rules only
 ```
 
 `ttsc fix` is a one-shot project pass. It rejects `--watch`, single-file mode, and `--emit`. Fixes write to disk before the recheck runs, so source stays modified even when the command exits non-zero on remaining errors. Recommended flow: `ttsc fix` locally, commit, then CI runs `ttsc --noEmit` to gate on cleanliness.
+
+`ttsc fix` and `ttsc format` differ on defaults: `ttsc format` applies the always-on default formatter even when no `format` block is configured, while `ttsc fix` applies formatting only from a configured `format` block. With no `format` block, `ttsc fix` is a pure lint autofix pass — add a `format` block (or run `ttsc format`) to reformat as well.
 
 ## What you don't get (yet)
 


### PR DESCRIPTION
Fixes #627.

A grab-bag of four low-severity hygiene items from the audit. Each was verified against master before acting; one is invalidated with evidence.

## Item 1 — `format/*` in the behavioral-witness audit (commit 2)
The audit required a positive production witness for every public rule but drew its set from `registeredRuleSetForParity`, which excludes `format/*` (format rules are configured through the `format` block, not a typed `rules` key). So the audit skipped the very family whose over-matches motivated the coverage doctrine.

- Added `behavioralWitnessPublicRuleSet` = the typed-key parity set **plus** the `format/*` family, and audit against it. `registeredRuleSetForParity` stays format-free so the typed-key parity test is unaffected.
- Dropped `format/` from `isNonPublicRuleName` so a stray/unregistered `format/*` witness is flagged instead of silently tolerated.
- No witness backfill needed: all 17 registered format rules already record witnesses through the `assertFixSnapshot` fixer harnesses under `test/format`. **Shield:** a new format rule that ships without a positive witness now fails the audit.

## Item 2 — `coverage:go` unwired — INVALIDATED (no change)
- The named hazard (library-overwrite flatten) is **already fixed**: `scripts/test-go-coverage.cjs` imports and uses the shared `copyGoTestsFlat` overlay with its seed-`seen` collision guard (#624).
- The "wired into no workflow" state is a **documented, deliberate design**: `website/.../authoring/testing.mdx` calls `coverage:go` "a manual Go coverage gate, separate from `pnpm test` and CI's `Run Tests` step" (since #85, May 2026).
- With the correctness bug already gone and the unwired state intentional, I did not wire it into CI (contradicts the documented design; heavy 100%-coverage gate I could not verify green locally) nor delete a valued/maintained tool. Surfacing for the maintainer: if you'd prefer it wired or dropped despite the doc, say so.

## Item 3 — cache option-derived regexes (commit 1)
`no-fallthrough`/`default-case` (`commentPattern`, per switch), `functional` (identifier patterns, per candidate), and `no-param-reassign` (`ignorePropertyModificationsForRegex`, per function node) rebuilt the same immutable option-derived regex on every `Check`. Added a shared `compileUserPattern` helper (a `sync.Map` keyed on pattern text, caching regexp **and** error) and routed the four per-node sites through it — a behavior-preserving drop-in. Default paths keep their package-level `MustCompile` patterns. **Shield:** `compile_user_pattern_caches_option_regex_test.go` proves compile-once (pointer identity) + stable cached errors.

(`ban-ts-comment`, `sort-imports`, `boundaries`, `no-restricted-imports` were considered and left out: they compile per-file or during option resolution, not per node, and/or use structurally different derived expressions.)

## Item 4 — `ttsc fix` vs `ttsc format` contract (commit 3)
The website claimed `ttsc fix` = "autofix everything (lint and format)", but `fix.go` deliberately wraps a bare `formatCommandResolver` (no `defaultOptions`), so with no `format` block it applies **no** default formatting — while `ttsc format` (via `newFormatCommandResolver`) does. Routing fix through the defaults would reformat every file during a plain lint fix and is contradicted by the existing fix-command tests (their inputs assert lint-only output), so I corrected the **contract statement**, not the behavior:
- Corrected the website command summary + added the fix-vs-format distinction.
- Rewrote the misleading `fix.go` comment (it claimed parity with `ttsc format`'s wrapping).
- **Shield:** `command_fix_skips_default_formatting_that_format_applies_test.go` — on a no-format-block project, `ttsc fix` applies the lint fix but no default formatting, while `ttsc format` applies the default formatter but no lint fix.

## Test plan
Ran the full `packages/lint` Go suite locally against the real tsgo binary (the runner `scripts/test-go-lint.cjs` materialization, `go test ./linthost`): **`ok ... 148.983s`**, exit 0 — this exercises the item-1 audit (format witnesses now required), all item-3 rule behavior, and the item-4 + item-3 shields. gofmt-2spaces applied to touched `.go` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Giu15S7hyRxpupc1XwXe89