### PR TITLE
fix(release): verify Marketplace versions before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Preflight - validate release tag and package versions
         run: node scripts/release-preflight.cjs
+      - name: Preflight - verify public Marketplace channel
+        run: node scripts/assert-marketplace-version.cjs --extension samchon.ttsc --timeout-ms 60000 --interval-ms 5000
       - name: Build all packages
         run: pnpm run build
       - name: Assert dist/ttsc.wasm exists and is >10MB
@@ -79,6 +81,8 @@ jobs:
         run: SKIP_BUILD=1 bash scripts/publish-vscode-marketplace.sh
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      - name: Verify VS Code Marketplace serves release
+        run: node scripts/assert-marketplace-version.cjs --extension samchon.ttsc --version "${GITHUB_REF_NAME#v}" --timeout-ms 300000 --interval-ms 10000
       - name: Publish to npm
         run: pnpm run package:latest:publish
   wasm-smoke:

--- a/scripts/assert-marketplace-version.cjs
+++ b/scripts/assert-marketplace-version.cjs
@@ -1,0 +1,406 @@
+// Public VS Code Marketplace release gate.
+//
+// `vsce publish` proves that the authenticated Gallery API accepted an upload;
+// it does not prove that anonymous VS Code clients can discover the extension.
+// This probe asks the same public exact-name endpoint used for install-by-id and
+// fails closed until the extension, and optionally one exact version, is served.
+//
+// Usage:
+//   node scripts/assert-marketplace-version.cjs \
+//     --extension samchon.ttsc
+//   node scripts/assert-marketplace-version.cjs \
+//     --extension samchon.ttsc --version 0.19.4
+
+const DEFAULT_ENDPOINT =
+  "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery";
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_INTERVAL_MS = 10 * 1000;
+const EXTENSION_ID_PATTERN = /^([a-z0-9][a-z0-9-]*)\.([a-z0-9][a-z0-9-]*)$/i;
+
+class MarketplaceProbeError extends Error {
+  constructor(message, options = {}) {
+    super(message, options.cause ? { cause: options.cause } : undefined);
+    this.name = "MarketplaceProbeError";
+    this.retryable = options.retryable === true;
+  }
+}
+
+function parseExtensionId(extensionId) {
+  if (typeof extensionId !== "string") {
+    throw new MarketplaceProbeError(
+      "marketplace-probe: --extension must be a string",
+    );
+  }
+  const match = EXTENSION_ID_PATTERN.exec(extensionId);
+  if (match === null) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: extension id ${JSON.stringify(extensionId)} must be exactly <publisher>.<name>`,
+    );
+  }
+  return {
+    extensionId,
+    publisher: match[1],
+    name: match[2],
+  };
+}
+
+function marketplaceQueryBody(extensionId) {
+  return JSON.stringify({
+    filters: [
+      {
+        criteria: [{ filterType: 7, value: extensionId }],
+        pageNumber: 1,
+        pageSize: 5,
+        sortBy: 0,
+        sortOrder: 0,
+      },
+    ],
+    assetTypes: [],
+    // IncludeVersions without IncludeLatestVersionOnly. An already-served
+    // historical version is valid after `vsce publish --skip-duplicate`, even
+    // when a newer Marketplace version now exists.
+    flags: 1,
+  });
+}
+
+async function queryMarketplace(options) {
+  const { extensionId, publisher, name } = parseExtensionId(
+    options.extensionId,
+  );
+  if (
+    options.version !== undefined &&
+    (typeof options.version !== "string" || options.version.length === 0)
+  ) {
+    throw new MarketplaceProbeError(
+      "marketplace-probe: version must be a non-empty string",
+    );
+  }
+  const endpoint = options.endpoint ?? DEFAULT_ENDPOINT;
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    throw new MarketplaceProbeError(
+      "marketplace-probe: this Node.js runtime does not provide fetch",
+    );
+  }
+
+  let response;
+  try {
+    response = await fetchImpl(endpoint, {
+      method: "POST",
+      headers: {
+        Accept: "application/json;api-version=7.2-preview.1",
+        "Content-Type": "application/json",
+        "User-Agent": "ttsc-release-marketplace-probe",
+      },
+      body: marketplaceQueryBody(extensionId),
+      signal: options.signal,
+    });
+  } catch (cause) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: public Gallery request failed: ${errorMessage(cause)}`,
+      { cause, retryable: true },
+    );
+  }
+
+  if (
+    response === null ||
+    typeof response !== "object" ||
+    typeof response.status !== "number"
+  ) {
+    throw new MarketplaceProbeError(
+      "marketplace-probe: public Gallery returned a malformed HTTP response",
+    );
+  }
+  if (response.status === 429 || response.status >= 500) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: public Gallery returned retryable HTTP ${response.status}`,
+      { retryable: true },
+    );
+  }
+  if (response.status < 200 || response.status >= 300) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: public Gallery returned HTTP ${response.status}`,
+    );
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (cause) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: public Gallery returned malformed JSON: ${errorMessage(cause)}`,
+      { cause },
+    );
+  }
+  const extensions = readExtensions(payload);
+  if (extensions.length === 0) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: ${extensionId} is not publicly served`,
+      { retryable: true },
+    );
+  }
+
+  const normalizedPublisher = publisher.toLowerCase();
+  const normalizedName = name.toLowerCase();
+  const exact = [];
+  const unrelated = [];
+  for (const extension of extensions) {
+    if (
+      extension === null ||
+      typeof extension !== "object" ||
+      typeof extension.extensionName !== "string" ||
+      extension.publisher === null ||
+      typeof extension.publisher !== "object" ||
+      typeof extension.publisher.publisherName !== "string"
+    ) {
+      throw new MarketplaceProbeError(
+        "marketplace-probe: public Gallery returned a malformed extension record",
+      );
+    }
+    if (
+      extension.publisher.publisherName.toLowerCase() === normalizedPublisher &&
+      extension.extensionName.toLowerCase() === normalizedName
+    ) {
+      exact.push(extension);
+    } else {
+      unrelated.push(
+        `${extension.publisher.publisherName}.${extension.extensionName}`,
+      );
+    }
+  }
+  if (unrelated.length !== 0) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: exact query for ${extensionId} returned unrelated extension(s): ${unrelated.join(", ")}`,
+    );
+  }
+  if (exact.length !== 1) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: exact query for ${extensionId} returned ${exact.length} matching records`,
+    );
+  }
+
+  const versions = exact[0].versions;
+  if (!Array.isArray(versions)) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: ${extensionId} has no version list in the public Gallery response`,
+    );
+  }
+  const versionNames = versions.map((entry) => {
+    if (
+      entry === null ||
+      typeof entry !== "object" ||
+      typeof entry.version !== "string" ||
+      entry.version.length === 0
+    ) {
+      throw new MarketplaceProbeError(
+        `marketplace-probe: ${extensionId} has a malformed public version record`,
+      );
+    }
+    return entry.version;
+  });
+  if (versionNames.length === 0) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: ${extensionId} is public but serves no versions`,
+      { retryable: true },
+    );
+  }
+  if (
+    options.version !== undefined &&
+    !versionNames.includes(options.version)
+  ) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: ${extensionId} does not publicly serve version ${options.version} (served: ${versionNames.join(", ")})`,
+      { retryable: true },
+    );
+  }
+
+  return {
+    extensionId,
+    publisher: exact[0].publisher.publisherName,
+    name: exact[0].extensionName,
+    version: options.version ?? versionNames[0],
+    versions: versionNames,
+  };
+}
+
+function readExtensions(payload) {
+  if (
+    payload === null ||
+    typeof payload !== "object" ||
+    !Array.isArray(payload.results) ||
+    payload.results.length !== 1 ||
+    payload.results[0] === null ||
+    typeof payload.results[0] !== "object" ||
+    !Array.isArray(payload.results[0].extensions)
+  ) {
+    throw new MarketplaceProbeError(
+      "marketplace-probe: public Gallery returned a malformed query result",
+    );
+  }
+  return payload.results[0].extensions;
+}
+
+async function waitForMarketplace(options) {
+  const timeoutMs = validateMilliseconds(
+    options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    "timeout",
+    true,
+  );
+  const intervalMs = validateMilliseconds(
+    options.intervalMs ?? DEFAULT_INTERVAL_MS,
+    "interval",
+    false,
+  );
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? defaultSleep;
+  const logger = options.logger ?? console;
+  const startedAt = now();
+  const deadline = startedAt + timeoutMs;
+  let attempts = 0;
+  let lastError;
+
+  while (true) {
+    attempts += 1;
+    const controller = new AbortController();
+    const remaining = Math.max(1, deadline - now());
+    const timer = setTimeout(() => controller.abort(), remaining);
+    try {
+      const result = await queryMarketplace({
+        ...options,
+        signal: controller.signal,
+      });
+      return { ...result, attempts, elapsedMs: now() - startedAt };
+    } catch (cause) {
+      const error =
+        cause instanceof MarketplaceProbeError
+          ? cause
+          : new MarketplaceProbeError(
+              `marketplace-probe: unexpected failure: ${errorMessage(cause)}`,
+              { cause },
+            );
+      if (!error.retryable) throw error;
+      lastError = error;
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (now() >= deadline) break;
+    const delay = Math.min(intervalMs, deadline - now());
+    logger.warn(
+      `marketplace-probe: attempt ${attempts} pending; retrying in ${delay} ms: ${lastError.message}`,
+    );
+    await sleep(delay);
+  }
+
+  throw new MarketplaceProbeError(
+    `marketplace-probe: ${options.extensionId}${options.version ? `@${options.version}` : ""} was not publicly served within ${timeoutMs} ms after ${attempts} attempt(s): ${lastError.message}`,
+    { cause: lastError },
+  );
+}
+
+function validateMilliseconds(value, label, allowZero) {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1)) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: ${label} milliseconds must be ${allowZero ? "a non-negative" : "a positive"} safe integer`,
+    );
+  }
+  return value;
+}
+
+function defaultSleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parseArgs(argv) {
+  const options = {
+    extensionId: undefined,
+    version: undefined,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    intervalMs: DEFAULT_INTERVAL_MS,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--extension") {
+      options.extensionId = argv[++i];
+    } else if (arg.startsWith("--extension=")) {
+      options.extensionId = arg.slice("--extension=".length);
+    } else if (arg === "--version") {
+      options.version = argv[++i];
+    } else if (arg.startsWith("--version=")) {
+      options.version = arg.slice("--version=".length);
+    } else if (arg === "--timeout-ms") {
+      options.timeoutMs = parseMilliseconds(argv[++i], "timeout");
+    } else if (arg.startsWith("--timeout-ms=")) {
+      options.timeoutMs = parseMilliseconds(
+        arg.slice("--timeout-ms=".length),
+        "timeout",
+      );
+    } else if (arg === "--interval-ms") {
+      options.intervalMs = parseMilliseconds(argv[++i], "interval");
+    } else if (arg.startsWith("--interval-ms=")) {
+      options.intervalMs = parseMilliseconds(
+        arg.slice("--interval-ms=".length),
+        "interval",
+      );
+    } else {
+      throw new MarketplaceProbeError(
+        `marketplace-probe: unknown argument ${JSON.stringify(arg)}`,
+      );
+    }
+  }
+  if (!options.extensionId) {
+    throw new MarketplaceProbeError(
+      "marketplace-probe: --extension is required",
+    );
+  }
+  if (options.version !== undefined && options.version.length === 0) {
+    throw new MarketplaceProbeError(
+      "marketplace-probe: --version must not be empty",
+    );
+  }
+  validateMilliseconds(options.timeoutMs, "timeout", true);
+  validateMilliseconds(options.intervalMs, "interval", false);
+  parseExtensionId(options.extensionId);
+  return options;
+}
+
+function parseMilliseconds(value, label) {
+  if (value === undefined || !/^\d+$/.test(value)) {
+    throw new MarketplaceProbeError(
+      `marketplace-probe: --${label}-ms requires an integer`,
+    );
+  }
+  return Number(value);
+}
+
+async function main(argv) {
+  const options = parseArgs(argv);
+  const result = await waitForMarketplace(options);
+  console.log(
+    `marketplace-probe: OK — ${result.extensionId} publicly serves ${options.version ? `version ${result.version}` : `${result.versions.length} version(s), latest ${result.version}`}`,
+  );
+}
+
+if (require.main === module) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(errorMessage(error));
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  DEFAULT_ENDPOINT,
+  DEFAULT_INTERVAL_MS,
+  DEFAULT_TIMEOUT_MS,
+  MarketplaceProbeError,
+  main,
+  marketplaceQueryBody,
+  parseArgs,
+  parseExtensionId,
+  queryMarketplace,
+  waitForMarketplace,
+};

--- a/tests/test-ttsc/src/features/platform/test_marketplace_probe_accepts_exact_served_version.ts
+++ b/tests/test-ttsc/src/features/platform/test_marketplace_probe_accepts_exact_served_version.ts
@@ -1,0 +1,53 @@
+import {
+  galleryPayload,
+  jsonResponse,
+  marketplaceProbe,
+} from "../../internal/marketplace-probe";
+import { assert } from "../../internal/toolchain";
+
+/**
+ * Verifies an exact public Marketplace version is a repeatable success.
+ *
+ * The release workflow may be retried after the Gallery already serves the
+ * tagged version. Both the readiness lane and exact-version lane must accept
+ * that public state instead of treating an already served release as an error.
+ *
+ * 1. Serve one exact publisher/name record with two valid versions.
+ * 2. Query readiness and the tagged version twice against the same response.
+ * 3. Assert every query succeeds with the exact public identity and version.
+ */
+export const test_marketplace_probe_accepts_exact_served_version = async () => {
+  const queryBodies: any[] = [];
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    queryBodies.push(JSON.parse(String(init?.body)));
+    return jsonResponse(
+      galleryPayload("samchon", "ttsc", ["0.19.5", "0.19.4"]),
+    );
+  };
+
+  const readiness = await marketplaceProbe.queryMarketplace({
+    extensionId: "samchon.ttsc",
+    fetchImpl,
+  });
+  assert.equal(readiness.extensionId, "samchon.ttsc");
+  assert.equal(readiness.publisher, "samchon");
+  assert.equal(readiness.name, "ttsc");
+  assert.equal(readiness.version, "0.19.5");
+
+  for (let retry = 0; retry < 2; retry++) {
+    const exact = await marketplaceProbe.queryMarketplace({
+      extensionId: "samchon.ttsc",
+      version: "0.19.4",
+      fetchImpl,
+    });
+    assert.equal(exact.version, "0.19.4");
+    assert.deepEqual(exact.versions, ["0.19.5", "0.19.4"]);
+  }
+  assert.equal(queryBodies.length, 3);
+  for (const body of queryBodies)
+    assert.equal(
+      body.flags,
+      1,
+      "the query must include all versions, not only the latest",
+    );
+};

--- a/tests/test-ttsc/src/features/platform/test_marketplace_probe_rejects_malformed_extension_ids.ts
+++ b/tests/test-ttsc/src/features/platform/test_marketplace_probe_rejects_malformed_extension_ids.ts
@@ -1,0 +1,45 @@
+import {
+  marketplaceProbe,
+  silentLogger,
+} from "../../internal/marketplace-probe";
+import { assert } from "../../internal/toolchain";
+
+/**
+ * Verifies malformed Marketplace extension identifiers fail before querying.
+ *
+ * The exact-name Gallery filter accepts arbitrary strings, but a release gate
+ * must not normalize whitespace, path separators, empty components, or extra
+ * components into another extension identity.
+ *
+ * 1. Pass malformed publisher/name combinations to the bounded waiter.
+ * 2. Supply a fetch implementation that records any attempted request.
+ * 3. Assert every identifier fails validation without network access.
+ */
+export const test_marketplace_probe_rejects_malformed_extension_ids =
+  async () => {
+    let attempts = 0;
+    for (const extensionId of [
+      "",
+      ".ttsc",
+      "samchon.",
+      "samchon.ttsc.extra",
+      "samchon/ttsc",
+      " samchon.ttsc",
+      "samchon.ttsc ",
+      "sam_chon.ttsc",
+    ])
+      await assert.rejects(
+        marketplaceProbe.waitForMarketplace({
+          extensionId,
+          timeoutMs: 1_000,
+          intervalMs: 1,
+          logger: silentLogger,
+          fetchImpl: async () => {
+            attempts += 1;
+            throw new Error("fetch must not run");
+          },
+        }),
+        /must be exactly <publisher>\.<name>/,
+      );
+    assert.equal(attempts, 0);
+  };

--- a/tests/test-ttsc/src/features/platform/test_marketplace_probe_rejects_malformed_gallery_response.ts
+++ b/tests/test-ttsc/src/features/platform/test_marketplace_probe_rejects_malformed_gallery_response.ts
@@ -1,0 +1,36 @@
+import {
+  marketplaceProbe,
+  silentLogger,
+} from "../../internal/marketplace-probe";
+import { assert } from "../../internal/toolchain";
+
+/**
+ * Verifies malformed public Gallery data fails without retrying.
+ *
+ * A successful HTTP status is not evidence of publication when its JSON or
+ * result shape cannot prove the exact extension identity and version. Retrying
+ * a structurally invalid response would hide an API-contract change until the
+ * deadline instead of failing the release with the actual cause.
+ *
+ * 1. Return HTTP 200 with invalid JSON from the injected public query.
+ * 2. Run the bounded waiter with a retry-capable deadline.
+ * 3. Assert it rejects as malformed after exactly one request.
+ */
+export const test_marketplace_probe_rejects_malformed_gallery_response =
+  async () => {
+    let attempts = 0;
+    await assert.rejects(
+      marketplaceProbe.waitForMarketplace({
+        extensionId: "samchon.ttsc",
+        timeoutMs: 1_000,
+        intervalMs: 1,
+        logger: silentLogger,
+        fetchImpl: async () => {
+          attempts += 1;
+          return new Response("{", { status: 200 });
+        },
+      }),
+      /malformed JSON/,
+    );
+    assert.equal(attempts, 1);
+  };

--- a/tests/test-ttsc/src/features/platform/test_marketplace_probe_rejects_unrelated_extension.ts
+++ b/tests/test-ttsc/src/features/platform/test_marketplace_probe_rejects_unrelated_extension.ts
@@ -1,0 +1,38 @@
+import {
+  galleryPayload,
+  jsonResponse,
+  marketplaceProbe,
+  silentLogger,
+} from "../../internal/marketplace-probe";
+import { assert } from "../../internal/toolchain";
+
+/**
+ * Verifies an exact-name query cannot pass on an unrelated extension.
+ *
+ * The Gallery query is only a release assertion if the response publisher and
+ * extension name independently match `samchon.ttsc`. Trusting the filter alone
+ * could turn a server-side broad match into a false-positive publication gate.
+ *
+ * 1. Query `samchon.ttsc` while returning another publisher/name record.
+ * 2. Give the waiter a deadline that would otherwise permit retries.
+ * 3. Assert the identity mismatch fails terminally after one request.
+ */
+export const test_marketplace_probe_rejects_unrelated_extension = async () => {
+  let attempts = 0;
+  await assert.rejects(
+    marketplaceProbe.waitForMarketplace({
+      extensionId: "samchon.ttsc",
+      timeoutMs: 1_000,
+      intervalMs: 1,
+      logger: silentLogger,
+      fetchImpl: async () => {
+        attempts += 1;
+        return jsonResponse(
+          galleryPayload("another-publisher", "another-name", ["0.19.4"]),
+        );
+      },
+    }),
+    /returned unrelated extension/,
+  );
+  assert.equal(attempts, 1);
+};

--- a/tests/test-ttsc/src/features/platform/test_marketplace_probe_retries_transient_failures.ts
+++ b/tests/test-ttsc/src/features/platform/test_marketplace_probe_retries_transient_failures.ts
@@ -1,0 +1,85 @@
+import { createServer } from "node:http";
+
+import {
+  galleryPayload,
+  marketplaceProbe,
+  silentLogger,
+} from "../../internal/marketplace-probe";
+import { assert } from "../../internal/toolchain";
+
+/**
+ * Verifies transient failures retry through a real local HTTP endpoint.
+ *
+ * Network errors, rate limits, server failures, and propagation gaps are all
+ * expected temporary states around Marketplace publication. The probe must
+ * retry them while preserving the exact query and only pass when the requested
+ * publisher/name/version becomes public.
+ *
+ * 1. Inject one network failure, then serve 429, 503, empty, and exact results.
+ * 2. Run the waiter against an ephemeral local HTTP Gallery server.
+ * 3. Assert the fifth attempt succeeds and every request used the exact filter.
+ */
+export const test_marketplace_probe_retries_transient_failures = async () => {
+  const requestBodies: unknown[] = [];
+  let serverAttempts = 0;
+  const server = createServer(async (request, response) => {
+    let body = "";
+    for await (const chunk of request) body += chunk;
+    requestBodies.push(JSON.parse(body));
+    serverAttempts += 1;
+
+    if (serverAttempts === 1) {
+      response.writeHead(429);
+      response.end();
+    } else if (serverAttempts === 2) {
+      response.writeHead(503);
+      response.end();
+    } else {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(
+        JSON.stringify(
+          serverAttempts === 3
+            ? { results: [{ extensions: [] }] }
+            : galleryPayload("samchon", "ttsc", ["0.19.4"]),
+        ),
+      );
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  try {
+    const address = server.address();
+    assert.ok(address !== null && typeof address === "object");
+    let fetchAttempts = 0;
+    const result = await marketplaceProbe.waitForMarketplace({
+      extensionId: "samchon.ttsc",
+      version: "0.19.4",
+      endpoint: `http://127.0.0.1:${address.port}`,
+      timeoutMs: 5_000,
+      intervalMs: 1,
+      logger: silentLogger,
+      fetchImpl: async (input, init) => {
+        fetchAttempts += 1;
+        if (fetchAttempts === 1) throw new Error("simulated socket reset");
+        return fetch(input, init);
+      },
+    });
+
+    assert.equal(result.version, "0.19.4");
+    assert.equal(result.attempts, 5);
+    assert.equal(fetchAttempts, 5);
+    assert.equal(serverAttempts, 4);
+    assert.equal(requestBodies.length, 4);
+    for (const body of requestBodies) {
+      assert.equal((body as any).filters[0].criteria[0].filterType, 7);
+      assert.equal((body as any).filters[0].criteria[0].value, "samchon.ttsc");
+    }
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+};

--- a/tests/test-ttsc/src/features/platform/test_marketplace_probe_stops_at_bounded_deadline.ts
+++ b/tests/test-ttsc/src/features/platform/test_marketplace_probe_stops_at_bounded_deadline.ts
@@ -1,0 +1,41 @@
+import {
+  jsonResponse,
+  marketplaceProbe,
+  silentLogger,
+} from "../../internal/marketplace-probe";
+import { assert } from "../../internal/toolchain";
+
+/**
+ * Verifies an absent public extension fails at a bounded deadline.
+ *
+ * Empty Gallery results can be transient during propagation and therefore merit
+ * retries, but publication must never wait without a fixed upper bound. A fake
+ * clock makes both the retry count and final deadline deterministic.
+ *
+ * 1. Return an empty valid Gallery result for every public query.
+ * 2. Advance an injected clock by each requested retry delay.
+ * 3. Assert failure occurs at 25 ms after four attempts and no overshoot.
+ */
+export const test_marketplace_probe_stops_at_bounded_deadline = async () => {
+  let now = 0;
+  let attempts = 0;
+  await assert.rejects(
+    marketplaceProbe.waitForMarketplace({
+      extensionId: "samchon.ttsc",
+      timeoutMs: 25,
+      intervalMs: 10,
+      now: () => now,
+      sleep: async (milliseconds) => {
+        now += milliseconds;
+      },
+      logger: silentLogger,
+      fetchImpl: async () => {
+        attempts += 1;
+        return jsonResponse({ results: [{ extensions: [] }] });
+      },
+    }),
+    /was not publicly served within 25 ms after 4 attempt\(s\)/,
+  );
+  assert.equal(attempts, 4);
+  assert.equal(now, 25);
+};

--- a/tests/test-ttsc/src/features/platform/test_release_workflow_runs_preflight_before_publication.ts
+++ b/tests/test-ttsc/src/features/platform/test_release_workflow_runs_preflight_before_publication.ts
@@ -1,26 +1,25 @@
 import { assert, fs, path, workspaceRoot } from "../../internal/toolchain";
 
 /**
- * Verifies the release workflow runs the preflight gate before any publication.
+ * Verifies release gates surround Marketplace publication before npm.
  *
- * Locks the ordering in `.github/workflows/release.yml`. The preflight script
- * is only a real gate if it executes before the first external mutation, so a
- * future edit that moves publication ahead of the preflight must fail here. The
- * negative twin is the publication commands themselves: their positions in the
- * workflow text must all come after the preflight invocation.
+ * Locks the ordering in `.github/workflows/release.yml`. Public Marketplace
+ * readiness must be proven before build or credential use, and the tagged
+ * version must be anonymously served after Marketplace publication but before
+ * the irreversible npm publication.
  *
  * Order is a property of what the workflow runs, so the comments come out
- * first. #726 documented the runner's disk reclaim in prose that names
- * `pnpm run build`, several lines above the step that invokes it, and a raw
- * text scan read that sentence as the build itself and reported it running
- * before the preflight. The workflow was correct and this gate was not. Prose
- * about a command is not the command, and a gate that cannot tell them apart
- * fails on the next comment that mentions one.
+ * first. #726 documented the runner's disk reclaim in prose that names `pnpm
+ * run build`, several lines above the step that invokes it, and a raw text scan
+ * read that sentence as the build itself and reported it running before the
+ * preflight. The workflow was correct and this gate was not. Prose about a
+ * command is not the command, and a gate that cannot tell them apart fails on
+ * the next comment that mentions one.
  *
  * 1. Read the release workflow and drop its comment lines.
- * 2. Locate the preflight invocation and each publication command.
- * 3. Assert the preflight appears exactly once and strictly before the build,
- *    the Marketplace publish, the npm publish, and the first credential use.
+ * 2. Locate both preflights, both publications, and the exact-version gate.
+ * 3. Assert readiness precedes every mutation and exact verification sits strictly
+ *    between Marketplace and npm publication.
  */
 export const test_release_workflow_runs_preflight_before_publication = () => {
   const source = fs.readFileSync(
@@ -42,6 +41,26 @@ export const test_release_workflow_runs_preflight_before_publication = () => {
     "release-preflight.cjs must be invoked exactly once",
   );
 
+  const marketplaceProbe = "scripts/assert-marketplace-version.cjs";
+  const readiness = workflow.indexOf(marketplaceProbe);
+  const exactVersion = workflow.indexOf(marketplaceProbe, readiness + 1);
+  assert.notEqual(readiness, -1, "Marketplace readiness gate is missing");
+  assert.notEqual(
+    exactVersion,
+    -1,
+    "Marketplace exact-version gate is missing",
+  );
+  assert.equal(
+    workflow.indexOf(marketplaceProbe, exactVersion + 1),
+    -1,
+    "Marketplace probe must be invoked exactly twice",
+  );
+  assert.match(
+    workflow.slice(exactVersion, workflow.indexOf("\n", exactVersion)),
+    /--version "\$\{GITHUB_REF_NAME#v\}"/,
+    "post-publish gate must query the tagged release version",
+  );
+
   const marketplacePublish = workflow.indexOf("publish-vscode-marketplace.sh");
   const npmPublish = workflow.indexOf("package:latest:publish");
   const credential = workflow.indexOf("VSCE_PAT");
@@ -55,8 +74,20 @@ export const test_release_workflow_runs_preflight_before_publication = () => {
   ] as Array<[string, number]>) {
     assert.notEqual(index, -1, `expected to find ${label} step`);
     assert.ok(
-      preflight < index,
-      `preflight (index ${preflight}) must run before ${label} (index ${index})`,
+      readiness < index,
+      `readiness (index ${readiness}) must run before ${label} (index ${index})`,
     );
   }
+  assert.ok(
+    preflight < readiness,
+    "deterministic release preflight must run before public readiness",
+  );
+  assert.ok(
+    marketplacePublish < exactVersion,
+    "exact-version gate must run after Marketplace publication",
+  );
+  assert.ok(
+    exactVersion < npmPublish,
+    "exact-version gate must run before npm publication",
+  );
 };

--- a/tests/test-ttsc/src/internal/marketplace-probe.ts
+++ b/tests/test-ttsc/src/internal/marketplace-probe.ts
@@ -1,0 +1,68 @@
+import { path, requireFromTest, workspaceRoot } from "./toolchain";
+
+interface MarketplaceProbeResult {
+  attempts: number;
+  elapsedMs: number;
+  extensionId: string;
+  publisher: string;
+  name: string;
+  version: string;
+  versions: string[];
+}
+
+interface MarketplaceQueryOptions {
+  extensionId: string;
+  version?: string;
+  endpoint?: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+}
+
+interface MarketplaceWaitOptions extends MarketplaceQueryOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+  logger?: { warn: (message: string) => void };
+}
+
+interface MarketplaceProbeModule {
+  queryMarketplace(
+    options: MarketplaceQueryOptions,
+  ): Promise<Omit<MarketplaceProbeResult, "attempts" | "elapsedMs">>;
+  waitForMarketplace(
+    options: MarketplaceWaitOptions,
+  ): Promise<MarketplaceProbeResult>;
+}
+
+const marketplaceProbe = requireFromTest(
+  path.join(workspaceRoot, "scripts", "assert-marketplace-version.cjs"),
+) as MarketplaceProbeModule;
+
+const galleryPayload = (
+  publisher: string,
+  name: string,
+  versions: string[],
+) => ({
+  results: [
+    {
+      extensions: [
+        {
+          extensionName: name,
+          publisher: { publisherName: publisher },
+          versions: versions.map((version) => ({ version })),
+        },
+      ],
+    },
+  ],
+});
+
+const jsonResponse = (payload: unknown, status = 200): Response =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const silentLogger = { warn: (_message: string) => undefined };
+
+export { galleryPayload, jsonResponse, marketplaceProbe, silentLogger };


### PR DESCRIPTION
## Intent

Make a release fail closed unless the advertised VS Code Marketplace channel is publicly reachable before any publication and serves the exact tagged version after `vsce publish`.

## Verified premise

Anonymous exact-name Gallery queries currently return no `samchon.ttsc` extension, while `esbenp.prettier-vscode` resolves with its full version history. The release workflow records `vsce publish` success but never verifies the public result.

The available evidence does **not** establish that every historical Marketplace publish was a silent no-op. The extension may have been public and later unpublished or hidden. This pull request owns the current public absence and the missing release-safety invariant, not that stronger historical claim.

## Scope

- Add a dependency-free Marketplace probe with strict response and identifier validation, exact extension/version matching, bounded retry, and fail-closed errors.
- Query all served versions so a legitimate `--skip-duplicate` retry of an older public version succeeds even when a newer version exists.
- Check that the established public channel is reachable before external publication.
- Check that the exact tagged version is publicly served after Marketplace publication and before npm publication.
- Add deterministic positive, negative, malformed, transient-failure, deadline, and workflow-ordering coverage.

## Deferred

- Restoring, publishing, unpublishing, or inspecting the extension in the owner-only Marketplace portal.
- Choosing whether the Marketplace channel is retained or removed.
- Changing Marketplace installation documentation.
- Closing #854; its product decision remains open.

## Verification

- `pnpm --filter @ttsc/test-ttsc start -- '--include=marketplace_probe,release_workflow_runs_preflight_before_publication'` — 7/7 passed.
- Changed TypeScript files passed an isolated strict `tsc --noEmit` check.
- `pnpm run assert:project-layout` — passed.
- `node --check scripts/assert-marketplace-version.cjs` — passed.
- Public control: `esbenp.prettier-vscode@12.3.0` passed, proving historical served versions are visible.
- Current negative: `samchon.ttsc` remained absent and failed after the bounded retry window.
- `pnpm run test:typecheck` could not complete because the existing unbuilt `@ttsc/graph` declarations are absent; it failed before reaching `test-ttsc` and reported only those unrelated imports.

Refs #854