### PR TITLE
feat(lint): offer the fix that was computed and withheld

### DIFF
--- a/packages/lint/linthost/rules_gap.go
+++ b/packages/lint/linthost/rules_gap.go
@@ -540,13 +540,6 @@ func (dotNotation) Check(ctx *Context, node *shimast.Node) {
     return
   }
   message := "Use dot notation instead of a string literal property access."
-  // Conservative: keep reserved words as bracket access. Modern JS accepts
-  // `obj.class`/`obj.if`/etc. syntactically but mixing them with member
-  // expression syntax is jarring and can confuse minifiers and older runtimes.
-  if isReservedWord(key) {
-    ctx.Report(node, message)
-    return
-  }
   src := ctx.File.Text()
   // Determine where the bracket access begins. With an optional chain
   // (`obj?.["foo"]`) the `?.` token already separates object from access, so
@@ -575,18 +568,34 @@ func (dotNotation) Check(ctx *Context, node *shimast.Node) {
     ctx.Report(node, message)
     return
   }
+  edit := TextEdit{Pos: replaceFrom, End: node.End(), Text: replacement}
+  switch {
   // A comment inside the replaced `[…]` tail (`p1 /* keep */ ["foo"]`) would be
-  // silently deleted by the splice. Decline to a report-only diagnostic,
-  // matching ESLint dot-notation's `commentsExistBetween` guard.
-  if hasCommentBetween(src, replaceFrom, node.End()) {
-    ctx.Report(node, message)
-    return
+  // silently deleted by the splice, so it is never imposed — matching ESLint
+  // dot-notation's `commentsExistBetween` guard. The rewrite itself is still
+  // correct, so it is offered as an opt-in suggestion that names the loss.
+  case hasCommentBetween(src, replaceFrom, node.End()):
+    ctx.ReportSuggestion(
+      node,
+      message,
+      "Use dot notation, discarding the comment inside the brackets.",
+      edit,
+    )
+  // Conservative: keep reserved words as bracket access. Modern JS accepts
+  // `obj.class`/`obj.if`/etc. syntactically but mixing them with member
+  // expression syntax is jarring and can confuse minifiers and older runtimes.
+  // ESLint's default `allowKeywords: true` does rewrite them, so the edit is
+  // offered as an opt-in suggestion rather than withheld outright.
+  case isReservedWord(key):
+    ctx.ReportSuggestion(
+      node,
+      message,
+      "Use dot notation for the reserved word `"+key+"`.",
+      edit,
+    )
+  default:
+    ctx.ReportFix(node, message, edit)
   }
-  ctx.ReportFix(
-    node,
-    message,
-    TextEdit{Pos: replaceFrom, End: node.End(), Text: replacement},
-  )
 }
 
 // isDecimalIntegerLiteralText reports whether raw is a numeric literal written

--- a/packages/lint/linthost/rules_logic.go
+++ b/packages/lint/linthost/rules_logic.go
@@ -86,8 +86,9 @@ func (noExtraBooleanCast) Check(ctx *Context, node *shimast.Node) {
 //     result, as do explicit parentheses around the cast itself.
 //   - Comments. The splice keeps only the inner expression's text, so a
 //     comment anywhere else in the replaced span (`!Boolean(/* why */ ok)`)
-//     would be silently deleted. The fix is declined — report only — when
-//     the replaced span contains a comment outside the kept text.
+//     would be silently deleted. Imposing that loss is unacceptable, so the
+//     same edit is offered as an opt-in suggestion instead: the author sees
+//     the title, chooses it, and reviews the result.
 func reportBooleanCastFix(ctx *Context, node, inner *shimast.Node, message string) {
   if inner == nil {
     ctx.Report(node, message)
@@ -105,17 +106,23 @@ func reportBooleanCastFix(ctx *Context, node, inner *shimast.Node, message strin
     ctx.Report(node, message)
     return
   }
-  if hasCommentBetween(src, editPos, keepStart) ||
-    hasCommentBetween(src, keepEnd, node.End()) {
-    ctx.Report(node, message)
-    return
-  }
   text := src[keepStart:keepEnd]
   if floor, bounded := booleanContextPrecedenceFloor(node); bounded &&
     shimast.GetExpressionPrecedence(inner) <= floor {
     text = "(" + text + ")"
   }
-  ctx.ReportFix(node, message, TextEdit{Pos: editPos, End: node.End(), Text: text})
+  edit := TextEdit{Pos: editPos, End: node.End(), Text: text}
+  if hasCommentBetween(src, editPos, keepStart) ||
+    hasCommentBetween(src, keepEnd, node.End()) {
+    ctx.ReportSuggestion(
+      node,
+      message,
+      "Remove the redundant cast, discarding the comment inside it.",
+      edit,
+    )
+    return
+  }
+  ctx.ReportFix(node, message, edit)
 }
 
 // booleanContextPrecedenceFloor returns the precedence at or below which a
@@ -239,21 +246,29 @@ func (eqeqeq) Check(ctx *Context, node *shimast.Node) {
   }
 }
 
+// reportEqeqeq reports the loose operator and rewrites it to `replacement`.
+// The rewrite is imposed only when `isEqeqeqAutoFixSafe` proves both operands
+// share a type, because tightening a genuinely mixed-type comparison changes
+// what the program computes. That is a judgement only the author can make, so
+// the same edit is still offered as an opt-in suggestion whose title names the
+// behavior change rather than being discarded.
 func reportEqeqeq(ctx *Context, operator *shimast.Node, expr *shimast.BinaryExpression, message, replacement string) {
   pos, end := tokenRange(ctx.File, operator)
   if pos < 0 {
     pos, end = operator.Pos(), operator.End()
   }
+  edit := TextEdit{Pos: pos, End: end, Text: replacement}
   if isEqeqeqAutoFixSafe(expr) {
-    ctx.ReportRangeFix(
-      pos,
-      end,
-      message,
-      TextEdit{Pos: pos, End: end, Text: replacement},
-    )
+    ctx.ReportRangeFix(pos, end, message, edit)
     return
   }
-  ctx.ReportRange(pos, end, message)
+  ctx.ReportRangeSuggestion(
+    pos,
+    end,
+    message,
+    "Replace with `"+replacement+"`, which changes the result when the operands differ in type.",
+    edit,
+  )
 }
 
 func isEqeqeqAutoFixSafe(expr *shimast.BinaryExpression) bool {

--- a/packages/lint/linthost/rules_suggestions.go
+++ b/packages/lint/linthost/rules_suggestions.go
@@ -185,11 +185,20 @@ func (noExtraBind) Check(ctx *Context, node *shimast.Node) {
     return
   }
 
-  edits := noExtraBindFixEdits(ctx, node, call, member, receiver)
-  if len(edits) == 0 {
-    ctx.Report(node, "The function binding is unnecessary.")
-  } else {
-    ctx.ReportFix(node, "The function binding is unnecessary.", edits...)
+  message := "The function binding is unnecessary."
+  edits, imposable := noExtraBindFixEdits(ctx, node, call, member, receiver)
+  switch {
+  case len(edits) == 0:
+    ctx.Report(node, message)
+  case imposable:
+    ctx.ReportFix(node, message, edits...)
+  default:
+    ctx.ReportSuggestion(
+      node,
+      message,
+      "Remove the unnecessary binding, discarding the comment inside it.",
+      edits...,
+    )
   }
 }
 
@@ -296,22 +305,28 @@ func noExtraBindThisBelongsToFunction(node, root *shimast.Node) bool {
 
 // noExtraBindFixEdits removes the member access and its one-argument call as
 // separate ranges. Parentheses and comments before the member operator remain
-// byte-for-byte intact. The fix is withheld when evaluating the receiver may
-// have effects or when any comment lies inside discarded syntax.
+// byte-for-byte intact.
+//
+// No edit exists at all when the removal would change what the program does —
+// evaluating the receiver may have effects — or when the ranges are degenerate;
+// both return `(nil, false)`. When the edit is well-formed but a comment lies
+// inside the discarded syntax, it returns `(edits, false)`: imposing silent
+// comment loss is unacceptable, yet the caller can still offer the removal as
+// an opt-in suggestion. Only `(edits, true)` may be applied automatically.
 func noExtraBindFixEdits(
   ctx *Context,
   callNode *shimast.Node,
   call *shimast.CallExpression,
   member *shimast.Node,
   receiver *shimast.Node,
-) []TextEdit {
+) (edits []TextEdit, imposable bool) {
   if ctx == nil || ctx.File == nil || callNode == nil || call == nil || call.Expression == nil || member == nil ||
     !noExtraBindReceiverIsSideEffectFree(receiver) {
-    return nil
+    return nil, false
   }
   parts, ok := referenceMemberParts(member)
   if !ok || parts.object == nil {
-    return nil
+    return nil, false
   }
 
   src := ctx.File.Text()
@@ -320,15 +335,12 @@ func noExtraBindFixEdits(
   callStart := shimscanner.SkipTrivia(src, call.Expression.End())
   callEnd := callNode.End()
   if memberStart < 0 || memberStart >= memberEnd || memberEnd > callStart || callStart >= callEnd || callEnd > len(src) {
-    return nil
-  }
-  if hasCommentBetween(src, memberStart, callEnd) {
-    return nil
+    return nil, false
   }
   return []TextEdit{
     {Pos: memberStart, End: memberEnd, Text: ""},
     {Pos: callStart, End: callEnd, Text: ""},
-  }
+  }, !hasCommentBetween(src, memberStart, callEnd)
 }
 
 func noExtraBindReceiverIsSideEffectFree(node *shimast.Node) bool {
@@ -1312,19 +1324,22 @@ func reportUselessRenameFix(ctx *Context, node, propertyName, name *shimast.Node
     ctx.Report(node, message)
     return
   }
+  edit := TextEdit{Pos: propertyName.End(), End: name.End(), Text: ""}
   // A comment between the two names (`{ a as /* c */ a }`) sits inside the
-  // deleted rename tail; dropping it would be silent data loss, so decline to
-  // a report-only diagnostic. Mirrors ESLint no-useless-rename's
-  // `commentsExistBetween` guard.
+  // deleted rename tail; imposing that loss is unacceptable, so the autofix
+  // declines. Mirrors ESLint no-useless-rename's `commentsExistBetween` guard.
+  // The collapse is still what the author wants, so the same edit is offered
+  // as an opt-in suggestion whose title states that the comment goes with it.
   if hasCommentBetween(ctx.File.Text(), propertyName.End(), name.End()) {
-    ctx.Report(node, message)
+    ctx.ReportSuggestion(
+      node,
+      message,
+      "Remove the redundant rename, discarding the comment inside it.",
+      edit,
+    )
     return
   }
-  ctx.ReportFix(
-    node,
-    message,
-    TextEdit{Pos: propertyName.End(), End: name.End(), Text: ""},
-  )
+  ctx.ReportFix(node, message, edit)
 }
 
 // objectShorthand: `{ x: x }` → `{ x }`.
@@ -1351,17 +1366,20 @@ func (objectShorthand) Check(ctx *Context, node *shimast.Node) {
   // that range.
   //
   // A comment inside that range (`{ x: /* c */ x }`) would be dropped by the
-  // deletion, so decline to a report-only diagnostic. Mirrors ESLint
-  // object-shorthand's `commentsExistBetween` guard.
+  // deletion, so the autofix declines. Mirrors ESLint object-shorthand's
+  // `commentsExistBetween` guard. The shorthand rewrite is still correct, so
+  // the same edit is offered as an opt-in suggestion that names the loss.
+  edit := TextEdit{Pos: prop.Name().End(), End: prop.Initializer.End(), Text: ""}
   if hasCommentBetween(ctx.File.Text(), prop.Name().End(), prop.Initializer.End()) {
-    ctx.Report(node, "Expected property shorthand.")
+    ctx.ReportSuggestion(
+      node,
+      "Expected property shorthand.",
+      "Use property shorthand, discarding the comment before the value.",
+      edit,
+    )
     return
   }
-  ctx.ReportFix(
-    node,
-    "Expected property shorthand.",
-    TextEdit{Pos: prop.Name().End(), End: prop.Initializer.End(), Text: ""},
-  )
+  ctx.ReportFix(node, "Expected property shorthand.", edit)
 }
 
 // operatorAssignment: `x = x + 1` → `x += 1`.
@@ -1494,21 +1512,24 @@ func (preferTemplate) Check(ctx *Context, node *shimast.Node) {
     ctx.Report(node, message)
     return
   }
+  edit := TextEdit{Pos: editPos, End: node.End(), Text: template}
   // A comment in an operator seam (`"a" + /* c */ b`) is dropped by the
-  // template rebuild, so decline to a report-only diagnostic. Mirrors ESLint
+  // template rebuild, so the autofix declines and the rendered literal is
+  // offered as an opt-in suggestion that names the loss. Mirrors ESLint
   // prefer-template's `commentsExistBetween` guard. Only the seams are scanned:
   // operand interiors are copied verbatim (their comments survive) and string
   // contents are cooked, so scanning the whole span would misread a `//` or
   // `/*` inside a string literal (`"https://" + host`) as a comment.
   if concatOperandSeamsHaveComment(src, operands) {
-    ctx.Report(node, message)
+    ctx.ReportSuggestion(
+      node,
+      message,
+      "Use a template literal, discarding the comments between the operands.",
+      edit,
+    )
     return
   }
-  ctx.ReportFix(
-    node,
-    message,
-    TextEdit{Pos: editPos, End: node.End(), Text: template},
-  )
+  ctx.ReportFix(node, message, edit)
 }
 
 // concatOperandSeamsHaveComment reports whether a comment sits in any seam

--- a/packages/lint/test/fix/fix_no_extra_bind_skips_effectful_or_commented_removals_test.go
+++ b/packages/lint/test/fix/fix_no_extra_bind_skips_effectful_or_commented_removals_test.go
@@ -7,7 +7,9 @@ import "testing"
 //
 // Evaluating the bound receiver can call code, access a getter, or mutate
 // state. Comments inside the member/call syntax also carry source information
-// that a deletion cannot safely relocate.
+// that a deletion cannot safely relocate. Neither shape may reach `ttsc fix`;
+// the commented shapes are separately offered as opt-in suggestions, pinned by
+// `TestNoExtraBindOffersWithheldRemovalAsSuggestion`.
 //
 // 1. Bind call, member-access, and update expressions as receivers.
 // 2. Place comments inside dot, computed-key, and argument syntax.

--- a/packages/lint/test/rules/arrays-objects/dot_notation_declines_fix_when_comment_in_bracket_span_test.go
+++ b/packages/lint/test/rules/arrays-objects/dot_notation_declines_fix_when_comment_in_bracket_span_test.go
@@ -9,7 +9,9 @@ import "testing"
 // The fix replaces the range from the receiver's end through the closing
 // bracket, so a comment there (`p1 /* keep */ ["foo"]`) would vanish after
 // `ttsc lint fix`. ESLint's dot-notation declines via `commentsExistBetween`;
-// the port reports the diagnostic but offers no edit. The negative twin — the
+// the port imposes no edit either and routes the rewrite to the opt-in
+// suggestion channel instead (pinned by
+// `TestDotNotationOffersWithheldBracketCollapseAsSuggestion`). The negative twin — the
 // same access with no comment — must still rewrite, proving the guard is scoped
 // to the comment and not a blanket suppression.
 //

--- a/packages/lint/test/rules/arrays-objects/dot_notation_fix_keeps_bracket_for_reserved_word_test.go
+++ b/packages/lint/test/rules/arrays-objects/dot_notation_fix_keeps_bracket_for_reserved_word_test.go
@@ -9,7 +9,9 @@ import "testing"
 // and older engines can break — the safe choice is to keep bracket
 // syntax for reserved-word keys, mirroring ESLint's
 // `allowKeywords: false` mode. This pin is independent of the main
-// rewrite branch and exercises the "detect but skip fix" arm.
+// rewrite branch and exercises the "detect but impose nothing" arm; the
+// rewrite is still offered as an opt-in suggestion, pinned by
+// `TestDotNotationOffersReservedWordCollapseAsSuggestion`.
 //
 // 1. Snapshot `box["class"]`.
 // 2. Enable `dot-notation`.

--- a/packages/lint/test/rules/arrays-objects/dot_notation_offers_reserved_word_collapse_as_suggestion_test.go
+++ b/packages/lint/test/rules/arrays-objects/dot_notation_offers_reserved_word_collapse_as_suggestion_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import "testing"
+
+// TestDotNotationOffersReservedWordCollapseAsSuggestion verifies a reserved-
+// word key reports with an opt-in `box.class` rewrite instead of no action.
+//
+// ESLint's default `allowKeywords: true` rewrites keyword keys outright; this
+// port stays stricter because `obj.class` can still trip old engines and
+// minifiers. That conservatism is a reason not to impose the edit, not a
+// reason to withhold it: the rewrite is syntactically valid on every modern
+// target, so the author gets to decide.
+//
+//  1. Report on `box["class"]` and assert nothing is applied automatically.
+//  2. Assert the single suggestion names the keyword and yields `box.class`.
+//  3. Assert the non-reserved twin `box["name"]` is still autofixed outright.
+func TestDotNotationOffersReservedWordCollapseAsSuggestion(t *testing.T) {
+  assertSuggestionSnapshot(
+    t,
+    "dot-notation",
+    "const box: any = { class: \"ttsc\" };\nconst value = box[\"class\"];\nJSON.stringify(value);\n",
+    "Use dot notation for the reserved word `class`.",
+    "const box: any = { class: \"ttsc\" };\nconst value = box.class;\nJSON.stringify(value);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "dot-notation",
+    "const box: any = { name: \"ttsc\" };\nconst value = box[\"name\"];\nJSON.stringify(value);\n",
+    "const box: any = { name: \"ttsc\" };\nconst value = box.name;\nJSON.stringify(value);\n",
+  )
+}

--- a/packages/lint/test/rules/arrays-objects/dot_notation_offers_withheld_bracket_collapse_as_suggestion_test.go
+++ b/packages/lint/test/rules/arrays-objects/dot_notation_offers_withheld_bracket_collapse_as_suggestion_test.go
@@ -1,0 +1,32 @@
+package linthost
+
+import "testing"
+
+// TestDotNotationOffersWithheldBracketCollapseAsSuggestion verifies the
+// bracket-to-dot rewrite withheld from a commented span is offered as an
+// opt-in suggestion that discards the comment.
+//
+// The splice replaces everything from the receiver's end through the closing
+// bracket, so `p1 /* keep */ ["foo"]` cannot be autofixed without erasing the
+// comment. Withholding it from `ttsc fix` is right; withholding it from the
+// author is not, because the collapse is exactly what the diagnostic asks for
+// and the title tells them what the comment costs.
+//
+//  1. Report on `p1 /* keep */ ["foo"]` and assert nothing is auto-applied.
+//  2. Assert the single suggestion collapses the access to `p1.foo`.
+//  3. Assert the comment-free twin is still autofixed without asking.
+func TestDotNotationOffersWithheldBracketCollapseAsSuggestion(t *testing.T) {
+  assertSuggestionSnapshot(
+    t,
+    "dot-notation",
+    "const p1: any = {};\nconst v1 = p1 /* keep */ [\"foo\"];\nJSON.stringify(v1);\n",
+    "Use dot notation, discarding the comment inside the brackets.",
+    "const p1: any = {};\nconst v1 = p1.foo;\nJSON.stringify(v1);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "dot-notation",
+    "const p2: any = {};\nconst v2 = p2[\"foo\"];\nJSON.stringify(v2);\n",
+    "const p2: any = {};\nconst v2 = p2.foo;\nJSON.stringify(v2);\n",
+  )
+}

--- a/packages/lint/test/rules/arrays-objects/object_shorthand_declines_fix_when_comment_in_value_span_test.go
+++ b/packages/lint/test/rules/arrays-objects/object_shorthand_declines_fix_when_comment_in_value_span_test.go
@@ -8,8 +8,10 @@ import "testing"
 //
 // The fix deletes from the key name's end through the initializer's end, so a
 // comment there (`{ x: /* keep */ x }`) would be erased. ESLint's
-// object-shorthand declines via `commentsExistBetween`; the port reports the
-// shorthand candidate but offers no edit. The negative twin — the same property
+// object-shorthand declines via `commentsExistBetween`; the port imposes no
+// edit either and routes the collapse to the opt-in suggestion channel instead
+// (pinned by `TestObjectShorthandOffersWithheldCollapseAsSuggestion`).
+// The negative twin — the same property
 // with no comment — must still collapse to `{ x }`, proving the guard is scoped
 // to the comment.
 //

--- a/packages/lint/test/rules/arrays-objects/object_shorthand_offers_withheld_collapse_as_suggestion_test.go
+++ b/packages/lint/test/rules/arrays-objects/object_shorthand_offers_withheld_collapse_as_suggestion_test.go
@@ -1,0 +1,32 @@
+package linthost
+
+import "testing"
+
+// TestObjectShorthandOffersWithheldCollapseAsSuggestion verifies the shorthand
+// collapse withheld from `{ x: /* keep */ x }` is offered as an opt-in
+// suggestion that discards the comment.
+//
+// The fix deletes from the key's end through the initializer's end, which is
+// precisely where the comment lives, so `ttsc fix` must not apply it. The
+// author choosing the action is a different contract from a tool rewriting the
+// file unasked, so the identical edit is advertised with a title that says the
+// comment goes with it.
+//
+//  1. Report on `{ x: /* keep */ x }` and assert nothing is auto-applied.
+//  2. Assert the single suggestion collapses the property to `{ x }`.
+//  3. Assert the comment-free twin is still autofixed without asking.
+func TestObjectShorthandOffersWithheldCollapseAsSuggestion(t *testing.T) {
+  assertSuggestionSnapshot(
+    t,
+    "object-shorthand",
+    "const x = 1;\nconst o = { x: /* keep */ x };\nJSON.stringify(o);\n",
+    "Use property shorthand, discarding the comment before the value.",
+    "const x = 1;\nconst o = { x };\nJSON.stringify(o);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "object-shorthand",
+    "const x = 1;\nconst o = { x: x };\nJSON.stringify(o);\n",
+    "const x = 1;\nconst o = { x };\nJSON.stringify(o);\n",
+  )
+}

--- a/packages/lint/test/rules/functions-classes/no_extra_bind_offers_withheld_removal_as_suggestion_test.go
+++ b/packages/lint/test/rules/functions-classes/no_extra_bind_offers_withheld_removal_as_suggestion_test.go
@@ -1,0 +1,38 @@
+package linthost
+
+import "testing"
+
+// TestNoExtraBindOffersWithheldRemovalAsSuggestion verifies a comment inside
+// the bind syntax downgrades the removal to an opt-in suggestion while an
+// effectful receiver still yields no action at all.
+//
+// The two withhold reasons are not interchangeable. A comment in the deleted
+// member/call ranges makes the edit lossy, which an author may accept once
+// told; an effectful receiver like `makeReceiver()` makes it wrong, because
+// deleting the bind deletes a call the program performs. Only the first may
+// reach the suggestion channel, so both arms are pinned together.
+//
+//  1. Report on `(function () {})./**/bind(receiver)` and assert no autofix.
+//  2. Assert the single suggestion strips the bind syntax and the comment.
+//  3. Assert an effectful receiver offers neither a fix nor a suggestion.
+//  4. Assert the comment-free twin is still autofixed without asking.
+func TestNoExtraBindOffersWithheldRemovalAsSuggestion(t *testing.T) {
+  assertSuggestionSnapshot(
+    t,
+    "no-extra-bind",
+    "declare const receiver: { value: unknown };\nconst bound = (function () { return 4; })./**/bind(receiver);\nJSON.stringify(bound);\n",
+    "Remove the unnecessary binding, discarding the comment inside it.",
+    "declare const receiver: { value: unknown };\nconst bound = (function () { return 4; });\nJSON.stringify(bound);\n",
+  )
+  assertReportOnlySnapshot(
+    t,
+    "no-extra-bind",
+    "declare function makeReceiver(): unknown;\nconst bound = (function () { return 4; }).bind(makeReceiver());\nJSON.stringify(bound);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "no-extra-bind",
+    "declare const receiver: { value: unknown };\nconst bound = (function () { return 4; }).bind(receiver);\nJSON.stringify(bound);\n",
+    "declare const receiver: { value: unknown };\nconst bound = (function () { return 4; });\nJSON.stringify(bound);\n",
+  )
+}

--- a/packages/lint/test/rules/runtime-safety/eqeqeq_offers_unsafe_operator_rewrite_as_suggestion_test.go
+++ b/packages/lint/test/rules/runtime-safety/eqeqeq_offers_unsafe_operator_rewrite_as_suggestion_test.go
@@ -1,0 +1,40 @@
+package linthost
+
+import "testing"
+
+// TestEqeqeqOffersUnsafeOperatorRewriteAsSuggestion verifies a coercion-
+// sensitive `==` still exposes the `===` rewrite as an opt-in suggestion.
+//
+// `isEqeqeqAutoFixSafe` refuses to impose the tightening because two operands
+// of unproven type can compare equal loosely and unequal strictly, so an
+// automatic rewrite would change what the program computes. That judgement
+// belongs to the author, which is exactly the opt-in channel's purpose: the
+// title names the behavior change and the edit waits to be chosen instead of
+// being thrown away.
+//
+//  1. Report on `left == right` between two `unknown` values.
+//  2. Assert nothing is applied automatically and the suggestion yields `===`.
+//  3. Assert the `!=` arm carries its own operator in the title and the edit.
+//  4. Assert the provably safe `typeof` twin is still autofixed outright.
+func TestEqeqeqOffersUnsafeOperatorRewriteAsSuggestion(t *testing.T) {
+  assertSuggestionSnapshot(
+    t,
+    "eqeqeq",
+    "declare const left: unknown;\ndeclare const right: unknown;\nif (left == right) { JSON.stringify(left); }\n",
+    "Replace with `===`, which changes the result when the operands differ in type.",
+    "declare const left: unknown;\ndeclare const right: unknown;\nif (left === right) { JSON.stringify(left); }\n",
+  )
+  assertSuggestionSnapshot(
+    t,
+    "eqeqeq",
+    "declare const left: unknown;\ndeclare const right: unknown;\nif (left != right) { JSON.stringify(left); }\n",
+    "Replace with `!==`, which changes the result when the operands differ in type.",
+    "declare const left: unknown;\ndeclare const right: unknown;\nif (left !== right) { JSON.stringify(left); }\n",
+  )
+  assertFixSnapshot(
+    t,
+    "eqeqeq",
+    "declare const value: unknown;\nif (typeof value == \"string\") { JSON.stringify(value); }\n",
+    "declare const value: unknown;\nif (typeof value === \"string\") { JSON.stringify(value); }\n",
+  )
+}

--- a/packages/lint/test/rules/strings-regex/prefer_template_declines_fix_when_comment_in_concat_span_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_declines_fix_when_comment_in_concat_span_test.go
@@ -9,8 +9,10 @@ import "testing"
 //
 // The fix replaces the whole `+` chain span with one template literal, so a
 // comment anywhere inside (`"hi " + /* keep */ who`) would be erased. ESLint's
-// prefer-template declines via `commentsExistBetween`; the port reports the
-// concatenation but offers no edit. The negative twin — the same concatenation
+// prefer-template declines via `commentsExistBetween`; the port imposes no edit
+// either and routes the rendered literal to the opt-in suggestion channel
+// instead (pinned by `TestPreferTemplateOffersWithheldTemplateAsSuggestion`).
+// The negative twin — the same concatenation
 // with no comment — must still become a template literal, proving the guard is
 // scoped to the comment.
 //

--- a/packages/lint/test/rules/strings-regex/prefer_template_offers_withheld_template_as_suggestion_test.go
+++ b/packages/lint/test/rules/strings-regex/prefer_template_offers_withheld_template_as_suggestion_test.go
@@ -1,0 +1,32 @@
+package linthost
+
+import "testing"
+
+// TestPreferTemplateOffersWithheldTemplateAsSuggestion verifies the rendered
+// template literal withheld from a seam-commented concatenation is offered as
+// an opt-in suggestion that discards the seam comment.
+//
+// The rebuild replaces the whole `+` chain with one literal, so a comment in
+// an operator seam has nowhere to land and the autofix declines. Throwing the
+// finished literal away was the waste: the renderer already produced the exact
+// text the diagnostic is asking for, and only the imposition — not the
+// rewrite — was ever unsafe.
+//
+//  1. Report on `"hi " + /* keep */ who` and assert nothing auto-applies.
+//  2. Assert the single suggestion yields the template literal `hi ${who}`.
+//  3. Assert the comment-free twin is still autofixed without asking.
+func TestPreferTemplateOffersWithheldTemplateAsSuggestion(t *testing.T) {
+  assertSuggestionSnapshot(
+    t,
+    "prefer-template",
+    "const who = \"world\";\nconst s = \"hi \" + /* keep */ who;\nJSON.stringify(s);\n",
+    "Use a template literal, discarding the comments between the operands.",
+    "const who = \"world\";\nconst s = `hi ${who}`;\nJSON.stringify(s);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "prefer-template",
+    "const who = \"world\";\nconst s = \"hi \" + who;\nJSON.stringify(s);\n",
+    "const who = \"world\";\nconst s = `hi ${who}`;\nJSON.stringify(s);\n",
+  )
+}

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_declines_fix_for_leading_comment_in_call_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_declines_fix_for_leading_comment_in_call_test.go
@@ -8,8 +8,9 @@ import "testing"
 //
 // The fix keeps only the argument's own text, so a comment ahead of it
 // inside the call would be silently deleted (#362). Upstream ESLint's fixer
-// bails out on comment loss; the port declines the same way and leaves the
-// finding report-only.
+// bails out on comment loss; the port declines the same way and offers the
+// splice as an opt-in suggestion instead, pinned by
+// `TestNoExtraBooleanCastOffersWithheldSpliceAsSuggestion`.
 //
 // 1. Snapshot `const z = !Boolean(/* why */ ok);` source.
 // 2. Run `no-extra-boolean-cast` through the fix applier.

--- a/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_offers_withheld_splice_as_suggestion_test.go
+++ b/packages/lint/test/rules/style-suggestions/no_extra_boolean_cast_offers_withheld_splice_as_suggestion_test.go
@@ -1,0 +1,32 @@
+package linthost
+
+import "testing"
+
+// TestNoExtraBooleanCastOffersWithheldSpliceAsSuggestion verifies the cast
+// removal withheld from `if (!/* c */!x)` is offered as an opt-in suggestion
+// that drops the comment along with the bangs.
+//
+// The splice keeps only the inner operand's text, so imposing it would delete
+// the comment silently — unacceptable for `ttsc fix`, which rewrites without
+// asking. A suggestion is chosen by the author, so the same edit becomes safe
+// to offer as long as its title says the comment goes with it. Discarding a
+// correct edit instead is the loss this pins.
+//
+//  1. Report on `if (!/* c */!x)` and assert nothing is applied automatically.
+//  2. Assert the single suggestion collapses the cast to `if (x)`.
+//  3. Assert the comment-free twin is still autofixed without asking.
+func TestNoExtraBooleanCastOffersWithheldSpliceAsSuggestion(t *testing.T) {
+  assertSuggestionSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(x: any) {\n  if (!/* c */!x) {\n    return 1;\n  }\n  return 0;\n}\nJSON.stringify(f);\n",
+    "Remove the redundant cast, discarding the comment inside it.",
+    "function f(x: any) {\n  if (x) {\n    return 1;\n  }\n  return 0;\n}\nJSON.stringify(f);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "no-extra-boolean-cast",
+    "function f(x: any) {\n  if (!!x) {\n    return 1;\n  }\n  return 0;\n}\nJSON.stringify(f);\n",
+    "function f(x: any) {\n  if (x) {\n    return 1;\n  }\n  return 0;\n}\nJSON.stringify(f);\n",
+  )
+}

--- a/packages/lint/test/rules/variables-assignments/no_useless_rename_declines_fix_when_comment_between_names_test.go
+++ b/packages/lint/test/rules/variables-assignments/no_useless_rename_declines_fix_when_comment_between_names_test.go
@@ -9,7 +9,9 @@ import "testing"
 // The fix deletes the rename tail from the property name's end through the
 // local name's end, so a comment there (`{ a as /* keep */ a }`) would be
 // erased. ESLint's no-useless-rename declines via `commentsExistBetween`; the
-// port reports the redundant rename but offers no edit. The negative twin — the
+// port imposes no edit either and routes the collapse to the opt-in suggestion
+// channel instead (pinned by
+// `TestNoUselessRenameOffersWithheldTailDeletionAsSuggestion`). The negative twin — the
 // same specifier with no comment — must still collapse, proving the guard fires
 // only on the comment.
 //

--- a/packages/lint/test/rules/variables-assignments/no_useless_rename_offers_withheld_tail_deletion_as_suggestion_test.go
+++ b/packages/lint/test/rules/variables-assignments/no_useless_rename_offers_withheld_tail_deletion_as_suggestion_test.go
@@ -1,0 +1,32 @@
+package linthost
+
+import "testing"
+
+// TestNoUselessRenameOffersWithheldTailDeletionAsSuggestion verifies the rename
+// tail withheld from `{ a as /* keep */ a }` is offered as an opt-in suggestion
+// that discards the comment.
+//
+// Deleting from the property name's end through the local name's end removes
+// the comment with the redundant alias, so the autofix declines exactly as
+// ESLint's `commentsExistBetween` guard does. The collapse itself stays
+// correct, so the author is offered it rather than left with a diagnostic that
+// names a problem and hands over no way to act on it.
+//
+//  1. Report on `import { a as /* keep */ a }` and assert nothing auto-applies.
+//  2. Assert the single suggestion collapses the specifier to `import { a }`.
+//  3. Assert the comment-free twin is still autofixed without asking.
+func TestNoUselessRenameOffersWithheldTailDeletionAsSuggestion(t *testing.T) {
+  assertSuggestionSnapshot(
+    t,
+    "no-useless-rename",
+    "import { a as /* keep */ a } from \"./m\";\nJSON.stringify(a);\n",
+    "Remove the redundant rename, discarding the comment inside it.",
+    "import { a } from \"./m\";\nJSON.stringify(a);\n",
+  )
+  assertFixSnapshot(
+    t,
+    "no-useless-rename",
+    "import { a as a } from \"./m\";\nJSON.stringify(a);\n",
+    "import { a } from \"./m\";\nJSON.stringify(a);\n",
+  )
+}

--- a/packages/lint/test/shared/helpers_test.go
+++ b/packages/lint/test/shared/helpers_test.go
@@ -556,6 +556,105 @@ func assertNoFixSnapshot(t *testing.T, ruleName, source string) {
   }
 }
 
+// assertSuggestionSnapshot verifies a rule withholds its automatic fix and
+// offers the same rewrite as one titled, opt-in suggestion instead.
+//
+// The suggestion channel exists for an edit that is correct but lossy or
+// behavior-changing, so both halves have to hold at once: `ttsc fix` and
+// source.fixAll must still change nothing, while the advertised edits must
+// produce `expected` once the author selects them. Asserting only the first
+// half would pass for a rule that dropped the edit entirely, which is the
+// regression this helper exists to catch.
+//
+//  1. Run one rule over `source` and require exactly one finding.
+//  2. Assert it carries no automatic fix and exactly one suggestion titled
+//     `title`, and that the automatic pass leaves the source untouched.
+//  3. Apply the suggestion's own edits and compare the result exactly.
+func assertSuggestionSnapshot(t *testing.T, ruleName, source, title, expected string) {
+  t.Helper()
+  _, _, findings := runRuleFindingsSnapshot(t, ruleName, source, nil)
+  if len(findings) != 1 {
+    t.Fatalf("%s: findings = %d, want 1 (%+v)", ruleName, len(findings), findings)
+  }
+  finding := findings[0]
+  if len(finding.Fix) != 0 {
+    t.Fatalf("%s: automatic fix must stay withheld, got %+v", ruleName, finding.Fix)
+  }
+  if len(finding.Suggestions) != 1 {
+    t.Fatalf(
+      "%s: suggestions = %d, want 1 (%+v)",
+      ruleName,
+      len(finding.Suggestions),
+      finding.Suggestions,
+    )
+  }
+  suggestion := finding.Suggestions[0]
+  if suggestion.Title != title {
+    t.Fatalf("%s: suggestion title:\nwant %q\ngot  %q", ruleName, title, suggestion.Title)
+  }
+  if unchanged, applied := applyFindingFixesToText(source, findings); applied != 0 || unchanged != source {
+    t.Fatalf(
+      "%s: automatic pass must change nothing: applied=%d got %q",
+      ruleName,
+      applied,
+      unchanged,
+    )
+  }
+  got, applied := applyFindingFixesToText(source, []*Finding{{Fix: suggestion.Edits}})
+  if applied != len(suggestion.Edits) {
+    t.Fatalf(
+      "%s: applied %d of %d suggestion edits",
+      ruleName,
+      applied,
+      len(suggestion.Edits),
+    )
+  }
+  if got != expected {
+    t.Fatalf("%s suggested source mismatch:\nwant %q\ngot  %q", ruleName, expected, got)
+  }
+}
+
+// assertReportOnlySnapshot verifies a rule reports but offers the author
+// nothing at all — neither an automatic fix nor an opt-in suggestion.
+//
+// It is the counter-assertion to `assertSuggestionSnapshot`. Where a rewrite
+// is withheld because applying it would change what the program does, routing
+// it to the suggestion channel is wrong, not merely cautious;
+// `assertNoFixSnapshot` alone cannot tell that apart from a correctly offered
+// suggestion because suggestion edits never reach the fix applier.
+//
+//  1. Run one rule over `source` and require at least one finding.
+//  2. Assert no finding carries a fix or a suggestion.
+//  3. Assert the automatic pass leaves the source byte-for-byte intact.
+func assertReportOnlySnapshot(t *testing.T, ruleName, source string) {
+  t.Helper()
+  _, _, findings := runRuleFindingsSnapshot(t, ruleName, source, nil)
+  if len(findings) == 0 {
+    t.Fatalf("%s: expected at least one finding", ruleName)
+  }
+  for index, finding := range findings {
+    if len(finding.Fix) != 0 {
+      t.Fatalf("%s: finding %d carries a fix: %+v", ruleName, index, finding.Fix)
+    }
+    if len(finding.Suggestions) != 0 {
+      t.Fatalf(
+        "%s: finding %d carries a suggestion: %+v",
+        ruleName,
+        index,
+        finding.Suggestions,
+      )
+    }
+  }
+  if unchanged, applied := applyFindingFixesToText(source, findings); applied != 0 || unchanged != source {
+    t.Fatalf(
+      "%s: automatic pass must change nothing: applied=%d got %q",
+      ruleName,
+      applied,
+      unchanged,
+    )
+  }
+}
+
 // assertRuleSkipsSource asserts the rule emits zero findings for the input.
 // Distinguished from `assertNoFixSnapshot`: the latter requires at least one
 // finding (and asserts no fix is applied); this helper is for cases where the

--- a/website/src/content/docs/lint/rules/core.mdx
+++ b/website/src/content/docs/lint/rules/core.mdx
@@ -376,9 +376,11 @@ function trailing(b: number, a?: number): number {
 
 Prefer dot access (`obj.value`) over bracket access (`obj["value"]`) when the string key is a valid JavaScript identifier.
 
-Bracket access remains accepted for reserved words, dynamic keys, or keys containing characters that cannot appear in an identifier.
+Bracket access remains accepted for dynamic keys or keys containing characters that cannot appear in an identifier.
 
-The autofix inserts a space after a bare decimal-integer receiver (`5["toString"]` becomes `5 .toString`) so the dot is not lexed as the number's decimal point, and declines the rewrite when a comment sits inside the bracket span rather than deleting it.
+The autofix inserts a space after a bare decimal-integer receiver (`5["toString"]` becomes `5 .toString`) so the dot is not lexed as the number's decimal point.
+
+Two cases are reported without an autofix and offer the rewrite as an editor suggestion instead: a comment inside the bracket span (applying the suggestion deletes that comment), and a reserved-word key such as `box["class"]` (valid on modern targets, but bracket access is kept by default because minifiers and older engines can break on it).
 
 Example:
 
@@ -397,6 +399,8 @@ const kept = box["not-valid-key"];
 Require strict equality operators `===` / `!==` over `==` / `!=`.
 
 Loose equality performs implicit type coercion that frequently hides bugs.
+
+The operator is autofixed only when both operands are provably the same type (two same-kind literals, or a `typeof` comparison). Otherwise tightening the comparison can change what the program computes, so the rewrite is offered as an editor suggestion the author opts into rather than being applied by `ttsc fix`.
 
 Example:
 
@@ -1393,7 +1397,7 @@ Allow specific builtins with the `exceptions` option:
 
 Reject `.bind(thisArg)` on an arrow function or on a regular function whose own scope never reads `this`. A nested arrow inherits the enclosing regular function's receiver and therefore counts as a use, while a nested regular function owns a separate receiver. Calls with arguments after `thisArg` and calls that spread their arguments remain unchanged because they can perform partial application.
 
-Dot, static computed, and optional member/call forms are recognized. The autofix removes the bind syntax only when evaluating `thisArg` is side-effect-free and no comment lies inside the discarded ranges; other findings remain diagnostic-only.
+Dot, static computed, and optional member/call forms are recognized. The autofix removes the bind syntax only when evaluating `thisArg` is side-effect-free and no comment lies inside the discarded ranges. A comment in those ranges downgrades the removal to an editor suggestion (applying it deletes the comment), while an effectful `thisArg` stays diagnostic-only because removing the bind would also remove an evaluation the program performs.
 
 Example:
 
@@ -1409,6 +1413,8 @@ const partial = ((value: number) => value).bind(null, 1);
 ### `no-extra-boolean-cast`
 
 Reject redundant boolean casts such as `!!Boolean(x)`, `if (Boolean(x))`, or `Boolean(!!x)`.
+
+The autofix splices the inner expression over the whole cast, parenthesizing it where precedence requires. When a comment sits inside the replaced span the splice would delete it, so the rewrite is offered as an editor suggestion instead of being applied automatically.
 
 Example:
 
@@ -2638,7 +2644,7 @@ const value = "ab\cdef";
 
 ### `no-useless-rename`
 
-Reject `{ x: x }` destructuring renames that bind back to the same name. Autofixable.
+Reject `{ x: x }` destructuring renames that bind back to the same name. Autofixable, except when a comment sits between the two names: deleting the rename tail would delete the comment, so the collapse is offered as an editor suggestion instead.
 
 Example:
 
@@ -2713,7 +2719,7 @@ function f(scope: Record<string, unknown>) {
 
 ### `object-shorthand`
 
-Reject `{ foo: foo }` and similar object-literal shorthand candidates in favor of `{ foo }`. Autofixable.
+Reject `{ foo: foo }` and similar object-literal shorthand candidates in favor of `{ foo }`. Autofixable, except when a comment sits between the key and the value: deleting the `: value` tail would delete the comment, so the collapse is offered as an editor suggestion instead.
 
 Example:
 
@@ -2937,6 +2943,8 @@ f.apply(null, args);
 ### `prefer-template`
 
 Prefer template literals over string concatenation when any operand is non-literal.
+
+The autofix rewrites the whole `+` chain as one template literal. A comment in an operator seam has nowhere to go in the rebuilt literal, so that case is reported without an autofix and the rendered literal is offered as an editor suggestion (applying it discards the seam comment).
 
 Example:
 

--- a/website/src/content/docs/lint/rules/index.mdx
+++ b/website/src/content/docs/lint/rules/index.mdx
@@ -126,6 +126,8 @@ Formatter behavior is configured separately through the top-level `format` block
 
 Suggestion-only rewrites, including removing an ordinary non-thenable `await` and replacing `@ts-ignore`, are available through `quickfix.ttsc`; `ttsc fix` and source fix-all do not apply them.
 
+A rule that computes a valid rewrite but refuses to impose it also offers that rewrite as a suggestion rather than dropping it. This covers `no-extra-boolean-cast`, `dot-notation`, `object-shorthand`, `no-useless-rename`, `prefer-template`, and `no-extra-bind` when a comment sits inside the span the edit replaces (the suggestion discards that comment, and its title says so), `dot-notation` on a reserved-word key, and `eqeqeq` when the operands are not provably the same type (the suggestion changes runtime behavior, and its title says so). Nothing in this group is ever applied by `ttsc fix` or source fix-all.
+
 ## See also
 
 - [Format](/docs/lint/format): the format rule set (including print-width reflow).


### PR DESCRIPTION
Refs #768.

## The insight

Seven core rules build the exact `TextEdit` they want, then discover the span they would replace is not safe to overwrite, and fall back to a bare `ctx.Report` — throwing the finished edit away.

Withholding an *imposed* autofix is right in every one of those cases: `ttsc fix` rewrites the file without asking, so silently eating a comment or silently changing what the program computes is unacceptable. But that is an argument against imposing the edit, not against having one. A suggestion is opt-in, titled, and reviewed by the author before it lands, so lossy is exactly what the suggestion channel is for. The reason the fix was withheld is the reason it should be offered.

`ctx.ReportSuggestion` / `ctx.ReportRangeSuggestion` already existed (#744), so no new plumbing was needed. Each site changes from `Report` to the suggestion call with the edit it had already computed. No shared helper was introduced: one would only have re-wrapped a two-line call and hidden which channel each rule uses.

## The seven sites

| rule | file | withheld because | converted |
| --- | --- | --- | --- |
| `no-extra-boolean-cast` | `rules_logic.go` | comment in the replaced span | yes (comment branch only) |
| `eqeqeq` | `rules_logic.go` | operands not provably same-type | yes |
| `dot-notation` | `rules_gap.go` | comment in the bracket span | yes |
| `dot-notation` | `rules_gap.go` | reserved-word key | yes |
| `object-shorthand` | `rules_suggestions.go` | comment in the `: value` span | yes |
| `no-useless-rename` | `rules_suggestions.go` | comment in the rename tail | yes |
| `prefer-template` | `rules_suggestions.go` | comment in an operator seam | yes (seam branch only) |
| `no-extra-bind` | `rules_suggestions.go` | comment in the discarded ranges | yes (comment branch only) |

Every guard that currently passes still calls `ReportFix` and still applies through `ttsc fix` and `source.fixAll.ttsc` exactly as before. Suggestion edits are never consumed by either.

## What the suggestions do to the comment

They drop it. That is deliberate: the withheld edit is the correct rewrite, and reconstructing a comment-preserving variant would be a different, speculative feature per rule. Because the loss is real, every title states it in the words the author sees, for example `Use property shorthand, discarding the comment before the value.` and `Remove the redundant rename, discarding the comment inside it.` No title claims the comment survives.

## Sites inspected and rejected

Three shapes inside the listed line ranges look like the pattern but are not it, and were left as plain reports:

- **`no-extra-boolean-cast` range branches** (the `keepStart` and `editPos` bound guards in `rules_logic.go`). These fire when the computed range is degenerate or out of bounds, so there is no valid edit to offer, only a malformed one.
- **`prefer-template` render and range branches** (`renderConcatAsTemplate` returning `!ok`, and the `editPos` bound check). Same reason: the template was never produced, or the splice range is degenerate.
- **`no-extra-bind` with an effectful receiver.** `noExtraBindFixEdits` returns before computing any edit when `thisArg` is not side-effect-free. Deleting `.bind(makeReceiver())` also deletes a call the program performs, which is not lossy but wrong, so this stays diagnostic-only. `noExtraBindFixEdits` now returns `(edits, imposable)` precisely so the comment case and the effectful case stop sharing one `nil` return, and `TestNoExtraBindOffersWithheldRemovalAsSuggestion` pins that they stay apart.

`eqeqeq` is the one conversion whose withhold reason is not comment loss. Its shape matches (the computed `===` / `!==` replacement is passed in and dropped), and a behavior-changing rewrite that needs a human decision is the textbook use of the suggestion channel, so it was converted with a title that names the risk rather than hiding it: ``Replace with `===`, which changes the result when the operands differ in type.``

## Specification changes

Called out explicitly, per the development skill:

- Eight new suggestions are advertised over LSP `quickfix.ttsc` where previously nothing was offered. No diagnostic message, range, or severity changed, and no rule reports on a shape it did not report on before.
- `dot-notation` on a reserved-word key now offers a rewrite. This moves toward ESLint's default `allowKeywords: true`, which rewrites keyword keys outright; the imposed autofix stays conservative.
- `noExtraBindFixEdits` changed signature from `[]TextEdit` to `([]TextEdit, bool)`. Package-internal; no exported surface touched.
- Docs updated in the same change: `website/src/content/docs/lint/rules/index.mdx` (autofix-coverage section) and the seven rule entries in `core.mdx`.

## Tests

Eight new cases, one per file, each pairing the positive with its negative twin:

- transformation direction: a mangled input produces the canonical ESLint output through the suggestion's own edits, not through whatever the code currently emits;
- negative twin: the same shape one property away (comment removed, reserved word removed, type provable) still imposes an ordinary autofix;
- boundaries: `eqeqeq` covers both `==` and `!=` because the title is built from the replacement, and `no-extra-bind` adds an effectful-receiver arm that must offer neither a fix nor a suggestion.

Two shared helpers were added next to `assertNoFixSnapshot` in `test/shared/helpers_test.go`. `assertSuggestionSnapshot` asserts nothing is auto-applied *and* that the advertised edits produce the expected source, because asserting only the first half would also pass for a rule that dropped the edit entirely. `assertReportOnlySnapshot` asserts a rule offers neither channel, which `assertNoFixSnapshot` cannot distinguish since suggestion edits never reach the fix applier.

Expected outputs were taken from the upstream ESLint rules' semantics, not from current output.

## Verification

- `go build ./linthost/` and `go vet ./linthost/` in `packages/lint`, through a temporary `go.work` listing `.`, `../ttsc`, and every `packages/ttsc/shim/*` module. The `go.work` was deleted afterwards and is not committed.
- `node scripts/test-go-lint.cjs`, the CI-equivalent lint Go suite, run against the main checkout's built `ttsx` launcher because this worktree has no `node_modules`.
- Touched Go files formatted with `.vscode/gofmt-2spaces.sh -w`. The repository-wide formatter was **not** run: an issue campaign is active.

CI is the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbiF9VH8TAGwdgFBnEQYfz
