### PR TITLE
fix(lint): reject optionless rule payloads

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -160,6 +160,8 @@ export default {
 } satisfies ITtscLintConfig;
 ```
 
+Rules with options use an ESLint-style tuple such as `["error", { allowElseIf: false }]`. A built-in rule whose typed setting is severity-only accepts no payload, even while it is `"off"`; the engine reports an invalid configuration instead of silently discarding the extra value.
+
 Rule IDs use ESLint-style kebab-case and slash namespaces, `no-var`, `react/jsx-key`, `testing-library/prefer-screen-queries`. The exported `ITtscLintRules` type is the intersection of family-specific interfaces such as `ITtscLintCoreRules`, `ITtscLintTypeScriptRules`, `ITtscLintReactRules`, and `ITtscLintVitestRules`, so users can type a whole config or a narrower family-shaped object.
 
 Each rule below links to its TypeScript fixture under [`tests/test-lint/src/cases/`](https://github.com/samchon/ttsc/tree/master/tests/test-lint/src/cases).
@@ -251,7 +253,7 @@ Source: [ESLint core rules](https://eslint.org/docs/latest/rules/).
 - [`no-dupe-keys`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-dupe-keys.ts): rejects duplicate object keys.
 - [`no-duplicate-case`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-duplicate-case.ts): rejects duplicate `switch` case labels.
 - [`no-duplicate-imports`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-duplicate-imports.ts): reject a repeated module specifier when the import declarations could be merged into one; `allowSeparateTypeImports` and `includeExports` match the ESLint options.
-- [`no-else-return`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-else-return.ts): reject an `else` block whose preceding `if` branch already terminates with `return`, `throw`, `break`, or `continue`.
+- [`no-else-return`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-else-return.ts): reject an `else` block whose preceding `if` branch returns on every path.
 - [`no-empty`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty.ts): rejects uncommented empty blocks and switches; `allowEmptyCatch` accepts empty catches.
 - [`no-empty-character-class`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty-character-class.ts): rejects empty regex character classes.
 - [`no-empty-function`](https://github.com/samchon/ttsc/blob/master/tests/test-lint/src/cases/no-empty-function.ts): rejects uncommented empty functions unless their category is allowed.
@@ -1143,6 +1145,20 @@ export default {
 Contributor rules emit autofixes the same way built-ins do, call `ctx.ReportFix(node, message, edits...)` or `ctx.ReportRangeFix(pos, end, message, edits...)`. The `rule/astutil` package re-exports the byte-range helpers built-ins use (`NodeText`, `KeywordStart`, `FindKeyword`, `TokenRange`). See the [contributor autofix path](https://ttsc.dev/docs/development/walkthroughs/lint#the-contributor-autofix-path) section for the full contract and an example.
 
 Contributor rules run on declaration files (`.d.ts`) by default. The engine skips its own value-level rules there — executable grammar cannot appear in a declaration file — but it cannot infer a third-party rule's shape, so contributors keep the conservative default. A rule that only inspects executable code can implement the optional `rule.DeclarationFileRule` marker (`VisitsDeclarationFiles() bool { return false }`) to get the same skip and save the dispatch on declaration-heavy projects.
+
+Contributor rules also keep accepting options by default because `rule.Context.Options` predates the options-capability contract. A contributor that is genuinely optionless can implement `rule.OptionsRule` with `AcceptsTtscLintOptions() bool { return false }`; the host then rejects any payload before calling the rule. The domain-specific method name avoids capturing an unrelated `AcceptsOptions` method on an existing contributor. The same marker applies to `rule.ProjectRule` implementations.
+
+A typed contributor package should publish the same optionless contract by augmenting `ITtscLintContributorRules` directly with `TtscLintRuleSetting`. Without this augmentation, the open contributor fallback keeps accepting an unknown payload for packages whose typings were not imported.
+
+```ts
+import type { TtscLintRuleSetting } from "@ttsc/lint";
+
+declare module "@ttsc/lint" {
+  interface ITtscLintContributorRules {
+    "demo/capitalize-exports"?: TtscLintRuleSetting;
+  }
+}
+```
 
 ### Project-scoped contributor rules
 

--- a/packages/lint/linthost/contrib_adapter.go
+++ b/packages/lint/linthost/contrib_adapter.go
@@ -88,6 +88,7 @@ func registerContributors() {
 // panic later during registry sorting or engine construction.
 type contributorMetadata struct {
   inner                  rule.Rule
+  acceptsOptions         bool
   isFormat               bool
   name                   string
   visits                 []shimast.Kind
@@ -108,6 +109,7 @@ func inspectContributor(contributor rule.Rule) (metadata contributorMetadata, er
   }()
   metadata = contributorMetadata{
     inner:                  contributor,
+    acceptsOptions:         true,
     name:                   contributor.Name(),
     visits:                 append([]shimast.Kind(nil), contributor.Visits()...),
     visitsDeclarationFiles: true,
@@ -122,6 +124,9 @@ func inspectContributor(contributor rule.Rule) (metadata contributorMetadata, er
   if typeAware, ok := contributor.(rule.TypeAwareRule); ok {
     metadata.needsTypeChecker = typeAware.NeedsTypeChecker()
   }
+  if optionsRule, ok := contributor.(rule.OptionsRule); ok {
+    metadata.acceptsOptions = optionsRule.AcceptsTtscLintOptions()
+  }
   return metadata, nil
 }
 
@@ -132,6 +137,7 @@ func inspectContributor(contributor rule.Rule) (metadata contributorMetadata, er
 func newContributorAdapter(metadata contributorMetadata) contributorAdapter {
   return contributorAdapter{
     inner:                  metadata.inner,
+    acceptsOptions:         metadata.acceptsOptions,
     name:                   metadata.name,
     visits:                 metadata.visits,
     visitsDeclarationFiles: metadata.visitsDeclarationFiles,
@@ -148,10 +154,19 @@ func newContributorAdapter(metadata contributorMetadata) contributorAdapter {
 // same shim AST types, so no wrapping / unwrapping of nodes is needed.
 type contributorAdapter struct {
   inner                  rule.Rule
+  acceptsOptions         bool
   name                   string
   visits                 []shimast.Kind
   visitsDeclarationFiles bool
   needsTypeChecker       bool
+}
+
+// AcceptsTtscLintOptions preserves the public contributor contract:
+// contributors have historically been allowed to decode an arbitrary options
+// blob, so the conservative default is true. A contributor can implement
+// rule.OptionsRule and return false to declare a genuinely optionless rule.
+func (a contributorAdapter) AcceptsTtscLintOptions() bool {
+  return a.acceptsOptions
 }
 
 // NeedsTypeChecker keeps contributor rules on the conservative checker path

--- a/packages/lint/linthost/engine.go
+++ b/packages/lint/linthost/engine.go
@@ -81,6 +81,21 @@ type ruleOptionsValidator interface {
   ValidateOptions(json.RawMessage) error
 }
 
+// ruleOptionsAcceptor is the structural declaration that a rule owns an
+// options schema. The engine uses the capability instead of a rule-name list,
+// so adding an options payload to a rule requires the implementation itself to
+// opt in. A false result is equivalent to omitting the interface.
+type ruleOptionsAcceptor interface {
+  AcceptsTtscLintOptions() bool
+}
+
+// optionsRule is embedded by built-in rules whose public configuration accepts
+// an options slot. Keeping the marker next to each implementation makes the
+// registry the runtime source of truth without a parallel name table.
+type optionsRule struct{}
+
+func (optionsRule) AcceptsTtscLintOptions() bool { return true }
+
 // isFormatRule reports whether `r` opts into the format category.
 func isFormatRule(r Rule) bool {
   fr, ok := r.(FormatRule)
@@ -92,7 +107,15 @@ func ruleNeedsTypeChecker(r Rule) bool {
   return ok && tr.NeedsTypeChecker()
 }
 
+func ruleAcceptsOptions(r Rule) bool {
+  acceptor, ok := r.(ruleOptionsAcceptor)
+  return ok && acceptor.AcceptsTtscLintOptions()
+}
+
 func validateRuleOptions(r Rule, options json.RawMessage) error {
+  if len(options) > 0 && !ruleAcceptsOptions(r) {
+    return errors.New("rule does not accept options")
+  }
   validator, ok := r.(ruleOptionsValidator)
   if !ok {
     return nil
@@ -496,24 +519,24 @@ func NewEngineWithResolver(config RuleResolver) *Engine {
     enabled:           make(map[string]Severity),
     unknownDirectives: make(map[string]struct{}),
   }
-  eng.projectSettings, eng.configError = config.ResolveProjectRules(allProjectRuleNames())
-  for _, setting := range eng.projectSettings {
+  projectRuleNames := allProjectRuleNames()
+  eng.projectSettings, eng.configError = config.ResolveProjectRules(projectRuleNames)
+  for _, name := range projectRuleNames {
+    setting := eng.projectSettings[name]
+    if setting.Declared && len(setting.Options) > 0 && !registeredProjectRules[name].acceptsOptions {
+      eng.configError = errors.Join(
+        eng.configError,
+        fmt.Errorf("@ttsc/lint: invalid options for rule %q: rule does not accept options", name),
+      )
+    }
     if setting.Declared && setting.Severity != SeverityOff {
       eng.needsTypeChecker = true
-      break
     }
   }
   displaySeverities := config.EnabledRuleConfig()
-  for _, name := range config.ActiveRuleNames() {
-    if _, isProjectRule := registeredProjectRules[name]; isProjectRule {
-      continue
-    }
-    rule, ok := registered.rules[name]
-    if !ok {
-      eng.unknown = append(eng.unknown, name)
-      continue
-    }
-    optionsValid := true
+  invalidRuleOptions := make(map[string]struct{})
+  for _, name := range AllRuleNames() {
+    rule := registered.rules[name]
     seenOptions := make(map[string]struct{})
     for _, options := range resolvedRuleOptionsVariants(config, name) {
       key := string(options)
@@ -526,10 +549,20 @@ func NewEngineWithResolver(config RuleResolver) *Engine {
           eng.configError,
           fmt.Errorf("@ttsc/lint: invalid options for rule %q: %w", name, err),
         )
-        optionsValid = false
+        invalidRuleOptions[name] = struct{}{}
       }
     }
-    if !optionsValid {
+  }
+  for _, name := range config.ActiveRuleNames() {
+    if _, isProjectRule := registeredProjectRules[name]; isProjectRule {
+      continue
+    }
+    rule, ok := registered.rules[name]
+    if !ok {
+      eng.unknown = append(eng.unknown, name)
+      continue
+    }
+    if _, invalid := invalidRuleOptions[name]; invalid {
       continue
     }
     if ruleNeedsTypeChecker(rule) {

--- a/packages/lint/linthost/project_rules.go
+++ b/packages/lint/linthost/project_rules.go
@@ -11,8 +11,9 @@ import (
 // projectRuleAdapter caches contributor metadata and keeps project checks on a
 // separate lifecycle from node rules.
 type projectRuleAdapter struct {
-  inner publicrule.ProjectRule
-  name  string
+  inner          publicrule.ProjectRule
+  name           string
+  acceptsOptions bool
 }
 
 var registeredProjectRules = map[string]projectRuleAdapter{}
@@ -56,7 +57,15 @@ func inspectProjectContributor(project publicrule.ProjectRule) (adapter projectR
   if project == nil {
     return projectRuleAdapter{}, fmt.Errorf("nil contributor project rule")
   }
-  return projectRuleAdapter{inner: project, name: project.Name()}, nil
+  adapter = projectRuleAdapter{
+    inner:          project,
+    name:           project.Name(),
+    acceptsOptions: true,
+  }
+  if optionsRule, ok := project.(publicrule.OptionsRule); ok {
+    adapter.acceptsOptions = optionsRule.AcceptsTtscLintOptions()
+  }
+  return adapter, nil
 }
 
 func allProjectRuleNames() []string {

--- a/packages/lint/linthost/rules_ban_ts_comment.go
+++ b/packages/lint/linthost/rules_ban_ts_comment.go
@@ -209,7 +209,7 @@ func normalizeTsDirectiveConfig(raw json.RawMessage, def tsDirectivePolicy) tsDi
 }
 
 // banTsComment implements typescript/ban-ts-comment.
-type banTsComment struct{}
+type banTsComment struct{ optionsRule }
 
 func (banTsComment) Name() string           { return "typescript/ban-ts-comment" }
 func (banTsComment) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSourceFile} }

--- a/packages/lint/linthost/rules_boundaries.go
+++ b/packages/lint/linthost/rules_boundaries.go
@@ -12,11 +12,11 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
 
-type boundariesElementTypes struct{}
-type boundariesExternal struct{}
-type boundariesEntryPoint struct{}
-type boundariesNoPrivate struct{}
-type boundariesNoUnknown struct{}
+type boundariesElementTypes struct{ optionsRule }
+type boundariesExternal struct{ optionsRule }
+type boundariesEntryPoint struct{ optionsRule }
+type boundariesNoPrivate struct{ optionsRule }
+type boundariesNoUnknown struct{ optionsRule }
 
 func (boundariesElementTypes) Name() string { return "boundaries/element-types" }
 func (boundariesExternal) Name() string     { return "boundaries/external" }

--- a/packages/lint/linthost/rules_boundaries_dependencies.go
+++ b/packages/lint/linthost/rules_boundaries_dependencies.go
@@ -24,7 +24,7 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
 
-type boundariesDependencies struct{}
+type boundariesDependencies struct{ optionsRule }
 
 type boundaryDependenciesOptions struct {
   Elements           []boundaryElement

--- a/packages/lint/linthost/rules_cypress.go
+++ b/packages/lint/linthost/rules_cypress.go
@@ -12,7 +12,7 @@ type cypressNoUnnecessaryWaiting struct{}
 type cypressNoForce struct{}
 type cypressNoPause struct{}
 type cypressNoDebug struct{}
-type cypressUnsafeToChainCommand struct{}
+type cypressUnsafeToChainCommand struct{ optionsRule }
 type cypressAssertionBeforeScreenshot struct{}
 type cypressNoAsyncTests struct{}
 type cypressNoAsyncBefore struct{}

--- a/packages/lint/linthost/rules_default_case.go
+++ b/packages/lint/linthost/rules_default_case.go
@@ -45,7 +45,7 @@ type defaultCaseOptions struct {
   CommentPattern string `json:"commentPattern"`
 }
 
-type defaultCase struct{}
+type defaultCase struct{ optionsRule }
 
 func (defaultCase) Name() string           { return "default-case" }
 func (defaultCase) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSwitchStatement} }

--- a/packages/lint/linthost/rules_empty.go
+++ b/packages/lint/linthost/rules_empty.go
@@ -8,7 +8,7 @@ import (
 // noEmpty rejects empty block and switch statements unless an interior
 // comment documents the intentional no-op.
 // https://eslint.org/docs/latest/rules/no-empty
-type noEmpty struct{}
+type noEmpty struct{ optionsRule }
 
 type noEmptyOptions struct {
   AllowEmptyCatch bool `json:"allowEmptyCatch"`
@@ -57,7 +57,7 @@ func (noEmpty) Check(ctx *Context, node *shimast.Node) {
 
 // noEmptyFunction: empty function / method / arrow / accessor bodies.
 // https://eslint.org/docs/latest/rules/no-empty-function
-type noEmptyFunction struct{}
+type noEmptyFunction struct{ optionsRule }
 
 type noEmptyFunctionOptions struct {
   Allow []string `json:"allow"`

--- a/packages/lint/linthost/rules_format_arrow_parens.go
+++ b/packages/lint/linthost/rules_format_arrow_parens.go
@@ -26,7 +26,7 @@ import (
 // or the `=>`, so a chained arrow `a => b => …` has each eligible arm
 // normalized independently. Idempotent: a parameter already in the
 // preferred shape compares equal and emits nothing.
-type formatArrowParens struct{}
+type formatArrowParens struct{ optionsRule }
 
 type formatArrowParensOptions struct {
   Prefer string `json:"prefer"`

--- a/packages/lint/linthost/rules_format_bracket_spacing.go
+++ b/packages/lint/linthost/rules_format_bracket_spacing.go
@@ -22,7 +22,7 @@ import (
 // and an empty `{}` has no interior to pad. It rewrites just the whitespace
 // run immediately inside each brace, so it never disturbs the contents.
 // Idempotent: a pair already in the preferred shape compares equal.
-type formatBracketSpacing struct{}
+type formatBracketSpacing struct{ optionsRule }
 
 type formatBracketSpacingOptions struct {
   Spacing *bool `json:"spacing"`

--- a/packages/lint/linthost/rules_format_clause_join.go
+++ b/packages/lint/linthost/rules_format_clause_join.go
@@ -23,7 +23,7 @@ import (
 // `format/indent` (leading whitespace of a line) or `format/print-width`
 // (interior reflow). Idempotent: once joined the gap holds no newline
 // and the rule abstains.
-type formatClauseJoin struct{}
+type formatClauseJoin struct{ optionsRule }
 
 // formatClauseJoinOptions mirrors the printWidth/indent keys the rule
 // needs to decide whether the joined line fits. The config layer mirrors

--- a/packages/lint/linthost/rules_format_declaration_header.go
+++ b/packages/lint/linthost/rules_format_declaration_header.go
@@ -46,7 +46,7 @@ import (
 // breaking heritage clause at once), a header carrying comments, or a
 // type/parameter that is itself multi-line makes the rule ABSTAIN, so it
 // never emits a header it cannot reproduce exactly.
-type formatDeclarationHeader struct{}
+type formatDeclarationHeader struct{ optionsRule }
 
 type formatDeclarationHeaderOptions struct {
   PrintWidth *int    `json:"printWidth"`

--- a/packages/lint/linthost/rules_format_indent.go
+++ b/packages/lint/linthost/rules_format_indent.go
@@ -31,7 +31,7 @@ import (
 //
 // Idempotent: a correctly-indented statement compares equal in step 3
 // and emits nothing.
-type formatIndent struct{}
+type formatIndent struct{ optionsRule }
 
 func (formatIndent) Name() string   { return "format/indent" }
 func (formatIndent) IsFormat() bool { return true }

--- a/packages/lint/linthost/rules_format_jsdoc.go
+++ b/packages/lint/linthost/rules_format_jsdoc.go
@@ -25,7 +25,7 @@ import (
 // `/** ... */` blocks; it deliberately avoids relying on the JSDoc AST
 // because comment attachment is a moving target across TypeScript
 // versions.
-type formatJSDoc struct{}
+type formatJSDoc struct{ optionsRule }
 
 // formatJSDocOptions mirrors `TtscLintRuleOptions.JSDoc`. The
 // `tagSynonyms` map layers on top of the built-in synonym table so

--- a/packages/lint/linthost/rules_format_orphan_semi.go
+++ b/packages/lint/linthost/rules_format_orphan_semi.go
@@ -24,7 +24,7 @@ import (
 // is left alone, dropping a redundant `;` safely depends on the
 // surrounding semicolon policy and is out of scope here. Idempotent:
 // once merged the gap holds no newline, so the rule finds nothing to do.
-type formatOrphanSemi struct{}
+type formatOrphanSemi struct{ optionsRule }
 
 // formatOrphanSemiOptions carries the effective `semi` setting, mirrored
 // from format.semi by the config layer. Defaults to true (semicolons),

--- a/packages/lint/linthost/rules_format_parameter_properties.go
+++ b/packages/lint/linthost/rules_format_parameter_properties.go
@@ -25,7 +25,7 @@ import (
 // region and emits no trailing comma, format/trailing-comma adds it on
 // the now-multi-line list, so the two rules stay disjoint. Idempotent:
 // an already-broken list contains a newline and is skipped.
-type formatParameterProperties struct{}
+type formatParameterProperties struct{ optionsRule }
 
 // formatParameterPropertiesOptions carries the indentation + EOL settings
 // the rewrite needs. The config layer mirrors

--- a/packages/lint/linthost/rules_format_print_width.go
+++ b/packages/lint/linthost/rules_format_print_width.go
@@ -49,7 +49,7 @@ import (
 // configured severities. Reuses the `error` severity caveat from
 // other format rules: only set `error` once the full reflow coverage
 // is mature.
-type formatPrintWidth struct{}
+type formatPrintWidth struct{ optionsRule }
 
 // formatPrintWidthOptions mirrors `TtscLintRuleOptions.PrintWidth`.
 //

--- a/packages/lint/linthost/rules_format_quote_props.go
+++ b/packages/lint/linthost/rules_format_quote_props.go
@@ -20,7 +20,7 @@ import (
 // the first) with no escapes. A key with escapes, unicode, a leading digit
 // (numeric-looking), or any non-identifier byte is left quoted in every
 // mode, so the rule can never produce an invalid key. Idempotent.
-type formatQuoteProps struct{}
+type formatQuoteProps struct{ optionsRule }
 
 type formatQuotePropsOptions struct {
   Mode string `json:"mode"`

--- a/packages/lint/linthost/rules_format_quotes.go
+++ b/packages/lint/linthost/rules_format_quotes.go
@@ -23,7 +23,7 @@ import (
 // quotes corrupts working code. Template literals, no-substitution
 // template literals, and JSX text nodes use distinct AST kinds and are
 // also intentionally out of scope.
-type formatQuotes struct{}
+type formatQuotes struct{ optionsRule }
 
 // formatQuotesOptions mirrors `TtscLintRuleOptions.Quotes`. Prefer accepts
 // `"double"` (the default, enforces double quotes) or `"single"` (enforces

--- a/packages/lint/linthost/rules_format_semi.go
+++ b/packages/lint/linthost/rules_format_semi.go
@@ -15,7 +15,7 @@ import (
 // optional semicolon. Body-shaped declarations (functions, classes,
 // namespaces, enums) and control-flow statements (if/for/while/try)
 // are out of scope because they parse correctly without a terminator.
-type formatSemi struct{}
+type formatSemi struct{ optionsRule }
 
 // formatSemiOptions is the Go mirror of `TtscLintRuleOptions.Semi`. The
 // JSON tag matches the TypeScript field name so users get the same key

--- a/packages/lint/linthost/rules_format_sort_imports.go
+++ b/packages/lint/linthost/rules_format_sort_imports.go
@@ -66,7 +66,7 @@ var defaultImportOrder = []string{
 // outcome than declining to sort. Every import other than `import type` can
 // evaluate a module, including default, namespace, and named binding imports,
 // so declaration-level rewriting is disabled for those blocks by default.
-type formatSortImports struct{}
+type formatSortImports struct{ optionsRule }
 
 func (formatSortImports) Name() string   { return "format/sort-imports" }
 func (formatSortImports) IsFormat() bool { return true }

--- a/packages/lint/linthost/rules_format_statement_split.go
+++ b/packages/lint/linthost/rules_format_statement_split.go
@@ -36,7 +36,7 @@ import (
 //
 // Idempotent: once each statement is alone on its line, step 2 abstains
 // for all of them and the rule emits nothing.
-type formatStatementSplit struct{}
+type formatStatementSplit struct{ optionsRule }
 
 // formatStatementSplitOptions carries the indentation + EOL settings the
 // rule needs to synthesize the inserted line break. The JSON tags match

--- a/packages/lint/linthost/rules_format_ternary_nullish_parens.go
+++ b/packages/lint/linthost/rules_format_ternary_nullish_parens.go
@@ -19,7 +19,7 @@ import (
 // so it is a normalization rule rather than part of the print-width
 // reflow. Idempotent: a wrapped operand parses as a parenthesized
 // expression, not a bare `??`, so the next pass leaves it alone.
-type formatTernaryNullishParens struct{}
+type formatTernaryNullishParens struct{ optionsRule }
 
 func (formatTernaryNullishParens) Name() string   { return "format/ternary-nullish-parens" }
 func (formatTernaryNullishParens) IsFormat() bool { return true }

--- a/packages/lint/linthost/rules_format_trailing_comma.go
+++ b/packages/lint/linthost/rules_format_trailing_comma.go
@@ -50,7 +50,7 @@ import (
 // no place to insert one. `findCloseTokenAfter` bails on the first
 // non-trivia byte after the parameter's `End()` (the `=>` token), so the
 // rule abstains without emitting an edit.
-type formatTrailingComma struct{}
+type formatTrailingComma struct{ optionsRule }
 
 // formatTrailingCommaOptions mirrors `TtscLintRuleOptions.TrailingComma`.
 type formatTrailingCommaOptions struct {

--- a/packages/lint/linthost/rules_format_whitespace.go
+++ b/packages/lint/linthost/rules_format_whitespace.go
@@ -34,7 +34,7 @@ import (
 // Idempotent: a file that already has no trailing whitespace, at most
 // one consecutive blank line, no leading/trailing blank lines, and a
 // single final EOL produces no edits.
-type formatWhitespace struct{}
+type formatWhitespace struct{ optionsRule }
 
 // formatWhitespaceOptions carries only the EOL setting; the rule needs
 // it to synthesize the file's final newline. Indentation is irrelevant

--- a/packages/lint/linthost/rules_functional.go
+++ b/packages/lint/linthost/rules_functional.go
@@ -6,26 +6,26 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
 
-type functionalParameters struct{}
-type functionalImmutableData struct{}
-type functionalNoClassInheritance struct{}
-type functionalNoClasses struct{}
-type functionalNoConditionalStatements struct{}
-type functionalNoExpressionStatements struct{}
-type functionalNoLet struct{}
-type functionalNoLoopStatements struct{}
-type functionalNoMixedTypes struct{}
-type functionalNoPromiseReject struct{}
-type functionalNoReturnVoid struct{}
-type functionalNoThisExpressions struct{}
-type functionalNoThrowStatements struct{}
-type functionalNoTryStatements struct{}
-type functionalPreferImmutableTypes struct{}
-type functionalPreferPropertySignatures struct{}
-type functionalPreferReadonlyType struct{}
-type functionalPreferTacit struct{}
-type functionalReadonlyType struct{}
-type functionalTypeDeclarationImmutability struct{}
+type functionalParameters struct{ optionsRule }
+type functionalImmutableData struct{ optionsRule }
+type functionalNoClassInheritance struct{ optionsRule }
+type functionalNoClasses struct{ optionsRule }
+type functionalNoConditionalStatements struct{ optionsRule }
+type functionalNoExpressionStatements struct{ optionsRule }
+type functionalNoLet struct{ optionsRule }
+type functionalNoLoopStatements struct{ optionsRule }
+type functionalNoMixedTypes struct{ optionsRule }
+type functionalNoPromiseReject struct{ optionsRule }
+type functionalNoReturnVoid struct{ optionsRule }
+type functionalNoThisExpressions struct{ optionsRule }
+type functionalNoThrowStatements struct{ optionsRule }
+type functionalNoTryStatements struct{ optionsRule }
+type functionalPreferImmutableTypes struct{ optionsRule }
+type functionalPreferPropertySignatures struct{ optionsRule }
+type functionalPreferReadonlyType struct{ optionsRule }
+type functionalPreferTacit struct{ optionsRule }
+type functionalReadonlyType struct{ optionsRule }
+type functionalTypeDeclarationImmutability struct{ optionsRule }
 
 func (functionalParameters) Name() string              { return "functional/functional-parameters" }
 func (functionalImmutableData) Name() string           { return "functional/immutable-data" }

--- a/packages/lint/linthost/rules_grouped_accessor_pairs.go
+++ b/packages/lint/linthost/rules_grouped_accessor_pairs.go
@@ -20,7 +20,7 @@ package linthost
 
 import shimast "github.com/microsoft/typescript-go/shim/ast"
 
-type groupedAccessorPairs struct{}
+type groupedAccessorPairs struct{ optionsRule }
 
 func (groupedAccessorPairs) Name() string { return "grouped-accessor-pairs" }
 func (groupedAccessorPairs) Visits() []shimast.Kind {

--- a/packages/lint/linthost/rules_no_duplicate_imports.go
+++ b/packages/lint/linthost/rules_no_duplicate_imports.go
@@ -63,7 +63,7 @@ type importExportEntry struct {
   isExport bool
 }
 
-type noDuplicateImports struct{}
+type noDuplicateImports struct{ optionsRule }
 
 func (noDuplicateImports) Name() string { return "no-duplicate-imports" }
 func (noDuplicateImports) Visits() []shimast.Kind {

--- a/packages/lint/linthost/rules_no_else_return.go
+++ b/packages/lint/linthost/rules_no_else_return.go
@@ -27,7 +27,7 @@ import (
 
 const noElseReturnMessage = "Remove the `else` — the preceding `if` branch already returns."
 
-type noElseReturn struct{}
+type noElseReturn struct{ optionsRule }
 
 // noElseReturnOptions mirrors ESLint's single object option. `AllowElseIf`
 // is a pointer so a missing option decodes to the upstream default (`true`)

--- a/packages/lint/linthost/rules_no_extend_native.go
+++ b/packages/lint/linthost/rules_no_extend_native.go
@@ -9,7 +9,7 @@ import shimast "github.com/microsoft/typescript-go/shim/ast"
 // `Object.defineProperty` / `Object.defineProperties` calls whose target is a
 // native prototype. The `exceptions` option removes builtins from the set.
 // https://eslint.org/docs/latest/rules/no-extend-native
-type noExtendNative struct{}
+type noExtendNative struct{ optionsRule }
 
 type noExtendNativeOptions struct {
   Exceptions []string `json:"exceptions"`

--- a/packages/lint/linthost/rules_no_fallthrough.go
+++ b/packages/lint/linthost/rules_no_fallthrough.go
@@ -71,7 +71,7 @@ type noFallthroughOptions struct {
   ReportUnusedFallthroughComment bool `json:"reportUnusedFallthroughComment"`
 }
 
-type noFallthrough struct{}
+type noFallthrough struct{ optionsRule }
 
 func (noFallthrough) Name() string           { return "no-fallthrough" }
 func (noFallthrough) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSwitchStatement} }

--- a/packages/lint/linthost/rules_no_inner_declarations.go
+++ b/packages/lint/linthost/rules_no_inner_declarations.go
@@ -13,7 +13,7 @@ import (
 // JavaScript and TypeScript with the current ECMAScript grammar, so strict
 // functions in ordinary parsed source have ES2015 block-function semantics.
 // https://eslint.org/docs/latest/rules/no-inner-declarations
-type noInnerDeclarations struct{}
+type noInnerDeclarations struct{ optionsRule }
 
 type noInnerDeclarationsOptions struct {
   both                 bool

--- a/packages/lint/linthost/rules_no_mixed_operators.go
+++ b/packages/lint/linthost/rules_no_mixed_operators.go
@@ -59,7 +59,7 @@ type noMixedOperatorsOptions struct {
   AllowSamePrecedence *bool      `json:"allowSamePrecedence"`
 }
 
-type noMixedOperators struct{}
+type noMixedOperators struct{ optionsRule }
 
 func (noMixedOperators) Name() string           { return "no-mixed-operators" }
 func (noMixedOperators) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindBinaryExpression} }

--- a/packages/lint/linthost/rules_no_param_reassign.go
+++ b/packages/lint/linthost/rules_no_param_reassign.go
@@ -20,7 +20,7 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
 
-type noParamReassign struct{}
+type noParamReassign struct{ optionsRule }
 
 type noParamReassignOptions struct {
   Props                               bool     `json:"props"`

--- a/packages/lint/linthost/rules_no_promise_executor_return.go
+++ b/packages/lint/linthost/rules_no_promise_executor_return.go
@@ -15,7 +15,7 @@ import shimast "github.com/microsoft/typescript-go/shim/ast"
 
 const noPromiseExecutorReturnMessage = "Return values from promise executor functions cannot be read."
 
-type noPromiseExecutorReturn struct{}
+type noPromiseExecutorReturn struct{ optionsRule }
 
 type noPromiseExecutorReturnOptions struct {
   AllowVoid bool `json:"allowVoid"`

--- a/packages/lint/linthost/rules_no_restricted_imports.go
+++ b/packages/lint/linthost/rules_no_restricted_imports.go
@@ -22,7 +22,7 @@ import (
   shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
 
-type noRestrictedImports struct{}
+type noRestrictedImports struct{ optionsRule }
 
 type noRestrictedImportsOptions struct {
   paths    []noRestrictedImportsPath

--- a/packages/lint/linthost/rules_no_restricted_syntax.go
+++ b/packages/lint/linthost/rules_no_restricted_syntax.go
@@ -21,7 +21,7 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
 
-type noRestrictedSyntax struct{}
+type noRestrictedSyntax struct{ optionsRule }
 
 type noRestrictedSyntaxOption struct {
   selector   string

--- a/packages/lint/linthost/rules_promise.go
+++ b/packages/lint/linthost/rules_promise.go
@@ -620,7 +620,7 @@ func isThenableType(checker *shimchecker.Checker, t *shimchecker.Type) bool {
 // statement: sequence expressions hide earlier values, logical and conditional
 // branches hide Promise-producing alternatives, and arrays retain every
 // Promise element even though the container itself is not awaitable.
-type noFloatingPromises struct{}
+type noFloatingPromises struct{ optionsRule }
 
 type noFloatingPromisesOptions struct {
   AllowForKnownSafeCalls    []promiseTypeOrValueSpecifier `json:"allowForKnownSafeCalls"`

--- a/packages/lint/linthost/rules_react_perf.go
+++ b/packages/lint/linthost/rules_react_perf.go
@@ -12,6 +12,7 @@ import (
 type reactPerfMatcher func(*shimast.Node) bool
 
 type reactPerfRule struct {
+  optionsRule
   name    string
   message string
   matcher reactPerfMatcher

--- a/packages/lint/linthost/rules_react_refresh.go
+++ b/packages/lint/linthost/rules_react_refresh.go
@@ -9,7 +9,7 @@ import (
 // onlyExportComponents enforces React Fast Refresh's module boundary rule:
 // files that export React components should not also export non-components.
 // Ported from eslint-plugin-react-refresh's only-export-components rule.
-type onlyExportComponents struct{}
+type onlyExportComponents struct{ optionsRule }
 
 type onlyExportComponentsOptions struct {
   ExtraHOCs           []string `json:"extraHOCs"`

--- a/packages/lint/linthost/rules_storybook.go
+++ b/packages/lint/linthost/rules_storybook.go
@@ -215,7 +215,7 @@ func (storybookNoTitlePropertyInMeta) Check(ctx *Context, node *shimast.Node) {
   }
 }
 
-type storybookNoUninstalledAddons struct{}
+type storybookNoUninstalledAddons struct{ optionsRule }
 
 type storybookNoUninstalledAddonsOptions struct {
   PackageJSONLocation string   `json:"packageJsonLocation"`

--- a/packages/lint/linthost/rules_suggestions.go
+++ b/packages/lint/linthost/rules_suggestions.go
@@ -710,7 +710,7 @@ func regexHasMultipleSpaces(src string) bool {
 }
 
 // noReturnAssign: `return a = b` mixes assignment with return.
-type noReturnAssign struct{}
+type noReturnAssign struct{ optionsRule }
 
 func (noReturnAssign) Name() string { return "no-return-assign" }
 func (noReturnAssign) Visits() []shimast.Kind {
@@ -972,7 +972,7 @@ func needsParensForUnaryNegation(node *shimast.Node) bool {
 // position rather than by recognized text, and the upstream option set
 // (`allowShortCircuit`, `allowTernary`, `allowTaggedTemplates`,
 // `enforceForJSX`, `ignoreDirectives`) decoded from the rule's options blob.
-type noUnusedExpressions struct{}
+type noUnusedExpressions struct{ optionsRule }
 
 // noUnusedExpressionsOptions mirrors the upstream ESLint option object;
 // every flag defaults to false, matching the rule's `defaultOptions`.

--- a/packages/lint/linthost/rules_testing_library.go
+++ b/packages/lint/linthost/rules_testing_library.go
@@ -13,6 +13,15 @@ type testingLibraryRule struct {
   name string
 }
 
+// testingLibraryOptionsRule marks the one rule in the shared SourceFile
+// dispatcher whose public contract includes an options object. Embedding the
+// base rule keeps dispatch shared while leaving every sibling genuinely
+// optionless in the registry.
+type testingLibraryOptionsRule struct {
+  testingLibraryRule
+  optionsRule
+}
+
 func (r testingLibraryRule) Name() string { return "testing-library/" + r.name }
 func (r testingLibraryRule) Visits() []shimast.Kind {
   return []shimast.Kind{shimast.KindSourceFile}
@@ -1168,11 +1177,13 @@ func testingLibraryFileName(fileName string) string {
 }
 
 func init() {
+  Register(testingLibraryOptionsRule{
+    testingLibraryRule: testingLibraryRule{name: "consistent-data-testid"},
+  })
   for _, name := range []string{
     "await-async-events",
     "await-async-queries",
     "await-async-utils",
-    "consistent-data-testid",
     "no-await-sync-events",
     "no-await-sync-queries",
     "no-container",

--- a/packages/lint/linthost/rules_ts_no_misused_promises.go
+++ b/packages/lint/linthost/rules_ts_no_misused_promises.go
@@ -12,7 +12,7 @@ import (
   shimchecker "github.com/microsoft/typescript-go/shim/checker"
 )
 
-type noMisusedPromises struct{}
+type noMisusedPromises struct{ optionsRule }
 
 type noMisusedPromisesRawOptions struct {
   ChecksConditionals *bool           `json:"checksConditionals"`

--- a/packages/lint/linthost/rules_ts_no_restricted_types.go
+++ b/packages/lint/linthost/rules_ts_no_restricted_types.go
@@ -18,7 +18,7 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
 
-type noRestrictedTypes struct{}
+type noRestrictedTypes struct{ optionsRule }
 
 type noRestrictedTypeConfig struct {
   enabled     bool

--- a/packages/lint/linthost/rules_ts_switch_exhaustiveness_check.go
+++ b/packages/lint/linthost/rules_ts_switch_exhaustiveness_check.go
@@ -16,7 +16,7 @@ import (
   shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
 
-type switchExhaustivenessCheck struct{}
+type switchExhaustivenessCheck struct{ optionsRule }
 
 type switchExhaustivenessCheckOptions struct {
   AllowDefaultCaseForExhaustiveSwitch *bool   `json:"allowDefaultCaseForExhaustiveSwitch"`

--- a/packages/lint/linthost/rules_unicorn_better_regex.go
+++ b/packages/lint/linthost/rules_unicorn_better_regex.go
@@ -26,7 +26,7 @@ import (
   shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
 
-type unicornBetterRegex struct{}
+type unicornBetterRegex struct{ optionsRule }
 
 // unicornBetterRegexOptions is the rule's public option object. A nil
 // `SortCharacterClasses` keeps the upstream default (sort/merge enabled).

--- a/packages/lint/linthost/rules_unicorn_consistent_function_scoping.go
+++ b/packages/lint/linthost/rules_unicorn_consistent_function_scoping.go
@@ -31,7 +31,7 @@ import (
   shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
 
-type unicornConsistentFunctionScoping struct{}
+type unicornConsistentFunctionScoping struct{ optionsRule }
 
 type unicornConsistentFunctionScopingOptions struct {
   checkArrowFunctions bool

--- a/packages/lint/linthost/rules_unicorn_filename_case.go
+++ b/packages/lint/linthost/rules_unicorn_filename_case.go
@@ -42,7 +42,7 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
 
-type unicornFilenameCase struct{}
+type unicornFilenameCase struct{ optionsRule }
 
 func (unicornFilenameCase) Name() string           { return "unicorn/filename-case" }
 func (unicornFilenameCase) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSourceFile} }

--- a/packages/lint/linthost/rules_unicorn_import_style.go
+++ b/packages/lint/linthost/rules_unicorn_import_style.go
@@ -30,7 +30,7 @@ import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
 
-type unicornImportStyle struct{}
+type unicornImportStyle struct{ optionsRule }
 
 const (
   unicornImportStyleUnassigned = "unassigned"

--- a/packages/lint/linthost/rules_unicorn_isolated_functions.go
+++ b/packages/lint/linthost/rules_unicorn_isolated_functions.go
@@ -39,7 +39,7 @@ var (
   unicornIsolatedFunctionsCommentMarginPattern = regexp.MustCompile(`^(?:\*\s*)*`)
 )
 
-type unicornIsolatedFunctions struct{}
+type unicornIsolatedFunctions struct{ optionsRule }
 
 type unicornIsolatedFunctionsRawOptions struct {
   Functions       json.RawMessage `json:"functions"`

--- a/packages/lint/linthost/rules_unicorn_no_typeof_undefined.go
+++ b/packages/lint/linthost/rules_unicorn_no_typeof_undefined.go
@@ -40,7 +40,7 @@ import (
   shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
 
-type unicornNoTypeofUndefined struct{}
+type unicornNoTypeofUndefined struct{ optionsRule }
 
 // unicornNoTypeofUndefinedOptions is the decoded option payload. Upstream's
 // only option is `checkGlobalVariables`, defaulting to false.

--- a/packages/lint/linthost/rules_unicorn_no_unnecessary_polyfills.go
+++ b/packages/lint/linthost/rules_unicorn_no_unnecessary_polyfills.go
@@ -45,7 +45,7 @@ func unicornNoUnnecessaryPolyfillsCoreJsMessage(coreJsModule string) string {
     "` are available as built-ins. Use the built-ins instead."
 }
 
-type unicornNoUnnecessaryPolyfills struct{}
+type unicornNoUnnecessaryPolyfills struct{ optionsRule }
 
 func (unicornNoUnnecessaryPolyfills) Name() string { return "unicorn/no-unnecessary-polyfills" }
 func (unicornNoUnnecessaryPolyfills) Visits() []shimast.Kind {

--- a/packages/lint/linthost/rules_unicorn_prefer_number_properties.go
+++ b/packages/lint/linthost/rules_unicorn_prefer_number_properties.go
@@ -47,7 +47,7 @@ var unicornPreferNumberPropertiesGlobals = map[string]bool{
   "isFinite":   false,
 }
 
-type unicornPreferNumberProperties struct{}
+type unicornPreferNumberProperties struct{ optionsRule }
 
 type unicornPreferNumberPropertiesOptions struct {
   checkInfinity bool

--- a/packages/lint/linthost/rules_unicorn_prevent_abbreviations.go
+++ b/packages/lint/linthost/rules_unicorn_prevent_abbreviations.go
@@ -34,7 +34,7 @@ import (
   "golang.org/x/text/language"
 )
 
-type unicornPreventAbbreviations struct{}
+type unicornPreventAbbreviations struct{ optionsRule }
 
 type unicornPreventAbbreviationsImportMode uint8
 

--- a/packages/lint/linthost/rules_unicorn_string_content.go
+++ b/packages/lint/linthost/rules_unicorn_string_content.go
@@ -49,7 +49,7 @@ var unicornStringContentIgnoredMemberObjects = map[string]struct{}{
   "styled": {},
 }
 
-type unicornStringContent struct{}
+type unicornStringContent struct{ optionsRule }
 
 type unicornStringContentPattern struct {
   match         string

--- a/packages/lint/linthost/rules_unicorn_template_indent.go
+++ b/packages/lint/linthost/rules_unicorn_template_indent.go
@@ -35,7 +35,7 @@ var (
   unicornTemplateIndentDefaultComments  = []string{"HTML", "indent"}
 )
 
-type unicornTemplateIndent struct{}
+type unicornTemplateIndent struct{ optionsRule }
 
 type unicornTemplateIndentRawOptions struct {
   Indent    json.RawMessage `json:"indent"`

--- a/packages/lint/linthost/rules_unicorn_text_encoding_identifier_case.go
+++ b/packages/lint/linthost/rules_unicorn_text_encoding_identifier_case.go
@@ -31,7 +31,7 @@ import (
 
 const unicornTextEncodingIdentifierCaseRuleName = "unicorn/text-encoding-identifier-case"
 
-type unicornTextEncodingIdentifierCase struct{}
+type unicornTextEncodingIdentifierCase struct{ optionsRule }
 
 // unicornTextEncodingIdentifierCaseOptions decodes the single `{withDash}`
 // option slot. `withDash: true` prefers the dashed WHATWG spelling (`utf-8`)

--- a/packages/lint/linthost/rules_var.go
+++ b/packages/lint/linthost/rules_var.go
@@ -574,7 +574,7 @@ func isValueReferenceIdentifier(node *shimast.Node) bool {
 // structure, so the existing keyword edit stays limited to an initialized,
 // single-declarator list. ESLint canonical:
 // https://eslint.org/docs/latest/rules/prefer-const
-type preferConst struct{}
+type preferConst struct{ optionsRule }
 
 type preferConstOptions struct {
   Destructuring          string `json:"destructuring"`

--- a/packages/lint/rule/rule.go
+++ b/packages/lint/rule/rule.go
@@ -133,6 +133,18 @@ type TypeAwareRule interface {
   NeedsTypeChecker() bool
 }
 
+// OptionsRule is an optional marker contributors implement to declare whether
+// their rule accepts an options slot in its `[severity, options]` setting.
+// Contributor rules default to accepting options for backward compatibility
+// with the original public Context.Options contract. Return false for a
+// genuinely optionless rule so the host can reject accidental payloads before
+// linting. The domain-specific method name prevents an unrelated generic
+// AcceptsOptions method on an existing contributor from opting in by accident.
+// ProjectRule implementations may use the same marker.
+type OptionsRule interface {
+  AcceptsTtscLintOptions() bool
+}
+
 // Reporter is the engine-supplied callback that records a finding. The
 // host implements this and passes it to `NewContext` when invoking a
 // contributor rule.

--- a/packages/lint/src/structures/rules/ITtscLintContributorRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintContributorRules.ts
@@ -7,8 +7,24 @@ import type { TtscLintSeverity } from "../TtscLintSeverity";
  * Plugin authors expose rules under their own namespace prefix (`demo/no-demo`,
  * `myplugin/foo-bar`). The signature here accepts any `"<namespace>/<rule>"`
  * key with either the bare severity form, the severity tuple, or the
- * severity-plus-options tuple. Plugins ship their own typings to tighten the
- * options shape per rule.
+ * severity-plus-options tuple. Plugins tighten a known rule by augmenting
+ * `ITtscLintRuleOptionsMap`; the mapped overlay intersected into
+ * `ITtscLintRules` then supersedes this `unknown` fallback for that key. An
+ * optionless contributor augments this interface directly with
+ * `TtscLintRuleSetting` instead:
+ *
+ * ```ts
+ * import type { TtscLintRuleSetting } from "@ttsc/lint";
+ *
+ * declare module "@ttsc/lint" {
+ *   interface ITtscLintContributorRules {
+ *     "demo/no-options"?: TtscLintRuleSetting;
+ *   }
+ * }
+ * ```
+ *
+ * Contributor namespaces with no imported augmentation retain the compatible
+ * `unknown` options slot.
  *
  * @reference https://ttsc.dev/lint/development/rules
  */

--- a/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRuleOptions.ts
@@ -387,3 +387,82 @@ export interface ITtscLintCorePreferConstRuleOptions {
    */
   ignoreReadBeforeAssign?: boolean;
 }
+
+/** `default-case` rule options. */
+export interface ITtscLintCoreDefaultCaseRuleOptions {
+  /**
+   * Regular-expression string that marks an intentionally omitted default
+   * clause. It replaces the default `^no default$` pattern.
+   */
+  commentPattern?: string;
+}
+
+/** Relative order accepted by `grouped-accessor-pairs`. */
+export type TtscLintCoreGroupedAccessorPairsOrder =
+  | "anyOrder"
+  | "getBeforeSet"
+  | "setBeforeGet";
+
+/** Canonical positional setting for `grouped-accessor-pairs`. */
+export type TtscLintCoreGroupedAccessorPairsRuleSetting =
+  | TtscLintRuleSetting
+  | readonly [TtscLintSeverity, TtscLintCoreGroupedAccessorPairsOrder];
+
+/** `no-else-return` rule options. */
+export interface ITtscLintCoreNoElseReturnRuleOptions {
+  /** Allow an `else if` after a branch that always returns. @default true */
+  allowElseIf?: boolean;
+}
+
+/** `no-extend-native` rule options. */
+export interface ITtscLintCoreNoExtendNativeRuleOptions {
+  /** Native constructor names whose prototypes may be extended. @default [] */
+  exceptions?: readonly string[];
+}
+
+/** Operator spelling accepted in a `no-mixed-operators` group. */
+export type TtscLintCoreNoMixedOperatorsOperator =
+  | "+"
+  | "-"
+  | "*"
+  | "/"
+  | "%"
+  | "**"
+  | "&"
+  | "|"
+  | "^"
+  | "~"
+  | "<<"
+  | ">>"
+  | ">>>"
+  | "=="
+  | "!="
+  | "==="
+  | "!=="
+  | ">"
+  | ">="
+  | "<"
+  | "<="
+  | "&&"
+  | "||"
+  | "in"
+  | "instanceof"
+  | "??"
+  | "?:";
+
+/** `no-mixed-operators` rule options. */
+export interface ITtscLintCoreNoMixedOperatorsRuleOptions {
+  /** Operator groups within which an unparenthesized mix is checked. */
+  groups?: readonly (readonly TtscLintCoreNoMixedOperatorsOperator[])[];
+
+  /** Allow different operators with the same precedence. @default true */
+  allowSamePrecedence?: boolean;
+}
+
+/** Canonical positional mode for `no-return-assign`. */
+export type TtscLintCoreNoReturnAssignMode = "except-parens" | "always";
+
+/** Canonical positional setting for `no-return-assign`. */
+export type TtscLintCoreNoReturnAssignRuleSetting =
+  | TtscLintRuleSetting
+  | readonly [TtscLintSeverity, TtscLintCoreNoReturnAssignMode];

--- a/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintCoreRules.ts
@@ -3,17 +3,23 @@ import type {
   TtscLintRuleSetting,
 } from "../TtscLintRuleSetting";
 import type {
+  ITtscLintCoreDefaultCaseRuleOptions,
   ITtscLintCoreNoDuplicateImportsRuleOptions,
+  ITtscLintCoreNoElseReturnRuleOptions,
   ITtscLintCoreNoEmptyFunctionRuleOptions,
   ITtscLintCoreNoEmptyRuleOptions,
+  ITtscLintCoreNoExtendNativeRuleOptions,
+  ITtscLintCoreNoMixedOperatorsRuleOptions,
   ITtscLintCoreNoParamReassignRuleOptions,
   ITtscLintCoreNoPromiseExecutorReturnRuleOptions,
   ITtscLintCoreNoUnusedExpressionsRuleOptions,
   ITtscLintCorePreferConstRuleOptions,
   ITtscLintNoFallthroughRuleOptions,
+  TtscLintCoreGroupedAccessorPairsRuleSetting,
   TtscLintCoreNoInnerDeclarationsRuleSetting,
   TtscLintCoreNoRestrictedImportsRuleSetting,
   TtscLintCoreNoRestrictedSyntaxRuleSetting,
+  TtscLintCoreNoReturnAssignRuleSetting,
 } from "./ITtscLintCoreRuleOptions";
 
 /**
@@ -53,7 +59,7 @@ export interface ITtscLintCoreRules {
    *
    * @reference https://eslint.org/docs/latest/rules/default-case
    */
-  "default-case"?: TtscLintRuleSetting;
+  "default-case"?: TtscLintRuleOptionsSetting<ITtscLintCoreDefaultCaseRuleOptions>;
 
   /**
    * Require the `default` clause of a `switch` statement to appear after every
@@ -151,7 +157,7 @@ export interface ITtscLintCoreRules {
    *
    * @reference https://eslint.org/docs/latest/rules/grouped-accessor-pairs
    */
-  "grouped-accessor-pairs"?: TtscLintRuleSetting;
+  "grouped-accessor-pairs"?: TtscLintCoreGroupedAccessorPairsRuleSetting;
 
   /**
    * Require the body of every `for (key in obj)` loop to begin with a guard
@@ -317,8 +323,8 @@ export interface ITtscLintCoreRules {
   "no-case-declarations"?: TtscLintRuleSetting;
 
   /**
-   * Reject every write to a binding introduced by a class declaration or
-   * named class expression.
+   * Reject every write to a binding introduced by a class declaration or named
+   * class expression.
    *
    * Binding identity is resolved lexically, so same-spelled parameter, catch,
    * block, and sibling bindings remain independent. Direct and compound
@@ -478,13 +484,12 @@ export interface ITtscLintCoreRules {
   "no-duplicate-imports"?: TtscLintRuleOptionsSetting<ITtscLintCoreNoDuplicateImportsRuleOptions>;
 
   /**
-   * Reject an `else` block whose preceding `if` branch already terminates
-   * control flow with `return`, `throw`, `break`, or `continue` — flatten the
-   * body into the surrounding scope.
+   * Reject an `else` block whose preceding `if` branch returns on every path;
+   * flatten the body into the surrounding scope.
    *
    * @reference https://eslint.org/docs/latest/rules/no-else-return
    */
-  "no-else-return"?: TtscLintRuleSetting;
+  "no-else-return"?: TtscLintRuleOptionsSetting<ITtscLintCoreNoElseReturnRuleOptions>;
 
   /**
    * Reject empty, uncommented blocks and switches. Set `allowEmptyCatch` to
@@ -572,13 +577,13 @@ export interface ITtscLintCoreRules {
   "no-ex-assign"?: TtscLintRuleSetting;
 
   /**
-   * Reject assignments to a built-in prototype such as `Array.prototype.foo =
-   * bar`. Only `<Builtin>.prototype.<key> = …` is flagged; assigning to
-   * `Object.foo = …` (a static property) is left alone.
+   * Reject extending a built-in prototype through direct assignment or
+   * `Object.defineProperty` / `Object.defineProperties`. Assigning to a static
+   * property such as `Object.foo` is left alone.
    *
    * @reference https://eslint.org/docs/latest/rules/no-extend-native
    */
-  "no-extend-native"?: TtscLintRuleSetting;
+  "no-extend-native"?: TtscLintRuleOptionsSetting<ITtscLintCoreNoExtendNativeRuleOptions>;
 
   /**
    * Reject `.bind(thisArg)` on an arrow function or on a regular function whose
@@ -751,14 +756,14 @@ export interface ITtscLintCoreRules {
    * The famous case is `a && b || c`: readers expect left-to-right grouping but
    * the parser sees `(a && b) || c` because `&&` binds tighter than `||`.
    *
-   * The conservative baseline only flags the highest-confusion mixes — logical
-   * mixed with a different logical (`&&` next to `||` / `??`), and bitwise
-   * (`&`, `|`, `^`) next to a comparison or logical. Wrapping the inner
-   * sub-expression in parens suppresses the report.
+   * The default groups cover arithmetic, bitwise, comparison, logical, and
+   * relational operators, matching ESLint. A custom `groups` option replaces
+   * that grouping, while `allowSamePrecedence` controls equal-precedence mixes.
+   * Wrapping the inner sub-expression in parens suppresses the report.
    *
    * @reference https://eslint.org/docs/latest/rules/no-mixed-operators
    */
-  "no-mixed-operators"?: TtscLintRuleSetting;
+  "no-mixed-operators"?: TtscLintRuleOptionsSetting<ITtscLintCoreNoMixedOperatorsRuleOptions>;
 
   /**
    * Reject chained assignment such as `a = b = 0`, which obscures intent and
@@ -866,8 +871,8 @@ export interface ITtscLintCoreRules {
   /**
    * Reject writes to a function parameter's binding, including through nested
    * closures and destructuring assignment targets. `props: true` also reports
-   * property writes, with the official exact-name and regular-expression
-   * ignore lists.
+   * property writes, with the official exact-name and regular-expression ignore
+   * lists.
    *
    * @reference https://eslint.org/docs/latest/rules/no-param-reassign
    */
@@ -885,9 +890,8 @@ export interface ITtscLintCoreRules {
 
   /**
    * Reject values returned by the global Promise constructor's executor. This
-   * covers concise arrows and explicit returns without crossing nested
-   * function boundaries. Set `allowVoid` to accept an explicit unary `void`
-   * return.
+   * covers concise arrows and explicit returns without crossing nested function
+   * boundaries. Set `allowVoid` to accept an explicit unary `void` return.
    *
    * @reference https://eslint.org/docs/latest/rules/no-promise-executor-return
    */
@@ -955,7 +959,7 @@ export interface ITtscLintCoreRules {
    *
    * @reference https://eslint.org/docs/latest/rules/no-return-assign
    */
-  "no-return-assign"?: TtscLintRuleSetting;
+  "no-return-assign"?: TtscLintCoreNoReturnAssignRuleSetting;
 
   /**
    * Reject `javascript:` URLs in string literals — they execute their body as

--- a/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
+++ b/packages/lint/src/structures/rules/ITtscLintRuleOptionsMap.ts
@@ -1,3 +1,4 @@
+import type { TtscLintRuleOptionsSetting } from "../TtscLintRuleSetting";
 import type {
   ITtscLintBoundariesDependenciesRuleOptions,
   ITtscLintBoundariesElementTypesRuleOptions,
@@ -7,9 +8,13 @@ import type {
   ITtscLintBoundariesNoUnknownRuleOptions,
 } from "./ITtscLintBoundariesRuleOptions";
 import type {
+  ITtscLintCoreDefaultCaseRuleOptions,
   ITtscLintCoreNoDuplicateImportsRuleOptions,
+  ITtscLintCoreNoElseReturnRuleOptions,
   ITtscLintCoreNoEmptyFunctionRuleOptions,
   ITtscLintCoreNoEmptyRuleOptions,
+  ITtscLintCoreNoExtendNativeRuleOptions,
+  ITtscLintCoreNoMixedOperatorsRuleOptions,
   ITtscLintCoreNoParamReassignRuleOptions,
   ITtscLintCoreNoPromiseExecutorReturnRuleOptions,
   ITtscLintCoreNoUnusedExpressionsRuleOptions,
@@ -50,10 +55,13 @@ import type {
   ITtscLintUnicornFilenameCaseRuleOptions,
   ITtscLintUnicornImportStyleRuleOptions,
   ITtscLintUnicornIsolatedFunctionsRuleOptions,
+  ITtscLintUnicornNoTypeofUndefinedRuleOptions,
   ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions,
+  ITtscLintUnicornPreferNumberPropertiesRuleOptions,
   ITtscLintUnicornPreventAbbreviationsRuleOptions,
   ITtscLintUnicornStringContentRuleOptions,
   ITtscLintUnicornTemplateIndentRuleOptions,
+  ITtscLintUnicornTextEncodingIdentifierCaseRuleOptions,
 } from "./ITtscLintUnicornRuleOptions";
 
 /**
@@ -66,25 +74,31 @@ import type {
  * ```ts
  * declare module "@ttsc/lint" {
  *   interface ITtscLintRuleOptionsMap {
- *     "demo/no-marker-comment": { marker: string };
+ *     "demo/no-marker-comment": { markers?: readonly string[] };
  *   }
  * }
  * ```
  *
- * After augmentation, `{@link TtscLintRuleOptionsSetting}` tuples and the
- * `defineConfig`-style helpers in plugin packages can type-check the options
- * object against the contributor's declared shape.
+ * {@link TtscLintRuleOptionsOverlay} maps every entry to its strongly typed
+ * severity tuple. {@link ITtscLintRules} intersects that overlay with the
+ * built-in families and the open contributor fallback, so importing a plugin's
+ * augmentation tightens its registered rule while unknown contributor names
+ * retain the backward-compatible `unknown` options slot.
  *
  * `format/*` is **not** listed: formatter behavior is configured through the
  * top-level `format` block ({@link ITtscLintFormat}), not through the `rules`
  * surface.
  */
 export interface ITtscLintRuleOptionsMap {
+  "default-case": ITtscLintCoreDefaultCaseRuleOptions;
   "unicorn/template-indent": ITtscLintUnicornTemplateIndentRuleOptions;
   "typescript/no-floating-promises": ITtscLintTypeScriptNoFloatingPromisesRuleOptions;
   "no-duplicate-imports": ITtscLintCoreNoDuplicateImportsRuleOptions;
+  "no-else-return": ITtscLintCoreNoElseReturnRuleOptions;
   "no-empty": ITtscLintCoreNoEmptyRuleOptions;
   "no-empty-function": ITtscLintCoreNoEmptyFunctionRuleOptions;
+  "no-extend-native": ITtscLintCoreNoExtendNativeRuleOptions;
+  "no-mixed-operators": ITtscLintCoreNoMixedOperatorsRuleOptions;
   "no-param-reassign": ITtscLintCoreNoParamReassignRuleOptions;
   "no-promise-executor-return": ITtscLintCoreNoPromiseExecutorReturnRuleOptions;
   "no-unused-expressions": ITtscLintCoreNoUnusedExpressionsRuleOptions;
@@ -135,5 +149,21 @@ export interface ITtscLintRuleOptionsMap {
   "unicorn/filename-case": ITtscLintUnicornFilenameCaseRuleOptions;
   "unicorn/string-content": ITtscLintUnicornStringContentRuleOptions;
   "unicorn/isolated-functions": ITtscLintUnicornIsolatedFunctionsRuleOptions;
+  "unicorn/no-typeof-undefined": ITtscLintUnicornNoTypeofUndefinedRuleOptions;
   "unicorn/no-unnecessary-polyfills": ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions;
+  "unicorn/prefer-number-properties": ITtscLintUnicornPreferNumberPropertiesRuleOptions;
+  "unicorn/text-encoding-identifier-case": ITtscLintUnicornTextEncodingIdentifierCaseRuleOptions;
 }
+
+/**
+ * Strongly typed rule settings derived from the augmentable options map.
+ *
+ * This mapped overlay is consumed by {@link ITtscLintRules}; keeping the
+ * derivation here makes module augmentation immediately affect the public
+ * configuration type without a second per-plugin rule-name declaration.
+ */
+export type TtscLintRuleOptionsOverlay = {
+  [TRuleName in keyof ITtscLintRuleOptionsMap]?: TtscLintRuleOptionsSetting<
+    ITtscLintRuleOptionsMap[TRuleName]
+  >;
+};

--- a/packages/lint/src/structures/rules/ITtscLintRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintRules.ts
@@ -12,6 +12,7 @@ import type { ITtscLintPromiseRules } from "./ITtscLintPromiseRules";
 import type { ITtscLintReactPerfRules } from "./ITtscLintReactPerfRules";
 import type { ITtscLintReactRules } from "./ITtscLintReactRules";
 import type { ITtscLintRegexpRules } from "./ITtscLintRegexpRules";
+import type { TtscLintRuleOptionsOverlay } from "./ITtscLintRuleOptionsMap";
 import type { ITtscLintSecurityRules } from "./ITtscLintSecurityRules";
 import type { ITtscLintSolidRules } from "./ITtscLintSolidRules";
 import type { ITtscLintStorybookRules } from "./ITtscLintStorybookRules";
@@ -51,7 +52,10 @@ import type { ITtscLintVitestRules } from "./ITtscLintVitestRules";
  *   public rules surface.
  * - Any other `"<namespace>/<rule>"` key is accepted via
  *   {@link ITtscLintContributorRules} so plugin-shipped rules compose cleanly
- *   without ambient module augmentation.
+ *   without ambient module augmentation. A plugin can augment
+ *   `ITtscLintRuleOptionsMap`; {@link TtscLintRuleOptionsOverlay} then tightens
+ *   that rule's options while the open fallback remains for unregistered
+ *   contributor names.
  */
 export type ITtscLintRules = ITtscLintCoreRules &
   ITtscLintTypeScriptRules &
@@ -74,4 +78,5 @@ export type ITtscLintRules = ITtscLintCoreRules &
   ITtscLintTestingLibraryRules &
   ITtscLintUnicornRules &
   ITtscLintVitestRules &
-  ITtscLintContributorRules;
+  ITtscLintContributorRules &
+  TtscLintRuleOptionsOverlay;

--- a/packages/lint/src/structures/rules/ITtscLintUnicornRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintUnicornRuleOptions.ts
@@ -327,3 +327,24 @@ export interface ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions {
   /** Browserslist query, array of queries, or a core-js-compat targets object. */
   targets: TtscLintUnicornNoUnnecessaryPolyfillsTargets;
 }
+
+/** Options for `unicorn/no-typeof-undefined`. */
+export interface ITtscLintUnicornNoTypeofUndefinedRuleOptions {
+  /** Also report undeclared global identifiers. @default false */
+  checkGlobalVariables?: boolean;
+}
+
+/** Options for `unicorn/prefer-number-properties`. */
+export interface ITtscLintUnicornPreferNumberPropertiesRuleOptions {
+  /** Also replace the global `Infinity` binding. @default false */
+  checkInfinity?: boolean;
+
+  /** Also replace the global `NaN` binding. @default false */
+  checkNaN?: boolean;
+}
+
+/** Options for `unicorn/text-encoding-identifier-case`. */
+export interface ITtscLintUnicornTextEncodingIdentifierCaseRuleOptions {
+  /** Prefer `utf-8` instead of `utf8` outside dash-required APIs. @default false */
+  withDash?: boolean;
+}

--- a/packages/lint/src/structures/rules/ITtscLintUnicornRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintUnicornRules.ts
@@ -8,10 +8,13 @@ import type {
   ITtscLintUnicornFilenameCaseRuleOptions,
   ITtscLintUnicornImportStyleRuleOptions,
   ITtscLintUnicornIsolatedFunctionsRuleOptions,
+  ITtscLintUnicornNoTypeofUndefinedRuleOptions,
   ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions,
+  ITtscLintUnicornPreferNumberPropertiesRuleOptions,
   ITtscLintUnicornPreventAbbreviationsRuleOptions,
   ITtscLintUnicornStringContentRuleOptions,
   ITtscLintUnicornTemplateIndentRuleOptions,
+  ITtscLintUnicornTextEncodingIdentifierCaseRuleOptions,
 } from "./ITtscLintUnicornRuleOptions";
 
 /**
@@ -460,7 +463,7 @@ export interface ITtscLintUnicornRules {
    *
    * @reference https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-typeof-undefined.md
    */
-  "unicorn/no-typeof-undefined"?: TtscLintRuleSetting;
+  "unicorn/no-typeof-undefined"?: TtscLintRuleOptionsSetting<ITtscLintUnicornNoTypeofUndefinedRuleOptions>;
 
   /**
    * Reject `1` as the explicit depth argument of `Array#flat`; the default is
@@ -885,7 +888,7 @@ export interface ITtscLintUnicornRules {
    *
    * @reference https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-number-properties.md
    */
-  "unicorn/prefer-number-properties"?: TtscLintRuleSetting;
+  "unicorn/prefer-number-properties"?: TtscLintRuleOptionsSetting<ITtscLintUnicornPreferNumberPropertiesRuleOptions>;
 
   /**
    * Prefer `Object.fromEntries` over `reduce`-into-object patterns.
@@ -1147,12 +1150,13 @@ export interface ITtscLintUnicornRules {
   "unicorn/template-indent"?: TtscLintRuleOptionsSetting<ITtscLintUnicornTemplateIndentRuleOptions>;
 
   /**
-   * Enforce a canonical case for text-encoding identifiers — `"utf-8"` (not
-   * `"UTF-8"` / `"utf8"`).
+   * Enforce canonical text-encoding identifiers: dash-less `"utf8"` by default,
+   * dashed `"utf-8"` for APIs that require it or when `withDash` is enabled,
+   * and lowercase `"ascii"`.
    *
    * @reference https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/text-encoding-identifier-case.md
    */
-  "unicorn/text-encoding-identifier-case"?: TtscLintRuleSetting;
+  "unicorn/text-encoding-identifier-case"?: TtscLintRuleOptionsSetting<ITtscLintUnicornTextEncodingIdentifierCaseRuleOptions>;
 
   /**
    * Require `throw new Error(...)` over `throw Error(...)`.

--- a/packages/lint/test/config/format_block_targets_option_accepting_rules_test.go
+++ b/packages/lint/test/config/format_block_targets_option_accepting_rules_test.go
@@ -1,0 +1,50 @@
+package linthost
+
+import (
+  "testing"
+)
+
+// TestFormatBlockTargetsOptionAcceptingRules verifies every formatter payload
+// produced by the public format block lands on a structurally option-accepting
+// rule, and every registered formatter is represented.
+//
+// Format settings are expanded into ordinary rule tuples before engine
+// construction. This includes an empty object for rules that need no fields,
+// so inferring acceptance only from DecodeOptions calls would reject a valid
+// default format run. Deriving both sets from the live expansion and registry
+// keeps the boundary free of a second formatter-name list.
+//
+//  1. Expand a format block with the opt-in sort rule enabled.
+//  2. Parse its generated option payloads and compare them with registered
+//     format rules.
+//  3. Assert every generated target reports AcceptsTtscLintOptions.
+func TestFormatBlockTargetsOptionAcceptingRules(t *testing.T) {
+  expanded, err := expandFormatBlock(map[string]any{"sortImports": true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  _, options, err := ParseRulesWithOptions(expanded)
+  if err != nil {
+    t.Fatal(err)
+  }
+
+  registeredFormat := map[string]struct{}{}
+  for _, name := range AllRuleNames() {
+    if isRegisteredBuiltInFormatRule(name, LookupRule(name)) {
+      registeredFormat[name] = struct{}{}
+    }
+  }
+  generated := make(map[string]struct{}, len(options))
+  for name := range options {
+    generated[name] = struct{}{}
+    rule := LookupRule(name)
+    if rule == nil {
+      t.Errorf("format block generated payload for unregistered rule %q", name)
+      continue
+    }
+    if !ruleAcceptsOptions(rule) {
+      t.Errorf("format block generated payload for optionless rule %q", name)
+    }
+  }
+  assertSameRuleNameSet(t, "registered format rules", registeredFormat, "generated format payloads", generated)
+}

--- a/packages/lint/test/engine/engine_accepts_null_tuple_slot_as_absent_options_test.go
+++ b/packages/lint/test/engine/engine_accepts_null_tuple_slot_as_absent_options_test.go
@@ -1,0 +1,29 @@
+package linthost
+
+import "testing"
+
+// TestEngineAcceptsNullTupleSlotAsAbsentOptions verifies the parser's null-slot
+// compatibility boundary reaches the runtime options gate unchanged.
+//
+// A two-slot `[severity, null]` setting is intentionally normalized to no
+// options, matching existing config behavior. It must not be mistaken for a
+// real payload and rejected on an optionless rule.
+//
+//  1. Parse `no-var: ["error", null]` through the standard rules parser.
+//  2. Bind the parsed maps into an inline resolver.
+//  3. Assert the optionless rule remains valid and enabled.
+func TestEngineAcceptsNullTupleSlotAsAbsentOptions(t *testing.T) {
+  rules, options, err := ParseRulesWithOptions(map[string]any{
+    "no-var": []any{"error", nil},
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  engine := NewEngineWithResolver(InlineRuleResolver{Rules: rules, Options: options})
+  if err := engine.ConfigError(); err != nil {
+    t.Fatalf("null tuple slot was treated as an options payload: %v", err)
+  }
+  if engine.EnabledRules()["no-var"] != SeverityError {
+    t.Fatalf("no-var was not enabled after null-slot normalization: %v", engine.EnabledRules())
+  }
+}

--- a/packages/lint/test/engine/engine_accepts_payload_for_option_rule_test.go
+++ b/packages/lint/test/engine/engine_accepts_payload_for_option_rule_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+)
+
+// TestEngineAcceptsPayloadForOptionRule verifies a rule with the structural
+// options capability retains its existing DecodeOptions path.
+//
+// `no-else-return` has no ValidateOptions method, so it is the important
+// negative twin to optionless rejection: acceptance comes from the uniform
+// marker rather than the older, incomplete validator interface.
+//
+//  1. Configure `no-else-return` with its valid object option.
+//  2. Construct the engine.
+//  3. Assert no configuration error and an enabled dispatch entry.
+func TestEngineAcceptsPayloadForOptionRule(t *testing.T) {
+  engine := NewEngineWithResolver(InlineRuleResolver{
+    Rules: RuleConfig{"no-else-return": SeverityError},
+    Options: RuleOptionsMap{
+      "no-else-return": json.RawMessage(`{"allowElseIf":false}`),
+    },
+  })
+  if err := engine.ConfigError(); err != nil {
+    t.Fatalf("marked option rule rejected valid payload: %v", err)
+  }
+  if engine.EnabledRules()["no-else-return"] != SeverityError {
+    t.Fatalf("marked option rule was not enabled: %v", engine.EnabledRules())
+  }
+}

--- a/packages/lint/test/engine/engine_accepts_severity_only_optionless_rule_test.go
+++ b/packages/lint/test/engine/engine_accepts_severity_only_optionless_rule_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestEngineAcceptsSeverityOnlyOptionlessRule verifies the new options gate
+// leaves the ordinary severity-only setting unchanged.
+//
+// Absence of an options slot is represented by a nil RawMessage. Optionless
+// rules remain valid and enabled in that state; only a present payload is an
+// error.
+//
+//  1. Enable `no-var` with a bare severity.
+//  2. Construct the engine.
+//  3. Assert no configuration error and an enabled dispatch entry.
+func TestEngineAcceptsSeverityOnlyOptionlessRule(t *testing.T) {
+  engine := NewEngine(RuleConfig{"no-var": SeverityError})
+  if err := engine.ConfigError(); err != nil {
+    t.Fatalf("severity-only optionless rule was rejected: %v", err)
+  }
+  if engine.EnabledRules()["no-var"] != SeverityError {
+    t.Fatalf("severity-only no-var was not enabled: %v", engine.EnabledRules())
+  }
+}

--- a/packages/lint/test/engine/engine_rejects_optionless_payload_while_rule_is_off_test.go
+++ b/packages/lint/test/engine/engine_rejects_optionless_payload_while_rule_is_off_test.go
@@ -1,0 +1,32 @@
+package linthost
+
+import (
+  "encoding/json"
+  "strings"
+  "testing"
+)
+
+// TestEngineRejectsOptionlessPayloadWhileRuleIsOff verifies configuration
+// validation covers declared payloads independently of dispatch severity.
+//
+// An off rule never enters ActiveRuleNames, but its tuple still belongs to the
+// user's configuration and may contain a typo that becomes active through a
+// later override. Validation walks registered rules, not only enabled rules,
+// so the inert severity cannot hide an invalid options slot.
+//
+//  1. Configure optionless `no-var` as off with an object payload.
+//  2. Construct the engine.
+//  3. Assert the payload is rejected and the rule remains disabled.
+func TestEngineRejectsOptionlessPayloadWhileRuleIsOff(t *testing.T) {
+  engine := NewEngineWithResolver(InlineRuleResolver{
+    Rules:   RuleConfig{"no-var": SeverityOff},
+    Options: RuleOptionsMap{"no-var": json.RawMessage(`{"typo":true}`)},
+  })
+  err := engine.ConfigError()
+  if err == nil || !strings.Contains(err.Error(), `invalid options for rule "no-var": rule does not accept options`) {
+    t.Fatalf("off optionless payload was not rejected: %v", err)
+  }
+  if _, enabled := engine.EnabledRules()["no-var"]; enabled {
+    t.Fatalf("off no-var unexpectedly entered dispatch: %v", engine.EnabledRules())
+  }
+}

--- a/packages/lint/test/engine/engine_rejects_payload_shapes_for_optionless_rule_test.go
+++ b/packages/lint/test/engine/engine_rejects_payload_shapes_for_optionless_rule_test.go
@@ -1,0 +1,41 @@
+package linthost
+
+import (
+  "encoding/json"
+  "strings"
+  "testing"
+)
+
+// TestEngineRejectsPayloadShapesForOptionlessRule verifies any real options
+// slot is rejected when the registered rule has no
+// AcceptsTtscLintOptions capability.
+//
+// The payload transport preserves a single scalar or object and wraps multiple
+// positional slots in an array. The contract is shape-independent: an empty
+// object or array is still a user-supplied slot and must not be silently
+// ignored by an optionless rule.
+//
+//  1. Configure `no-var` with object, scalar, empty-array, and multi-slot blobs.
+//  2. Construct an engine for each payload.
+//  3. Assert a configuration error and no dispatch-table entry.
+func TestEngineRejectsPayloadShapesForOptionlessRule(t *testing.T) {
+  payloads := []json.RawMessage{
+    json.RawMessage(`{}`),
+    json.RawMessage(`"always"`),
+    json.RawMessage(`[]`),
+    json.RawMessage(`["always",{"typo":true}]`),
+  }
+  for _, payload := range payloads {
+    engine := NewEngineWithResolver(InlineRuleResolver{
+      Rules:   RuleConfig{"no-var": SeverityError},
+      Options: RuleOptionsMap{"no-var": payload},
+    })
+    err := engine.ConfigError()
+    if err == nil || !strings.Contains(err.Error(), `invalid options for rule "no-var": rule does not accept options`) {
+      t.Errorf("payload %s was not rejected as optionless: %v", payload, err)
+    }
+    if _, enabled := engine.EnabledRules()["no-var"]; enabled {
+      t.Errorf("payload %s left optionless no-var enabled", payload)
+    }
+  }
+}

--- a/packages/lint/test/plugin/contributor_bootstrap_is_single_owner_for_reusable_main_test.go
+++ b/packages/lint/test/plugin/contributor_bootstrap_is_single_owner_for_reusable_main_test.go
@@ -18,6 +18,7 @@ type bootstrapFileRuleCounts struct {
   visits                atomic.Int32
   isFormat              atomic.Int32
   visitsDeclarationFile atomic.Int32
+  acceptsOptions        atomic.Int32
 }
 
 type bootstrapCountingFileRule struct {
@@ -34,6 +35,10 @@ func (r *bootstrapCountingFileRule) Visits() []shimast.Kind {
   return []shimast.Kind{shimast.KindSourceFile}
 }
 func (*bootstrapCountingFileRule) Check(*publicrule.Context, *shimast.Node) {}
+func (r *bootstrapCountingFileRule) AcceptsTtscLintOptions() bool {
+  r.counts.acceptsOptions.Add(1)
+  return true
+}
 
 type bootstrapPanickingFileRule struct {
   method string
@@ -69,9 +74,17 @@ func (r *bootstrapPanickingFileRule) VisitsDeclarationFiles() bool {
   }
   return true
 }
+func (r *bootstrapPanickingFileRule) AcceptsTtscLintOptions() bool {
+  r.counts.acceptsOptions.Add(1)
+  if r.method == "AcceptsTtscLintOptions" {
+    panic("bootstrap AcceptsTtscLintOptions boom")
+  }
+  return true
+}
 
 type bootstrapProjectRuleCounts struct {
-  name atomic.Int32
+  name           atomic.Int32
+  acceptsOptions atomic.Int32
 }
 
 type bootstrapCountingProjectRule struct {
@@ -84,16 +97,31 @@ func (r *bootstrapCountingProjectRule) Name() string {
   return r.name
 }
 func (*bootstrapCountingProjectRule) Check(*publicrule.ProjectContext) {}
+func (r *bootstrapCountingProjectRule) AcceptsTtscLintOptions() bool {
+  r.counts.acceptsOptions.Add(1)
+  return true
+}
 
 type bootstrapPanickingProjectRule struct {
+  method string
   counts bootstrapProjectRuleCounts
 }
 
 func (r *bootstrapPanickingProjectRule) Name() string {
   r.counts.name.Add(1)
-  panic("bootstrap project Name boom")
+  if r.method == "Name" {
+    panic("bootstrap project Name boom")
+  }
+  return "test/bootstrap-project-metadata-panic-" + strings.ToLower(r.method)
 }
 func (*bootstrapPanickingProjectRule) Check(*publicrule.ProjectContext) {}
+func (r *bootstrapPanickingProjectRule) AcceptsTtscLintOptions() bool {
+  r.counts.acceptsOptions.Add(1)
+  if r.method == "AcceptsTtscLintOptions" {
+    panic("bootstrap project AcceptsTtscLintOptions boom")
+  }
+  return true
+}
 
 var bootstrapFileRules = []*bootstrapCountingFileRule{
   {name: "test/bootstrap-file-file"},
@@ -106,6 +134,7 @@ var bootstrapPanickingFileRules = []*bootstrapPanickingFileRule{
   {method: "Visits"},
   {method: "IsFormat"},
   {method: "VisitsDeclarationFiles"},
+  {method: "AcceptsTtscLintOptions"},
 }
 
 var bootstrapProjectRules = []*bootstrapCountingProjectRule{
@@ -114,7 +143,10 @@ var bootstrapProjectRules = []*bootstrapCountingProjectRule{
   {name: "test/bootstrap-file-project"},
 }
 
-var bootstrapPanickingProjectRuleInstance = &bootstrapPanickingProjectRule{}
+var bootstrapPanickingProjectRules = []*bootstrapPanickingProjectRule{
+  {method: "Name"},
+  {method: "AcceptsTtscLintOptions"},
+}
 
 func init() {
   for _, fileRule := range bootstrapFileRules {
@@ -126,7 +158,9 @@ func init() {
   for _, projectRule := range bootstrapProjectRules {
     publicrule.RegisterProject(projectRule)
   }
-  publicrule.RegisterProject(bootstrapPanickingProjectRuleInstance)
+  for _, projectRule := range bootstrapPanickingProjectRules {
+    publicrule.RegisterProject(projectRule)
+  }
 }
 
 // TestMain exercises the only fresh-process bootstrap before ordinary tests
@@ -179,8 +213,10 @@ func verifyInitialContributorBootstrap() error {
     "metadata panicked: bootstrap Visits boom; dropping contributor entry",
     "metadata panicked: bootstrap IsFormat boom; dropping contributor entry",
     "metadata panicked: bootstrap VisitsDeclarationFiles boom; dropping contributor entry",
+    "metadata panicked: bootstrap AcceptsTtscLintOptions boom; dropping contributor entry",
     `contributor rule "test/bootstrap-file-file" collides with an existing rule; dropping contributor entry`,
     "metadata panicked: bootstrap project Name boom; dropping project contributor entry",
+    "metadata panicked: bootstrap project AcceptsTtscLintOptions boom; dropping project contributor entry",
     `contributor project rule "test/bootstrap-file-project" collides with a file rule; dropping project contributor entry`,
     `contributor project rule "test/bootstrap-project-project" collides with an existing project rule; dropping contributor entry`,
   }
@@ -215,8 +251,8 @@ func verifyInitialContributorBootstrap() error {
 
 func verifyContributorMetadataCounts() error {
   for index, fileRule := range bootstrapFileRules {
-    if names, visits := fileRule.counts.name.Load(), fileRule.counts.visits.Load(); names != 1 || visits != 1 {
-      return fmt.Errorf("file contributor %d metadata calls: Name=%d Visits=%d, want 1 each", index, names, visits)
+    if names, visits, options := fileRule.counts.name.Load(), fileRule.counts.visits.Load(), fileRule.counts.acceptsOptions.Load(); names != 1 || visits != 1 || options != 1 {
+      return fmt.Errorf("file contributor %d metadata calls: Name=%d Visits=%d AcceptsTtscLintOptions=%d, want 1 each", index, names, visits, options)
     }
   }
   expectedPanics := []struct {
@@ -224,11 +260,13 @@ func verifyContributorMetadataCounts() error {
     visits                int32
     isFormat              int32
     visitsDeclarationFile int32
+    acceptsOptions        int32
   }{
     {name: 1},
     {name: 1, visits: 1},
     {name: 1, visits: 1, isFormat: 1},
     {name: 1, visits: 1, isFormat: 1, visitsDeclarationFile: 1},
+    {name: 1, visits: 1, isFormat: 1, visitsDeclarationFile: 1, acceptsOptions: 1},
   }
   for index, fileRule := range bootstrapPanickingFileRules {
     expected := expectedPanics[index]
@@ -236,28 +274,49 @@ func verifyContributorMetadataCounts() error {
     if actual.name.Load() != expected.name ||
       actual.visits.Load() != expected.visits ||
       actual.isFormat.Load() != expected.isFormat ||
-      actual.visitsDeclarationFile.Load() != expected.visitsDeclarationFile {
+      actual.visitsDeclarationFile.Load() != expected.visitsDeclarationFile ||
+      actual.acceptsOptions.Load() != expected.acceptsOptions {
       return fmt.Errorf(
-        "panicking file contributor %d metadata calls = (%d,%d,%d,%d), want (%d,%d,%d,%d)",
+        "panicking file contributor %d metadata calls = (%d,%d,%d,%d,%d), want (%d,%d,%d,%d,%d)",
         index,
         actual.name.Load(),
         actual.visits.Load(),
         actual.isFormat.Load(),
         actual.visitsDeclarationFile.Load(),
+        actual.acceptsOptions.Load(),
         expected.name,
         expected.visits,
         expected.isFormat,
         expected.visitsDeclarationFile,
+        expected.acceptsOptions,
       )
     }
   }
   for index, projectRule := range bootstrapProjectRules {
-    if names := projectRule.counts.name.Load(); names != 1 {
-      return fmt.Errorf("project contributor %d Name calls = %d, want 1", index, names)
+    if names, options := projectRule.counts.name.Load(), projectRule.counts.acceptsOptions.Load(); names != 1 || options != 1 {
+      return fmt.Errorf("project contributor %d metadata calls: Name=%d AcceptsTtscLintOptions=%d, want 1 each", index, names, options)
     }
   }
-  if names := bootstrapPanickingProjectRuleInstance.counts.name.Load(); names != 1 {
-    return fmt.Errorf("panicking project contributor Name calls = %d, want 1", names)
+  expectedProjectPanics := []struct {
+    name           int32
+    acceptsOptions int32
+  }{
+    {name: 1},
+    {name: 1, acceptsOptions: 1},
+  }
+  for index, projectRule := range bootstrapPanickingProjectRules {
+    expected := expectedProjectPanics[index]
+    if projectRule.counts.name.Load() != expected.name ||
+      projectRule.counts.acceptsOptions.Load() != expected.acceptsOptions {
+      return fmt.Errorf(
+        "panicking project contributor %d metadata calls = (%d,%d), want (%d,%d)",
+        index,
+        projectRule.counts.name.Load(),
+        projectRule.counts.acceptsOptions.Load(),
+        expected.name,
+        expected.acceptsOptions,
+      )
+    }
   }
   return nil
 }

--- a/packages/lint/test/plugin/contributor_generic_accepts_options_method_keeps_legacy_payload_test.go
+++ b/packages/lint/test/plugin/contributor_generic_accepts_options_method_keeps_legacy_payload_test.go
@@ -1,0 +1,76 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestContributorGenericAcceptsOptionsMethodKeepsLegacyPayload verifies the
+// public options capability does not structurally capture an unrelated method.
+//
+// Go interfaces are structural, and contributor packages could already have
+// defined the generic AcceptsOptions method for their own API. Only the
+// domain-specific OptionsRule method may opt a contributor out of the legacy
+// permissive default, or an existing false result would reject configurations
+// that previously reached Context.Options.
+//
+//  1. Adapt a legacy file contributor with only AcceptsOptions returning false.
+//  2. Configure and dispatch it with an object payload.
+//  3. Assert its generic method is ignored and Check decodes the payload.
+func TestContributorGenericAcceptsOptionsMethodKeepsLegacyPayload(t *testing.T) {
+  contributor := &legacyGenericOptionsFileContributor{}
+  metadata, err := inspectContributor(contributor)
+  if err != nil {
+    t.Fatal(err)
+  }
+  registered.rules[metadata.name] = newContributorAdapter(metadata)
+  t.Cleanup(func() { delete(registered.rules, metadata.name) })
+
+  engine := NewEngineWithResolver(InlineRuleResolver{
+    Rules: RuleConfig{metadata.name: SeverityError},
+    Options: RuleOptionsMap{
+      metadata.name: json.RawMessage(`{"mode":"strict"}`),
+    },
+  })
+  if err := engine.ConfigError(); err != nil {
+    t.Fatalf("legacy generic method rejected contributor options: %v", err)
+  }
+  engine.Run([]*shimast.SourceFile{parseTS(t, "const value = 1;\n")}, nil)
+
+  if contributor.genericMethodCalls != 0 {
+    t.Fatalf("legacy AcceptsOptions method was treated as a host capability: calls=%d", contributor.genericMethodCalls)
+  }
+  if contributor.checkCalls != 1 || contributor.observedMode != "strict" {
+    t.Fatalf("legacy contributor dispatch = calls %d mode %q, want 1 and strict", contributor.checkCalls, contributor.observedMode)
+  }
+}
+
+type legacyGenericOptionsFileContributor struct {
+  genericMethodCalls int
+  checkCalls         int
+  observedMode       string
+}
+
+func (*legacyGenericOptionsFileContributor) Name() string {
+  return "compat-test/generic-accepts-options-file"
+}
+func (*legacyGenericOptionsFileContributor) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindSourceFile}
+}
+func (r *legacyGenericOptionsFileContributor) AcceptsOptions() bool {
+  r.genericMethodCalls++
+  return false
+}
+func (r *legacyGenericOptionsFileContributor) Check(ctx *publicrule.Context, _ *shimast.Node) {
+  r.checkCalls++
+  var options struct {
+    Mode string `json:"mode"`
+  }
+  if err := ctx.DecodeOptions(&options); err == nil {
+    r.observedMode = options.Mode
+  }
+}

--- a/packages/lint/test/plugin/contributor_metadata_panic_is_rejected_test.go
+++ b/packages/lint/test/plugin/contributor_metadata_panic_is_rejected_test.go
@@ -13,18 +13,20 @@ import (
 // are converted to one rejected registration instead of escaping startup.
 //
 // Contributor methods run before the engine can dispatch Check, so the normal
-// per-node panic barrier cannot protect Name or Visits. inspectContributor owns
-// that earlier boundary and must return an actionable error without panicking.
+// per-node panic barrier cannot protect Name, Visits, or optional capability
+// methods. inspectContributor owns that earlier boundary and must return an
+// actionable error without panicking.
 //
-//  1. Construct a public contributor whose Name method panics.
-//  2. Inspect its metadata through the host adapter.
-//  3. Assert the panic becomes an error naming the contributor failure.
+//  1. Construct public contributors whose metadata methods panic in turn.
+//  2. Inspect each contributor through the host adapter.
+//  3. Assert every panic becomes an error naming the contributor failure.
 func TestContributorMetadataPanicIsRejected(t *testing.T) {
   for _, method := range []string{
     "Name",
     "Visits",
     "IsFormat",
     "VisitsDeclarationFiles",
+    "AcceptsTtscLintOptions",
   } {
     t.Run(method, func(t *testing.T) {
       _, err := inspectContributor(metadataPanickingContributor{method: method})
@@ -62,6 +64,12 @@ func (r metadataPanickingContributor) IsFormat() bool {
 func (r metadataPanickingContributor) VisitsDeclarationFiles() bool {
   if r.method == "VisitsDeclarationFiles" {
     panic("VisitsDeclarationFiles boom")
+  }
+  return true
+}
+func (r metadataPanickingContributor) AcceptsTtscLintOptions() bool {
+  if r.method == "AcceptsTtscLintOptions" {
+    panic("AcceptsTtscLintOptions boom")
   }
   return true
 }

--- a/packages/lint/test/plugin/contributor_optionless_marker_rejects_payload_test.go
+++ b/packages/lint/test/plugin/contributor_optionless_marker_rejects_payload_test.go
@@ -1,0 +1,54 @@
+package linthost
+
+import (
+  "encoding/json"
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestContributorOptionlessMarkerRejectsPayload verifies a third-party rule can
+// opt out of the contributor API's backward-compatible options default.
+//
+// Contributors historically received arbitrary Context.Options, so omitting
+// OptionsRule must remain permissive. A contributor that knows it is genuinely
+// optionless can return false, letting the same engine gate reject user typos
+// before its Check method runs.
+//
+//  1. Adapt a contributor whose OptionsRule marker returns false.
+//  2. Configure it with an object payload.
+//  3. Assert a configuration error and no enabled dispatch entry.
+func TestContributorOptionlessMarkerRejectsPayload(t *testing.T) {
+  metadata, err := inspectContributor(optionlessContributorRule{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  registered.rules[metadata.name] = newContributorAdapter(metadata)
+  t.Cleanup(func() { delete(registered.rules, metadata.name) })
+
+  engine := NewEngineWithResolver(InlineRuleResolver{
+    Rules: RuleConfig{metadata.name: SeverityError},
+    Options: RuleOptionsMap{
+      metadata.name: json.RawMessage(`{"typo":true}`),
+    },
+  })
+  err = engine.ConfigError()
+  if err == nil || !strings.Contains(err.Error(), `rule does not accept options`) {
+    t.Fatalf("optionless contributor payload was not rejected: %v", err)
+  }
+  if _, enabled := engine.EnabledRules()[metadata.name]; enabled {
+    t.Fatalf("optionless contributor entered dispatch: %v", engine.EnabledRules())
+  }
+}
+
+type optionlessContributorRule struct{}
+
+func (optionlessContributorRule) Name() string { return "demo/optionless-contract" }
+func (optionlessContributorRule) Visits() []shimast.Kind {
+  return []shimast.Kind{shimast.KindSourceFile}
+}
+func (optionlessContributorRule) Check(*publicrule.Context, *shimast.Node) {}
+func (optionlessContributorRule) AcceptsTtscLintOptions() bool             { return false }

--- a/packages/lint/test/plugin/project_contributor_generic_accepts_options_method_keeps_legacy_payload_test.go
+++ b/packages/lint/test/plugin/project_contributor_generic_accepts_options_method_keeps_legacy_payload_test.go
@@ -1,0 +1,76 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestProjectContributorGenericAcceptsOptionsMethodKeepsLegacyPayload verifies
+// the project adapter ignores an unrelated generic options method.
+//
+// Project contributors share the public OptionsRule capability with file
+// contributors. A pre-existing AcceptsOptions method must not accidentally opt
+// a project rule out of its backward-compatible ProjectContext.Options payload.
+//
+//  1. Adapt a legacy project contributor with only AcceptsOptions returning false.
+//  2. Configure and run a project cycle with an object payload.
+//  3. Assert its generic method is ignored and Check decodes the payload.
+func TestProjectContributorGenericAcceptsOptionsMethodKeepsLegacyPayload(t *testing.T) {
+  contributor := &legacyGenericOptionsProjectContributor{}
+  adapter, err := inspectProjectContributor(contributor)
+  if err != nil {
+    t.Fatal(err)
+  }
+  previous, existed := registeredProjectRules[adapter.name]
+  registeredProjectRules[adapter.name] = adapter
+  t.Cleanup(func() {
+    if existed {
+      registeredProjectRules[adapter.name] = previous
+    } else {
+      delete(registeredProjectRules, adapter.name)
+    }
+  })
+
+  engine := NewEngineWithResolver(InlineRuleResolver{
+    Rules: RuleConfig{adapter.name: SeverityError},
+    Options: RuleOptionsMap{
+      adapter.name: json.RawMessage(`{"mode":"strict"}`),
+    },
+  })
+  if err := engine.ConfigError(); err != nil {
+    t.Fatalf("legacy generic method rejected project options: %v", err)
+  }
+  engine.Run(nil, nil)
+
+  if contributor.genericMethodCalls != 0 {
+    t.Fatalf("legacy AcceptsOptions method was treated as a project capability: calls=%d", contributor.genericMethodCalls)
+  }
+  if contributor.checkCalls != 1 || contributor.observedMode != "strict" {
+    t.Fatalf("legacy project dispatch = calls %d mode %q, want 1 and strict", contributor.checkCalls, contributor.observedMode)
+  }
+}
+
+type legacyGenericOptionsProjectContributor struct {
+  genericMethodCalls int
+  checkCalls         int
+  observedMode       string
+}
+
+func (*legacyGenericOptionsProjectContributor) Name() string {
+  return "compat-test/generic-accepts-options-project"
+}
+func (r *legacyGenericOptionsProjectContributor) AcceptsOptions() bool {
+  r.genericMethodCalls++
+  return false
+}
+func (r *legacyGenericOptionsProjectContributor) Check(ctx *publicrule.ProjectContext) {
+  r.checkCalls++
+  var options struct {
+    Mode string `json:"mode"`
+  }
+  if err := ctx.DecodeOptions(&options); err == nil {
+    r.observedMode = options.Mode
+  }
+}

--- a/packages/lint/test/plugin/project_contributor_optionless_marker_rejects_payload_test.go
+++ b/packages/lint/test/plugin/project_contributor_optionless_marker_rejects_payload_test.go
@@ -1,0 +1,53 @@
+package linthost
+
+import (
+  "encoding/json"
+  "strings"
+  "testing"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestProjectContributorOptionlessMarkerRejectsPayload verifies project rules
+// share the contributor options capability at their global config boundary.
+//
+// ProjectContext exposes the same options transport as file-rule Context and
+// therefore keeps the same default-compatible marker policy. An explicit false
+// declaration must be honored before the project cycle starts, including for a
+// globally configured rule.
+//
+//  1. Install a project contributor whose OptionsRule marker returns false.
+//  2. Configure it globally with an object payload.
+//  3. Assert engine construction reports the optionless payload.
+func TestProjectContributorOptionlessMarkerRejectsPayload(t *testing.T) {
+  adapter, err := inspectProjectContributor(optionlessProjectContributor{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  previous, existed := registeredProjectRules[adapter.name]
+  registeredProjectRules[adapter.name] = adapter
+  t.Cleanup(func() {
+    if existed {
+      registeredProjectRules[adapter.name] = previous
+    } else {
+      delete(registeredProjectRules, adapter.name)
+    }
+  })
+
+  engine := NewEngineWithResolver(InlineRuleResolver{
+    Rules: RuleConfig{adapter.name: SeverityError},
+    Options: RuleOptionsMap{
+      adapter.name: json.RawMessage(`{"typo":true}`),
+    },
+  })
+  err = engine.ConfigError()
+  if err == nil || !strings.Contains(err.Error(), `rule does not accept options`) {
+    t.Fatalf("optionless project contributor payload was not rejected: %v", err)
+  }
+}
+
+type optionlessProjectContributor struct{}
+
+func (optionlessProjectContributor) Name() string                     { return "project-test/optionless-contract" }
+func (optionlessProjectContributor) Check(*publicrule.ProjectContext) {}
+func (optionlessProjectContributor) AcceptsTtscLintOptions() bool     { return false }

--- a/packages/lint/test/plugin/project_contributor_without_marker_keeps_options_compatibility_test.go
+++ b/packages/lint/test/plugin/project_contributor_without_marker_keeps_options_compatibility_test.go
@@ -1,0 +1,49 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestProjectContributorWithoutMarkerKeepsOptionsCompatibility verifies the
+// public ProjectContext options contract remains backward compatible.
+//
+// Existing contributor packages predate OptionsRule and cannot be identified
+// as consumers from host source. The adapter therefore defaults to accepting
+// options; only an explicit false marker opts into rejection.
+//
+//  1. Install a project contributor with no OptionsRule method.
+//  2. Configure it globally with an object payload.
+//  3. Assert engine construction accepts the existing contributor contract.
+func TestProjectContributorWithoutMarkerKeepsOptionsCompatibility(t *testing.T) {
+  adapter, err := inspectProjectContributor(compatibleProjectContributor{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  previous, existed := registeredProjectRules[adapter.name]
+  registeredProjectRules[adapter.name] = adapter
+  t.Cleanup(func() {
+    if existed {
+      registeredProjectRules[adapter.name] = previous
+    } else {
+      delete(registeredProjectRules, adapter.name)
+    }
+  })
+
+  engine := NewEngineWithResolver(InlineRuleResolver{
+    Rules: RuleConfig{adapter.name: SeverityError},
+    Options: RuleOptionsMap{
+      adapter.name: json.RawMessage(`{"mode":"strict"}`),
+    },
+  })
+  if err := engine.ConfigError(); err != nil {
+    t.Fatalf("unmarked project contributor lost options compatibility: %v", err)
+  }
+}
+
+type compatibleProjectContributor struct{}
+
+func (compatibleProjectContributor) Name() string { return "project-test/options-compatible" }
+func (compatibleProjectContributor) Check(*publicrule.ProjectContext) {}

--- a/packages/lint/test/registry/option_accepting_rules_match_typed_settings_test.go
+++ b/packages/lint/test/registry/option_accepting_rules_match_typed_settings_test.go
@@ -1,0 +1,123 @@
+package linthost
+
+import (
+  "os"
+  "path/filepath"
+  "regexp"
+  "runtime"
+  "sort"
+  "strings"
+  "testing"
+)
+
+// TestOptionAcceptingRulesMatchTypedSettings verifies the runtime options
+// capability, each public TypeScript rule setting, and the single-object
+// options map describe the same built-in contract.
+//
+// The engine cannot infer option use from `Context.DecodeOptions`: helpers and
+// shared dispatchers hide calls from simple source scans, while some public
+// upstream-compatible schemas intentionally reserve options that the current
+// native check does not inspect. The structural `AcceptsTtscLintOptions`
+// capability is therefore the runtime source of truth. Exact parity with the
+// typed setting surface prevents both silent runtime-only options and typed
+// tuples that the engine would reject. Positional settings stay outside
+// `ITtscLintRuleOptionsMap`; every `TtscLintRuleOptionsSetting<T>` key must be
+// present in that map and no map-only key may exist.
+//
+//  1. Read every concrete family rule setting and options-map entry.
+//  2. Compare built-in, non-format rules accepting options with every typed
+//     setting richer than `TtscLintRuleSetting`.
+//  3. Compare generic single-object settings with the options map exactly.
+func TestOptionAcceptingRulesMatchTypedSettings(t *testing.T) {
+  settings, err := readTypedRuleSettings()
+  if err != nil {
+    t.Fatalf("read typed rule settings: %v", err)
+  }
+  mapped, err := readTypedRuleOptionsMapKeys()
+  if err != nil {
+    t.Fatalf("read typed rule options map: %v", err)
+  }
+
+  runtimeOptions := map[string]struct{}{}
+  for _, name := range AllRuleNames() {
+    rule := LookupRule(name)
+    if !isRegisteredBuiltInNonFormatRule(name, rule) {
+      continue
+    }
+    if ruleAcceptsOptions(rule) {
+      runtimeOptions[name] = struct{}{}
+    }
+  }
+
+  typedOptions := map[string]struct{}{}
+  genericOptions := map[string]struct{}{}
+  for name, setting := range settings {
+    if setting == "TtscLintRuleSetting" {
+      continue
+    }
+    typedOptions[name] = struct{}{}
+    if strings.HasPrefix(setting, "TtscLintRuleOptionsSetting<") {
+      genericOptions[name] = struct{}{}
+    }
+  }
+
+  assertSameRuleNameSet(t, "runtime AcceptsTtscLintOptions", runtimeOptions, "typed option settings", typedOptions)
+  assertSameRuleNameSet(t, "TtscLintRuleOptionsSetting keys", genericOptions, "ITtscLintRuleOptionsMap", mapped)
+}
+
+func readTypedRuleOptionsMapKeys() (map[string]struct{}, error) {
+  _, thisFile, _, ok := runtime.Caller(0)
+  if !ok {
+    return nil, errMissingCaller{}
+  }
+  path := filepath.Join(
+    filepath.Dir(thisFile), "..", "src", "structures", "rules",
+    "ITtscLintRuleOptionsMap.ts",
+  )
+  body, err := os.ReadFile(path)
+  if err != nil {
+    return nil, err
+  }
+  keys := map[string]struct{}{}
+  property := regexp.MustCompile(`^\s*"([\w][\w/-]*)"\s*:`)
+  for _, line := range strings.Split(string(body), "\n") {
+    if match := property.FindStringSubmatch(line); match != nil {
+      keys[match[1]] = struct{}{}
+    }
+  }
+  return keys, nil
+}
+
+func assertSameRuleNameSet(
+  t *testing.T,
+  leftLabel string,
+  left map[string]struct{},
+  rightLabel string,
+  right map[string]struct{},
+) {
+  t.Helper()
+  var onlyLeft, onlyRight []string
+  for name := range left {
+    if _, ok := right[name]; !ok {
+      onlyLeft = append(onlyLeft, name)
+    }
+  }
+  for name := range right {
+    if _, ok := left[name]; !ok {
+      onlyRight = append(onlyRight, name)
+    }
+  }
+  sort.Strings(onlyLeft)
+  sort.Strings(onlyRight)
+  if len(onlyLeft) > 0 || len(onlyRight) > 0 {
+    t.Fatalf(
+      "%s and %s differ: only %s=%v; only %s=%v",
+      leftLabel,
+      rightLabel,
+      leftLabel,
+      onlyLeft,
+      rightLabel,
+      onlyRight,
+    )
+  }
+}

--- a/packages/lint/test/registry/typed_keys_match_registered_rules_test.go
+++ b/packages/lint/test/registry/typed_keys_match_registered_rules_test.go
@@ -15,36 +15,24 @@ import (
 // surface exposed to plugin authors) and `AllRuleNames()` (the Go
 // runtime). Both sides must agree exactly on which rule ids exist.
 //
-// Round-1 review (Agent A) found zero drift today, but the surface
-// is ~470 rules and growing. A new rule added in Go without a typed
-// counterpart would only surface as a silent autocomplete miss; a new
-// typed key without a Go registration would silently no-op at runtime.
-// This test makes both sides honest at build time.
+// The surface contains hundreds of rules and keeps growing. A new rule added in
+// Go without a typed counterpart would only surface as a silent autocomplete
+// miss; a new typed key without a Go registration would silently no-op at
+// runtime. This test makes both sides honest at build time.
 //
-// `format/*` rules are deliberately registered in Go but absent from
-// the typed `rules` surface — formatter behavior is configured through
-// `ITtscLintFormat` (the top-level `format` block). They are filtered
-// out before the diff.
-//
-// `test/*` is reserved for in-test stubs (e.g. the
-// `duplicate-guard-sentinel` used by
-// `TestRegisterRejectsDuplicateRuleName`). Any name under that prefix
-// is also filtered out before the diff so the parity check does not
-// flap when other registry tests run in the same binary.
-//
-// `demo/*` is the upstream-facing contributor-plugin example namespace;
-// the in-tree tests under `test/plugin/` register their own `demo/*`
-// stubs that exist only at test time. These are not part of the public
-// rules surface and are filtered out as well.
+// The runtime side is classified without namespace assumptions. FormatRule
+// implementations are absent because formatter behavior belongs to the
+// top-level ITtscLintFormat block. Contributor adapters and arbitrary direct
+// test registrations are absent because only native built-ins own entries in
+// the append-only built-in rule-code ledger.
 //
 //  1. Walk every `ITtscLint*Rules.ts` file under
 //     `packages/lint/src/structures/rules/`.
 //  2. Extract every property key matching `"<id>"?` — either quoted
 //     kebab-case form. Bare-identifier keys are also accepted because
 //     three Core keys historically used the bare form.
-//  3. Compare the typed-key set against `AllRuleNames()` filtered as
-//     above. Report missing-from-TS and missing-from-Go separately so
-//     the failure points at the side that drifted.
+//  3. Compare the typed-key set against structurally classified built-in,
+//     non-format registrations, reporting drift on each side separately.
 func TestTypedKeysMatchRegisteredRules(t *testing.T) {
   typed, err := readTypedRuleKeys()
   if err != nil {
@@ -74,15 +62,14 @@ func TestTypedKeysMatchRegisteredRules(t *testing.T) {
   }
 }
 
-// registeredRuleSetForParity returns the canonical rule-name set used
-// by the parity check: everything from `AllRuleNames()` minus the
-// formatter-internal `format/*` ids and the test-only `test/*` ids.
+// registeredRuleSetForParity returns the canonical built-in, non-format rule
+// set used by typed-surface parity. Runtime contributors and test-only direct
+// registrations have no built-in TypeScript family property, while format
+// rules are configured through ITtscLintFormat instead of ITtscLintRules.
 func registeredRuleSetForParity() map[string]struct{} {
   out := make(map[string]struct{}, len(AllRuleNames()))
   for _, name := range AllRuleNames() {
-    if strings.HasPrefix(name, "format/") ||
-      strings.HasPrefix(name, "test/") ||
-      strings.HasPrefix(name, "demo/") {
+    if !isRegisteredBuiltInNonFormatRule(name, LookupRule(name)) {
       continue
     }
     out[name] = struct{}{}
@@ -90,10 +77,51 @@ func registeredRuleSetForParity() map[string]struct{} {
   return out
 }
 
+// isRegisteredBuiltInNonFormatRule classifies registry entries by runtime
+// provenance rather than namespace spelling. The append-only built-in rule-code
+// ledger excludes arbitrary direct registrations, and the structural adapter
+// check also excludes a contributor that reuses a retired ledger name.
+func isRegisteredBuiltInNonFormatRule(name string, candidate Rule) bool {
+  return isRegisteredBuiltInRule(name, candidate) && !isFormatRule(candidate)
+}
+
+// isRegisteredBuiltInFormatRule is the format-side twin used to compare the
+// live format-block expansion with every native formatter registration.
+func isRegisteredBuiltInFormatRule(name string, candidate Rule) bool {
+  return isRegisteredBuiltInRule(name, candidate) && isFormatRule(candidate)
+}
+
+func isRegisteredBuiltInRule(name string, candidate Rule) bool {
+  if candidate == nil {
+    return false
+  }
+  switch candidate.(type) {
+  case contributorAdapter, formatContributorAdapter:
+    return false
+  }
+  _, builtIn := builtInRuleCodes[name]
+  return builtIn
+}
+
 // readTypedRuleKeys scans `packages/lint/src/structures/rules/`
 // relative to this test file and pulls out every property key in
 // every family interface.
 func readTypedRuleKeys() (map[string]struct{}, error) {
+  settings, err := readTypedRuleSettings()
+  if err != nil {
+    return nil, err
+  }
+  keys := make(map[string]struct{}, len(settings))
+  for name := range settings {
+    keys[name] = struct{}{}
+  }
+  return keys, nil
+}
+
+// readTypedRuleSettings returns the declared property type for every concrete
+// built-in rule key. The options-contract parity test shares this source walk
+// so name parity and setting-shape parity cannot drift onto different parsers.
+func readTypedRuleSettings() (map[string]string, error) {
   _, thisFile, _, ok := runtime.Caller(0)
   if !ok {
     return nil, errMissingCaller{}
@@ -110,9 +138,9 @@ func readTypedRuleKeys() (map[string]struct{}, error) {
   if err != nil {
     return nil, err
   }
-  keys := make(map[string]struct{})
-  quoted := regexp.MustCompile(`^\s*"([\w][\w/-]*)"\?\s*:`)
-  bare := regexp.MustCompile(`^\s*([a-zA-Z_$][\w]*)\?\s*:\s*Ttsc`)
+  settings := make(map[string]string)
+  quoted := regexp.MustCompile(`^\s*"([\w][\w/-]*)"\?\s*:\s*([^;]+);`)
+  bare := regexp.MustCompile(`^\s*([a-zA-Z_$][\w]*)\?\s*:\s*([^;]+);`)
   for _, entry := range entries {
     name := entry.Name()
     if entry.IsDir() || !strings.HasSuffix(name, ".ts") {
@@ -133,15 +161,15 @@ func readTypedRuleKeys() (map[string]struct{}, error) {
     }
     for _, line := range strings.Split(string(body), "\n") {
       if m := quoted.FindStringSubmatch(line); m != nil {
-        keys[m[1]] = struct{}{}
+        settings[m[1]] = strings.TrimSpace(m[2])
         continue
       }
       if m := bare.FindStringSubmatch(line); m != nil {
-        keys[m[1]] = struct{}{}
+        settings[m[1]] = strings.TrimSpace(m[2])
       }
     }
   }
-  return keys, nil
+  return settings, nil
 }
 
 type errMissingCaller struct{}

--- a/packages/lint/test/registry/unicorn_no_unnecessary_polyfills_has_typed_options_key_test.go
+++ b/packages/lint/test/registry/unicorn_no_unnecessary_polyfills_has_typed_options_key_test.go
@@ -9,22 +9,17 @@ import (
   "testing"
 )
 
-// TestUnicornNoUnnecessaryPolyfillsHasTypedOptionsKey pins the typed surface for
-// `unicorn/no-unnecessary-polyfills` against its Go runtime.
+// TestUnicornNoUnnecessaryPolyfillsHasTypedOptionsKey pins the typed payload
+// surface for `unicorn/no-unnecessary-polyfills` against its Go runtime.
 //
 // The Go rule accepts and honors a `targets` option (validated in
 // `unicornNoUnnecessaryPolyfillsDecodeOptions`, consumed in Check), but the
-// published TypeScript key was severity-only (`TtscLintRuleSetting`), so a
-// type-checked `lint.config.ts` passing `{ targets: "node 18" }` was a TS error
-// even though the runtime needs it (samchon/ttsc#626). This test locks the
-// three-part wiring — the rules key, the options map, and the options interface —
-// so the typed surface can never silently regress back to severity-only.
-//
-// A general options-parity sweep (every ValidateOptions/DecodeOptions rule owns
-// an options-typed key) is intentionally NOT asserted here: several unrelated
-// rules still carry severity-only keys on master and are being corrected in
-// separate parity PRs, so a broad assertion would fail on rules outside this
-// change. This test is scoped to the rule this change fixes.
+// published TypeScript key was once severity-only, so a type-checked config
+// passing `{ targets: "node 18" }` failed even though the runtime needed it
+// (samchon/ttsc#626). The general options-parity test now locks the rule key,
+// marker, and options-map connection, but it cannot inspect semantic fields
+// inside each options interface. This focused assertion keeps the `targets`
+// payload itself from silently disappearing.
 //
 //  1. Read the three structures/rules TS sources next to this scratch test.
 //  2. Assert the rules key references TtscLintRuleOptionsSetting with the
@@ -54,17 +49,21 @@ func TestUnicornNoUnnecessaryPolyfillsHasTypedOptionsKey(t *testing.T) {
 
   optionsIface := readStructuresRuleFile(t, rulesDir, "ITtscLintUnicornRuleOptions.ts")
   ifacePattern := regexp.MustCompile(
-    `interface ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions\s*\{[^}]*\btargets\b`,
+    `(?s)export interface ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions\s*\{(.*?)\n\}`,
   )
-  if !ifacePattern.MatchString(optionsIface) {
+  iface := ifacePattern.FindStringSubmatch(optionsIface)
+  propertyPattern := regexp.MustCompile(
+    `(?m)^\s*targets\s*:\s*TtscLintUnicornNoUnnecessaryPolyfillsTargets\s*;\s*$`,
+  )
+  if iface == nil || !propertyPattern.MatchString(iface[1]) {
     t.Fatal("ITtscLintUnicornNoUnnecessaryPolyfillsRuleOptions must declare a `targets` property")
   }
 }
 
-// structuresRulesDir resolves packages/lint/src/structures/rules relative to the
-// running test file. scripts/test-go-lint.cjs flattens the Go tests into
+// structuresRulesDir resolves packages/lint/src/structures/rules relative to
+// the running test file. scripts/test-go-lint.cjs flattens the Go tests into
 // linthost/ alongside the verbatim src/ tree, so the rules directory sits one
-// level up — the same layout the name-parity test relies on.
+// level up, matching the layout used by the general parity tests.
 func structuresRulesDir(t *testing.T) string {
   t.Helper()
   _, thisFile, _, ok := runtime.Caller(0)

--- a/tests/lint-contributor-demo/rules/capitalize_exports.go
+++ b/tests/lint-contributor-demo/rules/capitalize_exports.go
@@ -20,6 +20,8 @@ type capitalizeExports struct{}
 
 func (capitalizeExports) Name() string { return "demo/capitalize-exports" }
 
+func (capitalizeExports) AcceptsTtscLintOptions() bool { return false }
+
 func (capitalizeExports) Visits() []shimast.Kind {
   return []shimast.Kind{shimast.KindVariableStatement}
 }

--- a/tests/lint-contributor-demo/rules/no_marker_comment.go
+++ b/tests/lint-contributor-demo/rules/no_marker_comment.go
@@ -41,6 +41,8 @@ func (noMarkerComment) Visits() []shimast.Kind {
   return []shimast.Kind{shimast.KindSourceFile}
 }
 
+func (noMarkerComment) AcceptsTtscLintOptions() bool { return true }
+
 func (noMarkerComment) Check(ctx *rule.Context, _ *shimast.Node) {
   if ctx == nil || ctx.File == nil {
     return

--- a/tests/lint-contributor-demo/src/index.ts
+++ b/tests/lint-contributor-demo/src/index.ts
@@ -10,7 +10,7 @@
 // `rule.Register(noTodoComment{})`. The literal tuple is `as const` so
 // the host's `ITtscLintConfig` type can suggest valid
 // `demo/no-todo-comment` keys in the user's `rules` map.
-import type { ITtscLintPlugin } from "@ttsc/lint";
+import type { ITtscLintPlugin, TtscLintRuleSetting } from "@ttsc/lint";
 import path from "node:path";
 
 /**
@@ -35,20 +35,23 @@ const plugin = {
   source: path.resolve(__dirname, "..", "rules"),
 } satisfies ITtscLintPlugin;
 
-// `demo/no-marker-comment` accepts a `{ markers: string[] }` options
-// blob. Augmenting `ITtscLintRuleOptionsMap` here is what unlocks the
-// `[severity, options]` tuple form in user configs — the autocomplete
-// for `markers` flows from this interface declaration into the
-// `ITtscLintRules` interface the user writes against. The Go
-// rule's option struct (`noMarkerCommentOptions` in
-// `rules/no_marker_comment.go`) uses matching JSON tags so the wire
-// payload decodes cleanly on the host side.
+// `demo/no-marker-comment` accepts a `{ markers: string[] }` options blob.
+// Augmenting `ITtscLintRuleOptionsMap` adds this key to @ttsc/lint's mapped
+// options overlay, which is intersected into `ITtscLintRules`. The known rule
+// therefore gets exact `markers` checking while the contributor index
+// signature remains an `unknown`-options fallback for plugins whose typings
+// were not imported. The Go rule's `noMarkerCommentOptions` struct uses the
+// same JSON key so the checked payload decodes cleanly on the host side.
 declare module "@ttsc/lint" {
   interface ITtscLintRuleOptionsMap {
     "demo/no-marker-comment": {
       /** Comment substrings to flag. Defaults to `["TODO", "FIXME"]`. */
       markers?: readonly string[];
     };
+  }
+
+  interface ITtscLintContributorRules {
+    "demo/capitalize-exports"?: TtscLintRuleSetting;
   }
 }
 

--- a/tests/lint-contributor-demo/src/test_rule_options_module_augmentation_types_contributor_configs.ts
+++ b/tests/lint-contributor-demo/src/test_rule_options_module_augmentation_types_contributor_configs.ts
@@ -1,0 +1,81 @@
+import type { ITtscLintConfig } from "@ttsc/lint";
+
+import "./index";
+
+/**
+ * Verifies importing a contributor's module augmentation tightens only the rule
+ * it registers.
+ *
+ * The public contributor index intentionally accepts an unknown options slot
+ * for packages whose typings are absent. The options map must tighten
+ * `demo/no-marker-comment`, while direct contributor-interface augmentation
+ * must make `demo/capitalize-exports` severity-only.
+ *
+ * 1. Type-check the registered rule with its valid `markers` option.
+ * 2. Pin option-name and option-value failures with `@ts-expect-error`.
+ * 3. Accept severity-only forms and reject a payload for the optionless rule.
+ * 4. Confirm an unregistered contributor namespace keeps unknown options.
+ */
+export const test_rule_options_module_augmentation_types_contributor_configs =
+  (): void => {
+    const valid = {
+      rules: {
+        "demo/no-marker-comment": ["error", { markers: ["TODO", "FIXME"] }],
+      },
+    } satisfies ITtscLintConfig;
+
+    const typo = {
+      rules: {
+        "demo/no-marker-comment": [
+          "error",
+          {
+            // @ts-expect-error — the augmented option is `markers`, not `marker`.
+            marker: ["TODO"],
+          },
+        ],
+      },
+    } satisfies ITtscLintConfig;
+
+    const invalidValue = {
+      rules: {
+        "demo/no-marker-comment": [
+          "warning",
+          {
+            // @ts-expect-error — `markers` is a readonly string array.
+            markers: "TODO",
+          },
+        ],
+      },
+    } satisfies ITtscLintConfig;
+
+    const validOptionless = {
+      rules: {
+        "demo/capitalize-exports": ["warning"],
+      },
+    } satisfies ITtscLintConfig;
+
+    const invalidOptionless = {
+      rules: {
+        // @ts-expect-error — direct augmentation makes this rule severity-only.
+        "demo/capitalize-exports": ["error", { typo: true }],
+      },
+    } satisfies ITtscLintConfig;
+
+    const unknownContributor = {
+      rules: {
+        "unregistered/opaque-options": [
+          "warning",
+          { markers: "opaque", extra: 1 },
+        ],
+      },
+    } satisfies ITtscLintConfig;
+
+    void [
+      valid,
+      typo,
+      invalidValue,
+      validOptionless,
+      invalidOptionless,
+      unknownContributor,
+    ];
+  };

--- a/website/src/content/docs/development/walkthroughs/lint.mdx
+++ b/website/src/content/docs/development/walkthroughs/lint.mdx
@@ -299,6 +299,8 @@ type Engine struct {
 
 The constructor also deduplicates kinds per rule, if a contributor accidentally listed `KindCallExpression` twice in `Visits()`, it only registers once. This is a deliberate kindness; the alternative would be a rule that silently fires twice per call.
 
+Before it builds that table, the constructor validates every options payload declared for a registered rule, including payloads on `"off"` rules and every file-scoped variant. Built-in rules opt into an options slot through a structural capability on their implementation. A severity-only built-in rejects any object, scalar, or positional payload instead of silently ignoring it.
+
 `unknown` collects names from the user's config that have no registered implementation. The CLI surfaces these as configuration warnings instead of silent typos.
 
 ### AST walk
@@ -498,11 +500,13 @@ The adapter layer lives in `linthost/contrib_adapter.go`. Third-party rule contr
 ```go
 type contributorAdapter struct {
   inner                  rule.Rule
+  acceptsOptions         bool
   name                   string
   visits                 []shimast.Kind
   visitsDeclarationFiles bool
 }
 
+func (a contributorAdapter) AcceptsTtscLintOptions() bool { return a.acceptsOptions }
 func (a contributorAdapter) Name() string           { return a.name }
 func (a contributorAdapter) Visits() []shimast.Kind { return a.visits }
 func (a contributorAdapter) Check(ctx *Context, node *shimast.Node) {
@@ -518,7 +522,7 @@ Two adapters, not one, `contributorAdapter` for lint-class rules, `formatContrib
 
 **Why two parallel interfaces?** The engine's internal `Rule` is allowed to evolve freely; the public `rule.Rule` is the stability boundary contributors compile against. By separating the two and bridging through an adapter, we can refactor the internal engine without breaking every published contributor.
 
-`registerContributors` evaluates `Name`, `Visits`, `IsFormat`, and `VisitsDeclarationFiles` once behind a recover barrier and stores the results in the adapter. A panic in those startup methods drops only that contributor entry with a stderr warning. A panic in `Check` becomes an error finding for that rule, and the engine continues running the remaining contributor and built-in rules.
+`registerContributors` evaluates `Name`, `Visits`, `IsFormat`, `VisitsDeclarationFiles`, and the optional `OptionsRule` capability once behind a recover barrier and stores the results in the adapter. Existing contributors default to accepting options because the public `Context.Options` field predates this capability. A genuinely optionless contributor returns `false` from `AcceptsTtscLintOptions`; the host then rejects a payload before linting. The domain-specific method name does not capture an unrelated `AcceptsOptions` method from an older contributor API. A panic in those startup methods drops only that contributor entry with a stderr warning. A panic in `Check` becomes an error finding for that rule, and the engine continues running the remaining contributor and built-in rules.
 
 The collision policy is "later wins is dangerous; prefer determinism." A contributor whose cached name collides with an existing rule is dropped with a stderr warning, not panicked-on. This is the same trade-off `@ttsc/lint` makes for the panic barrier: keep the build going whenever possible, surface the problem clearly.
 
@@ -540,7 +544,10 @@ ttsc-lint-plugin-demo/
 The JS descriptor:
 
 ```ts
-import type { ITtscLintPlugin } from "@ttsc/lint";
+import type {
+  ITtscLintPlugin,
+  TtscLintRuleSetting,
+} from "@ttsc/lint";
 import path from "node:path";
 
 const plugin = {
@@ -553,12 +560,16 @@ declare module "@ttsc/lint" {
   interface ITtscLintRuleOptionsMap {
     "demo/no-todo-comment": { markers?: readonly string[] };
   }
+
+  interface ITtscLintContributorRules {
+    "demo/capitalize-exports"?: TtscLintRuleSetting;
+  }
 }
 
 export default plugin;
 ```
 
-The `declare module` block is a **TypeScript declaration-merge** into `@ttsc/lint`'s public type surface. Users who write `["error", { markers: ["TODO"] }]` in their `lint.config.ts` get autocomplete and type-checking against your option shape, without `@ttsc/lint` knowing about your plugin at all.
+The `declare module` block is a **TypeScript declaration-merge** into `@ttsc/lint`'s public rule types. An option-bearing rule augments `ITtscLintRuleOptionsMap`; `ITtscLintRules` consumes its mapped overlay, so importing the plugin makes `["error", { markers: ["TODO"] }]` autocomplete and type-check against the exact shape. An optionless rule augments `ITtscLintContributorRules` directly with `TtscLintRuleSetting`, which rejects a second tuple slot. Contributor names with no imported augmentation keep the open `unknown`-options fallback for compatibility.
 
 The Go rule file:
 
@@ -575,6 +586,7 @@ type noTodoComment struct{}
 
 func (noTodoComment) Name() string           { return "demo/no-todo-comment" }
 func (noTodoComment) Visits() []shimast.Kind { return []shimast.Kind{shimast.KindSourceFile} }
+func (noTodoComment) AcceptsTtscLintOptions() bool { return true }
 func (noTodoComment) Check(ctx *rule.Context, node *shimast.Node) {
   var opts struct {
     Markers []string `json:"markers"`
@@ -631,6 +643,8 @@ func init() { rule.RegisterProject(noCycles{}) }
 ```
 
 The host runs each project rule once per Program, before file rules, even when `ctx.Sources` is empty. `ctx.Identity` keeps the caller's logical config and root spelling separate from the real paths used by the compiler, and also carries the invocation cwd, optional explicit project root, plugin-config origin, and lifecycle id. `ctx.Report` records a project finding and fails the rule; `ctx.Fail` fails it silently. A later file rule reads the finalized state through `ctx.ProjectResult(name)`, whose status is one of `absent`, `off`, `not_evaluated`, `passed`, or `failed`.
+
+Project contributors follow the same options compatibility boundary as file contributors. They accept options by default, while a genuinely optionless implementation can add `AcceptsTtscLintOptions() bool { return false }` to reject accidental payloads.
 
 Configure a project rule in the same `rules` map, but only in entries without `files`:
 

--- a/website/src/content/docs/lint/setup.mdx
+++ b/website/src/content/docs/lint/setup.mdx
@@ -33,6 +33,8 @@ export default {
 
 `"error"` fails the build. `"warning"` prints. `"off"` disables the rule.
 
+Rules with options use an ESLint-style tuple such as `["error", { "allowElseIf": false }]`. A built-in rule documented without options accepts only a severity, either bare or in a one-element tuple; adding an object or positional payload is a configuration error instead of a silently ignored setting, including while the rule is `"off"`.
+
 To exclude generated files from linting entirely, add a top-level `ignores` list (e.g. `ignores: [".next/**/*.ts", "next-env.d.ts"]`). Without a `files` filter it is a global ignore: the matched paths are skipped by every rule, including rules inherited through `extends`.
 
 The `format` block configures the formatter, keys mirror `.prettierrc`. Presence of the block (even empty `format: {}`) enables `ttsc format` at Prettier defaults. It does not make `ttsc check` fail on formatting unless you set `format.severity`.


### PR DESCRIPTION
Rejects options payloads for genuinely optionless rules while requiring every built-in option consumer to declare its capability structurally.

Contributor compatibility is preserved: existing rules still accept options by default, the public marker uses the collision-resistant AcceptsTtscLintOptions method, and legacy contributors with an unrelated AcceptsOptions method remain unchanged. TypeScript augmentation now documents and compile-checks both option-bearing and optionless contributor settings.

Local validation:
- full lint Go suite
- @ttsc/lint build
- 11-project repository typecheck
- contributor demo tsc
- targeted formatting and diff check
- exhaustive clean review over all 91 changed files

Development CI runs were intentionally cancelled; this issue PR is merged from local validation. Repository-wide format and CI green are handled by the final cleanup PR.

Fixes #651
