### PR TITLE
docs: saturate issue discovery before development

### DIFF
--- a/.agents/skills/issue-campaign/SKILL.md
+++ b/.agents/skills/issue-campaign/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: issue-campaign
-description: "Defines the default solo repository-wide issue campaign for ttsc: exhaustive discovery, lead-vetted issue publication, one unified CI-validated implementation pull request per cycle, solo Self-Review, and repeated rediscovery until a full clean round. Use for broad audits, many issue candidates, or repeated issue-to-pull-request campaigns unless the user explicitly requests parallel or multi-agent execution; do not use for one already-defined issue or an ordinary pull request."
+description: "Defines the default solo repository-wide issue campaign for ttsc: repeated full-scope discovery to an empty round before each unified CI-validated implementation pull request, lead-vetted issue publication, solo Self-Review, and renewed cycles until a cycle discovers nothing. Use for broad audits, many issue candidates, or repeated issue-to-pull-request campaigns unless the user explicitly requests parallel or multi-agent execution; do not use for one already-defined issue or an ordinary pull request."
 ---
 
 # Issue Campaign
 
-An issue campaign is a repeatable solo sequence of exhaustive discovery, issue publication, one unified implementation pull request, and renewed discovery. The main agent owns every phase and spawns no subagent other than the read-only commit early-warning pass that [development.md](development.md#implement-and-write-tests) defines.
+An issue campaign is a repeatable solo sequence. Each cycle saturates exhaustive discovery against one integrated repository state, publishes the accepted issues, and opens one unified implementation pull request only after a complete fresh discovery round is empty. A merge starts the next cycle against the new integrated state. The main agent owns every phase and spawns no subagent other than the read-only commit early-warning pass that [development.md](development.md#implement-and-write-tests) defines.
 
 Use the [multi-agent skill](../multi-agent/SKILL.md) and its issue-campaign procedure instead only when the user explicitly asks for a parallel or multi-agent issue campaign.
 
@@ -23,9 +23,9 @@ Keep concise, current Markdown documents for:
 
 - repository provenance, architecture, validation ownership, and product boundaries;
 - experiments, reproductions, dogfooding, and related issue or pull-request history;
-- every raw candidate, its evidence, dependencies, and final disposition;
+- every discovery round's integrated baseline, every raw candidate, its evidence, dependencies, and final disposition;
 - candidate combinations, splits, rejections, deferrals, and the evidence supporting each decision; and
-- the published-issue DAG, internal implementation order, the unified cycle pull request, CI and Self-Review iterations, external blockers, campaign timing, and cleanup state.
+- each cycle's final empty-round gate, published-issue DAG, internal implementation order, unified pull request, CI and Self-Review iterations, external blockers, campaign timing, and cleanup state.
 
 Record raw candidates before fact-checking. The knowledge base is the durable place to collect overlapping observations, then combine, split, rewrite, reject, or defer them without losing why.
 
@@ -33,21 +33,23 @@ The knowledge base supports the campaign but is not the final issue body. A publ
 
 ## Discover Issues
 
-Perform one complete Solo Issue Discovery Round over the entire declared campaign scope. Source is only one evidence layer. Exercise real workflows and inspect relevant upstream behavior, history, generated artifacts, consumers, fixtures, public documentation, and closed decisions.
+Perform a complete Solo Issue Discovery Round over the entire declared campaign scope. Source is only one evidence layer. Exercise real workflows and inspect relevant upstream behavior, history, generated artifacts, consumers, fixtures, public documentation, and closed decisions.
 
 Treat the development skill's [Forbidden](../development/SKILL.md#forbidden) section as a retrospective audit contract, not only a rule for future changes. In every complete round, inspect the implementation and history for a verified violation, even when existing tests pass. Prove the classification from purpose, control flow, consequence, and history. Resemblance or stylistic preference is not evidence.
 
-Do not stop after finding enough work for a pull request. Complete the entire scope, adjudicate the full candidate pool, and publish only the surviving issues when authorized.
+Do not stop after finding enough work for a pull request. Complete the entire scope, adjudicate the full candidate pool, and publish only the surviving issues when authorized. Any surviving candidate makes the round nonempty and requires another complete fresh round before development.
 
 ### Every Round Is Full-Scope
 
-Every round re-audits the entire declared scope against the current integrated state. A round is never partitioned: not by package, concern, or validation lane, not by the areas the last cycle happened to touch, and not by splitting the scope across rounds so that each one covers a slice. A merged cycle changes the state every earlier conclusion rested on, so what an earlier round read is not coverage for this one. The [review skill's Non-Negotiable Review Law](../review/SKILL.md#non-negotiable-review-law) states the same rule for every round and review the campaign runs.
+Every round re-audits the entire declared scope against the cycle's recorded pre-development integrated state. A round is never partitioned: not by package, concern, or validation lane, not by the areas the last round or cycle happened to touch, and not by splitting the scope across rounds so that each one covers a slice. The [review skill's Non-Negotiable Review Law](../review/SKILL.md#non-negotiable-review-law) states the same rule for every round and review the campaign runs.
 
-### Discovery Ends Only On An Empty Round
+### Development Starts Only After An Empty Round
 
-A merged cycle does not end the campaign. It produces one more round: begin a fresh full-scope round against the integrated repository. Discovery continues cycle after cycle, with no round limit, and ends only when one complete fresh round produces no meaningful issue candidate after fact-checking and no accepted issue remains unresolved.
+Keep implementation closed throughout the cycle's discovery saturation. After each round, adjudicate the full candidate pool and publish its surviving issues when authorized. If any meaningful candidate survives, accumulate every accepted issue in the cycle ledger and begin another complete fresh full-scope round against the same pre-development integrated state. Do not claim an implementation branch, write code, or substitute candidate rechecks for the required new round.
 
-Report the campaign complete only from a round that actually came up empty. Ending after a cycle that merely felt thorough leaves the issues the next round would have found unrecorded.
+Open development only after one complete fresh round produces no meaningful candidate after fact-checking. That empty round freezes the accumulated accepted issue set for the unified cycle pull request. Any integrated-state change before the implementation claim invalidates the gate and requires a new saturation sequence against the new state. An empty round with accepted issues ends only the discovery phase; the campaign remains active until those issues are resolved.
+
+After merge, start a new cycle and repeat the same saturation process against the new integrated state. Report the campaign complete only when that process reaches an empty round with no accepted campaign issue left unresolved.
 
 ## Vet And Publish Issues
 
@@ -76,6 +78,6 @@ Use tables for repeated case mappings. Read the rendered issue back and keep its
 
 ## Develop And Repeat The Campaign
 
-Read [development.md](development.md) in full when the user authorizes implementation pull requests or the end of a campaign that entered implementation. It owns the single cycle pull request, empty claim, internal DAG order, test authoring, formatting, ordinary CI, red-CI repair, solo Self-Review, merge, branch and temporary-asset cleanup, and renewed discovery.
+Read [development.md](development.md) in full when the user authorizes implementation pull requests or the end of a campaign that entered implementation. It owns the single cycle pull request, empty claim, internal DAG order, test authoring, formatting, ordinary CI, red-CI repair, solo Self-Review, merge, branch and temporary-asset cleanup, and renewed discovery. Do not take a development action until the cycle's empty-round gate has passed.
 
 An audit-only or issue-publication-only campaign does not load the development procedure or mutate repository or GitHub state beyond the authorized publications.

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -11,14 +11,17 @@ Read this document in full when the user authorizes implementation pull requests
 - [Merge And Clean Up](#merge-and-clean-up)
 - [Repeat Until A Clean Round](#repeat-until-a-clean-round)
 
-Four rules govern the implementation phase:
+Five rules govern the implementation phase:
 
+- Enter implementation only after the parent skill's discovery saturation ends with a complete fresh empty round against the recorded pre-development integrated state.
 - The main agent performs all implementation, test authoring, CI diagnosis, review, and cleanup. Spawn no subagent except the read-only [commit early-warning pass](#implement-and-write-tests).
 - Put every accepted, implementation-ready issue in the current cycle into one pull request. The issue DAG controls implementation order inside that pull request, not pull-request count.
 - Work in the current checkout and one topic branch. Do not create a clone or worktree for a solo campaign or its Self-Review.
 - The pull request's ordinary CI and a clean solo Self-Review are the acceptance gates. Repair every red CI lane in that same pull request, even when the failure predates the campaign or is unrelated to its original issues.
 
 ## Plan One Cycle Pull Request
+
+Confirm the discovery gate before planning or claiming work. The campaign ledger must identify the integrated baseline, every complete discovery round against it, the last round's empty result, and the accepted issue set accumulated across preceding nonempty rounds. Fetch the target branch and compare it with that baseline. If the last complete round is not empty or the target advanced, synchronize the target checkout, record the new baseline, and return to discovery instead of opening development.
 
 Recompute the published-issue dependency DAG after publication. Record dependencies because they determine safe edit order and when one fix can expose another, but do not partition ready issues into separate pull requests.
 
@@ -40,7 +43,7 @@ Difficulty never removes an issue from the cycle. When a resolution needs a judg
 
 Claim the whole cycle before implementation:
 
-1. Use the current checkout, update the target branch with `git pull --ff-only`, and create one topic branch. Do not create a clone or worktree.
+1. Use the current checkout, confirm the target branch still matches the gated baseline, and create one topic branch from that exact state. Do not create a clone or worktree.
 2. Create one implementation-free commit with `git commit --allow-empty`.
 3. Push the branch and open one draft pull request.
 4. Reference every cycle issue by number, mark verification pending, and state that the pull request owns the complete accepted cycle.
@@ -115,9 +118,11 @@ Formatting belongs to the unified cycle pull request, so a separate post-campaig
 
 ## Repeat Until A Clean Round
 
-After every merged cycle, return to the parent skill's Discover Issues phase and perform another complete fresh round over the entire declared scope.
+After every merged cycle, return to the parent skill's Discover Issues phase and start the next cycle against the new integrated state.
 
-If any meaningful candidate survives fact-checking, adjudicate and publish it when authorized, then claim the next single cycle pull request containing every implementation-ready issue. Repeat discovery, implementation, CI, review, merge, and cleanup without a fixed round limit.
+If any meaningful candidate survives fact-checking, adjudicate and publish it when authorized, accumulate it in the next cycle ledger, and run another complete fresh full-scope round against that same pre-development state. Repeat discovery without a fixed round limit and do not claim the next pull request until a subsequent complete round is empty.
+
+After the empty-round gate passes, claim the next single cycle pull request containing every implementation-ready issue accumulated by the preceding nonempty rounds. If the gate passes with no accepted issue to implement, finish the remaining cleanup and evaluate the completion conditions below.
 
 The campaign succeeds only when all of these are true:
 

--- a/.agents/skills/multi-agent/issue-campaign.md
+++ b/.agents/skills/multi-agent/issue-campaign.md
@@ -10,11 +10,12 @@ A multi-agent issue campaign parallelizes both discovery and implementation by d
 
 Switch to parallel discovery with solo implementation only when the user explicitly requests that combination. In that mode:
 
-1. Run Parallel Discovery and let the lead complete candidate adjudication and authorized publication.
-2. Stop every discovery agent before implementation begins.
-3. Read the base issue campaign's [solo development procedure](../issue-campaign/development.md).
-4. Put every implementation-ready issue into its one empty-claim pull request, use the current checkout without a worktree, run `pnpm format`, validate through ordinary CI, and complete solo Self-Review while CI runs.
-5. Apply that procedure's implementation, CI, merge, branch cleanup, and temporary-asset rules, but return here for the next parallel discovery round instead of switching to solo discovery.
+1. Run Parallel Discovery repeatedly against the recorded pre-development integrated state until one complete parallel round is empty. Let the lead adjudicate every round and publish accepted issues when authorized.
+2. Stop every discovery agent only after the empty-round development gate passes.
+3. If the gate passes with no accepted issue, skip implementation and evaluate [Completion](#completion).
+4. Otherwise read the base issue campaign's [solo development procedure](../issue-campaign/development.md).
+5. Put every implementation-ready issue into its one empty-claim pull request, use the current checkout without a worktree, run `pnpm format`, validate through ordinary CI, and complete solo Self-Review while CI runs.
+6. Apply that procedure's implementation, CI, merge, branch cleanup, and temporary-asset rules, but return here for the next parallel discovery round instead of switching to solo discovery.
 
 Do not infer solo implementation from quota concerns, a small issue count, or the fact that the lead performs publication. Only the user's explicit phase boundary selects it.
 
@@ -24,9 +25,11 @@ Use [review.md](review.md)'s Parallel Issue Discovery Rounds. Every discovery ag
 
 Pool raw candidates in `.wiki`, then reproduce and combine, split, rewrite, reject, or defer them before publication. Parallel discovery changes evidence breadth, not publication authority.
 
+Keep implementation closed while any meaningful candidate survives a round. Accumulate accepted issues, end the current discovery team, and run another complete parallel full-scope round against the same recorded pre-development integrated state. Begin implementation only after one complete team round is empty and the accumulated accepted issue set is nonempty.
+
 ## Build Coarse Implementation Batches
 
-When implementation is also parallel, recompute the published-issue DAG before every wave. Form the smallest number of maximal cohesive batches that dependency readiness and ownership permit.
+When implementation is also parallel, first confirm the empty-round discovery gate and freeze the accumulated accepted issue set. Recompute the published-issue DAG before every wave. Form the smallest number of maximal cohesive batches that dependency readiness and ownership permit.
 
 Group issues only when they are ready on the same frontier, share an architectural owner or root invariant, overlap in consequence surface, use mostly the same verification, and remain understandable and reversible as one diff. Split for a named dependency, external blocker, repository or target-branch boundary, independent release contract, incompatible verification owner, destructive file overlap, or lost issue-level attribution.
 
@@ -73,6 +76,6 @@ After every parallel implementation batch is resolved and its worktree and exter
 
 ## Completion
 
-After the selected implementation flow is resolved, run another complete parallel full-scope discovery round against the integrated repository.
+After the selected implementation flow is resolved, start the next cycle against the integrated repository. Repeat complete parallel full-scope rounds against that state until a full team round is empty, accumulating every accepted issue before any new implementation begins.
 
 The campaign succeeds only when every reviewer completes the whole scope, no meaningful candidate survives lead verification, no accepted issue remains unresolved, and every campaign worktree and assignment-owned temporary asset is removed. Report an external blocker as blocked, not complete.

--- a/.agents/skills/multi-agent/review.md
+++ b/.agents/skills/multi-agent/review.md
@@ -33,7 +33,9 @@ Use this mode only through the multi-agent issue-campaign procedure.
 2. Each reviewer independently audits source, tests, documentation, CI, packaging, generated artifacts, platform behavior, upstream or downstream provenance, and open and closed issue or pull-request history. Audit the current implementation and history against the development skill's **Forbidden** section.
 3. Each reviewer records its own evidence-backed raw candidates without seeing or negotiating a shared candidate list.
 4. The lead reopens every candidate from primary evidence, reproduces it, checks ownership and provenance, traces the consequence surface, and records accept, partial acceptance, rewrite, combine, split, reject, or defer in `.wiki`.
-5. If any meaningful candidate survives, complete the authorized campaign cycle and begin another fresh parallel round over the integrated state.
-6. End discovery only when every reviewer completes the whole scope and no meaningful candidate survives lead verification.
+5. If any meaningful candidate survives, complete its authorized adjudication and publication, keep implementation closed, end the current discovery team, and begin another complete parallel round against the same recorded pre-development integrated state.
+6. Repeat step 5 without a round limit. Earlier team rounds, candidate rechecks, and sampled areas do not count toward the new round.
+7. End the cycle's discovery phase only when every reviewer in one fresh round completes the whole scope and no meaningful candidate survives lead verification. Hand every implementation-ready accepted issue accumulated across the preceding nonempty rounds to implementation.
+8. After the integrated implementation merges, start the next cycle's discovery saturation from the new integrated state. End the campaign only when an empty round leaves no accepted campaign issue unresolved.
 
-An unresolved accepted issue or incomplete implementation prevents a successful campaign conclusion.
+An empty round can open implementation while accepted issues remain, but an unresolved accepted issue or incomplete implementation prevents a successful campaign conclusion.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -48,10 +48,12 @@ Use these rounds only through the solo issue-campaign skill.
 3. Reopen each candidate from primary evidence, reproduce it, verify ownership and provenance, and trace its complete consequence surface.
 4. Record accept, partial acceptance, rewrite, combine, split, reject, or defer. Keep the disposition and reason in the knowledge base so later passes do not rediscover a rejected premise as new.
 5. Publish only the surviving adjudicated form when the campaign is authorized to publish.
-6. If any meaningful candidate survives, finish the authorized issue and implementation flow, then begin another fresh full-scope round over the integrated state.
-7. End discovery only when one complete fresh round over the entire scope produces no meaningful candidate after fact-checking.
+6. If any meaningful candidate survives, complete its authorized adjudication and publication, keep implementation closed, and begin another complete fresh full-scope round against the same recorded pre-development integrated state.
+7. Repeat step 6 without a round limit. Candidate rechecks, sampled areas, and the completed work from earlier rounds do not count toward the next round.
+8. End the cycle's discovery phase only when one complete fresh round over the entire scope produces no meaningful candidate after fact-checking. Hand every implementation-ready accepted issue accumulated across the preceding nonempty rounds to the cycle's unified development pull request.
+9. After that pull request merges, start the next cycle's discovery saturation from the new integrated state. End the campaign only when an empty round leaves no accepted campaign issue unresolved.
 
-An unresolved accepted issue, external blocker, or incomplete implementation prevents a successful campaign conclusion. Report it as blocked or active rather than treating it as a clean round.
+An empty round can open development while accepted issues remain, but an unresolved accepted issue, external blocker, or incomplete implementation prevents a successful campaign conclusion. Report the campaign as blocked or active rather than complete.
 
 ## Explicit Multi-Agent Reviews
 


### PR DESCRIPTION
## Summary

- require every issue-campaign cycle to repeat fresh full-scope discovery until one round is empty before implementation begins
- accumulate all accepted issues from nonempty rounds into the cycle's unified implementation pull request
- invalidate the empty-round gate when the integrated target advances, and apply the same ordering to parallel campaigns

## Verification

- Main-agent full-document Self-Review pending on this pull request
- `git diff --check` passed
- Formatting, build, tests, and CI intentionally not run for this instruction-only documentation change