### PR TITLE
docs(graph): remove duplicate VS Code benchmark chart

### DIFF
--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -61,9 +61,7 @@ The faded head of each bar is the cold index build, the solid tail is the LLM an
 
 ![Cold time to a first answer, per repository](https://ttsc.dev/benchmark/svg/graph-time-to-answer.svg)
 
-At three million lines the index question stops being academic. On VS Code, `@ttsc/graph` builds in 29 seconds — the graph is a byproduct of the type-check the compiler runs anyway — where `codegraph` spends twelve minutes and serena four and a half:
-
-![Cold time to a first answer, VS Code alone](https://ttsc.dev/benchmark/svg/graph-time-to-answer-vscode.svg)
+At three million lines the index question stops being academic. On VS Code, `@ttsc/graph` builds in 29 seconds because the graph is a byproduct of the type-check the compiler runs anyway, while `codegraph` spends twelve minutes and serena four and a half.
 
 The interactive charts, every model, and the method are on the benchmark page: https://ttsc.dev/docs/benchmark/graph
 

--- a/website/build/graph-benchmark-svg.cjs
+++ b/website/build/graph-benchmark-svg.cjs
@@ -150,13 +150,6 @@ for (const combo of combos.values()) {
 // is not a token chart, so it renders on its own scale (wall clock).
 if (report.index && (report.index.cells ?? []).length > 0) {
   writeSvg("graph-time-to-answer.svg", renderTime(report.index, allCells));
-  writeSvg(
-    "graph-time-to-answer-vscode.svg",
-    renderTime(report.index, allCells, {
-      only: "vscode",
-      title: "Cold time to a first answer — VS Code, 3.4M lines (lower is better)",
-    }),
-  );
 }
 
 const pngs = writePngs();
@@ -581,9 +574,8 @@ function renderIndex(index) {
 // It is the other half of the trade a context-saving tool is making. A tool that
 // cuts an agent's token bill and then spends four minutes indexing and three
 // more re-searching what it indexed has moved the cost, not removed it.
-function renderTime(index, cells, options = {}) {
+function renderTime(index, cells) {
   const rows = [...new Set(index.cells.map((cell) => cell.project))]
-    .filter((project) => !options.only || project === options.only)
     .map((project) => ({
       project,
       label: REPO_LABELS[project] ?? project,
@@ -604,7 +596,7 @@ function renderTime(index, cells, options = {}) {
 
   // Banded blocks like the grouped chart: repo header + one row per tool, the
   // two-tone bar (faded index build + solid LLM answer) inside a full-width
-  // track. A single-project render (the VS Code cut) gets thicker bars.
+  // track. A report with one project gets thicker bars.
   const single = rows.length === 1;
   const width = 1240;
   const margin = 36;
@@ -622,8 +614,7 @@ function renderTime(index, cells, options = {}) {
   const titleBlock = 132;
   const fontSize = single ? 18 : 17;
   const crownSize = single ? 18 : 16;
-  const title =
-    options.title ?? "Cold time to a first answer (lower is better)";
+  const title = "Cold time to a first answer (lower is better)";
 
   const max = niceMax(
     Math.max(

--- a/website/src/content/blog/i-made-ts-compiler-graph-mcp.mdx
+++ b/website/src/content/blog/i-made-ts-compiler-graph-mcp.mdx
@@ -163,9 +163,7 @@ And none of that counts the wait before the first question. A code-graph MCP has
 
 > The faded head of each bar is the index build, the solid tail is the LLM answering, and each bar is labelled `index / LLM` in the order you wait for them. A tool that cuts the token bill and then spends twelve minutes indexing has moved the cost, not removed it.
 
-The place that trade bites hardest deserves its own frame. VS Code is three million lines, and on it the index builds diverge by a factor of twenty-five: `@ttsc/graph` is ready in 29 seconds because the graph falls out of the type-check the compiler was going to run anyway, while `codegraph` crawls for twelve minutes and serena for four and a half before either can say a word:
-
-![Cold time to a first answer, VS Code alone](/benchmark/svg/graph-time-to-answer-vscode.svg)
+The trade bites hardest on VS Code, a three-million-line repository. Its index builds diverge by a factor of twenty-five: `@ttsc/graph` is ready in 29 seconds because the graph falls out of the type-check the compiler was going to run anyway, while `codegraph` crawls for twelve minutes and serena for four and a half before either can say a word.
 
 So for my kind of question, all three left me worse off than before I installed them. Two things are true at once: they're the strongest tools of their kind, built by people who saw the problem before I did; and on an open question, every one made the agent spend more than nothing would have. That's when I went digging.
 


### PR DESCRIPTION
## Summary

- remove the duplicate VS Code-only elapsed-time chart from the graph package README and launch blog
- keep the VS Code timing comparison in prose so the surrounding explanation still flows
- stop generating the redundant dedicated SVG and remove its now-unused render options

## Verification

- `pnpm format`
- `pnpm --dir website build:benchmark:graph`
- `node --check website/build/graph-benchmark-svg.cjs`
- `git diff --check`
- confirmed no `graph-time-to-answer-vscode` references or generated artifact remain

Per the requested documentation-change workflow, automatic CI is intentionally cancelled after opening and is not used as the merge gate. The complete solo self-review finished with no remaining findings.
