### PR TITLE
fix(graph): preserve filenames in legacy absolute reroots

### DIFF
--- a/experimental/benchmark/graph/viewer.mjs
+++ b/experimental/benchmark/graph/viewer.mjs
@@ -29,14 +29,22 @@ const PUBLIC_GRAPH_DIR = path.join(REPO_ROOT, "website", "public", "graph");
 // Pure transform
 // ---------------------------------------------------------------------------
 
-/** Longest shared directory prefix of POSIX-normalized paths. */
-function commonRoot(files) {
-  if (files.length === 0) return "";
-  let parts = posix(files[0]).split("/");
-  for (const file of files.slice(1)) {
-    const other = posix(file).split("/");
+/** Longest shared prefix of POSIX-normalized directories. */
+function commonRoot(directories) {
+  if (directories.length === 0) return "";
+  let parts = posix(directories[0]).split("/");
+  const caseInsensitive = directories.every(isWindowsPath);
+  for (const directory of directories.slice(1)) {
+    const other = posix(directory).split("/");
     let i = 0;
-    while (i < parts.length && i < other.length && parts[i] === other[i]) i++;
+    while (
+      i < parts.length &&
+      i < other.length &&
+      (caseInsensitive
+        ? parts[i].toLowerCase() === other[i].toLowerCase()
+        : parts[i] === other[i])
+    )
+      i++;
     parts = parts.slice(0, i);
     if (parts.length === 0) break;
   }
@@ -52,18 +60,39 @@ function isAbsolute(p) {
   return /^(?:[A-Za-z]:)?\//.test(posix(p));
 }
 
+function isWindowsPath(p) {
+  const normalized = posix(p);
+  return /^[A-Za-z]:(?:\/|$)/.test(normalized) || normalized.startsWith("//");
+}
+
+function directoryOf(file) {
+  const normalized = posix(file).replace(/\/+$/, "");
+  const slash = normalized.lastIndexOf("/");
+  if (slash < 0) return "";
+  return slash === 0 ? "/" : normalized.slice(0, slash);
+}
+
 /**
  * Make an absolute path project-relative; a path outside the project keeps the
  * portion from its last node_modules/ segment, or its base name, so nothing
- * leaks an absolute machine path. An empty root means the dump's paths are
+ * leaks an absolute machine path. A null root means the dump's paths are
  * already project-relative (the current `ttscgraph dump` contract), so they
  * pass through with their directory structure intact.
  */
 function relativize(abs, root) {
   const a = posix(abs);
-  const r = posix(root).replace(/\/+$/, "");
-  if (!r) return a;
-  if (a === r || a.startsWith(r + "/"))
+  if (root === null) return a;
+  const normalizedRoot = posix(root);
+  const r = normalizedRoot === "/" ? "/" : normalizedRoot.replace(/\/+$/, "");
+  const caseInsensitive = isWindowsPath(a) && isWindowsPath(r);
+  const comparedPath = caseInsensitive ? a.toLowerCase() : a;
+  const comparedRoot = caseInsensitive ? r.toLowerCase() : r;
+  if (
+    comparedRoot &&
+    (comparedRoot === "/" ||
+      comparedPath === comparedRoot ||
+      comparedPath.startsWith(comparedRoot + "/"))
+  )
     return a.slice(r.length).replace(/^\/+/, "");
   const nm = a.lastIndexOf("node_modules/");
   if (nm >= 0) return a.slice(nm);
@@ -124,8 +153,8 @@ export function reduce(
     .map((n) => n.file);
   const root =
     projectFiles.length > 0 && isAbsolute(projectFiles[0])
-      ? commonRoot(projectFiles)
-      : "";
+      ? commonRoot(projectFiles.map(directoryOf))
+      : null;
 
   const liveIds = new Set(keptBoundary.map((n) => n.id));
   const liveEdges = raw.edges.filter(

--- a/experimental/benchmark/graph/viewer.mjs
+++ b/experimental/benchmark/graph/viewer.mjs
@@ -55,7 +55,7 @@ function posix(p) {
   return p.replace(/\\/g, "/");
 }
 
-/** An absolute path (POSIX or Windows drive); relative dumps skip rerooting. */
+/** Absolute POSIX, Windows drive, or UNC path; relative dumps skip rerooting. */
 function isAbsolute(p) {
   return /^(?:[A-Za-z]:)?\//.test(posix(p));
 }

--- a/packages/graph/src/reduce.ts
+++ b/packages/graph/src/reduce.ts
@@ -55,7 +55,7 @@ function posix(p: string): string {
   return p.replace(/\\/g, "/");
 }
 
-/** An absolute path (POSIX or Windows drive); relative dumps skip rerooting. */
+/** Absolute POSIX, Windows drive, or UNC path; relative dumps skip rerooting. */
 function isAbsolute(p: string): boolean {
   return /^(?:[A-Za-z]:)?\//.test(posix(p));
 }

--- a/packages/graph/src/reduce.ts
+++ b/packages/graph/src/reduce.ts
@@ -60,26 +60,55 @@ function isAbsolute(p: string): boolean {
   return /^(?:[A-Za-z]:)?\//.test(posix(p));
 }
 
-function commonRoot(files: string[]): string {
-  if (files.length === 0) return "";
-  let parts = posix(files[0]!).split("/");
-  for (const file of files.slice(1)) {
-    const other = posix(file).split("/");
+function isWindowsPath(p: string): boolean {
+  const normalized = posix(p);
+  return /^[A-Za-z]:(?:\/|$)/.test(normalized) || normalized.startsWith("//");
+}
+
+function directoryOf(file: string): string {
+  const normalized = posix(file).replace(/\/+$/, "");
+  const slash = normalized.lastIndexOf("/");
+  if (slash < 0) return "";
+  return slash === 0 ? "/" : normalized.slice(0, slash);
+}
+
+function commonRoot(directories: string[]): string {
+  if (directories.length === 0) return "";
+  let parts = posix(directories[0]!).split("/");
+  const caseInsensitive = directories.every(isWindowsPath);
+  for (const directory of directories.slice(1)) {
+    const other = posix(directory).split("/");
     let i = 0;
-    while (i < parts.length && i < other.length && parts[i] === other[i]) i++;
+    while (
+      i < parts.length &&
+      i < other.length &&
+      (caseInsensitive
+        ? parts[i]!.toLowerCase() === other[i]!.toLowerCase()
+        : parts[i] === other[i])
+    )
+      i++;
     parts = parts.slice(0, i);
     if (parts.length === 0) break;
   }
   return parts.join("/");
 }
 
-// An empty root means the dump's paths are already project-relative (the
-// current `ttscgraph dump` contract); they pass through structure-intact.
-function relativize(abs: string, root: string): string {
+// A null root means the dump's paths are already project-relative (the current
+// `ttscgraph dump` contract); they pass through structure-intact.
+function relativize(abs: string, root: string | null): string {
   const a = posix(abs);
-  const r = posix(root).replace(/\/+$/, "");
-  if (!r) return a;
-  if (a === r || a.startsWith(r + "/"))
+  if (root === null) return a;
+  const normalizedRoot = posix(root);
+  const r = normalizedRoot === "/" ? "/" : normalizedRoot.replace(/\/+$/, "");
+  const caseInsensitive = isWindowsPath(a) && isWindowsPath(r);
+  const comparedPath = caseInsensitive ? a.toLowerCase() : a;
+  const comparedRoot = caseInsensitive ? r.toLowerCase() : r;
+  if (
+    comparedRoot &&
+    (comparedRoot === "/" ||
+      comparedPath === comparedRoot ||
+      comparedPath.startsWith(comparedRoot + "/"))
+  )
     return a.slice(r.length).replace(/^\/+/, "");
   const nm = a.lastIndexOf("node_modules/");
   if (nm >= 0) return a.slice(nm);
@@ -87,7 +116,7 @@ function relativize(abs: string, root: string): string {
   return slash >= 0 ? a.slice(slash + 1) : a;
 }
 
-function rewriteId(id: string, root: string): string {
+function rewriteId(id: string, root: string | null): string {
   const hash = id.indexOf("#");
   if (hash < 0) return id;
   return relativize(id.slice(0, hash), root) + id.slice(hash);
@@ -139,8 +168,8 @@ export function reduce(
   const projectFiles = raw.nodes.filter((n) => !n.external).map((n) => n.file);
   const root =
     projectFiles.length > 0 && isAbsolute(projectFiles[0]!)
-      ? commonRoot(projectFiles)
-      : "";
+      ? commonRoot(projectFiles.map(directoryOf))
+      : null;
 
   const liveIds = new Set(keptByExternal.map((n) => n.id));
   const liveEdges = raw.edges.filter(

--- a/tests/test-graph/src/features/test_ttscgraph_viewer_reducers_preserve_legacy_absolute_filenames.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_viewer_reducers_preserve_legacy_absolute_filenames.ts
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+interface RawNode {
+  id: string;
+  name: string;
+  kind: string;
+  file: string;
+  external?: boolean;
+  ignored?: boolean;
+}
+
+interface RawDump {
+  project: string;
+  nodes: RawNode[];
+  edges: { from: string; to: string; kind: string }[];
+}
+
+interface ViewerPayload {
+  counts: {
+    nodes: number;
+    links: number;
+    droppedIgnored?: number;
+  };
+  nodes: { id: string; file: string }[];
+}
+
+type Reduce = (raw: RawDump) => ViewerPayload;
+
+const loadReducer = async (
+  relativePath: string,
+  exported: "named" | "default",
+): Promise<Reduce> => {
+  const repository = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../..",
+  );
+  const module = (await import(
+    pathToFileURL(path.join(repository, relativePath)).href
+  )) as {
+    reduce?: Reduce;
+    default?: { reduce?: Reduce };
+  };
+  const reduce = exported === "named" ? module.reduce : module.default?.reduce;
+  if (typeof reduce !== "function")
+    assert.fail(`${relativePath} exports reduce()`);
+  return reduce;
+};
+
+const createDump = (files: readonly string[]): RawDump => {
+  const nodes = files.map((file, index) => ({
+    id: `${file}#symbol${index}:function`,
+    name: `symbol${index}`,
+    kind: "function",
+    file,
+  }));
+  return {
+    project: "fixture",
+    nodes,
+    edges: nodes.map((node, index) => ({
+      from: node.id,
+      to: nodes[(index + 1) % nodes.length]!.id,
+      kind: "calls",
+    })),
+  };
+};
+
+const assertProjection = (
+  reduce: Reduce,
+  files: readonly string[],
+  expectedFiles: readonly string[],
+  label: string,
+): void => {
+  const result = reduce(createDump(files));
+  assert.deepEqual(
+    result.nodes.map((node) => node.file),
+    expectedFiles,
+    `${label}: file projection`,
+  );
+  assert.deepEqual(
+    result.nodes.map((node) => node.id.slice(0, node.id.indexOf("#"))),
+    expectedFiles,
+    `${label}: id projection`,
+  );
+};
+
+/**
+ * Verifies graph viewer reducers: legacy absolute paths retain source
+ * filenames.
+ *
+ * Locks the legacy reroot boundary shared by the package, website, and fixture
+ * reducers. The root must be a source directory rather than a complete file;
+ * Windows paths compare case-insensitively, POSIX paths remain case-sensitive,
+ * and current project-relative dumps must bypass rerooting entirely.
+ *
+ * 1. Load all three production reducer copies through Node's TypeScript loader.
+ * 2. Exercise single-file, repeated-file, nested, POSIX, drive, and UNC paths.
+ * 3. Assert IDs and files retain basenames while package/website filters differ.
+ */
+export const test_ttscgraph_viewer_reducers_preserve_legacy_absolute_filenames =
+  async (): Promise<void> => {
+    const reducers = [
+      {
+        name: "package",
+        reduce: await loadReducer("packages/graph/src/reduce.ts", "named"),
+      },
+      {
+        name: "website",
+        reduce: await loadReducer(
+          "website/src/components/graph/TtscWebsiteGraphReduce.ts",
+          "default",
+        ),
+      },
+      {
+        name: "fixture",
+        reduce: await loadReducer(
+          "experimental/benchmark/graph/viewer.mjs",
+          "named",
+        ),
+      },
+    ];
+
+    const cases = [
+      {
+        name: "single POSIX file with a self-edge",
+        files: ["/work/src/only.ts"],
+        expected: ["only.ts"],
+      },
+      {
+        name: "repeated nodes in one POSIX file",
+        files: ["/work/src/only.ts", "/work/src/only.ts"],
+        expected: ["only.ts", "only.ts"],
+      },
+      {
+        name: "multiple POSIX files",
+        files: ["/work/src/alpha.ts", "/work/src/beta.ts"],
+        expected: ["alpha.ts", "beta.ts"],
+      },
+      {
+        name: "nested POSIX files",
+        files: ["/work/src/alpha.ts", "/work/src/nested/beta.ts"],
+        expected: ["alpha.ts", "nested/beta.ts"],
+      },
+      {
+        name: "case-insensitive Windows drive",
+        files: ["C:\\Work\\src\\alpha.ts", "c:\\work\\SRC\\nested\\beta.ts"],
+        expected: ["alpha.ts", "nested/beta.ts"],
+      },
+      {
+        name: "case-insensitive Windows UNC share",
+        files: [
+          "\\\\Server\\Share\\Work\\src\\alpha.ts",
+          "\\\\server\\share\\work\\SRC\\nested\\beta.ts",
+        ],
+        expected: ["alpha.ts", "nested/beta.ts"],
+      },
+      {
+        name: "case-sensitive unrelated POSIX roots",
+        files: ["/work/src/alpha.ts", "/Work/src/nested/beta.ts"],
+        expected: ["alpha.ts", "beta.ts"],
+      },
+      {
+        name: "current project-relative paths",
+        files: ["src/alpha.ts", "src/nested/beta.ts"],
+        expected: ["src/alpha.ts", "src/nested/beta.ts"],
+      },
+    ] as const;
+
+    for (const reducer of reducers)
+      for (const scenario of cases)
+        assertProjection(
+          reducer.reduce,
+          scenario.files,
+          scenario.expected,
+          `${reducer.name}/${scenario.name}`,
+        );
+
+    const authored = "/work/src/authored.ts";
+    const generated = "/work/generated/client.ts";
+    const policyDump: RawDump = {
+      project: "policy",
+      nodes: [
+        {
+          id: `${authored}#authored:function`,
+          name: "authored",
+          kind: "function",
+          file: authored,
+        },
+        {
+          id: `${generated}#generated:function`,
+          name: "generated",
+          kind: "function",
+          file: generated,
+          ignored: true,
+        },
+      ],
+      edges: [
+        {
+          from: `${authored}#authored:function`,
+          to: `${authored}#authored:function`,
+          kind: "calls",
+        },
+        {
+          from: `${authored}#authored:function`,
+          to: `${generated}#generated:function`,
+          kind: "calls",
+        },
+      ],
+    };
+
+    const packageResult = reducers[0]!.reduce(policyDump);
+    const websiteResult = reducers[1]!.reduce(policyDump);
+    assert.deepEqual(
+      [packageResult.counts.nodes, packageResult.counts.links],
+      [2, 2],
+      "package reducer keeps ignored nodes by design",
+    );
+    assert.deepEqual(
+      [
+        websiteResult.counts.nodes,
+        websiteResult.counts.links,
+        websiteResult.counts.droppedIgnored,
+      ],
+      [1, 1, 1],
+      "website reducer drops ignored nodes by design",
+    );
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_viewer_reducers_preserve_legacy_absolute_filenames.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_viewer_reducers_preserve_legacy_absolute_filenames.ts
@@ -86,8 +86,7 @@ const assertProjection = (
 };
 
 /**
- * Verifies graph viewer reducers: legacy absolute paths retain source
- * filenames.
+ * Verifies graph viewer reducers: legacy paths retain filenames.
  *
  * Locks the legacy reroot boundary shared by the package, website, and fixture
  * reducers. The root must be a source directory rather than a complete file;
@@ -128,6 +127,11 @@ export const test_ttscgraph_viewer_reducers_preserve_legacy_absolute_filenames =
         expected: ["only.ts"],
       },
       {
+        name: "POSIX filesystem-root file",
+        files: ["/only.ts"],
+        expected: ["only.ts"],
+      },
+      {
         name: "repeated nodes in one POSIX file",
         files: ["/work/src/only.ts", "/work/src/only.ts"],
         expected: ["only.ts", "only.ts"],
@@ -146,6 +150,11 @@ export const test_ttscgraph_viewer_reducers_preserve_legacy_absolute_filenames =
         name: "case-insensitive Windows drive",
         files: ["C:\\Work\\src\\alpha.ts", "c:\\work\\SRC\\nested\\beta.ts"],
         expected: ["alpha.ts", "nested/beta.ts"],
+      },
+      {
+        name: "case-insensitive Windows drive root",
+        files: ["C:\\alpha.ts", "c:\\beta.ts"],
+        expected: ["alpha.ts", "beta.ts"],
       },
       {
         name: "case-insensitive Windows UNC share",

--- a/website/src/components/graph/TtscWebsiteGraphReduce.ts
+++ b/website/src/components/graph/TtscWebsiteGraphReduce.ts
@@ -14,7 +14,7 @@ function posix(p: string): string {
   return p.replace(/\\/g, "/");
 }
 
-/** An absolute path (POSIX or Windows drive); relative dumps skip rerooting. */
+/** Absolute POSIX, Windows drive, or UNC path; relative dumps skip rerooting. */
 function isAbsolute(p: string): boolean {
   return /^(?:[A-Za-z]:)?\//.test(posix(p));
 }

--- a/website/src/components/graph/TtscWebsiteGraphReduce.ts
+++ b/website/src/components/graph/TtscWebsiteGraphReduce.ts
@@ -19,14 +19,34 @@ function isAbsolute(p: string): boolean {
   return /^(?:[A-Za-z]:)?\//.test(posix(p));
 }
 
-/** Longest shared directory prefix of POSIX-normalized paths. */
-function commonRoot(files: string[]): string {
-  if (files.length === 0) return "";
-  let parts = posix(files[0]!).split("/");
-  for (const file of files.slice(1)) {
-    const other = posix(file).split("/");
+function isWindowsPath(p: string): boolean {
+  const normalized = posix(p);
+  return /^[A-Za-z]:(?:\/|$)/.test(normalized) || normalized.startsWith("//");
+}
+
+function directoryOf(file: string): string {
+  const normalized = posix(file).replace(/\/+$/, "");
+  const slash = normalized.lastIndexOf("/");
+  if (slash < 0) return "";
+  return slash === 0 ? "/" : normalized.slice(0, slash);
+}
+
+/** Longest shared prefix of POSIX-normalized directories. */
+function commonRoot(directories: string[]): string {
+  if (directories.length === 0) return "";
+  let parts = posix(directories[0]!).split("/");
+  const caseInsensitive = directories.every(isWindowsPath);
+  for (const directory of directories.slice(1)) {
+    const other = posix(directory).split("/");
     let i = 0;
-    while (i < parts.length && i < other.length && parts[i] === other[i]) i++;
+    while (
+      i < parts.length &&
+      i < other.length &&
+      (caseInsensitive
+        ? parts[i]!.toLowerCase() === other[i]!.toLowerCase()
+        : parts[i] === other[i])
+    )
+      i++;
     parts = parts.slice(0, i);
     if (parts.length === 0) break;
   }
@@ -35,15 +55,24 @@ function commonRoot(files: string[]): string {
 
 /**
  * Make an absolute path project-relative; a path outside the project keeps the
- * portion from its last node_modules/ segment, or its base name. An empty root
+ * portion from its last node_modules/ segment, or its base name. A null root
  * means the dump's paths are already project-relative (the current `ttscgraph
  * dump` contract), so they pass through with their structure intact.
  */
-function relativize(abs: string, root: string): string {
+function relativize(abs: string, root: string | null): string {
   const a = posix(abs);
-  const r = posix(root).replace(/\/+$/, "");
-  if (!r) return a;
-  if (a === r || a.startsWith(r + "/"))
+  if (root === null) return a;
+  const normalizedRoot = posix(root);
+  const r = normalizedRoot === "/" ? "/" : normalizedRoot.replace(/\/+$/, "");
+  const caseInsensitive = isWindowsPath(a) && isWindowsPath(r);
+  const comparedPath = caseInsensitive ? a.toLowerCase() : a;
+  const comparedRoot = caseInsensitive ? r.toLowerCase() : r;
+  if (
+    comparedRoot &&
+    (comparedRoot === "/" ||
+      comparedPath === comparedRoot ||
+      comparedPath.startsWith(comparedRoot + "/"))
+  )
     return a.slice(r.length).replace(/^\/+/, "");
   const nm = a.lastIndexOf("node_modules/");
   if (nm >= 0) return a.slice(nm);
@@ -55,7 +84,7 @@ function relativize(abs: string, root: string): string {
  * A node id is `<path>#<name>:<kind>`; rewrite only the path prefix so ids stay
  * a stable key and every edge endpoint (also an id) relativizes identically.
  */
-function rewriteId(id: string, root: string): string {
+function rewriteId(id: string, root: string | null): string {
   const hash = id.indexOf("#");
   if (hash < 0) return id;
   return relativize(id.slice(0, hash), root) + id.slice(hash);
@@ -119,8 +148,8 @@ function reduce(
     .map((n) => n.file);
   const root =
     projectFiles.length > 0 && isAbsolute(projectFiles[0]!)
-      ? commonRoot(projectFiles)
-      : "";
+      ? commonRoot(projectFiles.map(directoryOf))
+      : null;
 
   const liveIds = new Set(keptBoundary.map((n) => n.id));
   const liveEdges = raw.edges.filter(

--- a/website/src/content/docs/graph/viewer.mdx
+++ b/website/src/content/docs/graph/viewer.mdx
@@ -36,7 +36,7 @@ npx @ttsc/graph dump --tsconfig tsconfig.json > graph.json
 
 `dump` prints the whole graph as JSON: every node and edge the build resolved, with none of the per-response caps the MCP tool applies. It is the same export the MCP server loads at startup, so what you dump is exactly what the agent queries.
 
-That file is what "Load your own JSON" above accepts. The viewer reduces it client-side before rendering (the exact reduction is in [What is left out](#what-is-left-out)) so a large project stays legible. It also takes an already-reduced payload, so a graph you trimmed yourself loads as-is.
+That file is what "Load your own JSON" above accepts. The viewer reduces it client-side before rendering (the exact reduction is in [What is left out](#what-is-left-out)) so a large project stays legible. Current dumps keep their project-relative file structure; legacy dumps that contain absolute paths are rerooted at their shared source directory. The viewer also takes an already-reduced payload, so a graph you trimmed yourself loads as-is.
 
 ## Reading the graph
 


### PR DESCRIPTION
## Intent

Preserve source filenames when graph viewers reroot legacy absolute-path dumps, without changing current project-relative dump behavior.

Closes #761.

## Scope

- Correct legacy absolute-path projection in the package, website, and benchmark-fixture reducers.
- Cover single, repeated, nested, POSIX, Windows drive, and UNC paths while preserving each reducer's ignored-node policy.
- Keep current relative dumps unchanged.
- Keep ITtscGraphApplication and TtscGraphApplication untouched.

## Verification

- Full Graph end-to-end suite: 37/37.
- @ttsc/graph build and viewer bundle.
- graph, test-graph, and website TypeScript checks.
- git diff check and protected-file diff zero.

No paid AI/model benchmark was run or used as a merge gate, by owner direction.