### PR TITLE
fix(vscode): preserve literal percent through command shims

### DIFF
--- a/packages/vscode/bin/install.js
+++ b/packages/vscode/bin/install.js
@@ -22,15 +22,19 @@ function createCodeCommand(
 ) {
   if (platform === "win32") {
     const launcher = findWindowsCodeCommand(env, deps);
+    const commandShim = createWindowsCommandShim([launcher, ...args]);
     return {
       command: env.ComSpec || "cmd.exe",
-      args: ["/d", "/s", "/c", quoteWindowsCommand([launcher, ...args])],
+      args: ["/d", "/s", "/c", commandShim.payload],
       // The `/c` payload is already fully quoted. Node's Windows spawn escapes
       // each arg again unless told not to, turning `""code.cmd" ...` into
       // `"\"\"code.cmd\" ...\""`, which cmd.exe sees as one un-runnable token
       // after the CVE-2024-27980 argument-escaping change. Pass the payload
       // verbatim so cmd's `/s` strips the outer quotes and runs `code.cmd ...`.
-      options: { windowsVerbatimArguments: true },
+      options: {
+        env: { ...env, ...commandShim.environment },
+        windowsVerbatimArguments: true,
+      },
     };
   }
   return { command: "code", args, options: {} };
@@ -78,12 +82,24 @@ function findWindowsCodeCommand(env = process.env, deps = {}) {
   return candidates.find((candidate) => existsSync(candidate)) ?? "code.cmd";
 }
 
-function quoteWindowsCommand(args) {
-  return `"${args.map(quoteWindowsArg).join(" ")}"`;
+function createWindowsCommandShim(args) {
+  const prefix = "TTSC_VSCODE_COMMAND_SHIM_ARG_";
+  const environment = Object.fromEntries(
+    args.map((arg, index) => [prefix + index, quoteWindowsArg(arg)]),
+  );
+  return {
+    environment,
+    // cmd expands every placeholder exactly once. The environment values are
+    // already Windows-command-line arguments, so their literal `%` segments do
+    // not expand again and their quotes continue to protect shell metacharacters.
+    payload: `"${args.map((_, index) => `%${prefix}${index}%`).join(" ")}"`,
+  };
 }
 
 function quoteWindowsArg(arg) {
-  return `"${String(arg).replace(/"/g, '\\"').replace(/%/g, "%%")}"`;
+  return `"${String(arg)
+    .replace(/(\\*)"/g, "$1$1\\\"")
+    .replace(/(\\*)$/, "$1$1")}"`;
 }
 
 function spawnCode(args, vsixForFallback) {
@@ -160,5 +176,4 @@ module.exports = {
   findWindowsCodeCommand,
   findVsix,
   main,
-  quoteWindowsCommand,
 };

--- a/packages/vscode/src/serverResolution.ts
+++ b/packages/vscode/src/serverResolution.ts
@@ -28,6 +28,7 @@ export type ServerProcessOptions = {
 export type ServerLaunchCommand = {
   args: string[];
   command: string;
+  commandShimEnvironment?: NodeJS.ProcessEnv;
   // True only for the Windows `.cmd`/`.bat` command-shim launch path, whose
   // `args` are already a single fully quoted `/c` payload. Non-command launchers
   // omit it so their argument arrays keep Node's default escaping.
@@ -167,9 +168,11 @@ export function createServerLaunchCommand(
     return { command: process.execPath, args: [launcher, ...args] };
   }
   if (platform === "win32" && isWindowsCommandLauncher(launcher)) {
+    const commandShim = createWindowsCommandShim([launcher, ...args]);
     return {
       command: env.ComSpec || "cmd.exe",
-      args: ["/d", "/s", "/c", quoteWindowsCommand([launcher, ...args])],
+      args: ["/d", "/s", "/c", commandShim.payload],
+      commandShimEnvironment: commandShim.environment,
       windowsVerbatimArguments: true,
     };
   }
@@ -200,13 +203,13 @@ export function createServerExecutable(
     args: launch.args,
     options:
       options && launch.windowsVerbatimArguments
-        ? { ...options, windowsVerbatimArguments: true }
+        ? {
+            ...options,
+            env: { ...options.env, ...launch.commandShimEnvironment },
+            windowsVerbatimArguments: true,
+          }
         : options,
   };
-}
-
-export function quoteWindowsCommand(args: readonly string[]): string {
-  return `"${args.map(quoteWindowsArg).join(" ")}"`;
 }
 
 export function createDocumentSelectorPattern<T>(
@@ -420,8 +423,27 @@ function isWindowsCommandLauncher(launcher: string): boolean {
   return [".cmd", ".bat"].includes(path.extname(launcher).toLowerCase());
 }
 
+function createWindowsCommandShim(args: readonly string[]): {
+  environment: NodeJS.ProcessEnv;
+  payload: string;
+} {
+  const prefix = "TTSC_VSCODE_COMMAND_SHIM_ARG_";
+  const environment = Object.fromEntries(
+    args.map((arg, index) => [prefix + index, quoteWindowsArg(arg)]),
+  );
+  return {
+    environment,
+    // cmd expands every placeholder exactly once. The environment values are
+    // already Windows-command-line arguments, so their literal `%` segments do
+    // not expand again and their quotes continue to protect shell metacharacters.
+    payload: `"${args.map((_, index) => `%${prefix}${index}%`).join(" ")}"`,
+  };
+}
+
 function quoteWindowsArg(arg: string): string {
-  return `"${String(arg).replace(/"/g, '\\"').replace(/%/g, "%%")}"`;
+  return `"${String(arg)
+    .replace(/(\\*)"/g, "$1$1\\\"")
+    .replace(/(\\*)$/, "$1$1")}"`;
 }
 
 /**

--- a/scripts/smoke-vscode-install.cjs
+++ b/scripts/smoke-vscode-install.cjs
@@ -65,6 +65,7 @@ function run(command, args, options = {}) {
     cwd: options.cwd ?? process.cwd(),
     encoding: "utf8",
     stdio: options.capture ? "pipe" : "inherit",
+    env: options.env,
     windowsHide: true,
     windowsVerbatimArguments: options.windowsVerbatimArguments,
   });

--- a/tests/test-ttsc/src/features/ttscserver/test_vscode_install_script_uses_windows_command_shim.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_vscode_install_script_uses_windows_command_shim.ts
@@ -1,6 +1,9 @@
 import { TestProject } from "@ttsc/testing";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import { createRequire } from "node:module";
+import os from "node:os";
 import path from "node:path";
 
 /**
@@ -13,7 +16,8 @@ import path from "node:path";
  *
  * 1. Require the packaged install helper without running its CLI entrypoint.
  * 2. Build POSIX and Windows command shapes, including metacharacters.
- * 3. Assert Windows uses one quoted `cmd.exe /d /s /c` payload.
+ * 3. Assert Windows carries quoted argv fragments through its environment.
+ * 4. On Windows, spawn a recording `code.cmd` and compare its exact argv.
  */
 export const test_vscode_install_script_uses_windows_command_shim = () => {
   const repo = TestProject.WORKSPACE_ROOT;
@@ -32,7 +36,10 @@ export const test_vscode_install_script_uses_windows_command_shim = () => {
     ) => {
       args: string[];
       command: string;
-      options: { windowsVerbatimArguments?: boolean };
+      options: {
+        env?: NodeJS.ProcessEnv;
+        windowsVerbatimArguments?: boolean;
+      };
     };
     findWindowsCodeCommand: (
       env?: NodeJS.ProcessEnv,
@@ -54,6 +61,8 @@ export const test_vscode_install_script_uses_windows_command_shim = () => {
     existsSync: () => false,
     spawnSync: () => ({ stdout: "" }),
   };
+  const payload =
+    '"%TTSC_VSCODE_COMMAND_SHIM_ARG_0% %TTSC_VSCODE_COMMAND_SHIM_ARG_1% %TTSC_VSCODE_COMMAND_SHIM_ARG_2% %TTSC_VSCODE_COMMAND_SHIM_ARG_3%"';
   assert.deepEqual(
     mod.createCodeCommand(args, "win32", { ComSpec: "cmd" }, noCodeCmd),
     {
@@ -62,9 +71,18 @@ export const test_vscode_install_script_uses_windows_command_shim = () => {
         "/d",
         "/s",
         "/c",
-        '""code.cmd" "--install-extension" "C:\\tmp & 100%%\\ttsc.vsix" "--force""',
+        payload,
       ],
-      options: { windowsVerbatimArguments: true },
+      options: {
+        env: {
+          ComSpec: "cmd",
+          TTSC_VSCODE_COMMAND_SHIM_ARG_0: '"code.cmd"',
+          TTSC_VSCODE_COMMAND_SHIM_ARG_1: '"--install-extension"',
+          TTSC_VSCODE_COMMAND_SHIM_ARG_2: '"C:\\tmp & 100%\\ttsc.vsix"',
+          TTSC_VSCODE_COMMAND_SHIM_ARG_3: '"--force"',
+        },
+        windowsVerbatimArguments: true,
+      },
     },
   );
 
@@ -85,8 +103,93 @@ export const test_vscode_install_script_uses_windows_command_shim = () => {
       "/d",
       "/s",
       "/c",
-      `""${codeCmd}" "--install-extension" "C:\\tmp & 100%%\\ttsc.vsix" "--force""`,
+      payload,
     ],
-    options: { windowsVerbatimArguments: true },
+    options: {
+      env: {
+        ...env,
+        TTSC_VSCODE_COMMAND_SHIM_ARG_0: `"${codeCmd}"`,
+        TTSC_VSCODE_COMMAND_SHIM_ARG_1: '"--install-extension"',
+        TTSC_VSCODE_COMMAND_SHIM_ARG_2: '"C:\\tmp & 100%\\ttsc.vsix"',
+        TTSC_VSCODE_COMMAND_SHIM_ARG_3: '"--force"',
+      },
+      windowsVerbatimArguments: true,
+    },
   });
+
+  if (process.platform !== "win32") {
+    console.log(
+      "Skipped Windows code.cmd child-argv assertions: cmd.exe is unavailable.",
+    );
+    return;
+  }
+
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-vscode-code-"));
+  const sentinel = "TTSC_VSCODE_PERCENT_SENTINEL";
+  const dir = path.join(base, "Code & SDK 100% %" + sentinel + "% ^");
+  const code = path.join(dir, "code.cmd");
+  const record = path.join(base, "record-argv.json");
+  const recorder = path.join(base, "record-argv.cjs");
+  const actualArgs = [
+    "--install-extension",
+    path.join(dir, "%" + sentinel + "%.vsix"),
+    "--force",
+    "%",
+    "ends%",
+    "%" + sentinel + "%",
+    "%%",
+    "a&b",
+    "caret^",
+    "",
+    "trailing\\",
+    'embedded " quote',
+    'backslash-before-\\"quote',
+  ];
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      recorder,
+      [
+        'const fs = require("node:fs");',
+        'fs.writeFileSync(process.env.TTSC_VSCODE_TEST_RECORD, JSON.stringify(process.argv.slice(2)));',
+        "",
+      ].join("\n"),
+    );
+    fs.writeFileSync(
+      code,
+      [
+        "@echo off",
+        '"%TTSC_VSCODE_TEST_NODE%" "%TTSC_VSCODE_TEST_RECORDER%" %*',
+        "",
+      ].join("\r\n"),
+    );
+    const command = mod.createCodeCommand(
+      actualArgs,
+      "win32",
+      {
+        ...process.env,
+        ComSpec: process.env.ComSpec ?? process.env.COMSPEC ?? "cmd.exe",
+        [sentinel]: "EXPANDED",
+        TTSC_VSCODE_TEST_NODE: process.execPath,
+        TTSC_VSCODE_TEST_RECORDER: recorder,
+        TTSC_VSCODE_TEST_RECORD: record,
+      },
+      {
+        existsSync: (candidate: string) => candidate === code,
+        spawnSync: () => ({ stdout: code + "\r\n" }),
+      },
+    );
+    const result = spawnSync(command.command, command.args, {
+      ...command.options,
+      encoding: "utf8",
+      windowsHide: true,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(record, "utf8")),
+      actualArgs,
+    );
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
 };

--- a/tests/test-ttsc/src/features/ttscserver/test_vscode_server_launch_command_spawns_windows_command_shim.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_vscode_server_launch_command_spawns_windows_command_shim.ts
@@ -15,7 +15,7 @@ import path from "node:path";
  * must receive every LSP argument verbatim, while the negative twin — the same
  * command without the flag — must not.
  *
- * 1. Build launcher, cwd, and tsconfig paths containing spaces and `&`.
+ * 1. Build launcher, cwd, and tsconfig paths containing spaces, `&`, `%`, and `^`.
  * 2. Assert only the `.cmd`/`.bat` executables carry `windowsVerbatimArguments`.
  * 3. On Windows, spawn a recording `.cmd` and `.bat` with the exact executable
  *    options and confirm the recorded args equal the expected LSP args.
@@ -44,7 +44,23 @@ export const test_vscode_server_launch_command_spawns_windows_command_shim =
     )}).href);
 
     const base = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-vscode-launch-"));
-    const dir = path.join(base, "Tools & SDK (x86)");
+    const recorder = path.join(base, "record-argv.cjs");
+    const sentinel = "TTSC_VSCODE_PERCENT_SENTINEL";
+    process.env[sentinel] = "EXPANDED";
+    process.env.TTSC_VSCODE_TEST_NODE = process.execPath;
+    process.env.TTSC_VSCODE_TEST_RECORDER = recorder;
+    fs.writeFileSync(
+      recorder,
+      [
+        'const fs = require("node:fs");',
+        'fs.writeFileSync(process.env.TTSC_VSCODE_TEST_RECORD, JSON.stringify(process.argv.slice(2)));',
+        "",
+      ].join("\\n"),
+    );
+    const dir = path.join(
+      base,
+      "Tools & SDK (x86) 100% %" + sentinel + "% ^",
+    );
     const cwd = path.join(dir, "my project");
     fs.mkdirSync(cwd, { recursive: true });
     const tsconfig = path.join(cwd, "tsconfig.json");
@@ -67,30 +83,22 @@ export const test_vscode_server_launch_command_spawns_windows_command_shim =
     };
     const expectedArgs = build(path.join(cwd, "server.exe")).args;
 
-    const recorder = (record) =>
-      [
-        "@echo off",
-        "setlocal enabledelayedexpansion",
-        'break>"' + record + '"',
-        ":loop",
-        'if "%~1"=="" goto :done',
-        'set "arg=%~1"',
-        '>>"' + record + '" echo(!arg!',
-        "shift",
-        "goto :loop",
-        ":done",
-        "endlocal",
-        "exit /b 0",
-        "",
-      ].join("\\r\\n");
     const readRecord = (record) =>
       fs.existsSync(record)
-        ? fs.readFileSync(record, "utf8").split(/\\r?\\n/).filter(Boolean)
+        ? JSON.parse(fs.readFileSync(record, "utf8"))
         : null;
     const runShim = (ext) => {
       const launcher = path.join(dir, "server." + ext);
-      const record = path.join(dir, "record-" + ext + ".txt");
-      fs.writeFileSync(launcher, recorder(record));
+      const record = path.join(base, "record-" + ext + ".json");
+      process.env.TTSC_VSCODE_TEST_RECORD = record;
+      fs.writeFileSync(
+        launcher,
+        [
+          "@echo off",
+          '"%TTSC_VSCODE_TEST_NODE%" "%TTSC_VSCODE_TEST_RECORDER%" %*',
+          "",
+        ].join("\\r\\n"),
+      );
       const exec = build(launcher);
       if (fs.existsSync(record)) fs.rmSync(record);
       const verbatim = spawnSync(exec.command, exec.args, Object.assign(
@@ -165,6 +173,9 @@ export const test_vscode_server_launch_command_spawns_windows_command_shim =
     assert.equal(parsed.shape.native, null);
 
     if (parsed.platform !== "win32") {
+      console.log(
+        "Skipped Windows command-shim child-argv assertions: cmd.exe is unavailable.",
+      );
       assert.equal(parsed.spawn, null);
       return;
     }

--- a/tests/test-ttsc/src/features/ttscserver/test_vscode_server_launch_command_uses_command_mode.ts
+++ b/tests/test-ttsc/src/features/ttscserver/test_vscode_server_launch_command_uses_command_mode.ts
@@ -60,6 +60,7 @@ export const test_vscode_server_launch_command_uses_command_mode = () => {
     cmd: {
       args: string[];
       command: string;
+      commandShimEnvironment?: NodeJS.ProcessEnv;
       windowsVerbatimArguments?: boolean;
     };
     js: { args: string[]; command: string; windowsVerbatimArguments?: boolean };
@@ -101,6 +102,17 @@ export const test_vscode_server_launch_command_uses_command_mode = () => {
   assert.equal(parsed.cmd.args[1], "/s");
   assert.equal(parsed.cmd.args[2], "/c");
   const cmdPayload = parsed.cmd.args[3] ?? "";
-  assert.match(cmdPayload, /^""C:\\\\Tools & SDK\\\\ttscserver\.cmd"/);
-  assert.match(cmdPayload, /"--cwd=/);
+  assert.equal(
+    cmdPayload,
+    '"%TTSC_VSCODE_COMMAND_SHIM_ARG_0% %TTSC_VSCODE_COMMAND_SHIM_ARG_1% %TTSC_VSCODE_COMMAND_SHIM_ARG_2% %TTSC_VSCODE_COMMAND_SHIM_ARG_3% %TTSC_VSCODE_COMMAND_SHIM_ARG_4% %TTSC_VSCODE_COMMAND_SHIM_ARG_5%"',
+  );
+  assert.deepEqual(parsed.cmd.commandShimEnvironment, {
+    TTSC_VSCODE_COMMAND_SHIM_ARG_0: `"${cmdLauncher}"`,
+    TTSC_VSCODE_COMMAND_SHIM_ARG_1: '"--stdio"',
+    TTSC_VSCODE_COMMAND_SHIM_ARG_2: `"--cwd=${cwd}"`,
+    TTSC_VSCODE_COMMAND_SHIM_ARG_3:
+      '"--suppress-execute-command-ids=ttsc.lint.fixAll,ttsc.format.document"',
+    TTSC_VSCODE_COMMAND_SHIM_ARG_4: `"--execute-command-id-prefix=${parsed.prefix}"`,
+    TTSC_VSCODE_COMMAND_SHIM_ARG_5: `"--tsconfig=${tsconfig}"`,
+  });
 };


### PR DESCRIPTION
Closes #804.\n\nCampaign reservation for the duplicated Windows command-shim quoting surface. Implementation, Windows child-argv regression coverage, local verification, and solo self-review follow after the required exact-SHA CI gate.