### PR TITLE
fix(graph): report a failed plugin apply instead of describing the untransformed program

### DIFF
--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -578,14 +578,25 @@ func (p *Program) Diagnostics() []Diagnostic {
   // untransformed program with nothing to say about it, while `ttsc build` on
   // the same project reported the failure.
   //
-  // The apply is cached, so asking here costs nothing a caller was not going to
-  // pay, and the answer cannot differ between callers. `driver: nil program`
-  // above is the precedent for a driver-level entry with no file or code.
+  // The cached outcome is read, never forced. Calling `ApplyLinkedPlugins`
+  // here would move WHEN the apply happens: diagnostics would then be computed
+  // against the mutated tree, whose nodes carry positions that need not map
+  // into the original source text, and the diagnostic writer walks that text to
+  // render context. It panics on the mismatch.
+  //
+  // Reading the cache costs nothing and is enough for the consumers this is
+  // for: `SourceTexts` and `SourceFiles` run the apply, and both graph entry
+  // points call them before asking for diagnostics. A caller that has not
+  // applied yet has nothing to report, which is correct — the plugins have not
+  // failed, they have not run.
+  //
+  // `driver: nil program` above is the precedent for a driver-level entry with
+  // no file or code.
   var out []Diagnostic
-  if err := p.ApplyLinkedPlugins(); err != nil {
+  if p.pluginsApplied && p.pluginsApplyErr != nil {
     out = append(out, Diagnostic{
       Severity: SeverityError,
-      Message:  "driver: linked plugins failed to apply: " + err.Error(),
+      Message:  "driver: linked plugins failed to apply: " + p.pluginsApplyErr.Error(),
     })
   }
   ctx := context.Background()

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -101,6 +101,9 @@ func (p *Program) SourceFile(filename string) *ast.SourceFile {
   if p == nil || p.TSProgram == nil {
     return nil
   }
+  // Discarded on purpose: an accessor returning a source file has no channel
+  // for an apply failure, and growing one would ripple through every caller.
+  // `Diagnostics` reports it, and the emit path checks the error directly.
   _ = p.ApplyLinkedPlugins()
   normalized := filepath.ToSlash(filename)
   for _, file := range p.TSProgram.SourceFiles() {
@@ -513,6 +516,7 @@ func ApplySourcePreamble(text string, preamble string) string {
 // SourceFiles exposes the program's user-authored source files (declaration
 // files filtered out).
 func (p *Program) SourceFiles() []*ast.SourceFile {
+  // Discarded on purpose; see SourceFile. `Diagnostics` carries the failure.
   _ = p.ApplyLinkedPlugins()
   return p.sourceFilesRaw()
 }
@@ -563,6 +567,27 @@ func (p *Program) Diagnostics() []Diagnostic {
   if p == nil || p.TSProgram == nil {
     return []Diagnostic{{Message: "driver: nil program"}}
   }
+  // A linked ProgramPlugin that failed to apply is reported here, ahead of the
+  // compiler's own findings, because every other consumer of this program is
+  // then looking at a tree the plugin did not transform.
+  //
+  // `SourceFile`, `SourceFiles`, and the graph builder all run the apply and
+  // discard its error — they have no channel of their own and are not the place
+  // to grow one. The emit path checks it directly and fails the build, so this
+  // is the read-only half of the same fact: `ttscgraph` used to describe the
+  // untransformed program with nothing to say about it, while `ttsc build` on
+  // the same project reported the failure.
+  //
+  // The apply is cached, so asking here costs nothing a caller was not going to
+  // pay, and the answer cannot differ between callers. `driver: nil program`
+  // above is the precedent for a driver-level entry with no file or code.
+  var out []Diagnostic
+  if err := p.ApplyLinkedPlugins(); err != nil {
+    out = append(out, Diagnostic{
+      Severity: SeverityError,
+      Message:  "driver: linked plugins failed to apply: " + err.Error(),
+    })
+  }
   ctx := context.Background()
   raw := shimcompiler.GetDiagnosticsOfAnyProgram(
     ctx,
@@ -573,7 +598,7 @@ func (p *Program) Diagnostics() []Diagnostic {
     p.TSProgram.GetSemanticDiagnostics,
   )
   raw = filterDiagnostics(raw)
-  return convertDiagnostics(shimcompiler.SortAndDeduplicateDiagnostics(raw))
+  return append(out, convertDiagnostics(shimcompiler.SortAndDeduplicateDiagnostics(raw))...)
 }
 
 // filterDiagnostics removes diagnostics that are false positives in ttsc's

--- a/packages/ttsc/internal/graph/build.go
+++ b/packages/ttsc/internal/graph/build.go
@@ -35,6 +35,8 @@ func SourceTexts(prog *driver.Program) map[string]string {
   if prog == nil || prog.TSProgram == nil {
     return map[string]string{}
   }
+  // Discarded on purpose: this returns text, not an error channel. A failed
+  // apply reaches the dump through `NewDiagnostics`, which asks `Diagnostics`.
   _ = prog.ApplyLinkedPlugins()
   files := prog.TSProgram.SourceFiles()
   out := make(map[string]string, len(files))

--- a/packages/ttsc/test/driver/diagnostics_report_a_failed_plugin_apply_test.go
+++ b/packages/ttsc/test/driver/diagnostics_report_a_failed_plugin_apply_test.go
@@ -29,10 +29,17 @@ func (diagnosticsApplyErrorPlugin) ApplyProgram(*driver.Program, driver.PluginCo
 // no file or code (`driver: nil program`), and every read-only consumer of a
 // program's findings goes through it.
 //
+// The cached outcome is read, never forced. Forcing it here would move when the
+// apply happens, and diagnostics computed against a mutated tree carry positions
+// that need not map into the original source text — the diagnostic writer walks
+// that text to render context and panics on the mismatch. Every real consumer
+// reads source files before asking for diagnostics, so the cache is warm by
+// then; `SourceFiles` below is that step, not a contrivance.
+//
 //  1. Register a linked plugin whose ApplyProgram fails.
-//  2. Ask the program for its diagnostics.
-//  3. Assert the failure is among them, as an error, and that the compiler's own
-//     findings still follow it.
+//  2. Read the program's source files, as every consumer of this does.
+//  3. Ask for diagnostics, and assert the failure is among them as an error,
+//     with the compiler's own findings still beside it.
 func TestDriverDiagnosticsReportAFailedPluginApply(t *testing.T) {
   resetLinkedPluginRegistry()
   t.Setenv(driver.LinkedPluginsEnv, `[{"name":"diagnostics-apply-error","stage":"transform","config":{}}]`)
@@ -57,6 +64,9 @@ func TestDriverDiagnosticsReportAFailedPluginApply(t *testing.T) {
     t.Fatalf("unexpected load diagnostics: %#v", diags)
   }
   defer prog.Close()
+
+  // What a consumer does first, and what warms the cached apply outcome.
+  _ = prog.SourceFiles()
 
   found := false
   typecheck := 0
@@ -104,6 +114,7 @@ func TestDriverDiagnosticsStaySilentWhenPluginsApply(t *testing.T) {
   }
   defer prog.Close()
 
+  _ = prog.SourceFiles()
   for _, diagnostic := range prog.Diagnostics() {
     if strings.Contains(diagnostic.Message, "linked plugins failed to apply") {
       t.Fatalf("a clean apply must report nothing: %s", diagnostic.Message)

--- a/packages/ttsc/test/driver/diagnostics_report_a_failed_plugin_apply_test.go
+++ b/packages/ttsc/test/driver/diagnostics_report_a_failed_plugin_apply_test.go
@@ -1,0 +1,118 @@
+package driver_test
+
+import (
+  "errors"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+type diagnosticsApplyErrorPlugin struct{}
+
+func (diagnosticsApplyErrorPlugin) ApplyProgram(*driver.Program, driver.PluginContext) error {
+  return errors.New("apply boom")
+}
+
+// TestDriverDiagnosticsReportAFailedPluginApply verifies a linked plugin that
+// fails to apply reaches a read-only consumer.
+//
+// `ApplyLinkedPlugins` caches its outcome, and the emit path checks it — so
+// `ttsc build` fails on such a project. The read-only paths did not: `SourceFile`,
+// `SourceFiles`, and the graph builder all ran the apply and discarded the
+// error, having no channel of their own. `ttscgraph` therefore described the
+// untransformed program and said nothing, while the compiler on the same
+// project reported the failure. Two halves of one toolchain disagreeing about
+// whether the project is broken, with the quiet half the one an agent reads.
+//
+// `Diagnostics` is where it belongs: it already emits a driver-level entry with
+// no file or code (`driver: nil program`), and every read-only consumer of a
+// program's findings goes through it.
+//
+//  1. Register a linked plugin whose ApplyProgram fails.
+//  2. Ask the program for its diagnostics.
+//  3. Assert the failure is among them, as an error, and that the compiler's own
+//     findings still follow it.
+func TestDriverDiagnosticsReportAFailedPluginApply(t *testing.T) {
+  resetLinkedPluginRegistry()
+  t.Setenv(driver.LinkedPluginsEnv, `[{"name":"diagnostics-apply-error","stage":"transform","config":{}}]`)
+  driver.RegisterPlugin(diagnosticsApplyErrorPlugin{})
+
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": { "module": "commonjs", "target": "es2020", "strict": true },
+  "files": ["index.ts"]
+}
+`)
+  // A real type error too, so the plugin entry is proven to sit alongside the
+  // compiler's findings rather than replace them.
+  writeProjectFile(t, root, "index.ts", `export const value: number = "not a number";
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected load diagnostics: %#v", diags)
+  }
+  defer prog.Close()
+
+  found := false
+  typecheck := 0
+  for _, diagnostic := range prog.Diagnostics() {
+    if strings.Contains(diagnostic.Message, "apply boom") {
+      found = true
+      if !diagnostic.IsError() {
+        t.Fatalf("a failed apply must be an error, got severity %v", diagnostic.Severity)
+      }
+      continue
+    }
+    if diagnostic.Code != 0 {
+      typecheck++
+    }
+  }
+  if !found {
+    t.Fatalf("Diagnostics did not report the failed apply: %#v", prog.Diagnostics())
+  }
+  if typecheck == 0 {
+    t.Fatal("the compiler's own diagnostics were lost alongside the plugin entry")
+  }
+}
+
+// TestDriverDiagnosticsStaySilentWhenPluginsApply is the negative twin: a
+// project whose linked plugin applies cleanly reports exactly what the compiler
+// found and nothing else, so the entry above is driven by the failure rather
+// than by a plugin being linked at all.
+func TestDriverDiagnosticsStaySilentWhenPluginsApply(t *testing.T) {
+  resetLinkedPluginRegistry()
+  t.Setenv(driver.LinkedPluginsEnv, `[{"name":"diagnostics-apply-ok","stage":"transform","config":{}}]`)
+  driver.RegisterPlugin(diagnosticsApplyOKPlugin{})
+
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{
+  "compilerOptions": { "module": "commonjs", "target": "es2020" },
+  "files": ["index.ts"]
+}
+`)
+  writeProjectFile(t, root, "index.ts", `export const value = 1;
+`)
+
+  prog, _, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer prog.Close()
+
+  for _, diagnostic := range prog.Diagnostics() {
+    if strings.Contains(diagnostic.Message, "linked plugins failed to apply") {
+      t.Fatalf("a clean apply must report nothing: %s", diagnostic.Message)
+    }
+  }
+}
+
+type diagnosticsApplyOKPlugin struct{}
+
+func (diagnosticsApplyOKPlugin) ApplyProgram(*driver.Program, driver.PluginContext) error {
+  return nil
+}


### PR DESCRIPTION
## Intent

Cycle 6 of the 2026-07-21 campaign.

## What this closes

Closes #933.

`ApplyLinkedPlugins` caches its outcome and the emit path checks it, so `ttsc build` fails on a project whose linked `ProgramPlugin` cannot apply. The read-only paths did not: `SourceFile`, `SourceFiles`, and the graph's `SourceTexts` each ran the apply and discarded the error, and the graph has no later caller to ask — `dump` writes its payload and exits, `serve` answers the request.

So `ttscgraph` described the untransformed tree and said nothing, while the compiler on the same project reported the failure. The graph's own audit meanwhile tells its caller that every fact "was resolved by the TypeScript compiler against the program for the snapshot this call synced to".

## Where the fact goes

`Diagnostics`, which fixes every read-only consumer at once rather than growing a channel per accessor. It already emits a driver-level entry with no file or code — `driver: nil program` is the precedent — and `graph.NewDiagnostics` reads it, so the dump carries the failure through the field its own comment reserves for "the compiler's findings for the same program generation".

The three discards stay, because an accessor returning source files has no channel for an error. Each now says so and names who reports instead.

## Verification

`go build` and `go vet` pass locally on `packages/ttsc`, which is the package that does build outside the scratch-module materialization — the type error that took 23 lanes down in cycle 5 could not have survived here.