### PR TITLE
fix(wasm): keep boot and MemFS invariants consistent

### DIFF
--- a/packages/wasm/host/host.go
+++ b/packages/wasm/host/host.go
@@ -81,7 +81,19 @@ func Expose(apiName string, cfg Config) {
       continue
     }
     if _, dup := plugins[name]; dup {
-      panic(fmt.Sprintf("host.Expose: duplicate plugin name %q", name))
+      // A duplicate plugin name is a host-configuration error, but panicking
+      // here would terminate the Go runtime before any Ready/Failed signal is
+      // installed, leaving bootTtsc's `await ready` pending forever with no
+      // observable cause. Mirror the double-Expose path: surface the cause via
+      // console.error + the JS-visible Failed bridge, then return without
+      // starting the keepalive runtime so the boot rejects with the real
+      // reason instead of a generic "exited before readiness" error.
+      msg := fmt.Sprintf("host.Expose: duplicate plugin name %q", name)
+      fmt.Fprintln(os.Stderr, msg)
+      if failed := js.Global().Get(apiName + "Failed"); failed.Type() == js.TypeFunction {
+        failed.Invoke(js.Global().Get("Error").New(msg))
+      }
+      return
     }
     plugins[name] = p
     pluginNames = append(pluginNames, name)

--- a/packages/wasm/src/MemFSError.ts
+++ b/packages/wasm/src/MemFSError.ts
@@ -27,6 +27,8 @@ function errnoForCode(code: string): number {
       return -2;
     case "EBADF":
       return -9;
+    case "EBUSY":
+      return -16;
     case "EEXIST":
       return -17;
     case "ENOTDIR":
@@ -37,6 +39,8 @@ function errnoForCode(code: string): number {
       return -22;
     case "ESPIPE":
       return -29;
+    case "ENOTEMPTY":
+      return -39;
     default:
       return -1;
   }

--- a/packages/wasm/src/bootTtsc.ts
+++ b/packages/wasm/src/bootTtsc.ts
@@ -109,56 +109,124 @@ async function bootTtscOnce(
 
   const host = options.host ?? createMemFS();
   const globalAny = globalThis as Record<string, unknown>;
-  // Only install fs / process if they aren't already in place. A caller
-  // booting a second wasm over the same MemFS reuses the same shims.
-  if (!globalAny.fs) globalAny.fs = host.fs;
-  if (!globalAny.process) globalAny.process = createProcessShim();
-
-  // wasm_exec.js installs `globalThis.Go`. It also reads globalThis.fs at
-  // module-eval time, so this import must follow the assignment above.
-  importScripts(wasmExecUrl);
-
-  // Race the Ready resolver against a Failed signal so a wasm-side fault
-  // (e.g. `host.Expose` refusing a duplicate call) surfaces here instead of
-  // hanging on `await ready` forever. `go.run` is fire-and-forget so its
-  // own rejection cannot reach this promise without an explicit channel.
-  const ready = new Promise<void>((resolve, reject) => {
-    globalAny[apiName + "Ready"] = () => {
-      delete globalAny[apiName + "Failed"];
-      resolve();
-    };
-    globalAny[apiName + "Failed"] = (err: unknown) => {
-      delete globalAny[apiName + "Ready"];
-      reject(err instanceof Error ? err : new Error(String(err)));
-    };
-  });
-
-  const goCtor = (globalAny as { Go?: new () => IGoInstance }).Go;
-  if (typeof goCtor !== "function") {
-    throw new Error(
-      `bootTtsc: globalThis.Go was not installed by ${wasmExecUrl} — the file may not have loaded (CSP block, wrong content type, 404), or it is not the wasm_exec.js shipped with the Go toolchain.`,
-    );
+  // Install fs / process only if they aren't already in place, and remember
+  // whether THIS attempt installed them. The Go runtime this boot starts reads
+  // `globalThis.fs` when it runs, so the returned `host` must be the exact host
+  // backing those globals. A caller booting a second wasm over the same MemFS
+  // (or reusing one host across retries) reuses the same shims. When an earlier
+  // failed attempt already installed a different host's shims, those are torn
+  // down on failure below so this attempt can install its own.
+  const installedFs = !globalAny.fs;
+  const installedProcess = !globalAny.process;
+  let processShim: unknown;
+  if (installedFs) globalAny.fs = host.fs;
+  if (installedProcess) {
+    processShim = createProcessShim();
+    globalAny.process = processShim;
   }
-  const go = new goCtor();
 
-  const response = await fetch(wasmUrl);
-  if (!response.ok) {
-    throw new Error(`bootTtsc: failed to fetch ${wasmUrl}: ${response.status}`);
-  }
-  const wasm = await WebAssembly.instantiateStreaming(
-    response,
-    go.importObject,
-  );
-  // go.run never resolves until the wasm exits; we don't await it.
-  void go.run(wasm.instance);
-  await ready;
+  // Any failure after global installation must leave the globals as this
+  // attempt found them, so a retry installs its own host's fs (and the returned
+  // host keeps matching the runtime's filesystem). Only remove what we
+  // installed and only while it is still ours — never stomp a foreign fs or one
+  // a concurrently-booted runtime already claimed.
+  const restoreGlobals = (): void => {
+    if (installedFs && globalAny.fs === host.fs) delete globalAny.fs;
+    if (installedProcess && globalAny.process === processShim)
+      delete globalAny.process;
+  };
 
-  const api = (globalAny as Record<string, ITtscApi | undefined>)[apiName];
-  if (!api)
-    throw new Error(
-      `bootTtsc: ${apiName} global was not set — was the wasm built with host.Expose(${JSON.stringify(apiName)}, ...)?`,
+  try {
+    // wasm_exec.js installs `globalThis.Go`. It also reads globalThis.fs at
+    // module-eval time, so this import must follow the assignment above.
+    importScripts(wasmExecUrl);
+
+    // Race the Ready resolver against a Failed signal so a wasm-side fault
+    // (e.g. `host.Expose` refusing a duplicate call) surfaces here instead of
+    // hanging on `await ready` forever.
+    let readyCb!: () => void;
+    let failedCb!: (err: unknown) => void;
+    const ready = new Promise<void>((resolve, reject) => {
+      readyCb = () => {
+        delete globalAny[apiName + "Failed"];
+        resolve();
+      };
+      failedCb = (err: unknown) => {
+        delete globalAny[apiName + "Ready"];
+        reject(err instanceof Error ? err : new Error(String(err)));
+      };
+      globalAny[apiName + "Ready"] = readyCb;
+      globalAny[apiName + "Failed"] = failedCb;
+    });
+
+    const goCtor = (globalAny as { Go?: new () => IGoInstance }).Go;
+    if (typeof goCtor !== "function") {
+      throw new Error(
+        `bootTtsc: globalThis.Go was not installed by ${wasmExecUrl} — the file may not have loaded (CSP block, wrong content type, 404), or it is not the wasm_exec.js shipped with the Go toolchain.`,
+      );
+    }
+    const go = new goCtor();
+
+    const response = await fetch(wasmUrl);
+    if (!response.ok) {
+      throw new Error(
+        `bootTtsc: failed to fetch ${wasmUrl}: ${response.status}`,
+      );
+    }
+    const wasm = await WebAssembly.instantiateStreaming(
+      response,
+      go.importObject,
     );
-  return { api, host };
+
+    // A normal host keeps `go.run` pending forever after signaling Ready, so a
+    // settlement (fulfil OR reject) BEFORE Ready means the Go runtime exited or
+    // panicked before it could register — e.g. an early `host.Expose` panic
+    // that never reached the Failed bridge. Race that early exit against
+    // readiness so the boot rejects with an actionable cause instead of hanging.
+    // The standard Go runner discards the exit code, so an unknown early exit
+    // can only synthesize a generic message; known host validation failures
+    // reject through Failed above and keep their original cause.
+    const runPromise = Promise.resolve(go.run(wasm.instance));
+    const earlyExit = runPromise.then(
+      () => {
+        throw new Error(
+          `bootTtsc: the ${apiName} wasm runtime exited before signaling readiness (the host may have panicked; check the wasm stderr).`,
+        );
+      },
+      (err: unknown) => {
+        throw new Error(
+          `bootTtsc: the ${apiName} wasm runtime failed before signaling readiness: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      },
+    );
+    // When Ready wins, the long-running runtime's eventual `go.run` settlement
+    // must not surface as an unhandled rejection. Attach a terminal handler to
+    // the losing branch.
+    earlyExit.catch(() => {});
+
+    try {
+      await Promise.race([ready, earlyExit]);
+    } finally {
+      // Drop this attempt's readiness bridge so a later boot for the same
+      // apiName installs a clean pair and no stale resolver survives.
+      if (globalAny[apiName + "Ready"] === readyCb)
+        delete globalAny[apiName + "Ready"];
+      if (globalAny[apiName + "Failed"] === failedCb)
+        delete globalAny[apiName + "Failed"];
+    }
+
+    const api = (globalAny as Record<string, ITtscApi | undefined>)[apiName];
+    if (!api)
+      throw new Error(
+        `bootTtsc: ${apiName} global was not set — was the wasm built with host.Expose(${JSON.stringify(apiName)}, ...)?`,
+      );
+    return { api, host };
+  } catch (err) {
+    restoreGlobals();
+    throw err;
+  }
 }
 
 /**

--- a/packages/wasm/src/createMemFS.ts
+++ b/packages/wasm/src/createMemFS.ts
@@ -160,6 +160,59 @@ export function createMemFS(): IMemFSHost {
     }
   }
 
+  /** Absolute parent directory of a normalized path (`/` for a top-level path). */
+  function parentDir(norm: string): string {
+    const idx = norm.lastIndexOf("/");
+    return idx <= 0 ? "/" : norm.slice(0, idx);
+  }
+
+  /** True when `dir` has at least one descendant node in the tree. */
+  function hasChildren(dir: string): boolean {
+    const prefix = dir === "/" ? "/" : dir + "/";
+    for (const key of nodes.keys()) {
+      if (key !== dir && key.startsWith(prefix)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Grow or shrink a file's byte buffer to exactly `length`, zero-filling any
+   * extension. Callers validate `length >= 0` first.
+   */
+  function resizeFileData(data: Uint8Array, length: number): Uint8Array {
+    const next = new Uint8Array(length);
+    next.set(data.subarray(0, Math.min(length, data.byteLength)));
+    return next;
+  }
+
+  /**
+   * Move the entire subtree rooted at `src` to `dest`, overwriting any existing
+   * `dest` node. Every descendant key is re-parented so no old-prefix node is
+   * left orphaned, and open descriptors that referenced a moved path follow to
+   * the new location (a rename must not strand an fd's inode).
+   */
+  function moveSubtree(src: string, dest: string): void {
+    const srcPrefix = src + "/";
+    const moves: Array<[string, INode]> = [];
+    for (const [key, node] of nodes) {
+      if (key === src) moves.push([dest, node]);
+      else if (key.startsWith(srcPrefix))
+        moves.push([dest + "/" + key.slice(srcPrefix.length), node]);
+    }
+    // Delete the whole source subtree first so a nested overwrite cannot leave
+    // a stale descendant behind, then reinsert at the destination prefix. Any
+    // pre-existing `dest` node is replaced by the reinsert.
+    for (const key of [...nodes.keys()]) {
+      if (key === src || key.startsWith(srcPrefix)) nodes.delete(key);
+    }
+    for (const [key, node] of moves) nodes.set(key, node);
+    for (const entry of fdTable.values()) {
+      if (entry.path === src) entry.path = dest;
+      else if (entry.path.startsWith(srcPrefix))
+        entry.path = dest + "/" + entry.path.slice(srcPrefix.length);
+    }
+  }
+
   function mkdirp(p: string): void {
     const segments = normalize(p).split("/").filter(Boolean);
     let cursor = "";
@@ -508,8 +561,17 @@ export function createMemFS(): IMemFSHost {
 
     unlink(p, callback) {
       const norm = normalize(p);
-      if (!nodes.has(norm)) {
+      const node = nodes.get(norm);
+      if (!node) {
         callback(new MemFSError("ENOENT", "unlink", norm));
+        return;
+      }
+      // POSIX unlink refuses directories (EISDIR/EPERM). Go's os.Remove tries
+      // unlink first and only falls back to rmdir when it fails, so a false
+      // success here would delete just the directory node and orphan every
+      // descendant. Reject so the rmdir path (which validates emptiness) runs.
+      if (node.kind === "dir") {
+        callback(new MemFSError("EISDIR", "unlink", norm));
         return;
       }
       nodes.delete(norm);
@@ -523,14 +585,73 @@ export function createMemFS(): IMemFSHost {
         callback(new MemFSError("ENOENT", "rename", src));
         return;
       }
+      if (src === "/") {
+        callback(new MemFSError("EBUSY", "rename", src));
+        return;
+      }
       const dest = normalize(to);
-      nodes.delete(src);
-      nodes.set(dest, node);
+      // Renaming a path onto itself is a defined no-op success.
+      if (src === dest) {
+        callback(null);
+        return;
+      }
+      // A directory cannot be moved inside itself or its own descendants.
+      if (node.kind === "dir" && dest.startsWith(src + "/")) {
+        callback(new MemFSError("EINVAL", "rename", src));
+        return;
+      }
+      // The destination's parent must already exist as a directory.
+      const parent = nodes.get(parentDir(dest));
+      if (!parent) {
+        callback(new MemFSError("ENOENT", "rename", dest));
+        return;
+      }
+      if (parent.kind !== "dir") {
+        callback(new MemFSError("ENOTDIR", "rename", dest));
+        return;
+      }
+      // Reconcile against an existing destination before mutating anything so a
+      // rejected rename leaves the tree untouched (no partial state).
+      const destNode = nodes.get(dest);
+      if (destNode) {
+        if (node.kind === "file") {
+          if (destNode.kind === "dir") {
+            callback(new MemFSError("EISDIR", "rename", dest));
+            return;
+          }
+        } else if (destNode.kind !== "dir") {
+          callback(new MemFSError("ENOTDIR", "rename", dest));
+          return;
+        } else if (hasChildren(dest)) {
+          callback(new MemFSError("ENOTEMPTY", "rename", dest));
+          return;
+        }
+      }
+      moveSubtree(src, dest);
       callback(null);
     },
 
     rmdir(p, callback) {
-      this.unlink(p, callback);
+      const norm = normalize(p);
+      const node = nodes.get(norm);
+      if (!node) {
+        callback(new MemFSError("ENOENT", "rmdir", norm));
+        return;
+      }
+      if (node.kind !== "dir") {
+        callback(new MemFSError("ENOTDIR", "rmdir", norm));
+        return;
+      }
+      if (norm === "/") {
+        callback(new MemFSError("EBUSY", "rmdir", norm));
+        return;
+      }
+      if (hasChildren(norm)) {
+        callback(new MemFSError("ENOTEMPTY", "rmdir", norm));
+        return;
+      }
+      nodes.delete(norm);
+      callback(null);
     },
 
     chmod(_p, _mode, callback) {
@@ -560,10 +681,51 @@ export function createMemFS(): IMemFSHost {
     readlink(_p, callback) {
       callback(new MemFSError("EINVAL", "readlink"), "");
     },
-    truncate(_p, _length, callback) {
+    truncate(p, length, callback) {
+      const norm = normalize(p);
+      const node = nodes.get(norm);
+      if (!node) {
+        callback(new MemFSError("ENOENT", "truncate", norm));
+        return;
+      }
+      if (node.kind !== "file") {
+        callback(new MemFSError("EISDIR", "truncate", norm));
+        return;
+      }
+      if (!Number.isInteger(length) || length < 0) {
+        callback(new MemFSError("EINVAL", "truncate", norm));
+        return;
+      }
+      node.data = resizeFileData(node.data, length);
+      node.mtimeMs = Date.now();
       callback(null);
     },
-    ftruncate(_fd, _length, callback) {
+    ftruncate(fd, length, callback) {
+      // Pipe ends and the reserved stdout/stderr fds have no truncatable file.
+      if (pipes.has(fd)) {
+        callback(new MemFSError("EINVAL", "ftruncate"));
+        return;
+      }
+      const entry = fdTable.get(fd);
+      if (!entry) {
+        callback(new MemFSError("EBADF", "ftruncate"));
+        return;
+      }
+      if (entry.isStdout || entry.isStderr) {
+        callback(new MemFSError("EINVAL", "ftruncate"));
+        return;
+      }
+      const node = nodes.get(entry.path);
+      if (!node || node.kind !== "file") {
+        callback(new MemFSError("EINVAL", "ftruncate", entry.path));
+        return;
+      }
+      if (!Number.isInteger(length) || length < 0) {
+        callback(new MemFSError("EINVAL", "ftruncate", entry.path));
+        return;
+      }
+      node.data = resizeFileData(node.data, length);
+      node.mtimeMs = Date.now();
       callback(null);
     },
     pipe2(_flags, callback) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,6 +584,24 @@ importers:
         specifier: ^7.1.12
         version: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
 
+  tests/test-wasm:
+    devDependencies:
+      '@nestia/e2e':
+        specifier: catalog:utils
+        version: 12.0.0-rc.2
+      '@ttsc/testing':
+        specifier: workspace:*
+        version: link:../utils
+      '@ttsc/wasm':
+        specifier: workspace:*
+        version: link:../../packages/wasm
+      '@types/node':
+        specifier: catalog:utils
+        version: 25.9.1
+      typescript:
+        specifier: catalog:typescript
+        version: 7.0.2
+
   tests/utils:
     devDependencies:
       '@nestia/e2e':

--- a/tests/test-wasm/package.json
+++ b/tests/test-wasm/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "name": "@ttsc/test-wasm",
+  "version": "0.18.4",
+  "description": "@ttsc/wasm MemFS mutation and boot-lifecycle feature tests.",
+  "type": "module",
+  "scripts": {
+    "start": "node --disable-warning=ExperimentalWarning --import ../../scripts/register-extensionless-ts-loader.mjs --experimental-transform-types src/index.ts"
+  },
+  "devDependencies": {
+    "@nestia/e2e": "catalog:utils",
+    "@ttsc/testing": "workspace:*",
+    "@ttsc/wasm": "workspace:*",
+    "@types/node": "catalog:utils",
+    "typescript": "catalog:typescript"
+  }
+}

--- a/tests/test-wasm/src/features/boot/test_boot_ttsc_preserves_explicit_failed_cause.ts
+++ b/tests/test-wasm/src/features/boot/test_boot_ttsc_preserves_explicit_failed_cause.ts
@@ -1,0 +1,64 @@
+import { TestValidator } from "@nestia/e2e";
+import { bootTtsc } from "@ttsc/wasm";
+
+import { withBootStubs } from "../../internal/bootHarness";
+
+/**
+ * Verifies an explicit `Failed` signal rejects bootTtsc once with its original
+ * cause, even when the runtime also exits afterward.
+ *
+ * A known host validation failure (e.g. a duplicate plugin name) invokes the
+ * `Failed` bridge and then returns, so the Go runtime exits too. Both the
+ * `Failed` rejection and the early-exit race branch settle; the boot must
+ * reject exactly once with the real `Failed` cause — not the generic early-exit
+ * message — and the losing branch must not become an unhandled rejection.
+ *
+ * 1. Stub a runtime that fires `Failed` with a duplicate-plugin-name error then
+ *    exits.
+ * 2. Boot it and let the losing branch settle.
+ * 3. Assert the rejection preserves the duplicate-name cause and nothing leaked.
+ */
+export const test_boot_ttsc_preserves_explicit_failed_cause =
+  async (): Promise<void> => {
+    const apiName = "ttscFailedCause";
+    const cause = 'host.Expose: duplicate plugin name "duplicate"';
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown): void => {
+      rejections.push(reason);
+    };
+    process.on("unhandledRejection", onRejection);
+    let caught: Error | null = null;
+    try {
+      await withBootStubs(
+        apiName,
+        {
+          onRun: (runtime) => {
+            runtime.signalFailed(new Error(cause));
+            return Promise.resolve();
+          },
+        },
+        async () => {
+          try {
+            await bootTtsc({ apiName, wasmUrl: "http://local/failed-cause.wasm" });
+          } catch (error) {
+            caught = error as Error;
+          }
+        },
+      );
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      TestValidator.predicate("boot rejected", caught !== null);
+      TestValidator.equals(
+        "original Failed cause is preserved",
+        caught !== null ? (caught as Error).message : "",
+        cause,
+      );
+      TestValidator.equals(
+        "no unhandled rejection from the losing branch",
+        rejections.length,
+        0,
+      );
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+  };

--- a/tests/test-wasm/src/features/boot/test_boot_ttsc_rejects_before_readiness.ts
+++ b/tests/test-wasm/src/features/boot/test_boot_ttsc_rejects_before_readiness.ts
@@ -1,0 +1,45 @@
+import { TestValidator } from "@nestia/e2e";
+import { bootTtsc } from "@ttsc/wasm";
+
+import { withBootStubs } from "../../internal/bootHarness";
+
+/**
+ * Verifies bootTtsc rejects with an actionable error when the Go runtime exits
+ * before signaling readiness.
+ *
+ * This is the core RA-18 defect: `go.run` was started fire-and-forget and only
+ * `Ready`/`Failed` were awaited, so a runtime that exited before either signal
+ * (an early `host.Expose` panic that never reached the `Failed` bridge) left
+ * the public boot Promise pending forever. Racing `go.run` settlement against
+ * readiness makes an unsignaled early exit reject with a synthesized cause
+ * instead of hanging.
+ *
+ * 1. Stub a fake runtime whose `go.run` resolves without calling Ready/Failed.
+ * 2. Boot it.
+ * 3. Assert the boot rejects and the message names the early exit before
+ *    readiness.
+ */
+export const test_boot_ttsc_rejects_before_readiness = async (): Promise<void> => {
+  const apiName = "ttscEarlyExit";
+  let caught: Error | null = null;
+  await withBootStubs(
+    apiName,
+    {
+      onRun: () => Promise.resolve(),
+    },
+    async () => {
+      try {
+        await bootTtsc({ apiName, wasmUrl: "http://local/early-exit.wasm" });
+      } catch (error) {
+        caught = error as Error;
+      }
+    },
+  );
+
+  TestValidator.predicate("boot rejected instead of hanging", caught !== null);
+  TestValidator.predicate(
+    "rejection names the pre-readiness exit",
+    caught !== null &&
+      /exited before signaling readiness/.test((caught as Error).message),
+  );
+};

--- a/tests/test-wasm/src/features/boot/test_boot_ttsc_resolves_normal_host.ts
+++ b/tests/test-wasm/src/features/boot/test_boot_ttsc_resolves_normal_host.ts
@@ -1,0 +1,58 @@
+import { TestValidator } from "@nestia/e2e";
+import { bootTtsc } from "@ttsc/wasm";
+
+import { FAKE_API, withBootStubs } from "../../internal/bootHarness";
+
+/**
+ * Verifies bootTtsc resolves when the host signals readiness and its runtime
+ * keeps running, with no unhandled rejection.
+ *
+ * This is the positive baseline the early-exit rejection cases are twinned
+ * against: a normal Go host fires `Ready` and then keeps `go.run` pending
+ * forever. The boot must resolve on `Ready`, return the exact host it installed,
+ * and the never-settling `go.run` branch that lost the readiness race must not
+ * surface as an unhandled rejection.
+ *
+ * 1. Stub a fake runtime that signals ready then returns a never-settling
+ *    promise.
+ * 2. Boot it and let a few event-loop turns pass.
+ * 3. Assert the api and host came back and no unhandled rejection fired.
+ */
+export const test_boot_ttsc_resolves_normal_host = async (): Promise<void> => {
+  const apiName = "ttscNormalHost";
+  const rejections: unknown[] = [];
+  const onRejection = (reason: unknown): void => {
+    rejections.push(reason);
+  };
+  process.on("unhandledRejection", onRejection);
+  try {
+    const result = await withBootStubs(
+      apiName,
+      {
+        onRun: (runtime) => {
+          runtime.signalReady(FAKE_API);
+          return new Promise<void>(() => {});
+        },
+      },
+      () => bootTtsc({ apiName, wasmUrl: "http://local/normal-host.wasm" }),
+    );
+
+    TestValidator.predicate(
+      "api bound to the runtime global",
+      (result.api as unknown) === FAKE_API,
+    );
+    TestValidator.predicate(
+      "host returned with an fs shim",
+      typeof result.host.fs === "object" && result.host.fs !== null,
+    );
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    TestValidator.equals(
+      "the losing go.run branch stays silent",
+      rejections.length,
+      0,
+    );
+  } finally {
+    process.off("unhandledRejection", onRejection);
+  }
+};

--- a/tests/test-wasm/src/features/boot/test_boot_ttsc_retries_after_early_exit.ts
+++ b/tests/test-wasm/src/features/boot/test_boot_ttsc_retries_after_early_exit.ts
@@ -1,0 +1,47 @@
+import { TestValidator } from "@nestia/e2e";
+import { bootTtsc } from "@ttsc/wasm";
+
+import { FAKE_API, withBootStubs } from "../../internal/bootHarness";
+
+/**
+ * Verifies a boot that rejects before readiness releases its in-flight entry so
+ * a later boot for the same key can run and resolve.
+ *
+ * RA-18 requires that failure settlement also frees the per-key single-flight
+ * cache and the per-apiName serialization chain; otherwise a retry would be
+ * stuck behind the rejected promise. Using one `(apiName, wasmUrl)` key for both
+ * attempts proves the eviction path, not just a fresh-key boot.
+ *
+ * 1. First attempt's runtime exits before readiness; second attempt signals
+ *    ready.
+ * 2. Boot the same key twice in sequence.
+ * 3. Assert the first rejects and the second resolves with the api.
+ */
+export const test_boot_ttsc_retries_after_early_exit = async (): Promise<void> => {
+  const apiName = "ttscRetryEarlyExit";
+  const wasmUrl = "http://local/retry-early-exit.wasm";
+  let attempt = 0;
+
+  const result = await withBootStubs(
+    apiName,
+    {
+      onRun: (runtime) => {
+        attempt += 1;
+        if (attempt === 1) return Promise.resolve();
+        runtime.signalReady(FAKE_API);
+        return new Promise<void>(() => {});
+      },
+    },
+    async () => {
+      await TestValidator.error("first attempt rejects", () =>
+        bootTtsc({ apiName, wasmUrl }),
+      );
+      return bootTtsc({ apiName, wasmUrl });
+    },
+  );
+
+  TestValidator.predicate(
+    "retry resolved after the in-flight entry was released",
+    (result.api as unknown) === FAKE_API,
+  );
+};

--- a/tests/test-wasm/src/features/boot/test_boot_ttsc_retry_preserves_supplied_host.ts
+++ b/tests/test-wasm/src/features/boot/test_boot_ttsc_retry_preserves_supplied_host.ts
@@ -1,0 +1,55 @@
+import { TestValidator } from "@nestia/e2e";
+import { bootTtsc, createMemFS } from "@ttsc/wasm";
+
+import { FAKE_API, withBootStubs } from "../../internal/bootHarness";
+
+/**
+ * Verifies the host-identity invariant also holds for an explicit
+ * `options.host` reused across a failed attempt and a successful retry.
+ *
+ * RA-20 must not special-case default hosts: when the caller supplies one host
+ * for both attempts, the failed attempt's global restore must leave that host's
+ * `fs` reinstallable so the successful retry binds and returns the very same
+ * host the runtime captured. Reusing one host across attempts is explicitly
+ * supported and must stay safe.
+ *
+ * 1. Pass one `createMemFS()` host to both attempts; first fetch 503, second
+ *    200.
+ * 2. The successful runtime records its captured `globalThis.fs`.
+ * 3. Assert the returned host is the supplied host and its fs is the captured
+ *    one.
+ */
+export const test_boot_ttsc_retry_preserves_supplied_host =
+  async (): Promise<void> => {
+    const apiName = "ttscSuppliedHost";
+    const wasmUrl = "http://local/supplied-host.wasm";
+    const host = createMemFS();
+    let capturedFs: unknown;
+
+    const result = await withBootStubs(
+      apiName,
+      {
+        fetchStatuses: [503, 200],
+        onRun: (runtime) => {
+          capturedFs = runtime.capturedFs;
+          runtime.signalReady(FAKE_API);
+          return new Promise<void>(() => {});
+        },
+      },
+      async () => {
+        await TestValidator.error("first attempt rejects on 503", () =>
+          bootTtsc({ apiName, wasmUrl, host }),
+        );
+        return bootTtsc({ apiName, wasmUrl, host });
+      },
+    );
+
+    TestValidator.predicate(
+      "returned host is the supplied host",
+      result.host === host,
+    );
+    TestValidator.predicate(
+      "supplied host.fs is the runtime's captured filesystem",
+      (host.fs as unknown) === capturedFs,
+    );
+  };

--- a/tests/test-wasm/src/features/boot/test_boot_ttsc_retry_returns_runtime_host.ts
+++ b/tests/test-wasm/src/features/boot/test_boot_ttsc_retry_returns_runtime_host.ts
@@ -1,0 +1,60 @@
+import { TestValidator } from "@nestia/e2e";
+import { bootTtsc } from "@ttsc/wasm";
+
+import { FAKE_API, withBootStubs } from "../../internal/bootHarness";
+import { openFd, readFdText } from "../../internal/callbackFs";
+
+/**
+ * Verifies that after a boot fails past global installation and a retry
+ * succeeds, the returned host is the exact filesystem the Go runtime captured.
+ *
+ * This is the RA-20 defect: a failed attempt left its `globalThis.fs` installed,
+ * so a retry (which only installs `fs` when absent) created a fresh host, saw
+ * the stale global, and returned a host the runtime never used — files written
+ * through it were invisible to the compiler. Restoring the failed attempt's own
+ * globals lets the retry install and return the host its runtime binds.
+ *
+ * 1. First fetch returns 503 (fail after installing `fs`); second returns 200.
+ * 2. The successful runtime records the `globalThis.fs` it captured at start.
+ * 3. Assert the returned `host.fs` is that captured fs and a file written
+ *    through the returned host is readable via that same fs.
+ */
+export const test_boot_ttsc_retry_returns_runtime_host =
+  async (): Promise<void> => {
+    const apiName = "ttscRetryHost";
+    const wasmUrl = "http://local/retry-host.wasm";
+    let capturedFs: unknown;
+
+    const result = await withBootStubs(
+      apiName,
+      {
+        fetchStatuses: [503, 200],
+        onRun: (runtime) => {
+          capturedFs = runtime.capturedFs;
+          runtime.signalReady(FAKE_API);
+          return new Promise<void>(() => {});
+        },
+      },
+      async () => {
+        await TestValidator.error("first attempt rejects on 503", () =>
+          bootTtsc({ apiName, wasmUrl }),
+        );
+        return bootTtsc({ apiName, wasmUrl });
+      },
+    );
+
+    TestValidator.predicate(
+      "returned host.fs is the runtime's captured filesystem",
+      (result.host.fs as unknown) === capturedFs,
+    );
+
+    // A file mounted through the returned host must be visible to the exact fs
+    // the runtime reads through — the whole point of the identity invariant.
+    result.host.writeFile("/project/main.ts", "export const x = 1;\n");
+    const fd = await openFd(result.host.fs, "/project/main.ts", 0);
+    TestValidator.equals(
+      "runtime fs sees a file written through the returned host",
+      await readFdText(result.host.fs, fd, 64),
+      "export const x = 1;\n",
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_ftruncate_resizes_via_descriptor.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_ftruncate_resizes_via_descriptor.ts
@@ -1,0 +1,43 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { callMutation, expectFsError, openFd } from "../../internal/callbackFs";
+
+/**
+ * Verifies MemFS ftruncate resizes the file behind a valid descriptor and
+ * rejects inappropriate descriptors.
+ *
+ * `ftruncate` must apply the same byte rules as path `truncate` but through the
+ * descriptor table, and it must refuse descriptors that have no truncatable
+ * file: the reserved stdout/stderr fds and unknown fds. The pre-fix version was
+ * a no-op, so a descriptor-based truncate left the file unchanged.
+ *
+ * 1. Seed `/t.txt`="abcdef" and open it, then ftruncate the descriptor to 3.
+ * 2. Read the file back and attempt ftruncate on an unknown fd, the stdout fd,
+ *    and a negative length.
+ * 3. Assert the file shrank to "abc" and each invalid call carries its code.
+ */
+export const test_memfs_ftruncate_resizes_via_descriptor =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/t.txt", "abcdef");
+    const fd = await openFd(host.fs, "/t.txt", 2);
+
+    await callMutation((cb) => host.fs.ftruncate(fd, 3, cb));
+    TestValidator.equals(
+      "descriptor truncate shrinks the file",
+      host.readFileText("/t.txt"),
+      "abc",
+    );
+
+    const codes = {
+      unknownFd: await expectFsError((cb) => host.fs.ftruncate(987654, 0, cb)),
+      stdout: await expectFsError((cb) => host.fs.ftruncate(1, 0, cb)),
+      negative: await expectFsError((cb) => host.fs.ftruncate(fd, -1, cb)),
+    };
+    TestValidator.equals("rejection codes", codes, {
+      unknownFd: "EBADF",
+      stdout: "EINVAL",
+      negative: "EINVAL",
+    });
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_rename_directory_reparents_descendants_and_descriptors.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_rename_directory_reparents_descendants_and_descriptors.ts
@@ -1,0 +1,52 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { callMutation, openFd, readFdText } from "../../internal/callbackFs";
+
+/**
+ * Verifies MemFS rename of a directory moves every descendant and follows open
+ * descriptors to the new location.
+ *
+ * Pins the exact defect from RA-13: the pre-fix `rename` moved only the named
+ * directory node, orphaning every descendant at the old prefix and stranding
+ * any file descriptor that pointed inside the moved subtree. A successful
+ * rename must re-parent the whole subtree and keep an open `fd` reading the same
+ * inode, now reachable at its new path.
+ *
+ * 1. Seed `/old/child/file.txt` with "abcdef" and open it for reading.
+ * 2. Rename `/old` to `/new`.
+ * 3. Assert the old prefix is fully gone, the new prefix holds the file and its
+ *    bytes, and the pre-existing descriptor still reads "abcdef".
+ */
+export const test_memfs_rename_directory_reparents_descendants_and_descriptors =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.mkdirp("/old/child");
+    host.writeFile("/old/child/file.txt", "abcdef");
+    const fd = await openFd(host.fs, "/old/child/file.txt", 0);
+
+    await callMutation((cb) => host.fs.rename("/old", "/new", cb));
+
+    TestValidator.predicate(
+      "old subtree fully removed",
+      host.exists("/old") === false &&
+        host.exists("/old/child") === false &&
+        host.exists("/old/child/file.txt") === false,
+    );
+    TestValidator.predicate(
+      "new subtree materialized",
+      host.exists("/new") &&
+        host.exists("/new/child") &&
+        host.exists("/new/child/file.txt"),
+    );
+    TestValidator.equals(
+      "moved file bytes preserved",
+      host.readFileText("/new/child/file.txt"),
+      "abcdef",
+    );
+    TestValidator.equals(
+      "open descriptor follows the move",
+      await readFdText(host.fs, fd, 6),
+      "abcdef",
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_rename_directory_reparents_descendants_and_descriptors.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_rename_directory_reparents_descendants_and_descriptors.ts
@@ -1,7 +1,13 @@
 import { TestValidator } from "@nestia/e2e";
 import { createMemFS } from "@ttsc/wasm";
 
-import { callMutation, openFd, readFdText } from "../../internal/callbackFs";
+import {
+  callMutation,
+  openFd,
+  readdir,
+  readFdText,
+  stat,
+} from "../../internal/callbackFs";
 
 /**
  * Verifies MemFS rename of a directory moves every descendant and follows open
@@ -16,7 +22,8 @@ import { callMutation, openFd, readFdText } from "../../internal/callbackFs";
  * 1. Seed `/old/child/file.txt` with "abcdef" and open it for reading.
  * 2. Rename `/old` to `/new`.
  * 3. Assert the old prefix is fully gone, the new prefix holds the file and its
- *    bytes, and the pre-existing descriptor still reads "abcdef".
+ *    bytes (via `readdir` + `stat`, which scan the node map by prefix and would
+ *    expose an orphan), and the pre-existing descriptor still reads "abcdef".
  */
 export const test_memfs_rename_directory_reparents_descendants_and_descriptors =
   async (): Promise<void> => {
@@ -43,6 +50,21 @@ export const test_memfs_rename_directory_reparents_descendants_and_descriptors =
       "moved file bytes preserved",
       host.readFileText("/new/child/file.txt"),
       "abcdef",
+    );
+    TestValidator.equals(
+      "readdir lists the moved descendant under the new parent",
+      await readdir(host.fs, "/new/child"),
+      ["file.txt"],
+    );
+    TestValidator.equals(
+      "root no longer lists the old directory",
+      await readdir(host.fs, "/"),
+      ["new"],
+    );
+    const moved = await stat(host.fs, "/new/child/file.txt");
+    TestValidator.predicate(
+      "stat reports the moved node as a 6-byte file",
+      moved.isFile() && moved.isDirectory() === false && moved.size === 6,
     );
     TestValidator.equals(
       "open descriptor follows the move",

--- a/tests/test-wasm/src/features/memfs/test_memfs_rename_file_preserves_bytes.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_rename_file_preserves_bytes.ts
@@ -1,0 +1,29 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { callMutation } from "../../internal/callbackFs";
+
+/**
+ * Verifies MemFS rename: a file moves to the destination with its bytes intact
+ * and the source path gone.
+ *
+ * Pins the transformation direction of `createMemFS().fs.rename` on a file. The
+ * pre-fix implementation `nodes.delete(src); nodes.set(dest, node)` happened to
+ * work for a single file, so this positive case is the baseline the directory
+ * and overwrite cases build on: a successful callback must mean the tree
+ * actually reflects the move, not merely that the callback fired.
+ *
+ * 1. Seed `/a.txt` with "hello".
+ * 2. Rename `/a.txt` to `/b.txt`.
+ * 3. Assert `/a.txt` is gone, `/b.txt` exists, and its bytes are still "hello".
+ */
+export const test_memfs_rename_file_preserves_bytes = async (): Promise<void> => {
+  const host = createMemFS();
+  host.writeFile("/a.txt", "hello");
+
+  await callMutation((cb) => host.fs.rename("/a.txt", "/b.txt", cb));
+
+  TestValidator.predicate("source removed", host.exists("/a.txt") === false);
+  TestValidator.predicate("destination created", host.exists("/b.txt"));
+  TestValidator.equals("bytes preserved", host.readFileText("/b.txt"), "hello");
+};

--- a/tests/test-wasm/src/features/memfs/test_memfs_rename_onto_self_is_noop.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_rename_onto_self_is_noop.ts
@@ -1,0 +1,28 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { callMutation } from "../../internal/callbackFs";
+
+/**
+ * Verifies MemFS rename of a path onto itself is a success that changes
+ * nothing.
+ *
+ * Boundary case for the move algorithm: `src === dest` must short-circuit
+ * before the subtree-delete-then-reinsert logic runs, because that logic
+ * deletes the source subtree first and would otherwise erase the node it is
+ * supposed to keep. POSIX `rename(2)` defines same-path rename as a no-op
+ * success.
+ *
+ * 1. Seed `/keep.txt` with "same".
+ * 2. Rename `/keep.txt` onto itself (via a non-normalized alias `/./keep.txt`).
+ * 3. Assert the callback succeeded and the file and its bytes still exist.
+ */
+export const test_memfs_rename_onto_self_is_noop = async (): Promise<void> => {
+  const host = createMemFS();
+  host.writeFile("/keep.txt", "same");
+
+  await callMutation((cb) => host.fs.rename("/keep.txt", "/./keep.txt", cb));
+
+  TestValidator.predicate("file still present", host.exists("/keep.txt"));
+  TestValidator.equals("bytes untouched", host.readFileText("/keep.txt"), "same");
+};

--- a/tests/test-wasm/src/features/memfs/test_memfs_rename_overwrites_existing_destination.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_rename_overwrites_existing_destination.ts
@@ -1,0 +1,51 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { callMutation } from "../../internal/callbackFs";
+
+/**
+ * Verifies MemFS rename overwrites a compatible existing destination without
+ * orphaning either side.
+ *
+ * POSIX `rename(2)` replaces an existing destination when the types are
+ * compatible: file-onto-file overwrites the bytes, and directory-onto-empty-
+ * directory replaces the empty node with the moved subtree. This pins that the
+ * destination-reconciliation branch mutates atomically — the old destination
+ * node is gone and the source has fully moved, with no leftover nodes.
+ *
+ * 1. Seed a file `/from.txt`="NEW" over an existing `/to.txt`="OLD", and a
+ *    subtree `/srcdir/x.txt` over an empty `/destdir`.
+ * 2. Rename file-onto-file and directory-onto-empty-directory.
+ * 3. Assert both sources are gone and both destinations hold the moved content.
+ */
+export const test_memfs_rename_overwrites_existing_destination =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/from.txt", "NEW");
+    host.writeFile("/to.txt", "OLD");
+    host.mkdirp("/srcdir");
+    host.writeFile("/srcdir/x.txt", "XX");
+    host.mkdirp("/destdir");
+
+    await callMutation((cb) => host.fs.rename("/from.txt", "/to.txt", cb));
+    await callMutation((cb) => host.fs.rename("/srcdir", "/destdir", cb));
+
+    TestValidator.predicate(
+      "file source removed after overwrite",
+      host.exists("/from.txt") === false,
+    );
+    TestValidator.equals(
+      "destination file overwritten",
+      host.readFileText("/to.txt"),
+      "NEW",
+    );
+    TestValidator.predicate(
+      "directory source removed after overwrite",
+      host.exists("/srcdir") === false && host.exists("/srcdir/x.txt") === false,
+    );
+    TestValidator.equals(
+      "moved subtree landed on the replaced directory",
+      host.readFileText("/destdir/x.txt"),
+      "XX",
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_rename_rejects_invalid_targets_without_partial_state.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_rename_rejects_invalid_targets_without_partial_state.ts
@@ -1,0 +1,86 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { expectFsError } from "../../internal/callbackFs";
+
+/**
+ * Verifies MemFS rename rejects every ill-formed target with the right POSIX
+ * code and leaves the tree byte-for-byte unchanged.
+ *
+ * These are the negative twins of the successful move: a rename that cannot
+ * satisfy its contract must not partially mutate. RA-13 requires each rejected
+ * class (missing source, root, self-into-descendant, absent/non-directory
+ * destination parent, file-vs-directory collisions, non-empty overwrite) to
+ * fail cleanly rather than delete or half-move nodes.
+ *
+ * 1. Seed a fixed tree with files, nested and empty directories.
+ * 2. Attempt every invalid rename and record its rejection code.
+ * 3. Assert each expected code and that the whole tree is still intact with no
+ *    stray destination nodes.
+ */
+export const test_memfs_rename_rejects_invalid_targets_without_partial_state =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.mkdirp("/dir/sub");
+    host.writeFile("/dir/a.txt", "AAA");
+    host.writeFile("/dir/sub/b.txt", "BBB");
+    host.writeFile("/file.txt", "FILE");
+    host.mkdirp("/empty");
+    host.mkdirp("/empty2");
+
+    const codes = {
+      missingSource: await expectFsError((cb) =>
+        host.fs.rename("/nope", "/x", cb),
+      ),
+      root: await expectFsError((cb) => host.fs.rename("/", "/x", cb)),
+      selfDescendant: await expectFsError((cb) =>
+        host.fs.rename("/dir", "/dir/sub/inner", cb),
+      ),
+      absentParent: await expectFsError((cb) =>
+        host.fs.rename("/file.txt", "/nonexistent/x", cb),
+      ),
+      fileParent: await expectFsError((cb) =>
+        host.fs.rename("/file.txt", "/file.txt/x", cb),
+      ),
+      fileOntoDir: await expectFsError((cb) =>
+        host.fs.rename("/file.txt", "/empty", cb),
+      ),
+      dirOntoFile: await expectFsError((cb) =>
+        host.fs.rename("/dir", "/file.txt", cb),
+      ),
+      dirOntoNonEmptyDir: await expectFsError((cb) =>
+        host.fs.rename("/empty2", "/dir", cb),
+      ),
+    };
+
+    TestValidator.equals("rejection codes", codes, {
+      missingSource: "ENOENT",
+      root: "EBUSY",
+      selfDescendant: "EINVAL",
+      absentParent: "ENOENT",
+      fileParent: "ENOTDIR",
+      fileOntoDir: "EISDIR",
+      dirOntoFile: "ENOTDIR",
+      dirOntoNonEmptyDir: "ENOTEMPTY",
+    });
+
+    TestValidator.predicate(
+      "no stray destination nodes were created",
+      host.exists("/x") === false &&
+        host.exists("/nonexistent") === false &&
+        host.exists("/dir/sub/inner") === false,
+    );
+    TestValidator.equals("tree contents intact", {
+      a: host.readFileText("/dir/a.txt"),
+      b: host.readFileText("/dir/sub/b.txt"),
+      file: host.readFileText("/file.txt"),
+      empty: host.exists("/empty"),
+      empty2: host.exists("/empty2"),
+    }, {
+      a: "AAA",
+      b: "BBB",
+      file: "FILE",
+      empty: true,
+      empty2: true,
+    });
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_rmdir_enforces_empty_directory.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_rmdir_enforces_empty_directory.ts
@@ -1,7 +1,11 @@
 import { TestValidator } from "@nestia/e2e";
 import { createMemFS } from "@ttsc/wasm";
 
-import { callMutation, expectFsError } from "../../internal/callbackFs";
+import {
+  callMutation,
+  expectFsError,
+  readdir,
+} from "../../internal/callbackFs";
 
 /**
  * Verifies MemFS rmdir removes an empty directory and rejects every other case
@@ -46,5 +50,10 @@ export const test_memfs_rmdir_enforces_empty_directory =
     TestValidator.predicate(
       "non-empty directory and its descendant survive",
       host.exists("/full") && host.readFileText("/full/child.txt") === "child",
+    );
+    TestValidator.equals(
+      "readdir still lists the surviving descendant (no orphan drop)",
+      await readdir(host.fs, "/full"),
+      ["child.txt"],
     );
   };

--- a/tests/test-wasm/src/features/memfs/test_memfs_rmdir_enforces_empty_directory.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_rmdir_enforces_empty_directory.ts
@@ -1,0 +1,50 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { callMutation, expectFsError } from "../../internal/callbackFs";
+
+/**
+ * Verifies MemFS rmdir removes an empty directory and rejects every other case
+ * without orphaning descendants.
+ *
+ * The pre-fix `rmdir` delegated straight to `unlink`, which deleted the named
+ * node with no type, emptiness, or root check — a non-empty rmdir "succeeded"
+ * while leaving every descendant stranded at its old path. RA-13 requires
+ * rmdir to enforce POSIX semantics: empty directory succeeds, non-empty is
+ * ENOTEMPTY (tree untouched), a file is ENOTDIR, root is EBUSY, and a missing
+ * path is ENOENT.
+ *
+ * 1. Seed an empty `/empty`, a non-empty `/full/child.txt`, and a file `/f.txt`.
+ * 2. rmdir the empty directory, then attempt each invalid target.
+ * 3. Assert the empty one is gone, each rejection code, and the non-empty
+ *    directory still holds its descendant.
+ */
+export const test_memfs_rmdir_enforces_empty_directory =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.mkdirp("/empty");
+    host.mkdirp("/full");
+    host.writeFile("/full/child.txt", "child");
+    host.writeFile("/f.txt", "file");
+
+    await callMutation((cb) => host.fs.rmdir("/empty", cb));
+
+    const codes = {
+      nonEmpty: await expectFsError((cb) => host.fs.rmdir("/full", cb)),
+      file: await expectFsError((cb) => host.fs.rmdir("/f.txt", cb)),
+      root: await expectFsError((cb) => host.fs.rmdir("/", cb)),
+      missing: await expectFsError((cb) => host.fs.rmdir("/nope", cb)),
+    };
+
+    TestValidator.predicate("empty directory removed", host.exists("/empty") === false);
+    TestValidator.equals("rejection codes", codes, {
+      nonEmpty: "ENOTEMPTY",
+      file: "ENOTDIR",
+      root: "EBUSY",
+      missing: "ENOENT",
+    });
+    TestValidator.predicate(
+      "non-empty directory and its descendant survive",
+      host.exists("/full") && host.readFileText("/full/child.txt") === "child",
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_truncate_resizes_file_and_validates.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_truncate_resizes_file_and_validates.ts
@@ -1,0 +1,48 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { callMutation, expectFsError } from "../../internal/callbackFs";
+
+/**
+ * Verifies MemFS truncate shrinks and zero-extends file bytes and validates its
+ * path and length.
+ *
+ * The pre-fix `truncate` was a no-op that returned success without touching any
+ * node, so a caller that truncated then read saw stale bytes. RA-13 requires
+ * the real POSIX contract: shrink drops trailing bytes, grow zero-fills the
+ * extension, a negative length is EINVAL, a directory is EISDIR, and a missing
+ * path is ENOENT.
+ *
+ * 1. Seed `/t.txt`="abcdef", shrink to 2, then grow to 5.
+ * 2. Read back the resized bytes.
+ * 3. Assert "ab" survives, the grown tail is zero-filled to length 5, and each
+ *    invalid call carries its expected code.
+ */
+export const test_memfs_truncate_resizes_file_and_validates =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/t.txt", "abcdef");
+    host.mkdirp("/dir");
+
+    await callMutation((cb) => host.fs.truncate("/t.txt", 2, cb));
+    TestValidator.equals("shrink drops trailing bytes", host.readFileText("/t.txt"), "ab");
+
+    await callMutation((cb) => host.fs.truncate("/t.txt", 5, cb));
+    const grown = host.readFile("/t.txt");
+    TestValidator.equals(
+      "grow zero-fills to exact length",
+      grown === null ? null : [...grown],
+      [0x61, 0x62, 0, 0, 0],
+    );
+
+    const codes = {
+      negative: await expectFsError((cb) => host.fs.truncate("/t.txt", -1, cb)),
+      directory: await expectFsError((cb) => host.fs.truncate("/dir", 0, cb)),
+      missing: await expectFsError((cb) => host.fs.truncate("/nope", 0, cb)),
+    };
+    TestValidator.equals("rejection codes", codes, {
+      negative: "EINVAL",
+      directory: "EISDIR",
+      missing: "ENOENT",
+    });
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_unlink_removes_file_and_refuses_directory.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_unlink_removes_file_and_refuses_directory.ts
@@ -1,0 +1,46 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { callMutation, expectFsError } from "../../internal/callbackFs";
+
+/**
+ * Verifies MemFS unlink removes a file but refuses a directory so Go's
+ * os.Remove falls through to rmdir.
+ *
+ * Go's `os.Remove` tries `unlink` first and only falls back to `rmdir` when it
+ * fails. The pre-fix `unlink` deleted any node, so unlinking a directory
+ * "succeeded" and dropped only its node while orphaning descendants and
+ * skipping the emptiness check rmdir would have run. The fix makes a directory
+ * unlink reject with EISDIR; a missing path is still ENOENT and a plain file
+ * still unlinks.
+ *
+ * 1. Seed a file `/f.txt` and a non-empty directory `/d/child.txt`.
+ * 2. Unlink the file (succeeds); attempt to unlink the directory and a missing
+ *    path.
+ * 3. Assert the file is gone, the directory rejects EISDIR with its descendant
+ *    intact, and the missing path is ENOENT.
+ */
+export const test_memfs_unlink_removes_file_and_refuses_directory =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/f.txt", "file");
+    host.mkdirp("/d");
+    host.writeFile("/d/child.txt", "child");
+
+    await callMutation((cb) => host.fs.unlink("/f.txt", cb));
+
+    const codes = {
+      directory: await expectFsError((cb) => host.fs.unlink("/d", cb)),
+      missing: await expectFsError((cb) => host.fs.unlink("/nope", cb)),
+    };
+
+    TestValidator.predicate("file unlinked", host.exists("/f.txt") === false);
+    TestValidator.equals("rejection codes", codes, {
+      directory: "EISDIR",
+      missing: "ENOENT",
+    });
+    TestValidator.predicate(
+      "directory and descendant survive the refused unlink",
+      host.exists("/d") && host.readFileText("/d/child.txt") === "child",
+    );
+  };

--- a/tests/test-wasm/src/index.ts
+++ b/tests/test-wasm/src/index.ts
@@ -1,0 +1,9 @@
+import { TestExecutor } from "@ttsc/testing";
+import path from "node:path";
+
+TestExecutor.main({
+  location: path.join(process.cwd(), "src", "features"),
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/test-wasm/src/internal/bootHarness.ts
+++ b/tests/test-wasm/src/internal/bootHarness.ts
@@ -1,0 +1,137 @@
+// Node-side lifecycle harness for the real, built `bootTtsc`.
+//
+// `bootTtsc` runs in a Web Worker and reaches for `importScripts`, `fetch`,
+// `WebAssembly.instantiateStreaming`, and the `Go` constructor that
+// `wasm_exec.js` installs. None of those wasm mechanics are the subject under
+// test — the *lifecycle* (readiness settlement, retry global restore) is. This
+// harness stubs exactly those globals with a fake Go runtime whose behavior a
+// test controls, drives the real imported `bootTtsc`, and restores every
+// touched global afterward so sequential cases stay isolated.
+//
+// A successful `bootTtsc` deliberately leaves `globalThis.fs` installed, so the
+// snapshot/restore below is load-bearing: without it, a boot that resolves in
+// one case would leave `globalThis.fs` set and defeat the "install only when
+// absent" path the retry cases depend on.
+
+/** Controls handed to a fake `go.run` body so a case can steer readiness. */
+export interface IFakeRuntime {
+  /** The `apiName` this boot is waiting on. */
+  readonly apiName: string;
+  /** The exact `globalThis.fs` object visible to the runtime when it started. */
+  readonly capturedFs: unknown;
+  /** Bind `globalThis[apiName]` and fire the readiness resolver. */
+  signalReady(api?: unknown): void;
+  /** Fire the explicit `globalThis[apiName + "Failed"]` reject bridge. */
+  signalFailed(error: unknown): void;
+}
+
+/** Behavior a case installs for one boot attempt sequence. */
+export interface IBootStubOptions {
+  /**
+   * `Response.ok` status returned by successive `fetch` calls. A `< 400` status
+   * is `ok`; `>= 400` drives the pre-`go.run` fetch-failure branch. Defaults to
+   * a single `200`. The last entry repeats for any further calls.
+   */
+  fetchStatuses?: number[];
+  /**
+   * Fake `go.run` body, invoked once per attempt that reaches instantiation.
+   * Return the promise that represents the Go runtime's lifetime: a normal host
+   * returns a never-settling promise after `signalReady`; an early exit returns
+   * a settled promise without signaling.
+   */
+  onRun: (runtime: IFakeRuntime) => Promise<void>;
+}
+
+type GlobalRecord = Record<string, unknown>;
+
+/** A default fake API object so `signalReady()` binds something inspectable. */
+export const FAKE_API = Object.freeze({ version: () => ({ version: "test" }) });
+
+/**
+ * Install the boot stubs, run `body` (which calls the real `bootTtsc`), and
+ * restore every touched global — even on throw. Each case gets a clean slate.
+ */
+export async function withBootStubs<T>(
+  apiName: string,
+  options: IBootStubOptions,
+  body: () => Promise<T>,
+): Promise<T> {
+  const g = globalThis as GlobalRecord;
+  const keys = [
+    "fs",
+    "process",
+    "Go",
+    "importScripts",
+    "fetch",
+    apiName,
+    apiName + "Ready",
+    apiName + "Failed",
+  ];
+  // Snapshot presence + value so restore can distinguish "was absent" (delete)
+  // from "was present" (reassign) — `process` genuinely exists in Node and must
+  // survive untouched.
+  const snapshot = new Map<string, { had: boolean; value: unknown }>();
+  for (const key of keys)
+    snapshot.set(key, { had: key in g, value: g[key] });
+  const wasmDescriptor = Object.getOwnPropertyDescriptor(
+    WebAssembly,
+    "instantiateStreaming",
+  );
+
+  let fetchCall = 0;
+  const statuses = options.fetchStatuses ?? [200];
+
+  // `importScripts` is what installs the Go constructor in a Worker. Here it
+  // installs a fake Go whose `run` defers to the case's `onRun`.
+  g.importScripts = (): void => {
+    class FakeGo {
+      public importObject: WebAssembly.Imports = {} as WebAssembly.Imports;
+      public run(): Promise<void> {
+        const runtime: IFakeRuntime = {
+          apiName,
+          capturedFs: g.fs,
+          signalReady(api: unknown = FAKE_API): void {
+            g[apiName] = api;
+            const cb = g[apiName + "Ready"];
+            if (typeof cb === "function") (cb as () => void)();
+          },
+          signalFailed(error: unknown): void {
+            const cb = g[apiName + "Failed"];
+            if (typeof cb === "function")
+              (cb as (e: unknown) => void)(error);
+          },
+        };
+        return options.onRun(runtime);
+      }
+    }
+    g.Go = FakeGo;
+  };
+
+  g.fetch = ((): Promise<{ ok: boolean; status: number }> => {
+    const status = statuses[Math.min(fetchCall, statuses.length - 1)]!;
+    fetchCall += 1;
+    return Promise.resolve({ ok: status < 400, status });
+  }) as unknown as typeof fetch;
+
+  Object.defineProperty(WebAssembly, "instantiateStreaming", {
+    configurable: true,
+    writable: true,
+    value: async () => ({
+      instance: {} as WebAssembly.Instance,
+      module: {} as WebAssembly.Module,
+    }),
+  });
+
+  try {
+    return await body();
+  } finally {
+    if (wasmDescriptor)
+      Object.defineProperty(WebAssembly, "instantiateStreaming", wasmDescriptor);
+    else
+      delete (WebAssembly as unknown as GlobalRecord).instantiateStreaming;
+    for (const [key, snap] of snapshot) {
+      if (snap.had) g[key] = snap.value;
+      else delete g[key];
+    }
+  }
+}

--- a/tests/test-wasm/src/internal/callbackFs.ts
+++ b/tests/test-wasm/src/internal/callbackFs.ts
@@ -1,0 +1,68 @@
+// Promise adapters over the low-level `IWasmExecFS` errback API.
+//
+// The MemFS mutation methods (`rename`, `rmdir`, `unlink`, `truncate`,
+// `ftruncate`, `open`, `read`, `write`) all follow Node's `callback(err, ...)`
+// convention. The Go/wasm runtime is the real caller; these adapters let the
+// tests drive the exact same entry points and assert on the settled result
+// instead of nesting callbacks.
+import type { IWasmExecFS } from "@ttsc/wasm";
+
+/** A rejected `IWasmExecFS` callback error, carrying its POSIX `code`. */
+export interface IFsError extends Error {
+  code?: string;
+}
+
+/** Await a no-result mutation (`rename`/`rmdir`/`unlink`/`truncate`/…). */
+export function callMutation(
+  run: (cb: (err: IFsError | null) => void) => void,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    run((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+/**
+ * Await a mutation and return its rejection `code` (or `null` on success). Lets
+ * a negative-twin assertion pin the exact POSIX error a rejected mutation must
+ * carry without a try/catch per case.
+ */
+export async function expectFsError(
+  run: (cb: (err: IFsError | null) => void) => void,
+): Promise<string | null> {
+  try {
+    await callMutation(run);
+    return null;
+  } catch (err) {
+    return (err as IFsError).code ?? "UNKNOWN";
+  }
+}
+
+/** Open `path` with the given flags and resolve to its file descriptor. */
+export function openFd(
+  fs: IWasmExecFS,
+  path: string,
+  flags: number,
+): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    fs.open(path, flags, 0o644, (err, fd) => (err ? reject(err) : resolve(fd)));
+  });
+}
+
+/**
+ * Read up to `length` bytes from `fd` at the current position and return the
+ * decoded UTF-8 text of exactly the bytes reported read.
+ */
+export function readFdText(
+  fs: IWasmExecFS,
+  fd: number,
+  length: number,
+): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const buffer = new Uint8Array(length);
+    fs.read(fd, buffer, 0, length, null, (err, n) =>
+      err
+        ? reject(err)
+        : resolve(new TextDecoder().decode(buffer.subarray(0, n))),
+    );
+  });
+}

--- a/tests/test-wasm/src/internal/callbackFs.ts
+++ b/tests/test-wasm/src/internal/callbackFs.ts
@@ -5,7 +5,7 @@
 // convention. The Go/wasm runtime is the real caller; these adapters let the
 // tests drive the exact same entry points and assert on the settled result
 // instead of nesting callbacks.
-import type { IWasmExecFS } from "@ttsc/wasm";
+import type { IFileStats, IWasmExecFS } from "@ttsc/wasm";
 
 /** A rejected `IWasmExecFS` callback error, carrying its POSIX `code`. */
 export interface IFsError extends Error {
@@ -35,6 +35,22 @@ export async function expectFsError(
   } catch (err) {
     return (err as IFsError).code ?? "UNKNOWN";
   }
+}
+
+/** Read the sorted immediate child names of directory `path`. */
+export function readdir(fs: IWasmExecFS, path: string): Promise<string[]> {
+  return new Promise<string[]>((resolve, reject) => {
+    fs.readdir(path, (err, entries) =>
+      err ? reject(err) : resolve(entries),
+    );
+  });
+}
+
+/** Stat `path` and resolve to its `IFileStats`. */
+export function stat(fs: IWasmExecFS, path: string): Promise<IFileStats> {
+  return new Promise<IFileStats>((resolve, reject) => {
+    fs.stat(path, (err, stats) => (err ? reject(err) : resolve(stats)));
+  });
 }
 
 /** Open `path` with the given flags and resolve to its file descriptor. */

--- a/tests/test-wasm/tsconfig.json
+++ b/tests/test-wasm/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/website/src/content/docs/wasm/index.mdx
+++ b/website/src/content/docs/wasm/index.mdx
@@ -105,6 +105,7 @@ For the base endpoints, `raw.result` is a JSON string. Use `parseResult<T>` at t
 - `host.readFileText` reads emitted or transformed virtual files if your plugin writes into the MemFS.
 - `host.stdout.buffer` and `host.stderr.buffer` capture direct writes to fd 1 and fd 2. Call `host.resetStdio()` when you intentionally inspect those buffers across separate runs.
 - The filesystem is memory-only. Recreate the project tree from UI state before each compile, or serialize calls that mutate the same paths.
+- Mutations enforce POSIX-style invariants: renaming a directory moves its whole subtree (and follows open descriptors), `rmdir` requires an empty directory, `unlink` refuses directories, and `truncate`/`ftruncate` resize file bytes — zero-filling any growth — or reject an invalid path, descriptor, or length. A mutation that cannot satisfy its contract returns an error instead of partially changing the tree.
 - Symlinks and hardlinks are intentionally unsupported. Treat the project as a flat virtual workspace.
 
 The ttsc.dev playground writes one `/work` project per request, serializes all compile/lint/bundle calls, and reuses a single booted wasm for the whole Worker lifetime.
@@ -247,6 +248,7 @@ GOOS=js GOARCH=wasm go build -trimpath \
 | `Go is not defined` | `wasm_exec.js` was not loaded. Check `wasmExecUrl`; the default is the same directory as `wasmUrl`. |
 | `importScripts is not defined` | The worker was emitted as a module worker or the code ran on the main thread. Use a classic Worker-style bundle. |
 | `global was not set` | `apiName` does not match the name passed to `host.Expose`, or the wasm panicked before registering. |
+| Boot rejects with `exited before signaling readiness` | The Go host exited or panicked before calling `Ready` — often a `host.Expose` misconfiguration such as duplicate plugin names. `bootTtsc` now rejects with the cause instead of hanging forever; check the wasm stderr. |
 | `failed to fetch` | The `.wasm` URL is wrong, blocked by CORS, or not copied into the static output. |
 | `WebAssembly.instantiateStreaming` fails | Serve `.wasm` with `Content-Type: application/wasm`. |
 | The page locks up | Booted wasm on the main thread. Move it into a Worker. |


### PR DESCRIPTION
## Bundle b5 — wasm boot + MemFS invariants

Part of the `repository-audit-2026-07` issue campaign. This batch fixes three adjacent defects in `@ttsc/wasm`: two in the `bootTtsc` lifecycle and one in the `createMemFS` filesystem-mutation surface. They share the package and are validated by one new `tests/test-wasm` harness.

### Issues

- Closes #688 (RA-18) — **Reject `bootTtsc` when the Go host exits before readiness.** A pre-`Ready` Go exit (e.g. an early `host.Expose` panic) left the public boot Promise pending forever. Race `go.run` settlement against readiness so an early exit rejects with an actionable cause; route the duplicate-plugin-name host error through the `Failed` bridge (instead of `panic`) so its real cause survives.
- Closes #673 (RA-20) — **Keep the returned MemFS host aligned with the Go runtime across boot retries.** A failed attempt that had already installed `globalThis.fs`/`process` left them in place, so a later retry returned a different host than the runtime used. Restore only this attempt's own globals on failure, so a successful retry returns the exact host backing the runtime.
- Closes #671 (RA-13) — **Preserve MemFS tree and file-data invariants for successful mutations.** `rename` moved only a directory's own node (orphaning descendants); `rmdir` delegated to `unlink` with no type/emptiness/root checks; `truncate`/`ftruncate` were no-ops. Enforce Node/POSIX invariants: atomic subtree moves with descriptor follow, empty-directory `rmdir`, directory-refusing `unlink`, and validated path/descriptor truncation.

### Surface

- `packages/wasm/src/bootTtsc.ts` — lifecycle settlement + retry global restore.
- `packages/wasm/host/host.go` — duplicate-plugin-name via `Failed` bridge, no panic.
- `packages/wasm/src/createMemFS.ts` — rename/rmdir/unlink/truncate/ftruncate invariants.
- `packages/wasm/src/MemFSError.ts` — `EBUSY`/`ENOTEMPTY` errno mappings.
- `tests/test-wasm` — new TestExecutor package: `memfs` mutation cases + `boot` lifecycle harness.

### Verification

Package-scoped local verification (campaign CI is suspended per push):

- `pnpm --filter @ttsc/wasm build`
- `pnpm --filter @ttsc/test-wasm start`

Draft until implementation, tests, and solo Self-Review are complete.
