### PR TITLE
fix(metro): preserve upstream transformer initialization failures

### DIFF
--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -41,7 +41,7 @@ module.exports = withTtsc(getDefaultConfig(__dirname));
 
 `withTtsc` sets `transformer.babelTransformerPath` and leaves the rest of your config untouched. It auto-detects the upstream transformer to delegate to (`@expo/metro-config/babel-transformer` for Expo, then `@react-native/metro-babel-transformer`, then the legacy `metro-react-native-babel-transformer`).
 
-Auto-detection only skips a candidate that is genuinely **not installed**. A candidate that _is_ installed but fails while loading — a top-level throw, an incompatible runtime ABI, or a missing peer/transitive dependency — surfaces its original error (as the `cause` of a `@ttsc/metro` wrapper) instead of being treated as absent. This stops a broken Expo/React Native install from silently falling through to the wrong transformer, and stops an explicit `upstreamTransformer` failure from being reported as if the module did not exist.
+Auto-detection only skips a candidate whose entry point is genuinely **not available** — the package is not installed, or it is installed but the requested subpath is not exported (Expo/React Native version skew). A candidate that _does_ resolve but fails while loading — a top-level throw, an incompatible runtime ABI, or a missing peer/transitive dependency — surfaces its original error (as the `cause` of a `@ttsc/metro` wrapper) instead of being treated as absent. This stops a broken Expo/React Native install from silently falling through to the wrong transformer, and stops an explicit `upstreamTransformer` failure from being reported as if the module did not exist.
 
 ## Configuration
 

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -41,6 +41,8 @@ module.exports = withTtsc(getDefaultConfig(__dirname));
 
 `withTtsc` sets `transformer.babelTransformerPath` and leaves the rest of your config untouched. It auto-detects the upstream transformer to delegate to (`@expo/metro-config/babel-transformer` for Expo, then `@react-native/metro-babel-transformer`, then the legacy `metro-react-native-babel-transformer`).
 
+Auto-detection only skips a candidate that is genuinely **not installed**. A candidate that _is_ installed but fails while loading — a top-level throw, an incompatible runtime ABI, or a missing peer/transitive dependency — surfaces its original error (as the `cause` of a `@ttsc/metro` wrapper) instead of being treated as absent. This stops a broken Expo/React Native install from silently falling through to the wrong transformer, and stops an explicit `upstreamTransformer` failure from being reported as if the module did not exist.
+
 ## Configuration
 
 By default `@ttsc/metro` finds the nearest `tsconfig.json` from the file being transformed and runs the plugins configured there: the standard `ttsc` model. If that is the config you want, `withTtsc(getDefaultConfig(__dirname))` is enough.

--- a/packages/metro/src/core/upstream.ts
+++ b/packages/metro/src/core/upstream.ts
@@ -118,27 +118,44 @@ function tryRequire(modulePath: string): UpstreamTransformer | undefined {
   try {
     nodeRequire.resolve(modulePath);
   } catch (error) {
-    if (isModuleNotFound(error)) {
+    if (isCandidateAbsent(error)) {
       return undefined;
     }
-    // A non-"not found" resolution error (e.g. an invalid specifier) is not
-    // evidence of a plain absence; surface it.
+    // A resolution error that is not one of the known "entry point absent"
+    // codes (e.g. an invalid specifier) is not evidence of a plain absence;
+    // surface it rather than silently skipping the candidate.
     throw error;
   }
   return nodeRequire(modulePath) as UpstreamTransformer;
 }
 
 /**
- * Whether a resolution error means the requested module could not be found.
+ * Whether a resolution error means the requested candidate's entry point is not
+ * available here — i.e. genuine absence, not a broken initialization.
  *
- * A CJS `require.resolve` failure carries `code === "MODULE_NOT_FOUND"`; the
- * ESM loader uses `ERR_MODULE_NOT_FOUND`. Because resolution never executes the
- * module, this error can only refer to the requested specifier, never a
- * transitive import of it.
+ * Resolution never executes the module body, so a `require.resolve` failure can
+ * only concern the requested specifier, never a transitive import of it. Each
+ * recognised code says the same thing about that specifier:
+ *
+ * - `MODULE_NOT_FOUND` / `ERR_MODULE_NOT_FOUND` — the package or file itself is
+ *   not installed (CJS and ESM loaders respectively).
+ * - `ERR_PACKAGE_PATH_NOT_EXPORTED` — the package is installed but the requested
+ *   subpath is not exported (or its export target is missing). This matters for
+ *   the `@expo/metro-config/babel-transformer` candidate, a package subpath:
+ *   under Expo/React Native version skew a present but non-exporting package
+ *   must stay non-fatal so auto-detection falls through to the next candidate,
+ *   exactly as a wholly absent package does.
+ *
+ * An error thrown later, while the resolved module executes, is a real
+ * initialization failure and is never routed here — the caller preserves it.
  */
-function isModuleNotFound(error: unknown): boolean {
+function isCandidateAbsent(error: unknown): boolean {
   const code = (error as { code?: unknown } | null | undefined)?.code;
-  return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND";
+  return (
+    code === "MODULE_NOT_FOUND" ||
+    code === "ERR_MODULE_NOT_FOUND" ||
+    code === "ERR_PACKAGE_PATH_NOT_EXPORTED"
+  );
 }
 
 /** Best-effort message extraction for wrapping an unknown thrown value. */

--- a/packages/metro/src/core/upstream.ts
+++ b/packages/metro/src/core/upstream.ts
@@ -54,7 +54,18 @@ export function resolveUpstreamTransformer(
   load: (modulePath: string) => UpstreamTransformer | undefined = tryRequire,
 ): UpstreamTransformer {
   if (customPath !== undefined && customPath.length !== 0) {
-    const upstream = load(customPath);
+    let upstream: UpstreamTransformer | undefined;
+    try {
+      upstream = load(customPath);
+    } catch (cause) {
+      // The module resolves but failed while initializing (a top-level throw,
+      // a missing peer/transitive dependency, or a runtime-ABI rejection).
+      // Preserve the original diagnostic instead of masking it as absence.
+      throw new Error(
+        `[@ttsc/metro] Failed to load the configured upstream transformer "${customPath}": ${errorMessage(cause)}`,
+        { cause },
+      );
+    }
     if (upstream === undefined) {
       throw new Error(
         `[@ttsc/metro] Could not load the configured upstream transformer: ${customPath}`,
@@ -64,7 +75,19 @@ export function resolveUpstreamTransformer(
   }
 
   for (const candidate of UPSTREAM_CANDIDATES) {
-    const upstream = load(candidate);
+    let upstream: UpstreamTransformer | undefined;
+    try {
+      upstream = load(candidate);
+    } catch (cause) {
+      // A candidate that resolves but throws while initializing is a broken
+      // installation of the active stack, not an absent optional peer. Surface
+      // it rather than silently falling through to a candidate that does not
+      // match this project.
+      throw new Error(
+        `[@ttsc/metro] The upstream Metro transformer "${candidate}" is installed but failed to initialize: ${errorMessage(cause)}`,
+        { cause },
+      );
+    }
     if (upstream !== undefined) {
       return upstream;
     }
@@ -78,10 +101,50 @@ export function resolveUpstreamTransformer(
   );
 }
 
+/**
+ * Load an upstream transformer module, separating genuine absence from a broken
+ * installation.
+ *
+ * Resolution and execution are split deliberately. `require.resolve` only walks
+ * the module graph for the requested specifier; it never executes third-party
+ * code, so a failure there proves the requested candidate itself is not present
+ * — reported as `undefined` (absence) so automatic probing continues to the
+ * next optional peer. Once resolution succeeds, any error thrown by the actual
+ * `require` comes from executing the module body, including a missing peer or
+ * transitive dependency; that is a real initialization failure and is rethrown
+ * with its original message and stack so the caller can preserve it.
+ */
 function tryRequire(modulePath: string): UpstreamTransformer | undefined {
   try {
-    return nodeRequire(modulePath) as UpstreamTransformer;
-  } catch {
-    return undefined;
+    nodeRequire.resolve(modulePath);
+  } catch (error) {
+    if (isModuleNotFound(error)) {
+      return undefined;
+    }
+    // A non-"not found" resolution error (e.g. an invalid specifier) is not
+    // evidence of a plain absence; surface it.
+    throw error;
   }
+  return nodeRequire(modulePath) as UpstreamTransformer;
+}
+
+/**
+ * Whether a resolution error means the requested module could not be found.
+ *
+ * A CJS `require.resolve` failure carries `code === "MODULE_NOT_FOUND"`; the
+ * ESM loader uses `ERR_MODULE_NOT_FOUND`. Because resolution never executes the
+ * module, this error can only refer to the requested specifier, never a
+ * transitive import of it.
+ */
+function isModuleNotFound(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND";
+}
+
+/** Best-effort message extraction for wrapping an unknown thrown value. */
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
 }

--- a/tests/test-metro/src/features/upstream/test_upstream_auto_detect_init_failure_does_not_fall_through.ts
+++ b/tests/test-metro/src/features/upstream/test_upstream_auto_detect_init_failure_does_not_fall_through.ts
@@ -1,0 +1,21 @@
+import { assertAutoDetectInitFailureDoesNotFallThrough } from "../../internal/metro-upstream";
+
+/**
+ * Verifies auto-detection does not fall through when a resolvable candidate
+ * throws during initialization.
+ *
+ * Pins the loop guard in `resolveUpstreamTransformer`: a broken but installed
+ * Expo transformer must surface its own failure, not silently select the later
+ * legacy React Native candidate and run the wrong stack. The negative twin of
+ * priority-order fall-through, where the earlier candidate is broken rather than
+ * absent.
+ *
+ * 1. Inject a loader where the Expo candidate throws and later candidates load.
+ * 2. Resolve with no explicit path.
+ * 3. Assert it throws the Expo failure with cause, not the legacy candidate or
+ *    the terminal "install one of these" message.
+ */
+export const test_upstream_auto_detect_init_failure_does_not_fall_through =
+  async () => {
+    await assertAutoDetectInitFailureDoesNotFallThrough();
+  };

--- a/tests/test-metro/src/features/upstream/test_upstream_configured_init_failure_preserves_cause.ts
+++ b/tests/test-metro/src/features/upstream/test_upstream_configured_init_failure_preserves_cause.ts
@@ -1,0 +1,21 @@
+import { assertConfiguredInitFailurePreservesCause } from "../../internal/metro-upstream";
+
+/**
+ * Verifies an explicit upstream that throws during initialization surfaces the
+ * original diagnostic.
+ *
+ * Pins the initialization-error branch: a configured module that resolves but
+ * throws at top level (an ABI/runtime rejection) must not be flattened into the
+ * generic "could not load" absence message. The original message and stack are
+ * preserved through the Error `cause`, run through the production `require`
+ * loader against a real broken module on disk.
+ *
+ * 1. Point `upstreamTransformer` at a module that throws while loading.
+ * 2. Resolve it through the real loader.
+ * 3. Assert the original message is preserved and attached as `cause`, not the
+ *    absence message.
+ */
+export const test_upstream_configured_init_failure_preserves_cause =
+  async () => {
+    await assertConfiguredInitFailurePreservesCause();
+  };

--- a/tests/test-metro/src/features/upstream/test_upstream_genuinely_absent_candidate_stays_non_fatal.ts
+++ b/tests/test-metro/src/features/upstream/test_upstream_genuinely_absent_candidate_stays_non_fatal.ts
@@ -1,0 +1,20 @@
+import { assertAbsentConfiguredPathReportsNotLoaded } from "../../internal/metro-upstream";
+
+/**
+ * Verifies an explicit upstream path that does not resolve is reported as
+ * absence, not as a broken installation.
+ *
+ * Pins the absence branch of `tryRequire` on the real loader: `require.resolve`
+ * fails with `MODULE_NOT_FOUND` for a specifier that is not installed, so the
+ * candidate is genuinely absent and yields the "could not load the configured
+ * upstream transformer" guidance rather than a wrapped initialization failure
+ * with a `cause`. The negative twin of the init-failure cases.
+ *
+ * 1. Point `upstreamTransformer` at a module specifier that does not resolve.
+ * 2. Resolve it through the real loader.
+ * 3. Assert the absence message, with no init-failure wrapper and no `cause`.
+ */
+export const test_upstream_genuinely_absent_candidate_stays_non_fatal =
+  async () => {
+    await assertAbsentConfiguredPathReportsNotLoaded();
+  };

--- a/tests/test-metro/src/features/upstream/test_upstream_missing_transitive_dependency_reported.ts
+++ b/tests/test-metro/src/features/upstream/test_upstream_missing_transitive_dependency_reported.ts
@@ -1,0 +1,20 @@
+import { assertMissingTransitiveDependencyReported } from "../../internal/metro-upstream";
+
+/**
+ * Verifies a missing transitive dependency of the upstream is reported as that
+ * dependency's failure, not as candidate absence.
+ *
+ * Pins the resolve-then-execute split in `tryRequire`: the candidate itself
+ * resolves, so a `MODULE_NOT_FOUND` raised while its body `require`s an absent
+ * dependency must surface that dependency, never be misclassified as the
+ * candidate being uninstalled. Run through the production loader with a real
+ * module on disk whose `require` target does not exist.
+ *
+ * 1. Point `upstreamTransformer` at a module that requires an absent dependency.
+ * 2. Resolve it through the real loader.
+ * 3. Assert the diagnostic names the missing dependency, not the "could not
+ *    load" absence message.
+ */
+export const test_upstream_missing_transitive_dependency_reported = async () => {
+  await assertMissingTransitiveDependencyReported();
+};

--- a/tests/test-metro/src/features/upstream/test_upstream_unexported_subpath_stays_non_fatal.ts
+++ b/tests/test-metro/src/features/upstream/test_upstream_unexported_subpath_stays_non_fatal.ts
@@ -1,0 +1,20 @@
+import { assertUnexportedSubpathReportsNotLoaded } from "../../internal/metro-upstream";
+
+/**
+ * Verifies an installed package whose requested subpath is not exported is
+ * treated as absence, not as a broken installation.
+ *
+ * Pins the `ERR_PACKAGE_PATH_NOT_EXPORTED` arm of `isCandidateAbsent` on the
+ * real loader: the Expo candidate `@expo/metro-config/babel-transformer` is a
+ * package subpath, so under version skew a present-but-non-exporting package
+ * must stay non-fatal and let auto-detection fall through, exactly as a wholly
+ * absent package does. The boundary twin of the init-failure cases, where the
+ * candidate resolves and throws during execution.
+ *
+ * 1. Point `upstreamTransformer` at a bogus subpath of an installed package.
+ * 2. Resolve it through the real loader.
+ * 3. Assert the absence message, with no init-failure wrapper and no `cause`.
+ */
+export const test_upstream_unexported_subpath_stays_non_fatal = async () => {
+  await assertUnexportedSubpathReportsNotLoaded();
+};

--- a/tests/test-metro/src/internal/metro-runtime.ts
+++ b/tests/test-metro/src/internal/metro-runtime.ts
@@ -154,6 +154,51 @@ export namespace TestMetroRuntime {
     return file;
   }
 
+  let throwingUpstreamPath: string | undefined;
+  let missingDepUpstreamPath: string | undefined;
+
+  /**
+   * A fake upstream module that throws while initializing (a top-level `throw`),
+   * modelling an installed transformer that rejects the current runtime ABI. Its
+   * resolution succeeds, so the loader must classify it as a broken module, not
+   * as an absent candidate.
+   */
+  export function throwingUpstreamOnDisk(): string {
+    if (throwingUpstreamPath !== undefined) {
+      return throwingUpstreamPath;
+    }
+    const dir = TestProject.tmpdir("ttsc-metro-upstream-broken-");
+    const file = path.join(dir, "upstream.cjs");
+    fs.writeFileSync(
+      file,
+      'throw new Error("upstream dependency ABI mismatch");\n',
+      "utf8",
+    );
+    throwingUpstreamPath = file;
+    return file;
+  }
+
+  /**
+   * A fake upstream module that resolves but `require`s a transitive dependency
+   * that is not installed, so loading it throws `MODULE_NOT_FOUND` for that
+   * dependency — never for the candidate itself. The loader must report the
+   * dependency failure rather than claiming the candidate is absent.
+   */
+  export function missingDependencyUpstreamOnDisk(): string {
+    if (missingDepUpstreamPath !== undefined) {
+      return missingDepUpstreamPath;
+    }
+    const dir = TestProject.tmpdir("ttsc-metro-upstream-missingdep-");
+    const file = path.join(dir, "upstream.cjs");
+    fs.writeFileSync(
+      file,
+      'require("@@ttsc-metro-absent-transitive-dependency@@");\n',
+      "utf8",
+    );
+    missingDepUpstreamPath = file;
+    return file;
+  }
+
   /**
    * Set the worker-env options, load a fresh transformer, run `body`, and
    * always restore the previous env. Used by transform and cache-key tests that

--- a/tests/test-metro/src/internal/metro-upstream.ts
+++ b/tests/test-metro/src/internal/metro-upstream.ts
@@ -134,6 +134,32 @@ export async function assertAbsentConfiguredPathReportsNotLoaded(): Promise<void
 }
 
 /**
+ * Asserts an explicit configured path that resolves to an installed package but
+ * whose requested subpath is NOT exported is reported as absence ("could not
+ * load"), NOT as an initialization failure, on the PRODUCTION path. Node throws
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED` (not `MODULE_NOT_FOUND`) during resolution for
+ * such a specifier; because resolution never executes the module, this proves
+ * the requested candidate entry point is unavailable, so it must stay a plain
+ * absence — the boundary that keeps auto-detection falling through under
+ * Expo/React Native version skew instead of hard-failing. `typescript` is a
+ * stable devDependency with an `exports` map, so a bogus subpath of it triggers
+ * the code deterministically.
+ */
+export async function assertUnexportedSubpathReportsNotLoaded(): Promise<void> {
+  const { resolveUpstreamTransformer } = await TestMetroRuntime.loadUpstream();
+  const error = captureThrow(() =>
+    resolveUpstreamTransformer("typescript/@@ttsc-metro-absent-subpath@@"),
+  );
+  assert.match(
+    error.message,
+    /Could not load the configured upstream transformer/,
+  );
+  // A non-exported subpath is absence, not a wrapped initialization failure.
+  assert.doesNotMatch(error.message, /failed to (load|initialize)/i);
+  assert.equal((error as { cause?: unknown }).cause, undefined);
+}
+
+/**
  * Asserts an explicit configured transformer that throws while initializing
  * fails with its ORIGINAL diagnostic preserved (message + `cause`), not the
  * generic "Could not load the configured upstream transformer" absence message.

--- a/tests/test-metro/src/internal/metro-upstream.ts
+++ b/tests/test-metro/src/internal/metro-upstream.ts
@@ -2,6 +2,32 @@ import assert from "node:assert/strict";
 
 import { TestMetroRuntime } from "./metro-runtime";
 
+/** Run `fn`, returning the error it throws (fails the test if it does not). */
+function captureThrow(fn: () => unknown): Error {
+  try {
+    fn();
+  } catch (error) {
+    return error as Error;
+  }
+  return assert.fail("expected the call to throw") as never;
+}
+
+/** Escape a literal string for embedding in a `RegExp`. */
+function escapeRegExp(literal: string): RegExp {
+  return new RegExp(literal.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&"));
+}
+
+/** Walk the `cause` chain, collecting every message it exposes. */
+function messageChain(error: Error): string {
+  let text = error.message;
+  let cause: unknown = (error as { cause?: unknown }).cause;
+  while (cause instanceof Error) {
+    text += `\n${cause.message}`;
+    cause = (cause as { cause?: unknown }).cause;
+  }
+  return text;
+}
+
 /**
  * A stub upstream transformer tagged with the module specifier that produced
  * it.
@@ -83,4 +109,106 @@ export async function assertEmptyCustomPathFallsBackToAutoDetect(): Promise<void
     await nameOf(resolveUpstreamTransformer("", (p: string) => tagged(p))),
     (UPSTREAM_CANDIDATES as readonly string[])[0],
   );
+}
+
+/**
+ * Asserts an explicit configured path that genuinely does not resolve is
+ * reported as absence ("could not load"), NOT as an initialization failure, on
+ * the PRODUCTION path. This exercises the real `require.resolve` →
+ * `MODULE_NOT_FOUND` → undefined branch of `tryRequire` (no injected seam), the
+ * negative twin of the init-failure cases: a resolution failure of the
+ * requested specifier stays a plain absence.
+ */
+export async function assertAbsentConfiguredPathReportsNotLoaded(): Promise<void> {
+  const { resolveUpstreamTransformer } = await TestMetroRuntime.loadUpstream();
+  const error = captureThrow(() =>
+    resolveUpstreamTransformer("@@ttsc-metro-absent-candidate@@"),
+  );
+  assert.match(
+    error.message,
+    /Could not load the configured upstream transformer/,
+  );
+  // Absence is not wrapped as an initialization failure and carries no cause.
+  assert.doesNotMatch(error.message, /failed to (load|initialize)/i);
+  assert.equal((error as { cause?: unknown }).cause, undefined);
+}
+
+/**
+ * Asserts an explicit configured transformer that throws while initializing
+ * fails with its ORIGINAL diagnostic preserved (message + `cause`), not the
+ * generic "Could not load the configured upstream transformer" absence message.
+ * Runs through the production `require` loader against a real broken module on
+ * disk.
+ */
+export async function assertConfiguredInitFailurePreservesCause(): Promise<void> {
+  const { resolveUpstreamTransformer } = await TestMetroRuntime.loadUpstream();
+  const broken = TestMetroRuntime.throwingUpstreamOnDisk();
+  const error = captureThrow(() => resolveUpstreamTransformer(broken));
+  // The original throw is preserved somewhere in the chain...
+  assert.match(messageChain(error), /upstream dependency ABI mismatch/);
+  // ...and it is NOT masked as a plain absence.
+  assert.doesNotMatch(
+    error.message,
+    /Could not load the configured upstream transformer/,
+  );
+  // The cause carries the original stack context.
+  const cause = (error as { cause?: unknown }).cause;
+  assert.ok(cause instanceof Error, "original error is attached as `cause`");
+  assert.match((cause as Error).message, /upstream dependency ABI mismatch/);
+  assert.equal(typeof (cause as Error).stack, "string");
+}
+
+/**
+ * Asserts a configured transformer whose transitive dependency is missing
+ * reports THAT dependency failure (its `MODULE_NOT_FOUND`), rather than claiming
+ * the candidate itself is absent. This is the differentiator between a
+ * resolution failure of the requested specifier and a `MODULE_NOT_FOUND` raised
+ * while the (resolvable) module executes.
+ */
+export async function assertMissingTransitiveDependencyReported(): Promise<void> {
+  const { resolveUpstreamTransformer } = await TestMetroRuntime.loadUpstream();
+  const broken = TestMetroRuntime.missingDependencyUpstreamOnDisk();
+  const error = captureThrow(() => resolveUpstreamTransformer(broken));
+  // The missing transitive dependency is named in the diagnostic...
+  assert.match(
+    messageChain(error),
+    /@@ttsc-metro-absent-transitive-dependency@@/,
+  );
+  // ...and the candidate is not misreported as absent.
+  assert.doesNotMatch(
+    error.message,
+    /Could not load the configured upstream transformer/,
+  );
+}
+
+/**
+ * Asserts auto-detection does NOT fall through to a later candidate when an
+ * earlier, resolvable candidate throws during initialization. A broken Expo
+ * install must surface, not silently select the legacy React Native transformer.
+ */
+export async function assertAutoDetectInitFailureDoesNotFallThrough(): Promise<void> {
+  const { resolveUpstreamTransformer, UPSTREAM_CANDIDATES } =
+    await TestMetroRuntime.loadUpstream();
+  const [expo, , legacy] = UPSTREAM_CANDIDATES as readonly string[];
+  assert.ok(expo !== undefined && legacy !== undefined);
+  const error = captureThrow(() =>
+    resolveUpstreamTransformer(undefined, (p: string) => {
+      if (p === expo) {
+        throw new Error("expo transformer boom");
+      }
+      return tagged(p);
+    }),
+  );
+  // Surfaces the first candidate's failure with its cause...
+  assert.match(messageChain(error), /expo transformer boom/);
+  assert.match(error.message, escapeRegExp(expo));
+  const cause = (error as { cause?: unknown }).cause;
+  assert.ok(cause instanceof Error, "original error is attached as `cause`");
+  // ...and it is not the terminal "install one of these" message, i.e. it did
+  // not fall through to (and fail past) the legacy candidate.
+  assert.doesNotMatch(
+    error.message,
+    /Could not find an upstream Metro transformer/,
+  );
+  assert.doesNotMatch(error.message, escapeRegExp(legacy));
 }


### PR DESCRIPTION
## Bundle b8 — Metro upstream transformer errors

This bundle hardens `@ttsc/metro`'s upstream Babel-transformer loader so a broken-but-installed transformer is no longer masked as absence.

### Issues

- Closes #685 (RA-15) — `fix(metro): preserve upstream transformer initialization failures`

### Problem

`resolveUpstreamTransformer` treated every exception from `require`ing an upstream candidate as "module not present." An installed transformer that throws during top-level initialization, has a missing peer/transitive dependency, or rejects the current runtime ABI was silently discarded:

- an **explicit** `upstreamTransformer` failure surfaced only the generic `Could not load the configured upstream transformer`, dropping the original message and stack;
- **auto-detection** could skip the broken candidate and select a later one that does not match the active Expo/RN stack.

### Fix

`tryRequire` now splits resolution from execution. `require.resolve` never runs third-party code, so a `MODULE_NOT_FOUND` / `ERR_MODULE_NOT_FOUND` there proves the requested candidate itself is genuinely absent — reported as `undefined` so automatic probing continues to the next optional peer. Any error thrown while executing the (resolvable) module body is a real initialization failure and is preserved with its original message and stack as the `cause` of a `@ttsc/metro` wrapper. A candidate's own missing transitive dependency surfaces that dependency, not a false "absent candidate."

### Tests

Production-loader regressions under `tests/test-metro/src/features/upstream`, run with `pnpm --filter @ttsc/test-metro start -- --include=upstream`:

- genuinely-absent explicit path stays the plain absence message, no `cause`;
- explicit init-throw preserves the original diagnostic + `cause` + stack;
- missing transitive dependency is named, not misreported as absence;
- auto-detect does not fall through to a later candidate when an earlier one is broken.

Docs: `packages/metro/README.md` documents the absence-vs-broken distinction.
