### PR TITLE
fix(graph): decide dispatch from declaration facts, cross it in reverse, and stop calling a bounded path a disconnection

### DIFF
--- a/packages/graph/src/server/pathPolicy.ts
+++ b/packages/graph/src/server/pathPolicy.ts
@@ -9,6 +9,15 @@ export function isExternalNode(node: ITtscGraphNode): boolean {
   );
 }
 
+/**
+ * True for a `.d.ts` declaration file. Every declaration such a file holds is
+ * ambient by construction, so none of them carries a body the graph can walk
+ * into, whether or not the `declare` keyword is written out.
+ */
+export function isDeclarationFile(file: string): boolean {
+  return /\.d\.[cm]?ts$/.test(file);
+}
+
 /** True for tests, examples, fixtures, generated output, and build artifacts. */
 export function isSupportPath(file: string): boolean {
   return (
@@ -20,7 +29,7 @@ export function isSupportPath(file: string): boolean {
     ) ||
     /\.(test|spec)\.[cm]?tsx?$/.test(file) ||
     /(^|\/)typings\.[cm]?ts$/.test(file) ||
-    /\.d\.[cm]?ts$/.test(file) ||
+    isDeclarationFile(file) ||
     /(^|\/)(dist|build|coverage|generated|__generated__)\//.test(file)
   );
 }

--- a/packages/graph/src/server/runTrace.ts
+++ b/packages/graph/src/server/runTrace.ts
@@ -753,13 +753,22 @@ function dispatchEdges(
   if (declaration === undefined || hasDeclarationBody(graph, declaration))
     return [];
   const out: ITtscGraphEdge[] = [];
+  // Per implementation, not per relation. A class may name one base in two
+  // heritage clauses — `class Impl extends Base implements Base` is legal — and
+  // the producer records the member pair once per clause, as `overrides` and as
+  // `implements`. That is one implementation and one crossing: emitting it
+  // twice would repeat the hop and count the same class twice against the hub
+  // cut.
+  const dispatched = new Set<string>();
   for (const edge of relations) {
+    if (dispatched.has(edge.from)) continue;
     const implementation = graph.node(edge.from);
     if (
       implementation === undefined ||
       !hasDeclarationBody(graph, implementation)
     )
       continue;
+    dispatched.add(edge.from);
     out.push({
       from: id,
       to: edge.from,

--- a/packages/graph/src/server/runTrace.ts
+++ b/packages/graph/src/server/runTrace.ts
@@ -741,12 +741,19 @@ function dispatchEdges(
   focus: ITtscGraphTrace.IRequest["focus"],
 ): ITtscGraphEdge[] {
   if (focus === "types") return [];
+  // The checker relations first: almost no node has one, and reading a
+  // declaration's own facts walks its ownership chain, which is work worth
+  // doing only where there is something to dispatch to.
+  let relations: ITtscGraphEdge[] | undefined;
+  for (const edge of graph.incoming(id)) {
+    if (DISPATCH_KINDS.has(edge.kind)) (relations ??= []).push(edge);
+  }
+  if (relations === undefined) return [];
   const declaration = graph.node(id);
   if (declaration === undefined || hasDeclarationBody(graph, declaration))
     return [];
   const out: ITtscGraphEdge[] = [];
-  for (const edge of graph.incoming(id)) {
-    if (!DISPATCH_KINDS.has(edge.kind)) continue;
+  for (const edge of relations) {
     const implementation = graph.node(edge.from);
     if (
       implementation === undefined ||

--- a/packages/graph/src/server/runTrace.ts
+++ b/packages/graph/src/server/runTrace.ts
@@ -3,7 +3,7 @@ import { ITtscGraphEdge } from "../structures/ITtscGraphEdge";
 import { ITtscGraphEvidence } from "../structures/ITtscGraphEvidence";
 import { ITtscGraphNode } from "../structures/ITtscGraphNode";
 import { ITtscGraphTrace } from "../structures/ITtscGraphTrace";
-import { isExternalNode, isTestPath } from "./pathPolicy";
+import { isDeclarationFile, isExternalNode, isTestPath } from "./pathPolicy";
 import { resolveGraphHandle } from "./resolveHandle";
 import { IRunnerOutput, resultNext } from "./resultNext";
 import { edgeEvidenceOf, signatureOf } from "./runDetails";
@@ -20,15 +20,23 @@ const MAX_OPEN_DEPTH = 8;
 const MAX_OPEN_NODES = 32;
 const MAX_IMPACT_DEPTH = 4;
 const MAX_IMPACT_NODES = 16;
+// Path mode walks further than an open trace because it is looking for one
+// named end, not building a picture. The cap is the one the request contract
+// publishes for path mode.
+const MAX_PATH_DEPTH = 12;
 const MAX_HOPS_PER_NODE = 2;
 const MAX_STEPS = 12;
-const EXECUTION_KINDS = new Set<string>([
-  "calls",
-  "instantiates",
-  "accesses",
-  "renders",
-]);
 const DISPATCH_KINDS = new Set<string>(["overrides", "implements"]);
+// A declaration whose kind is a type surface never carries a body, and an
+// external leaf carries one the graph deliberately does not hold.
+const BODYLESS_KINDS = new Set<string>([
+  "interface",
+  "type",
+  "external_symbol",
+]);
+// `abstract` and `declare` are the two keywords that take the body away from a
+// declaration that would otherwise have to have one.
+const BODYLESS_MODIFIERS = new Set<string>(["abstract", "declare"]);
 // An interface the codebase implements everywhere — a disposable, a listener, a
 // lifecycle hook — is not a step in one flow, and naming its implementors is a
 // dump of the codebase rather than an answer. Past this many, the declaration
@@ -143,20 +151,26 @@ export function runTrace(
         ),
       };
     }
-    const found = findPath(
+    const pathDepth = bound(props.maxDepth, MAX_PATH_DEPTH, 1, MAX_PATH_DEPTH);
+    const search = findPath(
       graph,
       start.node.id,
       target.node.id,
-      bound(props.maxDepth, 12, 1, 12),
+      pathDepth,
       focus,
       includeExternal,
     );
-    const hasPath = found !== null;
-    const path = found?.path ?? [];
-    const hops = found?.hops ?? [];
-    const junctions = hasPath
-      ? []
-      : junctionsBetween(graph, start.node.id, target.node.id, focus);
+    const hasPath = search.found !== undefined;
+    const path = search.found?.path ?? [];
+    const hops = search.found?.hops ?? [];
+    // Junctions explain an absence, so they are only computed once absence is
+    // established: a walk the depth bound stopped has not established one, and
+    // presenting a shared symbol as "the seam" when a direct call path may run
+    // past the bound sends the caller to a seam that is not there.
+    const junctions =
+      hasPath || search.bounded
+        ? []
+        : junctionsBetween(graph, start.node.id, target.node.id, focus);
     return {
       result: {
         ...base,
@@ -169,27 +183,31 @@ export function runTrace(
       },
       // A missing path is a fact, not an answer, and the old message called it
       // one: "its path nodes and evidence ranges are what the graph holds
-      // between the two ends" — of a result that held nothing. `findPath` uses
-      // null for that state; zero hops is instead the valid path
-      // from a node to itself. Distinct nodes without a path do not call each
-      // other, which in an event-driven codebase is the common
-      // case: a pointer handler emits, an emitter's `emit()` runs listeners a
+      // between the two ends" — of a result that held nothing. `findPath` says
+      // which fact it is; zero hops is instead the valid path from a node to
+      // itself. A walk the depth bound stopped establishes nothing at all, so
+      // it reports the bound. A walk that ran out of eligible graph did
+      // establish an absence, and distinct nodes without a path do not call
+      // each other, which in an event-driven codebase is the common case: a
+      // pointer handler emits, an emitter's `emit()` runs listeners a
       // registration put in an array, and no call edge crosses that array. The
       // callers of the target are the way across, and the graph has them, so
       // say which call to make instead of handing back an empty result dressed
       // as the answer. Excalidraw's tour spent eleven calls finding this out.
       next: hasPath
         ? pathNext
-        : junctions.length > 0
-          ? resultNext(
-              "inspect",
-              "No call path runs between the two ends — a callback stands between them (an event emitter, a subscription, a lifecycle hook), and no call edge crosses one. `junctions` names the symbols both ends touch, which is the seam: trace the junction to see who registers on it and who fires it.",
-              "trace",
-            )
-          : resultNext(
-              "outside",
-              "No call path runs from the start to the target and they touch nothing in common, so the graph holds no connection between them.",
-            ),
+        : search.bounded
+          ? resultNext("inspect", boundedPathReason(pathDepth), "trace")
+          : junctions.length > 0
+            ? resultNext(
+                "inspect",
+                "No call path runs between the two ends — a callback stands between them (an event emitter, a subscription, a lifecycle hook), and no call edge crosses one. `junctions` names the symbols both ends touch, which is the seam: trace the junction to see who registers on it and who fires it.",
+                "trace",
+              )
+            : resultNext(
+                "outside",
+                "No call path runs from the start to the target and they touch nothing in common, so the graph holds no connection between them.",
+              ),
     };
   }
 
@@ -299,7 +317,7 @@ function traceEdges(
   focus: ITtscGraphTrace.IRequest["focus"],
 ): readonly ITtscGraphEdge[] {
   return reverse
-    ? graph.incoming(id)
+    ? [...graph.incoming(id), ...reverseDispatchEdges(graph, id, focus)]
     : [...graph.outgoing(id), ...dispatchEdges(graph, id, focus)];
 }
 
@@ -340,11 +358,6 @@ function traceSteps(
   });
 }
 
-/**
- * The shortest dependency path from `startId` to `targetId` over real (non-
- * structural) forward edges, breadth-first, or null when `targetId` is not
- * reachable within maxDepth. Returns the nodes in order and the hops between.
- */
 /**
  * The symbols both ends of an unreachable path touch.
  *
@@ -433,6 +446,57 @@ function touchedBy(
   return touched;
 }
 
+/**
+ * What to say when the depth bound, not the graph, ended a path search.
+ *
+ * The caller asked a bounded question and the old answer returned a claim about
+ * the whole graph — "they touch nothing in common, so the graph holds no
+ * connection between them" — which is the worst thing an index can say wrongly:
+ * the caller stops asking and either reads files or concludes the dependency is
+ * not there. So report the boundary, and make the continuation one the caller
+ * can actually take. At the 12-hop ceiling there is no larger `maxDepth` to
+ * retry with, and a message that only invites one would be a dead end of its
+ * own; two bounded walks from opposite ends cover twice the distance and are
+ * requests the tool already answers.
+ */
+function boundedPathReason(depth: number): string {
+  return (
+    `No path was found within the requested depth of ${depth}, but the walk stopped on that bound with eligible graph still ahead of it. ` +
+    `This is a boundary, not an absence: the two ends may be connected further out, and nothing here says they are not. ` +
+    (depth < MAX_PATH_DEPTH
+      ? `Re-run the same path request with a larger \`maxDepth\` (up to ${MAX_PATH_DEPTH}).`
+      : `\`maxDepth\` is already at its ${MAX_PATH_DEPTH}-hop maximum, so close the gap from both ends: trace forward from the start, trace the target with \`direction: "reverse"\`, then request the path between a symbol both results name.`)
+  );
+}
+
+/**
+ * What a bounded shortest-path walk learned: the path when it found one, and
+ * otherwise whether the walk was stopped by the caller's depth bound or ran the
+ * eligible graph out. The two are not the same answer and the caller must not
+ * be told the second when only the first happened.
+ */
+interface IPathSearch {
+  /** The shortest eligible path and its hops, when one was found. */
+  found?: { path: ITtscGraphNode[]; hops: ITtscGraphTrace.IHop[] };
+
+  /**
+   * True when the walk stopped at `maxDepth` with an eligible, unvisited node
+   * still ahead of it, so nothing was proven about the two ends.
+   */
+  bounded: boolean;
+}
+
+/**
+ * The shortest dependency path from `startId` to `targetId` over real (non-
+ * structural) forward edges, breadth-first, within `maxDepth` hops.
+ *
+ * When no path is found, the walk reports whether the bound stopped it. A
+ * boundary is a fact about the request; absence is a fact about the graph, and
+ * a search that never reached the far side of its own bound has not established
+ * one. Eligibility is the open trace's, so a frontier made only of nodes the
+ * selected focus, the external-node policy, a file node, or an earlier visit
+ * already excluded is not a frontier and the walk is exhausted.
+ */
 function findPath(
   graph: TtscGraphMemory,
   startId: string,
@@ -440,10 +504,11 @@ function findPath(
   maxDepth: number,
   focus: ITtscGraphTrace.IRequest["focus"],
   includeExternal: boolean,
-): { path: ITtscGraphNode[]; hops: ITtscGraphTrace.IHop[] } | null {
+): IPathSearch {
   const startNode = graph.node(startId);
-  if (startNode === undefined) return null;
-  if (startId === targetId) return { path: [startNode], hops: [] };
+  if (startNode === undefined) return { bounded: false };
+  if (startId === targetId)
+    return { found: { path: [startNode], hops: [] }, bounded: false };
   const parent = new Map<
     string,
     {
@@ -453,21 +518,36 @@ function findPath(
     }
   >();
   const visited = new Set<string>([startId]);
+  let bounded = false;
   let queue: Array<{ id: string; depth: number }> = [{ id: startId, depth: 0 }];
   while (queue.length > 0) {
     const next: Array<{ id: string; depth: number }> = [];
     for (const { id, depth } of queue) {
-      if (depth >= maxDepth) continue;
-      for (const edge of [
+      const candidates = [
         ...graph.outgoing(id),
         ...dispatchEdges(graph, id, focus),
-      ]) {
-        if (!traversable(edge.kind, focus)) continue;
-        const otherId = edge.to;
-        if (visited.has(otherId)) continue;
-        const other = graph.node(otherId);
-        if (other === undefined || other.kind === "file") continue;
-        if (!includeExternal && isExternalNode(other)) continue;
+      ];
+      if (depth >= maxDepth) {
+        if (
+          candidates.some(
+            (edge) =>
+              pathEndpoint(graph, edge, focus, includeExternal, visited) !==
+              undefined,
+          )
+        )
+          bounded = true;
+        continue;
+      }
+      for (const edge of candidates) {
+        const endpoint = pathEndpoint(
+          graph,
+          edge,
+          focus,
+          includeExternal,
+          visited,
+        );
+        if (endpoint === undefined) continue;
+        const otherId = endpoint.otherId;
         visited.add(otherId);
         const evidence = edgeEvidenceOf(edge);
         parent.set(otherId, {
@@ -503,14 +583,42 @@ function findPath(
               hop.evidence = parentEdge.evidence;
             hops.push(hop);
           }
-          return { path, hops };
+          return { found: { path, hops }, bounded };
         }
         next.push({ id: otherId, depth: depth + 1 });
       }
     }
     queue = next;
   }
-  return null;
+  return { bounded };
+}
+
+/**
+ * The node a path expansion would represent, or undefined when the selected
+ * policy or an earlier visit excludes it. The expansion and the boundary probe
+ * share this decision, so what the walk would have followed and what counts as
+ * unexplored graph beyond the bound cannot disagree.
+ *
+ * A path walk is always forward and, unlike the open trace, a node it already
+ * reached is not a continuation: the shortest path to it is already known, so a
+ * second arrival adds nothing to explore.
+ */
+function pathEndpoint(
+  graph: TtscGraphMemory,
+  edge: ITtscGraphEdge,
+  focus: ITtscGraphTrace.IRequest["focus"],
+  includeExternal: boolean,
+  visited: ReadonlySet<string>,
+): ITraceEndpoint | undefined {
+  const endpoint = eligibleTraceEndpoint(
+    graph,
+    edge,
+    false,
+    focus,
+    includeExternal,
+  );
+  if (endpoint === undefined || visited.has(endpoint.otherId)) return undefined;
+  return endpoint;
 }
 
 function orderedEdges(
@@ -632,12 +740,18 @@ function dispatchEdges(
   id: string,
   focus: ITtscGraphTrace.IRequest["focus"],
 ): ITtscGraphEdge[] {
-  if (focus === "types" || hasExecutionBody(graph, id)) return [];
+  if (focus === "types") return [];
+  const declaration = graph.node(id);
+  if (declaration === undefined || hasDeclarationBody(graph, declaration))
+    return [];
   const out: ITtscGraphEdge[] = [];
   for (const edge of graph.incoming(id)) {
     if (!DISPATCH_KINDS.has(edge.kind)) continue;
     const implementation = graph.node(edge.from);
-    if (implementation === undefined || !hasExecutionBody(graph, edge.from))
+    if (
+      implementation === undefined ||
+      !hasDeclarationBody(graph, implementation)
+    )
       continue;
     out.push({
       from: id,
@@ -649,11 +763,106 @@ function dispatchEdges(
   return out.length >= DISPATCH_HUB ? [] : out;
 }
 
-/** Whether the declaration has a body: something it calls, reads, or renders. */
-function hasExecutionBody(graph: TtscGraphMemory, id: string): boolean {
-  for (const edge of graph.outgoing(id))
-    if (EXECUTION_KINDS.has(edge.kind)) return true;
+/**
+ * The declaration a change to this implementation is a change to.
+ *
+ * `dispatches` is one fact and both directions have to see it. Forward, a call
+ * that lands on a bodyless declaration continues in the implementation that
+ * runs; reverse, a change to that implementation is a change every caller of
+ * the declaration feels — and `impact` is the query an agent runs _before_
+ * editing a method. The checker relation is oriented implementation-to-base, so
+ * from the implementation it is an outgoing edge and a reverse walk, which only
+ * reads incoming edges, never sees it. Both halves of the path are one step
+ * away in a direction the traversal does not take.
+ *
+ * The synthetic edge is the forward one, unchanged, so eligibility, checker
+ * validity, and the hub cut cannot drift apart between the two directions: ask
+ * the base what it dispatches to, and keep the edges that land here.
+ */
+function reverseDispatchEdges(
+  graph: TtscGraphMemory,
+  id: string,
+  focus: ITtscGraphTrace.IRequest["focus"],
+): ITtscGraphEdge[] {
+  if (focus === "types") return [];
+  const out: ITtscGraphEdge[] = [];
+  const bases = new Set<string>();
+  for (const edge of graph.outgoing(id)) {
+    if (!DISPATCH_KINDS.has(edge.kind) || bases.has(edge.to)) continue;
+    bases.add(edge.to);
+    for (const dispatch of dispatchEdges(graph, edge.to, focus))
+      if (dispatch.to === id) out.push(dispatch);
+  }
+  return out;
+}
+
+/**
+ * Whether the declaration this node stands for has a body of its own.
+ *
+ * Having a body and naming a modeled dependency are different facts. Counting
+ * outgoing `calls`/`accesses`/`instantiates`/`renders` edges measures the
+ * second and answers as though it were the first, and it is wrong in both
+ * directions: an implementation whose body returns a literal, throws, or only
+ * moves locals around has degree zero and was refused as a dispatch target,
+ * while a concrete base method was promoted through its own override the moment
+ * its body stopped naming anything the graph models. Two graphs identical in
+ * every declaration fact then answered differently because of one statement
+ * inside a body.
+ *
+ * So read the declaration instead. A type surface has no body; `abstract` and
+ * `declare` take it away; an interface member and anything inside an ambient
+ * container never had one; a `.d.ts` declaration is ambient whether or not the
+ * keyword is written; and an external leaf has a body the graph deliberately
+ * does not hold. Everything else is a concrete declaration, which is a real
+ * destination and is never promoted through an override, whatever it calls.
+ */
+function hasDeclarationBody(
+  graph: TtscGraphMemory,
+  node: ITtscGraphNode,
+): boolean {
+  if (BODYLESS_KINDS.has(node.kind)) return false;
+  if (isExternalNode(node)) return false;
+  if (isDeclarationFile(node.file)) return false;
+  if (hasBodylessModifier(node)) return false;
+  return !inBodylessContainer(graph, node);
+}
+
+function hasBodylessModifier(node: ITtscGraphNode): boolean {
+  return node.modifiers?.some((m) => BODYLESS_MODIFIERS.has(m)) === true;
+}
+
+/**
+ * Whether an owner up the `contains` tree makes this declaration bodyless: an
+ * interface, or an ambient container. A member writes no keyword of its own —
+ * `declare` on a class or namespace is not repeated on what it holds — so the
+ * fact lives on the owner and the walk has to go get it.
+ */
+function inBodylessContainer(
+  graph: TtscGraphMemory,
+  node: ITtscGraphNode,
+): boolean {
+  const seen = new Set<string>([node.id]);
+  let current: ITtscGraphNode | undefined = node;
+  while (current !== undefined) {
+    const container: ITtscGraphNode | undefined = containerOf(graph, current);
+    if (container === undefined || container.kind === "file") return false;
+    if (seen.has(container.id)) return false;
+    seen.add(container.id);
+    if (container.kind === "interface" || hasBodylessModifier(container))
+      return true;
+    current = container;
+  }
   return false;
+}
+
+/** The declaration that owns this one, through the synthesized ownership tree. */
+function containerOf(
+  graph: TtscGraphMemory,
+  node: ITtscGraphNode,
+): ITtscGraphNode | undefined {
+  for (const edge of graph.incoming(node.id))
+    if (edge.kind === "contains") return graph.node(edge.from);
+  return undefined;
 }
 
 /** An edge the trace should follow: a real dependency, not a structural edge. */

--- a/packages/graph/src/server/runTrace.ts
+++ b/packages/graph/src/server/runTrace.ts
@@ -316,9 +316,13 @@ function traceEdges(
   reverse: boolean,
   focus: ITtscGraphTrace.IRequest["focus"],
 ): readonly ITtscGraphEdge[] {
-  return reverse
-    ? [...graph.incoming(id), ...reverseDispatchEdges(graph, id, focus)]
-    : [...graph.outgoing(id), ...dispatchEdges(graph, id, focus)];
+  const edges = reverse ? graph.incoming(id) : graph.outgoing(id);
+  const dispatched = reverse
+    ? reverseDispatchEdges(graph, id, focus)
+    : dispatchEdges(graph, id, focus);
+  // Nothing to add is the common case, and a walk visits the nodes with the
+  // largest edge lists, so hand back the stored list rather than a copy of it.
+  return dispatched.length === 0 ? edges : [...edges, ...dispatched];
 }
 
 /**

--- a/packages/graph/src/server/runTrace.ts
+++ b/packages/graph/src/server/runTrace.ts
@@ -527,10 +527,9 @@ function findPath(
   while (queue.length > 0) {
     const next: Array<{ id: string; depth: number }> = [];
     for (const { id, depth } of queue) {
-      const candidates = [
-        ...graph.outgoing(id),
-        ...dispatchEdges(graph, id, focus),
-      ];
+      // The forward step the open trace would take, built in one place so the
+      // two walks cannot disagree about what a step follows.
+      const candidates = traceEdges(graph, id, false, focus);
       if (depth >= maxDepth) {
         if (
           candidates.some(

--- a/tests/test-graph/src/features/test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degree.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degree.ts
@@ -35,12 +35,15 @@ interface TraceResult {
  * 1. Materialize implementations that name nothing (empty, literal, local
  *    arithmetic, thrown literal) behind an interface member, an abstract
  *    method, and an ambient `declare class` member, plus two concrete bases
- *    with overrides that differ only in one statement, plus an overload set.
+ *    with overrides that differ only in one statement, an abstract member
+ *    standing between an interface and its concrete class, and an overload
+ *    set.
  * 2. Trace forward from each caller through the real MCP launcher, and request the
  *    same continuation in path mode.
  * 3. Assert every genuinely bodyless declaration dispatches to its dependency-
  *    free implementation, that neither concrete base is promoted through its
- *    override, and that `focus: "types"` still synthesizes nothing.
+ *    override, that no bodyless candidate is admitted as an implementation, and
+ *    that `focus: "types"` still synthesizes nothing.
  */
 export const test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degree =
   async () => {
@@ -113,6 +116,24 @@ export const test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degr
         "",
         "export class QuietTask extends Task {",
         "  public perform(): void {}",
+        "}",
+        "",
+        "export interface Shape {",
+        "  area(): number;",
+        "}",
+        "",
+        "export abstract class BaseShape implements Shape {",
+        "  public abstract area(): number;",
+        "}",
+        "",
+        "export class Square extends BaseShape {",
+        "  public area(): number {",
+        "    return 4;",
+        "  }",
+        "}",
+        "",
+        "export function callShape(shape: Shape): number {",
+        "  return shape.area();",
         "}",
         "",
         "declare class Native {",
@@ -239,6 +260,21 @@ export const test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degr
       assert.ok(
         dispatchedIn(abstractTask).includes("QuietTask.perform"),
         `an abstract method dispatches to a dependency-free override: ${JSON.stringify(abstractTask.hops)}`,
+      );
+
+      // The other half of the same predicate: a candidate that is itself
+      // bodyless is not an implementation. An abstract member standing between
+      // an interface and the concrete class is that candidate, and it must
+      // never be the destination of a hop that claims to name what runs.
+      const abstractCandidate = await forward("callShape");
+      assert.ok(
+        !dispatchedIn(abstractCandidate).includes("BaseShape.area"),
+        `an abstract member is never a dispatch destination: ${JSON.stringify(abstractCandidate.hops)}`,
+      );
+      const abstractIntermediate = await forward("BaseShape.area");
+      assert.ok(
+        dispatchedIn(abstractIntermediate).includes("Square.area"),
+        `and the concrete override below it still is: ${JSON.stringify(abstractIntermediate.hops)}`,
       );
 
       const ambient = await forward("callNative");

--- a/tests/test-graph/src/features/test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degree.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degree.ts
@@ -36,8 +36,8 @@ interface TraceResult {
  *    arithmetic, thrown literal) behind an interface member, an abstract
  *    method, and an ambient `declare class` member, plus two concrete bases
  *    with overrides that differ only in one statement, an abstract member
- *    standing between an interface and its concrete class, and an overload
- *    set.
+ *    standing between an interface and its concrete class, one implementation
+ *    named in two heritage clauses, and an overload set.
  * 2. Trace forward from each caller through the real MCP launcher, and request the
  *    same continuation in path mode.
  * 3. Assert every genuinely bodyless declaration dispatches to its dependency-
@@ -134,6 +134,18 @@ export const test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degr
         "",
         "export function callShape(shape: Shape): number {",
         "  return shape.area();",
+        "}",
+        "",
+        "export abstract class Twice {",
+        "  public abstract emit(): void;",
+        "}",
+        "",
+        "export class OnlyOnce extends Twice implements Twice {",
+        "  public emit(): void {}",
+        "}",
+        "",
+        "export function callTwice(twice: Twice): void {",
+        "  twice.emit();",
         "}",
         "",
         "declare class Native {",
@@ -268,6 +280,10 @@ export const test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degr
       // never be the destination of a hop that claims to name what runs.
       const abstractCandidate = await forward("callShape");
       assert.ok(
+        abstractCandidate.reached.some((node) => node.name === "Shape.area"),
+        `the walk stands on the interface member: ${abstractCandidate.reached.map((n) => n.name).join(", ")}`,
+      );
+      assert.ok(
         !dispatchedIn(abstractCandidate).includes("BaseShape.area"),
         `an abstract member is never a dispatch destination: ${JSON.stringify(abstractCandidate.hops)}`,
       );
@@ -275,6 +291,17 @@ export const test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degr
       assert.ok(
         dispatchedIn(abstractIntermediate).includes("Square.area"),
         `and the concrete override below it still is: ${JSON.stringify(abstractIntermediate.hops)}`,
+      );
+
+      // One implementation named in two heritage clauses is one implementation.
+      // The producer records the member pair once per clause, as `overrides`
+      // and as `implements`, so a walk over relations would cross to the same
+      // body twice and count one class twice against the hub cut.
+      const twoRelations = await forward("callTwice");
+      assert.deepEqual(
+        dispatchedIn(twoRelations),
+        ["OnlyOnce.emit"],
+        `a doubly related implementation is dispatched to once: ${JSON.stringify(twoRelations.hops)}`,
       );
 
       const ambient = await forward("callNative");

--- a/tests/test-graph/src/features/test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degree.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degree.ts
@@ -1,0 +1,320 @@
+import { TestProject } from "@ttsc/testing";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  structuredContent?: {
+    result?: TraceResult;
+  };
+}
+
+interface TraceResult {
+  type: "trace";
+  hops: { from: string; to: string; kind: string }[];
+  reached: { id: string; name: string }[];
+  path?: { id: string; name: string }[];
+}
+
+/**
+ * Verifies a dispatch hop is decided by what a declaration is, not by how many
+ * modeled symbols its body happens to name.
+ *
+ * Body detection used to count outgoing `calls`/`accesses`/`instantiates`/
+ * `renders` edges, which measures dependency degree instead. That is wrong in
+ * both directions: an implementation whose body is empty, returns a literal,
+ * throws, or only moves locals around scored zero and was refused as a dispatch
+ * target, so the trace dead-ended on the declaration and reported nothing was
+ * omitted; and a concrete base method was promoted through its own override the
+ * moment its body stopped naming anything the graph models, so two graphs
+ * identical in every declaration fact answered differently because of one
+ * statement inside a body. The declaration facts the fix reads — kind,
+ * `abstract`/`declare` modifiers, and interface or ambient ownership — are only
+ * proven end to end through the real producer, which is why this runs the
+ * shipped binary rather than a synthetic in-memory graph.
+ *
+ * 1. Materialize implementations that name nothing (empty, literal, local
+ *    arithmetic, thrown literal) behind an interface member, an abstract
+ *    method, and an ambient `declare class` member, plus two concrete bases
+ *    with overrides that differ only in one statement, plus an overload set.
+ * 2. Trace forward from each caller through the real MCP launcher, and request the
+ *    same continuation in path mode.
+ * 3. Assert every genuinely bodyless declaration dispatches to its dependency-
+ *    free implementation, that neither concrete base is promoted through its
+ *    override, and that `focus: "types"` still synthesizes nothing.
+ */
+export const test_ttscgraph_dispatch_reads_declaration_facts_not_dependency_degree =
+  async () => {
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify(
+        {
+          compilerOptions: {
+            target: "ES2022",
+            module: "commonjs",
+            strict: true,
+            rootDir: "src",
+            outDir: "dist",
+          },
+          include: ["src"],
+        },
+        null,
+        2,
+      ),
+      "src/app.ts": [
+        "export function accepted(): void {}",
+        "export function derivedOnly(): void {}",
+        "",
+        "export interface Pipeline {",
+        "  execute(): void;",
+        "}",
+        "",
+        "export class Empty implements Pipeline {",
+        "  public execute(): void {}",
+        "}",
+        "",
+        "export function callPipeline(pipeline: Pipeline): void {",
+        "  pipeline.execute();",
+        "}",
+        "",
+        "export interface Reader {",
+        "  read(): number;",
+        "}",
+        "",
+        "export class Constant implements Reader {",
+        "  public read(): number {",
+        "    return 1;",
+        "  }",
+        "}",
+        "",
+        "export class Computed implements Reader {",
+        "  public read(): number {",
+        "    let total = 0;",
+        "    for (let i = 0; i < 3; i++) total += i;",
+        "    return total;",
+        "  }",
+        "}",
+        "",
+        "export class Refusing implements Reader {",
+        "  public read(): number {",
+        '    throw "unsupported";',
+        "  }",
+        "}",
+        "",
+        "export function callReader(reader: Reader): number {",
+        "  return reader.read();",
+        "}",
+        "",
+        "export abstract class Task {",
+        "  public abstract perform(): void;",
+        "",
+        "  public start(): void {",
+        "    this.perform();",
+        "  }",
+        "}",
+        "",
+        "export class QuietTask extends Task {",
+        "  public perform(): void {}",
+        "}",
+        "",
+        "declare class Native {",
+        "  handle(): void;",
+        "}",
+        "",
+        "export class RealNative extends Native {",
+        "  public handle(): void {}",
+        "}",
+        "",
+        "export function callNative(native: Native): void {",
+        "  native.handle();",
+        "}",
+        "",
+        "export class Base {",
+        "  public run(): void {}",
+        "}",
+        "",
+        "export class Derived extends Base {",
+        "  public run(): void {",
+        "    derivedOnly();",
+        "  }",
+        "}",
+        "",
+        "export function callBase(base: Base): void {",
+        "  base.run();",
+        "}",
+        "",
+        "export class Loud {",
+        "  public speak(): void {",
+        "    accepted();",
+        "  }",
+        "}",
+        "",
+        "export class Louder extends Loud {",
+        "  public speak(): void {",
+        "    derivedOnly();",
+        "  }",
+        "}",
+        "",
+        "export function callLoud(loud: Loud): void {",
+        "  loud.speak();",
+        "}",
+        "",
+        "export class Formatter {",
+        "  public format(value: string): string;",
+        "  public format(value: number): string;",
+        "  public format(value: string | number): string {",
+        "    return String(value);",
+        "  }",
+        "}",
+        "",
+        "export function callFormatter(formatter: Formatter): string {",
+        "  return formatter.format(1);",
+        "}",
+        "",
+      ].join("\n"),
+    });
+
+    const client = TtsgraphClient.start(root);
+    try {
+      await client.request("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-graph", version: "0.0.0" },
+      });
+      client.notify("notifications/initialized", {});
+
+      const call = async (
+        request: Record<string, unknown>,
+      ): Promise<TraceResult> => {
+        const response = (await client.request("tools/call", {
+          name: "inspect_typescript_graph",
+          arguments: {
+            question: "What does this call actually run?",
+            draft: {
+              reason: "A trace is the smallest step for a runtime flow.",
+              type: "trace",
+            },
+            review: "Confirmed: answer from the trace's graph facts.",
+            request: { type: "trace", ...request },
+          },
+        })) as ToolResult;
+        const trace = response.structuredContent?.result;
+        assert.equal(
+          trace?.type,
+          "trace",
+          `expected a trace result: ${JSON.stringify(response)}`,
+        );
+        return trace!;
+      };
+
+      /** The names a trace reached over a synthesized `dispatches` hop. */
+      const dispatchedIn = (trace: TraceResult): string[] =>
+        trace.hops
+          .filter((hop) => hop.kind === "dispatches")
+          .map(
+            (hop) =>
+              trace.reached.find((node) => node.id === hop.to)?.name ?? hop.to,
+          );
+
+      const forward = async (from: string): Promise<TraceResult> =>
+        call({ from, direction: "forward", focus: "execution", maxDepth: 4 });
+
+      const emptyBody = await forward("callPipeline");
+      assert.ok(
+        dispatchedIn(emptyBody).includes("Empty.execute"),
+        `an implementation with an empty body is still the code that runs: ${JSON.stringify(emptyBody.hops)}`,
+      );
+
+      const dependencyFree = await forward("callReader");
+      const readers = dispatchedIn(dependencyFree);
+      for (const implementation of [
+        "Constant.read",
+        "Computed.read",
+        "Refusing.read",
+      ])
+        assert.ok(
+          readers.includes(implementation),
+          `a body that names nothing modeled is still a body (${implementation}): ${readers.join(", ")}`,
+        );
+
+      const abstractTask = await forward("Task.start");
+      assert.ok(
+        dispatchedIn(abstractTask).includes("QuietTask.perform"),
+        `an abstract method dispatches to a dependency-free override: ${JSON.stringify(abstractTask.hops)}`,
+      );
+
+      const ambient = await forward("callNative");
+      assert.ok(
+        dispatchedIn(ambient).includes("RealNative.handle"),
+        `an ambient member is bodyless by declaration, not by degree: ${JSON.stringify(ambient.hops)}`,
+      );
+
+      const concreteEmptyBase = await forward("callBase");
+      assert.deepEqual(
+        dispatchedIn(concreteEmptyBase),
+        [],
+        "a concrete base with a body is the destination, not a hop to its override",
+      );
+      assert.ok(
+        !concreteEmptyBase.reached.some((node) =>
+          ["Derived.run", "derivedOnly"].includes(node.name),
+        ),
+        `the override stays out of the flow: ${concreteEmptyBase.reached.map((n) => n.name).join(", ")}`,
+      );
+
+      const concreteCallingBase = await forward("callLoud");
+      assert.deepEqual(
+        dispatchedIn(concreteCallingBase),
+        [],
+        "the same shape answers the same way when the base body calls a helper",
+      );
+      assert.ok(
+        concreteCallingBase.reached.some((node) => node.name === "accepted"),
+        "the concrete base's own work is still reached",
+      );
+
+      const overloads = await forward("callFormatter");
+      assert.deepEqual(
+        dispatchedIn(overloads),
+        [],
+        "an overload set resolved to its one implementation dispatches nowhere",
+      );
+      assert.equal(
+        overloads.reached.filter((node) => node.name === "Formatter.format")
+          .length,
+        1,
+        `the implementation is reached exactly once: ${overloads.reached.map((n) => n.name).join(", ")}`,
+      );
+
+      const typed = await call({
+        from: "callPipeline",
+        direction: "forward",
+        focus: "types",
+        maxDepth: 4,
+      });
+      assert.deepEqual(
+        dispatchedIn(typed),
+        [],
+        '`focus: "types"` still synthesizes no runtime dispatch',
+      );
+
+      const asPath = await call({
+        from: "callPipeline",
+        to: "Empty.execute",
+        focus: "execution",
+        maxDepth: 4,
+      });
+      assert.deepEqual(
+        asPath.path?.map((node) => node.name),
+        ["callPipeline", "Pipeline.execute", "Empty.execute"],
+        `path mode agrees with the open trace: ${JSON.stringify(asPath.path)}`,
+      );
+    } finally {
+      client.endStdin();
+    }
+
+    const code = await client.waitForExit();
+    assert.equal(
+      code,
+      0,
+      `the launcher exits cleanly\nstderr: ${client.stderrText()}`,
+    );
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_path_reports_its_depth_bound_instead_of_a_disconnection.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_path_reports_its_depth_bound_instead_of_a_disconnection.ts
@@ -1,0 +1,408 @@
+import { TestProject } from "@ttsc/testing";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  structuredContent?: {
+    next?: { action?: string; request?: string; reason?: string };
+    result?: TraceResult;
+  };
+}
+
+interface TraceResult {
+  type: "trace";
+  hops: { from: string; to: string; kind: string }[];
+  path?: { id: string; name: string }[];
+  junctions?: unknown[];
+}
+
+/** One hop past the largest `maxDepth` path mode accepts. */
+const OVER_CEILING_HOPS = 13;
+
+/**
+ * Verifies path mode reports a depth-bounded miss as a bound with a usable
+ * continuation, and keeps the no-connection verdict for a search that actually
+ * exhausted the eligible graph.
+ *
+ * `findPath` returned one sentinel for two different facts — the search space
+ * ran out, or the walk was cut off before it could decide — and the path branch
+ * read it as complete knowledge, answering "they touch nothing in common, so
+ * the graph holds no connection between them" with `next.action: "outside"`.
+ * That is the worst thing an index can say wrongly: the caller stops asking.
+ * Worse, path mode caps `maxDepth` at 12, so a 13-hop path was unanswerable at
+ * every legal request and still reported as absent, and when the two ends
+ * happened to share a symbol the junction branch offered a seam that was not
+ * the seam. Eligibility here must mean what it means for the open trace, so a
+ * frontier of only filtered externals, file nodes, or already-visited nodes is
+ * exhaustion, not a bound.
+ *
+ * 1. Materialize a chain longer than the ceiling, a pair that shares a state
+ *    property and also has a direct path, a genuinely disconnected pair with
+ *    and without a shared junction, an external-only frontier, a cycle, a type
+ *    chain, and a dispatch seam.
+ * 2. Request each path through the real MCP launcher at bounds above, at, and
+ *    below the shortest path.
+ * 3. Assert a bounded miss never carries the disconnection verdict or a junction
+ *    seam, that its continuation changes at the ceiling, and that exhausted
+ *    searches, found paths, and the identity path are unchanged.
+ */
+export const test_ttscgraph_path_reports_its_depth_bound_instead_of_a_disconnection =
+  async () => {
+    const chain = Array.from(
+      { length: OVER_CEILING_HOPS + 1 },
+      (_unused, index) =>
+        index === OVER_CEILING_HOPS
+          ? `export function n${index}(): void {}`
+          : `export function n${index}(): void { n${index + 1}(); }`,
+    ).join("\n");
+
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify(
+        {
+          compilerOptions: {
+            target: "ES2022",
+            module: "commonjs",
+            moduleResolution: "node",
+            strict: true,
+            rootDir: "src",
+            outDir: "dist",
+          },
+          include: ["src"],
+        },
+        null,
+        2,
+      ),
+      "node_modules/path-dependency/package.json": JSON.stringify({
+        name: "path-dependency",
+        version: "1.0.0",
+        types: "index.d.ts",
+      }),
+      "node_modules/path-dependency/index.d.ts":
+        "export declare function externalWork(): void;\n",
+      "src/chain.ts": `${chain}\n`,
+      "src/app.ts": [
+        'import { externalWork } from "path-dependency";',
+        "",
+        "export class Store {",
+        "  public value = 0;",
+        "}",
+        "",
+        "export const store = new Store();",
+        "",
+        "export function seamStart(): void {",
+        "  if (store.value === 0) seamMiddleOne();",
+        "}",
+        "",
+        "function seamMiddleOne(): void {",
+        "  seamMiddleTwo();",
+        "}",
+        "",
+        "function seamMiddleTwo(): void {",
+        "  seamEnd();",
+        "}",
+        "",
+        "export function seamEnd(): number {",
+        "  return store.value;",
+        "}",
+        "",
+        "export function holderA(): number {",
+        "  return store.value;",
+        "}",
+        "",
+        "export function holderB(): number {",
+        "  return store.value + 1;",
+        "}",
+        "",
+        "export function apartLeft(): void {}",
+        "export function apartRight(): void {}",
+        "",
+        "export function edgeStart(): void {",
+        "  edgeMid();",
+        "}",
+        "",
+        "function edgeMid(): void {",
+        "  externalWork();",
+        "}",
+        "",
+        "export function ringA(): void {",
+        "  ringB();",
+        "}",
+        "",
+        "function ringB(): void {",
+        "  ringA();",
+        "}",
+        "",
+        "export interface TypeBase {",
+        "  value: number;",
+        "}",
+        "",
+        "export interface TypeMiddle extends TypeBase {",
+        "  extra: number;",
+        "}",
+        "",
+        "export interface TypeLeaf extends TypeMiddle {",
+        "  more: number;",
+        "}",
+        "",
+        "export interface Emitter {",
+        "  fire(): void;",
+        "}",
+        "",
+        "export class Silent implements Emitter {",
+        "  public fire(): void {}",
+        "}",
+        "",
+        "export function useEmitter(emitter: Emitter): void {",
+        "  emitter.fire();",
+        "}",
+        "",
+      ].join("\n"),
+    });
+
+    const client = TtsgraphClient.start(root);
+    try {
+      await client.request("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-graph", version: "0.0.0" },
+      });
+      client.notify("notifications/initialized", {});
+
+      const call = async (
+        request: Record<string, unknown>,
+      ): Promise<NonNullable<ToolResult["structuredContent"]>> => {
+        const response = (await client.request("tools/call", {
+          name: "inspect_typescript_graph",
+          arguments: {
+            question: "How does one end reach the other?",
+            draft: {
+              reason: "Path mode is the one-call answer for two known ends.",
+              type: "trace",
+            },
+            review: "Confirmed: answer from the path the graph holds.",
+            request: { type: "trace", ...request },
+          },
+        })) as ToolResult;
+        assert.equal(
+          response.structuredContent?.result?.type,
+          "trace",
+          `expected a trace result: ${JSON.stringify(response)}`,
+        );
+        return response.structuredContent!;
+      };
+
+      const exhausted = await call({
+        from: "apartLeft",
+        to: "apartRight",
+        focus: "execution",
+      });
+      assert.equal(
+        exhausted.next?.action,
+        "outside",
+        "an exhausted search with nothing in common keeps its verdict",
+      );
+
+      const junctioned = await call({
+        from: "holderA",
+        to: "holderB",
+        focus: "all",
+      });
+      assert.equal(
+        junctioned.next?.action,
+        "inspect",
+        "an exhausted search over a shared symbol keeps its junction verdict",
+      );
+      assert.ok(
+        (junctioned.result!.junctions?.length ?? 0) > 0,
+        `and still names the seam: ${JSON.stringify(junctioned.result!.junctions)}`,
+      );
+
+      const boundedSeam = await call({
+        from: "seamStart",
+        to: "seamEnd",
+        focus: "all",
+        maxDepth: 2,
+      });
+      assert.notEqual(
+        boundedSeam.next?.action,
+        "outside",
+        "a walk stopped by the bound is not evidence the graph holds no connection",
+      );
+      assert.equal(boundedSeam.next?.action, "inspect");
+      assert.equal(
+        boundedSeam.next?.request,
+        "trace",
+        "and the continuation is another graph call, not an escape",
+      );
+      assert.notEqual(
+        boundedSeam.next?.reason,
+        exhausted.next?.reason,
+        "the bound must not be narrated as a proven disconnection",
+      );
+      assert.notEqual(
+        boundedSeam.next?.reason,
+        junctioned.next?.reason,
+        "nor as a callback seam, when a direct path runs past the bound",
+      );
+      assert.equal(
+        boundedSeam.result!.junctions,
+        undefined,
+        "a junction explains an absence, and no absence was established",
+      );
+
+      const foundSeam = await call({
+        from: "seamStart",
+        to: "seamEnd",
+        focus: "all",
+        maxDepth: 3,
+      });
+      assert.equal(
+        foundSeam.next?.action,
+        "answer",
+        "the same query at the path's own length is unchanged",
+      );
+      assert.equal(
+        foundSeam.result!.hops.length,
+        3,
+        "and returns the whole path",
+      );
+
+      const overCeiling = await call({
+        from: "n0",
+        to: `n${OVER_CEILING_HOPS}`,
+        focus: "execution",
+        maxDepth: 12,
+      });
+      assert.notEqual(
+        overCeiling.next?.action,
+        "outside",
+        "a path longer than the hard ceiling is not reported as absent",
+      );
+      assert.notEqual(
+        overCeiling.next?.reason,
+        boundedSeam.next?.reason,
+        "at the ceiling the continuation cannot be 'raise maxDepth'",
+      );
+
+      const underCeiling = await call({
+        from: "n0",
+        to: `n${OVER_CEILING_HOPS - 1}`,
+        focus: "execution",
+        maxDepth: 12,
+      });
+      assert.equal(
+        underCeiling.next?.action,
+        "answer",
+        "the longest answerable path is still answered",
+      );
+      assert.equal(underCeiling.result!.hops.length, OVER_CEILING_HOPS - 1);
+
+      const identity = await call({ from: "apartLeft", to: "apartLeft" });
+      assert.deepEqual(
+        identity.result!.path?.map((node) => node.name),
+        ["apartLeft"],
+        "the identity path is unchanged",
+      );
+      assert.equal(identity.next?.action, "answer");
+
+      const oneHop = await call({
+        from: "n0",
+        to: "n1",
+        focus: "execution",
+        maxDepth: 1,
+      });
+      assert.equal(
+        oneHop.next?.action,
+        "answer",
+        "a path exactly as long as the smallest bound is found",
+      );
+
+      const externalFrontier = await call({
+        from: "edgeStart",
+        to: "apartRight",
+        focus: "execution",
+        maxDepth: 1,
+        includeExternal: false,
+      });
+      assert.equal(
+        externalFrontier.next?.action,
+        "outside",
+        "a frontier of only excluded externals is exhaustion, not a bound",
+      );
+      const externalEligible = await call({
+        from: "edgeStart",
+        to: "apartRight",
+        focus: "execution",
+        maxDepth: 1,
+        includeExternal: true,
+      });
+      assert.equal(
+        externalEligible.next?.action,
+        "inspect",
+        "the same frontier is a bound once those externals are eligible",
+      );
+
+      const cyclic = await call({
+        from: "ringA",
+        to: "apartRight",
+        focus: "execution",
+        maxDepth: 1,
+      });
+      assert.equal(
+        cyclic.next?.action,
+        "outside",
+        "a frontier of only already-visited nodes is exhaustion, not a bound",
+      );
+
+      const boundedTypes = await call({
+        from: "TypeLeaf",
+        to: "TypeBase",
+        focus: "types",
+        maxDepth: 1,
+      });
+      assert.equal(
+        boundedTypes.next?.action,
+        "inspect",
+        "the type focus is bounded by the same rule",
+      );
+      const foundTypes = await call({
+        from: "TypeLeaf",
+        to: "TypeBase",
+        focus: "types",
+        maxDepth: 2,
+      });
+      assert.equal(foundTypes.next?.action, "answer");
+
+      const boundedDispatch = await call({
+        from: "useEmitter",
+        to: "Silent.fire",
+        focus: "execution",
+        maxDepth: 1,
+      });
+      assert.equal(
+        boundedDispatch.next?.action,
+        "inspect",
+        "a synthesized dispatch edge beyond the bound is a frontier like any other",
+      );
+      const foundDispatch = await call({
+        from: "useEmitter",
+        to: "Silent.fire",
+        focus: "execution",
+        maxDepth: 2,
+      });
+      assert.equal(
+        foundDispatch.result!.hops.at(-1)?.kind,
+        "dispatches",
+        `the found path crosses the dispatch: ${JSON.stringify(foundDispatch.result!.hops)}`,
+      );
+    } finally {
+      client.endStdin();
+    }
+
+    const code = await client.waitForExit();
+    assert.equal(
+      code,
+      0,
+      `the launcher exits cleanly\nstderr: ${client.stderrText()}`,
+    );
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_reverse_and_impact_cross_virtual_dispatch.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_reverse_and_impact_cross_virtual_dispatch.ts
@@ -1,0 +1,389 @@
+import { TestProject } from "@ttsc/testing";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  structuredContent?: {
+    result?: TraceResult;
+  };
+}
+
+interface TraceResult {
+  type: "trace";
+  hops: { from: string; to: string; kind: string; depth: number }[];
+  reached: { id: string; name: string; roles?: string[] }[];
+  truncated: boolean;
+}
+
+/** The twelve-implementation cut `dispatchEdges` treats as a hub, not a flow. */
+const HUB_IMPLEMENTATIONS = 12;
+
+/**
+ * Verifies a reverse or impact trace crosses virtual dispatch the same way a
+ * forward trace does, under the forward direction's own eligibility and hub
+ * policy.
+ *
+ * Dispatch was synthesized on the forward side only, so an impact query on a
+ * concrete implementation reached neither the declaration it implements nor any
+ * caller resolved to that declaration, and reported `truncated: false` while
+ * doing it. That is the query an agent runs before changing a method, and the
+ * omission compounds: the base's callers, their callers, the exported surface,
+ * and the tests that exercise them all go missing at once. The checker relation
+ * is oriented implementation-to-base, so both halves of the path sit one step
+ * away in a direction reverse traversal does not take.
+ *
+ * 1. Materialize an interface with a checker-valid and a checker-rejected
+ *    implementation, an abstract base whose override closes a cycle, an
+ *    unrelated method, an external heritage leaf, and a twelve-implementation
+ *    hub.
+ * 2. Issue reverse and impact traces from the implementations through the real MCP
+ *    launcher, plus the forward and `focus: "types"` controls.
+ * 3. Assert the valid seam is crossed in reverse with roles tagged, that the
+ *    rejected pair, the external endpoint, and the hub stay governed by the
+ *    forward policy, and that bounds and cycles behave as before.
+ */
+export const test_ttscgraph_reverse_and_impact_cross_virtual_dispatch =
+  async () => {
+    const hubImplementations = Array.from(
+      { length: HUB_IMPLEMENTATIONS },
+      (_unused, index) =>
+        [
+          `export class Widget${index} implements Widget {`,
+          "  public draw(): void {}",
+          "}",
+          "",
+        ].join("\n"),
+    ).join("");
+
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify(
+        {
+          compilerOptions: {
+            target: "ES2022",
+            module: "commonjs",
+            moduleResolution: "node",
+            strict: true,
+            rootDir: "src",
+            outDir: "dist",
+          },
+          include: ["src"],
+        },
+        null,
+        2,
+      ),
+      "node_modules/graph-dependency/package.json": JSON.stringify({
+        name: "graph-dependency",
+        version: "1.0.0",
+        types: "index.d.ts",
+      }),
+      "node_modules/graph-dependency/index.d.ts":
+        "export interface Contract {\n  settle(): void;\n}\n",
+      "src/app.ts": [
+        'import { Contract } from "graph-dependency";',
+        "",
+        "export function accepted(): void {}",
+        "export function rejected(): void {}",
+        "",
+        "export interface Pipeline {",
+        "  execute(input: number): void;",
+        "}",
+        "",
+        "export class Good implements Pipeline {",
+        "  public execute(input: number): void {",
+        "    accepted();",
+        "  }",
+        "}",
+        "",
+        "export class Bad implements Pipeline {",
+        "  public execute(input: string): void {",
+        "    rejected();",
+        "  }",
+        "}",
+        "",
+        "export class Runner {",
+        "  public constructor(private readonly pipeline: Pipeline) {}",
+        "",
+        "  public run(): void {",
+        "    this.pipeline.execute(1);",
+        "  }",
+        "}",
+        "",
+        "export function main(runner: Runner): void {",
+        "  runner.run();",
+        "}",
+        "",
+        "export abstract class Task {",
+        "  public abstract perform(): void;",
+        "}",
+        "",
+        "export class RealTask extends Task {",
+        "  public perform(): void {",
+        "    startTask(this);",
+        "  }",
+        "}",
+        "",
+        "export function startTask(task: Task): void {",
+        "  task.perform();",
+        "}",
+        "",
+        "export class Alone {",
+        "  public solo(): void {}",
+        "}",
+        "",
+        "export function callSolo(alone: Alone): void {",
+        "  alone.solo();",
+        "}",
+        "",
+        "export class Settlement implements Contract {",
+        "  public settle(): void {}",
+        "}",
+        "",
+        "export interface Widget {",
+        "  draw(): void;",
+        "}",
+        "",
+        hubImplementations,
+        "export function paint(widget: Widget): void {",
+        "  widget.draw();",
+        "}",
+        "",
+      ].join("\n"),
+      "src/app.test.ts": [
+        'import { main, Runner } from "./app";',
+        "",
+        "export function exercisesMain(runner: Runner): void {",
+        "  main(runner);",
+        "}",
+        "",
+      ].join("\n"),
+    });
+
+    const client = TtsgraphClient.start(root);
+    try {
+      await client.request("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-graph", version: "0.0.0" },
+      });
+      client.notify("notifications/initialized", {});
+
+      const call = async (
+        request: Record<string, unknown>,
+      ): Promise<TraceResult> => {
+        const response = (await client.request("tools/call", {
+          name: "inspect_typescript_graph",
+          arguments: {
+            question: "What does changing this implementation reach?",
+            draft: {
+              reason: "A trace is the smallest step for a blast radius.",
+              type: "trace",
+            },
+            review: "Confirmed: answer from the trace's graph facts.",
+            request: { type: "trace", ...request },
+          },
+        })) as ToolResult;
+        const trace = response.structuredContent?.result;
+        assert.equal(
+          trace?.type,
+          "trace",
+          `expected a trace result: ${JSON.stringify(response)}`,
+        );
+        return trace!;
+      };
+
+      const names = (trace: TraceResult): string[] =>
+        trace.reached.map((node) => node.name);
+      const dispatchHops = (trace: TraceResult): number =>
+        trace.hops.filter((hop) => hop.kind === "dispatches").length;
+
+      for (const direction of ["reverse", "impact"]) {
+        for (const focus of ["execution", "all"]) {
+          const crossed = await call({
+            from: "Good.execute",
+            direction,
+            focus,
+            maxDepth: 4,
+            maxNodes: 12,
+          });
+          const reached = names(crossed);
+          for (const expected of ["Pipeline.execute", "Runner.run", "main"])
+            assert.ok(
+              reached.includes(expected),
+              `${direction}/${focus} crosses the seam to ${expected}: ${reached.join(", ")}`,
+            );
+          assert.ok(
+            dispatchHops(crossed) > 0,
+            `${direction}/${focus} records the crossing as a dispatches hop: ${JSON.stringify(crossed.hops)}`,
+          );
+        }
+      }
+
+      const impact = await call({
+        from: "Good.execute",
+        direction: "impact",
+        focus: "execution",
+        maxDepth: 4,
+        maxNodes: 16,
+      });
+      assert.ok(
+        impact.reached
+          .find((node) => node.name === "main")
+          ?.roles?.includes("exported"),
+        `impact tags the public surface it now reaches: ${JSON.stringify(impact.reached)}`,
+      );
+      assert.ok(
+        impact.reached.some((node) => node.roles?.includes("test")),
+        `impact tags the test that exercises the newly reached callers: ${JSON.stringify(impact.reached)}`,
+      );
+
+      const abstractOverride = await call({
+        from: "RealTask.perform",
+        direction: "reverse",
+        focus: "execution",
+        maxDepth: 4,
+        maxNodes: 12,
+      });
+      const overrideReached = names(abstractOverride);
+      for (const expected of ["Task.perform", "startTask"])
+        assert.ok(
+          overrideReached.includes(expected),
+          `an abstract-method override crosses back to ${expected}: ${overrideReached.join(", ")}`,
+        );
+      const signatures = abstractOverride.hops.map(
+        (hop) => `${hop.from}|${hop.to}|${hop.kind}`,
+      );
+      assert.equal(
+        signatures.length,
+        new Set(signatures).size,
+        `a cycle through an implementation and its base records no duplicate hop: ${signatures.join(", ")}`,
+      );
+
+      const invalid = await call({
+        from: "Bad.execute",
+        direction: "reverse",
+        focus: "execution",
+        maxDepth: 4,
+        maxNodes: 12,
+      });
+      assert.ok(
+        !names(invalid).includes("Pipeline.execute"),
+        `a checker-rejected member stays disconnected in reverse: ${names(invalid).join(", ")}`,
+      );
+
+      const unrelated = await call({
+        from: "Alone.solo",
+        direction: "reverse",
+        focus: "execution",
+        maxDepth: 4,
+        maxNodes: 12,
+      });
+      assert.deepEqual(
+        names(unrelated),
+        ["callSolo"],
+        "a method with no member relation reverses exactly as before",
+      );
+
+      const externalFiltered = await call({
+        from: "Settlement",
+        direction: "reverse",
+        focus: "all",
+        includeExternal: false,
+        maxDepth: 2,
+        maxNodes: 12,
+      });
+      assert.ok(
+        !names(externalFiltered).includes("Contract"),
+        `an external declaration stays filtered in reverse: ${names(externalFiltered).join(", ")}`,
+      );
+      const externalIncluded = await call({
+        from: "Settlement",
+        direction: "reverse",
+        focus: "all",
+        includeExternal: true,
+        maxDepth: 2,
+        maxNodes: 12,
+      });
+      assert.ok(
+        names(externalIncluded).includes("Contract"),
+        `the same endpoint is reached when externals are eligible: ${names(externalIncluded).join(", ")}`,
+      );
+
+      const hubForward = await call({
+        from: "paint",
+        direction: "forward",
+        focus: "execution",
+        maxDepth: 3,
+        maxNodes: 16,
+      });
+      assert.equal(
+        dispatchHops(hubForward),
+        0,
+        `a hub declaration stays a leaf going forward: ${JSON.stringify(hubForward.hops)}`,
+      );
+      const hubReverse = await call({
+        from: "Widget0.draw",
+        direction: "reverse",
+        focus: "execution",
+        maxDepth: 3,
+        maxNodes: 16,
+      });
+      assert.equal(
+        dispatchHops(hubReverse),
+        0,
+        `reverse applies the same hub policy: ${JSON.stringify(hubReverse.hops)}`,
+      );
+
+      const bounded = await call({
+        from: "Good.execute",
+        direction: "reverse",
+        focus: "execution",
+        maxDepth: 1,
+        maxNodes: 12,
+      });
+      assert.deepEqual(
+        names(bounded),
+        ["Pipeline.execute"],
+        "the depth bound governs the synthesized edge like any other",
+      );
+      assert.equal(
+        bounded.truncated,
+        true,
+        "and the omission beyond that bound is reported",
+      );
+
+      const typed = await call({
+        from: "Good.execute",
+        direction: "reverse",
+        focus: "types",
+        maxDepth: 4,
+        maxNodes: 12,
+      });
+      assert.equal(
+        dispatchHops(typed),
+        0,
+        `\`focus: "types"\` reverse is unchanged: ${JSON.stringify(typed.hops)}`,
+      );
+
+      const forward = await call({
+        from: "Runner.run",
+        direction: "forward",
+        focus: "execution",
+        maxDepth: 4,
+        maxNodes: 12,
+      });
+      assert.ok(
+        names(forward).includes("Good.execute") &&
+          names(forward).includes("accepted"),
+        `the forward direction is unchanged: ${names(forward).join(", ")}`,
+      );
+    } finally {
+      client.endStdin();
+    }
+
+    const code = await client.waitForExit();
+    assert.equal(
+      code,
+      0,
+      `the launcher exits cleanly\nstderr: ${client.stderrText()}`,
+    );
+  };

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -49,6 +49,10 @@ When a handle names several declarations, the graph scores every match by export
 
 In path mode, tracing a symbol to itself is a complete one-node path with no hops. In an open trace, `truncated` means an eligible node or relationship was left out by the depth, node, or hop bound. Reaching the configured depth on a leaf, or seeing only relationships excluded by the selected focus or external-node policy, remains complete.
 
+When path mode finds nothing, it says which of two things happened. A walk that ran the eligible graph out reports that the graph holds no connection between the two ends. A walk that stopped on the requested `maxDepth` with graph still ahead of it reports the bound and how to continue, because a boundary is a fact about the request, not about the code.
+
+A call that lands on a declaration with no body of its own (an interface member, an abstract method, an ambient declaration) continues into the implementations that run, as a `dispatches` hop cited at the implementation. Bodilessness is read from the declaration, so an implementation that calls nothing is still the code that runs, and a concrete method that has a body is the destination rather than a stop on the way to its own override. Reverse and impact traces cross the same seam the other way, so changing an implementation reaches the declaration it implements and everything that calls that declaration.
+
 A tree-sitter graph has no types and resolves edges by guessing from text. An editor's language server has types but no architecture projection. Only a graph built on the real checker holds the resolved structure and the affected set in one place. Every node and edge is resolved by the compiler, so an agent never mistakes inference for fact.
 
 ### What only the compiler can resolve


### PR DESCRIPTION
Campaign batch **B1 — Graph traversal**. One branch, one pull request, three issues, all in `packages/graph/src/server/runTrace.ts`.

- Closes #828 — dispatch decides "has a body" from outgoing-edge degree instead of declaration facts.
- Closes #829 — reverse and impact traces never cross verified virtual dispatch.
- Closes #827 — path mode reports a depth-bounded miss as a proven global disconnection.

## Landing order inside the batch

1. **#828 first.** It settles the rule the rest of the batch reads: dispatch continues only from a genuinely bodyless declaration (an interface member, an abstract member, an ambient or `declare`d declaration, a declaration-file declaration, an external leaf), and a concrete declaration with a body is a real destination that is never promoted through an override — whatever its dependency degree.
2. **#829 second.** Reverse dispatch mirrors #828's settled rule by reusing the same forward candidate builder rather than reimplementing it, so eligibility, checker validity and the hub cap cannot diverge between directions.
3. **#827 last.** It is independent of dispatch, but it judges the path-mode frontier, and landing it after #828 means the frontier it judges already contains corrected dispatch edges.

## Not in this batch

Published issue #784 (dispatch-hub omissions reported as trace truncation) is **not** implemented here. The `DISPATCH_HUB` cap keeps its current silent-suppression behaviour in both directions.

## Verification

Campaign CI is deliberately suspended; every push passes the exact-SHA cancellation gate and the tables are recorded in the campaign knowledge base. Local, package-scoped verification is recorded in the thread.

## Protected contract

`packages/graph/src/structures/` stays byte-identical. No structure, field, edge kind or JSDoc is touched, and `pnpm format` is not run on this branch.
