### PR TITLE
fix(graph): make dump identities portable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Build Packages
         run: pnpm run build
 
+      - name: Smoke release-candidate ttscgraph snapshot
+        run: node scripts/assert-ttscgraph-release-candidate.cjs
+
   wasm-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
         run: node scripts/assert-marketplace-version.cjs --extension samchon.ttsc --timeout-ms 60000 --interval-ms 5000
       - name: Build all packages
         run: pnpm run build
+      - name: Smoke release-candidate ttscgraph snapshot
+        run: node scripts/assert-ttscgraph-release-candidate.cjs
       - name: Assert dist/ttsc.wasm exists and is >10MB
         run: |
           test -f packages/wasm/dist/ttsc.wasm

--- a/packages/graph/src/model/TtscGraphMemory.ts
+++ b/packages/graph/src/model/TtscGraphMemory.ts
@@ -136,7 +136,7 @@ function ownerKey(node: ITtscGraphNode): string | undefined {
   return owner === "" ? undefined : owner;
 }
 
-/** A file's id and node name from its project-relative path. */
+/** A file's id and node name from its schema-v6 path coordinate. */
 function fileNodeId(file: string): string {
   return file;
 }

--- a/packages/graph/src/model/loadGraph.ts
+++ b/packages/graph/src/model/loadGraph.ts
@@ -24,7 +24,7 @@ const MAX_DUMP_BYTES = 1024 * 1024 * 1024;
  * the body's are independent, so a producer can speak this protocol and still
  * send a body from another schema.
  */
-export const DUMP_SCHEMA_VERSION = 5;
+export const DUMP_SCHEMA_VERSION = 6;
 
 /**
  * Build the resident {@link TtscGraphMemory} for a project by running `ttscgraph

--- a/packages/graph/src/structures/ITtscGraphDump.ts
+++ b/packages/graph/src/structures/ITtscGraphDump.ts
@@ -13,19 +13,19 @@ import { ITtscGraphSpan } from "./ITtscGraphSpan";
  * warm model while project inputs stay unchanged; the bundled 3D viewer reduces
  * the same dump.
  *
- * `project` is absolute. Every other path is relative to it — `tsconfig`, and
- * the `file` fields on nodes, edges, diagnostics, and the provenance manifest.
- *
- * Two kinds of path fall outside the project and so cannot be relative to it: a
- * dependency keeps its `node_modules/`-relative tail, which is what makes a
- * dependency leaf readable, and anything else the compiler loaded keeps the
- * identity the compiler gave it — a virtual lib stays `bundled:///…`.
+ * `project` is the producer-local absolute locator. Every identity-bearing path
+ * uses one schema-v6 coordinate relative to it: project files are ordinary
+ * relative paths; same-filesystem siblings use `../` segments; package files
+ * keep their full resolution context (including version/peer-store segments);
+ * and a virtual compiler source stays `bundled:///…`. Raw absolute identities
+ * are never emitted. A source on another drive or UNC share makes the producer
+ * fail unless a future contract supplies a logical root for it.
  */
 export interface ITtscGraphDump {
   /** Absolute path of the project root the graph was built for. */
   project: string;
 
-  /** The tsconfig the program was loaded from, relative to `project`. */
+  /** The tsconfig the program was loaded from, in the dump's path vocabulary. */
   tsconfig: string;
 
   /** Evidence about the one program that produced everything below. */
@@ -143,16 +143,16 @@ export namespace ITtscGraphDump {
 
   /** A root file attributed to the config that named it. */
   export interface IRootFile {
-    /** The tsconfig that named this root, project-relative. */
+    /** The tsconfig that named this root, in the dump's path vocabulary. */
     config: string;
 
-    /** The root file, project-relative. */
+    /** The root file, in the dump's path vocabulary. */
     file: string;
   }
 
   /** A file and the hex-encoded SHA-256 of its on-disk bytes. */
   export interface IFileDigest {
-    /** Project-relative. */
+    /** In the dump's path vocabulary. */
     file: string;
 
     /** Hex-encoded SHA-256. */
@@ -169,7 +169,7 @@ export namespace ITtscGraphDump {
    * on every build.
    */
   export interface ISourceDigest {
-    /** Project-relative. */
+    /** In the dump's path vocabulary. */
     file: string;
 
     /**
@@ -199,7 +199,7 @@ export namespace ITtscGraphDump {
 
   /** One compiler diagnostic from the generation that produced the facts. */
   export interface IDiagnostic {
-    /** Project-relative. */
+    /** In the dump's path vocabulary. */
     file: string;
 
     /** 1-based line. */

--- a/packages/ttsc/cmd/graphdump/main.go
+++ b/packages/ttsc/cmd/graphdump/main.go
@@ -60,7 +60,6 @@ func run() int {
   // `ttscgraph dump` is the one that proves the whole contract.
   data, err := graph.MarshalDump(g, root, *tsconfig, ignored, texts, graph.DumpOrigin{
     Provenance: graph.NewProvenance(
-      root,
       // No version: this tool is built from the tree on demand and never
       // stamped, and an invented one would be worse than an absent one.
       graph.Producer{Tool: "graphdump", Typescript: graph.TypescriptVersion()},

--- a/packages/ttsc/cmd/graphdump/main.go
+++ b/packages/ttsc/cmd/graphdump/main.go
@@ -28,9 +28,8 @@ func run() int {
   flag.Parse()
 
   // Resolve the project root the same way LoadProgram does (absolute, then
-  // tsgo-normalized) so it shares the node file paths' drive-letter case on
-  // Windows; otherwise the dump's prefix-based relativization would miss and
-  // leave every path absolute.
+  // tsgo-normalized) so the schema-v6 mapper receives the same canonical root
+  // grammar and drive-letter case as the compiler's source paths.
   root := *cwd
   if abs, err := filepath.Abs(root); err == nil {
     root = abs

--- a/packages/ttsc/cmd/ttscgraph/dump.go
+++ b/packages/ttsc/cmd/ttscgraph/dump.go
@@ -37,9 +37,8 @@ func runDump(args []string) int {
     cwd = resolved
   }
   // Resolve the project root the same way LoadProgram does (absolute, then
-  // tsgo-normalized) so it shares the node file paths' drive-letter case on
-  // Windows; otherwise the dump's prefix-based relativization would miss and
-  // leave every path absolute.
+  // tsgo-normalized) so the schema-v6 mapper receives the same canonical root
+  // grammar and drive-letter case as the compiler's source paths.
   if abs, err := filepath.Abs(cwd); err == nil {
     cwd = abs
   }
@@ -60,7 +59,7 @@ func runDump(args []string) int {
   g := graph.Build(prog)
   ignored := graph.GitIgnoredFiles(cwd, g)
   texts := graph.SourceTexts(prog)
-  origin, err := dumpOrigin(prog, cwd, texts)
+  origin, err := dumpOrigin(prog, texts)
   if err != nil {
     fmt.Fprintf(stderr, "ttscgraph: %v\n", err)
     return 1
@@ -90,7 +89,7 @@ func runDump(args []string) int {
 // saw the project, so it carries the same provenance a served snapshot does:
 // without it the file is a pile of facts with no way to tell which program, or
 // which day, they describe.
-func dumpOrigin(prog *driver.Program, cwd string, texts map[string]string) (graph.DumpOrigin, error) {
+func dumpOrigin(prog *driver.Program, texts map[string]string) (graph.DumpOrigin, error) {
   configs, err := parsedConfigs(prog)
   if err != nil {
     return graph.DumpOrigin{}, err

--- a/packages/ttsc/cmd/ttscgraph/dump.go
+++ b/packages/ttsc/cmd/ttscgraph/dump.go
@@ -105,7 +105,6 @@ func dumpOrigin(prog *driver.Program, cwd string, texts map[string]string) (grap
   }
   return graph.DumpOrigin{
     Provenance: graph.NewProvenance(
-      cwd,
       serveProducer(),
       fullSnapshotCapabilities,
       fileDigests(configHashes),
@@ -113,6 +112,6 @@ func dumpOrigin(prog *driver.Program, cwd string, texts map[string]string) (grap
       texts,
       diskDigests,
     ),
-    Diagnostics: graph.NewDiagnostics(prog, cwd),
+    Diagnostics: graph.NewDiagnostics(prog),
   }, nil
 }

--- a/packages/ttsc/cmd/ttscgraph/serve.go
+++ b/packages/ttsc/cmd/ttscgraph/serve.go
@@ -146,7 +146,10 @@ func (s *graphSession) Close() error {
 
 func (s *graphSession) Snapshot() (*graph.Dump, string, bool, error) {
   if !s.initialized {
-    dump := s.buildDump()
+    dump, err := s.buildDump()
+    if err != nil {
+      return nil, "", false, err
+    }
     s.initialized = true
     return &dump, serveModeInitial, true, nil
   }
@@ -159,16 +162,14 @@ func (s *graphSession) Snapshot() (*graph.Dump, string, bool, error) {
     if err := s.reload(); err != nil {
       return nil, "", false, err
     }
-    dump := s.buildDump()
-    return &dump, serveModeReload, true, nil
+    return s.changedSnapshot(serveModeReload)
   }
 
   if diskStatesChanged(s.auxStates) {
     if err := s.reload(); err != nil {
       return nil, "", false, err
     }
-    dump := s.buildDump()
-    return &dump, serveModeReload, true, nil
+    return s.changedSnapshot(serveModeReload)
   }
 
   roots, err := projectRootFiles(s.compiler.Program(), true)
@@ -179,8 +180,7 @@ func (s *graphSession) Snapshot() (*graph.Dump, string, bool, error) {
     if err := s.reload(); err != nil {
       return nil, "", false, err
     }
-    dump := s.buildDump()
-    return &dump, serveModeReload, true, nil
+    return s.changedSnapshot(serveModeReload)
   }
 
   changed, deleted, err := changedSources(s.sourceHashes)
@@ -191,8 +191,7 @@ func (s *graphSession) Snapshot() (*graph.Dump, string, bool, error) {
     if err := s.reload(); err != nil {
       return nil, "", false, err
     }
-    dump := s.buildDump()
-    return &dump, serveModeReload, true, nil
+    return s.changedSnapshot(serveModeReload)
   }
   if len(changed) == 0 {
     return nil, serveModeUnchanged, false, nil
@@ -201,8 +200,7 @@ func (s *graphSession) Snapshot() (*graph.Dump, string, bool, error) {
     if err := s.reload(); err != nil {
       return nil, "", false, err
     }
-    dump := s.buildDump()
-    return &dump, serveModeReload, true, nil
+    return s.changedSnapshot(serveModeReload)
   }
 
   mode := serveModeIncremental
@@ -221,14 +219,20 @@ func (s *graphSession) Snapshot() (*graph.Dump, string, bool, error) {
       if err := s.reload(); err != nil {
         return nil, "", false, err
       }
-      dump := s.buildDump()
-      return &dump, serveModeReload, true, nil
+      return s.changedSnapshot(serveModeReload)
     }
   }
   if err := s.captureState(); err != nil {
     return nil, "", false, err
   }
-  dump := s.buildDump()
+  return s.changedSnapshot(mode)
+}
+
+func (s *graphSession) changedSnapshot(mode string) (*graph.Dump, string, bool, error) {
+  dump, err := s.buildDump()
+  if err != nil {
+    return nil, "", false, err
+  }
   return &dump, mode, true, nil
 }
 
@@ -322,7 +326,7 @@ func missingRootInputs(configs []*shimtsoptions.ParsedCommandLine, sourceHashes 
   return missing
 }
 
-func (s *graphSession) buildDump() graph.Dump {
+func (s *graphSession) buildDump() (graph.Dump, error) {
   program := s.compiler.Program()
   built := graph.Build(program)
   // One texts map feeds both the spans and the manifest digests, so the bytes a
@@ -336,7 +340,6 @@ func (s *graphSession) buildDump() graph.Dump {
     texts,
     graph.DumpOrigin{
       Provenance: graph.NewProvenance(
-        s.cwd,
         serveProducer(),
         fullSnapshotCapabilities,
         s.configDigests,
@@ -344,7 +347,7 @@ func (s *graphSession) buildDump() graph.Dump {
         texts,
         s.diskDigests,
       ),
-      Diagnostics: graph.NewDiagnostics(program, s.cwd),
+      Diagnostics: graph.NewDiagnostics(program),
     },
   )
 }

--- a/packages/ttsc/cmd/ttscgraph/serve.go
+++ b/packages/ttsc/cmd/ttscgraph/serve.go
@@ -127,6 +127,10 @@ type graphSession struct {
   configDigests []graph.FileDigest
   roots         []graph.RootFile
   initialized   bool
+  // pendingDumpMode remembers a generation whose state was captured but whose
+  // dump failed. Until an input change lets the session rebuild, an unchanged
+  // request must retry that dump instead of falsely confirming the older graph.
+  pendingDumpMode string
 }
 
 func newGraphSession(cwd, tsconfig string) (*graphSession, error) {
@@ -146,11 +150,17 @@ func (s *graphSession) Close() error {
 
 func (s *graphSession) Snapshot() (*graph.Dump, string, bool, error) {
   if !s.initialized {
+    // The captured compiler state is initialized even when its first dump is
+    // not publishable. Mark the attempt before building so a later request can
+    // observe a config/source edit that repairs the path error instead of
+    // retrying the stale Program forever.
+    s.initialized = true
     dump, err := s.buildDump()
     if err != nil {
+      s.pendingDumpMode = serveModeInitial
       return nil, "", false, err
     }
-    s.initialized = true
+    s.pendingDumpMode = ""
     return &dump, serveModeInitial, true, nil
   }
 
@@ -194,6 +204,9 @@ func (s *graphSession) Snapshot() (*graph.Dump, string, bool, error) {
     return s.changedSnapshot(serveModeReload)
   }
   if len(changed) == 0 {
+    if s.pendingDumpMode != "" {
+      return s.changedSnapshot(s.pendingDumpMode)
+    }
     return nil, serveModeUnchanged, false, nil
   }
   if s.compiler.Program().HasLinkedProgramPlugins() {
@@ -231,8 +244,10 @@ func (s *graphSession) Snapshot() (*graph.Dump, string, bool, error) {
 func (s *graphSession) changedSnapshot(mode string) (*graph.Dump, string, bool, error) {
   dump, err := s.buildDump()
   if err != nil {
+    s.pendingDumpMode = mode
     return nil, "", false, err
   }
+  s.pendingDumpMode = ""
   return &dump, mode, true, nil
 }
 

--- a/packages/ttsc/cmd/ttscgraph/serve_session_retries_failed_dump_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_retries_failed_dump_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestServeSessionKeepsChangeDetectionLiveAfterInitialDumpError verifies a
+// rejected first dump still advances the session into its change-detection
+// state. The invalid relative cwd is a deterministic path-mapper failure; once
+// corrected, the same captured generation is retried and can become the first
+// published snapshot.
+func TestServeSessionKeepsChangeDetectionLiveAfterInitialDumpError(t *testing.T) {
+  root := graphSessionFixture(t)
+  compiler, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if compiler == nil {
+    t.Fatalf("NewSession returned nil session (diagnostics: %v)", diags)
+  }
+  session := &graphSession{
+    cwd:      root,
+    tsconfig: "tsconfig.json",
+    compiler: compiler,
+  }
+  defer session.Close()
+  if err := session.captureState(); err != nil {
+    t.Fatal(err)
+  }
+  session.cwd = "relative-project"
+
+  dump, _, changed, err := session.Snapshot()
+  if err == nil || !strings.Contains(err.Error(), "project root") {
+    t.Fatalf("initial dump error = %v, want absolute-root rejection", err)
+  }
+  if dump != nil || changed || !session.initialized || session.pendingDumpMode != serveModeInitial {
+    t.Fatalf(
+      "failed initial state = dump:%v changed:%v initialized:%v pending:%q",
+      dump != nil,
+      changed,
+      session.initialized,
+      session.pendingDumpMode,
+    )
+  }
+
+  session.cwd = root
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != serveModeInitial || !changed {
+    t.Fatalf("repaired initial dump = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+}
+
+// TestServeSessionRetriesAPendingDumpBeforeUnchanged pins the state boundary
+// introduced by dump-time path validation. A failed dump may occur after the
+// compiler generation and its hashes were captured; the next request must
+// retry that generation instead of confirming the older client graph as
+// unchanged.
+func TestServeSessionRetriesAPendingDumpBeforeUnchanged(t *testing.T) {
+  root := graphSessionFixture(t)
+  compiler, diags, err := driver.NewSession(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if compiler == nil {
+    t.Fatalf("NewSession returned nil session (diagnostics: %v)", diags)
+  }
+  session := &graphSession{
+    cwd:             root,
+    tsconfig:        "tsconfig.json",
+    compiler:        compiler,
+    initialized:     true,
+    pendingDumpMode: serveModeReload,
+  }
+  defer session.Close()
+  if err := session.captureState(); err != nil {
+    t.Fatal(err)
+  }
+
+  dump, mode, changed, err := session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump == nil || mode != serveModeReload || !changed {
+    t.Fatalf("pending dump retry = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+  if session.pendingDumpMode != "" {
+    t.Fatalf("successful retry left pending mode %q", session.pendingDumpMode)
+  }
+
+  dump, mode, changed, err = session.Snapshot()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if dump != nil || mode != serveModeUnchanged || changed {
+    t.Fatalf("retry did not converge: dump:%v mode:%q changed:%v", dump != nil, mode, changed)
+  }
+}

--- a/packages/ttsc/internal/graph/dump.go
+++ b/packages/ttsc/internal/graph/dump.go
@@ -4,7 +4,6 @@ import (
   "bufio"
   "encoding/json"
   "io"
-  "path/filepath"
   "sort"
   "strings"
 )
@@ -20,8 +19,8 @@ import (
 //     EdgeMemberRelation into "implements" / "overrides";
 //   - byte spans become 1-based line/col Evidence ranges;
 //   - decorator facts ride on their target node;
-//   - file paths are project-relative and the output is sorted, so the dump is
-//     deterministic and diffable.
+//   - file paths use one portable, injective project coordinate and the output
+//     is sorted, so the dump is deterministic and diffable.
 //
 // Structural derivations the schema also defines (file nodes, contains/exports
 // edges) are left to the TypeScript loader, which has the node set in hand and
@@ -147,12 +146,13 @@ type DumpOrigin struct {
 }
 
 // NewDump projects a built graph onto the export shape. project is the absolute
-// project root used to relativize file paths and node ids; ignored is the
-// git-ignored source set (nil for a non-git project); sources maps a source
-// file's path to its text so byte spans become line/col evidence (nil omits
-// evidence); origin is the snapshot evidence that proves where the facts came
-// from.
-func NewDump(g *Graph, project, tsconfig string, ignored map[string]bool, sources map[string]string, origin DumpOrigin) Dump {
+// root of the portable path coordinate; ignored is the git-ignored source set
+// (nil for a non-git project); sources maps a source file's physical path to its
+// text so byte spans become line/col evidence (nil omits evidence); origin is
+// the snapshot evidence that proves where the facts came from. It returns an
+// error before serialization when a path is on another filesystem root or two
+// physical sources would collide at one wire identity.
+func NewDump(g *Graph, project, tsconfig string, ignored map[string]bool, sources map[string]string, origin DumpOrigin) (Dump, error) {
   ctx := newDumpContext(project, sources)
 
   // Decorators ride on their target node; group by the internal node id before
@@ -222,7 +222,7 @@ func NewDump(g *Graph, project, tsconfig string, ignored map[string]bool, source
 
   // The schema version describes this code, not the caller's belief about it,
   // so stamp it here rather than trusting what came in.
-  provenance := origin.Provenance
+  provenance := ctx.provenance(origin.Provenance)
   provenance.SchemaVersion = DumpSchemaVersion
 
   // A nil slice encodes as JSON null, and null is not an empty list: a reader
@@ -241,19 +241,23 @@ func NewDump(g *Graph, project, tsconfig string, ignored map[string]bool, source
     provenance.Universe.Roots = []RootFile{}
   }
 
-  diagnostics := origin.Diagnostics
+  diagnostics := ctx.diagnostics(origin.Diagnostics)
   if diagnostics == nil {
     diagnostics = []Diagnostic{}
   }
 
-  return Dump{
+  dump := Dump{
     Project:     project,
-    Tsconfig:    tsconfig,
+    Tsconfig:    ctx.rel(tsconfig),
     Provenance:  provenance,
     Diagnostics: diagnostics,
     Nodes:       nodes,
     Edges:       edges,
   }
+  if err := ctx.pathError(); err != nil {
+    return Dump{}, err
+  }
+  return dump, nil
 }
 
 // dumpEnumMembers projects an enum's members onto the wire shape, nil for a
@@ -301,7 +305,10 @@ func objectMemberWireKind(kind NodeKind) string {
 // MarshalDump serializes a built graph to the export JSON, indented when pretty.
 // See NewDump for the parameters.
 func MarshalDump(g *Graph, project, tsconfig string, ignored map[string]bool, sources map[string]string, origin DumpOrigin, pretty bool) ([]byte, error) {
-  d := NewDump(g, project, tsconfig, ignored, sources, origin)
+  d, err := NewDump(g, project, tsconfig, ignored, sources, origin)
+  if err != nil {
+    return nil, err
+  }
   if pretty {
     return json.MarshalIndent(d, "", "  ")
   }
@@ -317,12 +324,16 @@ func MarshalDump(g *Graph, project, tsconfig string, ignored map[string]bool, so
 // copy of it held live beside the first — half a gigabyte of peak heap that
 // bought nothing, because the bytes were already exactly what stdout wanted.
 func EncodeDump(w io.Writer, g *Graph, project, tsconfig string, ignored map[string]bool, sources map[string]string, origin DumpOrigin, pretty bool) error {
+  dump, err := NewDump(g, project, tsconfig, ignored, sources, origin)
+  if err != nil {
+    return err
+  }
   buffered := bufio.NewWriterSize(w, 1<<20)
   encoder := json.NewEncoder(buffered)
   if pretty {
     encoder.SetIndent("", "  ")
   }
-  if err := encoder.Encode(NewDump(g, project, tsconfig, ignored, sources, origin)); err != nil {
+  if err := encoder.Encode(dump); err != nil {
     return err
   }
   return buffered.Flush()
@@ -387,40 +398,29 @@ func nodeNames(n *Node) (simple, qualified string) {
   return n.Simple, n.Name
 }
 
-// dumpContext relativizes paths and turns byte spans into line/col evidence,
-// caching a per-file line index so a large file's many edges cost O(log n) each
-// instead of a re-scan.
+// dumpContext maps paths and turns byte spans into line/col evidence, caching a
+// per-file line index so a large file's many edges cost O(log n) each instead
+// of a re-scan.
 type dumpContext struct {
-  project string
+  paths   *dumpPathMapper
   sources map[string]string
   lines   map[string]lineStarts
 }
 
 func newDumpContext(project string, sources map[string]string) *dumpContext {
   return &dumpContext{
-    project: strings.TrimRight(filepath.ToSlash(project), "/"),
+    paths:   newDumpPathMapper(project),
     sources: sources,
     lines:   map[string]lineStarts{},
   }
 }
 
-// rel makes a source file path project-relative; an external path keeps its
-// node_modules-relative tail so a dependency leaf stays readable.
+// rel delegates every identity-bearing path to the dump's one cached mapper.
 func (c *dumpContext) rel(file string) string {
-  f := filepath.ToSlash(file)
-  if c.project != "" {
-    if f == c.project {
-      return ""
-    }
-    if strings.HasPrefix(f, c.project+"/") {
-      return f[len(c.project)+1:]
-    }
-  }
-  if i := strings.LastIndex(f, "/node_modules/"); i >= 0 {
-    return f[i+1:]
-  }
-  return f
+  return c.paths.mapPath(file)
 }
+
+func (c *dumpContext) pathError() error { return c.paths.err() }
 
 // relID relativizes the path portion of a node id ("path#qualifiedName:kind").
 // An id with no path (a future virtual node) is returned unchanged.

--- a/packages/ttsc/internal/graph/dump_checkout_paths_are_stable_test.go
+++ b/packages/ttsc/internal/graph/dump_checkout_paths_are_stable_test.go
@@ -1,0 +1,196 @@
+package graph
+
+import (
+  "encoding/json"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+const portableDumpTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "noEmit": true
+  },
+  "files": ["src/main.ts", "../shared/value.ts", "../shared/types.d.ts"]
+}
+`
+
+// TestDumpCheckoutPathsAreStable verifies the whole schema-v6 consequence
+// surface, not only the path helper.
+//
+//   1. Build the same project plus sibling .ts/.d.ts under two checkout roots.
+//   2. Remove only the producer-local Project locator and require byte identity.
+//   3. Assert nodes, module names, endpoints, implementation evidence,
+//      diagnostics, manifests, and universe inputs all use one `../shared`
+//      coordinate, with the .ts internal and the .d.ts an external leaf.
+func TestDumpCheckoutPathsAreStable(t *testing.T) {
+  firstCheckout := filepath.Join(t.TempDir(), "checkout-one")
+  secondCheckout := filepath.Join(t.TempDir(), "checkout-two")
+  first := portableFixtureDump(t, firstCheckout)
+  second := portableFixtureDump(t, secondCheckout)
+
+  first.Project = ""
+  second.Project = ""
+  firstJSON, err := json.Marshal(first)
+  if err != nil {
+    t.Fatal(err)
+  }
+  secondJSON, err := json.Marshal(second)
+  if err != nil {
+    t.Fatal(err)
+  }
+  if string(firstJSON) != string(secondJSON) {
+    t.Fatalf("checkout relocation changed the dump:\nfirst  %s\nsecond %s", firstJSON, secondJSON)
+  }
+
+  assertPortableFixturePaths(t, first)
+  if strings.Contains(string(firstJSON), filepath.ToSlash(firstCheckout)) ||
+    strings.Contains(string(secondJSON), filepath.ToSlash(secondCheckout)) {
+    t.Fatal("a producer-local checkout path escaped into schema-v6 identity")
+  }
+}
+
+func portableFixtureDump(t *testing.T, checkout string) Dump {
+  t.Helper()
+  project := filepath.Join(checkout, "app")
+  config := filepath.Join(project, "tsconfig.json")
+  mainFile := filepath.Join(project, "src", "main.ts")
+  siblingFile := filepath.Join(checkout, "shared", "value.ts")
+  declarationFile := filepath.Join(checkout, "shared", "types.d.ts")
+
+  writeFile(t, config, portableDumpTSConfig)
+  writeFile(t, mainFile, `import { sibling } from "../../shared/value";
+import type { ExternalShape } from "../../shared/types";
+export function main(input: ExternalShape): number {
+  return sibling(input.value);
+}
+`)
+  writeFile(t, siblingFile, `export function sibling(value: number): number {
+  return value;
+}
+export const broken: number = "nope";
+`)
+  writeFile(t, declarationFile, `export interface ExternalShape {
+  value: number;
+}
+`)
+
+  prog, _, err := driver.LoadProgram(project, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer func() { _ = prog.Close() }()
+
+  built := Build(prog)
+  // An implementation span is the one evidence path that cannot be recovered
+  // from its owner node. Point one real node at the sibling source so this
+  // end-to-end projection proves that optional path uses the same mapper too.
+  for _, node := range built.Nodes {
+    if node.Kind == NodeFunction && node.Name == "main" {
+      node.ImplementationFile = siblingFile
+      node.ImplementationPos = 0
+      node.ImplementationEnd = len("export function sibling")
+      break
+    }
+  }
+
+  texts := SourceTexts(prog)
+  dump, err := NewDump(
+    built,
+    project,
+    "tsconfig.json",
+    nil,
+    texts,
+    DumpOrigin{
+      Provenance: NewProvenance(
+        Producer{Tool: "portable-fixture", Version: "test", Typescript: TypescriptVersion()},
+        []string{CapabilityUniverse, CapabilitySourceDigests, CapabilityDiagnostics},
+        []FileDigest{{File: config, Digest: "config-digest"}},
+        []RootFile{
+          {Config: config, File: mainFile},
+          {Config: config, File: siblingFile},
+          {Config: config, File: declarationFile},
+        },
+        texts,
+        nil,
+      ),
+      Diagnostics: NewDiagnostics(prog),
+    },
+  )
+  if err != nil {
+    t.Fatal(err)
+  }
+  return dump
+}
+
+func assertPortableFixturePaths(t *testing.T, dump Dump) {
+  t.Helper()
+  if dump.Tsconfig != "tsconfig.json" {
+    t.Fatalf("tsconfig coordinate = %q", dump.Tsconfig)
+  }
+
+  var internal, external, module, implemented bool
+  ids := map[string]bool{}
+  for _, node := range dump.Nodes {
+    ids[node.ID] = true
+    switch {
+    case node.Kind == string(NodeFunction) && node.Name == "sibling":
+      internal = node.File == "../shared/value.ts" && !node.External &&
+        strings.HasPrefix(node.ID, "../shared/value.ts#")
+    case node.Name == "ExternalShape":
+      external = node.File == "../shared/types.d.ts" && node.External &&
+        strings.HasPrefix(node.ID, "../shared/types.d.ts#")
+    case node.Kind == string(NodeModule) && node.File == "../shared/value.ts":
+      module = node.Name == "../shared/value.ts" &&
+        strings.Contains(node.ID, "#../shared/value.ts:module")
+    case node.Kind == string(NodeFunction) && node.Name == "main":
+      implemented = node.Implementation != nil && node.Implementation.File == "../shared/value.ts"
+    }
+  }
+  if !internal || !external || !module || !implemented {
+    t.Fatalf("portable node surfaces missing: internal=%t external=%t module=%t implementation=%t", internal, external, module, implemented)
+  }
+  for _, edge := range dump.Edges {
+    if !ids[edge.From] || !ids[edge.To] {
+      t.Fatalf("mapped edge endpoint is not a mapped node: %+v", edge)
+    }
+  }
+
+  diagnostic := false
+  for _, finding := range dump.Diagnostics {
+    if finding.Code == 2322 && finding.File == "../shared/value.ts" {
+      diagnostic = true
+    }
+  }
+  if !diagnostic {
+    t.Fatalf("sibling diagnostic did not use the shared coordinate: %+v", dump.Diagnostics)
+  }
+
+  source := false
+  for _, entry := range dump.Provenance.Sources {
+    if entry.File == "../shared/value.ts" {
+      source = true
+    }
+  }
+  if !source || len(dump.Provenance.Universe.Configs) != 1 ||
+    dump.Provenance.Universe.Configs[0].File != "tsconfig.json" {
+    t.Fatalf("manifest/config coordinates drifted: %+v", dump.Provenance)
+  }
+  roots := map[string]bool{}
+  for _, root := range dump.Provenance.Universe.Roots {
+    if root.Config != "tsconfig.json" {
+      t.Fatalf("root config coordinate = %q", root.Config)
+    }
+    roots[root.File] = true
+  }
+  for _, want := range []string{"src/main.ts", "../shared/value.ts", "../shared/types.d.ts"} {
+    if !roots[want] {
+      t.Fatalf("universe roots omit %q: %+v", want, dump.Provenance.Universe.Roots)
+    }
+  }
+}

--- a/packages/ttsc/internal/graph/dump_checkout_paths_are_stable_test.go
+++ b/packages/ttsc/internal/graph/dump_checkout_paths_are_stable_test.go
@@ -90,9 +90,23 @@ export const broken: number = "nope";
   // An implementation span is the one evidence path that cannot be recovered
   // from its owner node. Point one real node at the sibling source so this
   // end-to-end projection proves that optional path uses the same mapper too.
+  implementationFile := ""
+  for _, node := range built.Nodes {
+    if node.Kind == NodeFunction && node.Name == "sibling" {
+      implementationFile = node.File
+      break
+    }
+  }
+  if implementationFile == "" {
+    t.Fatal("fixture graph omitted sibling function")
+  }
   for _, node := range built.Nodes {
     if node.Kind == NodeFunction && node.Name == "main" {
-      node.ImplementationFile = siblingFile
+      // Use the compiler's canonical spelling rather than filepath.Join's host
+      // spelling. On Windows SourceTexts is keyed by tsgo-normalized slashes;
+      // injecting the fixture's backslash path would test a missing source-map
+      // lookup instead of the wire mapper.
+      node.ImplementationFile = implementationFile
       node.ImplementationPos = 0
       node.ImplementationEnd = len("export function sibling")
       break

--- a/packages/ttsc/internal/graph/dump_checkout_paths_are_stable_test.go
+++ b/packages/ttsc/internal/graph/dump_checkout_paths_are_stable_test.go
@@ -23,11 +23,11 @@ const portableDumpTSConfig = `{
 // TestDumpCheckoutPathsAreStable verifies the whole schema-v6 consequence
 // surface, not only the path helper.
 //
-//   1. Build the same project plus sibling .ts/.d.ts under two checkout roots.
-//   2. Remove only the producer-local Project locator and require byte identity.
-//   3. Assert nodes, module names, endpoints, implementation evidence,
-//      diagnostics, manifests, and universe inputs all use one `../shared`
-//      coordinate, with the .ts internal and the .d.ts an external leaf.
+//  1. Build the same project plus sibling .ts/.d.ts under two checkout roots.
+//  2. Remove only the producer-local Project locator and require byte identity.
+//  3. Assert nodes, module names, endpoints, implementation evidence,
+//     diagnostics, manifests, and universe inputs all use one `../shared`
+//     coordinate, with the .ts internal and the .d.ts an external leaf.
 func TestDumpCheckoutPathsAreStable(t *testing.T) {
   firstCheckout := filepath.Join(t.TempDir(), "checkout-one")
   secondCheckout := filepath.Join(t.TempDir(), "checkout-two")

--- a/packages/ttsc/internal/graph/dump_diagnostics_ride_the_generation_that_built_it_test.go
+++ b/packages/ttsc/internal/graph/dump_diagnostics_ride_the_generation_that_built_it_test.go
@@ -36,9 +36,12 @@ func TestDumpDiagnosticsRideTheGenerationThatBuiltIt(t *testing.T) {
   }
   defer func() { _ = prog.Close() }()
 
-  dump := NewDump(Build(prog), root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{
-    Diagnostics: NewDiagnostics(prog, root),
+  dump, err := NewDump(Build(prog), root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{
+    Diagnostics: NewDiagnostics(prog),
   })
+  if err != nil {
+    t.Fatal(err)
+  }
 
   var match *Diagnostic
   for i := range dump.Diagnostics {
@@ -69,7 +72,10 @@ func TestDumpDiagnosticsRideTheGenerationThatBuiltIt(t *testing.T) {
 
   // The negative twin: a caller that does not collect diagnostics publishes an
   // empty list, never a nil that would encode as JSON null.
-  quiet := NewDump(Build(prog), root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  quiet, err := NewDump(Build(prog), root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  if err != nil {
+    t.Fatal(err)
+  }
   if quiet.Diagnostics == nil {
     t.Fatal("an uncollected diagnostics list is nil, so it serializes as null rather than []")
   }

--- a/packages/ttsc/internal/graph/dump_paths.go
+++ b/packages/ttsc/internal/graph/dump_paths.go
@@ -1,0 +1,132 @@
+package graph
+
+import (
+  "fmt"
+  "strings"
+
+  shimtspath "github.com/microsoft/typescript-go/shim/tspath"
+)
+
+// dumpPathMapper owns the schema-v6 path vocabulary for one dump. Every
+// identity-bearing path passes through this one cache, so the producer can
+// reject both an unportable filesystem root and a non-injective projection
+// before any JSON is written.
+type dumpPathMapper struct {
+  project       string
+  caseSensitive bool
+
+  physicalToWire map[string]string
+  wireToPhysical map[string]string
+  mappingErr     error
+}
+
+func newDumpPathMapper(project string) *dumpPathMapper {
+  normalized := shimtspath.NormalizePath(shimtspath.NormalizeSlashes(project))
+  mapper := &dumpPathMapper{
+    project:        normalized,
+    caseSensitive:  dumpPathRootIsCaseSensitive(normalized),
+    physicalToWire: map[string]string{},
+    wireToPhysical: map[string]string{},
+  }
+  if normalized == "" || shimtspath.GetRootLength(normalized) == 0 {
+    mapper.mappingErr = fmt.Errorf("ttscgraph: project root %q is not absolute", project)
+  }
+  return mapper
+}
+
+// mapPath returns one portable, slash-normalized coordinate:
+//
+//   - project files stay project-relative;
+//   - same-root siblings use `../` segments, preserving workspace structure;
+//   - package paths keep their full resolution context instead of collapsing
+//     to the last node_modules tail;
+//   - compiler virtual paths keep their bundled identity.
+//
+// A source on another drive or UNC share has no portable coordinate relative
+// to the project. It records a precise error; NewDump returns that error before
+// a caller can serialize the partial projection.
+func (m *dumpPathMapper) mapPath(file string) string {
+  if file == "" {
+    return ""
+  }
+  normalized := shimtspath.NormalizeSlashes(file)
+  if strings.HasPrefix(normalized, "bundled:///") {
+    return m.claim(normalized, normalized)
+  }
+  normalized = shimtspath.NormalizePath(normalized)
+  if m.project == "" || shimtspath.GetRootLength(m.project) == 0 {
+    return normalized
+  }
+
+  physical := normalized
+  if shimtspath.GetRootLength(physical) == 0 {
+    physical = shimtspath.GetNormalizedAbsolutePath(physical, m.project)
+  }
+  options := shimtspath.ComparePathsOptions{
+    CurrentDirectory:          m.project,
+    UseCaseSensitiveFileNames: m.caseSensitive,
+  }
+  wire := shimtspath.GetRelativePathFromDirectory(m.project, physical, options)
+  if shimtspath.GetRootLength(wire) != 0 {
+    m.fail(fmt.Errorf(
+      "ttscgraph: source path %q cannot be represented relative to project %q because they are on different filesystem roots",
+      normalized,
+      m.project,
+    ))
+    return normalized
+  }
+  return m.claim(physical, wire)
+}
+
+// claim records both directions of the projection. The reverse map is the
+// injectivity gate: two distinct compiler sources may never acquire one wire
+// identity, even if a future coordinate rule is added incorrectly.
+func (m *dumpPathMapper) claim(physical, wire string) string {
+  key := physical
+  if !m.caseSensitive && !strings.HasPrefix(physical, "bundled:///") {
+    key = strings.ToLower(key)
+  }
+  if previous, ok := m.physicalToWire[key]; ok {
+    if previous != wire {
+      m.fail(fmt.Errorf(
+        "ttscgraph: source path %q mapped inconsistently to %q and %q",
+        physical,
+        previous,
+        wire,
+      ))
+    }
+    return previous
+  }
+  if previous, ok := m.wireToPhysical[wire]; ok && previous != key {
+    m.fail(fmt.Errorf(
+      "ttscgraph: source paths %q and %q collide at wire identity %q",
+      previous,
+      physical,
+      wire,
+    ))
+    return wire
+  }
+  m.physicalToWire[key] = wire
+  m.wireToPhysical[wire] = key
+  return wire
+}
+
+func (m *dumpPathMapper) fail(err error) {
+  if m.mappingErr == nil {
+    m.mappingErr = err
+  }
+}
+
+func (m *dumpPathMapper) err() error { return m.mappingErr }
+
+// Windows drive and UNC roots use case-insensitive path comparison. POSIX
+// roots remain case-sensitive. This decision follows the path's own grammar so
+// synthetic Windows/UNC fixtures behave the same on every CI host.
+func dumpPathRootIsCaseSensitive(path string) bool {
+  rootLength := shimtspath.GetRootLength(path)
+  if rootLength == 0 {
+    return true
+  }
+  root := path[:rootLength]
+  return !(strings.HasPrefix(root, "//") || (len(root) >= 2 && root[1] == ':'))
+}

--- a/packages/ttsc/internal/graph/dump_paths.go
+++ b/packages/ttsc/internal/graph/dump_paths.go
@@ -62,6 +62,14 @@ func (m *dumpPathMapper) mapPath(file string) string {
   if shimtspath.GetRootLength(physical) == 0 {
     physical = shimtspath.GetNormalizedAbsolutePath(physical, m.project)
   }
+  if !dumpPathRootsEqual(m.project, physical, m.caseSensitive) {
+    m.fail(fmt.Errorf(
+      "ttscgraph: source path %q cannot be represented relative to project %q because they are on different filesystem roots",
+      normalized,
+      m.project,
+    ))
+    return normalized
+  }
   options := shimtspath.ComparePathsOptions{
     CurrentDirectory:          m.project,
     UseCaseSensitiveFileNames: m.caseSensitive,
@@ -129,4 +137,36 @@ func dumpPathRootIsCaseSensitive(path string) bool {
   }
   root := path[:rootLength]
   return !(strings.HasPrefix(root, "//") || (len(root) >= 2 && root[1] == ':'))
+}
+
+// dumpPathRootsEqual compares filesystem roots before asking tspath for a
+// relative coordinate. tspath models a UNC root as `//server/`, which is useful
+// for URL-like path operations but too broad for a filesystem identity: on
+// Windows, `//server/share-a` and `//server/share-b` are different volumes and
+// no `../share-b` coordinate can cross between them. Include the share component
+// for that one grammar and keep tspath's roots for drive and POSIX paths.
+func dumpPathRootsEqual(left, right string, caseSensitive bool) bool {
+  leftRoot := dumpFilesystemRoot(left)
+  rightRoot := dumpFilesystemRoot(right)
+  if caseSensitive {
+    return leftRoot == rightRoot
+  }
+  return strings.EqualFold(leftRoot, rightRoot)
+}
+
+func dumpFilesystemRoot(path string) string {
+  normalized := shimtspath.NormalizeSlashes(path)
+  rootLength := shimtspath.GetRootLength(normalized)
+  if rootLength == 0 {
+    return ""
+  }
+  root := normalized[:rootLength]
+  if !strings.HasPrefix(root, "//") {
+    return root
+  }
+  remainder := normalized[rootLength:]
+  if slash := strings.IndexByte(remainder, '/'); slash >= 0 {
+    return root + remainder[:slash]
+  }
+  return root + remainder
 }

--- a/packages/ttsc/internal/graph/dump_paths_are_portable_and_injective_test.go
+++ b/packages/ttsc/internal/graph/dump_paths_are_portable_and_injective_test.go
@@ -8,9 +8,9 @@ import (
 // TestDumpPathMapperUsesPortableCoordinates verifies the schema-v6 vocabulary
 // directly, independent of the host OS running the test.
 //
-//   1. Map in-project and sibling paths for POSIX, drive, and UNC layouts.
-//   2. Keep two pnpm version/peer contexts with the same package subpath apart.
-//   3. Preserve compiler virtual identities exactly.
+//  1. Map in-project and sibling paths for POSIX, drive, and UNC layouts.
+//  2. Keep two pnpm version/peer contexts with the same package subpath apart.
+//  3. Preserve compiler virtual identities exactly.
 func TestDumpPathMapperUsesPortableCoordinates(t *testing.T) {
   tests := []struct {
     name    string
@@ -54,9 +54,9 @@ func TestDumpPathMapperUsesPortableCoordinates(t *testing.T) {
 // TestDumpPathMapperRejectsUnportableRootsAndCollisions pins both fail-closed
 // boundaries of the mapping contract.
 //
-//   1. Reject a different Windows drive and a different UNC share precisely.
-//   2. Force two physical sources through one coordinate and require a collision.
-//   3. Require NewDump to surface the root error before JSON serialization.
+//  1. Reject a different Windows drive and a different UNC share precisely.
+//  2. Force two physical sources through one coordinate and require a collision.
+//  3. Require NewDump to surface the root error before JSON serialization.
 func TestDumpPathMapperRejectsUnportableRootsAndCollisions(t *testing.T) {
   for _, test := range []struct {
     name    string

--- a/packages/ttsc/internal/graph/dump_paths_are_portable_and_injective_test.go
+++ b/packages/ttsc/internal/graph/dump_paths_are_portable_and_injective_test.go
@@ -1,0 +1,93 @@
+package graph
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestDumpPathMapperUsesPortableCoordinates verifies the schema-v6 vocabulary
+// directly, independent of the host OS running the test.
+//
+//   1. Map in-project and sibling paths for POSIX, drive, and UNC layouts.
+//   2. Keep two pnpm version/peer contexts with the same package subpath apart.
+//   3. Preserve compiler virtual identities exactly.
+func TestDumpPathMapperUsesPortableCoordinates(t *testing.T) {
+  tests := []struct {
+    name    string
+    project string
+    file    string
+    want    string
+  }{
+    {"posix-project", "/checkout/app", "/checkout/app/src/main.ts", "src/main.ts"},
+    {"posix-sibling", "/checkout/app", "/checkout/shared/src/value.ts", "../shared/src/value.ts"},
+    {"windows-project", `C:\checkout\app`, `C:\checkout\app\src\main.ts`, "src/main.ts"},
+    {"windows-sibling", `C:\checkout\app`, `C:\checkout\shared\src\value.ts`, "../shared/src/value.ts"},
+    {"unc-project", `\\server\share\checkout\app`, `\\server\share\checkout\app\src\main.ts`, "src/main.ts"},
+    {"unc-sibling", `\\server\share\checkout\app`, `\\server\share\checkout\shared\src\value.ts`, "../shared/src/value.ts"},
+    {
+      "pnpm-peer-a",
+      "/checkout/app",
+      "/checkout/app/node_modules/.pnpm/pkg@1.0.0_peer-a/node_modules/pkg/index.d.ts",
+      "node_modules/.pnpm/pkg@1.0.0_peer-a/node_modules/pkg/index.d.ts",
+    },
+    {
+      "pnpm-peer-b",
+      "/checkout/app",
+      "/checkout/app/node_modules/.pnpm/pkg@2.0.0_peer-b/node_modules/pkg/index.d.ts",
+      "node_modules/.pnpm/pkg@2.0.0_peer-b/node_modules/pkg/index.d.ts",
+    },
+    {"bundled", "/checkout/app", "bundled:///lib.es2024.d.ts", "bundled:///lib.es2024.d.ts"},
+  }
+  for _, test := range tests {
+    t.Run(test.name, func(t *testing.T) {
+      mapper := newDumpPathMapper(test.project)
+      if got := mapper.mapPath(test.file); got != test.want {
+        t.Fatalf("mapPath(%q) = %q, want %q", test.file, got, test.want)
+      }
+      if err := mapper.err(); err != nil {
+        t.Fatalf("mapPath(%q): %v", test.file, err)
+      }
+    })
+  }
+}
+
+// TestDumpPathMapperRejectsUnportableRootsAndCollisions pins both fail-closed
+// boundaries of the mapping contract.
+//
+//   1. Reject a different Windows drive and a different UNC share precisely.
+//   2. Force two physical sources through one coordinate and require a collision.
+//   3. Require NewDump to surface the root error before JSON serialization.
+func TestDumpPathMapperRejectsUnportableRootsAndCollisions(t *testing.T) {
+  for _, test := range []struct {
+    name    string
+    project string
+    file    string
+  }{
+    {"windows-drive", "C:/checkout/app", "D:/shared/value.ts"},
+    {"unc-share", "//server/share-a/app", "//server/share-b/value.ts"},
+  } {
+    t.Run(test.name, func(t *testing.T) {
+      mapper := newDumpPathMapper(test.project)
+      mapper.mapPath(test.file)
+      if err := mapper.err(); err == nil || !strings.Contains(err.Error(), "different filesystem roots") {
+        t.Fatalf("cross-root error = %v, want a precise filesystem-root rejection", err)
+      }
+    })
+  }
+
+  collision := newDumpPathMapper("/checkout/app")
+  collision.claim("/physical/one.ts", "shared.ts")
+  collision.claim("/physical/two.ts", "shared.ts")
+  if err := collision.err(); err == nil || !strings.Contains(err.Error(), "collide at wire identity") {
+    t.Fatalf("collision error = %v, want an injectivity rejection", err)
+  }
+
+  file := "D:/shared/value.ts"
+  id := nodeID(file, "value", NodeVariable)
+  _, err := NewDump(&Graph{Nodes: map[string]*Node{
+    id: &Node{ID: id, Name: "value", Simple: "value", Kind: NodeVariable, File: file},
+  }}, "C:/checkout/app", "tsconfig.json", nil, nil, DumpOrigin{})
+  if err == nil || !strings.Contains(err.Error(), "different filesystem roots") {
+    t.Fatalf("NewDump cross-root error = %v, want rejection before serialization", err)
+  }
+}

--- a/packages/ttsc/internal/graph/duplicate_variable_object_members_keep_first_declaration_test.go
+++ b/packages/ttsc/internal/graph/duplicate_variable_object_members_keep_first_declaration_test.go
@@ -44,7 +44,10 @@ export var duplicate = { second: 2 };
     t.Fatalf("first declaration members were overwritten: %+v", node.ObjectMembers)
   }
 
-  dump := NewDump(graph, root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  dump, err := NewDump(graph, root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  if err != nil {
+    t.Fatal(err)
+  }
   for _, dumped := range dump.Nodes {
     if dumped.ID != "src/main.ts#duplicate:variable" {
       continue

--- a/packages/ttsc/internal/graph/node_modifiers_emit_union_strings_test.go
+++ b/packages/ttsc/internal/graph/node_modifiers_emit_union_strings_test.go
@@ -47,7 +47,10 @@ export const enum Mode {
   defer func() { _ = prog.Close() }()
 
   g := Build(prog)
-  dump := NewDump(g, root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  dump, err := NewDump(g, root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  if err != nil {
+    t.Fatal(err)
+  }
 
   byID := make(map[string]DumpNode, len(dump.Nodes))
   for _, n := range dump.Nodes {

--- a/packages/ttsc/internal/graph/object_literal_members_ride_on_the_snapshot_test.go
+++ b/packages/ttsc/internal/graph/object_literal_members_ride_on_the_snapshot_test.go
@@ -121,7 +121,10 @@ export const shape = (({
     }
   }
 
-  dump := NewDump(graph, root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  dump, err := NewDump(graph, root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  if err != nil {
+    t.Fatal(err)
+  }
   var dumped *DumpNode
   for i := range dump.Nodes {
     if dump.Nodes[i].ID == "src/main.ts#shape:variable" {

--- a/packages/ttsc/internal/graph/object_member_signatures_preserve_literal_whitespace_test.go
+++ b/packages/ttsc/internal/graph/object_member_signatures_preserve_literal_whitespace_test.go
@@ -40,7 +40,10 @@ func TestObjectMemberSignaturesPreserveLiteralWhitespace(t *testing.T) {
   defer func() { _ = prog.Close() }()
 
   graph := Build(prog)
-  dump := NewDump(graph, root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  dump, err := NewDump(graph, root, "tsconfig.json", nil, SourceTexts(prog), DumpOrigin{})
+  if err != nil {
+    t.Fatal(err)
+  }
   signatures := map[string]string{}
   for _, node := range dump.Nodes {
     if node.ID != "src/main.ts#shape:variable" {

--- a/packages/ttsc/internal/graph/provenance.go
+++ b/packages/ttsc/internal/graph/provenance.go
@@ -14,7 +14,7 @@ import (
 // field is added, removed, or given a new meaning, independently of the serve
 // envelope's protocol version: a one-shot `ttscgraph dump` written to a file has
 // a schema but never rode the protocol.
-const DumpSchemaVersion = 5
+const DumpSchemaVersion = 6
 
 // The capabilities a snapshot can declare. Each names one class of evidence a
 // consumer may rely on when, and only when, the snapshot lists it.
@@ -119,16 +119,16 @@ type Universe struct {
 // references mean two configs can name the same file, and they are not the same
 // input, so the pair is the unit rather than the bare path.
 type RootFile struct {
-  // Config is the tsconfig that named this root, project-relative.
+  // Config is the tsconfig that named this root, in the dump's path vocabulary.
   Config string `json:"config"`
 
-  // File is the root file, project-relative.
+  // File is the root file, in the dump's path vocabulary.
   File string `json:"file"`
 }
 
 // FileDigest pairs a file with the SHA-256 of its bytes, hex-encoded.
 type FileDigest struct {
-  // File is project-relative.
+  // File uses the dump's path vocabulary.
   File string `json:"file"`
 
   // Digest is the hex-encoded SHA-256 of the file's on-disk bytes.
@@ -159,7 +159,7 @@ type FileDigest struct {
 // Both are digests. Neither is text: the wire never carries a file's bytes, and
 // the field names say digest so that stays true by reading.
 type SourceDigest struct {
-  // File is project-relative.
+  // File uses the dump's path vocabulary.
   File string `json:"file"`
 
   // Checker is the hex-encoded SHA-256 of the text the checker resolved
@@ -180,7 +180,7 @@ type SourceDigest struct {
 // Diagnostic is one compiler diagnostic riding the snapshot that produced the
 // facts. Positions are 1-based, matching what tsgo reports.
 type Diagnostic struct {
-  // File is project-relative.
+  // File uses the dump's path vocabulary.
   File string `json:"file"`
 
   // Line is the 1-based line.
@@ -207,13 +207,14 @@ func Digest(sum [sha256.Size]byte) string { return hex.EncodeToString(sum[:]) }
 // implements.
 func TypescriptVersion() string { return shimcore.Version() }
 
-// NewProvenance assembles the evidence for a snapshot. project relativizes every
-// path; texts maps a source file's absolute path to the text the checker read
-// (as SourceTexts returns it); disk maps a source file's absolute path to the
-// hex digest of its on-disk bytes, and a path absent from it is reported with an
-// empty Disk. configs and roots come from the same capture that produced texts.
+// NewProvenance assembles the evidence for a snapshot while retaining the
+// compiler's physical paths. NewDump projects those paths together with every
+// node, edge, span, and diagnostic through its one cached schema-v6 mapper.
+// texts maps a source file's path to the text the checker read (as SourceTexts
+// returns it); disk maps that path to the hex digest of its on-disk bytes, and
+// a path absent from it is reported with an empty Disk. configs and roots come
+// from the same capture that produced texts.
 func NewProvenance(
-  project string,
   producer Producer,
   capabilities []string,
   configs []FileDigest,
@@ -221,32 +222,31 @@ func NewProvenance(
   texts map[string]string,
   disk map[string]string,
 ) Provenance {
-  ctx := newDumpContext(project, nil)
   sources := make([]SourceDigest, 0, len(texts))
   for path, text := range texts {
     sources = append(sources, SourceDigest{
-      File:    ctx.rel(path),
+      File:    path,
       Checker: Digest(sha256.Sum256([]byte(text))),
       Disk:    disk[path],
     })
   }
   sort.Slice(sources, func(i, j int) bool { return sources[i].File < sources[j].File })
 
-  relConfigs := make([]FileDigest, 0, len(configs))
+  capturedConfigs := make([]FileDigest, 0, len(configs))
   for _, config := range configs {
-    relConfigs = append(relConfigs, FileDigest{File: ctx.rel(config.File), Digest: config.Digest})
+    capturedConfigs = append(capturedConfigs, FileDigest{File: config.File, Digest: config.Digest})
   }
-  sort.Slice(relConfigs, func(i, j int) bool { return relConfigs[i].File < relConfigs[j].File })
+  sort.Slice(capturedConfigs, func(i, j int) bool { return capturedConfigs[i].File < capturedConfigs[j].File })
 
-  relRoots := make([]RootFile, 0, len(roots))
+  capturedRoots := make([]RootFile, 0, len(roots))
   for _, root := range roots {
-    relRoots = append(relRoots, RootFile{Config: ctx.rel(root.Config), File: ctx.rel(root.File)})
+    capturedRoots = append(capturedRoots, RootFile{Config: root.Config, File: root.File})
   }
-  sort.Slice(relRoots, func(i, j int) bool {
-    if relRoots[i].Config != relRoots[j].Config {
-      return relRoots[i].Config < relRoots[j].Config
+  sort.Slice(capturedRoots, func(i, j int) bool {
+    if capturedRoots[i].Config != capturedRoots[j].Config {
+      return capturedRoots[i].Config < capturedRoots[j].Config
     }
-    return relRoots[i].File < relRoots[j].File
+    return capturedRoots[i].File < capturedRoots[j].File
   })
 
   // Copy before sorting: the caller's slice is a shared package-level constant,
@@ -259,32 +259,90 @@ func NewProvenance(
     SchemaVersion: DumpSchemaVersion,
     Capabilities:  declared,
     Producer:      producer,
-    Universe:      Universe{Configs: relConfigs, Roots: relRoots},
+    Universe:      Universe{Configs: capturedConfigs, Roots: capturedRoots},
     Sources:       sources,
   }
 }
 
-// NewDiagnostics projects the resident program's compiler diagnostics onto the
-// wire shape, relativized against project and ordered by file, line, column,
-// then code so a snapshot is byte-stable.
+// NewDiagnostics projects the resident program's compiler diagnostics while
+// retaining physical file identities. NewDump maps and re-sorts them with the
+// rest of the snapshot so every path uses one vocabulary.
 //
 // This is one Program.Diagnostics() call over the already-warm checker rather
 // than a second compile, but it is not free: it forces the semantic check of
 // every file the graph would otherwise only have bound. Callers that do not
 // publish diagnostics should not call it.
-func NewDiagnostics(prog *driver.Program, project string) []Diagnostic {
-  ctx := newDumpContext(project, nil)
+func NewDiagnostics(prog *driver.Program) []Diagnostic {
   raw := prog.Diagnostics()
   out := make([]Diagnostic, 0, len(raw))
   for _, diagnostic := range raw {
     out = append(out, Diagnostic{
-      File:     ctx.rel(diagnostic.File),
+      File:     diagnostic.File,
       Line:     diagnostic.Line,
       Column:   diagnostic.Column,
       Code:     int(diagnostic.Code),
       Category: diagnosticCategory(diagnostic.Severity),
       Message:  diagnostic.Message,
     })
+  }
+  sort.Slice(out, func(i, j int) bool {
+    if out[i].File != out[j].File {
+      return out[i].File < out[j].File
+    }
+    if out[i].Line != out[j].Line {
+      return out[i].Line < out[j].Line
+    }
+    if out[i].Column != out[j].Column {
+      return out[i].Column < out[j].Column
+    }
+    return out[i].Code < out[j].Code
+  })
+  return out
+}
+
+// provenance maps every path-bearing provenance field through the dump's one
+// mapper and sorts on the resulting wire identity.
+func (c *dumpContext) provenance(value Provenance) Provenance {
+  sources := make([]SourceDigest, 0, len(value.Sources))
+  for _, source := range value.Sources {
+    sources = append(sources, SourceDigest{
+      File:    c.rel(source.File),
+      Checker: source.Checker,
+      Disk:    source.Disk,
+    })
+  }
+  sort.Slice(sources, func(i, j int) bool { return sources[i].File < sources[j].File })
+
+  configs := make([]FileDigest, 0, len(value.Universe.Configs))
+  for _, config := range value.Universe.Configs {
+    configs = append(configs, FileDigest{File: c.rel(config.File), Digest: config.Digest})
+  }
+  sort.Slice(configs, func(i, j int) bool { return configs[i].File < configs[j].File })
+
+  roots := make([]RootFile, 0, len(value.Universe.Roots))
+  for _, root := range value.Universe.Roots {
+    roots = append(roots, RootFile{Config: c.rel(root.Config), File: c.rel(root.File)})
+  }
+  sort.Slice(roots, func(i, j int) bool {
+    if roots[i].Config != roots[j].Config {
+      return roots[i].Config < roots[j].Config
+    }
+    return roots[i].File < roots[j].File
+  })
+
+  value.Capabilities = append([]string{}, value.Capabilities...)
+  value.Sources = sources
+  value.Universe = Universe{Configs: configs, Roots: roots}
+  return value
+}
+
+// diagnostics maps and orders compiler findings after they join the dump, not
+// in their constructor, so they cannot drift onto a second path vocabulary.
+func (c *dumpContext) diagnostics(values []Diagnostic) []Diagnostic {
+  out := make([]Diagnostic, 0, len(values))
+  for _, diagnostic := range values {
+    diagnostic.File = c.rel(diagnostic.File)
+    out = append(out, diagnostic)
   }
   sort.Slice(out, func(i, j int) bool {
     if out[i].File != out[j].File {

--- a/scripts/assert-ttscgraph-release-candidate.cjs
+++ b/scripts/assert-ttscgraph-release-candidate.cjs
@@ -1,0 +1,135 @@
+// Exercise the packaged Linux ttscgraph binary before a release can publish.
+// The ordinary build workflow runs this while the candidate is still a pull
+// request; the tag workflow repeats it after the release build and before the
+// first Marketplace or npm side effect.
+
+const cp = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const binary = path.join(
+  root,
+  "packages",
+  "ttsc-linux-x64",
+  "bin",
+  "ttscgraph",
+);
+const version = require(path.join(root, "package.json")).version;
+
+if (!fs.existsSync(binary)) {
+  throw new Error(`ttscgraph release smoke: binary does not exist: ${binary}`);
+}
+
+const reported = run(["--version"]).stdout.trim();
+if (!reported.includes(version) || reported.includes("0.0.0-dev")) {
+  throw new Error(
+    `ttscgraph release smoke: ${JSON.stringify(reported)} does not carry release version ${version}`,
+  );
+}
+
+const workspace = fs.mkdtempSync(
+  path.join(os.tmpdir(), "ttscgraph-release-candidate-"),
+);
+try {
+  const project = path.join(workspace, "app");
+  const source = path.join(project, "src", "main.ts");
+  const outside = path.join(workspace, "shared", "types.d.ts");
+  fs.mkdirSync(path.dirname(source), { recursive: true });
+  fs.mkdirSync(path.dirname(outside), { recursive: true });
+  fs.writeFileSync(
+    path.join(project, "tsconfig.json"),
+    `${JSON.stringify(
+      {
+        compilerOptions: { noEmit: true, strict: true, target: "ES2022" },
+        files: ["src/main.ts", "../shared/types.d.ts"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  fs.writeFileSync(
+    source,
+    'import type { ExternalShape } from "../../shared/types";\n' +
+      "export const value: ExternalShape = { count: 1 };\n",
+  );
+  fs.writeFileSync(
+    outside,
+    "export interface ExternalShape { count: number; }\n",
+  );
+
+  const dumped = run([
+    "dump",
+    "--cwd",
+    project,
+    "--tsconfig",
+    "tsconfig.json",
+  ]).stdout;
+  const graph = JSON.parse(dumped);
+  if (graph.provenance?.schemaVersion !== 6) {
+    throw new Error(
+      `ttscgraph release smoke: dump schema is ${JSON.stringify(graph.provenance?.schemaVersion)}, want 6`,
+    );
+  }
+  if (graph.tsconfig !== "tsconfig.json") {
+    throw new Error(
+      `ttscgraph release smoke: tsconfig coordinate is ${JSON.stringify(graph.tsconfig)}`,
+    );
+  }
+
+  const sources = graph.provenance?.sources ?? [];
+  if (!sources.some((entry) => entry.file === "../shared/types.d.ts")) {
+    throw new Error(
+      "ttscgraph release smoke: outside declaration is absent from the portable source manifest",
+    );
+  }
+  if (!sources.some((entry) => entry.file.startsWith("bundled:///"))) {
+    throw new Error(
+      "ttscgraph release smoke: bundled compiler source is absent from the source manifest",
+    );
+  }
+  if (
+    !graph.nodes.some(
+      (node) =>
+        node.file === "../shared/types.d.ts" &&
+        node.name === "ExternalShape" &&
+        node.external === true,
+    )
+  ) {
+    throw new Error(
+      "ttscgraph release smoke: outside declaration did not retain its external portable identity",
+    );
+  }
+
+  const portable = { ...graph, project: "" };
+  const serialized = JSON.stringify(portable);
+  const checkout = workspace.replaceAll("\\", "/");
+  if (serialized.includes(workspace) || serialized.includes(checkout)) {
+    throw new Error(
+      "ttscgraph release smoke: producer-local checkout path escaped outside the project locator",
+    );
+  }
+} finally {
+  fs.rmSync(workspace, { recursive: true, force: true });
+}
+
+console.log(
+  `ttscgraph release smoke: schema v6 portable manifest passed for ${version}`,
+);
+
+function run(args) {
+  const result = cp.spawnSync(binary, args, {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 256 * 1024 * 1024,
+    windowsHide: true,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `ttscgraph release smoke: ${args.join(" ")} exited with ${result.status}: ${(result.stderr ?? "").trim()}`,
+    );
+  }
+  return result;
+}

--- a/tests/test-graph/src/features/test_ttscgraph_rejects_schema_v5_snapshot.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_rejects_schema_v5_snapshot.ts
@@ -1,0 +1,30 @@
+import { createNativeSessionFixture } from "../internal/nativeSession";
+import { assert } from "../internal/ttsgraph";
+
+/**
+ * Verifies the schema-v6 consumer refuses the prior path vocabulary precisely.
+ *
+ * Schema v5 can carry checkout-local absolute sibling paths and collapsed
+ * package tails, so accepting it as v6 would reintroduce ambiguous identity at
+ * the client boundary. The body version is checked separately from the serve
+ * envelope version and must name both sides of the mismatch.
+ *
+ * 1. Serve an otherwise valid protocol-v1 snapshot whose dump says schema 5.
+ * 2. Request the resident graph.
+ * 3. Require an explicit producer-v5/client-v6 error.
+ */
+export const test_ttscgraph_rejects_schema_v5_snapshot = async () => {
+  const { session } = createNativeSessionFixture({
+    mode: "respond",
+    requestTimeoutMs: 5_000,
+    schemaVersion: 5,
+  });
+  try {
+    await assert.rejects(
+      session.graph(),
+      /ttscgraph sends dump schema v5, this client reads v6/,
+    );
+  } finally {
+    session.close();
+  }
+};

--- a/tests/test-graph/src/features/test_ttscgraph_source_reader_enforces_snapshot_identity_once.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_source_reader_enforces_snapshot_identity_once.ts
@@ -87,6 +87,35 @@ export const test_ttscgraph_source_reader_enforces_snapshot_identity_once =
     assert.equal(stableReads, 1, "a successful file is read once per snapshot");
     assert.ok(Object.isFrozen(first), "cached source lines are immutable");
 
+    const sibling = "export const sibling = true;\n";
+    let siblingPath = "";
+    const siblingReader = new Reader(
+      "/checkout/app",
+      {
+        capabilities: ["sourceDigests", "diskDigests"],
+        sources: [
+          {
+            file: "../shared/sibling.ts",
+            checkerDigest: digest(sibling),
+            diskDigest: digest(Buffer.from(sibling, "utf8")),
+          },
+        ],
+      },
+      (file) => {
+        siblingPath = file;
+        return Buffer.from(sibling, "utf8");
+      },
+    );
+    assert.deepEqual(siblingReader.lines("../shared/sibling.ts"), [
+      "export const sibling = true;",
+      "",
+    ]);
+    assert.equal(
+      siblingPath,
+      path.resolve("/checkout/app", "../shared/sibling.ts"),
+      "schema-v6 sibling coordinates resolve against the project locator",
+    );
+
     const before = "export const before = 1;\n";
     let current = "export const after = 2;\n";
     let mutationReads = 0;

--- a/tests/test-graph/src/internal/nativeSession.ts
+++ b/tests/test-graph/src/internal/nativeSession.ts
@@ -3,7 +3,7 @@ import { TestProject } from "@ttsc/testing";
 import fs from "node:fs";
 import path from "node:path";
 
-const DUMP_SCHEMA_VERSION = 5;
+const DUMP_SCHEMA_VERSION = 6;
 let fakeBinary: string | undefined;
 
 export interface NativeSessionFixture {
@@ -16,6 +16,7 @@ export function createNativeSessionFixture(options: {
   requestTimeoutMs: number;
   stderr?: string;
   delayMs?: number;
+  schemaVersion?: number;
 }): NativeSessionFixture {
   const root = TestProject.tmpdir("ttscgraph-native-session-");
   fs.writeFileSync(
@@ -24,7 +25,7 @@ export function createNativeSessionFixture(options: {
       mode: options.mode,
       stderr: options.stderr ?? "",
       delayMs: options.delayMs ?? 0,
-      schemaVersion: DUMP_SCHEMA_VERSION,
+      schemaVersion: options.schemaVersion ?? DUMP_SCHEMA_VERSION,
     }),
     "utf8",
   );

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -68,6 +68,8 @@ A text search or a tree-sitter parse stops where the syntax stops. A real type c
 
 Source-derived display text is fail-closed. The snapshot manifest covers every source the checker loaded, including outside `.d.ts` boundary leaves and virtual compiler libraries. The server reuses a disk file only when its raw bytes match the disk snapshot and its compiler-decoded text matches the checker snapshot, so UTF-8 BOM and UTF-16 sources keep their display facts without mixing live-disk content into older graph facts. Its line slicing follows the compiler's ECMAScript LF, CRLF, CR, LS, and PS model, so signatures and JSDoc keep the same coordinates under every valid source spelling. A missing digest, read failure, or mismatch omits the optional text.
 
+Graph identities are portable across checkout directories. Project files remain project-relative; sibling and project-reference files use the same `../` coordinate everywhere; package declarations retain their complete resolution path, including pnpm version and peer-context segments; and compiler libraries retain `bundled:///...`. The producer applies this one mapping to nodes, edges, evidence, diagnostics, and provenance, and refuses a cross-drive source or any identity collision before it writes a snapshot.
+
 ## Get started
 
 Install, connect an agent, and where to read next.

--- a/website/src/content/docs/graph/viewer.mdx
+++ b/website/src/content/docs/graph/viewer.mdx
@@ -36,7 +36,7 @@ npx @ttsc/graph dump --tsconfig tsconfig.json > graph.json
 
 `dump` prints the whole graph as JSON: every node and edge the build resolved, with none of the per-response caps the MCP tool applies. It is the same export the MCP server loads at startup, so what you dump is exactly what the agent queries.
 
-That file is what "Load your own JSON" above accepts. The viewer reduces it client-side before rendering (the exact reduction is in [What is left out](#what-is-left-out)) so a large project stays legible. Current dumps keep their project-relative file structure; legacy dumps that contain absolute paths are rerooted at their shared source directory. The viewer also takes an already-reduced payload, so a graph you trimmed yourself loads as-is.
+That file is what "Load your own JSON" above accepts. The viewer reduces it client-side before rendering (the exact reduction is in [What is left out](#what-is-left-out)) so a large project stays legible. Current dumps preserve their portable project and sibling-relative structure; legacy payloads passed directly to the reducer that contain absolute paths are rerooted at their shared source directory. The viewer also takes an already-reduced payload, so a graph you trimmed yourself loads as-is.
 
 ## Reading the graph
 


### PR DESCRIPTION
## Intent

Cycle 8 of the 2026-07-21 campaign implements #783 by replacing checkout-local and tail-collapsing graph identities with one producer-owned schema-v6 path vocabulary. It also completes the remaining reversible #782 gate by exercising that schema from the packaged release candidate before any publication authority is used.

## What this changes

- Adds one cached dump-path mapper for node IDs/files/module names, edge endpoints, evidence, diagnostics, source manifests, universe configs/roots, and the tsconfig locator.
- Keeps project files relative, represents same-root sibling/project-reference files with stable `../` coordinates, preserves complete package resolution context, and leaves `bundled:///` identities unchanged.
- Rejects cross-drive/share paths and non-injective mappings before serialization instead of publishing raw absolute or colliding identities.
- Moves physical provenance and diagnostic paths through the same final mapper, bumps the Go/TypeScript dump contract to schema 6, and improves consumer mismatch diagnostics and documentation.
- Keeps resident sessions truthful after a dump-time path rejection: the failed generation remains pending and is retried or rebuilt after input changes instead of being reported as unchanged.
- Runs the built, release-versioned Linux `ttscgraph` against an outside `.d.ts` plus bundled compiler sources in ordinary PR CI, then repeats the same schema-v6/path smoke in the tag workflow before Marketplace or npm publication.

## Verification

- Adds host-independent POSIX, Windows-drive, UNC, package-context, bundled, cross-root, and collision tests for the mapper.
- Builds identical sibling `.ts`/`.d.ts` fixtures under two checkout roots and compares every identity-bearing dump surface after excluding only the producer-local project locator.
- Adds serve-session recovery regressions and a TypeScript client rejection test for schema-v5 snapshots.
- The release-candidate smoke asserts the binary version, schema 6, outside-source manifest and external node identity, bundled manifest coverage, and absence of the producer checkout outside `project`.
- `.vscode/gofmt-2spaces.sh` completed on every touched Go file, Prettier reports every touched TypeScript/MDX/workflow/script file formatted, `node --check` accepts the smoke script, and `git diff --check origin/master...HEAD` passes.
- The protected `ITtscGraphApplication.ts` remains byte-identical at SHA-256 `6AB7451FCD17E8A8C1F0F7BAEAA6A96AA4E6DEDCB379F70F030ECEE64197BE6C`.
- Per the maintainer campaign directive, no local build/test was run on this resource-constrained machine; ordinary GitHub Actions is the build, test, artifact-smoke, and format gate.

Closes #783.
Related #782.