### PR TITLE
fix(graph): name the fields details cut

### DIFF
--- a/packages/graph/src/server/runDetails.ts
+++ b/packages/graph/src/server/runDetails.ts
@@ -16,7 +16,8 @@ const MAX_SIGNATURE_LINES = 4;
 // A value set is the answer to "what may this be", so it is listed rather than
 // sampled: the cap is high enough that a real union or enum arrives whole, and
 // exists only so a type expanded from a template literal cannot flood a
-// response. Past it, literalsTruncated says so and the declaration has the rest.
+// response. Past it, `truncated` names the field and the declaration has the
+// rest.
 const MAX_LITERALS = 60;
 // A doc summary is one sentence; the rest of the comment is the file's to keep.
 const MAX_DOC_CHARS = 200;
@@ -118,63 +119,64 @@ export function runDetails(
         endLine: span.endLine,
       };
     }
-    const calls = dependencyRefs(
-      graph,
-      node,
-      executionKinds,
-      dependencyLimit,
-      includeExternal,
+    // Every list below is capped, and the caller cannot see a cap from the
+    // payload: two refs on a symbol that calls forty look exactly like two refs
+    // on a symbol that calls two. Each field that lost something names itself
+    // here, and the audit's "bounded only where `truncated` says" becomes true
+    // of this result instead of aspirational.
+    const truncated: string[] = [];
+    const keep = <T>(field: string, list: ICut<T>): T[] => {
+      if (list.truncated) truncated.push(field);
+      return list.items;
+    };
+
+    const calls = keep(
+      "calls",
+      dependencyRefs(graph, node, executionKinds, dependencyLimit, includeExternal),
     );
     if (calls.length > 0) detail.calls = calls;
-    const types = dependencyRefs(
-      graph,
-      node,
-      typeKinds,
-      dependencyLimit,
-      includeExternal,
+    const types = keep(
+      "types",
+      dependencyRefs(graph, node, typeKinds, dependencyLimit, includeExternal),
     );
     if (types.length > 0) detail.types = types;
-    const implementedBy = incomingDependencyRefs(
-      graph,
-      node,
-      implementationKinds,
-      dependencyLimit,
-      includeExternal,
+    const implementedBy = keep(
+      "implementedBy",
+      incomingDependencyRefs(
+        graph,
+        node,
+        implementationKinds,
+        dependencyLimit,
+        includeExternal,
+      ),
     );
     if (implementedBy.length > 0) detail.implementedBy = implementedBy;
     if (CONTAINER_KINDS.has(node.kind)) {
-      const list = members(graph, node, memberLimit);
+      const list = keep("members", members(graph, node, memberLimit));
       if (list.length > 0) detail.members = list;
     }
     if (node.kind === "variable" && detail.sourceSpan !== undefined) {
-      const list = objectLiteralMembers(
-        graph.project,
-        detail.sourceSpan,
-        memberLimit,
+      const list = keep(
+        "members",
+        objectLiteralMembers(graph.project, detail.sourceSpan, memberLimit),
       );
       if (list.length > 0) detail.members = list;
     }
-    const literals = node.literals ?? [];
-    if (literals.length > 0) {
-      detail.literals = literals.slice(0, MAX_LITERALS);
-      if (literals.length > MAX_LITERALS) detail.literalsTruncated = true;
-    }
+    const literals = keep("literals", cut(node.literals ?? [], MAX_LITERALS));
+    if (literals.length > 0) detail.literals = literals;
     if (wantNeighbors) {
-      detail.dependsOn = refs(
-        graph,
-        graph.outgoing(node.id),
-        "to",
-        neighborLimit,
-        includeExternal,
+      detail.dependsOn = keep(
+        "dependsOn",
+        refs(graph, graph.outgoing(node.id), "to", neighborLimit, includeExternal),
       );
-      detail.dependedOnBy = refs(
-        graph,
-        graph.incoming(node.id),
-        "from",
-        neighborLimit,
-        includeExternal,
+      detail.dependedOnBy = keep(
+        "dependedOnBy",
+        refs(graph, graph.incoming(node.id), "from", neighborLimit, includeExternal),
       );
     }
+    // A field that lost nothing is not named, and a node that lost nothing
+    // carries no marker at all: `truncated` present has to mean something.
+    if (truncated.length > 0) detail.truncated = [...new Set(truncated)];
     nodes.push(detail);
   }
   return {
@@ -208,12 +210,18 @@ function members(
   graph: TtscGraphMemory,
   node: ITtscGraphNode,
   limit: number,
-): ITtscGraphDetails.IMember[] {
-  const out: ITtscGraphDetails.IMember[] = [];
+): ICut<ITtscGraphDetails.IMember> {
+  // Count the owned set from the edges, then build only the page returned. A
+  // member's signature is a file read, so building the ones the cap drops would
+  // pay for a class's whole member list to answer with six of it.
+  const owned: ITtscGraphNode[] = [];
   for (const edge of graph.outgoing(node.id)) {
     if (edge.kind !== "contains") continue;
     const member = graph.node(edge.to);
     if (member === undefined) continue;
+    owned.push(member);
+  }
+  const items = owned.slice(0, limit).map((member) => {
     const m: ITtscGraphDetails.IMember = {
       name: member.qualifiedName ?? member.name,
       kind: member.kind,
@@ -223,21 +231,21 @@ function members(
     if (sig !== undefined) m.signature = sig;
     const decorators = decoratorsOf(member);
     if (decorators !== undefined) m.decorators = decorators;
-    out.push(m);
-    if (out.length >= limit) break;
-  }
-  return out;
+    return m;
+  });
+  return { items, truncated: owned.length > limit };
 }
 
 function objectLiteralMembers(
   project: string,
   span: Pick<ITtscGraphEvidence, "file" | "startLine" | "endLine">,
   limit: number,
-): ITtscGraphDetails.IMember[] {
-  if (span.endLine === undefined) return [];
-  if (span.endLine - span.startLine > MAX_OBJECT_MEMBER_LINES) return [];
+): ICut<ITtscGraphDetails.IMember> {
+  const none = { items: [], truncated: false };
+  if (span.endLine === undefined) return none;
+  if (span.endLine - span.startLine > MAX_OBJECT_MEMBER_LINES) return none;
   const lines = fileLines(project, span.file);
-  if (lines === undefined) return [];
+  if (lines === undefined) return none;
   const start = Math.max(0, span.startLine - 1);
   const end = Math.min(lines.length - 1, span.endLine - 1);
   const members: ITtscGraphDetails.IMember[] = [];
@@ -248,11 +256,11 @@ function objectLiteralMembers(
     const text = stripStrings(raw);
     const before = depth;
     if (entered && before === 1) {
+      // The scan runs the literal's whole span rather than stopping at the cap,
+      // so the count behind the page is real. It is bounded by
+      // MAX_OBJECT_MEMBER_LINES and reads no file the page did not already.
       const member = objectMemberOf(raw, i + 1);
-      if (member !== undefined) {
-        members.push(member);
-        if (members.length >= limit) break;
-      }
+      if (member !== undefined) members.push(member);
     }
     for (const char of text) {
       if (char === "{") {
@@ -263,7 +271,7 @@ function objectLiteralMembers(
       }
     }
   }
-  return members;
+  return cut(members, limit);
 }
 
 function objectMemberOf(
@@ -316,7 +324,7 @@ function refs(
   end: "to" | "from",
   limit: number,
   includeExternal: boolean,
-): ITtscGraphDetails.IReference[] {
+): ICut<ITtscGraphDetails.IReference> {
   const ranked: Array<{ ref: ITtscGraphDetails.IReference; rank: number }> = [];
   for (const edge of edges) {
     if (STRUCTURAL_KINDS.has(edge.kind)) continue;
@@ -336,12 +344,10 @@ function refs(
     ranked.push({ ref, rank: refRank(ref, edge) });
   }
   ranked.sort((a, b) => a.rank - b.rank);
-  const out: ITtscGraphDetails.IReference[] = [];
-  for (const item of ranked) {
-    out.push(item.ref);
-    if (out.length >= limit) break;
-  }
-  return out;
+  return cut(
+    ranked.map((item) => item.ref),
+    limit,
+  );
 }
 
 const executionKinds = new Set([
@@ -359,7 +365,7 @@ function dependencyRefs(
   kinds: ReadonlySet<string>,
   limit: number,
   includeExternal: boolean,
-): ITtscGraphDetails.IReference[] {
+): ICut<ITtscGraphDetails.IReference> {
   const ranked: Array<{ ref: ITtscGraphDetails.IReference; rank: number }> = [];
   for (const edge of graph.outgoing(node.id)) {
     if (!kinds.has(edge.kind)) continue;
@@ -383,16 +389,20 @@ function dependencyRefs(
     });
   }
   ranked.sort((a, b) => a.rank - b.rank);
-  const out: ITtscGraphDetails.IReference[] = [];
+  const unique: ITtscGraphDetails.IReference[] = [];
   const seen = new Set<string>();
   for (const item of ranked) {
     const key = `${item.ref.relation}:${item.ref.id}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    out.push(item.ref);
-    if (out.length >= limit) break;
+    unique.push(item.ref);
   }
-  return out;
+  // Dedup runs to the end instead of stopping at the limit: reaching the limit
+  // is not the same fact as there being more, and a node with exactly `limit`
+  // neighbors is whole. Marking that one would be a lie in the direction the
+  // marker exists to prevent. Every ref was built by the loop above already, so
+  // counting the rest costs nothing new.
+  return cut(unique, limit);
 }
 
 function incomingDependencyRefs(
@@ -401,7 +411,7 @@ function incomingDependencyRefs(
   kinds: ReadonlySet<string>,
   limit: number,
   includeExternal: boolean,
-): ITtscGraphDetails.IReference[] {
+): ICut<ITtscGraphDetails.IReference> {
   const ranked: Array<{ ref: ITtscGraphDetails.IReference; rank: number }> = [];
   for (const edge of graph.incoming(node.id)) {
     if (!kinds.has(edge.kind)) continue;
@@ -424,16 +434,34 @@ function incomingDependencyRefs(
     });
   }
   ranked.sort((a, b) => a.rank - b.rank);
-  const out: ITtscGraphDetails.IReference[] = [];
+  const unique: ITtscGraphDetails.IReference[] = [];
   const seen = new Set<string>();
   for (const item of ranked) {
     const key = `${item.ref.relation}:${item.ref.id}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    out.push(item.ref);
-    if (out.length >= limit) break;
+    unique.push(item.ref);
   }
-  return out;
+  // Dedup runs to the end instead of stopping at the limit: reaching the limit
+  // is not the same fact as there being more, and a node with exactly `limit`
+  // neighbors is whole. Marking that one would be a lie in the direction the
+  // marker exists to prevent. Every ref was built by the loop above already, so
+  // counting the rest costs nothing new.
+  return cut(unique, limit);
+}
+
+/**
+ * A list as this response carries it: cut to `limit`, and saying whether the
+ * cut took anything. `truncated` is false for a list that fit exactly, so the
+ * marker means "there is more", never "the cap was reached".
+ */
+interface ICut<T> {
+  items: T[];
+  truncated: boolean;
+}
+
+function cut<T>(items: T[], limit: number): ICut<T> {
+  return { items: items.slice(0, limit), truncated: items.length > limit };
 }
 
 function bound(
@@ -594,6 +622,13 @@ export function docOf(
  * The declaration signature: the head of the declaration up to and including
  * the line that opens its body (`{`), or the single declaration line when there
  * is no brace, capped so a wrapped signature cannot run away.
+ *
+ * It never runs past the declaration's own span. The stop used to be the brace,
+ * the trailing semicolon, or the line cap, and a declaration ending in none of
+ * them read its neighbors instead: an enum member ends in a comma, so `VIEW`
+ * came back as itself plus the two members after it and the closing brace. The
+ * span is the fact that says where the declaration ends, and it was already on
+ * the node.
  */
 export function signatureOf(
   project: string,
@@ -604,12 +639,12 @@ export function signatureOf(
     evidence === undefined ? undefined : fileLines(project, evidence.file);
   if (lines === undefined || evidence === undefined) return undefined;
   const start = Math.max(0, evidence.startLine - 1);
+  const last =
+    evidence.endLine === undefined
+      ? lines.length - 1
+      : Math.min(lines.length - 1, evidence.endLine - 1);
   const out: string[] = [];
-  for (
-    let i = start;
-    i < lines.length && out.length < MAX_SIGNATURE_LINES;
-    i++
-  ) {
+  for (let i = start; i <= last && out.length < MAX_SIGNATURE_LINES; i++) {
     const line = lines[i];
     if (line === undefined) break;
     out.push(line);

--- a/packages/graph/src/structures/ITtscGraphDetails.ts
+++ b/packages/graph/src/structures/ITtscGraphDetails.ts
@@ -150,21 +150,30 @@ export namespace ITtscGraphDetails {
      * `1`, `true`, `null`) — the checker's resolved union members, not the
      * quoted tokens that happened to fit in `signature`.
      *
-     * Complete unless `literalsTruncated` says otherwise, and absent when the
-     * type has no enumerable value set. A `signature` is capped at the
-     * declaration head, so for a union or enum written across several lines
-     * this is the field that carries the members.
+     * Complete unless `truncated` names it, and absent when the type has no
+     * enumerable value set. A `signature` is capped at the declaration head, so
+     * for a union or enum written across several lines this is the field that
+     * carries the members.
      */
     literals?: string[];
 
     /**
-     * True when `literals` was cut to the response cap; the values listed
-     * stand, but they are a prefix of the set rather than all of it.
+     * The fields on this node whose lists were cut, named: `["calls",
+     * "members"]`. Absent when everything returned is whole.
      *
-     * `literals` claims to be the whole type, so the one case where it is not
-     * has to say so. Read the declaration for the rest.
+     * What is listed is still exact — a cut list holds real neighbors, real
+     * members, real values — but it is a prefix, not the set. The audit says a
+     * result is bounded only where `truncated` says, so this is where it says
+     * it, and `calls: [2 refs]` on a symbol that calls forty is the case it
+     * exists for: the payload is identical either way, and nothing else
+     * distinguishes them.
+     *
+     * The cut is this response's, not the graph's. Raise the matching request
+     * limit (`dependencyLimit`, `memberLimit`, `neighborLimit`) to see more of
+     * a named field, or `trace` when the question is a flow rather than a
+     * neighbor list; the graph holds all of it either way.
      */
-    literalsTruncated?: boolean;
+    truncated?: string[];
 
     /**
      * Owned symbol or top-level property outline a consumer reaches for on a

--- a/tests/test-graph/src/features/test_ttscgraph_details_literals_enumerate_the_resolved_type.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_details_literals_enumerate_the_resolved_type.ts
@@ -14,7 +14,7 @@ interface DetailsResult {
     kind: string;
     signature?: string;
     literals?: string[];
-    literalsTruncated?: boolean;
+    truncated?: string[];
   }[];
   unknown: string[];
 }
@@ -166,10 +166,12 @@ export const test_ttscgraph_details_literals_enumerate_the_resolved_type =
         undefined,
         `a union widened by string reports no value set: ${JSON.stringify(literalsOf("Widened"))}`,
       );
-      // None of these are truncated, so the marker must stay off.
+      // None of these are truncated, so no node names `literals` as cut.
       assert.ok(
-        details.nodes.every((node) => node.literalsTruncated !== true),
-        "no value set here is capped, so nothing is marked truncated",
+        details.nodes.every(
+          (node) => !(node.truncated ?? []).includes("literals"),
+        ),
+        "no value set here is capped, so none is marked truncated",
       );
     } finally {
       client.endStdin();

--- a/tests/test-graph/src/features/test_ttscgraph_details_marks_a_capped_literal_set_truncated.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_details_marks_a_capped_literal_set_truncated.ts
@@ -12,7 +12,8 @@ interface DetailsResult {
   nodes: {
     name: string;
     literals?: string[];
-    literalsTruncated?: boolean;
+    calls?: unknown[];
+    truncated?: string[];
   }[];
 }
 
@@ -113,11 +114,12 @@ export const test_ttscgraph_details_marks_a_capped_literal_set_truncated =
         60,
         `the value set is cut to the response cap: ${String(big.literals?.length)}`,
       );
-      // The claim `literals` makes is completeness, so the exception is stated.
-      assert.strictEqual(
-        big.literalsTruncated,
-        true,
-        "a cut value set says it was cut",
+      // The claim `literals` makes is completeness, so the exception is stated,
+      // and it names the field rather than saying "something here was cut".
+      assert.deepStrictEqual(
+        big.truncated,
+        ["literals"],
+        `a cut value set names itself: ${JSON.stringify(big.truncated)}`,
       );
       // What survives the cut is still the type's own values, in source form.
       assert.ok(
@@ -133,8 +135,10 @@ export const test_ttscgraph_details_marks_a_capped_literal_set_truncated =
         ['"x"', '"y"'],
         `an uncapped value set is complete: ${JSON.stringify(small?.literals)}`,
       );
+      // A node that lost nothing carries no marker at all, so `truncated`
+      // present always means something was cut.
       assert.strictEqual(
-        small?.literalsTruncated,
+        small?.truncated,
         undefined,
         "an uncapped value set is not marked truncated",
       );

--- a/tests/test-graph/src/features/test_ttscgraph_details_names_each_field_it_cut.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_details_names_each_field_it_cut.ts
@@ -1,0 +1,167 @@
+import { TestProject } from "@ttsc/testing";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  content: { type: string; text: string }[];
+  structuredContent?: unknown;
+}
+
+interface DetailsResult {
+  type: "details";
+  nodes: {
+    name: string;
+    calls?: unknown[];
+    members?: unknown[];
+    truncated?: string[];
+  }[];
+}
+
+const graphArguments = (props: {
+  thinking: string;
+  request: Record<string, unknown>;
+}) => ({
+  question: props.thinking,
+  draft: {
+    reason: "The smallest useful sacred graph step.",
+    type: props.request.type,
+  },
+  review:
+    "Confirmed: keep this final request; do not replace graph facts with file reads.",
+  request: props.request,
+});
+
+const detailsOf = (result: ToolResult): DetailsResult => {
+  const value = (result.structuredContent ?? {}) as { result?: DetailsResult };
+  if (value.result?.type !== "details")
+    throw new Error(`Unexpected graph result: ${JSON.stringify(value)}`);
+  return value.result;
+};
+
+/**
+ * Verifies `details` names the fields it cut, and names none it did not.
+ *
+ * Every list on a node is capped, and a cap is invisible in the payload: two
+ * refs on a function that calls twenty look exactly like two refs on a function
+ * that calls two. The audit tells the caller a result is "bounded only where
+ * `truncated` says" and to re-verify nothing, so without the marker it is an
+ * instruction to trust a slice as the whole — #732's shape, arriving through
+ * the neighbor lists instead of the value set (#737).
+ *
+ * The exactly-at-the-limit case is the one that makes the marker mean
+ * something: reaching a cap is not the same fact as there being more, so a
+ * function calling exactly `dependencyLimit` things must come back unmarked.
+ *
+ * 1. Materialize a project with a function that calls twenty others, one that
+ *    calls exactly two, one that calls one, and a class of ten methods.
+ * 2. Ask for `details` on all four with the default limits.
+ * 3. Assert the over-limit ones name their cut field and the others name
+ *    nothing.
+ */
+export const test_ttscgraph_details_names_each_field_it_cut = async () => {
+  const targets = Array.from({ length: 20 }, (_, i) => `t${String(i)}`);
+  const methods = Array.from({ length: 10 }, (_, i) => `  m${String(i)}(): void {}`);
+  const root = TestProject.createProject({
+    "tsconfig.json": JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          rootDir: "src",
+          outDir: "dist",
+        },
+        include: ["src"],
+      },
+      null,
+      2,
+    ),
+    "src/app.ts": [
+      ...targets.map((t) => `export function ${t}(): void {}`),
+      "",
+      "// Twenty calls, and the default dependencyLimit is 2.",
+      `export function many(): void {`,
+      ...targets.map((t) => `  ${t}();`),
+      "}",
+      "",
+      "// Exactly the default limit: reached, but nothing was lost.",
+      "export function exactlyTwo(): void {",
+      "  t0();",
+      "  t1();",
+      "}",
+      "",
+      "export function justOne(): void {",
+      "  t0();",
+      "}",
+      "",
+      "// Ten members, and the default memberLimit is 6.",
+      "export class Wide {",
+      ...methods,
+      "}",
+      "",
+    ].join("\n"),
+  });
+
+  const client = TtsgraphClient.start(root);
+  try {
+    await client.request("initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "test-graph", version: "0.0.0" },
+    });
+    client.notify("notifications/initialized", {});
+
+    const result = (await client.request("tools/call", {
+      name: "inspect_typescript_graph",
+      arguments: graphArguments({
+        thinking: "What do these symbols depend on?",
+        request: {
+          type: "details",
+          handles: ["many", "exactlyTwo", "justOne", "Wide"],
+        },
+      }),
+    })) as ToolResult;
+
+    const details = detailsOf(result);
+    const nodeOf = (name: string) =>
+      details.nodes.find((node) => node.name === name);
+
+    // Twenty calls, two returned: the case the marker exists for.
+    const many = nodeOf("many");
+    assert.strictEqual(many?.calls?.length, 2, "the call list is cut to the cap");
+    assert.deepStrictEqual(
+      many?.truncated,
+      ["calls"],
+      `a cut call list names itself: ${JSON.stringify(many?.truncated)}`,
+    );
+
+    // The boundary: exactly at the limit is whole, so the marker stays off. A
+    // check that only asked "did we reach the cap" would mark this one.
+    const exactlyTwo = nodeOf("exactlyTwo");
+    assert.strictEqual(exactlyTwo?.calls?.length, 2, "both calls are returned");
+    assert.strictEqual(
+      exactlyTwo?.truncated,
+      undefined,
+      `a list that fits exactly is not marked: ${JSON.stringify(exactlyTwo?.truncated)}`,
+    );
+
+    // Under the limit: nothing to say.
+    assert.strictEqual(
+      nodeOf("justOne")?.truncated,
+      undefined,
+      "a list under the cap is not marked",
+    );
+
+    // A different field, cut by a different limit, named on its own.
+    const wide = nodeOf("Wide");
+    assert.strictEqual(wide?.members?.length, 6, "the member list is cut to the cap");
+    assert.deepStrictEqual(
+      wide?.truncated,
+      ["members"],
+      `a cut member list names itself, and only itself: ${JSON.stringify(wide?.truncated)}`,
+    );
+  } finally {
+    client.endStdin();
+    await client.waitForExit();
+  }
+};


### PR DESCRIPTION
Closes #737.

## Intent

`details` caps every list it returns and the payload never said so. `calls: [2 refs]` is the same bytes whether the symbol calls two things or forty, while `RESULT_AUDIT` tells the caller the result is "bounded only where `truncated` says" and to re-verify nothing. `ITtscGraphDetails` had no `truncated` field at all — it exists on tour, entrypoints and trace, but not here — so the audit promised a marker the type could not express, and a slice read as the whole. That is the defect #732 was about, arriving through the neighbor lists instead of the value set.

Each node now names what it lost:

```json
{ "name": "many", "calls": [ ... 2 refs ... ], "truncated": ["calls"] }
```

It points, it does not dump. The graph still holds all of it and the request's own limits still say how much to send; the marker only tells the caller whether looking further is worth it, which is what an index is for. `literalsTruncated` from #735 folds into this field before it ever shipped in a release.

## The marker measures loss, not the cap

Reaching a limit is not the same fact as there being more. A function calling exactly `dependencyLimit` things is whole, and marking it would lie in the direction the marker exists to prevent — so dedup and counting run past the limit and compare. Members are still built one page at a time, because a member's signature is a file read; only the count runs long, off edges already in memory.

## Also here

A signature no longer runs past its own declaration. `signatureOf` stopped at a brace, a trailing semicolon, or the four-line cap, so a declaration ending in none of those read its neighbors instead. The span was already on the node. This is independent of the marker and is a plain correctness fix.

## Scope

Nothing else moves. `truncated` is a `details` field; tour, lookup and trace do not carry it and do not read `members`. No node or edge is added, so no ranking, flow, seed or payload outside `details` changes — this needs no re-measure of the graph arm.

`ITtscGraphApplication` and `RESULT_AUDIT` are untouched.

## Verification

Left to CI, per instruction. Before the split I drove the real `runDetails` over a real `ttscgraph dump` of a fixture with a function calling twenty others, one calling exactly two, one calling one, and a class of ten methods:

```
many        calls=2 members=undefined truncated=["calls"]
exactlyTwo  calls=2 members=undefined truncated=undefined
justOne     calls=1 members=undefined truncated=undefined
Wide        calls=undefined members=6 truncated=["members"]
```

`exactlyTwo` is the assertion that matters: at the cap and unmarked.

New case `test_ttscgraph_details_names_each_field_it_cut.ts` pins that end to end through the real binary, including the boundary. The two literal cases from #735 are updated to the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ewvzm1RFiUHq22akQ6nPFb
