### PR TITLE
fix(graph): recover native sessions after stalled requests

### DIFF
--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -20,7 +20,11 @@ export {
 // found under that project's installed `ttsc`.
 export { resolveGraphBinary } from "./resolveGraphBinary";
 export { loadGraph } from "./model/loadGraph";
-export { TtscGraphSession } from "./model/TtscGraphSession";
+export {
+  TtscGraphSession,
+  type TtscGraphRequestOptions,
+  type TtscGraphSessionOptions,
+} from "./model/TtscGraphSession";
 
 // The server version reported in the MCP handshake; read from this package.
 const VERSION: string = (require("../package.json") as { version: string })

--- a/packages/graph/src/model/TtscGraphSession.ts
+++ b/packages/graph/src/model/TtscGraphSession.ts
@@ -5,8 +5,8 @@ import typia from "typia";
 import { ensureExecutable } from "../nativeExecutable";
 import { resolveGraphBinary } from "../resolveGraphBinary";
 import { ITtscGraphSnapshot } from "../structures/ITtscGraphSnapshot";
-import { DUMP_SCHEMA_VERSION } from "./loadGraph";
 import { TtscGraphMemory } from "./TtscGraphMemory";
+import { DUMP_SCHEMA_VERSION } from "./loadGraph";
 
 /**
  * The serve protocol version this client speaks.
@@ -17,10 +17,44 @@ import { TtscGraphMemory } from "./TtscGraphMemory";
  * constant out of this file and fails if the pair drifts.
  */
 const PROTOCOL_VERSION = 1;
+const DEFAULT_REQUEST_TIMEOUT_MS = 300_000;
+const MAX_TIMER_MS = 2_147_483_647;
+const TERMINATION_GRACE_MS = 1_000;
 
 interface Pending {
+  child: NativeChild;
   resolve: (response: ITtscGraphSnapshot) => void;
   reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+  signal?: AbortSignal;
+  abort?: () => void;
+}
+
+interface NativeChild {
+  process: ChildProcessWithoutNullStreams;
+  lines: readline.Interface;
+  stderr: string;
+}
+
+/** Construction options for a resident native graph session. */
+export interface TtscGraphSessionOptions {
+  /** Project root passed to `ttscgraph serve`. */
+  cwd: string;
+  /** Project tsconfig passed to `ttscgraph serve`. */
+  tsconfig: string;
+  /** Absolute native binary path, resolved from `cwd` when omitted. */
+  binary?: string;
+  /**
+   * Maximum time for one native snapshot response. Defaults to five minutes,
+   * which is more than ten times the published 28.7-second VS Code cold index.
+   */
+  requestTimeoutMs?: number;
+}
+
+/** Per-call controls for a native graph refresh. */
+export interface TtscGraphRequestOptions {
+  /** Cancel this refresh and retire its native session. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -35,19 +69,26 @@ export class TtscGraphSession {
   private readonly cwd: string;
   private readonly tsconfig: string;
   private readonly binary: string;
-  private child: ChildProcessWithoutNullStreams | undefined;
-  private stderr = "";
+  private readonly requestTimeoutMs: number;
+  private child: NativeChild | undefined;
   private nextId = 0;
   private readonly pending = new Map<number, Pending>();
   private queue: Promise<void> = Promise.resolve();
   private current: TtscGraphMemory | undefined;
   private closed = false;
 
-  public constructor(options: {
-    cwd: string;
-    tsconfig: string;
-    binary?: string;
-  }) {
+  public constructor(options: TtscGraphSessionOptions) {
+    const requestTimeoutMs =
+      options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    if (
+      !Number.isSafeInteger(requestTimeoutMs) ||
+      requestTimeoutMs <= 0 ||
+      requestTimeoutMs > MAX_TIMER_MS
+    ) {
+      throw new TypeError(
+        `@ttsc/graph: requestTimeoutMs must be an integer between 1 and ${String(MAX_TIMER_MS)}`,
+      );
+    }
     // Resolve the platform binary from the project this session serves, so the
     // MCP server started from an unrelated directory still finds the target's
     // installed `ttsc`.
@@ -64,21 +105,48 @@ export class TtscGraphSession {
     this.cwd = options.cwd;
     this.tsconfig = options.tsconfig;
     this.binary = binary;
+    this.requestTimeoutMs = requestTimeoutMs;
   }
 
   /** Return a graph for the current disk snapshot, serialized per tool call. */
-  public graph(): Promise<TtscGraphMemory> {
+  public graph(
+    options: TtscGraphRequestOptions = {},
+  ): Promise<TtscGraphMemory> {
+    if (this.closed) {
+      return Promise.reject(new Error("@ttsc/graph: native session is closed"));
+    }
     let resolve!: (graph: TtscGraphMemory) => void;
     let reject!: (error: Error) => void;
+    let started = false;
+    let settled = false;
     const result = new Promise<TtscGraphMemory>((res, rej) => {
-      resolve = res;
-      reject = rej;
+      resolve = (graph) => {
+        if (settled) return;
+        settled = true;
+        res(graph);
+      };
+      reject = (error) => {
+        if (settled) return;
+        settled = true;
+        rej(error);
+      };
     });
+    const cancelQueued = () => {
+      if (!started) reject(cancelledError(options.signal));
+    };
+    if (options.signal?.aborted) {
+      reject(cancelledError(options.signal));
+      return result;
+    }
+    options.signal?.addEventListener("abort", cancelQueued, { once: true });
     this.queue = this.queue
       .catch(() => undefined)
       .then(async () => {
+        started = true;
+        options.signal?.removeEventListener("abort", cancelQueued);
+        if (settled) return;
         try {
-          resolve(await this.refresh());
+          resolve(await this.refresh(options.signal));
         } catch (error) {
           reject(asError(error));
         }
@@ -88,17 +156,17 @@ export class TtscGraphSession {
 
   /** Close the native session. Safe to call more than once. */
   public close(): void {
+    if (this.closed) return;
     this.closed = true;
-    const child = this.child;
-    this.child = undefined;
-    if (child !== undefined && !child.killed) child.stdin.end();
-    this.failPending(new Error("@ttsc/graph: native session closed"));
+    const error = new Error("@ttsc/graph: native session closed");
+    if (this.child !== undefined) this.failChild(this.child, error);
+    else this.failPending(error);
   }
 
-  private async refresh(): Promise<TtscGraphMemory> {
+  private async refresh(signal?: AbortSignal): Promise<TtscGraphMemory> {
     // The protocol version and the envelope shape were both settled in onLine,
     // before this frame was ever routed here.
-    const response = await this.request();
+    const response = await this.request(signal);
     if (response.error !== undefined) {
       throw new Error(`@ttsc/graph: ${response.error}`);
     }
@@ -118,15 +186,41 @@ export class TtscGraphSession {
     return this.current;
   }
 
-  private request(): Promise<ITtscGraphSnapshot> {
+  private request(signal?: AbortSignal): Promise<ITtscGraphSnapshot> {
+    if (signal?.aborted) throw cancelledError(signal);
     const child = this.ensureChild();
     const id = ++this.nextId;
     return new Promise<ITtscGraphSnapshot>((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
-      child.stdin.write(`${JSON.stringify({ id })}\n`, (error) => {
+      const pending: Pending = {
+        child,
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          this.failChild(
+            child,
+            new Error(
+              `@ttsc/graph: native snapshot request timed out after ${String(this.requestTimeoutMs)} ms${stderrSuffix(child)}`,
+            ),
+          );
+        }, this.requestTimeoutMs),
+        signal,
+      };
+      pending.timer.unref();
+      if (signal !== undefined) {
+        pending.abort = () =>
+          this.failChild(child, cancelledError(signal, child));
+        signal.addEventListener("abort", pending.abort, { once: true });
+      }
+      this.pending.set(id, pending);
+      if (signal?.aborted) {
+        pending.abort!();
+        return;
+      }
+      child.process.stdin.write(`${JSON.stringify({ id })}\n`, (error) => {
         if (error === null || error === undefined) return;
-        this.pending.delete(id);
-        reject(
+        if (this.pending.get(id) !== pending) return;
+        this.failChild(
+          child,
           new Error(
             `@ttsc/graph: could not request native snapshot: ${error.message}`,
           ),
@@ -135,49 +229,61 @@ export class TtscGraphSession {
     });
   }
 
-  private ensureChild(): ChildProcessWithoutNullStreams {
+  private ensureChild(): NativeChild {
     if (this.closed) {
       // A request queued behind the close must not respawn the native
       // process; an orphaned resident compiler would outlive the MCP server.
       throw new Error("@ttsc/graph: native session is closed");
     }
-    if (this.child !== undefined && this.child.exitCode === null) {
+    if (
+      this.child !== undefined &&
+      this.child.process.exitCode === null &&
+      this.child.process.signalCode === null
+    ) {
       return this.child;
     }
-    this.stderr = "";
-    const child = spawn(
+    const process = spawn(
       this.binary,
       ["serve", "--cwd", this.cwd, "--tsconfig", this.tsconfig],
       { stdio: ["pipe", "pipe", "pipe"], windowsHide: true },
     );
+    const lines = readline.createInterface({ input: process.stdout });
+    const child: NativeChild = { process, lines, stderr: "" };
     this.child = child;
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk: string) => {
-      this.stderr = (this.stderr + chunk).slice(-64 * 1024);
+    process.stderr.setEncoding("utf8");
+    process.stderr.on("data", (chunk: string) => {
+      child.stderr = (child.stderr + chunk).slice(-64 * 1024);
     });
-    const lines = readline.createInterface({ input: child.stdout });
-    lines.on("line", (line) => this.onLine(line));
-    child.on("error", (error) => this.failChild(child, error));
-    child.on("exit", (code, signal) => {
+    lines.on("line", (line) => this.onLine(child, line));
+    process.on("error", (error) =>
+      this.failChild(
+        child,
+        new Error(`@ttsc/graph: native session failed: ${error.message}`),
+      ),
+    );
+    process.on("exit", (code, signal) => {
       if (this.child !== child) return;
-      this.child = undefined;
-      this.failPending(
+      this.failChild(
+        child,
         new Error(
-          `@ttsc/graph: native session exited (code=${String(code)}, signal=${String(signal)})${
-            this.stderr.trim() === "" ? "" : `: ${this.stderr.trim()}`
-          }`,
+          `@ttsc/graph: native session exited (code=${String(code)}, signal=${String(signal)})${stderrSuffix(
+            child,
+          )}`,
         ),
+        false,
       );
     });
     return child;
   }
 
-  private onLine(line: string): void {
+  private onLine(child: NativeChild, line: string): void {
+    if (this.child !== child) return;
     let parsed: unknown;
     try {
       parsed = JSON.parse(line);
     } catch (error) {
-      this.failPending(
+      this.failChild(
+        child,
         new Error(
           `@ttsc/graph: native session returned invalid JSON: ${asError(error).message}`,
         ),
@@ -199,7 +305,8 @@ export class TtscGraphSession {
     if (version !== PROTOCOL_VERSION) {
       // Session-wide: a version mismatch is not one bad frame, it is the wrong
       // binary, and every request against it is equally doomed.
-      this.failPending(
+      this.failChild(
+        child,
         new Error(
           `@ttsc/graph: ttscgraph speaks serve protocol ${
             version === undefined ? "an unknown version" : `v${String(version)}`
@@ -220,7 +327,8 @@ export class TtscGraphSession {
       // envelope belongs on this side of that line.
       response = typia.assert<ITtscGraphSnapshot>(parsed);
     } catch (error) {
-      this.failPending(
+      this.failChild(
+        child,
         new Error(
           `@ttsc/graph: native session returned an unreadable response: ${asError(error).message}`,
         ),
@@ -241,7 +349,8 @@ export class TtscGraphSession {
     ) {
       // Session-wide, for the same reason the protocol mismatch above is: it is
       // the wrong binary, not one bad frame.
-      this.failPending(
+      this.failChild(
+        child,
         new Error(
           `@ttsc/graph: ttscgraph sends dump schema v${String(
             response.dump.provenance.schemaVersion,
@@ -254,22 +363,86 @@ export class TtscGraphSession {
     }
 
     const pending = this.pending.get(response.id);
-    if (pending === undefined) return;
-    this.pending.delete(response.id);
-    pending.resolve(response);
+    if (pending === undefined || pending.child !== child) return;
+    this.settlePending(response.id, pending, response);
   }
 
-  private failChild(child: ChildProcessWithoutNullStreams, error: Error): void {
-    if (this.child === child) this.child = undefined;
-    this.failPending(
-      new Error(`@ttsc/graph: native session failed: ${error.message}`),
-    );
+  private failChild(child: NativeChild, error: Error, terminate = true): void {
+    if (this.child !== child) return;
+    this.child = undefined;
+    this.current = undefined;
+    child.lines.close();
+    this.failPending(error, child);
+    if (terminate) terminateChild(child.process);
   }
 
-  private failPending(error: Error): void {
-    for (const pending of this.pending.values()) pending.reject(error);
-    this.pending.clear();
+  private failPending(error: Error, child?: NativeChild): void {
+    for (const [id, pending] of this.pending) {
+      if (child === undefined || pending.child === child) {
+        this.settlePending(id, pending, error);
+      }
+    }
   }
+
+  private settlePending(
+    id: number,
+    pending: Pending,
+    result: ITtscGraphSnapshot | Error,
+  ): void {
+    if (this.pending.get(id) !== pending) return;
+    this.pending.delete(id);
+    clearTimeout(pending.timer);
+    if (pending.signal !== undefined && pending.abort !== undefined) {
+      pending.signal.removeEventListener("abort", pending.abort);
+    }
+    if (result instanceof Error) pending.reject(result);
+    else pending.resolve(result);
+  }
+}
+
+function terminateChild(child: ChildProcessWithoutNullStreams): void {
+  if (!child.stdin.destroyed) child.stdin.destroy();
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  try {
+    child.kill();
+  } catch {
+    return;
+  }
+  const force = setTimeout(() => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // The process exited between the liveness check and the signal.
+    }
+  }, TERMINATION_GRACE_MS);
+  force.unref();
+  child.once("exit", () => clearTimeout(force));
+}
+
+function cancelledError(signal?: AbortSignal, child?: NativeChild): Error {
+  const error = new Error(
+    `@ttsc/graph: native snapshot request cancelled${abortDetail(signal)}${
+      child === undefined ? "" : stderrSuffix(child)
+    }`,
+  );
+  error.name = "AbortError";
+  return error;
+}
+
+function abortDetail(signal?: AbortSignal): string {
+  const reason = signal?.reason;
+  if (reason === undefined) return "";
+  try {
+    return `: ${reason instanceof Error ? reason.message : String(reason)}`;
+  } catch {
+    return "";
+  }
+}
+
+function stderrSuffix(child: NativeChild): string {
+  const stderr = child.stderr.trim();
+  return stderr === "" ? "" : `: ${stderr}`;
 }
 
 function asError(error: unknown): Error {

--- a/tests/test-graph/src/features/test_ttscgraph_exited_native_child_restarts_session.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_exited_native_child_restarts_session.ts
@@ -1,0 +1,35 @@
+import {
+  createNativeSessionFixture,
+  readPids,
+  waitFor,
+} from "../internal/nativeSession";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies an early native child exit does not poison later graph requests.
+ *
+ * The process can exit before or while Node completes the stdin write callback.
+ * Both event orderings must settle the same pending owner once and leave the
+ * serialized queue able to spawn a new process.
+ *
+ * 1. Make the first fake process exit with a non-zero status before responding.
+ * 2. Assert the first graph call rejects through the child/write failure boundary.
+ * 3. Assert a later call starts a second process and returns a graph.
+ */
+export const test_ttscgraph_exited_native_child_restarts_session = async () => {
+  const { root, session } = createNativeSessionFixture({
+    mode: "exit-once",
+    requestTimeoutMs: 5_000,
+  });
+  try {
+    await assert.rejects(
+      session.graph(),
+      /native session exited|could not request native snapshot/,
+    );
+    const graph = await session.graph();
+    assert.deepEqual(graph.nodes, []);
+    await waitFor(() => readPids(root).length === 2, "replacement after exit");
+  } finally {
+    session.close();
+  }
+};

--- a/tests/test-graph/src/features/test_ttscgraph_malformed_native_frame_restarts_session.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_malformed_native_frame_restarts_session.ts
@@ -1,0 +1,36 @@
+import {
+  createNativeSessionFixture,
+  processIsAlive,
+  readPids,
+  waitFor,
+} from "../internal/nativeSession";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies malformed native output retires the offending child before retry.
+ *
+ * A framing failure is session-wide, not one bad request. Keeping that child
+ * reusable allows its later bytes to corrupt a new call, so the next request
+ * must begin on a different process generation.
+ *
+ * 1. Make the first fake process answer with invalid JSON and stay alive.
+ * 2. Assert the call rejects and the offending process is terminated.
+ * 3. Assert a later call spawns a replacement and succeeds.
+ */
+export const test_ttscgraph_malformed_native_frame_restarts_session =
+  async () => {
+    const { root, session } = createNativeSessionFixture({
+      mode: "malformed-once",
+      requestTimeoutMs: 5_000,
+    });
+    try {
+      await assert.rejects(session.graph(), /returned invalid JSON/);
+      const firstPid = readPids(root)[0]!;
+      await waitFor(() => !processIsAlive(firstPid), "malformed child exit");
+      const graph = await session.graph();
+      assert.deepEqual(graph.nodes, []);
+      assert.equal(readPids(root).length, 2);
+    } finally {
+      session.close();
+    }
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_native_request_abort_restarts_session.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_native_request_abort_restarts_session.ts
@@ -1,0 +1,44 @@
+import {
+  createNativeSessionFixture,
+  processIsAlive,
+  readPids,
+  waitFor,
+} from "../internal/nativeSession";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies aborting an active native request retires and restarts its session.
+ *
+ * Cancellation cannot merely reject the caller while leaving the child alive:
+ * that process can still emit the cancelled frame and its protocol position is
+ * no longer trusted. The same reset path as timeout must be used.
+ *
+ * 1. Start a first-process-only hanging fake and wait until it is resident.
+ * 2. Abort the active graph call and assert a cancellation error.
+ * 3. Assert the old child exits and a later graph call succeeds on a replacement.
+ */
+export const test_ttscgraph_native_request_abort_restarts_session =
+  async () => {
+    const { root, session } = createNativeSessionFixture({
+      mode: "hang-once",
+      requestTimeoutMs: 10_000,
+    });
+    try {
+      const controller = new AbortController();
+      const cancelled = session.graph({ signal: controller.signal });
+      await waitFor(() => readPids(root).length === 1, "first child start");
+      const firstPid = readPids(root)[0]!;
+      controller.abort({
+        toString(): string {
+          throw new Error("unprintable cancellation reason");
+        },
+      });
+      await assert.rejects(cancelled, /native snapshot request cancelled/);
+      await waitFor(() => !processIsAlive(firstPid), "cancelled child exit");
+      const graph = await session.graph();
+      assert.deepEqual(graph.nodes, []);
+      assert.equal(readPids(root).length, 2);
+    } finally {
+      session.close();
+    }
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_native_request_response_clears_watchdog.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_native_request_response_clears_watchdog.ts
@@ -1,0 +1,45 @@
+import {
+  createNativeSessionFixture,
+  delay,
+  pendingCount,
+  processIsAlive,
+  readPids,
+} from "../internal/nativeSession";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies a normal response clears its watchdog and ignores unknown IDs.
+ *
+ * A stale timer would kill a healthy resident compiler after a successful
+ * response. An unrelated response ID is also not authority to settle the live
+ * request, but must be harmless when the matching frame follows.
+ *
+ * 1. Make the fake emit an unknown response ID before its matching response.
+ * 2. Wait beyond the configured deadline after the successful graph call.
+ * 3. Assert the same child remains alive and answers a second call with no pending
+ *    leak.
+ */
+export const test_ttscgraph_native_request_response_clears_watchdog =
+  async () => {
+    const { root, session } = createNativeSessionFixture({
+      mode: "unknown-then-respond",
+      requestTimeoutMs: 500,
+    });
+    try {
+      const first = await session.graph();
+      assert.deepEqual(first.nodes, []);
+      const pid = readPids(root)[0]!;
+      await delay(750);
+      assert.equal(
+        processIsAlive(pid),
+        true,
+        "cleared timer keeps child alive",
+      );
+      const second = await session.graph();
+      assert.equal(second, first, "unchanged response reuses resident memory");
+      assert.equal(readPids(root).length, 1);
+      assert.equal(pendingCount(session), 0);
+    } finally {
+      session.close();
+    }
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_native_request_timeout_option_rejects_unsafe_values.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_native_request_timeout_option_rejects_unsafe_values.ts
@@ -1,0 +1,49 @@
+import { TtscGraphSession } from "@ttsc/graph";
+import { TestProject } from "@ttsc/testing";
+
+import { assert, resolveTtscgraphBinary } from "../internal/ttsgraph";
+
+/**
+ * Verifies the native request deadline rejects unsafe timer values.
+ *
+ * Node clamps oversized, fractional, and non-finite timers in surprising ways.
+ * Accepting those values would turn a configured safety boundary into an
+ * immediate timeout or an effectively different deadline.
+ *
+ * 1. Construct sessions at the zero, fractional, non-finite, and timer-overflow
+ *    boundaries.
+ * 2. Assert each is rejected before any child can spawn.
+ * 3. Construct the maximum valid integer timeout and close it without spawning.
+ */
+export const test_ttscgraph_native_request_timeout_option_rejects_unsafe_values =
+  () => {
+    const cwd = TestProject.tmpdir("ttscgraph-timeout-option-");
+    const binary = resolveTtscgraphBinary();
+    const construct = (requestTimeoutMs: number) =>
+      new TtscGraphSession({
+        cwd,
+        tsconfig: "tsconfig.json",
+        binary,
+        requestTimeoutMs,
+      });
+    for (const value of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      assert.throws(() => construct(value), /requestTimeoutMs/);
+    }
+    assert.throws(() => construct(2_147_483_648), /requestTimeoutMs/);
+    const maximum = construct(2_147_483_647);
+    maximum.close();
+    const defaults = new TtscGraphSession({
+      cwd,
+      tsconfig: "tsconfig.json",
+      binary,
+    });
+    assert.equal(
+      (
+        defaults as unknown as {
+          requestTimeoutMs: number;
+        }
+      ).requestTimeoutMs,
+      300_000,
+    );
+    defaults.close();
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_native_request_timeout_restarts_queued_call.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_native_request_timeout_restarts_queued_call.ts
@@ -1,0 +1,47 @@
+import {
+  createNativeSessionFixture,
+  pendingCount,
+  processIsAlive,
+  readPids,
+  waitFor,
+} from "../internal/nativeSession";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies a silent native request times out and the queued call restarts.
+ *
+ * A child that accepts stdin without answering used to hold the serialized
+ * graph queue forever. The timeout must retire that child, include its recent
+ * stderr, and leave the next queued call free to create a clean session.
+ *
+ * 1. Start a fake child that stalls only on its first process.
+ * 2. Queue two graph calls and assert the first times out with diagnostics.
+ * 3. Assert the first process dies, pending state clears, and the queued call
+ *    succeeds on a replacement.
+ */
+export const test_ttscgraph_native_request_timeout_restarts_queued_call =
+  async () => {
+    const { root, session } = createNativeSessionFixture({
+      mode: "hang-once",
+      requestTimeoutMs: 1_000,
+      stderr: "compiler fixture reached its deliberate stall",
+    });
+    try {
+      const first = session.graph();
+      const second = session.graph();
+      await assert.rejects(
+        first,
+        (error: Error) =>
+          /timed out after 1000 ms/.test(error.message) &&
+          /deliberate stall/.test(error.message),
+      );
+      await waitFor(() => readPids(root).length === 2, "replacement child");
+      const pids = readPids(root);
+      await waitFor(() => !processIsAlive(pids[0]!), "timed-out child exit");
+      const graph = await second;
+      assert.deepEqual(graph.nodes, []);
+      assert.equal(pendingCount(session), 0);
+    } finally {
+      session.close();
+    }
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_native_session_close_terminates_child_once.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_native_session_close_terminates_child_once.ts
@@ -1,0 +1,47 @@
+import {
+  createNativeSessionFixture,
+  pendingCount,
+  processIsAlive,
+  readPids,
+  waitFor,
+} from "../internal/nativeSession";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies closing a native session terminates outstanding work exactly once.
+ *
+ * Ending stdin alone is insufficient for a child that has stopped reading it.
+ * Close must reject active work, terminate the process, remain idempotent, and
+ * prevent any queued or later call from respawning an orphan.
+ *
+ * 1. Start a hanging graph request and count how often it settles.
+ * 2. Close twice and assert one rejection plus direct child termination.
+ * 3. Assert pending state is empty and calls after close cannot spawn again.
+ */
+export const test_ttscgraph_native_session_close_terminates_child_once =
+  async () => {
+    const { root, session } = createNativeSessionFixture({
+      mode: "hang",
+      requestTimeoutMs: 10_000,
+    });
+    let activeSettlements = 0;
+    let queuedSettlements = 0;
+    const active = session.graph().finally(() => {
+      activeSettlements++;
+    });
+    const queued = session.graph().finally(() => {
+      queuedSettlements++;
+    });
+    await waitFor(() => readPids(root).length === 1, "hanging child start");
+    const pid = readPids(root)[0]!;
+    session.close();
+    session.close();
+    await assert.rejects(active, /native session closed/);
+    await assert.rejects(queued, /native session is closed/);
+    await waitFor(() => !processIsAlive(pid), "closed child exit");
+    assert.equal(activeSettlements, 1);
+    assert.equal(queuedSettlements, 1);
+    assert.equal(pendingCount(session), 0);
+    await assert.rejects(session.graph(), /native session is closed/);
+    assert.equal(readPids(root).length, 1);
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_native_timeout_clears_resident_memory.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_native_timeout_clears_resident_memory.ts
@@ -1,0 +1,48 @@
+import {
+  createNativeSessionFixture,
+  processIsAlive,
+  readPids,
+  waitFor,
+} from "../internal/nativeSession";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies a timeout discards graph memory owned by the retired child.
+ *
+ * The resident model and native Program describe one process generation. A
+ * restart must not keep the old model available while the replacement session
+ * is establishing its own initial snapshot.
+ *
+ * 1. Let the first child answer once, then stall on its next request.
+ * 2. Assert the timeout kills that child and clears the private resident model.
+ * 3. Assert a replacement child publishes a new resident graph.
+ */
+export const test_ttscgraph_native_timeout_clears_resident_memory =
+  async () => {
+    const { root, session } = createNativeSessionFixture({
+      mode: "respond-then-hang",
+      requestTimeoutMs: 1_000,
+    });
+    try {
+      const initial = await session.graph();
+      await assert.rejects(session.graph(), /timed out after 1000 ms/);
+      const current = () =>
+        (
+          session as unknown as {
+            current: unknown;
+          }
+        ).current;
+      assert.equal(current(), undefined);
+      const firstPid = readPids(root)[0]!;
+      await waitFor(
+        () => !processIsAlive(firstPid),
+        "retired model owner exit",
+      );
+      const replacement = await session.graph();
+      assert.notEqual(replacement, initial);
+      assert.equal(current(), replacement);
+      assert.equal(readPids(root).length, 2);
+    } finally {
+      session.close();
+    }
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_queued_native_request_can_abort_before_start.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_queued_native_request_can_abort_before_start.ts
@@ -1,0 +1,48 @@
+import {
+  createNativeSessionFixture,
+  processIsAlive,
+  readPids,
+  waitFor,
+} from "../internal/nativeSession";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies a queued graph request can be cancelled before native work starts.
+ *
+ * Serialization must not turn cancellation into another wait behind the hung
+ * head request. A queued caller should reject promptly without disturbing the
+ * active child whose independent caller still owns it.
+ *
+ * 1. Hold the queue head in a hanging native request.
+ * 2. Queue a signalled second call, abort it, and assert prompt rejection.
+ * 3. Assert the first child remains alive until session close and no replacement
+ *    spawned.
+ */
+export const test_ttscgraph_queued_native_request_can_abort_before_start =
+  async () => {
+    const { root, session } = createNativeSessionFixture({
+      mode: "hang",
+      requestTimeoutMs: 10_000,
+    });
+    const first = session.graph();
+    try {
+      await waitFor(() => readPids(root).length === 1, "queue head child");
+      const pid = readPids(root)[0]!;
+      const controller = new AbortController();
+      const started = Date.now();
+      const queued = session.graph({ signal: controller.signal });
+      controller.abort();
+      await assert.rejects(queued, /native snapshot request cancelled/);
+      assert.ok(
+        Date.now() - started < 1_000,
+        "queued cancellation is immediate",
+      );
+      assert.equal(processIsAlive(pid), true);
+      assert.equal(readPids(root).length, 1);
+      session.close();
+      await assert.rejects(first, /native session closed/);
+    } finally {
+      session.close();
+      await first.catch(() => undefined);
+    }
+  };

--- a/tests/test-graph/src/internal/nativeSession.ts
+++ b/tests/test-graph/src/internal/nativeSession.ts
@@ -3,7 +3,7 @@ import { TestProject } from "@ttsc/testing";
 import fs from "node:fs";
 import path from "node:path";
 
-const DUMP_SCHEMA_VERSION = 3;
+const DUMP_SCHEMA_VERSION = 4;
 let fakeBinary: string | undefined;
 
 export interface NativeSessionFixture {

--- a/tests/test-graph/src/internal/nativeSession.ts
+++ b/tests/test-graph/src/internal/nativeSession.ts
@@ -1,0 +1,114 @@
+import { TtscGraphSession } from "@ttsc/graph";
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+
+const DUMP_SCHEMA_VERSION = 3;
+let fakeBinary: string | undefined;
+
+export interface NativeSessionFixture {
+  root: string;
+  session: TtscGraphSession;
+}
+
+export function createNativeSessionFixture(options: {
+  mode: string;
+  requestTimeoutMs: number;
+  stderr?: string;
+  delayMs?: number;
+}): NativeSessionFixture {
+  const root = TestProject.tmpdir("ttscgraph-native-session-");
+  fs.writeFileSync(
+    path.join(root, "native-session-fake.json"),
+    JSON.stringify({
+      mode: options.mode,
+      stderr: options.stderr ?? "",
+      delayMs: options.delayMs ?? 0,
+      schemaVersion: DUMP_SCHEMA_VERSION,
+    }),
+    "utf8",
+  );
+  return {
+    root,
+    session: new TtscGraphSession({
+      cwd: root,
+      tsconfig: "tsconfig.json",
+      binary: resolveNativeSessionFake(),
+      requestTimeoutMs: options.requestTimeoutMs,
+    }),
+  };
+}
+
+export function pendingCount(session: TtscGraphSession): number {
+  return (
+    session as unknown as {
+      pending: Map<number, unknown>;
+    }
+  ).pending.size;
+}
+
+export function readPids(root: string): number[] {
+  const file = path.join(root, "pids.log");
+  if (!fs.existsSync(file)) return [];
+  return fs
+    .readFileSync(file, "utf8")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(Number);
+}
+
+export function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+export async function waitFor(
+  predicate: () => boolean,
+  description: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+    await delay(20);
+  }
+}
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveNativeSessionFake(): string {
+  if (fakeBinary !== undefined) return fakeBinary;
+  const output = TestProject.tmpdir("ttscgraph-native-session-fake-");
+  const binary = path.join(
+    output,
+    process.platform === "win32"
+      ? "native-session-fake.exe"
+      : "native-session-fake",
+  );
+  const source = path.join(
+    TestProject.WORKSPACE_ROOT,
+    "tests",
+    "test-graph",
+    "src",
+    "internal",
+    "nativeSessionFake",
+    "main.go",
+  );
+  const result = TestProject.spawn("go", ["build", "-o", binary, source]);
+  if (result.status !== 0) {
+    throw new Error(
+      `failed to build native session fake (${String(result.status)})\n${result.stderr ?? ""}`,
+    );
+  }
+  fakeBinary = binary;
+  return binary;
+}

--- a/tests/test-graph/src/internal/nativeSessionFake/main.go
+++ b/tests/test-graph/src/internal/nativeSessionFake/main.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+  "bufio"
+  "encoding/json"
+  "errors"
+  "fmt"
+  "os"
+  "path/filepath"
+  "time"
+)
+
+type config struct {
+  Mode          string `json:"mode"`
+  Stderr        string `json:"stderr"`
+  DelayMs       int    `json:"delayMs"`
+  SchemaVersion int    `json:"schemaVersion"`
+}
+
+type request struct {
+  ID int `json:"id"`
+}
+
+func main() {
+  cwd := argument("--cwd")
+  raw, err := os.ReadFile(filepath.Join(cwd, "native-session-fake.json"))
+  if err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    os.Exit(2)
+  }
+  var cfg config
+  if err := json.Unmarshal(raw, &cfg); err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    os.Exit(2)
+  }
+  recordPID(cwd)
+
+  switch cfg.Mode {
+  case "hang":
+    hang(cfg)
+  case "hang-once":
+    if claimFirst(cwd) {
+      hang(cfg)
+    }
+  case "malformed-once":
+    if claimFirst(cwd) {
+      scanner := bufio.NewScanner(os.Stdin)
+      if scanner.Scan() {
+        fmt.Println("{not-json")
+        hangForever()
+      }
+      return
+    }
+  case "exit-once":
+    if claimFirst(cwd) {
+      os.Exit(17)
+    }
+  }
+  serve(cwd, cfg, cfg.Mode == "respond-then-hang" && claimFirst(cwd))
+}
+
+func argument(name string) string {
+  for i := 1; i+1 < len(os.Args); i++ {
+    if os.Args[i] == name {
+      return os.Args[i+1]
+    }
+  }
+  fmt.Fprintf(os.Stderr, "missing %s\n", name)
+  os.Exit(2)
+  return ""
+}
+
+func recordPID(cwd string) {
+  file, err := os.OpenFile(filepath.Join(cwd, "pids.log"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+  if err != nil {
+    fmt.Fprintln(os.Stderr, err)
+    os.Exit(2)
+  }
+  defer file.Close()
+  fmt.Fprintln(file, os.Getpid())
+}
+
+func claimFirst(cwd string) bool {
+  file, err := os.OpenFile(filepath.Join(cwd, "first.marker"), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+  if err == nil {
+    file.Close()
+    return true
+  }
+  if errors.Is(err, os.ErrExist) {
+    return false
+  }
+  fmt.Fprintln(os.Stderr, err)
+  os.Exit(2)
+  return false
+}
+
+func hang(cfg config) {
+  scanner := bufio.NewScanner(os.Stdin)
+  if !scanner.Scan() {
+    return
+  }
+  message := cfg.Stderr
+  if message == "" {
+    message = "fake native child accepted the request and stalled"
+  }
+  fmt.Fprintln(os.Stderr, message)
+  hangForever()
+}
+
+func hangForever() {
+  for {
+    time.Sleep(time.Hour)
+  }
+}
+
+func serve(cwd string, cfg config, stallAfterFirst bool) {
+  scanner := bufio.NewScanner(os.Stdin)
+  encoder := json.NewEncoder(os.Stdout)
+  initial := true
+  requests := 0
+  for scanner.Scan() {
+    var req request
+    if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+      fmt.Fprintln(os.Stderr, err)
+      os.Exit(3)
+    }
+    if cfg.DelayMs > 0 {
+      time.Sleep(time.Duration(cfg.DelayMs) * time.Millisecond)
+    }
+    if stallAfterFirst && requests == 1 {
+      message := cfg.Stderr
+      if message == "" {
+        message = "fake native child stalled after its first response"
+      }
+      fmt.Fprintln(os.Stderr, message)
+      hangForever()
+    }
+    if cfg.Mode == "unknown-then-respond" {
+      if err := encoder.Encode(response(req.ID+1000, false, cwd, cfg.SchemaVersion)); err != nil {
+        os.Exit(4)
+      }
+    }
+    if err := encoder.Encode(response(req.ID, initial, cwd, cfg.SchemaVersion)); err != nil {
+      os.Exit(4)
+    }
+    initial = false
+    requests++
+  }
+}
+
+func response(id int, changed bool, cwd string, schemaVersion int) map[string]any {
+  frame := map[string]any{
+    "id":              id,
+    "protocolVersion": 1,
+    "mode":            "unchanged",
+    "capabilities":    []string{},
+    "changed":         changed,
+  }
+  if !changed {
+    return frame
+  }
+  frame["mode"] = "initial"
+  frame["dump"] = map[string]any{
+    "project":     cwd,
+    "tsconfig":    "tsconfig.json",
+    "diagnostics": []any{},
+    "nodes":       []any{},
+    "edges":       []any{},
+    "provenance": map[string]any{
+      "schemaVersion": schemaVersion,
+      "capabilities":  []string{},
+      "producer": map[string]any{
+        "tool":       "native-session-fake",
+        "version":    "test",
+        "typescript": "test",
+      },
+      "universe": map[string]any{
+        "configs": []any{},
+        "roots":   []any{},
+      },
+      "sources": []any{},
+    },
+  }
+  return frame
+}

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -7,6 +7,8 @@ import TtscWebsiteGraphViewer3D from "../../../components/graph/TtscWebsiteGraph
 
 It runs `ttscgraph`, a native binary that keeps the type-checked project and resulting graph resident in memory. Before each graph operation it checks the config, root-file set, module-resolution inputs, and source contents. An unchanged project reuses the warm graph, a content-only edit updates the resident compiler incrementally, and config, file-addition, deletion, or resolution changes trigger a safe reload. Every relationship it reports is the current compiler's own answer, not a guess from reading text.
 
+Each native snapshot request has a five-minute deadline by default. This is more than ten times the 29-second cold index measured for the three-million-line VS Code fixture, so a valid cold compiler is not treated as stalled. A timeout terminates that native process, clears its pending request, and lets the next call start a fresh session. Programmatic users can set `requestTimeoutMs` on `TtscGraphSession`, or pass an `AbortSignal` to `session.graph({ signal })`; explicit cancellation follows the same clean-restart path.
+
 ## Why an agent needs it
 
 What the graph saves an agent, and what that looks like in tokens.


### PR DESCRIPTION
# Intent

Bound every native graph snapshot request and recover the resident session after timeout or cancellation, so one live-but-silent native child cannot block the MCP server forever.

Implements #763.

## Implementation

- Adds a configurable five-minute default request timeout and per-call `AbortSignal`.
- Gives every pending request one timer/listener owner and exactly-once settlement.
- Retires and terminates timed-out, cancelled, malformed, exited, or protocol-incompatible child generations.
- Clears resident memory on child failure and lets queued calls spawn a fresh generation.
- Makes `close()` idempotent and bounds retained stderr.
- Adds a compiled cross-platform fake child and lifecycle regressions for timeout, abort, exit, malformed frames, watchdog cleanup, queued recovery, memory reset, and close.

## Deterministic verification

- Lifecycle regressions: 9 targeted cases passed.
- Pre-rebase complete Graph suite: 28/28 passed; lifecycle stress: 10/10 passed.
- Post-rebase graph build and targeted lifecycle tests passed.
- Graph/test-graph/website typechecks, Go vet, Prettier, and diff checks passed on the implementation surface.
- `ITtscGraphApplication` and `TtscGraphApplication` remain byte-identical to master.

Paid AI benchmarks are intentionally omitted by repository-owner direction and are not a merge gate.