### PR TITLE
fix(ttsx): harden launcher runtime cache, exports, Node range, and CLI flag adjacency

### DIFF
--- a/packages/ttsc/package.json
+++ b/packages/ttsc/package.json
@@ -40,6 +40,9 @@
   },
   "author": "Jeongho Nam",
   "license": "MIT",
+  "engines": {
+    "node": ">=22.15.0"
+  },
   "bugs": {
     "url": "https://github.com/samchon/ttsc/issues"
   },

--- a/packages/ttsc/src/flags/parser.ts
+++ b/packages/ttsc/src/flags/parser.ts
@@ -58,6 +58,24 @@ export interface ParseOptions {
    * `--` is appended to `passthrough` as-is (ttsx already does this).
    */
   readonly honorDoubleDashSeparator?: boolean;
+  /**
+   * Classifies a bare (non-dash) token as a genuine positional argument (a
+   * source file, the ttsx entry, a project path) rather than the space-separated
+   * value of a preceding forwarded flag.
+   *
+   * When omitted, every bare token is a positional — the historical behaviour
+   * for project-shaped subcommands that never forward `--flag value` pairs.
+   *
+   * When provided, a bare token that fails the predicate is appended to
+   * `passthrough` in its original position instead of `positional`, so an
+   * unknown `--flag value` pair reaches tsgo with its adjacency and relative
+   * order intact. The parser deliberately does not guess a forwarded flag's
+   * arity from the flag itself (it has no schema for a truly unknown flag);
+   * the predicate is the only signal that separates a forwarded value from a
+   * real input file, and both callers key it on the TypeScript source
+   * extension.
+   */
+  readonly isPositional?: (token: string) => boolean;
 }
 
 /**
@@ -153,7 +171,17 @@ export function parseFlags(opts: ParseOptions): ParseResult {
       continue;
     }
 
-    // Bare token: positional argument (file / entry / project path).
+    // Bare token: either a genuine positional argument (file / entry / project
+    // path) or the space-separated value of a preceding forwarded flag. When a
+    // caller forwards unknown flags it supplies `isPositional` to tell the two
+    // apart; a forwarded value is appended to `passthrough` in place so the
+    // `--flag value` pair reaches tsgo in its original order and adjacency,
+    // instead of being split into a separate bucket the caller later
+    // concatenates out of order.
+    if (opts.isPositional !== undefined && !opts.isPositional(current)) {
+      passthrough.push(current);
+      continue;
+    }
     positional.push(current);
     if (opts.forwardAfterFirstPositional === true && positional.length === 1) {
       forwardingTail = true;

--- a/packages/ttsc/src/launcher/internal/runTtsc.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsc.ts
@@ -461,6 +461,12 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
   const result = parseFlags({
     argv,
     errorPrefix: "ttsc:",
+    // A bare token is a single-file input only when it carries a TypeScript
+    // source extension; any other bare token is the space-separated value of a
+    // preceding forwarded flag (e.g. the `es2020` in `--target es2020`). The
+    // parser routes those values into `passthrough` in place, so the forwarded
+    // flag/value pairs reach tsgo in their original order.
+    isPositional: looksLikeInputFile,
     subcommand: "build",
   });
   // Defaults: pinned by the previous hand-parser. `quiet` defaults true,
@@ -476,15 +482,13 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
   else if (explicitNoEmit === true) emit = false;
   if (emit === undefined && checkOnly) emit = false;
 
-  const files = result.positional.filter(looksLikeInputFile);
-  // Bare non-file positionals are flag values (e.g. the `es2020` in
-  // `--target es2020`). The engine left them in `positional` because the
-  // forwarded flag is unknown to the schema; route them back into
-  // passthrough so the user's pair reaches tsgo intact.
-  const trailingValues = result.positional.filter(
-    (token) => !looksLikeInputFile(token),
-  );
-  const passthrough = [...result.passthrough, ...trailingValues];
+  // `isPositional: looksLikeInputFile` guarantees every `result.positional`
+  // token is a TypeScript input file; forwarded flag values already live in
+  // `result.passthrough` in their original order, so no reconstruction is
+  // needed here (the previous `[...passthrough, ...trailingValues]` concat
+  // reordered every flag ahead of every value).
+  const files = [...result.positional];
+  const passthrough = [...result.passthrough];
 
   return {
     binary: getString(result, "--binary"),

--- a/packages/ttsc/src/launcher/internal/runTtsx.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsx.ts
@@ -12,6 +12,7 @@ import {
 import { getCompilerVersionText } from "./getCompilerVersionText";
 import { prepareExecution } from "./prepareExecution";
 import { resolveCacheDir } from "./resolveCacheDir";
+import { checkNodeRuntimeSupport } from "./runtimeHooks";
 
 /**
  * CLI entry point for `ttsx`. Type-checks the owning project via tsgo, emits
@@ -43,6 +44,17 @@ function run(argv: readonly string[]): number {
       `${getCompilerVersionText().replace(/^ttsc\b/, "ttsx")}\n`,
     );
     return 0;
+  }
+
+  // Refuse an unsupported Node.js before type-checking and spawning the child:
+  // the child inherits this process's Node version, so an early diagnostic here
+  // pre-empts both the Node 18 `--disable-warning` rejection and the Node 20
+  // missing-`registerHooks` TypeError with one actionable message. `--help` and
+  // `--version` are handled above so they still print on any Node.
+  const nodeSupport = checkNodeRuntimeSupport(process.versions.node);
+  if (nodeSupport !== null) {
+    process.stderr.write(`ttsx: ${nodeSupport}\n`);
+    return 2;
   }
 
   const cwd = path.resolve(parsed.cwd ?? process.cwd());
@@ -109,6 +121,14 @@ function parseCLI(argv: readonly string[]) {
     errorPrefix: "ttsx:",
     forwardAfterFirstPositional: true,
     honorDoubleDashSeparator: true,
+    // Only a TypeScript-extensioned bare token is the entry; every other bare
+    // token before it (e.g. the `es2020` in `--target es2020 entry.ts`) is a
+    // forwarded flag value. Classifying values via the predicate keeps them in
+    // `passthrough` in order AND stops a pre-entry value from being mistaken for
+    // the first positional sentinel — which previously flipped the parser into
+    // tail mode and pushed the real entry into `tail`, failing with
+    // "entry file is required".
+    isPositional: looksLikeEntryFile,
     subcommand: "ttsx",
   });
 
@@ -116,18 +136,13 @@ function parseCLI(argv: readonly string[]) {
   if (entry === undefined) {
     throw new Error("ttsx: entry file is required");
   }
-  // With `forwardAfterFirstPositional: true` the parser reports
-  // `result.positional` as just the entry, `result.passthrough` as flags
-  // arriving BEFORE the entry (tsgo-forwarded), and `result.tail` as every
-  // token AFTER the entry — those are the user program's argv (e.g. the
-  // `generate --input src/input` tail of `ttsx typia.ts generate
-  // --input src/input`) and MUST NOT reach tsgo. Anything in positional
-  // that is not the entry is a pre-entry flag value (e.g. `--target es2020`)
-  // that the parser stored positionally; forward those to tsgo with the
-  // rest of `passthrough`.
-  const preEntryValues: string[] = result.positional.filter(
-    (token) => token !== entry && !looksLikeEntryFile(token),
-  );
+  // With `forwardAfterFirstPositional: true` and `isPositional:
+  // looksLikeEntryFile`, the parser reports `result.positional` as just the
+  // entry, `result.passthrough` as the tsgo-forwarded flags (and their
+  // in-order space values) arriving BEFORE the entry, and `result.tail` as
+  // every token AFTER the entry — the user program's argv (e.g. the `generate
+  // --input src/input` tail of `ttsx typia.ts generate --input src/input`),
+  // which MUST NOT reach tsgo.
   const postEntryArgs: string[] = [...result.tail];
 
   const preload: string[] = [];
@@ -170,7 +185,7 @@ function parseCLI(argv: readonly string[]) {
     preload,
     project: getString(result, "--tsconfig"),
     singleThreaded: getBoolean(result, "--singleThreaded") === true,
-    tsgoFlags: [...result.passthrough, ...preEntryValues],
+    tsgoFlags: [...result.passthrough],
   };
 }
 

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -1187,8 +1187,19 @@ function serveBuiltDependency(
       };
 }
 
-/** On-disk completion marker for a built dependency, shared across processes. */
+/**
+ * On-disk completion marker for a built dependency, shared across processes.
+ *
+ * `generation` names the exact immutable emit directory this marker describes
+ * (`<cacheDir>/gen-<generation>`). Binding metadata to one generation is what
+ * makes publication atomic: a reader that parses this marker reads the emit of
+ * the SAME generation, never old metadata combined with a different, still
+ * partially-written directory. The marker is the last thing a build writes, and
+ * it is written by an atomic temp-and-rename, so a reader observes either one
+ * complete old generation or one complete new generation.
+ */
 interface DependencyCacheMeta {
+  generation: string;
   rootDir: string;
   moduleOption?: string;
 }
@@ -1210,25 +1221,28 @@ function ensureProjectBuilt(tsconfig: string): BuiltProject {
   if (cached !== undefined) {
     return cached;
   }
-  const { emitDir, lockDir, metaPath, root } = dependencyCachePaths(tsconfig);
+  const { cacheDir, lockDir, metaPath, root } = dependencyCachePaths(tsconfig);
 
-  const reuse = readDependencyCache(emitDir, metaPath);
+  const reuse = readDependencyCache(cacheDir, metaPath);
   if (reuse !== null) {
     builtProjects.set(tsconfig, reuse);
     return reuse;
   }
 
   fs.mkdirSync(root, { recursive: true });
-  const built = withBuildLock(lockDir, metaPath, emitDir, () =>
-    buildDependency(tsconfig, emitDir, metaPath),
+  const built = withBuildLock(cacheDir, metaPath, lockDir, () =>
+    buildDependency(tsconfig, cacheDir, metaPath),
   );
   builtProjects.set(tsconfig, built);
   return built;
 }
 
 interface DependencyCachePaths {
-  emitDir: string;
+  /** Container of this dependency's generation-stamped emit directories. */
+  cacheDir: string;
+  /** Fenced cross-process coordination directory (`<key>.lock`). */
   lockDir: string;
+  /** Atomic completion pointer (`<key>.json`) naming the live generation. */
   metaPath: string;
   root: string;
 }
@@ -1241,16 +1255,43 @@ function dependencyCachePaths(tsconfig: string): DependencyCachePaths {
     .slice(0, 16);
   const root = dependencyCacheRoot();
   return {
-    emitDir: path.join(root, key),
+    cacheDir: path.join(root, key),
     lockDir: path.join(root, `${key}.lock`),
     metaPath: path.join(root, `${key}.json`),
     root,
   };
 }
 
-/** Reuse a dependency another process (or an earlier import) already built. */
-function readDependencyCache(
-  emitDir: string,
+/** The immutable emit directory of one build generation under `cacheDir`. */
+function dependencyGenerationDir(cacheDir: string, generation: string): string {
+  return path.join(cacheDir, `gen-${generation}`);
+}
+
+/** A fresh 128-bit build-generation identifier. */
+function newDependencyGeneration(): string {
+  return crypto.randomBytes(16).toString("hex");
+}
+
+/** True for a well-formed 128-bit hex build generation. */
+function isDependencyGeneration(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{32}$/.test(value);
+}
+
+/**
+ * Reuse a dependency another process (or an earlier import) already built.
+ *
+ * The completion marker names the exact emit generation, so this reads metadata
+ * and emit as one unit: it returns a hit only when the marker parses to a valid
+ * generation AND that generation's directory holds emitted JavaScript. A reader
+ * that runs while a replacement build is populating a DIFFERENT generation
+ * directory keeps returning the previous complete generation until the atomic
+ * marker swap points at the new one — never a mix of old metadata and a partial
+ * new emit.
+ *
+ * Exported for the ttsx dependency-cache regressions.
+ */
+export function readDependencyCache(
+  cacheDir: string,
   metaPath: string,
 ): BuiltProject | null {
   let meta: DependencyCacheMeta;
@@ -1259,67 +1300,75 @@ function readDependencyCache(
   } catch {
     return null;
   }
+  if (!isDependencyGeneration(meta.generation) || typeof meta.rootDir !== "string") {
+    return null;
+  }
+  const emitDir = dependencyGenerationDir(cacheDir, meta.generation);
   if (!emittedAnything(emitDir)) {
     return null;
   }
   return {
     emitDir,
     emittedFiles: undefined,
-    moduleOption: meta.moduleOption,
+    moduleOption:
+      typeof meta.moduleOption === "string" ? meta.moduleOption : undefined,
     rootDir: meta.rootDir,
   };
 }
 
 /**
- * Run `build` while holding an exclusive lock for this dependency, re-checking
- * the cache once the lock is held (a concurrent builder may have just
- * finished). A waiter polls for the winner's meta marker, and steals an
- * abandoned lock (a builder that crashed) after a generous timeout so the run
- * never wedges.
+ * Run `build` while holding the fenced lock for this dependency, re-checking the
+ * cache once the lock is held (a concurrent builder may have just finished). A
+ * loser polls for the winner's completion marker and, only when the holding
+ * generation is provably abandoned (dead owner or the steal budget elapsed),
+ * retires precisely that generation before retrying — never a successor's.
  */
 function withBuildLock(
-  lockDir: string,
+  cacheDir: string,
   metaPath: string,
-  emitDir: string,
+  lockDir: string,
   build: () => BuiltProject,
 ): BuiltProject {
-  const stealAfterMs = 600_000;
   for (;;) {
-    try {
-      fs.mkdirSync(lockDir);
-    } catch {
-      const waited = waitForDependencyCache(emitDir, metaPath, stealAfterMs);
-      if (waited !== null) {
-        return waited;
-      }
-      fs.rmSync(lockDir, { force: true, recursive: true });
-      continue;
-    }
-    try {
-      const reuse = readDependencyCache(emitDir, metaPath);
-      return reuse ?? build();
-    } finally {
-      fs.rmSync(lockDir, { force: true, recursive: true });
-    }
-  }
-}
-
-/** Poll for a concurrent builder's completion, up to `timeoutMs`. */
-function waitForDependencyCache(
-  emitDir: string,
-  metaPath: string,
-  timeoutMs: number,
-): BuiltProject | null {
-  const startedAt = Date.now();
-  for (;;) {
-    const reuse = readDependencyCache(emitDir, metaPath);
+    const reuse = readDependencyCache(cacheDir, metaPath);
     if (reuse !== null) {
       return reuse;
     }
-    if (Date.now() - startedAt > timeoutMs) {
-      return null;
+    let lease: DependencyBuildLockLease | null;
+    try {
+      lease = acquireDependencyBuildLock(lockDir);
+    } catch {
+      // An unusable coordination directory must not silently skip the build.
+      // Generation-stamped emit and the atomic marker swap still keep every
+      // reader's view of publication consistent without the lock.
+      return build();
     }
-    sleepSync(50);
+    if (lease === null) {
+      const waited = waitForDependencyBuild(
+        cacheDir,
+        metaPath,
+        lockDir,
+        DEP_BUILD_LOCK_STEAL_MS,
+      );
+      if (waited.outcome === "built") {
+        return waited.built;
+      }
+      if (waited.outcome === "abandoned") {
+        // Retire only the generation this observation named. Losing the rename
+        // race means the holder's own release (or another waiter) already made
+        // progress, so a stale result never removes a live successor.
+        reclaimDependencyBuildLock(lockDir, waited.fence);
+      }
+      // "released" needs no repair: the holder freed the lock normally, so
+      // retry the ordinary acquisition.
+      continue;
+    }
+    try {
+      const reuseUnderLock = readDependencyCache(cacheDir, metaPath);
+      return reuseUnderLock ?? build();
+    } finally {
+      releaseDependencyBuildLock(lockDir, lease);
+    }
   }
 }
 
@@ -1328,14 +1377,27 @@ function sleepSync(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-/** Compile a dependency project to `emitDir` and write its completion marker. */
+/**
+ * Compile a dependency project into a fresh generation directory and publish
+ * its completion marker atomically.
+ *
+ * The emit lands in `<cacheDir>/gen-<generation>`, a directory no other
+ * generation or process shares, so it is never mutated in place while a reader
+ * looks at it. Only after the emit is proven non-empty is the marker written by
+ * temp-and-rename, binding metadata to that exact generation. A build that
+ * produced no output drops its partial directory so a failed generation can
+ * never be reused.
+ */
 function buildDependency(
   tsconfig: string,
-  emitDir: string,
+  cacheDir: string,
   metaPath: string,
 ): BuiltProject {
   const project = readProjectConfig({ cwd: path.dirname(tsconfig), tsconfig });
+  const generation = newDependencyGeneration();
+  const emitDir = dependencyGenerationDir(cacheDir, generation);
   fs.rmSync(emitDir, { force: true, recursive: true });
+  fs.mkdirSync(emitDir, { recursive: true });
   const result = runBuild({
     cwd: project.root,
     emit: true,
@@ -1376,6 +1438,9 @@ function buildDependency(
   // even on a clean build. A genuinely empty output directory is the real
   // failure; the caller then falls back to type-stripping the one file.
   if (!emittedAnything(emitDir)) {
+    // Drop the failed generation so its partial directory can never be mistaken
+    // for a reusable build.
+    fs.rmSync(emitDir, { force: true, recursive: true });
     throw new Error(
       [
         `ttsx: dependency build produced no output for ${tsconfig}`,
@@ -1393,15 +1458,33 @@ function buildDependency(
     typeof project.compilerOptions.module === "string"
       ? project.compilerOptions.module
       : undefined;
-  writeDependencyMeta(metaPath, { moduleOption, rootDir });
+  publishDependencyMeta(metaPath, { generation, moduleOption, rootDir });
   return { emitDir, emittedFiles: undefined, moduleOption, rootDir };
 }
 
-function writeDependencyMeta(
+/**
+ * Publish the completion marker atomically: write it to a private temp name in
+ * the same directory, then rename onto `metaPath`. Node's rename replaces an
+ * existing file atomically on POSIX and Windows alike, so a concurrent reader
+ * sees either the whole previous marker or the whole new one, never a
+ * half-written file. The marker is the LAST artifact a build writes, after its
+ * generation's emit is complete, so observing the new marker guarantees the new
+ * generation is complete.
+ */
+function publishDependencyMeta(
   metaPath: string,
   meta: DependencyCacheMeta,
 ): void {
-  fs.writeFileSync(metaPath, JSON.stringify(meta), "utf8");
+  const tmp = `${metaPath}.${process.pid}.${Date.now()}.${crypto
+    .randomBytes(6)
+    .toString("hex")}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(meta), "utf8");
+  try {
+    fs.renameSync(tmp, metaPath);
+  } catch (error) {
+    fs.rmSync(tmp, { force: true });
+    throw error;
+  }
 }
 
 function dependencyCacheRoot(): string {
@@ -1409,6 +1492,373 @@ function dependencyCacheRoot(): string {
   return m !== null && m.depCacheDir.length !== 0
     ? m.depCacheDir
     : path.join(os.tmpdir(), "ttsx-dep");
+}
+
+// -----------------------------------------------------------------------------
+// Fenced dependency-build lock.
+//
+// The lock serialises concurrent first-builders of one dependency so the
+// expensive `runBuild` runs once per key while the rest wait and reuse the
+// published generation. It is generation-fenced so a stale observer or a former
+// owner can never release a successor's lock:
+//
+//   * `<lockDir>/current` is the held generation — a directory carrying a
+//     `generation` id and an `owner.json` (pid + hostname). A contender writes a
+//     private candidate and atomically renames it onto `current`; a directory
+//     rename cannot replace a non-empty `current`, so exactly one contender wins
+//     with no empty-owner publication window.
+//   * Release and reclaim both retire a generation by renaming `current` to its
+//     deterministic tombstone `<lockDir>/retired/<generation>`. The only way to
+//     free `current` is to create that tombstone, so a successor can acquire only
+//     after its predecessor's tombstone exists. A late or duplicate retire of an
+//     already-retired generation therefore finds the tombstone occupied and
+//     fails atomically, and a reclaim that named an old generation can never move
+//     a different successor into that old tombstone.
+//
+// This mirrors the source-plugin v2 protocol (`buildSourcePlugin.ts`) proven by
+// issue #452 / PR #460, minus the legacy-compatibility layer: the ttsx
+// dependency cache lives under a per-run directory with no shipped on-disk
+// format to stay compatible with.
+// -----------------------------------------------------------------------------
+
+const DEP_BUILD_LOCK_STEAL_MS = 600_000;
+const DEP_BUILD_LOCK_POLL_MS = 50;
+const DEP_BUILD_LOCK_STALE_MS = 30_000;
+const DEP_BUILD_LOCK_CURRENT_DIR = "current";
+const DEP_BUILD_LOCK_RETIRED_DIR = "retired";
+const DEP_BUILD_LOCK_GENERATION_FILE = "generation";
+const DEP_BUILD_LOCK_OWNER_FILE = "owner.json";
+
+/** Ownership token returned only to the process that acquired `current`. */
+export type DependencyBuildLockLease = { generation: string };
+
+/** Opaque identity of one observed lock generation. */
+export type DependencyBuildLockFence = { generation: string };
+
+/**
+ * Atomically acquire the current generation of a dependency build lock, or
+ * `null` when another process already holds it. Exported for the deterministic
+ * multi-process cache regressions.
+ */
+export function acquireDependencyBuildLock(
+  lockDir: string,
+): DependencyBuildLockLease | null {
+  ensureDependencyLockRoot(lockDir);
+  const generation = newDependencyGeneration();
+  const candidateDir = path.join(lockDir, `candidate-${generation}`);
+  fs.mkdirSync(candidateDir);
+  try {
+    fs.writeFileSync(
+      path.join(candidateDir, DEP_BUILD_LOCK_GENERATION_FILE),
+      `${generation}\n`,
+      { encoding: "utf8", flag: "wx" },
+    );
+    writeDependencyLockOwner(candidateDir, generation);
+    const currentDir = path.join(lockDir, DEP_BUILD_LOCK_CURRENT_DIR);
+    try {
+      fs.renameSync(candidateDir, currentDir);
+    } catch (error) {
+      if (
+        isMissingPathError(error) ||
+        isRenameDestinationOccupied(error, currentDir)
+      ) {
+        return null;
+      }
+      throw error;
+    }
+    return { generation };
+  } finally {
+    // The candidate name carries this process's random generation and can never
+    // alias `current` or another contender's candidate.
+    fs.rmSync(candidateDir, { force: true, recursive: true });
+  }
+}
+
+/** Retire a held generation during the holder's `finally`. */
+export function releaseDependencyBuildLock(
+  lockDir: string,
+  lease: DependencyBuildLockLease,
+): boolean {
+  return retireDependencyBuildLock(lockDir, lease.generation);
+}
+
+/**
+ * Retire exactly the generation carried by an abandoned observation. Exported
+ * for the deterministic multi-process cache regressions.
+ */
+export function reclaimDependencyBuildLock(
+  lockDir: string,
+  fence: DependencyBuildLockFence,
+): boolean {
+  return retireDependencyBuildLock(lockDir, fence.generation);
+}
+
+function retireDependencyBuildLock(
+  lockDir: string,
+  generation: string,
+): boolean {
+  if (!isDependencyGeneration(generation)) {
+    return false;
+  }
+  const retiredDir = path.join(lockDir, DEP_BUILD_LOCK_RETIRED_DIR);
+  try {
+    fs.mkdirSync(retiredDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      if (isMissingPathError(error)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+  const destination = path.join(retiredDir, generation);
+  try {
+    fs.renameSync(path.join(lockDir, DEP_BUILD_LOCK_CURRENT_DIR), destination);
+    return true;
+  } catch (error) {
+    if (
+      isMissingPathError(error) ||
+      isRenameDestinationOccupied(error, destination)
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/** One observation of a dependency build lock's state. */
+export type DependencyBuildLockObservation =
+  | { state: "active"; owner: string; fence: DependencyBuildLockFence }
+  | { state: "abandoned"; reason: string; fence: DependencyBuildLockFence }
+  | { state: "released" };
+
+/**
+ * Classify the current state of a dependency build lock directory. Exported for
+ * the deterministic multi-process cache regressions.
+ */
+export function inspectDependencyBuildLock(
+  lockDir: string,
+  now: number,
+): DependencyBuildLockObservation {
+  const currentDir = path.join(lockDir, DEP_BUILD_LOCK_CURRENT_DIR);
+  const generation = readDependencyLockGeneration(currentDir);
+  if (generation === null) {
+    if (dependencyLockAgeMs(currentDir, now) === null) {
+      return { state: "released" };
+    }
+    // `current` exists without a readable generation id. Acquisition writes the
+    // id into the candidate BEFORE the atomic rename, so this is a transient or
+    // corrupt state; keep waiting rather than steal on ambiguous evidence.
+    return {
+      state: "active",
+      owner: "lock generation without a readable id",
+      fence: { generation: "" },
+    };
+  }
+  const fence: DependencyBuildLockFence = { generation };
+  const owner = readDependencyLockOwner(currentDir);
+  if (owner !== null) {
+    const label = describeDependencyLockOwner(owner);
+    if (isLocalHostName(owner.hostname) && !isProcessAlive(owner.pid)) {
+      return {
+        state: "abandoned",
+        reason: `${label} is no longer running`,
+        fence,
+      };
+    }
+    return { state: "active", owner: label, fence };
+  }
+  const ageMs = dependencyLockAgeMs(currentDir, now);
+  if (ageMs === null) {
+    return { state: "released" };
+  }
+  if (ageMs > DEP_BUILD_LOCK_STALE_MS) {
+    return {
+      state: "abandoned",
+      reason: `lock generation has no ${DEP_BUILD_LOCK_OWNER_FILE} and is ${formatDuration(
+        ageMs,
+      )} old`,
+      fence,
+    };
+  }
+  return {
+    state: "active",
+    owner: `lock generation with no ${DEP_BUILD_LOCK_OWNER_FILE}`,
+    fence,
+  };
+}
+
+/** Outcome of one waiting session on another process's dependency build lock. */
+type DependencyBuildWaitResult =
+  | { outcome: "built"; built: BuiltProject }
+  | { outcome: "released" }
+  | { outcome: "abandoned"; reason: string; fence: DependencyBuildLockFence };
+
+/** Poll for the locked builder to publish, up to `timeoutMs`. */
+function waitForDependencyBuild(
+  cacheDir: string,
+  metaPath: string,
+  lockDir: string,
+  timeoutMs: number,
+): DependencyBuildWaitResult {
+  const startedAt = Date.now();
+  for (;;) {
+    const reuse = readDependencyCache(cacheDir, metaPath);
+    if (reuse !== null) {
+      return { outcome: "built", built: reuse };
+    }
+    const now = Date.now();
+    const lock = inspectDependencyBuildLock(lockDir, now);
+    if (lock.state === "released") {
+      // The holder retired its generation between the cache check above and this
+      // observation: prefer the marker if it landed in that window, otherwise
+      // hand the free lock back to the caller to re-acquire.
+      const built = readDependencyCache(cacheDir, metaPath);
+      return built !== null
+        ? { outcome: "built", built }
+        : { outcome: "released" };
+    }
+    if (lock.state === "abandoned") {
+      return { outcome: "abandoned", reason: lock.reason, fence: lock.fence };
+    }
+    if (now - startedAt > timeoutMs) {
+      return {
+        outcome: "abandoned",
+        reason: `timed out after ${formatDuration(now - startedAt)}`,
+        fence: lock.fence,
+      };
+    }
+    sleepSync(DEP_BUILD_LOCK_POLL_MS);
+  }
+}
+
+function ensureDependencyLockRoot(lockDir: string): void {
+  fs.mkdirSync(path.join(lockDir, DEP_BUILD_LOCK_RETIRED_DIR), {
+    recursive: true,
+  });
+}
+
+interface DependencyLockOwner {
+  hostname: string;
+  pid: number;
+  startedAt?: string;
+}
+
+function writeDependencyLockOwner(
+  generationDir: string,
+  generation: string,
+): void {
+  fs.writeFileSync(
+    path.join(generationDir, DEP_BUILD_LOCK_OWNER_FILE),
+    `${JSON.stringify({
+      generation,
+      hostname: os.hostname(),
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    })}\n`,
+    "utf8",
+  );
+}
+
+function readDependencyLockOwner(
+  generationDir: string,
+): DependencyLockOwner | null {
+  try {
+    const parsed = JSON.parse(
+      fs.readFileSync(
+        path.join(generationDir, DEP_BUILD_LOCK_OWNER_FILE),
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    if (
+      typeof parsed.hostname !== "string" ||
+      typeof parsed.pid !== "number" ||
+      !Number.isInteger(parsed.pid) ||
+      parsed.pid <= 0
+    ) {
+      return null;
+    }
+    return {
+      hostname: parsed.hostname,
+      pid: parsed.pid,
+      startedAt:
+        typeof parsed.startedAt === "string" ? parsed.startedAt : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readDependencyLockGeneration(generationDir: string): string | null {
+  try {
+    const generation = fs
+      .readFileSync(
+        path.join(generationDir, DEP_BUILD_LOCK_GENERATION_FILE),
+        "utf8",
+      )
+      .trim();
+    return isDependencyGeneration(generation) ? generation : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Age of an observed lock directory, or `null` when it no longer exists. */
+function dependencyLockAgeMs(generationDir: string, now: number): number | null {
+  try {
+    return Math.max(0, now - fs.statSync(generationDir).mtimeMs);
+  } catch (error) {
+    return isMissingPathError(error) ? null : 0;
+  }
+}
+
+function describeDependencyLockOwner(owner: DependencyLockOwner): string {
+  const started =
+    owner.startedAt === undefined ? "" : ` started at ${owner.startedAt}`;
+  return `pid ${owner.pid} on ${owner.hostname}${started}`;
+}
+
+function isLocalHostName(hostname: string): boolean {
+  return hostname.toLowerCase() === os.hostname().toLowerCase();
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function isRenameDestinationOccupied(
+  error: unknown,
+  destination: string,
+): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code === "EEXIST" || code === "ENOTEMPTY") {
+    return true;
+  }
+  return (code === "EACCES" || code === "EPERM") && fs.existsSync(destination);
+}
+
+/** Render a millisecond duration for lock diagnostics (`137ms`, `42s`, `9m 3s`). */
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms)) {
+    return "an unknown time";
+  }
+  if (ms < 1_000) {
+    return `${Math.max(0, Math.round(ms))}ms`;
+  }
+  const seconds = Math.floor(ms / 1_000);
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return minutes === 0 ? `${seconds}s` : `${minutes}m ${remainder}s`;
 }
 
 /** Owning-tsconfig cache keyed by directory, mirroring `packageTypeCache`. */

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -132,6 +132,85 @@ function manifest(): RuntimeManifest | null {
   return manifestCache;
 }
 
+/**
+ * Lowest Node.js the ttsx source runtime supports. The synchronous
+ * `module.registerHooks` (Node 22.15.0) is the highest floor among the runtime
+ * APIs these hooks depend on — `stripTypeScriptTypes` (22.13.0) and the child's
+ * `--disable-warning` flag (20.11.0) are both lower — so it sets the effective
+ * minimum. Kept in sync with `packages/ttsc/package.json#engines.node` and the
+ * documented requirement in `website/src/content/docs/development/index.mdx`.
+ */
+export const TTSX_MINIMUM_NODE_VERSION = "22.15.0";
+
+const TTSX_MINIMUM_NODE_PARTS: readonly [number, number, number] = [22, 15, 0];
+
+/**
+ * Report why the running (or a candidate) Node.js version cannot execute the
+ * ttsx source runtime, or `null` when it can. Returning an actionable message
+ * — rather than letting the child die with an internal `TypeError` on the
+ * missing `registerHooks`, or Node 18 rejecting `--disable-warning` with exit 9
+ * — is what turns an opaque internal failure into a clear version diagnostic.
+ *
+ * Exported for direct exercise by the ttsx e2e suite: the built launcher can
+ * only be spawned under the Node version running the tests, so the boundary
+ * around the floor cannot otherwise be pinned on CI.
+ */
+export function checkNodeRuntimeSupport(version: string): string | null {
+  const parts = parseNodeVersion(version);
+  if (parts === null) {
+    // An unrecognizable version string is not proof of an unsupported runtime;
+    // let execution proceed rather than block on a parsing quirk.
+    return null;
+  }
+  if (compareVersionParts(parts, TTSX_MINIMUM_NODE_PARTS) >= 0) {
+    return null;
+  }
+  return (
+    `ttsx requires Node.js ${TTSX_MINIMUM_NODE_VERSION} or later, but this ` +
+    `process is Node.js ${version}. The source runtime installs synchronous ` +
+    `module hooks (module.registerHooks, Node 22.15.0) and strips types with ` +
+    `module.stripTypeScriptTypes (Node 22.13.0), neither of which exists on ` +
+    `earlier releases. Upgrade Node.js to 22.15.0+ (or the current LTS), or ` +
+    `compile the project with \`ttsc\` and run the emitted JavaScript directly.`
+  );
+}
+
+function parseNodeVersion(
+  version: string,
+): [number, number, number] | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(version.trim());
+  if (match === null) {
+    return null;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareVersionParts(
+  a: readonly [number, number, number],
+  b: readonly [number, number, number],
+): number {
+  for (let index = 0; index < 3; index += 1) {
+    if (a[index]! !== b[index]!) {
+      return a[index]! < b[index]! ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Throw an actionable version error when the current Node.js cannot run the
+ * ttsx source runtime. Guards the hook-installation boundary directly (a child
+ * or grandchild that inherits the runtime preload under an unsupported Node)
+ * so the failure is diagnosed here instead of surfacing as a bare `TypeError:
+ * registerHooks is not a function`.
+ */
+function assertNodeRuntimeSupport(): void {
+  const message = checkNodeRuntimeSupport(process.versions.node);
+  if (message !== null) {
+    throw new Error(message);
+  }
+}
+
 let installed = false;
 
 /**
@@ -151,6 +230,7 @@ export function installRuntimeHooks(): void {
   if (installed) {
     return;
   }
+  assertNodeRuntimeSupport();
   installed = true;
   // Map error stacks through the source maps the serve path now inlines, so a
   // thrown frame reports the true `.ts` line:col out of the box (no
@@ -743,14 +823,161 @@ function collectCommonJsExportNames(
 }
 
 function collectStaticCommonJsExportNames(source: string): Set<string> {
+  // Scan executable syntax only. Text that merely resembles an assignment —
+  // `exports.x =` inside a comment, string, or template-literal text — must not
+  // become an ESM-visible export name, or a named import of it would link to
+  // `undefined` for a property the CommonJS module never defines. Masking the
+  // inert lexical spans before matching keeps genuine top-level assignments
+  // (and executable `${ ... }` template substitutions) while dropping the
+  // decoys.
+  const scannable = maskCommentsAndStrings(source);
   const names = new Set<string>();
   const pattern =
     /(?:^|[^\w$])(?:exports|module\.exports)\.([A-Za-z_$][\w$]*)\s*=/g;
   let match: RegExpExecArray | null;
-  while ((match = pattern.exec(source)) !== null) {
+  while ((match = pattern.exec(scannable)) !== null) {
     names.add(match[1]!);
   }
   return names;
+}
+
+/**
+ * Blank out the interior of line comments, block comments, string literals, and
+ * template-literal text in emitted JavaScript, replacing each masked character
+ * with a space while preserving newlines, code, and template `${ ... }`
+ * substitutions verbatim. Positions and length are preserved so an offset in the
+ * masked text maps back to the same offset in the source.
+ *
+ * The input is tsgo's CommonJS emit (well-formed JavaScript), so a character
+ * scanner that tracks the standard comment/string/template states is sufficient
+ * to separate executable tokens from inert text. Regular-expression literals are
+ * intentionally not masked: distinguishing `/`-division from a regex literal
+ * needs full tokenization, and tsgo's CommonJS emit never wraps an
+ * `exports.<name> =` assignment inside a regex literal.
+ */
+function maskCommentsAndStrings(source: string): string {
+  const out = source.split("");
+  const n = out.length;
+  const blank = (index: number): void => {
+    const ch = out[index];
+    if (ch !== "\n" && ch !== "\r") {
+      out[index] = " ";
+    }
+  };
+  // A stack of lexical contexts. The base is code; each backtick pushes a
+  // template context, and each `${` inside a template pushes a nested code
+  // context whose `braceDepth` tracks `{}` nesting so an object literal inside
+  // the substitution does not end it early.
+  interface Context {
+    kind: "code" | "template";
+    braceDepth: number;
+  }
+  const stack: Context[] = [{ kind: "code", braceDepth: 0 }];
+  let i = 0;
+  while (i < n) {
+    const top = stack[stack.length - 1]!;
+    const ch = out[i]!;
+    if (top.kind === "template") {
+      if (ch === "\\") {
+        blank(i);
+        blank(i + 1);
+        i += 2;
+        continue;
+      }
+      if (ch === "`") {
+        blank(i);
+        stack.pop();
+        i += 1;
+        continue;
+      }
+      if (ch === "$" && out[i + 1] === "{") {
+        // Enter a code substitution: `${` and its contents stay executable.
+        stack.push({ kind: "code", braceDepth: 0 });
+        i += 2;
+        continue;
+      }
+      blank(i);
+      i += 1;
+      continue;
+    }
+    // Code context.
+    if (ch === "/" && out[i + 1] === "/") {
+      blank(i);
+      blank(i + 1);
+      i += 2;
+      while (i < n && out[i] !== "\n") {
+        blank(i);
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === "/" && out[i + 1] === "*") {
+      blank(i);
+      blank(i + 1);
+      i += 2;
+      while (i < n && !(out[i] === "*" && out[i + 1] === "/")) {
+        blank(i);
+        i += 1;
+      }
+      if (i < n) {
+        blank(i);
+        blank(i + 1);
+        i += 2;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      blank(i);
+      i += 1;
+      while (i < n && out[i] !== ch) {
+        if (out[i] === "\\") {
+          blank(i);
+          blank(i + 1);
+          i += 2;
+          continue;
+        }
+        // A bare newline ends an unterminated string; stop masking so the rest
+        // of the line is still scanned as code (defensive — tsgo never emits
+        // one).
+        if (out[i] === "\n") {
+          break;
+        }
+        blank(i);
+        i += 1;
+      }
+      if (i < n && out[i] === ch) {
+        blank(i);
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === "`") {
+      blank(i);
+      stack.push({ kind: "template", braceDepth: 0 });
+      i += 1;
+      continue;
+    }
+    if (ch === "{") {
+      top.braceDepth += 1;
+      i += 1;
+      continue;
+    }
+    if (ch === "}") {
+      if (top.braceDepth === 0 && stack.length > 1) {
+        // Close the enclosing template `${ ... }` and resume template text.
+        stack.pop();
+        i += 1;
+        continue;
+      }
+      if (top.braceDepth > 0) {
+        top.braceDepth -= 1;
+      }
+      i += 1;
+      continue;
+    }
+    i += 1;
+  }
+  return out.join("");
 }
 
 function collectSourceCommonJsExportNames(

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_preserves_two_spaced_tsgo_flag_pairs_in_order.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_preserves_two_spaced_tsgo_flag_pairs_in_order.ts
@@ -1,0 +1,46 @@
+import {
+  assert,
+  createProject,
+  fs,
+  path,
+  spawn,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies ttsc forwards two space-valued tsgo flags to the build with each
+ * flag still adjacent to its own value.
+ *
+ * The old parser split every unknown flag from its bare value and rebuilt the
+ * stream as `[...flags, ...values]`, so `--target es2020 --module commonjs`
+ * reached tsgo as `--target --module es2020 commonjs`. tsgo then reads `--module`
+ * as the value of `--target`, rejects it as an invalid target, and the build
+ * fails. A build that succeeds and emits proves each value stayed with its flag.
+ *
+ * 1. Create a minimal project.
+ * 2. Run `ttsc --emit --target es2020 --module commonjs`.
+ * 3. Assert a zero exit and that the project's JavaScript was emitted.
+ */
+export const test_ttsc_preserves_two_spaced_tsgo_flag_pairs_in_order = () => {
+  const root = createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": `export const value: string = "ordered";\n`,
+  });
+
+  const result = spawn(
+    ttscBin,
+    ["--cwd", root, "--emit", "--target", "es2020", "--module", "commonjs"],
+    { cwd: root },
+  );
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+  assert.ok(fs.existsSync(path.join(root, "dist", "main.js")));
+};

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_parseflags_keeps_the_ttsx_entry_after_a_spaced_flag_value.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_parseflags_keeps_the_ttsx_entry_after_a_spaced_flag_value.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+
+import { parseFlags } from "../../../../../packages/ttsc/lib/flags/parser.js";
+
+const isEntry = (token: string): boolean =>
+  [".ts", ".tsx", ".mts", ".cts"].some((ext) => token.endsWith(ext));
+
+/**
+ * Verifies the launcher parser identifies the ttsx entry after a spaced flag
+ * value and keeps the forwarded pairs and the program tail separated.
+ *
+ * With `forwardAfterFirstPositional`, a pre-entry flag value like the `es2020`
+ * of `--target es2020` used to become the first positional sentinel, flipping
+ * the parser into tail mode so the real entry was pushed into `tail` and ttsx
+ * failed with "entry file is required". Classifying the value with
+ * `isPositional` keeps it in `passthrough` in order, so the first true
+ * positional is the entry and only tokens after it become the program tail.
+ *
+ * 1. Parse `--target es2020 --module commonjs entry.ts generate --input X` with
+ *    the entry predicate and `forwardAfterFirstPositional`.
+ * 2. Assert the entry is the only positional and the two forwarded pairs keep
+ *    their order in `passthrough`.
+ * 3. Assert the post-entry tokens are the program `tail`, never forwarded to
+ *    tsgo.
+ */
+export const test_parseflags_keeps_the_ttsx_entry_after_a_spaced_flag_value =
+  () => {
+    const result = parseFlags({
+      argv: [
+        "--target",
+        "es2020",
+        "--module",
+        "commonjs",
+        "entry.ts",
+        "generate",
+        "--input",
+        "X",
+      ],
+      errorPrefix: "ttsx:",
+      forwardAfterFirstPositional: true,
+      honorDoubleDashSeparator: true,
+      isPositional: isEntry,
+      subcommand: "ttsx",
+    });
+    assert.deepEqual(result.positional, ["entry.ts"]);
+    assert.deepEqual(result.passthrough, [
+      "--target",
+      "es2020",
+      "--module",
+      "commonjs",
+    ]);
+    assert.deepEqual(result.tail, ["generate", "--input", "X"]);
+
+    // Negative twin: without the predicate, `es2020` becomes the sentinel and
+    // the real entry is lost to the tail — the exact failure being fixed.
+    const naive = parseFlags({
+      argv: ["--target", "es2020", "entry.ts"],
+      errorPrefix: "ttsx:",
+      forwardAfterFirstPositional: true,
+      honorDoubleDashSeparator: true,
+      subcommand: "ttsx",
+    });
+    assert.deepEqual(naive.positional, ["es2020"]);
+    assert.deepEqual(naive.tail, ["entry.ts"]);
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_parseflags_preserves_unknown_spaced_flag_value_order_for_ttsc.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_parseflags_preserves_unknown_spaced_flag_value_order_for_ttsc.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+
+import { parseFlags } from "../../../../../packages/ttsc/lib/flags/parser.js";
+
+const isTsInput = (token: string): boolean =>
+  [".ts", ".tsx", ".mts", ".cts"].some((ext) => token.endsWith(ext));
+
+/**
+ * Verifies the launcher parser keeps every unknown `--flag value` pair in its
+ * original order at the tsgo boundary for the ttsc build subcommand.
+ *
+ * The bug this pins split an unknown flag into `passthrough` and its bare value
+ * into `positional`, so `parseBuildArgs` rebuilt the stream as
+ * `[...passthrough, ...values]` — every flag ahead of every value. With
+ * `isPositional`, a bare value that is not a TypeScript input stays in
+ * `passthrough` in place, so two spaced pairs keep their adjacency and only the
+ * real `.ts` input is a positional.
+ *
+ * 1. Parse `--target es2020 --module commonjs a.ts` with the TS-extension
+ *    predicate.
+ * 2. Assert `passthrough` is exactly the two pairs interleaved in order.
+ * 3. Assert the negative twins: the `.ts` input is the only positional, an
+ *    inline `--flag=value` stays one token, and an unknown boolean is not given
+ *    a value.
+ */
+export const test_parseflags_preserves_unknown_spaced_flag_value_order_for_ttsc =
+  () => {
+    const result = parseFlags({
+      argv: ["--target", "es2020", "--module", "commonjs", "a.ts"],
+      errorPrefix: "ttsc:",
+      isPositional: isTsInput,
+      subcommand: "build",
+    });
+    assert.deepEqual(result.passthrough, [
+      "--target",
+      "es2020",
+      "--module",
+      "commonjs",
+    ]);
+    assert.deepEqual(result.positional, ["a.ts"]);
+
+    // Negative twin: without the predicate the bare values fall into
+    // `positional` (the historical behaviour these callers must not use).
+    const naive = parseFlags({
+      argv: ["--target", "es2020", "--module", "commonjs", "a.ts"],
+      errorPrefix: "ttsc:",
+      subcommand: "build",
+    });
+    assert.deepEqual(naive.positional, ["es2020", "commonjs", "a.ts"]);
+
+    // Inline `--flag=value` stays a single token; an unknown boolean is not
+    // given the following input file as a value.
+    const mixed = parseFlags({
+      argv: ["--target=es2020", "--experimentalUnknownBool", "b.ts"],
+      errorPrefix: "ttsc:",
+      isPositional: isTsInput,
+      subcommand: "build",
+    });
+    assert.deepEqual(mixed.passthrough, [
+      "--target=es2020",
+      "--experimentalUnknownBool",
+    ]);
+    assert.deepEqual(mixed.positional, ["b.ts"]);
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dependency_cache_fences_two_stale_observers_of_a_dead_owner.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dependency_cache_fences_two_stale_observers_of_a_dead_owner.ts
@@ -1,0 +1,182 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  dependencyCacheLibraryPath,
+  fs,
+  inspectDependencyBuildLock,
+  path,
+  spawnNodeWorker,
+  waitForCondition,
+} from "../../internal/dependency-cache";
+
+/**
+ * Verifies two stale observers of one dead-owner generation cannot both replace
+ * it, so exactly one successor build proceeds.
+ *
+ * Both real child processes capture the same abandoned generation's fence
+ * before either may act. Observer A reclaims and acquires the successor first
+ * and stops there; only then does stale observer B attempt its reclaim. B must
+ * find A's tombstone occupied, fail, and leave A's live successor intact — the
+ * third-contender guarantee that at most one successor executes the build.
+ *
+ * 1. A short-lived child acquires a lock and exits without releasing it.
+ * 2. Two observers report that generation abandoned and hold at a barrier.
+ * 3. Release A to reclaim and hold the successor, then release B and assert one
+ *    reclaim wins, one build-hold exists, and the successor is still current.
+ */
+export const test_ttsx_dependency_cache_fences_two_stale_observers_of_a_dead_owner =
+  async () => {
+    const root = TestProject.tmpdir("ttsx-depcache-fence-");
+    const lockDir = path.join(root, "entry.lock");
+    const libraryPath = dependencyCacheLibraryPath();
+
+    const seedScript = path.join(root, "seed.cjs");
+    fs.writeFileSync(
+      seedScript,
+      [
+        `const fs = require("node:fs");`,
+        `const { acquireDependencyBuildLock } = require(${JSON.stringify(libraryPath)});`,
+        `const lease = acquireDependencyBuildLock(${JSON.stringify(lockDir)});`,
+        `if (!lease) throw new Error("seed failed to acquire lock");`,
+        `fs.writeFileSync(${JSON.stringify(path.join(root, "seed.json"))}, JSON.stringify(lease), "utf8");`,
+        // Exit WITHOUT releasing: the owner pid is now dead, so observers see
+        // the generation as abandoned.
+        ``,
+      ].join("\n"),
+      "utf8",
+    );
+    const seeded = await spawnNodeWorker({ script: seedScript });
+    assert.equal(seeded.status, 0, seeded.stderr);
+    const seed = JSON.parse(
+      fs.readFileSync(path.join(root, "seed.json"), "utf8"),
+    ) as { generation: string };
+
+    const observerScript = path.join(root, "observer.cjs");
+    fs.writeFileSync(
+      observerScript,
+      [
+        `const fs = require("node:fs");`,
+        `const { acquireDependencyBuildLock, inspectDependencyBuildLock, reclaimDependencyBuildLock, releaseDependencyBuildLock } = require(${JSON.stringify(libraryPath)});`,
+        `const lockDir = ${JSON.stringify(lockDir)};`,
+        `const readyFile = process.env.OBS_READY;`,
+        `const releaseFile = process.env.OBS_RELEASE;`,
+        `const reclaimedFile = process.env.OBS_RECLAIMED;`,
+        `const holdingFile = process.env.OBS_HOLDING;`,
+        `const buildReleaseFile = ${JSON.stringify(path.join(root, "build-release"))};`,
+        `const observation = inspectDependencyBuildLock(lockDir, Date.now());`,
+        `if (observation.state !== "abandoned") throw new Error("expected abandoned, got " + observation.state);`,
+        `fs.writeFileSync(readyFile, JSON.stringify(observation.fence), "utf8");`,
+        `waitFor(() => fs.existsSync(releaseFile), "observer release");`,
+        `const reclaimed = reclaimDependencyBuildLock(lockDir, observation.fence);`,
+        `fs.writeFileSync(reclaimedFile, JSON.stringify({ reclaimed }), "utf8");`,
+        `let holding = false;`,
+        `const deadline = Date.now() + 120000;`,
+        `for (;;) {`,
+        `  const lease = acquireDependencyBuildLock(lockDir);`,
+        `  if (lease) {`,
+        `    holding = true;`,
+        `    fs.writeFileSync(holdingFile, JSON.stringify(lease), "utf8");`,
+        `    waitFor(() => fs.existsSync(buildReleaseFile), "build release");`,
+        `    releaseDependencyBuildLock(lockDir, lease);`,
+        `    break;`,
+        `  }`,
+        `  const state = inspectDependencyBuildLock(lockDir, Date.now());`,
+        `  if (state.state === "active") break;`,
+        `  if (Date.now() > deadline) throw new Error("timed out acquiring successor");`,
+        `  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);`,
+        `}`,
+        `process.stdout.write(JSON.stringify({ holding, reclaimed }) + "\\n");`,
+        `function waitFor(predicate, label) {`,
+        `  const d = Date.now() + 120000;`,
+        `  while (!predicate()) {`,
+        `    if (Date.now() > d) throw new Error("timed out waiting for " + label);`,
+        `    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);`,
+        `  }`,
+        `}`,
+        ``,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const readyA = path.join(root, "ready-a.json");
+    const readyB = path.join(root, "ready-b.json");
+    const releaseA = path.join(root, "release-a");
+    const releaseB = path.join(root, "release-b");
+    const reclaimedA = path.join(root, "reclaimed-a.json");
+    const reclaimedB = path.join(root, "reclaimed-b.json");
+    const holdingA = path.join(root, "holding-a.json");
+    const holdingB = path.join(root, "holding-b.json");
+
+    const workerA = spawnNodeWorker({
+      env: {
+        OBS_HOLDING: holdingA,
+        OBS_READY: readyA,
+        OBS_RECLAIMED: reclaimedA,
+        OBS_RELEASE: releaseA,
+      },
+      script: observerScript,
+    });
+    const workerB = spawnNodeWorker({
+      env: {
+        OBS_HOLDING: holdingB,
+        OBS_READY: readyB,
+        OBS_RECLAIMED: reclaimedB,
+        OBS_RELEASE: releaseB,
+      },
+      script: observerScript,
+    });
+
+    await waitForCondition(
+      () => fs.existsSync(readyA) && fs.existsSync(readyB),
+      "both stale observers",
+    );
+    assert.deepEqual(JSON.parse(fs.readFileSync(readyA, "utf8")), seed);
+    assert.deepEqual(JSON.parse(fs.readFileSync(readyB, "utf8")), seed);
+
+    // Let A reclaim and take the successor generation first.
+    fs.writeFileSync(releaseA, "release\n", "utf8");
+    await waitForCondition(
+      () => fs.existsSync(reclaimedA) && fs.existsSync(holdingA),
+      "observer A holds the successor",
+    );
+    const successorLease = JSON.parse(
+      fs.readFileSync(holdingA, "utf8"),
+    ) as { generation: string };
+
+    // Now let stale observer B attempt its reclaim of the already-retired gen.
+    fs.writeFileSync(releaseB, "release\n", "utf8");
+    await waitForCondition(
+      () => fs.existsSync(reclaimedB),
+      "observer B reclaim attempt",
+    );
+    const whileHeld = inspectDependencyBuildLock(lockDir, Date.now());
+
+    fs.writeFileSync(path.join(root, "build-release"), "release\n", "utf8");
+    const results = await Promise.all([workerA, workerB]);
+    for (const result of results) {
+      assert.equal(result.status, 0, result.stderr);
+    }
+    const reports = results.map(
+      (r) => JSON.parse(r.stdout) as { holding: boolean; reclaimed: boolean },
+    );
+
+    assert.deepEqual(JSON.parse(fs.readFileSync(reclaimedA, "utf8")), {
+      reclaimed: true,
+    });
+    assert.deepEqual(JSON.parse(fs.readFileSync(reclaimedB, "utf8")), {
+      reclaimed: false,
+    });
+    assert.equal(fs.existsSync(holdingB), false);
+    assert.equal(whileHeld.state, "active");
+    assert.deepEqual(
+      whileHeld.state === "active" ? whileHeld.fence : null,
+      successorLease,
+    );
+    assert.equal(reports.filter((r) => r.reclaimed).length, 1);
+    assert.equal(reports.filter((r) => r.holding).length, 1);
+    assert.equal(
+      fs.existsSync(path.join(lockDir, "retired", seed.generation)),
+      true,
+    );
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dependency_cache_old_finalizer_cannot_release_a_successor.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dependency_cache_old_finalizer_cannot_release_a_successor.ts
@@ -1,0 +1,120 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  inspectDependencyBuildLock,
+  path,
+  reclaimDependencyBuildLock,
+  releaseDependencyBuildLock,
+  spawnNodeWorker,
+  waitForCondition,
+  writeLockHolderScript,
+} from "../../internal/dependency-cache";
+
+/**
+ * Verifies an old dependency-lock holder's delayed finalizer cannot release its
+ * successor.
+ *
+ * Fences the exact race from the issue: holder A's `finally` runs only after a
+ * successor B already owns the lock. Because the only way to free `current` is
+ * to create the retiring generation's tombstone, A's deterministic tombstone
+ * already exists, so its late rename fails atomically and B stays current. A
+ * pathname-blind `rmSync` would instead have deleted B's live lock.
+ *
+ * 1. A child acquires generation A; the parent reclaims (retires) A.
+ * 2. A second child acquires successor B, then A's delayed `finally` runs.
+ * 3. Assert A reports release failure, B remains the active current generation,
+ *    and B later releases normally.
+ */
+export const test_ttsx_dependency_cache_old_finalizer_cannot_release_a_successor =
+  async () => {
+    const root = TestProject.tmpdir("ttsx-depcache-finalizer-");
+    const lockDir = path.join(root, "entry.lock");
+    const workerScript = writeLockHolderScript(root, lockDir);
+
+    const oldLeaseFile = path.join(root, "old-lease.json");
+    const oldFinalizeFile = path.join(root, "old-finalize");
+    const oldResultFile = path.join(root, "old-result.json");
+    const successorLeaseFile = path.join(root, "successor-lease.json");
+    const successorReleaseFile = path.join(root, "successor-release");
+    const successorResultFile = path.join(root, "successor-result.json");
+
+    const oldHolder = spawnNodeWorker({
+      env: {
+        LOCK_LEASE_FILE: oldLeaseFile,
+        LOCK_RELEASE_FILE: oldFinalizeFile,
+        LOCK_RESULT_FILE: oldResultFile,
+      },
+      script: workerScript,
+    });
+    await waitForCondition(
+      () => fs.existsSync(oldLeaseFile),
+      "old holder acquisition",
+    );
+    const oldLease = JSON.parse(fs.readFileSync(oldLeaseFile, "utf8")) as {
+      generation: string;
+    };
+    assert.equal(
+      reclaimDependencyBuildLock(lockDir, oldLease),
+      true,
+      "the parent should retire generation A",
+    );
+
+    const successor = spawnNodeWorker({
+      env: {
+        LOCK_LEASE_FILE: successorLeaseFile,
+        LOCK_RELEASE_FILE: successorReleaseFile,
+        LOCK_RESULT_FILE: successorResultFile,
+      },
+      script: workerScript,
+    });
+    await waitForCondition(
+      () => fs.existsSync(successorLeaseFile),
+      "successor acquisition",
+    );
+    const successorLease = JSON.parse(
+      fs.readFileSync(successorLeaseFile, "utf8"),
+    ) as { generation: string };
+
+    // Only now let A's normal `finally` run — B is already current.
+    fs.writeFileSync(oldFinalizeFile, "release\n", "utf8");
+    await waitForCondition(
+      () => fs.existsSync(oldResultFile),
+      "old finalizer result",
+    );
+    const oldResult = await oldHolder;
+    assert.equal(oldResult.status, 0, oldResult.stderr);
+    assert.deepEqual(JSON.parse(fs.readFileSync(oldResultFile, "utf8")), {
+      released: false,
+    });
+
+    const whileSuccessorHeld = inspectDependencyBuildLock(lockDir, Date.now());
+    assert.equal(whileSuccessorHeld.state, "active");
+    assert.deepEqual(
+      whileSuccessorHeld.state === "active" ? whileSuccessorHeld.fence : null,
+      successorLease,
+    );
+
+    fs.writeFileSync(successorReleaseFile, "release\n", "utf8");
+    const successorResult = await successor;
+    assert.equal(successorResult.status, 0, successorResult.stderr);
+    assert.deepEqual(JSON.parse(fs.readFileSync(successorResultFile, "utf8")), {
+      released: true,
+    });
+    assert.deepEqual(inspectDependencyBuildLock(lockDir, Date.now()), {
+      state: "released",
+    });
+    assert.equal(
+      fs.existsSync(path.join(lockDir, "retired", oldLease.generation)),
+      true,
+    );
+    assert.equal(
+      fs.existsSync(path.join(lockDir, "retired", successorLease.generation)),
+      true,
+    );
+
+    // The parent's late reclaim of the already-retired generation A must also
+    // fail without touching the released state.
+    assert.equal(releaseDependencyBuildLock(lockDir, oldLease), false);
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dependency_cache_reader_never_mixes_metadata_with_a_partial_emit.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dependency_cache_reader_never_mixes_metadata_with_a_partial_emit.ts
@@ -1,0 +1,112 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  dependencyCacheLibraryPath,
+  fs,
+  path,
+  readDependencyCache,
+  spawnNodeWorker,
+  waitForCondition,
+} from "../../internal/dependency-cache";
+
+/**
+ * Verifies a cache reader never combines an old generation's metadata with a
+ * newer generation's partially-written emit.
+ *
+ * Reproduces the issue's second race: a valid marker still names generation A
+ * while a rebuilding holder populates generation B and has not yet published
+ * B's marker. Because the marker is bound to one generation and B lands in its
+ * own directory, `readDependencyCache` keeps returning the complete A until the
+ * atomic marker swap points at B — never a mix of A's metadata and B's partial
+ * files.
+ *
+ * 1. Seed a complete generation A with a published marker.
+ * 2. A holder builds generation B, writes its first file, and halts at a
+ *    barrier before publishing B's marker; the reader observes A only.
+ * 3. Release the holder to swap the marker atomically; the reader now observes
+ *    the complete B and never a directory that lacks emitted JavaScript.
+ */
+export const test_ttsx_dependency_cache_reader_never_mixes_metadata_with_a_partial_emit =
+  async () => {
+    const root = TestProject.tmpdir("ttsx-depcache-publish-");
+    const cacheDir = path.join(root, "entry");
+    const metaPath = path.join(root, "entry.json");
+    const genA = "a".repeat(32);
+    const genB = "b".repeat(32);
+    const genADir = path.join(cacheDir, `gen-${genA}`);
+
+    // Seed a complete generation A.
+    fs.mkdirSync(genADir, { recursive: true });
+    fs.writeFileSync(path.join(genADir, "index.js"), "exports.value = 'A';\n");
+    fs.writeFileSync(
+      metaPath,
+      JSON.stringify({ generation: genA, moduleOption: "commonjs", rootDir: "/root" }),
+      "utf8",
+    );
+
+    const barrierFile = path.join(root, "partial-b");
+    const releaseFile = path.join(root, "publish-b");
+    const builderScript = path.join(root, "builder.cjs");
+    // The library is required only so the worker fails loudly if the built
+    // module is missing; the atomic swap it performs mirrors
+    // `publishDependencyMeta` exactly.
+    fs.writeFileSync(
+      builderScript,
+      [
+        `const fs = require("node:fs");`,
+        `const path = require("node:path");`,
+        `require(${JSON.stringify(dependencyCacheLibraryPath())});`,
+        `const cacheDir = ${JSON.stringify(cacheDir)};`,
+        `const metaPath = ${JSON.stringify(metaPath)};`,
+        `const genB = ${JSON.stringify(genB)};`,
+        `const genBDir = path.join(cacheDir, "gen-" + genB);`,
+        `fs.mkdirSync(genBDir, { recursive: true });`,
+        // First file of generation B, marker not yet published.
+        `fs.writeFileSync(path.join(genBDir, "index.js"), "exports.value = 'B';\\n");`,
+        `fs.writeFileSync(${JSON.stringify(barrierFile)}, "partial\\n", "utf8");`,
+        `const deadline = Date.now() + 120000;`,
+        `while (!fs.existsSync(${JSON.stringify(releaseFile)})) {`,
+        `  if (Date.now() > deadline) throw new Error("timed out waiting to publish");`,
+        `  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);`,
+        `}`,
+        `const tmp = metaPath + ".tmp";`,
+        `fs.writeFileSync(tmp, JSON.stringify({ generation: genB, moduleOption: "commonjs", rootDir: "/root" }), "utf8");`,
+        `fs.renameSync(tmp, metaPath);`,
+        ``,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const builder = spawnNodeWorker({ script: builderScript });
+    await waitForCondition(
+      () => fs.existsSync(barrierFile),
+      "generation B partial emit",
+    );
+
+    // Marker still names A: the reader must return the complete A, never a
+    // BuiltProject pointing at the partially-written B directory.
+    const midRebuild = readDependencyCache(cacheDir, metaPath);
+    assert.notEqual(midRebuild, null, "reader should still hit generation A");
+    assert.equal(midRebuild!.emitDir, genADir);
+
+    fs.writeFileSync(releaseFile, "publish\n", "utf8");
+    const built = await builder;
+    assert.equal(built.status, 0, built.stderr);
+
+    // After the atomic swap the reader observes the complete B.
+    const afterPublish = readDependencyCache(cacheDir, metaPath);
+    assert.notEqual(afterPublish, null, "reader should hit generation B");
+    assert.equal(afterPublish!.emitDir, path.join(cacheDir, `gen-${genB}`));
+
+    // Negative twin: a marker that names a generation whose directory holds no
+    // emitted JavaScript (a failed/partial generation) is never a hit.
+    const genC = "c".repeat(32);
+    fs.mkdirSync(path.join(cacheDir, `gen-${genC}`), { recursive: true });
+    fs.writeFileSync(
+      metaPath,
+      JSON.stringify({ generation: genC, moduleOption: "commonjs", rootDir: "/root" }),
+      "utf8",
+    );
+    assert.equal(readDependencyCache(cacheDir, metaPath), null);
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dependency_cache_recovers_from_a_dead_owner_and_reports_lock_states.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dependency_cache_recovers_from_a_dead_owner_and_reports_lock_states.ts
@@ -1,0 +1,91 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  acquireDependencyBuildLock,
+  assert,
+  dependencyCacheLibraryPath,
+  fs,
+  inspectDependencyBuildLock,
+  path,
+  reclaimDependencyBuildLock,
+  releaseDependencyBuildLock,
+  spawnNodeWorker,
+} from "../../internal/dependency-cache";
+
+/**
+ * Verifies the dependency build lock classifies a dead owner as abandoned so a
+ * crashed builder is recovered, and reports active and released states
+ * correctly.
+ *
+ * A builder that crashes mid-build would otherwise wedge every waiter until the
+ * generous steal timeout; keying abandonment on a same-host owner pid that is no
+ * longer running lets the next contender reclaim immediately. The active and
+ * released twins pin that a live owner is never stolen and a retired generation
+ * reads back as released.
+ *
+ * 1. A child acquires a generation and exits without releasing it.
+ * 2. Assert the lock reads abandoned, reclaim it, then acquire it live and
+ *    assert it reads active with the live fence.
+ * 3. Release the live generation and assert the lock reads released.
+ */
+export const test_ttsx_dependency_cache_recovers_from_a_dead_owner_and_reports_lock_states =
+  async () => {
+    const root = TestProject.tmpdir("ttsx-depcache-states-");
+    const lockDir = path.join(root, "entry.lock");
+    const seedFile = path.join(root, "seed.json");
+
+    const seedScript = path.join(root, "seed.cjs");
+    fs.writeFileSync(
+      seedScript,
+      [
+        `const fs = require("node:fs");`,
+        `const { acquireDependencyBuildLock } = require(${JSON.stringify(dependencyCacheLibraryPath())});`,
+        `const lease = acquireDependencyBuildLock(${JSON.stringify(lockDir)});`,
+        `if (!lease) throw new Error("seed failed to acquire lock");`,
+        `fs.writeFileSync(${JSON.stringify(seedFile)}, JSON.stringify(lease), "utf8");`,
+        // Exit without releasing — the owner pid is now dead.
+        ``,
+      ].join("\n"),
+      "utf8",
+    );
+    const seeded = await spawnNodeWorker({ script: seedScript });
+    assert.equal(seeded.status, 0, seeded.stderr);
+    const seed = JSON.parse(fs.readFileSync(seedFile, "utf8")) as {
+      generation: string;
+    };
+
+    // A crashed same-host owner reads as abandoned, not active.
+    const abandoned = inspectDependencyBuildLock(lockDir, Date.now());
+    assert.equal(abandoned.state, "abandoned");
+    assert.deepEqual(
+      abandoned.state === "abandoned" ? abandoned.fence : null,
+      seed,
+    );
+
+    // Recover: retire the dead generation, then take it live.
+    assert.equal(reclaimDependencyBuildLock(lockDir, seed), true);
+    const lease = acquireDependencyBuildLock(lockDir);
+    assert.notEqual(lease, null, "a fresh contender should acquire after recovery");
+
+    // A live local owner is never stolen.
+    const active = inspectDependencyBuildLock(lockDir, Date.now());
+    assert.equal(active.state, "active");
+    assert.deepEqual(active.state === "active" ? active.fence : null, lease);
+
+    // Ordinary release leaves the lock released.
+    assert.equal(releaseDependencyBuildLock(lockDir, lease!), true);
+    assert.deepEqual(inspectDependencyBuildLock(lockDir, Date.now()), {
+      state: "released",
+    });
+
+    // The dead owner's late reclaim can no longer affect the released lock.
+    assert.equal(reclaimDependencyBuildLock(lockDir, seed), false);
+    assert.equal(
+      fs.existsSync(path.join(lockDir, "retired", seed.generation)),
+      true,
+    );
+    assert.equal(
+      fs.existsSync(path.join(lockDir, "retired", lease!.generation)),
+      true,
+    );
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_diagnoses_unsupported_node_versions_at_the_documented_floor.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_diagnoses_unsupported_node_versions_at_the_documented_floor.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+
+import {
+  TTSX_MINIMUM_NODE_VERSION,
+  checkNodeRuntimeSupport,
+} from "../../../../../packages/ttsc/lib/launcher/internal/runtimeHooks.js";
+
+/**
+ * Verifies ttsx diagnoses every Node.js version below its documented floor with
+ * an actionable message and admits the floor and later.
+ *
+ * The runtime's highest requirement is synchronous `module.registerHooks`
+ * (Node 22.15.0); the docs, `engines.node`, and this diagnostic must agree on
+ * that floor. The e2e suite runs under a single Node version, so the boundary is
+ * pinned by exercising the exported guard directly rather than by spawning many
+ * runtimes. Below the floor the message must name the version and the missing
+ * API instead of surfacing an internal `TypeError`.
+ *
+ * 1. Assert Node 18, 20, and 22.13 (below 22.15) each return a message that
+ *    names the required version and `registerHooks`.
+ * 2. Assert the floor 22.15.0 and a later 24.x return `null` (supported).
+ * 3. Assert an unparseable version returns `null` rather than blocking on a
+ *    parsing quirk.
+ */
+export const test_ttsx_diagnoses_unsupported_node_versions_at_the_documented_floor =
+  () => {
+    assert.equal(TTSX_MINIMUM_NODE_VERSION, "22.15.0");
+
+    for (const version of ["18.20.8", "20.20.2", "22.13.0", "22.14.9"]) {
+      const message = checkNodeRuntimeSupport(version);
+      assert.notEqual(
+        message,
+        null,
+        `expected ${version} to be diagnosed as unsupported`,
+      );
+      assert.match(message!, /22\.15\.0/);
+      assert.match(message!, /registerHooks/);
+      assert.match(message!, new RegExp(version.replace(/\./g, "\\.")));
+    }
+
+    // Floor and later releases are supported (no diagnostic).
+    for (const version of ["22.15.0", "22.16.0", "24.3.0", "v24.0.0"]) {
+      assert.equal(
+        checkNodeRuntimeSupport(version),
+        null,
+        `expected ${version} to be supported`,
+      );
+    }
+
+    // An unrecognizable version is not proof of an unsupported runtime.
+    assert.equal(checkNodeRuntimeSupport("not-a-version"), null);
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_exposes_nested_cjs_source_star_exports_to_esm_named_imports.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_exposes_nested_cjs_source_star_exports_to_esm_named_imports.ts
@@ -13,10 +13,13 @@ import assert from "node:assert/strict";
  * still make those names visible to the ESM named-import bridge.
  *
  * 1. Install a `lib` package with no `type` field whose TS entry re-exports value
- *    names through a nested `export *` chain.
+ *    names through a nested `export *` chain, alongside `exports.<name> =`
+ *    assignment-shaped decoys inside a comment, a block comment, a string, and a
+ *    template literal.
  * 2. Run an ESM ttsx entry that imports `{ foo, bar }` from `lib`.
  * 3. Run a CJS ttsx entry that requires the same `lib` package.
- * 4. Assert both module formats observe the re-exported runtime values.
+ * 4. Assert both module formats observe the re-exported runtime values and that
+ *    none of the assignment-shaped decoys leak into the namespace.
  */
 export const test_ttsx_exposes_nested_cjs_source_star_exports_to_esm_named_imports =
   () => {
@@ -49,12 +52,21 @@ export const test_ttsx_exposes_nested_cjs_source_star_exports_to_esm_named_impor
         `export type Hidden = string;`,
         `// export const commentedGhost: string = "nope";`,
         `const decoy: string = "export const stringGhost: string = 'nope';";`,
+        // Assignment-shaped decoys: exactly the `exports.<name> =` /
+        // `module.exports.<name> =` form the static collector matches, placed in
+        // inert lexical positions. None is executable, so none may become a
+        // namespace key.
+        `// exports.commentAssignGhost = 1;`,
+        `/* module.exports.blockAssignGhost = 2; */`,
+        `const stringAssign: string = "exports.stringAssignGhost = 3;";`,
+        `const templateAssign: string = \`module.exports.templateAssignGhost = 4;\`;`,
         `const renamed: string = "renamed-ok";`,
         `export const foo: string = "foo-ok";`,
         `export function bar(): string {`,
         `  return "bar-ok";`,
         `}`,
         `export { renamed as qux };`,
+        `export const decoyLength: number = decoy.length + stringAssign.length + templateAssign.length;`,
         ``,
       ].join("\n"),
       "node_modules/lib/src/leaf.ts": `export const leaf: string = "leaf-ok";\n`,
@@ -64,6 +76,10 @@ export const test_ttsx_exposes_nested_cjs_source_star_exports_to_esm_named_impor
         `if ("Hidden" in lib) throw new Error("type-only export leaked");`,
         `if ("commentedGhost" in lib) throw new Error("comment export leaked");`,
         `if ("stringGhost" in lib) throw new Error("string export leaked");`,
+        `if ("commentAssignGhost" in lib) throw new Error("comment assign export leaked");`,
+        `if ("blockAssignGhost" in lib) throw new Error("block assign export leaked");`,
+        `if ("stringAssignGhost" in lib) throw new Error("string assign export leaked");`,
+        `if ("templateAssignGhost" in lib) throw new Error("template assign export leaked");`,
         `console.log(foo + ":" + bar() + ":" + qux + ":" + grouped.leaf);`,
         ``,
       ].join("\n"),
@@ -73,6 +89,10 @@ export const test_ttsx_exposes_nested_cjs_source_star_exports_to_esm_named_impor
         `if ("Hidden" in lib) throw new Error("type-only export leaked");`,
         `if ("commentedGhost" in lib) throw new Error("comment export leaked");`,
         `if ("stringGhost" in lib) throw new Error("string export leaked");`,
+        `if ("commentAssignGhost" in lib) throw new Error("comment assign export leaked");`,
+        `if ("blockAssignGhost" in lib) throw new Error("block assign export leaked");`,
+        `if ("stringAssignGhost" in lib) throw new Error("string assign export leaked");`,
+        `if ("templateAssignGhost" in lib) throw new Error("template assign export leaked");`,
         `console.log(lib.foo + ":" + lib.bar() + ":" + lib.qux + ":" + lib.grouped.leaf);`,
         ``,
       ].join("\n"),

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_the_entry_after_spaced_tsgo_flag_values.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_runs_the_entry_after_spaced_tsgo_flag_values.ts
@@ -1,0 +1,61 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx runs the entry when space-valued tsgo flags precede it and keeps
+ * the program tail out of tsgo.
+ *
+ * With `forwardAfterFirstPositional`, the old parser treated the `es2020` of a
+ * pre-entry `--target es2020` as the first positional sentinel, so the real
+ * entry was routed into the program tail and ttsx died with "entry file is
+ * required" before ever invoking tsgo. The entry must instead be found after the
+ * forwarded pairs, and post-entry tokens must reach the program's argv, never
+ * tsgo's option parser.
+ *
+ * 1. Create a CJS entry that prints `process.argv.slice(2)` as JSON.
+ * 2. Run `ttsx --target es2020 --module commonjs src/main.ts alpha beta`.
+ * 3. Assert a zero exit, no "entry file is required" / "Unknown compiler option",
+ *    and that the entry received exactly `["alpha", "beta"]`.
+ */
+export const test_ttsx_runs_the_entry_after_spaced_tsgo_flag_values = () => {
+  const root = TestProject.createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "commonjs",
+        strict: true,
+        outDir: "dist",
+        rootDir: "src",
+      },
+      include: ["src"],
+    }),
+    "src/main.ts": [
+      `declare const process: { argv: string[] };`,
+      `console.log(JSON.stringify(process.argv.slice(2)));`,
+      ``,
+    ].join("\n"),
+  });
+
+  const result = TestProject.spawn(
+    TestProject.TTSX_BIN,
+    [
+      "--cwd",
+      root,
+      "--target",
+      "es2020",
+      "--module",
+      "commonjs",
+      "src/main.ts",
+      "alpha",
+      "beta",
+    ],
+    { cwd: root },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(
+    `${result.stdout}${result.stderr}`,
+    /entry file is required|Unknown compiler option/i,
+  );
+  assert.deepEqual(JSON.parse(result.stdout.trim()), ["alpha", "beta"]);
+};

--- a/tests/test-ttsc/src/internal/dependency-cache.ts
+++ b/tests/test-ttsc/src/internal/dependency-cache.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared helpers for the ttsx dependency-cache regressions
+ * (`acquireDependencyBuildLock`, `releaseDependencyBuildLock`,
+ * `reclaimDependencyBuildLock`, `inspectDependencyBuildLock`,
+ * `readDependencyCache`). These drive the fenced generation protocol in
+ * `runtimeHooks.ts` directly, with real child processes held at explicit
+ * barrier files instead of sleeps, so a stale-observer / delayed-finalizer
+ * interleaving is deterministic rather than timing-dependent.
+ */
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import child_process from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  acquireDependencyBuildLock,
+  inspectDependencyBuildLock,
+  readDependencyCache,
+  reclaimDependencyBuildLock,
+  releaseDependencyBuildLock,
+} from "../../../../packages/ttsc/lib/launcher/internal/runtimeHooks.js";
+
+/** Captured output of one dependency-cache lock worker. */
+interface IDependencyCacheWorkerResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Spawn a Node.js worker script and capture its complete result. */
+function spawnNodeWorker(opts: {
+  env?: Record<string, string>;
+  script: string;
+  timeoutMs?: number;
+}): Promise<IDependencyCacheWorkerResult> {
+  return new Promise((resolve, reject) => {
+    const child = child_process.spawn(process.execPath, [opts.script], {
+      env: { ...process.env, ...opts.env },
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: opts.timeoutMs ?? 120_000,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+/** Absolute path to the built runtime-hooks module used by lock workers. */
+function dependencyCacheLibraryPath(): string {
+  return path.join(
+    TestProject.WORKSPACE_ROOT,
+    "packages",
+    "ttsc",
+    "lib",
+    "launcher",
+    "internal",
+    "runtimeHooks.js",
+  );
+}
+
+/**
+ * A CommonJS worker that acquires the lock, records its lease, waits for a
+ * release barrier file, then runs its normal `finally` release. The role is
+ * fixed only by the lease/release/result barrier files passed in the
+ * environment, so the same script drives both a held generation and its
+ * successor.
+ */
+function writeLockHolderScript(root: string, lockDir: string): string {
+  const libraryPath = dependencyCacheLibraryPath();
+  const script = path.join(root, "lock-holder.cjs");
+  fs.writeFileSync(
+    script,
+    [
+      `const fs = require("node:fs");`,
+      `const { acquireDependencyBuildLock, releaseDependencyBuildLock } = require(${JSON.stringify(
+        libraryPath,
+      )});`,
+      `const lockDir = ${JSON.stringify(lockDir)};`,
+      `const leaseFile = process.env.LOCK_LEASE_FILE;`,
+      `const releaseFile = process.env.LOCK_RELEASE_FILE;`,
+      `const resultFile = process.env.LOCK_RESULT_FILE;`,
+      `let lease = null;`,
+      `const acquireDeadline = Date.now() + 120000;`,
+      `while (lease === null) {`,
+      `  lease = acquireDependencyBuildLock(lockDir);`,
+      `  if (lease === null) {`,
+      `    if (Date.now() > acquireDeadline) throw new Error("timed out acquiring lock");`,
+      `    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);`,
+      `  }`,
+      `}`,
+      `fs.writeFileSync(leaseFile, JSON.stringify(lease), "utf8");`,
+      `const releaseDeadline = Date.now() + 120000;`,
+      `while (!fs.existsSync(releaseFile)) {`,
+      `  if (Date.now() > releaseDeadline) throw new Error("timed out waiting to release");`,
+      `  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);`,
+      `}`,
+      `const released = releaseDependencyBuildLock(lockDir, lease);`,
+      `fs.writeFileSync(resultFile, JSON.stringify({ released }), "utf8");`,
+      ``,
+    ].join("\n"),
+    "utf8",
+  );
+  return script;
+}
+
+/**
+ * Polls `predicate` every 25 ms until it holds, failing with `description`
+ * after `timeoutMs`. This observes an explicit barrier another process
+ * definitely produces; correctness never depends on how long the wait took.
+ */
+async function waitForCondition(
+  predicate: () => boolean,
+  description: string,
+  timeoutMs = 60_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+export {
+  acquireDependencyBuildLock,
+  assert,
+  dependencyCacheLibraryPath,
+  fs,
+  inspectDependencyBuildLock,
+  path,
+  readDependencyCache,
+  reclaimDependencyBuildLock,
+  releaseDependencyBuildLock,
+  spawnNodeWorker,
+  waitForCondition,
+  writeLockHolderScript,
+};

--- a/website/src/content/docs/development/index.mdx
+++ b/website/src/content/docs/development/index.mdx
@@ -66,6 +66,6 @@ v1 protocol, still moving. Don't publish `ttsc` as a peer dependency yet. Treat 
 
 ## Requirements
 
-- Node.js 18+: install from [nodejs.org/download](https://nodejs.org/en/download) if you don't have it.
+- Node.js 22.15+: install from [nodejs.org/download](https://nodejs.org/en/download) if you don't have it. The `ttsx` runner installs synchronous module hooks (`module.registerHooks`, added in Node 22.15.0) and strips types with `module.stripTypeScriptTypes` (Node 22.13.0), so it requires Node 22.15.0 or a later LTS; `ttsc` refuses an older runtime with an actionable version message instead of failing on a missing internal API, and the package's `engines.node` field surfaces the same floor at install time.
 - Go 1.22+ for direct `go test` / `go vet` against your plugin: install from [go.dev/dl](https://go.dev/dl/). `ttsc`'s bundled toolchain (shipped in the platform package) is what actually builds plugins on consumer machines; a system Go is only needed for local-dev workflows. The shipped plugins (and the `go.mod` examples in this chapter) target `go 1.26` because that is the bundled SDK; the bundled toolchain satisfies the `go` directive regardless of your system Go version.
 - A consumer test fixture with `ttsc` and `typescript` installed.


### PR DESCRIPTION
## Bundle b1 — ttsx / CLI launcher runtime

Repository-audit-2026-07 campaign batch covering the shared launcher flag
parser, the ttsx source runtime hooks, and the Node.js support contract. All
four issues touch the launcher/runtime surface and share verification.

### Issues

- Closes #663 (RA-02) — preserve unknown tsgo flag/value adjacency in `ttsc`
  and `ttsx`. The parser now classifies a bare token as a genuine positional or
  a forwarded flag value in place, so `--flag value` pairs reach tsgo in order
  and the ttsx entry is never mistaken for a flag value.
- Closes #668 (RA-10) — ignore comments and string/template-literal text during
  CommonJS export-name discovery, so a decoy `exports.x =` inside inert lexical
  text no longer leaks a phantom ESM export.
- Closes #678 (RA-25) — align the ttsx runtime with a single truthful Node.js
  floor (22.15.0): `engines.node`, an actionable launcher diagnostic, and the
  setup-guide requirement now agree.
- Closes #662 (RA-01) — fence ttsx dependency-cache generations and publish
  complete emits atomically. (In progress in this branch.)

### Verification

Package-scoped launcher + ttsx-runtime suites plus `pnpm run check:flags`;
exact commands and results posted on the thread. Campaign CI is cancelled per
the exact-SHA gate after every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYCpGEc14zxD99ZPPzAnpz
