### PR TITLE
fix(platform): coherent linux-arm baseline and release tag/version validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: pnpm/action-setup@v4
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Preflight - validate release tag and package versions
+        run: node scripts/release-preflight.cjs
       - name: Build all packages
         run: pnpm run build
       - name: Assert dist/ttsc.wasm exists and is >10MB

--- a/packages/ttsc-linux-arm/README.md
+++ b/packages/ttsc-linux-arm/README.md
@@ -4,6 +4,10 @@ Linux arm native binaries and bundled Go compiler package for `ttsc`.
 
 This package is normally installed as an optional dependency of `ttsc`. Application projects should install `ttsc`, not this package directly.
 
+## ARM baseline
+
+Every artifact in this package targets the **ARMv6** baseline. The three executables (`bin/ttsc`, `bin/ttscserver`, `bin/ttscgraph`) are cross-compiled with `GOARM=6`, and the bundled Go SDK is the `linux-armv6l` distribution, so the executables and the SDK share one minimum ARM generation. ARMv6 code runs on later ARM generations (ARMv7, ARMv8/`arm64` in 32-bit mode), so this package supports the broad npm `arm` CPU contract rather than an ARMv7-only subset.
+
 It contains the `ttsc` platform helper, the `ttscserver` LSP wrapper, the `ttscgraph` MCP code-graph server, and the Go SDK used when `ttsc` builds Go source plugins. If your package manager skipped optional dependencies, reinstall `ttsc` with optional dependencies enabled.
 
 ## Package contents

--- a/scripts/build-platform-package.cjs
+++ b/scripts/build-platform-package.cjs
@@ -3,6 +3,8 @@ const fs = require("node:fs");
 const path = require("node:path");
 const zlib = require("node:zlib");
 
+const { resolveGoTarget } = require("./platform-target.cjs");
+
 const cwd = process.cwd();
 const manifest = JSON.parse(
   fs.readFileSync(path.join(cwd, "package.json"), "utf8"),
@@ -18,8 +20,8 @@ if (!match) {
 }
 
 const [, npmOs, npmArch] = match;
-const goos = npmOs === "win32" ? "windows" : npmOs;
-const goarch = npmArch === "x64" ? "amd64" : npmArch;
+const goTarget = resolveGoTarget(npmOs, npmArch);
+const { goos, goarch, goarm } = goTarget;
 const root = path.resolve(cwd, "../..");
 const source = path.join(root, "packages", "ttsc");
 const outDir = path.join(cwd, "bin");
@@ -106,6 +108,9 @@ function buildGoTarget(name, output, pkg) {
       CGO_ENABLED: "0",
       GOARCH: goarch,
       GOOS: goos,
+      // Pin the ARM baseline for the 32-bit arm package so the executables match
+      // the bundled linux-armv6l SDK instead of defaulting to ARMv7.
+      ...(goarm ? { GOARM: goarm } : {}),
       PATH: pathValue,
     },
     stdio: "inherit",
@@ -244,10 +249,7 @@ function goArchiveName(version) {
 }
 
 function goArchiveTarget() {
-  const os = npmOs === "win32" ? "windows" : npmOs;
-  const arch =
-    npmArch === "x64" ? "amd64" : npmArch === "arm" ? "armv6l" : npmArch;
-  return `${os}-${arch}`;
+  return goTarget.archiveTarget;
 }
 
 function extractZipArchive(archivePath, extractDir) {

--- a/scripts/platform-target.cjs
+++ b/scripts/platform-target.cjs
@@ -1,0 +1,32 @@
+// Coherent Go build target for one `@ttsc/{os}-{arch}` platform package.
+//
+// A single record ties the executable build environment (`GOOS`, `GOARCH`,
+// `GOARM`) to the bundled Go SDK archive suffix so the two cannot drift onto
+// different CPU baselines. The linux-arm package bundles the `linux-armv6l`
+// SDK, so its executables must also be built for ARMv6: without an explicit
+// `GOARM` the toolchain defaults to ARMv7 and emits executables that the ARMv6
+// baseline is not guaranteed to run. Keeping the archive suffix derived from
+// the same record makes that ARMv6 contract the one source of truth.
+
+/**
+ * @param {"linux"|"darwin"|"win32"} npmOs
+ * @param {"x64"|"arm"|"arm64"} npmArch
+ * @returns {{ goos: string, goarch: string, goarm: string|undefined, archiveArch: string, archiveTarget: string }}
+ */
+function resolveGoTarget(npmOs, npmArch) {
+  const goos = npmOs === "win32" ? "windows" : npmOs;
+  const goarch = npmArch === "x64" ? "amd64" : npmArch;
+  // Only the 32-bit `arm` package pins an ARM sub-architecture. `arm64` (ARMv8)
+  // carries no GOARM, and non-ARM targets never set it.
+  const goarm = npmArch === "arm" ? "6" : undefined;
+  const archiveArch = goarm ? `armv${goarm}l` : goarch;
+  return {
+    goos,
+    goarch,
+    goarm,
+    archiveArch,
+    archiveTarget: `${goos}-${archiveArch}`,
+  };
+}
+
+module.exports = { resolveGoTarget };

--- a/scripts/release-preflight.cjs
+++ b/scripts/release-preflight.cjs
@@ -1,0 +1,156 @@
+// Release preflight gate: validate the pushed tag and every published package
+// version as one coherent release BEFORE any external publication command runs.
+//
+// The release workflow triggers on every pushed tag (`on.push.tags: ["*"]`) and
+// publishes to the VS Code Marketplace and npm before any tag-derived smoke test
+// runs. A malformed tag, or a tag whose version disagrees with the workspace
+// manifests, could therefore create irreversible external releases and only then
+// fail. This script encodes the repository's lockstep release shape and fails
+// with a non-zero exit and zero side effects when the release is incoherent:
+//
+//   - the tag must be exactly `v${version}` for a valid semver version
+//     (prerelease identifiers allowed);
+//   - every public workspace package selected by `package:latest:publish`
+//     (non-private `packages/*`) must carry that same version; and
+//   - the VS Code extension manifest (`packages/vscode`), whose version names
+//     the generated VSIX/Marketplace artifact, must agree as well.
+//
+// The script only reads files and writes to stdout/stderr; it never mutates a
+// registry, so it is safe to run as the first release step and to unit-test with
+// a synthetic `--root`.
+//
+// Usage:
+//   node scripts/release-preflight.cjs                 # tag from GITHUB_REF_NAME
+//   node scripts/release-preflight.cjs --tag v1.2.3    # explicit tag
+//   node scripts/release-preflight.cjs --tag v1.2.3 --root /path/to/workspace
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Official SemVer 2.0.0 grammar (https://semver.org). Captures the core version
+// and optional prerelease/build-metadata; anchored so garbage tags are rejected.
+const SEMVER =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+/**
+ * Validate a release without any side effects.
+ *
+ * @param {{ tag?: string, root?: string }} options
+ * @returns {{ ok: boolean, errors: string[], version: string|null, packages: string[] }}
+ */
+function runPreflight(options) {
+  const root = options.root ?? path.resolve(__dirname, "..");
+  const tag = options.tag;
+  const errors = [];
+
+  if (!tag) {
+    errors.push(
+      "release-preflight: no release tag provided (set GITHUB_REF_NAME or pass --tag)",
+    );
+    return { ok: false, errors, version: null, packages: [] };
+  }
+
+  const versionMatch = /^v(.+)$/.exec(tag);
+  if (!versionMatch) {
+    errors.push(
+      `release-preflight: tag ${JSON.stringify(tag)} must be exactly v\${version} (missing leading 'v')`,
+    );
+    return { ok: false, errors, version: null, packages: [] };
+  }
+  const version = versionMatch[1];
+  if (!SEMVER.test(version)) {
+    errors.push(
+      `release-preflight: tag ${JSON.stringify(tag)} does not encode a valid semver version (${JSON.stringify(version)})`,
+    );
+    return { ok: false, errors, version, packages: [] };
+  }
+
+  const packagesDir = path.join(root, "packages");
+  if (!fs.existsSync(packagesDir)) {
+    errors.push(`release-preflight: no packages directory at ${packagesDir}`);
+    return { ok: false, errors, version, packages: [] };
+  }
+
+  const published = [];
+  let vscodeChecked = false;
+  for (const entry of fs.readdirSync(packagesDir).sort()) {
+    const manifestPath = path.join(packagesDir, entry, "package.json");
+    if (!fs.existsSync(manifestPath)) continue;
+    let manifest;
+    try {
+      manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    } catch (cause) {
+      errors.push(
+        `release-preflight: packages/${entry}/package.json is not valid JSON: ${cause.message}`,
+      );
+      continue;
+    }
+    // `package:latest:publish` runs `pnpm -r publish`, which skips private
+    // packages; the preflight must mirror that selection exactly.
+    if (manifest.private === true) continue;
+    if (typeof manifest.name !== "string") continue;
+
+    published.push(manifest.name);
+    if (typeof manifest.version !== "string") {
+      errors.push(
+        `release-preflight: ${manifest.name} has no version to publish`,
+      );
+      continue;
+    }
+    if (manifest.version !== version) {
+      errors.push(
+        `release-preflight: ${manifest.name} version ${JSON.stringify(manifest.version)} does not match tag version ${JSON.stringify(version)}`,
+      );
+    }
+    if (manifest.name === "@ttsc/vscode") vscodeChecked = true;
+  }
+
+  if (published.length === 0) {
+    errors.push(
+      `release-preflight: no publishable packages found under ${packagesDir}`,
+    );
+  }
+  // The VSIX/Marketplace artifact name is derived from packages/vscode's
+  // version; if that package is absent the cross-artifact check silently passes,
+  // so require its presence explicitly.
+  if (published.length > 0 && !vscodeChecked) {
+    errors.push(
+      "release-preflight: @ttsc/vscode manifest not found; cannot validate the VSIX/Marketplace artifact version",
+    );
+  }
+
+  return { ok: errors.length === 0, errors, version, packages: published };
+}
+
+function parseArgs(argv) {
+  const options = { tag: process.env.GITHUB_REF_NAME, root: undefined };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--tag") {
+      options.tag = argv[++i];
+    } else if (arg.startsWith("--tag=")) {
+      options.tag = arg.slice("--tag=".length);
+    } else if (arg === "--root") {
+      options.root = argv[++i];
+    } else if (arg.startsWith("--root=")) {
+      options.root = arg.slice("--root=".length);
+    } else {
+      throw new Error(`release-preflight: unknown argument ${JSON.stringify(arg)}`);
+    }
+  }
+  return options;
+}
+
+if (require.main === module) {
+  const options = parseArgs(process.argv.slice(2));
+  const result = runPreflight(options);
+  if (!result.ok) {
+    for (const error of result.errors) console.error(error);
+    process.exit(1);
+  }
+  console.log(
+    `release-preflight: OK — tag v${result.version} matches ${result.packages.length} publishable package(s)`,
+  );
+}
+
+module.exports = { runPreflight, parseArgs, SEMVER };

--- a/tests/test-ttsc/src/features/platform/test_platform_target_matrix_pins_linux_arm_to_armv6.ts
+++ b/tests/test-ttsc/src/features/platform/test_platform_target_matrix_pins_linux_arm_to_armv6.ts
@@ -1,0 +1,80 @@
+import { assert, fs, path, requireFromTest, workspaceRoot } from "../../internal/toolchain";
+
+/**
+ * Verifies the platform build target matrix pins linux-arm to the ARMv6 baseline.
+ *
+ * Locks `scripts/platform-target.cjs::resolveGoTarget` and its use in
+ * `scripts/build-platform-package.cjs`. The linux-arm package bundles the
+ * `linux-armv6l` Go SDK, but the executables were cross-compiled with no GOARM,
+ * which the toolchain defaults to ARMv7; the SDK and executables then targeted
+ * different CPU baselines. The fix forces GOARM=6 and derives the SDK archive
+ * suffix from the same record so all three executables and the bundled SDK share
+ * one baseline. arm64 and non-ARM targets are the negative twins that must never
+ * acquire a GOARM.
+ *
+ * 1. Resolve the Go target for linux-arm and assert GOOS=linux, GOARCH=arm,
+ *    GOARM=6, and archiveTarget=linux-armv6l.
+ * 2. Resolve the negative twins (linux-arm64, linux-x64, darwin-arm64,
+ *    win32-x64) and assert none carries a GOARM and each keeps its own archive.
+ * 3. Read build-platform-package.cjs and assert the shared record injects GOARM
+ *    into a single buildGoTarget that builds all three executables.
+ */
+export const test_platform_target_matrix_pins_linux_arm_to_armv6 = () => {
+  const { resolveGoTarget } = requireFromTest(
+    path.join(workspaceRoot, "scripts", "platform-target.cjs"),
+  ) as {
+    resolveGoTarget: (
+      npmOs: string,
+      npmArch: string,
+    ) => {
+      goos: string;
+      goarch: string;
+      goarm: string | undefined;
+      archiveArch: string;
+      archiveTarget: string;
+    };
+  };
+
+  // Positive: the fix direction. linux-arm must build ARMv6 executables to match
+  // its bundled linux-armv6l SDK.
+  const arm = resolveGoTarget("linux", "arm");
+  assert.equal(arm.goos, "linux");
+  assert.equal(arm.goarch, "arm");
+  assert.equal(arm.goarm, "6");
+  assert.equal(arm.archiveArch, "armv6l");
+  assert.equal(arm.archiveTarget, "linux-armv6l");
+
+  // Negative twins: every other target must resolve without a GOARM, and its
+  // archive suffix must stay on its own architecture (never armv6l).
+  const arm64 = resolveGoTarget("linux", "arm64");
+  assert.equal(arm64.goarch, "arm64");
+  assert.equal(arm64.goarm, undefined);
+  assert.equal(arm64.archiveTarget, "linux-arm64");
+
+  const x64 = resolveGoTarget("linux", "x64");
+  assert.equal(x64.goarch, "amd64");
+  assert.equal(x64.goarm, undefined);
+  assert.equal(x64.archiveTarget, "linux-amd64");
+
+  const darwin = resolveGoTarget("darwin", "arm64");
+  assert.equal(darwin.goos, "darwin");
+  assert.equal(darwin.goarm, undefined);
+  assert.equal(darwin.archiveTarget, "darwin-arm64");
+
+  const win = resolveGoTarget("win32", "x64");
+  assert.equal(win.goos, "windows");
+  assert.equal(win.goarm, undefined);
+  assert.equal(win.archiveTarget, "windows-amd64");
+
+  // Structural guard: all three executables must flow through one buildGoTarget
+  // that injects GOARM from the shared record, so a future edit cannot pin only
+  // one binary to ARMv6 while the others drift back to the ARMv7 default.
+  const scriptSource = fs.readFileSync(
+    path.join(workspaceRoot, "scripts", "build-platform-package.cjs"),
+    "utf8",
+  );
+  assert.match(scriptSource, /GOARM:\s*goarm/);
+  for (const target of ["ttsc", "ttscserver", "ttscgraph"]) {
+    assert.match(scriptSource, new RegExp(`buildGoTarget\\("${target}"`));
+  }
+};

--- a/tests/test-ttsc/src/features/platform/test_release_preflight_rejects_incoherent_tag_and_versions.ts
+++ b/tests/test-ttsc/src/features/platform/test_release_preflight_rejects_incoherent_tag_and_versions.ts
@@ -1,0 +1,141 @@
+import {
+  assert,
+  child_process,
+  fs,
+  path,
+  workspaceRoot,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies the release preflight rejects incoherent tags and package versions.
+ *
+ * Locks `scripts/release-preflight.cjs::runPreflight`, the gate that must fail a
+ * release before the workflow reaches Marketplace or npm publication. The
+ * workflow triggers on every pushed tag, so a malformed tag or a tag whose
+ * version disagrees with the workspace manifests could otherwise publish
+ * irreversible releases and only then fail a post-publish smoke test. Each case
+ * has a negative twin so an over-permissive check cannot hide.
+ *
+ * 1. Materialize synthetic workspaces (canonical, prerelease, per-package
+ *    mismatch, missing vscode) under a temp root.
+ * 2. Spawn the preflight script with a tag against each root.
+ * 3. Assert exit 0 only for the coherent canonical and prerelease releases, and
+ *    exit 1 with the offending reason for every malformed or mismatched input,
+ *    proving the private package is skipped and no case mutates state.
+ */
+export const test_release_preflight_rejects_incoherent_tag_and_versions = () => {
+  const script = path.join(workspaceRoot, "scripts", "release-preflight.cjs");
+  const root = fs.mkdtempSync(path.join(process.cwd(), ".tmp-release-preflight-"));
+  try {
+    const run = (dir: string, tag: string) =>
+      child_process.spawnSync(
+        process.execPath,
+        [script, "--root", dir, "--tag", tag],
+        { cwd: workspaceRoot, encoding: "utf8", windowsHide: true },
+      );
+
+    // Canonical: every public package plus @ttsc/vscode at the tagged version,
+    // with a private package deliberately off-version to prove it is skipped.
+    const canonical = writeWorkspace(root, "canonical", "0.19.0", {
+      private: { name: "@ttsc/internal-tool", version: "0.0.0", private: true },
+    });
+    const okCanonical = run(canonical, "v0.19.0");
+    assert.equal(okCanonical.status, 0, okCanonical.stderr);
+
+    // Positive twin: a valid semver prerelease tag matching prerelease manifests.
+    const prerelease = writeWorkspace(root, "prerelease", "0.19.0-rc.1");
+    const okPrerelease = run(prerelease, "v0.19.0-rc.1");
+    assert.equal(okPrerelease.status, 0, okPrerelease.stderr);
+
+    // Malformed tag matching the workflow's `*` trigger but not `v${semver}`.
+    const malformed = run(canonical, "release-test");
+    assert.equal(malformed.status, 1, malformed.stdout);
+    assert.match(malformed.stderr, /must be exactly v\$\{version\}/);
+
+    // Missing leading `v`.
+    const noV = run(canonical, "0.19.0");
+    assert.equal(noV.status, 1, noV.stdout);
+    assert.match(noV.stderr, /missing leading 'v'/);
+
+    // Well-formed tag whose version differs from every manifest.
+    const wrongVersion = run(canonical, "v0.20.0");
+    assert.equal(wrongVersion.status, 1, wrongVersion.stdout);
+    assert.match(wrongVersion.stderr, /does not match tag version "0\.20\.0"/);
+
+    // Cross-artifact npm mismatch: a single package off the release version.
+    const npmSkew = writeWorkspace(root, "npm-skew", "0.19.0", {
+      lint: { name: "@ttsc/lint", version: "0.19.1" },
+    });
+    const npmSkewResult = run(npmSkew, "v0.19.0");
+    assert.equal(npmSkewResult.status, 1, npmSkewResult.stdout);
+    assert.match(
+      npmSkewResult.stderr,
+      /@ttsc\/lint version "0\.19\.1" does not match tag version "0\.19\.0"/,
+    );
+
+    // VSIX/Marketplace mismatch: the extension manifest naming the VSIX is skewed.
+    const vsixSkew = writeWorkspace(root, "vsix-skew", "0.19.0", {
+      vscode: { name: "@ttsc/vscode", version: "0.19.2" },
+    });
+    const vsixSkewResult = run(vsixSkew, "v0.19.0");
+    assert.equal(vsixSkewResult.status, 1, vsixSkewResult.stdout);
+    assert.match(
+      vsixSkewResult.stderr,
+      /@ttsc\/vscode version "0\.19\.2" does not match tag version "0\.19\.0"/,
+    );
+
+    // The VSIX artifact source must exist for the cross-artifact check to mean
+    // anything; a workspace without @ttsc/vscode must fail rather than pass.
+    const noVscode = writeWorkspace(root, "no-vscode", "0.19.0", {
+      dropVscode: true,
+    });
+    const noVscodeResult = run(noVscode, "v0.19.0");
+    assert.equal(noVscodeResult.status, 1, noVscodeResult.stdout);
+    assert.match(noVscodeResult.stderr, /@ttsc\/vscode manifest not found/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+};
+
+interface Override {
+  name: string;
+  version: string;
+  private?: boolean;
+}
+
+function writeWorkspace(
+  root: string,
+  label: string,
+  version: string,
+  options: {
+    lint?: Override;
+    vscode?: Override;
+    private?: Override;
+    dropVscode?: boolean;
+  } = {},
+): string {
+  const dir = path.join(root, label);
+  const packages: Array<{ dir: string; manifest: Override }> = [
+    { dir: "ttsc", manifest: { name: "ttsc", version } },
+    {
+      dir: "lint",
+      manifest: options.lint ?? { name: "@ttsc/lint", version },
+    },
+    { dir: "wasm", manifest: { name: "@ttsc/wasm", version } },
+  ];
+  if (!options.dropVscode) {
+    packages.push({
+      dir: "vscode",
+      manifest: options.vscode ?? { name: "@ttsc/vscode", version },
+    });
+  }
+  if (options.private) {
+    packages.push({ dir: "internal-tool", manifest: options.private });
+  }
+  for (const pkg of packages) {
+    const manifestPath = path.join(dir, "packages", pkg.dir, "package.json");
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+    fs.writeFileSync(manifestPath, JSON.stringify(pkg.manifest), "utf8");
+  }
+  return dir;
+}

--- a/tests/test-ttsc/src/features/platform/test_release_workflow_runs_preflight_before_publication.ts
+++ b/tests/test-ttsc/src/features/platform/test_release_workflow_runs_preflight_before_publication.ts
@@ -1,0 +1,48 @@
+import { assert, fs, path, workspaceRoot } from "../../internal/toolchain";
+
+/**
+ * Verifies the release workflow runs the preflight gate before any publication.
+ *
+ * Locks the ordering in `.github/workflows/release.yml`. The preflight script is
+ * only a real gate if it executes before the first external mutation, so a
+ * future edit that moves publication ahead of the preflight must fail here. The
+ * negative twin is the publication commands themselves: their positions in the
+ * workflow text must all come after the preflight invocation.
+ *
+ * 1. Read the release workflow.
+ * 2. Locate the preflight invocation and each publication command.
+ * 3. Assert the preflight appears exactly once and strictly before the
+ *    Marketplace publish, the npm publish, and the first credential use.
+ */
+export const test_release_workflow_runs_preflight_before_publication = () => {
+  const workflow = fs.readFileSync(
+    path.join(workspaceRoot, ".github", "workflows", "release.yml"),
+    "utf8",
+  );
+
+  const preflight = workflow.indexOf("scripts/release-preflight.cjs");
+  assert.notEqual(preflight, -1, "release-preflight.cjs step is missing");
+  assert.equal(
+    workflow.lastIndexOf("scripts/release-preflight.cjs"),
+    preflight,
+    "release-preflight.cjs must be invoked exactly once",
+  );
+
+  const marketplacePublish = workflow.indexOf("publish-vscode-marketplace.sh");
+  const npmPublish = workflow.indexOf("package:latest:publish");
+  const credential = workflow.indexOf("VSCE_PAT");
+  const build = workflow.indexOf("pnpm run build");
+
+  for (const [label, index] of [
+    ["build", build],
+    ["Marketplace publish", marketplacePublish],
+    ["npm publish", npmPublish],
+    ["credential use", credential],
+  ] as Array<[string, number]>) {
+    assert.notEqual(index, -1, `expected to find ${label} step`);
+    assert.ok(
+      preflight < index,
+      `preflight (index ${preflight}) must run before ${label} (index ${index})`,
+    );
+  }
+};


### PR DESCRIPTION
## Bundle b11 — linux-arm ARM baseline + release tag/version validation

Part of the `repository-audit-2026-07` campaign (tracker #667 / #682). Two independent P1 platform/release correctness fixes.

### RA-06 — one coherent ARM baseline in `@ttsc/linux-arm` (#667)

`@ttsc/linux-arm` bundles the `linux-armv6l` Go SDK but cross-compiled its `ttsc`/`ttscserver`/`ttscgraph` executables with no `GOARM`, which the current toolchain defaults to ARMv7. The SDK and executables then targeted different ARM generations, so ARMv6 hardware could install a package whose primary executables might not run.

- New `scripts/platform-target.cjs::resolveGoTarget` resolves one coherent Go target record per platform package, tying `GOOS`/`GOARCH`/`GOARM` to the bundled SDK archive suffix.
- `scripts/build-platform-package.cjs` now forces `GOARM=6` for all three arm executables and derives the archive target from the same record (single source of truth).
- README documents the ARMv6 baseline contract; the broad npm `arm` CPU contract is preserved (no support-boundary narrowing).

### RA-08 — validate release tag and package versions before publication (#682)

`release.yml` triggers on every pushed tag (`on.push.tags: ["*"]`) and publishes to the VS Code Marketplace and npm before any tag-derived smoke test runs, so a malformed tag or a tag/manifest version mismatch could create irreversible external releases and only then fail.

- New `scripts/release-preflight.cjs` runs as the first release step, before build and any publication. Side-effect free (reads files, never mutates a registry).
- Validates: tag is exactly `v${version}` for a valid semver (prerelease allowed); every non-private `packages/*` manifest (the exact set `package:latest:publish` publishes) carries that version; the `@ttsc/vscode` manifest that names the VSIX/Marketplace artifact agrees.
- `release.yml` invokes the preflight before `pnpm run build`, the Marketplace publish, the npm publish, and any credential use.

### Tests

- `test_platform_target_matrix_pins_linux_arm_to_armv6` — asserts the resolved matrix pins linux-arm to `GOARM=6` / `linux-armv6l` and that arm64 / non-ARM negative twins never acquire a `GOARM`; structural guard that all three executables flow through one `buildGoTarget`.
- `test_release_preflight_rejects_incoherent_tag_and_versions` — synthetic workspaces exercised via the real script: canonical + prerelease pass; malformed tag, missing `v`, tag/manifest mismatch, per-package npm skew, VSIX skew, and missing `@ttsc/vscode` all fail with the offending reason. Private package proven skipped; no case mutates state.
- `test_release_workflow_runs_preflight_before_publication` — locks workflow ordering: preflight appears exactly once and strictly before build, both publishes, and credential use.

Closes #667, #682
