### PR TITLE
refactor(playground): own invocation output and derive Typia packs

### DIFF
--- a/packages/lint/linthost/compile.go
+++ b/packages/lint/linthost/compile.go
@@ -33,9 +33,14 @@ import (
 
 // RunCheck implements `@ttsc/lint check` — typecheck + lint, no emit.
 func RunCheck(args []string) int {
-  opts, err := parseSubcommandFlags("check", args)
+  return RunCheckWithIO(args, os.Stdout, os.Stderr)
+}
+
+// RunCheckWithIO runs check with invocation-owned output streams.
+func RunCheckWithIO(args []string, stdout, stderr io.Writer) int {
+  opts, err := parseSubcommandFlagsWithIO("check", args, stdout, stderr)
   if err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(stderr, err)
     return 2
   }
   opts.noEmit = true
@@ -45,9 +50,14 @@ func RunCheck(args []string) int {
 // RunBuild implements `@ttsc/lint build` — same diagnostic flow as
 // `check`, plus the tsgo emit pipeline when emit is requested.
 func RunBuild(args []string) int {
-  opts, err := parseSubcommandFlags("build", args)
+  return RunBuildWithIO(args, os.Stdout, os.Stderr)
+}
+
+// RunBuildWithIO runs build with invocation-owned output streams.
+func RunBuildWithIO(args []string, stdout, stderr io.Writer) int {
+  opts, err := parseSubcommandFlagsWithIO("build", args, stdout, stderr)
   if err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(stderr, err)
     return 2
   }
   return runProject(opts)
@@ -57,8 +67,13 @@ func RunBuild(args []string) int {
 // still run for the whole program (lint quality depends on context), but
 // emit is restricted to the requested file's JS output.
 func RunTransform(args []string) int {
+  return RunTransformWithIO(args, os.Stdout, os.Stderr)
+}
+
+// RunTransformWithIO runs transform with invocation-owned output streams.
+func RunTransformWithIO(args []string, stdout, stderr io.Writer) int {
   fs := flag.NewFlagSet("transform", flag.ContinueOnError)
-  fs.SetOutput(os.Stderr)
+  fs.SetOutput(stderr)
   file := fs.String("file", "", "absolute or cwd-relative path of the .ts file to transform")
   out := fs.String("out", "", "write output JS to PATH (default: stdout)")
   tsconfig := fs.String("tsconfig", "tsconfig.json", "tsconfig owning --file")
@@ -74,32 +89,32 @@ func RunTransform(args []string) int {
     return 2
   }
   if *file == "" {
-    fmt.Fprintln(os.Stderr, "@ttsc/lint transform: --file is required")
+    fmt.Fprintln(stderr, "@ttsc/lint transform: --file is required")
     return 2
   }
   tsgoArgs, err := decodeTsgoArgs(*tsgoArgsRaw)
   if err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(stderr, err)
     return 2
   }
   resolvedCwd, err := resolveCwd(*cwd)
   if err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(stderr, err)
     return 2
   }
   projectIdentity, err := decodeProjectIdentity(*projectContextJSON)
   if err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(stderr, err)
     return 2
   }
   rules, err := loadRules(*pluginsJSON, resolvedCwd, *tsconfig)
   if err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(stderr, err)
     return 2
   }
   engine := NewEngineWithResolver(rules)
   if err := engine.ConfigError(); err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(stderr, err)
     return 2
   }
   engine.SetSerial(*singleThreaded)
@@ -113,22 +128,22 @@ func RunTransform(args []string) int {
     projectIdentity:  projectIdentity,
   })
   if err != nil {
-    fmt.Fprintf(os.Stderr, "@ttsc/lint: %v\n", err)
+    fmt.Fprintf(stderr, "@ttsc/lint: %v\n", err)
     return 2
   }
   if len(parseDiags) > 0 {
-    shimdw.FormatASTDiagnosticsWithColorAndContext(os.Stderr, parseDiags, resolvedCwd)
+    shimdw.FormatASTDiagnosticsWithColorAndContext(stderr, parseDiags, resolvedCwd)
     return 2
   }
   defer prog.close()
 
   astDiags, lintDiags, err := collectDiagnostics(prog, engine)
   if err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(stderr, err)
     return 2
   }
-  warnUnknownRules(os.Stderr, engine.UnknownRules())
-  if errors := shimdw.FormatMixedDiagnostics(os.Stderr, astDiags, lintDiags, resolvedCwd); errors > 0 {
+  warnUnknownRules(stderr, engine.UnknownRules())
+  if errors := shimdw.FormatMixedDiagnostics(stderr, astDiags, lintDiags, resolvedCwd); errors > 0 {
     return 2
   }
 
@@ -141,7 +156,7 @@ func RunTransform(args []string) int {
   absFile := shimtspath.ResolvePath(resolvedCwd, *file)
   target := prog.findSourceFile(absFile)
   if target == nil {
-    fmt.Fprintf(os.Stderr, "@ttsc/lint transform: source file not in program: %s\n", absFile)
+    fmt.Fprintf(stderr, "@ttsc/lint transform: source file not in program: %s\n", absFile)
     return 2
   }
 
@@ -158,26 +173,26 @@ func RunTransform(args []string) int {
     WriteFile:        shimcompiler.WriteFile(capture),
   })
   if result == nil {
-    fmt.Fprintln(os.Stderr, "@ttsc/lint transform: Emit returned nil")
+    fmt.Fprintln(stderr, "@ttsc/lint transform: Emit returned nil")
     return 3
   }
   if len(result.Diagnostics) > 0 {
-    shimdw.FormatASTDiagnosticsWithColorAndContext(os.Stderr, result.Diagnostics, resolvedCwd)
+    shimdw.FormatASTDiagnosticsWithColorAndContext(stderr, result.Diagnostics, resolvedCwd)
   }
   if captured == "" {
-    fmt.Fprintf(os.Stderr, "@ttsc/lint transform: no output produced for %s\n", absFile)
+    fmt.Fprintf(stderr, "@ttsc/lint transform: no output produced for %s\n", absFile)
     return 3
   }
   if *out == "" {
-    fmt.Fprint(os.Stdout, captured)
+    fmt.Fprint(stdout, captured)
     return 0
   }
   if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
-    fmt.Fprintf(os.Stderr, "@ttsc/lint transform: mkdir: %v\n", err)
+    fmt.Fprintf(stderr, "@ttsc/lint transform: mkdir: %v\n", err)
     return 3
   }
   if err := os.WriteFile(*out, []byte(captured), 0o644); err != nil {
-    fmt.Fprintf(os.Stderr, "@ttsc/lint transform: write: %v\n", err)
+    fmt.Fprintf(stderr, "@ttsc/lint transform: write: %v\n", err)
     return 3
   }
   return 0
@@ -197,14 +212,26 @@ type subcommandOpts struct {
   checkers        int
   tsgoArgs        []string
   projectIdentity publicrule.ProjectIdentity
+  stdout          io.Writer
+  stderr          io.Writer
 }
 
 // parseSubcommandFlags parses the shared flag set used by the `check`,
 // `build`, and `fix`/`format` subcommands. Unknown flags are silently
 // stripped by `filterKnownFlags` before the standard FlagSet sees them.
 func parseSubcommandFlags(name string, args []string) (*subcommandOpts, error) {
+  return parseSubcommandFlagsWithIO(name, args, os.Stdout, os.Stderr)
+}
+
+func parseSubcommandFlagsWithIO(name string, args []string, stdout, stderr io.Writer) (*subcommandOpts, error) {
+  if stdout == nil {
+    stdout = io.Discard
+  }
+  if stderr == nil {
+    stderr = io.Discard
+  }
   fs := flag.NewFlagSet(name, flag.ContinueOnError)
-  fs.SetOutput(os.Stderr)
+  fs.SetOutput(stderr)
   cwd := fs.String("cwd", "", "")
   tsconfig := fs.String("tsconfig", "tsconfig.json", "")
   pluginsJSON := fs.String("plugins-json", "", "")
@@ -251,6 +278,8 @@ func parseSubcommandFlags(name string, args []string) (*subcommandOpts, error) {
     checkers:        *checkers,
     tsgoArgs:        tsgoArgs,
     projectIdentity: projectIdentity,
+    stdout:          stdout,
+    stderr:          stderr,
   }, nil
 }
 
@@ -274,12 +303,12 @@ func decodeTsgoArgs(raw string) ([]string, error) {
 func runProject(opts *subcommandOpts) int {
   rules, err := loadRules(opts.pluginsJSON, opts.cwd, opts.tsconfig)
   if err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(opts.stderr, err)
     return 2
   }
   engine := NewEngineWithResolver(rules)
   if err := engine.ConfigError(); err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(opts.stderr, err)
     return 2
   }
   engine.SetSerial(opts.singleThreaded)
@@ -295,23 +324,23 @@ func runProject(opts *subcommandOpts) int {
     projectIdentity:  opts.projectIdentity,
   })
   if err != nil {
-    fmt.Fprintf(os.Stderr, "@ttsc/lint: %v\n", err)
+    fmt.Fprintf(opts.stderr, "@ttsc/lint: %v\n", err)
     return 2
   }
   if len(parseDiags) > 0 {
-    shimdw.FormatASTDiagnosticsWithColorAndContext(os.Stderr, parseDiags, opts.cwd)
+    shimdw.FormatASTDiagnosticsWithColorAndContext(opts.stderr, parseDiags, opts.cwd)
     return 2
   }
   defer prog.close()
 
   astDiags, lintDiags, diagnosticsTiming, err := collectDiagnosticsTimed(prog, engine)
   if err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(opts.stderr, err)
     return 2
   }
-  printLintDiagnosticsTiming(os.Stdout, opts.diagnostics, diagnosticsTiming)
-  warnUnknownRules(os.Stderr, engine.UnknownRules())
-  if errCount := shimdw.FormatMixedDiagnostics(os.Stderr, astDiags, lintDiags, opts.cwd); errCount > 0 {
+  printLintDiagnosticsTiming(opts.stdout, opts.diagnostics, diagnosticsTiming)
+  warnUnknownRules(opts.stderr, engine.UnknownRules())
+  if errCount := shimdw.FormatMixedDiagnostics(opts.stderr, astDiags, lintDiags, opts.cwd); errCount > 0 {
     return 2
   }
 
@@ -325,19 +354,19 @@ func runProject(opts *subcommandOpts) int {
     }),
   })
   if result == nil {
-    fmt.Fprintln(os.Stderr, "@ttsc/lint: Emit returned nil")
+    fmt.Fprintln(opts.stderr, "@ttsc/lint: Emit returned nil")
     return 3
   }
   if len(result.Diagnostics) > 0 {
-    errCount := shimdw.FormatMixedDiagnostics(os.Stderr, result.Diagnostics, nil, opts.cwd)
+    errCount := shimdw.FormatMixedDiagnostics(opts.stderr, result.Diagnostics, nil, opts.cwd)
     if errCount > 0 {
       return 2
     }
   }
   if opts.verbose && result.EmittedFiles != nil {
-    fmt.Fprintf(os.Stdout, "@ttsc/lint: emitted=%d files\n", len(result.EmittedFiles))
+    fmt.Fprintf(opts.stdout, "@ttsc/lint: emitted=%d files\n", len(result.EmittedFiles))
     for _, f := range result.EmittedFiles {
-      fmt.Fprintln(os.Stdout, "  +", f)
+      fmt.Fprintln(opts.stdout, "  +", f)
     }
   }
   return 0

--- a/packages/lint/linthost/dispatch.go
+++ b/packages/lint/linthost/dispatch.go
@@ -8,6 +8,7 @@ package linthost
 
 import (
   "fmt"
+  "io"
   "os"
 )
 
@@ -27,6 +28,39 @@ var Version = "dev"
 // ttscserver. Anything else is a usage error (exit code 2).
 func Main(args []string) int {
   return run(args)
+}
+
+// MainWithIO dispatches the browser-owned project commands without consulting
+// process-global stdout or stderr. Native-only mutation and LSP commands retain
+// Main as their CLI entrypoint.
+func MainWithIO(args []string, stdout, stderr io.Writer) int {
+  if stdout == nil {
+    stdout = io.Discard
+  }
+  if stderr == nil {
+    stderr = io.Discard
+  }
+  if len(args) == 0 {
+    fmt.Fprintln(stderr, "@ttsc/lint: command required (expected check|build|transform|version)")
+    return 2
+  }
+  switch args[0] {
+  case "-v", "--version", "version":
+    fmt.Fprintf(stdout, "@ttsc/lint %s\n", Version)
+    return 0
+  case "check":
+    registerContributorsOnce()
+    return RunCheckWithIO(args[1:], stdout, stderr)
+  case "build":
+    registerContributorsOnce()
+    return RunBuildWithIO(args[1:], stdout, stderr)
+  case "transform":
+    registerContributorsOnce()
+    return RunTransformWithIO(args[1:], stdout, stderr)
+  default:
+    fmt.Fprintf(stderr, "@ttsc/lint: command %q is unavailable in the browser host\n", args[0])
+    return 2
+  }
 }
 
 // run is the package-local dispatcher invoked by Main and by the in-tree

--- a/packages/ttsc/utility/host.go
+++ b/packages/ttsc/utility/host.go
@@ -4,6 +4,7 @@ import (
   "encoding/json"
   "flag"
   "fmt"
+  "io"
   "os"
   "path/filepath"
   "strings"
@@ -29,6 +30,8 @@ type hostOptions struct {
   singleThreaded bool
   checkers       int
   tsgoArgs       []string
+  stdout         io.Writer
+  stderr         io.Writer
   // fs overrides the filesystem the program loads from. Only the resident serve
   // host sets it (to an OverlayFS), so build/check/transform leave it nil and
   // LoadProgram falls back to the default filesystem.
@@ -46,7 +49,12 @@ type transformResult struct {
 // RunCheck validates the project and linked plugin configuration without
 // emitting output.
 func RunCheck(args []string) int {
-  opts, ok := parseHostOptions("check", args)
+  return RunCheckWithIO(args, os.Stdout, os.Stderr)
+}
+
+// RunCheckWithIO runs check with invocation-owned output streams.
+func RunCheckWithIO(args []string, stdout, stderr io.Writer) int {
+  opts, ok := parseHostOptions("check", args, stdout, stderr)
   if !ok {
     return 2
   }
@@ -57,7 +65,7 @@ func RunCheck(args []string) int {
   }
   defer prog.Close()
   if err := prog.ApplyLinkedPlugins(); err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(opts.stderr, err)
     return 2
   }
   return 0
@@ -65,7 +73,12 @@ func RunCheck(args []string) int {
 
 // RunBuild hosts linked transform packages inside one compiler emit.
 func RunBuild(args []string) int {
-  opts, ok := parseHostOptions("build", args)
+  return RunBuildWithIO(args, os.Stdout, os.Stderr)
+}
+
+// RunBuildWithIO runs build with invocation-owned output streams.
+func RunBuildWithIO(args []string, stdout, stderr io.Writer) int {
+  opts, ok := parseHostOptions("build", args, stdout, stderr)
   if !ok {
     return 2
   }
@@ -81,21 +94,21 @@ func RunBuild(args []string) int {
     opts.quiet = false // --verbose overrides the default --quiet=true
   }
   if !opts.quiet {
-    fmt.Fprintf(os.Stdout, "// ttsc utility: plugins=%d emit=%v\n", len(entries), !opts.noEmit)
+    fmt.Fprintf(opts.stdout, "// ttsc utility: plugins=%d emit=%v\n", len(entries), !opts.noEmit)
   }
   res, eDiags, err := prog.EmitAllRaw(makeSourcePreambleWriteFile(prog))
   if err != nil {
-    fmt.Fprintf(os.Stderr, "ttsc utility: emit failed: %v\n", err)
+    fmt.Fprintf(opts.stderr, "ttsc utility: emit failed: %v\n", err)
     return 3
   }
   for _, d := range eDiags {
-    fmt.Fprintln(os.Stderr, "  -", d.String())
+    fmt.Fprintln(opts.stderr, "  -", d.String())
   }
   if driver.CountErrors(eDiags) > 0 {
     return 2
   }
   if res != nil && !opts.quiet {
-    fmt.Fprintf(os.Stdout, "// ttsc utility: emitted=%d files\n", len(res.EmittedFiles))
+    fmt.Fprintf(opts.stdout, "// ttsc utility: emitted=%d files\n", len(res.EmittedFiles))
   }
   return 0
 }
@@ -103,7 +116,12 @@ func RunBuild(args []string) int {
 // RunTransform returns the project TypeScript text after linked source
 // mutations.
 func RunTransform(args []string) int {
-  opts, ok := parseHostOptions("transform", args)
+  return RunTransformWithIO(args, os.Stdout, os.Stderr)
+}
+
+// RunTransformWithIO runs transform with invocation-owned output streams.
+func RunTransformWithIO(args []string, stdout, stderr io.Writer) int {
+  opts, ok := parseHostOptions("transform", args, stdout, stderr)
   if !ok {
     return 2
   }
@@ -113,7 +131,7 @@ func RunTransform(args []string) int {
   }
   defer prog.Close()
   if err := prog.ApplyLinkedPlugins(); err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(opts.stderr, err)
     return 2
   }
   printer := shimprinter.NewPrinter(shimprinter.PrinterOptions{}, shimprinter.PrintHandlers{}, nil)
@@ -123,7 +141,7 @@ func RunTransform(args []string) int {
     out.TypeScript[apiOutputKey(opts.cwd, file.FileName())] = text
   }
   data, _ := json.Marshal(out)
-  fmt.Fprintln(os.Stdout, string(data))
+  fmt.Fprintln(opts.stdout, string(data))
   return 0
 }
 
@@ -131,9 +149,15 @@ func RunTransform(args []string) int {
 // Unknown flags forwarded from the JS launcher are stripped by filterHostArgs
 // before flag.FlagSet sees them, so spurious "flag provided but not defined"
 // errors are avoided. Returns (zero, false) on any parse or validation error.
-func parseHostOptions(command string, args []string) (hostOptions, bool) {
+func parseHostOptions(command string, args []string, stdout, stderr io.Writer) (hostOptions, bool) {
+  if stdout == nil {
+    stdout = io.Discard
+  }
+  if stderr == nil {
+    stderr = io.Discard
+  }
   fs := flag.NewFlagSet(command, flag.ContinueOnError)
-  fs.SetOutput(os.Stderr)
+  fs.SetOutput(stderr)
   cwd := fs.String("cwd", "", "project directory")
   emit := fs.Bool("emit", false, "force emit")
   noEmit := fs.Bool("noEmit", false, "force no emit")
@@ -151,12 +175,12 @@ func parseHostOptions(command string, args []string) (hostOptions, bool) {
   var tsgoArgs []string
   if *tsgoArgsRaw != "" {
     if err := json.Unmarshal([]byte(*tsgoArgsRaw), &tsgoArgs); err != nil {
-      fmt.Fprintf(os.Stderr, "ttsc utility: invalid --tsgo-args: %v\n", err)
+      fmt.Fprintf(stderr, "ttsc utility: invalid --tsgo-args: %v\n", err)
       return hostOptions{}, false
     }
   }
   if *emit && *noEmit {
-    fmt.Fprintln(os.Stderr, "ttsc utility: --emit and --noEmit are mutually exclusive")
+    fmt.Fprintln(stderr, "ttsc utility: --emit and --noEmit are mutually exclusive")
     return hostOptions{}, false
   }
   resolvedCwd := *cwd
@@ -164,14 +188,14 @@ func parseHostOptions(command string, args []string) (hostOptions, bool) {
     var err error
     resolvedCwd, err = os.Getwd()
     if err != nil {
-      fmt.Fprintf(os.Stderr, "ttsc utility: cwd: %v\n", err)
+      fmt.Fprintf(stderr, "ttsc utility: cwd: %v\n", err)
       return hostOptions{}, false
     }
   }
   if !filepath.IsAbs(resolvedCwd) {
     abs, err := filepath.Abs(resolvedCwd)
     if err != nil {
-      fmt.Fprintf(os.Stderr, "ttsc utility: cwd: %v\n", err)
+      fmt.Fprintf(stderr, "ttsc utility: cwd: %v\n", err)
       return hostOptions{}, false
     }
     resolvedCwd = abs
@@ -188,6 +212,8 @@ func parseHostOptions(command string, args []string) (hostOptions, bool) {
     singleThreaded: *singleThreaded,
     checkers:       *checkers,
     tsgoArgs:       tsgoArgs,
+    stdout:         stdout,
+    stderr:         stderr,
   }, true
 }
 
@@ -243,7 +269,7 @@ func flagName(arg string) (string, bool) {
 func loadUtilityProgram(opts hostOptions) (*driver.Program, []driver.PluginEntry, bool) {
   entries, err := parsePluginEntries(opts.pluginsJSON)
   if err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(opts.stderr, err)
     return nil, nil, false
   }
   restoreEnv := setLinkedPluginManifest(opts.pluginsJSON)
@@ -259,15 +285,15 @@ func loadUtilityProgram(opts hostOptions) (*driver.Program, []driver.PluginEntry
     FS:             opts.fs,
   })
   if err != nil {
-    fmt.Fprintf(os.Stderr, "ttsc utility: %v\n", err)
+    fmt.Fprintf(opts.stderr, "ttsc utility: %v\n", err)
     return nil, nil, false
   }
   if len(diags) > 0 {
-    driver.WritePrettyDiagnostics(os.Stderr, diags, opts.cwd)
+    driver.WritePrettyDiagnostics(opts.stderr, diags, opts.cwd)
     return nil, nil, false
   }
   if diags := prog.Diagnostics(); len(diags) > 0 {
-    driver.WritePrettyDiagnostics(os.Stderr, diags, opts.cwd)
+    driver.WritePrettyDiagnostics(opts.stderr, diags, opts.cwd)
     _ = prog.Close()
     return nil, nil, false
   }

--- a/packages/ttsc/utility/serve.go
+++ b/packages/ttsc/utility/serve.go
@@ -56,7 +56,7 @@ type serveUpdateResponse struct {
 // in and out are explicit so the request loop is testable; the utility-host
 // command wires them to os.Stdin and os.Stdout.
 func RunServe(in io.Reader, out io.Writer, args []string) int {
-  opts, ok := parseHostOptions("serve", args)
+  opts, ok := parseHostOptions("serve", args, out, os.Stderr)
   if !ok {
     return 2
   }

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -47,6 +47,7 @@ The native sibling `main.go` is recommended when you want `go run ./cmd/your-was
 package main
 
 import (
+  "context"
   "fmt"
   "os"
 
@@ -60,7 +61,10 @@ func main() {
     name, command := os.Args[1], os.Args[2]
     for _, p := range plugins {
       if p.Name() == name {
-        os.Exit(p.Run(command, os.Args[3:]))
+        result := host.InvokePlugin(context.Background(), p, command, os.Args[3:])
+        fmt.Fprint(os.Stdout, result.Stdout)
+        fmt.Fprint(os.Stderr, result.Stderr)
+        os.Exit(result.Code)
       }
     }
   }
@@ -169,12 +173,14 @@ Verbs and payload types:
 
 ```go
 type Plugin interface {
-  Name() string                            // e.g. "@ttsc/banner"
-  Run(command string, args []string) int   // returns CLI exit code
+  Name() string
+  Run(invocation *PluginInvocation) int
 }
 ```
 
-The host installs `globalThis[apiName].plugin({ name, command, ...opts })` that translates the JS options object into a CLI-shaped argv and calls your plugin's `Run`. Your `Run` body can forward to the same function the native sidecar's `main.go` calls, for example `utility.RunBuild(args)` for plugins backed by `packages/ttsc/utility`.
+The host installs `globalThis[apiName].plugin({ name, command, ...opts })` that translates the JS options object into `invocation.Command` and CLI-shaped `invocation.Args`. Write output to `invocation.Stdout` and `invocation.Stderr`. Utility-backed plugins can call `utility.RunBuildWithIO(invocation.Args, invocation.Stdout, invocation.Stderr)` so the native command and browser adapter share implementation without replacing process-global streams.
+
+Use `invocation.Go` for asynchronous work that belongs to the result. Register it before `Run` returns; the host waits for registered work, closes registration when `Run` returns, and rejects later writes to the invocation streams.
 
 ## Published-tarball Go module layout
 

--- a/packages/wasm/host/api.go
+++ b/packages/wasm/host/api.go
@@ -16,7 +16,7 @@ import (
   "github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
-// APIResult is the stdout/stderr capture returned by runWithCapturedIO. The
+// APIResult is the stdout/stderr capture returned by InvokePlugin. The
 // js/wasm binding wraps it in the same JS result envelope that build/check/
 // transform use, adding `result` when an endpoint has a JSON payload. `code`
 // follows the native CLI exit-code contract (0 success, 2 compiler/config/

--- a/packages/wasm/host/host.go
+++ b/packages/wasm/host/host.go
@@ -10,10 +10,10 @@
 package host
 
 import (
+  "context"
   "fmt"
   "os"
   "runtime"
-  "sync"
   "sync/atomic"
   "syscall/js"
   "time"
@@ -180,9 +180,7 @@ func jsPluginDispatch(plugins map[string]Plugin) func(this js.Value, args []js.V
       return errorPromise(2, fmt.Sprintf("host: unknown plugin %q", name))
     }
     return makePromise(func() any {
-      res := runWithCapturedIO(func() int {
-        return plugin.Run(command, argv)
-      })
+      res := InvokePlugin(context.Background(), plugin, command, argv)
       return js.ValueOf(map[string]any{
         "code":   res.Code,
         "stdout": res.Stdout,
@@ -324,106 +322,3 @@ func stringProp(obj js.Value, key string) string {
   }
   return v.String()
 }
-
-// runWithCapturedIO redirects os.Stdout / os.Stderr to temp MemFS files for
-// the duration of `task`. Plugin Run methods write to os.Stdout / os.Stderr
-// the same way the native sidecar binaries do; capturing the output lets the
-// JS host render it in a console panel without spawning a subprocess.
-//
-// We use MemFS temp files instead of os.Pipe because Go's js/wasm runtime
-// returns `pipe: not implemented on js` for `syscall.Pipe` — pipes are not
-// supported on the wasm target. The temp-file approach works because the
-// MemFS shim implements file open/write/read.
-func runWithCapturedIO(task func() int) APIResult {
-  captureMu.Lock()
-  defer captureMu.Unlock()
-
-  prevOut, prevErr := os.Stdout, os.Stderr
-  // The defer is a safety net: if an early return skips the explicit restore
-  // below, os.Stdout/os.Stderr are still restored. The explicit restore that
-  // follows the task call is a no-op for the defer but makes the happy path
-  // readable without tracing the defer.
-  defer func() {
-    os.Stdout = prevOut
-    os.Stderr = prevErr
-  }()
-
-  stdoutPath := fmt.Sprintf("/tmp/ttsc-host-capture-%d-%d.stdout", os.Getpid(), captureCounter.Add(1))
-  stderrPath := fmt.Sprintf("/tmp/ttsc-host-capture-%d-%d.stderr", os.Getpid(), captureCounter.Add(1))
-
-  outFile, outErr := os.Create(stdoutPath)
-  errFile, errErr := os.Create(stderrPath)
-  if outErr != nil || errErr != nil {
-    // Fall back to the original streams. Better to lose capture than the
-    // call. The MemFS writeSync shim surfaces the failure to the host
-    // console so the regression is visible.
-    if outErr != nil {
-      fmt.Fprintf(prevErr, "host.runWithCapturedIO: stdout temp file failed: %v\n", outErr)
-    }
-    if errErr != nil {
-      fmt.Fprintf(prevErr, "host.runWithCapturedIO: stderr temp file failed: %v\n", errErr)
-    }
-    if outFile != nil {
-      _ = outFile.Close()
-      _ = os.Remove(stdoutPath)
-    }
-    if errFile != nil {
-      _ = errFile.Close()
-      _ = os.Remove(stderrPath)
-    }
-    return APIResult{Code: task()}
-  }
-  capturing := false
-  defer func() {
-    if capturing {
-      os.Stdout = prevOut
-      os.Stderr = prevErr
-    }
-    if outFile != nil {
-      _ = outFile.Close()
-    }
-    if errFile != nil {
-      _ = errFile.Close()
-    }
-    _ = os.Remove(stdoutPath)
-    _ = os.Remove(stderrPath)
-  }()
-
-  os.Stdout = outFile
-  os.Stderr = errFile
-  capturing = true
-
-  code := task()
-
-  // Sync + close BEFORE swapping back, so the plugin's last writes hit the
-  // file before we read it.
-  _ = outFile.Sync()
-  _ = errFile.Sync()
-  _ = outFile.Close()
-  outFile = nil
-  _ = errFile.Close()
-  errFile = nil
-
-  os.Stdout = prevOut
-  os.Stderr = prevErr
-  capturing = false
-
-  stdoutBytes, _ := os.ReadFile(stdoutPath)
-  stderrBytes, _ := os.ReadFile(stderrPath)
-
-  return APIResult{
-    Code:   code,
-    Stdout: string(stdoutBytes),
-    Stderr: string(stderrBytes),
-  }
-}
-
-// captureCounter avoids temp-file name collisions when plugin dispatches
-// overlap (multiple goroutines could be in runWithCapturedIO concurrently
-// from independent JS callers).
-var captureCounter atomic.Uint64
-
-// captureMu serializes temporary replacement of package-global stdout/stderr.
-// The temp filenames are unique, but os.Stdout/os.Stderr themselves are shared
-// process state in the wasm runtime.
-var captureMu sync.Mutex

--- a/packages/wasm/host/plugin.go
+++ b/packages/wasm/host/plugin.go
@@ -1,60 +1,128 @@
 package host
 
-// API stability: experimental until v1.0; signatures may change between
-// minor releases. Pin exact versions in production playgrounds.
-//
+import (
+  "bytes"
+  "context"
+  "io"
+  "sync"
+)
+
 // Plugin is the in-process equivalent of ttsc's native CLI sidecar.
 //
-// The native CLI invokes plugins by spawning their binary with argv (e.g.
-// `@ttsc/lint check --tsconfig=tsconfig.json --plugins-json=...`). Inside the
-// wasm there is no subprocess support, so the consumer wasm bundles plugin
-// code directly and exposes the same dispatch through Plugin.Run.
-//
-// A typical Plugin implementation in the consumer wasm is a thin adapter that
-// forwards to the same Run* function the native sidecar's `main.go` calls:
-//
-//  type bannerPlugin struct{}
-//
-//  func (bannerPlugin) Name() string { return "@ttsc/banner" }
-//  func (bannerPlugin) Run(command string, args []string) int {
-//    switch command {
-//    case "build":     return utility.RunBuild(args)
-//    case "check":     return utility.RunCheck(args)
-//    case "transform": return utility.RunTransform(args)
-//    default:          return 2
-//    }
-//  }
-//
-// The host installs the package-level writers in `runWithCapturedIO` before
-// calling Run, so anything the plugin writes to ttsc's `stdout` / `stderr`
-// streams is captured and returned to the JS caller.
+// The browser cannot spawn plugin binaries, so a consumer wasm links their Go
+// adapters and registers them with Config. Every run receives invocation-owned
+// streams; a plugin must write only to those streams, never os.Stdout or
+// os.Stderr.
 type Plugin interface {
-  // Name is the npm-style plugin id (e.g. `@ttsc/banner`). The JS side
-  // passes this exact string when dispatching:
-  // `api.plugin({ name: "@ttsc/banner", command: "build", ...opts })`.
-  // Names must be unique within a Config.
+  // Name is the npm-style plugin id passed to api.plugin.
   Name() string
 
-  // Run dispatches a subcommand. `command` is the verb the JS caller asked
-  // for (typically build / check / transform / fix / format / version);
-  // `args` is the rest of the argv, already prefixed with `--flag=value`
-  // pairs the host built from the JS options object.
-  //
-  // Return the exit code (0 for success, 2 for compiler/config/usage errors, 3
-  // for runtime errors — mirrors the native CLI exit-code contract). Anything written
-  // to `os.Stdout` / `os.Stderr` is captured by the host.
-  //
-  // API stability: experimental until v1.0; the signature is expected to
-  // change to `Run(ctx *PluginContext) int` in a follow-up release.
-  Run(command string, args []string) int
+  // Run dispatches one subcommand and returns the native CLI exit code.
+  Run(invocation *PluginInvocation) int
+}
+
+// PluginInvocation owns all mutable state for one plugin call.
+//
+// A plugin that needs asynchronous work must register it with Go before Run
+// returns. InvokePlugin waits for every registered function. Registration
+// after Run returns is rejected, and writes made after the invocation closes
+// return io.ErrClosedPipe. This gives child goroutines an explicit ownership
+// boundary without sharing process-global output state.
+type PluginInvocation struct {
+  Context context.Context
+  Command string
+  Args    []string
+  Stdout  io.Writer
+  Stderr  io.Writer
+
+  childrenMu     sync.Mutex
+  children       sync.WaitGroup
+  acceptingChild bool
+}
+
+// Go registers and starts invocation-owned asynchronous work. It returns false
+// when Run has already returned and the ownership boundary is closed.
+func (invocation *PluginInvocation) Go(task func(context.Context)) bool {
+  if task == nil {
+    return false
+  }
+  invocation.childrenMu.Lock()
+  if !invocation.acceptingChild {
+    invocation.childrenMu.Unlock()
+    return false
+  }
+  invocation.children.Add(1)
+  invocation.childrenMu.Unlock()
+  go func() {
+    defer invocation.children.Done()
+    task(invocation.Context)
+  }()
+  return true
+}
+
+// InvokePlugin executes one plugin call and captures its request-owned output.
+// Independent invocations may run concurrently without sharing buffers.
+func InvokePlugin(ctx context.Context, plugin Plugin, command string, args []string) APIResult {
+  if ctx == nil {
+    ctx = context.Background()
+  }
+  stdout := &invocationBuffer{}
+  stderr := &invocationBuffer{}
+  invocation := &PluginInvocation{
+    Context:        ctx,
+    Command:        command,
+    Args:           append([]string(nil), args...),
+    Stdout:         stdout,
+    Stderr:         stderr,
+    acceptingChild: true,
+  }
+  code := plugin.Run(invocation)
+
+  invocation.childrenMu.Lock()
+  invocation.acceptingChild = false
+  invocation.childrenMu.Unlock()
+  invocation.children.Wait()
+
+  stdout.close()
+  stderr.close()
+  return APIResult{
+    Code:   code,
+    Stdout: stdout.String(),
+    Stderr: stderr.String(),
+  }
 }
 
 // Config carries the optional registrations the host applies before binding
-// `globalThis[name]`. Pass `Config{}` for a vanilla ttsc + tsgo wasm.
+// globalThis[name]. Pass Config{} for a vanilla ttsc + tsgo wasm.
 type Config struct {
-  // Plugins are dispatched through `api.plugin({ name, command, ...opts })` from
-  // JS. Their Run methods share the same `os.Stdout` / `os.Stderr` streams
-  // the base build/check/transform endpoints use, so diagnostics render
-  // the same way no matter which lane produced them.
   Plugins []Plugin
+}
+
+// invocationBuffer serializes writers owned by one invocation. Closing it
+// prevents an unregistered or late goroutine from modifying a completed result.
+type invocationBuffer struct {
+  mu     sync.Mutex
+  data   bytes.Buffer
+  closed bool
+}
+
+func (buffer *invocationBuffer) Write(data []byte) (int, error) {
+  buffer.mu.Lock()
+  defer buffer.mu.Unlock()
+  if buffer.closed {
+    return 0, io.ErrClosedPipe
+  }
+  return buffer.data.Write(data)
+}
+
+func (buffer *invocationBuffer) String() string {
+  buffer.mu.Lock()
+  defer buffer.mu.Unlock()
+  return buffer.data.String()
+}
+
+func (buffer *invocationBuffer) close() {
+  buffer.mu.Lock()
+  buffer.closed = true
+  buffer.mu.Unlock()
 }

--- a/packages/wasm/src/createMemFS.ts
+++ b/packages/wasm/src/createMemFS.ts
@@ -335,7 +335,7 @@ export function createMemFS(): IMemFSHost {
         return buf.length;
       }
       // Open-file fds (>= 100): append to the underlying file. This is the
-      // path the wasm host's runWithCapturedIO uses to capture plugin
+      // path browser-hosted tools use for temporary files and outputs
       // stdout/stderr via /tmp/* temp files (os.Pipe is not implemented on
       // js/wasm so we mirror its semantics via files).
       const entry = fdTable.get(fd);

--- a/packages/wasm/src/createMemFS.ts
+++ b/packages/wasm/src/createMemFS.ts
@@ -334,10 +334,8 @@ export function createMemFS(): IMemFSHost {
           console.error("[wasm]", line);
         return buf.length;
       }
-      // Open-file fds (>= 100): append to the underlying file. This is the
-      // path browser-hosted tools use for temporary files and outputs
-      // stdout/stderr via /tmp/* temp files (os.Pipe is not implemented on
-      // js/wasm so we mirror its semantics via files).
+      // Open-file fds (>= 100): append to the underlying file. Browser-hosted
+      // tools use this path for ordinary virtual files and explicit outputs.
       const entry = fdTable.get(fd);
       if (entry) {
         const node = nodes.get(entry.path);

--- a/packages/wasm/test/host/plugin_invocation_ownership_test.go
+++ b/packages/wasm/test/host/plugin_invocation_ownership_test.go
@@ -1,0 +1,103 @@
+package host_test
+
+import (
+  "context"
+  "fmt"
+  "io"
+  "strings"
+  "sync"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/wasm/host"
+)
+
+type invocationPlugin struct {
+  name string
+  run  func(*host.PluginInvocation) int
+}
+
+func (plugin invocationPlugin) Name() string { return plugin.name }
+
+func (plugin invocationPlugin) Run(invocation *host.PluginInvocation) int {
+  return plugin.run(invocation)
+}
+
+// TestPluginInvocationOutputOwnership proves that normal writes, registered
+// child writes, concurrent calls, and late writes all stay inside the request
+// that owns their writers. It prevents the browser host from regressing to
+// process-global stdout/stderr capture.
+func TestPluginInvocationOutputOwnership(t *testing.T) {
+  t.Run("captures normal and registered child output", func(t *testing.T) {
+    childRelease := make(chan struct{})
+    result := make(chan host.APIResult, 1)
+    plugin := invocationPlugin{name: "child", run: func(invocation *host.PluginInvocation) int {
+      fmt.Fprint(invocation.Stdout, "parent")
+      if !invocation.Go(func(context.Context) {
+        <-childRelease
+        fmt.Fprint(invocation.Stderr, "child")
+      }) {
+        t.Fatal("child registration was rejected while Run was active")
+      }
+      return 7
+    }}
+    go func() {
+      result <- host.InvokePlugin(context.Background(), plugin, "build", []string{"one"})
+    }()
+    close(childRelease)
+    got := <-result
+    if got.Code != 7 || got.Stdout != "parent" || got.Stderr != "child" {
+      t.Fatalf("unexpected result: %#v", got)
+    }
+  })
+
+  t.Run("separates concurrent invocations", func(t *testing.T) {
+    start := make(chan struct{})
+    var ready sync.WaitGroup
+    ready.Add(2)
+    plugin := invocationPlugin{name: "concurrent", run: func(invocation *host.PluginInvocation) int {
+      ready.Done()
+      <-start
+      for range 32 {
+        fmt.Fprint(invocation.Stdout, invocation.Args[0])
+        fmt.Fprint(invocation.Stderr, invocation.Args[0])
+      }
+      return 0
+    }}
+    results := make(chan host.APIResult, 2)
+    go func() { results <- host.InvokePlugin(context.Background(), plugin, "run", []string{"A"}) }()
+    go func() { results <- host.InvokePlugin(context.Background(), plugin, "run", []string{"B"}) }()
+    ready.Wait()
+    close(start)
+    for range 2 {
+      got := <-results
+      if got.Stdout == "" || got.Stdout != got.Stderr {
+        t.Fatalf("mismatched streams: %#v", got)
+      }
+      if strings.Contains(got.Stdout, "A") && strings.Contains(got.Stdout, "B") {
+        t.Fatalf("concurrent output was contaminated: %q", got.Stdout)
+      }
+    }
+  })
+
+  t.Run("closes ownership after Run returns", func(t *testing.T) {
+    var invocation *host.PluginInvocation
+    plugin := invocationPlugin{name: "late", run: func(current *host.PluginInvocation) int {
+      invocation = current
+      fmt.Fprint(current.Stdout, "owned")
+      return 0
+    }}
+    got := host.InvokePlugin(context.Background(), plugin, "run", nil)
+    if got.Stdout != "owned" {
+      t.Fatalf("unexpected captured output: %q", got.Stdout)
+    }
+    if invocation.Go(func(context.Context) {}) {
+      t.Fatal("child registration succeeded after Run returned")
+    }
+    if _, err := io.WriteString(invocation.Stdout, "late"); err != io.ErrClosedPipe {
+      t.Fatalf("late write error = %v, want %v", err, io.ErrClosedPipe)
+    }
+    if got.Stdout != "owned" {
+      t.Fatalf("completed result changed after late write: %q", got.Stdout)
+    }
+  })
+}

--- a/packages/wasm/test/host/plugin_invocation_ownership_test.go
+++ b/packages/wasm/test/host/plugin_invocation_ownership_test.go
@@ -97,23 +97,33 @@ func TestPluginInvocationOutputOwnership(t *testing.T) {
       <-start
       for range 32 {
         fmt.Fprint(invocation.Stdout, invocation.Args[0])
-        fmt.Fprint(invocation.Stderr, invocation.Args[0])
+        fmt.Fprint(invocation.Stderr, invocation.Args[1])
       }
       return 0
     }}
     results := make(chan host.APIResult, 2)
-    go func() { results <- host.InvokePlugin(context.Background(), plugin, "run", []string{"A"}) }()
-    go func() { results <- host.InvokePlugin(context.Background(), plugin, "run", []string{"B"}) }()
+    go func() {
+      results <- host.InvokePlugin(context.Background(), plugin, "run", []string{"A-out", "A-err"})
+    }()
+    go func() {
+      results <- host.InvokePlugin(context.Background(), plugin, "run", []string{"B-out", "B-err"})
+    }()
     ready.Wait()
     close(start)
+    want := map[string]string{
+      strings.Repeat("A-out", 32): strings.Repeat("A-err", 32),
+      strings.Repeat("B-out", 32): strings.Repeat("B-err", 32),
+    }
     for range 2 {
       got := <-results
-      if got.Stdout == "" || got.Stdout != got.Stderr {
-        t.Fatalf("mismatched streams: %#v", got)
+      stderr, ok := want[got.Stdout]
+      if !ok || got.Stderr != stderr {
+        t.Fatalf("concurrent output was contaminated or incomplete: %#v", got)
       }
-      if strings.Contains(got.Stdout, "A") && strings.Contains(got.Stdout, "B") {
-        t.Fatalf("concurrent output was contaminated: %q", got.Stdout)
-      }
+      delete(want, got.Stdout)
+    }
+    if len(want) != 0 {
+      t.Fatalf("missing concurrent invocation results: %#v", want)
     }
   })
 

--- a/packages/wasm/test/host/plugin_invocation_ownership_test.go
+++ b/packages/wasm/test/host/plugin_invocation_ownership_test.go
@@ -1,9 +1,11 @@
 package host_test
 
 import (
+  "bytes"
   "context"
   "fmt"
   "io"
+  "os"
   "strings"
   "sync"
   "testing"
@@ -27,6 +29,42 @@ func (plugin invocationPlugin) Run(invocation *host.PluginInvocation) int {
 // that owns their writers. It prevents the browser host from regressing to
 // process-global stdout/stderr capture.
 func TestPluginInvocationOutputOwnership(t *testing.T) {
+  t.Run("leaves unrelated process output outside the result", func(t *testing.T) {
+    originalStdout, originalStderr := os.Stdout, os.Stderr
+    ready := make(chan struct{})
+    release := make(chan struct{})
+    result := make(chan host.APIResult, 1)
+    plugin := invocationPlugin{name: "global-sentinel", run: func(invocation *host.PluginInvocation) int {
+      close(ready)
+      <-release
+      fmt.Fprint(invocation.Stdout, "owned-stdout")
+      fmt.Fprint(invocation.Stderr, "owned-stderr")
+      return 0
+    }}
+    go func() {
+      result <- host.InvokePlugin(context.Background(), plugin, "run", nil)
+    }()
+    <-ready
+
+    // This write is deliberately unrelated to the invocation and occurs while
+    // Plugin.Run is active. InvokePlugin must never redirect the exported
+    // process-global file pointers to its request-owned buffers.
+    fmt.Fprint(os.Stdout, "unrelated-process-sentinel")
+    close(release)
+    got := <-result
+
+    if os.Stdout != originalStdout || os.Stderr != originalStderr {
+      t.Fatal("InvokePlugin mutated process-global stdout or stderr")
+    }
+    if bytes.Contains([]byte(got.Stdout), []byte("unrelated-process-sentinel")) ||
+      bytes.Contains([]byte(got.Stderr), []byte("unrelated-process-sentinel")) {
+      t.Fatalf("unrelated process output entered invocation result: %#v", got)
+    }
+    if got.Stdout != "owned-stdout" || got.Stderr != "owned-stderr" {
+      t.Fatalf("unexpected owned output: %#v", got)
+    }
+  })
+
   t.Run("captures normal and registered child output", func(t *testing.T) {
     childRelease := make(chan struct{})
     result := make(chan host.APIResult, 1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,16 +17,16 @@ catalogs:
       version: 4.60.4
   samchon:
     '@typia/interface':
-      specifier: ^13.1.0
+      specifier: 13.1.0
       version: 13.1.0
     '@typia/mcp':
-      specifier: ^13.1.0
+      specifier: 13.1.0
       version: 13.1.0
     '@typia/utils':
-      specifier: ^13.1.0
+      specifier: 13.1.0
       version: 13.1.0
     typia:
-      specifier: ^13.1.0
+      specifier: 13.1.0
       version: 13.1.0
   typescript:
     ts-legacy:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,10 +16,10 @@ catalogs:
     '@rollup/plugin-node-resolve': ^16.0.3
     rollup: ^4.56.0
   samchon:
-    '@typia/interface': ^13.1.0
-    '@typia/mcp': ^13.1.0
-    '@typia/utils': ^13.1.0
-    typia: ^13.1.0
+    '@typia/interface': 13.1.0
+    '@typia/mcp': 13.1.0
+    '@typia/utils': 13.1.0
+    typia: 13.1.0
   utils:
     '@nestia/e2e': ^12.0.0-rc.2
     '@types/node': ^25.3.0

--- a/website/build/compiler.cjs
+++ b/website/build/compiler.cjs
@@ -92,54 +92,19 @@ const force =
 //     the EXACT typia install the wasm is compiled against, not a different
 //     install that happens to share a major version).
 //
-// Resolve the typia install in the same priority order go.mod uses (see
-// website/compiler/go.mod `replace github.com/samchon/typia/... =>
-// ../node_modules/typia/native`). website/node_modules wins; pnpm virtual
-// store comes second; compiler-dependencies/ is the last fallback.
-const resolvePackagePathForCacheKey = (packageName) => {
-  const candidates = [
-    path.join(ROOT, "node_modules", ...packageName.split("/")),
-  ];
-  const pnpmStore = path.join(REPO_ROOT, "node_modules", ".pnpm");
-  if (fs.existsSync(pnpmStore)) {
-    for (const entry of fs.readdirSync(pnpmStore)) {
-      candidates.push(path.join(pnpmStore, entry, "node_modules", ...packageName.split("/")));
-    }
-  }
-  candidates.push(
-    path.join(ROOT, "compiler-dependencies", "node_modules", ...packageName.split("/")),
-  );
-  for (const c of candidates) {
-    try {
-      const real = fs.realpathSync(c);
-      if (fs.existsSync(path.join(real, "package.json"))) return real;
-    } catch { /* keep trying */ }
-  }
-  return null;
-};
-
-const TYPIA_ROOT = resolvePackagePathForCacheKey("typia");
-let typiaPkgVersion = "unknown";
-if (TYPIA_ROOT) {
-  try {
-    typiaPkgVersion = JSON.parse(fs.readFileSync(path.join(TYPIA_ROOT, "package.json"), "utf8")).version;
-  } catch {
-    /* fresh checkout — leave as "unknown" */
-  }
-}
-const TYPIA_NATIVE_ADAPTER = TYPIA_ROOT
-  ? (() => {
-      const adapter = path.join(TYPIA_ROOT, "native", "adapter");
-      return fs.existsSync(adapter) ? adapter : null;
-    })()
-  : null;
+// Resolve the one website/node_modules/typia install named by compiler/go.mod.
+// The same graph object owns the version stamp and all generated packs.
+const { createTypiaDependencyGraph } = require("./typia-dependency-graph.cjs");
+const typiaGraph = createTypiaDependencyGraph({ websiteRoot: ROOT });
+const typiaPkgVersion = typiaGraph.version;
+const TYPIA_NATIVE_ADAPTER = typiaGraph.goAdapterRoot;
 const wasmSourceMtime = Math.max(
   newestMtime(COMPILER_DIR),
   newestMtime(path.join(REPO_ROOT, "packages", "wasm")),
   newestMtime(path.join(REPO_ROOT, "packages", "ttsc")),
   newestMtime(path.join(REPO_ROOT, "packages", "lint", "linthost")),
   newestMtime(path.join(REPO_ROOT, "packages", "lint", "rule")),
-  TYPIA_NATIVE_ADAPTER ? newestMtime(TYPIA_NATIVE_ADAPTER) : 0,
+  newestMtime(TYPIA_NATIVE_ADAPTER),
 );
 // Stamp the typia version into a sidecar file so a version bump alone busts
 // the cache. The wasm itself doesn't carry the version, so without this a
@@ -215,7 +180,7 @@ require("./typia-types.cjs");
 
 // ── 5. Build the typia source pack the worker mounts into MemFS ────────────
 // Mirrors typia's own `typia-pack.js` flow: copies the published source tree
-// under `node_modules/typia` (plus @typia/{interface,utils,core}) into one
+// under `node_modules/typia` with its discovered dependency closure into one
 // JSON blob the worker fetches at boot. Without it, the wasm-side compiler
 // can't resolve `import typia, { tags } from "typia"`.
 require("./pack-typia-sources.cjs");
@@ -225,8 +190,7 @@ require("./pack-typia-sources.cjs");
 // `new Function(...)` sandbox. The bundle does `require("typia/lib/internal/X")`
 // for the per-feature helpers typia's transform emits (validators, random
 // generators, JSON encoders). Without resolvable modules, every Execute
-// throws. The runtime pack ships the published JS for typia + @typia/* +
-// randexp so the sandbox can resolve those requires.
+// throws. The runtime pack follows those real requires transitively.
 require("./pack-typia-runtime.cjs");
 
 log("done.");

--- a/website/build/pack-typia-runtime.cjs
+++ b/website/build/pack-typia-runtime.cjs
@@ -1,32 +1,12 @@
-// Builds website/public/compiler/typia-runtime-pack.json — a CommonJS bundle
-// the playground's Execute sandbox uses to resolve typia/@typia/randexp
-// requires emitted by typia's source transform.
-//
-// Unlike pack-typia-sources.cjs (which ships TypeScript source so the wasm's
-// tsgo can typecheck `import typia, { tags } from "typia"`), this pack ships
-// the published JS so the Execute sandbox can actually call typia helpers at
-// runtime.
-//
-// Why it exists:
-//   The typia transform emits calls like
-//     require("typia/lib/internal/_isFormatEmail")
-//   in the CommonJS bundle the Execute sandbox runs. Without those modules
-//   resolvable, every "Execute" hit throws
-//     require("typia/lib/internal/...") is not available in the playground sandbox.
-//
-// Source roots: website/compiler-dependencies/node_modules/. That tree has
-// typia + transitive deps pinned to the same version the playground wasm was
-// built against, installed by npm (not pnpm) so hoisting matches a normal
-// consumer install.
-//
-// Output shape: { [absoluteSpec]: jsCode }. Mounts under sandbox-relative
-// paths like `typia/lib/internal/_isFormatEmail.js`.
+// Packs the CommonJS graph reachable from Typia's exported runtime surface.
+// Transitive packages are discovered from actual require/import statements.
 
 const fs = require("fs");
 const path = require("path");
 
+const { createTypiaDependencyGraph } = require("./typia-dependency-graph.cjs");
+
 const websiteRoot = path.resolve(__dirname, "..");
-const repoRoot = path.resolve(websiteRoot, "..");
 const outFile = path.join(
   websiteRoot,
   "public",
@@ -34,120 +14,21 @@ const outFile = path.join(
   "typia-runtime-pack.json",
 );
 
-// Resolve packages the same way pack-typia-sources.cjs does so the runtime
-// pack ships JS from the SAME typia install whose source the wasm sees. A
-// version skew between this pack and the source pack would let the Compiled
-// JS preview show typia.is(...) lowered against helpers the sandbox can't
-// resolve.
-function resolvePackageRoot(packageName) {
-  const candidates = [
-    path.join(websiteRoot, "node_modules", ...packageName.split("/")),
-  ];
-  const pnpmStore = path.join(repoRoot, "node_modules", ".pnpm");
-  if (fs.existsSync(pnpmStore)) {
-    for (const entry of fs.readdirSync(pnpmStore)) {
-      const candidate = path.join(pnpmStore, entry, "node_modules", ...packageName.split("/"));
-      candidates.push(candidate);
-    }
-  }
-  candidates.push(
-    path.join(websiteRoot, "compiler-dependencies", "node_modules", ...packageName.split("/")),
-  );
-  for (const c of candidates) {
-    try {
-      const real = fs.realpathSync(c);
-      if (fs.existsSync(path.join(real, "package.json"))) return real;
-    } catch {
-      /* keep trying */
-    }
-  }
-  return candidates[0];
-}
-
-// Each entry packs `<pkgDir>/lib/**/*.js` (or full tree for randexp & friends
-// which don't have a lib/ subdir). Maps & ESM `.mjs` variants are skipped:
-// the sandbox is CJS-only so mjs only adds weight.
-const SOURCES = [
-  { name: "typia", root: resolvePackageRoot("typia"), pickDirs: ["lib"], pickRoot: true },
-  { name: "@typia/utils", root: resolvePackageRoot("@typia/utils"), pickDirs: ["lib"], pickRoot: true },
-  { name: "@typia/core", root: resolvePackageRoot("@typia/core"), pickDirs: ["lib"], pickRoot: true },
-  { name: "@typia/interface", root: resolvePackageRoot("@typia/interface"), pickDirs: ["lib"], pickRoot: true },
-  // randexp + its transitive runtime deps (typia.random's regex generators).
-  { name: "randexp", root: resolvePackageRoot("randexp"), pickDirs: ["lib"], pickRoot: true },
-  { name: "ret", root: resolvePackageRoot("ret"), pickDirs: ["lib"], pickRoot: true },
-  { name: "drange", root: resolvePackageRoot("drange"), pickDirs: ["lib"], pickRoot: true },
-  { name: "discontinuous-range", root: resolvePackageRoot("discontinuous-range"), pickDirs: [], pickRoot: true },
-];
-
-function walk(dir) {
-  const out = [];
-  const stack = [dir];
-  while (stack.length > 0) {
-    const cur = stack.pop();
-    let entries;
-    try {
-      entries = fs.readdirSync(cur, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (entry.name === "node_modules") continue;
-      const full = path.join(cur, entry.name);
-      if (entry.isDirectory()) stack.push(full);
-      else if (entry.isFile()) out.push(full);
-    }
-  }
-  return out;
-}
-
-const KEEP = /\.js$/;
-const SKIP = /(\.mjs|\.map|\.d\.ts|\.test\.js|\.spec\.js)$/;
-
-function packDir(out, pkgName, pkgRoot, sub) {
-  const start = path.join(pkgRoot, sub);
-  if (!fs.existsSync(start)) return;
-  for (const file of walk(start)) {
-    if (SKIP.test(file)) continue;
-    if (!KEEP.test(file)) continue;
-    const rel = path.relative(pkgRoot, file).split(path.sep).join("/");
-    out[`${pkgName}/${rel}`] = fs.readFileSync(file, "utf8");
-  }
-}
-
-function packPackageJson(out, pkgName, pkgRoot) {
-  const pj = path.join(pkgRoot, "package.json");
-  if (fs.existsSync(pj)) {
-    out[`${pkgName}/package.json`] = fs.readFileSync(pj, "utf8");
-  }
-}
-
 function main() {
-  fs.mkdirSync(path.dirname(outFile), { recursive: true });
+  const graph = createTypiaDependencyGraph({ websiteRoot });
+  const closure = graph.collect("runtime");
   const pack = {};
-  for (const source of SOURCES) {
-    if (!fs.existsSync(source.root)) {
-      console.warn(`[pack-typia-runtime] missing ${source.name} at ${source.root}`);
-      continue;
-    }
-    if (source.pickRoot) packPackageJson(pack, source.name, source.root);
-    if (source.pickDirs.length === 0) {
-      // Pack the entire package root (excluding node_modules, maps, mjs).
-      for (const file of walk(source.root)) {
-        if (SKIP.test(file)) continue;
-        if (!KEEP.test(file)) continue;
-        const rel = path.relative(source.root, file).split(path.sep).join("/");
-        pack[`${source.name}/${rel}`] = fs.readFileSync(file, "utf8");
-      }
-    } else {
-      for (const sub of source.pickDirs) packDir(pack, source.name, source.root, sub);
-    }
+  for (const [key, file] of [...closure.files].sort(([left], [right]) => left.localeCompare(right))) {
+    if (file.endsWith(".mjs")) continue;
+    pack[key] = fs.readFileSync(file, "utf8");
   }
+  for (const [name, pkg] of [...closure.packages].sort(([left], [right]) => left.localeCompare(right))) {
+    pack[`${name}/package.json`] = JSON.stringify(pkg.manifest, null, 2);
+  }
+  fs.mkdirSync(path.dirname(outFile), { recursive: true });
   fs.writeFileSync(outFile, JSON.stringify(pack));
-  const stats = fs.statSync(outFile);
   console.log(
-    `[pack-typia-runtime] wrote ${Object.keys(pack).length} files (${(
-      stats.size / 1024
-    ).toFixed(1)} KB) to ${path.relative(websiteRoot, outFile)}`,
+    `[pack-typia-runtime] typia@${graph.version}: ${closure.packages.size} packages, ${Object.keys(pack).length} files (${(fs.statSync(outFile).size / 1024).toFixed(1)} KB)`,
   );
 }
 

--- a/website/build/pack-typia-runtime.cjs
+++ b/website/build/pack-typia-runtime.cjs
@@ -18,11 +18,14 @@ function main() {
   const graph = createTypiaDependencyGraph({ websiteRoot });
   const closure = graph.collect("runtime");
   const pack = {};
-  for (const [key, file] of [...closure.files].sort(([left], [right]) => left.localeCompare(right))) {
-    if (file.endsWith(".mjs")) continue;
+  for (const [key, file] of [...closure.files].sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
     pack[key] = fs.readFileSync(file, "utf8");
   }
-  for (const [name, pkg] of [...closure.packages].sort(([left], [right]) => left.localeCompare(right))) {
+  for (const [name, pkg] of [...closure.packages].sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
     pack[`${name}/package.json`] = JSON.stringify(pkg.manifest, null, 2);
   }
   fs.mkdirSync(path.dirname(outFile), { recursive: true });

--- a/website/build/pack-typia-sources.cjs
+++ b/website/build/pack-typia-sources.cjs
@@ -1,292 +1,45 @@
-// Builds website/public/compiler/typia-pack.json — the source pack the
-// playground worker mounts at `/work/node_modules/` so the in-browser ttsc
-// wasm can resolve `import typia, { tags } from "typia"`.
-//
-// We ship the original TypeScript source (not the published `.d.ts`/`.js`)
-// because the typescript-go compiler embedded in the wasm runs over the
-// same code the published package uses; typia's transformer wants to see
-// the real call signatures, not their type-only declarations.
-//
-// Output shape: { [relativePath]: contents }. Mount path is
-// `/work/node_modules/<relativePath>`. The companion runtime helper
-// `installTypiaPack` (in `src/compiler/typia-pack.ts`) does the mount.
-//
-// Mirrors typia's own `website/build/typia-pack.js` strategy. Differences:
-//
-//   - We source from the website's installed `node_modules/typia/src/` (and
-//     the @typia/interface, @typia/utils peer packages) — these are the
-//     versions the website's package-lock pinned.
-//   - We rewrite each package's `package.json` so `main`/`types`/`exports`
-//     point at `src/*.ts` instead of the published `lib/*.js`. tsgo's
-//     module resolver follows `types` when present.
+// Packs the source graph reachable from the exact Typia installation used by
+// the playground wasm. Package membership is derived from real imports and
+// export maps by typia-dependency-graph.cjs.
 
 const fs = require("fs");
 const path = require("path");
 
+const {
+  createTypiaDependencyGraph,
+  rewriteSourceManifest,
+} = require("./typia-dependency-graph.cjs");
+
 const websiteRoot = path.resolve(__dirname, "..");
-const repoRoot = path.resolve(websiteRoot, "..");
 const outFile = path.join(websiteRoot, "public", "compiler", "typia-pack.json");
 
-// CRITICAL: source the pack from the SAME typia install the wasm Go binary
-// links against. The compiler/go.mod has
-//   replace github.com/samchon/typia/packages/typia/native => ../node_modules/typia/native
-// which resolves to website/node_modules/typia/native — the pnpm-hoisted
-// typia install (may be a newer dev version than compiler-dependencies/).
-// If the pack's TypeScript surface drifts from the Go adapter's expectations,
-// CollectCallSites returns zero, transform becomes a no-op, and the
-// playground emits literal `typia.is(member)`.
-//
-// The script prefers website/node_modules/typia, then falls back to the
-// pnpm virtual store (pnpm puts the real files under
-// node_modules/.pnpm/typia@VERSION_.../node_modules/typia), then to the
-// website's compiler-dependencies/ tree.
-function resolveTypiaRoot(packageName) {
-  const candidates = [
-    path.join(websiteRoot, "node_modules", ...packageName.split("/")),
-  ];
-  // pnpm virtual store: walk node_modules/.pnpm for the first matching entry
-  const pnpmStore = path.join(repoRoot, "node_modules", ".pnpm");
-  if (fs.existsSync(pnpmStore)) {
-    for (const entry of fs.readdirSync(pnpmStore)) {
-      if (!entry.startsWith(packageName.replace("@", "+").replace("/", "+") + "@") && !entry.startsWith(packageName.split("/")[0] + "+" + packageName.split("/")[1] + "@") && !entry.startsWith(packageName.replace("/", "+") + "@") && !entry.startsWith(packageName + "@")) continue;
-      const candidate = path.join(pnpmStore, entry, "node_modules", ...packageName.split("/"));
-      candidates.push(candidate);
-    }
-  }
-  candidates.push(
-    path.join(websiteRoot, "compiler-dependencies", "node_modules", ...packageName.split("/")),
-  );
-  for (const c of candidates) {
-    try {
-      // Resolve symlinks so we end up at the real source the Go module sees.
-      const real = fs.realpathSync(c);
-      if (fs.existsSync(path.join(real, "package.json"))) return real;
-    } catch {
-      /* keep trying */
-    }
-  }
-  return candidates[0]; // last-ditch — the warn-on-missing below will catch it
-}
-
-// Each entry copies one published package's `src/` tree into the pack under
-// `<dest>/src/`. The skip predicate prunes files that pull in build-tool
-// imports the playground wasm can't satisfy (e.g. the typia transformer
-// entry, which imports its `transformers/` directory — only useful in a
-// build pipeline that runs `ttsc-typia`, not inside the wasm).
-const SOURCES = [
-  {
-    dest: "typia",
-    pkgRoot: resolveTypiaRoot("typia"),
-    // Skip only the truly build-tool-only entries. `transformers/` is NOT
-    // skipped: typia's runtime entries (functional.ts, json.ts, http.ts,
-    // misc.ts, module.ts, llm.ts, protobuf.ts, notations.ts, reflect.ts) all
-    // import `./transformers/NoTransformConfigurationError`, and dropping
-    // that file produces TS2307/TS2534/TS2355 errors when the wasm's tsgo
-    // loads the typia package. Those errors poison the type checker the
-    // typia adapter relies on — every typia.X() call site falls out of
-    // CollectCallSites, every transform becomes a no-op, and the playground
-    // emits literal `typia.is(member)`.
-    skip: (rel) =>
-      rel.startsWith("executable/") ||
-      rel === "transform.ts",
-  },
-  {
-    dest: "@typia/interface",
-    pkgRoot: resolveTypiaRoot("@typia/interface"),
-    skip: () => false,
-  },
-  {
-    dest: "@typia/utils",
-    pkgRoot: resolveTypiaRoot("@typia/utils"),
-    skip: () => false,
-  },
-  // typia 13.0.0-dev imports StandardSchemaV1 from @standard-schema/spec in
-  // _createStandardSchema.ts and module.ts. Without the package on the MemFS
-  // those imports emit TS2307 and poison the type checker → typia adapter
-  // can't resolve typia.X() call sites → transform is a no-op.
-  {
-    dest: "@standard-schema/spec",
-    pkgRoot: resolveTypiaRoot("@standard-schema/spec"),
-    skip: () => false,
-    fromDist: true, // ships built dist/, not src/
-  },
-];
-
-// NOTE: @typia/core is intentionally NOT in SOURCES. typia 13.0.0-dev does
-// not import from @typia/core directly (verified via `grep "@typia/core"
-// typia/src/`). Including it pulls in @typia/core/src/programmers/*, every
-// one of which `import ts from "typescript"` — and no `typescript` package
-// is in the MemFS. The resulting TS2307 errors poison the type checker the
-// typia adapter depends on.
-
-// File extensions we copy. `.tsx`/`.mts`/`.cts` are kept for symmetry; in
-// practice the trees we pack are all plain `.ts`.
-const FILE_FILTER = /\.(ts|tsx|mts|cts)$/;
-
-function walk(dir) {
-  const out = [];
-  const stack = [dir];
-  while (stack.length > 0) {
-    const cur = stack.pop();
-    let entries;
-    try {
-      entries = fs.readdirSync(cur, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      const full = path.join(cur, entry.name);
-      if (entry.isDirectory()) stack.push(full);
-      else if (entry.isFile()) out.push(full);
-    }
-  }
-  return out;
-}
-
-function copyPackageSrc(pack, { dest, pkgRoot, skip, fromDist }) {
-  // `fromDist` packages (like @standard-schema/spec) ship the .d.ts under
-  // dist/ already — the wasm's tsgo can consume those declarations directly,
-  // so we just mount them as-is without the lib/→src/ rewrite.
-  if (fromDist) {
-    const distRoot = path.join(pkgRoot, "dist");
-    if (!fs.existsSync(distRoot)) {
-      console.warn(`[pack-typia-sources] missing dist tree for ${dest} at ${distRoot}`);
-      return;
-    }
-    for (const file of walk(distRoot)) {
-      const rel = path.relative(distRoot, file).split(path.sep).join("/");
-      // include declarations + JS + esm so resolver finds whatever it asks for
-      if (!/\.(d\.ts|d\.cts|d\.mts|js|cjs|mjs|ts)$/.test(rel)) continue;
-      const key = path.posix.join(dest, "dist", rel);
-      pack[key] = fs.readFileSync(file, "utf8");
-    }
-    const pkgJsonPath = path.join(pkgRoot, "package.json");
-    if (fs.existsSync(pkgJsonPath)) {
-      pack[`${dest}/package.json`] = fs.readFileSync(pkgJsonPath, "utf8");
-    }
-    return;
-  }
-
-  const srcRoot = path.join(pkgRoot, "src");
-  if (!fs.existsSync(srcRoot)) {
-    console.warn(`[pack-typia-sources] missing src tree for ${dest} at ${srcRoot}`);
-    return;
-  }
-  for (const file of walk(srcRoot)) {
-    const rel = path.relative(srcRoot, file).split(path.sep).join("/");
-    if (skip(rel)) continue;
-    if (!FILE_FILTER.test(rel)) continue;
-    const key = path.posix.join(dest, "src", rel);
+function main() {
+  const graph = createTypiaDependencyGraph({ websiteRoot });
+  const closure = graph.collect("source");
+  const pack = {};
+  for (const [key, file] of [...closure.files].sort(([left], [right]) => left.localeCompare(right))) {
     pack[key] = fs.readFileSync(file, "utf8");
   }
-
-  // Rewrite the package.json so `types`/`main`/`exports` all point at the
-  // source tree. tsgo's resolver respects `types`/`exports` like tsc does.
-  const pkgJsonPath = path.join(pkgRoot, "package.json");
-  if (!fs.existsSync(pkgJsonPath)) {
-    console.warn(`[pack-typia-sources] missing package.json for ${dest}`);
-    return;
+  for (const [name, pkg] of [...closure.packages].sort(([left], [right]) => left.localeCompare(right))) {
+    pack[`${name}/package.json`] = JSON.stringify(
+      rewriteSourceManifest(pkg.manifest, pkg.root),
+      null,
+      2,
+    );
   }
-  const original = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
-  const exportsMap =
-    typeof original.exports === "object" && original.exports !== null
-      ? rewriteExports(original.exports)
-      : {
-          ".": "./src/index.ts",
-          "./package.json": "./package.json",
-        };
-  pack[`${dest}/package.json`] = JSON.stringify(
-    {
-      name: original.name,
-      version: original.version,
-      type: original.type,
-      main: "src/index.ts",
-      types: "src/index.ts",
-      exports: exportsMap,
-    },
-    null,
-    2,
-  );
-}
-
-// rewriteExports maps a published `exports` map ({ ".": { "types": "./lib/x.d.ts", ... } })
-// onto the equivalent source path ({ ".": "./src/x.ts" }). Preserves the
-// subpath conditions so deep imports like `typia/lib/internal/_isFormatUuid`
-// still resolve.
-function rewriteExports(exports) {
-  const out = {};
-  for (const [subpath, value] of Object.entries(exports)) {
-    if (typeof value === "string") {
-      out[subpath] = mapLibToSrc(value);
-      continue;
-    }
-    if (value && typeof value === "object") {
-      // Conditional exports: prefer `types` (declaration file) since the
-      // wasm's compile reads .ts/.d.ts. Fall back to `import` then `default`.
-      const candidate = value.types ?? value.import ?? value.default;
-      if (typeof candidate === "string") {
-        out[subpath] = mapLibToSrc(candidate);
-        continue;
-      }
-    }
-  }
-  // Always expose package.json for resolvers that probe it.
-  out["./package.json"] = "./package.json";
-  return out;
-}
-
-function mapLibToSrc(relPath) {
-  // ./lib/foo.d.ts → ./src/foo.ts. Wildcards in subpaths (`./lib/internal/*`)
-  // are preserved verbatim — the resolver replaces the `*` from the
-  // request side.
-  let p = relPath.replace(/^\.\/lib\//, "./src/");
-  p = p.replace(/\.d\.ts$/, ".ts");
-  p = p.replace(/\.mjs$/, ".ts");
-  p = p.replace(/\.js$/, ".ts");
-  return p;
-}
-
-// Stub `typescript` so `@typia/interface`'s `import type ts from "typescript"`
-// resolves without dragging the entire TypeScript Compiler API onto the
-// MemFS. We only need the *types* to be reachable — runtime never touches
-// this path inside the playground. Any unresolved-symbol use the typia
-// adapter triggers against the stub falls back to `any`, which is fine for
-// the call sites typia actually emits in the playground examples.
-function installTypeScriptStub(pack) {
-  pack["typescript/package.json"] = JSON.stringify(
-    {
-      name: "typescript",
-      version: "0.0.0-stub",
-      types: "lib/typescript.d.ts",
-      main: "lib/typescript.js",
-    },
-    null,
-    2,
-  );
-  pack["typescript/lib/typescript.d.ts"] = `// Minimal stub used by the playground's typia pack.\n// Real consumers ship their own typescript install; this stub only exists so\n// \`import type ts from "typescript"\` in @typia/interface compiles cleanly\n// inside the wasm's tsgo. The members listed here are the EXACT ts.* types\n// the runtime-relevant typia source files reference (audit: grep "ts\\." in\n// @typia/interface/src/ and typia/src/).\n\ndeclare namespace ts {\n  type Expression = any;\n  type Node = any;\n  type TypeNode = any;\n  type Type = any;\n  type Symbol = any;\n  type SourceFile = any;\n  type Statement = any;\n  type Declaration = any;\n  type TypeChecker = any;\n  type Program = any;\n  type CallExpression = any;\n  type Identifier = any;\n  type StringLiteral = any;\n  type NumericLiteral = any;\n  type ObjectLiteralExpression = any;\n  type ArrayLiteralExpression = any;\n  type PropertyAssignment = any;\n  type Modifier = any;\n  type ImportDeclaration = any;\n  type ImportSpecifier = any;\n  type NamedImports = any;\n  type CompilerOptions = any;\n}\nexport = ts;\nexport as namespace ts;\n`;
-  pack["typescript/lib/typescript.js"] = `// Stub. The playground never executes this module at runtime.\nmodule.exports = {};\n`;
-}
-
-function main() {
-  fs.mkdirSync(path.dirname(outFile), { recursive: true });
-  const pack = {};
-  for (const source of SOURCES) {
-    if (!fs.existsSync(source.pkgRoot)) {
-      console.warn(
-        `[pack-typia-sources] missing package ${source.dest} at ${source.pkgRoot}`,
-      );
-      continue;
-    }
-    copyPackageSrc(pack, source);
-  }
-  installTypeScriptStub(pack);
-  fs.writeFileSync(outFile, JSON.stringify(pack));
-  const stats = fs.statSync(outFile);
+  writePack(outFile, pack);
   console.log(
-    `[pack-typia-sources] wrote ${Object.keys(pack).length} files (${(
-      stats.size / 1024
-    ).toFixed(1)} KB) to ${path.relative(websiteRoot, outFile)}`,
+    `[pack-typia-sources] typia@${graph.version}: ${closure.packages.size} packages, ${Object.keys(pack).length} files (${kilobytes(outFile)} KB)`,
   );
+}
+
+function writePack(file, pack) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(pack));
+}
+
+function kilobytes(file) {
+  return (fs.statSync(file).size / 1024).toFixed(1);
 }
 
 main();

--- a/website/build/typia-dependency-graph.cjs
+++ b/website/build/typia-dependency-graph.cjs
@@ -5,7 +5,15 @@ const path = require("path");
 const DEFAULT_WEBSITE_ROOT = path.resolve(__dirname, "..");
 const SOURCE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".d.ts"];
 const RUNTIME_EXTENSIONS = [".js", ".cjs", ".mjs"];
-const TYPE_EXTENSIONS = [".d.ts", ".d.mts", ".d.cts"];
+const TYPE_EXTENSIONS = [
+  ".d.ts",
+  ".d.mts",
+  ".d.cts",
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+];
 const BUILTINS = new Set(
   moduleApi.builtinModules.flatMap((name) => [name, `node:${name}`]),
 );
@@ -38,7 +46,9 @@ function createTypiaDependencyGraph(options = {}) {
     goAdapterRoot,
     collect(kind) {
       if (!new Set(["source", "runtime", "types"]).has(kind)) {
-        throw new Error(`[typia-graph] unknown closure kind ${JSON.stringify(kind)}`);
+        throw new Error(
+          `[typia-graph] unknown closure kind ${JSON.stringify(kind)}`,
+        );
       }
       return collectClosure({
         kind,
@@ -58,7 +68,12 @@ function collectClosure({ kind, root, manifest, expectedVersion }) {
 
   registerPackage(packages, manifest.name, root, manifest, expectedVersion);
   for (const entry of rootEntrypoints(root, manifest, kind)) {
-    queued.push({ file: entry, packageName: manifest.name, packageRoot: root });
+    queued.push({
+      file: entry,
+      packageName: manifest.name,
+      packageRoot: root,
+      chain: [],
+    });
   }
 
   while (queued.length > 0) {
@@ -68,29 +83,47 @@ function collectClosure({ kind, root, manifest, expectedVersion }) {
     visited.add(real);
     const rel = slash(path.relative(current.packageRoot, real));
     if (rel === ".." || rel.startsWith("../")) {
-      throw new Error(`[typia-graph] resolved file escaped package root: ${real}`);
+      throw new Error(
+        `[typia-graph] resolved file escaped package root: ${real}`,
+      );
     }
-    files.set(`${current.packageName}/${rel}`, real);
+    const key = `${current.packageName}/${rel}`;
+    if (kind === "runtime" && real.endsWith(".mjs")) {
+      throw new Error(
+        `[typia-graph] ${formatImportChain(current.chain, key)} resolves to an ESM-only runtime module; the playground Execute sandbox requires CommonJS`,
+      );
+    }
+    files.set(key, real);
 
     const text = fs.readFileSync(real, "utf8");
     for (const specifier of parseModuleSpecifiers(text)) {
       if (BUILTINS.has(specifier) || specifier.startsWith("node:")) continue;
       if (specifier.startsWith(".") || specifier.startsWith("/")) {
-        const target = resolveFile(path.resolve(path.dirname(real), specifier), kind);
+        const target = resolveFile(
+          path.resolve(path.dirname(real), specifier),
+          kind,
+        );
         if (!target) {
           throw new Error(
-            `[typia-graph] ${current.packageName}/${rel} imports missing ${JSON.stringify(specifier)}`,
+            `[typia-graph] ${formatImportChain(current.chain, key)} imports missing ${JSON.stringify(specifier)}`,
           );
         }
-        queued.push({ ...current, file: target });
+        queued.push({
+          ...current,
+          file: target,
+          chain: [...current.chain, key],
+        });
         continue;
       }
 
       const { packageName, subpath } = splitPackageSpecifier(specifier);
-      const dependencyRoot = findDependencyRoot(current.packageRoot, packageName);
+      const dependencyRoot = findDependencyRoot(
+        current.packageRoot,
+        packageName,
+      );
       if (!dependencyRoot) {
         throw new Error(
-          `[typia-graph] ${current.packageName}/${rel} imports missing package ${JSON.stringify(packageName)}`,
+          `[typia-graph] ${formatImportChain(current.chain, key)} imports missing package ${JSON.stringify(packageName)}`,
         );
       }
       const dependencyManifest = readManifest(dependencyRoot);
@@ -114,13 +147,14 @@ function collectClosure({ kind, root, manifest, expectedVersion }) {
       );
       if (!target) {
         throw new Error(
-          `[typia-graph] ${current.packageName}/${rel} cannot resolve ${JSON.stringify(specifier)} for ${kind}`,
+          `[typia-graph] ${formatImportChain(current.chain, key)} cannot resolve ${JSON.stringify(specifier)} for ${kind}`,
         );
       }
       queued.push({
         file: target,
         packageName,
         packageRoot: dependencyRoot,
+        chain: [...current.chain, key],
       });
     }
   }
@@ -144,10 +178,20 @@ function rootEntrypoints(root, manifest, kind) {
   entries.push(resolvedRoot);
 
   for (const [subpath, value] of Object.entries(manifest.exports ?? {})) {
-    if (!subpath.includes("*")) continue;
+    if (subpath === "." || subpath === "./package.json") continue;
     const target = selectConditionalTarget(value, kind);
-    if (typeof target !== "string" || !target.includes("*")) continue;
-    entries.push(...expandWildcardTarget(root, target, kind));
+    if (typeof target !== "string") continue;
+    if (target.includes("*")) {
+      entries.push(...expandWildcardTarget(root, target, kind));
+      continue;
+    }
+    const resolved = resolveManifestTarget(root, target, kind);
+    if (!resolved) {
+      throw new Error(
+        `[typia-graph] typia ${kind} export ${JSON.stringify(subpath)} is missing: ${target}`,
+      );
+    }
+    entries.push(resolved);
   }
   return [...new Set(entries.map((entry) => fs.realpathSync(entry)))];
 }
@@ -180,9 +224,11 @@ function resolvePackageImport(root, manifest, subpath, kind) {
 function selectTarget(rootExport, manifest, kind) {
   const exported = selectConditionalTarget(rootExport, kind);
   if (typeof exported === "string") return exported;
-  if (kind === "types") return manifest.types ?? manifest.typings ?? manifest.main;
-  if (kind === "source") return manifest.types ?? manifest.typings ?? manifest.main;
-  return manifest.main ?? manifest.module;
+  if (kind === "types")
+    return manifest.types ?? manifest.typings ?? manifest.main;
+  if (kind === "source")
+    return manifest.types ?? manifest.typings ?? manifest.main;
+  return manifest.main;
 }
 
 function selectConditionalTarget(value, kind) {
@@ -191,7 +237,7 @@ function selectConditionalTarget(value, kind) {
   const conditions =
     kind === "types" || kind === "source"
       ? ["types", "default", "import", "require"]
-      : ["require", "default", "import"];
+      : ["require", "default"];
   for (const condition of conditions) {
     const selected = selectConditionalTarget(value[condition], kind);
     if (selected) return selected;
@@ -210,7 +256,8 @@ function mapPublishedPathToSource(root, relative) {
     .replace(/^lib\//, "src/")
     .replace(/\.d\.(?:mts|cts|ts)$/, ".ts")
     .replace(/\.(?:mjs|cjs|js)$/, ".ts");
-  if (mapped.includes("*") && fs.existsSync(path.join(root, "src"))) return mapped;
+  if (mapped.includes("*") && fs.existsSync(path.join(root, "src")))
+    return mapped;
   return resolveFile(path.join(root, mapped), "source") ? mapped : relative;
 }
 
@@ -222,11 +269,17 @@ function expandWildcardTarget(root, target, kind) {
   const suffix = relative.slice(star + 1);
   const searchRoot = path.join(root, path.dirname(prefix));
   if (!fs.existsSync(searchRoot)) {
-    throw new Error(`[typia-graph] wildcard export root is missing: ${searchRoot}`);
+    throw new Error(
+      `[typia-graph] wildcard export root is missing: ${searchRoot}`,
+    );
   }
   return walkFiles(searchRoot).filter((file) => {
     const rel = slash(path.relative(root, file));
-    return rel.startsWith(prefix) && rel.endsWith(suffix) && extensionAllowed(rel, kind);
+    return (
+      rel.startsWith(prefix) &&
+      rel.endsWith(suffix) &&
+      extensionAllowed(rel, kind)
+    );
   });
 }
 
@@ -239,7 +292,8 @@ function resolveFile(base, kind) {
         : TYPE_EXTENSIONS;
   const candidates = [base];
   for (const extension of extensions) candidates.push(`${base}${extension}`);
-  for (const extension of extensions) candidates.push(path.join(base, `index${extension}`));
+  for (const extension of extensions)
+    candidates.push(path.join(base, `index${extension}`));
   for (const candidate of candidates) {
     try {
       if (fs.statSync(candidate).isFile()) return fs.realpathSync(candidate);
@@ -253,7 +307,7 @@ function resolveFile(base, kind) {
 function extensionAllowed(file, kind) {
   if (kind === "source") return /\.(?:ts|tsx|mts|cts)$/.test(file);
   if (kind === "runtime") return /\.(?:js|cjs|mjs)$/.test(file);
-  return /\.d\.(?:ts|mts|cts)$/.test(file);
+  return /(?:\.d)?\.(?:ts|tsx|mts|cts)$/.test(file);
 }
 
 function parseModuleSpecifiers(text) {
@@ -295,7 +349,11 @@ function registerPackage(packages, name, root, manifest, expectedVersion) {
 function findDependencyRoot(fromPackageRoot, packageName) {
   let current = fs.realpathSync(fromPackageRoot);
   while (true) {
-    const candidate = path.join(current, "node_modules", ...packageName.split("/"));
+    const candidate = path.join(
+      current,
+      "node_modules",
+      ...packageName.split("/"),
+    );
     try {
       return realPackageRoot(candidate, packageName);
     } catch {
@@ -327,8 +385,12 @@ function readManifest(root) {
 }
 
 function readExactTypiaPin(repoRoot) {
-  const workspace = fs.readFileSync(path.join(repoRoot, "pnpm-workspace.yaml"), "utf8");
-  const samchon = workspace.match(/\n  samchon:\r?\n([\s\S]*?)(?:\n  [a-zA-Z]|$)/)?.[1] ?? "";
+  const workspace = fs.readFileSync(
+    path.join(repoRoot, "pnpm-workspace.yaml"),
+    "utf8",
+  );
+  const samchon =
+    workspace.match(/\n  samchon:\r?\n([\s\S]*?)(?:\n  [a-zA-Z]|$)/)?.[1] ?? "";
   const version = samchon.match(/^    typia:\s+['"]?([^'"\s#]+)['"]?/m)?.[1];
   if (!version || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
     throw new Error(
@@ -341,7 +403,10 @@ function readExactTypiaPin(repoRoot) {
 function splitPackageSpecifier(specifier) {
   const parts = specifier.split("/");
   if (specifier.startsWith("@")) {
-    return { packageName: parts.slice(0, 2).join("/"), subpath: parts.slice(2).join("/") };
+    return {
+      packageName: parts.slice(0, 2).join("/"),
+      subpath: parts.slice(2).join("/"),
+    };
   }
   return { packageName: parts[0], subpath: parts.slice(1).join("/") };
 }
@@ -362,18 +427,21 @@ function walkFiles(root) {
 }
 
 function rewriteSourceManifest(manifest, packageRoot) {
-  const hasSourceTree = packageRoot && fs.existsSync(path.join(packageRoot, "src"));
+  const hasSourceTree =
+    packageRoot && fs.existsSync(path.join(packageRoot, "src"));
   const rewrite = (value) => {
     if (typeof value === "string") {
-      if (!hasSourceTree || !value.startsWith("./lib/")) return value;
+      if (!hasSourceTree || !/^(?:\.\/)?lib\//.test(value)) return value;
       return value
-        .replace(/^\.\/lib\//, "./src/")
+        .replace(/^(\.\/)?lib\//, "$1src/")
         .replace(/\.d\.(?:mts|cts|ts)$/, ".ts")
         .replace(/\.(?:mjs|cjs|js)$/, ".ts");
     }
     if (!value || typeof value !== "object") return value;
     if (Array.isArray(value)) return value.map(rewrite);
-    return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, rewrite(child)]));
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, rewrite(child)]),
+    );
   };
   const output = { ...manifest };
   if (output.main) output.main = rewrite(output.main);
@@ -382,6 +450,10 @@ function rewriteSourceManifest(manifest, packageRoot) {
   if (output.typings) output.typings = rewrite(output.typings);
   if (output.exports) output.exports = rewrite(output.exports);
   return output;
+}
+
+function formatImportChain(chain, key) {
+  return [...chain, key].join(" -> ");
 }
 
 function slash(value) {

--- a/website/build/typia-dependency-graph.cjs
+++ b/website/build/typia-dependency-graph.cjs
@@ -1,0 +1,395 @@
+const fs = require("fs");
+const moduleApi = require("module");
+const path = require("path");
+
+const DEFAULT_WEBSITE_ROOT = path.resolve(__dirname, "..");
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".d.ts"];
+const RUNTIME_EXTENSIONS = [".js", ".cjs", ".mjs"];
+const TYPE_EXTENSIONS = [".d.ts", ".d.mts", ".d.cts"];
+const BUILTINS = new Set(
+  moduleApi.builtinModules.flatMap((name) => [name, `node:${name}`]),
+);
+
+function createTypiaDependencyGraph(options = {}) {
+  const websiteRoot = path.resolve(options.websiteRoot ?? DEFAULT_WEBSITE_ROOT);
+  const repoRoot = path.resolve(websiteRoot, "..");
+  const requestedRoot =
+    options.typiaRoot ?? path.join(websiteRoot, "node_modules", "typia");
+  const typiaRoot = realPackageRoot(requestedRoot, "typia");
+  const typiaManifest = readManifest(typiaRoot);
+  const expectedVersion =
+    options.expectedVersion ??
+    (options.typiaRoot ? typiaManifest.version : readExactTypiaPin(repoRoot));
+  if (typiaManifest.version !== expectedVersion) {
+    throw new Error(
+      `[typia-graph] installed typia ${typiaManifest.version} does not match exact workspace pin ${expectedVersion}`,
+    );
+  }
+  const goAdapterRoot = path.join(typiaRoot, "native", "adapter");
+  if (!fs.existsSync(goAdapterRoot)) {
+    throw new Error(
+      `[typia-graph] authoritative typia install has no native adapter: ${goAdapterRoot}`,
+    );
+  }
+
+  return {
+    version: typiaManifest.version,
+    typiaRoot,
+    goAdapterRoot,
+    collect(kind) {
+      if (!new Set(["source", "runtime", "types"]).has(kind)) {
+        throw new Error(`[typia-graph] unknown closure kind ${JSON.stringify(kind)}`);
+      }
+      return collectClosure({
+        kind,
+        root: typiaRoot,
+        manifest: typiaManifest,
+        expectedVersion,
+      });
+    },
+  };
+}
+
+function collectClosure({ kind, root, manifest, expectedVersion }) {
+  const packages = new Map();
+  const files = new Map();
+  const queued = [];
+  const visited = new Set();
+
+  registerPackage(packages, manifest.name, root, manifest, expectedVersion);
+  for (const entry of rootEntrypoints(root, manifest, kind)) {
+    queued.push({ file: entry, packageName: manifest.name, packageRoot: root });
+  }
+
+  while (queued.length > 0) {
+    const current = queued.shift();
+    const real = fs.realpathSync(current.file);
+    if (visited.has(real)) continue;
+    visited.add(real);
+    const rel = slash(path.relative(current.packageRoot, real));
+    if (rel === ".." || rel.startsWith("../")) {
+      throw new Error(`[typia-graph] resolved file escaped package root: ${real}`);
+    }
+    files.set(`${current.packageName}/${rel}`, real);
+
+    const text = fs.readFileSync(real, "utf8");
+    for (const specifier of parseModuleSpecifiers(text)) {
+      if (BUILTINS.has(specifier) || specifier.startsWith("node:")) continue;
+      if (specifier.startsWith(".") || specifier.startsWith("/")) {
+        const target = resolveFile(path.resolve(path.dirname(real), specifier), kind);
+        if (!target) {
+          throw new Error(
+            `[typia-graph] ${current.packageName}/${rel} imports missing ${JSON.stringify(specifier)}`,
+          );
+        }
+        queued.push({ ...current, file: target });
+        continue;
+      }
+
+      const { packageName, subpath } = splitPackageSpecifier(specifier);
+      const dependencyRoot = findDependencyRoot(current.packageRoot, packageName);
+      if (!dependencyRoot) {
+        throw new Error(
+          `[typia-graph] ${current.packageName}/${rel} imports missing package ${JSON.stringify(packageName)}`,
+        );
+      }
+      const dependencyManifest = readManifest(dependencyRoot);
+      if (dependencyManifest.name !== packageName) {
+        throw new Error(
+          `[typia-graph] resolved ${packageName} to manifest ${dependencyManifest.name} at ${dependencyRoot}`,
+        );
+      }
+      registerPackage(
+        packages,
+        packageName,
+        dependencyRoot,
+        dependencyManifest,
+        expectedVersion,
+      );
+      const target = resolvePackageImport(
+        dependencyRoot,
+        dependencyManifest,
+        subpath,
+        kind,
+      );
+      if (!target) {
+        throw new Error(
+          `[typia-graph] ${current.packageName}/${rel} cannot resolve ${JSON.stringify(specifier)} for ${kind}`,
+        );
+      }
+      queued.push({
+        file: target,
+        packageName,
+        packageRoot: dependencyRoot,
+      });
+    }
+  }
+
+  return { kind, version: expectedVersion, packages, files };
+}
+
+function rootEntrypoints(root, manifest, kind) {
+  const entries = [];
+  const rootExport = manifest.exports?.["."];
+  const rootTarget = selectTarget(rootExport, manifest, kind);
+  if (!rootTarget) {
+    throw new Error(`[typia-graph] typia has no ${kind} root entrypoint`);
+  }
+  const resolvedRoot = resolveManifestTarget(root, rootTarget, kind);
+  if (!resolvedRoot) {
+    throw new Error(
+      `[typia-graph] typia ${kind} root entrypoint is missing: ${rootTarget}`,
+    );
+  }
+  entries.push(resolvedRoot);
+
+  for (const [subpath, value] of Object.entries(manifest.exports ?? {})) {
+    if (!subpath.includes("*")) continue;
+    const target = selectConditionalTarget(value, kind);
+    if (typeof target !== "string" || !target.includes("*")) continue;
+    entries.push(...expandWildcardTarget(root, target, kind));
+  }
+  return [...new Set(entries.map((entry) => fs.realpathSync(entry)))];
+}
+
+function resolvePackageImport(root, manifest, subpath, kind) {
+  if (subpath === "") {
+    const target = selectTarget(manifest.exports?.["."], manifest, kind);
+    return target ? resolveManifestTarget(root, target, kind) : null;
+  }
+  const key = `./${subpath}`;
+  const direct = manifest.exports?.[key];
+  if (direct !== undefined) {
+    const target = selectConditionalTarget(direct, kind);
+    return typeof target === "string"
+      ? resolveManifestTarget(root, target, kind)
+      : null;
+  }
+  for (const [pattern, value] of Object.entries(manifest.exports ?? {})) {
+    if (!pattern.includes("*")) continue;
+    const [prefix, suffix] = pattern.split("*");
+    if (!key.startsWith(prefix) || !key.endsWith(suffix)) continue;
+    const wildcard = key.slice(prefix.length, key.length - suffix.length);
+    const target = selectConditionalTarget(value, kind);
+    if (typeof target !== "string") return null;
+    return resolveManifestTarget(root, target.replace("*", wildcard), kind);
+  }
+  return resolveFile(path.join(root, subpath), kind);
+}
+
+function selectTarget(rootExport, manifest, kind) {
+  const exported = selectConditionalTarget(rootExport, kind);
+  if (typeof exported === "string") return exported;
+  if (kind === "types") return manifest.types ?? manifest.typings ?? manifest.main;
+  if (kind === "source") return manifest.types ?? manifest.typings ?? manifest.main;
+  return manifest.main ?? manifest.module;
+}
+
+function selectConditionalTarget(value, kind) {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const conditions =
+    kind === "types" || kind === "source"
+      ? ["types", "default", "import", "require"]
+      : ["require", "default", "import"];
+  for (const condition of conditions) {
+    const selected = selectConditionalTarget(value[condition], kind);
+    if (selected) return selected;
+  }
+  return null;
+}
+
+function resolveManifestTarget(root, target, kind) {
+  let relative = target.replace(/^\.\//, "");
+  if (kind === "source") relative = mapPublishedPathToSource(root, relative);
+  return resolveFile(path.join(root, relative), kind);
+}
+
+function mapPublishedPathToSource(root, relative) {
+  const mapped = relative
+    .replace(/^lib\//, "src/")
+    .replace(/\.d\.(?:mts|cts|ts)$/, ".ts")
+    .replace(/\.(?:mjs|cjs|js)$/, ".ts");
+  if (mapped.includes("*") && fs.existsSync(path.join(root, "src"))) return mapped;
+  return resolveFile(path.join(root, mapped), "source") ? mapped : relative;
+}
+
+function expandWildcardTarget(root, target, kind) {
+  let relative = target.replace(/^\.\//, "");
+  if (kind === "source") relative = mapPublishedPathToSource(root, relative);
+  const star = relative.indexOf("*");
+  const prefix = relative.slice(0, star);
+  const suffix = relative.slice(star + 1);
+  const searchRoot = path.join(root, path.dirname(prefix));
+  if (!fs.existsSync(searchRoot)) {
+    throw new Error(`[typia-graph] wildcard export root is missing: ${searchRoot}`);
+  }
+  return walkFiles(searchRoot).filter((file) => {
+    const rel = slash(path.relative(root, file));
+    return rel.startsWith(prefix) && rel.endsWith(suffix) && extensionAllowed(rel, kind);
+  });
+}
+
+function resolveFile(base, kind) {
+  const extensions =
+    kind === "source"
+      ? SOURCE_EXTENSIONS
+      : kind === "runtime"
+        ? RUNTIME_EXTENSIONS
+        : TYPE_EXTENSIONS;
+  const candidates = [base];
+  for (const extension of extensions) candidates.push(`${base}${extension}`);
+  for (const extension of extensions) candidates.push(path.join(base, `index${extension}`));
+  for (const candidate of candidates) {
+    try {
+      if (fs.statSync(candidate).isFile()) return fs.realpathSync(candidate);
+    } catch {
+      // Continue through the deterministic extension list.
+    }
+  }
+  return null;
+}
+
+function extensionAllowed(file, kind) {
+  if (kind === "source") return /\.(?:ts|tsx|mts|cts)$/.test(file);
+  if (kind === "runtime") return /\.(?:js|cjs|mjs)$/.test(file);
+  return /\.d\.(?:ts|mts|cts)$/.test(file);
+}
+
+function parseModuleSpecifiers(text) {
+  const stripped = stripComments(text);
+  const found = new Set();
+  const patterns = [
+    /\b(?:import|export)\s+(?:type\s+)?(?:[^"']*?\s+from\s*)?["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of stripped.matchAll(pattern)) found.add(match[1]);
+  }
+  return [...found];
+}
+
+function stripComments(text) {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+function registerPackage(packages, name, root, manifest, expectedVersion) {
+  const existing = packages.get(name);
+  const real = fs.realpathSync(root);
+  if (existing && existing.root !== real) {
+    throw new Error(
+      `[typia-graph] package ${name} resolved to two installations: ${existing.root} and ${real}`,
+    );
+  }
+  if (name.startsWith("@typia/") && manifest.version !== expectedVersion) {
+    throw new Error(
+      `[typia-graph] ${name}@${manifest.version} does not match typia@${expectedVersion}`,
+    );
+  }
+  packages.set(name, { name, root: real, manifest });
+}
+
+function findDependencyRoot(fromPackageRoot, packageName) {
+  let current = fs.realpathSync(fromPackageRoot);
+  while (true) {
+    const candidate = path.join(current, "node_modules", ...packageName.split("/"));
+    try {
+      return realPackageRoot(candidate, packageName);
+    } catch {
+      // Keep walking through the pnpm virtual-store ancestry.
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function realPackageRoot(candidate, expectedName) {
+  const real = fs.realpathSync(candidate);
+  const manifest = readManifest(real);
+  if (manifest.name !== expectedName) {
+    throw new Error(
+      `[typia-graph] expected ${expectedName} at ${candidate}, found ${manifest.name}`,
+    );
+  }
+  return real;
+}
+
+function readManifest(root) {
+  const file = path.join(root, "package.json");
+  if (!fs.existsSync(file)) {
+    throw new Error(`[typia-graph] missing package.json: ${file}`);
+  }
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function readExactTypiaPin(repoRoot) {
+  const workspace = fs.readFileSync(path.join(repoRoot, "pnpm-workspace.yaml"), "utf8");
+  const samchon = workspace.match(/\n  samchon:\r?\n([\s\S]*?)(?:\n  [a-zA-Z]|$)/)?.[1] ?? "";
+  const version = samchon.match(/^    typia:\s+['"]?([^'"\s#]+)['"]?/m)?.[1];
+  if (!version || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(
+      `[typia-graph] catalogs.samchon.typia must be one exact version, found ${JSON.stringify(version)}`,
+    );
+  }
+  return version;
+}
+
+function splitPackageSpecifier(specifier) {
+  const parts = specifier.split("/");
+  if (specifier.startsWith("@")) {
+    return { packageName: parts.slice(0, 2).join("/"), subpath: parts.slice(2).join("/") };
+  }
+  return { packageName: parts[0], subpath: parts.slice(1).join("/") };
+}
+
+function walkFiles(root) {
+  const files = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.name === "node_modules") continue;
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.isFile()) files.push(full);
+    }
+  }
+  return files.sort();
+}
+
+function rewriteSourceManifest(manifest, packageRoot) {
+  const hasSourceTree = packageRoot && fs.existsSync(path.join(packageRoot, "src"));
+  const rewrite = (value) => {
+    if (typeof value === "string") {
+      if (!hasSourceTree || !value.startsWith("./lib/")) return value;
+      return value
+        .replace(/^\.\/lib\//, "./src/")
+        .replace(/\.d\.(?:mts|cts|ts)$/, ".ts")
+        .replace(/\.(?:mjs|cjs|js)$/, ".ts");
+    }
+    if (!value || typeof value !== "object") return value;
+    if (Array.isArray(value)) return value.map(rewrite);
+    return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, rewrite(child)]));
+  };
+  const output = { ...manifest };
+  if (output.main) output.main = rewrite(output.main);
+  if (output.module) output.module = rewrite(output.module);
+  if (output.types) output.types = rewrite(output.types);
+  if (output.typings) output.typings = rewrite(output.typings);
+  if (output.exports) output.exports = rewrite(output.exports);
+  return output;
+}
+
+function slash(value) {
+  return value.split(path.sep).join("/");
+}
+
+module.exports = {
+  createTypiaDependencyGraph,
+  parseModuleSpecifiers,
+  rewriteSourceManifest,
+};

--- a/website/build/typia-types.cjs
+++ b/website/build/typia-types.cjs
@@ -1,135 +1,33 @@
-// Packs typia's d.ts surface into a JSON file consumed by Monaco's
-// `addExtraLib` so the playground source editor can resolve
-// `import typia, { tags } from "typia"` without red squigglies.
-//
-// We walk every `.d.ts` file under the packages typia's public types depend
-// on. Anything Monaco still can't resolve is shimmed with an ambient module
-// declaration (see the AMBIENT_MODULE_STUBS list below). The output goes to
-// `src/compiler/typia-types.json` keyed by `file:///node_modules/...` paths.
+// Packs the declaration graph reachable from Typia's editor surface. Every
+// transitive declaration is real; missing packages fail generation instead of
+// being hidden behind ambient-any modules.
 
 const fs = require("fs");
 const path = require("path");
 
-const ROOT = path.resolve(__dirname, "..");
-const OUT_FILE = path.join(ROOT, "src/compiler/typia-types.json");
+const { createTypiaDependencyGraph } = require("./typia-dependency-graph.cjs");
 
-// Packages whose `lib/` (or fallback `dist/`) d.ts trees we copy in full.
-// Order matters only for readability; Monaco resolves by path.
-const PACKAGES = [
-  { name: "typia", subdir: "lib" },
-  { name: "@typia/interface", subdir: "lib" },
-  { name: "@typia/utils", subdir: "lib" },
-  { name: "@standard-schema/spec", subdir: "dist" },
-];
-
-// Ambient stubs for transitive references that appear in typia .d.ts files
-// (mostly inside JSDoc-tagged example imports) but whose real packages aren't
-// shipped to the browser.
-const AMBIENT_MODULE_STUBS = [
-  "@typia/mcp",
-  "@typia/core",
-  "@modelcontextprotocol/sdk/server/mcp.js",
-  "node-fetch",
-  "ttsc",
-];
-
-function findPackageDir(name) {
-  // We walk node_modules trees starting at known roots — the website, the
-  // monorepo root, and typia's own pnpm folder so that peer deps like
-  // `@standard-schema/spec` are reachable. `require.resolve` is unreliable
-  // for sibling packages whose `exports` map blocks `./package.json`.
-  const typiaRoot = (() => {
-    try {
-      return path.dirname(
-        require.resolve("typia/package.json", { paths: [ROOT] }),
-      );
-    } catch {
-      return null;
-    }
-  })();
-  const seeds = [
-    ROOT,
-    path.join(ROOT, ".."),
-    ...(typiaRoot ? [typiaRoot, path.join(typiaRoot, "..")] : []),
-  ];
-  for (const seed of seeds) {
-    let current = seed;
-    while (true) {
-      const candidate = path.join(current, "node_modules", name);
-      if (fs.existsSync(path.join(candidate, "package.json"))) return candidate;
-      const parent = path.dirname(current);
-      if (parent === current) break;
-      current = parent;
-    }
-  }
-  return null;
-}
-
-function collectDtsFiles(dir) {
-  const out = [];
-  const stack = [dir];
-  while (stack.length > 0) {
-    const current = stack.pop();
-    let entries;
-    try {
-      entries = fs.readdirSync(current, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      const full = path.join(current, entry.name);
-      if (entry.isDirectory()) stack.push(full);
-      else if (entry.isFile() && entry.name.endsWith(".d.ts")) out.push(full);
-    }
-  }
-  return out;
-}
+const websiteRoot = path.resolve(__dirname, "..");
+const outFile = path.join(websiteRoot, "src", "compiler", "typia-types.json");
 
 function main() {
-  const packed = {};
-  for (const { name, subdir } of PACKAGES) {
-    const pkgDir = findPackageDir(name);
-    if (!pkgDir) {
-      console.warn(`[build:typia-types] could not resolve ${name}, skipping`);
-      continue;
-    }
-    const root = path.join(pkgDir, subdir);
-    if (!fs.existsSync(root)) {
-      console.warn(`[build:typia-types] ${name}/${subdir} missing, skipping`);
-      continue;
-    }
-    const files = collectDtsFiles(root);
-    for (const file of files) {
-      const rel = path.relative(pkgDir, file).split(path.sep).join("/");
-      const key = `file:///node_modules/${name}/${rel}`;
-      packed[key] = fs.readFileSync(file, "utf8");
-    }
-    // Also expose package.json so Monaco's resolver can pick up
-    // the `types`/`exports` field.
-    const pkgJsonPath = path.join(pkgDir, "package.json");
-    if (fs.existsSync(pkgJsonPath)) {
-      packed[`file:///node_modules/${name}/package.json`] =
-        fs.readFileSync(pkgJsonPath, "utf8");
-    }
+  const graph = createTypiaDependencyGraph({ websiteRoot });
+  const closure = graph.collect("types");
+  const pack = {};
+  for (const [key, file] of [...closure.files].sort(([left], [right]) => left.localeCompare(right))) {
+    pack[`file:///node_modules/${key}`] = fs.readFileSync(file, "utf8");
   }
-
-  for (const moduleName of AMBIENT_MODULE_STUBS) {
-    const key = `file:///node_modules/__ttsc_playground_stub_${moduleName.replace(
-      /[^a-z0-9]+/gi,
-      "_",
-    )}.d.ts`;
-    packed[key] = `declare module "${moduleName}" {\n  const value: any;\n  export = value;\n}\n`;
+  for (const [name, pkg] of [...closure.packages].sort(([left], [right]) => left.localeCompare(right))) {
+    pack[`file:///node_modules/${name}/package.json`] = JSON.stringify(
+      pkg.manifest,
+      null,
+      2,
+    );
   }
-
-  fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true });
-  fs.writeFileSync(OUT_FILE, JSON.stringify(packed), "utf8");
-
-  const fileCount = Object.keys(packed).length;
-  const bytes = fs.statSync(OUT_FILE).size;
+  fs.mkdirSync(path.dirname(outFile), { recursive: true });
+  fs.writeFileSync(outFile, JSON.stringify(pack));
   console.log(
-    `[build:typia-types] wrote ${fileCount} entries (${(bytes / 1024).toFixed(
-      1,
-    )} KB) to ${path.relative(ROOT, OUT_FILE)}`,
+    `[build:typia-types] typia@${graph.version}: ${closure.packages.size} packages, ${Object.keys(pack).length} files (${(fs.statSync(outFile).size / 1024).toFixed(1)} KB)`,
   );
 }
 

--- a/website/compiler/cmd/playground/main.go
+++ b/website/compiler/cmd/playground/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+  "context"
   "fmt"
   "os"
 
@@ -31,7 +32,10 @@ func main() {
     name, command := args[0], args[1]
     for _, p := range plugins {
       if p.Name() == name {
-        os.Exit(p.Run(command, args[2:]))
+        result := host.InvokePlugin(context.Background(), p, command, args[2:])
+        fmt.Fprint(os.Stdout, result.Stdout)
+        fmt.Fprint(os.Stderr, result.Stderr)
+        os.Exit(result.Code)
       }
     }
   }

--- a/website/compiler/cmd/playground/plugins.go
+++ b/website/compiler/cmd/playground/plugins.go
@@ -9,17 +9,11 @@ package main
 import (
   "encoding/json"
   "fmt"
-  "io"
-  "os"
 
   "github.com/samchon/ttsc/packages/lint/linthost"
   "github.com/samchon/ttsc/packages/ttsc/utility"
+  "github.com/samchon/ttsc/packages/wasm/host"
 )
-
-// stderrOf returns the host stderr stream. utility.Run* writes to os.Stderr
-// directly, so we use the same writer to keep plugin diagnostics on one
-// stream the host can capture.
-func stderrOf(_ []string) io.Writer { return os.Stderr }
 
 type bannerPlugin struct{}
 
@@ -27,8 +21,8 @@ func newBannerPlugin() bannerPlugin { return bannerPlugin{} }
 
 func (bannerPlugin) Name() string { return "@ttsc/banner" }
 
-func (bannerPlugin) Run(command string, args []string) int {
-  return runUtilityPlugin("@ttsc/banner", command, args)
+func (bannerPlugin) Run(invocation *host.PluginInvocation) int {
+  return runUtilityPlugin("@ttsc/banner", invocation)
 }
 
 type pathsPlugin struct{}
@@ -37,8 +31,8 @@ func newPathsPlugin() pathsPlugin { return pathsPlugin{} }
 
 func (pathsPlugin) Name() string { return "@ttsc/paths" }
 
-func (pathsPlugin) Run(command string, args []string) int {
-  return runUtilityPlugin("@ttsc/paths", command, args)
+func (pathsPlugin) Run(invocation *host.PluginInvocation) int {
+  return runUtilityPlugin("@ttsc/paths", invocation)
 }
 
 type stripPlugin struct{}
@@ -47,8 +41,8 @@ func newStripPlugin() stripPlugin { return stripPlugin{} }
 
 func (stripPlugin) Name() string { return "@ttsc/strip" }
 
-func (stripPlugin) Run(command string, args []string) int {
-  return runUtilityPlugin("@ttsc/strip", command, args)
+func (stripPlugin) Run(invocation *host.PluginInvocation) int {
+  return runUtilityPlugin("@ttsc/strip", invocation)
 }
 
 // lintPlugin runs the real `@ttsc/lint` engine inside the playground wasm by
@@ -69,20 +63,21 @@ func newLintPlugin() lintPlugin { return lintPlugin{} }
 
 func (lintPlugin) Name() string { return "@ttsc/lint" }
 
-func (lintPlugin) Run(command string, args []string) int {
+func (lintPlugin) Run(invocation *host.PluginInvocation) int {
+  command := invocation.Command
   if command == "" {
     command = "check"
   }
-  args = ensureLintPluginsJSON(args)
+  args := ensureLintPluginsJSON(invocation.Args, invocation.Stderr)
   dispatch := append([]string{command}, args...)
-  return linthost.Main(dispatch)
+  return linthost.MainWithIO(dispatch, invocation.Stdout, invocation.Stderr)
 }
 
 // ensureLintPluginsJSON injects a synthetic `--plugins-json` payload when the
 // caller didn't supply one. The default enables the full recommended preset
 // so users who paste a snippet into the playground see the same diagnostics
 // they would in a project that extends `@ttsc/lint/lib/recommended`.
-func ensureLintPluginsJSON(args []string) []string {
+func ensureLintPluginsJSON(args []string, stderr interface{ Write([]byte) (int, error) }) []string {
   for _, a := range args {
     if hasFlagPrefix(a, "--plugins-json=") || a == "--plugins-json" {
       return args
@@ -99,7 +94,7 @@ func ensureLintPluginsJSON(args []string) []string {
     },
   })
   if err != nil {
-    fmt.Fprintf(stderrOf(args), "@ttsc/lint: synthesize plugins-json: %v\n", err)
+    fmt.Fprintf(stderr, "@ttsc/lint: synthesize plugins-json: %v\n", err)
     return args
   }
   return append(args, "--plugins-json="+string(payload))
@@ -130,24 +125,24 @@ var playgroundLintRules = map[string]any{
 // host reads that JSON to decide which transforms to run (banner = source
 // preamble; paths = module specifier rewrite; strip = call/statement
 // stripping); other plugin names in the payload are ignored.
-func runUtilityPlugin(name, command string, args []string) int {
+func runUtilityPlugin(name string, invocation *host.PluginInvocation) int {
   payload, err := json.Marshal([]map[string]any{
     {"name": name, "config": map[string]any{}, "stage": "transform"},
   })
   if err != nil {
-    fmt.Fprintf(stderrOf(args), "%s: synthesize plugins-json: %v\n", name, err)
+    fmt.Fprintf(invocation.Stderr, "%s: synthesize plugins-json: %v\n", name, err)
     return 2
   }
-  args = appendArg(args, "--plugins-json="+string(payload))
-  switch command {
+  args := appendArg(invocation.Args, "--plugins-json="+string(payload))
+  switch invocation.Command {
   case "build", "":
-    return utility.RunBuild(args)
+    return utility.RunBuildWithIO(args, invocation.Stdout, invocation.Stderr)
   case "check":
-    return utility.RunCheck(args)
+    return utility.RunCheckWithIO(args, invocation.Stdout, invocation.Stderr)
   case "transform":
-    return utility.RunTransform(args)
+    return utility.RunTransformWithIO(args, invocation.Stdout, invocation.Stderr)
   default:
-    fmt.Fprintf(stderrOf(args), "%s: unknown command %q\n", name, command)
+    fmt.Fprintf(invocation.Stderr, "%s: unknown command %q\n", name, invocation.Command)
     return 2
   }
 }

--- a/website/compiler/cmd/playground/typia_plugin.go
+++ b/website/compiler/cmd/playground/typia_plugin.go
@@ -2,9 +2,7 @@
 //
 // Mirrors the dispatch flow of typia's `cmd/ttsc-typia/{build,transform}.go`,
 // but reframes it as a host.Plugin so the playground wasm can run typia's
-// real transform inline. Whereas the standalone `ttsc-typia` binary owns
-// its own package-level stdout/stderr, here we rely on host.runWithCapturedIO
-// to redirect `os.Stdout` / `os.Stderr` for us — the Plugin contract.
+// real transform inline. Its stdout and stderr belong to one invocation.
 //
 // As of typia 13.0.0-dev the native backend is AST-integrated: typia's
 // per-file node transformer runs inside tsgo's emit pipeline (sharing the
@@ -24,6 +22,7 @@ import (
   "encoding/json"
   "flag"
   "fmt"
+  "io"
   "os"
   "path/filepath"
   "regexp"
@@ -34,6 +33,7 @@ import (
   shimprinter "github.com/microsoft/typescript-go/shim/printer"
 
   "github.com/samchon/ttsc/packages/ttsc/driver"
+  "github.com/samchon/ttsc/packages/wasm/host"
   typiaadapter "github.com/samchon/typia/packages/typia/native/adapter"
   nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
   nativetransform "github.com/samchon/typia/packages/typia/native/transform"
@@ -48,23 +48,24 @@ func (typiaPlugin) Name() string { return "typia" }
 // Run dispatches the typia subcommands. The verb defaults to `transform` —
 // the playground's TypeScript view is what users see, so an unspecified
 // command should return the rewritten TS rather than spawn an emit pass.
-func (typiaPlugin) Run(command string, args []string) int {
+func (typiaPlugin) Run(invocation *host.PluginInvocation) int {
+  command := invocation.Command
   if command == "" {
     command = "transform"
   }
   switch command {
   case "build":
-    return runTypiaBuild(args)
+    return runTypiaBuild(invocation.Args, invocation.Stdout, invocation.Stderr)
   case "check":
     // `check` is `build --noEmit` in typia's CLI; mirror that here.
-    return runTypiaBuild(append([]string{"--noEmit"}, args...))
+    return runTypiaBuild(append([]string{"--noEmit"}, invocation.Args...), invocation.Stdout, invocation.Stderr)
   case "transform":
-    return runTypiaTransform(args)
+    return runTypiaTransform(invocation.Args, invocation.Stdout, invocation.Stderr)
   case "-v", "--version", "version":
-    fmt.Fprintln(os.Stdout, "typia (playground-wasm bundled)")
+    fmt.Fprintln(invocation.Stdout, "typia (playground-wasm bundled)")
     return 0
   default:
-    fmt.Fprintf(os.Stderr, "typia: unknown command %q\n", command)
+    fmt.Fprintf(invocation.Stderr, "typia: unknown command %q\n", command)
     return 2
   }
 }
@@ -91,7 +92,7 @@ func (d typiaTransformDiag) String(cwd string) string {
   return fmt.Sprintf("%s - error TS(%s): %s", file, d.Code, d.Message)
 }
 
-func writeTypiaTransformDiagnostics(w *os.File, diagnostics []typiaTransformDiag, cwd string) {
+func writeTypiaTransformDiagnostics(w io.Writer, diagnostics []typiaTransformDiag, cwd string) {
   for _, diag := range diagnostics {
     fmt.Fprintln(w, diag.String(cwd))
   }
@@ -121,11 +122,11 @@ func buildTypiaTransform(prog *driver.Program, cwd, tsconfigPath string) (driver
 // runTypiaBuild is a stripped-down port of typia's `cmd/ttsc-typia/build.go`
 // runBuild. Differences from the upstream:
 //
-//   - writes via os.Stdout / os.Stderr (no package-level writer indirection)
+//   - writes through invocation-owned stdout and stderr
 //   - omits the manifest output (the playground has no use for it)
-func runTypiaBuild(args []string) int {
+func runTypiaBuild(args []string, stdout, stderr io.Writer) int {
   fs := flag.NewFlagSet("build", flag.ContinueOnError)
-  fs.SetOutput(os.Stderr)
+  fs.SetOutput(stderr)
   tsconfigPath := fs.String("tsconfig", "tsconfig.json", "path to tsconfig.json")
   cwdOverride := fs.String("cwd", "", "override the working directory")
   quiet := fs.Bool("quiet", true, "suppress the per-call diagnostic summary")
@@ -138,7 +139,7 @@ func runTypiaBuild(args []string) int {
     return 2
   }
   if *emit && *noEmit {
-    fmt.Fprintln(os.Stderr, "typia build: --emit and --noEmit are mutually exclusive")
+    fmt.Fprintln(stderr, "typia build: --emit and --noEmit are mutually exclusive")
     return 2
   }
   if *verbose {
@@ -150,7 +151,7 @@ func runTypiaBuild(args []string) int {
     var err error
     cwd, err = os.Getwd()
     if err != nil {
-      fmt.Fprintf(os.Stderr, "typia build: cwd: %v\n", err)
+      fmt.Fprintf(stderr, "typia build: cwd: %v\n", err)
       return 2
     }
   }
@@ -160,23 +161,23 @@ func runTypiaBuild(args []string) int {
     OutDir:      *outDir,
   })
   if err != nil {
-    fmt.Fprintf(os.Stderr, "typia build: %v\n", err)
+    fmt.Fprintf(stderr, "typia build: %v\n", err)
     return 2
   }
   if len(diags) > 0 {
-    driver.WritePrettyDiagnostics(os.Stderr, diags, cwd)
+    driver.WritePrettyDiagnostics(stderr, diags, cwd)
     return 2
   }
   defer prog.Close()
   if pdiags := prog.Diagnostics(); len(pdiags) > 0 {
-    driver.WritePrettyDiagnostics(os.Stderr, pdiags, cwd)
+    driver.WritePrettyDiagnostics(stderr, pdiags, cwd)
     return 2
   }
 
   shouldEmit := !prog.ParsedConfig.ParsedConfig.CompilerOptions.NoEmit.IsTrue()
   typiaTransform, transformDiags := buildTypiaTransform(prog, cwd, *tsconfigPath)
   if !*quiet {
-    fmt.Fprintf(os.Stdout, "// typia build: tsconfig=%s cwd=%s emit=%v\n", *tsconfigPath, cwd, shouldEmit)
+    fmt.Fprintf(stdout, "// typia build: tsconfig=%s cwd=%s emit=%v\n", *tsconfigPath, cwd, shouldEmit)
   }
   if shouldEmit {
     emitted := 0
@@ -186,18 +187,18 @@ func runTypiaBuild(args []string) int {
     })
     eDiags, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{typiaTransform}, writeFile)
     if err != nil {
-      fmt.Fprintf(os.Stderr, "typia build: emit failed: %v\n", err)
+      fmt.Fprintf(stderr, "typia build: emit failed: %v\n", err)
       return 3
     }
     for _, d := range eDiags {
-      fmt.Fprintln(os.Stderr, "  -", d.String())
+      fmt.Fprintln(stderr, "  -", d.String())
     }
     if !*quiet {
-      fmt.Fprintf(os.Stdout, "// typia build: emitted=%d files\n", emitted)
+      fmt.Fprintf(stdout, "// typia build: emitted=%d files\n", emitted)
     }
   }
   if len(*transformDiags) > 0 {
-    writeTypiaTransformDiagnostics(os.Stderr, *transformDiags, cwd)
+    writeTypiaTransformDiagnostics(stderr, *transformDiags, cwd)
     return 3
   }
   return 0
@@ -208,9 +209,9 @@ func runTypiaBuild(args []string) int {
 // (the JSON-shaped output that maps file path → rewritten source); we keep
 // the single-file emit branch so command-line smoke tests stay close to the
 // CLI flow.
-func runTypiaTransform(args []string) int {
+func runTypiaTransform(args []string, stdout, stderr io.Writer) int {
   fs := flag.NewFlagSet("transform", flag.ContinueOnError)
-  fs.SetOutput(os.Stderr)
+  fs.SetOutput(stderr)
   file := fs.String("file", "", "absolute or cwd-relative path of the .ts file to transform")
   tsconfigPath := fs.String("tsconfig", "tsconfig.json", "tsconfig.json owning --file")
   cwdOverride := fs.String("cwd", "", "override the working directory")
@@ -221,7 +222,7 @@ func runTypiaTransform(args []string) int {
     return 2
   }
   if *output != "js" && *output != "ts" {
-    fmt.Fprintf(os.Stderr, "typia transform: unknown --output value %q\n", *output)
+    fmt.Fprintf(stderr, "typia transform: unknown --output value %q\n", *output)
     return 2
   }
   cwd := *cwdOverride
@@ -229,7 +230,7 @@ func runTypiaTransform(args []string) int {
     var err error
     cwd, err = os.Getwd()
     if err != nil {
-      fmt.Fprintf(os.Stderr, "typia transform: cwd: %v\n", err)
+      fmt.Fprintf(stderr, "typia transform: cwd: %v\n", err)
       return 2
     }
   }
@@ -238,11 +239,11 @@ func runTypiaTransform(args []string) int {
     ForceEmit: true,
   })
   if err != nil {
-    fmt.Fprintf(os.Stderr, "typia transform: %v\n", err)
+    fmt.Fprintf(stderr, "typia transform: %v\n", err)
     return 2
   }
   if len(diags) > 0 {
-    driver.WritePrettyDiagnostics(os.Stderr, diags, cwd)
+    driver.WritePrettyDiagnostics(stderr, diags, cwd)
     return 2
   }
   defer prog.Close()
@@ -251,10 +252,10 @@ func runTypiaTransform(args []string) int {
 
   if *file == "" {
     if *out != "" {
-      fmt.Fprintln(os.Stderr, "typia transform: --out requires --file")
+      fmt.Fprintln(stderr, "typia transform: --out requires --file")
       return 2
     }
-    return runTypiaTransformProject(prog, cwd, typiaTransform, transformDiags)
+    return runTypiaTransformProject(prog, cwd, typiaTransform, transformDiags, stdout, stderr)
   }
 
   absFile := *file
@@ -264,15 +265,15 @@ func runTypiaTransform(args []string) int {
   absFile = filepath.ToSlash(absFile)
   target := prog.SourceFile(absFile)
   if target == nil {
-    fmt.Fprintf(os.Stderr, "typia transform: source file is not in program: %s\n", absFile)
+    fmt.Fprintf(stderr, "typia transform: source file is not in program: %s\n", absFile)
     return 2
   }
 
   if *output == "js" {
-    return runTypiaTransformSingleJS(prog, typiaTransform, absFile, *out)
+    return runTypiaTransformSingleJS(prog, typiaTransform, absFile, *out, stdout, stderr)
   }
   text := transformFileToTypeScript(prog, typiaTransform, target)
-  return writeSingleOutput(text, *out)
+  return writeSingleOutput(text, *out, stdout, stderr)
 }
 
 // runTypiaTransformProject walks every project source file and writes a JSON
@@ -283,6 +284,8 @@ func runTypiaTransformProject(
   cwd string,
   typiaTransform driver.PluginTransform,
   transformDiags *[]typiaTransformDiag,
+  stdout io.Writer,
+  stderr io.Writer,
 ) int {
   type compilerDiag struct {
     File        *string `json:"file"`
@@ -322,8 +325,8 @@ func runTypiaTransformProject(
       MessageText: diag.Message,
     })
   }
-  if err := json.NewEncoder(os.Stdout).Encode(res); err != nil {
-    fmt.Fprintf(os.Stderr, "typia transform: encode output: %v\n", err)
+  if err := json.NewEncoder(stdout).Encode(res); err != nil {
+    fmt.Fprintf(stderr, "typia transform: encode output: %v\n", err)
     return 3
   }
   if len(res.Diagnostics) > 0 {
@@ -360,6 +363,8 @@ func runTypiaTransformSingleJS(
   typiaTransform driver.PluginTransform,
   absFile string,
   outPath string,
+  stdout io.Writer,
+  stderr io.Writer,
 ) int {
   var captured string
   found := false
@@ -372,14 +377,14 @@ func runTypiaTransformSingleJS(
     return nil
   })
   if _, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{typiaTransform}, writeFile); err != nil {
-    fmt.Fprintf(os.Stderr, "typia transform: emit: %v\n", err)
+    fmt.Fprintf(stderr, "typia transform: emit: %v\n", err)
     return 3
   }
   if !found {
-    fmt.Fprintf(os.Stderr, "typia transform: no output produced for %s\n", absFile)
+    fmt.Fprintf(stderr, "typia transform: no output produced for %s\n", absFile)
     return 3
   }
-  return writeSingleOutput(captured, outPath)
+  return writeSingleOutput(captured, outPath, stdout, stderr)
 }
 
 // sameSourceStem reports whether an emitted .js path corresponds to a .ts source
@@ -395,19 +400,19 @@ func sameSourceStem(tsPath, jsPath string) bool {
   return filepath.Base(jsStem) == filepath.Base(tsStem)
 }
 
-func writeSingleOutput(text, outPath string) int {
+func writeSingleOutput(text, outPath string, stdout, stderr io.Writer) int {
   if outPath == "" {
-    fmt.Fprint(os.Stdout, text)
+    fmt.Fprint(stdout, text)
     return 0
   }
   if dir := filepath.Dir(outPath); dir != "" {
     if err := os.MkdirAll(dir, 0o755); err != nil {
-      fmt.Fprintf(os.Stderr, "typia transform: mkdir: %v\n", err)
+      fmt.Fprintf(stderr, "typia transform: mkdir: %v\n", err)
       return 3
     }
   }
   if err := os.WriteFile(outPath, []byte(text), 0o644); err != nil {
-    fmt.Fprintf(os.Stderr, "typia transform: write %s: %v\n", outPath, err)
+    fmt.Fprintf(stderr, "typia transform: write %s: %v\n", outPath, err)
     return 3
   }
   return 0

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,7 @@
     "build:compiler": "node build/compiler.cjs",
     "build:blog:rss": "node build/blog.cjs",
     "test:rss-autodiscovery": "node --test test/rss-autodiscovery.test.cjs",
+    "test:typia-dependency-graph": "node --test test/typia-dependency-graph.test.cjs",
     "build:benchmark:graph": "node build/graph-benchmark-svg.cjs",
     "build:benchmark:png": "node build/graph-benchmark-svg.cjs --png",
     "charts:png": "node build/svg-to-png.cjs",

--- a/website/src/content/docs/wasm/index.mdx
+++ b/website/src/content/docs/wasm/index.mdx
@@ -207,16 +207,18 @@ Inside wasm there is no subprocess boundary, so plugins cannot be launched as ex
 ```go
 type Plugin interface {
   Name() string
-  Run(command string, args []string) int
+  Run(invocation *PluginInvocation) int
 }
 ```
 
 The method should forward to the same command dispatcher your native sidecar uses. The first-party playground does this for `@ttsc/banner`, `@ttsc/paths`, `@ttsc/strip`, `@ttsc/lint`, and typia:
 
 - `Name()` returns the id the Worker passes to `api.plugin`.
-- `Run(command, args)` runs `build`, `check`, `transform`, `format`, or any other plugin command you support.
-- Anything written to `os.Stdout` or `os.Stderr` is captured and returned to JavaScript as `stdout` or `stderr`.
+- `invocation.Command` and `invocation.Args` carry the requested verb and CLI-shaped flags.
+- Write to `invocation.Stdout` and `invocation.Stderr`; those request-owned streams become JavaScript `stdout` and `stderr` without replacing process globals.
 - Return codes should mirror the native CLI: `0` success, `2` usage or diagnostics, `3` runtime failure.
+
+For utility-backed plugins, call `utility.RunBuildWithIO(invocation.Args, invocation.Stdout, invocation.Stderr)` (or the matching check/transform function). Use `invocation.Go` when a child goroutine contributes to the result. The host accepts registrations only while `Run` is active, waits for every registered child, then closes the streams. An unregistered goroutine that writes after completion receives `io.ErrClosedPipe` and cannot contaminate another request.
 
 For a real reference, read the playground wasm sources:
 
@@ -253,7 +255,7 @@ GOOS=js GOARCH=wasm go build -trimpath \
 | `WebAssembly.instantiateStreaming` fails | Serve `.wasm` with `Content-Type: application/wasm`. |
 | The page locks up | Booted wasm on the main thread. Move it into a Worker. |
 | `ENOENT` for `tsconfig.json` | Write `/work/tsconfig.json` and every included source file before calling the API. |
-| Plugin output is empty | For custom plugins, make sure the plugin writes to `os.Stdout`/`os.Stderr` or returns data through the virtual filesystem. |
+| Plugin output is empty | For custom plugins, write to `invocation.Stdout`/`invocation.Stderr` or return data through the virtual filesystem. |
 | Two wasm binaries conflict | Give each binary a unique `apiName`. Use separate Workers when they need independent `fs`/`process` globals or filesystems. |
 
 ## Published tarball layout

--- a/website/test/typia-dependency-graph.test.cjs
+++ b/website/test/typia-dependency-graph.test.cjs
@@ -6,6 +6,7 @@ const test = require("node:test");
 
 const {
   createTypiaDependencyGraph,
+  rewriteSourceManifest,
 } = require("../build/typia-dependency-graph.cjs");
 
 test("Typia browser packs derive one fail-fast dependency graph", async (t) => {
@@ -32,12 +33,16 @@ test("Typia browser packs derive one fail-fast dependency graph", async (t) => {
     const fixture = createFixture();
     try {
       writePackage(fixture, "typia", {
-        source: 'import value from "missing-transitive"; export default value;\n',
+        source: 'import value from "first-dependency"; export default value;\n',
+      });
+      writePackage(fixture, "first-dependency", {
+        source:
+          'import value from "missing-transitive"; export default value;\n',
       });
       const graph = fixtureGraph(fixture);
       assert.throws(
         () => graph.collect("source"),
-        /imports missing package "missing-transitive"/,
+        /typia\/src\/index\.ts -> first-dependency\/src\/index\.ts imports missing package "missing-transitive"/,
       );
     } finally {
       fs.rmSync(fixture, { recursive: true, force: true });
@@ -57,15 +62,111 @@ test("Typia browser packs derive one fail-fast dependency graph", async (t) => {
         source: "export const value = 1;\n",
       });
       const closure = fixtureGraph(fixture).collect("source");
-      assert.deepEqual(
-        [...closure.packages.keys()].sort(),
-        ["first-dependency", "new-transitive", "typia"],
-      );
+      assert.deepEqual([...closure.packages.keys()].sort(), [
+        "first-dependency",
+        "new-transitive",
+        "typia",
+      ]);
       assert.ok(closure.files.has("new-transitive/src/index.ts"));
     } finally {
       fs.rmSync(fixture, { recursive: true, force: true });
     }
   });
+
+  await t.test("a newly exported public subpath is discovered", () => {
+    const fixture = createFixture();
+    try {
+      const root = writePackage(fixture, "typia", {
+        source: "export const root = 1;\n",
+      });
+      const manifestFile = path.join(root, "package.json");
+      const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
+      manifest.exports["./feature"] = {
+        types: "./lib/feature.d.ts",
+        default: "./lib/feature.js",
+      };
+      fs.writeFileSync(manifestFile, JSON.stringify(manifest));
+      fs.writeFileSync(
+        path.join(root, "src", "feature.ts"),
+        "export const feature = 1;\n",
+      );
+      fs.writeFileSync(
+        path.join(root, "lib", "feature.d.ts"),
+        "export declare const feature: number;\n",
+      );
+      fs.writeFileSync(
+        path.join(root, "lib", "feature.js"),
+        "exports.feature = 1;\n",
+      );
+
+      const graph = fixtureGraph(fixture);
+      assert.ok(graph.collect("source").files.has("typia/src/feature.ts"));
+      assert.ok(graph.collect("runtime").files.has("typia/lib/feature.js"));
+      assert.ok(graph.collect("types").files.has("typia/lib/feature.d.ts"));
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  await t.test(
+    "source manifests rewrite bare and relative lib fallbacks",
+    () => {
+      const fixture = createFixture();
+      try {
+        const root = writePackage(fixture, "typia", {
+          source: "export const value = 1;\n",
+        });
+        const rewritten = rewriteSourceManifest(
+          {
+            main: "lib/index.js",
+            types: "lib/index.d.ts",
+            exports: { ".": { default: "./lib/index.js" } },
+          },
+          root,
+        );
+        assert.equal(rewritten.main, "src/index.ts");
+        assert.equal(rewritten.types, "src/index.ts");
+        assert.equal(rewritten.exports["."].default, "./src/index.ts");
+      } finally {
+        fs.rmSync(fixture, { recursive: true, force: true });
+      }
+    },
+  );
+
+  await t.test(
+    "an ESM-only runtime dependency fails instead of being omitted",
+    () => {
+      const fixture = createFixture();
+      try {
+        const typiaRoot = writePackage(fixture, "typia", {
+          source: "export const value = 1;\n",
+        });
+        fs.writeFileSync(
+          path.join(typiaRoot, "lib", "index.js"),
+          'require("esm-only");\n',
+        );
+        const esmRoot = writePackage(fixture, "esm-only", {
+          source: "export const value = 1;\n",
+        });
+        const manifestFile = path.join(esmRoot, "package.json");
+        const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
+        delete manifest.main;
+        manifest.exports["."] = { default: "./lib/index.mjs" };
+        fs.writeFileSync(manifestFile, JSON.stringify(manifest));
+        fs.writeFileSync(
+          path.join(esmRoot, "lib", "index.mjs"),
+          "export const value = 1;\n",
+        );
+
+        assert.throws(
+          () => fixtureGraph(fixture).collect("runtime"),
+          /typia\/lib\/index\.js -> esm-only\/lib\/index\.mjs resolves to an ESM-only runtime module/,
+        );
+      } finally {
+        fs.rmSync(fixture, { recursive: true, force: true });
+      }
+    },
+  );
 
   await t.test("a mismatched Typia-family package fails generation", () => {
     const fixture = createFixture();
@@ -105,7 +206,8 @@ function writePackage(fixture, name, { source, version = "1.2.3" }) {
   const root = path.join(fixture, "node_modules", ...name.split("/"));
   fs.mkdirSync(path.join(root, "src"), { recursive: true });
   fs.mkdirSync(path.join(root, "lib"), { recursive: true });
-  if (name === "typia") fs.mkdirSync(path.join(root, "native", "adapter"), { recursive: true });
+  if (name === "typia")
+    fs.mkdirSync(path.join(root, "native", "adapter"), { recursive: true });
   fs.writeFileSync(
     path.join(root, "package.json"),
     JSON.stringify({
@@ -123,5 +225,9 @@ function writePackage(fixture, name, { source, version = "1.2.3" }) {
   );
   fs.writeFileSync(path.join(root, "src", "index.ts"), source);
   fs.writeFileSync(path.join(root, "lib", "index.d.ts"), "export {};\n");
-  fs.writeFileSync(path.join(root, "lib", "index.js"), "module.exports = {};\n");
+  fs.writeFileSync(
+    path.join(root, "lib", "index.js"),
+    "module.exports = {};\n",
+  );
+  return root;
 }

--- a/website/test/typia-dependency-graph.test.cjs
+++ b/website/test/typia-dependency-graph.test.cjs
@@ -1,0 +1,127 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  createTypiaDependencyGraph,
+} = require("../build/typia-dependency-graph.cjs");
+
+test("Typia browser packs derive one fail-fast dependency graph", async (t) => {
+  await t.test("the real install owns Go, source, runtime, and types", () => {
+    const websiteRoot = path.resolve(__dirname, "..");
+    const graph = createTypiaDependencyGraph({ websiteRoot });
+    assert.equal(
+      path.relative(graph.typiaRoot, graph.goAdapterRoot),
+      path.join("native", "adapter"),
+    );
+    for (const kind of ["source", "runtime", "types"]) {
+      const closure = graph.collect(kind);
+      assert.equal(closure.version, graph.version);
+      assert.equal(closure.packages.get("typia").root, graph.typiaRoot);
+      for (const pkg of closure.packages.values()) {
+        if (pkg.name.startsWith("@typia/")) {
+          assert.equal(pkg.manifest.version, graph.version);
+        }
+      }
+    }
+  });
+
+  await t.test("a missing imported package fails generation", () => {
+    const fixture = createFixture();
+    try {
+      writePackage(fixture, "typia", {
+        source: 'import value from "missing-transitive"; export default value;\n',
+      });
+      const graph = fixtureGraph(fixture);
+      assert.throws(
+        () => graph.collect("source"),
+        /imports missing package "missing-transitive"/,
+      );
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("a newly imported transitive package is discovered", () => {
+    const fixture = createFixture();
+    try {
+      writePackage(fixture, "typia", {
+        source: 'export { value } from "first-dependency";\n',
+      });
+      writePackage(fixture, "first-dependency", {
+        source: 'export { value } from "new-transitive";\n',
+      });
+      writePackage(fixture, "new-transitive", {
+        source: "export const value = 1;\n",
+      });
+      const closure = fixtureGraph(fixture).collect("source");
+      assert.deepEqual(
+        [...closure.packages.keys()].sort(),
+        ["first-dependency", "new-transitive", "typia"],
+      );
+      assert.ok(closure.files.has("new-transitive/src/index.ts"));
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  await t.test("a mismatched Typia-family package fails generation", () => {
+    const fixture = createFixture();
+    try {
+      writePackage(fixture, "typia", {
+        source: 'export { value } from "@typia/interface";\n',
+      });
+      writePackage(fixture, "@typia/interface", {
+        source: "export const value = 1;\n",
+        version: "9.9.9",
+      });
+      assert.throws(
+        () => fixtureGraph(fixture).collect("source"),
+        /@typia\/interface@9\.9\.9 does not match typia@1\.2\.3/,
+      );
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});
+
+function createFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-typia-graph-"));
+  fs.mkdirSync(path.join(root, "node_modules"), { recursive: true });
+  return root;
+}
+
+function fixtureGraph(fixture) {
+  return createTypiaDependencyGraph({
+    websiteRoot: fixture,
+    typiaRoot: path.join(fixture, "node_modules", "typia"),
+    expectedVersion: "1.2.3",
+  });
+}
+
+function writePackage(fixture, name, { source, version = "1.2.3" }) {
+  const root = path.join(fixture, "node_modules", ...name.split("/"));
+  fs.mkdirSync(path.join(root, "src"), { recursive: true });
+  fs.mkdirSync(path.join(root, "lib"), { recursive: true });
+  if (name === "typia") fs.mkdirSync(path.join(root, "native", "adapter"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name,
+      version,
+      main: "lib/index.js",
+      types: "lib/index.d.ts",
+      exports: {
+        ".": {
+          types: "./lib/index.d.ts",
+          default: "./lib/index.js",
+        },
+      },
+    }),
+  );
+  fs.writeFileSync(path.join(root, "src", "index.ts"), source);
+  fs.writeFileSync(path.join(root, "lib", "index.d.ts"), "export {};\n");
+  fs.writeFileSync(path.join(root, "lib", "index.js"), "module.exports = {};\n");
+}


### PR DESCRIPTION
## Intent

Give browser compiler invocations request-owned output and make every Typia playground artifact derive from one authoritative installation and dependency graph.

Closes #702
Closes #705

## Scope

- Replace WASM host process-global stdout/stderr capture with invocation-owned writers, an explicit registered-child lifetime, and per-request result ownership while preserving exit and error envelopes.
- Thread explicit writers through utility, lint, and Typia playground adapters; keep native entrypoints on their normal process streams.
- Resolve exact Typia 13.1.0 once and derive source, CommonJS runtime, declaration, version-stamp, and Go-adapter inputs through one shared fail-fast resolver.
- Remove fake TypeScript/ambient-any packages, fallback installs, warn-and-skip roots, and hand-maintained transitive package lists.

## Verification

- `go test -count=50 ./test/host` in `packages/wasm`.
- `go test -count=1 ./...` in `packages/wasm`, `packages/ttsc`, and `website/compiler`.
- `pnpm --dir website run test:typia-dependency-graph` (8/8 tests).
- `pnpm --dir packages/wasm run build:ts` and `pnpm --dir packages/playground run build`.
- `pnpm --dir website run build:compiler` and `pnpm --dir website run build:next` (84 pages).
- Generated packs from Typia 13.1.0: source 7 packages/336 files, runtime 6/296, declarations 4/249.
- Real headless Chrome Compile produced non-blank Typia helper imports including `_isFormatUuid`; Execute returned `matched: true`.
- Three solo Self-Review rounds completed; the final full-diff round reported no actionable findings.

Campaign CI is intentionally suspended. Runs created for each exact campaign SHA are cancelled under the repository-audit campaign gate; repository Actions and workflow settings remain unchanged.
