### PR TITLE
fix(ttsx): preserve prefix-only builtin URLs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,13 @@ jobs:
               scope: test-ttsc,
             }
           - {
+              name: "ttsx node 22.15",
+              node: "22.15.0",
+              build: "pnpm --filter ttsc build",
+              run: "pnpm --filter @ttsc/test-ttsc start -- --include=commonjs_loads_prefix_only_node_builtins",
+              dir: features/ttsx-runtime,
+            }
+          - {
               name: "ttsc native corpus-source",
               run: "pnpm --filter @ttsc/test-ttsc start",
               dir: native-plugins/corpus-source,
@@ -203,7 +210,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24.x
+          node-version: ${{ matrix.node || '24.x' }}
 
       - uses: actions/setup-go@v5
         with:

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -1,6 +1,11 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
-import { Module, registerHooks, stripTypeScriptTypes } from "node:module";
+import {
+  Module,
+  isBuiltin,
+  registerHooks,
+  stripTypeScriptTypes,
+} from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -294,7 +299,10 @@ function resolve(
 ): ResolveResult {
   try {
     return rememberCommonJsNamedInterop(
-      nextResolve(specifier, context),
+      restoreStrippedNodeBuiltinScheme(
+        specifier,
+        nextResolve(specifier, context),
+      ),
       context,
     );
   } catch (error) {
@@ -307,6 +315,26 @@ function resolve(
       context,
     );
   }
+}
+
+/**
+ * Restore a `node:` builtin URL when affected Node releases return the exact
+ * prefix-stripped spelling from their synchronous CommonJS resolver.
+ *
+ * Every other result passes through unchanged. In particular, a user hook that
+ * intentionally remaps a `node:` specifier to another URL retains ownership of
+ * that mapping, while ordinary and ESM builtin results already carrying the
+ * scheme avoid an unnecessary copy.
+ */
+export function restoreStrippedNodeBuiltinScheme(
+  specifier: string,
+  result: ResolveResult,
+): ResolveResult {
+  return isBuiltin(specifier) &&
+    specifier.startsWith("node:") &&
+    result.url === specifier.slice("node:".length)
+    ? { ...result, url: specifier }
+    : result;
 }
 
 /** Cache of built projects keyed by owning tsconfig path. */

--- a/packages/wasm/test/host/fountain_position_tokens_test.go
+++ b/packages/wasm/test/host/fountain_position_tokens_test.go
@@ -36,8 +36,10 @@ type fountainSymbol struct {
 // offsets, position errors, and release lifecycle errors.
 func TestFountainPositionVerbsResolveTouchingTokens(t *testing.T) {
 	api := startFountainAPI(t)
-	root := fmt.Sprintf("/fountain-position-%d", time.Now().UnixNano())
-	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	root := os.Getenv("TTSC_WASM_TEST_ROOT")
+	if root == "" || !filepath.IsAbs(root) {
+		t.Fatalf("TTSC_WASM_TEST_ROOT must be an absolute wasm path, got %q", root)
+	}
 	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/scripts/go-wasm-exec.cjs
+++ b/scripts/go-wasm-exec.cjs
@@ -21,6 +21,7 @@ const keep = new Set([
   "PATHEXT",
   "SystemRoot",
   "TEMP",
+  "TTSC_WASM_TEST_ROOT",
   "TMP",
   "USERPROFILE",
 ]);
@@ -28,5 +29,9 @@ for (const key of Object.keys(process.env)) {
   if (!keep.has(key)) delete process.env[key];
 }
 
-process.argv = [process.argv[0], path.resolve(wasmExec), ...process.argv.slice(3)];
+process.argv = [
+  process.argv[0],
+  path.resolve(wasmExec),
+  ...process.argv.slice(3),
+];
 require(process.argv[1]);

--- a/scripts/test-go-wasm.cjs
+++ b/scripts/test-go-wasm.cjs
@@ -11,13 +11,19 @@ const ttscDir = path.join(root, "packages", "ttsc");
 const wasmDir = path.join(root, "packages", "wasm");
 const wasmExecRunner = path.join(__dirname, "go-wasm-exec.cjs");
 const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-wasm-go-work-"));
+let fixtureRoot;
 
 try {
+  const fixtureParent = path.join(root, "node_modules", ".cache");
+  fs.mkdirSync(fixtureParent, { recursive: true });
+  fixtureRoot = fs.mkdtempSync(path.join(fixtureParent, "ttsc-wasm-fixture-"));
   const goWork = path.join(workdir, "go.work");
   writeGoWork(goWork);
-  const goroot = cp.execFileSync("go", ["env", "GOROOT"], {
-    encoding: "utf8",
-  }).trim();
+  const goroot = cp
+    .execFileSync("go", ["env", "GOROOT"], {
+      encoding: "utf8",
+    })
+    .trim();
   const wasmExec = path.join(goroot, "lib", "wasm", "wasm_exec_node.js");
   const result = cp.spawnSync(
     "go",
@@ -35,6 +41,7 @@ try {
         GOOS: "js",
         GOARCH: "wasm",
         GOWORK: goWork,
+        TTSC_WASM_TEST_ROOT: toWasmAbsolutePath(fixtureRoot),
         PATH: fs.existsSync(goRoot)
           ? `${goRoot}${path.delimiter}${process.env.PATH ?? ""}`
           : process.env.PATH,
@@ -44,9 +51,21 @@ try {
     },
   );
   if (result.error) throw result.error;
-  if (result.status !== 0) process.exit(result.status ?? 1);
+  if (result.status !== 0) process.exitCode = result.status ?? 1;
 } finally {
+  if (fixtureRoot !== undefined) {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
   fs.rmSync(workdir, { recursive: true, force: true });
+}
+
+function toWasmAbsolutePath(location) {
+  const normalized = location.split(path.sep).join("/");
+  if (process.platform !== "win32") return normalized;
+  if (!/^[A-Za-z]:\//.test(normalized)) {
+    throw new Error(`unsupported Windows wasm test path: ${location}`);
+  }
+  return normalized.slice(2);
 }
 
 function writeGoWork(location) {

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_restore_stripped_node_builtin_scheme_normalizes_only_exact_core_builtins.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_restore_stripped_node_builtin_scheme_normalizes_only_exact_core_builtins.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+
+import { restoreStrippedNodeBuiltinScheme } from "../../../../../packages/ttsc/lib/launcher/internal/runtimeHooks.js";
+
+/**
+ * Verifies builtin URL normalization owns only Node's exact resolver defect.
+ *
+ * The compatibility helper must copy a result only for a real core builtin
+ * whose URL is its exact prefix-stripped spelling. All already-correct,
+ * remapped, near-boundary, and non-builtin results retain both their values and
+ * object identities.
+ *
+ * 1. Normalize every known prefix-only builtin with extra resolve metadata.
+ * 2. Exercise ordinary, ESM-shaped, custom, near-boundary, and non-core cases.
+ * 3. Assert exact copies preserve metadata and every passthrough stays identical.
+ */
+export const test_restore_stripped_node_builtin_scheme_normalizes_only_exact_core_builtins =
+  () => {
+    for (const specifier of [
+      "node:sqlite",
+      "node:test",
+      "node:test/reporters",
+      "node:sea",
+    ]) {
+      const result = {
+        format: "builtin",
+        shortCircuit: false,
+        url: specifier.slice("node:".length),
+      };
+      const normalized = restoreStrippedNodeBuiltinScheme(specifier, result);
+      assert.notStrictEqual(normalized, result);
+      assert.deepEqual(normalized, {
+        format: "builtin",
+        shortCircuit: false,
+        url: specifier,
+      });
+    }
+
+    for (const [specifier, result] of [
+      ["node:crypto", { format: "builtin", url: "node:crypto" }],
+      ["node:sqlite", { format: "builtin", url: "node:sqlite" }],
+      ["node:sqlite", { shortCircuit: true, url: "ttsx-custom:sqlite" }],
+      ["node:sqlite", { shortCircuit: true, url: "sqlite?custom" }],
+      ["node:custom", { format: "commonjs", url: "custom" }],
+      ["virtual:sqlite", { format: "commonjs", url: "sqlite" }],
+    ] as const) {
+      assert.strictEqual(
+        restoreStrippedNodeBuiltinScheme(specifier, result),
+        result,
+      );
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_commonjs_keeps_ordinary_node_builtin_resolution.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_commonjs_keeps_ordinary_node_builtin_resolution.ts
@@ -1,0 +1,32 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies the ttsx compatibility path leaves ordinary Node builtins alone.
+ *
+ * Ordinary builtins such as `node:crypto` already retain their scheme in the
+ * affected Node resolver. The prefix-only correction must not replace or
+ * otherwise perturb this successful CommonJS resolution path.
+ *
+ * 1. Create a CommonJS entry that requires `node:crypto`.
+ * 2. Run the entry through the real ttsx launcher.
+ * 3. Assert the native builtin API executes successfully.
+ */
+export const test_ttsx_commonjs_keeps_ordinary_node_builtin_resolution = () => {
+  const root = TestProject.commonJsProject({
+    "src/main.ts": `
+      declare function require(specifier: "node:crypto"): {
+        randomUUID(): string;
+      };
+      console.log(require("node:crypto").randomUUID().length);
+    `,
+  });
+
+  const result = TestProject.spawn(
+    TestProject.TTSX_BIN,
+    ["--cwd", root, "src/main.ts"],
+    { cwd: root },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "36");
+};

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_commonjs_loads_prefix_only_node_builtins.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_commonjs_loads_prefix_only_node_builtins.ts
@@ -1,0 +1,37 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx preserves prefix-only Node builtin URLs in CommonJS graphs.
+ *
+ * Node 22.15 through 22.17 can strip the `node:` scheme from the synchronous
+ * resolve result for prefix-only builtins. Returning that stripped result from
+ * the ttsx hook makes Node reject the builtins' otherwise valid null source
+ * before the entry can execute.
+ *
+ * 1. Create a CommonJS entry that requires every prefix-only builtin family.
+ * 2. Run the entry through the real ttsx launcher on the current Node runtime.
+ * 3. Assert every builtin loads and the entry reaches its success marker.
+ */
+export const test_ttsx_commonjs_loads_prefix_only_node_builtins = () => {
+  const root = TestProject.commonJsProject({
+    "src/main.ts": `
+      declare function require(specifier: string): unknown;
+      const builtins = [
+        "node:sqlite",
+        "node:test",
+        "node:test/reporters",
+        "node:sea",
+      ].map((specifier) => require(specifier));
+      console.log(builtins.every((value) => value !== null && value !== undefined));
+    `,
+  });
+
+  const result = TestProject.spawn(
+    TestProject.TTSX_BIN,
+    ["--cwd", root, "src/main.ts"],
+    { cwd: root },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "true");
+};

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_esm_keeps_prefix_only_node_builtin_imports.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_esm_keeps_prefix_only_node_builtin_imports.ts
@@ -1,0 +1,49 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies the CommonJS compatibility correction leaves ESM builtins intact.
+ *
+ * ESM imports of `node:sqlite` already resolve successfully on affected Node
+ * releases. The ttsx resolve hook must preserve that native ESM path while it
+ * corrects only the stripped CommonJS result.
+ *
+ * 1. Create an ESM project whose entry imports and uses `node:sqlite`.
+ * 2. Run the entry through the real ttsx launcher.
+ * 3. Assert the database opens, closes, and reaches the success marker.
+ */
+export const test_ttsx_esm_keeps_prefix_only_node_builtin_imports = () => {
+  const root = TestProject.createProject({
+    "package.json": JSON.stringify({ type: "module" }),
+    "tsconfig.json": TestProject.tsconfig({
+      target: "ES2022",
+      module: "ES2022",
+      moduleResolution: "bundler",
+      strict: true,
+      outDir: "dist",
+      rootDir: "src",
+    }),
+    "src/node-sqlite.d.ts": `
+      declare module "node:sqlite" {
+        export class DatabaseSync {
+          constructor(location: string);
+          close(): void;
+        }
+      }
+    `,
+    "src/main.ts": `
+      import { DatabaseSync } from "node:sqlite";
+      const database = new DatabaseSync(":memory:");
+      database.close();
+      console.log("esm-sqlite-ok");
+    `,
+  });
+
+  const result = TestProject.spawn(
+    TestProject.TTSX_BIN,
+    ["--cwd", root, "src/main.ts"],
+    { cwd: root },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "esm-sqlite-ok");
+};

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_preserves_custom_node_builtin_remaps.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_preserves_custom_node_builtin_remaps.ts
@@ -1,0 +1,74 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+/**
+ * Verifies ttsx preserves custom remaps outside the exact stripped boundary.
+ *
+ * A user hook may intentionally map a builtin to another URL or use a
+ * `node:`-shaped specifier outside Node's builtin set. The compatibility
+ * correction owns only Node's exact prefix-stripping defect, so both custom
+ * results must pass through.
+ *
+ * 1. Remap `node:sqlite` to a custom URL and `node:custom` to exact `custom`.
+ * 2. Run a CommonJS entry that requires both remapped specifiers through ttsx.
+ * 3. Assert both custom modules load instead of being rewritten by ttsx.
+ */
+export const test_ttsx_preserves_custom_node_builtin_remaps = () => {
+  const root = TestProject.commonJsProject({
+    "custom-hook.cjs": `
+      const { registerHooks } = require("node:module");
+      const url = "ttsx-custom:sqlite-boundary";
+      registerHooks({
+        resolve(specifier, context, nextResolve) {
+          if (specifier === "node:sqlite") {
+            return { format: "commonjs", shortCircuit: true, url };
+          }
+          if (specifier === "node:custom") {
+            return { format: "commonjs", shortCircuit: true, url: "custom" };
+          }
+          return nextResolve(specifier, context);
+        },
+        load(candidate, context, nextLoad) {
+          if (candidate === url) {
+            return {
+              format: "commonjs",
+              shortCircuit: true,
+              source: 'module.exports = { source: "custom-remap" };',
+            };
+          }
+          if (candidate === "custom") {
+            return {
+              format: "commonjs",
+              shortCircuit: true,
+              source: 'module.exports = { source: "non-builtin-exact-strip" };',
+            };
+          }
+          return nextLoad(candidate, context);
+        },
+      });
+    `,
+    "src/main.ts": `
+      declare function require(specifier: "node:sqlite" | "node:custom"): {
+        source: string;
+      };
+      console.log([
+        require("node:sqlite").source,
+        require("node:custom").source,
+      ].join(","));
+    `,
+  });
+
+  const result = TestProject.spawn(
+    TestProject.TTSX_BIN,
+    ["--cwd", root, "src/main.ts"],
+    {
+      cwd: root,
+      env: {
+        NODE_OPTIONS: `--require ${JSON.stringify(path.join(root, "custom-hook.cjs"))}`,
+      },
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "custom-remap,non-builtin-exact-strip");
+};

--- a/tests/test-ttsc/src/internal/watch.ts
+++ b/tests/test-ttsc/src/internal/watch.ts
@@ -14,7 +14,7 @@ export class WatchSession {
   private output = "";
 
   public constructor(root: string, options: { env?: NodeJS.ProcessEnv } = {}) {
-    this.child = child_process.spawn(
+    const child = child_process.spawn(
       process.execPath,
       [ttscBin, "--watch", "--cwd", root],
       {
@@ -29,6 +29,12 @@ export class WatchSession {
         windowsHide: true,
       },
     );
+    const { stderr, stdout } = child;
+    if (stdout === null || stderr === null) {
+      child.kill();
+      throw new Error("ttsc --watch must expose piped stdout and stderr");
+    }
+    this.child = child;
     const onChunk = (chunk: Buffer): void => {
       this.output += chunk.toString("utf8");
       this.builds = (
@@ -36,8 +42,8 @@ export class WatchSession {
       ).length;
       for (const listener of this.listeners) listener();
     };
-    this.child.stdout.on("data", onChunk);
-    this.child.stderr.on("data", onChunk);
+    stdout.on("data", onChunk);
+    stderr.on("data", onChunk);
   }
 
   /** Wait until at least `count` build completions have been observed. */

--- a/website/src/content/docs/ttsc/execute.mdx
+++ b/website/src/content/docs/ttsc/execute.mdx
@@ -32,6 +32,8 @@ The type-check covers your whole program, but at runtime your dependencies are l
 
 These hooks are runtime-only and never weaken the compile gate: the up-front tsgo build still deep-checks the whole program, imported workspace neighbours included, so a type error in a dependency's source fails the run before anything executes. A genuinely missing module still throws `ERR_MODULE_NOT_FOUND`. This makes `ttsx` strictly stronger than `tsx`: a full type-check plus the same runtime reach.
 
+On supported Node releases whose CommonJS resolver strips the `node:` scheme from prefix-only builtins such as `node:sqlite`, `ttsx` restores only that exact native result before loading it. Ordinary builtins, ESM imports, and custom module-hook remaps keep their original resolution.
+
 When an ESM entry imports named bindings from a CommonJS-classified source package, `ttsx` also exposes names re-exported through nested `export *` barrels. Node's CommonJS interop can miss those names because TypeScript-Go lowers them through dynamic helper calls, so the runtime hook makes the emitted CommonJS names visible without changing the package's CommonJS `require` path.
 
 ## Source maps, stack traces, and coverage


### PR DESCRIPTION
## Summary

- restore the `node:` scheme only when Node's synchronous resolver returns the exact prefix-stripped URL for an actual core builtin
- preserve all other resolver results, including their metadata and object identity, while leaving builtin `load` results and valid null sources unchanged
- cover prefix-only CommonJS builtins, ordinary builtins, ESM imports, custom remaps, and non-builtin `node:` specifiers with real `ttsx` runs and a pure helper matrix
- run the failing CommonJS regression on Node.js 22.15.0 in CI and document the compatibility behavior

## Cause

Affected Node.js releases pass a prefix-only builtin such as `node:sqlite` to synchronous resolve hooks but return `sqlite` from `nextResolve()` on the CommonJS path. Returning that stripped URL prevents the following load result from being recognized as a builtin, so Node rejects its otherwise valid null source with `ERR_INVALID_RETURN_PROPERTY_VALUE`.

The correction is deliberately narrower than a general `node:` rewrite. It requires `module.isBuiltin(specifier)` and an exact prefix-stripped result, so user hook remaps and non-core `node:`-shaped specifiers remain untouched.

## Validation

- reproduced the pre-fix failure with the real `ttsx` launcher on Node.js 22.15.0
- focused helper and real `ttsx` regressions pass on Node.js 22.15.0
- `pnpm run build:current`
- `pnpm run test:typecheck`
- `pnpm run check:flags`
- `node --test packages/ttsc/scripts/check-flags.test.cjs`
- `pnpm --filter @ttsc/website build`
- `pnpm format`

The full local `features/ttsx-runtime` run passed the changed surface and all but two pre-existing Windows environment cases. One cannot spawn a copied temporary `tsc.exe` on this machine (`spawnSync ... UNKNOWN`), and one requires symlink permission (`EPERM`). Ordinary CI remains the acceptance gate for those platform-independent lanes.

## Integration chronology

- rebased the implementation onto `origin/master` at `a8288d649d62eb941ac0638b58bb5fb1b7b30abd`
- verified head `b119af085d36fba87fa740e094432c8143e605e9` with `pnpm install`, `pnpm --filter ttsc build`, and all five focused regressions on Node.js 22.15.0
- confirmed the branch is exactly one commit ahead of that master with a clean eight-file diff
- rerunning the repository-wide typecheck after the rebase reaches a pre-existing failure introduced on current master in `test_compiler_client_fences_connection_generations.ts`: its `ICompilerService`-typed driver is asserted through a test-only `connectorId`. The #880 files do not touch playground code; the earlier full typecheck passed before that upstream refresh.

Closes #880
