### PR TITLE
fix(ttsc): quote Go workspace comment-prefix paths

### DIFF
--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -1473,9 +1473,9 @@ export function formatGoWorkPath(p: string): string {
  * Quote `token` for a `go.mod`/`go.work` line exactly as
  * `golang.org/x/mod/modfile`'s `AutoQuote` does: return it unchanged when it is
  * already a clean bare token, otherwise return its Go double-quoted form so the
- * value round-trips through the modfile lexer. A space-free path is therefore
- * emitted byte-for-byte as before; only tokens that would otherwise
- * mis-tokenize are quoted.
+ * value round-trips through the modfile lexer. A clean bare token is therefore
+ * emitted byte-for-byte as before; only tokens that would otherwise be split
+ * or interpreted as comments are quoted.
  *
  * Exported for unit tests.
  */

--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -1506,11 +1506,11 @@ function mustQuoteGoModToken(s: string): boolean {
       }
       continue;
     }
-    if (!isGoGraphic(ch)) {
+    if (!isGoPrintable(ch)) {
       return true;
     }
   }
-  return s === "" || s === "//" || s === "/*";
+  return s === "" || s.includes("//") || s.includes("/*");
 }
 
 // Mirror `strconv.Quote`: wrap in double quotes, backslash-escape `"` and `\`,
@@ -1561,13 +1561,6 @@ function escapeGoRune(ch: string): string {
       return `\\U${cp.toString(16).padStart(8, "0")}`;
     }
   }
-}
-
-// `unicode.IsGraphic`: categories L, M, N, P, S, Zs (all spacing).
-const GO_GRAPHIC_RE = /^[\p{L}\p{M}\p{N}\p{P}\p{S}\p{Zs}]$/u;
-
-function isGoGraphic(ch: string): boolean {
-  return GO_GRAPHIC_RE.test(ch);
 }
 
 // `strconv.IsPrint`: the graphic categories except that the ONLY spacing

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_gomod_token_quoting_mirrors_go_autoquote.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_gomod_token_quoting_mirrors_go_autoquote.ts
@@ -21,7 +21,8 @@ import {
  * 3. Assert each output equals the value Go would emit for the same token.
  */
 export const test_gomod_token_quoting_mirrors_go_autoquote = () => {
-  const NBSP = " "; // U+00A0: a Zs (graphic) space that is not ASCII space.
+  const NBSP = String.fromCodePoint(0x00a0);
+  const IDEOGRAPHIC_SPACE = String.fromCodePoint(0x3000);
 
   // [input, expected] where expected is exactly what modfile.AutoQuote emits.
   const autoQuoteCases: readonly [string, string][] = [
@@ -34,7 +35,6 @@ export const test_gomod_token_quoting_mirrors_go_autoquote = () => {
     [".", "."],
     ["café", "café"], // lone Unicode letter is graphic → not forced.
     ["a😀b", "a😀b"], // lone astral symbol is graphic → not forced.
-    [`a${NBSP}b`, `a${NBSP}b`], // NBSP is Zs (graphic) → not forced.
     ["(", "("], // a lone bracket/comma is a legal bare token.
     [")", ")"],
     [",", ","],
@@ -49,6 +49,8 @@ export const test_gomod_token_quoting_mirrors_go_autoquote = () => {
     ["", '""'], // empty string is not a valid bare token.
     ["//", '"//"'], // a line comment opener must be quoted to be a token.
     ["/*", '"/*"'], // a block comment opener too.
+    ["a//b", '"a//b"'], // an embedded line-comment opener too.
+    ["a/*b", '"a/*b"'], // an embedded block-comment opener too.
 
     // strconv.Quote escape forms (control runes force quoting on their own).
     ["a\tb", '"a\\tb"'], // \t
@@ -60,6 +62,8 @@ export const test_gomod_token_quoting_mirrors_go_autoquote = () => {
     ["a\x07b", '"a\\ab"'], // \a (bell)
     ["a\x01b", '"a\\x01b"'], // \xNN for other C0 controls
     ["a\x7fb", '"a\\x7fb"'], // \x7f for DEL
+    [`a${NBSP}b`, '"a\\u00a0b"'], // non-ASCII Zs is not printable.
+    [`a${IDEOGRAPHIC_SPACE}b`, '"a\\u3000b"'], // neither is U+3000.
     [`a ${NBSP}`, '"a \\u00a0"'], // \uNNNN: NBSP is not printable inside a quote.
     [String.fromCodePoint(0x10ffff), '"\\U0010ffff"'], // \UNNNNNNNN for astral non-printable.
 
@@ -81,6 +85,9 @@ export const test_gomod_token_quoting_mirrors_go_autoquote = () => {
   const formatCases: readonly [string, string][] = [
     ["C:\\Users\\John Smith\\proj", '"C:/Users/John Smith/proj"'],
     ["C:\\Users\\jsmith\\proj", "C:/Users/jsmith/proj"],
+    [String.raw`\\server\share\proj`, '"//server/share/proj"'],
+    [String.raw`\\?\C:\Users\x\proj`, '"//?/C:/Users/x/proj"'],
+    [String.raw`C:\Users\x\\y\proj`, '"C:/Users/x//y/proj"'],
     ["/Users/John Smith/x", '"/Users/John Smith/x"'],
     ["/home/user/x", "/home/user/x"],
     [".", "."],

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_writegowork_quotes_workspace_paths_with_spaces.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_writegowork_quotes_workspace_paths_with_spaces.ts
@@ -1,4 +1,5 @@
 import { TestProject } from "@ttsc/testing";
+import child_process from "node:child_process";
 
 import {
   assert,
@@ -9,7 +10,7 @@ import {
 } from "../../internal/source-build";
 
 /**
- * Verifies writeGoWork quotes go.work paths that contain spaces (#394).
+ * Verifies writeGoWork quotes unsafe go.work workspace paths (#394, #857).
  *
  * `writeGoWork` emitted `use`/`replace` paths unquoted, so an overlay resolved
  * under a directory with a space — the common `C:\Users\John Smith\...` /
@@ -17,19 +18,35 @@ import {
  * into extra tokens, and `go` failed to parse it. The emitter now quotes each
  * path via `modfile.AutoQuote`. This drives the real build pipeline (fake `go`)
  * and inspects the generated `go.work` to pin both directives, plus a
- * space-free twin that must stay unquoted so the fix never over-quotes.
+ * space-free twin that must stay unquoted so the fix never over-quotes. A
+ * namespaced Windows path (or a POSIX double-slash spelling of the same local
+ * directory) also proves a normalized comment-prefix path survives a real
+ * `go work edit -json` parse.
  *
  * 1. Build a plugin whose overlays are a ttsc-module dir under a `"space dir"`
  *    path and a space-free shim dir.
  * 2. Capture the `go.work` the builder hands to `go build`.
- * 3. Assert the spaced path is quoted in both `use` and `replace`, and the
- *    space-free path stays bare.
+ * 3. Assert the spaced path is quoted in both `use` and `replace`, the
+ *    space-free path stays bare, and the normalized comment-prefix path is
+ *    quoted in `use`.
+ * 4. Parse the captured workspace with the real Go modfile tool and assert it
+ *    retains that `use` entry.
  */
 export const test_writegowork_quotes_workspace_paths_with_spaces = () => {
   const root = TestProject.tmpdir("ttsc-gowork-spaces-");
   const source = path.join(root, "plugin");
   const spacedOverlay = path.join(root, "space dir", "ttsc");
   const bareOverlay = path.join(root, "nospace", "shim");
+  const commentPrefixBase = path.join(root, "comment-prefix", "shim");
+  const commentPrefixOverlay =
+    process.platform === "win32"
+      ? path.toNamespacedPath(commentPrefixBase)
+      : `/${commentPrefixBase}`;
+
+  writeFile(
+    path.join(root, "go.mod"),
+    "module example.com/workspace\n\ngo 1.26\n",
+  );
 
   writeFile(
     path.join(source, "go.mod"),
@@ -47,8 +64,13 @@ export const test_writegowork_quotes_workspace_paths_with_spaces = () => {
     "module github.com/microsoft/typescript-go/shim/foo\n\ngo 1.26\n",
   );
   writeFile(path.join(bareOverlay, "foo.go"), "package foo\n");
+  writeFile(
+    path.join(commentPrefixBase, "go.mod"),
+    "module example.com/comment-prefix\n\ngo 1.26\n",
+  );
+  writeFile(path.join(commentPrefixBase, "shim.go"), "package shim\n");
 
-  const capture = path.join(root, "captured-go.work");
+  const capture = path.join(root, "go.work");
   const fakeGo = createGoWorkCapturingGoBinary(root);
 
   const previousGo = process.env.TTSC_GO_BINARY;
@@ -58,7 +80,7 @@ export const test_writegowork_quotes_workspace_paths_with_spaces = () => {
   try {
     buildSourcePlugin({
       baseDir: root,
-      overlayDirs: [spacedOverlay, bareOverlay],
+      overlayDirs: [spacedOverlay, bareOverlay, commentPrefixOverlay],
       pluginName: "gowork-spaces",
       source,
       quiet: true,
@@ -73,6 +95,7 @@ export const test_writegowork_quotes_workspace_paths_with_spaces = () => {
   const goWork = fs.readFileSync(capture, "utf8");
   const spaced = spacedOverlay.replace(/\\/g, "/");
   const bare = bareOverlay.replace(/\\/g, "/");
+  const commentPrefix = commentPrefixOverlay.replace(/\\/g, "/");
 
   // The spaced overlay must appear quoted in the `use` block and the `replace`
   // directive, and must never appear as a bare (unquoted) token.
@@ -100,6 +123,31 @@ export const test_writegowork_quotes_workspace_paths_with_spaces = () => {
   assert.ok(
     !goWork.includes(`"${bare}"`),
     `go.work must not quote the space-free path:\n${goWork}`,
+  );
+
+  assert.ok(
+    goWork.includes(`\n\t"${commentPrefix}"\n`),
+    `go.work should quote the comment-prefix use path:\n${goWork}`,
+  );
+
+  const parsed = child_process.spawnSync("go", ["work", "edit", "-json"], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, GOWORK: capture },
+    windowsHide: true,
+  });
+  if (parsed.error) throw parsed.error;
+  assert.equal(
+    parsed.status,
+    0,
+    `go work edit -json should parse generated go.work:\n${parsed.stderr || parsed.stdout}`,
+  );
+  const workspace = JSON.parse(parsed.stdout) as {
+    Use?: readonly { DiskPath?: string }[];
+  };
+  assert.ok(
+    workspace.Use?.some((entry) => entry.DiskPath === commentPrefix),
+    `go work edit -json should retain ${commentPrefix}:\n${parsed.stdout}`,
   );
 };
 


### PR DESCRIPTION
Closes #857

## Scope

Reserve the Go module token-quoting repair in `buildSourcePlugin`:

- mirror `modfile.MustQuote` for embedded comment openers and non-printable Unicode spaces;
- preserve the established `strconv.Quote` escaping path;
- prove generated `go.work` remains parseable for normalized UNC and extended Windows paths.

## Verification

Pending implementation. The final snapshot will run the focused source-plugin
suite and the broader feature suite locally. Campaign-triggered Actions runs
for this exact reservation SHA are being cancelled and recorded; repository
Actions configuration remains unchanged.
