### PR TITLE
test(ttscserver): drive the real LSP wire end to end

### DIFF
--- a/tests/test-ttsc/src/native-plugins/server/test_ttscserver_lsp_editor_session_merges_suppresses_and_fixes.ts
+++ b/tests/test-ttsc/src/native-plugins/server/test_ttscserver_lsp_editor_session_merges_suppresses_and_fixes.ts
@@ -1,0 +1,374 @@
+import { TestLint } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { SHARED_PLUGIN_CACHE_DIR } from "../../internal/plugin-cache";
+import {
+  TtscserverClient,
+  assert,
+  shutdownTtscserverClient,
+} from "../../internal/ttscserver";
+
+type Position = { character?: number; line?: number };
+
+type Range = { end?: Position; start?: Position };
+
+type Diagnostic = {
+  code?: unknown;
+  message?: string;
+  range?: Range;
+  severity?: number;
+  source?: string;
+};
+
+type PublishDiagnosticsParams = {
+  diagnostics?: Diagnostic[];
+  uri: string;
+  version?: number;
+};
+
+type CodeAction = {
+  command?: { arguments?: unknown[]; command?: string };
+  kind?: string;
+  title?: string;
+};
+
+type InitializeResult = {
+  capabilities?: {
+    codeActionProvider?: boolean | { codeActionKinds?: string[] };
+    diagnosticProvider?: unknown;
+    documentFormattingProvider?: boolean;
+    executeCommandProvider?: { commands?: string[] };
+  };
+};
+
+type TextEdit = { newText?: string; range?: Range };
+
+type WorkspaceEdit = { changes?: Record<string, TextEdit[]> };
+
+const OPENED = "var legacy = 1;\nconsole.log(legacy);\n";
+
+const APPENDED_LINE = 'console.log("edited");\n';
+
+/**
+ * End of {@link OPENED}. Its trailing newline closes line 1, so the empty line 2
+ * is where an editor's caret sits when the user types the next line.
+ */
+const APPEND_POSITION = { character: 0, line: 2 };
+
+const SAVED = OPENED + APPENDED_LINE;
+
+/** `no-var` alone rewrites the keyword to `let`; `const` needs `prefer-const`. */
+const FIXED = SAVED.replace("var legacy", "let legacy");
+
+/**
+ * Verifies one ttscserver LSP session carries diagnostics through to a fix.
+ *
+ * The VS Code extension's whole job is this JSON-RPC conversation, yet each
+ * sibling server test pins a single verb in its own process. Nothing reads the
+ * `initialize` capabilities the editor registers its commands and lightbulb
+ * kinds from, and nothing sends `didChange` or `didSave` at all — so the
+ * dirty-buffer suppression between an edit and its save, and the republication
+ * that ends it, have no coverage. A break anywhere along initialize → didOpen →
+ * didChange → didSave → codeAction → executeCommand would leave every existing
+ * test green while the editor showed nothing.
+ *
+ * 1. Materialize a `@ttsc/lint` project with a `no-var` violation, handshake,
+ *    and assert ttsc's command ids and action kinds are merged into tsgo's
+ *    advertised capabilities rather than replacing them.
+ * 2. Open the file and assert the lint diagnostic underlines the `var` keyword;
+ *    edit the buffer and assert the dirty publish drops the finding; save and
+ *    assert it returns.
+ * 3. Ask for code actions over that diagnostic's own range and assert the
+ *    ttsc-owned `ttsc.lint.fixAll` action comes back.
+ * 4. Execute that command and assert the returned WorkspaceEdit fixes the
+ *    violation without writing the file, then shut the server down cleanly.
+ */
+export const test_ttscserver_lsp_editor_session_merges_suppresses_and_fixes =
+  async () => {
+    const project = TestLint.createProject({
+      name: "ttscserver-lsp-editor-session",
+      rules: { "no-var": "error" },
+      source: OPENED,
+    });
+    const file = path.join(project.tmpdir, "src", "main.ts");
+    const uri = pathToFileURL(file).href;
+    const client = TtscserverClient.startLauncher(project.tmpdir, {
+      env: { TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR },
+    });
+
+    try {
+      // 1. Handshake. The editor builds its command palette and lightbulb menu
+      // from this response, so the advertised ids are editor-visible behavior.
+      const initialized = await step(
+        "initialize",
+        client.request<InitializeResult>(
+          "initialize",
+          {
+            capabilities: {},
+            processId: process.pid,
+            rootUri: pathToFileURL(project.tmpdir).href,
+          },
+          // Deliberately unbounded, matching
+          // test_ttscserver_lsp_honors_explicit_lint_config_file: the launcher
+          // builds project plugins before it spawns the server, so a cold
+          // `@ttsc/lint` source build — minutes, and measured at over ten on a
+          // cold Go cache — is charged entirely to this one request. Any bound
+          // small enough to be a useful hang signal is small enough to flake.
+          // The wait still ends on server death: the client rejects every
+          // pending request when the child closes.
+        ),
+      );
+      const capabilities = initialized.capabilities ?? {};
+      assert.ok(
+        capabilities.executeCommandProvider?.commands?.includes(
+          "ttsc.lint.fixAll",
+        ),
+        `initialize should advertise ttsc.lint.fixAll: ${JSON.stringify(capabilities.executeCommandProvider)}`,
+      );
+      assert.equal(
+        capabilities.documentFormattingProvider,
+        true,
+        "ttsc owns ttsc.format.document, so formatOnSave must stay advertised",
+      );
+      // ttsc rewrites the initialize result in flight. Assert both sides of
+      // every field it touches: tsgo advertises codeActionProvider as an object
+      // carrying its own kinds, and a regression that replaced the capability
+      // instead of merging into it would still satisfy either half alone.
+      const codeActionKinds =
+        typeof capabilities.codeActionProvider === "object"
+          ? (capabilities.codeActionProvider.codeActionKinds ?? [])
+          : [];
+      assert.ok(
+        codeActionKinds.includes("source.fixAll.ttsc"),
+        `initialize should advertise source.fixAll.ttsc: ${JSON.stringify(capabilities.codeActionProvider)}`,
+      );
+      assert.ok(
+        codeActionKinds.includes("quickfix"),
+        `ttsc must merge into tsgo's kinds, not replace them: ${JSON.stringify(capabilities.codeActionProvider)}`,
+      );
+      // tsgo 7 reports its own findings through the pull channel
+      // (`textDocument/diagnostic`) rather than pushing publishDiagnostics, so
+      // ttsc's push-side merge has nothing upstream to merge with. Its
+      // capability still has to survive the rewrite, or the editor would stop
+      // asking tsgo for type errors entirely.
+      assert.ok(
+        capabilities.diagnosticProvider,
+        `ttsc must not drop tsgo's diagnosticProvider: ${JSON.stringify(capabilities)}`,
+      );
+      client.notify("initialized", {});
+
+      // 2. didOpen. Register the waiter first: publishDiagnostics is
+      // server-initiated and races the notification that triggers it.
+      const opened = step(
+        "didOpen publishDiagnostics",
+        client.waitForNotification<PublishDiagnosticsParams>(
+          "textDocument/publishDiagnostics",
+          (params) => params.uri === uri && findLint(params) !== undefined,
+          DIAGNOSTICS_TIMEOUT,
+        ),
+      );
+      client.notify("textDocument/didOpen", {
+        textDocument: {
+          languageId: "typescript",
+          text: fs.readFileSync(file, "utf8"),
+          uri,
+          version: 1,
+        },
+      });
+      const openedLint = findLint(await opened)!;
+      assert.deepEqual(
+        openedLint.range,
+        { end: { character: 3, line: 0 }, start: { character: 0, line: 0 } },
+        "the lint diagnostic must underline the `var` keyword itself",
+      );
+      assert.equal(openedLint.severity, 1, "no-var is configured as an error");
+      assert.match(
+        openedLint.message ?? "",
+        /Unexpected var, use let or const instead/,
+      );
+
+      // 3. didChange. While the buffer is dirty the proxy deliberately drops
+      // plugin findings: the sidecar reads disk, so a stale underline would sit
+      // on text the user has already changed. The edit keeps the violation, so
+      // an empty plugin contribution here is suppression, not absence.
+      assert.ok(SAVED.includes("var legacy"), "the edit must keep the finding");
+      const dirty = step(
+        "didChange publishDiagnostics",
+        client.waitForNotification<PublishDiagnosticsParams>(
+          "textDocument/publishDiagnostics",
+          (params) =>
+            params.uri === uri &&
+            params.version === 2 &&
+            findLint(params) === undefined,
+          DIAGNOSTICS_TIMEOUT,
+        ),
+      );
+      // tsgo advertises `textDocumentSync.change: 2` (Incremental), so send the
+      // ranged edit a real client sends rather than a full replacement.
+      client.notify("textDocument/didChange", {
+        contentChanges: [
+          {
+            range: { end: APPEND_POSITION, start: APPEND_POSITION },
+            text: APPENDED_LINE,
+          },
+        ],
+        textDocument: { uri, version: 2 },
+      });
+      await dirty;
+
+      // 4. didSave. The editor writes the buffer, then notifies; the sidecar
+      // re-reads disk and the findings come back.
+      const saved = step(
+        "didSave publishDiagnostics",
+        client.waitForNotification<PublishDiagnosticsParams>(
+          "textDocument/publishDiagnostics",
+          (params) => params.uri === uri && findLint(params) !== undefined,
+          DIAGNOSTICS_TIMEOUT,
+        ),
+      );
+      fs.writeFileSync(file, SAVED, "utf8");
+      client.notify("textDocument/didSave", {
+        text: SAVED,
+        textDocument: { uri },
+      });
+      const savedLint = findLint(await saved)!;
+      assert.deepEqual(
+        savedLint.range,
+        openedLint.range,
+        "the appended line is below the violation, so its range must not move",
+      );
+
+      // 5. The lightbulb request, scoped to the diagnostic the editor is
+      // showing: its own range, its own diagnostic object, and the fix-all kind
+      // VS Code asks for on a ttsc squiggle.
+      const actions = await step(
+        "textDocument/codeAction",
+        client.request<CodeAction[] | null>(
+          "textDocument/codeAction",
+          {
+            context: {
+              diagnostics: [savedLint],
+              only: ["source.fixAll.ttsc"],
+              triggerKind: 1,
+            },
+            range: savedLint.range,
+            textDocument: { uri },
+          },
+          REQUEST_TIMEOUT,
+        ),
+      );
+      const fixAll = (actions ?? []).find(
+        (action) => action.command?.command === "ttsc.lint.fixAll",
+      );
+      assert.ok(
+        fixAll,
+        `expected a ttsc.lint.fixAll action: ${JSON.stringify(actions)}`,
+      );
+      assert.equal(fixAll.kind, "source.fixAll.ttsc");
+      assert.deepEqual(
+        fixAll.command?.arguments,
+        [uri],
+        "the action must target the open document",
+      );
+
+      // 6. executeCommand. The extension applies the returned WorkspaceEdit
+      // itself, so the sidecar must not touch the file.
+      const edit = await step(
+        "workspace/executeCommand",
+        client.request<WorkspaceEdit>(
+          "workspace/executeCommand",
+          { arguments: fixAll.command?.arguments, command: "ttsc.lint.fixAll" },
+          REQUEST_TIMEOUT,
+        ),
+      );
+      const edits = edit.changes?.[uri] ?? [];
+      assert.ok(edits.length > 0, "expected WorkspaceEdit changes");
+      assert.equal(
+        applyTextEdits(SAVED, edits),
+        FIXED,
+        "applying the edit must remove the diagnosed `var`",
+      );
+      assert.equal(
+        fs.readFileSync(file, "utf8"),
+        SAVED,
+        "LSP executeCommand should return edits, not write the file",
+      );
+    } finally {
+      await shutdownTtscserverClient(client);
+      project.cleanup();
+    }
+  };
+
+/**
+ * Bound for a publishDiagnostics wait. `lsp-diagnostics` goes to the resident
+ * sidecar daemon, which the proxy bounds at 30s per verb and falls back to a
+ * fresh spawn on timeout — so a single wait can legitimately cost two attempts
+ * plus the first one's Program load.
+ */
+const DIAGNOSTICS_TIMEOUT = 120_000;
+
+/** Bound for a request the sidecar answers with a Program already loaded. */
+const REQUEST_TIMEOUT = 60_000;
+
+/**
+ * Label a bounded wait with the chain step it belongs to. Three steps await the
+ * same `textDocument/publishDiagnostics` method, so the harness's own timeout
+ * message cannot say which link of the chain broke.
+ */
+async function step<T>(name: string, pending: Promise<T>): Promise<T> {
+  try {
+    return await pending;
+  } catch (error) {
+    throw new Error(
+      `ttscserver LSP session step "${name}" never completed: ${
+        error instanceof Error ? (error.stack ?? error.message) : String(error)
+      }`,
+    );
+  }
+}
+
+function findLint(params: PublishDiagnosticsParams): Diagnostic | undefined {
+  return (params.diagnostics ?? []).find(
+    (diagnostic) =>
+      diagnostic.source === "@ttsc/lint" && diagnostic.code === "no-var",
+  );
+}
+
+function applyTextEdits(source: string, edits: readonly TextEdit[]): string {
+  let next = source;
+  for (let i = edits.length - 1; i >= 0; i--) {
+    const edit = edits[i]!;
+    assert.ok(edit.range?.start && edit.range.end, "expected text edit range");
+    const start = offsetAt(next, edit.range.start);
+    const end = offsetAt(next, edit.range.end);
+    next = next.slice(0, start) + (edit.newText ?? "") + next.slice(end);
+  }
+  return next;
+}
+
+/** Map an LSP (line, UTF-16 character) position onto a JS string offset. */
+function offsetAt(source: string, position: Position): number {
+  let line = 0;
+  let character = 0;
+  for (let offset = 0; offset < source.length; ) {
+    if (line === position.line && character === position.character) {
+      return offset;
+    }
+    const codePoint = source.codePointAt(offset);
+    if (codePoint === undefined) break;
+    const size = codePoint > 0xffff ? 2 : 1;
+    if (source[offset] === "\n") {
+      line++;
+      character = 0;
+    } else {
+      character += size;
+    }
+    offset += size;
+  }
+  if (line === position.line && character === position.character) {
+    return source.length;
+  }
+  throw new Error(`position outside source: ${JSON.stringify(position)}`);
+}


### PR DESCRIPTION
Adds one end-to-end test that drives the real `ttscserver` over real LSP JSON-RPC on stdio against a materialized `@ttsc/lint` project, and asserts what an editor actually receives.

## Where it lives, and why

`tests/test-ttsc/src/native-plugins/server/`. That suite already owns the ttscserver LSP e2e scenarios, already has a real JSON-RPC client (`tests/test-ttsc/src/internal/ttscserver.ts`), and is already wired into CI as the `ttsc native server` lane — so the new file needs no CI change and introduces no parallel harness.

`TtscserverClient.startLauncher` spawns the **JavaScript launcher**, so `TTSC_LSP_PLUGINS_JSON` is built by production code (`runTtscserver.ts`) from descriptors whose `capabilities.lsp === true`, rather than hand-assembled by the test.

## Scope note: this fills a gap, not a vacuum

The premise I started from was that nothing exercises the editor wire. That was wrong: the four sibling tests in that directory already cover diagnostics, code actions, `executeCommand`, formatting, and config handoff. What none of them covers, verified by grep across `tests/`:

- **`initialize` capabilities are never asserted.** `executeCommandProvider`, `codeActionProvider`, and `documentFormattingProvider` appear in zero test files. The one initialize test asserts only that `capabilities` is truthy, against a plugin-less `os.tmpdir()` project.
- **`didChange` / `didSave` are never sent.** Both are absent from the whole `tests/` tree, so the dirty-buffer suppression and the save-time republication have no coverage at all.
- **The chain is never driven in one session.** Each sibling pins one verb in its own process.

So this is the whole-chain test, and it asserts the links nothing else does.

## Editor-visible behaviors asserted

1. **initialize** — `executeCommandProvider.commands` contains `ttsc.lint.fixAll`; `codeActionProvider.codeActionKinds` contains **both** ttsc's `source.fixAll.ttsc` and tsgo's `quickfix` (a replace-instead-of-merge regression satisfies either half alone, so both are asserted); `documentFormattingProvider` is `true`; tsgo's `diagnosticProvider` survives ttsc's rewrite of the result.
2. **didOpen → publishDiagnostics** — the `@ttsc/lint` / `no-var` diagnostic arrives with `severity: 1` and a range that underlines the `var` keyword exactly (`0:0–0:3`).
3. **didChange → suppression** — the publish for version 2 carries no plugin finding. The edit deliberately keeps the violation in the buffer, so this asserts suppression rather than absence. The change is sent as a **ranged** edit, because tsgo advertises `textDocumentSync.change: 2` (Incremental) — that is what a real client sends.
4. **didSave → republication** — the finding returns, at an unmoved range (the appended line sits below it).
5. **codeAction** — scoped to that diagnostic's own range, with the diagnostic itself in `context.diagnostics`; returns `ttsc.lint.fixAll` with kind `source.fixAll.ttsc` and `arguments: [uri]`.
6. **executeCommand** — returns a `WorkspaceEdit` which, applied, turns `var legacy` into `let legacy`, and the file on disk is unchanged.
7. **shutdown** — clean exit 0 through the shared helper.

## Constraints that shaped it

- **Diagnostics publish on didOpen and didSave, not didChange.** The test never expects diagnostics mid-edit; it asserts the opposite, and pins version 2 so it cannot accidentally match a stale frame.
- **Diagnostics are server-initiated.** Every waiter is registered *before* the notification that triggers it.
- **Step-labeled deadlines.** Three steps await the same `publishDiagnostics` method, so a bare method-level timeout could not say which link broke. A local `step()` wrapper prefixes every failure with the chain step. This is not cosmetic — see "verified locally".
- **`initialize` is deliberately unbounded**, matching the documented precedent in `test_ttscserver_lsp_honors_explicit_lint_config_file`. The launcher builds project plugins *before* spawning the server, so a cold `@ttsc/lint` build is charged entirely to that one request; I measured over ten minutes on a cold Go cache. Any bound tight enough to be a useful hang signal is tight enough to flake. The wait still ends on server death — the client rejects all pending requests when the child closes. Every other step keeps a tight bound.
- **Small fixture** (two lines, one rule) to respect the per-verb sidecar timeout and the 4 MiB stdout cap.

## Two findings worth recording

**tsgo 7.0.2 does not push-publish diagnostics.** It advertises `diagnosticProvider` (pull, `textDocument/diagnostic`), and the only diagnostics arriving on `publishDiagnostics` are ttsc's. I first wrote the "merged alongside upstream tsgo diagnostics" assertion the task asked for; probing the live wire showed there is nothing upstream to merge into, so asserting a merge would have asserted a fiction. The test instead asserts that ttsc does not *drop* tsgo's `diagnosticProvider`, which is the real contract on the push side today.

**Requests needing an upstream tsgo answer hang in this harness.** `textDocument/codeAction` without an `only` filter, and pull `textDocument/diagnostic`, both time out, while every ttsc-owned path answers in about a second. The likely cause is that tsgo sends `client/registerCapability` (a server→client request) and the shared `TtscserverClient` ignores server→client requests entirely, so tsgo never receives its registration response. That is plausibly why the existing code-action test uses `only: ["source.fixAll.ttsc"]`, which the proxy answers locally. I kept this test on the same locally-answered path rather than build on an unverified one, and did not touch the shared harness — teaching it to answer `client/registerCapability` affects all five tests in the directory and belongs in its own change.

## Verified locally

- **The test passes end to end**: run through the suite runner (`TTSC_TEST_DIR=native-plugins/server … --include=editor_session`) → `Success`, exit 0, 839,760 ms (almost entirely the cold `@ttsc/lint` Go build).
- `prettier --check` clean; `tsc --noEmit -p tests/test-ttsc/tsconfig.json` reports no errors for the new file. Only the touched file was formatted — no repository-wide formatter run, per the active issue campaign.
- Before writing the assertions I drove the real launcher + `ttscserver` + `@ttsc/lint` sidecar over stdio by hand and captured every frame, confirming each asserted value against live output: the merged capability list, the `no-var` diagnostic at `0:0–0:3`, the empty version-2 publish after `didChange`, the republication after `didSave`, the `source.fixAll.ttsc` action shape, and the `WorkspaceEdit` rewriting `var`→`let` without touching disk.
- An earlier run failed on a then-600s `initialize` bound and produced exactly the intended message — `ttscserver LSP session step "initialize" never completed: … timed out waiting for initialize response (stderr=ttsc: building source plugin "@ttsc/lint" …)` — which both motivated the unbounded `initialize` and demonstrated that the step labeling names the broken link.

Caveat: the passing run executed against a local checkout whose built `packages/ttsc/lib` was slightly ahead of this branch's base. The harness files it depends on are byte-identical, and the only relevant delta on master is the resident lsp-serve daemon, which makes the sidecar verbs faster rather than changing their contract. CI is the final gate.
