### PR TITLE
fix(unplugin): harden adapters, cache eviction, packaging, and tsconfig presets

### DIFF
--- a/packages/ttsc/src/compiler/internal/project/readProjectConfig.ts
+++ b/packages/ttsc/src/compiler/internal/project/readProjectConfig.ts
@@ -254,11 +254,67 @@ function resolveExtendsConfig(tsconfig: string, specifier: string): string {
     return resolveExistingExtendsPath(path.resolve(baseDir, specifier));
   }
   const resolver = createRequire(tsconfig);
+  // A bare package root selects its preset through `package.json#tsconfig`,
+  // matching TypeScript's config resolution. Presets shipped this way often
+  // have no JavaScript/JSON entrypoint at all, so Node's entrypoint resolver
+  // and the `<specifier>.json` fallback below both miss them.
+  const viaManifest = resolvePackageManifestTsconfig(resolver, specifier);
+  if (viaManifest !== undefined) {
+    return resolveExistingExtendsPath(viaManifest);
+  }
   try {
     return resolveRealPath(resolver.resolve(specifier));
   } catch {
     return resolveRealPath(resolver.resolve(`${specifier}.json`));
   }
+}
+
+/**
+ * When `specifier` names a bare package root, resolve the config file its
+ * `package.json#tsconfig` field selects (anchored at the package directory).
+ * Returns `undefined` when the specifier is a subpath, the manifest is
+ * unresolvable/unparsable, or it declares no `tsconfig` field, so the caller
+ * falls back to Node entrypoint resolution.
+ */
+function resolvePackageManifestTsconfig(
+  resolver: NodeRequire,
+  specifier: string,
+): string | undefined {
+  if (!isBarePackageRoot(specifier)) {
+    return undefined;
+  }
+  let manifestPath: string;
+  try {
+    manifestPath = resolver.resolve(`${specifier}/package.json`);
+  } catch {
+    return undefined;
+  }
+  let field: unknown;
+  try {
+    field = (
+      JSON.parse(stripLeadingBom(fs.readFileSync(manifestPath, "utf8"))) as {
+        tsconfig?: unknown;
+      }
+    ).tsconfig;
+  } catch {
+    return undefined;
+  }
+  if (typeof field !== "string" || field.length === 0) {
+    return undefined;
+  }
+  return path.resolve(path.dirname(manifestPath), field);
+}
+
+/**
+ * Return true when `specifier` is a bare package root (no subpath): a plain
+ * package name (`preset`) or a scoped name (`@scope/preset`). Subpaths such as
+ * `@scope/preset/base.json` resolve directly and keep their current meaning.
+ */
+function isBarePackageRoot(specifier: string): boolean {
+  if (specifier.startsWith("@")) {
+    return specifier.split("/").length === 2;
+  }
+  return !specifier.includes("/");
 }
 
 /**

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -97,6 +97,9 @@
   "dependencies": {
     "unplugin": "^2.3.11"
   },
+  "peerDependencies": {
+    "ttsc": "workspace:*"
+  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-node-resolve": "^16.0.3",

--- a/packages/unplugin/src/bun-register.ts
+++ b/packages/unplugin/src/bun-register.ts
@@ -13,6 +13,21 @@ interface BunRuntimeGlobal {
 }
 
 /**
+ * Effective options for the single runtime loader.
+ *
+ * Bun uses the first matching `onLoad` hook and does not fall through to a
+ * later overlapping plugin (oven-sh/bun#20583). Registering twice — once
+ * implicitly on import, once explicitly — would let the default loader shadow
+ * the configured one. Instead exactly one Bun plugin is registered; it resolves
+ * these options lazily on first load (see {@link bun}'s provider form), so an
+ * explicit `register(options)` made right after importing this module overrides
+ * the preload defaults without a second shadowing registration.
+ */
+let activeOptions: TtscUnpluginOptions | undefined;
+/** Whether the single runtime loader has already been registered with Bun. */
+let registered = false;
+
+/**
  * Register the ttsc transform as a Bun **runtime** plugin.
  *
  * The other `@ttsc/unplugin/*` adapters cover bundlers (`Bun.build`, Vite,
@@ -23,6 +38,12 @@ interface BunRuntimeGlobal {
  * ["@ttsc/unplugin/bun-register"]` — or imperatively with `import
  * "@ttsc/unplugin/bun-register"`. Options are read from the nearest
  * `tsconfig.json`, identical to the bundler adapters.
+ *
+ * Registration is idempotent: the first call (implicit on import, or explicit)
+ * registers the one loader with Bun; later calls only update the effective
+ * options, so accessing the explicit API cannot install a second default loader
+ * that shadows the caller's configuration. Repeated explicit calls are
+ * last-write-wins for the effective options.
  *
  * @throws When called explicitly off the Bun runtime (`globalThis.Bun.plugin`
  *   is unavailable). The auto-registration below stays silent off Bun so the
@@ -37,7 +58,15 @@ export function register(options?: TtscUnpluginOptions): void {
         "@ttsc/unplugin/vite for non-Bun toolchains.",
     );
   }
-  runtime.plugin(bun(options));
+  activeOptions = options;
+  if (registered) {
+    return;
+  }
+  registered = true;
+  // Register a single loader whose options are read from `activeOptions` on
+  // first load, so an explicit call made after the import-time auto-register
+  // still wins.
+  runtime.plugin(bun(() => activeOptions));
 }
 
 function bunRuntime(): BunRuntimeGlobal | undefined {

--- a/packages/unplugin/src/bun.ts
+++ b/packages/unplugin/src/bun.ts
@@ -23,6 +23,44 @@ export interface BunLikePlugin {
 export type BunLoader = "ts" | "tsx";
 
 /**
+ * Options accepted by {@link bun}, either resolved eagerly or supplied through a
+ * provider evaluated lazily on the first `onLoad` call.
+ *
+ * The provider form exists for the runtime registration path
+ * (`bun-register`), where a single Bun plugin is registered on import but its
+ * effective options may be overridden by an explicit `register(options)` call
+ * made in the same synchronous tick. Resolving through the provider on first
+ * load, rather than at registration, lets that later call win without Bun ever
+ * seeing a second shadowing loader.
+ */
+export type TtscBunOptions =
+  | TtscUnpluginOptions
+  | (() => TtscUnpluginOptions | undefined);
+
+/**
+ * Transform context handed to the raw unplugin transform under Bun.
+ *
+ * The shared transform calls `addWatchFile` once per plugin-reported dependency
+ * so type-only inputs can enter a bundler's watch graph. Bun's bundler and
+ * runtime loaders expose no per-module dependency-registration channel, so the
+ * hook is an explicit no-op here: reported dependencies cannot participate in
+ * Bun invalidation, but a valid dependency list must never crash the loader by
+ * reaching a missing context method. Passing an empty object made
+ * `this.addWatchFile` `undefined`, so any plugin reporting dependencies threw
+ * `TypeError: this.addWatchFile is not a function`.
+ */
+const bunTransformContext = {
+  addWatchFile(): void {},
+};
+
+/** Resolve {@link TtscBunOptions} to a plain options object (or `undefined`). */
+function resolveBunOptions(
+  options?: TtscBunOptions,
+): TtscUnpluginOptions | undefined {
+  return typeof options === "function" ? options() : options;
+}
+
+/**
  * Minimal subset of the Bun `BuildConfig` plugin build object.
  *
  * Only the `onLoad` hook is used; other hooks are not needed for a
@@ -61,17 +99,31 @@ export interface BunLikeBuild {
  * transpiling the emitted TypeScript at runtime; `sourceFilePattern` only
  * matches TypeScript, so the loader is always `ts`/`tsx`.
  */
-export default function bun(options?: TtscUnpluginOptions): BunLikePlugin {
+export default function bun(options?: TtscBunOptions): BunLikePlugin {
   return {
     name: "ttsc-unplugin",
     setup(build) {
-      const raw = unplugin.raw(options, {} as UnpluginContextMeta);
+      // Build the raw transform lazily on first load rather than in `setup`.
+      // Bun runs `setup` synchronously when the plugin is registered, so a
+      // runtime registration (bun-register) that resolves its effective options
+      // through a provider must defer that resolution until after any explicit
+      // `register(options)` call in the same tick. Deferring also keeps a single
+      // transform (and its project cache) shared across every loaded module.
+      let raw: ReturnType<typeof unplugin.raw> | undefined;
       build.onLoad({ filter: sourceFilePattern }, async (args) => {
+        raw ??= unplugin.raw(
+          resolveBunOptions(options),
+          {} as UnpluginContextMeta,
+        );
         const loader = bunLoaderFor(args.path);
         const source = await fs.readFile(args.path, "utf8");
         const result =
           typeof raw.transform === "function"
-            ? await raw.transform.call({} as never, source, args.path)
+            ? await raw.transform.call(
+                bunTransformContext as never,
+                source,
+                args.path,
+              )
             : undefined;
         // Unpack both shorthand string and object result shapes.
         if (typeof result === "string") {

--- a/packages/unplugin/src/core/transform.ts
+++ b/packages/unplugin/src/core/transform.ts
@@ -147,10 +147,14 @@ export async function transformTtsc(
 
   let transformed = cache?.get(key);
   if (transformed !== undefined) {
-    const cached = await transformed;
+    // A rejected in-flight generation must not stay cached: evict it (only if
+    // it is still the current entry) so a later call re-runs the transform.
+    const cached = await awaitOrEvict(cache, key, transformed);
     if (matchesCachedSource(cached, file, source)) {
       reportSuccessDiagnostics(cached.result);
-      const code = selectTransformedSource({
+      // A resolved `"exception"` / `"failure"` envelope makes this throw; that
+      // is a failed generation too, so evict before surfacing it.
+      const code = selectOrEvict(cache, key, transformed, {
         file,
         projectRoot: cached.projectRoot,
         result: cached.result,
@@ -177,11 +181,79 @@ export async function transformTtsc(
     });
     cache?.set(key, transformed);
   }
-  const { projectRoot, result } = await transformed;
+  const generation = transformed;
+  const { projectRoot, result } = await awaitOrEvict(cache, key, generation);
   reportSuccessDiagnostics(result);
-  const code = selectTransformedSource({ file, projectRoot, result });
+  const code = selectOrEvict(cache, key, generation, {
+    file,
+    projectRoot,
+    result,
+  });
   notifyFileDependencies(hooks, { file, projectRoot, result });
   return createTransformResult(source, code);
+}
+
+/**
+ * Await a cached generation, evicting it on rejection.
+ *
+ * The cache stores the in-flight transform Promise before it settles so
+ * concurrent callers share one compilation. A rejected generation must not
+ * remain the authoritative cached result, or a transient toolchain/host
+ * failure becomes permanent for a long-lived worker. Eviction is
+ * identity-guarded so a newer generation another caller installed under the
+ * same key survives.
+ */
+async function awaitOrEvict(
+  cache: TtscTransformCache | undefined,
+  key: string,
+  generation: Promise<TtscCachedProjectTransform>,
+): Promise<TtscCachedProjectTransform> {
+  try {
+    return await generation;
+  } catch (error) {
+    evictGeneration(cache, key, generation);
+    throw error;
+  }
+}
+
+/**
+ * Extract the transformed source, evicting the generation when the result is a
+ * host `"exception"` or compiler `"failure"` (which makes
+ * {@link selectTransformedSource} throw). Such a failed generation must not be
+ * replayed to later callers of an unchanged module.
+ */
+function selectOrEvict(
+  cache: TtscTransformCache | undefined,
+  key: string,
+  generation: Promise<TtscCachedProjectTransform>,
+  props: {
+    file: string;
+    projectRoot: string;
+    result: ITtscCompilerTransformation;
+  },
+): string {
+  try {
+    return selectTransformedSource(props);
+  } catch (error) {
+    evictGeneration(cache, key, generation);
+    throw error;
+  }
+}
+
+/**
+ * Delete a failed generation from the cache only when it is still the entry
+ * stored under `key`. The identity check prevents an older failed generation's
+ * cleanup from removing a newer replacement created by another caller for the
+ * same key.
+ */
+function evictGeneration(
+  cache: TtscTransformCache | undefined,
+  key: string,
+  generation: Promise<TtscCachedProjectTransform>,
+): void {
+  if (cache?.get(key) === generation) {
+    cache.delete(key);
+  }
 }
 
 /**

--- a/packages/unplugin/src/core/tsconfigPaths.ts
+++ b/packages/unplugin/src/core/tsconfigPaths.ts
@@ -148,6 +148,15 @@ function resolveExtendsConfig(
     );
   }
   const resolver = createRequire(tsconfig);
+  // A bare package root selects its preset through `package.json#tsconfig`,
+  // matching TypeScript's config resolution and the core project reader. Such
+  // presets often ship no JS/JSON entrypoint, so Node's entrypoint resolver and
+  // the `<specifier>.json` fallback both miss them, silently dropping the
+  // preset's inherited `paths`.
+  const viaManifest = resolvePackageManifestTsconfig(resolver, specifier);
+  if (viaManifest !== null) {
+    return viaManifest;
+  }
   try {
     return resolveRealPath(resolver.resolve(specifier));
   } catch {
@@ -157,6 +166,58 @@ function resolveExtendsConfig(
       return null;
     }
   }
+}
+
+/**
+ * When `specifier` names a bare package root, resolve the config file its
+ * `package.json#tsconfig` field selects (anchored at the package directory).
+ * Best-effort: returns `null` for a subpath, an unresolvable/unparsable
+ * manifest, a missing `tsconfig` field, or a field target that does not exist —
+ * the compiler owns the real diagnostic, and this reader must not invent
+ * aliases.
+ */
+function resolvePackageManifestTsconfig(
+  resolver: NodeRequire,
+  specifier: string,
+): string | null {
+  if (!isBarePackageRoot(specifier)) {
+    return null;
+  }
+  let manifestPath: string;
+  try {
+    manifestPath = resolver.resolve(`${specifier}/package.json`);
+  } catch {
+    return null;
+  }
+  let field: unknown;
+  try {
+    const text = fs.readFileSync(manifestPath, "utf8");
+    field = (
+      JSON.parse(text.charCodeAt(0) === 0xfeff ? text.slice(1) : text) as {
+        tsconfig?: unknown;
+      }
+    ).tsconfig;
+  } catch {
+    return null;
+  }
+  if (typeof field !== "string" || field.length === 0) {
+    return null;
+  }
+  return resolveExistingExtendsPath(
+    path.resolve(path.dirname(manifestPath), field),
+  );
+}
+
+/**
+ * Return true when `specifier` is a bare package root (no subpath): a plain
+ * package name (`preset`) or a scoped name (`@scope/preset`). Subpaths such as
+ * `@scope/preset/base.json` resolve directly and keep their current meaning.
+ */
+function isBarePackageRoot(specifier: string): boolean {
+  if (specifier.startsWith("@")) {
+    return specifier.split("/").length === 2;
+  }
+  return !specifier.includes("/");
 }
 
 /**

--- a/packages/unplugin/src/turbopack.ts
+++ b/packages/unplugin/src/turbopack.ts
@@ -21,6 +21,14 @@ export interface TtscTurbopackLoaderContext {
   resourcePath: string;
   /** The rule's `options` object, when one was configured. */
   getOptions?(): TtscUnpluginOptions | undefined;
+  /**
+   * Register an additional file the transformed module depends on. Part of the
+   * webpack loader context contract Turbopack implements; a registered file
+   * enters Turbopack's `fileDependencies` set so editing it re-runs this loader
+   * for the owning module. Optional so a minimal stub context (or a Turbopack
+   * build that predates the method) still loads.
+   */
+  addDependency?(file: string): void;
 }
 
 /** Matches any path segment that is a `node_modules` directory (cross-platform). */
@@ -71,12 +79,19 @@ export default function turbopack(
     callback(undefined, source);
     return;
   }
+  // Forward plugin-reported dependencies into Turbopack's `fileDependencies`
+  // set so editing a type-only input a transform consulted re-runs this loader.
+  // `addDependency` is bound so the webpack loader context stays `this` inside
+  // it; the hook fires on cache hits too, which is required because the shared
+  // transform cache lives for the worker lifetime across requests.
+  const addDependency = this.addDependency?.bind(this);
   transformTtsc(
     file,
     source,
     resolveOptions(this.getOptions?.() ?? {}),
     undefined,
     transformCache,
+    addDependency === undefined ? undefined : { addWatchFile: addDependency },
   ).then(
     (result) => callback(undefined, result?.code ?? source),
     (error) => callback(error),

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_rejects_missing_package_tsconfig_manifest_target.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_rejects_missing_package_tsconfig_manifest_target.ts
@@ -1,0 +1,54 @@
+import { TestProject } from "@ttsc/testing";
+
+import { assert, fs, path, readProjectConfig } from "../../internal/project";
+
+/**
+ * Verifies readProjectConfig fails visibly when a package.json#tsconfig target
+ * is missing.
+ *
+ * The manifest-preset resolution must stay a resolution of TypeScript's
+ * accepted contract, not a silent best-effort: when a preset declares a
+ * `tsconfig` field whose file does not exist, the core reader owns config
+ * diagnostics and must throw rather than fall back to Node entrypoint
+ * resolution and hide the misconfiguration. This is the negative twin of the
+ * successful manifest-selected resolution.
+ *
+ * 1. Create `node_modules/broken-preset` whose `package.json#tsconfig` points at
+ *    a non-existent `missing.json`.
+ * 2. Write a project tsconfig that extends the bare `"broken-preset"`.
+ * 3. Assert `readProjectConfig` throws about the unresolved extended tsconfig.
+ */
+export const test_readprojectconfig_rejects_missing_package_tsconfig_manifest_target =
+  () => {
+    const root = TestProject.tmpdir("ttsc-project-");
+    const preset = path.join(root, "node_modules", "broken-preset");
+    const project = path.join(root, "project");
+    fs.mkdirSync(preset, { recursive: true });
+    fs.mkdirSync(project, { recursive: true });
+    fs.writeFileSync(
+      path.join(preset, "package.json"),
+      JSON.stringify(
+        { name: "broken-preset", version: "1.0.0", tsconfig: "missing.json" },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(project, "tsconfig.json"),
+      JSON.stringify(
+        { extends: "broken-preset", compilerOptions: {} },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    assert.throws(
+      () =>
+        readProjectConfig({
+          tsconfig: path.join(project, "tsconfig.json"),
+        }),
+      /extended tsconfig not found|missing\.json/,
+    );
+  };

--- a/tests/test-ttsc/src/features/project/test_readprojectconfig_resolves_package_tsconfig_extends_via_manifest.ts
+++ b/tests/test-ttsc/src/features/project/test_readprojectconfig_resolves_package_tsconfig_extends_via_manifest.ts
@@ -1,0 +1,76 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  path,
+  readProjectConfig,
+} from "../../internal/project";
+
+/**
+ * Verifies readProjectConfig resolves package tsconfig extends via
+ * package.json#tsconfig.
+ *
+ * A bare `extends` specifier may name an npm preset that selects its config
+ * file through `package.json#tsconfig` and ships no JavaScript/JSON entrypoint.
+ * Node's entrypoint resolver and the `<specifier>.json` fallback both miss such
+ * a package, so `readProjectConfig` must honor the manifest field the way
+ * `tsc` does, or a TypeScript-valid project fails before native compilation.
+ *
+ * 1. Create `node_modules/example-preset` whose `package.json` has only a
+ *    `tsconfig` field (no `main`/`exports`) pointing at `base.json`.
+ * 2. Write a project tsconfig that extends the bare `"example-preset"`.
+ * 3. Assert the inherited plugins and absolute `outDir` come from the
+ *    manifest-selected `base.json`.
+ */
+export const test_readprojectconfig_resolves_package_tsconfig_extends_via_manifest =
+  () => {
+    const root = TestProject.tmpdir("ttsc-project-");
+    const preset = path.join(root, "node_modules", "example-preset");
+    const project = path.join(root, "project");
+    fs.mkdirSync(preset, { recursive: true });
+    fs.mkdirSync(project, { recursive: true });
+    fs.writeFileSync(
+      path.join(preset, "package.json"),
+      JSON.stringify(
+        { name: "example-preset", version: "1.0.0", tsconfig: "base.json" },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(preset, "base.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            outDir: "../../dist/preset",
+            plugins: [{ transform: "./plugins/from-preset.cjs" }],
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(project, "tsconfig.json"),
+      JSON.stringify(
+        { extends: "example-preset", compilerOptions: {} },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const parsed = readProjectConfig({
+      tsconfig: path.join(project, "tsconfig.json"),
+    });
+    assert.deepEqual(parsed.compilerOptions.plugins, [
+      { transform: "./plugins/from-preset.cjs" },
+    ]);
+    assert.equal(
+      parsed.compilerOptions.outDir,
+      path.join(root, "dist", "preset"),
+    );
+  };

--- a/tests/test-unplugin/src/features/adapters/test_bun_adapter_survives_plugin_reported_dependencies.ts
+++ b/tests/test-unplugin/src/features/adapters/test_bun_adapter_survives_plugin_reported_dependencies.ts
@@ -1,0 +1,24 @@
+import { assertBunAdapterSurvivesPluginReportedDependencies } from "../../internal/adapter-bun";
+
+/**
+ * Verifies the Bun adapter is safe for plugin-reported dependencies (#665).
+ *
+ * The shared transform notifies `addWatchFile` for every dependency a plugin
+ * reports. The Bun adapter used to call the raw transform with an empty
+ * receiver, so `this.addWatchFile` was `undefined` and any reported dependency
+ * crashed the loader with `TypeError: this.addWatchFile is not a function`
+ * before it could return transformed source. Bun has no per-module dependency
+ * channel, so the adapter must pass an explicit no-op watch context; a valid
+ * dependency list must never crash the loader.
+ *
+ * 1. Build the `emit-dependencies` fixture whose plugin reports a mix of
+ *    relative, absolute, duplicate, and self dependency entries.
+ * 2. Capture the Bun `onLoad` handler and invoke it for the main module.
+ * 3. Assert the fresh transform returns plugin-transformed `ts` output without
+ *    throwing, and that the subsequent cache-hit load (which replays the same
+ *    dependency notification) is equally safe.
+ */
+export const test_bun_adapter_survives_plugin_reported_dependencies =
+  async () => {
+    await assertBunAdapterSurvivesPluginReportedDependencies();
+  };

--- a/tests/test-unplugin/src/features/adapters/test_bun_register_explicit_options_are_not_shadowed_in_same_runtime_order.ts
+++ b/tests/test-unplugin/src/features/adapters/test_bun_register_explicit_options_are_not_shadowed_in_same_runtime_order.ts
@@ -1,0 +1,24 @@
+import { assertBunRegisterSameRuntimeExplicitOptionsWin } from "../../internal/adapter-bun-register";
+
+/**
+ * Verifies bun-register does not shadow explicit options in same-runtime order
+ * (#676).
+ *
+ * `@ttsc/unplugin/bun-register` auto-registers on import under Bun and also
+ * exports `register(options)`. Bun uses the first matching `onLoad` hook and
+ * does not fall through to a later overlapping plugin (oven-sh/bun#20583), so a
+ * default plugin registered at import time used to shadow the explicit one,
+ * silently ignoring the caller's `project`, `plugins`, and compiler options. The
+ * entry must register exactly one loader whose effective options resolve on
+ * first load, so an explicit call after import wins.
+ *
+ * 1. Freshly evaluate the entry with a Bun-like global present (import-time
+ *    auto-registration runs, as in a real preload).
+ * 2. Call `register(options)` with an explicit prefix plugin afterwards.
+ * 3. Assert exactly one plugin is ever registered and that driving it applies
+ *    the explicit options, not the fixture's tsconfig defaults.
+ */
+export const test_bun_register_explicit_options_are_not_shadowed_in_same_runtime_order =
+  async () => {
+    await assertBunRegisterSameRuntimeExplicitOptionsWin();
+  };

--- a/tests/test-unplugin/src/features/adapters/test_bun_register_preload_only_registers_a_single_default_plugin.ts
+++ b/tests/test-unplugin/src/features/adapters/test_bun_register_preload_only_registers_a_single_default_plugin.ts
@@ -1,0 +1,22 @@
+import { assertBunRegisterPreloadOnlyRegistersOneDefaultPlugin } from "../../internal/adapter-bun-register";
+
+/**
+ * Verifies a preload-only bun-register import registers one default plugin
+ * (#676).
+ *
+ * The negative twin of the same-runtime shadowing fix: the one-line
+ * `bunfig.toml` preload convenience must keep working. Importing the side-effect
+ * entry under Bun with no explicit `register` call must register exactly one
+ * default loader, which transforms using the project's own tsconfig
+ * configuration.
+ *
+ * 1. Freshly evaluate the entry with a Bun-like global present and make no
+ *    explicit `register` call.
+ * 2. Assert exactly one plugin was registered.
+ * 3. Drive that plugin and assert it applies the fixture's tsconfig-declared
+ *    transform.
+ */
+export const test_bun_register_preload_only_registers_a_single_default_plugin =
+  async () => {
+    await assertBunRegisterPreloadOnlyRegistersOneDefaultPlugin();
+  };

--- a/tests/test-unplugin/src/features/adapters/test_packaged_manifest_declares_the_external_ttsc_host.ts
+++ b/tests/test-unplugin/src/features/adapters/test_packaged_manifest_declares_the_external_ttsc_host.ts
@@ -1,0 +1,21 @@
+import { assertPackedManifestDeclaresTtscHost } from "../../internal/packaged-host-contract";
+
+/**
+ * Verifies the published @ttsc/unplugin manifest declares its ttsc host (#679).
+ *
+ * The adapter imports `ttsc` at runtime but keeps it external in the bundle.
+ * With `ttsc` declared only under `devDependencies`, a clean install of
+ * `@ttsc/unplugin` succeeded while the first import crashed with
+ * `Cannot find module 'ttsc'`. The published dependency contract must represent
+ * the required external host so a package manager can install, validate, or warn
+ * about it.
+ *
+ * 1. Pack the package as it would be published (rewriting `workspace:*` to a
+ *    concrete version).
+ * 2. Assert the packed manifest declares `ttsc` as a required peer dependency
+ *    with a concrete, resolvable version spec.
+ * 3. Assert `ttsc` stays external — not a bundled runtime dependency copy.
+ */
+export const test_packaged_manifest_declares_the_external_ttsc_host = async () => {
+  await assertPackedManifestDeclaresTtscHost();
+};

--- a/tests/test-unplugin/src/features/adapters/test_turbopack_loader_registers_no_dependencies_without_a_report.ts
+++ b/tests/test-unplugin/src/features/adapters/test_turbopack_loader_registers_no_dependencies_without_a_report.ts
@@ -1,0 +1,19 @@
+import { assertTurbopackLoaderRegistersNoDependenciesWithoutReport } from "../../internal/adapter-turbopack";
+
+/**
+ * Verifies the Turbopack loader registers nothing when a plugin reports no
+ * dependencies (#666).
+ *
+ * The negative twin of dependency registration: a transform whose plugin never
+ * reports a `dependencies` envelope field must not fabricate loader
+ * dependencies, or it would pollute Turbopack's invalidation graph and force
+ * needless reruns. The module must still transform normally.
+ *
+ * 1. Build the default fixture (no `emit-dependencies` operation).
+ * 2. Invoke the loader with a context that records `addDependency` calls.
+ * 3. Assert the module transformed and no dependencies were registered.
+ */
+export const test_turbopack_loader_registers_no_dependencies_without_a_report =
+  async () => {
+    await assertTurbopackLoaderRegistersNoDependenciesWithoutReport();
+  };

--- a/tests/test-unplugin/src/features/adapters/test_turbopack_loader_registers_plugin_dependencies_as_file_dependencies.ts
+++ b/tests/test-unplugin/src/features/adapters/test_turbopack_loader_registers_plugin_dependencies_as_file_dependencies.ts
@@ -1,0 +1,22 @@
+import { assertTurbopackLoaderRegistersPluginDependencies } from "../../internal/adapter-turbopack";
+
+/**
+ * Verifies the Turbopack loader registers plugin-reported dependencies (#666).
+ *
+ * The standalone Turbopack loader transformed source but dropped the transform
+ * envelope's reported dependency list, so type-only inputs a plugin consulted
+ * never entered Turbopack's `fileDependencies` invalidation set and edits to
+ * them could leave generated code stale. The loader must forward each reported
+ * dependency through the webpack loader context's `addDependency(file)`, with
+ * the same path normalization the other adapters use.
+ *
+ * 1. Build the `emit-dependencies` fixture reporting a mix of relative,
+ *    absolute, duplicate, and self dependency entries.
+ * 2. Invoke the loader with a context that records `addDependency` calls.
+ * 3. Assert the module transformed and the registered paths are the absolutized,
+ *    deduplicated set with the module itself excluded.
+ */
+export const test_turbopack_loader_registers_plugin_dependencies_as_file_dependencies =
+  async () => {
+    await assertTurbopackLoaderRegistersPluginDependencies();
+  };

--- a/tests/test-unplugin/src/features/adapters/test_turbopack_loader_registers_plugin_dependencies_on_cache_hit.ts
+++ b/tests/test-unplugin/src/features/adapters/test_turbopack_loader_registers_plugin_dependencies_on_cache_hit.ts
@@ -1,0 +1,22 @@
+import { assertTurbopackLoaderRegistersDependenciesOnCacheHit } from "../../internal/adapter-turbopack";
+
+/**
+ * Verifies the Turbopack loader replays dependency registration on cache hits
+ * (#666).
+ *
+ * The loader keeps one transform cache for the worker lifetime across requests,
+ * but Turbopack rebuilds each module's `fileDependencies` set per loader
+ * invocation. If a cache hit skipped re-registration, the second and later
+ * requests for a module would lose invalidation on its plugin-reported
+ * dependencies. Registration must therefore fire on every call, not only the
+ * fresh compile.
+ *
+ * 1. Build the `emit-dependencies` fixture reporting one dependency.
+ * 2. Invoke the loader twice for the same module sharing the loader's cache.
+ * 3. Assert both the fresh transform and the cache-served transform register the
+ *    same normalized dependency.
+ */
+export const test_turbopack_loader_registers_plugin_dependencies_on_cache_hit =
+  async () => {
+    await assertTurbopackLoaderRegistersDependenciesOnCacheHit();
+  };

--- a/tests/test-unplugin/src/features/adapters/test_turbopack_loader_transforms_without_an_add_dependency_context.ts
+++ b/tests/test-unplugin/src/features/adapters/test_turbopack_loader_transforms_without_an_add_dependency_context.ts
@@ -1,0 +1,19 @@
+import { assertTurbopackLoaderTransformsWithoutAddDependency } from "../../internal/adapter-turbopack";
+
+/**
+ * Verifies the Turbopack loader transforms even when the context omits
+ * `addDependency` (#666).
+ *
+ * `addDependency` is part of the webpack loader context contract, but a minimal
+ * stub context or a Turbopack build predating the method may not expose it. The
+ * dependency channel is a best-effort enhancement, so its absence must not
+ * prevent the transform from running or throw.
+ *
+ * 1. Build the `emit-dependencies` fixture reporting a dependency.
+ * 2. Invoke the loader with a context that deliberately omits `addDependency`.
+ * 3. Assert the module still transforms and nothing is registered.
+ */
+export const test_turbopack_loader_transforms_without_an_add_dependency_context =
+  async () => {
+    await assertTurbopackLoaderTransformsWithoutAddDependency();
+  };

--- a/tests/test-unplugin/src/features/transform/test_transformttsc_alias_overlay_resolves_package_tsconfig_preset_paths.ts
+++ b/tests/test-unplugin/src/features/transform/test_transformttsc_alias_overlay_resolves_package_tsconfig_preset_paths.ts
@@ -1,0 +1,25 @@
+import { assertAliasOverlayResolvesPackageTsconfigPresetPaths } from "../../internal/transform-alias-resolution";
+
+/**
+ * Verifies the alias overlay preserves paths from a package.json#tsconfig preset
+ * (#686).
+ *
+ * A bare `extends` specifier may name an npm preset that selects its config file
+ * through `package.json#tsconfig` and ships no JS/JSON entrypoint. The unplugin
+ * paths reader approximated bare resolution with Node's entrypoint resolver and
+ * a `<specifier>.json` fallback, both of which miss such a preset, so its
+ * inherited `paths` silently disappeared from the transform overlay and aliased
+ * imports collapsed to `any`. The reader must honor `package.json#tsconfig` like
+ * `tsc`, anchoring inherited relative targets at the preset's directory.
+ *
+ * 1. Build a project extending a bare manifest-selected preset that declares a
+ *    `#preset/*` alias and ships its target type.
+ * 2. Transform a module whose deliberate type error rides the inherited alias
+ *    (forwarding a bundler alias to trigger the overlay).
+ * 3. Assert the type error surfaces (alias resolved) and that well-typed source
+ *    transforms cleanly (no spurious overlay diagnostics).
+ */
+export const test_transformttsc_alias_overlay_resolves_package_tsconfig_preset_paths =
+  async () => {
+    await assertAliasOverlayResolvesPackageTsconfigPresetPaths();
+  };

--- a/tests/test-unplugin/src/features/transform/test_transformttsc_eviction_keeps_a_newer_generation_for_the_same_key.ts
+++ b/tests/test-unplugin/src/features/transform/test_transformttsc_eviction_keeps_a_newer_generation_for_the_same_key.ts
@@ -1,0 +1,20 @@
+import { assertStaleEvictionKeepsNewerGeneration } from "../../internal/transform-project-cache";
+
+/**
+ * Verifies failed-generation eviction is identity-guarded (#672).
+ *
+ * Eviction must remove only the exact failed generation, never a newer one that
+ * another caller installed under the same key while the failure was resolving. A
+ * naive `cache.delete(key)` would drop a valid in-flight replacement and force a
+ * redundant recompile (or lose single-flight sharing).
+ *
+ * 1. Prime a shared cache, then plant a rejected generation under its key.
+ * 2. Start the retry (which begins awaiting the rejected generation) and, before
+ *    its eviction runs, swap in a newer generation for the same key.
+ * 3. Assert the retry still rejects but the newer generation survives in the
+ *    cache.
+ */
+export const test_transformttsc_eviction_keeps_a_newer_generation_for_the_same_key =
+  async () => {
+    await assertStaleEvictionKeepsNewerGeneration();
+  };

--- a/tests/test-unplugin/src/features/transform/test_transformttsc_evicts_a_host_exception_transform_and_recovers.ts
+++ b/tests/test-unplugin/src/features/transform/test_transformttsc_evicts_a_host_exception_transform_and_recovers.ts
@@ -1,0 +1,22 @@
+import { assertHostExceptionTransformIsEvictedAndRecovers } from "../../internal/transform-project-cache";
+
+/**
+ * Verifies a resolved host-exception transform is evicted so adapters recover
+ * (#672).
+ *
+ * A generation can fail not only by rejecting but by resolving to an
+ * `ITtscCompilerTransformation` whose `type` is `"exception"`, which makes
+ * `selectTransformedSource` throw. That failed generation used to remain cached
+ * and replay the exception for the worker's lifetime. It must be surfaced and
+ * removed like a rejected one.
+ *
+ * 1. Prime a shared cache with one successful transform of the fixture.
+ * 2. Replace that entry with a resolved `"exception"` envelope (reusing the
+ *    primed project hashes so the cached entry validates) and retry the module.
+ * 3. Assert the retry throws and the entry is evicted, then a further retry
+ *    re-runs the transform and succeeds.
+ */
+export const test_transformttsc_evicts_a_host_exception_transform_and_recovers =
+  async () => {
+    await assertHostExceptionTransformIsEvictedAndRecovers();
+  };

--- a/tests/test-unplugin/src/features/transform/test_transformttsc_evicts_a_rejected_transform_and_recovers.ts
+++ b/tests/test-unplugin/src/features/transform/test_transformttsc_evicts_a_rejected_transform_and_recovers.ts
@@ -1,0 +1,21 @@
+import { assertRejectedTransformIsEvictedAndRecovers } from "../../internal/transform-project-cache";
+
+/**
+ * Verifies a rejected transform generation is evicted so adapters recover
+ * (#672).
+ *
+ * The per-build cache stores the in-flight transform Promise before it settles
+ * so concurrent callers share one compile. A rejected generation used to stay
+ * cached, making a transient toolchain/host failure permanent for a long-lived
+ * Metro or Turbopack worker: the unchanged module replayed the old rejection
+ * forever. A failed generation must instead be surfaced and removed.
+ *
+ * 1. Prime a shared cache with one successful transform of the fixture.
+ * 2. Replace that entry with a rejected Promise and retry the same module.
+ * 3. Assert the retry rejects and the failed entry is evicted, then a further
+ *    retry re-runs the transform and succeeds.
+ */
+export const test_transformttsc_evicts_a_rejected_transform_and_recovers =
+  async () => {
+    await assertRejectedTransformIsEvictedAndRecovers();
+  };

--- a/tests/test-unplugin/src/features/transform/test_transformttsc_shares_one_compile_across_concurrent_callers.ts
+++ b/tests/test-unplugin/src/features/transform/test_transformttsc_shares_one_compile_across_concurrent_callers.ts
@@ -1,0 +1,21 @@
+import { assertConcurrentTransformsCompileOnce } from "../../internal/transform-project-cache";
+
+/**
+ * Verifies concurrent transforms of one module still compile the project once
+ * (#672).
+ *
+ * The failed-generation eviction fix must preserve single-flight: two callers
+ * racing for the same cache key share the one in-flight generation rather than
+ * each spawning a compile. This is the preservation twin of the eviction
+ * scenarios.
+ *
+ * 1. Build the run-log fixture that counts whole-project compiles.
+ * 2. Fire two `transformTtsc` calls for the same module concurrently, sharing
+ *    one cache.
+ * 3. Assert both return transformed output and the fixture compiled exactly
+ *    once.
+ */
+export const test_transformttsc_shares_one_compile_across_concurrent_callers =
+  async () => {
+    await assertConcurrentTransformsCompileOnce();
+  };

--- a/tests/test-unplugin/src/internal/adapter-bun-register.ts
+++ b/tests/test-unplugin/src/internal/adapter-bun-register.ts
@@ -1,10 +1,67 @@
-import { TestUnpluginRuntime } from "@ttsc/testing";
+import { TestUnpluginProject, TestUnpluginRuntime } from "@ttsc/testing";
 import assert from "node:assert/strict";
 
 /** Shape the runtime preload forwards to `Bun.plugin`. */
 interface CapturedPlugin {
   name: string;
   setup: (build: unknown) => unknown;
+}
+
+/** Minimal Bun load handler shape: path in, transformed contents + loader out. */
+type BunLoader = (args: {
+  path: string;
+}) => Promise<{ contents: string; loader: string }>;
+
+/**
+ * Run `body` with a Bun-like global installed for the whole scope, so both the
+ * import-time auto-registration and any explicit `register(options)` call see
+ * the same runtime. Every `Bun.plugin` registration is appended to `captured`.
+ * The prior global is restored afterwards.
+ */
+async function withBunRuntime(
+  captured: CapturedPlugin[],
+  body: () => Promise<void>,
+): Promise<void> {
+  const holder = globalThis as { Bun?: unknown };
+  const priorBun = holder.Bun;
+  holder.Bun = { plugin: (plugin: CapturedPlugin) => captured.push(plugin) };
+  try {
+    await body();
+  } finally {
+    if (priorBun === undefined) delete holder.Bun;
+    else holder.Bun = priorBun;
+  }
+}
+
+/**
+ * Freshly evaluate the built `bun-register` entry, so the module-level
+ * auto-registration runs during import exactly as it would inside a Bun preload.
+ * A unique query busts the ESM module cache so each call re-runs the module's
+ * registration state. The caller must already have a Bun-like global installed
+ * (see {@link withBunRuntime}).
+ */
+async function importFreshBunRegister(): Promise<(options?: unknown) => void> {
+  const url = `${TestUnpluginRuntime.libUrl("bun-register")}?ra23=${Date.now()}-${Math.random()}`;
+  const mod = await import(url);
+  return mod.default as (options?: unknown) => void;
+}
+
+/**
+ * Drive a captured Bun plugin's single `onLoad` handler for one file and return
+ * the transformed contents, mirroring how Bun invokes the loader.
+ */
+async function driveCapturedLoader(
+  plugin: CapturedPlugin,
+  file: string,
+): Promise<string> {
+  let loader: BunLoader | undefined;
+  await plugin.setup({
+    onLoad(_options: { filter: RegExp }, handler: BunLoader) {
+      loader = handler;
+    },
+  });
+  assert.ok(loader, "captured plugin registered no onLoad handler");
+  return (await loader({ path: file })).contents;
 }
 
 /**
@@ -41,4 +98,71 @@ async function assertBunRegisterRegistersRuntimePlugin() {
   assert.equal(typeof captured[0]?.setup, "function");
 }
 
-export { assertBunRegisterRegistersRuntimePlugin };
+/**
+ * Asserts that accessing the explicit `register(options)` API in the real
+ * same-runtime order cannot install a shadowing default loader, and that the
+ * explicit options are the ones that transform.
+ *
+ * Bun uses the first matching `onLoad` hook and does not fall through to a later
+ * overlapping plugin (oven-sh/bun#20583). The module auto-registers on import,
+ * so a caller importing it to reach `register(options)` would, under the old
+ * code, get a default plugin registered first that shadows the explicit one.
+ * The entry must register exactly one Bun loader whose effective options are
+ * resolved on first load, so the later explicit call wins.
+ */
+async function assertBunRegisterSameRuntimeExplicitOptionsWin(): Promise<void> {
+  const captured: CapturedPlugin[] = [];
+  await withBunRuntime(captured, async () => {
+    const register = await importFreshBunRegister();
+
+    // Import-time auto-registration produced exactly one loader.
+    assert.equal(captured.length, 1);
+
+    // Accessing the explicit API afterwards must not add a second, shadowing
+    // loader; it updates the single loader's effective options.
+    register({
+      plugins: [{ transform: "./plugin.cjs", name: "prefix", prefix: "A:" }],
+    });
+    assert.equal(captured.length, 1);
+
+    // The single effective loader must apply the explicit options, not
+    // defaults: the fixture's tsconfig declares no such prefix plugin.
+    const root = TestUnpluginProject.createProject({ plugins: [] });
+    const output = await driveCapturedLoader(
+      captured[0]!,
+      TestUnpluginProject.mainFile(root),
+    );
+    assert.match(output, /"A:plugin"/);
+  });
+}
+
+/**
+ * Asserts the negative twin: a pure preload import with no explicit call
+ * registers exactly one default loader that transforms with the project's own
+ * tsconfig configuration.
+ *
+ * The one-line `bunfig.toml` preload convenience must keep working: importing
+ * the side-effect entry under Bun registers a single default plugin, and that
+ * plugin applies the fixture's tsconfig-declared transform.
+ */
+async function assertBunRegisterPreloadOnlyRegistersOneDefaultPlugin(): Promise<void> {
+  const captured: CapturedPlugin[] = [];
+  await withBunRuntime(captured, async () => {
+    await importFreshBunRegister();
+
+    assert.equal(captured.length, 1);
+
+    const root = TestUnpluginProject.createProject();
+    const output = await driveCapturedLoader(
+      captured[0]!,
+      TestUnpluginProject.mainFile(root),
+    );
+    TestUnpluginProject.assertTransformedToPlugin(output);
+  });
+}
+
+export {
+  assertBunRegisterPreloadOnlyRegistersOneDefaultPlugin,
+  assertBunRegisterRegistersRuntimePlugin,
+  assertBunRegisterSameRuntimeExplicitOptionsWin,
+};

--- a/tests/test-unplugin/src/internal/adapter-bun.ts
+++ b/tests/test-unplugin/src/internal/adapter-bun.ts
@@ -1,5 +1,6 @@
 import { TestUnpluginProject, TestUnpluginRuntime } from "@ttsc/testing";
 import assert from "node:assert/strict";
+import path from "node:path";
 
 /** Minimal shape of the options object passed to `onLoad` in the Bun plugin API. */
 type BunLoadOptions = { filter: RegExp };
@@ -11,6 +12,25 @@ type BunLoadOptions = { filter: RegExp };
 type BunLoader = (args: {
   path: string;
 }) => Promise<{ contents: string; loader: string }>;
+
+/**
+ * Register the Bun adapter against a capturing `setup` stub and return the first
+ * `onLoad` handler plus its filter, mirroring how Bun drives the plugin. No real
+ * Bun runtime is required.
+ */
+async function captureBunLoader(
+  plugin: { setup(build: unknown): void },
+): Promise<{ loader: BunLoader; options: BunLoadOptions }> {
+  const loaders: { loader: BunLoader; options: BunLoadOptions }[] = [];
+  plugin.setup({
+    onLoad(options: BunLoadOptions, loader: BunLoader) {
+      loaders.push({ loader, options });
+    },
+  });
+  const registration = loaders[0];
+  assert.ok(registration, "Bun adapter did not register an onLoad handler");
+  return registration;
+}
 
 /**
  * Asserts that the Bun adapter registers an `onLoad` transformer whose filter
@@ -44,4 +64,51 @@ async function assertBunAdapterTransformsSource() {
   assert.equal(result.loader, "ts");
 }
 
-export { assertBunAdapterTransformsSource };
+/**
+ * Asserts the Bun adapter never crashes when a transform plugin reports
+ * dependencies, and keeps producing correct output on both the fresh transform
+ * and the subsequent cache hit.
+ *
+ * The shared transform calls `addWatchFile` once per plugin-reported dependency.
+ * The Bun adapter used to invoke the raw transform with an empty receiver
+ * (`{}`), so `this.addWatchFile` was `undefined` and any reported dependency
+ * threw `TypeError: this.addWatchFile is not a function` before the loader could
+ * return transformed source. Bun exposes no per-module dependency channel, so
+ * the adapter must supply an explicit no-op watch context rather than a missing
+ * one. The dependency list deliberately mixes a project-relative entry, an
+ * absolute entry, a duplicate, and the module itself — every shape that reaches
+ * the watch hook — because a single reported entry is enough to trip the old
+ * crash.
+ */
+async function assertBunAdapterSurvivesPluginReportedDependencies() {
+  const unpluginBun = await TestUnpluginRuntime.loadUnpluginAdapter("bun");
+  const absolute = path.join("/abs", "types", "model.d.ts");
+  const root = TestUnpluginProject.createProject({
+    plugins: [
+      {
+        transform: "./plugin.cjs",
+        name: "fixture",
+        operation: "emit-dependencies",
+        dependencies: ["src/types.d.ts", absolute, "src/types.d.ts", "src/main.ts"],
+      },
+    ],
+  });
+  const { loader } = await captureBunLoader(unpluginBun());
+
+  // Fresh transform: the reported dependencies reach the watch hook. The old
+  // empty-receiver context threw here instead of returning source.
+  const first = await loader({ path: TestUnpluginProject.mainFile(root) });
+  TestUnpluginProject.assertTransformedToPlugin(first.contents);
+  assert.equal(first.loader, "ts");
+
+  // Cache hit: the shared transform replays the dependency notification, so the
+  // no-op context must stay valid on the second load too.
+  const second = await loader({ path: TestUnpluginProject.mainFile(root) });
+  TestUnpluginProject.assertTransformedToPlugin(second.contents);
+  assert.equal(second.loader, "ts");
+}
+
+export {
+  assertBunAdapterSurvivesPluginReportedDependencies,
+  assertBunAdapterTransformsSource,
+};

--- a/tests/test-unplugin/src/internal/adapter-turbopack.ts
+++ b/tests/test-unplugin/src/internal/adapter-turbopack.ts
@@ -12,23 +12,67 @@ async function runTurbopackLoader(props: {
   source: string;
   options?: unknown;
 }): Promise<string> {
+  return (await runTurbopackLoaderWithContext(props)).content;
+}
+
+/**
+ * Invoke the built turbopack loader and return both the transformed content and
+ * the files it registered through the webpack loader context's
+ * `addDependency(file)` — the channel that feeds Turbopack's `fileDependencies`
+ * invalidation set. Setting `omitAddDependency` models a minimal/older loader
+ * context that does not expose the method at all, proving the loader stays
+ * optional about it.
+ */
+async function runTurbopackLoaderWithContext(props: {
+  resourcePath: string;
+  source: string;
+  options?: unknown;
+  omitAddDependency?: boolean;
+}): Promise<{ content: string; dependencies: string[] }> {
   const loader = await TestUnpluginRuntime.loadUnpluginAdapter("turbopack");
-  return new Promise<string>((resolve, reject) => {
-    const context = {
-      resourcePath: props.resourcePath,
-      getOptions: () => props.options,
-      async:
-        () =>
-        (error?: unknown, content?: string): void => {
-          if (error !== undefined && error !== null) {
-            reject(error instanceof Error ? error : new Error(String(error)));
-            return;
-          }
-          resolve(content ?? "");
-        },
-    };
-    loader.call(context, props.source);
-  });
+  const dependencies: string[] = [];
+  return new Promise<{ content: string; dependencies: string[] }>(
+    (resolve, reject) => {
+      const context: Record<string, unknown> = {
+        resourcePath: props.resourcePath,
+        getOptions: () => props.options,
+        async:
+          () =>
+          (error?: unknown, content?: string): void => {
+            if (error !== undefined && error !== null) {
+              reject(error instanceof Error ? error : new Error(String(error)));
+              return;
+            }
+            resolve({ content: content ?? "", dependencies });
+          },
+      };
+      if (props.omitAddDependency !== true) {
+        context.addDependency = function (this: unknown, file: string): void {
+          // Capture `this` binding: the loader must call addDependency bound to
+          // the webpack loader context, not the transform hooks object.
+          assert.equal(this, context, "addDependency lost its context binding");
+          dependencies.push(file);
+        };
+      }
+      loader.call(context, props.source);
+    },
+  );
+}
+
+/**
+ * Plugin descriptor routing the fixture through the `emit-dependencies`
+ * operation with the given dependency entries. Options ride the plugin entry's
+ * top level; the protocol forwards the whole entry as the plugin's config.
+ */
+function emitDependenciesPlugins(dependencies: string[]): unknown[] {
+  return [
+    {
+      transform: "./plugin.cjs",
+      name: "fixture",
+      operation: "emit-dependencies",
+      dependencies,
+    },
+  ];
 }
 
 /**
@@ -85,8 +129,116 @@ async function assertTurbopackLoaderPassesThroughFilteredPaths(): Promise<void> 
   assert.equal(vendoredOut, vendored);
 }
 
+/**
+ * Asserts the loader registers plugin-reported dependencies through
+ * `addDependency`, normalized exactly as the other adapters normalize their
+ * watch files: project-relative entries absolutized against the project root,
+ * absolute entries kept, duplicates collapsed, and the transformed module itself
+ * excluded.
+ *
+ * The standalone Turbopack loader used to call the shared transform without a
+ * hooks argument, so the reported dependency list was silently dropped and
+ * type-only inputs never entered Turbopack's invalidation graph. The dependency
+ * list mixes a relative entry, an absolute entry, a duplicate, and the module
+ * itself to pin the normalization.
+ */
+async function assertTurbopackLoaderRegistersPluginDependencies(): Promise<void> {
+  const root = TestUnpluginProject.createProject({ plugins: [] });
+  const absolute = path.join(root, "types", "model.d.ts");
+  const { content, dependencies } = await runTurbopackLoaderWithContext({
+    resourcePath: TestUnpluginProject.mainFile(root),
+    source: TestUnpluginProject.mainSource(root),
+    options: {
+      plugins: emitDependenciesPlugins([
+        "src/types.d.ts",
+        absolute,
+        "src/types.d.ts",
+        "src/main.ts",
+      ]),
+    },
+  });
+  TestUnpluginProject.assertTransformedToPlugin(content);
+  assert.deepEqual(dependencies, [
+    path.join(root, "src", "types.d.ts"),
+    absolute,
+  ]);
+}
+
+/**
+ * Asserts a cache-served transform still registers the dependency list.
+ *
+ * The Turbopack loader shares one transform cache for the worker lifetime across
+ * requests, but Turbopack rebuilds its `fileDependencies` set per loader
+ * invocation. A cache hit that skipped re-registration would drop invalidation
+ * for the second and later requests, so the loader must replay the dependencies
+ * on every call, not only the fresh compile.
+ */
+async function assertTurbopackLoaderRegistersDependenciesOnCacheHit(): Promise<void> {
+  const root = TestUnpluginProject.createProject({ plugins: [] });
+  const options = {
+    plugins: emitDependenciesPlugins(["src/types.d.ts"]),
+  };
+  const expected = [path.join(root, "src", "types.d.ts")];
+
+  const first = await runTurbopackLoaderWithContext({
+    resourcePath: TestUnpluginProject.mainFile(root),
+    source: TestUnpluginProject.mainSource(root),
+    options,
+  });
+  TestUnpluginProject.assertTransformedToPlugin(first.content);
+  assert.deepEqual(first.dependencies, expected);
+
+  const second = await runTurbopackLoaderWithContext({
+    resourcePath: TestUnpluginProject.mainFile(root),
+    source: TestUnpluginProject.mainSource(root),
+    options,
+  });
+  TestUnpluginProject.assertTransformedToPlugin(second.content);
+  assert.deepEqual(second.dependencies, expected);
+}
+
+/**
+ * Asserts the negative twin: a transform whose plugin reports no `dependencies`
+ * envelope field registers nothing, while still transforming the module. A
+ * loader that fabricated dependencies would pollute Turbopack's invalidation
+ * graph.
+ */
+async function assertTurbopackLoaderRegistersNoDependenciesWithoutReport(): Promise<void> {
+  const root = TestUnpluginProject.createProject();
+  const { content, dependencies } = await runTurbopackLoaderWithContext({
+    resourcePath: TestUnpluginProject.mainFile(root),
+    source: TestUnpluginProject.mainSource(root),
+  });
+  TestUnpluginProject.assertTransformedToPlugin(content);
+  assert.deepEqual(dependencies, []);
+}
+
+/**
+ * Asserts a loader context that does not expose `addDependency` (a minimal stub
+ * or a Turbopack build predating the method) still transforms without throwing.
+ * The dependency channel is a best-effort enhancement, not a hard requirement of
+ * the loader contract.
+ */
+async function assertTurbopackLoaderTransformsWithoutAddDependency(): Promise<void> {
+  const root = TestUnpluginProject.createProject({ plugins: [] });
+  const { content, dependencies } = await runTurbopackLoaderWithContext({
+    resourcePath: TestUnpluginProject.mainFile(root),
+    source: TestUnpluginProject.mainSource(root),
+    options: {
+      plugins: emitDependenciesPlugins(["src/types.d.ts"]),
+    },
+    omitAddDependency: true,
+  });
+  TestUnpluginProject.assertTransformedToPlugin(content);
+  assert.deepEqual(dependencies, []);
+}
+
 export {
   assertTurbopackLoaderForwardsRuleOptions,
   assertTurbopackLoaderPassesThroughFilteredPaths,
+  assertTurbopackLoaderRegistersDependenciesOnCacheHit,
+  assertTurbopackLoaderRegistersNoDependenciesWithoutReport,
+  assertTurbopackLoaderRegistersPluginDependencies,
   assertTurbopackLoaderTransformsSource,
+  assertTurbopackLoaderTransformsWithoutAddDependency,
 };

--- a/tests/test-unplugin/src/internal/packaged-host-contract.ts
+++ b/tests/test-unplugin/src/internal/packaged-host-contract.ts
@@ -1,0 +1,89 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Pack `@ttsc/unplugin` exactly as it would be published and return the packed
+ * `package.json`.
+ *
+ * `pnpm pack` is offline and deterministic, and it rewrites the `workspace:*`
+ * protocol to the concrete version a real consumer's package manager sees — the
+ * published dependency contract. Reading that manifest (rather than the source
+ * one) is what proves the contract a clean install would receive, without a
+ * network install.
+ */
+function readPackedManifest(): Record<string, any> {
+  const unpluginDir = path.join(
+    TestProject.WORKSPACE_ROOT,
+    "packages",
+    "unplugin",
+  );
+  const dest = TestProject.tmpdir("ttsc-unplugin-pack-");
+  const pack = spawnSync("pnpm", ["pack", "--pack-destination", dest], {
+    cwd: unpluginDir,
+    encoding: "utf8",
+    shell: process.platform === "win32",
+  });
+  assert.equal(pack.status, 0, `pnpm pack failed:\n${pack.stderr}`);
+
+  const tarball = fs
+    .readdirSync(dest)
+    .find((name) => name.endsWith(".tgz"));
+  assert.ok(tarball, "pnpm pack produced no tarball");
+
+  // Extract just the manifest to stdout; `tar -O` is available cross-platform
+  // (bsdtar on Windows, GNU tar elsewhere) and avoids a tar library. Run with
+  // `cwd: dest` and a relative tarball name so a Windows drive-letter colon in
+  // the path is never mistaken for a remote `host:path` spec by GNU tar.
+  const show = spawnSync(
+    "tar",
+    ["-xzOf", tarball, "package/package.json"],
+    { cwd: dest, encoding: "utf8" },
+  );
+  assert.equal(show.status, 0, `tar extraction failed:\n${show.stderr}`);
+  return JSON.parse(show.stdout);
+}
+
+/**
+ * Asserts the published `@ttsc/unplugin` manifest declares its external `ttsc`
+ * host in the runtime dependency contract.
+ *
+ * The package imports `ttsc` at runtime but the Rollup build leaves it external.
+ * With `ttsc` declared only under `devDependencies`, a clean install succeeded
+ * yet the first import failed with `Cannot find module 'ttsc'`. The host must be
+ * a required `peerDependency` so a package manager installs, validates, or warns
+ * about it — while staying external (never a bundled second compiler copy).
+ *
+ * 1. Pack the package as it would be published (rewriting `workspace:*`).
+ * 2. Assert `ttsc` is declared as a required peer dependency with a concrete
+ *    version — no leaked `workspace:` protocol a consumer cannot resolve.
+ * 3. Assert `ttsc` is not also a bundled runtime `dependencies` entry.
+ */
+async function assertPackedManifestDeclaresTtscHost(): Promise<void> {
+  const manifest = readPackedManifest();
+
+  const peer = manifest.peerDependencies?.ttsc;
+  assert.ok(
+    typeof peer === "string" && peer.length !== 0,
+    "published manifest must declare ttsc as a peer dependency host",
+  );
+  assert.doesNotMatch(
+    peer,
+    /^workspace:/,
+    "workspace protocol leaked into the published ttsc spec",
+  );
+  assert.notEqual(
+    manifest.peerDependenciesMeta?.ttsc?.optional,
+    true,
+    "the ttsc host must be required, not optional",
+  );
+  assert.equal(
+    manifest.dependencies?.ttsc,
+    undefined,
+    "ttsc must stay external, not a bundled runtime dependency",
+  );
+}
+
+export { assertPackedManifestDeclaresTtscHost };

--- a/tests/test-unplugin/src/internal/transform-alias-resolution.ts
+++ b/tests/test-unplugin/src/internal/transform-alias-resolution.ts
@@ -199,8 +199,131 @@ async function assertAliasOverlayMergesExtendedJsoncPaths(): Promise<void> {
   );
 }
 
+/**
+ * Create a project that extends a bare npm preset selecting its config through
+ * `package.json#tsconfig` (no JS/JSON entrypoint). The preset declares a
+ * `#preset/*` path alias anchored at its own directory and ships the target
+ * type it points at.
+ *
+ * TypeScript accepts this project and resolves `#preset/model` through the
+ * inherited alias. The unplugin paths reader must do the same — honoring
+ * `package.json#tsconfig` and anchoring the inherited relative target at the
+ * preset config's directory — or the alias silently collapses to `any`.
+ */
+function createManifestPresetProject(): string {
+  const root = TestProject.tmpdir("ttsc-unplugin-preset-");
+  const preset = path.join(root, "node_modules", "example-preset");
+  fs.mkdirSync(path.join(preset, "types"), { recursive: true });
+  fs.mkdirSync(path.join(root, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(preset, "package.json"),
+    JSON.stringify(
+      { name: "example-preset", version: "1.0.0", tsconfig: "base.json" },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(preset, "base.json"),
+    JSON.stringify(
+      { compilerOptions: { paths: { "#preset/*": ["./types/*"] } } },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(preset, "types", "model.ts"),
+    "export interface PresetModel { id: number }\n",
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(root, "tsconfig.json"),
+    JSON.stringify(
+      {
+        extends: "example-preset",
+        compilerOptions: {
+          module: "ESNext",
+          moduleResolution: "bundler",
+          target: "ES2022",
+          strict: true,
+        },
+        include: ["src"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({ private: true, type: "commonjs" }, null, 2),
+    "utf8",
+  );
+  return root;
+}
+
+/**
+ * Asserts the alias overlay preserves `paths` inherited from a bare preset
+ * selected through `package.json#tsconfig`.
+ *
+ * The transform overlay re-states the project's effective `paths` (walking the
+ * `extends` chain) whenever a bundler alias is forwarded. If the unplugin reader
+ * cannot resolve a bare manifest-selected preset, its inherited `#preset/*`
+ * alias disappears from the overlay and the aliased import collapses to `any` —
+ * no diagnostic surfaces. The probe is a deliberate type error through the
+ * inherited alias: it can only be reported when `PresetModel` resolved to the
+ * real interface. The negative twin (well-typed source) pins that the overlay
+ * introduces no diagnostics of its own.
+ */
+async function assertAliasOverlayResolvesPackageTsconfigPresetPaths(): Promise<void> {
+  const root = createManifestPresetProject();
+  const aliases = { "@": path.join(root, "src") };
+
+  await assert.rejects(
+    () =>
+      transformWithAliases(
+        root,
+        aliases,
+        [
+          'import type { PresetModel } from "#preset/model";',
+          'export const bad: PresetModel = { id: "oops" };',
+          "",
+        ].join("\n"),
+      ),
+    /not assignable/,
+  );
+
+  const clean = await transformWithAliases(
+    root,
+    aliases,
+    [
+      'import type { PresetModel } from "#preset/model";',
+      'export const good: PresetModel = { id: 1 };',
+      "",
+    ].join("\n"),
+  );
+  // No plugins are configured, so a clean transform leaves the source as-is.
+  assert.equal(clean, undefined);
+}
+
+/** Run `transformTtsc` over `src/main.ts` with an explicit bundler alias map. */
+async function transformWithAliases(
+  root: string,
+  aliases: Record<string, string>,
+  source: string,
+): Promise<unknown> {
+  const { resolveOptions, transformTtsc } =
+    await TestUnpluginRuntime.loadUnpluginApi();
+  const file = path.join(root, "src", "main.ts");
+  fs.writeFileSync(file, source, "utf8");
+  return transformTtsc(file, source, resolveOptions({}), aliases);
+}
+
 export {
   assertAliasOverlapResolvesTypes,
   assertAliasOverlayMergesExtendedJsoncPaths,
   assertAliasOverlayPreservesUnaliasedPaths,
+  assertAliasOverlayResolvesPackageTsconfigPresetPaths,
 };

--- a/tests/test-unplugin/src/internal/transform-project-cache.ts
+++ b/tests/test-unplugin/src/internal/transform-project-cache.ts
@@ -1,6 +1,10 @@
 // Loading @ttsc/testing evaluates TestUnpluginProject, which seeds
 // TTSC_TSGO_BINARY for in-process transformTtsc calls.
-import { TestProject, TestUnpluginRuntime } from "@ttsc/testing";
+import {
+  TestProject,
+  TestUnpluginProject,
+  TestUnpluginRuntime,
+} from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
@@ -101,6 +105,183 @@ async function assertCacheHitsDespiteOutOfWalkOutputKey(): Promise<void> {
   for (const code of outputs) {
     assert.match(code, /PROBED/);
   }
+}
+
+/**
+ * Prime a shared cache with one real successful transform of the default
+ * fixture and return the cache API, the single cache key, the resolved good
+ * generation value, and the arguments needed to retry the same module.
+ *
+ * The eviction scenarios below reuse this to plant a failed generation under
+ * the exact key `transformTtsc` computes, without depending on the private
+ * cache-key encoding.
+ */
+async function primeSuccessfulTransform(): Promise<{
+  api: {
+    createTtscTransformCache: () => Map<string, Promise<unknown>>;
+    resolveOptions: (raw?: unknown) => unknown;
+    transformTtsc: (...args: unknown[]) => Promise<{ code: string } | undefined>;
+  };
+  cache: Map<string, Promise<unknown>>;
+  key: string;
+  good: unknown;
+  file: string;
+  source: string;
+  options: unknown;
+}> {
+  const api = await TestUnpluginRuntime.loadUnpluginApi();
+  const root = TestUnpluginProject.createProject();
+  const cache = api.createTtscTransformCache();
+  const file = TestUnpluginProject.mainFile(root);
+  const source = TestUnpluginProject.mainSource(root);
+  const options = api.resolveOptions();
+  const first = await api.transformTtsc(file, source, options, undefined, cache);
+  assert.ok(first, "expected the primed transform to produce output");
+  TestUnpluginProject.assertTransformedToPlugin(first.code);
+  assert.equal(cache.size, 1);
+  const key = [...cache.keys()][0]!;
+  const good = await cache.get(key);
+  return { api, cache, key, good, file, source, options };
+}
+
+/**
+ * Asserts a rejected in-flight transform generation is surfaced to the caller
+ * and evicted, so a corrected environment recovers.
+ *
+ * The cache stores the transform Promise before it settles so concurrent
+ * callers share one compile. If a rejected generation stayed cached, a transient
+ * toolchain/host failure would become permanent for a long-lived Metro or
+ * Turbopack worker: every later request for the unchanged module would replay
+ * the old rejection instead of retrying. Replacing the primed success with a
+ * rejected Promise reproduces the `await transformed` branch exactly.
+ */
+async function assertRejectedTransformIsEvictedAndRecovers(): Promise<void> {
+  const { api, cache, key, file, source, options } =
+    await primeSuccessfulTransform();
+
+  const rejected = Promise.reject(new Error("transient host failure"));
+  rejected.catch(() => undefined); // suppress the unhandled-rejection warning
+  cache.set(key, rejected);
+
+  await assert.rejects(
+    () => api.transformTtsc(file, source, options, undefined, cache),
+    /transient host failure/,
+  );
+  assert.equal(cache.size, 0, "rejected generation must not stay cached");
+
+  const recovered = await api.transformTtsc(
+    file,
+    source,
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(recovered, "corrected retry must re-run the transform");
+  TestUnpluginProject.assertTransformedToPlugin(recovered.code);
+  assert.equal(cache.size, 1);
+}
+
+/**
+ * Asserts a resolved host-`"exception"` envelope is surfaced and evicted.
+ *
+ * A generation can also fail by resolving to an `ITtscCompilerTransformation`
+ * whose `type` is `"exception"`, which makes `selectTransformedSource` throw.
+ * That is a failed generation too and must not be retained, or a long-lived
+ * worker replays the exception forever. Reusing the primed generation's project
+ * root and input hashes keeps `matchesCachedSource` passing so control reaches
+ * the exception path.
+ */
+async function assertHostExceptionTransformIsEvictedAndRecovers(): Promise<void> {
+  const { api, cache, key, good, file, source, options } =
+    await primeSuccessfulTransform();
+
+  cache.set(
+    key,
+    Promise.resolve({
+      ...(good as Record<string, unknown>),
+      result: { type: "exception", error: new Error("host exploded") },
+    }),
+  );
+
+  await assert.rejects(
+    () => api.transformTtsc(file, source, options, undefined, cache),
+    /host exploded/,
+  );
+  assert.equal(cache.size, 0, "resolved-exception generation must not persist");
+
+  const recovered = await api.transformTtsc(
+    file,
+    source,
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(recovered, "corrected retry must re-run the transform");
+  TestUnpluginProject.assertTransformedToPlugin(recovered.code);
+  assert.equal(cache.size, 1);
+}
+
+/**
+ * Asserts a failed generation's cleanup cannot remove a newer generation another
+ * caller installed under the same key.
+ *
+ * Eviction is identity-guarded: it deletes the entry only when the cache still
+ * holds the exact failed generation. This pins that guard by replacing the
+ * failed generation with a fresh one after the failing call has begun awaiting
+ * but before its rejection eviction runs; the newer generation must survive.
+ */
+async function assertStaleEvictionKeepsNewerGeneration(): Promise<void> {
+  const { api, cache, key, good, file, source, options } =
+    await primeSuccessfulTransform();
+
+  const stale = Promise.reject(new Error("stale generation"));
+  stale.catch(() => undefined);
+  cache.set(key, stale);
+  const newer = Promise.resolve(good);
+
+  // transformTtsc runs synchronously up to `await` on the stale generation, then
+  // yields. Swap in the newer generation before the rejection eviction fires.
+  const pending = api.transformTtsc(file, source, options, undefined, cache);
+  cache.set(key, newer);
+
+  await assert.rejects(() => pending, /stale generation/);
+  assert.equal(
+    cache.get(key),
+    newer,
+    "stale generation's eviction must not remove the newer entry",
+  );
+}
+
+/**
+ * Asserts concurrent transforms of one module still compile the project once.
+ *
+ * The eviction fix must not weaken the single-flight guarantee: two callers
+ * racing for the same key share the one in-flight generation stored in the
+ * cache. The run-log fixture counts whole-project compiles, so two concurrent
+ * `transformTtsc` calls must produce exactly one.
+ */
+async function assertConcurrentTransformsCompileOnce(): Promise<void> {
+  const { createTtscTransformCache, resolveOptions, transformTtsc } =
+    await TestUnpluginRuntime.loadUnpluginApi();
+  const project = createCacheProject({ fileCount: 1 });
+  const cache = createTtscTransformCache();
+  const file = path.join(project.root, "src", "mod0.ts");
+  const source = fs.readFileSync(file, "utf8");
+  const options = resolveOptions();
+
+  const [first, second] = await Promise.all([
+    transformTtsc(file, source, options, undefined, cache),
+    transformTtsc(file, source, options, undefined, cache),
+  ]);
+  assert.ok(first);
+  assert.ok(second);
+  assert.match(first.code, /PROBED/);
+  assert.match(second.code, /PROBED/);
+
+  const pluginRuns = fs.existsSync(project.runLog)
+    ? fs.readFileSync(project.runLog, "utf8").length
+    : 0;
+  assert.equal(pluginRuns, 1, "concurrent callers must share one compile");
 }
 
 /** Absolute, sorted list of the project's `src/*.ts` modules. */
@@ -301,4 +482,8 @@ function writeGoPlugin(root: string): void {
 export {
   assertCacheHitsDespiteOutOfWalkOutputKey,
   assertCacheTransformsMultiFileProjectOnce,
+  assertConcurrentTransformsCompileOnce,
+  assertHostExceptionTransformIsEvictedAndRecovers,
+  assertRejectedTransformIsEvictedAndRecovers,
+  assertStaleEvictionKeepsNewerGeneration,
 };


### PR DESCRIPTION
## Bundle b4 — unplugin adapters, cache, packaging + tsconfig preset

Part of the `repository-audit-2026-07` campaign (tracker #665). This batch fixes six independently-verified defects across the `@ttsc/unplugin` adapter family and the shared tsconfig-preset resolution used by both the core project reader and the unplugin paths reader.

### Issues

- Closes #665 (RA-04) — **Bun adapter safe for plugin-reported dependencies.** The Bun `onLoad` path invoked the shared transform with an empty receiver, so `this.addWatchFile` was `undefined` and any plugin reporting dependencies crashed the loader with `TypeError`. Bun exposes no per-module dependency channel, so the adapter now passes an explicit no-op `addWatchFile` context: a valid dependency list can never crash the loader, while transform output and `ts`/`tsx` loader selection are preserved.
- Closes #666 (RA-05) — **Register plugin dependencies from the Turbopack loader.** The Turbopack loader dropped the transform's reported dependency list. It now models the webpack-compatible `addDependency(file)` on the loader context and forwards each normalized dependency through the shared `transformTtsc` hook (fires on cache hits too), so type-only inputs enter Turbopack's `fileDependencies` invalidation set.
- Closes #686 (RA-16) — **Resolve npm tsconfig presets through `package.json#tsconfig`.** Both config readers (`readProjectConfig` core, `tsconfigPaths` unplugin) now honor a bare preset's manifest-selected config file, matching TypeScript's contract. Core fails visibly on a missing/malformed manifest target; the unplugin reader stays best-effort and never invents aliases.
- Closes #672 (RA-19) — **Evict failed transforms so long-lived adapters can recover.** A rejected transform Promise or a resolved `"exception"`/`"failure"` envelope no longer stays cached: the generation is evicted (identity-guarded so a newer replacement survives) so a corrected environment re-runs the transform. Single-flight success caching and input-hash invalidation are unchanged.
- Closes #676 (RA-23) — **Prevent Bun auto-registration from shadowing explicit register options.** `bun-register` now registers exactly one Bun loader whose effective options resolve lazily on first load, so an explicit `register(options)` after the import-time auto-register wins instead of being shadowed by a default loader (Bun uses the first matching `onLoad`; oven-sh/bun#20583).
- Closes #679 (RA-26) — **Declare the external `ttsc` host in the published dependency contract.** `@ttsc/unplugin` imports `ttsc` at runtime but declared it only as a dev dependency, so a clean install failed with `Cannot find module 'ttsc'`. `ttsc` is now a required `peerDependency`, keeping the host external and consumer-controlled while making the relationship visible to npm/pnpm/Yarn.

### Verification

Package-scoped builds and focused suites are listed in the PR comments as each increment lands.
