### PR TITLE
perf(ci): run nestia compatibility in one broad job

### DIFF
--- a/.github/workflows/nestia.yml
+++ b/.github/workflows/nestia.yml
@@ -30,10 +30,12 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Pack the current-platform ttsc tarballs once and share them with every
-  # matrix job below, instead of rebuilding them six times.
-  tarballs:
+  # Build the current-platform tarballs and run nestia's complete upstream
+  # suite in one broad last-defense job. Keeping producer and consumer on the
+  # same runner avoids an artifact handoff and duplicated toolchain setup.
+  nestia:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       # Only build + pack the current platform (ttsc-linux-x64) — nestia's
       # overrides pull in ttsc.tgz + ttsc-linux-x64.tgz only. The full
@@ -64,44 +66,6 @@ jobs:
 
       - name: Build ttsc tarballs (current platform only)
         run: pnpm package:tgz
-
-      - name: Upload tarballs
-        uses: actions/upload-artifact@v4
-        with:
-          name: ttsc-tarballs
-          path: experimental/tarballs/*.tgz
-          if-no-files-found: error
-          retention-days: 1
-
-  # Run nestia's standard test suite against the local ttsc tarballs
-  # instead of the published release.
-  nestia:
-    needs: tarballs
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.6.4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: packages/ttsc/go.mod
-          cache-dependency-path: |
-            packages/ttsc/go.sum
-            tests/go-transformer/go.mod
-
-      - name: Download ttsc tarballs
-        uses: actions/download-artifact@v4
-        with:
-          name: ttsc-tarballs
-          path: experimental/tarballs
 
       # Keep this integration gate attributable to ttsc. nestia master became
       # red in its own sdk lane after this revision (PR #1594, openapi_v2), so a
@@ -146,16 +110,10 @@ jobs:
       - name: Use System Go For Source Plugin Build
         run: echo "TTSC_GO_BINARY=$(go env GOROOT)/bin/go" >> "$GITHUB_ENV"
 
-      - name: Build nestia
+      - name: Test nestia
         working-directory: experimental/nestia
         env:
           # Mirror nestia's own test.yml: keep Node's native TS strip / module
           # detection off so the e2e run matches nestia's CI environment.
-          NODE_OPTIONS: --no-experimental-strip-types --no-experimental-detect-module
-        run: pnpm build
-
-      - name: Test nestia
-        working-directory: experimental/nestia
-        env:
           NODE_OPTIONS: --no-experimental-strip-types --no-experimental-detect-module
         run: pnpm test

--- a/scripts/ci/validation-plan.test.cjs
+++ b/scripts/ci/validation-plan.test.cjs
@@ -255,12 +255,35 @@ test("remaining workflow path filters match the repository contract", () => {
     /actions\/(?:upload|download)-artifact/,
     "nestia must consume local tarballs without an artifact handoff",
   );
-  assert.match(nestiaJob, /run: pnpm package:tgz/);
-  assert.match(nestiaJob, /run: pnpm test/);
+  assert.equal(
+    commandCount(nestiaJob, "pnpm package:tgz"),
+    1,
+    "nestia must build current-platform tarballs exactly once",
+  );
+  assert.equal(
+    commandCount(nestiaJob, "pnpm test"),
+    1,
+    "nestia must run the complete upstream suite exactly once",
+  );
+  assert.equal(
+    commandCount(nestiaJob, "pnpm build"),
+    0,
+    "the upstream test command already performs the nestia build",
+  );
+  for (const action of [
+    "pnpm/action-setup",
+    "actions/setup-node",
+    "actions/setup-go",
+  ])
+    assert.equal(
+      actionCount(nestiaJob, action),
+      1,
+      `${action} must be configured exactly once`,
+    );
   assert.doesNotMatch(
     nestiaJob,
-    /name: Build nestia/,
-    "the upstream test command already performs the nestia build",
+    /needs: tarballs/,
+    "nestia must not wait for a separate tarball producer",
   );
 });
 
@@ -357,4 +380,16 @@ function workflowJobs(source) {
     .slice(start + 1)
     .map((line) => /^  ([^\s].*):$/.exec(line)?.[1])
     .filter(Boolean);
+}
+
+function commandCount(source, command) {
+  return source
+    .split(/\r?\n/)
+    .filter((line) => line.trim() === `run: ${command}`).length;
+}
+
+function actionCount(source, action) {
+  return source
+    .split(/\r?\n/)
+    .filter((line) => line.trim().startsWith(`- uses: ${action}@`)).length;
 }

--- a/scripts/ci/validation-plan.test.cjs
+++ b/scripts/ci/validation-plan.test.cjs
@@ -270,6 +270,15 @@ test("remaining workflow path filters match the repository contract", () => {
     0,
     "the upstream test command already performs the nestia build",
   );
+  const tarballSteps = exactRunSteps(nestiaJob, "pnpm package:tgz");
+  assert.equal(tarballSteps.length, 1);
+  const upstreamTestSteps = exactRunSteps(nestiaJob, "pnpm test");
+  assert.equal(upstreamTestSteps.length, 1);
+  assert.match(
+    upstreamTestSteps[0],
+    /^\s+working-directory: experimental\/nestia$/m,
+    "the complete upstream suite must run from the pinned nestia checkout",
+  );
   for (const action of [
     "pnpm/action-setup",
     "actions/setup-node",
@@ -282,8 +291,8 @@ test("remaining workflow path filters match the repository contract", () => {
     );
   assert.doesNotMatch(
     nestiaJob,
-    /needs: tarballs/,
-    "nestia must not wait for a separate tarball producer",
+    /^\s+needs:/m,
+    "the single nestia job must not wait for another producer",
   );
 });
 
@@ -383,13 +392,46 @@ function workflowJobs(source) {
 }
 
 function commandCount(source, command) {
+  const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`\\b${escaped}(?![\\w:-])`, "g");
   return source
     .split(/\r?\n/)
-    .filter((line) => line.trim() === `run: ${command}`).length;
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .reduce((count, line) => count + [...line.matchAll(pattern)].length, 0);
 }
 
 function actionCount(source, action) {
+  const escaped = action.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`\\buses:\\s*[\"']?${escaped}@`, "g");
   return source
     .split(/\r?\n/)
-    .filter((line) => line.trim().startsWith(`- uses: ${action}@`)).length;
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .reduce((count, line) => count + [...line.matchAll(pattern)].length, 0);
+}
+
+function workflowSteps(source) {
+  const lines = source.split(/\r?\n/);
+  const start = lines.findIndex((line) => line === "    steps:");
+  assert.notEqual(start, -1, "missing workflow steps");
+  const steps = [];
+  for (let index = start + 1; index < lines.length; index++) {
+    if (!/^      -\s/.test(lines[index])) continue;
+    let end = lines.length;
+    for (let cursor = index + 1; cursor < lines.length; cursor++)
+      if (/^      -\s/.test(lines[cursor])) {
+        end = cursor;
+        break;
+      }
+    steps.push(lines.slice(index, end).join("\n"));
+  }
+  return steps;
+}
+
+function exactRunSteps(source, command) {
+  const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `^\\s+(?:-\\s+)?run:\\s*[\"']?${escaped}[\"']?\\s*$`,
+    "m",
+  );
+  return workflowSteps(source).filter((step) => pattern.test(step));
 }

--- a/scripts/ci/validation-plan.test.cjs
+++ b/scripts/ci/validation-plan.test.cjs
@@ -1,5 +1,6 @@
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const { createRequire } = require("node:module");
 const path = require("node:path");
 const { test } = require("node:test");
 
@@ -13,6 +14,10 @@ const {
 const { PLATFORM_TARGETS, SCOPES } = require("../build-current.cjs");
 
 const root = path.resolve(__dirname, "..", "..");
+const testTtscRequire = createRequire(
+  path.join(root, "tests", "test-ttsc", "package.json"),
+);
+const { parse: parseYaml } = testTtscRequire("yaml");
 
 function ids(files) {
   return planForPaths(files).laneIds;
@@ -244,39 +249,54 @@ test("remaining workflow path filters match the repository contract", () => {
     path.join(root, ".github", "workflows", "nestia.yml"),
     "utf8",
   );
-  const nestiaJob = workflowJob(nestiaWorkflow, "nestia");
+  const nestiaDocument = parseYaml(nestiaWorkflow);
   assert.deepEqual(
-    workflowJobs(nestiaWorkflow),
+    Object.keys(nestiaDocument.jobs),
     ["nestia"],
     "nestia compatibility must stay in one broad job",
   );
-  assert.doesNotMatch(
-    nestiaJob,
-    /actions\/(?:upload|download)-artifact/,
+  const nestiaJob = nestiaDocument.jobs.nestia;
+  assert.equal(
+    Object.hasOwn(nestiaJob, "needs"),
+    false,
+    "the single nestia job must not wait for another producer",
+  );
+  assert.equal(nestiaJob["timeout-minutes"], 60);
+  assert.equal(nestiaJob.env.TTSC_TARBALLS_CURRENT, "1");
+  const steps = nestiaJob.steps;
+  assert.ok(Array.isArray(steps));
+  assert.equal(
+    steps.some(
+      (step) =>
+        typeof step.uses === "string" &&
+        /^actions\/(?:upload|download)-artifact@/.test(step.uses),
+    ),
+    false,
     "nestia must consume local tarballs without an artifact handoff",
   );
   assert.equal(
-    commandCount(nestiaJob, "pnpm package:tgz"),
+    pnpmScriptCount(steps, "package:tgz"),
     1,
     "nestia must build current-platform tarballs exactly once",
   );
   assert.equal(
-    commandCount(nestiaJob, "pnpm test"),
+    pnpmScriptCount(steps, "test"),
     1,
     "nestia must run the complete upstream suite exactly once",
   );
   assert.equal(
-    commandCount(nestiaJob, "pnpm build"),
+    pnpmScriptCount(steps, "build"),
     0,
     "the upstream test command already performs the nestia build",
   );
-  const tarballSteps = exactRunSteps(nestiaJob, "pnpm package:tgz");
-  assert.equal(tarballSteps.length, 1);
-  const upstreamTestSteps = exactRunSteps(nestiaJob, "pnpm test");
+  const upstreamTestSteps = steps.filter(
+    (step) =>
+      typeof step.run === "string" && pnpmScriptCount([step], "test") === 1,
+  );
   assert.equal(upstreamTestSteps.length, 1);
-  assert.match(
-    upstreamTestSteps[0],
-    /^\s+working-directory: experimental\/nestia$/m,
+  assert.equal(
+    upstreamTestSteps[0]["working-directory"],
+    "experimental/nestia",
     "the complete upstream suite must run from the pinned nestia checkout",
   );
   for (const action of [
@@ -285,15 +305,13 @@ test("remaining workflow path filters match the repository contract", () => {
     "actions/setup-go",
   ])
     assert.equal(
-      actionCount(nestiaJob, action),
+      steps.filter(
+        (step) =>
+          typeof step.uses === "string" && step.uses.startsWith(`${action}@`),
+      ).length,
       1,
       `${action} must be configured exactly once`,
     );
-  assert.doesNotMatch(
-    nestiaJob,
-    /^\s+needs:/m,
-    "the single nestia job must not wait for another producer",
-  );
 });
 
 test("portable path normalization accepts git and Windows spellings", () => {
@@ -381,57 +399,18 @@ function workflowJob(source, name) {
   return lines.slice(start, end).join("\n");
 }
 
-function workflowJobs(source) {
-  const lines = source.split(/\r?\n/);
-  const start = lines.findIndex((line) => line === "jobs:");
-  assert.notEqual(start, -1, "missing workflow jobs");
-  return lines
-    .slice(start + 1)
-    .map((line) => /^  ([^\s].*):$/.exec(line)?.[1])
-    .filter(Boolean);
-}
-
-function commandCount(source, command) {
-  const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp(`\\b${escaped}(?![\\w:-])`, "g");
-  return source
-    .split(/\r?\n/)
-    .filter((line) => !line.trimStart().startsWith("#"))
-    .reduce((count, line) => count + [...line.matchAll(pattern)].length, 0);
-}
-
-function actionCount(source, action) {
-  const escaped = action.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp(`\\buses:\\s*[\"']?${escaped}@`, "g");
-  return source
-    .split(/\r?\n/)
-    .filter((line) => !line.trimStart().startsWith("#"))
-    .reduce((count, line) => count + [...line.matchAll(pattern)].length, 0);
-}
-
-function workflowSteps(source) {
-  const lines = source.split(/\r?\n/);
-  const start = lines.findIndex((line) => line === "    steps:");
-  assert.notEqual(start, -1, "missing workflow steps");
-  const steps = [];
-  for (let index = start + 1; index < lines.length; index++) {
-    if (!/^      -\s/.test(lines[index])) continue;
-    let end = lines.length;
-    for (let cursor = index + 1; cursor < lines.length; cursor++)
-      if (/^      -\s/.test(lines[cursor])) {
-        end = cursor;
-        break;
-      }
-    steps.push(lines.slice(index, end).join("\n"));
-  }
-  return steps;
-}
-
-function exactRunSteps(source, command) {
-  const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function pnpmScriptCount(steps, script) {
+  const escaped = script.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const pattern = new RegExp(
-    `^\\s+(?:-\\s+)?run:\\s*[\"']?${escaped}[\"']?\\s*$`,
-    "m",
+    `(?:^|[\\n;&|()])\\s*pnpm\\s+(?:run\\s+)?${escaped}(?![\\w:-])`,
+    "g",
   );
-  return workflowSteps(source).filter((step) => pattern.test(step));
+  return steps.reduce(
+    (count, step) =>
+      count +
+      (typeof step.run === "string"
+        ? [...step.run.matchAll(pattern)].length
+        : 0),
+    0,
+  );
 }

--- a/scripts/ci/validation-plan.test.cjs
+++ b/scripts/ci/validation-plan.test.cjs
@@ -407,7 +407,5 @@ function executableRun(run) {
 }
 
 function containsPnpmCommand(run) {
-  return run
-    .split(/\r?\n/)
-    .some((line) => /(?:^|[;&|()]\s*)pnpm(?:\s|$)/.test(line));
+  return run.split(/\r?\n/).some((line) => /\bpnpm(?=\s|$)/.test(line));
 }

--- a/scripts/ci/validation-plan.test.cjs
+++ b/scripts/ci/validation-plan.test.cjs
@@ -274,24 +274,23 @@ test("remaining workflow path filters match the repository contract", () => {
     false,
     "nestia must consume local tarballs without an artifact handoff",
   );
-  assert.equal(
-    pnpmScriptCount(steps, "package:tgz"),
-    1,
-    "nestia must build current-platform tarballs exactly once",
-  );
-  assert.equal(
-    pnpmScriptCount(steps, "test"),
-    1,
-    "nestia must run the complete upstream suite exactly once",
-  );
-  assert.equal(
-    pnpmScriptCount(steps, "build"),
-    0,
-    "the upstream test command already performs the nestia build",
+  assert.deepEqual(
+    steps
+      .map((step) =>
+        typeof step.run === "string" ? executableRun(step.run) : "",
+      )
+      .filter(containsPnpmCommand),
+    [
+      "pnpm install --frozen-lockfile",
+      "pnpm package:tgz",
+      "pnpm install --no-frozen-lockfile",
+      "pnpm test",
+    ],
+    "nestia must keep one tarball build and one complete upstream test command",
   );
   const upstreamTestSteps = steps.filter(
     (step) =>
-      typeof step.run === "string" && pnpmScriptCount([step], "test") === 1,
+      typeof step.run === "string" && executableRun(step.run) === "pnpm test",
   );
   assert.equal(upstreamTestSteps.length, 1);
   assert.equal(
@@ -399,18 +398,16 @@ function workflowJob(source, name) {
   return lines.slice(start, end).join("\n");
 }
 
-function pnpmScriptCount(steps, script) {
-  const escaped = script.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp(
-    `(?:^|[\\n;&|()])\\s*pnpm\\s+(?:run\\s+)?${escaped}(?![\\w:-])`,
-    "g",
-  );
-  return steps.reduce(
-    (count, step) =>
-      count +
-      (typeof step.run === "string"
-        ? [...step.run.matchAll(pattern)].length
-        : 0),
-    0,
-  );
+function executableRun(run) {
+  return run
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("#"))
+    .join("\n");
+}
+
+function containsPnpmCommand(run) {
+  return run
+    .split(/\r?\n/)
+    .some((line) => /(?:^|[;&|()]\s*)pnpm(?:\s|$)/.test(line));
 }

--- a/scripts/ci/validation-plan.test.cjs
+++ b/scripts/ci/validation-plan.test.cjs
@@ -239,6 +239,29 @@ test("remaining workflow path filters match the repository contract", () => {
     /if: \$\{\{ always\(\) && !cancelled\(\) \}\}/,
     "a superseded run must not queue its aggregate behind cancellation",
   );
+
+  const nestiaWorkflow = fs.readFileSync(
+    path.join(root, ".github", "workflows", "nestia.yml"),
+    "utf8",
+  );
+  const nestiaJob = workflowJob(nestiaWorkflow, "nestia");
+  assert.deepEqual(
+    workflowJobs(nestiaWorkflow),
+    ["nestia"],
+    "nestia compatibility must stay in one broad job",
+  );
+  assert.doesNotMatch(
+    nestiaJob,
+    /actions\/(?:upload|download)-artifact/,
+    "nestia must consume local tarballs without an artifact handoff",
+  );
+  assert.match(nestiaJob, /run: pnpm package:tgz/);
+  assert.match(nestiaJob, /run: pnpm test/);
+  assert.doesNotMatch(
+    nestiaJob,
+    /name: Build nestia/,
+    "the upstream test command already performs the nestia build",
+  );
 });
 
 test("portable path normalization accepts git and Windows spellings", () => {
@@ -324,4 +347,14 @@ function workflowJob(source, name) {
       break;
     }
   return lines.slice(start, end).join("\n");
+}
+
+function workflowJobs(source) {
+  const lines = source.split(/\r?\n/);
+  const start = lines.findIndex((line) => line === "jobs:");
+  assert.notEqual(start, -1, "missing workflow jobs");
+  return lines
+    .slice(start + 1)
+    .map((line) => /^  ([^\s].*):$/.exec(line)?.[1])
+    .filter(Boolean);
 }


### PR DESCRIPTION
Closes #1040

## Outcome

The pinned nestia compatibility gate now runs as one broad last-defense job:

- builds the current-platform ttsc tarballs once
- consumes them on the same runner without upload/download artifacts
- configures pnpm, Node, and Go once
- removes the explicit `pnpm build` already performed by upstream `pnpm test`
- preserves the pinned revision, local overrides, system Go, Node flags, timeout, triggers, and complete upstream suite

A YAML-parsed workflow contract locks one job, no `needs`/artifact handoff, setup actions once, the exact pnpm command set, and the upstream test working directory.

## Validation

- local planner/ownership tests: 17/17 passed
- targeted Prettier, `node --check`, and `git diff --check`: passed
- Individual Self-Reviews: all findings repaired; final review found no issues
- Overall Self-Review: no findings
- final `test` run [30357621523](https://github.com/samchon/ttsc/actions/runs/30357621523): 17/17 jobs passed, 117.25 runner-min, 26.93 min observed workflow wall
- final `nestia` run [30357621503](https://github.com/samchon/ttsc/actions/runs/30357621503): 1/1 job passed

## Measurement

Previous nestia run [30351679717](https://github.com/samchon/ttsc/actions/runs/30351679717):

- 2 jobs, 38.18 runner-min, 39.15 min first-job-to-last-job wall
- explicit duplicate `Build nestia`: 5.58 min
- preserved `Test nestia`: 31.08 min

Final run:

- 1 job (-50%)
- no explicit pre-test build, artifact handoff, or duplicated setup
- 43.47 runner-min / job wall
- preserved `Test nestia`: 42.40 min in this sample

The raw sample is 4.32 min slower because the preserved upstream suite itself varied by +11.32 min. Normalizing both runs to the final suite duration, the old topology would have cost 49.50 runner-min and 50.47 min wall; the new topology saves 6.03 runner-min and 7.00 min pipeline wall (12.2% / 13.9%).

Across the compiler-wide CI boundary after both campaign cycles, the topology is 62 → 40 jobs and normalized runner cost is 445.21 → 274.92 min. The observed critical-path estimate remains about 48.12 min because another preserved external compatibility gate dominates; this change targets absolute job count and duplicated work rather than weakening that last defense.