### PR TITLE
fix(paths): preserve module reference semantics

### DIFF
--- a/packages/paths/driver/paths.go
+++ b/packages/paths/driver/paths.go
@@ -6,6 +6,7 @@ import (
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimchecker "github.com/microsoft/typescript-go/shim/checker"
   shimcore "github.com/microsoft/typescript-go/shim/core"
   shimtspath "github.com/microsoft/typescript-go/shim/tspath"
 
@@ -32,6 +33,7 @@ func (plugin) ApplyProgram(prog *driver.Program, _ driver.PluginContext) error {
 // rewriter holds the resolved tsconfig paths configuration used to rewrite
 // module specifiers across an entire program.
 type rewriter struct {
+  checker     *shimchecker.Checker
   basePath    string
   jsxPreserve bool
   outDir      string
@@ -60,6 +62,7 @@ func newRewriter(prog *driver.Program) *rewriter {
   if prog == nil || prog.ParsedConfig == nil || prog.ParsedConfig.ParsedConfig == nil || prog.ParsedConfig.ParsedConfig.CompilerOptions == nil {
     return out
   }
+  out.checker = prog.Checker
   options := prog.ParsedConfig.ParsedConfig.CompilerOptions
   cwd := prog.Host.GetCurrentDirectory()
   out.basePath = filepath.Clean(options.GetPathsBasePath(cwd))
@@ -104,7 +107,7 @@ func (r *rewriter) apply(file *shimast.SourceFile) {
   if r == nil || file == nil || len(r.patterns) == 0 {
     return
   }
-  visitModuleSpecifiers(file.AsNode(), func(lit *shimast.Node) {
+  visitModuleSpecifiers(file, r.checker, func(lit *shimast.Node) {
     if lit == nil || lit.Kind != shimast.KindStringLiteral {
       return
     }
@@ -118,16 +121,16 @@ func (r *rewriter) apply(file *shimast.SourceFile) {
   })
 }
 
-// visitModuleSpecifiers recursively walks the AST rooted at node, calling
-// visit for every string-literal module specifier it finds. Covered nodes
-// include import/export declarations, require() calls, dynamic import()
-// expressions, import-equals declarations, and import-type nodes.
+// visitModuleSpecifiers recursively walks file, calling visit for every
+// string-literal module reference it finds. Syntax identifies candidates, then
+// SourceFile and Checker facts exclude declarations and calls whose literal is
+// not actually a module reference in the containing file.
 //
 // The recursion runs through one closure created per walk, not one per node:
 // handing ForEachChild a fresh closure at every node would allocate once per
 // AST node across the whole program on every apply pass.
-func visitModuleSpecifiers(node *shimast.Node, visit func(*shimast.Node)) {
-  if node == nil {
+func visitModuleSpecifiers(file *shimast.SourceFile, checker *shimchecker.Checker, visit func(*shimast.Node)) {
+  if file == nil {
     return
   }
   var walk func(node *shimast.Node) bool
@@ -152,24 +155,24 @@ func visitModuleSpecifiers(node *shimast.Node, visit func(*shimast.Node)) {
       }
     case shimast.KindModuleDeclaration:
       decl := node.AsModuleDeclaration()
-      if decl != nil {
+      if file.ExternalModuleIndicator != nil && decl != nil {
         visit(decl.Name())
       }
     case shimast.KindCallExpression:
       call := node.AsCallExpression()
-      if isModuleSpecifierCall(call) && call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+      if isModuleSpecifierCall(checker, call) && call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
         visit(call.Arguments.Nodes[0])
       }
     }
     node.ForEachChild(walk)
     return false
   }
-  walk(node)
+  walk(file.AsNode())
 }
 
 // isModuleSpecifierCall reports whether call is a dynamic import() or a
-// CommonJS require() expression.
-func isModuleSpecifierCall(call *shimast.CallExpression) bool {
+// CommonJS require() expression that resolves to the module loader.
+func isModuleSpecifierCall(checker *shimchecker.Checker, call *shimast.CallExpression) bool {
   if call == nil || call.Expression == nil {
     return false
   }
@@ -177,10 +180,26 @@ func isModuleSpecifierCall(call *shimast.CallExpression) bool {
   case shimast.KindImportKeyword:
     return true
   case shimast.KindIdentifier:
-    return call.Expression.Text() == "require"
+    return call.Expression.Text() == "require" && isModuleLoader(checker, call.Expression)
   default:
     return false
   }
+}
+
+// isModuleLoader reports whether expression names the CommonJS loader rather
+// than a parameter, local, or imported binding named require. An unresolved
+// bare require is the runtime CommonJS global; declared loaders are ambient.
+func isModuleLoader(checker *shimchecker.Checker, expression *shimast.Node) bool {
+  if checker == nil || expression == nil {
+    return false
+  }
+  symbol := checker.GetSymbolAtLocation(expression)
+  if symbol == nil {
+    return true
+  }
+  return symbol.Flags&shimast.SymbolFlagsAlias == 0 &&
+    symbol.ValueDeclaration != nil &&
+    symbol.ValueDeclaration.Flags&shimast.NodeFlagsAmbient != 0
 }
 
 // rewrite resolves specifier from fromSource using the tsconfig paths table and

--- a/packages/paths/test/command_preserves_global_ambient_module_test.go
+++ b/packages/paths/test/command_preserves_global_ambient_module_test.go
@@ -1,0 +1,44 @@
+package paths_test
+
+import (
+  "encoding/json"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestCommandPreservesGlobalAmbientModule verifies paths does not make a global ambient module relative.
+//
+// A string-named declaration is an augmentation only inside an external module.
+// Rewriting the same declaration in a script creates TS2436, so this reaches the
+// sidecar and re-checks its returned source rather than only inspecting text.
+//
+// 1. Transform a script that declares an aliased ambient module.
+// 2. Assert the returned declaration keeps its non-relative name.
+// 3. Check the transformed source without the plugin.
+func TestCommandPreservesGlobalAmbientModule(t *testing.T) {
+  root := seedProject(t, map[string]string{
+    "tsconfig.json":      `{"compilerOptions":{"target":"ES2022","module":"commonjs","strict":true,"paths":{"@lib/*":["./src/lib/*"]},"outDir":"dist","rootDir":"src"},"include":["src"]}`,
+    "src/global.ts":      `declare module "@lib/ambient" { export const value: "global"; }` + "\n",
+    "src/lib/ambient.ts": `export const value = "global";` + "\n",
+  })
+
+  code, stdout, stderr := runPlugin(t, "transform", "--cwd="+root, "--tsconfig="+filepath.Join(root, "tsconfig.json"), "--plugins-json="+pathsManifest(t))
+  if code != 0 || stderr != "" {
+    t.Fatalf("transform branch mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+  var result transformResult
+  if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &result); err != nil {
+    t.Fatalf("transform output is not JSON: %v\n%s", err, stdout)
+  }
+  global := result.TypeScript["src/global.ts"]
+  if !strings.Contains(global, `declare module "@lib/ambient"`) || strings.Contains(global, `./lib/ambient.js`) {
+    t.Fatalf("global ambient module was rewritten:\n%s", global)
+  }
+
+  writeFile(t, filepath.Join(root, "src", "global.ts"), global)
+  code, stdout, stderr = runPlugin(t, "check", "--cwd="+root, "--tsconfig="+filepath.Join(root, "tsconfig.json"), "--plugins-json=[]", "--quiet")
+  if code != 0 || stdout != "" || stderr != "" {
+    t.Fatalf("transformed global ambient module did not type-check: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+}

--- a/packages/paths/test/command_rewrites_all_module_specifier_forms_test.go
+++ b/packages/paths/test/command_rewrites_all_module_specifier_forms_test.go
@@ -34,6 +34,8 @@ type Box = import("@types/box").Box;
 declare module "@ambient/thing" { export const ambient: string; }
 declare function fn(value: string): void;
 declare const obj: { require(id: string): void };
+namespace UntouchedNamespace {}
+declare module "@unmatched/name" {}
 fn("@lib/message");
 obj.require("@lib/message");
 export const value = message;
@@ -67,6 +69,9 @@ void load;
   }
   if !strings.Contains(main, `obj.require("@lib/message")`) {
     t.Fatalf("property access call should stay untouched:\n%s", main)
+  }
+  if !strings.Contains(main, `namespace UntouchedNamespace`) || !strings.Contains(main, `module "@unmatched/name"`) {
+    t.Fatalf("non-module and unmatched declarations should stay untouched:\n%s", main)
   }
 
   localNoRootDir := seedProject(t, map[string]string{

--- a/packages/paths/test/command_rewrites_only_unshadowed_require_test.go
+++ b/packages/paths/test/command_rewrites_only_unshadowed_require_test.go
@@ -24,6 +24,9 @@ func TestCommandRewritesOnlyUnshadowedRequire(t *testing.T) {
     "src/loader.ts": `declare function require(id: string): { message: string };
 export const loaded = require("@lib/message").message;
 `,
+    "src/unbound.ts": `// @ts-nocheck
+export const loaded = require("@lib/message").message;
+`,
     "src/parameter.ts": `export const value = (require: (id: string) => string): string => require("@lib/message");
 `,
     "src/local.ts": `export function value(): string {
@@ -47,6 +50,10 @@ export const value = require("@lib/message");
   if !strings.Contains(loader, `require("./lib/message.cjs")`) {
     t.Fatalf("ambient loader did not rewrite:\n%s", loader)
   }
+  unbound := readFile(t, filepath.Join(root, "dist", "unbound.js"))
+  if !strings.Contains(unbound, `require("./lib/message.cjs")`) {
+    t.Fatalf("unbound loader did not rewrite:\n%s", unbound)
+  }
   for _, file := range []string{"parameter.js", "local.js", "imported.js"} {
     output := readFile(t, filepath.Join(root, "dist", file))
     if !strings.Contains(output, `@lib/message`) {
@@ -60,11 +67,13 @@ const parameter = await import("./parameter.js");
 const local = await import("./local.js");
 const imported = await import("./imported.js");
 const loader = await import("./loader.js");
+const unbound = await import("./unbound.js");
 process.stdout.write(JSON.stringify([
   parameter.value((id) => id),
   local.value(),
   imported.value,
   loader.loaded,
+  unbound.loaded,
 ]));
 `)
   command := exec.Command("node", "runner.mjs")
@@ -73,7 +82,7 @@ process.stdout.write(JSON.stringify([
   if err != nil {
     t.Fatalf("emitted require cases did not run: %v\n%s", err, output)
   }
-  if got, want := strings.TrimSpace(string(output)), `["@lib/message","local:@lib/message","imported:@lib/message","ok"]`; got != want {
+  if got, want := strings.TrimSpace(string(output)), `["@lib/message","local:@lib/message","imported:@lib/message","ok","ok"]`; got != want {
     t.Fatalf("emitted require results mismatch: got %s, want %s", got, want)
   }
 }

--- a/packages/paths/test/command_rewrites_only_unshadowed_require_test.go
+++ b/packages/paths/test/command_rewrites_only_unshadowed_require_test.go
@@ -1,0 +1,79 @@
+package paths_test
+
+import (
+  "os/exec"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestCommandRewritesOnlyUnshadowedRequire verifies paths rewrites only the CommonJS loader.
+//
+// The identifier spelling alone cannot distinguish the global loader from a
+// parameter, local, or imported binding. The emitted program must preserve
+// those callback arguments because changing them alters observable results.
+//
+// 1. Build one project with ambient, parameter, local, and imported require calls.
+// 2. Assert only the ambient loader's emitted argument became a relative path.
+// 3. Execute the emitted modules and assert each shadowed call returns its original value.
+func TestCommandRewritesOnlyUnshadowedRequire(t *testing.T) {
+  root := seedProject(t, map[string]string{
+    "package.json":       `{"type":"module"}` + "\n",
+    "tsconfig.json":      `{"compilerOptions":{"target":"ES2022","module":"nodenext","moduleResolution":"nodenext","strict":true,"paths":{"@lib/*":["./src/lib/*"]},"outDir":"dist","rootDir":"src"},"include":["src"]}`,
+    "src/lib/message.cts": `export const message = "ok";` + "\n",
+    "src/loader.ts": `declare function require(id: string): { message: string };
+export const loaded = require("@lib/message").message;
+`,
+    "src/parameter.ts": `export const value = (require: (id: string) => string): string => require("@lib/message");
+`,
+    "src/local.ts": `export function value(): string {
+  const require = (id: string): string => "local:" + id;
+  return require("@lib/message");
+}
+`,
+    "src/shadow.ts": `export const require = (id: string): string => "imported:" + id;
+`,
+    "src/imported.ts": `import { require } from "./shadow.js";
+export const value = require("@lib/message");
+`,
+  })
+
+  code, stdout, stderr := runPlugin(t, "build", "--cwd="+root, "--tsconfig="+filepath.Join(root, "tsconfig.json"), "--plugins-json="+pathsManifest(t), "--emit", "--quiet")
+  if code != 0 || stdout != "" || stderr != "" {
+    t.Fatalf("build branch mismatch: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+  }
+
+  loader := readFile(t, filepath.Join(root, "dist", "loader.js"))
+  if !strings.Contains(loader, `require("./lib/message.cjs")`) {
+    t.Fatalf("ambient loader did not rewrite:\n%s", loader)
+  }
+  for _, file := range []string{"parameter.js", "local.js", "imported.js"} {
+    output := readFile(t, filepath.Join(root, "dist", file))
+    if !strings.Contains(output, `@lib/message`) {
+      t.Fatalf("shadowed require in %s was rewritten:\n%s", file, output)
+    }
+  }
+
+  writeFile(t, filepath.Join(root, "dist", "runner.mjs"), `import { createRequire } from "node:module";
+globalThis.require = createRequire(import.meta.url);
+const parameter = await import("./parameter.js");
+const local = await import("./local.js");
+const imported = await import("./imported.js");
+const loader = await import("./loader.js");
+process.stdout.write(JSON.stringify([
+  parameter.value((id) => id),
+  local.value(),
+  imported.value,
+  loader.loaded,
+]));
+`)
+  command := exec.Command("node", "runner.mjs")
+  command.Dir = filepath.Join(root, "dist")
+  output, err := command.CombinedOutput()
+  if err != nil {
+    t.Fatalf("emitted require cases did not run: %v\n%s", err, output)
+  }
+  if got, want := strings.TrimSpace(string(output)), `["@lib/message","local:@lib/message","imported:@lib/message","ok"]`; got != want {
+    t.Fatalf("emitted require results mismatch: got %s, want %s", got, want)
+  }
+}

--- a/packages/paths/test/linkname_helpers_test.go
+++ b/packages/paths/test/linkname_helpers_test.go
@@ -6,6 +6,7 @@ package paths_test
 
 import (
   shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimchecker "github.com/microsoft/typescript-go/shim/checker"
 
   _ "github.com/samchon/ttsc/packages/paths/driver"
   "github.com/samchon/ttsc/packages/ttsc/driver"
@@ -13,6 +14,7 @@ import (
 )
 
 type pathsRewriter struct {
+  checker     *shimchecker.Checker
   basePath    string
   jsxPreserve bool
   outDir      string
@@ -33,10 +35,10 @@ func pathsNewRewriter(prog *driver.Program) *pathsRewriter
 func pathsApply(r *pathsRewriter, file *shimast.SourceFile)
 
 //go:linkname pathsVisitModuleSpecifiers github.com/samchon/ttsc/packages/paths/driver.visitModuleSpecifiers
-func pathsVisitModuleSpecifiers(node *shimast.Node, visit func(*shimast.Node))
+func pathsVisitModuleSpecifiers(file *shimast.SourceFile, checker *shimchecker.Checker, visit func(*shimast.Node))
 
 //go:linkname pathsIsModuleSpecifierCall github.com/samchon/ttsc/packages/paths/driver.isModuleSpecifierCall
-func pathsIsModuleSpecifierCall(call *shimast.CallExpression) bool
+func pathsIsModuleSpecifierCall(checker *shimchecker.Checker, call *shimast.CallExpression) bool
 
 //go:linkname pathsRewrite github.com/samchon/ttsc/packages/paths/driver.(*rewriter).rewrite
 func pathsRewrite(r *pathsRewriter, fromSource string, specifier string) (string, bool)

--- a/packages/paths/test/rewriter_helpers_cover_resolution_edges_test.go
+++ b/packages/paths/test/rewriter_helpers_cover_resolution_edges_test.go
@@ -23,10 +23,10 @@ func TestRewriterHelpersCoverResolutionEdges(t *testing.T) {
   }
   pathsApply(nil, nil)
   pathsApply(&pathsRewriter{}, nil)
-  pathsVisitModuleSpecifiers(nil, func(*shimast.Node) {
+  pathsVisitModuleSpecifiers(nil, nil, func(*shimast.Node) {
     t.Fatal("nil node should not be visited")
   })
-  if pathsIsModuleSpecifierCall(nil) {
+  if pathsIsModuleSpecifierCall(nil, nil) {
     t.Fatal("nil call should not be a module specifier call")
   }
 

--- a/website/src/content/docs/development/walkthroughs/paths.mdx
+++ b/website/src/content/docs/development/walkthroughs/paths.mdx
@@ -4,7 +4,7 @@
 
 This page is also the canonical reference for **leaf-text AST mutation**, changing a string literal's `Text` field correctly. The invariant lives in three lines of code at the heart of `rewriter.apply`.
 
-If [`@ttsc/strip`](/docs/development/walkthroughs/strip) felt manageable, this should too. The new ideas are: read tsconfig fields through the driver, walk every syntactic shape that holds a module specifier, and the synthesize-flag rule.
+If [`@ttsc/strip`](/docs/development/walkthroughs/strip) felt manageable, this should too. The new ideas are: read tsconfig fields through the driver, walk each syntactic shape that can hold a module specifier, confirm that the literal is a module reference in its containing file, and apply the synthesize-flag rule.
 
 ## What it does for the consumer
 
@@ -77,7 +77,7 @@ Everything below is in [`packages/paths/driver/paths.go`](https://github.com/sam
 
 1. **Build the rewriter** from the loaded Program. This is where tsconfig paths, `rootDir`, `outDir`, and the source-file index get cached.
 2. **Sort patterns by specificity** so `@lib/foo/*` wins before `@lib/*` for the same specifier.
-3. **For each file**, walk every node and find string literals that are module specifiers.
+3. **For each file**, walk every node and select only string literals that are module references in that file.
 4. **Resolve the specifier** to a source file inside the Program.
 5. **Compute the relative output path** from the rewriter's source file to the target's emitted JS.
 6. **Mutate the string literal's `Text`**: with the synthesize-flag invariant.
@@ -86,6 +86,7 @@ Everything below is in [`packages/paths/driver/paths.go`](https://github.com/sam
 
 ```go
 type rewriter struct {
+  checker     *shimchecker.Checker
   basePath    string
   jsxPreserve bool
   outDir      string
@@ -106,6 +107,7 @@ func newRewriter(prog *driver.Program) *rewriter {
     prog.ParsedConfig.ParsedConfig.CompilerOptions == nil {
     return out
   }
+  out.checker = prog.Checker
   options := prog.ParsedConfig.ParsedConfig.CompilerOptions
   cwd := prog.Host.GetCurrentDirectory()
   out.basePath = filepath.Clean(options.GetPathsBasePath(cwd))
@@ -187,14 +189,14 @@ func patternPrefixLength(pattern string) int {
 
 The order is tsc's `matchPatternOrExact` contract: an exact pattern (no `*`) always wins, and among wildcards the longest literal _prefix_ wins — `@lib/foo/*` (prefix 9) beats `@lib/*` (prefix 5). Ranking by total literal length instead would let a long-suffix pattern like `*-styles` capture a specifier that tsc's module resolution routes through `@app/*`, and the rewrite would then disagree with the type checker.
 
-### 3. Walk every node that could hold a module specifier
+### 3. Walk every node that could hold a module reference
 
 ```go
 func (r *rewriter) apply(file *shimast.SourceFile) {
   if r == nil || file == nil || len(r.patterns) == 0 {
     return
   }
-  visitModuleSpecifiers(file.AsNode(), func(lit *shimast.Node) {
+  visitModuleSpecifiers(file, r.checker, func(lit *shimast.Node) {
     if lit == nil || lit.Kind != shimast.KindStringLiteral {
       return
     }
@@ -211,11 +213,11 @@ func (r *rewriter) apply(file *shimast.SourceFile) {
 
 This three-line tail is the synthesize-flag rule for leaf-text mutations, the most consequential lines on the page. Discussion in [§6 below](#6-mutating-a-string-literal--the-synthesize-flag-invariant).
 
-The visitor:
+The visitor uses syntax to find candidate literals, then the source file and checker to keep only module references:
 
 ```go
-func visitModuleSpecifiers(node *shimast.Node, visit func(*shimast.Node)) {
-  if node == nil {
+func visitModuleSpecifiers(file *shimast.SourceFile, checker *shimchecker.Checker, visit func(*shimast.Node)) {
+  if file == nil {
     return
   }
   var walk func(node *shimast.Node) bool
@@ -240,22 +242,22 @@ func visitModuleSpecifiers(node *shimast.Node, visit func(*shimast.Node)) {
       }
     case shimast.KindModuleDeclaration:
       decl := node.AsModuleDeclaration()
-      if decl != nil {
+      if file.ExternalModuleIndicator != nil && decl != nil {
         visit(decl.Name())
       }
     case shimast.KindCallExpression:
       call := node.AsCallExpression()
-      if isModuleSpecifierCall(call) && call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+      if isModuleSpecifierCall(checker, call) && call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
         visit(call.Arguments.Nodes[0])
       }
     }
     node.ForEachChild(walk)
     return false
   }
-  walk(node)
+  walk(file.AsNode())
 }
 
-func isModuleSpecifierCall(call *shimast.CallExpression) bool {
+func isModuleSpecifierCall(checker *shimchecker.Checker, call *shimast.CallExpression) bool {
   if call == nil || call.Expression == nil {
     return false
   }
@@ -263,23 +265,37 @@ func isModuleSpecifierCall(call *shimast.CallExpression) bool {
   case shimast.KindImportKeyword:
     return true
   case shimast.KindIdentifier:
-    return call.Expression.Text() == "require"
+    return call.Expression.Text() == "require" && isModuleLoader(checker, call.Expression)
   default:
     return false
   }
 }
+
+func isModuleLoader(checker *shimchecker.Checker, expression *shimast.Node) bool {
+  if checker == nil || expression == nil {
+    return false
+  }
+  symbol := checker.GetSymbolAtLocation(expression)
+  if symbol == nil {
+    return true
+  }
+  return symbol.Flags&shimast.SymbolFlagsAlias == 0 &&
+    symbol.ValueDeclaration != nil &&
+    symbol.ValueDeclaration.Flags&shimast.NodeFlagsAmbient != 0
+}
 ```
 
-Six syntactic positions hold a module specifier in TypeScript. The visitor enumerates each one explicitly because the field name and depth differ per kind:
+Six syntactic positions can contain a module-specifier literal. Syntax locates the candidate; the two marked rows also require semantic classification because TypeScript gives the same shape different meanings in different files and scopes:
 
-| Source | Kind | Where the literal hides |
-| --- | --- | --- |
-| `import x from "pkg"` | `ImportDeclaration` | `.ModuleSpecifier` |
-| `export { x } from "pkg"` | `ExportDeclaration` | `.ModuleSpecifier` |
-| `import x = require("pkg")` | `ImportEqualsDeclaration` | `.ModuleReference.AsExternalModuleReference().Expression` |
-| `type T = import("pkg").T` | `ImportType` | `.Argument.AsLiteralTypeNode().Literal` |
-| `declare module "pkg" {}` | `ModuleDeclaration` | `.Name()` (a `StringLiteral` only for the ambient `declare module "pkg"` form; `namespace foo {}` / `module foo {}` resolve to an `Identifier` and are filtered out by the `KindStringLiteral` check inside `apply`) |
-| `require("pkg")` / `import("pkg")` | `CallExpression` | `.Arguments.Nodes[0]` |
+| Source | Kind | Literal location | Rewrite condition |
+| --- | --- | --- | --- |
+| `import x from "pkg"` | `ImportDeclaration` | `.ModuleSpecifier` | Always |
+| `export { x } from "pkg"` | `ExportDeclaration` | `.ModuleSpecifier` | Always |
+| `import x = require("pkg")` | `ImportEqualsDeclaration` | `.ModuleReference.AsExternalModuleReference().Expression` | Always |
+| `type T = import("pkg").T` | `ImportType` | `.Argument.AsLiteralTypeNode().Literal` | Always |
+| `declare module "pkg" {}` | `ModuleDeclaration` | `.Name()` | Only when the containing `SourceFile` is an external module, where the declaration augments that module. A global ambient declaration in a script stays unchanged. `namespace foo {}` and `module foo {}` have `Identifier` names and are still filtered out by `apply`. |
+| `import("pkg")` | `CallExpression` | `.Arguments.Nodes[0]` | Always |
+| `require("pkg")` | `CallExpression` | `.Arguments.Nodes[0]` | Only when the identifier resolves to the module loader, not to a parameter, local, or imported binding. |
 
 After the switch, `node.ForEachChild` recurses into every child. This is what makes the visitor catch deeply-nested cases like `function f(x = await import("pkg")) {}`. The `CallExpression` is buried inside parameter default initializers, but every node still gets visited because we always recurse.
 
@@ -469,7 +485,7 @@ When in doubt, set both. The cost is zero and the failure mode is silent.
 
 ## Pulling it together
 
-`rewriter` is the only shipped transform in this tour that needs project-wide Program facts beyond the source file currently being visited. Its constructor caches the Program's `ParsedConfig.CompilerOptions`, `SourceFiles`, and the `Paths` map; everything else is a pure function of those four facts and the input specifier string.
+`rewriter` is the only shipped transform in this tour that needs project-wide Program facts beyond the source file currently being visited. Its constructor caches the Program's `ParsedConfig.CompilerOptions`, `SourceFiles`, `Checker`, and `Paths` map; everything else is a pure function of those facts and the input specifier string.
 
 The pattern generalizes to any plugin that needs to query _project-level_ information:
 
@@ -484,7 +500,7 @@ The pattern generalizes to any plugin that needs to query _project-level_ inform
 
 - The pattern of caching tsconfig facts on a constructor-built struct (`rewriter`). Avoids re-querying for every node.
 - The pattern-precedence sort. Whenever you read a user-supplied map keyed on globs or patterns, copy this idiom: pull entries into a slice, then `sort.SliceStable` into the upstream tool's own precedence order. This makes resolution deterministic across runs and keeps it in agreement with the resolver you are mirroring.
-- The visitor that enumerates every module-specifier kind. If your plugin cares about module specifiers, this is the exhaustive list as of TypeScript 5.x.
+- The syntax enumeration plus semantic gates. Do not infer a module reference from node kind or identifier text alone. Use `SourceFile` and `Checker` facts when TypeScript gives a construct different meanings.
 - The synthesize-flag invariant. Read it once; tattoo it.
 
 **Do not copy:**


### PR DESCRIPTION
## Intent

Fix #805 by rewriting a paths alias only when the string is a module reference in its containing source file.

## Scope

- classify string-named module declarations using the source file's external-module state;
- classify bare `require` calls with the TypeScript-Go checker so locally or imported bindings stay untouched;
- add real `@ttsc/paths` sidecar regression coverage and update the paths walkthrough.

## Deferred

No shim change is expected: the pinned aliases already expose the required checker, symbol, and source-file state.

## Verification

Pending. This is an implementation-free campaign reservation. Campaign Actions for this branch are deliberately cancelled by exact commit SHA; local sidecar and feature-suite verification plus solo Self-Review are the merge gates.

Closes #805.
