### PR TITLE
fix(wasm,website): key Go build caches by effective inputs

### DIFF
--- a/packages/wasm/build/build-wasm.cjs
+++ b/packages/wasm/build/build-wasm.cjs
@@ -2,23 +2,15 @@
 //
 // Usage: node build/build-wasm.cjs [--force]
 //
-// Behavior:
-//   * Skips the Go build when `dist/ttsc.wasm` is newer than every .go file
-//     under `packages/{ttsc,wasm}/`. Pass `--force` or set
-//     `TTSC_WASM_FORCE=1` to rebuild unconditionally.
-//   * Hard failure if the Go toolchain is missing.
-//
-// Outputs:
-//   * packages/wasm/dist/ttsc.wasm
-//   * packages/wasm/dist/wasm_exec.js
-//
-// Downstream consumers (the website, plugin-author playgrounds) point their
-// own bundle pipelines at `node_modules/@ttsc/wasm/dist/wasm_exec.js` and
-// build their own .wasm against the same Go module.
+// The cache records a content identity for every effective Go dependency,
+// module manifest, build flag, toolchain bridge, and published shim artifact.
+// It never accepts a partially staged publication directory as a cache hit.
 
 const cp = require("child_process");
 const fs = require("fs");
 const path = require("path");
+
+const { createGoBuildCache } = require("../../../scripts/go-build-cache.cjs");
 
 const packageRoot = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(packageRoot, "..", "..");
@@ -31,96 +23,60 @@ const wasmOut = path.join(outDir, "ttsc.wasm");
 const wasmExecOut = path.join(outDir, "wasm_exec.js");
 const goModPath = path.join(packageRoot, "go.mod");
 const publishedGoModOut = path.join(outDir, "go.mod");
-const forceRebuild =
-  process.argv.includes("--force") || !!process.env.TTSC_WASM_FORCE;
-
-fs.mkdirSync(outDir, { recursive: true });
-
-function hasGoToolchain() {
-  try {
-    cp.execSync("go env GOROOT", { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
+const cachePath = path.join(outDir, ".ttsc-wasm-build.json");
+const buildArguments = [
+  "go",
+  "build",
+  "-trimpath",
+  "-ldflags",
+  "-s -w",
+  "-o",
+  wasmOut,
+  "./cmd/ttsc-wasm",
+];
+const buildEnvironment = { GOOS: "js", GOARCH: "wasm" };
 
 function locateWasmExec() {
-  if (!hasGoToolchain()) return null;
-  const goroot =
-    process.env.GOROOT ??
-    cp.execSync("go env GOROOT", { encoding: "utf8" }).trim();
+  let goroot;
+  try {
+    goroot =
+      process.env.GOROOT ??
+      cp.execFileSync("go", ["env", "GOROOT"], { encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
   // Go 1.24+ ships wasm_exec.js under lib/wasm/. Older releases kept it
   // under misc/wasm/. Try both so the build works across Go installs.
-  const candidates = [
+  for (const candidate of [
     path.join(goroot, "lib", "wasm", "wasm_exec.js"),
     path.join(goroot, "misc", "wasm", "wasm_exec.js"),
-  ];
-  for (const candidate of candidates) {
+  ]) {
     if (fs.existsSync(candidate)) return candidate;
   }
   return null;
 }
 
-function newestMtime(...roots) {
-  let max = 0;
-  for (const root of roots) {
-    if (!root || !fs.existsSync(root)) continue;
-    walk(root, (_file, stat) => {
-      if (stat.mtimeMs > max) max = stat.mtimeMs;
-    });
-  }
-  return max;
-}
-
-function walk(root, visit) {
-  const stack = [root];
-  while (stack.length) {
-    const cur = stack.pop();
-    let stat;
-    try {
-      stat = fs.statSync(cur);
-    } catch {
-      continue;
-    }
-    if (stat.isDirectory()) {
-      const base = path.basename(cur);
-      if (
-        base === "node_modules" ||
-        base === ".ttsc" ||
-        base === ".git" ||
-        base === "lib" ||
-        base === "dist"
-      )
-        continue;
-      for (const entry of fs.readdirSync(cur)) {
-        stack.push(path.join(cur, entry));
-      }
-    } else if (stat.isFile() && cur.endsWith(".go")) {
-      visit(cur, stat);
-    }
-  }
+function createCacheOptions({ force, wasmExecSrc }) {
+  return {
+    artifactPaths: [wasmOut, wasmExecOut, publishedGoModOut, vendorShimDir],
+    buildArguments,
+    cachePath,
+    cwd: packageRoot,
+    dependencyPackages: ["./cmd/ttsc-wasm"],
+    environment: buildEnvironment,
+    extraFiles: [__filename, goModPath, wasmExecSrc],
+    force,
+    inputDirectories: [shimSrc],
+  };
 }
 
 function buildWasm() {
   console.log(`build/build-wasm.cjs: building ${wasmOut}`);
-  cp.execFileSync(
-    "go",
-    [
-      "build",
-      "-trimpath",
-      "-ldflags",
-      "-s -w",
-      "-o",
-      wasmOut,
-      "./cmd/ttsc-wasm",
-    ],
-    {
-      cwd: packageRoot,
-      env: { ...process.env, GOOS: "js", GOARCH: "wasm" },
-      stdio: "inherit",
-    },
-  );
+  cp.execFileSync("go", buildArguments.slice(1), {
+    cwd: packageRoot,
+    env: { ...process.env, ...buildEnvironment },
+    stdio: "inherit",
+  });
 }
 
 // Mirror packages/ttsc/shim/* into packages/wasm/shim-vendor/shim/* so the
@@ -141,7 +97,7 @@ function vendorShim() {
   fs.mkdirSync(vendorShimDir, { recursive: true });
   copyTree(shimSrc, vendorShimDir);
   console.log(
-    `build/build-wasm.cjs: vendored shim/* → ${path.relative(packageRoot, vendorShimDir)}`,
+    `build/build-wasm.cjs: vendored shim/* -> ${path.relative(packageRoot, vendorShimDir)}`,
   );
 }
 
@@ -159,18 +115,14 @@ function copyTree(src, dst) {
   }
 }
 
-// Rewrite go.mod so the published copy points at ./shim-vendor/shim/* instead of
-// ../ttsc/shim/*. The `replace github.com/samchon/ttsc/packages/ttsc => ...`
-// line is dropped: consumers of the published tarball who want to compile
-// their own wasm binary must supply that module themselves (documented in
-// README.md). The working-tree go.mod is untouched.
+// Rewrite go.mod so the published copy points at ./shim-vendor/shim/* instead
+// of ../ttsc/shim/*. The ../ttsc consumer-module replacement is intentionally
+// removed: consumers compiling their own wasm binary supply it themselves.
 function rewritePublishedGoMod() {
-  const src = fs.readFileSync(goModPath, "utf8");
-  const lines = src.split(/\r?\n/);
+  const lines = fs.readFileSync(goModPath, "utf8").split(/\r?\n/);
   const out = [];
   for (const line of lines) {
     const trimmed = line.trim();
-    // Drop the ../ttsc consumer-module replace (handled at consumer side).
     if (
       /^github\.com\/samchon\/ttsc\/packages\/ttsc\s+=>\s+\.\.\/ttsc\b/.test(
         trimmed,
@@ -178,63 +130,63 @@ function rewritePublishedGoMod() {
     ) {
       continue;
     }
-    // Rewrite each shim replace from ../ttsc/shim/X to ./shim-vendor/shim/X.
     const shimMatch = trimmed.match(
       /^(github\.com\/microsoft\/typescript-go\/shim\/[A-Za-z0-9_/]+)\s+=>\s+\.\.\/ttsc\/shim\/([A-Za-z0-9_/]+)$/,
     );
     if (shimMatch) {
       const indent = line.match(/^\s*/)[0];
-      out.push(`${indent}${shimMatch[1]} => ./shim-vendor/shim/${shimMatch[2]}`);
+      out.push(
+        `${indent}${shimMatch[1]} => ./shim-vendor/shim/${shimMatch[2]}`,
+      );
       continue;
     }
     out.push(line);
   }
   fs.writeFileSync(publishedGoModOut, out.join("\n"));
   console.log(
-    `build/build-wasm.cjs: emitted published go.mod → ${path.relative(packageRoot, publishedGoModOut)}`,
+    `build/build-wasm.cjs: emitted published go.mod -> ${path.relative(packageRoot, publishedGoModOut)}`,
   );
 }
 
-const wasmExecSrc = locateWasmExec();
-
-if (!forceRebuild && fs.existsSync(wasmOut)) {
-  const wasmMtime = fs.statSync(wasmOut).mtimeMs;
-  const sourceMtime = newestMtime(packageRoot, ttscDir);
-  if (sourceMtime > 0 && wasmMtime >= sourceMtime) {
+function main() {
+  fs.mkdirSync(outDir, { recursive: true });
+  const wasmExecSrc = locateWasmExec();
+  if (!wasmExecSrc) {
+    throw new Error(
+      "build/build-wasm.cjs: wasm_exec.js not located. Install Go 1.24+.",
+    );
+  }
+  const cache = createGoBuildCache(
+    createCacheOptions({
+      force: process.argv.includes("--force") || !!process.env.TTSC_WASM_FORCE,
+      wasmExecSrc,
+    }),
+  );
+  if (cache.isCurrent()) {
     console.log(
       `build/build-wasm.cjs: cached ttsc.wasm is up to date (${(
         fs.statSync(wasmOut).size /
         1024 /
         1024
-      ).toFixed(2)} MiB) — skipping rebuild`,
+      ).toFixed(2)} MiB) -> skipping rebuild`,
     );
-    if (wasmExecSrc && !fs.existsSync(wasmExecOut)) {
-      fs.copyFileSync(wasmExecSrc, wasmExecOut);
-    }
-    // Even on cache hit, refresh the vendored shim + published go.mod so
-    // `pnpm pack` always sees up-to-date publish artifacts.
-    vendorShim();
-    rewritePublishedGoMod();
     return;
   }
-}
 
-if (!wasmExecSrc) {
-  console.error(
-    "build/build-wasm.cjs: wasm_exec.js not located. Install Go 1.24+.",
+  vendorShim();
+  rewritePublishedGoMod();
+  buildWasm();
+  fs.copyFileSync(wasmExecSrc, wasmExecOut);
+  cache.write();
+  console.log(
+    `build/build-wasm.cjs: done. ttsc.wasm = ${(
+      fs.statSync(wasmOut).size /
+      1024 /
+      1024
+    ).toFixed(2)} MiB`,
   );
-  process.exit(1);
 }
 
-vendorShim();
-rewritePublishedGoMod();
-buildWasm();
-fs.copyFileSync(wasmExecSrc, wasmExecOut);
+if (require.main === module) main();
 
-console.log(
-  `build/build-wasm.cjs: done. ttsc.wasm = ${(
-    fs.statSync(wasmOut).size /
-    1024 /
-    1024
-  ).toFixed(2)} MiB`,
-);
+module.exports = { createCacheOptions, locateWasmExec };

--- a/scripts/go-build-cache-builders.test.cjs
+++ b/scripts/go-build-cache-builders.test.cjs
@@ -1,0 +1,31 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const {
+  createCacheOptions: createWasmCacheOptions,
+} = require("../packages/wasm/build/build-wasm.cjs");
+const {
+  createCacheOptions: createWebsiteCacheOptions,
+} = require("../website/build/compiler.cjs");
+
+test("WASM builders share the Go input identity contract", () => {
+  const bridge = path.resolve("fixture-wasm_exec.js");
+  const typiaRoot = path.resolve("fixture-typia");
+  const wasm = createWasmCacheOptions({ force: false, wasmExecSrc: bridge });
+  const website = createWebsiteCacheOptions({
+    force: false,
+    typiaGraph: { typiaRoot },
+  });
+
+  assert.deepEqual(wasm.environment, { GOOS: "js", GOARCH: "wasm" });
+  assert.deepEqual(website.environment, wasm.environment);
+  assert.deepEqual(wasm.dependencyPackages, ["./cmd/ttsc-wasm"]);
+  assert.deepEqual(website.dependencyPackages, ["./cmd/playground"]);
+  assert.ok(wasm.extraFiles.includes(bridge));
+  assert.ok(
+    wasm.inputDirectories.some((entry) => path.basename(entry) === "shim"),
+  );
+  assert.ok(website.extraFiles.includes(path.join(typiaRoot, "package.json")));
+  assert.ok(website.extraFiles.some((entry) => entry.endsWith("wasm_exec.js")));
+});

--- a/scripts/go-build-cache.cjs
+++ b/scripts/go-build-cache.cjs
@@ -94,6 +94,8 @@ function createInputIdentity({
       "GOARCH",
       "GOFLAGS",
       "GOEXPERIMENT",
+      "GOTOOLCHAIN",
+      "GOWASM",
       "CGO_ENABLED",
       "GOWORK",
     ]),

--- a/scripts/go-build-cache.cjs
+++ b/scripts/go-build-cache.cjs
@@ -89,6 +89,7 @@ function createInputIdentity({
       "env",
       "-json",
       "GOVERSION",
+      "GOROOT",
       "GOOS",
       "GOARCH",
       "GOFLAGS",
@@ -97,6 +98,7 @@ function createInputIdentity({
       "GOWORK",
     ]),
   );
+  addToolchainBinaryIdentity(toolchain);
   const files = new Set([path.resolve(__filename)]);
 
   for (const pkg of packages) {
@@ -138,6 +140,25 @@ function createInputIdentity({
     hash: digest(stableJson(payload)),
     payload,
   };
+}
+
+function addToolchainBinaryIdentity(toolchain) {
+  const goroot = toolchain.GOROOT;
+  delete toolchain.GOROOT;
+  if (!goroot) return;
+  const executable = path.join(
+    goroot,
+    "bin",
+    process.platform === "win32" ? "go.exe" : "go",
+  );
+  try {
+    toolchain.goBinarySha256 = fileDigest(executable);
+  } catch {
+    // `go env` supplied a toolchain root, but the compiler binary vanished
+    // before its identity could be read. Keep the miss deterministic instead
+    // of reusing an artifact built by an unknown compiler.
+    toolchain.goBinarySha256 = null;
+  }
 }
 
 function parseJsonStream(source) {

--- a/scripts/go-build-cache.cjs
+++ b/scripts/go-build-cache.cjs
@@ -95,6 +95,7 @@ function createInputIdentity({
       "GOFLAGS",
       "GOEXPERIMENT",
       "GOTOOLCHAIN",
+      "GOTOOLDIR",
       "GOWASM",
       "CGO_ENABLED",
       "GOWORK",
@@ -147,7 +148,9 @@ function createInputIdentity({
 
 function addToolchainBinaryIdentity(toolchain) {
   const goroot = toolchain.GOROOT;
+  const goToolDir = toolchain.GOTOOLDIR;
   delete toolchain.GOROOT;
+  delete toolchain.GOTOOLDIR;
   if (!goroot) return;
   const executable = path.join(
     goroot,
@@ -162,6 +165,29 @@ function addToolchainBinaryIdentity(toolchain) {
     // of reusing an artifact built by an unknown compiler.
     toolchain.goBinarySha256 = null;
   }
+  if (!goToolDir) return;
+  try {
+    toolchain.goToolDirectorySha256 = directoryDigest(goToolDir);
+  } catch {
+    // The compiler driver may still be present when an incomplete toolchain
+    // loses its compile/link programs. Treat that transition as a cache miss.
+    toolchain.goToolDirectorySha256 = null;
+  }
+}
+
+function directoryDigest(directory) {
+  const files = new Set();
+  addDirectory(files, directory);
+  return digest(
+    stableJson(
+      [...files]
+        .sort()
+        .map((file) => ({
+          path: path.relative(directory, file).replaceAll(path.sep, "/"),
+          sha256: fileDigest(file),
+        })),
+    ),
+  );
 }
 
 function parseJsonStream(source) {

--- a/scripts/go-build-cache.cjs
+++ b/scripts/go-build-cache.cjs
@@ -119,6 +119,7 @@ function createInputIdentity({
   }
   if (toolchain.GOWORK && toolchain.GOWORK !== "off") {
     addIfFile(files, toolchain.GOWORK);
+    addIfFile(files, path.join(path.dirname(toolchain.GOWORK), "go.work.sum"));
   }
   for (const file of extraFiles) files.add(path.resolve(file));
   for (const directory of inputDirectories) addDirectory(files, directory);

--- a/scripts/go-build-cache.cjs
+++ b/scripts/go-build-cache.cjs
@@ -1,0 +1,277 @@
+const cp = require("node:child_process");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const SOURCE_FIELDS = [
+  "GoFiles",
+  "CgoFiles",
+  "CFiles",
+  "CXXFiles",
+  "MFiles",
+  "HFiles",
+  "FFiles",
+  "SFiles",
+  "SysoFiles",
+  "EmbedFiles",
+];
+
+function createGoBuildCache({
+  artifactPaths,
+  buildArguments,
+  cachePath,
+  cwd,
+  dependencyPackages,
+  environment,
+  extraFiles = [],
+  force = false,
+  inputDirectories = [],
+  execFileSync = cp.execFileSync,
+}) {
+  const identity = createInputIdentity({
+    buildArguments,
+    cwd,
+    dependencyPackages,
+    environment,
+    extraFiles,
+    inputDirectories,
+    execFileSync,
+  });
+
+  return {
+    identity,
+    isCurrent() {
+      if (force) return false;
+      const record = readRecord(cachePath);
+      if (record?.identity !== identity.hash) return false;
+      try {
+        return (
+          stableJson(record.artifacts) ===
+          stableJson(snapshotPaths(artifactPaths))
+        );
+      } catch {
+        return false;
+      }
+    },
+    write() {
+      const record = {
+        schema: 1,
+        identity: identity.hash,
+        artifacts: snapshotPaths(artifactPaths),
+      };
+      writeAtomically(cachePath, `${JSON.stringify(record, null, 2)}\n`);
+    },
+  };
+}
+
+function createInputIdentity({
+  buildArguments,
+  cwd,
+  dependencyPackages,
+  environment,
+  extraFiles,
+  inputDirectories,
+  execFileSync,
+}) {
+  const runGo = (args) =>
+    execFileSync("go", args, {
+      cwd,
+      encoding: "utf8",
+      env: { ...process.env, ...environment },
+      windowsHide: true,
+    });
+  const packages = parseJsonStream(
+    runGo(["list", "-deps", "-json", ...dependencyPackages]),
+  );
+  const modules = parseJsonStream(runGo(["list", "-m", "-json", "all"]));
+  const toolchain = JSON.parse(
+    runGo([
+      "env",
+      "-json",
+      "GOVERSION",
+      "GOOS",
+      "GOARCH",
+      "GOFLAGS",
+      "GOEXPERIMENT",
+      "CGO_ENABLED",
+      "GOWORK",
+    ]),
+  );
+  const files = new Set([path.resolve(__filename)]);
+
+  for (const pkg of packages) {
+    if (!pkg.Dir) continue;
+    for (const field of SOURCE_FIELDS) {
+      for (const file of pkg[field] ?? []) {
+        files.add(path.join(pkg.Dir, file));
+      }
+    }
+    if (pkg.Module?.GoMod) addIfFile(files, pkg.Module.GoMod);
+  }
+  for (const mod of modules) {
+    if (!mod.GoMod) continue;
+    addIfFile(files, mod.GoMod);
+    addIfFile(files, path.join(path.dirname(mod.GoMod), "go.sum"));
+  }
+  if (toolchain.GOWORK && toolchain.GOWORK !== "off") {
+    addIfFile(files, toolchain.GOWORK);
+  }
+  for (const file of extraFiles) files.add(path.resolve(file));
+  for (const directory of inputDirectories) addDirectory(files, directory);
+
+  const inputs = [...files]
+    .sort((a, b) =>
+      normalizedPath(a, cwd).localeCompare(normalizedPath(b, cwd)),
+    )
+    .map((file) => ({
+      path: normalizedPath(file, cwd),
+      sha256: fileDigest(file),
+    }));
+  const payload = {
+    schema: 1,
+    buildArguments,
+    environment,
+    toolchain,
+    inputs,
+  };
+  return {
+    hash: digest(stableJson(payload)),
+    payload,
+  };
+}
+
+function parseJsonStream(source) {
+  const records = [];
+  let start = 0;
+  while (start < source.length) {
+    while (/\s/.test(source[start] ?? "")) start += 1;
+    if (start >= source.length) break;
+    if (source[start] !== "{") {
+      throw new Error("go command returned a non-JSON record");
+    }
+    let depth = 0;
+    let quoted = false;
+    let escaped = false;
+    let end = start;
+    for (; end < source.length; end += 1) {
+      const character = source[end];
+      if (quoted) {
+        if (escaped) escaped = false;
+        else if (character === "\\") escaped = true;
+        else if (character === '"') quoted = false;
+        continue;
+      }
+      if (character === '"') quoted = true;
+      else if (character === "{") depth += 1;
+      else if (character === "}") {
+        depth -= 1;
+        if (depth === 0) break;
+      }
+    }
+    if (depth !== 0) throw new Error("go command returned incomplete JSON");
+    records.push(JSON.parse(source.slice(start, end + 1)));
+    start = end + 1;
+  }
+  return records;
+}
+
+function snapshotPaths(paths) {
+  return paths.map((entry) => snapshotPath(entry));
+}
+
+function snapshotPath(entry) {
+  const target = path.resolve(entry);
+  let stat;
+  try {
+    stat = fs.statSync(target);
+  } catch {
+    throw new Error(`cache artifact is missing: ${target}`);
+  }
+  if (stat.isFile())
+    return { path: target, type: "file", sha256: fileDigest(target) };
+  if (!stat.isDirectory())
+    throw new Error(`cache artifact is not a file or directory: ${target}`);
+  const files = new Set();
+  addDirectory(files, target);
+  return {
+    path: target,
+    type: "directory",
+    files: [...files].sort().map((file) => ({
+      path: path.relative(target, file),
+      sha256: fileDigest(file),
+    })),
+  };
+}
+
+function addDirectory(files, directory) {
+  const root = path.resolve(directory);
+  let stat;
+  try {
+    stat = fs.statSync(root);
+  } catch {
+    throw new Error(`cache input directory is missing: ${root}`);
+  }
+  if (!stat.isDirectory())
+    throw new Error(`cache input is not a directory: ${root}`);
+  const stack = [root];
+  while (stack.length) {
+    const current = stack.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const file = path.join(current, entry.name);
+      if (entry.isDirectory()) stack.push(file);
+      else if (entry.isFile()) files.add(file);
+    }
+  }
+}
+
+function addIfFile(files, file) {
+  try {
+    if (fs.statSync(file).isFile()) files.add(file);
+  } catch {
+    // A module can be in the graph without a colocated go.sum. Its go.mod is
+    // still tracked; absent optional sums must not make every cache lookup fail.
+  }
+}
+
+function readRecord(cachePath) {
+  try {
+    const record = JSON.parse(fs.readFileSync(cachePath, "utf8"));
+    return record?.schema === 1 ? record : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeAtomically(destination, content) {
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  const temporary = `${destination}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(temporary, content);
+  fs.rmSync(destination, { force: true });
+  fs.renameSync(temporary, destination);
+}
+
+function normalizedPath(file, cwd) {
+  const relative = path.relative(cwd, file);
+  return (relative.startsWith("..") ? path.resolve(file) : relative).replaceAll(
+    path.sep,
+    "/",
+  );
+}
+
+function fileDigest(file) {
+  return digest(fs.readFileSync(file));
+}
+
+function digest(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function stableJson(value) {
+  return JSON.stringify(value);
+}
+
+module.exports = {
+  createGoBuildCache,
+  createInputIdentity,
+  parseJsonStream,
+};

--- a/scripts/go-build-cache.test.cjs
+++ b/scripts/go-build-cache.test.cjs
@@ -36,8 +36,23 @@ test("Go build cache keys every effective input and rejects corrupt state", () =
     );
     invalidates(fixture.goSum, "example.test/dependency v1.0.1 h1:changed\n");
     invalidates(fixture.goWork, "go 1.26\n\nuse ./other-module\n");
+    invalidates(
+      fixture.dependencySource,
+      "package dependency\nfunc Version() int { return 2 }\n",
+    );
     invalidates(fixture.bridge, "new wasm bridge\n");
     invalidates(fixture.shimSource, "package shim\nconst Version = 2\n");
+    record();
+    fs.writeFileSync(
+      fixture.shimOutput,
+      "package shim\nconst Version = stale\n",
+    );
+    assert.equal(current().isCurrent(), false);
+    fs.writeFileSync(
+      fixture.shimOutput,
+      "package shim\nconst Version = 1\n",
+    );
+    invalidates(fixture.goBinary, "go compiler v2\n");
 
     record();
     assert.equal(
@@ -54,9 +69,11 @@ test("Go build cache keys every effective input and rejects corrupt state", () =
       current({
         execFileSync: fakeGo({
           command: fixture.command,
+          dependency: fixture.dependency,
           goMod: fixture.goMod,
           goVersion: "go1.26.5",
           goWork: fixture.goWork,
+          goroot: fixture.goroot,
         }),
       }).isCurrent(),
       false,
@@ -80,33 +97,46 @@ function createFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-go-build-cache-"));
   const module = path.join(root, "module");
   const command = path.join(module, "cmd", "example");
+  const dependency = path.join(module, "dependency");
   const output = path.join(root, "out");
   const shimSourceRoot = path.join(root, "shim-source");
   const shimOutputRoot = path.join(output, "shim");
+  const goroot = path.join(root, "go");
   fs.mkdirSync(command, { recursive: true });
+  fs.mkdirSync(dependency, { recursive: true });
   fs.mkdirSync(shimSourceRoot, { recursive: true });
   fs.mkdirSync(shimOutputRoot, { recursive: true });
+  fs.mkdirSync(path.join(goroot, "bin"), { recursive: true });
 
   const goMod = path.join(module, "go.mod");
   const goSum = path.join(module, "go.sum");
   const goWork = path.join(root, "go.work");
   const goSource = path.join(command, "main.go");
+  const dependencySource = path.join(dependency, "dependency.go");
   const embed = path.join(command, "schema.json");
   const bridge = path.join(root, "wasm_exec.js");
   const wasm = path.join(output, "example.wasm");
   const shimSource = path.join(shimSourceRoot, "shim.go");
+  const shimOutput = path.join(shimOutputRoot, "shim.go");
+  const goBinary = path.join(
+    goroot,
+    "bin",
+    process.platform === "win32" ? "go.exe" : "go",
+  );
   fs.writeFileSync(goMod, "module example.test/cache\ngo 1.26\n");
   fs.writeFileSync(goSum, "example.test/dependency v1.0.0 h1:original\n");
   fs.writeFileSync(goWork, "go 1.26\n\nuse ./module\n");
   fs.writeFileSync(goSource, "package main\nfunc main() { println(1) }\n");
+  fs.writeFileSync(
+    dependencySource,
+    "package dependency\nfunc Version() int { return 1 }\n",
+  );
   fs.writeFileSync(embed, '{"schema":1}\n');
   fs.writeFileSync(bridge, "wasm bridge\n");
   fs.writeFileSync(wasm, "wasm artifact\n");
   fs.writeFileSync(shimSource, "package shim\nconst Version = 1\n");
-  fs.writeFileSync(
-    path.join(shimOutputRoot, "shim.go"),
-    "package shim\nconst Version = 1\n",
-  );
+  fs.writeFileSync(shimOutput, "package shim\nconst Version = 1\n");
+  fs.writeFileSync(goBinary, "go compiler v1\n");
 
   const options = {
     artifactPaths: [wasm, bridge, shimOutputRoot],
@@ -117,30 +147,46 @@ function createFixture() {
     environment: { GOOS: "js", GOARCH: "wasm" },
     extraFiles: [bridge],
     inputDirectories: [shimSourceRoot],
-    execFileSync: fakeGo({ command, goMod, goWork }),
+    execFileSync: fakeGo({ command, dependency, goMod, goWork, goroot }),
   };
   return {
     root,
     options,
     bridge,
     command,
+    dependency,
+    dependencySource,
     embed,
+    goBinary,
     goMod,
     goSource,
     goSum,
     goWork,
+    goroot,
     shimSource,
+    shimOutput,
     wasm,
   };
 }
 
-function fakeGo({ command, goMod, goVersion = "go1.26.4", goWork }) {
+function fakeGo({
+  command,
+  dependency,
+  goMod,
+  goVersion = "go1.26.4",
+  goWork,
+  goroot,
+}) {
   return (_command, args) => {
     if (args[0] === "list" && args[1] === "-deps") {
       return `${JSON.stringify({
         Dir: command,
         GoFiles: ["main.go"],
         EmbedFiles: ["schema.json"],
+        Module: { GoMod: goMod },
+      })}\n${JSON.stringify({
+        Dir: dependency,
+        GoFiles: ["dependency.go"],
         Module: { GoMod: goMod },
       })}\n`;
     }
@@ -150,6 +196,7 @@ function fakeGo({ command, goMod, goVersion = "go1.26.4", goWork }) {
     if (args[0] === "env") {
       return JSON.stringify({
         GOVERSION: goVersion,
+        GOROOT: goroot,
         GOOS: "js",
         GOARCH: "wasm",
         GOFLAGS: "",

--- a/scripts/go-build-cache.test.cjs
+++ b/scripts/go-build-cache.test.cjs
@@ -71,6 +71,19 @@ test("Go build cache keys every effective input and rejects corrupt state", () =
           command: fixture.command,
           dependency: fixture.dependency,
           goMod: fixture.goMod,
+          goWasm: "satconv",
+          goWork: fixture.goWork,
+          goroot: fixture.goroot,
+        }),
+      }).isCurrent(),
+      false,
+    );
+    assert.equal(
+      current({
+        execFileSync: fakeGo({
+          command: fixture.command,
+          dependency: fixture.dependency,
+          goMod: fixture.goMod,
           goVersion: "go1.26.5",
           goWork: fixture.goWork,
           goroot: fixture.goroot,
@@ -173,6 +186,7 @@ function fakeGo({
   command,
   dependency,
   goMod,
+  goWasm = "",
   goVersion = "go1.26.4",
   goWork,
   goroot,
@@ -201,6 +215,8 @@ function fakeGo({
         GOARCH: "wasm",
         GOFLAGS: "",
         GOEXPERIMENT: "",
+        GOTOOLCHAIN: "auto",
+        GOWASM: goWasm,
         CGO_ENABLED: "0",
         GOWORK: goWork,
       });

--- a/scripts/go-build-cache.test.cjs
+++ b/scripts/go-build-cache.test.cjs
@@ -54,6 +54,7 @@ test("Go build cache keys every effective input and rejects corrupt state", () =
       "package shim\nconst Version = 1\n",
     );
     invalidates(fixture.goBinary, "go compiler v2\n");
+    invalidates(fixture.goToolCompiler, "go compile tool v2\n");
 
     record();
     assert.equal(
@@ -72,6 +73,7 @@ test("Go build cache keys every effective input and rejects corrupt state", () =
           command: fixture.command,
           dependency: fixture.dependency,
           goMod: fixture.goMod,
+          goToolDir: fixture.goToolDir,
           goWasm: "satconv",
           goWork: fixture.goWork,
           goroot: fixture.goroot,
@@ -85,6 +87,7 @@ test("Go build cache keys every effective input and rejects corrupt state", () =
           command: fixture.command,
           dependency: fixture.dependency,
           goMod: fixture.goMod,
+          goToolDir: fixture.goToolDir,
           goVersion: "go1.26.5",
           goWork: fixture.goWork,
           goroot: fixture.goroot,
@@ -116,11 +119,13 @@ function createFixture() {
   const shimSourceRoot = path.join(root, "shim-source");
   const shimOutputRoot = path.join(output, "shim");
   const goroot = path.join(root, "go");
+  const goToolDir = path.join(goroot, "pkg", "tool", "fixture");
   fs.mkdirSync(command, { recursive: true });
   fs.mkdirSync(dependency, { recursive: true });
   fs.mkdirSync(shimSourceRoot, { recursive: true });
   fs.mkdirSync(shimOutputRoot, { recursive: true });
   fs.mkdirSync(path.join(goroot, "bin"), { recursive: true });
+  fs.mkdirSync(goToolDir, { recursive: true });
 
   const goMod = path.join(module, "go.mod");
   const goSum = path.join(module, "go.sum");
@@ -138,6 +143,10 @@ function createFixture() {
     "bin",
     process.platform === "win32" ? "go.exe" : "go",
   );
+  const goToolCompiler = path.join(
+    goToolDir,
+    process.platform === "win32" ? "compile.exe" : "compile",
+  );
   fs.writeFileSync(goMod, "module example.test/cache\ngo 1.26\n");
   fs.writeFileSync(goSum, "example.test/dependency v1.0.0 h1:original\n");
   fs.writeFileSync(goWork, "go 1.26\n\nuse ./module\n");
@@ -153,6 +162,7 @@ function createFixture() {
   fs.writeFileSync(shimSource, "package shim\nconst Version = 1\n");
   fs.writeFileSync(shimOutput, "package shim\nconst Version = 1\n");
   fs.writeFileSync(goBinary, "go compiler v1\n");
+  fs.writeFileSync(goToolCompiler, "go compile tool v1\n");
 
   const options = {
     artifactPaths: [wasm, bridge, shimOutputRoot],
@@ -163,7 +173,14 @@ function createFixture() {
     environment: { GOOS: "js", GOARCH: "wasm" },
     extraFiles: [bridge],
     inputDirectories: [shimSourceRoot],
-    execFileSync: fakeGo({ command, dependency, goMod, goWork, goroot }),
+    execFileSync: fakeGo({
+      command,
+      dependency,
+      goMod,
+      goToolDir,
+      goWork,
+      goroot,
+    }),
   };
   return {
     root,
@@ -174,6 +191,8 @@ function createFixture() {
     dependencySource,
     embed,
     goBinary,
+    goToolDir,
+    goToolCompiler,
     goMod,
     goSource,
     goSum,
@@ -190,6 +209,7 @@ function fakeGo({
   command,
   dependency,
   goMod,
+  goToolDir,
   goWasm = "",
   goVersion = "go1.26.4",
   goWork,
@@ -220,6 +240,7 @@ function fakeGo({
         GOFLAGS: "",
         GOEXPERIMENT: "",
         GOTOOLCHAIN: "auto",
+        GOTOOLDIR: goToolDir,
         GOWASM: goWasm,
         CGO_ENABLED: "0",
         GOWORK: goWork,

--- a/scripts/go-build-cache.test.cjs
+++ b/scripts/go-build-cache.test.cjs
@@ -50,6 +50,17 @@ test("Go build cache keys every effective input and rejects corrupt state", () =
       current({ environment: { GOOS: "js", GOARCH: "wasm64" } }).isCurrent(),
       false,
     );
+    assert.equal(
+      current({
+        execFileSync: fakeGo({
+          command: fixture.command,
+          goMod: fixture.goMod,
+          goVersion: "go1.26.5",
+          goWork: fixture.goWork,
+        }),
+      }).isCurrent(),
+      false,
+    );
     assert.equal(current({ force: true }).isCurrent(), false);
 
     record();
@@ -112,6 +123,7 @@ function createFixture() {
     root,
     options,
     bridge,
+    command,
     embed,
     goMod,
     goSource,
@@ -122,7 +134,7 @@ function createFixture() {
   };
 }
 
-function fakeGo({ command, goMod, goWork }) {
+function fakeGo({ command, goMod, goVersion = "go1.26.4", goWork }) {
   return (_command, args) => {
     if (args[0] === "list" && args[1] === "-deps") {
       return `${JSON.stringify({
@@ -137,7 +149,7 @@ function fakeGo({ command, goMod, goWork }) {
     }
     if (args[0] === "env") {
       return JSON.stringify({
-        GOVERSION: "go1.26.4",
+        GOVERSION: goVersion,
         GOOS: "js",
         GOARCH: "wasm",
         GOFLAGS: "",

--- a/scripts/go-build-cache.test.cjs
+++ b/scripts/go-build-cache.test.cjs
@@ -1,0 +1,151 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { createGoBuildCache } = require("./go-build-cache.cjs");
+
+test("Go build cache keys every effective input and rejects corrupt state", () => {
+  const fixture = createFixture();
+  try {
+    const current = (overrides = {}) =>
+      createGoBuildCache({ ...fixture.options, ...overrides });
+    const record = () => {
+      const cache = current();
+      cache.write();
+      assert.equal(current().isCurrent(), true);
+    };
+    const invalidates = (file, contents) => {
+      record();
+      const original = fs.readFileSync(file, "utf8");
+      fs.writeFileSync(file, contents);
+      assert.equal(current().isCurrent(), false);
+      fs.writeFileSync(file, original);
+    };
+
+    record();
+    fs.writeFileSync(path.join(fixture.root, "README.md"), "unrelated docs\n");
+    assert.equal(current().isCurrent(), true);
+
+    invalidates(fixture.goSource, "package main\nfunc main() { println(2) }\n");
+    invalidates(fixture.embed, '{"schema":2}\n');
+    invalidates(
+      fixture.goMod,
+      "module example.test/cache\n\ngo 1.26\n\nrequire example.test/dependency v1.0.1\n",
+    );
+    invalidates(fixture.goSum, "example.test/dependency v1.0.1 h1:changed\n");
+    invalidates(fixture.goWork, "go 1.26\n\nuse ./other-module\n");
+    invalidates(fixture.bridge, "new wasm bridge\n");
+    invalidates(fixture.shimSource, "package shim\nconst Version = 2\n");
+
+    record();
+    assert.equal(
+      current({
+        buildArguments: [...fixture.options.buildArguments, "-tags=extra"],
+      }).isCurrent(),
+      false,
+    );
+    assert.equal(
+      current({ environment: { GOOS: "js", GOARCH: "wasm64" } }).isCurrent(),
+      false,
+    );
+    assert.equal(current({ force: true }).isCurrent(), false);
+
+    record();
+    fs.writeFileSync(fixture.wasm, "corrupt wasm\n");
+    assert.equal(current().isCurrent(), false);
+
+    fs.writeFileSync(fixture.wasm, "wasm artifact\n");
+    record();
+    fs.writeFileSync(fixture.options.cachePath, "not json\n");
+    assert.equal(current().isCurrent(), false);
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+function createFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ttsc-go-build-cache-"));
+  const module = path.join(root, "module");
+  const command = path.join(module, "cmd", "example");
+  const output = path.join(root, "out");
+  const shimSourceRoot = path.join(root, "shim-source");
+  const shimOutputRoot = path.join(output, "shim");
+  fs.mkdirSync(command, { recursive: true });
+  fs.mkdirSync(shimSourceRoot, { recursive: true });
+  fs.mkdirSync(shimOutputRoot, { recursive: true });
+
+  const goMod = path.join(module, "go.mod");
+  const goSum = path.join(module, "go.sum");
+  const goWork = path.join(root, "go.work");
+  const goSource = path.join(command, "main.go");
+  const embed = path.join(command, "schema.json");
+  const bridge = path.join(root, "wasm_exec.js");
+  const wasm = path.join(output, "example.wasm");
+  const shimSource = path.join(shimSourceRoot, "shim.go");
+  fs.writeFileSync(goMod, "module example.test/cache\ngo 1.26\n");
+  fs.writeFileSync(goSum, "example.test/dependency v1.0.0 h1:original\n");
+  fs.writeFileSync(goWork, "go 1.26\n\nuse ./module\n");
+  fs.writeFileSync(goSource, "package main\nfunc main() { println(1) }\n");
+  fs.writeFileSync(embed, '{"schema":1}\n');
+  fs.writeFileSync(bridge, "wasm bridge\n");
+  fs.writeFileSync(wasm, "wasm artifact\n");
+  fs.writeFileSync(shimSource, "package shim\nconst Version = 1\n");
+  fs.writeFileSync(
+    path.join(shimOutputRoot, "shim.go"),
+    "package shim\nconst Version = 1\n",
+  );
+
+  const options = {
+    artifactPaths: [wasm, bridge, shimOutputRoot],
+    buildArguments: ["go", "build", "-trimpath", "./cmd/example"],
+    cachePath: path.join(output, ".cache.json"),
+    cwd: module,
+    dependencyPackages: ["./cmd/example"],
+    environment: { GOOS: "js", GOARCH: "wasm" },
+    extraFiles: [bridge],
+    inputDirectories: [shimSourceRoot],
+    execFileSync: fakeGo({ command, goMod, goWork }),
+  };
+  return {
+    root,
+    options,
+    bridge,
+    embed,
+    goMod,
+    goSource,
+    goSum,
+    goWork,
+    shimSource,
+    wasm,
+  };
+}
+
+function fakeGo({ command, goMod, goWork }) {
+  return (_command, args) => {
+    if (args[0] === "list" && args[1] === "-deps") {
+      return `${JSON.stringify({
+        Dir: command,
+        GoFiles: ["main.go"],
+        EmbedFiles: ["schema.json"],
+        Module: { GoMod: goMod },
+      })}\n`;
+    }
+    if (args[0] === "list" && args[1] === "-m") {
+      return `${JSON.stringify({ Path: "example.test/cache", GoMod: goMod })}\n`;
+    }
+    if (args[0] === "env") {
+      return JSON.stringify({
+        GOVERSION: "go1.26.4",
+        GOOS: "js",
+        GOARCH: "wasm",
+        GOFLAGS: "",
+        GOEXPERIMENT: "",
+        CGO_ENABLED: "0",
+        GOWORK: goWork,
+      });
+    }
+    throw new Error(`unexpected go command: ${args.join(" ")}`);
+  };
+}

--- a/scripts/go-build-cache.test.cjs
+++ b/scripts/go-build-cache.test.cjs
@@ -36,6 +36,7 @@ test("Go build cache keys every effective input and rejects corrupt state", () =
     );
     invalidates(fixture.goSum, "example.test/dependency v1.0.1 h1:changed\n");
     invalidates(fixture.goWork, "go 1.26\n\nuse ./other-module\n");
+    invalidates(fixture.goWorkSum, "example.test/dependency v1.0.1 h1:changed\n");
     invalidates(
       fixture.dependencySource,
       "package dependency\nfunc Version() int { return 2 }\n",
@@ -124,6 +125,7 @@ function createFixture() {
   const goMod = path.join(module, "go.mod");
   const goSum = path.join(module, "go.sum");
   const goWork = path.join(root, "go.work");
+  const goWorkSum = path.join(root, "go.work.sum");
   const goSource = path.join(command, "main.go");
   const dependencySource = path.join(dependency, "dependency.go");
   const embed = path.join(command, "schema.json");
@@ -139,6 +141,7 @@ function createFixture() {
   fs.writeFileSync(goMod, "module example.test/cache\ngo 1.26\n");
   fs.writeFileSync(goSum, "example.test/dependency v1.0.0 h1:original\n");
   fs.writeFileSync(goWork, "go 1.26\n\nuse ./module\n");
+  fs.writeFileSync(goWorkSum, "example.test/dependency v1.0.0 h1:original\n");
   fs.writeFileSync(goSource, "package main\nfunc main() { println(1) }\n");
   fs.writeFileSync(
     dependencySource,
@@ -175,6 +178,7 @@ function createFixture() {
     goSource,
     goSum,
     goWork,
+    goWorkSum,
     goroot,
     shimSource,
     shimOutput,

--- a/scripts/test-go.cjs
+++ b/scripts/test-go.cjs
@@ -25,6 +25,8 @@ const harnessTests = [
   path.join(__dirname, "ci", "go-test-runners.test.cjs"),
   path.join(__dirname, "ci", "website-compiler-module.test.cjs"),
   path.join(__dirname, "assert-project-layout.test.cjs"),
+  path.join(__dirname, "go-build-cache.test.cjs"),
+  path.join(__dirname, "go-build-cache-builders.test.cjs"),
 ];
 
 // runAll invokes every entry through `spawn` and returns the list that failed.

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -10,6 +10,7 @@ public/benchmark/png/
 public/compiler/index.js
 public/compiler/*.map
 public/compiler/playground.wasm
+public/compiler/.playground-wasm-build.json
 public/compiler/playground.wasm.br
 public/compiler/typia-pack.json
 public/compiler/typia-runtime-pack.json

--- a/website/build/compiler.cjs
+++ b/website/build/compiler.cjs
@@ -2,21 +2,15 @@
 //
 // Produces three artifacts the playground depends on:
 //
-//   1. `public/compiler/playground.wasm` — the website's consumer wasm.
-//      Built from `website/compiler/cmd/playground` against `@ttsc/wasm`'s
-//      host helper, with banner / paths / strip wired in.
-//   2. `public/compiler/wasm_exec.js` — Go's bootstrap shim. Copied from
-//      `node_modules/@ttsc/wasm/dist/wasm_exec.js` so the worker can
-//      `importScripts` it before instantiating the wasm.
-//   3. `public/compiler/index.js` — the rspack-bundled Web Worker that
-//      drives the in-browser compile through tgrid's WorkerServer.
-//
-// `build/typia-types.cjs` keeps populating Monaco's `addExtraLib` source so
-// red-squigglies stay quiet inside the editor.
+//   1. public/compiler/playground.wasm, the website's consumer wasm.
+//   2. public/compiler/wasm_exec.js, Go's matching bootstrap shim.
+//   3. public/compiler/index.js, the rspack-bundled Web Worker.
 
 const cp = require("child_process");
 const fs = require("fs");
 const path = require("path");
+
+const { createGoBuildCache } = require("../../scripts/go-build-cache.cjs");
 
 const ROOT = path.resolve(__dirname, "..");
 const REPO_ROOT = path.resolve(ROOT, "..");
@@ -45,152 +39,101 @@ const run = (command, opts = {}) => {
   });
 };
 
-const newestMtime = (root) => {
-  let max = 0;
-  const stack = [root];
-  while (stack.length) {
-    const cur = stack.pop();
-    let stat;
-    try {
-      stat = fs.statSync(cur);
-    } catch {
-      continue;
-    }
-    if (stat.isDirectory()) {
-      const base = path.basename(cur);
-      if (
-        base === "node_modules" ||
-        base === ".git" ||
-        base === "lib" ||
-        base === "dist" ||
-        base === ".ttsc"
-      )
-        continue;
-      for (const entry of fs.readdirSync(cur)) {
-        stack.push(path.join(cur, entry));
-      }
-    } else if (stat.isFile() && cur.endsWith(".go")) {
-      if (stat.mtimeMs > max) max = stat.mtimeMs;
-    }
-  }
-  return max;
-};
-
-// ── 1. Build playground.wasm ──────────────────────────────────────────────
-fs.mkdirSync(OUT_DIR, { recursive: true });
-
-const force =
-  process.argv.includes("--force") || !!process.env.TTSC_PLAYGROUND_FORCE;
-
-// The cache key has to track every Go source the playground links in:
-//   • compiler/ — the playground entry itself.
-//   • packages/wasm — the host helper.
-//   • packages/ttsc — the compiler + driver.
-//   • packages/lint/linthost + rule — the lint engine the playground exposes.
-//   • typia/native/adapter — typia's wasm adapter Go (resolved through the
-//     same go.mod replace the compiler module uses, so the cache key tracks
-//     the EXACT typia install the wasm is compiled against, not a different
-//     install that happens to share a major version).
-//
-// Resolve the one website/node_modules/typia install named by compiler/go.mod.
-// The same graph object owns the version stamp and all generated packs.
-const { createTypiaDependencyGraph } = require("./typia-dependency-graph.cjs");
-const typiaGraph = createTypiaDependencyGraph({ websiteRoot: ROOT });
-const typiaPkgVersion = typiaGraph.version;
-const TYPIA_NATIVE_ADAPTER = typiaGraph.goAdapterRoot;
-const wasmSourceMtime = Math.max(
-  newestMtime(COMPILER_DIR),
-  newestMtime(path.join(REPO_ROOT, "packages", "wasm")),
-  newestMtime(path.join(REPO_ROOT, "packages", "ttsc")),
-  newestMtime(path.join(REPO_ROOT, "packages", "lint", "linthost")),
-  newestMtime(path.join(REPO_ROOT, "packages", "lint", "rule")),
-  newestMtime(TYPIA_NATIVE_ADAPTER),
-);
-// Stamp the typia version into a sidecar file so a version bump alone busts
-// the cache. The wasm itself doesn't carry the version, so without this a
-// floor-mtime cache hit would silently keep using yesterday's typia.
-const TYPIA_VERSION_STAMP = path.join(OUT_DIR, ".typia-version");
-let lastTypiaVersion = null;
-try {
-  lastTypiaVersion = fs.readFileSync(TYPIA_VERSION_STAMP, "utf8").trim();
-} catch {
-  /* first run — no stamp yet */
-}
-const typiaVersionChanged = lastTypiaVersion !== typiaPkgVersion;
-const cached =
-  !force &&
-  !typiaVersionChanged &&
-  fs.existsSync(WASM_OUT) &&
-  fs.statSync(WASM_OUT).mtimeMs >= wasmSourceMtime;
-
-if (cached) {
-  log(
-    `playground.wasm is up to date (${(
-      fs.statSync(WASM_OUT).size /
-      1024 /
-      1024
-    ).toFixed(2)} MiB) — skipping Go build`,
-  );
-} else {
-  log(`building playground.wasm`);
-  if (typiaVersionChanged && lastTypiaVersion !== null) {
-    log(
-      `typia version changed (${lastTypiaVersion} → ${typiaPkgVersion}); rebuilding`,
-    );
-  }
-  run(
-    `go build -trimpath -ldflags "-s -w" -o ${JSON.stringify(WASM_OUT)} ./cmd/playground`,
-    {
-      cwd: COMPILER_DIR,
-      env: { GOOS: "js", GOARCH: "wasm" },
-    },
-  );
-  log(
-    `playground.wasm = ${(
-      fs.statSync(WASM_OUT).size /
-      1024 /
-      1024
-    ).toFixed(2)} MiB`,
-  );
-  fs.writeFileSync(TYPIA_VERSION_STAMP, typiaPkgVersion);
+function createCacheOptions({ force, typiaGraph }) {
+  return {
+    artifactPaths: [WASM_OUT, WASM_EXEC_OUT],
+    buildArguments: [
+      "go",
+      "build",
+      "-trimpath",
+      "-ldflags",
+      "-s -w",
+      "-o",
+      WASM_OUT,
+      "./cmd/playground",
+    ],
+    cachePath: path.join(OUT_DIR, ".playground-wasm-build.json"),
+    cwd: COMPILER_DIR,
+    dependencyPackages: ["./cmd/playground"],
+    environment: { GOOS: "js", GOARCH: "wasm" },
+    extraFiles: [
+      __filename,
+      WASM_EXEC_SRC,
+      path.join(typiaGraph.typiaRoot, "package.json"),
+    ],
+    force,
+  };
 }
 
-// ── 2. Stage wasm_exec.js ────────────────────────────────────────────────
-if (!fs.existsSync(WASM_EXEC_SRC)) {
-  log(
-    `@ttsc/wasm dist not built yet; running its build to source wasm_exec.js`,
-  );
+function main() {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const force =
+    process.argv.includes("--force") || !!process.env.TTSC_PLAYGROUND_FORCE;
+  const {
+    createTypiaDependencyGraph,
+  } = require("./typia-dependency-graph.cjs");
+  const typiaGraph = createTypiaDependencyGraph({ websiteRoot: ROOT });
+
+  // The bridge belongs to the same Go toolchain as both wasm files. Running
+  // @ttsc/wasm's identity-aware build first makes its staged bridge a valid
+  // input instead of copying a stale bridge after a website cache hit.
   run("pnpm run build:wasm", {
     cwd: path.join(REPO_ROOT, "packages", "wasm"),
   });
+  if (!fs.existsSync(WASM_EXEC_SRC)) {
+    throw new Error(
+      `@ttsc/wasm did not stage wasm_exec.js at ${WASM_EXEC_SRC}`,
+    );
+  }
+
+  const cache = createGoBuildCache(createCacheOptions({ force, typiaGraph }));
+  if (cache.isCurrent()) {
+    log(
+      `playground.wasm is up to date (${(
+        fs.statSync(WASM_OUT).size /
+        1024 /
+        1024
+      ).toFixed(2)} MiB) -> skipping Go build`,
+    );
+  } else {
+    log("building playground.wasm");
+    run(
+      `go build -trimpath -ldflags "-s -w" -o ${JSON.stringify(WASM_OUT)} ./cmd/playground`,
+      {
+        cwd: COMPILER_DIR,
+        env: { GOOS: "js", GOARCH: "wasm" },
+      },
+    );
+    fs.copyFileSync(WASM_EXEC_SRC, WASM_EXEC_OUT);
+    cache.write();
+    log(
+      `playground.wasm = ${(fs.statSync(WASM_OUT).size / 1024 / 1024).toFixed(
+        2,
+      )} MiB`,
+    );
+    log(
+      `copied wasm_exec.js (${(fs.statSync(WASM_EXEC_OUT).size / 1024).toFixed(
+        1,
+      )} KB)`,
+    );
+  }
+
+  // 3. Bundle the worker entry with rspack.
+  log("bundling the playground compiler worker with rspack");
+  run("npx --no-install rspack");
+
+  // 4. Keep typia type definitions for Monaco's editor squigglies.
+  require("./typia-types.cjs");
+
+  // 5. Build the typia source pack the worker mounts into MemFS.
+  require("./pack-typia-sources.cjs");
+
+  // 6. Build the typia runtime pack the Execute sandbox uses.
+  require("./pack-typia-runtime.cjs");
+
+  log("done.");
 }
-fs.copyFileSync(WASM_EXEC_SRC, WASM_EXEC_OUT);
-log(
-  `copied wasm_exec.js (${(
-    fs.statSync(WASM_EXEC_OUT).size / 1024
-  ).toFixed(1)} KB)`,
-);
 
-// ── 3. Bundle the worker entry with rspack ────────────────────────────────
-log(`bundling the playground compiler worker with rspack`);
-run("npx --no-install rspack");
+if (require.main === module) main();
 
-// ── 4. Keep typia type definitions for Monaco's editor squigglies ──────────
-require("./typia-types.cjs");
-
-// ── 5. Build the typia source pack the worker mounts into MemFS ────────────
-// Mirrors typia's own `typia-pack.js` flow: copies the published source tree
-// under `node_modules/typia` with its discovered dependency closure into one
-// JSON blob the worker fetches at boot. Without it, the wasm-side compiler
-// can't resolve `import typia, { tags } from "typia"`.
-require("./pack-typia-sources.cjs");
-
-// ── 6. Build the typia runtime pack the Execute sandbox uses ──────────────
-// The playground's "Execute" button runs the transformed bundle inside a
-// `new Function(...)` sandbox. The bundle does `require("typia/lib/internal/X")`
-// for the per-feature helpers typia's transform emits (validators, random
-// generators, JSON encoders). Without resolvable modules, every Execute
-// throws. The runtime pack follows those real requires transitively.
-require("./pack-typia-runtime.cjs");
-
-log("done.");
+module.exports = { createCacheOptions };


### PR DESCRIPTION
## Intent

Closes #815.

Replace the two timestamp-and-`.go` build-cache predicates with one
deterministic effective-input identity contract. A cache hit must pair the
recorded identity, the wasm binary, and `wasm_exec.js` from one build.

## Scope

- `packages/wasm/build/build-wasm.cjs`
- `website/build/compiler.cjs`
- focused cache-identity regressions for both builders
- the matching playground/wasm documentation only if the published behavior
  changes

`#847` owns the independent fountain-token path. `#848` depends on this cache
root and will not begin until this PR merges.

## Verification

Pending implementation. Campaign implementation runs are cancelled by exact
commit SHA; local two-build cache tests and builder smoke checks are the merge
gate.
