### PR TITLE
docs(ttsc): persist the source-plugin cache across container builds

### DIFF
--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -267,7 +267,8 @@ function compileSourcePlugin(opts: {
             .join(", ")}`;
     process.stderr.write(
       `ttsc: building ${opts.label} "${opts.pluginName}" from ${opts.source}${extra} ` +
-        `(this runs once per cache key and can take several minutes on a cold Go cache)\n`,
+        `(this runs once per cache key and can take several minutes on a cold Go cache) ` +
+        `See https://ttsc.dev/docs/ttsc/compile#plugin-cache to persist it across builds.\n`,
     );
   }
 

--- a/website/src/content/docs/faq.mdx
+++ b/website/src/content/docs/faq.mdx
@@ -49,7 +49,7 @@ No. `ttsc` bundles its own Go toolchain and uses it to compile plugin binaries o
 
 ## Why is the first build slow?
 
-On a fresh checkout, `ttsc` compiles each plugin binary into the **project-local** cache the first time you run it. The cache lives in the workspace's `node_modules/.cache/ttsc` (the `find-cache-dir` convention); in a monorepo it resolves to the workspace root's `node_modules`, so every package builds a given plugin once and shares it. On a typical machine a build is under 10 seconds per plugin and happens once per source-plugin content key. Pre-warm with `npx ttsc prepare`. Drop the cache with `npx ttsc clean`. See [Compile → Plugin cache](/docs/ttsc/compile#plugin-cache) for cache locations and overrides.
+On a fresh checkout, `ttsc` compiles each plugin binary into the **project-local** cache the first time you run it. The cache lives in the workspace's `node_modules/.cache/ttsc` (the `find-cache-dir` convention); in a monorepo it resolves to the workspace root's `node_modules`, so every package builds a given plugin once and shares it. A small transform compiles in seconds, but a plugin that links a full native host (such as `typia`, which bundles the TypeScript-Go checker alongside its own transform) can take several minutes on a cold Go cache: a fresh CI worker, or a machine that has never built it. Either way it happens once per source-plugin content key, and it recurs on every build unless you persist the cache (see [Persisting the cache in containers](/docs/ttsc/compile#plugin-cache)). Pre-warm with `npx ttsc prepare`. Drop the cache with `npx ttsc clean`. See [Compile → Plugin cache](/docs/ttsc/compile#plugin-cache) for cache locations and overrides.
 
 ## Does `ttsx` replace `tsx` / `ts-node`?
 

--- a/website/src/content/docs/setup/unplugin.mdx
+++ b/website/src/content/docs/setup/unplugin.mdx
@@ -201,6 +201,8 @@ A plugin that knows exactly which declarations it consulted can go the other way
 
 The transform cache validates against the same input set: every file under the project root plus the graph-reported inputs outside it. Hosts that keep one cache for the process lifetime instead of per build (Metro workers, the Turbopack loader, Bun) therefore recompile when an out-of-project input such as a `node_modules` declaration or a monorepo sibling source changes, not only on in-project edits.
 
+This section is about the **transform** cache (which files a rebuild depends on), not the **source-plugin binary** cache (the compiled Go plugin ttsc builds on first use). They are independent: persisting a bundler cache such as Next.js `.next/cache` does not carry the plugin binary across builds, and a fresh CI or container build recompiles the plugin (the `ttsc: building source plugin ...` line) even with a warm bundler cache. To keep that first-build compile from recurring on every build, persist the binary cache as described in [Compile → Plugin cache](/docs/ttsc/compile#plugin-cache). In a monorepo, run `ttsc prepare` from the same project directory the bundler builds, so the warmed binary matches the cache key the bundler build looks up.
+
 ## CLI or bundler?
 
 Whichever tool owns the build runs the pass. A plain Node library builds with `npx ttsc`. A frontend behind Vite or webpack builds through `@ttsc/unplugin`. A monorepo with both uses both, one per package. The plugin pass is identical everywhere, and diagnostics show up wherever the bundler surfaces them.

--- a/website/src/content/docs/ttsc/compile.mdx
+++ b/website/src/content/docs/ttsc/compile.mdx
@@ -111,6 +111,30 @@ steps:
 
 Run `npx ttsc cache paths --json` to discover the exact directories instead of hardcoding them: the `cacheableRoots` field lists the minimal set a CI cache must persist (it adds `TTSC_GO_CACHE_DIR`/`GOCACHE` when either points outside the ttsc cache root). This works the same for pnpm, yarn, bun, and npm workspaces.
 
+### Persisting the cache in containers
+
+A container image build (Docker, Google Cloud Build, Cloud Run) is not a persistent runner: each build starts from a clean filesystem, so a source plugin recompiles cold on every deploy unless the compiled binary is carried forward. This is a different mechanism from the split-CI recipe above. There the cache is a directory persisted with `actions/cache`; here it has to travel inside the image build, as a build layer or a build-scoped cache.
+
+Warm the binary in its own layer, ordered before the app source is copied, and pin `TTSC_CACHE_DIR` at a stable absolute path whose basename is `ttsc`, so `ttsc clean` still owns its `plugins/` and `go-build/`:
+
+```dockerfile
+FROM node:24
+WORKDIR /app
+ENV TTSC_CACHE_DIR=/root/.cache/ttsc
+COPY package*.json ./
+RUN npm ci
+COPY tsconfig*.json ./
+RUN npx ttsc prepare        # the cold Go build happens here, once
+COPY . .
+RUN npm run build           # the bundler build reuses the warm cache
+```
+
+`ttsc prepare` builds whatever `tsconfig.json` declares, so `tsconfig.json` must be copied before it runs, or the build fails to find a project. A bundler build through `@ttsc/unplugin` reads the same tsconfig, so the warmed binary is the exact one the later build looks up. If `prepare` prints `no source plugins found`, the plugin is declared only in the bundler config; add it to `tsconfig.json` `compilerOptions.plugins` so both steps compute the same content key.
+
+An ephemeral builder (Google Cloud Build, most CI Docker builds) discards its local layer and BuildKit cache between builds, so the warm layer is reused only through a cache that outlives the build: a registry-backed layer cache (`docker build --cache-from <pushed-image> --build-arg BUILDKIT_INLINE_CACHE=1`, then deploy the built image) or a bucket-backed cache. A bare `RUN --mount=type=cache` or plain layer caching starts empty on every fresh build VM and silently recompiles. `gcloud run deploy --source` passes no cache flag and, under buildpacks, offers no layer to hold the binary; to reuse it you must take over the build (`gcloud builds submit` with a registry cache, or a prebuilt base image) rather than deploy from source.
+
+Verify the cache actually hit: on the second build the cold-build line (`ttsc: building source plugin ... this runs once per cache key`) must not appear, and `npx ttsc cache paths --json` reports the directories that hold the binary.
+
 ## See also
 
 - [TTSC · `ttsx` runner](/docs/ttsc/execute): same compile, then runs the result.


### PR DESCRIPTION
## Summary

Closes #741. A user (Vite + `@ttsc/unplugin` + typia 13) saw Google Cloud Build add ~7 minutes on every deploy, at the step `ttsc: building source plugin "typia" ... (this runs once per cache key ...)`.

**Root cause (fact-checked):** a cache-persistence gap, not an `@ttsc/unplugin` bug and not a defect. typia's source plugin links a full native host (TypeScript-Go checker + shim + typia's transform), so a cold `go build` is genuinely several minutes. The binary is content-keyed and cached at `node_modules/.cache/ttsc`, but ephemeral Cloud Build workers keep no cache between builds, so every deploy is a cache miss. `@ttsc/unplugin` only triggers the compile and already honors `TTSC_CACHE_DIR` (it builds `TtscCompiler` with no `env`, falling back to `process.env`). The fix mechanism (`TTSC_CACHE_DIR`, `ttsc prepare`, `ttsc cache paths --json`) already ships; the real problem was **discoverability** for a container/bundler user.

Orthodox, boundary-respecting action: documentation + one guarded diagnostic line. **No behavior/default change** (the workspace-local default and the deliberate absence of a machine-global cache, per #677, are untouched; ttsc does not ship prebuilt binaries — that is typia's call).

## Changes

- **`website/src/content/docs/ttsc/compile.mdx`** — new `### Persisting the cache in containers` under the stable `## Plugin cache` H2. Provider-neutral recipe: pin `TTSC_CACHE_DIR` at a basename-`ttsc` path, warm with `ttsc prepare` in a layer ordered before the app-source copy (with `tsconfig.json` copied before `prepare`, or the build cannot find a project), reuse only through a registry/bucket-backed cache (a bare local mount silently misses on ephemeral builders), an honest `gcloud run deploy --source`/buildpacks limitation, and a mandatory verify step. Distinguishes runner-build (`actions/cache`) from image-build.
- **`website/src/content/docs/setup/unplugin.mdx`** — breadcrumb distinguishing the source-plugin **binary** cache from the transform/watch cache, noting bundler caches (`.next/cache`) do not persist the binary, plus a monorepo `prepare`-cwd/key-alignment tip.
- **`website/src/content/docs/faq.mdx`** — soften "under 10 seconds" to distinguish a warm relink (seconds) from a cold native-host link like typia (minutes), and note it recurs unless the cache is persisted.
- **`packages/ttsc/src/plugin/internal/buildSourcePlugin.ts`** — append the docs URL to the cold-build message. Tail-only, preserving the substrings tests assert: the prefix `building source plugin "<name>"` and the suffix `this runs once per cache key`.

## How the decision was reached

A six-participant, three-round design discussion (compiler-host, bundler/DX, CI/DevOps, product-boundary, consumer advocate, skeptical verifier), each independently verifying against source. Unanimous on root cause and on documentation-first with no default/behavior change; explicitly rejected changing the default cache location (#677), ttsc-shipped prebuilt binaries (typia's boundary), and GOCACHE seeding. The round-3 pass produced nine source-verified must-fixes, all applied here (notably: `COPY tsconfig*.json` before `ttsc prepare` or `docker build` hard-fails; cache basename must be exactly `ttsc` so `ttsc clean` reclaims `go-build/`; the full `cloudbuild.yaml` stays in the issue reply, not the doc; the diagnostic URL targets the stable `#plugin-cache` anchor).

## Verification

- `prettier` (repo config) clean on all four files.
- Verified by grep that the appended message clause preserves every asserted substring across ~17 test files plus `scripts/ci/plugin-cache-persistence.mjs` (all substring/`doesNotMatch` regexes; tail-append breaks none). The code change is a pure string append; no control-flow or type change.
- The two new cross-links and the diagnostic URL all target the stable `#plugin-cache` H2 anchor.
- Local full test/build not run (this Windows checkout cannot run the `test-*` suites; the rollup build needs Node 24). CI validates end to end.

A concrete reporter reply (Dockerfile + `cloudbuild.yaml` with `--cache-from`/inline cache + `gcloud run deploy --image` + verify step) will be posted on #741.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
