### PR TITLE
fix(wasm): keep MemFS a tree, honor descriptor semantics, and correct the pipe2 contract

### DIFF
--- a/packages/wasm/src/createMemFS.ts
+++ b/packages/wasm/src/createMemFS.ts
@@ -72,19 +72,52 @@ export function createMemFS(): IMemFSHost {
   const stdout = { buffer: "" };
   const stderr = { buffer: "" };
 
-  const fdTable = new Map<
-    number,
-    { path: string; position: number; isStdout?: boolean; isStderr?: boolean }
-  >();
+  /**
+   * One open descriptor.
+   *
+   * `readable`, `writable`, and `append` are the access mode and `O_APPEND`
+   * flag captured at `open`; without them no read or write below can tell an
+   * allowed operation from a forbidden one. `position` is the cursor a
+   * `position: null` read or write uses and advances, exactly as Node's `fs`
+   * defines it.
+   */
+  interface IDescriptor {
+    path: string;
+    position: number;
+    readable: boolean;
+    writable: boolean;
+    append: boolean;
+    isStdout?: boolean;
+    isStderr?: boolean;
+  }
+  const fdTable = new Map<number, IDescriptor>();
   let nextFd = 100;
   // Reserve 1/2 for stdout/stderr writeSync routing.
-  fdTable.set(1, { path: "/dev/stdout", position: 0, isStdout: true });
-  fdTable.set(2, { path: "/dev/stderr", position: 0, isStderr: true });
+  fdTable.set(1, {
+    path: "/dev/stdout",
+    position: 0,
+    readable: false,
+    writable: true,
+    append: true,
+    isStdout: true,
+  });
+  fdTable.set(2, {
+    path: "/dev/stderr",
+    position: 0,
+    readable: false,
+    writable: true,
+    append: true,
+    isStderr: true,
+  });
 
   // Pipe state. fs.pipe2 mints a pair of fds backed by a shared queue;
   // writes append, reads consume. The state is keyed by fd so a single Map
   // lookup in read/write/close can detect "this is a pipe end" without
   // changing the existing fdTable entries.
+  //
+  // These fds only ever come from a direct JavaScript `fs.pipe2` call. Go's
+  // wasm `os.Pipe` returns ENOSYS without crossing the `globalThis.fs` bridge,
+  // so the Go runtime never reaches this state — see IWasmExecFS.pipe2.
   interface IPipeState {
     buffers: Uint8Array[];
     pendingReaders: Array<{
@@ -143,21 +176,55 @@ export function createMemFS(): IMemFSHost {
     }
   }
 
-  /** Silently create any missing ancestor directories for path `p`. */
-  function ensureParentDirs(p: string): void {
-    const segments = normalize(p).split("/").filter(Boolean);
+  /**
+   * Validate the ancestor chain of normalized path `norm` and report the
+   * ancestors that do not exist yet, root-first.
+   *
+   * An ancestor that exists as a file makes `norm` impossible: a file has no
+   * descendants, so creating one below it would leave a node map that is not a
+   * tree. Validation is deliberately separate from creation so a caller can
+   * reject before touching anything, and so a rejected operation never leaves
+   * half a directory chain behind.
+   */
+  function missingAncestors(norm: string, syscall: string): string[] {
+    const segments = norm.split("/").filter(Boolean);
     segments.pop();
+    const missing: string[] = [];
     let cursor = "";
     for (const seg of segments) {
       cursor += "/" + seg;
-      if (!nodes.has(cursor)) {
-        nodes.set(cursor, {
-          kind: "dir",
-          data: new Uint8Array(),
-          mtimeMs: Date.now(),
-        });
-      }
+      const existing = nodes.get(cursor);
+      if (!existing) missing.push(cursor);
+      else if (existing.kind !== "dir")
+        throw new MemFSError("ENOTDIR", syscall, cursor);
     }
+    return missing;
+  }
+
+  /** Materialize the ancestor directories `missingAncestors` reported. */
+  function createDirs(paths: string[]): void {
+    for (const path of paths)
+      nodes.set(path, {
+        kind: "dir",
+        data: new Uint8Array(),
+        mtimeMs: Date.now(),
+      });
+  }
+
+  /**
+   * Validate that normalized path `norm` may hold a regular file, returning the
+   * node already there when one exists.
+   *
+   * A directory is never silently replaced by a file — including the root,
+   * which is a directory node like any other. POSIX answers `EISDIR`, and
+   * overwriting the node here would strand every descendant in the map behind a
+   * path `readdir` can no longer walk.
+   */
+  function assertFileTarget(norm: string, syscall: string): INode | undefined {
+    const existing = nodes.get(norm);
+    if (existing && existing.kind !== "file")
+      throw new MemFSError("EISDIR", syscall, norm);
+    return existing;
   }
 
   /** Absolute parent directory of a normalized path (`/` for a top-level path). */
@@ -183,6 +250,39 @@ export function createMemFS(): IMemFSHost {
     const next = new Uint8Array(length);
     next.set(data.subarray(0, Math.min(length, data.byteLength)));
     return next;
+  }
+
+  /**
+   * Write `view` through descriptor `entry` and return the bytes stored.
+   *
+   * Three offsets are possible and only one of them is right per call: an
+   * `O_APPEND` descriptor always writes at end-of-file, an explicit `position`
+   * writes exactly there without disturbing the cursor (POSIX `pwrite`), and
+   * `position: null` writes at the cursor and advances it. A write that starts
+   * past end-of-file zero-fills the gap rather than silently relocating.
+   */
+  function writeThroughDescriptor(
+    entry: IDescriptor,
+    view: Uint8Array,
+    position: number | null,
+    syscall: string,
+  ): number {
+    if (!entry.writable) throw new MemFSError("EBADF", syscall, entry.path);
+    const node = nodes.get(entry.path);
+    if (!node) throw new MemFSError("ENOENT", syscall, entry.path);
+    if (node.kind !== "file")
+      throw new MemFSError("EISDIR", syscall, entry.path);
+    const start = entry.append
+      ? node.data.byteLength
+      : (position ?? entry.position);
+    if (!Number.isInteger(start) || start < 0)
+      throw new MemFSError("EINVAL", syscall, entry.path);
+    const end = start + view.byteLength;
+    if (end > node.data.byteLength) node.data = resizeFileData(node.data, end);
+    node.data.set(view, start);
+    node.mtimeMs = Date.now();
+    if (position === null || entry.append) entry.position = end;
+    return view.byteLength;
   }
 
   /**
@@ -233,10 +333,19 @@ export function createMemFS(): IMemFSHost {
 
   function writeFile(p: string, data: string | Uint8Array): void {
     const norm = normalize(p);
-    ensureParentDirs(norm);
+    // Resolve left to right the way POSIX does: an impossible ancestor is
+    // reported before the target, and both are checked before any mutation.
+    const missing = missingAncestors(norm, "open");
+    const existing = assertFileTarget(norm, "open");
     const bytes =
       typeof data === "string" ? encoder.encode(data) : new Uint8Array(data);
-    nodes.set(norm, { kind: "file", data: bytes, mtimeMs: Date.now() });
+    createDirs(missing);
+    // Overwriting keeps the same node so descriptors already pointing at this
+    // file observe the replacement instead of a detached predecessor.
+    if (existing) {
+      existing.data = bytes;
+      existing.mtimeMs = Date.now();
+    } else nodes.set(norm, { kind: "file", data: bytes, mtimeMs: Date.now() });
   }
 
   function readFile(p: string): Uint8Array | null {
@@ -334,40 +443,19 @@ export function createMemFS(): IMemFSHost {
           console.error("[wasm]", line);
         return buf.length;
       }
-      // Open-file fds (>= 100): append to the underlying file. Browser-hosted
-      // tools use this path for ordinary virtual files and explicit outputs.
+      // Open-file fds (>= 100): write at the descriptor cursor, the way Node's
+      // own `writeSync` without a position does. Browser-hosted tools use this
+      // path for ordinary virtual files and explicit outputs.
+      //
+      // An unknown or already-closed fd throws instead of being diverted into
+      // the captured stderr: reporting the byte count of a write nobody
+      // performed made the caller continue on a false success and quietly
+      // contaminated a diagnostic channel consumers read.
       const entry = fdTable.get(fd);
-      if (entry) {
-        const node = nodes.get(entry.path);
-        if (node && node.kind === "file") {
-          // subarray(0) is a zero-copy view over the full incoming buffer; the
-          // bytes are copied into `next` before writeSync returns.
-          const incoming = buf.subarray(0);
-          const existing = node.data;
-          const next = new Uint8Array(
-            existing.byteLength + incoming.byteLength,
-          );
-          next.set(existing, 0);
-          next.set(incoming, existing.byteLength);
-          node.data = next;
-          node.mtimeMs = Date.now();
-          entry.position = next.byteLength;
-          return incoming.byteLength;
-        }
-      }
-      // Unknown fd. Fall back to the stderr buffer so the bytes aren't lost
-      // entirely (and surface as a console.error so the regression is
-      // visible to whoever's looking).
-      stderr.buffer += decoder.decode(buf);
-      // eslint-disable-next-line no-console
-      console.error(
-        "[wasm] writeSync to unknown fd " +
-          fd +
-          " (" +
-          buf.byteLength +
-          " bytes); routed to stderr buffer",
-      );
-      return buf.length;
+      if (!entry) throw new MemFSError("EBADF", "write");
+      // subarray(0) is a zero-copy view over the full incoming buffer; the
+      // bytes are copied into the node before writeSync returns.
+      return writeThroughDescriptor(entry, buf.subarray(0), null, "write");
     },
 
     write(fd, buf, offset, length, position, callback) {
@@ -390,44 +478,82 @@ export function createMemFS(): IMemFSHost {
           callback(null, length);
           return;
         }
-        if (position !== null && position !== 0) {
-          callback(new MemFSError("ESPIPE", "write"), 0);
+        const view = buf.subarray(offset, offset + length);
+        // The stdout/stderr capture buffers are streams, not files: they have
+        // no seekable offset, so an explicit position is meaningless on them.
+        if (fd === 1 || fd === 2) {
+          if (position !== null && position !== 0)
+            throw new MemFSError("ESPIPE", "write");
+          callback(null, this.writeSync(fd, view));
           return;
         }
-        const view = buf.subarray(offset, offset + length);
-        const written = this.writeSync(fd, view);
-        callback(null, written);
+        const entry = fdTable.get(fd);
+        if (!entry) throw new MemFSError("EBADF", "write");
+        callback(null, writeThroughDescriptor(entry, view, position, "write"));
       } catch (err) {
         callback(err as NodeJS.ErrnoException, 0);
       }
     },
 
+    // Every rejection happens before the first mutation and before a
+    // descriptor is minted, so a refused open leaves neither a half-created
+    // node nor a leaked fd behind.
     open(p, flags, _mode, callback) {
-      const norm = normalize(p);
-      const node = nodes.get(norm);
-      const creating = (flags & (this.constants.O_CREAT ?? 0)) !== 0;
-      if (!node) {
-        if (!creating) {
-          callback(new MemFSError("ENOENT", "open", norm), -1);
-          return;
+      try {
+        const norm = normalize(p);
+        const creating = (flags & (this.constants.O_CREAT ?? 0)) !== 0;
+        const exclusive = (flags & (this.constants.O_EXCL ?? 0)) !== 0;
+        const truncating = (flags & (this.constants.O_TRUNC ?? 0)) !== 0;
+        const appending = (flags & (this.constants.O_APPEND ?? 0)) !== 0;
+        const directoryOnly = (flags & (this.constants.O_DIRECTORY ?? 0)) !== 0;
+        // The access mode is the low bits of `flags`: absent both means
+        // read-only, and `O_RDWR` alongside `O_WRONLY` still grants both.
+        const writeOnly = (flags & (this.constants.O_WRONLY ?? 0)) !== 0;
+        const readWrite = (flags & (this.constants.O_RDWR ?? 0)) !== 0;
+        const writable = writeOnly || readWrite;
+        const readable = !writeOnly || readWrite;
+
+        let node = nodes.get(norm);
+        if (!node) {
+          if (!creating) throw new MemFSError("ENOENT", "open", norm);
+          // `open` can only ever create a regular file, so a caller demanding a
+          // directory cannot be satisfied by creating one.
+          if (directoryOnly) throw new MemFSError("ENOTDIR", "open", norm);
+          // Creating the missing ancestor chain is the documented job of
+          // `writeFile` and `mkdirp`; the low-level `open` never promised it.
+          const missing = missingAncestors(norm, "open");
+          if (missing.length > 0)
+            throw new MemFSError("ENOENT", "open", missing[0]!);
+          node = { kind: "file", data: new Uint8Array(), mtimeMs: Date.now() };
+          nodes.set(norm, node);
+        } else {
+          if (creating && exclusive)
+            throw new MemFSError("EEXIST", "open", norm);
+          if (node.kind === "dir") {
+            // A directory opens read-only — Go stats the fd and lists the path
+            // that way. Writing to it or truncating it would turn it into a
+            // file and orphan every descendant.
+            if (writable || truncating)
+              throw new MemFSError("EISDIR", "open", norm);
+          } else if (directoryOnly)
+            throw new MemFSError("ENOTDIR", "open", norm);
         }
-        ensureParentDirs(norm);
-        nodes.set(norm, {
-          kind: "file",
-          data: new Uint8Array(),
-          mtimeMs: Date.now(),
+        if (truncating) {
+          node.data = new Uint8Array();
+          node.mtimeMs = Date.now();
+        }
+        const fd = nextFd++;
+        fdTable.set(fd, {
+          path: norm,
+          position: 0,
+          readable,
+          writable,
+          append: appending,
         });
+        callback(null, fd);
+      } catch (err) {
+        callback(err as NodeJS.ErrnoException, -1);
       }
-      const fd = nextFd++;
-      fdTable.set(fd, { path: norm, position: 0 });
-      if ((flags & (this.constants.O_TRUNC ?? 0)) !== 0) {
-        nodes.set(norm, {
-          kind: "file",
-          data: new Uint8Array(),
-          mtimeMs: Date.now(),
-        });
-      }
-      callback(null, fd);
     },
 
     close(fd, callback) {
@@ -475,16 +601,29 @@ export function createMemFS(): IMemFSHost {
         callback(new MemFSError("EBADF", "read"), 0);
         return;
       }
+      // A write-only descriptor is not a readable one. POSIX answers EBADF for
+      // an operation the descriptor's access mode never granted.
+      if (!entry.readable) {
+        callback(new MemFSError("EBADF", "read", entry.path), 0);
+        return;
+      }
       const node = nodes.get(entry.path);
       if (!node || node.kind !== "file") {
         callback(new MemFSError("ENOENT", "read", entry.path), 0);
         return;
       }
       const start = position ?? entry.position;
+      if (!Number.isInteger(start) || start < 0) {
+        callback(new MemFSError("EINVAL", "read", entry.path), 0);
+        return;
+      }
       const end = Math.min(start + length, node.data.byteLength);
       const slice = node.data.subarray(start, end);
       buffer.set(slice, offset);
-      if (position === null) entry.position = end;
+      // The cursor advances by the bytes actually read. Assigning `end` would
+      // rewind a cursor already past end-of-file (after `ftruncate`, say) back
+      // onto live bytes and make the next sequential write overwrite them.
+      if (position === null) entry.position = start + slice.byteLength;
       callback(null, slice.byteLength);
     },
 
@@ -521,9 +660,9 @@ export function createMemFS(): IMemFSHost {
     },
 
     fstat(fd, callback) {
-      // fstat against a pipe end returns a synthetic file-stat. Go's
-      // os.Pipe-backed File uses fstat at construction time to populate
-      // Stat_t; without this it errors and falls back to invalid fds.
+      // fstat against a pipe end returns a synthetic file-stat so a direct
+      // JavaScript caller that wraps the fd in a file-like abstraction can
+      // populate its stat fields. A pipe end has no node in the tree.
       if (pipes.has(fd)) {
         callback(
           null,

--- a/packages/wasm/src/createMemFS.ts
+++ b/packages/wasm/src/createMemFS.ts
@@ -64,6 +64,12 @@ function normalize(p: string): string {
  * `globalThis.fs` before loading `wasm_exec.js`) and convenience helpers
  * (`writeFile`, `readFile`, `mkdirp`, …) for seeding source files and reading
  * compiler output without touching the real filesystem.
+ *
+ * Every successful mutation leaves a valid tree: `/` stays a directory, each
+ * proper ancestor of a node exists and is a directory, and a file has no
+ * descendants. An operation that cannot satisfy that throws (`writeFile`,
+ * `mkdirp`) or reports a POSIX error through its callback, having changed no
+ * node, byte, or descriptor.
  */
 export function createMemFS(): IMemFSHost {
   const nodes = new Map<string, INode>();
@@ -176,32 +182,39 @@ export function createMemFS(): IMemFSHost {
     }
   }
 
-  /**
-   * Validate the ancestor chain of normalized path `norm` and report the
-   * ancestors that do not exist yet, root-first.
-   *
-   * An ancestor that exists as a file makes `norm` impossible: a file has no
-   * descendants, so creating one below it would leave a node map that is not a
-   * tree. Validation is deliberately separate from creation so a caller can
-   * reject before touching anything, and so a rejected operation never leaves
-   * half a directory chain behind.
-   */
-  function missingAncestors(norm: string, syscall: string): string[] {
-    const segments = norm.split("/").filter(Boolean);
-    segments.pop();
-    const missing: string[] = [];
+  /** Root-to-leaf path of every segment of `norm` (`/a/b` → `["/a", "/a/b"]`). */
+  function pathChain(norm: string): string[] {
+    const chain: string[] = [];
     let cursor = "";
-    for (const seg of segments) {
+    for (const seg of norm.split("/").filter(Boolean)) {
       cursor += "/" + seg;
-      const existing = nodes.get(cursor);
-      if (!existing) missing.push(cursor);
+      chain.push(cursor);
+    }
+    return chain;
+  }
+
+  /**
+   * Validate that every path in root-to-leaf `chain` is or can become a
+   * directory, and report the ones that do not exist yet.
+   *
+   * A segment that exists as a file makes everything below it impossible: a
+   * file has no descendants, so creating one there would leave a node map that
+   * is not a tree. Validation is deliberately separate from creation so every
+   * caller can reject before touching anything, and so a rejected operation
+   * never leaves half a directory chain behind.
+   */
+  function missingDirs(chain: string[], syscall: string): string[] {
+    const missing: string[] = [];
+    for (const path of chain) {
+      const existing = nodes.get(path);
+      if (!existing) missing.push(path);
       else if (existing.kind !== "dir")
-        throw new MemFSError("ENOTDIR", syscall, cursor);
+        throw new MemFSError("ENOTDIR", syscall, path);
     }
     return missing;
   }
 
-  /** Materialize the ancestor directories `missingAncestors` reported. */
+  /** Materialize the directories `missingDirs` reported. */
   function createDirs(paths: string[]): void {
     for (const path of paths)
       nodes.set(path, {
@@ -260,6 +273,9 @@ export function createMemFS(): IMemFSHost {
    * writes exactly there without disturbing the cursor (POSIX `pwrite`), and
    * `position: null` writes at the cursor and advances it. A write that starts
    * past end-of-file zero-fills the gap rather than silently relocating.
+   *
+   * A zero-byte write changes nothing at all, so a cursor sitting past
+   * end-of-file cannot extend the file by writing nothing into it.
    */
   function writeThroughDescriptor(
     entry: IDescriptor,
@@ -277,6 +293,7 @@ export function createMemFS(): IMemFSHost {
       : (position ?? entry.position);
     if (!Number.isInteger(start) || start < 0)
       throw new MemFSError("EINVAL", syscall, entry.path);
+    if (view.byteLength === 0) return 0;
     const end = start + view.byteLength;
     if (end > node.data.byteLength) node.data = resizeFileData(node.data, end);
     node.data.set(view, start);
@@ -314,28 +331,16 @@ export function createMemFS(): IMemFSHost {
   }
 
   function mkdirp(p: string): void {
-    const segments = normalize(p).split("/").filter(Boolean);
-    let cursor = "";
-    for (const seg of segments) {
-      cursor += "/" + seg;
-      const existing = nodes.get(cursor);
-      if (!existing) {
-        nodes.set(cursor, {
-          kind: "dir",
-          data: new Uint8Array(),
-          mtimeMs: Date.now(),
-        });
-      } else if (existing.kind !== "dir") {
-        throw new MemFSError("ENOTDIR", "mkdir", cursor);
-      }
-    }
+    // Validate the whole chain before creating any of it: a rejected mkdirp
+    // must not leave the prefix it had already walked past behind.
+    createDirs(missingDirs(pathChain(normalize(p)), "mkdir"));
   }
 
   function writeFile(p: string, data: string | Uint8Array): void {
     const norm = normalize(p);
     // Resolve left to right the way POSIX does: an impossible ancestor is
     // reported before the target, and both are checked before any mutation.
-    const missing = missingAncestors(norm, "open");
+    const missing = missingDirs(pathChain(norm).slice(0, -1), "open");
     const existing = assertFileTarget(norm, "open");
     const bytes =
       typeof data === "string" ? encoder.encode(data) : new Uint8Array(data);
@@ -521,7 +526,7 @@ export function createMemFS(): IMemFSHost {
           if (directoryOnly) throw new MemFSError("ENOTDIR", "open", norm);
           // Creating the missing ancestor chain is the documented job of
           // `writeFile` and `mkdirp`; the low-level `open` never promised it.
-          const missing = missingAncestors(norm, "open");
+          const missing = missingDirs(pathChain(norm).slice(0, -1), "open");
           if (missing.length > 0)
             throw new MemFSError("ENOENT", "open", missing[0]!);
           node = { kind: "file", data: new Uint8Array(), mtimeMs: Date.now() };

--- a/packages/wasm/src/structures/IWasmExecFS.ts
+++ b/packages/wasm/src/structures/IWasmExecFS.ts
@@ -135,10 +135,20 @@ export interface IWasmExecFS {
     callback: (err: NodeJS.ErrnoException | null) => void,
   ): void;
   /**
-   * `pipe2` is what Go's wasm `os.Pipe()` calls. Returns two fds: a read end
-   * and a write end. The host's stdout/stderr capture currently uses MemFS temp
-   * files, but this keeps direct pipe callers compatible with the wasm fs
-   * surface.
+   * JavaScript-only pipe emulation. Returns two fds: a read end and a write
+   * end.
+   *
+   * Installing this does **not** make Go's wasm `os.Pipe()` work. Under the
+   * pinned Go toolchain neither `GOOS=js` nor `GOOS=wasip1` has pipes:
+   * `os.Pipe` returns an `ENOSYS` syscall error and `syscall.Pipe` returns
+   * `ENOSYS`, and neither one crosses the `globalThis.fs` bridge, so no
+   * JavaScript method is ever consulted. A custom Go/wasm host cannot reach
+   * this shim.
+   *
+   * The host captures wasm output without pipes: process-level writes to fd 1
+   * and fd 2 land in `stdout.buffer` and `stderr.buffer` through `writeSync`,
+   * and a plugin's output is collected by the Go-side `host.InvokePlugin` into
+   * invocation-owned in-process buffers.
    */
   pipe2(
     flags: number,

--- a/packages/wasm/test/host/pipe_unsupported_on_wasm_test.go
+++ b/packages/wasm/test/host/pipe_unsupported_on_wasm_test.go
@@ -1,0 +1,49 @@
+//go:build js && wasm
+
+package host_test
+
+import (
+  "errors"
+  "os"
+  "syscall"
+  "testing"
+)
+
+// TestPipeUnsupportedOnWasm pins the syscall boundary the `@ttsc/wasm` MemFS
+// documents: under the pinned Go toolchain neither `GOOS=js` nor `GOOS=wasip1`
+// has pipes, so `os.Pipe` fails with ENOSYS without ever crossing the
+// `globalThis.fs` bridge. The MemFS `pipe2` shim therefore cannot be reached
+// from Go, and `IWasmExecFS.pipe2` documents itself as JavaScript-only.
+//
+// If a future toolchain gains js/wasm pipes this test turns red, so the shim's
+// contract is revisited deliberately instead of drifting back into a claim the
+// implementation cannot honor.
+//
+// The suite is compiled for js/wasm, so it runs through the toolchain's wasm
+// exec wrapper:
+//
+//  GOOS=js GOARCH=wasm go test \
+//    -exec="node $(go env GOROOT)/lib/wasm/wasm_exec_node.js" ./test/host/
+func TestPipeUnsupportedOnWasm(t *testing.T) {
+  reader, writer, err := os.Pipe()
+  if err == nil {
+    if reader != nil {
+      reader.Close()
+    }
+    if writer != nil {
+      writer.Close()
+    }
+    t.Fatal("os.Pipe succeeded on js/wasm; the MemFS pipe2 contract must be revisited")
+  }
+  if reader != nil || writer != nil {
+    t.Fatalf("failed os.Pipe returned files: reader=%v writer=%v", reader, writer)
+  }
+  if !errors.Is(err, syscall.ENOSYS) {
+    t.Fatalf("expected an ENOSYS-bearing error, got %v", err)
+  }
+
+  var fds [2]int
+  if err := syscall.Pipe(fds[:]); !errors.Is(err, syscall.ENOSYS) {
+    t.Fatalf("expected syscall.Pipe to report ENOSYS, got %v", err)
+  }
+}

--- a/tests/test-wasm/src/features/memfs/test_memfs_descriptor_state_survives_ftruncate_and_rename.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_descriptor_state_survives_ftruncate_and_rename.ts
@@ -1,0 +1,82 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import {
+  callMutation,
+  openFd,
+  readFdText,
+  writeFdText,
+} from "../../internal/callbackFs";
+
+/** Node open flags as `createMemFS` advertises them to the Go runtime. */
+const O_WRONLY = 1;
+const O_RDWR = 2;
+const O_APPEND = 1024;
+
+/**
+ * Verifies a MemFS descriptor keeps its cursor and flags across `ftruncate` and
+ * a rename that moves the file underneath it.
+ *
+ * `rename` already re-points open descriptors at the moved path and `ftruncate`
+ * already resizes through one, but neither ever met a write that consults the
+ * cursor. A descriptor left pointing past a shrunken end-of-file must zero-fill
+ * the gap on the next sequential write instead of silently relocating it, and a
+ * moved descriptor must apply its retained append flag to the node at its new
+ * path.
+ *
+ * 1. Read four bytes, shrink the file to one with `ftruncate`, then write at the
+ *    cursor.
+ * 2. Rename the file and write again through the same descriptor.
+ * 3. Assert the gap was zero-filled, the write followed the rename, and an
+ *    `O_APPEND` descriptor still appends after its file moves.
+ */
+export const test_memfs_descriptor_state_survives_ftruncate_and_rename =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/f.txt", "abcdef");
+    const fd = await openFd(host.fs, "/f.txt", O_RDWR);
+
+    TestValidator.equals(
+      "reading four bytes leaves the cursor at 4",
+      await readFdText(host.fs, fd, 4),
+      "abcd",
+    );
+    await callMutation((cb) => host.fs.ftruncate(fd, 1, cb));
+    const afterTruncate = await writeFdText(host.fs, fd, "Z", null);
+    TestValidator.equals(
+      "a cursor beyond end-of-file zero-fills the gap",
+      {
+        ...afterTruncate,
+        bytes: [...(host.readFile("/f.txt") ?? new Uint8Array())],
+      },
+      { code: null, n: 1, bytes: [0x61, 0x00, 0x00, 0x00, 0x5a] },
+    );
+
+    await callMutation((cb) => host.fs.rename("/f.txt", "/moved.txt", cb));
+    const afterRename = await writeFdText(host.fs, fd, "!", null);
+    TestValidator.equals(
+      "the descriptor writes into the renamed file",
+      {
+        ...afterRename,
+        bytes: [...(host.readFile("/moved.txt") ?? new Uint8Array())],
+        original: host.exists("/f.txt"),
+      },
+      {
+        code: null,
+        n: 1,
+        bytes: [0x61, 0x00, 0x00, 0x00, 0x5a, 0x21],
+        original: false,
+      },
+    );
+
+    // A retained O_APPEND flag applies to the node at the descriptor's new path.
+    host.writeFile("/log.txt", "L");
+    const appendFd = await openFd(host.fs, "/log.txt", O_WRONLY | O_APPEND);
+    await callMutation((cb) => host.fs.rename("/log.txt", "/renamed.txt", cb));
+    await writeFdText(host.fs, appendFd, "M", null);
+    TestValidator.equals(
+      "append still appends after the rename",
+      host.readFileText("/renamed.txt"),
+      "LM",
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_descriptor_state_survives_ftruncate_and_rename.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_descriptor_state_survives_ftruncate_and_rename.ts
@@ -42,6 +42,16 @@ export const test_memfs_descriptor_state_survives_ftruncate_and_rename =
       "abcd",
     );
     await callMutation((cb) => host.fs.ftruncate(fd, 1, cb));
+
+    // Boundary: writing nothing from a cursor past end-of-file must not
+    // resize the file up to that cursor.
+    const empty = await writeFdText(host.fs, fd, "", null);
+    TestValidator.equals(
+      "a zero-byte write changes nothing",
+      { ...empty, text: host.readFileText("/f.txt") },
+      { code: null, n: 0, text: "a" },
+    );
+
     const afterTruncate = await writeFdText(host.fs, fd, "Z", null);
     TestValidator.equals(
       "a cursor beyond end-of-file zero-fills the gap",

--- a/tests/test-wasm/src/features/memfs/test_memfs_descriptors_enforce_their_access_mode.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_descriptors_enforce_their_access_mode.ts
@@ -1,0 +1,87 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import {
+  expectFsError,
+  openFd,
+  openResult,
+  readFdText,
+  writeFdText,
+} from "../../internal/callbackFs";
+
+/** Node open flags as `createMemFS` advertises them to the Go runtime. */
+const O_WRONLY = 1;
+const O_RDWR = 2;
+const O_TRUNC = 512;
+
+/**
+ * Verifies a MemFS descriptor only permits the operations its `open` access
+ * mode granted.
+ *
+ * The descriptor record stored just a path and an offset, so a read-only
+ * descriptor accepted writes and a write-only descriptor accepted reads. Both
+ * reported success, which is worse than a refusal: the caller keeps a handle it
+ * believes is restricted while the file changes underneath it.
+ *
+ * 1. Open the same file read-only, write-only, and read-write.
+ * 2. Drive a write through the read-only fd and a read through the write-only fd,
+ *    then exercise both directions on the read-write fd.
+ * 3. Assert the forbidden operations return `EBADF` with zero bytes and no byte
+ *    change, and that the permitted ones still work.
+ */
+export const test_memfs_descriptors_enforce_their_access_mode =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/f.txt", "abc");
+
+    const readOnly = await openFd(host.fs, "/f.txt", 0);
+    const writeOnly = await openFd(host.fs, "/f.txt", O_WRONLY);
+    const readWrite = await openFd(host.fs, "/f.txt", O_RDWR);
+
+    const rejectedWrite = await writeFdText(host.fs, readOnly, "Z", null);
+    TestValidator.equals(
+      "a read-only descriptor rejects writes",
+      { ...rejectedWrite, text: host.readFileText("/f.txt") },
+      { code: "EBADF", n: 0, text: "abc" },
+    );
+    TestValidator.equals(
+      "a write-only descriptor rejects reads",
+      await expectFsError((cb) =>
+        host.fs.read(writeOnly, new Uint8Array(1), 0, 1, null, cb),
+      ),
+      "EBADF",
+    );
+
+    // Positive twins: the granted directions still work.
+    TestValidator.equals(
+      "a read-only descriptor still reads",
+      await readFdText(host.fs, readOnly, 3),
+      "abc",
+    );
+    const allowedWrite = await writeFdText(host.fs, readWrite, "X", 0);
+    TestValidator.equals(
+      "a read-write descriptor reads and writes",
+      {
+        ...allowedWrite,
+        text: host.readFileText("/f.txt"),
+        read: await readFdText(host.fs, readWrite, 3),
+      },
+      { code: null, n: 1, text: "Xbc", read: "Xbc" },
+    );
+
+    // A directory opens read-only only; a write mode would replace it.
+    host.mkdirp("/dir");
+    TestValidator.equals(
+      "a directory refuses a write access mode",
+      {
+        writeOnly: await openResult(host.fs, "/dir", O_WRONLY),
+        readWrite: await openResult(host.fs, "/dir", O_RDWR),
+        truncate: await openResult(host.fs, "/dir", O_TRUNC),
+      },
+      {
+        writeOnly: { code: "EISDIR", fd: -1 },
+        readWrite: { code: "EISDIR", fd: -1 },
+        truncate: { code: "EISDIR", fd: -1 },
+      },
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_link_operations_stay_unsupported.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_link_operations_stay_unsupported.ts
@@ -1,0 +1,47 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { expectFsError, readdir } from "../../internal/callbackFs";
+
+/**
+ * Verifies MemFS keeps refusing links and reading link targets.
+ *
+ * Symlinks and hardlinks are intentionally unsupported: the node map is a plain
+ * path-to-node tree with no indirection, so a link that appeared to succeed
+ * would produce exactly the incoherent state the tree invariant exists to
+ * prevent. Tightening the writer and descriptor paths must not accidentally
+ * turn any of these into a success, and none of them had a case before.
+ *
+ * 1. Seed a file and a directory.
+ * 2. Call `link`, `symlink`, and `readlink` against them.
+ * 3. Assert `EPERM`, `EPERM`, and `EINVAL`, and that no node was created.
+ */
+export const test_memfs_link_operations_stay_unsupported =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/f.txt", "abc");
+    host.mkdirp("/dir");
+
+    const codes = {
+      link: await expectFsError((cb) => host.fs.link("/f.txt", "/hard", cb)),
+      linkDirectory: await expectFsError((cb) =>
+        host.fs.link("/dir", "/hard-dir", cb),
+      ),
+      symlink: await expectFsError((cb) =>
+        host.fs.symlink("/f.txt", "/soft", cb),
+      ),
+      readlink: await expectFsError((cb) => host.fs.readlink("/f.txt", cb)),
+    };
+    TestValidator.equals("rejection codes", codes, {
+      link: "EPERM",
+      linkDirectory: "EPERM",
+      symlink: "EPERM",
+      readlink: "EINVAL",
+    });
+
+    TestValidator.equals(
+      "no link node was created",
+      await readdir(host.fs, "/"),
+      ["dir", "f.txt"],
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_mkdirp_creates_nothing_when_a_segment_is_a_file.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_mkdirp_creates_nothing_when_a_segment_is_a_file.ts
@@ -1,0 +1,68 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { expectHostError, readdir } from "../../internal/callbackFs";
+
+/**
+ * Verifies MemFS mkdirp creates a whole chain or none of it, and refuses a
+ * segment that is a file.
+ *
+ * `mkdirp` shares the ancestor walk with `writeFile` and `open` now, so it
+ * validates the whole chain before creating any of it instead of creating each
+ * segment as it goes. That makes the "no partial mutation" property structural
+ * rather than a consequence of the tree invariant holding elsewhere, and it is
+ * deliberately stricter than `mkdir -p`, which does keep the prefix it managed
+ * to create. `mkdirp` had no direct case of its own before.
+ *
+ * 1. Create a deep chain, then repeat the same call.
+ * 2. Seed a file at `/blocked` and call `mkdirp` below it and onto it.
+ * 3. Assert both rejections are `ENOTDIR`, no directory was created, and the file
+ *    still holds its bytes.
+ */
+export const test_memfs_mkdirp_creates_nothing_when_a_segment_is_a_file =
+  async (): Promise<void> => {
+    const host = createMemFS();
+
+    // Positive: an ordinary deep chain, and a repeat call, both succeed.
+    host.mkdirp("/deep/a/b");
+    host.mkdirp("/deep/a/b");
+    TestValidator.equals(
+      "mkdirp creates the whole chain and is idempotent",
+      {
+        root: await readdir(host.fs, "/deep"),
+        nested: await readdir(host.fs, "/deep/a"),
+        leaf: await readdir(host.fs, "/deep/a/b"),
+      },
+      { root: ["a"], nested: ["b"], leaf: [] },
+    );
+
+    host.writeFile("/blocked", "FILE");
+    const codes = {
+      belowFile: expectHostError(() => host.mkdirp("/blocked/a/b")),
+      ontoFile: expectHostError(() => host.mkdirp("/blocked")),
+      normalizedAlias: expectHostError(() =>
+        host.mkdirp("/deep/..//blocked/a"),
+      ),
+    };
+    TestValidator.equals("rejection codes", codes, {
+      belowFile: "ENOTDIR",
+      ontoFile: "ENOTDIR",
+      normalizedAlias: "ENOTDIR",
+    });
+
+    TestValidator.equals(
+      "a rejected mkdirp leaves no directory behind",
+      {
+        blocked: host.readFileText("/blocked"),
+        firstSegment: host.exists("/blocked/a"),
+        secondSegment: host.exists("/blocked/a/b"),
+        root: await readdir(host.fs, "/"),
+      },
+      {
+        blocked: "FILE",
+        firstSegment: false,
+        secondSegment: false,
+        root: ["blocked", "deep"],
+      },
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_open_append_always_writes_at_end_of_file.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_open_append_always_writes_at_end_of_file.ts
@@ -1,0 +1,55 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { openFd, writeFdText } from "../../internal/callbackFs";
+
+/** Node open flags as `createMemFS` advertises them to the Go runtime. */
+const O_WRONLY = 1;
+const O_RDWR = 2;
+const O_APPEND = 1024;
+
+/**
+ * Verifies an `O_APPEND` MemFS descriptor writes at end-of-file regardless of
+ * the cursor or an explicit position, while a plain descriptor does not.
+ *
+ * The descriptor table never recorded the append flag, so appending was only a
+ * coincidence of an implementation that could do nothing else. Once writes
+ * honor the cursor, `O_APPEND` has to be retained or Go's `os.OpenFile` with
+ * `O_APPEND` — which typescript-go's `AppendFile` uses — would start
+ * overwriting from byte 0.
+ *
+ * 1. Open `abc` with `O_APPEND` and write with `position: null` and then with an
+ *    explicit in-bounds position.
+ * 2. Open the same file without `O_APPEND` and write at an explicit position.
+ * 3. Assert both append writes landed at the end and the plain write overwrote in
+ *    place.
+ */
+export const test_memfs_open_append_always_writes_at_end_of_file =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/log.txt", "abc");
+
+    const appendFd = await openFd(host.fs, "/log.txt", O_WRONLY | O_APPEND);
+    const atCursor = await writeFdText(host.fs, appendFd, "D", null);
+    TestValidator.equals(
+      "a null-position append lands at the end",
+      { ...atCursor, text: host.readFileText("/log.txt") },
+      { code: null, n: 1, text: "abcD" },
+    );
+
+    const positioned = await writeFdText(host.fs, appendFd, "E", 0);
+    TestValidator.equals(
+      "an explicit position cannot pull an append back",
+      { ...positioned, text: host.readFileText("/log.txt") },
+      { code: null, n: 1, text: "abcDE" },
+    );
+
+    // Negative twin: the same write without O_APPEND overwrites in place.
+    const plainFd = await openFd(host.fs, "/log.txt", O_RDWR);
+    const overwrite = await writeFdText(host.fs, plainFd, "z", 0);
+    TestValidator.equals(
+      "a descriptor without O_APPEND overwrites at the offset",
+      { ...overwrite, text: host.readFileText("/log.txt") },
+      { code: null, n: 1, text: "zbcDE" },
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_open_create_requires_an_existing_directory_parent.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_open_create_requires_an_existing_directory_parent.ts
@@ -1,0 +1,92 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { openResult, readdir } from "../../internal/callbackFs";
+
+/** Node open flags as `createMemFS` advertises them to the Go runtime. */
+const O_WRONLY = 1;
+const O_CREAT = 64;
+
+/**
+ * Verifies MemFS open with `O_CREAT` creates a file inside an existing
+ * directory and refuses every path whose parent chain cannot hold it.
+ *
+ * The low-level `open` used to run the same silent `ensureParentDirs` walk as
+ * `writeFile`, so it invented a whole directory chain the syscall never
+ * promised, and it created files below file-valued ancestors. Parent creation
+ * belongs to `writeFile` and `mkdirp`; `open` must fail instead.
+ *
+ * 1. Create `/dir` and open `/dir/made.js` with `O_CREAT`, asserting the file
+ *    appears.
+ * 2. Attempt `O_CREAT` below a file ancestor, below a missing chain, and through a
+ *    normalized alias of the missing chain.
+ * 3. Assert each rejection carries its code with `fd` -1, and that no directory or
+ *    file node was invented anywhere.
+ */
+export const test_memfs_open_create_requires_an_existing_directory_parent =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.mkdirp("/dir");
+    host.writeFile("/base", "BASE");
+
+    // Positive: creating inside a directory that exists still works.
+    const created = await openResult(
+      host.fs,
+      "/dir/made.js",
+      O_CREAT | O_WRONLY,
+    );
+    TestValidator.equals(
+      "O_CREAT inside an existing directory creates the file",
+      {
+        code: created.code,
+        allocated: created.fd >= 100,
+        exists: host.exists("/dir/made.js"),
+      },
+      { code: null, allocated: true, exists: true },
+    );
+
+    const results = {
+      belowFile: await openResult(
+        host.fs,
+        "/base/generated.js",
+        O_CREAT | O_WRONLY,
+      ),
+      missingChain: await openResult(host.fs, "/a/b/c.ts", O_CREAT | O_WRONLY),
+      normalizedAlias: await openResult(
+        host.fs,
+        "/dir/.././/a/b/c.ts",
+        O_CREAT | O_WRONLY,
+      ),
+    };
+    TestValidator.equals(
+      "rejections allocate no descriptor",
+      {
+        belowFile: results.belowFile,
+        missingChain: results.missingChain,
+        normalizedAlias: results.normalizedAlias,
+      },
+      {
+        belowFile: { code: "ENOTDIR", fd: -1 },
+        missingChain: { code: "ENOENT", fd: -1 },
+        normalizedAlias: { code: "ENOENT", fd: -1 },
+      },
+    );
+
+    TestValidator.equals(
+      "no node was invented by a rejected open",
+      {
+        child: host.exists("/base/generated.js"),
+        chainRoot: host.exists("/a"),
+        chainLeaf: host.exists("/a/b"),
+        base: host.readFileText("/base"),
+        root: await readdir(host.fs, "/"),
+      },
+      {
+        child: false,
+        chainRoot: false,
+        chainLeaf: false,
+        base: "BASE",
+        root: ["base", "dir"],
+      },
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_open_directory_read_only_still_stats_and_lists.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_open_directory_read_only_still_stats_and_lists.ts
@@ -1,0 +1,62 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { openResult, readdir, stat } from "../../internal/callbackFs";
+
+/** Node open flags as `createMemFS` advertises them to the Go runtime. */
+const O_DIRECTORY = 65536;
+
+/**
+ * Verifies opening a directory read-only still yields a descriptor that stats
+ * as a directory.
+ *
+ * This is the sequence Go's `syscall.Open` runs for every directory: open the
+ * path, `fstat` the descriptor, and only then `readdir` the path when the stat
+ * says directory. Tightening `open` so a write mode or `O_TRUNC` can no longer
+ * replace a directory must not close that read-only door, or every `os.ReadDir`
+ * inside the wasm compiler would fail.
+ *
+ * 1. Seed a directory with one child and open it with the default read-only access
+ *    mode, then again with `O_DIRECTORY`.
+ * 2. `fstat` the read-only descriptor.
+ * 3. Assert both opens succeeded, the descriptor stats as a directory, and
+ *    `readdir` lists the child.
+ */
+export const test_memfs_open_directory_read_only_still_stats_and_lists =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/dir/child.ts", "CHILD");
+
+    const readOnly = await openResult(host.fs, "/dir", 0);
+    const directoryFlag = await openResult(host.fs, "/dir", O_DIRECTORY);
+    TestValidator.equals(
+      "a directory opens read-only",
+      {
+        readOnly: readOnly.code,
+        readOnlyAllocated: readOnly.fd >= 100,
+        directoryFlag: directoryFlag.code,
+        directoryFlagAllocated: directoryFlag.fd >= 100,
+      },
+      {
+        readOnly: null,
+        readOnlyAllocated: true,
+        directoryFlag: null,
+        directoryFlagAllocated: true,
+      },
+    );
+
+    const stats = await new Promise<boolean>((resolve, reject) => {
+      host.fs.fstat(readOnly.fd, (err, value) =>
+        err ? reject(err) : resolve(value.isDirectory()),
+      );
+    });
+    TestValidator.equals(
+      "the descriptor stats as a directory and lists its children",
+      {
+        fstatIsDirectory: stats,
+        statIsDirectory: (await stat(host.fs, "/dir")).isDirectory(),
+        entries: await readdir(host.fs, "/dir"),
+      },
+      { fstatIsDirectory: true, statIsDirectory: true, entries: ["child.ts"] },
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_open_enforces_exclusive_creation_and_directory_flag.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_open_enforces_exclusive_creation_and_directory_flag.ts
@@ -1,0 +1,103 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { openResult, readdir } from "../../internal/callbackFs";
+
+/** Node open flags as `createMemFS` advertises them to the Go runtime. */
+const O_WRONLY = 1;
+const O_CREAT = 64;
+const O_EXCL = 128;
+const O_DIRECTORY = 65536;
+
+/**
+ * Verifies MemFS open honors the `O_EXCL` and `O_DIRECTORY` flags it advertises
+ * to the Go runtime.
+ *
+ * `open` consulted only `O_CREAT` and `O_TRUNC`, so `O_CREAT | O_EXCL` handed
+ * back a descriptor for a path that already existed — defeating the one
+ * guarantee exclusive creation offers — and `O_DIRECTORY` accepted a regular
+ * file. Both constants are published by `createMemFS().fs.constants`, so Go
+ * translates its own flags into them and trusts the answer.
+ *
+ * 1. Exclusively create a new path, then repeat the same call on the now existing
+ *    path.
+ * 2. Open a regular file with `O_DIRECTORY`, and a directory with and without it.
+ * 3. Assert the second exclusive create is `EEXIST`, `O_DIRECTORY` on a file is
+ *    `ENOTDIR`, both allocate no descriptor, and the tree is unchanged.
+ */
+export const test_memfs_open_enforces_exclusive_creation_and_directory_flag =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.mkdirp("/dir");
+    host.writeFile("/f.txt", "abc");
+
+    // Positive: exclusive creation of a path that does not exist yet.
+    const created = await openResult(
+      host.fs,
+      "/fresh.txt",
+      O_CREAT | O_EXCL | O_WRONLY,
+    );
+    TestValidator.equals(
+      "O_EXCL creates a path that is free",
+      { code: created.code, allocated: created.fd >= 100 },
+      { code: null, allocated: true },
+    );
+
+    TestValidator.equals(
+      "flag conflicts are rejected without a descriptor",
+      {
+        exclusiveOnFile: await openResult(
+          host.fs,
+          "/f.txt",
+          O_CREAT | O_EXCL | O_WRONLY,
+        ),
+        exclusiveOnFresh: await openResult(
+          host.fs,
+          "/fresh.txt",
+          O_CREAT | O_EXCL | O_WRONLY,
+        ),
+        exclusiveOnDirectory: await openResult(
+          host.fs,
+          "/dir",
+          O_CREAT | O_EXCL,
+        ),
+        directoryFlagOnFile: await openResult(host.fs, "/f.txt", O_DIRECTORY),
+        directoryFlagOnMissing: await openResult(
+          host.fs,
+          "/dir/new",
+          O_CREAT | O_DIRECTORY,
+        ),
+      },
+      {
+        exclusiveOnFile: { code: "EEXIST", fd: -1 },
+        exclusiveOnFresh: { code: "EEXIST", fd: -1 },
+        exclusiveOnDirectory: { code: "EEXIST", fd: -1 },
+        directoryFlagOnFile: { code: "ENOTDIR", fd: -1 },
+        directoryFlagOnMissing: { code: "ENOTDIR", fd: -1 },
+      },
+    );
+
+    // Positive twin: O_DIRECTORY on an actual directory is accepted.
+    const directory = await openResult(host.fs, "/dir", O_DIRECTORY);
+    TestValidator.equals(
+      "O_DIRECTORY accepts a directory",
+      { code: directory.code, allocated: directory.fd >= 100 },
+      { code: null, allocated: true },
+    );
+
+    TestValidator.equals(
+      "no rejected open changed the tree",
+      {
+        file: host.readFileText("/f.txt"),
+        fresh: host.readFileText("/fresh.txt"),
+        directory: await readdir(host.fs, "/dir"),
+        root: await readdir(host.fs, "/"),
+      },
+      {
+        file: "abc",
+        fresh: "",
+        directory: [],
+        root: ["dir", "f.txt", "fresh.txt"],
+      },
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_open_trunc_never_turns_a_directory_into_a_file.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_open_trunc_never_turns_a_directory_into_a_file.ts
@@ -1,0 +1,68 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { openResult, readdir, stat } from "../../internal/callbackFs";
+
+/** Node open flags as `createMemFS` advertises them to the Go runtime. */
+const O_WRONLY = 1;
+const O_RDWR = 2;
+const O_TRUNC = 512;
+
+/**
+ * Verifies MemFS open with `O_TRUNC` empties a regular file and rejects a
+ * directory target without stranding its descendants.
+ *
+ * The truncate branch replaced whatever node sat at the path with an empty
+ * file, so truncating a directory succeeded, orphaned the whole subtree, and
+ * broke `readdir` on a path `exists` still reported. It also allocated the
+ * descriptor before applying the truncation, so a late failure would have
+ * leaked an fd.
+ *
+ * 1. Truncate a regular file through `open` and confirm it is empty.
+ * 2. Attempt `O_TRUNC` on a non-empty directory and on the root.
+ * 3. Assert both are rejected with `EISDIR` and `fd` -1, and that each directory
+ *    still stats as a directory with every descendant readable.
+ */
+export const test_memfs_open_trunc_never_turns_a_directory_into_a_file =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/tree/leaf.ts", "LEAF");
+    host.writeFile("/file.ts", "CONTENT");
+
+    // Positive: O_TRUNC on a regular file still empties it.
+    const truncated = await openResult(host.fs, "/file.ts", O_TRUNC | O_WRONLY);
+    TestValidator.equals(
+      "O_TRUNC empties a regular file",
+      { code: truncated.code, text: host.readFileText("/file.ts") },
+      { code: null, text: "" },
+    );
+
+    const results = {
+      directory: await openResult(host.fs, "/tree", O_TRUNC | O_WRONLY),
+      directoryReadWrite: await openResult(host.fs, "/tree", O_TRUNC | O_RDWR),
+      root: await openResult(host.fs, "/", O_TRUNC | O_WRONLY),
+    };
+    TestValidator.equals("rejections allocate no descriptor", results, {
+      directory: { code: "EISDIR", fd: -1 },
+      directoryReadWrite: { code: "EISDIR", fd: -1 },
+      root: { code: "EISDIR", fd: -1 },
+    });
+
+    TestValidator.equals(
+      "directories and descendants are untouched",
+      {
+        treeIsDirectory: (await stat(host.fs, "/tree")).isDirectory(),
+        treeEntries: await readdir(host.fs, "/tree"),
+        leaf: host.readFileText("/tree/leaf.ts"),
+        rootIsDirectory: (await stat(host.fs, "/")).isDirectory(),
+        rootEntries: await readdir(host.fs, "/"),
+      },
+      {
+        treeIsDirectory: true,
+        treeEntries: ["leaf.ts"],
+        leaf: "LEAF",
+        rootIsDirectory: true,
+        rootEntries: ["file.ts", "tree"],
+      },
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_write_file_refuses_to_replace_a_directory.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_write_file_refuses_to_replace_a_directory.ts
@@ -1,0 +1,69 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { expectHostError, readdir, stat } from "../../internal/callbackFs";
+
+/**
+ * Verifies MemFS writeFile overwrites a regular file but never replaces a
+ * directory, including the root.
+ *
+ * Turning a directory node into a file left every descendant in the map under a
+ * path that is no longer walkable: `exists` and `stat` still answered for both
+ * the new file and its stranded children while `readdir` failed with `ENOTDIR`.
+ * The caller got neither the mutation it asked for nor an error it could act
+ * on.
+ *
+ * 1. Seed a non-empty directory, an empty directory, and a regular file.
+ * 2. Overwrite the regular file, then attempt to write onto each directory and
+ *    onto `/` (directly and through a normalized alias).
+ * 3. Assert the overwrite replaced the bytes, every directory write was rejected
+ *    with `EISDIR`, and each directory plus its descendants survived intact.
+ */
+export const test_memfs_write_file_refuses_to_replace_a_directory =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/tree/leaf.ts", "LEAF");
+    host.mkdirp("/empty");
+    host.writeFile("/keep.ts", "BEFORE");
+
+    // Positive: overwriting a regular file still replaces its bytes.
+    host.writeFile("/keep.ts", "AFTER");
+    TestValidator.equals(
+      "regular-file overwrite replaces bytes",
+      host.readFileText("/keep.ts"),
+      "AFTER",
+    );
+
+    const codes = {
+      nonEmptyDirectory: expectHostError(() => host.writeFile("/tree", "X")),
+      emptyDirectory: expectHostError(() => host.writeFile("/empty", "X")),
+      root: expectHostError(() => host.writeFile("/", "X")),
+      normalizedRoot: expectHostError(() => host.writeFile("/tree/..", "X")),
+    };
+    TestValidator.equals("rejection codes", codes, {
+      nonEmptyDirectory: "EISDIR",
+      emptyDirectory: "EISDIR",
+      root: "EISDIR",
+      normalizedRoot: "EISDIR",
+    });
+
+    TestValidator.equals(
+      "every directory and descendant survived",
+      {
+        tree: await readdir(host.fs, "/tree"),
+        leaf: host.readFileText("/tree/leaf.ts"),
+        empty: await readdir(host.fs, "/empty"),
+        root: await readdir(host.fs, "/"),
+        treeIsDirectory: (await stat(host.fs, "/tree")).isDirectory(),
+        rootIsDirectory: (await stat(host.fs, "/")).isDirectory(),
+      },
+      {
+        tree: ["leaf.ts"],
+        leaf: "LEAF",
+        empty: [],
+        root: ["empty", "keep.ts", "tree"],
+        treeIsDirectory: true,
+        rootIsDirectory: true,
+      },
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_write_file_rejects_a_file_valued_ancestor.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_write_file_rejects_a_file_valued_ancestor.ts
@@ -1,0 +1,62 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { expectHostError, readdir } from "../../internal/callbackFs";
+
+/**
+ * Verifies `host.writeFile` still creates missing parent directories but
+ * refuses to create a file underneath an ancestor that is already a file.
+ *
+ * A file has no descendants, so `/parent/child.ts` cannot exist while `/parent`
+ * is a file. The pre-fix `ensureParentDirs` only asked whether an ancestor
+ * segment was present, never whether it was a directory, so the write reported
+ * success and left `exists` and `readdir` disagreeing about `/parent`.
+ *
+ * 1. Write `/nested/deep/file.ts` and confirm the convenience parent creation
+ *    still works.
+ * 2. Write the file `/parent`, then attempt `/parent/child.ts` and a deeper
+ *    `/parent/a/b.ts`.
+ * 3. Assert both are rejected with `ENOTDIR`, no node was added, and `/parent`
+ *    still holds its original bytes.
+ */
+export const test_memfs_write_file_rejects_a_file_valued_ancestor =
+  async (): Promise<void> => {
+    const host = createMemFS();
+
+    // Positive: the documented convenience is unchanged.
+    host.writeFile("/nested/deep/file.ts", "OK");
+    TestValidator.equals(
+      "nested write creates its parents",
+      {
+        file: host.readFileText("/nested/deep/file.ts"),
+        parents: await readdir(host.fs, "/nested"),
+      },
+      { file: "OK", parents: ["deep"] },
+    );
+
+    host.writeFile("/parent", "PARENT");
+    const codes = {
+      directChild: expectHostError(() =>
+        host.writeFile("/parent/child.ts", "X"),
+      ),
+      deepChild: expectHostError(() => host.writeFile("/parent/a/b.ts", "X")),
+      normalizedAlias: expectHostError(() =>
+        host.writeFile("/nested/../parent//child.ts", "X"),
+      ),
+    };
+    TestValidator.equals("rejection codes", codes, {
+      directChild: "ENOTDIR",
+      deepChild: "ENOTDIR",
+      normalizedAlias: "ENOTDIR",
+    });
+
+    TestValidator.equals(
+      "no descendant or ancestor node was created",
+      {
+        child: host.exists("/parent/child.ts"),
+        deepDir: host.exists("/parent/a"),
+        parent: host.readFileText("/parent"),
+      },
+      { child: false, deepDir: false, parent: "PARENT" },
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_write_follows_the_descriptor_cursor.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_write_follows_the_descriptor_cursor.ts
@@ -1,0 +1,79 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { openFd, readFdText, writeFdText } from "../../internal/callbackFs";
+
+/** Node open flags as `createMemFS` advertises them to the Go runtime. */
+const O_WRONLY = 1;
+const O_RDWR = 2;
+const O_CREAT = 64;
+const O_TRUNC = 512;
+
+/**
+ * Verifies a MemFS write with `position: null` uses and advances the
+ * descriptor's own cursor, and that two descriptors on one file keep separate
+ * cursors.
+ *
+ * Go's `syscall.Write` passes `null` for every unseeked write, so the cursor is
+ * the only offset the JavaScript side is given. The old implementation tracked
+ * `entry.position` but never read it, appending instead — which happened to
+ * match for a freshly truncated output file and silently diverged for every
+ * other descriptor.
+ *
+ * 1. Read two bytes of `abcdef`, then write one byte with `position: null`.
+ * 2. Open the same file twice and interleave cursor writes on both descriptors.
+ * 3. Assert the write landed at the cursor, the cursor advanced, and neither
+ *    descriptor moved the other's offset.
+ */
+export const test_memfs_write_follows_the_descriptor_cursor =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/f.txt", "abcdef");
+    const fd = await openFd(host.fs, "/f.txt", O_RDWR);
+
+    TestValidator.equals(
+      "reading two bytes advances the cursor",
+      await readFdText(host.fs, fd, 2),
+      "ab",
+    );
+    const written = await writeFdText(host.fs, fd, "Q", null);
+    TestValidator.equals(
+      "a cursor write overwrites at the cursor",
+      { ...written, text: host.readFileText("/f.txt") },
+      { code: null, n: 1, text: "abQdef" },
+    );
+    TestValidator.equals(
+      "the cursor advanced past the written byte",
+      await readFdText(host.fs, fd, 2),
+      "de",
+    );
+
+    // Two descriptors over shared data keep independent cursors.
+    host.writeFile("/shared.txt", "");
+    const first = await openFd(host.fs, "/shared.txt", O_WRONLY | O_CREAT);
+    const second = await openFd(host.fs, "/shared.txt", O_WRONLY | O_CREAT);
+    await writeFdText(host.fs, first, "AAA", null);
+    await writeFdText(host.fs, second, "b", null);
+    await writeFdText(host.fs, first, "C", null);
+    TestValidator.equals(
+      "each descriptor writes at its own offset",
+      host.readFileText("/shared.txt"),
+      "bAAC",
+    );
+
+    // The common compiler-output shape stays byte-identical: create, truncate,
+    // then write sequentially with a null position.
+    host.mkdirp("/out");
+    const output = await openFd(
+      host.fs,
+      "/out/index.js",
+      O_WRONLY | O_CREAT | O_TRUNC,
+    );
+    await writeFdText(host.fs, output, "export const a = 1;\n", null);
+    await writeFdText(host.fs, output, "export const b = 2;\n", null);
+    TestValidator.equals(
+      "sequential output writes concatenate",
+      host.readFileText("/out/index.js"),
+      "export const a = 1;\nexport const b = 2;\n",
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_write_honors_explicit_positions.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_write_honors_explicit_positions.ts
@@ -1,0 +1,64 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { openFd, readFdText, writeFdText } from "../../internal/callbackFs";
+
+/** Node open flags as `createMemFS` advertises them to the Go runtime. */
+const O_RDWR = 2;
+
+/**
+ * Verifies a positioned MemFS write overwrites at exactly that offset, extends
+ * with zero-fill beyond end-of-file, and never moves the descriptor cursor.
+ *
+ * The write branch built `existing + incoming` and set the cursor to the new
+ * end, so it could only ever append: position 0 appended and every other
+ * explicit offset was rejected with `ESPIPE`, including in-bounds ones. Go
+ * reaches this path through `syscall.Pwrite`, which a seeked `os.File.Write`
+ * uses, so a caller saw `null` and got bytes somewhere it never asked for.
+ *
+ * 1. Open `abcdef` read-write and write one byte at position 0, then at 2.
+ * 2. Write past end-of-file to force a zero-filled gap.
+ * 3. Assert each write landed at its offset, the gap is NUL-filled, and a
+ *    following cursor read still starts at byte 0.
+ */
+export const test_memfs_write_honors_explicit_positions =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/f.txt", "abcdef");
+    const fd = await openFd(host.fs, "/f.txt", O_RDWR);
+
+    const atZero = await writeFdText(host.fs, fd, "Z", 0);
+    TestValidator.equals(
+      "explicit position 0 overwrites the first byte",
+      { ...atZero, text: host.readFileText("/f.txt") },
+      { code: null, n: 1, text: "Zbcdef" },
+    );
+
+    const inBounds = await writeFdText(host.fs, fd, "YY", 2);
+    TestValidator.equals(
+      "an in-bounds offset overwrites there",
+      { ...inBounds, text: host.readFileText("/f.txt") },
+      { code: null, n: 2, text: "ZbYYef" },
+    );
+
+    const beyondEof = await writeFdText(host.fs, fd, "!", 8);
+    TestValidator.equals(
+      "a write past end-of-file zero-fills the gap",
+      {
+        ...beyondEof,
+        bytes: [...(host.readFile("/f.txt") ?? new Uint8Array())],
+      },
+      {
+        code: null,
+        n: 1,
+        bytes: [0x5a, 0x62, 0x59, 0x59, 0x65, 0x66, 0x00, 0x00, 0x21],
+      },
+    );
+
+    // Every write above was positioned, so the cursor never moved off byte 0.
+    TestValidator.equals(
+      "positioned writes leave the cursor alone",
+      await readFdText(host.fs, fd, 3),
+      "ZbY",
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_write_rejects_unknown_descriptors_without_touching_stdio.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_write_rejects_unknown_descriptors_without_touching_stdio.ts
@@ -1,0 +1,69 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import { callMutation, openFd, writeFdText } from "../../internal/callbackFs";
+
+/** Node open flags as `createMemFS` advertises them to the Go runtime. */
+const O_WRONLY = 1;
+
+/**
+ * Verifies a MemFS write through an unknown or closed descriptor fails with
+ * `EBADF` instead of being diverted into the captured stderr.
+ *
+ * The unknown-fd branch appended the bytes to `stderr.buffer`, logged a console
+ * error, and returned the full byte count, so the caller continued on a success
+ * that never happened while a diagnostic channel consumers read silently gained
+ * content it did not produce. That is much broader than the deliberate fd 1 /
+ * fd 2 routing, which must keep working.
+ *
+ * 1. Write through a descriptor that was never opened and through one that was
+ *    opened and closed.
+ * 2. Write through fd 1 and fd 2.
+ * 3. Assert the bad descriptors return `EBADF` with zero bytes and leave both
+ *    capture buffers untouched, while fd 1 and fd 2 still capture.
+ */
+export const test_memfs_write_rejects_unknown_descriptors_without_touching_stdio =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.writeFile("/f.txt", "abc");
+    const closed = await openFd(host.fs, "/f.txt", O_WRONLY);
+    await callMutation((cb) => host.fs.close(closed, cb));
+
+    TestValidator.equals(
+      "bad descriptors write nothing",
+      {
+        unknown: await writeFdText(host.fs, 999, "BAD", null),
+        closed: await writeFdText(host.fs, closed, "BAD", null),
+        stdout: host.stdout.buffer,
+        stderr: host.stderr.buffer,
+        file: host.readFileText("/f.txt"),
+      },
+      {
+        unknown: { code: "EBADF", n: 0 },
+        closed: { code: "EBADF", n: 0 },
+        stdout: "",
+        stderr: "",
+        file: "abc",
+      },
+    );
+
+    // writeSync is the synchronous entry wasm_exec.js calls; it throws rather
+    // than reporting a byte count it did not write.
+    let syncCode: string | null = null;
+    try {
+      host.fs.writeSync(999, new TextEncoder().encode("BAD"));
+    } catch (err) {
+      syncCode = (err as { code?: string }).code ?? "UNKNOWN";
+    }
+    TestValidator.equals("writeSync throws EBADF", syncCode, "EBADF");
+
+    // Positive twin: the reserved stdio descriptors are unchanged.
+    await writeFdText(host.fs, 1, "OUT", null);
+    await writeFdText(host.fs, 2, "ERR", null);
+    host.fs.writeSync(1, new TextEncoder().encode("SYNC"));
+    TestValidator.equals(
+      "fd 1 and fd 2 still capture",
+      { stdout: host.stdout.buffer, stderr: host.stderr.buffer },
+      { stdout: "OUTSYNC", stderr: "ERR" },
+    );
+  };

--- a/tests/test-wasm/src/internal/callbackFs.ts
+++ b/tests/test-wasm/src/internal/callbackFs.ts
@@ -37,6 +37,22 @@ export async function expectFsError(
   }
 }
 
+/**
+ * Run a synchronous host helper (`writeFile`, `mkdirp`) and return the POSIX
+ * `code` it threw, or `null` when it succeeded.
+ *
+ * The convenience helpers on `IMemFSHost` report failure by throwing rather
+ * than through an errback, so their negative twins need this shape.
+ */
+export function expectHostError(run: () => void): string | null {
+  try {
+    run();
+    return null;
+  } catch (err) {
+    return (err as IFsError).code ?? "UNKNOWN";
+  }
+}
+
 /** Read the sorted immediate child names of directory `path`. */
 export function readdir(fs: IWasmExecFS, path: string): Promise<string[]> {
   return new Promise<string[]>((resolve, reject) => {
@@ -59,6 +75,44 @@ export function openFd(
 ): Promise<number> {
   return new Promise<number>((resolve, reject) => {
     fs.open(path, flags, 0o644, (err, fd) => (err ? reject(err) : resolve(fd)));
+  });
+}
+
+/**
+ * Open `path` and resolve to both outcomes at once: the POSIX `code` of a
+ * rejection (or `null`) and the descriptor the callback received.
+ *
+ * A rejected `open` must allocate nothing, so a case that pins the failure also
+ * has to see the `fd` argument rather than only the error.
+ */
+export function openResult(
+  fs: IWasmExecFS,
+  path: string,
+  flags: number,
+): Promise<{ code: string | null; fd: number }> {
+  return new Promise((resolve) => {
+    fs.open(path, flags, 0o644, (err, fd) =>
+      resolve({ code: err ? ((err as IFsError).code ?? "UNKNOWN") : null, fd }),
+    );
+  });
+}
+
+/**
+ * Write UTF-8 `text` through `fd` at `position` (`null` writes at the cursor)
+ * and resolve to the rejection `code` and the byte count the callback
+ * reported.
+ */
+export function writeFdText(
+  fs: IWasmExecFS,
+  fd: number,
+  text: string,
+  position: number | null,
+): Promise<{ code: string | null; n: number }> {
+  return new Promise((resolve) => {
+    const bytes = new TextEncoder().encode(text);
+    fs.write(fd, bytes, 0, bytes.byteLength, position, (err, n) =>
+      resolve({ code: err ? ((err as IFsError).code ?? "UNKNOWN") : null, n }),
+    );
   });
 }
 

--- a/website/src/content/docs/wasm/index.mdx
+++ b/website/src/content/docs/wasm/index.mdx
@@ -100,13 +100,17 @@ For the base endpoints, `raw.result` is a JSON string. Use `parseResult<T>` at t
 
 - Use absolute virtual paths for files and `cwd`, for example `/work`.
 - `tsconfig` is relative to `cwd` and defaults to `tsconfig.json`.
-- `host.writeFile` creates parent directories automatically; `host.mkdirp` exists when you need to create directories without writing a file.
+- `host.writeFile` creates parent directories automatically; `host.mkdirp` exists when you need to create directories without writing a file. The low-level `fs.open` never does: with `O_CREAT` it requires the parent directory to exist already and fails with `ENOENT` otherwise.
 - `host.writeFile` copies `Uint8Array` input, and `host.readFile` returns a copy. Call `writeFile` again when you want to replace stored bytes.
+- A file never replaces a directory. `host.writeFile` and `fs.open` with `O_TRUNC` throw or return `EISDIR` for a directory target — including `/` — and `ENOTDIR` when an ancestor of the path is a file, so a conflicting file map is reported instead of stranding the directory's descendants.
 - `host.readFileText` reads emitted or transformed virtual files if your plugin writes into the MemFS.
 - `host.stdout.buffer` and `host.stderr.buffer` capture direct writes to fd 1 and fd 2. Call `host.resetStdio()` when you intentionally inspect those buffers across separate runs.
 - The filesystem is memory-only. Recreate the project tree from UI state before each compile, or serialize calls that mutate the same paths.
-- Mutations enforce POSIX-style invariants: renaming a directory moves its whole subtree (and follows open descriptors), `rmdir` requires an empty directory, `unlink` refuses directories, and `truncate`/`ftruncate` resize file bytes — zero-filling any growth — or reject an invalid path, descriptor, or length. A mutation that cannot satisfy its contract returns an error instead of partially changing the tree.
+- Mutations enforce POSIX-style invariants: renaming a directory moves its whole subtree (and follows open descriptors), `rmdir` requires an empty directory, `unlink` refuses directories, and `truncate`/`ftruncate` resize file bytes — zero-filling any growth — or reject an invalid path, descriptor, or length. A mutation that cannot satisfy its contract returns an error instead of partially changing the tree, and a rejected `fs.open` allocates no descriptor.
+- Descriptors carry the access mode and `O_APPEND` flag they were opened with. A read-only descriptor rejects writes and a write-only descriptor rejects reads with `EBADF`, `O_CREAT | O_EXCL` on an existing path returns `EEXIST`, and `O_DIRECTORY` on a regular file returns `ENOTDIR`. Directories open read-only, which is what Go's `os.ReadDir` needs.
+- Writes follow Node's offset rules: `position: null` writes at the descriptor cursor and advances it, an explicit position overwrites there without moving the cursor, a write past end-of-file zero-fills the gap, and an `O_APPEND` descriptor always writes at the end. An unknown or closed descriptor fails with `EBADF` and changes nothing — only fd 1 and fd 2 reach the capture buffers.
 - Symlinks and hardlinks are intentionally unsupported. Treat the project as a flat virtual workspace.
+- `fs.pipe2` is a JavaScript-only shim. Go's wasm `os.Pipe()` returns `ENOSYS` under the pinned toolchain without crossing the `globalThis.fs` bridge, so a custom Go/wasm host cannot reach it; wasm output is captured through fd 1 and fd 2 and through the Go-side `host.InvokePlugin` invocation buffers.
 
 The ttsc.dev playground writes one `/work` project per request, serializes all compile/lint/bundle calls, and reuses a single booted wasm for the whole Worker lifetime.
 


### PR DESCRIPTION
Campaign batch **B4 — the WASM MemFS host**. One branch, one pull request, three sequenced issues that all edit `packages/wasm/src/createMemFS.ts` and its `open` function.

## Scope

| Issue | Owns | Landing order |
| --- | --- | --- |
| #811 | The **tree**: `writeFile`, `O_CREAT`, `O_TRUNC` must never leave the node map describing something that is not a tree — file-valued ancestors, directory targets, root protection, orphan prevention, implicit parent creation. | first |
| #813 | The **descriptor**: open modes, `O_EXCL`, `O_DIRECTORY`, append state, offsets, positioned writes, and bad-descriptor errors. | second, on top of #811 |
| #808 | The **contract**: `IWasmExecFS.pipe2`'s JSDoc claims Go wasm `os.Pipe()` calls it, which is false under the pinned Go toolchain. | with the above |

#811 and #813 were split on purpose and are sequenced rather than parallelized: they edit the same function, and the second must not re-open the first's `O_TRUNC`-on-a-directory hole.

For #808 only the **accepted half** is in scope — correcting the false Go-compatibility contract. Deleting the `pipe2` member and its pipe state is explicitly deferred pending an enumeration of external JavaScript consumers of `fs.pipe2`; this pull request does not decide it.

## Campaign conditions

- `pnpm format` is **not** run on this branch; Post-Campaign Cleanup owns the repository-wide formatter result.
- Repository Actions and workflow settings are unchanged. Every push to this branch passes an exact-SHA cancellation gate, and the run states are recorded in the campaign knowledge base.
- `tests/test-wasm` has no CI lane today (a separate published issue owns that gap), so a green run of this suite is local verification, not CI signal.

## Verification

Pending. Narrow: `pnpm --filter @ttsc/wasm build:ts` and `pnpm --filter @ttsc/test-wasm start`. Broader as the batch requires.

Closes #811
Closes #813
Closes #808
