### PR TITLE
perf(ci): run plugin-cache managers in two broad OS jobs

### DIFF
--- a/.github/workflows/plugin-cache.yml
+++ b/.github/workflows/plugin-cache.yml
@@ -48,22 +48,12 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  cache:
-    name: ${{ matrix.pm }} (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # All four workspace-capable managers on Linux, plus Windows lanes so the
-        # per-OS cache-path resolution (node_modules/.cache/ttsc) is exercised on
-        # a non-POSIX filesystem. bun on Windows is omitted (flaky in Actions).
-        include:
-          - { os: ubuntu-latest, pm: pnpm }
-          - { os: ubuntu-latest, pm: yarn }
-          - { os: ubuntu-latest, pm: bun }
-          - { os: ubuntu-latest, pm: npm }
-          - { os: windows-latest, pm: npm }
-          - { os: windows-latest, pm: pnpm }
+  # Package managers need distinct real workspace installs, but they do not need
+  # distinct runners or native compiler builds. Run every supported layout
+  # sequentially after one current-platform build per irreducible OS boundary.
+  cache-linux:
+    name: managers (ubuntu-latest)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
@@ -82,8 +72,7 @@ jobs:
         with:
           version: 10.6.4
 
-      - if: matrix.pm == 'bun'
-        uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -99,5 +88,53 @@ jobs:
         env:
           TTSC_BUILD_SCOPE: plugin-cache
 
-      - name: Verify Plugin Cache Persistence (${{ matrix.pm }})
-        run: node scripts/ci/plugin-cache-persistence.mjs --pm=${{ matrix.pm }}
+      - name: Verify Linux Package Managers
+        shell: bash
+        run: |
+          status=0
+          node scripts/ci/plugin-cache-persistence.mjs --pm=pnpm || status=1
+          node scripts/ci/plugin-cache-persistence.mjs --pm=yarn || status=1
+          node scripts/ci/plugin-cache-persistence.mjs --pm=bun || status=1
+          node scripts/ci/plugin-cache-persistence.mjs --pm=npm || status=1
+          exit "$status"
+
+  cache-windows:
+    name: managers (windows-latest)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.x
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: packages/ttsc/go.mod
+          cache-dependency-path: |
+            packages/ttsc/go.sum
+            tests/go-transformer/go.mod
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.6.4
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Use System Go For Source Plugin Builds
+        shell: bash
+        run: echo "TTSC_GO_BINARY=$(go env GOROOT)/bin/go" >> "$GITHUB_ENV"
+
+      - name: Build Current Platform
+        run: pnpm run build:current
+        env:
+          TTSC_BUILD_SCOPE: plugin-cache
+
+      - name: Verify Windows Package Managers
+        shell: bash
+        run: |
+          status=0
+          node scripts/ci/plugin-cache-persistence.mjs --pm=npm || status=1
+          node scripts/ci/plugin-cache-persistence.mjs --pm=pnpm || status=1
+          exit "$status"

--- a/.github/workflows/plugin-cache.yml
+++ b/.github/workflows/plugin-cache.yml
@@ -2,8 +2,8 @@ name: plugin-cache
 
 # Regression gate for issue #326: a source plugin must build ONCE per workspace
 # and be reused across packages and processes, for every workspace-capable
-# package manager. Each job scaffolds a real monorepo, installs it with one
-# manager, and runs scripts/ci/plugin-cache-persistence.mjs, which fails if a
+# package manager. Each OS job builds the native compiler once, then the harness
+# scaffolds and installs a fresh real monorepo for every manager. It fails if a
 # second package rebuilds the plugin or if anything is written to a global cache.
 
 on:

--- a/scripts/ci/validation-plan.test.cjs
+++ b/scripts/ci/validation-plan.test.cjs
@@ -431,31 +431,19 @@ test("remaining workflow path filters match the repository contract", () => {
       ).length,
       expected.bun,
     );
-    assert.equal(
-      job.steps.filter(
-        (step) =>
-          typeof step.run === "string" &&
-          step.run.trim() === "pnpm install --frozen-lockfile",
-      ).length,
-      1,
-      `${jobName} must install the repository exactly once`,
-    );
     const systemGo = job.steps.find(
       (step) => step.name === "Use System Go For Source Plugin Builds",
     );
     assert.equal(systemGo.shell, "bash");
-    assert.match(systemGo.run, /TTSC_GO_BINARY=.*go env GOROOT/);
-    const buildSteps = job.steps.filter(
-      (step) =>
-        typeof step.run === "string" &&
-        step.run.trim() === "pnpm run build:current",
-    );
     assert.equal(
-      buildSteps.length,
-      1,
-      `${jobName} must build the native compiler exactly once`,
+      systemGo.run,
+      'echo "TTSC_GO_BINARY=$(go env GOROOT)/bin/go" >> "$GITHUB_ENV"',
     );
-    assert.equal(buildSteps[0].env.TTSC_BUILD_SCOPE, "plugin-cache");
+    const build = job.steps.find(
+      (step) => step.name === "Build Current Platform",
+    );
+    assert.equal(build.run, "pnpm run build:current");
+    assert.equal(build.env.TTSC_BUILD_SCOPE, "plugin-cache");
     const verification = job.steps.find(
       (step) =>
         typeof step.name === "string" &&
@@ -464,20 +452,33 @@ test("remaining workflow path filters match the repository contract", () => {
     );
     assert.ok(verification, `${jobName} lost package-manager verification`);
     assert.equal(verification.shell, "bash");
+    const verificationLines = [
+      "status=0",
+      ...expected.managers.map(
+        (manager) =>
+          `node scripts/ci/plugin-cache-persistence.mjs --pm=${manager} || status=1`,
+      ),
+      'exit "$status"',
+    ];
     assert.deepEqual(
       verification.run
         .split(/\r?\n/)
         .map((line) => line.trim())
         .filter(Boolean),
-      [
-        "status=0",
-        ...expected.managers.map(
-          (manager) =>
-            `node scripts/ci/plugin-cache-persistence.mjs --pm=${manager} || status=1`,
-        ),
-        'exit "$status"',
-      ],
+      verificationLines,
       `${jobName} must run every manager before reporting failure`,
+    );
+    assert.deepEqual(
+      job.steps
+        .filter((step) => typeof step.run === "string")
+        .map((step) => step.run.trim()),
+      [
+        "pnpm install --frozen-lockfile",
+        'echo "TTSC_GO_BINARY=$(go env GOROOT)/bin/go" >> "$GITHUB_ENV"',
+        "pnpm run build:current",
+        verificationLines.join("\n"),
+      ],
+      `${jobName} must install and build exactly once before verification`,
     );
   }
 });

--- a/scripts/ci/validation-plan.test.cjs
+++ b/scripts/ci/validation-plan.test.cjs
@@ -389,26 +389,73 @@ test("remaining workflow path filters match the repository contract", () => {
     "cache-linux",
     "cache-windows",
   ]);
-  const expectedPluginManagers = {
-    "cache-linux": ["pnpm", "yarn", "bun", "npm"],
-    "cache-windows": ["npm", "pnpm"],
+  const expectedPluginJobs = {
+    "cache-linux": {
+      runner: "ubuntu-latest",
+      managers: ["pnpm", "yarn", "bun", "npm"],
+      bun: 1,
+    },
+    "cache-windows": {
+      runner: "windows-latest",
+      managers: ["npm", "pnpm"],
+      bun: 0,
+    },
   };
-  for (const [jobName, managers] of Object.entries(expectedPluginManagers)) {
+  for (const [jobName, expected] of Object.entries(expectedPluginJobs)) {
     const job = pluginCacheDocument.jobs[jobName];
+    assert.equal(job["runs-on"], expected.runner);
     assert.equal(
       job.strategy,
       undefined,
       `${jobName} must not expand a matrix`,
     );
+    for (const action of [
+      "actions/checkout",
+      "actions/setup-node",
+      "actions/setup-go",
+      "pnpm/action-setup",
+    ])
+      assert.equal(
+        job.steps.filter(
+          (step) =>
+            typeof step.uses === "string" && step.uses.startsWith(`${action}@`),
+        ).length,
+        1,
+        `${jobName} must configure ${action} exactly once`,
+      );
+    assert.equal(
+      job.steps.filter(
+        (step) =>
+          typeof step.uses === "string" &&
+          step.uses.startsWith("oven-sh/setup-bun@"),
+      ).length,
+      expected.bun,
+    );
     assert.equal(
       job.steps.filter(
         (step) =>
           typeof step.run === "string" &&
-          step.run.trim() === "pnpm run build:current",
+          step.run.trim() === "pnpm install --frozen-lockfile",
       ).length,
+      1,
+      `${jobName} must install the repository exactly once`,
+    );
+    const systemGo = job.steps.find(
+      (step) => step.name === "Use System Go For Source Plugin Builds",
+    );
+    assert.equal(systemGo.shell, "bash");
+    assert.match(systemGo.run, /TTSC_GO_BINARY=.*go env GOROOT/);
+    const buildSteps = job.steps.filter(
+      (step) =>
+        typeof step.run === "string" &&
+        step.run.trim() === "pnpm run build:current",
+    );
+    assert.equal(
+      buildSteps.length,
       1,
       `${jobName} must build the native compiler exactly once`,
     );
+    assert.equal(buildSteps[0].env.TTSC_BUILD_SCOPE, "plugin-cache");
     const verification = job.steps.find(
       (step) =>
         typeof step.name === "string" &&
@@ -416,14 +463,20 @@ test("remaining workflow path filters match the repository contract", () => {
         step.name.endsWith(" Package Managers"),
     );
     assert.ok(verification, `${jobName} lost package-manager verification`);
+    assert.equal(verification.shell, "bash");
     assert.deepEqual(
-      [...verification.run.matchAll(/--pm=([a-z]+)/g)].map((match) => match[1]),
-      managers,
-      `${jobName} package-manager coverage drifted`,
-    );
-    assert.match(
-      verification.run,
-      /status=0[\s\S]+exit "\$status"/,
+      verification.run
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean),
+      [
+        "status=0",
+        ...expected.managers.map(
+          (manager) =>
+            `node scripts/ci/plugin-cache-persistence.mjs --pm=${manager} || status=1`,
+        ),
+        'exit "$status"',
+      ],
       `${jobName} must run every manager before reporting failure`,
     );
   }

--- a/scripts/ci/validation-plan.test.cjs
+++ b/scripts/ci/validation-plan.test.cjs
@@ -378,6 +378,55 @@ test("remaining workflow path filters match the repository contract", () => {
       distSmokeIndex < tarballSmokeIndex,
     "the broad build must produce artifacts before every smoke assertion",
   );
+
+  const pluginCacheDocument = parseYaml(
+    fs.readFileSync(
+      path.join(root, ".github", "workflows", "plugin-cache.yml"),
+      "utf8",
+    ),
+  );
+  assert.deepEqual(Object.keys(pluginCacheDocument.jobs), [
+    "cache-linux",
+    "cache-windows",
+  ]);
+  const expectedPluginManagers = {
+    "cache-linux": ["pnpm", "yarn", "bun", "npm"],
+    "cache-windows": ["npm", "pnpm"],
+  };
+  for (const [jobName, managers] of Object.entries(expectedPluginManagers)) {
+    const job = pluginCacheDocument.jobs[jobName];
+    assert.equal(
+      job.strategy,
+      undefined,
+      `${jobName} must not expand a matrix`,
+    );
+    assert.equal(
+      job.steps.filter(
+        (step) =>
+          typeof step.run === "string" &&
+          step.run.trim() === "pnpm run build:current",
+      ).length,
+      1,
+      `${jobName} must build the native compiler exactly once`,
+    );
+    const verification = job.steps.find(
+      (step) =>
+        typeof step.name === "string" &&
+        step.name.startsWith("Verify ") &&
+        step.name.endsWith(" Package Managers"),
+    );
+    assert.ok(verification, `${jobName} lost package-manager verification`);
+    assert.deepEqual(
+      [...verification.run.matchAll(/--pm=([a-z]+)/g)].map((match) => match[1]),
+      managers,
+      `${jobName} package-manager coverage drifted`,
+    );
+    assert.match(
+      verification.run,
+      /status=0[\s\S]+exit "\$status"/,
+      `${jobName} must run every manager before reporting failure`,
+    );
+  }
 });
 
 test("portable path normalization accepts git and Windows spellings", () => {


### PR DESCRIPTION
Closes #1046

## Intent

Replace the six package-manager matrix runners with one broad Linux job and one broad Windows job.

## Coverage retained

- Linux: pnpm, yarn, bun, npm
- Windows: npm, pnpm
- one native ttsc build per OS
- same real workspace-cache harness per manager, with a fresh temporary workspace/home for every invocation

## Validation

- parsed workflow contract pins both runners, setup counts, exact run order, build scope, manager order, failure aggregation, and system-Go export
- `node --test scripts/ci/validation-plan.test.cjs scripts/ci/test-owners.test.cjs`: 17/17
- syntax, Prettier, and `git diff --check`: pass
- [plugin-cache run 30367059838](https://github.com/samchon/ttsc/actions/runs/30367059838): 2/2 jobs pass
- [full test run 30367059090](https://github.com/samchon/ttsc/actions/runs/30367059090): 17/17 jobs pass
- Individual and Overall Self-Review: no remaining findings

## Measured result

Compared with successful baseline [30355210464](https://github.com/samchon/ttsc/actions/runs/30355210464):

- jobs: 6 ? 2 (-4, -66.7%)
- current-platform Go/native builds: 6 ? 2 (-4, -66.7%)
- summed runner time: 9.00 ? 4.23 minutes (-4.77 minutes, -53.0%)
- parallel wall time: 3.30 ? 3.23 minutes (-0.07 minutes); coverage remains parallel by the two irreducible OS boundaries
- compiler-wide campaign topology: 39 ? 35 jobs in this cycle
