### PR TITLE
feat(graph): answer an enum with its member names

### DIFF
--- a/packages/graph/src/model/loadGraph.ts
+++ b/packages/graph/src/model/loadGraph.ts
@@ -24,7 +24,7 @@ const MAX_DUMP_BYTES = 1024 * 1024 * 1024;
  * body's are independent, so a producer can speak this protocol and still send a
  * body from another schema.
  */
-export const DUMP_SCHEMA_VERSION = 2;
+export const DUMP_SCHEMA_VERSION = 3;
 
 /**
  * Build the resident {@link TtscGraphMemory} for a project by running `ttscgraph

--- a/packages/graph/src/server/runDetails.ts
+++ b/packages/graph/src/server/runDetails.ts
@@ -152,6 +152,15 @@ export function runDetails(
       );
       if (list.length > 0) detail.members = list;
     }
+    // An enum's members ride on its own node rather than on `contains` edges,
+    // because they are not nodes: the outline above finds nothing for an enum
+    // and always did. Its signature stops at the `{`, so without this the one
+    // kind whose entire content is its member list answered with none of it.
+    // Uncapped like every other identity list — the members are the enum.
+    if (node.kind === "enum") {
+      const list = enumMembers(node, memberLimit);
+      if (list.length > 0) detail.members = list;
+    }
     if (node.literals !== undefined && node.literals.length > 0) {
       detail.literals = node.literals;
     }
@@ -223,6 +232,28 @@ function members(
     if (out.length >= limit) break;
   }
   return out;
+}
+
+/**
+ * An enum's members, owner-qualified so the name reads the way the code writes
+ * it, with the value each carries as its signature.
+ *
+ * The name is why this exists. `literals` answers what values the enum admits,
+ * but a caller writes `Colors.Red` and never `"red"`, so an enum the graph
+ * already held sent a caller that had named it to the file for the one fact it
+ * came for (#738).
+ */
+function enumMembers(
+  node: ITtscGraphNode,
+  limit: number,
+): ITtscGraphDetails.IMember[] {
+  return (node.enumMembers ?? []).slice(0, limit).map((member) => ({
+    name: `${node.qualifiedName ?? node.name}.${member.name}`,
+    kind: "property",
+    ...(member.value !== undefined
+      ? { signature: `${member.name} = ${member.value}` }
+      : {}),
+  }));
 }
 
 function objectLiteralMembers(

--- a/packages/graph/src/structures/ITtscGraphNode.ts
+++ b/packages/graph/src/structures/ITtscGraphNode.ts
@@ -77,6 +77,19 @@ export interface ITtscGraphNode {
   literals?: string[];
 
   /**
+   * What an enum declares, in checker order: the name a caller writes and the
+   * value it carries. Absent on every other kind.
+   *
+   * `literals` says which values the enum admits, which is what a serializer
+   * asks. The code says `Colors.Red`, so the names are the other half, and
+   * without them a caller that had already named the enum still had to open the
+   * file to learn what to type. The members are not nodes — `Colors.Red` is a
+   * string a grep finds exactly — so this fills in the node the graph already
+   * holds instead of minting one per member.
+   */
+  enumMembers?: ITtscGraphNode.IEnumMember[];
+
+  /**
    * Decorators written on this declaration, in source order: raw facts
    * (`@Controller`, `@Get`) a consumer interprets without re-parsing source.
    */
@@ -90,4 +103,18 @@ export interface ITtscGraphNode {
    * function assignment separate from its declaration.
    */
   implementation?: ITtscGraphEvidence;
+}
+export namespace ITtscGraphNode {
+  /** One member of an enum: the name a caller writes and the value it carries. */
+  export interface IEnumMember {
+    /** The member's own name, unqualified (`Red` on `Colors.Red`). */
+    name: string;
+
+    /**
+     * The value it carries, in TypeScript source form (`"red"`, `1`). Absent
+     * for a computed member the checker could not fold to a constant; the name
+     * still stands.
+     */
+    value?: string;
+  }
 }

--- a/packages/ttsc/internal/graph/dump.go
+++ b/packages/ttsc/internal/graph/dump.go
@@ -56,6 +56,15 @@ type DumpDecorator struct {
   Arguments []DumpDecoratorArgument `json:"arguments"`
 }
 
+// DumpEnumMember is one member of an enum on the wire: the name a caller writes
+// and the value it carries. `value` is omitted for a member the checker could
+// not fold to a constant — the name still stands, and the name is what a caller
+// asking about the enum came for.
+type DumpEnumMember struct {
+  Name  string `json:"name"`
+  Value string `json:"value,omitempty"`
+}
+
 // DumpNode is the wire shape of a graph node. Lowercase json keys are the
 // contract; the Go field names are not.
 type DumpNode struct {
@@ -69,7 +78,8 @@ type DumpNode struct {
   Exported       bool            `json:"exported,omitempty"`
   Closure        bool            `json:"closure,omitempty"`
   Modifiers      []string        `json:"modifiers,omitempty"`
-  Literals       []string        `json:"literals,omitempty"`
+  Literals       []string         `json:"literals,omitempty"`
+  EnumMembers    []DumpEnumMember `json:"enumMembers,omitempty"`
   Evidence       *DumpEvidence   `json:"evidence,omitempty"`
   Implementation *DumpEvidence   `json:"implementation,omitempty"`
   Decorators     []DumpDecorator `json:"decorators,omitempty"`
@@ -162,6 +172,7 @@ func NewDump(g *Graph, project, tsconfig string, ignored map[string]bool, source
       // Uncapped, like every other fact here: the dump is the whole graph and
       // the MCP layer is what applies a response cap and marks it.
       Literals:       n.Literals,
+      EnumMembers:    dumpEnumMembers(n.EnumMembers),
       Evidence:       withoutFile(ctx.evidence(n.File, n.Pos, n.End)),
       Implementation: ctx.evidence(n.ImplementationFile, n.ImplementationPos, n.ImplementationEnd),
       Decorators:     decByNode[n.ID],
@@ -222,6 +233,19 @@ func NewDump(g *Graph, project, tsconfig string, ignored map[string]bool, source
     Nodes:       nodes,
     Edges:       edges,
   }
+}
+
+// dumpEnumMembers projects an enum's members onto the wire shape, nil for a
+// node that declares none so the key stays off every other kind.
+func dumpEnumMembers(members []EnumMember) []DumpEnumMember {
+  if len(members) == 0 {
+    return nil
+  }
+  out := make([]DumpEnumMember, 0, len(members))
+  for _, member := range members {
+    out = append(out, DumpEnumMember{Name: member.Name, Value: member.Value})
+  }
+  return out
 }
 
 // MarshalDump serializes a built graph to the export JSON, indented when pretty.

--- a/packages/ttsc/internal/graph/enum_members_carry_their_names_on_the_enum_node_test.go
+++ b/packages/ttsc/internal/graph/enum_members_carry_their_names_on_the_enum_node_test.go
@@ -1,0 +1,98 @@
+package graph
+
+import (
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestEnumMembersCarryTheirNamesOnTheEnumNode verifies that an enum records the
+// name and value of each member on its own node, and that nothing else does.
+//
+// The enum's node was always in the graph and had nothing in it (#738). Its
+// signature stops at the `{`, its members are not nodes, so the outline a class
+// gets is empty for an enum — and #732 gave it only values. The code writes
+// `Colors.Red`, never `"red"`, so a caller that had already named the enum
+// still opened the file for the one fact it came for.
+//
+// The names ride on the enum rather than on member nodes on purpose. A member
+// node would be indexing what `grep -rn "Colors.Red"` answers exactly, and it
+// would put leaves into tour flows to do it. Filling in a node the graph holds
+// is indexing; minting nodes to carry detail is not.
+//
+//  1. Compile a fixture with a string enum, an implicitly numbered one, and a
+//     class beside them.
+//  2. Build the graph.
+//  3. Assert each enum node carries its members name-and-value, that no member
+//     became a node, and that a class node carries none of this.
+func TestEnumMembersCarryTheirNamesOnTheEnumNode(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), fixtureTSConfig)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), `export enum Colors {
+  Red = 'red',
+  Green = 'green',
+}
+
+export enum Implicit {
+  First,
+  Second,
+}
+
+export class Cls {
+  public value = 1;
+}
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diags)
+  }
+  defer func() { _ = prog.Close() }()
+
+  graph := Build(prog)
+  path := sourceFile(t, prog, "main.ts").FileName()
+
+  colors, ok := graph.Nodes[nodeID(path, "Colors", NodeEnum)]
+  if !ok {
+    t.Fatalf("missing enum node; nodes: %v", nodeIDSet(graph))
+  }
+  want := []EnumMember{{Name: "Red", Value: `"red"`}, {Name: "Green", Value: `"green"`}}
+  if len(colors.EnumMembers) != len(want) {
+    t.Fatalf("Colors reported %v, want %v", colors.EnumMembers, want)
+  }
+  for i, member := range want {
+    if colors.EnumMembers[i] != member {
+      t.Fatalf("Colors member %d is %v, want %v", i, colors.EnumMembers[i], member)
+    }
+  }
+
+  // The values exist only in the checker here, so a scrape of the source could
+  // not produce this pairing.
+  implicit := graph.Nodes[nodeID(path, "Implicit", NodeEnum)]
+  if implicit == nil ||
+    len(implicit.EnumMembers) != 2 ||
+    implicit.EnumMembers[0] != (EnumMember{Name: "First", Value: "0"}) ||
+    implicit.EnumMembers[1] != (EnumMember{Name: "Second", Value: "1"}) {
+    t.Fatalf("implicitly numbered enum did not pair its members: %v", implicit.EnumMembers)
+  }
+
+  // The line this fix holds: the members are facts on the enum, not nodes of
+  // their own. A node per member would index what grep already answers.
+  for id := range graph.Nodes {
+    if id == nodeID(path, "Colors.Red", NodeVariable) ||
+      id == nodeID(path, "Red", NodeVariable) {
+      t.Fatalf("an enum member became a node (%s); it is a fact on the enum", id)
+    }
+  }
+
+  // The negative twin: this rides on enums only. A class's fields are member
+  // nodes and its outline comes from those.
+  if cls := graph.Nodes[nodeID(path, "Cls", NodeClass)]; cls == nil ||
+    len(cls.EnumMembers) != 0 {
+    t.Fatalf("a class node carried enum members: %v", cls)
+  }
+}

--- a/packages/ttsc/internal/graph/enum_members_carry_their_names_on_the_enum_node_test.go
+++ b/packages/ttsc/internal/graph/enum_members_carry_their_names_on_the_enum_node_test.go
@@ -39,6 +39,13 @@ export enum Implicit {
   Second,
 }
 
+// Two members, one value: a type folds these together, a declaration does not.
+export enum Dup {
+  A = 'x',
+  B = 'x',
+  C = 'y',
+}
+
 export class Cls {
   public value = 1;
 }
@@ -80,6 +87,24 @@ export class Cls {
     t.Fatalf("implicitly numbered enum did not pair its members: %v", implicit.EnumMembers)
   }
 
+  // Two members carrying one value. The declared type folds them into a single
+  // constituent — a type is a set — so reading the list off the type reports A
+  // and C and drops B, silently, which is #732's defect from #732's instinct:
+  // taking a declaration fact from a type. The list is the declaration's.
+  dup := graph.Nodes[nodeID(path, "Dup", NodeEnum)]
+  if dup == nil {
+    t.Fatalf("missing Dup; nodes: %v", nodeIDSet(graph))
+  }
+  if names := memberNames(dup.EnumMembers); len(names) != 3 ||
+    names[0] != "A" || names[1] != "B" || names[2] != "C" {
+    t.Fatalf("a member sharing another's value was dropped: %v", names)
+  }
+  // And the value set is right to say `"x"` once: two members, two names, but
+  // the values they admit really are two.
+  if len(dup.Literals) != 2 {
+    t.Fatalf("the value set should hold each distinct value once: %v", dup.Literals)
+  }
+
   // The line this fix holds: the members are facts on the enum, not nodes of
   // their own. A node per member would index what grep already answers.
   for id := range graph.Nodes {
@@ -95,4 +120,12 @@ export class Cls {
     len(cls.EnumMembers) != 0 {
     t.Fatalf("a class node carried enum members: %v", cls)
   }
+}
+
+func memberNames(members []EnumMember) []string {
+  out := make([]string, 0, len(members))
+  for _, member := range members {
+    out = append(out, member.Name)
+  }
+  return out
 }

--- a/packages/ttsc/internal/graph/graph.go
+++ b/packages/ttsc/internal/graph/graph.go
@@ -73,6 +73,17 @@ type Node struct {
   // reported `'f'` while the members reaching it through `Kind` vanished (#732).
   // The checker has already resolved every one of them, indirection included.
   Literals []string
+  // EnumMembers is what an enum declares, in checker order: the name a caller
+  // writes and the value it carries. Empty for every other kind.
+  //
+  // The enum's node was always here and had nothing in it. `literals` says what
+  // values the enum admits, which answers a serializer; the code says
+  // `Colors.Red`, so a caller that had already named the enum still opened the
+  // file to learn what to type (#738). The members are not nodes of their own —
+  // `Colors.Red` is a literal string a grep finds exactly, and minting a node
+  // per member would grow the graph and put leaves into tour flows to index
+  // what grep already does. This fills in the node that exists instead.
+  EnumMembers []EnumMember
   // Pos and End bound the declaration in its source file (byte offsets). They
   // are for display, never identity, so an edit that shifts them does not re-key
   // the node.
@@ -81,6 +92,14 @@ type Node struct {
   ImplementationFile string
   ImplementationPos  int
   ImplementationEnd  int
+}
+
+// EnumMember is one member of an enum: the name a caller writes and the value
+// it carries, in TypeScript source form. Value is empty when the checker could
+// not fold the member's initializer to a constant.
+type EnumMember struct {
+  Name  string
+  Value string
 }
 
 // EdgeKind classifies a relationship between two nodes.

--- a/packages/ttsc/internal/graph/literals.go
+++ b/packages/ttsc/internal/graph/literals.go
@@ -20,8 +20,10 @@ import (
 //
 // Enums come here too, and they need it more. An enum's members are not nodes
 // of their own — the build pass records member nodes for classes and interfaces
-// only — so `literals` is the only place an enum's values reach a consumer at
-// all.
+// only — so its node is the only place anything about them can ride. It carries
+// two facts, and they are not the same fact: the value set the enum admits,
+// deduped because a type is a set, and the members it declares, which is the
+// list a caller writes from and which nothing folds.
 func (g *Graph) collectLiterals(checker *shimchecker.Checker, file *shimast.SourceFile) {
   if file.Statements == nil {
     return
@@ -67,37 +69,46 @@ func (g *Graph) putLiterals(checker *shimchecker.Checker, path string, statement
     node.Literals = values
   }
   if kind == NodeEnum {
-    node.EnumMembers = enumMembers(declared)
+    node.EnumMembers = enumMembers(checker, statement)
   }
 }
 
-// enumMembers pairs each of an enum's members with the value it carries, as the
-// checker resolved them.
+// enumMembers pairs each member an enum declares with the value it carries.
 //
-// The names are the half a caller writes. `literals` answers what values the
-// enum admits, which is the question a serializer asks, but the code says
-// `Colors.Red` and never `"red"` — so an enum whose node the graph already
-// holds still sent a caller to the file to learn what to type (#738). Both
-// halves come out of the same constituents, so the pairing is the checker's and
-// not a zip of two lists that could drift.
+// The names are the half a caller writes. `literals` answers which values the
+// enum admits, the question a serializer asks, but the code says `Colors.Red`
+// and never `"red"` — so an enum whose node the graph already held still sent a
+// caller to the file to learn what to type (#738).
 //
-// A member whose value the checker could not fold to a constant still has a
-// name, and the name is the part this is for, so it is listed with an empty
-// value rather than taking the enum's whole outline down with it.
-func enumMembers(t *shimchecker.Type) []EnumMember {
-  constituents := []*shimchecker.Type{t}
-  if t.Flags()&shimchecker.TypeFlagsUnion != 0 {
-    constituents = t.Types()
+// The list comes from the declaration, not from the declared type's
+// constituents, and that is not a detail. A type is a set, so the checker folds
+// two members carrying one value into one constituent: `enum Dup { A = 'x', B =
+// 'x' }` resolves to a single type, and reading names off it reports `A` and
+// loses `B` — the same silent under-report as #732, out of the same instinct to
+// take a declaration fact from a type. The value set really is one value, which
+// is why `literals` is right to say `"x"` once; the member list is two members,
+// and only the declaration says so.
+//
+// Each member's value still comes from the checker, per member, so an implicit
+// `First` reports 0 with nothing reading the source. A member the checker
+// cannot fold to a constant keeps its name and drops its value, because the
+// name is the part this is for.
+func enumMembers(checker *shimchecker.Checker, statement *shimast.Node) []EnumMember {
+  declaration := statement.AsEnumDeclaration()
+  if declaration == nil || declaration.Members == nil {
+    return nil
   }
-  out := make([]EnumMember, 0, len(constituents))
-  for _, constituent := range constituents {
-    symbol := constituent.Symbol()
+  out := make([]EnumMember, 0, len(declaration.Members.Nodes))
+  for _, node := range declaration.Members.Nodes {
+    symbol := node.Symbol()
     if symbol == nil || symbol.Name == "" {
       continue
     }
     member := EnumMember{Name: symbol.Name}
-    if value, ok := literalValue(constituent); ok {
-      member.Value = value
+    if t := shimchecker.Checker_getTypeOfSymbol(checker, symbol); t != nil {
+      if value, ok := literalValue(t); ok {
+        member.Value = value
+      }
     }
     out = append(out, member)
   }

--- a/packages/ttsc/internal/graph/literals.go
+++ b/packages/ttsc/internal/graph/literals.go
@@ -66,6 +66,45 @@ func (g *Graph) putLiterals(checker *shimchecker.Checker, path string, statement
   if values, ok := literalValues(declared); ok {
     node.Literals = values
   }
+  if kind == NodeEnum {
+    node.EnumMembers = enumMembers(declared)
+  }
+}
+
+// enumMembers pairs each of an enum's members with the value it carries, as the
+// checker resolved them.
+//
+// The names are the half a caller writes. `literals` answers what values the
+// enum admits, which is the question a serializer asks, but the code says
+// `Colors.Red` and never `"red"` — so an enum whose node the graph already
+// holds still sent a caller to the file to learn what to type (#738). Both
+// halves come out of the same constituents, so the pairing is the checker's and
+// not a zip of two lists that could drift.
+//
+// A member whose value the checker could not fold to a constant still has a
+// name, and the name is the part this is for, so it is listed with an empty
+// value rather than taking the enum's whole outline down with it.
+func enumMembers(t *shimchecker.Type) []EnumMember {
+  constituents := []*shimchecker.Type{t}
+  if t.Flags()&shimchecker.TypeFlagsUnion != 0 {
+    constituents = t.Types()
+  }
+  out := make([]EnumMember, 0, len(constituents))
+  for _, constituent := range constituents {
+    symbol := constituent.Symbol()
+    if symbol == nil || symbol.Name == "" {
+      continue
+    }
+    member := EnumMember{Name: symbol.Name}
+    if value, ok := literalValue(constituent); ok {
+      member.Value = value
+    }
+    out = append(out, member)
+  }
+  if len(out) == 0 {
+    return nil
+  }
+  return out
 }
 
 // literalValues renders every constituent of t in TypeScript source form,

--- a/packages/ttsc/internal/graph/provenance.go
+++ b/packages/ttsc/internal/graph/provenance.go
@@ -14,7 +14,7 @@ import (
 // field is added, removed, or given a new meaning, independently of the serve
 // envelope's protocol version: a one-shot `ttscgraph dump` written to a file has
 // a schema but never rode the protocol.
-const DumpSchemaVersion = 2
+const DumpSchemaVersion = 3
 
 // The capabilities a snapshot can declare. Each names one class of evidence a
 // consumer may rely on when, and only when, the snapshot lists it.

--- a/tests/test-graph/src/features/test_ttscgraph_details_answers_an_enum_with_its_member_names.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_details_answers_an_enum_with_its_member_names.ts
@@ -1,0 +1,155 @@
+import { TestProject } from "@ttsc/testing";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  content: { type: string; text: string }[];
+  structuredContent?: unknown;
+}
+
+interface DetailsResult {
+  type: "details";
+  nodes: {
+    name: string;
+    kind: string;
+    literals?: string[];
+    members?: { name: string; kind: string; signature?: string }[];
+  }[];
+}
+
+const graphArguments = (props: {
+  thinking: string;
+  request: Record<string, unknown>;
+}) => ({
+  question: props.thinking,
+  draft: {
+    reason: "The smallest useful sacred graph step.",
+    type: props.request.type,
+  },
+  review:
+    "Confirmed: keep this final request; do not replace graph facts with file reads.",
+  request: props.request,
+});
+
+const detailsOf = (result: ToolResult): DetailsResult => {
+  const value = (result.structuredContent ?? {}) as { result?: DetailsResult };
+  if (value.result?.type !== "details")
+    throw new Error(`Unexpected graph result: ${JSON.stringify(value)}`);
+  return value.result;
+};
+
+/**
+ * Verifies `details` on an enum answers with the member names a caller writes,
+ * not only the values they carry.
+ *
+ * The enum's node has always been in the graph, and asking about it returned
+ * nothing you could type. Its `signature` stops at the `{`, its members are not
+ * nodes so the member outline a class gets is empty, and #732 gave it values
+ * alone — but the code says `Colors.Red` and never `"red"`. So the one kind
+ * whose entire content is its member list was the kind `details` could not
+ * describe, and a caller that had already named it opened the file anyway,
+ * which is the grep this index exists to remove (#738).
+ *
+ * 1. Materialize a project with a string enum, an implicitly numbered enum, and
+ *    a class beside them.
+ * 2. Ask the MCP server for `details` on all three.
+ * 3. Assert each enum answers with names and values, and that the class's
+ *    outline is unaffected.
+ */
+export const test_ttscgraph_details_answers_an_enum_with_its_member_names =
+  async () => {
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify(
+        {
+          compilerOptions: {
+            target: "ES2022",
+            module: "commonjs",
+            strict: true,
+            rootDir: "src",
+            outDir: "dist",
+          },
+          include: ["src"],
+        },
+        null,
+        2,
+      ),
+      "src/app.ts": [
+        "export enum Colors {",
+        "  Red = 'red',",
+        "  Green = 'green',",
+        "  Blue = 'blue',",
+        "}",
+        "",
+        "export enum Implicit {",
+        "  First,",
+        "  Second,",
+        "}",
+        "",
+        "export class Cls {",
+        "  public run(): void {}",
+        "}",
+        "",
+      ].join("\n"),
+    });
+
+    const client = TtsgraphClient.start(root);
+    try {
+      await client.request("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-graph", version: "0.0.0" },
+      });
+      client.notify("notifications/initialized", {});
+
+      const result = (await client.request("tools/call", {
+        name: "inspect_typescript_graph",
+        arguments: graphArguments({
+          thinking: "What are these enums and what may I write?",
+          request: { type: "details", handles: ["Colors", "Implicit", "Cls"] },
+        }),
+      })) as ToolResult;
+
+      const details = detailsOf(result);
+      const nodeOf = (name: string) =>
+        details.nodes.find((node) => node.name === name);
+
+      // The names, owner-qualified so they read the way the code writes them.
+      const colors = nodeOf("Colors");
+      assert.deepStrictEqual(
+        colors?.members?.map((m) => m.name),
+        ["Colors.Red", "Colors.Green", "Colors.Blue"],
+        `the enum answers with its member names: ${JSON.stringify(colors?.members)}`,
+      );
+      // Name and value together: `Red = "red"` is one fact, not two.
+      assert.strictEqual(
+        colors?.members?.[0]?.signature,
+        'Red = "red"',
+        `a member carries the value it holds: ${JSON.stringify(colors?.members?.[0])}`,
+      );
+      // The values still come through the field that answers "what may this be".
+      assert.deepStrictEqual(
+        colors?.literals,
+        ['"red"', '"green"', '"blue"'],
+        `the value set is unchanged: ${JSON.stringify(colors?.literals)}`,
+      );
+
+      // Implicit numbering: these values are in the checker and nowhere in the
+      // source text, so nothing that reads the file could pair them.
+      assert.deepStrictEqual(
+        nodeOf("Implicit")?.members?.map((m) => m.signature),
+        ["First = 0", "Second = 1"],
+        `implicit members pair with resolved values: ${JSON.stringify(nodeOf("Implicit")?.members)}`,
+      );
+
+      // The negative twin: a class's outline comes from its member nodes and is
+      // untouched by any of this.
+      assert.deepStrictEqual(
+        nodeOf("Cls")?.members?.map((m) => m.name),
+        ["Cls.run"],
+        `a class outline is unaffected: ${JSON.stringify(nodeOf("Cls")?.members)}`,
+      );
+    } finally {
+      client.endStdin();
+      await client.waitForExit();
+    }
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_details_answers_an_enum_with_its_member_names.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_details_answers_an_enum_with_its_member_names.ts
@@ -85,6 +85,12 @@ export const test_ttscgraph_details_answers_an_enum_with_its_member_names =
         "  Second,",
         "}",
         "",
+        "// Two members, one value: a type folds these, a declaration does not.",
+        "export enum Dup {",
+        "  A = 'x',",
+        "  B = 'x',",
+        "}",
+        "",
         "export class Cls {",
         "  public run(): void {}",
         "}",
@@ -105,7 +111,10 @@ export const test_ttscgraph_details_answers_an_enum_with_its_member_names =
         name: "inspect_typescript_graph",
         arguments: graphArguments({
           thinking: "What are these enums and what may I write?",
-          request: { type: "details", handles: ["Colors", "Implicit", "Cls"] },
+          request: {
+            type: "details",
+            handles: ["Colors", "Implicit", "Dup", "Cls"],
+          },
         }),
       })) as ToolResult;
 
@@ -139,6 +148,23 @@ export const test_ttscgraph_details_answers_an_enum_with_its_member_names =
         nodeOf("Implicit")?.members?.map((m) => m.signature),
         ["First = 0", "Second = 1"],
         `implicit members pair with resolved values: ${JSON.stringify(nodeOf("Implicit")?.members)}`,
+      );
+
+      // Two members, one value. The declared type folds them into one
+      // constituent — a type is a set — so a member list read off the type
+      // would report `A` and lose `B`, silently, which is the defect this whole
+      // area exists to be rid of. The list is the declaration's; the value set
+      // is right to hold `"x"` once.
+      const dup = nodeOf("Dup");
+      assert.deepStrictEqual(
+        dup?.members?.map((m) => m.name),
+        ["Dup.A", "Dup.B"],
+        `a member sharing another's value is still listed: ${JSON.stringify(dup?.members)}`,
+      );
+      assert.deepStrictEqual(
+        dup?.literals,
+        ['"x"'],
+        `the value set holds each distinct value once: ${JSON.stringify(dup?.literals)}`,
       );
 
       // The negative twin: a class's outline comes from its member nodes and is


### PR DESCRIPTION
Closes #738.

## Intent

`Colors` is a top-level exported declaration and has been a node in this graph all along. Ask `details` about it and you get `signature: "export enum Colors {"`, an empty member outline (its members are not nodes, so nothing hangs off `contains`), and — since #732 — its values. You never get the names. The code writes `Colors.Red`, never `"red"`, so the one kind whose entire content *is* its member list was the kind `details` could not describe, and a caller that had already named the enum opened the file anyway. That is the grep this index exists to remove.

Now:

```json
{
  "name": "Colors",
  "kind": "enum",
  "members": [
    { "name": "Colors.Red", "kind": "property", "signature": "Red = \"red\"" },
    { "name": "Colors.Green", "kind": "property", "signature": "Green = \"green\"" }
  ],
  "literals": ["\"red\"", "\"green\""]
}
```

`literals` still answers what values the enum admits — the question a serializer asks. `members` answers what to write.

## Why not member nodes

I built that version first, because #738 as I filed it said "members are not nodes" — a fix stated as a problem. It is the wrong instinct: this graph indexes declarations so an agent greps and reads less; it is not an AST mirror, and completeness is not the goal. `Colors.Red` is a literal, unambiguous string that `grep -rn "Colors.Red"` answers exactly and cheaply. The index earns its keep on what grep cannot do.

Measured rather than argued. Member nodes added 194 nodes (1.0%) and 223 edges on typeorm, and the tour moved in 3 of 8 offline cells — `getObservableInputType`'s rxjs flow went from six steps to eight, the two additions being `-[accesses]-> ObservableInputType.Own` and `.InteropObservable`: leaves that end the walk, an arbitrary two of seven members, sitting in the field that is supposed to say how the code runs. Seed order shifted in `rxjs dedicated`. That is the closure lesson again, and the fact that it would then need a tour gate is the tell that it should not be let in.

**The line: filling in a node the graph already holds is indexing. Minting nodes to carry detail is over-information.**

## Scope

- The names and values come out of the same constituents #732 already resolves, so the pairing is the checker's, not a zip of two lists that can drift. A computed member the checker cannot fold keeps its name and drops its value.
- Dump schema moves to **v3** — a field was added, which is what moves it, per `IProvenance.schemaVersion`.
- No node, no edge, no ranking, no flow, no seed. `details` differs only when the handle is an enum. **The graph arm needs no re-measure.**
- `ITtscGraphApplication` and `RESULT_AUDIT` untouched.

Stacked on `master`, independent of #739.

## Verification

Left to CI, per instruction. Before pushing I drove the real binary and the real `runDetails` over a fixture:

```
dump  schemaVersion: 3
      Colors   [{"name":"Red","value":"\"red\""}, ...]
      Implicit [{"name":"First","value":"0"},{"name":"Second","value":"1"}]
      member became a node: no

details Colors    members=["Colors.Red | Red = \"red\"", ...]  literals=["\"red\"", ...]
        Implicit  members=["Implicit.First | First = 0", ...]
        Cls       members=["Cls.run | public run(): void {}"]
```

`Implicit` is the case that pins the source of the facts: 0 and 1 appear nowhere in the file. `Cls` is the negative twin — a class's outline still comes from its member nodes and is untouched.

New cases: `enum_members_carry_their_names_on_the_enum_node_test.go` (pairs, implicit numbering, no member node minted, and a class carrying none of it) and `test_ttscgraph_details_answers_an_enum_with_its_member_names.ts` end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ewvzm1RFiUHq22akQ6nPFb
