### PR TITLE
feat(lint): the regexp family offers the correction it already computed

### DIFF
--- a/packages/lint/linthost/rules_regexp.go
+++ b/packages/lint/linthost/rules_regexp.go
@@ -18,12 +18,38 @@ import (
 type regexpSourceRule struct {
   name  string
   check func(regexpLiteralParts) bool
+  // repair turns an accepted finding into the correction the check already
+  // located. A rule without one stays diagnostic-only.
+  repair func(regexpLiteralParts) regexpRepair
 }
 
 type regexpLiteralParts struct {
+  // start is the literal's offset in the source file. Repairs are computed in
+  // literal-relative coordinates and lifted onto the file through it.
+  start   int
   raw     string
   pattern string
   flags   string
+}
+
+// patternOffset is where the pattern begins inside `raw`, past the opening `/`.
+func (regexpLiteralParts) patternOffset() int { return 1 }
+
+// flagsOffset is where the flag run begins inside `raw`, past the closing `/`.
+func (parts regexpLiteralParts) flagsOffset() int { return len(parts.pattern) + 2 }
+
+// regexpRepair is the correction a regexp rule computed for one literal.
+//
+// Its edits are relative to the literal's own text, so a rule never handles
+// file coordinates; `Check` validates and lifts the whole repair in one place.
+type regexpRepair struct {
+  // message replaces regexpRuleMessage when non-empty, for a rule whose
+  // finding can name the exact thing it located.
+  message string
+  // fix is the one correct rewrite, applied by `ttsc fix`.
+  fix []TextEdit
+  // suggestions are competing rewrites only the author can choose between.
+  suggestions []Suggestion
 }
 
 func (r regexpSourceRule) Name() string { return r.name }
@@ -35,7 +61,80 @@ func (r regexpSourceRule) Check(ctx *Context, node *shimast.Node) {
   if !ok || r.check == nil || !r.check(parts) {
     return
   }
-  ctx.Report(node, regexpRuleMessage(r.name))
+  message := regexpRuleMessage(r.name)
+  if r.repair == nil {
+    ctx.Report(node, message)
+    return
+  }
+  repair := r.repair(parts)
+  if repair.message != "" {
+    message = repair.message
+  }
+  suggestions := make([]Suggestion, 0, len(repair.suggestions))
+  for _, suggestion := range repair.suggestions {
+    edits := parts.acceptEdits(suggestion.Edits)
+    if len(edits) == 0 {
+      continue
+    }
+    suggestions = append(suggestions, Suggestion{Title: suggestion.Title, Edits: edits})
+  }
+  ctx.ReportFixSuggestions(node, message, parts.acceptEdits(repair.fix), suggestions...)
+}
+
+// acceptEdits validates one candidate rewrite of this literal and lifts it into
+// file coordinates, or returns nil to leave the finding without that edit.
+//
+// The gate is the compiler's own regexp parser applied to the rewritten literal
+// as a whole. Every repair here is a splice into live regex syntax, where a
+// locally correct edit can still leave a pattern the engine rejects: `/{1,}/`
+// carries no atom, so its brace run is an Annex B literal rather than a
+// quantifier, and rewriting it to `/+/` yields "nothing to repeat". Rules stay
+// free to compute the ideal edit and cannot emit one that fails to parse.
+//
+// Validity is not equivalence. That a rewrite still parses says nothing about
+// whether it matches the same strings, so preserving semantics remains each
+// rule's own burden -- this only keeps a syntactically broken edit off disk.
+func (parts regexpLiteralParts) acceptEdits(edits []TextEdit) []TextEdit {
+  rewritten, ok := applyRegexpLiteralEdits(parts.raw, edits)
+  if !ok || rewritten == parts.raw {
+    return nil
+  }
+  if !shimscanner.IsValidRegularExpressionLiteral(rewritten) {
+    return nil
+  }
+  shifted := make([]TextEdit, 0, len(edits))
+  for _, edit := range edits {
+    shifted = append(shifted, TextEdit{
+      Pos:  parts.start + edit.Pos,
+      End:  parts.start + edit.End,
+      Text: edit.Text,
+    })
+  }
+  return shifted
+}
+
+// applyRegexpLiteralEdits splices literal-relative edits into `raw`. It reports
+// false for an empty, out-of-bounds, or overlapping edit set rather than
+// producing text from a half-applied rewrite.
+func applyRegexpLiteralEdits(raw string, edits []TextEdit) (string, bool) {
+  if len(edits) == 0 {
+    return "", false
+  }
+  ordered := make([]TextEdit, len(edits))
+  copy(ordered, edits)
+  sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].Pos < ordered[j].Pos })
+  boundary := 0
+  for _, edit := range ordered {
+    if edit.Pos < boundary || edit.End < edit.Pos || edit.End > len(raw) {
+      return "", false
+    }
+    boundary = edit.End
+  }
+  out := raw
+  for i := len(ordered) - 1; i >= 0; i-- {
+    out = out[:ordered[i].Pos] + ordered[i].Text + out[ordered[i].End:]
+  }
+  return out, true
 }
 
 type regexpNoUselessEscapeAlias struct{}
@@ -53,8 +152,11 @@ func (regexpNoUselessEscapeAlias) Check(ctx *Context, node *shimast.Node) {
 }
 
 func parseRegexpLiteralParts(ctx *Context, node *shimast.Node) (regexpLiteralParts, bool) {
+  // `nodeText` and `tokenRange` skip the same leading trivia, so the text a
+  // repair reasons about always begins at exactly `start` in the file.
+  start, _ := tokenRange(ctx.File, node)
   raw := nodeText(ctx.File, node)
-  if len(raw) < 2 || raw[0] != '/' {
+  if start < 0 || len(raw) < 2 || raw[0] != '/' {
     return regexpLiteralParts{}, false
   }
   closing := strings.LastIndexByte(raw, '/')
@@ -62,6 +164,7 @@ func parseRegexpLiteralParts(ctx *Context, node *shimast.Node) (regexpLiteralPar
     return regexpLiteralParts{}, false
   }
   return regexpLiteralParts{
+    start:   start,
     raw:     raw,
     pattern: raw[1:closing],
     flags:   raw[closing+1:],
@@ -184,40 +287,34 @@ func regexpHasEmptyCharacterClass(parts regexpLiteralParts) bool {
   return false
 }
 
-func regexpHasZeroQuantifier(parts regexpLiteralParts) bool {
-  return scanRegexpQuantifiers(parts.pattern, func(min, max int, hasComma bool) bool {
-    return min == 0 && (!hasComma || max == 0)
-  })
+func regexpQuantifierIsZero(quantifier regexpQuantifier) bool {
+  return quantifier.min == 0 && (!quantifier.hasComma || quantifier.max == 0)
 }
 
-func regexpHasUselessTwoNumsQuantifier(parts regexpLiteralParts) bool {
-  return scanRegexpQuantifiers(parts.pattern, func(min, max int, hasComma bool) bool {
-    return hasComma && min == max && min >= 0
-  })
+func regexpQuantifierIsTwoNums(quantifier regexpQuantifier) bool {
+  return quantifier.hasComma && quantifier.min == quantifier.max && quantifier.min >= 0
 }
 
-func regexpHasUselessQuantifier(parts regexpLiteralParts) bool {
-  return scanRegexpQuantifiers(parts.pattern, func(min, max int, hasComma bool) bool {
-    return !hasComma && min == 1 && max == -1
-  })
+func regexpQuantifierIsUseless(quantifier regexpQuantifier) bool {
+  return !quantifier.hasComma && quantifier.min == 1 && quantifier.max == -1
 }
 
-func regexpHasPlusQuantifierCandidate(parts regexpLiteralParts) bool {
-  return scanRegexpQuantifiers(parts.pattern, func(min, max int, hasComma bool) bool {
-    return hasComma && min == 1 && max == -1
-  })
+func regexpQuantifierIsPlus(quantifier regexpQuantifier) bool {
+  return quantifier.hasComma && quantifier.min == 1 && quantifier.max == -1
 }
 
-func regexpHasStarQuantifierCandidate(parts regexpLiteralParts) bool {
-  return scanRegexpQuantifiers(parts.pattern, func(min, max int, hasComma bool) bool {
-    return hasComma && min == 0 && max == -1
-  })
+func regexpQuantifierIsStar(quantifier regexpQuantifier) bool {
+  return quantifier.hasComma && quantifier.min == 0 && quantifier.max == -1
 }
 
-func regexpHasQuestionQuantifierCandidate(parts regexpLiteralParts) bool {
-  return scanRegexpQuantifiers(parts.pattern, func(min, max int, hasComma bool) bool {
-    return hasComma && min == 0 && max == 1
-  })
+func regexpQuantifierIsQuestion(quantifier regexpQuantifier) bool {
+  return quantifier.hasComma && quantifier.min == 0 && quantifier.max == 1
+}
+
+func regexpQuantifierCheck(accept func(regexpQuantifier) bool) func(regexpLiteralParts) bool {
+  return func(parts regexpLiteralParts) bool {
+    return scanRegexpQuantifiers(parts.pattern, accept)
+  }
 }
 
 func regexpNeedsUnicodeFlag(parts regexpLiteralParts) bool {
@@ -229,11 +326,75 @@ func regexpNeedsUnicodeSetsFlag(parts regexpLiteralParts) bool {
 }
 
 func regexpFlagsUnsorted(parts regexpLiteralParts) bool {
-  sorted := []byte(parts.flags)
+  return regexpSortedFlags(parts.flags) != parts.flags
+}
+
+func regexpSortedFlags(flags string) string {
+  sorted := []byte(flags)
   sort.SliceStable(sorted, func(i, j int) bool {
     return regexpFlagOrder(sorted[i]) < regexpFlagOrder(sorted[j])
   })
-  return string(sorted) != parts.flags
+  return string(sorted)
+}
+
+// regexpSortFlagsRepair hands back the sorted flag string the check already
+// built to decide the finding. A permutation of the flag run cannot change what
+// the literal matches, so this is a fix rather than a suggestion.
+func regexpSortFlagsRepair(parts regexpLiteralParts) regexpRepair {
+  return regexpRepair{fix: []TextEdit{parts.flagEdit(regexpSortedFlags(parts.flags))}}
+}
+
+// flagEdit replaces this literal's whole flag run.
+func (parts regexpLiteralParts) flagEdit(flags string) TextEdit {
+  return TextEdit{
+    Pos:  parts.flagsOffset(),
+    End:  parts.flagsOffset() + len(parts.flags),
+    Text: flags,
+  }
+}
+
+// regexpFlagsWith inserts `flag` at its canonical `dgimsuvy` position without
+// reordering the flags already present, so adding one flag never silently does
+// `regexp/sort-flags`' job on an unsorted literal.
+func regexpFlagsWith(flags string, flag byte) string {
+  if strings.IndexByte(flags, flag) >= 0 {
+    return flags
+  }
+  order := regexpFlagOrder(flag)
+  for i := 0; i < len(flags); i++ {
+    if regexpFlagOrder(flags[i]) > order {
+      return flags[:i] + string(flag) + flags[i:]
+    }
+  }
+  return flags + string(flag)
+}
+
+// regexpUnicodeFlagRepair offers `u` and `v` as competing suggestions.
+//
+// Both satisfy the rule and neither is the obvious answer: `u` is the widely
+// supported mode, `v` the stricter ES2024 superset. Both also change what the
+// pattern matches -- surrogate pairs stop being two independent code units --
+// so this is never applied automatically by `ttsc fix`.
+func regexpUnicodeFlagRepair(parts regexpLiteralParts) regexpRepair {
+  return regexpRepair{suggestions: []Suggestion{
+    {Title: "Add the `u` flag.", Edits: []TextEdit{parts.flagEdit(regexpFlagsWith(parts.flags, 'u'))}},
+    {Title: "Add the `v` flag.", Edits: []TextEdit{parts.flagEdit(regexpFlagsWith(parts.flags, 'v'))}},
+  }}
+}
+
+// regexpUnicodeSetsFlagRepair offers the single `v` rewrite, replacing `u`
+// where the literal already carries it. It stays a suggestion for the same
+// reason as regexpUnicodeFlagRepair: `v` is a stricter mode with its own
+// matching semantics, not a spelling of the existing pattern.
+func regexpUnicodeSetsFlagRepair(parts regexpLiteralParts) regexpRepair {
+  title, flags := "Add the `v` flag.", parts.flags
+  if strings.IndexByte(flags, 'u') >= 0 {
+    title = "Replace the `u` flag with `v`."
+    flags = strings.Replace(flags, "u", "", 1)
+  }
+  return regexpRepair{suggestions: []Suggestion{
+    {Title: title, Edits: []TextEdit{parts.flagEdit(regexpFlagsWith(flags, 'v'))}},
+  }}
 }
 
 func regexpFlagOrder(flag byte) int {
@@ -257,22 +418,65 @@ func regexpFlagOrder(flag byte) int {
 // A literal the parser rejects yields no finding at all: the rule tells people
 // to delete a flag, so it stays silent whenever it cannot see the whole pattern.
 func regexpHasUselessFlag(parts regexpLiteralParts) bool {
+  return regexpUselessFlags(parts) != ""
+}
+
+// regexpUselessFlags returns every flag the literal carries that its own
+// pattern can never exercise, in canonical order.
+func regexpUselessFlags(parts regexpLiteralParts) string {
   ignoreCase := strings.Contains(parts.flags, "i")
   multiline := strings.Contains(parts.flags, "m")
   if !ignoreCase && !multiline {
-    return false
+    return ""
   }
   parsed, err := regexParseLiteral(parts.raw)
   if err != nil {
-    return false
+    return ""
   }
+  useless := make([]byte, 0, 2)
   if ignoreCase && !regexpNodeIsCaseVariant(parsed.Body, strings.ContainsAny(parts.flags, "uv")) {
-    return true
+    useless = append(useless, 'i')
   }
   if multiline && !regexpNodeHasLineAnchor(parsed.Body) {
-    return true
+    useless = append(useless, 'm')
   }
-  return false
+  return string(useless)
+}
+
+// regexpUselessFlagRepair deletes the dead flags the analysis named. The
+// analysis is one-sided -- anything it cannot settle counts as using the flag
+// -- so a flag it does reach here is provably inert and the deletion is a fix
+// rather than a suggestion.
+func regexpUselessFlagRepair(parts regexpLiteralParts) regexpRepair {
+  useless := regexpUselessFlags(parts)
+  if useless == "" {
+    return regexpRepair{}
+  }
+  var edits []TextEdit
+  for i := 0; i < len(parts.flags); i++ {
+    if strings.IndexByte(useless, parts.flags[i]) < 0 {
+      continue
+    }
+    edits = append(edits, TextEdit{
+      Pos: parts.flagsOffset() + i,
+      End: parts.flagsOffset() + i + 1,
+    })
+  }
+  return regexpRepair{message: regexpUselessFlagMessage(useless), fix: edits}
+}
+
+// regexpUselessFlagMessage names the flags rather than leaving the reader to
+// rediscover which one the analysis found inert. Only `i` and `m` are ever
+// judged, so the list is one or two entries.
+func regexpUselessFlagMessage(useless string) string {
+  quoted := make([]string, 0, len(useless))
+  for i := 0; i < len(useless); i++ {
+    quoted = append(quoted, "`"+string(useless[i])+"`")
+  }
+  if len(quoted) == 1 {
+    return "Unexpected useless regular expression flag " + quoted[0] + "."
+  }
+  return "Unexpected useless regular expression flags " + strings.Join(quoted, " and ") + "."
 }
 
 func regexpHasPreferD(parts regexpLiteralParts) bool {
@@ -341,7 +545,22 @@ func scanRegexpPattern(pattern string, visit func(pattern string, i int) bool) b
   return false
 }
 
-func scanRegexpQuantifiers(pattern string, visit func(min, max int, hasComma bool) bool) bool {
+// regexpQuantifier is one `{...}` count quantifier located in a pattern.
+//
+// The span travels with the bounds because every quantifier-shorthand rule in
+// this family answers "is this quantifier redundant?" and "what replaces it?"
+// from the same scan.
+type regexpQuantifier struct {
+  // start and end bracket `{`..`}` inclusive-exclusive, relative to the
+  // pattern rather than to the whole literal.
+  start    int
+  end      int
+  min      int
+  max      int
+  hasComma bool
+}
+
+func scanRegexpQuantifiers(pattern string, visit func(regexpQuantifier) bool) bool {
   return scanRegexpPattern(pattern, func(pattern string, i int) bool {
     if pattern[i] != '{' {
       return false
@@ -365,8 +584,79 @@ func scanRegexpQuantifiers(pattern string, visit func(min, max int, hasComma boo
     } else {
       min = parseRegexpQuantifierNumber(body)
     }
-    return min >= 0 && visit(min, max, hasComma)
+    return min >= 0 && visit(regexpQuantifier{
+      start:    i,
+      end:      end + 1,
+      min:      min,
+      max:      max,
+      hasComma: hasComma,
+    })
   })
+}
+
+// regexpQuantifierRepair builds the repair shared by the quantifier-shorthand
+// rules: every `{...}` the rule accepts is rewritten by `rewrite`, and the
+// whole set travels as one atomic fix so a literal is never half-canonicalized.
+//
+// `rewrite` may decline an individual quantifier whose neighbours make the
+// rewrite unsafe; the remaining ones still apply.
+func regexpQuantifierRepair(
+  accept func(regexpQuantifier) bool,
+  rewrite func(pattern string, quantifier regexpQuantifier) (string, bool),
+) func(regexpLiteralParts) regexpRepair {
+  return func(parts regexpLiteralParts) regexpRepair {
+    var edits []TextEdit
+    scanRegexpQuantifiers(parts.pattern, func(quantifier regexpQuantifier) bool {
+      if !accept(quantifier) {
+        return false
+      }
+      if text, ok := rewrite(parts.pattern, quantifier); ok {
+        edits = append(edits, TextEdit{
+          Pos:  parts.patternOffset() + quantifier.start,
+          End:  parts.patternOffset() + quantifier.end,
+          Text: text,
+        })
+      }
+      return false
+    })
+    return regexpRepair{fix: edits}
+  }
+}
+
+// regexpQuantifierSymbol rewrites a count quantifier to its one-character
+// shorthand. `{1,}` and `+` bind identically, so a trailing lazy `?` survives
+// the swap unchanged.
+func regexpQuantifierSymbol(symbol string) func(string, regexpQuantifier) (string, bool) {
+  return func(string, regexpQuantifier) (string, bool) { return symbol, true }
+}
+
+// regexpQuantifierExactCount collapses `{n,n}` to `{n}`. The braces stay, so
+// nothing can fuse with a neighbouring token.
+func regexpQuantifierExactCount(_ string, quantifier regexpQuantifier) (string, bool) {
+  return "{" + strconv.Itoa(quantifier.min) + "}", true
+}
+
+// regexpQuantifierDrop deletes a `{1}` that repeats its atom exactly once.
+//
+// Two following characters make the deletion unsafe, and neither is caught by
+// re-parsing the result, because both rewrites still parse:
+//
+//   - `?`, `*`, `+`, or `{`: the braces are the quantifier and the `?` in
+//     `/a{1}?/` only makes it lazy, so dropping them turns "exactly one" into
+//     "zero or one".
+//   - A digit: the braces separate a backreference or octal escape from a
+//     digit, and `/\1{1}2/` would fuse into `\12`, backreference twelve.
+func regexpQuantifierDrop(pattern string, quantifier regexpQuantifier) (string, bool) {
+  if quantifier.end >= len(pattern) {
+    return "", true
+  }
+  switch next := pattern[quantifier.end]; {
+  case next == '?', next == '*', next == '+', next == '{':
+    return "", false
+  case next >= '0' && next <= '9':
+    return "", false
+  }
+  return "", true
 }
 
 func parseRegexpQuantifierNumber(text string) int {
@@ -385,7 +675,20 @@ func parseRegexpQuantifierNumber(text string) int {
   return value
 }
 
-func walkRegexpCharacterClasses(pattern string, visit func(content string) bool) bool {
+// regexpClassSpan is one character class located in a pattern.
+type regexpClassSpan struct {
+  // start and end bracket `[`..`]` inclusive-exclusive, relative to the
+  // pattern rather than to the whole literal.
+  start   int
+  end     int
+  content string
+}
+
+// walkRegexpCharacterClassSpans visits every character class in source order,
+// stopping early when visit returns true and reporting whether it did. A `[`
+// that opens no class -- an escaped bracket, or one with no closing `]` -- is
+// skipped, which is what keeps `/\[0-9]/` from being read as a digit class.
+func walkRegexpCharacterClassSpans(pattern string, visit func(regexpClassSpan) bool) bool {
   for i := 0; i < len(pattern); i++ {
     if pattern[i] == '\\' {
       i++
@@ -401,7 +704,7 @@ func walkRegexpCharacterClasses(pattern string, visit func(content string) bool)
         continue
       }
       if pattern[j] == ']' {
-        if visit(pattern[start:j]) {
+        if visit(regexpClassSpan{start: i, end: j + 1, content: pattern[start:j]}) {
           return true
         }
         i = j
@@ -410,6 +713,47 @@ func walkRegexpCharacterClasses(pattern string, visit func(content string) bool)
     }
   }
   return false
+}
+
+func walkRegexpCharacterClasses(pattern string, visit func(content string) bool) bool {
+  return walkRegexpCharacterClassSpans(pattern, func(span regexpClassSpan) bool {
+    return visit(span.content)
+  })
+}
+
+// regexpClassShorthandRepair rewrites every character class spelled exactly as
+// one of `spellings` into `shorthand`.
+//
+// The shorthand always begins with a backslash, so it cannot fuse with the
+// atom before it the way a bare character could, and it is a complete atom, so
+// a following quantifier keeps applying to the same thing.
+//
+// The class walk is stricter than the substring test that decides the finding:
+// it will not see a spelled-out class nested inside a `v`-mode class, so such a
+// literal is reported without a fix rather than rewritten through a bracket
+// that is not the class boundary.
+func regexpClassShorthandRepair(
+  shorthand string,
+  spellings ...string,
+) func(regexpLiteralParts) regexpRepair {
+  return func(parts regexpLiteralParts) regexpRepair {
+    var edits []TextEdit
+    walkRegexpCharacterClassSpans(parts.pattern, func(span regexpClassSpan) bool {
+      for _, spelling := range spellings {
+        if span.content != spelling {
+          continue
+        }
+        edits = append(edits, TextEdit{
+          Pos:  parts.patternOffset() + span.start,
+          End:  parts.patternOffset() + span.end,
+          Text: shorthand,
+        })
+        break
+      }
+      return false
+    })
+    return regexpRepair{fix: edits}
+  }
 }
 
 func classHasRange(content string) bool {
@@ -611,16 +955,66 @@ func init() {
   }})
   Register(regexpSourceRule{name: "regexp/no-useless-character-class", check: regexpHasUselessCharacterClass})
   Register(regexpNoUselessEscapeAlias{})
-  Register(regexpSourceRule{name: "regexp/no-useless-flag", check: regexpHasUselessFlag})
-  Register(regexpSourceRule{name: "regexp/no-useless-quantifier", check: regexpHasUselessQuantifier})
-  Register(regexpSourceRule{name: "regexp/no-useless-two-nums-quantifier", check: regexpHasUselessTwoNumsQuantifier})
-  Register(regexpSourceRule{name: "regexp/no-zero-quantifier", check: regexpHasZeroQuantifier})
-  Register(regexpSourceRule{name: "regexp/prefer-d", check: regexpHasPreferD})
-  Register(regexpSourceRule{name: "regexp/prefer-plus-quantifier", check: regexpHasPlusQuantifierCandidate})
-  Register(regexpSourceRule{name: "regexp/prefer-question-quantifier", check: regexpHasQuestionQuantifierCandidate})
-  Register(regexpSourceRule{name: "regexp/prefer-star-quantifier", check: regexpHasStarQuantifierCandidate})
-  Register(regexpSourceRule{name: "regexp/prefer-w", check: regexpHasPreferW})
-  Register(regexpSourceRule{name: "regexp/require-unicode-regexp", check: regexpNeedsUnicodeFlag})
-  Register(regexpSourceRule{name: "regexp/require-unicode-sets-regexp", check: regexpNeedsUnicodeSetsFlag})
-  Register(regexpSourceRule{name: "regexp/sort-flags", check: regexpFlagsUnsorted})
+  Register(regexpSourceRule{
+    name:   "regexp/no-useless-flag",
+    check:  regexpHasUselessFlag,
+    repair: regexpUselessFlagRepair,
+  })
+  Register(regexpSourceRule{
+    name:   "regexp/no-useless-quantifier",
+    check:  regexpQuantifierCheck(regexpQuantifierIsUseless),
+    repair: regexpQuantifierRepair(regexpQuantifierIsUseless, regexpQuantifierDrop),
+  })
+  Register(regexpSourceRule{
+    name:   "regexp/no-useless-two-nums-quantifier",
+    check:  regexpQuantifierCheck(regexpQuantifierIsTwoNums),
+    repair: regexpQuantifierRepair(regexpQuantifierIsTwoNums, regexpQuantifierExactCount),
+  })
+  // `regexp/no-zero-quantifier` stays diagnostic-only: `{0}` says the atom
+  // never matches, so the correction is to delete the atom or repair the
+  // bound, and the rule computes neither.
+  Register(regexpSourceRule{
+    name:  "regexp/no-zero-quantifier",
+    check: regexpQuantifierCheck(regexpQuantifierIsZero),
+  })
+  Register(regexpSourceRule{
+    name:   "regexp/prefer-d",
+    check:  regexpHasPreferD,
+    repair: regexpClassShorthandRepair("\\d", "0-9"),
+  })
+  Register(regexpSourceRule{
+    name:   "regexp/prefer-plus-quantifier",
+    check:  regexpQuantifierCheck(regexpQuantifierIsPlus),
+    repair: regexpQuantifierRepair(regexpQuantifierIsPlus, regexpQuantifierSymbol("+")),
+  })
+  Register(regexpSourceRule{
+    name:   "regexp/prefer-question-quantifier",
+    check:  regexpQuantifierCheck(regexpQuantifierIsQuestion),
+    repair: regexpQuantifierRepair(regexpQuantifierIsQuestion, regexpQuantifierSymbol("?")),
+  })
+  Register(regexpSourceRule{
+    name:   "regexp/prefer-star-quantifier",
+    check:  regexpQuantifierCheck(regexpQuantifierIsStar),
+    repair: regexpQuantifierRepair(regexpQuantifierIsStar, regexpQuantifierSymbol("*")),
+  })
+  Register(regexpSourceRule{
+    name:   "regexp/prefer-w",
+    check:  regexpHasPreferW,
+    repair: regexpClassShorthandRepair("\\w", "A-Za-z0-9_", "a-zA-Z0-9_"),
+  })
+  Register(regexpSourceRule{
+    name:   "regexp/require-unicode-regexp",
+    check:  regexpNeedsUnicodeFlag,
+    repair: regexpUnicodeFlagRepair,
+  })
+  Register(regexpSourceRule{
+    name:   "regexp/require-unicode-sets-regexp",
+    check:  regexpNeedsUnicodeSetsFlag,
+    repair: regexpUnicodeSetsFlagRepair,
+  })
+  Register(regexpSourceRule{
+    name:   "regexp/sort-flags",
+    check:  regexpFlagsUnsorted,
+    repair: regexpSortFlagsRepair,
+  })
 }

--- a/packages/lint/src/structures/rules/ITtscLintRegexpRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintRegexpRules.ts
@@ -103,7 +103,8 @@ export interface ITtscLintRegexpRules {
   /**
    * Reject regex flags that the literal does not exercise — `i` on a pattern
    * with no case-variable character, `m` on a pattern with no `^`/`$`
-   * assertion.
+   * assertion. Autofixable: the diagnostic names the dead flags and the
+   * fix deletes exactly those, leaving the live ones in place.
    *
    * Cleans up flag combos that suggest behavior the pattern can never trigger.
    * A character is case-variable wherever it sits, so `/[a-z]/i` keeps its flag
@@ -121,12 +122,18 @@ export interface ITtscLintRegexpRules {
    * (`/a{1}/`), `?` on patterns already matching the empty string
    * (`/(?:a+|b*)?/`), and quantifiers on non-consuming atoms (`/(?:\b)+/`).
    *
+   * Autofixable for the constant-one count, except where the next character
+   * would change the meaning of the deletion: a lazy marker (`/a{1}?/` is
+   * "exactly one", not optional) or a digit (`/\1{1}2/` would fuse into
+   * backreference twelve).
+   *
    * @reference https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-quantifier.html
    */
   "regexp/no-useless-quantifier"?: TtscLintRuleSetting;
 
   /**
    * Reject equal min/max quantifiers (`/a{2,2}/`) in favor of `/a{2}/`.
+   * Autofixable.
    *
    * @reference https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-two-nums-quantifier.html
    */
@@ -136,42 +143,45 @@ export interface ITtscLintRegexpRules {
    * Reject zero-repeat quantifiers (`/a{0}/`, `/a{0,0}/`) — the atom never
    * matches, so the quantifier is either dead code or a typo for `{1,…}`.
    *
-   * The fix is normally to delete the atom or correct the upper bound.
+   * Diagnostic-only: the correction is to delete the atom or repair the
+   * bound, and which one was meant is not recoverable from the source.
    *
    * @reference https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-zero-quantifier.html
    */
   "regexp/no-zero-quantifier"?: TtscLintRuleSetting;
 
   /**
-   * Prefer `\d` over `[0-9]` in regex literals.
+   * Prefer `\d` over `[0-9]` in regex literals. Autofixable.
    *
    * @reference https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-d.html
    */
   "regexp/prefer-d"?: TtscLintRuleSetting;
 
   /**
-   * Prefer `+` over `{1,}` in regex literals.
+   * Prefer `+` over `{1,}` in regex literals. Autofixable.
    *
    * @reference https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-plus-quantifier.html
    */
   "regexp/prefer-plus-quantifier"?: TtscLintRuleSetting;
 
   /**
-   * Prefer `?` over `{0,1}` in regex literals.
+   * Prefer `?` over `{0,1}` in regex literals. Autofixable; a lazy `{0,1}`
+   * correctly becomes `??`.
    *
    * @reference https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-question-quantifier.html
    */
   "regexp/prefer-question-quantifier"?: TtscLintRuleSetting;
 
   /**
-   * Prefer `*` over `{0,}` in regex literals.
+   * Prefer `*` over `{0,}` in regex literals. Autofixable.
    *
    * @reference https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-star-quantifier.html
    */
   "regexp/prefer-star-quantifier"?: TtscLintRuleSetting;
 
   /**
-   * Prefer `\w` over `[A-Za-z0-9_]` in regex literals.
+   * Prefer `\w` over `[A-Za-z0-9_]` in regex literals. Autofixable for both
+   * accepted spellings.
    *
    * @reference https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-w.html
    */
@@ -180,6 +190,9 @@ export interface ITtscLintRegexpRules {
   /**
    * Require regex literals to use the `u` or `v` flag, so Unicode-property
    * escapes and surrogate-pair handling stay predictable.
+   *
+   * Offers `u` and `v` as editor suggestions rather than an automatic fix:
+   * both satisfy the rule, and both change what the pattern matches.
    *
    * @reference https://ota-meshi.github.io/eslint-plugin-regexp/rules/require-unicode-regexp.html
    */
@@ -191,7 +204,8 @@ export interface ITtscLintRegexpRules {
    * stricter escape rules on top of `u`.
    *
    * Choose this over `require-unicode-regexp` only on engines that ship
-   * ES2024-era regex.
+   * ES2024-era regex. Offers one editor suggestion, which replaces an
+   * existing `u` because the two flags are mutually exclusive.
    *
    * @reference https://ota-meshi.github.io/eslint-plugin-regexp/rules/require-unicode-sets-regexp.html
    */
@@ -201,7 +215,8 @@ export interface ITtscLintRegexpRules {
    * Require regex flags to appear in canonical alphabetical order (`dgimsuvy`).
    *
    * Stable ordering keeps diffs small and lets readers compare flag sets at a
-   * glance.
+   * glance. Autofixable: a permutation of a flag run cannot change what the
+   * literal matches.
    *
    * @reference https://ota-meshi.github.io/eslint-plugin-regexp/rules/sort-flags.html
    */

--- a/packages/lint/test/fix/fix_regexp_no_useless_flag_deletes_the_flag_it_named_test.go
+++ b/packages/lint/test/fix/fix_regexp_no_useless_flag_deletes_the_flag_it_named_test.go
@@ -1,0 +1,69 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestFixRegexpNoUselessFlagDeletesTheFlagItNamed verifies
+// `regexp/no-useless-flag` deletes exactly the dead flags its analysis
+// identified and names them in the diagnostic.
+//
+// The analysis already decided which of `i` and `m` the pattern cannot
+// exercise, and it is one-sided: anything it cannot settle counts as using the
+// flag, so a flag that reaches the fix is provably inert and the deletion is
+// safe to impose. The load-bearing part is that the live flags around it
+// survive — a whole-run rewrite would take `g` with it.
+//
+//  1. Fix `/\d+/gim`, where `g` is live and both `i` and `m` are dead.
+//  2. Assert only `g` remains and the message names both dead flags.
+//  3. Assert the negative twins keep their flag: `/[a-z]/i`, where `i` is what
+//     extends the class, and `/^a$/m`, which has anchors for `m` to re-define.
+func TestFixRegexpNoUselessFlagDeletesTheFlagItNamed(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "regexp/no-useless-flag",
+    "const value = /\\d+/gim;\nJSON.stringify(value);\n",
+    "const value = /\\d+/g;\nJSON.stringify(value);\n",
+  )
+  _, _, findings := runRuleFindingsSnapshot(
+    t,
+    "regexp/no-useless-flag",
+    "const value = /\\d+/gim;\nJSON.stringify(value);\n",
+    nil,
+  )
+  if len(findings) != 1 {
+    t.Fatalf("findings = %d, want 1", len(findings))
+  }
+  expected := "Unexpected useless regular expression flags `i` and `m`."
+  if findings[0].Message != expected {
+    t.Fatalf("message:\nwant %q\ngot  %q", expected, findings[0].Message)
+  }
+
+  assertFixSnapshot(
+    t,
+    "regexp/no-useless-flag",
+    "const value = /\\d/i;\nJSON.stringify(value);\n",
+    "const value = /\\d/;\nJSON.stringify(value);\n",
+  )
+  _, _, single := runRuleFindingsSnapshot(
+    t,
+    "regexp/no-useless-flag",
+    "const value = /\\d/i;\nJSON.stringify(value);\n",
+    nil,
+  )
+  if len(single) != 1 || !strings.Contains(single[0].Message, "flag `i`.") {
+    t.Fatalf("single-flag message = %+v", single)
+  }
+
+  assertRuleSkipsSource(
+    t,
+    "regexp/no-useless-flag",
+    "const value = /[a-z]/i;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/no-useless-flag",
+    "const value = /^a$/m;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_regexp_no_useless_quantifier_drops_exactly_one_repeat_test.go
+++ b/packages/lint/test/fix/fix_regexp_no_useless_quantifier_drops_exactly_one_repeat_test.go
@@ -1,0 +1,52 @@
+package linthost
+
+import "testing"
+
+// TestFixRegexpNoUselessQuantifierDropsExactlyOneRepeat verifies
+// `regexp/no-useless-quantifier` deletes a `{1}` only where the neighbouring
+// characters leave the deletion meaning-preserving.
+//
+// Both unsafe shapes still parse after the edit, so the engine's own regexp
+// parser cannot catch them and the rule has to decline on its own:
+// `/a{1}?/` is "exactly one, lazily" and would become the optional `/a?/`, and
+// `/\1{1}2/` would fuse into `\12`, backreference twelve rather than
+// backreference one followed by a literal `2`.
+//
+//  1. Fix a `{1}` between two ordinary atoms and one following a group.
+//  2. Assert both collapse to the bare atom.
+//  3. Assert the lazy and backreference neighbours still report but apply no
+//     edit, and that `{1,}` and `{2}` do not report at all.
+func TestFixRegexpNoUselessQuantifierDropsExactlyOneRepeat(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "regexp/no-useless-quantifier",
+    "const value = /a{1}b/;\nJSON.stringify(value);\n",
+    "const value = /ab/;\nJSON.stringify(value);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "regexp/no-useless-quantifier",
+    "const value = /(?:ab){1}c/;\nJSON.stringify(value);\n",
+    "const value = /(?:ab)c/;\nJSON.stringify(value);\n",
+  )
+  assertNoFixSnapshot(
+    t,
+    "regexp/no-useless-quantifier",
+    "const value = /a{1}?/;\nJSON.stringify(value);\n",
+  )
+  assertNoFixSnapshot(
+    t,
+    "regexp/no-useless-quantifier",
+    "const value = /(a)\\1{1}2/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/no-useless-quantifier",
+    "const value = /a{1,}/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/no-useless-quantifier",
+    "const value = /a{2}/;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_regexp_no_useless_two_nums_quantifier_collapses_equal_bounds_test.go
+++ b/packages/lint/test/fix/fix_regexp_no_useless_two_nums_quantifier_collapses_equal_bounds_test.go
@@ -1,0 +1,45 @@
+package linthost
+
+import "testing"
+
+// TestFixRegexpNoUselessTwoNumsQuantifierCollapsesEqualBounds verifies
+// `regexp/no-useless-two-nums-quantifier` rewrites `{n,n}` to `{n}`.
+//
+// The count is reprinted from the parsed minimum rather than sliced out of the
+// source, so a multi-digit bound has to survive the round trip; `{10,10}` would
+// come back as `{1}` under a one-character assumption. The braces stay in
+// place, so unlike the `{1}` deletion nothing can fuse with a neighbour.
+//
+//  1. Fix a literal carrying a two-digit and a one-digit equal-bound run.
+//  2. Assert the result is `/a{10}b{2}/`.
+//  3. Assert the zero boundary collapses to `{0}` as well, and that `{2,3}`,
+//     `{2,}`, and the already-collapsed `{2}` report nothing.
+func TestFixRegexpNoUselessTwoNumsQuantifierCollapsesEqualBounds(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "regexp/no-useless-two-nums-quantifier",
+    "const value = /a{10,10}b{2,2}/;\nJSON.stringify(value);\n",
+    "const value = /a{10}b{2}/;\nJSON.stringify(value);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "regexp/no-useless-two-nums-quantifier",
+    "const value = /a{0,0}/;\nJSON.stringify(value);\n",
+    "const value = /a{0}/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/no-useless-two-nums-quantifier",
+    "const value = /a{2,3}/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/no-useless-two-nums-quantifier",
+    "const value = /a{2,}/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/no-useless-two-nums-quantifier",
+    "const value = /a{2}/;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_regexp_no_zero_quantifier_stays_diagnostic_only_test.go
+++ b/packages/lint/test/fix/fix_regexp_no_zero_quantifier_stays_diagnostic_only_test.go
@@ -1,0 +1,34 @@
+package linthost
+
+import "testing"
+
+// TestFixRegexpNoZeroQuantifierStaysDiagnosticOnly verifies
+// `regexp/no-zero-quantifier` reports without offering an edit, deliberately,
+// while the rest of the quantifier family now rewrites.
+//
+// `{0}` is a bug rather than a redundancy: it says the atom never matches, so
+// the correction is to delete the atom or repair the bound, and which one is
+// meant is not recoverable from the source. Deleting only the braces would turn
+// "never" into "once" — the loudest possible wrong rewrite — and this case
+// exists so a later pass cannot add that edit by symmetry with its siblings.
+//
+//  1. Assert `/a{0}/` and `/a{0,0}/` both report.
+//  2. Assert neither applies any edit.
+//  3. Assert `/a{0,1}/`, one step away on the upper bound, does not report.
+func TestFixRegexpNoZeroQuantifierStaysDiagnosticOnly(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "regexp/no-zero-quantifier",
+    "const value = /a{0}/;\nJSON.stringify(value);\n",
+  )
+  assertNoFixSnapshot(
+    t,
+    "regexp/no-zero-quantifier",
+    "const value = /a{0,0}/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/no-zero-quantifier",
+    "const value = /a{0,1}/;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_regexp_prefer_d_replaces_spelled_out_digit_class_test.go
+++ b/packages/lint/test/fix/fix_regexp_prefer_d_replaces_spelled_out_digit_class_test.go
@@ -1,0 +1,40 @@
+package linthost
+
+import "testing"
+
+// TestFixRegexpPreferDReplacesSpelledOutDigitClass verifies `regexp/prefer-d`
+// rewrites every `[0-9]` character class in the literal to `\d`.
+//
+// The fix is located by the character-class walk rather than by the substring
+// test that decides the finding, and the difference is load-bearing: in
+// `/\[0-9]/` the bracket is escaped, so there is no class there at all and a
+// substring-driven splice would emit `/\\d/`, a literal backslash followed by
+// `d`. That literal keeps its (pre-existing) report and gets no edit.
+//
+//  1. Fix a literal holding two separate `[0-9]` classes.
+//  2. Assert both become `\d`.
+//  3. Assert the escaped-bracket literal applies no edit, and that `[0-9a]`
+//     and the negated `[^0-9]` report nothing.
+func TestFixRegexpPreferDReplacesSpelledOutDigitClass(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "regexp/prefer-d",
+    "const value = /[0-9]-[0-9]+/;\nJSON.stringify(value);\n",
+    "const value = /\\d-\\d+/;\nJSON.stringify(value);\n",
+  )
+  assertNoFixSnapshot(
+    t,
+    "regexp/prefer-d",
+    "const value = /\\[0-9]/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-d",
+    "const value = /[0-9a]/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-d",
+    "const value = /[^0-9]/;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_regexp_prefer_plus_quantifier_replaces_open_ended_one_test.go
+++ b/packages/lint/test/fix/fix_regexp_prefer_plus_quantifier_replaces_open_ended_one_test.go
@@ -1,0 +1,40 @@
+package linthost
+
+import "testing"
+
+// TestFixRegexpPreferPlusQuantifierReplacesOpenEndedOne verifies
+// `regexp/prefer-plus-quantifier` rewrites every `{1,}` in the literal to `+`.
+//
+// `+` and `{1,}` are the same quantifier with the same binding, so a trailing
+// lazy `?` keeps applying to the rewritten quantifier rather than turning into
+// a second one. The scan already located each brace run; only the span was
+// thrown away.
+//
+//  1. Fix a literal carrying two `{1,}` runs, one of them lazy, so the atomic
+//     multi-edit group and the lazy-marker survival are pinned together.
+//  2. Assert the result is `/a+?b+/`.
+//  3. Assert `{2,}`, `{1,2}`, and the comma-free `{1}` report nothing, so the
+//     rewrite cannot reach a quantifier with a different meaning.
+func TestFixRegexpPreferPlusQuantifierReplacesOpenEndedOne(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "regexp/prefer-plus-quantifier",
+    "const value = /a{1,}?b{1,}/;\nJSON.stringify(value);\n",
+    "const value = /a+?b+/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-plus-quantifier",
+    "const value = /a{2,}/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-plus-quantifier",
+    "const value = /a{1,2}/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-plus-quantifier",
+    "const value = /a{1}/;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_regexp_prefer_question_quantifier_replaces_zero_to_one_test.go
+++ b/packages/lint/test/fix/fix_regexp_prefer_question_quantifier_replaces_zero_to_one_test.go
@@ -1,0 +1,38 @@
+package linthost
+
+import "testing"
+
+// TestFixRegexpPreferQuestionQuantifierReplacesZeroToOne verifies
+// `regexp/prefer-question-quantifier` rewrites `{0,1}` to `?`.
+//
+// The lazy arm is the interesting one: `/a{0,1}?/` is a lazy optional, and `?`
+// is both the shorthand and the lazy marker, so the correct output stutters to
+// `/a??/`. Emitting a single `?` would silently make the quantifier greedy.
+//
+//  1. Fix a literal whose `{0,1}` carries a lazy marker.
+//  2. Assert the result is `/a??/`, taken from the quantifier semantics rather
+//     than from what reads naturally.
+//  3. Assert `{0,2}`, `{1,1}`, and `{0,}` report nothing.
+func TestFixRegexpPreferQuestionQuantifierReplacesZeroToOne(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "regexp/prefer-question-quantifier",
+    "const value = /a{0,1}?/;\nJSON.stringify(value);\n",
+    "const value = /a??/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-question-quantifier",
+    "const value = /a{0,2}/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-question-quantifier",
+    "const value = /a{1,1}/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-question-quantifier",
+    "const value = /a{0,}/;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_regexp_prefer_star_quantifier_replaces_open_ended_zero_test.go
+++ b/packages/lint/test/fix/fix_regexp_prefer_star_quantifier_replaces_open_ended_zero_test.go
@@ -1,0 +1,38 @@
+package linthost
+
+import "testing"
+
+// TestFixRegexpPreferStarQuantifierReplacesOpenEndedZero verifies
+// `regexp/prefer-star-quantifier` rewrites `{0,}` to `*`.
+//
+// The sibling of the `+` rewrite, separated so an over-match in one shorthand
+// cannot hide behind the other: `{0,}` and `{1,}` differ only in the minimum,
+// and the scan reports the two through the same code path.
+//
+//  1. Fix a literal whose `{0,}` follows a group, so the rewrite is pinned on
+//     an atom wider than one character.
+//  2. Assert the result is `/(?:ab)*c/`.
+//  3. Assert `{1,}`, `{0,1}`, and the comma-free `{0}` report nothing.
+func TestFixRegexpPreferStarQuantifierReplacesOpenEndedZero(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "regexp/prefer-star-quantifier",
+    "const value = /(?:ab){0,}c/;\nJSON.stringify(value);\n",
+    "const value = /(?:ab)*c/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-star-quantifier",
+    "const value = /a{1,}/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-star-quantifier",
+    "const value = /a{0,1}/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-star-quantifier",
+    "const value = /a{0}/;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_regexp_prefer_w_replaces_spelled_out_word_class_test.go
+++ b/packages/lint/test/fix/fix_regexp_prefer_w_replaces_spelled_out_word_class_test.go
@@ -1,0 +1,34 @@
+package linthost
+
+import "testing"
+
+// TestFixRegexpPreferWReplacesSpelledOutWordClass verifies `regexp/prefer-w`
+// rewrites both accepted spellings of the word class to `\w`.
+//
+// The rule accepts `[A-Za-z0-9_]` and `[a-zA-Z0-9_]`, so the fix has to cover
+// both orderings rather than the one the check happens to test first. `\w` is
+// equivalent to the spelled-out class under every flag combination, including
+// `iu`, where the flag widens both sides to the same two extra code points.
+//
+//  1. Fix a literal holding one class in each accepted spelling.
+//  2. Assert both become `\w`.
+//  3. Assert the same class missing its underscore reports nothing, since that
+//     one is genuinely narrower than `\w`.
+func TestFixRegexpPreferWReplacesSpelledOutWordClass(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "regexp/prefer-w",
+    "const value = /[A-Za-z0-9_]-[a-zA-Z0-9_]/;\nJSON.stringify(value);\n",
+    "const value = /\\w-\\w/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-w",
+    "const value = /[A-Za-z0-9]/;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/prefer-w",
+    "const value = /[A-Za-z_]/;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_regexp_require_unicode_regexp_offers_u_and_v_suggestions_test.go
+++ b/packages/lint/test/fix/fix_regexp_require_unicode_regexp_offers_u_and_v_suggestions_test.go
@@ -1,0 +1,65 @@
+package linthost
+
+import "testing"
+
+// TestFixRegexpRequireUnicodeRegexpOffersUAndVSuggestions verifies
+// `regexp/require-unicode-regexp` offers `u` and `v` as competing suggestions
+// and imposes neither.
+//
+// Both flags satisfy the rule and both change what the pattern matches — a
+// surrogate pair stops being two independent code units — so there is no single
+// right answer to apply automatically. The flag is inserted at its canonical
+// position rather than appended, so adding it to a literal ending in `y` does
+// not leave a run that `regexp/sort-flags` immediately re-reports.
+//
+//  1. Report on `/a/gy`, whose canonical insertion point is in the middle.
+//  2. Assert `ttsc fix` applies nothing, and each suggestion produces `guy`
+//     and `gvy` respectively.
+//  3. Assert a literal that already carries `u`, and one that carries `v`,
+//     report nothing.
+func TestFixRegexpRequireUnicodeRegexpOffersUAndVSuggestions(t *testing.T) {
+  source := "const value = /a/gy;\nJSON.stringify(value);\n"
+  _, _, findings := runRuleFindingsSnapshot(t, "regexp/require-unicode-regexp", source, nil)
+  if len(findings) != 1 {
+    t.Fatalf("findings = %d, want 1", len(findings))
+  }
+  finding := findings[0]
+  if len(finding.Fix) != 0 {
+    t.Fatalf("automatic fixes = %d, want 0", len(finding.Fix))
+  }
+  if len(finding.Suggestions) != 2 {
+    t.Fatalf("suggestions = %+v", finding.Suggestions)
+  }
+  expected := []struct {
+    title  string
+    result string
+  }{
+    {"Add the `u` flag.", "const value = /a/guy;\nJSON.stringify(value);\n"},
+    {"Add the `v` flag.", "const value = /a/gvy;\nJSON.stringify(value);\n"},
+  }
+  for index, want := range expected {
+    suggestion := finding.Suggestions[index]
+    if suggestion.Title != want.title {
+      t.Fatalf("suggestion %d title = %q, want %q", index, suggestion.Title, want.title)
+    }
+    rewritten, applied := applyFindingFixesToText(source, []*Finding{{Fix: suggestion.Edits}})
+    if applied != 1 || rewritten != want.result {
+      t.Fatalf("suggestion %d: applied=%d\nwant %q\ngot  %q", index, applied, want.result, rewritten)
+    }
+  }
+  automatic, applied := applyFindingFixesToText(source, findings)
+  if applied != 0 || automatic != source {
+    t.Fatalf("automatic edits changed source: applied=%d source=%q", applied, automatic)
+  }
+
+  assertRuleSkipsSource(
+    t,
+    "regexp/require-unicode-regexp",
+    "const value = /a/u;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/require-unicode-regexp",
+    "const value = /a/v;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_regexp_require_unicode_sets_regexp_offers_the_v_flag_test.go
+++ b/packages/lint/test/fix/fix_regexp_require_unicode_sets_regexp_offers_the_v_flag_test.go
@@ -1,0 +1,70 @@
+package linthost
+
+import "testing"
+
+// TestFixRegexpRequireUnicodeSetsRegexpOffersTheVFlag verifies
+// `regexp/require-unicode-sets-regexp` offers the single `v` rewrite, replacing
+// `u` where the literal already carries it.
+//
+// `u` and `v` are mutually exclusive, so on a `u` literal the correction is a
+// substitution and not an insertion; appending would produce `uv`, which is not
+// a legal flag run. It stays a suggestion rather than a fix for the same reason
+// as its sibling rule: `v` is a stricter matching mode, not a respelling.
+//
+//  1. Assert `/a/giu` offers a replacement suggestion producing `giv`.
+//  2. Assert `/a/g`, which carries no Unicode flag, offers an insertion
+//     producing `gv`, and that neither literal is edited automatically.
+//  3. Assert a literal already carrying `v` reports nothing.
+func TestFixRegexpRequireUnicodeSetsRegexpOffersTheVFlag(t *testing.T) {
+  cases := []struct {
+    source string
+    title  string
+    result string
+  }{
+    {
+      "const value = /a/giu;\nJSON.stringify(value);\n",
+      "Replace the `u` flag with `v`.",
+      "const value = /a/giv;\nJSON.stringify(value);\n",
+    },
+    {
+      "const value = /a/g;\nJSON.stringify(value);\n",
+      "Add the `v` flag.",
+      "const value = /a/gv;\nJSON.stringify(value);\n",
+    },
+  }
+  for _, tc := range cases {
+    _, _, findings := runRuleFindingsSnapshot(
+      t,
+      "regexp/require-unicode-sets-regexp",
+      tc.source,
+      nil,
+    )
+    if len(findings) != 1 {
+      t.Fatalf("%q: findings = %d, want 1", tc.source, len(findings))
+    }
+    finding := findings[0]
+    if len(finding.Fix) != 0 || len(finding.Suggestions) != 1 {
+      t.Fatalf("%q: fixes=%d suggestions=%+v", tc.source, len(finding.Fix), finding.Suggestions)
+    }
+    if finding.Suggestions[0].Title != tc.title {
+      t.Fatalf("%q: title = %q, want %q", tc.source, finding.Suggestions[0].Title, tc.title)
+    }
+    rewritten, applied := applyFindingFixesToText(
+      tc.source,
+      []*Finding{{Fix: finding.Suggestions[0].Edits}},
+    )
+    if applied != 1 || rewritten != tc.result {
+      t.Fatalf("%q: applied=%d\nwant %q\ngot  %q", tc.source, applied, tc.result, rewritten)
+    }
+    automatic, applied := applyFindingFixesToText(tc.source, findings)
+    if applied != 0 || automatic != tc.source {
+      t.Fatalf("%q: automatic edits applied=%d got %q", tc.source, applied, automatic)
+    }
+  }
+
+  assertRuleSkipsSource(
+    t,
+    "regexp/require-unicode-sets-regexp",
+    "const value = /a/v;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_regexp_sort_flags_rewrites_flag_run_in_canonical_order_test.go
+++ b/packages/lint/test/fix/fix_regexp_sort_flags_rewrites_flag_run_in_canonical_order_test.go
@@ -1,0 +1,43 @@
+package linthost
+
+import "testing"
+
+// TestFixRegexpSortFlagsRewritesFlagRunInCanonicalOrder verifies
+// `regexp/sort-flags` emits the sorted flag run it already built to decide the
+// finding.
+//
+// The check sorted the flags into ECMAScript's `dgimsuvy` order and compared
+// the result against the source, then discarded it; the correction was computed
+// on every report and never offered. A permutation of a flag run cannot change
+// what the literal matches, which is why this is an automatic fix and not a
+// suggestion.
+//
+//  1. Fix a literal whose five flags are fully scrambled, so the assertion
+//     pins the order rather than a single swap.
+//  2. Assert the emitted run is `gimuy`.
+//  3. Assert the already-sorted twin, a single flag, and no flags at all report
+//     nothing, so the fix cannot be reached by a literal that is already
+//     canonical.
+func TestFixRegexpSortFlagsRewritesFlagRunInCanonicalOrder(t *testing.T) {
+  assertFixSnapshot(
+    t,
+    "regexp/sort-flags",
+    "const value = /a/ygimu;\nJSON.stringify(value);\n",
+    "const value = /a/gimuy;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/sort-flags",
+    "const value = /a/gimuy;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/sort-flags",
+    "const value = /a/i;\nJSON.stringify(value);\n",
+  )
+  assertRuleSkipsSource(
+    t,
+    "regexp/sort-flags",
+    "const value = /a/;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/fix/fix_regexp_withholds_a_rewrite_the_regex_parser_rejects_test.go
+++ b/packages/lint/test/fix/fix_regexp_withholds_a_rewrite_the_regex_parser_rejects_test.go
@@ -1,0 +1,56 @@
+package linthost
+
+import "testing"
+
+// TestFixRegexpWithholdsARewriteTheRegexParserRejects verifies the shared
+// regexp repair gate drops a candidate edit whose result is not a valid regular
+// expression, keeping the diagnostic.
+//
+// Every regexp repair is a splice into live regex syntax, where a locally
+// correct edit can still produce a pattern the engine rejects. `/{1,}/` has no
+// atom in front of the brace run, so Annex B reads it as four literal
+// characters rather than a quantifier; both quantifier rules still report it,
+// and rewriting it would emit `/+/` or `//` — "nothing to repeat" and a line
+// comment. `/\-/` is the flag-side twin: `\-` is a legal identity escape only
+// while the literal has no Unicode flag, so both `u` and `v` candidates fall
+// away and the finding is left with no suggestion at all.
+//
+//  1. Assert both brace rules report `/{1,}/` and `/{1}/` yet apply no edit.
+//  2. Assert `regexp/require-unicode-regexp` reports `/\-/` with zero
+//     suggestions, rather than offering a flag that would not compile.
+//  3. Assert the same rules do rewrite the well-formed twin, so the gate is
+//     rejecting the invalid result and not disabling the fixers.
+func TestFixRegexpWithholdsARewriteTheRegexParserRejects(t *testing.T) {
+  assertNoFixSnapshot(
+    t,
+    "regexp/prefer-plus-quantifier",
+    "const value = /{1,}/;\nJSON.stringify(value);\n",
+  )
+  assertNoFixSnapshot(
+    t,
+    "regexp/no-useless-quantifier",
+    "const value = /{1}/;\nJSON.stringify(value);\n",
+  )
+
+  source := "const value = /\\-/;\nJSON.stringify(value);\n"
+  _, _, findings := runRuleFindingsSnapshot(t, "regexp/require-unicode-regexp", source, nil)
+  if len(findings) != 1 {
+    t.Fatalf("findings = %d, want 1", len(findings))
+  }
+  if len(findings[0].Fix) != 0 || len(findings[0].Suggestions) != 0 {
+    t.Fatalf("fixes=%d suggestions=%+v", len(findings[0].Fix), findings[0].Suggestions)
+  }
+
+  assertFixSnapshot(
+    t,
+    "regexp/prefer-plus-quantifier",
+    "const value = /a{1,}/;\nJSON.stringify(value);\n",
+    "const value = /a+/;\nJSON.stringify(value);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "regexp/no-useless-quantifier",
+    "const value = /a{1}/;\nJSON.stringify(value);\n",
+    "const value = /a/;\nJSON.stringify(value);\n",
+  )
+}

--- a/website/src/content/docs/lint/rules/index.mdx
+++ b/website/src/content/docs/lint/rules/index.mdx
@@ -122,9 +122,10 @@ Formatter behavior is configured separately through the top-level `format` block
 - `typescript/prefer-as-const` (assertions only; annotation rewrites are editor suggestions), `no-useless-rename`, `object-shorthand`, `typescript/no-extra-non-null-assertion`
 - `typescript/no-unnecessary-type-constraint`, `typescript/prefer-namespace-keyword`, `no-useless-escape`
 - `typescript/no-import-type-side-effects` (hoists inline `type` modifiers)
+- `regexp/sort-flags`, `regexp/no-useless-flag`, `regexp/prefer-d`, `regexp/prefer-w`, and the quantifier shorthands `regexp/prefer-plus-quantifier`, `regexp/prefer-star-quantifier`, `regexp/prefer-question-quantifier`, `regexp/no-useless-two-nums-quantifier`, `regexp/no-useless-quantifier`
 - Every format rule
 
-Suggestion-only rewrites, including removing an ordinary non-thenable `await` and replacing `@ts-ignore`, are available through `quickfix.ttsc`; `ttsc fix` and source fix-all do not apply them.
+Suggestion-only rewrites, including removing an ordinary non-thenable `await`, replacing `@ts-ignore`, and adding a Unicode flag for `regexp/require-unicode-regexp` / `regexp/require-unicode-sets-regexp`, are available through `quickfix.ttsc`; `ttsc fix` and source fix-all do not apply them.
 
 ## See also
 

--- a/website/src/content/docs/lint/rules/regexp.mdx
+++ b/website/src/content/docs/lint/rules/regexp.mdx
@@ -8,6 +8,12 @@ Some rules duplicate (and supersede) the regex-related rules in [Core](./core); 
 
 Source: [`eslint-plugin-regexp`](https://github.com/ota-meshi/eslint-plugin-regexp) (MIT).
 
+## Corrections
+
+A rule in this family offers an automatic fix only where the rewrite provably matches the same strings — reordering flags, swapping a count quantifier for its shorthand, deleting a flag the pattern cannot exercise. Where the correction changes what the literal matches, or where more than one repair is valid, the rule offers editor suggestions instead; `ttsc fix` and `source.fixAll.ttsc` never apply those.
+
+Every candidate rewrite is re-parsed by the compiler's own regexp parser before it is offered. A regex repair is a splice into live syntax, so an edit that is locally right can still leave a pattern the engine rejects: `/{1,}/` has no atom in front of the brace run, which makes it four literal characters rather than a quantifier, and rewriting it would produce `/+/`. Such a literal keeps its diagnostic and is left untouched. A rule may also decline an individual edit whose neighbours make it unsafe even though the result would parse — see [`regexp/no-useless-quantifier`](#rule-regexp-no-useless-quantifier).
+
 ## Rule index
 
 Each rule name links to the detailed section below.
@@ -187,6 +193,8 @@ A character is case-variable when the `i` flag widens what it matches, wherever 
 
 Undecidable patterns are left alone rather than reported: a Unicode property escape (`/\p{Nd}/iu`), a backreference (`i` makes the backreference comparison itself case-insensitive, so `/(.)\1/i` genuinely needs the flag), and a `v`-mode set-notation class all count as using the flag.
 
+The diagnostic names the dead flags, and the autofix deletes exactly those, leaving the live flags in place (`/\d+/gim` becomes `/\d+/g`). Because the analysis is one-sided — anything it cannot settle counts as using the flag — a flag it does report is provably inert.
+
 Example:
 
 ```ts
@@ -203,6 +211,11 @@ const liveLowercaseRange = /[a-z]/i;
 
 Reject quantifiers that do not change the match, constant-one counts (`/a{1}/`), `?` on patterns already matching the empty string (`/(?:a+|b*)?/`), and quantifiers on non-consuming atoms (`/(?:\b)+/`).
 
+Autofixable for the constant-one count: `/a{1}b/` becomes `/ab/`. Two following characters make the deletion unsafe, and both still parse afterwards, so the rule declines the edit and reports only:
+
+- A lazy or nested marker (`?`, `*`, `+`, `{`). `/a{1}?/` is "exactly one, lazily"; dropping the braces would leave the optional `/a?/`.
+- A digit. `/\1{1}2/` would fuse into `\12`, backreference twelve rather than backreference one followed by a literal `2`.
+
 Example:
 
 ```ts
@@ -214,7 +227,7 @@ const value = /a{1}/;
 
 ### `regexp/no-useless-two-nums-quantifier`
 
-Reject equal min/max quantifiers (`/a{2,2}/`) in favor of `/a{2}/`.
+Reject equal min/max quantifiers (`/a{2,2}/`) in favor of `/a{2}/`. Autofixable; the braces stay in place, so the count collapses without exposing the atom to its neighbours.
 
 Example:
 
@@ -229,7 +242,7 @@ const value = /a{2,2}/;
 
 Reject zero-repeat quantifiers (`/a{0}/`, `/a{0,0}/`), the atom never matches, so the quantifier is either dead code or a typo for `{1,...}`.
 
-The fix is normally to delete the atom or correct the upper bound.
+Diagnostic-only, unlike the rest of the quantifier family. The correction is to delete the atom or repair the bound, and which one was meant is not recoverable from the source; deleting only the braces would turn "never" into "once".
 
 Example:
 
@@ -242,7 +255,9 @@ const value = /a{0}/;
 
 ### `regexp/prefer-d`
 
-Prefer `\d` over `[0-9]` in regex literals.
+Prefer `\d` over `[0-9]` in regex literals. Autofixable; every spelled-out digit class in the literal is rewritten in one edit. `\d` is defined as exactly `[0-9]` under every flag combination.
+
+The fix is located by walking real character classes, so a literal whose bracket is escaped (`/\[0-9]/`, which contains no class at all) keeps its diagnostic without being rewritten.
 
 Example:
 
@@ -255,7 +270,7 @@ const digit = /[0-9]/;
 
 ### `regexp/prefer-plus-quantifier`
 
-Prefer `+` over `{1,}` in regex literals.
+Prefer `+` over `{1,}` in regex literals. Autofixable; `+` and `{1,}` bind identically, so a trailing lazy marker survives the swap (`/a{1,}?/` becomes `/a+?/`).
 
 Example:
 
@@ -268,7 +283,7 @@ const value = /a{1,}/;
 
 ### `regexp/prefer-question-quantifier`
 
-Prefer `?` over `{0,1}` in regex literals.
+Prefer `?` over `{0,1}` in regex literals. Autofixable. `?` is both the shorthand and the lazy marker, so a lazy `{0,1}` correctly stutters: `/a{0,1}?/` becomes `/a??/`.
 
 Example:
 
@@ -281,7 +296,7 @@ const value = /a{0,1}/;
 
 ### `regexp/prefer-star-quantifier`
 
-Prefer `*` over `{0,}` in regex literals.
+Prefer `*` over `{0,}` in regex literals. Autofixable, on the same terms as [`regexp/prefer-plus-quantifier`](#rule-regexp-prefer-plus-quantifier).
 
 Example:
 
@@ -294,7 +309,7 @@ const value = /a{0,}/;
 
 ### `regexp/prefer-w`
 
-Prefer `\w` over `[A-Za-z0-9_]` in regex literals.
+Prefer `\w` over `[A-Za-z0-9_]` in regex literals. Autofixable for both accepted spellings (`[A-Za-z0-9_]` and `[a-zA-Z0-9_]`). `\w` matches the same set under every flag combination, including `iu`, where the flag widens the shorthand and the spelled-out class to the same two extra code points.
 
 Example:
 
@@ -308,6 +323,8 @@ const word = /[A-Za-z0-9_]/;
 ### `regexp/require-unicode-regexp`
 
 Require regex literals to use the `u` or `v` flag, so Unicode-property escapes and surrogate-pair handling stay predictable.
+
+Offers `u` and `v` as editor suggestions rather than an automatic fix: both satisfy the rule, and both change what the pattern matches, since a surrogate pair stops being two independent code units. The flag is inserted at its canonical position instead of appended, so adding it does not leave a run that [`regexp/sort-flags`](#rule-regexp-sort-flags) immediately re-reports. A pattern that is only legal without a Unicode flag (`/\-/`, whose `\-` is an identity escape the stricter modes reject) is reported with no suggestion at all.
 
 Example:
 
@@ -324,6 +341,8 @@ Require regex literals to use the `v` flag specifically, the stricter Unicode-se
 
 Choose this over `require-unicode-regexp` only on engines that ship ES2024-era regex.
 
+Offers one editor suggestion, for the same reason as its sibling: `v` is a stricter matching mode, not a respelling. Because `u` and `v` are mutually exclusive, the suggestion replaces an existing `u` (`/a/giu` becomes `/a/giv`) rather than appending.
+
 Example:
 
 ```ts
@@ -339,9 +358,14 @@ Require regex flags to appear in canonical alphabetical order (`dgimsuvy`).
 
 Stable ordering keeps diffs small and lets readers compare flag sets at a glance.
 
+Autofixable: the sorted run the check already built to decide the finding is what gets written back. A permutation of a flag run cannot change what the literal matches.
+
 Example:
 
 ```ts
 // reports: regexp/sort-flags (error)
-const value = /a/im;
+const value = /a/mi;
+
+// not reported: `im` is already the canonical order
+const sorted = /a/im;
 ```


### PR DESCRIPTION
Every rule in the `regexp/*` table computed exactly where and what was wrong, then discarded it: all 21 table-registered rules funnelled through one `func(regexpLiteralParts) bool` predicate and a bare `ctx.Report`. `regexp/sort-flags` built the sorted flag string and threw it away; the quantifier scan knew each `{…}` span and passed only a bool; `regexp/no-useless-flag` decided *which* flag was dead and did not even name it.

`regexpSourceRule` now carries an optional `repair func(regexpLiteralParts) regexpRepair`. A repair returns edits in **literal-relative** coordinates, so a rule never handles file offsets; `Check` lifts them onto the file in one place.

## The shared safety gate

Before any edit is offered, `Check` splices it into the literal and re-parses the result with `shimscanner.IsValidRegularExpressionLiteral` — the compiler's own regexp parser. A regex repair is a splice into live syntax, so a locally correct edit can still leave a pattern the engine rejects: `/{1,}/` has no atom in front of the brace run, which makes it four literal characters rather than a quantifier, and rewriting it would emit `/+/` ("nothing to repeat") or `//` (a line comment). Such a literal keeps its diagnostic and is left untouched.

Validity is explicitly **not** equivalence, and the code says so: preserving semantics stays each rule's own burden. Where a still-parsing rewrite would change meaning, the rule declines on its own (see `no-useless-quantifier` below).

## What each rule now offers

**Automatic fixes** (applied by `ttsc fix` / `source.fixAll.ttsc`):

| Rule | Correction |
| --- | --- |
| `regexp/sort-flags` | Writes back the sorted run the check already built. `/a/ygimu` → `/a/gimuy`. A permutation cannot change what the literal matches. |
| `regexp/prefer-plus-quantifier` | `{1,}` → `+`, every occurrence in one atomic group. `+` binds identically, so `/a{1,}?/` → `/a+?/` keeps the lazy marker. |
| `regexp/prefer-star-quantifier` | `{0,}` → `*`. |
| `regexp/prefer-question-quantifier` | `{0,1}` → `?`. `?` is both the shorthand and the lazy marker, so `/a{0,1}?/` correctly stutters to `/a??/`. |
| `regexp/no-useless-two-nums-quantifier` | `{n,n}` → `{n}`, count reprinted from the parsed minimum so `{10,10}` → `{10}`, not `{1}`. |
| `regexp/no-useless-quantifier` | `{1}` deleted. Declines on two neighbours, both of which still parse afterwards: a following `?`/`*`/`+`/`{` (`/a{1}?/` is "exactly one, lazily" and would become the optional `/a?/`) and a following digit (`/\1{1}2/` would fuse into `\12`, backreference twelve). |
| `regexp/no-useless-flag` | Deletes exactly the dead flags, leaving live ones: `/\d+/gim` → `/\d+/g`. Safe to impose because the analysis is one-sided — anything it cannot settle counts as using the flag. |
| `regexp/prefer-d` | `[0-9]` → `\d`, every class in the literal. `\d` is defined as exactly `[0-9]` under all flags. |
| `regexp/prefer-w` | `[A-Za-z0-9_]` / `[a-zA-Z0-9_]` → `\w`. Equivalent under every flag combination, including `iu`, where the flag widens the shorthand and the spelled-out class to the same two extra code points. |

**Suggestions** (offered via `quickfix.ttsc`, never applied automatically) — both change what the pattern matches, so neither can be imposed:

- `regexp/require-unicode-regexp` — a genuine choice of two: "Add the `u` flag." and "Add the `v` flag.".
- `regexp/require-unicode-sets-regexp` — one suggestion, which **replaces** an existing `u` (`/a/giu` → `/a/giv`) because `u` and `v` are mutually exclusive.

Both insert the flag at its canonical `dgimsuvy` position rather than appending, so adding a flag to `/a/gy` yields `guy` and does not leave a run `regexp/sort-flags` immediately re-reports. Both fall away entirely when the pattern is only legal without a Unicode flag: `/\-/` is reported with **zero** suggestions rather than one that would not compile.

## Deliberately left alone

- **`regexp/no-zero-quantifier`** — `{0}` is a bug, not a redundancy. The correction is to delete the atom or repair the bound, and which was meant is unrecoverable; deleting only the braces would turn "never" into "once". Pinned by a dedicated test so a later pass cannot add it by symmetry with its siblings.
- **`regexp/no-useless-character-class`** (`[a]` → `a`) — the replacement is a *bare* character, so unlike `\d`/`\w` it can fuse with the preceding atom, and the fused result still parses: `/\1[2]/` → `/\12/` and `/\c[a]/` → `/\ca/`. A correct guard needs backward atom analysis the rule does not do today.
- **`no-empty-alternative`, `no-empty-capturing-group`, `no-empty-character-class`, `no-empty-group`, `no-empty-lookarounds-assertion`, `no-control-character`, `no-dupe-characters-character-class`, `no-misleading-unicode-character`** — these report a defect, not a redundancy; none computes a correction. `no-empty-character-class` in particular is a bug, as the task noted.
- `regexp/no-useless-escape` already fixes through its own alias and is untouched.

I evaluated routing rules through `regexOptimizeLiteral` + a `regexTransformList` blacklist and did not use it. The transform names map onto the rule names, but a blacklisted-transform run rewrites the **whole literal** through the tree printer, so the emitted diff is not confined to what the rule reported, and the optimizer is already gated off for `u`/`v` literals in `unicorn/better-regex`. A direct span edit is both narrower and easier to prove; the shared re-parse gate gives the safety the optimizer route was attractive for.

## Message changes (specification)

`regexp/no-useless-flag` previously emitted the generic **"Unexpected useless regular expression flag."**, which did not say which flag. It now names them:

- **"Unexpected useless regular expression flag `i`."**
- **"Unexpected useless regular expression flags `i` and `m`."**

Detection is unchanged: the old code returned early on a dead `i`, the new code collects both, and it still fires exactly when either is dead. No other rule's message changed.

## Behavior deliberately *not* changed

`regexp/prefer-d` and `regexp/prefer-w` still decide the finding with the existing `strings.Contains` test, while the fix is located by walking real character classes. The two disagree on one shape: `/\[0-9]/` has an escaped bracket and therefore no class at all, yet the substring test reports it. That is a pre-existing false positive; it keeps its report and now correctly gets **no** edit (a substring-driven splice would have emitted `/\\d/`, a literal backslash followed by `d`). I left the predicate alone rather than silently narrow detection in a fixes PR — flagging it here as a follow-up candidate. It is covered by a test so the mismatch is documented rather than latent.

One documentation bug fixed in passing: the `regexp/sort-flags` example claimed `/a/im` reports, but `im` is already canonical. Corrected to `/a/mi` with the sorted twin as a counter-example.

## Tests

13 new cases under `packages/lint/test/fix/`, one per file, each carrying the transformation direction (a mangled input producing the canonical output), a negative twin one property away, and the boundaries. Expected outputs were taken from regex semantics, not from what the code emits — `/a{0,1}?/` → `/a??/` and `/a{10,10}/` → `/a{10}/` are the cases where that mattered.

Notable arms: `fix_regexp_no_useless_quantifier_drops_exactly_one_repeat_test.go` asserts the lazy and backreference neighbours report **without** applying an edit; `fix_regexp_withholds_a_rewrite_the_regex_parser_rejects_test.go` pins the shared gate on `/{1,}/`, `/{1}/`, and `/\-/`, then asserts the well-formed twins still rewrite, so the gate is rejecting invalid results rather than disabling the fixers; `fix_regexp_no_zero_quantifier_stays_diagnostic_only_test.go` pins the deliberate omission.

## Verification

- `go build ./linthost/` and `go vet ./linthost/` in a temporary `go.work` (deleted; not committed).
- **Full `packages/lint` Go suite green**, 439s, via a local mirror of `scripts/test-go-lint.cjs` — this worktree has no `node_modules`, so the runner's own `ttsx`/`tsgo` resolution was pointed at the main checkout's binaries; materialization, overlay flattening, and `go test -count=1 ./linthost` are otherwise identical to CI.
- All 13 new tests pass individually and after formatting.
- Formatting: `.vscode/gofmt-2spaces.sh -w` on the touched Go files only; `prettier --check` clean on the touched `.ts`/`.mdx` files. The repository-wide formatter was **not** run (issue campaign active).
- Not run locally: the `tests/test-lint` TypeScript feature corpus (needs a built workspace this worktree lacks). The corpus asserts rule/severity/line and no message text, and `regexp-no-useless-flag.ts` is annotation-only, so the message change should not reach it — CI is the gate.

## Docs

`website/src/content/docs/lint/rules/regexp.mdx` gains a "Corrections" section covering the fix-vs-suggestion policy and the re-parse gate, plus per-rule notes; `rules/index.mdx` autofix-coverage list updated; `ITtscLintRegexpRules.ts` JSDoc now states fix availability per rule, matching the convention `core.mdx` documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbiF9VH8TAGwdgFBnEQYfz
