### PR TITLE
docs(agents): make campaign workflows solo by default

### DIFF
--- a/.agents/skills/benchmark/SKILL.md
+++ b/.agents/skills/benchmark/SKILL.md
@@ -21,17 +21,17 @@ Read both only when changing shared fixture infrastructure or a surface that aff
 
 ## Benchmark Improvement Campaigns
 
-When benchmark evidence leads to multiple published issues and the user authorizes repeated issue-to-pull-request implementation, use the issue-campaign skill with this skill. This skill owns workload integrity, measurement, fixture handling, and result publication. The issue-campaign skill owns issue publication, regrouping every published and unclaimed dependency-ready node into cohesive batches, active claim stability, implementation, and Post-Campaign Cleanup.
+When benchmark evidence leads to multiple published issues and the user authorizes repeated issue-to-pull-request implementation, use the issue-campaign skill with this skill. This skill owns workload integrity, measurement, fixture handling, and result publication. The applicable issue-campaign workflow owns issue publication, implementation topology, claim stability, CI, review, cleanup, and renewed discovery. The default is the solo workflow; use the multi-agent workflow only on an explicit parallel request.
 
 ## Temporary Asset Cleanup
 
-Each benchmark run must own an exact temporary root. Place run-only worktrees, cloned repositories, indexes, Go build caches, and Go temporary directories below it. For Go commands, set `GOCACHE` and `GOTMPDIR` to run-specific directories rather than the user's shared Go cache or system temp directory.
+Each benchmark run must own an exact temporary root. A solo run uses the current checkout and existing fixture checkouts; do not create a clone or worktree. Place run-only indexes, Go build caches, and Go temporary directories below the exact root. For Go commands, set `GOCACHE` and `GOTMPDIR` to run-specific directories rather than the user's shared Go cache or system temp directory.
 
-After a run, retry, aborted attempt, or completed benchmark campaign, preserve the report and any user-authorized fixture change, then remove the run's exact temporary root. First confirm no process still uses it, then verify the directory is absent. Never recursively clean shared `GOCACHE`, `GOMODCACHE`, `GOPATH`, or a broad temp directory. A `--keep-...` option or another explicit user retention request is the only exception; record the retained path and reason.
+After a run, retry, aborted attempt, or completed benchmark-driven campaign, preserve the report and any user-authorized fixture change, then remove the run's exact temporary root. First confirm no process still uses it, then verify the directory is absent. Never recursively clean shared `GOCACHE`, `GOMODCACHE`, `GOPATH`, or a broad temp directory. A `--keep-...` option or another explicit user retention request is the only exception; record the retained path and reason.
 
 ## Fixture Changes
 
-Benchmark setup resets local fixture clones to their upstream branch tips. Edit the fixture repository itself, not a clone under a benchmark work directory.
+Benchmark setup resets existing local fixture checkouts to their upstream branch tips. Edit the fixture repository itself, not a new clone under a benchmark work directory.
 
 Finish every fixture change before pushing it:
 

--- a/.agents/skills/development/SKILL.md
+++ b/.agents/skills/development/SKILL.md
@@ -32,7 +32,7 @@ These four are never acceptable; choosing any one means the approach is already 
 - Plugin descriptors are JS; transform logic is Go. JS transform functions (e.g. `transformSource`, `transformOutput`) are not part of the public contract.
 - `shim.go` files marked `gen_shims:hand-maintained` are not regenerated.
 - When code behavior changes, update the matching page under `website/src/content/docs/` in the same change.
-- Run `pnpm format` before every ordinary commit and stage the result; never commit unformatted output. The sole exception is an active issue campaign: campaign issue pull requests must not run the repository-wide formatter, and the issue-campaign skill performs one dedicated Post-Campaign Cleanup format pull request after the campaign ends.
+- Run `pnpm format` before every ordinary commit and stage the result; never commit unformatted output. A solo issue campaign formats its unified cycle pull request. The sole exception is an active multi-agent issue campaign implementation batch: its detailed procedure owns the repository-wide formatter result and integrated cleanup.
 
 ## Consequence Analysis
 

--- a/.agents/skills/issue-campaign/SKILL.md
+++ b/.agents/skills/issue-campaign/SKILL.md
@@ -1,42 +1,49 @@
 ---
 name: issue-campaign
-description: Defines repository-wide issue discovery, lead-vetted issue publication, per-push CI cancellation during implementation waves, and post-campaign cleanup for ttsc. Use when the user asks for a broad audit, many issue candidates, or a repeated issue-to-pull-request campaign; do not use for one already-defined issue or an ordinary pull request.
+description: "Defines the default solo repository-wide issue campaign for ttsc: exhaustive discovery, lead-vetted issue publication, one unified CI-validated implementation pull request per cycle, solo Self-Review, and repeated rediscovery until a full clean round. Use for broad audits, many issue candidates, or repeated issue-to-pull-request campaigns unless the user explicitly requests parallel or multi-agent execution; do not use for one already-defined issue or an ordinary pull request."
 ---
 
 # Issue Campaign
 
-An issue campaign is a repeatable sequence of exhaustive discovery, issue publication, implementation pull requests, and final repository cleanup. The user's requested phase boundary controls how far to proceed; do not infer permission to publish issues, push branches, open pull requests, or merge from an audit-only request.
+An issue campaign is a repeatable solo sequence of exhaustive discovery, issue publication, one unified implementation pull request, and renewed discovery. The main agent owns every phase and never spawns or delegates to a subagent.
 
-Choose the principled course throughout the campaign. Its scale, duration, and consequence surface require stronger evidence, deeper consequence analysis, and complete verification; they never justify accepting an unverified candidate, a shortcut, or a weaker implementation or review standard.
+Use the [multi-agent skill](../multi-agent/SKILL.md) and its issue-campaign procedure instead only when the user explicitly asks for a parallel or multi-agent issue campaign.
 
-Read the project, development, and review skills before starting, and require every discovery-agent brief to do the same. Use the review skill's Issue Discovery Rounds; issue discovery is independent review, not discussion.
+The user's requested phase boundary controls how far to proceed. Do not infer permission to publish issues, push branches, open pull requests, or merge from an audit-only request.
+
+Apply [AGENTS.md's **Choose the principled course** rule](../../../AGENTS.md#attitude) to every admission, disposition, implementation, and review decision.
+
+Read the project and review skills before starting. Use the review skill's Solo Issue Discovery Rounds. Read [development.md](development.md) in full only when implementation is authorized.
 
 ## Campaign Knowledge Base
 
-Create `.wiki/<campaign>/` with a short filesystem-safe campaign name. Preserve any existing campaign directory and reconcile it rather than deleting or assuming a blank slate.
+Create `.wiki/<campaign>/` with a short filesystem-safe campaign name. Preserve and reconcile an existing campaign directory.
 
 Keep concise, current Markdown documents for:
 
-- repository provenance, architecture, and ownership boundaries;
+- repository provenance, architecture, validation ownership, and product boundaries;
 - experiments, reproductions, dogfooding, and related issue or pull-request history;
-- candidates, evidence, dependencies, and lead disposition;
-- implementation pull requests, local verification, and cancelled campaign-run records when those phases apply.
+- every raw candidate, its evidence, dependencies, and final disposition;
+- candidate combinations, splits, rejections, deferrals, and the evidence supporting each decision; and
+- the published-issue DAG, internal implementation order, the unified cycle pull request, CI and Self-Review iterations, external blockers, campaign timing, and cleanup state.
+
+Record raw candidates before fact-checking. The knowledge base is the durable place to collect overlapping observations, then combine, split, rewrite, reject, or defer them without losing why.
 
 The knowledge base supports the campaign but is not the final issue body. A published issue must stand alone without access to `.wiki`.
 
 ## Discover Issues
 
-Run the review skill's Issue Discovery Rounds over the entire declared campaign scope. Every agent independently audits the whole surface in every round. Never divide it by package, file, concern, platform, candidate class, agent, or round.
+Perform one complete Solo Issue Discovery Round over the entire declared campaign scope. Source is only one evidence layer. Exercise real workflows and inspect relevant upstream behavior, history, generated artifacts, consumers, fixtures, public documentation, and closed decisions.
 
-Source is only one evidence layer. Exercise real workflows and inspect relevant upstream behavior, history, generated artifacts, consumers, fixtures, and public documentation.
+Treat the development skill's [Forbidden](../development/SKILL.md#forbidden) section as a retrospective audit contract, not only a rule for future changes. In every complete round, inspect the implementation and history for a verified violation, even when existing tests pass. Prove the classification from purpose, control flow, consequence, and history. Resemblance or stylistic preference is not evidence.
 
-Treat the development skill's **Forbidden** section as an explicit retrospective audit contract, not only a rule for future changes. In every complete round, inspect the current implementation and its history for violations, including code that predates the campaign or passes every test. A verified violation is a meaningful issue candidate. Prove the classification from purpose, control flow, consequence, and history; resemblance or stylistic preference alone is not evidence.
+Do not stop after finding enough work for a pull request. Complete the entire scope, adjudicate the full candidate pool, and publish only the surviving issues when authorized.
 
-Discovery ends only when a complete round from every agent produces no meaningful candidate that survives lead verification.
+After the cycle pull request merges, begin a fresh full-scope round against the integrated repository. Earlier rounds are not coverage. The campaign ends only when a complete fresh round produces no meaningful issue candidate after fact-checking and no accepted issue remains unresolved.
 
 ## Vet And Publish Issues
 
-The lead, not a discovery agent, owns every publication decision. For each candidate:
+The same main agent owns every publication decision. For each candidate:
 
 1. Reopen its evidence and reproduce the behavior.
 2. Verify ownership, provenance, and any claimed classification under the development skill's **Forbidden** section.
@@ -55,12 +62,12 @@ Write enough context for a fresh AI agent to begin implementation from the issue
 - **Consequence surface:** affected consumers, states, platforms, compatibility and failure paths, plus the complete case matrix for the cause.
 - **Approach:** the invariant and architectural owner, without prescribing an unverified implementation.
 - **Acceptance and verification:** positive, negative, boundary, and regression outcomes with narrow and broader proving commands.
-- **Coordination:** dependencies, safe parallelism, exclusions, migration concerns, and related open, closed, accepted, or rejected work.
+- **Coordination:** dependencies, exclusions, migration concerns, external blockers, and related open, closed, accepted, or rejected work.
 
 Use tables for repeated case mappings. Read the rendered issue back and keep its body as the current operative handoff; use comments only for chronology.
 
 ## Develop And Repeat The Campaign
 
-Read [development.md](development.md) in full when the user authorizes implementation pull requests or ends a campaign that entered implementation. It owns issue admission, DAG-based batching, immediate claim pull requests, implementation-wave CI cancellation, non-idling implementation and review, worktree and scoped Go-temporary-asset cleanup, renewed discovery, the no-format rule, and Post-Campaign Cleanup. It requires cancellation to begin immediately after every implementation-wave remote mutation, but a pending local command or cancellation poll must never make an implementation agent idle; all cancellation records must be complete before merge.
+Read [development.md](development.md) in full when the user authorizes implementation pull requests or the end of a campaign that entered implementation. It owns the single cycle pull request, empty claim, internal DAG order, test authoring, formatting, ordinary CI, red-CI repair, solo Self-Review, merge, branch and temporary-asset cleanup, and renewed discovery.
 
-An audit or issue-publication-only campaign does not load this campaign's [implementation procedure](development.md) or mutate repository Actions.
+An audit-only or issue-publication-only campaign does not load the development procedure or mutate repository or GitHub state beyond the authorized publications.

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -1,160 +1,107 @@
-# Campaign Development
+# Solo Campaign Development
 
-Read this document in full when the user authorizes implementation pull requests or ends a campaign that entered implementation. Also read the repository development, pull-request, and review skills before acting.
+Read this document in full when the user authorizes implementation pull requests or the end of a solo issue campaign that entered implementation. Also read the repository development, pull-request, and review skills before acting.
 
 ## Flow
 
-- [Cancel Implementation-Wave CI](#cancel-implementation-wave-ci)
-- [Admit And Reserve A Pull Request Wave](#admit-and-reserve-a-pull-request-wave)
-- [Keep Working While Commands Run](#keep-working-while-commands-run)
-- [Implement And Revalidate A Batch](#implement-and-revalidate-a-batch)
-- [Remove Every Finished Worktree](#remove-every-finished-worktree)
-- [While Campaign CI Is Cancelled](#while-campaign-ci-is-cancelled)
-- [Repeat A Campaign Cycle](#repeat-a-campaign-cycle)
-- [Post-Campaign Cleanup](#post-campaign-cleanup)
+- [Plan One Cycle Pull Request](#plan-one-cycle-pull-request)
+- [Claim The Complete Cycle](#claim-the-complete-cycle)
+- [Implement And Write Tests](#implement-and-write-tests)
+- [Validate With CI And Self-Review](#validate-with-ci-and-self-review)
+- [Merge And Clean Up](#merge-and-clean-up)
+- [Repeat Until A Clean Round](#repeat-until-a-clean-round)
 
-Three rules govern the entire implementation phase:
+Four rules govern the implementation phase:
 
-- Local tests, lead verification, and solo Self-Review are the implementation gates.
-- Do not run `pnpm format` during discovery, issue publication, or implementation. Post-Campaign Cleanup owns the repository-wide formatter result.
-- Never disable repository Actions or any workflow for a campaign. After every implementation-wave push and pull-request creation, immediately start cancellation only for runs caused by that campaign commit. Keep the cancellation record current and complete it before merge, but do not make local development wait for it.
+- The main agent performs all implementation, test authoring, CI diagnosis, review, and cleanup. Do not spawn or delegate to a subagent.
+- Put every accepted, implementation-ready issue in the current cycle into one pull request. The issue DAG controls implementation order inside that pull request, not pull-request count.
+- Work in the current checkout and one topic branch. Do not create a clone or worktree for a solo campaign or its Self-Review.
+- The pull request's ordinary CI and a clean solo Self-Review are the acceptance gates. Repair every red CI lane in that same pull request, even when the failure predates the campaign or is unrelated to its original issues.
 
-## Cancel Implementation-Wave CI
+## Plan One Cycle Pull Request
 
-Repository-wide Actions and workflow settings must remain unchanged. Before the first push, record `gh api repos/{owner}/{repo}/actions/permissions` and `gh workflow list --all --limit 1000 --json id,name,path,state` in `.wiki/<campaign>/ci-state.md` so the lead can prove the campaign did not alter them.
+Recompute the published-issue dependency DAG after publication. Record dependencies because they determine safe edit order and when one fix can expose another, but do not partition ready issues into separate pull requests.
 
-Every implementation-wave push gets a cancellation record. Start it immediately in a background supervisor rather than leaving an implementation agent to poll it:
+Build the cycle scope in this order:
 
-1. Record the campaign branch and pushed commit SHA.
-2. List runs for that exact SHA with `gh run list --commit <sha> --limit 100 --json databaseId,headBranch,headSha,status,conclusion,url`.
-3. Cancel every `queued`, `in_progress`, `waiting`, `pending`, or `requested` run for that SHA with `gh run cancel <run-id>`. Never cancel by broad repository, workflow, or contributor filters.
-4. Poll again because push, pull-request, chained, and ruleset runs can appear after the first query. Continue until two consecutive polls find no new run and every observed run is terminal; every run observed as active must end `cancelled`, while a run already terminal when first observed is only recorded.
-5. Record the run IDs and final states in `.wiki/<campaign>/ci-state.md`. If enumeration, cancellation, or readback fails, surface the failure and suspend later remote mutations and merge until it is repaired.
+1. Reopen every published, unclaimed issue and verify it still belongs to this repository and campaign.
+2. Remove only issues proved duplicate, invalid, out of scope, or externally blocked, and record the exact disposition. An accepted unresolved issue prevents campaign completion.
+3. Check open pull requests and remote branches for overlapping work before claiming.
+4. Put every remaining issue into one cycle ledger with its acceptance matrix, consequence surface, affected files, and DAG predecessors.
+5. Record the issue count before grouping and the result as one pull-request unit.
 
-Opening or updating an implementation pull request can enqueue additional runs for the already-pushed SHA. Start the same background record immediately after pull-request creation and after any operation that retriggers checks. The exact-SHA boundary is mandatory: never cancel unrelated contributors' runs.
+Different packages, invariants, or validation lanes do not split the solo cycle. Keep issue-level commits when that improves diagnosis, but the pull request remains the integrated campaign unit.
 
-A live cancellation record does not block reading source, changing code, writing tests, starting local commands, committing, or Self-Review. It is a merge gate, not an excuse to idle. The initial claim push and the immediately following claim pull request are one reservation transaction, so opening that pull request does not wait for the first poll. Before merge, read every campaign SHA record back and require the final terminal state described above.
+An issue whose only predecessor is another issue in the same cycle is implementation-ready for this purpose. Order the edits through the DAG instead of deferring it to another pull request.
 
-## Admit And Reserve A Pull Request Wave
+## Claim The Complete Cycle
 
-Only a published, admitted, unclaimed issue can enter a new implementation batch. The lead first reopens the issue evidence, reproduces the reported behavior, verifies ownership and the full consequence surface, compares related open and closed work, and records an accept, partial acceptance, rewrite, combine, split, reject, or defer disposition. A rejected or deferred issue has no worktree and no claim pull request.
+Claim the whole cycle before implementation:
 
-Recompute the published-issue dependency DAG after publication and before every implementation wave. A published issue is an evidence and acceptance unit, not a default pull-request boundary. Form the smallest number of maximal cohesive batches that the verified dependencies and implementation surfaces permit.
+1. Use the current checkout, update the target branch with `git pull --ff-only`, and create one topic branch. Do not create a clone or worktree.
+2. Create one implementation-free commit with `git commit --allow-empty`.
+3. Push the branch and open one draft pull request.
+4. Link every cycle issue, mark verification pending, and state that the pull request owns the complete accepted cycle.
+5. Record the checkout, branch, pull request, head SHA, issue set, and external temporary-asset ledger in `.wiki`.
 
-Admit two or more dependency-ready issues to one batch only when every row below supports the same implementation unit:
+The empty pull request prevents overlapping contributor work before code is written. Measure official duration from its GitHub `createdAt` timestamp through `mergedAt`, including implementation, CI, review, fixes, rebases, and merge.
 
-| Decision axis | Group when | Split when |
-| --- | --- | --- |
-| Dependency readiness | Every issue is ready on the same DAG frontier and the batch can finish without waiting for another member or an external state transition. | An issue has a different prerequisite, external blocker, release gate, or target-branch timing. |
-| Architectural ownership and root cause | The issues belong to the same repository, target branch, and architectural owner, and repair the same verified root cause. | They belong to different repositories, target branches, architectural owners, independently releasable contracts, or root causes. |
-| Change and consequence surface | The owned files overlap, must move together, or form one traceable consequence surface. Disjoint files may still group when one root cause requires all of them. | The changes can land and roll back independently without leaving either issue incomplete. |
-| Verification | The issues share most setup, focused regressions, generated consequences, and broad validation lanes. | They require materially different environments, validation owners, or merge gates, or one failure would unnecessarily block the others. |
-| Atomicity and review | One diff can keep every issue's acceptance matrix explicit and can be reviewed, reverted, and diagnosed as one coherent change. | Combining them obscures root cause, issue-level acceptance, rollback, or failure attribution. |
+## Implement And Write Tests
 
-Topic, label, package proximity, reporter, and issue count do not justify a batch by themselves. File disjointness does not require a split when one root cause and verification lane bind the files, and file overlap does not justify grouping issues with different readiness or atomicity.
+Work through the DAG on the claimed topic branch. Analyze the full consequence and case surface across every issue before editing, then implement the complete cycle and its tests.
 
-Build each wave in this order:
+Each issue remains an evidence and acceptance unit inside the combined diff. Keep its positive, negative, boundary, and regression cases identifiable. Near-100% coverage of changed behavior is required; a green happy path is not completion.
 
-1. Take every published, admitted, unclaimed node on the current dependency frontier.
-2. Partition the nodes by architectural owner and verified root cause.
-3. Merge partitions that share a change and consequence surface and most verification work while preserving issue-level acceptance and rollback.
-4. Split only for a named dependency, ownership, atomicity, or validation reason from the table.
-5. Check open pull requests and remote branches for overlapping implementation immediately before claiming.
-6. Freeze the batch once its empty claim pull request exists. Do not close, move, or combine an active claim merely to improve throughput statistics; change it only when correctness, overlap, or invalidated evidence requires a lead decision.
+Follow the development skill for test shape and narrow-then-broad local evidence. Do not treat a local build or test result as a substitute for the pull request's ordinary CI acceptance gate. After the source, tests, documentation, fixtures, and generated consequences are ready, run `pnpm format` and include its integrated result in the same pull request.
 
-Run disjoint dependency-ready batches concurrently up to practical capacity and serialize batches that overlap or depend on one another. Assign one batch to one agent, worktree, branch, and pull request.
+If implementation disproves, narrows, or externally blocks an issue, reopen the evidence and update the issue and campaign ledger before changing the claimed scope. Do not leave an orphan issue or pretend an unresolved accepted issue was completed.
 
-Record the DAG edges, the issues in each batch, the architectural owner and root cause, the owned change and consequence surfaces, the shared verification lane, every grouping reason, and every split reason in the campaign knowledge base. Report the pull-request unit count before batching and after batching before opening claims.
+## Validate With CI And Self-Review
 
-The agent assigned an admitted batch reserves its surface before installing dependencies or writing implementation code:
+Commit and push the formatted integrated snapshot, then let every ordinary pull-request check run. Start solo Self-Review immediately over that exact base-to-head diff while CI executes.
 
-1. Create one isolated worktree and topic branch.
-2. Create `<worktree>/.campaign-tmp/go-cache` and `<worktree>/.campaign-tmp/go-tmp`. Every Go command for that batch must set `GOCACHE` and `GOTMPDIR` to those exact directories. Do not reuse the user's global Go cache or temp directory for campaign-only build assets.
-3. Create one implementation-free claim commit with `git commit --allow-empty`.
-4. Push the branch, start its exact-SHA cancellation record, and immediately open a draft claim pull request that overviews the batch scope and links every batched issue. This is an empty reservation pull request, not a request to wait for setup or validation.
-5. Start the pull-request-triggered cancellation record, mark verification as pending, and record the batch, worktree, branch, issues, pull request, cancellation records, and scoped Go temporary paths in the campaign knowledge base.
-6. Start `pnpm install` asynchronously in the worktree, then begin the source, consequence-surface, and test-design work immediately.
+CI and review are independent gates:
 
-The draft pull request reserves the whole batch before code is written, preventing another contributor from starting overlapping work.
+- CI must prove every configured build, type-check, test, packaging, and platform lane.
+- Self-Review must prove requirement fidelity, consequence coverage, issue-by-issue acceptance, test quality, documentation, generated output, and risks not encoded in CI.
 
-Measure the official duration of a merged batch from the empty claim pull request's GitHub `createdAt` timestamp through its `mergedAt` timestamp. Include installation, implementation, validation, review, dependency waiting, rebases, cancellation completion, and merge, and do not remove outliers from the official mean. Record the issue count beside the duration so batch density remains visible, but do not replace the official per-pull-request measure with a commit-to-merge or per-issue metric. Record a closed unmerged claim separately without inventing a merge duration or erasing it from campaign history.
+When either gate finds a defect:
 
-## Keep Working While Commands Run
+1. Diagnose the real cause from the CI log or review evidence.
+2. Correct the source and complete the corresponding regression coverage.
+3. Run `pnpm format`.
+4. Commit and push the correction to the same pull request.
+5. Let the new CI run to completion and restart Self-Review as a fresh complete round over the new head.
 
-Start every long command asynchronously and continue with work that does not depend on its result. `pnpm install`, package builds, compiler downloads, and test suites are all background work. Watching a CLI process, repeatedly polling it without a decision to make, or reserving an agent solely to wait is not campaign work.
+Fix every red CI lane in the same pull request even when the failure predates the campaign or is unrelated to the campaign's original issues. Do not dismiss it as another contributor's failure.
 
-Maintain a compact command record containing the command, worktree, source snapshot, start time, dependent decision, and final result. Check a running command at a genuine decision boundary, when it exits, or before merge. Do not use sleep loops or foreground waits merely to discover that a command is still running.
+Do not merge a head whose green checks belong to an older SHA or whose clean review predates a correction. Continue the loop until the same immutable head has green required checks and a complete Self-Review round with no sound improvement.
 
-The usual overlap follows the state of the batch. While installation runs, read the admitted issue and nearby implementation, map the consequence surface, and write the implementation and regression test. Once a stable source-and-test snapshot is committed and pushed, launch the narrow package-scoped tests and begin Self-Review at once. A test process may run during review because it does not change the snapshot. When several independent checks are needed, start them together rather than serially discovering that each needs the same environment.
+## Merge And Clean Up
 
-Some boundaries remain strict because overlap would destroy the evidence:
+Merge only with user authorization, including a campaign-local standing authorization that explicitly covers merge.
 
-- **A Self-Review round must not race a source change.** Freeze and commit the snapshot before opening the round, then inspect its complete diff while tests run. If review or a test result requires a change, commit the correction and restart from a fresh complete round over the new snapshot.
-- **A merge must not precede its evidence.** Local verification is the only gate a CI-suspended campaign has, so every required result and cancellation record must be final before merge.
-- **A failed cancellation record stops remote progression, not local thought.** Repair it before the next remote mutation or merge, while the agent continues the local work that is still safe and useful.
+After merge:
 
-Report any command still running, its dependency, and its last observed state when handing work off. Waiting is only justified when the next decision genuinely depends on the completed result and no safe, independent work remains.
+1. Verify GitHub records the pull request as merged into the intended target and every linked issue has the correct final state.
+2. Confirm the checkout has no unpushed or uncommitted work worth preserving.
+3. Switch back to the target branch, pull with `git pull --ff-only`, and delete the local topic branch.
+4. For every assignment-created external path, confirm no live process or other assignment uses it, preserve required evidence, delete only the exact proven path, and verify it is absent.
+5. Never bulk-delete a shared temporary directory, global `GOCACHE`, `GOMODCACHE`, an installed Go toolchain, or an asset whose ownership is uncertain.
 
-## Implement And Revalidate A Batch
+Formatting belongs to the unified cycle pull request, so a separate post-campaign formatting pull request is not part of this solo workflow.
 
-Analyze the full consequence and case surface across every issue in the batch. Follow the repository development skill for implementation, tests, documentation, generated artifacts, and narrow-then-broad local verification.
+## Repeat Until A Clean Round
 
-A batch progresses through one-way states: admitted, reserved, active, snapshotted, reviewed, verified, then resolved. Admission is the lead's evidence-based decision. Reservation is the empty claim pull request. Active work begins as installation runs. Snapshot means the implementation and its tests are committed and pushed, not that their background processes have finished. Review starts on that immutable snapshot while narrow tests run. Verification consumes every required result, applies any correction through a new snapshot and fresh review, and only then permits resolution.
+After every merged cycle, return to the parent skill's Discover Issues phase and perform another complete fresh round over the entire declared scope.
 
-An implementation agent may find that an issue is false or too broad. The lead must independently validate that conclusion before changing campaign state:
+If any meaningful candidate survives fact-checking, adjudicate and publish it when authorized, then claim the next single cycle pull request containing every implementation-ready issue. Repeat discovery, implementation, CI, review, merge, and cleanup without a fixed round limit.
 
-- For a narrowed issue, record the evidence on the issue and pull-request thread, then update the batch scope.
-- For a confirmed-invalid issue, record the evidence and close the issue.
-- If no issue remains in the batch, close the claim pull request instead of leaving an orphan reservation.
+The campaign succeeds only when all of these are true:
 
-Commit and push every coherent implementation increment to the claimed branch as soon as its source and test program are complete. Do not hold a completed snapshot locally while waiting for the tests it already launched. Start the exact-SHA cancellation record immediately after the push, consume the test results when they become available, and make any correction in a new commit with the same discipline.
+- one complete fresh full-scope discovery round produces no meaningful candidate after fact-checking;
+- no accepted or published campaign issue remains unresolved;
+- no campaign pull request, branch, process, or assignment-owned temporary asset remains; and
+- the target checkout is clean and synchronized.
 
-Before merge, complete solo Self-Review. When a round finds an improvement, comment its findings and remediation plan on the pull request before applying the change so the thread records why every follow-up commit happened. A pending narrow test never delays the start of that review, but its final result is required before merge. The implementing agent then merges its own pull request with the repository's established method, with no separate lead approval, once implementation, that Self-Review, the batch's package-scoped local verification, and all campaign cancellation records are complete. Under an ordinary campaign it waits for explicit user authorization; under a standing autonomous mandate, an autonomous or remote-control campaign, or an instruction to carry the campaign through merge, it merges as soon as those gates pass without a per-pull-request request.
-
-## Remove Every Finished Worktree
-
-Worktree removal is part of finishing an assignment, not optional housekeeping.
-
-After a pull request merges:
-
-1. Verify GitHub records it as merged into the intended target. This works for merge, squash, and rebase strategies.
-2. Confirm the worktree has no unpushed or uncommitted work worth preserving.
-3. Run `git worktree remove --force <path>` so ignored build artifacts are deleted too.
-4. Verify the directory no longer exists.
-5. Verify `<path>/.campaign-tmp/go-cache` and `<path>/.campaign-tmp/go-tmp` are gone with the worktree. If the batch recorded another exact Go temporary path, first confirm no command still refers to it, remove only that path, and verify it no longer exists.
-6. Run `git worktree prune` and delete the local topic branch.
-7. Confirm `git worktree list --porcelain` contains no record of the removed path.
-
-Never recursively clean a user's shared `GOCACHE`, `GOMODCACHE`, `GOPATH`, or system temp directory. They can contain another worktree's active build inputs. A worktree that Git has deregistered but failed to delete is still unfinished: after confirming it has no `.git` metadata, no live process, and no retained evidence, remove that exact directory and its recorded scoped Go temporary paths, then verify their absence.
-
-If an assignment ends without a merge, first record retained evidence and confirm the remaining contents are disposable. Then remove its worktree and local branch by the same standard.
-
-Apply this rule to every campaign-created worktree, including one used for Post-Campaign Cleanup. Do not mark an assignment complete while its worktree remains on disk.
-
-## While Campaign CI Is Cancelled
-
-- Record local verification for each pull request. Do not dispatch replacement CI.
-- Keep repository Actions and workflow settings unchanged. Cancel only exact-SHA campaign runs after every push or pull-request retrigger.
-- If work pauses, report local verification and the final state of every run for the latest campaign SHAs.
-
-## Repeat A Campaign Cycle
-
-Report the wave after every surviving issue is covered by its assigned batch pull request.
-
-When the user requests another discovery cycle, return to the parent skill's Discover Issues phase and start new unlimited full rounds over the entire campaign scope. Earlier rounds are not coverage. Repository Actions remains unchanged, and discovery alone does not authorize issue publication, pull requests, or merging.
-
-## Post-Campaign Cleanup
-
-Run this phase only after the user ends the campaign, every campaign pull request is resolved, every campaign worktree is removed, and no campaign branch needs another push.
-
-1. Return to `master` in the main checkout and confirm it contains no unrelated user changes.
-2. Pull the final campaign result with `git pull --ff-only origin master`.
-3. Run `pnpm format` once against the integrated repository.
-4. If formatting produces no diff, report that no cleanup pull request was needed and stop.
-5. If formatting changes files, create a dedicated topic branch containing the formatter result and only directly necessary fixes.
-6. Commit, push, and open the Post-Campaign Cleanup pull request under the pull-request skill. This is an ordinary pull request: resume its check loop instead of cancelling its runs.
-7. Diagnose any locally reproducible failure, fix it, commit, push, and resume the ordinary check loop.
-8. Merge once required checks pass: with explicit user authorization, or on a standing autonomous mandate without a separate request.
-9. If cleanup used the main checkout, return it to `master`, pull with `git pull --ff-only origin master`, and delete the local cleanup branch.
-10. If cleanup used an auxiliary worktree, remove it and its branch under Remove Every Finished Worktree, then pull `master` in the main checkout.
-11. Require the main checkout to be clean. Compare the final repository Actions permission and workflow inventory with the initial record and require that the campaign made no change.
+If an external blocker makes those conditions impossible, report the campaign as blocked rather than complete.

--- a/.agents/skills/multi-agent/SKILL.md
+++ b/.agents/skills/multi-agent/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: multi-agent
+description: "Defines the explicitly parallel variants of ttsc review and issue campaigns. Use only when the user explicitly requests a team, parallel, or multi-agent review or campaign. Route review work to review.md and issue campaigns to issue-campaign.md. Self-Review and unqualified review remain solo. Multi-agent issue campaigns parallelize discovery and implementation by default, but an explicit request may limit parallelism to discovery and return implementation to the solo campaign."
+---
+
+# Multi-Agent Workflows
+
+This skill is the single entry point for every explicitly parallel review or campaign. Read the base solo skill first, then enter through the detailed document below for the requested workflow. That document names any shared multi-agent topic procedures it also requires.
+
+| Explicit request | Base skill | Detailed multi-agent procedure |
+| --- | --- | --- |
+| Team, parallel, or multi-agent review | [review](../review/SKILL.md) | [review.md](review.md) |
+| Parallel or multi-agent issue campaign | [issue-campaign](../issue-campaign/SKILL.md) | [issue-campaign.md](issue-campaign.md) |
+
+`ttsc` has no benchmark-campaign skill. Use [benchmark](../benchmark/SKILL.md) for measurement integrity, then the applicable issue-campaign workflow for authorized benchmark-driven implementation.
+
+Do not load this skill for Self-Review, an unqualified review, or a campaign that does not explicitly request parallel agents.
+
+## Shared Parallelism Rules
+
+- Use the smallest number of agents that adds independent evidence or owns immediately executable disjoint work. Available thread capacity is not a reason to create an agent.
+- Never create a waiter, poller, coordinator-only child, duplicate implementation owner, or agent that cannot begin useful work immediately.
+- Give every review or discovery agent the complete declared surface. Parallel review adds independent full passes; it never partitions coverage by package, file, concern, platform, or test lane.
+- Partition implementation only through verified dependency and file-ownership boundaries. One agent owns one coarse batch, branch, pull request, and worktree.
+- Keep the lead active on fact-checking, integration, conflict resolution, and decisions that do not duplicate an assigned agent.
+- Do not let agents re-delegate.
+- Self-Review remains solo for every author and every implementation branch.
+- Create worktrees only for parallel implementation batches and their integrated cleanup. Solo implementation and review use the current checkout.
+- Remove every finished worktree, local branch, process, and assignment-owned temporary asset before declaring its assignment complete.

--- a/.agents/skills/multi-agent/issue-campaign.md
+++ b/.agents/skills/multi-agent/issue-campaign.md
@@ -1,0 +1,78 @@
+# Multi-Agent Issue Campaign
+
+Read this document only through the multi-agent skill for an explicitly parallel issue campaign. Read the base issue-campaign, project, development, pull-request, review, and [multi-agent review](review.md) procedures before acting.
+
+The base issue-campaign skill owns authorization, the knowledge base, candidate adjudication, self-contained issue bodies, and the clean full-scope completion gate. This document overrides only discovery and implementation topology.
+
+## Select The Parallel Boundary
+
+A multi-agent issue campaign parallelizes both discovery and implementation by default.
+
+Switch to parallel discovery with solo implementation only when the user explicitly requests that combination. In that mode:
+
+1. Run Parallel Discovery and let the lead complete candidate adjudication and authorized publication.
+2. Stop every discovery agent before implementation begins.
+3. Read the base issue campaign's [solo development procedure](../issue-campaign/development.md).
+4. Put every implementation-ready issue into its one empty-claim pull request, use the current checkout without a worktree, run `pnpm format`, validate through ordinary CI, and complete solo Self-Review while CI runs.
+5. Apply that procedure's implementation, CI, merge, branch cleanup, and temporary-asset rules, but return here for the next parallel discovery round instead of switching to solo discovery.
+
+Do not infer solo implementation from quota concerns, a small issue count, or the fact that the lead performs publication. Only the user's explicit phase boundary selects it.
+
+## Parallel Discovery
+
+Use [review.md](review.md)'s Parallel Issue Discovery Rounds. Every discovery agent audits the whole declared scope independently. The lead alone fact-checks and publishes.
+
+Pool raw candidates in `.wiki`, then reproduce and combine, split, rewrite, reject, or defer them before publication. Parallel discovery changes evidence breadth, not publication authority.
+
+## Build Coarse Implementation Batches
+
+When implementation is also parallel, recompute the published-issue DAG before every wave. Form the smallest number of maximal cohesive batches that dependency readiness and ownership permit.
+
+Group issues only when they are ready on the same frontier, share an architectural owner or root invariant, overlap in consequence surface, use mostly the same verification, and remain understandable and reversible as one diff. Split for a named dependency, external blocker, repository or target-branch boundary, independent release contract, incompatible verification owner, destructive file overlap, or lost issue-level attribution.
+
+Topic, label, package proximity, reporter, and issue count do not justify a split. Record the original issue count, final pull-request count, DAG edges, grouping reasons, split reasons, owned files, and verification lanes in `.wiki` before opening claims.
+
+Freeze a batch once its empty claim pull request exists. Re-cut an active batch only when correctness, overlap, or invalidated evidence requires a lead decision.
+
+Open only as many implementation agents as there are immediately executable, non-overlapping batches.
+
+## Claim And Implement Parallel Batches
+
+For each immediately executable batch:
+
+1. Create one isolated worktree and topic branch.
+2. Create `<worktree>/.campaign-tmp/go-cache` and `<worktree>/.campaign-tmp/go-tmp`. Every Go command for that batch must set `GOCACHE` and `GOTMPDIR` to those exact directories.
+3. Create an implementation-free commit with `git commit --allow-empty`.
+4. Push and open a draft pull request linking every batch issue and stating its owned files.
+5. Cancel that exact branch's queued or running campaign Actions and record the terminal cancellation state. Never disable repository Actions or a workflow, and never cancel another branch's run.
+6. Install dependencies asynchronously when needed, then implement the full consequence surface and near-100% positive, negative, boundary, and regression coverage.
+7. Commit and push coherent increments, cancelling only the new runs for that exact branch.
+8. Run the narrowest local proving commands followed by the broader locally owned lanes.
+9. Freeze the head and complete solo Self-Review. If code changes, rerun the necessary local gates and restart the full review.
+10. Let the lead independently verify issue fit, dispositions, evidence, and batch scope.
+11. If any campaign pull-request run reaches red, diagnose and repair it in the same pull request, then commit and push the repair even when the failure predates the campaign or is unrelated to its original issues.
+12. Merge only with user authorization after local verification, lead review, the final campaign-run cancellation record, and any red-CI repair are complete.
+
+Measure each batch from its empty pull request's GitHub `createdAt` through `mergedAt`, including installation, dependency waiting, implementation, validation, review, rebases, cancellation, and merge. Keep outliers and record issue count beside the duration.
+
+Start long local commands asynchronously and continue useful independent work. Do not reserve an agent solely to watch installation, build, test, CI, or cancellation.
+
+When batches overlap unexpectedly, stop the later mutation, report the exact file and invariant conflict, and let the lead serialize or re-cut the work. Agents never edit another batch's owned files.
+
+## Integrated Cleanup
+
+After every parallel implementation batch is resolved and its worktree and external assets are removed:
+
+1. Create one cleanup worktree and topic branch from the integrated target.
+2. Install dependencies when needed and run `pnpm format`.
+3. Run the full integrated local validation required by the project skill.
+4. If formatting changes files, open one ordinary cleanup pull request, let all CI checks run, and perform solo Self-Review while they run.
+5. Repair every CI or review finding in the same cleanup pull request, including a red lane unrelated to the campaign's original changes, and repeat until the same head is green and clean.
+6. Merge with authorization, then remove the cleanup worktree, branch, and assignment-owned external assets.
+7. If formatting produces no diff, complete solo Self-Review over the integrated target, then remove the unused cleanup worktree and branch without opening a pull request.
+
+## Completion
+
+After the selected implementation flow is resolved, run another complete parallel full-scope discovery round against the integrated repository.
+
+The campaign succeeds only when every reviewer completes the whole scope, no meaningful candidate survives lead verification, no accepted issue remains unresolved, and every campaign worktree and assignment-owned temporary asset is removed. Report an external blocker as blocked, not complete.

--- a/.agents/skills/multi-agent/review.md
+++ b/.agents/skills/multi-agent/review.md
@@ -1,0 +1,39 @@
+# Multi-Agent Review
+
+Read this document only through the multi-agent skill for an explicitly requested team, parallel, or multi-agent review. The base review skill's Non-Negotiable Review Law still governs every reviewer: one agent performs one complete review of the entire declared surface from scratch.
+
+Do not use this procedure for Self-Review. The author always completes Self-Review alone even when a separate team review is also authorized.
+
+## Bound The Team
+
+Use the smallest team of two or more reviewers that adds meaningful independent evidence. Open a reviewer slot only when it owns one complete independent pass and can run immediately.
+
+Give every reviewer the same complete surface. Different analytical lenses or primary sources are useful, but package, file, concern, platform, or test-lane partitions are forbidden.
+
+## Team Review Cycle
+
+1. Freeze the exact surface and record its base and head.
+2. Give each reviewer a self-contained brief containing the objective, complete surface, constraints, evidence locations, required output format, and exact repository instructions and skills to read.
+3. Require every reviewer to inspect the full surface independently and report evidence-backed findings directly to the lead. Reviewers do not discuss findings with one another.
+4. The lead independently reproduces and validates every proposal against the repository and relevant provenance. Accept, rewrite, combine, partially accept, or reject it according to evidence.
+5. Apply every accepted in-scope improvement, complete the authorized verification, and freeze a new exact surface.
+6. If anything changed, end the current team and begin another complete cycle. Stop only when one whole team cycle yields no accepted improvement.
+
+## Research Review Round
+
+Use a Research Review Round when the review needs external primary sources or sibling-repository provenance.
+
+Each reviewer still inspects the complete change surface and relevant sources independently. Agents submit evidence-backed proposals directly to the lead without a discussion phase. External research adds evidence; it does not relax full-surface coverage or the fresh-cycle stop rule.
+
+## Parallel Issue Discovery Rounds
+
+Use this mode only through the multi-agent issue-campaign procedure.
+
+1. Give every discovery reviewer the entire declared campaign scope.
+2. Each reviewer independently audits source, tests, documentation, CI, packaging, generated artifacts, platform behavior, upstream or downstream provenance, and open and closed issue or pull-request history. Audit the current implementation and history against the development skill's **Forbidden** section.
+3. Each reviewer records its own evidence-backed raw candidates without seeing or negotiating a shared candidate list.
+4. The lead reopens every candidate from primary evidence, reproduces it, checks ownership and provenance, traces the consequence surface, and records accept, partial acceptance, rewrite, combine, split, reject, or defer in `.wiki`.
+5. If any meaningful candidate survives, complete the authorized campaign cycle and begin another fresh parallel round over the integrated state.
+6. End discovery only when every reviewer completes the whole scope and no meaningful candidate survives lead verification.
+
+An unresolved accepted issue or incomplete implementation prevents a successful campaign conclusion.

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -11,13 +11,13 @@ Act on this skill only when the user explicitly requests the corresponding remot
 
 Branch from the pull-request target (`master` unless stated otherwise); never commit or push directly to the target. Name the branch for the merged outcome with the repository's established type and scope, such as `feat/<scope>`, `fix/<scope>`, `docs/<scope>`, or `ci/<scope>`.
 
-If the current checkout contains unrelated or protected work, create an isolated worktree from the target branch instead of stashing, reverting, or mixing it.
+Solo work never creates a clone or worktree. If the current checkout contains unrelated or protected work, stage only the authorized paths; if that cannot keep the pull request isolated, report the conflict rather than stashing, reverting, mixing, or relocating the work.
 
 ## Commit Logical Units
 
 Use one commit per coherent unit when the diff is large. Follow the repository's `<type>(<scope>): <subject>` history with an imperative lowercase subject and no trailing period.
 
-Run the validation required by the development skill. Run `pnpm format` before ordinary commits. During an issue campaign, do not run `pnpm format` on implementation branches; the campaign's dedicated Post-Campaign Cleanup pull request owns the repository-wide formatter result.
+Run the validation required by the development skill. Run `pnpm format` before ordinary commits. A solo issue campaign formats its unified implementation branch. Only an explicit multi-agent campaign implementation batch defers the repository-wide formatter result to its integrated cleanup.
 
 Stage explicit paths when the worktree is mixed. Never include unrelated user changes silently.
 
@@ -31,14 +31,14 @@ Push only the topic branch with upstream tracking. Use a file-backed body for mu
 
 ## Issue Campaign Override
 
-Before any issue-campaign push or pull request, complete `.agents/skills/issue-campaign/development.md`. Its no-format, local-verification, suspended-Actions, and Post-Campaign Cleanup rules override the ordinary commit and check flow here; cleanup returns to the ordinary check loop after restoring Actions.
+Before any issue-campaign push or pull request, complete `.agents/skills/issue-campaign/development.md`. A solo campaign uses one formatted pull request and the ordinary check loop. Only the explicit multi-agent procedure overrides that flow with worktree batches, exact-SHA campaign-run cancellation, local implementation gates, and integrated cleanup.
 
 ## Watch Checks After Every Ordinary Push
 
-After each ordinary push, including every Post-Campaign Cleanup push, monitor the pull-request checks until every check settles. Only CI-suspended campaign implementation waves skip this loop. On failure, fetch the relevant job log, diagnose the real cause, fix it in place, push a new commit, and resume monitoring. Do not treat a green unrelated job as acceptance for a failed required surface.
+After each ordinary push, including every multi-agent integrated-cleanup push, monitor the pull-request checks until every check settles. Only CI-suspended campaign implementation waves skip this loop. On failure, fetch the relevant job log, diagnose the real cause, fix it in place, push a new commit, and resume monitoring. Do not treat a green unrelated job as acceptance for a failed required surface.
 
 ## Merge On Explicit Request Or Standing Autonomous Mandate
 
 Do not merge, squash-merge, rebase, or update the target branch on unprompted initiative. Merge when the user explicitly asks, or when a standing autonomous mandate authorizes end-to-end delivery; use the repository's established merge method unless another is specified. Under an autonomous mandate the author that owns the pull request merges it themselves once the merge gate below passes, without separate approval.
 
-Before merging an ordinary or Post-Campaign Cleanup pull request, confirm required checks pass. For a campaign implementation pull request whose automatic CI is deliberately suspended, confirm the issue-campaign local-verification and lead-review gates instead. If branch protection blocks the requested merge, report the blocker rather than bypassing it.
+Before merging an ordinary or multi-agent integrated-cleanup pull request, confirm required checks pass. For a campaign implementation pull request whose automatic CI is deliberately suspended, confirm the issue-campaign local-verification and lead-review gates instead. If branch protection blocks the requested merge, report the blocker rather than bypassing it.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,70 +1,50 @@
 ---
 name: review
-description: Defines exhaustive solo and team review workflows for ttsc changes and issue discovery. Use when reviewing or self-reviewing a change or pull request, running a Review Cycle or Research Review Round, or conducting repository-wide issue-discovery rounds. Self-Review and unqualified review requests are always solo; review agents work independently rather than discussing.
+description: Defines exhaustive solo review, Self-Review, and solo repository-wide issue-discovery rounds for ttsc. Use for every self-review or unqualified review request and as the default review mode inside issue campaigns. This skill never spawns review agents; use the multi-agent skill only when the user explicitly requests a team, parallel, or multi-agent review.
 ---
 
 # Review
 
 ## Non-Negotiable Review Law
 
-Every review mode uses the same unit of work: one reviewer performs one complete, from-scratch review of the entire declared surface. A team adds independent complete reviews; it never divides one review among agents.
+One reviewer performs every review in this skill from scratch over the entire declared surface. Do not spawn a subagent, delegate a concern, or load the discussion skill. Do not create a clone or worktree for solo review or Self-Review.
 
-Choose the principled conclusion. Review duration, difficulty, and consequence surface are reasons to inspect more deeply and verify more carefully, never reasons to overlook a sound improvement, accept an unsupported claim, or lower the completion standard.
+Apply [AGENTS.md's **Choose the principled course** rule](../../../AGENTS.md#attitude) to every review decision. Review duration, difficulty, and consequence surface never lower the completion standard.
 
 A complete round must satisfy all four rules:
 
-- **Whole surface:** read every changed file and hunk. For issue discovery, audit the entire campaign scope. Never partition by file, package, concern, platform, agent, or round, and never substitute another reviewer's coverage.
+- **Whole surface:** read every changed file and hunk. For issue discovery, audit the entire campaign scope. Never partition by file, package, concern, platform, or pass.
 - **Consequence surface:** inspect affected code paths, tests, generated artifacts, CI, packaging, documentation, and consumers. Trace side effects, state transitions, concurrency, platforms, boundaries, compatibility, and failure and recovery paths beyond the named symptom or diff.
 - **Fresh start:** use the current state and repeat the whole inspection. Earlier rounds, sampled files, and a recheck of only the latest fix do not count as coverage.
-- **Unlimited rounds:** whenever a solo reviewer applies an improvement, or a lead accepts an improvement or meaningful issue candidate, update the work and start another complete round. Stop only after a complete round produces nothing that survives verification.
+- **Unlimited rounds:** whenever the reviewer applies an improvement or accepts a meaningful issue candidate, update the work and start another complete round. Stop only after a complete round produces nothing that survives verification.
 
 ## Self-Review
 
-Self-Review is strictly solo. The author does not spawn subagents, form a team, or load the discussion skill. An ordinary review request also defaults to this solo workflow unless the user explicitly asks for a team.
+Self-Review and an unqualified review request use this solo workflow:
 
-1. Establish the complete change surface, including the pull request base-to-head diff and any uncommitted changes.
+1. Establish the complete change surface, including the pull-request base-to-head diff and any uncommitted changes.
 2. Perform one complete round under the Non-Negotiable Review Law. Include correctness and boundaries, Windows and POSIX behavior, concurrency and state, data loss and security, cache and recovery invariants, public API and compatibility, test isolation, CI and packaging, generated output, documentation, and migration effects.
-3. Apply every sound improvement and run the narrowest verification that proves it.
-4. If anything changed, restart at step 1 as a fresh full round.
-5. Finish only when a complete round finds nothing to improve. Report the final clean round and any verification that could not run.
+3. Reproduce every suspected defect before accepting it.
+4. Apply every sound improvement and run the narrowest verification authorized by the owning workflow.
+5. If anything changed, restart at step 1 as a fresh full round.
+6. Finish only when a complete round finds nothing to improve. Report the final clean round and every verification that could not run.
 
 Self-Review does not authorize creating, pushing, updating, or merging a pull request. If the user separately requests one of those actions, follow the pull-request skill.
 
-## Team Review Cycle
+## Solo Issue Discovery Rounds
 
-Use Review Cycle only when the user explicitly asks for a team or multi-agent review.
+Use these rounds only through the solo issue-campaign skill.
 
-1. Form the largest practical team, up to six review agents. Give every agent the same complete surface and require an independent complete round. Different analytical lenses are welcome; divided coverage is forbidden.
-2. Agents submit independent findings to the lead. They do not negotiate a consensus or use discussion transcripts.
-3. The lead independently reproduces and validates every proposal against the repository. Apply only technically sound, in-scope improvements; rewrite, combine, partially accept, or reject proposals as the evidence warrants.
-4. If the lead applies any improvement, replace the team and begin another complete cycle. Stop only after a full cycle yields no accepted improvement.
+1. Audit the entire declared campaign scope yourself. Inspect source, tests, documentation, CI, packaging, generated artifacts, platform behavior, upstream or downstream provenance, and open and closed issue or pull-request history. Audit the current implementation and history against the development skill's **Forbidden** section.
+2. Record every raw candidate and its evidence in the campaign knowledge base before adjudication. Do not silently discard a suspicion because it looks duplicative or inconvenient.
+3. Reopen each candidate from primary evidence, reproduce it, verify ownership and provenance, and trace its complete consequence surface.
+4. Record accept, partial acceptance, rewrite, combine, split, reject, or defer. Keep the disposition and reason in the knowledge base so later passes do not rediscover a rejected premise as new.
+5. Publish only the surviving adjudicated form when the campaign is authorized to publish.
+6. If any meaningful candidate survives, finish the authorized issue and implementation flow, then begin another fresh full-scope round over the integrated state.
+7. End discovery only when one complete fresh round over the entire scope produces no meaningful candidate after fact-checking.
 
-## Research Review Round
+An unresolved accepted issue, external blocker, or incomplete implementation prevents a successful campaign conclusion. Report it as blocked or active rather than treating it as a clean round.
 
-Use Research Review Round when a team review needs external or cross-repository evidence before proposing changes.
+## Explicit Multi-Agent Reviews
 
-Each agent independently reviews the complete change surface and all relevant primary sources or sibling repositories. Agents submit evidence-backed proposals directly to the lead without a discussion phase.
-
-The lead validates every proposal and applies the Team Review Cycle stop rule. External research adds evidence; it does not relax full-surface coverage.
-
-## Issue Discovery Rounds
-
-Use issue discovery only as part of the issue-campaign skill.
-
-1. Form the largest practical review team, up to six agents, and apply the briefing rules below. Give every agent the entire campaign scope and require the issue-campaign, project, development, and review skills in its brief.
-2. Every agent independently audits source, tests, documentation, CI, packaging, generated artifacts, platform behavior, upstream or downstream provenance, and open and closed issue or pull-request history. Audit the current implementation and history against the repository development skill's **Forbidden** section; a verified violation remains a meaningful candidate even when existing tests pass. Never divide the repository by package, file, concern, agent, or round.
-3. Each agent submits its own evidence-backed candidates without discussion or a shared list.
-4. The lead reopens the evidence, reproduces the behavior, checks ownership, provenance, and any claimed **Forbidden** classification, and compares existing issues and pull requests. Reject, rewrite, combine, partially accept, or return a proposal as the evidence requires.
-5. Record only surviving candidates in the campaign knowledge base. If any meaningful candidate survives, replace the team and run another complete discovery round.
-6. Stop only when a complete round from every agent produces no meaningful candidate that survives lead verification.
-
-## Briefing Review Agents
-
-Review agents may start without conversation history or loaded repository instructions. Give each a self-contained brief containing:
-
-- the objective and complete declared surface;
-- constraints and evidence locations;
-- the required output format; and
-- the exact repository instructions and skills to read.
-
-State facts and constraints, not a preferred conclusion. Agents execute the brief directly and do not re-delegate.
+When the user explicitly asks for a team, parallel, or multi-agent review, load the [multi-agent skill](../multi-agent/SKILL.md) and its [review procedure](../multi-agent/review.md) instead of this workflow. It inherits the same whole-surface and fresh-round law while defining independent parallel reviewers and lead adjudication.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,11 +36,15 @@ README, website-guide, and agent-instruction writing rules, `.agents/skills/docu
 
 ### Issue Campaigns
 
-Repository-wide issue discovery, lead-verified issue writing, CI-suspended DAG-batched implementation, and cleanup, `.agents/skills/issue-campaign/SKILL.md`. Read when the user asks for a broad audit, many issue candidates, or an issue-to-implementation campaign; do not use it for one already-defined issue.
+Default solo repository-wide issue discovery, issue publication, one CI-validated implementation pull request per cycle, and renewed discovery, `.agents/skills/issue-campaign/SKILL.md`. Read when the user asks for a broad audit, many issue candidates, or an issue-to-implementation campaign without explicitly requesting parallel agents; do not use it for one already-defined issue.
 
 ### Review
 
-Solo review, team Review Cycle, research review, and exhaustive issue-discovery rounds, `.agents/skills/review/SKILL.md`. Every agent inspects the whole declared surface independently, and rounds continue until a complete pass produces no sound improvement or meaningful issue candidate. Self-Review and any unqualified review request are always solo.
+Default solo Self-Review, unqualified review, and exhaustive issue-discovery rounds, `.agents/skills/review/SKILL.md`. The reviewer inspects the whole declared surface and repeats fresh rounds until a complete pass produces no sound improvement or meaningful issue candidate.
+
+### Multi-Agent Workflows
+
+Explicitly parallel review and issue-campaign variants live under one entry point, `.agents/skills/multi-agent/SKILL.md`. Read it only when the user explicitly asks for a team, parallel, or multi-agent workflow. Multi-agent issue campaigns parallelize discovery and implementation by default and switch to solo implementation only on an explicit discovery-only parallel request; Self-Review remains solo.
 
 ### Discussion
 
@@ -50,9 +54,9 @@ Structured multi-agent topic discussion with persistent research notes and trans
 
 Branch, commit, pull request, check, and merge flow, `.agents/skills/pull-request/SKILL.md`. Read when the user explicitly asks to open, submit, update, or merge a pull request, or when a standing autonomous mandate authorizes end-to-end delivery; never open, push, or propose one on unprompted initiative.
 
-### Benchmark
+### Benchmark Measurement
 
-Benchmark runners, fixture repositories, measurement integrity, and publication, `.agents/skills/benchmark/SKILL.md`. Read before running, modifying, or publishing benchmark results.
+Benchmark runners, fixture repositories, measurement integrity, and publication, `.agents/skills/benchmark/SKILL.md`. Read before running, modifying, or publishing benchmark results. `ttsc` has no benchmark-campaign skill; benchmark-driven issue-to-implementation work enters the issue-campaign skill.
 
 ## Maintenance
 
@@ -72,5 +76,6 @@ Update AGENTS.md only for repository-contract changes: a new skill area, a renam
 - **Core in SKILL.md, conditional topics as sibling documents.** Keep always-applicable procedure in SKILL.md. Move a topic needed only under a specific condition to a one-level-deep sibling document and link it with that read condition.
 - **Two trigger surfaces, one scope.** The frontmatter description is the full trigger contract, including exclusions. The AGENTS.md pointer mirrors that scope more briefly. Correct the frontmatter first when the scope changes.
 - **Create or merge.** Add a skill when a substantial repository concern would otherwise inflate AGENTS.md beyond an index. Merge sibling concerns when they share most of their structure.
+- **Repository skill files only.** Keep repository skills to `SKILL.md` and conditionally loaded sibling documents. Do not add `agents/openai.yaml` UI metadata or separate `multi-agent-*` skills.
 - **Headings are plain.** No chapter numbers in skill or AGENTS.md headings. Use descriptive titles.
-- **Current set.** The repository skills are `project`, `development`, `typescript-go-sync`, `documentation`, `issue-campaign`, `review`, `discussion`, `pull-request`, and `benchmark`.
+- **Current set.** The repository skills are `project`, `development`, `typescript-go-sync`, `documentation`, `issue-campaign`, `review`, `multi-agent`, `discussion`, `pull-request`, and `benchmark`.


### PR DESCRIPTION
## Intent

Make solo execution the default for ttsc issue campaigns and reviews, and make explicit parallel work enter through one `multi-agent` skill.

## Scope

- Add the single `multi-agent` skill with review and issue-campaign detail documents.
- Move the default solo issue-campaign and review procedures to their base skills.
- Align AGENTS.md, development, pull-request, and benchmark guidance with the new topology.
- Keep ttsc's measurement-only benchmark skill. Do not add a benchmark-campaign skill, `multi-agent-*` skills, or `agents/openai.yaml` metadata.

## Verification

- `pnpm exec prettier --check` for every changed Markdown document
- local Markdown-link resolution
- `git diff --check`
- complete solo Self-Review over the post-rebase base-to-head diff

## Deferred

No benchmark-campaign procedure is introduced because ttsc does not have one.

## CI

The user explicitly requested no CI wait for this documentation-only change. CI is not a merge gate for this pull request.
