### PR TITLE
fix(campaign): cycle 5 — tour flow dedup and the Solid import relocation

### DIFF
--- a/packages/graph/src/server/runTour.ts
+++ b/packages/graph/src/server/runTour.ts
@@ -152,16 +152,26 @@ export function runTour(
     if (start === undefined) continue;
     const { kept: hops, demotable } = tourHops(graph, trace.hops);
     if (hops.length === 0) {
-      if (demoted === undefined && demotable.length > 0)
+      // Held back under the same rule the published path uses: a candidate that
+      // reached nothing is not a flow, so it is not worth holding either.
+      const demotedReach =
+        demotable.length === 0 ? [] : reachedOf(graph, trace, demotable);
+      if (demoted === undefined && demotedReach.length > 0)
         demoted = {
           start,
           hops: demotable,
-          reached: reachedOf(graph, trace, demotable),
+          reached: demotedReach,
           truncated: trace.truncated === true,
         };
       continue;
     }
     const reached = reachedOf(graph, trace, hops);
+    // A flow that reached nothing is not a flow. It can still have a hop —
+    // `runTrace` records a back-edge to the start without adding a node,
+    // because the start travels separately — so `hops.length` does not answer
+    // this. What a flow is for is the handles a caller goes on with, and this
+    // one has none.
+    if (reached.length === 0) continue;
     const landed = new Set(reached.map((node) => node.id));
     if (told.some((earlier) => overlaps(landed, earlier))) continue;
     told.push(landed);
@@ -730,11 +740,20 @@ function flowSeedIdsOf(seeds: ITtscGraphNode[]): string[] {
  * twice. Overlap is measured against the smaller flow, so a short chain fully
  * contained in a longer one counts as told, which is what a sibling entry
  * (`parse` beside `safeParse`) actually is.
+ *
+ * Neither side matches when it is empty, and the two are empty for different
+ * reasons. An empty CANDIDATE reached nothing, so it is not a flow at all and
+ * the caller settles it before asking here. An empty TOLD would mean the tour
+ * had published a flow that reached nothing; it cannot now, and while it could,
+ * this function reported every later candidate as a synonym of that emptiness.
+ * One directly self-recursive function — a retry loop, a tree walk, a parser's
+ * descent — produced exactly that set, and the tour lost every real flow ranked
+ * after it.
  */
 function overlaps(candidate: Set<string>, told: Set<string>): boolean {
+  if (candidate.size === 0 || told.size === 0) return false;
   const smaller = candidate.size <= told.size ? candidate : told;
   const larger = smaller === candidate ? told : candidate;
-  if (smaller.size === 0) return true;
   let shared = 0;
   for (const id of smaller) if (larger.has(id)) shared++;
   return shared / smaller.size >= FLOW_OVERLAP;

--- a/packages/lint/linthost/rules_solid.go
+++ b/packages/lint/linthost/rules_solid.go
@@ -391,32 +391,37 @@ func solidImportSourceEdits(
   if clause == nil || named == nil || named.Elements == nil || file == nil {
     return nil
   }
-  sole := clause.Name() == nil && len(named.Elements.Nodes) == 1
+  // "Alone" means alone among the NAMED bindings. A default binding beside them
+  // does not make the specifier a sibling of anything, but it does decide how
+  // much has to be cut, which is why the two are tracked apart.
+  alone := len(named.Elements.Nodes) == 1
+  bare := clause.Name() == nil
   // The destination is consulted BEFORE the in-place rewrite, or the rewrite
   // wins on a file that already imports from the correct module and leaves two
   // declarations of it — the duplicate the rule's own description promises to
-  // avoid. `import { render, hydrate } from "solid-js"` converged that way in
-  // two passes.
+  // avoid.
   if destination != nil {
     insert, ok := solidAppendPoint(file, destination)
     if !ok {
       return nil
     }
-    cut, text, ok := solidBindingCut(file, clause, named, specNode, sole)
+    cut, text, ok := solidBindingCut(file, clause, named, specNode)
     if !ok {
       return nil
     }
     // Disjoint: the cut lies in this declaration and the append in another.
     return []TextEdit{cut, {Pos: insert, End: insert, Text: ", " + text}}
   }
-  if sole {
+  if alone && bare {
+    // The declaration IS the import, so retarget it where it stands. The
+    // narrowest edit available, and the only one the rule used to make.
     pos, end, ok := solidQuotedTextRange(file, moduleSpecifier)
     if !ok {
       return nil
     }
     return []TextEdit{{Pos: pos, End: end, Text: correct}}
   }
-  cut, text, ok := solidBindingCut(file, clause, named, specNode, false)
+  cut, text, ok := solidBindingCut(file, clause, named, specNode)
   if !ok {
     return nil
   }
@@ -437,41 +442,63 @@ func solidImportSourceEdits(
 }
 
 // solidBindingCut removes the misrouted specifier from its declaration and
-// reports the text removed.
+// reports the text removed, in whichever of three shapes the declaration is.
 //
-// Two shapes. With siblings it cuts the specifier and one comma. Alone beside a
-// DEFAULT binding (`import Solid, { render } from "solid-js"`) the braces go
-// too, because `import Solid, {} from` is not what anyone meant: the cut runs
-// from the end of the default name through the closing brace, taking the comma
-// that joined them. That shape had no fix at all before, and it is a row in the
-// issue's acceptance table.
+// With named siblings it takes the specifier and one comma. Alone beside a
+// DEFAULT binding it takes the braces too, because `import Solid, {} from` is
+// not what anyone meant. Alone with no default the specifier IS the whole
+// declaration, so the declaration goes — leaving `import {} from "solid-js";`
+// behind would be a statement importing nothing.
 func solidBindingCut(
   file *shimast.SourceFile,
   clause *shimast.ImportClause,
   named *shimast.NamedImports,
   specNode *shimast.Node,
-  sole bool,
 ) (TextEdit, string, bool) {
-  if !sole {
+  if len(named.Elements.Nodes) > 1 {
     return solidSpecifierCut(file, named, specNode)
   }
-  name := clause.Name()
-  if name == nil {
-    // Sole binding with no default: the caller rewrites the module specifier
-    // instead, so there is nothing here to cut.
-    return TextEdit{}, "", false
-  }
   pos, end := tokenRange(file, specNode)
-  if pos < 0 || end < pos {
+  if pos < 0 || end < pos || end > len(file.Text()) {
     return TextEdit{}, "", false
   }
   text := file.Text()[pos:end]
-  from := name.End()
-  to := named.AsNode().End()
-  if from < 0 || to > len(file.Text()) || from >= to {
+  if name := clause.Name(); name != nil {
+    from := name.End()
+    to := named.AsNode().End()
+    if from < 0 || to > len(file.Text()) || from >= to {
+      return TextEdit{}, "", false
+    }
+    return TextEdit{Pos: from, End: to}, text, true
+  }
+  from, to, ok := solidDeclarationRange(file, clause)
+  if !ok {
     return TextEdit{}, "", false
   }
   return TextEdit{Pos: from, End: to}, text, true
+}
+
+// solidDeclarationRange bounds the whole import declaration owning `clause`,
+// including the line break after it so removing the declaration does not leave
+// a blank line where it stood.
+func solidDeclarationRange(file *shimast.SourceFile, clause *shimast.ImportClause) (int, int, bool) {
+  node := clause.AsNode()
+  if node == nil || node.Parent == nil {
+    return 0, 0, false
+  }
+  text := file.Text()
+  pos := shimscanner.SkipTrivia(text, node.Parent.Pos())
+  end := node.Parent.End()
+  if pos < 0 || end < pos || end > len(text) {
+    return 0, 0, false
+  }
+  if end < len(text) && text[end] == '\r' {
+    end++
+  }
+  if end < len(text) && text[end] == '\n' {
+    end++
+  }
+  return pos, end, true
 }
 
 // solidSpecifierCut removes one specifier from a named-import list along with

--- a/packages/lint/linthost/rules_solid.go
+++ b/packages/lint/linthost/rules_solid.go
@@ -316,7 +316,7 @@ func (s *solidState) reportImports(ctx *Context) {
         decl.ModuleSpecifier,
         correct,
         specNode,
-        s.solidNamedImportFrom(correct, clause.IsTypeOnly),
+        s.solidNamedImportFrom(correct, clause.IsTypeOnly()),
       )
       ctx.ReportFix(specNode, message, edits...)
     }
@@ -347,7 +347,7 @@ func (s *solidState) solidNamedImportFrom(source string, typeOnly bool) *shimast
       continue
     }
     clause := decl.ImportClause.AsImportClause()
-    if clause == nil || clause.Name() != nil || clause.IsTypeOnly != typeOnly ||
+    if clause == nil || clause.Name() != nil || clause.IsTypeOnly() != typeOnly ||
       clause.NamedBindings == nil ||
       clause.NamedBindings.Kind != shimast.KindNamedImports {
       continue
@@ -429,7 +429,7 @@ func solidImportSourceEdits(
   // emits a runtime import under `verbatimModuleSyntax` for a symbol that has
   // no runtime existence.
   keyword := "import "
-  if clause.IsTypeOnly {
+  if clause.IsTypeOnly() {
     keyword = "import type "
   }
   line := keyword + "{ " + text + " } from " + quote + correct + quote + ";\n"

--- a/packages/lint/linthost/rules_solid.go
+++ b/packages/lint/linthost/rules_solid.go
@@ -4,6 +4,7 @@ import (
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
   publicrule "github.com/samchon/ttsc/packages/lint/rule"
 )
 
@@ -308,7 +309,15 @@ func (s *solidState) reportImports(ctx *Context) {
         continue
       }
       message := "Import `" + imported + "` from `" + correct + "`."
-      edits := solidImportSourceEdits(ctx.File, clause, named, decl.ModuleSpecifier, correct)
+      edits := solidImportSourceEdits(
+        ctx.File,
+        clause,
+        named,
+        decl.ModuleSpecifier,
+        correct,
+        specNode,
+        s.solidNamedImportFrom(correct),
+      )
       ctx.ReportFix(specNode, message, edits...)
     }
   }
@@ -327,24 +336,181 @@ func (s *solidState) reportImports(ctx *Context) {
 // Only the text between the quotes is replaced, so the file's quote style
 // survives. Returns nil when the specifier is not a plainly quoted literal,
 // which downgrades the caller to a plain diagnostic.
+// solidNamedImportFrom returns the file's named-import list for `source`, or
+// nil when the file has none. It is how the fix finds a declaration to move a
+// misrouted specifier INTO, which is what upstream's `appendImports` does and
+// what the rule's published description means by merging.
+//
+// A declaration carrying a default binding is skipped: appending there is legal
+// but rewrites a line the user did not ask about, and the synthesized-import
+// path below covers the case without touching it.
+func (s *solidState) solidNamedImportFrom(source string) *shimast.NamedImports {
+  for _, node := range s.imports {
+    decl := node.AsImportDeclaration()
+    if decl == nil || decl.ImportClause == nil {
+      continue
+    }
+    if stringLiteralText(decl.ModuleSpecifier) != source {
+      continue
+    }
+    clause := decl.ImportClause.AsImportClause()
+    if clause == nil || clause.Name() != nil || clause.NamedBindings == nil ||
+      clause.NamedBindings.Kind != shimast.KindNamedImports {
+      continue
+    }
+    if named := clause.NamedBindings.AsNamedImports(); named != nil &&
+      named.Elements != nil && len(named.Elements.Nodes) > 0 {
+      return named
+    }
+  }
+  return nil
+}
+
+// solidImportSourceEdits relocates one misrouted specifier to its canonical
+// module.
+//
+// Three shapes, because a specifier can be alone or not and the destination can
+// exist or not:
+//
+//  1. The specifier is the declaration's only binding, so the declaration IS the
+//     import: rewrite its module specifier in place. The narrowest edit, and the
+//     only one the rule used to make.
+//  2. The specifier has siblings and a declaration from the correct source
+//     already exists: cut the specifier out and append it there, which is the
+//     merge the rule's description promises and upstream's `appendImports`
+//     performs.
+//  3. The specifier has siblings and no such declaration exists: cut it out and
+//     synthesize one directly above the declaration it left.
+//
+// Returning nil for every shape but the first is what made the rule report the
+// most ordinary import in a Solid file — `import { createEffect, render } from
+// "solid-js"` — with a message and no fix.
 func solidImportSourceEdits(
   file *shimast.SourceFile,
   clause *shimast.ImportClause,
   named *shimast.NamedImports,
   moduleSpecifier *shimast.Node,
   correct string,
+  specNode *shimast.Node,
+  destination *shimast.NamedImports,
 ) []TextEdit {
-  if clause == nil || clause.Name() != nil || named == nil || named.Elements == nil {
+  if clause == nil || named == nil || named.Elements == nil || file == nil {
     return nil
   }
-  if len(named.Elements.Nodes) != 1 {
-    return nil
+  if clause.Name() == nil && len(named.Elements.Nodes) == 1 {
+    pos, end, ok := solidQuotedTextRange(file, moduleSpecifier)
+    if !ok {
+      return nil
+    }
+    return []TextEdit{{Pos: pos, End: end, Text: correct}}
   }
-  pos, end, ok := solidQuotedTextRange(file, moduleSpecifier)
+  cut, text, ok := solidSpecifierCut(file, named, specNode)
   if !ok {
     return nil
   }
-  return []TextEdit{{Pos: pos, End: end, Text: correct}}
+  if destination != nil {
+    insert, ok := solidAppendPoint(file, destination)
+    if !ok {
+      return nil
+    }
+    // The two edits are disjoint: the cut lies inside this declaration's brace
+    // list and the append lies inside another declaration's.
+    return []TextEdit{cut, {Pos: insert, End: insert, Text: ", " + text}}
+  }
+  declaration, ok := solidDeclarationStart(file, clause)
+  if !ok {
+    return nil
+  }
+  quote := solidQuoteCharacter(file, moduleSpecifier)
+  line := "import { " + text + " } from " + quote + correct + quote + ";\n"
+  return []TextEdit{{Pos: declaration, End: declaration, Text: line}, cut}
+}
+
+// solidSpecifierCut removes one specifier from a named-import list along with
+// the comma that joined it, and reports the text it removed so a caller can put
+// it somewhere else.
+//
+// The comma taken is the one BEFORE the specifier when it has a predecessor,
+// and the one after when it is first. Taking the wrong side leaves either a
+// leading or a doubled comma, both of which are parse errors rather than
+// cosmetic damage.
+func solidSpecifierCut(
+  file *shimast.SourceFile,
+  named *shimast.NamedImports,
+  specNode *shimast.Node,
+) (TextEdit, string, bool) {
+  nodes := named.Elements.Nodes
+  index := -1
+  for i, node := range nodes {
+    if node == specNode {
+      index = i
+      break
+    }
+  }
+  if index < 0 || len(nodes) < 2 {
+    return TextEdit{}, "", false
+  }
+  pos, end := tokenRange(file, specNode)
+  if pos < 0 || end < pos {
+    return TextEdit{}, "", false
+  }
+  text := file.Text()[pos:end]
+  src := file.Text()
+  if index > 0 {
+    previousEnd := nodes[index-1].End()
+    if previousEnd < 0 || previousEnd > pos {
+      return TextEdit{}, "", false
+    }
+    return TextEdit{Pos: previousEnd, End: end}, text, true
+  }
+  nextPos := shimscanner.SkipTrivia(src, nodes[index+1].Pos())
+  if nextPos < end || nextPos > len(src) {
+    return TextEdit{}, "", false
+  }
+  return TextEdit{Pos: pos, End: nextPos}, text, true
+}
+
+// solidAppendPoint returns the offset just past a named-import list's last
+// specifier, where a relocated one is appended.
+func solidAppendPoint(file *shimast.SourceFile, named *shimast.NamedImports) (int, bool) {
+  nodes := named.Elements.Nodes
+  if len(nodes) == 0 {
+    return 0, false
+  }
+  end := nodes[len(nodes)-1].End()
+  if end < 0 || end > len(file.Text()) {
+    return 0, false
+  }
+  return end, true
+}
+
+// solidDeclarationStart returns the offset of the `import` keyword owning
+// `clause`, which is where a synthesized declaration is inserted so it lands on
+// its own line directly above.
+func solidDeclarationStart(file *shimast.SourceFile, clause *shimast.ImportClause) (int, bool) {
+  node := clause.AsNode()
+  if node == nil || node.Parent == nil {
+    return 0, false
+  }
+  pos := shimscanner.SkipTrivia(file.Text(), node.Parent.Pos())
+  if pos < 0 || pos > len(file.Text()) {
+    return 0, false
+  }
+  return pos, true
+}
+
+// solidQuoteCharacter returns the quote the file already used for this module
+// specifier, so a synthesized import matches the surrounding style instead of
+// fighting `format/quotes`.
+func solidQuoteCharacter(file *shimast.SourceFile, moduleSpecifier *shimast.Node) string {
+  pos, end := tokenRange(file, moduleSpecifier)
+  if pos < 0 || end-pos < 2 {
+    return "\""
+  }
+  if quote := file.Text()[pos]; quote == '\'' || quote == '"' {
+    return string(quote)
+  }
+  return "\""
 }
 
 // solidQuotedTextRange returns the byte range of the text inside a string

--- a/packages/lint/linthost/rules_solid.go
+++ b/packages/lint/linthost/rules_solid.go
@@ -316,35 +316,28 @@ func (s *solidState) reportImports(ctx *Context) {
         decl.ModuleSpecifier,
         correct,
         specNode,
-        s.solidNamedImportFrom(correct),
+        s.solidNamedImportFrom(correct, clause.IsTypeOnly),
       )
       ctx.ReportFix(specNode, message, edits...)
     }
   }
 }
 
-// solidImportSourceEdits rewrites the declaration's module specifier to
-// `correct`, but only when this specifier is the declaration's sole binding.
-//
-// A declaration that also carries a default binding or further named
-// specifiers cannot be repaired by rewriting the specifier: the other symbols
-// belong to the module as written and would be dragged along with it. Moving
-// one specifier out of such a declaration means splitting it, which is a
-// rewrite of the import block rather than of one token, so those findings stay
-// diagnostic-only and the message names the module instead.
-//
-// Only the text between the quotes is replaced, so the file's quote style
-// survives. Returns nil when the specifier is not a plainly quoted literal,
-// which downgrades the caller to a plain diagnostic.
 // solidNamedImportFrom returns the file's named-import list for `source`, or
 // nil when the file has none. It is how the fix finds a declaration to move a
 // misrouted specifier INTO, which is what upstream's `appendImports` does and
 // what the rule's published description means by merging.
 //
 // A declaration carrying a default binding is skipped: appending there is legal
-// but rewrites a line the user did not ask about, and the synthesized-import
-// path below covers the case without touching it.
-func (s *solidState) solidNamedImportFrom(source string) *shimast.NamedImports {
+// but rewrites a line the user did not ask about, and the synthesized path
+// covers the case without touching it.
+//
+// `typeOnly` must match the declaration the specifier is leaving. A value
+// import appended into `import type { … }` becomes unusable as a value
+// (TS1361), and a type import appended into a value declaration survives into
+// the emitted JavaScript under `verbatimModuleSyntax`. Neither is a formatting
+// difference, so the two kinds never share a destination.
+func (s *solidState) solidNamedImportFrom(source string, typeOnly bool) *shimast.NamedImports {
   for _, node := range s.imports {
     decl := node.AsImportDeclaration()
     if decl == nil || decl.ImportClause == nil {
@@ -354,7 +347,8 @@ func (s *solidState) solidNamedImportFrom(source string) *shimast.NamedImports {
       continue
     }
     clause := decl.ImportClause.AsImportClause()
-    if clause == nil || clause.Name() != nil || clause.NamedBindings == nil ||
+    if clause == nil || clause.Name() != nil || clause.IsTypeOnly != typeOnly ||
+      clause.NamedBindings == nil ||
       clause.NamedBindings.Kind != shimast.KindNamedImports {
       continue
     }
@@ -397,33 +391,87 @@ func solidImportSourceEdits(
   if clause == nil || named == nil || named.Elements == nil || file == nil {
     return nil
   }
-  if clause.Name() == nil && len(named.Elements.Nodes) == 1 {
+  sole := clause.Name() == nil && len(named.Elements.Nodes) == 1
+  // The destination is consulted BEFORE the in-place rewrite, or the rewrite
+  // wins on a file that already imports from the correct module and leaves two
+  // declarations of it — the duplicate the rule's own description promises to
+  // avoid. `import { render, hydrate } from "solid-js"` converged that way in
+  // two passes.
+  if destination != nil {
+    insert, ok := solidAppendPoint(file, destination)
+    if !ok {
+      return nil
+    }
+    cut, text, ok := solidBindingCut(file, clause, named, specNode, sole)
+    if !ok {
+      return nil
+    }
+    // Disjoint: the cut lies in this declaration and the append in another.
+    return []TextEdit{cut, {Pos: insert, End: insert, Text: ", " + text}}
+  }
+  if sole {
     pos, end, ok := solidQuotedTextRange(file, moduleSpecifier)
     if !ok {
       return nil
     }
     return []TextEdit{{Pos: pos, End: end, Text: correct}}
   }
-  cut, text, ok := solidSpecifierCut(file, named, specNode)
+  cut, text, ok := solidBindingCut(file, clause, named, specNode, false)
   if !ok {
     return nil
-  }
-  if destination != nil {
-    insert, ok := solidAppendPoint(file, destination)
-    if !ok {
-      return nil
-    }
-    // The two edits are disjoint: the cut lies inside this declaration's brace
-    // list and the append lies inside another declaration's.
-    return []TextEdit{cut, {Pos: insert, End: insert, Text: ", " + text}}
   }
   declaration, ok := solidDeclarationStart(file, clause)
   if !ok {
     return nil
   }
   quote := solidQuoteCharacter(file, moduleSpecifier)
-  line := "import { " + text + " } from " + quote + correct + quote + ";\n"
+  // A type-only declaration synthesizes a type-only one. Dropping the keyword
+  // emits a runtime import under `verbatimModuleSyntax` for a symbol that has
+  // no runtime existence.
+  keyword := "import "
+  if clause.IsTypeOnly {
+    keyword = "import type "
+  }
+  line := keyword + "{ " + text + " } from " + quote + correct + quote + ";\n"
   return []TextEdit{{Pos: declaration, End: declaration, Text: line}, cut}
+}
+
+// solidBindingCut removes the misrouted specifier from its declaration and
+// reports the text removed.
+//
+// Two shapes. With siblings it cuts the specifier and one comma. Alone beside a
+// DEFAULT binding (`import Solid, { render } from "solid-js"`) the braces go
+// too, because `import Solid, {} from` is not what anyone meant: the cut runs
+// from the end of the default name through the closing brace, taking the comma
+// that joined them. That shape had no fix at all before, and it is a row in the
+// issue's acceptance table.
+func solidBindingCut(
+  file *shimast.SourceFile,
+  clause *shimast.ImportClause,
+  named *shimast.NamedImports,
+  specNode *shimast.Node,
+  sole bool,
+) (TextEdit, string, bool) {
+  if !sole {
+    return solidSpecifierCut(file, named, specNode)
+  }
+  name := clause.Name()
+  if name == nil {
+    // Sole binding with no default: the caller rewrites the module specifier
+    // instead, so there is nothing here to cut.
+    return TextEdit{}, "", false
+  }
+  pos, end := tokenRange(file, specNode)
+  if pos < 0 || end < pos {
+    return TextEdit{}, "", false
+  }
+  text := file.Text()[pos:end]
+  from := name.End()
+  to := named.AsNode().End()
+  if from < 0 || to > len(file.Text()) || from >= to {
+    return TextEdit{}, "", false
+  }
+  return TextEdit{Pos: from, End: to}, text, true
 }
 
 // solidSpecifierCut removes one specifier from a named-import list along with

--- a/packages/lint/src/structures/rules/ITtscLintSolidRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintSolidRules.ts
@@ -35,10 +35,10 @@ export interface ITtscLintSolidRules {
    * it belongs, joining an existing import from that entry when the file
    * already has one. The diagnostic names the symbol and its entry point.
    *
-   * Autofixable only when the misplaced specifier is its declaration's sole
-   * binding: rewriting the module specifier moves every binding in that
-   * declaration, so a declaration with a second specifier or a default binding
-   * keeps its diagnostic instead.
+   * Autofixable. A specifier that stands alone has its declaration's module
+   * specifier rewritten; one with siblings, or one beside a default binding, is
+   * cut out and relocated. A type-only declaration relocates into a type-only
+   * one, never into a value import.
    *
    * @reference https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/imports.md
    */

--- a/packages/lint/src/structures/rules/ITtscLintSolidRules.ts
+++ b/packages/lint/src/structures/rules/ITtscLintSolidRules.ts
@@ -31,8 +31,9 @@ export interface ITtscLintSolidRules {
 
   /**
    * Route each Solid export to the correct entry point (`solid-js`,
-   * `solid-js/web`, or `solid-js/store`) and merge duplicate imports from the
-   * same entry. The diagnostic names the symbol and its entry point.
+   * `solid-js/web`, or `solid-js/store`) and relocate a misrouted one to where
+   * it belongs, joining an existing import from that entry when the file
+   * already has one. The diagnostic names the symbol and its entry point.
    *
    * Autofixable only when the misplaced specifier is its declaration's sole
    * binding: rewriting the module specifier moves every binding in that

--- a/packages/lint/test/fix/fix_solid_imports_rewrites_sole_specifier_module_test.go
+++ b/packages/lint/test/fix/fix_solid_imports_rewrites_sole_specifier_module_test.go
@@ -8,11 +8,14 @@ import "testing"
 //
 // The rule looked the correct entry point up in `solidPreferredSource` and
 // then reported a message that did not say which symbol or which module it
-// meant. Naming both is the point; the autofix is deliberately narrower than
-// the message, because rewriting the module specifier moves every binding in
-// the declaration. Only a declaration whose sole binding is the misplaced
-// specifier can be repaired that way — anything else needs the import block
-// split, which is not a one-token edit.
+// meant. Naming both is the point.
+//
+// This case owns the narrowest repair: a declaration whose sole binding is the
+// misplaced specifier is fixed by rewriting the module specifier, moving no
+// other text. The shapes that need the specifier cut out and relocated are
+// pinned by `solid_imports_relocates_a_misrouted_specifier_test.go`; they used
+// to be negative twins here, asserting the absence of a fix that the rule now
+// has.
 //
 //  1. Fix `import { render } from "solid-js"`, whose sole binding belongs to
 //     `solid-js/web`, and assert the module is rewritten and the message names
@@ -51,17 +54,6 @@ func TestFixSolidImportsRewritesSoleSpecifierModule(t *testing.T) {
     "solid/imports",
     "import { render as mount } from \"solid-js\";\nmount();\n",
     "import { render as mount } from \"solid-js/web\";\nmount();\n",
-  )
-
-  assertNoFixSnapshot(
-    t,
-    "solid/imports",
-    "import { createSignal, render } from \"solid-js\";\nrender(createSignal);\n",
-  )
-  assertNoFixSnapshot(
-    t,
-    "solid/imports",
-    "import Solid, { render } from \"solid-js\";\nrender(Solid);\n",
   )
 
   assertRuleSkipsSource(

--- a/packages/lint/test/rules/solid/solid_imports_leaves_a_type_only_destination_alone_test.go
+++ b/packages/lint/test/rules/solid/solid_imports_leaves_a_type_only_destination_alone_test.go
@@ -1,0 +1,37 @@
+package linthost
+
+import "testing"
+
+// TestSolidImportsLeavesATypeOnlyDestinationAlone is the negative twin for the
+// relocation's type-only rule.
+//
+// A value specifier must not join `import type { … }`, and a type specifier
+// must not join a value declaration. Both are legal edits that produce code the
+// compiler rejects or the emitter mishandles: the first makes every use of the
+// symbol a TS1361 error, and the second survives into the emitted JavaScript
+// under `verbatimModuleSyntax` for a symbol with no runtime existence.
+//
+// The fix is expected to synthesize a matching declaration instead of appending
+// into the mismatched one, which is what these two sources assert.
+func TestSolidImportsLeavesATypeOnlyDestinationAlone(t *testing.T) {
+  for _, tc := range []struct {
+    name   string
+    source string
+    fixed  string
+  }{
+    {
+      "a value specifier does not join a type-only destination",
+      "import type { MountableElement } from \"solid-js/web\";\nimport { createEffect, render } from \"solid-js\";\nJSON.stringify({ createEffect, render } as unknown as MountableElement);\n",
+      "import type { MountableElement } from \"solid-js/web\";\nimport { render } from \"solid-js/web\";\nimport { createEffect } from \"solid-js\";\nJSON.stringify({ createEffect, render } as unknown as MountableElement);\n",
+    },
+    {
+      "a type specifier does not join a value destination",
+      "import { hydrate } from \"solid-js/web\";\nimport type { createEffect, render } from \"solid-js\";\nJSON.stringify({ hydrate } as { a: typeof createEffect; b: typeof render });\n",
+      "import { hydrate } from \"solid-js/web\";\nimport type { render } from \"solid-js/web\";\nimport type { createEffect } from \"solid-js\";\nJSON.stringify({ hydrate } as { a: typeof createEffect; b: typeof render });\n",
+    },
+  } {
+    t.Run(tc.name, func(t *testing.T) {
+      assertFixSnapshot(t, "solid/imports", tc.source, tc.fixed)
+    })
+  }
+}

--- a/packages/lint/test/rules/solid/solid_imports_relocates_a_misrouted_specifier_test.go
+++ b/packages/lint/test/rules/solid/solid_imports_relocates_a_misrouted_specifier_test.go
@@ -1,0 +1,61 @@
+package linthost
+
+import "testing"
+
+// TestSolidImportsRelocatesAMisroutedSpecifier verifies `solid/imports` fixes
+// the ordinary shape, not only the one where the misrouted name stands alone.
+//
+// The fix used to return no edits whenever the specifier had a sibling or the
+// declaration carried a default binding, so `import { createEffect, render }
+// from "solid-js"` — the most common way a Solid file goes wrong — produced a
+// message and nothing else. `ReportFix` with no edits is a diagnostic, and the
+// corpus asserted only that the diagnostic appeared, so the restriction was
+// invisible.
+//
+// Three shapes, because a specifier is alone or not and the destination exists
+// or not:
+//
+//  1. Alone: rewrite the module specifier in place, the narrowest edit.
+//  2. With siblings and no destination: cut it out and synthesize the import.
+//  3. With siblings and a destination: cut it out and append it there, which is
+//     the merge the rule's own description promises.
+func TestSolidImportsRelocatesAMisroutedSpecifier(t *testing.T) {
+  t.Run("sole binding rewrites the source", func(t *testing.T) {
+    assertFixSnapshot(
+      t,
+      "solid/imports",
+      "import { render } from \"solid-js\";\nJSON.stringify(render);\n",
+      "import { render } from \"solid-js/web\";\nJSON.stringify(render);\n",
+    )
+  })
+
+  t.Run("a sibling no longer blocks the fix", func(t *testing.T) {
+    assertFixSnapshot(
+      t,
+      "solid/imports",
+      "import { createEffect, render } from \"solid-js\";\nJSON.stringify({ createEffect, render });\n",
+      "import { render } from \"solid-js/web\";\nimport { createEffect } from \"solid-js\";\nJSON.stringify({ createEffect, render });\n",
+    )
+  })
+
+  t.Run("an existing destination receives the specifier", func(t *testing.T) {
+    assertFixSnapshot(
+      t,
+      "solid/imports",
+      "import { createEffect, render } from \"solid-js\";\nimport { hydrate } from \"solid-js/web\";\nJSON.stringify({ createEffect, render, hydrate });\n",
+      "import { createEffect } from \"solid-js\";\nimport { hydrate, render } from \"solid-js/web\";\nJSON.stringify({ createEffect, render, hydrate });\n",
+    )
+  })
+}
+
+// TestSolidImportsLeavesCorrectlyRoutedImportsAlone is the negative twin: a
+// specifier already importing from its canonical module produces no finding, so
+// the relocation above is driven by the routing table rather than by the
+// declaration's shape.
+func TestSolidImportsLeavesCorrectlyRoutedImportsAlone(t *testing.T) {
+  assertRuleSkipsSource(
+    t,
+    "solid/imports",
+    "import { createEffect, createSignal } from \"solid-js\";\nimport { render } from \"solid-js/web\";\nimport { createStore } from \"solid-js/store\";\nJSON.stringify({ createEffect, createSignal, render, createStore });\n",
+  )
+}

--- a/packages/lint/test/rules/solid/solid_imports_relocates_a_misrouted_specifier_test.go
+++ b/packages/lint/test/rules/solid/solid_imports_relocates_a_misrouted_specifier_test.go
@@ -3,7 +3,8 @@ package linthost
 import "testing"
 
 // TestSolidImportsRelocatesAMisroutedSpecifier verifies `solid/imports` fixes
-// the ordinary shape, not only the one where the misrouted name stands alone.
+// every shape a misrouted specifier can be in, not only the one where it stands
+// alone.
 //
 // The fix used to return no edits whenever the specifier had a sibling or the
 // declaration carried a default binding, so `import { createEffect, render }
@@ -12,50 +13,58 @@ import "testing"
 // corpus asserted only that the diagnostic appeared, so the restriction was
 // invisible.
 //
-// Three shapes, because a specifier is alone or not and the destination exists
-// or not:
+// The destination is consulted before the in-place rewrite. Checking the other
+// order lets the rewrite win on a file that already imports from the correct
+// module, leaving two declarations of it — the duplicate the rule's own
+// description promises to avoid.
 //
-//  1. Alone: rewrite the module specifier in place, the narrowest edit.
-//  2. With siblings and no destination: cut it out and synthesize the import.
-//  3. With siblings and a destination: cut it out and append it there, which is
-//     the merge the rule's own description promises.
+// A type-only declaration relocates into a type-only one. Appending a value
+// import into `import type { … }` makes every use of it a TS1361 error, and
+// dropping `type` from a synthesized declaration emits a runtime import for a
+// symbol with no runtime existence.
 func TestSolidImportsRelocatesAMisroutedSpecifier(t *testing.T) {
-  t.Run("sole binding rewrites the source", func(t *testing.T) {
-    assertFixSnapshot(
-      t,
-      "solid/imports",
+  for _, tc := range []struct {
+    name   string
+    source string
+    fixed  string
+  }{
+    {
+      "sole binding rewrites the source in place",
       "import { render } from \"solid-js\";\nJSON.stringify(render);\n",
       "import { render } from \"solid-js/web\";\nJSON.stringify(render);\n",
-    )
-  })
-
-  t.Run("a sibling no longer blocks the fix", func(t *testing.T) {
-    assertFixSnapshot(
-      t,
-      "solid/imports",
+    },
+    {
+      "a sibling no longer blocks the fix",
       "import { createEffect, render } from \"solid-js\";\nJSON.stringify({ createEffect, render });\n",
       "import { render } from \"solid-js/web\";\nimport { createEffect } from \"solid-js\";\nJSON.stringify({ createEffect, render });\n",
-    )
-  })
-
-  t.Run("an existing destination receives the specifier", func(t *testing.T) {
-    assertFixSnapshot(
-      t,
-      "solid/imports",
+    },
+    {
+      "an existing destination receives the specifier",
       "import { createEffect, render } from \"solid-js\";\nimport { hydrate } from \"solid-js/web\";\nJSON.stringify({ createEffect, render, hydrate });\n",
       "import { createEffect } from \"solid-js\";\nimport { hydrate, render } from \"solid-js/web\";\nJSON.stringify({ createEffect, render, hydrate });\n",
-    )
-  })
-}
-
-// TestSolidImportsLeavesCorrectlyRoutedImportsAlone is the negative twin: a
-// specifier already importing from its canonical module produces no finding, so
-// the relocation above is driven by the routing table rather than by the
-// declaration's shape.
-func TestSolidImportsLeavesCorrectlyRoutedImportsAlone(t *testing.T) {
-  assertRuleSkipsSource(
-    t,
-    "solid/imports",
-    "import { createEffect, createSignal } from \"solid-js\";\nimport { render } from \"solid-js/web\";\nimport { createStore } from \"solid-js/store\";\nJSON.stringify({ createEffect, createSignal, render, createStore });\n",
-  )
+    },
+    {
+      // Preferring the destination over the in-place rewrite is what keeps this
+      // from becoming a second `solid-js/web` declaration.
+      "a sole binding joins an existing destination rather than duplicating it",
+      "import { render } from \"solid-js\";\nimport { hydrate } from \"solid-js/web\";\nJSON.stringify({ render, hydrate });\n",
+      "import { hydrate, render } from \"solid-js/web\";\nJSON.stringify({ render, hydrate });\n",
+    },
+    {
+      // The braces go with the specifier: `import Solid, {} from` is not what
+      // anyone meant. This shape had no fix at all before.
+      "a default binding no longer blocks the fix",
+      "import Solid, { render } from \"solid-js\";\nJSON.stringify({ Solid, render });\n",
+      "import { render } from \"solid-js/web\";\nimport Solid from \"solid-js\";\nJSON.stringify({ Solid, render });\n",
+    },
+    {
+      "a type-only declaration synthesizes a type-only one",
+      "import type { createEffect, render } from \"solid-js\";\nJSON.stringify({} as { a: typeof createEffect; b: typeof render });\n",
+      "import type { render } from \"solid-js/web\";\nimport type { createEffect } from \"solid-js\";\nJSON.stringify({} as { a: typeof createEffect; b: typeof render });\n",
+    },
+  } {
+    t.Run(tc.name, func(t *testing.T) {
+      assertFixSnapshot(t, "solid/imports", tc.source, tc.fixed)
+    })
+  }
 }

--- a/packages/lint/test/rules/solid/solid_imports_relocates_a_misrouted_specifier_test.go
+++ b/packages/lint/test/rules/solid/solid_imports_relocates_a_misrouted_specifier_test.go
@@ -45,7 +45,8 @@ func TestSolidImportsRelocatesAMisroutedSpecifier(t *testing.T) {
     },
     {
       // Preferring the destination over the in-place rewrite is what keeps this
-      // from becoming a second `solid-js/web` declaration.
+      // from becoming a second `solid-js/web` declaration. The emptied
+      // declaration goes with it, line break included.
       "a sole binding joins an existing destination rather than duplicating it",
       "import { render } from \"solid-js\";\nimport { hydrate } from \"solid-js/web\";\nJSON.stringify({ render, hydrate });\n",
       "import { hydrate, render } from \"solid-js/web\";\nJSON.stringify({ render, hydrate });\n",

--- a/tests/test-graph/src/features/test_ttscgraph_tour_keeps_flows_after_a_self_recursive_seed.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_tour_keeps_flows_after_a_self_recursive_seed.ts
@@ -85,8 +85,8 @@ const tourOfProject = async (
 };
 
 const SELF_RECURSIVE = [
-  "export function retry(): void {",
-  "  retry();",
+  "export function attempt(): void {",
+  "  attempt();",
   "}",
   "",
 ].join("\n");
@@ -115,16 +115,22 @@ const REAL_FLOW = [
  * flow behind it. Recursion is ordinary — a retry loop, a tree walk, a parser's
  * descent — so this was not an exotic input.
  *
+ * The recursive function is named `attempt` on purpose. Dump nodes are sorted
+ * by id, so a name that sorts AFTER `handle` puts the empty candidate last,
+ * where it poisons nothing and the test passes against the unfixed code.
+ * `attempt` sorts first, which is the ordering the defect needs.
+ *
  * 1. Tour a project holding a self-recursive function and a real two-hop chain.
  * 2. Assert the real chain is reported.
  * 3. Assert no flow was published with an empty `reached`.
- * 4. Tour the same project without the self-recursive function and assert the real
- *    chain is reported identically, so its presence changes nothing.
+ * 4. Tour the same project without the self-recursive function and assert it
+ *    reports the same set of non-empty flows, so the recursion changes nothing
+ *    about what the tour says.
  */
 export const test_ttscgraph_tour_keeps_flows_after_a_self_recursive_seed =
   async () => {
     const withRecursion = await tourOfProject(`${SELF_RECURSIVE}${REAL_FLOW}`, [
-      "retry",
+      "attempt",
       "handle",
     ]);
 
@@ -144,12 +150,20 @@ export const test_ttscgraph_tour_keeps_flows_after_a_self_recursive_seed =
       );
 
     // The negative twin, and the reason the assertions above prove anything:
-    // the same project without the recursion must give the same real flow, so
-    // the recursion's presence is what is being measured rather than the
-    // fixture happening to rank `handle` first.
+    // the same project without the recursion must report the same flows, so the
+    // recursion's presence is what is measured rather than the fixture
+    // happening to rank the chain first.
     const withoutRecursion = await tourOfProject(REAL_FLOW, ["handle"]);
-    assert.ok(
-      reaches(withoutRecursion, "work"),
-      `the control project must report the same chain: ${JSON.stringify(withoutRecursion.primaryFlow)}`,
+    const shape = (tour: TourResult): string =>
+      JSON.stringify(
+        tour.primaryFlow.map((flow) => [
+          flow.start.name,
+          flow.reached.map((node) => node.name).sort(),
+        ]),
+      );
+    assert.equal(
+      shape(withRecursion),
+      shape(withoutRecursion),
+      "the self-edge must not change which flows the tour reports",
     );
   };

--- a/tests/test-graph/src/features/test_ttscgraph_tour_keeps_flows_after_a_self_recursive_seed.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_tour_keeps_flows_after_a_self_recursive_seed.ts
@@ -1,0 +1,155 @@
+import { TestProject } from "@ttsc/testing";
+
+import { TtsgraphClient, assert } from "../internal/ttsgraph";
+
+interface ToolResult {
+  content: { type: string; text: string }[];
+  structuredContent?: unknown;
+}
+
+interface TourResult {
+  type: "tour";
+  primaryFlow: {
+    start: { id: string; name: string };
+    steps: string[];
+    reached: { id: string; name: string }[];
+  }[];
+}
+
+const graphArguments = (props: {
+  thinking: string;
+  request: Record<string, unknown>;
+}) => ({
+  question: props.thinking,
+  draft: {
+    reason: "The smallest useful sacred graph step.",
+    type: props.request.type,
+  },
+  review:
+    "Confirmed: keep this final request; do not replace graph facts with file reads.",
+  request: props.request,
+});
+
+const tourOf = (result: ToolResult): TourResult => {
+  const value = (result.structuredContent ?? {}) as { result?: TourResult };
+  if (value.result?.type !== "tour")
+    throw new Error(`Unexpected graph result: ${JSON.stringify(value)}`);
+  return value.result;
+};
+
+const TSCONFIG = JSON.stringify(
+  {
+    compilerOptions: {
+      target: "ES2022",
+      module: "commonjs",
+      strict: true,
+      rootDir: "src",
+      outDir: "dist",
+    },
+    include: ["src"],
+  },
+  null,
+  2,
+);
+
+/** Ask the resident server for a tour of `source`, seeded on `names`. */
+const tourOfProject = async (
+  source: string,
+  names: string[],
+): Promise<TourResult> => {
+  const root = TestProject.createProject({
+    "tsconfig.json": TSCONFIG,
+    "src/app.ts": source,
+  });
+  const client = TtsgraphClient.start(root);
+  try {
+    await client.request("initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "test-graph", version: "0.0.0" },
+    });
+    client.notify("notifications/initialized", {});
+    return tourOf(
+      (await client.request("tools/call", {
+        name: "inspect_typescript_graph",
+        arguments: graphArguments({
+          thinking: `I'm new here; show me what ${names.join(" and ")} do.`,
+          request: { type: "tour", reinterpretations: names },
+        }),
+      })) as ToolResult,
+    );
+  } finally {
+    client.endStdin();
+    await client.waitForExit();
+  }
+};
+
+const SELF_RECURSIVE = [
+  "export function retry(): void {",
+  "  retry();",
+  "}",
+  "",
+].join("\n");
+
+const REAL_FLOW = [
+  "export function work(): void {}",
+  "export function handle(): void {",
+  "  work();",
+  "}",
+  "",
+].join("\n");
+
+/**
+ * Verifies one self-recursive function cannot silence the flows ranked after
+ * it.
+ *
+ * `runTour` deduplicates flows by comparing where each candidate landed against
+ * what it has already told, and `overlaps` reported a match whenever the
+ * smaller of the two sets was empty. `told` is a candidate for "smaller", so
+ * one empty set entering it made every later candidate a synonym of nothing.
+ *
+ * A directly self-recursive function produces exactly that set: `runTrace`
+ * records a back-edge to the start as a hop without adding a node, because the
+ * start travels separately, so the flow had a hop and reached nobody. The tour
+ * then published one flow that said it went nowhere and discarded every real
+ * flow behind it. Recursion is ordinary — a retry loop, a tree walk, a parser's
+ * descent — so this was not an exotic input.
+ *
+ * 1. Tour a project holding a self-recursive function and a real two-hop chain.
+ * 2. Assert the real chain is reported.
+ * 3. Assert no flow was published with an empty `reached`.
+ * 4. Tour the same project without the self-recursive function and assert the real
+ *    chain is reported identically, so its presence changes nothing.
+ */
+export const test_ttscgraph_tour_keeps_flows_after_a_self_recursive_seed =
+  async () => {
+    const withRecursion = await tourOfProject(`${SELF_RECURSIVE}${REAL_FLOW}`, [
+      "retry",
+      "handle",
+    ]);
+
+    const reaches = (tour: TourResult, name: string): boolean =>
+      tour.primaryFlow.some((flow) =>
+        flow.reached.some((node) => node.name === name),
+      );
+
+    assert.ok(
+      reaches(withRecursion, "work"),
+      `the real chain must survive a self-recursive seed: ${JSON.stringify(withRecursion.primaryFlow)}`,
+    );
+    for (const flow of withRecursion.primaryFlow)
+      assert.ok(
+        flow.reached.length > 0,
+        `a flow that reached nothing was published: ${JSON.stringify(flow)}`,
+      );
+
+    // The negative twin, and the reason the assertions above prove anything:
+    // the same project without the recursion must give the same real flow, so
+    // the recursion's presence is what is being measured rather than the
+    // fixture happening to rank `handle` first.
+    const withoutRecursion = await tourOfProject(REAL_FLOW, ["handle"]);
+    assert.ok(
+      reaches(withoutRecursion, "work"),
+      `the control project must report the same chain: ${JSON.stringify(withoutRecursion.primaryFlow)}`,
+    );
+  };

--- a/website/src/content/docs/lint/rules/index.mdx
+++ b/website/src/content/docs/lint/rules/index.mdx
@@ -123,7 +123,7 @@ Formatter behavior is configured separately through the top-level `format` block
 - `typescript/no-unnecessary-type-constraint`, `typescript/prefer-namespace-keyword`, `no-useless-escape`
 - `typescript/no-import-type-side-effects` (hoists inline `type` modifiers)
 - `regexp/sort-flags`, `regexp/no-useless-flag`, `regexp/prefer-d`, `regexp/prefer-w`, and the quantifier shorthands `regexp/prefer-plus-quantifier`, `regexp/prefer-star-quantifier`, `regexp/prefer-question-quantifier`, `regexp/no-useless-two-nums-quantifier`, `regexp/no-useless-quantifier`
-- `security/detect-pseudoRandomBytes` (only for a proven Node `crypto` import or require), `solid/no-react-specific-props` (the `className` and `htmlFor` renames), `solid/imports` (only when the misplaced specifier is its declaration's sole binding)
+- `security/detect-pseudoRandomBytes` (only for a proven Node `crypto` import or require), `solid/no-react-specific-props` (the `className` and `htmlFor` renames), `solid/imports`
 - Every format rule
 
 Suggestion-only rewrites, including removing an ordinary non-thenable `await`, replacing `@ts-ignore`, adding a Unicode flag for `regexp/require-unicode-regexp` / `regexp/require-unicode-sets-regexp`, choosing a `new Buffer` successor for `security/detect-new-buffer`, renaming an unproven name-only `crypto.pseudoRandomBytes` match, and choosing a framework package for `storybook/no-renderer-packages`, are available through `quickfix.ttsc`; `ttsc fix` and source fix-all do not apply them.

--- a/website/src/content/docs/lint/rules/solid.mdx
+++ b/website/src/content/docs/lint/rules/solid.mdx
@@ -82,7 +82,7 @@ Route each Solid export to the correct entry point (`solid-js`, `solid-js/web`, 
 
 Autofixable. A specifier that stands alone has its declaration's module specifier rewritten; one with siblings is cut out and either appended to an existing import from the correct entry or given a synthesized one.
 
-The diagnostic names the symbol and the entry point it belongs to (``Import `render` from `solid-js/web`.``). Autofixable only when the misplaced specifier is the declaration's sole binding, because rewriting the module specifier moves every binding in that declaration: `import { render } from "solid-js"` is repaired in place, while `import { createSignal, render } from "solid-js"` keeps its diagnostic. `createSignal` belongs to the module as written, and separating the two means splitting the import block rather than editing one token.
+The diagnostic names the symbol and the entry point it belongs to (``Import `render` from `solid-js/web`.``). The fix relocates the specifier rather than dragging its neighbours along: `import { render } from "solid-js"` has its module specifier rewritten in place, while `import { createSignal, render } from "solid-js"` keeps `createSignal` where it belongs and moves `render` out — into an existing import from the correct entry when the file has one, otherwise into a synthesized declaration above. A type-only declaration stays type-only on both ends.
 
 Example:
 

--- a/website/src/content/docs/lint/rules/solid.mdx
+++ b/website/src/content/docs/lint/rules/solid.mdx
@@ -16,7 +16,7 @@ Examples come from the checked [lint corpus](https://github.com/samchon/ttsc/tre
 
 - [`solid/components-return-once`](#rule-solid-components-return-once): Reject early and conditional `return` from a Solid component.
 - [`solid/event-handlers`](#rule-solid-event-handlers): Require DOM event handler props to use canonical Solid casing.
-- [`solid/imports`](#rule-solid-imports): Route each Solid export to the correct entry point and merge duplicate imports from the same entry.
+- [`solid/imports`](#rule-solid-imports): Route each Solid export to the correct entry point, relocating a misrouted one and joining an existing import from that entry.
 - [`solid/jsx-no-duplicate-props`](#rule-solid-jsx-no-duplicate-props): Reject duplicate JSX props on the same Solid element.
 - [`solid/jsx-no-script-url`](#rule-solid-jsx-no-script-url): Reject `javascript:` URLs in Solid JSX attributes (`href`, `src`, ...).
 - [`solid/jsx-no-undef`](#rule-solid-jsx-no-undef): Reject Solid JSX component names that are not declared or imported in scope.
@@ -78,7 +78,9 @@ const tree = <button onclick="save">save</button>;
 
 ### `solid/imports`
 
-Route each Solid export to the correct entry point (`solid-js`, `solid-js/web`, or `solid-js/store`) and merge duplicate imports from the same entry.
+Route each Solid export to the correct entry point (`solid-js`, `solid-js/web`, or `solid-js/store`).
+
+Autofixable. A specifier that stands alone has its declaration's module specifier rewritten; one with siblings is cut out and either appended to an existing import from the correct entry or given a synthesized one.
 
 The diagnostic names the symbol and the entry point it belongs to (``Import `render` from `solid-js/web`.``). Autofixable only when the misplaced specifier is the declaration's sole binding, because rewriting the module specifier moves every binding in that declaration: `import { render } from "solid-js"` is repaired in place, while `import { createSignal, render } from "solid-js"` keeps its diagnostic. `createSignal` belongs to the module as written, and separating the two means splitting the import block rather than editing one token.
 


### PR DESCRIPTION
## Intent

Cycle 5 of the 2026-07-21 campaign.

## What this closes

Closes #926.
Closes #932.

`runTour` deduplicates flows by comparing where a candidate landed against what it has already told, and `overlaps` returned true whenever the smaller of the two sets was empty. `told` is a candidate for "smaller", so one empty set entering it made every later candidate a synonym of nothing.

A directly self-recursive function produces exactly that set: `runTrace` records a back-edge to the start as a hop without adding a node, because the start travels separately. So the flow had a hop and reached nobody, the tour published it, and every real flow ranked behind it was discarded. A retry loop, a tree walk, a parser's descent — the input is ordinary.

Two changes, because either alone leaves the other half wrong: a candidate that reached nothing is neither published nor recorded as told, and `overlaps` no longer treats an empty set as matching everything. The empty case belongs to the candidate side, and the caller settles it.

### #932 — solid/imports declined the fix it advertised

`solidImportSourceEdits` returned nil unless the misrouted specifier was its declaration's sole binding, so `import { createEffect, render } from "solid-js"` got a message and no edits. The corpus asserted only that the diagnostic appeared, which is why the restriction shipped unnoticed.

The fix now covers all three shapes: rewrite the module specifier when the specifier stands alone, append it to an existing declaration from the correct source, or synthesize one. The published sentence claimed the rule "merges duplicate imports from the same entry" — it does not, and neither does upstream, whose *fix* relocates via `appendImports`. All three published locations now describe the relocation.

Carried in the campaign knowledge base as candidate R1-7 since cycle 1, deferred there pending the upstream question this issue answers.

## A false issue, and what it cost

#930 was filed during this cycle's discovery round and is **closed as invalid**. It claimed `camelcase`, `complexity`, and `curly` were missing from the typed config surface. They are not, and the gate I claimed was absent — `typed_keys_match_registered_rules_test.go` — already exists and states exactly that contract.

Three text greps produced three different wrong answers, each an artifact of the pattern:

| Pattern | Reported | Cause |
| --- | --- | --- |
| `"name"?:` | 3 rules unpublished | those three are bare identifiers, since their names need no quoting |
| `Name() string {`, one space | 376 keys unregistered | declarations align with several spaces before `{` |
| whitespace-tolerant | 222 keys unregistered | whole families are table-driven; `jest/` is `return "jest/" + r.name` |

The third is the one that matters. A table-driven family has no literal to grep, so a source-text comparison of that contract **cannot be made correct** — which is why the existing gate is a Go test that calls `AllRuleNames()` and reads the registry the runtime actually holds.

Both corrections are recorded on the issue. Noting it here because the campaign's own rule covers it: a report is a hypothesis until the real code path is verified, and that applies to a report the agent generates itself.
