### PR TITLE
docs: require individual self-review for campaign commits

### DIFF
--- a/.agents/skills/issue-campaign/SKILL.md
+++ b/.agents/skills/issue-campaign/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: issue-campaign
-description: "Defines the default solo repository-wide issue campaign for ttsc: repeated full-scope discovery to an empty round before each unified CI-validated implementation pull request, lead-vetted issue publication, solo Self-Review, and renewed cycles until a cycle discovers nothing. Use for broad audits, many issue candidates, or repeated issue-to-pull-request campaigns unless the user explicitly requests parallel or multi-agent execution; do not use for one already-defined issue or an ordinary pull request."
+description: "Defines the default solo repository-wide issue campaign for ttsc: repeated full-scope discovery to an empty round before each unified CI-validated implementation pull request, lead-vetted issue publication, mandatory Individual and Overall Self-Review, and renewed cycles until a cycle discovers nothing. Use for broad audits, many issue candidates, or repeated issue-to-pull-request campaigns unless the user explicitly requests parallel or multi-agent execution; do not use for one already-defined issue or an ordinary pull request."
 ---
 
 # Issue Campaign
 
-An issue campaign is a repeatable solo sequence. Each cycle saturates exhaustive discovery against one integrated repository state, publishes the accepted issues, and opens one unified implementation pull request only after a complete fresh discovery round is empty. A merge starts the next cycle against the new integrated state. The main agent owns every phase and spawns no subagent other than the read-only commit early-warning pass that [development.md](development.md#implement-and-write-tests) defines.
+An issue campaign is a repeatable solo sequence. Each cycle saturates exhaustive discovery against one integrated repository state, publishes the accepted issues, and opens one unified implementation pull request only after a complete fresh discovery round is empty. A merge starts the next cycle against the new integrated state. The main agent owns every phase and spawns no subagent other than the mandatory read-only Individual Self-Review that [development.md](development.md#implement-and-write-tests) defines for each coherent pushed issue-implementation commit.
 
 Use the [multi-agent skill](../multi-agent/SKILL.md) and its issue-campaign procedure instead only when the user explicitly asks for a parallel or multi-agent issue campaign.
 
@@ -78,6 +78,6 @@ Use tables for repeated case mappings. Read the rendered issue back and keep its
 
 ## Develop And Repeat The Campaign
 
-Read [development.md](development.md) in full when the user authorizes implementation pull requests or the end of a campaign that entered implementation. It owns the single cycle pull request, empty claim, internal DAG order, test authoring, formatting, ordinary CI, red-CI repair, solo Self-Review, merge, branch and temporary-asset cleanup, and renewed discovery. Do not take a development action until the cycle's empty-round gate has passed.
+Read [development.md](development.md) in full when the user authorizes implementation pull requests or the end of a campaign that entered implementation. It owns the single cycle pull request, empty claim, internal DAG order, test authoring, formatting, ordinary CI, Individual and Overall Self-Review, red-CI repair, merge, branch and temporary-asset cleanup, and renewed discovery. Do not take a development action until the cycle's empty-round gate has passed.
 
 An audit-only or issue-publication-only campaign does not load the development procedure or mutate repository or GitHub state beyond the authorized publications.

--- a/.agents/skills/issue-campaign/development.md
+++ b/.agents/skills/issue-campaign/development.md
@@ -7,17 +7,17 @@ Read this document in full when the user authorizes implementation pull requests
 - [Plan One Cycle Pull Request](#plan-one-cycle-pull-request)
 - [Claim The Complete Cycle](#claim-the-complete-cycle)
 - [Implement And Write Tests](#implement-and-write-tests)
-- [Validate With CI And Self-Review](#validate-with-ci-and-self-review)
+- [Validate With CI And Overall Self-Review](#validate-with-ci-and-overall-self-review)
 - [Merge And Clean Up](#merge-and-clean-up)
 - [Repeat Until A Clean Round](#repeat-until-a-clean-round)
 
 Five rules govern the implementation phase:
 
 - Enter implementation only after the parent skill's discovery saturation ends with a complete fresh empty round against the recorded pre-development integrated state.
-- The main agent performs all implementation, test authoring, CI diagnosis, review, and cleanup. Spawn no subagent except the read-only [commit early-warning pass](#implement-and-write-tests).
+- The main agent performs all implementation, test authoring, CI diagnosis, adjudication, Overall Self-Review, and cleanup. For every coherent pushed issue-implementation commit, spawn exactly one read-only [Individual Self-Review](#implement-and-write-tests) subagent.
 - Put every accepted, implementation-ready issue in the current cycle into one pull request. The issue DAG controls implementation order inside that pull request, not pull-request count.
 - Work in the current checkout and one topic branch. Do not create a clone or worktree for a solo campaign or its Self-Review.
-- The pull request's ordinary CI and a clean solo Self-Review are the acceptance gates. Repair every red CI lane in that same pull request, even when the failure predates the campaign or is unrelated to its original issues.
+- The pull request's ordinary CI and a clean Overall Self-Review are the acceptance gates. Repair every red CI lane in that same pull request, even when the failure predates the campaign or is unrelated to its original issues.
 
 ## Plan One Cycle Pull Request
 
@@ -57,17 +57,19 @@ The empty pull request prevents overlapping contributor work before code is writ
 
 Work through the DAG on the claimed topic branch. Analyze the full consequence and case surface across every issue before editing, then implement the complete cycle and its tests.
 
-Implement without interruption. Write each piece's tests as that piece lands instead of leaving the tests for the end of the cycle, and keep committing as each unit becomes coherent. Do not pause the sequence for a check run; [CI is read once per settled head](#validate-with-ci-and-self-review).
+Implement without interruption. Write each piece's tests as that piece lands instead of leaving the tests for the end of the cycle, and keep committing as each unit becomes coherent. Do not pause the sequence for a check run; [CI is read once per settled head](#validate-with-ci-and-overall-self-review).
 
 Close each issue from the commit that earns it. End the commit message with one `Close #n: <issue title>` line per resolved issue, so a commit that resolves several issues carries several lines. GitHub matches the keyword and the number and ignores the title tail, so the line closes the issue normally while the log stays legible without opening each number.
 
 A revert inside the pull request must not carry the closing keyword forward: `git revert` quotes the original subject, so rewrite its default `Revert "Close #n: ..."` without the closing phrase, and drop any `Closes #n` line for that issue from the pull-request body. That does not spare the issue by itself. A squash merge concatenates every commit message into the merge commit body, where the reverted commit's own `Close #n` line still sits, so the merge closes an issue whose fix no longer exists at `HEAD` and [the merge gate](#merge-and-clean-up) has to reopen it.
 
-After each pushed commit, submit a formal GitHub pull-request review with the `COMMENT` event naming the commit, what it landed, and which issues it resolved. The review is the running ledger for a reader who does not read the diff, not a closing mechanism: GitHub closes an issue only from a commit message or the pull-request body. Follow the [pull-request skill](../pull-request/SKILL.md#write-the-pull-request) for inline comments, review bodies, and self-review restrictions; do not replace this ledger with ordinary issue-style pull-request comments.
+Immediately after each coherent issue-implementation commit is pushed, start exactly one read-only subagent Individual Self-Review over that commit's parent-to-commit diff. Do not wait for its result or for per-commit CI. Continue the next ready issue immediately while the review runs.
 
-Once a commit lands, the main agent may spawn one read-only subagent as a commit early-warning pass over that commit and keep implementing while it runs. The pass reads that one commit and reports candidates. It never edits, commits, pushes, or makes an implementation decision. Its value is timing: a defect named while that code is the newest thing written costs little to correct, and nothing has been built on top of it yet.
+The individual reviewer advises the main agent only. It reports candidate findings for that one commit and never edits, commits, pushes, posts to GitHub, or makes implementation or disposition decisions.
 
-The pass never reduces the [Self-Review](#validate-with-ci-and-self-review) that gates the merge. A reader holding one commit cannot see what appears only across files: a helper that duplicates one the package already has, a document claiming a verification that the component it describes does not perform, or a replacement whose needle cannot match because the file on disk uses CRLF. The main agent's own complete round over the whole base-to-head diff is what finds those, and no number of passes substitutes for it. The [review skill](../review/SKILL.md#commit-early-warning-pass) owns that boundary and the name the pass must not take.
+When the result arrives, the main agent adjudicates every candidate and records the Individual Self-Review as one formal GitHub pull-request review with the `COMMENT` event. Name the commit, summarize what landed and which issues it resolved, attach line-specific findings as inline review comments, and put commit-wide findings or a clean result in the review body. This review is the running ledger for a reader who does not read the diff, not a closing mechanism. Do not replace it with an ordinary issue-style pull-request comment.
+
+Individual Self-Review never reduces or substitutes for [Overall Self-Review](#validate-with-ci-and-overall-self-review). One commit cannot expose every cross-file or integrated consequence, and individual reviews do not combine into an overall round. The [review skill](../review/SKILL.md#individual-self-review) owns this boundary.
 
 Each issue remains an evidence and acceptance unit inside the combined diff. Keep its positive, negative, boundary, and regression cases identifiable. Near-100% coverage of changed behavior is required; a green happy path is not completion.
 
@@ -75,18 +77,18 @@ Follow the development skill for test shape and narrow-then-broad local evidence
 
 If implementation disproves, narrows, or externally blocks an issue, reopen the evidence and update the issue and campaign ledger before changing the claimed scope. Do not leave an orphan issue or pretend an unresolved accepted issue was completed.
 
-## Validate With CI And Self-Review
+## Validate With CI And Overall Self-Review
 
-Commit and push the formatted integrated snapshot, then let every ordinary pull-request check run. Start solo Self-Review immediately over that exact base-to-head diff while CI executes.
+After no ready issue remains, receive and adjudicate every outstanding Individual Self-Review result. Commit and push the formatted integrated snapshot, then let every ordinary pull-request check run. Start the solo Overall Self-Review immediately over that exact base-to-head diff while CI executes.
 
-Submit every Self-Review finding round and the final clean round as a formal GitHub pull-request review with the `COMMENT` event. Attach line-specific findings as inline review comments and summarize round-wide findings or the clean conclusion in the review body; do not post ordinary issue-style pull-request comments for Self-Review.
+Submit every Overall Self-Review finding round and the final clean round as a formal GitHub pull-request review with the `COMMENT` event. Attach line-specific findings as inline review comments and summarize round-wide findings or the clean conclusion in the review body. Do not post ordinary issue-style pull-request comments for Self-Review.
 
 Read CI once per settled head. It gates the cycle, not each commit: every pull-request workflow sets `cancel-in-progress`, so the next push cancels an intermediate commit's run and waiting on that run stalls implementation for a discarded result.
 
 CI and review are independent gates:
 
 - CI must prove every configured build, type-check, test, packaging, and platform lane.
-- Self-Review must prove requirement fidelity, consequence coverage, issue-by-issue acceptance, test quality, documentation, generated output, and risks not encoded in CI.
+- Overall Self-Review must prove requirement fidelity, consequence coverage, issue-by-issue acceptance, test quality, documentation, generated output, and risks not encoded in CI.
 
 When either gate finds a defect:
 
@@ -94,11 +96,12 @@ When either gate finds a defect:
 2. Correct the source and complete the corresponding regression coverage.
 3. Run `pnpm format`.
 4. Commit and push the correction to the same pull request.
-5. Let the new CI run to completion and restart Self-Review as a fresh complete round over the new head.
+5. Immediately start exactly one Individual Self-Review for that correction commit without waiting for it or per-commit CI.
+6. Adjudicate and record the individual result when it arrives, let the new CI run to completion, and restart Overall Self-Review as a fresh complete round over the new head.
 
 Fix every red CI lane in the same pull request even when the failure predates the campaign or is unrelated to the campaign's original issues. Do not dismiss it as another contributor's failure.
 
-Do not merge a head whose green checks belong to an older SHA or whose clean review predates a correction. Continue the loop until the same immutable head has green required checks and a complete Self-Review round with no sound improvement.
+Do not merge a head whose green checks belong to an older SHA, whose clean Overall Self-Review predates a correction, or whose required Individual Self-Review result remains unrecorded. Continue the loop until the same immutable head has green required checks and a complete Overall Self-Review round with no sound improvement.
 
 ## Merge And Clean Up
 

--- a/.agents/skills/multi-agent/SKILL.md
+++ b/.agents/skills/multi-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multi-agent
-description: "Defines the explicitly parallel variants of ttsc review and issue campaigns. Use only when the user explicitly requests a team, parallel, or multi-agent review or campaign. Route review work to review.md and issue campaigns to issue-campaign.md. Self-Review and unqualified review remain solo. Multi-agent issue campaigns parallelize discovery and implementation by default, but an explicit request may limit parallelism to discovery and return implementation to the solo campaign."
+description: "Defines the explicitly parallel variants of ttsc review and issue campaigns. Use only when the user explicitly requests a team, parallel, or multi-agent review or campaign. Route review work to review.md and issue campaigns to issue-campaign.md. Overall Self-Review and unqualified review remain solo; the solo campaign's mandatory Individual Self-Review is a separate narrow subagent workflow. Multi-agent issue campaigns parallelize discovery and implementation by default, but an explicit request may limit parallelism to discovery and return implementation to the solo campaign."
 ---
 
 # Multi-Agent Workflows
@@ -14,7 +14,7 @@ This skill is the single entry point for every explicitly parallel review or cam
 
 `ttsc` has no benchmark-campaign skill. Use [benchmark](../benchmark/SKILL.md) for measurement integrity, then the applicable issue-campaign workflow for authorized benchmark-driven implementation.
 
-Do not load this skill for Self-Review, an unqualified review, or a campaign that does not explicitly request parallel agents.
+Do not load this skill merely for Individual Self-Review, Overall Self-Review, an unqualified review, or a campaign that does not explicitly request parallel agents.
 
 ## Shared Parallelism Rules
 
@@ -24,8 +24,8 @@ Do not load this skill for Self-Review, an unqualified review, or a campaign tha
 - Partition implementation only through verified dependency and file-ownership boundaries. One agent owns one coarse batch, branch, pull request, and worktree.
 - Keep the lead active on fact-checking, integration, conflict resolution, and decisions that do not duplicate an assigned agent.
 - Do not let agents re-delegate.
-- Self-Review remains solo for every author and every implementation branch.
+- Overall Self-Review remains solo for every author and every implementation branch.
 - Create worktrees only for parallel implementation batches and their integrated cleanup. Solo implementation and review use the current checkout.
 - Remove every finished worktree, local branch, process, and assignment-owned temporary asset before declaring its assignment complete.
 
-The solo campaign's [commit early-warning pass](../review/SKILL.md#commit-early-warning-pass) is a different topology and relaxes neither the full-surface rule nor the solo Self-Review rule above. A parallel review gives several reviewers the entire declared surface independently and the lead adjudicates their findings. The pass gives one read-only reader one commit's slice, reports candidates to the author who is still implementing, and leaves that author's own whole-surface round as the gate. A batch implementation agent here runs no pass, because agents do not re-delegate; the carve-out in the solo development procedure belongs to a solo campaign's main agent.
+The solo campaign's [Individual Self-Review](../review/SKILL.md#individual-self-review) is a different topology and relaxes neither the full-surface rule nor the solo Overall Self-Review rule above. A parallel review gives several reviewers the entire declared surface independently and the lead adjudicates their findings. Individual Self-Review gives exactly one read-only reviewer one pushed commit's parent-to-commit diff, returns advice to the main agent while implementation continues, and leaves that main agent's whole-surface Overall Self-Review as the merge gate. A batch implementation agent here runs no Individual Self-Review because agents do not re-delegate; the mandatory carve-out in the solo development procedure belongs to a solo campaign's main agent.

--- a/.agents/skills/multi-agent/issue-campaign.md
+++ b/.agents/skills/multi-agent/issue-campaign.md
@@ -14,7 +14,7 @@ Switch to parallel discovery with solo implementation only when the user explici
 2. Stop every discovery agent only after the empty-round development gate passes.
 3. If the gate passes with no accepted issue, skip implementation and evaluate [Completion](#completion).
 4. Otherwise read the base issue campaign's [solo development procedure](../issue-campaign/development.md).
-5. Put every implementation-ready issue into its one empty-claim pull request, use the current checkout without a worktree, run `pnpm format`, validate through ordinary CI, and complete solo Self-Review while CI runs.
+5. Put every implementation-ready issue into its one empty-claim pull request, use the current checkout without a worktree, run `pnpm format`, validate through ordinary CI, and follow the solo development procedure's Individual and Overall Self-Review rules.
 6. Apply that procedure's implementation, CI, merge, branch cleanup, and temporary-asset rules, but return here for the next parallel discovery round instead of switching to solo discovery.
 
 Do not infer solo implementation from quota concerns, a small issue count, or the fact that the lead performs publication. Only the user's explicit phase boundary selects it.
@@ -51,7 +51,7 @@ For each immediately executable batch:
 6. Install dependencies asynchronously when needed, then implement the full consequence surface and near-100% positive, negative, boundary, and regression coverage.
 7. Commit and push coherent increments, cancelling only the new runs for that exact branch.
 8. Run the narrowest local proving commands followed by the broader locally owned lanes.
-9. Freeze the head and complete solo Self-Review. If code changes, rerun the necessary local gates and restart the full review.
+9. Freeze the head and complete solo Overall Self-Review. If code changes, rerun the necessary local gates and restart the full review.
 10. Let the lead independently verify issue fit, dispositions, evidence, and batch scope.
 11. If any campaign pull-request run reaches red, diagnose and repair it in the same pull request, then commit and push the repair even when the failure predates the campaign or is unrelated to its original issues.
 12. Merge only with user authorization after local verification, lead review, the final campaign-run cancellation record, and any red-CI repair are complete.
@@ -69,10 +69,10 @@ After every parallel implementation batch is resolved and its worktree and exter
 1. Create one cleanup worktree and topic branch from the integrated target.
 2. Install dependencies when needed and run `pnpm format`.
 3. Run the full integrated local validation required by the project skill.
-4. If formatting changes files, open one ordinary cleanup pull request, let all CI checks run, and perform solo Self-Review while they run.
+4. If formatting changes files, open one ordinary cleanup pull request, let all CI checks run, and perform solo Overall Self-Review while they run.
 5. Repair every CI or review finding in the same cleanup pull request, including a red lane unrelated to the campaign's original changes, and repeat until the same head is green and clean.
 6. Merge with authorization, then remove the cleanup worktree, branch, and assignment-owned external assets.
-7. If formatting produces no diff, complete solo Self-Review over the integrated target, then remove the unused cleanup worktree and branch without opening a pull request.
+7. If formatting produces no diff, complete solo Overall Self-Review over the integrated target, then remove the unused cleanup worktree and branch without opening a pull request.
 
 ## Completion
 

--- a/.agents/skills/multi-agent/review.md
+++ b/.agents/skills/multi-agent/review.md
@@ -2,7 +2,7 @@
 
 Read this document only through the multi-agent skill for an explicitly requested team, parallel, or multi-agent review. The base review skill's Non-Negotiable Review Law still governs every reviewer: one agent performs one complete review of the entire declared surface from scratch.
 
-Do not use this procedure for Self-Review. The author always completes Self-Review alone even when a separate team review is also authorized.
+Do not use this procedure for Individual or Overall Self-Review. The author always completes Overall Self-Review alone even when a separate team review is also authorized. Individual Self-Review exists only in the solo issue-campaign workflow defined by the base review and campaign-development skills.
 
 ## Bound The Team
 

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -5,7 +5,7 @@ description: Defines ttsc branch, commit, pull-request, check, and merge workflo
 
 # Pull Request Submission
 
-Act on this skill only when the user explicitly requests the corresponding remote action, or when a standing autonomous mandate authorizes it. Permission to edit locally is not permission to push or open a pull request, and permission to open or update is not permission to merge. The one exception is a standing autonomous mandate — an autonomous or remote-control campaign, or an explicit instruction to carry the work through merge: it is the request for every step it names, including push and merge, and the skill's check, verification, and self-review gates still apply to each step.
+Act on this skill only when the user explicitly requests the corresponding remote action, or when a standing autonomous mandate authorizes it. Permission to edit locally is not permission to push or open a pull request, and permission to open or update is not permission to merge. The one exception is a standing autonomous mandate, such as an autonomous or remote-control campaign or an explicit instruction to carry the work through merge. It requests every step it names, including push and merge, and the skill's check, verification, and Self-Review gates still apply to each step.
 
 ## Branch From The Target
 
@@ -25,7 +25,7 @@ Stage explicit paths when the worktree is mixed. Never include unrelated user ch
 
 Write the body at open as the historical intent statement. Include the intent, scope, deferred items, and exact local verification. State skipped checks and disabled campaign CI honestly.
 
-Do not rewrite the body after every follow-up push. Record later CI fixes, newly discovered design issues, promoted deferred work, and Self-Review results as formal GitHub pull-request reviews with the `COMMENT` event so the thread preserves chronology. Use inline review comments when an observation belongs to a changed line and the review body for commit-wide or round-wide results. Do not use ordinary issue-style pull-request comments for this ledger, and never `APPROVE` or `REQUEST_CHANGES` on your own pull request. The title describes the merged outcome in Conventional Commits style, not the work process.
+Do not rewrite the body after every follow-up push. Record later CI fixes, newly discovered design issues, promoted deferred work, Individual Self-Review results, and Overall Self-Review rounds as formal GitHub pull-request reviews with the `COMMENT` event so the thread preserves chronology. Use inline review comments when an observation belongs to a changed line and the review body for commit-wide or round-wide results. Do not use ordinary issue-style pull-request comments for this ledger, and never `APPROVE` or `REQUEST_CHANGES` on your own pull request. The title describes the merged outcome in Conventional Commits style, not the work process.
 
 Push only the topic branch with upstream tracking. Use a file-backed body for multiline Markdown when opening through `gh`.
 
@@ -35,7 +35,7 @@ Before any issue-campaign push or pull request, complete `.agents/skills/issue-c
 
 ## Watch Checks After Every Ordinary Push
 
-After each ordinary push, including every multi-agent integrated-cleanup push, monitor the pull-request checks until every check settles. Only CI-suspended campaign implementation waves skip this loop. On failure, fetch the relevant job log, diagnose the real cause, fix it in place, push a new commit, and resume monitoring. Do not treat a green unrelated job as acceptance for a failed required surface.
+After each ordinary push, including every multi-agent integrated-cleanup push, monitor the pull-request checks until every check settles. Solo issue-campaign implementation commits and CI-suspended campaign implementation waves skip this per-push wait. The solo campaign main agent starts the required Individual Self-Review and immediately implements the next ready issue, then reads CI once the integrated head settles as its development procedure requires. On failure, fetch the relevant job log, diagnose the real cause, fix it in place, push a new commit, and resume monitoring. Do not treat a green unrelated job as acceptance for a failed required surface.
 
 ## Merge On Explicit Request Or Standing Autonomous Mandate
 

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: review
-description: Defines exhaustive solo review, Self-Review, and solo repository-wide issue-discovery rounds for ttsc. Use for every self-review or unqualified review request and as the default review mode inside issue campaigns. This skill never spawns review agents; use the multi-agent skill only when the user explicitly requests a team, parallel, or multi-agent review.
+description: Defines exhaustive solo Overall Self-Review, mandatory advisory Individual Self-Review for solo issue-campaign commits, unqualified review, and solo repository-wide issue-discovery rounds for ttsc. Use for every self-review or unqualified review request and as the default review mode inside issue campaigns; use the multi-agent skill only when the user explicitly requests a team, parallel, or multi-agent review.
 ---
 
 # Review
 
+Individual Self-Review and Overall Self-Review are both Self-Review workflows. Individual review is a mandatory advisory pass over one pushed campaign commit, while Overall review is the solo whole-diff merge gate.
+
 ## Non-Negotiable Review Law
 
-One reviewer performs every review in this skill from scratch over the entire declared surface. Do not spawn a subagent, delegate a concern, or load the discussion skill. Do not create a clone or worktree for solo review or Self-Review.
+One reviewer performs every review in this skill from scratch over its entire declared surface. Do not spawn a subagent for an unqualified review, Overall Self-Review, or issue discovery, and do not delegate a concern or load the discussion skill. The mandatory Individual Self-Review defined below is the sole subagent carve-out. Do not create a clone or worktree for review.
 
 Apply [AGENTS.md's **Choose the principled course** rule](../../../AGENTS.md#attitude) to every review decision. Review duration, difficulty, and consequence surface never lower the completion standard.
 
@@ -18,9 +20,9 @@ A complete round must satisfy all four rules:
 - **Fresh start:** use the current state and repeat the whole inspection. Earlier rounds, sampled files, and a recheck of only the latest fix do not count as coverage.
 - **Unlimited rounds:** whenever the reviewer applies an improvement or accepts a meaningful issue candidate, update the work and start another complete round. Stop only after a complete round produces nothing that survives verification.
 
-## Self-Review
+## Overall Self-Review
 
-Self-Review and an unqualified review request use this solo workflow:
+Overall Self-Review uses this solo workflow. Outside a solo issue campaign, an unqualified Self-Review request means Overall Self-Review.
 
 1. Establish the complete change surface, including the pull-request base-to-head diff and any uncommitted changes.
 2. Perform one complete round under the Non-Negotiable Review Law. Include correctness and boundaries, Windows and POSIX behavior, concurrency and state, data loss and security, cache and recovery invariants, public API and compatibility, test isolation, CI and packaging, generated output, documentation, and migration effects.
@@ -29,15 +31,17 @@ Self-Review and an unqualified review request use this solo workflow:
 5. If anything changed, restart at step 1 as a fresh full round.
 6. Finish only when a complete round finds nothing to improve. Report the final clean round and every verification that could not run.
 
-Self-Review does not authorize creating, pushing, updating, or merging a pull request. If the user separately requests one of those actions, follow the pull-request skill.
+Overall Self-Review does not authorize creating, pushing, updating, or merging a pull request. If the user separately requests one of those actions, follow the pull-request skill.
 
-## Commit Early-Warning Pass
+## Individual Self-Review
 
-A commit early-warning pass is not a review under this skill. It is the read-only per-commit reader a solo campaign author may run while still implementing, defined by the [solo campaign development document](../issue-campaign/development.md#implement-and-write-tests).
+Individual Self-Review is the mandatory read-only review of exactly one coherent pushed issue-implementation commit in a solo issue campaign. The [solo campaign development document](../issue-campaign/development.md#implement-and-write-tests) defines its timing and pull-request record.
 
-It delegates nothing the Non-Negotiable Review Law governs. The law governs the author's own round, which still runs alone over the whole surface before merge under all four rules. One commit is not a declared surface, a reported candidate is not an accepted finding, and the passes do not add up to a round.
+The main agent immediately starts exactly one review subagent for that commit and continues implementing the next ready issue without waiting for the result or per-commit CI. The reviewer reads only the parent-to-commit change, reports advice and candidate findings to the main agent, and never edits, commits, pushes, comments on GitHub, or makes implementation decisions.
 
-Never call the pass a Self-Review, and never report it as one. A reader who sees that name concludes the gate already ran, and the whole-surface round disappears without anyone deciding to drop it.
+When the result arrives, the main agent adjudicates every candidate and records the Individual Self-Review result as a formal GitHub pull-request review with the `COMMENT` event. Put line-specific observations in inline review comments and commit-wide results in the review body.
+
+Individual Self-Review never reduces or substitutes for Overall Self-Review. The main agent still performs a fresh, exhaustive, solo Overall Self-Review of the complete pull-request base-to-head diff before merge, and only that clean Overall Self-Review is the review gate. Individual reviews do not combine into an Overall Self-Review round.
 
 ## Solo Issue Discovery Rounds
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,11 +40,11 @@ Default solo repository-wide issue discovery, issue publication, one CI-validate
 
 ### Review
 
-Default solo Self-Review, unqualified review, and exhaustive issue-discovery rounds, `.agents/skills/review/SKILL.md`. The reviewer inspects the whole declared surface and repeats fresh rounds until a complete pass produces no sound improvement or meaningful issue candidate.
+Default solo Overall Self-Review, mandatory advisory Individual Self-Review for solo issue-campaign commits, unqualified review, and exhaustive issue-discovery rounds, `.agents/skills/review/SKILL.md`. Overall review and discovery inspect the whole declared surface and repeat fresh rounds until a complete pass produces no sound improvement or meaningful issue candidate.
 
 ### Multi-Agent Workflows
 
-Explicitly parallel review and issue-campaign variants live under one entry point, `.agents/skills/multi-agent/SKILL.md`. Read it only when the user explicitly asks for a team, parallel, or multi-agent workflow. Multi-agent issue campaigns parallelize discovery and implementation by default and switch to solo implementation only on an explicit discovery-only parallel request; Self-Review remains solo.
+Explicitly parallel review and issue-campaign variants live under one entry point, `.agents/skills/multi-agent/SKILL.md`. Read it only when the user explicitly asks for a team, parallel, or multi-agent workflow. Multi-agent issue campaigns parallelize discovery and implementation by default and switch to solo implementation only on an explicit discovery-only parallel request. Overall Self-Review remains solo, while Individual Self-Review is the solo campaign's mandatory per-commit advisory subagent workflow.
 
 ### Discussion
 


### PR DESCRIPTION
## Summary

- require exactly one read-only Individual Self-Review for every coherent pushed issue-implementation commit
- require the main agent to continue the next ready issue without waiting for that review or per-commit CI
- distinguish advisory Individual Self-Review from the solo, exhaustive, merge-gating Overall Self-Review
- record both review forms as formal COMMENT-event GitHub pull-request reviews

## Verification

- main-agent complete instruction-diff review found no remaining contradiction
- obsolete terminology and optional wording search returned no matches
- `git diff --check` passed
- formatting, build, tests, and CI intentionally not run for this instruction-only documentation change