### PR TITLE
fix(test): restore TSX lint corpus execution

### DIFF
--- a/packages/lint/linthost/rules_nextjs.go
+++ b/packages/lint/linthost/rules_nextjs.go
@@ -79,30 +79,119 @@ func nextjsInlineScriptID(ctx *Context, file *shimast.Node) {
 }
 
 func nextjsNextScriptForGA(ctx *Context, file *shimast.Node) {
-  imports := nextjsCollectImports(file)
-  if len(imports.scriptFromNextScript) == 0 {
-    return
-  }
-  walkDescendants(file, func(node *shimast.Node) {
-    if node.Kind != shimast.KindJsxElement && node.Kind != shimast.KindJsxSelfClosingElement {
-      return
-    }
-    opening := nextjsOpeningLike(node)
-    if !imports.scriptFromNextScript[nextjsJSXName(opening)] {
+  nextjsWalkOpeningLike(file, func(opening *shimast.Node) {
+    if nextjsJSXName(opening) != "script" {
       return
     }
     src := nextjsJSXAttrString(opening, "src")
-    if strings.Contains(src, "googletagmanager.com/gtag/js") || strings.Contains(src, "googletagmanager.com/gtm.js") {
+    if strings.Contains(src, "www.google-analytics.com/analytics.js") ||
+      strings.Contains(src, "www.googletagmanager.com/gtag/js") {
       ctx.Report(opening, "Use Next.js Google Analytics helpers instead of hand-written gtag scripts.")
       return
     }
-    if node.Kind == shimast.KindJsxElement {
-      text := nodeText(ctx.File, node)
-      if strings.Contains(text, "gtag(") || strings.Contains(text, "GTM-") {
-        ctx.Report(opening, "Use Next.js Google Analytics helpers instead of hand-written gtag scripts.")
-      }
+    inline := nextjsDangerouslySetInnerHTMLSource(opening)
+    if strings.Contains(inline, "www.google-analytics.com/analytics.js") ||
+      strings.Contains(inline, "www.googletagmanager.com/gtm.js") {
+      ctx.Report(opening, "Use Next.js Google Analytics helpers instead of hand-written gtag scripts.")
     }
   })
+}
+
+// nextjsDangerouslySetInnerHTMLSource returns the final static `__html`
+// payload from `dangerouslySetInnerHTML={{ __html: "..." }}`. Object-literal
+// properties are inspected from last to first so an earlier spread or dynamic
+// property cannot obscure a later static assignment, while any later write
+// that might replace `__html` keeps the payload unknown.
+func nextjsDangerouslySetInnerHTMLSource(opening *shimast.Node) string {
+  attrNode := nextjsJSXAttr(opening, "dangerouslySetInnerHTML")
+  if attrNode == nil {
+    return ""
+  }
+  attr := attrNode.AsJsxAttribute()
+  if attr == nil || attr.Initializer == nil || attr.Initializer.Kind != shimast.KindJsxExpression {
+    return ""
+  }
+  container := attr.Initializer.AsJsxExpression()
+  if container == nil {
+    return ""
+  }
+  expression := stripParens(container.Expression)
+  if expression == nil || expression.Kind != shimast.KindObjectLiteralExpression {
+    return ""
+  }
+  object := expression.AsObjectLiteralExpression()
+  if object == nil || object.Properties == nil {
+    return ""
+  }
+  properties := object.Properties.Nodes
+  for i := len(properties) - 1; i >= 0; i-- {
+    propertyNode := properties[i]
+    if propertyNode == nil {
+      return ""
+    }
+    if propertyNode.Kind == shimast.KindSpreadAssignment {
+      return ""
+    }
+
+    switch propertyNode.Kind {
+    case shimast.KindPropertyAssignment:
+      property := propertyNode.AsPropertyAssignment()
+      if property == nil {
+        return ""
+      }
+      name, known := nextjsStaticPropertyName(property.Name())
+      if !known {
+        return ""
+      }
+      if name == "__html" {
+        return stringLiteralText(stripParens(property.Initializer))
+      }
+    case shimast.KindShorthandPropertyAssignment,
+      shimast.KindMethodDeclaration,
+      shimast.KindGetAccessor,
+      shimast.KindSetAccessor:
+      name, known := nextjsStaticPropertyName(propertyNode.Name())
+      if !known {
+        return ""
+      }
+      if name == "__html" {
+        return ""
+      }
+    default:
+      return ""
+    }
+  }
+  return ""
+}
+
+func nextjsStaticPropertyName(node *shimast.Node) (string, bool) {
+  if node == nil {
+    return "", false
+  }
+  switch node.Kind {
+  case shimast.KindIdentifier:
+    return identifierText(node), true
+  case shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral:
+    return stringLiteralText(node), true
+  case shimast.KindNumericLiteral, shimast.KindBigIntLiteral:
+    return numericLiteralText(node), true
+  case shimast.KindComputedPropertyName:
+    computed := node.AsComputedPropertyName()
+    if computed == nil {
+      return "", false
+    }
+    expression := stripParens(computed.Expression)
+    if expression == nil {
+      return "", false
+    }
+    switch expression.Kind {
+    case shimast.KindStringLiteral, shimast.KindNoSubstitutionTemplateLiteral:
+      return stringLiteralText(expression), true
+    case shimast.KindNumericLiteral, shimast.KindBigIntLiteral:
+      return numericLiteralText(expression), true
+    }
+  }
+  return "", false
 }
 
 func nextjsNoAssignModuleVariable(ctx *Context, file *shimast.Node) {

--- a/packages/lint/linthost/rules_react_hooks.go
+++ b/packages/lint/linthost/rules_react_hooks.go
@@ -174,6 +174,9 @@ func (a *reactHooksAnalyzer) checkComponentHookFactories(root *shimast.Node) {
 
 func (a *reactHooksAnalyzer) checkSetStateInRender(root *shimast.Node) {
   walkDescendants(root, func(node *shimast.Node) {
+    if node == nil || node.Kind != shimast.KindCallExpression {
+      return
+    }
     call := node.AsCallExpression()
     if call == nil {
       return
@@ -192,6 +195,9 @@ func (a *reactHooksAnalyzer) checkSetStateInRender(root *shimast.Node) {
 
 func (a *reactHooksAnalyzer) checkSetStateInEffect(root *shimast.Node) {
   walkDescendants(root, func(node *shimast.Node) {
+    if node == nil || node.Kind != shimast.KindCallExpression {
+      return
+    }
     call := node.AsCallExpression()
     if call == nil {
       return
@@ -255,6 +261,9 @@ func (a *reactHooksAnalyzer) reportImmutableWrite(target *shimast.Node, reportNo
 
 func (a *reactHooksAnalyzer) checkRefs(root *shimast.Node) {
   walkDescendants(root, func(node *shimast.Node) {
+    if node == nil || node.Kind != shimast.KindPropertyAccessExpression {
+      return
+    }
     access := node.AsPropertyAccessExpression()
     if access == nil || identifierText(access.Name()) != "current" {
       return
@@ -279,6 +288,9 @@ func (a *reactHooksAnalyzer) collectFunctionBindings(fn *reactHooksFunction) {
   }
   walkDescendants(fn.body, func(node *shimast.Node) {
     if a.nearestFunction(node) != fn {
+      return
+    }
+    if node == nil || node.Kind != shimast.KindVariableDeclaration {
       return
     }
     decl := node.AsVariableDeclaration()
@@ -487,7 +499,11 @@ func isNamedReactCallee(node *shimast.Node, name string) bool {
 }
 
 func isNamedReactCalleeFromCall(node *shimast.Node, name string) bool {
-  call := stripParens(node).AsCallExpression()
+  node = stripParens(node)
+  if node == nil || node.Kind != shimast.KindCallExpression {
+    return false
+  }
+  call := node.AsCallExpression()
   return call != nil && isNamedReactCallee(call.Expression, name)
 }
 
@@ -563,7 +579,7 @@ func statementContainsOwnReturn(stmt *shimast.Node, fnNode *shimast.Node) bool {
 func functionContainsReactHookCall(node *shimast.Node) bool {
   found := false
   walkDescendants(reactFunctionBody(node), func(child *shimast.Node) {
-    if found || child == node {
+    if found || child == nil || child == node || child.Kind != shimast.KindCallExpression {
       return
     }
     call := child.AsCallExpression()

--- a/packages/lint/linthost/rules_solid.go
+++ b/packages/lint/linthost/rules_solid.go
@@ -188,7 +188,7 @@ func (s *solidState) collectVariable(node *shimast.Node) {
   }
   collectSolidBindingNames(decl.Name(), s.declared)
   init := stripParens(decl.Initializer)
-  if init == nil {
+  if init == nil || init.Kind != shimast.KindCallExpression {
     return
   }
   initCall := init.AsCallExpression()
@@ -203,7 +203,11 @@ func (s *solidState) collectVariable(node *shimast.Node) {
   if binding == nil || binding.Elements == nil || len(binding.Elements.Nodes) == 0 {
     return
   }
-  first := binding.Elements.Nodes[0].AsBindingElement()
+  firstNode := binding.Elements.Nodes[0]
+  if firstNode == nil || firstNode.Kind != shimast.KindBindingElement {
+    return
+  }
+  first := firstNode.AsBindingElement()
   if first == nil {
     return
   }
@@ -461,7 +465,7 @@ func (s *solidState) reportPreferClassList(ctx *Context) {
       continue
     }
     expr := solidJSXAttrExpression(attr)
-    if expr == nil {
+    if expr == nil || expr.Kind != shimast.KindCallExpression {
       continue
     }
     call := expr.AsCallExpression()
@@ -562,6 +566,9 @@ func (s *solidState) reportStyleProp(ctx *Context) {
       continue
     }
     for _, propNode := range obj.Properties.Nodes {
+      if propNode == nil || propNode.Kind != shimast.KindPropertyAssignment {
+        continue
+      }
       prop := propNode.AsPropertyAssignment()
       if prop == nil {
         continue
@@ -728,6 +735,9 @@ func collectSolidBindingNames(node *shimast.Node, out map[string]bool) {
       return
     }
     for _, elementNode := range pattern.Elements.Nodes {
+      if elementNode == nil || elementNode.Kind != shimast.KindBindingElement {
+        continue
+      }
       el := elementNode.AsBindingElement()
       if el != nil {
         collectSolidBindingNames(el.Name(), out)

--- a/packages/lint/test/rules/nextjs/next_script_for_ga_reports_analytics_src_test.go
+++ b/packages/lint/test/rules/nextjs/next_script_for_ga_reports_analytics_src_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestNextjsNextScriptForGAReportsAnalyticsSrc verifies static analytics.js sources are reported.
+//
+// Google Analytics' legacy loader is a separate static URL branch from the
+// Google Tag Manager gtag loader. An unrelated native script is the negative
+// twin so substring matching cannot classify every external script as GA.
+//
+//  1. Render native scripts for analytics.js and an unrelated dependency.
+//  2. Enable `nextjs/next-script-for-ga` through the corpus helper.
+//  3. Assert only the analytics.js opening reports.
+func TestNextjsNextScriptForGAReportsAnalyticsSrc(t *testing.T) {
+  assertRuleCorpusCaseTSX(t, "pages/index.tsx", `
+export default function Page() {
+  return (
+    <>
+      // expect: nextjs/next-script-for-ga error
+      <script src="https://www.google-analytics.com/analytics.js" />
+      <script src="https://cdn.example.com/application.js" />
+    </>
+  );
+}
+`)
+}

--- a/packages/lint/test/rules/nextjs/next_script_for_ga_reports_gtag_src_test.go
+++ b/packages/lint/test/rules/nextjs/next_script_for_ga_reports_gtag_src_test.go
@@ -4,12 +4,13 @@ import "testing"
 
 // TestNextjsNextScriptForGAReportsGtagSrc verifies handwritten GA scripts are reported.
 //
-// The implementation only needs static `next/script` src values; this keeps the
-// rule independent from Next.js runtime packages.
+// The upstream rule owns native `script` tags. A component imported from
+// `next/script` may carry the same URL but is not the hand-written HTML shape,
+// so it is the adjacent negative that prevents an over-match by tag text.
 //
-// 1. Import Script from `next/script`.
-// 2. Render a Google Tag Manager gtag URL.
-// 3. Assert `nextjs/next-script-for-ga` reports the Script element.
+//  1. Render a native script with a static Google Tag Manager gtag URL.
+//  2. Render the same URL through the imported `next/script` component.
+//  3. Assert only the native script reports.
 func TestNextjsNextScriptForGAReportsGtagSrc(t *testing.T) {
   assertRuleCorpusCaseTSX(t, "pages/index.tsx", `
 import Script from "next/script";
@@ -18,6 +19,7 @@ export default function Page() {
   return (
     <>
       // expect: nextjs/next-script-for-ga error
+      <script src="https://www.googletagmanager.com/gtag/js?id=G-1" />
       <Script src="https://www.googletagmanager.com/gtag/js?id=G-1" />
     </>
   );

--- a/packages/lint/test/rules/nextjs/next_script_for_ga_reports_inline_analytics_test.go
+++ b/packages/lint/test/rules/nextjs/next_script_for_ga_reports_inline_analytics_test.go
@@ -1,0 +1,42 @@
+package linthost
+
+import "testing"
+
+// TestNextjsNextScriptForGAReportsInlineAnalytics verifies static inline analytics.js payloads are reported.
+//
+// Inline detection reads only the final statically known
+// `dangerouslySetInnerHTML.__html` value. Positive and negative twins cover
+// the last-write behavior of spreads, computed keys, and duplicate keys.
+//
+//  1. Render native scripts with literal and dynamic object writes.
+//  2. Put a known static `__html` both before and after unknown writes.
+//  3. Assert only payloads whose final value is statically known report.
+func TestNextjsNextScriptForGAReportsInlineAnalytics(t *testing.T) {
+  assertRuleCorpusCaseTSX(t, "pages/index.tsx", `
+const analytics = "https://www.google-analytics.com/analytics.js";
+const overrides = { __html: analytics };
+const htmlKey = "__html";
+
+export default function Page() {
+  return (
+    <>
+      // expect: nextjs/next-script-for-ga error
+      <script dangerouslySetInnerHTML={{ __html: "https://www.google-analytics.com/analytics.js" }} />
+      <script dangerouslySetInnerHTML={{ __html: analytics }} />
+
+      // expect: nextjs/next-script-for-ga error
+      <script dangerouslySetInnerHTML={{ ...overrides, __html: "https://www.google-analytics.com/analytics.js" }} />
+      <script dangerouslySetInnerHTML={{ __html: "https://www.google-analytics.com/analytics.js", ...overrides }} />
+
+      // expect: nextjs/next-script-for-ga error
+      <script dangerouslySetInnerHTML={{ [htmlKey]: analytics, __html: "https://www.google-analytics.com/analytics.js" }} />
+      <script dangerouslySetInnerHTML={{ __html: "https://www.google-analytics.com/analytics.js", [htmlKey]: analytics }} />
+
+      // expect: nextjs/next-script-for-ga error
+      <script dangerouslySetInnerHTML={{ __html: analytics, __html: "https://www.google-analytics.com/analytics.js" }} />
+      <script dangerouslySetInnerHTML={{ __html: "https://www.google-analytics.com/analytics.js", __html: analytics }} />
+    </>
+  );
+}
+`)
+}

--- a/packages/lint/test/rules/nextjs/next_script_for_ga_reports_inline_tag_manager_test.go
+++ b/packages/lint/test/rules/nextjs/next_script_for_ga_reports_inline_tag_manager_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestNextjsNextScriptForGAReportsInlineTagManager verifies static inline GTM payloads are reported.
+//
+// Google Tag Manager's inline loader uses gtm.js rather than the gtag/js URL
+// used by the static `src` branch. A static non-GTM template literal is the
+// negative twin for exact host/path matching.
+//
+//  1. Render native scripts with static template-literal `__html` payloads.
+//  2. Use gtm.js in one payload and an unrelated loader in the other.
+//  3. Assert only the GTM payload reports.
+func TestNextjsNextScriptForGAReportsInlineTagManager(t *testing.T) {
+  assertRuleCorpusCaseTSX(t, "pages/index.tsx", `
+export default function Page() {
+  return (
+    <>
+      // expect: nextjs/next-script-for-ga error
+      <script dangerouslySetInnerHTML={{ __html: `+"`https://www.googletagmanager.com/gtm.js?id=GTM-1`"+` }} />
+      <script dangerouslySetInnerHTML={{ __html: `+"`https://cdn.example.com/loader.js`"+` }} />
+    </>
+  );
+}
+`)
+}

--- a/packages/lint/test/rules/nextjs/no_page_custom_font_reports_page_font_link_test.go
+++ b/packages/lint/test/rules/nextjs/no_page_custom_font_reports_page_font_link_test.go
@@ -1,15 +1,19 @@
 package linthost
 
-import "testing"
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
 
 // TestNextjsNoPageCustomFontReportsPageFontLink verifies page-level Google font links are rejected.
 //
-// Custom font links should live in pages/_document. The test uses a regular
-// pages file to pin the diagnostic path.
+// Custom font links should live in pages/_document. The positive and negative
+// use the same link so only the logical filename can change the result.
 //
-// 1. Parse a regular pages TSX file.
-// 2. Render a Google Fonts stylesheet link.
-// 3. Assert `nextjs/no-page-custom-font` reports it.
+//  1. Parse a regular page and pages/_document with the same font link.
+//  2. Assert `nextjs/no-page-custom-font` reports the regular page.
+//  3. Dispatch the rule for _document and assert it produces no finding.
 func TestNextjsNoPageCustomFontReportsPageFontLink(t *testing.T) {
   assertRuleCorpusCaseTSX(t, "pages/index.tsx", `
 export default function Page() {
@@ -21,4 +25,16 @@ export default function Page() {
   );
 }
 `)
+
+  document := parseTSXFile(t, "/virtual/pages/_document.tsx", `
+export default function Document() {
+  return <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap" />;
+}
+`)
+  findings := NewEngine(RuleConfig{
+    "nextjs/no-page-custom-font": SeverityError,
+  }).Run([]*shimast.SourceFile{document}, nil)
+  if len(findings) != 0 {
+    t.Fatalf("pages/_document.tsx should allow the shared font link, got %+v", findings)
+  }
 }

--- a/packages/lint/test/rules/react/react_source_file_rules_handle_tsx_descendants_test.go
+++ b/packages/lint/test/rules/react/react_source_file_rules_handle_tsx_descendants_test.go
@@ -1,0 +1,63 @@
+package linthost
+
+import (
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// TestReactSourceFileRulesHandleTSXDescendants verifies compiler-era React rules traverse mixed TSX nodes safely.
+//
+// Source-file rules share one analyzer that visits every descendant. TSX adds
+// specialized node payloads that cannot be converted with an unchecked `As*`
+// accessor, so collectors must filter by Kind before reading typed payloads.
+//
+//  1. Parse a component mixing state, refs, nested Hooks, and JSX initializers.
+//  2. Enable every React rule that uses the shared source-file analyzer.
+//  3. Assert each intended violation is reported at its own node, never as a panic diagnostic.
+func TestReactSourceFileRulesHandleTSXDescendants(t *testing.T) {
+  source := `
+function Component(props: { value: { count: number } }) {
+  const [value, setValue] = useState(0);
+  const ref = useRef(0);
+  const view = <div>{value}</div>;
+  props.value.count = 1;
+  const current = ref.current;
+  setValue(1);
+  useEffect(() => {
+    setValue(2);
+  }, []);
+  function useNested() {
+    useState(1);
+    return null;
+  }
+  return <section>{view}{current}{useNested()}</section>;
+}
+`
+  file := parseTSXFile(t, "/virtual/react-source-file-rules.tsx", source)
+  findings := NewEngine(RuleConfig{
+    "react/component-hook-factories": SeverityError,
+    "react/immutability":             SeverityError,
+    "react/refs":                     SeverityError,
+    "react/set-state-in-effect":      SeverityError,
+    "react/set-state-in-render":      SeverityError,
+  }).Run([]*shimast.SourceFile{file}, nil)
+
+  actual := normalizeRuleFindings(file, findings)
+  expected := []ruleExpectation{
+    {Rule: "react/immutability", Severity: SeverityError, Line: 6},
+    {Rule: "react/refs", Severity: SeverityError, Line: 7},
+    {Rule: "react/set-state-in-render", Severity: SeverityError, Line: 8},
+    {Rule: "react/set-state-in-effect", Severity: SeverityError, Line: 10},
+    {Rule: "react/component-hook-factories", Severity: SeverityError, Line: 12},
+  }
+  if len(actual) != len(expected) {
+    t.Fatalf("want %v, got %v", expected, actual)
+  }
+  for i := range expected {
+    if actual[i] != expected[i] {
+      t.Fatalf("[%d]: want %+v, got %+v; all findings=%+v", i, expected[i], actual[i], actual)
+    }
+  }
+  recordExpectedBehavioralWitnesses(t, expected, behavioralWitnessEngine)
+}

--- a/packages/lint/test/rules/solid/solid_rendering_style_preferences_test.go
+++ b/packages/lint/test/rules/solid/solid_rendering_style_preferences_test.go
@@ -39,10 +39,10 @@ function Icon() {
     "solid/self-closing-comp": SeverityError,
     "solid/style-prop":        SeverityError,
   }, []ruleExpectation{
-    {Rule: "solid/prefer-classlist", Severity: SeverityError, Line: 1},
-    {Rule: "solid/prefer-for", Severity: SeverityError, Line: 1},
-    {Rule: "solid/prefer-show", Severity: SeverityError, Line: 1},
-    {Rule: "solid/self-closing-comp", Severity: SeverityError, Line: 1},
-    {Rule: "solid/style-prop", Severity: SeverityError, Line: 1},
+    {Rule: "solid/prefer-for", Severity: SeverityError, Line: 8},
+    {Rule: "solid/prefer-show", Severity: SeverityError, Line: 9},
+    {Rule: "solid/prefer-classlist", Severity: SeverityError, Line: 10},
+    {Rule: "solid/style-prop", Severity: SeverityError, Line: 11},
+    {Rule: "solid/self-closing-comp", Severity: SeverityError, Line: 12},
   })
 }

--- a/packages/lint/test/rules/solid/solid_source_file_rules_handle_jsx_initializers_test.go
+++ b/packages/lint/test/rules/solid/solid_source_file_rules_handle_jsx_initializers_test.go
@@ -1,0 +1,42 @@
+package linthost
+
+import "testing"
+
+// TestSolidSourceFileRulesHandleJSXInitializers verifies Solid collection narrows mixed initializer and attribute nodes.
+//
+// Every Solid rule shares one source-file collector. JSX-valued variables and
+// non-call class expressions, object spreads, and shorthand properties carry
+// typed payloads that are not the nodes the rules otherwise expect.
+// TypeScript-Go represents the first hole in `const [, setter]` as an
+// OmittedExpression rather than a BindingElement, so every access must narrow
+// its node first.
+//
+//  1. Parse a Solid fixture with mixed binding, initializer, class, and style nodes.
+//  2. Enable the list, class, and style preference rules.
+//  3. Assert only the valid positives report and no panic diagnostic replaces them.
+func TestSolidSourceFileRulesHandleJSXInitializers(t *testing.T) {
+  source := `
+import { createSignal } from "solid-js";
+const [items] = createSignal([1]);
+const [, setItems] = createSignal([1]);
+const shared = {}, color = "red";
+const tree = (
+  <section>
+    {items().map((item) => <span>{item}</span>)}
+    <div class={clsx({ active: true })} />
+    <div class={{ active: true }} />
+    <div style={{ ...shared, color, fontSize: "12px" }} />
+  </section>
+);
+void setItems;
+`
+  assertSolidFindings(t, source, RuleConfig{
+    "solid/prefer-classlist": SeverityError,
+    "solid/prefer-for":       SeverityError,
+    "solid/style-prop":       SeverityError,
+  }, []ruleExpectation{
+    {Rule: "solid/prefer-for", Severity: SeverityError, Line: 8},
+    {Rule: "solid/prefer-classlist", Severity: SeverityError, Line: 9},
+    {Rule: "solid/style-prop", Severity: SeverityError, Line: 11},
+  })
+}

--- a/tests/test-lint/src/cases/nextjs-google-font-display.tsx
+++ b/tests/test-lint/src/cases/nextjs-google-font-display.tsx
@@ -1,6 +1,6 @@
 // Positive: Google Fonts `<link>` without a `font-display` parameter.
-// expect: nextjs/google-font-display error
 const a = (
+  // expect: nextjs/google-font-display error
   <link
     rel="stylesheet"
     href="https://fonts.googleapis.com/css2?family=Inter"

--- a/tests/test-lint/src/cases/nextjs-next-script-for-ga.tsx
+++ b/tests/test-lint/src/cases/nextjs-next-script-for-ga.tsx
@@ -1,13 +1,19 @@
+import Script from "next/script";
+
 // Positive: hand-written Google Analytics `<script>` tag.
-// expect: nextjs/next-script-for-ga error
 const a = (
+  // expect: nextjs/next-script-for-ga error
   <script
     async
     src="https://www.googletagmanager.com/gtag/js?id=GA_TRACKING_ID"
   />
 );
 
-// Negative: same effect achieved through `next/script` GA helper.
-const b = null;
+// Negative: the imported `next/script` component is not a native script tag.
+const b = (
+  <Script
+    src="https://www.googletagmanager.com/gtag/js?id=GA_TRACKING_ID"
+  />
+);
 
 JSON.stringify({ a, b });

--- a/tests/test-lint/src/cases/nextjs-no-async-client-component.tsx
+++ b/tests/test-lint/src/cases/nextjs-no-async-client-component.tsx
@@ -2,7 +2,7 @@
 
 // Positive: `async` body on a React Client Component.
 // expect: nextjs/no-async-client-component error
-export async function Page() {
+export default async function Page() {
   return <div>hi</div>;
 }
 

--- a/tests/test-lint/src/cases/nextjs-no-document-import-in-page.tsx
+++ b/tests/test-lint/src/cases/nextjs-no-document-import-in-page.tsx
@@ -1,3 +1,4 @@
+// @ttsc-corpus-filename: src/pages/index.tsx
 // Positive: importing `next/document` from a regular page file.
 // expect: nextjs/no-document-import-in-page error
 import Document from "next/document";

--- a/tests/test-lint/src/cases/nextjs-no-head-import-in-document.tsx
+++ b/tests/test-lint/src/cases/nextjs-no-head-import-in-document.tsx
@@ -1,3 +1,4 @@
+// @ttsc-corpus-filename: src/pages/_document.tsx
 // Positive: `next/head` import inside `pages/_document.tsx`.
 // expect: nextjs/no-head-import-in-document error
 import Head from "next/head";

--- a/tests/test-lint/src/cases/nextjs-no-page-custom-font.tsx
+++ b/tests/test-lint/src/cases/nextjs-no-page-custom-font.tsx
@@ -1,6 +1,7 @@
+// @ttsc-corpus-filename: src/pages/index.tsx
 // Positive: Google Fonts `<link>` inside a regular pages file.
-// expect: nextjs/no-page-custom-font error
 const a = (
+  // expect: nextjs/no-page-custom-font error
   <link
     rel="stylesheet"
     href="https://fonts.googleapis.com/css2?family=Inter&display=swap"

--- a/tests/test-lint/src/cases/react-exhaustive-deps.tsx
+++ b/tests/test-lint/src/cases/react-exhaustive-deps.tsx
@@ -2,9 +2,9 @@ declare function useEffect(effect: () => void, deps: ReadonlyArray<unknown>): vo
 
 function Component(props: { value: number }) {
   // Positive: deps array omits `props.value`.
-  // expect: react/exhaustive-deps error
   useEffect(() => {
     JSON.stringify(props.value);
+    // expect: react/exhaustive-deps error
   }, []);
 
   // Negative: deps array lists every reactive identifier.

--- a/tests/test-lint/src/cases/react-jsx-key.tsx
+++ b/tests/test-lint/src/cases/react-jsx-key.tsx
@@ -2,6 +2,7 @@ const items = [1, 2, 3];
 
 // Positive: array literal of JSX without keys.
 // expect: react/jsx-key error
+// expect: react/jsx-key error
 const a = [<span>one</span>, <span>two</span>];
 
 // Positive: `.map()` callback returning JSX without `key`.

--- a/tests/test-lint/src/cases/react-jsx-no-undef.tsx
+++ b/tests/test-lint/src/cases/react-jsx-no-undef.tsx
@@ -5,8 +5,8 @@ declare const Declared: () => JSX.Element;
 const a = <Missing />;
 
 // Positive: capitalized tag inside a paired element, still undeclared.
-// expect: react/jsx-no-undef error
 const b = (
+  // expect: react/jsx-no-undef error
   <AlsoMissing>
     text
   </AlsoMissing>

--- a/tests/test-lint/src/cases/react-no-danger-with-children.tsx
+++ b/tests/test-lint/src/cases/react-no-danger-with-children.tsx
@@ -1,8 +1,8 @@
 declare const html: string;
 
 // Positive: `dangerouslySetInnerHTML` combined with children content.
-// expect: react/no-danger-with-children error
 const a = (
+  // expect: react/no-danger-with-children error
   <div dangerouslySetInnerHTML={{ __html: html }}>extra</div>
 );
 

--- a/tests/test-lint/src/cases/react-only-export-components.tsx
+++ b/tests/test-lint/src/cases/react-only-export-components.tsx
@@ -1,7 +1,7 @@
 // Positive: a module that exports both a component and a non-component.
+// expect: react/only-export-components error
 export const helper = 1;
 
-// expect: react/only-export-components error
 export function Widget() {
   return <div>hi</div>;
 }

--- a/tests/test-lint/src/cases/solid-no-react-specific-props.tsx
+++ b/tests/test-lint/src/cases/solid-no-react-specific-props.tsx
@@ -13,6 +13,8 @@ import { createSignal } from "solid-js";
 createSignal(0);
 
 // expect: solid/no-react-specific-props error
+// expect: solid/no-react-specific-props error
+// expect: solid/no-react-specific-props error
 const tree = <label className="primary" htmlFor="field" key="save" />;
 
 JSON.stringify({ tree });

--- a/tests/test-lint/src/cases/solid-reactivity.tsx
+++ b/tests/test-lint/src/cases/solid-reactivity.tsx
@@ -12,7 +12,7 @@ import { createEffect, createSignal } from "solid-js";
 
 function App() {
   const [count] = createSignal(0);
-  createEffect(async () => count());
+  createEffect(() => count());
   // expect: solid/reactivity error
   return <span>{count}</span>;
 }

--- a/tests/test-lint/src/features/harness/test_lint_corpus_source_paths_preserve_tsx_and_select_jsx_mode.ts
+++ b/tests/test-lint/src/features/harness/test_lint_corpus_source_paths_preserve_tsx_and_select_jsx_mode.ts
@@ -1,0 +1,139 @@
+import { TestLint } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { resolveCorpusSourcePath } from "../../helpers/assertLintCase";
+
+/**
+ * Verifies lint corpus source paths preserve TSX and select JSX mode only for
+ * TSX.
+ *
+ * Pins the corpus-to-project boundary that previously wrote every fixture as
+ * `src/main.ts`. A TSX fixture must retain its extension and enable JSX
+ * parsing. Multi-file projects make the same decision across every source
+ * included under `src/`, independent of the caller's path separators, while
+ * TS-only and out-of-include files keep the original non-JSX project shape.
+ *
+ * 1. Resolve default TS and TSX corpus paths and an explicit filename override.
+ * 2. Materialize default, TS-only companion, and POSIX/Windows TSX companion
+ *    projects.
+ * 3. Assert only projects with an included TSX source select React JSX mode.
+ */
+export const test_lint_corpus_source_paths_preserve_tsx_and_select_jsx_mode =
+  (): void => {
+    const tsSourcePath = resolveCorpusSourcePath("", "no-console.ts");
+    const tsxSourcePath = resolveCorpusSourcePath("", "react/jsx-key.tsx");
+    assert.equal(tsSourcePath, "src/main.ts");
+    assert.equal(tsxSourcePath, "src/main.tsx");
+    assert.equal(
+      resolveCorpusSourcePath(
+        "// @ttsc-corpus-filename: src/components/Named.tsx\n",
+        "react/jsx-key.tsx",
+      ),
+      "src/components/Named.tsx",
+    );
+
+    const projects: TestLint.IRunLintProject[] = [];
+    try {
+      const tsProject = TestLint.createProject({
+        name: "corpus-default-ts",
+        source: "export const value = 1;\n",
+        sourcePath: tsSourcePath,
+      });
+      projects.push(tsProject);
+      const tsxProject = TestLint.createProject({
+        name: "corpus-default-tsx",
+        source: "export const value = <div />;\n",
+        sourcePath: tsxSourcePath,
+      });
+      projects.push(tsxProject);
+      const tsCompanionProject = TestLint.createProject({
+        name: "corpus-ts-companion",
+        source: "export const value = 1;\n",
+        sourcePath: tsSourcePath,
+        extraSources: {
+          "src/companion.ts": "export const companion = 2;\n",
+          "outside.tsx": "export const excluded = <div />;\n",
+        },
+      });
+      projects.push(tsCompanionProject);
+      const posixTSXCompanionProject = TestLint.createProject({
+        name: "corpus-posix-tsx-companion",
+        source: "export const value = 1;\n",
+        sourcePath: tsSourcePath,
+        extraSources: {
+          "src/companion.tsx": "export const companion = <div />;\n",
+        },
+      });
+      projects.push(posixTSXCompanionProject);
+      const windowsTSXCompanionProject = TestLint.createProject({
+        name: "corpus-windows-tsx-companion",
+        source: "export const value = 1;\n",
+        sourcePath: tsSourcePath,
+        extraSources: {
+          "src\\nested\\companion.tsx": "export const companion = <div />;\n",
+        },
+      });
+      projects.push(windowsTSXCompanionProject);
+
+      assert.equal(
+        fs.existsSync(path.join(tsProject.tmpdir, "src/main.ts")),
+        true,
+      );
+      assert.equal(
+        fs.existsSync(path.join(tsProject.tmpdir, "src/main.tsx")),
+        false,
+      );
+      assert.equal(readCompilerOptions(tsProject.tmpdir).jsx, undefined);
+
+      assert.equal(
+        fs.existsSync(path.join(tsxProject.tmpdir, "src/main.tsx")),
+        true,
+      );
+      assert.equal(
+        fs.existsSync(path.join(tsxProject.tmpdir, "src/main.ts")),
+        false,
+      );
+      assert.equal(readCompilerOptions(tsxProject.tmpdir).jsx, "react-jsx");
+
+      assert.equal(
+        fs.existsSync(path.join(tsCompanionProject.tmpdir, "src/companion.ts")),
+        true,
+      );
+      assert.equal(
+        readCompilerOptions(tsCompanionProject.tmpdir).jsx,
+        undefined,
+      );
+      assert.equal(
+        readCompilerOptions(posixTSXCompanionProject.tmpdir).jsx,
+        "react-jsx",
+      );
+      assert.equal(
+        fs.existsSync(
+          path.join(
+            windowsTSXCompanionProject.tmpdir,
+            "src/nested/companion.tsx",
+          ),
+        ),
+        true,
+      );
+      assert.equal(
+        readCompilerOptions(windowsTSXCompanionProject.tmpdir).jsx,
+        "react-jsx",
+      );
+    } finally {
+      for (const project of projects.reverse()) project.cleanup();
+    }
+  };
+
+function readCompilerOptions(tmpdir: string): Record<string, unknown> {
+  const config: unknown = JSON.parse(
+    fs.readFileSync(path.join(tmpdir, "tsconfig.json"), "utf8"),
+  );
+  assert.ok(typeof config === "object" && config !== null);
+  const compilerOptions = (config as { compilerOptions?: unknown })
+    .compilerOptions;
+  assert.ok(typeof compilerOptions === "object" && compilerOptions !== null);
+  return compilerOptions as Record<string, unknown>;
+}

--- a/tests/test-lint/src/features/harness/test_lint_diagnostic_parser_accepts_tsx_source_paths.ts
+++ b/tests/test-lint/src/features/harness/test_lint_diagnostic_parser_accepts_tsx_source_paths.ts
@@ -1,0 +1,41 @@
+import { TestLint } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies the lint diagnostic parser accepts both TSX and TS source paths.
+ *
+ * Preserving a corpus fixture as `src/main.tsx` also changes the filename in
+ * rendered diagnostics. The parser must retain TSX lint records without
+ * regressing the original TS path or accepting unrelated JavaScript output.
+ *
+ * 1. Render adjacent TSX, TS, and JavaScript diagnostic lines.
+ * 2. Parse the combined stderr stream.
+ * 3. Assert both TypeScript records survive and the JavaScript line is ignored.
+ */
+export const test_lint_diagnostic_parser_accepts_tsx_source_paths =
+  (): void => {
+    const stderr = [
+      "src/main.tsx:6:12 - error TS9001: [react/jsx-key] Missing key.",
+      "src/main.ts:2:3 - warning TS9002: [no-console] Unexpected console.",
+      "src/main.js:1:1 - error TS9003: [no-debugger] Unexpected debugger.",
+    ].join("\n");
+
+    assert.deepEqual(TestLint.parseDiagnostics(stderr), [
+      {
+        file: "src/main.tsx",
+        line: 6,
+        column: 12,
+        severity: "error",
+        rule: "react/jsx-key",
+        message: "Missing key.",
+      },
+      {
+        file: "src/main.ts",
+        line: 2,
+        column: 3,
+        severity: "warn",
+        rule: "no-console",
+        message: "Unexpected console.",
+      },
+    ]);
+  };

--- a/tests/test-lint/src/helpers/assertLintCase.ts
+++ b/tests/test-lint/src/helpers/assertLintCase.ts
@@ -49,9 +49,9 @@ const corpusSkipManifest = loadCorpusSkipManifest();
  * expectation or corpus-skip directive and delegates to `assertLintCase` for
  * each. Fails immediately if the corpus is empty.
  *
- * A fixture may opt out with one
- * `// @ttsc-corpus-skip(<constraint>): <reason>` directive. Its rule,
- * constraint, and Go harness must match the mechanically audited manifest.
+ * A fixture may opt out with one `// @ttsc-corpus-skip(<constraint>): <reason>`
+ * directive. Its rule, constraint, and Go harness must match the mechanically
+ * audited manifest.
  *
  * The corpus is the single heaviest lint scenario, so CI runs it as a handful
  * of parallel partitions: pass `{ index, total }` and this asserts only the `i
@@ -92,9 +92,10 @@ export function assertAllLintCases(partition?: {
  *
  * Honors the `// @ttsc-corpus-filename: <path>` directive: the fixture is
  * materialized at the given project-root-relative path (under `src/`) instead
- * of the default `src/main.ts`, so path-sensitive rules (filename
- * conventions, directory layouts) can carry their logical filename while the
- * on-disk fixture keeps a corpus-friendly name.
+ * of the extension-preserving default (`src/main.ts` or `src/main.tsx`), so
+ * path-sensitive rules (filename conventions, directory layouts) can carry
+ * their logical filename while the on-disk fixture keeps a corpus-friendly
+ * name.
  *
  * @param relativeFile - File path relative to `casesRoot` (forward-slash
  *   separated, e.g. `"consistentTypeImports/violation.ts"`).
@@ -110,7 +111,7 @@ export function assertLintCase(relativeFile: string): void {
   const result = TestLint.run({
     name: relativeFile,
     source,
-    sourcePath: parseCorpusFilename(source, relativeFile),
+    sourcePath: resolveCorpusSourcePath(source, relativeFile),
     rules: applyCorpusOptions(
       relativeFile,
       source,
@@ -362,28 +363,29 @@ function parseCorpusSkip(
 }
 
 /**
- * Read the first `// @ttsc-corpus-filename: <path>` directive from the
- * source, if any. Returns the project-root-relative path the fixture should
- * be materialized at, or `undefined` to use the harness default
- * (`src/main.ts`). Path validation (must stay under `src/`) is owned by
+ * Resolve the project-root-relative path at which a corpus fixture is
+ * materialized. An explicit `// @ttsc-corpus-filename: <path>` directive wins;
+ * otherwise the fixture's TypeScript extension is preserved under `src/` so TSX
+ * is parsed as TSX. Path validation (must stay under `src/`) is owned by
  * `TestLint`.
  */
-function parseCorpusFilename(
+export function resolveCorpusSourcePath(
   source: string,
   relativeFile: string,
-): string | undefined {
+): string {
   for (const line of source.split(/\r?\n/)) {
     const match = line.match(/^\s*\/\/\s*@ttsc-corpus-filename:\s*(.*?)\s*$/);
     if (match) {
+      const sourcePath = match[1] ?? "";
       assert.notEqual(
-        (match[1] ?? "").length,
+        sourcePath.length,
         0,
         `${relativeFile}: \`// @ttsc-corpus-filename:\` requires a path`,
       );
-      return match[1];
+      return sourcePath;
     }
   }
-  return undefined;
+  return path.posix.join("src", `main${path.posix.extname(relativeFile)}`);
 }
 
 /**
@@ -408,9 +410,7 @@ function parseSkippedRule(relativeFile: string, source: string): string {
     TestLint.parseExpectations(source).map((item) => item.rule),
   );
   const declared = [
-    ...source.matchAll(
-      /^\s*\/\/\s*@ttsc-corpus-rule:\s*([@\w/-]+)\s*$/gm,
-    ),
+    ...source.matchAll(/^\s*\/\/\s*@ttsc-corpus-rule:\s*([@\w/-]+)\s*$/gm),
   ].map((match) => match[1] as string);
   assert.ok(
     declared.length <= 1,

--- a/tests/utils/src/lint/TestLint.ts
+++ b/tests/utils/src/lint/TestLint.ts
@@ -9,10 +9,10 @@ import { TestProject } from "../TestProject";
 // Spawn the real `ttsc` binary against an isolated TypeScript fixture
 // and parse the rendered stderr diagnostics into structured records.
 //
-// Each rule's e2e test passes one `.ts` file (the violation case) and a
-// rules-map. The helper:
-//   1. mkdtemp's a fixture project with the supplied source as
-//      `src/main.ts` and a synthesized `tsconfig.json`.
+// Each rule's e2e test passes one `.ts` or `.tsx` file (the violation case) and
+// a rules-map. The helper:
+//   1. mkdtemp's a fixture project with the supplied source at the selected
+//      path (default `src/main.ts`) and a synthesized `tsconfig.json`.
 //   2. Symlinks `node_modules/@ttsc/lint` to the workspace package so
 //      the plugin resolver finds it the same way it would for an npm
 //      install.
@@ -189,19 +189,24 @@ export namespace TestLint {
       assertDisposableProjectRoot(projectRoot);
     }
     try {
+      const materializedExtraSources = Object.entries(extraSources ?? {}).map(
+        ([relativePath, content]) =>
+          [normalizeFixtureRelativePath(relativePath), content] as const,
+      );
       // The tsconfig plugin entry never carries rules: it is empty, or
       // optionally names a config file via `configFile`. When a test uses the
       // `rules` shorthand, materialize a discoverable `lint.config.json`.
-      writeFixtureProject(tmpdir, source, pluginConfig ?? {}, sourcePath);
-      if (extraSources) {
-        for (const [relPath, content] of Object.entries(extraSources) as [
-          string,
-          string,
-        ][]) {
-          const target = path.join(tmpdir, relPath);
-          fs.mkdirSync(path.dirname(target), { recursive: true });
-          fs.writeFileSync(target, content, "utf8");
-        }
+      writeFixtureProject(
+        tmpdir,
+        source,
+        pluginConfig ?? {},
+        sourcePath,
+        materializedExtraSources.map(([relativePath]) => relativePath),
+      );
+      for (const [relativePath, content] of materializedExtraSources) {
+        const target = path.join(tmpdir, relativePath);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(target, content, "utf8");
       }
       if (rules !== undefined) {
         fs.writeFileSync(
@@ -265,8 +270,13 @@ export namespace TestLint {
     source: string,
     pluginConfig: Record<string, unknown>,
     sourcePath: string = path.posix.join("src", "main.ts"),
+    extraSourcePaths: readonly string[] = [],
   ): void {
-    const target = path.join(tmpdir, resolveMainSourcePath(sourcePath));
+    const mainSourcePath = resolveMainSourcePath(sourcePath);
+    const usesTSX = [mainSourcePath, ...extraSourcePaths].some(
+      isIncludedTSXSourcePath,
+    );
+    const target = path.join(tmpdir, mainSourcePath);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, source, "utf8");
     fs.writeFileSync(
@@ -279,6 +289,7 @@ export namespace TestLint {
             strict: true,
             noEmit: true,
             rootDir: "src",
+            ...(usesTSX ? { jsx: "react-jsx" } : {}),
             plugins: [
               {
                 transform: "@ttsc/lint",
@@ -299,14 +310,14 @@ export namespace TestLint {
    * Validate a caller-selected main-source path and normalize it to POSIX
    * separators relative to the project root.
    *
-   * The synthesized tsconfig pins `rootDir: "src"` and `include: ["src"]`, so
-   * a logical filename outside `src/` would silently fall out of the compiled
+   * The synthesized tsconfig pins `rootDir: "src"` and `include: ["src"]`, so a
+   * logical filename outside `src/` would silently fall out of the compiled
    * program instead of exercising the rule under test. Escapes and absolute
    * paths are rejected for the same reason fixture roots are validated: the
    * harness must never write outside its disposable project.
    */
   function resolveMainSourcePath(sourcePath: string): string {
-    const normalized = path.posix.normalize(sourcePath.replaceAll("\\", "/"));
+    const normalized = normalizeFixtureRelativePath(sourcePath);
     if (
       path.isAbsolute(normalized) ||
       !normalized.startsWith("src/") ||
@@ -319,6 +330,20 @@ export namespace TestLint {
       );
     }
     return normalized;
+  }
+
+  /** Normalize caller paths so POSIX and Windows separators materialize alike. */
+  function normalizeFixtureRelativePath(sourcePath: string): string {
+    return path.posix.normalize(sourcePath.replaceAll("\\", "/"));
+  }
+
+  /** Whether a generated tsconfig includes this TSX source under `src/`. */
+  function isIncludedTSXSourcePath(sourcePath: string): boolean {
+    const normalized = normalizeFixtureRelativePath(sourcePath);
+    return (
+      normalized.startsWith("src/") &&
+      path.posix.extname(normalized).toLowerCase() === ".tsx"
+    );
   }
 
   function assertDisposableProjectRoot(projectRoot: string): void {
@@ -392,7 +417,7 @@ export namespace TestLint {
 
   const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
   const BANNER_PATTERN =
-    /(?:^|[\s/])([^\s:]+\.ts):(\d+):(\d+)\s+-\s+(error|warning)\s+TS\d+:\s*\[([^\]]+)\]\s*(.*)$/;
+    /(?:^|[\s/])([^\s:]+\.tsx?):(\d+):(\d+)\s+-\s+(error|warning)\s+TS\d+:\s*\[([^\]]+)\]\s*(.*)$/;
 
   /**
    * Parse the renderer's stderr into structured records.


### PR DESCRIPTION
Restores real TSX lint-corpus execution by preserving TSX source paths and selecting JSX compiler mode across every included fixture source.

The restored corpus exposed unsafe unchecked AST casts and a reversed Next.js GA rule oracle. The implementation now narrows React/Solid TSX nodes, matches the upstream native-script contract, handles static inline object last-write semantics conservatively, and covers filename-sensitive negatives.

Local validation:
- full lint Go suite
- @ttsc/lint build
- repository typecheck
- harness 2/2
- TSX corpus 68/68
- exhaustive clean review over all 28 changed files

Development CI runs were intentionally cancelled; this issue PR is merged from local validation. Repository-wide format and CI green are handled by the final cleanup PR.

Fixes #615
