### PR TITLE
fix(playground): restore loader contracts

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -33,7 +33,8 @@
   },
   "homepage": "https://ttsc.dev",
   "dependencies": {
-    "lz-string": "^1.5.0"
+    "lz-string": "^1.5.0",
+    "semver": "^7.8.1"
   },
   "peerDependencies": {
     "@monaco-editor/react": "^4.6.0",
@@ -46,6 +47,7 @@
   "devDependencies": {
     "@monaco-editor/react": "^4.6.0",
     "@ttsc/wasm": "workspace:^",
+    "@types/semver": "^7.7.1",
     "@types/node": "catalog:utils",
     "@types/react": "^18.3.1",
     "monaco-editor": "^0.52.0",
@@ -55,5 +57,12 @@
     "tgrid": "^1.0.3",
     "typescript": "catalog:typescript"
   },
-  "keywords": ["ttsc", "playground", "typescript", "browser", "wasm", "react"]
+  "keywords": [
+    "ttsc",
+    "playground",
+    "typescript",
+    "browser",
+    "wasm",
+    "react"
+  ]
 }

--- a/packages/playground/src/npm/collectExternalPackageNames.ts
+++ b/packages/playground/src/npm/collectExternalPackageNames.ts
@@ -152,14 +152,6 @@ function tokenize(source: string): Token[] {
 
   // A `/` opens a regex only in operator/statement position — never right after
   // a value (identifier, number, string, template, regex, `)` or `]`).
-  const regexAllowed = (): boolean => {
-    const prev = tokens[tokens.length - 1];
-    if (!prev) return true;
-    if (prev.kind === "string" || prev.kind === "other") return false;
-    if (prev.kind === "word") return REGEX_PRECEDING_KEYWORDS.has(prev.value);
-    return prev.value !== ")" && prev.value !== "]";
-  };
-
   let i = 0;
   while (i < n) {
     const c = source[i]!;
@@ -189,25 +181,8 @@ function tokenize(source: string): Token[] {
       continue;
     }
     // Regular-expression literal.
-    if (c === "/" && regexAllowed()) {
-      i++;
-      let inClass = false;
-      while (i < n) {
-        const d = source[i];
-        if (d === "\\") {
-          i += 2;
-          continue;
-        }
-        if (d === "\n") break;
-        if (d === "[") inClass = true;
-        else if (d === "]") inClass = false;
-        else if (d === "/" && !inClass) {
-          i++;
-          break;
-        }
-        i++;
-      }
-      while (i < n && isIdPart(source[i]!)) i++; // flags
+    if (c === "/" && isRegexAllowed(tokens)) {
+      i = skipRegularExpression(source, i, isIdPart);
       tokens.push({ kind: "other" });
       continue;
     }
@@ -233,29 +208,26 @@ function tokenize(source: string): Token[] {
       tokens.push({ kind: "string", value });
       continue;
     }
-    // Template literal. Contents (including `${...}` expressions) are treated as
-    // opaque: a template specifier is not statically resolvable.
+    // Template quasis are opaque, but `${...}` substitutions are executable
+    // JavaScript and must receive the same lexical treatment as top-level code.
     if (c === "`") {
       i++;
-      let depth = 0;
       while (i < n) {
         const d = source[i];
         if (d === "\\") {
           i += 2;
           continue;
         }
-        if (depth === 0 && d === "`") {
+        if (d === "`") {
           i++;
           break;
         }
         if (d === "$" && source[i + 1] === "{") {
-          depth++;
-          i += 2;
-          continue;
-        }
-        if (depth > 0 && d === "}") {
-          depth--;
-          i++;
+          const start = i + 2;
+          const end = findTemplateSubstitutionEnd(source, start);
+          tokens.push({ kind: "other" }, ...tokenize(source.slice(start, end)));
+          tokens.push({ kind: "other" });
+          i = end < n ? end + 1 : end;
           continue;
         }
         i++;
@@ -284,4 +256,105 @@ function tokenize(source: string): Token[] {
     i++;
   }
   return tokens;
+}
+
+function findTemplateSubstitutionEnd(source: string, start: number): number {
+  let depth = 1;
+  for (let i = start; i < source.length; i++) {
+    const c = source[i]!;
+    if (c === "\\") {
+      i++;
+      continue;
+    }
+    if (c === "'" || c === '"') {
+      i = skipQuoted(source, i, c);
+      continue;
+    }
+    if (c === "`") {
+      i = skipTemplate(source, i);
+      continue;
+    }
+    if (c === "/" && source[i + 1] === "/") {
+      i += 2;
+      while (i < source.length && source[i] !== "\n") i++;
+      continue;
+    }
+    if (c === "/" && source[i + 1] === "*") {
+      i += 2;
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/"))
+        i++;
+      i++;
+      continue;
+    }
+    if (c === "/" && isRegexAllowed(tokenize(source.slice(start, i)))) {
+      i = skipRegularExpression(source, i, (character) =>
+        /[A-Za-z0-9_$]/.test(character),
+      );
+      i--;
+      continue;
+    }
+    if (c === "{") depth++;
+    else if (c === "}" && --depth === 0) return i;
+  }
+  return source.length;
+}
+
+function isRegexAllowed(tokens: readonly Token[]): boolean {
+  const previous = tokens[tokens.length - 1];
+  if (!previous) return true;
+  if (previous.kind === "string" || previous.kind === "other") return false;
+  if (previous.kind === "word")
+    return REGEX_PRECEDING_KEYWORDS.has(previous.value);
+  return previous.value !== ")" && previous.value !== "]";
+}
+
+function skipRegularExpression(
+  source: string,
+  start: number,
+  isIdentifierPart: (character: string) => boolean,
+): number {
+  let index = start + 1;
+  let inClass = false;
+  while (index < source.length) {
+    const character = source[index];
+    if (character === "\\") {
+      index += 2;
+      continue;
+    }
+    if (character === "\n") break;
+    if (character === "[") inClass = true;
+    else if (character === "]") inClass = false;
+    else if (character === "/" && !inClass) {
+      index++;
+      break;
+    }
+    index++;
+  }
+  while (index < source.length && isIdentifierPart(source[index]!)) index++;
+  return index;
+}
+
+function skipQuoted(source: string, start: number, quote: string): number {
+  for (let i = start + 1; i < source.length; i++) {
+    if (source[i] === "\\") {
+      i++;
+      continue;
+    }
+    if (source[i] === quote || source[i] === "\n") return i;
+  }
+  return source.length;
+}
+
+function skipTemplate(source: string, start: number): number {
+  for (let i = start + 1; i < source.length; i++) {
+    if (source[i] === "\\") {
+      i++;
+      continue;
+    }
+    if (source[i] === "`") return i;
+    if (source[i] === "$" && source[i + 1] === "{") {
+      i = findTemplateSubstitutionEnd(source, i + 2);
+    }
+  }
+  return source.length;
 }

--- a/packages/playground/src/npm/collectExternalPackageNames.ts
+++ b/packages/playground/src/npm/collectExternalPackageNames.ts
@@ -260,18 +260,26 @@ function tokenize(source: string): Token[] {
 
 function findTemplateSubstitutionEnd(source: string, start: number): number {
   let depth = 1;
+  let previous: Token | undefined;
+  const isIdentifierStart = (character: string): boolean =>
+    /[A-Za-z_$]/.test(character);
+  const isIdentifierPart = (character: string): boolean =>
+    /[A-Za-z0-9_$]/.test(character);
   for (let i = start; i < source.length; i++) {
     const c = source[i]!;
+    if (/\s/.test(c)) continue;
     if (c === "\\") {
       i++;
       continue;
     }
     if (c === "'" || c === '"') {
       i = skipQuoted(source, i, c);
+      previous = { kind: "string", value: "" };
       continue;
     }
     if (c === "`") {
       i = skipTemplate(source, i);
+      previous = { kind: "other" };
       continue;
     }
     if (c === "/" && source[i + 1] === "/") {
@@ -286,21 +294,41 @@ function findTemplateSubstitutionEnd(source: string, start: number): number {
       i++;
       continue;
     }
-    if (c === "/" && isRegexAllowed(tokenize(source.slice(start, i)))) {
+    if (c === "/" && isRegexAllowedAfter(previous)) {
       i = skipRegularExpression(source, i, (character) =>
         /[A-Za-z0-9_$]/.test(character),
       );
       i--;
+      previous = { kind: "other" };
+      continue;
+    }
+    if (isIdentifierStart(c)) {
+      let end = i + 1;
+      while (end < source.length && isIdentifierPart(source[end]!)) end++;
+      previous = { kind: "word", value: source.slice(i, end) };
+      i = end - 1;
+      continue;
+    }
+    if (c >= "0" && c <= "9") {
+      let end = i + 1;
+      while (end < source.length && /[0-9a-fA-FxXoObBeE._]/.test(source[end]!))
+        end++;
+      previous = { kind: "other" };
+      i = end - 1;
       continue;
     }
     if (c === "{") depth++;
     else if (c === "}" && --depth === 0) return i;
+    previous = { kind: "punct", value: c };
   }
   return source.length;
 }
 
 function isRegexAllowed(tokens: readonly Token[]): boolean {
-  const previous = tokens[tokens.length - 1];
+  return isRegexAllowedAfter(tokens[tokens.length - 1]);
+}
+
+function isRegexAllowedAfter(previous: Token | undefined): boolean {
   if (!previous) return true;
   if (previous.kind === "string" || previous.kind === "other") return false;
   if (previous.kind === "word")

--- a/packages/playground/src/npm/installPlaygroundDependencies.ts
+++ b/packages/playground/src/npm/installPlaygroundDependencies.ts
@@ -228,7 +228,8 @@ function selectQueuedVersion(
     const message = error instanceof Error ? error.message : String(error);
     const requestedBy = requests
       .map(
-        ({ requester, range }) => `${requester} requests ${JSON.stringify(range)}`,
+        ({ requester, range }) =>
+          `${requester} requests ${JSON.stringify(range)}`,
       )
       .join("; ");
     throw new Error(`${message} Requested by ${requestedBy}.`);

--- a/packages/playground/src/npm/installPlaygroundDependencies.ts
+++ b/packages/playground/src/npm/installPlaygroundDependencies.ts
@@ -5,6 +5,7 @@ import { BUILT_IN_PLAYGROUND_PACKAGES } from "./BUILT_IN_PLAYGROUND_PACKAGES";
 import {
   DECLARATION_FILE_REGEXP,
   type IQueueItem,
+  type IVersionRequest,
   downloadTarball,
   enqueuePackageDependencies,
   fetchNpmMetadata,
@@ -63,8 +64,8 @@ export async function installPlaygroundDependencies(
           `Conflicting npm aliases for ${normalized.name}: ${known.registryName} and ${normalized.registryName}.`,
         );
       }
-      known.ranges ??= [known.range];
-      known.ranges.push(normalized.range);
+      known.requests ??= [toVersionRequest(known)];
+      known.requests.push(toVersionRequest(normalized));
       known.optional &&= normalized.optional;
       const completed = done.get(normalized.name);
       const metadata = metadataByName.get(normalized.name);
@@ -73,7 +74,7 @@ export async function installPlaygroundDependencies(
         // already been installed. Pin the installed version into the combined
         // solve so a compatible late constraint is accepted, but a range that
         // rejects the mounted version fails instead of being silently lost.
-        selectVersion(metadata, [...known.ranges, completed]);
+        selectQueuedVersion(metadata, known, [completed]);
       } else if (completed !== undefined && !known.optional) {
         // An optional 404 may later be reached through a required edge. Retry
         // that edge so the required dependency cannot remain silently absent.
@@ -83,7 +84,7 @@ export async function installPlaygroundDependencies(
       return;
     }
     if (installed.has(normalized.name)) return;
-    normalized.ranges = [normalized.range];
+    normalized.requests = [toVersionRequest(normalized)];
     queued.set(normalized.name, normalized);
     queue.push(normalized);
     report("queued", normalized, `Queued ${normalized.name}`);
@@ -135,7 +136,7 @@ export async function installPlaygroundDependencies(
     }
 
     metadataByName.set(item.name, metadata);
-    const version = selectVersion(metadata, item.ranges ?? [item.range]);
+    const version = selectQueuedVersion(metadata, item);
     const versionMetadata = metadata.versions[version];
     const tarball = versionMetadata?.dist?.tarball;
     if (!versionMetadata || !tarball) {
@@ -178,12 +179,13 @@ export async function installPlaygroundDependencies(
     installed.add(item.name);
     report("done", item, `Installed ${item.name}@${version}`, version);
 
-    enqueuePackageDependencies(packageJson, enqueue);
+    enqueuePackageDependencies(packageJson, enqueue, item.name);
     if (declarationCount === 0 && !item.name.startsWith("@types/")) {
       enqueue({
         name: toTypesPackageName(item.name),
         range: "*",
         optional: true,
+        requester: item.name,
       });
     }
   }
@@ -206,4 +208,29 @@ function normalizeRegistryRequest(item: IQueueItem): IQueueItem {
     registryName: match[1]!,
     range: match[2] || "*",
   };
+}
+
+function toVersionRequest(item: IQueueItem): IVersionRequest {
+  return { range: item.range, requester: item.requester };
+}
+
+function selectQueuedVersion(
+  metadata: Parameters<typeof selectVersion>[0],
+  item: IQueueItem,
+  extraRanges: readonly string[] = [],
+): string {
+  const requests = item.requests ?? [toVersionRequest(item)];
+  const ranges = [...requests.map((request) => request.range), ...extraRanges];
+  try {
+    return selectVersion(metadata, ranges);
+  } catch (error) {
+    if (requests.length < 2) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    const requestedBy = requests
+      .map(
+        ({ requester, range }) => `${requester} requests ${JSON.stringify(range)}`,
+      )
+      .join("; ");
+    throw new Error(`${message} Requested by ${requestedBy}.`);
+  }
 }

--- a/packages/playground/src/npm/installPlaygroundDependencies.ts
+++ b/packages/playground/src/npm/installPlaygroundDependencies.ts
@@ -43,8 +43,9 @@ export async function installPlaygroundDependencies(
   const installed = new Set(options.installedPackages ?? []);
   const maxPackages = options.maxPackages ?? DEFAULT_MAX_PACKAGES;
   const queue: IQueueItem[] = [];
-  const queued = new Set<string>();
-  const done = new Set<string>();
+  const queued = new Map<string, IQueueItem>();
+  const done = new Map<string, string>();
+  const metadataByName = new Map<string, Parameters<typeof selectVersion>[0]>();
   const result: IPlaygroundDependencyInstallResult = {
     packages: [],
     compilerFiles: {},
@@ -53,11 +54,39 @@ export async function installPlaygroundDependencies(
   };
 
   const enqueue = (item: IQueueItem): void => {
-    if (ignored.has(item.name) || installed.has(item.name)) return;
-    if (queued.has(item.name) || done.has(item.name)) return;
-    queued.add(item.name);
-    queue.push(item);
-    report("queued", item, `Queued ${item.name}`);
+    const normalized = normalizeRegistryRequest(item);
+    if (ignored.has(normalized.name)) return;
+    const known = queued.get(normalized.name);
+    if (known) {
+      if (known.registryName !== normalized.registryName) {
+        throw new Error(
+          `Conflicting npm aliases for ${normalized.name}: ${known.registryName} and ${normalized.registryName}.`,
+        );
+      }
+      known.ranges ??= [known.range];
+      known.ranges.push(normalized.range);
+      known.optional &&= normalized.optional;
+      const completed = done.get(normalized.name);
+      const metadata = metadataByName.get(normalized.name);
+      if (completed !== undefined && metadata) {
+        // A dependency can discover an additional range after this package has
+        // already been installed. Pin the installed version into the combined
+        // solve so a compatible late constraint is accepted, but a range that
+        // rejects the mounted version fails instead of being silently lost.
+        selectVersion(metadata, [...known.ranges, completed]);
+      } else if (completed !== undefined && !known.optional) {
+        // An optional 404 may later be reached through a required edge. Retry
+        // that edge so the required dependency cannot remain silently absent.
+        done.delete(normalized.name);
+        queue.push(known);
+      }
+      return;
+    }
+    if (installed.has(normalized.name)) return;
+    normalized.ranges = [normalized.range];
+    queued.set(normalized.name, normalized);
+    queue.push(normalized);
+    report("queued", normalized, `Queued ${normalized.name}`);
   };
 
   const report = (
@@ -77,7 +106,7 @@ export async function installPlaygroundDependencies(
   };
 
   for (const name of packageNames) {
-    enqueue({ name, range: "latest", optional: false });
+    enqueue({ name, range: "*", optional: false, requester: "source" });
   }
 
   for (let index = 0; index < queue.length; index++) {
@@ -94,23 +123,24 @@ export async function installPlaygroundDependencies(
     report("resolve", item, `Resolving ${item.name}`);
     const metadata = await fetchNpmMetadata(
       fetchImpl,
-      item.name,
+      item.registryName ?? item.name,
       item.optional,
       options.signal,
     );
     throwIfAborted(options.signal);
     if (!metadata) {
-      done.add(item.name);
+      done.set(item.name, "");
       report("skip", item, `Skipped optional ${item.name}`);
       continue;
     }
 
-    const version = selectVersion(metadata, item.range);
+    metadataByName.set(item.name, metadata);
+    const version = selectVersion(metadata, item.ranges ?? [item.range]);
     const versionMetadata = metadata.versions[version];
     const tarball = versionMetadata?.dist?.tarball;
     if (!versionMetadata || !tarball) {
       if (item.optional) {
-        done.add(item.name);
+        done.set(item.name, version);
         report("skip", item, `Skipped optional ${item.name}`);
         continue;
       }
@@ -144,7 +174,7 @@ export async function installPlaygroundDependencies(
       declarationCount,
     });
 
-    done.add(item.name);
+    done.set(item.name, version);
     installed.add(item.name);
     report("done", item, `Installed ${item.name}@${version}`, version);
 
@@ -152,7 +182,7 @@ export async function installPlaygroundDependencies(
     if (declarationCount === 0 && !item.name.startsWith("@types/")) {
       enqueue({
         name: toTypesPackageName(item.name),
-        range: "latest",
+        range: "*",
         optional: true,
       });
     }
@@ -160,4 +190,20 @@ export async function installPlaygroundDependencies(
 
   report("done", null, "Dependency install complete");
   return result;
+}
+
+function normalizeRegistryRequest(item: IQueueItem): IQueueItem {
+  if (!item.range.startsWith("npm:"))
+    return { ...item, registryName: item.name };
+  const match = /^npm:((?:@[^/]+\/)?[^@/]+)(?:@(.+))?$/.exec(item.range);
+  if (!match) {
+    throw new Error(
+      `Unsupported npm alias ${JSON.stringify(item.range)} for ${item.name}.`,
+    );
+  }
+  return {
+    ...item,
+    registryName: match[1]!,
+    range: match[2] || "*",
+  };
 }

--- a/packages/playground/src/npm/internal/npmRegistry.ts
+++ b/packages/playground/src/npm/internal/npmRegistry.ts
@@ -1,3 +1,5 @@
+import { maxSatisfying, satisfies, valid, validRange } from "semver";
+
 // Internal npm-registry helpers used by `installPlaygroundDependencies`.
 // Grouped in one file because every helper is privately coupled to the tar
 // + version-resolve + tarball-extract flow; splitting them per the public
@@ -37,6 +39,9 @@ export interface IQueueItem {
   name: string;
   range: string;
   optional: boolean;
+  registryName?: string;
+  ranges?: string[];
+  requester?: string;
 }
 
 export type FetchLike = (
@@ -79,19 +84,43 @@ export async function fetchNpmMetadata(
   return (await response.json()) as INpmMetadata;
 }
 
-export function selectVersion(metadata: INpmMetadata, range: string): string {
+export function selectVersion(
+  metadata: INpmMetadata,
+  ranges: readonly string[] | string,
+): string {
   const versions = metadata.versions;
-  if (versions[range]) return range;
-  const tag = metadata["dist-tags"]?.[range];
-  if (tag && versions[tag]) return tag;
-  const normalized = range.replace(/^[~^<>= ]+/, "").trim();
-  if (normalized && versions[normalized]) return normalized;
-  const latest = metadata["dist-tags"]?.latest;
-  if (latest && versions[latest]) return latest;
-  const all = Object.keys(versions).sort(compareVersionDesc);
-  const fallback = all[0];
-  if (!fallback) throw new Error(`No versions found for ${metadata.name}.`);
-  return fallback;
+  const requested = Array.isArray(ranges) ? ranges : [ranges];
+  const semverRanges = requested.filter((range) => validRange(range) !== null);
+  const tags = requested.filter((range) => validRange(range) === null);
+  const taggedVersions = new Set<string>();
+  for (const tag of tags) {
+    const version = metadata["dist-tags"]?.[tag];
+    if (!version || !versions[version]) {
+      throw new Error(
+        `No npm dist-tag ${JSON.stringify(tag)} exists for ${metadata.name}.`,
+      );
+    }
+    taggedVersions.add(version);
+  }
+  if (taggedVersions.size > 1) {
+    throw new Error(
+      `Conflicting npm tags for ${metadata.name}: ${requested.join(", ")}.`,
+    );
+  }
+
+  const candidates = Object.keys(versions).filter(
+    (version) =>
+      valid(version) !== null &&
+      semverRanges.every((range) => satisfies(version, range)) &&
+      (taggedVersions.size === 0 || taggedVersions.has(version)),
+  );
+  const selected = maxSatisfying(candidates, "*");
+  if (selected) return selected;
+  throw new Error(
+    `No version of ${metadata.name} satisfies ${requested
+      .map((range) => JSON.stringify(range))
+      .join(", ")}.`,
+  );
 }
 
 export async function downloadTarball(
@@ -136,7 +165,7 @@ export async function unpackNpmTarball(
       continue;
     }
     if (type === "x") {
-      paxPath = parsePaxPath(decoder.decode(body));
+      paxPath = parsePaxPath(body);
       continue;
     }
     if (type !== "0" && type !== "\0") {
@@ -256,19 +285,32 @@ function parseOctal(bytes: Uint8Array): number {
   return text ? Number.parseInt(text, 8) : 0;
 }
 
-function parsePaxPath(text: string): string | null {
-  let rest = text;
-  while (rest.length > 0) {
-    const space = rest.indexOf(" ");
-    if (space < 0) return null;
-    const length = Number(rest.slice(0, space));
-    if (!Number.isFinite(length) || length <= space) return null;
-    const record = rest.slice(space + 1, length - 1);
+function parsePaxPath(bytes: Uint8Array): string | null {
+  const decoder = new TextDecoder();
+  let offset = 0;
+  let path: string | null = null;
+  while (offset < bytes.length) {
+    let space = offset;
+    while (space < bytes.length && bytes[space] !== 0x20) space++;
+    if (space === bytes.length) throw new Error("Invalid PAX header length.");
+    const lengthText = decoder.decode(bytes.subarray(offset, space));
+    if (!/^[1-9][0-9]*$/.test(lengthText))
+      throw new Error("Invalid PAX header length.");
+    const length = Number(lengthText);
+    const end = offset + length;
+    if (
+      !Number.isSafeInteger(length) ||
+      length <= space - offset + 1 ||
+      end > bytes.length ||
+      bytes[end - 1] !== 0x0a
+    )
+      throw new Error("Invalid PAX header record.");
+    const record = decoder.decode(bytes.subarray(space + 1, end - 1));
     const eq = record.indexOf("=");
-    if (eq > 0 && record.slice(0, eq) === "path") return record.slice(eq + 1);
-    rest = rest.slice(length);
+    if (eq > 0 && record.slice(0, eq) === "path") path = record.slice(eq + 1);
+    offset = end;
   }
-  return null;
+  return path;
 }
 
 function stripTarRoot(path: string): string {
@@ -278,15 +320,4 @@ function stripTarRoot(path: string): string {
     return normalized.slice("package/".length);
   const slash = normalized.indexOf("/");
   return slash < 0 ? normalized : normalized.slice(slash + 1);
-}
-
-function compareVersionDesc(a: string, b: string): number {
-  const pa = a.split(/[.-]/).map((part) => Number.parseInt(part, 10));
-  const pb = b.split(/[.-]/).map((part) => Number.parseInt(part, 10));
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const av = Number.isFinite(pa[i]) ? pa[i]! : 0;
-    const bv = Number.isFinite(pb[i]) ? pb[i]! : 0;
-    if (av !== bv) return bv - av;
-  }
-  return b.localeCompare(a);
 }

--- a/packages/playground/src/npm/internal/npmRegistry.ts
+++ b/packages/playground/src/npm/internal/npmRegistry.ts
@@ -39,9 +39,14 @@ export interface IQueueItem {
   name: string;
   range: string;
   optional: boolean;
+  requester: string;
   registryName?: string;
-  ranges?: string[];
-  requester?: string;
+  requests?: IVersionRequest[];
+}
+
+export interface IVersionRequest {
+  range: string;
+  requester: string;
 }
 
 export type FetchLike = (
@@ -242,9 +247,11 @@ export function enqueuePackageDependencies(
     peerDependenciesMeta?: Record<string, { optional?: boolean }>;
   },
   enqueue: (item: IQueueItem) => void,
+  requester: string,
 ): void {
   for (const [name, range] of Object.entries(packageJson.dependencies ?? {})) {
-    if (isRegistryRange(range)) enqueue({ name, range, optional: false });
+    if (isRegistryRange(range))
+      enqueue({ name, range, optional: false, requester });
   }
   for (const [name, range] of Object.entries(
     packageJson.peerDependencies ?? {},
@@ -257,7 +264,7 @@ export function enqueuePackageDependencies(
     // silent skip that leaves the wasm-side compile reporting a generic
     // "Cannot find module" with no breadcrumb back to the dep installer.
     if (!optional && isRegistryRange(range))
-      enqueue({ name, range, optional: false });
+      enqueue({ name, range, optional: false, requester });
   }
 }
 

--- a/packages/playground/src/npm/packageNameFromSpecifier.ts
+++ b/packages/playground/src/npm/packageNameFromSpecifier.ts
@@ -1,15 +1,22 @@
 const BUILTIN_MODULES = new Set([
   "assert",
+  "async_hooks",
   "buffer",
   "child_process",
+  "cluster",
   "console",
   "constants",
   "crypto",
+  "dgram",
+  "diagnostics_channel",
   "dns",
+  "domain",
   "events",
   "fs",
   "http",
+  "http2",
   "https",
+  "inspector",
   "module",
   "net",
   "os",
@@ -19,14 +26,19 @@ const BUILTIN_MODULES = new Set([
   "punycode",
   "querystring",
   "readline",
+  "repl",
   "stream",
   "string_decoder",
+  "sys",
   "timers",
   "tls",
+  "trace_events",
   "tty",
   "url",
   "util",
+  "v8",
   "vm",
+  "wasi",
   "worker_threads",
   "zlib",
 ]);
@@ -38,6 +50,10 @@ const BUILTIN_MODULES = new Set([
  * built-in modules — the caller doesn't install those from npm.
  */
 export function packageNameFromSpecifier(specifier: string): string | null {
+  const nodePrefixed = specifier.startsWith("node:");
+  const bare = nodePrefixed ? specifier.slice("node:".length) : specifier;
+  const first = bare.split("/")[0];
+  if (first && BUILTIN_MODULES.has(first)) return null;
   if (
     specifier.startsWith("#") ||
     specifier.startsWith(".") ||
@@ -45,9 +61,6 @@ export function packageNameFromSpecifier(specifier: string): string | null {
     /^[a-z][a-z0-9+.-]*:/i.test(specifier)
   )
     return null;
-  const bare = specifier.startsWith("node:") ? specifier.slice(5) : specifier;
-  const first = bare.split("/")[0];
-  if (first && BUILTIN_MODULES.has(first)) return null;
   if (bare.startsWith("@")) {
     const firstSlash = bare.indexOf("/");
     if (firstSlash < 0) return null;

--- a/packages/playground/src/react/createCompilerClient.ts
+++ b/packages/playground/src/react/createCompilerClient.ts
@@ -19,6 +19,7 @@ export function createCompilerClient(options: ICreateCompilerClientOptions): {
 } {
   type Connection = {
     connector: WorkerConnector<null, null, null>;
+    close(): Promise<void>;
     promise: Promise<ICompilerService>;
   };
   let current: Connection | null = null;
@@ -30,14 +31,22 @@ export function createCompilerClient(options: ICreateCompilerClientOptions): {
         null,
         null,
       );
+      let closePromise: Promise<void> | null = null;
       const connection = {} as Connection;
       current = connection;
       connection.connector = connector;
+      connection.close = () =>
+        (closePromise ??= Promise.resolve()
+          .then(() => connector.close())
+          .catch(() => {}));
       connection.promise = Promise.resolve()
         .then(() => connector.connect(options.workerUrl))
         .then(() => connector.getDriver() as unknown as ICompilerService)
-        .catch((error: unknown) => {
-          if (current === connection) current = null;
+        .catch(async (error: unknown) => {
+          if (current === connection) {
+            current = null;
+            await connection.close();
+          }
           throw error;
         });
       return connection.promise;
@@ -51,7 +60,7 @@ export function createCompilerClient(options: ICreateCompilerClientOptions): {
       } catch {
         // A rejected connection never became usable.
       }
-      await invalidated.connector.close().catch(() => {});
+      await invalidated.close();
     },
   };
 }

--- a/packages/playground/src/react/createCompilerClient.ts
+++ b/packages/playground/src/react/createCompilerClient.ts
@@ -9,72 +9,49 @@ import type { ICreateCompilerClientOptions } from "../structures/ICreateCompiler
  * UI-side singleton: connect to the playground worker over tgrid and return the
  * typed `ICompilerService` driver.
  *
- * The promise is cached; the first call boots, every subsequent call shares the
- * same connection. If the boot rejects the cache is cleared so the next call
- * retries — otherwise every retry would resolve to the same rejection.
+ * One connection generation owns the cached promise and connector. A reset
+ * invalidates that generation before awaiting it, so a late settlement cannot
+ * replace a newer connection or clear its retry state.
  */
 export function createCompilerClient(options: ICreateCompilerClientOptions): {
   connect(): Promise<ICompilerService>;
   reset(): Promise<void>;
 } {
-  let connectionPromise: Promise<ICompilerService> | null = null;
-  // Track the active connector AND the in-flight connector promise so
-  // reset() can dispose either one — disposing only the resolved
-  // `activeConnector` leaks the connector when reset() is called during
-  // an in-flight `await connector.connect(...)` (the connector reference
-  // exists but isn't yet assigned to activeConnector).
-  let activeConnector: WorkerConnector<null, null, null> | null = null;
-  let pendingConnector: Promise<WorkerConnector<null, null, null>> | null =
-    null;
+  type Connection = {
+    connector: WorkerConnector<null, null, null>;
+    promise: Promise<ICompilerService>;
+  };
+  let current: Connection | null = null;
 
   return {
     connect(): Promise<ICompilerService> {
-      if (connectionPromise) return connectionPromise;
+      if (current) return current.promise;
       const connector: WorkerConnector<null, null, null> = new WorkerConnector(
         null,
         null,
       );
-      const connectPromise = connector
-        .connect(options.workerUrl)
-        .then(() => connector);
-      pendingConnector = connectPromise;
-      connectionPromise = (async () => {
-        try {
-          await connectPromise;
-        } catch (err) {
-          connectionPromise = null;
-          if (pendingConnector === connectPromise) pendingConnector = null;
-          throw err;
-        }
-        if (pendingConnector === connectPromise) pendingConnector = null;
-        activeConnector = connector;
-        return connector.getDriver() as unknown as ICompilerService;
-      })();
-      return connectionPromise;
+      const connection = {} as Connection;
+      current = connection;
+      connection.connector = connector;
+      connection.promise = Promise.resolve()
+        .then(() => connector.connect(options.workerUrl))
+        .then(() => connector.getDriver() as unknown as ICompilerService)
+        .catch((error: unknown) => {
+          if (current === connection) current = null;
+          throw error;
+        });
+      return connection.promise;
     },
     async reset(): Promise<void> {
-      const inflight = pendingConnector;
-      const active = activeConnector;
-      connectionPromise = null;
-      pendingConnector = null;
-      activeConnector = null;
-      // Swallow close errors: the worker is already being torn down,
-      // and a Retry that fails to close cleanly should not block the
-      // next connect attempt. Cover both code paths — the in-flight
-      // connector (await it first, then close) and the resolved active
-      // connector. Either may be null; both may be the same instance
-      // after a successful connect().
-      if (inflight) {
-        try {
-          const c = await inflight;
-          if (c !== active) await c.close().catch(() => {});
-        } catch {
-          // connect() rejected — nothing to close.
-        }
+      const invalidated = current;
+      current = null;
+      if (!invalidated) return;
+      try {
+        await invalidated.promise;
+      } catch {
+        // A rejected connection never became usable.
       }
-      if (active) {
-        await active.close().catch(() => {});
-      }
+      await invalidated.connector.close().catch(() => {});
     },
   };
 }

--- a/packages/playground/src/sandbox/createSandboxRequire.ts
+++ b/packages/playground/src/sandbox/createSandboxRequire.ts
@@ -30,6 +30,12 @@ interface ISandboxRequireOptions {
     | Record<string, (...args: unknown[]) => void>;
 }
 
+// The sandbox evaluates CommonJS through a `require` wrapper in a browser. It
+// therefore activates `require`; `default` is always available as the portable
+// fallback. `node` and `import` stay inactive because the sandbox supplies
+// neither Node's runtime nor an ESM evaluator.
+const ACTIVE_EXPORT_CONDITIONS = new Set(["require", "default"]);
+
 /**
  * Build a sandboxed `require` function over a runtime pack. Resolves typia /
  * `@typia/*` / randexp specifiers from the pack; throws on anything else so the
@@ -50,6 +56,35 @@ export function createSandboxRequire(
     return null;
   };
 
+  const packageDeclaresExports = (pkg: string): boolean => {
+    const key = `${pkg}/package.json`;
+    if (!has(key)) return false;
+    try {
+      return Object.prototype.hasOwnProperty.call(
+        JSON.parse(pack[key]!) as IPackJson,
+        "exports",
+      );
+    } catch {
+      return false;
+    }
+  };
+
+  const resolveExportTarget = (
+    pkg: string,
+    target: unknown,
+    replacement = "",
+  ): string | null => {
+    const candidates = conditionalExportTargets(target);
+    if (!candidates) return null;
+    for (const candidate of candidates) {
+      const resolved = `${pkg}/${stripDotSlash(
+        candidate.split("*").join(replacement),
+      )}`;
+      if (has(resolved)) return resolved;
+    }
+    return null;
+  };
+
   // Read package.json from pack and resolve via main/exports.
   const resolvePackageEntry = (
     pkg: string,
@@ -66,12 +101,8 @@ export function createSandboxRequire(
     if (subpath === null) {
       // bare "name": honor the root `exports` entry (string, subpath table
       // "." key, or bare condition map) → CJS target, else main, else index.
-      const root = rootExportTarget(pj.exports);
-      const r = pickConditionalExport(root);
-      if (r) {
-        const resolved = `${pkg}/${stripDotSlash(r)}`;
-        return has(resolved) ? resolved : null;
-      }
+      if (pj.exports !== undefined)
+        return resolveExportTarget(pkg, rootExportTarget(pj.exports));
       if (typeof pj.main === "string") {
         return tryPaths(
           `${pkg}/${stripDotSlash(pj.main)}`,
@@ -87,25 +118,26 @@ export function createSandboxRequire(
     }
     // Subpath: honor exports["./subpath"] or exports["./subpath/*"] patterns.
     const exportsAny = pj.exports;
-    if (typeof exportsAny === "object" && exportsAny !== null) {
+    if (
+      exportsAny !== undefined &&
+      typeof exportsAny === "object" &&
+      exportsAny !== null
+    ) {
       const entries = exportsAny as Record<string, unknown>;
       // Exact match first.
-      const exact = entries[`./${subpath}`];
-      const ex = pickConditionalExport(exact);
-      if (ex) {
-        const resolved = `${pkg}/${stripDotSlash(ex)}`;
-        if (has(resolved)) return resolved;
-      }
-      // Wildcard match.
-      for (const [pattern, target] of Object.entries(entries)) {
+      const exactKey = `./${subpath}`;
+      if (Object.prototype.hasOwnProperty.call(entries, exactKey))
+        return resolveExportTarget(pkg, entries[exactKey]);
+      // Node resolves the most-specific wildcard, not insertion order.
+      const patterns = Object.entries(entries)
+        .filter(([pattern]) => pattern.endsWith("/*"))
+        .sort(([a], [b]) => b.length - a.length);
+      for (const [pattern, target] of patterns) {
         if (!pattern.endsWith("/*")) continue;
         const prefix = pattern.slice(2, -1); // strip "./" and trailing "*"
         if (!subpath.startsWith(prefix)) continue;
         const rest = subpath.slice(prefix.length);
-        const targetStr = pickConditionalExport(target);
-        if (!targetStr) continue;
-        const resolved = `${pkg}/${stripDotSlash(targetStr.replace("*", rest))}`;
-        if (has(resolved)) return resolved;
+        return resolveExportTarget(pkg, target, rest);
       }
     }
     return null;
@@ -136,7 +168,10 @@ export function createSandboxRequire(
     if (subpath === null) {
       return resolvePackageEntry(pkg, null);
     }
-    // First try direct paths (covers the common typia/lib/internal/X case).
+    // A declared exports map is the public boundary. Only packages without one
+    // retain the historical packed-file fallback.
+    if (packageDeclaresExports(pkg)) return resolvePackageEntry(pkg, subpath);
+    // First try direct paths (covers packages that do not declare exports).
     const direct = tryPaths(
       `${pkg}/${subpath}`,
       `${pkg}/${subpath}.js`,
@@ -220,8 +255,8 @@ export function createSandboxRequire(
 
 /**
  * Reduce a `package.json` `exports` field to the value describing its ROOT
- * (".") entry, ready for {@link pickConditionalExport}. Node accepts three valid
- * root shapes and they must all resolve consistently:
+ * (".") entry, ready for {@link conditionalExportTargets}. Node accepts three
+ * valid root shapes and they must all resolve consistently:
  *
  * - A bare string target — `"exports": "./index.cjs"`;
  * - A subpath table keyed by "." — `{ ".": <target>, "./sub": ... }`;
@@ -243,14 +278,22 @@ function rootExportTarget(exports: unknown): unknown {
   return hasSubpathKey ? obj["."] : obj;
 }
 
-function pickConditionalExport(value: unknown): string | null {
-  if (typeof value === "string") return value;
+function conditionalExportTargets(value: unknown): string[] | null {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) {
+    const candidates: string[] = [];
+    for (const target of value) {
+      const resolved = conditionalExportTargets(target);
+      if (resolved) candidates.push(...resolved);
+    }
+    return candidates.length === 0 ? null : candidates;
+  }
   if (value && typeof value === "object") {
     const obj = value as Record<string, unknown>;
-    // Prefer require (CJS) > default > node.
-    const pick = obj.require ?? obj.default ?? obj.node;
-    if (typeof pick === "string") return pick;
-    if (pick && typeof pick === "object") return pickConditionalExport(pick);
+    for (const [condition, target] of Object.entries(obj)) {
+      if (!ACTIVE_EXPORT_CONDITIONS.has(condition)) continue;
+      return conditionalExportTargets(target);
+    }
   }
   return null;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       lz-string:
         specifier: ^1.5.0
         version: 1.5.0
+      semver:
+        specifier: ^7.8.1
+        version: 7.8.1
     devDependencies:
       '@monaco-editor/react':
         specifier: ^4.6.0
@@ -238,6 +241,9 @@ importers:
       '@types/react':
         specifier: ^18.3.1
         version: 18.3.29
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       monaco-editor:
         specifier: ^0.52.0
         version: 0.52.2
@@ -523,6 +529,9 @@ importers:
       '@types/node':
         specifier: catalog:utils
         version: 25.9.1
+      tgrid:
+        specifier: ^1.0.3
+        version: 1.2.1
       typescript:
         specifier: catalog:typescript
         version: 7.0.2
@@ -3074,6 +3083,9 @@ packages:
 
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
@@ -9635,6 +9647,8 @@ snapshots:
   '@types/retry@0.12.2': {}
 
   '@types/sarif@2.1.7': {}
+
+  '@types/semver@7.7.1': {}
 
   '@types/send@0.17.6':
     dependencies:

--- a/tests/test-playground/package.json
+++ b/tests/test-playground/package.json
@@ -12,6 +12,7 @@
     "@ttsc/testing": "workspace:*",
     "@ttsc/wasm": "workspace:*",
     "@types/node": "catalog:utils",
+    "tgrid": "^1.0.3",
     "typescript": "catalog:typescript"
   }
 }

--- a/tests/test-playground/src/features/test_collect_external_package_names_reads_template_substitutions.ts
+++ b/tests/test-playground/src/features/test_collect_external_package_names_reads_template_substitutions.ts
@@ -27,11 +27,13 @@ export const test_collect_external_package_names_reads_template_substitutions =
       'const string = `${"import(\\"string-ghost\\")"}`;',
       'const regex = `${/require\\("regex-ghost"\\)/.test("x")}`;',
       'const regexBrace = `${/}/.test("x") ? require("after-regex") : null}`;',
+      'const division = `${value / 2 ? require("after-division") : null}`;',
       "const computed = `${import(`computed-${name}`)}`;",
       'obj.require("method-ghost");',
     ].join("\n");
 
     assert.deepEqual(collectExternalPackageNames(source, []), [
+      "after-division",
       "after-regex",
       "inside-import",
       "inside-require",

--- a/tests/test-playground/src/features/test_collect_external_package_names_reads_template_substitutions.ts
+++ b/tests/test-playground/src/features/test_collect_external_package_names_reads_template_substitutions.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+
+import { collectExternalPackageNames } from "../../../../packages/playground/lib/src/npm/collectExternalPackageNames.js";
+
+/**
+ * Verifies playground package discovery: scans executable template
+ * substitutions.
+ *
+ * Template quasis are inert text, but `${...}` is ordinary JavaScript. The
+ * collector must recurse into substitutions without weakening its comment,
+ * string, regular-expression, computed-specifier, or nested-template guards.
+ *
+ * 1. Collect literal `import` and `require` calls inside ordinary, tagged, and
+ *    nested template substitutions.
+ * 2. Keep raw template text and lookalikes inside comments, strings, regexes, and
+ *    computed arguments inert, including a regex body containing `}`.
+ */
+export const test_collect_external_package_names_reads_template_substitutions =
+  () => {
+    const source = [
+      'const raw = `require("raw-template-text")`;',
+      'const imported = `${await import("inside-import")}`;',
+      'const required = `${require("inside-require")}`;',
+      'const nested = `${`${require("nested-require")}`}`;',
+      'const tagged = tag`${import("tagged-import")}`;',
+      'const comment = `${/* require("comment-ghost") */ "ok"}`;',
+      'const string = `${"import(\\"string-ghost\\")"}`;',
+      'const regex = `${/require\\("regex-ghost"\\)/.test("x")}`;',
+      'const regexBrace = `${/}/.test("x") ? require("after-regex") : null}`;',
+      "const computed = `${import(`computed-${name}`)}`;",
+      'obj.require("method-ghost");',
+    ].join("\n");
+
+    assert.deepEqual(collectExternalPackageNames(source, []), [
+      "after-regex",
+      "inside-import",
+      "inside-require",
+      "nested-require",
+      "tagged-import",
+    ]);
+  };

--- a/tests/test-playground/src/features/test_compiler_client_fences_connection_generations.ts
+++ b/tests/test-playground/src/features/test_compiler_client_fences_connection_generations.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+import { createCompilerClient } from "../../../../packages/playground/lib/src/react/createCompilerClient.js";
+
+interface IControlledConnector {
+  close(): Promise<void>;
+  connect(): Promise<void>;
+  getDriver(): { connectorId: number };
+}
+
+interface IWorkerConnectorConstructor {
+  prototype: IControlledConnector;
+}
+
+interface IGate {
+  reject(error: Error): void;
+  resolve(): void;
+}
+
+interface IRecord {
+  closeCount: number;
+  id: number;
+}
+
+/**
+ * Verifies playground compiler client: fences overlapping connection
+ * generations.
+ *
+ * A reset invalidates its generation before awaiting connection settlement. A
+ * replacement that resolves or becomes current while that cleanup is pending
+ * must remain cached and reachable; otherwise a wasm Worker leaks and a later
+ * retry allocates a duplicate connection.
+ *
+ * 1. Settle replacement B before original A, then settle and reject A in separate
+ *    orderings while resets overlap both attempts.
+ * 2. Assert each invalidated connector closes exactly once and B remains the
+ *    shared cached connection until its own reset.
+ */
+export const test_compiler_client_fences_connection_generations = async () => {
+  // `createCompilerClient` compiles to CommonJS, so load tgrid through the same
+  // CJS module cache rather than importing tgrid's separate ESM entry point.
+  const { WorkerConnector } = createRequire(import.meta.url)("tgrid") as {
+    WorkerConnector: IWorkerConnectorConstructor;
+  };
+  const prototype = WorkerConnector.prototype;
+  const originals = {
+    close: prototype.close,
+    connect: prototype.connect,
+    getDriver: prototype.getDriver,
+  };
+  const gates: IGate[] = [];
+  const records = new Map<object, IRecord>();
+  let nextId = 0;
+  const recordOf = (connector: object): IRecord => {
+    let record = records.get(connector);
+    if (!record) {
+      record = { closeCount: 0, id: ++nextId };
+      records.set(connector, record);
+    }
+    return record;
+  };
+
+  prototype.connect = function (): Promise<void> {
+    recordOf(this);
+    return new Promise<void>((resolve, reject) =>
+      gates.push({ resolve, reject }),
+    );
+  };
+  prototype.getDriver = function (): { connectorId: number } {
+    return { connectorId: recordOf(this).id };
+  };
+  prototype.close = async function (): Promise<void> {
+    recordOf(this).closeCount++;
+  };
+  const waitForGates = async (count: number): Promise<void> => {
+    for (let attempt = 0; attempt < 20 && gates.length < count; attempt++)
+      await Promise.resolve();
+    assert.equal(gates.length, count, `expected ${count} controlled connects`);
+  };
+
+  try {
+    // B settles before A. A is only ever owned by the reset that invalidated it.
+    const firstClient = createCompilerClient({ workerUrl: "worker.js" });
+    const a = firstClient.connect();
+    await waitForGates(1);
+    const resetA = firstClient.reset();
+    const b = firstClient.connect();
+    await waitForGates(2);
+    gates[1]!.resolve();
+    const bDriver = await b;
+    gates[0]!.resolve();
+    await Promise.all([a, resetA]);
+    const cachedB = firstClient.connect();
+    assert.strictEqual(cachedB, b, "B must remain the cached generation");
+    await firstClient.reset();
+
+    // A rejects only after B has been returned. Its rejection must not clear B.
+    const secondClient = createCompilerClient({ workerUrl: "worker.js" });
+    const rejectionStart = gates.length;
+    const rejectedA = secondClient.connect().catch((error: unknown) => error);
+    await waitForGates(rejectionStart + 1);
+    const resetRejectedA = secondClient.reset();
+    const secondB = secondClient.connect();
+    await waitForGates(rejectionStart + 2);
+    gates[rejectionStart + 1]!.resolve();
+    const secondBDriver = await secondB;
+    gates[rejectionStart]!.reject(new Error("boot failed"));
+    await rejectedA;
+    await resetRejectedA;
+    assert.strictEqual(
+      secondClient.connect(),
+      secondB,
+      "a stale rejection must not discard B's cache",
+    );
+    await secondClient.reset();
+
+    // Concurrent resets share the invalidated generation instead of double-close.
+    const concurrentClient = createCompilerClient({ workerUrl: "worker.js" });
+    const concurrentStart = gates.length;
+    const connection = concurrentClient.connect();
+    await waitForGates(concurrentStart + 1);
+    gates[concurrentStart]!.resolve();
+    await connection;
+    await Promise.all([concurrentClient.reset(), concurrentClient.reset()]);
+
+    const counts = [...records.values()].map((record) => record.closeCount);
+    assert.deepEqual(
+      counts,
+      [1, 1, 1, 1, 1],
+      "each allocated connector must remain reachable until one close",
+    );
+    assert.deepEqual(bDriver, { connectorId: 2 });
+    assert.deepEqual(secondBDriver, { connectorId: 4 });
+  } finally {
+    prototype.close = originals.close;
+    prototype.connect = originals.connect;
+    prototype.getDriver = originals.getDriver;
+  }
+};

--- a/tests/test-playground/src/features/test_compiler_client_fences_connection_generations.ts
+++ b/tests/test-playground/src/features/test_compiler_client_fences_connection_generations.ts
@@ -51,6 +51,7 @@ export const test_compiler_client_fences_connection_generations = async () => {
   };
   const gates: IGate[] = [];
   const records = new Map<object, IRecord>();
+  const throwOnClose = new Set<number>();
   let nextId = 0;
   const recordOf = (connector: object): IRecord => {
     let record = records.get(connector);
@@ -71,7 +72,9 @@ export const test_compiler_client_fences_connection_generations = async () => {
     return { connectorId: recordOf(this).id };
   };
   prototype.close = async function (): Promise<void> {
-    recordOf(this).closeCount++;
+    const record = recordOf(this);
+    record.closeCount++;
+    if (throwOnClose.has(record.id)) throw new Error("close failed");
   };
   const waitForGates = async (count: number): Promise<void> => {
     for (let attempt = 0; attempt < 20 && gates.length < count; attempt++)
@@ -124,14 +127,32 @@ export const test_compiler_client_fences_connection_generations = async () => {
     await connection;
     await Promise.all([concurrentClient.reset(), concurrentClient.reset()]);
 
+    // A failed current generation clears the cache and closes its connector, so
+    // retry remains possible without orphaning the failed Worker. reset() also
+    // continues through a close failure.
+    const retryClient = createCompilerClient({ workerUrl: "worker.js" });
+    await retryClient.reset();
+    const failureStart = gates.length;
+    const failed = retryClient.connect();
+    await waitForGates(failureStart + 1);
+    gates[failureStart]!.reject(new Error("normal boot failure"));
+    await assert.rejects(failed, /normal boot failure/);
+    const retried = retryClient.connect();
+    await waitForGates(failureStart + 2);
+    gates[failureStart + 1]!.resolve();
+    const retryDriver = await retried;
+    throwOnClose.add(retryDriver.connectorId);
+    await retryClient.reset();
+
     const counts = [...records.values()].map((record) => record.closeCount);
     assert.deepEqual(
       counts,
-      [1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1, 1],
       "each allocated connector must remain reachable until one close",
     );
     assert.deepEqual(bDriver, { connectorId: 2 });
     assert.deepEqual(secondBDriver, { connectorId: 4 });
+    assert.deepEqual(retryDriver, { connectorId: 7 });
   } finally {
     prototype.close = originals.close;
     prototype.connect = originals.connect;

--- a/tests/test-playground/src/features/test_create_sandbox_require_preserves_fallback_resolution.ts
+++ b/tests/test-playground/src/features/test_create_sandbox_require_preserves_fallback_resolution.ts
@@ -25,11 +25,35 @@ export const test_create_sandbox_require_preserves_fallback_resolution = () => {
         exports: { "./sub": "./dist/sub.js" },
       }),
       "s/dist/sub.js": "module.exports = { v: 'sub' };",
+      "s/sub.js": "module.exports = { v: 'private-direct-path' };",
       // wildcard subpath export
       "w/package.json": JSON.stringify({
-        exports: { "./feat/*": "./src/feat/*.js" },
+        exports: {
+          "./feat/*": "./src/feat/*.js",
+          "./feat/deep/*": "./src/deep/*.js",
+        },
       }),
       "w/src/feat/x.js": "module.exports = { v: 'wild' };",
+      "w/src/deep/x.js": "module.exports = { v: 'deep-wild' };",
+      // array fallback, null blocker, and inactive condition target
+      "a/package.json": JSON.stringify({
+        exports: { "./entry": ["./missing.js", "./available.js"] },
+      }),
+      "a/available.js": "module.exports = { v: 'array' };",
+      "blocked/package.json": JSON.stringify({ exports: { "./x": null } }),
+      "blocked/x.js": "module.exports = { v: 'private' };",
+      "conditions/package.json": JSON.stringify({
+        exports: {
+          "./entry": {
+            node: "./node.js",
+            import: "./import.mjs",
+            default: "./default.js",
+          },
+        },
+      }),
+      "conditions/node.js": "module.exports = { v: 'node' };",
+      "conditions/import.mjs": "export default { v: 'import' };",
+      "conditions/default.js": "module.exports = { v: 'default' };",
       // scoped package, main fallback
       "@sc/pkg/package.json": JSON.stringify({ main: "./main.js" }),
       "@sc/pkg/main.js": "module.exports = { v: 'scoped' };",
@@ -52,6 +76,17 @@ export const test_create_sandbox_require_preserves_fallback_resolution = () => {
     { v: "wild" },
     "wildcard subpath export",
   );
+  assert.deepEqual(
+    require("w/feat/deep/x"),
+    { v: "deep-wild" },
+    "the longest wildcard prefix wins",
+  );
+  assert.deepEqual(require("a/entry"), { v: "array" }, "array fallback");
+  assert.deepEqual(
+    require("conditions/entry"),
+    { v: "default" },
+    "node/import conditions stay inactive in the browser sandbox",
+  );
   assert.deepEqual(require("@sc/pkg"), { v: "scoped" }, "scoped package name");
   assert.deepEqual(require("r"), { v: 42 }, "relative sibling require");
   assert.deepEqual(require("j"), { v: "json" }, "JSON module");
@@ -60,5 +95,10 @@ export const test_create_sandbox_require_preserves_fallback_resolution = () => {
   assert.throws(
     () => require("totally-absent"),
     /require\("totally-absent"\) is not available/,
+  );
+  assert.throws(
+    () => require("blocked/x"),
+    /require\("blocked\/x"\) is not available/,
+    "a declared null export must block packed private files",
   );
 };

--- a/tests/test-playground/src/features/test_create_sandbox_require_supports_commonjs_root_exports.ts
+++ b/tests/test-playground/src/features/test_create_sandbox_require_supports_commonjs_root_exports.ts
@@ -14,7 +14,7 @@ import { createSandboxRequire } from "../../../../packages/playground/lib/src/sa
  *
  * 1. Root string, `"."`-table, and bare condition map all load the same CJS entry
  *    and return its exports.
- * 2. `require` is preferred over `default` in a condition map (CJS precedence).
+ * 2. Active `require` / `default` conditions are selected in manifest order.
  * 3. Negative twin: an ESM-only root condition map with no CJS-compatible target
  *    and no main/index fallback still fails, naming the requested package.
  */
@@ -44,10 +44,32 @@ export const test_create_sandbox_require_supports_commonjs_root_exports =
       value: "ok",
     });
 
-    // require is preferred over default: only the require target exists.
+    // `require` is selected because it is the first active manifest condition.
     assert.deepEqual(
       load({ require: "./entry.cjs", default: "./missing.mjs" }),
       { value: "ok" },
+    );
+
+    // Reordering two active conditions deliberately changes the selected branch;
+    // this proves the resolver reads package.json key order rather than a fixed
+    // `require ?? default` priority expression.
+    assert.deepEqual(
+      createSandboxRequire(
+        {
+          "ordered/package.json": JSON.stringify({
+            exports: {
+              default: "./default.cjs",
+              require: "./require.cjs",
+              node: "./node.cjs",
+            },
+          }),
+          "ordered/default.cjs": "module.exports = { value: 'default' };",
+          "ordered/require.cjs": "module.exports = { value: 'require' };",
+          "ordered/node.cjs": "module.exports = { value: 'node' };",
+        },
+        { console },
+      )("ordered"),
+      { value: "default" },
     );
 
     // Negative twin: ESM-only root with no CJS target and no main/index fails,

--- a/tests/test-playground/src/features/test_npm_registry_respects_manifest_constraints.ts
+++ b/tests/test-playground/src/features/test_npm_registry_respects_manifest_constraints.ts
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+
+import { installPlaygroundDependencies } from "../../../../packages/playground/lib/src/npm/installPlaygroundDependencies.js";
+import { selectVersion } from "../../../../packages/playground/lib/src/npm/internal/npmRegistry.js";
+import { createTarball } from "../internal/tarball";
+
+type Metadata = Parameters<typeof selectVersion>[0];
+
+/**
+ * Verifies playground npm registry: preserves declared package constraints.
+ *
+ * The loader mounts code into the compiler, editor, and Execute sandbox, so it
+ * must solve every range that reaches a package and resolve an npm alias
+ * through the package named on the right side of `npm:`. Dropping a late range
+ * or querying the alias name installs a package the manifest never selected.
+ *
+ * 1. Select versions across semver ranges and reject unsatisfied constraints.
+ * 2. Install an aliased transitive dependency under its alias key, then reject a
+ *    second range discovered after the first version was already mounted.
+ */
+export const test_npm_registry_respects_manifest_constraints = async () => {
+  const versions: Metadata = {
+    name: "fixture",
+    "dist-tags": { stable: "1.9.9" },
+    versions: {
+      "1.0.0": { name: "fixture", version: "1.0.0" },
+      "1.9.9": { name: "fixture", version: "1.9.9" },
+      "2.0.0": { name: "fixture", version: "2.0.0" },
+    },
+  };
+  for (const range of ["^1", ">=1 <2", "<2.0.0", "~1.9", "1.x"]) {
+    assert.equal(selectVersion(versions, range), "1.9.9", range);
+  }
+  assert.equal(selectVersion(versions, ["stable", "^1"]), "1.9.9");
+  assert.throws(() => selectVersion(versions, "^3"), /No version/);
+  assert.throws(() => selectVersion(versions, "missing-tag"), /dist-tag/);
+
+  const rootTarball = createTarball([
+    {
+      body: JSON.stringify({
+        dependencies: { aliased: "npm:actual@^1.0.0" },
+      }),
+      path: "package/package.json",
+    },
+    { body: "export {};", path: "package/index.d.ts" },
+  ]);
+  const actualTarball = createTarball([
+    { body: JSON.stringify({}), path: "package/package.json" },
+    { body: "export declare const answer: 42;", path: "package/index.d.ts" },
+    { body: "module.exports = 42;", path: "package/index.js" },
+  ]);
+  const metadata = new Map<string, Metadata>([
+    [
+      "root",
+      {
+        name: "root",
+        versions: {
+          "1.0.0": {
+            dist: { tarball: "https://tar.invalid/root.tgz" },
+            name: "root",
+            version: "1.0.0",
+          },
+        },
+      },
+    ],
+    [
+      "actual",
+      {
+        name: "actual",
+        versions: {
+          "1.9.9": {
+            dist: { tarball: "https://tar.invalid/actual.tgz" },
+            name: "actual",
+            version: "1.9.9",
+          },
+        },
+      },
+    ],
+  ]);
+  const requests: string[] = [];
+  const result = await installPlaygroundDependencies(["root"], {
+    fetch: async (input: string): Promise<Response> => {
+      const url = String(input);
+      requests.push(url);
+      if (url.startsWith("https://registry.npmjs.org/")) {
+        const name = decodeURIComponent(url.slice(url.lastIndexOf("/") + 1));
+        const value = metadata.get(name);
+        return value
+          ? new Response(JSON.stringify(value))
+          : new Response("not found", { status: 404 });
+      }
+      if (url.endsWith("root.tgz")) return new Response(rootTarball);
+      if (url.endsWith("actual.tgz")) return new Response(actualTarball);
+      throw new Error(`Unexpected request ${url}.`);
+    },
+  });
+  assert.ok(
+    requests.some((url) => url.endsWith("/actual")),
+    "the alias must query its npm target",
+  );
+  assert.ok(
+    !requests.some((url) => url.endsWith("/aliased")),
+    "the alias name is only the mount point",
+  );
+  assert.deepEqual(
+    result.packages.map(({ name, version }) => ({ name, version })),
+    [
+      { name: "root", version: "1.0.0" },
+      { name: "aliased", version: "1.9.9" },
+    ],
+  );
+  assert.equal(result.runtimeFiles["aliased/index.js"], "module.exports = 42;");
+
+  const lateConstraintTarballs = new Map<string, ArrayBuffer>([
+    [
+      "root",
+      createTarball([
+        {
+          body: JSON.stringify({ dependencies: { a: "^1", b: "*" } }),
+          path: "package/package.json",
+        },
+        { body: "export {};", path: "package/index.d.ts" },
+      ]),
+    ],
+    [
+      "a",
+      createTarball([
+        { body: JSON.stringify({}), path: "package/package.json" },
+        { body: "export {};", path: "package/index.d.ts" },
+      ]),
+    ],
+    [
+      "b",
+      createTarball([
+        {
+          body: JSON.stringify({ dependencies: { a: "^2" } }),
+          path: "package/package.json",
+        },
+        { body: "export {};", path: "package/index.d.ts" },
+      ]),
+    ],
+  ]);
+  const lateMetadata = new Map<string, Metadata>([
+    ["root", metadataFor("root", "1.0.0", "https://tar.invalid/root-late.tgz")],
+    [
+      "a",
+      {
+        name: "a",
+        versions: {
+          "1.9.9": {
+            dist: { tarball: "https://tar.invalid/a-late.tgz" },
+            name: "a",
+            version: "1.9.9",
+          },
+          "2.0.0": {
+            dist: { tarball: "https://tar.invalid/a-late.tgz" },
+            name: "a",
+            version: "2.0.0",
+          },
+        },
+      },
+    ],
+    ["b", metadataFor("b", "1.0.0", "https://tar.invalid/b-late.tgz")],
+  ]);
+  await assert.rejects(
+    installPlaygroundDependencies(["root"], {
+      fetch: async (input: string): Promise<Response> => {
+        const url = String(input);
+        if (url.startsWith("https://registry.npmjs.org/")) {
+          const name = decodeURIComponent(url.slice(url.lastIndexOf("/") + 1));
+          return new Response(JSON.stringify(lateMetadata.get(name)));
+        }
+        const name = url.includes("root-")
+          ? "root"
+          : url.includes("a-")
+            ? "a"
+            : "b";
+        return new Response(lateConstraintTarballs.get(name)!);
+      },
+    }),
+    /No version of a satisfies/,
+  );
+};
+
+function metadataFor(name: string, version: string, tarball: string): Metadata {
+  return {
+    name,
+    versions: {
+      [version]: {
+        dist: { tarball },
+        name,
+        version,
+      },
+    },
+  };
+}

--- a/tests/test-playground/src/features/test_npm_registry_respects_manifest_constraints.ts
+++ b/tests/test-playground/src/features/test_npm_registry_respects_manifest_constraints.ts
@@ -178,7 +178,7 @@ export const test_npm_registry_respects_manifest_constraints = async () => {
         return new Response(lateConstraintTarballs.get(name)!);
       },
     }),
-    /No version of a satisfies/,
+    /No version of a satisfies .*Requested by root requests "\^1"; b requests "\^2"\./,
   );
 };
 

--- a/tests/test-playground/src/features/test_npm_tarball_parses_pax_bytes.ts
+++ b/tests/test-playground/src/features/test_npm_tarball_parses_pax_bytes.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+
+import {
+  mountPackageFiles,
+  unpackNpmTarball,
+} from "../../../../packages/playground/lib/src/npm/internal/npmRegistry.js";
+import { createPaxRecord, createTarball } from "../internal/tarball";
+
+/**
+ * Verifies playground npm tarball: parses PAX records by byte boundaries.
+ *
+ * PAX record lengths count UTF-8 bytes, not JavaScript string code units. A
+ * multibyte path must therefore survive into all three mounted views instead of
+ * acquiring a newline or corrupting the cursor before the next record.
+ *
+ * 1. Unpack a header with a multibyte non-path record followed by a multibyte
+ *    `path` record, alongside an ASCII control.
+ * 2. Mount the extracted file and reject malformed PAX record lengths rather than
+ *    silently treating an invalid header as a different path.
+ */
+export const test_npm_tarball_parses_pax_bytes = async () => {
+  const unicodePath = "package/한글/日本語.ts";
+  const archive = createTarball([
+    {
+      body: concat([
+        createPaxRecord("comment", "앞선 multibyte record"),
+        createPaxRecord("path", unicodePath),
+      ]),
+      path: "PaxHeader",
+      type: "x",
+    },
+    { body: "export const value = 1;\n", path: "ignored.ts" },
+    {
+      body: createPaxRecord("path", "package/package.json"),
+      path: "PaxHeader",
+      type: "x",
+    },
+    { body: '{"name":"fixture"}', path: "ignored.json" },
+    {
+      body: createPaxRecord("path", "package/index.d.ts"),
+      path: "PaxHeader",
+      type: "x",
+    },
+    { body: "export declare const typed: true;\n", path: "ignored.ts" },
+    {
+      body: createPaxRecord("path", "package/index.js"),
+      path: "PaxHeader",
+      type: "x",
+    },
+    { body: "module.exports = true;\n", path: "ignored.js" },
+    {
+      body: createPaxRecord("path", "package/plain.ts"),
+      path: "PaxHeader",
+      type: "x",
+    },
+    { body: "export const plain = 1;\n", path: "ignored.ts" },
+  ]);
+  const unpacked = await unpackNpmTarball(archive, undefined);
+  assert.deepEqual(unpacked.files, {
+    "index.d.ts": "export declare const typed: true;\n",
+    "index.js": "module.exports = true;\n",
+    "package.json": '{"name":"fixture"}',
+    "plain.ts": "export const plain = 1;\n",
+    "한글/日本語.ts": "export const value = 1;\n",
+  });
+
+  const mounted = mountPackageFiles("fixture", unpacked.files);
+  assert.equal(
+    mounted.compilerFiles["node_modules/fixture/한글/日本語.ts"],
+    "export const value = 1;\n",
+  );
+  assert.equal(
+    mounted.editorLibs["file:///node_modules/fixture/index.d.ts"],
+    "export declare const typed: true;\n",
+  );
+  assert.equal(
+    mounted.runtimeFiles["fixture/index.js"],
+    "module.exports = true;\n",
+  );
+  assert.equal(
+    mounted.runtimeFiles["fixture/package.json"],
+    '{"name":"fixture"}',
+    "PAX-derived package metadata reaches the Execute runtime pack",
+  );
+
+  await assert.rejects(
+    unpackNpmTarball(
+      createTarball([
+        {
+          body: "999 path=package/missing.ts\n",
+          path: "PaxHeader",
+          type: "x",
+        },
+        { body: "export {};", path: "ignored.ts" },
+      ]),
+      undefined,
+    ),
+    /Invalid PAX header record/,
+  );
+};
+
+function concat(parts: readonly Uint8Array[]): Uint8Array {
+  const length = parts.reduce((sum, part) => sum + part.length, 0);
+  const output = new Uint8Array(length);
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.length;
+  }
+  return output;
+}

--- a/tests/test-playground/src/features/test_package_name_from_specifier_matches_node_builtins.ts
+++ b/tests/test-playground/src/features/test_package_name_from_specifier_matches_node_builtins.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { builtinModules } from "node:module";
+
+import { packageNameFromSpecifier } from "../../../../packages/playground/lib/src/npm/packageNameFromSpecifier.js";
+
+/**
+ * Verifies playground package names: matches the pinned Node builtin surface.
+ *
+ * The browser cannot read Node's builtin list at runtime, so this Node-side
+ * feature test is the drift guard for the checked-in classifier. A bare builtin
+ * must never become an npm registry request merely because a package with the
+ * same name exists on the public registry.
+ *
+ * 1. Compare every ordinary builtin root and subpath against Node's runtime list
+ *    in both bare and `node:` spellings.
+ * 2. Keep prefix-only builtins, URL specifiers, scoped packages, and ordinary npm
+ *    names on their distinct classification paths.
+ */
+export const test_package_name_from_specifier_matches_node_builtins = () => {
+  const roots = [
+    ...new Set(
+      builtinModules.filter(
+        (moduleName) =>
+          !moduleName.startsWith("_") &&
+          !moduleName.startsWith("node:") &&
+          !moduleName.includes("/"),
+      ),
+    ),
+  ];
+  for (const root of roots) {
+    assert.equal(packageNameFromSpecifier(root), null, `bare ${root}`);
+    assert.equal(
+      packageNameFromSpecifier(`node:${root}`),
+      null,
+      `node:${root}`,
+    );
+    assert.equal(packageNameFromSpecifier(`${root}/promises`), null);
+  }
+
+  // Node exposes these only with the `node:` prefix. Their bare spellings stay
+  // valid npm requests instead of expanding the checked-in bare builtin set.
+  for (const prefixed of builtinModules.filter(
+    (moduleName) => moduleName.startsWith("node:") && !moduleName.includes("/"),
+  )) {
+    const bare = prefixed.slice("node:".length);
+    assert.equal(packageNameFromSpecifier(prefixed), null, prefixed);
+    assert.equal(packageNameFromSpecifier(bare), bare, bare);
+  }
+
+  assert.equal(
+    packageNameFromSpecifier("@scope/package/deep"),
+    "@scope/package",
+  );
+  assert.equal(packageNameFromSpecifier("ordinary/deep"), "ordinary");
+  assert.equal(packageNameFromSpecifier("https://example.com/pkg"), null);
+  assert.equal(packageNameFromSpecifier("node:not-a-real-builtin"), null);
+};

--- a/tests/test-playground/src/internal/tarball.ts
+++ b/tests/test-playground/src/internal/tarball.ts
@@ -1,0 +1,68 @@
+import { gzipSync } from "node:zlib";
+
+const encoder = new TextEncoder();
+
+export interface ITarEntry {
+  body: string | Uint8Array;
+  path: string;
+  type?: "0" | "L" | "x";
+}
+
+/** Build a minimal gzip tarball for browser-side npm-loader feature tests. */
+export function createTarball(entries: readonly ITarEntry[]): ArrayBuffer {
+  const blocks: Uint8Array[] = [];
+  for (const entry of entries) {
+    const body =
+      typeof entry.body === "string" ? encoder.encode(entry.body) : entry.body;
+    const header = new Uint8Array(512);
+    header.set(encoder.encode(entry.path).subarray(0, 100), 0);
+    writeOctal(header, 100, 8, 0o644);
+    writeOctal(header, 124, 12, body.length);
+    writeOctal(header, 136, 12, 0);
+    header[156] = (entry.type ?? "0").charCodeAt(0);
+    header.set(encoder.encode("ustar\0"), 257);
+    blocks.push(
+      header,
+      body,
+      new Uint8Array((512 - (body.length % 512)) % 512),
+    );
+  }
+  blocks.push(new Uint8Array(1024));
+  const tar = concat(blocks);
+  const compressed = gzipSync(tar);
+  return compressed.buffer.slice(
+    compressed.byteOffset,
+    compressed.byteOffset + compressed.byteLength,
+  ) as ArrayBuffer;
+}
+
+/** Build one correctly length-prefixed PAX record in the byte domain. */
+export function createPaxRecord(key: string, value: string): Uint8Array {
+  for (let length = 1; length < 100_000; length++) {
+    const record = `${length} ${key}=${value}\n`;
+    const encoded = encoder.encode(record);
+    if (encoded.length === length) return encoded;
+  }
+  throw new Error(`Could not encode PAX record ${key}.`);
+}
+
+function concat(parts: readonly Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const output = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.length;
+  }
+  return output;
+}
+
+function writeOctal(
+  target: Uint8Array,
+  offset: number,
+  width: number,
+  value: number,
+): void {
+  const encoded = encoder.encode(value.toString(8).padStart(width - 1, "0"));
+  target.set(encoded, offset);
+}

--- a/website/src/content/docs/playground.mdx
+++ b/website/src/content/docs/playground.mdx
@@ -8,7 +8,9 @@ While package files are being resolved, downloaded, unpacked, and installed, the
 
 ## Package Support
 
-The dependency loader starts from bare imports, dynamic imports, and `require("package")` calls in the source. It installs the imported package, its registry dependencies, non-optional peer dependencies, and a matching `@types/*` package when the package itself does not ship declarations.
+The dependency loader starts from bare imports, dynamic imports, and `require("package")` calls in executable source, including template substitutions. It installs the imported package, its registry dependencies, non-optional peer dependencies, and a matching `@types/*` package when the package itself does not ship declarations. Every installed version must satisfy its declared npm range. An npm alias resolves its declared target and stays mounted under the alias name.
+
+Node builtins, in either bare or `node:` form, are never requested from npm. The Execute sandbox treats a package `exports` map as its public boundary and evaluates the first applicable `require` or `default` condition in manifest order. It does not activate Node-only or ESM-only conditions.
 
 The `typia` packages used by the default examples remain bundled because the wasm-side typia adapter must match the exact typia source version linked into the playground compiler.
 


### PR DESCRIPTION
## Intent

Restore the public `@ttsc/playground` dependency-loader, sandbox, and
compiler-client contracts as one compatible package batch.

Closes #802
Closes #803
Closes #820
Closes #823
Closes #824
Closes #826

## Scope

- fence overlapping compiler-client connection generations;
- resolve declared npm ranges and aliases, reconcile constraints, and parse PAX
  records in bytes;
- make sandbox package `exports` authoritative with explicitly declared active
  conditions;
- classify the pinned Node builtin surface and scan executable template
  substitutions;
- add focused browser-free feature coverage, then validate the full playground
  feature package.

## Campaign verification

This is the empty reservation commit. Implementation verification is pending.
Every campaign push and pull-request mutation receives an exact-SHA Actions
cancellation record; repository workflow configuration remains unchanged.
