### PR TITLE
docs(agents): state the solo campaign cycle cadence

### DIFF
--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -34,7 +34,7 @@ Different packages, invariants, or validation lanes do not split the solo cycle.
 
 An issue whose only predecessor is another issue in the same cycle is implementation-ready for this purpose. Order the edits through the DAG instead of deferring it to another pull request.
 
-Difficulty never removes an issue from the cycle. When a resolution needs a judgment call about design, invariant ownership, or an acceptable behavior change, settle it from the issue's evidence and implement that decision here. Proved duplicate, invalid premise, out of scope, and external blocker stay the only dispositions that take an issue out of the cycle.
+Difficulty never removes an issue from the cycle. When a resolution needs a judgment call about design, invariant ownership, or an acceptable behavior change, settle it from the issue's evidence and implement that decision inside the cycle. A proved duplicate, an invalid premise, an out-of-scope finding, and an external blocker remain the only dispositions that remove one.
 
 ## Claim The Complete Cycle
 
@@ -46,7 +46,7 @@ Claim the whole cycle before implementation:
 4. Reference every cycle issue by number, mark verification pending, and state that the pull request owns the complete accepted cycle.
 5. Record the checkout, branch, pull request, head SHA, issue set, and external temporary-asset ledger in `.wiki`.
 
-Reference the issues in the claim body, and keep every closing keyword out of it. The body is written before any code exists, so a claim-time closing list closes whatever the cycle later drops, defers, or disproves and buries the analysis those issues carry. The cycle's closing set is the union of the commit trailers, which makes the merge close exactly what landed.
+Reference the issues in the claim body, and keep every closing keyword out of it. The body is written before any code exists, so a claim-time closing list closes whatever the cycle later drops, defers, or disproves, burying the analysis those issues carry. The cycle's closing set is the union of the [commit closing lines](#implement-and-write-tests), which makes the merge close exactly what landed.
 
 The empty pull request prevents overlapping contributor work before code is written. Measure official duration from its GitHub `createdAt` timestamp through `mergedAt`, including implementation, CI, review, fixes, rebases, and merge.
 

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -43,8 +43,10 @@ Claim the whole cycle before implementation:
 1. Use the current checkout, update the target branch with `git pull --ff-only`, and create one topic branch. Do not create a clone or worktree.
 2. Create one implementation-free commit with `git commit --allow-empty`.
 3. Push the branch and open one draft pull request.
-4. Link every cycle issue, mark verification pending, and state that the pull request owns the complete accepted cycle.
+4. Reference every cycle issue by number, mark verification pending, and state that the pull request owns the complete accepted cycle.
 5. Record the checkout, branch, pull request, head SHA, issue set, and external temporary-asset ledger in `.wiki`.
+
+Reference the issues in the claim body, and keep every closing keyword out of it. The body is written before any code exists, so a claim-time closing list closes whatever the cycle later drops, defers, or disproves and buries the analysis those issues carry. The cycle's closing set is the union of the commit trailers, which makes the merge close exactly what landed.
 
 The empty pull request prevents overlapping contributor work before code is written. Measure official duration from its GitHub `createdAt` timestamp through `mergedAt`, including implementation, CI, review, fixes, rebases, and merge.
 
@@ -53,6 +55,8 @@ The empty pull request prevents overlapping contributor work before code is writ
 Work through the DAG on the claimed topic branch. Analyze the full consequence and case surface across every issue before editing, then implement the complete cycle and its tests.
 
 Implement without interruption. Write each piece's tests as that piece lands instead of saving a test pass for the end of the cycle, and keep committing as each unit becomes coherent. Do not pause the sequence for a check run; [CI is read once per settled head](#validate-with-ci-and-self-review).
+
+Give each commit message a `Closes #n` trailer for every issue that commit resolves, then post a pull-request comment naming what the commit landed and which issues it resolved. GitHub closes an issue from a commit message or the pull-request body and never from a comment: the trailer attaches each closing to the change that earned it, and the comment is the running ledger a reader follows without reading the diff.
 
 Each issue remains an evidence and acceptance unit inside the combined diff. Keep its positive, negative, boundary, and regression cases identifiable. Near-100% coverage of changed behavior is required; a green happy path is not completion.
 

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -54,7 +54,7 @@ The empty pull request prevents overlapping contributor work before code is writ
 
 Work through the DAG on the claimed topic branch. Analyze the full consequence and case surface across every issue before editing, then implement the complete cycle and its tests.
 
-Implement without interruption. Write each piece's tests as that piece lands instead of saving a test pass for the end of the cycle, and keep committing as each unit becomes coherent. Do not pause the sequence for a check run; [CI is read once per settled head](#validate-with-ci-and-self-review).
+Implement without interruption. Write each piece's tests as that piece lands instead of leaving the tests for the end of the cycle, and keep committing as each unit becomes coherent. Do not pause the sequence for a check run; [CI is read once per settled head](#validate-with-ci-and-self-review).
 
 Close each issue from the commit that earns it. End the commit message with one `Close #n: <issue title>` line per resolved issue, so a commit that resolves several issues carries several lines. GitHub matches the keyword and the number and ignores the title tail, so the line closes the issue normally while the log stays legible without opening each number.
 

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -46,7 +46,7 @@ Claim the whole cycle before implementation:
 4. Reference every cycle issue by number, mark verification pending, and state that the pull request owns the complete accepted cycle.
 5. Record the checkout, branch, pull request, head SHA, issue set, and external temporary-asset ledger in `.wiki`.
 
-Reference the issues in the claim body, and keep every closing keyword out of it. The body is written before any code exists, so a claim-time closing list closes whatever the cycle later drops, defers, or disproves, burying the analysis those issues carry. The cycle's closing set is the union of the [commit closing lines](#implement-and-write-tests), which makes the merge close exactly what landed.
+Keep every closing keyword out of the claim body. The body is written before any code exists, so a claim-time closing list closes whatever the cycle later drops, defers, or disproves, burying the analysis those issues carry. The cycle's closing set is the union of the [commit closing lines](#implement-and-write-tests), which makes the merge close exactly what landed.
 
 The empty pull request prevents overlapping contributor work before code is written. Measure official duration from its GitHub `createdAt` timestamp through `mergedAt`, including implementation, CI, review, fixes, rebases, and merge.
 
@@ -56,9 +56,9 @@ Work through the DAG on the claimed topic branch. Analyze the full consequence a
 
 Implement without interruption. Write each piece's tests as that piece lands instead of saving a test pass for the end of the cycle, and keep committing as each unit becomes coherent. Do not pause the sequence for a check run; [CI is read once per settled head](#validate-with-ci-and-self-review).
 
-Close each issue from the commit that earns it. End the commit message with one `Close #n: <issue title>` line per resolved issue, so a commit that resolves several issues carries several lines. GitHub matches the keyword and the number and reads the title tail as free text, which keeps the log legible without opening each issue.
+Close each issue from the commit that earns it. End the commit message with one `Close #n: <issue title>` line per resolved issue, so a commit that resolves several issues carries several lines. GitHub matches the keyword and the number and ignores the title tail, so the line closes the issue normally while the log stays legible without opening each number.
 
-Post a pull-request comment after each commit naming what that commit landed and which issues it resolved. The comment is the running ledger for a reader who does not read the diff, never a closing mechanism: GitHub closes an issue from a commit message or the pull-request body and never from a comment.
+Post a pull-request comment after each commit naming what that commit landed and which issues it resolved. The comment is the running ledger for a reader who does not read the diff, not a closing mechanism: GitHub closes an issue only from a commit message or the pull-request body.
 
 Each issue remains an evidence and acceptance unit inside the combined diff. Keep its positive, negative, boundary, and regression cases identifiable. Near-100% coverage of changed behavior is required; a green happy path is not completion.
 

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -34,6 +34,8 @@ Different packages, invariants, or validation lanes do not split the solo cycle.
 
 An issue whose only predecessor is another issue in the same cycle is implementation-ready for this purpose. Order the edits through the DAG instead of deferring it to another pull request.
 
+Difficulty never removes an issue from the cycle. When a resolution needs a judgment call about design, invariant ownership, or an acceptable behavior change, settle it from the issue's evidence and implement that decision here. Proved duplicate, invalid premise, out of scope, and external blocker stay the only dispositions that take an issue out of the cycle.
+
 ## Claim The Complete Cycle
 
 Claim the whole cycle before implementation:
@@ -50,6 +52,8 @@ The empty pull request prevents overlapping contributor work before code is writ
 
 Work through the DAG on the claimed topic branch. Analyze the full consequence and case surface across every issue before editing, then implement the complete cycle and its tests.
 
+Implement without interruption. Write each piece's tests as that piece lands instead of saving a test pass for the end of the cycle, and keep committing as each unit becomes coherent. Do not pause the sequence for a check run; [CI is read once per settled head](#validate-with-ci-and-self-review).
+
 Each issue remains an evidence and acceptance unit inside the combined diff. Keep its positive, negative, boundary, and regression cases identifiable. Near-100% coverage of changed behavior is required; a green happy path is not completion.
 
 Follow the development skill for test shape and narrow-then-broad local evidence. Do not treat a local build or test result as a substitute for the pull request's ordinary CI acceptance gate. After the source, tests, documentation, fixtures, and generated consequences are ready, run `pnpm format` and include its integrated result in the same pull request.
@@ -59,6 +63,8 @@ If implementation disproves, narrows, or externally blocks an issue, reopen the 
 ## Validate With CI And Self-Review
 
 Commit and push the formatted integrated snapshot, then let every ordinary pull-request check run. Start solo Self-Review immediately over that exact base-to-head diff while CI executes.
+
+Read CI once per settled head. It gates the cycle, not each commit: every pull-request workflow sets `cancel-in-progress`, so the next push cancels an intermediate commit's run and waiting on that run stalls implementation for a discarded result.
 
 CI and review are independent gates:
 

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -56,7 +56,9 @@ Work through the DAG on the claimed topic branch. Analyze the full consequence a
 
 Implement without interruption. Write each piece's tests as that piece lands instead of saving a test pass for the end of the cycle, and keep committing as each unit becomes coherent. Do not pause the sequence for a check run; [CI is read once per settled head](#validate-with-ci-and-self-review).
 
-Give each commit message a `Closes #n` trailer for every issue that commit resolves, then post a pull-request comment naming what the commit landed and which issues it resolved. GitHub closes an issue from a commit message or the pull-request body and never from a comment: the trailer attaches each closing to the change that earned it, and the comment is the running ledger a reader follows without reading the diff.
+Close each issue from the commit that earns it. End the commit message with one `Close #n: <issue title>` line per resolved issue, so a commit that resolves several issues carries several lines. GitHub matches the keyword and the number and reads the title tail as free text, which keeps the log legible without opening each issue.
+
+Post a pull-request comment after each commit naming what that commit landed and which issues it resolved. The comment is the running ledger for a reader who does not read the diff, never a closing mechanism: GitHub closes an issue from a commit message or the pull-request body and never from a comment.
 
 Each issue remains an evidence and acceptance unit inside the combined diff. Keep its positive, negative, boundary, and regression cases identifiable. Near-100% coverage of changed behavior is required; a green happy path is not completion.
 


### PR DESCRIPTION
## Intent

The maintainer's working cadence for a solo issue campaign was not written down, so `.agents/skills/issue-campaign/development.md` left five operative rules to be inferred: every admitted issue is conquered in one cycle regardless of difficulty, implementation runs continuously with its tests, CI is consumed once instead of per commit, and the claim body, commit messages, and pull-request comments each own a different part of the issue bookkeeping.

## Scope

One file, `.agents/skills/issue-campaign/development.md`. Five added paragraphs and one reworded list item.

**`Plan One Cycle Pull Request`** gains the difficulty closure. The section already refused to split the cycle by package, invariant, or validation lane, and step 2 already listed the four dispositions that remove an issue. What it did not say is that an issue whose resolution needs a judgment call about design, invariant ownership, or an acceptable behavior change is settled and implemented inside the cycle. The new paragraph names those four dispositions as the only exits, so difficulty is excluded by construction rather than by a separate prohibition.

**`Claim The Complete Cycle`** step 4 changes from "Link every cycle issue" to "Reference every cycle issue by number", and a new paragraph keeps closing keywords out of the claim body. The body is written before any code exists, so a claim-time closing list closes whatever the cycle later drops, defers, or disproves, and buries the analysis those issues carry. The cycle's closing set is the union of the commit lines, which makes the merge close exactly what landed. This is stated as the rule rather than as a warning about the failure.

**`Implement And Write Tests`** gains three paragraphs:

- implement without interruption, write each piece's tests as that piece lands, keep committing as each unit becomes coherent, and do not pause the sequence for a check run;
- end each commit message with one `Close #n: <issue title>` line per resolved issue, so a multi-issue commit carries one legible line per issue;
- post a pull-request comment after each commit naming what landed and which issues it resolved.

The three roles are stated separately because they are mechanically different. GitHub auto-closes from a commit message or the pull-request body and never from a comment, so a reader who folded them together would put the closing keyword in the comment and close nothing. The keyword and the number are what GitHub matches, and the `: <issue title>` tail is free text, so the format closes normally while keeping the log readable without opening each number.

**`Validate With CI And Self-Review`** gains the read-once rule. The repair loop below it already operated over a settled head, but nothing said CI is not a per-commit gate. The paragraph states the cadence and the fact that enforces it: every workflow under `.github/workflows/` sets `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`, so an intermediate commit's run is cancelled by the next push and waiting on it stalls implementation for a discarded result.

## Already covered, left alone

- **Commits split for diagnosis, not for pacing.** `Plan One Cycle Pull Request` already says "Keep issue-level commits when that improves diagnosis, but the pull request remains the integrated campaign unit." The cadence paragraph adds only the missing half, that the sequence is not paused for a check run, and does not restate the diagnosis rationale.
- **One pull request per cycle, and no package or lane splitting.** Stated in the flow rules and in `Plan One Cycle Pull Request`. Untouched.
- **The DAG does not defer an issue to a later pull request.** Already the closing paragraph of `Plan One Cycle Pull Request`. The difficulty paragraph follows it instead of merging into it, because predecessor order and difficulty are separate reasons an implementer reaches for a second pull request.
- **The claim pull request opens empty and prevents overlapping work.** Already steps 2 through 4 plus the rationale paragraph. Only the linking verb changed, so the following paragraph's reference-versus-close distinction is unambiguous.
- **Repair every red lane in the same pull request, including a pre-existing failure.** Already in the flow rules and in `Validate With CI And Self-Review`. Untouched.

## Deliberately not added

- **No edit to `.agents/skills/pull-request/SKILL.md`.** Its "Watch Checks After Every Ordinary Push" loop is not contradicted. This document's flow pushes the claim commit and then the integrated snapshot, and the read-once rule governs implementation pauses, not the settled head's check loop, which still runs through the existing repair cycle.
- **No edit to `.agents/skills/multi-agent/issue-campaign.md`.** Its batch pull requests link issues under a different ownership model, and the maintainer stated this cadence for the solo campaign.
- **No new section and no sibling document.** Each point landed in the section that already owns its phase, per the documentation skill's rule that always-applicable procedure stays in the owning document.

## Verification

- Prettier over the changed file with the options `prettier.config.js` applies to `*.md` (`--prose-wrap never --embedded-language-formatting off --print-width 80 --tab-width 2`), reported unchanged on the final content. The flags were passed explicitly because this worktree has no `node_modules`; the two plugins in that config apply only to TypeScript and JSDoc, not to Markdown.
- `git diff --check` clean.
- The one added link, `[CI is read once per settled head](#validate-with-ci-and-self-review)`, resolves to the existing `## Validate With CI And Self-Review` heading, the same anchor the document's Flow list already uses. No other link was touched.
- `cancel-in-progress` verified by reading every `concurrency` block under `.github/workflows/`; all eleven set it to `${{ github.event_name == 'pull_request' }}`.
- `Closes`, `closing keyword`, and issue-linking wording grepped across `.agents/` and `AGENTS.md` to confirm no other document states a conflicting rule.
- No build, test, or Go command was run. This is a Markdown-only change.
