### PR TITLE
fix(ttscserver): decide JSDoc completion scope by lexical scan

### DIFF
--- a/packages/ttsc/internal/lspserver/lsp_completion.go
+++ b/packages/ttsc/internal/lspserver/lsp_completion.go
@@ -59,31 +59,6 @@ func completionHintApplies(
   return strings.Contains(linePrefix, hint.After)
 }
 
-// cursorInJSDoc reports whether an offset sits inside a `/** */` block.
-//
-// A plain backward scan for the nearest `/**` or `*/`, which is enough because
-// the question is only ever asked about the cursor. It deliberately does not
-// parse: the proxy holds text, not a tree, and reaching for tsgo's parser here
-// would put a round trip on the keystroke path — the exact cost this design
-// exists to avoid.
-//
-// Line comments are not considered: `// @evidence` is not a doc comment and a
-// tag there means nothing to the rule that published the hint.
-func cursorInJSDoc(text string, offset int) bool {
-  if offset < 0 || offset > len(text) {
-    return false
-  }
-  head := text[:offset]
-  open := strings.LastIndex(head, "/**")
-  if open == -1 {
-    return false
-  }
-  close := strings.LastIndex(head, "*/")
-  // `/**` is itself followed by no `*/` yet, or the last close precedes the
-  // last open — either way the cursor is still inside the block.
-  return close < open
-}
-
 // linePrefixAt returns the text from the start of the cursor's line up to the
 // cursor.
 //

--- a/packages/ttsc/internal/lspserver/lsp_completion_refuses_hints_inside_a_string_literal_test.go
+++ b/packages/ttsc/internal/lspserver/lsp_completion_refuses_hints_inside_a_string_literal_test.go
@@ -1,0 +1,69 @@
+package lspserver
+
+import (
+  "encoding/json"
+  "testing"
+)
+
+type jsdocTagCompletionHintSource struct{ NullPluginSource }
+
+func (jsdocTagCompletionHintSource) CompletionHints() []LSPCompletionHint {
+  return []LSPCompletionHint{{
+    Scope: "jsdoc",
+    After: "@",
+    Items: []LSPCompletionItem{{Insert: "param"}},
+  }}
+}
+
+// TestLSPCompletionRefusesHintsInsideAStringLiteral verifies the scope decision
+// where it is observable.
+//
+// The lexical table proves the scanner; this proves the request path still asks
+// it. A refactor that recomputed scope from the line prefix, or that passed the
+// wrong offset, would put `jsdoc/check-tag-names` tags into ordinary source
+// text — a position the owning rule never inspects — and no unit test of the
+// matcher alone would notice.
+//
+//  1. Ask for completion after `@par` inside a string literal that contains the
+//     JSDoc opener.
+//  2. Ask again at the same tag inside a real doc comment.
+//  3. Assert silence for the first and the published item for the second.
+func TestLSPCompletionRefusesHintsInsideAStringLiteral(t *testing.T) {
+  const literalURI = "file:///project/src/literal.ts"
+  const blockURI = "file:///project/src/block.ts"
+  proxy := &Proxy{
+    source: jsdocTagCompletionHintSource{},
+    documentText: map[string]string{
+      literalURI: "const example = \"/** @par\";\n",
+      blockURI:   "/**\n * @par\n */\nexport const value = 1;\n",
+    },
+  }
+
+  literalParams, err := json.Marshal(map[string]any{
+    "textDocument": map[string]any{"uri": literalURI},
+    "position":     map[string]any{"line": 0, "character": 25},
+  })
+  if err != nil {
+    t.Fatalf("encode completion params: %v", err)
+  }
+  if pending := proxy.completionItemsFor(Envelope{Params: literalParams}); len(pending.items) != 0 {
+    t.Errorf("a string literal was offered %v, want nothing", inserts(pending.items))
+  }
+
+  blockParams, err := json.Marshal(map[string]any{
+    "textDocument": map[string]any{"uri": blockURI},
+    "position":     map[string]any{"line": 1, "character": 7},
+  })
+  if err != nil {
+    t.Fatalf("encode completion params: %v", err)
+  }
+  pending := proxy.completionItemsFor(Envelope{Params: blockParams})
+  if got := inserts(pending.items); !equalStrings(got, []string{"param"}) {
+    t.Fatalf("a real doc comment was offered %v, want [param]", got)
+  }
+  // The refusal must not have come from a broken filter range either.
+  if pending.replaceRange.Start != (LSPPosition{Line: 1, Character: 4}) ||
+    pending.replaceRange.End != (LSPPosition{Line: 1, Character: 7}) {
+    t.Errorf("replacement range = %+v, want character 4..7", pending.replaceRange)
+  }
+}

--- a/packages/ttsc/internal/lspserver/lsp_completion_scope.go
+++ b/packages/ttsc/internal/lspserver/lsp_completion_scope.go
@@ -1,0 +1,320 @@
+package lspserver
+
+// lexicalScope names the kind of token a byte offset sits in.
+//
+// It is what a scanner can decide without a parse: comments, string and
+// template literals, and regular expression literals all carry text that is not
+// code, and every one of them can hold bytes that look like a comment
+// delimiter.
+type lexicalScope int
+
+const (
+  lexicalScopeCode lexicalScope = iota
+  lexicalScopeLineComment
+  lexicalScopeBlockComment
+  lexicalScopeJSDoc
+  lexicalScopeString
+  lexicalScopeTemplate
+  lexicalScopeRegex
+)
+
+func (scope lexicalScope) String() string {
+  switch scope {
+  case lexicalScopeLineComment:
+    return "line comment"
+  case lexicalScopeBlockComment:
+    return "block comment"
+  case lexicalScopeJSDoc:
+    return "jsdoc"
+  case lexicalScopeString:
+    return "string"
+  case lexicalScopeTemplate:
+    return "template"
+  case lexicalScopeRegex:
+    return "regex"
+  default:
+    return "code"
+  }
+}
+
+// cursorInJSDoc reports whether an offset sits inside a `/** */` block.
+//
+// Line comments are not considered: `// @evidence` is not a doc comment and a
+// tag there means nothing to the rule that published the hint.
+func cursorInJSDoc(text string, offset int) bool {
+  if offset < 0 || offset > len(text) {
+    return false
+  }
+  return lexicalScopeAt(text, offset) == lexicalScopeJSDoc
+}
+
+// lexicalScopeAt reports the scope of the byte at offset, scanning forward from
+// the start of the document.
+//
+// A backward search for the nearest `/**` cannot answer the question, because
+// the same three bytes appear in `const example = "/** @par"` — and answering
+// "jsdoc" there offers a JSDoc rule's tags in the middle of a string literal.
+// Comment state is not a property of the bytes before the cursor; it is a
+// property of the token stream that produced them, so the scan starts where the
+// token stream does.
+//
+// It stays a scanner rather than a parse. The proxy holds text, not a tree, and
+// asking tsgo would put a round trip on the keystroke path — the exact cost this
+// design exists to avoid. Forward scanning costs one pass over the prefix, the
+// same complexity the backward search it replaced already had: a few
+// milliseconds per megabyte, so well under a millisecond for an ordinary source
+// file (see BenchmarkCursorInJSDoc). That is small enough beside the upstream
+// completion round trip the same request makes, so the scan is recomputed per
+// request instead of a span cache having to be invalidated per didChange.
+//
+// Recovery matters as much as recognition here, because the buffer is live and
+// therefore usually not valid TypeScript. An unterminated string ends at the
+// line break, exactly as the TypeScript scanner recovers, so a stray apostrophe
+// mid-edit cannot swallow every JSDoc block below it.
+//
+// One boundary stays with the scanner: JSX element text is read as code, so
+// `/**` typed between JSX tags still opens a comment here. Separating JSX text
+// from a comparison operator needs the grammar, which is the parse this pass
+// exists to avoid, and the position is far rarer than the literals above.
+func lexicalScopeAt(text string, offset int) lexicalScope {
+  if offset > len(text) {
+    offset = len(text)
+  }
+  scope := lexicalScopeCode
+  quote := byte(0)
+  // braces counts the `{` depth of the current code region, and templateBraces
+  // remembers the enclosing depth per open `${`, so the `}` that ends an
+  // interpolation is told apart from the `}` that ends an object literal in it.
+  braces := 0
+  templateBraces := []int{}
+  // last is the most recent significant code byte. It is the only context the
+  // `/` ambiguity needs: division after a value, a regex literal otherwise.
+  last := byte(0)
+
+  index := 0
+  for index < offset {
+    symbol := text[index]
+    switch scope {
+    case lexicalScopeCode:
+      // A switch on the byte itself, so the overwhelmingly common case — a byte
+      // that starts no literal and no comment — costs one jump rather than a
+      // walk through every delimiter test.
+      switch symbol {
+      case '/':
+        next := byte(0)
+        if index+1 < len(text) {
+          next = text[index+1]
+        }
+        switch {
+        case next == '*':
+          // `/**/` is an empty block comment, not a JSDoc block; TypeScript
+          // reads the third `*` as part of the terminator.
+          if index+2 < len(text) && text[index+2] == '*' &&
+            (index+3 >= len(text) || text[index+3] != '/') {
+            scope = lexicalScopeJSDoc
+          } else {
+            scope = lexicalScopeBlockComment
+          }
+          index += 2
+        case next == '/':
+          scope = lexicalScopeLineComment
+          index += 2
+        default:
+          // A comment opener already won above, so this `/` can only be
+          // division or a regex literal. Skipping the literal keeps a class
+          // such as `/["'/*]/` from opening a string or a comment that the
+          // source never wrote.
+          end := -1
+          if regexAllowedAfter(text[:index], last) {
+            end = regexLiteralEnd(text, index)
+          }
+          if end == -1 {
+            // Division, or no terminator before the line ended.
+            last = symbol
+            index++
+            break
+          }
+          if offset < end {
+            return lexicalScopeRegex
+          }
+          last = symbol
+          index = end
+        }
+      case '"', '\'':
+        scope = lexicalScopeString
+        quote = symbol
+        last = symbol
+        index++
+      case '`':
+        scope = lexicalScopeTemplate
+        last = symbol
+        index++
+      case '{':
+        braces++
+        last = symbol
+        index++
+      case '}':
+        if braces > 0 {
+          braces--
+        } else if depth := len(templateBraces); depth > 0 {
+          braces = templateBraces[depth-1]
+          templateBraces = templateBraces[:depth-1]
+          scope = lexicalScopeTemplate
+        }
+        last = symbol
+        index++
+      default:
+        // Every whitespace byte is below `' '`, and so is every control byte
+        // that could not precede a regex either.
+        if symbol > ' ' {
+          last = symbol
+        }
+        index++
+      }
+    case lexicalScopeLineComment:
+      if symbol == '\n' {
+        scope = lexicalScopeCode
+      }
+      index++
+    case lexicalScopeBlockComment, lexicalScopeJSDoc:
+      if symbol == '*' && index+1 < len(text) && text[index+1] == '/' {
+        scope = lexicalScopeCode
+        index += 2
+        break
+      }
+      index++
+    case lexicalScopeString:
+      switch {
+      case symbol == '\\':
+        index += escapeWidth(text, index)
+      case symbol == quote:
+        scope = lexicalScopeCode
+        index++
+      case symbol == '\n' || symbol == '\r':
+        scope = lexicalScopeCode
+        index++
+      default:
+        index++
+      }
+    case lexicalScopeTemplate:
+      switch {
+      case symbol == '\\':
+        index += escapeWidth(text, index)
+      case symbol == '`':
+        scope = lexicalScopeCode
+        last = symbol
+        index++
+      case symbol == '$' && index+1 < len(text) && text[index+1] == '{':
+        templateBraces = append(templateBraces, braces)
+        braces = 0
+        scope = lexicalScopeCode
+        last = '{'
+        index += 2
+      default:
+        index++
+      }
+    }
+  }
+  return scope
+}
+
+// escapeWidth returns how many bytes a backslash escape consumes, counting a
+// CRLF line continuation as one unit so the `\n` cannot be mistaken for the
+// unterminated-literal recovery point.
+func escapeWidth(text string, index int) int {
+  if index+2 < len(text) && text[index+1] == '\r' && text[index+2] == '\n' {
+    return 3
+  }
+  return 2
+}
+
+// regexAllowedAfter reports whether a `/` at this position can open a regular
+// expression literal rather than divide.
+//
+// The distinction needs the previous token, which is exactly what `last`
+// carries. A value — identifier, number, string, or a closing bracket — can be
+// divided, so `/` after one is an operator; everything else is an expression
+// position where only a literal fits. The keyword check exists because
+// `return /re/` ends in an identifier byte yet is an expression position.
+func regexAllowedAfter(head string, last byte) bool {
+  switch {
+  case last == 0:
+    return true
+  case isIdentifierByte(last):
+    return regexKeywordPrecedes(head)
+  case last == ')' || last == ']' || last == '}':
+    return false
+  case last == '"' || last == '\'' || last == '`':
+    return false
+  default:
+    return true
+  }
+}
+
+func regexKeywordPrecedes(head string) bool {
+  end := len(head)
+  for end > 0 && isSpaceByte(head[end-1]) {
+    end--
+  }
+  start := end
+  for start > 0 && isIdentifierByte(head[start-1]) {
+    start--
+  }
+  switch head[start:end] {
+  case "await", "case", "delete", "do", "else", "in", "instanceof", "new",
+    "of", "return", "throw", "typeof", "void", "yield":
+    return true
+  default:
+    return false
+  }
+}
+
+// regexLiteralEnd returns the offset just past a regular expression literal
+// that starts at index, or -1 when the text is not one.
+//
+// A regex literal cannot span a line, so an unterminated scan means the `/` was
+// division after all and the caller resumes there. The `[...]` class is tracked
+// because an unescaped `/` inside one does not terminate the literal.
+func regexLiteralEnd(text string, index int) int {
+  inClass := false
+  for cursor := index + 1; cursor < len(text); cursor++ {
+    switch text[cursor] {
+    case '\\':
+      cursor++
+    case '\n', '\r':
+      return -1
+    case '[':
+      inClass = true
+    case ']':
+      inClass = false
+    case '/':
+      if !inClass {
+        // Flags are identifier bytes; code scope reads them harmlessly.
+        return cursor + 1
+      }
+    }
+  }
+  return -1
+}
+
+func isIdentifierByte(symbol byte) bool {
+  switch {
+  case symbol >= 'a' && symbol <= 'z':
+    return true
+  case symbol >= 'A' && symbol <= 'Z':
+    return true
+  case symbol >= '0' && symbol <= '9':
+    return true
+  case symbol == '_' || symbol == '$':
+    return true
+  default:
+    // Every byte of a non-ASCII rune belongs to an identifier or to literal
+    // text; either way it is not an operator that could precede a regex.
+    return symbol >= 0x80
+  }
+}
+
+func isSpaceByte(symbol byte) bool {
+  return symbol == ' ' || symbol == '\t' || symbol == '\r' || symbol == '\n' ||
+    symbol == '\v' || symbol == '\f'
+}

--- a/packages/ttsc/internal/lspserver/lsp_completion_scope.go
+++ b/packages/ttsc/internal/lspserver/lsp_completion_scope.go
@@ -86,7 +86,7 @@ func lexicalScopeAt(text string, offset int) lexicalScope {
   // remembers the enclosing depth per open `${`, so the `}` that ends an
   // interpolation is told apart from the `}` that ends an object literal in it.
   braces := 0
-  templateBraces := []int{}
+  var templateBraces []int
   // last is the most recent significant code byte. It is the only context the
   // `/` ambiguity needs: division after a value, a regex literal otherwise.
   last := byte(0)
@@ -172,7 +172,9 @@ func lexicalScopeAt(text string, offset int) lexicalScope {
         index++
       }
     case lexicalScopeLineComment:
-      if symbol == '\n' {
+      // CR ends a line for TypeScript too, so a CR-only buffer cannot leave the
+      // rest of the file inside one `//`.
+      if symbol == '\n' || symbol == '\r' {
         scope = lexicalScopeCode
       }
       index++
@@ -246,6 +248,10 @@ func regexAllowedAfter(head string, last byte) bool {
     return false
   case last == '"' || last == '\'' || last == '`':
     return false
+  case last == '/':
+    // The byte a completed regex literal leaves behind. A literal is a value,
+    // so what follows it divides.
+    return false
   default:
     return true
   }
@@ -259,6 +265,11 @@ func regexKeywordPrecedes(head string) bool {
   start := end
   for start > 0 && isIdentifierByte(head[start-1]) {
     start--
+  }
+  if start > 0 && head[start-1] == '.' {
+    // `in`, `of`, `new`, and the rest are legal property names, and a member
+    // access is a value: `obj.in / 2` divides.
+    return false
   }
   switch head[start:end] {
   case "await", "case", "delete", "do", "else", "in", "instanceof", "new",

--- a/packages/ttsc/internal/lspserver/lsp_completion_scope_bench_test.go
+++ b/packages/ttsc/internal/lspserver/lsp_completion_scope_bench_test.go
@@ -1,0 +1,41 @@
+package lspserver
+
+import (
+  "strings"
+  "testing"
+)
+
+// BenchmarkCursorInJSDoc measures the scope decision on the completion hot path.
+//
+// Completion asks it per request on the live buffer, so its cost has to stay
+// small against the round trip to tsgo that the same request makes. The buffer
+// here is deliberately larger than a real source file and the cursor sits at its
+// end, which is the worst case for a forward scan: the whole prefix is walked.
+//
+// Usage:
+//
+//  go test ./internal/lspserver -run=^$ -bench=^BenchmarkCursorInJSDoc$
+func BenchmarkCursorInJSDoc(b *testing.B) {
+  chunk := strings.Join([]string{
+    "/**",
+    " * Greets one user.",
+    " * @param name user name",
+    " */",
+    "export function greet(name: string): string {",
+    "  const quoted = \"/** not a doc comment */\";",
+    "  const pattern = /[\"'/*]/;",
+    "  return `Hello, ${name}${quoted.length / 2}`;",
+    "}",
+    "",
+  }, "\n")
+  text := strings.Repeat(chunk, 1+1024*1024/len(chunk))
+  text += "\n/**\n * @par"
+
+  b.SetBytes(int64(len(text)))
+  b.ResetTimer()
+  for range b.N {
+    if !cursorInJSDoc(text, len(text)) {
+      b.Fatal("the trailing doc comment must be in scope")
+    }
+  }
+}

--- a/packages/ttsc/internal/lspserver/lsp_completion_scope_ignores_jsdoc_bytes_in_literals_test.go
+++ b/packages/ttsc/internal/lspserver/lsp_completion_scope_ignores_jsdoc_bytes_in_literals_test.go
@@ -8,9 +8,9 @@ import "testing"
 // `/**` is three ordinary bytes. A string, a template, a regex class, and a line
 // comment can all contain them, and a backward search for the nearest opener
 // calls every one of those positions a doc comment — which is how
-// `const example = "/** @par"` came to be offered JSDoc tag completions. The
-// cases below are chosen so each one fails under that backward search or under a
-// scanner that drops one of its recovery rules.
+// `const example = "/** @par"` came to be offered JSDoc tag completions. Every
+// impostor below is a position that search answered wrongly; every real block
+// below is what stops a replacement from passing by refusing everything.
 //
 //  1. Put the cursor after JSDoc-shaped bytes in every token kind that can hold
 //     them.
@@ -52,6 +52,9 @@ func TestLSPCompletionScopeIgnoresJSDocBytesInLiterals(t *testing.T) {
     {name: "escaped quote inside string", text: "const x = 'it\\'s /** @par", want: lexicalScopeString},
     // An escaped backslash does end it, so the block that follows is real.
     {name: "escaped backslash ends the string", text: "const x = \"a\\\\\" /** @par", want: lexicalScopeJSDoc},
+    // A backslash before CRLF is one line continuation, so the string keeps
+    // going and the line-end recovery must not fire on that `\n`.
+    {name: "escaped crlf continues the string", text: "const s = \"a\\\r\nb /** @par", want: lexicalScopeString},
     {name: "block after a string holding the opener", text: "const x = \"/**\";\n/** @par", want: lexicalScopeJSDoc},
     // A `*/` inside a string closes nothing, so the block after it still opens.
     {name: "block after a string holding the terminator", text: "const x = \"*/\";\n/** @par", want: lexicalScopeJSDoc},
@@ -91,7 +94,8 @@ func TestLSPCompletionScopeIgnoresJSDocBytesInLiterals(t *testing.T) {
     t.Errorf("a cursor before the opener is in %s, want code", got)
   }
   // A cursor inside a terminated regex literal is inside the literal, not in
-  // the comment its bytes spell.
+  // the comment its bytes spell. Offset 15 is the second `*` of the character
+  // class, the byte a backward search reads as an open doc comment.
   if got := lexicalScopeAt("const re = /[/**]/; @par", 15); got != lexicalScopeRegex {
     t.Errorf("a cursor inside a regex literal is in %s, want regex", got)
   }

--- a/packages/ttsc/internal/lspserver/lsp_completion_scope_ignores_jsdoc_bytes_in_literals_test.go
+++ b/packages/ttsc/internal/lspserver/lsp_completion_scope_ignores_jsdoc_bytes_in_literals_test.go
@@ -1,0 +1,96 @@
+package lspserver
+
+import "testing"
+
+// TestLSPCompletionScopeIgnoresJSDocBytesInLiterals pins the lexical table the
+// JSDoc scope decision rests on.
+//
+// `/**` is three ordinary bytes. A string, a template, a regex class, and a line
+// comment can all contain them, and a backward search for the nearest opener
+// calls every one of those positions a doc comment — which is how
+// `const example = "/** @par"` came to be offered JSDoc tag completions. The
+// cases below are chosen so each one fails under that backward search or under a
+// scanner that drops one of its recovery rules.
+//
+//  1. Put the cursor after JSDoc-shaped bytes in every token kind that can hold
+//     them.
+//  2. Assert the scanner's scope and the `cursorInJSDoc` answer derived from it.
+//  3. Keep a real block adjacent to each impostor, so a scanner that simply
+//     refused everything could not pass.
+func TestLSPCompletionScopeIgnoresJSDocBytesInLiterals(t *testing.T) {
+  cases := []struct {
+    name string
+    text string
+    want lexicalScope
+  }{
+    {name: "real block", text: "/** @par", want: lexicalScopeJSDoc},
+    {name: "multi line block", text: "/**\n * ok\n * @par", want: lexicalScopeJSDoc},
+    // The buffer an editor sends on Windows, with prose the rule may cite.
+    {name: "crlf block with non ascii prose", text: "/**\r\n * 가격 😀\r\n * @par", want: lexicalScopeJSDoc},
+    {name: "closed block", text: "/** ok */ @par", want: lexicalScopeCode},
+    {name: "empty block comment", text: "/**/ @par", want: lexicalScopeCode},
+    {name: "plain block comment", text: "/* @par", want: lexicalScopeBlockComment},
+    {name: "line comment", text: "// /** @par", want: lexicalScopeLineComment},
+    {name: "no delimiter", text: "const x = 1; @par", want: lexicalScopeCode},
+
+    {name: "double quoted string", text: "const x = \"/** @par", want: lexicalScopeString},
+    {name: "single quoted string", text: "const x = '/** @par", want: lexicalScopeString},
+    {name: "template literal", text: "const x = `/** @par", want: lexicalScopeTemplate},
+    // The interpolation returns to code, so the template text after it is still
+    // template text.
+    {name: "template after interpolation", text: "const x = `${ y } /** @par", want: lexicalScopeTemplate},
+    {name: "string inside interpolation", text: "const x = `${ \"/** @par", want: lexicalScopeString},
+    {name: "nested template inside interpolation", text: "const x = `${ `inner /** @par", want: lexicalScopeTemplate},
+    // A comment inside an interpolation is a real comment: nesting must not be
+    // answered by refusing everything under a backtick.
+    {name: "block comment inside interpolation", text: "const x = `${ /** @par", want: lexicalScopeJSDoc},
+    // An escaped quote does not end the string.
+    {name: "escaped quote inside string", text: "const x = 'it\\'s /** @par", want: lexicalScopeString},
+    // An escaped backslash does end it, so the block that follows is real.
+    {name: "escaped backslash ends the string", text: "const x = \"a\\\\\" /** @par", want: lexicalScopeJSDoc},
+    {name: "block after a string holding the opener", text: "const x = \"/**\";\n/** @par", want: lexicalScopeJSDoc},
+    // A `*/` inside a string closes nothing, so the block after it still opens.
+    {name: "block after a string holding the terminator", text: "const x = \"*/\";\n/** @par", want: lexicalScopeJSDoc},
+    // The mirror image: a quote inside a doc comment is prose, not a string.
+    {name: "quote inside a block", text: "/** the user's @par", want: lexicalScopeJSDoc},
+    // A live buffer is usually invalid mid-edit. Without line-end recovery one
+    // stray quote would hide every doc comment below it.
+    {name: "unterminated string recovers at the line end", text: "const bad = \"oops\nconst y = 1;\n/** @par", want: lexicalScopeJSDoc},
+
+    {name: "regex class holding the opener", text: "const re = /[/**]/; @par", want: lexicalScopeCode},
+    // Without regex skipping the quote in the class would open a string and
+    // swallow the real block that follows on the same line.
+    {name: "block after a regex holding a quote", text: "const re = /[\"]/; /** @par", want: lexicalScopeJSDoc},
+    {name: "regex after a keyword", text: "function f() { return /[\"]/; } /** @par", want: lexicalScopeJSDoc},
+    // The negative twin: `/` after a value divides, and reading it as a literal
+    // would swallow the block that follows.
+    {name: "division is not a regex", text: "const ratio = a / b; /** @par", want: lexicalScopeJSDoc},
+  }
+
+  for _, entry := range cases {
+    offset := len(entry.text)
+    if got := lexicalScopeAt(entry.text, offset); got != entry.want {
+      t.Errorf("%s: lexicalScopeAt(%q, %d) = %s, want %s", entry.name, entry.text, offset, got, entry.want)
+    }
+    wantJSDoc := entry.want == lexicalScopeJSDoc
+    if got := cursorInJSDoc(entry.text, offset); got != wantJSDoc {
+      t.Errorf("%s: cursorInJSDoc(%q, %d) = %v, want %v", entry.name, entry.text, offset, got, wantJSDoc)
+    }
+  }
+
+  // A cursor before the opener is outside the block the opener will start.
+  if got := lexicalScopeAt("/** @par", 0); got != lexicalScopeCode {
+    t.Errorf("a cursor before the opener is in %s, want code", got)
+  }
+  // A cursor inside a terminated regex literal is inside the literal, not in
+  // the comment its bytes spell.
+  if got := lexicalScopeAt("const re = /[/**]/; @par", 15); got != lexicalScopeRegex {
+    t.Errorf("a cursor inside a regex literal is in %s, want regex", got)
+  }
+
+  // Out-of-range offsets stay refusals rather than panics, because the position
+  // comes from the editor and the buffer from the proxy's own splice.
+  if cursorInJSDoc("/** @par", -1) || cursorInJSDoc("/** @par", 99) {
+    t.Error("an out-of-range offset must be refused rather than answered")
+  }
+}

--- a/packages/ttsc/internal/lspserver/lsp_completion_scope_ignores_jsdoc_bytes_in_literals_test.go
+++ b/packages/ttsc/internal/lspserver/lsp_completion_scope_ignores_jsdoc_bytes_in_literals_test.go
@@ -31,6 +31,10 @@ func TestLSPCompletionScopeIgnoresJSDocBytesInLiterals(t *testing.T) {
     {name: "empty block comment", text: "/**/ @par", want: lexicalScopeCode},
     {name: "plain block comment", text: "/* @par", want: lexicalScopeBlockComment},
     {name: "line comment", text: "// /** @par", want: lexicalScopeLineComment},
+    // CR ends a line for TypeScript, so a CR-only buffer must not leave the
+    // rest of the file inside one `//`.
+    {name: "line comment ended by a lone cr", text: "// note\r/** @par", want: lexicalScopeJSDoc},
+    {name: "line comment ended by crlf", text: "// note\r\n/** @par", want: lexicalScopeJSDoc},
     {name: "no delimiter", text: "const x = 1; @par", want: lexicalScopeCode},
 
     {name: "double quoted string", text: "const x = \"/** @par", want: lexicalScopeString},
@@ -65,6 +69,10 @@ func TestLSPCompletionScopeIgnoresJSDocBytesInLiterals(t *testing.T) {
     // The negative twin: `/` after a value divides, and reading it as a literal
     // would swallow the block that follows.
     {name: "division is not a regex", text: "const ratio = a / b; /** @par", want: lexicalScopeJSDoc},
+    // A keyword is a legal property name, and a member access is a value.
+    {name: "keyword as a property name divides", text: "const n = obj.in / 2; /** @par", want: lexicalScopeJSDoc},
+    // What follows a completed literal divides, flags or not.
+    {name: "division after a flagless regex", text: "const n = /re/ / 2; /** @par", want: lexicalScopeJSDoc},
   }
 
   for _, entry := range cases {

--- a/website/src/content/docs/lint/editor.mdx
+++ b/website/src/content/docs/lint/editor.mdx
@@ -57,7 +57,7 @@ export function greet(name: string): string {
 
 With the cursor after `@par`, VS Code offers `param` from the same tag set that `jsdoc/check-tag-names` validates. Select it, then finish the line as `@param name user name`. You can also press Ctrl+Space to request completion explicitly.
 
-Use the completion inside a TypeScript `/** ... */` JSDoc block. Decorators, line comments, and Markdown documents are outside the supported scope.
+Use the completion inside a TypeScript `/** ... */` JSDoc block. Decorators, line comments, Markdown documents, and text inside string, template, or regular expression literals are outside the supported scope. A literal that contains the characters `/**`, such as `const example = "/** @par"`, is literal text and stays outside it too.
 
 Completion uses the live editor buffer, so it remains available while the file is dirty. The rule's completion corpus is discovered in the background when the language server starts. If you have just enabled the rule or changed inputs that shape a contributor's project index, run **ttsc: Restart language server** to force a fresh discovery.
 


### PR DESCRIPTION
Fixes #789.

## Intent

`cursorInJSDoc` decided the completion scope by comparing the last raw `/**` and `*/` before the cursor, so any position after JSDoc-shaped bytes counted as a doc comment. `const example = "/** @par"` was JSDoc scope, and the proxy appended `jsdoc/check-tag-names` items in ordinary source text where the owning rule never inspects.

Comment state is not a property of the bytes before the cursor, it is a property of the token stream that produced them. The decision now comes from a forward scanner-level pass, `lexicalScopeAt`, which reports the token kind a byte offset sits in: code, line comment, block comment, JSDoc, string, template, or regex literal. `cursorInJSDoc` is that pass answering `jsdoc`.

## Scope

- `packages/ttsc/internal/lspserver/lsp_completion_scope.go` (new): the scanner, plus `cursorInJSDoc` moved out of `lsp_completion.go`.
- `packages/ttsc/internal/lspserver/lsp_completion.go`: the backward-search implementation removed. `matchCompletionHints` and `completionHintApplies` are untouched, and the refuse-unknown-scope stance stays as written.
- Tests: a lexical table, a completion-level regression through `completionItemsFor`, and a hot-path benchmark.
- `website/src/content/docs/lint/editor.mdx`: the supported scope sentence now names literal text, which is what the code enforces.

`lsp_proxy.go` and `lsp_native_plugin_source.go` are deliberately untouched; nothing in this fix needed them.

## Design decisions

**Scanner, not a parse.** The proxy holds text, not a tree, and completion runs on the live dirty buffer, so a tsgo round trip per keystroke is the cost this channel exists to avoid. The forward pass has the same complexity the backward search already had.

**No span cache.** `BenchmarkCursorInJSDoc` walks a ~1 MB buffer with the cursor at its end, the worst case for a forward scan: 4.3 to 5.6 ms per pass on a loaded dev machine, so well under a millisecond for an ordinary source file and small beside the upstream completion round trip the same request makes. A cross-request cache would buy that back at the price of invalidation on every `didChange`, which is a larger correctness surface than the one being fixed.

**Recovery is part of the contract.** The buffer is usually invalid mid-edit, so an unterminated string ends at the line break exactly as the TypeScript scanner recovers. Without that, one stray apostrophe would hide every doc comment below it.

**Regex literals are skipped.** A `/` that opens a literal rather than divides is decided from the previous significant byte plus a keyword check, and the literal scan is bounded to its line, so an unterminated one falls back to division. This keeps `const re = /["]/; /** @par` reading as a real doc comment instead of a string that swallowed it. `/**` never starts a regex, so a comment opener always wins that test and a misread cannot hide a doc comment.

## Deferred

JSX element text is scanned as code, so `/**` typed between JSX tags still reads as a comment opener. Separating JSX text from a comparison operator needs the grammar, which is the parse this pass exists to avoid, and the position is far rarer than the literals fixed here. The boundary is stated in the code comment.

## Verification

Cases covered by `TestLSPCompletionScopeIgnoresJSDocBytesInLiterals`: real block, multi-line block, CRLF block with non-ASCII prose, closed block, `/**/`, plain block comment, line comment holding `/**`, no delimiter, cursor before the opener, double quoted string, single quoted string, template literal, template text after an interpolation, string inside an interpolation, nested template inside an interpolation, real comment inside an interpolation, escaped quote inside a string, escaped backslash ending a string, block after a string holding the opener, block after a string holding the terminator, quote inside a block, unterminated string recovering at the line end, regex class holding the opener, block after a regex holding a quote, regex after a keyword, division that is not a regex, cursor inside a regex literal, and out-of-range offsets.

Before the fix, the new tests fail: the completion-level case offers `param` inside the string literal, and nine lexical cases report `jsdoc` (line comment, both quoted strings, template, template after interpolation, string inside interpolation, nested template, escaped quote, regex class). After it, all pass.

Local, from `packages/ttsc`:

```
go vet ./internal/lspserver
go test ./internal/lspserver -count=1
go test ./internal/... -count=1
go build ./...
go test ./internal/lspserver -run='^$' -bench='^BenchmarkCursorInJSDoc$'
```

Go files formatted with `.vscode/gofmt-2spaces.sh -w`, the MDX file with the repository Prettier config. The full `pnpm test` suite was not run locally; CI owns it.
