### PR TITLE
fix(lint): reject options for optionless rules; type unicorn/no-unnecessary-polyfills targets

### DIFF
--- a/packages/lint/linthost/contrib_adapter.go
+++ b/packages/lint/linthost/contrib_adapter.go
@@ -164,6 +164,17 @@ func (a contributorAdapter) VisitsDeclarationFiles() bool {
   return a.visitsDeclarationFiles
 }
 
+// ConsumesOptions keeps every contributor rule eligible for a configuration
+// options payload. The public `rule.Context` exposes `Options` /
+// `DecodeOptions` with no schema or optionless marker, so the host cannot infer
+// that a third-party rule rejects options. Treating them all as option-bearing
+// preserves the public contract — rejecting a payload a contributor honors
+// would break its config — at the cost of not surfacing an unsupported option
+// for contributor rules, the same conservative default as NeedsTypeChecker.
+func (a contributorAdapter) ConsumesOptions() bool {
+  return true
+}
+
 // formatContributorAdapter is the FormatRule-tagged variant of
 // contributorAdapter. Wrapping the lint-only adapter (rather than
 // duplicating its method set) keeps the marker addition trivial and

--- a/packages/lint/linthost/engine.go
+++ b/packages/lint/linthost/engine.go
@@ -18,6 +18,7 @@
 package linthost
 
 import (
+  "bytes"
   "encoding/json"
   "errors"
   "fmt"
@@ -81,6 +82,17 @@ type ruleOptionsValidator interface {
   ValidateOptions(json.RawMessage) error
 }
 
+// ruleOptionsConsumer marks a rule that reads a configuration options payload
+// but declares no ValidateOptions schema (it decodes leniently). It lets the
+// engine tell a genuinely optionless rule — where a supplied payload is a
+// configuration error rather than an ignored typo — from an options-bearing
+// rule that merely skips strict validation. ValidateOptions implementers and
+// format rules already advertise option support through their own interfaces
+// and need not implement this.
+type ruleOptionsConsumer interface {
+  ConsumesOptions() bool
+}
+
 // isFormatRule reports whether `r` opts into the format category.
 func isFormatRule(r Rule) bool {
   fr, ok := r.(FormatRule)
@@ -98,6 +110,32 @@ func validateRuleOptions(r Rule, options json.RawMessage) error {
     return nil
   }
   return validator.ValidateOptions(options)
+}
+
+// ruleAcceptsOptions reports whether the rule can receive a configuration
+// options payload. A rule advertises option support one of three ways: a
+// ValidateOptions schema, the format category (options arrive from the
+// top-level `format` block), or the ConsumesOptions marker for rules that
+// decode leniently. A rule matching none is optionless, so a payload targeting
+// it is a configuration error instead of a silently dropped setting.
+func ruleAcceptsOptions(r Rule) bool {
+  if _, ok := r.(ruleOptionsValidator); ok {
+    return true
+  }
+  if isFormatRule(r) {
+    return true
+  }
+  consumer, ok := r.(ruleOptionsConsumer)
+  return ok && consumer.ConsumesOptions()
+}
+
+// hasOptionsPayload reports whether raw carries an actual options value rather
+// than a bare severity. Nil, empty, and an explicit JSON null all mean "no
+// options"; anything else — an object, array, string, number, or boolean — is a
+// payload the rule is expected to honor.
+func hasOptionsPayload(raw json.RawMessage) bool {
+  trimmed := bytes.TrimSpace(raw)
+  return len(trimmed) != 0 && !bytes.Equal(trimmed, []byte("null"))
 }
 
 // Context is the per-(file, rule) handle the engine passes to `Check`.
@@ -514,6 +552,7 @@ func NewEngineWithResolver(config RuleResolver) *Engine {
       continue
     }
     optionsValid := true
+    acceptsOptions := ruleAcceptsOptions(rule)
     seenOptions := make(map[string]struct{})
     for _, options := range resolvedRuleOptionsVariants(config, name) {
       key := string(options)
@@ -521,6 +560,19 @@ func NewEngineWithResolver(config RuleResolver) *Engine {
         continue
       }
       seenOptions[key] = struct{}{}
+      if !acceptsOptions {
+        // An optionless rule that is handed a payload would silently drop it,
+        // leaving the user's config inert. Surface it like the validator path
+        // so a config typo or an unsupported option is a hard error.
+        if hasOptionsPayload(options) {
+          eng.configError = errors.Join(
+            eng.configError,
+            fmt.Errorf("@ttsc/lint: rule %q does not accept options", name),
+          )
+          optionsValid = false
+        }
+        continue
+      }
       if err := validateRuleOptions(rule, options); err != nil {
         eng.configError = errors.Join(
           eng.configError,

--- a/packages/lint/linthost/rules_option_consumers.go
+++ b/packages/lint/linthost/rules_option_consumers.go
@@ -1,0 +1,64 @@
+// Option-consumer declarations.
+//
+// The engine rejects a configuration options payload aimed at an optionless
+// rule (see `ruleAcceptsOptions` in engine.go) so a config typo or an
+// unsupported option surfaces instead of being silently dropped. A rule proves
+// it is *not* optionless one of three ways: a `ValidateOptions` schema, the
+// format category (its options arrive from the top-level `format` block), or
+// the `ConsumesOptions` marker below.
+//
+// The rules here read an options payload at runtime — via `ctx.DecodeOptions`
+// or `ctx.Options` — but decode it leniently without a `ValidateOptions`
+// schema. Each must advertise option support so its payload keeps flowing.
+// Rules that already implement `ValidateOptions` (for example
+// `no-restricted-syntax`, `unicorn/better-regex`, `typescript/no-restricted-types`)
+// are deliberately absent: they advertise support through the validator and
+// listing them here too would be redundant. Keeping the full lenient-decoder
+// set in one place makes it auditable against the rule registry.
+package linthost
+
+// boundaries/* (except `boundaries/dependencies`, which validates its options)
+// each decode the shared `boundariesOptions` payload.
+func (boundariesElementTypes) ConsumesOptions() bool { return true }
+func (boundariesExternal) ConsumesOptions() bool     { return true }
+func (boundariesEntryPoint) ConsumesOptions() bool   { return true }
+func (boundariesNoPrivate) ConsumesOptions() bool    { return true }
+func (boundariesNoUnknown) ConsumesOptions() bool    { return true }
+
+// Core / stylistic rules that decode a positional or object options payload.
+func (banTsComment) ConsumesOptions() bool            { return true }
+func (defaultCase) ConsumesOptions() bool             { return true }
+func (noEmpty) ConsumesOptions() bool                 { return true }
+func (noEmptyFunction) ConsumesOptions() bool         { return true }
+func (noDuplicateImports) ConsumesOptions() bool      { return true }
+func (noElseReturn) ConsumesOptions() bool            { return true }
+func (noExtendNative) ConsumesOptions() bool          { return true }
+func (noFallthrough) ConsumesOptions() bool           { return true }
+func (noInnerDeclarations) ConsumesOptions() bool     { return true }
+func (noPromiseExecutorReturn) ConsumesOptions() bool { return true }
+func (noReturnAssign) ConsumesOptions() bool          { return true }
+func (noUnusedExpressions) ConsumesOptions() bool     { return true }
+func (preferConst) ConsumesOptions() bool             { return true }
+
+// functional/* rules that decode a functional-pattern options payload.
+func (functionalParameters) ConsumesOptions() bool                  { return true }
+func (functionalImmutableData) ConsumesOptions() bool               { return true }
+func (functionalNoLet) ConsumesOptions() bool                       { return true }
+func (functionalNoTryStatements) ConsumesOptions() bool             { return true }
+func (functionalPreferImmutableTypes) ConsumesOptions() bool        { return true }
+func (functionalPreferReadonlyType) ConsumesOptions() bool          { return true }
+func (functionalReadonlyType) ConsumesOptions() bool                { return true }
+func (functionalTypeDeclarationImmutability) ConsumesOptions() bool { return true }
+
+// TypeScript rules that decode an options payload.
+func (noFloatingPromises) ConsumesOptions() bool        { return true }
+func (noMisusedPromises) ConsumesOptions() bool         { return true }
+func (switchExhaustivenessCheck) ConsumesOptions() bool { return true }
+
+// Remaining plugin-namespace rules with lenient option decoders.
+func (reactPerfRule) ConsumesOptions() bool                     { return true }
+func (onlyExportComponents) ConsumesOptions() bool              { return true }
+func (storybookNoUninstalledAddons) ConsumesOptions() bool      { return true }
+func (testingLibraryRule) ConsumesOptions() bool                { return true }
+func (cypressUnsafeToChainCommand) ConsumesOptions() bool       { return true }
+func (unicornTextEncodingIdentifierCase) ConsumesOptions() bool { return true }

--- a/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
+++ b/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
@@ -50,6 +50,7 @@ import type {
   ITtscLintUnicornFilenameCaseRuleOptions,
   ITtscLintUnicornImportStyleRuleOptions,
   ITtscLintUnicornIsolatedFunctionsRuleOptions,
+  ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions,
   ITtscLintUnicornPreventAbbreviationsRuleOptions,
   ITtscLintUnicornStringContentRuleOptions,
   ITtscLintUnicornTemplateIndentRuleOptions,
@@ -134,4 +135,5 @@ export interface ITtscLintRuleOptionsMap {
   "unicorn/filename-case": ITtscLintUnicornFilenameCaseRuleOptions;
   "unicorn/string-content": ITtscLintUnicornStringContentRuleOptions;
   "unicorn/isolated-functions": ITtscLintUnicornIsolatedFunctionsRuleOptions;
+  "unicorn/no-unnecessary-polyfills": ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions;
 }

--- a/packages/lint/src/structures/rules/ITtscLintUnicornRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintUnicornRuleOptions.ts
@@ -298,3 +298,32 @@ export interface ITtscLintUnicornStringContentRuleOptions {
   /** AST selectors that replace the default Literal/TemplateElement targets. */
   selectors?: readonly string[];
 }
+
+/**
+ * A Browserslist / core-js-compat targets object: each runtime or browser name
+ * mapped to the minimum supported version (`{ node: "18" }`), or an ESM
+ * capability flag (`{ esmodules: true }`). The `browsers` key may carry a
+ * Browserslist query string or an array of queries.
+ */
+export type TtscLintUnicornPolyfillTargets = Readonly<
+  Record<string, string | number | boolean | readonly string[]>
+>;
+
+/**
+ * Options for `unicorn/no-unnecessary-polyfills`.
+ *
+ * `targets` selects the runtime baseline each imported polyfill is compared
+ * against. Omit it to fall back to Browserslist config discovery from the
+ * linted file's directory and, last, the nearest `package.json` `engines`
+ * field — mirroring the upstream rule.
+ *
+ * @reference https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unnecessary-polyfills.md
+ */
+export interface ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions {
+  /**
+   * A Browserslist query string (`"node 18"`), an array of queries
+   * (`["node 18", "chrome 120"]`), or a targets object mapping each runtime to
+   * its minimum version.
+   */
+  targets?: string | readonly string[] | TtscLintUnicornPolyfillTargets;
+}

--- a/packages/lint/src/structures/rules/ITtscLintUnicornRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintUnicornRules.ts
@@ -8,6 +8,7 @@ import type {
   ITtscLintUnicornFilenameCaseRuleOptions,
   ITtscLintUnicornImportStyleRuleOptions,
   ITtscLintUnicornIsolatedFunctionsRuleOptions,
+  ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions,
   ITtscLintUnicornPreventAbbreviationsRuleOptions,
   ITtscLintUnicornStringContentRuleOptions,
   ITtscLintUnicornTemplateIndentRuleOptions,
@@ -490,7 +491,7 @@ export interface ITtscLintUnicornRules {
    *
    * @reference https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unnecessary-polyfills.md
    */
-  "unicorn/no-unnecessary-polyfills"?: TtscLintRuleSetting;
+  "unicorn/no-unnecessary-polyfills"?: TtscLintRuleOptionsSetting<ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions>;
 
   /**
    * Reject `.length` / `Infinity` as the end argument to `slice`; omit it to

--- a/packages/lint/test/engine/engine_accepts_options_for_options_bearing_rule_test.go
+++ b/packages/lint/test/engine/engine_accepts_options_for_options_bearing_rule_test.go
@@ -1,0 +1,43 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+)
+
+// TestEngineAcceptsOptionsForOptionsBearingRule is the negative twin proving the
+// optionless gate does not over-reject: a rule that advertises option support
+// keeps its payload.
+//
+// Support is advertised two ways the gate must both honor — the ConsumesOptions
+// marker for a lenient decoder (`default-case`) and a ValidateOptions schema
+// (`unicorn/string-content`). Each receives a valid payload; neither may raise a
+// ConfigError, and both must stay enabled. Were `ruleAcceptsOptions` to miss
+// either path, an option-bearing rule would be wrongly reported as optionless.
+//
+//  1. Configure a marker rule and a validator rule each with a valid payload.
+//  2. Assert no ConfigError is raised.
+//  3. Assert both rules are active in EnabledRules.
+func TestEngineAcceptsOptionsForOptionsBearingRule(t *testing.T) {
+  cases := []struct {
+    rule    string
+    options string
+  }{
+    {rule: "default-case", options: `{"commentPattern":"^skip"}`},
+    {rule: "unicorn/string-content", options: `{"patterns":{"foo":"bar"}}`},
+  }
+  for _, testCase := range cases {
+    t.Run(testCase.rule, func(t *testing.T) {
+      engine := NewEngineWithResolver(InlineRuleResolver{
+        Rules:   RuleConfig{testCase.rule: SeverityError},
+        Options: RuleOptionsMap{testCase.rule: json.RawMessage(testCase.options)},
+      })
+      if err := engine.ConfigError(); err != nil {
+        t.Fatalf("valid options %q on %q raised ConfigError: %v", testCase.options, testCase.rule, err)
+      }
+      if _, active := engine.EnabledRules()[testCase.rule]; !active {
+        t.Fatalf("option-bearing rule %q dropped out of dispatch: %v", testCase.rule, engine.EnabledRules())
+      }
+    })
+  }
+}

--- a/packages/lint/test/engine/engine_keeps_optionless_rule_without_a_payload_test.go
+++ b/packages/lint/test/engine/engine_keeps_optionless_rule_without_a_payload_test.go
@@ -1,0 +1,35 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+)
+
+// TestEngineKeepsOptionlessRuleWithoutAPayload is the negative twin of
+// TestEngineRejectsOptionsForOptionlessRule: the optionless gate must fire only
+// on an actual payload, never on a bare severity.
+//
+// A bare severity, an absent options slot, and an explicit JSON `null` all mean
+// "use the rule's defaults" and must leave an optionless rule enabled with no
+// ConfigError. An over-eager gate that rejected these would break every
+// severity-only config for the ~400 rules that take no options.
+//
+//  1. Configure an optionless rule with no payload, an empty payload, and null.
+//  2. Assert no ConfigError is raised.
+//  3. Assert the rule is active in EnabledRules.
+func TestEngineKeepsOptionlessRuleWithoutAPayload(t *testing.T) {
+  const rule = "no-labels"
+  payloads := []json.RawMessage{nil, json.RawMessage(``), json.RawMessage(`null`)}
+  for _, payload := range payloads {
+    engine := NewEngineWithResolver(InlineRuleResolver{
+      Rules:   RuleConfig{rule: SeverityError},
+      Options: RuleOptionsMap{rule: payload},
+    })
+    if err := engine.ConfigError(); err != nil {
+      t.Fatalf("bare-severity payload %q raised ConfigError: %v", string(payload), err)
+    }
+    if _, active := engine.EnabledRules()[rule]; !active {
+      t.Fatalf("optionless rule dropped out of dispatch for payload %q: %v", string(payload), engine.EnabledRules())
+    }
+  }
+}

--- a/packages/lint/test/engine/engine_rejects_options_for_optionless_rule_test.go
+++ b/packages/lint/test/engine/engine_rejects_options_for_optionless_rule_test.go
@@ -1,0 +1,53 @@
+package linthost
+
+import (
+  "encoding/json"
+  "strings"
+  "testing"
+)
+
+// TestEngineRejectsOptionsForOptionlessRule verifies engine construction turns
+// an options payload aimed at a rule with no options schema into a hard
+// ConfigError instead of silently dropping it.
+//
+// The optionless-rule case is the general half of issue #626: `no-labels` and
+// `no-cond-assign` are ports that take no options, so ESLint-style config like
+// `["error", {allowLoop: true}]` or `["error", "always"]` used to be accepted
+// and ignored — inert config with no signal, an option-dependent false positive
+// AND false negative. Both the object and the bare-scalar payload shapes must be
+// rejected, and the rule must not enter the dispatch table.
+//
+//  1. Build an engine that gives an optionless rule an options payload.
+//  2. Assert ConfigError names the rule and the "does not accept options" cause.
+//  3. Assert the rule is absent from EnabledRules.
+func TestEngineRejectsOptionsForOptionlessRule(t *testing.T) {
+  cases := []struct {
+    name    string
+    rule    string
+    options string
+  }{
+    {name: "object payload", rule: "no-labels", options: `{"allowLoop":true}`},
+    {name: "scalar payload", rule: "no-cond-assign", options: `"always"`},
+    {name: "array payload", rule: "no-labels", options: `["always"]`},
+    {name: "empty object payload", rule: "no-cond-assign", options: `{}`},
+  }
+  for _, testCase := range cases {
+    t.Run(testCase.name, func(t *testing.T) {
+      engine := NewEngineWithResolver(InlineRuleResolver{
+        Rules:   RuleConfig{testCase.rule: SeverityError},
+        Options: RuleOptionsMap{testCase.rule: json.RawMessage(testCase.options)},
+      })
+      err := engine.ConfigError()
+      if err == nil ||
+        !strings.Contains(err.Error(), testCase.rule) ||
+        !strings.Contains(err.Error(), "does not accept options") {
+        t.Fatalf("options %q on %q: want ConfigError \"does not accept options\", got %v",
+          testCase.options, testCase.rule, err)
+      }
+      if _, active := engine.EnabledRules()[testCase.rule]; active {
+        t.Fatalf("%q entered dispatch despite an invalid options payload: %v",
+          testCase.rule, engine.EnabledRules())
+      }
+    })
+  }
+}

--- a/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
+++ b/tests/test-lint/src/features/plugin/test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts
@@ -47,6 +47,9 @@ import assert from "node:assert/strict";
  *   out-of-enum global policies.
  * - An empty object policy for `typescript/ban-ts-comment` is rejected because
  *   the object form requires `descriptionFormat`.
+ * - `unicorn/no-unnecessary-polyfills` accepts `targets` as a query string, an
+ *   array of queries, or a targets object, and the option may be omitted;
+ *   a typo'd key and a non-query `targets` value are rejected.
  * - A lint-only rule (`no-var`) cannot carry an options object.
  * - An identifier-form built-in name without the canonical slash (`reactJsxKey`)
  *   is rejected.
@@ -233,8 +236,33 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
         },
       ],
       "unicorn/better-regex": ["warning", { sortCharacterClasses: false }],
+      "unicorn/no-unnecessary-polyfills": [
+        "error",
+        { targets: { node: "18", esmodules: true, browsers: ["chrome 120"] } },
+      ],
     },
   };
+
+  // `unicorn/no-unnecessary-polyfills` accepts `targets` as a Browserslist query
+  // string, an array of queries, or a targets object, and the option may be
+  // omitted (config discovery / package.json engines resolves the baseline).
+  const polyfillsTargetForms: readonly ITtscLintConfig[] = [
+    {
+      rules: {
+        "unicorn/no-unnecessary-polyfills": ["error", { targets: "node 18" }],
+      },
+    },
+    {
+      rules: {
+        "unicorn/no-unnecessary-polyfills": [
+          "error",
+          { targets: ["node 18", "chrome 120"] },
+        ],
+      },
+    },
+    { rules: { "unicorn/no-unnecessary-polyfills": "error" } },
+    { rules: { "unicorn/no-unnecessary-polyfills": ["error"] } },
+  ];
 
   const bareTuple: ITtscLintConfig = {
     rules: {
@@ -589,8 +617,23 @@ export const test_lib_index_d_ts_rule_options_autocomplete_per_rule = () => {
       reactJsxKey: "error",
     },
   };
+  const polyfillsOptionKeyTypo: ITtscLintConfig = {
+    rules: {
+      // @ts-expect-error — `target` is a typo of `targets`; the rule exposes no arbitrary option keys.
+      "unicorn/no-unnecessary-polyfills": ["error", { target: "node 18" }],
+    },
+  };
+  const polyfillsTargetsValueShape: ITtscLintConfig = {
+    rules: {
+      // @ts-expect-error — targets is a query string, an array of queries, or a targets object; a bare number is rejected.
+      "unicorn/no-unnecessary-polyfills": ["error", { targets: 42 }],
+    },
+  };
 
   assert.ok(config);
+  assert.ok(polyfillsTargetForms.every((form) => form.rules));
+  assert.ok(polyfillsOptionKeyTypo);
+  assert.ok(polyfillsTargetsValueShape);
   assert.ok(bareTuple);
   assert.ok(noParamReassignImplicitProps);
   assert.ok(ruleNameTypo);


### PR DESCRIPTION
Fixes #626.

## Intent

Two related option-handling defects in `@ttsc/lint`:

1. **Options silently ignored for optionless rules.** Engine construction accepted and dropped an options payload aimed at a rule with no options schema, so a config typo / unsupported option left the config inert with no diagnostic — option-dependent false positive AND false negative (`["error", {allowLoop: true}]` on `no-labels` still fired; `["error", "always"]` on `no-cond-assign` stayed silent).
2. **`unicorn/no-unnecessary-polyfills` `targets` forbidden by the published TS types.** The Go rule validates and honors a `targets` option, but the typed key was severity-only and absent from `ITtscLintRuleOptionsMap`, so a type-checked config passing `{ targets: "node 18" }` was a TS error the runtime nonetheless honors.

Verified against current `master` (both claims reproduce).

## Scope

**Defect 1 — general engine gate.** `ruleAcceptsOptions` classifies a rule as option-bearing via `ValidateOptions`, the format category, or a new `ConsumesOptions` marker; the binding loop rejects a real payload (`hasOptionsPayload`: non-nil, non-`null`) for any rule matching none, emitting `rule "X" does not accept options` and keeping it out of dispatch. This seals every optionless rule (~400), not just the two examples.
- Every built-in rule that reads `ctx.Options` / `ctx.DecodeOptions` without a validator carries the marker, declared in one auditable file (`rules_option_consumers.go`).
- Contributor rules keep accepting options unconditionally — the public `rule.Context` has no optionless marker, so the host cannot infer one (same conservative default as `NeedsTypeChecker`).

**Defect 2 — polyfills typing (this issue's named rule only).** New `ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions` (`targets`: query string | array of queries | targets object; optional, matching the decoder's config-discovery fallback), wired into `ITtscLintRuleOptionsMap`, key switched to `TtscLintRuleOptionsSetting<…>`. `TtscLintRuleOptionsSetting` is a superset of `TtscLintRuleSetting`, so no existing config breaks.

## Deferred / notes

- **Broader defect-2 class.** `no-unnecessary-polyfills` is *not* the sole option-consuming rule missing a typed key on current master; the same mismatch exists for `unicorn/no-typeof-undefined`, `unicorn/prefer-number-properties`, `default-case`, `no-else-return`, `no-extend-native`, `no-inner-declarations`, `no-return-assign`, and `unicorn/text-encoding-identifier-case`. Per the issue's stated scope this PR fixes only polyfills; the marker preserves the others' runtime behavior so nothing regresses. A full options-parity test (typed key ⇔ Go option support) is deferred until those are individually aligned, since a strict cross-check would red-CI on rules other branches own.
- **Overlap with `fix/lint-checker-pool-and-options-v2`.** That branch reworks `unicorn/prefer-number-properties` / `no-mixed-operators` options and does **not** touch the engine, the marker file, or `contrib_adapter.go`, so there is no overlap with this change. (`prefer-number-properties` uses `ValidateOptions`, so it needs no marker here.)

## Test plan

- `packages/lint/test/engine/`: an optionless rule's payload (object, scalar, array, `{}`) is rejected and dropped from dispatch; the negative twins — bare severity / empty / explicit `null` stays enabled, and a marker rule (`default-case`) and a validator rule (`unicorn/string-content`) keep their payloads.
- `test_lib_index_d_ts_rule_options_autocomplete_per_rule.ts`: the three valid `targets` forms plus omission compile; a typo'd key and a non-query value are `@ts-expect-error`.
- Full `packages/lint` Go suite green locally (engine, config, rules, plugin/contributor, format). TS type contract validated with a standalone `tsc --strict` probe over the structures.