### PR TITLE
perf(ci): fold wasm smoke into broad build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
           go-version-file: packages/ttsc/go.mod
           cache-dependency-path: |
             packages/ttsc/go.sum
+            packages/wasm/go.sum
             tests/go-transformer/go.mod
 
       - uses: pnpm/action-setup@v6
@@ -71,32 +72,6 @@ jobs:
 
       - name: Smoke release-candidate ttscgraph snapshot
         run: node scripts/assert-ttscgraph-release-candidate.cjs
-
-  wasm-build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24.x
-
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: packages/ttsc/go.mod
-          cache-dependency-path: |
-            packages/ttsc/go.sum
-            packages/wasm/go.sum
-
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 10.6.4
-
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build @ttsc/wasm
-        run: pnpm --filter @ttsc/wasm build
 
       - name: Assert dist artifacts exist
         run: |

--- a/scripts/ci/validation-plan.test.cjs
+++ b/scripts/ci/validation-plan.test.cjs
@@ -324,7 +324,8 @@ test("remaining workflow path filters match the repository contract", () => {
     ["Ubuntu"],
     "the broad build job must also own wasm package smoke checks",
   );
-  const buildRuns = buildDocument.jobs.Ubuntu.steps
+  const buildSteps = buildDocument.jobs.Ubuntu.steps;
+  const buildRuns = buildSteps
     .map((step) => (typeof step.run === "string" ? step.run : ""))
     .filter(Boolean);
   assert.equal(
@@ -356,6 +357,26 @@ test("remaining workflow path filters match the repository contract", () => {
         run.includes("grep -q dist/ttsc.wasm"),
     ),
     "the broad job must retain wasm tarball smoke",
+  );
+  const stepIndex = (predicate) =>
+    buildSteps.findIndex(
+      (step) => typeof step.run === "string" && predicate(step.run),
+    );
+  const buildIndex = stepIndex((run) => run.trim() === "pnpm run build");
+  const releaseSmokeIndex = stepIndex((run) =>
+    run.includes("assert-ttscgraph-release-candidate.cjs"),
+  );
+  const distSmokeIndex = stepIndex((run) =>
+    run.includes("test -f packages/wasm/dist/ttsc.wasm"),
+  );
+  const tarballSmokeIndex = stepIndex((run) =>
+    run.includes("pnpm pack --pack-destination /tmp"),
+  );
+  assert.ok(
+    buildIndex < releaseSmokeIndex &&
+      releaseSmokeIndex < distSmokeIndex &&
+      distSmokeIndex < tarballSmokeIndex,
+    "the broad build must produce artifacts before every smoke assertion",
   );
 });
 

--- a/scripts/ci/validation-plan.test.cjs
+++ b/scripts/ci/validation-plan.test.cjs
@@ -12,6 +12,7 @@ const {
   planForPaths,
 } = require("./validation-plan.cjs");
 const { PLATFORM_TARGETS, SCOPES } = require("../build-current.cjs");
+const { PACKAGE_BUILDS_BEFORE_PLATFORMS } = require("../build-platforms.cjs");
 
 const root = path.resolve(__dirname, "..", "..");
 const testTtscRequire = createRequire(
@@ -311,6 +312,51 @@ test("remaining workflow path filters match the repository contract", () => {
       1,
       `${action} must be configured exactly once`,
     );
+
+  const buildDocument = parseYaml(
+    fs.readFileSync(
+      path.join(root, ".github", "workflows", "build.yml"),
+      "utf8",
+    ),
+  );
+  assert.deepEqual(
+    Object.keys(buildDocument.jobs),
+    ["Ubuntu"],
+    "the broad build job must also own wasm package smoke checks",
+  );
+  const buildRuns = buildDocument.jobs.Ubuntu.steps
+    .map((step) => (typeof step.run === "string" ? step.run : ""))
+    .filter(Boolean);
+  assert.equal(
+    buildRuns.filter((run) => run.trim() === "pnpm run build").length,
+    1,
+  );
+  assert.ok(
+    PACKAGE_BUILDS_BEFORE_PLATFORMS.includes("@ttsc/wasm"),
+    "the broad package build must produce wasm artifacts before smoke checks",
+  );
+  assert.equal(
+    buildRuns.some((run) => run.includes("pnpm --filter @ttsc/wasm build")),
+    false,
+    "the broad package build already builds @ttsc/wasm",
+  );
+  assert.ok(
+    buildRuns.some(
+      (run) =>
+        run.includes("test -f packages/wasm/dist/ttsc.wasm") &&
+        run.includes("test -d packages/wasm/shim-vendor/shim"),
+    ),
+    "the broad job must retain wasm dist assertions",
+  );
+  assert.ok(
+    buildRuns.some(
+      (run) =>
+        run.includes("pnpm pack --pack-destination /tmp") &&
+        run.includes("grep -q shim-vendor/shim/ast/shim.go") &&
+        run.includes("grep -q dist/ttsc.wasm"),
+    ),
+    "the broad job must retain wasm tarball smoke",
+  );
 });
 
 test("portable path normalization accepts git and Windows spellings", () => {


### PR DESCRIPTION
Closes #1044

## Outcome

The build workflow now has one broad Ubuntu job. Its existing `pnpm run build` already produces `@ttsc/wasm`; the wasm dist and packed-tarball smoke assertions now run immediately afterward on the same runner.

Removed:

- separate `wasm-build` job
- duplicated checkout, Node/Go/pnpm setup, workspace install, and wasm build

Preserved:

- complete package/platform build
- release-candidate ttscgraph smoke
- wasm dist file assertions
- wasm packed-tarball content assertions
- triggers and concurrency

A parsed workflow contract enforces one job, broad-build ownership of wasm, no explicit duplicate build, smoke contents, and strict execution order.

## Validation

- local planner/ownership tests: 17/17 passed
- Prettier, `node --check`, `git diff --check`, actionlint: passed
- final Individual Self-Review: no findings
- Overall Self-Review: no findings
- build run [30361727177](https://github.com/samchon/ttsc/actions/runs/30361727177): 1/1 passed
- test run [30361724140](https://github.com/samchon/ttsc/actions/runs/30361724140): 17/17 passed, 119.68 runner-min, 38.25 min observed wall including runner queue

## Measurement

Previous build run [30355211555](https://github.com/samchon/ttsc/actions/runs/30355211555): 2 jobs, 23.12 runner-min. Final build run: 1 job, 22.97 runner-min. Raw saving is 0.15 runner-min in this sample; structurally the removed job accounted for 1.22 runner-min, while its two smoke assertions add only seconds to the retained broad job. Critical path remains the broad package build.

Compiler-wide topology after all campaign cycles: 62 → 39 jobs.