### PR TITLE
release: prepare manifest-complete ttscgraph 0.19.4

### DIFF
--- a/.github/workflows/typia.yml
+++ b/.github/workflows/typia.yml
@@ -22,8 +22,9 @@ jobs:
     timeout-minutes: 60
     env:
       # Only build + pack the current platform (ttsc-linux-x64) — typia's
-      # overrides below pull in ttsc.tgz + ttsc-linux-x64.tgz only. The full
-      # cross-platform matrix takes ~20 min for tarballs we never consume.
+      # overrides below pull in ttsc.tgz, unplugin.tgz, and the current native
+      # package. The full cross-platform matrix takes ~20 min for tarballs we
+      # never consume.
       TTSC_TARBALLS_CURRENT: "1"
     steps:
       - uses: actions/checkout@v4
@@ -69,13 +70,22 @@ jobs:
           const file = "pnpm-workspace.yaml";
           const entries = [
             "  ttsc: file:../tarballs/ttsc.tgz",
+            "  \"@ttsc/unplugin\": file:../tarballs/unplugin.tgz",
             "  \"@ttsc/linux-x64\": file:../tarballs/ttsc-linux-x64.tgz",
           ].join("\n");
           const text = fs.readFileSync(file, "utf8");
-          if (text.includes("file:../tarballs/ttsc.tgz")) process.exit(0);
+          const localTarballs = entries.split("\n").map((entry) => entry.trim());
+          const present = localTarballs.filter((entry) => text.includes(entry));
+          if (present.length === localTarballs.length) process.exit(0);
+          if (present.length !== 0) {
+            throw new Error(`partial local-tarball overrides: ${present.join(", ")}`);
+          }
           const merged = /^overrides:[ \t]*$/m.test(text)
             ? text.replace(/^overrides:[ \t]*$/m, (line) => line + "\n" + entries)
             : text.replace(/\s*$/, "") + "\n\noverrides:\n" + entries + "\n";
+          for (const entry of localTarballs) {
+            if (!merged.includes(entry)) throw new Error(`missing local override: ${entry}`);
+          }
           fs.writeFileSync(file, merged);
           '
 

--- a/.github/workflows/typia.yml
+++ b/.github/workflows/typia.yml
@@ -67,6 +67,7 @@ jobs:
           # instead, creating the block only when typia drops it.
           node -e '
           const fs = require("fs");
+          const path = require("path");
           const file = "pnpm-workspace.yaml";
           const entries = [
             "  ttsc: file:../tarballs/ttsc.tgz",
@@ -76,17 +77,50 @@ jobs:
           const text = fs.readFileSync(file, "utf8");
           const localTarballs = entries.split("\n").map((entry) => entry.trim());
           const present = localTarballs.filter((entry) => text.includes(entry));
-          if (present.length === localTarballs.length) process.exit(0);
-          if (present.length !== 0) {
+          if (present.length !== 0 && present.length !== localTarballs.length) {
             throw new Error(`partial local-tarball overrides: ${present.join(", ")}`);
           }
-          const merged = /^overrides:[ \t]*$/m.test(text)
-            ? text.replace(/^overrides:[ \t]*$/m, (line) => line + "\n" + entries)
-            : text.replace(/\s*$/, "") + "\n\noverrides:\n" + entries + "\n";
+          const merged = present.length === localTarballs.length
+            ? text
+            : /^overrides:[ \t]*$/m.test(text)
+              ? text.replace(/^overrides:[ \t]*$/m, (line) => line + "\n" + entries)
+              : text.replace(/\s*$/, "") + "\n\noverrides:\n" + entries + "\n";
           for (const entry of localTarballs) {
             if (!merged.includes(entry)) throw new Error(`missing local override: ${entry}`);
           }
           fs.writeFileSync(file, merged);
+
+          // pnpm 10 does not apply a file override to an auto-installed exact
+          // peer. Give importers that consume only @ttsc/unplugin an explicit
+          // local ttsc so they cannot resolve the unpublished candidate from npm.
+          const ttscTarball = path.resolve("../tarballs/ttsc.tgz");
+          const dependencySections = [
+            "dependencies",
+            "devDependencies",
+            "optionalDependencies",
+            "peerDependencies",
+          ];
+          const visit = (directory) => {
+            for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+              if (entry.name === ".git" || entry.name === "node_modules") continue;
+              const target = path.join(directory, entry.name);
+              if (entry.isDirectory()) visit(target);
+              else if (entry.name === "package.json") patchImporter(target);
+            }
+          };
+          const patchImporter = (manifestFile) => {
+            const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
+            const has = (name) => dependencySections.some(
+              (section) => manifest[section]?.[name] !== undefined,
+            );
+            if (!has("@ttsc/unplugin") || has("ttsc")) return;
+            manifest.devDependencies ??= {};
+            const relative = path.relative(path.dirname(manifestFile), ttscTarball)
+              .replaceAll(path.sep, "/");
+            manifest.devDependencies.ttsc = `file:${relative}`;
+            fs.writeFileSync(manifestFile, `${JSON.stringify(manifest, null, 2)}\n`);
+          };
+          visit(".");
           '
 
       - name: Test typia next

--- a/config/package.json
+++ b/config/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/config",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Shared build configuration for ttsc packages.",
   "devDependencies": {
     "@rollup/plugin-commonjs": "catalog:rollup",

--- a/experimental/tarballs/index.ts
+++ b/experimental/tarballs/index.ts
@@ -50,7 +50,14 @@ function build(target: { dir: string; name: string; tarballName: string }) {
   const out = path.join(outputDir, `${target.tarballName}.tgz`);
   fs.rmSync(out, { force: true });
 
-  const result = cp.spawnSync("pnpm", ["pack", "--out", out], {
+  const pack =
+    process.platform === "win32"
+      ? {
+          command: process.env.ComSpec ?? "cmd.exe",
+          args: ["/d", "/s", "/c", "pnpm", "pack", "--out", out],
+        }
+      : { command: "pnpm", args: ["pack", "--out", out] };
+  const result = cp.spawnSync(pack.command, pack.args, {
     cwd: target.dir,
     encoding: "utf8",
     windowsHide: true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/station",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Standalone TypeScript-Go compiler, runtime, plugin host, and LSP host workspace.",
   "scripts": {
     "build": "node scripts/build-platforms.cjs",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/banner",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "First-party ttsc plugin that adds package-documentation JSDoc banners during emit.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/factory/package.json
+++ b/packages/factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/factory",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Self-contained legacy-style TypeScript AST factory and printer for source code generation, surviving the TypeScript-Go (tsgo) migration. Zero dependencies, no `typescript` import.",
   "main": "src/index.ts",
   "exports": {

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/graph",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Checker-resolved architecture graph over MCP for coding agents, backed by ttsc's in-process TypeScript-Go compiler.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/lint",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Reference ttsc plugin: ESLint-style lint rules over the TypeScript-Go Program used by the type-check pass.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/metro",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Metro (React Native / Expo) adapter for ttsc plugins.",
   "main": "lib/index.js",
   "module": "lib/index.mjs",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/paths",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "First-party ttsc plugin that rewrites emitted module specifiers from tsconfig paths.",
   "main": "src/index.cjs",
   "exports": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/playground",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Reusable React + Web Worker scaffolding for in-browser ttsc playgrounds built on @ttsc/wasm.",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/strip",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "First-party ttsc plugin that removes configured calls and statements from emitted JavaScript.",
   "main": "src/index.cjs",
   "types": "src/index.d.ts",

--- a/packages/ttsc-darwin-arm64/package.json
+++ b/packages/ttsc-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/darwin-arm64",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "macOS arm64 native ttsc/ttscserver/ttscgraph binaries and bundled Go compiler for ttsc.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/packages/ttsc-darwin-x64/package.json
+++ b/packages/ttsc-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/darwin-x64",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "macOS x64 native ttsc/ttscserver/ttscgraph binaries and bundled Go compiler for ttsc.",
   "os": ["darwin"],
   "cpu": ["x64"],

--- a/packages/ttsc-linux-arm/package.json
+++ b/packages/ttsc-linux-arm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/linux-arm",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Linux arm native ttsc/ttscserver/ttscgraph binaries and bundled Go compiler for ttsc.",
   "os": ["linux"],
   "cpu": ["arm"],

--- a/packages/ttsc-linux-arm64/package.json
+++ b/packages/ttsc-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/linux-arm64",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Linux arm64 native ttsc/ttscserver/ttscgraph binaries and bundled Go compiler for ttsc.",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/packages/ttsc-linux-x64/package.json
+++ b/packages/ttsc-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/linux-x64",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Linux x64 native ttsc/ttscserver/ttscgraph binaries and bundled Go compiler for ttsc.",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/packages/ttsc-win32-arm64/package.json
+++ b/packages/ttsc-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/win32-arm64",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Windows arm64 native ttsc/ttscserver/ttscgraph binaries and bundled Go compiler for ttsc.",
   "os": ["win32"],
   "cpu": ["arm64"],

--- a/packages/ttsc-win32-x64/package.json
+++ b/packages/ttsc-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/win32-x64",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Windows x64 native ttsc/ttscserver/ttscgraph binaries and bundled Go compiler for ttsc.",
   "os": ["win32"],
   "cpu": ["x64"],

--- a/packages/ttsc/package.json
+++ b/packages/ttsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttsc",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "General-purpose TypeScript-Go compiler, runtime, plugin host, and LSP host.",
   "main": "lib/index.js",
   "types": "src/index.ts",

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/unplugin",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Bundler adapters for ttsc plugins.",
   "main": "lib/index.js",
   "module": "lib/index.mjs",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "@ttsc/vscode",
   "displayName": "ttsc",
   "description": "Show ttsc plugin diagnostics in VS Code, with @ttsc/lint errors, fix-all actions, and formatter support.",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "publisher": "samchon",
   "icon": "images/icon.png",
   "license": "MIT",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/wasm",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Build in-browser ttsc playgrounds. Compose ttsc + typescript-go with your own plugins via the Go host helper.",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/tests/lint-contributor-demo/package.json
+++ b/tests/lint-contributor-demo/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "lint-contributor-demo",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Test-only contributor plugin for @ttsc/lint exercising the contributors descriptor field.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/tests/test-banner/package.json
+++ b/tests/test-banner/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-banner",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "@ttsc/banner project-shape feature tests.",
   "type": "module",
   "scripts": {

--- a/tests/test-factory/package.json
+++ b/tests/test-factory/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-factory",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "@ttsc/factory behavior feature tests.",
   "type": "module",
   "scripts": {

--- a/tests/test-graph/package.json
+++ b/tests/test-graph/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-graph",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "@ttsc/graph MCP server end-to-end tests.",
   "type": "module",
   "scripts": {

--- a/tests/test-lint/package.json
+++ b/tests/test-lint/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-lint",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "@ttsc/lint descriptor, config, and rule corpus tests.",
   "type": "module",
   "scripts": {

--- a/tests/test-metro/package.json
+++ b/tests/test-metro/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-metro",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Adapter and transform tests for @ttsc/metro.",
   "type": "module",
   "scripts": {

--- a/tests/test-paths/package.json
+++ b/tests/test-paths/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-paths",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "@ttsc/paths project-shape feature tests.",
   "type": "module",
   "scripts": {

--- a/tests/test-playground/package.json
+++ b/tests/test-playground/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-playground",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "@ttsc/playground worker plugin-failure, npm-discovery, and sandbox feature tests.",
   "type": "module",
   "scripts": {

--- a/tests/test-strip/package.json
+++ b/tests/test-strip/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-strip",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "@ttsc/strip project-shape feature tests.",
   "type": "module",
   "scripts": {

--- a/tests/test-ttsc/package.json
+++ b/tests/test-ttsc/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-ttsc",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Compiler, API, plugin host, platform, and utility plugin integration tests for ttsc.",
   "type": "module",
   "scripts": {

--- a/tests/test-unplugin/package.json
+++ b/tests/test-unplugin/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-unplugin",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Adapter entrypoint and transform tests for @ttsc/unplugin.",
   "type": "module",
   "scripts": {

--- a/tests/test-wasm/package.json
+++ b/tests/test-wasm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/test-wasm",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "@ttsc/wasm MemFS mutation and boot-lifecycle feature tests.",
   "type": "module",
   "scripts": {

--- a/tests/utils/package.json
+++ b/tests/utils/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ttsc/testing",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Shared test-only helpers for ttsc workspace packages.",
   "type": "module",
   "exports": {

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttsc/website",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "ttsc Guide Documents, Tutorial, and Playground.",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Intent

Make the merged manifest-complete schema-5 `ttscgraph` producer installable as the next lockstep release candidate.

## Scope

- Advance all 35 workspace package manifests from 0.19.3 to 0.19.4.
- Keep the change version-only except for release-path repairs required to verify unpublished 0.19.4 artifacts.
- Make the external typia smoke consume local `ttsc` and `@ttsc/unplugin` tarballs together, including importers that previously received npm's 0.19.3 peer.
- Make Windows tarball packing invoke pnpm through `cmd.exe` without enabling a general shell.
- Do not create or push a tag; this PR cannot publish.

## Verification

- `node scripts/release-preflight.cjs --tag v0.19.4` — passed; 19 publishable packages match.
- `pnpm install --frozen-lockfile` — passed.
- `TTSC_TARBALLS_CURRENT=1 pnpm package:tgz` — passed on Windows; seven current tarballs produced, including the platform package.
- Extracted typia workflow transform applied twice — passed and remained idempotent.
- `pnpm install --no-frozen-lockfile --ignore-scripts` in the transformed external typia clone — passed using unpublished local 0.19.4 tarballs.
- Upstream manifest repair PR #781 — merged after 56/56 checks passed.

## Remaining pre-tag gates

- Let ordinary CI settle green on the release-candidate SHA.
- Execute `ttscgraph` against an outside `.d.ts` plus `bundled:///` fixture and prove schema 5 manifest completeness from the release artifact.
- Obtain explicit release-owner authorization before pushing `v0.19.4`; that tag starts npm and VS Code Marketplace publication immediately.
- After registry publication, clean-install a platform package and repeat the strict manifest smoke. Never reuse 0.19.4 after a partial publication; fix forward.

Related: #782, #787, #791

Merging this PR alone does not close #782 because the tagged release and registry smoke remain operational gates.