### PR TITLE
fix(factory): keep printed text faithful to the AST across parentheses, list commas and JSX whitespace

### DIFF
--- a/packages/factory/README.md
+++ b/packages/factory/README.md
@@ -89,6 +89,8 @@ factory.createCallExpression(id("foo"), undefined, [a, b]); // foo(a, b)
 // )
 ```
 
+`printWidth` picks a layout, never a meaning. The break-time trailing comma is dropped where it would change the program (after the rest element of a destructuring assignment target, or after an argument-list hole), and it is written in both layouts where it is a value (the hole in `["a", "b", ,]`). JSX children stay on one line whenever a break would delete a whitespace-only child or trim the significant edge space off a text child, so the same tree renders the same text at every width.
+
 ### Comments
 
 Attach leading / trailing comments with the legacy `ts.addSyntheticLeadingComment` family. The printer renders them in place — multi-line bodies re-indent with their node, so JSDoc on a nested member stays aligned.

--- a/packages/factory/src/TsPrinter.ts
+++ b/packages/factory/src/TsPrinter.ts
@@ -22,6 +22,7 @@ import {
   join,
   line,
   printDocToString,
+  raw,
   softline,
 } from "./internal/doc";
 import { NodeFlags, SyntaxKind } from "./syntax";
@@ -116,7 +117,7 @@ export class TsPrinter {
     close: string,
     opts: {
       space?: boolean;
-      trailingComma?: boolean;
+      trailingComma?: TrailingComma;
       forceBreak?: boolean;
     } = {},
   ): Doc {
@@ -126,7 +127,11 @@ export class TsPrinter {
       concat([
         open,
         indent(concat([ln, join(concat([",", line]), items)])),
-        opts.trailingComma ? ifBreak(",") : "",
+        opts.trailingComma === "always"
+          ? ","
+          : opts.trailingComma === "onBreak"
+            ? ifBreak(",")
+            : "",
         ln,
         close,
       ]),
@@ -191,28 +196,78 @@ export class TsPrinter {
           args.map((a) => this.emit(a)),
           ">",
           {
-            trailingComma: false,
+            trailingComma: "never",
           },
         )
       : "";
   }
 
   /**
-   * Whether a broken parameter list / binding pattern may append a synthetic
-   * trailing comma after its last element.
+   * Trailing-comma policy for a parameter list or binding pattern.
    *
-   * A trailing comma after a rest element (`...rest`) is a syntax error (TS1013
-   * / V8 `SyntaxError`), and one after a trailing elision (`OmittedExpression`)
-   * is not cosmetic: `[a, ,]` parses to one more hole than `[a, ]`, so the flat
-   * and broken layouts of the same node would disagree. Call arguments and
-   * array / object literals are unaffected — a trailing comma after a spread is
-   * legal there.
+   * A comma the printer adds only because a group broke must never change
+   * whether the text parses, nor what it parses to. After a rest element
+   * (`...rest`) it changes the first: a trailing comma there is a syntax error
+   * (TS1013 / V8 `SyntaxError`). After a trailing elision it changes the
+   * second: `[a, ,]` has one more hole than `[a, ]`, so the flat and broken
+   * layouts of the same node would disagree. A binding pattern is the one place
+   * where dropping that hole is lossless, since a trailing hole binds nothing;
+   * {@link literalTrailingComma} materializes it instead, because in an array
+   * literal the hole is a value.
    */
-  private listTrailingComma(nodes: readonly Node[]): boolean {
+  private listTrailingComma(nodes: readonly Node[]): TrailingComma {
     const last: Node | undefined = nodes[nodes.length - 1];
-    if (last === undefined) return true;
-    if (last.kind === "OmittedExpression") return false;
-    return !("dotDotDotToken" in last && last.dotDotDotToken !== undefined);
+    if (last === undefined) return "onBreak";
+    if (last.kind === "OmittedExpression") return "never";
+    return "dotDotDotToken" in last && last.dotDotDotToken !== undefined
+      ? "never"
+      : "onBreak";
+  }
+
+  /**
+   * Trailing-comma policy for a call or `new` argument list.
+   *
+   * A trailing `OmittedExpression` prints as nothing, so the list already ends
+   * in the separator comma of its last real argument: `f(a, )`, which is what
+   * the legacy printer emits too and parses as one argument. Adding the break
+   * comma on top produces `f(a, ,)`, which is a syntax error. A trailing spread
+   * is unaffected — a comma after it is legal in an argument list.
+   */
+  private argsTrailingComma(args: readonly Expression[]): TrailingComma {
+    const last: Expression | undefined = args[args.length - 1];
+    return last !== undefined && last.kind === "OmittedExpression"
+      ? "never"
+      : "onBreak";
+  }
+
+  /**
+   * Trailing-comma policy for an array or object literal.
+   *
+   * Two positions make the comma load-bearing rather than cosmetic.
+   *
+   * A trailing elision is a **value**: the comma is the token that materializes
+   * the hole, so `["a", ]` has one element and `["a", ,]` has two. The legacy
+   * printer emits it in every layout, so this printer emits it in every layout
+   * too; leaving it to the break would make the same node mean different things
+   * at different widths.
+   *
+   * A destructuring **assignment target** is the same node kind as an rvalue
+   * literal, but ECMAScript forbids a comma after its `AssignmentRestElement` /
+   * `AssignmentRestProperty`: `[a, ...rest,] = source` is a syntax error, while
+   * the identical rvalue `[a, ...rest,]` is legal. Only the target position
+   * suppresses it, so the rvalue twin keeps its break comma.
+   */
+  private literalTrailingComma(
+    elements: readonly Node[],
+    assignmentTarget: boolean,
+  ): TrailingComma {
+    const last: Node | undefined = elements[elements.length - 1];
+    if (last === undefined) return "onBreak";
+    if (last.kind === "OmittedExpression") return "always";
+    return assignmentTarget &&
+      (last.kind === "SpreadElement" || last.kind === "SpreadAssignment")
+      ? "never"
+      : "onBreak";
   }
 
   private params(params: readonly Node[]): Doc {
@@ -232,7 +287,7 @@ export class TsPrinter {
       args.map((a) => this.expressionForDisallowedComma(a)),
       ")",
       {
-        trailingComma: true,
+        trailingComma: this.argsTrailingComma(args),
       },
     );
   }
@@ -277,6 +332,51 @@ export class TsPrinter {
       : "";
   }
 
+  /**
+   * Lay out a JSX element's or fragment's children.
+   *
+   * A line break between JSX children is not cosmetic. JSX deletes a
+   * whitespace-only text child that contains a newline and trims
+   * whitespace-carrying-a-newline off both edges of every other text child, so
+   * a break introduced only because the group did not fit changes what the
+   * component renders: `<div>Hello there, {name}!</div>` becomes
+   * `Hello there,NAME!`, and the separator in `<div>{a} {b}</div>` disappears
+   * outright.
+   *
+   * Children are therefore laid out across lines only when the break survives
+   * that transformation unchanged: every text child must carry non-whitespace
+   * content, must not begin or end with whitespace, and must not sit next to
+   * another text child, since inserting a newline between two of them would
+   * merge into one text with a space in the middle. Otherwise the children are
+   * emitted verbatim on one line, whatever `printWidth` says — width may choose
+   * a layout, never a meaning.
+   */
+  private jsxChildren(
+    open: Doc,
+    children: readonly Node[],
+    close: Doc,
+  ): Doc {
+    if (!this.jsxChildrenMayBreak(children))
+      return concat([open, concat(children.map((c) => this.emit(c))), close]);
+    return group(
+      concat([
+        open,
+        indent(concat(children.map((c) => concat([softline, this.emit(c)])))),
+        softline,
+        close,
+      ]),
+    );
+  }
+
+  private jsxChildrenMayBreak(children: readonly Node[]): boolean {
+    return children.every(
+      (child, index) =>
+        child.kind !== "JsxText" ||
+        (isBreakSafeJsxText(child.text) &&
+          children[index + 1]?.kind !== "JsxText"),
+    );
+  }
+
   private optType(type: Node | undefined): Doc {
     return type ? concat([": ", this.emit(type)]) : "";
   }
@@ -285,8 +385,16 @@ export class TsPrinter {
     return body ? concat([" ", this.emit(body)]) : ";";
   }
 
-  private emit(node: Node): Doc {
-    const body: Doc = this.emitNode(node);
+  /**
+   * @param assignmentTarget Whether `node` occupies destructuring
+   *   assignment-target position, where an array or object literal is a pattern
+   *   rather than a value. The flag is set by the assignment and `for…in` /
+   *   `for…of` cases, forwarded by every node that is transparent to it (a
+   *   spread, a property's initializer, a parenthesis, an `=` default), and
+   *   dropped by every other node.
+   */
+  private emit(node: Node, assignmentTarget: boolean = false): Doc {
+    const body: Doc = this.emitNode(node, assignmentTarget);
     const leading: SynthesizedComment[] | undefined =
       getSyntheticLeadingComments(node);
     const trailing: SynthesizedComment[] | undefined =
@@ -338,7 +446,7 @@ export class TsPrinter {
     ]);
   }
 
-  private emitNode(node: Node): Doc {
+  private emitNode(node: Node, assignmentTarget: boolean): Doc {
     switch (node.kind) {
       /* names & tokens */
       case "Identifier":
@@ -350,7 +458,7 @@ export class TsPrinter {
       case "Token":
         return node.token;
       case "Decorator":
-        return concat(["@", this.leftSideExpression(node.expression)]);
+        return concat(["@", this.leftSideExpression(node.expression, false)]);
 
       /* literals */
       case "StringLiteral":
@@ -364,18 +472,29 @@ export class TsPrinter {
       case "ArrayLiteralExpression":
         return this.delim(
           "[",
-          node.elements.map((e) => this.expressionForDisallowedComma(e)),
+          node.elements.map((e) =>
+            this.expressionForDisallowedComma(e, assignmentTarget),
+          ),
           "]",
-          { trailingComma: true, forceBreak: node.multiLine === true },
+          {
+            trailingComma: this.literalTrailingComma(
+              node.elements,
+              assignmentTarget,
+            ),
+            forceBreak: node.multiLine === true,
+          },
         );
       case "ObjectLiteralExpression":
         return this.delim(
           "{",
-          node.properties.map((p) => this.emit(p)),
+          node.properties.map((p) => this.emit(p, assignmentTarget)),
           "}",
           {
             space: true,
-            trailingComma: true,
+            trailingComma: this.literalTrailingComma(
+              node.properties,
+              assignmentTarget,
+            ),
             forceBreak: node.multiLine === true,
           },
         );
@@ -383,7 +502,7 @@ export class TsPrinter {
         return concat([
           this.emit(node.name),
           ": ",
-          this.expressionForDisallowedComma(node.initializer),
+          this.expressionForDisallowedComma(node.initializer, assignmentTarget),
         ]);
       case "ShorthandPropertyAssignment":
         return concat([
@@ -400,24 +519,24 @@ export class TsPrinter {
       case "SpreadAssignment":
         return concat([
           "...",
-          this.expressionForDisallowedComma(node.expression),
+          this.expressionForDisallowedComma(node.expression, assignmentTarget),
         ]);
       case "PropertyAccessExpression":
         return concat([
-          this.leftSideExpression(node.expression),
+          this.leftSideExpression(node.expression, false),
           ".",
           this.emit(node.name),
         ]);
       case "ElementAccessExpression":
         return concat([
-          this.leftSideExpression(node.expression),
+          this.leftSideExpression(node.expression, false),
           "[",
           this.expressionForDisallowedComma(node.argumentExpression),
           "]",
         ]);
       case "CallExpression":
         return concat([
-          this.leftSideExpression(node.expression),
+          this.leftSideExpression(node.expression, false),
           this.typeArguments(node.typeArguments),
           this.args(node.arguments),
         ]);
@@ -429,11 +548,19 @@ export class TsPrinter {
           this.args(node.arguments ?? []),
         ]);
       case "ParenthesizedExpression":
-        return concat(["(", this.emit(node.expression), ")"]);
+        return concat(["(", this.emit(node.expression, assignmentTarget), ")"]);
       case "BinaryExpression":
+        // the left side of `=` is a destructuring assignment target, both for a
+        // top-level assignment and for a `[a = init]` default inside one
         return group(
           concat([
-            this.binaryOperand(node.operator, node.left, true),
+            this.binaryOperand(
+              node.operator,
+              node.left,
+              true,
+              undefined,
+              node.operator === SyntaxKind.EqualsToken,
+            ),
             " ",
             node.operator,
             indent(
@@ -501,11 +628,11 @@ export class TsPrinter {
           this.emit(node.type),
         ]);
       case "NonNullExpression":
-        return concat([this.leftSideExpression(node.expression), "!"]);
+        return concat([this.leftSideExpression(node.expression, false), "!"]);
       case "SpreadElement":
         return concat([
           "...",
-          this.expressionForDisallowedComma(node.expression),
+          this.expressionForDisallowedComma(node.expression, assignmentTarget),
         ]);
       case "AwaitExpression":
         return concat(["await ", this.prefixUnaryOperand(node.expression)]);
@@ -543,7 +670,7 @@ export class TsPrinter {
           node.elements.map((e) => this.emit(e)),
           "]",
           {
-            trailingComma: true,
+            trailingComma: "onBreak",
           },
         );
       case "ParenthesizedTypeNode":
@@ -564,8 +691,11 @@ export class TsPrinter {
       case "TypeQueryNode":
         return concat(["typeof ", this.emit(node.exprName)]);
       case "ExpressionWithTypeArguments":
+        // heritage clauses take a LeftHandSideExpression: `class A extends
+        // (X || Y) {}` does not parse without the parentheses, and a bare comma
+        // sequence silently becomes two base classes
         return concat([
-          this.emit(node.expression),
+          this.leftSideExpression(node.expression, false),
           this.typeArguments(node.typeArguments),
         ]);
       case "PropertySignature":
@@ -840,7 +970,7 @@ export class TsPrinter {
           "{",
           node.elements.map((e) => this.emit(e)),
           "}",
-          { space: true, trailingComma: true },
+          { space: true, trailingComma: "onBreak" },
         );
       case "ImportSpecifier":
         return concat([
@@ -868,7 +998,7 @@ export class TsPrinter {
           "{",
           node.elements.map((e) => this.emit(e)),
           "}",
-          { space: true, trailingComma: true },
+          { space: true, trailingComma: "onBreak" },
         );
       case "ExportSpecifier":
         return concat([
@@ -914,7 +1044,7 @@ export class TsPrinter {
       case "ForInStatement":
         return concat([
           "for (",
-          this.emit(node.initializer),
+          this.emit(node.initializer, true),
           " in ",
           this.emit(node.expression),
           ") ",
@@ -925,7 +1055,7 @@ export class TsPrinter {
           "for ",
           node.awaitModifier ? "await " : "",
           "(",
-          this.emit(node.initializer),
+          this.emit(node.initializer, true),
           " of ",
           this.emit(node.expression),
           ") ",
@@ -1195,7 +1325,7 @@ export class TsPrinter {
         ]);
       case "TaggedTemplateExpression":
         return concat([
-          this.leftSideExpression(node.tag),
+          this.leftSideExpression(node.tag, false),
           this.typeArguments(node.typeArguments),
           this.emit(node.template),
         ]);
@@ -1276,13 +1406,13 @@ export class TsPrinter {
         ]);
       case "PropertyAccessChain":
         return concat([
-          this.leftSideExpression(node.expression),
+          this.leftSideExpression(node.expression, true),
           node.questionDotToken ? "?." : ".",
           this.emit(node.name),
         ]);
       case "ElementAccessChain":
         return concat([
-          this.leftSideExpression(node.expression),
+          this.leftSideExpression(node.expression, true),
           node.questionDotToken ? "?." : "",
           "[",
           this.expressionForDisallowedComma(node.argumentExpression),
@@ -1290,27 +1420,20 @@ export class TsPrinter {
         ]);
       case "CallChain":
         return concat([
-          this.leftSideExpression(node.expression),
+          this.leftSideExpression(node.expression, true),
           node.questionDotToken ? "?." : "",
           this.typeArguments(node.typeArguments),
           this.args(node.arguments),
         ]);
       case "NonNullChain":
-        return concat([this.leftSideExpression(node.expression), "!"]);
+        return concat([this.leftSideExpression(node.expression, true), "!"]);
 
       /* jsx */
       case "JsxElement":
-        return group(
-          concat([
-            this.emit(node.openingElement),
-            indent(
-              concat(
-                node.children.map((c) => concat([softline, this.emit(c)])),
-              ),
-            ),
-            softline,
-            this.emit(node.closingElement),
-          ]),
+        return this.jsxChildren(
+          this.emit(node.openingElement),
+          node.children,
+          this.emit(node.closingElement),
         );
       case "JsxSelfClosingElement":
         return concat([
@@ -1331,24 +1454,19 @@ export class TsPrinter {
       case "JsxClosingElement":
         return concat(["</", this.emit(node.tagName), ">"]);
       case "JsxFragment":
-        return group(
-          concat([
-            this.emit(node.openingFragment),
-            indent(
-              concat(
-                node.children.map((c) => concat([softline, this.emit(c)])),
-              ),
-            ),
-            softline,
-            this.emit(node.closingFragment),
-          ]),
+        return this.jsxChildren(
+          this.emit(node.openingFragment),
+          node.children,
+          this.emit(node.closingFragment),
         );
       case "JsxOpeningFragment":
         return "<>";
       case "JsxClosingFragment":
         return "</>";
       case "JsxText":
-        return node.text;
+        // the one node emitted as unquoted source text: its trailing spaces are
+        // rendered content, so they must survive the layout engine's line trim
+        return raw(node.text);
       case "JsxAttribute":
         return node.initializer === undefined
           ? this.emit(node.name)
@@ -1626,16 +1744,63 @@ export class TsPrinter {
       : concat(["(", this.emit(expression), ")"]);
   }
 
-  private expressionForDisallowedComma(expression: Expression): Doc {
+  private expressionForDisallowedComma(
+    expression: Expression,
+    assignmentTarget: boolean = false,
+  ): Doc {
     return this.expressionPrecedence(expression) > ExpressionPrecedence.Comma
-      ? this.emit(expression)
+      ? this.emit(expression, assignmentTarget)
       : this.parenthesizedExpression(expression);
   }
 
-  private leftSideExpression(expression: Expression): Doc {
-    return this.isLeftHandSideExpression(expression)
-      ? this.emit(expression)
-      : this.parenthesizedExpression(expression);
+  /**
+   * Emit an operand the grammar requires to be a `LeftHandSideExpression`,
+   * mirroring the legacy parenthesizer's
+   * `parenthesizeLeftSideOfAccess(expression, optionalChain)`.
+   *
+   * `optionalChain` is the **consuming** node's own chain-ness, not the
+   * operand's. An optional chain may be emitted bare only when the node
+   * consuming it continues the same chain: `a?.b?.()` is one chain, while
+   * `(a?.b)()` is a plain call on the chain's value. Emitting the second as
+   * `a?.b()` re-parses as the first, which stops throwing on a nullish head,
+   * and in `new`, tagged-template and decorator position it does not compile at
+   * all.
+   */
+  private leftSideExpression(
+    expression: Expression,
+    optionalChain: boolean,
+  ): Doc {
+    return this.leftSideNeedsParentheses(expression, optionalChain)
+      ? this.parenthesizedExpression(expression)
+      : this.emit(expression);
+  }
+
+  /**
+   * Whether {@link leftSideExpression} wraps this operand.
+   *
+   * The legacy rule also parenthesizes an argument-less `new` here, because it
+   * prints `new X` bare and `new X.y` would re-parse with `y` on the target.
+   * This printer always emits the argument list, so `new X().y` already says
+   * what the tree says and needs no wrapper.
+   */
+  private leftSideNeedsParentheses(
+    expression: Expression,
+    optionalChain: boolean,
+  ): boolean {
+    if (!this.isLeftHandSideExpression(expression)) return true;
+    return !optionalChain && this.isOptionalChain(expression);
+  }
+
+  private isOptionalChain(expression: Expression): boolean {
+    switch (expression.kind) {
+      case "CallChain":
+      case "ElementAccessChain":
+      case "NonNullChain":
+      case "PropertyAccessChain":
+        return true;
+      default:
+        return false;
+    }
   }
 
   private newExpressionTarget(expression: Expression): Doc {
@@ -1648,21 +1813,76 @@ export class TsPrinter {
    * Whether a `new` target must be parenthesized to keep its call arguments
    * from re-binding to the `new` — mirroring the legacy printer's
    * `parenthesizeExpressionOfNew`. A `new` target is grammatically a
-   * `MemberExpression`, so a call anywhere on the target's left spine (not just
-   * a direct one: `new (f().bar)()`, `new (a.b().c)()`) would otherwise
-   * re-parse with the call's arguments consumed by the `new` — a different
-   * program. Argument-less `new` on the spine is kept parenthesized for
-   * continuity with the direct case, though this printer always prints an
-   * argument list, which already disambiguates it.
+   * `MemberExpression`, so a call anywhere on the target's printed left spine
+   * (not just a direct one: `new (f().bar)()`, `new (a.b().c)()`) would
+   * otherwise re-parse with the call's arguments consumed by the `new` — a
+   * different program. Argument-less `new` on the spine is kept parenthesized
+   * for continuity with the direct case, though this printer always prints an
+   * argument list, which already disambiguates it. Anything else falls back to
+   * the shared left-side rule, which is what parenthesizes an optional-chain
+   * target (`new (a?.b)()`, TS1209 without it).
    */
   private newExpressionTargetNeedsParentheses(expression: Expression): boolean {
-    if (!this.isLeftHandSideExpression(expression)) return true;
-    const leftmost: Expression = this.leftmostExpression(expression, true);
-    return (
-      leftmost.kind === "CallExpression" ||
-      leftmost.kind === "CallChain" ||
-      (leftmost.kind === "NewExpression" && leftmost.arguments === undefined)
-    );
+    const leftmost: Expression | undefined =
+      this.leftmostPrintedExpression(expression);
+    if (leftmost !== undefined) {
+      if (leftmost.kind === "CallExpression" || leftmost.kind === "CallChain")
+        return true;
+      if (leftmost.kind === "NewExpression")
+        return leftmost.arguments === undefined;
+    }
+    return this.leftSideNeedsParentheses(expression, false);
+  }
+
+  /**
+   * The node whose own text opens `expression`'s printed form, or `undefined`
+   * when that text opens with a printer-inserted `(`.
+   *
+   * The legacy factory parenthesizes each operand as it builds the node, so its
+   * `getLeftmostExpression` walk halts on the resulting
+   * `ParenthesizedExpression`. This printer decides the same parentheses at
+   * emit time instead, so the walk has to ask {@link leftSideNeedsParentheses}
+   * the same question directly; otherwise `new` re-wraps a target whose call is
+   * already behind parentheses, and `new (f?.()).bar()` comes out as
+   * `new ((f?.()).bar)()`. Calls halt the walk, matching the legacy
+   * `stopAtCallExpressions` mode this predicate is the only user of.
+   */
+  private leftmostPrintedExpression(
+    expression: Expression,
+  ): Expression | undefined {
+    switch (expression.kind) {
+      case "CallExpression":
+      case "CallChain":
+        return expression;
+      case "ElementAccessExpression":
+      case "NonNullExpression":
+      case "PropertyAccessExpression":
+        return this.leftmostPrintedLeftSide(expression.expression, false);
+      case "ElementAccessChain":
+      case "NonNullChain":
+      case "PropertyAccessChain":
+        return this.leftmostPrintedLeftSide(expression.expression, true);
+      case "TaggedTemplateExpression":
+        return this.leftmostPrintedLeftSide(expression.tag, false);
+      case "AsExpression":
+      case "SatisfiesExpression":
+        return this.leftmostPrintedExpression(expression.expression);
+      case "BinaryExpression":
+        return this.leftmostPrintedExpression(expression.left);
+      case "ConditionalExpression":
+        return this.leftmostPrintedExpression(expression.condition);
+      default:
+        return expression;
+    }
+  }
+
+  private leftmostPrintedLeftSide(
+    operand: Expression,
+    optionalChain: boolean,
+  ): Expression | undefined {
+    return this.leftSideNeedsParentheses(operand, optionalChain)
+      ? undefined
+      : this.leftmostPrintedExpression(operand);
   }
 
   private prefixUnaryOperand(operand: Expression, operator?: SyntaxKind): Doc {
@@ -1728,6 +1948,7 @@ export class TsPrinter {
     operand: Expression,
     isLeftSide: boolean,
     leftOperand?: Expression,
+    assignmentTarget: boolean = false,
   ): Doc {
     return this.binaryOperandNeedsParentheses(
       operator,
@@ -1736,7 +1957,7 @@ export class TsPrinter {
       leftOperand,
     )
       ? this.parenthesizedExpression(operand)
-      : this.emit(operand);
+      : this.emit(operand, assignmentTarget);
   }
 
   private binaryOperandNeedsParentheses(
@@ -2014,20 +2235,18 @@ export class TsPrinter {
 
   /**
    * Walk to the expression's leftmost node — the one that starts its printed
-   * text. With `stopAtCall`, calls terminate the walk instead of being walked
-   * through, matching the legacy `getLeftmostExpression`'s
-   * `stopAtCallExpressions` mode used by the `new`-target parenthesizer.
+   * text — matching the legacy `getLeftmostExpression`.
+   *
+   * Used by the statement, concise-body and export-default predicates, which
+   * ask only whether the text opens with a `function`, `class` or `{` token.
+   * The `new`-target predicate needs the printed left edge instead and uses
+   * {@link leftmostPrintedExpression}.
    */
-  private leftmostExpression(
-    expression: Expression,
-    stopAtCall: boolean = false,
-  ): Expression {
+  private leftmostExpression(expression: Expression): Expression {
     switch (expression.kind) {
+      case "AsExpression":
       case "CallExpression":
       case "CallChain":
-        if (stopAtCall) return expression;
-        return this.leftmostExpression(expression.expression, stopAtCall);
-      case "AsExpression":
       case "ElementAccessExpression":
       case "ElementAccessChain":
       case "NonNullExpression":
@@ -2035,13 +2254,13 @@ export class TsPrinter {
       case "PropertyAccessExpression":
       case "PropertyAccessChain":
       case "SatisfiesExpression":
-        return this.leftmostExpression(expression.expression, stopAtCall);
+        return this.leftmostExpression(expression.expression);
       case "BinaryExpression":
-        return this.leftmostExpression(expression.left, stopAtCall);
+        return this.leftmostExpression(expression.left);
       case "ConditionalExpression":
-        return this.leftmostExpression(expression.condition, stopAtCall);
+        return this.leftmostExpression(expression.condition);
       case "TaggedTemplateExpression":
-        return this.leftmostExpression(expression.tag, stopAtCall);
+        return this.leftmostExpression(expression.tag);
       default:
         return expression;
     }
@@ -2224,6 +2443,19 @@ const escapeTemplateText = (text: string): string =>
     .replace(/\r\n/g, "\\r\\n")
     .replace(/\r/g, "\\r");
 
+/**
+ * Whether a JSX text child means the same thing with a line break and
+ * indentation around it.
+ *
+ * JSX drops a whitespace-only child that contains a newline and trims an edge
+ * whose whitespace contains one, so only a child with non-whitespace content
+ * and no edge whitespace survives being moved onto its own line. Newlines
+ * *inside* the text are unaffected, because JSX collapses each interior line
+ * break to a single space in either layout.
+ */
+const isBreakSafeJsxText = (text: string): boolean =>
+  text.length !== 0 && !/^\s/.test(text) && !/\s$/.test(text);
+
 const escapeString = (text: string, singleQuote?: boolean): string => {
   const escaped: string = text
     .replace(/\\/g, "\\\\")
@@ -2261,6 +2493,15 @@ const ExpressionPrecedence = {
 
 type ExpressionPrecedence =
   (typeof ExpressionPrecedence)[keyof typeof ExpressionPrecedence];
+
+/**
+ * Whether a delimited list may end with a comma, and in which layout.
+ *
+ * `"onBreak"` is the cosmetic default: the comma appears only when the group
+ * breaks. `"always"` and `"never"` are for the lists where the comma is part of
+ * the program rather than its layout.
+ */
+type TrailingComma = "never" | "onBreak" | "always";
 
 const Associativity = {
   Left: "left",

--- a/packages/factory/src/internal/doc.ts
+++ b/packages/factory/src/internal/doc.ts
@@ -12,6 +12,7 @@
  */
 export type Doc =
   | string
+  | { type: "raw"; text: string }
   | { type: "concat"; parts: Doc[] }
   | { type: "line" }
   | { type: "softline" }
@@ -22,6 +23,16 @@ export type Doc =
 
 /** Concatenate documents. */
 export const concat = (parts: Doc[]): Doc => ({ type: "concat", parts });
+/**
+ * Literal text whose trailing whitespace is content, not layout.
+ *
+ * {@link printDocToString} strips spaces and tabs from the end of a line before
+ * writing a newline, which is right for generated code and wrong for the one
+ * node emitted as unquoted source text, `JsxText`: a trimmed trailing space
+ * there deletes a JSX separator and changes what the component renders. Text
+ * emitted through this node is never trimmed.
+ */
+export const raw = (text: string): Doc => ({ type: "raw", text });
 /** A group: printed flat when it fits, broken otherwise. */
 export const group = (doc: Doc, shouldBreak: boolean = false): Doc => ({
   type: "group",
@@ -100,6 +111,9 @@ const fits = (next: Cmd, rest: readonly Cmd[], remaining: number): boolean => {
       continue;
     }
     switch (doc.type) {
+      case "raw":
+        width -= doc.text.length;
+        break;
       case "concat":
         for (let i = doc.parts.length - 1; i >= 0; i--)
           cmds.push([ind, mode, doc.parts[i]!]);
@@ -143,21 +157,30 @@ export const printDocToString = (
   const { printWidth, newLine, indent: tab } = options;
   const out: string[] = [];
   let pos = 0;
+  // whether the tail of `out` is raw text, whose trailing whitespace is content
+  let rawTail = false;
   const cmds: Cmd[] = [[0, MODE_BREAK, doc]];
   const newlineTo = (ind: number): void => {
-    if (out.length)
+    if (out.length && !rawTail)
       out[out.length - 1] = out[out.length - 1]!.replace(/[ \t]+$/, "");
     out.push(newLine + tab.repeat(ind));
     pos = tab.length * ind;
+    rawTail = false;
   };
   while (cmds.length) {
     const [ind, mode, d] = cmds.pop()!;
     if (typeof d === "string") {
       out.push(d);
       pos += d.length;
+      rawTail = false;
       continue;
     }
     switch (d.type) {
+      case "raw":
+        out.push(d.text);
+        pos += d.text.length;
+        rawTail = true;
+        break;
       case "concat":
         for (let i = d.parts.length - 1; i >= 0; i--)
           cmds.push([ind, mode, d.parts[i]!]);

--- a/packages/factory/src/internal/doc.ts
+++ b/packages/factory/src/internal/doc.ts
@@ -170,9 +170,13 @@ export const printDocToString = (
   while (cmds.length) {
     const [ind, mode, d] = cmds.pop()!;
     if (typeof d === "string") {
-      out.push(d);
-      pos += d.length;
-      rawTail = false;
+      // an empty string contributes nothing but would become the tail that
+      // `newlineTo` trims, hiding the real end of the line behind it
+      if (d.length !== 0) {
+        out.push(d);
+        pos += d.length;
+        rawTail = false;
+      }
       continue;
     }
     switch (d.type) {

--- a/tests/test-factory/src/features/declarations/test_heritage_expression_parentheses.ts
+++ b/tests/test-factory/src/features/declarations/test_heritage_expression_parentheses.ts
@@ -1,0 +1,333 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression, SyntaxKind } from "@ttsc/factory";
+import ts from "ts-legacy";
+
+import { id } from "../../internal/helpers";
+import { assertOracle, parseDiagnostics, wide } from "../../internal/oracle";
+
+const lid = (text: string) => ts.factory.createIdentifier(text);
+
+const extendsClass = (expression: Expression) =>
+  factory.createClassDeclaration(
+    undefined,
+    "A",
+    undefined,
+    [
+      factory.createHeritageClause(SyntaxKind.ExtendsKeyword, [
+        factory.createExpressionWithTypeArguments(expression, undefined),
+      ]),
+    ],
+    [],
+  );
+const legacyExtendsClass = (expression: ts.Expression) =>
+  ts.factory.createClassDeclaration(
+    undefined,
+    lid("A"),
+    undefined,
+    [
+      ts.factory.createHeritageClause(ts.SyntaxKind.ExtendsKeyword, [
+        ts.factory.createExpressionWithTypeArguments(expression, undefined),
+      ]),
+    ],
+    [],
+  );
+
+/**
+ * Verifies a heritage-clause expression is parenthesized when the grammar
+ * requires a `LeftHandSideExpression` there.
+ *
+ * `ExpressionWithTypeArguments` was the one expression-operand position still
+ * emitted with a raw `this.emit`, so `class A extends (X || Y) {}` printed
+ * without its parentheses and did not compile (TS1005), while a parenthesized
+ * comma sequence silently became *two* base classes — a single `extends`
+ * entry turning into two. Every `extends` and `implements` clause on a class
+ * declaration, class expression or interface funnels through this one branch.
+ * Expectations come from the legacy printer's output for the same tree.
+ *
+ * 1. Print a class `extends` clause over each non-left-hand-side expression
+ *    shape, and assert the printed text parses and means what the oracle's
+ *    text means.
+ * 2. Repeat the comma sequence through `implements`, a class expression and an
+ *    interface, since all four share the branch.
+ * 3. Assert the negative twins — a call and a qualified name — stay bare.
+ */
+export const test_heritage_expression_parentheses = (): void => {
+  const rows: [string, Expression, ts.Expression, string][] = [
+    [
+      "logical or",
+      factory.createBinaryExpression(id("X"), SyntaxKind.BarBarToken, id("Y")),
+      ts.factory.createBinaryExpression(
+        lid("X"),
+        ts.SyntaxKind.BarBarToken,
+        lid("Y"),
+      ),
+      "class A extends (X || Y) {}",
+    ],
+    [
+      "conditional",
+      factory.createConditionalExpression(
+        id("c"),
+        undefined,
+        id("X"),
+        undefined,
+        id("Y"),
+      ),
+      ts.factory.createConditionalExpression(
+        lid("c"),
+        undefined,
+        lid("X"),
+        undefined,
+        lid("Y"),
+      ),
+      "class A extends (c ? X : Y) {}",
+    ],
+    [
+      "as expression",
+      factory.createAsExpression(
+        id("Base"),
+        factory.createKeywordTypeNode(SyntaxKind.AnyKeyword),
+      ),
+      ts.factory.createAsExpression(
+        lid("Base"),
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+      ),
+      "class A extends (Base as any) {}",
+    ],
+    [
+      "await",
+      factory.createAwaitExpression(id("Base")),
+      ts.factory.createAwaitExpression(lid("Base")),
+      "class A extends (await Base) {}",
+    ],
+    [
+      "arrow function",
+      factory.createArrowFunction(
+        undefined,
+        undefined,
+        [],
+        undefined,
+        undefined,
+        id("x"),
+      ),
+      ts.factory.createArrowFunction(
+        undefined,
+        undefined,
+        [],
+        undefined,
+        undefined,
+        lid("x"),
+      ),
+      "class A extends (() => x) {}",
+    ],
+    [
+      "assignment",
+      factory.createAssignment(id("X"), id("Y")),
+      ts.factory.createAssignment(lid("X"), lid("Y")),
+      "class A extends (X = Y) {}",
+    ],
+    [
+      "optional chain",
+      factory.createPropertyAccessChain(
+        id("m"),
+        factory.createToken(SyntaxKind.QuestionDotToken),
+        "Base",
+      ),
+      ts.factory.createPropertyAccessChain(
+        lid("m"),
+        ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+        lid("Base"),
+      ),
+      "class A extends (m?.Base) {}",
+    ],
+  ];
+  for (const [title, expression, oracle, expected] of rows) {
+    const printed: string = wide.print(extendsClass(expression));
+    TestValidator.equals(title, printed, expected);
+    assertOracle(title, printed, legacyExtendsClass(oracle));
+  }
+
+  // the comma sequence is the silent one: without parentheses it parses, as two
+  // base classes rather than one
+  const comma = () =>
+    factory.createBinaryExpression(id("a"), SyntaxKind.CommaToken, id("B"));
+  const legacyComma = () =>
+    ts.factory.createBinaryExpression(
+      lid("a"),
+      ts.SyntaxKind.CommaToken,
+      lid("B"),
+    );
+  const baseCount = (text: string): number => {
+    const file: ts.SourceFile = ts.createSourceFile(
+      "case.ts",
+      text,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    TestValidator.equals("comma sequence parses", parseDiagnostics(file), []);
+    let count = -1;
+    const visit = (node: ts.Node): void => {
+      if (count < 0 && ts.isHeritageClause(node)) count = node.types.length;
+      ts.forEachChild(node, visit);
+    };
+    visit(file);
+    return count;
+  };
+  const commaExtends: string = wide.print(extendsClass(comma()));
+  TestValidator.equals(
+    "comma sequence stays one base class",
+    baseCount(commaExtends),
+    1,
+  );
+  assertOracle("comma sequence", commaExtends, legacyExtendsClass(legacyComma()));
+
+  const implementsClass: string = wide.print(
+    factory.createClassDeclaration(
+      undefined,
+      "A",
+      undefined,
+      [
+        factory.createHeritageClause(SyntaxKind.ImplementsKeyword, [
+          factory.createExpressionWithTypeArguments(id("P"), undefined),
+          factory.createExpressionWithTypeArguments(comma(), undefined),
+        ]),
+      ],
+      [],
+    ),
+  );
+  TestValidator.equals(
+    "implements keeps two entries",
+    baseCount(implementsClass),
+    2,
+  );
+  assertOracle(
+    "implements",
+    implementsClass,
+    ts.factory.createClassDeclaration(
+      undefined,
+      lid("A"),
+      undefined,
+      [
+        ts.factory.createHeritageClause(ts.SyntaxKind.ImplementsKeyword, [
+          ts.factory.createExpressionWithTypeArguments(lid("P"), undefined),
+          ts.factory.createExpressionWithTypeArguments(legacyComma(), undefined),
+        ]),
+      ],
+      [],
+    ),
+  );
+
+  const classExpression: string = wide.print(
+    factory.createExpressionStatement(
+      factory.createClassExpression(
+        undefined,
+        "C",
+        undefined,
+        [
+          factory.createHeritageClause(SyntaxKind.ExtendsKeyword, [
+            factory.createExpressionWithTypeArguments(comma(), undefined),
+          ]),
+        ],
+        [],
+      ),
+    ),
+  );
+  TestValidator.equals(
+    "class expression keeps one base class",
+    baseCount(classExpression),
+    1,
+  );
+  assertOracle(
+    "class expression",
+    classExpression,
+    ts.factory.createExpressionStatement(
+      ts.factory.createClassExpression(
+        undefined,
+        lid("C"),
+        undefined,
+        [
+          ts.factory.createHeritageClause(ts.SyntaxKind.ExtendsKeyword, [
+            ts.factory.createExpressionWithTypeArguments(
+              legacyComma(),
+              undefined,
+            ),
+          ]),
+        ],
+        [],
+      ),
+    ),
+  );
+
+  const interfaceExtends: string = wide.print(
+    factory.createInterfaceDeclaration(
+      undefined,
+      "I",
+      undefined,
+      [
+        factory.createHeritageClause(SyntaxKind.ExtendsKeyword, [
+          factory.createExpressionWithTypeArguments(comma(), undefined),
+        ]),
+      ],
+      [],
+    ),
+  );
+  TestValidator.equals(
+    "interface keeps one base",
+    baseCount(interfaceExtends),
+    1,
+  );
+
+  // an expression carrying type arguments as well as parentheses
+  const withTypeArguments: string = wide.print(
+    factory.createClassDeclaration(
+      undefined,
+      "A",
+      undefined,
+      [
+        factory.createHeritageClause(SyntaxKind.ExtendsKeyword, [
+          factory.createExpressionWithTypeArguments(
+            factory.createAsExpression(
+              id("Base"),
+              factory.createTypeReferenceNode("any"),
+            ),
+            [factory.createTypeReferenceNode("T")],
+          ),
+        ]),
+      ],
+      [],
+    ),
+  );
+  TestValidator.equals(
+    "type arguments follow the parentheses",
+    withTypeArguments,
+    "class A extends (Base as any)<T> {}",
+  );
+
+  // negative twins
+  TestValidator.equals(
+    "mixin call stays bare",
+    wide.print(
+      extendsClass(factory.createCallExpression(id("mixin"), undefined, [id("Base")])),
+    ),
+    "class A extends mixin(Base) {}",
+  );
+  TestValidator.equals(
+    "qualified name stays bare",
+    wide.print(
+      factory.createInterfaceDeclaration(
+        undefined,
+        "I",
+        undefined,
+        [
+          factory.createHeritageClause(SyntaxKind.ExtendsKeyword, [
+            factory.createExpressionWithTypeArguments(
+              factory.createPropertyAccessExpression(id("a"), "B"),
+              undefined,
+            ),
+          ]),
+        ],
+        [],
+      ),
+    ),
+    "interface I extends a.B {}",
+  );
+};

--- a/tests/test-factory/src/features/expressions/test_new_expression_target_spine_operator_parentheses.ts
+++ b/tests/test-factory/src/features/expressions/test_new_expression_target_spine_operator_parentheses.ts
@@ -16,22 +16,32 @@ const construct = (target: Expression): Expression =>
  * Boundary cases of the stop-at-call walk in `TsPrinter.newExpressionTarget`.
  * The walk must traverse every construct that keeps the call on the printed
  * left edge — not just plain property accesses — and must stop at both a
- * `CallExpression` and a `CallChain`. A non-null assertion over a call, a
- * tagged template whose tag is a call, an optional call at the chain head, and
- * an optional property access over a call would each re-bind the arguments to
- * the `new` (or, for the optional access, produce the illegal `new f()?.bar()`)
- * once printed bare. The tag-over-identifier twin guards against wrapping every
- * tagged template used as a target.
+ * `CallExpression` and a `CallChain`, and also where the printer's own
+ * left-side parentheses already end that edge. A non-null assertion over a
+ * call, a tagged template whose tag is a call, and an optional property access
+ * over a call would each re-bind the arguments to the `new` (or, for the
+ * optional access, produce the illegal `new f()?.bar()`) once printed bare. An
+ * optional call at the chain head is the counter-case: a non-optional property
+ * access over it is already parenthesized as `(f?.())`, so wrapping the whole
+ * target as well would print `new ((f?.()).bar)()`, and dropping the inner
+ * wrapper would print `new (f?.().bar)()`, whose `.bar` re-parses as part of
+ * the optional chain — a different tree. The tag-over-identifier twin guards
+ * against wrapping every tagged template used as a target.
+ *
+ * Every expectation here is the string `ts-legacy`'s own factory and
+ * `ts.createPrinter()` produce for the same tree, not this printer's output.
  *
  * 1. Print `new` expressions targeting a non-null assertion, a call-tagged
  *    template, an optional call at the chain head (leftmost node is a
  *    `CallChain`), and an optional property access over a call (a runtime
  *    `TypeError` shape, but the printed text must still parse back to the same
  *    AST).
- * 2. Assert each target is parenthesized, and the identifier-tagged twin stays
- *    bare.
+ * 2. Assert each target's parentheses land where the oracle puts them, and the
+ *    identifier-tagged twin stays bare.
  * 3. Re-parse each output with the legacy compiler and assert the top-level
  *    expression is still a `NewExpression`.
+ * 4. Assert the chain-head target re-parses with `.bar` outside the optional
+ *    chain, which is what the parentheses are there to preserve.
  */
 export const test_new_expression_target_spine_operator_parentheses =
   (): void => {
@@ -98,7 +108,7 @@ export const test_new_expression_target_spine_operator_parentheses =
     TestValidator.equals(
       "optional call at chain head",
       printed["optional call at chain head"],
-      "new (f?.().bar)()",
+      "new (f?.()).bar()",
     );
     TestValidator.equals(
       "optional chain over a call",
@@ -116,4 +126,18 @@ export const test_new_expression_target_spine_operator_parentheses =
         reparse(source).kind,
         ts.SyntaxKind.NewExpression,
       );
+    const chainHead: ts.Expression = reparse(
+      printed["optional call at chain head"],
+    );
+    if (!ts.isNewExpression(chainHead))
+      throw new Error("expected a new expression");
+    const target: ts.LeftHandSideExpression = chainHead.expression;
+    if (!ts.isPropertyAccessExpression(target))
+      throw new Error("expected a property access target");
+    TestValidator.equals(
+      "chain-head target keeps `.bar` out of the optional chain",
+      target.questionDotToken === undefined &&
+        ts.isParenthesizedExpression(target.expression),
+      true,
+    );
   };

--- a/tests/test-factory/src/features/expressions/test_optional_chain_operand_parentheses.ts
+++ b/tests/test-factory/src/features/expressions/test_optional_chain_operand_parentheses.ts
@@ -1,0 +1,240 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression, SyntaxKind } from "@ttsc/factory";
+import ts from "ts-legacy";
+
+import { id, print } from "../../internal/helpers";
+import { assertOracle, wide } from "../../internal/oracle";
+
+const qd = () => factory.createToken(SyntaxKind.QuestionDotToken);
+const lqd = () => ts.factory.createToken(ts.SyntaxKind.QuestionDotToken);
+const lid = (text: string) => ts.factory.createIdentifier(text);
+
+/** `a?.b`, built twice. */
+const propertyChain = (): Expression =>
+  factory.createPropertyAccessChain(id("a"), qd(), "b");
+const legacyPropertyChain = (): ts.Expression =>
+  ts.factory.createPropertyAccessChain(lid("a"), lqd(), lid("b"));
+
+/** `a?.()`, built twice. */
+const callChain = (): Expression =>
+  factory.createCallChain(id("a"), qd(), undefined, []);
+const legacyCallChain = (): ts.Expression =>
+  ts.factory.createCallChain(lid("a"), lqd(), undefined, []);
+
+/** `a?.[0]`, built twice. */
+const elementChain = (): Expression =>
+  factory.createElementAccessChain(
+    id("a"),
+    qd(),
+    factory.createNumericLiteral("0"),
+  );
+const legacyElementChain = (): ts.Expression =>
+  ts.factory.createElementAccessChain(
+    lid("a"),
+    lqd(),
+    ts.factory.createNumericLiteral("0"),
+  );
+
+/**
+ * Verifies an optional chain consumed by a non-optional parent is
+ * parenthesized.
+ *
+ * Pins `TsPrinter.leftSideExpression`'s `optionalChain` argument, which is the
+ * consuming node's chain-ness, not the operand's. Emitting `(a?.b)()` as
+ * `a?.b()` re-parses the call *into* the chain, so a nullish head stops
+ * throwing and quietly evaluates to `undefined`; in `new`, tagged-template and
+ * decorator position the same omission does not compile at all (TS1209,
+ * TS1358, TS1146). Every expectation below is the legacy printer's own output
+ * for the same tree, taken through the differential oracle rather than from
+ * this printer.
+ *
+ * 1. Print each non-optional consumer over each optional-chain node kind.
+ * 2. Assert the printed text means what the legacy printer's text means, and
+ *    pin the exact string where the two printers also agree on spacing.
+ * 3. Assert the negative twins — a consumer that continues the same chain, and
+ *    a postfix update, which the legacy parenthesizer does not guard — stay
+ *    bare.
+ */
+export const test_optional_chain_operand_parentheses = (): void => {
+  const rows: [string, Expression, ts.Expression, string][] = [
+    [
+      "call",
+      factory.createCallExpression(propertyChain(), undefined, []),
+      ts.factory.createCallExpression(legacyPropertyChain(), undefined, []),
+      "(a?.b)()",
+    ],
+    [
+      "new",
+      factory.createNewExpression(propertyChain(), undefined, []),
+      ts.factory.createNewExpression(legacyPropertyChain(), undefined, []),
+      "new (a?.b)()",
+    ],
+    [
+      "property access",
+      factory.createPropertyAccessExpression(propertyChain(), "c"),
+      ts.factory.createPropertyAccessExpression(
+        legacyPropertyChain(),
+        lid("c"),
+      ),
+      "(a?.b).c",
+    ],
+    [
+      "element access",
+      factory.createElementAccessExpression(
+        propertyChain(),
+        factory.createNumericLiteral("0"),
+      ),
+      ts.factory.createElementAccessExpression(
+        legacyPropertyChain(),
+        ts.factory.createNumericLiteral("0"),
+      ),
+      "(a?.b)[0]",
+    ],
+    [
+      "property access over a call chain",
+      factory.createPropertyAccessExpression(callChain(), "c"),
+      ts.factory.createPropertyAccessExpression(legacyCallChain(), lid("c")),
+      "(a?.()).c",
+    ],
+    [
+      "element access over an element chain",
+      factory.createElementAccessExpression(
+        elementChain(),
+        factory.createNumericLiteral("1"),
+      ),
+      ts.factory.createElementAccessExpression(
+        legacyElementChain(),
+        ts.factory.createNumericLiteral("1"),
+      ),
+      "(a?.[0])[1]",
+    ],
+    [
+      "non-null assertion",
+      factory.createNonNullExpression(propertyChain()),
+      ts.factory.createNonNullExpression(legacyPropertyChain()),
+      "(a?.b)!",
+    ],
+    [
+      "call over a non-null chain",
+      factory.createCallExpression(
+        factory.createNonNullChain(propertyChain()),
+        undefined,
+        [],
+      ),
+      ts.factory.createCallExpression(
+        ts.factory.createNonNullChain(legacyPropertyChain()),
+        undefined,
+        [],
+      ),
+      "(a?.b!)()",
+    ],
+  ];
+  for (const [title, node, oracle, expected] of rows) {
+    const printed: string = wide.print(node);
+    TestValidator.equals(title, printed, expected);
+    assertOracle(title, printed, ts.factory.createExpressionStatement(oracle));
+  }
+
+  // the tagged-template tag and the decorator expression are the same rule in
+  // positions the printer spaces differently from the legacy printer, so only
+  // their meaning is compared
+  const tagged: string = wide.print(
+    factory.createTaggedTemplateExpression(
+      propertyChain(),
+      undefined,
+      factory.createNoSubstitutionTemplateLiteral("x"),
+    ),
+  );
+  TestValidator.equals("tagged template tag", tagged, "(a?.b)`x`");
+  assertOracle(
+    "tagged template tag",
+    tagged,
+    ts.factory.createExpressionStatement(
+      ts.factory.createTaggedTemplateExpression(
+        legacyPropertyChain(),
+        undefined,
+        ts.factory.createNoSubstitutionTemplateLiteral("x"),
+      ),
+    ),
+  );
+  const decorated: string = wide.print(
+    factory.createClassDeclaration(
+      [factory.createDecorator(propertyChain())],
+      "A",
+      undefined,
+      undefined,
+      [],
+    ),
+  );
+  TestValidator.equals(
+    "decorator expression",
+    decorated,
+    "@(a?.b)\nclass A {}",
+  );
+  assertOracle(
+    "decorator expression",
+    decorated,
+    ts.factory.createClassDeclaration(
+      [ts.factory.createDecorator(legacyPropertyChain())],
+      lid("A"),
+      undefined,
+      undefined,
+      [],
+    ),
+  );
+
+  // negative twins: a consumer continuing the same chain adds nothing, and the
+  // legacy parenthesizer does not guard the postfix-update operand either
+  TestValidator.equals(
+    "property chain over a call chain",
+    print(factory.createPropertyAccessChain(callChain(), qd(), "b")),
+    "a?.()?.b",
+  );
+  TestValidator.equals(
+    "element chain over a property chain",
+    print(
+      factory.createElementAccessChain(
+        propertyChain(),
+        qd(),
+        factory.createNumericLiteral("0"),
+      ),
+    ),
+    "a?.b?.[0]",
+  );
+  TestValidator.equals(
+    "call chain over a property chain",
+    print(factory.createCallChain(propertyChain(), qd(), undefined, [])),
+    "a?.b?.()",
+  );
+  TestValidator.equals(
+    "non-null chain over a property chain",
+    print(factory.createNonNullChain(propertyChain())),
+    "a?.b!",
+  );
+  TestValidator.equals(
+    "chain link without its own question dot",
+    print(factory.createPropertyAccessChain(propertyChain(), undefined, "c")),
+    "a?.b.c",
+  );
+  TestValidator.equals(
+    "postfix update over a chain",
+    print(
+      factory.createPostfixUnaryExpression(
+        propertyChain(),
+        SyntaxKind.PlusPlusToken,
+      ),
+    ),
+    "a?.b++",
+  );
+  TestValidator.equals(
+    "plain access needs nothing",
+    print(
+      factory.createCallExpression(
+        factory.createPropertyAccessExpression(id("a"), "b"),
+        undefined,
+        [],
+      ),
+    ),
+    "a.b()",
+  );
+};

--- a/tests/test-factory/src/features/jsx/test_jsx_break_without_text_children.ts
+++ b/tests/test-factory/src/features/jsx/test_jsx_break_without_text_children.ts
@@ -1,0 +1,112 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type JsxChild, SyntaxKind, TsPrinter } from "@ttsc/factory";
+
+import { id, str } from "../../internal/helpers";
+import { jsxChildren } from "../../internal/oracle";
+
+const tiny = new TsPrinter({ printWidth: 40 });
+
+const element = (children: readonly JsxChild[]): JsxChild =>
+  factory.createJsxElement(
+    factory.createJsxOpeningElement(
+      factory.createIdentifier("div"),
+      undefined,
+      factory.createJsxAttributes([]),
+    ),
+    children,
+    factory.createJsxClosingElement(factory.createIdentifier("div")),
+  );
+const expression = (name: string) =>
+  factory.createJsxExpression(undefined, factory.createIdentifier(name));
+
+/**
+ * Verifies the JSX whitespace guard is scoped: children with nothing to lose
+ * still break, and ordinary code still has its trailing whitespace trimmed.
+ *
+ * The guard that keeps `printWidth` from editing JSX text must not turn into a
+ * blanket refusal to lay JSX out, and the raw-text exemption that keeps a
+ * trailing space alive must not leak into generated code, where a line ending
+ * in spaces is noise. These are the two over-match twins of the fix: an element
+ * whose children carry no whitespace at all, and a broken argument list, object
+ * literal and binary expression in plain TypeScript.
+ *
+ * 1. Print `<div>{a}{b}</div>` narrow and assert it breaks onto separate lines,
+ *    gains no `{" "}`, and still transpiles to the same two children.
+ * 2. Emit a `JsxText` immediately before a hard line break and assert its
+ *    trailing space survives, which is the raw-text exemption itself.
+ * 3. Print a narrow call, object literal and binary expression.
+ * 4. Assert no line of that output ends in a space or tab.
+ */
+export const test_jsx_break_without_text_children = (): void => {
+  const printed: string = tiny.print(
+    element([
+      expression("alphaAlphaAlphaAlphaAlpha"),
+      expression("bravoBravoBravoBravoBravo"),
+    ]),
+  );
+  TestValidator.equals("breaks freely", printed.includes("\n"), true);
+  TestValidator.equals(
+    "gains no explicit space child",
+    printed.includes('{" "}'),
+    false,
+  );
+  TestValidator.equals(
+    "children survive the break",
+    jsxChildren(printed),
+    jsxChildren(
+      new TsPrinter({ printWidth: 200 }).print(
+        element([
+          expression("alphaAlphaAlphaAlphaAlpha"),
+          expression("bravoBravoBravoBravoBravo"),
+        ]),
+      ),
+    ),
+  );
+
+  // the raw-text exemption: the layout engine trims a line's trailing spaces
+  // before writing a newline, which would silently edit JSX text content
+  TestValidator.equals(
+    "raw JSX text keeps its trailing space across a line break",
+    new TsPrinter().printNodes([
+      factory.createJsxText("Hello there, "),
+      factory.createJsxText("!"),
+    ]),
+    "Hello there, \n!",
+  );
+
+  const code: string[] = [
+    tiny.print(
+      factory.createExpressionStatement(
+        factory.createCallExpression(id("handlerFunctionName"), undefined, [
+          str("alphaAlphaAlphaAlpha"),
+          str("bravoBravoBravoBravo"),
+        ]),
+      ),
+    ),
+    tiny.print(
+      factory.createExpressionStatement(
+        factory.createParenthesizedExpression(
+          factory.createObjectLiteralExpression([
+            factory.createPropertyAssignment("firstPropertyName", str("alpha")),
+            factory.createPropertyAssignment("secondPropertyName", str("bravo")),
+          ]),
+        ),
+      ),
+    ),
+    tiny.print(
+      factory.createExpressionStatement(
+        factory.createBinaryExpression(
+          id("firstOperandName"),
+          SyntaxKind.PlusToken,
+          id("secondOperandName"),
+        ),
+      ),
+    ),
+  ];
+  for (const text of code)
+    TestValidator.equals(
+      "no line ends in whitespace",
+      text.split("\n").filter((line) => /[ \t]$/.test(line)),
+      [],
+    );
+};

--- a/tests/test-factory/src/features/jsx/test_jsx_children_width_invariant.ts
+++ b/tests/test-factory/src/features/jsx/test_jsx_children_width_invariant.ts
@@ -38,9 +38,10 @@ const expression = (name: string) =>
  * what the JSX runtime is actually handed — not the printed characters, since
  * the whole point is that the characters are allowed to move.
  *
- * 1. Build the four whitespace-carrying shapes: text before an expression, a
- *    whitespace-only separator between two expressions in an element and in a
- *    fragment, and text on both sides of an expression.
+ * 1. Build the whitespace-carrying shapes: text before an expression, a
+ *    whitespace-only separator between two expressions in an element, the same
+ *    in a fragment, text on both sides of an expression, and a fragment nested
+ *    in an element.
  * 2. Print each at `printWidth` 200, 80, 40 and 10 and transpile every layout.
  * 3. Assert all four widths yield one and the same `children` argument.
  */

--- a/tests/test-factory/src/features/jsx/test_jsx_children_width_invariant.ts
+++ b/tests/test-factory/src/features/jsx/test_jsx_children_width_invariant.ts
@@ -97,10 +97,5 @@ export const test_jsx_children_width_invariant = (): void => {
       new Set(rendered).size,
       1,
     );
-    TestValidator.equals(
-      `${title} has children at all`,
-      rendered[0] !== "<no children>",
-      true,
-    );
   }
 };

--- a/tests/test-factory/src/features/jsx/test_jsx_children_width_invariant.ts
+++ b/tests/test-factory/src/features/jsx/test_jsx_children_width_invariant.ts
@@ -1,0 +1,106 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type JsxChild, TsPrinter } from "@ttsc/factory";
+
+import { jsxChildren } from "../../internal/oracle";
+
+const element = (children: readonly JsxChild[]): JsxChild =>
+  factory.createJsxElement(
+    factory.createJsxOpeningElement(
+      factory.createIdentifier("div"),
+      undefined,
+      factory.createJsxAttributes([]),
+    ),
+    children,
+    factory.createJsxClosingElement(factory.createIdentifier("div")),
+  );
+const fragmentChild = (children: readonly JsxChild[]): JsxChild =>
+  factory.createJsxFragment(
+    factory.createJsxOpeningFragment(),
+    children,
+    factory.createJsxJsxClosingFragment(),
+  );
+
+const text = (value: string) => factory.createJsxText(value);
+const expression = (name: string) =>
+  factory.createJsxExpression(undefined, factory.createIdentifier(name));
+
+/**
+ * Verifies JSX children transpile to the same `children` argument at every
+ * `printWidth`.
+ *
+ * `printWidth` chooses a layout; it must never change the program. For JSX it
+ * did: children were joined with a break-capable separator, and once the group
+ * broke, JSX deleted every whitespace-only child that had gained a newline and
+ * trimmed the significant edge space off the rest. `<div>Hello there,
+ * {name}!</div>` rendered as `Hello there,NAME!` at width 40 and correctly at
+ * width 200, so the defect appeared and disappeared as unrelated content
+ * changed length. The observable here is the transpiled `children` argument —
+ * what the JSX runtime is actually handed — not the printed characters, since
+ * the whole point is that the characters are allowed to move.
+ *
+ * 1. Build the four whitespace-carrying shapes: text before an expression, a
+ *    whitespace-only separator between two expressions in an element and in a
+ *    fragment, and text on both sides of an expression.
+ * 2. Print each at `printWidth` 200, 80, 40 and 10 and transpile every layout.
+ * 3. Assert all four widths yield one and the same `children` argument.
+ */
+export const test_jsx_children_width_invariant = (): void => {
+  const cases: [string, JsxChild][] = [
+    [
+      "text before an expression",
+      element([
+        text("aaaaaaaaaaaaaaaaaaaa "),
+        expression("bbbbbbbbbbbbbbbbbbbb"),
+      ]),
+    ],
+    [
+      "whitespace-only separator",
+      element([
+        expression("alphaAlphaAlphaAlpha"),
+        text(" "),
+        expression("bravoBravoBravoBravo"),
+      ]),
+    ],
+    [
+      "whitespace-only separator in a fragment",
+      fragmentChild([
+        expression("alphaAlphaAlphaAlpha"),
+        text(" "),
+        expression("bravoBravoBravoBravo"),
+      ]),
+    ],
+    [
+      "text on both sides of an expression",
+      element([
+        text("Hello there, "),
+        expression("nameOfTheCurrentlySignedInVisitor"),
+        text("!"),
+      ]),
+    ],
+    [
+      "a fragment nested in an element",
+      element([
+        fragmentChild([
+          expression("alphaAlphaAlphaAlpha"),
+          text(" "),
+          expression("bravoBravoBravoBravo"),
+        ]),
+      ]),
+    ],
+  ];
+  for (const [title, node] of cases) {
+    const rendered: string[] = [200, 80, 40, 10].map((printWidth) =>
+      jsxChildren(new TsPrinter({ printWidth }).print(node)),
+    );
+    TestValidator.equals(
+      `${title} renders the same at every width`,
+      new Set(rendered).size,
+      1,
+    );
+    TestValidator.equals(
+      `${title} has children at all`,
+      rendered[0] !== "<no children>",
+      true,
+    );
+  }
+};

--- a/tests/test-factory/src/features/jsx/test_jsx_whitespace_boundaries.ts
+++ b/tests/test-factory/src/features/jsx/test_jsx_whitespace_boundaries.ts
@@ -1,0 +1,115 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type JsxChild, TsPrinter } from "@ttsc/factory";
+
+import { str } from "../../internal/helpers";
+import { jsxChildren } from "../../internal/oracle";
+
+const element = (
+  tag: string,
+  children: readonly JsxChild[],
+  attribute?: string,
+): JsxChild =>
+  factory.createJsxElement(
+    factory.createJsxOpeningElement(
+      factory.createIdentifier(tag),
+      undefined,
+      factory.createJsxAttributes(
+        attribute === undefined
+          ? []
+          : [
+              factory.createJsxAttribute(
+                factory.createIdentifier(attribute),
+                str("someRatherLongAttributeValueHere"),
+              ),
+            ],
+      ),
+    ),
+    children,
+    factory.createJsxClosingElement(factory.createIdentifier(tag)),
+  );
+const fragment = (children: readonly JsxChild[]): JsxChild =>
+  factory.createJsxFragment(
+    factory.createJsxOpeningFragment(),
+    children,
+    factory.createJsxJsxClosingFragment(),
+  );
+const text = (value: string) => factory.createJsxText(value);
+const expression = (name: string) =>
+  factory.createJsxExpression(undefined, factory.createIdentifier(name));
+
+/**
+ * Verifies the boundary shapes of JSX whitespace stay width-invariant.
+ *
+ * The failure nests and hides: one long attribute at the top of a tree forces
+ * the outer group to break, which used to put every descendant text child on
+ * its own line, so whitespace vanished deep inside a subtree that was itself
+ * short. These are the shapes where the guard is easiest to get wrong — an
+ * element that is nothing but whitespace, text that already contains its own
+ * newlines, two text children side by side, an opening tag wider than
+ * `printWidth`, and an outer element that breaks over an inner one that fits.
+ *
+ * 1. Build each boundary shape.
+ * 2. Print it at `printWidth` 200, 80, 40 and 10.
+ * 3. Assert every width transpiles to the same `children` argument.
+ */
+export const test_jsx_whitespace_boundaries = (): void => {
+  const cases: [string, JsxChild][] = [
+    ["whitespace-only element", element("div", [text(" ")])],
+    [
+      "text carrying its own newlines",
+      element("div", [text("firstLineOfTheText\nsecondLineOfTheText")]),
+    ],
+    [
+      "two text children side by side",
+      element("div", [text("firstTextChildValue"), text("secondTextChild")]),
+    ],
+    [
+      "nested fragments",
+      fragment([
+        fragment([
+          expression("alphaAlphaAlphaAlpha"),
+          text(" "),
+          expression("bravoBravoBravoBravo"),
+        ]),
+      ]),
+    ],
+    [
+      "self-closing child",
+      element("div", [
+        text("Hello there, "),
+        factory.createJsxSelfClosingElement(
+          factory.createIdentifier("Avatar"),
+          undefined,
+          factory.createJsxAttributes([]),
+        ),
+        text("!"),
+      ]),
+    ],
+    [
+      "opening tag alone exceeds the width",
+      element(
+        "section",
+        [text("Hello there, "), expression("visitorName")],
+        "className",
+      ),
+    ],
+    [
+      "outer breaks while the inner fits",
+      element("section", [
+        expression("headerContentValue"),
+        element("span", [text("Hi "), expression("visitorName")]),
+        expression("footerContentValue"),
+      ]),
+    ],
+  ];
+  for (const [title, node] of cases) {
+    const rendered: string[] = [200, 80, 40, 10].map((printWidth) =>
+      jsxChildren(new TsPrinter({ printWidth }).print(node)),
+    );
+    TestValidator.equals(
+      `${title} renders the same at every width`,
+      new Set(rendered).size,
+      1,
+    );
+  }
+};

--- a/tests/test-factory/src/features/jsx/test_jsx_whitespace_boundaries.ts
+++ b/tests/test-factory/src/features/jsx/test_jsx_whitespace_boundaries.ts
@@ -47,6 +47,9 @@ const expression = (name: string) =>
  * element that is nothing but whitespace, text that already contains its own
  * newlines, two text children side by side, an opening tag wider than
  * `printWidth`, and an outer element that breaks over an inner one that fits.
+ * The text child with no edge whitespace is the positive twin: it is the one
+ * shape the guard is supposed to let break, so it also asserts that the layout
+ * really does break.
  *
  * 1. Build each boundary shape.
  * 2. Print it at `printWidth` 200, 80, 40 and 10.
@@ -55,6 +58,10 @@ const expression = (name: string) =>
 export const test_jsx_whitespace_boundaries = (): void => {
   const cases: [string, JsxChild][] = [
     ["whitespace-only element", element("div", [text(" ")])],
+    [
+      "text with no edge whitespace, which may break",
+      element("div", [text("HelloHelloHelloHelloHelloHelloHello")]),
+    ],
     [
       "text carrying its own newlines",
       element("div", [text("firstLineOfTheText\nsecondLineOfTheText")]),
@@ -112,4 +119,13 @@ export const test_jsx_whitespace_boundaries = (): void => {
       1,
     );
   }
+
+  // the positive twin: with nothing to lose at its edges, the text child breaks
+  TestValidator.equals(
+    "a text child with no edge whitespace still breaks",
+    new TsPrinter({ printWidth: 10 })
+      .print(element("div", [text("HelloHelloHelloHelloHelloHelloHello")]))
+      .includes("\n"),
+    true,
+  );
 };

--- a/tests/test-factory/src/features/jsx/test_jsx_whitespace_boundaries.ts
+++ b/tests/test-factory/src/features/jsx/test_jsx_whitespace_boundaries.ts
@@ -2,7 +2,7 @@ import { TestValidator } from "@nestia/e2e";
 import factory, { type JsxChild, TsPrinter } from "@ttsc/factory";
 
 import { str } from "../../internal/helpers";
-import { jsxChildren } from "../../internal/oracle";
+import { jsxChildren, jsxEmit } from "../../internal/oracle";
 
 const element = (
   tag: string,
@@ -54,6 +54,9 @@ const expression = (name: string) =>
  * 1. Build each boundary shape.
  * 2. Print it at `printWidth` 200, 80, 40 and 10.
  * 3. Assert every width transpiles to the same `children` argument.
+ * 4. Assert the two shapes that have no `children` argument to compare: a
+ *    childless element, whose whole emitted call must match across widths, and
+ *    the breakable text child, whose layout must actually break.
  */
 export const test_jsx_whitespace_boundaries = (): void => {
   const cases: [string, JsxChild][] = [
@@ -119,6 +122,18 @@ export const test_jsx_whitespace_boundaries = (): void => {
       1,
     );
   }
+
+  // an element with no children at all has no `children` argument to compare,
+  // so the whole emitted call is the observable
+  TestValidator.equals(
+    "a childless element emits the same call at every width",
+    new Set(
+      [200, 5].map((printWidth) =>
+        jsxEmit(new TsPrinter({ printWidth }).print(element("div", []))),
+      ),
+    ).size,
+    1,
+  );
 
   // the positive twin: with nothing to lose at its edges, the text child breaks
   TestValidator.equals(

--- a/tests/test-factory/src/features/parity/test_parenthesizer_oracle_differential.ts
+++ b/tests/test-factory/src/features/parity/test_parenthesizer_oracle_differential.ts
@@ -1,0 +1,555 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression, type Node, SyntaxKind } from "@ttsc/factory";
+import ts from "ts-legacy";
+
+import { kindsOf, printLegacy, structure, wide } from "../../internal/oracle";
+
+const f = factory;
+const l = ts.factory;
+const id = (text: string) => f.createIdentifier(text);
+const lid = (text: string) => l.createIdentifier(text);
+const qd = () => f.createToken(SyntaxKind.QuestionDotToken);
+const lqd = () => l.createToken(ts.SyntaxKind.QuestionDotToken);
+
+/** One operand shape, built once for each printer. */
+interface Operand {
+  name: string;
+  ttsc: () => Expression;
+  legacy: () => ts.Expression;
+}
+/** One position that consumes an operand, built once for each printer. */
+interface Consumer {
+  name: string;
+  ttsc: (operand: Expression) => Node;
+  legacy: (operand: ts.Expression) => ts.Node;
+}
+
+const operands: Operand[] = [
+  {
+    name: "property chain",
+    ttsc: () => f.createPropertyAccessChain(id("a"), qd(), "b"),
+    legacy: () => l.createPropertyAccessChain(lid("a"), lqd(), lid("b")),
+  },
+  {
+    name: "element chain",
+    ttsc: () =>
+      f.createElementAccessChain(id("a"), qd(), f.createNumericLiteral("0")),
+    legacy: () =>
+      l.createElementAccessChain(lid("a"), lqd(), l.createNumericLiteral("0")),
+  },
+  {
+    name: "call chain",
+    ttsc: () => f.createCallChain(id("a"), qd(), undefined, []),
+    legacy: () => l.createCallChain(lid("a"), lqd(), undefined, []),
+  },
+  {
+    name: "non-null chain",
+    ttsc: () => f.createNonNullChain(f.createPropertyAccessChain(id("a"), qd(), "b")),
+    legacy: () =>
+      l.createNonNullChain(l.createPropertyAccessChain(lid("a"), lqd(), lid("b"))),
+  },
+  {
+    name: "chain whose head is a chain",
+    ttsc: () =>
+      f.createPropertyAccessChain(
+        f.createCallChain(id("a"), qd(), undefined, []),
+        qd(),
+        "b",
+      ),
+    legacy: () =>
+      l.createPropertyAccessChain(
+        l.createCallChain(lid("a"), lqd(), undefined, []),
+        lqd(),
+        lid("b"),
+      ),
+  },
+  {
+    name: "call",
+    ttsc: () => f.createCallExpression(id("a"), undefined, []),
+    legacy: () => l.createCallExpression(lid("a"), undefined, []),
+  },
+  {
+    name: "property access",
+    ttsc: () => f.createPropertyAccessExpression(id("a"), "b"),
+    legacy: () => l.createPropertyAccessExpression(lid("a"), lid("b")),
+  },
+  {
+    name: "identifier",
+    ttsc: () => id("a"),
+    legacy: () => lid("a"),
+  },
+  {
+    name: "logical or",
+    ttsc: () => f.createBinaryExpression(id("X"), SyntaxKind.BarBarToken, id("Y")),
+    legacy: () =>
+      l.createBinaryExpression(lid("X"), ts.SyntaxKind.BarBarToken, lid("Y")),
+  },
+  {
+    name: "conditional",
+    ttsc: () =>
+      f.createConditionalExpression(id("c"), undefined, id("X"), undefined, id("Y")),
+    legacy: () =>
+      l.createConditionalExpression(
+        lid("c"),
+        undefined,
+        lid("X"),
+        undefined,
+        lid("Y"),
+      ),
+  },
+  {
+    name: "as expression over a call",
+    ttsc: () =>
+      f.createAsExpression(
+        f.createCallExpression(id("g"), undefined, []),
+        f.createTypeReferenceNode("any"),
+      ),
+    legacy: () =>
+      l.createAsExpression(
+        l.createCallExpression(lid("g"), undefined, []),
+        l.createTypeReferenceNode("any", undefined),
+      ),
+  },
+  {
+    name: "await",
+    ttsc: () => f.createAwaitExpression(id("Base")),
+    legacy: () => l.createAwaitExpression(lid("Base")),
+  },
+  {
+    name: "arrow function",
+    ttsc: () =>
+      f.createArrowFunction(undefined, undefined, [], undefined, undefined, id("x")),
+    legacy: () =>
+      l.createArrowFunction(undefined, undefined, [], undefined, undefined, lid("x")),
+  },
+  {
+    name: "assignment",
+    ttsc: () => f.createAssignment(id("X"), id("Y")),
+    legacy: () => l.createAssignment(lid("X"), lid("Y")),
+  },
+  {
+    name: "comma sequence",
+    ttsc: () => f.createBinaryExpression(id("a"), SyntaxKind.CommaToken, id("B")),
+    legacy: () =>
+      l.createBinaryExpression(lid("a"), ts.SyntaxKind.CommaToken, lid("B")),
+  },
+  {
+    name: "function expression",
+    ttsc: () =>
+      f.createFunctionExpression(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [],
+        undefined,
+        f.createBlock([]),
+      ),
+    legacy: () =>
+      l.createFunctionExpression(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [],
+        undefined,
+        l.createBlock([]),
+      ),
+  },
+  {
+    name: "object literal",
+    ttsc: () => f.createObjectLiteralExpression([]),
+    legacy: () => l.createObjectLiteralExpression([]),
+  },
+  {
+    name: "new without arguments",
+    ttsc: () => f.createNewExpression(id("N"), undefined, undefined),
+    legacy: () => l.createNewExpression(lid("N"), undefined, undefined),
+  },
+  {
+    name: "new with arguments",
+    ttsc: () => f.createNewExpression(id("N"), undefined, []),
+    legacy: () => l.createNewExpression(lid("N"), undefined, []),
+  },
+];
+
+const statement = (expression: Expression): Node =>
+  f.createExpressionStatement(expression);
+const legacyStatement = (expression: ts.Expression): ts.Node =>
+  l.createExpressionStatement(expression);
+
+const consumers: Consumer[] = [
+  {
+    name: "call",
+    ttsc: (o) => statement(f.createCallExpression(o, undefined, [])),
+    legacy: (o) => legacyStatement(l.createCallExpression(o, undefined, [])),
+  },
+  {
+    name: "new target",
+    ttsc: (o) => statement(f.createNewExpression(o, undefined, [])),
+    legacy: (o) => legacyStatement(l.createNewExpression(o, undefined, [])),
+  },
+  {
+    name: "new target through a property access",
+    ttsc: (o) =>
+      statement(
+        f.createNewExpression(
+          f.createPropertyAccessExpression(o, "bar"),
+          undefined,
+          [],
+        ),
+      ),
+    legacy: (o) =>
+      legacyStatement(
+        l.createNewExpression(
+          l.createPropertyAccessExpression(o, lid("bar")),
+          undefined,
+          [],
+        ),
+      ),
+  },
+  {
+    name: "property access",
+    ttsc: (o) => statement(f.createPropertyAccessExpression(o, "c")),
+    legacy: (o) => legacyStatement(l.createPropertyAccessExpression(o, lid("c"))),
+  },
+  {
+    name: "element access",
+    ttsc: (o) =>
+      statement(f.createElementAccessExpression(o, f.createNumericLiteral("1"))),
+    legacy: (o) =>
+      legacyStatement(
+        l.createElementAccessExpression(o, l.createNumericLiteral("1")),
+      ),
+  },
+  {
+    name: "non-null assertion",
+    ttsc: (o) => statement(f.createNonNullExpression(o)),
+    legacy: (o) => legacyStatement(l.createNonNullExpression(o)),
+  },
+  {
+    name: "tagged template tag",
+    ttsc: (o) =>
+      statement(
+        f.createTaggedTemplateExpression(
+          o,
+          undefined,
+          f.createNoSubstitutionTemplateLiteral("x"),
+        ),
+      ),
+    legacy: (o) =>
+      legacyStatement(
+        l.createTaggedTemplateExpression(
+          o,
+          undefined,
+          l.createNoSubstitutionTemplateLiteral("x"),
+        ),
+      ),
+  },
+  {
+    name: "property chain",
+    ttsc: (o) => statement(f.createPropertyAccessChain(o, qd(), "c")),
+    legacy: (o) => legacyStatement(l.createPropertyAccessChain(o, lqd(), lid("c"))),
+  },
+  {
+    name: "element chain",
+    ttsc: (o) =>
+      statement(f.createElementAccessChain(o, qd(), f.createNumericLiteral("1"))),
+    legacy: (o) =>
+      legacyStatement(
+        l.createElementAccessChain(o, lqd(), l.createNumericLiteral("1")),
+      ),
+  },
+  {
+    name: "call chain",
+    ttsc: (o) => statement(f.createCallChain(o, qd(), undefined, [])),
+    legacy: (o) => legacyStatement(l.createCallChain(o, lqd(), undefined, [])),
+  },
+  {
+    name: "non-null chain",
+    ttsc: (o) => statement(f.createNonNullChain(o)),
+    legacy: (o) => legacyStatement(l.createNonNullChain(o)),
+  },
+  {
+    name: "postfix update",
+    ttsc: (o) =>
+      statement(f.createPostfixUnaryExpression(o, SyntaxKind.PlusPlusToken)),
+    legacy: (o) =>
+      legacyStatement(
+        l.createPostfixUnaryExpression(o, ts.SyntaxKind.PlusPlusToken),
+      ),
+  },
+  {
+    name: "decorator",
+    ttsc: (o) =>
+      f.createClassDeclaration([f.createDecorator(o)], "A", undefined, undefined, []),
+    legacy: (o) =>
+      l.createClassDeclaration(
+        [l.createDecorator(o)],
+        lid("A"),
+        undefined,
+        undefined,
+        [],
+      ),
+  },
+  {
+    name: "class extends",
+    ttsc: (o) => heritage(SyntaxKind.ExtendsKeyword, [o]),
+    legacy: (o) => legacyHeritage(ts.SyntaxKind.ExtendsKeyword, [o]),
+  },
+  {
+    name: "class implements",
+    ttsc: (o) => heritage(SyntaxKind.ImplementsKeyword, [id("P"), o]),
+    legacy: (o) => legacyHeritage(ts.SyntaxKind.ImplementsKeyword, [lid("P"), o]),
+  },
+  {
+    name: "class extends with type arguments",
+    ttsc: (o) => heritage(SyntaxKind.ExtendsKeyword, [o], true),
+    legacy: (o) => legacyHeritage(ts.SyntaxKind.ExtendsKeyword, [o], true),
+  },
+  {
+    name: "class expression extends",
+    ttsc: (o) =>
+      statement(
+        f.createClassExpression(
+          undefined,
+          "C",
+          undefined,
+          [
+            f.createHeritageClause(SyntaxKind.ExtendsKeyword, [
+              f.createExpressionWithTypeArguments(o, undefined),
+            ]),
+          ],
+          [],
+        ),
+      ),
+    legacy: (o) =>
+      legacyStatement(
+        l.createClassExpression(
+          undefined,
+          lid("C"),
+          undefined,
+          [
+            l.createHeritageClause(ts.SyntaxKind.ExtendsKeyword, [
+              l.createExpressionWithTypeArguments(o, undefined),
+            ]),
+          ],
+          [],
+        ),
+      ),
+  },
+  {
+    name: "interface extends",
+    ttsc: (o) =>
+      f.createInterfaceDeclaration(
+        undefined,
+        "I",
+        undefined,
+        [
+          f.createHeritageClause(SyntaxKind.ExtendsKeyword, [
+            f.createExpressionWithTypeArguments(o, undefined),
+          ]),
+        ],
+        [],
+      ),
+    legacy: (o) =>
+      l.createInterfaceDeclaration(
+        undefined,
+        lid("I"),
+        undefined,
+        [
+          l.createHeritageClause(ts.SyntaxKind.ExtendsKeyword, [
+            l.createExpressionWithTypeArguments(o, undefined),
+          ]),
+        ],
+        [],
+      ),
+  },
+  {
+    name: "expression statement",
+    ttsc: (o) => statement(o),
+    legacy: (o) => legacyStatement(o),
+  },
+  {
+    name: "export default",
+    ttsc: (o) => f.createExportAssignment(undefined, false, o),
+    legacy: (o) => l.createExportAssignment(undefined, false, o),
+  },
+  {
+    name: "arrow concise body",
+    ttsc: (o) =>
+      statement(
+        f.createArrowFunction(undefined, undefined, [], undefined, undefined, o),
+      ),
+    legacy: (o) =>
+      legacyStatement(
+        l.createArrowFunction(undefined, undefined, [], undefined, undefined, o),
+      ),
+  },
+];
+
+/**
+ * The one cell where the legacy printer's own text does not mean what its own
+ * tree says, so the differential cannot use it as an oracle.
+ *
+ * `isLeftHandSideExpression` is true for an object literal upstream, so the
+ * legacy printer emits `class A extends {}<T> {}`, which re-parses as a type
+ * assertion `<T>{}` and loses the heritage clause outright. This printer treats
+ * an object literal as needing parentheses and emits `class A extends ({})<T>
+ * {}`, which round-trips. The expected text is asserted directly instead.
+ */
+const oracleUnfaithful: ReadonlySet<string> = new Set([
+  "class extends with type arguments / object literal",
+]);
+
+const heritage = (
+  token: SyntaxKind,
+  expressions: readonly Expression[],
+  typeArguments: boolean = false,
+): Node =>
+  f.createClassDeclaration(
+    undefined,
+    "A",
+    undefined,
+    [
+      f.createHeritageClause(
+        token,
+        expressions.map((e) =>
+          f.createExpressionWithTypeArguments(
+            e,
+            typeArguments ? [f.createTypeReferenceNode("T")] : undefined,
+          ),
+        ),
+      ),
+    ],
+    [],
+  );
+const legacyHeritage = (
+  token: ts.SyntaxKind.ExtendsKeyword | ts.SyntaxKind.ImplementsKeyword,
+  expressions: readonly ts.Expression[],
+  typeArguments: boolean = false,
+): ts.Node =>
+  l.createClassDeclaration(
+    undefined,
+    lid("A"),
+    undefined,
+    [
+      l.createHeritageClause(
+        token,
+        expressions.map((e) =>
+          l.createExpressionWithTypeArguments(
+            e,
+            typeArguments ? [l.createTypeReferenceNode("T", undefined)] : undefined,
+          ),
+        ),
+      ),
+    ],
+    [],
+  );
+
+/**
+ * Every operand kind this differential must be able to place in every consuming
+ * position. The generator is checked against this list, so a production that
+ * stops being generated fails the case instead of silently shrinking coverage.
+ *
+ * This is the guard the three earlier fuzzing rounds lacked: sweeps of 1,312,
+ * 5,000 and 100,000 cases all reported this parenthesizer clean because no
+ * generator could emit an optional chain or a heritage clause at all. Case
+ * count is not coverage; the grammar is.
+ */
+const requiredProductions: readonly string[] = [
+  "PropertyAccessChain",
+  "ElementAccessChain",
+  "CallChain",
+  "NonNullChain",
+  "PropertyAccessExpression",
+  "ElementAccessExpression",
+  "CallExpression",
+  "NewExpression",
+  "NonNullExpression",
+  "TaggedTemplateExpression",
+  "PostfixUnaryExpression",
+  "Decorator",
+  "ExpressionWithTypeArguments",
+  "HeritageClause",
+  "ClassDeclaration",
+  "ClassExpression",
+  "InterfaceDeclaration",
+  "ExportAssignment",
+  "ArrowFunction",
+  "FunctionExpression",
+  "BinaryExpression",
+  "ConditionalExpression",
+  "AsExpression",
+  "AwaitExpression",
+  "ObjectLiteralExpression",
+];
+
+/**
+ * Verifies every operand position the parenthesizer owns prints text that means
+ * what the legacy printer's text for the same tree means.
+ *
+ * The corpus is a full cross product of consuming positions and operand shapes,
+ * built twice — once with `@ttsc/factory`, once with the pinned `ts-legacy`
+ * factory — so no expectation comes from the printer under test. Comparison is
+ * structural, not byte-wise: printed text is parsed back and reduced to its
+ * node-kind tree with parentheses removed and optional-chain membership
+ * recorded, which ignores formatting while still separating `a?.b()` from
+ * `(a?.b)()`.
+ *
+ * 1. Build every consumer-over-operand pair with both factories.
+ * 2. Assert the generated corpus actually contains every required production,
+ *    so a grammar gap fails rather than passing vacuously.
+ * 3. Assert each printed text parses cleanly and reduces to the same structure
+ *    as the oracle's text.
+ */
+export const test_parenthesizer_oracle_differential = (): void => {
+  const generated: Set<string> = new Set();
+  const failures: string[] = [];
+  let count: number = 0;
+  for (const consumer of consumers)
+    for (const operand of operands) {
+      const title: string = `${consumer.name} / ${operand.name}`;
+      const node: Node = consumer.ttsc(operand.ttsc());
+      for (const kind of kindsOf(node)) generated.add(kind);
+      count++;
+      if (oracleUnfaithful.has(title)) continue;
+      const printed: string = wide.print(node);
+      let actual: string;
+      try {
+        actual = structure(printed);
+      } catch (error) {
+        failures.push(`${title}: ${(error as Error).message}`);
+        continue;
+      }
+      const expected: string = structure(
+        printLegacy(consumer.legacy(operand.legacy())),
+      );
+      if (actual !== expected)
+        failures.push(
+          `${title}: ${JSON.stringify(printed)}\n    actual   ${actual}\n    expected ${expected}`,
+        );
+    }
+
+  TestValidator.equals(
+    "every required production is generated",
+    requiredProductions.filter((kind) => !generated.has(kind)),
+    [],
+  );
+  TestValidator.equals(
+    "corpus size",
+    count,
+    consumers.length * operands.length,
+  );
+  TestValidator.equals("differential failures", failures, []);
+
+  // the excluded cell, asserted directly: the oracle's own text loses its
+  // heritage clause, so only this printer's text is checked to round-trip
+  TestValidator.equals(
+    "object literal base with type arguments round-trips",
+    wide.print(
+      heritage(SyntaxKind.ExtendsKeyword, [f.createObjectLiteralExpression([])], true),
+    ),
+    "class A extends ({})<T> {}",
+  );
+};

--- a/tests/test-factory/src/features/parity/test_parenthesizer_oracle_differential.ts
+++ b/tests/test-factory/src/features/parity/test_parenthesizer_oracle_differential.ts
@@ -280,6 +280,11 @@ const consumers: Consumer[] = [
       ),
   },
   {
+    name: "typeof operand",
+    ttsc: (o) => statement(f.createTypeOfExpression(o)),
+    legacy: (o) => legacyStatement(l.createTypeOfExpression(o)),
+  },
+  {
     name: "decorator",
     ttsc: (o) =>
       f.createClassDeclaration([f.createDecorator(o)], "A", undefined, undefined, []),
@@ -482,6 +487,7 @@ const requiredProductions: readonly string[] = [
   "ConditionalExpression",
   "AsExpression",
   "AwaitExpression",
+  "TypeOfExpression",
   "ObjectLiteralExpression",
 ];
 

--- a/tests/test-factory/src/features/width/test_array_literal_break_trailing_elision.ts
+++ b/tests/test-factory/src/features/width/test_array_literal_break_trailing_elision.ts
@@ -1,0 +1,118 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression, TsPrinter } from "@ttsc/factory";
+import ts from "ts-legacy";
+
+import { str } from "../../internal/helpers";
+import { printLegacy, structure } from "../../internal/oracle";
+
+const wide = new TsPrinter({ printWidth: 200 });
+const tiny = new TsPrinter({ printWidth: 20 });
+
+const arity = (text: string): number => {
+  const file: ts.SourceFile = ts.createSourceFile(
+    "case.ts",
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  let length = -1;
+  const visit = (node: ts.Node): void => {
+    if (length < 0 && ts.isArrayLiteralExpression(node))
+      length = node.elements.length;
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+  return length;
+};
+
+/**
+ * Verifies an array literal ending in an elision keeps its hole at every width.
+ *
+ * A trailing `OmittedExpression` prints as nothing, so the comma before it is
+ * the token that materializes the hole: `["a", "b", ]` has two elements and
+ * `["a", "b", ,]` has three. Leaving that comma to the width break made the
+ * same node a two-element array on one line and a three-element array once it
+ * wrapped. The legacy printer emits the comma in both layouts, so this printer
+ * does too — the direction is taken from the oracle, not from either of this
+ * printer's own previous layouts, which disagreed with each other.
+ *
+ * 1. Print an array literal ending in an elision flat, broken, and with
+ *    `multiLine: true`.
+ * 2. Assert every layout re-parses to the same arity as the legacy printer's
+ *    text for the same tree, and means the same thing structurally.
+ * 3. Assert the boundary cases — a lone hole and an interior hole — behave the
+ *    same way.
+ */
+export const test_array_literal_break_trailing_elision = (): void => {
+  const trailing = (multiLine?: boolean): Expression =>
+    factory.createArrayLiteralExpression(
+      [str("alphaAlphaAlpha"), str("bravoBravoBravo"), factory.createOmittedExpression()],
+      multiLine,
+    );
+  const legacyTrailing = (multiLine?: boolean): ts.Expression =>
+    ts.factory.createArrayLiteralExpression(
+      [
+        ts.factory.createStringLiteral("alphaAlphaAlpha"),
+        ts.factory.createStringLiteral("bravoBravoBravo"),
+        ts.factory.createOmittedExpression(),
+      ],
+      multiLine,
+    );
+
+  const oracle: string = printLegacy(
+    ts.factory.createExpressionStatement(legacyTrailing()),
+  );
+  TestValidator.equals("oracle arity", arity(oracle), 3);
+
+  const flat: string = wide.print(factory.createExpressionStatement(trailing()));
+  const broken: string = tiny.print(factory.createExpressionStatement(trailing()));
+  const forced: string = wide.print(
+    factory.createExpressionStatement(trailing(true)),
+  );
+  TestValidator.equals("flat stays on one line", flat.includes("\n"), false);
+  TestValidator.equals("broken layout breaks", broken.includes("\n"), true);
+  TestValidator.equals("multiLine breaks at any width", forced.includes("\n"), true);
+  for (const [title, text] of [
+    ["flat", flat],
+    ["broken", broken],
+    ["multiLine", forced],
+  ] as const)
+    TestValidator.equals(`${title} arity`, arity(text), arity(oracle));
+  TestValidator.equals("flat means what the oracle means", structure(flat), structure(oracle));
+  TestValidator.equals(
+    "broken means what the oracle means",
+    structure(broken),
+    structure(oracle),
+  );
+
+  // boundary: a lone hole is still a one-element array
+  const lone: string = wide.print(
+    factory.createExpressionStatement(
+      factory.createArrayLiteralExpression([factory.createOmittedExpression()]),
+    ),
+  );
+  TestValidator.equals(
+    "lone hole matches the oracle",
+    lone,
+    printLegacy(
+      ts.factory.createExpressionStatement(
+        ts.factory.createArrayLiteralExpression([
+          ts.factory.createOmittedExpression(),
+        ]),
+      ),
+    ),
+  );
+  TestValidator.equals("lone hole arity", arity(lone), 1);
+
+  // negative twin: an interior hole is untouched, in both layouts
+  const interior = () =>
+    factory.createExpressionStatement(
+      factory.createArrayLiteralExpression([
+        str("alphaAlphaAlpha"),
+        factory.createOmittedExpression(),
+        str("bravoBravoBravo"),
+      ]),
+    );
+  TestValidator.equals("interior hole flat arity", arity(wide.print(interior())), 3);
+  TestValidator.equals("interior hole broken arity", arity(tiny.print(interior())), 3);
+};

--- a/tests/test-factory/src/features/width/test_array_target_break_rest_no_trailing_comma.ts
+++ b/tests/test-factory/src/features/width/test_array_target_break_rest_no_trailing_comma.ts
@@ -1,0 +1,133 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression, type Node, TsPrinter } from "@ttsc/factory";
+
+import { id } from "../../internal/helpers";
+import { syntaxErrorOf } from "../../internal/oracle";
+
+const wide = new TsPrinter({ printWidth: 200 });
+const tiny = new TsPrinter({ printWidth: 20 });
+
+/** `[first, second, ...rest]`, long enough to break at the default width. */
+const target = (multiLine?: boolean): Expression =>
+  factory.createArrayLiteralExpression(
+    [
+      id("firstDestructuredBinding"),
+      id("secondDestructuredBinding"),
+      factory.createSpreadElement(id("remainingDestructuredBindings")),
+    ],
+    multiLine,
+  );
+
+/**
+ * Verifies a broken array destructuring assignment target ending in a rest
+ * element drops the synthetic trailing comma.
+ *
+ * An array literal is not only an rvalue: the same node kind is how a
+ * destructuring assignment target is represented, and ECMAScript forbids a
+ * comma after an `AssignmentRestElement`. The width-break comma therefore
+ * decided whether the printed text ran at all — with ordinary identifiers, at
+ * the *default* `printWidth`, so the same generator emitted working code while
+ * its names were short and a `SyntaxError` once they grew. Every route into
+ * target position is covered, because the flag is threaded from the emitting
+ * site rather than read off a parent link.
+ *
+ * 1. Print the same target through `=`, `createAssignment`, `for…of`, a nested
+ *    inner target, and `multiLine: true`, flat and broken.
+ * 2. Assert every layout compiles in V8, which is what rejects the comma.
+ * 3. Assert the broken layout of the plain (non-rest) twin still gains its
+ *    trailing comma, so the suppression is scoped to the rest element.
+ */
+export const test_array_target_break_rest_no_trailing_comma = (): void => {
+  const cases: [string, Node][] = [
+    [
+      "assignment",
+      factory.createExpressionStatement(
+        factory.createAssignment(target(), id("sourceCollectionValue")),
+      ),
+    ],
+    [
+      "for-of",
+      factory.createForOfStatement(
+        undefined,
+        target(),
+        id("sourceCollectionValues"),
+        factory.createBlock([]),
+      ),
+    ],
+    [
+      "nested inner target",
+      factory.createExpressionStatement(
+        factory.createAssignment(
+          factory.createArrayLiteralExpression([
+            id("outerBindingName"),
+            target(),
+          ]),
+          id("sourceCollectionValue"),
+        ),
+      ),
+    ],
+    [
+      "inside a default",
+      factory.createExpressionStatement(
+        factory.createAssignment(
+          factory.createArrayLiteralExpression([
+            factory.createAssignment(target(), id("fallbackCollectionValue")),
+          ]),
+          id("sourceCollectionValue"),
+        ),
+      ),
+    ],
+    [
+      "multiLine forces the break at any width",
+      factory.createExpressionStatement(
+        factory.createAssignment(target(true), id("sourceCollectionValue")),
+      ),
+    ],
+  ];
+  for (const [title, node] of cases) {
+    const flat: string = wide.print(node);
+    const broken: string = tiny.print(node);
+    TestValidator.equals(`${title} flat compiles`, syntaxErrorOf(flat), undefined);
+    TestValidator.equals(
+      `${title} broken compiles`,
+      syntaxErrorOf(broken),
+      undefined,
+    );
+    TestValidator.equals(
+      `${title} broken has no comma after the rest`,
+      /\.\.\.[A-Za-z]+,/.test(broken),
+      false,
+    );
+  }
+  TestValidator.equals(
+    "the broken layout really breaks",
+    tiny
+      .print(
+        factory.createExpressionStatement(
+          factory.createAssignment(target(), id("sourceCollectionValue")),
+        ),
+      )
+      .includes("\n"),
+    true,
+  );
+
+  // negative twin: the same shape without a rest keeps the break comma
+  const plain: string = tiny.print(
+    factory.createExpressionStatement(
+      factory.createAssignment(
+        factory.createArrayLiteralExpression([
+          id("firstDestructuredBinding"),
+          id("secondDestructuredBinding"),
+          id("thirdDestructuredBinding"),
+        ]),
+        id("sourceCollectionValue"),
+      ),
+    ),
+  );
+  TestValidator.equals(
+    "plain last element keeps its trailing comma",
+    plain.includes("thirdDestructuredBinding,"),
+    true,
+  );
+  TestValidator.equals("plain twin compiles", syntaxErrorOf(plain), undefined);
+};

--- a/tests/test-factory/src/features/width/test_call_args_break_trailing_elision.ts
+++ b/tests/test-factory/src/features/width/test_call_args_break_trailing_elision.ts
@@ -112,6 +112,13 @@ export const test_call_args_break_trailing_elision = (): void => {
       /,\s*,/.test(broken),
       false,
     );
+    // the elision prints as nothing, so the line it would have occupied must
+    // collapse rather than survive as indentation
+    TestValidator.equals(
+      `${title} broken leaves no trailing whitespace`,
+      broken.split("\n").filter((line) => /[ \t]$/.test(line)),
+      [],
+    );
   }
 
   // negative twin: a trailing spread keeps the break comma, which is legal

--- a/tests/test-factory/src/features/width/test_call_args_break_trailing_elision.ts
+++ b/tests/test-factory/src/features/width/test_call_args_break_trailing_elision.ts
@@ -1,0 +1,132 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Node, TsPrinter } from "@ttsc/factory";
+import ts from "ts-legacy";
+
+import { id, str } from "../../internal/helpers";
+import { printLegacy, structure, syntaxErrorOf } from "../../internal/oracle";
+
+const wide = new TsPrinter({ printWidth: 200 });
+const tiny = new TsPrinter({ printWidth: 20 });
+
+/**
+ * Verifies a call or `new` argument list ending in an elision parses in both
+ * layouts.
+ *
+ * A trailing `OmittedExpression` prints as nothing, so the list already ends in
+ * the separator comma of its last real argument — `f(a, )`, one argument, which
+ * is exactly what the legacy printer emits. Adding the width-break comma on top
+ * produced `f(a, ,)`, which is a hard syntax error, so the same call printed
+ * fine until its arguments grew past `printWidth`. The boundary this pins is
+ * that the fix must not leave two commas on separate lines either.
+ *
+ * 1. Print a call and a `new` whose last argument is an elision, flat and
+ *    broken.
+ * 2. Assert every layout parses, compiles in V8, and keeps one argument — the
+ *    same count the legacy printer's text yields.
+ * 3. Assert an argument list ending in a spread still gains its break comma.
+ */
+export const test_call_args_break_trailing_elision = (): void => {
+  const argumentCount = (text: string): number => {
+    const file: ts.SourceFile = ts.createSourceFile(
+      "case.ts",
+      text,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    let count = -1;
+    const visit = (node: ts.Node): void => {
+      if (count < 0 && (ts.isCallExpression(node) || ts.isNewExpression(node)))
+        count = node.arguments?.length ?? -1;
+      ts.forEachChild(node, visit);
+    };
+    visit(file);
+    return count;
+  };
+  const cases: [string, Node, ts.Node][] = [
+    [
+      "call",
+      factory.createExpressionStatement(
+        factory.createCallExpression(id("handlerFunctionName"), undefined, [
+          str("alphaAlphaAlphaAlphaAlpha"),
+          factory.createOmittedExpression(),
+        ]),
+      ),
+      ts.factory.createExpressionStatement(
+        ts.factory.createCallExpression(
+          ts.factory.createIdentifier("handlerFunctionName"),
+          undefined,
+          [
+            ts.factory.createStringLiteral("alphaAlphaAlphaAlphaAlpha"),
+            ts.factory.createOmittedExpression(),
+          ],
+        ),
+      ),
+    ],
+    [
+      "new",
+      factory.createExpressionStatement(
+        factory.createNewExpression(id("HandlerConstructorName"), undefined, [
+          str("alphaAlphaAlphaAlpha"),
+          factory.createOmittedExpression(),
+        ]),
+      ),
+      ts.factory.createExpressionStatement(
+        ts.factory.createNewExpression(
+          ts.factory.createIdentifier("HandlerConstructorName"),
+          undefined,
+          [
+            ts.factory.createStringLiteral("alphaAlphaAlphaAlpha"),
+            ts.factory.createOmittedExpression(),
+          ],
+        ),
+      ),
+    ],
+  ];
+  for (const [title, node, oracle] of cases) {
+    const flat: string = wide.print(node);
+    const broken: string = tiny.print(node);
+    const expected: string = printLegacy(oracle);
+    TestValidator.equals(`${title} broken layout breaks`, broken.includes("\n"), true);
+    for (const [layout, text] of [
+      ["flat", flat],
+      ["broken", broken],
+    ] as const) {
+      TestValidator.equals(
+        `${title} ${layout} compiles`,
+        syntaxErrorOf(text),
+        undefined,
+      );
+      TestValidator.equals(
+        `${title} ${layout} argument count`,
+        argumentCount(text),
+        argumentCount(expected),
+      );
+      TestValidator.equals(
+        `${title} ${layout} means what the oracle means`,
+        structure(text),
+        structure(expected),
+      );
+    }
+    TestValidator.equals(
+      `${title} broken has no doubled comma`,
+      /,\s*,/.test(broken),
+      false,
+    );
+  }
+
+  // negative twin: a trailing spread keeps the break comma, which is legal
+  const spread: string = tiny.print(
+    factory.createExpressionStatement(
+      factory.createCallExpression(id("handlerFunctionName"), undefined, [
+        id("firstArgumentName"),
+        factory.createSpreadElement(id("remainingArgumentNames")),
+      ]),
+    ),
+  );
+  TestValidator.equals(
+    "trailing spread keeps its comma",
+    spread.includes("...remainingArgumentNames,"),
+    true,
+  );
+  TestValidator.equals("trailing spread compiles", syntaxErrorOf(spread), undefined);
+};

--- a/tests/test-factory/src/features/width/test_object_target_break_rest_no_trailing_comma.ts
+++ b/tests/test-factory/src/features/width/test_object_target_break_rest_no_trailing_comma.ts
@@ -1,0 +1,117 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression, type Node, TsPrinter } from "@ttsc/factory";
+
+import { id } from "../../internal/helpers";
+import { syntaxErrorOf } from "../../internal/oracle";
+
+const wide = new TsPrinter({ printWidth: 200 });
+const tiny = new TsPrinter({ printWidth: 20 });
+
+/** `{ first, ...rest }`, long enough to break at the default width. */
+const target = (multiLine?: boolean): Expression =>
+  factory.createObjectLiteralExpression(
+    [
+      factory.createShorthandPropertyAssignment("firstDestructuredBinding"),
+      factory.createSpreadAssignment(id("remainingDestructuredBindings")),
+    ],
+    multiLine,
+  );
+
+/**
+ * Verifies a broken object destructuring assignment target ending in a rest
+ * property drops the synthetic trailing comma.
+ *
+ * The object half of the same cause as the array target: `({ a, ...rest } =
+ * source)` is an `ObjectLiteralExpression`, not a binding pattern, so it took
+ * the unguarded literal path, and a comma after its `AssignmentRestProperty` is
+ * a `SyntaxError`. The rvalue twin proves the suppression is positional — the
+ * identical literal used as a value keeps its break comma, because there the
+ * comma is legal.
+ *
+ * 1. Print the same target through `=`, `for…in`, a nested property target and
+ *    `multiLine: true`, flat and broken.
+ * 2. Assert every layout compiles in V8.
+ * 3. Assert the rvalue twin keeps its trailing comma when it breaks.
+ */
+export const test_object_target_break_rest_no_trailing_comma = (): void => {
+  const cases: [string, Node][] = [
+    [
+      "assignment",
+      factory.createExpressionStatement(
+        factory.createAssignment(target(), id("sourceCollectionValue")),
+      ),
+    ],
+    [
+      "for-in",
+      factory.createForInStatement(
+        target(),
+        id("sourceCollectionValues"),
+        factory.createBlock([]),
+      ),
+    ],
+    [
+      "nested property target",
+      factory.createExpressionStatement(
+        factory.createAssignment(
+          factory.createObjectLiteralExpression([
+            factory.createPropertyAssignment("propertyName", target()),
+          ]),
+          id("sourceCollectionValue"),
+        ),
+      ),
+    ],
+    [
+      "nested behind a spread target",
+      factory.createExpressionStatement(
+        factory.createAssignment(
+          factory.createArrayLiteralExpression([
+            factory.createSpreadElement(target()),
+          ]),
+          id("sourceCollectionValue"),
+        ),
+      ),
+    ],
+    [
+      "multiLine forces the break at any width",
+      factory.createExpressionStatement(
+        factory.createAssignment(target(true), id("sourceCollectionValue")),
+      ),
+    ],
+  ];
+  for (const [title, node] of cases) {
+    const flat: string = wide.print(node);
+    const broken: string = tiny.print(node);
+    TestValidator.equals(`${title} flat compiles`, syntaxErrorOf(flat), undefined);
+    TestValidator.equals(
+      `${title} broken compiles`,
+      syntaxErrorOf(broken),
+      undefined,
+    );
+    TestValidator.equals(
+      `${title} broken has no comma after the rest`,
+      /\.\.\.[A-Za-z]+,/.test(broken),
+      false,
+    );
+  }
+
+  // negative twin: the same literal as a value keeps the break comma
+  const rvalue: string = tiny.print(
+    factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList([
+        factory.createVariableDeclaration(
+          "mergedValue",
+          undefined,
+          undefined,
+          target(),
+        ),
+      ]),
+    ),
+  );
+  TestValidator.equals(
+    "rvalue object spread keeps its trailing comma",
+    rvalue.includes("...remainingDestructuredBindings,"),
+    true,
+  );
+  TestValidator.equals("rvalue twin compiles", syntaxErrorOf(rvalue), undefined);
+};

--- a/tests/test-factory/src/internal/oracle.ts
+++ b/tests/test-factory/src/internal/oracle.ts
@@ -1,0 +1,204 @@
+import type { Node } from "@ttsc/factory";
+import { TsPrinter } from "@ttsc/factory";
+import ts from "ts-legacy";
+
+/**
+ * Differential oracle against the pinned legacy compiler (`ts-legacy`).
+ *
+ * `@ttsc/factory`'s printer re-implements the legacy printer's parenthesizer
+ * and list rules, so the authority for what a tree must print as is the legacy
+ * printer's own output for the same tree — never this printer's current output.
+ * An expectation copied from the code under test cannot fail when that code is
+ * wrong; it only records what the code did the day the test was written.
+ *
+ * Comparing the two texts byte for byte would compare formatting, not meaning
+ * (the legacy printer writes `class A extends B {\n}` and a space before a
+ * template tag). {@link structure} therefore reduces printed text to what the
+ * program *means*: the parsed node-kind tree, with parentheses removed and
+ * optional-chain membership recorded, so `a?.b()` and `(a?.b)()` — the same
+ * characters modulo one pair of parentheses, but different programs — do not
+ * compare equal.
+ *
+ * @author Jeongho Nam - https://github.com/samchon
+ */
+
+/** Print a legacy (`ts-legacy`) node with the legacy printer: the oracle text. */
+export const printLegacy = (node: ts.Node): string =>
+  legacyPrinter.printNode(
+    ts.EmitHint.Unspecified,
+    node,
+    ts.createSourceFile("oracle.ts", "", ts.ScriptTarget.Latest),
+  );
+
+/** Parse `text`, throwing when it does not parse cleanly. */
+export const parseClean = (
+  text: string,
+  scriptKind: ts.ScriptKind = ts.ScriptKind.TS,
+): ts.SourceFile => {
+  const file: ts.SourceFile = parse(text, scriptKind);
+  const diagnostics: readonly string[] = parseDiagnostics(file);
+  if (diagnostics.length !== 0)
+    throw new Error(
+      `printed source does not parse: ${JSON.stringify(text)} :: ${diagnostics.join(" | ")}`,
+    );
+  return file;
+};
+
+/** Diagnostic messages the parser produced for a parsed file. */
+export const parseDiagnostics = (file: ts.SourceFile): string[] =>
+  (
+    (file as unknown as { parseDiagnostics?: readonly ts.Diagnostic[] })
+      .parseDiagnostics ?? []
+  ).map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "));
+
+/**
+ * Structural signature of printed source: the node-kind tree with
+ * `ParenthesizedExpression` elided and optional-chain membership marked.
+ *
+ * Eliding parentheses is what makes the comparison a *meaning* comparison
+ * rather than a formatting one; marking chain membership is what keeps it from
+ * being blind to the difference the parentheses make, since `(a?.b)()` parses
+ * to a call that is not part of the chain and `a?.b()` to one that is.
+ */
+export const structure = (
+  text: string,
+  scriptKind: ts.ScriptKind = ts.ScriptKind.TS,
+): string => signature(parseClean(text, scriptKind));
+
+/** {@link structure}'s reduction, over an already-parsed node. */
+export const signature = (node: ts.Node): string => {
+  if (ts.isParenthesizedExpression(node)) return signature(node.expression);
+  const parts: string[] = [];
+  node.forEachChild((child) => void parts.push(signature(child)));
+  let name: string = ts.SyntaxKind[node.kind]!;
+  if (isOptionalChain(node)) name += "?";
+  if (
+    ts.isIdentifier(node) ||
+    ts.isNumericLiteral(node) ||
+    ts.isStringLiteral(node) ||
+    ts.isJsxText(node)
+  )
+    name += `(${JSON.stringify(node.text)})`;
+  return parts.length === 0 ? name : `${name}[${parts.join(",")}]`;
+};
+
+/**
+ * Assert that `printed` means what the legacy printer's own output for
+ * `oracle` means.
+ */
+export const assertOracle = (
+  title: string,
+  printed: string,
+  oracle: ts.Node,
+  scriptKind: ts.ScriptKind = ts.ScriptKind.TS,
+): void => {
+  const expected: string = structure(printLegacy(oracle), scriptKind);
+  const actual: string = structure(printed, scriptKind);
+  if (actual !== expected)
+    throw new Error(
+      `${title}: printed source does not mean what the oracle prints\n  printed: ${JSON.stringify(printed)}\n  oracle:  ${JSON.stringify(printLegacy(oracle))}\n  actual:   ${actual}\n  expected: ${expected}`,
+    );
+};
+
+/**
+ * The `children` argument the JSX runtime receives for the first element in
+ * `text`, which is what a reader of the rendered page actually sees.
+ *
+ * JSX whitespace is not layout: a whitespace-only child containing a newline is
+ * deleted and every text child is trimmed at an edge that carries a newline, so
+ * this is the observable that a width-driven line break must not change.
+ */
+export const jsxChildren = (text: string): string => {
+  const emitted: string = ts.transpileModule(text, {
+    compilerOptions: {
+      jsx: ts.JsxEmit.ReactJSX,
+      target: ts.ScriptTarget.ESNext,
+    },
+    reportDiagnostics: true,
+  }).outputText;
+  const file: ts.SourceFile = parseClean(emitted, ts.ScriptKind.JS);
+  let children: string | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      children === undefined &&
+      ts.isPropertyAssignment(node) &&
+      node.name.getText(file) === "children"
+    )
+      // the signature keeps every string literal's exact text while ignoring
+      // how the emitter laid the call out
+      children = signature(node.initializer);
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+  return children ?? "<no children>";
+};
+
+/**
+ * The V8 `SyntaxError` message for `source`, or `undefined` when it compiles.
+ *
+ * The TypeScript parser accepts a trailing comma after a destructuring
+ * assignment's rest element and only rejects it later, so the engine — which is
+ * what actually runs generated code — is the authority for that row.
+ */
+export const syntaxErrorOf = (source: string): string | undefined => {
+  try {
+    new Function(source);
+    return undefined;
+  } catch (error) {
+    return (error as Error).message;
+  }
+};
+
+/** Collect every `kind` appearing in a `@ttsc/factory` tree. */
+export const kindsOf = (node: Node): Set<string> => {
+  const kinds = new Set<string>();
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+    if (value === null || typeof value !== "object") return;
+    const record = value as Record<string, unknown>;
+    if (typeof record.kind === "string") kinds.add(record.kind);
+    for (const item of Object.values(record)) visit(item);
+  };
+  visit(node);
+  return kinds;
+};
+
+/** Printer wide enough that no group breaks: layout is out of the way. */
+export const wide = new TsPrinter({ printWidth: 200 });
+
+const legacyPrinter: ts.Printer = ts.createPrinter({
+  newLine: ts.NewLineKind.LineFeed,
+});
+
+const parse = (text: string, scriptKind: ts.ScriptKind): ts.SourceFile =>
+  ts.createSourceFile(
+    scriptKind === ts.ScriptKind.TSX
+      ? "case.tsx"
+      : scriptKind === ts.ScriptKind.JS
+        ? "case.js"
+        : "case.ts",
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  );
+
+/**
+ * Whether a parsed node is part of an optional chain, mirroring the
+ * `NodeFlags.OptionalChain` the compiler sets: a `?.` link, or an access, call
+ * or non-null assertion continuing one. A parenthesized head ends the chain,
+ * which is exactly the distinction under test.
+ */
+const isOptionalChain = (node: ts.Node): boolean => {
+  if (
+    ts.isPropertyAccessExpression(node) ||
+    ts.isElementAccessExpression(node) ||
+    ts.isCallExpression(node)
+  )
+    return node.questionDotToken !== undefined || isOptionalChain(node.expression);
+  if (ts.isNonNullExpression(node)) return isOptionalChain(node.expression);
+  return false;
+};

--- a/tests/test-factory/src/internal/oracle.ts
+++ b/tests/test-factory/src/internal/oracle.ts
@@ -109,22 +109,7 @@ export const assertOracle = (
  * this is the observable that a width-driven line break must not change.
  */
 export const jsxChildren = (text: string): string => {
-  const output: ts.TranspileOutput = ts.transpileModule(text, {
-    compilerOptions: {
-      jsx: ts.JsxEmit.ReactJSX,
-      target: ts.ScriptTarget.ESNext,
-    },
-    fileName: "case.tsx",
-    reportDiagnostics: true,
-  });
-  const diagnostics: readonly ts.Diagnostic[] = output.diagnostics ?? [];
-  if (diagnostics.length !== 0)
-    throw new Error(
-      `printed JSX does not transpile: ${JSON.stringify(text)} :: ${diagnostics
-        .map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "))
-        .join(" | ")}`,
-    );
-  const file: ts.SourceFile = parseClean(output.outputText, ts.ScriptKind.JS);
+  const file: ts.SourceFile = parseClean(transpileJsx(text), ts.ScriptKind.JS);
   let children: string | undefined;
   const visit = (node: ts.Node): void => {
     if (
@@ -143,6 +128,32 @@ export const jsxChildren = (text: string): string => {
       `printed JSX produced no children argument: ${JSON.stringify(text)}`,
     );
   return children;
+};
+
+/**
+ * {@link structure} of the whole transpiled module, for JSX shapes that
+ * legitimately have no `children` argument at all.
+ */
+export const jsxEmit = (text: string): string =>
+  signature(parseClean(transpileJsx(text), ts.ScriptKind.JS));
+
+const transpileJsx = (text: string): string => {
+  const output: ts.TranspileOutput = ts.transpileModule(text, {
+    compilerOptions: {
+      jsx: ts.JsxEmit.ReactJSX,
+      target: ts.ScriptTarget.ESNext,
+    },
+    fileName: "case.tsx",
+    reportDiagnostics: true,
+  });
+  const diagnostics: readonly ts.Diagnostic[] = output.diagnostics ?? [];
+  if (diagnostics.length !== 0)
+    throw new Error(
+      `printed JSX does not transpile: ${JSON.stringify(text)} :: ${diagnostics
+        .map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "))
+        .join(" | ")}`,
+    );
+  return output.outputText;
 };
 
 /**

--- a/tests/test-factory/src/internal/oracle.ts
+++ b/tests/test-factory/src/internal/oracle.ts
@@ -109,14 +109,22 @@ export const assertOracle = (
  * this is the observable that a width-driven line break must not change.
  */
 export const jsxChildren = (text: string): string => {
-  const emitted: string = ts.transpileModule(text, {
+  const output: ts.TranspileOutput = ts.transpileModule(text, {
     compilerOptions: {
       jsx: ts.JsxEmit.ReactJSX,
       target: ts.ScriptTarget.ESNext,
     },
+    fileName: "case.tsx",
     reportDiagnostics: true,
-  }).outputText;
-  const file: ts.SourceFile = parseClean(emitted, ts.ScriptKind.JS);
+  });
+  const diagnostics: readonly ts.Diagnostic[] = output.diagnostics ?? [];
+  if (diagnostics.length !== 0)
+    throw new Error(
+      `printed JSX does not transpile: ${JSON.stringify(text)} :: ${diagnostics
+        .map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "))
+        .join(" | ")}`,
+    );
+  const file: ts.SourceFile = parseClean(output.outputText, ts.ScriptKind.JS);
   let children: string | undefined;
   const visit = (node: ts.Node): void => {
     if (
@@ -130,7 +138,11 @@ export const jsxChildren = (text: string): string => {
     ts.forEachChild(node, visit);
   };
   visit(file);
-  return children ?? "<no children>";
+  if (children === undefined)
+    throw new Error(
+      `printed JSX produced no children argument: ${JSON.stringify(text)}`,
+    );
+  return children;
 };
 
 /**


### PR DESCRIPTION
Campaign batch **B3** of the `repository-audit-2026-07-19` campaign. One owner, one branch, one pull request for the three `@ttsc/factory` printer issues whose common cause is the same: **the printed text does not mean what the AST says.**

Closes #851
Closes #837
Closes #836

## Scope

| Issue | Defect | Owner in the code |
| --- | --- | --- |
| #851 | Optional chains under a non-optional parent, and heritage-clause expressions, are emitted without the parentheses the grammar requires. `new (a?.b)()` prints as `new a?.b();` (TS1209); `class A extends (X \|\| Y) {}` prints without the parentheses (TS1005). Four further chain rows compile and silently change the program. | `TsPrinter.leftSideExpression` and its call sites, `newExpressionTargetNeedsParentheses`, the `ExpressionWithTypeArguments` case |
| #837 | A trailing comma added only because a list broke changes whether the text parses and what arity it has, in destructuring assignment targets and in argument lists ending in an elision — at the **default** `printWidth: 80`. | `TsPrinter.delim` and the three call sites that hardcode `trailingComma: true` |
| #836 | JSX children are joined with a line-break-capable separator, so `printWidth` deletes whitespace-only children and trims significant edge whitespace off text children. | `TsPrinter`'s `JsxElement`/`JsxFragment`/`JsxText` cases and `printDocToString`'s trailing-space trim in `internal/doc.ts` |

They are batched together because all three edit `packages/factory/src/TsPrinter.ts`; the issues themselves require the same-file siblings to be sequenced under one owner rather than run in parallel worktrees.

#818 (signature and escaping parity) is **not** in this batch and this branch does not touch its surface.

## Method commitment

Three prior audit rounds fuzzed this parenthesizer with 1,312, 5,000 and 100,000 cases and all reported it clean, because no generator could emit an optional chain or a heritage clause. This batch therefore **extends the corpus grammar, not the case count**.

Several existing `tests/test-factory` expectations were taken from this printer's own output rather than from the pinned `ts-legacy` oracle, so they pin the defect. Every expectation this branch touches is re-derived from the oracle and the change is stated explicitly in a later comment on this thread.

## Campaign CI

Per `.agents/skills/issue-campaign/development.md`, automatic CI is suspended for this branch: every push passes an exact-SHA cancellation gate and the results are recorded in `.wiki/repository-audit-2026-07-19/ci-state.md`. Repository Actions permissions and workflow states are unchanged. `pnpm format` is not run on this branch; Post-Campaign Cleanup owns the repository-wide formatter result.

Local verification is the gate. Commands and results are posted to this thread as the work lands.

## Status

Draft, claim only. No implementation in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HZ6QbzkgY5nKd14RKEqdN
