### PR TITLE
feat(metro): sound cache invalidation from the reference graph

### DIFF
--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -74,10 +74,19 @@ For each TypeScript file Metro asks to transform:
 
 The plugin contract, `tsconfig` discovery, and per-build cache are identical to every other `ttsc` bundler integration.
 
+## Cache invalidation
+
+Metro keys its transform cache on each file's own content plus one static transformer key, and its babel-transformer contract has no per-file dependency registration. A `ttsc` transform can depend on a _type_ in another file, so `@ttsc/metro` folds a project fingerprint into that static key: every input file under the project root, plus the reference-graph inputs outside it (`node_modules` declarations, monorepo sibling sources, out-of-root tsconfig `extends` ancestry) recorded under `node_modules/.cache/ttsc-metro`. Editing any of them re-keys the next run, so `metro bundle` and dev-server starts pick up cross-file type changes without `--reset-cache`.
+
+The granularity is project-level by necessity: Metro evaluates the transformer key once per run, so any fingerprinted change re-transforms every file on the next run. What remains outside the mechanism's reach:
+
+- **Within a running dev server**, Metro re-transforms only files its watcher reports changed. Editing a type in file B updates a dependent file A on A's next transform — save A, or restart the dev server (no `--reset-cache` needed).
+- **Files a plugin declares `volatile`** depend on non-file inputs that no fingerprint can represent; while a volatile declaration is recorded, cross-run cache reuse is disabled entirely.
+- **If `node_modules/.cache` is unwritable**, the recorded input set is unknown, and cross-run cache reuse is disabled rather than made unsound.
+
 ## Caveats (v1)
 
 - **Cost model.** This release reuses `@ttsc/unplugin`'s transform core, which type-checks the whole `tsconfig` project and caches the result per process. Metro runs transforms in a multi-process worker pool, so the project is compiled once per worker (on that worker's first file). A resident, incremental, per-file compiler shared across workers is the planned optimization, tracked in [samchon/ttsc#255](https://github.com/samchon/ttsc/issues/255).
-- **Cache invalidation.** Metro keys its transform cache on per-file content plus a static transformer key. A `ttsc` transform can depend on a _type_ in another file; editing that type does not change the dependent file's content, so Metro may serve a stale transform. After changing `tsconfig`/plugin configuration or a depended-upon type, restart Metro with `--reset-cache`.
 - **Type errors fail the build.** The `ttsc` pass type-checks; a project type error surfaces as a Metro build error, matching the other `ttsc` bundler integrations.
 
 ## Sponsors

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -80,7 +80,7 @@ Metro keys its transform cache on each file's own content plus one static transf
 
 The granularity is project-level by necessity: Metro evaluates the transformer key once per run, so any fingerprinted change re-transforms every file on the next run. What remains outside the mechanism's reach:
 
-- **Within a running dev server**, Metro re-transforms only files its watcher reports changed. Editing a type in file B updates a dependent file A on A's next transform — save A, or restart the dev server (no `--reset-cache` needed).
+- **Within a running dev server**, Metro re-transforms only files its watcher reports changed. Editing a type in file B updates a dependent file A on A's next transform: save A, or restart the dev server (no `--reset-cache` needed).
 - **Files a plugin declares `volatile`** depend on non-file inputs that no fingerprint can represent; while a volatile declaration is recorded, cross-run cache reuse is disabled entirely.
 - **If `node_modules/.cache` is unwritable**, the recorded input set is unknown, and cross-run cache reuse is disabled rather than made unsound.
 

--- a/packages/metro/src/core/fingerprint.ts
+++ b/packages/metro/src/core/fingerprint.ts
@@ -1,0 +1,468 @@
+/**
+ * Project fingerprint and reference-graph snapshot for `@ttsc/metro`.
+ *
+ * Metro's transform cache keys each file on its own content plus one static
+ * transformer key computed once per run (`getCacheKey`, called on the main
+ * process at `Transformer` construction). A ttsc transform's output can depend
+ * on inputs Metro never keys: other project sources reached through type-only
+ * edges, `node_modules` declarations, monorepo sibling sources, and the
+ * tsconfig `extends` ancestry. This module folds all of them into the static
+ * key so the cache key incorporates every input that can influence a
+ * transform's output:
+ *
+ * - **Project walk.** Every input file under the fingerprint roots (Metro's
+ *   `projectRoot` plus the resolved tsconfig's directory when it lies outside),
+ *   hashed with the exact walk universe the `@ttsc/unplugin` transform core
+ *   validates its own cache against.
+ * - **Recorded out-of-walk inputs.** The transform core cannot walk files outside
+ *   the roots or under ignored directories, but the host-owned reference graph
+ *   (samchon/ttsc#718) reports them per transform. Workers record them into a
+ *   snapshot under `node_modules/.cache/ttsc-metro`; the next run's
+ *   `getCacheKey` re-hashes the recorded set.
+ *
+ * Snapshot layout: one main file carrying a random epoch id plus per-worker
+ * files with unique names, so concurrent workers never race a shared write.
+ * `withTtsc` (the single config process, before workers exist) compacts worker
+ * files into the main file. Readers take the union of every file, reading the
+ * worker files strictly before the main file: the compactor renames the merged
+ * main into place strictly before deleting a worker file, so a worker file that
+ * disappears mid-read is always already merged into the main the reader loads
+ * afterwards.
+ *
+ * Sound degradations, by design:
+ *
+ * - No readable snapshot (first run, wiped cache dir, unwritable filesystem)
+ *   folds a random nonce: that run shares no cache entries with any other run.
+ * - A recreated snapshot carries a fresh epoch id, so it can never alias a key
+ *   from an older epoch whose recorded set is unknown.
+ * - A plugin-declared volatile output (non-file inputs; unrepresentable in any
+ *   file fingerprint) marks the snapshot volatile, which also folds a nonce
+ *   until a later run records the volatile declaration gone.
+ * - A recorded input that disappears hashes as a stable `missing` marker, so
+ *   deletion and reappearance both move the key.
+ */
+import {
+  collectExternalInputHashes,
+  collectProjectInputHashes,
+  isProjectWalkPath,
+} from "@ttsc/unplugin/api";
+import { createHash, randomBytes } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+/** Bumped when the snapshot JSON shape changes; mismatches read as corrupt. */
+const SNAPSHOT_VERSION = 1;
+
+/** Snapshot directory segments under the fingerprint base directory. */
+const SNAPSHOT_DIRECTORY = ["node_modules", ".cache", "ttsc-metro"];
+
+/** Main snapshot file name (epoch id + compacted recorded inputs). */
+const MAIN_SNAPSHOT = "graph-inputs.json";
+
+/** Worker snapshot file prefix; each worker appends a unique suffix. */
+const WORKER_SNAPSHOT_PREFIX = "graph-inputs.worker-";
+
+/** Union of the snapshot state readable on disk. */
+interface SnapshotState {
+  /** Random epoch id minted when the main snapshot was created. */
+  id: string;
+  /** Absolute paths of every recorded out-of-walk input. */
+  files: string[];
+  /** Whether any recorded transform declared volatile output. */
+  volatile: boolean;
+}
+
+/** Serialized shape of the main and worker snapshot files. */
+interface SnapshotDocument {
+  files: string[];
+  id?: string;
+  version: number;
+  volatile: boolean;
+}
+
+/**
+ * Resolve the base directory both fingerprint sides agree on: Metro's
+ * `projectRoot` when known (`withTtsc` reads it from the config, `getCacheKey`
+ * from Metro's cache-key options, the transformer from each file's transform
+ * options — all the same value in a real Metro run), else the working directory
+ * Metro was launched from.
+ */
+export function resolveFingerprintBase(
+  projectRoot: string | undefined,
+): string {
+  return path.resolve(
+    typeof projectRoot === "string" && projectRoot.length !== 0
+      ? projectRoot
+      : process.cwd(),
+  );
+}
+
+/**
+ * The directories whose walk universes the fingerprint hashes: the base
+ * directory, plus the resolved tsconfig's directory when the tsconfig is not
+ * already inside the base walk (an explicit out-of-root `project`, or a
+ * monorepo-root tsconfig discovered above the app). Matching the transform
+ * core's own validation universe keeps the invariant simple: everything the
+ * core treats as an input is fingerprinted, either by a walk here or by the
+ * recorded out-of-walk snapshot.
+ */
+export function fingerprintRoots(
+  base: string,
+  explicitProject: string | undefined,
+): string[] {
+  const tsconfig = resolveProjectTsconfig(base, explicitProject);
+  if (isProjectWalkPath(base, tsconfig)) {
+    return [base];
+  }
+  return [base, path.dirname(tsconfig)];
+}
+
+/**
+ * Locate the tsconfig governing the project, mirroring the transform core's
+ * discovery: an explicit `project` resolves against the working directory;
+ * otherwise ancestor directories starting at `base` are searched for a
+ * `tsconfig.json`, falling back to `<base>/tsconfig.json`.
+ */
+function resolveProjectTsconfig(
+  base: string,
+  explicitProject: string | undefined,
+): string {
+  if (explicitProject !== undefined && explicitProject.length !== 0) {
+    return path.isAbsolute(explicitProject)
+      ? explicitProject
+      : path.resolve(process.cwd(), explicitProject);
+  }
+  let current = base;
+  while (true) {
+    const candidate = path.join(current, "tsconfig.json");
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+  return path.resolve(base, "tsconfig.json");
+}
+
+/**
+ * Compute the fingerprint `getCacheKey` folds into Metro's static transformer
+ * key. Never throws: any failure degrades to a nonce, which soundly disables
+ * cross-run cache reuse for this run instead of serving stale output.
+ */
+export function computeProjectFingerprint(props: {
+  explicitProject?: string;
+  projectRoot?: string;
+}): string {
+  try {
+    const base = resolveFingerprintBase(props.projectRoot);
+    const hash = createHash("sha256");
+    for (const root of fingerprintRoots(base, props.explicitProject)) {
+      hash.update(stableStringify(collectProjectInputHashes(root)));
+    }
+    const snapshot = readSnapshotState(base);
+    if (snapshot === undefined || snapshot.volatile) {
+      hash.update(nonce());
+    } else {
+      hash.update(`snapshot:${snapshot.id}`);
+      hash.update(stableStringify(collectExternalInputHashes(snapshot.files)));
+    }
+    return hash.digest("hex");
+  } catch {
+    return nonce();
+  }
+}
+
+/**
+ * A value no other run can reproduce. Folding it means this run's cache entries
+ * are written but never reused by later runs, and this run reuses nothing from
+ * earlier ones — the sound fallback whenever the recorded out-of-walk input set
+ * is unknown or unrepresentable.
+ */
+function nonce(): string {
+  return `nonce:${randomBytes(32).toString("hex")}`;
+}
+
+/**
+ * Prepare the snapshot for a new run. Called from `withTtsc` in the single
+ * Metro config process, before any worker exists: creates the main snapshot
+ * (fresh epoch id) when missing or corrupt, and compacts leftover worker files
+ * into it. Never throws — an unwritable cache directory leaves the snapshot
+ * unreadable and `getCacheKey` degrades to a nonce.
+ */
+export function prepareSnapshot(projectRoot: string | undefined): void {
+  try {
+    const directory = snapshotDirectory(resolveFingerprintBase(projectRoot));
+    fs.mkdirSync(directory, { recursive: true });
+    // Read the worker files strictly before the main file (see the module doc
+    // comment): a concurrent compactor deletes a worker file only after the
+    // merged main is renamed into place, so whatever this enumeration misses
+    // is already inside the main read below.
+    const workers = readWorkerFiles(directory);
+    const main = readMainDocument(directory);
+    const files = new Set(main?.files ?? []);
+    let volatile =
+      workers.entries.length === 0
+        ? (main?.volatile ?? false)
+        : // Worker files carry the previous run's fresh observations, so they
+          // own the volatile verdict: a removed volatile declaration must be
+          // able to clear the sticky flag.
+          workers.entries.some((entry) => entry.volatile);
+    for (const entry of workers.entries) {
+      for (const file of entry.files) {
+        files.add(file);
+      }
+    }
+    writeSnapshotDocument(path.join(directory, MAIN_SNAPSHOT), {
+      files: [...files].sort(),
+      id: main?.id ?? randomBytes(16).toString("hex"),
+      version: SNAPSHOT_VERSION,
+      volatile,
+    });
+    for (const file of workers.paths) {
+      try {
+        fs.rmSync(file, { force: true });
+      } catch {
+        // A locked worker file stays behind; readers union it, so nothing is
+        // lost, and the next compaction retries.
+      }
+    }
+  } catch {
+    // Snapshot maintenance must never break the Metro config process.
+  }
+}
+
+/**
+ * Read the unioned snapshot state, or `undefined` when the main snapshot is
+ * missing or any snapshot file is corrupt (a torn or foreign write means the
+ * recorded set cannot be trusted, so the caller degrades to a nonce).
+ */
+export function readSnapshotState(base: string): SnapshotState | undefined {
+  const directory = snapshotDirectory(base);
+  // Worker files strictly before the main file — see the module doc comment.
+  const workers = readWorkerFiles(directory);
+  if (workers.corrupt) {
+    return undefined;
+  }
+  const main = readMainDocument(directory);
+  if (main === undefined || typeof main.id !== "string") {
+    return undefined;
+  }
+  const files = new Set(main.files);
+  let volatile = main.volatile;
+  for (const entry of workers.entries) {
+    for (const file of entry.files) {
+      files.add(file);
+    }
+    volatile ||= entry.volatile;
+  }
+  return { files: [...files].sort(), id: main.id, volatile };
+}
+
+/**
+ * Recorder held by each Metro worker. Collects the out-of-walk inputs derived
+ * for every transformed file (the plugin-reported dependencies unioned with the
+ * reference graph's reach, globals, and configs — delivered through the
+ * transform core's `addWatchFile` hook) plus any volatile declaration, and
+ * persists them to this worker's uniquely named snapshot file whenever the
+ * observed state grows. The unique name makes worker writes race-free;
+ * `withTtsc` compacts the files on the next run.
+ */
+export function createSnapshotRecorder(): {
+  record: (props: {
+    explicitProject?: string;
+    input: string;
+    projectRoot?: string;
+  }) => void;
+  recordVolatile: (props: {
+    explicitProject?: string;
+    projectRoot?: string;
+  }) => void;
+} {
+  const suffix = `${process.pid.toString(36)}-${randomBytes(6).toString("hex")}`;
+  interface BaseState {
+    dirty: boolean;
+    files: Set<string>;
+    roots: string[];
+    volatile: boolean;
+  }
+  const states = new Map<string, BaseState>();
+
+  function stateFor(
+    projectRoot: string | undefined,
+    explicitProject: string | undefined,
+  ): BaseState {
+    const base = resolveFingerprintBase(projectRoot);
+    let state = states.get(base);
+    if (state === undefined) {
+      state = {
+        dirty: false,
+        files: new Set(),
+        roots: fingerprintRoots(base, explicitProject),
+        volatile: false,
+      };
+      states.set(base, state);
+    }
+    return state;
+  }
+
+  function flush(base: string, state: BaseState): void {
+    if (!state.dirty) {
+      return;
+    }
+    state.dirty = false;
+    try {
+      const directory = snapshotDirectory(base);
+      fs.mkdirSync(directory, { recursive: true });
+      writeSnapshotDocument(
+        path.join(directory, `${WORKER_SNAPSHOT_PREFIX}${suffix}.json`),
+        {
+          files: [...state.files].sort(),
+          version: SNAPSHOT_VERSION,
+          volatile: state.volatile,
+        },
+      );
+    } catch {
+      // An unwritable snapshot leaves the main snapshot unreadable or stale;
+      // getCacheKey degrades to a nonce rather than serving stale output.
+    }
+  }
+
+  return {
+    record(props) {
+      const base = resolveFingerprintBase(props.projectRoot);
+      const state = stateFor(props.projectRoot, props.explicitProject);
+      const input = path.resolve(props.input);
+      if (
+        state.files.has(input) ||
+        state.roots.some((root) => isProjectWalkPath(root, input))
+      ) {
+        return;
+      }
+      state.files.add(input);
+      state.dirty = true;
+      flush(base, state);
+    },
+    recordVolatile(props) {
+      const base = resolveFingerprintBase(props.projectRoot);
+      const state = stateFor(props.projectRoot, props.explicitProject);
+      if (state.volatile) {
+        return;
+      }
+      state.volatile = true;
+      state.dirty = true;
+      flush(base, state);
+    },
+  };
+}
+
+function snapshotDirectory(base: string): string {
+  return path.join(base, ...SNAPSHOT_DIRECTORY);
+}
+
+/**
+ * Read every worker snapshot file in `directory`. A file that disappears
+ * mid-read was compacted (merged into the main snapshot first) and is skipped;
+ * a file that exists but does not parse marks the result corrupt.
+ */
+function readWorkerFiles(directory: string): {
+  corrupt: boolean;
+  entries: SnapshotDocument[];
+  paths: string[];
+} {
+  let names: string[];
+  try {
+    names = fs.readdirSync(directory);
+  } catch {
+    return { corrupt: false, entries: [], paths: [] };
+  }
+  const entries: SnapshotDocument[] = [];
+  const paths: string[] = [];
+  let corrupt = false;
+  for (const name of names) {
+    if (!name.startsWith(WORKER_SNAPSHOT_PREFIX) || !name.endsWith(".json")) {
+      continue;
+    }
+    const file = path.join(directory, name);
+    let text: string;
+    try {
+      text = fs.readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    const parsed = parseSnapshotDocument(text);
+    if (parsed === undefined) {
+      corrupt = true;
+      continue;
+    }
+    entries.push(parsed);
+    paths.push(file);
+  }
+  return { corrupt, entries, paths };
+}
+
+function readMainDocument(directory: string): SnapshotDocument | undefined {
+  let text: string;
+  try {
+    text = fs.readFileSync(path.join(directory, MAIN_SNAPSHOT), "utf8");
+  } catch {
+    return undefined;
+  }
+  return parseSnapshotDocument(text);
+}
+
+function parseSnapshotDocument(text: string): SnapshotDocument | undefined {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const document = value as Record<string, unknown>;
+  if (document.version !== SNAPSHOT_VERSION || !Array.isArray(document.files)) {
+    return undefined;
+  }
+  return {
+    files: document.files.filter(
+      (entry): entry is string => typeof entry === "string",
+    ),
+    ...(typeof document.id === "string" ? { id: document.id } : {}),
+    version: SNAPSHOT_VERSION,
+    volatile: document.volatile === true,
+  };
+}
+
+/** Write a snapshot document atomically (unique temp file, then rename). */
+function writeSnapshotDocument(file: string, document: SnapshotDocument): void {
+  const temp = `${file}.${randomBytes(6).toString("hex")}.tmp`;
+  fs.writeFileSync(temp, JSON.stringify(document), "utf8");
+  try {
+    fs.renameSync(temp, file);
+  } catch (error) {
+    fs.rmSync(temp, { force: true });
+    throw error;
+  }
+}
+
+/**
+ * JSON-serialise with object keys sorted recursively, so two semantically equal
+ * records always hash to the same fingerprint regardless of property order.
+ * Shared with the transformer's option digest.
+ */
+export function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/packages/metro/src/core/fingerprint.ts
+++ b/packages/metro/src/core/fingerprint.ts
@@ -188,8 +188,12 @@ function nonce(): string {
 /**
  * Prepare the snapshot for a new run. Called from `withTtsc` in the single
  * Metro config process, before any worker exists: creates the main snapshot
- * (fresh epoch id) when missing or corrupt, and compacts leftover worker files
- * into it. Never throws — an unwritable cache directory leaves the snapshot
+ * (fresh epoch id) when missing or corrupt, compacts leftover worker files into
+ * it, and sweeps unparseable worker files plus crash-leftover temp files. An
+ * unparseable worker file's recordings are unrecoverable, so its removal mints
+ * a fresh epoch id — every key that might have depended on the lost recordings
+ * is soundly orphaned, and later runs stabilize instead of degrading to a nonce
+ * forever. Never throws — an unwritable cache directory leaves the snapshot
  * unreadable and `getCacheKey` degrades to a nonce.
  */
 export function prepareSnapshot(projectRoot: string | undefined): void {
@@ -203,7 +207,7 @@ export function prepareSnapshot(projectRoot: string | undefined): void {
     const workers = readWorkerFiles(directory);
     const main = readMainDocument(directory);
     const files = new Set(main?.files ?? []);
-    let volatile =
+    const volatile =
       workers.entries.length === 0
         ? (main?.volatile ?? false)
         : // Worker files carry the previous run's fresh observations, so they
@@ -217,11 +221,18 @@ export function prepareSnapshot(projectRoot: string | undefined): void {
     }
     writeSnapshotDocument(path.join(directory, MAIN_SNAPSHOT), {
       files: [...files].sort(),
-      id: main?.id ?? randomBytes(16).toString("hex"),
+      id:
+        workers.corruptPaths.length === 0
+          ? (main?.id ?? randomBytes(16).toString("hex"))
+          : randomBytes(16).toString("hex"),
       version: SNAPSHOT_VERSION,
       volatile,
     });
-    for (const file of workers.paths) {
+    for (const file of [
+      ...workers.paths,
+      ...workers.corruptPaths,
+      ...listTemporaryFiles(directory),
+    ]) {
       try {
         fs.rmSync(file, { force: true });
       } catch {
@@ -235,6 +246,31 @@ export function prepareSnapshot(projectRoot: string | undefined): void {
 }
 
 /**
+ * Crash-leftover temp files from the atomic writer, swept at compaction. Only
+ * files older than a day qualify: a young temp file may belong to a live writer
+ * in a concurrently running Metro instance, and deleting it mid-write would
+ * silently drop that writer's recordings.
+ */
+function listTemporaryFiles(directory: string): string[] {
+  const horizon = Date.now() - 24 * 60 * 60 * 1000;
+  try {
+    return fs
+      .readdirSync(directory)
+      .filter((name) => name.endsWith(".tmp"))
+      .map((name) => path.join(directory, name))
+      .filter((file) => {
+        try {
+          return fs.statSync(file).mtimeMs < horizon;
+        } catch {
+          return false;
+        }
+      });
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Read the unioned snapshot state, or `undefined` when the main snapshot is
  * missing or any snapshot file is corrupt (a torn or foreign write means the
  * recorded set cannot be trusted, so the caller degrades to a nonce).
@@ -243,7 +279,7 @@ export function readSnapshotState(base: string): SnapshotState | undefined {
   const directory = snapshotDirectory(base);
   // Worker files strictly before the main file — see the module doc comment.
   const workers = readWorkerFiles(directory);
-  if (workers.corrupt) {
+  if (workers.corruptPaths.length !== 0) {
     return undefined;
   }
   const main = readMainDocument(directory);
@@ -312,7 +348,6 @@ export function createSnapshotRecorder(): {
     if (!state.dirty) {
       return;
     }
-    state.dirty = false;
     try {
       const directory = snapshotDirectory(base);
       fs.mkdirSync(directory, { recursive: true });
@@ -324,6 +359,9 @@ export function createSnapshotRecorder(): {
           volatile: state.volatile,
         },
       );
+      // Cleared only on success so a transient write failure retries on the
+      // next recording instead of silently dropping the observed state.
+      state.dirty = false;
     } catch {
       // An unwritable snapshot leaves the main snapshot unreadable or stale;
       // getCacheKey degrades to a nonce rather than serving stale output.
@@ -365,10 +403,11 @@ function snapshotDirectory(base: string): string {
 /**
  * Read every worker snapshot file in `directory`. A file that disappears
  * mid-read was compacted (merged into the main snapshot first) and is skipped;
- * a file that exists but does not parse marks the result corrupt.
+ * a file that exists but does not parse is reported in `corruptPaths` so
+ * readers can degrade to a nonce and the compactor can sweep it.
  */
 function readWorkerFiles(directory: string): {
-  corrupt: boolean;
+  corruptPaths: string[];
   entries: SnapshotDocument[];
   paths: string[];
 } {
@@ -376,11 +415,11 @@ function readWorkerFiles(directory: string): {
   try {
     names = fs.readdirSync(directory);
   } catch {
-    return { corrupt: false, entries: [], paths: [] };
+    return { corruptPaths: [], entries: [], paths: [] };
   }
   const entries: SnapshotDocument[] = [];
   const paths: string[] = [];
-  let corrupt = false;
+  const corruptPaths: string[] = [];
   for (const name of names) {
     if (!name.startsWith(WORKER_SNAPSHOT_PREFIX) || !name.endsWith(".json")) {
       continue;
@@ -394,13 +433,13 @@ function readWorkerFiles(directory: string): {
     }
     const parsed = parseSnapshotDocument(text);
     if (parsed === undefined) {
-      corrupt = true;
+      corruptPaths.push(file);
       continue;
     }
     entries.push(parsed);
     paths.push(file);
   }
-  return { corrupt, entries, paths };
+  return { corruptPaths, entries, paths };
 }
 
 function readMainDocument(directory: string): SnapshotDocument | undefined {

--- a/packages/metro/src/core/fingerprint.ts
+++ b/packages/metro/src/core/fingerprint.ts
@@ -198,7 +198,14 @@ function nonce(): string {
  */
 export function prepareSnapshot(projectRoot: string | undefined): void {
   try {
-    const directory = snapshotDirectory(resolveFingerprintBase(projectRoot));
+    const base = resolveFingerprintBase(projectRoot);
+    // A nonexistent base can never be a working Metro setup (Metro verifies
+    // the project root exists), so preparing a snapshot there would only
+    // materialize directory trees at arbitrary paths.
+    if (!fs.existsSync(base)) {
+      return;
+    }
+    const directory = snapshotDirectory(base);
     fs.mkdirSync(directory, { recursive: true });
     // Read the worker files strictly before the main file (see the module doc
     // comment): a concurrent compactor deletes a worker file only after the

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -30,6 +30,7 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { prepareSnapshot } from "./core/fingerprint";
 import type { TtscMetroOptions } from "./core/options";
 import { ENV_KEY, serializeOptions } from "./core/options";
 
@@ -69,6 +70,13 @@ export function withTtsc<T extends MetroConfigLike>(
   options: TtscMetroOptions = {},
 ): T {
   process.env[ENV_KEY] = serializeOptions(options);
+  // Prepare the reference-graph snapshot backing the transformer's cache-key
+  // fingerprint (see `core/fingerprint.ts`). This runs in the single Metro
+  // config process before any worker exists, so it is the race-free moment to
+  // mint the snapshot epoch and compact the previous run's worker files.
+  prepareSnapshot(
+    typeof config.projectRoot === "string" ? config.projectRoot : undefined,
+  );
   return {
     ...config,
     transformer: {

--- a/packages/metro/src/transformer.ts
+++ b/packages/metro/src/transformer.ts
@@ -10,8 +10,10 @@
  *
  * The ttsc pass reuses `@ttsc/unplugin`'s `transformTtsc`, so the plugin
  * contract, tsconfig discovery, and per-build cache are identical to every
- * other bundler integration. See the package README for the v1 cost model and
- * the cross-file cache-invalidation caveat.
+ * other bundler integration. Cross-file cache invalidation rides the project
+ * fingerprint {@link getCacheKey} folds into Metro's static transformer key (see
+ * `core/fingerprint.ts`); the package README covers the v1 cost model and the
+ * remaining watch-session boundary.
  */
 import {
   createTtscTransformCache,
@@ -22,6 +24,11 @@ import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import path from "node:path";
 
+import {
+  computeProjectFingerprint,
+  createSnapshotRecorder,
+  stableStringify,
+} from "./core/fingerprint";
 import type { ResolvedTtscMetroOptions } from "./core/options";
 import { resolveOptionsFromEnv } from "./core/options";
 import { resolveUpstreamTransformer } from "./core/upstream";
@@ -45,6 +52,7 @@ const DECLARATION = /\.d\.[cm]?ts$/;
 let resolved: ResolvedTtscMetroOptions | undefined;
 let unpluginOptions: ReturnType<typeof resolveOptions> | undefined;
 const cache = createTtscTransformCache();
+const snapshotRecorder = createSnapshotRecorder();
 
 /** Lazily resolve the worker-side options (from {@link resolveOptionsFromEnv}). */
 function options(): ResolvedTtscMetroOptions {
@@ -106,12 +114,33 @@ export async function transform(params: {
   let transformedSrc = params.src;
   try {
     unpluginOptions ??= resolveOptions(opts.ttsc);
+    const projectRoot =
+      typeof params.options.projectRoot === "string"
+        ? params.options.projectRoot
+        : undefined;
+    const explicitProject =
+      typeof opts.ttsc.project === "string" ? opts.ttsc.project : undefined;
     const result = await transformTtsc(
       resolveAbsoluteFilename(params.filename, params.options),
       params.src,
       unpluginOptions,
       undefined,
       cache,
+      {
+        // Metro offers no per-file dependency registration, so the derived
+        // watch inputs (plugin-reported dependencies unioned with the
+        // reference graph's reach, globals, and configs) feed the snapshot
+        // that the next run's getCacheKey re-hashes instead. Fires on cache
+        // hits too, so a worker that never recompiled still records the
+        // inputs backing the outputs it serves.
+        addWatchFile: (input) =>
+          snapshotRecorder.record({ explicitProject, input, projectRoot }),
+        // A volatile declaration means the output depends on non-file inputs
+        // that no file fingerprint can represent; the snapshot marks it and
+        // getCacheKey degrades to a per-run nonce (no cross-run reuse).
+        markVolatile: () =>
+          snapshotRecorder.recordVolatile({ explicitProject, projectRoot }),
+      },
     );
     if (result !== undefined && typeof result.code === "string") {
       transformedSrc = result.code;
@@ -131,15 +160,25 @@ export async function transform(params: {
 /**
  * Metro transform-cache key.
  *
- * Metro already content-hashes each file, so this only has to invalidate when
- * the transformer itself changes: package version + resolved options + the
- * upstream transformer's own key (forwarded Metro's args, e.g. `projectRoot`,
- * so a `babel.config.js` change still busts the cache). Resolving the upstream
- * is deliberately non-fatal here: a missing peer must not crash cache-key
- * computation. NOTE: this does not encode the tsconfig / plugin configuration
- * or cross-file type dependencies, so after editing those (or a depended-upon
- * type) run Metro with `--reset-cache`. See the README "Caveats" and
- * samchon/ttsc#255.
+ * Metro calls this once per run (dev-server start or cold `metro bundle`), on
+ * the main process, and folds the result into every file's per-content cache
+ * key. It must therefore incorporate every input that can influence a
+ * transform's output beyond the file's own content:
+ *
+ * - The transformer identity: package version + resolved options + the upstream
+ *   transformer's own key (forwarded Metro's args, e.g. `projectRoot`, so a
+ *   `babel.config.js` change still busts the cache);
+ * - The project fingerprint (see `core/fingerprint.ts`): every input file under
+ *   the project walk (tsconfig, plugin configs, type-only siblings) plus the
+ *   recorded out-of-walk reference-graph members from previous transforms
+ *   (`node_modules` declarations, monorepo sibling sources, out-of-root config
+ *   ancestry).
+ *
+ * A change to any fingerprinted input re-keys every transformed file —
+ * project-level granularity, forced by Metro's single static key — replacing
+ * the former manual `--reset-cache` step. Resolving the upstream is
+ * deliberately non-fatal here: a missing peer must not crash cache-key
+ * computation. See the README "Caveats" and samchon/ttsc#721.
  */
 export function getCacheKey(...args: unknown[]): string {
   const opts = options();
@@ -157,7 +196,32 @@ export function getCacheKey(...args: unknown[]): string {
   if (upstreamKey.length !== 0) {
     hash.update(upstreamKey);
   }
+  hash.update(
+    computeProjectFingerprint({
+      explicitProject:
+        typeof opts.ttsc.project === "string" ? opts.ttsc.project : undefined,
+      projectRoot: cacheKeyProjectRoot(args),
+    }),
+  );
   return hash.digest("hex");
+}
+
+/**
+ * Extract Metro's `projectRoot` from the cache-key options
+ * (`metro-transform-worker` calls `getCacheKey({ projectRoot,
+ * enableBabelRCLookup })`). Defensive against foreign callers: anything but a
+ * non-empty string yields `undefined` and the fingerprint falls back to the
+ * working directory.
+ */
+function cacheKeyProjectRoot(args: unknown[]): string | undefined {
+  const first = args[0];
+  if (typeof first !== "object" || first === null) {
+    return undefined;
+  }
+  const projectRoot = (first as Record<string, unknown>).projectRoot;
+  return typeof projectRoot === "string" && projectRoot.length !== 0
+    ? projectRoot
+    : undefined;
 }
 
 /**
@@ -229,21 +293,4 @@ function packageVersion(): string {
   } catch {
     return "0";
   }
-}
-
-/**
- * JSON-serialise with object keys sorted recursively, so two semantically equal
- * option sets always hash to the same cache key regardless of property order.
- */
-function stableStringify(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(",")}]`;
-  }
-  if (value !== null && typeof value === "object") {
-    return `{${Object.entries(value)
-      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
-      .join(",")}}`;
-  }
-  return JSON.stringify(value);
 }

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -308,6 +308,8 @@ The transform host reports the program's reference graph (the transform envelope
 
 Transform plugins may additionally report, per file, the source files they consulted (the envelope's `dependencies` field); the adapter registers those as watch files too, union semantics. Files a plugin declares `volatile` (output depending on non-file inputs such as environment or time) bypass the adapter's transform cache and are marked uncacheable where the bundler exposes that control.
 
+The transform cache itself validates against the same input set: every file under the project root plus the graph-reported inputs outside it (`node_modules` declarations, monorepo sibling sources, out-of-root `extends` ancestry). Hosts that keep one cache for the process lifetime instead of per build (Metro workers, the Turbopack loader, Bun) therefore recompile when any of those inputs changes, not only in-project ones.
+
 ## Sponsors
 
 [![Sponsors](https://raw.githubusercontent.com/samchon/sponsor-images/refs/heads/master/public/circle.svg)](https://github.com/sponsors/samchon)

--- a/packages/unplugin/src/core/index.ts
+++ b/packages/unplugin/src/core/index.ts
@@ -4,8 +4,11 @@ import { createUnplugin } from "unplugin";
 import type { TtscUnpluginOptions } from "./options";
 import { resolveOptions } from "./options";
 import {
+  collectExternalInputHashes,
+  collectProjectInputHashes,
   createTtscTransformCache,
   isDeclarationFile,
+  isProjectWalkPath,
   stripQuery,
   transformTtsc,
 } from "./transform";
@@ -99,7 +102,15 @@ export type {
   TtscUnpluginOptions,
 } from "./options";
 export type { TtscTransformHooks } from "./transform";
-export { createTtscTransformCache, resolveOptions, transformTtsc, unplugin };
+export {
+  collectExternalInputHashes,
+  collectProjectInputHashes,
+  createTtscTransformCache,
+  isProjectWalkPath,
+  resolveOptions,
+  transformTtsc,
+  unplugin,
+};
 
 export default unplugin;
 

--- a/packages/unplugin/src/core/transform.ts
+++ b/packages/unplugin/src/core/transform.ts
@@ -52,6 +52,20 @@ export interface TtscTransformAlias {
  */
 export interface TtscCachedProjectTransform {
   /**
+   * SHA-256 hash of every input the compiler reported outside the project walk
+   * (keyed by absolute path), captured at the time of the transform.
+   *
+   * The project walk cannot see files outside the project root or under ignored
+   * directories (`node_modules` declarations, monorepo sibling sources,
+   * out-of-root tsconfig `extends` ancestry), yet the host-owned reference
+   * graph proves they are transform inputs. Long-lived hosts that never clear
+   * the cache between builds (Metro workers, the Turbopack loader, Bun) would
+   * otherwise replay a project transform computed against a stale out-of-walk
+   * input for the whole process lifetime; per-build hosts clear the cache on
+   * `buildStart` and never replay across edits.
+   */
+  externalInputHashes?: Record<string, string>;
+  /**
    * SHA-256 hash of each project-relative input path at the time of the
    * transform.
    */
@@ -545,11 +559,12 @@ export function createTransformResult(
  * in-memory source, then compares the snapshot against the one captured when
  * the result was produced. Any input under the project root changing (the
  * module itself or a sibling the plugin reads) invalidates the entry and forces
- * a re-transform. Out-of-walk inputs a plugin pulls in (`node_modules`
- * declarations, sibling-package sources) are not seen here; adapters invalidate
- * on those through the derived watch inputs (the host-owned `graph` union the
- * reported `dependencies`) → `addWatchFile` → the bundler's next `buildStart`
- * cache clear.
+ * a re-transform. Out-of-walk inputs the compiler reported (`node_modules`
+ * declarations, sibling-package sources, out-of-root config ancestry) are
+ * validated through {@link TtscCachedProjectTransform.externalInputHashes};
+ * adapters additionally register them as derived watch inputs (the host-owned
+ * `graph` union the reported `dependencies`) → `addWatchFile` → the bundler's
+ * next `buildStart` cache clear.
  *
  * Both this snapshot and {@link collectInputHashes} draw their keys from the
  * exact same {@link collectProjectInputHashes} walk, so the two always agree on
@@ -567,7 +582,22 @@ function matchesCachedSource(
   const currentKey = toProjectKey(cached.projectRoot, file);
   const currentHashes = collectProjectInputHashes(cached.projectRoot);
   currentHashes[currentKey] = hashText(source);
-  return sameHashes(cached.inputHashes, currentHashes);
+  if (!sameHashes(cached.inputHashes, currentHashes)) {
+    return false;
+  }
+  // Re-hash the out-of-walk inputs the compiler reported for this generation
+  // over exactly the recorded key universe, so an edit to a `node_modules`
+  // declaration or a monorepo sibling source invalidates the entry even in a
+  // host that never clears the cache between builds. A new out-of-walk input
+  // cannot appear without some recorded input changing first: a new reference
+  // edge requires editing an in-walk source, and a new global or config file
+  // requires a tsconfig or package manifest change, both of which the project
+  // walk above already detects.
+  const externalHashes = cached.externalInputHashes ?? {};
+  return sameHashes(
+    externalHashes,
+    collectExternalInputHashes(Object.keys(externalHashes)),
+  );
 }
 
 /**
@@ -596,7 +626,13 @@ function collectInputHashes(props: {
   return hashes;
 }
 
-function collectProjectInputHashes(
+/**
+ * Hash every input file under `projectRoot` (the same walk universe
+ * {@link matchesCachedSource} validates against), keyed by project-relative
+ * slash path. Exported so hosts without a per-build boundary (`@ttsc/metro`)
+ * can fold the identical input universe into their own cache fingerprints.
+ */
+export function collectProjectInputHashes(
   projectRoot: string,
 ): Record<string, string> {
   const hashes: Record<string, string> = {};
@@ -644,6 +680,110 @@ function listProjectInputFiles(root: string): string[] {
   }
   out.sort();
   return out;
+}
+
+/**
+ * Report whether an absolute `file` belongs to the project walk universe of
+ * `root`: it lies under `root` and no segment of the relative path (including
+ * the basename) is an ignored directory name. The predicate mirrors
+ * {@link listProjectInputFiles} exactly, so "walk-visible" here means "hashed by
+ * {@link collectProjectInputHashes}". Anything else is an out-of-walk input that
+ * only the reference graph can prove relevant.
+ */
+export function isProjectWalkPath(root: string, file: string): boolean {
+  const relative = path.relative(path.resolve(root), path.resolve(file));
+  if (
+    relative.length === 0 ||
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    return false;
+  }
+  return relative
+    .split(path.sep)
+    .every((segment) => !isIgnoredProjectDirectory(segment));
+}
+
+/**
+ * Hash a list of absolute out-of-walk input paths: content SHA-256 for a
+ * readable file, a stable `missing` marker otherwise. The marker is state, not
+ * an error — a recorded input disappearing (or reappearing) must change the
+ * comparison exactly like a content edit. Exported so `@ttsc/metro` can re-hash
+ * its recorded snapshot with identical semantics at cache-key time.
+ */
+export function collectExternalInputHashes(
+  paths: readonly string[],
+): Record<string, string> {
+  const hashes: Record<string, string> = {};
+  for (const file of paths) {
+    try {
+      hashes[file] = hashText(fs.readFileSync(file));
+    } catch {
+      hashes[file] = "missing";
+    }
+  }
+  return hashes;
+}
+
+/**
+ * Derive the absolute out-of-walk input set of a whole project transform: the
+ * union of every reference-graph member (edge keys and targets, globals, the
+ * config chain) and every plugin-reported dependency, minus everything the
+ * project walk already hashes and the disposed temp-dir tsconfig. These are the
+ * inputs {@link matchesCachedSource}'s walk cannot see.
+ */
+function selectExternalInputPaths(props: {
+  projectRoot: string;
+  result: ITtscCompilerTransformation;
+  temporaryTsconfig?: string;
+}): string[] {
+  if (props.result.type === "exception") {
+    return [];
+  }
+  const members: string[] = [];
+  const graph = props.result.graph;
+  if (graph !== undefined) {
+    for (const [source, targets] of Object.entries(graph.edges ?? {})) {
+      members.push(source);
+      if (Array.isArray(targets)) {
+        members.push(...targets);
+      }
+    }
+    for (const listed of [graph.globals, graph.configs]) {
+      if (Array.isArray(listed)) {
+        members.push(...listed);
+      }
+    }
+  }
+  for (const entries of Object.values(props.result.dependencies ?? {})) {
+    if (Array.isArray(entries)) {
+      members.push(...entries);
+    }
+  }
+  const excluded =
+    props.temporaryTsconfig === undefined
+      ? undefined
+      : path.resolve(props.temporaryTsconfig);
+  const output: string[] = [];
+  const seen = new Set<string>();
+  for (const member of members) {
+    if (typeof member !== "string" || member.length === 0) {
+      continue;
+    }
+    const absolute = path.resolve(props.projectRoot, member);
+    if (
+      absolute === excluded ||
+      seen.has(absolute) ||
+      isProjectWalkPath(props.projectRoot, absolute)
+    ) {
+      continue;
+    }
+    seen.add(absolute);
+    output.push(absolute);
+  }
+  output.sort();
+  return output;
 }
 
 function isIgnoredProjectDirectory(name: string): boolean {
@@ -706,7 +846,15 @@ async function transformProject(props: {
       projectRoot,
       tsconfig: configured.path,
     }).transform();
+    const temporaryTsconfig =
+      configured.path === props.tsconfig ? undefined : configured.path;
     return {
+      // Capture the out-of-walk input hashes while the generation is fresh so
+      // cache validation can re-check them; computed before dispose so the
+      // exclusion of the temp-dir tsconfig is the only reason it never keys.
+      externalInputHashes: collectExternalInputHashes(
+        selectExternalInputPaths({ projectRoot, result, temporaryTsconfig }),
+      ),
       inputHashes: collectInputHashes({
         currentFile: props.currentFile,
         currentSource: props.currentSource,
@@ -717,9 +865,7 @@ async function transformProject(props: {
       // Remember the generated temp-dir tsconfig (disposed below) so watch
       // derivation can drop it from the envelope's config chain; a registered
       // but deleted file would invalidate every persistent-cache snapshot.
-      ...(configured.path === props.tsconfig
-        ? {}
-        : { temporaryTsconfig: configured.path }),
+      ...(temporaryTsconfig === undefined ? {} : { temporaryTsconfig }),
     };
   } finally {
     configured.dispose();

--- a/tests/test-metro/src/features/cache/test_cache_key_changes_when_a_project_source_file_changes.ts
+++ b/tests/test-metro/src/features/cache/test_cache_key_changes_when_a_project_source_file_changes.ts
@@ -1,0 +1,17 @@
+import { assertCacheKeyChangesWhenProjectSourceChanges } from "../../internal/metro-cache";
+
+/**
+ * Verifies editing any project source between runs changes the cache key.
+ *
+ * Metro keys each file only on its own content, so an edit to file B never
+ * re-keys a dependent file A; the project-walk half of the fingerprint
+ * (samchon/ttsc#721) is what re-keys the whole run instead.
+ *
+ * 1. Create a plugin-less project, prepare the snapshot, compute the key.
+ * 2. Edit one source file; compute the key in a fresh transformer module.
+ * 3. Assert the keys differ.
+ */
+export const test_cache_key_changes_when_a_project_source_file_changes =
+  async () => {
+    await assertCacheKeyChangesWhenProjectSourceChanges();
+  };

--- a/tests/test-metro/src/features/cache/test_cache_key_changes_when_a_recorded_external_input_changes.ts
+++ b/tests/test-metro/src/features/cache/test_cache_key_changes_when_a_recorded_external_input_changes.ts
@@ -1,0 +1,24 @@
+import { assertCacheKeyChangesWhenRecordedExternalInputChanges } from "../../internal/metro-cache";
+
+/**
+ * Verifies the two-run acceptance reproduction of samchon/ttsc#721, out-of-walk
+ * direction: a transform input outside the project root (the shape of
+ * `node_modules` declarations and monorepo sibling sources) is recorded by run
+ * 1, compacted into the main snapshot, and re-hashed by the next run's key, so
+ * editing only that external file re-keys the run.
+ *
+ * No project walk can see this class of input; only the reference-graph channel
+ * (samchon/ttsc#718) can prove it relevant. Exercises the real native compiler,
+ * so it runs where the Go toolchain is present (CI).
+ *
+ * 1. Run 1 transforms a project whose plugin reads and reports a file outside the
+ *    project root; assert the worker snapshot recorded it.
+ * 2. Prepare the next run (compaction): the main snapshot carries the path;
+ *    compute the key.
+ * 3. Edit only the external file: a fresh run's key differs and its transform
+ *    carries the regenerated output.
+ */
+export const test_cache_key_changes_when_a_recorded_external_input_changes =
+  async () => {
+    await assertCacheKeyChangesWhenRecordedExternalInputChanges();
+  };

--- a/tests/test-metro/src/features/cache/test_cache_key_changes_when_the_snapshot_is_recreated.ts
+++ b/tests/test-metro/src/features/cache/test_cache_key_changes_when_the_snapshot_is_recreated.ts
@@ -1,0 +1,18 @@
+import { assertCacheKeyChangesWhenSnapshotRecreated } from "../../internal/metro-cache";
+
+/**
+ * Verifies a deleted-and-recreated snapshot mints a new key epoch.
+ *
+ * The recorded out-of-walk input set of a lost snapshot is unknown, so its keys
+ * must never alias: a wiped `node_modules` combined with a retained Metro cache
+ * in the OS temp directory would otherwise replay outputs whose external inputs
+ * changed while no snapshot was watching.
+ *
+ * 1. Prepare the snapshot and compute the key.
+ * 2. Delete the snapshot directory and prepare again (fresh epoch id).
+ * 3. Assert the new run's key differs.
+ */
+export const test_cache_key_changes_when_the_snapshot_is_recreated =
+  async () => {
+    await assertCacheKeyChangesWhenSnapshotRecreated();
+  };

--- a/tests/test-metro/src/features/cache/test_cache_key_folds_a_nonce_while_the_snapshot_records_volatile.ts
+++ b/tests/test-metro/src/features/cache/test_cache_key_folds_a_nonce_while_the_snapshot_records_volatile.ts
@@ -1,0 +1,19 @@
+import { assertCacheKeyFoldsNonceWhileSnapshotVolatile } from "../../internal/metro-cache";
+
+/**
+ * Verifies a volatile marker in the snapshot degrades the key to a per-run
+ * nonce.
+ *
+ * A plugin-declared volatile output depends on non-file inputs (environment,
+ * time, network) that no file fingerprint can represent, and Metro exposes no
+ * per-file uncacheable control; disabling cross-run reuse for the whole project
+ * is the only sound encoding Metro's contract admits.
+ *
+ * 1. Prepare the snapshot, then drop a worker snapshot with `volatile: true`.
+ * 2. Compute `getCacheKey` in two fresh transformer modules.
+ * 3. Assert the keys differ.
+ */
+export const test_cache_key_folds_a_nonce_while_the_snapshot_records_volatile =
+  async () => {
+    await assertCacheKeyFoldsNonceWhileSnapshotVolatile();
+  };

--- a/tests/test-metro/src/features/cache/test_cache_key_folds_a_nonce_without_a_readable_snapshot.ts
+++ b/tests/test-metro/src/features/cache/test_cache_key_folds_a_nonce_without_a_readable_snapshot.ts
@@ -1,0 +1,20 @@
+import { assertCacheKeyFoldsNonceWithoutReadableSnapshot } from "../../internal/metro-cache";
+
+/**
+ * Verifies the sound degradation without a readable snapshot: every run folds a
+ * fresh nonce, so no run ever reuses another run's cache entries.
+ *
+ * Without the snapshot the out-of-walk input set is unknown, and a stable
+ * fallback marker would let a stale-input entry from an earlier snapshot-less
+ * run be served forever. Cache-less is the sound trade; the documented setup
+ * path (`withTtsc`) creates the snapshot so real projects never stay in this
+ * mode.
+ *
+ * 1. Create a project but never prepare a snapshot.
+ * 2. Compute `getCacheKey` in two fresh transformer modules.
+ * 3. Assert the keys differ.
+ */
+export const test_cache_key_folds_a_nonce_without_a_readable_snapshot =
+  async () => {
+    await assertCacheKeyFoldsNonceWithoutReadableSnapshot();
+  };

--- a/tests/test-metro/src/features/cache/test_cache_key_is_stable_across_runs_for_an_unchanged_project.ts
+++ b/tests/test-metro/src/features/cache/test_cache_key_is_stable_across_runs_for_an_unchanged_project.ts
@@ -1,0 +1,18 @@
+import { assertCacheKeyStableAcrossRunsForUnchangedProject } from "../../internal/metro-cache";
+
+/**
+ * Verifies the cache key stays stable across runs of an unchanged project.
+ *
+ * The negative twin of every fingerprint invalidation case: the project
+ * fingerprint (samchon/ttsc#721) must re-key runs only when an input actually
+ * changed, or Metro's persistent cache would never be reused and the mechanism
+ * would degrade to a permanent `--reset-cache`.
+ *
+ * 1. Create a plugin-less project and prepare the snapshot (as `withTtsc` does).
+ * 2. Compute `getCacheKey` in two fresh transformer modules (two runs).
+ * 3. Assert both keys are equal 64-char digests.
+ */
+export const test_cache_key_is_stable_across_runs_for_an_unchanged_project =
+  async () => {
+    await assertCacheKeyStableAcrossRunsForUnchangedProject();
+  };

--- a/tests/test-metro/src/features/cache/test_cache_key_rekeys_a_dependent_transform_when_its_input_file_changes.ts
+++ b/tests/test-metro/src/features/cache/test_cache_key_rekeys_a_dependent_transform_when_its_input_file_changes.ts
@@ -1,0 +1,22 @@
+import { assertCacheKeyRekeysWhenTransformInputFileChanges } from "../../internal/metro-cache";
+
+/**
+ * Verifies the two-run acceptance reproduction of samchon/ttsc#721, in-project
+ * direction: edit only a file the transform's output depends on, re-run without
+ * `--reset-cache`, and the run is re-keyed with the regenerated output.
+ *
+ * The dependent file's own content never changes, which is exactly the v1
+ * staleness class: Metro's per-content key would have replayed the run-1 output
+ * forever. Exercises the real native compiler, so it runs where the Go
+ * toolchain is present (CI), like the other plugin-pass scenarios.
+ *
+ * 1. Project whose plugin output embeds `src/helper.ts` content ("first"); run 1
+ *    computes the key and transforms `src/main.ts` → `PLUGIN:FIRST`.
+ * 2. Edit only `src/helper.ts` to "second".
+ * 3. Run 2 (fresh module): the key differs and the transform carries
+ *    `PLUGIN:SECOND`.
+ */
+export const test_cache_key_rekeys_a_dependent_transform_when_its_input_file_changes =
+  async () => {
+    await assertCacheKeyRekeysWhenTransformInputFileChanges();
+  };

--- a/tests/test-metro/src/features/cache/test_prepare_snapshot_compacts_worker_files_into_the_main_snapshot.ts
+++ b/tests/test-metro/src/features/cache/test_prepare_snapshot_compacts_worker_files_into_the_main_snapshot.ts
@@ -1,0 +1,20 @@
+import { assertPrepareSnapshotCompactsWorkerFiles } from "../../internal/metro-cache";
+
+/**
+ * Verifies snapshot compaction merges worker files into the main snapshot.
+ *
+ * Workers write uniquely named files to stay race-free; `withTtsc` compacts
+ * them at the next config load. The files union must survive, the epoch id must
+ * be preserved (compaction is maintenance, not an epoch change that would
+ * spuriously invalidate every cache entry), and the worker files must be gone
+ * afterwards.
+ *
+ * 1. Prepare a snapshot; note its id; drop a worker file recording a path.
+ * 2. Prepare again.
+ * 3. Assert the main snapshot keeps the id, contains the path, and no worker files
+ *    remain.
+ */
+export const test_prepare_snapshot_compacts_worker_files_into_the_main_snapshot =
+  async () => {
+    await assertPrepareSnapshotCompactsWorkerFiles();
+  };

--- a/tests/test-metro/src/features/cache/test_prepare_snapshot_creates_nothing_for_a_nonexistent_root.ts
+++ b/tests/test-metro/src/features/cache/test_prepare_snapshot_creates_nothing_for_a_nonexistent_root.ts
@@ -1,0 +1,17 @@
+import { assertPrepareSnapshotSkipsNonexistentRoot } from "../../internal/metro-cache";
+
+/**
+ * Verifies snapshot preparation creates nothing for a nonexistent project root.
+ *
+ * Metro verifies the project root exists before running, so a nonexistent base
+ * can never be a working setup; `withTtsc` recursively creating
+ * `node_modules/.cache/ttsc-metro` there would materialize directory trees at
+ * arbitrary filesystem paths as a config-load side effect.
+ *
+ * 1. Point snapshot preparation at a path that does not exist.
+ * 2. Assert the path still does not exist afterwards.
+ */
+export const test_prepare_snapshot_creates_nothing_for_a_nonexistent_root =
+  async () => {
+    await assertPrepareSnapshotSkipsNonexistentRoot();
+  };

--- a/tests/test-metro/src/features/cache/test_prepare_snapshot_heals_a_corrupt_worker_file_with_a_new_epoch.ts
+++ b/tests/test-metro/src/features/cache/test_prepare_snapshot_heals_a_corrupt_worker_file_with_a_new_epoch.ts
@@ -1,0 +1,20 @@
+import { assertPrepareSnapshotHealsCorruptWorkerFile } from "../../internal/metro-cache";
+
+/**
+ * Verifies compaction heals a corrupt worker snapshot with a new epoch.
+ *
+ * A torn write from a crashed process leaves an unparseable worker file whose
+ * recordings are unrecoverable. Readers must degrade to a per-run nonce while
+ * it exists (unknown inputs must never alias a key), and compaction must sweep
+ * it and mint a fresh epoch id so later runs stabilize instead of staying
+ * nonced forever.
+ *
+ * 1. Prepare a snapshot; drop an unparseable worker file; assert two runs no
+ *    longer share a key.
+ * 2. Prepare again: the corrupt file is gone and the epoch id changed.
+ * 3. Assert two fresh runs share a stable key again.
+ */
+export const test_prepare_snapshot_heals_a_corrupt_worker_file_with_a_new_epoch =
+  async () => {
+    await assertPrepareSnapshotHealsCorruptWorkerFile();
+  };

--- a/tests/test-metro/src/features/cache/test_transformer_records_only_external_inputs_in_the_worker_snapshot.ts
+++ b/tests/test-metro/src/features/cache/test_transformer_records_only_external_inputs_in_the_worker_snapshot.ts
@@ -1,0 +1,20 @@
+import { assertTransformerRecordsOnlyExternalInputs } from "../../internal/metro-cache";
+
+/**
+ * Verifies the worker snapshot records only out-of-walk inputs.
+ *
+ * The project walk already fingerprints everything under the project root, so
+ * recording in-project dependencies would only bloat the snapshot and the
+ * per-run re-hash; the out-of-walk classification is the load-bearing filter.
+ * Exercises the real native compiler, so it runs where the Go toolchain is
+ * present (CI).
+ *
+ * 1. Transform a file whose plugin reports one in-project and one out-of-project
+ *    dependency.
+ * 2. Read the worker snapshot.
+ * 3. Assert it contains exactly the out-of-project path.
+ */
+export const test_transformer_records_only_external_inputs_in_the_worker_snapshot =
+  async () => {
+    await assertTransformerRecordsOnlyExternalInputs();
+  };

--- a/tests/test-metro/src/features/cache/test_transformer_records_volatile_declarations_in_the_worker_snapshot.ts
+++ b/tests/test-metro/src/features/cache/test_transformer_records_volatile_declarations_in_the_worker_snapshot.ts
@@ -1,0 +1,19 @@
+import { assertTransformerRecordsVolatileDeclarations } from "../../internal/metro-cache";
+
+/**
+ * Verifies a plugin-declared volatile transform marks the worker snapshot
+ * volatile.
+ *
+ * The marker is what feeds the nonce degradation on the next run's key; a
+ * dropped declaration would let Metro replay outputs that depend on non-file
+ * inputs. Exercises the real native compiler, so it runs where the Go toolchain
+ * is present (CI).
+ *
+ * 1. Transform a file through a plugin that declares it volatile.
+ * 2. Read this worker's snapshot file.
+ * 3. Assert `volatile: true`.
+ */
+export const test_transformer_records_volatile_declarations_in_the_worker_snapshot =
+  async () => {
+    await assertTransformerRecordsVolatileDeclarations();
+  };

--- a/tests/test-metro/src/features/config/test_withttsc_prepares_the_reference_graph_snapshot.ts
+++ b/tests/test-metro/src/features/config/test_withttsc_prepares_the_reference_graph_snapshot.ts
@@ -1,0 +1,16 @@
+import { assertWithTtscPreparesTheSnapshot } from "../../internal/metro-cache";
+
+/**
+ * Verifies `withTtsc` prepares the reference-graph snapshot at config load.
+ *
+ * The config process is the single race-free moment before workers exist, and
+ * an existing snapshot is what keeps an unchanged project's cache key stable
+ * from the second run onward (no snapshot means a per-run nonce).
+ *
+ * 1. Call `withTtsc` on a config pointing at a fresh project root.
+ * 2. Assert the transformer path is set (the config contract is untouched).
+ * 3. Assert the main snapshot exists with a non-empty epoch id and no files.
+ */
+export const test_withttsc_prepares_the_reference_graph_snapshot = async () => {
+  await assertWithTtscPreparesTheSnapshot();
+};

--- a/tests/test-metro/src/internal/metro-cache.ts
+++ b/tests/test-metro/src/internal/metro-cache.ts
@@ -1,0 +1,419 @@
+import { TestProject, TestUnpluginProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TestMetroRuntime } from "./metro-runtime";
+
+/**
+ * Assertions for the reference-graph cache fingerprint (samchon/ttsc#721).
+ *
+ * Metro evaluates `getCacheKey` once per run and folds it into every file's
+ * per-content cache key, so "two runs" are simulated the way Metro produces
+ * them: a fresh transformer module instance per run (Metro loads the module
+ * once per process), with the on-disk project mutated between runs. A key
+ * change between runs is exactly Metro's re-transform trigger; a stable key is
+ * exactly its cache reuse.
+ */
+
+/** Absolute path of the main snapshot file for a project root. */
+function mainSnapshotPath(root: string): string {
+  return path.join(
+    root,
+    "node_modules",
+    ".cache",
+    "ttsc-metro",
+    "graph-inputs.json",
+  );
+}
+
+/** Absolute path of the snapshot directory for a project root. */
+function snapshotDirectory(root: string): string {
+  return path.dirname(mainSnapshotPath(root));
+}
+
+/** Parse the main snapshot document, failing the test when absent. */
+function readMainSnapshot(root: string): {
+  files: string[];
+  id: string;
+  version: number;
+  volatile: boolean;
+} {
+  return JSON.parse(fs.readFileSync(mainSnapshotPath(root), "utf8"));
+}
+
+/** List the per-worker snapshot files currently on disk. */
+function listWorkerSnapshots(root: string): string[] {
+  const directory = snapshotDirectory(root);
+  if (!fs.existsSync(directory)) {
+    return [];
+  }
+  return fs
+    .readdirSync(directory)
+    .filter(
+      (name) =>
+        name.startsWith("graph-inputs.worker-") && name.endsWith(".json"),
+    )
+    .map((name) => path.join(directory, name));
+}
+
+/** Union of the `files` arrays across every worker snapshot on disk. */
+function workerSnapshotFiles(root: string): string[] {
+  const union = new Set<string>();
+  for (const file of listWorkerSnapshots(root)) {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+    for (const entry of parsed.files ?? []) {
+      union.add(entry);
+    }
+  }
+  return [...union].sort();
+}
+
+/** Run `prepareSnapshot` the way `withTtsc` does at config load. */
+export async function prepareSnapshot(root: string): Promise<void> {
+  const fingerprint = await TestMetroRuntime.loadFingerprint();
+  fingerprint.prepareSnapshot(root);
+}
+
+/**
+ * Create a plugin-less TypeScript project for fingerprint-only scenarios that
+ * must not require the native compiler or a Go toolchain.
+ */
+export function createBareProject(): string {
+  const root = TestProject.tmpdir("ttsc-metro-cache-");
+  fs.mkdirSync(path.join(root, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "src", "app.ts"),
+    "export const value: number = 1;\n",
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(root, "tsconfig.json"),
+    JSON.stringify({ compilerOptions: { strict: true }, include: ["src"] }),
+    "utf8",
+  );
+  return root;
+}
+
+/** Compute one run's cache key: fresh module, Metro-shaped key options. */
+async function cacheKeyForRun(
+  root: string,
+  options: Record<string, unknown> = {},
+): Promise<string> {
+  return TestMetroRuntime.withTransformerEnv(options, (mod) =>
+    mod.getCacheKey({ projectRoot: root }),
+  );
+}
+
+/**
+ * Asserts the cache key is stable across two simulated runs of an unchanged
+ * project. The negative twin of every invalidation case below: without it, the
+ * fingerprint could "pass" invalidation tests by never letting Metro reuse a
+ * cache entry at all.
+ */
+export async function assertCacheKeyStableAcrossRunsForUnchangedProject(): Promise<void> {
+  const root = createBareProject();
+  await prepareSnapshot(root);
+  const first = await cacheKeyForRun(root);
+  const second = await cacheKeyForRun(root);
+  assert.equal(first.length, 64);
+  assert.equal(first, second);
+}
+
+/**
+ * Asserts editing any project source between runs changes the cache key, even
+ * though Metro never re-keys unchanged files itself: the project walk is the
+ * fingerprint half that covers in-project type dependencies and configs.
+ */
+export async function assertCacheKeyChangesWhenProjectSourceChanges(): Promise<void> {
+  const root = createBareProject();
+  await prepareSnapshot(root);
+  const before = await cacheKeyForRun(root);
+  fs.writeFileSync(
+    path.join(root, "src", "app.ts"),
+    "export const value: 1 | 2 = 2;\n",
+    "utf8",
+  );
+  const after = await cacheKeyForRun(root);
+  assert.notEqual(before, after);
+}
+
+/**
+ * The issue's two-run acceptance reproduction, in-project direction: a
+ * transform whose output depends on another file, the dependency edited between
+ * runs, no `--reset-cache` anywhere. The dependent file's content is untouched,
+ * so v1's static key would have served the stale run-1 output; the fingerprint
+ * re-keys the run and the fresh transform carries the regenerated output.
+ */
+export async function assertCacheKeyRekeysWhenTransformInputFileChanges(): Promise<void> {
+  const root = TestUnpluginProject.createProject({
+    plugins: [
+      { transform: "./plugin.cjs", name: "fixture", operation: "read-helper" },
+    ],
+  });
+  const helper = path.join(root, "src", "helper.ts");
+  fs.writeFileSync(helper, "first\n", "utf8");
+  await prepareSnapshot(root);
+
+  const options = {
+    upstreamTransformer: TestMetroRuntime.fakeUpstreamPathOnDisk(),
+  };
+  const runOne = await TestMetroRuntime.withTransformerEnv(
+    options,
+    async (mod) => ({
+      key: mod.getCacheKey({ projectRoot: root }) as string,
+      result: await mod.transform({
+        src: TestUnpluginProject.mainSource(root),
+        filename: "src/main.ts",
+        options: { projectRoot: root },
+      }),
+    }),
+  );
+  assert.match(runOne.result.ast.src, /PLUGIN:FIRST/);
+
+  fs.writeFileSync(helper, "second\n", "utf8");
+  const runTwo = await TestMetroRuntime.withTransformerEnv(
+    options,
+    async (mod) => ({
+      key: mod.getCacheKey({ projectRoot: root }) as string,
+      result: await mod.transform({
+        src: TestUnpluginProject.mainSource(root),
+        filename: "src/main.ts",
+        options: { projectRoot: root },
+      }),
+    }),
+  );
+  assert.notEqual(runTwo.key, runOne.key);
+  assert.match(runTwo.result.ast.src, /PLUGIN:SECOND/);
+}
+
+/**
+ * The two-run acceptance reproduction, out-of-walk direction: the transform
+ * depends on a file outside the project root, which no project walk can see.
+ * Run 1 records it into the worker snapshot through the derived watch inputs;
+ * the next run's key re-hashes the recorded path, so editing only that external
+ * file re-keys the run and a fresh transform regenerates the output.
+ */
+export async function assertCacheKeyChangesWhenRecordedExternalInputChanges(): Promise<void> {
+  const shared = TestProject.tmpdir("ttsc-metro-shared-");
+  const external = path.join(shared, "helper.ts");
+  fs.writeFileSync(external, "first\n", "utf8");
+
+  const root = TestUnpluginProject.createProject({ plugins: [] });
+  const relative = path.relative(root, external);
+  const options = {
+    upstreamTransformer: TestMetroRuntime.fakeUpstreamPathOnDisk(),
+    plugins: [
+      {
+        transform: "./plugin.cjs",
+        name: "reader",
+        operation: "read-configured-helper",
+        path: relative,
+      },
+      {
+        transform: "./plugin.cjs",
+        name: "reporter",
+        operation: "emit-dependencies",
+        dependencies: [relative.split(path.sep).join("/")],
+      },
+    ],
+  };
+
+  await prepareSnapshot(root);
+  const runOne = await TestMetroRuntime.runTransform({
+    options,
+    params: {
+      src: TestUnpluginProject.mainSource(root),
+      filename: "src/main.ts",
+      options: { projectRoot: root },
+    },
+  });
+  assert.match(runOne.ast.src as string, /PLUGIN:FIRST/);
+  // The transform recorded the external input into this worker's snapshot.
+  assert.deepEqual(workerSnapshotFiles(root), [external]);
+
+  // Next run: withTtsc compacts the worker snapshot into the main file.
+  await prepareSnapshot(root);
+  assert.deepEqual(listWorkerSnapshots(root), []);
+  assert.ok(readMainSnapshot(root).files.includes(external));
+  const before = await cacheKeyForRun(root, options);
+
+  fs.writeFileSync(external, "second\n", "utf8");
+  const after = await cacheKeyForRun(root, options);
+  assert.notEqual(before, after);
+  const runThree = await TestMetroRuntime.runTransform({
+    options,
+    params: {
+      src: TestUnpluginProject.mainSource(root),
+      filename: "src/main.ts",
+      options: { projectRoot: root },
+    },
+  });
+  assert.match(runThree.ast.src as string, /PLUGIN:SECOND/);
+}
+
+/**
+ * Asserts a deleted-and-recreated snapshot mints a new epoch: the recorded
+ * out-of-walk set of the old epoch is unknown, so its keys must never alias.
+ * Guards the residual staleness path of a wiped `node_modules` combined with a
+ * retained Metro cache directory in the OS temp dir.
+ */
+export async function assertCacheKeyChangesWhenSnapshotRecreated(): Promise<void> {
+  const root = createBareProject();
+  await prepareSnapshot(root);
+  const before = await cacheKeyForRun(root);
+  fs.rmSync(snapshotDirectory(root), { force: true, recursive: true });
+  await prepareSnapshot(root);
+  const after = await cacheKeyForRun(root);
+  assert.notEqual(before, after);
+}
+
+/**
+ * Asserts that without a readable snapshot the key folds a per-run nonce: two
+ * runs never share a key, so an unknown out-of-walk input set can never serve
+ * stale output. This is the sound degradation for unwritable cache directories
+ * and for transformer use without `withTtsc`.
+ */
+export async function assertCacheKeyFoldsNonceWithoutReadableSnapshot(): Promise<void> {
+  const root = createBareProject();
+  const first = await cacheKeyForRun(root);
+  const second = await cacheKeyForRun(root);
+  assert.equal(first.length, 64);
+  assert.notEqual(first, second);
+}
+
+/**
+ * Asserts a volatile marker in the snapshot also degrades the key to a per-run
+ * nonce: a plugin-declared volatile output depends on non-file inputs no
+ * fingerprint can represent, so Metro must never replay it across runs.
+ */
+export async function assertCacheKeyFoldsNonceWhileSnapshotVolatile(): Promise<void> {
+  const root = createBareProject();
+  await prepareSnapshot(root);
+  fs.writeFileSync(
+    path.join(snapshotDirectory(root), "graph-inputs.worker-test.json"),
+    JSON.stringify({ files: [], version: 1, volatile: true }),
+    "utf8",
+  );
+  const first = await cacheKeyForRun(root);
+  const second = await cacheKeyForRun(root);
+  assert.notEqual(first, second);
+}
+
+/**
+ * Asserts snapshot compaction: leftover worker files merge into the main
+ * snapshot (files unioned, epoch id preserved — compaction is maintenance, not
+ * an epoch change) and are deleted afterwards.
+ */
+export async function assertPrepareSnapshotCompactsWorkerFiles(): Promise<void> {
+  const root = createBareProject();
+  await prepareSnapshot(root);
+  const identity = readMainSnapshot(root).id;
+  const recorded = path.join(root, "..", "somewhere", "external.d.ts");
+  fs.writeFileSync(
+    path.join(snapshotDirectory(root), "graph-inputs.worker-test.json"),
+    JSON.stringify({ files: [recorded], version: 1, volatile: false }),
+    "utf8",
+  );
+  await prepareSnapshot(root);
+  const main = readMainSnapshot(root);
+  assert.equal(main.id, identity);
+  assert.ok(main.files.includes(recorded));
+  assert.deepEqual(listWorkerSnapshots(root), []);
+}
+
+/**
+ * Asserts the transformer records only out-of-walk inputs into the worker
+ * snapshot: an in-project dependency is already covered by the project-walk
+ * half of the fingerprint, and recording it would only bloat the snapshot.
+ */
+export async function assertTransformerRecordsOnlyExternalInputs(): Promise<void> {
+  const shared = TestProject.tmpdir("ttsc-metro-shared-");
+  const external = path.join(shared, "types.d.ts");
+  fs.writeFileSync(external, "declare const marker: string;\n", "utf8");
+
+  const root = TestUnpluginProject.createProject({ plugins: [] });
+  const inner = path.join(root, "src", "inner.d.ts");
+  fs.writeFileSync(inner, "declare const inner: string;\n", "utf8");
+  await prepareSnapshot(root);
+  await TestMetroRuntime.runTransform({
+    options: {
+      upstreamTransformer: TestMetroRuntime.fakeUpstreamPathOnDisk(),
+      plugins: [
+        {
+          transform: "./plugin.cjs",
+          name: "reporter",
+          operation: "emit-dependencies",
+          dependencies: [
+            "src/inner.d.ts",
+            path.relative(root, external).split(path.sep).join("/"),
+          ],
+        },
+      ],
+    },
+    params: {
+      src: TestUnpluginProject.mainSource(root),
+      filename: "src/main.ts",
+      options: { projectRoot: root },
+    },
+  });
+  assert.deepEqual(workerSnapshotFiles(root), [external]);
+}
+
+/**
+ * Asserts a plugin-declared volatile transform marks this worker's snapshot
+ * volatile, feeding the nonce degradation checked by the volatile key case.
+ */
+export async function assertTransformerRecordsVolatileDeclarations(): Promise<void> {
+  const root = TestUnpluginProject.createProject({ plugins: [] });
+  await prepareSnapshot(root);
+  await TestMetroRuntime.runTransform({
+    options: {
+      upstreamTransformer: TestMetroRuntime.fakeUpstreamPathOnDisk(),
+      plugins: [
+        {
+          transform: "./plugin.cjs",
+          name: "volatile",
+          operation: "emit-volatile",
+          volatile: ["src/main.ts"],
+        },
+      ],
+    },
+    params: {
+      src: TestUnpluginProject.mainSource(root),
+      filename: "src/main.ts",
+      options: { projectRoot: root },
+    },
+  });
+  const workers = listWorkerSnapshots(root);
+  assert.equal(workers.length, 1);
+  const parsed = JSON.parse(fs.readFileSync(workers[0]!, "utf8"));
+  assert.equal(parsed.volatile, true);
+}
+
+/**
+ * Asserts `withTtsc` prepares the snapshot epoch in the config process: the
+ * main snapshot exists with a random id before any worker or `getCacheKey`
+ * call, which is what keeps unchanged projects on a stable key from the second
+ * run onward.
+ */
+export async function assertWithTtscPreparesTheSnapshot(): Promise<void> {
+  const root = createBareProject();
+  const { ENV_KEY } = await TestMetroRuntime.loadOptions();
+  const { withTtsc } = await TestMetroRuntime.loadIndex();
+  const previous = process.env[ENV_KEY];
+  try {
+    const config = withTtsc({ projectRoot: root, transformer: {} });
+    assert.equal(typeof config.transformer.babelTransformerPath, "string");
+  } finally {
+    if (previous === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = previous;
+    }
+  }
+  const main = readMainSnapshot(root);
+  assert.equal(typeof main.id, "string");
+  assert.notEqual(main.id.length, 0);
+  assert.deepEqual(main.files, []);
+}

--- a/tests/test-metro/src/internal/metro-cache.ts
+++ b/tests/test-metro/src/internal/metro-cache.ts
@@ -323,6 +323,21 @@ export async function assertPrepareSnapshotCompactsWorkerFiles(): Promise<void> 
 }
 
 /**
+ * Asserts preparing a snapshot for a nonexistent project root touches nothing:
+ * Metro verifies the root exists before running, so such a base can never be a
+ * working setup, and `withTtsc` must not materialize directory trees at
+ * arbitrary filesystem paths as a side effect.
+ */
+export async function assertPrepareSnapshotSkipsNonexistentRoot(): Promise<void> {
+  const missing = path.join(
+    TestProject.tmpdir("ttsc-metro-missing-"),
+    "does-not-exist",
+  );
+  await prepareSnapshot(missing);
+  assert.equal(fs.existsSync(missing), false);
+}
+
+/**
  * Asserts compaction heals a corrupt worker snapshot: the unparseable file is
  * swept and the epoch id changes, so keys that might have depended on the lost
  * recordings are orphaned while later runs return to a stable key instead of

--- a/tests/test-metro/src/internal/metro-cache.ts
+++ b/tests/test-metro/src/internal/metro-cache.ts
@@ -323,6 +323,30 @@ export async function assertPrepareSnapshotCompactsWorkerFiles(): Promise<void> 
 }
 
 /**
+ * Asserts compaction heals a corrupt worker snapshot: the unparseable file is
+ * swept and the epoch id changes, so keys that might have depended on the lost
+ * recordings are orphaned while later runs return to a stable key instead of
+ * degrading to a nonce forever.
+ */
+export async function assertPrepareSnapshotHealsCorruptWorkerFile(): Promise<void> {
+  const root = createBareProject();
+  await prepareSnapshot(root);
+  const identity = readMainSnapshot(root).id;
+  const corrupt = path.join(
+    snapshotDirectory(root),
+    "graph-inputs.worker-torn.json",
+  );
+  fs.writeFileSync(corrupt, "{ torn", "utf8");
+  // Until compaction, the unreadable recordings force the nonce degradation.
+  assert.notEqual(await cacheKeyForRun(root), await cacheKeyForRun(root));
+  await prepareSnapshot(root);
+  assert.equal(fs.existsSync(corrupt), false);
+  assert.notEqual(readMainSnapshot(root).id, identity);
+  // Healed: runs share a stable key again.
+  assert.equal(await cacheKeyForRun(root), await cacheKeyForRun(root));
+}
+
+/**
  * Asserts the transformer records only out-of-walk inputs into the worker
  * snapshot: an in-project dependency is already covered by the project-walk
  * half of the fingerprint, and recording it would only bloat the snapshot.

--- a/tests/test-metro/src/internal/metro-cjs.ts
+++ b/tests/test-metro/src/internal/metro-cjs.ts
@@ -1,3 +1,4 @@
+import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 
@@ -34,7 +35,12 @@ export async function assertCjsBuildLoadsAndRuns(): Promise<void> {
   try {
     const index = nodeRequire(TestMetroRuntime.libPath("index", "js"));
     assert.equal(typeof index.withTtsc, "function");
-    const config = index.withTtsc({ transformer: {} });
+    // A real temp-dir projectRoot keeps the snapshot preparation out of the
+    // suite's own working directory.
+    const config = index.withTtsc({
+      projectRoot: TestProject.tmpdir("ttsc-metro-cjs-"),
+      transformer: {},
+    });
     assert.match(config.transformer.babelTransformerPath, /transformer\.js$/);
 
     const transformer = nodeRequire(

--- a/tests/test-metro/src/internal/metro-config.ts
+++ b/tests/test-metro/src/internal/metro-config.ts
@@ -1,8 +1,18 @@
+import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 
 import { TestMetroRuntime } from "./metro-runtime";
+
+/**
+ * A real temp-dir `projectRoot` for config passthrough cases: `withTtsc`
+ * prepares the snapshot under the project root (falling back to the working
+ * directory), so a config without one would write into the suite's own tree.
+ */
+function tempProjectRoot(): string {
+  return TestProject.tmpdir("ttsc-metro-config-");
+}
 
 /**
  * Run `body` with `TTSC_METRO_OPTIONS` saved and restored, so config-level env
@@ -30,7 +40,10 @@ async function withCleanEnv(body: () => Promise<void>): Promise<void> {
 export async function assertWithTtscSetsBabelTransformerPath(): Promise<void> {
   await withCleanEnv(async () => {
     const { withTtsc } = await TestMetroRuntime.loadIndex();
-    const config = withTtsc({ transformer: {} });
+    const config = withTtsc({
+      projectRoot: tempProjectRoot(),
+      transformer: {},
+    });
     const target = config.transformer.babelTransformerPath;
     assert.equal(typeof target, "string");
     assert.equal(path.isAbsolute(target), true);
@@ -48,7 +61,7 @@ export async function assertWithTtscPreservesExistingConfig(): Promise<void> {
   await withCleanEnv(async () => {
     const { withTtsc } = await TestMetroRuntime.loadIndex();
     const base = {
-      projectRoot: "/workspace/app",
+      projectRoot: tempProjectRoot(),
       resolver: { sourceExts: ["ts", "tsx"] },
       transformer: {
         minifierPath: "metro-minify-terser",
@@ -81,8 +94,9 @@ export async function assertWithTtscPublishesWorkerEnv(): Promise<void> {
     const { ENV_KEY } = await TestMetroRuntime.loadOptions();
     const { withTtsc } = await TestMetroRuntime.loadIndex();
 
+    const projectRoot = tempProjectRoot();
     withTtsc(
-      { transformer: {} },
+      { projectRoot, transformer: {} },
       { project: "tsconfig.build.json", exclude: ["__tests__"] },
     );
     assert.deepEqual(JSON.parse(process.env[ENV_KEY] as string), {
@@ -91,7 +105,7 @@ export async function assertWithTtscPublishesWorkerEnv(): Promise<void> {
     });
 
     // No options still publishes an explicit (empty) payload, never undefined.
-    withTtsc({ transformer: {} });
+    withTtsc({ projectRoot, transformer: {} });
     assert.equal(process.env[ENV_KEY], "{}");
   });
 }
@@ -104,8 +118,9 @@ export async function assertWithTtscPublishesWorkerEnv(): Promise<void> {
 export async function assertWithTtscAddsTransformerWhenAbsent(): Promise<void> {
   await withCleanEnv(async () => {
     const { withTtsc } = await TestMetroRuntime.loadIndex();
-    const config = withTtsc({ projectRoot: "/workspace/app" });
-    assert.equal(config.projectRoot, "/workspace/app");
+    const projectRoot = tempProjectRoot();
+    const config = withTtsc({ projectRoot });
+    assert.equal(config.projectRoot, projectRoot);
     assert.equal(typeof config.transformer.babelTransformerPath, "string");
     assert.match(config.transformer.babelTransformerPath, /transformer\.js$/);
   });

--- a/tests/test-metro/src/internal/metro-runtime.ts
+++ b/tests/test-metro/src/internal/metro-runtime.ts
@@ -43,6 +43,14 @@ export namespace TestMetroRuntime {
     return import(libUrl("core/upstream"));
   }
 
+  /**
+   * Load the internal fingerprint module (`prepareSnapshot`,
+   * `computeProjectFingerprint`, `readSnapshotState`).
+   */
+  export async function loadFingerprint(): Promise<any> {
+    return import(libUrl("core/fingerprint"));
+  }
+
   // The transformer keeps module-level singletons (resolved options + transform
   // cache), exactly as Metro loads it once per worker. To exercise distinct
   // option sets across cases, each load is cache-busted with a unique query so

--- a/tests/test-metro/src/internal/metro-transform.ts
+++ b/tests/test-metro/src/internal/metro-transform.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 
+import { createBareProject, prepareSnapshot } from "./metro-cache";
 import { TestMetroRuntime } from "./metro-runtime";
 
 const ROOT = "/workspace/app";
@@ -273,21 +274,25 @@ export async function assertGatesByIncludeAndExclude(): Promise<void> {
 
 /**
  * Asserts `getCacheKey` is a stable 64-char hex digest, equal across calls for
- * the same options and different when the options differ.
+ * the same options and different when the options differ. The project carries a
+ * prepared snapshot: key stability is only guaranteed on the `withTtsc` setup
+ * path (without a snapshot the key soundly folds a per-run nonce).
  */
 export async function assertCacheKeyIsDeterministicAndOptionSensitive(): Promise<void> {
+  const root = createBareProject();
+  await prepareSnapshot(root);
   const fake = TestMetroRuntime.fakeUpstreamPathOnDisk();
   const first = await TestMetroRuntime.withTransformerEnv(
     { upstreamTransformer: fake, exclude: ["a"] },
-    (mod) => mod.getCacheKey(),
+    (mod) => mod.getCacheKey({ projectRoot: root }),
   );
   const repeat = await TestMetroRuntime.withTransformerEnv(
     { upstreamTransformer: fake, exclude: ["a"] },
-    (mod) => mod.getCacheKey(),
+    (mod) => mod.getCacheKey({ projectRoot: root }),
   );
   const other = await TestMetroRuntime.withTransformerEnv(
     { upstreamTransformer: fake, exclude: ["b"] },
-    (mod) => mod.getCacheKey(),
+    (mod) => mod.getCacheKey({ projectRoot: root }),
   );
   assert.equal(typeof first, "string");
   assert.equal(first.length, 64);
@@ -297,18 +302,22 @@ export async function assertCacheKeyIsDeterministicAndOptionSensitive(): Promise
 
 /**
  * Asserts `getCacheKey` forwards Metro's arguments to the upstream
- * `getCacheKey` (so a `projectRoot`/babelrc change busts the key) and still
- * produces a valid key when the upstream exposes no `getCacheKey`.
+ * `getCacheKey` (so a babelrc-lookup change busts the key) and still produces a
+ * valid key when the upstream exposes no `getCacheKey`. The two keys share one
+ * snapshot-backed `projectRoot`, so only the upstream's contribution can differ
+ * — the fingerprint ignores `enableBabelRCLookup`.
  */
 export async function assertCacheKeyForwardsAndFoldsUpstreamKey(): Promise<void> {
+  const root = createBareProject();
+  await prepareSnapshot(root);
   const fake = TestMetroRuntime.fakeUpstreamPathOnDisk();
   const keyA = await TestMetroRuntime.withTransformerEnv(
     { upstreamTransformer: fake },
-    (mod) => mod.getCacheKey({ projectRoot: "/a" }),
+    (mod) => mod.getCacheKey({ projectRoot: root, enableBabelRCLookup: true }),
   );
   const keyB = await TestMetroRuntime.withTransformerEnv(
     { upstreamTransformer: fake },
-    (mod) => mod.getCacheKey({ projectRoot: "/b" }),
+    (mod) => mod.getCacheKey({ projectRoot: root, enableBabelRCLookup: false }),
   );
   // Forwarded args reach the upstream getCacheKey → different inputs, different key.
   assert.notEqual(keyA, keyB);
@@ -317,7 +326,7 @@ export async function assertCacheKeyForwardsAndFoldsUpstreamKey(): Promise<void>
   const noKey = TestMetroRuntime.fakeUpstreamWithoutCacheKeyOnDisk();
   const keyC = await TestMetroRuntime.withTransformerEnv(
     { upstreamTransformer: noKey },
-    (mod) => mod.getCacheKey({ projectRoot: "/a" }),
+    (mod) => mod.getCacheKey({ projectRoot: root, enableBabelRCLookup: true }),
   );
   assert.equal(typeof keyC, "string");
   assert.equal(keyC.length, 64);

--- a/tests/test-unplugin/src/features/transform/test_transformttsc_external_validation_ignores_the_generated_tsconfig.ts
+++ b/tests/test-unplugin/src/features/transform/test_transformttsc_external_validation_ignores_the_generated_tsconfig.ts
@@ -1,0 +1,21 @@
+import { assertExternalValidationIgnoresGeneratedTsconfig } from "../../internal/transform-external";
+
+/**
+ * Verifies the disposed temp-dir tsconfig never joins the external validation
+ * universe.
+ *
+ * A `compilerOptions` overlay compiles through a generated tsconfig in the
+ * system temp directory; the host's config chain reports it, and it is deleted
+ * right after the compile. Hashing it at store time would flip to `missing` on
+ * the first revalidation and silently turn every subsequent transform of the
+ * project into a full recompile.
+ *
+ * 1. Transform with an overlay whose fixture graph echoes the generated tsconfig
+ *    into the config chain; capture the cached generation.
+ * 2. Transform again without touching anything.
+ * 3. Assert the cached generation is replayed, not replaced.
+ */
+export const test_transformttsc_external_validation_ignores_the_generated_tsconfig =
+  async () => {
+    await assertExternalValidationIgnoresGeneratedTsconfig();
+  };

--- a/tests/test-unplugin/src/features/transform/test_transformttsc_invalidates_project_cache_through_an_external_graph_edge.ts
+++ b/tests/test-unplugin/src/features/transform/test_transformttsc_invalidates_project_cache_through_an_external_graph_edge.ts
@@ -1,0 +1,21 @@
+import { assertCacheInvalidatesThroughExternalGraphEdge } from "../../internal/transform-external";
+
+/**
+ * Verifies cache invalidation flows through a reference-graph edge to an
+ * out-of-walk file the plugin never reads.
+ *
+ * Type-only inputs (`node_modules` declarations, monorepo sibling sources)
+ * reach the transform through the host-owned graph, not through plugin file
+ * reads, so the external validation must consume the graph channel — not just
+ * the reported dependencies list.
+ *
+ * 1. Transform with a graph edge from `src/main.ts` to a file outside the project
+ *    root; capture the cached generation object.
+ * 2. Edit only that external file.
+ * 3. Transform again with the same cache; assert a new generation replaced the
+ *    cached one.
+ */
+export const test_transformttsc_invalidates_project_cache_through_an_external_graph_edge =
+  async () => {
+    await assertCacheInvalidatesThroughExternalGraphEdge();
+  };

--- a/tests/test-unplugin/src/features/transform/test_transformttsc_invalidates_project_cache_when_a_node_modules_declaration_changes.ts
+++ b/tests/test-unplugin/src/features/transform/test_transformttsc_invalidates_project_cache_when_a_node_modules_declaration_changes.ts
@@ -1,0 +1,21 @@
+import { assertCacheInvalidatesOnNodeModulesDeclarationChange } from "../../internal/transform-external";
+
+/**
+ * Verifies the project cache invalidates when an in-root `node_modules`
+ * declaration named by the reference graph changes.
+ *
+ * The everyday member of the out-of-walk class: the file sits under the project
+ * root, but the walk skips `node_modules` segments, so only the external
+ * validation can see it. Without it a persistent-cache host serves generated
+ * code computed against a dependency's stale type declarations.
+ *
+ * 1. Transform with a graph edge from `src/main.ts` to an in-root `node_modules`
+ *    declaration; capture the cached generation.
+ * 2. Edit only that declaration.
+ * 3. Transform again with the same cache; assert a new generation replaced the
+ *    cached one.
+ */
+export const test_transformttsc_invalidates_project_cache_when_a_node_modules_declaration_changes =
+  async () => {
+    await assertCacheInvalidatesOnNodeModulesDeclarationChange();
+  };

--- a/tests/test-unplugin/src/features/transform/test_transformttsc_invalidates_project_cache_when_an_external_input_changes.ts
+++ b/tests/test-unplugin/src/features/transform/test_transformttsc_invalidates_project_cache_when_an_external_input_changes.ts
@@ -1,0 +1,22 @@
+import { assertCacheInvalidatesOnExternalInputChange } from "../../internal/transform-external";
+
+/**
+ * Verifies the project cache invalidates when a reported out-of-walk input
+ * changes.
+ *
+ * The walk snapshot cannot see files outside the project root, so before
+ * samchon/ttsc#721 a host that never clears its cache between builds (Metro
+ * workers, the Turbopack loader, Bun) replayed the stale generation for its
+ * whole process lifetime after such an edit. `externalInputHashes` re-hashes
+ * the reported set on every validation.
+ *
+ * 1. Transform a file whose plugin reads and reports a helper outside the project
+ *    root ("first") through one shared cache.
+ * 2. Edit only the external helper to "second" — no in-project change.
+ * 3. Transform again with the same cache; assert the output carries
+ *    `PLUGIN:SECOND`.
+ */
+export const test_transformttsc_invalidates_project_cache_when_an_external_input_changes =
+  async () => {
+    await assertCacheInvalidatesOnExternalInputChange();
+  };

--- a/tests/test-unplugin/src/features/transform/test_transformttsc_replays_the_project_cache_when_external_inputs_are_unchanged.ts
+++ b/tests/test-unplugin/src/features/transform/test_transformttsc_replays_the_project_cache_when_external_inputs_are_unchanged.ts
@@ -1,0 +1,19 @@
+import { assertCacheReplaysWhenExternalInputsUnchanged } from "../../internal/transform-external";
+
+/**
+ * Verifies the project cache still replays when external inputs are unchanged.
+ *
+ * The negative twin of the external-input invalidation case: re-hashing the
+ * recorded out-of-walk set on every validation must not evict entries whose
+ * inputs did not change, or the cache would degrade into a per-call recompile.
+ *
+ * 1. Transform a file with a reported external input through one shared cache;
+ *    capture the cached generation object.
+ * 2. Transform again without touching anything.
+ * 3. Assert the same generation object is still cached and the output is
+ *    byte-identical.
+ */
+export const test_transformttsc_replays_the_project_cache_when_external_inputs_are_unchanged =
+  async () => {
+    await assertCacheReplaysWhenExternalInputsUnchanged();
+  };

--- a/tests/test-unplugin/src/internal/transform-external.ts
+++ b/tests/test-unplugin/src/internal/transform-external.ts
@@ -1,0 +1,226 @@
+import {
+  TestProject,
+  TestUnpluginProject,
+  TestUnpluginRuntime,
+} from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { emitGraphPlugins } from "./transform-graph";
+
+/**
+ * Scenarios for the out-of-walk cache validation
+ * (`TtscCachedProjectTransform.externalInputHashes`, samchon/ttsc#721).
+ *
+ * The project-walk snapshot cannot see inputs outside the project root or under
+ * ignored directories, yet the reference graph and the plugin-reported
+ * dependencies prove they feed the transform. Hosts without a per-build cache
+ * boundary (Metro workers, the Turbopack loader, Bun) keep one cache for the
+ * process lifetime, so validation itself must re-hash those inputs.
+ */
+
+/** Create a project plus a transform input file outside its root. */
+function createProjectWithExternalInput(content: string): {
+  external: string;
+  relative: string;
+  root: string;
+} {
+  const shared = TestProject.tmpdir("ttsc-unplugin-external-");
+  const external = path.join(shared, "helper.ts");
+  fs.writeFileSync(external, content, "utf8");
+  const root = TestUnpluginProject.createProject({ plugins: [] });
+  return {
+    external,
+    relative: path.relative(root, external).split(path.sep).join("/"),
+    root,
+  };
+}
+
+/** The single cached generation object, for cache-identity assertions. */
+function cacheEntry(cache: Map<string, unknown>): unknown {
+  assert.equal(cache.size, 1);
+  return [...cache.values()][0];
+}
+
+/**
+ * Asserts a persistent cache invalidates when a reported out-of-walk input
+ * changes: the plugin reads a file outside the project root and reports it as a
+ * dependency; editing only that file must produce regenerated output from the
+ * same cache instance (no `buildStart` clear in between).
+ */
+export async function assertCacheInvalidatesOnExternalInputChange(): Promise<void> {
+  const { resolveOptions, transformTtsc, createTtscTransformCache } =
+    await TestUnpluginRuntime.loadUnpluginApi();
+  const { external, relative, root } =
+    createProjectWithExternalInput("first\n");
+  const options = resolveOptions({
+    plugins: [
+      {
+        transform: "./plugin.cjs",
+        name: "reader",
+        operation: "read-configured-helper",
+        path: relative,
+      },
+      {
+        transform: "./plugin.cjs",
+        name: "reporter",
+        operation: "emit-dependencies",
+        dependencies: [relative],
+      },
+    ],
+  });
+  const cache = createTtscTransformCache();
+
+  const before = await transformTtsc(
+    TestUnpluginProject.mainFile(root),
+    TestUnpluginProject.mainSource(root),
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(before);
+  assert.match(before.code, /PLUGIN:FIRST/);
+
+  fs.writeFileSync(external, "second\n", "utf8");
+  const after = await transformTtsc(
+    TestUnpluginProject.mainFile(root),
+    TestUnpluginProject.mainSource(root),
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(after);
+  assert.match(after.code, /PLUGIN:SECOND/);
+}
+
+/**
+ * Asserts the negative twin: with the external input untouched, the second
+ * transform replays the cached generation (same promise identity) instead of
+ * recompiling — the external re-hash must not turn the cache into a per-call
+ * recompile.
+ */
+export async function assertCacheReplaysWhenExternalInputsUnchanged(): Promise<void> {
+  const { resolveOptions, transformTtsc, createTtscTransformCache } =
+    await TestUnpluginRuntime.loadUnpluginApi();
+  const { relative, root } = createProjectWithExternalInput("first\n");
+  const options = resolveOptions({
+    plugins: [
+      {
+        transform: "./plugin.cjs",
+        name: "reader",
+        operation: "read-configured-helper",
+        path: relative,
+      },
+      {
+        transform: "./plugin.cjs",
+        name: "reporter",
+        operation: "emit-dependencies",
+        dependencies: [relative],
+      },
+    ],
+  });
+  const cache = createTtscTransformCache();
+
+  const before = await transformTtsc(
+    TestUnpluginProject.mainFile(root),
+    TestUnpluginProject.mainSource(root),
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(before);
+  const generation = cacheEntry(cache);
+
+  const after = await transformTtsc(
+    TestUnpluginProject.mainFile(root),
+    TestUnpluginProject.mainSource(root),
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(after);
+  assert.equal(after.code, before.code);
+  assert.strictEqual(cacheEntry(cache), generation);
+}
+
+/**
+ * Asserts invalidation flows through a reference-graph edge alone: the plugin
+ * never reads the external file, only the host graph names it, so a content
+ * edit is observable purely as a replaced cache generation.
+ */
+export async function assertCacheInvalidatesThroughExternalGraphEdge(): Promise<void> {
+  const { resolveOptions, transformTtsc, createTtscTransformCache } =
+    await TestUnpluginRuntime.loadUnpluginApi();
+  const shared = TestProject.tmpdir("ttsc-unplugin-external-");
+  const external = path.join(shared, "types.d.ts");
+  fs.writeFileSync(external, "declare const first: string;\n", "utf8");
+  const root = TestUnpluginProject.createProject({ plugins: [] });
+  const relative = path.relative(root, external).split(path.sep).join("/");
+  const options = resolveOptions({
+    plugins: emitGraphPlugins({ edges: { "src/main.ts": [relative] } }),
+  });
+  const cache = createTtscTransformCache();
+
+  const before = await transformTtsc(
+    TestUnpluginProject.mainFile(root),
+    TestUnpluginProject.mainSource(root),
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(before);
+  const generation = cacheEntry(cache);
+
+  fs.writeFileSync(external, "declare const second: string;\n", "utf8");
+  const after = await transformTtsc(
+    TestUnpluginProject.mainFile(root),
+    TestUnpluginProject.mainSource(root),
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(after);
+  assert.notStrictEqual(cacheEntry(cache), generation);
+}
+
+/**
+ * Asserts the disposed temp-dir tsconfig never joins the external validation
+ * universe. A `compilerOptions` overlay compiles through a generated tsconfig
+ * that the host's config chain reports and that is deleted right after the
+ * compile; hashing it would flip to `missing` on the first revalidation and
+ * turn every subsequent transform into a recompile.
+ */
+export async function assertExternalValidationIgnoresGeneratedTsconfig(): Promise<void> {
+  const { resolveOptions, transformTtsc, createTtscTransformCache } =
+    await TestUnpluginRuntime.loadUnpluginApi();
+  const root = TestUnpluginProject.createProject({ plugins: [] });
+  const options = resolveOptions({
+    compilerOptions: { removeComments: true },
+    plugins: emitGraphPlugins({
+      echoTsconfig: true,
+      edges: { "src/main.ts": ["src/types.d.ts"] },
+    }),
+  });
+  const cache = createTtscTransformCache();
+
+  const before = await transformTtsc(
+    TestUnpluginProject.mainFile(root),
+    TestUnpluginProject.mainSource(root),
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(before);
+  const generation = cacheEntry(cache);
+
+  const after = await transformTtsc(
+    TestUnpluginProject.mainFile(root),
+    TestUnpluginProject.mainSource(root),
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(after);
+  assert.strictEqual(cacheEntry(cache), generation);
+}

--- a/tests/test-unplugin/src/internal/transform-external.ts
+++ b/tests/test-unplugin/src/internal/transform-external.ts
@@ -185,6 +185,53 @@ export async function assertCacheInvalidatesThroughExternalGraphEdge(): Promise<
 }
 
 /**
+ * Asserts invalidation covers the in-root ignored-directory class: a
+ * `node_modules` declaration lives under the project root yet the walk skips
+ * the segment, so only the external validation can see it — the everyday shape
+ * of a dependency's hand-edited or reinstalled type declarations.
+ */
+export async function assertCacheInvalidatesOnNodeModulesDeclarationChange(): Promise<void> {
+  const { resolveOptions, transformTtsc, createTtscTransformCache } =
+    await TestUnpluginRuntime.loadUnpluginApi();
+  const root = TestUnpluginProject.createProject({ plugins: [] });
+  const declaration = path.join(
+    root,
+    "node_modules",
+    "fixture-types",
+    "types.d.ts",
+  );
+  fs.mkdirSync(path.dirname(declaration), { recursive: true });
+  fs.writeFileSync(declaration, "declare const first: string;\n", "utf8");
+  const options = resolveOptions({
+    plugins: emitGraphPlugins({
+      edges: { "src/main.ts": ["node_modules/fixture-types/types.d.ts"] },
+    }),
+  });
+  const cache = createTtscTransformCache();
+
+  const before = await transformTtsc(
+    TestUnpluginProject.mainFile(root),
+    TestUnpluginProject.mainSource(root),
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(before);
+  const generation = cacheEntry(cache);
+
+  fs.writeFileSync(declaration, "declare const second: string;\n", "utf8");
+  const after = await transformTtsc(
+    TestUnpluginProject.mainFile(root),
+    TestUnpluginProject.mainSource(root),
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(after);
+  assert.notStrictEqual(cacheEntry(cache), generation);
+}
+
+/**
  * Asserts the disposed temp-dir tsconfig never joins the external validation
  * universe. A `compilerOptions` overlay compiles through a generated tsconfig
  * that the host's config chain reports and that is deleted right after the

--- a/website/src/content/docs/setup/metro.mdx
+++ b/website/src/content/docs/setup/metro.mdx
@@ -75,8 +75,16 @@ module.exports = withTtsc(getDefaultConfig(__dirname), {
 
 Options travel from the Metro config process to its worker processes through an environment variable, so they must stay JSON-serialisable: substring patterns, not `RegExp`.
 
+## Cache invalidation
+
+Metro keys its transform cache on each file's own content plus one static transformer key evaluated once per run, and its babel-transformer contract offers no per-file dependency registration. A `ttsc` transform can depend on a type declared in another file, so `@ttsc/metro` folds a project fingerprint into the static key: every input file under the project root, plus the [reference-graph](/docs/development/reference/driver-api#reference-graph) inputs outside it (`node_modules` declarations, monorepo sibling sources, out-of-root tsconfig `extends` ancestry), which the transformer records under `node_modules/.cache/ttsc-metro` as it runs. Editing any fingerprinted input re-keys the next run, so `metro bundle` and dev-server starts pick up cross-file type changes, `tsconfig` edits, and plugin configuration changes without `--reset-cache`.
+
+The granularity is project-level because Metro's contract admits nothing finer: one key per run means any fingerprinted change re-transforms every file on the next run. Two behaviors sit outside the mechanism's reach:
+
+- **Within a running dev server**, Metro re-transforms only files its watcher reports changed, so editing a type in file B refreshes a dependent file A on A's next transform. Save A, or restart the dev server; no `--reset-cache` is needed in either case.
+- **Files a plugin declares [`volatile`](/docs/development/concepts/protocol#transform)** depend on non-file inputs no fingerprint can represent; while a volatile declaration is recorded, cross-run cache reuse is disabled entirely. The same sound fallback applies when `node_modules/.cache` is unwritable.
+
 ## Caveats (v1)
 
 - **Cost model.** The transform core type-checks the whole project and caches the result per process. Metro runs a multi-process worker pool, so the project compiles once per worker, on that worker's first file. A resident incremental compiler shared across workers is the planned fix, tracked in [#255](https://github.com/samchon/ttsc/issues/255).
-- **Cache invalidation.** Metro keys its transform cache on per-file content, but a `ttsc` transform can depend on a type in another file. Editing that type does not change the dependent file's content, so Metro may serve a stale transform. After changing `tsconfig`, plugin configuration, or a depended-upon type, restart with `--reset-cache`.
 - **Type errors fail the build.** The pass type-checks, and a project type error surfaces as a Metro build error, matching every other `ttsc` integration.

--- a/website/src/content/docs/setup/unplugin.mdx
+++ b/website/src/content/docs/setup/unplugin.mdx
@@ -197,6 +197,8 @@ Bundlers invalidate a module only when its registered inputs change, and they er
 
 This works for every adapter automatically when the transform host emits the envelope's `graph` section — the built-in host and linked plugins always do; executable sidecar plugins adopt through the [driver SDK](/docs/development/reference/driver-api#reference-graph). Plugins whose output additionally depends on non-file inputs declare those files [`volatile`](/docs/development/concepts/protocol#transform), which excludes them from caching entirely.
 
+The transform cache validates against the same input set: every file under the project root plus the graph-reported inputs outside it. Hosts that keep one cache for the process lifetime instead of per build (Metro workers, the Turbopack loader, Bun) therefore recompile when an out-of-project input such as a `node_modules` declaration or a monorepo sibling source changes, not only on in-project edits.
+
 ## CLI or bundler?
 
 Whichever tool owns the build runs the pass. A plain Node library builds with `npx ttsc`. A frontend behind Vite or webpack builds through `@ttsc/unplugin`. A monorepo with both uses both, one per package. The plugin pass is identical everywhere, and diagnostics show up wherever the bundler surfaces them.


### PR DESCRIPTION
Implements samchon/ttsc#721: sound cache invalidation for `@ttsc/metro`, derived from the host-owned reference graph (#718 primitives).

## Intent

`@ttsc/metro` v1 (#255) shipped with a documented `--reset-cache` caveat: Metro keys its transform cache on per-file content plus a static transformer key, so editing only a depended-upon type in another file leaves the dependent file's cache entry valid and Metro serves a stale transform. This PR makes Metro's cache key incorporate every input that can influence a transform's output, replacing the manual `--reset-cache` step for cross-run staleness, and closes the matching in-session gap in the shared transform core.

## Investigation record (mandated by the issue, verified against Metro 0.87 source)

**1. Metro's cache-key semantics and cache layers.**

- `getCacheKey` is called once per Metro instantiation (dev-server start or cold `metro bundle` run), on the main process, synchronously: `Server` -> `Bundler` -> `Transformer` constructor -> `getTransformCacheKey` (`metro/src/DeltaBundler/getTransformCacheKey.js`) -> `require(transformerPath).getCacheKey(transformerConfig, { projectRoot })`. For the default `transformerPath` (`metro-transform-worker`), its `getCacheKey` folds in `require(babelTransformerPath).getCacheKey({ projectRoot, enableBabelRCLookup })` — that is the `@ttsc/metro` hook. It is never re-called per file, per worker, or per rebuild within a session; `metro-babel-transformer`'s own docs state "called once by the main thread (not on worker instances)".
- The result becomes `Transformer._baseHash`; each file's cache key is `stableHash([baseHash, posix-relative path, transform options...]) + sha1(file content)` (`Transformer.transformFile`).
- Cache layers: the per-file key is looked up in `config.cacheStores` — default a single persistent `FileStore` at `os.tmpdir()/metro-cache`, shared across runs. Within a dev-server session, transformed modules additionally live in the in-memory DeltaBundler graph. `--reset-cache` clears the stores at `Server` construction. `unstable_autoSaveCache` persists only the file map (`metro-file-map`), not transform outputs, so a restart re-evaluates `getCacheKey` and re-keys every lookup.

**2. Resident-compiler freshness within a session.**

The per-worker "resident compiler" in `@ttsc/metro` is the module-level `createTtscTransformCache()` singleton. Its entries are revalidated on every transform call by re-hashing every file under the project root (`matchesCachedSource`), and a miss constructs a fresh `TtscCompiler` and recompiles — there is no long-lived stale program for in-project inputs. The verified residual gap: inputs outside the project-root walk (files outside the project root, or under walk-ignored directories such as `node_modules`) were not in the validation universe, so a worker could serve a project transform computed against a stale out-of-walk input for its whole lifetime. Web bundlers never hit this because the unplugin factory clears the cache on every `buildStart`; Metro (and the Turbopack loader, and Bun) hold the cache for the process lifetime. This PR closes that gap in the shared core (see below).

**3. Per-file dependency registration in Metro.**

None exists, including unstable APIs, as of metro 0.87 / metro-transform-worker 0.87 / metro-babel-transformer 0.87. The `BabelTransformer` contract is exactly `{ transform, getCacheKey? }`; the transform result (`{ ast, functionMap?, metadata? }`) has no dependency channel; the worker-level `dependencies` output is import extraction for module-graph resolution (adding entries would add modules to the bundle). The DeltaBundler re-transforms only watcher-reported changed files (`DeltaCalculator`), so no cache key can force a re-transform of an unchanged dependent file within a running session. The project-level fingerprint is therefore the sound encoding Metro's contract admits, exactly as the issue anticipated.

## Mechanism

**Cross-run soundness — a project fingerprint folded into `getCacheKey`** (`packages/metro`):

- `getCacheKey` now folds a fingerprint with two parts:
  1. a hash of every input file under the fingerprint roots (Metro's `projectRoot` from the cache-key options, plus the resolved tsconfig's directory when it lies outside), using the same directory-walk semantics as the transform core's own cache validation; and
  2. a re-hash, at key time, of every recorded out-of-walk reference-graph member (node_modules declarations, monorepo sibling sources, out-of-root tsconfig `extends` ancestry) from the snapshot the transformer maintains.
- The snapshot lives at `<projectRoot>/node_modules/.cache/ttsc-metro/`. Each worker owns a uniquely named snapshot file (no write races); `withTtsc`, which runs in the single config process before workers exist, compacts them into the main snapshot. Snapshot identity carries a random id preserved across merges, so a deleted-and-recreated snapshot can never alias an older key epoch. When no snapshot is readable at key time, a random nonce is folded instead: that run shares no cache with any other run, which is the sound degradation.
- The out-of-walk members are derived from the existing `addWatchFile` hook plumbing (#718): plugin-reported `dependencies` unioned with the reference graph's reach, globals, and configs.

**In-session soundness — out-of-walk revalidation in the shared core** (`packages/unplugin`):

- `TtscCachedProjectTransform` now records the hash of every out-of-walk reference-graph member at transform time, and cache validation re-hashes them alongside the project walk. A worker that lives across edits to `node_modules` declarations or monorepo sibling sources now recompiles instead of replaying the stale project transform. This also hardens the Turbopack loader and Bun runtime paths, which share the process-lifetime cache model.

**Soundness boundary (documented in the metro guide, README, and code):**

- Any change to a fingerprinted input invalidates every transformed file (project-level granularity — forced by Metro's single static key, not chosen).
- Within a running dev-server session, Metro re-transforms only files the watcher reports changed; editing only a type dependency updates the dependent file on the next transform of that file (save it, or restart the dev server — no `--reset-cache` needed). This is Metro's DeltaBundler contract; no transformer-side mechanism can reach it.
- If the snapshot cache directory is unwritable, cross-run caching is disabled (nonce) rather than made unsound.

## Verification

- Two-run reproduction (issue acceptance): new `tests/test-metro/src/features/cache` scenarios simulate Metro's exact key flow — `getCacheKey` once per run, per-file content key — and assert that editing only a type-dependency file changes the key between runs (regenerated output), that an unchanged project keeps the key stable (cache reuse preserved), and both the in-project and out-of-walk edit directions.
- `tests/test-unplugin` gains scenarios pinning the new out-of-walk revalidation (stale before, fresh after; stability twin included).
- Full `tests/test-metro` and `tests/test-unplugin` suites locally; broader suites per the repository's canonical commands. Exact commands and results recorded on this thread as they complete.

## Coordination

- Closes #721. Builds on #718 (`driver.NewTransformGraph` envelope `graph`) and #255 (v1 open question 1). Independent of #720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3kDYEkHutvSMcHPBXhd7P
