### PR TITLE
fix(graph): rank candidates before applying limits

### DIFF
--- a/packages/graph/src/server/resolveHandle.ts
+++ b/packages/graph/src/server/resolveHandle.ts
@@ -42,21 +42,17 @@ export function resolveGraphHandle(
   const byId = graph.node(handle);
   if (byId !== undefined) return { node: byId };
 
-  const byName = resolveGraphName(graph, handle, candidateLimit);
+  const byName = resolveGraphName(graph, handle);
   if (byName.node !== undefined || byName.candidates !== undefined)
     return rank(graph, byName, candidateLimit);
 
-  const byFile = resolveFileQualified(graph, handle, candidateLimit);
+  const byFile = resolveFileQualified(graph, handle);
   if (byFile.node !== undefined || byFile.candidates !== undefined)
     return rank(graph, byFile, candidateLimit);
 
   const symbol = symbolPartOf(handle) ?? memberPartOf(handle);
   if (symbol !== undefined)
-    return rank(
-      graph,
-      resolveGraphName(graph, symbol, candidateLimit),
-      candidateLimit,
-    );
+    return rank(graph, resolveGraphName(graph, symbol), candidateLimit);
   return {};
 }
 
@@ -88,11 +84,10 @@ function symbolPartOf(handle: string): string | undefined {
 function resolveGraphName(
   graph: TtscGraphMemory,
   name: string,
-  candidateLimit: number,
 ): IResolvedGraphHandle {
   const exact = graph.symbols(name);
   if (exact.length === 1) return { node: exact[0] };
-  if (exact.length > 1) return { candidates: exact.slice(0, candidateLimit) };
+  if (exact.length > 1) return { candidates: [...exact] };
 
   if (name.includes(".")) {
     const suffix = `.${name}`;
@@ -102,7 +97,7 @@ function resolveGraphName(
     );
     if (suffixMatches.length === 1) return { node: suffixMatches[0] };
     if (suffixMatches.length > 1) {
-      return { candidates: suffixMatches.slice(0, candidateLimit) };
+      return { candidates: suffixMatches };
     }
   }
   return {};
@@ -117,7 +112,6 @@ function resolveGraphName(
 function resolveFileQualified(
   graph: TtscGraphMemory,
   handle: string,
-  candidateLimit: number,
 ): IResolvedGraphHandle {
   const dot = handle.indexOf(".");
   if (dot <= 0) return {};
@@ -128,8 +122,7 @@ function resolveFileQualified(
     .symbols(name)
     .filter((node) => fileStem(node.file) === stem);
   if (matches.length === 1) return { node: matches[0] };
-  if (matches.length > 1)
-    return { candidates: matches.slice(0, candidateLimit) };
+  if (matches.length > 1) return { candidates: matches };
   return {};
 }
 
@@ -153,10 +146,20 @@ function rank(
   candidateLimit: number,
 ): IResolvedGraphHandle {
   if (resolved.candidates === undefined) return resolved;
-  const ranked = [...resolved.candidates]
-    .sort((a, b) => candidateScore(graph, b) - candidateScore(graph, a))
-    .slice(0, candidateLimit);
+  const ranked = resolved.candidates
+    .map((node) => ({ node, score: candidateScore(graph, node) }))
+    .sort((a, b) => {
+      const score = b.score - a.score;
+      return score !== 0 ? score : compareIdentity(a.node.id, b.node.id);
+    })
+    .slice(0, candidateLimit)
+    .map(({ node }) => node);
   return { candidates: ranked };
+}
+
+/** Compare position-invariant ids without locale-dependent collation. */
+function compareIdentity(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 function candidateScore(graph: TtscGraphMemory, node: ITtscGraphNode): number {

--- a/tests/test-graph/src/features/test_ttscgraph_resolver_applies_candidate_limits_after_ranking.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_resolver_applies_candidate_limits_after_ranking.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+
+import {
+  type ResolverGraphNode,
+  resolveSyntheticGraph,
+} from "../internal/resolverGraph";
+
+/**
+ * Verifies resolver ranking: candidate limits cap only the ranked response.
+ *
+ * The limit is a payload boundary, not a search boundary. Small and oversized
+ * limits must both preserve the same best candidate while returning no more
+ * than the caller requested.
+ *
+ * 1. Build five exact-name candidates with the exported winner last.
+ * 2. Resolve them with zero, small, exact, and oversized limits.
+ * 3. Assert each length is bounded and every non-empty result starts with the
+ *    winner.
+ */
+export const test_ttscgraph_resolver_applies_candidate_limits_after_ranking =
+  () => {
+    const nodes: ResolverGraphNode[] = Array.from(
+      { length: 5 },
+      (_, index) => ({
+        id: `src/limit-${String(index)}.ts#Bounded:class`,
+        kind: "class",
+        name: "Bounded",
+        file: `src/limit-${String(index)}.ts`,
+        external: false,
+        ...(index === 4 ? { exported: true } : {}),
+      }),
+    );
+
+    for (const [limit, expectedLength] of [
+      [0, 0],
+      [1, 1],
+      [3, 3],
+      [5, 5],
+      [8, 5],
+    ] as const) {
+      const resolved = resolveSyntheticGraph(nodes, "Bounded", limit);
+      assert.strictEqual(resolved.candidates?.length, expectedLength);
+      if (expectedLength > 0)
+        assert.strictEqual(resolved.candidates?.[0]?.id, nodes[4]!.id);
+    }
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_resolver_breaks_equal_score_ties_by_identity.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_resolver_breaks_equal_score_ties_by_identity.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+
+import {
+  type ResolverGraphNode,
+  resolveSyntheticGraph,
+} from "../internal/resolverGraph";
+
+/**
+ * Verifies resolver ranking: equal-score ties use stable graph identity.
+ *
+ * JavaScript's stable sort preserves input order when the comparator returns
+ * zero, but graph input order is compiler visitation order. Equal relevance
+ * therefore needs an explicit identity tie-break so two equivalent dumps
+ * agree.
+ *
+ * 1. Build three equal-score candidates in two opposite visitation orders.
+ * 2. Resolve the same ambiguous name from both memories.
+ * 3. Assert both results use the same ascending id order.
+ */
+export const test_ttscgraph_resolver_breaks_equal_score_ties_by_identity =
+  () => {
+    const nodes: ResolverGraphNode[] = ["c", "a", "b"].map((letter) => ({
+      id: `src/${letter}.ts#Tied:class`,
+      kind: "class",
+      name: "Tied",
+      file: `src/${letter}.ts`,
+      external: false,
+    }));
+    const expected = [
+      "src/a.ts#Tied:class",
+      "src/b.ts#Tied:class",
+      "src/c.ts#Tied:class",
+    ];
+
+    const forward = resolveSyntheticGraph(nodes, "Tied", 3);
+    const reverse = resolveSyntheticGraph([...nodes].reverse(), "Tied", 3);
+    assert.deepStrictEqual(
+      forward.candidates?.map((node) => node.id),
+      expected,
+    );
+    assert.deepStrictEqual(
+      reverse.candidates?.map((node) => node.id),
+      expected,
+    );
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_resolver_ranks_exact_candidates_before_limiting.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_resolver_ranks_exact_candidates_before_limiting.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+
+import {
+  type ResolverGraphNode,
+  resolveSyntheticGraph,
+} from "../internal/resolverGraph";
+
+/**
+ * Verifies resolver ranking: exact-name candidates are scored before limiting.
+ *
+ * The exact-name branch used to discard every node after the first twelve
+ * before the exported-symbol score ran, so compiler visitation order could hide
+ * the strongest match from every consumer.
+ *
+ * 1. Build thirteen exact-name candidates with the exported winner last.
+ * 2. Resolve the shared name with the default twelve-candidate limit.
+ * 3. Assert the late winner is returned first and the response stays capped.
+ */
+export const test_ttscgraph_resolver_ranks_exact_candidates_before_limiting =
+  () => {
+    const nodes: ResolverGraphNode[] = Array.from(
+      { length: 13 },
+      (_, index) => ({
+        id: `src/exact-${String(index).padStart(2, "0")}.ts#Shared:class`,
+        kind: "class",
+        name: "Shared",
+        file: `src/exact-${String(index).padStart(2, "0")}.ts`,
+        external: false,
+        ...(index === 12 ? { exported: true } : {}),
+      }),
+    );
+
+    const resolved = resolveSyntheticGraph(nodes, "Shared");
+    assert.strictEqual(resolved.candidates?.length, 12);
+    assert.strictEqual(resolved.candidates?.[0]?.id, nodes[12]!.id);
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_resolver_ranks_file_qualified_candidates_before_limiting.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_resolver_ranks_file_qualified_candidates_before_limiting.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+
+import {
+  type ResolverGraphNode,
+  resolveSyntheticGraph,
+} from "../internal/resolverGraph";
+
+/**
+ * Verifies resolver ranking: file-qualified candidates are scored before
+ * limiting.
+ *
+ * A repeated file stem can still be ambiguous across package directories. The
+ * file-qualified branch previously sliced that list independently, so its best
+ * declaration could disappear even though ranking knew it was exported.
+ *
+ * 1. Build thirteen `shared.ts` files that each declare `Thing`.
+ * 2. Place the exported declaration last in graph order.
+ * 3. Assert `shared.Thing` returns that candidate first within the limit.
+ */
+export const test_ttscgraph_resolver_ranks_file_qualified_candidates_before_limiting =
+  () => {
+    const nodes: ResolverGraphNode[] = Array.from(
+      { length: 13 },
+      (_, index) => ({
+        id: `packages/p${String(index)}/shared.ts#Thing:class`,
+        kind: "class",
+        name: "Thing",
+        file: `packages/p${String(index)}/shared.ts`,
+        external: false,
+        ...(index === 12 ? { exported: true } : {}),
+      }),
+    );
+
+    const resolved = resolveSyntheticGraph(nodes, "shared.Thing");
+    assert.strictEqual(resolved.candidates?.length, 12);
+    assert.strictEqual(resolved.candidates?.[0]?.id, nodes[12]!.id);
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_resolver_ranks_member_fallback_before_limiting.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_resolver_ranks_member_fallback_before_limiting.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+
+import {
+  type ResolverGraphNode,
+  resolveSyntheticGraph,
+} from "../internal/resolverGraph";
+
+/**
+ * Verifies resolver ranking: value-member fallback ranks the complete member
+ * set.
+ *
+ * Calls such as `client.run` have no graph node for the runtime receiver, so
+ * the resolver finally searches the member name `run`. That recovery must
+ * consider every declaring type rather than the first twelve methods indexed.
+ *
+ * 1. Build thirteen owner-qualified `run` methods with the winner last.
+ * 2. Resolve the value-shaped handle `client.run`.
+ * 3. Assert fallback returns the late exported method first within the cap.
+ */
+export const test_ttscgraph_resolver_ranks_member_fallback_before_limiting =
+  () => {
+    const nodes: ResolverGraphNode[] = Array.from(
+      { length: 13 },
+      (_, index) => ({
+        id: `src/service-${String(index).padStart(2, "0")}.ts#Service${String(index)}.run:method`,
+        kind: "method",
+        name: "run",
+        qualifiedName: `Service${String(index)}.run`,
+        file: `src/service-${String(index).padStart(2, "0")}.ts`,
+        external: false,
+        ...(index === 12 ? { exported: true } : {}),
+      }),
+    );
+
+    const resolved = resolveSyntheticGraph(nodes, "client.run");
+    assert.strictEqual(resolved.candidates?.length, 12);
+    assert.strictEqual(resolved.candidates?.[0]?.id, nodes[12]!.id);
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_resolver_ranks_stale_id_fallback_before_limiting.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_resolver_ranks_stale_id_fallback_before_limiting.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+
+import {
+  type ResolverGraphNode,
+  resolveSyntheticGraph,
+} from "../internal/resolverGraph";
+
+/**
+ * Verifies resolver ranking: stale-id fallback ranks the complete symbol set.
+ *
+ * A stale `file#symbol:kind` handle falls back to its symbol portion after the
+ * direct id misses. That recovery reuses exact-name resolution and must not
+ * inherit a pre-ranked prefix that omits the strongest current declaration.
+ *
+ * 1. Build thirteen current declarations named `Moved` with the winner last.
+ * 2. Resolve an id whose old file no longer exists.
+ * 3. Assert the recovered ambiguity starts with the late exported declaration.
+ */
+export const test_ttscgraph_resolver_ranks_stale_id_fallback_before_limiting =
+  () => {
+    const nodes: ResolverGraphNode[] = Array.from(
+      { length: 13 },
+      (_, index) => ({
+        id: `src/current-${String(index).padStart(2, "0")}.ts#Moved:class`,
+        kind: "class",
+        name: "Moved",
+        file: `src/current-${String(index).padStart(2, "0")}.ts`,
+        external: false,
+        ...(index === 12 ? { exported: true } : {}),
+      }),
+    );
+
+    const resolved = resolveSyntheticGraph(nodes, "src/old.ts#Moved:class");
+    assert.strictEqual(resolved.candidates?.length, 12);
+    assert.strictEqual(resolved.candidates?.[0]?.id, nodes[12]!.id);
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_resolver_ranks_suffix_candidates_before_limiting.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_resolver_ranks_suffix_candidates_before_limiting.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+
+import {
+  type ResolverGraphNode,
+  resolveSyntheticGraph,
+} from "../internal/resolverGraph";
+
+/**
+ * Verifies resolver ranking: qualified suffix candidates are scored before
+ * limiting.
+ *
+ * Suffix matching has its own candidate producer, and it carried the same early
+ * truncation as exact names. Fixing only the common-name witness would leave
+ * nested declarations dependent on graph traversal order.
+ *
+ * 1. Build thirteen methods whose qualified names end in `Inner.run`.
+ * 2. Put the only exported method after the response limit.
+ * 3. Assert suffix resolution ranks that method first before returning twelve.
+ */
+export const test_ttscgraph_resolver_ranks_suffix_candidates_before_limiting =
+  () => {
+    const nodes: ResolverGraphNode[] = Array.from(
+      { length: 13 },
+      (_, index) => ({
+        id: `src/suffix-${String(index).padStart(2, "0")}.ts#Outer${String(index)}.Inner.run:method`,
+        kind: "method",
+        name: "run",
+        qualifiedName: `Outer${String(index)}.Inner.run`,
+        file: `src/suffix-${String(index).padStart(2, "0")}.ts`,
+        external: false,
+        ...(index === 12 ? { exported: true } : {}),
+      }),
+    );
+
+    const resolved = resolveSyntheticGraph(nodes, "Inner.run");
+    assert.strictEqual(resolved.candidates?.length, 12);
+    assert.strictEqual(resolved.candidates?.[0]?.id, nodes[12]!.id);
+  };

--- a/tests/test-graph/src/internal/resolverGraph.ts
+++ b/tests/test-graph/src/internal/resolverGraph.ts
@@ -1,0 +1,72 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
+export interface ResolverGraphNode {
+  id: string;
+  kind: "class" | "method";
+  name: string;
+  qualifiedName?: string;
+  file: string;
+  external: boolean;
+  exported?: boolean;
+}
+
+interface ResolverGraphEdge {
+  from: string;
+  to: string;
+  kind: "calls" | "exports";
+}
+
+interface GraphMemory {
+  node(id: string): ResolverGraphNode | undefined;
+  nodes: readonly ResolverGraphNode[];
+  outgoing(id: string): readonly ResolverGraphEdge[];
+  incoming(id: string): readonly ResolverGraphEdge[];
+  symbols(handle: string): readonly ResolverGraphNode[];
+}
+
+interface GraphMemoryConstructor {
+  from(dump: {
+    project: string;
+    nodes: ResolverGraphNode[];
+    edges: ResolverGraphEdge[];
+  }): GraphMemory;
+}
+
+interface ResolvedGraphHandle {
+  node?: ResolverGraphNode;
+  candidates?: ResolverGraphNode[];
+}
+
+interface ResolveHandleModule {
+  resolveGraphHandle(
+    graph: GraphMemory,
+    handle: string,
+    candidateLimit?: number,
+  ): ResolvedGraphHandle;
+}
+
+const require = createRequire(import.meta.url);
+const graphEntry = require.resolve("@ttsc/graph");
+const graphLib = path.dirname(graphEntry);
+const { TtscGraphMemory } = require(
+  path.join(graphLib, "model", "TtscGraphMemory.js"),
+) as { TtscGraphMemory: GraphMemoryConstructor };
+const { resolveGraphHandle } = require(
+  path.join(graphLib, "server", "resolveHandle.js"),
+) as ResolveHandleModule;
+
+/** Resolve a handle through the package's built memory indexes and resolver. */
+export function resolveSyntheticGraph(
+  nodes: ResolverGraphNode[],
+  handle: string,
+  candidateLimit = 12,
+  edges: ResolverGraphEdge[] = [],
+): ResolvedGraphHandle {
+  const graph = TtscGraphMemory.from({
+    project: "C:/synthetic-graph",
+    nodes,
+    edges,
+  });
+  return resolveGraphHandle(graph, handle, candidateLimit);
+}

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -43,6 +43,8 @@ The graph answers the questions an agent actually asks, all from the same checke
 - **What does this reach, and what reaches it?** Forward to callees, reverse to callers, and an impact projection onto the public API and tests: `trace`.
 - **What is this, exactly?** The declaration shape, its range, its dependencies, and its dependents: `details`.
 
+When a handle names several declarations, the graph scores every match by export surface and graph use before it caps the response. Equal scores use the declaration's stable graph id, so compiler visitation order cannot hide a stronger match or reshuffle a tie.
+
 A tree-sitter graph has no types and resolves edges by guessing from text. An editor's language server has types but no architecture projection. Only a graph built on the real checker holds the resolved structure and the affected set in one place. Every node and edge is resolved by the compiler, so an agent never mistakes inference for fact.
 
 ### What only the compiler can resolve


### PR DESCRIPTION
# Intent

Make ambiguous graph handles return the most relevant declarations independent of compiler visitation order by ranking every matching candidate before applying the response limit.

Implements #759 without changing the issue body.

## Implementation

- Exact, qualified-suffix, and file-qualified branches return their complete match sets.
- One shared ranker computes each candidate score once, sorts by relevance, breaks ties by stable graph id, and applies the response limit last.
- Stale-id and value-member fallbacks inherit the same invariant.
- Seven regressions cover exact, suffix, file-qualified, stale-id, member fallback, limit boundaries, and deterministic ties.
- The graph guide documents the ambiguity-ordering contract.

## Deterministic verification

- New resolver regressions: 7/7 passed.
- Complete `@ttsc/test-graph`: 26/26 passed on the rebased implementation.
- `packages/graph` and `tests/test-graph` typechecks passed.
- `@ttsc/graph` build and viewer bundle passed.
- Targeted Prettier and `git diff --check` passed.
- Offline old/new tour payloads were byte-identical in 16/16 repository × prompt-family cells.
- Solo Self-Review recorded one score-recomputation finding, remediated it, then completed a clean second round.

## Contract boundary

`packages/graph/src/structures/ITtscGraphApplication.ts`, all of its types and JSDoc, and `packages/graph/src/TtscGraphApplication.ts` remain byte-identical to `master`.

No dependency, schema, prompt, fixture, or benchmark publication changes are included.

## Benchmark ownership

An exploratory model sweep was stopped after 50/64 valid cells when the repository owner clarified that paid AI benchmarks are owner-run and are not a campaign merge gate. Those partial cells are not published or used as correctness evidence. This PR is gated only by deterministic logic, integration, build, and type checks.