### PR TITLE
fix(website): mirror the astnav shim in the compiler module

### DIFF
--- a/scripts/ci/website-compiler-module.test.cjs
+++ b/scripts/ci/website-compiler-module.test.cjs
@@ -1,0 +1,109 @@
+const assert = require("node:assert/strict");
+const cp = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const ROOT = path.resolve(__dirname, "../..");
+const WEBSITE_COMPILER = path.join(ROOT, "website", "compiler");
+const SHIM_PREFIX = "github.com/microsoft/typescript-go/shim/";
+
+/**
+ * Read a module with Go's own parser so the regression follows go.mod syntax
+ * instead of maintaining a second, partial parser in JavaScript.
+ */
+function readGoMod(directory) {
+  const result = cp.spawnSync("go", ["mod", "edit", "-json"], {
+    cwd: directory,
+    encoding: "utf8",
+    windowsHide: true,
+  });
+  if (result.error) throw result.error;
+  assert.equal(
+    result.status,
+    0,
+    `go mod edit failed in ${directory}:\n${result.stderr}`,
+  );
+  return JSON.parse(result.stdout);
+}
+
+function locallyReplacedRequiredShims(directory) {
+  const mod = readGoMod(directory);
+  const replacements = new Map(
+    (mod.Replace ?? [])
+      .filter(
+        (entry) =>
+          entry.Old.Path.startsWith(SHIM_PREFIX) &&
+          entry.New.Version === undefined,
+      )
+      .map((entry) => [
+        entry.Old.Path,
+        path.resolve(directory, entry.New.Path),
+      ]),
+  );
+  return (mod.Require ?? [])
+    .map((entry) => entry.Path)
+    .filter((modulePath) => replacements.has(modulePath))
+    .map((modulePath) => [modulePath, replacements.get(modulePath)]);
+}
+
+test("website compiler mirrors every in-tree shim its local modules require", () => {
+  const required = new Map();
+  for (const directory of [
+    path.join(ROOT, "packages", "ttsc"),
+    path.join(ROOT, "packages", "wasm"),
+  ]) {
+    for (const [modulePath, target] of locallyReplacedRequiredShims(
+      directory,
+    )) {
+      const previous = required.get(modulePath);
+      assert.ok(
+        previous === undefined || previous === target,
+        `${modulePath} has conflicting local replacements`,
+      );
+      required.set(modulePath, target);
+    }
+  }
+  const website = readGoMod(WEBSITE_COMPILER);
+  const websiteRequires = new Set(
+    (website.Require ?? []).map((entry) => entry.Path),
+  );
+  const websiteReplaces = new Map(
+    (website.Replace ?? []).map((entry) => [entry.Old.Path, entry.New]),
+  );
+
+  for (const [modulePath, expectedTarget] of [...required.entries()].sort(
+    ([left], [right]) => left.localeCompare(right),
+  )) {
+    assert.ok(
+      websiteRequires.has(modulePath),
+      `website/compiler/go.mod must require ${modulePath}`,
+    );
+    const replacement = websiteReplaces.get(modulePath);
+    assert.ok(
+      replacement,
+      `website/compiler/go.mod must replace ${modulePath}`,
+    );
+    assert.equal(
+      replacement.Version,
+      undefined,
+      `${modulePath} must use an in-tree replacement`,
+    );
+
+    const target = path.resolve(WEBSITE_COMPILER, replacement.Path);
+    assert.equal(
+      target,
+      expectedTarget,
+      `${modulePath} must mirror its local source replacement`,
+    );
+    assert.ok(
+      fs.existsSync(path.join(target, "go.mod")),
+      `${modulePath} replacement has no go.mod at ${target}`,
+    );
+    assert.equal(
+      readGoMod(target).Module.Path,
+      modulePath,
+      `${modulePath} replacement points at a different module`,
+    );
+  }
+});

--- a/scripts/test-go.cjs
+++ b/scripts/test-go.cjs
@@ -23,6 +23,7 @@ const runners = [
 // runner harness and the project Layout contract.
 const harnessTests = [
   path.join(__dirname, "ci", "go-test-runners.test.cjs"),
+  path.join(__dirname, "ci", "website-compiler-module.test.cjs"),
   path.join(__dirname, "assert-project-layout.test.cjs"),
 ];
 

--- a/website/compiler/go.mod
+++ b/website/compiler/go.mod
@@ -12,6 +12,7 @@ go 1.26
 // also lists this module, but its replaces are independent.
 replace (
 	github.com/microsoft/typescript-go/shim/ast => ../../packages/ttsc/shim/ast
+	github.com/microsoft/typescript-go/shim/astnav => ../../packages/ttsc/shim/astnav
 	github.com/microsoft/typescript-go/shim/bundled => ../../packages/ttsc/shim/bundled
 	github.com/microsoft/typescript-go/shim/checker => ../../packages/ttsc/shim/checker
 	github.com/microsoft/typescript-go/shim/compiler => ../../packages/ttsc/shim/compiler
@@ -48,6 +49,7 @@ require (
 	github.com/mackerelio/go-osstat v0.2.7 // indirect
 	github.com/microsoft/typescript-go v0.0.0-20260429010842-56ab4af42157 // indirect
 	github.com/microsoft/typescript-go/shim/ast v0.0.0 // indirect
+	github.com/microsoft/typescript-go/shim/astnav v0.0.0 // indirect
 	github.com/microsoft/typescript-go/shim/bundled v0.0.0 // indirect
 	github.com/microsoft/typescript-go/shim/checker v0.0.0 // indirect
 	github.com/microsoft/typescript-go/shim/core v0.0.0 // indirect


### PR DESCRIPTION
## Intent

Fixes #899.

Restore the website compiler's self-contained Go module graph after #885 added the in-tree `shim/astnav` module to its imported wasm host.

## Scope

- mirror the new `shim/astnav` requirement and local replacement in `website/compiler/go.mod`;
- keep the module metadata exact through Go's own module tooling;
- add a generic regression that proves every locally replaced TypeScript-Go shim required by the imported `packages/ttsc` and `packages/wasm` modules remains mirrored by the website compiler main module;
- leave #890's runtime-hook branch unchanged.

## Verification

Implementation is active. The pre-fix `master` website run fails while building `website/compiler/cmd/playground` with a missing `shim/astnav` Go sum entry.

This is an implementation pull request in the active campaign. Repository Actions remain enabled, but runs caused by each exact branch SHA are cancelled and recorded under the campaign policy. The merge gates are focused module-mirror regression coverage, the real website compiler Go build, the website build, directly affected type/module checks, diff validation, and a clean solo Self-Review.

## Campaign CI

Claim SHA `d7578224d53013075f15df82c74a7523d249106b` is under exact-SHA cancellation supervision. Implementation SHA records will be added in chronology comments after each push.