### PR TITLE
fix(ttscgraph): canonicalize symlinked dump paths

### DIFF
--- a/packages/ttsc/internal/graph/dump.go
+++ b/packages/ttsc/internal/graph/dump.go
@@ -246,8 +246,12 @@ func NewDump(g *Graph, project, tsconfig string, ignored map[string]bool, source
     diagnostics = []Diagnostic{}
   }
 
+  // Every relative coordinate above is relative to the mapper's canonical base,
+  // not to the spelling the caller happened to select. Publishing the raw
+  // spelling would leave a consumer resolving `../sibling.ts` against a symlink
+  // whose parent is a different directory entirely.
   dump := Dump{
-    Project:     project,
+    Project:     ctx.paths.project,
     Tsconfig:    ctx.rel(tsconfig),
     Provenance:  provenance,
     Diagnostics: diagnostics,

--- a/packages/ttsc/internal/graph/dump_path_mapper_caches_alias_resolution_test.go
+++ b/packages/ttsc/internal/graph/dump_path_mapper_caches_alias_resolution_test.go
@@ -1,0 +1,30 @@
+package graph
+
+import "testing"
+
+// TestDumpPathMapperCachesAliasResolution verifies repeated graph facts do not
+// repeat filesystem canonicalization for the same raw source path.
+//
+// One source rides the wire once per node, once per node id and twice per edge
+// endpoint, so canonicalizing inside mapPath without a raw-path cache would
+// turn every fact of a large graph into a fresh EvalSymlinks walk.
+//
+//  1. Install a counting canonicalizer on one mapper.
+//  2. Map the same absolute source path repeatedly.
+//  3. Require one canonicalization and one stable wire coordinate.
+func TestDumpPathMapperCachesAliasResolution(t *testing.T) {
+  mapper := newDumpPathMapper("C:/checkout/app")
+  calls := 0
+  mapper.canonicalize = func(path string) string {
+    calls++
+    return path
+  }
+  for range 100 {
+    if wire := mapper.mapPath("C:/checkout/app/src/main.ts"); wire != "src/main.ts" {
+      t.Fatalf("wire path = %q, want src/main.ts", wire)
+    }
+  }
+  if calls != 1 {
+    t.Fatalf("canonicalizer calls = %d, want 1", calls)
+  }
+}

--- a/packages/ttsc/internal/graph/dump_paths.go
+++ b/packages/ttsc/internal/graph/dump_paths.go
@@ -3,6 +3,7 @@ package graph
 import (
   "fmt"
   "path/filepath"
+  "runtime"
   "strings"
 
   shimtspath "github.com/microsoft/typescript-go/shim/tspath"
@@ -13,19 +14,26 @@ import (
 // reject both an unportable filesystem root and a non-injective projection
 // before any JSON is written.
 type dumpPathMapper struct {
+  rawProject    string
   project       string
   caseSensitive bool
+  canonicalize  func(string) string
 
+  rawToWire      map[string]string
   physicalToWire map[string]string
   wireToPhysical map[string]string
   mappingErr     error
 }
 
 func newDumpPathMapper(project string) *dumpPathMapper {
-  normalized := canonicalDumpPath(project)
+  raw := shimtspath.NormalizePath(shimtspath.NormalizeSlashes(project))
+  normalized := canonicalDumpPath(raw)
   mapper := &dumpPathMapper{
+    rawProject:     raw,
     project:        normalized,
     caseSensitive:  dumpPathRootIsCaseSensitive(normalized),
+    canonicalize:   canonicalDumpPath,
+    rawToWire:      map[string]string{},
     physicalToWire: map[string]string{},
     wireToPhysical: map[string]string{},
   }
@@ -54,22 +62,32 @@ func (m *dumpPathMapper) mapPath(file string) string {
   if strings.HasPrefix(normalized, "bundled:///") {
     return m.claim(normalized, normalized)
   }
-  normalized = canonicalDumpPath(normalized)
+  normalized = shimtspath.NormalizePath(normalized)
   if m.project == "" || shimtspath.GetRootLength(m.project) == 0 {
     return normalized
   }
 
-  physical := normalized
-  if shimtspath.GetRootLength(physical) == 0 {
-    physical = shimtspath.GetNormalizedAbsolutePath(physical, m.project)
+  // A relative compiler path is relative to the project the caller named, so
+  // absolutize it against the raw spelling before collapsing aliases.
+  rawPhysical := normalized
+  if shimtspath.GetRootLength(rawPhysical) == 0 {
+    rawPhysical = shimtspath.GetNormalizedAbsolutePath(rawPhysical, m.rawProject)
   }
+  // One source rides the wire once per node, once per node id and twice per
+  // edge endpoint. Cache before canonicalization so a large graph pays the
+  // filesystem walk once per distinct raw path instead of once per fact.
+  rawKey := m.pathKey(rawPhysical)
+  if wire, ok := m.rawToWire[rawKey]; ok {
+    return wire
+  }
+  physical := m.canonicalize(rawPhysical)
   if !dumpPathRootsEqual(m.project, physical, m.caseSensitive) {
     m.fail(fmt.Errorf(
       "ttscgraph: source path %q cannot be represented relative to project %q because they are on different filesystem roots",
-      normalized,
+      rawPhysical,
       m.project,
     ))
-    return normalized
+    return rawPhysical
   }
   options := shimtspath.ComparePathsOptions{
     CurrentDirectory:          m.project,
@@ -79,32 +97,76 @@ func (m *dumpPathMapper) mapPath(file string) string {
   if shimtspath.GetRootLength(wire) != 0 {
     m.fail(fmt.Errorf(
       "ttscgraph: source path %q cannot be represented relative to project %q because they are on different filesystem roots",
-      normalized,
+      rawPhysical,
       m.project,
     ))
-    return normalized
+    return rawPhysical
   }
-  return m.claim(physical, wire)
+  wire = m.claim(physical, wire)
+  m.rawToWire[rawKey] = wire
+  return wire
 }
 
-// canonicalDumpPath resolves host filesystem aliases before applying the
-// compiler's portable path grammar. On macOS, for example, a temporary
-// directory can be observed as both /var/... and /private/var/...; treating
-// those spellings as different trees would make an in-project source appear
-// outside the graph's project root.
+func (m *dumpPathMapper) pathKey(path string) string {
+  if !m.caseSensitive {
+    return strings.ToLower(path)
+  }
+  return path
+}
+
+// canonicalDumpPath collapses host filesystem aliases before the portable path
+// grammar is applied. On macOS one temporary project is observable as both
+// /var/... and /private/var/...; on Windows the same directory answers to an
+// 8.3 short spelling and its expanded name. Comparing those raw strings would
+// make an in-project source look like a sibling outside the project root.
 //
-// Synthetic Windows and UNC paths used by portable tests do not resolve on a
-// non-Windows host. In that case (and for paths that do not exist yet), retain
-// the lexical path so the mapper can still enforce its root rules.
-func canonicalDumpPath(path string) string {
-  normalized := shimtspath.NormalizeSlashes(path)
-  if shimtspath.GetRootLength(normalized) == 0 {
-    return shimtspath.NormalizePath(normalized)
+// Resolution is anchored on the longest existing ancestor rather than the leaf.
+// A source the compiler names before it exists on disk — a `rootDirs` target, a
+// deleted-and-revisited file, a path the checker resolved through a container
+// that was removed — must still land on the same canonical base as its
+// neighbours; resolving only complete paths would leave exactly those inputs
+// spelled through the alias and reproduce the misprojection for them.
+//
+// Synthetic Windows and UNC fixtures in the mapper's own unit tests are not
+// host paths at all, so they keep their lexical spelling and continue to prove
+// the cross-root and injectivity rules on every CI host.
+func canonicalDumpPath(location string) string {
+  normalized := shimtspath.NormalizePath(shimtspath.NormalizeSlashes(location))
+  if normalized == "" || shimtspath.GetRootLength(normalized) == 0 {
+    return normalized
   }
-  if resolved, err := filepath.EvalSymlinks(filepath.FromSlash(normalized)); err == nil {
-    normalized = filepath.ToSlash(resolved)
+  if !dumpPathUsesHostFilesystem(normalized) {
+    return normalized
   }
-  return shimtspath.NormalizePath(normalized)
+  candidate := filepath.Clean(filepath.FromSlash(normalized))
+  suffix := []string{}
+  for {
+    physical, err := filepath.EvalSymlinks(candidate)
+    if err == nil {
+      for index := len(suffix) - 1; index >= 0; index-- {
+        physical = filepath.Join(physical, suffix[index])
+      }
+      return shimtspath.NormalizePath(shimtspath.NormalizeSlashes(physical))
+    }
+    parent := filepath.Dir(candidate)
+    if parent == candidate {
+      break
+    }
+    suffix = append(suffix, filepath.Base(candidate))
+    candidate = parent
+  }
+  return normalized
+}
+
+// dumpPathUsesHostFilesystem separates a real path on this host from a
+// synthetic path that only exercises another platform's grammar. A POSIX host
+// never owns `C:/...` or `//server/share/...`, and a Windows host never owns a
+// single-slash absolute path, so neither should reach the filesystem.
+func dumpPathUsesHostFilesystem(path string) bool {
+  if runtime.GOOS == "windows" {
+    return strings.HasPrefix(path, "//") || (len(path) >= 2 && path[1] == ':')
+  }
+  return strings.HasPrefix(path, "/") && !strings.HasPrefix(path, "//")
 }
 
 // claim records both directions of the projection. The reverse map is the

--- a/packages/ttsc/internal/graph/dump_paths.go
+++ b/packages/ttsc/internal/graph/dump_paths.go
@@ -2,6 +2,7 @@ package graph
 
 import (
   "fmt"
+  "path/filepath"
   "strings"
 
   shimtspath "github.com/microsoft/typescript-go/shim/tspath"
@@ -21,7 +22,7 @@ type dumpPathMapper struct {
 }
 
 func newDumpPathMapper(project string) *dumpPathMapper {
-  normalized := shimtspath.NormalizePath(shimtspath.NormalizeSlashes(project))
+  normalized := canonicalDumpPath(project)
   mapper := &dumpPathMapper{
     project:        normalized,
     caseSensitive:  dumpPathRootIsCaseSensitive(normalized),
@@ -53,7 +54,7 @@ func (m *dumpPathMapper) mapPath(file string) string {
   if strings.HasPrefix(normalized, "bundled:///") {
     return m.claim(normalized, normalized)
   }
-  normalized = shimtspath.NormalizePath(normalized)
+  normalized = canonicalDumpPath(normalized)
   if m.project == "" || shimtspath.GetRootLength(m.project) == 0 {
     return normalized
   }
@@ -84,6 +85,26 @@ func (m *dumpPathMapper) mapPath(file string) string {
     return normalized
   }
   return m.claim(physical, wire)
+}
+
+// canonicalDumpPath resolves host filesystem aliases before applying the
+// compiler's portable path grammar. On macOS, for example, a temporary
+// directory can be observed as both /var/... and /private/var/...; treating
+// those spellings as different trees would make an in-project source appear
+// outside the graph's project root.
+//
+// Synthetic Windows and UNC paths used by portable tests do not resolve on a
+// non-Windows host. In that case (and for paths that do not exist yet), retain
+// the lexical path so the mapper can still enforce its root rules.
+func canonicalDumpPath(path string) string {
+  normalized := shimtspath.NormalizeSlashes(path)
+  if shimtspath.GetRootLength(normalized) == 0 {
+    return shimtspath.NormalizePath(normalized)
+  }
+  if resolved, err := filepath.EvalSymlinks(filepath.FromSlash(normalized)); err == nil {
+    normalized = filepath.ToSlash(resolved)
+  }
+  return shimtspath.NormalizePath(normalized)
 }
 
 // claim records both directions of the projection. The reverse map is the

--- a/packages/ttsc/internal/graph/dump_paths_are_portable_and_injective_test.go
+++ b/packages/ttsc/internal/graph/dump_paths_are_portable_and_injective_test.go
@@ -1,6 +1,8 @@
 package graph
 
 import (
+  "os"
+  "path/filepath"
   "strings"
   "testing"
 )
@@ -48,6 +50,30 @@ func TestDumpPathMapperUsesPortableCoordinates(t *testing.T) {
         t.Fatalf("mapPath(%q): %v", test.file, err)
       }
     })
+  }
+}
+
+func TestDumpPathMapperCanonicalizesSymlinkedProjectPaths(t *testing.T) {
+  project := t.TempDir()
+  source := filepath.Join(project, "src", "main.ts")
+  if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+    t.Fatal(err)
+  }
+  if err := os.WriteFile(source, []byte("export {};\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+
+  alias := filepath.Join(t.TempDir(), "project")
+  if err := os.Symlink(project, alias); err != nil {
+    t.Skipf("symlinks are unavailable: %v", err)
+  }
+
+  mapper := newDumpPathMapper(alias)
+  if got := mapper.mapPath(source); got != "src/main.ts" {
+    t.Fatalf("mapPath(%q) = %q, want project-relative path", source, got)
+  }
+  if err := mapper.err(); err != nil {
+    t.Fatalf("mapPath(%q): %v", source, err)
   }
 }
 

--- a/packages/ttsc/internal/graph/dump_paths_are_portable_and_injective_test.go
+++ b/packages/ttsc/internal/graph/dump_paths_are_portable_and_injective_test.go
@@ -1,8 +1,6 @@
 package graph
 
 import (
-  "os"
-  "path/filepath"
   "strings"
   "testing"
 )
@@ -50,30 +48,6 @@ func TestDumpPathMapperUsesPortableCoordinates(t *testing.T) {
         t.Fatalf("mapPath(%q): %v", test.file, err)
       }
     })
-  }
-}
-
-func TestDumpPathMapperCanonicalizesSymlinkedProjectPaths(t *testing.T) {
-  project := t.TempDir()
-  source := filepath.Join(project, "src", "main.ts")
-  if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
-    t.Fatal(err)
-  }
-  if err := os.WriteFile(source, []byte("export {};\n"), 0o644); err != nil {
-    t.Fatal(err)
-  }
-
-  alias := filepath.Join(t.TempDir(), "project")
-  if err := os.Symlink(project, alias); err != nil {
-    t.Skipf("symlinks are unavailable: %v", err)
-  }
-
-  mapper := newDumpPathMapper(alias)
-  if got := mapper.mapPath(source); got != "src/main.ts" {
-    t.Fatalf("mapPath(%q) = %q, want project-relative path", source, got)
-  }
-  if err := mapper.err(); err != nil {
-    t.Fatalf("mapPath(%q): %v", source, err)
   }
 }
 

--- a/packages/ttsc/internal/graph/dump_paths_canonicalize_windows_short_root_test.go
+++ b/packages/ttsc/internal/graph/dump_paths_canonicalize_windows_short_root_test.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package graph
+
+import (
+  "path/filepath"
+  "testing"
+)
+
+// TestDumpPathMapperCanonicalizesWindowsShortRoot verifies that a project
+// selected through an 8.3 path still owns checker sources reported through the
+// expanded physical spelling.
+//
+// Windows reaches the same alias class as the macOS `/var` symlink through a
+// different mechanism, so the canonical base has to be derived from the
+// filesystem on both platforms rather than from POSIX symlinks alone.
+//
+//  1. Obtain the environment's temp spelling and its physical spelling.
+//  2. Skip hosts where Windows exposes only one spelling.
+//  3. Require a physical child and a not-yet-created child to stay
+//     project-relative.
+func TestDumpPathMapperCanonicalizesWindowsShortRoot(t *testing.T) {
+  project := t.TempDir()
+  physical, err := filepath.EvalSymlinks(project)
+  if err != nil {
+    t.Fatal(err)
+  }
+  if filepath.Clean(project) == filepath.Clean(physical) {
+    t.Skip("temporary directory has no alternate Windows path spelling")
+  }
+
+  mapper := newDumpPathMapper(project)
+  source := filepath.Join(physical, "src", "main.ts")
+  if got := mapper.mapPath(source); got != "src/main.ts" {
+    t.Fatalf("mapPath(%q) = %q, want project-relative identity", source, got)
+  }
+  missing := filepath.Join(project, "future", "main.ts")
+  if got := mapper.mapPath(missing); got != "future/main.ts" {
+    t.Fatalf("mapPath(%q) = %q, want stable missing-root identity", missing, got)
+  }
+  if err := mapper.err(); err != nil {
+    t.Fatal(err)
+  }
+}

--- a/packages/ttsc/internal/graph/dump_serializes_the_full_graph_test.go
+++ b/packages/ttsc/internal/graph/dump_serializes_the_full_graph_test.go
@@ -55,8 +55,8 @@ export function main(): void {
   if err := json.Unmarshal(data, &dump); err != nil {
     t.Fatalf("dump is not valid JSON: %v\n%s", err, data)
   }
-  if dump.Project != root || dump.Tsconfig != "tsconfig.json" {
-    t.Fatalf("project/tsconfig not echoed: %q / %q", dump.Project, dump.Tsconfig)
+  if dump.Project != canonicalDumpPath(root) || dump.Tsconfig != "tsconfig.json" {
+    t.Fatalf("project/tsconfig coordinates are not canonical: %q / %q", dump.Project, dump.Tsconfig)
   }
   if len(dump.Nodes) != len(g.Nodes) {
     t.Fatalf("dumped %d nodes, graph has %d", len(dump.Nodes), len(g.Nodes))

--- a/packages/ttsc/internal/graph/dump_symlink_project_publishes_matching_base_test.go
+++ b/packages/ttsc/internal/graph/dump_symlink_project_publishes_matching_base_test.go
@@ -1,0 +1,88 @@
+package graph
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestDumpSymlinkProjectPublishesMatchingBase verifies relative wire paths and
+// the published project coordinate share one canonical filesystem base.
+//
+// This is the macOS `/var` vs `/private/var` failure in its general form. A raw
+// symlink project root combined with canonical compiler sources makes `../`
+// siblings, sources that do not exist yet and a symlinked relative tsconfig
+// resolve against a directory the consumer cannot reach, unless project
+// publication and path mapping agree on the same physical root.
+//
+//  1. Select a real project directory through a symlink and add sibling inputs.
+//  2. Map an existing sibling, a missing child and a relative config symlink.
+//  3. Require stable coordinates and a canonical published project base.
+func TestDumpSymlinkProjectPublishesMatchingBase(t *testing.T) {
+  root := t.TempDir()
+  realRoot := filepath.Join(root, "real")
+  project := filepath.Join(realRoot, "pkg")
+  configDir := filepath.Join(realRoot, "config")
+  if err := os.MkdirAll(project, 0o755); err != nil {
+    t.Fatal(err)
+  }
+  if err := os.MkdirAll(configDir, 0o755); err != nil {
+    t.Fatal(err)
+  }
+  shared := filepath.Join(realRoot, "shared.ts")
+  config := filepath.Join(configDir, "tsconfig.json")
+  if err := os.WriteFile(shared, []byte("export const shared = true;\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  if err := os.WriteFile(config, []byte("{}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  alias := filepath.Join(root, "project-link")
+  if err := os.Symlink(project, alias); err != nil {
+    t.Skipf("host cannot create directory symlink: %v", err)
+  }
+  if err := os.Symlink(config, filepath.Join(project, "tsconfig.json")); err != nil {
+    t.Skipf("host cannot create file symlink: %v", err)
+  }
+
+  mapper := newDumpPathMapper(alias)
+  if wire := mapper.mapPath(shared); wire != "../shared.ts" {
+    t.Fatalf("sibling wire path = %q, want ../shared.ts", wire)
+  }
+  if wire := mapper.mapPath(filepath.Join(alias, "src", "new.ts")); wire != "src/new.ts" {
+    t.Fatalf("missing-root wire path = %q, want src/new.ts", wire)
+  }
+  if wire := mapper.mapPath("tsconfig.json"); wire != "../config/tsconfig.json" {
+    t.Fatalf("relative config wire path = %q, want ../config/tsconfig.json", wire)
+  }
+  if err := mapper.err(); err != nil {
+    t.Fatal(err)
+  }
+
+  dump, err := NewDump(&Graph{Nodes: map[string]*Node{}}, alias, "tsconfig.json", nil, nil, DumpOrigin{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  physicalProject, err := filepath.EvalSymlinks(alias)
+  if err != nil {
+    t.Fatal(err)
+  }
+  if filepath.Clean(filepath.FromSlash(dump.Project)) != filepath.Clean(physicalProject) {
+    t.Fatalf("published project = %q, want %q", dump.Project, physicalProject)
+  }
+  resolvedSibling := filepath.Clean(filepath.Join(filepath.FromSlash(dump.Project), filepath.FromSlash("../shared.ts")))
+  resolvedSiblingInfo, err := os.Stat(resolvedSibling)
+  if err != nil {
+    t.Fatal(err)
+  }
+  sharedInfo, err := os.Stat(shared)
+  if err != nil {
+    t.Fatal(err)
+  }
+  if !os.SameFile(resolvedSiblingInfo, sharedInfo) {
+    t.Fatalf("published base resolves sibling to %q, want %q", resolvedSibling, shared)
+  }
+  if dump.Tsconfig != "../config/tsconfig.json" {
+    t.Fatalf("published tsconfig = %q, want ../config/tsconfig.json", dump.Tsconfig)
+  }
+}


### PR DESCRIPTION
Closes #1050

## Summary

- canonicalize existing absolute project and source paths before graph-coordinate mapping
- retain lexical fallback for missing paths and portable Windows or UNC fixtures
- cover a real project-root symlink regression

## Validation

- `node scripts/test-go-graph.cjs`
- `pnpm --filter @ttsc/test-graph start`