### PR TITLE
docs(agents): clarify principled campaign flow

### DIFF
--- a/.agents/skills/development/SKILL.md
+++ b/.agents/skills/development/SKILL.md
@@ -26,6 +26,7 @@ These four are never acceptable; choosing any one means the approach is already 
 
 ## Work Rules
 
+- Choose the principled course. Time, difficulty, and the breadth of consequences require more careful analysis and validation; they never justify a workaround, a narrowed fix, or a weaker acceptance standard.
 - Match existing conventions. Before adding a file, function, or test, open a nearby peer and mirror its naming, location, and code style, don't create parallel structures.
 - Respect existing package boundaries. Don't hardcode consumer-specific behavior into the compiler host.
 - Plugin descriptors are JS; transform logic is Go. JS transform functions (e.g. `transformSource`, `transformOutput`) are not part of the public contract.

--- a/.agents/skills/development/SKILL.md
+++ b/.agents/skills/development/SKILL.md
@@ -26,7 +26,7 @@ These four are never acceptable; choosing any one means the approach is already 
 
 ## Work Rules
 
-- Choose the principled course. Time, difficulty, and the breadth of consequences require more careful analysis and validation; they never justify a workaround, a narrowed fix, or a weaker acceptance standard.
+- Choose the principled course. Time, difficulty, and the breadth of consequences require more careful analysis and validation; they never justify a shortcut, leaving a verified consequence unaddressed, or a weaker acceptance standard.
 - Match existing conventions. Before adding a file, function, or test, open a nearby peer and mirror its naming, location, and code style, don't create parallel structures.
 - Respect existing package boundaries. Don't hardcode consumer-specific behavior into the compiler host.
 - Plugin descriptors are JS; transform logic is Go. JS transform functions (e.g. `transformSource`, `transformOutput`) are not part of the public contract.

--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -36,7 +36,7 @@ Concise and clear means:
 - Give each paragraph one job. Separate purpose, rule, rationale, procedure, and consequence when combining them obscures the action.
 - Use structure to compress meaning: ordered lists for procedures, bullets for choices and checks, tables for repeated mappings, and code blocks for exact commands.
 - State the rule before its reason. Use a negative rule only when it prevents a named failure the affirmative rule does not already exclude.
-- Point to source documentation instead of paraphrasing it.
+- Link to website guides, READMEs, or source comments instead of paraphrasing them.
 
 ## Prose line breaks
 

--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: documentation
-description: Defines README and website-guide structure, audience, prose formatting, and voice for ttsc. Use before writing, modifying, renaming, or moving repository documentation.
+description: Defines README, website-guide, and agent-instruction structure, concise prose, and voice for ttsc. Use before writing, modifying, renaming, or moving repository documentation.
 ---
 
 # Documentation
@@ -24,6 +24,19 @@ Organize the tree by audience:
 Package guides may cover full options, recipes, troubleshooting, compatibility, and migration. Plugin-author guides may cover protocols, Go APIs, testing, publishing, and internals.
 
 Keep one audience and task per page. Update the matching `_meta.ts` whenever a guide is added, renamed, or moved.
+
+## Agent Instructions
+
+`AGENTS.md` and `SKILL.md` files are operational documents for humans and agents. Keep only the product-wide contract in `AGENTS.md`, the always-applicable procedure in `SKILL.md`, and conditional detail in a linked sibling document.
+
+Concise and clear means:
+
+- Include the context needed to act correctly. Do not make the reader infer prerequisites, exceptions, reasons, or stop conditions merely to shorten the document.
+- State each rule at its owning document and link to it elsewhere. Remove repeated wording, not necessary substance.
+- Give each paragraph one job. Separate purpose, rule, rationale, procedure, and consequence when combining them obscures the action.
+- Use structure to compress meaning: ordered lists for procedures, bullets for choices and checks, tables for repeated mappings, and code blocks for exact commands.
+- State the rule before its reason. Use a negative rule only when it prevents a named failure the affirmative rule does not already exclude.
+- Point to source documentation instead of paraphrasing it.
 
 ## Prose line breaks
 

--- a/.agents/skills/issue-campaign/SKILL.md
+++ b/.agents/skills/issue-campaign/SKILL.md
@@ -61,6 +61,6 @@ Use tables for repeated case mappings. Read the rendered issue back and keep its
 
 ## Develop And Repeat The Campaign
 
-Read [development.md](development.md) in full when the user authorizes implementation pull requests or ends a campaign that entered implementation. It owns issue admission, DAG-based batching, immediate claim pull requests, per-push campaign CI cancellation, non-idling implementation and review, worktree cleanup, renewed discovery, the no-format rule, and Post-Campaign Cleanup. It requires cancellation to begin immediately after every remote mutation, but a pending local command or cancellation poll must never make an implementation agent idle; all cancellation records must be complete before merge.
+Read [development.md](development.md) in full when the user authorizes implementation pull requests or ends a campaign that entered implementation. It owns issue admission, DAG-based batching, immediate claim pull requests, implementation-wave CI cancellation, non-idling implementation and review, worktree cleanup, renewed discovery, the no-format rule, and Post-Campaign Cleanup. It requires cancellation to begin immediately after every implementation-wave remote mutation, but a pending local command or cancellation poll must never make an implementation agent idle; all cancellation records must be complete before merge.
 
 An audit or issue-publication-only campaign does not load this campaign's [implementation procedure](development.md) or mutate repository Actions.

--- a/.agents/skills/issue-campaign/SKILL.md
+++ b/.agents/skills/issue-campaign/SKILL.md
@@ -7,6 +7,8 @@ description: Defines repository-wide issue discovery, lead-vetted issue publicat
 
 An issue campaign is a repeatable sequence of exhaustive discovery, issue publication, implementation pull requests, and final repository cleanup. The user's requested phase boundary controls how far to proceed; do not infer permission to publish issues, push branches, open pull requests, or merge from an audit-only request.
 
+Choose the principled course throughout the campaign. Its scale, duration, and consequence surface require stronger evidence, deeper consequence analysis, and complete verification; they never justify accepting an unverified candidate, a shortcut, or a weaker implementation or review standard.
+
 Read the project, development, and review skills before starting, and require every discovery-agent brief to do the same. Use the review skill's Issue Discovery Rounds; issue discovery is independent review, not discussion.
 
 ## Campaign Knowledge Base
@@ -59,6 +61,6 @@ Use tables for repeated case mappings. Read the rendered issue back and keep its
 
 ## Develop And Repeat The Campaign
 
-Read [development.md](development.md) in full when the user authorizes implementation pull requests or ends a campaign that entered implementation. It owns per-push campaign CI cancellation, DAG-based batching, claim pull requests, implementation waves, the concurrency discipline that keeps an agent from idling on a long command, worktree cleanup, renewed discovery, the no-format rule, and Post-Campaign Cleanup. Do not continue after a push until its cancellation gate passes.
+Read [development.md](development.md) in full when the user authorizes implementation pull requests or ends a campaign that entered implementation. It owns issue admission, DAG-based batching, immediate claim pull requests, per-push campaign CI cancellation, non-idling implementation and review, worktree cleanup, renewed discovery, the no-format rule, and Post-Campaign Cleanup. It requires cancellation to begin immediately after every remote mutation, but a pending local command or cancellation poll must never make an implementation agent idle; all cancellation records must be complete before merge.
 
 An audit or issue-publication-only campaign does not load this campaign's [implementation procedure](development.md) or mutate repository Actions.

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -5,8 +5,8 @@ Read this document in full when the user authorizes implementation pull requests
 ## Flow
 
 - [Cancel Campaign CI After Every Push](#cancel-campaign-ci-after-every-push)
-- [Plan And Claim A Pull Request Wave](#plan-and-claim-a-pull-request-wave)
-- [Never Idle On A Long Command](#never-idle-on-a-long-command)
+- [Admit And Reserve A Pull Request Wave](#admit-and-reserve-a-pull-request-wave)
+- [Keep Working While Commands Run](#keep-working-while-commands-run)
 - [Implement And Revalidate A Batch](#implement-and-revalidate-a-batch)
 - [Remove Every Finished Worktree](#remove-every-finished-worktree)
 - [While Campaign CI Is Cancelled](#while-campaign-ci-is-cancelled)
@@ -17,25 +17,29 @@ Three rules govern the entire implementation phase:
 
 - Local tests, lead verification, and solo Self-Review are the implementation gates.
 - Do not run `pnpm format` during discovery, issue publication, or implementation. Post-Campaign Cleanup owns the repository-wide formatter result.
-- Never disable repository Actions or any workflow for a campaign. After every campaign push and pull-request creation, immediately cancel only the runs for that campaign commit and verify cancellation before continuing.
+- Never disable repository Actions or any workflow for a campaign. After every campaign push and pull-request creation, immediately start cancellation only for runs caused by that campaign commit. Keep the cancellation record current and complete it before merge, but do not make local development wait for it.
 
 ## Cancel Campaign CI After Every Push
 
 Repository-wide Actions and workflow settings must remain unchanged. Before the first push, record `gh api repos/{owner}/{repo}/actions/permissions` and `gh workflow list --all --limit 1000 --json id,name,path,state` in `.wiki/<campaign>/ci-state.md` so the lead can prove the campaign did not alter them.
 
-Every push gets its own cancellation gate:
+Every push gets a cancellation record. Start it immediately in a background supervisor rather than leaving an implementation agent to poll it:
 
 1. Record the campaign branch and pushed commit SHA.
 2. List runs for that exact SHA with `gh run list --commit <sha> --limit 100 --json databaseId,headBranch,headSha,status,conclusion,url`.
 3. Cancel every `queued`, `in_progress`, `waiting`, `pending`, or `requested` run for that SHA with `gh run cancel <run-id>`. Never cancel by broad repository, workflow, or contributor filters.
 4. Poll again because push, pull-request, chained, and ruleset runs can appear after the first query. Continue until two consecutive polls find no new run and every observed run is terminal; every run observed as active must end `cancelled`, while a run already terminal when first observed is only recorded.
-5. Record the run IDs and final states in `.wiki/<campaign>/ci-state.md`. Stop further pushes or pull-request mutations if enumeration, cancellation, or readback fails.
+5. Record the run IDs and final states in `.wiki/<campaign>/ci-state.md`. If enumeration, cancellation, or readback fails, surface the failure and suspend later remote mutations and merge until it is repaired.
 
-Opening or updating a pull request can enqueue additional runs for the already-pushed SHA. Run the same gate immediately after pull-request creation and after any operation that retriggers checks. The exact-SHA boundary is mandatory: never cancel unrelated contributors' runs.
+Opening or updating a pull request can enqueue additional runs for the already-pushed SHA. Start the same background record immediately after pull-request creation and after any operation that retriggers checks. The exact-SHA boundary is mandatory: never cancel unrelated contributors' runs.
 
-## Plan And Claim A Pull Request Wave
+A live cancellation record does not block reading source, changing code, writing tests, starting local commands, committing, or Self-Review. It is a merge gate, not an excuse to idle. The initial claim push and the immediately following claim pull request are one reservation transaction, so opening that pull request does not wait for the first poll. Before merge, read every campaign SHA record back and require the final terminal state described above.
 
-Build the issue dependency DAG before assigning implementation. Use it to form cohesive batches, not to create one worktree per issue.
+## Admit And Reserve A Pull Request Wave
+
+Only an admitted issue can enter implementation. The lead first reopens the issue evidence, reproduces the reported behavior, verifies ownership and the full consequence surface, compares related open and closed work, and records an accept, partial acceptance, rewrite, combine, split, reject, or defer disposition. A rejected or deferred issue has no worktree and no claim pull request.
+
+Build the dependency DAG from the admitted issues before assigning implementation. Use it to form cohesive batches, not to create one worktree per issue.
 
 Batching follows these rules:
 
@@ -44,38 +48,37 @@ Batching follows these rules:
 - Split jointly implementable issues only for a concrete dependency, ownership, atomicity, or validation reason. Record that reason in the campaign knowledge base.
 - Immediately before claiming a batch, check again for an overlapping implementation pull request or branch.
 
-The agent assigned a batch claims it as its first action, before writing any code:
+The agent assigned an admitted batch reserves its surface before installing dependencies or writing implementation code:
 
 1. Create one isolated worktree and topic branch.
 2. Create one implementation-free claim commit with `git commit --allow-empty`.
-3. Push the branch and pass the exact-SHA cancellation gate.
-4. Open a draft pull request that overviews the batch scope and links every batched issue, then pass the gate again for runs triggered by pull-request creation.
-5. Mark verification as pending, and record the batch, worktree, branch, issues, pull request, and cancelled run IDs in the campaign knowledge base.
+3. Push the branch, start its exact-SHA cancellation record, and immediately open a draft claim pull request that overviews the batch scope and links every batched issue. This is an empty reservation pull request, not a request to wait for setup or validation.
+4. Start the pull-request-triggered cancellation record, mark verification as pending, and record the batch, worktree, branch, issues, pull request, and cancellation records in the campaign knowledge base.
+5. Start `pnpm install` asynchronously in the worktree, then begin the source, consequence-surface, and test-design work immediately.
 
 The draft pull request reserves the whole batch before code is written, preventing another contributor from starting overlapping work.
 
-## Never Idle On A Long Command
+## Keep Working While Commands Run
 
-Start every long command in the background and keep working. Idle waiting is the campaign's largest avoidable cost, and parallel batches multiply it: an agent that watches `pnpm install`, a build, or a suite finish before doing anything else spends most of its wall clock producing nothing.
+Start every long command asynchronously and continue with work that does not depend on its result. `pnpm install`, package builds, compiler downloads, and test suites are all background work. Watching a CLI process, repeatedly polling it without a decision to make, or reserving an agent solely to wait is not campaign work.
 
-Overlap by default:
+Maintain a compact command record containing the command, worktree, source snapshot, start time, dependent decision, and final result. Check a running command at a genuine decision boundary, when it exits, or before merge. Do not use sleep loops or foreground waits merely to discover that a command is still running.
 
-- **Claim before setup finishes.** The claim commit, push, cancellation gate, and draft pull request need no installed dependencies, and claiming first is what reserves the surface while setup runs.
-- **Read and implement against the source tree.** Reading the batch's issues, mapping the consequence surface, and writing the change need the repository, not `node_modules`.
-- **Fill a verification wait with work that does not consume its result.** The next test, the next issue in the batch, the pull-request record, or the gate table for a push already made are all independent of the command in flight.
-- **Batch the dependent work.** When several checks must run, start them together rather than serially discovering that each needs the previous one's environment.
+The usual overlap follows the state of the batch. While installation runs, read the admitted issue and nearby implementation, map the consequence surface, and write the implementation and regression test. Once a stable source-and-test snapshot is committed and pushed, launch the narrow package-scoped tests and begin Self-Review at once. A test process may run during review because it does not change the snapshot. When several independent checks are needed, start them together rather than serially discovering that each needs the same environment.
 
-These must never be overlapped, because overlapping them destroys the evidence they exist to produce:
+Some boundaries remain strict because overlap would destroy the evidence:
 
-- **A Self-Review round must not race a change.** The review skill requires one complete round over a final surface and a restart whenever anything changes, so a round begun while the code can still move is not a round at all. Prepare its inputs early — the base-to-head diff inventory, consequence-surface notes, the list of generated artifacts to re-check — and open the round once the batch stops changing.
-- **A merge must not precede its evidence.** Local verification is the only gate a CI-suspended campaign has, so a result that lands after the merge proves nothing about what was merged.
-- **The cancellation gate is a barrier, not a slow command.** [Cancel Campaign CI After Every Push](#cancel-campaign-ci-after-every-push) already forbids continuing while a gate is unresolved; nothing in this section relaxes that. Poll it to completion before doing anything else.
+- **A Self-Review round must not race a source change.** Freeze and commit the snapshot before opening the round, then inspect its complete diff while tests run. If review or a test result requires a change, commit the correction and restart from a fresh complete round over the new snapshot.
+- **A merge must not precede its evidence.** Local verification is the only gate a CI-suspended campaign has, so every required result and cancellation record must be final before merge.
+- **A failed cancellation record stops remote progression, not local thought.** Repair it before the next remote mutation or merge, while the agent continues the local work that is still safe and useful.
 
-Report wall-clock honestly when a wait was unavoidable, such as a toolchain download or a suite with no narrower subset. An unavoidable wait is a fact; an unexamined one is a habit.
+Report any command still running, its dependency, and its last observed state when handing work off. Waiting is only justified when the next decision genuinely depends on the completed result and no safe, independent work remains.
 
 ## Implement And Revalidate A Batch
 
 Analyze the full consequence and case surface across every issue in the batch. Follow the repository development skill for implementation, tests, documentation, generated artifacts, and narrow-then-broad local verification.
+
+A batch progresses through one-way states: admitted, reserved, active, snapshotted, reviewed, verified, then resolved. Admission is the lead's evidence-based decision. Reservation is the empty claim pull request. Active work begins as installation runs. Snapshot means the implementation and its tests are committed and pushed, not that their background processes have finished. Review starts on that immutable snapshot while narrow tests run. Verification consumes every required result, applies any correction through a new snapshot and fresh review, and only then permits resolution.
 
 An implementation agent may find that an issue is false or too broad. The lead must independently validate that conclusion before changing campaign state:
 
@@ -83,9 +86,9 @@ An implementation agent may find that an issue is false or too broad. The lead m
 - For a confirmed-invalid issue, record the evidence and close the issue.
 - If no issue remains in the batch, close the claim pull request instead of leaving an orphan reservation.
 
-Commit and push every coherent implementation increment to the claimed branch. Immediately pass the exact-SHA cancellation gate after each push; do not hold a completed implementation locally until handoff or continue working while that gate is unresolved.
+Commit and push every coherent implementation increment to the claimed branch as soon as its source and test program are complete. Do not hold a completed snapshot locally while waiting for the tests it already launched. Start the exact-SHA cancellation record immediately after the push, consume the test results when they become available, and make any correction in a new commit with the same discipline.
 
-Before merge, complete solo Self-Review, opening each round by commenting its findings and remediation plan on the pull request before acting on them so the thread records why every follow-up change happened. The implementing agent then merges its own pull request with the repository's established method — no separate lead approval — once implementation, that Self-Review, and the batch's package-scoped local verification all pass. Under an ordinary campaign it waits for explicit user authorization; under a standing autonomous mandate — an autonomous or remote-control campaign, or an instruction to carry the campaign through merge — it merges as soon as those gates pass, without a per-pull-request request.
+Before merge, complete solo Self-Review. When a round finds an improvement, comment its findings and remediation plan on the pull request before applying the change so the thread records why every follow-up commit happened. A pending narrow test never delays the start of that review, but its final result is required before merge. The implementing agent then merges its own pull request with the repository's established method, with no separate lead approval, once implementation, that Self-Review, the batch's package-scoped local verification, and all campaign cancellation records are complete. Under an ordinary campaign it waits for explicit user authorization; under a standing autonomous mandate, an autonomous or remote-control campaign, or an instruction to carry the campaign through merge, it merges as soon as those gates pass without a per-pull-request request.
 
 ## Remove Every Finished Worktree
 

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -17,13 +17,13 @@ Three rules govern the entire implementation phase:
 
 - Local tests, lead verification, and solo Self-Review are the implementation gates.
 - Do not run `pnpm format` during discovery, issue publication, or implementation. Post-Campaign Cleanup owns the repository-wide formatter result.
-- Never disable repository Actions or any workflow for a campaign. After every campaign push and pull-request creation, immediately start cancellation only for runs caused by that campaign commit. Keep the cancellation record current and complete it before merge, but do not make local development wait for it.
+- Never disable repository Actions or any workflow for a campaign. After every implementation-wave push and pull-request creation, immediately start cancellation only for runs caused by that campaign commit. Keep the cancellation record current and complete it before merge, but do not make local development wait for it.
 
 ## Cancel Campaign CI After Every Push
 
 Repository-wide Actions and workflow settings must remain unchanged. Before the first push, record `gh api repos/{owner}/{repo}/actions/permissions` and `gh workflow list --all --limit 1000 --json id,name,path,state` in `.wiki/<campaign>/ci-state.md` so the lead can prove the campaign did not alter them.
 
-Every push gets a cancellation record. Start it immediately in a background supervisor rather than leaving an implementation agent to poll it:
+Every implementation-wave push gets a cancellation record. Start it immediately in a background supervisor rather than leaving an implementation agent to poll it:
 
 1. Record the campaign branch and pushed commit SHA.
 2. List runs for that exact SHA with `gh run list --commit <sha> --limit 100 --json databaseId,headBranch,headSha,status,conclusion,url`.
@@ -31,7 +31,7 @@ Every push gets a cancellation record. Start it immediately in a background supe
 4. Poll again because push, pull-request, chained, and ruleset runs can appear after the first query. Continue until two consecutive polls find no new run and every observed run is terminal; every run observed as active must end `cancelled`, while a run already terminal when first observed is only recorded.
 5. Record the run IDs and final states in `.wiki/<campaign>/ci-state.md`. If enumeration, cancellation, or readback fails, surface the failure and suspend later remote mutations and merge until it is repaired.
 
-Opening or updating a pull request can enqueue additional runs for the already-pushed SHA. Start the same background record immediately after pull-request creation and after any operation that retriggers checks. The exact-SHA boundary is mandatory: never cancel unrelated contributors' runs.
+Opening or updating an implementation pull request can enqueue additional runs for the already-pushed SHA. Start the same background record immediately after pull-request creation and after any operation that retriggers checks. The exact-SHA boundary is mandatory: never cancel unrelated contributors' runs.
 
 A live cancellation record does not block reading source, changing code, writing tests, starting local commands, committing, or Self-Review. It is a merge gate, not an excuse to idle. The initial claim push and the immediately following claim pull request are one reservation transaction, so opening that pull request does not wait for the first poll. Before merge, read every campaign SHA record back and require the final terminal state described above.
 
@@ -128,8 +128,8 @@ Run this phase only after the user ends the campaign, every campaign pull reques
 3. Run `pnpm format` once against the integrated repository.
 4. If formatting produces no diff, report that no cleanup pull request was needed and stop.
 5. If formatting changes files, create a dedicated topic branch containing the formatter result and only directly necessary fixes.
-6. Commit and push under the pull-request skill, pass the exact-SHA cancellation gate, open the Post-Campaign Cleanup pull request, and pass the gate again for pull-request-triggered runs.
-7. Diagnose any locally reproducible failure, fix it, commit, push, and cancel the new commit's runs by the same gate.
+6. Commit, push, and open the Post-Campaign Cleanup pull request under the pull-request skill. This is an ordinary pull request: resume its check loop instead of cancelling its runs.
+7. Diagnose any locally reproducible failure, fix it, commit, push, and resume the ordinary check loop.
 8. Merge once required checks pass: with explicit user authorization, or on a standing autonomous mandate without a separate request.
 9. If cleanup used the main checkout, return it to `master`, pull with `git pull --ff-only origin master`, and delete the local cleanup branch.
 10. If cleanup used an auxiliary worktree, remove it and its branch under Remove Every Finished Worktree, then pull `master` in the main checkout.

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -4,7 +4,7 @@ Read this document in full when the user authorizes implementation pull requests
 
 ## Flow
 
-- [Cancel Campaign CI After Every Push](#cancel-campaign-ci-after-every-push)
+- [Cancel Implementation-Wave CI](#cancel-implementation-wave-ci)
 - [Admit And Reserve A Pull Request Wave](#admit-and-reserve-a-pull-request-wave)
 - [Keep Working While Commands Run](#keep-working-while-commands-run)
 - [Implement And Revalidate A Batch](#implement-and-revalidate-a-batch)
@@ -19,7 +19,7 @@ Three rules govern the entire implementation phase:
 - Do not run `pnpm format` during discovery, issue publication, or implementation. Post-Campaign Cleanup owns the repository-wide formatter result.
 - Never disable repository Actions or any workflow for a campaign. After every implementation-wave push and pull-request creation, immediately start cancellation only for runs caused by that campaign commit. Keep the cancellation record current and complete it before merge, but do not make local development wait for it.
 
-## Cancel Campaign CI After Every Push
+## Cancel Implementation-Wave CI
 
 Repository-wide Actions and workflow settings must remain unchanged. Before the first push, record `gh api repos/{owner}/{repo}/actions/permissions` and `gh workflow list --all --limit 1000 --json id,name,path,state` in `.wiki/<campaign>/ci-state.md` so the lead can prove the campaign did not alter them.
 

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -9,6 +9,8 @@ description: Defines exhaustive solo and team review workflows for ttsc changes 
 
 Every review mode uses the same unit of work: one reviewer performs one complete, from-scratch review of the entire declared surface. A team adds independent complete reviews; it never divides one review among agents.
 
+Choose the principled conclusion. Review duration, difficulty, and consequence surface are reasons to inspect more deeply and verify more carefully, never reasons to overlook a sound improvement, accept an unsupported claim, or lower the completion standard.
+
 A complete round must satisfy all four rules:
 
 - **Whole surface:** read every changed file and hunk. For issue discovery, audit the entire campaign scope. Never partition by file, package, concern, platform, agent, or round, and never substitute another reviewer's coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ Follow the literal request; it is the contract, not a hint at what the user "rea
 
 - **Scope is the user's to widen.** Reinterpret the goal, weigh alternatives, or expand the task only on an explicit hand-off ("figure it out", "you decide"). Take a confident, specific ask as given.
 - **Fidelity binds the goal, not the effort.** Within that goal, act with full initiative: do the substeps it needs, verify your work, surface what you notice. Literal scope is no excuse for passive execution.
+- **Match the user's language.** Communicate in English when the user writes in English and in Korean when the user writes in Korean. Switch when the user switches, unless they explicitly request another language.
+- **Choose the principled course.** Decide from evidence, correctness, product boundaries, and the durable consequence. Time, difficulty, and consequence surface are reasons to investigate and validate more carefully, never reasons to settle for a shortcut, workaround, or weaker standard.
 - **Evidence precedes correction.** Treat issue reports, review proposals, and claims that something is wrong or missing as hypotheses. Verify the real code path, tests, generated artifacts, upstream ownership, and history before accepting the premise or changing behavior.
 - **Trace the consequence surface.** A named file or failing case is the starting point, not the investigation boundary. Follow the same cause through downstream consumers, side effects, state transitions, platforms, and boundary cases, then address the whole verified class of failure within the requested goal.
 - **Default over ask.** On an ambiguous detail, pick the sensible default and say what you chose; reserve questions for forks only the user can settle.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,15 +58,7 @@ Benchmark runners, fixture repositories, measurement integrity, and publication,
 
 ### Writing style
 
-AGENTS.md and SKILL.md files are read by humans as well as agents.
-
-- **Optimize for comprehension, not minimum length.** A shorter document that forces the reader to infer prerequisites, reasons, exceptions, or stop conditions is not concise. Add the context needed to execute correctly.
-- **Remove repetition, not substance.** State a rule once at its owner and link to it elsewhere. Keep the rationale when it prevents a plausible mistake.
-- **Give each paragraph one job.** Split purpose, rule, rationale, procedure, and consequence when combining them would make the reader unpack a dense block.
-- **Use structure as compression.** Use numbered lists for ordered procedures, bullets for choices or checklists, tables for repeated mappings, and code blocks for exact commands. Do not hide a workflow inside one long sentence.
-- **State the rule before its reason.** Use negative phrasing only for a named failure mode that the affirmative rule does not already exclude.
-- **Skills point, not paraphrase.** Do not restate what the website, READMEs, or source comments already say; link to them.
-- **Source lines are not paragraphs.** Keep each prose paragraph on one source line and never hard-wrap it, but insert as many blank-line paragraph boundaries as the ideas require.
+`AGENTS.md` and `SKILL.md` files are read by humans as well as agents. Read the documentation skill before editing either; it defines concise, clear operational writing and prose-line rules.
 
 ### AGENTS.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Keeping `packages/ttsc/shim/*` synced with typescript-go and complete for plugin
 
 ### Documentation
 
-README and website guide authoring rules, `.agents/skills/documentation/SKILL.md`. Read before writing or modifying documentation.
+README, website-guide, and agent-instruction writing rules, `.agents/skills/documentation/SKILL.md`. Read before writing or modifying documentation.
 
 ### Issue Campaigns
 


### PR DESCRIPTION
## Intent

Clarify the agent contract for language matching and principled decisions, then make issue-campaign implementation continuously productive while setup, tests, and cancellation records run.

## Scope

- Add the user-language and principled-course rules to the shared contract and their development, campaign, and review applications.
- Define admitted issues, immediate empty claim PRs, background setup and verification, immutable-snapshot self-review, and merge-only completion gates.

## Deferred

None.

## Local verification

- `git diff --check`
- `python C:/Users/samch/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/issue-campaign`
- `pnpm exec prettier --check AGENTS.md .agents/skills/development/SKILL.md .agents/skills/issue-campaign/SKILL.md .agents/skills/issue-campaign/development.md .agents/skills/review/SKILL.md`

Repository-wide formatting is intentionally out of scope for this documentation-only change.
