### PR TITLE
fix(ttsc): share cache-subcommand flag identity

### DIFF
--- a/packages/ttsc/src/flags/schema.ts
+++ b/packages/ttsc/src/flags/schema.ts
@@ -26,6 +26,7 @@
 export type TtscSubcommand =
   | "ttsc"
   | "build"
+  | "cache"
   | "check"
   | "fix"
   | "format"
@@ -221,6 +222,7 @@ export const FLAG_SCHEMA: readonly FlagSpec[] = [
       "ttsc",
       "ttsx",
       "build",
+      "cache",
       "check",
       "fix",
       "format",
@@ -237,6 +239,7 @@ export const FLAG_SCHEMA: readonly FlagSpec[] = [
       "ttsc",
       "ttsx",
       "build",
+      "cache",
       "check",
       "fix",
       "format",
@@ -336,6 +339,7 @@ export const FLAG_SCHEMA: readonly FlagSpec[] = [
       "ttsc",
       "ttsx",
       "build",
+      "cache",
       "check",
       "fix",
       "format",
@@ -344,6 +348,13 @@ export const FLAG_SCHEMA: readonly FlagSpec[] = [
     ],
     consumedBy: ["launcher"],
     description: "Override the runner and source-plugin cache root.",
+  },
+  {
+    name: "--json",
+    kind: "boolean",
+    subcommands: ["cache"],
+    consumedBy: ["launcher"],
+    description: "Print cache paths as JSON.",
   },
 
   // -------------------------------------------------------------------------

--- a/packages/ttsc/src/launcher/internal/runTtsc.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsc.ts
@@ -307,8 +307,14 @@ function parseCachePathsArgs(argv: readonly string[]): {
   const rest = [...argv];
   while (rest.length !== 0) {
     const token = rest.shift()!;
-    const [flag, inlineValue] = splitInlineFlag(token);
-    switch (flag) {
+    const [rawFlag, inlineValue] = splitInlineFlag(token);
+    const flag = resolveFlagSpec(rawFlag);
+    if (flag?.subcommands.includes("cache") !== true) {
+      throw new Error(
+        `ttsc: cache paths does not support ${JSON.stringify(token)}`,
+      );
+    }
+    switch (flag.name) {
       case "--json":
         if (inlineValue !== undefined) {
           throw new Error("ttsc: --json does not take a value");
@@ -316,15 +322,13 @@ function parseCachePathsArgs(argv: readonly string[]): {
         out.json = true;
         break;
       case "--cache-dir":
-        out.cacheDir = readCachePathsValue(flag, inlineValue, rest);
+        out.cacheDir = readCachePathsValue(flag.name, inlineValue, rest);
         break;
       case "--cwd":
-        out.cwd = readCachePathsValue(flag, inlineValue, rest);
+        out.cwd = readCachePathsValue(flag.name, inlineValue, rest);
         break;
-      case "-p":
-      case "--project":
       case "--tsconfig":
-        out.tsconfig = readCachePathsValue(flag, inlineValue, rest);
+        out.tsconfig = readCachePathsValue(flag.name, inlineValue, rest);
         break;
       default:
         throw new Error(

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_cache_paths_resolves_schema_flag_spellings.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_cache_paths_resolves_schema_flag_spellings.ts
@@ -1,0 +1,74 @@
+import {
+  assert,
+  createProject,
+  spawn,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies `ttsc cache paths` resolves every supported flag through the shared schema identity.
+ *
+ * `cache paths` used to compare raw flag text even though the main launcher
+ * normalizes every schema-owned spelling. A CI script with `--JSON`, `--Cwd`,
+ * or `-P` therefore failed only on this subcommand. This drives the real
+ * launcher so canonical and case-variant spellings reach the same cache path
+ * calculation while the command keeps its strict value and unknown-option
+ * boundary.
+ *
+ * 1. Create a project and compare canonical cache options with case variants and `-P`.
+ * 2. Assert that every supported spelling returns the same JSON path record.
+ * 3. Assert `--json` values and unknown options still fail at the cache command boundary.
+ */
+export const test_ttsc_cache_paths_resolves_schema_flag_spellings = () => {
+  const root = createProject({
+    "src/main.ts": "export const value = 1;\n",
+    "tsconfig.json": JSON.stringify({ include: ["src"] }),
+  });
+  const canonical = spawn(
+    ttscBin,
+    ["cache", "paths", "--json", "--cwd", root, "--cache-dir", ".cache"],
+    { cwd: root },
+  );
+  assert.equal(canonical.status, 0, canonical.stderr);
+
+  const caseVariants = spawn(
+    ttscBin,
+    [
+      "cache",
+      "paths",
+      "--JSON",
+      "--Cwd",
+      root,
+      "--CACHE-DIR",
+      ".cache",
+    ],
+    { cwd: root },
+  );
+  assert.equal(caseVariants.status, 0, caseVariants.stderr);
+  assert.deepEqual(JSON.parse(caseVariants.stdout), JSON.parse(canonical.stdout));
+
+  const projectAlias = spawn(
+    ttscBin,
+    ["cache", "paths", "--JSON", "--CWD", root, "-P", "tsconfig.json"],
+    { cwd: root },
+  );
+  assert.equal(projectAlias.status, 0, projectAlias.stderr);
+  assert.equal(JSON.parse(projectAlias.stdout).projectRoot, root);
+
+  const jsonValue = spawn(ttscBin, ["cache", "paths", "--json=true"], {
+    cwd: root,
+  });
+  assert.notEqual(jsonValue.status, 0);
+  assert.match(jsonValue.stderr, /--json does not take a value/);
+
+  const unknown = spawn(
+    ttscBin,
+    ["cache", "paths", "--not-a-real-cache-option"],
+    { cwd: root },
+  );
+  assert.notEqual(unknown.status, 0);
+  assert.match(
+    unknown.stderr,
+    /cache paths does not support "--not-a-real-cache-option"/,
+  );
+};

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_cache_paths_resolves_schema_flag_spellings.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_cache_paths_resolves_schema_flag_spellings.ts
@@ -61,6 +61,17 @@ export const test_ttsc_cache_paths_resolves_schema_flag_spellings = () => {
   assert.notEqual(jsonValue.status, 0);
   assert.match(jsonValue.stderr, /--json does not take a value/);
 
+  const spacedJsonValue = spawn(
+    ttscBin,
+    ["cache", "paths", "--json", "false"],
+    { cwd: root },
+  );
+  assert.notEqual(spacedJsonValue.status, 0);
+  assert.match(
+    spacedJsonValue.stderr,
+    /cache paths does not support "false"/,
+  );
+
   const unknown = spawn(
     ttscBin,
     ["cache", "paths", "--not-a-real-cache-option"],

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_cache_paths_resolves_schema_flag_spellings.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_cache_paths_resolves_schema_flag_spellings.ts
@@ -12,12 +12,12 @@ import {
  * normalizes every schema-owned spelling. A CI script with `--JSON`, `--Cwd`,
  * or `-P` therefore failed only on this subcommand. This drives the real
  * launcher so canonical and case-variant spellings reach the same cache path
- * calculation while the command keeps its strict value and unknown-option
- * boundary.
+ * calculation while the command keeps its strict value, command-scope, and
+ * unknown-option boundaries.
  *
  * 1. Create a project and compare canonical cache options with case variants and `-P`.
  * 2. Assert that every supported spelling returns the same JSON path record.
- * 3. Assert `--json` values and unknown options still fail at the cache command boundary.
+ * 3. Assert `--json` values, non-cache schema flags, and unknown options still fail at the cache command boundary.
  */
 export const test_ttsc_cache_paths_resolves_schema_flag_spellings = () => {
   const root = createProject({
@@ -70,6 +70,17 @@ export const test_ttsc_cache_paths_resolves_schema_flag_spellings = () => {
   assert.match(
     spacedJsonValue.stderr,
     /cache paths does not support "false"/,
+  );
+
+  const unsupportedSchemaFlag = spawn(
+    ttscBin,
+    ["cache", "paths", "--binary", "tsgo"],
+    { cwd: root },
+  );
+  assert.notEqual(unsupportedSchemaFlag.status, 0);
+  assert.match(
+    unsupportedSchemaFlag.stderr,
+    /cache paths does not support "--binary"/,
   );
 
   const unknown = spawn(

--- a/website/src/content/docs/ttsc/flags.mdx
+++ b/website/src/content/docs/ttsc/flags.mdx
@@ -21,8 +21,8 @@ one layer and silently disappears at the next boundary.
 | --- | --- | --- | --- | --- | --- | --- |
 | `--help` | `-h` | boolean | ttsc, ttsx, build, check, fix, format | launcher | terminal, consumed-not-forwarded | Show command help and exit. |
 | `--version` | `-v` | boolean | ttsc, ttsx | launcher | terminal, consumed-not-forwarded | Print the launcher version and exit. |
-| `--tsconfig` | `-p`, `--project` | value | ttsc, ttsx, build, check, fix, format, prepare, clean | launcher, host, lint | - | Resolve project settings from this tsconfig. |
-| `--cwd` | - | value | ttsc, ttsx, build, check, fix, format, prepare, clean | launcher, host, lint | - | Resolve project-relative paths from this directory. |
+| `--tsconfig` | `-p`, `--project` | value | ttsc, ttsx, build, cache, check, fix, format, prepare, clean | launcher, host, lint | - | Resolve project settings from this tsconfig. |
+| `--cwd` | - | value | ttsc, ttsx, build, cache, check, fix, format, prepare, clean | launcher, host, lint | - | Resolve project-relative paths from this directory. |
 | `--emit` | - | boolean | ttsc, build, check | launcher, runBuild, host, lint | - | Force emitted files during build. |
 | `--noEmit` | - | boolean | ttsc, build, check | launcher, runBuild, host, lint | shadow | Force analysis-only build with no file writes. |
 | `--outDir` | - | value | ttsc, build, check | launcher, host, lint | - | Override compilerOptions.outDir for this invocation. |
@@ -31,7 +31,8 @@ one layer and silently disappears at the next boundary.
 | `--quiet` | - | boolean | ttsc, build, check, fix, format | launcher, host, lint | - | Keep build output quiet (default). |
 | `--verbose` | - | boolean | ttsc, build, check, fix, format | launcher, host, lint | - | Print the build summary and emitted files. |
 | `--binary` | - | value | ttsc, ttsx, build, check, fix, format, prepare, clean | launcher | consumed-not-forwarded | Use an explicit tsgo binary. |
-| `--cache-dir` | - | value | ttsc, ttsx, build, check, fix, format, prepare, clean | launcher | consumed-not-forwarded | Override the runner and source-plugin cache root. |
+| `--cache-dir` | - | value | ttsc, ttsx, build, cache, check, fix, format, prepare, clean | launcher | consumed-not-forwarded | Override the runner and source-plugin cache root. |
+| `--json` | - | boolean | cache | launcher | consumed-not-forwarded | Print cache paths as JSON. |
 | `--singleThreaded` | - | boolean | ttsc, ttsx, build, check, fix, format | launcher, runBuild, tsgo, host, lint | capability: threadingArgs | Run TypeScript-Go single-threaded (one checker). |
 | `--checkers` | - | value | ttsc, ttsx, build, check, fix, format | launcher, runBuild, tsgo, host, lint | capability: threadingArgs | Type-checker pool size (default: TypeScript-Go's). |
 | `--require` | `-r` | value | ttsx | launcher | repeatable, consumed-not-forwarded | Preload a module before the entrypoint (ttsx; repeatable). |


### PR DESCRIPTION
Campaign batch: **CLI cache-subcommand flag identity**.

Closes #873.

`cache paths` is the remaining launcher path that parses its flags with a
literal-string switch instead of the schema identity #844 made authoritative.
This batch will make its supported `--json`, `--cache-dir`, `--cwd`, and
project spellings resolve through that shared owner while preserving its
subcommand-specific value and unknown-option errors.

## Scope

- `packages/ttsc/src/launcher/internal/runTtsc.ts` and focused launcher tests.
- The regression covers canonical and case-variant spellings, `-P`, inline
  value rejection for `--json`, and the unchanged unknown-option failure.
- No generated output is hand-edited; a schema change, if evidence requires
  one, moves through the existing generator and flag checks.

## Campaign constraints

- The branch is an empty reservation at opening; implementation and local
  verification are pending.
- Campaign Actions are not modified. Exact-SHA runs for every push and this
  pull-request creation are cancelled and recorded; local verification is the
  merge gate.
- `pnpm format` is intentionally not run. Post-Campaign Cleanup owns the
  repository-wide formatter result.

