### PR TITLE
test(playground): narrow compiler-client fixture instrumentation

### DIFF
--- a/tests/test-playground/src/features/test_compiler_client_fences_connection_generations.ts
+++ b/tests/test-playground/src/features/test_compiler_client_fences_connection_generations.ts
@@ -141,6 +141,11 @@ export const test_compiler_client_fences_connection_generations = async () => {
     await waitForGates(failureStart + 2);
     gates[failureStart + 1]!.resolve();
     const retryDriver = await retried;
+    assert.ok(
+      "connectorId" in retryDriver &&
+        typeof retryDriver.connectorId === "number",
+      "the controlled driver must expose its numeric connector marker",
+    );
     throwOnClose.add(retryDriver.connectorId);
     await retryClient.reset();
 


### PR DESCRIPTION
## Intent

Restore current `master` typechecking after merged PR #884 added a runtime-valid compiler-client fixture that reads its fake connector marker through the public `ICompilerService` type.

Closes #896

## Scope

- keep `connectorId` owned by the test fake;
- prove and narrow the fake marker before consuming it;
- leave `packages/playground/src` and the public `ICompilerService` contract unchanged;
- retain the full compiler-client runtime regression.

## Coordination

- follow-up to #884 and #802;
- unblocks latest-`master` validation for #890;
- no production API or runtime behavior change is in scope.

## Verification

Claim snapshot only. On baseline `a8288d649d62eb941ac0638b58bb5fb1b7b30abd`:

- `pnpm --filter @ttsc/wasm build:ts` — pass
- `pnpm --filter @ttsc/playground build` — pass
- `pnpm exec tsc -p tests/test-playground/tsconfig.json --noEmit` — fails only with `TS2339` at the test-only `connectorId` read
- `pnpm --filter @ttsc/test-playground start -- --include=compiler_client` — pass

Implementation verification is pending. Repository-wide formatting remains assigned to the campaign's dedicated final cleanup PR, so this follow-up will not absorb unrelated formatter output.
