### PR TITLE
fix(release): make Go SDK extraction portable on Windows

### DIFF
--- a/scripts/build-platform-package.cjs
+++ b/scripts/build-platform-package.cjs
@@ -9,6 +9,7 @@ const {
   recordVerifiedGoExtraction,
   verifyOrReplaceGoArchive,
 } = require("./go-sdk-integrity.cjs");
+const { extractTarGzArchive } = require("./go-sdk-extraction.cjs");
 const { resolveGoTarget } = require("./platform-target.cjs");
 
 const GO_DOWNLOADS_URL = "https://go.dev/dl/?mode=json&include=all";
@@ -217,9 +218,7 @@ function ensureDownloadedGoRoot() {
   fs.rmSync(extractDir, { recursive: true, force: true });
   fs.mkdirSync(extractDir, { recursive: true });
   if (archive.endsWith(".tar.gz")) {
-    cp.execFileSync("tar", ["-xzf", archivePath, "-C", extractDir], {
-      stdio: "inherit",
-    });
+    extractTarGzArchive(archivePath, extractDir);
   } else {
     extractZipArchive(archivePath, extractDir);
   }

--- a/scripts/build-platform-package.cjs
+++ b/scripts/build-platform-package.cjs
@@ -5,11 +5,9 @@ const zlib = require("node:zlib");
 
 const {
   findGoArchiveChecksum,
-  hasVerifiedGoExtraction,
-  recordVerifiedGoExtraction,
   verifyOrReplaceGoArchive,
 } = require("./go-sdk-integrity.cjs");
-const { extractTarGzArchive } = require("./go-sdk-extraction.cjs");
+const { ensureVerifiedGoExtraction } = require("./go-sdk-extraction.cjs");
 const { resolveGoTarget } = require("./platform-target.cjs");
 
 const GO_DOWNLOADS_URL = "https://go.dev/dl/?mode=json&include=all";
@@ -212,22 +210,15 @@ function ensureDownloadedGoRoot() {
   const archivePath = path.join(cacheRoot, archive);
   const url = `https://go.dev/dl/${archive}`;
   const checksum = fetchGoArchiveChecksum(cacheRoot, version, archive);
-  ensureVerifiedGoArchive(archivePath, url, checksum);
-  if (hasVerifiedGoExtraction(extractDir, goBinary, checksum)) return goroot;
-
-  fs.rmSync(extractDir, { recursive: true, force: true });
-  fs.mkdirSync(extractDir, { recursive: true });
-  if (archive.endsWith(".tar.gz")) {
-    extractTarGzArchive(archivePath, extractDir);
-  } else {
-    extractZipArchive(archivePath, extractDir);
-  }
-  if (!fs.existsSync(goBinary)) {
-    throw new Error(
-      `build-platform-package: downloaded Go compiler missing: ${goBinary}`,
-    );
-  }
-  recordVerifiedGoExtraction(extractDir, checksum);
+  ensureVerifiedGoExtraction({
+    archivePath,
+    checksum,
+    extractDir,
+    extractZipArchive,
+    goBinary,
+    verifyArchive: (file, expected) =>
+      ensureVerifiedGoArchive(file, url, expected),
+  });
   return goroot;
 }
 

--- a/scripts/go-sdk-extraction.cjs
+++ b/scripts/go-sdk-extraction.cjs
@@ -1,5 +1,11 @@
 const cp = require("node:child_process");
+const fs = require("node:fs");
 const path = require("node:path");
+
+const {
+  hasVerifiedGoExtraction,
+  recordVerifiedGoExtraction,
+} = require("./go-sdk-integrity.cjs");
 
 /**
  * Resolve tar operands relative to the archive cache directory.
@@ -30,19 +36,55 @@ function resolveTarExtraction(archivePath, extractDir) {
   return {
     args: ["-xzf", archive, "-C", destination],
     cwd,
+    executable: "tar",
   };
 }
 
 /** Extract one verified Go SDK archive through the ambient tar implementation. */
 function extractTarGzArchive(archivePath, extractDir) {
   const command = resolveTarExtraction(archivePath, extractDir);
-  cp.execFileSync("tar", command.args, {
+  cp.execFileSync(command.executable, command.args, {
     cwd: command.cwd,
     stdio: "inherit",
   });
 }
 
+/**
+ * Verify, recover, and record one downloaded Go SDK extraction transaction.
+ *
+ * `verifyArchive` owns download/cache authentication and must return only when
+ * `archivePath` matches `checksum`. Extraction is then reset atomically from
+ * the marker's perspective: any failure propagates before the marker is
+ * written, while a matching existing marker reuses the verified SDK.
+ */
+function ensureVerifiedGoExtraction({
+  archivePath,
+  checksum,
+  extractDir,
+  extractZipArchive,
+  goBinary,
+  verifyArchive,
+}) {
+  verifyArchive(archivePath, checksum);
+  if (hasVerifiedGoExtraction(extractDir, goBinary, checksum)) return;
+
+  fs.rmSync(extractDir, { recursive: true, force: true });
+  fs.mkdirSync(extractDir, { recursive: true });
+  if (archivePath.endsWith(".tar.gz")) {
+    extractTarGzArchive(archivePath, extractDir);
+  } else {
+    extractZipArchive(archivePath, extractDir);
+  }
+  if (!fs.existsSync(goBinary)) {
+    throw new Error(
+      `build-platform-package: downloaded Go compiler missing: ${goBinary}`,
+    );
+  }
+  recordVerifiedGoExtraction(extractDir, checksum);
+}
+
 module.exports = {
+  ensureVerifiedGoExtraction,
   extractTarGzArchive,
   resolveTarExtraction,
 };

--- a/scripts/go-sdk-extraction.cjs
+++ b/scripts/go-sdk-extraction.cjs
@@ -1,0 +1,48 @@
+const cp = require("node:child_process");
+const path = require("node:path");
+
+/**
+ * Resolve tar operands relative to the archive cache directory.
+ *
+ * Git for Windows ships GNU tar, which interprets an absolute `D:\...`
+ * archive operand as a remote-host archive. Keeping both filesystem operands
+ * relative is portable across GNU tar and bsdtar.
+ */
+function resolveTarExtraction(archivePath, extractDir) {
+  if (!path.isAbsolute(archivePath) || !path.isAbsolute(extractDir)) {
+    throw new Error(
+      "go-sdk-extraction: archive and extraction paths must be absolute",
+    );
+  }
+  const cwd = path.dirname(archivePath);
+  const archive = path.basename(archivePath);
+  const destination = path.relative(cwd, extractDir);
+  if (
+    destination.length === 0 ||
+    path.isAbsolute(destination) ||
+    destination === ".." ||
+    destination.startsWith(`..${path.sep}`)
+  ) {
+    throw new Error(
+      "go-sdk-extraction: extraction directory must be inside the archive cache",
+    );
+  }
+  return {
+    args: ["-xzf", archive, "-C", destination],
+    cwd,
+  };
+}
+
+/** Extract one verified Go SDK archive through the ambient tar implementation. */
+function extractTarGzArchive(archivePath, extractDir) {
+  const command = resolveTarExtraction(archivePath, extractDir);
+  cp.execFileSync("tar", command.args, {
+    cwd: command.cwd,
+    stdio: "inherit",
+  });
+}
+
+module.exports = {
+  extractTarGzArchive,
+  resolveTarExtraction,
+};

--- a/tests/test-ttsc/src/features/platform/test_platform_package_extracts_go_tar_with_relative_operands.ts
+++ b/tests/test-ttsc/src/features/platform/test_platform_package_extracts_go_tar_with_relative_operands.ts
@@ -20,7 +20,7 @@ import {
  *
  * 1. Build a small real Go-shaped tar.gz beneath paths containing spaces.
  * 2. Drive the verified-extraction owner and assert its tar process boundary.
- * 3. Pin checksum-first recovery, cache reuse, and failure-marker behavior.
+ * 3. Pin checksum-first recovery, zip preservation, and marker boundaries.
  */
 export const test_platform_package_extracts_go_tar_with_relative_operands =
   () => {
@@ -209,6 +209,55 @@ export const test_platform_package_extracts_go_tar_with_relative_operands =
         fs.existsSync(path.join(missingBinaryDir, markerName)),
         false,
       );
+
+      const zipArchive = path.join(cacheRoot, "go-sdk.zip");
+      const zipExtractDir = path.join(cacheRoot, "zip extraction");
+      const zipGoBinary = path.join(zipExtractDir, "go", "bin", "go.exe");
+      fs.writeFileSync(zipArchive, "verified zip fixture", "utf8");
+      const zipChecksum = createHash("sha256")
+        .update(fs.readFileSync(zipArchive))
+        .digest("hex");
+      let zipExtractionCount = 0;
+      extraction.ensureVerifiedGoExtraction({
+        archivePath: zipArchive,
+        checksum: zipChecksum,
+        extractDir: zipExtractDir,
+        extractZipArchive: (file, destination) => {
+          zipExtractionCount++;
+          assert.equal(file, zipArchive);
+          assert.equal(destination, zipExtractDir);
+          fs.mkdirSync(path.dirname(zipGoBinary), { recursive: true });
+          fs.writeFileSync(zipGoBinary, "go compiler fixture\n", "utf8");
+        },
+        goBinary: zipGoBinary,
+        verifyArchive,
+      });
+      assert.equal(zipExtractionCount, 1);
+      assert.equal(
+        integrity.hasVerifiedGoExtraction(
+          zipExtractDir,
+          zipGoBinary,
+          zipChecksum,
+        ),
+        true,
+      );
+
+      const failedZipDir = path.join(cacheRoot, "failed zip extraction");
+      assert.throws(
+        () =>
+          extraction.ensureVerifiedGoExtraction({
+            archivePath: zipArchive,
+            checksum: zipChecksum,
+            extractDir: failedZipDir,
+            extractZipArchive: () => {
+              throw new Error("zip extraction failed");
+            },
+            goBinary: path.join(failedZipDir, "go", "bin", "go.exe"),
+            verifyArchive,
+          }),
+        /zip extraction failed/,
+      );
+      assert.equal(fs.existsSync(path.join(failedZipDir, markerName)), false);
 
       const invalidArchive = path.join(cacheRoot, "invalid.tar.gz");
       const failedExtractDir = path.join(cacheRoot, "failed extraction");

--- a/tests/test-ttsc/src/features/platform/test_platform_package_extracts_go_tar_with_relative_operands.ts
+++ b/tests/test-ttsc/src/features/platform/test_platform_package_extracts_go_tar_with_relative_operands.ts
@@ -1,0 +1,113 @@
+import { TestProject } from "@ttsc/testing";
+import { execFileSync } from "node:child_process";
+
+import {
+  assert,
+  fs,
+  path,
+  requireFromTest,
+  workspaceRoot,
+} from "../../internal/toolchain";
+
+/**
+ * Verifies platform package: extracts Go tar archives with relative operands.
+ *
+ * Git for Windows GNU tar parses an absolute drive-letter archive path as a
+ * remote host. The packager must anchor tar in the archive cache and keep both
+ * filesystem operands relative without weakening extraction failures.
+ *
+ * 1. Create a real tar.gz beneath cache and source paths containing spaces.
+ * 2. Assert the resolved tar command uses cache-relative filesystem operands.
+ * 3. Extract and verify the payload, then assert a corrupt archive still fails.
+ */
+export const test_platform_package_extracts_go_tar_with_relative_operands =
+  () => {
+    const extraction = requireFromTest(
+      path.join(workspaceRoot, "scripts", "go-sdk-extraction.cjs"),
+    ) as {
+      extractTarGzArchive: (archivePath: string, extractDir: string) => void;
+      resolveTarExtraction: (
+        archivePath: string,
+        extractDir: string,
+      ) => {
+        args: string[];
+        cwd: string;
+      };
+    };
+    const root = TestProject.tmpdir("ttsc go sdk extraction ");
+    const cacheRoot = path.join(root, "cache with spaces");
+    const sourceRoot = path.join(root, "source with spaces");
+    const archivePath = path.join(cacheRoot, "go-sdk.tar.gz");
+    const extractDir = path.join(cacheRoot, "extracted sdk");
+    const versionFile = path.join(sourceRoot, "go", "VERSION");
+    try {
+      fs.mkdirSync(path.dirname(versionFile), { recursive: true });
+      fs.mkdirSync(cacheRoot, { recursive: true });
+      fs.writeFileSync(versionFile, "go1.99.0\n", "utf8");
+      execFileSync(
+        "tar",
+        [
+          "-czf",
+          path.basename(archivePath),
+          "-C",
+          path.relative(cacheRoot, sourceRoot),
+          "go",
+        ],
+        { cwd: cacheRoot, stdio: "pipe" },
+      );
+
+      const command = extraction.resolveTarExtraction(archivePath, extractDir);
+      assert.equal(command.cwd, cacheRoot);
+      assert.deepEqual(command.args, [
+        "-xzf",
+        path.basename(archivePath),
+        "-C",
+        path.basename(extractDir),
+      ]);
+      assert.equal(path.isAbsolute(command.args[1]!), false);
+      assert.equal(path.isAbsolute(command.args[3]!), false);
+      assert.throws(
+        () =>
+          extraction.resolveTarExtraction(
+            path.basename(archivePath),
+            extractDir,
+          ),
+        /paths must be absolute/,
+      );
+      assert.throws(
+        () =>
+          extraction.resolveTarExtraction(
+            archivePath,
+            path.join(root, "outside cache"),
+          ),
+        /must be inside the archive cache/,
+      );
+
+      fs.mkdirSync(extractDir, { recursive: true });
+      extraction.extractTarGzArchive(archivePath, extractDir);
+      assert.equal(
+        fs.readFileSync(path.join(extractDir, "go", "VERSION"), "utf8"),
+        "go1.99.0\n",
+      );
+
+      const invalidArchive = path.join(cacheRoot, "invalid.tar.gz");
+      const failedExtractDir = path.join(cacheRoot, "failed extraction");
+      fs.writeFileSync(invalidArchive, "not a tar archive", "utf8");
+      fs.mkdirSync(failedExtractDir, { recursive: true });
+      assert.throws(() =>
+        extraction.extractTarGzArchive(invalidArchive, failedExtractDir),
+      );
+
+      const packager = fs.readFileSync(
+        path.join(workspaceRoot, "scripts", "build-platform-package.cjs"),
+        "utf8",
+      );
+      assert.match(
+        packager,
+        /extractTarGzArchive\(archivePath, extractDir\)[\s\S]*recordVerifiedGoExtraction\(extractDir, checksum\)/,
+        "failed tar extraction must precede the verified-extraction marker",
+      );
+    } finally {
+      fs.rmSync(root, { force: true, recursive: true });
+    }
+  };

--- a/tests/test-ttsc/src/features/platform/test_platform_package_extracts_go_tar_with_relative_operands.ts
+++ b/tests/test-ttsc/src/features/platform/test_platform_package_extracts_go_tar_with_relative_operands.ts
@@ -1,5 +1,6 @@
 import { TestProject } from "@ttsc/testing";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 
 import {
   assert,
@@ -13,37 +14,60 @@ import {
  * Verifies platform package: extracts Go tar archives with relative operands.
  *
  * Git for Windows GNU tar parses an absolute drive-letter archive path as a
- * remote host. The packager must anchor tar in the archive cache and keep both
- * filesystem operands relative without weakening extraction failures.
+ * remote host. The package owner must compose authenticated cache reuse,
+ * cwd-relative extraction, binary validation, and marker publication without
+ * letting a verification or extraction failure publish success.
  *
- * 1. Create a real tar.gz beneath cache and source paths containing spaces.
- * 2. Assert the resolved tar command uses cache-relative filesystem operands.
- * 3. Extract and verify the payload, then assert a corrupt archive still fails.
+ * 1. Build a small real Go-shaped tar.gz beneath paths containing spaces.
+ * 2. Drive the verified-extraction owner and assert its tar process boundary.
+ * 3. Pin checksum-first recovery, cache reuse, and failure-marker behavior.
  */
 export const test_platform_package_extracts_go_tar_with_relative_operands =
   () => {
     const extraction = requireFromTest(
       path.join(workspaceRoot, "scripts", "go-sdk-extraction.cjs"),
     ) as {
-      extractTarGzArchive: (archivePath: string, extractDir: string) => void;
+      ensureVerifiedGoExtraction: (input: {
+        archivePath: string;
+        checksum: string;
+        extractDir: string;
+        extractZipArchive: (archivePath: string, extractDir: string) => void;
+        goBinary: string;
+        verifyArchive: (archivePath: string, checksum: string) => void;
+      }) => void;
       resolveTarExtraction: (
         archivePath: string,
         extractDir: string,
       ) => {
         args: string[];
         cwd: string;
+        executable: string;
       };
+    };
+    const integrity = requireFromTest(
+      path.join(workspaceRoot, "scripts", "go-sdk-integrity.cjs"),
+    ) as {
+      hasVerifiedGoExtraction: (
+        extractDir: string,
+        goBinary: string,
+        checksum: string,
+      ) => boolean;
+      verifyGoArchiveChecksum: (file: string, expected: string) => void;
     };
     const root = TestProject.tmpdir("ttsc go sdk extraction ");
     const cacheRoot = path.join(root, "cache with spaces");
     const sourceRoot = path.join(root, "source with spaces");
     const archivePath = path.join(cacheRoot, "go-sdk.tar.gz");
     const extractDir = path.join(cacheRoot, "extracted sdk");
-    const versionFile = path.join(sourceRoot, "go", "VERSION");
+    const sourceVersionFile = path.join(sourceRoot, "go", "VERSION");
+    const sourceGoBinary = path.join(sourceRoot, "go", "bin", "go");
+    const goBinary = path.join(extractDir, "go", "bin", "go");
+    const markerName = ".ttsc-go-sdk-sha256";
     try {
-      fs.mkdirSync(path.dirname(versionFile), { recursive: true });
+      fs.mkdirSync(path.dirname(sourceGoBinary), { recursive: true });
       fs.mkdirSync(cacheRoot, { recursive: true });
-      fs.writeFileSync(versionFile, "go1.99.0\n", "utf8");
+      fs.writeFileSync(sourceVersionFile, "go1.99.0\n", "utf8");
+      fs.writeFileSync(sourceGoBinary, "go compiler fixture\n", "utf8");
       execFileSync(
         "tar",
         [
@@ -55,8 +79,12 @@ export const test_platform_package_extracts_go_tar_with_relative_operands =
         ],
         { cwd: cacheRoot, stdio: "pipe" },
       );
+      const checksum = createHash("sha256")
+        .update(fs.readFileSync(archivePath))
+        .digest("hex");
 
       const command = extraction.resolveTarExtraction(archivePath, extractDir);
+      assert.equal(command.executable, "tar");
       assert.equal(command.cwd, cacheRoot);
       assert.deepEqual(command.args, [
         "-xzf",
@@ -83,29 +111,124 @@ export const test_platform_package_extracts_go_tar_with_relative_operands =
         /must be inside the archive cache/,
       );
 
+      const staleFile = path.join(extractDir, "stale");
       fs.mkdirSync(extractDir, { recursive: true });
-      extraction.extractTarGzArchive(archivePath, extractDir);
+      fs.writeFileSync(staleFile, "stale", "utf8");
+      let verificationCount = 0;
+      const verifyArchive = (file: string, expected: string) => {
+        verificationCount++;
+        if (verificationCount === 1) {
+          assert.equal(
+            fs.existsSync(staleFile),
+            true,
+            "archive verification must finish before stale extraction reset",
+          );
+        }
+        integrity.verifyGoArchiveChecksum(file, expected);
+      };
+      const rejectZip = () => assert.fail("tar archive reached zip extractor");
+      extraction.ensureVerifiedGoExtraction({
+        archivePath,
+        checksum,
+        extractDir,
+        extractZipArchive: rejectZip,
+        goBinary,
+        verifyArchive,
+      });
+      assert.equal(verificationCount, 1);
+      assert.equal(fs.existsSync(staleFile), false);
       assert.equal(
         fs.readFileSync(path.join(extractDir, "go", "VERSION"), "utf8"),
         "go1.99.0\n",
+      );
+      assert.equal(
+        integrity.hasVerifiedGoExtraction(extractDir, goBinary, checksum),
+        true,
+      );
+
+      fs.writeFileSync(
+        path.join(extractDir, "go", "VERSION"),
+        "retained cache\n",
+        "utf8",
+      );
+      extraction.ensureVerifiedGoExtraction({
+        archivePath,
+        checksum,
+        extractDir,
+        extractZipArchive: rejectZip,
+        goBinary,
+        verifyArchive,
+      });
+      assert.equal(verificationCount, 2);
+      assert.equal(
+        fs.readFileSync(path.join(extractDir, "go", "VERSION"), "utf8"),
+        "retained cache\n",
+        "a matching marker must reuse the authenticated extraction",
+      );
+
+      const mismatchExtractDir = path.join(cacheRoot, "mismatch extraction");
+      const mismatchSentinel = path.join(mismatchExtractDir, "sentinel");
+      fs.mkdirSync(mismatchExtractDir, { recursive: true });
+      fs.writeFileSync(mismatchSentinel, "keep", "utf8");
+      assert.throws(
+        () =>
+          extraction.ensureVerifiedGoExtraction({
+            archivePath,
+            checksum: "0".repeat(64),
+            extractDir: mismatchExtractDir,
+            extractZipArchive: rejectZip,
+            goBinary: path.join(mismatchExtractDir, "go", "bin", "go"),
+            verifyArchive,
+          }),
+        /checksum mismatch/,
+      );
+      assert.equal(
+        fs.existsSync(mismatchSentinel),
+        true,
+        "failed authentication must not reset the existing extraction",
+      );
+      assert.equal(
+        fs.existsSync(path.join(mismatchExtractDir, markerName)),
+        false,
+      );
+
+      const missingBinaryDir = path.join(cacheRoot, "missing binary");
+      assert.throws(
+        () =>
+          extraction.ensureVerifiedGoExtraction({
+            archivePath,
+            checksum,
+            extractDir: missingBinaryDir,
+            extractZipArchive: rejectZip,
+            goBinary: path.join(missingBinaryDir, "go", "bin", "missing"),
+            verifyArchive,
+          }),
+        /downloaded Go compiler missing/,
+      );
+      assert.equal(
+        fs.existsSync(path.join(missingBinaryDir, markerName)),
+        false,
       );
 
       const invalidArchive = path.join(cacheRoot, "invalid.tar.gz");
       const failedExtractDir = path.join(cacheRoot, "failed extraction");
       fs.writeFileSync(invalidArchive, "not a tar archive", "utf8");
-      fs.mkdirSync(failedExtractDir, { recursive: true });
+      const invalidChecksum = createHash("sha256")
+        .update(fs.readFileSync(invalidArchive))
+        .digest("hex");
       assert.throws(() =>
-        extraction.extractTarGzArchive(invalidArchive, failedExtractDir),
+        extraction.ensureVerifiedGoExtraction({
+          archivePath: invalidArchive,
+          checksum: invalidChecksum,
+          extractDir: failedExtractDir,
+          extractZipArchive: rejectZip,
+          goBinary: path.join(failedExtractDir, "go", "bin", "go"),
+          verifyArchive,
+        }),
       );
-
-      const packager = fs.readFileSync(
-        path.join(workspaceRoot, "scripts", "build-platform-package.cjs"),
-        "utf8",
-      );
-      assert.match(
-        packager,
-        /extractTarGzArchive\(archivePath, extractDir\)[\s\S]*recordVerifiedGoExtraction\(extractDir, checksum\)/,
-        "failed tar extraction must precede the verified-extraction marker",
+      assert.equal(
+        fs.existsSync(path.join(failedExtractDir, markerName)),
+        false,
       );
     } finally {
       fs.rmSync(root, { force: true, recursive: true });

--- a/tests/test-ttsc/src/features/platform/test_platform_package_verifies_downloaded_go_archives.ts
+++ b/tests/test-ttsc/src/features/platform/test_platform_package_verifies_downloaded_go_archives.ts
@@ -10,8 +10,15 @@ import {
 } from "../../internal/toolchain";
 
 /**
- * The platform packager must source a checksum from official Go metadata and
- * reject a cached or newly downloaded archive whose bytes differ from it.
+ * Verifies platform package: authenticates downloaded Go SDK archives.
+ *
+ * A corrupt cached or newly downloaded SDK must never enter the extraction
+ * transaction. The package owner sources the official checksum, verifies or
+ * replaces the archive, and then delegates authenticated extraction.
+ *
+ * 1. Resolve official metadata and replace a corrupt cache through SHA-256.
+ * 2. Pin replacement failure cleanup and checksum-bound extraction markers.
+ * 3. Assert the platform package wires authentication into extraction.
  */
 export const test_platform_package_verifies_downloaded_go_archives = () => {
   const integrity = requireFromTest(
@@ -113,6 +120,5 @@ export const test_platform_package_verifies_downloaded_go_archives = () => {
   assert.match(packager, /https:\/\/go\.dev\/dl\/\?mode=json&include=all/);
   assert.match(packager, /fetchGoArchiveChecksum/);
   assert.match(packager, /ensureVerifiedGoArchive/);
-  assert.match(packager, /hasVerifiedGoExtraction/);
-  assert.match(packager, /recordVerifiedGoExtraction/);
+  assert.match(packager, /ensureVerifiedGoExtraction/);
 };

--- a/tests/test-ttsc/src/features/platform/test_platform_package_verifies_downloaded_go_archives.ts
+++ b/tests/test-ttsc/src/features/platform/test_platform_package_verifies_downloaded_go_archives.ts
@@ -91,6 +91,11 @@ export const test_platform_package_verifies_downloaded_go_archives = () => {
         ),
       /checksum mismatch/,
     );
+    assert.equal(
+      fs.existsSync(temporary),
+      false,
+      "a failed replacement must remove its temporary download",
+    );
 
     const extractDir = path.join(root, "extract");
     const goBinary = path.join(extractDir, "go", "bin", "go");
@@ -119,6 +124,9 @@ export const test_platform_package_verifies_downloaded_go_archives = () => {
   );
   assert.match(packager, /https:\/\/go\.dev\/dl\/\?mode=json&include=all/);
   assert.match(packager, /fetchGoArchiveChecksum/);
-  assert.match(packager, /ensureVerifiedGoArchive/);
-  assert.match(packager, /ensureVerifiedGoExtraction/);
+  assert.match(
+    packager,
+    /ensureVerifiedGoExtraction\(\{\s*archivePath,\s*checksum,\s*extractDir,\s*extractZipArchive,\s*goBinary,\s*verifyArchive: \(file, expected\) =>\s*ensureVerifiedGoArchive\(file, url, expected\),\s*\}\)/,
+    "the package owner must authenticate the same archive before extraction",
+  );
 };


### PR DESCRIPTION
## Intent

Own the complete accepted fourth-cycle campaign scope and make Go SDK
extraction portable when a Windows root build selects Git for Windows GNU tar.

## Scope

- #1025
- Invoke ambient tar from the archive cache with validated relative archive and
  destination operands, removing Git for Windows GNU tar's `D:` remote-host
  ambiguity without selecting a tar vendor.
- Preserve checksum-first authentication, stale-cache recovery, Go-binary
  validation, marker-last publication, and the Node zip extraction path.
- Exercise the complete authenticated extraction transaction, including paths
  with spaces and real GNU tar/bsdtar extraction.

This draft pull request owns every accepted issue from the cycle. No other
campaign issue remains unclaimed.

## Deferred

None.

## Verification

The discovery gate closed after a complete fresh empty round against
`bc3e2e9950fa71c5a1f328699e09766e46ede98e`.

- The previously failing real `@ttsc/darwin-arm64` Windows package build
  completed all binaries and embedded the verified Go 1.26.4 SDK with Git GNU
  tar.
- Exact-head `features/platform`: 17/17 passed.
- Exact-head test-ttsc typecheck passed.
- The focused regression passed with both Git GNU tar 1.35 and Windows system
  bsdtar 3.8.4.
- All thirteen workspace typechecks passed before the later test-only review
  corrections.
- CJS syntax, diff whitespace, project layout, and all 83 test-owner assertions
  passed.
- Ordinary exact-head pull-request CI is the remaining independent merge gate.

## Review

Every pushed implementation or correction commit received its required
read-only Individual Self-Review. Three reviews found and drove test-integrity
improvements; the final exact-head review is clean:

- Initial review:
  https://github.com/samchon/ttsc/pull/1026#pullrequestreview-4783476258
- Transaction-owner review:
  https://github.com/samchon/ttsc/pull/1026#pullrequestreview-4783496978
- Wiring/cleanup review:
  https://github.com/samchon/ttsc/pull/1026#pullrequestreview-4783497191
- Final clean Individual Self-Review:
  https://github.com/samchon/ttsc/pull/1026#pullrequestreview-4783518011
- Final clean Overall Self-Review:
  https://github.com/samchon/ttsc/pull/1026#pullrequestreview-4783522610
