### PR TITLE
fix: preserve package and filesystem boundary semantics

### DIFF
--- a/packages/paths/driver/paths.go
+++ b/packages/paths/driver/paths.go
@@ -33,13 +33,14 @@ func (plugin) ApplyProgram(prog *driver.Program, _ driver.PluginContext) error {
 // rewriter holds the resolved tsconfig paths configuration used to rewrite
 // module specifiers across an entire program.
 type rewriter struct {
-  checker     *shimchecker.Checker
-  basePath    string
-  jsxPreserve bool
-  outDir      string
-  patterns    []pathPattern
-  rootDir     string
-  sourceFiles map[string]string // normalized source path → same path (used as a set)
+  checker           *shimchecker.Checker
+  basePath          string
+  canonicalFileName func(string) string
+  jsxPreserve       bool
+  outDir            string
+  patterns          []pathPattern
+  rootDir           string
+  sourceFiles       map[string]string // canonical source path → original normalized path
 }
 
 // pathPattern is a single tsconfig paths entry with its wildcard pattern and
@@ -58,7 +59,13 @@ var sourceLookupExtensions = []string{
 // Patterns are sorted by decreasing specificity (longer literal prefix first)
 // so the most-specific match wins on overlapping patterns.
 func newRewriter(prog *driver.Program) *rewriter {
-  out := &rewriter{sourceFiles: map[string]string{}}
+  caseSensitive := useCaseSensitiveFileNames(prog)
+  out := &rewriter{
+    canonicalFileName: func(name string) string {
+      return shimtspath.GetCanonicalFileName(name, caseSensitive)
+    },
+    sourceFiles: map[string]string{},
+  }
   if prog == nil || prog.ParsedConfig == nil || prog.ParsedConfig.ParsedConfig == nil || prog.ParsedConfig.ParsedConfig.CompilerOptions == nil {
     return out
   }
@@ -78,7 +85,7 @@ func newRewriter(prog *driver.Program) *rewriter {
     out.rootDir = inferredRootDir(options.ConfigFilePath, fileNames, cwd, useCaseSensitiveFileNames(prog))
   }
   for _, name := range fileNames {
-    out.sourceFiles[name] = name
+    out.sourceFiles[out.sourceKey(name)] = name
   }
   if options.Paths != nil {
     for key, targets := range options.Paths.Entries() {
@@ -255,21 +262,33 @@ func (r *rewriter) resolveSource(specifier string) (string, bool) {
 // extension) corresponds to a known source file. It tries the exact path, stem
 // with each known TypeScript/JavaScript source extension, and index files.
 func (r *rewriter) lookupSource(candidate string) (string, bool) {
-  if source, ok := r.sourceFiles[normalizePath(candidate)]; ok {
+  normalized := normalizePath(candidate)
+  if source, ok := r.sourceFiles[r.sourceKey(normalized)]; ok {
     return source, true
   }
-  stem := stripKnownSourceExtension(normalizePath(candidate))
+  stem := stripKnownSourceExtension(normalized)
   for _, ext := range sourceLookupExtensions {
-    if source, ok := r.sourceFiles[stem+ext]; ok {
+    if source, ok := r.sourceFiles[r.sourceKey(stem+ext)]; ok {
       return source, true
     }
   }
   for _, ext := range sourceLookupExtensions {
-    if source, ok := r.sourceFiles[normalizePath(filepath.Join(stem, "index"+ext))]; ok {
+    if source, ok := r.sourceFiles[r.sourceKey(filepath.Join(stem, "index"+ext))]; ok {
       return source, true
     }
   }
   return "", false
+}
+
+// sourceKey applies the compiler host's filesystem identity rule to one path.
+// Synthetic test rewriters leave canonicalFileName nil and retain the previous
+// exact-key behavior.
+func (r *rewriter) sourceKey(value string) string {
+  normalized := normalizePath(value)
+  if r.canonicalFileName == nil {
+    return normalized
+  }
+  return r.canonicalFileName(normalized)
 }
 
 // outputPathForSource maps a source file path to its emitted output path under

--- a/packages/paths/test/linkname_helpers_test.go
+++ b/packages/paths/test/linkname_helpers_test.go
@@ -14,13 +14,14 @@ import (
 )
 
 type pathsRewriter struct {
-  checker     *shimchecker.Checker
-  basePath    string
-  jsxPreserve bool
-  outDir      string
-  patterns    []pathsPathPattern
-  rootDir     string
-  sourceFiles map[string]string
+  checker           *shimchecker.Checker
+  basePath          string
+  canonicalFileName func(string) string
+  jsxPreserve       bool
+  outDir            string
+  patterns          []pathsPathPattern
+  rootDir           string
+  sourceFiles       map[string]string
 }
 
 type pathsPathPattern struct {
@@ -48,6 +49,9 @@ func pathsResolveSource(r *pathsRewriter, specifier string) (string, bool)
 
 //go:linkname pathsLookupSource github.com/samchon/ttsc/packages/paths/driver.(*rewriter).lookupSource
 func pathsLookupSource(r *pathsRewriter, candidate string) (string, bool)
+
+//go:linkname pathsSourceKey github.com/samchon/ttsc/packages/paths/driver.(*rewriter).sourceKey
+func pathsSourceKey(r *pathsRewriter, value string) string
 
 //go:linkname pathsOutputPathForSource github.com/samchon/ttsc/packages/paths/driver.(*rewriter).outputPathForSource
 func pathsOutputPathForSource(r *pathsRewriter, source string) string

--- a/packages/paths/test/rewriter_lookup_source_honors_host_case_sensitivity_test.go
+++ b/packages/paths/test/rewriter_lookup_source_honors_host_case_sensitivity_test.go
@@ -1,0 +1,46 @@
+package paths_test
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestRewriterLookupSourceHonorsHostCaseSensitivity pins canonical lookup keys.
+func TestRewriterLookupSourceHonorsHostCaseSensitivity(t *testing.T) {
+  root := filepath.ToSlash(filepath.Join(t.TempDir(), "Repo"))
+  sources := []string{
+    root + "/src/exact.ts",
+    root + "/src/extensionless.tsx",
+    root + "/src/explicit.mts",
+    root + "/src/directory/index.cts",
+  }
+  insensitive := &pathsRewriter{
+    canonicalFileName: strings.ToLower,
+    sourceFiles:       map[string]string{},
+  }
+  sensitive := &pathsRewriter{sourceFiles: map[string]string{}}
+  for _, source := range sources {
+    insensitive.sourceFiles[pathsSourceKey(insensitive, source)] = source
+    sensitive.sourceFiles[pathsSourceKey(sensitive, source)] = source
+  }
+
+  cases := []struct {
+    candidate string
+    expected  string
+  }{
+    {root + "/SRC/EXACT.TS", sources[0]},
+    {root + "/SRC/EXTENSIONLESS", sources[1]},
+    {root + "/SRC/EXPLICIT.MTS", sources[2]},
+    {root + "/SRC/DIRECTORY", sources[3]},
+  }
+  for _, tc := range cases {
+    source, ok := pathsLookupSource(insensitive, tc.candidate)
+    if !ok || source != tc.expected {
+      t.Fatalf("case-insensitive lookup mismatch for %q: source=%q ok=%v", tc.candidate, source, ok)
+    }
+    if source, ok := pathsLookupSource(sensitive, tc.candidate); ok {
+      t.Fatalf("case-sensitive lookup unexpectedly resolved %q to %q", tc.candidate, source)
+    }
+  }
+}

--- a/packages/paths/test/rewriter_lookup_source_honors_host_case_sensitivity_test.go
+++ b/packages/paths/test/rewriter_lookup_source_honors_host_case_sensitivity_test.go
@@ -6,7 +6,15 @@ import (
   "testing"
 )
 
-// TestRewriterLookupSourceHonorsHostCaseSensitivity pins canonical lookup keys.
+// Verifies paths: source lookup follows the compiler host's case sensitivity.
+//
+// The rewriter once stored and queried case-preserving keys even when the host
+// treated case-only paths as identical. Canonical keys must still return the
+// Program's original normalized source spelling.
+//
+// 1. Seed exact, extensionless, explicit-extension, and index source paths.
+// 2. Query case-only variants through sensitive and insensitive rewriters.
+// 3. Assert only the insensitive host resolves each original source path.
 func TestRewriterLookupSourceHonorsHostCaseSensitivity(t *testing.T) {
   root := filepath.ToSlash(filepath.Join(t.TempDir(), "Repo"))
   sources := []string{

--- a/packages/playground/src/npm/internal/npmRegistry.ts
+++ b/packages/playground/src/npm/internal/npmRegistry.ts
@@ -278,12 +278,21 @@ export function enqueuePackageDependencies(
 }
 
 function isRegistryRange(range: string): boolean {
-  if (range.startsWith("npm:")) return true;
-  if (validRange(range) !== null) return true;
+  const spec = range.trim();
+  // Match npm-package-arg's file classification before its registry fallback:
+  // dot/home/root/drive paths and tar archive names are source specs even
+  // though their characters could also form a URI-safe dist-tag.
+  if (
+    /^(?:\.|~[\\/]|[\\/]|[a-zA-Z]:)/.test(spec) ||
+    /\.(?:tgz|tar\.gz|tar)$/i.test(spec)
+  )
+    return false;
+  if (spec.startsWith("npm:")) return true;
+  if (validRange(spec) !== null) return true;
   // npm accepts a dist-tag only when it is a non-empty URI-component-safe
   // token. Git, hosted, URL, and local-path specs all require punctuation that
   // encodeURIComponent escapes, so they cannot fall through as fake tags.
-  return range.length > 0 && encodeURIComponent(range) === range;
+  return spec.length > 0 && encodeURIComponent(spec) === spec;
 }
 
 export function toTypesPackageName(packageName: string): string {

--- a/packages/playground/src/npm/internal/npmRegistry.ts
+++ b/packages/playground/src/npm/internal/npmRegistry.ts
@@ -278,7 +278,12 @@ export function enqueuePackageDependencies(
 }
 
 function isRegistryRange(range: string): boolean {
-  return !/^(file:|link:|workspace:|portal:|git\+|github:|https?:)/.test(range);
+  if (range.startsWith("npm:")) return true;
+  if (validRange(range) !== null) return true;
+  // npm accepts a dist-tag only when it is a non-empty URI-component-safe
+  // token. Git, hosted, URL, and local-path specs all require punctuation that
+  // encodeURIComponent escapes, so they cannot fall through as fake tags.
+  return range.length > 0 && encodeURIComponent(range) === range;
 }
 
 export function toTypesPackageName(packageName: string): string {

--- a/packages/playground/src/sandbox/createSandboxRequire.ts
+++ b/packages/playground/src/sandbox/createSandboxRequire.ts
@@ -116,7 +116,7 @@ export function createSandboxRequire(
       }
       return tryPaths(`${pkg}/index.js`, `${pkg}/index.cjs`);
     }
-    // Subpath: honor exports["./subpath"] or exports["./subpath/*"] patterns.
+    // Subpath: honor exact exports and general single-star patterns.
     const exportsAny = pj.exports;
     if (
       exportsAny !== undefined &&
@@ -130,14 +130,18 @@ export function createSandboxRequire(
         return resolveExportTarget(pkg, entries[exactKey]);
       // Node resolves the most-specific wildcard, not insertion order.
       const patterns = Object.entries(entries)
-        .filter(([pattern]) => pattern.endsWith("/*"))
-        .sort(([a], [b]) => b.length - a.length);
-      for (const [pattern, target] of patterns) {
-        if (!pattern.endsWith("/*")) continue;
-        const prefix = pattern.slice(2, -1); // strip "./" and trailing "*"
-        if (!subpath.startsWith(prefix)) continue;
-        const rest = subpath.slice(prefix.length);
-        return resolveExportTarget(pkg, target, rest);
+        .map(([pattern, target]) => ({
+          pattern,
+          replacement: exportPatternReplacement(pattern, exactKey),
+          target,
+        }))
+        .filter(
+          (entry): entry is typeof entry & { replacement: string } =>
+            entry.replacement !== undefined,
+        )
+        .sort((a, b) => compareExportPatternKeys(a.pattern, b.pattern));
+      for (const { replacement, target } of patterns) {
+        return resolveExportTarget(pkg, target, replacement);
       }
     }
     return null;
@@ -256,6 +260,41 @@ export function createSandboxRequire(
     }
     return evaluate(resolved).exports;
   };
+}
+
+/** Capture the middle of one valid single-star exports key. */
+function exportPatternReplacement(
+  pattern: string,
+  subpath: string,
+): string | undefined {
+  const star = pattern.indexOf("*");
+  if (
+    !pattern.startsWith("./") ||
+    star === -1 ||
+    pattern.indexOf("*", star + 1) !== -1
+  ) {
+    return undefined;
+  }
+  const prefix = pattern.slice(0, star);
+  const suffix = pattern.slice(star + 1);
+  if (
+    subpath.length < prefix.length + suffix.length ||
+    !subpath.startsWith(prefix) ||
+    !subpath.endsWith(suffix)
+  ) {
+    return undefined;
+  }
+  return subpath.slice(prefix.length, subpath.length - suffix.length);
+}
+
+/** Node exports patterns rank longer prefixes, then longer full keys, first. */
+function compareExportPatternKeys(left: string, right: string): number {
+  const leftPrefix = left.indexOf("*");
+  const rightPrefix = right.indexOf("*");
+  if (leftPrefix !== rightPrefix) {
+    return rightPrefix - leftPrefix;
+  }
+  return right.length - left.length;
 }
 
 /**

--- a/packages/playground/src/sandbox/createSandboxRequire.ts
+++ b/packages/playground/src/sandbox/createSandboxRequire.ts
@@ -126,7 +126,11 @@ export function createSandboxRequire(
       const entries = exportsAny as Record<string, unknown>;
       // Exact match first.
       const exactKey = `./${subpath}`;
-      if (Object.prototype.hasOwnProperty.call(entries, exactKey))
+      if (
+        Object.prototype.hasOwnProperty.call(entries, exactKey) &&
+        !exactKey.includes("*") &&
+        !exactKey.endsWith("/")
+      )
         return resolveExportTarget(pkg, entries[exactKey]);
       // Node resolves the most-specific wildcard, not insertion order.
       const patterns = Object.entries(entries)
@@ -278,7 +282,7 @@ function exportPatternReplacement(
   const prefix = pattern.slice(0, star);
   const suffix = pattern.slice(star + 1);
   if (
-    subpath.length < prefix.length + suffix.length ||
+    subpath.length < pattern.length ||
     !subpath.startsWith(prefix) ||
     !subpath.endsWith(suffix)
   ) {

--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -1762,24 +1762,58 @@ function goToolchainNotFoundMessage(pluginName: string): string {
   );
 }
 
-function spawnGoTool(
+export function spawnGoTool(
   goBinary: string,
   args: readonly string[],
   options: SpawnSyncOptionsWithStringEncoding,
 ): SpawnSyncReturns<string> {
-  const shell = shouldSpawnGoToolThroughShell(goBinary);
-  // Under shell:true (a Windows .cmd/.bat wrapper) Node does not quote the
-  // command, so a wrapper at a path containing a space would be split by cmd.
-  // Quote it here; the go arguments ttsc passes never contain spaces, and
-  // quoting a space-free path is harmless.
-  return spawnSync(shell ? `"${goBinary}"` : goBinary, [...args], {
-    ...options,
-    shell,
-  });
+  if (!shouldSpawnGoToolThroughShell(goBinary)) {
+    return spawnSync(goBinary, [...args], options);
+  }
+  const inheritedEnv = options.env ?? process.env;
+  const shim = createWindowsGoCommandShim([goBinary, ...args]);
+  return spawnSync(
+    inheritedEnv.ComSpec ?? inheritedEnv.COMSPEC ?? "cmd.exe",
+    ["/d", "/s", "/c", shim.payload],
+    {
+      ...options,
+      env: { ...inheritedEnv, ...shim.environment },
+      shell: false,
+      // The /c payload is already one fully quoted Windows command line.
+      windowsVerbatimArguments: true,
+    },
+  );
 }
 
 function shouldSpawnGoToolThroughShell(goBinary: string): boolean {
   return process.platform === "win32" && /\.(?:bat|cmd)$/i.test(goBinary);
+}
+
+/** Pass volatile cmd wrapper arguments through one-pass environment expansion. */
+function createWindowsGoCommandShim(args: readonly string[]): {
+  environment: NodeJS.ProcessEnv;
+  payload: string;
+} {
+  const prefix = `TTSC_GO_COMMAND_SHIM_${crypto
+    .randomBytes(8)
+    .toString("hex")
+    .toUpperCase()}_ARG_`;
+  const environment = Object.fromEntries(
+    args.map((arg, index) => [prefix + index, quoteWindowsCommandArg(arg)]),
+  );
+  return {
+    environment,
+    // cmd expands each placeholder exactly once. Percent-shaped text inside an
+    // expanded value is not scanned as a second environment reference.
+    payload: `"${args.map((_, index) => `%${prefix}${index}%`).join(" ")}"`,
+  };
+}
+
+/** Quote one argv value for the Windows command-line parser used by cmd. */
+function quoteWindowsCommandArg(arg: string): string {
+  return `"${String(arg)
+    .replace(/(\\*)"/g, '$1$1\\"')
+    .replace(/(\\*)$/, "$1$1")}"`;
 }
 
 function goBuildEnv(

--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -1774,7 +1774,7 @@ export function spawnGoTool(
   const shim = createWindowsGoCommandShim([goBinary, ...args]);
   return spawnSync(
     inheritedEnv.ComSpec ?? inheritedEnv.COMSPEC ?? "cmd.exe",
-    ["/d", "/s", "/c", shim.payload],
+    ["/d", "/v:off", "/s", "/c", shim.payload],
     {
       ...options,
       env: { ...inheritedEnv, ...shim.environment },

--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -2537,11 +2537,8 @@ function resolveWindowsGoTool(
 
   const hasExtension = windowsFileNameHasExtension(binary);
   for (const candidate of candidates) {
-    if (hasExtension) {
-      if (isExecutableFile(candidate)) {
-        return { location: candidate, wrapper: false };
-      }
-      continue;
+    if (hasExtension && isExecutableFile(candidate)) {
+      return { location: candidate, wrapper: false };
     }
     for (const extension of [".com", ".exe"]) {
       const executable = candidate + extension;
@@ -2550,8 +2547,6 @@ function resolveWindowsGoTool(
       }
     }
   }
-
-  if (hasExtension) return { location: null, wrapper: false };
 
   const wrapperExtensions = windowsExecutableExtensions(env).filter((ext) =>
     /\.(?:bat|cmd)$/i.test(ext),
@@ -2580,9 +2575,7 @@ function executableSearchBases(
       ? splitWindowsSearchPath(readPathEnvironment(env))
           .map(unquoteWindowsSearchEntry)
           .filter((dir) => dir.length > 0)
-      : readPathEnvironment(env)
-          .split(path.delimiter)
-          .filter((dir) => dir.length > 0);
+      : readPathEnvironment(env).split(path.delimiter);
   const noDefaultCurrentDirectory =
     process.platform === "win32"
       ? (readWindowsEnvironmentValue(
@@ -2647,7 +2640,7 @@ function splitWindowsSearchPath(value: string): string[] {
     const character = value[index]!;
     if (quote !== "") {
       if (character === quote) quote = "";
-    } else if (character === '"' && index === start) {
+    } else if ((character === '"' || character === "'") && index === start) {
       quote = character;
     } else if (character === ";") {
       entries.push(value.slice(start, index));
@@ -2659,9 +2652,13 @@ function splitWindowsSearchPath(value: string): string[] {
 }
 
 function unquoteWindowsSearchEntry(location: string): string {
-  if (!location.startsWith('"')) return location;
-  const unquoted = location.slice(1);
-  return unquoted.endsWith('"') ? unquoted.slice(0, -1) : unquoted;
+  const first = location[0];
+  const withoutFirst =
+    first === '"' || first === "'" ? location.slice(1) : location;
+  const last = withoutFirst[withoutFirst.length - 1];
+  return last === '"' || last === "'"
+    ? withoutFirst.slice(0, -1)
+    : withoutFirst;
 }
 
 function windowsExecutableExtensions(
@@ -2680,7 +2677,7 @@ function readPathEnvironment(env: NodeJS.ProcessEnv = process.env): string {
     ? (readWindowsEnvironmentValue(env, "PATH") ??
         readWindowsEnvironmentValue(process.env, "PATH") ??
         "")
-    : (env.PATH ?? "");
+    : (env.PATH ?? "/usr/bin:/bin");
 }
 
 function readWindowsEnvironmentValue(

--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -194,7 +194,7 @@ export function buildSourcePlugin(opts: {
   const { dir, entry, source } = resolveSourceBuildTarget(opts);
   const overlayDirs = [...(opts.overlayDirs ?? findTtscOverlayDirs())].sort();
   const contributors = opts.contributors ?? [];
-  const goBinary = resolveGoCompiler(env);
+  const goBinary = resolveGoToolForBuild(resolveGoCompiler(env), env, dir);
   ensureExecutableGoToolchain(goBinary);
   const key = computeCacheKey({
     contributors,
@@ -1772,22 +1772,24 @@ export function spawnGoTool(
     return spawnSync(goBinary, [...args], options);
   }
   const inheritedEnv = options.env ?? process.env;
-  const resolved = findExecutablePath(
+  const resolved = resolveWindowsGoTool(
     goBinary,
     inheritedEnv,
     spawnWorkingDirectory(options.cwd),
   );
-  if (!isWindowsCommandWrapper(resolved ?? goBinary)) {
+  if (!resolved.wrapper) {
     return spawnSync(goBinary, [...args], options);
   }
   // Preserve the native spawn ENOENT contract before cmd.exe becomes the
   // actual child process. The callers use that code for the install guidance.
-  if (resolved === null) {
+  if (resolved.location === null) {
     return spawnSync(goBinary, [...args], options);
   }
-  const shim = createWindowsGoCommandShim([resolved, ...args]);
+  const shim = createWindowsGoCommandShim([resolved.location, ...args]);
   return spawnSync(
-    readWindowsEnvironmentValue(inheritedEnv, "COMSPEC") ?? "cmd.exe",
+    readWindowsEnvironmentValue(inheritedEnv, "COMSPEC") ??
+      readWindowsEnvironmentValue(process.env, "COMSPEC") ??
+      "cmd.exe",
     windowsGoCommandArgs(shim.payload),
     {
       ...options,
@@ -2289,15 +2291,19 @@ export function computeCacheKey(inputs: {
   tsgoVersion: string;
 }): string {
   const env = inputs.env ?? process.env;
+  const goBinary =
+    inputs.goBinary === undefined
+      ? undefined
+      : resolveGoToolForBuild(inputs.goBinary, env, inputs.dir);
   const hash = crypto.createHash("sha256");
   hash.update(`ttsc=${inputs.ttscVersion}\n`);
   hash.update(`tsgo=${inputs.tsgoVersion}\n`);
   hash.update(`platform=${process.platform}/${process.arch}\n`);
   hash.update(`entry=${inputs.entry}\n`);
-  if (inputs.goBinary !== undefined) {
-    hash.update(`go=${resolveGoCompilerIdentity(inputs.goBinary, env)}\n`);
+  if (goBinary !== undefined) {
+    hash.update(`go=${resolveGoCompilerIdentity(goBinary, env, inputs.dir)}\n`);
   }
-  hashGoBuildEnvironment(hash, inputs.goBinary, inputs.dir, env);
+  hashGoBuildEnvironment(hash, goBinary, inputs.dir, env);
   hashExternalGoBuildEnvironment(hash, env);
   hashSourceDirectory(hash, "plugin", inputs.dir);
   for (const [index, dir] of [...(inputs.overlayDirs ?? [])].sort().entries()) {
@@ -2389,23 +2395,42 @@ function isHashableFile(name: string): boolean {
 // content signature (byte size + nanosecond mtime). That signature changes if
 // a long-lived host rewrites the binary in place between calls, so the memo
 // re-derives the identity exactly as the un-memoized code would and the
-// cache-key bytes stay byte-for-byte identical to today. `go version` reads no
-// cwd/custom env (the spawn passes neither), so cwd is not part of the key.
+// cache-key bytes stay byte-for-byte identical to today. The selected compiler
+// path is shared by every build subprocess on Windows, while `go version` uses
+// the same effective cwd and environment as the cache-key `go env` query. The
+// memo key includes that context so an environment-sensitive wrapper cannot
+// lend its version result to another compiler invocation.
 const goCompilerIdentityCache = new Map<string, string>();
 
 function resolveGoCompilerIdentity(
   goBinary: string,
   env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
 ): string {
-  const resolved = resolveExecutableIdentityPath(goBinary, env);
-  const memoKey = goCompilerIdentityMemoKey(goBinary, resolved);
+  const selected = resolveGoToolForBuild(goBinary, env, cwd);
+  const resolved =
+    process.platform === "win32"
+      ? resolveRealPath(selected)
+      : resolveExecutableIdentityPath(selected, env, cwd);
+  const compilerEnv = goBuildEnv(selected, undefined, env);
+  const memoKey = goCompilerIdentityMemoKey(
+    goBinary,
+    resolved,
+    compilerEnv,
+    cwd,
+  );
   if (memoKey !== null) {
     const cached = goCompilerIdentityCache.get(memoKey);
     if (cached !== undefined) {
       return cached;
     }
   }
-  const identity = computeGoCompilerIdentity(goBinary, resolved);
+  const identity = computeGoCompilerIdentity(
+    selected,
+    resolved,
+    compilerEnv,
+    cwd,
+  );
   if (memoKey !== null) {
     goCompilerIdentityCache.set(memoKey, identity);
   }
@@ -2418,21 +2443,38 @@ function resolveGoCompilerIdentity(
 function goCompilerIdentityMemoKey(
   goBinary: string,
   resolved: string,
+  env: NodeJS.ProcessEnv,
+  cwd: string,
 ): string | null {
   try {
     const stat = fs.statSync(resolved);
-    return `${goBinary}\0${resolved}\0${stat.size}\0${stat.mtimeMs}`;
+    const context = crypto.createHash("sha256");
+    context.update(cwd);
+    for (const [key, value] of Object.entries(env).sort(([left], [right]) =>
+      left === right ? 0 : left < right ? -1 : 1,
+    )) {
+      if (value === undefined) continue;
+      context.update(`\0${key.length}:${key}${value.length}:${value}`);
+    }
+    return `${goBinary}\0${resolved}\0${stat.size}\0${stat.mtimeMs}\0${context.digest("hex")}`;
   } catch {
     return null;
   }
 }
 
-function computeGoCompilerIdentity(goBinary: string, resolved: string): string {
+function computeGoCompilerIdentity(
+  goBinary: string,
+  resolved: string,
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+): string {
   if (!fs.existsSync(resolved)) {
     return "missing";
   }
   const version = spawnGoTool(goBinary, ["version"], {
+    cwd,
     encoding: "utf8",
+    env,
     windowsHide: true,
   });
   const versionText =
@@ -2446,9 +2488,20 @@ function computeGoCompilerIdentity(goBinary: string, resolved: string): string {
 function resolveExecutableIdentityPath(
   binary: string,
   env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
 ): string {
-  const resolved = findExecutablePath(binary, env, process.cwd());
+  const resolved = findExecutablePath(binary, env, cwd);
   return resolved === null ? binary : resolveRealPath(resolved);
+}
+
+/** Pin Windows PATH and command-wrapper lookup to one build-wide target. */
+function resolveGoToolForBuild(
+  binary: string,
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+): string {
+  if (process.platform !== "win32") return binary;
+  return resolveWindowsGoTool(binary, env, cwd).location ?? binary;
 }
 
 function findExecutablePath(
@@ -2456,23 +2509,95 @@ function findExecutablePath(
   env: NodeJS.ProcessEnv,
   cwd: string,
 ): string | null {
-  if (path.isAbsolute(binary)) {
-    return findExecutableCandidate(binary, env);
-  }
-  if (hasPathSeparator(binary)) {
-    return findExecutableCandidate(path.resolve(cwd, binary), env);
-  }
-
-  const directories = readPathEnvironment(env)
-    .split(path.delimiter)
-    .map((dir) => stripPathQuotes(dir));
-  if (process.platform === "win32") directories.unshift(cwd);
-  for (const dir of directories) {
-    const candidate = path.resolve(cwd, dir, binary);
+  for (const candidate of executableSearchBases(binary, env, cwd)) {
     const resolved = findExecutableCandidate(candidate, env);
     if (resolved !== null) return resolved;
   }
   return null;
+}
+
+interface IWindowsGoToolResolution {
+  location: string | null;
+  wrapper: boolean;
+}
+
+/** Preserve libuv's native target before falling back to cmd/bat wrappers. */
+function resolveWindowsGoTool(
+  binary: string,
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+): IWindowsGoToolResolution {
+  const candidates = executableSearchBases(binary, env, cwd);
+  if (isWindowsCommandWrapper(binary)) {
+    return {
+      location: candidates.find(isExecutableFile) ?? null,
+      wrapper: true,
+    };
+  }
+
+  const hasExtension = windowsFileNameHasExtension(binary);
+  for (const candidate of candidates) {
+    if (hasExtension) {
+      if (isExecutableFile(candidate)) {
+        return { location: candidate, wrapper: false };
+      }
+      continue;
+    }
+    for (const extension of [".com", ".exe"]) {
+      const executable = candidate + extension;
+      if (isExecutableFile(executable)) {
+        return { location: executable, wrapper: false };
+      }
+    }
+  }
+
+  if (hasExtension) return { location: null, wrapper: false };
+
+  const wrapperExtensions = windowsExecutableExtensions(env).filter((ext) =>
+    /\.(?:bat|cmd)$/i.test(ext),
+  );
+  for (const candidate of candidates) {
+    for (const extension of wrapperExtensions) {
+      const executable = candidate + extension;
+      if (isExecutableFile(executable)) {
+        return { location: executable, wrapper: true };
+      }
+    }
+  }
+  return { location: null, wrapper: false };
+}
+
+function executableSearchBases(
+  binary: string,
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+): string[] {
+  if (path.isAbsolute(binary)) return [binary];
+  if (hasPathQualifier(binary)) return [path.resolve(cwd, binary)];
+
+  const directories =
+    process.platform === "win32"
+      ? splitWindowsSearchPath(readPathEnvironment(env))
+          .map(unquoteWindowsSearchEntry)
+          .filter((dir) => dir.length > 0)
+      : readPathEnvironment(env)
+          .split(path.delimiter)
+          .filter((dir) => dir.length > 0);
+  const noDefaultCurrentDirectory =
+    process.platform === "win32"
+      ? (readWindowsEnvironmentValue(
+          env,
+          "NoDefaultCurrentDirectoryInExePath",
+        ) ??
+        readWindowsEnvironmentValue(
+          process.env,
+          "NoDefaultCurrentDirectoryInExePath",
+        ))
+      : undefined;
+  if (process.platform === "win32" && noDefaultCurrentDirectory === undefined) {
+    directories.unshift(cwd);
+  }
+  return directories.map((dir) => path.resolve(cwd, dir, binary));
 }
 
 function findExecutableCandidate(
@@ -2480,9 +2605,7 @@ function findExecutableCandidate(
   env: NodeJS.ProcessEnv,
 ): string | null {
   if (isExecutableFile(candidate)) return candidate;
-  if (process.platform !== "win32" || path.extname(candidate) !== "") {
-    return null;
-  }
+  if (process.platform !== "win32") return null;
   // Probe every PATHEXT extension, not just `.exe`, so a compiler backed by a
   // `.cmd`/`.bat` wrapper is both launched correctly and hashed into the cache
   // key. Otherwise the wrapper reads as missing and changes do not invalidate
@@ -2502,18 +2625,43 @@ function isExecutableFile(location: string): boolean {
   }
 }
 
-function hasPathSeparator(location: string): boolean {
+function hasPathQualifier(location: string): boolean {
   return (
     location.includes(path.sep) ||
-    (process.platform === "win32" && location.includes("/"))
+    (process.platform === "win32" &&
+      (location.includes("/") || /^[a-zA-Z]:/.test(location)))
   );
 }
 
-function stripPathQuotes(location: string): string {
-  const trimmed = location.trim();
-  return trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')
-    ? trimmed.slice(1, -1)
-    : trimmed;
+function windowsFileNameHasExtension(location: string): boolean {
+  const name = path.basename(location);
+  const dot = name.indexOf(".");
+  return dot >= 0 && dot < name.length - 1;
+}
+
+function splitWindowsSearchPath(value: string): string[] {
+  const entries: string[] = [];
+  let start = 0;
+  let quote = "";
+  for (let index = 0; index < value.length; index++) {
+    const character = value[index]!;
+    if (quote !== "") {
+      if (character === quote) quote = "";
+    } else if (character === '"' && index === start) {
+      quote = character;
+    } else if (character === ";") {
+      entries.push(value.slice(start, index));
+      start = index + 1;
+    }
+  }
+  entries.push(value.slice(start));
+  return entries;
+}
+
+function unquoteWindowsSearchEntry(location: string): string {
+  if (!location.startsWith('"')) return location;
+  const unquoted = location.slice(1);
+  return unquoted.endsWith('"') ? unquoted.slice(0, -1) : unquoted;
 }
 
 function windowsExecutableExtensions(
@@ -2521,15 +2669,17 @@ function windowsExecutableExtensions(
 ): readonly string[] {
   const pathext = readWindowsEnvironmentValue(env, "PATHEXT");
   const raw = pathext && pathext.length > 0 ? pathext : ".COM;.EXE;.BAT;.CMD";
-  return raw
-    .split(";")
-    .map((ext) => ext.trim().toLowerCase())
+  return splitWindowsSearchPath(raw)
+    .map(unquoteWindowsSearchEntry)
+    .map((ext) => ext.toLowerCase())
     .filter((ext) => ext.length > 0);
 }
 
 function readPathEnvironment(env: NodeJS.ProcessEnv = process.env): string {
   return process.platform === "win32"
-    ? (readWindowsEnvironmentValue(env, "PATH") ?? "")
+    ? (readWindowsEnvironmentValue(env, "PATH") ??
+        readWindowsEnvironmentValue(process.env, "PATH") ??
+        "")
     : (env.PATH ?? "");
 }
 
@@ -2540,9 +2690,9 @@ function readWindowsEnvironmentValue(
   const exact = env[name];
   if (exact !== undefined) return exact;
   const normalized = name.toLowerCase();
-  const key = Object.keys(env).find(
-    (candidate) => candidate.toLowerCase() === normalized,
-  );
+  const key = Object.keys(env)
+    .filter((candidate) => candidate.toLowerCase() === normalized)
+    .sort()[0];
   return key === undefined ? undefined : env[key];
 }
 

--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -2573,19 +2573,17 @@ function executableSearchBases(
   const directories =
     process.platform === "win32"
       ? splitWindowsSearchPath(readPathEnvironment(env))
+          // libuv skips only genuinely empty slices. A quoted-empty slice
+          // survives that check, unquotes to "", and therefore names cwd.
+          .filter((entry) => entry.length > 0)
           .map(unquoteWindowsSearchEntry)
-          .filter((dir) => dir.length > 0)
       : readPathEnvironment(env).split(path.delimiter);
   const noDefaultCurrentDirectory =
     process.platform === "win32"
-      ? (readWindowsEnvironmentValue(
-          env,
-          "NoDefaultCurrentDirectoryInExePath",
-        ) ??
-        readWindowsEnvironmentValue(
+      ? readWindowsEnvironmentValue(
           process.env,
           "NoDefaultCurrentDirectoryInExePath",
-        ))
+        )
       : undefined;
   if (process.platform === "win32" && noDefaultCurrentDirectory === undefined) {
     directories.unshift(cwd);

--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -8,6 +8,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { findNearestGoMod } from "../../compiler/internal/paths";
 
@@ -1767,18 +1768,26 @@ export function spawnGoTool(
   args: readonly string[],
   options: SpawnSyncOptionsWithStringEncoding,
 ): SpawnSyncReturns<string> {
-  if (!shouldSpawnGoToolThroughShell(goBinary)) {
+  if (process.platform !== "win32") {
+    return spawnSync(goBinary, [...args], options);
+  }
+  const inheritedEnv = options.env ?? process.env;
+  const resolved = findExecutablePath(
+    goBinary,
+    inheritedEnv,
+    spawnWorkingDirectory(options.cwd),
+  );
+  if (!isWindowsCommandWrapper(resolved ?? goBinary)) {
     return spawnSync(goBinary, [...args], options);
   }
   // Preserve the native spawn ENOENT contract before cmd.exe becomes the
   // actual child process. The callers use that code for the install guidance.
-  if (path.isAbsolute(goBinary) && !fs.existsSync(goBinary)) {
+  if (resolved === null) {
     return spawnSync(goBinary, [...args], options);
   }
-  const inheritedEnv = options.env ?? process.env;
-  const shim = createWindowsGoCommandShim([goBinary, ...args]);
+  const shim = createWindowsGoCommandShim([resolved, ...args]);
   return spawnSync(
-    inheritedEnv.ComSpec ?? inheritedEnv.COMSPEC ?? "cmd.exe",
+    readWindowsEnvironmentValue(inheritedEnv, "COMSPEC") ?? "cmd.exe",
     windowsGoCommandArgs(shim.payload),
     {
       ...options,
@@ -1795,8 +1804,15 @@ export function windowsGoCommandArgs(payload: string): string[] {
   return ["/d", "/v:off", "/s", "/c", payload];
 }
 
-function shouldSpawnGoToolThroughShell(goBinary: string): boolean {
-  return process.platform === "win32" && /\.(?:bat|cmd)$/i.test(goBinary);
+function spawnWorkingDirectory(
+  cwd: SpawnSyncOptionsWithStringEncoding["cwd"],
+): string {
+  if (cwd === undefined) return process.cwd();
+  return path.resolve(typeof cwd === "string" ? cwd : fileURLToPath(cwd));
+}
+
+function isWindowsCommandWrapper(location: string): boolean {
+  return process.platform === "win32" && /\.(?:bat|cmd)$/i.test(location);
 }
 
 /** Pass volatile cmd wrapper arguments through one-pass environment expansion. */
@@ -2431,38 +2447,79 @@ function resolveExecutableIdentityPath(
   binary: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
+  const resolved = findExecutablePath(binary, env, process.cwd());
+  return resolved === null ? binary : resolveRealPath(resolved);
+}
+
+function findExecutablePath(
+  binary: string,
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+): string | null {
   if (path.isAbsolute(binary)) {
-    return resolveRealPath(binary);
+    return findExecutableCandidate(binary, env);
   }
-  if (binary.includes(path.sep)) {
-    return resolveRealPath(path.resolve(binary));
+  if (hasPathSeparator(binary)) {
+    return findExecutableCandidate(path.resolve(cwd, binary), env);
   }
-  for (const dir of readPathEnvironment(env).split(path.delimiter)) {
-    if (dir.length === 0) continue;
-    const candidate = path.join(dir, binary);
-    if (fs.existsSync(candidate)) {
-      return resolveRealPath(candidate);
-    }
-    if (process.platform === "win32") {
-      // Probe every PATHEXT extension, not just `.exe`, so a compiler backed by
-      // a `.cmd`/`.bat` wrapper resolves to its real file and is hashed into the
-      // cache key. Otherwise the wrapper reads as "missing" and a change to it
-      // would not invalidate the cached plugin binary.
-      for (const ext of windowsExecutableExtensions(env)) {
-        const executable = `${candidate}${ext}`;
-        if (fs.existsSync(executable)) {
-          return resolveRealPath(executable);
-        }
-      }
-    }
+
+  const directories = readPathEnvironment(env)
+    .split(path.delimiter)
+    .map((dir) => stripPathQuotes(dir));
+  if (process.platform === "win32") directories.unshift(cwd);
+  for (const dir of directories) {
+    const candidate = path.resolve(cwd, dir, binary);
+    const resolved = findExecutableCandidate(candidate, env);
+    if (resolved !== null) return resolved;
   }
-  return binary;
+  return null;
+}
+
+function findExecutableCandidate(
+  candidate: string,
+  env: NodeJS.ProcessEnv,
+): string | null {
+  if (isExecutableFile(candidate)) return candidate;
+  if (process.platform !== "win32" || path.extname(candidate) !== "") {
+    return null;
+  }
+  // Probe every PATHEXT extension, not just `.exe`, so a compiler backed by a
+  // `.cmd`/`.bat` wrapper is both launched correctly and hashed into the cache
+  // key. Otherwise the wrapper reads as missing and changes do not invalidate
+  // the cached plugin binary.
+  for (const ext of windowsExecutableExtensions(env)) {
+    const executable = `${candidate}${ext}`;
+    if (isExecutableFile(executable)) return executable;
+  }
+  return null;
+}
+
+function isExecutableFile(location: string): boolean {
+  try {
+    return fs.statSync(location).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function hasPathSeparator(location: string): boolean {
+  return (
+    location.includes(path.sep) ||
+    (process.platform === "win32" && location.includes("/"))
+  );
+}
+
+function stripPathQuotes(location: string): string {
+  const trimmed = location.trim();
+  return trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')
+    ? trimmed.slice(1, -1)
+    : trimmed;
 }
 
 function windowsExecutableExtensions(
   env: NodeJS.ProcessEnv = process.env,
 ): readonly string[] {
-  const pathext = env.PATHEXT;
+  const pathext = readWindowsEnvironmentValue(env, "PATHEXT");
   const raw = pathext && pathext.length > 0 ? pathext : ".COM;.EXE;.BAT;.CMD";
   return raw
     .split(";")
@@ -2471,7 +2528,22 @@ function windowsExecutableExtensions(
 }
 
 function readPathEnvironment(env: NodeJS.ProcessEnv = process.env): string {
-  return env.PATH ?? env.Path ?? "";
+  return process.platform === "win32"
+    ? (readWindowsEnvironmentValue(env, "PATH") ?? "")
+    : (env.PATH ?? "");
+}
+
+function readWindowsEnvironmentValue(
+  env: NodeJS.ProcessEnv,
+  name: string,
+): string | undefined {
+  const exact = env[name];
+  if (exact !== undefined) return exact;
+  const normalized = name.toLowerCase();
+  const key = Object.keys(env).find(
+    (candidate) => candidate.toLowerCase() === normalized,
+  );
+  return key === undefined ? undefined : env[key];
 }
 
 function resolveRealPath(location: string): string {

--- a/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
+++ b/packages/ttsc/src/plugin/internal/buildSourcePlugin.ts
@@ -1770,11 +1770,16 @@ export function spawnGoTool(
   if (!shouldSpawnGoToolThroughShell(goBinary)) {
     return spawnSync(goBinary, [...args], options);
   }
+  // Preserve the native spawn ENOENT contract before cmd.exe becomes the
+  // actual child process. The callers use that code for the install guidance.
+  if (path.isAbsolute(goBinary) && !fs.existsSync(goBinary)) {
+    return spawnSync(goBinary, [...args], options);
+  }
   const inheritedEnv = options.env ?? process.env;
   const shim = createWindowsGoCommandShim([goBinary, ...args]);
   return spawnSync(
     inheritedEnv.ComSpec ?? inheritedEnv.COMSPEC ?? "cmd.exe",
-    ["/d", "/v:off", "/s", "/c", shim.payload],
+    windowsGoCommandArgs(shim.payload),
     {
       ...options,
       env: { ...inheritedEnv, ...shim.environment },
@@ -1783,6 +1788,11 @@ export function spawnGoTool(
       windowsVerbatimArguments: true,
     },
   );
+}
+
+/** Build the fixed cmd.exe switch sequence for one already quoted payload. */
+export function windowsGoCommandArgs(payload: string): string[] {
+  return ["/d", "/v:off", "/s", "/c", payload];
 }
 
 function shouldSpawnGoToolThroughShell(goBinary: string): boolean {

--- a/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
+++ b/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
@@ -1164,7 +1164,74 @@ function selectExportTarget(exportsField: unknown, subpath: string): unknown {
     // Conditions object: the whole value is the `.` target.
     return subpath === "." ? exportsField : undefined;
   }
-  return subpath in record ? record[subpath] : undefined;
+  if (Object.prototype.hasOwnProperty.call(record, subpath)) {
+    return record[subpath];
+  }
+  const patterns = Object.keys(record)
+    .filter((key) => exportPatternReplacement(key, subpath) !== undefined)
+    .sort(compareExportPatternKeys);
+  if (patterns.length === 0) {
+    return undefined;
+  }
+  const pattern = patterns[0]!;
+  return substituteExportTarget(
+    record[pattern],
+    exportPatternReplacement(pattern, subpath)!,
+  );
+}
+
+/** Capture the middle of one valid single-star exports key. */
+function exportPatternReplacement(
+  pattern: string,
+  subpath: string,
+): string | undefined {
+  const star = pattern.indexOf("*");
+  if (
+    !pattern.startsWith("./") ||
+    star === -1 ||
+    pattern.indexOf("*", star + 1) !== -1
+  ) {
+    return undefined;
+  }
+  const prefix = pattern.slice(0, star);
+  const suffix = pattern.slice(star + 1);
+  if (
+    subpath.length < prefix.length + suffix.length ||
+    !subpath.startsWith(prefix) ||
+    !subpath.endsWith(suffix)
+  ) {
+    return undefined;
+  }
+  return subpath.slice(prefix.length, subpath.length - suffix.length);
+}
+
+/** Node exports patterns rank longer prefixes, then longer full keys, first. */
+function compareExportPatternKeys(left: string, right: string): number {
+  const leftPrefix = left.indexOf("*");
+  const rightPrefix = right.indexOf("*");
+  if (leftPrefix !== rightPrefix) {
+    return rightPrefix - leftPrefix;
+  }
+  return right.length - left.length;
+}
+
+/** Substitute the selected pattern capture into every string target branch. */
+function substituteExportTarget(target: unknown, replacement: string): unknown {
+  if (typeof target === "string") {
+    return target.split("*").join(replacement);
+  }
+  if (Array.isArray(target)) {
+    return target.map((entry) => substituteExportTarget(entry, replacement));
+  }
+  if (typeof target !== "object" || target === null) {
+    return target;
+  }
+  return Object.fromEntries(
+    Object.entries(target).map(([condition, value]) => [
+      condition,
+      substituteExportTarget(value, replacement),
+    ]),
+  );
 }
 
 /** True when condition key `condition` appears anywhere in a (nested) target. */

--- a/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
+++ b/packages/ttsc/src/plugin/internal/loadProjectPlugins.ts
@@ -1164,7 +1164,11 @@ function selectExportTarget(exportsField: unknown, subpath: string): unknown {
     // Conditions object: the whole value is the `.` target.
     return subpath === "." ? exportsField : undefined;
   }
-  if (Object.prototype.hasOwnProperty.call(record, subpath)) {
+  if (
+    Object.prototype.hasOwnProperty.call(record, subpath) &&
+    !subpath.includes("*") &&
+    !subpath.endsWith("/")
+  ) {
     return record[subpath];
   }
   const patterns = Object.keys(record)
@@ -1196,7 +1200,7 @@ function exportPatternReplacement(
   const prefix = pattern.slice(0, star);
   const suffix = pattern.slice(star + 1);
   if (
-    subpath.length < prefix.length + suffix.length ||
+    subpath.length < pattern.length ||
     !subpath.startsWith(prefix) ||
     !subpath.endsWith(suffix)
   ) {

--- a/packages/wasm/src/createMemFS.ts
+++ b/packages/wasm/src/createMemFS.ts
@@ -81,14 +81,15 @@ export function createMemFS(): IMemFSHost {
   /**
    * One open descriptor.
    *
-   * `readable`, `writable`, and `append` are the access mode and `O_APPEND`
-   * flag captured at `open`; without them no read or write below can tell an
-   * allowed operation from a forbidden one. `position` is the cursor a
-   * `position: null` read or write uses and advances, exactly as Node's `fs`
-   * defines it.
+   * `node` retains the object opened even after its pathname is unlinked or
+   * replaced. `readable`, `writable`, and `append` are the access mode and
+   * `O_APPEND` flag captured at `open`; without them no descriptor mutation can
+   * distinguish an allowed operation from a forbidden one. `position` is the
+   * cursor a `position: null` read or write uses and advances.
    */
   interface IDescriptor {
     path: string;
+    node?: INode;
     position: number;
     readable: boolean;
     writable: boolean;
@@ -284,7 +285,7 @@ export function createMemFS(): IMemFSHost {
     syscall: string,
   ): number {
     if (!entry.writable) throw new MemFSError("EBADF", syscall, entry.path);
-    const node = nodes.get(entry.path);
+    const node = entry.node;
     if (!node) throw new MemFSError("ENOENT", syscall, entry.path);
     if (node.kind !== "file")
       throw new MemFSError("EISDIR", syscall, entry.path);
@@ -550,6 +551,7 @@ export function createMemFS(): IMemFSHost {
         const fd = nextFd++;
         fdTable.set(fd, {
           path: norm,
+          node,
           position: 0,
           readable,
           writable,
@@ -612,7 +614,7 @@ export function createMemFS(): IMemFSHost {
         callback(new MemFSError("EBADF", "read", entry.path), 0);
         return;
       }
-      const node = nodes.get(entry.path);
+      const node = entry.node;
       if (!node || node.kind !== "file") {
         callback(new MemFSError("ENOENT", "read", entry.path), 0);
         return;
@@ -642,7 +644,17 @@ export function createMemFS(): IMemFSHost {
 
     mkdir(p, _perm, callback) {
       try {
-        mkdirp(p);
+        const norm = normalize(p);
+        if (nodes.has(norm)) throw new MemFSError("EEXIST", "mkdir", norm);
+        const parent = nodes.get(parentDir(norm));
+        if (!parent) throw new MemFSError("ENOENT", "mkdir", parentDir(norm));
+        if (parent.kind !== "dir")
+          throw new MemFSError("ENOTDIR", "mkdir", parentDir(norm));
+        nodes.set(norm, {
+          kind: "dir",
+          data: new Uint8Array(),
+          mtimeMs: Date.now(),
+        });
         callback(null);
       } catch (err) {
         callback(err as NodeJS.ErrnoException);
@@ -688,7 +700,8 @@ export function createMemFS(): IMemFSHost {
         return;
       }
       try {
-        callback(null, statSync(entry.path));
+        if (!entry.node) throw new MemFSError("ENOENT", "fstat", entry.path);
+        callback(null, makeStats(entry.node));
       } catch (err) {
         callback(
           err as NodeJS.ErrnoException,
@@ -857,7 +870,11 @@ export function createMemFS(): IMemFSHost {
         callback(new MemFSError("EINVAL", "ftruncate"));
         return;
       }
-      const node = nodes.get(entry.path);
+      if (!entry.writable) {
+        callback(new MemFSError("EBADF", "ftruncate", entry.path));
+        return;
+      }
+      const node = entry.node;
       if (!node || node.kind !== "file") {
         callback(new MemFSError("EINVAL", "ftruncate", entry.path));
         return;

--- a/tests/test-paths/src/features/test_paths_rewrites_case_only_targets_on_windows.ts
+++ b/tests/test-paths/src/features/test_paths_rewrites_case_only_targets_on_windows.ts
@@ -1,0 +1,69 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TestPaths } from "../internal/TestPaths";
+import { SHARED_PLUGIN_CACHE_DIR } from "../internal/plugin-cache";
+
+/**
+ * Windows resolves paths aliases with the same case-insensitive identity as
+ * tsgo.
+ */
+export const test_paths_rewrites_case_only_targets_on_windows = () => {
+  if (process.platform !== "win32") return;
+
+  const root = TestProject.createProject({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "CommonJS",
+        forceConsistentCasingInFileNames: false,
+        paths: {
+          "@exact": ["./SRC/EXACT.TS"],
+          "@extensionless": ["./SRC/EXTENSIONLESS"],
+          "@explicit": ["./SRC/EXPLICIT.TS"],
+          "@directory": ["./SRC/DIRECTORY"],
+        },
+        outDir: "dist",
+        rootDir: "src",
+        plugins: [{ transform: "@ttsc/paths" }],
+      },
+      include: ["src"],
+    }),
+    "src/exact.ts": `export const exact = "exact";\n`,
+    "src/extensionless.ts": `export const extensionless = "extensionless";\n`,
+    "src/explicit.ts": `export const explicit = "explicit";\n`,
+    "src/directory/index.ts": `export const directory = "directory";\n`,
+    "src/main.ts": [
+      `import { exact } from "@exact";`,
+      `import { extensionless } from "@extensionless";`,
+      `import { explicit } from "@explicit";`,
+      `import { directory } from "@directory";`,
+      `export const value = exact + extensionless + explicit + directory;`,
+      ``,
+    ].join("\n"),
+  });
+  TestPaths.seedPackage(root);
+
+  const result = TestProject.spawn(
+    TestProject.TTSC_BIN,
+    ["--cwd", root, "--emit"],
+    {
+      cwd: root,
+      env: {
+        PATH: TestPaths.goPath(),
+        TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
+      },
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+
+  const output = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+  for (const alias of ["@exact", "@extensionless", "@explicit", "@directory"])
+    assert.doesNotMatch(output, new RegExp(alias));
+  assert.match(output, /require\("\.\/exact\.js"\)/i);
+  assert.match(output, /require\("\.\/extensionless\.js"\)/i);
+  assert.match(output, /require\("\.\/explicit\.js"\)/i);
+  assert.match(output, /require\("\.\/directory\/index\.js"\)/i);
+};

--- a/tests/test-paths/src/features/test_paths_rewrites_case_only_targets_on_windows.ts
+++ b/tests/test-paths/src/features/test_paths_rewrites_case_only_targets_on_windows.ts
@@ -7,8 +7,15 @@ import { TestPaths } from "../internal/TestPaths";
 import { SHARED_PLUGIN_CACHE_DIR } from "../internal/plugin-cache";
 
 /**
- * Windows resolves paths aliases with the same case-insensitive identity as
- * tsgo.
+ * Verifies paths: Windows aliases use the compiler host's file identity.
+ *
+ * The plugin used case-preserving map keys after tsgo had already accepted a
+ * case-only target, leaving the alias in emitted JavaScript. Source lookup must
+ * canonicalize every exact, extension, and index candidate with the host rule.
+ *
+ * 1. Create lowercase sources and uppercase exact and extensionless aliases.
+ * 2. Compile the project through the real Windows ttsc and paths plugin.
+ * 3. Assert every alias becomes the relative emitted JavaScript path.
  */
 export const test_paths_rewrites_case_only_targets_on_windows = () => {
   if (process.platform !== "win32") return;

--- a/tests/test-playground/src/features/test_create_sandbox_require_resolves_general_export_patterns.ts
+++ b/tests/test-playground/src/features/test_create_sandbox_require_resolves_general_export_patterns.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+
+import { createSandboxRequire } from "../../../../packages/playground/lib/src/sandbox/createSandboxRequire.js";
+
+/**
+ * The Execute sandbox follows Node's exact and general single-star exports
+ * rules.
+ */
+export const test_create_sandbox_require_resolves_general_export_patterns =
+  () => {
+    const require = createSandboxRequire(
+      {
+        "patterns/package.json": JSON.stringify({
+          exports: {
+            "./features/exact.js": "./dist/exact.cjs",
+            "./features/*": "./dist/plain/*.cjs",
+            "./features/*.js": "./dist/suffixed/*.cjs",
+            "./features/special-*.js": "./dist/special/*.cjs",
+            "./twice/*.js": "./dist/twice/*/*.cjs",
+            "./private/*.js": null,
+          },
+        }),
+        "patterns/dist/exact.cjs": "module.exports = { value: 'exact' };",
+        "patterns/dist/plain/tool.js.cjs":
+          "module.exports = { value: 'plain' };",
+        "patterns/dist/plain/tool.css.cjs":
+          "module.exports = { value: 'plain-css' };",
+        "patterns/dist/suffixed/tool.cjs":
+          "module.exports = { value: 'suffix' };",
+        "patterns/dist/special/tool.cjs":
+          "module.exports = { value: 'special' };",
+        "patterns/dist/twice/tool/tool.cjs":
+          "module.exports = { value: 'twice' };",
+        "patterns/private/secret.js": "module.exports = { value: 'private' };",
+      },
+      { console },
+    );
+
+    assert.deepEqual(require("patterns/features/exact.js"), { value: "exact" });
+    assert.deepEqual(require("patterns/features/tool.js"), { value: "suffix" });
+    assert.deepEqual(require("patterns/features/special-tool.js"), {
+      value: "special",
+    });
+    assert.deepEqual(require("patterns/features/tool.css"), {
+      value: "plain-css",
+    });
+    assert.deepEqual(require("patterns/twice/tool.js"), { value: "twice" });
+    assert.throws(
+      () => require("patterns/private/secret.js"),
+      /require\("patterns\/private\/secret\.js"\) is not available/,
+    );
+  };

--- a/tests/test-playground/src/features/test_create_sandbox_require_resolves_general_export_patterns.ts
+++ b/tests/test-playground/src/features/test_create_sandbox_require_resolves_general_export_patterns.ts
@@ -3,8 +3,15 @@ import assert from "node:assert/strict";
 import { createSandboxRequire } from "../../../../packages/playground/lib/src/sandbox/createSandboxRequire.js";
 
 /**
- * The Execute sandbox follows Node's exact and general single-star exports
- * rules.
+ * Verifies playground: sandbox require resolves general exports patterns.
+ *
+ * The sandbox recognized only trailing `/*`, so suffix-bearing Node patterns
+ * appeared private after the compiler had accepted them. The resolver must rank
+ * one-star keys by Node specificity and preserve null boundaries.
+ *
+ * 1. Define exact, overlapping, suffix, repeated-target, empty, and null cases.
+ * 2. Require matching package subpaths through the sandbox.
+ * 3. Assert the selected exports and rejected boundaries.
  */
 export const test_create_sandbox_require_resolves_general_export_patterns =
   () => {

--- a/tests/test-playground/src/features/test_create_sandbox_require_resolves_general_export_patterns.ts
+++ b/tests/test-playground/src/features/test_create_sandbox_require_resolves_general_export_patterns.ts
@@ -17,6 +17,7 @@ export const test_create_sandbox_require_resolves_general_export_patterns =
             "./features/*.js": "./dist/suffixed/*.cjs",
             "./features/special-*.js": "./dist/special/*.cjs",
             "./twice/*.js": "./dist/twice/*/*.cjs",
+            "./empty/*.js": "./dist/empty/*.cjs",
             "./private/*.js": null,
           },
         }),
@@ -31,6 +32,7 @@ export const test_create_sandbox_require_resolves_general_export_patterns =
           "module.exports = { value: 'special' };",
         "patterns/dist/twice/tool/tool.cjs":
           "module.exports = { value: 'twice' };",
+        "patterns/dist/empty/.cjs": "module.exports = { value: 'empty' };",
         "patterns/private/secret.js": "module.exports = { value: 'private' };",
       },
       { console },
@@ -45,6 +47,10 @@ export const test_create_sandbox_require_resolves_general_export_patterns =
       value: "plain-css",
     });
     assert.deepEqual(require("patterns/twice/tool.js"), { value: "twice" });
+    assert.throws(
+      () => require("patterns/empty/.js"),
+      /require\("patterns\/empty\/\.js"\) is not available/,
+    );
     assert.throws(
       () => require("patterns/private/secret.js"),
       /require\("patterns\/private\/secret\.js"\) is not available/,

--- a/tests/test-playground/src/features/test_npm_registry_skips_every_non_registry_spec_family.ts
+++ b/tests/test-playground/src/features/test_npm_registry_skips_every_non_registry_spec_family.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+
+import { installPlaygroundDependencies } from "../../../../packages/playground/lib/src/npm/installPlaygroundDependencies.js";
+import {
+  type INpmMetadata,
+  enqueuePackageDependencies,
+} from "../../../../packages/playground/lib/src/npm/internal/npmRegistry.js";
+import { createTarball } from "../internal/tarball";
+
+/** Unsupported npm source specs never become registry dist-tag requests. */
+export const test_npm_registry_skips_every_non_registry_spec_family =
+  async () => {
+    const skipped: Record<string, string> = {
+      "from-file": "file:../local",
+      "from-link": "link:../local",
+      "from-workspace": "workspace:*",
+      "from-portal": "portal:../local",
+      "from-http": "https://example.invalid/archive.tgz",
+      "from-git-plus": "git+ssh://git@example.invalid/repo.git",
+      "from-git-url": "git://example.invalid/repo.git",
+      "from-ssh": "ssh://git@example.invalid/repo.git",
+      "from-scp": "git@example.invalid:owner/repo.git",
+      "from-github": "github:owner/repo",
+      "from-gitlab": "gitlab:owner/repo",
+      "from-bitbucket": "bitbucket:owner/repo",
+      "from-hosted": "owner/repo",
+      "from-relative": "./local",
+      "from-parent": "../local",
+      "from-absolute": "/local",
+      "from-home": "~/local",
+      "from-drive": "C:\\local",
+      "from-unc": "\\\\server\\share",
+      "from-malformed": "not a tag",
+    };
+    const queued: string[] = [];
+    enqueuePackageDependencies(
+      {
+        dependencies: {
+          ...skipped,
+          alias: "npm:actual@^1",
+          exact: "1.0.0",
+          range: "^1",
+          tagged: "next!",
+        },
+      },
+      ({ name }) => queued.push(name),
+      "classification-root",
+    );
+    assert.deepEqual(queued, ["alias", "exact", "range", "tagged"]);
+
+    const rootTarball = createTarball([
+      {
+        body: JSON.stringify({
+          dependencies: {
+            ...skipped,
+            supported: "^1",
+          },
+        }),
+        path: "package/package.json",
+      },
+      { body: "export {};", path: "package/index.d.ts" },
+    ]);
+    const supportedTarball = createTarball([
+      { body: JSON.stringify({}), path: "package/package.json" },
+      { body: "export declare const value: 1;", path: "package/index.d.ts" },
+    ]);
+    const metadata = new Map<string, INpmMetadata>([
+      [
+        "root",
+        {
+          name: "root",
+          versions: {
+            "1.0.0": {
+              name: "root",
+              version: "1.0.0",
+              dist: { tarball: "https://tar.invalid/root.tgz" },
+            },
+          },
+        },
+      ],
+      [
+        "supported",
+        {
+          name: "supported",
+          versions: {
+            "1.0.0": {
+              name: "supported",
+              version: "1.0.0",
+              dist: { tarball: "https://tar.invalid/supported.tgz" },
+            },
+          },
+        },
+      ],
+    ]);
+    const registryNames: string[] = [];
+    const result = await installPlaygroundDependencies(["root"], {
+      fetch: async (input: string): Promise<Response> => {
+        const url = String(input);
+        if (url.startsWith("https://registry.npmjs.org/")) {
+          const name = decodeURIComponent(url.slice(url.lastIndexOf("/") + 1));
+          registryNames.push(name);
+          const value = metadata.get(name);
+          return value
+            ? new Response(JSON.stringify(value))
+            : new Response("not found", { status: 404 });
+        }
+        if (url.endsWith("/root.tgz")) return new Response(rootTarball);
+        if (url.endsWith("/supported.tgz"))
+          return new Response(supportedTarball);
+        throw new Error(`Unexpected request ${url}.`);
+      },
+    });
+
+    assert.deepEqual(registryNames, ["root", "supported"]);
+    assert.deepEqual(
+      result.packages.map(({ name }) => name),
+      ["root", "supported"],
+    );
+  };

--- a/tests/test-playground/src/features/test_npm_registry_skips_every_non_registry_spec_family.ts
+++ b/tests/test-playground/src/features/test_npm_registry_skips_every_non_registry_spec_family.ts
@@ -26,10 +26,14 @@ export const test_npm_registry_skips_every_non_registry_spec_family =
       "from-hosted": "owner/repo",
       "from-relative": "./local",
       "from-parent": "../local",
+      "from-dot": ".",
+      "from-dot-name": ".local",
       "from-absolute": "/local",
       "from-home": "~/local",
       "from-drive": "C:\\local",
       "from-unc": "\\\\server\\share",
+      "from-tgz": "archive.tgz",
+      "from-tar-gz": "archive.tar.gz",
       "from-malformed": "not a tag",
     };
     const queued: string[] = [];

--- a/tests/test-playground/src/features/test_npm_registry_skips_every_non_registry_spec_family.ts
+++ b/tests/test-playground/src/features/test_npm_registry_skips_every_non_registry_spec_family.ts
@@ -7,7 +7,18 @@ import {
 } from "../../../../packages/playground/lib/src/npm/internal/npmRegistry.js";
 import { createTarball } from "../internal/tarball";
 
-/** Unsupported npm source specs never become registry dist-tag requests. */
+/**
+ * Verifies playground: npm source specs never become registry requests.
+ *
+ * Prefix-only classification sent valid path, archive, URL, git, and hosted
+ * specs to the dist-tag branch. The browser installer must enqueue only its
+ * supported registry grammar while supported siblings still install.
+ *
+ * 1. Mix every unsupported source family with ranges, tags, and an alias.
+ * 2. Assert only supported dependency names enter the queue.
+ * 3. Install a tarball carrying the same mix through a fake registry.
+ * 4. Assert no unsupported name triggers a metadata request.
+ */
 export const test_npm_registry_skips_every_non_registry_spec_family =
   async () => {
     const skipped: Record<string, string> = {

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_missing_go_toolchain_points_users_at_the_install_hint.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_missing_go_toolchain_points_users_at_the_install_hint.ts
@@ -5,7 +5,6 @@ import {
   copyProject,
   fs,
   os,
-  path,
   spawn,
   ttscBin,
 } from "../../internal/plugin-corpus";
@@ -16,9 +15,9 @@ import {
  *
  * Source plugins require `go build`, and first-time users often do not have Go
  * in PATH. When neither `go` nor the `TTSC_GO_BINARY` override resolves to a
- * real binary, including a missing Windows `.cmd` wrapper launched through
- * `cmd.exe`, ttsc must emit a human-readable message (`Go toolchain was not
- * found`) and name the env variable they can set to fix it.
+ * real binary, including a missing named Windows `.cmd` wrapper rejected before
+ * selecting `cmd.exe`, ttsc must emit a human-readable message (`Go toolchain
+ * was not found`) and name the env variable they can set to fix it.
  *
  * 1. Copy the `go-source-plugin` fixture into a temp directory.
  * 2. Run ttsc with a PATH that contains no Go binary and `TTSC_GO_BINARY` pointing
@@ -35,10 +34,8 @@ export const test_plugin_corpus_missing_go_toolchain_points_users_at_the_install
         // Strip Go binaries from PATH and force lookup of a guaranteed-missing
         // toolchain via TTSC_GO_BINARY.
         PATH: "/nonexistent",
-        TTSC_GO_BINARY: path.join(
-          root,
+        TTSC_GO_BINARY:
           process.platform === "win32" ? "missing-go.cmd" : "missing-go",
-        ),
         TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-source-plugin-no-go-"),
       },
     });

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_missing_go_toolchain_points_users_at_the_install_hint.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_missing_go_toolchain_points_users_at_the_install_hint.ts
@@ -16,7 +16,8 @@ import {
  *
  * Source plugins require `go build`, and first-time users often do not have Go
  * in PATH. When neither `go` nor the `TTSC_GO_BINARY` override resolves to a
- * real binary, ttsc must emit a human-readable message (`Go toolchain was not
+ * real binary, including a missing Windows `.cmd` wrapper launched through
+ * `cmd.exe`, ttsc must emit a human-readable message (`Go toolchain was not
  * found`) and name the env variable they can set to fix it.
  *
  * 1. Copy the `go-source-plugin` fixture into a temp directory.
@@ -34,7 +35,10 @@ export const test_plugin_corpus_missing_go_toolchain_points_users_at_the_install
         // Strip Go binaries from PATH and force lookup of a guaranteed-missing
         // toolchain via TTSC_GO_BINARY.
         PATH: "/nonexistent",
-        TTSC_GO_BINARY: "/nonexistent/go-binary-that-does-not-exist",
+        TTSC_GO_BINARY: path.join(
+          root,
+          process.platform === "win32" ? "missing-go.cmd" : "missing-go",
+        ),
         TTSC_CACHE_DIR: TestProject.tmpdir("ttsc-source-plugin-no-go-"),
       },
     });

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_ttsc_export_condition_resolves_pattern_descriptor.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_ttsc_export_condition_resolves_pattern_descriptor.ts
@@ -1,0 +1,85 @@
+import { SHARED_PLUGIN_CACHE_DIR } from "../../internal/plugin-cache";
+import {
+  assert,
+  commonJsProject,
+  copyDirectory,
+  fs,
+  goPath,
+  path,
+  spawn,
+  ttscBin,
+  workspaceRoot,
+} from "../../internal/plugin-corpus";
+
+/** A ttsc-condition subpath pattern selects and substitutes its descriptor. */
+export const test_plugin_ttsc_export_condition_resolves_pattern_descriptor =
+  () => {
+    const root = commonJsProject({
+      "src/main.ts": `export const value: string = goUpper("pattern");\nconsole.log(value);\n`,
+    });
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({ dependencies: { "pattern-plugin": "0.1.0" } }),
+    );
+    copyDirectory(
+      path.join(workspaceRoot, "tests", "go-transformer"),
+      path.join(root, "go-plugin"),
+    );
+
+    const packageRoot = path.join(root, "node_modules", "pattern-plugin");
+    fs.mkdirSync(path.join(packageRoot, "descriptors"), { recursive: true });
+    fs.mkdirSync(path.join(packageRoot, "runtime"), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "pattern-plugin",
+        version: "0.1.0",
+        exports: {
+          "./plugins/*.js": {
+            ttsc: "./descriptors/*.cjs",
+            default: "./runtime/*.cjs",
+          },
+        },
+        ttsc: {
+          plugin: {
+            transform: "pattern-plugin/plugins/prefix.js",
+            name: "prefix",
+            prefix: "PATTERN:",
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(packageRoot, "descriptors", "prefix.cjs"),
+      `const path = require("node:path");
+module.exports = (context) => ({
+  name: context.plugin.name,
+  source: path.resolve(
+    context.dirname,
+    "..",
+    "..",
+    "..",
+    "go-plugin",
+    "cmd",
+    "ttsc-go-transformer"
+  ),
+});
+`,
+    );
+    fs.writeFileSync(
+      path.join(packageRoot, "runtime", "prefix.cjs"),
+      `throw new Error("TTSC_TEST_PATTERN_RUNTIME_LOADED");\n`,
+    );
+
+    const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+      cwd: root,
+      env: {
+        PATH: goPath(),
+        TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
+      },
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.doesNotMatch(result.stderr, /TTSC_TEST_PATTERN_RUNTIME_LOADED/);
+    const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
+    assert.match(js, /"PATTERN:pattern"/);
+  };

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_ttsc_export_condition_resolves_pattern_descriptor.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_ttsc_export_condition_resolves_pattern_descriptor.ts
@@ -11,7 +11,18 @@ import {
   workspaceRoot,
 } from "../../internal/plugin-corpus";
 
-/** A ttsc-condition subpath pattern selects and substitutes its descriptor. */
+/**
+ * Verifies plugin corpus: ttsc resolves a patterned descriptor export.
+ *
+ * Exact-only export selection fell through to the runtime branch for valid
+ * single-star subpaths, reintroducing the plugin self-hosting cycle. The
+ * private `ttsc` condition must select and substitute the runtime-free
+ * descriptor.
+ *
+ * 1. Package a plugin with patterned `ttsc` and default export targets.
+ * 2. Compile through the real source-plugin corpus entrypoint.
+ * 3. Assert the descriptor transform ran and the runtime branch did not load.
+ */
 export const test_plugin_ttsc_export_condition_resolves_pattern_descriptor =
   () => {
     const root = commonJsProject({

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_computecachekey_changes_when_go_compiler_identity_changes.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_computecachekey_changes_when_go_compiler_identity_changes.ts
@@ -3,8 +3,8 @@ import { TestProject } from "@ttsc/testing";
 import {
   assert,
   computeCacheKey,
+  createFakeGoBinary,
   fs,
-  os,
   path,
 } from "../../internal/source-build";
 
@@ -18,7 +18,8 @@ import {
  *
  * 1. Create one source plugin and two fake Go executables with different content.
  * 2. Compute the cache key with each executable as `goBinary`.
- * 3. Assert the keys differ.
+ * 3. On POSIX, contrast an empty leading PATH entry with PATH-only lookup.
+ * 4. Assert each effective compiler identity receives a distinct key.
  */
 export const test_computecachekey_changes_when_go_compiler_identity_changes =
   () => {
@@ -52,4 +53,30 @@ export const test_computecachekey_changes_when_go_compiler_identity_changes =
     });
 
     assert.notEqual(first, second);
+
+    if (process.platform === "win32") return;
+    const cwdGo = createFakeGoBinary(plugin);
+    fs.renameSync(cwdGo, path.join(plugin, "go"));
+    const pathToolchain = path.join(root, "path-toolchain");
+    fs.mkdirSync(pathToolchain, { recursive: true });
+    const pathGo = createFakeGoBinary(pathToolchain);
+    fs.renameSync(pathGo, path.join(pathToolchain, "go"));
+
+    const cwdFirst = computeCacheKey({
+      dir: plugin,
+      entry: ".",
+      env: { ...process.env, PATH: `${path.delimiter}${pathToolchain}` },
+      goBinary: "go",
+      ttscVersion: "1.0.0",
+      tsgoVersion: "7.0.0-dev",
+    });
+    const pathOnly = computeCacheKey({
+      dir: plugin,
+      entry: ".",
+      env: { ...process.env, PATH: pathToolchain },
+      goBinary: "go",
+      ttscVersion: "1.0.0",
+      tsgoVersion: "7.0.0-dev",
+    });
+    assert.notEqual(cwdFirst, pathOnly);
   };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
@@ -1,6 +1,7 @@
 import { TestProject } from "@ttsc/testing";
 
 import {
+  computeCacheKey,
   spawnGoTool,
   windowsGoCommandArgs,
 } from "../../../../../packages/ttsc/lib/plugin/internal/buildSourcePlugin.js";
@@ -15,9 +16,9 @@ import { assert, fs, path } from "../../internal/source-build";
  * environment indirection without mutating the caller's environment.
  *
  * 1. Assert the production cmd argument plan explicitly contains `/v:off`.
- * 2. Put a fake `go.cmd` under a path containing expansion and shell syntax.
+ * 2. Put fake wrappers under hostile, whitespace, and quoted-semicolon paths.
  * 3. Run absolute, PATH-resolved, and relative wrappers with hostile argv.
- * 4. Assert argv/environment fidelity and ENOENT for missing wrapper forms.
+ * 4. Assert native precedence, search-policy fidelity, and missing ENOENT.
  */
 export const test_spawngotool_preserves_windows_command_wrapper_arguments =
   () => {
@@ -122,7 +123,195 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
       relativeResult.stderr || relativeResult.error?.message,
     );
 
-    for (const missing of ["missing-go.cmd", ".\\missing-go.cmd"]) {
+    const whitespaceRoot = path.join(root, " leading-path-entry");
+    fs.mkdirSync(whitespaceRoot, { recursive: true });
+    fs.copyFileSync(script, path.join(whitespaceRoot, "capture.cjs"));
+    fs.copyFileSync(wrapper, path.join(whitespaceRoot, "go.cmd"));
+    const whitespaceArgs = ["version", "literal PATH whitespace"];
+    const whitespaceResult = spawnGoTool("go", whitespaceArgs, {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...env, PATH: whitespaceRoot, PATHEXT: ".CMD" },
+      windowsHide: true,
+    });
+    assert.equal(
+      whitespaceResult.status,
+      0,
+      whitespaceResult.stderr || whitespaceResult.error?.message,
+    );
+
+    const semicolonRoot = path.join(root, "quoted;path-entry");
+    fs.mkdirSync(semicolonRoot, { recursive: true });
+    fs.copyFileSync(script, path.join(semicolonRoot, "capture.cjs"));
+    fs.copyFileSync(wrapper, path.join(semicolonRoot, "go.cmd"));
+    const semicolonArgs = ["version", "quoted semicolon PATH"];
+    const semicolonResult = spawnGoTool("go", semicolonArgs, {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...env, PATH: `"${semicolonRoot}"`, PATHEXT: ".CMD" },
+      windowsHide: true,
+    });
+    assert.equal(
+      semicolonResult.status,
+      0,
+      semicolonResult.stderr || semicolonResult.error?.message,
+    );
+
+    fs.copyFileSync(wrapper, path.join(wrapperRoot, "node.cmd"));
+    const nativeMarker = path.join(root, "native-selected.txt");
+    const nativeResult = spawnGoTool(
+      "node",
+      [
+        "-e",
+        'require("node:fs").writeFileSync(process.env.TTSC_GO_NATIVE_MARKER, "native")',
+      ],
+      {
+        cwd: wrapperRoot,
+        encoding: "utf8",
+        env: {
+          ...env,
+          PATH: path.dirname(process.execPath),
+          PATHEXT: ".CMD;.EXE",
+          TTSC_GO_NATIVE_MARKER: nativeMarker,
+        },
+        windowsHide: true,
+      },
+    );
+    assert.equal(
+      nativeResult.status,
+      0,
+      nativeResult.stderr || nativeResult.error?.message,
+    );
+    assert.equal(fs.readFileSync(nativeMarker, "utf8"), "native");
+
+    const blockedRoot = path.join(root, "blocked-current-directory");
+    fs.mkdirSync(blockedRoot, { recursive: true });
+    fs.writeFileSync(path.join(blockedRoot, "go.cmd"), "@exit /b 91\r\n");
+    const noCwdArgs = ["version", "skip current directory"];
+    const noDefaultCurrentDirectory =
+      process.env.NoDefaultCurrentDirectoryInExePath;
+    try {
+      process.env.NoDefaultCurrentDirectoryInExePath = "1";
+      const noCwdResult = spawnGoTool("go", noCwdArgs, {
+        cwd: blockedRoot,
+        encoding: "utf8",
+        env: {
+          ...env,
+          PATH: `"${semicolonRoot}"`,
+          PATHEXT: ".CMD",
+        },
+        windowsHide: true,
+      });
+      assert.equal(
+        noCwdResult.status,
+        0,
+        noCwdResult.stderr || noCwdResult.error?.message,
+      );
+    } finally {
+      if (noDefaultCurrentDirectory === undefined) {
+        delete process.env.NoDefaultCurrentDirectoryInExePath;
+      } else {
+        process.env.NoDefaultCurrentDirectoryInExePath =
+          noDefaultCurrentDirectory;
+      }
+    }
+
+    const envWithoutPath: NodeJS.ProcessEnv = { ...env, PATHEXT: ".CMD" };
+    for (const key of Object.keys(envWithoutPath)) {
+      if (key.toLowerCase() === "path") delete envWithoutPath[key];
+    }
+    const parentPath = process.env.PATH;
+    const inheritedPathArgs = ["version", "inherited PATH"];
+    try {
+      process.env.PATH = whitespaceRoot;
+      const inheritedPathResult = spawnGoTool("go", inheritedPathArgs, {
+        cwd: root,
+        encoding: "utf8",
+        env: envWithoutPath,
+        windowsHide: true,
+      });
+      assert.equal(
+        inheritedPathResult.status,
+        0,
+        inheritedPathResult.stderr || inheritedPathResult.error?.message,
+      );
+    } finally {
+      if (parentPath === undefined) delete process.env.PATH;
+      else process.env.PATH = parentPath;
+    }
+
+    const duplicatePathArgs = ["version", "duplicate PATH casing"];
+    const duplicatePathResult = spawnGoTool("go", duplicatePathArgs, {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...envWithoutPath,
+        Path: `"${semicolonRoot}"`,
+        path: blockedRoot,
+      },
+      windowsHide: true,
+    });
+    assert.equal(
+      duplicatePathResult.status,
+      0,
+      duplicatePathResult.stderr || duplicatePathResult.error?.message,
+    );
+
+    const plugin = path.join(root, "plugin");
+    const relativeToolchainA = path.join(plugin, "relative-toolchain-a");
+    const relativeToolchainB = path.join(plugin, "relative-toolchain-b");
+    fs.mkdirSync(relativeToolchainA, { recursive: true });
+    fs.mkdirSync(relativeToolchainB, { recursive: true });
+    fs.writeFileSync(
+      path.join(plugin, "go.mod"),
+      "module example.com/plugin\n\ngo 1.26\n",
+      "utf8",
+    );
+    fs.writeFileSync(path.join(plugin, "main.go"), "package main\n", "utf8");
+    for (const toolchain of [relativeToolchainA, relativeToolchainB]) {
+      fs.copyFileSync(script, path.join(toolchain, "capture.cjs"));
+    }
+    fs.writeFileSync(
+      path.join(relativeToolchainA, "go.cmd"),
+      `@echo off\r\nrem compiler a\r\n"%TTSC_GO_TEST_NODE%" "%~dp0capture.cjs" %*\r\n`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(relativeToolchainB, "go.cmd"),
+      `@echo off\r\nrem compiler b\r\n"%TTSC_GO_TEST_NODE%" "%~dp0capture.cjs" %*\r\n`,
+      "utf8",
+    );
+    const keyA = computeCacheKey({
+      dir: plugin,
+      entry: ".",
+      env: {
+        ...env,
+        PATH: "relative-toolchain-a",
+        PATHEXT: ".CMD",
+      },
+      goBinary: "go",
+      ttscVersion: "1.0.0",
+      tsgoVersion: "7.0.0-dev",
+    });
+    const keyB = computeCacheKey({
+      dir: plugin,
+      entry: ".",
+      env: {
+        ...env,
+        PATH: "relative-toolchain-b",
+        PATHEXT: ".CMD",
+      },
+      goBinary: "go",
+      ttscVersion: "1.0.0",
+      tsgoVersion: "7.0.0-dev",
+    });
+    assert.notEqual(keyA, keyB);
+
+    for (const missing of [
+      "missing-go",
+      "missing-go.cmd",
+      ".\\missing-go.cmd",
+    ]) {
       const result = spawnGoTool(missing, ["version"], {
         cwd: root,
         encoding: "utf8",
@@ -143,10 +332,25 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
         (line) =>
           JSON.parse(line) as { args: string[]; sentinel: string | undefined },
       );
+    const expectedArgs = [
+      ...commands,
+      lookupArgs,
+      relativeArgs,
+      whitespaceArgs,
+      semicolonArgs,
+      noCwdArgs,
+      inheritedPathArgs,
+      duplicatePathArgs,
+    ];
     assert.deepEqual(
-      captured.map(({ args }) => args),
-      [...commands, lookupArgs, relativeArgs],
+      captured.slice(0, expectedArgs.length).map(({ args }) => args),
+      expectedArgs,
     );
+    assert.equal(captured.length, expectedArgs.length + 4);
+    for (let index = expectedArgs.length; index < captured.length; index += 2) {
+      assert.deepEqual(captured[index]?.args, ["version"]);
+      assert.deepEqual(captured[index + 1]?.args.slice(0, 2), ["env", "-json"]);
+    }
     assert.ok(captured.every(({ sentinel }) => sentinel === "preserved"));
     assert.equal(
       Object.keys(env).some((key) => key.startsWith("TTSC_GO_COMMAND_SHIM_")),

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
@@ -203,6 +203,24 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
     const noDefaultCurrentDirectory =
       process.env.NoDefaultCurrentDirectoryInExePath;
     try {
+      delete process.env.NoDefaultCurrentDirectoryInExePath;
+      const childPolicyResult = spawnGoTool("go", ["version"], {
+        cwd: blockedRoot,
+        encoding: "utf8",
+        env: {
+          ...env,
+          NoDefaultCurrentDirectoryInExePath: "1",
+          PATH: `"${semicolonRoot}"`,
+          PATHEXT: ".CMD",
+        },
+        windowsHide: true,
+      });
+      assert.equal(
+        childPolicyResult.status,
+        91,
+        "the child environment must not disable libuv's parent cwd probe",
+      );
+
       process.env.NoDefaultCurrentDirectoryInExePath = "1";
       const noCwdResult = spawnGoTool("go", noCwdArgs, {
         cwd: blockedRoot,
@@ -218,6 +236,21 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
         noCwdResult.status,
         0,
         noCwdResult.stderr || noCwdResult.error?.message,
+      );
+      const quotedEmptyResult = spawnGoTool("go", ["version"], {
+        cwd: blockedRoot,
+        encoding: "utf8",
+        env: {
+          ...env,
+          PATH: `"";"${semicolonRoot}"`,
+          PATHEXT: ".CMD",
+        },
+        windowsHide: true,
+      });
+      assert.equal(
+        quotedEmptyResult.status,
+        91,
+        "a quoted-empty PATH entry must explicitly select cwd",
       );
     } finally {
       if (noDefaultCurrentDirectory === undefined) {

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
@@ -1,0 +1,83 @@
+import { TestProject } from "@ttsc/testing";
+
+import { spawnGoTool } from "../../../../../packages/ttsc/lib/plugin/internal/buildSourcePlugin.js";
+import { assert, fs, path } from "../../internal/source-build";
+
+/** Windows command wrappers receive literal paths and argv through cmd.exe. */
+export const test_spawngotool_preserves_windows_command_wrapper_arguments =
+  () => {
+    if (process.platform !== "win32") return;
+
+    const root = TestProject.tmpdir("ttsc-go-command-shim-");
+    const wrapperRoot = path.join(
+      root,
+      "%TTSC_GO_EXPANDS% literal %% & (parentheses) ^ caret",
+    );
+    fs.mkdirSync(wrapperRoot, { recursive: true });
+    const capture = path.join(root, "argv.jsonl");
+    const script = path.join(wrapperRoot, "capture.cjs");
+    fs.writeFileSync(
+      script,
+      [
+        'const fs = require("node:fs");',
+        "fs.appendFileSync(",
+        "  process.env.TTSC_GO_ARGV_CAPTURE,",
+        "  JSON.stringify({",
+        "    args: process.argv.slice(2),",
+        "    sentinel: process.env.TTSC_GO_CALLER_SENTINEL,",
+        '  }) + "\\n",',
+        '  "utf8",',
+        ");",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const wrapper = path.join(wrapperRoot, "go.cmd");
+    fs.writeFileSync(
+      wrapper,
+      `@echo off\r\n"%TTSC_GO_TEST_NODE%" "%~dp0capture.cjs" %*\r\n`,
+      "utf8",
+    );
+
+    const commands = [
+      ["version"],
+      ["env", "-json", "GOOS", "%SET_VALUE%", "%%", "%", "%UNKNOWN%"],
+      ["mod", "edit", "-json", "space value", "&", "(value)", "^"],
+      ["build", "-o", path.join(wrapperRoot, '%OUTPUT% & "quoted" \\'), "."],
+    ];
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      TTSC_GO_ARGV_CAPTURE: capture,
+      TTSC_GO_CALLER_SENTINEL: "preserved",
+      TTSC_GO_EXPANDS: "WRONG_DIRECTORY",
+      TTSC_GO_TEST_NODE: process.execPath,
+      SET_VALUE: "WRONG_ARGUMENT",
+    };
+    for (const args of commands) {
+      const result = spawnGoTool(wrapper, args, {
+        encoding: "utf8",
+        env,
+        windowsHide: true,
+      });
+      assert.equal(result.status, 0, result.stderr || result.error?.message);
+    }
+
+    const captured = fs
+      .readFileSync(capture, "utf8")
+      .trim()
+      .split(/\r?\n/)
+      .map(
+        (line) =>
+          JSON.parse(line) as { args: string[]; sentinel: string | undefined },
+      );
+    assert.deepEqual(
+      captured.map(({ args }) => args),
+      commands,
+    );
+    assert.ok(captured.every(({ sentinel }) => sentinel === "preserved"));
+    assert.equal(
+      Object.keys(env).some((key) => key.startsWith("TTSC_GO_COMMAND_SHIM_")),
+      false,
+      "the caller's environment object must not be mutated",
+    );
+  };

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
@@ -131,7 +131,7 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
     const whitespaceResult = spawnGoTool("go", whitespaceArgs, {
       cwd: root,
       encoding: "utf8",
-      env: { ...env, PATH: whitespaceRoot, PATHEXT: ".CMD" },
+      env: { ...env, PATH: " leading-path-entry", PATHEXT: ".CMD" },
       windowsHide: true,
     });
     assert.equal(
@@ -155,6 +155,18 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
       semicolonResult.status,
       0,
       semicolonResult.stderr || semicolonResult.error?.message,
+    );
+    const singleQuoteArgs = ["version", "single-quoted semicolon PATH"];
+    const singleQuoteResult = spawnGoTool("go", singleQuoteArgs, {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...env, PATH: `'${semicolonRoot}'`, PATHEXT: ".CMD" },
+      windowsHide: true,
+    });
+    assert.equal(
+      singleQuoteResult.status,
+      0,
+      singleQuoteResult.stderr || singleQuoteResult.error?.message,
     );
 
     fs.copyFileSync(wrapper, path.join(wrapperRoot, "node.cmd"));
@@ -307,6 +319,39 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
     });
     assert.notEqual(keyA, keyB);
 
+    const nativeTemplate = path.join(
+      process.env.SystemRoot ?? "C:\\Windows",
+      "System32",
+      "where.exe",
+    );
+    const extendedNativeA = path.join(root, "extended-native-a");
+    const extendedNativeB = path.join(root, "extended-native-b");
+    fs.mkdirSync(extendedNativeA, { recursive: true });
+    fs.mkdirSync(extendedNativeB, { recursive: true });
+    const goV1A = path.join(extendedNativeA, "go.v1.exe");
+    const goV1B = path.join(extendedNativeB, "go.v1.exe");
+    fs.copyFileSync(nativeTemplate, goV1A);
+    fs.copyFileSync(nativeTemplate, goV1B);
+    fs.appendFileSync(goV1A, "compiler a");
+    fs.appendFileSync(goV1B, "compiler b");
+    const extendedKeyA = computeCacheKey({
+      dir: plugin,
+      entry: ".",
+      env: { ...env, PATH: extendedNativeA },
+      goBinary: "go.v1",
+      ttscVersion: "1.0.0",
+      tsgoVersion: "7.0.0-dev",
+    });
+    const extendedKeyB = computeCacheKey({
+      dir: plugin,
+      entry: ".",
+      env: { ...env, PATH: extendedNativeB },
+      goBinary: "go.v1",
+      ttscVersion: "1.0.0",
+      tsgoVersion: "7.0.0-dev",
+    });
+    assert.notEqual(extendedKeyA, extendedKeyB);
+
     for (const missing of [
       "missing-go",
       "missing-go.cmd",
@@ -338,6 +383,7 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
       relativeArgs,
       whitespaceArgs,
       semicolonArgs,
+      singleQuoteArgs,
       noCwdArgs,
       inheritedPathArgs,
       duplicatePathArgs,

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
@@ -11,7 +11,7 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
     const root = TestProject.tmpdir("ttsc-go-command-shim-");
     const wrapperRoot = path.join(
       root,
-      "%TTSC_GO_EXPANDS% literal %% & (parentheses) ^ caret",
+      "%TTSC_GO_EXPANDS% literal %% & (parentheses) ^ caret !TTSC_GO_DELAYED!",
     );
     fs.mkdirSync(wrapperRoot, { recursive: true });
     const capture = path.join(root, "argv.jsonl");
@@ -41,7 +41,18 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
 
     const commands = [
       ["version"],
-      ["env", "-json", "GOOS", "%SET_VALUE%", "%%", "%", "%UNKNOWN%"],
+      [
+        "env",
+        "-json",
+        "GOOS",
+        "%SET_VALUE%",
+        "%%",
+        "%",
+        "%UNKNOWN%",
+        "!SET_VALUE!",
+        "!",
+        "!UNKNOWN!",
+      ],
       ["mod", "edit", "-json", "space value", "&", "(value)", "^"],
       ["build", "-o", path.join(wrapperRoot, '%OUTPUT% & "quoted" \\'), "."],
     ];
@@ -49,6 +60,7 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
       ...process.env,
       TTSC_GO_ARGV_CAPTURE: capture,
       TTSC_GO_CALLER_SENTINEL: "preserved",
+      TTSC_GO_DELAYED: "WRONG_DIRECTORY",
       TTSC_GO_EXPANDS: "WRONG_DIRECTORY",
       TTSC_GO_TEST_NODE: process.execPath,
       SET_VALUE: "WRONG_ARGUMENT",

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
@@ -1,11 +1,33 @@
 import { TestProject } from "@ttsc/testing";
 
-import { spawnGoTool } from "../../../../../packages/ttsc/lib/plugin/internal/buildSourcePlugin.js";
+import {
+  spawnGoTool,
+  windowsGoCommandArgs,
+} from "../../../../../packages/ttsc/lib/plugin/internal/buildSourcePlugin.js";
 import { assert, fs, path } from "../../internal/source-build";
 
-/** Windows command wrappers receive literal paths and argv through cmd.exe. */
+/**
+ * Verifies source plugins: Windows command wrappers receive literal argv.
+ *
+ * `cmd.exe` expands percent references and, when enabled, delayed exclamation
+ * references even inside quoted command text. The source-plugin launcher must
+ * disable delayed expansion and pass every volatile value through one-pass
+ * environment indirection without mutating the caller's environment.
+ *
+ * 1. Assert the production cmd argument plan explicitly contains `/v:off`.
+ * 2. Put a fake `go.cmd` under a path containing expansion and shell syntax.
+ * 3. Run every Go subcommand shape with hostile argv and capture what arrived.
+ * 4. Assert every byte and caller-owned environment entry is preserved.
+ */
 export const test_spawngotool_preserves_windows_command_wrapper_arguments =
   () => {
+    assert.deepEqual(windowsGoCommandArgs("payload"), [
+      "/d",
+      "/v:off",
+      "/s",
+      "/c",
+      "payload",
+    ]);
     if (process.platform !== "win32") return;
 
     const root = TestProject.tmpdir("ttsc-go-command-shim-");

--- a/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
+++ b/tests/test-ttsc/src/native-plugins/source-plugin/test_spawngotool_preserves_windows_command_wrapper_arguments.ts
@@ -16,8 +16,8 @@ import { assert, fs, path } from "../../internal/source-build";
  *
  * 1. Assert the production cmd argument plan explicitly contains `/v:off`.
  * 2. Put a fake `go.cmd` under a path containing expansion and shell syntax.
- * 3. Run every Go subcommand shape with hostile argv and capture what arrived.
- * 4. Assert every byte and caller-owned environment entry is preserved.
+ * 3. Run absolute, PATH-resolved, and relative wrappers with hostile argv.
+ * 4. Assert argv/environment fidelity and ENOENT for missing wrapper forms.
  */
 export const test_spawngotool_preserves_windows_command_wrapper_arguments =
   () => {
@@ -96,6 +96,45 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
       assert.equal(result.status, 0, result.stderr || result.error?.message);
     }
 
+    const lookupArgs = ["env", "PATH lookup", "%LOOKUP%", "!LOOKUP!"];
+    const lookupResult = spawnGoTool("go", lookupArgs, {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...env, PATH: wrapperRoot, PATHEXT: ".EXE;.CMD" },
+      windowsHide: true,
+    });
+    assert.equal(
+      lookupResult.status,
+      0,
+      lookupResult.stderr || lookupResult.error?.message,
+    );
+
+    const relativeArgs = ["version", "relative wrapper"];
+    const relativeResult = spawnGoTool(".\\go.cmd", relativeArgs, {
+      cwd: wrapperRoot,
+      encoding: "utf8",
+      env,
+      windowsHide: true,
+    });
+    assert.equal(
+      relativeResult.status,
+      0,
+      relativeResult.stderr || relativeResult.error?.message,
+    );
+
+    for (const missing of ["missing-go.cmd", ".\\missing-go.cmd"]) {
+      const result = spawnGoTool(missing, ["version"], {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...env, PATH: root, PATHEXT: ".CMD" },
+        windowsHide: true,
+      });
+      assert.equal(
+        (result.error as NodeJS.ErrnoException | undefined)?.code,
+        "ENOENT",
+      );
+    }
+
     const captured = fs
       .readFileSync(capture, "utf8")
       .trim()
@@ -106,7 +145,7 @@ export const test_spawngotool_preserves_windows_command_wrapper_arguments =
       );
     assert.deepEqual(
       captured.map(({ args }) => args),
-      commands,
+      [...commands, lookupArgs, relativeArgs],
     );
     assert.ok(captured.every(({ sentinel }) => sentinel === "preserved"));
     assert.equal(

--- a/tests/test-wasm/src/features/memfs/test_memfs_descriptors_enforce_their_access_mode.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_descriptors_enforce_their_access_mode.ts
@@ -1,5 +1,5 @@
 import { TestValidator } from "@nestia/e2e";
-import { createMemFS } from "@ttsc/wasm";
+import { type IWasmExecFS, createMemFS } from "@ttsc/wasm";
 
 import {
   callMutation,
@@ -14,6 +14,12 @@ import {
 const O_WRONLY = 1;
 const O_RDWR = 2;
 const O_TRUNC = 512;
+
+function fstatMtime(fs: IWasmExecFS, fd: number): Promise<number> {
+  return new Promise<number>((resolve, reject) =>
+    fs.fstat(fd, (err, stats) => (err ? reject(err) : resolve(stats.mtimeMs))),
+  );
+}
 
 /**
  * Verifies a MemFS descriptor only permits the operations its `open` access
@@ -43,13 +49,23 @@ export const test_memfs_descriptors_enforce_their_access_mode =
       { ...rejectedWrite, text: host.readFileText("/f.txt") },
       { code: "EBADF", n: 0, text: "abc" },
     );
+    const readOnlyMtime = await fstatMtime(host.fs, readOnly);
+    while (Date.now() <= readOnlyMtime)
+      await new Promise((resolve) => setTimeout(resolve, 1));
     TestValidator.equals(
       "a read-only descriptor rejects ftruncate without moving its cursor",
       {
+        beforeMtime: readOnlyMtime,
         code: await expectFsError((cb) => host.fs.ftruncate(readOnly, 1, cb)),
+        afterMtime: await fstatMtime(host.fs, readOnly),
         text: host.readFileText("/f.txt"),
       },
-      { code: "EBADF", text: "abc" },
+      {
+        beforeMtime: readOnlyMtime,
+        code: "EBADF",
+        afterMtime: readOnlyMtime,
+        text: "abc",
+      },
     );
     TestValidator.equals(
       "a write-only descriptor rejects reads",

--- a/tests/test-wasm/src/features/memfs/test_memfs_descriptors_enforce_their_access_mode.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_descriptors_enforce_their_access_mode.ts
@@ -2,6 +2,7 @@ import { TestValidator } from "@nestia/e2e";
 import { createMemFS } from "@ttsc/wasm";
 
 import {
+  callMutation,
   expectFsError,
   openFd,
   openResult,
@@ -45,6 +46,14 @@ export const test_memfs_descriptors_enforce_their_access_mode =
       { code: "EBADF", n: 0, text: "abc" },
     );
     TestValidator.equals(
+      "a read-only descriptor rejects ftruncate without moving its cursor",
+      {
+        code: await expectFsError((cb) => host.fs.ftruncate(readOnly, 1, cb)),
+        text: host.readFileText("/f.txt"),
+      },
+      { code: "EBADF", text: "abc" },
+    );
+    TestValidator.equals(
       "a write-only descriptor rejects reads",
       await expectFsError((cb) =>
         host.fs.read(writeOnly, new Uint8Array(1), 0, 1, null, cb),
@@ -54,19 +63,20 @@ export const test_memfs_descriptors_enforce_their_access_mode =
 
     // Positive twins: the granted directions still work.
     TestValidator.equals(
-      "a read-only descriptor still reads",
+      "a rejected ftruncate leaves the read-only cursor unchanged",
       await readFdText(host.fs, readOnly, 3),
       "abc",
     );
     const allowedWrite = await writeFdText(host.fs, readWrite, "X", 0);
+    await callMutation((cb) => host.fs.ftruncate(writeOnly, 2, cb));
     TestValidator.equals(
-      "a read-write descriptor reads and writes",
+      "writable descriptors still write and truncate",
       {
         ...allowedWrite,
         text: host.readFileText("/f.txt"),
         read: await readFdText(host.fs, readWrite, 3),
       },
-      { code: null, n: 1, text: "Xbc", read: "Xbc" },
+      { code: null, n: 1, text: "Xb", read: "Xb" },
     );
 
     // A directory opens read-only only; a write mode would replace it.

--- a/tests/test-wasm/src/features/memfs/test_memfs_descriptors_enforce_their_access_mode.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_descriptors_enforce_their_access_mode.ts
@@ -32,7 +32,7 @@ function fstatMtime(fs: IWasmExecFS, fd: number): Promise<number> {
  *
  * 1. Open the same file read-only, write-only, and read-write.
  * 2. Reject read-only write and truncate plus write-only read operations.
- * 3. Assert `EBADF`, unchanged bytes and cursor, and permitted mutations.
+ * 3. Assert `EBADF`, unchanged bytes, mtime, and cursor, plus permitted mutations.
  */
 export const test_memfs_descriptors_enforce_their_access_mode =
   async (): Promise<void> => {
@@ -48,6 +48,11 @@ export const test_memfs_descriptors_enforce_their_access_mode =
       "a read-only descriptor rejects writes",
       { ...rejectedWrite, text: host.readFileText("/f.txt") },
       { code: "EBADF", n: 0, text: "abc" },
+    );
+    TestValidator.equals(
+      "the read-only descriptor advances before rejected ftruncate",
+      await readFdText(host.fs, readOnly, 1),
+      "a",
     );
     const readOnlyMtime = await fstatMtime(host.fs, readOnly);
     while (Date.now() <= readOnlyMtime)
@@ -78,8 +83,8 @@ export const test_memfs_descriptors_enforce_their_access_mode =
     // Positive twins: the granted directions still work.
     TestValidator.equals(
       "a rejected ftruncate leaves the read-only cursor unchanged",
-      await readFdText(host.fs, readOnly, 3),
-      "abc",
+      await readFdText(host.fs, readOnly, 2),
+      "bc",
     );
     const allowedWrite = await writeFdText(host.fs, readWrite, "X", 0);
     await callMutation((cb) => host.fs.ftruncate(writeOnly, 2, cb));

--- a/tests/test-wasm/src/features/memfs/test_memfs_descriptors_enforce_their_access_mode.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_descriptors_enforce_their_access_mode.ts
@@ -20,15 +20,13 @@ const O_TRUNC = 512;
  * mode granted.
  *
  * The descriptor record stored just a path and an offset, so a read-only
- * descriptor accepted writes and a write-only descriptor accepted reads. Both
- * reported success, which is worse than a refusal: the caller keeps a handle it
- * believes is restricted while the file changes underneath it.
+ * descriptor accepted writes and a write-only descriptor accepted reads. A
+ * later gap also let read-only descriptors truncate the file. These operations
+ * must fail before changing bytes, mtime, or the shared cursor.
  *
  * 1. Open the same file read-only, write-only, and read-write.
- * 2. Drive a write through the read-only fd and a read through the write-only fd,
- *    then exercise both directions on the read-write fd.
- * 3. Assert the forbidden operations return `EBADF` with zero bytes and no byte
- *    change, and that the permitted ones still work.
+ * 2. Reject read-only write and truncate plus write-only read operations.
+ * 3. Assert `EBADF`, unchanged bytes and cursor, and permitted mutations.
  */
 export const test_memfs_descriptors_enforce_their_access_mode =
   async (): Promise<void> => {

--- a/tests/test-wasm/src/features/memfs/test_memfs_descriptors_keep_open_node_identity.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_descriptors_keep_open_node_identity.ts
@@ -23,8 +23,15 @@ function fstatSize(fs: IWasmExecFS, fd: number): Promise<number> {
 }
 
 /**
- * Open descriptors retain their node when unlink or replacement rename changes
- * names.
+ * Verifies MemFS: open descriptors retain identity across namespace changes.
+ *
+ * Path-only descriptors either disappeared after unlink or retargeted to a
+ * replacement rename destination. Each fd must retain its opened node while the
+ * namespace independently removes or replaces names.
+ *
+ * 1. Unlink an open file, then read, write, truncate, and stat through its fd.
+ * 2. Rename one open file over another open file.
+ * 3. Mutate both fds and assert their bytes remain distinct after close.
  */
 export const test_memfs_descriptors_keep_open_node_identity =
   async (): Promise<void> => {

--- a/tests/test-wasm/src/features/memfs/test_memfs_descriptors_keep_open_node_identity.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_descriptors_keep_open_node_identity.ts
@@ -31,7 +31,7 @@ function fstatSize(fs: IWasmExecFS, fd: number): Promise<number> {
  *
  * 1. Unlink an open file, then read, write, truncate, and stat through its fd.
  * 2. Rename one open file over another open file.
- * 3. Mutate both fds and assert their bytes remain distinct after close.
+ * 3. Mutate both fds, assert distinct bytes, then close without recreating names.
  */
 export const test_memfs_descriptors_keep_open_node_identity =
   async (): Promise<void> => {

--- a/tests/test-wasm/src/features/memfs/test_memfs_descriptors_keep_open_node_identity.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_descriptors_keep_open_node_identity.ts
@@ -1,0 +1,85 @@
+import { TestValidator } from "@nestia/e2e";
+import { type IWasmExecFS, createMemFS } from "@ttsc/wasm";
+
+import { callMutation, openFd, writeFdText } from "../../internal/callbackFs";
+
+const O_RDWR = 2;
+
+function readAt(fs: IWasmExecFS, fd: number, length: number): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const buffer = new Uint8Array(length);
+    fs.read(fd, buffer, 0, length, 0, (err, n) =>
+      err
+        ? reject(err)
+        : resolve(new TextDecoder().decode(buffer.subarray(0, n))),
+    );
+  });
+}
+
+function fstatSize(fs: IWasmExecFS, fd: number): Promise<number> {
+  return new Promise<number>((resolve, reject) =>
+    fs.fstat(fd, (err, stats) => (err ? reject(err) : resolve(stats.size))),
+  );
+}
+
+/**
+ * Open descriptors retain their node when unlink or replacement rename changes
+ * names.
+ */
+export const test_memfs_descriptors_keep_open_node_identity =
+  async (): Promise<void> => {
+    const host = createMemFS();
+
+    host.writeFile("/unlinked.txt", "KEEP");
+    const unlinkedFd = await openFd(host.fs, "/unlinked.txt", O_RDWR);
+    await callMutation((cb) => host.fs.unlink("/unlinked.txt", cb));
+    await writeFdText(host.fs, unlinkedFd, "X", 0);
+    await callMutation((cb) => host.fs.ftruncate(unlinkedFd, 2, cb));
+    TestValidator.equals(
+      "unlink removes only the name",
+      {
+        pathExists: host.exists("/unlinked.txt"),
+        fdText: await readAt(host.fs, unlinkedFd, 4),
+        fdSize: await fstatSize(host.fs, unlinkedFd),
+      },
+      { pathExists: false, fdText: "XE", fdSize: 2 },
+    );
+
+    host.writeFile("/source.txt", "NEW");
+    host.writeFile("/destination.txt", "OLD");
+    const sourceFd = await openFd(host.fs, "/source.txt", O_RDWR);
+    const destinationFd = await openFd(host.fs, "/destination.txt", O_RDWR);
+    await callMutation((cb) =>
+      host.fs.rename("/source.txt", "/destination.txt", cb),
+    );
+
+    TestValidator.equals(
+      "replacement rename keeps both opened nodes distinct",
+      {
+        source: await readAt(host.fs, sourceFd, 3),
+        destination: await readAt(host.fs, destinationFd, 3),
+      },
+      { source: "NEW", destination: "OLD" },
+    );
+
+    await writeFdText(host.fs, sourceFd, "S", 0);
+    await writeFdText(host.fs, destinationFd, "D", 0);
+    TestValidator.equals(
+      "writes through either descriptor do not cross over",
+      {
+        named: host.readFileText("/destination.txt"),
+        displaced: await readAt(host.fs, destinationFd, 3),
+      },
+      { named: "SEW", displaced: "DLD" },
+    );
+
+    await callMutation((cb) => host.fs.close(destinationFd, cb));
+    TestValidator.equals(
+      "closing the displaced descriptor does not recreate a name",
+      {
+        source: host.exists("/source.txt"),
+        destination: host.readFileText("/destination.txt"),
+      },
+      { source: false, destination: "SEW" },
+    );
+  };

--- a/tests/test-wasm/src/features/memfs/test_memfs_descriptors_keep_open_node_identity.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_descriptors_keep_open_node_identity.ts
@@ -1,7 +1,12 @@
 import { TestValidator } from "@nestia/e2e";
 import { type IWasmExecFS, createMemFS } from "@ttsc/wasm";
 
-import { callMutation, openFd, writeFdText } from "../../internal/callbackFs";
+import {
+  callMutation,
+  expectFsError,
+  openFd,
+  writeFdText,
+} from "../../internal/callbackFs";
 
 const O_RDWR = 2;
 
@@ -29,7 +34,7 @@ function fstatSize(fs: IWasmExecFS, fd: number): Promise<number> {
  * replacement rename destination. Each fd must retain its opened node while the
  * namespace independently removes or replaces names.
  *
- * 1. Unlink an open file, then read, write, truncate, and stat through its fd.
+ * 1. Unlink an open file, reject path stat, then use every fd operation.
  * 2. Rename one open file over another open file.
  * 3. Mutate both fds, assert distinct bytes, then close without recreating names.
  */
@@ -46,10 +51,13 @@ export const test_memfs_descriptors_keep_open_node_identity =
       "unlink removes only the name",
       {
         pathExists: host.exists("/unlinked.txt"),
+        pathStat: await expectFsError((cb) =>
+          host.fs.stat("/unlinked.txt", cb),
+        ),
         fdText: await readAt(host.fs, unlinkedFd, 4),
         fdSize: await fstatSize(host.fs, unlinkedFd),
       },
-      { pathExists: false, fdText: "XE", fdSize: 2 },
+      { pathExists: false, pathStat: "ENOENT", fdText: "XE", fdSize: 2 },
     );
 
     host.writeFile("/source.txt", "NEW");

--- a/tests/test-wasm/src/features/memfs/test_memfs_ftruncate_resizes_via_descriptor.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_ftruncate_resizes_via_descriptor.ts
@@ -14,7 +14,7 @@ import { callMutation, expectFsError, openFd } from "../../internal/callbackFs";
  *
  * 1. Seed `/t.txt`="abcdef", then shrink its descriptor to 3 and grow it to 5.
  * 2. Read the bytes and reject unknown, stdout, and negative-length calls.
- * 3. Assert shrink, zero-filled growth, and each invalid descriptor code.
+ * 3. Assert shrink, zero-filled growth, and each rejection code.
  */
 export const test_memfs_ftruncate_resizes_via_descriptor =
   async (): Promise<void> => {

--- a/tests/test-wasm/src/features/memfs/test_memfs_ftruncate_resizes_via_descriptor.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_ftruncate_resizes_via_descriptor.ts
@@ -12,10 +12,9 @@ import { callMutation, expectFsError, openFd } from "../../internal/callbackFs";
  * file: the reserved stdout/stderr fds and unknown fds. The pre-fix version was
  * a no-op, so a descriptor-based truncate left the file unchanged.
  *
- * 1. Seed `/t.txt`="abcdef" and open it, then ftruncate the descriptor to 3.
- * 2. Read the file back and attempt ftruncate on an unknown fd, the stdout fd, and
- *    a negative length.
- * 3. Assert the file shrank to "abc" and each invalid call carries its code.
+ * 1. Seed `/t.txt`="abcdef", then shrink its descriptor to 3 and grow it to 5.
+ * 2. Read the bytes and reject unknown, stdout, and negative-length calls.
+ * 3. Assert shrink, zero-filled growth, and each invalid descriptor code.
  */
 export const test_memfs_ftruncate_resizes_via_descriptor =
   async (): Promise<void> => {
@@ -28,6 +27,13 @@ export const test_memfs_ftruncate_resizes_via_descriptor =
       "descriptor truncate shrinks the file",
       host.readFileText("/t.txt"),
       "abc",
+    );
+    await callMutation((cb) => host.fs.ftruncate(fd, 5, cb));
+    const grown = host.readFile("/t.txt");
+    TestValidator.equals(
+      "descriptor truncate zero-extends the file",
+      grown === null ? null : [...grown],
+      [97, 98, 99, 0, 0],
     );
 
     const codes = {

--- a/tests/test-wasm/src/features/memfs/test_memfs_low_level_mkdir_creates_one_directory.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_low_level_mkdir_creates_one_directory.ts
@@ -8,8 +8,15 @@ import {
 } from "../../internal/callbackFs";
 
 /**
- * The low-level mkdir callback creates one directory and preserves mkdirp
- * semantics.
+ * Verifies MemFS: low-level mkdir creates exactly one directory.
+ *
+ * Delegating the callback API to `mkdirp` created missing ancestors and treated
+ * existing targets as success. The low-level operation must reject before any
+ * mutation while the host convenience helper stays recursive and idempotent.
+ *
+ * 1. Create normalized children beneath an existing parent.
+ * 2. Attempt missing-parent, file-parent, existing-target, and root cases.
+ * 3. Assert exact error codes, atomic state, and unchanged `mkdirp` behavior.
  */
 export const test_memfs_low_level_mkdir_creates_one_directory =
   async (): Promise<void> => {

--- a/tests/test-wasm/src/features/memfs/test_memfs_low_level_mkdir_creates_one_directory.ts
+++ b/tests/test-wasm/src/features/memfs/test_memfs_low_level_mkdir_creates_one_directory.ts
@@ -1,0 +1,74 @@
+import { TestValidator } from "@nestia/e2e";
+import { createMemFS } from "@ttsc/wasm";
+
+import {
+  callMutation,
+  expectFsError,
+  readdir,
+} from "../../internal/callbackFs";
+
+/**
+ * The low-level mkdir callback creates one directory and preserves mkdirp
+ * semantics.
+ */
+export const test_memfs_low_level_mkdir_creates_one_directory =
+  async (): Promise<void> => {
+    const host = createMemFS();
+    host.mkdirp("/parent");
+    host.writeFile("/file", "FILE");
+
+    await callMutation((cb) => host.fs.mkdir("/parent/child", 0o755, cb));
+    await callMutation((cb) =>
+      host.fs.mkdir("/parent/./nested/../alias", 0o755, cb),
+    );
+
+    TestValidator.equals(
+      "mkdir creates exactly one normalized child",
+      await readdir(host.fs, "/parent"),
+      ["alias", "child"],
+    );
+
+    const codes = {
+      missingParent: await expectFsError((cb) =>
+        host.fs.mkdir("/missing/child", 0o755, cb),
+      ),
+      fileParent: await expectFsError((cb) =>
+        host.fs.mkdir("/file/child", 0o755, cb),
+      ),
+      existingFile: await expectFsError((cb) =>
+        host.fs.mkdir("/file", 0o755, cb),
+      ),
+      existingDirectory: await expectFsError((cb) =>
+        host.fs.mkdir("/parent", 0o755, cb),
+      ),
+      normalizedExisting: await expectFsError((cb) =>
+        host.fs.mkdir("/parent/x/../child", 0o755, cb),
+      ),
+      root: await expectFsError((cb) => host.fs.mkdir("/", 0o755, cb)),
+    };
+    TestValidator.equals("mkdir rejection codes", codes, {
+      missingParent: "ENOENT",
+      fileParent: "ENOTDIR",
+      existingFile: "EEXIST",
+      existingDirectory: "EEXIST",
+      normalizedExisting: "EEXIST",
+      root: "EEXIST",
+    });
+    TestValidator.equals(
+      "rejected mkdir never creates a missing ancestor",
+      {
+        missing: host.exists("/missing"),
+        child: host.exists("/missing/child"),
+        file: host.readFileText("/file"),
+      },
+      { missing: false, child: false, file: "FILE" },
+    );
+
+    host.mkdirp("/deep/a/b");
+    host.mkdirp("/deep/a/b");
+    TestValidator.equals(
+      "mkdirp remains recursive and idempotent",
+      await readdir(host.fs, "/deep/a"),
+      ["b"],
+    );
+  };


### PR DESCRIPTION
## Intent

Claim the complete accepted third cycle of the 2026-07-22 solo issue campaign in one pull request.

## Scope

- retain MemFS descriptor authority and node identity across unlink and replacement rename;
- give the low-level MemFS `mkdir` callback single-directory semantics while preserving `mkdirp`;
- pass Windows Go command wrappers and their arguments as literal data through `cmd.exe`;
- key `@ttsc/paths` source lookup with the compiler host's filesystem case sensitivity;
- honor general single-star package export patterns in the plugin loader and playground sandbox; and
- classify only registry-supported npm ranges, aliases, and dist-tags as registry requests.

Closes #950.
Closes #951.
Closes #952.
Closes #953.
Closes #954.
Closes #955.

## Verification

Focused regression coverage accompanies every implementation unit, including Windows-only process and case-sensitivity witnesses.

Per maintainer direction, no local build or test command ran. Ordinary pull-request CI owns all build and test verification; `typia.yml` and `nestia.yml` are not campaign gates.

## Review Ledger

Every pushed commit and every Self-Review round is recorded as a formal `COMMENT`-event GitHub pull-request review. Ordinary issue-style PR comments are not used for this ledger.
