### PR TITLE
fix(release): verify Windows platform package contents

### DIFF
--- a/scripts/assert-platform-package.cjs
+++ b/scripts/assert-platform-package.cjs
@@ -76,11 +76,13 @@ function inspectPackageDir(dir) {
       failures.push(`${manifest.name}: missing executable ${rel}`);
       continue;
     }
-    const mode = fs.statSync(file).mode & 0o777;
-    if (platform.os !== "win32" && !hasExecutableMode(mode)) {
-      failures.push(
-        `${manifest.name}: ${rel} has mode ${formatMode(mode)}, expected executable mode`,
-      );
+    if (platform.os !== "win32") {
+      const mode = fs.statSync(file).mode & 0o777;
+      if (!hasExecutableMode(mode)) {
+        failures.push(
+          `${manifest.name}: ${rel} has mode ${formatMode(mode)}, expected executable mode`,
+        );
+      }
     }
   }
 }

--- a/scripts/assert-platform-package.cjs
+++ b/scripts/assert-platform-package.cjs
@@ -7,7 +7,7 @@ const args = process.argv.slice(2);
 const sourceMode = args.includes("--source");
 const targets = args.filter((arg) => !arg.startsWith("--"));
 const failures = [];
-const baseExecutablePaths = [
+const posixBaseExecutablePaths = [
   "bin/ttsc",
   "bin/ttscserver",
   "bin/ttscgraph",
@@ -19,7 +19,7 @@ const minimumExecutablePaths = [
   "bin/go/bin/go",
   "bin/go/bin/gofmt",
 ];
-const requiredExecutableConfigPaths = baseExecutablePaths.map(
+const requiredExecutableConfigPaths = posixBaseExecutablePaths.map(
   (rel) => `./${rel}`,
 );
 
@@ -64,10 +64,12 @@ function inspectPackageDir(dir) {
   const manifestPath = path.join(dir, "package.json");
   const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
   const platform = platformFromPackageName(manifest.name);
-  if (platform === null || platform.os === "win32") return;
+  if (platform === null) return;
 
-  const executablePaths = requiredExecutablePaths(dir);
-  inspectExecutablePublishConfig(manifest, executablePaths);
+  const executablePaths = requiredExecutablePaths(dir, platform);
+  if (platform.os !== "win32") {
+    inspectExecutablePublishConfig(manifest, executablePaths);
+  }
   for (const rel of executablePaths) {
     const file = path.join(dir, rel);
     if (!fs.existsSync(file)) {
@@ -75,7 +77,7 @@ function inspectPackageDir(dir) {
       continue;
     }
     const mode = fs.statSync(file).mode & 0o777;
-    if (!hasExecutableMode(mode)) {
+    if (platform.os !== "win32" && !hasExecutableMode(mode)) {
       failures.push(
         `${manifest.name}: ${rel} has mode ${formatMode(mode)}, expected executable mode`,
       );
@@ -92,16 +94,20 @@ function inspectTarball(file) {
   }
   const manifest = JSON.parse(packageJson.content.toString("utf8"));
   const platform = platformFromPackageName(manifest.name);
-  if (platform === null || platform.os === "win32") return;
+  if (platform === null) return;
 
-  for (const rel of requiredExecutablePathsFromEntries(entries, manifest)) {
+  for (const rel of requiredExecutablePathsFromEntries(
+    entries,
+    manifest,
+    platform,
+  )) {
     const name = `package/${rel}`;
     const entry = entries.get(name);
     if (!entry) {
       failures.push(`${manifest.name}: tarball missing executable ${rel}`);
       continue;
     }
-    if (!hasExecutableMode(entry.mode)) {
+    if (platform.os !== "win32" && !hasExecutableMode(entry.mode)) {
       failures.push(
         `${manifest.name}: tarball ${rel} has mode ${formatMode(entry.mode)}, expected executable mode`,
       );
@@ -135,8 +141,9 @@ function inspectExecutablePublishConfig(manifest, executablePaths) {
   }
 }
 
-function requiredExecutablePaths(packageDir) {
-  const paths = [...baseExecutablePaths];
+function requiredExecutablePaths(packageDir, platform) {
+  const paths = baseExecutablePaths(platform);
+  if (platform.os === "win32") return paths;
   const toolDir = path.join(packageDir, "bin", "go", "pkg", "tool");
   if (fs.existsSync(toolDir)) {
     for (const file of walkFiles(toolDir)) {
@@ -146,9 +153,10 @@ function requiredExecutablePaths(packageDir) {
   return paths;
 }
 
-function requiredExecutablePathsFromEntries(entries, manifest) {
+function requiredExecutablePathsFromEntries(entries, manifest, platform) {
+  if (platform.os === "win32") return baseExecutablePaths(platform);
   const configured = configuredExecutablePaths(manifest);
-  const paths = configured ?? [...baseExecutablePaths];
+  const paths = configured ?? baseExecutablePaths(platform);
   for (const rel of minimumExecutablePaths) {
     if (!paths.includes(rel)) paths.push(rel);
   }
@@ -163,6 +171,11 @@ function requiredExecutablePathsFromEntries(entries, manifest) {
     }
   }
   return paths;
+}
+
+function baseExecutablePaths(platform) {
+  const suffix = platform.os === "win32" ? ".exe" : "";
+  return posixBaseExecutablePaths.map((rel) => `${rel}${suffix}`);
 }
 
 function configuredExecutablePaths(manifest) {

--- a/tests/test-ttsc/src/features/platform/test_platform_package_windows_contents_require_base_executables.ts
+++ b/tests/test-ttsc/src/features/platform/test_platform_package_windows_contents_require_base_executables.ts
@@ -1,0 +1,224 @@
+import zlib from "node:zlib";
+
+import {
+  assert,
+  child_process,
+  fs,
+  path,
+  workspaceRoot,
+} from "../../internal/toolchain";
+
+const windowsBaseExecutables = [
+  "bin/ttsc.exe",
+  "bin/ttscserver.exe",
+  "bin/ttscgraph.exe",
+  "bin/go/bin/go.exe",
+  "bin/go/bin/gofmt.exe",
+];
+
+/**
+ * Verifies Windows platform package contents require the base executables.
+ *
+ * Windows tarballs need every launcher and bundled-Go base executable even
+ * though they do not carry POSIX executable bits or pnpm's POSIX-only
+ * `executableFiles` metadata. The source and tarball gates must therefore share
+ * the same independent five-path inventory instead of accepting an empty
+ * package or trusting the artifact to inventory itself.
+ *
+ * 1. Exercise empty and single-file-missing Windows source packages and tarballs
+ *    against the real release verifier.
+ * 2. Accept complete 0644 Windows artifacts without executable metadata while
+ *    keeping the unlisted Go-tool and non-platform boundaries explicit.
+ * 3. Confirm win32-arm64 follows the same base-path rule.
+ */
+export const test_platform_package_windows_contents_require_base_executables =
+  () => {
+    const root = fs.mkdtempSync(
+      path.join(process.cwd(), ".tmp-platform-windows-"),
+    );
+    try {
+      const script = path.join(
+        workspaceRoot,
+        "scripts",
+        "assert-platform-package.cjs",
+      );
+      const emptySource = path.join(root, "empty-source");
+      const emptyTarball = path.join(root, "empty.tgz");
+      writeWindowsSourcePackage(emptySource, []);
+      writeWindowsTarball(emptyTarball, []);
+      assertMissing(script, emptySource, "missing executable bin/ttsc.exe");
+      assertMissing(
+        script,
+        emptyTarball,
+        "tarball missing executable bin/ttsc.exe",
+      );
+
+      const withoutGofmt = windowsBaseExecutables.filter(
+        (rel) => rel !== "bin/go/bin/gofmt.exe",
+      );
+      const missingGofmtSource = path.join(root, "missing-gofmt-source");
+      const missingGofmtTarball = path.join(root, "missing-gofmt.tgz");
+      writeWindowsSourcePackage(missingGofmtSource, withoutGofmt);
+      writeWindowsTarball(missingGofmtTarball, withoutGofmt);
+      assertMissing(
+        script,
+        missingGofmtSource,
+        "missing executable bin/go/bin/gofmt.exe",
+      );
+      assertMissing(
+        script,
+        missingGofmtTarball,
+        "tarball missing executable bin/go/bin/gofmt.exe",
+      );
+
+      const completeSource = path.join(root, "complete-source");
+      const completeTarball = path.join(root, "complete.tgz");
+      const unlistedTool = "bin/go/pkg/tool/windows_amd64/compile.exe";
+      writeWindowsSourcePackage(completeSource, [
+        ...windowsBaseExecutables,
+        unlistedTool,
+      ]);
+      writeWindowsTarball(completeTarball, [
+        ...windowsBaseExecutables,
+        unlistedTool,
+      ]);
+      assertAccepted(script, completeSource);
+      assertAccepted(script, completeTarball);
+
+      const baseOnlySource = path.join(root, "base-only-source");
+      const baseOnlyTarball = path.join(root, "base-only.tgz");
+      writeWindowsSourcePackage(baseOnlySource, windowsBaseExecutables);
+      writeWindowsTarball(baseOnlyTarball, windowsBaseExecutables);
+      assertAccepted(script, baseOnlySource);
+      assertAccepted(script, baseOnlyTarball);
+
+      const arm64Source = path.join(root, "arm64-source");
+      writeWindowsSourcePackage(
+        arm64Source,
+        windowsBaseExecutables,
+        "@ttsc/win32-arm64",
+      );
+      assertAccepted(script, arm64Source);
+
+      const nonPlatform = path.join(root, "non-platform");
+      writeWindowsSourcePackage(nonPlatform, [], "@ttsc/example");
+      assertAccepted(script, nonPlatform);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };
+
+function assertMissing(script: string, target: string, expected: string): void {
+  const result = runVerifier(script, target);
+  assert.equal(result.status, 1, result.stderr);
+  assert.ok(result.stderr.includes(expected), result.stderr);
+}
+
+function assertAccepted(script: string, target: string): void {
+  const result = runVerifier(script, target);
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function runVerifier(script: string, target: string) {
+  return child_process.spawnSync(process.execPath, [script, target], {
+    cwd: workspaceRoot,
+    encoding: "utf8",
+    windowsHide: true,
+  });
+}
+
+function writeWindowsSourcePackage(
+  root: string,
+  paths: string[],
+  name = "@ttsc/win32-x64",
+): void {
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({ name, version: "0.0.0" }),
+    "utf8",
+  );
+  for (const rel of paths) {
+    const file = path.join(root, rel);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "x", "utf8");
+  }
+}
+
+function writeWindowsTarball(
+  file: string,
+  paths: string[],
+  name = "@ttsc/win32-x64",
+): void {
+  const entries: TarEntry[] = [
+    {
+      content: JSON.stringify({ name, version: "0.0.0" }),
+      mode: 0o644,
+      name: "package/package.json",
+    },
+    ...paths.map((rel) => ({
+      content: "x",
+      mode: 0o644,
+      name: `package/${rel}`,
+    })),
+  ];
+  fs.writeFileSync(
+    file,
+    zlib.gzipSync(
+      Buffer.concat([...entries.map(tarEntry), Buffer.alloc(1024)]),
+    ),
+  );
+}
+
+interface TarEntry {
+  content: string;
+  mode: number;
+  name: string;
+}
+
+function tarEntry(entry: TarEntry): Buffer {
+  const body = Buffer.from(entry.content);
+  const header = Buffer.alloc(512, 0);
+  writeString(header, 0, 100, entry.name);
+  writeOctal(header, 100, 8, entry.mode);
+  writeOctal(header, 108, 8, 0);
+  writeOctal(header, 116, 8, 0);
+  writeOctal(header, 124, 12, body.length);
+  writeOctal(header, 136, 12, 0);
+  header.fill(0x20, 148, 156);
+  writeString(header, 156, 1, "0");
+  writeString(header, 257, 6, "ustar");
+  writeString(header, 263, 2, "00");
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  writeOctal(header, 148, 8, checksum);
+  return Buffer.concat([header, body, Buffer.alloc(padding(body.length), 0)]);
+}
+
+function writeString(
+  buffer: Buffer,
+  offset: number,
+  length: number,
+  value: string,
+): void {
+  buffer.write(
+    value,
+    offset,
+    Math.min(length, Buffer.byteLength(value)),
+    "utf8",
+  );
+}
+
+function writeOctal(
+  buffer: Buffer,
+  offset: number,
+  length: number,
+  value: number,
+): void {
+  const text = value.toString(8).padStart(length - 2, "0");
+  buffer.write(`${text}\0`, offset, length, "ascii");
+}
+
+function padding(size: number): number {
+  const remainder = size % 512;
+  return remainder === 0 ? 0 : 512 - remainder;
+}

--- a/tests/test-ttsc/src/features/platform/test_platform_package_windows_contents_require_base_executables.ts
+++ b/tests/test-ttsc/src/features/platform/test_platform_package_windows_contents_require_base_executables.ts
@@ -46,11 +46,15 @@ export const test_platform_package_windows_contents_require_base_executables =
       const emptyTarball = path.join(root, "empty.tgz");
       writeWindowsSourcePackage(emptySource, []);
       writeWindowsTarball(emptyTarball, []);
-      assertMissing(script, emptySource, "missing executable bin/ttsc.exe");
-      assertMissing(
+      assertAllBaseExecutablesMissing(
+        script,
+        emptySource,
+        "missing executable",
+      );
+      assertAllBaseExecutablesMissing(
         script,
         emptyTarball,
-        "tarball missing executable bin/ttsc.exe",
+        "tarball missing executable",
       );
 
       const withoutGofmt = windowsBaseExecutables.filter(
@@ -93,12 +97,19 @@ export const test_platform_package_windows_contents_require_base_executables =
       assertAccepted(script, baseOnlyTarball);
 
       const arm64Source = path.join(root, "arm64-source");
+      const arm64Tarball = path.join(root, "arm64.tgz");
       writeWindowsSourcePackage(
         arm64Source,
         windowsBaseExecutables,
         "@ttsc/win32-arm64",
       );
+      writeWindowsTarball(
+        arm64Tarball,
+        windowsBaseExecutables,
+        "@ttsc/win32-arm64",
+      );
       assertAccepted(script, arm64Source);
+      assertAccepted(script, arm64Tarball);
 
       const nonPlatform = path.join(root, "non-platform");
       writeWindowsSourcePackage(nonPlatform, [], "@ttsc/example");
@@ -112,6 +123,18 @@ function assertMissing(script: string, target: string, expected: string): void {
   const result = runVerifier(script, target);
   assert.equal(result.status, 1, result.stderr);
   assert.ok(result.stderr.includes(expected), result.stderr);
+}
+
+function assertAllBaseExecutablesMissing(
+  script: string,
+  target: string,
+  prefix: string,
+): void {
+  const result = runVerifier(script, target);
+  assert.equal(result.status, 1, result.stderr);
+  for (const rel of windowsBaseExecutables) {
+    assert.ok(result.stderr.includes(`${prefix} ${rel}`), result.stderr);
+  }
 }
 
 function assertAccepted(script: string, target: string): void {


### PR DESCRIPTION
## Intent

Fix #807 by making the platform-package release gate verify Windows package
contents without imposing POSIX executable-mode requirements.

## Scope

- require the independently derivable Windows `.exe` launcher and bundled Go
  base paths in source-package and tarball inspection;
- retain the POSIX-only `publishConfig.executableFiles` and tar-header mode
  assertions;
- add synthetic Windows directory/tarball coverage beside the existing POSIX
  regression, including the pass/fail boundaries in #807.

## Deferred

The current `pnpm 10.6.4` and `npm 11.14.1` pack comparison confirms that
`publishConfig.executableFiles` only controls pnpm tar-entry mode. This change
therefore does not add it to Windows manifests or infer completeness from the
artifact's own `pkg/tool` listing.

## Verification

Pending. This is an implementation-free campaign reservation. Actions caused
by this branch are cancelled only by exact commit SHA; local platform feature
tests, source/tarball probes, and solo Self-Review are the merge gates.

Closes #807.
