### PR TITLE
fix(release): publish upgradeable host ranges

### DIFF
--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -23,7 +23,7 @@
     "typia": "catalog:samchon"
   },
   "peerDependencies": {
-    "ttsc": "workspace:*"
+    "ttsc": "workspace:^"
   },
   "keywords": [
     "ttsc",

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -38,7 +38,7 @@
     "src"
   ],
   "dependencies": {
-    "@ttsc/unplugin": "workspace:*"
+    "@ttsc/unplugin": "workspace:^"
   },
   "peerDependencies": {
     "@expo/metro-config": "*",

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -98,7 +98,7 @@
     "unplugin": "^2.3.11"
   },
   "peerDependencies": {
-    "ttsc": "workspace:*"
+    "ttsc": "workspace:^"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^29.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,7 +184,7 @@ importers:
         specifier: '*'
         version: 0.86.0(@babel/core@7.29.7)
       '@ttsc/unplugin':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../unplugin
       metro-react-native-babel-transformer:
         specifier: '*'

--- a/tests/test-graph/src/features/test_packaged_manifest_declares_upgradeable_ttsc_host.ts
+++ b/tests/test-graph/src/features/test_packaged_manifest_declares_upgradeable_ttsc_host.ts
@@ -77,7 +77,9 @@ function assertCompatibleCaretRange(range: string, dependency: string): void {
     match,
     `${dependency} must publish a caret range, received ${range}`,
   );
-  const [major, minor, patch] = match.slice(1).map(Number);
+  const major = Number(match[1]!);
+  const minor = Number(match[2]!);
+  const patch = Number(match[3]!);
   const lower: [number, number, number] = [major, minor, patch];
   const upper: [number, number, number] =
     major > 0
@@ -99,8 +101,5 @@ function compareVersions(
   left: [number, number, number],
   right: [number, number, number],
 ): number {
-  for (let index = 0; index < left.length; ++index) {
-    if (left[index] !== right[index]) return left[index] - right[index];
-  }
-  return 0;
+  return left[0] - right[0] || left[1] - right[1] || left[2] - right[2];
 }

--- a/tests/test-graph/src/features/test_packaged_manifest_declares_upgradeable_ttsc_host.ts
+++ b/tests/test-graph/src/features/test_packaged_manifest_declares_upgradeable_ttsc_host.ts
@@ -1,0 +1,103 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Verifies the published @ttsc/graph manifest permits compatible ttsc upgrades.
+ *
+ * The graph server runs inside the consumer's ttsc host, so an exact peer pin
+ * makes a normal independent patch upgrade fail npm's peer solver. Reading the
+ * packed manifest tests the release artifact, where pnpm expands the workspace
+ * protocol, rather than merely restating the source manifest spelling.
+ *
+ * 1. Pack @ttsc/graph and extract its published package manifest.
+ * 2. Assert the required ttsc peer is a concrete caret range that admits the next
+ *    compatible patch.
+ * 3. Assert the range rejects its next incompatible semver boundary and ttsc
+ *    remains external to the graph package.
+ */
+export const test_packaged_manifest_declares_upgradeable_ttsc_host = () => {
+  const manifest = readPackedManifest();
+  const peer = manifest.peerDependencies?.ttsc;
+  assert.ok(
+    typeof peer === "string",
+    "published graph manifest needs a ttsc peer",
+  );
+  assert.notEqual(
+    manifest.peerDependenciesMeta?.ttsc?.optional,
+    true,
+    "published graph ttsc peer must be required",
+  );
+  assert.equal(
+    manifest.dependencies?.ttsc,
+    undefined,
+    "published graph must not bundle a second ttsc runtime",
+  );
+  assertCompatibleCaretRange(peer, "ttsc");
+};
+
+function readPackedManifest(): Record<string, any> {
+  const packageDir = path.join(TestProject.WORKSPACE_ROOT, "packages", "graph");
+  const destination = TestProject.tmpdir("ttsc-graph-pack-");
+  const pack = spawnSync("pnpm", ["pack", "--pack-destination", destination], {
+    cwd: packageDir,
+    encoding: "utf8",
+    shell: process.platform === "win32",
+  });
+  assert.equal(pack.status, 0, `pnpm pack failed:\n${pack.stderr}`);
+
+  const tarball = fs
+    .readdirSync(destination)
+    .find((name) => name.endsWith(".tgz"));
+  assert.ok(tarball, "pnpm pack produced no graph tarball");
+  const manifest = spawnSync(
+    "tar",
+    ["-xzOf", tarball, "package/package.json"],
+    {
+      cwd: destination,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(
+    manifest.status,
+    0,
+    `tar extraction failed:\n${manifest.stderr}`,
+  );
+  return JSON.parse(manifest.stdout);
+}
+
+function assertCompatibleCaretRange(range: string, dependency: string): void {
+  const match = /^\^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(range);
+  assert.ok(
+    match,
+    `${dependency} must publish a caret range, received ${range}`,
+  );
+  const [major, minor, patch] = match.slice(1).map(Number);
+  const lower: [number, number, number] = [major, minor, patch];
+  const upper: [number, number, number] =
+    major > 0
+      ? [major + 1, 0, 0]
+      : minor > 0
+        ? [0, minor + 1, 0]
+        : [0, 0, patch + 1];
+  const accepts = (candidate: [number, number, number]): boolean =>
+    compareVersions(candidate, lower) >= 0 &&
+    compareVersions(candidate, upper) < 0;
+
+  if (minor > 0 || major > 0) {
+    assert.equal(accepts([major, minor, patch + 1]), true);
+  }
+  assert.equal(accepts(upper), false);
+}
+
+function compareVersions(
+  left: [number, number, number],
+  right: [number, number, number],
+): number {
+  for (let index = 0; index < left.length; ++index) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}

--- a/tests/test-graph/src/features/test_packaged_manifest_declares_upgradeable_ttsc_host.ts
+++ b/tests/test-graph/src/features/test_packaged_manifest_declares_upgradeable_ttsc_host.ts
@@ -14,7 +14,7 @@ import path from "node:path";
  *
  * 1. Pack @ttsc/graph and extract its published package manifest.
  * 2. Assert the required ttsc peer is a concrete caret range that admits the next
- *    compatible patch.
+ *    compatible patch, while an exact pin is rejected.
  * 3. Assert the range rejects its next incompatible semver boundary and ttsc
  *    remains external to the graph package.
  */
@@ -36,6 +36,11 @@ export const test_packaged_manifest_declares_upgradeable_ttsc_host = () => {
     "published graph must not bundle a second ttsc runtime",
   );
   assertCompatibleCaretRange(peer, "ttsc");
+  assert.throws(
+    () => assertCompatibleCaretRange(peer.slice(1), "ttsc"),
+    /caret range/,
+    "an exact ttsc pin must not satisfy the upgradeable-host contract",
+  );
 };
 
 function readPackedManifest(): Record<string, any> {

--- a/tests/test-graph/src/features/test_packaged_manifest_declares_upgradeable_ttsc_host.ts
+++ b/tests/test-graph/src/features/test_packaged_manifest_declares_upgradeable_ttsc_host.ts
@@ -69,7 +69,10 @@ function readPackedManifest(): Record<string, any> {
 }
 
 function assertCompatibleCaretRange(range: string, dependency: string): void {
-  const match = /^\^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(range);
+  const match =
+    /^\^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.exec(
+      range,
+    );
   assert.ok(
     match,
     `${dependency} must publish a caret range, received ${range}`,

--- a/tests/test-metro/src/features/build/test_packaged_manifest_declares_upgradeable_unplugin_dependency.ts
+++ b/tests/test-metro/src/features/build/test_packaged_manifest_declares_upgradeable_unplugin_dependency.ts
@@ -15,7 +15,7 @@ import path from "node:path";
  *
  * 1. Pack @ttsc/metro and extract its published package manifest.
  * 2. Assert @ttsc/unplugin is a concrete caret runtime dependency that admits the
- *    next compatible patch.
+ *    next compatible patch, while an exact pin is rejected.
  * 3. Assert that range rejects its next incompatible semver boundary.
  */
 export const test_packaged_manifest_declares_upgradeable_unplugin_dependency =
@@ -27,6 +27,11 @@ export const test_packaged_manifest_declares_upgradeable_unplugin_dependency =
       "published Metro manifest needs an @ttsc/unplugin runtime dependency",
     );
     assertCompatibleCaretRange(dependency, "@ttsc/unplugin");
+    assert.throws(
+      () => assertCompatibleCaretRange(dependency.slice(1), "@ttsc/unplugin"),
+      /caret range/,
+      "an exact @ttsc/unplugin pin must not satisfy the upgradeable dependency contract",
+    );
   };
 
 function readPackedManifest(): Record<string, any> {

--- a/tests/test-metro/src/features/build/test_packaged_manifest_declares_upgradeable_unplugin_dependency.ts
+++ b/tests/test-metro/src/features/build/test_packaged_manifest_declares_upgradeable_unplugin_dependency.ts
@@ -60,7 +60,10 @@ function readPackedManifest(): Record<string, any> {
 }
 
 function assertCompatibleCaretRange(range: string, dependency: string): void {
-  const match = /^\^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(range);
+  const match =
+    /^\^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.exec(
+      range,
+    );
   assert.ok(
     match,
     `${dependency} must publish a caret range, received ${range}`,

--- a/tests/test-metro/src/features/build/test_packaged_manifest_declares_upgradeable_unplugin_dependency.ts
+++ b/tests/test-metro/src/features/build/test_packaged_manifest_declares_upgradeable_unplugin_dependency.ts
@@ -68,7 +68,9 @@ function assertCompatibleCaretRange(range: string, dependency: string): void {
     match,
     `${dependency} must publish a caret range, received ${range}`,
   );
-  const [major, minor, patch] = match.slice(1).map(Number);
+  const major = Number(match[1]!);
+  const minor = Number(match[2]!);
+  const patch = Number(match[3]!);
   const lower: [number, number, number] = [major, minor, patch];
   const upper: [number, number, number] =
     major > 0
@@ -90,8 +92,5 @@ function compareVersions(
   left: [number, number, number],
   right: [number, number, number],
 ): number {
-  for (let index = 0; index < left.length; ++index) {
-    if (left[index] !== right[index]) return left[index] - right[index];
-  }
-  return 0;
+  return left[0] - right[0] || left[1] - right[1] || left[2] - right[2];
 }

--- a/tests/test-metro/src/features/build/test_packaged_manifest_declares_upgradeable_unplugin_dependency.ts
+++ b/tests/test-metro/src/features/build/test_packaged_manifest_declares_upgradeable_unplugin_dependency.ts
@@ -1,0 +1,94 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Verifies the published @ttsc/metro manifest permits compatible unplugin
+ * upgrades.
+ *
+ * Metro leaves @ttsc/unplugin external, so an exact published dependency forces
+ * every consumer to wait for a Metro republish before accepting an unplugin
+ * patch. The artifact manifest is the consumer contract because pnpm expands
+ * workspace protocols while packing.
+ *
+ * 1. Pack @ttsc/metro and extract its published package manifest.
+ * 2. Assert @ttsc/unplugin is a concrete caret runtime dependency that admits the
+ *    next compatible patch.
+ * 3. Assert that range rejects its next incompatible semver boundary.
+ */
+export const test_packaged_manifest_declares_upgradeable_unplugin_dependency =
+  () => {
+    const manifest = readPackedManifest();
+    const dependency = manifest.dependencies?.["@ttsc/unplugin"];
+    assert.ok(
+      typeof dependency === "string",
+      "published Metro manifest needs an @ttsc/unplugin runtime dependency",
+    );
+    assertCompatibleCaretRange(dependency, "@ttsc/unplugin");
+  };
+
+function readPackedManifest(): Record<string, any> {
+  const packageDir = path.join(TestProject.WORKSPACE_ROOT, "packages", "metro");
+  const destination = TestProject.tmpdir("ttsc-metro-pack-");
+  const pack = spawnSync("pnpm", ["pack", "--pack-destination", destination], {
+    cwd: packageDir,
+    encoding: "utf8",
+    shell: process.platform === "win32",
+  });
+  assert.equal(pack.status, 0, `pnpm pack failed:\n${pack.stderr}`);
+
+  const tarball = fs
+    .readdirSync(destination)
+    .find((name) => name.endsWith(".tgz"));
+  assert.ok(tarball, "pnpm pack produced no Metro tarball");
+  const manifest = spawnSync(
+    "tar",
+    ["-xzOf", tarball, "package/package.json"],
+    {
+      cwd: destination,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(
+    manifest.status,
+    0,
+    `tar extraction failed:\n${manifest.stderr}`,
+  );
+  return JSON.parse(manifest.stdout);
+}
+
+function assertCompatibleCaretRange(range: string, dependency: string): void {
+  const match = /^\^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(range);
+  assert.ok(
+    match,
+    `${dependency} must publish a caret range, received ${range}`,
+  );
+  const [major, minor, patch] = match.slice(1).map(Number);
+  const lower: [number, number, number] = [major, minor, patch];
+  const upper: [number, number, number] =
+    major > 0
+      ? [major + 1, 0, 0]
+      : minor > 0
+        ? [0, minor + 1, 0]
+        : [0, 0, patch + 1];
+  const accepts = (candidate: [number, number, number]): boolean =>
+    compareVersions(candidate, lower) >= 0 &&
+    compareVersions(candidate, upper) < 0;
+
+  if (minor > 0 || major > 0) {
+    assert.equal(accepts([major, minor, patch + 1]), true);
+  }
+  assert.equal(accepts(upper), false);
+}
+
+function compareVersions(
+  left: [number, number, number],
+  right: [number, number, number],
+): number {
+  for (let index = 0; index < left.length; ++index) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}

--- a/tests/test-ttsc/src/features/platform/test_packed_ttsc_manifest_keeps_platform_binaries_exact.ts
+++ b/tests/test-ttsc/src/features/platform/test_packed_ttsc_manifest_keeps_platform_binaries_exact.ts
@@ -1,0 +1,106 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Verifies the packed ttsc manifest keeps bundled platform binaries exact.
+ *
+ * Unlike an external host or adapter, each @ttsc platform package carries the
+ * native executable selected by the matching launcher release. A caret range
+ * could resolve a mismatched binary, so these seven edges deliberately remain
+ * exact while independently upgradeable package relationships use ranges.
+ *
+ * 1. Pack ttsc and extract its published package manifest.
+ * 2. Assert every platform optional dependency equals the packed ttsc version with
+ *    no range operator.
+ * 3. Assert the exact-version guard rejects a caret range for that version.
+ */
+export const test_packed_ttsc_manifest_keeps_platform_binaries_exact = () => {
+  const manifest = readPackedManifest();
+  assert.equal(
+    typeof manifest.version,
+    "string",
+    "packed ttsc needs a version",
+  );
+  for (const name of PLATFORM_PACKAGES) {
+    assertExactPlatformVersion(
+      manifest.optionalDependencies?.[name],
+      manifest.version,
+      name,
+    );
+  }
+  assert.throws(
+    () =>
+      assertExactPlatformVersion(
+        `^${manifest.version}`,
+        manifest.version,
+        "range",
+      ),
+    /exact version/,
+  );
+};
+
+const PLATFORM_PACKAGES = [
+  "@ttsc/linux-x64",
+  "@ttsc/linux-arm",
+  "@ttsc/linux-arm64",
+  "@ttsc/darwin-x64",
+  "@ttsc/darwin-arm64",
+  "@ttsc/win32-x64",
+  "@ttsc/win32-arm64",
+] as const;
+
+function readPackedManifest(): Record<string, any> {
+  const packageDir = path.join(TestProject.WORKSPACE_ROOT, "packages", "ttsc");
+  const destination = TestProject.tmpdir("ttsc-runtime-pack-");
+  const pack = spawnSync("pnpm", ["pack", "--pack-destination", destination], {
+    cwd: packageDir,
+    encoding: "utf8",
+    shell: process.platform === "win32",
+  });
+  assert.equal(pack.status, 0, `pnpm pack failed:\n${pack.stderr}`);
+
+  const tarball = fs
+    .readdirSync(destination)
+    .find((name) => name.endsWith(".tgz"));
+  assert.ok(tarball, "pnpm pack produced no ttsc tarball");
+  const manifest = spawnSync(
+    "tar",
+    ["-xzOf", tarball, "package/package.json"],
+    {
+      cwd: destination,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(
+    manifest.status,
+    0,
+    `tar extraction failed:\n${manifest.stderr}`,
+  );
+  return JSON.parse(manifest.stdout);
+}
+
+function assertExactPlatformVersion(
+  value: unknown,
+  version: string,
+  dependency: string,
+): void {
+  assert.equal(
+    typeof value,
+    "string",
+    `${dependency} must publish a platform binary version`,
+  );
+  const spec = value as string;
+  assert.match(
+    spec,
+    /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/,
+    `${dependency} must publish an exact version, not a range`,
+  );
+  assert.equal(
+    spec,
+    version,
+    `${dependency} must publish the exact matching platform binary version`,
+  );
+}

--- a/tests/test-ttsc/src/features/platform/test_packed_ttsc_manifest_keeps_platform_binaries_exact.ts
+++ b/tests/test-ttsc/src/features/platform/test_packed_ttsc_manifest_keeps_platform_binaries_exact.ts
@@ -95,7 +95,7 @@ function assertExactPlatformVersion(
   const spec = value as string;
   assert.match(
     spec,
-    /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/,
+    /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/,
     `${dependency} must publish an exact version, not a range`,
   );
   assert.equal(

--- a/tests/test-unplugin/src/features/adapters/test_packaged_manifest_declares_the_external_ttsc_host.ts
+++ b/tests/test-unplugin/src/features/adapters/test_packaged_manifest_declares_the_external_ttsc_host.ts
@@ -9,10 +9,10 @@ import { assertPackedManifestDeclaresTtscHost } from "../../internal/packaged-ho
  * module 'ttsc'`. The published dependency contract must represent the required
  * external host so a package manager can install, validate, or warn about it.
  *
- * 1. Pack the package as it would be published (rewriting `workspace:*` to a
- *    concrete version).
+ * 1. Pack the package as it would be published (rewriting `workspace:^` to a
+ *    concrete caret range).
  * 2. Assert the packed manifest declares `ttsc` as a required peer dependency with
- *    a concrete, resolvable version spec.
+ *    a concrete caret range that admits a compatible patch upgrade.
  * 3. Assert `ttsc` stays external — not a bundled runtime dependency copy.
  */
 export const test_packaged_manifest_declares_the_external_ttsc_host =

--- a/tests/test-unplugin/src/internal/packaged-host-contract.ts
+++ b/tests/test-unplugin/src/internal/packaged-host-contract.ts
@@ -74,6 +74,11 @@ async function assertPackedManifestDeclaresTtscHost(): Promise<void> {
     "workspace protocol leaked into the published ttsc spec",
   );
   assertCompatibleCaretRange(peer, "ttsc");
+  assert.throws(
+    () => assertCompatibleCaretRange(peer.slice(1), "ttsc"),
+    /caret range/,
+    "an exact ttsc pin must not satisfy the upgradeable-host contract",
+  );
   assert.notEqual(
     manifest.peerDependenciesMeta?.ttsc?.optional,
     true,

--- a/tests/test-unplugin/src/internal/packaged-host-contract.ts
+++ b/tests/test-unplugin/src/internal/packaged-host-contract.ts
@@ -72,6 +72,7 @@ async function assertPackedManifestDeclaresTtscHost(): Promise<void> {
     /^workspace:/,
     "workspace protocol leaked into the published ttsc spec",
   );
+  assertCompatibleCaretRange(peer, "ttsc");
   assert.notEqual(
     manifest.peerDependenciesMeta?.ttsc?.optional,
     true,
@@ -82,6 +83,48 @@ async function assertPackedManifestDeclaresTtscHost(): Promise<void> {
     undefined,
     "ttsc must stay external, not a bundled runtime dependency",
   );
+}
+
+function assertCompatibleCaretRange(range: string, dependency: string): void {
+  const match = /^\^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(range);
+  assert.ok(
+    match,
+    `${dependency} must publish a concrete caret range, received ${JSON.stringify(range)}`,
+  );
+  const [major, minor, patch] = match.slice(1).map(Number);
+  const lower: [number, number, number] = [major, minor, patch];
+  const upper: [number, number, number] =
+    major > 0
+      ? [major + 1, 0, 0]
+      : minor > 0
+        ? [0, minor + 1, 0]
+        : [0, 0, patch + 1];
+  const accepts = (candidate: [number, number, number]): boolean =>
+    compareVersions(candidate, lower) >= 0 &&
+    compareVersions(candidate, upper) < 0;
+
+  if (minor > 0 || major > 0) {
+    assert.equal(
+      accepts([major, minor, patch + 1]),
+      true,
+      `${dependency} must admit its next compatible patch`,
+    );
+  }
+  assert.equal(
+    accepts(upper),
+    false,
+    `${dependency} must reject its next incompatible boundary`,
+  );
+}
+
+function compareVersions(
+  left: [number, number, number],
+  right: [number, number, number],
+): number {
+  for (let index = 0; index < left.length; ++index) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
 }
 
 export { assertPackedManifestDeclaresTtscHost };

--- a/tests/test-unplugin/src/internal/packaged-host-contract.ts
+++ b/tests/test-unplugin/src/internal/packaged-host-contract.ts
@@ -86,7 +86,10 @@ async function assertPackedManifestDeclaresTtscHost(): Promise<void> {
 }
 
 function assertCompatibleCaretRange(range: string, dependency: string): void {
-  const match = /^\^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(range);
+  const match =
+    /^\^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.exec(
+      range,
+    );
   assert.ok(
     match,
     `${dependency} must publish a concrete caret range, received ${JSON.stringify(range)}`,

--- a/tests/test-unplugin/src/internal/packaged-host-contract.ts
+++ b/tests/test-unplugin/src/internal/packaged-host-contract.ts
@@ -8,8 +8,8 @@ import path from "node:path";
  * Pack `@ttsc/unplugin` exactly as it would be published and return the packed
  * `package.json`.
  *
- * `pnpm pack` is offline and deterministic, and it rewrites the `workspace:*`
- * protocol to the concrete version a real consumer's package manager sees — the
+ * `pnpm pack` is offline and deterministic, and it rewrites `workspace:^` to
+ * the concrete caret range a real consumer's package manager sees — the
  * published dependency contract. Reading that manifest (rather than the source
  * one) is what proves the contract a clean install would receive, without a
  * network install.
@@ -54,9 +54,10 @@ function readPackedManifest(): Record<string, any> {
  * validates, or warns about it — while staying external (never a bundled second
  * compiler copy).
  *
- * 1. Pack the package as it would be published (rewriting `workspace:*`).
- * 2. Assert `ttsc` is declared as a required peer dependency with a concrete
- *    version — no leaked `workspace:` protocol a consumer cannot resolve.
+ * 1. Pack the package as it would be published (rewriting `workspace:^`).
+ * 2. Assert `ttsc` is declared as a required peer dependency with a concrete caret
+ *    range — no leaked `workspace:` protocol or exact pin a consumer cannot
+ *    upgrade through.
  * 3. Assert `ttsc` is not also a bundled runtime `dependencies` entry.
  */
 async function assertPackedManifestDeclaresTtscHost(): Promise<void> {
@@ -94,7 +95,9 @@ function assertCompatibleCaretRange(range: string, dependency: string): void {
     match,
     `${dependency} must publish a concrete caret range, received ${JSON.stringify(range)}`,
   );
-  const [major, minor, patch] = match.slice(1).map(Number);
+  const major = Number(match[1]!);
+  const minor = Number(match[2]!);
+  const patch = Number(match[3]!);
   const lower: [number, number, number] = [major, minor, patch];
   const upper: [number, number, number] =
     major > 0
@@ -124,10 +127,7 @@ function compareVersions(
   left: [number, number, number],
   right: [number, number, number],
 ): number {
-  for (let index = 0; index < left.length; ++index) {
-    if (left[index] !== right[index]) return left[index] - right[index];
-  }
-  return 0;
+  return left[0] - right[0] || left[1] - right[1] || left[2] - right[2];
 }
 
 export { assertPackedManifestDeclaresTtscHost };


### PR DESCRIPTION
## Summary

Reserves the admitted #842 packaging-contract correction.

- change only the published runtime relationships in `@ttsc/unplugin`,
  `@ttsc/graph`, and `@ttsc/metro` from `workspace:*` to `workspace:^`;
- prove each owning package's packed tarball publishes the intended compatible
  range, including negative and boundary cases;
- keep the three packages' development-only `workspace:*` edges and ttsc's
  seven native-platform optional dependency pins exact.

## Excluded

No release, tag, publication, workflow change, lockstep-version change, or
typia workflow workaround removal is part of this pull request. The protected
Graph application contract remains byte-for-byte unchanged.

Closes #842.

## Verification

Pending. This is the implementation-free campaign reservation. Actions caused
by this branch are cancelled only by exact commit SHA; the merge gates will be
the package-owned packed-tarball suites, appropriate broader feature coverage,
and a fresh solo Self-Review.
