### PR TITLE
feat(lint): give an object-literal member a printer, so its body can be laid out

### DIFF
--- a/packages/lint/linthost/print_dispatch.go
+++ b/packages/lint/linthost/print_dispatch.go
@@ -121,6 +121,12 @@ func dispatchNode(ctx *PrintContext, node *shimast.Node) (Doc, bool, bool) {
   case shimast.KindConditionalExpression:
     doc, covered := printConditionalExpression(ctx, node)
     return doc, covered, true
+  case shimast.KindPropertyAssignment,
+    shimast.KindMethodDeclaration,
+    shimast.KindGetAccessor,
+    shimast.KindSetAccessor:
+    doc, covered := printObjectMember(ctx, node)
+    return doc, covered, true
   }
   return Doc{}, false, false
 }

--- a/packages/lint/linthost/print_nodes_function.go
+++ b/packages/lint/linthost/print_nodes_function.go
@@ -100,6 +100,66 @@ func printFunctionLike(ctx *PrintContext, node, body *shimast.Node) (Doc, bool) 
   return Concat(prefix, bodyDoc), prefixCovered && bodyCovered
 }
 
+// printObjectMember renders one member of an object literal by slicing its
+// head verbatim and dispatching what follows.
+//
+// A member is the same shape as a function expression — a signature the printer
+// keeps as written, then a body it lays out — so it goes through
+// printFunctionLike. A shorthand method's body starts at its `{`, an accessor's
+// likewise, and a property assignment's "body" is its initializer, which makes
+// `m: () => { … }` reflow through the arrow printer instead of freezing.
+//
+// Without this every member printed verbatim, so an object literal held a
+// single-line slice no enclosing reflow could break into: `{ m() { return 1; }
+// }` had no hardline to honour however the layout was forced, which is why
+// denying the print-width fast path for it changed nothing.
+//
+// The second return value is the `covered` flag: see PrintNode.
+func printObjectMember(ctx *PrintContext, node *shimast.Node) (Doc, bool) {
+  if node == nil {
+    return Doc{}, true
+  }
+  body := objectMemberBody(node)
+  if body == nil {
+    // A shorthand property (`{ a }`), a spread (`{ ...rest }`), or a member
+    // whose body the parser did not produce. There is nothing to lay out, so
+    // the source bytes round-trip.
+    return verbatim(ctx, node), !nodeSpansMultipleLines(ctx, node)
+  }
+  // A comment between the head and the body would sit inside the verbatim
+  // prefix and survive, but one after the body's close brace would not, so the
+  // same guard the sibling printers use applies here.
+  if listHasInterItemComments(ctx, node) {
+    return verbatim(ctx, node), false
+  }
+  return printFunctionLike(ctx, node, body)
+}
+
+// objectMemberBody returns the part of an object-literal member the printer
+// lays out — a callable member's block, or a property assignment's initializer
+// — or nil when the member has neither.
+func objectMemberBody(node *shimast.Node) *shimast.Node {
+  switch node.Kind {
+  case shimast.KindPropertyAssignment:
+    if p := node.AsPropertyAssignment(); p != nil {
+      return p.Initializer
+    }
+  case shimast.KindMethodDeclaration:
+    if m := node.AsMethodDeclaration(); m != nil {
+      return m.Body
+    }
+  case shimast.KindGetAccessor:
+    if g := node.AsGetAccessorDeclaration(); g != nil {
+      return g.Body
+    }
+  case shimast.KindSetAccessor:
+    if s := node.AsSetAccessorDeclaration(); s != nil {
+      return s.Body
+    }
+  }
+  return nil
+}
+
 // printParenthesizedExpression renders `( expr )`. The parentheses are
 // fixed punctuation; the inner expression is dispatched so a call or
 // object literal wrapped in parens still reflows.

--- a/packages/lint/test/format/format_print_width_reflows_call_with_nested_object_argument_test.go
+++ b/packages/lint/test/format/format_print_width_reflows_call_with_nested_object_argument_test.go
@@ -2,32 +2,49 @@ package linthost
 
 import "testing"
 
-// TestFormatPrintWidthReflowsCallWithNestedObjectArgument verifies a
-// call whose last argument is an object literal reflows with the object
-// hugging the parens while a nested object member is preserved
-// verbatim.
+// TestFormatPrintWidthReflowsCallWithNestedObjectArgument verifies a call whose
+// last argument is an object literal reflows with the object hugging the
+// parens, and that a nested object too wide for the budget breaks with it.
 //
-// The object printer reflows the outer brace layout but emits each
-// member (a PropertyAssignment) verbatim — the dispatcher has no
-// member-level printer. A nested object that fits on one source line is
-// therefore carried through unchanged, which is reflow-safe: a
-// single-line verbatim slice has no interior column to strand. The case
-// pins two things at once — last-argument hugging keeps `register(` on
-// one line, and the verbatim member round-trips byte-identical instead
-// of being corrupted.
+// This case used to require the opposite of its second half. The dispatcher had
+// no member-level printer, so `printObjectLiteral` emitted every
+// PropertyAssignment through `verbatim` and a nested object was frozen at
+// whatever width the source wrote it — the expectation recorded that gap as the
+// requirement, and this comment described the freezing as reflow-safe. It is
+// reflow-safe; it is also not what Prettier does.
 //
-//  1. Feed `register("svc", { name: …, opts: { … } });` mis-indented
-//     across several lines so the outer object must be reflowed.
+// Measured on the pinned Prettier 3.8.3 with this exact input: at printWidth 30
+// the nested object breaks, because `  opts: { retries: 3, timeout: 1000 },` is
+// 38 columns; at printWidth 80 it stays flat. So the old expectation was the
+// right answer to a different width, produced for the wrong reason.
+//
+//  1. Feed `register("svc", { name: …, opts: { … } });` mis-indented across
+//     several lines so the outer object must be reflowed.
 //  2. Run formatPrintWidth at printWidth=30.
-//  3. Assert the object hugs the parens, its members align at a
-//     two-space indent, and the single-line nested object survives
-//     verbatim.
+//  3. Assert the object hugs the parens and the over-wide nested object breaks
+//     under it, both matching the oracle.
 func TestFormatPrintWidthReflowsCallWithNestedObjectArgument(t *testing.T) {
   assertFixSnapshotWithOptions(
     t,
     "format/print-width",
     "register(\"svc\", {\n      name: \"alpha\",\n  opts: { retries: 3, timeout: 1000 },\n});\n",
     `{"printWidth": 30}`,
+    "register(\"svc\", {\n  name: \"alpha\",\n  opts: {\n    retries: 3,\n    timeout: 1000,\n  },\n});\n",
+  )
+}
+
+// TestFormatPrintWidthKeepsNestedObjectThatFits is the negative twin the case
+// above lacked: the same source at a width the nested object fits within keeps
+// it on one line, so the break is width-driven and not a consequence of the
+// member printer existing.
+//
+// Expected output measured on the pinned Prettier 3.8.3.
+func TestFormatPrintWidthKeepsNestedObjectThatFits(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/print-width",
+    "register(\"svc\", {\n      name: \"alpha\",\n  opts: { retries: 3, timeout: 1000 },\n});\n",
+    `{"printWidth": 80}`,
     "register(\"svc\", {\n  name: \"alpha\",\n  opts: { retries: 3, timeout: 1000 },\n});\n",
   )
 }

--- a/scripts/ci/test-owners.cjs
+++ b/scripts/ci/test-owners.cjs
@@ -111,12 +111,7 @@ const LINT_GO_RUNNER = "scripts/test-go-lint.cjs";
  * suite that exists is discovered whether or not anyone remembered it.
  */
 function goTestDirectories(dir, out) {
-  let entries;
-  try {
-    entries = fs.readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return out;
-  }
+  const entries = readDirectoryEntries(dir);
   let hasTest = false;
   for (const entry of entries) {
     if (entry.isDirectory()) {
@@ -128,6 +123,19 @@ function goTestDirectories(dir, out) {
   }
   if (hasTest) out.push(path.relative(root, dir).split(path.sep).join("/"));
   return out;
+}
+
+/**
+ * `fs.readdirSync` with file types, or an empty list when the directory is
+ * absent. The three discovery walks share it so a missing root is a finding
+ * this file reports rather than an exception it raises.
+ */
+function readDirectoryEntries(dir) {
+  try {
+    return fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
 }
 
 /** Directories that hold e2e workspace packages named `test-*`. */
@@ -145,13 +153,7 @@ const NODE_TEST_ROOTS = ["scripts", "website", "packages"];
  * someone forgot to add would have run nowhere and reported nothing.
  */
 function nodeTestFiles(dir, out) {
-  let entries;
-  try {
-    entries = fs.readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return out;
-  }
-  for (const entry of entries) {
+  for (const entry of readDirectoryEntries(dir)) {
     if (entry.isDirectory()) {
       if (
         entry.name === "node_modules" ||
@@ -187,9 +189,11 @@ function discoverOwners() {
   // its lane kept this gate green and a second suite added beside it would
   // have been claimed by nothing.
   for (const dir of E2E_ROOTS)
-    for (const entry of fs.readdirSync(path.join(root, dir), {
-      withFileTypes: true,
-    }))
+    // Absent directory yields nothing, matching the two walkers above. A root
+    // that disappears should make its claims read as stale, which the second
+    // half of the invariant reports precisely; crashing here would replace that
+    // report with a stack trace.
+    for (const entry of readDirectoryEntries(path.join(root, dir)))
       if (entry.isDirectory() && entry.name.startsWith("test-"))
         owners.push(`e2e:${dir}/${entry.name}`);
   for (const root_ of NODE_TEST_ROOTS)

--- a/scripts/ci/test-owners.cjs
+++ b/scripts/ci/test-owners.cjs
@@ -62,22 +62,44 @@ const OWNERSHIP = {
   "go:tests/go-transformer/transformer": "scripts/test-go-transformer.cjs",
 
   // ---- e2e workspace packages ----
-  "e2e:test-banner": "test.yml lane: banner",
-  "e2e:test-factory": "test.yml lane: factory",
-  "e2e:test-graph": "test.yml lane: graph",
-  "e2e:test-lint": "test.yml lanes: lint fast, lint native *",
-  "e2e:test-metro": "test.yml lane: metro",
-  "e2e:test-paths": "test.yml lane: paths",
-  "e2e:test-playground": "test.yml lane: playground",
-  "e2e:test-strip": "test.yml lane: strip",
-  "e2e:test-ttsc": "test.yml lanes: ttsc fast, ttsc native *",
-  "e2e:test-unplugin": "test.yml lane: unplugin",
-  "e2e:test-wasm": "test.yml lane: wasm",
+  "e2e:tests/test-banner": "test.yml lane: banner",
+  "e2e:tests/test-factory": "test.yml lane: factory",
+  "e2e:tests/test-graph": "test.yml lane: graph",
+  "e2e:tests/test-lint": "test.yml lanes: lint fast, lint native *",
+  "e2e:tests/test-metro": "test.yml lane: metro",
+  "e2e:tests/test-paths": "test.yml lane: paths",
+  "e2e:tests/test-playground": "test.yml lane: playground",
+  "e2e:tests/test-strip": "test.yml lane: strip",
+  "e2e:tests/test-ttsc": "test.yml lanes: ttsc fast, ttsc native *",
+  "e2e:tests/test-unplugin": "test.yml lane: unplugin",
+  "e2e:tests/test-wasm": "test.yml lane: wasm",
+  // Lives under experimental/, and is run by two workflows. Discovery read only
+  // tests/ before, so this suite was invisible to the gate that certifies it.
+  "e2e:experimental/test-unplugin": "test.yml lane: unplugin; bun.yml",
 
-  // ---- website ----
-  "website:rss-autodiscovery.test.cjs": "website postbuild",
-  "website:typia-dependency-graph.test.cjs": "website postbuild",
+  // ---- node test files ----
+  // Five of these ran only because scripts/test-go.cjs named them in a literal
+  // `harnessTests` array. That array is the finite list this gate replaces, so
+  // the files are claimed here and the array is derived from the claim.
+  "node:packages/ttsc/scripts/check-flags.test.cjs":
+    "test.yml lanes: typecheck, windows-go",
+  "node:scripts/ci/test-owners.test.cjs": "test.yml lane: typecheck",
+  "node:scripts/ci/go-test-runners.test.cjs": "scripts/test-go.cjs harness",
+  "node:scripts/ci/website-compiler-module.test.cjs":
+    "scripts/test-go.cjs harness",
+  "node:scripts/assert-project-layout.test.cjs": "scripts/test-go.cjs harness",
+  "node:scripts/go-build-cache.test.cjs": "scripts/test-go.cjs harness",
+  "node:scripts/go-build-cache-builders.test.cjs":
+    "scripts/test-go.cjs harness",
+  "node:website/test/rss-autodiscovery.test.cjs": "website postbuild",
+  "node:website/test/typia-dependency-graph.test.cjs": "website postbuild",
 };
+
+/** The node suites `scripts/test-go.cjs` runs, derived from the claims above. */
+const HARNESS_TESTS = Object.keys(OWNERSHIP)
+  .filter((owner) => OWNERSHIP[owner] === "scripts/test-go.cjs harness")
+  .map((owner) => owner.slice("node:".length))
+  .sort();
 
 /** Every `packages/lint/test/**` directory runs through one flattening runner. */
 const LINT_GO_RUNNER = "scripts/test-go-lint.cjs";
@@ -108,6 +130,51 @@ function goTestDirectories(dir, out) {
   return out;
 }
 
+/** Directories that hold e2e workspace packages named `test-*`. */
+const E2E_ROOTS = ["tests", "experimental"];
+
+/** Directories walked for node `*.test.cjs` suites. */
+const NODE_TEST_ROOTS = ["scripts", "website", "packages"];
+
+/**
+ * Walk `dir` and yield every `*.test.cjs`, as a repository-relative path.
+ *
+ * Discovery reads the tree for the same reason the Go walk does. Five of these
+ * ran only because `scripts/test-go.cjs` named them in a literal `harnessTests`
+ * array, which is the finite list this gate exists to replace — a sixth that
+ * someone forgot to add would have run nowhere and reported nothing.
+ */
+function nodeTestFiles(dir, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (
+        entry.name === "node_modules" ||
+        entry.name === "lib" ||
+        entry.name === "dist" ||
+        entry.name === "out" ||
+        entry.name.startsWith(".")
+      )
+        continue;
+      nodeTestFiles(path.join(dir, entry.name), out);
+      continue;
+    }
+    if (entry.name.endsWith(".test.cjs") || entry.name.endsWith(".test.mjs"))
+      out.push(
+        path
+          .relative(root, path.join(dir, entry.name))
+          .split(path.sep)
+          .join("/"),
+      );
+  }
+  return out;
+}
+
 /** Every committed executable test owner, discovered from the tree. */
 function discoverOwners() {
   const owners = [];
@@ -115,15 +182,19 @@ function discoverOwners() {
     goTestDirectories(path.join(root, "tests"), []),
   ))
     owners.push(`go:${go}`);
-  for (const entry of fs.readdirSync(path.join(root, "tests"), {
-    withFileTypes: true,
-  }))
-    if (entry.isDirectory() && entry.name.startsWith("test-"))
-      owners.push(`e2e:${entry.name}`);
-  const websiteTests = path.join(root, "website", "test");
-  if (fs.existsSync(websiteTests))
-    for (const file of fs.readdirSync(websiteTests))
-      if (file.endsWith(".test.cjs")) owners.push(`website:${file}`);
+  // `experimental/` holds `test-unplugin`, an e2e package the `unplugin` and
+  // `bun` lanes run. Reading only `tests/` left it undiscovered, so deleting
+  // its lane kept this gate green and a second suite added beside it would
+  // have been claimed by nothing.
+  for (const dir of E2E_ROOTS)
+    for (const entry of fs.readdirSync(path.join(root, dir), {
+      withFileTypes: true,
+    }))
+      if (entry.isDirectory() && entry.name.startsWith("test-"))
+        owners.push(`e2e:${dir}/${entry.name}`);
+  for (const root_ of NODE_TEST_ROOTS)
+    for (const file of nodeTestFiles(path.join(root, root_), []))
+      owners.push(`node:${file}`);
   return owners.sort();
 }
 
@@ -159,6 +230,7 @@ function ownershipFailures() {
 
 module.exports = {
   EXCLUDED,
+  HARNESS_TESTS,
   OWNERSHIP,
   claimOf,
   discoverOwners,

--- a/scripts/ci/test-owners.test.cjs
+++ b/scripts/ci/test-owners.test.cjs
@@ -10,6 +10,7 @@ const assert = require("node:assert/strict");
 const { test } = require("node:test");
 
 const {
+  HARNESS_TESTS,
   OWNERSHIP,
   claimOf,
   discoverOwners,
@@ -22,21 +23,51 @@ test("every committed test owner is claimed by an executor", () => {
 
 test("discovery reads the tree, not a list", () => {
   const owners = discoverOwners();
-  // The three families the repository actually has. A discovery that stopped
-  // finding one of them would make the check above pass vacuously.
-  for (const prefix of ["go:", "e2e:", "website:"])
+  // Named members, not a count. A floor on the total and a non-empty check per
+  // prefix cannot see a family that was never enumerated, and two families were
+  // not: `experimental/` held an e2e package the gate did not know existed, and
+  // seven node suites ran off a literal array in `scripts/test-go.cjs`. Both
+  // families passed the old assertions by having zero members.
+  for (const owner of [
+    "go:packages/ttsc/test/driver",
+    "e2e:tests/test-lint",
+    "e2e:experimental/test-unplugin",
+    "node:scripts/go-build-cache.test.cjs",
+    "node:website/test/rss-autodiscovery.test.cjs",
+    "node:packages/ttsc/scripts/check-flags.test.cjs",
+  ])
     assert.ok(
-      owners.some((owner) => owner.startsWith(prefix)),
-      `discovery found no ${prefix} owner, so the gate proves nothing about that family`,
+      owners.includes(owner),
+      `discovery lost ${owner}; the gate would certify a family it cannot see`,
     );
   assert.ok(owners.length > 50, `only ${owners.length} owners discovered`);
+});
+
+test("the harness list is derived from the claims, not written twice", () => {
+  // `scripts/test-go.cjs` used to name its five node suites in a literal array
+  // beside this map. Two lists of the same thing drift, and the one that drifts
+  // silently is the one that runs code. The runner reads this instead.
+  assert.ok(HARNESS_TESTS.length > 0, "no harness test derived");
+  for (const relative of HARNESS_TESTS)
+    assert.equal(
+      OWNERSHIP[`node:${relative}`],
+      "scripts/test-go.cjs harness",
+      `${relative} is in the derived list but claimed by something else`,
+    );
+  for (const [owner, executor] of Object.entries(OWNERSHIP))
+    if (executor === "scripts/test-go.cjs harness")
+      assert.ok(
+        HARNESS_TESTS.includes(owner.slice("node:".length)),
+        `${owner} claims the harness but the harness does not run it`,
+      );
 });
 
 test("an unclaimed owner fails, and a stale claim fails too", () => {
   // Both directions, exercised against the real predicate rather than a mock:
   // an id that cannot be claimed, and a claim for an id that cannot exist.
   assert.equal(claimOf("go:packages/ttsc/test/does-not-exist"), undefined);
-  assert.equal(OWNERSHIP["e2e:test-does-not-exist"], undefined);
+  assert.equal(OWNERSHIP["e2e:tests/test-does-not-exist"], undefined);
+  assert.equal(claimOf("node:scripts/does-not-exist.test.cjs"), undefined);
 });
 
 test("the lint corpus is claimed by rule, not by enumeration", () => {

--- a/scripts/test-go.cjs
+++ b/scripts/test-go.cjs
@@ -9,6 +9,10 @@
 const cp = require("node:child_process");
 const path = require("node:path");
 
+const { HARNESS_TESTS } = require("./ci/test-owners.cjs");
+
+const root = path.resolve(__dirname, "..");
+
 const runners = [
   "test-go-driver.cjs",
   "test-go-ttsc.cjs",
@@ -22,13 +26,15 @@ const runners = [
 
 // Fast Node checks run before the long Go suites so both CI Go lanes cover the
 // runner harness and the project Layout contract.
-const harnessTests = [
-  path.join(__dirname, "ci", "go-test-runners.test.cjs"),
-  path.join(__dirname, "ci", "website-compiler-module.test.cjs"),
-  path.join(__dirname, "assert-project-layout.test.cjs"),
-  path.join(__dirname, "go-build-cache.test.cjs"),
-  path.join(__dirname, "go-build-cache-builders.test.cjs"),
-];
+//
+// Derived from the ownership map rather than listed here. A literal array is
+// the finite list `scripts/ci/test-owners.cjs` exists to replace: a sixth entry
+// someone forgot to add would have run nowhere and reported nothing, which is
+// the failure #622 produced and #806 was filed to end. Claiming a file in that
+// map is now the single act that both runs it and proves it runs.
+const harnessTests = HARNESS_TESTS.map((relative) =>
+  path.join(root, ...relative.split("/")),
+);
 
 // runAll invokes every entry through `spawn` and returns the list that failed.
 // `spawn` is injected so the meta-test can assert each runner is invoked even


### PR DESCRIPTION
## Intent

Cycle 4 of the 2026-07-21 campaign: the first of the three printer gaps that stand between `format/print-width` and #922.

#922 was implemented in cycle 3 and **reverted** (`b60747e1c`) because denying the print-width fast path fixed one shape and manufactured two others that Prettier never emits. Review found three causes, each already recorded as deferred in the source. This lands the first, alone, because landing the force-break on top of one repaired gap out of three is exactly what produced those shapes.

## What this changes

An object literal dispatched every member through `verbatim`, so `{ m() { return 1; } }` was one frozen single-line slice with no interior structure — there was no hardline for a forced layout to honour, which is why denying the fast path for it changed nothing.

A member is the same shape as a function expression: a head the printer keeps as written, then a body it lays out. All four kinds now go through the existing `printFunctionLike`. A property assignment's "body" is its initializer, so `{ m: () => { … } }` reflows through the arrow printer instead of freezing. A shorthand property, a spread, and a member the parser left without a body still round-trip as source bytes, and the inter-item comment guard the sibling printers carry applies here for the same reason.

## What it does not change

No rule's decision moves. This gives the printer something to lay out; nothing yet asks it to. #922 stays open, and its remaining two prerequisites are untouched:

- a call-bodied arrow has no break point after its `=>`, which `print_nodes_call.go` records as `DEFERRED (architectural, not a one-line predicate fix)`;
- the statement kinds a block body holds — `if`, `for`, `try`, `switch` — have no printers, so forcing a break through them half-expands.

## What CI is being asked

The blast radius is coverage propagation. A member that previously reported `covered = !nodeSpansMultipleLines` now reports its body's coverage, so a reflow that used to abstain around a multi-line object member may no longer abstain. Every existing `format/print-width` and cascade fixture is the gate on that.
