### PR TITLE
fix(lint): render mixed diagnostics in source order

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,17 @@ let total = count;
 
 ```text
 $ npx ttsc --noEmit
-src/index.ts:2:5 - error TS17397: [prefer-const] Use const instead of let.
-
-2 let total = count;
-      ~~~~~~~~~~~~~
-
 src/index.ts:1:1 - error TS11966: [no-var] Unexpected var, use let or const instead.
 
 1 var count = 3;
-  ~~~~~~~~~~~~~~
+  ~~~
+
+src/index.ts:2:5 - error TS17397: [prefer-const] Use const instead of let.
+
+2 let total = count;
+    ~~~~~
+
+Found 2 errors in the same file, starting at: src/index.ts:1
 ```
 
 Clean the project in place:

--- a/packages/lint/linthost/compile.go
+++ b/packages/lint/linthost/compile.go
@@ -455,9 +455,9 @@ func filterKnownFlags(args []string, known map[string]bool) []string {
   return out
 }
 
-// collectDiagnostics merges tsgo typecheck diagnostics with the lint
-// engine's findings. The renderer takes the two slices and walks them in
-// source order, so we don't need to interleave here.
+// collectDiagnostics collects tsgo typecheck diagnostics and lint findings
+// for the shared renderer. FormatMixedDiagnostics establishes one source
+// order across those independent producer slices.
 func collectDiagnostics(prog *program, engine *Engine) ([]*shimast.Diagnostic, []*shimdw.LintDiagnostic, error) {
   astDiags, lintDiags, _, err := collectDiagnosticsTimed(prog, engine)
   return astDiags, lintDiags, err

--- a/packages/lint/test/plugin/mixed_diagnostics_render_empty_is_silent_test.go
+++ b/packages/lint/test/plugin/mixed_diagnostics_render_empty_is_silent_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import (
+  "bytes"
+  "testing"
+
+  shimdw "github.com/microsoft/typescript-go/shim/diagnosticwriter"
+)
+
+// TestMixedDiagnosticsRenderEmptyIsSilent verifies the shared renderer keeps
+// the zero-diagnostic fast path silent after mixed-order support is added.
+//
+// 1. Render an empty parser and lint batch.
+// 2. Observe the returned error count and captured output.
+// 3. Assert no summary or diagnostic text was introduced.
+func TestMixedDiagnosticsRenderEmptyIsSilent(t *testing.T) {
+  var rendered bytes.Buffer
+  if got := shimdw.FormatMixedDiagnostics(&rendered, nil, nil, "/virtual"); got != 0 {
+    t.Fatalf("empty render error count = %d, want 0", got)
+  }
+  if rendered.Len() != 0 {
+    t.Fatalf("empty render produced output: %q", rendered.String())
+  }
+}

--- a/packages/lint/test/plugin/mixed_diagnostics_render_interleaves_parser_and_lint_test.go
+++ b/packages/lint/test/plugin/mixed_diagnostics_render_interleaves_parser_and_lint_test.go
@@ -1,0 +1,46 @@
+package linthost
+
+import (
+  "bytes"
+  "strings"
+  "testing"
+
+  shimdw "github.com/microsoft/typescript-go/shim/diagnosticwriter"
+)
+
+// TestMixedDiagnosticsRenderInterleavesParserAndLint verifies the shared
+// renderer places an earlier lint finding before a later tsgo parser error,
+// instead of preserving the producers' separate collection order.
+//
+// 1. Parse a source whose parser error is on the second line.
+// 2. Add a lint error on the first line and render the mixed batch.
+// 3. Assert source order and the unchanged error count.
+func TestMixedDiagnosticsRenderInterleavesParserAndLint(t *testing.T) {
+  source := parseTSFile(t, "/virtual/mixed.ts", "const early = 1;\nconst broken: = 2;\n")
+  astDiags := source.Diagnostics()
+  if len(astDiags) == 0 {
+    t.Fatal("malformed source did not produce a parser diagnostic")
+  }
+  lint := shimdw.NewLintDiagnostic(
+    source,
+    6,
+    11,
+    9101,
+    shimdw.LintCategoryError,
+    "lint finding on the first line",
+  )
+
+  var rendered bytes.Buffer
+  if got, want := shimdw.FormatMixedDiagnostics(&rendered, astDiags, []*shimdw.LintDiagnostic{lint}, "/virtual"), len(astDiags)+1; got != want {
+    t.Fatalf("error count = %d, want %d", got, want)
+  }
+  output := rendered.String()
+  lintIndex := strings.Index(output, lint.Message())
+  parserIndex := strings.Index(output, astDiags[0].String())
+  if lintIndex < 0 || parserIndex < 0 {
+    t.Fatalf("mixed render omitted a diagnostic:\n%s", output)
+  }
+  if lintIndex > parserIndex {
+    t.Fatalf("diagnostics retained producer order instead of source order:\n%s", output)
+  }
+}

--- a/packages/lint/test/plugin/mixed_diagnostics_render_orders_files_and_ties_test.go
+++ b/packages/lint/test/plugin/mixed_diagnostics_render_orders_files_and_ties_test.go
@@ -1,0 +1,49 @@
+package linthost
+
+import (
+  "bytes"
+  "strings"
+  "testing"
+
+  shimdw "github.com/microsoft/typescript-go/shim/diagnosticwriter"
+)
+
+// TestMixedDiagnosticsRenderOrdersFilesAndTies verifies the shared renderer
+// orders mixed batches by path and then applies deterministic source-key
+// tiebreaks when two findings share one source range.
+//
+// 1. Supply findings in reverse file and code order.
+// 2. Render the same batch twice through the shared formatter.
+// 3. Assert file, source-key, and repeatable output order.
+func TestMixedDiagnosticsRenderOrdersFilesAndTies(t *testing.T) {
+  firstFile := parseTSFile(t, "/virtual/a.ts", "const alpha = 1;\n")
+  secondFile := parseTSFile(t, "/virtual/b.ts", "const broken: = 1;\n")
+  astDiags := secondFile.Diagnostics()
+  if len(astDiags) == 0 {
+    t.Fatal("malformed second file did not produce a parser diagnostic")
+  }
+  diagnostics := []*shimdw.LintDiagnostic{
+    shimdw.NewLintDiagnostic(secondFile, 0, 5, 9201, shimdw.LintCategoryWarning, "second file"),
+    shimdw.NewLintDiagnostic(firstFile, 0, 5, 9202, shimdw.LintCategoryWarning, "same range, higher code"),
+    shimdw.NewLintDiagnostic(firstFile, 0, 5, 9201, shimdw.LintCategoryWarning, "same range, lower code"),
+  }
+
+  var first bytes.Buffer
+  shimdw.FormatMixedDiagnostics(&first, astDiags, diagnostics, "/virtual")
+  var second bytes.Buffer
+  shimdw.FormatMixedDiagnostics(&second, astDiags, diagnostics, "/virtual")
+  if first.String() != second.String() {
+    t.Fatalf("identical mixed batches rendered differently:\nfirst:\n%s\nsecond:\n%s", first.String(), second.String())
+  }
+  output := first.String()
+  lowerCode := strings.Index(output, "same range, lower code")
+  higherCode := strings.Index(output, "same range, higher code")
+  secondFileIndex := strings.Index(output, "second file")
+  parserIndex := strings.Index(output, astDiags[0].String())
+  if lowerCode < 0 || higherCode < 0 || secondFileIndex < 0 || parserIndex < 0 {
+    t.Fatalf("mixed render omitted an expected diagnostic:\n%s", output)
+  }
+  if lowerCode > higherCode || higherCode > secondFileIndex || secondFileIndex > parserIndex {
+    t.Fatalf("diagnostics are not ordered by file, position, end, and code:\n%s", output)
+  }
+}

--- a/packages/ttsc/shim/diagnosticwriter/lint.go
+++ b/packages/ttsc/shim/diagnosticwriter/lint.go
@@ -12,7 +12,10 @@
 package diagnosticwriter
 
 import (
+  "cmp"
   "io"
+  "slices"
+  "strings"
 
   "github.com/microsoft/typescript-go/internal/ast"
   "github.com/microsoft/typescript-go/internal/diagnostics"
@@ -166,7 +169,54 @@ func FormatMixedDiagnostics(
     },
     NewLine: "\n",
   }
+  slices.SortFunc(all, compareMixedDiagnostics)
   inner.FormatDiagnosticsWithColorAndContext(output, all, options)
   inner.WriteErrorSummaryText(output, all, options)
   return errors
+}
+
+// compareMixedDiagnostics imposes one deterministic source order on tsgo and
+// lint diagnostics before the upstream renderer consumes them. The renderer
+// intentionally writes its input order, while the two producers have separate
+// collection paths; ordering here keeps neither producer's traversal visible
+// in CLI output.
+func compareMixedDiagnostics(a, b inner.Diagnostic) int {
+  if c := strings.Compare(mixedDiagnosticFileName(a), mixedDiagnosticFileName(b)); c != 0 {
+    return c
+  }
+  if c := cmp.Compare(a.Pos(), b.Pos()); c != 0 {
+    return c
+  }
+  if c := cmp.Compare(a.End(), b.End()); c != 0 {
+    return c
+  }
+  if c := cmp.Compare(a.Code(), b.Code()); c != 0 {
+    return c
+  }
+  if c := cmp.Compare(a.Category(), b.Category()); c != 0 {
+    return c
+  }
+  if c := strings.Compare(a.Localize(locale.Default), b.Localize(locale.Default)); c != 0 {
+    return c
+  }
+  if c := compareMixedDiagnosticLists(a.MessageChain(), b.MessageChain()); c != 0 {
+    return c
+  }
+  return compareMixedDiagnosticLists(a.RelatedInformation(), b.RelatedInformation())
+}
+
+func mixedDiagnosticFileName(d inner.Diagnostic) string {
+  if file := d.File(); file != nil {
+    return file.FileName()
+  }
+  return ""
+}
+
+func compareMixedDiagnosticLists(a, b []inner.Diagnostic) int {
+  for i := 0; i < len(a) && i < len(b); i++ {
+    if c := compareMixedDiagnostics(a[i], b[i]); c != 0 {
+      return c
+    }
+  }
+  return cmp.Compare(len(a), len(b))
 }

--- a/packages/ttsc/test/driver/mixed_diagnostics_render_in_source_order_test.go
+++ b/packages/ttsc/test/driver/mixed_diagnostics_render_in_source_order_test.go
@@ -1,0 +1,56 @@
+package driver_test
+
+import (
+  "bytes"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestMixedDiagnosticsRenderInSourceOrder verifies the public driver keeps
+// a plugin finding ahead of a later compiler error after it separates the
+// rich diagnostics into tsgo and lint slices for the shared renderer.
+//
+// 1. Load a program with a second-line type error.
+// 2. Add a first-line lint diagnostic to the returned compiler diagnostics.
+// 3. Assert pretty output follows source order across both producers.
+func TestMixedDiagnosticsRenderInSourceOrder(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": { "module": "commonjs", "target": "es2020" },
+  "files": ["index.ts"]
+}
+`)
+  writeProjectFile(t, root, "index.ts", "const early = 1;\nconst later: number = 'wrong';\n")
+  prog, configDiags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(configDiags) != 0 {
+    t.Fatalf("unexpected config diagnostics: %#v", configDiags)
+  }
+  defer prog.Close()
+  compilerDiags := prog.Diagnostics()
+  if len(compilerDiags) == 0 {
+    t.Fatal("type error did not produce a compiler diagnostic")
+  }
+  source := prog.SourceFile(filepath.Join(root, "index.ts"))
+  if source == nil {
+    t.Fatal("source file not found")
+  }
+  diagnostics := append(compilerDiags, driver.NewLintDiagnostic(source, 6, 11, 9301, driver.SeverityError, "lint finding on the first line"))
+
+  var rendered bytes.Buffer
+  driver.WritePrettyDiagnostics(&rendered, diagnostics, root)
+  output := rendered.String()
+  lintIndex := strings.Index(output, "lint finding on the first line")
+  compilerIndex := strings.Index(output, compilerDiags[0].Message)
+  if lintIndex < 0 || compilerIndex < 0 {
+    t.Fatalf("pretty render omitted a diagnostic:\n%s", output)
+  }
+  if lintIndex > compilerIndex {
+    t.Fatalf("driver rich diagnostics retained producer order:\n%s", output)
+  }
+}

--- a/tests/test-lint/src/features/plugin/test_lint_mixed_diagnostics_follow_source_order.ts
+++ b/tests/test-lint/src/features/plugin/test_lint_mixed_diagnostics_follow_source_order.ts
@@ -1,0 +1,50 @@
+import { assert, runLint } from "../../internal/config-file";
+
+/**
+ * Verifies mixed CLI diagnostics: lint and TypeScript errors share source order
+ * instead of retaining the order in which their separate producers collected
+ * them.
+ *
+ * 1. Run a project with no-var on line 1, prefer-const on line 2, and a TypeScript
+ *    assignment error on line 5.
+ * 2. Read both the rendered stderr stream and its lint-diagnostic parser view.
+ * 3. Assert all three output positions follow the source and lint parsing retains
+ *    the same rule sequence.
+ */
+export const test_lint_mixed_diagnostics_follow_source_order = (): void => {
+  const result = runLint({
+    name: "mixed-diagnostics-source-order",
+    source: [
+      "var count = 3;",
+      "let total = count;",
+      "",
+      "",
+      'const invalid: number = "wrong";',
+      "",
+    ].join("\n"),
+    rules: {
+      "no-var": "error",
+      "prefer-const": "error",
+    },
+  });
+  assert.notEqual(result.status, 0, result.stderr);
+
+  const noVar = result.stderr.indexOf("[no-var]");
+  const preferConst = result.stderr.indexOf("[prefer-const]");
+  const typeError = result.stderr.indexOf(
+    "Type 'string' is not assignable to type 'number'.",
+  );
+  assert.ok(noVar >= 0, result.stderr);
+  assert.ok(preferConst >= 0, result.stderr);
+  assert.ok(typeError >= 0, result.stderr);
+  assert.ok(noVar < preferConst, result.stderr);
+  assert.ok(preferConst < typeError, result.stderr);
+  assert.deepEqual(
+    result.diagnostics.map((diagnostic) => [diagnostic.rule, diagnostic.line]),
+    [
+      ["no-var", 1],
+      ["prefer-const", 2],
+    ],
+    result.stderr,
+  );
+};


### PR DESCRIPTION
## Intent

Reserve #853: render tsgo and lint diagnostics in one deterministic source
order that does not depend on the producing slice or lint traversal order.

## Scope

- Own the mixed diagnostic renderer boundary and its `compile`, `fix`, and
  driver callers.
- Add focused rendering and end-to-end regressions for producer interleaving,
  per-file ordering, same-position stability, and unchanged error counts.
- Regenerate the README diagnostic block from the real corrected command.

## Excluded

- `format/*` conformance and formatter behavior (#838, #839, #856).
- Contributor namespace and floating-promise option work (#821, #858).
- LSP payload ordering, rule traversal order, Graph, release, and workflow
  changes.

## Verification

Implementation is pending. The intended gates are the focused lint Go lane,
the real lint feature lane, `pnpm test:go`, and a clean solo Self-Review. The
repository-wide formatter is deliberately not run during this campaign.

## Campaign CI

This implementation-free claim is commit
`800ba0ef0e0379a422958c5f00427332bcbbb693`. Actions remain enabled; only runs
for this branch's exact campaign commit SHAs are cancelled and recorded in the
campaign knowledge base.
