### PR TITLE
fix(graph): keep detail members on the compiler snapshot

### DIFF
--- a/packages/graph/src/model/TtscGraphMemory.ts
+++ b/packages/graph/src/model/TtscGraphMemory.ts
@@ -4,16 +4,18 @@ import { ITtscGraphEvidence } from "../structures/ITtscGraphEvidence";
 import { ITtscGraphNode } from "../structures/ITtscGraphNode";
 import { ITtscGraphSpan } from "../structures/ITtscGraphSpan";
 import { TtscGraphEdgeKind } from "../structures/TtscGraphEdgeKind";
+import { TtscGraphSourceReader } from "./TtscGraphSourceReader";
 
 /**
  * The in-memory resident graph the MCP tools answer from.
  *
  * It loads one `ttscgraph dump` — the checker-resolved fact graph — then
  * synthesizes the structural relationships the dump deliberately leaves to this
- * layer: `file` container nodes, the `contains` ownership tree, and `exports`
- * edges, plus class/interface member implementation edges and the refinement of
- * a class-member `variable` to a `property`. Every tool call is then a lookup
- * or a traversal over the indexes built here; nothing recompiles.
+ * layer: `file` container nodes and the `contains` ownership tree, plus the
+ * refinement of a class-member `variable` to a `property`. Export and member
+ * implementation relationships are checker facts already present in the dump.
+ * Every tool call is then a lookup or traversal over the indexes built here;
+ * nothing recompiles.
  */
 export class TtscGraphMemory {
   private readonly byId: Map<string, ITtscGraphNode>;
@@ -26,17 +28,21 @@ export class TtscGraphMemory {
   readonly project: string;
   /** Every node, raw plus synthesized (file containers). */
   readonly nodes: readonly ITtscGraphNode[];
-  /** Every edge, raw plus synthesized (contains, exports). */
+  /** Every edge, raw plus synthesized containment. */
   readonly edges: readonly ITtscGraphEdge[];
+  /** Provenance-gated source display facts cached for this exact snapshot. */
+  readonly source: TtscGraphSourceReader;
 
   private constructor(
     project: string,
     nodes: ITtscGraphNode[],
     edges: ITtscGraphEdge[],
+    provenance: ITtscGraphDump.IProvenance,
   ) {
     this.project = project;
     this.nodes = nodes;
     this.edges = edges;
+    this.source = new TtscGraphSourceReader(project, provenance);
 
     this.byId = new Map(nodes.map((n) => [n.id, n]));
     this.byNameIndex = new Map();
@@ -63,7 +69,7 @@ export class TtscGraphMemory {
   /** Build a model from a parsed dump, synthesizing structural relationships. */
   static from(dump: ITtscGraphDump): TtscGraphMemory {
     const { nodes, edges } = synthesize(dump);
-    return new TtscGraphMemory(dump.project, nodes, edges);
+    return new TtscGraphMemory(dump.project, nodes, edges, dump.provenance);
   }
 
   /** The node with this id, or undefined. */
@@ -149,8 +155,8 @@ function basename(file: string): string {
 
 /**
  * Derive the structural layer from a dump's faithful facts: refine class-member
- * variables to properties, add a `file` node per workspace source, and connect
- * the `contains` ownership tree and `exports` surface.
+ * variables to properties, add a `file` node per workspace source, connect the
+ * `contains` ownership tree, and re-anchor compiler-owned `exports` edges.
  */
 function synthesize(dump: ITtscGraphDump): {
   nodes: ITtscGraphNode[];

--- a/packages/graph/src/model/TtscGraphSourceReader.ts
+++ b/packages/graph/src/model/TtscGraphSourceReader.ts
@@ -1,0 +1,83 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { type ITtscGraphDump } from "../structures/ITtscGraphDump";
+
+type ReadFile = (file: string) => Buffer;
+
+/**
+ * Immutable, provenance-gated source lines owned by one graph snapshot.
+ *
+ * Signatures and declaration docs are display facts derived from source text,
+ * but the live disk is not the snapshot the checker resolved. A file becomes
+ * readable here only after its current bytes hash to the snapshot's
+ * `checkerDigest`. Both success and failure are cached, so every consumer of a
+ * `TtscGraphMemory` sees one adjudication and one immutable line array.
+ */
+export class TtscGraphSourceReader {
+  private readonly project: string;
+  private readonly checkerDigests: ReadonlyMap<string, string>;
+  private readonly read: ReadFile;
+  private readonly cache = new Map<string, readonly string[] | undefined>();
+
+  constructor(
+    project: string,
+    provenance:
+      | Pick<ITtscGraphDump.IProvenance, "capabilities" | "sources">
+      | undefined,
+    read: ReadFile = (file) => fs.readFileSync(file),
+  ) {
+    this.project = project;
+    this.read = read;
+    this.checkerDigests = new Map(
+      provenance?.capabilities.includes("sourceDigests") === true
+        ? provenance.sources.map((source) => [
+            normalize(source.file),
+            source.checkerDigest,
+          ])
+        : [],
+    );
+  }
+
+  /**
+   * Return frozen lines only when the bytes still equal the checker snapshot. A
+   * missing manifest entry, read failure, or digest mismatch is a cached
+   * absence rather than a reason to mix current disk text into old graph
+   * facts.
+   */
+  lines(file: string): readonly string[] | undefined {
+    const key = normalize(file);
+    if (this.cache.has(key)) return this.cache.get(key);
+
+    const expected = this.checkerDigests.get(key);
+    if (expected === undefined || expected === "") {
+      this.cache.set(key, undefined);
+      return undefined;
+    }
+
+    let text: string;
+    try {
+      text = this.read(path.resolve(this.project, file)).toString("utf8");
+    } catch {
+      this.cache.set(key, undefined);
+      return undefined;
+    }
+    if (sha256(text) !== expected) {
+      this.cache.set(key, undefined);
+      return undefined;
+    }
+
+    const lines: readonly string[] = Object.freeze(text.split(/\r?\n/));
+    this.cache.set(key, lines);
+    return lines;
+  }
+}
+
+function normalize(file: string): string {
+  return file.replace(/\\/g, "/");
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}

--- a/packages/graph/src/model/loadGraph.ts
+++ b/packages/graph/src/model/loadGraph.ts
@@ -20,11 +20,11 @@ const MAX_DUMP_BYTES = 1024 * 1024 * 1024;
  * constant out of this file and fails if the pair drifts.
  *
  * Exported because the resident session reads the same dump body over the serve
- * protocol and has to hold it to the same number: the envelope's version and the
- * body's are independent, so a producer can speak this protocol and still send a
- * body from another schema.
+ * protocol and has to hold it to the same number: the envelope's version and
+ * the body's are independent, so a producer can speak this protocol and still
+ * send a body from another schema.
  */
-export const DUMP_SCHEMA_VERSION = 4;
+export const DUMP_SCHEMA_VERSION = 5;
 
 /**
  * Build the resident {@link TtscGraphMemory} for a project by running `ttscgraph

--- a/packages/graph/src/server/runDetails.ts
+++ b/packages/graph/src/server/runDetails.ts
@@ -1,6 +1,3 @@
-import fs from "node:fs";
-import path from "node:path";
-
 import { TtscGraphMemory } from "../model/TtscGraphMemory";
 import { ITtscGraphDecorator } from "../structures/ITtscGraphDecorator";
 import { ITtscGraphDetails } from "../structures/ITtscGraphDetails";
@@ -15,9 +12,6 @@ import { IRunnerOutput, resultNext } from "./resultNext";
 const MAX_SIGNATURE_LINES = 4;
 // A doc summary is one sentence; the rest of the comment is the file's to keep.
 const MAX_DOC_CHARS = 200;
-// An object literal's outline is scanned from source, so a runaway literal is
-// bounded here; the members it does find are not capped.
-const MAX_OBJECT_MEMBER_LINES = 300;
 // A symbol's fan-out — what it calls, what names it in a type, what depends on
 // it — scales with how popular it is, not with the symbol: a central type is
 // named in a thousand places, and returning all of them is a hundred thousand
@@ -57,7 +51,11 @@ export function runDetails(
   // does not: what names or uses a symbol is bounded by its popularity, not by
   // it, so those stay a small slice with `trace` for the rest.
   const memberLimit = limitOf(props.memberLimit);
-  const neighborLimit = capOf(props.neighborLimit, DEFAULT_NEIGHBORS, MAX_NEIGHBORS);
+  const neighborLimit = capOf(
+    props.neighborLimit,
+    DEFAULT_NEIGHBORS,
+    MAX_NEIGHBORS,
+  );
   const dependencyLimit = capOf(
     props.dependencyLimit,
     DEFAULT_DEPENDENCIES,
@@ -100,9 +98,9 @@ export function runDetails(
       file: node.file,
     };
     if (node.evidence?.startLine) detail.line = node.evidence.startLine;
-    const sig = signatureOf(graph.project, node);
+    const sig = signatureOf(graph, node);
     if (sig !== undefined) detail.signature = sig;
-    const doc = docOf(graph.project, node);
+    const doc = docOf(graph, node);
     if (doc !== undefined) detail.doc = doc;
     const decorators = decoratorsOf(node);
     if (decorators !== undefined) detail.decorators = decorators;
@@ -144,12 +142,8 @@ export function runDetails(
       const list = members(graph, node, memberLimit);
       if (list.length > 0) detail.members = list;
     }
-    if (node.kind === "variable" && detail.sourceSpan !== undefined) {
-      const list = objectLiteralMembers(
-        graph.project,
-        detail.sourceSpan,
-        memberLimit,
-      );
+    if (node.kind === "variable") {
+      const list = objectLiteralMembers(node, memberLimit);
       if (list.length > 0) detail.members = list;
     }
     // An enum's members ride on its own node rather than on `contains` edges,
@@ -224,7 +218,7 @@ function members(
       kind: member.kind,
     };
     if (member.evidence?.startLine) m.line = member.evidence.startLine;
-    const sig = signatureOf(graph.project, member);
+    const sig = signatureOf(graph, member);
     if (sig !== undefined) m.signature = sig;
     const decorators = decoratorsOf(member);
     if (decorators !== undefined) m.decorators = decorators;
@@ -257,83 +251,15 @@ function enumMembers(
 }
 
 function objectLiteralMembers(
-  project: string,
-  span: Pick<ITtscGraphEvidence, "file" | "startLine" | "endLine">,
+  node: ITtscGraphNode,
   limit: number,
 ): ITtscGraphDetails.IMember[] {
-  if (span.endLine === undefined) return [];
-  if (span.endLine - span.startLine > MAX_OBJECT_MEMBER_LINES) return [];
-  const lines = fileLines(project, span.file);
-  if (lines === undefined) return [];
-  const start = Math.max(0, span.startLine - 1);
-  const end = Math.min(lines.length - 1, span.endLine - 1);
-  const members: ITtscGraphDetails.IMember[] = [];
-  let depth = 0;
-  let entered = false;
-  for (let i = start; i <= end; i++) {
-    const raw = lines[i] ?? "";
-    const text = stripStrings(raw);
-    const before = depth;
-    if (entered && before === 1) {
-      const member = objectMemberOf(raw, i + 1);
-      if (member !== undefined) {
-        members.push(member);
-        if (members.length >= limit) break;
-      }
-    }
-    for (const char of text) {
-      if (char === "{") {
-        depth++;
-        entered = true;
-      } else if (char === "}") {
-        depth = Math.max(0, depth - 1);
-      }
-    }
-  }
-  return members;
-}
-
-function objectMemberOf(
-  line: string,
-  lineNumber: number,
-): ITtscGraphDetails.IMember | undefined {
-  const text = line.trim();
-  if (
-    text === "" ||
-    text.startsWith("//") ||
-    text.startsWith("/*") ||
-    text.startsWith("*")
-  ) {
-    return undefined;
-  }
-  const property = /^(['"]?)([A-Za-z_$][\w$-]*)\1\s*\??\s*:/.exec(text);
-  if (property !== null) {
-    return {
-      name: property[2]!,
-      kind: "property",
-      line: lineNumber,
-      signature: signatureLine(text),
-    };
-  }
-  const method =
-    /^(?:async\s+)?(?:get\s+|set\s+)?([A-Za-z_$][\w$-]*)\s*\(/.exec(text);
-  if (method !== null) {
-    return {
-      name: method[1]!,
-      kind: "method",
-      line: lineNumber,
-      signature: signatureLine(text),
-    };
-  }
-  return undefined;
-}
-
-function signatureLine(text: string): string {
-  return text.replace(/\s+/g, " ").replace(/,$/, "");
-}
-
-function stripStrings(line: string): string {
-  return line.replace(/\/\/.*$/, "").replace(/(['"`])(?:\\.|(?!\1).)*\1/g, "");
+  return (node.objectMembers ?? []).slice(0, limit).map((member) => ({
+    name: member.name,
+    kind: member.kind,
+    ...(member.line !== undefined ? { line: member.line } : {}),
+    ...(member.signature !== undefined ? { signature: member.signature } : {}),
+  }));
 }
 
 /** Map dependency edges to references on their far endpoint, dropping structure. */
@@ -461,8 +387,8 @@ function rankedRefs(
 
 /**
  * An identity list's cap: none by default, honored when a caller passes one.
- * details answers a named handle's own shape in full — its members, its values —
- * so the default is unlimited; the tour passes an explicit number to embed a
+ * details answers a named handle's own shape in full — its members, its values
+ * — so the default is unlimited; the tour passes an explicit number to embed a
  * compact slice of its own.
  */
 function limitOf(value: number | undefined): number {
@@ -476,7 +402,11 @@ function limitOf(value: number | undefined): number {
  * uses a symbol grows with its popularity, not with the symbol, so the whole
  * list is a trace/impact answer and details returns an orientation slice.
  */
-function capOf(value: number | undefined, fallback: number, max: number): number {
+function capOf(
+  value: number | undefined,
+  fallback: number,
+  max: number,
+): number {
   const n = value === undefined || !Number.isFinite(value) ? fallback : value;
   return Math.max(1, Math.min(max, Math.floor(n)));
 }
@@ -564,16 +494,6 @@ function evidenceCoordinatesOf(
   };
 }
 
-/** Read a file's lines once, or undefined when it cannot be read. */
-function fileLines(project: string, file: string): string[] | undefined {
-  if (file === "") return undefined;
-  try {
-    return fs.readFileSync(path.join(project, file), "utf8").split(/\r?\n/);
-  } catch {
-    return undefined;
-  }
-}
-
 /**
  * What the declaration says it is: the first sentence of the doc comment
  * written above it.
@@ -587,12 +507,12 @@ function fileLines(project: string, file: string): string[] | undefined {
  * symbol with what it is for is doing an index's job.
  */
 export function docOf(
-  project: string,
+  graph: TtscGraphMemory,
   node: ITtscGraphNode,
 ): string | undefined {
   const evidence = node.evidence;
   const lines =
-    evidence === undefined ? undefined : fileLines(project, evidence.file);
+    evidence === undefined ? undefined : graph.source.lines(evidence.file);
   if (lines === undefined || evidence === undefined) return undefined;
   let index = evidence.startLine - 2;
   while (index >= 0 && (lines[index] ?? "").trim() === "") index--;
@@ -638,12 +558,12 @@ export function docOf(
  * the node.
  */
 export function signatureOf(
-  project: string,
+  graph: TtscGraphMemory,
   node: ITtscGraphNode,
 ): string | undefined {
   const evidence = node.evidence;
   const lines =
-    evidence === undefined ? undefined : fileLines(project, evidence.file);
+    evidence === undefined ? undefined : graph.source.lines(evidence.file);
   if (lines === undefined || evidence === undefined) return undefined;
   const start = Math.max(0, evidence.startLine - 1);
   const last =

--- a/packages/graph/src/server/runEntrypoints.ts
+++ b/packages/graph/src/server/runEntrypoints.ts
@@ -118,7 +118,7 @@ function nodeOf(
   };
   if (node.evidence?.startLine !== undefined)
     out.line = node.evidence.startLine;
-  const signature = signatureOf(graph.project, node);
+  const signature = signatureOf(graph, node);
   if (signature !== undefined) out.signature = signature;
   const decorators = decoratorsOf(node);
   if (decorators !== undefined) out.decorators = decorators;

--- a/packages/graph/src/server/runLookup.ts
+++ b/packages/graph/src/server/runLookup.ts
@@ -88,7 +88,7 @@ export function runLookup(
   for (const hit of hits) {
     const node = graph.node(hit.id);
     if (node === undefined) continue;
-    const sig = signatureOf(graph.project, node);
+    const sig = signatureOf(graph, node);
     if (sig !== undefined) hit.signature = sig;
   }
   return {

--- a/packages/graph/src/server/runTour.ts
+++ b/packages/graph/src/server/runTour.ts
@@ -354,8 +354,8 @@ function graphNodeOf(
   node: ITtscGraphNode,
 ): ITtscGraphTour.INode {
   const span = node.implementation ?? node.evidence;
-  const signature = signatureOf(graph.project, node);
-  const doc = docOf(graph.project, node);
+  const signature = signatureOf(graph, node);
+  const doc = docOf(graph, node);
   const decorators = decoratorsOf(node);
   return {
     id: node.id,

--- a/packages/graph/src/server/runTrace.ts
+++ b/packages/graph/src/server/runTrace.ts
@@ -595,7 +595,7 @@ function summary(
   }
   if (depth !== undefined) out.depth = depth;
   if (withSignature) {
-    const sig = signatureOf(graph.project, node);
+    const sig = signatureOf(graph, node);
     if (sig !== undefined) out.signature = sig;
   }
   if (withRoles) {

--- a/packages/graph/src/structures/ITtscGraphNode.ts
+++ b/packages/graph/src/structures/ITtscGraphNode.ts
@@ -90,6 +90,17 @@ export interface ITtscGraphNode {
   enumMembers?: ITtscGraphNode.IEnumMember[];
 
   /**
+   * Direct, statically named members when this variable is initialized with an
+   * object literal, in declaration order.
+   *
+   * The native builder takes identity from the compiler AST and renders the
+   * compact signature from the same Program-owned source snapshot. A spread or
+   * dynamic computed name has no declaration name it can report soundly, so it
+   * contributes no fabricated member.
+   */
+  objectMembers?: ITtscGraphNode.IObjectMember[];
+
+  /**
    * Decorators written on this declaration, in source order: raw facts
    * (`@Controller`, `@Get`) a consumer interprets without re-parsing source.
    */
@@ -116,5 +127,20 @@ export namespace ITtscGraphNode {
      * still stands.
      */
     value?: string;
+  }
+
+  /** One direct, statically named member of an object-literal variable. */
+  export interface IObjectMember {
+    /** The source-visible static property name. */
+    name: string;
+
+    /** Whether the declaration is a data property or callable/accessor member. */
+    kind: "property" | "method";
+
+    /** 1-based declaration line in the node's file, when source was available. */
+    line?: number;
+
+    /** Compact declaration outline rendered from the compiler source snapshot. */
+    signature?: string;
   }
 }

--- a/packages/ttsc/internal/graph/build.go
+++ b/packages/ttsc/internal/graph/build.go
@@ -114,6 +114,7 @@ func collectVariables(g *Graph, path string, statement *shimast.Node) {
   }
   for _, binding := range list.Declarations.Nodes {
     addNode(g, path, binding, NodeVariable)
+    g.collectObjectMembers(path, binding)
     collectClosures(g, path, binding)
   }
 }

--- a/packages/ttsc/internal/graph/dump.go
+++ b/packages/ttsc/internal/graph/dump.go
@@ -465,9 +465,9 @@ func (c *dumpContext) evidence(file string, pos, end int) *DumpEvidence {
   return ev
 }
 
-// objectMemberSignature reproduces the compact one-line outline details has
-// historically returned, but slices it from Program-owned text while the dump
-// is built instead of reopening the live file later.
+// objectMemberSignature reproduces the compact outline details has historically
+// returned, but slices it from Program-owned text while the dump is built
+// instead of reopening the live file later.
 func (c *dumpContext) objectMemberSignature(file string, member ObjectMember) string {
   pos, end := member.Pos, member.SignatureEnd
   if pos < 0 || end <= pos || c.sources == nil {
@@ -488,21 +488,151 @@ func (c *dumpContext) objectMemberSignature(file string, member ObjectMember) st
   if pos >= end {
     return ""
   }
-  if !member.SignatureBoundary {
-    if lineEnd := strings.IndexByte(text[pos:end], '\n'); lineEnd >= 0 {
-      end = pos + lineEnd
-    }
-  }
   if pos >= end {
     return ""
   }
-  signature := strings.TrimSuffix(strings.Join(strings.Fields(text[pos:end]), " "), ",")
+  signature := strings.TrimSuffix(compactObjectMemberSignature(text[pos:end]), ",")
   const maxObjectMemberSignatureRunes = 160
   runes := []rune(signature)
   if len(runes) > maxObjectMemberSignatureRunes {
     signature = string(runes[:maxObjectMemberSignatureRunes-3]) + "..."
   }
   return signature
+}
+
+// compactObjectMemberSignature collapses trivia outside lexical values while
+// leaving quoted strings, template literals, regular expressions, and comments
+// byte-for-byte intact. A display outline may be compact, but changing literal
+// whitespace would change the declaration it claims to quote.
+func compactObjectMemberSignature(text string) string {
+  var out strings.Builder
+  pendingSpace := false
+  for i := 0; i < len(text); {
+    if isSignatureWhitespace(text[i]) {
+      pendingSpace = out.Len() > 0
+      i++
+      continue
+    }
+    if pendingSpace {
+      out.WriteByte(' ')
+      pendingSpace = false
+    }
+
+    end := i + 1
+    switch text[i] {
+    case '\'', '"':
+      end = quotedSourceEnd(text, i, text[i])
+    case '`':
+      end = templateSourceEnd(text, i)
+    case '/':
+      switch {
+      case i+1 < len(text) && text[i+1] == '/':
+        end = lineCommentEnd(text, i)
+      case i+1 < len(text) && text[i+1] == '*':
+        end = blockCommentEnd(text, i)
+      default:
+        if candidate := regularExpressionEnd(text, i); candidate > i {
+          end = candidate
+        }
+      }
+    }
+    out.WriteString(text[i:end])
+    i = end
+  }
+  return strings.TrimSpace(out.String())
+}
+
+func isSignatureWhitespace(ch byte) bool {
+  switch ch {
+  case ' ', '\t', '\r', '\n', '\v', '\f':
+    return true
+  default:
+    return false
+  }
+}
+
+func quotedSourceEnd(text string, start int, quote byte) int {
+  escaped := false
+  for i := start + 1; i < len(text); i++ {
+    if escaped {
+      escaped = false
+      continue
+    }
+    if text[i] == '\\' {
+      escaped = true
+      continue
+    }
+    if text[i] == quote {
+      return i + 1
+    }
+  }
+  return len(text)
+}
+
+// templateSourceEnd returns the last unescaped backtick in the member span.
+// This deliberately treats substitutions and nested templates as one protected
+// lexical region: preserving a little extra spacing is safer than compacting
+// whitespace that belongs to either template's value.
+func templateSourceEnd(text string, start int) int {
+  end := len(text)
+  for i := len(text) - 1; i > start; i-- {
+    if text[i] == '`' && !sourceByteEscaped(text, i) {
+      return i + 1
+    }
+  }
+  return end
+}
+
+func sourceByteEscaped(text string, pos int) bool {
+  slashes := 0
+  for i := pos - 1; i >= 0 && text[i] == '\\'; i-- {
+    slashes++
+  }
+  return slashes%2 == 1
+}
+
+func lineCommentEnd(text string, start int) int {
+  if end := strings.IndexByte(text[start:], '\n'); end >= 0 {
+    return start + end + 1
+  }
+  return len(text)
+}
+
+func blockCommentEnd(text string, start int) int {
+  if end := strings.Index(text[start+2:], "*/"); end >= 0 {
+    return start + 2 + end + 2
+  }
+  return len(text)
+}
+
+// regularExpressionEnd conservatively protects a slash-delimited region when
+// one closes on the same source line. Division can look the same without parser
+// context; preserving its spaces is harmless, while compacting a real regular
+// expression would change its pattern.
+func regularExpressionEnd(text string, start int) int {
+  escaped := false
+  inClass := false
+  for i := start + 1; i < len(text); i++ {
+    switch {
+    case text[i] == '\n' || text[i] == '\r':
+      return start
+    case escaped:
+      escaped = false
+    case text[i] == '\\':
+      escaped = true
+    case text[i] == '[':
+      inClass = true
+    case text[i] == ']':
+      inClass = false
+    case text[i] == '/' && !inClass:
+      i++
+      for i < len(text) && ((text[i] >= 'a' && text[i] <= 'z') || (text[i] >= 'A' && text[i] <= 'Z')) {
+        i++
+      }
+      return i
+    }
+  }
+  return start
 }
 
 // firstCodeOffset advances past leading trivia: whitespace, // line comments,

--- a/packages/ttsc/internal/graph/dump.go
+++ b/packages/ttsc/internal/graph/dump.go
@@ -66,24 +66,35 @@ type DumpEnumMember struct {
   Value string `json:"value,omitempty"`
 }
 
+// DumpObjectMember is one direct object-literal member carried on its variable
+// node. Line and Signature are rendered from the same Program-owned source text
+// as the node evidence, so the outline cannot race a later disk write.
+type DumpObjectMember struct {
+  Name      string `json:"name"`
+  Kind      string `json:"kind"`
+  Line      int    `json:"line,omitempty"`
+  Signature string `json:"signature,omitempty"`
+}
+
 // DumpNode is the wire shape of a graph node. Lowercase json keys are the
 // contract; the Go field names are not.
 type DumpNode struct {
-  ID             string          `json:"id"`
-  Kind           string          `json:"kind"`
-  Name           string          `json:"name"`
-  QualifiedName  string          `json:"qualifiedName,omitempty"`
-  File           string          `json:"file"`
-  External       bool            `json:"external"`
-  Ignored        bool            `json:"ignored,omitempty"`
-  Exported       bool            `json:"exported,omitempty"`
-  Closure        bool            `json:"closure,omitempty"`
-  Modifiers      []string        `json:"modifiers,omitempty"`
-  Literals       []string         `json:"literals,omitempty"`
-  EnumMembers    []DumpEnumMember `json:"enumMembers,omitempty"`
-  Evidence       *DumpEvidence   `json:"evidence,omitempty"`
-  Implementation *DumpEvidence   `json:"implementation,omitempty"`
-  Decorators     []DumpDecorator `json:"decorators,omitempty"`
+  ID             string             `json:"id"`
+  Kind           string             `json:"kind"`
+  Name           string             `json:"name"`
+  QualifiedName  string             `json:"qualifiedName,omitempty"`
+  File           string             `json:"file"`
+  External       bool               `json:"external"`
+  Ignored        bool               `json:"ignored,omitempty"`
+  Exported       bool               `json:"exported,omitempty"`
+  Closure        bool               `json:"closure,omitempty"`
+  Modifiers      []string           `json:"modifiers,omitempty"`
+  Literals       []string           `json:"literals,omitempty"`
+  EnumMembers    []DumpEnumMember   `json:"enumMembers,omitempty"`
+  ObjectMembers  []DumpObjectMember `json:"objectMembers,omitempty"`
+  Evidence       *DumpEvidence      `json:"evidence,omitempty"`
+  Implementation *DumpEvidence      `json:"implementation,omitempty"`
+  Decorators     []DumpDecorator    `json:"decorators,omitempty"`
 }
 
 // DumpEdge is the wire shape of a graph edge. Lowercase json keys are the
@@ -174,6 +185,7 @@ func NewDump(g *Graph, project, tsconfig string, ignored map[string]bool, source
       // the MCP layer is what applies a response cap and marks it.
       Literals:       n.Literals,
       EnumMembers:    dumpEnumMembers(n.EnumMembers),
+      ObjectMembers:  ctx.objectMembers(n),
       Evidence:       withoutFile(ctx.evidence(n.File, n.Pos, n.End)),
       Implementation: ctx.evidence(n.ImplementationFile, n.ImplementationPos, n.ImplementationEnd),
       Decorators:     decByNode[n.ID],
@@ -247,6 +259,35 @@ func dumpEnumMembers(members []EnumMember) []DumpEnumMember {
     out = append(out, DumpEnumMember{Name: member.Name, Value: member.Value})
   }
   return out
+}
+
+// objectMembers projects AST-owned object member identity and snapshot-owned
+// display text. A missing source omits only line/signature; identity still came
+// from the AST and therefore remains sound.
+func (c *dumpContext) objectMembers(node *Node) []DumpObjectMember {
+  if len(node.ObjectMembers) == 0 {
+    return nil
+  }
+  out := make([]DumpObjectMember, 0, len(node.ObjectMembers))
+  for _, member := range node.ObjectMembers {
+    dumped := DumpObjectMember{
+      Name: member.Name,
+      Kind: objectMemberWireKind(member.Kind),
+    }
+    if evidence := c.evidence(node.File, member.Pos, member.End); evidence != nil {
+      dumped.Line = evidence.StartLine
+    }
+    dumped.Signature = c.objectMemberSignature(node.File, member)
+    out = append(out, dumped)
+  }
+  return out
+}
+
+func objectMemberWireKind(kind NodeKind) string {
+  if kind == NodeMethod {
+    return "method"
+  }
+  return "property"
 }
 
 // MarshalDump serializes a built graph to the export JSON, indented when pretty.
@@ -422,6 +463,46 @@ func (c *dumpContext) evidence(file string, pos, end int) *DumpEvidence {
     ev.EndLine, ev.EndCol = ls.at(end)
   }
   return ev
+}
+
+// objectMemberSignature reproduces the compact one-line outline details has
+// historically returned, but slices it from Program-owned text while the dump
+// is built instead of reopening the live file later.
+func (c *dumpContext) objectMemberSignature(file string, member ObjectMember) string {
+  pos, end := member.Pos, member.SignatureEnd
+  if pos < 0 || end <= pos || c.sources == nil {
+    return ""
+  }
+  text, ok := c.sources[file]
+  if !ok || pos > len(text) {
+    return ""
+  }
+  pos = firstCodeOffset(text, pos)
+  if end > len(text) {
+    end = len(text)
+  }
+  if member.SignatureTokenLen > 0 {
+    end = firstCodeOffset(text, end)
+    end = min(end+member.SignatureTokenLen, len(text))
+  }
+  if pos >= end {
+    return ""
+  }
+  if !member.SignatureBoundary {
+    if lineEnd := strings.IndexByte(text[pos:end], '\n'); lineEnd >= 0 {
+      end = pos + lineEnd
+    }
+  }
+  if pos >= end {
+    return ""
+  }
+  signature := strings.TrimSuffix(strings.Join(strings.Fields(text[pos:end]), " "), ",")
+  const maxObjectMemberSignatureRunes = 160
+  runes := []rune(signature)
+  if len(runes) > maxObjectMemberSignatureRunes {
+    signature = string(runes[:maxObjectMemberSignatureRunes-3]) + "..."
+  }
+  return signature
 }
 
 // firstCodeOffset advances past leading trivia: whitespace, // line comments,

--- a/packages/ttsc/internal/graph/duplicate_variable_object_members_keep_first_declaration_test.go
+++ b/packages/ttsc/internal/graph/duplicate_variable_object_members_keep_first_declaration_test.go
@@ -1,0 +1,58 @@
+package graph
+
+import (
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestDuplicateVariableObjectMembersKeepFirstDeclaration verifies that a legal
+// repeated var declaration cannot attach its initializer to the first node.
+//
+// Variable symbols merge across declarations, while graph node identity keeps
+// the first declaration. Collecting object members after every add used to
+// combine the first declaration's span with the second declaration's members,
+// producing a node that never existed in the compiler snapshot.
+//
+//  1. Compile two var declarations with the same symbol and different objects.
+//  2. Assert the graph keeps the first declaration and its direct member.
+//  3. Dump the graph and assert the same member remains on the wire.
+func TestDuplicateVariableObjectMembersKeepFirstDeclaration(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), fixtureTSConfig)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), `export var duplicate = { first: 1 };
+export var duplicate = { second: 2 };
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diags)
+  }
+  defer func() { _ = prog.Close() }()
+
+  graph := Build(prog)
+  path := sourceFile(t, prog, "main.ts").FileName()
+  node := graph.Nodes[nodeID(path, "duplicate", NodeVariable)]
+  if node == nil {
+    t.Fatalf("missing duplicate variable; nodes: %v", nodeIDSet(graph))
+  }
+  if len(node.ObjectMembers) != 1 || node.ObjectMembers[0].Name != "first" {
+    t.Fatalf("first declaration members were overwritten: %+v", node.ObjectMembers)
+  }
+
+  dump := NewDump(graph, root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  for _, dumped := range dump.Nodes {
+    if dumped.ID != "src/main.ts#duplicate:variable" {
+      continue
+    }
+    if len(dumped.ObjectMembers) != 1 || dumped.ObjectMembers[0].Name != "first" || dumped.ObjectMembers[0].Signature != "first: 1" {
+      t.Fatalf("dump mixed declarations: %+v", dumped.ObjectMembers)
+    }
+    return
+  }
+  t.Fatalf("dump omitted duplicate variable: %+v", dump.Nodes)
+}

--- a/packages/ttsc/internal/graph/graph.go
+++ b/packages/ttsc/internal/graph/graph.go
@@ -84,6 +84,12 @@ type Node struct {
   // per member would grow the graph and put leaves into tour flows to index
   // what grep already does. This fills in the node that exists instead.
   EnumMembers []EnumMember
+  // ObjectMembers is the direct, statically named outline of an object literal
+  // assigned to this variable. It is captured from the compiler AST, in source
+  // order, so comments and lexical trivia cannot change member identity. The
+  // positions point into the same Program-owned source snapshot NewDump uses to
+  // render the compact signature and line carried on the wire.
+  ObjectMembers []ObjectMember
   // Pos and End bound the declaration in its source file (byte offsets). They
   // are for display, never identity, so an edit that shifts them does not re-key
   // the node.
@@ -100,6 +106,24 @@ type Node struct {
 type EnumMember struct {
   Name  string
   Value string
+}
+
+// ObjectMember is one direct, statically named property, method, or accessor of
+// an object-literal variable. A spread has no declaration name of its own and a
+// dynamic computed key cannot be named soundly, so neither fabricates a member.
+type ObjectMember struct {
+  Name string
+  Kind NodeKind
+  Pos  int
+  End  int
+  // SignatureEnd is the AST boundary before a nested value body. When the
+  // boundary lands at an opening token's full start, SignatureTokenLen says how
+  // many source bytes belong to the outline (`{`, `[`, or `class`). A true
+  // SignatureBoundary permits whitespace-normalizing a multiline declaration
+  // through that safe endpoint; otherwise the outline stops at its first line.
+  SignatureEnd      int
+  SignatureBoundary bool
+  SignatureTokenLen int
 }
 
 // EdgeKind classifies a relationship between two nodes.

--- a/packages/ttsc/internal/graph/object_literal_members_ride_on_the_snapshot_test.go
+++ b/packages/ttsc/internal/graph/object_literal_members_ride_on_the_snapshot_test.go
@@ -1,0 +1,189 @@
+package graph
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestObjectLiteralMembersRideOnTheSnapshot verifies that object-literal
+// member identity is captured from the compiler AST and projected from the
+// same source snapshot as the graph.
+//
+// The details server used to reopen the live file and reconstruct this list
+// with a brace counter and regular expressions. A brace inside a block comment
+// changed that counter, while valid shorthand, literal-keyed, computed, and
+// multiline members depended on which line happened to match. This test pins
+// the ownership boundary instead: the native graph records direct AST members,
+// and the dump renders snapshot-owned, body-bounded compact signatures from
+// Program-owned text.
+//
+//  1. Compile a wrapped object literal containing comment braces, every direct
+//     static member shape, a dynamic key, a spread, and a nested object.
+//  2. Assert the variable node records only its direct statically named members
+//     in declaration order, with method/property kinds independent of trivia.
+//  3. Dump the graph and assert member lines/signatures come from the snapshot,
+//     while spread and nested members are not fabricated as outer identity.
+func TestObjectLiteralMembersRideOnTheSnapshot(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), fixtureTSConfig)
+  source := `const shorthand = 1;
+const dynamic = Math.random() > 0.5 ? "a" : "b";
+const spread = { fromSpread: true };
+
+export const shape = (({
+  /* { */
+  real: 1,
+  close: "}",
+  text: "{",
+  template: ` + "`{${shorthand}}`" + `,
+  long: "` + strings.Repeat("x", 200) + `",
+  shorthand,
+  ["static-key"]: 2,
+  [""]: 4,
+  [1]: true,
+  [dynamic]: 3,
+  method() {
+    return shorthand;
+  },
+  get value() {
+    return shorthand;
+  },
+  set value(input: number) {
+    void "SETTER_BODY_MUST_NOT_APPEAR";
+  },
+  oneLineMethod() { return "METHOD_BODY_MUST_NOT_APPEAR"; },
+  get oneLineValue() { return "ACCESSOR_BODY_MUST_NOT_APPEAR"; },
+  run: () => "ARROW_BODY_MUST_NOT_APPEAR",
+  classic: function () { return "FUNCTION_BODY_MUST_NOT_APPEAR"; },
+  klass: class { method() { return "CLASS_BODY_MUST_NOT_APPEAR"; } },
+  list: ["ARRAY_CONTENT_MUST_NOT_APPEAR"],
+  nested: {
+    inner: "NESTED_BODY_MUST_NOT_APPEAR",
+  },
+  ...spread,
+  /* } */
+  afterSpread: true,
+}) as const) satisfies Record<PropertyKey, unknown>;
+`
+  writeFile(t, filepath.Join(root, "src", "main.ts"), source)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diags)
+  }
+  defer func() { _ = prog.Close() }()
+
+  graph := Build(prog)
+  path := sourceFile(t, prog, "main.ts").FileName()
+  node := graph.Nodes[nodeID(path, "shape", NodeVariable)]
+  if node == nil {
+    t.Fatalf("missing shape variable; nodes: %v", nodeIDSet(graph))
+  }
+
+  want := []ObjectMember{
+    {Name: "real", Kind: NodeVariable},
+    {Name: "close", Kind: NodeVariable},
+    {Name: "text", Kind: NodeVariable},
+    {Name: "template", Kind: NodeVariable},
+    {Name: "long", Kind: NodeVariable},
+    {Name: "shorthand", Kind: NodeVariable},
+    {Name: "static-key", Kind: NodeVariable},
+    {Name: "", Kind: NodeVariable},
+    {Name: "1", Kind: NodeVariable},
+    {Name: "method", Kind: NodeMethod},
+    {Name: "value", Kind: NodeMethod},
+    {Name: "value", Kind: NodeMethod},
+    {Name: "oneLineMethod", Kind: NodeMethod},
+    {Name: "oneLineValue", Kind: NodeMethod},
+    {Name: "run", Kind: NodeVariable},
+    {Name: "classic", Kind: NodeVariable},
+    {Name: "klass", Kind: NodeVariable},
+    {Name: "list", Kind: NodeVariable},
+    {Name: "nested", Kind: NodeVariable},
+    {Name: "afterSpread", Kind: NodeVariable},
+  }
+  if len(node.ObjectMembers) != len(want) {
+    t.Fatalf("object members = %v, want %v", node.ObjectMembers, want)
+  }
+  for i, expected := range want {
+    actual := node.ObjectMembers[i]
+    if actual.Name != expected.Name || actual.Kind != expected.Kind {
+      t.Fatalf("object member %d = %+v, want %+v", i, actual, expected)
+    }
+    if actual.Pos < 0 || actual.End <= actual.Pos {
+      t.Fatalf("object member %q has no snapshot span: %+v", actual.Name, actual)
+    }
+  }
+
+  dump := NewDump(graph, root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  var dumped *DumpNode
+  for i := range dump.Nodes {
+    if dump.Nodes[i].ID == "src/main.ts#shape:variable" {
+      dumped = &dump.Nodes[i]
+      break
+    }
+  }
+  if dumped == nil {
+    t.Fatalf("dump omitted shape: %+v", dump.Nodes)
+  }
+  if len(dumped.ObjectMembers) != len(want) {
+    t.Fatalf("dumped object members = %+v, want %d", dumped.ObjectMembers, len(want))
+  }
+  for _, member := range dumped.ObjectMembers {
+    if member.Line <= 0 || member.Signature == "" {
+      t.Fatalf("member lacks snapshot line/signature: %+v", member)
+    }
+    if member.Name == "inner" || member.Name == "fromSpread" || member.Name == "dynamic" {
+      t.Fatalf("non-direct or non-static member was fabricated: %+v", member)
+    }
+  }
+  if got := dumped.ObjectMembers[0]; got.Name != "real" || got.Line != 7 || got.Signature != "real: 1" {
+    t.Fatalf("comment brace corrupted the first real member: %+v", got)
+  }
+  if got := dumped.ObjectMembers[len(dumped.ObjectMembers)-1]; got.Name != "afterSpread" || got.Signature != "afterSpread: true" {
+    t.Fatalf("spread/comment boundary corrupted the following member: %+v", got)
+  }
+  signatures := map[string]string{}
+  for _, member := range dumped.ObjectMembers {
+    signatures[member.Name] = member.Signature
+  }
+  expectedSignatures := map[string]string{
+    "oneLineMethod": "oneLineMethod() {",
+    "oneLineValue":  "get oneLineValue() {",
+    "run":           "run: () =>",
+    "classic":       "classic: function () {",
+    "klass":         "klass: class",
+    "list":          "list: [",
+    "nested":        "nested: {",
+  }
+  for name, expected := range expectedSignatures {
+    if actual := signatures[name]; actual != expected {
+      t.Fatalf("signature for %q = %q, want %q", name, actual, expected)
+    }
+  }
+  for _, forbidden := range []string{
+    "METHOD_BODY_MUST_NOT_APPEAR",
+    "ACCESSOR_BODY_MUST_NOT_APPEAR",
+    "SETTER_BODY_MUST_NOT_APPEAR",
+    "ARROW_BODY_MUST_NOT_APPEAR",
+    "FUNCTION_BODY_MUST_NOT_APPEAR",
+    "CLASS_BODY_MUST_NOT_APPEAR",
+    "ARRAY_CONTENT_MUST_NOT_APPEAR",
+    "NESTED_BODY_MUST_NOT_APPEAR",
+  } {
+    for _, member := range dumped.ObjectMembers {
+      if strings.Contains(member.Signature, forbidden) {
+        t.Fatalf("signature inlined source body %q: %+v", forbidden, member)
+      }
+    }
+  }
+  if signature := signatures["long"]; len([]rune(signature)) != 160 || !strings.HasSuffix(signature, "...") {
+    t.Fatalf("long member signature is not bounded to 160 runes: %q", signature)
+  }
+}

--- a/packages/ttsc/internal/graph/object_member_signatures_preserve_literal_whitespace_test.go
+++ b/packages/ttsc/internal/graph/object_member_signatures_preserve_literal_whitespace_test.go
@@ -1,0 +1,64 @@
+package graph
+
+import (
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestObjectMemberSignaturesPreserveLiteralWhitespace verifies that compact
+// display text never rewrites whitespace owned by a lexical value.
+//
+// strings.Fields treated quoted and template contents as trivia. It changed
+// string and regular-expression values, and its first-line cut left a multiline
+// template without a closing backtick. The outline may compact surrounding
+// syntax only when the literal itself remains byte-identical and complete.
+//
+//  1. Compile object members with spaced strings, a regexp, and a template.
+//  2. Dump the graph from the Program-owned source snapshot.
+//  3. Assert literal whitespace and the complete template delimiter survive.
+func TestObjectMemberSignaturesPreserveLiteralWhitespace(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), fixtureTSConfig)
+  source := `export const shape = {
+  double: "a  b",
+  single: 'c  d',
+  regexp: /e  f/,
+  template: ` + "`left\n  right`" + `,
+};
+`
+  writeFile(t, filepath.Join(root, "src", "main.ts"), source)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diags)
+  }
+  defer func() { _ = prog.Close() }()
+
+  graph := Build(prog)
+  dump := NewDump(graph, root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  signatures := map[string]string{}
+  for _, node := range dump.Nodes {
+    if node.ID != "src/main.ts#shape:variable" {
+      continue
+    }
+    for _, member := range node.ObjectMembers {
+      signatures[member.Name] = member.Signature
+    }
+  }
+  expected := map[string]string{
+    "double":   `double: "a  b"`,
+    "single":   `single: 'c  d'`,
+    "regexp":   `regexp: /e  f/`,
+    "template": "template: `left\n  right`",
+  }
+  for name, want := range expected {
+    if got := signatures[name]; got != want {
+      t.Fatalf("signature for %q = %q, want %q", name, got, want)
+    }
+  }
+}

--- a/packages/ttsc/internal/graph/object_members.go
+++ b/packages/ttsc/internal/graph/object_members.go
@@ -1,0 +1,229 @@
+package graph
+
+import shimast "github.com/microsoft/typescript-go/shim/ast"
+
+// collectObjectMembers records the direct, statically named members of the
+// object literal bound by declaration on the variable node Build already owns.
+// The AST is the structure oracle: no source text, brace counter, or regex is
+// involved in deciding which properties belong to the outer object.
+func (g *Graph) collectObjectMembers(path string, declaration *shimast.Node) {
+  if declaration == nil || declaration.Symbol() == nil {
+    return
+  }
+  variable := declaration.AsVariableDeclaration()
+  if variable == nil {
+    return
+  }
+  object := objectLiteralInitializer(variable.Initializer)
+  if object == nil || object.Properties == nil {
+    return
+  }
+  node := g.Nodes[nodeID(path, qualifiedName(declaration.Symbol()), NodeVariable)]
+  if node == nil {
+    return
+  }
+  members := make([]ObjectMember, 0, len(object.Properties.Nodes))
+  for _, property := range object.Properties.Nodes {
+    name, kind, ok := objectMemberIdentity(property)
+    if !ok {
+      continue
+    }
+    signatureEnd, signatureBoundary, signatureTokenLen := objectMemberSignatureSpan(property)
+    members = append(members, ObjectMember{
+      Name:              name,
+      Kind:              kind,
+      Pos:               property.Pos(),
+      End:               property.End(),
+      SignatureEnd:      signatureEnd,
+      SignatureBoundary: signatureBoundary,
+      SignatureTokenLen: signatureTokenLen,
+    })
+  }
+  if len(members) > 0 {
+    node.ObjectMembers = members
+  }
+}
+
+// objectMemberSignatureSpan finds the earliest AST boundary after which source
+// belongs to a value body rather than the member outline. It keeps compact
+// scalar initializers such as `real: 1`, but stops before function bodies,
+// arrow expressions, nested object members, and array contents can be copied
+// onto the wire.
+func objectMemberSignatureSpan(property *shimast.Node) (end int, boundary bool, tokenLen int) {
+  end = property.End()
+  candidate, found := sourceBodyBoundary(property)
+  if !found || candidate.end <= property.Pos() || candidate.end > end {
+    return end, false, 0
+  }
+  return candidate.end, true, candidate.tokenLen
+}
+
+type signatureBoundary struct {
+  end      int
+  tokenLen int
+}
+
+func sourceBodyBoundary(node *shimast.Node) (signatureBoundary, bool) {
+  if node == nil {
+    return signatureBoundary{}, false
+  }
+  switch node.Kind {
+  case shimast.KindArrowFunction:
+    arrow := node.AsArrowFunction()
+    if arrow != nil && arrow.EqualsGreaterThanToken != nil {
+      return signatureBoundary{end: arrow.EqualsGreaterThanToken.End()}, true
+    }
+  case shimast.KindBlock, shimast.KindObjectLiteralExpression, shimast.KindArrayLiteralExpression:
+    return signatureBoundary{end: node.Pos(), tokenLen: 1}, true
+  case shimast.KindClassExpression:
+    return signatureBoundary{end: node.Pos(), tokenLen: len("class")}, true
+  }
+
+  var boundary signatureBoundary
+  found := false
+  node.ForEachChild(func(child *shimast.Node) bool {
+    candidate, ok := sourceBodyBoundary(child)
+    if ok {
+      boundary = candidate
+      found = true
+      // ForEachChild visits source order, so the first body boundary is the
+      // earliest and later children cannot improve the outline cut.
+      return true
+    }
+    return false
+  })
+  return boundary, found
+}
+
+// objectLiteralInitializer unwraps the transparent expression wrappers a
+// declaration commonly places around an object literal. None changes which
+// direct properties the literal declares.
+func objectLiteralInitializer(initializer *shimast.Node) *shimast.ObjectLiteralExpression {
+  for initializer != nil {
+    switch initializer.Kind {
+    case shimast.KindObjectLiteralExpression:
+      return initializer.AsObjectLiteralExpression()
+    case shimast.KindAsExpression:
+      expression := initializer.AsAsExpression()
+      if expression == nil {
+        return nil
+      }
+      initializer = expression.Expression
+    case shimast.KindSatisfiesExpression:
+      expression := initializer.AsSatisfiesExpression()
+      if expression == nil {
+        return nil
+      }
+      initializer = expression.Expression
+    case shimast.KindParenthesizedExpression:
+      expression := initializer.AsParenthesizedExpression()
+      if expression == nil {
+        return nil
+      }
+      initializer = expression.Expression
+    case shimast.KindTypeAssertionExpression:
+      expression := initializer.AsTypeAssertion()
+      if expression == nil {
+        return nil
+      }
+      initializer = expression.Expression
+    case shimast.KindNonNullExpression:
+      expression := initializer.AsNonNullExpression()
+      if expression == nil {
+        return nil
+      }
+      initializer = expression.Expression
+    default:
+      return nil
+    }
+  }
+  return nil
+}
+
+// objectMemberIdentity returns the source-visible name and details kind of one
+// direct object-literal property. The boolean distinguishes an unsupported
+// spread or dynamic computed key from the valid static property name `""`.
+func objectMemberIdentity(property *shimast.Node) (string, NodeKind, bool) {
+  if property == nil {
+    return "", "", false
+  }
+  kind := NodeVariable
+  switch property.Kind {
+  case shimast.KindPropertyAssignment, shimast.KindShorthandPropertyAssignment:
+  case shimast.KindMethodDeclaration, shimast.KindGetAccessor, shimast.KindSetAccessor:
+    kind = NodeMethod
+  default:
+    return "", "", false
+  }
+  name, ok := staticObjectMemberName(property.Name())
+  return name, kind, ok
+}
+
+// staticObjectMemberName resolves the declaration forms whose property name is
+// fixed by syntax. A computed literal is fixed; a computed expression is not.
+func staticObjectMemberName(name *shimast.Node) (string, bool) {
+  if name == nil {
+    return "", false
+  }
+  switch name.Kind {
+  case shimast.KindIdentifier:
+    if identifier := name.AsIdentifier(); identifier != nil {
+      return identifier.Text, true
+    }
+  case shimast.KindStringLiteral:
+    if literal := name.AsStringLiteral(); literal != nil {
+      return literal.Text, true
+    }
+  case shimast.KindNoSubstitutionTemplateLiteral:
+    if literal := name.AsNoSubstitutionTemplateLiteral(); literal != nil {
+      return literal.Text, true
+    }
+  case shimast.KindNumericLiteral:
+    if literal := name.AsNumericLiteral(); literal != nil {
+      return literal.Text, true
+    }
+  case shimast.KindBigIntLiteral:
+    if literal := name.AsBigIntLiteral(); literal != nil {
+      return literal.Text, true
+    }
+  case shimast.KindComputedPropertyName:
+    computed := name.AsComputedPropertyName()
+    if computed == nil {
+      return "", false
+    }
+    return staticComputedObjectMemberName(computed.Expression)
+  }
+  return "", false
+}
+
+func staticComputedObjectMemberName(expression *shimast.Node) (string, bool) {
+  for expression != nil && expression.Kind == shimast.KindParenthesizedExpression {
+    parenthesized := expression.AsParenthesizedExpression()
+    if parenthesized == nil {
+      return "", false
+    }
+    expression = parenthesized.Expression
+  }
+  if expression == nil {
+    return "", false
+  }
+  switch expression.Kind {
+  case shimast.KindStringLiteral:
+    if literal := expression.AsStringLiteral(); literal != nil {
+      return literal.Text, true
+    }
+  case shimast.KindNoSubstitutionTemplateLiteral:
+    if literal := expression.AsNoSubstitutionTemplateLiteral(); literal != nil {
+      return literal.Text, true
+    }
+  case shimast.KindNumericLiteral:
+    if literal := expression.AsNumericLiteral(); literal != nil {
+      return literal.Text, true
+    }
+  case shimast.KindBigIntLiteral:
+    if literal := expression.AsBigIntLiteral(); literal != nil {
+      return literal.Text, true
+    }
+  }
+  return "", false
+}

--- a/packages/ttsc/internal/graph/object_members.go
+++ b/packages/ttsc/internal/graph/object_members.go
@@ -19,7 +19,7 @@ func (g *Graph) collectObjectMembers(path string, declaration *shimast.Node) {
     return
   }
   node := g.Nodes[nodeID(path, qualifiedName(declaration.Symbol()), NodeVariable)]
-  if node == nil {
+  if node == nil || node.Pos != declaration.Pos() || node.End != declaration.End() {
     return
   }
   members := make([]ObjectMember, 0, len(object.Properties.Nodes))

--- a/packages/ttsc/internal/graph/provenance.go
+++ b/packages/ttsc/internal/graph/provenance.go
@@ -14,7 +14,7 @@ import (
 // field is added, removed, or given a new meaning, independently of the serve
 // envelope's protocol version: a one-shot `ttscgraph dump` written to a file has
 // a schema but never rode the protocol.
-const DumpSchemaVersion = 4
+const DumpSchemaVersion = 5
 
 // The capabilities a snapshot can declare. Each names one class of evidence a
 // consumer may rely on when, and only when, the snapshot lists it.

--- a/tests/test-graph/src/features/test_ttscgraph_details_object_members_follow_compiler_snapshot.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_details_object_members_follow_compiler_snapshot.ts
@@ -1,0 +1,199 @@
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  structuredContent?: unknown;
+}
+
+interface Member {
+  name: string;
+  kind: string;
+  line?: number;
+  signature?: string;
+}
+
+const detailsArguments = (handle: string) => ({
+  question: `What direct members does ${handle} declare?`,
+  graphNeed: "The synchronized graph owns the declaration outline.",
+  draft: {
+    reason: "One details request is the smallest complete identity lookup.",
+    type: "details",
+  },
+  review:
+    "Confirmed: inspect the named object without replacing graph facts with a file read.",
+  request: { type: "details", handles: [handle] },
+});
+
+const membersOf = (result: ToolResult, name: string): Member[] => {
+  const value = (result.structuredContent ?? {}) as {
+    result?: {
+      type?: string;
+      nodes?: { name?: string; members?: Member[] }[];
+    };
+  };
+  assert.equal(value.result?.type, "details", JSON.stringify(value));
+  return value.result?.nodes?.find((node) => node.name === name)?.members ?? [];
+};
+
+/**
+ * Verifies object details use compiler-snapshot member identity rather than a
+ * live-disk brace scanner.
+ *
+ * Braces in block comments and strings previously changed the scanner depth,
+ * while shorthand, literal computed keys, spreads, and wrapped literals fell
+ * outside its regex grammar. The direct outline is declaration identity: a
+ * spread has no direct property name of its own and must not promote names from
+ * another object, just as an inherited class member is not directly owned.
+ * Explicit siblings around it remain complete and ordered.
+ *
+ * 1. Synchronize a wrapped object containing comment/string braces, static and
+ *    dynamic keys, nested objects, methods/accessors, and a spread.
+ * 2. Assert every direct statically named member is returned in AST order while
+ *    nested, spread-origin, and dynamic names are not fabricated.
+ * 3. Replace the file in the same MCP session and assert a later details call
+ *    observes the new compiler snapshot rather than cached stale identity.
+ */
+export const test_ttscgraph_details_object_members_follow_compiler_snapshot =
+  async () => {
+    const before = [
+      "const shorthand = 1;",
+      'const dynamic = Math.random() > 0.5 ? "a" : "b";',
+      "const spread = { fromSpread: true };",
+      "",
+      "export const shape = (({",
+      "  /* { */",
+      "  real: 1,",
+      '  close: "}",',
+      '  text: "{",',
+      "  shorthand,",
+      '  ["static-key"]: 2,',
+      '  [""]: 4,',
+      "  [1]: true,",
+      "  [dynamic]: 3,",
+      '  method() { return "METHOD_BODY_MUST_NOT_APPEAR"; },',
+      '  get value() { return "ACCESSOR_BODY_MUST_NOT_APPEAR"; },',
+      '  set value(input: number) { void "SETTER_BODY_MUST_NOT_APPEAR"; },',
+      '  run: () => "ARROW_BODY_MUST_NOT_APPEAR",',
+      '  classic: function () { return "FUNCTION_BODY_MUST_NOT_APPEAR"; },',
+      '  klass: class { method() { return "CLASS_BODY_MUST_NOT_APPEAR"; } },',
+      '  list: ["ARRAY_CONTENT_MUST_NOT_APPEAR"],',
+      '  nested: { inner: "NESTED_BODY_MUST_NOT_APPEAR" },',
+      "  ...spread,",
+      "  /* } */",
+      "  afterSpread: true,",
+      "}) as const) satisfies Record<PropertyKey, unknown>;",
+      "",
+    ].join("\n");
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+        },
+        include: ["src"],
+      }),
+      "src/index.ts": before,
+    });
+
+    const client = TtsgraphClient.start(root);
+    try {
+      await client.request("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-graph", version: "0.0.0" },
+      });
+      client.notify("notifications/initialized", {});
+
+      const original = membersOf(
+        (await client.request("tools/call", {
+          name: "inspect_typescript_graph",
+          arguments: detailsArguments("shape"),
+        })) as ToolResult,
+        "shape",
+      );
+      assert.deepEqual(
+        original.map((member) => [member.name, member.kind]),
+        [
+          ["real", "property"],
+          ["close", "property"],
+          ["text", "property"],
+          ["shorthand", "property"],
+          ["static-key", "property"],
+          ["", "property"],
+          ["1", "property"],
+          ["method", "method"],
+          ["value", "method"],
+          ["value", "method"],
+          ["run", "property"],
+          ["classic", "property"],
+          ["klass", "property"],
+          ["list", "property"],
+          ["nested", "property"],
+          ["afterSpread", "property"],
+        ],
+      );
+      assert.ok(
+        original.every(
+          (member) =>
+            member.name !== "inner" &&
+            member.name !== "fromSpread" &&
+            member.name !== "dynamic",
+        ),
+        JSON.stringify(original),
+      );
+      assert.equal(original[0]?.line, 7);
+      assert.equal(original[0]?.signature, "real: 1");
+      assert.equal(original.at(-1)?.signature, "afterSpread: true");
+      const signatures = new Map(
+        original.map((member) => [member.name, member.signature]),
+      );
+      assert.equal(signatures.get("method"), "method() {");
+      assert.equal(signatures.get("run"), "run: () =>");
+      assert.equal(signatures.get("classic"), "classic: function () {");
+      assert.equal(signatures.get("klass"), "klass: class");
+      assert.equal(signatures.get("list"), "list: [");
+      assert.equal(signatures.get("nested"), "nested: {");
+      for (const forbidden of [
+        "METHOD_BODY_MUST_NOT_APPEAR",
+        "ACCESSOR_BODY_MUST_NOT_APPEAR",
+        "SETTER_BODY_MUST_NOT_APPEAR",
+        "ARROW_BODY_MUST_NOT_APPEAR",
+        "FUNCTION_BODY_MUST_NOT_APPEAR",
+        "CLASS_BODY_MUST_NOT_APPEAR",
+        "ARRAY_CONTENT_MUST_NOT_APPEAR",
+        "NESTED_BODY_MUST_NOT_APPEAR",
+      ])
+        assert.ok(
+          original.every(
+            (member) => member.signature?.includes(forbidden) !== true,
+          ),
+          `${forbidden}: ${JSON.stringify(original)}`,
+        );
+
+      fs.writeFileSync(
+        path.join(root, "src", "index.ts"),
+        "export const shape = { replacement: 2 };\n",
+      );
+      const refreshed = membersOf(
+        (await client.request("tools/call", {
+          name: "inspect_typescript_graph",
+          arguments: detailsArguments("shape"),
+        })) as ToolResult,
+        "shape",
+      );
+      assert.deepEqual(
+        refreshed.map((member) => member.name),
+        ["replacement"],
+      );
+      assert.equal(refreshed[0]?.signature, "replacement: 2");
+    } finally {
+      client.endStdin();
+    }
+
+    const code = await client.waitForExit();
+    assert.equal(code, 0, client.stderrText());
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_source_reader_enforces_snapshot_identity_once.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_source_reader_enforces_snapshot_identity_once.ts
@@ -1,0 +1,202 @@
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { assert } from "../internal/ttsgraph";
+
+interface Provenance {
+  capabilities: string[];
+  sources: {
+    file: string;
+    checkerDigest: string;
+    diskDigest: string;
+  }[];
+}
+
+interface SourceReader {
+  lines(file: string): readonly string[] | undefined;
+}
+
+interface SourceReaderConstructor {
+  new (
+    project: string,
+    provenance: Provenance | undefined,
+    read: (file: string) => Buffer,
+  ): SourceReader;
+}
+
+const digest = (text: string): string =>
+  createHash("sha256").update(text, "utf8").digest("hex");
+
+/**
+ * Verifies the graph source reader returns one immutable checker-identical
+ * snapshot per file and caches both success and failure.
+ *
+ * A request-only line cache reduces repeated `readFileSync` calls but can still
+ * mix graph facts with bytes written after the native snapshot. It is also
+ * unsound for a source-preamble project: the disk digest can match even though
+ * the checker resolved augmented text. The reader must compare the bytes it
+ * actually read with `checkerDigest`, then freeze and cache that adjudication
+ * for the lifetime of its `TtscGraphMemory` snapshot.
+ *
+ * 1. Read one checker-identical file twice and assert one physical read plus an
+ *    immutable, reused line array.
+ * 2. Mutate a file after its provenance was captured and assert the mismatch is
+ *    rejected and cached even if the disk later reverts.
+ * 3. Model a source-preamble divergence and an I/O failure, asserting neither can
+ *    be presented as checker text and neither is retried.
+ * 4. Build the minimal synthetic memory used by internal resolver tests and assert
+ *    an absent provenance manifest fails closed without crashing.
+ */
+export const test_ttscgraph_source_reader_enforces_snapshot_identity_once =
+  async () => {
+    const graphRoot = path.dirname(
+      createRequire(import.meta.url).resolve("@ttsc/graph/package.json"),
+    );
+    const module = (await import(
+      pathToFileURL(
+        path.join(graphRoot, "lib", "model", "TtscGraphSourceReader.js"),
+      ).href
+    )) as { TtscGraphSourceReader: SourceReaderConstructor };
+    const Reader = module.TtscGraphSourceReader;
+
+    const stable = "export const stable = 1;\n";
+    let stableReads = 0;
+    const stableReader = new Reader(
+      "C:/project",
+      {
+        capabilities: ["sourceDigests", "diskDigests"],
+        sources: [
+          {
+            file: "src/stable.ts",
+            checkerDigest: digest(stable),
+            diskDigest: digest(stable),
+          },
+        ],
+      },
+      () => {
+        stableReads++;
+        return Buffer.from(stable, "utf8");
+      },
+    );
+    const first = stableReader.lines("src/stable.ts");
+    const second = stableReader.lines("src/stable.ts");
+    assert.deepEqual(first, ["export const stable = 1;", ""]);
+    assert.strictEqual(second, first, "the immutable snapshot array is reused");
+    assert.equal(stableReads, 1, "a successful file is read once per snapshot");
+    assert.ok(Object.isFrozen(first), "cached source lines are immutable");
+
+    const before = "export const before = 1;\n";
+    let current = "export const after = 2;\n";
+    let mutationReads = 0;
+    const mutatedReader = new Reader(
+      "C:/project",
+      {
+        capabilities: ["sourceDigests", "diskDigests"],
+        sources: [
+          {
+            file: "src/mutated.ts",
+            checkerDigest: digest(before),
+            diskDigest: digest(before),
+          },
+        ],
+      },
+      () => {
+        mutationReads++;
+        return Buffer.from(current, "utf8");
+      },
+    );
+    assert.equal(
+      mutatedReader.lines("src/mutated.ts"),
+      undefined,
+      "post-snapshot bytes cannot be mixed with the older graph",
+    );
+    current = before;
+    assert.equal(
+      mutatedReader.lines("src/mutated.ts"),
+      undefined,
+      "a failed snapshot adjudication is stable, not timing-dependent",
+    );
+    assert.equal(mutationReads, 1, "digest mismatches are cached as failures");
+
+    const disk = "export const disk = true;\n";
+    const checker = "declare const injected: number;\n" + disk;
+    let preambleReads = 0;
+    const preambleReader = new Reader(
+      "C:/project",
+      {
+        capabilities: ["sourceDigests", "diskDigests"],
+        sources: [
+          {
+            file: "src/preamble.ts",
+            checkerDigest: digest(checker),
+            diskDigest: digest(disk),
+          },
+        ],
+      },
+      () => {
+        preambleReads++;
+        return Buffer.from(disk, "utf8");
+      },
+    );
+    assert.equal(
+      preambleReader.lines("src/preamble.ts"),
+      undefined,
+      "disk-identical preamble sources are not checker-identical sources",
+    );
+    assert.equal(preambleReads, 1);
+
+    let failureReads = 0;
+    const failureReader = new Reader(
+      "C:/project",
+      {
+        capabilities: ["sourceDigests"],
+        sources: [
+          {
+            file: "src/missing.ts",
+            checkerDigest: digest("missing"),
+            diskDigest: "",
+          },
+        ],
+      },
+      () => {
+        failureReads++;
+        throw new Error("missing");
+      },
+    );
+    assert.equal(failureReader.lines("src/missing.ts"), undefined);
+    assert.equal(failureReader.lines("src/missing.ts"), undefined);
+    assert.equal(failureReads, 1, "I/O failures are cached per snapshot");
+
+    let absentReads = 0;
+    const absentReader = new Reader("C:/project", undefined, () => {
+      absentReads++;
+      return Buffer.from(stable, "utf8");
+    });
+    assert.equal(absentReader.lines("src/stable.ts"), undefined);
+    assert.equal(
+      absentReads,
+      0,
+      "synthetic graph memories without provenance fail closed before disk I/O",
+    );
+
+    const memoryModule = (await import(
+      pathToFileURL(path.join(graphRoot, "lib", "model", "TtscGraphMemory.js"))
+        .href
+    )) as {
+      TtscGraphMemory: {
+        from(dump: unknown): { source: SourceReader };
+      };
+    };
+    const synthetic = memoryModule.TtscGraphMemory.from({
+      project: "C:/project",
+      nodes: [],
+      edges: [],
+    });
+    assert.equal(
+      synthetic.source.lines("src/stable.ts"),
+      undefined,
+      "a no-manifest synthetic memory remains usable and source-free",
+    );
+  };

--- a/tests/test-graph/src/internal/nativeSession.ts
+++ b/tests/test-graph/src/internal/nativeSession.ts
@@ -3,7 +3,7 @@ import { TestProject } from "@ttsc/testing";
 import fs from "node:fs";
 import path from "node:path";
 
-const DUMP_SCHEMA_VERSION = 4;
+const DUMP_SCHEMA_VERSION = 5;
 let fakeBinary: string | undefined;
 
 export interface NativeSessionFixture {

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -60,6 +60,9 @@ A text search or a tree-sitter parse stops where the syntax stops. A real type c
 - **Barrel re-exports.** An `index.ts` that only re-exports is unwrapped to the file that actually declares the symbol.
 - **Your code vs the world.** Anything in `node_modules` or a `.d.ts` is reported as an outside boundary, not walked into. The graph stays your code.
 - **Generated code stays out of the way.** A source file your `.gitignore` covers, such as a Prisma client or other codegen emitted as `.ts`, is de-ranked: it never dominates a broad or keyword match, though it stays reachable as an edge target and by its exact name. The graph surfaces what you wrote, not what a generator did.
+- **Object-literal ownership.** `details` lists direct, statically named properties in declaration order. Spread properties do not promote names from another object, dynamic computed names are omitted, and nested members stay with their nested object.
+
+Source-derived display text is fail-closed. The server reuses a file only when its current bytes match the compiler snapshot digest; a missing digest, read failure, or mismatch omits the optional text instead of mixing live-disk content into older graph facts.
 
 ## Get started
 


### PR DESCRIPTION
## Intent

Keep object-literal detail members on the immutable compiler snapshot and remove request-time source reconstruction.

Closes #757.
Closes #764.

## Implemented

- Native graph schema v5 carries direct, statically named object-literal member identity, bounded signatures, evidence, and documentation.
- Spread and dynamic computed members are omitted instead of guessed.
- Details reuse snapshot-owned source text and fail closed when snapshot identity or digest no longer matches.
- Legal duplicate variable declarations cannot mix the first node with a later initializer.
- Signature compaction preserves whitespace inside strings, regular expressions, and multiline templates.
- The lifecycle test fixture emits schema v5.
- ITtscGraphApplication and TtscGraphApplication remain untouched.

## Verification

- Native graph and ttscgraph Go suites: pass.
- Focused duplicate-declaration, literal-whitespace/template, and snapshot-member regressions: pass.
- Go vet: pass.
- Full Graph end-to-end suite: 39/39.
- @ttsc/graph build and viewer bundle: pass.
- graph and test-graph TypeScript checks: pass.
- Changed-file Prettier, git diff check, and protected-file diff zero: pass.

Website-wide typecheck was unavailable in this isolated worktree because its Nextra/React dependencies are not linked; the only website change is formatted MDX prose. No paid AI/model benchmark was run or used as a merge gate, by owner direction.