### PR TITLE
fix(paths): preserve JSON extensions when aliases are rewritten to emitted files

### DIFF
--- a/packages/paths/driver/paths.go
+++ b/packages/paths/driver/paths.go
@@ -264,13 +264,21 @@ func (r *rewriter) outputPathForSource(source string) string {
   if err != nil || isOutsideRelativePath(rel) {
     return ""
   }
-  return normalizePath(filepath.Join(r.outDir, replaceSourceExtension(rel, emittedJavaScriptExtension(rel, r.jsxPreserve))))
+  return normalizePath(filepath.Join(r.outDir, replaceSourceExtension(rel, emittedExtension(rel, r.jsxPreserve))))
 }
 
-// emittedJavaScriptExtension returns the JavaScript file extension that TypeScript
-// emits for a given source path.
-func emittedJavaScriptExtension(source string, jsxPreserve bool) string {
-  switch strings.ToLower(filepath.Ext(source)) {
+// emittedExtension returns the output-file extension that TypeScript-Go writes
+// for a given Program source. TypeScript/JavaScript-family sources are
+// transpiled to the matching JavaScript runtime extension. Non-transpiled
+// assets that the compiler copies verbatim — such as `.json` sources pulled in
+// by resolveJsonModule — keep their original extension, so a rewritten
+// specifier names the file the compiler actually emits instead of an invented
+// `.js` sibling that never exists on disk.
+func emittedExtension(source string, jsxPreserve bool) string {
+  ext := filepath.Ext(source)
+  switch strings.ToLower(ext) {
+  case ".ts", ".js":
+    return ".js"
   case ".mts", ".mjs":
     return ".mjs"
   case ".cts", ".cjs":
@@ -281,7 +289,7 @@ func emittedJavaScriptExtension(source string, jsxPreserve bool) string {
     }
     return ".js"
   default:
-    return ".js"
+    return ext
   }
 }
 

--- a/packages/paths/test/linkname_helpers_test.go
+++ b/packages/paths/test/linkname_helpers_test.go
@@ -80,5 +80,5 @@ func pathsReplaceSourceExtension(value string, ext string) string
 //go:linkname pathsIsOutsideRelativePath github.com/samchon/ttsc/packages/paths/driver.isOutsideRelativePath
 func pathsIsOutsideRelativePath(rel string) bool
 
-//go:linkname pathsEmittedJavaScriptExtension github.com/samchon/ttsc/packages/paths/driver.emittedJavaScriptExtension
-func pathsEmittedJavaScriptExtension(source string, jsxPreserve bool) string
+//go:linkname pathsEmittedExtension github.com/samchon/ttsc/packages/paths/driver.emittedExtension
+func pathsEmittedExtension(source string, jsxPreserve bool) string

--- a/packages/paths/test/rewriter_helpers_cover_resolution_edges_test.go
+++ b/packages/paths/test/rewriter_helpers_cover_resolution_edges_test.go
@@ -180,14 +180,14 @@ func TestRewriterHelpersCoverResolutionEdges(t *testing.T) {
   if !pathsIsOutsideRelativePath("..") || !pathsIsOutsideRelativePath(filepath.Join("..", "x")) || pathsIsOutsideRelativePath("..x") {
     t.Fatal("outside relative path classification mismatch")
   }
-  if pathsEmittedJavaScriptExtension("x.mts", false) != ".mjs" ||
-    pathsEmittedJavaScriptExtension("x.mjs", false) != ".mjs" ||
-    pathsEmittedJavaScriptExtension("x.cts", false) != ".cjs" ||
-    pathsEmittedJavaScriptExtension("x.cjs", false) != ".cjs" ||
-    pathsEmittedJavaScriptExtension("x.tsx", true) != ".jsx" ||
-    pathsEmittedJavaScriptExtension("x.jsx", true) != ".jsx" ||
-    pathsEmittedJavaScriptExtension("x.jsx", false) != ".js" ||
-    pathsEmittedJavaScriptExtension("x.ts", false) != ".js" {
+  if pathsEmittedExtension("x.mts", false) != ".mjs" ||
+    pathsEmittedExtension("x.mjs", false) != ".mjs" ||
+    pathsEmittedExtension("x.cts", false) != ".cjs" ||
+    pathsEmittedExtension("x.cjs", false) != ".cjs" ||
+    pathsEmittedExtension("x.tsx", true) != ".jsx" ||
+    pathsEmittedExtension("x.jsx", true) != ".jsx" ||
+    pathsEmittedExtension("x.jsx", false) != ".js" ||
+    pathsEmittedExtension("x.ts", false) != ".js" {
     t.Fatal("emitted extension mismatch")
   }
 }

--- a/packages/paths/test/rewriter_maps_source_to_emitted_output_extension_test.go
+++ b/packages/paths/test/rewriter_maps_source_to_emitted_output_extension_test.go
@@ -1,0 +1,73 @@
+package paths_test
+
+import (
+  "testing"
+)
+
+// TestRewriterMapsSourceToEmittedOutputExtension verifies the source-to-output
+// extension matrix at outputPathForSource.
+//
+// The predictor must name the file TypeScript-Go actually emits or copies for a
+// resolved Program source. TypeScript/JavaScript-family sources transpile to
+// their runtime suffix, but copied assets (`.json` under resolveJsonModule) keep
+// their extension. Pinning `.json` here proves the fix for the invented `.js`
+// JSON target (#680) and the negative twins keep the established JS-family
+// mappings from silently absorbing every unknown extension into `.js`.
+//
+// 1. Build a rewriter rooted at src → dist with jsx preserve toggled per case.
+// 2. Map each source extension through outputPathForSource.
+// 3. Assert copied assets keep their extension while code compiles to JS.
+func TestRewriterMapsSourceToEmittedOutputExtension(t *testing.T) {
+  const root = "/repo"
+  const src = root + "/src"
+  const out = root + "/dist"
+
+  base := func(jsxPreserve bool) *pathsRewriter {
+    return &pathsRewriter{
+      basePath:    root,
+      jsxPreserve: jsxPreserve,
+      outDir:      out,
+      rootDir:     src,
+      sourceFiles: map[string]string{},
+    }
+  }
+
+  cases := []struct {
+    name        string
+    source      string
+    jsxPreserve bool
+    want        string
+  }{
+    // Copied assets keep their own extension: the fix for #680.
+    {"json commonjs asset", src + "/data.json", false, out + "/data.json"},
+    {"json nested asset", src + "/config/data.json", false, out + "/config/data.json"},
+    {"json double extension", src + "/data.config.json", false, out + "/data.config.json"},
+    {"json uppercase preserved", src + "/DATA.JSON", false, out + "/DATA.JSON"},
+    // JavaScript/TypeScript families still transpile to their runtime suffix.
+    {"ts to js", src + "/main.ts", false, out + "/main.js"},
+    {"tsx to js without preserve", src + "/view.tsx", false, out + "/view.js"},
+    {"tsx to jsx with preserve", src + "/view.tsx", true, out + "/view.jsx"},
+    {"jsx to js without preserve", src + "/view.jsx", false, out + "/view.js"},
+    {"jsx to jsx with preserve", src + "/view.jsx", true, out + "/view.jsx"},
+    {"js stays js", src + "/legacy.js", false, out + "/legacy.js"},
+    {"mts to mjs", src + "/module.mts", false, out + "/module.mjs"},
+    {"mjs stays mjs", src + "/module.mjs", false, out + "/module.mjs"},
+    {"cts to cjs", src + "/module.cts", false, out + "/module.cjs"},
+    {"cjs stays cjs", src + "/module.cjs", false, out + "/module.cjs"},
+  }
+
+  for _, tc := range cases {
+    if got := pathsOutputPathForSource(base(tc.jsxPreserve), tc.source); got != tc.want {
+      t.Fatalf("%s: outputPathForSource(%q) = %q, want %q", tc.name, tc.source, got, tc.want)
+    }
+  }
+
+  // Negative twin at the extension helper: an unknown copied asset must never be
+  // rewritten to a `.js` sibling that the compiler never produced.
+  if got := pathsEmittedExtension("asset.json", false); got != ".json" {
+    t.Fatalf("json emitted extension = %q, want .json", got)
+  }
+  if got := pathsEmittedExtension("asset.js", false); got != ".js" {
+    t.Fatalf("js emitted extension = %q, want .js", got)
+  }
+}

--- a/packages/paths/test/rewriter_resolves_exact_json_alias_without_widening_extensionless_lookup_test.go
+++ b/packages/paths/test/rewriter_resolves_exact_json_alias_without_widening_extensionless_lookup_test.go
@@ -1,0 +1,62 @@
+package paths_test
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestRewriterResolvesExactJsonAliasWithoutWideningExtensionlessLookup pins the
+// resolution seam that feeds the JSON output-extension fix (#680).
+//
+// The predictor may only preserve a `.json` extension for a source the resolver
+// actually committed to. Two invariants keep that honest: an exact alias to a
+// `.json` source resolves and rewrites to `./data.json` (the file the compiler
+// copies), while an extensionless alias whose stem only exists as `.json` must
+// stay unrewritten — `sourceLookupExtensions` deliberately excludes `.json`, so
+// the negative twin proves the extension-fallback lookup was not accidentally
+// widened. Without the negative case a future edit adding `.json` to that list
+// would silently pass every other test.
+//
+//  1. Build a rewriter with an exact `.json` target and an extensionless target
+//     backed only by a `.json` source.
+//  2. Resolve and rewrite both aliases from a sibling `.ts` source.
+//  3. Assert the exact alias rewrites to `./data.json` and the extensionless one
+//     is left unchanged.
+func TestRewriterResolvesExactJsonAliasWithoutWideningExtensionlessLookup(t *testing.T) {
+	root := filepath.ToSlash(filepath.Join(t.TempDir(), "repo"))
+	src := root + "/src"
+	out := root + "/dist"
+	rewriter := &pathsRewriter{
+		basePath: root,
+		outDir:   out,
+		rootDir:  src,
+		patterns: []pathsPathPattern{
+			{pattern: "@data", targets: []string{"src/data.json"}},
+			{pattern: "@bare", targets: []string{"src/config"}},
+		},
+		sourceFiles: map[string]string{
+			src + "/main.ts":     src + "/main.ts",
+			src + "/data.json":   src + "/data.json",
+			src + "/config.json": src + "/config.json",
+		},
+	}
+
+	// Transformation direction: an exact `.json` alias resolves to the copied
+	// source and rewrites to the extension the compiler actually emits.
+	if source, ok := pathsResolveSource(rewriter, "@data"); !ok || source != src+"/data.json" {
+		t.Fatalf("exact json source mismatch: source=%q ok=%v", source, ok)
+	}
+	if rewritten, ok := pathsRewrite(rewriter, src+"/main.ts", "@data"); !ok || rewritten != "./data.json" {
+		t.Fatalf("exact json rewrite mismatch: rewritten=%q ok=%v", rewritten, ok)
+	}
+
+	// Negative twin: an extensionless target backed only by a `.json` source must
+	// not resolve, because `.json` is not a source-lookup extension. The alias is
+	// left untouched instead of being rewritten to an invented file.
+	if source, ok := pathsResolveSource(rewriter, "@bare"); ok {
+		t.Fatalf("extensionless json target must not resolve: source=%q", source)
+	}
+	if rewritten, ok := pathsRewrite(rewriter, src+"/main.ts", "@bare"); ok || rewritten != "@bare" {
+		t.Fatalf("extensionless json rewrite must be left alone: rewritten=%q ok=%v", rewritten, ok)
+	}
+}

--- a/tests/test-paths/src/features/test_paths_rewrites_commonjs_json_alias_to_copied_extension.ts
+++ b/tests/test-paths/src/features/test_paths_rewrites_commonjs_json_alias_to_copied_extension.ts
@@ -1,0 +1,84 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TestPaths } from "../internal/TestPaths";
+import { SHARED_PLUGIN_CACHE_DIR } from "../internal/plugin-cache";
+
+/**
+ * Verifies the @ttsc/paths plugin: an exact `.json` alias keeps the copied
+ * extension in CommonJS emit.
+ *
+ * Under `resolveJsonModule`, TypeScript-Go copies the JSON asset to `outDir`
+ * under its own name, but the output-path predictor used to treat every
+ * unrecognized source extension as JavaScript and rewrote `@data` to a
+ * nonexistent `./data.js`. The build then succeeded while `node` failed with
+ * `MODULE_NOT_FOUND`. This pins the copied-asset extension end to end: the
+ * emitted `require` must name `./data.json`, that file must exist, no `.js`
+ * sibling may be invented, and the program must actually run.
+ *
+ * 1. Build a CommonJS `resolveJsonModule` project whose `@data` alias targets
+ *    `./src/data.json`, imported from `src/main.ts`.
+ * 2. Run real `ttsc --emit`, then execute the emitted `dist/main.js` with Node.
+ * 3. Assert the emit requires `./data.json`, `dist/data.json` exists, no
+ *    `dist/data.js` was invented, and the program prints the JSON payload.
+ */
+export const test_paths_rewrites_commonjs_json_alias_to_copied_extension =
+  () => {
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          module: "commonjs",
+          target: "ES2022",
+          resolveJsonModule: true,
+          esModuleInterop: true,
+          rootDir: "src",
+          outDir: "dist",
+          paths: { "@data": ["./src/data.json"] },
+          plugins: [{ transform: "@ttsc/paths" }],
+        },
+        include: ["src"],
+      }),
+      "src/data.json": JSON.stringify({ name: "ttsc", answer: 42 }, null, 2),
+      "src/main.ts": [
+        `import data from "@data";`,
+        `console.log(data.name + ":" + data.answer);`,
+        ``,
+      ].join("\n"),
+    });
+    TestPaths.seedPackage(root);
+
+    const result = TestProject.spawn(
+      TestProject.TTSC_BIN,
+      ["--cwd", root, "--emit"],
+      {
+        cwd: root,
+        env: {
+          PATH: TestPaths.goPath(),
+          TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+
+    const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+    assert.match(js, /require\("\.\/data\.json"\)/);
+    assert.doesNotMatch(js, /require\("\.\/data\.js"\)/);
+    assert.doesNotMatch(js, /@data/);
+
+    assert.ok(
+      fs.existsSync(path.join(root, "dist", "data.json")),
+      "dist/data.json must be copied by the compiler",
+    );
+    assert.ok(
+      !fs.existsSync(path.join(root, "dist", "data.js")),
+      "no invented dist/data.js sibling may exist",
+    );
+
+    const run = TestProject.runNode(path.join(root, "dist", "main.js"), {
+      cwd: root,
+    });
+    assert.equal(run.status, 0, run.stderr);
+    assert.match(run.stdout, /ttsc:42/);
+  };

--- a/tests/test-paths/src/features/test_paths_rewrites_esm_json_alias_with_import_attribute.ts
+++ b/tests/test-paths/src/features/test_paths_rewrites_esm_json_alias_with_import_attribute.ts
@@ -1,0 +1,78 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TestPaths } from "../internal/TestPaths";
+import { SHARED_PLUGIN_CACHE_DIR } from "../internal/plugin-cache";
+
+/**
+ * Verifies the @ttsc/paths plugin: an exact `.json` alias keeps the copied
+ * extension and its import attribute in ESM emit with declarations.
+ *
+ * The output-path predictor must name the file TypeScript-Go copies (`.json`),
+ * not an invented `.js` sibling, and the rewrite must touch only the specifier
+ * text — the `with { type: "json" }` attribute Node requires for ESM JSON stays
+ * intact. Declaration emit must likewise never introduce a nonexistent `.js`
+ * JSON target. A `.mjs`/`.d.mts` project pins all three under NodeNext.
+ *
+ * 1. Build a NodeNext `resolveJsonModule` project whose `@data` alias targets
+ *    `./src/data.json`, imported with an attribute from `src/main.mts`.
+ * 2. Run real `ttsc --emit`.
+ * 3. Assert the emitted specifier is `./data.json` with its attribute retained,
+ *    no `.js` JSON target appears in the JavaScript or declaration output, and
+ *    `dist/data.json` exists.
+ */
+export const test_paths_rewrites_esm_json_alias_with_import_attribute = () => {
+  const root = TestProject.createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        target: "ES2022",
+        declaration: true,
+        resolveJsonModule: true,
+        strict: true,
+        rootDir: "src",
+        outDir: "dist",
+        paths: { "@data": ["./src/data.json"] },
+        plugins: [{ transform: "@ttsc/paths" }],
+      },
+      include: ["src"],
+    }),
+    "src/data.json": JSON.stringify({ answer: 42 }, null, 2),
+    "src/main.mts": [
+      `import data from "@data" with { type: "json" };`,
+      `export const answer: number = data.answer;`,
+      ``,
+    ].join("\n"),
+  });
+  TestPaths.seedPackage(root);
+
+  const result = TestProject.spawn(
+    TestProject.TTSC_BIN,
+    ["--cwd", root, "--emit"],
+    {
+      cwd: root,
+      env: {
+        PATH: TestPaths.goPath(),
+        TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
+      },
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+
+  const mjs = fs.readFileSync(path.join(root, "dist", "main.mjs"), "utf8");
+  assert.match(mjs, /from "\.\/data\.json"/);
+  assert.match(mjs, /type: "json"/);
+  assert.doesNotMatch(mjs, /\.\/data\.js"/);
+  assert.doesNotMatch(mjs, /@data/);
+
+  assert.ok(
+    fs.existsSync(path.join(root, "dist", "data.json")),
+    "dist/data.json must be copied by the compiler",
+  );
+
+  const dts = fs.readFileSync(path.join(root, "dist", "main.d.mts"), "utf8");
+  assert.doesNotMatch(dts, /data\.js"/);
+};

--- a/website/src/content/docs/development/walkthroughs/paths.mdx
+++ b/website/src/content/docs/development/walkthroughs/paths.mdx
@@ -389,7 +389,7 @@ The captured `*` substitutes into each target: `./src/modules/*` → `./src/modu
 
 `lookupSource` walks three stages, falling through on each miss: literal match in the `sourceFiles` map → stem with each of `.ts` / `.tsx` / `.mts` / `.cts` / `.js` / `.jsx` / `.mjs` / `.cjs` appended → stem + `/index.<ext>` for directory-style imports. The exact source is in [`driver/paths.go::lookupSource`](https://github.com/samchon/ttsc/tree/master/packages/paths/driver/paths.go).
 
-### 5. Mapping source to emitted-JS path
+### 5. Mapping source to emitted-output path
 
 ```go
 func (r *rewriter) outputPathForSource(source string) string {
@@ -400,11 +400,14 @@ func (r *rewriter) outputPathForSource(source string) string {
   if err != nil || isOutsideRelativePath(rel) {
     return ""
   }
-  return normalizePath(filepath.Join(r.outDir, replaceSourceExtension(rel, emittedJavaScriptExtension(rel, r.jsxPreserve))))
+  return normalizePath(filepath.Join(r.outDir, replaceSourceExtension(rel, emittedExtension(rel, r.jsxPreserve))))
 }
 
-func emittedJavaScriptExtension(source string, jsxPreserve bool) string {
-  switch strings.ToLower(filepath.Ext(source)) {
+func emittedExtension(source string, jsxPreserve bool) string {
+  ext := filepath.Ext(source)
+  switch strings.ToLower(ext) {
+  case ".ts", ".js":
+    return ".js"
   case ".mts", ".mjs":
     return ".mjs"
   case ".cts", ".cjs":
@@ -415,12 +418,12 @@ func emittedJavaScriptExtension(source string, jsxPreserve bool) string {
     }
     return ".js"
   default:
-    return ".js"
+    return ext
   }
 }
 ```
 
-The mapping is tsgo's emit rule, replicated here because the plugin needs to predict the output path the compiler will write. `replaceSourceExtension(rel, ext)` strips the source extension and appends `.js`, `.mjs`, `.cjs`, or `.jsx` depending on the matched source and `jsx` mode.
+The mapping is tsgo's emit rule, replicated here because the plugin needs to predict the output path the compiler will write. `replaceSourceExtension(rel, ext)` strips the source extension and appends the predicted one. TypeScript/JavaScript-family sources transpile to `.js`, `.mjs`, `.cjs`, or `.jsx` depending on the matched source and `jsx` mode. The `default` branch returns the source's own extension unchanged, so an asset the compiler _copies_ rather than transpiles — a `.json` source pulled in by `resolveJsonModule` — keeps its extension and the rewritten specifier names the file tsgo actually writes (`./data.json`) instead of an invented `./data.js` that never exists on disk.
 
 `isOutsideRelativePath` checks `rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))`, sources outside the rootDir do not have a well-defined output and the rewriter bails out.
 

--- a/website/src/content/docs/plugins/paths.mdx
+++ b/website/src/content/docs/plugins/paths.mdx
@@ -52,6 +52,7 @@ import { value } from "./modules/value.js";
 - When several patterns match one specifier, an exact pattern wins, then the longest literal prefix: the same order tsc uses to resolve the import.
 - Rewrites JavaScript-family emit (`.js`, `.mjs`, `.cjs`, `.jsx`) and `.d.ts` declarations.
 - Resolves extensionless path targets against `.ts`, `.tsx`, `.mts`, `.cts`, then `.js`, `.jsx`, `.mjs`, and `.cjs` source files.
+- Preserves the extension of assets the compiler copies rather than transpiles: an exact alias to a `.json` source pulled in by `resolveJsonModule` rewrites to `./data.json`, the file TypeScript-Go actually copies, keeping any `import ... with { type: "json" }` attribute intact — never an invented `./data.js`.
 - No separate plugin config.
 - Only rewrites specifiers that match `compilerOptions.paths`; relative, absolute, and non-matching package specifiers are left alone.
 - Uses TypeScript-Go's emitted runtime suffix for matched targets (`.js`, `.mjs`, `.cjs`, or `.jsx` depending on the source file and `jsx` mode).


### PR DESCRIPTION
## Bundle b10 — `@ttsc/paths` JSON extension preservation

Part of the `repository-audit-2026-07` issue campaign.

### Scope

`@ttsc/paths` predicts the emitted output path for a resolved Program source so it can rewrite a `compilerOptions.paths` alias to the file the compiler actually produces. Its predictor treated **every** unrecognized source extension as JavaScript. When `resolveJsonModule` pulls a `.json` source into the Program and an exact alias targets it, the plugin rewrote the specifier to a nonexistent `./data.js` even though TypeScript-Go copies the asset as `.json`. The build exited 0 and Node failed at runtime with `MODULE_NOT_FOUND`.

### Fix

At the output-path owner (`packages/paths/driver/paths.go`):

- Rename `emittedJavaScriptExtension` → `emittedExtension` and change the default branch to **preserve** the source extension for assets the compiler copies verbatim (`.json`), instead of inventing a `.js` sibling.
- Keep every established TypeScript/JavaScript-family mapping (`.ts`/`.js`→`.js`, `.mts`/`.mjs`→`.mjs`, `.cts`/`.cjs`→`.cjs`, `.tsx`/`.jsx`→`.js` or `.jsx` under `jsx: preserve`).
- Extensionless target lookup (`sourceLookupExtensions`) is **not** widened to include `.json`; only exact `.json` aliases resolve, matching the issue's boundary.

### Tests

- `packages/paths/test/rewriter_maps_source_to_emitted_output_extension_test.go` — full source-to-output extension matrix (copied assets keep their extension incl. nested / double-extension / uppercase; JS/TS families transpile; negative twin at the helper proving unknown assets are never absorbed into `.js`).
- `tests/test-paths/src/features/test_paths_rewrites_commonjs_json_alias_to_copied_extension.ts` — real CommonJS build + Node run; asserts the emit requires `./data.json`, no `./data.js` is invented, the file exists, and the program runs.
- `tests/test-paths/src/features/test_paths_rewrites_esm_json_alias_with_import_attribute.ts` — NodeNext ESM + declarations; asserts the `with { type: "json" }` attribute survives, the specifier is `./data.json`, and neither the `.mjs` nor `.d.mts` output invents a `.js` JSON target.

Docs updated: `website/src/content/docs/plugins/paths.mdx`.

### Issues

Closes #680
