### PR TITLE
docs: present code graph before lint across readme, landing, and docs nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A `typescript-go` toolchain for compiler-powered plugins and type-safe execution
 
 - **`ttsc`**: build, check, and transform.
 - **`ttsx`**: execute TypeScript with type checking.
-- [**`@ttsc/lint`**](https://github.com/samchon/ttsc/tree/master/packages/lint): lint violations as compiler errors.
 - [**`@ttsc/graph`**](https://github.com/samchon/ttsc/tree/master/packages/graph): MCP code graph that reduces agent token usage.
+- [**`@ttsc/lint`**](https://github.com/samchon/ttsc/tree/master/packages/lint): lint violations as compiler errors.
 - **plugin support**: compiler-powered libraries, such as `typia`.
 
 ## Setup
@@ -34,6 +34,33 @@ That covers the CLI. The integrations each have a short guide:
 - [`@ttsc/unplugin`](https://ttsc.dev/docs/setup/unplugin): Vite, Rollup, Rolldown, esbuild, webpack, Rspack, Next.js, Turbopack, Farm, and Bun.
 - [`@ttsc/metro`](https://ttsc.dev/docs/setup/metro): React Native and Expo.
 - [`@ttsc/vscode`](https://ttsc.dev/docs/setup/vscode): live editor diagnostics.
+
+## Graph
+
+Your coding agent answers from the compiler, spending roughly 90% fewer tokens.
+
+`@ttsc/graph` is an MCP server that gives the agent a compiler-resolved graph of your project: what calls what, what a change would touch, and where to start reading. The agent asks the type checker instead of grepping and re-reading files.
+
+Register it with your MCP client. For Claude Code, a `.mcp.json` in the project root:
+
+```bash
+npm install -D ttsc @ttsc/graph typescript
+```
+
+```json
+{
+  "mcpServers": {
+    "ttsc-graph": {
+      "command": "npx",
+      "args": ["-y", "@ttsc/graph"]
+    }
+  }
+}
+```
+
+On the agent-cost benchmark, Claude agents answer reading zero files, cutting tokens by roughly 90% and tool calls by 93% to 96%. The design and per-repository numbers are in the [Code Graph guide](https://ttsc.dev/docs/graph) and the [benchmark](https://ttsc.dev/docs/benchmark/graph).
+
+![Median tokens on the shared onboarding question, lower is better](https://ttsc.dev/benchmark/svg/graph-common-codex-gpt-5.6-sol.svg)
 
 ## Lint
 
@@ -97,33 +124,6 @@ npx ttsc format   # format edits only, never changes behavior
 
 The rule catalog and every `format` key are in the [Lint & Format guide](https://ttsc.dev/docs/lint).
 
-## Graph
-
-Your coding agent answers from the compiler, spending roughly 90% fewer tokens.
-
-`@ttsc/graph` is an MCP server that gives the agent a compiler-resolved graph of your project: what calls what, what a change would touch, and where to start reading. The agent asks the type checker instead of grepping and re-reading files.
-
-Register it with your MCP client. For Claude Code, a `.mcp.json` in the project root:
-
-```bash
-npm install -D ttsc @ttsc/graph typescript
-```
-
-```json
-{
-  "mcpServers": {
-    "ttsc-graph": {
-      "command": "npx",
-      "args": ["-y", "@ttsc/graph"]
-    }
-  }
-}
-```
-
-On the agent-cost benchmark, Claude agents answer reading zero files, cutting tokens by roughly 90% and tool calls by 93% to 96%. The design and per-repository numbers are in the [Code Graph guide](https://ttsc.dev/docs/graph) and the [benchmark](https://ttsc.dev/docs/benchmark/graph).
-
-![Median tokens on the shared onboarding question, lower is better](https://ttsc.dev/benchmark/svg/graph-common-codex-gpt-5.6-sol.svg)
-
 ## Plugins
 
 A plugin hooks the compile to add checks, transforms, or type-driven code generation, all driven by the types the checker has already resolved. It runs on every `ttsc` build and `ttsx` run, with no extra step.
@@ -148,8 +148,8 @@ export const isStringArray = (() => {
 Utility plugins shipped in this repository:
 
 - [`@ttsc/banner`](https://github.com/samchon/ttsc/tree/master/packages/banner): adds `@packageDocumentation` JSDoc banners.
-- [`@ttsc/lint`](https://github.com/samchon/ttsc/tree/master/packages/lint): lints and formats TypeScript source.
 - [`@ttsc/graph`](https://github.com/samchon/ttsc/tree/master/packages/graph): MCP server exposing a checker-resolved code graph to coding agents.
+- [`@ttsc/lint`](https://github.com/samchon/ttsc/tree/master/packages/lint): lints and formats TypeScript source.
 - [`@ttsc/paths`](https://github.com/samchon/ttsc/tree/master/packages/paths): rewrites source path aliases so JS and declaration emit receive relative imports.
 - [`@ttsc/strip`](https://github.com/samchon/ttsc/tree/master/packages/strip): removes configured calls and `debugger` statements.
 - [`@ttsc/unplugin`](https://github.com/samchon/ttsc/tree/master/packages/unplugin): runs `ttsc` plugins inside bundlers supported by `unplugin`.

--- a/website/src/content/docs/_meta.ts
+++ b/website/src/content/docs/_meta.ts
@@ -6,8 +6,8 @@ const meta: MetaRecord = {
 
   "-- features": { type: "separator", title: "📖 Features" },
   ttsc: "TTSC",
-  lint: "Lint & Format",
   graph: "Code Graph (MCP)",
+  lint: "Lint & Format",
   plugins: "Plugin Ecosystem",
 
   "-- authoring": { type: "separator", title: "🧰 Authoring" },

--- a/website/src/content/docs/setup/_meta.ts
+++ b/website/src/content/docs/setup/_meta.ts
@@ -3,8 +3,8 @@ import type { MetaRecord } from "nextra";
 const meta: MetaRecord = {
   index: "Overview",
   ttsc: "CLI & Scripts",
-  lint: "Lint & Format",
   graph: "Code Graph (MCP)",
+  lint: "Lint & Format",
   vscode: "VS Code Plugin",
   unplugin: "Unplugin (Bundlers)",
   metro: "Metro (React Native, Expo)",

--- a/website/src/content/docs/setup/index.mdx
+++ b/website/src/content/docs/setup/index.mdx
@@ -36,8 +36,8 @@ Every surface starts from the same two packages:
 ## Pick your surface
 
 - [CLI & Scripts](/docs/setup/ttsc): package.json scripts, watch mode, and CI with plugin-binary caching.
-- [Lint & Format](/docs/setup/lint): `lint.config.ts`, severities, and the format block.
 - [Code Graph (MCP)](/docs/setup/graph): connect a coding agent to the compiler's graph.
+- [Lint & Format](/docs/setup/lint): `lint.config.ts`, severities, and the format block.
 - [VS Code Plugin](/docs/setup/vscode): editor diagnostics that match your build, plus format on save.
 - [Unplugin (Bundlers)](/docs/setup/unplugin): Vite, Rollup, Rolldown, esbuild, webpack, Rspack, Next.js, Turbopack, Farm, and Bun.
 - [Metro (React Native, Expo)](/docs/setup/metro): the Metro transformer for React Native and Expo.

--- a/website/src/movies/landing/TtscWebsiteLandingFooter.tsx
+++ b/website/src/movies/landing/TtscWebsiteLandingFooter.tsx
@@ -9,8 +9,8 @@ const LEARN = [
 const USE = [
   { name: "Compiler (ttsc)", href: "/docs/ttsc/compile" },
   { name: "Runner (ttsx)", href: "/docs/ttsc/execute" },
-  { name: "Lint & Prettier", href: "/docs/lint" },
   { name: "Code Graph (MCP)", href: "/docs/graph" },
+  { name: "Lint & Prettier", href: "/docs/lint" },
   { name: "Plugin Ecosystem", href: "/docs/plugins" },
   { name: "Playground", href: "/playground" },
 ];
@@ -33,7 +33,7 @@ export default function TtscWebsiteLandingFooter() {
               ttsc
             </p>
             <p className="text-sm leading-relaxed text-blue-100">
-              TypeScript-Go compiler, runner, lint, code graph, and plugin host.
+              TypeScript-Go compiler, runner, code graph, lint, and plugin host.
             </p>
             <p className="mt-4 font-mono text-xs tracking-wider text-blue-200">
               From the author of{" "}

--- a/website/src/movies/landing/TtscWebsiteLandingHero.tsx
+++ b/website/src/movies/landing/TtscWebsiteLandingHero.tsx
@@ -8,16 +8,16 @@ const CLAIMS = [
       "TypeScript-Go checks natively, in parallel. JavaScript tsc does neither.",
   },
   {
-    value: "800x",
-    label: "faster lint loop",
-    detail:
-      "Rules reuse the AST and types the compiler already built. ESLint parses it all again.",
-  },
-  {
     value: "90%",
     label: "fewer agent tokens",
     detail:
       "Agents read one compiler-resolved graph over MCP instead of crawling source files.",
+  },
+  {
+    value: "800x",
+    label: "faster lint loop",
+    detail:
+      "Rules reuse the AST and types the compiler already built. ESLint parses it all again.",
   },
   {
     value: "type-safe",
@@ -39,14 +39,14 @@ const FLOW = [
     tone: "text-blue-200",
   },
   {
+    name: "@ttsc/graph",
+    text: "code graph for coding agents, over MCP",
+    tone: "text-blue-300",
+  },
+  {
     name: "@ttsc/lint",
     text: "rules as compiler diagnostics",
     tone: "text-cyan-300",
-  },
-  {
-    name: "@ttsc/graph",
-    text: "code map for coding agents, over MCP",
-    tone: "text-blue-300",
   },
   {
     name: "plugins",

--- a/website/src/movies/landing/TtscWebsiteLandingMovie.tsx
+++ b/website/src/movies/landing/TtscWebsiteLandingMovie.tsx
@@ -14,8 +14,8 @@ export default function TtscWebsiteLandingMovie() {
     <div className="ttsc-landing min-h-screen bg-white text-[#102a43]">
       <TtscWebsiteLandingHero />
       <TtscWebsiteLandingRestOfToolchain />
-      <TtscWebsiteLandingLintAsCompileError />
       <TtscWebsiteLandingCodeGraph />
+      <TtscWebsiteLandingLintAsCompileError />
       <TtscWebsiteLandingPluginEcosystem />
       <TtscWebsiteLandingInTheBrowser />
       <TtscWebsiteLandingSponsors />

--- a/website/src/movies/landing/TtscWebsiteLandingRestOfToolchain.tsx
+++ b/website/src/movies/landing/TtscWebsiteLandingRestOfToolchain.tsx
@@ -23,21 +23,21 @@ const CARDS = [
     accent: false,
   },
   {
+    name: "@ttsc/graph",
+    tagline: "Coding agents",
+    description:
+      "Hand a coding agent a checker-resolved graph of your codebase over MCP, so it stops grepping and re-reading files.",
+    meta: "MCP code graph",
+    href: "/docs/graph",
+    accent: false,
+  },
+  {
     name: "@ttsc/lint",
     tagline: "Lint and format",
     description:
       "Report rules as TS diagnostics, apply autofixes, and format through the same compiler pass.",
     meta: "fix / format / TSxxxxx",
     href: "/docs/lint",
-    accent: false,
-  },
-  {
-    name: "@ttsc/graph",
-    tagline: "Coding agents",
-    description:
-      "Hand a coding agent a checker-resolved map of your codebase over MCP, so it stops grepping and re-reading files.",
-    meta: "MCP code graph",
-    href: "/docs/graph",
     accent: false,
   },
 ] as const;


### PR DESCRIPTION
﻿Present Code Graph before Lint on every outward-facing surface, so the higher-impact feature leads.

## Scope

- `README.md`: package bullets, `## Graph` section moved ahead of `## Lint`, Plugins utility list order (docs introduction renders this file directly)
- Landing page: section order (`TtscWebsiteLandingMovie`), Hero claims and compiler-path flow, Toolchain cards, Footer Use links and brand line
- Docs nav: `docs/_meta.ts`, `docs/setup/_meta.ts`, setup overview bullets
- Terminology: two landing strings changed from "map" to "graph"

## Verification

- `npx tsc --noEmit` in `website/`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
