### PR TITLE
fix(test): audit every lint corpus source

### DIFF
--- a/packages/lint/linthost/rules_jsx_a11y.go
+++ b/packages/lint/linthost/rules_jsx_a11y.go
@@ -5,6 +5,7 @@ import (
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
+  "golang.org/x/text/language"
 )
 
 type jsxAttr struct {
@@ -456,7 +457,7 @@ func jsxIsFocusable(info jsxElementInfo) bool {
 
 func jsxIsNonInteractiveElement(tag string) bool {
   switch tag {
-  case "article", "aside", "div", "footer", "header", "li", "main", "nav", "ol", "p", "section", "ul",
+  case "article", "aside", "footer", "header", "li", "main", "nav", "ol", "p", "section", "ul",
     "h1", "h2", "h3", "h4", "h5", "h6":
     return true
   }
@@ -573,7 +574,26 @@ var jsxAutocompleteTokens = map[string]bool{
   "transaction-currency": true, "transaction-amount": true, "language": true, "bday": true,
   "bday-day": true, "bday-month": true, "bday-year": true, "sex": true, "tel": true,
   "tel-country-code": true, "tel-national": true, "tel-area-code": true, "tel-local": true,
-  "tel-extension": true, "impp": true, "url": true, "photo": true,
+  "tel-local-prefix": true, "tel-local-suffix": true, "tel-extension": true,
+  "impp": true, "url": true, "photo": true,
+}
+
+var jsxAutocompleteContactQualifiers = map[string]bool{
+  "home": true, "work": true, "mobile": true, "fax": true, "pager": true,
+}
+
+var jsxAutocompleteContactPurposes = map[string]bool{
+  "email": true, "impp": true, "tel": true, "tel-country-code": true,
+  "tel-national": true, "tel-area-code": true, "tel-local": true,
+  "tel-local-prefix": true, "tel-local-suffix": true, "tel-extension": true,
+}
+
+var jsxHTMLInputTypes = map[string]bool{
+  "button": true, "checkbox": true, "color": true, "date": true, "datetime-local": true,
+  "email": true, "file": true, "hidden": true, "image": true, "month": true,
+  "number": true, "password": true, "radio": true, "range": true, "reset": true,
+  "search": true, "submit": true, "tel": true, "text": true, "time": true,
+  "url": true, "week": true,
 }
 
 type jsxA11yAltText struct{}
@@ -608,8 +628,10 @@ func (jsxA11yAltText) Check(ctx *Context, node *shimast.Node) {
 
 type jsxA11yAnchorHasContent struct{}
 
-func (jsxA11yAnchorHasContent) Name() string           { return "jsx-a11y/anchor-has-content" }
-func (jsxA11yAnchorHasContent) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindJsxElement} }
+func (jsxA11yAnchorHasContent) Name() string { return "jsx-a11y/anchor-has-content" }
+func (jsxA11yAnchorHasContent) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindJsxElement, shimast.KindJsxSelfClosingElement}
+}
 func (jsxA11yAnchorHasContent) Check(ctx *Context, node *shimast.Node) {
   info := jsxElementFromNode(node)
   if info.tag == "a" && !info.spread && !jsxHasAccessibleLabel(info) {
@@ -756,21 +778,123 @@ func (jsxA11yAutocompleteValid) Visits() []shimast.Kind {
 }
 func (jsxA11yAutocompleteValid) Check(ctx *Context, node *shimast.Node) {
   info := jsxElementFromNode(node)
-  attr, ok := jsxKnownAttr(info.attrs, "autoComplete")
-  if !ok {
-    attr, ok = jsxKnownAttr(info.attrs, "autocomplete")
-  }
-  if !ok || strings.TrimSpace(attr.value) == "" {
+  if info.tag != "input" {
     return
   }
-  for _, token := range strings.Fields(strings.ToLower(attr.value)) {
-    if strings.HasPrefix(token, "section-") || token == "shipping" || token == "billing" || token == "home" || token == "work" || token == "mobile" || token == "fax" || token == "pager" {
-      continue
+  attr, ok := info.attrs["autoComplete"]
+  if !ok {
+    attr, ok = info.attrs["autocomplete"]
+  }
+  if !ok {
+    return
+  }
+  value, ok := jsxStringLiteralAttrValue(attr)
+  if !ok || strings.TrimSpace(value) == "" {
+    return
+  }
+  purpose, valid := jsxAutocompletePurpose(value)
+  if !valid {
+    ctx.Report(attr.node, "autocomplete contains an invalid token sequence.")
+    return
+  }
+  if !jsxAutocompletePurposeAllowsInputType(purpose, jsxAutocompleteInputType(info)) {
+    ctx.Report(attr.node, "autocomplete token is not valid for this input type.")
+  }
+}
+
+func jsxStringLiteralAttrValue(attr jsxAttr) (string, bool) {
+  if attr.node == nil || attr.boolean {
+    return "", false
+  }
+  jsx := attr.node.AsJsxAttribute()
+  if jsx == nil || jsx.Initializer == nil {
+    return "", false
+  }
+  switch jsx.Initializer.Kind {
+  case shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral:
+    return stringLiteralText(jsx.Initializer), true
+  case shimast.KindJsxExpression:
+    expression := jsx.Initializer.AsJsxExpression()
+    if expression != nil && expression.Expression != nil && (expression.Expression.Kind == shimast.KindStringLiteral || expression.Expression.Kind == shimast.KindNoSubstitutionTemplateLiteral) {
+      return stringLiteralText(expression.Expression), true
     }
-    if !jsxAutocompleteTokens[token] {
-      ctx.Report(attr.node, "autocomplete contains an invalid token.")
-      return
+  }
+  return "", false
+}
+
+func jsxAutocompletePurpose(value string) (string, bool) {
+  tokens := strings.Fields(strings.ToLower(value))
+  if len(tokens) == 1 && (tokens[0] == "on" || tokens[0] == "off") {
+    return tokens[0], true
+  }
+  index := 0
+  if index < len(tokens) && strings.HasPrefix(tokens[index], "section-") {
+    if len(tokens[index]) == len("section-") {
+      return "", false
     }
+    index++
+  }
+  if index < len(tokens) && (tokens[index] == "shipping" || tokens[index] == "billing") {
+    index++
+  }
+  qualifier := ""
+  if index < len(tokens) && jsxAutocompleteContactQualifiers[tokens[index]] {
+    qualifier = tokens[index]
+    index++
+  }
+  if index >= len(tokens) {
+    return "", false
+  }
+  purpose := tokens[index]
+  index++
+  if index < len(tokens) {
+    if index != len(tokens)-1 || tokens[index] != "webauthn" {
+      return "", false
+    }
+    index++
+  }
+  if purpose == "on" || purpose == "off" || !jsxAutocompleteTokens[purpose] {
+    return "", false
+  }
+  if qualifier != "" && !jsxAutocompleteContactPurposes[purpose] {
+    return "", false
+  }
+  return purpose, index == len(tokens)
+}
+
+func jsxAutocompleteInputType(info jsxElementInfo) string {
+  attr, ok := jsxKnownAttr(info.attrs, "type")
+  if !ok {
+    return "text"
+  }
+  inputType := strings.ToLower(strings.TrimSpace(attr.value))
+  if !jsxHTMLInputTypes[inputType] {
+    return "text"
+  }
+  return inputType
+}
+
+func jsxAutocompletePurposeAllowsInputType(purpose string, inputType string) bool {
+  if purpose == "" || purpose == "on" || purpose == "off" || inputType == "text" {
+    return true
+  }
+  switch purpose {
+  case "email", "username":
+    return inputType == "email" || inputType == "search"
+  case "url", "photo", "impp":
+    return inputType == "url" || inputType == "search"
+  case "tel", "tel-country-code", "tel-national", "tel-area-code", "tel-local", "tel-local-prefix", "tel-local-suffix", "tel-extension":
+    return inputType == "tel" || inputType == "search"
+  case "new-password", "current-password":
+    return inputType == "password" || inputType == "search"
+  case "bday":
+    return inputType == "date" || inputType == "search"
+  case "cc-exp":
+    return inputType == "month" || inputType == "tel" || inputType == "search"
+  case "cc-number", "cc-exp-month", "cc-exp-year", "cc-csc", "transaction-amount", "bday-day", "bday-month", "bday-year":
+    return inputType == "number" || inputType == "tel" || inputType == "search"
+  default:
+    return false
   }
 }
 
@@ -806,7 +930,7 @@ type jsxA11yHeadingHasContent struct{}
 
 func (jsxA11yHeadingHasContent) Name() string { return "jsx-a11y/heading-has-content" }
 func (jsxA11yHeadingHasContent) Visits() []shimast.Kind {
-  return []shimast.Kind{shimast.KindJsxElement}
+  return []shimast.Kind{shimast.KindJsxElement, shimast.KindJsxSelfClosingElement}
 }
 func (jsxA11yHeadingHasContent) Check(ctx *Context, node *shimast.Node) {
   info := jsxElementFromNode(node)
@@ -826,8 +950,55 @@ func (jsxA11yHtmlHasLang) Visits() []shimast.Kind {
 }
 func (jsxA11yHtmlHasLang) Check(ctx *Context, node *shimast.Node) {
   info := jsxElementFromNode(node)
-  if info.tag == "html" && !info.spread && !jsxHasAttr(info.attrs, "lang") {
-    ctx.Report(info.opening, "The html element must have a lang attribute.")
+  if info.tag != "html" {
+    return
+  }
+  if !jsxHasAttr(info.attrs, "lang") {
+    if !info.spread {
+      ctx.Report(info.opening, "The html element must have a lang attribute.")
+    }
+    return
+  }
+  if attr := info.attrs["lang"]; jsxA11yHtmlLangIsStaticallyFalsy(attr) {
+    ctx.Report(attr.node, "The html element must have a non-empty lang attribute.")
+  }
+}
+
+func jsxA11yHtmlLangIsStaticallyFalsy(attr jsxAttr) bool {
+  if attr.node == nil || attr.boolean {
+    return false
+  }
+  jsx := attr.node.AsJsxAttribute()
+  if jsx == nil || jsx.Initializer == nil {
+    return false
+  }
+  if jsx.Initializer.Kind == shimast.KindStringLiteral || jsx.Initializer.Kind == shimast.KindNoSubstitutionTemplateLiteral {
+    return strings.TrimSpace(stringLiteralText(jsx.Initializer)) == ""
+  }
+  if jsx.Initializer.Kind != shimast.KindJsxExpression {
+    return false
+  }
+  expression := jsx.Initializer.AsJsxExpression()
+  if expression == nil || expression.Expression == nil {
+    return true
+  }
+  switch expression.Expression.Kind {
+  case shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral:
+    return strings.TrimSpace(stringLiteralText(expression.Expression)) == ""
+  case shimast.KindFalseKeyword, shimast.KindNullKeyword:
+    return true
+  case shimast.KindNumericLiteral:
+    value := strings.ReplaceAll(numericLiteralText(expression.Expression), "_", "")
+    if integer, err := strconv.ParseInt(value, 0, 64); err == nil {
+      return integer == 0
+    }
+    if unsigned, err := strconv.ParseUint(value, 0, 64); err == nil {
+      return unsigned == 0
+    }
+    number, err := strconv.ParseFloat(value, 64)
+    return err == nil && number == 0
+  default:
+    return identifierText(expression.Expression) == "undefined"
   }
 }
 
@@ -910,21 +1081,60 @@ func (jsxA11yLang) Visits() []shimast.Kind {
 }
 func (jsxA11yLang) Check(ctx *Context, node *shimast.Node) {
   info := jsxElementFromNode(node)
-  attr, ok := jsxKnownAttr(info.attrs, "lang")
+  if info.tag != "html" {
+    return
+  }
+  attr, ok := info.attrs["lang"]
   if !ok {
     return
   }
-  value := strings.TrimSpace(attr.value)
-  parts := strings.Split(value, "-")
-  if value == "" || len(parts[0]) < 2 || len(parts[0]) > 3 {
+  if jsxA11yLangIsInvalid(attr) {
     ctx.Report(attr.node, "lang must be a valid BCP 47 language tag.")
+  }
+}
+
+func jsxA11yLangIsInvalid(attr jsxAttr) bool {
+  if attr.node == nil || attr.boolean {
+    return true
+  }
+  jsx := attr.node.AsJsxAttribute()
+  if jsx == nil || jsx.Initializer == nil {
+    return true
+  }
+  validate := func(value string) bool {
+    if value != strings.TrimSpace(value) {
+      return true
+    }
+    _, err := language.Parse(value)
+    return err != nil
+  }
+  switch jsx.Initializer.Kind {
+  case shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral:
+    return validate(stringLiteralText(jsx.Initializer))
+  case shimast.KindJsxExpression:
+    expression := jsx.Initializer.AsJsxExpression()
+    if expression == nil || expression.Expression == nil {
+      return true
+    }
+    switch expression.Expression.Kind {
+    case shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral:
+      return validate(stringLiteralText(expression.Expression))
+    case shimast.KindTrueKeyword, shimast.KindFalseKeyword, shimast.KindNumericLiteral:
+      return true
+    default:
+      return identifierText(expression.Expression) == "undefined"
+    }
+  default:
+    return false
   }
 }
 
 type jsxA11yMediaHasCaption struct{}
 
-func (jsxA11yMediaHasCaption) Name() string           { return "jsx-a11y/media-has-caption" }
-func (jsxA11yMediaHasCaption) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindJsxElement} }
+func (jsxA11yMediaHasCaption) Name() string { return "jsx-a11y/media-has-caption" }
+func (jsxA11yMediaHasCaption) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindJsxElement, shimast.KindJsxSelfClosingElement}
+}
 func (jsxA11yMediaHasCaption) Check(ctx *Context, node *shimast.Node) {
   info := jsxElementFromNode(node)
   if (info.tag == "audio" || info.tag == "video") && !info.spread && !jsxHasTrackCaption(info.children) {

--- a/packages/lint/test/registry/behavioral_witness_exclusions.json
+++ b/packages/lint/test/registry/behavioral_witness_exclusions.json
@@ -1,8 +1,33 @@
 [
   {
-    "rule": "nextjs/no-typos",
-    "constraint": "filename",
-    "harness": "packages/lint/test/rules/nextjs/no_typos_reports_misspelled_data_export_test.go"
+    "rule": "boundaries/dependencies",
+    "constraint": "project",
+    "harness": "packages/lint/test/rules/boundaries/boundaries_dependencies_test.go"
+  },
+  {
+    "rule": "boundaries/element-types",
+    "constraint": "project",
+    "harness": "packages/lint/test/rules/boundaries/boundaries_element_types_rejects_disallowed_import_test.go"
+  },
+  {
+    "rule": "boundaries/entry-point",
+    "constraint": "project",
+    "harness": "packages/lint/test/rules/boundaries/boundaries_entry_point_rejects_non_entry_import_test.go"
+  },
+  {
+    "rule": "boundaries/external",
+    "constraint": "project",
+    "harness": "packages/lint/test/rules/boundaries/boundaries_external_rejects_disallowed_package_test.go"
+  },
+  {
+    "rule": "boundaries/no-private",
+    "constraint": "project",
+    "harness": "packages/lint/test/rules/boundaries/boundaries_no_private_rejects_cross_element_private_import_test.go"
+  },
+  {
+    "rule": "boundaries/no-unknown",
+    "constraint": "project",
+    "harness": "packages/lint/test/rules/boundaries/boundaries_no_unknown_rejects_unknown_import_target_test.go"
   },
   {
     "rule": "storybook/no-uninstalled-addons",

--- a/packages/lint/test/rules/jsx-a11y/jsx_a11y_anchor_has_content_rejects_empty_anchor_test.go
+++ b/packages/lint/test/rules/jsx-a11y/jsx_a11y_anchor_has_content_rejects_empty_anchor_test.go
@@ -4,12 +4,13 @@ import "testing"
 
 // TestJsxA11yAnchorHasContentRejectsEmptyAnchor verifies anchors need content.
 //
-// Empty links are invisible to assistive technology. This case locks the child
-// text scan for normal JSX elements rather than self-closing attribute-only nodes.
+// Empty links are invisible to assistive technology. Both normal and
+// self-closing JSX elements can omit accessible child content.
 //
-// 1. Parse an anchor with an href but no children or accessible label.
+// 1. Parse normal and self-closing anchors with no accessible label.
 // 2. Enable only `jsx-a11y/anchor-has-content`.
-// 3. Assert one diagnostic is reported.
+// 3. Assert each empty anchor reports a diagnostic.
 func TestJsxA11yAnchorHasContentRejectsEmptyAnchor(t *testing.T) {
   assertJsxA11yRuleFinds(t, "jsx-a11y/anchor-has-content", `const Component = () => <a href="/home"></a>;`, "content")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/anchor-has-content", `const Component = () => <a href="/home" />;`, "content")
 }

--- a/packages/lint/test/rules/jsx-a11y/jsx_a11y_autocomplete_valid_allows_appropriate_input_type_test.go
+++ b/packages/lint/test/rules/jsx-a11y/jsx_a11y_autocomplete_valid_allows_appropriate_input_type_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestJsxA11yAutocompleteValidAllowsAppropriateInputType verifies compatible purposes remain valid.
+//
+// Specialized inputs should retain the autofill purpose designed for their
+// value domain. Invalid types use HTML's text fallback; non-inputs are ignored.
+//
+// 1. Parse matching inputs and a non-input carrying an arbitrary value.
+// 2. Enable only `jsx-a11y/autocomplete-valid`.
+// 3. Assert each compatible pair reports no diagnostic.
+func TestJsxA11yAutocompleteValidAllowsAppropriateInputType(t *testing.T) {
+  assertJsxA11yRuleSkips(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input type="email" autoComplete="email" />;`)
+  assertJsxA11yRuleSkips(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input type="url" autoComplete="url" />;`)
+  assertJsxA11yRuleSkips(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input type="potato" autoComplete="name" />;`)
+  assertJsxA11yRuleSkips(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input type autoComplete="name" />;`)
+  assertJsxA11yRuleSkips(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input type="email" autoComplete="section-blue shipping home email" />;`)
+  assertJsxA11yRuleSkips(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input autoComplete="username webauthn" />;`)
+  assertJsxA11yRuleSkips(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input autoComplete />;`)
+  assertJsxA11yRuleSkips(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input autoComplete={true} />;`)
+  assertJsxA11yRuleSkips(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input autoComplete={42} />;`)
+  assertJsxA11yRuleSkips(t, "jsx-a11y/autocomplete-valid", `const Component = () => <div autoComplete="definitely" />;`)
+}

--- a/packages/lint/test/rules/jsx-a11y/jsx_a11y_autocomplete_valid_rejects_inappropriate_input_type_test.go
+++ b/packages/lint/test/rules/jsx-a11y/jsx_a11y_autocomplete_valid_rejects_inappropriate_input_type_test.go
@@ -1,0 +1,15 @@
+package linthost
+
+import "testing"
+
+// TestJsxA11yAutocompleteValidRejectsInappropriateInputType verifies purpose/type compatibility.
+//
+// A registered autofill purpose can still be invalid for a specialized input.
+// URL data must not be offered to an email control.
+//
+// 1. Parse an email input with the registered `url` autocomplete purpose.
+// 2. Enable only `jsx-a11y/autocomplete-valid`.
+// 3. Assert one compatibility diagnostic is reported.
+func TestJsxA11yAutocompleteValidRejectsInappropriateInputType(t *testing.T) {
+  assertJsxA11yRuleFinds(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input type="email" autoComplete="url" />;`, "input type")
+}

--- a/packages/lint/test/rules/jsx-a11y/jsx_a11y_autocomplete_valid_rejects_invalid_token_sequence_test.go
+++ b/packages/lint/test/rules/jsx-a11y/jsx_a11y_autocomplete_valid_rejects_invalid_token_sequence_test.go
@@ -1,0 +1,18 @@
+package linthost
+
+import "testing"
+
+// TestJsxA11yAutocompleteValidRejectsInvalidTokenSequence verifies token grammar.
+//
+// Contact qualifiers apply only to contact purposes, and every detail list has
+// exactly one terminal purpose. Known tokens in an invalid order must fail.
+//
+// 1. Parse qualified, multiple-purpose, mixed-state, and empty-section lists.
+// 2. Enable only `jsx-a11y/autocomplete-valid`.
+// 3. Assert every invalid sequence reports a diagnostic.
+func TestJsxA11yAutocompleteValidRejectsInvalidTokenSequence(t *testing.T) {
+  assertJsxA11yRuleFinds(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input autoComplete="home url" />;`, "invalid token sequence")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input autoComplete="name email" />;`, "invalid token sequence")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input autoComplete="on email" />;`, "invalid token sequence")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/autocomplete-valid", `const Component = () => <input autoComplete="section- name" />;`, "invalid token sequence")
+}

--- a/packages/lint/test/rules/jsx-a11y/jsx_a11y_heading_has_content_rejects_empty_heading_test.go
+++ b/packages/lint/test/rules/jsx-a11y/jsx_a11y_heading_has_content_rejects_empty_heading_test.go
@@ -4,12 +4,13 @@ import "testing"
 
 // TestJsxA11yHeadingHasContentRejectsEmptyHeading verifies headings need content.
 //
-// Heading text is discovered through JSX children, not attributes alone. This
-// case pins empty child-list handling for intrinsic heading tags.
+// Both normal empty headings and self-closing headings omit child text. The
+// rule must visit both JSX node kinds for intrinsic heading tags.
 //
-// 1. Parse an empty h2 element.
+// 1. Parse normal and self-closing empty h2 elements.
 // 2. Enable only `jsx-a11y/heading-has-content`.
-// 3. Assert one diagnostic is reported.
+// 3. Assert each empty heading reports a diagnostic.
 func TestJsxA11yHeadingHasContentRejectsEmptyHeading(t *testing.T) {
   assertJsxA11yRuleFinds(t, "jsx-a11y/heading-has-content", `const Component = () => <h2></h2>;`, "Headings")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/heading-has-content", `const Component = () => <h2 />;`, "Headings")
 }

--- a/packages/lint/test/rules/jsx-a11y/jsx_a11y_html_has_lang_allows_non_empty_lang_test.go
+++ b/packages/lint/test/rules/jsx-a11y/jsx_a11y_html_has_lang_allows_non_empty_lang_test.go
@@ -1,0 +1,16 @@
+package linthost
+
+import "testing"
+
+// TestJsxA11yHtmlHasLangAllowsNonEmptyLang verifies valid content is preserved.
+//
+// The empty-value branch must not turn every explicit lang attribute into a
+// diagnostic.
+//
+// 1. Parse html elements with a non-empty value and boolean shorthand.
+// 2. Enable only `jsx-a11y/html-has-lang`.
+// 3. Assert the valid attribute is not reported.
+func TestJsxA11yHtmlHasLangAllowsNonEmptyLang(t *testing.T) {
+  assertJsxA11yRuleSkips(t, "jsx-a11y/html-has-lang", `const Component = () => <html lang="en" />;`)
+  assertJsxA11yRuleSkips(t, "jsx-a11y/html-has-lang", `const Component = () => <html lang />;`)
+}

--- a/packages/lint/test/rules/jsx-a11y/jsx_a11y_html_has_lang_rejects_empty_lang_test.go
+++ b/packages/lint/test/rules/jsx-a11y/jsx_a11y_html_has_lang_rejects_empty_lang_test.go
@@ -1,0 +1,21 @@
+package linthost
+
+import "testing"
+
+// TestJsxA11yHtmlHasLangRejectsEmptyLang verifies an explicit lang has content.
+//
+// Presence alone is insufficient for screen readers to select a language, and
+// the upstream html-has-lang rule rejects empty values.
+//
+// 1. Parse empty strings and statically falsy lang values, including a spread.
+// 2. Enable only `jsx-a11y/html-has-lang`.
+// 3. Assert every explicitly falsy attribute is reported.
+func TestJsxA11yHtmlHasLangRejectsEmptyLang(t *testing.T) {
+  assertJsxA11yRuleFinds(t, "jsx-a11y/html-has-lang", `const Component = () => <html lang="" />;`, "non-empty")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/html-has-lang", `const Component = () => <html lang="   " />;`, "non-empty")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/html-has-lang", `const Component = () => <html lang={false} />;`, "non-empty")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/html-has-lang", `const Component = () => <html lang={0} />;`, "non-empty")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/html-has-lang", `const Component = () => <html lang={null} />;`, "non-empty")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/html-has-lang", `const Component = () => <html lang={undefined} />;`, "non-empty")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/html-has-lang", `declare const props: object; const Component = () => <html {...props} lang="" />;`, "non-empty")
+}

--- a/packages/lint/test/rules/jsx-a11y/jsx_a11y_lang_allows_valid_bcp47_tag_test.go
+++ b/packages/lint/test/rules/jsx-a11y/jsx_a11y_lang_allows_valid_bcp47_tag_test.go
@@ -1,0 +1,17 @@
+package linthost
+
+import "testing"
+
+// TestJsxA11yLangAllowsValidBcp47Tag verifies registered language tags are accepted.
+//
+// BCP 47 permits regional and script subtags. Registry-backed validation must
+// preserve these standard forms on html and ignore other JSX elements.
+//
+// 1. Parse html elements with registered tags and a non-html invalid tag.
+// 2. Enable only `jsx-a11y/lang`.
+// 3. Assert valid html tags and the out-of-scope element report no diagnostic.
+func TestJsxA11yLangAllowsValidBcp47Tag(t *testing.T) {
+  assertJsxA11yRuleSkips(t, "jsx-a11y/lang", `const Component = () => <html lang="en-US" />;`)
+  assertJsxA11yRuleSkips(t, "jsx-a11y/lang", `const Component = () => <html lang="zh-Hant-HK" />;`)
+  assertJsxA11yRuleSkips(t, "jsx-a11y/lang", `const Component = () => <div lang="foo" />;`)
+}

--- a/packages/lint/test/rules/jsx-a11y/jsx_a11y_lang_rejects_empty_lang_test.go
+++ b/packages/lint/test/rules/jsx-a11y/jsx_a11y_lang_rejects_empty_lang_test.go
@@ -4,12 +4,11 @@ import "testing"
 
 // TestJsxA11yLangRejectsEmptyLang verifies literal language tags are validated.
 //
-// The native check is intentionally conservative but should still reject an
-// empty language tag when the value is statically known.
+// Registry-backed parsing must reject an empty value before language matching.
 //
 // 1. Parse an html element with an empty lang string.
 // 2. Enable only `jsx-a11y/lang`.
-// 3. Assert one diagnostic is reported.
+// 3. Assert the empty literal reports a diagnostic.
 func TestJsxA11yLangRejectsEmptyLang(t *testing.T) {
   assertJsxA11yRuleFinds(t, "jsx-a11y/lang", `const Component = () => <html lang="" />;`, "lang")
 }

--- a/packages/lint/test/rules/jsx-a11y/jsx_a11y_lang_rejects_invalid_bcp47_tag_test.go
+++ b/packages/lint/test/rules/jsx-a11y/jsx_a11y_lang_rejects_invalid_bcp47_tag_test.go
@@ -1,0 +1,19 @@
+package linthost
+
+import "testing"
+
+// TestJsxA11yLangRejectsInvalidBcp47Tag verifies registry-backed validation.
+//
+// Non-empty syntax is insufficient: whitespace, unknown language subtags, and
+// statically undefined or non-string values cannot identify a language.
+//
+// 1. Parse padded, unregistered, malformed, undefined, and shorthand values.
+// 2. Enable only `jsx-a11y/lang`.
+// 3. Assert every statically invalid attribute reports a diagnostic.
+func TestJsxA11yLangRejectsInvalidBcp47Tag(t *testing.T) {
+  assertJsxA11yRuleFinds(t, "jsx-a11y/lang", `const Component = () => <html lang=" en " />;`, "lang")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/lang", `const Component = () => <html lang="foo" />;`, "lang")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/lang", `const Component = () => <html lang="zz-LL" />;`, "lang")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/lang", `const Component = () => <html lang={undefined} />;`, "lang")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/lang", `const Component = () => <html lang />;`, "lang")
+}

--- a/packages/lint/test/rules/jsx-a11y/jsx_a11y_media_has_caption_requires_track_test.go
+++ b/packages/lint/test/rules/jsx-a11y/jsx_a11y_media_has_caption_requires_track_test.go
@@ -4,12 +4,13 @@ import "testing"
 
 // TestJsxA11yMediaHasCaptionRequiresTrack verifies media elements need captions.
 //
-// Audio and video content should expose captions or subtitles. This pins the
-// child scan for track elements under normal JSX elements.
+// Empty normal and self-closing media elements cannot provide caption tracks.
+// The rule must visit both JSX node kinds for video elements.
 //
-// 1. Parse a video element with no track child.
+// 1. Parse normal and self-closing videos with no track child.
 // 2. Enable only `jsx-a11y/media-has-caption`.
-// 3. Assert one diagnostic is reported.
+// 3. Assert each captionless video reports a diagnostic.
 func TestJsxA11yMediaHasCaptionRequiresTrack(t *testing.T) {
   assertJsxA11yRuleFinds(t, "jsx-a11y/media-has-caption", `const Component = () => <video src="/movie.mp4"></video>;`, "caption")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/media-has-caption", `const Component = () => <video src="/movie.mp4" />;`, "caption")
 }

--- a/packages/lint/test/rules/jsx-a11y/jsx_a11y_no_static_element_interactions_requires_role_test.go
+++ b/packages/lint/test/rules/jsx-a11y/jsx_a11y_no_static_element_interactions_requires_role_test.go
@@ -4,12 +4,12 @@ import "testing"
 
 // TestJsxA11yNoStaticElementInteractionsRequiresRole verifies static elements with handlers need roles.
 //
-// A span with an activation handler has no native semantics. This rule asks for
+// A div with an activation handler has no native semantics. This rule asks for
 // an explicit role when static markup becomes interactive.
 //
-// 1. Parse a span with onClick and no role.
+// 1. Parse a div with onClick and no role.
 // 2. Enable only `jsx-a11y/no-static-element-interactions`.
 // 3. Assert one diagnostic is reported.
 func TestJsxA11yNoStaticElementInteractionsRequiresRole(t *testing.T) {
-  assertJsxA11yRuleFinds(t, "jsx-a11y/no-static-element-interactions", `const Component = () => <span onClick={() => {}} />;`, "Static")
+  assertJsxA11yRuleFinds(t, "jsx-a11y/no-static-element-interactions", `const Component = () => <div onClick={() => {}} />;`, "Static")
 }

--- a/tests/test-lint/scripts/audit-fixtures.mjs
+++ b/tests/test-lint/scripts/audit-fixtures.mjs
@@ -1,40 +1,22 @@
 #!/usr/bin/env node
-// Run every annotated lint fixture under `src/cases` and report every
-// mismatch in one pass. The standard e2e runner halts on first failure,
-// which makes triaging fixture drift slow when many fixtures have shifted.
-import fs from "node:fs";
+// Run every classified lint fixture under `src/cases` and print a final
+// pass/failure summary. It shares the strict discovery contract used by the
+// partitioned e2e runner.
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
-const here = path.dirname(new URL(import.meta.url).pathname);
+const here = path.dirname(fileURLToPath(import.meta.url));
 const pkgRoot = path.join(here, "..");
 process.chdir(pkgRoot);
 
-// Use the package's loader chain to pull in the workspace TestLint helper.
-const { TestLint } = await import("@ttsc/testing");
-const { assertLintCase } = await import(
-  pathToFileURL(path.join(pkgRoot, "src", "helpers", "assertLintCase.ts"))
-);
+// Use the same strict discovery contract as the partitioned corpus runner.
+const { assertLintCase, listLintCases, validateCorpusSkipManifestCoverage } =
+  await import(
+    pathToFileURL(path.join(pkgRoot, "src", "helpers", "assertLintCase.ts"))
+  );
 
-const casesRoot = path.join(pkgRoot, "src", "cases");
-
-function walk(dir) {
-  const out = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const file = path.join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...walk(file));
-    else if (entry.isFile()) out.push(file);
-  }
-  return out.sort();
-}
-
-const cases = walk(casesRoot)
-  .filter((f) => f.endsWith(".ts"))
-  .map((f) => path.relative(casesRoot, f).replaceAll(path.sep, "/"))
-  .filter((f) => {
-    const src = fs.readFileSync(path.join(casesRoot, f), "utf8");
-    return TestLint.parseExpectations(src).length !== 0;
-  });
+const cases = listLintCases();
+validateCorpusSkipManifestCoverage(cases);
 
 let pass = 0;
 const failures = [];

--- a/tests/test-lint/src/cases/boundaries-dependencies.ts
+++ b/tests/test-lint/src/cases/boundaries-dependencies.ts
@@ -1,3 +1,5 @@
+// @ttsc-corpus-skip(project): rule requires a configured multi-file element graph; positive project coverage lives at packages/lint/test/rules/boundaries/boundaries_dependencies_test.go.
+// @ttsc-corpus-rule: boundaries/dependencies
 /**
  * Fixture for `boundaries/dependencies`.
  *
@@ -7,10 +9,9 @@
  * classifies aliases and relative imports against `elements`, and evaluates
  * ordered allow/disallow effects across entity and dependency metadata.
  *
- * This fixture exists to document the rule id in the consumer corpus
- * tree. It declares no `// expect:` annotations, so the corpus runner
- * skips it; package-level tests materialize the multi-file layouts and real
- * command runs needed to exercise the rule.
+ * This fixture documents the rule id in the consumer corpus tree. Its audited
+ * project skip points to the package-level test that materializes the
+ * multi-file layout needed to exercise the rule.
  *
  * Example config:
  *

--- a/tests/test-lint/src/cases/boundaries-element-types.ts
+++ b/tests/test-lint/src/cases/boundaries-element-types.ts
@@ -1,3 +1,5 @@
+// @ttsc-corpus-skip(project): rule requires configured source and target elements; positive project coverage lives at packages/lint/test/rules/boundaries/boundaries_element_types_rejects_disallowed_import_test.go.
+// @ttsc-corpus-rule: boundaries/element-types
 /**
  * Fixture for `boundaries/element-types`.
  *
@@ -6,7 +8,7 @@
  * fire, so a single virtual fixture cannot produce a diagnostic; the Go test
  * under `packages/lint/test/rules/boundaries/` pins the actual contract.
  *
- * This fixture documents the rule id in the consumer corpus tree. It declares
- * no `// expect:` annotations, so the corpus runner skips it.
+ * This fixture documents the rule id in the consumer corpus tree. Its audited
+ * project skip points to that positive package-level witness.
  */
 export {};

--- a/tests/test-lint/src/cases/boundaries-entry-point.ts
+++ b/tests/test-lint/src/cases/boundaries-entry-point.ts
@@ -1,3 +1,5 @@
+// @ttsc-corpus-skip(project): rule requires a configured multi-file public entry; positive project coverage lives at packages/lint/test/rules/boundaries/boundaries_entry_point_rejects_non_entry_import_test.go.
+// @ttsc-corpus-rule: boundaries/entry-point
 /**
  * Fixture for `boundaries/entry-point`.
  *
@@ -5,7 +7,7 @@
  * entry files. It needs project-level configuration to fire; the Go test under
  * `packages/lint/test/rules/boundaries/` pins the actual contract.
  *
- * This fixture documents the rule id in the consumer corpus tree. It declares
- * no `// expect:` annotations, so the corpus runner skips it.
+ * This fixture documents the rule id in the consumer corpus tree. Its audited
+ * project skip points to that positive package-level witness.
  */
 export {};

--- a/tests/test-lint/src/cases/boundaries-external.ts
+++ b/tests/test-lint/src/cases/boundaries-external.ts
@@ -1,3 +1,5 @@
+// @ttsc-corpus-skip(project): rule requires a configured external package policy; positive project coverage lives at packages/lint/test/rules/boundaries/boundaries_external_rejects_disallowed_package_test.go.
+// @ttsc-corpus-rule: boundaries/external
 /**
  * Fixture for `boundaries/external`.
  *
@@ -5,7 +7,7 @@
  * It needs project-level `disallow` config to fire; the Go test under
  * `packages/lint/test/rules/boundaries/` pins the actual contract.
  *
- * This fixture documents the rule id in the consumer corpus tree. It declares
- * no `// expect:` annotations, so the corpus runner skips it.
+ * This fixture documents the rule id in the consumer corpus tree. Its audited
+ * project skip points to that positive package-level witness.
  */
 export {};

--- a/tests/test-lint/src/cases/boundaries-no-private.ts
+++ b/tests/test-lint/src/cases/boundaries-no-private.ts
@@ -1,3 +1,5 @@
+// @ttsc-corpus-skip(project): rule requires configured cross-element private paths; positive project coverage lives at packages/lint/test/rules/boundaries/boundaries_no_private_rejects_cross_element_private_import_test.go.
+// @ttsc-corpus-rule: boundaries/no-private
 /**
  * Fixture for `boundaries/no-private`.
  *
@@ -5,7 +7,7 @@
  * element. It needs project-level configuration to fire; the Go test under
  * `packages/lint/test/rules/boundaries/` pins the actual contract.
  *
- * This fixture documents the rule id in the consumer corpus tree. It declares
- * no `// expect:` annotations, so the corpus runner skips it.
+ * This fixture documents the rule id in the consumer corpus tree. Its audited
+ * project skip points to that positive package-level witness.
  */
 export {};

--- a/tests/test-lint/src/cases/boundaries-no-unknown.ts
+++ b/tests/test-lint/src/cases/boundaries-no-unknown.ts
@@ -1,3 +1,5 @@
+// @ttsc-corpus-skip(project): rule requires a configured multi-file element graph; positive project coverage lives at packages/lint/test/rules/boundaries/boundaries_no_unknown_rejects_unknown_import_target_test.go.
+// @ttsc-corpus-rule: boundaries/no-unknown
 /**
  * Fixture for `boundaries/no-unknown`.
  *
@@ -5,7 +7,7 @@
  * configured element. It needs project-level configuration to fire; the Go
  * test under `packages/lint/test/rules/boundaries/` pins the actual contract.
  *
- * This fixture documents the rule id in the consumer corpus tree. It declares
- * no `// expect:` annotations, so the corpus runner skips it.
+ * This fixture documents the rule id in the consumer corpus tree. Its audited
+ * project skip points to that positive package-level witness.
  */
 export {};

--- a/tests/test-lint/src/cases/consistent-type-imports/src/types-fixture.ts
+++ b/tests/test-lint/src/cases/consistent-type-imports/src/types-fixture.ts
@@ -1,3 +1,4 @@
+// @ttsc-corpus-companion
 export interface Foo {
   id: number;
 }

--- a/tests/test-lint/src/cases/jsx-a11y-alt-text.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-alt-text.tsx
@@ -8,4 +8,5 @@
  * 1. Render an `<img>` with only a `src`, no `alt` and no `aria-label`.
  * 2. Lint flags it as a missing text-alternative.
  */
+// expect: jsx-a11y/alt-text error
 export const X = () => <img src="/logo.png" />;

--- a/tests/test-lint/src/cases/jsx-a11y-anchor-has-content.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-anchor-has-content.tsx
@@ -1,11 +1,11 @@
 /**
  * Verifies jsx-a11y/anchor-has-content: anchors need accessible content.
  *
- * Pins the "empty anchor" branch — an `<a>` with no text, no
- * `aria-label`, and no labelled child gives assistive tech nothing to
- * announce, so the rule rejects it.
+ * Pins the self-closing branch: an `<a />` with no text, `aria-label`, or
+ * labelled child gives assistive tech nothing to announce.
  *
- * 1. Render an `<a>` with an `href` but no children or label.
+ * 1. Render an empty self-closing anchor with an `href` but no label.
  * 2. Lint flags the empty anchor.
  */
+// expect: jsx-a11y/anchor-has-content error
 export const X = () => <a href="/docs" />;

--- a/tests/test-lint/src/cases/jsx-a11y-anchor-is-valid.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-anchor-is-valid.tsx
@@ -8,4 +8,5 @@
  * 1. Render an `<a>` whose `href` is a `javascript:` URL.
  * 2. Lint flags the invalid anchor target.
  */
+// expect: jsx-a11y/anchor-is-valid error
 export const X = () => <a href="javascript:void(0)">go</a>;

--- a/tests/test-lint/src/cases/jsx-a11y-aria-activedescendant-has-tabindex.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-aria-activedescendant-has-tabindex.tsx
@@ -9,4 +9,5 @@
  * 1. Render a `<div>` with `aria-activedescendant` and no `tabIndex`.
  * 2. Lint flags the missing tabindex on the composite host.
  */
+// expect: jsx-a11y/aria-activedescendant-has-tabindex error
 export const X = () => <div aria-activedescendant="opt-1" />;

--- a/tests/test-lint/src/cases/jsx-a11y-aria-props.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-aria-props.tsx
@@ -9,4 +9,5 @@
  * 1. Render a `<div>` with a misspelled `aria-labeledby` attribute.
  * 2. Lint flags the unknown ARIA property name.
  */
+// expect: jsx-a11y/aria-props error
 export const X = () => <div aria-labeledby="title" />;

--- a/tests/test-lint/src/cases/jsx-a11y-aria-proptypes.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-aria-proptypes.tsx
@@ -9,4 +9,5 @@
  * 1. Render a `<div>` with `aria-hidden="yes"`.
  * 2. Lint flags the value as wrong for the declared boolean type.
  */
+// expect: jsx-a11y/aria-proptypes error
 export const X = () => <div aria-hidden="yes" />;

--- a/tests/test-lint/src/cases/jsx-a11y-aria-role.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-aria-role.tsx
@@ -8,4 +8,5 @@
  * 1. Render a `<div>` with `role="range"`.
  * 2. Lint flags the abstract role assignment.
  */
+// expect: jsx-a11y/aria-role error
 export const X = () => <div role="range" />;

--- a/tests/test-lint/src/cases/jsx-a11y-aria-unsupported-elements.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-aria-unsupported-elements.tsx
@@ -8,4 +8,5 @@
  * 1. Render a `<meta>` element with an ARIA attribute.
  * 2. Lint flags the ARIA attribute on the unsupported element.
  */
+// expect: jsx-a11y/aria-unsupported-elements error
 export const X = () => <meta aria-checked="true" />;

--- a/tests/test-lint/src/cases/jsx-a11y-autocomplete-valid.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-autocomplete-valid.tsx
@@ -1,12 +1,12 @@
 /**
- * Verifies jsx-a11y/autocomplete-valid: `autocomplete` token must match
- * the HTML vocabulary and the surrounding `type`.
+ * Verifies jsx-a11y/autocomplete-valid: `autocomplete` tokens must suit the
+ * input type that consumes them.
  *
- * Pins the "type/token mismatch" branch — `autocomplete="url"` and
- * `type="email"` belong to disjoint vocabularies, so the rule rejects
- * the pair.
+ * Pins type compatibility: `url` is a real token, but an email input cannot
+ * consume a URL-specific autofill value.
  *
- * 1. Render an `<input type="email">` with `autocomplete="url"`.
- * 2. Lint flags the token as invalid for the input type.
+ * 1. Render an email input with `autocomplete="url"`.
+ * 2. Lint flags the token as inappropriate for that input type.
  */
+// expect: jsx-a11y/autocomplete-valid error
 export const X = () => <input type="email" autoComplete="url" />;

--- a/tests/test-lint/src/cases/jsx-a11y-click-events-have-key-events.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-click-events-have-key-events.tsx
@@ -9,4 +9,5 @@
  * 1. Render a `<div>` with an `onClick` and no key handler.
  * 2. Lint flags the missing keyboard counterpart.
  */
+// expect: jsx-a11y/click-events-have-key-events error
 export const X = () => <div onClick={() => {}} />;

--- a/tests/test-lint/src/cases/jsx-a11y-control-has-associated-label.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-control-has-associated-label.tsx
@@ -9,4 +9,5 @@
  * 1. Render an empty `<button>` with no labelling attribute.
  * 2. Lint flags the missing accessible label.
  */
+// expect: jsx-a11y/control-has-associated-label error
 export const X = () => <button />;

--- a/tests/test-lint/src/cases/jsx-a11y-heading-has-content.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-heading-has-content.tsx
@@ -1,12 +1,11 @@
 /**
- * Verifies jsx-a11y/heading-has-content: heading tags need announcable
- * content.
+ * Verifies jsx-a11y/heading-has-content: heading tags need announcable content.
  *
- * Pins the "empty heading" branch — assistive tech cannot announce
- * what does not exist, so the rule rejects an `<h1>` (or peer heading)
- * with no children.
+ * Pins the self-closing branch: assistive tech cannot announce a heading with
+ * no children or accessible label.
  *
- * 1. Render an `<h1>` with no children.
+ * 1. Render an empty self-closing `<h1 />` element.
  * 2. Lint flags the empty heading.
  */
+// expect: jsx-a11y/heading-has-content error
 export const X = () => <h1 />;

--- a/tests/test-lint/src/cases/jsx-a11y-html-has-lang.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-html-has-lang.tsx
@@ -1,11 +1,14 @@
 /**
  * Verifies jsx-a11y/html-has-lang: `<html>` needs a non-empty `lang`.
  *
- * Pins the "missing lang" branch — screen readers fall back to the
- * user's default voice without a `lang` attribute, which mispronounces
- * content, so the rule requires the attribute to exist and be non-empty.
+ * Pins both invalid branches: omitting the attribute and supplying an empty
+ * value leave assistive technology without a document language.
  *
- * 1. Render an `<html>` element with no `lang` attribute.
- * 2. Lint flags the missing language declaration.
+ * 1. Render `<html>` elements with a missing and empty `lang`.
+ * 2. Lint flags both invalid language declarations.
  */
-export const X = () => <html />;
+// expect: jsx-a11y/html-has-lang error
+export const MissingLang = () => <html />;
+
+// expect: jsx-a11y/html-has-lang error
+export const EmptyLang = () => <html lang="" />;

--- a/tests/test-lint/src/cases/jsx-a11y-iframe-has-title.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-iframe-has-title.tsx
@@ -8,4 +8,5 @@
  * 1. Render an `<iframe>` with `src` but no `title`.
  * 2. Lint flags the missing iframe title.
  */
+// expect: jsx-a11y/iframe-has-title error
 export const X = () => <iframe src="/embed" />;

--- a/tests/test-lint/src/cases/jsx-a11y-img-redundant-alt.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-img-redundant-alt.tsx
@@ -8,4 +8,5 @@
  * 1. Render an `<img>` whose `alt` includes the word "photo".
  * 2. Lint flags the redundant alt phrasing.
  */
+// expect: jsx-a11y/img-redundant-alt error
 export const X = () => <img src="/cat.png" alt="A photo of a cat" />;

--- a/tests/test-lint/src/cases/jsx-a11y-interactive-supports-focus.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-interactive-supports-focus.tsx
@@ -10,4 +10,5 @@
  *    `tabIndex`.
  * 2. Lint flags the missing focusability.
  */
+// expect: jsx-a11y/interactive-supports-focus error
 export const X = () => <div role="button" onClick={() => {}} />;

--- a/tests/test-lint/src/cases/jsx-a11y-label-has-associated-control.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-label-has-associated-control.tsx
@@ -9,4 +9,5 @@
  *    control.
  * 2. Lint flags the unassociated label.
  */
+// expect: jsx-a11y/label-has-associated-control error
 export const X = () => <label>Name</label>;

--- a/tests/test-lint/src/cases/jsx-a11y-label-has-for.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-label-has-for.tsx
@@ -8,4 +8,5 @@
  * 1. Render a `<label>` with no `htmlFor` and no wrapped control.
  * 2. Lint flags the missing association under the legacy rule.
  */
+// expect: jsx-a11y/label-has-for error
 export const X = () => <label>Email</label>;

--- a/tests/test-lint/src/cases/jsx-a11y-lang.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-lang.tsx
@@ -1,11 +1,11 @@
 /**
- * Verifies jsx-a11y/lang: `<html lang>` must be a valid BCP-47 tag.
+ * Verifies jsx-a11y/lang: `<html lang>` must contain a valid BCP 47 tag.
  *
- * Pins the "present but invalid tag" branch — this rule is the
- * superset of `html-has-lang` that also catches a non-empty `lang`
- * whose value is not a recognized IETF tag, so `lang="foo"` is rejected.
+ * Pins registry validation: html-has-lang accepts this non-empty value, while
+ * this rule rejects the unregistered primary language `foo`.
  *
- * 1. Render an `<html>` element with `lang="foo"`.
- * 2. Lint flags the invalid language tag.
+ * 1. Render an `<html>` element with the invalid `lang="foo"` value.
+ * 2. Lint flags the unregistered language tag.
  */
+// expect: jsx-a11y/lang error
 export const X = () => <html lang="foo" />;

--- a/tests/test-lint/src/cases/jsx-a11y-media-has-caption.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-media-has-caption.tsx
@@ -1,12 +1,11 @@
 /**
- * Verifies jsx-a11y/media-has-caption: `<audio>`/`<video>` need
- * captions.
+ * Verifies jsx-a11y/media-has-caption: `<audio>`/`<video>` need captions.
  *
- * Pins the "no caption track" branch — without a `<track
- * kind="captions">` child, deaf and hard-of-hearing users have no
- * access to the audio content, so the rule rejects the media element.
+ * Pins the self-closing branch: without a `<track kind="captions">` child,
+ * deaf and hard-of-hearing users have no access to the audio content.
  *
- * 1. Render a `<video>` with no `<track kind="captions">` child.
+ * 1. Render a self-closing `<video />` with no caption track child.
  * 2. Lint flags the missing caption track.
  */
+// expect: jsx-a11y/media-has-caption error
 export const X = () => <video src="/clip.mp4" />;

--- a/tests/test-lint/src/cases/jsx-a11y-mouse-events-have-key-events.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-mouse-events-have-key-events.tsx
@@ -9,4 +9,5 @@
  * 1. Render a `<div>` with `onMouseOver` and no `onFocus`.
  * 2. Lint flags the missing focus counterpart.
  */
+// expect: jsx-a11y/mouse-events-have-key-events error
 export const X = () => <div onMouseOver={() => {}} />;

--- a/tests/test-lint/src/cases/jsx-a11y-no-access-key.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-no-access-key.tsx
@@ -8,4 +8,5 @@
  * 1. Render a `<button>` with an `accessKey` attribute.
  * 2. Lint flags the prohibited access key.
  */
+// expect: jsx-a11y/no-access-key error
 export const X = () => <button accessKey="s">Save</button>;

--- a/tests/test-lint/src/cases/jsx-a11y-no-aria-hidden-on-focusable.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-no-aria-hidden-on-focusable.tsx
@@ -9,4 +9,5 @@
  * 1. Render a `<button>` with `aria-hidden`.
  * 2. Lint flags the focusable hidden element.
  */
+// expect: jsx-a11y/no-aria-hidden-on-focusable error
 export const X = () => <button aria-hidden="true">Save</button>;

--- a/tests/test-lint/src/cases/jsx-a11y-no-autofocus.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-no-autofocus.tsx
@@ -8,4 +8,5 @@
  * 1. Render an `<input>` with the `autoFocus` attribute.
  * 2. Lint flags the prohibited autofocus.
  */
+// expect: jsx-a11y/no-autofocus error
 export const X = () => <input autoFocus />;

--- a/tests/test-lint/src/cases/jsx-a11y-no-distracting-elements.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-no-distracting-elements.tsx
@@ -8,4 +8,5 @@
  * 1. Render a `<marquee>` element.
  * 2. Lint flags the distracting element.
  */
+// expect: jsx-a11y/no-distracting-elements error
 export const X = () => <marquee>scroll</marquee>;

--- a/tests/test-lint/src/cases/jsx-a11y-no-interactive-element-to-noninteractive-role.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-no-interactive-element-to-noninteractive-role.tsx
@@ -9,4 +9,5 @@
  * 1. Render a `<button>` with `role="presentation"`.
  * 2. Lint flags the downgrade to a non-interactive role.
  */
+// expect: jsx-a11y/no-interactive-element-to-noninteractive-role error
 export const X = () => <button role="presentation">Save</button>;

--- a/tests/test-lint/src/cases/jsx-a11y-no-noninteractive-element-interactions.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-no-noninteractive-element-interactions.tsx
@@ -9,4 +9,5 @@
  * 1. Render an `<li>` with an `onClick` and no interactive role.
  * 2. Lint flags the handler on the non-interactive element.
  */
+// expect: jsx-a11y/no-noninteractive-element-interactions error
 export const X = () => <li onClick={() => {}}>row</li>;

--- a/tests/test-lint/src/cases/jsx-a11y-no-noninteractive-element-to-interactive-role.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-no-noninteractive-element-to-interactive-role.tsx
@@ -9,4 +9,5 @@
  * 1. Render an `<li>` with `role="button"`.
  * 2. Lint flags the upgrade to an interactive role.
  */
+// expect: jsx-a11y/no-noninteractive-element-to-interactive-role error
 export const X = () => <li role="button">click</li>;

--- a/tests/test-lint/src/cases/jsx-a11y-no-noninteractive-tabindex.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-no-noninteractive-tabindex.tsx
@@ -9,4 +9,5 @@
  * 1. Render a `<div>` with `tabIndex={0}` and no interactive role.
  * 2. Lint flags the tabindex on a non-interactive element.
  */
+// expect: jsx-a11y/no-noninteractive-tabindex error
 export const X = () => <div tabIndex={0} />;

--- a/tests/test-lint/src/cases/jsx-a11y-no-redundant-roles.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-no-redundant-roles.tsx
@@ -8,4 +8,5 @@
  * 1. Render a `<button>` with `role="button"`.
  * 2. Lint flags the redundant role attribute.
  */
+// expect: jsx-a11y/no-redundant-roles error
 export const X = () => <button role="button">Save</button>;

--- a/tests/test-lint/src/cases/jsx-a11y-no-static-element-interactions.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-no-static-element-interactions.tsx
@@ -2,11 +2,12 @@
  * Verifies jsx-a11y/no-static-element-interactions: static elements
  * with interaction handlers need an interactive role.
  *
- * Pins the "static click target" branch — a `<div>` carrying
- * `onClick` looks interactive at runtime but has no role for
- * assistive tech to announce, so the rule requires an explicit role.
+ * Pins the "static click target" branch: a `<div>` carrying `onClick` looks
+ * interactive at runtime but has no role for assistive tech to announce, so the
+ * rule requires an explicit role.
  *
  * 1. Render a `<div>` with `onClick` and no role.
  * 2. Lint flags the static element with an interaction.
  */
+// expect: jsx-a11y/no-static-element-interactions error
 export const X = () => <div onClick={() => {}}>open</div>;

--- a/tests/test-lint/src/cases/jsx-a11y-prefer-tag-over-role.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-prefer-tag-over-role.tsx
@@ -9,4 +9,5 @@
  * 1. Render a `<div>` with `role="button"`.
  * 2. Lint flags the role that a native tag already covers.
  */
+// expect: jsx-a11y/prefer-tag-over-role error
 export const X = () => <div role="button">Save</div>;

--- a/tests/test-lint/src/cases/jsx-a11y-role-has-required-aria-props.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-role-has-required-aria-props.tsx
@@ -9,4 +9,5 @@
  * 1. Render a `<div>` with `role="checkbox"` and no `aria-checked`.
  * 2. Lint flags the missing required ARIA prop.
  */
+// expect: jsx-a11y/role-has-required-aria-props error
 export const X = () => <div role="checkbox" />;

--- a/tests/test-lint/src/cases/jsx-a11y-role-supports-aria-props.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-role-supports-aria-props.tsx
@@ -9,4 +9,5 @@
  * 1. Render a `<div>` with `role="link"` and `aria-checked`.
  * 2. Lint flags the aria prop that the role does not support.
  */
+// expect: jsx-a11y/role-supports-aria-props error
 export const X = () => <div role="link" aria-checked="true" />;

--- a/tests/test-lint/src/cases/jsx-a11y-scope.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-scope.tsx
@@ -8,4 +8,5 @@
  * 1. Render a `<div>` with `scope="col"`.
  * 2. Lint flags the misplaced scope attribute.
  */
+// expect: jsx-a11y/scope error
 export const X = () => <div scope="col" />;

--- a/tests/test-lint/src/cases/jsx-a11y-tabindex-no-positive.tsx
+++ b/tests/test-lint/src/cases/jsx-a11y-tabindex-no-positive.tsx
@@ -8,4 +8,5 @@
  * 1. Render a `<button>` with `tabIndex={1}`.
  * 2. Lint flags the positive tabindex value.
  */
+// expect: jsx-a11y/tabindex-no-positive error
 export const X = () => <button tabIndex={1}>Save</button>;

--- a/tests/test-lint/src/cases/nextjs-no-duplicate-head.tsx
+++ b/tests/test-lint/src/cases/nextjs-no-duplicate-head.tsx
@@ -1,15 +1,11 @@
+// @ttsc-corpus-filename: src/pages/_document.tsx
 import { Head } from "next/document";
 
-// Positive: more than one `<Head>` element in the same render tree.
-const a = (
+// Positive: every `Head` after the first is a file-level duplicate.
+export const documentHead = (
   <>
     <Head />
     {/* expect: nextjs/no-duplicate-head error */}
     <Head />
   </>
 );
-
-// Negative: a single `<Head>` element.
-const b = <Head />;
-
-JSON.stringify({ a, b });

--- a/tests/test-lint/src/cases/nextjs-no-styled-jsx-in-document.tsx
+++ b/tests/test-lint/src/cases/nextjs-no-styled-jsx-in-document.tsx
@@ -1,3 +1,4 @@
+// @ttsc-corpus-filename: src/pages/_document.tsx
 // Positive: `styled-jsx` tag inside `pages/_document.tsx`.
 const a = (
   <div>

--- a/tests/test-lint/src/cases/nextjs-no-title-in-document-head.tsx
+++ b/tests/test-lint/src/cases/nextjs-no-title-in-document-head.tsx
@@ -1,3 +1,4 @@
+// @ttsc-corpus-filename: src/pages/_document.tsx
 import { Head } from "next/document";
 
 // Positive: `<title>` inside `Head` from `next/document`.

--- a/tests/test-lint/src/cases/nextjs-no-typos.ts
+++ b/tests/test-lint/src/cases/nextjs-no-typos.ts
@@ -1,7 +1,7 @@
-// @ttsc-corpus-skip(filename): rule fires only on files whose path contains `/pages/`; the flat corpus runner writes every fixture to `src/main.ts`. Go corpus coverage lives at packages/lint/test/rules/nextjs/no_typos_reports_misspelled_data_export_test.go.
+// @ttsc-corpus-filename: src/pages/index.ts
 // Positive: near-miss typo on a Next.js data-fetching export.
 // expect: nextjs/no-typos error
-export function getstaticprops() {
+export function getStaticProp() {
   return { props: {} };
 }
 
@@ -10,4 +10,4 @@ export function getStaticProps() {
   return { props: {} };
 }
 
-JSON.stringify({ getstaticprops, getStaticProps });
+JSON.stringify({ getStaticProp, getStaticProps });

--- a/tests/test-lint/src/cases/no-import-type-side-effects/src/types-fixture.ts
+++ b/tests/test-lint/src/cases/no-import-type-side-effects/src/types-fixture.ts
@@ -1,3 +1,4 @@
+// @ttsc-corpus-companion
 export interface Foo {
   id: number;
 }

--- a/tests/test-lint/src/cases/no-restricted-imports.ts
+++ b/tests/test-lint/src/cases/no-restricted-imports.ts
@@ -1,7 +1,9 @@
-// No options means no project policy is inferred.
+// @ttsc-corpus-options: no-restricted-imports {"paths":["lodash"]}
+// Positive: the configured exact path is rejected.
+// expect: no-restricted-imports error
 import _ from "lodash";
 
-// Re-exports are likewise unrestricted until paths or patterns are supplied.
+// Negative: re-exports outside the configured paths remain unrestricted.
 export { isArray } from "underscore";
 
 // Arbitrary imports remain accepted.

--- a/tests/test-lint/src/cases/no-restricted-syntax.ts
+++ b/tests/test-lint/src/cases/no-restricted-syntax.ts
@@ -1,13 +1,8 @@
-function runWith(target: { value: number }): number {
-  let total = 0;
-  with (target) {
-    total = value;
-  }
-  return total;
-}
+// @ttsc-corpus-options: no-restricted-syntax "LabeledStatement"
 
 function runLabeled(): number {
   let acc = 0;
+  // expect: no-restricted-syntax error
   outer: for (let i = 0; i < 3; i += 1) {
     for (let j = 0; j < 3; j += 1) {
       if (i + j > 3) break outer;
@@ -23,7 +18,6 @@ function plain(value: number): number {
 }
 
 JSON.stringify({
-  runWith: runWith({ value: 7 }),
   runLabeled: runLabeled(),
   plain: plain(3),
 });

--- a/tests/test-lint/src/cases/triple-slash-reference/src/other-fixture.d.ts
+++ b/tests/test-lint/src/cases/triple-slash-reference/src/other-fixture.d.ts
@@ -1,1 +1,2 @@
+// @ttsc-corpus-companion
 export {};

--- a/tests/test-lint/src/cases/typescript-prefer-reduce-type-parameter.ts
+++ b/tests/test-lint/src/cases/typescript-prefer-reduce-type-parameter.ts
@@ -3,7 +3,7 @@ declare const names: string[];
 // Positive: the accumulator is annotated only via `as` on the initial
 // value — `reduce<T>(...)` would lock the accumulator type at the call
 // site instead. The rule reports on the `as` expression itself, so the
-// expect annotation anchors to the initial-value line.
+// expectation annotation anchors to the initial-value line.
 const intoSet = names.reduce(
   (acc, name) => {
     acc.add(name);

--- a/tests/test-lint/src/features/harness/test_lint_corpus_batch_reports_every_failure.ts
+++ b/tests/test-lint/src/features/harness/test_lint_corpus_batch_reports_every_failure.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+
+import { assertLintCases } from "../../helpers/assertLintCase";
+
+/**
+ * Verifies lint corpus batches: one failed fixture does not hide later
+ * failures.
+ *
+ * A fail-fast partition forced the entire native corpus lane to restart for
+ * every stale fixture contract. The batch must finish its sweep and preserve
+ * each fixture's identity in the aggregate report.
+ *
+ * 1. Assert two deliberately missing fixture paths as one batch.
+ * 2. Capture the aggregate failure after both paths have been attempted.
+ * 3. Assert the report retains both failures in input order.
+ */
+export const test_lint_corpus_batch_reports_every_failure = (): void => {
+  let thrown: unknown;
+  try {
+    assertLintCases(["__missing__/first.ts", "__missing__/second.ts"]);
+  } catch (error) {
+    thrown = error;
+  }
+
+  assert.ok(thrown instanceof AggregateError);
+  assert.equal(thrown.errors.length, 2);
+  assert.deepEqual(
+    thrown.errors.map((error) =>
+      error instanceof Error ? error.message.split(":", 1)[0] : error,
+    ),
+    ["__missing__/first.ts", "__missing__/second.ts"],
+  );
+};

--- a/tests/test-lint/src/features/harness/test_lint_corpus_companion_owner_allows_src_in_case_path.ts
+++ b/tests/test-lint/src/features/harness/test_lint_corpus_companion_owner_allows_src_in_case_path.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  collectExtraSources,
+  listLintCases,
+} from "../../helpers/assertLintCase";
+
+/**
+ * Verifies lint corpus companions: `src` in a case path is not a project root.
+ *
+ * Ownership follows a positive entry's directory and its own `src/` subtree; it
+ * does not infer the project root from the first path segment named `src`.
+ *
+ * 1. Materialize a grouped case below a directory named `src`.
+ * 2. Discover the positive entry and validate its companion ownership.
+ * 3. Assert collection preserves the companion's project-relative path.
+ */
+export const test_lint_corpus_companion_owner_allows_src_in_case_path =
+  (): void => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "ttsc-lint-src-path-companion-corpus-"),
+    );
+    const caseDirectory = path.join(root, "examples", "src", "grouped-case");
+    try {
+      fs.mkdirSync(path.join(caseDirectory, "src"), { recursive: true });
+      fs.writeFileSync(
+        path.join(caseDirectory, "violation.ts"),
+        "// expect: fixture/rule error\nexport const violation = true;\n",
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(caseDirectory, "src", "helper.ts"),
+        "// @ttsc-corpus-companion\nexport const helper = true;\n",
+        "utf8",
+      );
+
+      assert.deepEqual(listLintCases(root), [
+        "examples/src/grouped-case/violation.ts",
+      ]);
+      assert.deepEqual(
+        Object.keys(
+          collectExtraSources("examples/src/grouped-case/violation.ts", root),
+        ),
+        ["src/helper.ts"],
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };

--- a/tests/test-lint/src/features/harness/test_lint_corpus_companion_sources_are_classified_and_materialized_once.ts
+++ b/tests/test-lint/src/features/harness/test_lint_corpus_companion_sources_are_classified_and_materialized_once.ts
@@ -1,0 +1,66 @@
+import { TestLint } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  collectExtraSources,
+  listLintCases,
+} from "../../helpers/assertLintCase";
+
+/**
+ * Verifies lint corpus companions: one grouped entry consumes each source once.
+ *
+ * The old collector prefixed a companion's existing `src/` path a second time,
+ * leaving imports unresolved at `src/src/...`. Explicit companions remain out
+ * of the entry list and preserve their case-root-relative project path.
+ *
+ * 1. Materialize one grouped entry and one marked `src/` companion.
+ * 2. Discover entries and collect the entry's extra sources.
+ * 3. Assert the project contains `src/types.ts` and no doubled path.
+ */
+export const test_lint_corpus_companion_sources_are_classified_and_materialized_once =
+  (): void => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "ttsc-lint-companion-corpus-"),
+    );
+    const caseRoot = path.join(root, "type-aware-case");
+    let project: TestLint.IRunLintProject | undefined;
+    try {
+      fs.mkdirSync(path.join(caseRoot, "src"), { recursive: true });
+      fs.writeFileSync(
+        path.join(caseRoot, "violation.ts"),
+        "// expect: fixture/rule error\nimport type { Box } from './types';\n",
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(caseRoot, "src", "types.ts"),
+        "// @ttsc-corpus-companion\nexport interface Box { value: string }\n",
+        "utf8",
+      );
+
+      assert.deepEqual(listLintCases(root), ["type-aware-case/violation.ts"]);
+      const extraSources = collectExtraSources(
+        "type-aware-case/violation.ts",
+        root,
+      );
+      assert.deepEqual(Object.keys(extraSources), ["src/types.ts"]);
+      project = TestLint.createProject({
+        name: "corpus-companion-path",
+        source: fs.readFileSync(path.join(caseRoot, "violation.ts"), "utf8"),
+        extraSources,
+      });
+      assert.equal(
+        fs.existsSync(path.join(project.tmpdir, "src", "types.ts")),
+        true,
+      );
+      assert.equal(
+        fs.existsSync(path.join(project.tmpdir, "src", "src", "types.ts")),
+        false,
+      );
+    } finally {
+      project?.cleanup();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };

--- a/tests/test-lint/src/features/harness/test_lint_corpus_diagnostics_are_attributed_to_main_source.ts
+++ b/tests/test-lint/src/features/harness/test_lint_corpus_diagnostics_are_attributed_to_main_source.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+
+import { assertLintDiagnostics } from "../../helpers/assertLintCase";
+
+/**
+ * Verifies lint corpus diagnostics: only the resolved main file may satisfy it.
+ *
+ * Rule, severity, and line alone let a companion diagnostic impersonate the
+ * expected main-source failure. File identities must tolerate portable path
+ * spelling without accepting a different source target.
+ *
+ * 1. Compare POSIX, Windows-separator, and case-variant main-file diagnostics.
+ * 2. Compare a companion diagnostic with the same rule, severity, and line.
+ * 3. Assert portable main spellings pass and the companion spelling fails.
+ */
+export const test_lint_corpus_diagnostics_are_attributed_to_main_source =
+  (): void => {
+    const sourcePath = "src/Main.ts";
+    const expected = [
+      { rule: "fixture/rule", severity: "error", line: 2 },
+    ] as const;
+    const diagnostic = (file: string) => [
+      {
+        file,
+        line: 2,
+        column: 1,
+        severity: "error" as const,
+        rule: "fixture/rule",
+        message: "fixture diagnostic",
+      },
+    ];
+
+    for (const file of [
+      "src/Main.ts",
+      "./src/Main.ts",
+      "src\\Main.ts",
+      "SRC\\MAIN.TS",
+    ]) {
+      assert.doesNotThrow(() =>
+        assertLintDiagnostics(sourcePath, diagnostic(file), expected),
+      );
+    }
+
+    assert.throws(
+      () =>
+        assertLintDiagnostics(
+          sourcePath,
+          diagnostic("src/helper.ts"),
+          expected,
+        ),
+      /src\/helper\.ts/,
+    );
+  };

--- a/tests/test-lint/src/features/harness/test_lint_corpus_directives_reject_malformed_or_duplicate_markers.ts
+++ b/tests/test-lint/src/features/harness/test_lint_corpus_directives_reject_malformed_or_duplicate_markers.ts
@@ -1,0 +1,72 @@
+import { TestLint } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  applyCorpusOptions,
+  resolveCorpusSourcePath,
+} from "../../helpers/assertLintCase";
+
+/**
+ * Verifies corpus directives: marker-shaped typos and duplicates fail loudly.
+ *
+ * A valid expectation can keep a fixture classified after a malformed option or
+ * filename directive is ignored, falsely leaving an option/path branch
+ * uncovered. Every reserved directive token must therefore parse exactly once.
+ *
+ * 1. Mix valid directives with missing-colon and duplicate markers.
+ * 2. Parse each source through the same option and filename helpers as corpus.
+ * 3. Assert malformed and duplicate contracts report before execution.
+ */
+export const test_lint_corpus_directives_reject_malformed_or_duplicate_markers =
+  (): void => {
+    const rules = (): Record<string, TestLint.LintRuleConfigEntry> => ({
+      "rule/name": "error",
+    });
+
+    assert.throws(
+      () =>
+        applyCorpusOptions(
+          "mixed-options.ts",
+          [
+            '// @ttsc-corpus-options: rule/name {"enabled":true}',
+            "// @ttsc-corpus-options rule/name {}",
+          ].join("\n"),
+          rules(),
+        ),
+      /mixed-options\.ts.*malformed.*corpus-options/,
+    );
+    assert.throws(
+      () =>
+        applyCorpusOptions(
+          "duplicate-options.ts",
+          [
+            '// @ttsc-corpus-options: rule/name {"enabled":true}',
+            '// @ttsc-corpus-options: rule/name {"enabled":false}',
+          ].join("\n"),
+          rules(),
+        ),
+      /duplicate-options\.ts.*duplicate.*rule\/name/,
+    );
+    assert.throws(
+      () =>
+        resolveCorpusSourcePath(
+          [
+            "// @ttsc-corpus-filename: src/valid.ts",
+            "// @ttsc-corpus-filename src/ignored.ts",
+          ].join("\n"),
+          "mixed-filename.ts",
+        ),
+      /mixed-filename\.ts.*malformed.*corpus-filename/,
+    );
+    assert.throws(
+      () =>
+        resolveCorpusSourcePath(
+          [
+            "// @ttsc-corpus-filename: src/first.ts",
+            "// @ttsc-corpus-filename: src/second.ts",
+          ].join("\n"),
+          "duplicate-filename.ts",
+        ),
+      /duplicate-filename\.ts.*at most one corpus-filename/,
+    );
+  };

--- a/tests/test-lint/src/features/harness/test_lint_corpus_discovery_rejects_invalid_companion_contracts.ts
+++ b/tests/test-lint/src/features/harness/test_lint_corpus_discovery_rejects_invalid_companion_contracts.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { listLintCases } from "../../helpers/assertLintCase";
+
+/**
+ * Verifies lint corpus companions: malformed, conflicting, and orphan roles
+ * fail.
+ *
+ * A companion exclusion is safe only when its directive is exact, exclusive,
+ * and consumed by one positive entry in the grouped case. Otherwise the marker
+ * would recreate the silent-drop path under a different name.
+ *
+ * 1. Materialize malformed, duplicate, conflicting, orphan, and ambiguous roles.
+ * 2. Run strict discovery against each isolated corpus root.
+ * 3. Assert every invalid contract fails for its structural reason.
+ */
+export const test_lint_corpus_discovery_rejects_invalid_companion_contracts =
+  (): void => {
+    const validEntry =
+      "// expect: fixture/rule error\nexport const violation = true;\n";
+    const scenarios: readonly {
+      name: string;
+      files: Readonly<Record<string, string>>;
+      error: RegExp;
+    }[] = [
+      {
+        name: "malformed",
+        files: {
+          "case/violation.ts": validEntry,
+          "case/src/helper.ts":
+            "// @ttsc-corpus-companion: helper\nexport {};\n",
+        },
+        error: /helper\.ts: malformed `\/\/ @ttsc-corpus-companion` directive/,
+      },
+      {
+        name: "duplicate",
+        files: {
+          "case/violation.ts": validEntry,
+          "case/src/helper.ts":
+            "// @ttsc-corpus-companion\n// @ttsc-corpus-companion\nexport {};\n",
+        },
+        error:
+          /helper\.ts: a corpus source may declare at most one companion directive/,
+      },
+      {
+        name: "expectation-conflict",
+        files: {
+          "case/violation.ts": validEntry,
+          "case/src/helper.ts":
+            "// @ttsc-corpus-companion\n// expect: fixture/rule error\nexport {};\n",
+        },
+        error: /helper\.ts: a corpus companion cannot declare expectations/,
+      },
+      {
+        name: "skip-conflict",
+        files: {
+          "case/violation.ts": validEntry,
+          "case/src/helper.ts":
+            "// @ttsc-corpus-companion\n// @ttsc-corpus-skip(project): packages\/lint\/test\/fixture_test.go\nexport {};\n",
+        },
+        error: /helper\.ts: a corpus companion cannot also be an audited skip/,
+      },
+      {
+        name: "entry-directive-conflict",
+        files: {
+          "case/violation.ts": validEntry,
+          "case/src/helper.ts":
+            "// @ttsc-corpus-companion\n// @ttsc-corpus-filename: src/helper.ts\nexport {};\n",
+        },
+        error: /helper\.ts: a corpus companion cannot declare entry directives/,
+      },
+      {
+        name: "root-orphan",
+        files: {
+          "entry.ts": validEntry,
+          "src/helper.ts": "// @ttsc-corpus-companion\nexport {};\n",
+        },
+        error:
+          /helper\.ts: a corpus companion must belong to exactly one positive entry whose case directory contains it under src\//,
+      },
+      {
+        name: "missing-owner",
+        files: {
+          "entry.ts": validEntry,
+          "case/src/helper.ts": "// @ttsc-corpus-companion\nexport {};\n",
+        },
+        error:
+          /helper\.ts: a corpus companion must belong to exactly one positive entry whose case directory contains it under src\//,
+      },
+      {
+        name: "ambiguous-owner",
+        files: {
+          "case/one.ts": validEntry,
+          "case/two.ts": validEntry,
+          "case/src/helper.ts": "// @ttsc-corpus-companion\nexport {};\n",
+        },
+        error:
+          /helper\.ts: a corpus companion must belong to exactly one positive entry whose case directory contains it under src\//,
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      const root = fs.mkdtempSync(
+        path.join(os.tmpdir(), `ttsc-lint-companion-${scenario.name}-`),
+      );
+      try {
+        for (const [relativeFile, source] of Object.entries(scenario.files)) {
+          const target = path.join(root, relativeFile);
+          fs.mkdirSync(path.dirname(target), { recursive: true });
+          fs.writeFileSync(target, source, "utf8");
+        }
+        assert.throws(() => listLintCases(root), scenario.error);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    }
+  };

--- a/tests/test-lint/src/features/harness/test_lint_corpus_discovery_rejects_unclassified_sources.ts
+++ b/tests/test-lint/src/features/harness/test_lint_corpus_discovery_rejects_unclassified_sources.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { listLintCases } from "../../helpers/assertLintCase";
+
+/**
+ * Verifies lint corpus discovery: unclassified TypeScript sources are rejected.
+ *
+ * Filtering on parsed expectations made an annotation typo indistinguishable
+ * from an unrelated file. Discovery must enumerate the source first and then
+ * demand an explicit positive, audited-skip, or companion role.
+ *
+ * 1. Materialize one plain TypeScript file in an isolated corpus root.
+ * 2. Discover the corpus without adding any role directive.
+ * 3. Assert discovery fails with the unclassified relative path.
+ */
+export const test_lint_corpus_discovery_rejects_unclassified_sources =
+  (): void => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "ttsc-lint-unclassified-corpus-"),
+    );
+    try {
+      fs.writeFileSync(
+        path.join(root, "forgotten.ts"),
+        "export const forgotten = true;\n",
+        "utf8",
+      );
+      assert.throws(
+        () => listLintCases(root),
+        /forgotten\.ts: a corpus source must declare an expectation, audited skip, or @ttsc-corpus-companion/,
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };

--- a/tests/test-lint/src/features/harness/test_lint_corpus_discovery_supports_typescript_source_extensions.ts
+++ b/tests/test-lint/src/features/harness/test_lint_corpus_discovery_supports_typescript_source_extensions.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { listLintCases } from "../../helpers/assertLintCase";
+
+/**
+ * Verifies corpus discovery recognizes every supported TypeScript suffix.
+ *
+ * A suffix omitted from discovery would silently bypass the classification
+ * contract as soon as a matching fixture is added. The compiler's wildcard
+ * scanner recognizes only canonical lowercase suffixes, so case variants must
+ * fail explicitly instead of being silently excluded from the program.
+ *
+ * 1. Materialize every canonical TypeScript suffix and a JavaScript control.
+ * 2. Discover exactly the lowercase TypeScript sources.
+ * 3. Add each uppercase suffix in turn and assert discovery rejects it.
+ */
+export const test_lint_corpus_discovery_supports_typescript_source_extensions =
+  (): void => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "ttsc-lint-source-extensions-"),
+    );
+    const files = [
+      "case.ts",
+      "case.tsx",
+      "case.mts",
+      "case.cts",
+      "case.d.ts",
+      "case.d.mts",
+      "case.d.cts",
+    ];
+    const nonCanonicalFiles = [
+      "uppercase-ts.TS",
+      "uppercase-tsx.TSX",
+      "uppercase-mts.MTS",
+      "uppercase-cts.CTS",
+      "uppercase-dts.D.TS",
+      "uppercase-dmts.D.MTS",
+      "uppercase-dcts.D.CTS",
+    ];
+    try {
+      for (const file of files) {
+        fs.writeFileSync(
+          path.join(root, file),
+          "// expect: fixture/rule error\nexport {};\n",
+          "utf8",
+        );
+      }
+      fs.writeFileSync(path.join(root, "ignored.js"), "export {};\n", "utf8");
+      assert.deepEqual(listLintCases(root), [...files].sort());
+      for (const file of nonCanonicalFiles) {
+        const target = path.join(root, file);
+        fs.writeFileSync(
+          target,
+          "// expect: fixture/rule error\nexport {};\n",
+          "utf8",
+        );
+        assert.throws(
+          () => listLintCases(root),
+          new RegExp(`${file.replaceAll(".", "\\.")}.*canonical lowercase`),
+        );
+        fs.rmSync(target);
+      }
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };

--- a/tests/test-lint/src/features/harness/test_lint_corpus_nested_companions_are_consumed_only_by_their_owner.ts
+++ b/tests/test-lint/src/features/harness/test_lint_corpus_nested_companions_are_consumed_only_by_their_owner.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  collectExtraSources,
+  listLintCases,
+} from "../../helpers/assertLintCase";
+
+/**
+ * Verifies lint corpus companions: nested grouped cases keep separate owners.
+ *
+ * Recursive collection must not let an outer entry consume the companion of a
+ * nested grouped case. Each companion belongs to the one positive entry whose
+ * case directory contains it in that case's project-level `src/` subtree.
+ *
+ * 1. Materialize nested grouped entries with one companion each.
+ * 2. Validate the complete corpus ownership graph.
+ * 3. Assert each entry collects only its own companion path.
+ */
+export const test_lint_corpus_nested_companions_are_consumed_only_by_their_owner =
+  (): void => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "ttsc-lint-nested-companion-corpus-"),
+    );
+    const files: Readonly<Record<string, string>> = {
+      "outer/violation.ts":
+        "// expect: fixture/outer error\nexport const outer = true;\n",
+      "outer/src/outer.ts":
+        "// @ttsc-corpus-companion\nexport const outerHelper = true;\n",
+      "outer/nested/violation.ts":
+        "// expect: fixture/nested error\nexport const nested = true;\n",
+      "outer/nested/src/nested.ts":
+        "// @ttsc-corpus-companion\nexport const nestedHelper = true;\n",
+    };
+    try {
+      for (const [relativeFile, source] of Object.entries(files)) {
+        const target = path.join(root, relativeFile);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(target, source, "utf8");
+      }
+      assert.equal(listLintCases(root).length, 2);
+      assert.deepEqual(
+        Object.keys(collectExtraSources("outer/violation.ts", root)),
+        ["src/outer.ts"],
+      );
+      assert.deepEqual(
+        Object.keys(collectExtraSources("outer/nested/violation.ts", root)),
+        ["src/nested.ts"],
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };

--- a/tests/test-lint/src/features/harness/test_lint_corpus_source_paths_preserve_tsx_and_select_jsx_mode.ts
+++ b/tests/test-lint/src/features/harness/test_lint_corpus_source_paths_preserve_tsx_and_select_jsx_mode.ts
@@ -26,6 +26,19 @@ export const test_lint_corpus_source_paths_preserve_tsx_and_select_jsx_mode =
     const tsxSourcePath = resolveCorpusSourcePath("", "react/jsx-key.tsx");
     assert.equal(tsSourcePath, "src/main.ts");
     assert.equal(tsxSourcePath, "src/main.tsx");
+    for (const [fixture, expected] of [
+      ["module.mts", "src/main.mts"],
+      ["module.cts", "src/main.cts"],
+      ["types.d.ts", "src/main.d.ts"],
+      ["types.d.mts", "src/main.d.mts"],
+      ["types.d.cts", "src/main.d.cts"],
+    ] as const) {
+      assert.equal(resolveCorpusSourcePath("", fixture), expected);
+    }
+    assert.throws(
+      () => resolveCorpusSourcePath("", "module.TS"),
+      /module\.TS.*canonical lowercase/,
+    );
     assert.equal(
       resolveCorpusSourcePath(
         "// @ttsc-corpus-filename: src/components/Named.tsx\n",

--- a/tests/test-lint/src/features/harness/test_lint_diagnostic_parser_accepts_tsx_source_paths.ts
+++ b/tests/test-lint/src/features/harness/test_lint_diagnostic_parser_accepts_tsx_source_paths.ts
@@ -2,25 +2,18 @@ import { TestLint } from "@ttsc/testing";
 import assert from "node:assert/strict";
 
 /**
- * Verifies the lint diagnostic parser accepts both TSX and TS source paths.
+ * Verifies the lint diagnostic parser accepts every TypeScript source suffix.
  *
- * Preserving a corpus fixture as `src/main.tsx` also changes the filename in
- * rendered diagnostics. The parser must retain TSX lint records without
- * regressing the original TS path or accepting unrelated JavaScript output.
+ * Corpus diagnostics are exact only when the parser retains the source file and
+ * every rendered field without admitting unrelated JavaScript output.
  *
- * 1. Render adjacent TSX, TS, and JavaScript diagnostic lines.
- * 2. Parse the combined stderr stream.
- * 3. Assert both TypeScript records survive and the JavaScript line is ignored.
+ * 1. Render diagnostics for every supported TypeScript suffix.
+ * 2. Preserve file, position, severity, rule, and message expectations.
+ * 3. Assert JavaScript and non-canonical uppercase suffixes are ignored.
  */
 export const test_lint_diagnostic_parser_accepts_tsx_source_paths =
   (): void => {
-    const stderr = [
-      "src/main.tsx:6:12 - error TS9001: [react/jsx-key] Missing key.",
-      "src/main.ts:2:3 - warning TS9002: [no-console] Unexpected console.",
-      "src/main.js:1:1 - error TS9003: [no-debugger] Unexpected debugger.",
-    ].join("\n");
-
-    assert.deepEqual(TestLint.parseDiagnostics(stderr), [
+    const expected: TestLint.ILintDiagnostic[] = [
       {
         file: "src/main.tsx",
         line: 6,
@@ -30,12 +23,42 @@ export const test_lint_diagnostic_parser_accepts_tsx_source_paths =
         message: "Missing key.",
       },
       {
-        file: "src/main.ts",
+        file: "src/my fixture.ts",
         line: 2,
         column: 3,
         severity: "warn",
         rule: "no-console",
         message: "Unexpected console.",
       },
-    ]);
+      ...[
+        "src/component fixture.mts",
+        "src/main.cts",
+        "src/main.d.ts",
+        "src/main.d.mts",
+        "src/main.d.cts",
+      ].map(
+        (file, index): TestLint.ILintDiagnostic => ({
+          file,
+          line: index + 10,
+          column: 2,
+          severity: "error",
+          rule: "fixture/rule",
+          message: `Message ${index}.`,
+        }),
+      ),
+    ];
+    const stderr = [
+      ...expected.map(
+        ({ file, line, column, severity, rule, message }) =>
+          `${file}:${line}:${column} - ${
+            severity === "warn" ? "warning" : "error"
+          } TS9001: [${rule}] ${message}`,
+      ),
+      "src/main.js:1:1 - error TS9003: [no-debugger] Unexpected debugger.",
+      "src/uppercase.TS:1:1 - error TS9003: [fixture/rule] Ignored.",
+      "src/uppercase.TSX:1:1 - error TS9003: [fixture/rule] Ignored.",
+      "src/uppercase.D.TS:1:1 - error TS9003: [fixture/rule] Ignored.",
+    ].join("\n");
+
+    assert.deepEqual(TestLint.parseDiagnostics(stderr), expected);
   };

--- a/tests/test-lint/src/features/harness/test_lint_expectation_parser_accepts_line_and_jsx_block_markers.ts
+++ b/tests/test-lint/src/features/harness/test_lint_expectation_parser_accepts_line_and_jsx_block_markers.ts
@@ -1,0 +1,40 @@
+import { TestLint } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies lint expectations: line and JSX-block markers share one target.
+ *
+ * JSX fixtures cannot place a `//` comment between JSX children. Mixed marker
+ * stacks must therefore recognize both standalone forms and preserve the
+ * special ban-ts-comment targeting rule.
+ *
+ * 1. Parse stacked line and JSX markers followed by one statement.
+ * 2. Parse a ban-ts-comment marker followed by a TypeScript suppressor.
+ * 3. Assert each marker resolves to the intended source line.
+ */
+export const test_lint_expectation_parser_accepts_line_and_jsx_block_markers =
+  (): void => {
+    const source = [
+      "/** Mentions `// expect:` as prose, not as a marker. */",
+      "// This prose comment mentions expect but is not a marker.",
+      "{ /* This JSX prose comment mentions expect but is not a marker. */ }",
+      "declare const expect: unknown;",
+      "// expect: first/rule error",
+      "{ /* expect: second/rule warn */ }",
+      "",
+      "const value = 1;",
+      "// expect: typescript/ban-ts-comment error",
+      "// @ts-ignore",
+      "const ignored = value;",
+    ].join("\n");
+
+    assert.deepEqual(TestLint.parseExpectations(source), [
+      { rule: "first/rule", severity: "error", line: 8 },
+      { rule: "second/rule", severity: "warn", line: 8 },
+      {
+        rule: "typescript/ban-ts-comment",
+        severity: "error",
+        line: 10,
+      },
+    ]);
+  };

--- a/tests/test-lint/src/features/harness/test_lint_expectation_parser_rejects_malformed_or_targetless_markers.ts
+++ b/tests/test-lint/src/features/harness/test_lint_expectation_parser_rejects_malformed_or_targetless_markers.ts
@@ -1,0 +1,58 @@
+import { TestLint } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies lint expectations: malformed and targetless markers fail loudly.
+ *
+ * Discovery previously interpreted a parser miss as "not a fixture", so one
+ * typo could remove coverage. Every marker-shaped line must either parse and
+ * reach a target or throw before corpus partitioning, even after valid
+ * markers.
+ *
+ * 1. Parse malformed line, JSX-block, and mixed marker stacks.
+ * 2. Parse valid markers at end-of-file with no following source line.
+ * 3. Assert every invalid form reports its line and failure category.
+ */
+export const test_lint_expectation_parser_rejects_malformed_or_targetless_markers =
+  (): void => {
+    for (const [source, pattern] of [
+      ["// expect: rule/name fatal\nconst x = 1;", /malformed.*line 1/],
+      ["// expect : rule/name error\nconst x = 1;", /malformed.*line 1/],
+      [
+        "// expect: first/rule error\nconst first = 1;\n// expect second/rule warn\nconst second = 2;",
+        /malformed.*line 3/,
+      ],
+      [
+        "// expect: first/rule error\nconst first = 1;\n// expect second/rule\nconst second = 2;",
+        /malformed.*line 3/,
+      ],
+      [
+        "// expect: first/rule error\nconst first = 1;\n// expect second/rule warn trailing\nconst second = 2;",
+        /malformed.*line 3/,
+      ],
+      ["{/* expect: rule\/name error *\/\nconst x = 1;", /malformed.*line 1/],
+      ["{ /* expect : rule/name error */ }\nconst x = 1;", /malformed.*line 1/],
+      [
+        "{ /* expect: first/rule error */ }\n<div />\n{ /* expect second/rule warn */ }\n<span />",
+        /malformed.*line 3/,
+      ],
+      [
+        "{ /* expect: first/rule error */ }\n<div />\n{ /* expect second/rule */ }\n<span />",
+        /malformed.*line 3/,
+      ],
+      [
+        "// expect: first/rule error\n{ /* expect: second/rule fatal */ }\nconst x = 1;",
+        /malformed.*line 2/,
+      ],
+      [
+        "const x = 1;\n// expect: rule/name error",
+        /line 2.*no following target/,
+      ],
+      [
+        "const x = 1;\n{/* expect: rule/name warn */}",
+        /line 2.*no following target/,
+      ],
+    ] as const) {
+      assert.throws(() => TestLint.parseExpectations(source), pattern);
+    }
+  };

--- a/tests/test-lint/src/features/harness/test_lint_fixture_source_paths_are_preflighted_portably.ts
+++ b/tests/test-lint/src/features/harness/test_lint_fixture_source_paths_are_preflighted_portably.ts
@@ -1,0 +1,393 @@
+import { TestLint, TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Verifies lint fixture paths: every source target is preflighted portably.
+ *
+ * Unchecked companions could escape the temporary project or overwrite the main
+ * fixture through separator and case aliases. Validation must happen before any
+ * fixture file is written while root-level config files stay legal.
+ *
+ * 1. Try invalid source, package-link, exact-temp, and junction targets.
+ * 2. Assert every rejected plan leaves its pre-existing roots untouched.
+ * 3. Materialize normalized spaced sources and a scoped package link.
+ */
+export const test_lint_fixture_source_paths_are_preflighted_portably =
+  (): void => {
+    const invalidRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "ttsc-lint-source-preflight-"),
+    );
+    const sentinel = path.join(invalidRoot, "sentinel.txt");
+    fs.writeFileSync(sentinel, "untouched", "utf8");
+
+    const invalidPlans: readonly [
+      string,
+      Pick<
+        TestLint.IRunLintOptions,
+        "sourcePath" | "extraSources" | "linkNodeModules" | "rules"
+      >,
+      RegExp,
+    ][] = [
+      ["empty-main", { sourcePath: "" }, /sourcePath.*non-empty/],
+      [
+        "absolute-main",
+        { sourcePath: "C:\\outside.ts" },
+        /sourcePath.*project-root-relative/,
+      ],
+      [
+        "escaping-main",
+        { sourcePath: "src/../../outside.ts" },
+        /sourcePath.*project-root-relative/,
+      ],
+      [
+        "main-trailing-dot-alias",
+        { sourcePath: "src/main.ts." },
+        /sourcePath.*portable.*main\.ts\./,
+      ],
+      [
+        "main-uppercase-typescript-suffix",
+        { sourcePath: "src/main.TS" },
+        /sourcePath.*canonical lowercase.*main\.TS/,
+      ],
+      ["empty-extra", { extraSources: { "": "" } }, /extraSources.*non-empty/],
+      [
+        "posix-directory-extra",
+        { extraSources: { "src/generated/": "" } },
+        /extraSources.*file path/,
+      ],
+      [
+        "windows-directory-extra",
+        { extraSources: { "src\\generated\\": "" } },
+        /extraSources.*file path/,
+      ],
+      [
+        "absolute-extra",
+        { extraSources: { "/outside.ts": "" } },
+        /extraSources.*project-root-relative/,
+      ],
+      [
+        "escaping-extra",
+        { extraSources: { "../outside.ts": "" } },
+        /extraSources.*project-root-relative/,
+      ],
+      [
+        "extra-trailing-dot-alias",
+        { extraSources: { "src/main.ts.": "companion" } },
+        /extraSources.*portable.*main\.ts\./,
+      ],
+      [
+        "extra-uppercase-tsx-suffix",
+        { extraSources: { "src/component.TSX": "companion" } },
+        /extraSources.*canonical lowercase.*component\.TSX/,
+      ],
+      [
+        "extra-uppercase-declaration-suffix",
+        { extraSources: { "src/types.D.TS": "companion" } },
+        /extraSources.*canonical lowercase.*types\.D\.TS/,
+      ],
+      [
+        "generated-tsconfig-trailing-space-alias",
+        { extraSources: { "tsconfig.json ": "{}" } },
+        /extraSources.*portable.*tsconfig\.json/,
+      ],
+      [
+        "generated-lint-config-trailing-dot-alias",
+        {
+          rules: {},
+          extraSources: { "lint.config.json.": "{}" },
+        },
+        /extraSources.*portable.*lint\.config\.json\./,
+      ],
+      [
+        "main-alternate-data-stream-alias",
+        { extraSources: { "src/main.ts::$DATA": "companion" } },
+        /extraSources.*portable.*main\.ts::\$DATA/,
+      ],
+      [
+        "generated-config-alternate-data-stream-alias",
+        { extraSources: { "tsconfig.json::$DATA": "{}" } },
+        /extraSources.*portable.*tsconfig\.json::\$DATA/,
+      ],
+      [
+        "windows-reserved-device-name",
+        { extraSources: { "src/CON.ts": "companion" } },
+        /extraSources.*portable.*CON\.ts/,
+      ],
+      [
+        "windows-numbered-device-name",
+        { extraSources: { "src/COM9.ts": "companion" } },
+        /extraSources.*portable.*COM9\.ts/,
+      ],
+      [
+        "windows-superscript-device-name",
+        { extraSources: { "src/LPT¹.ts": "companion" } },
+        /extraSources.*portable.*LPT¹\.ts/,
+      ],
+      [
+        "windows-console-device-name",
+        { extraSources: { "src/CONOUT$.ts": "companion" } },
+        /extraSources.*portable.*CONOUT\$\.ts/,
+      ],
+      [
+        "windows-forbidden-file-character",
+        { extraSources: { "src/invalid?.ts": "companion" } },
+        /extraSources.*portable.*invalid\?\.ts/,
+      ],
+      [
+        "default-main-separator-alias",
+        { extraSources: { "src\\main.ts": "companion" } },
+        /paths collide.*src\/main\.ts.*src\\main\.ts/,
+      ],
+      [
+        "explicit-main-case-alias",
+        {
+          sourcePath: "src/Feature.ts",
+          extraSources: { "SRC\\FEATURE.ts": "companion" },
+        },
+        /source root as src\/.*SRC\\FEATURE\.ts/,
+      ],
+      [
+        "companion-separator-case-alias",
+        {
+          extraSources: {
+            "src/helper.ts": "first",
+            "src\\HELPER.ts": "second",
+          },
+        },
+        /paths collide.*src\/helper\.ts.*src\\HELPER\.ts/,
+      ],
+      [
+        "included-source-root-case-alias",
+        { extraSources: { "SRC/helper.tsx": "export {};" } },
+        /source root as src\/.*SRC\/helper\.tsx/,
+      ],
+      [
+        "main-directory-alias",
+        { extraSources: { src: "companion" } },
+        /paths collide.*src\/main\.ts.*src/,
+      ],
+      [
+        "main-descendant-alias",
+        { extraSources: { "src/main.ts/child.ts": "companion" } },
+        /paths collide.*src\/main\.ts.*src\/main\.ts\/child\.ts/,
+      ],
+      [
+        "extra-source-file-directory-alias",
+        {
+          extraSources: {
+            "src/generated": "file",
+            "src/generated/child.ts": "child",
+          },
+        },
+        /paths collide.*src\/generated.*src\/generated\/child\.ts/,
+      ],
+      [
+        "generated-tsconfig-descendant",
+        { extraSources: { "tsconfig.json/child.ts": "child" } },
+        /generated target.*tsconfig\.json\/child\.ts.*tsconfig\.json/,
+      ],
+      [
+        "generated-tsconfig-case-alias",
+        { extraSources: { "TSCONFIG.JSON": "{}" } },
+        /generated target.*TSCONFIG\.JSON.*tsconfig\.json/,
+      ],
+      [
+        "generated-lint-config-case-alias",
+        {
+          rules: {},
+          extraSources: { "LINT.CONFIG.JSON": "{}" },
+        },
+        /generated target.*LINT\.CONFIG\.JSON.*lint\.config\.json/,
+      ],
+      [
+        "generated-node-modules-ancestor",
+        { extraSources: { node_modules: "file" } },
+        /generated target.*node_modules.*node_modules\/@ttsc\/lint/,
+      ],
+      [
+        "link-node-modules-traversal",
+        { linkNodeModules: ["../outside"] },
+        /linkNodeModules.*npm package name.*\.\.\/outside/,
+      ],
+      [
+        "link-node-modules-backslash",
+        { linkNodeModules: ["scope\\package"] },
+        /linkNodeModules.*npm package name.*scope\\package/,
+      ],
+      [
+        "link-node-modules-absolute",
+        { linkNodeModules: ["/package"] },
+        /linkNodeModules.*npm package name.*\/package/,
+      ],
+      [
+        "link-node-modules-nonportable",
+        { linkNodeModules: ["con"] },
+        /linkNodeModules.*portable npm package name.*con/,
+      ],
+    ];
+
+    try {
+      for (const [name, overrides, pattern] of invalidPlans) {
+        assert.throws(
+          () =>
+            TestLint.createProject({
+              name,
+              source: "export {};",
+              projectRoot: invalidRoot,
+              ...overrides,
+            }),
+          pattern,
+        );
+        assert.equal(fs.readFileSync(sentinel, "utf8"), "untouched");
+        assert.deepEqual(fs.readdirSync(invalidRoot), ["sentinel.txt"]);
+      }
+
+      const fileRoot = path.join(invalidRoot, "project-root.txt");
+      fs.writeFileSync(fileRoot, "untouched", "utf8");
+      assert.throws(
+        () =>
+          TestLint.createProject({
+            name: "existing-file-project-root",
+            source: "export {};",
+            projectRoot: fileRoot,
+          }),
+        /projectRoot.*disposable directory strictly under/,
+      );
+      assert.equal(fs.readFileSync(fileRoot, "utf8"), "untouched");
+
+      assert.throws(
+        () =>
+          TestLint.createProject({
+            name: "exact-system-temp-root",
+            source: "export {};",
+            projectRoot: os.tmpdir(),
+          }),
+        /projectRoot.*disposable directory strictly under/,
+      );
+
+      const externalRoot = fs.mkdtempSync(
+        path.join(
+          TestProject.WORKSPACE_ROOT,
+          ".ttsc-lint-source-preflight-external-",
+        ),
+      );
+      const externalSentinel = path.join(externalRoot, "sentinel.txt");
+      const escapedRoot = path.join(invalidRoot, "escaped-root");
+      const nestedRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), "ttsc-lint-nested-junction-root-"),
+      );
+      const nestedSourceRoot = path.join(nestedRoot, "src");
+      try {
+        fs.writeFileSync(externalSentinel, "untouched", "utf8");
+        fs.symlinkSync(
+          externalRoot,
+          escapedRoot,
+          process.platform === "win32" ? "junction" : "dir",
+        );
+        assert.throws(
+          () =>
+            TestLint.createProject({
+              name: "junction-root-escape",
+              source: "export {};",
+              projectRoot: escapedRoot,
+            }),
+          /projectRoot.*disposable directory strictly under/,
+        );
+        assert.deepEqual(fs.readdirSync(externalRoot), ["sentinel.txt"]);
+        assert.equal(fs.readFileSync(externalSentinel, "utf8"), "untouched");
+
+        fs.symlinkSync(
+          externalRoot,
+          nestedSourceRoot,
+          process.platform === "win32" ? "junction" : "dir",
+        );
+        assert.throws(
+          () =>
+            TestLint.createProject({
+              name: "nested-junction-write-escape",
+              source: "export {};",
+              projectRoot: nestedRoot,
+            }),
+          /projectRoot.*empty disposable directory strictly under/,
+        );
+        assert.deepEqual(fs.readdirSync(externalRoot), ["sentinel.txt"]);
+        assert.equal(fs.readFileSync(externalSentinel, "utf8"), "untouched");
+      } finally {
+        if (fs.existsSync(escapedRoot)) fs.unlinkSync(escapedRoot);
+        if (fs.existsSync(nestedSourceRoot)) fs.unlinkSync(nestedSourceRoot);
+        fs.rmSync(nestedRoot, { recursive: true, force: true });
+        fs.rmSync(externalRoot, { recursive: true, force: true });
+      }
+
+      const generatedCollisionRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), "ttsc-lint-generated-collision-"),
+      );
+      try {
+        assert.throws(
+          () =>
+            TestLint.createProject({
+              name: "generated-lint-config-exact-collision",
+              source: "export {};",
+              projectRoot: generatedCollisionRoot,
+              rules: {},
+              extraSources: { "lint.config.json": "custom fixture" },
+            }),
+          /generated target.*lint\.config\.json/,
+        );
+        assert.deepEqual(fs.readdirSync(generatedCollisionRoot), []);
+      } finally {
+        fs.rmSync(generatedCollisionRoot, { recursive: true, force: true });
+      }
+
+      const project = TestLint.createProject({
+        name: "legal-portable-source-paths",
+        source: "export const value = 1;",
+        sourcePath: "src\\nested\\entry fixture.ts",
+        extraSources: {
+          "./lint.config.json": JSON.stringify({ rules: {} }),
+          "src\\nested\\child\\..\\support.ts": "export type Support = string;",
+          "src/COM0.ts": "export const com0 = true;",
+          "src/LPT0.ts": "export const lpt0 = true;",
+        },
+        linkNodeModules: ["@ttsc/lint"],
+      });
+      try {
+        assert.equal(
+          fs.readFileSync(
+            path.join(project.tmpdir, "src", "nested", "entry fixture.ts"),
+            "utf8",
+          ),
+          "export const value = 1;",
+        );
+        assert.equal(
+          fs.readFileSync(
+            path.join(project.tmpdir, "lint.config.json"),
+            "utf8",
+          ),
+          JSON.stringify({ rules: {} }),
+        );
+        assert.equal(
+          fs.readFileSync(
+            path.join(project.tmpdir, "src", "nested", "support.ts"),
+            "utf8",
+          ),
+          "export type Support = string;",
+        );
+        assert.equal(
+          fs.readFileSync(path.join(project.tmpdir, "src", "COM0.ts"), "utf8"),
+          "export const com0 = true;",
+        );
+        assert.equal(
+          fs.readFileSync(path.join(project.tmpdir, "src", "LPT0.ts"), "utf8"),
+          "export const lpt0 = true;",
+        );
+      } finally {
+        project.cleanup();
+      }
+    } finally {
+      fs.rmSync(invalidRoot, { recursive: true, force: true });
+    }
+  };

--- a/tests/test-lint/src/helpers/assertLintCase.ts
+++ b/tests/test-lint/src/helpers/assertLintCase.ts
@@ -40,14 +40,22 @@ interface CorpusSkipManifestEntry {
   harness: string;
 }
 
+interface CorpusFileRecord {
+  relativeFile: string;
+  source: string;
+  expectations: TestLint.ILintExpectation[];
+  skip: CorpusSkipDirective | null;
+  companion: boolean;
+}
+
 const corpusSkipManifest = loadCorpusSkipManifest();
 
 /**
- * Discover and assert every annotated lint fixture under `src/cases`.
+ * Discover and assert every classified lint fixture under `src/cases`.
  *
- * Iterates all `.ts` and `.tsx` files in the cases tree that contain an
- * expectation or corpus-skip directive and delegates to `assertLintCase` for
- * each. Fails immediately if the corpus is empty.
+ * Classifies every supported TypeScript source in the cases tree as a positive
+ * entry, audited skip, or explicit companion, then delegates every entry to
+ * `assertLintCase`. Unclassified or conflicting sources fail immediately.
  *
  * A fixture may opt out with one `// @ttsc-corpus-skip(<constraint>): <reason>`
  * directive. Its rule, constraint, and Go harness must match the mechanically
@@ -68,22 +76,45 @@ export function assertAllLintCases(partition?: {
   const selected = partition
     ? cases.filter((_, i) => i % partition.total === partition.index)
     : cases;
-  for (const file of selected) {
-    assertLintCase(file);
+  assertLintCases(selected);
+}
+
+/**
+ * Assert a batch of lint fixtures and report every failure from the sweep.
+ *
+ * Corpus partitions are expensive real-launcher tests. Continuing after an
+ * individual mismatch exposes all stale fixture contracts in one run instead of
+ * requiring a full partition restart for each successive failure.
+ */
+export function assertLintCases(relativeFiles: readonly string[]): void {
+  const failures: Error[] = [];
+  for (const file of relativeFiles) {
+    try {
+      assertLintCase(file);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      failures.push(new Error(`${file}: ${detail}`, { cause: error }));
+    }
+  }
+  if (failures.length !== 0) {
+    throw new AggregateError(
+      failures,
+      `${failures.length} lint corpus fixture(s) failed`,
+    );
   }
 }
 
 /**
  * Assert that running the native lint engine on a single fixture file produces
- * exactly the diagnostics annotated in its `// expect:` comments.
+ * exactly the diagnostics declared by its expectation comments.
  *
  * Reads the rule set from the fixture's own annotations so that adding or
  * removing a rule only requires editing the fixture — no other file changes. A
  * rule that needs options carries them in a `// @ttsc-corpus-options: <rule>
  * <json>` directive, which upgrades that rule's config entry to the `[severity,
  * options]` tuple (see `applyCorpusOptions`). Extra sources in the same
- * subdirectory (e.g. `src/` fixtures for multi-file rules) are gathered by
- * `collectExtraSources`.
+ * subdirectory carry `// @ttsc-corpus-companion`; `collectExtraSources`
+ * materializes those files at their case-root-relative paths.
  *
  * Honors the audited `// @ttsc-corpus-skip(<constraint>): <reason>` directive:
  * a matching fixture is validated but its flat native run is skipped. The
@@ -92,26 +123,36 @@ export function assertAllLintCases(partition?: {
  *
  * Honors the `// @ttsc-corpus-filename: <path>` directive: the fixture is
  * materialized at the given project-root-relative path (under `src/`) instead
- * of the extension-preserving default (`src/main.ts` or `src/main.tsx`), so
- * path-sensitive rules (filename conventions, directory layouts) can carry
- * their logical filename while the on-disk fixture keeps a corpus-friendly
- * name.
+ * of the extension-preserving `src/main<suffix>` default, so path-sensitive
+ * rules (filename conventions, directory layouts) can carry their logical
+ * filename while the on-disk fixture keeps a corpus-friendly name.
  *
  * @param relativeFile - File path relative to `casesRoot` (forward-slash
- *   separated, e.g. `"consistentTypeImports/violation.ts"`).
+ *   separated, e.g. `"consistent-type-imports/violation.ts"`).
  */
 export function assertLintCase(relativeFile: string): void {
   const source = fs.readFileSync(path.join(casesRoot, relativeFile), "utf8");
+  assert.equal(
+    parseCorpusCompanion(relativeFile, source),
+    false,
+    `${relativeFile}: a corpus companion cannot run as a standalone fixture`,
+  );
   const skip = parseCorpusSkip(relativeFile, source);
   if (skip !== null) {
     validateCorpusSkip(relativeFile, source, skip);
     return;
   }
   const expected = TestLint.parseExpectations(source);
+  assert.notEqual(
+    expected.length,
+    0,
+    `${relativeFile}: a corpus entry requires an expectation or audited skip`,
+  );
+  const sourcePath = resolveCorpusSourcePath(source, relativeFile);
   const result = TestLint.run({
     name: relativeFile,
     source,
-    sourcePath: resolveCorpusSourcePath(source, relativeFile),
+    sourcePath,
     rules: applyCorpusOptions(
       relativeFile,
       source,
@@ -125,15 +166,46 @@ export function assertLintCase(relativeFile: string): void {
     0,
     `${relativeFile} should report lint diagnostics.\n${result.stderr}`,
   );
+  assertLintDiagnostics(
+    sourcePath,
+    result.diagnostics,
+    expected,
+    result.stderr,
+  );
+}
+
+/**
+ * Assert exact corpus diagnostics, including their portable fixture-file
+ * identity. TestLint rejects case-only source aliases, so case folding here
+ * identifies the same target consistently on Windows and POSIX runners.
+ */
+export function assertLintDiagnostics(
+  sourcePath: string,
+  diagnostics: readonly TestLint.ILintDiagnostic[],
+  expected: readonly TestLint.ILintExpectation[],
+  message?: string,
+): void {
+  const file = portableSourceFileIdentity(sourcePath);
   assert.deepEqual(
-    result.diagnostics.map(({ rule, severity, line }) => ({
+    diagnostics.map(({ file: actualFile, rule, severity, line }) => ({
+      file: portableSourceFileIdentity(actualFile),
       rule,
       severity,
       line,
     })),
-    expected.map(({ rule, severity, line }) => ({ rule, severity, line })),
-    result.stderr,
+    expected.map(({ rule, severity, line }) => ({
+      file,
+      rule,
+      severity,
+      line,
+    })),
+    message,
   );
+}
+
+/** Normalize a rendered source path to the fixture's portable identity. */
+function portableSourceFileIdentity(sourcePath: string): string {
+  return path.posix.normalize(sourcePath.replaceAll("\\", "/")).toLowerCase();
 }
 
 function validateCorpusSkip(
@@ -196,7 +268,9 @@ function validateCorpusSkip(
   return rule;
 }
 
-function validateCorpusSkipManifestCoverage(cases: readonly string[]): void {
+export function validateCorpusSkipManifestCoverage(
+  cases: readonly string[],
+): void {
   const used = new Set<string>();
   for (const relativeFile of cases) {
     const source = fs.readFileSync(path.join(casesRoot, relativeFile), "utf8");
@@ -282,7 +356,7 @@ function isCorpusConstraint(value: unknown): value is CorpusConstraint {
 
 /**
  * Merge `// @ttsc-corpus-options: <rule> <json>` directives into the rules map
- * parsed from the fixture's `// expect:` annotations. Each directive turns the
+ * parsed from the fixture's expectation annotations. Each directive turns the
  * named rule's severity into the `[severity, options]` tuple the lint config
  * format accepts, so option-bearing rules (e.g. `unicorn/string-content`, which
  * reports nothing without configured patterns) can run through the same flat
@@ -292,23 +366,32 @@ function isCorpusConstraint(value: unknown): value is CorpusConstraint {
  * options would silently configure nothing, so it fails loudly. The Go rule
  * corpus helper (`newRuleCorpusEngine`) parses the identical directive.
  */
-function applyCorpusOptions(
+export function applyCorpusOptions(
   relativeFile: string,
   source: string,
   rules: Record<string, TestLint.LintRuleConfigEntry>,
 ): Record<string, TestLint.LintRuleConfigEntry> {
-  for (const line of source.split(/\r?\n/)) {
-    const match = line.match(
-      /^\s*\/\/\s*@ttsc-corpus-options:\s*(\S+)\s+(\S.*?)\s*$/,
-    );
-    if (!match) continue;
+  const markerCount = [
+    ...source.matchAll(/^\s*\/\/\s*@ttsc-corpus-options(?=\s|:|$).*$/gm),
+  ].length;
+  const directives = [
+    ...source.matchAll(
+      /^\s*\/\/\s*@ttsc-corpus-options\s*:\s*(\S+)\s+(\S.*?)\s*$/gm,
+    ),
+  ];
+  assert.equal(
+    directives.length,
+    markerCount,
+    `${relativeFile}: malformed \`// @ttsc-corpus-options: <rule> <json>\` directive`,
+  );
+  for (const match of directives) {
     const [, rule, payload] = match;
     if (!rule || !payload) continue;
     const severity = rules[rule];
     assert.notEqual(
       severity,
       undefined,
-      `${relativeFile}: @ttsc-corpus-options names ${rule}, which has no // expect: annotation`,
+      `${relativeFile}: @ttsc-corpus-options names ${rule}, which has no expectation annotation`,
     );
     assert.ok(
       typeof severity === "string",
@@ -373,36 +456,154 @@ export function resolveCorpusSourcePath(
   source: string,
   relativeFile: string,
 ): string {
-  for (const line of source.split(/\r?\n/)) {
-    const match = line.match(/^\s*\/\/\s*@ttsc-corpus-filename:\s*(.*?)\s*$/);
-    if (match) {
-      const sourcePath = match[1] ?? "";
-      assert.notEqual(
-        sourcePath.length,
-        0,
-        `${relativeFile}: \`// @ttsc-corpus-filename:\` requires a path`,
-      );
-      return sourcePath;
-    }
+  const markerCount = [
+    ...source.matchAll(/^\s*\/\/\s*@ttsc-corpus-filename(?=\s|:|$).*$/gm),
+  ].length;
+  const directives = [
+    ...source.matchAll(/^\s*\/\/\s*@ttsc-corpus-filename\s*:\s*(.*?)\s*$/gm),
+  ];
+  assert.equal(
+    directives.length,
+    markerCount,
+    `${relativeFile}: malformed \`// @ttsc-corpus-filename: <path>\` directive`,
+  );
+  assert.ok(
+    directives.length <= 1,
+    `${relativeFile}: a lint fixture may declare at most one corpus-filename directive`,
+  );
+  if (directives[0]) {
+    const sourcePath = directives[0][1] ?? "";
+    assert.notEqual(
+      sourcePath.length,
+      0,
+      `${relativeFile}: \`// @ttsc-corpus-filename:\` requires a path`,
+    );
+    return sourcePath;
   }
-  return path.posix.join("src", `main${path.posix.extname(relativeFile)}`);
+  if (TestLint.hasNonCanonicalTypeScriptSourceExtension(relativeFile)) {
+    throw new Error(
+      `${relativeFile}: TypeScript source extension must use canonical lowercase spelling`,
+    );
+  }
+  const extension = TestLint.typescriptSourceExtension(relativeFile);
+  assert.notEqual(
+    extension,
+    null,
+    `${relativeFile}: unsupported TypeScript source extension`,
+  );
+  return path.posix.join("src", `main${extension}`);
 }
 
 /**
- * List every expected or explicitly excluded lint fixture under `casesRoot` as
- * a forward-slash path relative to that root.
+ * List every lint entry under a corpus root as a forward-slash relative path.
+ *
+ * Discovery starts from every TypeScript source instead of treating the
+ * presence of an expectation as an implicit entry marker. Each source must be a
+ * positive entry, an audited skip, or an explicit companion; an unclassified
+ * source fails loudly so a typo cannot silently remove coverage.
  */
-function listLintCases(): string[] {
-  return walk(casesRoot)
-    .filter((file) => file.endsWith(".ts") || file.endsWith(".tsx"))
-    .map((file) => path.relative(casesRoot, file).replaceAll(path.sep, "/"))
+export function listLintCases(root: string = casesRoot): string[] {
+  const records = walk(root)
     .filter((file) => {
-      const source = fs.readFileSync(path.join(casesRoot, file), "utf8");
+      if (TestLint.hasNonCanonicalTypeScriptSourceExtension(file)) {
+        const relativeFile = path
+          .relative(root, file)
+          .replaceAll(path.sep, "/");
+        throw new Error(
+          `${relativeFile}: TypeScript source extension must use canonical lowercase spelling`,
+        );
+      }
+      return TestLint.isTypeScriptSourcePath(file);
+    })
+    .map((file): CorpusFileRecord => {
+      const relativeFile = path.relative(root, file).replaceAll(path.sep, "/");
+      const source = fs.readFileSync(file, "utf8");
+      return {
+        relativeFile,
+        source,
+        expectations: TestLint.parseExpectations(source),
+        skip: parseCorpusSkip(relativeFile, source),
+        companion: parseCorpusCompanion(relativeFile, source),
+      };
+    });
+
+  for (const record of records) {
+    if (record.companion) {
+      validateCorpusCompanionRole(record);
+      continue;
+    }
+    assert.ok(
+      record.expectations.length !== 0 || record.skip !== null,
+      `${record.relativeFile}: a corpus source must declare an expectation, audited skip, or @ttsc-corpus-companion`,
+    );
+  }
+  validateCorpusCompanionCoverage(records);
+  return records
+    .filter((record) => !record.companion)
+    .map((record) => record.relativeFile);
+}
+
+/** Read and validate the single explicit companion marker, if present. */
+function parseCorpusCompanion(relativeFile: string, source: string): boolean {
+  const markerCount = [
+    ...source.matchAll(/^\s*\/\/\s*@ttsc-corpus-companion\b.*$/gm),
+  ].length;
+  const directives = [
+    ...source.matchAll(/^\s*\/\/\s*@ttsc-corpus-companion\s*$/gm),
+  ];
+  assert.equal(
+    directives.length,
+    markerCount,
+    `${relativeFile}: malformed \`// @ttsc-corpus-companion\` directive`,
+  );
+  assert.ok(
+    directives.length <= 1,
+    `${relativeFile}: a corpus source may declare at most one companion directive`,
+  );
+  return directives.length === 1;
+}
+
+function validateCorpusCompanionRole(record: CorpusFileRecord): void {
+  assert.equal(
+    record.expectations.length,
+    0,
+    `${record.relativeFile}: a corpus companion cannot declare expectations`,
+  );
+  assert.equal(
+    record.skip,
+    null,
+    `${record.relativeFile}: a corpus companion cannot also be an audited skip`,
+  );
+  assert.equal(
+    /^\s*\/\/\s*@ttsc-corpus-(?:filename|options|rule)\b/m.test(record.source),
+    false,
+    `${record.relativeFile}: a corpus companion cannot declare entry directives`,
+  );
+}
+
+function validateCorpusCompanionCoverage(
+  records: readonly CorpusFileRecord[],
+): void {
+  const entries = records.filter(
+    (record) =>
+      !record.companion &&
+      record.skip === null &&
+      record.expectations.length !== 0,
+  );
+  for (const companion of records.filter((record) => record.companion)) {
+    const owners = entries.filter((entry) => {
+      const caseDirectory = path.posix.dirname(entry.relativeFile);
       return (
-        TestLint.parseExpectations(source).length !== 0 ||
-        parseCorpusSkip(file, source) !== null
+        caseDirectory !== "." &&
+        companion.relativeFile.startsWith(`${caseDirectory}/src/`)
       );
     });
+    assert.equal(
+      owners.length,
+      1,
+      `${companion.relativeFile}: a corpus companion must belong to exactly one positive entry whose case directory contains it under src/`,
+    );
+  }
 }
 
 function parseSkippedRule(relativeFile: string, source: string): string {
@@ -426,24 +627,32 @@ function parseSkippedRule(relativeFile: string, source: string): string {
 }
 
 /**
- * Gather sibling files from the same subdirectory as `relativeFile` to pass as
- * extra sources. Used for rules that need a companion type-declaration or
- * separate module file (e.g. `consistentTypeImports/src/types-fixture.ts`).
+ * Gather explicitly marked companion files from the same grouped case as
+ * `relativeFile`. The companion tree mirrors project-root-relative paths, so a
+ * case's `src/types-fixture.ts` is materialized once at that exact path.
  *
  * Returns an empty object when the fixture sits directly under `casesRoot`
  * (i.e. no subdirectory companion files are expected).
  *
- * @param relativeFile - File path relative to `casesRoot`.
+ * @param relativeFile - File path relative to `root`.
+ * @param root - Corpus root containing the grouped case.
  */
-function collectExtraSources(relativeFile: string): Record<string, string> {
-  const dir = path.dirname(relativeFile);
+export function collectExtraSources(
+  relativeFile: string,
+  root: string = casesRoot,
+): Record<string, string> {
+  const dir = path.posix.dirname(relativeFile);
   if (dir === ".") return {};
-  const root = path.join(casesRoot, dir);
+  const caseRoot = path.join(root, dir);
   const out: Record<string, string> = {};
-  for (const file of walk(root)) {
-    const rel = path.relative(root, file).replaceAll(path.sep, "/");
-    if (rel === path.basename(relativeFile)) continue;
-    out[path.posix.join("src", rel)] = fs.readFileSync(file, "utf8");
+  for (const file of walk(caseRoot)) {
+    const rel = path.relative(caseRoot, file).replaceAll(path.sep, "/");
+    if (!rel.startsWith("src/")) continue;
+    if (!TestLint.isTypeScriptSourcePath(file)) continue;
+    const source = fs.readFileSync(file, "utf8");
+    const companionFile = path.posix.join(dir, rel);
+    if (!parseCorpusCompanion(companionFile, source)) continue;
+    out[rel] = source;
   }
   return out;
 }

--- a/tests/test-lint/src/native-plugins/corpus-2/test_lint_rules_corpus_partition_2_of_4.ts
+++ b/tests/test-lint/src/native-plugins/corpus-2/test_lint_rules_corpus_partition_2_of_4.ts
@@ -1,16 +1,16 @@
 import { assertAllLintCases } from "../../helpers/assertLintCase";
 
 /**
- * Verifies lint corpus partition 2/4 against its annotated fixtures.
+ * Verifies lint corpus partition 2/4 against its classified fixtures.
  *
- * The 600+ fixture corpus is the single heaviest lint scenario, so it is split
+ * The large fixture corpus is the single heaviest lint scenario, so it is split
  * into four evenly-costed partitions that run on parallel CI lanes. This one
  * asserts every 2nd fixture (`index % 4 === 1`); the four partitions together
  * cover the whole corpus exactly once.
  *
- * 1. Discover every annotated fixture under `src/cases`.
+ * 1. Classify every TypeScript fixture under `src/cases`.
  * 2. Keep this partition's `index % 4 === 1` slice.
- * 3. Assert the native lint output equals each fixture's `// expect:` annotations.
+ * 3. Assert every entry's native output or audited skip contract.
  */
 export const test_lint_rules_corpus_partition_2_of_4 = (): void => {
   assertAllLintCases({ index: 1, total: 4 });

--- a/tests/test-lint/src/native-plugins/corpus-3/test_lint_rules_corpus_partition_3_of_4.ts
+++ b/tests/test-lint/src/native-plugins/corpus-3/test_lint_rules_corpus_partition_3_of_4.ts
@@ -1,16 +1,16 @@
 import { assertAllLintCases } from "../../helpers/assertLintCase";
 
 /**
- * Verifies lint corpus partition 3/4 against its annotated fixtures.
+ * Verifies lint corpus partition 3/4 against its classified fixtures.
  *
- * The 600+ fixture corpus is the single heaviest lint scenario, so it is split
+ * The large fixture corpus is the single heaviest lint scenario, so it is split
  * into four evenly-costed partitions that run on parallel CI lanes. This one
  * asserts every 3rd fixture (`index % 4 === 2`); the four partitions together
  * cover the whole corpus exactly once.
  *
- * 1. Discover every annotated fixture under `src/cases`.
+ * 1. Classify every TypeScript fixture under `src/cases`.
  * 2. Keep this partition's `index % 4 === 2` slice.
- * 3. Assert the native lint output equals each fixture's `// expect:` annotations.
+ * 3. Assert every entry's native output or audited skip contract.
  */
 export const test_lint_rules_corpus_partition_3_of_4 = (): void => {
   assertAllLintCases({ index: 2, total: 4 });

--- a/tests/test-lint/src/native-plugins/corpus-4/test_lint_rules_corpus_partition_4_of_4.ts
+++ b/tests/test-lint/src/native-plugins/corpus-4/test_lint_rules_corpus_partition_4_of_4.ts
@@ -1,16 +1,16 @@
 import { assertAllLintCases } from "../../helpers/assertLintCase";
 
 /**
- * Verifies lint corpus partition 4/4 against its annotated fixtures.
+ * Verifies lint corpus partition 4/4 against its classified fixtures.
  *
- * The 600+ fixture corpus is the single heaviest lint scenario, so it is split
+ * The large fixture corpus is the single heaviest lint scenario, so it is split
  * into four evenly-costed partitions that run on parallel CI lanes. This one
  * asserts every 4th fixture (`index % 4 === 3`); the four partitions together
  * cover the whole corpus exactly once.
  *
- * 1. Discover every annotated fixture under `src/cases`.
+ * 1. Classify every TypeScript fixture under `src/cases`.
  * 2. Keep this partition's `index % 4 === 3` slice.
- * 3. Assert the native lint output equals each fixture's `// expect:` annotations.
+ * 3. Assert every entry's native output or audited skip contract.
  */
 export const test_lint_rules_corpus_partition_4_of_4 = (): void => {
   assertAllLintCases({ index: 3, total: 4 });

--- a/tests/test-lint/src/native-plugins/corpus/test_lint_rules_corpus_partition_1_of_4.ts
+++ b/tests/test-lint/src/native-plugins/corpus/test_lint_rules_corpus_partition_1_of_4.ts
@@ -1,16 +1,16 @@
 import { assertAllLintCases } from "../../helpers/assertLintCase";
 
 /**
- * Verifies lint corpus partition 1/4 against its annotated fixtures.
+ * Verifies lint corpus partition 1/4 against its classified fixtures.
  *
- * The 600+ fixture corpus is the single heaviest lint scenario, so it is split
+ * The large fixture corpus is the single heaviest lint scenario, so it is split
  * into four evenly-costed partitions that run on parallel CI lanes. This one
  * asserts every 1st fixture (`index % 4 === 0`); the four partitions together
  * cover the whole corpus exactly once.
  *
- * 1. Discover every annotated fixture under `src/cases`.
+ * 1. Classify every TypeScript fixture under `src/cases`.
  * 2. Keep this partition's `index % 4 === 0` slice.
- * 3. Assert the native lint output equals each fixture's `// expect:` annotations.
+ * 3. Assert every entry's native output or audited skip contract.
  */
 export const test_lint_rules_corpus_partition_1_of_4 = (): void => {
   assertAllLintCases({ index: 0, total: 4 });

--- a/tests/utils/src/lint/TestLint.ts
+++ b/tests/utils/src/lint/TestLint.ts
@@ -9,7 +9,8 @@ import { TestProject } from "../TestProject";
 // Spawn the real `ttsc` binary against an isolated TypeScript fixture
 // and parse the rendered stderr diagnostics into structured records.
 //
-// Each rule's e2e test passes one `.ts` or `.tsx` file (the violation case) and
+// Each rule's e2e test passes one supported TypeScript source file (the
+// violation case) and
 // a rules-map. The helper:
 //   1. mkdtemp's a fixture project with the supplied source at the selected
 //      path (default `src/main.ts`) and a synthesized `tsconfig.json`.
@@ -98,7 +99,7 @@ export namespace TestLint {
     message: string;
   }
 
-  /** Expected diagnostic encoded in a fixture with `// expect:` comments. */
+  /** Expected diagnostic encoded in a fixture expectation comment. */
   export interface ILintExpectation {
     rule: string;
     severity: LintSeverity;
@@ -129,7 +130,7 @@ export namespace TestLint {
      * still cover it.
      */
     sourcePath?: string;
-    /** Optional disposable root under the OS temp dir; cleanup removes it. */
+    /** Optional nonexistent or empty disposable root under the OS temp dir. */
     projectRoot?: string;
     rules?: Record<string, LintRuleConfigEntry>;
     pluginConfig?: Record<string, unknown>;
@@ -182,17 +183,24 @@ export namespace TestLint {
       extraSources,
       linkNodeModules,
     } = options;
-    const tmpdir =
-      projectRoot ??
-      TestProject.tmpdir(`ttsc-lint-case-${sanitizeForFsName(name)}-`);
+    const linkedNodeModules = resolveLinkedNodeModules(linkNodeModules);
+    const mainSourcePath = resolveMainSourcePath(
+      sourcePath ?? path.posix.join("src", "main.ts"),
+    );
+    const resolvedExtraSources = resolveExtraSourcePaths(mainSourcePath, {
+      extraSources,
+      linkedNodeModulePaths: linkedNodeModules.map(
+        ({ relativePath }) => relativePath,
+      ),
+      writesGeneratedLintConfig: rules !== undefined,
+    });
     if (projectRoot !== undefined) {
       assertDisposableProjectRoot(projectRoot);
     }
+    const tmpdir =
+      projectRoot ??
+      TestProject.tmpdir(`ttsc-lint-case-${sanitizeForFsName(name)}-`);
     try {
-      const materializedExtraSources = Object.entries(extraSources ?? {}).map(
-        ([relativePath, content]) =>
-          [normalizeFixtureRelativePath(relativePath), content] as const,
-      );
       // The tsconfig plugin entry never carries rules: it is empty, or
       // optionally names a config file via `configFile`. When a test uses the
       // `rules` shorthand, materialize a discoverable `lint.config.json`.
@@ -200,10 +208,10 @@ export namespace TestLint {
         tmpdir,
         source,
         pluginConfig ?? {},
-        sourcePath,
-        materializedExtraSources.map(([relativePath]) => relativePath),
+        mainSourcePath,
+        resolvedExtraSources.map(([relativePath]) => relativePath),
       );
-      for (const [relativePath, content] of materializedExtraSources) {
+      for (const [relativePath, content] of resolvedExtraSources) {
         const target = path.join(tmpdir, relativePath);
         fs.mkdirSync(path.dirname(target), { recursive: true });
         fs.writeFileSync(target, content, "utf8");
@@ -216,10 +224,8 @@ export namespace TestLint {
         );
       }
       seedNodeModulesLink(tmpdir);
-      if (linkNodeModules) {
-        for (const packageName of linkNodeModules) {
-          linkNodeModulePackage(tmpdir, packageName);
-        }
+      for (const linkedNodeModule of linkedNodeModules) {
+        linkNodeModulePackage(tmpdir, linkedNodeModule);
       }
       return {
         tmpdir,
@@ -269,10 +275,9 @@ export namespace TestLint {
     tmpdir: string,
     source: string,
     pluginConfig: Record<string, unknown>,
-    sourcePath: string = path.posix.join("src", "main.ts"),
-    extraSourcePaths: readonly string[] = [],
+    mainSourcePath: string,
+    extraSourcePaths: readonly string[],
   ): void {
-    const mainSourcePath = resolveMainSourcePath(sourcePath);
     const usesTSX = [mainSourcePath, ...extraSourcePaths].some(
       isIncludedTSXSourcePath,
     );
@@ -317,14 +322,13 @@ export namespace TestLint {
    * harness must never write outside its disposable project.
    */
   function resolveMainSourcePath(sourcePath: string): string {
-    const normalized = normalizeFixtureRelativePath(sourcePath);
-    if (
-      path.isAbsolute(normalized) ||
-      !normalized.startsWith("src/") ||
-      normalized
-        .split("/")
-        .some((segment) => segment === ".." || segment === "")
-    ) {
+    const normalized = resolveProjectSourcePath(sourcePath, "sourcePath");
+    assertCanonicalTypeScriptSourceExtension(
+      normalized,
+      "sourcePath",
+      sourcePath,
+    );
+    if (!normalized.startsWith("src/")) {
       throw new Error(
         `TestLint sourcePath must be a project-root-relative path under src/: ${sourcePath}`,
       );
@@ -332,55 +336,242 @@ export namespace TestLint {
     return normalized;
   }
 
-  /** Normalize caller paths so POSIX and Windows separators materialize alike. */
-  function normalizeFixtureRelativePath(sourcePath: string): string {
-    return path.posix.normalize(sourcePath.replaceAll("\\", "/"));
+  /**
+   * Normalize every extra-source target and reject portable aliases before the
+   * fixture writes its main source or generated config files.
+   */
+  function resolveExtraSourcePaths(
+    mainSourcePath: string,
+    options: {
+      extraSources: Record<string, string> | undefined;
+      linkedNodeModulePaths: readonly string[];
+      writesGeneratedLintConfig: boolean;
+    },
+  ): [string, string][] {
+    const sources = [mainSourcePath];
+    const generatedTargets: readonly {
+      path: string;
+      sourceMayReplaceExactFile: boolean;
+    }[] = [
+      { path: "tsconfig.json", sourceMayReplaceExactFile: true },
+      ...(options.writesGeneratedLintConfig
+        ? [{ path: "lint.config.json", sourceMayReplaceExactFile: false }]
+        : []),
+      {
+        path: "node_modules/@ttsc/lint",
+        sourceMayReplaceExactFile: false,
+      },
+      ...options.linkedNodeModulePaths.map((relativePath) => ({
+        path: relativePath,
+        sourceMayReplaceExactFile: false,
+      })),
+    ];
+    if (options.extraSources === undefined) return [];
+    return (Object.entries(options.extraSources) as [string, string][]).map(
+      ([sourcePath, content]) => {
+        const normalized = resolveProjectSourcePath(
+          sourcePath,
+          "extraSources path",
+        );
+        assertCanonicalTypeScriptSourceExtension(
+          normalized,
+          "extraSources path",
+          sourcePath,
+        );
+        if (
+          normalized.toLowerCase().startsWith("src/") &&
+          !normalized.startsWith("src/")
+        ) {
+          throw new Error(
+            `TestLint extraSources path must spell the included source root as src/: ${sourcePath}`,
+          );
+        }
+        for (const previous of sources) {
+          assertFixtureTargetsDoNotCollide(previous, normalized, sourcePath);
+        }
+        for (const generated of generatedTargets) {
+          const generatedKey = portableFixturePathKey(generated.path);
+          const sourceKey = portableFixturePathKey(normalized);
+          if (
+            isStrictFixturePathAncestor(generatedKey, sourceKey) ||
+            isStrictFixturePathAncestor(sourceKey, generatedKey) ||
+            (generatedKey === sourceKey &&
+              (!generated.sourceMayReplaceExactFile ||
+                normalized !== generated.path))
+          ) {
+            throw new Error(
+              `TestLint fixture source path collides with generated target: ${sourcePath} and ${generated.path}`,
+            );
+          }
+        }
+        sources.push(normalized);
+        return [normalized, content];
+      },
+    );
+  }
+
+  function assertFixtureTargetsDoNotCollide(
+    previous: string,
+    normalized: string,
+    sourcePath: string,
+  ): void {
+    const previousKey = portableFixturePathKey(previous);
+    const sourceKey = portableFixturePathKey(normalized);
+    if (
+      previousKey === sourceKey ||
+      isStrictFixturePathAncestor(previousKey, sourceKey) ||
+      isStrictFixturePathAncestor(sourceKey, previousKey)
+    ) {
+      throw new Error(
+        `TestLint fixture source paths collide after portable normalization: ${previous} and ${sourcePath}`,
+      );
+    }
+  }
+
+  function isStrictFixturePathAncestor(parent: string, child: string): boolean {
+    return child.startsWith(`${parent}/`);
+  }
+
+  /** Normalize a writable fixture target to one project-relative POSIX path. */
+  function resolveProjectSourcePath(
+    sourcePath: string,
+    optionName: string,
+  ): string {
+    const portable = sourcePath.replaceAll("\\", "/");
+    const normalized = path.posix.normalize(portable);
+    const hasNonPortableWindowsSegment = portable
+      .split("/")
+      .some(
+        (segment) =>
+          segment !== "." &&
+          segment !== ".." &&
+          (/[<>:"|?*\u0000-\u001f]/.test(segment) ||
+            /[. ]$/.test(segment) ||
+            /^(?:con|prn|aux|nul|clock\$|conin\$|conout\$|com[1-9¹²³]|lpt[1-9¹²³])(?:\..*)?$/i.test(
+              segment,
+            )),
+      );
+    if (
+      sourcePath.trim().length === 0 ||
+      sourcePath.includes("\0") ||
+      hasNonPortableWindowsSegment ||
+      portable.endsWith("/") ||
+      path.posix.isAbsolute(portable) ||
+      path.win32.parse(sourcePath).root.length !== 0 ||
+      normalized === "." ||
+      normalized === ".." ||
+      normalized.startsWith("../")
+    ) {
+      throw new Error(
+        `TestLint ${optionName} must be a portable non-empty project-root-relative file path: ${sourcePath}`,
+      );
+    }
+    return normalized;
+  }
+
+  /** Match Windows path aliases even when the test suite runs on POSIX. */
+  function portableFixturePathKey(sourcePath: string): string {
+    return sourcePath.toLowerCase();
   }
 
   /** Whether a generated tsconfig includes this TSX source under `src/`. */
   function isIncludedTSXSourcePath(sourcePath: string): boolean {
-    const normalized = normalizeFixtureRelativePath(sourcePath);
     return (
-      normalized.startsWith("src/") &&
-      path.posix.extname(normalized).toLowerCase() === ".tsx"
+      sourcePath.startsWith("src/") &&
+      typescriptSourceExtension(sourcePath) === ".tsx"
     );
   }
 
   function assertDisposableProjectRoot(projectRoot: string): void {
     const tempRoot = path.resolve(os.tmpdir());
     const resolved = path.resolve(projectRoot);
-    const tempRoots = new Set([tempRoot, realpathIfPossible(tempRoot)]);
+    const canonicalTempRoot = realpathWithMissingSuffix(tempRoot);
+    const tempRoots = new Set([tempRoot, canonicalTempRoot]);
+    const canonicalResolved = realpathWithMissingSuffix(resolved);
+    let existingRoot: fs.Stats | undefined;
+    try {
+      existingRoot = fs.lstatSync(resolved);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
     if (
-      [...tempRoots].some(
-        (candidate) =>
-          isSameOrChildPath(candidate, resolved) ||
-          isSameOrChildPath(candidate, realpathIfPossible(resolved)),
-      )
+      [...tempRoots].some((candidate) =>
+        isStrictChildPath(candidate, resolved),
+      ) &&
+      isStrictChildPath(canonicalTempRoot, canonicalResolved) &&
+      (existingRoot === undefined ||
+        (existingRoot.isDirectory() && fs.readdirSync(resolved).length === 0))
     ) {
       return;
     }
     throw new Error(
-      `TestLint projectRoot must be a disposable directory under ${tempRoot}: ${projectRoot}`,
+      `TestLint projectRoot must be an empty disposable directory strictly under ${tempRoot}: ${projectRoot}`,
     );
   }
 
-  function isSameOrChildPath(parent: string, child: string): boolean {
+  function isStrictChildPath(parent: string, child: string): boolean {
     const relative = path.relative(parent, child);
-    if (
-      relative === "" ||
-      (!relative.startsWith("..") && !path.isAbsolute(relative))
-    ) {
-      return true;
-    }
-    return false;
+    return (
+      relative !== "" &&
+      relative !== ".." &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative)
+    );
   }
 
-  function realpathIfPossible(location: string): string {
-    try {
-      return fs.realpathSync(location);
-    } catch {
-      return location;
+  /** Canonicalize through the nearest existing ancestor without creating it. */
+  function realpathWithMissingSuffix(location: string): string {
+    let existing = location;
+    const missing: string[] = [];
+    while (!fs.existsSync(existing)) {
+      const parent = path.dirname(existing);
+      if (parent === existing) return location;
+      missing.unshift(path.basename(existing));
+      existing = parent;
     }
+    return path.resolve(fs.realpathSync(existing), ...missing);
+  }
+
+  function resolveLinkedNodeModules(
+    packageNames: readonly string[] | undefined,
+  ): { packageName: string; relativePath: string }[] {
+    return (packageNames ?? []).map((packageName) => {
+      const segments = packageName.split("/");
+      const [scopeOrName, scopedName] = segments;
+      const isPackageSegment = (segment: string): boolean =>
+        segment.length > 0 &&
+        !segment.startsWith(".") &&
+        !segment.startsWith("_") &&
+        /^[a-z0-9._~-]+$/.test(segment);
+      const valid =
+        packageName.length <= 214 &&
+        ((segments.length === 1 && isPackageSegment(scopeOrName ?? "")) ||
+          (segments.length === 2 &&
+            scopeOrName !== undefined &&
+            scopeOrName.startsWith("@") &&
+            isPackageSegment(scopeOrName.slice(1)) &&
+            isPackageSegment(scopedName ?? "")));
+      if (!valid) {
+        throw new Error(
+          `TestLint linkNodeModules entry must be an npm package name: ${packageName}`,
+        );
+      }
+      let relativePath: string;
+      try {
+        relativePath = resolveProjectSourcePath(
+          path.posix.join("node_modules", ...segments),
+          "linkNodeModules entry",
+        );
+      } catch {
+        throw new Error(
+          `TestLint linkNodeModules entry must be a portable npm package name: ${packageName}`,
+        );
+      }
+      return {
+        packageName,
+        relativePath,
+      };
+    });
   }
 
   /** Link the workspace @ttsc/lint package as if the fixture had installed it. */
@@ -397,7 +588,11 @@ export namespace TestLint {
   }
 
   /** Link optional runtime dependencies used by ESLint-backed config tests. */
-  function linkNodeModulePackage(tmpdir: string, packageName: string): void {
+  function linkNodeModulePackage(
+    tmpdir: string,
+    linkedNodeModule: { packageName: string; relativePath: string },
+  ): void {
+    const { packageName, relativePath } = linkedNodeModule;
     const packageJson = TestProject.REQUIRE_FROM_TEST.resolve(
       `${packageName}/package.json`,
       {
@@ -405,7 +600,7 @@ export namespace TestLint {
       },
     );
     const source = path.dirname(packageJson);
-    const target = path.join(tmpdir, "node_modules", ...packageName.split("/"));
+    const target = path.join(tmpdir, relativePath);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     try {
       fs.symlinkSync(source, target, "junction");
@@ -417,7 +612,43 @@ export namespace TestLint {
 
   const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
   const BANNER_PATTERN =
-    /(?:^|[\s/])([^\s:]+\.tsx?):(\d+):(\d+)\s+-\s+(error|warning)\s+TS\d+:\s*\[([^\]]+)\]\s*(.*)$/;
+    /^(.+):(\d+):(\d+)\s+-\s+(error|warning)\s+TS\d+:\s*\[([^\]]+)\]\s*(.*)$/;
+  const TYPESCRIPT_SOURCE_EXTENSION_PATTERN =
+    /(\.d\.mts|\.d\.cts|\.d\.ts|\.tsx|\.mts|\.cts|\.ts)$/;
+  const TYPESCRIPT_SOURCE_EXTENSION_CASE_INSENSITIVE_PATTERN =
+    /(\.d\.mts|\.d\.cts|\.d\.ts|\.tsx|\.mts|\.cts|\.ts)$/i;
+
+  /** Return the canonical supported TypeScript suffix for a source path. */
+  export function typescriptSourceExtension(sourcePath: string): string | null {
+    return sourcePath.match(TYPESCRIPT_SOURCE_EXTENSION_PATTERN)?.[1] ?? null;
+  }
+
+  /** Whether a path has one of the TypeScript source extensions we execute. */
+  export function isTypeScriptSourcePath(sourcePath: string): boolean {
+    return typescriptSourceExtension(sourcePath) !== null;
+  }
+
+  /** Whether a TypeScript-looking suffix differs from the compiler's casing. */
+  export function hasNonCanonicalTypeScriptSourceExtension(
+    sourcePath: string,
+  ): boolean {
+    return (
+      !isTypeScriptSourcePath(sourcePath) &&
+      TYPESCRIPT_SOURCE_EXTENSION_CASE_INSENSITIVE_PATTERN.test(sourcePath)
+    );
+  }
+
+  function assertCanonicalTypeScriptSourceExtension(
+    normalized: string,
+    optionName: string,
+    sourcePath: string,
+  ): void {
+    if (hasNonCanonicalTypeScriptSourceExtension(normalized)) {
+      throw new Error(
+        `TestLint ${optionName} must use a canonical lowercase TypeScript source extension: ${sourcePath}`,
+      );
+    }
+  }
 
   /**
    * Parse the renderer's stderr into structured records.
@@ -434,6 +665,7 @@ export namespace TestLint {
       const [, file, lineStr, columnStr, category, rule, message] = match;
       if (
         !file ||
+        !isTypeScriptSourcePath(file) ||
         !lineStr ||
         !columnStr ||
         !category ||
@@ -454,27 +686,23 @@ export namespace TestLint {
   }
 
   /**
-   * Read `// expect: <rule> <severity>` comments and return the line each one
-   * anchors to (the next non-comment, non-blank line after the annotation).
-   * Mirrors the ttsc plugin corpus expectation format.
+   * Read standalone line or JSX-block expectation comments and return the
+   * target line each one anchors to. Mirrors the ttsc plugin corpus expectation
+   * format.
    *
-   * Blank lines and stacked `// expect:` annotations between the marker and its
+   * Blank lines and stacked expectation annotations between the marker and its
    * target are skipped. A `@ts-expect-error` / `@ts-ignore` suppressor is also
-   * skipped unless the rule being tested is `ban-ts-comment` itself.
+   * skipped unless the rule being tested is `ban-ts-comment` itself. Malformed
+   * markers and markers without a following target fail immediately.
    */
   export function parseExpectations(source: string): ILintExpectation[] {
     const lines = source.split(/\r?\n/);
     const expected: ILintExpectation[] = [];
     for (let i = 0; i < lines.length; i++) {
-      const line = lines[i] ?? "";
-      const match = line.match(
-        /\/\/\s*expect:\s*([\w][\w/-]*)\s+(error|warn)\s*$/,
-      );
-      if (!match) continue;
-      const rule = match[1];
-      const severity = match[2] as LintSeverity | undefined;
-      if (!rule || !severity) continue;
-      // Skip blank lines and other `// expect:` annotations stacked
+      const marker = parseExpectationMarker(lines[i] ?? "", i + 1);
+      if (marker === null) continue;
+      const { rule, severity } = marker;
+      // Skip blank lines and other expectation annotations stacked
       // above the same target, but NOT regular comment lines — rules
       // like typescript/ban-ts-comment / typescript/triple-slash-reference
       // fire on a comment itself, and the convention is to put the
@@ -483,7 +711,7 @@ export namespace TestLint {
       while (
         target < lines.length &&
         (/^\s*$/.test(lines[target] ?? "") ||
-          /^\s*\/\/\s*expect:/.test(lines[target] ?? "") ||
+          parseExpectationMarker(lines[target] ?? "", target + 1) !== null ||
           (rule !== "typescript/ban-ts-comment" &&
             /^\s*\/\/\s*@ts-(?:expect-error|ignore)\b/.test(
               lines[target] ?? "",
@@ -491,16 +719,45 @@ export namespace TestLint {
       ) {
         target++;
       }
-      if (target < lines.length) {
-        expected.push({ rule, severity, line: target + 1 });
+      if (target >= lines.length) {
+        throw new Error(
+          `lint expectation at line ${i + 1} has no following target`,
+        );
       }
+      expected.push({ rule, severity, line: target + 1 });
     }
     return expected;
   }
 
+  function parseExpectationMarker(
+    line: string,
+    lineNumber: number,
+  ): { rule: string; severity: LintSeverity } | null {
+    const isLineMarker = /^\s*\/\/\s*expect\b/.test(line);
+    const isJsxMarker = /^\s*\{\s*\/\*\s*expect\b/.test(line);
+    if (!isLineMarker && !isJsxMarker) return null;
+
+    const match = isLineMarker
+      ? line.match(/^\s*\/\/\s*expect:\s*([\w][\w/-]*)\s+(error|warn)\s*$/)
+      : line.match(
+          /^\s*\{\s*\/\*\s*expect:\s*([\w][\w/-]*)\s+(error|warn)\s*\*\/\s*\}\s*$/,
+        );
+    if (!match?.[1] || !match[2]) {
+      throw new Error(
+        `malformed lint expectation at line ${lineNumber}; expected ` +
+          "`// expect: <rule> <error|warn>` or " +
+          "`{ /* expect: <rule> <error|warn> */ }`",
+      );
+    }
+    return {
+      rule: match[1],
+      severity: match[2] as LintSeverity,
+    };
+  }
+
   /**
    * Build a `rules` map for tsconfig from the expectations parsed out of a
-   * fixture file. Every rule that appears in `// expect:` annotations is
+   * fixture file. Every rule that appears in an expectation annotation is
    * enabled at its annotated severity; everything else is implicitly off (the
    * default for unconfigured rules).
    */


### PR DESCRIPTION
Implements the valid #623 reproduction by classifying every TypeScript corpus source as an executable case, an audited skip, or an explicit companion.

Development is still in progress on this draft. Independent exhaustive review is checking malformed expectation syntax, path collisions, companion ownership, and the stacked interaction with #615.

CI runs are intentionally cancelled during development. Full format and CI validation will be enabled only at the final completion gate.

Fixes #623
