### PR TITLE
chore(agents): clean campaign temporary assets

### DIFF
--- a/.agents/skills/benchmark/SKILL.md
+++ b/.agents/skills/benchmark/SKILL.md
@@ -19,6 +19,12 @@ Read both only when changing shared fixture infrastructure or a surface that aff
 - Preserve the workload defined by the selected procedure. A faster result obtained by compiling, linting, formatting, indexing, or reading less input is not an optimization.
 - Treat a surprising result as evidence that the change is not yet understood. Inspect the raw report or trace before accepting, explaining away, or patching around it.
 
+## Temporary Asset Cleanup
+
+Each benchmark run must own an exact temporary root. Place run-only worktrees, cloned repositories, indexes, Go build caches, and Go temporary directories below it. For Go commands, set `GOCACHE` and `GOTMPDIR` to run-specific directories rather than the user's shared Go cache or system temp directory.
+
+After a run, retry, aborted attempt, or completed benchmark campaign, preserve the report and any user-authorized fixture change, then remove the run's exact temporary root. First confirm no process still uses it, then verify the directory is absent. Never recursively clean shared `GOCACHE`, `GOMODCACHE`, `GOPATH`, or a broad temp directory. A `--keep-...` option or another explicit user retention request is the only exception; record the retained path and reason.
+
 ## Fixture Changes
 
 Benchmark setup resets local fixture clones to their upstream branch tips. Edit the fixture repository itself, not a clone under a benchmark work directory.

--- a/.agents/skills/issue-campaign/SKILL.md
+++ b/.agents/skills/issue-campaign/SKILL.md
@@ -61,6 +61,6 @@ Use tables for repeated case mappings. Read the rendered issue back and keep its
 
 ## Develop And Repeat The Campaign
 
-Read [development.md](development.md) in full when the user authorizes implementation pull requests or ends a campaign that entered implementation. It owns issue admission, DAG-based batching, immediate claim pull requests, implementation-wave CI cancellation, non-idling implementation and review, worktree cleanup, renewed discovery, the no-format rule, and Post-Campaign Cleanup. It requires cancellation to begin immediately after every implementation-wave remote mutation, but a pending local command or cancellation poll must never make an implementation agent idle; all cancellation records must be complete before merge.
+Read [development.md](development.md) in full when the user authorizes implementation pull requests or ends a campaign that entered implementation. It owns issue admission, DAG-based batching, immediate claim pull requests, implementation-wave CI cancellation, non-idling implementation and review, worktree and scoped Go-temporary-asset cleanup, renewed discovery, the no-format rule, and Post-Campaign Cleanup. It requires cancellation to begin immediately after every implementation-wave remote mutation, but a pending local command or cancellation poll must never make an implementation agent idle; all cancellation records must be complete before merge.
 
 An audit or issue-publication-only campaign does not load this campaign's [implementation procedure](development.md) or mutate repository Actions.

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -51,10 +51,11 @@ Batching follows these rules:
 The agent assigned an admitted batch reserves its surface before installing dependencies or writing implementation code:
 
 1. Create one isolated worktree and topic branch.
-2. Create one implementation-free claim commit with `git commit --allow-empty`.
-3. Push the branch, start its exact-SHA cancellation record, and immediately open a draft claim pull request that overviews the batch scope and links every batched issue. This is an empty reservation pull request, not a request to wait for setup or validation.
-4. Start the pull-request-triggered cancellation record, mark verification as pending, and record the batch, worktree, branch, issues, pull request, and cancellation records in the campaign knowledge base.
-5. Start `pnpm install` asynchronously in the worktree, then begin the source, consequence-surface, and test-design work immediately.
+2. Create `<worktree>/.campaign-tmp/go-cache` and `<worktree>/.campaign-tmp/go-tmp`. Every Go command for that batch must set `GOCACHE` and `GOTMPDIR` to those exact directories. Do not reuse the user's global Go cache or temp directory for campaign-only build assets.
+3. Create one implementation-free claim commit with `git commit --allow-empty`.
+4. Push the branch, start its exact-SHA cancellation record, and immediately open a draft claim pull request that overviews the batch scope and links every batched issue. This is an empty reservation pull request, not a request to wait for setup or validation.
+5. Start the pull-request-triggered cancellation record, mark verification as pending, and record the batch, worktree, branch, issues, pull request, cancellation records, and scoped Go temporary paths in the campaign knowledge base.
+6. Start `pnpm install` asynchronously in the worktree, then begin the source, consequence-surface, and test-design work immediately.
 
 The draft pull request reserves the whole batch before code is written, preventing another contributor from starting overlapping work.
 
@@ -100,8 +101,11 @@ After a pull request merges:
 2. Confirm the worktree has no unpushed or uncommitted work worth preserving.
 3. Run `git worktree remove --force <path>` so ignored build artifacts are deleted too.
 4. Verify the directory no longer exists.
-5. Run `git worktree prune` and delete the local topic branch.
-6. Confirm `git worktree list --porcelain` contains no record of the removed path.
+5. Verify `<path>/.campaign-tmp/go-cache` and `<path>/.campaign-tmp/go-tmp` are gone with the worktree. If the batch recorded another exact Go temporary path, first confirm no command still refers to it, remove only that path, and verify it no longer exists.
+6. Run `git worktree prune` and delete the local topic branch.
+7. Confirm `git worktree list --porcelain` contains no record of the removed path.
+
+Never recursively clean a user's shared `GOCACHE`, `GOMODCACHE`, `GOPATH`, or system temp directory. They can contain another worktree's active build inputs. A worktree that Git has deregistered but failed to delete is still unfinished: after confirming it has no `.git` metadata, no live process, and no retained evidence, remove that exact directory and its recorded scoped Go temporary paths, then verify their absence.
 
 If an assignment ends without a merge, first record retained evidence and confirm the remaining contents are disposable. Then remove its worktree and local branch by the same standard.
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage/
 # Local caches and package archives
 .cache/
 .turbo/
+.campaign-tmp/
 *.tgz
 *.tsbuildinfo
 *.log


### PR DESCRIPTION
Defines per-worktree and per-benchmark temporary roots, isolates Go build cache and temporary directories, requires removal verification, and ignores .campaign-tmp. Validation: targeted Prettier check and git diff --check. Deferred: current pre-reboot orphan directories await the session deletion policy; shared Go cache and temp roots remain untouched.