### PR TITLE
fix(graph): report trace existence and completeness truthfully

### DIFF
--- a/packages/graph/src/server/runTrace.ts
+++ b/packages/graph/src/server/runTrace.ts
@@ -151,12 +151,12 @@ export function runTrace(
       focus,
       includeExternal,
     );
+    const hasPath = found !== null;
     const path = found?.path ?? [];
     const hops = found?.hops ?? [];
-    const junctions =
-      hops.length > 0
-        ? []
-        : junctionsBetween(graph, start.node.id, target.node.id, focus);
+    const junctions = hasPath
+      ? []
+      : junctionsBetween(graph, start.node.id, target.node.id, focus);
     return {
       result: {
         ...base,
@@ -167,28 +167,29 @@ export function runTrace(
         steps: traceSteps(graph, hops),
         ...(junctions.length > 0 ? { junctions } : {}),
       },
-      // An empty path is a fact, not an answer, and the old message called it
+      // A missing path is a fact, not an answer, and the old message called it
       // one: "its path nodes and evidence ranges are what the graph holds
-      // between the two ends" — of a result that held nothing. The two ends do
-      // not call each other, which in an event-driven codebase is the common
+      // between the two ends" — of a result that held nothing. `findPath` uses
+      // null for that state; zero hops is instead the valid path
+      // from a node to itself. Distinct nodes without a path do not call each
+      // other, which in an event-driven codebase is the common
       // case: a pointer handler emits, an emitter's `emit()` runs listeners a
       // registration put in an array, and no call edge crosses that array. The
       // callers of the target are the way across, and the graph has them, so
       // say which call to make instead of handing back an empty result dressed
       // as the answer. Excalidraw's tour spent eleven calls finding this out.
-      next:
-        hops.length > 0
-          ? pathNext
-          : junctions.length > 0
-            ? resultNext(
-                "inspect",
-                "No call path runs between the two ends — a callback stands between them (an event emitter, a subscription, a lifecycle hook), and no call edge crosses one. `junctions` names the symbols both ends touch, which is the seam: trace the junction to see who registers on it and who fires it.",
-                "trace",
-              )
-            : resultNext(
-                "outside",
-                "No call path runs from the start to the target and they touch nothing in common, so the graph holds no connection between them.",
-              ),
+      next: hasPath
+        ? pathNext
+        : junctions.length > 0
+          ? resultNext(
+              "inspect",
+              "No call path runs between the two ends — a callback stands between them (an event emitter, a subscription, a lifecycle hook), and no call edge crosses one. `junctions` names the symbols both ends touch, which is the seam: trace the junction to see who registers on it and who fires it.",
+              "trace",
+            )
+          : resultNext(
+              "outside",
+              "No call path runs from the start to the target and they touch nothing in common, so the graph holds no connection between them.",
+            ),
     };
   }
 
@@ -203,24 +204,22 @@ export function runTrace(
   while (queue.length > 0) {
     const next: Array<{ id: string; depth: number }> = [];
     for (const { id, depth } of queue) {
-      if (depth >= maxDepth) {
-        truncated = true;
-        continue;
-      }
-      const edges = orderedEdges(
+      const edges = eligibleTraceEdges(
         graph,
-        reverse
-          ? graph.incoming(id)
-          : [...graph.outgoing(id), ...dispatchEdges(graph, id, focus)],
+        id,
         direction,
         reverse,
+        focus,
+        includeExternal,
       );
-      for (const edge of edges) {
-        if (!traversable(edge.kind, focus)) continue;
-        const otherId = reverse ? edge.from : edge.to;
-        const other = graph.node(otherId);
-        if (other === undefined || other.kind === "file") continue;
-        if (!includeExternal && isExternalNode(other)) continue;
+      if (depth >= maxDepth) {
+        // Reaching the configured boundary does not itself omit data. The
+        // response is truncated only when the selected walk has another hop
+        // (and, for an unseen endpoint, another node) beyond the boundary.
+        if (edges.length > 0) truncated = true;
+        continue;
+      }
+      for (const { edge, otherId, other } of edges) {
         const hop: ITtscGraphTrace.IHop = {
           from: edge.from,
           to: edge.to,
@@ -270,6 +269,46 @@ export function runTrace(
       "Steps, hops, reached nodes, and evidence ranges are the flow the graph holds from this start.",
     ),
   };
+}
+
+interface IEligibleTraceEdge {
+  edge: ITtscGraphEdge;
+  otherId: string;
+  other: ITtscGraphNode;
+}
+
+/**
+ * Edges the selected open trace would represent if no result bound stopped it.
+ * The depth-boundary probe and traversal must share this policy so focus,
+ * external nodes, file nodes, dispatch, and direction cannot disagree about
+ * whether content was actually omitted.
+ */
+function eligibleTraceEdges(
+  graph: TtscGraphMemory,
+  id: string,
+  direction: string,
+  reverse: boolean,
+  focus: ITtscGraphTrace.IRequest["focus"],
+  includeExternal: boolean,
+): IEligibleTraceEdge[] {
+  const edges = orderedEdges(
+    graph,
+    reverse
+      ? graph.incoming(id)
+      : [...graph.outgoing(id), ...dispatchEdges(graph, id, focus)],
+    direction,
+    reverse,
+  );
+  const eligible: IEligibleTraceEdge[] = [];
+  for (const edge of edges) {
+    if (!traversable(edge.kind, focus)) continue;
+    const otherId = reverse ? edge.from : edge.to;
+    const other = graph.node(otherId);
+    if (other === undefined || other.kind === "file") continue;
+    if (!includeExternal && isExternalNode(other)) continue;
+    eligible.push({ edge, otherId, other });
+  }
+  return eligible;
 }
 
 function traceSteps(

--- a/packages/graph/src/server/runTrace.ts
+++ b/packages/graph/src/server/runTrace.ts
@@ -204,22 +204,37 @@ export function runTrace(
   while (queue.length > 0) {
     const next: Array<{ id: string; depth: number }> = [];
     for (const { id, depth } of queue) {
-      const edges = eligibleTraceEdges(
-        graph,
-        id,
-        direction,
-        reverse,
-        focus,
-        includeExternal,
-      );
+      const candidates = traceEdges(graph, id, reverse, focus);
       if (depth >= maxDepth) {
         // Reaching the configured boundary does not itself omit data. The
         // response is truncated only when the selected walk has another hop
         // (and, for an unseen endpoint, another node) beyond the boundary.
-        if (edges.length > 0) truncated = true;
+        if (
+          candidates.some(
+            (edge) =>
+              eligibleTraceEndpoint(
+                graph,
+                edge,
+                reverse,
+                focus,
+                includeExternal,
+              ) !== undefined,
+          )
+        )
+          truncated = true;
         continue;
       }
-      for (const { edge, otherId, other } of edges) {
+      const edges = orderedEdges(graph, candidates, direction, reverse);
+      for (const edge of edges) {
+        const endpoint = eligibleTraceEndpoint(
+          graph,
+          edge,
+          reverse,
+          focus,
+          includeExternal,
+        );
+        if (endpoint === undefined) continue;
+        const { otherId, other } = endpoint;
         const hop: ITtscGraphTrace.IHop = {
           from: edge.from,
           to: edge.to,
@@ -271,44 +286,41 @@ export function runTrace(
   };
 }
 
-interface IEligibleTraceEdge {
-  edge: ITtscGraphEdge;
+interface ITraceEndpoint {
   otherId: string;
   other: ITtscGraphNode;
 }
 
-/**
- * Edges the selected open trace would represent if no result bound stopped it.
- * The depth-boundary probe and traversal must share this policy so focus,
- * external nodes, file nodes, dispatch, and direction cannot disagree about
- * whether content was actually omitted.
- */
-function eligibleTraceEdges(
+/** Candidate edges in the selected direction before focus and node policy. */
+function traceEdges(
   graph: TtscGraphMemory,
   id: string,
-  direction: string,
+  reverse: boolean,
+  focus: ITtscGraphTrace.IRequest["focus"],
+): readonly ITtscGraphEdge[] {
+  return reverse
+    ? graph.incoming(id)
+    : [...graph.outgoing(id), ...dispatchEdges(graph, id, focus)];
+}
+
+/**
+ * The endpoint the selected open trace would represent if no result bound
+ * stopped it. The depth probe and traversal share this decision so focus,
+ * external nodes, file nodes, and direction cannot disagree about omission.
+ */
+function eligibleTraceEndpoint(
+  graph: TtscGraphMemory,
+  edge: ITtscGraphEdge,
   reverse: boolean,
   focus: ITtscGraphTrace.IRequest["focus"],
   includeExternal: boolean,
-): IEligibleTraceEdge[] {
-  const edges = orderedEdges(
-    graph,
-    reverse
-      ? graph.incoming(id)
-      : [...graph.outgoing(id), ...dispatchEdges(graph, id, focus)],
-    direction,
-    reverse,
-  );
-  const eligible: IEligibleTraceEdge[] = [];
-  for (const edge of edges) {
-    if (!traversable(edge.kind, focus)) continue;
-    const otherId = reverse ? edge.from : edge.to;
-    const other = graph.node(otherId);
-    if (other === undefined || other.kind === "file") continue;
-    if (!includeExternal && isExternalNode(other)) continue;
-    eligible.push({ edge, otherId, other });
-  }
-  return eligible;
+): ITraceEndpoint | undefined {
+  if (!traversable(edge.kind, focus)) return undefined;
+  const otherId = reverse ? edge.from : edge.to;
+  const other = graph.node(otherId);
+  if (other === undefined || other.kind === "file") return undefined;
+  if (!includeExternal && isExternalNode(other)) return undefined;
+  return { otherId, other };
 }
 
 function traceSteps(

--- a/packages/graph/src/structures/ITtscGraphTrace.ts
+++ b/packages/graph/src/structures/ITtscGraphTrace.ts
@@ -17,7 +17,7 @@ export interface ITtscGraphTrace {
   /** Unique nodes reached (excluding the start), each with its depth and roles. */
   reached: ITtscGraphTrace.INode[];
 
-  /** True when the trace hit its node or depth cap; the returned flow stands. */
+  /** In an open trace, true when a bound omitted an eligible node or hop. */
   truncated: boolean;
 
   /** The resolved `to` target, when a path was requested. */

--- a/tests/test-graph/src/features/test_ttscgraph_trace_reports_only_actual_omissions.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_trace_reports_only_actual_omissions.ts
@@ -1,0 +1,369 @@
+import { TestProject } from "@ttsc/testing";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  structuredContent?: {
+    next?: { action?: string };
+    result?: TraceResult;
+  };
+}
+
+interface TraceResult {
+  type: "trace";
+  hops: { from: string; to: string; kind: string }[];
+  reached: { id: string; name: string }[];
+  truncated: boolean;
+  path?: { id: string; name: string }[];
+  steps?: string[];
+  junctions?: unknown[];
+  candidates?: { id: string; name: string }[];
+}
+
+const graphArguments = (request: Record<string, unknown>) => ({
+  question: "Which represented flow does this trace prove?",
+  draft: {
+    reason: "Trace is the smallest graph operation for this flow boundary.",
+    type: "trace",
+  },
+  review: "Confirmed: keep the trace and answer from its graph facts.",
+  request,
+});
+
+/**
+ * Verifies graph traces report success and truncation from represented facts,
+ * not merely from a zero hop count or reaching a configured depth boundary.
+ *
+ * A self path has no hops by definition, while an open trace at `maxDepth` can
+ * be complete when its boundary is a leaf or has only policy-filtered edges.
+ * Conversely, a back/cross edge to an already represented node is still omitted
+ * content when its hop is absent. This case locks those distinctions together
+ * with the independent node and hop caps, because all of them feed the same
+ * `next` and `truncated` completeness contract used by graph callers.
+ *
+ * 1. Materialize leaf, chain, filtered, cyclic, cross-edge, cap, identity, and
+ *    ambiguous-handle shapes in one resident compiler graph.
+ * 2. Trace each shape through the real MCP launcher in forward, reverse, impact,
+ *    execution, all-edge, external-excluded, and external-included modes.
+ * 3. Assert success for zero-hop identity paths and truncation only when an
+ *    otherwise eligible node or hop is actually absent from the response.
+ */
+export const test_ttscgraph_trace_reports_only_actual_omissions = async () => {
+  const root = TestProject.createProject({
+    "tsconfig.json": JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          moduleResolution: "node",
+          strict: true,
+          rootDir: "src",
+          outDir: "dist",
+        },
+        include: ["src"],
+      },
+      null,
+      2,
+    ),
+    "node_modules/trace-dependency/package.json": JSON.stringify({
+      name: "trace-dependency",
+      version: "1.0.0",
+      types: "index.d.ts",
+    }),
+    "node_modules/trace-dependency/index.d.ts":
+      "export declare function externalWork(): void;\n",
+    "src/app.ts": [
+      'import { externalWork } from "trace-dependency";',
+      "",
+      "export function shared(): void {}",
+      "export function identity(): void { shared(); }",
+      "export function disconnected(): void {}",
+      "",
+      "export function leaf(): void {}",
+      "export function leafStart(): void { leaf(); }",
+      "",
+      "export function chainTail(): void {}",
+      "export function chainMiddle(): void { chainTail(); }",
+      "export function chainStart(): void { chainMiddle(); }",
+      "",
+      "export function reverseRoot(): void { reverseMiddle(); }",
+      "export function reverseMiddle(): void { reverseLeaf(); }",
+      "export function reverseLeaf(): void {}",
+      "",
+      "export type TypeOnly = { value: number };",
+      "export function typeBoundary(_value: TypeOnly): void {}",
+      "export function typeStart(): void { typeBoundary({ value: 1 }); }",
+      "",
+      "export function externalBoundary(): void { externalWork(); }",
+      "export function externalStart(): void { externalBoundary(); }",
+      "",
+      "export function cycleA(): void { cycleB(); }",
+      "export function cycleB(): void { cycleA(); }",
+      "",
+      "export function crossStart(): void { crossLeft(); crossRight(); }",
+      "export function crossLeft(): void { crossRight(); }",
+      "export function crossRight(): void {}",
+      "",
+      "export function exactNode(): void {}",
+      "export function exactNodeStart(): void { exactNode(); }",
+      "export function overflowNodeA(): void {}",
+      "export function overflowNodeB(): void {}",
+      "export function overflowNodeStart(): void { overflowNodeA(); overflowNodeB(); }",
+      "",
+      "export function exactHopStart(): void { exactHopA(); exactHopB(); }",
+      "export function exactHopA(): void { exactHopB(); exactHopStart(); }",
+      "export function exactHopB(): void {}",
+      "",
+      "export function overflowHopStart(): void { overflowHopA(); overflowHopB(); }",
+      "export function overflowHopA(): void { overflowHopB(); overflowHopStart(); }",
+      "export function overflowHopB(): void { overflowHopA(); }",
+      "",
+      "export namespace First { export function duplicate(): void {} }",
+      "export namespace Second { export function duplicate(): void {} }",
+      "",
+    ].join("\n"),
+  });
+
+  const client = TtsgraphClient.start(root);
+  try {
+    await client.request("initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "test-graph", version: "0.0.0" },
+    });
+    client.notify("notifications/initialized", {});
+
+    const call = async (
+      request: Record<string, unknown>,
+    ): Promise<NonNullable<ToolResult["structuredContent"]>> => {
+      const response = (await client.request("tools/call", {
+        name: "inspect_typescript_graph",
+        arguments: graphArguments({ type: "trace", ...request }),
+      })) as ToolResult;
+      assert.equal(
+        response.structuredContent?.result?.type,
+        "trace",
+        `expected a trace result: ${JSON.stringify(response)}`,
+      );
+      return response.structuredContent!;
+    };
+
+    const identity = await call({ from: "identity", to: "identity" });
+    assert.deepEqual(
+      identity.result!.path?.map((node) => node.name),
+      ["identity"],
+      "a self trace returns its one-node identity path",
+    );
+    assert.deepEqual(identity.result!.hops, [], "a self path has zero hops");
+    assert.deepEqual(identity.result!.steps, [], "a self path has zero steps");
+    assert.equal(
+      identity.result!.junctions,
+      undefined,
+      "a found self path does not search for junctions",
+    );
+    assert.equal(
+      identity.next?.action,
+      "answer",
+      "zero-hop path existence, not hop count, selects the next action",
+    );
+
+    const disconnected = await call({
+      from: "identity",
+      to: "disconnected",
+      focus: "execution",
+    });
+    assert.equal(
+      disconnected.next?.action,
+      "outside",
+      "distinct disconnected nodes preserve the no-path result",
+    );
+
+    const ambiguousStart = await call({ from: "duplicate", to: "duplicate" });
+    assert.ok(
+      (ambiguousStart.result!.candidates?.length ?? 0) >= 2,
+      "an ambiguous start still returns candidates",
+    );
+    assert.equal(ambiguousStart.next?.action, "clarify");
+    const ambiguousTarget = await call({ from: "identity", to: "duplicate" });
+    assert.ok(
+      (ambiguousTarget.result!.candidates?.length ?? 0) >= 2,
+      "an ambiguous target still returns candidates",
+    );
+    assert.equal(ambiguousTarget.next?.action, "inspect");
+
+    for (const request of [
+      { from: "leafStart", direction: "forward" },
+      { from: "leaf", direction: "reverse" },
+      { from: "leaf", direction: "impact" },
+    ]) {
+      const complete = await call({
+        ...request,
+        focus: "execution",
+        maxDepth: 1,
+        maxNodes: 8,
+      });
+      assert.equal(
+        complete.result!.truncated,
+        false,
+        `${request.direction} leaf at maxDepth is complete`,
+      );
+    }
+
+    for (const request of [
+      { from: "chainStart", direction: "forward" },
+      { from: "reverseLeaf", direction: "reverse" },
+      { from: "reverseLeaf", direction: "impact" },
+    ]) {
+      const omitted = await call({
+        ...request,
+        focus: "execution",
+        maxDepth: 1,
+        maxNodes: 8,
+      });
+      assert.equal(
+        omitted.result!.truncated,
+        true,
+        `${request.direction} eligible continuation beyond maxDepth is omitted`,
+      );
+    }
+
+    const focusFiltered = await call({
+      from: "typeStart",
+      direction: "forward",
+      focus: "execution",
+      maxDepth: 1,
+      maxNodes: 8,
+    });
+    assert.equal(
+      focusFiltered.result!.truncated,
+      false,
+      "a type-only boundary edge filtered from execution focus is not omitted",
+    );
+    const focusEligible = await call({
+      from: "typeStart",
+      direction: "forward",
+      focus: "all",
+      maxDepth: 1,
+      maxNodes: 8,
+    });
+    assert.equal(
+      focusEligible.result!.truncated,
+      true,
+      "the same boundary edge truncates when the selected focus includes it",
+    );
+
+    const externalFiltered = await call({
+      from: "externalStart",
+      direction: "forward",
+      focus: "execution",
+      includeExternal: false,
+      maxDepth: 1,
+      maxNodes: 8,
+    });
+    assert.equal(
+      externalFiltered.result!.truncated,
+      false,
+      "an excluded external boundary is intentional filtering",
+    );
+    const externalEligible = await call({
+      from: "externalStart",
+      direction: "forward",
+      focus: "execution",
+      includeExternal: true,
+      maxDepth: 1,
+      maxNodes: 8,
+    });
+    assert.equal(
+      externalEligible.result!.truncated,
+      true,
+      "the same external boundary truncates when externals are eligible",
+    );
+
+    const cycleOmitted = await call({
+      from: "cycleA",
+      focus: "execution",
+      maxDepth: 1,
+      maxNodes: 8,
+    });
+    assert.equal(
+      cycleOmitted.result!.truncated,
+      true,
+      "an omitted back-edge hop is content even when its node is represented",
+    );
+    const cycleRepresented = await call({
+      from: "cycleA",
+      focus: "execution",
+      maxDepth: 2,
+      maxNodes: 8,
+    });
+    assert.equal(cycleRepresented.result!.hops.length, 2);
+    assert.equal(
+      cycleRepresented.result!.truncated,
+      false,
+      "a represented cycle has no omitted continuation",
+    );
+
+    const crossOmitted = await call({
+      from: "crossStart",
+      focus: "execution",
+      maxDepth: 1,
+      maxNodes: 8,
+    });
+    assert.equal(
+      crossOmitted.result!.truncated,
+      true,
+      "an omitted cross-edge hop is content even when both nodes are represented",
+    );
+    const crossRepresented = await call({
+      from: "crossStart",
+      focus: "execution",
+      maxDepth: 2,
+      maxNodes: 8,
+    });
+    assert.equal(crossRepresented.result!.hops.length, 3);
+    assert.equal(crossRepresented.result!.truncated, false);
+
+    const exactNodes = await call({
+      from: "exactNodeStart",
+      focus: "execution",
+      maxDepth: 3,
+      maxNodes: 1,
+    });
+    assert.equal(exactNodes.result!.reached.length, 1);
+    assert.equal(exactNodes.result!.truncated, false);
+    const omittedNode = await call({
+      from: "overflowNodeStart",
+      focus: "execution",
+      maxDepth: 3,
+      maxNodes: 1,
+    });
+    assert.equal(omittedNode.result!.reached.length, 1);
+    assert.equal(omittedNode.result!.truncated, true);
+
+    const exactHops = await call({
+      from: "exactHopStart",
+      focus: "execution",
+      maxDepth: 3,
+      maxNodes: 2,
+    });
+    assert.equal(exactHops.result!.hops.length, 4);
+    assert.equal(exactHops.result!.truncated, false);
+    const omittedHop = await call({
+      from: "overflowHopStart",
+      focus: "execution",
+      maxDepth: 3,
+      maxNodes: 2,
+    });
+    assert.equal(omittedHop.result!.hops.length, 4);
+    assert.equal(omittedHop.result!.truncated, true);
+  } finally {
+    client.endStdin();
+  }
+
+  const code = await client.waitForExit();
+  assert.equal(
+    code,
+    0,
+    `the launcher exits cleanly\nstderr: ${client.stderrText()}`,
+  );
+};

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -47,6 +47,8 @@ The graph answers the questions an agent actually asks, all from the same checke
 
 When a handle names several declarations, the graph scores every match by export surface and graph use before it caps the response. Equal scores use the declaration's stable graph id, so compiler visitation order cannot hide a stronger match or reshuffle a tie.
 
+In path mode, tracing a symbol to itself is a complete one-node path with no hops. In an open trace, `truncated` means an eligible node or relationship was left out by the depth, node, or hop bound. Reaching the configured depth on a leaf, or seeing only relationships excluded by the selected focus or external-node policy, remains complete.
+
 A tree-sitter graph has no types and resolves edges by guessing from text. An editor's language server has types but no architecture projection. Only a graph built on the real checker holds the resolved structure and the affected set in one place. Every node and edge is resolved by the compiler, so an agent never mistakes inference for fact.
 
 ### What only the compiler can resolve


### PR DESCRIPTION
# Intent

Make trace results distinguish path existence from hop count and report truncation only when an eligible open-trace fact was actually omitted.

Implements #758 and #762.

## Implementation

- A self trace is a valid one-node, zero-hop path and returns `answer` without fabricated junctions.
- Open-trace depth boundaries inspect the same direction, focus, external, file-node, and dispatch eligibility as traversal before setting `truncated`.
- Node/hop omission behavior remains intact.
- The public `truncated` JSDoc is explicitly scoped to open trace mode.
- A real MCP regression matrix covers self/direct/disconnected paths, forward/reverse/impact boundaries, focus/external filtering, cycles/cross edges, and exact/overflow node/hop limits.

## Deterministic verification

- Complete combined Graph suite after #759 and #763: 36/36 passed.
- Graph build/viewer passed.
- Graph, test-graph, and website typechecks passed.
- Prettier and `git diff --check` passed on the implementation.
- Protected Application files remain byte-identical to master.
- Solo review findings on boundary allocation and JSDoc scope were recorded and resolved.

Paid AI benchmarks are intentionally omitted by repository-owner direction and are not a merge gate.