### PR TITLE
fix(ttsc): derive emitted plugin aliases without a suffix ceiling

### DIFF
--- a/packages/ttsc/driver/rewrite.go
+++ b/packages/ttsc/driver/rewrite.go
@@ -598,6 +598,7 @@ func rewriteAliases(r Rewrite, emittedBindings map[string][]emittedImportBinding
   }
   candidates := []emittedImportBinding{}
   preferred := []emittedImportBinding{}
+  sourceBindings := sourceTopLevelVariableNames(r.File)
   wantKind := emittedImportDirect
   switch imported.kind {
   case sourceImportDefault:
@@ -606,6 +607,9 @@ func rewriteAliases(r Rewrite, emittedBindings map[string][]emittedImportBinding
     wantKind = emittedImportNamespace
   }
   for _, binding := range emittedBindings[imported.module] {
+    if _, sourceOwned := sourceBindings[binding.name]; sourceOwned {
+      continue
+    }
     if !emittedNameForRoot(binding.name, r.RootName) {
       continue
     }
@@ -677,6 +681,39 @@ func sourceImportForRoot(file *ast.SourceFile, root string) (sourceImport, bool)
     }
   }
   return sourceImport{}, false
+}
+
+func sourceTopLevelVariableNames(file *ast.SourceFile) map[string]struct{} {
+  names := map[string]struct{}{}
+  if file == nil || file.Statements == nil {
+    return names
+  }
+  for _, statement := range file.Statements.Nodes {
+    if statement == nil || statement.Kind != ast.KindVariableStatement {
+      continue
+    }
+    variables := statement.AsVariableStatement()
+    if variables == nil || variables.DeclarationList == nil {
+      continue
+    }
+    declarations := variables.DeclarationList.AsVariableDeclarationList()
+    if declarations == nil || declarations.Declarations == nil {
+      continue
+    }
+    for _, declaration := range declarations.Declarations.Nodes {
+      if declaration == nil {
+        continue
+      }
+      variable := declaration.AsVariableDeclaration()
+      if variable == nil {
+        continue
+      }
+      if name := identifierName(variable.Name()); name != "" {
+        names[name] = struct{}{}
+      }
+    }
+  }
+  return names
 }
 
 func emittedNameForRoot(name, root string) bool {

--- a/packages/ttsc/driver/rewrite.go
+++ b/packages/ttsc/driver/rewrite.go
@@ -400,6 +400,8 @@ const (
   emittedImportDirect emittedImportKind = iota
   emittedImportDefault
   emittedImportNamespace
+  emittedImportRetainedDefault
+  emittedImportRetainedNamespace
 )
 
 type emittedImportBinding struct {
@@ -418,7 +420,14 @@ func collectEmittedImportBindings(outputName, text string) map[string][]emittedI
     return bindings
   }
   for _, statement := range file.Statements.Nodes {
-    if statement == nil || statement.Kind != ast.KindVariableStatement {
+    if statement == nil {
+      continue
+    }
+    if statement.Kind == ast.KindImportDeclaration {
+      collectRetainedImportBinding(bindings, statement.AsImportDeclaration())
+      continue
+    }
+    if statement.Kind != ast.KindVariableStatement {
       continue
     }
     variables := statement.AsVariableStatement()
@@ -446,6 +455,33 @@ func collectEmittedImportBindings(outputName, text string) map[string][]emittedI
     }
   }
   return bindings
+}
+
+func collectRetainedImportBinding(bindings map[string][]emittedImportBinding, declaration *ast.ImportDeclaration) {
+  if declaration == nil || declaration.ImportClause == nil {
+    return
+  }
+  module, ok := stringLiteralValue(declaration.ModuleSpecifier)
+  if !ok {
+    return
+  }
+  clause := declaration.ImportClause.AsImportClause()
+  if clause == nil {
+    return
+  }
+  if name := identifierName(clause.Name()); name != "" {
+    bindings[module] = append(bindings[module], emittedImportBinding{name: name, kind: emittedImportRetainedDefault})
+  }
+  if clause.NamedBindings == nil || clause.NamedBindings.Kind != ast.KindNamespaceImport {
+    return
+  }
+  namespace := clause.NamedBindings.AsNamespaceImport()
+  if namespace == nil {
+    return
+  }
+  if name := identifierName(namespace.Name()); name != "" {
+    bindings[module] = append(bindings[module], emittedImportBinding{name: name, kind: emittedImportRetainedNamespace})
+  }
 }
 
 // emittedRequireModule recognizes the declaration shapes TypeScript-Go owns
@@ -548,6 +584,17 @@ func rewriteAliases(r Rewrite, emittedBindings map[string][]emittedImportBinding
   imported, ok := sourceImportForRoot(r.File, r.RootName)
   if !ok {
     return []string{r.RootName + ".default", r.RootName}
+  }
+  retainedKind := emittedImportRetainedDefault
+  if imported.kind == sourceImportNamespace {
+    retainedKind = emittedImportRetainedNamespace
+  }
+  if imported.kind != sourceImportEquals {
+    for _, binding := range emittedBindings[imported.module] {
+      if binding.name == r.RootName && binding.kind == retainedKind {
+        return []string{r.RootName}
+      }
+    }
   }
   candidates := []emittedImportBinding{}
   preferred := []emittedImportBinding{}

--- a/packages/ttsc/driver/rewrite.go
+++ b/packages/ttsc/driver/rewrite.go
@@ -248,9 +248,14 @@ func applyRewrites(outputName, text string, rs *RewriteSet, cursors map[string]i
   pos := cursors[srcPath]
   out := text
   searchFrom := 0
+  aliasesByRoot := map[string][]string{}
   for pos < len(rewrites) {
     r := rewrites[pos]
-    aliases := rewriteAliases(r, emittedBindings)
+    aliases, cached := aliasesByRoot[r.RootName]
+    if !cached {
+      aliases = rewriteAliases(r, emittedBindings)
+      aliasesByRoot[r.RootName] = aliases
+    }
     replaced, nextSearchFrom, ok, err := spliceCallWithAliases(out, r, aliases, searchFrom)
     if err != nil {
       return "", err

--- a/packages/ttsc/driver/rewrite.go
+++ b/packages/ttsc/driver/rewrite.go
@@ -27,10 +27,15 @@ import (
 
   "github.com/microsoft/typescript-go/shim/ast"
   shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+  shimcore "github.com/microsoft/typescript-go/shim/core"
+  shimparser "github.com/microsoft/typescript-go/shim/parser"
 )
 
 // Rewrite describes one emit-time patch. Produced by CollectCallSites after
-// the engine has generated a replacement JS fragment for the call.
+// the engine has generated a replacement JS fragment for the call. When
+// RootName names a default or namespace import, emit resolves it through the
+// matching emitted require declaration, including any collision suffix chosen
+// by TypeScript-Go.
 type Rewrite struct {
   File          *ast.SourceFile
   RootName      string
@@ -233,12 +238,20 @@ func applyRewrites(outputName, text string, rs *RewriteSet, cursors map[string]i
     return text, nil
   }
   rewrites := rs.byPath[srcPath]
+  emittedBindings := map[string][]emittedImportBinding{}
+  for _, rewrite := range rewrites {
+    if _, imported := sourceImportForRoot(rewrite.File, rewrite.RootName); imported {
+      emittedBindings = collectEmittedImportBindings(outputName, text)
+      break
+    }
+  }
   pos := cursors[srcPath]
   out := text
   searchFrom := 0
   for pos < len(rewrites) {
     r := rewrites[pos]
-    replaced, nextSearchFrom, ok, err := spliceCall(out, r, searchFrom)
+    aliases := rewriteAliases(r, emittedBindings)
+    replaced, nextSearchFrom, ok, err := spliceCallWithAliases(out, r, aliases, searchFrom)
     if err != nil {
       return "", err
     }
@@ -247,7 +260,7 @@ func applyRewrites(outputName, text string, rs *RewriteSet, cursors map[string]i
       if len(preview) > 400 {
         preview = preview[:400] + "…"
       }
-      return "", fmt.Errorf("driver: could not locate %s.%s(…) call in %s (tried roots %v; preview: %q)", joinRootAndNamespaces(r), r.Method, outputName, candidateRoots(r.RootName), preview)
+      return "", fmt.Errorf("driver: could not locate %s.%s(…) call in %s (tried roots %v; preview: %q)", joinRootAndNamespaces(r), r.Method, outputName, aliases, preview)
     }
     out = replaced
     searchFrom = nextSearchFrom
@@ -349,7 +362,15 @@ func sourceTail(srcPath, commonDir string) string {
 // Returns the patched text, the byte position to resume from on the next
 // call, a found flag, and any error from the paren-matching step.
 func spliceCall(text string, r Rewrite, searchFrom int) (string, int, bool, error) {
-  aliases := candidateRoots(r.RootName)
+  emittedBindings := map[string][]emittedImportBinding{}
+  if _, imported := sourceImportForRoot(r.File, r.RootName); imported {
+    emittedBindings = collectEmittedImportBindings("/rewrite.js", text)
+  }
+  aliases := rewriteAliases(r, emittedBindings)
+  return spliceCallWithAliases(text, r, aliases, searchFrom)
+}
+
+func spliceCallWithAliases(text string, r Rewrite, aliases []string, searchFrom int) (string, int, bool, error) {
   pattern := callRegexFor(aliases, r.Namespaces, r.Method)
   idx, needleLen := findCallMatch(text, pattern, searchFrom)
   if idx < 0 {
@@ -366,6 +387,265 @@ func spliceCall(text string, r Rewrite, searchFrom int) (string, int, bool, erro
   }
   replaced := text[:idx] + r.Replacement + text[idx+needleLen:]
   return replaced, idx + len(r.Replacement), true, nil
+}
+
+// collectEmittedImportBindings recovers the identifiers TypeScript-Go
+// actually assigned to top-level CommonJS imports in one emitted JavaScript
+// file. The source-level import name is not enough: the emitter owns collision
+// suffixes and may choose any free number. Parsing the emitted declarations
+// keeps alias discovery coupled to that output instead of guessing a maximum.
+type emittedImportKind uint8
+
+const (
+  emittedImportDirect emittedImportKind = iota
+  emittedImportDefault
+  emittedImportNamespace
+)
+
+type emittedImportBinding struct {
+  name string
+  kind emittedImportKind
+}
+
+func collectEmittedImportBindings(outputName, text string) map[string][]emittedImportBinding {
+  parseName := filepath.ToSlash(outputName)
+  if !filepath.IsAbs(outputName) {
+    parseName = "/" + strings.TrimPrefix(parseName, "/")
+  }
+  file := shimparser.ParseSourceFile(ast.SourceFileParseOptions{FileName: parseName}, text, shimcore.ScriptKindJS)
+  bindings := map[string][]emittedImportBinding{}
+  if file == nil || file.Statements == nil {
+    return bindings
+  }
+  for _, statement := range file.Statements.Nodes {
+    if statement == nil || statement.Kind != ast.KindVariableStatement {
+      continue
+    }
+    variables := statement.AsVariableStatement()
+    if variables == nil || variables.DeclarationList == nil {
+      continue
+    }
+    declarations := variables.DeclarationList.AsVariableDeclarationList()
+    if declarations == nil || declarations.Declarations == nil {
+      continue
+    }
+    for _, declaration := range declarations.Declarations.Nodes {
+      if declaration == nil {
+        continue
+      }
+      variable := declaration.AsVariableDeclaration()
+      if variable == nil {
+        continue
+      }
+      name := identifierName(variable.Name())
+      module, kind, ok := emittedRequireModule(variable.Initializer)
+      if name == "" || !ok {
+        continue
+      }
+      bindings[module] = append(bindings[module], emittedImportBinding{name: name, kind: kind})
+    }
+  }
+  return bindings
+}
+
+// emittedRequireModule recognizes the declaration shapes TypeScript-Go owns
+// for CommonJS imports: a direct require or a require wrapped in its
+// __importDefault/__importStar helper. User calls with other wrappers are not
+// import declarations and therefore cannot become rewrite aliases.
+func emittedRequireModule(node *ast.Node) (string, emittedImportKind, bool) {
+  node = unwrapParentheses(node)
+  if node == nil || node.Kind != ast.KindCallExpression {
+    return "", emittedImportDirect, false
+  }
+  call := node.AsCallExpression()
+  if call == nil || call.QuestionDotToken != nil || call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
+    return "", emittedImportDirect, false
+  }
+  if identifierName(call.Expression) == "require" {
+    module, ok := stringLiteralValue(call.Arguments.Nodes[0])
+    return module, emittedImportDirect, ok
+  }
+  helper := callExpressionName(call.Expression)
+  if helper != "__importDefault" && helper != "__importStar" {
+    return "", emittedImportDirect, false
+  }
+  module, _, ok := emittedRequireModule(call.Arguments.Nodes[0])
+  if !ok {
+    return "", emittedImportDirect, false
+  }
+  if helper == "__importDefault" {
+    return module, emittedImportDefault, true
+  }
+  return module, emittedImportNamespace, true
+}
+
+func callExpressionName(node *ast.Node) string {
+  node = unwrapParentheses(node)
+  if name := identifierName(node); name != "" {
+    return name
+  }
+  if node == nil || node.Kind != ast.KindPropertyAccessExpression {
+    return ""
+  }
+  access := node.AsPropertyAccessExpression()
+  if access == nil {
+    return ""
+  }
+  return identifierName(access.Name())
+}
+
+func unwrapParentheses(node *ast.Node) *ast.Node {
+  for node != nil && node.Kind == ast.KindParenthesizedExpression {
+    expression := node.AsParenthesizedExpression()
+    if expression == nil || expression.Expression == nil {
+      return nil
+    }
+    node = expression.Expression
+  }
+  return node
+}
+
+func identifierName(node *ast.Node) string {
+  if node == nil || node.Kind != ast.KindIdentifier {
+    return ""
+  }
+  identifier := node.AsIdentifier()
+  if identifier == nil {
+    return ""
+  }
+  return identifier.Text
+}
+
+func stringLiteralValue(node *ast.Node) (string, bool) {
+  if node == nil || node.Kind != ast.KindStringLiteral {
+    return "", false
+  }
+  literal := node.AsStringLiteral()
+  if literal == nil {
+    return "", false
+  }
+  return literal.Text, true
+}
+
+// rewriteAliases binds one source import to the identifiers recovered from its
+// emitted require declaration. Retained ESM imports and non-import roots keep
+// their source spelling; CommonJS imports use only emitter-owned bindings so a
+// nearby identifier cannot be mistaken for the plugin call.
+type sourceImportKind uint8
+
+const (
+  sourceImportDefault sourceImportKind = iota
+  sourceImportNamespace
+  sourceImportEquals
+)
+
+type sourceImport struct {
+  module string
+  kind   sourceImportKind
+}
+
+func rewriteAliases(r Rewrite, emittedBindings map[string][]emittedImportBinding) []string {
+  imported, ok := sourceImportForRoot(r.File, r.RootName)
+  if !ok {
+    return []string{r.RootName + ".default", r.RootName}
+  }
+  candidates := []emittedImportBinding{}
+  preferred := []emittedImportBinding{}
+  wantKind := emittedImportDirect
+  switch imported.kind {
+  case sourceImportDefault:
+    wantKind = emittedImportDefault
+  case sourceImportNamespace:
+    wantKind = emittedImportNamespace
+  }
+  for _, binding := range emittedBindings[imported.module] {
+    if !emittedNameForRoot(binding.name, r.RootName) {
+      continue
+    }
+    candidates = append(candidates, binding)
+    if binding.kind == wantKind {
+      preferred = append(preferred, binding)
+    }
+  }
+  var binding emittedImportBinding
+  switch {
+  case len(preferred) == 1:
+    binding = preferred[0]
+  case len(preferred) > 1:
+    return []string{r.RootName}
+  case len(candidates) == 1:
+    binding = candidates[0]
+  case len(candidates) > 1:
+    return []string{r.RootName}
+  default:
+    // An ESM emit retains the source binding instead of creating a require.
+    return []string{r.RootName}
+  }
+  if imported.kind == sourceImportDefault {
+    return []string{binding.name + ".default"}
+  }
+  return []string{binding.name}
+}
+
+func sourceImportForRoot(file *ast.SourceFile, root string) (sourceImport, bool) {
+  if file == nil || file.Statements == nil {
+    return sourceImport{}, false
+  }
+  for _, statement := range file.Statements.Nodes {
+    if statement == nil {
+      continue
+    }
+    switch statement.Kind {
+    case ast.KindImportDeclaration:
+      declaration := statement.AsImportDeclaration()
+      if declaration == nil || declaration.ImportClause == nil {
+        continue
+      }
+      clause := declaration.ImportClause.AsImportClause()
+      if clause == nil {
+        continue
+      }
+      if identifierName(clause.Name()) == root {
+        module, ok := stringLiteralValue(declaration.ModuleSpecifier)
+        return sourceImport{module: module, kind: sourceImportDefault}, ok
+      }
+      if clause.NamedBindings != nil && clause.NamedBindings.Kind == ast.KindNamespaceImport {
+        namespace := clause.NamedBindings.AsNamespaceImport()
+        if namespace != nil && identifierName(namespace.Name()) == root {
+          module, ok := stringLiteralValue(declaration.ModuleSpecifier)
+          return sourceImport{module: module, kind: sourceImportNamespace}, ok
+        }
+      }
+    case ast.KindImportEqualsDeclaration:
+      declaration := statement.AsImportEqualsDeclaration()
+      if declaration == nil || identifierName(declaration.Name()) != root || declaration.ModuleReference == nil ||
+        declaration.ModuleReference.Kind != ast.KindExternalModuleReference {
+        continue
+      }
+      reference := declaration.ModuleReference.AsExternalModuleReference()
+      if reference != nil {
+        module, ok := stringLiteralValue(reference.Expression)
+        return sourceImport{module: module, kind: sourceImportEquals}, ok
+      }
+    }
+  }
+  return sourceImport{}, false
+}
+
+func emittedNameForRoot(name, root string) bool {
+  if name == root {
+    return true
+  }
+  suffix := strings.TrimPrefix(name, root+"_")
+  if suffix == "" || suffix == name {
+    return false
+  }
+  for _, ch := range suffix {
+    if ch < '0' || ch > '9' {
+      return false
+    }
+  }
+  return true
 }
 
 // callRegexFor compiles the loose-match needle pattern used by spliceCall.
@@ -441,22 +721,6 @@ func findCallMatch(text string, pattern *regexp.Regexp, searchFrom int) (int, in
     return matchStart, parenStart - matchStart
   }
   return -1, 0
-}
-
-// candidateRoots expands a bare module name into the set of identifier stems
-// tsgo's CommonJS emitter may produce for it. For example "typia" becomes
-// ["typia", "typia_1.default", "typia_2.default", "typia.default",
-// "typia_1", "typia_2"]. The regex alternation built from these candidates
-// matches the emitted call regardless of which deduplication suffix tsgo chose.
-func candidateRoots(root string) []string {
-  return []string{
-    root,
-    root + "_1.default",
-    root + "_2.default",
-    root + ".default",
-    root + "_1",
-    root + "_2",
-  }
 }
 
 // joinRootAndNamespaces returns the human-readable "root.ns1.ns2" form of

--- a/packages/ttsc/go.mod
+++ b/packages/ttsc/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/microsoft/typescript-go/shim/compiler v0.0.0
 	github.com/microsoft/typescript-go/shim/core v0.0.0
 	github.com/microsoft/typescript-go/shim/diagnosticwriter v0.0.0
+	github.com/microsoft/typescript-go/shim/parser v0.0.0
 	github.com/microsoft/typescript-go/shim/printer v0.0.0
 	github.com/microsoft/typescript-go/shim/scanner v0.0.0
 	github.com/microsoft/typescript-go/shim/tsoptions v0.0.0

--- a/packages/ttsc/test/driver/helpers_test.go
+++ b/packages/ttsc/test/driver/helpers_test.go
@@ -10,6 +10,16 @@ import (
   "github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
+// readFileForTest returns one fixture artifact as text.
+func readFileForTest(t *testing.T, path string) string {
+  t.Helper()
+  contents, err := os.ReadFile(path)
+  if err != nil {
+    t.Fatal(err)
+  }
+  return string(contents)
+}
+
 // writeProjectFile materializes one project-shaped fixture file. The tests in
 // this package intentionally build real tsconfig projects instead of mocking
 // compiler internals, so each scenario owns its whole temporary project tree.

--- a/packages/ttsc/test/driver/rewrite_derives_alias_from_owned_require_declaration_test.go
+++ b/packages/ttsc/test/driver/rewrite_derives_alias_from_owned_require_declaration_test.go
@@ -1,0 +1,102 @@
+package driver_test
+
+import (
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverRewriteDerivesAliasFromOwnedRequireDeclaration verifies decoy
+// identifiers do not compete with the import declaration that owns a rewrite.
+//
+// An unbounded identifier regex would remove the suffix ceiling but could
+// rewrite `plugin_99.make` merely because its name looks generated. Matching
+// the source module to the emitted require declaration rejects that decoy and
+// still supports multiple ordered rewrites for the real import.
+//
+// 1. Place a generated-looking decoy call before a colliding default import.
+// 2. Register two rewrites for the imported plugin's two calls.
+// 3. Execute the output and assert the decoy survives beside both replacements.
+func TestDriverRewriteDerivesAliasFromOwnedRequireDeclaration(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true
+  },
+  "files": ["index.ts", "plugin.ts"]
+}
+`)
+  writeProjectFile(t, root, "plugin.ts", `export default {
+  make(input: string): string {
+    return "plugin:" + input;
+  }
+};
+`)
+  writeProjectFile(t, root, "index.ts", `declare function require(path: string): {
+  default: { make(input: string): string };
+};
+const plugin_99 = require("./plugin");
+import plugin from "./plugin";
+export const decoy = plugin_99.default.make("kept");
+export const first = plugin.make("first");
+export const second = plugin.make("second");
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+  file := prog.SourceFile(filepath.Join(root, "index.ts"))
+  if file == nil {
+    t.Fatal("SourceFile did not find index.ts")
+  }
+  rewrites := driver.NewRewriteSet()
+  rewrites.Add(driver.Rewrite{
+    File:          file,
+    RootName:      "plugin",
+    Method:        "make",
+    Replacement:   `"rewritten-first"`,
+    ConsumeParens: true,
+  })
+  rewrites.Add(driver.Rewrite{
+    File:          file,
+    RootName:      "plugin",
+    Method:        "make",
+    Replacement:   `"rewritten-second"`,
+    ConsumeParens: true,
+  })
+  _, emitDiags, err := prog.EmitAll(rewrites, nil)
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+  jsPath := filepath.Join(root, "bin", "index.js")
+  js := readFileForTest(t, jsPath)
+  if !strings.Contains(js, `plugin_99.default.make("kept")`) {
+    t.Fatalf("decoy call was rewritten:\n%s", js)
+  }
+  command := exec.Command("node", "-e", `const v = require("./index.js"); process.stdout.write(JSON.stringify(v))`)
+  command.Dir = filepath.Dir(jsPath)
+  output, err := command.CombinedOutput()
+  if err != nil {
+    t.Fatalf("rewritten JavaScript failed: %v\n%s", err, output)
+  }
+  got := string(output)
+  for _, want := range []string{`"decoy":"plugin:kept"`, `"first":"rewritten-first"`, `"second":"rewritten-second"`} {
+    if !strings.Contains(got, want) {
+      t.Fatalf("runtime output missing %s: %s\n%s", want, got, js)
+    }
+  }
+}

--- a/packages/ttsc/test/driver/rewrite_derives_emitted_aliases_without_suffix_ceiling_test.go
+++ b/packages/ttsc/test/driver/rewrite_derives_emitted_aliases_without_suffix_ceiling_test.go
@@ -1,0 +1,118 @@
+package driver_test
+
+import (
+  "fmt"
+  "os/exec"
+  "path/filepath"
+  "regexp"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverRewriteDerivesEmittedAliasesWithoutSuffixCeiling verifies rewrites
+// follow TypeScript-Go's actual CommonJS binding at every collision depth.
+//
+// The driver used to enumerate only the bare root, `_1`, and `_2`. That made a
+// valid default import fail as soon as ordinary locals pushed the emitter to
+// `_3`; a substantially higher case proves the repair has no new finite cap.
+//
+// 1. Compile bare-root and default-import cases for suffixes 0, 1, 2, 3, and 16.
+// 2. Register the same source-level rewrite through the public driver API.
+// 3. Assert the actual emitted alias, successful emit, and rewritten runtime value.
+func TestDriverRewriteDerivesEmittedAliasesWithoutSuffixCeiling(t *testing.T) {
+  cases := []struct {
+    name       string
+    suffix     int
+    collisions int
+    ambient    bool
+  }{
+    {name: "suffix_0_bare_root", suffix: 0, ambient: true},
+    {name: "suffix_1", suffix: 1},
+    {name: "suffix_2", suffix: 2, collisions: 1},
+    {name: "suffix_3", suffix: 3, collisions: 2},
+    {name: "suffix_16", suffix: 16, collisions: 15},
+  }
+  for _, test := range cases {
+    t.Run(test.name, func(t *testing.T) {
+      root := t.TempDir()
+      writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true
+  },
+  "files": ["index.ts", "plugin.ts"]
+}
+`)
+      writeProjectFile(t, root, "plugin.ts", `export default {
+  make(input: string): string {
+    return "plugin:" + input;
+  }
+};
+`)
+      var source strings.Builder
+      if test.ambient {
+        source.WriteString("declare const plugin: { make(input: string): string };\n")
+      } else {
+        for i := 1; i <= test.collisions; i++ {
+          fmt.Fprintf(&source, "const plugin_%d = %d;\n", i, i)
+        }
+        source.WriteString(`import plugin from "./plugin";
+`)
+      }
+      source.WriteString(`export const value = plugin.make("input");
+`)
+      writeProjectFile(t, root, "index.ts", source.String())
+
+      prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+      if err != nil {
+        t.Fatal(err)
+      }
+      if len(diags) != 0 {
+        t.Fatalf("unexpected config diagnostics: %#v", diags)
+      }
+      defer prog.Close()
+      file := prog.SourceFile(filepath.Join(root, "index.ts"))
+      if file == nil {
+        t.Fatal("SourceFile did not find index.ts")
+      }
+      rewrites := driver.NewRewriteSet()
+      want := "rewritten-" + test.name
+      rewrites.Add(driver.Rewrite{
+        File:          file,
+        RootName:      "plugin",
+        Method:        "make",
+        Replacement:   fmt.Sprintf("%q", want),
+        ConsumeParens: true,
+      })
+      _, emitDiags, err := prog.EmitAll(rewrites, nil)
+      if err != nil {
+        t.Fatal(err)
+      }
+      if len(emitDiags) != 0 {
+        t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+      }
+      jsPath := filepath.Join(root, "bin", "index.js")
+      js := readFileForTest(t, jsPath)
+      if !test.ambient {
+        binding := regexp.MustCompile(`const (plugin(?:_\d+)?) = __importDefault\(require\("\./plugin"\)\);`).FindStringSubmatch(js)
+        expected := fmt.Sprintf("plugin_%d", test.suffix)
+        if len(binding) != 2 || binding[1] != expected {
+          t.Fatalf("emitted binding mismatch: got %v, want %q\n%s", binding, expected, js)
+        }
+      }
+      command := exec.Command("node", "-e", `process.stdout.write(String(require("./index.js").value))`)
+      command.Dir = filepath.Dir(jsPath)
+      output, err := command.CombinedOutput()
+      if err != nil {
+        t.Fatalf("rewritten JavaScript failed: %v\n%s", err, output)
+      }
+      if string(output) != want {
+        t.Fatalf("runtime value = %q, want %q\n%s", output, want, js)
+      }
+    })
+  }
+}

--- a/packages/ttsc/test/driver/rewrite_derives_namespace_import_bare_binding_test.go
+++ b/packages/ttsc/test/driver/rewrite_derives_namespace_import_bare_binding_test.go
@@ -1,0 +1,92 @@
+package driver_test
+
+import (
+  "fmt"
+  "os/exec"
+  "path/filepath"
+  "regexp"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverRewriteDerivesNamespaceImportBareBinding verifies a namespace
+// import uses the emitter-owned bare binding recovered from its declaration.
+//
+// Namespace calls omit `.default`, so default-import coverage alone could hide
+// a repair that derives the declaration but still constructs the wrong call
+// head. The same declaration-derived identity must serve both import forms,
+// including the unsuffixed namespace form TypeScript-Go deliberately retains.
+//
+// 1. Place fifteen generated-looking locals before a namespace import.
+// 2. Rewrite its call through public `EmitAll` and inspect the bare binding.
+// 3. Execute the emitted CommonJS file and assert the replacement value.
+func TestDriverRewriteDerivesNamespaceImportBareBinding(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true
+  },
+  "files": ["index.ts", "plugin.ts"]
+}
+`)
+  writeProjectFile(t, root, "plugin.ts", `export function make(input: string): string {
+  return "plugin:" + input;
+}
+`)
+  var source strings.Builder
+  for i := 1; i < 16; i++ {
+    fmt.Fprintf(&source, "const plugin_%d = %d;\n", i, i)
+  }
+  source.WriteString(`import * as plugin from "./plugin";
+export const value = plugin.make("input");
+`)
+  writeProjectFile(t, root, "index.ts", source.String())
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+  file := prog.SourceFile(filepath.Join(root, "index.ts"))
+  if file == nil {
+    t.Fatal("SourceFile did not find index.ts")
+  }
+  rewrites := driver.NewRewriteSet()
+  rewrites.Add(driver.Rewrite{
+    File:          file,
+    RootName:      "plugin",
+    Method:        "make",
+    Replacement:   `"rewritten-namespace"`,
+    ConsumeParens: true,
+  })
+  _, emitDiags, err := prog.EmitAll(rewrites, nil)
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+  jsPath := filepath.Join(root, "bin", "index.js")
+  js := readFileForTest(t, jsPath)
+  binding := regexp.MustCompile(`const (plugin(?:_\d+)?) = __importStar\(require\("\./plugin"\)\);`).FindStringSubmatch(js)
+  if len(binding) != 2 || binding[1] != "plugin" {
+    t.Fatalf("emitted namespace binding mismatch: %v\n%s", binding, js)
+  }
+  command := exec.Command("node", "-e", `process.stdout.write(String(require("./index.js").value))`)
+  command.Dir = filepath.Dir(jsPath)
+  output, err := command.CombinedOutput()
+  if err != nil {
+    t.Fatalf("rewritten JavaScript failed: %v\n%s", err, output)
+  }
+  if string(output) != "rewritten-namespace" {
+    t.Fatalf("runtime value = %q\n%s", output, js)
+  }
+}

--- a/packages/ttsc/test/driver/rewrite_excludes_source_owned_helper_declaration_test.go
+++ b/packages/ttsc/test/driver/rewrite_excludes_source_owned_helper_declaration_test.go
@@ -1,0 +1,108 @@
+package driver_test
+
+import (
+  "os/exec"
+  "path/filepath"
+  "regexp"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverRewriteExcludesSourceOwnedHelperDeclaration verifies helper shape
+// cannot make a source variable impersonate an emitter-owned import binding.
+//
+// A user variable may use the same __importDefault helper shape as the emitted
+// default import. Helper kind alone then leaves two preferred candidates and
+// cannot establish which declaration owns the source import.
+//
+// 1. Emit a default import beside a same-module, helper-shaped user decoy.
+// 2. Register one rewrite for the imported call through the public driver API.
+// 3. Execute the output and assert the decoy survives beside the replacement.
+func TestDriverRewriteExcludesSourceOwnedHelperDeclaration(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true,
+    "esModuleInterop": false
+  },
+  "files": ["index.ts", "plugin.ts"]
+}
+`)
+  writeProjectFile(t, root, "plugin.ts", `export default {
+  make(input: string): string {
+    return "plugin:" + input;
+  }
+};
+`)
+  writeProjectFile(t, root, "index.ts", `declare function require(path: string): {
+  default: { make(input: string): string };
+};
+function __importDefault<T>(value: T): T {
+  return value;
+}
+const plugin_99 = __importDefault(require("./plugin"));
+import plugin from "./plugin";
+export const decoy = plugin_99.default.make("kept");
+export const value = plugin.make("input");
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+  file := prog.SourceFile(filepath.Join(root, "index.ts"))
+  if file == nil {
+    t.Fatal("SourceFile did not find index.ts")
+  }
+  rewrites := driver.NewRewriteSet()
+  rewrites.Add(driver.Rewrite{
+    File:          file,
+    RootName:      "plugin",
+    Method:        "make",
+    Replacement:   `"rewritten-import"`,
+    ConsumeParens: true,
+  })
+  _, emitDiags, err := prog.EmitAll(rewrites, nil)
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+  jsPath := filepath.Join(root, "bin", "index.js")
+  js := readFileForTest(t, jsPath)
+  bindings := regexp.MustCompile(`const (plugin(?:_\d+)?) = __importDefault\(require\("\./plugin"\)\);`).FindAllStringSubmatch(js, -1)
+  emitted := ""
+  for _, binding := range bindings {
+    if len(binding) == 2 && binding[1] != "plugin_99" {
+      emitted = binding[1]
+    }
+  }
+  if emitted == "" {
+    t.Fatalf("emitter-owned default import binding was not found: %v\n%s", bindings, js)
+  }
+  if !strings.Contains(js, `plugin_99.default.make("kept")`) {
+    t.Fatalf("source-owned helper declaration was rewritten:\n%s", js)
+  }
+  command := exec.Command("node", "-e", `const v = require("./index.js"); process.stdout.write(JSON.stringify(v))`)
+  command.Dir = filepath.Dir(jsPath)
+  output, err := command.CombinedOutput()
+  if err != nil {
+    t.Fatalf("rewritten JavaScript failed: %v\n%s", err, output)
+  }
+  got := string(output)
+  for _, want := range []string{`"decoy":"plugin:kept"`, `"value":"rewritten-import"`} {
+    if !strings.Contains(got, want) {
+      t.Fatalf("runtime output missing %s: %s\n%s", want, got, js)
+    }
+  }
+}

--- a/packages/ttsc/test/driver/rewrite_prefers_retained_esm_import_over_require_decoy_test.go
+++ b/packages/ttsc/test/driver/rewrite_prefers_retained_esm_import_over_require_decoy_test.go
@@ -1,0 +1,100 @@
+package driver_test
+
+import (
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverRewritePrefersRetainedESMImportOverRequireDecoy verifies a
+// CommonJS-shaped local cannot impersonate an import retained in ESM output.
+//
+// The emitted declaration parser sees both user code and emitter-owned code.
+// When a real import remains in the output, its exact source-local identity
+// must win over a same-module helper/require declaration that merely resembles
+// the CommonJS emitter shape.
+//
+// 1. Emit ESM with a retained default import and a same-module require decoy.
+// 2. Register one rewrite for the imported call through the public driver API.
+// 3. Execute the module and assert only the imported call was replaced.
+func TestDriverRewritePrefersRetainedESMImportOverRequireDecoy(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "package.json", `{"type":"module"}
+`)
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true
+  },
+  "files": ["index.ts", "plugin.ts"]
+}
+`)
+  writeProjectFile(t, root, "plugin.ts", `export default {
+  make(input: string): string {
+    return "plugin:" + input;
+  }
+};
+`)
+  writeProjectFile(t, root, "index.ts", `function require(_path: string) {
+  return { default: { make: (input: string) => "decoy:" + input } };
+}
+function __importDefault<T>(value: T): T {
+  return value;
+}
+const plugin_99 = __importDefault(require("./plugin.js"));
+import plugin from "./plugin.js";
+export const decoy = plugin_99.default.make("kept");
+export const value = plugin.make("input");
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+  file := prog.SourceFile(filepath.Join(root, "index.ts"))
+  if file == nil {
+    t.Fatal("SourceFile did not find index.ts")
+  }
+  rewrites := driver.NewRewriteSet()
+  rewrites.Add(driver.Rewrite{
+    File:          file,
+    RootName:      "plugin",
+    Method:        "make",
+    Replacement:   `"rewritten-esm"`,
+    ConsumeParens: true,
+  })
+  _, emitDiags, err := prog.EmitAll(rewrites, nil)
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(emitDiags) != 0 {
+    t.Fatalf("unexpected emit diagnostics: %#v", emitDiags)
+  }
+  jsPath := filepath.Join(root, "bin", "index.js")
+  js := readFileForTest(t, jsPath)
+  if !strings.Contains(js, `plugin_99.default.make("kept")`) {
+    t.Fatalf("require-shaped decoy was rewritten:\n%s", js)
+  }
+  command := exec.Command("node", "--input-type=module", "-e", `const v = await import("./index.js"); process.stdout.write(JSON.stringify(v))`)
+  command.Dir = filepath.Dir(jsPath)
+  output, err := command.CombinedOutput()
+  if err != nil {
+    t.Fatalf("rewritten JavaScript failed: %v\n%s", err, output)
+  }
+  got := string(output)
+  for _, want := range []string{`"decoy":"decoy:kept"`, `"value":"rewritten-esm"`} {
+    if !strings.Contains(got, want) {
+      t.Fatalf("runtime output missing %s: %s\n%s", want, got, js)
+    }
+  }
+}

--- a/packages/ttsc/test/driver/rewrite_reports_actual_emitted_alias_for_missing_import_call_test.go
+++ b/packages/ttsc/test/driver/rewrite_reports_actual_emitted_alias_for_missing_import_call_test.go
@@ -1,0 +1,83 @@
+package driver_test
+
+import (
+  "fmt"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDriverRewriteReportsActualEmittedAliasForMissingImportCall verifies the
+// missing-call diagnostic retains source ownership and reports the real alias.
+//
+// Alias discovery must not turn an absent target into a silent pass or a decoy
+// rewrite. A high-suffix import with a different method therefore still fails,
+// but its diagnostic now names the declaration TypeScript-Go actually emitted.
+//
+// 1. Emit a default import at `_16` whose only call uses another method.
+// 2. Register a rewrite for the missing `plugin.make` call.
+// 3. Assert emit fails with the source call and actual emitted alias in the error.
+func TestDriverRewriteReportsActualEmittedAliasForMissingImportCall(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "bin",
+    "strict": true
+  },
+  "files": ["index.ts", "plugin.ts"]
+}
+`)
+  writeProjectFile(t, root, "plugin.ts", `export default {
+  other(input: string): string {
+    return input;
+  }
+};
+`)
+  var source strings.Builder
+  for i := 1; i < 16; i++ {
+    fmt.Fprintf(&source, "const plugin_%d = %d;\n", i, i)
+  }
+  source.WriteString(`import plugin from "./plugin";
+export const value = plugin.other("input");
+`)
+  writeProjectFile(t, root, "index.ts", source.String())
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{ForceEmit: true})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+  file := prog.SourceFile(filepath.Join(root, "index.ts"))
+  if file == nil {
+    t.Fatal("SourceFile did not find index.ts")
+  }
+  rewrites := driver.NewRewriteSet()
+  rewrites.Add(driver.Rewrite{
+    File:          file,
+    RootName:      "plugin",
+    Method:        "make",
+    Replacement:   `"unreachable"`,
+    ConsumeParens: true,
+  })
+  _, emitDiags, err := prog.EmitAll(rewrites, nil)
+  messages := []string{}
+  if err != nil {
+    messages = append(messages, err.Error())
+  }
+  for _, diag := range emitDiags {
+    messages = append(messages, diag.String())
+  }
+  message := strings.Join(messages, "\n")
+  for _, want := range []string{"could not locate plugin.make", "tried roots [plugin_16.default]", "index.js"} {
+    if !strings.Contains(message, want) {
+      t.Fatalf("diagnostic missing %q: %s", want, message)
+    }
+  }
+}

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -98,7 +98,11 @@ rs.Add(driver.Rewrite{
 prog.EmitAll(rs, driver.DefaultWriteFile)
 ```
 
-`RewriteSet` is the path the engine uses to splice replacements over plugin-owned call expressions in the emitted JavaScript text. Pair with `EmitAll`; pass `DefaultWriteFile` unless you need to intercept. The `RewriteSentinel` constant (`/* @ttsc-rewritten */`) is the idempotency marker inserted at the top of a patched file so re-emitting an already-rewritten file is a no-op.
+`RewriteSet` is the path the engine uses to splice replacements over plugin-owned call expressions in the emitted JavaScript text. Pair with `EmitAll`; pass `DefaultWriteFile` unless you need to intercept.
+
+For a default or namespace import, set `RootName` to its source-local binding. The driver matches that import's module specifier to the actual emitted `require` declaration, so TypeScript-Go remains free to choose any collision suffix without redirecting the rewrite to a similar local identifier. Non-import roots keep their source spelling.
+
+The `RewriteSentinel` constant (`/* @ttsc-rewritten */`) is the idempotency marker inserted at the top of a patched file so re-emitting an already-rewritten file is a no-op.
 
 ## Source preambles
 

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -100,7 +100,7 @@ prog.EmitAll(rs, driver.DefaultWriteFile)
 
 `RewriteSet` is the path the engine uses to splice replacements over plugin-owned call expressions in the emitted JavaScript text. Pair with `EmitAll`; pass `DefaultWriteFile` unless you need to intercept.
 
-For a default or namespace import, set `RootName` to its source-local binding. The driver matches that import's module specifier to the actual emitted `require` declaration, so TypeScript-Go remains free to choose any collision suffix without redirecting the rewrite to a similar local identifier. Non-import roots keep their source spelling.
+For a default or namespace import, set `RootName` to its source-local binding. When CommonJS lowering creates a `require` declaration, the driver matches the import's module specifier to that actual emitted declaration, so TypeScript-Go remains free to choose any collision suffix without redirecting the rewrite to a similar local identifier. Retained ESM imports and non-import roots keep their source spelling.
 
 The `RewriteSentinel` constant (`/* @ttsc-rewritten */`) is the idempotency marker inserted at the top of a patched file so re-emitting an already-rewritten file is a no-op.
 


### PR DESCRIPTION
Closes #701

## Intent

Replace `RewriteSet`'s finite guesses for TypeScript-Go's emitted CommonJS plugin binding with emitter-derived alias ownership that has no suffix ceiling.

## Scope

- preserve exact source-to-output rewrite ownership across default and namespace imports;
- preserve decoy rejection, multiple rewrites, whitespace/property chains, multiple outputs, and missing-call diagnostics;
- add public-driver observable emit and runtime regression coverage across low and high generated suffixes;
- update the driver API documentation when the observable contract changes.

## Verification

Pending implementation and local verification.

## Campaign CI

This issue-campaign claim uses exact-SHA Actions cancellation. The claim SHA is `0bb554ef6d1e54efba8a643b1f09dddf70be66f5`; its post-push gate observed no runs in two consecutive polls. Runs created by this draft pull request will be cancelled only when their `headSha` exactly matches that claim SHA, then polled to terminal state before implementation begins.
