### PR TITLE
fix(vscode): launch Windows .cmd/.bat server paths with verbatim arguments

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -81,7 +81,7 @@
         "ttsc.serverPath": {
           "type": "string",
           "default": "",
-          "description": "Absolute path to a ttscserver launcher or native binary. Leave empty to use the project ttsc launcher, which builds TTSC_LSP_PLUGINS_JSON for plugin diagnostics/actions; direct native paths need that manifest supplied out of band.",
+          "description": "Absolute path to a ttscserver launcher, native binary, or Windows .cmd/.bat command shim. Leave empty to use the project ttsc launcher, which builds TTSC_LSP_PLUGINS_JSON for plugin diagnostics/actions; direct native paths need that manifest supplied out of band.",
           "scope": "resource"
         },
         "ttsc.trace.server": {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -27,7 +27,7 @@ import {
 import {
   createDocumentSelectorPattern,
   createResolutionCandidates,
-  createServerLaunchCommand,
+  createServerExecutable,
   executeCommandIDPrefix,
   filterNonOverlappingCandidates,
   isPathInsideRoot,
@@ -38,7 +38,6 @@ import {
   rootsToStopForPlan,
   rootsToStopForTarget,
   selectDeepestRootForPath,
-  serverProcessOptions,
 } from "./serverResolution";
 
 type ServerLaunchSpec = {
@@ -153,12 +152,10 @@ function createServerOptions(
   launcher: string,
   candidate: ReturnType<typeof createResolutionCandidates>[number],
 ): ServerOptions {
-  const launch = createServerLaunchCommand(launcher, candidate);
-  return {
-    command: launch.command,
-    args: launch.args,
-    options: serverProcessOptions(candidate.cwd),
-  };
+  // `ServerExecutable.options` carries the Node-only `windowsVerbatimArguments`
+  // flag that `ExecutableOptions` does not declare; the client forwards it to
+  // `child_process.spawn` verbatim, so it is structurally compatible here.
+  return createServerExecutable(launcher, candidate);
 }
 
 function workspaceFolderFor(root: string, index: number): WorkspaceFolder {

--- a/packages/vscode/src/serverResolution.ts
+++ b/packages/vscode/src/serverResolution.ts
@@ -18,11 +18,26 @@ export type ResolutionCandidateInput = {
 export type ServerProcessOptions = {
   cwd: string;
   env: NodeJS.ProcessEnv;
+  // Node-only `child_process.spawn` option. `vscode-languageclient`'s
+  // `ExecutableOptions` does not declare it, but the client forwards
+  // `command.options` verbatim to `spawn`, so carrying it here lets a pre-quoted
+  // Windows `cmd.exe /c` payload reach cmd without a second escaping pass.
+  windowsVerbatimArguments?: boolean;
 };
 
 export type ServerLaunchCommand = {
   args: string[];
   command: string;
+  // True only for the Windows `.cmd`/`.bat` command-shim launch path, whose
+  // `args` are already a single fully quoted `/c` payload. Non-command launchers
+  // omit it so their argument arrays keep Node's default escaping.
+  windowsVerbatimArguments?: boolean;
+};
+
+export type ServerExecutable = {
+  args: string[];
+  command: string;
+  options: ServerProcessOptions | undefined;
 };
 
 export type ClientRootSelection = {
@@ -155,9 +170,38 @@ export function createServerLaunchCommand(
     return {
       command: env.ComSpec || "cmd.exe",
       args: ["/d", "/s", "/c", quoteWindowsCommand([launcher, ...args])],
+      windowsVerbatimArguments: true,
     };
   }
   return { command: launcher, args };
+}
+
+/**
+ * Compose the full launch command with its `child_process` spawn options.
+ *
+ * This is the boundary handed to `vscode-languageclient`'s `Executable`. A
+ * Windows `.cmd`/`.bat` launcher is already encoded as one fully quoted
+ * `cmd.exe /c` payload, so its process options must set
+ * `windowsVerbatimArguments` to stop Node from escaping that payload a second
+ * time; every other launcher keeps the default array escaping. The cwd and
+ * TypeScript-Go environment injection from `serverProcessOptions` are preserved.
+ */
+export function createServerExecutable(
+  launcher: string,
+  candidate: ResolutionCandidate,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): ServerExecutable {
+  const launch = createServerLaunchCommand(launcher, candidate, platform, env);
+  const options = serverProcessOptions(candidate.cwd);
+  return {
+    command: launch.command,
+    args: launch.args,
+    options:
+      options && launch.windowsVerbatimArguments
+        ? { ...options, windowsVerbatimArguments: true }
+        : options,
+  };
 }
 
 export function quoteWindowsCommand(args: readonly string[]): string {

--- a/tests/test-ttsc/src/features/ttscserver/test_vscode_server_launch_command_spawns_windows_command_shim.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_vscode_server_launch_command_spawns_windows_command_shim.ts
@@ -1,0 +1,193 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+/**
+ * Verifies VS Code `ttsc.serverPath` launches a Windows `.cmd`/`.bat` shim.
+ *
+ * `createServerLaunchCommand` encodes a Windows command shim as one fully
+ * quoted `cmd.exe /d /s /c` payload, but without `windowsVerbatimArguments`
+ * Node escapes that payload a second time and cmd.exe rejects it before the
+ * language server starts. This pins the fix at the `createServerExecutable`
+ * boundary (the exact command/args/options the extension hands
+ * `vscode-languageclient`), not just the quoted string: the `.cmd`/`.bat` shim
+ * must receive every LSP argument verbatim, while the negative twin — the same
+ * command without the flag — must not.
+ *
+ * 1. Build launcher, cwd, and tsconfig paths containing spaces and `&`.
+ * 2. Assert only the `.cmd`/`.bat` executables carry `windowsVerbatimArguments`.
+ * 3. On Windows, spawn a recording `.cmd` and `.bat` with the exact executable
+ *    options and confirm the recorded args equal the expected LSP args.
+ * 4. Spawn the same command without the flag and confirm the shim does not
+ *    receive those args.
+ */
+export const test_vscode_server_launch_command_spawns_windows_command_shim =
+  () => {
+    const repo = TestProject.WORKSPACE_ROOT;
+    const serverResolution = path.join(
+      repo,
+      "packages",
+      "vscode",
+      "src",
+      "serverResolution.ts",
+    );
+    const script = `
+    import { pathToFileURL } from "node:url";
+    import fs from "node:fs";
+    import os from "node:os";
+    import path from "node:path";
+    import { spawnSync } from "node:child_process";
+
+    const mod = await import(pathToFileURL(${JSON.stringify(
+      serverResolution,
+    )}).href);
+
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-vscode-launch-"));
+    const dir = path.join(base, "Tools & SDK (x86)");
+    const cwd = path.join(dir, "my project");
+    fs.mkdirSync(cwd, { recursive: true });
+    const tsconfig = path.join(cwd, "tsconfig.json");
+    fs.writeFileSync(tsconfig, "{}");
+
+    const candidate = { cwd: cwd, resolveFrom: cwd, tsconfig: tsconfig };
+    const env = Object.assign({}, process.env, {
+      ComSpec: process.env.ComSpec || "cmd.exe",
+    });
+    const build = (launcher) =>
+      mod.createServerExecutable(launcher, candidate, "win32", env);
+    const verbatimOf = (launcher) =>
+      build(launcher).options.windowsVerbatimArguments ?? null;
+
+    const shape = {
+      cmd: verbatimOf(path.join(dir, "server.cmd")),
+      bat: verbatimOf(path.join(dir, "server.bat")),
+      js: verbatimOf(path.join(cwd, "server.js")),
+      native: verbatimOf(path.join(cwd, "server.exe")),
+    };
+    const expectedArgs = build(path.join(cwd, "server.exe")).args;
+
+    const recorder = (record) =>
+      [
+        "@echo off",
+        "setlocal enabledelayedexpansion",
+        'break>"' + record + '"',
+        ":loop",
+        'if "%~1"=="" goto :done',
+        'set "arg=%~1"',
+        '>>"' + record + '" echo(!arg!',
+        "shift",
+        "goto :loop",
+        ":done",
+        "endlocal",
+        "exit /b 0",
+        "",
+      ].join("\\r\\n");
+    const readRecord = (record) =>
+      fs.existsSync(record)
+        ? fs.readFileSync(record, "utf8").split(/\\r?\\n/).filter(Boolean)
+        : null;
+    const runShim = (ext) => {
+      const launcher = path.join(dir, "server." + ext);
+      const record = path.join(dir, "record-" + ext + ".txt");
+      fs.writeFileSync(launcher, recorder(record));
+      const exec = build(launcher);
+      if (fs.existsSync(record)) fs.rmSync(record);
+      const verbatim = spawnSync(exec.command, exec.args, Object.assign(
+        {},
+        exec.options,
+        { encoding: "utf8", windowsHide: true },
+      ));
+      const verbatimRecord = readRecord(record);
+      if (fs.existsSync(record)) fs.rmSync(record);
+      const plainOptions = Object.assign({}, exec.options);
+      delete plainOptions.windowsVerbatimArguments;
+      const plain = spawnSync(exec.command, exec.args, Object.assign(
+        {},
+        plainOptions,
+        { encoding: "utf8", windowsHide: true },
+      ));
+      const plainRecord = readRecord(record);
+      return {
+        verbatimStatus: verbatim.status,
+        verbatimRecord: verbatimRecord,
+        plainRecord: plainRecord,
+      };
+    };
+
+    const isWin = process.platform === "win32";
+    const spawn = isWin ? { cmd: runShim("cmd"), bat: runShim("bat") } : null;
+    try {
+      fs.rmSync(base, { recursive: true, force: true });
+    } catch {}
+    console.log(JSON.stringify({
+      platform: process.platform,
+      shape: shape,
+      expectedArgs: expectedArgs,
+      spawn: spawn,
+    }));
+  `;
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--disable-warning=ExperimentalWarning",
+        "--experimental-transform-types",
+        "--input-type=module",
+        "--eval",
+        script,
+      ],
+      {
+        cwd: repo,
+        encoding: "utf8",
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout) as {
+      platform: string;
+      shape: {
+        bat: boolean | null;
+        cmd: boolean | null;
+        js: boolean | null;
+        native: boolean | null;
+      };
+      expectedArgs: string[];
+      spawn: null | {
+        bat: ShimResult;
+        cmd: ShimResult;
+      };
+    };
+
+    // Only the pre-quoted Windows command shim requests verbatim spawn
+    // arguments; JS and native launchers keep Node's default array escaping.
+    assert.equal(parsed.shape.cmd, true);
+    assert.equal(parsed.shape.bat, true);
+    assert.equal(parsed.shape.js, null);
+    assert.equal(parsed.shape.native, null);
+
+    if (parsed.platform !== "win32") {
+      assert.equal(parsed.spawn, null);
+      return;
+    }
+    const spawnResults = parsed.spawn;
+    assert.ok(spawnResults);
+    for (const ext of ["cmd", "bat"] as const) {
+      const shim = spawnResults[ext];
+      assert.equal(shim.verbatimStatus, 0, `verbatim ${ext} exit status`);
+      assert.deepEqual(
+        shim.verbatimRecord,
+        parsed.expectedArgs,
+        `verbatim ${ext} recorded args`,
+      );
+      assert.notDeepEqual(
+        shim.plainRecord,
+        parsed.expectedArgs,
+        `non-verbatim ${ext} must not deliver the LSP arguments`,
+      );
+    }
+  };
+
+type ShimResult = {
+  plainRecord: string[] | null;
+  verbatimRecord: string[] | null;
+  verbatimStatus: number | null;
+};

--- a/tests/test-ttsc/src/features/ttscserver/test_vscode_server_launch_command_uses_command_mode.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_vscode_server_launch_command_uses_command_mode.ts
@@ -57,9 +57,13 @@ export const test_vscode_server_launch_command_uses_command_mode = () => {
   );
   assert.equal(result.status, 0, result.stderr);
   const parsed = JSON.parse(result.stdout) as {
-    cmd: { args: string[]; command: string };
-    js: { args: string[]; command: string };
-    native: { args: string[]; command: string };
+    cmd: { args: string[]; command: string; windowsVerbatimArguments?: boolean };
+    js: { args: string[]; command: string; windowsVerbatimArguments?: boolean };
+    native: {
+      args: string[];
+      command: string;
+      windowsVerbatimArguments?: boolean;
+    };
     otherPrefix: string;
     prefix: string;
   };
@@ -83,6 +87,11 @@ export const test_vscode_server_launch_command_uses_command_mode = () => {
     "--execute-command-id-prefix=" + parsed.prefix,
     "--tsconfig=" + tsconfig,
   ]);
+  // Only the pre-quoted Windows command shim requests verbatim spawn arguments;
+  // JS and native launchers keep Node's default array escaping.
+  assert.equal(parsed.cmd.windowsVerbatimArguments, true);
+  assert.equal(parsed.js.windowsVerbatimArguments, undefined);
+  assert.equal(parsed.native.windowsVerbatimArguments, undefined);
   assert.equal(parsed.cmd.command, "cmd.exe");
   assert.equal(parsed.cmd.args[0], "/d");
   assert.equal(parsed.cmd.args[1], "/s");


### PR DESCRIPTION
## Bundle b9 — VS Code Windows `.cmd`/`.bat` server launch

Campaign `repository-audit-2026-07`. Fixes the VS Code language-server launch path for a `ttsc.serverPath` that points at a Windows `.cmd`/`.bat` command shim (npm/pnpm/Yarn deployment form).

### Issue

Closes #675 (RA-22) — **fix(vscode): launch Windows `.cmd`/`.bat` server paths with verbatim arguments**

### Root cause

`createServerLaunchCommand` encodes a Windows command shim as one fully quoted `cmd.exe /d /s /c` payload, but the `LanguageClient` process options omitted `windowsVerbatimArguments`. Node then escaped the already-quoted payload a second time and `cmd.exe` rejected the command (`The filename, directory name, or volume label syntax is incorrect.`) before the language server started — disabling plugin diagnostics, code actions, formatting, and execute-command support for that workspace.

### Fix

- `createServerLaunchCommand` now marks the Windows command-shim path with `windowsVerbatimArguments: true`; every other launcher kind (JS, native `.exe`, POSIX) is untouched.
- A new `createServerExecutable` seam composes the launch command with `serverProcessOptions`, propagating the flag into the spawn options **only** for the command-shim path, while preserving cwd and TypeScript-Go env injection.
- `createServerOptions` in `extension.ts` now delegates to `createServerExecutable`. The local `ServerProcessOptions` type carries the Node-only `windowsVerbatimArguments` flag that `vscode-languageclient`'s `ExecutableOptions` does not declare (the client forwards `command.options` to `child_process.spawn` verbatim). This mirrors the repository's own `packages/vscode/bin/install.js` precedent.
- `package.json` config description updated to mention Windows `.cmd`/`.bat` command shims.

### Tests

- New boundary test `test_vscode_server_launch_command_spawns_windows_command_shim.ts`: builds launcher/cwd/tsconfig paths containing spaces and `&`, asserts only `.cmd`/`.bat` executables carry the flag, and on Windows spawns a recording `.cmd` and `.bat` with the **exact** `createServerExecutable` command/args/options — confirming every LSP argument arrives verbatim, and that the negative twin (same command without the flag) does **not** deliver those args.
- Extended `test_vscode_server_launch_command_uses_command_mode.ts` to pin the flag shape across `.cmd`, JS, and native launchers.

### Verification

- `pnpm --filter @ttsc/vscode build` — green
- `pnpm --filter @ttsc/test-ttsc start -- --include=vscode_server_launch` — (recorded in final PR comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
