### PR TITLE
fix(graph): resolve details.literals from the checker's type

### DIFF
--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -22,6 +22,9 @@
     "@typia/mcp": "catalog:samchon",
     "typia": "catalog:samchon"
   },
+  "peerDependencies": {
+    "ttsc": "workspace:*"
+  },
   "keywords": [
     "ttsc",
     "mcp",

--- a/packages/graph/src/model/TtscGraphSession.ts
+++ b/packages/graph/src/model/TtscGraphSession.ts
@@ -5,6 +5,7 @@ import typia from "typia";
 import { ensureExecutable } from "../nativeExecutable";
 import { resolveGraphBinary } from "../resolveGraphBinary";
 import { ITtscGraphSnapshot } from "../structures/ITtscGraphSnapshot";
+import { DUMP_SCHEMA_VERSION } from "./loadGraph";
 import { TtscGraphMemory } from "./TtscGraphMemory";
 
 /**
@@ -226,6 +227,32 @@ export class TtscGraphSession {
       );
       return;
     }
+    // The envelope's version is not the body's, and only the envelope has been
+    // held to one so far. A producer can speak this protocol and still carry a
+    // dump from another schema — the two move apart the moment a node field is
+    // added without the frame around it changing — and then the facts that field
+    // holds are silently absent rather than refused. `literals` is exactly that
+    // shape: an older producer resolves no value set, so a union comes back
+    // looking like a type with no members. Hold the body to its own number too,
+    // once the frame is understood.
+    if (
+      response.dump !== undefined &&
+      response.dump.provenance.schemaVersion !== DUMP_SCHEMA_VERSION
+    ) {
+      // Session-wide, for the same reason the protocol mismatch above is: it is
+      // the wrong binary, not one bad frame.
+      this.failPending(
+        new Error(
+          `@ttsc/graph: ttscgraph sends dump schema v${String(
+            response.dump.provenance.schemaVersion,
+          )}, this client reads v${String(DUMP_SCHEMA_VERSION)}. ` +
+            "Install a matching `ttsc` (the binary resolves from the target " +
+            "project, or from TTSC_GRAPH_BINARY).",
+        ),
+      );
+      return;
+    }
+
     const pending = this.pending.get(response.id);
     if (pending === undefined) return;
     this.pending.delete(response.id);

--- a/packages/graph/src/model/loadGraph.ts
+++ b/packages/graph/src/model/loadGraph.ts
@@ -18,8 +18,13 @@ const MAX_DUMP_BYTES = 1024 * 1024 * 1024;
  * `packages/ttsc/internal/graph/provenance.go`. The two are hand-synchronized,
  * and `dump_schema_version_matches_the_typescript_client_test.go` reads this
  * constant out of this file and fails if the pair drifts.
+ *
+ * Exported because the resident session reads the same dump body over the serve
+ * protocol and has to hold it to the same number: the envelope's version and the
+ * body's are independent, so a producer can speak this protocol and still send a
+ * body from another schema.
  */
-const DUMP_SCHEMA_VERSION = 1;
+export const DUMP_SCHEMA_VERSION = 2;
 
 /**
  * Build the resident {@link TtscGraphMemory} for a project by running `ttscgraph

--- a/packages/graph/src/resolveGraphBinary.ts
+++ b/packages/graph/src/resolveGraphBinary.ts
@@ -5,9 +5,15 @@ import path from "node:path";
  * Resolve the per-platform `ttscgraph` binary, or `null` when it cannot be
  * located.
  *
- * `ttsc` is a peer the user installs alongside `@ttsc/graph` (not a dependency
- * of this launcher), so resolution starts from the user's project, not from
- * this package's own tree.
+ * `ttsc` is a peer dependency pinned to this package's own version, installed
+ * alongside `@ttsc/graph` in the user's project rather than nested under this
+ * launcher, so resolution starts from the user's project, not from this
+ * package's own tree.
+ *
+ * The pin is what keeps the two halves of the graph in step. `literals` and the
+ * rest of the node facts are resolved by the Go builder and ride the dump, so a
+ * newer `@ttsc/graph` reading an older `ttscgraph` would find those fields
+ * simply absent and answer from a graph missing facts it believes are there.
  *
  * Resolution order:
  *

--- a/packages/graph/src/server/runDetails.ts
+++ b/packages/graph/src/server/runDetails.ts
@@ -13,6 +13,11 @@ import { IRunnerOutput, resultNext } from "./resultNext";
 
 // A signature is the declaration head up to the body brace: a handful of lines.
 const MAX_SIGNATURE_LINES = 4;
+// A value set is the answer to "what may this be", so it is listed rather than
+// sampled: the cap is high enough that a real union or enum arrives whole, and
+// exists only so a type expanded from a template literal cannot flood a
+// response. Past it, literalsTruncated says so and the declaration has the rest.
+const MAX_LITERALS = 60;
 // A doc summary is one sentence; the rest of the comment is the file's to keep.
 const MAX_DOC_CHARS = 200;
 // Neighbor lists are a map, not a dump; keep them scannable.
@@ -101,7 +106,6 @@ export function runDetails(
     if (sig !== undefined) detail.signature = sig;
     const doc = docOf(graph.project, node);
     if (doc !== undefined) detail.doc = doc;
-    const signatureLiterals = literalSummaries(sig);
     const decorators = decoratorsOf(node);
     if (decorators !== undefined) detail.decorators = decorators;
     const implementation = evidenceCoordinatesOf(node.implementation);
@@ -150,8 +154,11 @@ export function runDetails(
       );
       if (list.length > 0) detail.members = list;
     }
-    if (signatureLiterals.length > 0)
-      detail.literals = signatureLiterals.slice(0, 6);
+    const literals = node.literals ?? [];
+    if (literals.length > 0) {
+      detail.literals = literals.slice(0, MAX_LITERALS);
+      if (literals.length > MAX_LITERALS) detail.literalsTruncated = true;
+    }
     if (wantNeighbors) {
       detail.dependsOn = refs(
         graph,
@@ -427,30 +434,6 @@ function incomingDependencyRefs(
     if (out.length >= limit) break;
   }
   return out;
-}
-
-function literalSummaries(text: string | undefined): string[] {
-  if (text === undefined) return [];
-  const out: string[] = [];
-  for (const match of text.matchAll(/(["'`])((?:\\.|(?!\1).){1,80})\1/g)) {
-    const value = cleanLiteral(match[2]);
-    if (value !== undefined && !out.includes(value)) out.push(value);
-    if (out.length >= 20) break;
-  }
-  return out;
-}
-
-function cleanLiteral(value: string | undefined): string | undefined {
-  const text = value?.replace(/\s+/g, " ").trim();
-  if (
-    text === undefined ||
-    text === "" ||
-    text.length > 40 ||
-    /^[{}()[\],.:;]+$/.test(text)
-  ) {
-    return undefined;
-  }
-  return text;
 }
 
 function bound(

--- a/packages/graph/src/structures/ITtscGraphDetails.ts
+++ b/packages/graph/src/structures/ITtscGraphDetails.ts
@@ -145,8 +145,26 @@ export namespace ITtscGraphDetails {
     /** Concrete nodes that implement or override this interface/base member. */
     implementedBy?: IReference[];
 
-    /** String literal values from the signature. */
+    /**
+     * The values a type alias or enum admits, in TypeScript source form (`"a"`,
+     * `1`, `true`, `null`) — the checker's resolved union members, not the
+     * quoted tokens that happened to fit in `signature`.
+     *
+     * Complete unless `literalsTruncated` says otherwise, and absent when the
+     * type has no enumerable value set. A `signature` is capped at the
+     * declaration head, so for a union or enum written across several lines
+     * this is the field that carries the members.
+     */
     literals?: string[];
+
+    /**
+     * True when `literals` was cut to the response cap; the values listed
+     * stand, but they are a prefix of the set rather than all of it.
+     *
+     * `literals` claims to be the whole type, so the one case where it is not
+     * has to say so. Read the declaration for the rest.
+     */
+    literalsTruncated?: boolean;
 
     /**
      * Owned symbol or top-level property outline a consumer reaches for on a

--- a/packages/graph/src/structures/ITtscGraphDetails.ts
+++ b/packages/graph/src/structures/ITtscGraphDetails.ts
@@ -66,7 +66,7 @@ export namespace ITtscGraphDetails {
     /**
      * Maximum direct execution and type references per group.
      *
-     * @default 1
+     * @default 2
      */
     dependencyLimit?: number;
 

--- a/packages/graph/src/structures/ITtscGraphNode.ts
+++ b/packages/graph/src/structures/ITtscGraphNode.ts
@@ -64,6 +64,19 @@ export interface ITtscGraphNode {
   modifiers?: TtscGraphNodeModifier[];
 
   /**
+   * The complete value set of a type alias or enum whose declared type the
+   * checker resolved to literals, each in TypeScript source form (`"a"`, `1`,
+   * `true`, `null`).
+   *
+   * Present only when every constituent is enumerable, so the list is the whole
+   * type and never a sample of it: `type T = Kind | string` admits values no
+   * list can name and carries none. It is resolved from the type, not read off
+   * the declaration, so indirection (`type I = Kind | 'f'`) is followed and the
+   * answer does not depend on how the declaration is wrapped.
+   */
+  literals?: string[];
+
+  /**
    * Decorators written on this declaration, in source order: raw facts
    * (`@Controller`, `@Get`) a consumer interprets without re-parsing source.
    */

--- a/packages/graph/src/structures/ITtscGraphTour.ts
+++ b/packages/graph/src/structures/ITtscGraphTour.ts
@@ -66,7 +66,7 @@ export namespace ITtscGraphTour {
      * Central entrypoints to seed the tour. Raise only when the question names
      * several public paths that must all appear in one answer.
      *
-     * @default 4
+     * @default 5
      */
     limit?: number;
 

--- a/packages/ttsc/internal/graph/dump.go
+++ b/packages/ttsc/internal/graph/dump.go
@@ -69,6 +69,7 @@ type DumpNode struct {
   Exported       bool            `json:"exported,omitempty"`
   Closure        bool            `json:"closure,omitempty"`
   Modifiers      []string        `json:"modifiers,omitempty"`
+  Literals       []string        `json:"literals,omitempty"`
   Evidence       *DumpEvidence   `json:"evidence,omitempty"`
   Implementation *DumpEvidence   `json:"implementation,omitempty"`
   Decorators     []DumpDecorator `json:"decorators,omitempty"`
@@ -148,16 +149,19 @@ func NewDump(g *Graph, project, tsconfig string, ignored map[string]bool, source
       name, qualified = ctx.rel(name), ""
     }
     nodes = append(nodes, DumpNode{
-      ID:             ctx.relID(n.ID),
-      Kind:           string(n.Kind),
-      Name:           name,
-      QualifiedName:  qualified,
-      File:           ctx.rel(n.File),
-      External:       n.External,
-      Ignored:        ignored[n.File],
-      Exported:       n.Exported,
-      Closure:        n.Closure,
-      Modifiers:      n.Modifiers,
+      ID:            ctx.relID(n.ID),
+      Kind:          string(n.Kind),
+      Name:          name,
+      QualifiedName: qualified,
+      File:          ctx.rel(n.File),
+      External:      n.External,
+      Ignored:       ignored[n.File],
+      Exported:      n.Exported,
+      Closure:       n.Closure,
+      Modifiers:     n.Modifiers,
+      // Uncapped, like every other fact here: the dump is the whole graph and
+      // the MCP layer is what applies a response cap and marks it.
+      Literals:       n.Literals,
       Evidence:       withoutFile(ctx.evidence(n.File, n.Pos, n.End)),
       Implementation: ctx.evidence(n.ImplementationFile, n.ImplementationPos, n.ImplementationEnd),
       Decorators:     decByNode[n.ID],

--- a/packages/ttsc/internal/graph/dump_schema_version_matches_the_typescript_client_test.go
+++ b/packages/ttsc/internal/graph/dump_schema_version_matches_the_typescript_client_test.go
@@ -29,7 +29,7 @@ func TestDumpSchemaVersionMatchesTheTypescriptClient(t *testing.T) {
   // The checkout is CRLF on Windows, and a line-anchored match would never
   // see the end of a line that ends in a carriage return.
   source = bytes.ReplaceAll(source, []byte("\r\n"), []byte("\n"))
-  match := regexp.MustCompile(`(?m)^const DUMP_SCHEMA_VERSION = (\d+);$`).FindSubmatch(source)
+  match := regexp.MustCompile(`(?m)^(?:export )?const DUMP_SCHEMA_VERSION = (\d+);$`).FindSubmatch(source)
   if match == nil {
     t.Fatalf("no `const DUMP_SCHEMA_VERSION = <n>;` in %s; if it moved, this gate must follow it", reader)
   }

--- a/packages/ttsc/internal/graph/edges.go
+++ b/packages/ttsc/internal/graph/edges.go
@@ -7,11 +7,17 @@ import (
   "github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
-// addEdges resolves the relationships between the declaration nodes Build
-// recorded. It walks each source file again and, for every class or interface,
-// resolves its heritage bases through the checker (unwrapping barrel re-exports
-// to the real declaration) and links the declaration to that base, materializing
-// an external boundary-leaf node when the base lives in node_modules or a `.d.ts`.
+// addEdges is the checker pass over the declaration nodes Build recorded. It
+// walks each source file again and, for every class or interface, resolves its
+// heritage bases through the checker (unwrapping barrel re-exports to the real
+// declaration) and links the declaration to that base, materializing an external
+// boundary-leaf node when the base lives in node_modules or a `.d.ts`.
+//
+// Not everything it resolves is an edge. A fact that belongs to one declaration
+// rather than to a pair of them rides on its own node: a decorator on the target
+// it annotates, a literal value set on the type that admits it. Both need the
+// same checker and the same walk, so they are resolved here and written to the
+// node the build pass keyed.
 func (g *Graph) addEdges(prog *driver.Program) {
   checker := prog.Checker
   for _, file := range prog.SourceFiles() {
@@ -19,6 +25,7 @@ func (g *Graph) addEdges(prog *driver.Program) {
     g.collectHeritage(checker, file)
     g.collectCalls(checker, file)
     g.collectTypeRefs(checker, file)
+    g.collectLiterals(checker, file)
     if file.Statements != nil {
       g.collectDecorators(file.FileName(), file.Statements.Nodes)
     }

--- a/packages/ttsc/internal/graph/graph.go
+++ b/packages/ttsc/internal/graph/graph.go
@@ -58,6 +58,21 @@ type Node struct {
   // the declaration's combined modifier flags during the build pass and emitted
   // for projections that filter on visibility and shape.
   Modifiers []string
+  // Literals is the complete value set of a type alias or enum whose declared
+  // type the checker resolved to literals, each rendered in TypeScript source
+  // form ("a", 1, true, null). It is set only when every constituent is
+  // enumerable, so a present list is the whole type and never a sample of it;
+  // a union that mixes in `string`, a type parameter, or a computed enum member
+  // has no complete answer and gets none.
+  //
+  // It is a checker fact because nothing else is sound. The value set was read
+  // off the declaration's source text for a while, which made the answer a
+  // function of line wrapping rather than of the type: a union written one
+  // member per line reported the members that fit in the snippet, an enum
+  // written across lines reported nothing at all, and `type I = Kind | 'f'`
+  // reported `'f'` while the members reaching it through `Kind` vanished (#732).
+  // The checker has already resolved every one of them, indirection included.
+  Literals []string
   // Pos and End bound the declaration in its source file (byte offsets). They
   // are for display, never identity, so an edit that shifts them does not re-key
   // the node.

--- a/packages/ttsc/internal/graph/literals.go
+++ b/packages/ttsc/internal/graph/literals.go
@@ -1,0 +1,125 @@
+package graph
+
+import (
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimchecker "github.com/microsoft/typescript-go/shim/checker"
+)
+
+// collectLiterals records the value set of every type alias and enum in file
+// whose declared type resolves to literals, so a consumer asking what values a
+// type admits is answered from the checker rather than from the declaration's
+// source text.
+//
+// It runs on the checker for the reason markExports does: the syntactic reading
+// is not the real answer. A union's members are only spelled out at the
+// declaration when nothing indirects — `type Indirect = Kind | 'f'` names one
+// literal and reaches five more through an alias, and only the checker has
+// resolved that. It has also already flattened nested unions, dropped
+// duplicates, and reduced subtypes, so the constituents it hands back are the
+// type's members exactly once each.
+//
+// Enums come here too, and they need it more. An enum's members are not nodes
+// of their own — the build pass records member nodes for classes and interfaces
+// only — so `literals` is the only place an enum's values reach a consumer at
+// all.
+func (g *Graph) collectLiterals(checker *shimchecker.Checker, file *shimast.SourceFile) {
+  if file.Statements == nil {
+    return
+  }
+  g.collectLiteralsIn(checker, file.FileName(), file.Statements.Nodes)
+}
+
+// collectLiteralsIn walks a statement list — a file's top level, or a namespace
+// body it recurses into — and records the value set of each type alias and enum
+// it holds. It mirrors collectStatements' descent so a `namespace X { type K =
+// … }` is resolved on the node the build pass keyed by its qualified name.
+func (g *Graph) collectLiteralsIn(checker *shimchecker.Checker, path string, statements []*shimast.Node) {
+  for _, statement := range statements {
+    switch statement.Kind {
+    case shimast.KindTypeAliasDeclaration:
+      g.putLiterals(checker, path, statement, NodeTypeAlias)
+    case shimast.KindEnumDeclaration:
+      g.putLiterals(checker, path, statement, NodeEnum)
+    case shimast.KindModuleDeclaration:
+      g.collectLiteralsIn(checker, path, moduleStatements(statement))
+    }
+  }
+}
+
+// putLiterals resolves the declared type of statement's symbol and records its
+// value set on the node the build pass recorded for it. A declaration the graph
+// does not hold a node for, or whose type has no complete literal answer, is
+// left alone rather than given a partial one.
+func (g *Graph) putLiterals(checker *shimchecker.Checker, path string, statement *shimast.Node, kind NodeKind) {
+  symbol := statement.Symbol()
+  if symbol == nil || symbol.Name == "" {
+    return
+  }
+  node, ok := g.Nodes[nodeID(path, qualifiedName(symbol), kind)]
+  if !ok {
+    return
+  }
+  declared := shimchecker.Checker_getDeclaredTypeOfSymbol(checker, symbol)
+  if declared == nil {
+    return
+  }
+  if values, ok := literalValues(declared); ok {
+    node.Literals = values
+  }
+}
+
+// literalValues renders every constituent of t in TypeScript source form,
+// reporting false unless all of them are enumerable.
+//
+// All-or-nothing is the contract. `type T = Kind | number` admits five literals
+// and every other number besides; answering with the five would describe a type
+// that does not exist, and the caller cannot tell that answer from a complete
+// one. So a type whose members cannot all be named yields no list, and its
+// signature carries the shape instead.
+func literalValues(t *shimchecker.Type) ([]string, bool) {
+  // Types() panics on anything that is not a union, an intersection, or a
+  // template literal, so the flag test is what makes the union branch safe. A
+  // single-literal alias (`type One = 'a'`) is not a union and is its own only
+  // constituent.
+  constituents := []*shimchecker.Type{t}
+  if t.Flags()&shimchecker.TypeFlagsUnion != 0 {
+    constituents = t.Types()
+  }
+  values := make([]string, 0, len(constituents))
+  for _, constituent := range constituents {
+    value, ok := literalValue(constituent)
+    if !ok {
+      return nil, false
+    }
+    values = append(values, value)
+  }
+  if len(values) == 0 {
+    return nil, false
+  }
+  return values, true
+}
+
+// literalValue renders one constituent in TypeScript source form, reporting
+// false when it names no single value a caller could write.
+func literalValue(t *shimchecker.Type) (string, bool) {
+  flags := t.Flags()
+  switch {
+  case flags&shimchecker.TypeFlagsNull != 0:
+    return "null", true
+  case flags&shimchecker.TypeFlagsUndefined != 0:
+    return "undefined", true
+  case flags&shimchecker.TypeFlagsLiteral != 0:
+    // TypeFlagsLiteral covers an enum member too: EnumLiteral is always paired
+    // with StringLiteral or NumberLiteral on a member, and with Union on the
+    // enum type itself, which the union branch above has already opened.
+    value := t.AsLiteralType().Value()
+    if value == nil {
+      // A computed enum member the checker could not fold to a constant. It has
+      // a value at runtime that nothing here can name, so the enum has no
+      // complete answer.
+      return "", false
+    }
+    return shimchecker.ValueToString(value), true
+  }
+  return "", false
+}

--- a/packages/ttsc/internal/graph/literals_are_absent_when_the_type_admits_more_than_it_can_name_test.go
+++ b/packages/ttsc/internal/graph/literals_are_absent_when_the_type_admits_more_than_it_can_name_test.go
@@ -1,0 +1,74 @@
+package graph
+
+import (
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestLiteralsAreAbsentWhenTheTypeAdmitsMoreThanItCanName verifies the negative
+// twin of every literal case: a type whose members cannot all be named reports
+// none of them rather than the subset that can.
+//
+// This is what lets a present `literals` mean the whole type. `Widened` admits
+// four literals and every other string besides, and a caller cannot tell a
+// four-value answer for it from a four-value answer for a genuine four-member
+// union — so it must get no answer, and read the signature instead. Each fixture
+// here is one way a constituent stops being nameable: a primitive next to the
+// literals, an unresolved type parameter, a plain primitive alias, and a
+// computed enum member whose value the checker cannot fold to a constant.
+//
+//  1. Compile a fixture holding each non-enumerable shape.
+//  2. Build the graph.
+//  3. Assert none of them recorded a value set.
+func TestLiteralsAreAbsentWhenTheTypeAdmitsMoreThanItCanName(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), fixtureTSConfig)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), `declare const compute: () => number;
+
+export type Narrow = 'a' | 'b' | 'c' | 'd';
+export type Widened = Narrow | string;
+export type Generic<T> = T | 'a';
+export type Primitive = string;
+
+export enum Computed {
+  A = 'a',
+  B = compute(),
+}
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diags)
+  }
+  defer func() { _ = prog.Close() }()
+
+  graph := Build(prog)
+  path := sourceFile(t, prog, "main.ts").FileName()
+
+  // The control: the shapes below differ from this one by exactly the property
+  // that makes them unnameable, so an empty result there is the rule acting and
+  // not the pass failing to run on this fixture at all.
+  if got := literalsOf(t, graph, nodeID(path, "Narrow", NodeTypeAlias)); len(got) != 4 {
+    t.Fatalf("control union did not report its four members: got %v", got)
+  }
+
+  for _, testCase := range []struct {
+    name string
+    kind NodeKind
+    why  string
+  }{
+    {"Widened", NodeTypeAlias, "a union with `string` in it admits values no list can name"},
+    {"Generic", NodeTypeAlias, "an unresolved type parameter names no value"},
+    {"Primitive", NodeTypeAlias, "a primitive is not a value set"},
+    {"Computed", NodeEnum, "a computed enum member has a value nothing here can name"},
+  } {
+    if got := literalsOf(t, graph, nodeID(path, testCase.name, testCase.kind)); len(got) != 0 {
+      t.Fatalf("%s reported a partial value set %v: %s", testCase.name, got, testCase.why)
+    }
+  }
+}

--- a/packages/ttsc/internal/graph/literals_cover_enum_members_the_graph_has_no_nodes_for_test.go
+++ b/packages/ttsc/internal/graph/literals_cover_enum_members_the_graph_has_no_nodes_for_test.go
@@ -1,0 +1,79 @@
+package graph
+
+import (
+  "path/filepath"
+  "slices"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestLiteralsCoverEnumMembersTheGraphHasNoNodesFor verifies that an enum
+// reports its member values, string-valued, numeric, and implicitly numbered
+// alike, however the declaration is laid out.
+//
+// An enum needed this more than a union did (#732). Its members are not nodes —
+// the build pass records member nodes for classes and interfaces only — so
+// nothing else in a details result carries them, and the old source-text scrape
+// stopped at the line holding `{`, which is the first line of every enum written
+// the ordinary way. A multi-line enum therefore reported no members at all,
+// through `literals` or otherwise, and only a single-line one answered. The
+// implicit fixture pins that the values come from the checker rather than the
+// text: nothing in `Implicit`'s source spells out 0 and 1.
+//
+//  1. Compile a fixture with a multi-line string enum, a single-line one, and an
+//     enum whose members are implicitly numbered.
+//  2. Build the graph.
+//  3. Assert each reports its resolved member values, and that the enum still
+//     has no member nodes so `literals` is genuinely the only carrier.
+func TestLiteralsCoverEnumMembersTheGraphHasNoNodesFor(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), fixtureTSConfig)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), `export enum Wrapped {
+  A = 'a',
+  B = 'b',
+  C = 'c',
+}
+
+export enum Flat { A = 'a', B = 'b', C = 'c' }
+
+export enum Implicit {
+  First,
+  Second,
+}
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diags)
+  }
+  defer func() { _ = prog.Close() }()
+
+  graph := Build(prog)
+  path := sourceFile(t, prog, "main.ts").FileName()
+
+  // The declaration whose members the old scrape could never reach.
+  wrapped := literalsOf(t, graph, nodeID(path, "Wrapped", NodeEnum))
+  if want := []string{`"a"`, `"b"`, `"c"`}; !slices.Equal(wrapped, want) {
+    t.Fatalf("multi-line enum under-reported its members: got %v, want %v", wrapped, want)
+  }
+  // Layout is not the fact; the single-line twin must agree exactly.
+  flat := literalsOf(t, graph, nodeID(path, "Flat", NodeEnum))
+  if !slices.Equal(flat, wrapped) {
+    t.Fatalf("enum layout changed the value set: wrapped %v, flat %v", wrapped, flat)
+  }
+  // Implicitly numbered members: the values exist only in the checker, never in
+  // the source text, so a scrape of any kind cannot produce this list.
+  implicit := literalsOf(t, graph, nodeID(path, "Implicit", NodeEnum))
+  if want := []string{"0", "1"}; !slices.Equal(implicit, want) {
+    t.Fatalf("implicitly numbered enum did not report its resolved values: got %v, want %v", implicit, want)
+  }
+  // The premise: no member node exists to carry these instead, so dropping
+  // `literals` for an enum would take its members out of the graph entirely.
+  if node, ok := graph.Nodes[nodeID(path, "Wrapped.A", NodeMethod)]; ok {
+    t.Fatalf("enum member unexpectedly modeled as a node (%v); literals may no longer be the only carrier", node.ID)
+  }
+}

--- a/packages/ttsc/internal/graph/literals_do_not_depend_on_declaration_line_wrapping_test.go
+++ b/packages/ttsc/internal/graph/literals_do_not_depend_on_declaration_line_wrapping_test.go
@@ -1,0 +1,84 @@
+package graph
+
+import (
+  "path/filepath"
+  "slices"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestLiteralsDoNotDependOnDeclarationLineWrapping verifies that collectLiterals
+// answers with the union's members whatever the declaration's layout: the same
+// eight-member type written one member per line and written on one line both
+// report all eight.
+//
+// This is the #732 regression. The value set used to be scraped out of the
+// declaration's first four lines of source text and cut to six, so completeness
+// was a function of line wrapping and of member count rather than of the type:
+// the wrapped form reported the three members that fit in the snippet, and the
+// flat form reported six of eight. Both cuts were silent. Eight members is the
+// boundary that pins both at once — it is past the old six-member cap, so a
+// reintroduced cap fails here on the flat twin instead of hiding behind a small
+// fixture.
+//
+//  1. Compile a fixture with a wrapped union and a flat union of the same eight
+//     string literals.
+//  2. Build the graph.
+//  3. Assert both nodes carry all eight values, in source form, and that the two
+//     lists are identical.
+func TestLiteralsDoNotDependOnDeclarationLineWrapping(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), fixtureTSConfig)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), `export type Wrapped =
+  | 'a' // a trailing comment the old snippet scrape also had to survive
+  | 'b'
+  | 'c'
+  | 'd'
+  | 'e'
+  | 'f'
+  | 'g'
+  | 'h';
+
+export type Flat = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h';
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diags)
+  }
+  defer func() { _ = prog.Close() }()
+
+  graph := Build(prog)
+  path := sourceFile(t, prog, "main.ts").FileName()
+
+  want := []string{`"a"`, `"b"`, `"c"`, `"d"`, `"e"`, `"f"`, `"g"`, `"h"`}
+  wrapped := literalsOf(t, graph, nodeID(path, "Wrapped", NodeTypeAlias))
+  flat := literalsOf(t, graph, nodeID(path, "Flat", NodeTypeAlias))
+
+  if !slices.Equal(wrapped, want) {
+    t.Fatalf("wrapped union under-reported its members: got %v, want %v", wrapped, want)
+  }
+  if !slices.Equal(flat, want) {
+    t.Fatalf("flat union under-reported its members: got %v, want %v", flat, want)
+  }
+  // The point of the fix stated directly: layout is not allowed to change the
+  // answer for one and the same type.
+  if !slices.Equal(wrapped, flat) {
+    t.Fatalf("line wrapping changed the value set: wrapped %v, flat %v", wrapped, flat)
+  }
+}
+
+// literalsOf returns the recorded value set of the node id names, failing the
+// test when the graph holds no such node.
+func literalsOf(t *testing.T, graph *Graph, id string) []string {
+  t.Helper()
+  node, ok := graph.Nodes[id]
+  if !ok {
+    t.Fatalf("graph has no node %q; nodes: %v", id, nodeIDSet(graph))
+  }
+  return node.Literals
+}

--- a/packages/ttsc/internal/graph/literals_render_every_value_in_typescript_source_form_test.go
+++ b/packages/ttsc/internal/graph/literals_render_every_value_in_typescript_source_form_test.go
@@ -1,0 +1,77 @@
+package graph
+
+import (
+  "path/filepath"
+  "slices"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestLiteralsRenderEveryValueInTypescriptSourceForm verifies that each kind of
+// literal a union can hold reaches the wire as the way it is written, and that
+// the rendering is the checker's own rather than this package's.
+//
+// Source form is what makes the list readable as the type: it is the only
+// rendering that tells `1` from `"1"` and `true` from `"true"`, which bare
+// contents cannot, and the old string-only scrape could not report a numeric
+// union at all. The escaping fixture is why the checker's `ValueToString` is
+// used instead of a local formatter — a quote inside a value has to come back
+// escaped the way TypeScript escapes it, and Go's own quoting is not that.
+//
+//  1. Compile a fixture with a string, numeric, boolean, bigint, nullable, and
+//     escaped-string union.
+//  2. Build the graph.
+//  3. Assert each value set renders in TypeScript source form.
+func TestLiteralsRenderEveryValueInTypescriptSourceForm(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), fixtureTSConfig)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), `export type Strings = 'a' | 'b';
+export type Numbers = 1 | 2 | 3;
+export type Bools = true | false;
+export type Bigints = 1n | 2n;
+export type Nullable = 'a' | null;
+export type Optional = 'a' | undefined;
+export type Escaped = 'he said "hi"' | "it's" | 'tab\there';
+export type Mixed = 'a' | 1 | true;
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diags)
+  }
+  defer func() { _ = prog.Close() }()
+
+  graph := Build(prog)
+  path := sourceFile(t, prog, "main.ts").FileName()
+
+  for _, testCase := range []struct {
+    name string
+    want []string
+  }{
+    // A string keeps its quotes, so the list reads as the type does.
+    {"Strings", []string{`"a"`, `"b"`}},
+    // Numbers were absent entirely under the string-only scrape.
+    {"Numbers", []string{"1", "2", "3"}},
+    {"Bools", []string{"false", "true"}},
+    {"Bigints", []string{"1n", "2n"}},
+    // A unit type that is not a literal still names one value a caller writes,
+    // so the set stays complete rather than dropping to nothing.
+    {"Nullable", []string{"null", `"a"`}},
+    {"Optional", []string{"undefined", `"a"`}},
+    // The checker's escaping, not Go's: an inner double quote is backslashed,
+    // an apostrophe is not re-quoted, and a tab stays an escape rather than a
+    // raw control character.
+    {"Escaped", []string{`"he said \"hi\""`, `"it's"`, `"tab\there"`}},
+    // Kinds mix in one union, and source form is what keeps them apart.
+    {"Mixed", []string{`"a"`, "1", "true"}},
+  } {
+    got := literalsOf(t, graph, nodeID(path, testCase.name, NodeTypeAlias))
+    if !slices.Equal(got, testCase.want) {
+      t.Fatalf("%s rendered %v, want %v", testCase.name, got, testCase.want)
+    }
+  }
+}

--- a/packages/ttsc/internal/graph/literals_resolve_through_alias_indirection_test.go
+++ b/packages/ttsc/internal/graph/literals_resolve_through_alias_indirection_test.go
@@ -1,0 +1,64 @@
+package graph
+
+import (
+  "path/filepath"
+  "slices"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestLiteralsResolveThroughAliasIndirection verifies that a union assembled out
+// of other unions reports every member it admits, including the ones no token of
+// its own declaration names.
+//
+// This is the half of #732 that was not truncation but a wrong answer of the
+// right shape. Reading `type Wide = Narrow | 'd'` off the source text finds one
+// quoted token and reports `'d'`, a complete-looking three-member type reduced
+// to one, with nothing marking the loss. Only the checker has followed Narrow.
+// The nested case (`Wider = Wide | 'e'`) pins that the resolution is not one hop
+// deep, and the checker also flattens and dedups, so `Duplicated` must report
+// `'a'` once rather than twice.
+//
+//  1. Compile a fixture whose aliases build on each other, one of them
+//     re-listing a member an aliased union already has.
+//  2. Build the graph.
+//  3. Assert each alias reports the full set it admits, deduplicated.
+func TestLiteralsResolveThroughAliasIndirection(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), fixtureTSConfig)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), `export type Narrow = 'a' | 'b' | 'c';
+export type Wide = Narrow | 'd';
+export type Wider = Wide | 'e';
+export type Duplicated = Narrow | 'a';
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diags)
+  }
+  defer func() { _ = prog.Close() }()
+
+  graph := Build(prog)
+  path := sourceFile(t, prog, "main.ts").FileName()
+
+  // One hop: the three members reaching Wide through Narrow are Wide's too.
+  wide := literalsOf(t, graph, nodeID(path, "Wide", NodeTypeAlias))
+  if want := []string{`"a"`, `"b"`, `"c"`, `"d"`}; !slices.Equal(wide, want) {
+    t.Fatalf("alias indirection lost members: got %v, want %v", wide, want)
+  }
+  // Two hops: resolution is the type's, so depth costs nothing.
+  wider := literalsOf(t, graph, nodeID(path, "Wider", NodeTypeAlias))
+  if want := []string{`"a"`, `"b"`, `"c"`, `"d"`, `"e"`}; !slices.Equal(wider, want) {
+    t.Fatalf("nested alias indirection lost members: got %v, want %v", wider, want)
+  }
+  // A member named twice is one member; the checker has already deduped, so the
+  // list must not report `"a"` once per mention.
+  duplicated := literalsOf(t, graph, nodeID(path, "Duplicated", NodeTypeAlias))
+  if want := []string{`"a"`, `"b"`, `"c"`}; !slices.Equal(duplicated, want) {
+    t.Fatalf("a member named twice was reported twice: got %v, want %v", duplicated, want)
+  }
+}

--- a/packages/ttsc/internal/graph/provenance.go
+++ b/packages/ttsc/internal/graph/provenance.go
@@ -14,7 +14,7 @@ import (
 // field is added, removed, or given a new meaning, independently of the serve
 // envelope's protocol version: a one-shot `ttscgraph dump` written to a file has
 // a schema but never rode the protocol.
-const DumpSchemaVersion = 1
+const DumpSchemaVersion = 2
 
 // The capabilities a snapshot can declare. Each names one class of evidence a
 // consumer may rely on when, and only when, the snapshot lists it.

--- a/packages/ttsc/shim/checker/shim.go
+++ b/packages/ttsc/shim/checker/shim.go
@@ -49,6 +49,19 @@ func Checker_getRegularTypeOfLiteralType(recv *innerchecker.Checker, t *innerche
   return checkerGetRegularTypeOfLiteralType(recv, t)
 }
 
+// ValueToString renders a literal type's value in TypeScript source form: a
+// string as a double-quoted, escaped literal, a number, boolean, or bigint as
+// the way it is written. It is the checker's own renderer, so a consumer
+// enumerating a literal union reports the values the way the compiler prints
+// them, including numeric formatting and string escaping it should not re-derive.
+//
+// It panics on a value it does not handle — notably the nil a computed enum
+// member carries — so a caller holding a `LiteralType.Value()` must reject nil
+// before calling this.
+func ValueToString(value any) string {
+  return innerchecker.ValueToString(value)
+}
+
 // Checker_typeToStringFullyQualified formats a type with the same stable,
 // alias-aware flags TypeScript uses in diagnostics that name union members.
 // Keeping the flag bundle inside the shim avoids leaking checker-internal enum

--- a/tests/test-graph/src/features/test_ttscgraph_details_literals_enumerate_the_resolved_type.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_details_literals_enumerate_the_resolved_type.ts
@@ -1,0 +1,178 @@
+import { TestProject } from "@ttsc/testing";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  content: { type: string; text: string }[];
+  structuredContent?: unknown;
+}
+
+interface DetailsResult {
+  type: "details";
+  nodes: {
+    name: string;
+    kind: string;
+    signature?: string;
+    literals?: string[];
+    literalsTruncated?: boolean;
+  }[];
+  unknown: string[];
+}
+
+const graphArguments = (props: {
+  thinking: string;
+  request: Record<string, unknown>;
+}) => ({
+  question: props.thinking,
+  draft: {
+    reason: "The smallest useful sacred graph step.",
+    type: props.request.type,
+  },
+  review:
+    "Confirmed: keep this final request; do not replace graph facts with file reads.",
+  request: props.request,
+});
+
+const detailsOf = (result: ToolResult): DetailsResult => {
+  const value = (result.structuredContent ?? {}) as { result?: DetailsResult };
+  if (value.result?.type !== "details")
+    throw new Error(`Unexpected graph result: ${JSON.stringify(value)}`);
+  return value.result;
+};
+
+/**
+ * Verifies `details` reports the values a union or enum admits from the
+ * checker's resolved type, so the answer does not depend on how the declaration
+ * is wrapped.
+ *
+ * `literals` was scraped out of the `signature` snippet, which stops after four
+ * source lines or at the first `{`, and was then cut to six. So a union written
+ * one member per line reported the first three of them, an enum written across
+ * lines reported none at all, and `type Indirect = Kind | 'f'` reported `'f'`
+ * alone while the members reaching it through `Kind` disappeared — all
+ * silently, under an audit telling the caller these facts are compiler-resolved
+ * (#732). This pins the whole class end to end, through the real binary: the
+ * same type must answer the same way whatever its layout, and a type whose
+ * members cannot all be named must report none rather than a subset that reads
+ * as complete.
+ *
+ * 1. Materialize a project holding a wrapped union, a flat twin, a multi-line
+ *    enum, an aliased union, and a union widened by `string`.
+ * 2. Ask the MCP server for `details` on all five.
+ * 3. Assert each value set is complete and layout-independent, that indirection
+ *    resolves, and that the widened union reports nothing.
+ */
+export const test_ttscgraph_details_literals_enumerate_the_resolved_type =
+  async () => {
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify(
+        {
+          compilerOptions: {
+            target: "ES2022",
+            module: "commonjs",
+            strict: true,
+            rootDir: "src",
+            outDir: "dist",
+          },
+          include: ["src"],
+        },
+        null,
+        2,
+      ),
+      "src/app.ts": [
+        "export type Wrapped =",
+        "  | 'a'",
+        "  | 'b'",
+        "  | 'c'",
+        "  | 'd'",
+        "  | 'e'",
+        "  | 'f'",
+        "  | 'g';",
+        "",
+        "export type Flat = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g';",
+        "",
+        "export enum Colors {",
+        "  Red = 'red',",
+        "  Green = 'green',",
+        "  Blue = 'blue',",
+        "}",
+        "",
+        "export type Indirect = Wrapped | 'h';",
+        "",
+        "export type Widened = Wrapped | string;",
+        "",
+      ].join("\n"),
+    });
+
+    const client = TtsgraphClient.start(root);
+    try {
+      await client.request("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-graph", version: "0.0.0" },
+      });
+      client.notify("notifications/initialized", {});
+
+      const result = (await client.request("tools/call", {
+        name: "inspect_typescript_graph",
+        arguments: graphArguments({
+          thinking: "Which values do these types admit?",
+          request: {
+            type: "details",
+            handles: ["Wrapped", "Flat", "Colors", "Indirect", "Widened"],
+          },
+        }),
+      })) as ToolResult;
+
+      const details = detailsOf(result);
+      const literalsOf = (name: string): string[] | undefined =>
+        details.nodes.find((node) => node.name === name)?.literals;
+
+      const wrapped = literalsOf("Wrapped");
+      const flat = literalsOf("Flat");
+      const seven = ['"a"', '"b"', '"c"', '"d"', '"e"', '"f"', '"g"'];
+
+      // The reported case: seven members, one per line, past the old six-member
+      // cap and the old four-line signature window.
+      assert.deepStrictEqual(
+        wrapped,
+        seven,
+        `the wrapped union reports every member it admits: ${JSON.stringify(wrapped)}`,
+      );
+      // The same type, wrapped differently, is the same answer.
+      assert.deepStrictEqual(
+        flat,
+        seven,
+        `line wrapping does not change the value set: ${JSON.stringify(flat)}`,
+      );
+      // A multi-line enum used to report nothing: its signature stops at `{`, and
+      // its members are not nodes, so `literals` is their only carrier.
+      assert.deepStrictEqual(
+        literalsOf("Colors"),
+        ['"red"', '"green"', '"blue"'],
+        `the enum reports its member values: ${JSON.stringify(literalsOf("Colors"))}`,
+      );
+      // Indirection: the seven members reaching Indirect through Wrapped are its
+      // own, though no token of its declaration names them.
+      assert.deepStrictEqual(
+        literalsOf("Indirect"),
+        [...seven, '"h"'],
+        `alias indirection resolves: ${JSON.stringify(literalsOf("Indirect"))}`,
+      );
+      // The negative twin: this type admits every other string too, so a
+      // seven-value answer would read as complete while being false.
+      assert.strictEqual(
+        literalsOf("Widened"),
+        undefined,
+        `a union widened by string reports no value set: ${JSON.stringify(literalsOf("Widened"))}`,
+      );
+      // None of these are truncated, so the marker must stay off.
+      assert.ok(
+        details.nodes.every((node) => node.literalsTruncated !== true),
+        "no value set here is capped, so nothing is marked truncated",
+      );
+    } finally {
+      client.endStdin();
+      await client.waitForExit();
+    }
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_details_marks_a_capped_literal_set_truncated.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_details_marks_a_capped_literal_set_truncated.ts
@@ -1,0 +1,145 @@
+import { TestProject } from "@ttsc/testing";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  content: { type: string; text: string }[];
+  structuredContent?: unknown;
+}
+
+interface DetailsResult {
+  type: "details";
+  nodes: {
+    name: string;
+    literals?: string[];
+    literalsTruncated?: boolean;
+  }[];
+}
+
+const graphArguments = (props: {
+  thinking: string;
+  request: Record<string, unknown>;
+}) => ({
+  question: props.thinking,
+  draft: {
+    reason: "The smallest useful sacred graph step.",
+    type: props.request.type,
+  },
+  review:
+    "Confirmed: keep this final request; do not replace graph facts with file reads.",
+  request: props.request,
+});
+
+const detailsOf = (result: ToolResult): DetailsResult => {
+  const value = (result.structuredContent ?? {}) as { result?: DetailsResult };
+  if (value.result?.type !== "details")
+    throw new Error(`Unexpected graph result: ${JSON.stringify(value)}`);
+  return value.result;
+};
+
+/**
+ * Verifies a value set larger than the response cap comes back cut and says so.
+ *
+ * `literals` claims to be the whole type, which is the entire point of resolving
+ * it from the checker instead of scraping the declaration — so the one case
+ * where it is a prefix has to be marked, or the claim is false exactly the way
+ * the old six-value cut was (#732). The truncation is invisible without the
+ * marker: 60 plausible members read as a complete 60-member union. The fixture
+ * crosses two unions in a template literal so the checker expands them into 72
+ * members, more than any hand-written union but the same shape on the wire, and
+ * the dump carries all 72 because the cap belongs to the response and not to the
+ * graph.
+ *
+ * 1. Materialize a project whose type expands to 72 string literals.
+ * 2. Ask the MCP server for `details` on it and on a small union beside it.
+ * 3. Assert the big one is cut to the cap and marked, and the small one is
+ *    whole and unmarked.
+ */
+export const test_ttscgraph_details_marks_a_capped_literal_set_truncated =
+  async () => {
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify(
+        {
+          compilerOptions: {
+            target: "ES2022",
+            module: "commonjs",
+            strict: true,
+            rootDir: "src",
+            outDir: "dist",
+          },
+          include: ["src"],
+        },
+        null,
+        2,
+      ),
+      "src/app.ts": [
+        "type Letter = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i';",
+        "type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7';",
+        "",
+        "// 9 x 8 = 72 members, expanded by the checker.",
+        "export type Big = `${Letter}${Digit}`;",
+        "",
+        "export type Small = 'x' | 'y';",
+        "",
+      ].join("\n"),
+    });
+
+    const client = TtsgraphClient.start(root);
+    try {
+      await client.request("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-graph", version: "0.0.0" },
+      });
+      client.notify("notifications/initialized", {});
+
+      const result = (await client.request("tools/call", {
+        name: "inspect_typescript_graph",
+        arguments: graphArguments({
+          thinking: "Which values do these types admit?",
+          request: { type: "details", handles: ["Big", "Small"] },
+        }),
+      })) as ToolResult;
+
+      const details = detailsOf(result);
+      const nodeOf = (name: string) =>
+        details.nodes.find((node) => node.name === name);
+
+      const big = nodeOf("Big");
+      assert.ok(big !== undefined, "the expanded union resolved to a node");
+      // Cut to the cap rather than shipped whole: 72 members were resolved.
+      assert.strictEqual(
+        big.literals?.length,
+        60,
+        `the value set is cut to the response cap: ${String(big.literals?.length)}`,
+      );
+      // The claim `literals` makes is completeness, so the exception is stated.
+      assert.strictEqual(
+        big.literalsTruncated,
+        true,
+        "a cut value set says it was cut",
+      );
+      // What survives the cut is still the type's own values, in source form.
+      assert.ok(
+        big.literals?.[0] === '"a0"',
+        `the kept values are real members: ${JSON.stringify(big.literals?.slice(0, 2))}`,
+      );
+
+      // The negative twin: a set that fits is whole and carries no marker, so
+      // the flag tracks the cap rather than being stamped on every union.
+      const small = nodeOf("Small");
+      assert.deepStrictEqual(
+        small?.literals,
+        ['"x"', '"y"'],
+        `an uncapped value set is complete: ${JSON.stringify(small?.literals)}`,
+      );
+      assert.strictEqual(
+        small?.literalsTruncated,
+        undefined,
+        "an uncapped value set is not marked truncated",
+      );
+    } finally {
+      client.endStdin();
+      await client.waitForExit();
+    }
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_request_defaults_match_the_runner_constants.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_request_defaults_match_the_runner_constants.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { assert } from "../internal/ttsgraph";
+
+/** The package's own source tree, resolved the way the suite resolves its bin. */
+const graphRoot = path.dirname(
+  createRequire(import.meta.url).resolve("@ttsc/graph/package.json"),
+);
+
+const read = (...segments: string[]): string =>
+  fs.readFileSync(path.join(graphRoot, ...segments), "utf8");
+
+/** The `@default` typia publishes to the model for a numeric request field. */
+const documentedDefault = (source: string, field: string): number | undefined => {
+  const match = source.match(
+    new RegExp(`@default (\\d+)\\s*\\*/\\s*${field}\\?: number;`),
+  );
+  return match === null ? undefined : Number(match[1]);
+};
+
+/** The value the runner actually falls back to. */
+const runnerConstant = (source: string, name: string): number | undefined => {
+  const match = source.match(new RegExp(`^const ${name} = (\\d+);$`, "m"));
+  return match === null ? undefined : Number(match[1]);
+};
+
+/**
+ * Verifies each request default the MCP schema publishes is the one the runner
+ * applies.
+ *
+ * The default is written twice — as a JSDoc `@default` typia turns into the
+ * tool schema, and as the runner's fallback constant — and the two drifted
+ * apart twice, in the same way both times: a commit raised the constant for a
+ * benchmark result and left the tag behind. `details.dependencyLimit` said 1
+ * and gave 2 (`77dc14d04`), `tour.limit` said 4 and gave 5 (`c5243ad1c`). The
+ * schema is the only description of these knobs a model ever reads, so a stale
+ * tag is the graph telling the caller something the graph does not do — the
+ * same shape as #732, arriving through the request contract instead of the
+ * result. Neither drift was visible to anything that runs.
+ *
+ * This is the gate the pair needs, mirroring the one that holds the dump schema
+ * version to its TypeScript reader. Whichever side moves, the other has to
+ * follow, and the test says which.
+ *
+ * 1. Read each structure file and its runner.
+ * 2. Extract the documented `@default` and the runner's constant.
+ * 3. Assert they agree.
+ */
+export const test_ttscgraph_request_defaults_match_the_runner_constants = () => {
+  const details = read("src", "structures", "ITtscGraphDetails.ts");
+  const tour = read("src", "structures", "ITtscGraphTour.ts");
+  const runDetails = read("src", "server", "runDetails.ts");
+  const runTour = read("src", "server", "runTour.ts");
+  const runLookup = read("src", "server", "runLookup.ts");
+  const runTrace = read("src", "server", "runTrace.ts");
+  const runEntrypoints = read("src", "server", "runEntrypoints.ts");
+  const lookup = read("src", "structures", "ITtscGraphLookup.ts");
+  const trace = read("src", "structures", "ITtscGraphTrace.ts");
+  const entrypoints = read("src", "structures", "ITtscGraphEntrypoints.ts");
+
+  for (const testCase of [
+    { field: "neighborLimit", schema: details, runner: runDetails, constant: "DEFAULT_NEIGHBORS" },
+    { field: "memberLimit", schema: details, runner: runDetails, constant: "DEFAULT_MEMBERS" },
+    { field: "dependencyLimit", schema: details, runner: runDetails, constant: "DEFAULT_DEPENDENCIES" },
+    { field: "limit", schema: tour, runner: runTour, constant: "DEFAULT_LIMIT" },
+    { field: "limit", schema: lookup, runner: runLookup, constant: "DEFAULT_LIMIT" },
+    { field: "maxDepth", schema: trace, runner: runTrace, constant: "DEFAULT_DEPTH" },
+    { field: "maxNodes", schema: trace, runner: runTrace, constant: "DEFAULT_MAX_NODES" },
+    { field: "limit", schema: entrypoints, runner: runEntrypoints, constant: "DEFAULT_LIMIT" },
+    { field: "neighbors", schema: entrypoints, runner: runEntrypoints, constant: "DEFAULT_NEIGHBORS" },
+  ]) {
+    const documented = documentedDefault(testCase.schema, testCase.field);
+    const applied = runnerConstant(testCase.runner, testCase.constant);
+    // A pair that stops being findable is a pair that stops being checked, so
+    // the gate fails rather than passing vacuously when either side moves.
+    assert.notEqual(
+      documented,
+      undefined,
+      `no \`@default\` on ${testCase.field}; if it moved, this gate must follow it`,
+    );
+    assert.notEqual(
+      applied,
+      undefined,
+      `no \`const ${testCase.constant}\`; if it moved, this gate must follow it`,
+    );
+    assert.strictEqual(
+      documented,
+      applied,
+      `${testCase.field} is published as @default ${String(documented)} but ${testCase.constant} applies ${String(applied)}`,
+    );
+  }
+};

--- a/tests/test-ttsc/src/features/platform/test_release_workflow_runs_preflight_before_publication.ts
+++ b/tests/test-ttsc/src/features/platform/test_release_workflow_runs_preflight_before_publication.ts
@@ -9,16 +9,30 @@ import { assert, fs, path, workspaceRoot } from "../../internal/toolchain";
  * negative twin is the publication commands themselves: their positions in the
  * workflow text must all come after the preflight invocation.
  *
- * 1. Read the release workflow.
+ * Order is a property of what the workflow runs, so the comments come out
+ * first. #726 documented the runner's disk reclaim in prose that names
+ * `pnpm run build`, several lines above the step that invokes it, and a raw
+ * text scan read that sentence as the build itself and reported it running
+ * before the preflight. The workflow was correct and this gate was not. Prose
+ * about a command is not the command, and a gate that cannot tell them apart
+ * fails on the next comment that mentions one.
+ *
+ * 1. Read the release workflow and drop its comment lines.
  * 2. Locate the preflight invocation and each publication command.
- * 3. Assert the preflight appears exactly once and strictly before the Marketplace
- *    publish, the npm publish, and the first credential use.
+ * 3. Assert the preflight appears exactly once and strictly before the build,
+ *    the Marketplace publish, the npm publish, and the first credential use.
  */
 export const test_release_workflow_runs_preflight_before_publication = () => {
-  const workflow = fs.readFileSync(
+  const source = fs.readFileSync(
     path.join(workspaceRoot, ".github", "workflows", "release.yml"),
     "utf8",
   );
+  // A `#` opening a line is a YAML comment; one inside a value is not, and no
+  // step this gate looks for is written on a commented line.
+  const workflow = source
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
 
   const preflight = workflow.indexOf("scripts/release-preflight.cjs");
   assert.notEqual(preflight, -1, "release-preflight.cjs step is missing");


### PR DESCRIPTION
Fixes #732.

## Intent

`details.literals` claimed to be a compiler-resolved fact and was a regex over source text. `signatureOf()` reads at most four lines from the declaration start (stopping at `{` or a trailing `;`), and `literals` was `literalSummaries(signature).slice(0, 6)` over that snippet, so what a union reported depended on how it was wrapped rather than on the type. All of it silently, under a `RESULT_AUDIT` telling the caller that facts here are resolved and need no re-verification.

The reporter's witness was one of four faces of that root cause. Verified against the shipped code before changing anything:

| case | before | now |
|---|---|---|
| 5-member union, one per line | `["a","b","c"]` | all 5 |
| 10-member union, single line | 6 of 10 (the cap bites whatever the layout) | all 10 |
| multi-line `enum` | **no `literals` at all**, and `members` empty too | all values |
| `type Indirect = Kind \| 'f'` | `["f"]` — a wrong answer of the right shape | all 6 |

The enum case was the worst and was not merely truncation: `signatureOf` stops at the line holding `{`, and enum members are not graph nodes (the builder records member nodes for classes and interfaces only), so a multi-line enum's `details` carried no member information whatsoever.

## Scope

Issue option 1, the checker route. The Go builder resolves each type-alias/enum symbol's declared type (`getDeclaredTypeOfSymbol`) and enumerates the union's literal constituents. That is complete by construction, indifferent to line wrapping, and follows indirection; the checker has also already flattened, deduped, and subtype-reduced, so the constituents are the members exactly once each. Values ride the dump uncapped — the dump is the whole graph by contract — and the MCP layer applies the response cap.

- `Node.Literals` + a `collectLiterals` checker pass (`packages/ttsc/internal/graph/literals.go`), rendered by the checker's own `ValueToString`, newly re-exported through `shim/checker` (numeric formatting and string escaping are not things a consumer should re-derive).
- `literals` on `ITtscGraphNode`; the scrape helpers are deleted rather than left reachable.
- `literalsTruncated` on `ITtscGraphDetails.INode`, which `details` had no field to express before.

Two decisions worth flagging, both a change of specification:

1. **All-or-nothing.** `type T = Kind | string` admits values no list can name, so it reports none rather than the four that can — a partial list is indistinguishable from a complete one, and the audit's promise is that a returned fact cannot be wrong. `signature` still carries the shape.
2. **Source form.** Values are rendered as written (`"a"`, `1`, `true`, `null`), not as bare contents (`a`). The old field was string-only, so `type N = 1 | 2` reported nothing; source form covers every literal kind and is the only rendering that can tell `1` from `"1"`. The field's sole consumer is the model reading the payload.

`ttsc` becomes a peer dependency of `@ttsc/graph` pinned to the same version (the `@ttsc/unplugin` pattern; `workspace:*` publishes as an exact pin — verified against the published `@ttsc/unplugin@0.19.2`, which carries `ttsc: '0.19.2'`). This fix is resolved in the Go builder and read in TypeScript, so a newer `@ttsc/graph` against an older `ttscgraph` would find `literals` absent and answer from a graph missing facts it believes are there. The reporter is running graph 0.19.1 against ttsc 0.18.4, which is exactly that skew.

## Deferred

`details` still caps `calls`/`types`/`implementedBy` at 2 by default, `members` at 6, and `signature` at 4 lines, none of them marked — while `RESULT_AUDIT` and the `IOutput.audit` doc both say a `details` result is "bounded only where `truncated` says". `literalsTruncated` closes that gap for the field this issue is about; the rest is the same class of silent bound and wants its own issue, not a drive-by here.

Enum members as graph nodes is likewise left alone. `literals` now carries their values, which is what #732 asked for, but their names still reach no consumer.

## Verification

Local, on this branch:

- `go test ./internal/graph/` — full package green, including four new cases. Each was confirmed to **fail** with the `collectLiterals` call commented out, so they pin the bug rather than the code.
  - `literals_do_not_depend_on_declaration_line_wrapping_test.go` — eight members wrapped vs flat, past the old six-cap so a reintroduced cap fails on the flat twin.
  - `literals_resolve_through_alias_indirection_test.go` — one hop, two hops, and a member named twice reported once.
  - `literals_cover_enum_members_the_graph_has_no_nodes_for_test.go` — multi-line, single-line, and implicitly numbered members (the values exist only in the checker), plus an assertion that no enum member node exists, so `literals` is genuinely the only carrier.
  - `literals_are_absent_when_the_type_admits_more_than_it_can_name_test.go` — the negative twins (`| string`, type parameter, primitive alias, computed enum member) against a four-member control.
- `pnpm --filter ttsc shim:audit` — OK, closed after the `ValueToString` re-export.
- `npx tsc --noEmit -p packages/graph/tsconfig.json` — clean.
- Real `ttscgraph dump` over a fixture, then the real `runDetails` driven over that dump: `Kind` 3→5, `Colors` (multi-line enum) none→3, `Indirect` `["f"]`→6, `Widened` absent, escaping intact (`'he said "hi"'`). An 80-member template-literal union arrives whole in the dump and comes back as 60 + `literalsTruncated`, with the marker staying off for every uncapped type.

Not run locally, left to CI:

- `tests/test-graph` e2e (`test_ttscgraph_details_literals_enumerate_the_resolved_type.ts`), which drives the real binary over MCP. The suite cannot start on this Windows checkout (`ERR_UNSUPPORTED_ESM_URL_SCHEME`), and `pnpm --filter @ttsc/graph build` could not complete here either — the D: volume is at 100%, so the typia plugin's Go build fails on disk, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ewvzm1RFiUHq22akQ6nPFb
