### PR TITLE
fix(graph): verify source display against reproducible bytes

### DIFF
--- a/packages/graph/src/model/TtscGraphSourceReader.ts
+++ b/packages/graph/src/model/TtscGraphSourceReader.ts
@@ -11,13 +11,17 @@ type ReadFile = (file: string) => Buffer;
  *
  * Signatures and declaration docs are display facts derived from source text,
  * but the live disk is not the snapshot the checker resolved. A file becomes
- * readable here only after its current bytes hash to the snapshot's
- * `checkerDigest`. Both success and failure are cached, so every consumer of a
- * `TtscGraphMemory` sees one adjudication and one immutable line array.
+ * readable here only after its current bytes hash to `diskDigest` and the
+ * compiler-decoded text hashes to `checkerDigest`. Both success and failure are
+ * cached, so every consumer of a `TtscGraphMemory` sees one adjudication and
+ * one immutable line array.
  */
 export class TtscGraphSourceReader {
   private readonly project: string;
-  private readonly checkerDigests: ReadonlyMap<string, string>;
+  private readonly digests: ReadonlyMap<
+    string,
+    { checker: string; disk: string }
+  >;
   private readonly read: ReadFile;
   private readonly cache = new Map<string, readonly string[] | undefined>();
 
@@ -30,40 +34,51 @@ export class TtscGraphSourceReader {
   ) {
     this.project = project;
     this.read = read;
-    this.checkerDigests = new Map(
-      provenance?.capabilities.includes("sourceDigests") === true
+    this.digests = new Map(
+      provenance?.capabilities.includes("sourceDigests") === true &&
+        provenance.capabilities.includes("diskDigests") === true
         ? provenance.sources.map((source) => [
             normalize(source.file),
-            source.checkerDigest,
+            { checker: source.checkerDigest, disk: source.diskDigest },
           ])
         : [],
     );
   }
 
   /**
-   * Return frozen lines only when the bytes still equal the checker snapshot. A
-   * missing manifest entry, read failure, or digest mismatch is a cached
-   * absence rather than a reason to mix current disk text into old graph
-   * facts.
+   * Return frozen lines only when raw disk bytes and compiler-decoded text both
+   * equal the checker snapshot. A missing manifest entry, read failure, or
+   * digest mismatch is a cached absence rather than a reason to mix current
+   * disk text into old graph facts.
    */
   lines(file: string): readonly string[] | undefined {
     const key = normalize(file);
     if (this.cache.has(key)) return this.cache.get(key);
 
-    const expected = this.checkerDigests.get(key);
-    if (expected === undefined || expected === "") {
+    const expected = this.digests.get(key);
+    if (
+      expected === undefined ||
+      expected.checker === "" ||
+      expected.disk === ""
+    ) {
       this.cache.set(key, undefined);
       return undefined;
     }
 
-    let text: string;
+    let bytes: Buffer;
     try {
-      text = this.read(path.resolve(this.project, file)).toString("utf8");
+      bytes = this.read(path.resolve(this.project, file));
     } catch {
       this.cache.set(key, undefined);
       return undefined;
     }
-    if (sha256(text) !== expected) {
+    if (sha256(bytes) !== expected.disk) {
+      this.cache.set(key, undefined);
+      return undefined;
+    }
+
+    const text = decodeSource(bytes);
+    if (sha256(text) !== expected.checker) {
       this.cache.set(key, undefined);
       return undefined;
     }
@@ -78,6 +93,23 @@ function normalize(file: string): string {
   return file.replace(/\\/g, "/");
 }
 
-function sha256(text: string): string {
-  return createHash("sha256").update(text, "utf8").digest("hex");
+function decodeSource(bytes: Buffer): string {
+  if (bytes.length >= 2) {
+    const body = bytes.subarray(2, bytes.length - ((bytes.length - 2) % 2));
+    if (bytes[0] === 0xff && bytes[1] === 0xfe) return body.toString("utf16le");
+    if (bytes[0] === 0xfe && bytes[1] === 0xff)
+      return Buffer.from(body).swap16().toString("utf16le");
+  }
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xef &&
+    bytes[1] === 0xbb &&
+    bytes[2] === 0xbf
+  )
+    return bytes.subarray(3).toString("utf8");
+  return bytes.toString("utf8");
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
 }

--- a/tests/test-graph/src/features/test_ttscgraph_details_reads_bom_and_utf16_source_snapshot.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_details_reads_bom_and_utf16_source_snapshot.ts
@@ -120,6 +120,7 @@ export const test_ttscgraph_details_reads_bom_and_utf16_source_snapshot =
       }
     } finally {
       client.endStdin();
-      await client.waitForExit();
+      const code = await client.waitForExit();
+      assert.equal(code, 0, client.stderrText());
     }
   };

--- a/tests/test-graph/src/features/test_ttscgraph_details_reads_bom_and_utf16_source_snapshot.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_details_reads_bom_and_utf16_source_snapshot.ts
@@ -1,0 +1,125 @@
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  structuredContent?: unknown;
+}
+
+interface DetailsResult {
+  type: "details";
+  nodes: { name: string; signature?: string; doc?: string }[];
+}
+
+const graphArguments = (handles: string[]) => ({
+  question: "Inspect declaration signatures from the current source snapshot.",
+  draft: {
+    reason: "The named declarations need one precise graph details request.",
+    type: "details",
+  },
+  review:
+    "Confirmed: the graph details answer is the needed source-derived fact.",
+  request: { type: "details", handles },
+});
+
+const detailsOf = (result: ToolResult): DetailsResult => {
+  const value = (result.structuredContent ?? {}) as { result?: DetailsResult };
+  if (value.result?.type !== "details")
+    throw new Error(`Unexpected graph result: ${JSON.stringify(value)}`);
+  return value.result;
+};
+
+const utf16be = (text: string): Buffer =>
+  Buffer.concat([
+    Buffer.from([0xfe, 0xff]),
+    Buffer.from(text, "utf16le").swap16(),
+  ]);
+
+/**
+ * Verifies graph details preserves display facts for BOM and UTF-16 sources.
+ *
+ * The native snapshot hashes raw on-disk bytes separately from the decoded
+ * source text that its checker parsed. The Node reader must prove both domains
+ * before it slices declarations. Otherwise ordinary Windows-generated files
+ * fail the checker-digest gate forever and details silently drops signatures
+ * and docs.
+ *
+ * 1. Materialize equivalent exported functions as UTF-8 BOM, UTF-16LE, and
+ *    UTF-16BE files.
+ * 2. Ask the real resident `ttscgraph` server for all three declaration details.
+ * 3. Assert each result contains its compiler-aligned signature and doc.
+ */
+export const test_ttscgraph_details_reads_bom_and_utf16_source_snapshot =
+  async () => {
+    const source = (name: string) =>
+      [
+        `/** ${name} docs. */`,
+        `export function ${name}(): string {`,
+        `  return "${name}";`,
+        "}",
+        "",
+      ].join("\n");
+    const root = TestProject.createProject({
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: { target: "ES2022", module: "commonjs", strict: true },
+        include: ["src"],
+      }),
+      "src/Utf8Bom.ts": "",
+      "src/Utf16Le.ts": "",
+      "src/Utf16Be.ts": "",
+    });
+    fs.writeFileSync(
+      path.join(root, "src", "Utf8Bom.ts"),
+      Buffer.concat([
+        Buffer.from([0xef, 0xbb, 0xbf]),
+        Buffer.from(source("Utf8Bom")),
+      ]),
+    );
+    fs.writeFileSync(
+      path.join(root, "src", "Utf16Le.ts"),
+      Buffer.concat([
+        Buffer.from([0xff, 0xfe]),
+        Buffer.from(source("Utf16Le"), "utf16le"),
+      ]),
+    );
+    fs.writeFileSync(
+      path.join(root, "src", "Utf16Be.ts"),
+      utf16be(source("Utf16Be")),
+    );
+
+    const names = ["Utf8Bom", "Utf16Le", "Utf16Be"];
+    const client = TtsgraphClient.start(root);
+    try {
+      await client.request("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test-graph", version: "0.0.0" },
+      });
+      client.notify("notifications/initialized", {});
+
+      const details = detailsOf(
+        (await client.request("tools/call", {
+          name: "inspect_typescript_graph",
+          arguments: graphArguments(names),
+        })) as ToolResult,
+      );
+      for (const name of names) {
+        const node = details.nodes.find((candidate) => candidate.name === name);
+        assert.ok(node, `details resolves ${name}: ${JSON.stringify(details)}`);
+        assert.ok(
+          node.signature?.includes(`export function ${name}(): string {`),
+          `details keeps ${name}'s signature: ${JSON.stringify(node)}`,
+        );
+        assert.equal(
+          node.doc,
+          `${name} docs.`,
+          `details keeps ${name}'s doc: ${JSON.stringify(node)}`,
+        );
+      }
+    } finally {
+      client.endStdin();
+      await client.waitForExit();
+    }
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_source_reader_enforces_snapshot_identity_once.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_source_reader_enforces_snapshot_identity_once.ts
@@ -26,8 +26,8 @@ interface SourceReaderConstructor {
   ): SourceReader;
 }
 
-const digest = (text: string): string =>
-  createHash("sha256").update(text, "utf8").digest("hex");
+const digest = (value: string | Buffer): string =>
+  createHash("sha256").update(value).digest("hex");
 
 /**
  * Verifies the graph source reader returns one immutable checker-identical
@@ -36,16 +36,16 @@ const digest = (text: string): string =>
  * A request-only line cache reduces repeated `readFileSync` calls but can still
  * mix graph facts with bytes written after the native snapshot. It is also
  * unsound for a source-preamble project: the disk digest can match even though
- * the checker resolved augmented text. The reader must compare the bytes it
- * actually read with `checkerDigest`, then freeze and cache that adjudication
- * for the lifetime of its `TtscGraphMemory` snapshot.
+ * the checker resolved augmented text. The reader must prove the bytes it read
+ * against `diskDigest`, then prove its decoded text against `checkerDigest` and
+ * freeze that adjudication for the lifetime of its `TtscGraphMemory` snapshot.
  *
  * 1. Read one checker-identical file twice and assert one physical read plus an
  *    immutable, reused line array.
- * 2. Mutate a file after its provenance was captured and assert the mismatch is
- *    rejected and cached even if the disk later reverts.
- * 3. Model a source-preamble divergence and an I/O failure, asserting neither can
- *    be presented as checker text and neither is retried.
+ * 2. Mutate a file and re-encode another after provenance capture, asserting text
+ *    and raw-byte mismatches are rejected and cached.
+ * 3. Model preamble, virtual, capability, and I/O failures, asserting none can be
+ *    presented as checker text or retried.
  * 4. Build the minimal synthetic memory used by internal resolver tests and assert
  *    an absent provenance manifest fails closed without crashing.
  */
@@ -71,7 +71,7 @@ export const test_ttscgraph_source_reader_enforces_snapshot_identity_once =
           {
             file: "src/stable.ts",
             checkerDigest: digest(stable),
-            diskDigest: digest(stable),
+            diskDigest: digest(Buffer.from(stable, "utf8")),
           },
         ],
       },
@@ -98,7 +98,7 @@ export const test_ttscgraph_source_reader_enforces_snapshot_identity_once =
           {
             file: "src/mutated.ts",
             checkerDigest: digest(before),
-            diskDigest: digest(before),
+            diskDigest: digest(Buffer.from(before, "utf8")),
           },
         ],
       },
@@ -120,6 +120,35 @@ export const test_ttscgraph_source_reader_enforces_snapshot_identity_once =
     );
     assert.equal(mutationReads, 1, "digest mismatches are cached as failures");
 
+    const reencoded = "export const reencoded = true;\n";
+    let reencodedReads = 0;
+    const reencodedReader = new Reader(
+      "C:/project",
+      {
+        capabilities: ["sourceDigests", "diskDigests"],
+        sources: [
+          {
+            file: "src/reencoded.ts",
+            checkerDigest: digest(reencoded),
+            diskDigest: digest(Buffer.from(reencoded, "utf8")),
+          },
+        ],
+      },
+      () => {
+        reencodedReads++;
+        return Buffer.concat([
+          Buffer.from([0xef, 0xbb, 0xbf]),
+          Buffer.from(reencoded, "utf8"),
+        ]);
+      },
+    );
+    assert.equal(
+      reencodedReader.lines("src/reencoded.ts"),
+      undefined,
+      "same decoded text with different raw bytes is not this snapshot",
+    );
+    assert.equal(reencodedReads, 1, "raw-byte mismatches are not retried");
+
     const disk = "export const disk = true;\n";
     const checker = "declare const injected: number;\n" + disk;
     let preambleReads = 0;
@@ -131,7 +160,7 @@ export const test_ttscgraph_source_reader_enforces_snapshot_identity_once =
           {
             file: "src/preamble.ts",
             checkerDigest: digest(checker),
-            diskDigest: digest(disk),
+            diskDigest: digest(Buffer.from(disk, "utf8")),
           },
         ],
       },
@@ -147,8 +176,8 @@ export const test_ttscgraph_source_reader_enforces_snapshot_identity_once =
     );
     assert.equal(preambleReads, 1);
 
-    let failureReads = 0;
-    const failureReader = new Reader(
+    let missingCapabilityReads = 0;
+    const missingCapabilityReader = new Reader(
       "C:/project",
       {
         capabilities: ["sourceDigests"],
@@ -157,6 +186,64 @@ export const test_ttscgraph_source_reader_enforces_snapshot_identity_once =
             file: "src/missing.ts",
             checkerDigest: digest("missing"),
             diskDigest: "",
+          },
+        ],
+      },
+      () => {
+        missingCapabilityReads++;
+        return Buffer.from("missing", "utf8");
+      },
+    );
+    assert.equal(
+      missingCapabilityReader.lines("src/missing.ts"),
+      undefined,
+      "a snapshot without disk digests stays conservative",
+    );
+    assert.equal(
+      missingCapabilityReads,
+      0,
+      "a missing disk-digest capability fails closed before disk I/O",
+    );
+
+    let virtualReads = 0;
+    const virtualReader = new Reader(
+      "C:/project",
+      {
+        capabilities: ["sourceDigests", "diskDigests"],
+        sources: [
+          {
+            file: "bundled:///lib.d.ts",
+            checkerDigest: digest("declare const bundled: true;\n"),
+            diskDigest: "",
+          },
+        ],
+      },
+      () => {
+        virtualReads++;
+        return Buffer.from("declare const bundled: true;\n", "utf8");
+      },
+    );
+    assert.equal(
+      virtualReader.lines("bundled:///lib.d.ts"),
+      undefined,
+      "virtual sources without a disk digest remain unverifiable",
+    );
+    assert.equal(
+      virtualReads,
+      0,
+      "an empty disk digest fails closed before disk I/O",
+    );
+
+    let failureReads = 0;
+    const failureReader = new Reader(
+      "C:/project",
+      {
+        capabilities: ["sourceDigests", "diskDigests"],
+        sources: [
+          {
+            file: "src/missing.ts",
+            checkerDigest: digest("missing"),
+            diskDigest: digest(Buffer.from("missing", "utf8")),
           },
         ],
       },

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -66,7 +66,7 @@ A text search or a tree-sitter parse stops where the syntax stops. A real type c
 - **Generated code stays out of the way.** A source file your `.gitignore` covers, such as a Prisma client or other codegen emitted as `.ts`, is de-ranked: it never dominates a broad or keyword match, though it stays reachable as an edge target and by its exact name. The graph surfaces what you wrote, not what a generator did.
 - **Object-literal ownership.** `details` lists direct, statically named properties in declaration order. Spread properties do not promote names from another object, dynamic computed names are omitted, and nested members stay with their nested object.
 
-Source-derived display text is fail-closed. The snapshot manifest covers every source the checker loaded, including outside `.d.ts` boundary leaves and virtual compiler libraries. The server reuses a disk file only when its current bytes match the compiler snapshot digest; a missing digest, read failure, or mismatch omits the optional text instead of mixing live-disk content into older graph facts.
+Source-derived display text is fail-closed. The snapshot manifest covers every source the checker loaded, including outside `.d.ts` boundary leaves and virtual compiler libraries. The server reuses a disk file only when its raw bytes match the disk snapshot and its compiler-decoded text matches the checker snapshot, so UTF-8 BOM and UTF-16 sources keep their display facts without mixing live-disk content into older graph facts. A missing digest, read failure, or mismatch omits the optional text.
 
 ## Get started
 


### PR DESCRIPTION
## Intent

Fix #833 by proving the raw source bytes against `diskDigest`, then decoding them with the TypeScript-Go source-file rules before proving the resulting text against `checkerDigest`.

## Scope

- preserve graph display facts for UTF-8 BOM and UTF-16 source files whose disk bytes and decoded checker text both match the snapshot;
- retain fail-closed behavior for edited files, source-preamble divergence, virtual or vanished sources, and snapshots without `diskDigests`;
- add source-reader and end-to-end graph regression coverage, plus the matching graph guide correction.

## Deferred

#812 owns ECMAScript line-terminator splitting after this encoding and provenance root is merged. #810 remains downstream of that work.

## Verification

Pending. This is an implementation-free campaign reservation. Campaign Actions for this branch are deliberately cancelled by exact commit SHA; local graph verification and solo Self-Review are the merge gates.

Closes #833.
