### PR TITLE
fix(factory): align expression kind coverage

### DIFF
--- a/packages/factory/src/TsPrinter.ts
+++ b/packages/factory/src/TsPrinter.ts
@@ -1739,9 +1739,20 @@ export class TsPrinter {
    * re-associate — matching the legacy printer's parenthesizer rules.
    */
   private parenthesizedExpression(expression: Expression): Doc {
-    return expression.kind === "ParenthesizedExpression"
+    return this.skipPartiallyEmittedExpressions(expression).kind ===
+      "ParenthesizedExpression"
       ? this.emit(expression)
       : concat(["(", this.emit(expression), ")"]);
+  }
+
+  /**
+   * The partial-emission wrapper carries transform provenance but emits no
+   * syntax of its own, so every grammar predicate must inspect its inner node.
+   */
+  private skipPartiallyEmittedExpressions(expression: Expression): Expression {
+    while (expression.kind === "PartiallyEmittedExpression")
+      expression = expression.expression;
+    return expression;
   }
 
   private expressionForDisallowedComma(
@@ -1792,6 +1803,7 @@ export class TsPrinter {
   }
 
   private isOptionalChain(expression: Expression): boolean {
+    expression = this.skipPartiallyEmittedExpressions(expression);
     switch (expression.kind) {
       case "CallChain":
       case "ElementAccessChain":
@@ -1850,6 +1862,7 @@ export class TsPrinter {
   private leftmostPrintedExpression(
     expression: Expression,
   ): Expression | undefined {
+    expression = this.skipPartiallyEmittedExpressions(expression);
     switch (expression.kind) {
       case "CallExpression":
       case "CallChain":
@@ -1966,43 +1979,53 @@ export class TsPrinter {
     isLeftSide: boolean,
     leftOperand?: Expression,
   ): boolean {
-    if (operand.kind === "ParenthesizedExpression") return false;
+    const emittedOperand: Expression = this.skipPartiallyEmittedExpressions(
+      operand,
+    );
+    if (emittedOperand.kind === "ParenthesizedExpression") return false;
     if (
       operator === SyntaxKind.AsteriskAsteriskToken &&
       isLeftSide &&
-      this.expressionPrecedence(operand) === ExpressionPrecedence.Unary
+      this.expressionPrecedence(emittedOperand) === ExpressionPrecedence.Unary
     )
       return true;
     if (
-      operand.kind === "BinaryExpression" &&
-      this.mixingBinaryOperatorsRequiresParentheses(operator, operand.operator)
+      emittedOperand.kind === "BinaryExpression" &&
+      this.mixingBinaryOperatorsRequiresParentheses(
+        operator,
+        emittedOperand.operator,
+      )
     )
       return true;
 
     const operatorPrecedence: ExpressionPrecedence =
       this.binaryOperatorPrecedence(operator);
     const operandPrecedence: ExpressionPrecedence =
-      this.expressionPrecedence(operand);
+      this.expressionPrecedence(emittedOperand);
     if (operandPrecedence < operatorPrecedence) return true;
     if (operandPrecedence > operatorPrecedence) return false;
 
     if (isLeftSide)
       return this.binaryOperatorAssociativity(operator) === Associativity.Right;
-    if (operand.kind === "BinaryExpression" && operand.operator === operator) {
+    if (
+      emittedOperand.kind === "BinaryExpression" &&
+      emittedOperand.operator === operator
+    ) {
       if (this.operatorHasAssociativeProperty(operator)) return false;
       if (
         operator === SyntaxKind.PlusToken &&
         leftOperand !== undefined &&
         this.literalKindOfBinaryPlusOperand(leftOperand) !== undefined &&
         this.literalKindOfBinaryPlusOperand(leftOperand) ===
-          this.literalKindOfBinaryPlusOperand(operand)
+          this.literalKindOfBinaryPlusOperand(emittedOperand)
       )
         return false;
     }
-    return this.expressionAssociativity(operand) === Associativity.Left;
+    return this.expressionAssociativity(emittedOperand) === Associativity.Left;
   }
 
   private expressionPrecedence(expression: Expression): ExpressionPrecedence {
+    expression = this.skipPartiallyEmittedExpressions(expression);
     switch (expression.kind) {
       case "CommaListExpression":
         return ExpressionPrecedence.Comma;
@@ -2045,6 +2068,7 @@ export class TsPrinter {
   }
 
   private expressionAssociativity(expression: Expression): Associativity {
+    expression = this.skipPartiallyEmittedExpressions(expression);
     switch (expression.kind) {
       case "NewExpression":
         return expression.arguments === undefined
@@ -2162,6 +2186,7 @@ export class TsPrinter {
   private literalKindOfBinaryPlusOperand(
     expression: Expression,
   ): string | undefined {
+    expression = this.skipPartiallyEmittedExpressions(expression);
     switch (expression.kind) {
       case "StringLiteral":
       case "NumericLiteral":
@@ -2187,6 +2212,7 @@ export class TsPrinter {
   }
 
   private isLeftHandSideExpression(expression: Expression): boolean {
+    expression = this.skipPartiallyEmittedExpressions(expression);
     switch (expression.kind) {
       case "ArrowFunction":
       case "ClassExpression":
@@ -2243,6 +2269,7 @@ export class TsPrinter {
    * {@link leftmostPrintedExpression}.
    */
   private leftmostExpression(expression: Expression): Expression {
+    expression = this.skipPartiallyEmittedExpressions(expression);
     switch (expression.kind) {
       case "AsExpression":
       case "CallExpression":
@@ -2270,6 +2297,7 @@ export class TsPrinter {
     operator: SyntaxKind | undefined,
     operand: Expression,
   ): boolean {
+    operand = this.skipPartiallyEmittedExpressions(operand);
     if (operator === undefined || operand.kind !== "PrefixUnaryExpression")
       return false;
     return (

--- a/packages/factory/src/ast/expressions/Expression.ts
+++ b/packages/factory/src/ast/expressions/Expression.ts
@@ -24,6 +24,7 @@ import type { NumericLiteral } from "./NumericLiteral";
 import type { ObjectLiteralExpression } from "./ObjectLiteralExpression";
 import type { OmittedExpression } from "./OmittedExpression";
 import type { ParenthesizedExpression } from "./ParenthesizedExpression";
+import type { PartiallyEmittedExpression } from "./PartiallyEmittedExpression";
 import type { PostfixUnaryExpression } from "./PostfixUnaryExpression";
 import type { PrefixUnaryExpression } from "./PrefixUnaryExpression";
 import type { PropertyAccessChain } from "./PropertyAccessChain";
@@ -38,6 +39,9 @@ import type { TypeAssertion } from "./TypeAssertion";
 import type { TypeOfExpression } from "./TypeOfExpression";
 import type { VoidExpression } from "./VoidExpression";
 import type { YieldExpression } from "./YieldExpression";
+import type { JsxElement } from "../jsx/JsxElement";
+import type { JsxFragment } from "../jsx/JsxFragment";
+import type { JsxSelfClosingElement } from "../jsx/JsxSelfClosingElement";
 
 /**
  * Any expression node.
@@ -61,6 +65,9 @@ export type Expression =
   | ElementAccessExpression
   | FunctionExpression
   | Identifier
+  | JsxElement
+  | JsxFragment
+  | JsxSelfClosingElement
   | MetaProperty
   | NewExpression
   | NoSubstitutionTemplateLiteral
@@ -70,6 +77,7 @@ export type Expression =
   | ObjectLiteralExpression
   | OmittedExpression
   | ParenthesizedExpression
+  | PartiallyEmittedExpression
   | PostfixUnaryExpression
   | PrefixUnaryExpression
   | PropertyAccessChain

--- a/tests/test-factory/src/features/parity/test_expression_union_coverage.ts
+++ b/tests/test-factory/src/features/parity/test_expression_union_coverage.ts
@@ -152,6 +152,23 @@ export const test_expression_union_coverage = (): void => {
       ),
     ],
     [
+      "nested partial comma sequence keeps binary precedence",
+      f.createExpressionStatement(
+        f.createAdd(
+          partial(partial(f.createCommaListExpression([id("a"), id("b")]))),
+          id("c"),
+        ),
+      ),
+      l.createExpressionStatement(
+        l.createAdd(
+          legacyPartial(
+            legacyPartial(l.createCommaListExpression([lid("a"), lid("b")])),
+          ),
+          lid("c"),
+        ),
+      ),
+    ],
+    [
       "partial object literal keeps expression-statement parentheses",
       f.createExpressionStatement(partial(f.createObjectLiteralExpression([]))),
       l.createExpressionStatement(

--- a/tests/test-factory/src/features/parity/test_expression_union_coverage.ts
+++ b/tests/test-factory/src/features/parity/test_expression_union_coverage.ts
@@ -1,0 +1,186 @@
+import { TestValidator } from "@nestia/e2e";
+import factory, { type Expression, type Node, SyntaxKind } from "@ttsc/factory";
+import ts from "ts-legacy";
+
+import { assertOracle, wide } from "../../internal/oracle";
+
+const f = factory;
+const l = ts.factory;
+const id = (text: string) => f.createIdentifier(text);
+const lid = (text: string) => l.createIdentifier(text);
+const qd = () => f.createToken(SyntaxKind.QuestionDotToken);
+const lqd = () => l.createToken(ts.SyntaxKind.QuestionDotToken);
+
+const jsxElement = (): Expression =>
+  f.createJsxElement(
+    f.createJsxOpeningElement(id("Item"), undefined, f.createJsxAttributes([])),
+    [],
+    f.createJsxClosingElement(id("Item")),
+  );
+const legacyJsxElement = (): ts.Expression =>
+  l.createJsxElement(
+    l.createJsxOpeningElement(lid("Item"), undefined, l.createJsxAttributes([])),
+    [],
+    l.createJsxClosingElement(lid("Item")),
+  );
+const jsxSelfClosingElement = (): Expression =>
+  f.createJsxSelfClosingElement(id("Item"), undefined, f.createJsxAttributes([]));
+const legacyJsxSelfClosingElement = (): ts.Expression =>
+  l.createJsxSelfClosingElement(
+    lid("Item"),
+    undefined,
+    l.createJsxAttributes([]),
+  );
+const jsxFragment = (): Expression =>
+  f.createJsxFragment(
+    f.createJsxOpeningFragment(),
+    [],
+    f.createJsxJsxClosingFragment(),
+  );
+const legacyJsxFragment = (): ts.Expression =>
+  l.createJsxFragment(
+    l.createJsxOpeningFragment(),
+    [],
+    l.createJsxJsxClosingFragment(),
+  );
+const partial = (expression: Expression): Expression =>
+  f.createPartiallyEmittedExpression(expression);
+const legacyPartial = (expression: ts.Expression): ts.Expression =>
+  l.createPartiallyEmittedExpression(expression);
+
+/**
+ * Verifies expression union coverage: printable JSX and partial wrappers reach every parenthesizer predicate.
+ *
+ * `PartiallyEmittedExpression` prints only its inner expression, so treating the wrapper as a primary expression loses parentheses around comma sequences, optional chains, objects, functions, and call-based `new` targets. The public union must also admit every JSX expression form the printer has always rendered. Each expected program comes from the pinned legacy factory and printer, never from this printer's own output.
+ *
+ * 1. Pass each newly admitted expression through `createExpressionStatement` and compare JSX output with the legacy printer in TSX mode.
+ * 2. Place partial wrappers in left-side, precedence, statement, and new-target contexts, then compare parsed structures with the legacy oracle.
+ */
+export const test_expression_union_coverage = (): void => {
+  const expressions: readonly Expression[] = [
+    jsxElement(),
+    jsxSelfClosingElement(),
+    jsxFragment(),
+    partial(id("value")),
+  ];
+  const statements: readonly Node[] = expressions.map((expression) =>
+    f.createExpressionStatement(expression),
+  );
+  TestValidator.equals(
+    "every newly admitted kind reaches createExpressionStatement",
+    statements.map((statement) => statement.kind),
+    [
+      "ExpressionStatement",
+      "ExpressionStatement",
+      "ExpressionStatement",
+      "ExpressionStatement",
+    ],
+  );
+
+  for (const [title, expression, oracle] of [
+    ["JSX element", jsxElement(), legacyJsxElement()],
+    [
+      "JSX self-closing element",
+      jsxSelfClosingElement(),
+      legacyJsxSelfClosingElement(),
+    ],
+    ["JSX fragment", jsxFragment(), legacyJsxFragment()],
+  ] as const)
+    assertOracle(
+      title,
+      wide.print(f.createExpressionStatement(expression)),
+      l.createExpressionStatement(oracle),
+      ts.ScriptKind.TSX,
+    );
+
+  const optional = (): Expression =>
+    f.createPropertyAccessChain(id("a"), qd(), "b");
+  const legacyOptional = (): ts.Expression =>
+    l.createPropertyAccessChain(lid("a"), lqd(), lid("b"));
+  const emptyFunction = (): Expression =>
+    f.createFunctionExpression(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      [],
+      undefined,
+      f.createBlock([], true),
+    );
+  const legacyEmptyFunction = (): ts.Expression =>
+    l.createFunctionExpression(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      [],
+      undefined,
+      l.createBlock([], true),
+    );
+  const rows: readonly [string, Node, ts.Node][] = [
+    [
+      "partial identifier is a left-side expression",
+      f.createExpressionStatement(
+        f.createCallExpression(partial(id("callee")), undefined, []),
+      ),
+      l.createExpressionStatement(
+        l.createCallExpression(legacyPartial(lid("callee")), undefined, []),
+      ),
+    ],
+    [
+      "partial optional chain keeps the call outside the chain",
+      f.createExpressionStatement(
+        f.createCallExpression(partial(optional()), undefined, []),
+      ),
+      l.createExpressionStatement(
+        l.createCallExpression(legacyPartial(legacyOptional()), undefined, []),
+      ),
+    ],
+    [
+      "partial comma sequence keeps binary precedence",
+      f.createExpressionStatement(
+        f.createAdd(
+          partial(f.createCommaListExpression([id("a"), id("b")])),
+          id("c"),
+        ),
+      ),
+      l.createExpressionStatement(
+        l.createAdd(
+          legacyPartial(l.createCommaListExpression([lid("a"), lid("b")])),
+          lid("c"),
+        ),
+      ),
+    ],
+    [
+      "partial object literal keeps expression-statement parentheses",
+      f.createExpressionStatement(partial(f.createObjectLiteralExpression([]))),
+      l.createExpressionStatement(
+        legacyPartial(l.createObjectLiteralExpression([])),
+      ),
+    ],
+    [
+      "partial function keeps expression-statement parentheses",
+      f.createExpressionStatement(partial(emptyFunction())),
+      l.createExpressionStatement(legacyPartial(legacyEmptyFunction())),
+    ],
+    [
+      "partial call remains visible to new-target leftmost traversal",
+      f.createExpressionStatement(
+        f.createNewExpression(
+          partial(f.createCallExpression(id("Factory"), undefined, [])),
+          undefined,
+          [],
+        ),
+      ),
+      l.createExpressionStatement(
+        l.createNewExpression(
+          legacyPartial(l.createCallExpression(lid("Factory"), undefined, [])),
+          undefined,
+          [],
+        ),
+      ),
+    ],
+  ];
+  for (const [title, node, oracle] of rows)
+    assertOracle(title, wide.print(node), oracle);
+};

--- a/tests/test-factory/src/features/parity/test_parenthesizer_oracle_differential.ts
+++ b/tests/test-factory/src/features/parity/test_parenthesizer_oracle_differential.ts
@@ -79,6 +79,11 @@ const operands: Operand[] = [
     legacy: () => lid("a"),
   },
   {
+    name: "partially emitted identifier",
+    ttsc: () => f.createPartiallyEmittedExpression(id("a")),
+    legacy: () => l.createPartiallyEmittedExpression(lid("a")),
+  },
+  {
     name: "logical or",
     ttsc: () => f.createBinaryExpression(id("X"), SyntaxKind.BarBarToken, id("Y")),
     legacy: () =>
@@ -472,6 +477,7 @@ const requiredProductions: readonly string[] = [
   "CallExpression",
   "NewExpression",
   "NonNullExpression",
+  "PartiallyEmittedExpression",
   "TaggedTemplateExpression",
   "PostfixUnaryExpression",
   "Decorator",


### PR DESCRIPTION
## Summary

Reserves the implementation surface for #864: align `@ttsc/factory`'s public `Expression` union and expression parenthesizer with the printable TypeScript legacy AST kinds.

## Scope

- Include `PartiallyEmittedExpression` and all printable JSX expression forms in the public union.
- Verify transparent partially emitted wrappers and JSX expressions against the pinned `ts-legacy` printer.
- Extend the existing factory kind-coverage regression checks.
- Excludes #834's maintainer-gated signature and compatibility decisions.

## Verification

Pending implementation. Planned gates are `pnpm --filter @ttsc/test-factory start` and `pnpm test:features`.

## Campaign CI

This is an issue-campaign implementation PR. Actions runs triggered by this branch are cancelled per exact commit SHA; local verification and solo self-review are the merge gates.
