### PR TITLE
docs(agents): make the campaign discovery loop and full-scope round unmissable

### DIFF
--- a/.agents/skills/issue-campaign/SKILL.md
+++ b/.agents/skills/issue-campaign/SKILL.md
@@ -39,7 +39,15 @@ Treat the development skill's [Forbidden](../development/SKILL.md#forbidden) sec
 
 Do not stop after finding enough work for a pull request. Complete the entire scope, adjudicate the full candidate pool, and publish only the surviving issues when authorized.
 
-After the cycle pull request merges, begin a fresh full-scope round against the integrated repository. Earlier rounds are not coverage. The campaign ends only when a complete fresh round produces no meaningful issue candidate after fact-checking and no accepted issue remains unresolved.
+### Every Round Is Full-Scope
+
+Every round re-audits the entire declared scope against the current integrated state. A round is never partitioned: not by package, concern, or validation lane, not by the areas the last cycle happened to touch, and not by splitting the scope across rounds so that each one covers a slice. A merged cycle changes the state every earlier conclusion rested on, so what an earlier round read is not coverage for this one. The [review skill's Non-Negotiable Review Law](../review/SKILL.md#non-negotiable-review-law) states the same rule for every round and review the campaign runs.
+
+### Discovery Ends Only On An Empty Round
+
+A merged cycle does not end the campaign. It produces one more round: begin a fresh full-scope round against the integrated repository. Discovery continues cycle after cycle, with no round limit, and ends only when one complete fresh round produces no meaningful issue candidate after fact-checking and no accepted issue remains unresolved.
+
+Report the campaign complete only from a round that actually came up empty. Ending after a cycle that merely felt thorough leaves the issues the next round would have found unrecorded.
 
 ## Vet And Publish Issues
 


### PR DESCRIPTION
## Problem

`.agents/skills/issue-campaign/SKILL.md` carried two load-bearing rules in one closing paragraph of `## Discover Issues`:

> After the cycle pull request merges, begin a fresh full-scope round against the integrated repository. Earlier rounds are not coverage. The campaign ends only when a complete fresh round produces no meaningful issue candidate after fact-checking and no accepted issue remains unresolved.

That is the campaign's shape stated as a closing remark, and it read as one. In the 2026-07-21 campaign, cycles 2 and 3 both merged without a single post-merge discovery round. When a round was finally run against the integrated state, it produced three issues: #926, #927, and #928. The loop was neither optional nor already exhausted; it had simply been skipped.

The full-scope requirement had the same problem from the other direction. The [review skill's Non-Negotiable Review Law](https://github.com/samchon/ttsc/blob/master/.agents/skills/review/SKILL.md#non-negotiable-review-law) already forbids partitioning a round by file, package, concern, platform, or pass, but a reader working from the campaign skill may never open the review skill, and the campaign skill never said it in its own words.

## Change

Documentation only. One file, one section: the closing paragraph of `## Discover Issues` becomes two named subsections.

### `### Every Round Is Full-Scope`

> Every round re-audits the entire declared scope against the current integrated state. A round is never partitioned: not by package, concern, or validation lane, not by the areas the last cycle happened to touch, and not by splitting the scope across rounds so that each one covers a slice. A merged cycle changes the state every earlier conclusion rested on, so what an earlier round read is not coverage for this one. The [review skill's Non-Negotiable Review Law](../review/SKILL.md#non-negotiable-review-law) states the same rule for every round and review the campaign runs.

The excluded partitions are the ones actually reached for: by package, by concern or lane, by "the areas the last cycle touched", and by spreading one scope across several rounds so each covers a slice. The review skill keeps ownership of the law and is linked, not restated. `Full-Scope` matches the term already used in `development.md`, `review/SKILL.md`, and `multi-agent/issue-campaign.md`.

### `### Discovery Ends Only On An Empty Round`

> A merged cycle does not end the campaign. It produces one more round: begin a fresh full-scope round against the integrated repository. Discovery continues cycle after cycle, with no round limit, and ends only when one complete fresh round produces no meaningful issue candidate after fact-checking and no accepted issue remains unresolved.
>
> Report the campaign complete only from a round that actually came up empty. Ending after a cycle that merely felt thorough leaves the issues the next round would have found unrecorded.

The merge is the trigger for the next round, which is the step that was missed, and the termination condition is stated as evidence from a round rather than a judgment about a cycle.

## Scope

- No new policy. Both rules already existed in the same section; only their prominence and wording changed.
- No restructuring beyond splitting that one paragraph. Section order, every other paragraph, and the frontmatter are untouched.
- `.agents/skills/review/SKILL.md`, `.agents/skills/multi-agent/`, and `.agents/skills/issue-campaign/development.md` are untouched. `multi-agent/issue-campaign.md` already requires that "Every discovery agent audits the whole declared scope independently", so the new subsection does not conflict with the parallel variant.
- `npx prettier --check` passes on the changed file.

No closing keyword appears in the commit range or in this body, verified against `git log origin/master..HEAD`. #926, #927, and #928 are cited only as evidence of the skipped rounds and stay open.
