### PR TITLE
docs(agents): forbid idling on a long command during a campaign wave

### DIFF
--- a/.agents/skills/issue-campaign/SKILL.md
+++ b/.agents/skills/issue-campaign/SKILL.md
@@ -59,6 +59,6 @@ Use tables for repeated case mappings. Read the rendered issue back and keep its
 
 ## Develop And Repeat The Campaign
 
-Read [development.md](development.md) in full when the user authorizes implementation pull requests or ends a campaign that entered implementation. It owns per-push campaign CI cancellation, DAG-based batching, claim pull requests, implementation waves, worktree cleanup, renewed discovery, the no-format rule, and Post-Campaign Cleanup. Do not continue after a push until its cancellation gate passes.
+Read [development.md](development.md) in full when the user authorizes implementation pull requests or ends a campaign that entered implementation. It owns per-push campaign CI cancellation, DAG-based batching, claim pull requests, implementation waves, the concurrency discipline that keeps an agent from idling on a long command, worktree cleanup, renewed discovery, the no-format rule, and Post-Campaign Cleanup. Do not continue after a push until its cancellation gate passes.
 
 An audit or issue-publication-only campaign does not load this campaign's [implementation procedure](development.md) or mutate repository Actions.

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -69,6 +69,7 @@ Two things must never be overlapped, because overlapping them destroys the evide
 
 - **A Self-Review round must not race a change.** The review skill requires one complete round over a final surface and a restart whenever anything changes, so a round begun while the code can still move is not a round at all. Prepare its inputs early — the base-to-head diff inventory, consequence-surface notes, the list of generated artifacts to re-check — and open the round once the batch stops changing.
 - **A merge must not precede its evidence.** Local verification is the only gate a CI-suspended campaign has, so a result that lands after the merge proves nothing about what was merged.
+- **The cancellation gate is a barrier, not a slow command.** [Cancel Campaign CI After Every Push](#cancel-campaign-ci-after-every-push) already forbids continuing while a gate is unresolved; nothing in this section relaxes that. Poll it to completion before doing anything else.
 
 Report wall-clock honestly when a wait was unavoidable, such as a toolchain download or a suite with no narrower subset. An unavoidable wait is a fact; an unexamined one is a habit.
 

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -6,6 +6,7 @@ Read this document in full when the user authorizes implementation pull requests
 
 - [Cancel Campaign CI After Every Push](#cancel-campaign-ci-after-every-push)
 - [Plan And Claim A Pull Request Wave](#plan-and-claim-a-pull-request-wave)
+- [Never Idle On A Long Command](#never-idle-on-a-long-command)
 - [Implement And Revalidate A Batch](#implement-and-revalidate-a-batch)
 - [Remove Every Finished Worktree](#remove-every-finished-worktree)
 - [While Campaign CI Is Cancelled](#while-campaign-ci-is-cancelled)
@@ -52,6 +53,24 @@ The agent assigned a batch claims it as its first action, before writing any cod
 5. Mark verification as pending, and record the batch, worktree, branch, issues, pull request, and cancelled run IDs in the campaign knowledge base.
 
 The draft pull request reserves the whole batch before code is written, preventing another contributor from starting overlapping work.
+
+## Never Idle On A Long Command
+
+Start every long command in the background and keep working. Idle waiting is the campaign's largest avoidable cost, and parallel batches multiply it: an agent that watches `pnpm install`, a build, or a suite finish before doing anything else spends most of its wall clock producing nothing.
+
+Overlap by default:
+
+- **Claim before setup finishes.** The claim commit, push, cancellation gate, and draft pull request need no installed dependencies, and claiming first is what reserves the surface while setup runs.
+- **Read and implement against the source tree.** Reading the batch's issues, mapping the consequence surface, and writing the change need the repository, not `node_modules`.
+- **Fill a verification wait with work that does not consume its result.** The next test, the next issue in the batch, the pull-request record, or the gate table for a push already made are all independent of the command in flight.
+- **Batch the dependent work.** When several checks must run, start them together rather than serially discovering that each needs the previous one's environment.
+
+Two things must never be overlapped, because overlapping them destroys the evidence they exist to produce:
+
+- **A Self-Review round must not race a change.** The review skill requires one complete round over a final surface and a restart whenever anything changes, so a round begun while the code can still move is not a round at all. Prepare its inputs early — the base-to-head diff inventory, consequence-surface notes, the list of generated artifacts to re-check — and open the round once the batch stops changing.
+- **A merge must not precede its evidence.** Local verification is the only gate a CI-suspended campaign has, so a result that lands after the merge proves nothing about what was merged.
+
+Report wall-clock honestly when a wait was unavoidable, such as a toolchain download or a suite with no narrower subset. An unavoidable wait is a fact; an unexamined one is a habit.
 
 ## Implement And Revalidate A Batch
 

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -65,7 +65,7 @@ Overlap by default:
 - **Fill a verification wait with work that does not consume its result.** The next test, the next issue in the batch, the pull-request record, or the gate table for a push already made are all independent of the command in flight.
 - **Batch the dependent work.** When several checks must run, start them together rather than serially discovering that each needs the previous one's environment.
 
-Two things must never be overlapped, because overlapping them destroys the evidence they exist to produce:
+These must never be overlapped, because overlapping them destroys the evidence they exist to produce:
 
 - **A Self-Review round must not race a change.** The review skill requires one complete round over a final surface and a restart whenever anything changes, so a round begun while the code can still move is not a round at all. Prepare its inputs early — the base-to-head diff inventory, consequence-surface notes, the list of generated artifacts to re-check — and open the round once the batch stops changing.
 - **A merge must not precede its evidence.** Local verification is the only gate a CI-suspended campaign has, so a result that lands after the merge proves nothing about what was merged.


### PR DESCRIPTION
## Intent

The campaign development document tells an implementing agent what to do and in which order, but never that a long command is something to run *alongside* work rather than watch. The waves of the current campaign paid for that omission: an agent would claim a batch, wait for a dependency install, then wait again for each verification, with four batches idling in parallel.

This adds the missing rule, stated where the waiting happens.

## Scope

- `.agents/skills/issue-campaign/development.md` gains a `Never Idle On A Long Command` section, listed in the document's Flow.
- `.agents/skills/issue-campaign/SKILL.md`'s pointer sentence gains the same concern, so the index still describes what the linked document owns.

The section says to start long commands in the background and keep working, and names the four overlaps that are always available: claim before setup finishes, read and implement against the source tree, fill a verification wait with work that does not consume its result, and start co-dependent checks together.

## What it deliberately does not allow

Two overlaps are forbidden, because overlapping them destroys the evidence they exist to produce:

- **A Self-Review round must not race a change.** The review skill already requires one complete round over a final surface and a restart whenever anything changes, so a round begun while code can still move is not a round. What may move earlier is its preparation — the diff inventory and consequence-surface notes.
- **A merge must not precede its evidence.** Under a CI-suspended campaign, local verification is the only gate, so a result arriving after the merge proves nothing about what was merged.

Without those two exclusions the rule would quietly authorize reviewing a moving target and merging on a pending check, which is the opposite of what the campaign's gates exist for.

## Verification

Documentation only; no code, no generated artifact, no workflow touched.

- `git diff --stat origin/master...HEAD` — two files, both under `.agents/skills/issue-campaign/`.
- Anchor check: the new Flow entry `#never-idle-on-a-long-command` matches the section heading.
- Read back in rendered form for section order and list structure.
- `pnpm format` deliberately not run: the campaign's no-format rule holds until Post-Campaign Cleanup owns the repository-wide formatter result.
- Campaign CI cancellation gate run for the pushed SHA `26c119a5`: no workflow run was enqueued for it, recorded in `ci-state.md`.
