### PR TITLE
fix(graph): attest every resident source

### DIFF
--- a/packages/ttsc/internal/graph/build.go
+++ b/packages/ttsc/internal/graph/build.go
@@ -28,12 +28,20 @@ func Build(prog *driver.Program) *Graph {
   return g
 }
 
-// SourceTexts maps each program source file to its text — the evidence input
-// NewDump needs to turn a node or edge byte span into a line/column.
+// SourceTexts maps every program source to the resident checker text.
+// Declaration and virtual bundled files are included because external graph
+// leaves still carry facts and spans the source manifest must attest to.
 func SourceTexts(prog *driver.Program) map[string]string {
-  files := prog.SourceFiles()
+  if prog == nil || prog.TSProgram == nil {
+    return map[string]string{}
+  }
+  _ = prog.ApplyLinkedPlugins()
+  files := prog.TSProgram.SourceFiles()
   out := make(map[string]string, len(files))
   for _, file := range files {
+    if file == nil {
+      continue
+    }
     out[file.FileName()] = file.Text()
   }
   return out

--- a/packages/ttsc/internal/graph/source_texts_cover_every_resident_program_source_test.go
+++ b/packages/ttsc/internal/graph/source_texts_cover_every_resident_program_source_test.go
@@ -1,0 +1,73 @@
+package graph
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimtspath "github.com/microsoft/typescript-go/shim/tspath"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestSourceTextsCoverEveryResidentProgramSource verifies that snapshot
+// evidence includes every class of source the checker loaded.
+//
+// External graph leaves still carry checker-derived facts and spans. Omitting
+// their resident text from the source manifest leaves those facts without the
+// byte identity that the sourceDigests capability promises. Virtual bundled
+// libraries need the same checker digest even though they have no disk digest.
+//
+//  1. Compile a project that calls a function declared by an outside `.d.ts`.
+//  2. Build the graph and capture the resident program's source texts.
+//  3. Assert both the outside declaration and a virtual bundled library are in
+//     the checker-text manifest.
+func TestSourceTextsCoverEveryResidentProgramSource(t *testing.T) {
+  workspace := t.TempDir()
+  root := filepath.Join(workspace, "app")
+  declaration := filepath.Join(workspace, "dependency", "index.d.ts")
+  writeFile(t, filepath.Join(root, "tsconfig.json"), fixtureTSConfig)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), `import { external } from "../../dependency";
+
+export const value = external();
+`)
+  writeFile(t, declaration, `export declare function external(): number;
+`)
+  declaration = shimtspath.ResolvePath(declaration)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diags)
+  }
+  defer func() { _ = prog.Close() }()
+
+  built := Build(prog)
+  hasExternalFact := false
+  for _, node := range built.Nodes {
+    if node.External && node.File == declaration {
+      hasExternalFact = true
+      break
+    }
+  }
+  if !hasExternalFact {
+    t.Fatalf("graph has no external fact from %s", declaration)
+  }
+
+  texts := SourceTexts(prog)
+  if got, ok := texts[declaration]; !ok || got != "export declare function external(): number;\n" {
+    t.Fatalf("declaration source text = %q, present %v", got, ok)
+  }
+  hasBundledSource := false
+  for path := range texts {
+    if strings.HasPrefix(path, "bundled:///") {
+      hasBundledSource = true
+      break
+    }
+  }
+  if !hasBundledSource {
+    t.Fatal("source manifest has no virtual bundled library")
+  }
+}

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -62,7 +62,7 @@ A text search or a tree-sitter parse stops where the syntax stops. A real type c
 - **Generated code stays out of the way.** A source file your `.gitignore` covers, such as a Prisma client or other codegen emitted as `.ts`, is de-ranked: it never dominates a broad or keyword match, though it stays reachable as an edge target and by its exact name. The graph surfaces what you wrote, not what a generator did.
 - **Object-literal ownership.** `details` lists direct, statically named properties in declaration order. Spread properties do not promote names from another object, dynamic computed names are omitted, and nested members stay with their nested object.
 
-Source-derived display text is fail-closed. The server reuses a file only when its current bytes match the compiler snapshot digest; a missing digest, read failure, or mismatch omits the optional text instead of mixing live-disk content into older graph facts.
+Source-derived display text is fail-closed. The snapshot manifest covers every source the checker loaded, including outside `.d.ts` boundary leaves and virtual compiler libraries. The server reuses a disk file only when its current bytes match the compiler snapshot digest; a missing digest, read failure, or mismatch omits the optional text instead of mixing live-disk content into older graph facts.
 
 ## Get started
 


### PR DESCRIPTION
## Intent

Make schema v5 provenance prove every graph fact against the exact resident compiler generation that produced it. External declaration nodes and virtual compiler-library targets previously escaped the source manifest because `SourceTexts` used the user-source-only driver view.

Closes #780.

## Scope

- Capture checker text from every resident `TSProgram.SourceFiles()` entry after linked program plugins apply.
- Preserve outside `.d.ts` and `bundled:///` identities in source digests; virtual sources retain an empty disk digest through the existing hashing contract.
- Add a regression that proves an outside declaration contributes a graph fact and that both it and a bundled library enter the checker-text manifest.
- Document the complete snapshot-manifest guarantee.

## Deferred

None.

## Verification

- `pnpm format`
- `go test ./internal/graph ./cmd/ttscgraph -count=1`
- Built `ttscgraph.exe` from this branch with `go build ./cmd/ttscgraph`.
- Used that binary through `TTSC_GRAPH_BINARY` against `@samchon/graph-sitter`: strict `lsp`, 558 nodes, 1,522 edges, zero warnings.
- Used that binary through `TTSC_GRAPH_BINARY` against `@samchon/graph`: strict `lsp`, 1,325 nodes, 4,600 edges, zero warnings.

## Not run locally

- Full workspace TypeScript feature suite; CI is authoritative for unrelated packages.
