### PR TITLE
fix(ttsc): reconcile watch inputs from compiler topology

### DIFF
--- a/packages/ttsc/src/compiler/internal/project/readProjectConfig.ts
+++ b/packages/ttsc/src/compiler/internal/project/readProjectConfig.ts
@@ -19,6 +19,7 @@ const PATH_OPTIONS = new Set(["baseUrl", "declarationDir", "rootDir"]);
  * projected into `ITtscParsedProjectConfig`.
  */
 type ResolvedCompilerOptions = {
+  configPaths: string[];
   options: Record<string, unknown>;
   /** Directory of the tsconfig that last declared each option key. */
   optionBaseDirs: Record<string, string>;
@@ -46,6 +47,7 @@ export function readProjectConfig(
   const root = identity.physicalProjectRoot;
   const compilerOptions = readResolvedCompilerOptions(tsconfig);
   return {
+    configPaths: compilerOptions.configPaths,
     compilerOptions: {
       ...compilerOptions.options,
       outDir: compilerOptions.outDir,
@@ -135,6 +137,7 @@ function readResolvedCompilerOptions(
       ? ownPlugins.filter(isProjectPluginConfig)
       : base.plugins;
     return {
+      configPaths: uniquePaths([...base.configPaths, canonical]),
       optionBaseDirs,
       options,
       outDir:
@@ -175,6 +178,7 @@ function resolveBaseCompilerOptions(
   }
   if (!Array.isArray(extended)) {
     return {
+      configPaths: [],
       optionBaseDirs: {},
       options: {},
       pluginBaseDirs: [],
@@ -183,6 +187,7 @@ function resolveBaseCompilerOptions(
     };
   }
   let merged: ResolvedCompilerOptions = {
+    configPaths: [],
     optionBaseDirs: {},
     options: {},
     pluginBaseDirs: [],
@@ -198,6 +203,7 @@ function resolveBaseCompilerOptions(
       seen,
     );
     merged = {
+      configPaths: uniquePaths([...merged.configPaths, ...current.configPaths]),
       optionBaseDirs: {
         ...merged.optionBaseDirs,
         ...current.optionBaseDirs,
@@ -215,6 +221,10 @@ function resolveBaseCompilerOptions(
     };
   }
   return merged;
+}
+
+function uniquePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths)];
 }
 
 /**

--- a/packages/ttsc/src/compiler/internal/runBuild.ts
+++ b/packages/ttsc/src/compiler/internal/runBuild.ts
@@ -27,6 +27,12 @@ type RunBuildOptions = TtscBuildOptions & {
   skipDiagnosticsCheck?: boolean;
   forceListEmittedFiles?: boolean;
   /**
+   * Receives selected native-plugin source roots after the project resolves.
+   * The watch launcher uses these roots to invalidate a sidecar when its Go
+   * implementation changes between rebuilds.
+   */
+  onWatchInputs?: (inputs: readonly string[]) => void;
+  /**
    * Emit an external source map from the direct tsgo build lane even when the
    * project configures none. Set by the ttsx runtime builds so a served emit
    * carries a map to inline under the source URL (issue #353). Applied only to
@@ -194,6 +200,12 @@ function runBuildTimed(
   if (projectFree !== null) return projectFree;
   const setupStartedAt = process.hrtime.bigint();
   const execution = resolveExecutionContext(options);
+  options.onWatchInputs?.(
+    execution.nativePlugins.flatMap((plugin) => [
+      plugin.source,
+      ...(plugin.contributors?.map((contributor) => contributor.source) ?? []),
+    ]),
+  );
   if (
     execution.nativePlugins.length > 0 ||
     execution.pluginSetupFailure !== undefined

--- a/packages/ttsc/src/launcher/internal/runTtsc.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsc.ts
@@ -22,6 +22,7 @@ import {
 import type { TtscBuildOptions } from "../../structures/internal/TtscBuildOptions";
 import { getCompilerVersionText } from "./getCompilerVersionText";
 import { resolveCacheDir } from "./resolveCacheDir";
+import { WatchTopology } from "./watchTopology";
 
 /**
  * CLI entry point for `ttsc`. Dispatches argv to the appropriate build lane
@@ -680,9 +681,13 @@ function runWatch(
   checkOnly: boolean,
 ): number {
   const cwd = path.resolve(options.cwd ?? process.cwd());
+  let topology: WatchTopology | undefined;
   const invocation = {
     ...options,
     cwd,
+    onWatchInputs: (inputs: readonly string[]) => {
+      topology?.setExtraInputs(inputs);
+    },
     quiet: true,
   };
   const root = path.dirname(
@@ -700,6 +705,7 @@ function runWatch(
 
   const runOnce = () => {
     running = true;
+    let completed = false;
     try {
       if (!options.preserveWatchOutput) {
         process.stdout.write("\x1bc");
@@ -725,6 +731,7 @@ function runWatch(
               return result.status;
             })();
       lastStatus = status;
+      completed = true;
       process.stdout.write(
         `[ttsc] ${status === 0 ? "watch build complete" : "watch build failed"}\n`,
       );
@@ -734,6 +741,19 @@ function runWatch(
       process.stdout.write(`[ttsc] watch build failed\n`);
     } finally {
       running = false;
+      if (completed) {
+        try {
+          // A filesystem event can arrive after the build reports completion
+          // but before this synchronous cleanup reaches its re-resolution.
+          // Notify for a membership change here as well, otherwise that new
+          // input is silently absorbed into the watch set without a rebuild.
+          topology?.refresh(true);
+        } catch (error) {
+          process.stderr.write(
+            `[ttsc] watch error on ${path.relative(cwd, root) || "."}: ${formatError(error)}\n`,
+          );
+        }
+      }
     }
     if (rerun) {
       rerun = false;
@@ -749,23 +769,20 @@ function runWatch(
     timer = setTimeout(runOnce, 60);
   };
 
-  const directories = collectWatchDirectories(root);
-  const watchers = directories.map((dir) => {
-    const watcher = fs.watch(dir, { persistent: true }, () => trigger());
-    // Without an error handler Node rethrows watcher errors as uncaught
-    // exceptions, which would crash the session. inotify limits (ENOSPC) and
-    // transient FS errors should be logged while the session stays alive.
-    watcher.on("error", (err) => {
+  topology = new WatchTopology(invocation, {
+    onError: (location, error) => {
       process.stderr.write(
-        `[ttsc] watch error on ${path.relative(cwd, dir) || "."}: ${formatError(err)}\n`,
+        `[ttsc] watch error on ${path.relative(cwd, location) || "."}: ${formatError(error)}\n`,
       );
-    });
-    return watcher;
+    },
+    onInputChange: trigger,
+    onTopologyChange: trigger,
   });
+  topology.refresh(false);
 
   const close = () => {
     if (timer) clearTimeout(timer);
-    for (const watcher of watchers) watcher.close();
+    topology?.close();
   };
   process.on("SIGINT", () => {
     close();
@@ -795,29 +812,6 @@ function runWatch(
 // non-zero (or non-finite) status collapses to 1 so the session signals failure.
 function toExitCode(status: number): number {
   return Number.isInteger(status) && status >= 0 && status <= 255 ? status : 1;
-}
-
-function collectWatchDirectories(root: string): string[] {
-  const out: string[] = [];
-  const stack: string[] = [root];
-  while (stack.length !== 0) {
-    const current = stack.pop()!;
-    out.push(current);
-    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
-      if (
-        entry.name === "node_modules" ||
-        entry.name === ".git" ||
-        entry.name === "lib" ||
-        entry.name === "dist"
-      ) {
-        continue;
-      }
-      if (entry.isDirectory()) {
-        stack.push(path.join(current, entry.name));
-      }
-    }
-  }
-  return out;
 }
 
 function formatError(error: unknown): string {

--- a/packages/ttsc/src/launcher/internal/watchTopology.ts
+++ b/packages/ttsc/src/launcher/internal/watchTopology.ts
@@ -1,0 +1,466 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { readJsoncFile } from "../../compiler/internal/project/readConfigJson";
+import { readProjectConfig } from "../../compiler/internal/project/readProjectConfig";
+import { resolveTsgo } from "../../compiler/internal/resolveTsgo";
+import { outputText, spawnNative } from "../../compiler/internal/spawnNative";
+import type { ITtscParsedProjectConfig } from "../../structures/internal/ITtscParsedProjectConfig";
+import type { TtscBuildOptions } from "../../structures/internal/TtscBuildOptions";
+
+type WatchTopologyOptions = Pick<
+  TtscBuildOptions,
+  "binary" | "env" | "outDir" | "passthrough" | "projectRoot" | "tsconfig"
+> & {
+  cwd: string;
+  files: readonly string[];
+};
+
+type WatchTopologyCallbacks = {
+  onError(location: string, error: unknown): void;
+  onInputChange(): void;
+  onTopologyChange(): void;
+};
+
+type ResolvedWatchTopology = {
+  directories: Map<string, string>;
+  files: Map<string, string>;
+  outputs: Map<string, string>;
+};
+
+/**
+ * Keeps the launcher watch set aligned with the compiler's current program.
+ *
+ * TypeScript-Go's `--listFilesOnly` output is the authority for source and
+ * declaration inputs. Configuration files, project-reference roots, and the
+ * source trees of selected native plugins supplement that list, while compiler
+ * outputs are filtered before any watcher is installed.
+ */
+export class WatchTopology {
+  private directories = new Map<string, string>();
+  private directoryWatchers = new Map<string, fs.FSWatcher>();
+  private extraInputs: readonly string[] = [];
+  private extraWatchers = new Map<string, fs.FSWatcher>();
+  private files = new Map<string, string>();
+  private fileWatchers = new Map<string, fs.FSWatcher>();
+  private observedDirectories = new Map<string, string>();
+  private outputs = new Map<string, string>();
+
+  public constructor(
+    private readonly options: WatchTopologyOptions,
+    private readonly callbacks: WatchTopologyCallbacks,
+  ) {}
+
+  /** Re-resolve compiler inputs and notify only when their membership changed. */
+  public refresh(notify: boolean): void {
+    const next = resolveWatchTopology(this.options, this.extraInputs);
+    const changed =
+      mapsEqual(this.files, next.files) === false ||
+      mapsEqual(this.directories, next.directories) === false ||
+      mapsEqual(this.outputs, next.outputs) === false;
+    this.files = next.files;
+    this.directories = next.directories;
+    this.outputs = next.outputs;
+    this.syncFileWatchers();
+    this.syncDirectoryWatchers();
+    this.syncExtraWatchers();
+    if (notify && changed) {
+      this.callbacks.onTopologyChange();
+    }
+  }
+
+  /** Add Go plugin source trees discovered by the real build lane. */
+  public setExtraInputs(inputs: readonly string[]): void {
+    const next = uniqueExistingPaths(inputs);
+    if (arraysEqual(this.extraInputs, next)) return;
+    this.extraInputs = next;
+    this.refresh(false);
+  }
+
+  /** Close every watcher so SIGINT/SIGTERM can drain the event loop. */
+  public close(): void {
+    closeWatchers(this.fileWatchers);
+    closeWatchers(this.directoryWatchers);
+    closeWatchers(this.extraWatchers);
+  }
+
+  private syncFileWatchers(): void {
+    syncWatchers(
+      this.fileWatchers,
+      this.files,
+      (location) =>
+        fs.watch(location, { persistent: true }, () => {
+          this.callbacks.onInputChange();
+        }),
+      (location, error) => this.callbacks.onError(location, error),
+    );
+  }
+
+  private syncDirectoryWatchers(): void {
+    const desired = new Map(this.directories);
+    for (const [key, location] of this.observedDirectories) {
+      if (
+        isDirectory(location) === false ||
+        this.isCompilerOutputDirectory(location)
+      ) {
+        this.observedDirectories.delete(key);
+        continue;
+      }
+      desired.set(key, location);
+    }
+    syncWatchers(
+      this.directoryWatchers,
+      desired,
+      (location) =>
+        fs.watch(location, { persistent: true }, (_event, filename) => {
+          const changed =
+            filename === null
+              ? undefined
+              : path.resolve(location, filename.toString());
+          // File watchers own ordinary source/config edits. Directory watchers
+          // only reconcile membership, so an emit in an unrelated output folder
+          // cannot schedule another build.
+          if (
+            changed !== undefined &&
+            this.files.has(pathKey(changed)) &&
+            fs.existsSync(changed)
+          ) {
+            return;
+          }
+          this.refreshFromDirectory(location, changed);
+        }),
+      (location, error) => this.callbacks.onError(location, error),
+    );
+  }
+
+  private syncExtraWatchers(): void {
+    const directories = new Map<string, string>();
+    for (const input of this.extraInputs) {
+      for (const directory of collectInputDirectories(input)) {
+        directories.set(pathKey(directory), directory);
+      }
+    }
+    syncWatchers(
+      this.extraWatchers,
+      directories,
+      (location) =>
+        fs.watch(location, { persistent: true }, () => {
+          this.callbacks.onInputChange();
+        }),
+      (location, error) => this.callbacks.onError(location, error),
+    );
+  }
+
+  private refreshFromDirectory(location: string, changed?: string): void {
+    if (
+      changed !== undefined &&
+      isDirectory(changed) &&
+      this.isCompilerOutputDirectory(changed) === false
+    ) {
+      this.observedDirectories.set(pathKey(changed), changed);
+    }
+    try {
+      this.refresh(true);
+    } catch (error) {
+      this.callbacks.onError(location, error);
+    }
+  }
+
+  private isCompilerOutputDirectory(location: string): boolean {
+    return [...this.outputs.values()].some((output) =>
+      isPathWithin(output, location),
+    );
+  }
+}
+
+function resolveWatchTopology(
+  options: WatchTopologyOptions,
+  extraInputs: readonly string[],
+): ResolvedWatchTopology {
+  const files = new Map<string, string>();
+  const outputs = new Map<string, string>();
+  const roots: string[] = [];
+  if (options.files.length !== 0) {
+    const project = readProjectConfig({
+      cwd: options.cwd,
+      projectRoot: options.projectRoot,
+      tsconfig: options.tsconfig,
+    });
+    roots.push(project.root);
+    addPaths(files, project.configPaths);
+    addPaths(outputs, resolveCompilerOutputs(project, options).directories);
+    addPaths(
+      files,
+      options.files.map((file) => path.resolve(options.cwd, file)),
+    );
+  } else {
+    for (const project of readReferencedProjects(options)) {
+      roots.push(project.root);
+      addPaths(files, project.configPaths);
+      addPaths(outputs, resolveCompilerOutputs(project, options).directories);
+      addPaths(files, listCompilerInputs(project, options));
+    }
+  }
+  addPaths(files, extraInputs);
+  return {
+    directories: collectTopologyDirectories(files.values(), roots),
+    files,
+    outputs,
+  };
+}
+
+function readReferencedProjects(
+  options: WatchTopologyOptions,
+): ITtscParsedProjectConfig[] {
+  const root = readProjectConfig({
+    cwd: options.cwd,
+    projectRoot: options.projectRoot,
+    tsconfig: options.tsconfig,
+  });
+  const projects: ITtscParsedProjectConfig[] = [];
+  const queue = [root];
+  const seen = new Set<string>();
+  while (queue.length !== 0) {
+    const project = queue.shift()!;
+    if (seen.has(pathKey(project.path))) continue;
+    seen.add(pathKey(project.path));
+    projects.push(project);
+    for (const reference of readProjectReferences(project.path)) {
+      queue.push(
+        readProjectConfig({
+          cwd: path.dirname(project.path),
+          tsconfig: reference,
+        }),
+      );
+    }
+  }
+  return projects;
+}
+
+function readProjectReferences(tsconfig: string): string[] {
+  const parsed = readJsoncFile(tsconfig);
+  if (
+    isRecord(parsed) === false ||
+    Array.isArray(parsed.references) === false
+  ) {
+    return [];
+  }
+  const base = path.dirname(tsconfig);
+  const references: string[] = [];
+  for (const reference of parsed.references) {
+    if (
+      isRecord(reference) === false ||
+      typeof reference.path !== "string" ||
+      reference.path.length === 0
+    ) {
+      continue;
+    }
+    references.push(path.resolve(base, reference.path));
+  }
+  return references;
+}
+
+function listCompilerInputs(
+  project: ITtscParsedProjectConfig,
+  options: WatchTopologyOptions,
+): string[] {
+  const tsgo = resolveTsgo({
+    binary: options.binary,
+    cwd: project.root,
+    env: options.env,
+  });
+  const result = spawnNative(
+    tsgo.binary,
+    [
+      "-p",
+      project.path,
+      "--listFilesOnly",
+      "--pretty",
+      "false",
+      ...(options.passthrough ?? []),
+    ],
+    {
+      cwd: project.root,
+      env: { ...process.env, ...options.env },
+      encoding: "utf8",
+    },
+  );
+  if (result.error) {
+    throw new Error(
+      `ttsc: failed to list compiler inputs: ${result.error.message}`,
+    );
+  }
+  const outputs = resolveCompilerOutputs(project, options);
+  const inputs = outputText(result.stdout)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => path.isAbsolute(line))
+    .map((line) => path.resolve(line))
+    .filter((file) => isCompilerOutput(file, outputs) === false);
+  if (result.status !== 0 && inputs.length === 0) {
+    throw new Error(
+      `ttsc: failed to list compiler inputs:\n${outputText(result.stderr) || outputText(result.stdout)}`,
+    );
+  }
+  return inputs;
+}
+
+function resolveCompilerOutputs(
+  project: ITtscParsedProjectConfig,
+  options: WatchTopologyOptions,
+): { directories: string[]; files: string[] } {
+  const compilerOptions = project.compilerOptions;
+  const outDir = options.outDir
+    ? path.resolve(options.cwd, options.outDir)
+    : compilerOptions.outDir;
+  return {
+    directories: [outDir, compilerOptions.declarationDir]
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => path.resolve(value)),
+    files: [compilerOptions.outFile, compilerOptions.tsBuildInfoFile]
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => path.resolve(project.root, value)),
+  };
+}
+
+function isCompilerOutput(
+  file: string,
+  outputs: { directories: readonly string[]; files: readonly string[] },
+): boolean {
+  return (
+    outputs.files.some((output) => pathKey(output) === pathKey(file)) ||
+    outputs.directories.some((directory) => isPathWithin(directory, file))
+  );
+}
+
+function collectTopologyDirectories(
+  files: Iterable<string>,
+  roots: readonly string[],
+): Map<string, string> {
+  const directories = new Map<string, string>();
+  for (const root of roots) {
+    directories.set(pathKey(root), root);
+  }
+  for (const file of files) {
+    const directory = path.dirname(file);
+    const root = roots.find((candidate) => isPathWithin(candidate, directory));
+    if (root === undefined) {
+      directories.set(pathKey(directory), directory);
+      continue;
+    }
+    let current = directory;
+    while (true) {
+      directories.set(pathKey(current), current);
+      if (pathKey(current) === pathKey(root)) break;
+      const parent = path.dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+  }
+  return directories;
+}
+
+function collectInputDirectories(input: string): string[] {
+  if (isDirectory(input) === false) return [];
+  const directories: string[] = [];
+  const stack = [input];
+  while (stack.length !== 0) {
+    const current = stack.pop()!;
+    directories.push(current);
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        stack.push(path.join(current, entry.name));
+      }
+    }
+  }
+  return directories;
+}
+
+function isDirectory(location: string): boolean {
+  try {
+    return fs.statSync(location).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function syncWatchers(
+  watchers: Map<string, fs.FSWatcher>,
+  desired: ReadonlyMap<string, string>,
+  create: (location: string) => fs.FSWatcher,
+  onError: (location: string, error: unknown) => void,
+): void {
+  for (const [key, watcher] of watchers) {
+    if (desired.has(key)) continue;
+    watcher.close();
+    watchers.delete(key);
+  }
+  for (const [key, location] of desired) {
+    if (watchers.has(key)) continue;
+    try {
+      const watcher = create(location);
+      watcher.on("error", (error) => onError(location, error));
+      watchers.set(key, watcher);
+    } catch (error) {
+      onError(location, error);
+    }
+  }
+}
+
+function closeWatchers(watchers: Map<string, fs.FSWatcher>): void {
+  for (const watcher of watchers.values()) watcher.close();
+  watchers.clear();
+}
+
+function addPaths(target: Map<string, string>, paths: Iterable<string>): void {
+  for (const location of paths) {
+    const resolved = path.resolve(location);
+    target.set(pathKey(resolved), resolved);
+  }
+}
+
+function uniqueExistingPaths(paths: readonly string[]): string[] {
+  const unique = new Map<string, string>();
+  for (const location of paths) {
+    if (location.length === 0) continue;
+    const resolved = path.resolve(location);
+    unique.set(pathKey(resolved), resolved);
+  }
+  return [...unique.values()];
+}
+
+function mapsEqual(
+  left: ReadonlyMap<string, string>,
+  right: ReadonlyMap<string, string>,
+): boolean {
+  if (left.size !== right.size) return false;
+  return [...left].every(([key, value]) => right.get(key) === value);
+}
+
+function arraysEqual(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length && left.every((value, i) => value === right[i])
+  );
+}
+
+function isPathWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === "" ||
+    (relative !== ".." &&
+      relative.startsWith(`..${path.sep}`) === false &&
+      !path.isAbsolute(relative))
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function pathKey(location: string): string {
+  const resolved = path.resolve(location);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}

--- a/packages/ttsc/src/structures/internal/ITtscParsedProjectConfig.ts
+++ b/packages/ttsc/src/structures/internal/ITtscParsedProjectConfig.ts
@@ -3,6 +3,8 @@ import type { ITtscProjectIdentity } from "./ITtscProjectIdentity";
 
 /** Resolved project config subset used inside the ttsc host. */
 export interface ITtscParsedProjectConfig {
+  /** Every resolved tsconfig/jsconfig in the inherited `extends` chain. */
+  configPaths: readonly string[];
   /** Compiler options after extends inheritance has been applied. */
   compilerOptions: {
     /** Absolute output directory when configured. */

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_watch_ignores_a_preexisting_outdir_after_emit.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_watch_ignores_a_preexisting_outdir_after_emit.ts
@@ -1,0 +1,39 @@
+import { createProject } from "../../internal/toolchain";
+import { WatchSession } from "../../internal/watch";
+
+/**
+ * Verifies `ttsc --watch` ignores emits into a pre-existing output directory.
+ *
+ * The former directory walk watched arbitrary output names, so the initial
+ * build wrote to `build` and immediately scheduled another build forever. The
+ * resolved-program watch set must exclude compiler-owned output regardless of
+ * whether that directory existed before watch startup.
+ *
+ * 1. Materialize an emit project with a pre-existing `build` directory.
+ * 2. Start the real watch launcher and wait for its initial build.
+ * 3. Require a quiet period with no self-triggered rebuild.
+ */
+export const test_ttsc_watch_ignores_a_preexisting_outdir_after_emit =
+  async (): Promise<void> => {
+    const root = createProject({
+      "build/.keep": "",
+      "src/main.ts": `export const value = 1;\n`,
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          module: "commonjs",
+          outDir: "build",
+          rootDir: "src",
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src"],
+      }),
+    });
+    const session = new WatchSession(root);
+    try {
+      await session.waitForBuilds(1);
+      await session.waitForQuiet();
+    } finally {
+      await session.close();
+    }
+  };

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_watch_ignores_an_outdir_created_by_initial_emit.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_watch_ignores_an_outdir_created_by_initial_emit.ts
@@ -1,0 +1,38 @@
+import { createProject } from "../../internal/toolchain";
+import { WatchSession } from "../../internal/watch";
+
+/**
+ * Verifies `ttsc --watch` ignores an output directory created by its first
+ * emit.
+ *
+ * The output directory does not exist while the watch topology is resolved, so
+ * this covers the creation event that used to turn an otherwise idle compiler
+ * into a rebuild loop.
+ *
+ * 1. Materialize an emit project whose configured `build` directory is absent.
+ * 2. Start the real watch launcher and wait for its initial emit.
+ * 3. Require a quiet period after `build` is created by that emit.
+ */
+export const test_ttsc_watch_ignores_an_outdir_created_by_initial_emit =
+  async (): Promise<void> => {
+    const root = createProject({
+      "src/main.ts": `export const value = 1;\n`,
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          module: "commonjs",
+          outDir: "build",
+          rootDir: "src",
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src"],
+      }),
+    });
+    const session = new WatchSession(root);
+    try {
+      await session.waitForBuilds(1);
+      await session.waitForQuiet();
+    } finally {
+      await session.close();
+    }
+  };

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_watch_ignores_an_unrelated_readme.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_watch_ignores_an_unrelated_readme.ts
@@ -1,0 +1,38 @@
+import { createProject, fs, path } from "../../internal/toolchain";
+import { WatchSession } from "../../internal/watch";
+
+/**
+ * Verifies `ttsc --watch` does not rebuild for an unrelated README edit.
+ *
+ * Directory events are used only to reconcile compiler membership. A file that
+ * remains outside the resolved program must not turn a repository-level edit
+ * into a compiler invocation.
+ *
+ * 1. Start a no-emit project whose program contains only `src`.
+ * 2. Wait for the initial real watch build to settle.
+ * 3. Edit the root README and require that the session stays quiet.
+ */
+export const test_ttsc_watch_ignores_an_unrelated_readme =
+  async (): Promise<void> => {
+    const root = createProject({
+      "README.md": "initial\n",
+      "src/main.ts": `export const value = 1;\n`,
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          module: "commonjs",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src"],
+      }),
+    });
+    const session = new WatchSession(root);
+    try {
+      await session.waitForBuilds(1);
+      fs.writeFileSync(path.join(root, "README.md"), "changed\n", "utf8");
+      await session.waitForQuiet();
+    } finally {
+      await session.close();
+    }
+  };

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_watch_rebuilds_for_a_selected_go_plugin_source.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_watch_rebuilds_for_a_selected_go_plugin_source.ts
@@ -1,0 +1,42 @@
+import { goPath } from "../../internal/plugin-corpus";
+import { fs, os, path, workspaceRoot } from "../../internal/toolchain";
+import { WatchSession } from "../../internal/watch";
+
+/**
+ * Verifies `ttsc --watch` follows the selected Go plugin source tree.
+ *
+ * Native plugins are compiler inputs after their descriptor resolves, not a
+ * project-directory convention. Their source edit must rebuild the running
+ * session so the content-addressed plugin binary is selected again.
+ *
+ * 1. Copy the real source-plugin fixture and wait for the initial watch build.
+ * 2. Edit the selected plugin's Go implementation.
+ * 3. Require one more real watch build without restarting the process.
+ */
+export const test_ttsc_watch_rebuilds_for_a_selected_go_plugin_source =
+  async (): Promise<void> => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-watch-"));
+    const cache = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-watch-cache-"));
+    fs.cpSync(
+      path.join(workspaceRoot, "tests", "projects", "go-source-plugin"),
+      root,
+      { recursive: true },
+    );
+    const source = path.join(root, "go-plugin", "main.go");
+    const localGo = goPath();
+    const session = new WatchSession(root, {
+      env: {
+        ...(localGo === undefined ? {} : { PATH: localGo }),
+        TTSC_CACHE_DIR: cache,
+      },
+    });
+    try {
+      await session.waitForBuilds(1);
+      fs.appendFileSync(source, "\n// watch topology regression\n", "utf8");
+      await session.waitForBuilds(2);
+    } finally {
+      await session.close();
+      fs.rmSync(root, { force: true, recursive: true });
+      fs.rmSync(cache, { force: true, recursive: true });
+    }
+  };

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_watch_rebuilds_for_an_external_extended_config.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_watch_rebuilds_for_an_external_extended_config.ts
@@ -1,0 +1,67 @@
+import { fs, os, path } from "../../internal/toolchain";
+import { WatchSession } from "../../internal/watch";
+
+/**
+ * Verifies `ttsc --watch` follows an `extends` config outside the project root.
+ *
+ * A recursive snapshot of the selected tsconfig directory cannot see a shared
+ * parent config. The resolved config chain is an explicit compiler input and
+ * must therefore rebuild the already-running session when it changes.
+ *
+ * 1. Create a project whose tsconfig extends a sibling shared config directory.
+ * 2. Start a real watch session and wait for its initial build.
+ * 3. Edit the external base config and require one topology rebuild.
+ */
+export const test_ttsc_watch_rebuilds_for_an_external_extended_config =
+  async (): Promise<void> => {
+    const container = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-watch-"));
+    const root = path.join(container, "project");
+    const config = path.join(container, "config", "base.json");
+    fs.mkdirSync(path.join(root, "src"), { recursive: true });
+    fs.mkdirSync(path.dirname(config), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "tsconfig.json"),
+      JSON.stringify({
+        extends: "../config/base.json",
+        include: ["src"],
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(root, "src", "main.ts"),
+      `export const value = 1;\n`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      config,
+      JSON.stringify({
+        compilerOptions: {
+          module: "commonjs",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+      }),
+      "utf8",
+    );
+    const session = new WatchSession(root);
+    try {
+      await session.waitForBuilds(1);
+      fs.writeFileSync(
+        config,
+        JSON.stringify({
+          compilerOptions: {
+            module: "commonjs",
+            noEmit: true,
+            strict: false,
+            target: "ES2022",
+          },
+        }),
+        "utf8",
+      );
+      await session.waitForBuilds(2);
+    } finally {
+      await session.close();
+      fs.rmSync(container, { force: true, recursive: true });
+    }
+  };

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_watch_rebuilds_for_an_external_loaded_source.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_watch_rebuilds_for_an_external_loaded_source.ts
@@ -1,0 +1,52 @@
+import { fs, os, path } from "../../internal/toolchain";
+import { WatchSession } from "../../internal/watch";
+
+/**
+ * Verifies `ttsc --watch` follows a resolved source dependency outside its
+ * root.
+ *
+ * The compiler's list-files result can contain a source loaded through a
+ * relative import beyond the selected config directory. Its direct file watch
+ * must remain active after the first build.
+ *
+ * 1. Create a project importing a TypeScript file from a sibling directory.
+ * 2. Start the real watch launcher and wait for its initial build.
+ * 3. Edit that external loaded source and require a rebuild.
+ */
+export const test_ttsc_watch_rebuilds_for_an_external_loaded_source =
+  async (): Promise<void> => {
+    const container = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-watch-"));
+    const root = path.join(container, "project");
+    const dependency = path.join(container, "dependency", "value.ts");
+    fs.mkdirSync(path.join(root, "src"), { recursive: true });
+    fs.mkdirSync(path.dirname(dependency), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          module: "commonjs",
+          moduleResolution: "node",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src"],
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(root, "src", "main.ts"),
+      `import { value } from "../../dependency/value";\nexport { value };\n`,
+      "utf8",
+    );
+    fs.writeFileSync(dependency, `export const value = 1;\n`, "utf8");
+    const session = new WatchSession(root);
+    try {
+      await session.waitForBuilds(1);
+      fs.writeFileSync(dependency, `export const value = 2;\n`, "utf8");
+      await session.waitForBuilds(2);
+    } finally {
+      await session.close();
+      fs.rmSync(container, { force: true, recursive: true });
+    }
+  };

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_watch_rebuilds_for_an_external_project_reference.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_watch_rebuilds_for_an_external_project_reference.ts
@@ -1,0 +1,68 @@
+import { fs, os, path } from "../../internal/toolchain";
+import { WatchSession } from "../../internal/watch";
+
+/**
+ * Verifies `ttsc --watch` follows sources in an external project reference.
+ *
+ * A referenced project's source tree is neither a child of the selected root
+ * nor necessarily an import in the root program. The watch topology must walk
+ * declared references and retain their compiler-resolved inputs explicitly.
+ *
+ * 1. Create a root project with a sibling composite project reference.
+ * 2. Start the real watch launcher and wait for its initial build.
+ * 3. Edit the referenced project's source and require a rebuild.
+ */
+export const test_ttsc_watch_rebuilds_for_an_external_project_reference =
+  async (): Promise<void> => {
+    const container = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-watch-"));
+    const root = path.join(container, "root");
+    const reference = path.join(container, "reference");
+    const referenceSource = path.join(reference, "src", "value.ts");
+    fs.mkdirSync(path.join(root, "src"), { recursive: true });
+    fs.mkdirSync(path.dirname(referenceSource), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          module: "commonjs",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src"],
+        references: [{ path: "../reference" }],
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(root, "src", "main.ts"),
+      `export const root = 1;\n`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(reference, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          composite: true,
+          declaration: true,
+          module: "commonjs",
+          outDir: "lib",
+          rootDir: "src",
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src"],
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(referenceSource, `export const value = 1;\n`, "utf8");
+    const session = new WatchSession(root);
+    try {
+      await session.waitForBuilds(1);
+      fs.writeFileSync(referenceSource, `export const value = 2;\n`, "utf8");
+      await session.waitForBuilds(2);
+    } finally {
+      await session.close();
+      fs.rmSync(container, { force: true, recursive: true });
+    }
+  };

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_watch_reconciles_a_new_included_directory.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_watch_reconciles_a_new_included_directory.ts
@@ -1,0 +1,43 @@
+import { createProject, fs, path } from "../../internal/toolchain";
+import { WatchSession } from "../../internal/watch";
+
+/**
+ * Verifies `ttsc --watch` reconciles a newly included source directory.
+ *
+ * A one-time directory snapshot can notice the directory creation but cannot
+ * observe the next edit inside it. The launcher must rebuild once the new
+ * included file appears, then add its directory to the persistent watch set.
+ *
+ * 1. Start a real watch session with one existing `src` file.
+ * 2. Create `src/later/value.ts` and wait for the topology rebuild.
+ * 3. Edit that new file and require one more rebuild after the session is idle.
+ */
+export const test_ttsc_watch_reconciles_a_new_included_directory =
+  async (): Promise<void> => {
+    const root = createProject({
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          module: "commonjs",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src"],
+      }),
+      "src/seed.ts": `export const seed = 1;\n`,
+    });
+    const session = new WatchSession(root);
+    try {
+      await session.waitForBuilds(1);
+      const later = path.join(root, "src", "later");
+      fs.mkdirSync(later);
+      const value = path.join(later, "value.ts");
+      fs.writeFileSync(value, `export const value = 1;\n`, "utf8");
+      await session.waitForBuilds(2);
+      await session.waitForQuiet();
+      fs.writeFileSync(value, `export const value = 2;\n`, "utf8");
+      await session.waitForBuilds(3);
+    } finally {
+      await session.close();
+    }
+  };

--- a/tests/test-ttsc/src/features/compiler/test_ttsc_watch_tracks_sources_below_lib_and_dist.ts
+++ b/tests/test-ttsc/src/features/compiler/test_ttsc_watch_tracks_sources_below_lib_and_dist.ts
@@ -1,0 +1,50 @@
+import { createProject, fs, path } from "../../internal/toolchain";
+import { WatchSession } from "../../internal/watch";
+
+/**
+ * Verifies `ttsc --watch` follows included source roots named `lib` and `dist`.
+ *
+ * Those names were output guesses, not a compiler boundary. An authored source
+ * in either directory must invalidate the program exactly like the ordinary
+ * `src` input, without granting those names a permanent exclusion.
+ *
+ * 1. Start a no-emit project that includes `src`, `lib`, and `dist`.
+ * 2. Edit the `lib` input and wait for the next build.
+ * 3. After the session settles, edit the `dist` input and require another build.
+ */
+export const test_ttsc_watch_tracks_sources_below_lib_and_dist =
+  async (): Promise<void> => {
+    const root = createProject({
+      "dist/value.ts": `export const distValue = 1;\n`,
+      "lib/value.ts": `export const libValue = 1;\n`,
+      "src/main.ts": `export const sourceValue = 1;\n`,
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          module: "commonjs",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src", "lib", "dist"],
+      }),
+    });
+    const session = new WatchSession(root);
+    try {
+      await session.waitForBuilds(1);
+      fs.writeFileSync(
+        path.join(root, "lib", "value.ts"),
+        `export const libValue = 2;\n`,
+        "utf8",
+      );
+      await session.waitForBuilds(2);
+      await session.waitForQuiet();
+      fs.writeFileSync(
+        path.join(root, "dist", "value.ts"),
+        `export const distValue = 2;\n`,
+        "utf8",
+      );
+      await session.waitForBuilds(3);
+    } finally {
+      await session.close();
+    }
+  };

--- a/tests/test-ttsc/src/internal/watch.ts
+++ b/tests/test-ttsc/src/internal/watch.ts
@@ -1,0 +1,121 @@
+import {
+  assert,
+  child_process,
+  nativeBinary,
+  tsgoBinary,
+  ttscBin,
+} from "./toolchain";
+
+/** A real `ttsc --watch` child with build-count and quiet-period assertions. */
+export class WatchSession {
+  private readonly child: ReturnType<typeof child_process.spawn>;
+  private readonly listeners = new Set<() => void>();
+  private builds = 0;
+  private output = "";
+
+  public constructor(root: string, options: { env?: NodeJS.ProcessEnv } = {}) {
+    this.child = child_process.spawn(
+      process.execPath,
+      [ttscBin, "--watch", "--cwd", root],
+      {
+        cwd: root,
+        env: {
+          ...process.env,
+          ...options.env,
+          TTSC_BINARY: nativeBinary,
+          TTSC_TSGO_BINARY: tsgoBinary,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      },
+    );
+    const onChunk = (chunk: Buffer): void => {
+      this.output += chunk.toString("utf8");
+      this.builds = (
+        this.output.match(/\[ttsc\] watch build (?:complete|failed)/g) ?? []
+      ).length;
+      for (const listener of this.listeners) listener();
+    };
+    this.child.stdout.on("data", onChunk);
+    this.child.stderr.on("data", onChunk);
+  }
+
+  /** Wait until at least `count` build completions have been observed. */
+  public waitForBuilds(count: number, timeout = 120_000): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const finish = (): void => {
+        clearTimeout(timer);
+        this.listeners.delete(check);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        this.listeners.delete(check);
+        reject(
+          new Error(
+            `ttsc --watch did not reach ${count} builds:\n${this.output}`,
+          ),
+        );
+      }, timeout);
+      const check = (): void => {
+        if (this.builds >= count) finish();
+      };
+      this.listeners.add(check);
+      check();
+    });
+  }
+
+  /** Assert that no additional build lands during a deliberate idle period. */
+  public waitForQuiet(duration = 900): Promise<void> {
+    const initial = this.builds;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.listeners.delete(check);
+        resolve();
+      }, duration);
+      const check = (): void => {
+        if (this.builds === initial) return;
+        clearTimeout(timer);
+        this.listeners.delete(check);
+        reject(
+          new Error(
+            `ttsc --watch rebuilt during an idle period:\n${this.output}`,
+          ),
+        );
+      };
+      this.listeners.add(check);
+    });
+  }
+
+  /** Stop the child and fail if its persistent watcher handles do not drain. */
+  public async close(): Promise<void> {
+    if (this.child.exitCode !== null || this.child.signalCode !== null) {
+      this.assertNoUncaughtExit();
+      return;
+    }
+    const exited = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.child.kill("SIGKILL");
+        reject(new Error(`ttsc --watch did not exit:\n${this.output}`));
+      }, 30_000);
+      this.child.on("close", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      this.child.on("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+    });
+    this.child.kill("SIGTERM");
+    await exited;
+    this.assertNoUncaughtExit();
+  }
+
+  private assertNoUncaughtExit(): void {
+    assert.equal(
+      /Uncaught|UnhandledPromiseRejection/.test(this.output),
+      false,
+      `ttsc --watch must terminate without an uncaught error:\n${this.output}`,
+    );
+  }
+}

--- a/website/src/content/docs/setup/ttsc.mdx
+++ b/website/src/content/docs/setup/ttsc.mdx
@@ -30,7 +30,7 @@ npx ttsc --watch
 
 Re-compiles on save. Add `--preserveWatchOutput` to keep your scrollback.
 
-The watcher snapshots source directories at startup: a directory created later needs a restart, and `lib`, `dist`, `node_modules`, and `.git` are never watched.
+The watcher follows the compiler's resolved program inputs. New included folders and referenced config or declaration inputs join the session as the project changes, while compiler output and cache products do not trigger another build.
 
 ## CI
 

--- a/website/src/content/docs/ttsc/compile.mdx
+++ b/website/src/content/docs/ttsc/compile.mdx
@@ -27,7 +27,7 @@ npx ttsc --watch
 
 Re-compiles on save. Pass `--preserveWatchOutput` to keep your scrollback.
 
-The watch loop snapshots the source directories once at startup, so directories created after that are not picked up until you restart. Directories named `lib` or `dist` are skipped, along with `node_modules` and `.git`, so source roots under those names are not watched.
+The watcher follows TypeScript-Go's resolved program inputs instead of guessing from directory names. It reconciles the set after each build and when directory topology changes, so newly included folders, `extends` configs, project references, loaded declarations, and selected Go plugin sources join the running session. Compiler output and cache products are not inputs, so an emit-mode build stays quiet until a real input changes.
 
 ## Other day-to-day commands
 


### PR DESCRIPTION
## Intent

Close #817 by deriving `ttsc --watch` invalidation from the compiler's resolved input topology rather than one startup directory walk.

## Implementation

- Resolve TypeScript-Go program inputs with `--listFilesOnly`, then reconcile file and directory watchers after every build and topology event.
- Keep the resolved `extends` chain, recursive project references, loaded external sources, and selected Go plugin source trees in the running watch session.
- Exclude configured compiler output locations from topology discovery, so initial and later emits do not schedule another build.
- Replace literal `lib`/`dist` exclusions with compiler ownership, and update the two watch guides to describe the new contract.

## Regression coverage

- Dynamic included directories; existing and initially absent `outDir` quietness; authored `lib` and `dist` inputs; unrelated README quietness.
- External extended configs, loaded TypeScript dependencies, project references, and selected Go plugin source edits.
- Existing watch recovery, error, and shutdown cases remain in the same real-launcher suite.

## Verification

- `pnpm --filter ttsc build`
- `TTSC_TEST_DIR=features/compiler pnpm --filter @ttsc/test-ttsc start -- --include=watch_` (15 cases, including the Go plugin source case)
- `TTSC_TEST_DIR=features/project pnpm --filter @ttsc/test-ttsc start`: all exercised config/plugin cases passed; the symlink-only case is blocked locally by Windows `EPERM` symlink permission.
- A full compiler-feature run exercised all watch cases successfully; two existing consumer-local fake-`tsc.exe` cases remain blocked by Windows `spawnSync ... UNKNOWN` in the fixture executable path.

## Coordination

This is only the compiler DAG root. #855 and #852 remain unclaimed until this PR merges.

Closes #817
