### PR TITLE
docs(agents): separate per-commit early warning from Self-Review

### DIFF
--- a/.agents/skills/issue-campaign/SKILL.md
+++ b/.agents/skills/issue-campaign/SKILL.md
@@ -5,7 +5,7 @@ description: "Defines the default solo repository-wide issue campaign for ttsc: 
 
 # Issue Campaign
 
-An issue campaign is a repeatable solo sequence of exhaustive discovery, issue publication, one unified implementation pull request, and renewed discovery. The main agent owns every phase and delegates no decision, edit, or review round to a subagent. Implementation may run one read-only [per-commit early-warning pass](development.md#implement-and-write-tests) alongside it.
+An issue campaign is a repeatable solo sequence of exhaustive discovery, issue publication, one unified implementation pull request, and renewed discovery. The main agent owns every phase and delegates no decision, edit, or review round to a subagent. The only subagent it may spawn is the read-only [per-commit early-warning pass](development.md#implement-and-write-tests), which reads a landed commit while implementation continues.
 
 Use the [multi-agent skill](../multi-agent/SKILL.md) and its issue-campaign procedure instead only when the user explicitly asks for a parallel or multi-agent issue campaign.
 

--- a/.agents/skills/issue-campaign/SKILL.md
+++ b/.agents/skills/issue-campaign/SKILL.md
@@ -5,7 +5,7 @@ description: "Defines the default solo repository-wide issue campaign for ttsc: 
 
 # Issue Campaign
 
-An issue campaign is a repeatable solo sequence of exhaustive discovery, issue publication, one unified implementation pull request, and renewed discovery. The main agent owns every phase and never spawns or delegates to a subagent.
+An issue campaign is a repeatable solo sequence of exhaustive discovery, issue publication, one unified implementation pull request, and renewed discovery. The main agent owns every phase and delegates no decision, edit, or review round to a subagent. Implementation may run one read-only [per-commit early-warning pass](development.md#implement-and-write-tests) alongside it.
 
 Use the [multi-agent skill](../multi-agent/SKILL.md) and its issue-campaign procedure instead only when the user explicitly asks for a parallel or multi-agent issue campaign.
 

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -13,7 +13,7 @@ Read this document in full when the user authorizes implementation pull requests
 
 Four rules govern the implementation phase:
 
-- The main agent performs all implementation, test authoring, CI diagnosis, review, and cleanup. Do not spawn or delegate to a subagent.
+- The main agent performs all implementation, test authoring, CI diagnosis, review, and cleanup. The only permitted subagent is the read-only [per-commit early-warning pass](#implement-and-write-tests), which decides and changes nothing.
 - Put every accepted, implementation-ready issue in the current cycle into one pull request. The issue DAG controls implementation order inside that pull request, not pull-request count.
 - Work in the current checkout and one topic branch. Do not create a clone or worktree for a solo campaign or its Self-Review.
 - The pull request's ordinary CI and a clean solo Self-Review are the acceptance gates. Repair every red CI lane in that same pull request, even when the failure predates the campaign or is unrelated to its original issues.
@@ -55,6 +55,12 @@ The empty pull request prevents overlapping contributor work before code is writ
 Work through the DAG on the claimed topic branch. Analyze the full consequence and case surface across every issue before editing, then implement the complete cycle and its tests.
 
 Implement without interruption. Write each piece's tests as that piece lands instead of leaving the tests for the end of the cycle, and keep committing as each unit becomes coherent. Do not pause the sequence for a check run; [CI is read once per settled head](#validate-with-ci-and-self-review).
+
+One early-warning subagent may read a commit while implementation continues. Spawn it after the commit lands, hand it that commit's diff and the repository instructions it needs, and keep implementing without waiting for its report. It reads and reports candidates; it never edits, commits, pushes, or settles a design question, which is why it leaves the rule above intact.
+
+Run the pass for timing, not for coverage. A defect named while the commit is the newest thing written costs little to correct and carries nothing built on top of it yet. Treat each reported candidate as any other evidence: reproduce it first, then fix it in a later commit on the same branch, and record a disproved one so it is not rediscovered.
+
+The pass never counts toward this cycle's Self-Review, which stays solo, whole-surface, and after the last commit. The review skill's [Early Warning Is Not Self-Review](../review/SKILL.md#early-warning-is-not-self-review) owns the naming rule and the reason a commit-sized reader cannot replace the final round.
 
 Close each issue from the commit that earns it. End the commit message with one `Close #n: <issue title>` line per resolved issue, so a commit that resolves several issues carries several lines. GitHub matches the keyword and the number and ignores the title tail, so the line closes the issue normally while the log stays legible without opening each number.
 

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -56,7 +56,7 @@ Work through the DAG on the claimed topic branch. Analyze the full consequence a
 
 Implement without interruption. Write each piece's tests as that piece lands instead of leaving the tests for the end of the cycle, and keep committing as each unit becomes coherent. Do not pause the sequence for a check run; [CI is read once per settled head](#validate-with-ci-and-self-review).
 
-One early-warning subagent may read a commit while implementation continues. Spawn it after the commit lands, hand it that commit's diff and the repository instructions it needs, and keep implementing without waiting for its report. It reads and reports candidates; it never edits, commits, pushes, or settles a design question, which is why it leaves the rule above intact.
+One early-warning subagent may read a commit while implementation continues. Spawn it after the commit lands, hand it that commit's diff and the repository instructions it needs, and keep implementing without waiting for its report. It reads and reports candidates; it never edits, commits, pushes, or settles a design question, so every implementation, test, CI diagnosis, review, and cleanup decision stays with the main agent.
 
 Run the pass for timing, not for coverage. A defect named while the commit is the newest thing written costs little to correct and carries nothing built on top of it yet. Treat each reported candidate as any other evidence: reproduce it first, then fix it in a later commit on the same branch, and record a disproved one so it is not rediscovered.
 

--- a/.agents/skills/multi-agent/SKILL.md
+++ b/.agents/skills/multi-agent/SKILL.md
@@ -16,6 +16,8 @@ This skill is the single entry point for every explicitly parallel review or cam
 
 Do not load this skill for Self-Review, an unqualified review, or a campaign that does not explicitly request parallel agents.
 
+A solo campaign's per-commit early-warning pass is not this topology and does not enter here. Parallel review gives several reviewers the same whole declared surface for independent passes that the lead adjudicates. The early-warning pass gives one reader one commit's slice to report on while the author keeps implementing, and the author's own whole-surface round before merge is still the gate. Its cadence lives in [solo campaign development](../issue-campaign/development.md#implement-and-write-tests) and its naming rule in the [review skill](../review/SKILL.md#early-warning-is-not-self-review).
+
 ## Shared Parallelism Rules
 
 - Use the smallest number of agents that adds independent evidence or owns immediately executable disjoint work. Available thread capacity is not a reason to create an agent.

--- a/.agents/skills/multi-agent/SKILL.md
+++ b/.agents/skills/multi-agent/SKILL.md
@@ -16,7 +16,7 @@ This skill is the single entry point for every explicitly parallel review or cam
 
 Do not load this skill for Self-Review, an unqualified review, or a campaign that does not explicitly request parallel agents.
 
-A solo campaign's per-commit early-warning pass is not this topology and does not enter here. Parallel review gives several reviewers the same whole declared surface for independent passes that the lead adjudicates. The early-warning pass gives one reader one commit's slice to report on while the author keeps implementing, and the author's own whole-surface round before merge is still the gate. Its cadence lives in [solo campaign development](../issue-campaign/development.md#implement-and-write-tests) and its naming rule in the [review skill](../review/SKILL.md#early-warning-is-not-self-review).
+A solo campaign's per-commit early-warning pass is not this topology. Parallel review gives every reviewer the same whole declared surface for an independent pass that the lead adjudicates. The early-warning pass gives one reader one commit's slice to report on while the author keeps implementing, and the author's own whole-surface round before merge is still the gate. Its cadence lives in [solo campaign development](../issue-campaign/development.md#implement-and-write-tests) and its naming rule in the [review skill](../review/SKILL.md#early-warning-is-not-self-review).
 
 ## Shared Parallelism Rules
 

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -31,6 +31,16 @@ Self-Review and an unqualified review request use this solo workflow:
 
 Self-Review does not authorize creating, pushing, updating, or merging a pull request. If the user separately requests one of those actions, follow the pull-request skill.
 
+## Early Warning Is Not Self-Review
+
+An author implementing a long branch may run a per-commit early-warning pass: one subagent reads a commit as it lands and reports candidates while the author keeps implementing. It reads and reports only, so it delegates nothing the Non-Negotiable Review Law governs. It never edits, commits, pushes, or settles a design question, and its report is evidence the author still has to reproduce. [Solo campaign development](../issue-campaign/development.md#implement-and-write-tests) owns that cadence.
+
+The law's first sentence keeps its exact meaning, and all four rules still bind the author's own round unchanged. No number of per-commit passes counts toward whole-surface coverage or stands in for the complete round over the base-to-head diff before merge.
+
+Never call the early-warning pass a Self-Review. Under the gate's name it reads as the gate already run, and the whole-surface round quietly disappears, which is the failure the fresh-start rule exists to prevent.
+
+A commit-sized reader also cannot see what exists only between commits: a document or issue asserting a verification the code never performs, a helper reimplemented next to one that already lives in the same package, a string match that can never fire because of how the target file is stored. Each one is consistent inside the commit that introduced it and becomes visible only across the whole diff.
+
 ## Solo Issue Discovery Rounds
 
 Use these rounds only through the solo issue-campaign skill.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -33,13 +33,13 @@ Self-Review does not authorize creating, pushing, updating, or merging a pull re
 
 ## Early Warning Is Not Self-Review
 
-An author implementing a long branch may run a per-commit early-warning pass: one subagent reads a commit as it lands and reports candidates while the author keeps implementing. It reads and reports only, so it delegates nothing the Non-Negotiable Review Law governs. It never edits, commits, pushes, or settles a design question, and its report is evidence the author still has to reproduce. [Solo campaign development](../issue-campaign/development.md#implement-and-write-tests) owns that cadence.
+A per-commit early-warning pass is a different activity under a different name, not a review under this skill. One subagent reads a commit as it lands and reports candidates while the author keeps implementing. It reads and reports only: it never edits, commits, pushes, or settles a design question, and its report is evidence the author still has to reproduce. [Solo campaign development](../issue-campaign/development.md#implement-and-write-tests) authorizes and bounds that cadence.
 
-The law's first sentence keeps its exact meaning, and all four rules still bind the author's own round unchanged. No number of per-commit passes counts toward whole-surface coverage or stands in for the complete round over the base-to-head diff before merge.
+Because the pass decides nothing, it delegates nothing the Non-Negotiable Review Law governs. The law's prohibition on spawning a subagent and delegating a concern keeps its exact meaning, and all four rules still bind the author's own round unchanged. No number of per-commit passes counts toward whole-surface coverage or stands in for the complete round over the base-to-head diff before merge.
 
-Never call the early-warning pass a Self-Review. Under the gate's name it reads as the gate already run, and the whole-surface round quietly disappears, which is the failure the fresh-start rule exists to prevent.
+Never call the early-warning pass a Self-Review. A reader who sees the gate's name concludes the gate already ran, and the whole-surface round then disappears without anyone deciding to drop it, which is the failure the fresh-start rule exists to prevent.
 
-A commit-sized reader also cannot see what exists only between commits: a document or issue asserting a verification the code never performs, a helper reimplemented next to one that already lives in the same package, a string match that can never fire because of how the target file is stored. Each one is consistent inside the commit that introduced it and becomes visible only across the whole diff.
+A commit-sized reader also cannot see what appears only across files and commits: a document or issue asserting a verification the code never performs, a helper reimplemented next to one that already lives in the same package, a string match that can never fire because of how the target file is stored. Each one is consistent inside the commit that introduced it and becomes visible only over the whole diff.
 
 ## Solo Issue Discovery Rounds
 


### PR DESCRIPTION
## Intent

A solo campaign's cycle pull request carries many commits, and the maintainer asked whether each commit's review can be handed to a subagent while the author keeps implementing. The answer is that two layers exist and neither replaces the other, so this records both and keeps them distinguishable by name.

- **Layer 1, per-commit early warning.** After a commit lands the author may spawn one subagent to read it and report candidates while implementation continues. It reads and reports; it never edits, commits, pushes, or settles a design question. Its value is timing: a defect named while the commit is the newest thing written is cheap and nothing is built on it yet.
- **Layer 2, the author's own Self-Review over the whole base-to-head diff before merge.** Unchanged, undelegated, unpartitioned, and not satisfied by any number of per-commit passes.

Naming is the load-bearing part. If the early-warning pass is called a Self-Review, a reader concludes the gate already ran and the whole-surface round quietly disappears, which is exactly the failure the fresh-start rule exists to prevent.

## Scope

| File | Share |
| --- | --- |
| `.agents/skills/review/SKILL.md` | New `Early Warning Is Not Self-Review` section: the pass is a different activity under a different name, it delegates nothing the Non-Negotiable Review Law governs, the law's four rules still bind the author's own round, and a commit-sized reader cannot see cross-commit defects. |
| `.agents/skills/issue-campaign/development.md` | Layer 1 as implementation cadence, placed next to the implement-without-interruption paragraph #919 added, plus a precise amendment to the no-subagent rule in the four governing rules. |
| `.agents/skills/multi-agent/SKILL.md` | One paragraph of contrast so a reader of that skill does not assume the same topology: several reviewers each take the whole declared surface and the lead adjudicates, versus one reader on one commit's slice with the author's final whole-surface round still the gate. |
| `.agents/skills/issue-campaign/SKILL.md` | One-sentence precision fix. Its opening said the main agent "never spawns or delegates to a subagent", which would have flatly contradicted the new carve-out for a reader entering the campaign from the parent skill. It now says the main agent delegates no decision, edit, or review round, and links to the cadence. |

The design is stated once and linked from the other documents rather than repeated. `Self-Review remains solo for every author and every implementation branch` in the multi-agent skill stays true and stays where it is; this adds a parallel early-warning reader, it does not loosen that line.

## Deliberately not added

- No change to the Non-Negotiable Review Law's own text. Its first sentence had to keep meaning exactly what it says, so the carve-out is a separate named section that leaves the law verbatim.
- No new sibling document. The material is short enough to live in the owning sections.
- No `AGENTS.md` change. This is not a new skill area, a rename, or a rule that must apply before any skill loads.
- No procedure for how to brief the early-warning subagent beyond what it may and may not do. Prescribing a brief format would outrun the settled design.
- No repository-wide sweep for other prose about delegation. The four touched files are the verified surface where the new rule changes meaning.

## Verification

- `prettier --write` on all four touched Markdown files, using the repository config. No reflow beyond the added lines; `git diff --stat` is 20 insertions and 2 deletions.
- `git diff --check` clean.
- Every link touched resolves: `../review/SKILL.md#early-warning-is-not-self-review` against the new `## Early Warning Is Not Self-Review` heading, and `development.md#implement-and-write-tests` (relative and `../issue-campaign/` forms) against the existing `## Implement And Write Tests` heading.
- No build or test was run. The change is Markdown only.
- Solo Self-Review over the base-to-head diff follows in a comment on this pull request.
