### PR TITLE
ci(release): reclaim runner disk before cross-compiling every platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,30 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # `pnpm run build` cross-compiles every platform package in one job: seven
+      # GOOS/GOARCH pairs, each producing a tsgo-sized ttsc and ttscserver, each
+      # filling its own Go build cache. v0.19.2 died on the seventh of them with
+      # "no space left on device" while linking ttscserver.exe for win32-x64 —
+      # after the tag was pushed and before anything published, which is the
+      # worst place to run out of anything.
+      #
+      # The runner ships ~25 GB of toolchains this build never uses. Reclaiming
+      # them is cheaper and less fragile than teaching the build to prune its own
+      # cache mid-flight, which would trade disk for a slower link on every
+      # platform. `df` on both sides so the next person to hit this can see the
+      # headroom in the log instead of inferring it from a crash.
+      - name: Free runner disk space
+        run: |
+          df -h /
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/local/.ghcup \
+            /opt/ghc \
+            /usr/share/dotnet \
+            /usr/share/swift
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          df -h /
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Intent

The `v0.19.2` release never published. The tag pushed, `release` ran, and **Build all packages** failed:

```
compile: writing output: write $WORK/b070/_pkg_.a: no space left on device
```

([run 29520304099](https://github.com/samchon/ttsc/actions/runs/29520304099), failed linking `ttscserver.exe` for `win32-x64`.)

Nothing published — the failure is upstream of every publish step, and npm still has `ttsc@0.19.1` / `@ttsc/graph@0.19.1` with `latest` = `0.19.1`. So the registry is clean and `0.19.2` is still free.

## Why it happened

`pnpm run build` (`scripts/build-platforms.cjs`) cross-compiles **seven** platform packages in a single job, each producing a tsgo-sized `ttsc` and `ttscserver`, each filling its own `GOOS/GOARCH` Go build cache. The failure landed on the seventh — consistent with accumulation rather than any one binary being too large.

`v0.19.1` succeeded eleven hours earlier, so this is a threshold the repository has just crossed, not a new fault. **It will reproduce on the next tag.** Deleting and re-pushing the tag — the obvious first instinct — changes nothing about the disk.

## The fix

Reclaim the ~25 GB of preinstalled toolchains this build never uses (Android SDK, CodeQL, GHC/ghcup, dotnet, Swift) plus the prewarmed Docker images, before checkout.

Considered and rejected: pruning the Go build cache between platforms. It would trade disk for a cold link on every subsequent platform, slowing a release that already takes ~30 minutes, and it would put the workaround inside the build script where it would also affect local builds that have no such problem.

`df -h /` runs on both sides so the next person to hit this reads the headroom out of the log instead of inferring it from a crash.

## Scope

`release.yml` only. It is the sole workflow that builds all seven platforms, and the only one with a reproduced disk failure. `nestia.yml` and `typia.yml` set `TTSC_TARBALLS_CURRENT` and pack the current platform only; both are green on current branches, so there is no evidence to act on there and nothing speculative is being changed.

## Verification

- The workflow is not exercised by pull-request CI — it triggers on tag push only, so this change is proven by the next release rather than by this PR. Stated plainly rather than implied.
- YAML parses; the new step is the first step of the `publish` job, before `actions/checkout`, so it cannot touch the working tree.
- Every removed path is a GitHub-hosted-runner preinstall that no step here consumes: the job installs its own Node (`setup-node`), Go (`setup-go`), and pnpm.
- `docker image prune` is `|| true` — the runner having no images is not a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XsPmVseWirNXRSm6HgGAj
