### PR TITLE
fix(ttsc): honor no-emit in single-file mode

### DIFF
--- a/packages/ttsc/src/launcher/internal/runTtsc.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsc.ts
@@ -109,7 +109,7 @@ type TtscMode = "build" | "check" | "fix" | "format";
 
 function runCompatibleBuild(argv: readonly string[], mode: TtscMode): number {
   const checkOnly = mode !== "build";
-  const options = normalizeBuildOptions(parseBuildArgs(argv, checkOnly));
+  const options = normalizeBuildOptions(parseBuildArgs(argv));
   if (mode === "fix") {
     if (options.emit === true) {
       throw new Error("ttsc: fix and --emit are mutually exclusive");
@@ -137,16 +137,17 @@ function runCompatibleBuild(argv: readonly string[], mode: TtscMode): number {
     }
     return runWatch(options, checkOnly);
   }
-  if (options.files.length !== 0) {
+  const buildOptions = checkOnly ? { ...options, emit: false } : options;
+  if (buildOptions.files.length !== 0) {
     if (mode === "fix") {
       throw new Error("ttsc: fix requires a project, not single-file mode");
     }
     if (mode === "format") {
       throw new Error("ttsc: format requires a project, not single-file mode");
     }
-    return runSingleFile(options);
+    return runSingleFile(buildOptions);
   }
-  const result = runBuild(checkOnly ? { ...options, emit: false } : options);
+  const result = runBuild(buildOptions);
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);
   return result.status;
@@ -414,7 +415,7 @@ function parseProjectArgs(argv: readonly string[]) {
   };
 }
 
-function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
+function parseBuildArgs(argv: readonly string[]) {
   const result = parseFlags({
     argv,
     errorPrefix: "ttsc:",
@@ -427,17 +428,15 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
     subcommand: "build",
   });
   // Defaults: pinned by the previous hand-parser. `quiet` defaults true,
-  // `--verbose` flips it to false; `emit` defaults `undefined` in build
-  // mode (let tsconfig decide) and `false` in check/fix/format mode.
+  // `--verbose` flips it to false; `emit` defaults `undefined` so the resolved
+  // project controls ordinary build mode. `runCompatibleBuild` applies the
+  // check/fix/format no-emit decision before either execution lane runs.
   const verbose = getBoolean(result, "--verbose");
   const quietFlag = getBoolean(result, "--quiet");
   const quiet = verbose === true ? false : (quietFlag ?? true);
   const explicitEmit = getBoolean(result, "--emit");
   const explicitNoEmit = getBoolean(result, "--noEmit");
-  let emit: boolean | undefined;
-  if (explicitEmit === true) emit = true;
-  else if (explicitNoEmit === true) emit = false;
-  if (emit === undefined && checkOnly) emit = false;
+  const emit = resolveExplicitEmit(explicitEmit, explicitNoEmit);
 
   // `isPositional: looksLikeInputFile` guarantees every `result.positional`
   // token is a TypeScript input file; forwarded flag values already live in
@@ -464,6 +463,21 @@ function parseBuildArgs(argv: readonly string[], checkOnly: boolean) {
     tsconfig: getString(result, "--tsconfig"),
     watch: getBoolean(result, "--watch") === true,
   };
+}
+
+/**
+ * Collapse the two launcher-owned emit switches into the tri-state consumed by
+ * `runBuild` and the single-file lane. A specified boolean is significant even
+ * when it is `false`: `--emit=false` is analysis-only and `--noEmit=false`
+ * explicitly overrides a project's `noEmit`. `--emit` retains precedence when
+ * callers supply both switches, matching the legacy true-only resolution.
+ */
+function resolveExplicitEmit(
+  explicitEmit: boolean | undefined,
+  explicitNoEmit: boolean | undefined,
+): boolean | undefined {
+  if (explicitEmit !== undefined) return explicitEmit;
+  return explicitNoEmit === undefined ? undefined : !explicitNoEmit;
 }
 
 /**
@@ -557,12 +571,15 @@ function runSingleFile(options: ReturnType<typeof parseBuildArgs>): number {
   }
   const cwd = path.resolve(options.cwd ?? process.cwd());
   const file = path.resolve(cwd, options.files[0]!);
-  const out = resolveSingleFileOut({
-    cliOutDir: options.outDir,
-    cwd,
-    file,
-    tsconfig: options.tsconfig,
-  });
+  const emit = singleFileShouldEmit(options, cwd, file);
+  const out = emit
+    ? resolveSingleFileOut({
+        cliOutDir: options.outDir,
+        cwd,
+        file,
+        tsconfig: options.tsconfig,
+      })
+    : undefined;
   const text = runSingleFileEmit({
     binary: options.binary,
     checkers: options.checkers,
@@ -573,12 +590,35 @@ function runSingleFile(options: ReturnType<typeof parseBuildArgs>): number {
     singleThreaded: options.singleThreaded,
     tsconfig: options.tsconfig,
   });
-  if (!fs.existsSync(out)) {
+  if (out !== undefined && !fs.existsSync(out)) {
     fs.mkdirSync(path.dirname(out), { recursive: true });
     fs.writeFileSync(out, text, "utf8");
   }
-  process.stdout.write(`${path.relative(cwd, out) || path.basename(out)}\n`);
+  if (out !== undefined) {
+    process.stdout.write(`${path.relative(cwd, out) || path.basename(out)}\n`);
+  }
   return 0;
+}
+
+/**
+ * Resolve the same effective emit decision used by the project lane before
+ * entering the single-file compatibility path. The compatibility path still
+ * emits into a private temporary directory to obtain transformed text and
+ * diagnostics, but only this boundary is allowed to write into the user's
+ * tree.
+ */
+function singleFileShouldEmit(
+  options: ReturnType<typeof parseBuildArgs>,
+  cwd: string,
+  file: string,
+): boolean {
+  if (options.emit !== undefined) return options.emit;
+  const project = readProjectConfig({
+    cwd,
+    file,
+    tsconfig: options.tsconfig,
+  });
+  return project.compilerOptions.noEmit !== true;
 }
 
 function resolveSingleFileOut(opts: {
@@ -683,7 +723,7 @@ function runWatch(
   const cwd = path.resolve(options.cwd ?? process.cwd());
   let topology: WatchTopology | undefined;
   const invocation = {
-    ...options,
+    ...(checkOnly ? { ...options, emit: false } : options),
     cwd,
     onWatchInputs: (inputs: readonly string[]) => {
       topology?.setExtraInputs(inputs);

--- a/tests/test-ttsc/src/native-plugins/compiler/test_compiler_corpus_explicit_emit_booleans_control_project_mode.ts
+++ b/tests/test-ttsc/src/native-plugins/compiler/test_compiler_corpus_explicit_emit_booleans_control_project_mode.ts
@@ -1,0 +1,53 @@
+import {
+  assert,
+  commonJsProject,
+  fs,
+  path,
+  spawn,
+  ttscBin,
+} from "../../internal/compiler-corpus";
+
+/**
+ * Verifies compiler corpus: explicit emit booleans control project mode.
+ *
+ * The launcher consumes `--emit` and `--noEmit` before invoking the project
+ * lane, so dropping an explicit `false` silently changes the build decision.
+ * These twins prove both false forms remain meaningful after parsing.
+ *
+ * 1. Run `--emit=false` against a normally emitting project.
+ * 2. Run `--noEmit=false` against a `noEmit` project.
+ * 3. Assert the first writes nothing and the second explicitly restores output.
+ */
+export const test_compiler_corpus_explicit_emit_booleans_control_project_mode =
+  (): void => {
+    const disabledRoot = commonJsProject({
+      "src/main.ts": `export const value: number = 1;\n`,
+    });
+    const disabled = spawn(
+      ttscBin,
+      ["--cwd", disabledRoot, "--emit=false"],
+      { cwd: disabledRoot },
+    );
+    assert.equal(disabled.status, 0, disabled.stderr);
+    assert.equal(
+      fs.existsSync(path.join(disabledRoot, "dist", "main.js")),
+      false,
+    );
+
+    const enabledRoot = commonJsProject(
+      {
+        "src/main.ts": `export const value: number = 1;\n`,
+      },
+      { compilerOptions: { noEmit: true } },
+    );
+    const enabled = spawn(
+      ttscBin,
+      ["--cwd", enabledRoot, "--noEmit=false"],
+      { cwd: enabledRoot },
+    );
+    assert.equal(enabled.status, 0, enabled.stderr);
+    assert.equal(
+      fs.existsSync(path.join(enabledRoot, "dist", "main.js")),
+      true,
+    );
+  };

--- a/tests/test-ttsc/src/native-plugins/compiler/test_compiler_corpus_single_file_honors_tsconfig_noemit_without_outdir.ts
+++ b/tests/test-ttsc/src/native-plugins/compiler/test_compiler_corpus_single_file_honors_tsconfig_noemit_without_outdir.ts
@@ -1,0 +1,52 @@
+import {
+  assert,
+  createProject,
+  fs,
+  path,
+  spawn,
+  ttscBin,
+} from "../../internal/compiler-corpus";
+
+/**
+ * Verifies compiler corpus: single-file mode honors tsconfig noEmit without outDir.
+ *
+ * Without an `outDir`, the compatibility lane's fallback would write a JavaScript
+ * sibling beside the source. A resolved `noEmit` must suppress that write, while
+ * explicit `--emit` retains the project lane's documented override.
+ *
+ * 1. Materialize a no-emit project without an output directory.
+ * 2. Run one positional file and assert its JavaScript sibling is absent.
+ * 3. Repeat with `--emit` and assert the sibling is intentionally written.
+ */
+export const test_compiler_corpus_single_file_honors_tsconfig_noemit_without_outdir =
+  (): void => {
+    const root = createProject({
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          module: "commonjs",
+          noEmit: true,
+          rootDir: "src",
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src"],
+      }),
+      "src/main.ts": `export const value: number = 1;\n`,
+    });
+    const output = path.join(root, "src", "main.js");
+
+    const suppressed = spawn(ttscBin, ["--cwd", root, "src/main.ts"], {
+      cwd: root,
+    });
+    assert.equal(suppressed.status, 0, suppressed.stderr);
+    assert.equal(fs.existsSync(output), false);
+    assert.equal(suppressed.stdout.includes("main.js"), false);
+
+    const override = spawn(
+      ttscBin,
+      ["--cwd", root, "--emit", "src/main.ts"],
+      { cwd: root },
+    );
+    assert.equal(override.status, 0, override.stderr);
+    assert.equal(fs.existsSync(output), true);
+  };

--- a/tests/test-ttsc/src/native-plugins/compiler/test_compiler_corpus_single_file_noemit_forms_leave_tree_unchanged.ts
+++ b/tests/test-ttsc/src/native-plugins/compiler/test_compiler_corpus_single_file_noemit_forms_leave_tree_unchanged.ts
@@ -1,0 +1,71 @@
+import {
+  assert,
+  commonJsProject,
+  fs,
+  path,
+  spawn,
+  ttscBin,
+} from "../../internal/compiler-corpus";
+
+const cases = [
+  {
+    name: "--noEmit",
+    argv: (root: string) => ["--cwd", root, "--noEmit", "src/main.ts"],
+  },
+  {
+    name: "check",
+    argv: (root: string) => ["check", "--cwd", root, "src/main.ts"],
+  },
+  {
+    name: "--emit=false",
+    argv: (root: string) => [
+      "--cwd",
+      root,
+      "--emit=false",
+      "src/main.ts",
+    ],
+  },
+  {
+    name: "--noEmit=true",
+    argv: (root: string) => [
+      "--cwd",
+      root,
+      "--noEmit=true",
+      "src/main.ts",
+    ],
+  },
+] as const;
+
+/**
+ * Verifies compiler corpus: single-file no-emit forms leave the tree unchanged.
+ *
+ * `runSingleFileEmit` needs a private temporary emit to return transformed text,
+ * but none of the analysis-only forms may turn that text into a user-visible
+ * output. The four forms cover the command alias and both boolean spellings at
+ * the launcher boundary.
+ *
+ * 1. Materialize an otherwise-emitting CommonJS project for each no-emit form.
+ * 2. Run that form with one TypeScript input file.
+ * 3. Assert the expected JavaScript file and emitted-file stdout line are absent.
+ */
+export const test_compiler_corpus_single_file_noemit_forms_leave_tree_unchanged =
+  (): void => {
+    for (const current of cases) {
+      const root = commonJsProject({
+        "src/main.ts": `export const value: number = 1;\n`,
+      });
+      const result = spawn(ttscBin, current.argv(root), { cwd: root });
+      const output = path.join(root, "dist", "main.js");
+      assert.equal(result.status, 0, `${current.name}: ${result.stderr}`);
+      assert.equal(
+        fs.existsSync(output),
+        false,
+        `${current.name} must not write ${output}`,
+      );
+      assert.equal(
+        result.stdout.includes("dist"),
+        false,
+        `${current.name} must not print an emitted file path: ${result.stdout}`,
+      );
+    }
+  };

--- a/tests/test-ttsc/src/native-plugins/compiler/test_compiler_corpus_single_file_noemit_preserves_diagnostics.ts
+++ b/tests/test-ttsc/src/native-plugins/compiler/test_compiler_corpus_single_file_noemit_preserves_diagnostics.ts
@@ -1,0 +1,37 @@
+import {
+  assert,
+  commonJsProject,
+  fs,
+  path,
+  spawn,
+  ttscBin,
+} from "../../internal/compiler-corpus";
+
+/**
+ * Verifies compiler corpus: single-file no-emit preserves diagnostics.
+ *
+ * Suppressing the final user-tree write must not skip the temporary compiler
+ * pass that detects type errors. This pins the failed-build path rather than
+ * only a clean analysis-only invocation.
+ *
+ * 1. Materialize a project with one type-invalid source file.
+ * 2. Run that file through single-file `--noEmit`.
+ * 3. Assert a TypeScript diagnostic and non-zero exit with no JavaScript output.
+ */
+export const test_compiler_corpus_single_file_noemit_preserves_diagnostics =
+  (): void => {
+    const root = commonJsProject({
+      "src/broken.ts": `const value: number = "not a number";\n`,
+    });
+    const result = spawn(
+      ttscBin,
+      ["--cwd", root, "--noEmit", "src/broken.ts"],
+      { cwd: root },
+    );
+    assert.notEqual(result.status, 0, "invalid TypeScript must fail");
+    assert.match(`${result.stdout}${result.stderr}`, /TS2322/);
+    assert.equal(
+      fs.existsSync(path.join(root, "dist", "broken.js")),
+      false,
+    );
+  };

--- a/tests/test-ttsc/src/native-plugins/compiler/test_compiler_corpus_single_file_noemit_watch_rebuilds_without_writes.ts
+++ b/tests/test-ttsc/src/native-plugins/compiler/test_compiler_corpus_single_file_noemit_watch_rebuilds_without_writes.ts
@@ -1,0 +1,110 @@
+import {
+  assert,
+  child_process,
+  commonJsProject,
+  fs,
+  nativeBinary,
+  path,
+  tsgoBinary,
+  ttscBin,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies compiler corpus: single-file no-emit watch rebuilds without writes.
+ *
+ * `runWatch` owns a second single-file dispatch, so a correct one-shot path is
+ * insufficient. Both documented analysis-only watch forms must stay write-free
+ * for the initial build and a real source-triggered rebuild.
+ *
+ * 1. Start each real watch form against a normally emitting single-file project.
+ * 2. Wait for its initial build, verify no output, then modify the source.
+ * 3. Verify the rebuilt session still wrote nothing and exits on SIGTERM.
+ */
+export const test_compiler_corpus_single_file_noemit_watch_rebuilds_without_writes =
+  async (): Promise<void> => {
+    for (const argv of [
+      ["--noEmit", "--watch"],
+      ["check", "--watch"],
+    ]) {
+      const root = commonJsProject({
+        "src/main.ts": `export const value: number = 1;\n`,
+      });
+      await watchWithoutWriting(root, argv);
+    }
+  };
+
+async function watchWithoutWriting(
+  root: string,
+  mode: readonly string[],
+): Promise<void> {
+  const output = path.join(root, "dist", "main.js");
+  const child = child_process.spawn(
+    process.execPath,
+    [
+      ttscBin,
+      ...mode,
+      "--preserveWatchOutput",
+      "--cwd",
+      root,
+      "src/main.ts",
+    ],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        TTSC_BINARY: nativeBinary,
+        TTSC_TSGO_BINARY: tsgoBinary,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    },
+  );
+
+  let transcript = "";
+  let mutated = false;
+  let stopped = false;
+  const exit = new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`single-file watch did not settle:\n${transcript}`));
+    }, 120_000);
+    child.on("close", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+  const onChunk = (chunk: Buffer): void => {
+    transcript += chunk.toString("utf8");
+    const completed =
+      transcript.match(/\[ttsc\] watch build complete/g)?.length ?? 0;
+    if (!mutated && completed >= 1) {
+      assert.equal(fs.existsSync(output), false, `${mode[0]} wrote ${output}`);
+      mutated = true;
+      fs.writeFileSync(
+        path.join(root, "src", "main.ts"),
+        `export const value: number = 2;\n`,
+        "utf8",
+      );
+      return;
+    }
+    if (mutated && !stopped && completed >= 2) {
+      assert.equal(
+        fs.existsSync(output),
+        false,
+        `${mode[0]} wrote ${output} after rebuilding`,
+      );
+      stopped = true;
+      child.kill("SIGTERM");
+    }
+  };
+  child.stdout.on("data", onChunk);
+  child.stderr.on("data", onChunk);
+  await exit;
+
+  assert.equal(stopped, true, `watch did not rebuild:\n${transcript}`);
+  assert.equal(fs.existsSync(output), false, `${mode[0]} wrote ${output}`);
+}

--- a/tests/test-ttsc/src/native-plugins/compiler/test_compiler_corpus_single_file_noemit_watch_rebuilds_without_writes.ts
+++ b/tests/test-ttsc/src/native-plugins/compiler/test_compiler_corpus_single_file_noemit_watch_rebuilds_without_writes.ts
@@ -1,12 +1,14 @@
 import {
   assert,
-  child_process,
   commonJsProject,
   fs,
-  nativeBinary,
   path,
-  tsgoBinary,
   ttscBin,
+} from "../../internal/compiler-corpus";
+import {
+  child_process,
+  nativeBinary,
+  tsgoBinary,
 } from "../../internal/toolchain";
 
 /**

--- a/website/src/content/docs/ttsc/compile.mdx
+++ b/website/src/content/docs/ttsc/compile.mdx
@@ -67,8 +67,8 @@ npx ttsc clean                      # drop the plugin cache
 | `-p, --project <file>` | tsconfig file. Same as `--tsconfig`. |
 | `--tsconfig <file>` | tsconfig file. |
 | `--cwd <dir>` | Resolve relative paths against this directory. |
-| `--noEmit` | Type-check only, no file writes. |
-| `--emit` | Force emit even when `tsconfig` sets `noEmit: true`. On a plugin build, output stays confined to `outDir`: a source pulled in from outside `rootDir` (e.g. a dependency package's raw `.ts` entry) whose computed output would escape `outDir` is skipped instead of written next to its own source. |
+| `--noEmit` | Type-check only, no file writes, including a positional single-file build and every rebuild under `--watch`. `check` has the same no-write behavior. |
+| `--emit` | Force emit even when `tsconfig` sets `noEmit: true`. `--emit=false` disables writes and `--noEmit=false` explicitly restores them. On a plugin build, output stays confined to `outDir`: a source pulled in from outside `rootDir` (e.g. a dependency package's raw `.ts` entry) whose computed output would escape `outDir` is skipped instead of written next to its own source. |
 | `-w, --watch` | Watch source files and re-check on change. |
 | `--preserveWatchOutput` | Don't clear the screen between watch runs. |
 | `--outDir <dir>` | Override `compilerOptions.outDir`. |

--- a/website/src/content/docs/ttsc/compile.mdx
+++ b/website/src/content/docs/ttsc/compile.mdx
@@ -68,7 +68,7 @@ npx ttsc clean                      # drop the plugin cache
 | `--tsconfig <file>` | tsconfig file. |
 | `--cwd <dir>` | Resolve relative paths against this directory. |
 | `--noEmit` | Type-check only, no file writes, including a positional single-file build and every rebuild under `--watch`. `check` has the same no-write behavior. |
-| `--emit` | Force emit even when `tsconfig` sets `noEmit: true`. `--emit=false` disables writes and `--noEmit=false` explicitly restores them. On a plugin build, output stays confined to `outDir`: a source pulled in from outside `rootDir` (e.g. a dependency package's raw `.ts` entry) whose computed output would escape `outDir` is skipped instead of written next to its own source. |
+| `--emit` | Force emit even when `tsconfig` sets `noEmit: true`. In the `ttsc` and `ttsc build` lanes, `--emit=false` disables writes and `--noEmit=false` explicitly restores them. On a plugin build, output stays confined to `outDir`: a source pulled in from outside `rootDir` (e.g. a dependency package's raw `.ts` entry) whose computed output would escape `outDir` is skipped instead of written next to its own source. |
 | `-w, --watch` | Watch source files and re-check on change. |
 | `--preserveWatchOutput` | Don't clear the screen between watch runs. |
 | `--outDir <dir>` | Override `compilerOptions.outDir`. |


### PR DESCRIPTION
## Reserved issue

Closes #855.

## Scope

Reserve the single-file `ttsc` emit-decision boundary. The implementation will preserve the temporary compiler output needed for diagnostics and transformed text, while suppressing every final user-tree write and emitted-path line when the effective decision is no-emit. It will carry CLI boolean forms, `check`, and resolved `tsconfig` `noEmit` through the normal and watch single-file callers.

## Verification plan

The real `native-plugins/compiler` lane will cover each no-write invocation, the no-`outDir` sibling boundary, diagnostic preservation, both live watch forms, and the explicit `--emit` override. Existing plain and explicit-`--outDir` single-file emit tests remain positive twins. Package build and the targeted compiler corpus are pending implementation.

## Coordination

PR #887 resolved #817 before this reservation. This PR does not include #852, which depends on this no-emit behavior, and does not change graph, plugin protocol, workflow, or Actions configuration. Campaign implementation CI is deliberately cancelled only by exact head SHA; local verification and solo self-review are the merge gates.
