### PR TITLE
fix(graph): recover structured identity components

### DIFF
--- a/experimental/benchmark/graph/viewer.mjs
+++ b/experimental/benchmark/graph/viewer.mjs
@@ -101,8 +101,9 @@ function relativize(abs, root) {
 }
 
 /**
- * A node id is `<path>#<name>:<kind>`; rewrite only the path prefix so ids stay
- * a stable key and every edge endpoint (also an id) relativizes identically.
+ * A node id quotes `#` and `\\` inside its `<path>#<name>:<kind>` components.
+ * Rewrite only the decoded path so ids stay stable keys and every edge endpoint
+ * (also an id) relativizes identically.
  */
 function rewriteId(id, root) {
   const hash = graphNodeIdHash(id);

--- a/experimental/benchmark/graph/viewer.mjs
+++ b/experimental/benchmark/graph/viewer.mjs
@@ -105,9 +105,47 @@ function relativize(abs, root) {
  * a stable key and every edge endpoint (also an id) relativizes identically.
  */
 function rewriteId(id, root) {
-  const hash = id.indexOf("#");
+  const hash = graphNodeIdHash(id);
   if (hash < 0) return id;
-  return relativize(id.slice(0, hash), root) + id.slice(hash);
+  return (
+    escapeGraphNodeIdPart(relativize(unescapeGraphNodeIdPart(id.slice(0, hash)), root)) +
+    id.slice(hash)
+  );
+}
+
+function escapeGraphNodeIdPart(value) {
+  return value.replaceAll("\\", "\\\\").replaceAll("#", "\\#");
+}
+
+function unescapeGraphNodeIdPart(value) {
+  let result = "";
+  for (let index = 0; index < value.length; index++) {
+    const next = value[index + 1];
+    if (value[index] === "\\" && next !== undefined) {
+      if (next === "#" || (next === "\\" && !legacyUNCStart(value, index))) {
+        result += next;
+        index++;
+        continue;
+      }
+    }
+    result += value[index];
+  }
+  return result;
+}
+
+function legacyUNCStart(value, index) {
+  return index === 0 && value.length > 2 && value[2] !== "\\" && value[2] !== "#";
+}
+
+function graphNodeIdHash(id) {
+  for (let index = 0; index < id.length; index++) {
+    if (id[index] !== "#") continue;
+    let slashes = 0;
+    for (let slash = index - 1; slash >= 0 && id[slash] === "\\"; slash--)
+      slashes++;
+    if (slashes % 2 === 0) return index;
+  }
+  return -1;
 }
 
 /**

--- a/packages/graph/src/model/TtscGraphMemory.ts
+++ b/packages/graph/src/model/TtscGraphMemory.ts
@@ -5,6 +5,7 @@ import { ITtscGraphNode } from "../structures/ITtscGraphNode";
 import { ITtscGraphSpan } from "../structures/ITtscGraphSpan";
 import { TtscGraphEdgeKind } from "../structures/TtscGraphEdgeKind";
 import { TtscGraphSourceReader } from "./TtscGraphSourceReader";
+import { ttscGraphNodeIdPath } from "./TtscGraphNodeId";
 
 /**
  * The in-memory resident graph the MCP tools answer from.
@@ -119,10 +120,20 @@ function keyOf(node: ITtscGraphNode): string {
   return node.qualifiedName ?? node.name;
 }
 
-/** The owner key of a dotted key (`A.B.c` -> `A.B`), or "" for a top-level key. */
-function ownerKey(key: string): string {
-  const dot = key.lastIndexOf(".");
-  return dot >= 0 ? key.slice(0, dot) : "";
+/**
+ * The owner key derived from facts the producer serialized separately.
+ *
+ * A quoted member named `"a.b"` has Name `a.b` and QualifiedName `Box.a.b`.
+ * Cutting the qualified name at its last dot invents owner `Box.a`; removing
+ * the exact `.${name}` suffix instead preserves the producer's real boundary.
+ */
+function ownerKey(node: ITtscGraphNode): string | undefined {
+  if (node.qualifiedName === undefined || node.qualifiedName === node.name)
+    return undefined;
+  const suffix = `.${node.name}`;
+  if (!node.qualifiedName.endsWith(suffix)) return undefined;
+  const owner = node.qualifiedName.slice(0, -suffix.length);
+  return owner === "" ? undefined : owner;
 }
 
 /** A file's id and node name from its project-relative path. */
@@ -144,8 +155,7 @@ function spanIn(span: ITtscGraphSpan, file: string): ITtscGraphEvidence {
  * file node's id is the path itself.
  */
 function fileOfNodeId(id: string): string {
-  const hash = id.indexOf("#");
-  return hash === -1 ? id : id.slice(0, hash);
+  return ttscGraphNodeIdPath(id) ?? id;
 }
 
 function basename(file: string): string {
@@ -213,8 +223,8 @@ function synthesize(dump: ITtscGraphDump): {
     if (!node.external) byFileKey.set(node.file + "\0" + keyOf(node), node);
   }
   const owner = (node: ITtscGraphNode): ITtscGraphNode | undefined => {
-    const parent = ownerKey(keyOf(node));
-    if (parent === "") return undefined;
+    const parent = ownerKey(node);
+    if (parent === undefined) return undefined;
     return byFileKey.get(node.file + "\0" + parent);
   };
 

--- a/packages/graph/src/model/TtscGraphNodeId.ts
+++ b/packages/graph/src/model/TtscGraphNodeId.ts
@@ -19,7 +19,7 @@ export function parseTtscGraphNodeId(
   const tail = id.slice(hash + 1);
   if (tail === "") return undefined;
   const colon = tail.lastIndexOf(":");
-  if (colon === tail.length - 1) return undefined;
+  if (colon === 0 || colon === tail.length - 1) return undefined;
   return {
     path: unescapeGraphNodeIdPart(id.slice(0, hash)),
     name: unescapeGraphNodeIdPart(colon < 0 ? tail : tail.slice(0, colon)),

--- a/packages/graph/src/model/TtscGraphNodeId.ts
+++ b/packages/graph/src/model/TtscGraphNodeId.ts
@@ -1,0 +1,82 @@
+/** The structured components carried by a graph symbol id. */
+export interface ITtscGraphNodeId {
+  path: string;
+  name: string;
+  kind?: string;
+}
+
+/**
+ * Decode the graph's position-invariant `path#name:kind` identity.
+ *
+ * The producer quotes `#` and `\\` inside path and name. This reader also
+ * accepts pre-codec ordinary ids, so a current package can read an older dump.
+ */
+export function parseTtscGraphNodeId(
+  id: string,
+): ITtscGraphNodeId | undefined {
+  const hash = graphNodeIdHash(id);
+  if (hash < 0) return undefined;
+  const tail = id.slice(hash + 1);
+  if (tail === "") return undefined;
+  const colon = tail.lastIndexOf(":");
+  if (colon === tail.length - 1) return undefined;
+  return {
+    path: unescapeGraphNodeIdPart(id.slice(0, hash)),
+    name: unescapeGraphNodeIdPart(colon < 0 ? tail : tail.slice(0, colon)),
+    ...(colon < 0 ? {} : { kind: tail.slice(colon + 1) }),
+  };
+}
+
+/** Encode a symbol identity without making its component boundaries ambiguous. */
+export function writeTtscGraphNodeId(
+  path: string,
+  name: string,
+  kind: string,
+): string {
+  return `${escapeGraphNodeIdPart(path)}#${escapeGraphNodeIdPart(name)}:${kind}`;
+}
+
+/** Return the raw path component when id is a symbol identity. */
+export function ttscGraphNodeIdPath(id: string): string | undefined {
+  return parseTtscGraphNodeId(id)?.path;
+}
+
+function escapeGraphNodeIdPart(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("#", "\\#");
+}
+
+function unescapeGraphNodeIdPart(value: string): string {
+  let result = "";
+  for (let index = 0; index < value.length; index++) {
+    const next = value[index + 1];
+    if (value[index] === "\\" && next !== undefined) {
+      if (next === "#" || (next === "\\" && !legacyUNCStart(value, index))) {
+        result += next;
+        index++;
+        continue;
+      }
+    }
+    result += value[index];
+  }
+  return result;
+}
+
+function legacyUNCStart(value: string, index: number): boolean {
+  return (
+    index === 0 &&
+    value.length > 2 &&
+    value[2] !== "\\" &&
+    value[2] !== "#"
+  );
+}
+
+function graphNodeIdHash(id: string): number {
+  for (let index = 0; index < id.length; index++) {
+    if (id[index] !== "#") continue;
+    let slashes = 0;
+    for (let slash = index - 1; slash >= 0 && id[slash] === "\\"; slash--)
+      slashes++;
+    if (slashes % 2 === 0) return index;
+  }
+  return -1;
+}

--- a/packages/graph/src/reduce.ts
+++ b/packages/graph/src/reduce.ts
@@ -117,9 +117,47 @@ function relativize(abs: string, root: string | null): string {
 }
 
 function rewriteId(id: string, root: string | null): string {
-  const hash = id.indexOf("#");
+  const hash = graphNodeIdHash(id);
   if (hash < 0) return id;
-  return relativize(id.slice(0, hash), root) + id.slice(hash);
+  return (
+    escapeGraphNodeIdPart(relativize(unescapeGraphNodeIdPart(id.slice(0, hash)), root)) +
+    id.slice(hash)
+  );
+}
+
+function escapeGraphNodeIdPart(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("#", "\\#");
+}
+
+function unescapeGraphNodeIdPart(value: string): string {
+  let result = "";
+  for (let index = 0; index < value.length; index++) {
+    const next = value[index + 1];
+    if (value[index] === "\\" && next !== undefined) {
+      if (next === "#" || (next === "\\" && !legacyUNCStart(value, index))) {
+        result += next;
+        index++;
+        continue;
+      }
+    }
+    result += value[index];
+  }
+  return result;
+}
+
+function legacyUNCStart(value: string, index: number): boolean {
+  return index === 0 && value.length > 2 && value[2] !== "\\" && value[2] !== "#";
+}
+
+function graphNodeIdHash(id: string): number {
+  for (let index = 0; index < id.length; index++) {
+    if (id[index] !== "#") continue;
+    let slashes = 0;
+    for (let slash = index - 1; slash >= 0 && id[slash] === "\\"; slash--)
+      slashes++;
+    if (slashes % 2 === 0) return index;
+  }
+  return -1;
 }
 
 function degreeOf(

--- a/packages/graph/src/server/resolveHandle.ts
+++ b/packages/graph/src/server/resolveHandle.ts
@@ -1,4 +1,5 @@
 import { TtscGraphMemory } from "../model/TtscGraphMemory";
+import { parseTtscGraphNodeId } from "../model/TtscGraphNodeId";
 import { ITtscGraphNode } from "../structures/ITtscGraphNode";
 import { exportFanIn } from "./exportSurface";
 import { isSupportPath } from "./pathPolicy";
@@ -73,12 +74,7 @@ function memberPartOf(handle: string): string | undefined {
 
 /** The symbol an id-shaped handle names: `dir/file.ts#Class.method:kind`. */
 function symbolPartOf(handle: string): string | undefined {
-  const hash = handle.lastIndexOf("#");
-  if (hash < 0) return undefined;
-  const symbol = handle.slice(hash + 1);
-  const kind = symbol.lastIndexOf(":");
-  const name = kind < 0 ? symbol : symbol.slice(0, kind);
-  return name.length > 0 ? name : undefined;
+  return parseTtscGraphNodeId(handle)?.name;
 }
 
 function resolveGraphName(

--- a/packages/ttsc/internal/graph/dump.go
+++ b/packages/ttsc/internal/graph/dump.go
@@ -421,17 +421,15 @@ func (c *dumpContext) rel(file string) string {
 // both relativize. Every other node is named by a symbol, which passes through
 // untouched.
 func (c *dumpContext) relID(id string) string {
-  hash := strings.Index(id, "#")
-  if hash < 0 {
+  parts, ok := parseNodeID(id)
+  if !ok {
     return id
   }
-  head, tail := c.rel(id[:hash]), id[hash+1:]
-  suffix := ":" + string(NodeModule)
-  if strings.HasSuffix(tail, suffix) {
-    name := strings.TrimSuffix(tail, suffix)
-    return head + "#" + c.rel(name) + suffix
+  name := parts.name
+  if parts.kind == NodeModule {
+    name = c.rel(name)
   }
-  return head + "#" + tail
+  return nodeID(c.rel(parts.path), name, parts.kind)
 }
 
 // evidence builds the line/col span for a byte range in file, or nil when the
@@ -637,15 +635,6 @@ func withoutFile(ev *DumpEvidence) *DumpEvidence {
   }
   ev.File = ""
   return ev
-}
-
-// nodeFile recovers the source file path embedded in a node id
-// ("path#qualifiedName:kind"); "" for an id without a path.
-func nodeFile(id string) string {
-  if hash := strings.Index(id, "#"); hash >= 0 {
-    return id[:hash]
-  }
-  return ""
 }
 
 // lineStarts holds the byte offset of each line's start, so an offset maps to a

--- a/packages/ttsc/internal/graph/graph.go
+++ b/packages/ttsc/internal/graph/graph.go
@@ -1,6 +1,8 @@
 package graph
 
 import (
+  "strings"
+
   shimast "github.com/microsoft/typescript-go/shim/ast"
 )
 
@@ -214,7 +216,103 @@ type edgeKey struct {
 }
 
 // nodeID builds the position-invariant identity for a symbol named name,
-// declared as kind in the source file at path.
+// declared as kind in the source file at path. The visible grammar remains
+// path#name:kind, but path and name quote a literal backslash and hash so a
+// consumer never has to guess which hash separates the two components.
 func nodeID(path string, name string, kind NodeKind) string {
-  return path + "#" + name + ":" + string(kind)
+  return escapeNodeIDPart(path) + "#" + escapeNodeIDPart(name) + ":" + string(kind)
+}
+
+// nodeIDParts are the structured facts carried by a symbol id. File nodes are
+// raw paths rather than symbol ids, so parseNodeID deliberately rejects them.
+type nodeIDParts struct {
+  path string
+  name string
+  kind NodeKind
+}
+
+// parseNodeID recovers the structured path, name, and kind from an id emitted
+// by nodeID. It also accepts older ids whose ordinary components were not
+// escaped, so a newer reader can still consume a pre-codec dump.
+func parseNodeID(id string) (nodeIDParts, bool) {
+  hash := nodeIDHash(id)
+  if hash < 0 {
+    return nodeIDParts{}, false
+  }
+  tail := id[hash+1:]
+  colon := strings.LastIndex(tail, ":")
+  if colon <= 0 || colon == len(tail)-1 {
+    return nodeIDParts{}, false
+  }
+  return nodeIDParts{
+    path: unescapeNodeIDPart(id[:hash]),
+    name: unescapeNodeIDPart(tail[:colon]),
+    kind: NodeKind(tail[colon+1:]),
+  }, true
+}
+
+// nodeFile recovers the raw source path embedded in a symbol id. An id without
+// a symbol component is a file id, and therefore has no node-file component.
+func nodeFile(id string) string {
+  parts, ok := parseNodeID(id)
+  if !ok {
+    return ""
+  }
+  return parts.path
+}
+
+// NodeFile is the graph-symbol provider's shared view of the node-id grammar.
+// Keeping the parser here prevents its LSP path comparison from drifting from
+// the dump producer's edge-evidence lookup.
+func NodeFile(id string) string {
+  return nodeFile(id)
+}
+
+func escapeNodeIDPart(value string) string {
+  value = strings.ReplaceAll(value, "\\", "\\\\")
+  return strings.ReplaceAll(value, "#", "\\#")
+}
+
+func unescapeNodeIDPart(value string) string {
+  var out strings.Builder
+  out.Grow(len(value))
+  for i := 0; i < len(value); i++ {
+    if value[i] == '\\' && i+1 < len(value) {
+      next := value[i+1]
+      if next == '#' || (next == '\\' && !legacyUNCStart(value, i)) {
+        i++
+      }
+    }
+    out.WriteByte(value[i])
+  }
+  return out.String()
+}
+
+// legacyUNCStart distinguishes an older raw UNC path (\\server) from a new
+// codec spelling (\\\\server). The former predates backslash escaping and must
+// remain readable by a current consumer.
+func legacyUNCStart(value string, index int) bool {
+  return index == 0 && len(value) > 2 && value[2] != '\\' && value[2] != '#'
+}
+
+func nodeIDHash(id string) int {
+  for i := 0; i < len(id); i++ {
+    if id[i] != '#' {
+      continue
+    }
+    if i == 0 || id[i-1] != '\\' || escapedBackslash(id, i-1) {
+      return i
+    }
+  }
+  return -1
+}
+
+// escapedBackslash reports whether slash is itself escaped by the run before
+// it. Only an odd run quotes the following hash.
+func escapedBackslash(id string, slash int) bool {
+  count := 0
+  for i := slash; i >= 0 && id[i] == '\\'; i-- {
+    count++
+  }
+  return count%2 == 0
 }

--- a/packages/ttsc/internal/graph/node_ids_preserve_hash_bearing_components_test.go
+++ b/packages/ttsc/internal/graph/node_ids_preserve_hash_bearing_components_test.go
@@ -1,0 +1,41 @@
+package graph
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestNodeIDsPreserveHashBearingComponents verifies graph identity: quoted
+// path and symbol hashes remain structured facts through dump relativization.
+//
+// A source path and an authored private member may both contain '#'. Splitting
+// the display id at either raw occurrence made the dump lose its project
+// relative path and made consumers read the member as an id separator. The
+// codec must escape those components while keeping ordinary ids byte-identical.
+//
+//  1. Build ordinary and hash-bearing ids from their raw structured facts.
+//  2. Relativize the hash-bearing id as the dump does.
+//  3. Recover its raw file component and assert the escaped wire spelling.
+func TestNodeIDsPreserveHashBearingComponents(t *testing.T) {
+	if got, want := nodeID("src/main.ts", "main", NodeFunction), "src/main.ts#main:function"; got != want {
+		t.Fatalf("ordinary id = %q, want %q", got, want)
+	}
+	if got, want := nodeID(`C:\work\a#b\main.ts`, "label:part", NodeVariable), `C:\\work\\a\#b\\main.ts#label:part:variable`; got != want {
+		t.Fatalf("escaped id = %q, want %q", got, want)
+	} else if parts, ok := parseNodeID(got); !ok || parts.path != `C:\work\a#b\main.ts` || parts.name != "label:part" {
+		t.Fatalf("decoded id = %#v, %t; want raw path and name", parts, ok)
+	}
+
+	root := filepath.Join(t.TempDir(), "a#b")
+	file := filepath.Join(root, "src#generated", "main#file.ts")
+	id := nodeID(file, "Counter.#count", NodeVariable)
+	context := newDumpContext(root, nil)
+	got := context.relID(id)
+	want := "src\\#generated/main\\#file.ts#Counter.\\#count:variable"
+	if got != want {
+		t.Fatalf("relativized id = %q, want %q", got, want)
+	}
+	if file := nodeFile(got); file != "src#generated/main#file.ts" {
+		t.Fatalf("decoded file = %q, want raw hash-bearing relative path", file)
+	}
+}

--- a/packages/ttsc/internal/graphsymbols/provider.go
+++ b/packages/ttsc/internal/graphsymbols/provider.go
@@ -188,7 +188,7 @@ func (pr *Provider) References(uri string, pos lspserver.LSPPosition, includeDec
     if e.To != target.ID || isStructuralEdge(e.Kind) {
       continue
     }
-    f := nodeFile(e.From)
+    f := graph.NodeFile(e.From)
     if f == "" {
       continue
     }
@@ -322,7 +322,7 @@ func targetNodeAt(g *graph.Graph, file string, offset int) *graph.Node {
     return best
   }
   for _, e := range g.Edges {
-    if !pathsEqual(nodeFile(e.From), file) {
+    if !pathsEqual(graph.NodeFile(e.From), file) {
       continue
     }
     if offset >= e.Pos && offset < e.End {
@@ -357,15 +357,6 @@ func sortNodes(nodes []*graph.Node) {
     }
     return nodes[i].Name < nodes[j].Name
   })
-}
-
-// nodeFile recovers the source file path embedded in a node id
-// ("path#name:kind"); "" for an id without a path.
-func nodeFile(id string) string {
-  if hash := strings.Index(id, "#"); hash >= 0 {
-    return id[:hash]
-  }
-  return ""
 }
 
 // fileFromURI maps a file:// uri onto the source map key for the same file,

--- a/packages/ttsc/test/driver/run_lsp_graph_symbols_preserve_hash_bearing_paths_test.go
+++ b/packages/ttsc/test/driver/run_lsp_graph_symbols_preserve_hash_bearing_paths_test.go
@@ -1,0 +1,55 @@
+package driver_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samchon/ttsc/packages/ttsc/driver"
+	"github.com/samchon/ttsc/packages/ttsc/internal/graphsymbols"
+)
+
+// TestRunLSPGraphSymbolsPreserveHashBearingPaths verifies graph LSP references:
+// ids whose source path contains '#' still map back to the real source file.
+//
+// The graph producer escapes a hash inside the id's path component. The LSP
+// provider must decode that component before comparing an edge to the editor's
+// URI; otherwise every reference from the file is discarded as a different
+// source path.
+//
+//  1. Build a project whose root, directory, and source filename contain '#'.
+//  2. Warm the graph-backed provider and request references for `greet`.
+//  3. Assert the declaration and usage from that exact file are returned.
+func TestRunLSPGraphSymbolsPreserveHashBearingPaths(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "project#root")
+	relative := "src#generated/main#file.ts"
+	mainPath := filepath.Join(root, filepath.FromSlash(relative))
+	writeGraphSymbolFile(t, filepath.Join(root, "tsconfig.json"), strings.Replace(graphSymbolTSConfig, "src/main.ts", relative, 1))
+	writeGraphSymbolFile(t, mainPath, `export function greet(): void {}
+export function use(): void { greet(); }
+`)
+	mainURI := fileURIForPath(mainPath)
+	provider := graphsymbols.NewProvider(root, "tsconfig.json")
+	if _, err := provider.DocumentSymbols(mainURI); err != nil {
+		t.Fatalf("provider load failed: %v", err)
+	}
+
+	h := newProxyHarnessWithOptions(t, nil, driver.ProxyOptions{SymbolProvider: provider})
+	h.sendEditor(symbolRequestBody(t, 1, "textDocument/references", map[string]any{
+		"textDocument": map[string]any{"uri": mainURI},
+		"position":     map[string]any{"line": 0, "character": 17},
+		"context":      map[string]any{"includeDeclaration": true},
+	}))
+	var locations []driver.LSPLocation
+	decodeResult(t, h.recvEditor(), &locations)
+	h.expectNoUpstreamFrame(150 * time.Millisecond)
+	if len(locations) != 2 {
+		t.Fatalf("hash-bearing-path references = %d, want declaration and usage: %+v", len(locations), locations)
+	}
+	for _, location := range locations {
+		if location.URI != mainURI {
+			t.Fatalf("reference uri = %q, want %q", location.URI, mainURI)
+		}
+	}
+}

--- a/tests/test-graph/src/features/test_ttscgraph_memory_keeps_quoted_dotted_members_on_their_owner.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_memory_keeps_quoted_dotted_members_on_their_owner.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+
+import {
+  createSyntheticGraph,
+  type ResolverGraphNode,
+} from "../internal/resolverGraph";
+
+/**
+ * Verifies graph memory ownership: a quoted dotted member remains on its
+ * declaring class.
+ *
+ * The producer sends `name` and `qualifiedName` separately because the dot in
+ * `a.b` belongs to the member. Deriving an owner by cutting the qualified name
+ * at its final dot invents `Box.a`; the exact simple-name suffix identifies
+ * `Box` instead.
+ *
+ * 1. Build a class and its quoted dotted variable from a synthetic dump.
+ * 2. Let the real memory synthesis refine containment and property kind.
+ * 3. Assert the class owns the refined property.
+ */
+export const test_ttscgraph_memory_keeps_quoted_dotted_members_on_their_owner =
+  (): void => {
+    const box: ResolverGraphNode = {
+      id: "src/box.ts#Box:class",
+      kind: "class",
+      name: "Box",
+      file: "src/box.ts",
+      external: false,
+    };
+    const member: ResolverGraphNode = {
+      id: "src/box.ts#Box.a.b:variable",
+      kind: "variable",
+      name: "a.b",
+      qualifiedName: "Box.a.b",
+      file: "src/box.ts",
+      external: false,
+    };
+    const graph = createSyntheticGraph([box, member]);
+    const property = graph.nodes.find((node) => node.id === member.id);
+    assert.strictEqual(property?.kind, "property");
+    assert.ok(
+      graph.incoming(member.id).some(
+        (edge) => edge.kind === "contains" && edge.from === box.id,
+      ),
+    );
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_node_id_rejects_empty_symbol_components.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_node_id_rejects_empty_symbol_components.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const graphEntry = require.resolve("@ttsc/graph");
+const graphLib = path.dirname(graphEntry);
+const { parseTtscGraphNodeId } = require(
+  path.join(graphLib, "model", "TtscGraphNodeId.js"),
+) as {
+  parseTtscGraphNodeId(id: string): unknown;
+};
+
+/**
+ * Verifies node identity parsing: an id with an empty symbol component is not
+ * a readable graph identity.
+ *
+ * The Go producer rejects `path#:kind`; accepting it in the TypeScript reader
+ * would make malformed stale handles silently enter the symbol lookup path.
+ * Both codec endpoints must fail closed for the same invalid component shape.
+ *
+ * 1. Load the built graph package's node-id reader.
+ * 2. Decode an id whose name component is empty.
+ * 3. Assert the reader rejects it.
+ */
+export const test_ttscgraph_node_id_rejects_empty_symbol_components =
+  (): void => {
+    assert.strictEqual(
+      parseTtscGraphNodeId("src/example.ts#:variable"),
+      undefined,
+    );
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_resolver_recovers_private_member_from_escaped_stale_id.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_resolver_recovers_private_member_from_escaped_stale_id.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+
+import {
+  type ResolverGraphNode,
+  resolveSyntheticGraph,
+} from "../internal/resolverGraph";
+
+/**
+ * Verifies resolver identity: an escaped private-member stale id recovers its
+ * authored `Counter.#count` name.
+ *
+ * The final `#` in a private member is data, not a second id boundary. The
+ * stale-id fallback must decode the producer's escaped name before consulting
+ * the structured symbol index.
+ *
+ * 1. Build the current private property under its escaped graph id.
+ * 2. Resolve an escaped id from an obsolete file.
+ * 3. Assert recovery returns the current private member.
+ */
+export const test_ttscgraph_resolver_recovers_private_member_from_escaped_stale_id =
+  (): void => {
+    const node: ResolverGraphNode = {
+      id: "src/current.ts#Counter.\\#count:variable",
+      kind: "variable",
+      name: "#count",
+      qualifiedName: "Counter.#count",
+      file: "src/current.ts",
+      external: false,
+    };
+    const resolved = resolveSyntheticGraph(
+      [node],
+      "src/old.ts#Counter.\\#count:variable",
+    );
+    assert.strictEqual(resolved.node?.id, node.id);
+  };

--- a/tests/test-graph/src/features/test_ttscgraph_viewer_reducers_rewrite_escaped_identity_paths.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_viewer_reducers_rewrite_escaped_identity_paths.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+interface Reducer {
+  reduce(raw: {
+    project: string;
+    nodes: {
+      id: string;
+      name: string;
+      kind: string;
+      file: string;
+    }[];
+    edges: { from: string; to: string; kind: string }[];
+  }): { nodes: { id: string; file: string }[] };
+}
+
+const loadReducer = async (
+  relativePath: string,
+  exported: "named" | "default",
+): Promise<Reducer> => {
+  const repository = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../..",
+  );
+  const module = (await import(
+    pathToFileURL(path.join(repository, relativePath)).href
+  )) as { reduce?: Reducer["reduce"]; default?: { reduce?: Reducer["reduce"] } };
+  const reduce = exported === "named" ? module.reduce : module.default?.reduce;
+  if (reduce === undefined) assert.fail(`${relativePath} exports reduce()`);
+  return { reduce };
+};
+
+/**
+ * Verifies viewer identity: every reducer rewrites the escaped path component,
+ * not the first literal hash it encounters.
+ *
+ * A raw path can contain '#', while the wire id quotes it as `\\#`. All three
+ * viewer runtimes must decode the path before relativizing it and re-encode the
+ * result, otherwise the node id and its edge endpoints stop matching.
+ *
+ * 1. Load the package, website, and benchmark reducer copies.
+ * 2. Reduce one hash-bearing absolute source id and self edge.
+ * 3. Assert each produces the same relative id and file.
+ */
+export const test_ttscgraph_viewer_reducers_rewrite_escaped_identity_paths =
+  async (): Promise<void> => {
+    const reducers = [
+      await loadReducer("packages/graph/src/reduce.ts", "named"),
+      await loadReducer(
+        "website/src/components/graph/TtscWebsiteGraphReduce.ts",
+        "default",
+      ),
+      await loadReducer("experimental/benchmark/graph/viewer.mjs", "named"),
+    ];
+    const file = "/work/a#b/src/main.ts";
+    const id = "/work/a\\#b/src/main.ts#main:function";
+    const dump = {
+      project: "fixture",
+      nodes: [{ id, name: "main", kind: "function", file }],
+      edges: [{ from: id, to: id, kind: "calls" }],
+    };
+    for (const reducer of reducers) {
+      const result = reducer.reduce(dump);
+      assert.strictEqual(result.nodes.length, 1);
+      assert.deepEqual(
+        { id: result.nodes[0]!.id, file: result.nodes[0]!.file },
+        { id: "main.ts#main:function", file: "main.ts" },
+      );
+    }
+  };

--- a/tests/test-graph/src/internal/resolverGraph.ts
+++ b/tests/test-graph/src/internal/resolverGraph.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 export interface ResolverGraphNode {
   id: string;
-  kind: "class" | "method";
+  kind: "class" | "method" | "variable" | "property";
   name: string;
   qualifiedName?: string;
   file: string;
@@ -14,10 +14,10 @@ export interface ResolverGraphNode {
 interface ResolverGraphEdge {
   from: string;
   to: string;
-  kind: "calls" | "exports";
+  kind: "calls" | "contains" | "exports";
 }
 
-interface GraphMemory {
+export interface GraphMemory {
   node(id: string): ResolverGraphNode | undefined;
   nodes: readonly ResolverGraphNode[];
   outgoing(id: string): readonly ResolverGraphEdge[];
@@ -63,10 +63,19 @@ export function resolveSyntheticGraph(
   candidateLimit = 12,
   edges: ResolverGraphEdge[] = [],
 ): ResolvedGraphHandle {
+  const graph = createSyntheticGraph(nodes, edges);
+  return resolveGraphHandle(graph, handle, candidateLimit);
+}
+
+/** Build the package's real memory indexes from a compact synthetic dump. */
+export function createSyntheticGraph(
+  nodes: ResolverGraphNode[],
+  edges: ResolverGraphEdge[] = [],
+): GraphMemory {
   const graph = TtscGraphMemory.from({
     project: "C:/synthetic-graph",
     nodes,
     edges,
   });
-  return resolveGraphHandle(graph, handle, candidateLimit);
+  return graph;
 }

--- a/website/src/components/graph/TtscWebsiteGraphReduce.ts
+++ b/website/src/components/graph/TtscWebsiteGraphReduce.ts
@@ -85,9 +85,47 @@ function relativize(abs: string, root: string | null): string {
  * a stable key and every edge endpoint (also an id) relativizes identically.
  */
 function rewriteId(id: string, root: string | null): string {
-  const hash = id.indexOf("#");
+  const hash = graphNodeIdHash(id);
   if (hash < 0) return id;
-  return relativize(id.slice(0, hash), root) + id.slice(hash);
+  return (
+    escapeGraphNodeIdPart(relativize(unescapeGraphNodeIdPart(id.slice(0, hash)), root)) +
+    id.slice(hash)
+  );
+}
+
+function escapeGraphNodeIdPart(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("#", "\\#");
+}
+
+function unescapeGraphNodeIdPart(value: string): string {
+  let result = "";
+  for (let index = 0; index < value.length; index++) {
+    const next = value[index + 1];
+    if (value[index] === "\\" && next !== undefined) {
+      if (next === "#" || (next === "\\" && !legacyUNCStart(value, index))) {
+        result += next;
+        index++;
+        continue;
+      }
+    }
+    result += value[index];
+  }
+  return result;
+}
+
+function legacyUNCStart(value: string, index: number): boolean {
+  return index === 0 && value.length > 2 && value[2] !== "\\" && value[2] !== "#";
+}
+
+function graphNodeIdHash(id: string): number {
+  for (let index = 0; index < id.length; index++) {
+    if (id[index] !== "#") continue;
+    let slashes = 0;
+    for (let slash = index - 1; slash >= 0 && id[slash] === "\\"; slash--)
+      slashes++;
+    if (slashes % 2 === 0) return index;
+  }
+  return -1;
 }
 
 function degreeOf(

--- a/website/src/components/graph/TtscWebsiteGraphReduce.ts
+++ b/website/src/components/graph/TtscWebsiteGraphReduce.ts
@@ -81,8 +81,9 @@ function relativize(abs: string, root: string | null): string {
 }
 
 /**
- * A node id is `<path>#<name>:<kind>`; rewrite only the path prefix so ids stay
- * a stable key and every edge endpoint (also an id) relativizes identically.
+ * A node id quotes `#` and `\\` inside its `<path>#<name>:<kind>` components.
+ * Rewrite only the decoded path so ids stay stable keys and every edge endpoint
+ * (also an id) relativizes identically.
  */
 function rewriteId(id: string, root: string | null): string {
   const hash = graphNodeIdHash(id);


### PR DESCRIPTION
## Intent

Resolve #810 by recovering Graph identity components from structured facts
rather than ambiguous `#` and `.` display-string splits.

## Scope

- Reserve the canonical Graph id codec, native parser, TypeScript memory, and
  viewer-rewrite surface.
- Reserve owner derivation and its native, LSP, memory, and viewer consumers.
- Add issue-specific regression coverage after the implementation snapshot.

## Deferred

- #822 and #835 remain a separate post-#810 combined reducer batch.

## Verification

This is an implementation-free claim. Local verification is pending; campaign
Actions runs for this reservation are cancelled by exact commit SHA.
