### PR TITLE
fix(ttsc): bound resident transform request lifetimes

### DIFF
--- a/packages/ttsc/src/TtscService.ts
+++ b/packages/ttsc/src/TtscService.ts
@@ -4,6 +4,18 @@ import type { ResidentTransformProcess } from "./compiler/internal/residentTrans
 import { startResidentTransform } from "./compiler/internal/startResidentTransform";
 import type { ITtscCompilerContext } from "./structures/ITtscCompilerContext";
 
+/** Construction controls for the resident transform request lifecycle. */
+export interface TtscServiceOptions {
+  /** Maximum time one transform or update request may await the host's reply. */
+  requestTimeoutMs?: number;
+}
+
+/** Per-call controls for a resident transform or update request. */
+export interface TtscServiceRequestOptions {
+  /** Abort this call before it receives a reply. */
+  signal?: AbortSignal;
+}
+
 /**
  * Resident, incremental transform service for the `ttsc` TypeScript-Go
  * pipeline.
@@ -37,14 +49,20 @@ export class TtscService {
    * host. The context is the same shape {@link TtscCompiler} accepts; it is not
    * replaceable per call.
    */
-  public constructor(context: ITtscCompilerContext = {}) {
-    const started = startResidentTransform({
-      ...context,
-      env: context.env ? { ...context.env } : undefined,
-      plugins: Array.isArray(context.plugins)
-        ? [...context.plugins]
-        : context.plugins,
-    });
+  public constructor(
+    context: ITtscCompilerContext = {},
+    options: TtscServiceOptions = {},
+  ) {
+    const started = startResidentTransform(
+      {
+        ...context,
+        env: context.env ? { ...context.env } : undefined,
+        plugins: Array.isArray(context.plugins)
+          ? [...context.plugins]
+          : context.plugins,
+      },
+      options,
+    );
     this.resident = started.process;
     this.projectRoot = started.projectRoot;
   }
@@ -57,10 +75,14 @@ export class TtscService {
    * Rejects when the resident host failed to compile the project; the rejection
    * carries the host's diagnostics so callers can surface a real build error.
    */
-  public async transformFile(fileName: string): Promise<string | undefined> {
+  public async transformFile(
+    fileName: string,
+    options: TtscServiceRequestOptions = {},
+  ): Promise<string | undefined> {
     const reply = await this.resident.request(
       { file: this.absolutePath(fileName) },
       "transform",
+      options,
     );
     // The resident client already validated the reply shape (boolean `found`,
     // string `typescript` when found), so a malformed or wrong-shape reply
@@ -78,10 +100,15 @@ export class TtscService {
    * did not compile and the previous transform is still in effect. A relative
    * `fileName` is resolved against the project root.
    */
-  public async updateFile(fileName: string, content: string): Promise<boolean> {
+  public async updateFile(
+    fileName: string,
+    content: string,
+    options: TtscServiceRequestOptions = {},
+  ): Promise<boolean> {
     const reply = await this.resident.request(
       { content, update: this.absolutePath(fileName) },
       "update",
+      options,
     );
     // The resident client validated the reply carries a boolean `updated`, so a
     // malformed or wrong-shape reply rejected instead of collapsing to `false`.

--- a/packages/ttsc/src/compiler/internal/residentTransformProcess.ts
+++ b/packages/ttsc/src/compiler/internal/residentTransformProcess.ts
@@ -7,6 +7,15 @@ const STDERR_TAIL_LIMIT = 64 * 1024;
 /** Cap on how much of an offending line an error message echoes back. */
 const REPLY_ECHO_LIMIT = 200;
 
+/** Default deadline for one request to the resident transform host. */
+const DEFAULT_REQUEST_TIMEOUT_MS = 300_000;
+
+/** Node clamps timers beyond this signed 32-bit millisecond duration. */
+const MAX_TIMER_MS = 2_147_483_647;
+
+/** Allow a cooperative host a short shutdown window before forcing it down. */
+const TERMINATION_GRACE_MS = 1_000;
+
 /**
  * The operation a request expects a reply for. The host answers a transform
  * request (`{"file":...}`) with `{"typescript":...,"found":...}` and an update
@@ -23,12 +32,24 @@ export interface ResidentTransformProcessOptions {
   binary: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  /** Maximum time one request may wait for the resident host's reply. */
+  requestTimeoutMs?: number;
+}
+
+/** Per-request lifecycle controls for a resident transform host. */
+export interface ResidentTransformRequestOptions {
+  /** Abort this request. An in-flight abort retires the FIFO host. */
+  signal?: AbortSignal;
 }
 
 interface PendingRequest {
+  abort?: () => void;
   kind: ResidentReplyKind;
   reject: (reason: Error) => void;
   resolve: (reply: Record<string, unknown>) => void;
+  settled: boolean;
+  signal?: AbortSignal;
+  timer: NodeJS.Timeout;
 }
 
 /**
@@ -49,10 +70,12 @@ export class ResidentTransformProcess {
   private readonly child: ChildProcess;
   private readonly reader: Interface;
   private readonly pending: PendingRequest[] = [];
+  private readonly requestTimeoutMs: number;
   private stderr = "";
   private failure: Error | undefined;
 
   public constructor(options: ResidentTransformProcessOptions) {
+    this.requestTimeoutMs = normalizeRequestTimeoutMs(options.requestTimeoutMs);
     // Default stdio is "pipe" for stdin/stdout/stderr, which is exactly what the
     // line protocol needs; spelling it out as a string[] would not narrow to
     // StdioOptions, so it is left implicit.
@@ -102,9 +125,13 @@ export class ResidentTransformProcess {
   public request(
     payload: Record<string, unknown>,
     kind: ResidentReplyKind,
+    options: ResidentTransformRequestOptions = {},
   ): Promise<Record<string, unknown>> {
     if (this.failure !== undefined) {
       return Promise.reject(this.failure);
+    }
+    if (options.signal?.aborted) {
+      return Promise.reject(cancelledError(options.signal));
     }
     const stdin = this.child.stdin;
     if (stdin === null || stdin.destroyed) {
@@ -112,15 +139,54 @@ export class ResidentTransformProcess {
         new Error("ttsc: resident transform host stdin is closed"),
       );
     }
+    let line: string;
+    try {
+      line = `${JSON.stringify(payload)}\n`;
+    } catch (error) {
+      return Promise.reject(asError(error));
+    }
     return new Promise<Record<string, unknown>>((resolve, reject) => {
-      const pending: PendingRequest = { kind, reject, resolve };
+      let pending!: PendingRequest;
+      pending = {
+        kind,
+        reject,
+        resolve,
+        settled: false,
+        signal: options.signal,
+        timer: setTimeout(() => this.timeout(pending), this.requestTimeoutMs),
+      };
+      pending.timer.unref();
+      if (options.signal !== undefined) {
+        pending.abort = () => this.cancel(pending, options.signal!);
+        options.signal.addEventListener("abort", pending.abort, { once: true });
+      }
       this.pending.push(pending);
-      stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
-        if (error) {
-          this.removePending(pending);
-          reject(error);
-        }
-      });
+      if (options.signal?.aborted) {
+        pending.abort!();
+        return;
+      }
+      try {
+        stdin.write(line, (error) => {
+          if (error === null || error === undefined || pending.settled) {
+            return;
+          }
+          this.settlePending(pending, error);
+          this.fail(
+            new Error(
+              `ttsc: resident transform host could not write a request: ${error.message}`,
+            ),
+          );
+        });
+      } catch (error) {
+        if (pending.settled) return;
+        const reason = asError(error);
+        this.settlePending(pending, reason);
+        this.fail(
+          new Error(
+            `ttsc: resident transform host could not write a request: ${reason.message}`,
+          ),
+        );
+      }
     });
   }
 
@@ -129,31 +195,23 @@ export class ResidentTransformProcess {
    * call more than once.
    */
   public dispose(): void {
-    if (this.failure === undefined) {
-      // If the host already died, reject with its real exit error (stderr +
-      // exit code) rather than a bland "disposed" message.
-      this.failure =
-        this.child.exitCode !== null || this.child.signalCode !== null
-          ? this.exitError()
-          : new Error("ttsc: resident transform host disposed");
-    }
-    const stdin = this.child.stdin;
-    if (stdin !== null && !stdin.destroyed) {
-      stdin.end();
-    }
-    this.reader.close();
-    this.rejectAll(this.failure);
-    if (this.child.exitCode === null && this.child.signalCode === null) {
-      this.child.kill();
-    }
+    if (this.failure !== undefined) return;
+    // If the host already died, reject with its real exit error (stderr + exit
+    // code) rather than a bland "disposed" message.
+    this.fail(
+      this.child.exitCode !== null || this.child.signalCode !== null
+        ? this.exitError()
+        : new Error("ttsc: resident transform host disposed"),
+    );
   }
 
   private onLine(line: string): void {
+    if (this.failure !== undefined) return;
     const trimmed = line.trim();
     if (trimmed.length === 0) {
       return;
     }
-    const request = this.pending.shift();
+    const request = this.pending[0];
     if (request === undefined) {
       // The host must emit exactly one reply per request, so an unmatched line
       // is a protocol violation that would desync every later reply into the
@@ -179,7 +237,7 @@ export class ResidentTransformProcess {
           trimmed,
         )}`,
       );
-      request.reject(error);
+      this.settlePending(request, error);
       this.fail(error);
       return;
     }
@@ -189,7 +247,8 @@ export class ResidentTransformProcess {
       // line consumed exactly one slot — so only this request is corrupt; later
       // replies still pair correctly. Reject just this request instead of
       // failing the whole process.
-      request.reject(
+      this.settlePending(
+        request,
         new Error(
           `ttsc: resident transform host sent an invalid ${request.kind} reply: ${echoLine(
             trimmed,
@@ -198,32 +257,93 @@ export class ResidentTransformProcess {
       );
       return;
     }
-    request.resolve(reply);
+    this.settlePending(request, reply);
   }
 
   private onReaderClose(): void {
-    if (this.pending.length === 0) {
-      return;
-    }
-    this.rejectAll(this.failure ?? this.exitError());
+    if (this.failure === undefined) this.fail(this.exitError());
   }
 
   private fail(error: Error): void {
-    this.failure ??= error;
-    this.rejectAll(this.failure);
+    if (this.failure !== undefined) return;
+    this.failure = error;
+    this.rejectAll(error);
+    this.terminate();
   }
 
   private rejectAll(error: Error): void {
     while (this.pending.length !== 0) {
-      this.pending.shift()!.reject(error);
+      this.settlePending(this.pending[0]!, error);
     }
   }
 
-  private removePending(target: PendingRequest): void {
-    const index = this.pending.indexOf(target);
-    if (index !== -1) {
-      this.pending.splice(index, 1);
+  private settlePending(
+    pending: PendingRequest,
+    result: Error | Record<string, unknown>,
+  ): void {
+    if (pending.settled) return;
+    pending.settled = true;
+    const index = this.pending.indexOf(pending);
+    if (index !== -1) this.pending.splice(index, 1);
+    clearTimeout(pending.timer);
+    if (pending.signal !== undefined && pending.abort !== undefined) {
+      pending.signal.removeEventListener("abort", pending.abort);
     }
+    if (result instanceof Error) pending.reject(result);
+    else pending.resolve(result);
+  }
+
+  private timeout(pending: PendingRequest): void {
+    if (pending.settled) return;
+    const timeout = new Error(
+      `ttsc: resident transform request timed out after ${String(
+        this.requestTimeoutMs,
+      )} ms${stderrSuffix(this.stderr)}`,
+    );
+    this.settlePending(pending, timeout);
+    this.fail(
+      new Error(
+        `ttsc: resident transform host retired after another request timed out${stderrSuffix(
+          this.stderr,
+        )}`,
+      ),
+    );
+  }
+
+  private cancel(pending: PendingRequest, signal: AbortSignal): void {
+    if (pending.settled) return;
+    this.settlePending(pending, cancelledError(signal));
+    this.fail(
+      new Error(
+        `ttsc: resident transform host retired after another request was cancelled${abortDetail(
+          signal,
+        )}${stderrSuffix(this.stderr)}`,
+      ),
+    );
+  }
+
+  private terminate(): void {
+    const stdin = this.child.stdin;
+    if (stdin !== null && !stdin.destroyed) stdin.destroy();
+    if (this.child.exitCode !== null || this.child.signalCode !== null) return;
+    try {
+      this.child.kill();
+    } catch {
+      // The host exited between the liveness check and termination.
+      return;
+    }
+    const force = setTimeout(() => {
+      if (this.child.exitCode !== null || this.child.signalCode !== null) {
+        return;
+      }
+      try {
+        this.child.kill("SIGKILL");
+      } catch {
+        // The host exited between the liveness check and the forced signal.
+      }
+    }, TERMINATION_GRACE_MS);
+    force.unref();
+    this.child.once("exit", () => clearTimeout(force));
   }
 
   private exitError(): Error {
@@ -240,6 +360,48 @@ export class ResidentTransformProcess {
       `ttsc: resident transform host exited (code ${code ?? "null"}${signal})`,
     );
   }
+}
+
+/** Validate and normalize the caller-visible resident request deadline. */
+export function normalizeRequestTimeoutMs(requestTimeoutMs?: number): number {
+  const value = requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  if (
+    !Number.isSafeInteger(value) ||
+    value <= 0 ||
+    value > MAX_TIMER_MS
+  ) {
+    throw new TypeError(
+      `ttsc: requestTimeoutMs must be an integer between 1 and ${String(MAX_TIMER_MS)}`,
+    );
+  }
+  return value;
+}
+
+function cancelledError(signal: AbortSignal): Error {
+  const error = new Error(
+    `ttsc: resident transform request cancelled${abortDetail(signal)}`,
+  );
+  error.name = "AbortError";
+  return error;
+}
+
+function abortDetail(signal: AbortSignal): string {
+  const reason = signal.reason;
+  if (reason === undefined) return "";
+  try {
+    return `: ${reason instanceof Error ? reason.message : String(reason)}`;
+  } catch {
+    return "";
+  }
+}
+
+function stderrSuffix(stderr: string): string {
+  const detail = stderr.trim();
+  return detail.length === 0 ? "" : `: ${detail}`;
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }
 
 /**

--- a/packages/ttsc/src/compiler/internal/startResidentTransform.ts
+++ b/packages/ttsc/src/compiler/internal/startResidentTransform.ts
@@ -4,7 +4,10 @@ import { loadProjectPlugins } from "../../plugin/internal/loadProjectPlugins";
 import type { ITtscCompilerContext } from "../../structures/ITtscCompilerContext";
 import type { ITtscLoadedNativePlugin } from "../../structures/internal/ITtscLoadedNativePlugin";
 import { readProjectConfig } from "./project/readProjectConfig";
-import { ResidentTransformProcess } from "./residentTransformProcess";
+import {
+  normalizeRequestTimeoutMs,
+  ResidentTransformProcess,
+} from "./residentTransformProcess";
 import { resolveBinary } from "./resolveBinary";
 import { resolveTsgo } from "./resolveTsgo";
 import {
@@ -21,6 +24,11 @@ import {
 export interface StartedResidentTransform {
   process: ResidentTransformProcess;
   projectRoot: string;
+}
+
+/** Construction controls owned by the resident request client. */
+export interface StartResidentTransformOptions {
+  requestTimeoutMs?: number;
 }
 
 /**
@@ -40,7 +48,9 @@ export interface StartedResidentTransform {
  */
 export function startResidentTransform(
   context: ITtscCompilerContext,
+  options: StartResidentTransformOptions = {},
 ): StartedResidentTransform {
+  const requestTimeoutMs = normalizeRequestTimeoutMs(options.requestTimeoutMs);
   const cwd = path.resolve(context.cwd ?? process.cwd());
   const project = readProjectConfig({
     cwd,
@@ -80,6 +90,7 @@ export function startResidentTransform(
     binary: host.binary,
     cwd: project.root,
     env: residentEnv(context, tsgoBinary, loaded.nativePlugins),
+    requestTimeoutMs,
   });
   return { process: resident, projectRoot: project.root };
 }

--- a/tests/test-ttsc/src/features/api/test_residenttransformprocess_request_bounds.ts
+++ b/tests/test-ttsc/src/features/api/test_residenttransformprocess_request_bounds.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+
+import { ResidentTransformProcess } from "../../../../../packages/ttsc/lib/compiler/internal/residentTransformProcess.js";
+
+/** A host that stays alive and consumes stdin but intentionally never replies. */
+const SILENT_STUB = `
+process.stdin.resume();
+setInterval(() => {}, 1_000);
+`;
+
+/** A host that answers one transform request after a controlled delay. */
+function delayedReplyStub(delayMs: number): string {
+  return `
+process.stdin.setEncoding("utf8");
+let buf = "";
+process.stdin.on("data", (chunk) => {
+  buf += chunk;
+  let i;
+  while ((i = buf.indexOf("\\n")) !== -1) {
+    const line = buf.slice(0, i);
+    buf = buf.slice(i + 1);
+    if (line.trim().length === 0) continue;
+    const request = JSON.parse(line);
+    setTimeout(() => {
+      process.stdout.write(JSON.stringify({ found: true, typescript: request.file }) + "\\n");
+    }, ${String(delayMs)});
+  }
+});
+`;
+}
+
+function spawnStub(
+  stub: string,
+  requestTimeoutMs: number,
+): ResidentTransformProcess {
+  return new ResidentTransformProcess({
+    args: ["-e", stub],
+    binary: process.execPath,
+    requestTimeoutMs,
+  });
+}
+
+function pendingCount(process: ResidentTransformProcess): number {
+  return (
+    process as unknown as {
+      pending: unknown[];
+    }
+  ).pending.length;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Verifies the resident client bounds a live-silent FIFO host without losing
+ * reply ownership.
+ *
+ * A timeout or in-flight cancellation cannot remove one positional slot and
+ * continue reading, because a reply that arrives later would then be paired to
+ * the wrong caller. The process is consequently retired and this client fails
+ * closed. The request that caused retirement retains its specific error, while
+ * other pending calls receive the host-retirement error.
+ *
+ * 1. Reject invalid deadlines and preserve a delayed reply within the bound.
+ * 2. Time out two pipelined requests, clear their pending state, and fail a
+ *    later call closed.
+ * 3. Preserve cancellation before write as one caller's concern, then prove an
+ *    in-flight cancellation retires a shared host without leaving another
+ *    pending request behind.
+ * 4. Deliver a synthetic late protocol line after retirement and prove it
+ *    cannot settle a later caller; dispose remains idempotent after timeout.
+ */
+export const test_residenttransformprocess_request_bounds = async () => {
+  for (const value of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.throws(
+      () => spawnStub(SILENT_STUB, value),
+      /requestTimeoutMs/,
+    );
+  }
+  assert.throws(
+    () => spawnStub(SILENT_STUB, 2_147_483_648),
+    /requestTimeoutMs/,
+  );
+
+  // A host may be slow without being failed. Its reply remains valid while it
+  // lands inside the caller-selected bound.
+  {
+    const proc = spawnStub(delayedReplyStub(40), 500);
+    try {
+      const reply = await proc.request({ file: "slow.ts" }, "transform");
+      assert.equal(reply.typescript, "slow.ts");
+    } finally {
+      proc.dispose();
+    }
+  }
+
+  // A silent host leaves no request pending forever. Every concurrent entry
+  // settles, and future requests fail closed instead of reusing an untrusted
+  // FIFO stream.
+  {
+    const proc = spawnStub(SILENT_STUB, 60);
+    try {
+      const first = proc.request({ file: "first.ts" }, "transform");
+      const second = proc.request({ file: "second.ts" }, "transform");
+      await assert.rejects(() => first, /timed out after 60 ms/);
+      await assert.rejects(
+        () => second,
+        /retired after another request timed out/,
+      );
+      assert.equal(pendingCount(proc), 0);
+      await assert.rejects(
+        () => proc.request({ file: "after.ts" }, "transform"),
+        /retired after another request timed out/,
+      );
+      proc.dispose();
+      proc.dispose();
+    } finally {
+      proc.dispose();
+    }
+  }
+
+  // An already-aborted signal is never written into the FIFO. It rejects only
+  // that call and leaves the still-healthy host available to another caller.
+  {
+    const proc = spawnStub(delayedReplyStub(0), 500);
+    const controller = new AbortController();
+    controller.abort("caller stopped before write");
+    try {
+      await assert.rejects(
+        () => proc.request({ file: "cancelled.ts" }, "transform", {
+          signal: controller.signal,
+        }),
+        (error: Error) =>
+          error.name === "AbortError" &&
+          /caller stopped before write/.test(error.message),
+      );
+      const reply = await proc.request({ file: "healthy.ts" }, "transform");
+      assert.equal(reply.typescript, "healthy.ts");
+    } finally {
+      proc.dispose();
+    }
+  }
+
+  // Once a request has entered the FIFO, cancelling it retires the host. The
+  // caller sees AbortError, while a concurrent request settles with a distinct
+  // collateral failure instead of hanging or receiving a mismatched reply.
+  {
+    const proc = spawnStub(SILENT_STUB, 500);
+    const controller = new AbortController();
+    try {
+      const cancelled = proc.request({ file: "cancelled.ts" }, "transform", {
+        signal: controller.signal,
+      });
+      const collateral = proc.request({ file: "other.ts" }, "transform");
+      controller.abort("editor closed the file");
+      await assert.rejects(
+        cancelled,
+        (error: Error) =>
+          error.name === "AbortError" &&
+          /editor closed the file/.test(error.message),
+      );
+      await assert.rejects(
+        collateral,
+        /retired after another request was cancelled/,
+      );
+      assert.equal(pendingCount(proc), 0);
+    } finally {
+      proc.dispose();
+    }
+  }
+
+  // A line buffered after retirement belongs to no new request. Calling the
+  // reader boundary directly models that late pipe tail without relying on a
+  // platform-specific child-process kill race.
+  {
+    const proc = spawnStub(SILENT_STUB, 40);
+    try {
+      await assert.rejects(
+        () => proc.request({ file: "late.ts" }, "transform"),
+        /timed out after 40 ms/,
+      );
+      (
+        proc as unknown as {
+          onLine: (line: string) => void;
+        }
+      ).onLine(JSON.stringify({ found: true, typescript: "late.ts" }));
+      await delay(10);
+      await assert.rejects(
+        () => proc.request({ file: "later.ts" }, "transform"),
+        /retired after another request timed out/,
+      );
+    } finally {
+      proc.dispose();
+      proc.dispose();
+    }
+  }
+};

--- a/tests/test-ttsc/src/native-plugins/service/test_ttscservice_transforms_a_file_through_the_resident_host.ts
+++ b/tests/test-ttsc/src/native-plugins/service/test_ttscservice_transforms_a_file_through_the_resident_host.ts
@@ -30,17 +30,21 @@ export const test_ttscservice_transforms_a_file_through_the_resident_host =
   async () => {
     const root = TestProject.copyProject("ttsc-utility-plugins");
     TestUtilityPlugins.seedPackages(root);
-    const service = new TtscService({
-      binary: tsgo,
-      cwd: root,
-      env: {
-        PATH: TestUtilityPlugins.goPath(),
-        TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-resident-"),
+    const service = new TtscService(
+      {
+        binary: tsgo,
+        cwd: root,
+        env: {
+          PATH: TestUtilityPlugins.goPath(),
+          TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-resident-"),
+        },
       },
-    });
+      { requestTimeoutMs: 30_000 },
+    );
     try {
       const first = await service.transformFile(
         path.join(root, "src", "main.ts"),
+        { signal: new AbortController().signal },
       );
       assert.ok(first, "resident host returned no output for src/main.ts");
       // The banner is a source-preamble plugin, so its block must appear in the

--- a/website/src/content/docs/development/reference/programmatic-api.mdx
+++ b/website/src/content/docs/development/reference/programmatic-api.mdx
@@ -136,10 +136,16 @@ In that case the parent cache root itself is never removed (it may be shared wit
 ```ts
 import { TtscService } from "ttsc";
 
-const service = new TtscService({ cwd: "/abs/path/to/project" });
+const service = new TtscService(
+  { cwd: "/abs/path/to/project" },
+  { requestTimeoutMs: 60_000 },
+);
 try {
   // The file's post-plugin TypeScript, or undefined when it is not in the program.
-  const code = await service.transformFile("src/index.ts");
+  const request = new AbortController();
+  const code = await service.transformFile("src/index.ts", {
+    signal: request.signal,
+  });
 
   // Apply an unsaved edit and re-transform; a later transformFile reflects it.
   const ok = await service.updateFile("src/index.ts", "export const x: number = 2;\n");
@@ -150,11 +156,13 @@ try {
 }
 ```
 
-The constructor takes the same [`ITtscCompilerContext`](#context-options) and launches the host synchronously; the host compiles in the background, so the first `transformFile` resolves once that compile lands.
+The constructor takes the same [`ITtscCompilerContext`](#context-options), followed by optional `{ requestTimeoutMs }`, and launches the host synchronously; the host compiles in the background, so the first `transformFile` resolves once that compile lands. The request deadline defaults to five minutes. It must be a positive integer no greater than Node's maximum timer duration (2,147,483,647 ms).
 
 - `transformFile(name)` → `Promise<string | undefined>`. The file's post-plugin TypeScript source. A relative `name` resolves against the project root. Resolves `undefined` when the file is outside the compiled program. Rejects when the project failed to compile, carrying the host's diagnostics in the rejection.
 - `updateFile(name, content)` → `Promise<boolean>`. Apply new in-memory content for a file and re-transform. Returns whether the rebuild succeeded; `false` means the edit did not compile and the previous transform is still in effect.
 - `dispose()`. Terminate the resident host and reject any in-flight requests. Always call it (use `try`/`finally`) so the host process does not leak.
+
+Pass `{ signal }` as the optional final argument to `transformFile` or `updateFile` to cancel one call. A request that exceeds `requestTimeoutMs` rejects with a timeout error. Passing an already-aborted signal rejects only that call before it enters the host's FIFO. Once a request has been written, a timeout or cancellation retires the host because a later reply could no longer be safely paired. Any concurrent requests reject with a distinct host-retirement error. `TtscService` then fails closed: later calls reject with that error rather than respawning a host. Construct a new service when the caller wants a fresh resident program.
 
 `undefined` and `false` are the service's domain negatives — a genuinely absent file and an edit that did not compile. A reply the host could never validly send (a malformed line, a non-object, or a well-formed object of the wrong operation shape) is a protocol failure, not a negative result: the call rejects rather than collapsing to `undefined`/`false`, and a corrupt line can no longer be mispaired with a later request.
 


### PR DESCRIPTION
Closes #825.

## Reservation

This draft reserves the resident `TtscService` request-lifecycle surface only:

- `ResidentTransformProcess` request lifetime, FIFO teardown, and child retirement;
- public timeout and per-call cancellation controls on `TtscService`;
- direct protocol regressions, existing real native-service lanes, and the programmatic API guide.

No implementation is included in this claim commit. Verification is pending. Campaign Actions runs for every branch SHA are supervised and cancelled by exact SHA only.