### PR TITLE
feat(lint): deliver rule-published completion to VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ experimental/nestia/
 # Benchmark results — an ephemeral artifact, never committed.
 experimental/benchmark/.work/
 
+# Promotional media. Rendered locally, published as GitHub-hosted attachments,
+# and referenced by URL from the website. The binaries never enter the repository.
+/.media/
+
 # Stray native sanity binary from `go build ./cmd/ttsc-wasm` (host build).
 packages/wasm/ttsc-wasm
 

--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -158,7 +158,8 @@ type RuleResolver interface {
   RuleOptions(name string) json.RawMessage
   // ResolveProjectRules folds global declarations for registered project-rule
   // names. A mention under a files selector is rejected because project state
-  // has no file identity.
+  // has no file identity, except when the same built-in name also owns a file
+  // rule; that scoped declaration remains exclusively file-local.
   ResolveProjectRules(names []string) (map[string]ProjectRuleSetting, error)
 }
 
@@ -517,8 +518,10 @@ func (s *ConfigStore) EnabledRuleConfig() RuleConfig {
 }
 
 // ResolveProjectRules folds the extends-expanded entries base-first. Only
-// global entries participate; any project-rule mention under files is an
-// invalid configuration, including off declarations and option tuples.
+// global entries participate. A project-only rule mentioned under files is an
+// invalid configuration, including off declarations and option tuples. A
+// built-in companion sharing a file-rule name ignores that scoped declaration
+// so the file rule can retain its existing per-file configuration.
 func (s *ConfigStore) ResolveProjectRules(names []string) (map[string]ProjectRuleSetting, error) {
   out := make(map[string]ProjectRuleSetting, len(names))
   wanted := make(map[string]string, len(names))
@@ -540,6 +543,13 @@ func (s *ConfigStore) ResolveProjectRules(names []string) (map[string]ProjectRul
         continue
       }
       if entry.HasFilesSelector {
+        // A built-in project companion shares its public name with a file
+        // rule. Keep the file-scoped declaration for that file rule, but do
+        // not turn it into project-wide state: only a global declaration can
+        // activate the companion and its consumers.
+        if LookupRule(name) != nil {
+          continue
+        }
         return nil, fmt.Errorf(
           "@ttsc/lint: project rule %q cannot be configured in an entry with files",
           name,

--- a/packages/lint/linthost/engine.go
+++ b/packages/lint/linthost/engine.go
@@ -669,11 +669,11 @@ func NewEngineWithResolver(config RuleResolver) *Engine {
     }
   }
   for _, name := range config.ActiveRuleNames() {
-    if _, isProjectRule := registeredProjectRules[name]; isProjectRule {
-      continue
-    }
     rule, ok := registered.rules[name]
     if !ok {
+      if _, isProjectRule := registeredProjectRules[name]; isProjectRule {
+        continue
+      }
       eng.unknown = append(eng.unknown, name)
       continue
     }

--- a/packages/lint/linthost/project_rules.go
+++ b/packages/lint/linthost/project_rules.go
@@ -27,6 +27,35 @@ type projectRuleAdapter struct {
 
 var registeredProjectRules = map[string]projectRuleAdapter{}
 
+// registerBuiltInProjectCompanion attaches a project lifecycle to an existing
+// built-in file rule. Both halves deliberately share one public rule name and
+// therefore one config setting: the file rule keeps reporting source ranges,
+// while the project companion can publish finished state for consumers such as
+// editor hints.
+//
+// Contributor rules remain single-lifecycle registrations. Their collision
+// checks in registerProjectContributors still reject a file/project name pair,
+// because only built-ins can be audited together as one rule implementation.
+func registerBuiltInProjectCompanion(project publicrule.ProjectRule) {
+  adapter, err := inspectProjectContributor(project)
+  if err != nil {
+    panic(fmt.Sprintf("@ttsc/lint: invalid built-in project companion: %v", err))
+  }
+  if adapter.name == "" {
+    panic("@ttsc/lint: built-in project companion has an empty name")
+  }
+  if LookupRule(adapter.name) == nil {
+    panic(fmt.Sprintf("@ttsc/lint: built-in project companion %q has no file rule", adapter.name))
+  }
+  if _, builtIn := builtInRuleCodes[adapter.name]; !builtIn {
+    panic(fmt.Sprintf("@ttsc/lint: project companion %q is not a built-in rule", adapter.name))
+  }
+  if _, exists := registeredProjectRules[adapter.name]; exists {
+    panic(fmt.Sprintf("@ttsc/lint: project rule %q registered twice", adapter.name))
+  }
+  registeredProjectRules[adapter.name] = adapter
+}
+
 func registerProjectContributors() {
   projects := publicrule.RegisteredProjects()
   adapters := make([]projectRuleAdapter, 0, len(projects))

--- a/packages/lint/linthost/rules_jsdoc.go
+++ b/packages/lint/linthost/rules_jsdoc.go
@@ -1,14 +1,67 @@
 package linthost
 
 import (
+  "sort"
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
 )
 
 type jsdocLintRule struct {
   name  string
   check func(*Context, string, parsedJSDocBlock)
+}
+
+type jsdocCheckTagNamesHintRule struct{}
+
+type jsdocCheckTagNamesHintState struct{}
+
+func (jsdocCheckTagNamesHintRule) Name() string { return "jsdoc/check-tag-names" }
+func (jsdocCheckTagNamesHintRule) Check(ctx *publicrule.ProjectContext) {
+  ctx.SetState(jsdocCheckTagNamesHintState{})
+}
+func (jsdocCheckTagNamesHintRule) AcceptsTtscLintOptions() bool { return false }
+func (jsdocCheckTagNamesHintRule) NeedsTypeChecker() bool       { return false }
+func (jsdocCheckTagNamesHintRule) Hints(ctx *publicrule.HintContext) []publicrule.Hint {
+  if ctx == nil {
+    return nil
+  }
+  if _, ok := ctx.State.(jsdocCheckTagNamesHintState); !ok {
+    return nil
+  }
+  tags := make([]string, 0, len(knownJSDocTags))
+  for tag := range knownJSDocTags {
+    tags = append(tags, tag)
+  }
+  sort.Strings(tags)
+  hints := make([]publicrule.Hint, 0, len(tags))
+  for _, tag := range tags {
+    hints = append(hints, publicrule.Hint{
+      Insert: tag,
+      Detail: jsdocTagHintDetail(tag),
+      Trigger: publicrule.HintTrigger{
+        Scope: publicrule.HintScopeJSDoc,
+        After: "@",
+      },
+    })
+  }
+  return hints
+}
+
+func jsdocTagHintDetail(tag string) string {
+  normalized := strings.ToLower(tag)
+  if canonical, alias := jsdocTagSynonyms[normalized]; alias {
+    return "alias for @" + canonical
+  }
+  if _, typed := jsdocTagsWithType[normalized]; typed {
+    return "accepts a type"
+  }
+  if _, empty := emptyJSDocTags[normalized]; empty {
+    return "no content"
+  }
+  return "JSDoc tag"
 }
 
 func (r jsdocLintRule) Name() string { return r.name }
@@ -488,6 +541,7 @@ func checkJSDocEmptyTags(ctx *Context, _ string, block parsedJSDocBlock) {
 
 func init() {
   Register(jsdocLintRule{name: "jsdoc/check-tag-names", check: checkJSDocTagNames})
+  registerBuiltInProjectCompanion(jsdocCheckTagNamesHintRule{})
   Register(jsdocLintRule{name: "jsdoc/check-values", check: checkJSDocCheckValues})
   Register(jsdocLintRule{name: "jsdoc/empty-tags", check: checkJSDocEmptyTags})
   Register(jsdocLintRule{name: "jsdoc/no-types", check: checkJSDocNoTypes})

--- a/packages/lint/test/command/lsp_hints_publishes_jsdoc_check_tag_names_corpus_test.go
+++ b/packages/lint/test/command/lsp_hints_publishes_jsdoc_check_tag_names_corpus_test.go
@@ -1,0 +1,51 @@
+package linthost
+
+import (
+  "encoding/json"
+  "testing"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestLSPHintsPublishesJSDocCheckTagNamesCorpus verifies the real sidecar verb
+// carries the built-in tag corpus across the process boundary.
+//
+// Direct collection alone would not pin config discovery, Program loading, or
+// JSON serialization. This fixture enables the rule in a discovered lint
+// config and asks through the same command ttscserver invokes.
+//
+//  1. Seed a valid TypeScript project with the JSDoc validator enabled.
+//  2. Run lsp-hints through the command dispatcher and decode its JSON.
+//  3. Assert a representative typed tag retains its trigger and detail.
+func TestLSPHintsPublishesJSDocCheckTagNamesCorpus(t *testing.T) {
+  root := seedLintProject(t, "/** Public value. */\nexport const value = 1;\n")
+  seedLintRules(t, root, map[string]string{"jsdoc/check-tag-names": "warn"})
+
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    return run([]string{
+      "lsp-hints",
+      "--cwd", root,
+      "--plugins-json", lintManifest(t),
+    })
+  })
+  if code != 0 || stderr != "" {
+    t.Fatalf("lsp-hints mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  var hints []publicrule.Hint
+  if err := json.Unmarshal([]byte(stdout), &hints); err != nil {
+    t.Fatalf("lsp-hints JSON: %v\n%s", err, stdout)
+  }
+  if len(hints) != len(knownJSDocTags) {
+    t.Fatalf("want %d known-tag hints, got %d", len(knownJSDocTags), len(hints))
+  }
+  for _, hint := range hints {
+    if hint.Insert != "param" {
+      continue
+    }
+    if hint.Detail != "accepts a type" || hint.Trigger.Scope != publicrule.HintScopeJSDoc || hint.Trigger.After != "@" {
+      t.Fatalf("@param hint lost its wire metadata: %#v", hint)
+    }
+    return
+  }
+  t.Fatal("lsp-hints omitted @param")
+}

--- a/packages/lint/test/config/project_companion_preserves_file_scoped_rule_config_test.go
+++ b/packages/lint/test/config/project_companion_preserves_file_scoped_rule_config_test.go
@@ -1,0 +1,40 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestProjectCompanionPreservesFileScopedRuleConfig verifies adding editor
+// state to a built-in file rule does not make its existing scoped config
+// illegal or project-wide.
+//
+// Project state has no file identity, so the companion may run only from a
+// global declaration. The matching file rule must still receive a files entry
+// exactly as before, while the companion remains not evaluated.
+//
+//  1. Parse a files-scoped jsdoc/check-tag-names declaration.
+//  2. Resolve both project and matching-file views of that config.
+//  3. Assert the file rule is enabled and the companion is undeclared.
+func TestProjectCompanionPreservesFileScopedRuleConfig(t *testing.T) {
+  const name = "jsdoc/check-tag-names"
+  root := t.TempDir()
+  store, err := parseExternalConfigStore(map[string]any{
+    "files": []any{"src/**"},
+    "rules": map[string]any{name: "warn"},
+  }, root)
+  if err != nil {
+    t.Fatalf("parse scoped companion config: %v", err)
+  }
+  settings, err := store.ResolveProjectRules([]string{name})
+  if err != nil {
+    t.Fatalf("file-scoped companion declaration should remain valid: %v", err)
+  }
+  if settings[name].Declared {
+    t.Fatalf("file-scoped declaration leaked into project state: %#v", settings[name])
+  }
+  resolved := store.ResolveRules(filepath.Join(root, "src", "main.ts"))
+  if severity := resolved.Rules[name]; severity != SeverityWarn {
+    t.Fatalf("matching file lost its rule severity: want %v, got %v", SeverityWarn, severity)
+  }
+}

--- a/packages/lint/test/plugin/project_hint_collection_requires_passed_published_state_test.go
+++ b/packages/lint/test/plugin/project_hint_collection_requires_passed_published_state_test.go
@@ -1,0 +1,97 @@
+package linthost
+
+import (
+  "testing"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+type hintRuleTestDouble struct {
+  name  string
+  check func(*publicrule.ProjectContext)
+  hints func(*publicrule.HintContext) []publicrule.Hint
+}
+
+func (r hintRuleTestDouble) Name() string { return r.name }
+func (r hintRuleTestDouble) Check(ctx *publicrule.ProjectContext) {
+  if r.check != nil {
+    r.check(ctx)
+  }
+}
+func (r hintRuleTestDouble) Hints(ctx *publicrule.HintContext) []publicrule.Hint {
+  if r.hints == nil {
+    return nil
+  }
+  return r.hints(ctx)
+}
+
+func installHintRuleTestDouble(t *testing.T, project hintRuleTestDouble) {
+  t.Helper()
+  previous, existed := registeredProjectRules[project.name]
+  registeredProjectRules[project.name] = projectRuleAdapter{inner: project, name: project.name}
+  t.Cleanup(func() {
+    if existed {
+      registeredProjectRules[project.name] = previous
+    } else {
+      delete(registeredProjectRules, project.name)
+    }
+  })
+}
+
+// TestProjectHintCollectionRequiresPassedPublishedState verifies collection
+// cannot offer a corpus that its project rule did not finish and endorse.
+//
+// Off rules never run, failed rules disown the state they built, and a passed
+// rule without state published no corpus. Only the passed-and-published rule is
+// allowed through, and the call counter proves the other Hints methods were not
+// merely called and filtered afterward.
+//
+//  1. Install off, failed, stateless, and passed hint-rule doubles.
+//  2. Evaluate one project cycle and collect its hints.
+//  3. Assert only the passed-and-published provider was invoked and retained.
+func TestProjectHintCollectionRequiresPassedPublishedState(t *testing.T) {
+  const (
+    failedName    = "hint-test/failed"
+    offName       = "hint-test/off"
+    passedName    = "hint-test/passed"
+    statelessName = "hint-test/stateless"
+  )
+  calls := map[string]int{}
+  install := func(name string, check func(*publicrule.ProjectContext)) {
+    installHintRuleTestDouble(t, hintRuleTestDouble{
+      name:  name,
+      check: check,
+      hints: func(*publicrule.HintContext) []publicrule.Hint {
+        calls[name]++
+        return []publicrule.Hint{{
+          Insert: name,
+          Trigger: publicrule.HintTrigger{
+            Scope: publicrule.HintScopeJSDoc,
+            After: "@",
+          },
+        }}
+      },
+    })
+  }
+  install(offName, func(ctx *publicrule.ProjectContext) { ctx.SetState("off") })
+  install(failedName, func(ctx *publicrule.ProjectContext) {
+    ctx.SetState("failed")
+    ctx.Fail()
+  })
+  install(statelessName, nil)
+  install(passedName, func(ctx *publicrule.ProjectContext) { ctx.SetState("passed") })
+
+  engine := NewEngine(RuleConfig{
+    failedName:    SeverityError,
+    offName:       SeverityOff,
+    passedName:    SeverityWarn,
+    statelessName: SeverityError,
+  })
+  hints := collectProjectHints(engine.evaluateProject(publicrule.ProjectIdentity{}, nil, nil))
+  if len(hints) != 1 || hints[0].Insert != passedName {
+    t.Fatalf("only passed-and-published hints should survive: %#v", hints)
+  }
+  if len(calls) != 1 || calls[passedName] != 1 {
+    t.Fatalf("inactive providers should not be called: %#v", calls)
+  }
+}

--- a/packages/lint/test/plugin/project_hint_publication_filters_malformed_and_recovers_panic_test.go
+++ b/packages/lint/test/plugin/project_hint_publication_filters_malformed_and_recovers_panic_test.go
@@ -1,0 +1,61 @@
+package linthost
+
+import (
+  "strings"
+  "testing"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestProjectHintPublicationFiltersMalformedAndRecoversPanic verifies a broken
+// provider loses only the unusable corpus it published.
+//
+// Empty insert text, scope, or trigger literal would create a completion that
+// fires too broadly or inserts nothing, while a panic must not terminate the
+// editor-facing sidecar. The direct ruleHints seam isolates both policies from
+// project evaluation so each failure mode is intentional.
+//
+//  1. Publish one valid hint alongside every degenerate shape.
+//  2. Assert only the valid item remains in its original order.
+//  3. Panic from Hints and assert recovery returns no items and logs the rule.
+func TestProjectHintPublicationFiltersMalformedAndRecoversPanic(t *testing.T) {
+  valid := publicrule.Hint{
+    Insert: "valid",
+    Trigger: publicrule.HintTrigger{
+      Scope: publicrule.HintScopeJSDoc,
+      After: "@",
+    },
+  }
+  malformed := hintRuleTestDouble{
+    name: "hint-test/malformed",
+    hints: func(*publicrule.HintContext) []publicrule.Hint {
+      return []publicrule.Hint{
+        {},
+        {Insert: "missing-scope", Trigger: publicrule.HintTrigger{After: "@"}},
+        {Insert: "missing-after", Trigger: publicrule.HintTrigger{Scope: publicrule.HintScopeJSDoc}},
+        valid,
+      }
+    },
+  }
+  snapshot := publicrule.ProjectRuleResult{Status: publicrule.ProjectRulePassed, State: "ready"}
+  hints := ruleHints(malformed.name, malformed, projectCycleResult{}, snapshot)
+  if len(hints) != 1 || hints[0] != valid {
+    t.Fatalf("malformed hints should be dropped without disturbing valid items: %#v", hints)
+  }
+
+  panicking := hintRuleTestDouble{
+    name: "hint-test/panicking",
+    hints: func(*publicrule.HintContext) []publicrule.Hint {
+      panic("hint boom")
+    },
+  }
+  var recovered []publicrule.Hint
+  code, stdout, stderr := captureCommandOutput(t, func() int {
+    recovered = ruleHints(panicking.name, panicking, projectCycleResult{}, snapshot)
+    return 0
+  })
+  if code != 0 || stdout != "" || len(recovered) != 0 ||
+    !strings.Contains(stderr, `project rule "hint-test/panicking" panicked while publishing hints: hint boom`) {
+    t.Fatalf("panic recovery mismatch: code=%d stdout=%q stderr=%q hints=%#v", code, stdout, stderr, recovered)
+  }
+}

--- a/packages/lint/test/registry/rule_code_is_stable_test.go
+++ b/packages/lint/test/registry/rule_code_is_stable_test.go
@@ -119,7 +119,15 @@ func TestRuleCodesAreUniqueAcrossCompleteRegistry(t *testing.T) {
   allNames := append(fileRuleNames, allProjectRuleNames()...)
   sort.Strings(allNames)
   activeCodes := make(map[int32]string, len(allNames))
+  seenNames := make(map[string]struct{}, len(allNames))
   for _, name := range allNames {
+    // A built-in project companion is a second lifecycle for the same public
+    // rule identity, so it must resolve to the same ledger entry rather than
+    // count as a diagnostic-code collision with itself.
+    if _, seen := seenNames[name]; seen {
+      continue
+    }
+    seenNames[name] = struct{}{}
     code := RuleCode(name)
     if code < rulecode.Minimum || code >= rulecode.MaximumExclusive {
       t.Fatalf("active rule %q has out-of-range code %d", name, code)

--- a/packages/lint/test/rules/jsdoc/check_tag_names_publishes_canonical_hints_test.go
+++ b/packages/lint/test/rules/jsdoc/check_tag_names_publishes_canonical_hints_test.go
@@ -1,0 +1,55 @@
+package linthost
+
+import (
+  "sort"
+  "testing"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestJSDocCheckTagNamesPublishesCanonicalHints verifies the built-in
+// validator also supplies the exact tag vocabulary it accepts to editors.
+//
+// The map is the rule's source of truth, so copying it into a second fixture
+// would let validation and completion drift together unnoticed. The assertion
+// derives the expected order from that map, then pins the JSDoc trigger and the
+// existing type, empty, and synonym classifications used as item detail.
+//
+//  1. Evaluate the globally enabled rule through its project companion.
+//  2. Collect the finished hint corpus through the host gate.
+//  3. Compare every sorted item with the validator's canonical tag tables.
+func TestJSDocCheckTagNamesPublishesCanonicalHints(t *testing.T) {
+  const name = "jsdoc/check-tag-names"
+  engine := NewEngine(RuleConfig{name: SeverityWarn})
+  cycle := engine.evaluateProject(publicrule.ProjectIdentity{}, nil, nil)
+  hints := collectProjectHints(cycle)
+
+  tags := make([]string, 0, len(knownJSDocTags))
+  for tag := range knownJSDocTags {
+    tags = append(tags, tag)
+  }
+  sort.Strings(tags)
+  if len(hints) != len(tags) {
+    t.Fatalf("want %d known-tag hints, got %d: %#v", len(tags), len(hints), hints)
+  }
+  details := make(map[string]string, len(hints))
+  for index, tag := range tags {
+    hint := hints[index]
+    if hint.Insert != tag || hint.Label != "" || hint.Detail != jsdocTagHintDetail(tag) ||
+      hint.Trigger.Scope != publicrule.HintScopeJSDoc || hint.Trigger.After != "@" {
+      t.Fatalf("hint %d for %q does not match the rule corpus: %#v", index, tag, hint)
+    }
+    details[tag] = hint.Detail
+  }
+  expectedDetails := map[string]string{
+    "alpha":      "JSDoc tag",
+    "inheritDoc": "no content",
+    "method":     "alias for @function",
+    "param":      "accepts a type",
+  }
+  for tag, expected := range expectedDetails {
+    if detail := details[tag]; detail != expected {
+      t.Fatalf("%q detail: want %q, got %q", tag, expected, detail)
+    }
+  }
+}

--- a/packages/ttsc/driver/lsp.go
+++ b/packages/ttsc/driver/lsp.go
@@ -55,6 +55,12 @@ type LSPProjectDiagnostics = lspserver.LSPProjectDiagnostics
 // LSPDiagnosticsResult separates document and project plugin diagnostics.
 type LSPDiagnosticsResult = lspserver.LSPDiagnosticsResult
 
+// LSPCompletionHint is the driver-level alias for lspserver.LSPCompletionHint.
+type LSPCompletionHint = lspserver.LSPCompletionHint
+
+// LSPCompletionItem is the driver-level alias for lspserver.LSPCompletionItem.
+type LSPCompletionItem = lspserver.LSPCompletionItem
+
 // LSPSymbolKind is the driver-level alias for lspserver.LSPSymbolKind.
 type LSPSymbolKind = lspserver.LSPSymbolKind
 
@@ -73,6 +79,12 @@ type SymbolProvider = lspserver.SymbolProvider
 // It is the public seam downstream pipelines implement to contribute
 // diagnostics, code actions, and workspace commands to the LSP proxy.
 type PluginSource = lspserver.PluginSource
+
+// CompletionHintSource is the optional extension a PluginSource implements to
+// contribute editor completion hints to the LSP proxy.
+type CompletionHintSource interface {
+  CompletionHints() []LSPCompletionHint
+}
 
 // NullPluginSource is the driver-level alias for lspserver.NullPluginSource.
 type NullPluginSource = lspserver.NullPluginSource

--- a/packages/ttsc/internal/lspserver/lsp_completion_preserves_completion_list_extensions_test.go
+++ b/packages/ttsc/internal/lspserver/lsp_completion_preserves_completion_list_extensions_test.go
@@ -1,0 +1,99 @@
+package lspserver
+
+import (
+  "encoding/json"
+  "reflect"
+  "testing"
+)
+
+// TestLSPCompletionPreservesCompletionListExtensions verifies lossless merging.
+//
+// TypeScript-Go uses CompletionList.itemDefaults, and newer protocol versions
+// may add more list-level fields. Decoding into a closed local struct silently
+// removed those fields whenever a plugin contributed even one completion.
+//
+//  1. Build an upstream CompletionList with itemDefaults, applyKind, and a future field.
+//  2. Merge one plugin completion.
+//  3. Assert every upstream list field and both items survive.
+func TestLSPCompletionPreservesCompletionListExtensions(t *testing.T) {
+  body := []byte(`{
+    "jsonrpc":"2.0",
+    "id":1,
+    "result":{
+      "isIncomplete":true,
+      "itemDefaults":{"commitCharacters":["."],"insertTextFormat":2,"data":{"session":"upstream","shared":"default"}},
+      "applyKind":{"commitCharacters":2,"data":2},
+      "x-future":{"nested":[1,2,3]},
+      "items":[{
+        "label":"upstream",
+        "labelDetails":{"detail":" kept"},
+        "commitCharacters":["("],
+        "data":{"shared":"item","token":42}
+      }]
+    }
+  }`)
+  merged := mergeCompletionResponse(body, []LSPCompletionItem{{Insert: "plugin"}})
+  var response struct {
+    Result map[string]json.RawMessage `json:"result"`
+  }
+  if err := json.Unmarshal(merged, &response); err != nil {
+    t.Fatalf("decode merged completion response: %v\n%s", err, merged)
+  }
+
+  assertJSON := func(field string, want string) {
+    t.Helper()
+    raw, exists := response.Result[field]
+    if !exists {
+      t.Errorf("CompletionList field %q was dropped", field)
+      return
+    }
+    var gotValue any
+    var wantValue any
+    if err := json.Unmarshal(raw, &gotValue); err != nil {
+      t.Errorf("decode field %q: %v", field, err)
+      return
+    }
+    if err := json.Unmarshal([]byte(want), &wantValue); err != nil {
+      t.Fatalf("decode expected field %q: %v", field, err)
+    }
+    if !reflect.DeepEqual(gotValue, wantValue) {
+      t.Errorf("CompletionList field %q = %s, want %s", field, raw, want)
+    }
+  }
+  assertJSON("itemDefaults", `{"commitCharacters":["."],"insertTextFormat":2,"data":{"session":"upstream","shared":"default"}}`)
+  assertJSON("applyKind", `{"commitCharacters":1,"data":1}`)
+  assertJSON("x-future", `{"nested":[1,2,3]}`)
+
+  var items []map[string]json.RawMessage
+  if err := json.Unmarshal(response.Result["items"], &items); err != nil {
+    t.Fatalf("decode merged items: %v", err)
+  }
+  if len(items) != 2 {
+    t.Fatalf("merged %d completion items, want upstream plus plugin", len(items))
+  }
+  assertItemJSON := func(index int, field string, want string) {
+    t.Helper()
+    raw, exists := items[index][field]
+    if !exists {
+      t.Errorf("item %d field %q was dropped", index, field)
+      return
+    }
+    var gotValue any
+    var wantValue any
+    if err := json.Unmarshal(raw, &gotValue); err != nil {
+      t.Errorf("decode item %d field %q: %v", index, field, err)
+      return
+    }
+    if err := json.Unmarshal([]byte(want), &wantValue); err != nil {
+      t.Fatalf("decode expected item %d field %q: %v", index, field, err)
+    }
+    if !reflect.DeepEqual(gotValue, wantValue) {
+      t.Errorf("item %d field %q = %s, want %s", index, field, raw, want)
+    }
+  }
+  assertItemJSON(0, "commitCharacters", `["(","."]`)
+  assertItemJSON(0, "data", `{"session":"upstream","shared":"item","token":42}`)
+  assertItemJSON(1, "commitCharacters", `[]`)
+  assertItemJSON(1, "data", `{"$ttsc":"ttsc/completion-hint/v1"}`)
+  assertJSON("isIncomplete", "true")
+}

--- a/packages/ttsc/internal/lspserver/lsp_completion_replaces_full_filter_in_rank_order_test.go
+++ b/packages/ttsc/internal/lspserver/lsp_completion_replaces_full_filter_in_rank_order_test.go
@@ -1,0 +1,85 @@
+package lspserver
+
+import (
+  "encoding/json"
+  "testing"
+)
+
+type rankedCompletionHintSource struct{ NullPluginSource }
+
+func (rankedCompletionHintSource) CompletionHints() []LSPCompletionHint {
+  return []LSPCompletionHint{{
+    Scope: "jsdoc",
+    After: "@evidence ",
+    Items: []LSPCompletionItem{
+      {Insert: "docs/stable.md", Label: "stable"},
+      {Insert: "docs/derived.md"},
+    },
+  }}
+}
+
+// TestLSPCompletionReplacesFullFilterInRankOrder verifies path completion edits.
+//
+// A completion label containing slashes cannot rely on the editor's default
+// word range: replacing only the last segment of `文档/sp` would duplicate the
+// path prefix. The range is measured in UTF-16 units, and explicit sort keys
+// preserve the publisher's ranking instead of letting the client alphabetize it.
+//
+//  1. Match two ranked hints after a non-BMP character and a CJK path prefix.
+//  2. Merge them into the null completion response tsgo uses in JSDoc prose.
+//  3. Assert both text edits replace the full filter and sort in slice order.
+func TestLSPCompletionReplacesFullFilterInRankOrder(t *testing.T) {
+  const uri = "file:///project/src/main.ts"
+  const text = "/** 😀 @evidence 文档/sp"
+  proxy := &Proxy{
+    source:       rankedCompletionHintSource{},
+    documentText: map[string]string{uri: text},
+  }
+  params, _ := json.Marshal(map[string]any{
+    "textDocument": map[string]any{"uri": uri},
+    "position":     map[string]any{"line": 0, "character": 22},
+  })
+  pending := proxy.completionItemsFor(Envelope{Params: params})
+  if len(pending.items) != 2 {
+    t.Fatalf("matched %d completion items, want 2", len(pending.items))
+  }
+
+  merged := mergeCompletionResponseWithRequest(
+    []byte(`{"jsonrpc":"2.0","id":1,"result":null}`),
+    pending,
+  )
+  var response struct {
+    Result struct {
+      Items []struct {
+        FilterText string `json:"filterText"`
+        SortText   string `json:"sortText"`
+        TextEdit   struct {
+          Range   LSPRange `json:"range"`
+          NewText string   `json:"newText"`
+        } `json:"textEdit"`
+      } `json:"items"`
+    } `json:"result"`
+  }
+  if err := json.Unmarshal(merged, &response); err != nil {
+    t.Fatalf("decode merged completion response: %v\n%s", err, merged)
+  }
+  if len(response.Result.Items) != 2 {
+    t.Fatalf("merged %d completion items, want 2", len(response.Result.Items))
+  }
+  for index, item := range response.Result.Items {
+    if item.TextEdit.Range.Start != (LSPPosition{Line: 0, Character: 17}) ||
+      item.TextEdit.Range.End != (LSPPosition{Line: 0, Character: 22}) {
+      t.Errorf("item %d replacement range = %+v, want character 17..22", index, item.TextEdit.Range)
+    }
+    if item.FilterText != item.TextEdit.NewText {
+      t.Errorf("item %d filterText = %q, want inserted text %q", index, item.FilterText, item.TextEdit.NewText)
+    }
+  }
+  if response.Result.Items[0].SortText >= response.Result.Items[1].SortText {
+    t.Errorf(
+      "sort keys %q, %q do not preserve publisher order",
+      response.Result.Items[0].SortText,
+      response.Result.Items[1].SortText,
+    )
+  }
+}

--- a/packages/ttsc/internal/lspserver/lsp_completion_request.go
+++ b/packages/ttsc/internal/lspserver/lsp_completion_request.go
@@ -2,7 +2,17 @@ package lspserver
 
 import (
   "encoding/json"
+  "fmt"
+  "unicode/utf16"
 )
+
+const pluginCompletionDataMarker = "ttsc/completion-hint/v1"
+
+type pendingCompletionRequest struct {
+  items        []LSPCompletionItem
+  replaceRange LSPRange
+  hasRange     bool
+}
 
 // handleCompletionRequest computes the plugin's contribution for a cursor and
 // remembers it for the response.
@@ -17,8 +27,8 @@ import (
 // proxy already splices per didChange is the right source, and the only one
 // that exists mid-edit.
 func (p *Proxy) handleCompletionRequest(env Envelope) (bool, error) {
-  items := p.completionItemsFor(env)
-  if len(items) == 0 {
+  pending := p.completionItemsFor(env)
+  if len(pending.items) == 0 {
     return false, nil
   }
   key := env.IDKey()
@@ -27,11 +37,35 @@ func (p *Proxy) handleCompletionRequest(env Envelope) (bool, error) {
   }
   p.pendingMu.Lock()
   if p.pendingCompletions == nil {
-    p.pendingCompletions = map[string][]LSPCompletionItem{}
+    p.pendingCompletions = map[string]pendingCompletionRequest{}
   }
-  p.pendingCompletions[key] = items
+  p.pendingCompletions[key] = pending
   p.pendingMu.Unlock()
   return false, nil
+}
+
+// handleCompletionResolveRequest completes plugin-owned items locally.
+//
+// tsgo advertises completionItem/resolve for its own items and expects its
+// private data payload on every request. Plugin hints are already fully
+// resolved, so forwarding one to tsgo would hand it an item it did not create.
+// The private marker added while merging items is the ownership boundary.
+func (p *Proxy) handleCompletionResolveRequest(env Envelope) (bool, error) {
+  if !env.IsRequest() || !isPluginCompletionItem(env.Params) {
+    return false, nil
+  }
+  return true, p.writeResult(env.ID, json.RawMessage(env.Params))
+}
+
+func isPluginCompletionItem(params json.RawMessage) bool {
+  var item struct {
+    Data struct {
+      Marker string `json:"$ttsc"`
+    } `json:"data"`
+  }
+  return len(params) > 0 &&
+    json.Unmarshal(params, &item) == nil &&
+    item.Data.Marker == pluginCompletionDataMarker
 }
 
 // completionItemsFor resolves the cursor to a line prefix and asks the corpus.
@@ -39,10 +73,10 @@ func (p *Proxy) handleCompletionRequest(env Envelope) (bool, error) {
 // Returns nothing when the document's text is unknown. Failing open — matching
 // against an empty prefix — would offer every broad trigger's items at a
 // position the proxy cannot see, which is worse than silence.
-func (p *Proxy) completionItemsFor(env Envelope) []LSPCompletionItem {
+func (p *Proxy) completionItemsFor(env Envelope) pendingCompletionRequest {
   hints := p.pluginCompletionHints()
   if len(hints) == 0 {
-    return nil
+    return pendingCompletionRequest{}
   }
   var params struct {
     TextDocument struct {
@@ -54,22 +88,51 @@ func (p *Proxy) completionItemsFor(env Envelope) []LSPCompletionItem {
     } `json:"position"`
   }
   if len(env.Params) == 0 || json.Unmarshal(env.Params, &params) != nil {
-    return nil
+    return pendingCompletionRequest{}
   }
   text, ok := p.cachedDocumentText(params.TextDocument.URI)
   if !ok {
-    return nil
+    return pendingCompletionRequest{}
   }
   offset, ok := offsetForPosition(text, params.Position.Line, params.Position.Character)
   if !ok {
-    return nil
+    return pendingCompletionRequest{}
   }
-  items, _ := matchCompletionHints(
+  items, filter := matchCompletionHints(
     hints,
     linePrefixAt(text, offset),
     cursorInJSDoc(text, offset),
   )
-  return items
+  if len(items) == 0 {
+    return pendingCompletionRequest{}
+  }
+  filterUnits := utf16Length(filter)
+  if filterUnits > params.Position.Character {
+    return pendingCompletionRequest{}
+  }
+  return pendingCompletionRequest{
+    items: items,
+    replaceRange: LSPRange{
+      Start: LSPPosition{
+        Line:      params.Position.Line,
+        Character: params.Position.Character - filterUnits,
+      },
+      End: LSPPosition(params.Position),
+    },
+    hasRange: true,
+  }
+}
+
+func utf16Length(text string) int {
+  units := 0
+  for _, symbol := range text {
+    width := utf16.RuneLen(symbol)
+    if width <= 0 {
+      width = 1
+    }
+    units += width
+  }
+  return units
 }
 
 // offsetForPosition converts an LSP line/character to a byte offset.
@@ -126,7 +189,11 @@ func indexByteFrom(text string, from int, target byte) int {
 // own items. Ours are complete by construction — the corpus is already in
 // memory — so re-merging per keystroke is free either way.
 func mergeCompletionResponse(body []byte, items []LSPCompletionItem) []byte {
-  if len(items) == 0 {
+  return mergeCompletionResponseWithRequest(body, pendingCompletionRequest{items: items})
+}
+
+func mergeCompletionResponseWithRequest(body []byte, pending pendingCompletionRequest) []byte {
+  if len(pending.items) == 0 {
     return body
   }
   var envelope struct {
@@ -141,37 +208,70 @@ func mergeCompletionResponse(body []byte, items []LSPCompletionItem) []byte {
     return body
   }
 
-  encoded := make([]map[string]any, 0, len(items))
-  for _, item := range items {
-    entry := map[string]any{"label": item.Label}
-    if item.Label == "" {
-      entry["label"] = item.Insert
+  encoded := make([]json.RawMessage, 0, len(pending.items))
+  for index, item := range pending.items {
+    label := item.Label
+    if label == "" {
+      label = item.Insert
     }
+    entry := map[string]any{"label": label}
     entry["insertText"] = item.Insert
+    // Matching uses Insert, so keep client-side filtering on the same value.
+    // A friendlier Label may omit a path prefix that the user already typed.
+    entry["filterText"] = item.Insert
+    entry["sortText"] = fmt.Sprintf("ttsc:%010d", index)
+    entry["data"] = map[string]string{"$ttsc": pluginCompletionDataMarker}
+    // CompletionList.itemDefaults belong to upstream items. State every
+    // defaultable value a plugin item owns so an upstream snippet or commit
+    // character default cannot silently change a plain-text hint.
+    entry["commitCharacters"] = []string{}
+    entry["insertTextFormat"] = 1
+    entry["insertTextMode"] = 1
+    if pending.hasRange {
+      entry["textEdit"] = map[string]any{
+        "range":   pending.replaceRange,
+        "newText": item.Insert,
+      }
+    }
     if item.Detail != "" {
       entry["detail"] = item.Detail
     }
-    encoded = append(encoded, entry)
-  }
-
-  var list struct {
-    IsIncomplete bool             `json:"isIncomplete"`
-    Items        []map[string]any `json:"items"`
-  }
-  switch {
-  case len(envelope.Result) == 0 || string(envelope.Result) == "null":
-    list.Items = encoded
-  case envelope.Result[0] == '[':
-    if json.Unmarshal(envelope.Result, &list.Items) != nil {
+    raw, err := json.Marshal(entry)
+    if err != nil {
       return body
     }
-    list.Items = append(list.Items, encoded...)
+    encoded = append(encoded, raw)
+  }
+
+  list := map[string]json.RawMessage{}
+  existing := []json.RawMessage{}
+  switch {
+  case len(envelope.Result) == 0 || string(envelope.Result) == "null":
+    list["isIncomplete"] = json.RawMessage("false")
+  case envelope.Result[0] == '[':
+    if json.Unmarshal(envelope.Result, &existing) != nil {
+      return body
+    }
+    list["isIncomplete"] = json.RawMessage("false")
   default:
     if json.Unmarshal(envelope.Result, &list) != nil {
       return body
     }
-    list.Items = append(list.Items, encoded...)
+    if rawItems, exists := list["items"]; exists && json.Unmarshal(rawItems, &existing) != nil {
+      return body
+    }
+    normalized, ok := normalizeCompletionListDefaults(list, existing)
+    if !ok {
+      return body
+    }
+    existing = normalized
   }
+  existing = append(existing, encoded...)
+  mergedItems, err := json.Marshal(existing)
+  if err != nil {
+    return body
+  }
+  list["items"] = mergedItems
 
   result, err := json.Marshal(list)
   if err != nil {
@@ -186,4 +286,145 @@ func mergeCompletionResponse(body []byte, items []LSPCompletionItem) []byte {
     return body
   }
   return merged
+}
+
+// normalizeCompletionListDefaults materializes merge-kind defaults into the
+// upstream items before plugin items are appended. Otherwise a CompletionList
+// default such as data or commitCharacters would also merge into plugin items
+// even though those defaults belong to tsgo's producer. Unknown defaults fail
+// closed because a future protocol field could change plugin item semantics.
+func normalizeCompletionListDefaults(
+  list map[string]json.RawMessage,
+  items []json.RawMessage,
+) ([]json.RawMessage, bool) {
+  rawDefaults, hasDefaults := list["itemDefaults"]
+  if !hasDefaults {
+    return items, true
+  }
+  defaults := map[string]json.RawMessage{}
+  if json.Unmarshal(rawDefaults, &defaults) != nil {
+    return nil, false
+  }
+  supportedDefaults := map[string]struct{}{
+    "commitCharacters": {},
+    "data":             {},
+    "editRange":        {},
+    "insertTextFormat": {},
+    "insertTextMode":   {},
+  }
+  for field := range defaults {
+    if _, supported := supportedDefaults[field]; !supported {
+      return nil, false
+    }
+  }
+
+  rawApplyKind, hasApplyKind := list["applyKind"]
+  if !hasApplyKind {
+    return items, true
+  }
+  applyKind := map[string]json.RawMessage{}
+  if json.Unmarshal(rawApplyKind, &applyKind) != nil {
+    return nil, false
+  }
+  for field, rawKind := range applyKind {
+    var kind int
+    if json.Unmarshal(rawKind, &kind) != nil || (kind != 1 && kind != 2) {
+      return nil, false
+    }
+    if field != "commitCharacters" && field != "data" {
+      if kind == 2 {
+        return nil, false
+      }
+      continue
+    }
+    if kind != 2 {
+      continue
+    }
+    defaultValue, exists := defaults[field]
+    if exists {
+      materialized, ok := materializeCompletionDefault(items, field, defaultValue)
+      if !ok {
+        return nil, false
+      }
+      items = materialized
+    }
+    applyKind[field] = json.RawMessage("1")
+  }
+  normalizedApplyKind, err := json.Marshal(applyKind)
+  if err != nil {
+    return nil, false
+  }
+  list["applyKind"] = normalizedApplyKind
+  return items, true
+}
+
+func materializeCompletionDefault(
+  items []json.RawMessage,
+  field string,
+  defaultValue json.RawMessage,
+) ([]json.RawMessage, bool) {
+  materialized := make([]json.RawMessage, 0, len(items))
+  for _, rawItem := range items {
+    item := map[string]json.RawMessage{}
+    if json.Unmarshal(rawItem, &item) != nil {
+      return nil, false
+    }
+    if itemValue, exists := item[field]; exists {
+      merged, ok := mergeCompletionDefault(field, itemValue, defaultValue)
+      if !ok {
+        return nil, false
+      }
+      item[field] = merged
+    } else {
+      item[field] = defaultValue
+    }
+    rawMaterialized, err := json.Marshal(item)
+    if err != nil {
+      return nil, false
+    }
+    materialized = append(materialized, rawMaterialized)
+  }
+  return materialized, true
+}
+
+func mergeCompletionDefault(
+  field string,
+  itemValue json.RawMessage,
+  defaultValue json.RawMessage,
+) (json.RawMessage, bool) {
+  switch field {
+  case "commitCharacters":
+    var itemCharacters []string
+    var defaultCharacters []string
+    if json.Unmarshal(itemValue, &itemCharacters) != nil ||
+      json.Unmarshal(defaultValue, &defaultCharacters) != nil {
+      return nil, false
+    }
+    seen := make(map[string]struct{}, len(itemCharacters)+len(defaultCharacters))
+    merged := make([]string, 0, len(itemCharacters)+len(defaultCharacters))
+    for _, characters := range [][]string{itemCharacters, defaultCharacters} {
+      for _, character := range characters {
+        if _, exists := seen[character]; exists {
+          continue
+        }
+        seen[character] = struct{}{}
+        merged = append(merged, character)
+      }
+    }
+    rawMerged, err := json.Marshal(merged)
+    return rawMerged, err == nil
+  case "data":
+    defaults := map[string]json.RawMessage{}
+    item := map[string]json.RawMessage{}
+    if json.Unmarshal(defaultValue, &defaults) != nil || json.Unmarshal(itemValue, &item) != nil {
+      return nil, false
+    }
+    for key, value := range item {
+      defaults[key] = value
+    }
+    rawMerged, err := json.Marshal(defaults)
+    return rawMerged, err == nil
+  default:
+    return nil, false
+  }
 }

--- a/packages/ttsc/internal/lspserver/lsp_completion_trigger_uses_last_rune_test.go
+++ b/packages/ttsc/internal/lspserver/lsp_completion_trigger_uses_last_rune_test.go
@@ -1,0 +1,24 @@
+package lspserver
+
+import (
+  "reflect"
+  "testing"
+)
+
+type unicodeCompletionTriggerSource struct{ NullPluginSource }
+
+func (unicodeCompletionTriggerSource) CompletionHints() []LSPCompletionHint {
+  return []LSPCompletionHint{
+    {Scope: "jsdoc", After: "@"},
+    {Scope: "jsdoc", After: "문서／"},
+  }
+}
+
+func TestLSPCompletionTriggerUsesLastRune(t *testing.T) {
+  proxy := &Proxy{source: unicodeCompletionTriggerSource{}}
+  got := proxy.pluginCompletionTriggerCharacters()
+  want := []string{"@", "／"}
+  if !reflect.DeepEqual(got, want) {
+    t.Fatalf("trigger characters = %#v, want %#v", got, want)
+  }
+}

--- a/packages/ttsc/internal/lspserver/lsp_native_completion_hints_decode_flat_lint_wire_test.go
+++ b/packages/ttsc/internal/lspserver/lsp_native_completion_hints_decode_flat_lint_wire_test.go
@@ -1,0 +1,66 @@
+package lspserver
+
+import (
+  "reflect"
+  "testing"
+)
+
+// TestNativeCompletionHintsDecodeFlatLintWire verifies the real lint boundary.
+//
+// @ttsc/lint publishes a flat []rule.Hint rather than the proxy's grouped
+// matching shape. Repeated triggers must coalesce without moving the group or
+// reordering its items, because slice order is the publisher's ranking channel.
+//
+//  1. Decode interleaved flat hints using the exact public rule.Hint JSON shape.
+//  2. Assert first-trigger group order and per-trigger item order are preserved.
+//  3. Feed the decoded corpus to the live matcher and verify it is offerable.
+func TestNativeCompletionHintsDecodeFlatLintWire(t *testing.T) {
+  body := []byte(`[
+    {
+      "insert":"docs/stable.md",
+      "label":"stable",
+      "detail":"pinned document",
+      "trigger":{"scope":"jsdoc","after":"@evidence "}
+    },
+    {
+      "insert":"param",
+      "detail":"JSDoc tag",
+      "trigger":{"scope":"jsdoc","after":"@"}
+    },
+    {
+      "insert":"docs/derived.md",
+      "label":"derived",
+      "trigger":{"scope":"jsdoc","after":"@evidence "}
+    }
+  ]`)
+
+  got, err := decodeNativeCompletionHints(body)
+  if err != nil {
+    t.Fatalf("decode flat lint hint wire: %v", err)
+  }
+  want := []LSPCompletionHint{
+    {
+      Scope: "jsdoc",
+      After: "@evidence ",
+      Items: []LSPCompletionItem{
+        {Insert: "docs/stable.md", Label: "stable", Detail: "pinned document"},
+        {Insert: "docs/derived.md", Label: "derived"},
+      },
+    },
+    {
+      Scope: "jsdoc",
+      After: "@",
+      Items: []LSPCompletionItem{
+        {Insert: "param", Detail: "JSDoc tag"},
+      },
+    },
+  }
+  if !reflect.DeepEqual(got, want) {
+    t.Fatalf("decoded flat hints:\n got %#v\nwant %#v", got, want)
+  }
+
+  items, filter := matchCompletionHints(got, " * @evidence docs/", true)
+  if filter != "docs/" || !reflect.DeepEqual(items, want[0].Items) {
+    t.Errorf("decoded corpus did not reach matcher: filter=%q items=%#v", filter, items)
+  }
+}

--- a/packages/ttsc/internal/lspserver/lsp_native_completion_hints_grouped_compatibility_boundary_test.go
+++ b/packages/ttsc/internal/lspserver/lsp_native_completion_hints_grouped_compatibility_boundary_test.go
@@ -1,0 +1,60 @@
+package lspserver
+
+import (
+  "reflect"
+  "testing"
+)
+
+// TestNativeCompletionHintsKeepGroupedWireAndRejectInvalidEntries verifies the
+// compatibility and validation boundary.
+//
+// Third-party sidecars may already publish the grouped shape documented by the
+// first proxy implementation. Those responses remain valid, while empty items,
+// empty triggers, and structurally malformed JSON must not enter the corpus.
+//
+//  1. Decode a grouped response containing valid and empty entries.
+//  2. Assert the valid group's item order survives and empty entries are dropped.
+//  3. Assert a field with the wrong JSON type rejects the response.
+func TestNativeCompletionHintsKeepGroupedWireAndRejectInvalidEntries(t *testing.T) {
+  body := []byte(`[
+    {
+      "scope":"jsdoc",
+      "after":"@legacy ",
+      "items":[
+        {"insert":"legacy-first","detail":"kept"},
+        {"insert":""},
+        {"insert":"legacy-second"}
+      ]
+    },
+    {"scope":"","after":"@missing-scope ","items":[{"insert":"drop"}]},
+    {"scope":"jsdoc","after":"","items":[{"insert":"drop"}]},
+    {"scope":"jsdoc","after":"@empty ","items":[]},
+    {"insert":"","trigger":{"scope":"jsdoc","after":"@flat-empty "}},
+    {"insert":"drop","trigger":{"scope":"","after":"@flat-empty-scope "}},
+    {"insert":"drop","trigger":{"scope":"jsdoc","after":""}},
+    {}
+  ]`)
+
+  got, err := decodeNativeCompletionHints(body)
+  if err != nil {
+    t.Fatalf("decode grouped completion hints: %v", err)
+  }
+  want := []LSPCompletionHint{{
+    Scope: "jsdoc",
+    After: "@legacy ",
+    Items: []LSPCompletionItem{
+      {Insert: "legacy-first", Detail: "kept"},
+      {Insert: "legacy-second"},
+    },
+  }}
+  if !reflect.DeepEqual(got, want) {
+    t.Errorf("grouped compatibility result:\n got %#v\nwant %#v", got, want)
+  }
+
+  malformed := []byte(`[
+    {"insert":42,"trigger":{"scope":"jsdoc","after":"@broken "}}
+  ]`)
+  if _, err := decodeNativeCompletionHints(malformed); err == nil {
+    t.Error("wrongly typed flat hint was accepted")
+  }
+}

--- a/packages/ttsc/internal/lspserver/lsp_native_plugin_source.go
+++ b/packages/ttsc/internal/lspserver/lsp_native_plugin_source.go
@@ -384,24 +384,96 @@ func (s *NativePluginSource) discoverCompletionHints() {
       // a rare new one.
       continue
     }
-    var published []LSPCompletionHint
-    if err := json.Unmarshal(body, &published); err != nil {
+    published, err := decodeNativeCompletionHints(body)
+    if err != nil {
       // Not silent. A plugin that answered and answered wrongly implements the
       // verb and got it wrong, which is worth saying — unlike one that never
       // implemented it at all.
       s.log("ttscserver: %s lsp-hints returned invalid JSON: %v", pluginLabel(plugin), err)
       continue
     }
-    for _, hint := range published {
-      if hint.Scope == "" || hint.After == "" || len(hint.Items) == 0 {
-        continue
-      }
-      hints = append(hints, hint)
-    }
+    hints = append(hints, published...)
   }
   s.hintsMu.Lock()
   s.completionHints = hints
   s.hintsMu.Unlock()
+}
+
+// decodeNativeCompletionHints accepts both generations of the lsp-hints wire.
+//
+// @ttsc/lint publishes one flat rule.Hint per item, with the scope and trigger
+// nested under `trigger`. The first proxy implementation instead documented a
+// grouped response with `scope`, `after`, and `items` at the top level. Flat
+// entries are grouped here by trigger so the proxy keeps its efficient matching
+// shape, while grouped responses remain valid for existing third-party
+// sidecars. The first occurrence of a trigger fixes its group position and each
+// later occurrence appends in publication order, preserving rule ranking.
+func decodeNativeCompletionHints(body []byte) ([]LSPCompletionHint, error) {
+  var entries []json.RawMessage
+  if err := json.Unmarshal(body, &entries); err != nil {
+    return nil, err
+  }
+
+  type triggerKey struct {
+    scope string
+    after string
+  }
+  flatGroups := map[triggerKey]int{}
+  hints := make([]LSPCompletionHint, 0, len(entries))
+  for _, entry := range entries {
+    var fields map[string]json.RawMessage
+    if err := json.Unmarshal(entry, &fields); err != nil {
+      return nil, err
+    }
+    if _, grouped := fields["items"]; grouped {
+      var hint LSPCompletionHint
+      if err := json.Unmarshal(entry, &hint); err != nil {
+        return nil, err
+      }
+      hint.Items = usableNativeCompletionItems(hint.Items)
+      if hint.Scope == "" || hint.After == "" || len(hint.Items) == 0 {
+        continue
+      }
+      hints = append(hints, hint)
+      continue
+    }
+
+    var flat struct {
+      LSPCompletionItem
+      Trigger struct {
+        Scope string `json:"scope"`
+        After string `json:"after"`
+      } `json:"trigger"`
+    }
+    if err := json.Unmarshal(entry, &flat); err != nil {
+      return nil, err
+    }
+    if flat.Insert == "" || flat.Trigger.Scope == "" || flat.Trigger.After == "" {
+      continue
+    }
+    key := triggerKey{scope: flat.Trigger.Scope, after: flat.Trigger.After}
+    index, exists := flatGroups[key]
+    if !exists {
+      index = len(hints)
+      flatGroups[key] = index
+      hints = append(hints, LSPCompletionHint{
+        Scope: flat.Trigger.Scope,
+        After: flat.Trigger.After,
+      })
+    }
+    hints[index].Items = append(hints[index].Items, flat.LSPCompletionItem)
+  }
+  return hints, nil
+}
+
+func usableNativeCompletionItems(items []LSPCompletionItem) []LSPCompletionItem {
+  kept := make([]LSPCompletionItem, 0, len(items))
+  for _, item := range items {
+    if item.Insert != "" {
+      kept = append(kept, item)
+    }
+  }
+  return kept
 }
 
 func (s *NativePluginSource) CodeActionKinds() []string {

--- a/packages/ttsc/internal/lspserver/lsp_plugin_completion_resolve_stays_local_test.go
+++ b/packages/ttsc/internal/lspserver/lsp_plugin_completion_resolve_stays_local_test.go
@@ -1,0 +1,82 @@
+package lspserver
+
+import (
+  "bytes"
+  "encoding/json"
+  "testing"
+)
+
+// TestLSPPluginCompletionResolveStaysLocal verifies completion ownership.
+//
+// TypeScript-Go advertises resolve support but dereferences its private data
+// payload for every resolved item. A plugin hint has no such payload and is
+// already complete, so forwarding it upstream can fault the language server.
+//
+//  1. Encode a plugin completion and send that item back as a resolve request.
+//  2. Assert the proxy answers locally with the item unchanged.
+//  3. Assert an upstream-owned item remains unhandled and is still forwarded.
+func TestLSPPluginCompletionResolveStaysLocal(t *testing.T) {
+  merged := mergeCompletionResponse(
+    []byte(`{"jsonrpc":"2.0","id":1,"result":null}`),
+    []LSPCompletionItem{{Insert: "evidence"}},
+  )
+  var completion struct {
+    Result struct {
+      Items []json.RawMessage `json:"items"`
+    } `json:"result"`
+  }
+  if err := json.Unmarshal(merged, &completion); err != nil || len(completion.Result.Items) != 1 {
+    t.Fatalf("decode plugin completion item: %v\n%s", err, merged)
+  }
+  item := completion.Result.Items[0]
+
+  var editor bytes.Buffer
+  proxy := &Proxy{editorOut: &editor}
+  handled, err := proxy.handleEditorEnvelope(Envelope{
+    JSONRPC: "2.0",
+    ID:      json.RawMessage("7"),
+    Method:  methodCompletionResolve,
+    Params:  item,
+  }, nil)
+  if err != nil {
+    t.Fatalf("resolve plugin completion: %v", err)
+  }
+  if !handled {
+    t.Fatal("plugin completion resolve was forwarded upstream")
+  }
+  _, body, err := NewFrameReader(bytes.NewReader(editor.Bytes())).Read()
+  if err != nil {
+    t.Fatalf("read local resolve response: %v", err)
+  }
+  response, err := ParseEnvelope(body)
+  if err != nil {
+    t.Fatalf("parse local resolve response: %v", err)
+  }
+  var got any
+  var want any
+  if err := json.Unmarshal(response.Result, &got); err != nil {
+    t.Fatalf("decode local resolve result: %v", err)
+  }
+  if err := json.Unmarshal(item, &want); err != nil {
+    t.Fatalf("decode original plugin item: %v", err)
+  }
+  gotJSON, _ := json.Marshal(got)
+  wantJSON, _ := json.Marshal(want)
+  if !bytes.Equal(gotJSON, wantJSON) {
+    t.Errorf("local resolve changed the plugin item:\n got %s\nwant %s", gotJSON, wantJSON)
+  }
+
+  editor.Reset()
+  handled, err = proxy.handleEditorEnvelope(Envelope{
+    JSONRPC: "2.0",
+    ID:      json.RawMessage("8"),
+    Method:  methodCompletionResolve,
+    Params:  json.RawMessage(`{"label":"upstream","data":{"fileName":"/project/main.ts"}}`),
+  }, nil)
+  if err != nil {
+    t.Fatalf("route upstream completion resolve: %v", err)
+  }
+  if handled || editor.Len() != 0 {
+    t.Error("upstream completion resolve was intercepted instead of forwarded")
+  }
+}

--- a/packages/ttsc/internal/lspserver/lsp_proxy.go
+++ b/packages/ttsc/internal/lspserver/lsp_proxy.go
@@ -37,6 +37,7 @@ const (
   methodDocumentSymbol     = "textDocument/documentSymbol"
   methodReferences         = "textDocument/references"
   methodCompletion         = "textDocument/completion"
+  methodCompletionResolve  = "completionItem/resolve"
 )
 
 // formatDocumentCommand is the ttsc-owned workspace command that the lint
@@ -107,7 +108,7 @@ type Proxy struct {
   pendingActions map[string]pendingCodeActionRequest
   // pendingCompletions holds the plugin items computed for a forwarded
   // completion request, keyed by request id, until upstream answers it.
-  pendingCompletions       map[string][]LSPCompletionItem
+  pendingCompletions       map[string]pendingCompletionRequest
   pendingAugmentingActions map[string]struct{}
   pendingLocalActions      map[string]struct{}
   pendingCommands          map[string]struct{}
@@ -335,6 +336,8 @@ func (p *Proxy) handleEditorEnvelope(env Envelope, body []byte) (bool, error) {
     }
   case methodCompletion:
     return p.handleCompletionRequest(env)
+  case methodCompletionResolve:
+    return p.handleCompletionResolveRequest(env)
   case methodCancelRequest:
     // $/cancelRequest names an in-flight id the editor has given up on.
     // The proxy drops any pending codeAction entry for that id so the
@@ -959,7 +962,7 @@ func (p *Proxy) augmentUpstream(env Envelope, body []byte) []byte {
     }
     p.pendingMu.Unlock()
     if hasCompletions {
-      return mergeCompletionResponse(body, completions)
+      return mergeCompletionResponseWithRequest(body, completions)
     }
     if pendingInitialize {
       if augmented, augOk := p.augmentInitializeResult(env); augOk {
@@ -1818,7 +1821,8 @@ func (p *Proxy) pluginCompletionTriggerCharacters() []string {
     if hint.After == "" {
       continue
     }
-    characters = append(characters, hint.After[len(hint.After)-1:])
+    trigger, _ := utf8.DecodeLastRuneInString(hint.After)
+    characters = append(characters, string(trigger))
   }
   return characters
 }

--- a/packages/ttsc/test/driver/lsp_plugin_source_embedder_can_publish_completion_hints_test.go
+++ b/packages/ttsc/test/driver/lsp_plugin_source_embedder_can_publish_completion_hints_test.go
@@ -1,0 +1,50 @@
+package driver_test
+
+import (
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+type completionHintPluginSource struct {
+  driver.PluginSource
+}
+
+func (*completionHintPluginSource) CompletionHints() []driver.LSPCompletionHint {
+  return []driver.LSPCompletionHint{{
+    Scope: "jsdoc",
+    After: "@evidence ",
+    Items: []driver.LSPCompletionItem{{
+      Insert: "docs/spec.md",
+      Label:  "spec",
+      Detail: "Evidence specification",
+    }},
+  }}
+}
+
+var _ driver.PluginSource = (*completionHintPluginSource)(nil)
+var _ driver.CompletionHintSource = (*completionHintPluginSource)(nil)
+
+// TestLSPPluginSourceEmbedderCanPublishCompletionHints verifies an external
+// driver consumer can add the proxy's optional completion-hint capability
+// while importing only the public driver package.
+//
+// 1. Embed a public PluginSource backed by NullPluginSource.
+// 2. Publish hints using the public completion aliases.
+// 3. Assert the optional public interface exposes the complete hint payload.
+func TestLSPPluginSourceEmbedderCanPublishCompletionHints(t *testing.T) {
+  source := &completionHintPluginSource{
+    PluginSource: driver.NullPluginSource{},
+  }
+
+  hints := source.CompletionHints()
+  if len(hints) != 1 {
+    t.Fatalf("CompletionHints length: want 1, got %d", len(hints))
+  }
+  if hints[0].Scope != "jsdoc" || hints[0].After != "@evidence " {
+    t.Fatalf("CompletionHints trigger: want jsdoc/@evidence, got %#v", hints[0])
+  }
+  if len(hints[0].Items) != 1 || hints[0].Items[0].Insert != "docs/spec.md" {
+    t.Fatalf("CompletionHints items: want docs/spec.md, got %#v", hints[0].Items)
+  }
+}

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -4,9 +4,9 @@
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/ttsc/blob/master/LICENSE) [![NPM Version](https://img.shields.io/npm/v/@ttsc/vscode.svg)](https://www.npmjs.com/package/@ttsc/vscode) [![NPM Downloads](https://img.shields.io/npm/dm/@ttsc/vscode.svg)](https://www.npmjs.com/package/@ttsc/vscode) [![Build Status](https://github.com/samchon/ttsc/workflows/test/badge.svg)](https://github.com/samchon/ttsc/actions?query=workflow%3Atest) [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://ttsc.dev/docs) [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)
 
-Bring [`ttsc`](https://ttsc.dev) plugin diagnostics into VS Code.
+Bring TypeScript-Go and supported [`ttsc`](https://ttsc.dev) plugin features into one VS Code session.
 
-When `@ttsc/lint` or another LSP-capable `ttsc` plugin like `typia` reports a compile-time diagnostic, this extension shows it in the editor next to normal TypeScript errors.
+The extension keeps TypeScript-Go completion and diagnostics in one `ttscserver` stream with `@ttsc/lint` diagnostics, suggestions, fix-all actions, formatting, and completion published by lint project rules.
 
 Use it when the project already runs `ttsc`. Add `@ttsc/lint` when you also want lint diagnostics, fix-all actions, and formatting in the editor.
 
@@ -102,13 +102,16 @@ Lint fixes stay off-save by default because they can change code meaning. Run `t
 ## What it adds
 
 - TypeScript-Go diagnostics, hover, navigation, and completions.
-- `@ttsc/lint` diagnostics and code actions, including `source.fixAll.ttsc`.
+- `@ttsc/lint` diagnostics, suggestions, code actions, and `source.fixAll.ttsc`.
+- JSDoc completion from a built-in lint rule and project-indexed completion from contributor rules that publish it.
 - Diagnostics reported by other LSP-capable `ttsc` plugins.
 - `ttsc: Fix all lint issues`, `ttsc: Format document`, and `ttsc: Restart language server` in the command palette.
 - Format on save with the `format` block from `lint.config.*`.
 - Multi-root workspace support. Each package can use its own `ttsc`, `typescript`, `tsconfig.json`, and `lint.config.*`.
 
 Save the file before relying on lint diagnostics or running the command-palette lint and format commands. Format-on-save works on the live editor buffer.
+
+Completion uses the live editor buffer. Enable `jsdoc/check-tag-names` to try built-in lint completion inside a `/** ... */` block. The [Lint in VS Code guide](https://ttsc.dev/docs/lint/editor) covers that workflow and contributor project indexes.
 
 ## Troubleshooting
 
@@ -119,6 +122,8 @@ No diagnostics? Work through these in order:
 3. Confirm the project itself checks: `npx ttsc --noEmit`.
 4. Open **View → Output → ttsc** and read the server log.
 5. For full LSP tracing, set `ttsc.trace.server` to `"verbose"` and reload the window.
+
+If diagnostics work but lint completion does not, press Ctrl+Space after `@` inside a JSDoc block and run `ttsc: Restart language server` after changing the lint config or project-indexed inputs.
 
 ## Sponsors
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ttsc/vscode",
   "displayName": "ttsc",
-  "description": "Show ttsc plugin diagnostics in VS Code, with @ttsc/lint errors, fix-all actions, and formatter support.",
+  "description": "TypeScript-Go and ttsc plugin diagnostics, completions, lint actions, and formatting for VS Code.",
   "version": "0.19.4",
   "publisher": "samchon",
   "icon": "images/icon.png",

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -180,7 +180,28 @@ Do not derive an injected import binding with `NewGeneratedNameForNode(moduleSpe
 
 These symbols are for embedders of `ttscserver`, **not for plugin authors**. Skip this section unless you are building a `ttsc`-aware editor extension.
 
-`ttscserver` is a process wrapper around the project-selected `tsc --lsp --stdio` binary. Resolve `typescript` in the user project, pass its absolute executable path as `TsgoBinary`, and keep plugin diagnostics, code actions, and `executeCommand` handlers in your `PluginSource`. `CommandIDs()` is the ownership gate: the proxy calls `ExecuteCommand()` only for ids returned there. Returning a nil `WorkspaceEdit` is a valid handled no-op. `ErrCommandNotHandled` is only for commands not listed by `CommandIDs()`; if `ExecuteCommand()` returns it for an advertised id, the proxy returns an LSP error instead of forwarding upstream. Implement an optional `CodeActionKinds() []string` method on the same source when your actions should be advertised in the initialize result. The shipped VS Code extension is the reference client for TypeScript-Go plus the built-in lint/format command bridge; it suppresses those two wrapper-owned command ids while leaving other plugin command ids advertised through `vscode-languageclient`. Because VS Code command ids are global, the extension also sets `ExecuteCommandIDPrefix` per project root so custom plugin commands from multiple roots do not collide; the proxy maps prefixed ids back before calling `ExecuteCommand()`. If an embedder relies on `vscode-languageclient` to register advertised plugin commands, it must still apply any returned `changes`-map `WorkspaceEdit`; the languageclient command handler only invokes `workspace/executeCommand`.
+`ttscserver` is a process wrapper around the project-selected `tsc --lsp --stdio` binary. Resolve `typescript` in the user project, pass its absolute executable path as `TsgoBinary`, and keep plugin diagnostics, code actions, and `executeCommand` handlers in your `PluginSource`. `CommandIDs()` is the ownership gate: the proxy calls `ExecuteCommand()` only for ids returned there. Returning a nil `WorkspaceEdit` is a valid handled no-op. `ErrCommandNotHandled` is only for commands not listed by `CommandIDs()`; if `ExecuteCommand()` returns it for an advertised id, the proxy returns an LSP error instead of forwarding upstream. Implement an optional `CodeActionKinds() []string` method on the same source when your actions should be advertised in the initialize result. Implement `driver.CompletionHintSource` when the source also publishes an in-memory completion corpus. The shipped VS Code extension is the reference client for TypeScript-Go plus the built-in lint/format command bridge; it suppresses those two wrapper-owned command ids while leaving other plugin command ids advertised through `vscode-languageclient`. Because VS Code command ids are global, the extension also sets `ExecuteCommandIDPrefix` per project root so custom plugin commands from multiple roots do not collide; the proxy maps prefixed ids back before calling `ExecuteCommand()`. If an embedder relies on `vscode-languageclient` to register advertised plugin commands, it must still apply any returned `changes`-map `WorkspaceEdit`; the languageclient command handler only invokes `workspace/executeCommand`.
+
+`CompletionHintSource.CompletionHints()` returns `[]driver.LSPCompletionHint`. Each group names a JSDoc-scoped literal in `After` and an ordered list of `LSPCompletionItem` values. The proxy matches the corpus against the live document, appends the matching items to TypeScript-Go's completion response, and keeps TypeScript-Go's own items. The items are fully resolved plain-text insertions with optional labels and short details; they do not use `completionItem/resolve`.
+
+```go
+type source struct {
+    driver.NullPluginSource
+}
+
+var _ driver.CompletionHintSource = (*source)(nil)
+
+func (s *source) CompletionHints() []driver.LSPCompletionHint {
+    return []driver.LSPCompletionHint{{
+        Scope: "jsdoc",
+        After: "@",
+        Items: []driver.LSPCompletionItem{{
+            Insert: "example",
+            Detail: "project tag",
+        }},
+    }}
+}
+```
 
 `LSPServerOptions.Upstream` is an invocation-scoped dependency for controlled embedders and tests. Its zero value selects the production runner and enforces the absolute `TsgoBinary` contract. A custom `LSPUpstream` carries its runner and optional validator together; a custom validator without a custom runner is rejected with `ErrLSPUpstreamRunnerRequired`. `RunLSPServer` captures that pair before it starts the proxy and upstream goroutines, so concurrent servers cannot replace each other's execution path.
 
@@ -201,6 +222,7 @@ err := driver.RunLSPServer(context.Background(), driver.LSPServerOptions{
 | Symbol | Purpose |
 | --- | --- |
 | `PluginSource` interface, `NullPluginSource` | The seam downstream pipelines implement to feed ttsc plugins into the LSP. |
+| `CompletionHintSource`, `LSPCompletionHint`, `LSPCompletionItem` | Optional completion corpus contributed alongside a `PluginSource`. |
 | `NativePluginSource`, `NewNativePluginSource`, `NativePluginManifest` | Sidecar-backed `PluginSource` implementation used by the shipped `ttscserver` launcher. |
 | `RunLSPServer`, `LSPServerOptions`, `LSPUpstream`, `ErrLSPUpstreamRunnerRequired`, `ErrCommandNotHandled` | Host-side entry points and invocation-scoped upstream dependency. |
 | `LSPDocumentVersion`, `LSPDiagnostic`, `LSPCodeAction`, `LSPRange`, `LSPWorkspaceEdit` | Wire types in the LSP envelope. |

--- a/website/src/content/docs/faq.mdx
+++ b/website/src/content/docs/faq.mdx
@@ -90,6 +90,16 @@ code --install-extension samchon.ttsc
 6. Run **ttsc: Restart language server** from the command palette.
 7. Set `ttsc.trace.server` to `"verbose"` in VS Code settings, then read **View → Output → ttsc (trace)** if the server log is empty.
 
+## VS Code shows lint diagnostics but no lint completion: what's wrong?
+
+1. Confirm the rule that owns the completion is enabled globally. To test the built-in path, set `"jsdoc/check-tag-names": "error"` in the top-level `rules` map.
+2. Put the cursor inside a real `/** ... */` block in a TypeScript file. Decorators, line comments, and Markdown files are outside the supported scope.
+3. Press Ctrl+Space after `@` to request completion explicitly.
+4. Run **ttsc: Restart language server** after changing the lint config or the project inputs a contributor rule indexes.
+5. Open **View → Output → ttsc** and enable `ttsc.trace.server: "verbose"` if completion still stays empty.
+
+The [Lint in VS Code](/docs/lint/editor) guide explains which features use the live buffer and which use saved project state.
+
 ## Does it work in a monorepo?
 
 Yes. Each package has its own `tsconfig.json` and its own `lint.config.ts`. `ttsc` reads from the directory it's invoked in (or `-p path/to/tsconfig.json`). `pnpm` / `npm` / `yarn` workspaces all work.

--- a/website/src/content/docs/lint/_meta.ts
+++ b/website/src/content/docs/lint/_meta.ts
@@ -3,6 +3,7 @@ import type { MetaRecord } from "nextra";
 const meta: MetaRecord = {
   index: "Overview",
   setup: "Setup",
+  editor: "VS Code",
   format: "Format",
   rules: "Rules",
 };

--- a/website/src/content/docs/lint/editor.mdx
+++ b/website/src/content/docs/lint/editor.mdx
@@ -1,0 +1,113 @@
+# Lint in VS Code
+
+This page is for `@ttsc/lint` users who want compiler, lint, and contributor-plugin assistance in one VS Code session.
+
+The `@ttsc/vscode` extension starts one `ttscserver` for the selected project. That server forwards TypeScript-Go language features and merges the editor features published by `@ttsc/lint` and its contributor rules into the same LSP stream.
+
+| Editor feature | Provider |
+| --- | --- |
+| TypeScript and JavaScript hover, navigation, completion, and diagnostics | TypeScript-Go |
+| Lint diagnostics, suggestions, fix-all actions, and formatting | `@ttsc/lint` |
+| Rule-published completion, such as known JSDoc tags or project-indexed document anchors | A lint project rule that publishes completion hints |
+
+The editor does not start a separate ESLint language server or maintain a second rule config. It resolves the project's own `ttsc`, `typescript`, `tsconfig.json`, plugins, and `lint.config.*`.
+
+## Install the editor path
+
+Install the project dependencies, then install the extension:
+
+```bash
+npm install -D ttsc typescript @ttsc/lint
+npx @ttsc/vscode
+```
+
+The extension also ships through the VS Code Marketplace as `samchon.ttsc`. See [Setup → VS Code](/docs/setup/vscode) for the direct `code --install-extension` form, formatter settings, multi-root behavior, and server tracing.
+
+## Complete a valid JSDoc tag
+
+Enable the built-in `jsdoc/check-tag-names` rule in the global rules map:
+
+```ts
+// lint.config.ts
+import type { ITtscLintConfig } from "@ttsc/lint";
+
+export default {
+  rules: {
+    "jsdoc/check-tag-names": "error",
+    "no-var": "error",
+  },
+  format: {
+    singleQuote: true,
+    trailingComma: "all",
+  },
+} satisfies ITtscLintConfig;
+```
+
+Open a TypeScript file and start a JSDoc tag:
+
+```ts
+/**
+ * Greets one user.
+ * @par
+ */
+export function greet(name: string): string {
+  return `Hello, ${name}`;
+}
+```
+
+With the cursor after `@par`, VS Code offers `param` from the same tag set that `jsdoc/check-tag-names` validates. Select it, then finish the line as `@param name user name`. You can also press Ctrl+Space to request completion explicitly.
+
+Use the completion inside a TypeScript `/** ... */` JSDoc block. Decorators, line comments, and Markdown documents are outside the supported scope.
+
+Completion uses the live editor buffer, so it remains available while the file is dirty. The rule's completion corpus is discovered in the background when the language server starts. If you have just enabled the rule or changed inputs that shape a contributor's project index, run **ttsc: Restart language server** to force a fresh discovery.
+
+## See the same rule reject a typo
+
+Leave an unknown tag such as `@parm` in the JSDoc block and save the file. `jsdoc/check-tag-names` publishes its finding beside TypeScript-Go diagnostics through the same Problems panel and source underline.
+
+Plugin diagnostics and code actions use the saved project state. Save before relying on a new lint diagnostic or invoking a lint action. TypeScript-Go language features and project-rule completion continue to use the live buffer, while format-on-save formats that live buffer as part of the save.
+
+## Suggestions, fixes, and format
+
+Rules can offer suggestions for repairs that require a choice. Put the cursor on the diagnostic and open **Quick Fix** to select one. Suggestions are editor-only actions and never run automatically during `ttsc fix`.
+
+Automatic fixes are available through **ttsc: Fix all lint issues** or the `source.fixAll.ttsc` code action. To run fix-all explicitly on save:
+
+```jsonc
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.ttsc": "explicit"
+  }
+}
+```
+
+Formatting is a separate write operation. Set `samchon.ttsc` as the default formatter to use the same `format` block from `lint.config.*` in VS Code and `ttsc format`:
+
+```jsonc
+{
+  "[typescript][typescriptreact]": {
+    "editor.defaultFormatter": "samchon.ttsc",
+    "editor.formatOnSave": true
+  }
+}
+```
+
+See [Format](/docs/lint/format) for every supported key and the fallback to VS Code indentation and line-ending settings when no `format` block exists.
+
+## Contributor project indexes
+
+`jsdoc/check-tag-names` publishes a fixed set of known tags. A contributor project rule can publish completions from the state it indexed for the loaded Program. `ttscserver` appends those items to TypeScript-Go's completion response instead of replacing it.
+
+The feature originated from work on [`@samchon/evidence`](https://github.com/samchon/evidence). Its [`feat/editor-hints`](https://github.com/samchon/evidence/tree/feat/editor-hints) development branch shows a richer external use: a project index describing JSDoc citation tags, document paths, and section anchors. That package has its own release schedule and is not part of the `ttsc` distribution.
+
+Plugin authors can implement this channel through [`rule.HintRule`](/docs/development/walkthroughs/lint#editor-hints-from-a-project-rule). Editor embedders can implement the driver-level [`CompletionHintSource`](/docs/development/reference/driver-api#hosting-ttscserver).
+
+## Troubleshooting completion
+
+1. Confirm the workspace has a `tsconfig.json` and resolves `ttsc`: `npx ttsc --version`.
+2. Confirm `jsdoc/check-tag-names` is enabled in the global rules map.
+3. Put the cursor inside a `/** ... */` block in a TypeScript file, then press Ctrl+Space after `@`.
+4. Run **ttsc: Restart language server** after changing the rule config or a contributor's indexed project inputs.
+5. Open **View → Output → ttsc** for the server log. Set `ttsc.trace.server` to `"verbose"` when the normal log is not enough.
+
+For general extension startup and project-selection failures, continue with the [VS Code troubleshooting checklist](/docs/faq#vs-code-doesnt-show-typescript-go-or-plugin-diagnostics-whats-wrong).

--- a/website/src/content/docs/lint/index.mdx
+++ b/website/src/content/docs/lint/index.mdx
@@ -23,8 +23,9 @@ Rules contributed by another Go package use the same collision-free band. Their 
 ## The shape of the chapter
 
 1. [Setup](/docs/lint/setup): install and write `lint.config.ts`. Five minutes.
-2. [Format](/docs/lint/format): the `format` block. Quotes, semis, trailing commas, print-width reflow. The Prettier surface.
-3. [Rules](/docs/lint/rules): the lint rule catalog by category.
+2. [VS Code](/docs/lint/editor): completion, diagnostics, suggestions, fixes, and formatting through one `ttscserver`.
+3. [Format](/docs/lint/format): the `format` block. Quotes, semis, trailing commas, print-width reflow. The Prettier surface.
+4. [Rules](/docs/lint/rules): the lint rule catalog by category.
 
 If you only have five minutes: read [Setup](/docs/lint/setup), copy the `lint.config.ts` starter from there, run `ttsc fix` once, and let the diagnostics tell you the rest.
 
@@ -32,6 +33,7 @@ If you only have five minutes: read [Setup](/docs/lint/setup), copy the `lint.co
 
 - **A format block** that covers Prettier's territory: semis, quotes, trailing commas, a print-width reflow. Replaces `prettier`.
 - **720+ lint rules** across 21 families (Core, TypeScript, React, JSX-A11y, Promise, Solid, Unicorn, Testing Library, Jest, Vitest, Playwright, Cypress, Storybook, Next.js, TanStack Query, Regexp, Security, JSDoc, Functional, Boundaries, react-perf). Severity per rule (`error` / `warning` / `off`). Replaces `eslint`.
+- **One editor stream** for TypeScript-Go completion and diagnostics, lint findings and actions, and completion corpora published by project rules.
 
 ## Commands
 
@@ -51,4 +53,4 @@ npx ttsc format         # rewrite source files with the format rules only
 
 ## Next
 
-→ [Setup](/docs/lint/setup)
+→ [Setup](/docs/lint/setup) · [VS Code](/docs/lint/editor)

--- a/website/src/content/docs/lint/rules/jsdoc.mdx
+++ b/website/src/content/docs/lint/rules/jsdoc.mdx
@@ -40,6 +40,8 @@ Examples come from the checked [lint corpus](https://github.com/samchon/ttsc/tre
 
 Reject unknown JSDoc block-tag names. Catches typos like `@returs` or `@parm`.
 
+When this rule is enabled in the global rules map, the VS Code extension completes the same known tag names inside `/** ... */` blocks. A `files`-scoped setting still validates matching files, but it does not publish a project-wide completion corpus. See [Lint in VS Code](/docs/lint/editor) for a runnable example.
+
 Example:
 
 ```ts

--- a/website/src/content/docs/setup/vscode.mdx
+++ b/website/src/content/docs/setup/vscode.mdx
@@ -1,6 +1,6 @@
 # VS Code
 
-The extension shows your build's diagnostics in the editor. It reads the project's own `ttsc`, `typescript`, and plugin config, so what you see while typing is what `npx ttsc` will say in CI, including lint violations from `@ttsc/lint` and diagnostics from any other LSP-capable plugin.
+The extension brings TypeScript-Go and supported `ttsc` plugin features into one editor session. It reads the project's own `ttsc`, `typescript`, and plugin config, so the lint diagnostics you see in VS Code match what `npx ttsc` reports in CI.
 
 It needs VS Code 1.94 or later and a workspace with a `tsconfig.json` (or `jsconfig.json`).
 
@@ -17,9 +17,12 @@ That wraps the `code` CLI; the direct form is `code --install-extension samchon.
 ## What it adds
 
 - TypeScript-Go hover, navigation, completions, and diagnostics.
-- `@ttsc/lint` diagnostics and code actions, including fix-all and format.
+- `@ttsc/lint` diagnostics, suggestions, fix-all actions, and format.
+- JSDoc completion from a built-in lint rule and project-indexed completion from contributor rules that publish it.
 - Command palette entries: `ttsc: Fix all lint issues`, `ttsc: Format document`, `ttsc: Restart language server`.
 - Multi-root workspaces, each folder keeping its own `ttsc`, `typescript`, and plugin config.
+
+The [Lint in VS Code](/docs/lint/editor) guide walks through the single-server workflow with a runnable JSDoc completion example.
 
 ## Format on save
 
@@ -54,4 +57,4 @@ Work through these in order:
 4. Open **View → Output**, pick **ttsc** from the dropdown, and read the server log.
 5. For full LSP tracing, set `ttsc.trace.server` to `"verbose"` and reload the window.
 
-The full reference, including the uninstall command, is in the [`@ttsc/vscode` README](https://github.com/samchon/ttsc/tree/master/packages/vscode).
+The full extension reference, including the uninstall command, is in the [`@ttsc/vscode` README](https://github.com/samchon/ttsc/tree/master/packages/vscode). See [Lint in VS Code](/docs/lint/editor) for completion, diagnostics, suggestions, fixes, and formatting in one workflow.


### PR DESCRIPTION
## Summary

Carry the lint hint corpus all the way through `ttscserver` into VS Code, then use that channel in the built-in JSDoc validator and document the complete editor workflow.

This follows the editor-hint channel introduced by #736 and the built-in candidate identified by #768. The original external use case is [`samchon/evidence#17`](https://github.com/samchon/evidence/issues/17).

## What changed

- Decode the real flat `[]rule.Hint` wire while keeping grouped third-party compatibility.
- Merge plugin items into array, null, and open `CompletionList` responses without losing upstream fields or leaking `itemDefaults`.
- Replace the complete post-trigger filter with a UTF-16 range, preserve publisher ranking, and resolve plugin-owned items locally.
- Expose the completion-hint source and wire types through the public driver package.
- Make `jsdoc/check-tag-names` publish the same sorted canonical tag vocabulary it validates, without changing files-scoped rule semantics.
- Add the VS Code user guide, driver reference, troubleshooting, and the FAQ and setup entries that point at them.

## What is deliberately not here

**Promotional media.** An earlier revision of this branch carried 45 rendered video files, about 22 MB, which would have roughly doubled the tracked website payload with binaries no checkout could rebuild. They are now rendered locally into a gitignored `/.media/` folder, published as GitHub-hosted attachments in #792, and referenced from documentation by URL. The `.gitignore` entry that records this policy is the only trace left in the tree.

The flagship clip changed with the policy. JSDoc tag completion is something TypeScript already offers, so a clip of it demonstrates a capability a viewer would reasonably assume predates the plugin; the replacement set shows two rules per family and what each publishes into the editor.

**The end-to-end completion test.** It is in #793 instead. It failed twice in a way that does not look like a harness problem — the sibling server tests passed, the lint diagnostic arrived, and only `textDocument/completion` went unanswered — so it carries a probe to settle whether the fault is in the enriched path. Holding this reviewed change behind that question would trade a verified improvement for an unfinished investigation.

## Verification

- `go test ./internal/lspserver ./driver ./test/driver -count=1`
- `go vet ./internal/lspserver ./driver`
- `node scripts/test-go-lint.cjs`
- `pnpm test:typecheck`
- `pnpm --dir packages/vscode build`
- full repository CI on this branch

## Follow-ups

- #793 settles whether a real session answers rule-published completion.
- #788 refreshes project-derived corpora and late trigger characters without a language-server restart.
- #789 makes JSDoc scope lexical so delimiter-shaped text inside strings cannot trigger the corpus.
- #771 remains the prerequisite for exercising server→client dynamic capability registration in the shared LSP test harness.
