### PR TITLE
feat(graph): expose semantic inspect CLI

### DIFF
--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -35,6 +35,18 @@ Start the client from the project root. The server builds one resident graph and
 
 `@ttsc/graph` reads the graph from the program `ttsc` type-checked, so the project needs `ttsc` and `typescript` installed alongside it. `ttsc` runs on the native TypeScript 7 compiler from the `typescript` package; it does not run on the legacy TypeScript v6.x compiler. There is no separate index step and no static-parser fallback: the graph is a byproduct of the type-check the compiler already runs, or it is not built at all.
 
+## CLI
+
+The default `ttsc-graph` command is the MCP stdio server. For one-off shell work, `inspect` exposes the same compiler-resolved request union and writes the same `{ audit, next, result }` JSON envelope:
+
+```bash
+npx -y @ttsc/graph inspect overview --cwd .
+npx -y @ttsc/graph inspect trace Service.run --to helper --focus execution
+npx -y @ttsc/graph inspect tour "How does the request flow work?" --hint Service.run
+```
+
+Run `ttsc-graph inspect --help` for `entrypoints`, `lookup`, `details`, `trace`, `overview`, and `tour` arguments. Every invocation synchronizes one current disk snapshot; use MCP when a client can reuse a resident session for several requests. `ttsc-graph dump --help` and `ttsc-graph view --help` are also local help pages and do not launch native graph work.
+
 ## Benchmark
 
 Each repository is measured with one headless agent run per arm (`baseline` with no MCP, `@ttsc/graph`, `codegraph`, `codebase-memory`, `serena`) on two prompt families, across two agent CLIs (`codex` and Claude Code). The corpus pins eight real TypeScript repositories.

--- a/packages/graph/src/bin.ts
+++ b/packages/graph/src/bin.ts
@@ -3,16 +3,24 @@
 import { runGraph } from "./index";
 import { GraphArgumentError } from "./launcherArgs";
 
-try {
-  const code = runGraph(process.argv.slice(2));
-  if (typeof code === "number") {
-    process.exitCode = code;
-  }
-} catch (error) {
-  if (error instanceof GraphArgumentError) {
-    process.stderr.write(`@ttsc/graph: ${error.message}\n`);
-    process.exitCode = 2;
-  } else {
-    throw error;
+async function main(): Promise<void> {
+  try {
+    const code = await runGraph(process.argv.slice(2));
+    if (typeof code === "number") {
+      process.exitCode = code;
+    }
+  } catch (error) {
+    if (error instanceof GraphArgumentError) {
+      process.stderr.write(`@ttsc/graph: ${error.message}\n`);
+      process.exitCode = 2;
+      return;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      `${message.startsWith("@ttsc/graph:") ? message : `@ttsc/graph: ${message}`}\n`,
+    );
+    process.exitCode = 1;
   }
 }
+
+void main();

--- a/packages/graph/src/help.ts
+++ b/packages/graph/src/help.ts
@@ -24,13 +24,11 @@ export function printGraphHelp(): void {
 }
 
 /**
- * Print `ttsc-graph dump` help without starting the native binary.
+ * Print fallback `ttsc-graph dump` help when no native binary is available.
  *
- * `dump` forwards to `ttscgraph`, which owns the flag contract, so this page is
- * a summary and not the source of truth. Answering locally is still right —
- * help has to work when no platform package is installed — but the page names
- * the authority so a reader who needs the exact current set knows where it
- * lives rather than trusting a copy that can drift.
+ * When `ttscgraph` resolves, the launcher forwards its help verbatim. This
+ * compact page keeps help usable without a platform package and identifies the
+ * native binary as the authority for its complete flag contract.
  */
 export function printDumpHelp(): void {
   write([

--- a/packages/graph/src/help.ts
+++ b/packages/graph/src/help.ts
@@ -1,0 +1,85 @@
+/** Write a launcher help page to stdout. */
+function write(lines: readonly string[]): void {
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+/** Print the top-level `ttsc-graph` command help. */
+export function printGraphHelp(): void {
+  write([
+    "Usage: ttsc-graph [command] [options]",
+    "",
+    "Without a command, serve the inspect_typescript_graph MCP tool over stdio.",
+    "",
+    "Commands:",
+    "  dump       Write the native compiler graph as JSON.",
+    "  view       Open a local 3D graph viewer.",
+    "  inspect    Run one semantic graph request and write its JSON result.",
+    "",
+    "MCP options:",
+    "  --cwd <path>          Project root (default: current directory).",
+    "  --tsconfig <file>     tsconfig relative to --cwd (default: tsconfig.json).",
+    "",
+    "Run 'ttsc-graph <command> --help' for command-specific options.",
+  ]);
+}
+
+/** Print `ttsc-graph dump` help without starting the native binary. */
+export function printDumpHelp(): void {
+  write([
+    "Usage: ttsc-graph dump [options]",
+    "",
+    "Write the compiler graph as JSON to stdout.",
+    "",
+    "Options:",
+    "  --cwd <path>          Project root (default: current directory).",
+    "  --tsconfig <file>     tsconfig relative to --cwd (default: tsconfig.json).",
+    "  --pretty[=true|false] Pretty-print the graph JSON.",
+  ]);
+}
+
+/** Print `ttsc-graph view` help without starting the local web server. */
+export function printViewHelp(): void {
+  write([
+    "Usage: ttsc-graph view [options]",
+    "",
+    "Build the graph and serve a local 3D viewer until Ctrl+C.",
+    "",
+    "Options:",
+    "  --cwd <path>          Project root (default: current directory).",
+    "  --tsconfig, -p <file> tsconfig relative to --cwd (default: tsconfig.json).",
+    "  --port <number>       Local port, or 0 for an available port (default: 0).",
+    "  --no-open             Do not open the viewer in the default browser.",
+    "  --max-nodes <number>  Visible-node budget (default: 1200).",
+  ]);
+}
+
+/** Print the semantic CLI projection of the MCP request union. */
+export function printInspectHelp(): void {
+  write([
+    "Usage: ttsc-graph inspect <request> [arguments] [options]",
+    "",
+    "Run one compiler-resolved graph request and write { audit, next, result } JSON.",
+    "Each command reads the current disk snapshot; it does not start an MCP server.",
+    "",
+    "Requests:",
+    "  overview [--aspect all|layers|hotspots|publicApi]",
+    "  entrypoints <question> [--limit <1..8>] [--neighbors <0..2>]",
+    "  lookup <query> [--limit <1..6>] [--include-external]",
+    "  details <handle...> [--neighbors] [--neighbor-limit <1..3>]",
+    "      [--member-limit <number>] [--dependency-limit <1..4>] [--include-external]",
+    "  trace <from> [--to <target>] [--direction forward|reverse|impact]",
+    "      [--focus all|execution|types] [--max-depth <number>]",
+    "      [--max-nodes <number>] [--include-external]",
+    "  tour <question> [--hint <symbol>]... [--limit <1..5>] [--no-tests]",
+    "",
+    "Shared options:",
+    "  --cwd <path>          Project root (default: current directory).",
+    "  --tsconfig, -p <file> tsconfig relative to --cwd (default: tsconfig.json).",
+    "  --pretty              Pretty-print the result JSON.",
+    "",
+    "Examples:",
+    "  ttsc-graph inspect overview --cwd .",
+    "  ttsc-graph inspect trace Service.run --to helper --focus execution",
+    "  ttsc-graph inspect tour 'How does the request flow work?' --hint Service.run",
+  ]);
+}

--- a/packages/graph/src/help.ts
+++ b/packages/graph/src/help.ts
@@ -23,12 +23,23 @@ export function printGraphHelp(): void {
   ]);
 }
 
-/** Print `ttsc-graph dump` help without starting the native binary. */
+/**
+ * Print `ttsc-graph dump` help without starting the native binary.
+ *
+ * `dump` forwards to `ttscgraph`, which owns the flag contract, so this page is
+ * a summary and not the source of truth. Answering locally is still right —
+ * help has to work when no platform package is installed — but the page names
+ * the authority so a reader who needs the exact current set knows where it
+ * lives rather than trusting a copy that can drift.
+ */
 export function printDumpHelp(): void {
   write([
     "Usage: ttsc-graph dump [options]",
     "",
-    "Write the compiler graph as JSON to stdout.",
+    "Write the whole compiler graph as JSON to stdout: every node and edge,",
+    "none of the MCP response caps. The native `ttscgraph` binary owns these",
+    "flags; run `ttscgraph dump --help` through an installed ttsc for its",
+    "authoritative list.",
     "",
     "Options:",
     "  --cwd <path>          Project root (default: current directory).",

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,6 +1,9 @@
 import { spawnSync } from "node:child_process";
 
+import { printDumpHelp, printGraphHelp, printViewHelp } from "./help";
+import { runInspect } from "./inspect";
 import {
+  GraphArgumentError,
   PROJECT_OPTIONS,
   parseLauncherOptions,
   projectOptions,
@@ -59,28 +62,42 @@ const DUMP_OPTIONS = [
  * - `view`: JS-orchestrated 3D viewer (dump -> reduce -> serve -> open).
  * - `dump`: pass through to the native `ttscgraph dump`, which prints the whole
  *   graph as JSON for piping or the viewer.
+ * - `inspect`: run one semantic request and print the same result shape as MCP.
  * - Default: serve the MCP graph over stdio. The TypeScript server keeps a native
  *   incremental compiler session resident, checks the disk snapshot before each
  *   graph operation, and reuses the in-memory graph when unchanged; the agent's
  *   MCP client speaks JSON-RPC over this process's stdin/stdout.
  */
-export function runGraph(
+export async function runGraph(
   argv: readonly string[] = process.argv.slice(2),
-): number | void {
-  if (argv[0] === "view") return runView(argv.slice(1));
+): Promise<number | void> {
+  if (
+    argv[0] === "help" ||
+    ((argv[0] === undefined || argv[0].startsWith("-")) &&
+      (argv.includes("--help") || argv.includes("-h")))
+  ) {
+    printGraphHelp();
+    return 0;
+  }
+  if (argv[0] === "view") {
+    if (argv.slice(1).includes("--help") || argv.slice(1).includes("-h")) {
+      printViewHelp();
+      return 0;
+    }
+    return runView(argv.slice(1));
+  }
   if (argv[0] === "dump") return runDump(argv.slice(1));
+  if (argv[0] === "inspect") return runInspect(argv.slice(1));
+  if (argv[0] !== undefined && !argv[0].startsWith("-")) {
+    throw new GraphArgumentError(
+      `unknown command ${argv[0]}; run 'ttsc-graph --help' for usage`,
+    );
+  }
 
   const { cwd, tsconfig } = projectOptions(
     parseLauncherOptions(argv, PROJECT_OPTIONS),
   );
-  void startServer({ cwd, tsconfig, version: VERSION }).catch(
-    (error: unknown) => {
-      process.stderr.write(
-        `@ttsc/graph: ${error instanceof Error ? error.message : String(error)}\n`,
-      );
-      process.exit(1);
-    },
-  );
+  await startServer({ cwd, tsconfig, version: VERSION });
 }
 
 /**
@@ -88,6 +105,14 @@ export function runGraph(
  * on this process's stdout. Returns the child's exit code.
  */
 function runDump(argv: readonly string[]): number {
+  if (
+    argv.includes("--help") ||
+    argv.includes("-help") ||
+    argv.includes("-h")
+  ) {
+    printDumpHelp();
+    return 0;
+  }
   // Resolve the native binary from the target project the caller named with
   // `--cwd`, not from wherever the launcher process happened to start.
   const { cwd } = projectOptions(parseLauncherOptions(argv, DUMP_OPTIONS));

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -117,14 +117,20 @@ export async function runGraph(
  * on this process's stdout. Returns the child's exit code.
  */
 function runDump(argv: readonly string[]): number {
-  if (argv.includes("--help") || argv.includes("-h")) {
-    printDumpHelp();
-    return 0;
-  }
   // Resolve the native binary from the target project the caller named with
   // `--cwd`, not from wherever the launcher process happened to start.
   const { cwd } = projectOptions(parseLauncherOptions(argv, DUMP_OPTIONS));
   const binary = resolveGraphBinary(process.env, cwd);
+  if (argv.includes("--help") || argv.includes("-h")) {
+    // The native binary owns this command's full flag contract. Keep the
+    // launcher usable without a platform package by falling back to a compact
+    // local page only when no native binary can be resolved.
+    if (binary === null) {
+      printDumpHelp();
+      return 0;
+    }
+    return runNativeDump(binary, argv);
+  }
   if (binary === null) {
     process.stderr.write(
       "@ttsc/graph: could not resolve the ttscgraph binary. " +
@@ -133,6 +139,10 @@ function runDump(argv: readonly string[]): number {
     );
     return 1;
   }
+  return runNativeDump(binary, argv);
+}
+
+function runNativeDump(binary: string, argv: readonly string[]): number {
   ensureExecutable(binary);
   const result = spawnSync(binary, ["dump", ...argv], {
     stdio: "inherit",

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -97,7 +97,19 @@ export async function runGraph(
   const { cwd, tsconfig } = projectOptions(
     parseLauncherOptions(argv, PROJECT_OPTIONS),
   );
-  await startServer({ cwd, tsconfig, version: VERSION });
+  try {
+    await startServer({ cwd, tsconfig, version: VERSION });
+  } catch (error) {
+    // `startServer` refs stdin before it awaits the transport connect, so that
+    // listener keeps the event loop alive. Letting this reach the bin wrapper,
+    // which only sets `process.exitCode`, would leave a live process with no
+    // server attached — an MCP client sees a launcher that started and never
+    // answers. Exit rather than fall out of the call.
+    process.stderr.write(
+      `@ttsc/graph: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exit(1);
+  }
 }
 
 /**
@@ -105,11 +117,7 @@ export async function runGraph(
  * on this process's stdout. Returns the child's exit code.
  */
 function runDump(argv: readonly string[]): number {
-  if (
-    argv.includes("--help") ||
-    argv.includes("-help") ||
-    argv.includes("-h")
-  ) {
+  if (argv.includes("--help") || argv.includes("-h")) {
     printDumpHelp();
     return 0;
   }

--- a/packages/graph/src/inspect.ts
+++ b/packages/graph/src/inspect.ts
@@ -35,6 +35,76 @@ const SHARED_OPTIONS = [
   { key: "pretty", flags: ["--pretty"], kind: "flag" },
 ] as const satisfies readonly IInspectOption[];
 
+type InspectRequest = Exclude<
+  ITtscGraphApplication.IProps["request"]["type"],
+  "escape"
+>;
+
+/**
+ * Per-request CLI options, keyed by the producer request discriminator.
+ *
+ * The CLI projects the MCP request union by hand. Keeping this table keyed by
+ * that union means a new graph-reading request fails type-checking until both
+ * its option set and `parseInvocation` branch are intentionally defined.
+ */
+const INSPECT_OPTIONS = {
+  overview: [
+    { key: "aspect", flags: ["--aspect"], kind: "value" },
+  ],
+  entrypoints: [
+    { key: "limit", flags: ["--limit"], kind: "value" },
+    { key: "neighbors", flags: ["--neighbors"], kind: "value" },
+  ],
+  lookup: [
+    { key: "limit", flags: ["--limit"], kind: "value" },
+    {
+      key: "include_external",
+      flags: ["--include-external"],
+      kind: "flag",
+    },
+  ],
+  details: [
+    { key: "neighbors", flags: ["--neighbors"], kind: "flag" },
+    {
+      key: "neighbor_limit",
+      flags: ["--neighbor-limit"],
+      kind: "value",
+    },
+    {
+      key: "member_limit",
+      flags: ["--member-limit"],
+      kind: "value",
+    },
+    {
+      key: "dependency_limit",
+      flags: ["--dependency-limit"],
+      kind: "value",
+    },
+    {
+      key: "include_external",
+      flags: ["--include-external"],
+      kind: "flag",
+    },
+  ],
+  trace: [
+    { key: "to", flags: ["--to"], kind: "value" },
+    { key: "direction", flags: ["--direction"], kind: "value" },
+    { key: "focus", flags: ["--focus"], kind: "value" },
+    { key: "max_depth", flags: ["--max-depth"], kind: "value" },
+    { key: "max_nodes", flags: ["--max-nodes"], kind: "value" },
+    {
+      key: "include_external",
+      flags: ["--include-external"],
+      kind: "flag",
+    },
+  ],
+  tour: [
+    { key: "hint", flags: ["--hint"], kind: "value", multiple: true },
+    { key: "limit", flags: ["--limit"], kind: "value" },
+    { key: "no_tests", flags: ["--no-tests"], kind: "flag" },
+  ],
+} as const satisfies Record<InspectRequest, readonly IInspectOption[]>;
+
 /**
  * Run one semantic graph request outside MCP.
  *
@@ -210,109 +280,12 @@ function parseInvocation(argv: readonly string[]): IInspectInvocation {
   }
 }
 
-/**
- * Every graph-reading request this CLI projects.
- *
- * `escape` is the one union member with no shell equivalent: it performs no
- * graph work and only tells an MCP client the answer is outside the graph.
- *
- * The `satisfies` is the contract, not decoration. The CLI hand-mirrors the
- * request union, and both switches below fall through silently — an added
- * member would keep compiling and keep passing, since the tests can only
- * enumerate the requests that exist when they are written. Keying this record
- * by the union's own discriminator makes `tsc` fail until the new member is
- * named here, so drift becomes a type error instead of a silent gap.
- */
-const INSPECT_REQUESTS = {
-  overview: true,
-  entrypoints: true,
-  lookup: true,
-  details: true,
-  trace: true,
-  tour: true,
-} as const satisfies Record<
-  Exclude<ITtscGraphApplication.IProps["request"]["type"], "escape">,
-  true
->;
-
-type InspectRequest = keyof typeof INSPECT_REQUESTS;
-
 function isInspectRequest(command: string): command is InspectRequest {
-  return Object.prototype.hasOwnProperty.call(INSPECT_REQUESTS, command);
+  return Object.prototype.hasOwnProperty.call(INSPECT_OPTIONS, command);
 }
 
-function optionsFor(command: string): readonly IInspectOption[] {
-  switch (command) {
-    case "overview":
-      return [
-        ...SHARED_OPTIONS,
-        { key: "aspect", flags: ["--aspect"], kind: "value" },
-      ];
-    case "entrypoints":
-      return [
-        ...SHARED_OPTIONS,
-        { key: "limit", flags: ["--limit"], kind: "value" },
-        { key: "neighbors", flags: ["--neighbors"], kind: "value" },
-      ];
-    case "lookup":
-      return [
-        ...SHARED_OPTIONS,
-        { key: "limit", flags: ["--limit"], kind: "value" },
-        {
-          key: "include_external",
-          flags: ["--include-external"],
-          kind: "flag",
-        },
-      ];
-    case "details":
-      return [
-        ...SHARED_OPTIONS,
-        { key: "neighbors", flags: ["--neighbors"], kind: "flag" },
-        {
-          key: "neighbor_limit",
-          flags: ["--neighbor-limit"],
-          kind: "value",
-        },
-        {
-          key: "member_limit",
-          flags: ["--member-limit"],
-          kind: "value",
-        },
-        {
-          key: "dependency_limit",
-          flags: ["--dependency-limit"],
-          kind: "value",
-        },
-        {
-          key: "include_external",
-          flags: ["--include-external"],
-          kind: "flag",
-        },
-      ];
-    case "trace":
-      return [
-        ...SHARED_OPTIONS,
-        { key: "to", flags: ["--to"], kind: "value" },
-        { key: "direction", flags: ["--direction"], kind: "value" },
-        { key: "focus", flags: ["--focus"], kind: "value" },
-        { key: "max_depth", flags: ["--max-depth"], kind: "value" },
-        { key: "max_nodes", flags: ["--max-nodes"], kind: "value" },
-        {
-          key: "include_external",
-          flags: ["--include-external"],
-          kind: "flag",
-        },
-      ];
-    case "tour":
-      return [
-        ...SHARED_OPTIONS,
-        { key: "hint", flags: ["--hint"], kind: "value", multiple: true },
-        { key: "limit", flags: ["--limit"], kind: "value" },
-        { key: "no_tests", flags: ["--no-tests"], kind: "flag" },
-      ];
-    default:
-      return SHARED_OPTIONS;
-  }
+function optionsFor(command: InspectRequest): readonly IInspectOption[] {
+  return [...SHARED_OPTIONS, ...INSPECT_OPTIONS[command]];
 }
 
 function parseInspectArgs(

--- a/packages/graph/src/inspect.ts
+++ b/packages/graph/src/inspect.ts
@@ -69,6 +69,11 @@ function parseInvocation(argv: readonly string[]): IInspectInvocation {
       "inspect requires a request; run 'ttsc-graph inspect --help' for usage",
     );
   }
+  if (!isInspectRequest(command)) {
+    throw new GraphArgumentError(
+      `unknown inspect request ${command}; run 'ttsc-graph inspect --help' for usage`,
+    );
+  }
   const parsed = parseInspectArgs(argv.slice(1), optionsFor(command));
   const project = projectOptions(parsed.values);
   const pretty = parsed.values.get("pretty") === true;
@@ -193,11 +198,47 @@ function parseInvocation(argv: readonly string[]): IInspectInvocation {
           : {}),
       });
     }
-    default:
+    default: {
+      // `command` is narrowed to the projected union above, so this branch is
+      // unreachable and the assignment is the second half of the drift guard:
+      // a new member that reaches here fails to compile.
+      const unhandled: never = command;
       throw new GraphArgumentError(
-        `unknown inspect request ${command}; run 'ttsc-graph inspect --help' for usage`,
+        `unknown inspect request ${String(unhandled)}; run 'ttsc-graph inspect --help' for usage`,
       );
+    }
   }
+}
+
+/**
+ * Every graph-reading request this CLI projects.
+ *
+ * `escape` is the one union member with no shell equivalent: it performs no
+ * graph work and only tells an MCP client the answer is outside the graph.
+ *
+ * The `satisfies` is the contract, not decoration. The CLI hand-mirrors the
+ * request union, and both switches below fall through silently — an added
+ * member would keep compiling and keep passing, since the tests can only
+ * enumerate the requests that exist when they are written. Keying this record
+ * by the union's own discriminator makes `tsc` fail until the new member is
+ * named here, so drift becomes a type error instead of a silent gap.
+ */
+const INSPECT_REQUESTS = {
+  overview: true,
+  entrypoints: true,
+  lookup: true,
+  details: true,
+  trace: true,
+  tour: true,
+} as const satisfies Record<
+  Exclude<ITtscGraphApplication.IProps["request"]["type"], "escape">,
+  true
+>;
+
+type InspectRequest = keyof typeof INSPECT_REQUESTS;
+
+function isInspectRequest(command: string): command is InspectRequest {
+  return Object.prototype.hasOwnProperty.call(INSPECT_REQUESTS, command);
 }
 
 function optionsFor(command: string): readonly IInspectOption[] {

--- a/packages/graph/src/inspect.ts
+++ b/packages/graph/src/inspect.ts
@@ -1,0 +1,420 @@
+import { TtscGraphApplication } from "./TtscGraphApplication";
+import { printInspectHelp } from "./help";
+import {
+  GraphArgumentError,
+  type ILauncherOption,
+  type IProjectOptions,
+  nonNegativeIntegerOption,
+  positiveIntegerOption,
+  projectOptions,
+} from "./launcherArgs";
+import { TtscGraphSession } from "./model/TtscGraphSession";
+import { ITtscGraphApplication } from "./structures/ITtscGraphApplication";
+
+type ParsedValue = string | boolean;
+
+interface IInspectOption extends ILauncherOption {
+  multiple?: boolean;
+}
+
+interface IParsedInspectArgs {
+  values: ReadonlyMap<string, ParsedValue>;
+  multiples: ReadonlyMap<string, readonly string[]>;
+  positionals: readonly string[];
+}
+
+interface IInspectInvocation {
+  project: IProjectOptions;
+  pretty: boolean;
+  props: ITtscGraphApplication.IProps;
+}
+
+const SHARED_OPTIONS = [
+  { key: "cwd", flags: ["--cwd"], kind: "value" },
+  { key: "tsconfig", flags: ["--tsconfig", "-p"], kind: "value" },
+  { key: "pretty", flags: ["--pretty"], kind: "flag" },
+] as const satisfies readonly IInspectOption[];
+
+/**
+ * Run one semantic graph request outside MCP.
+ *
+ * This is deliberately a one-shot session: a shell invocation cannot reuse the
+ * resident compiler process that an MCP client keeps open, but it does answer
+ * from the same current compiler snapshot and application contract.
+ */
+export async function runInspect(argv: readonly string[]): Promise<number> {
+  if (argv[0] === "help" || argv.includes("--help") || argv.includes("-h")) {
+    printInspectHelp();
+    return 0;
+  }
+  const invocation = parseInvocation(argv);
+  const session = new TtscGraphSession(invocation.project);
+  try {
+    const output = await new TtscGraphApplication(() =>
+      session.graph(),
+    ).inspect_typescript_graph(invocation.props);
+    process.stdout.write(
+      `${JSON.stringify(output, undefined, invocation.pretty ? 2 : undefined)}\n`,
+    );
+    return 0;
+  } finally {
+    session.close();
+  }
+}
+
+function parseInvocation(argv: readonly string[]): IInspectInvocation {
+  const command = argv[0];
+  if (command === undefined) {
+    throw new GraphArgumentError(
+      "inspect requires a request; run 'ttsc-graph inspect --help' for usage",
+    );
+  }
+  const parsed = parseInspectArgs(argv.slice(1), optionsFor(command));
+  const project = projectOptions(parsed.values);
+  const pretty = parsed.values.get("pretty") === true;
+  const build = (
+    question: string,
+    request: ITtscGraphApplication.IProps["request"],
+  ): IInspectInvocation => ({
+    project,
+    pretty,
+    props: {
+      question,
+      draft: {
+        reason:
+          "The CLI request maps directly to the smallest graph operation.",
+        type: request.type,
+      },
+      review: "Confirmed: run the CLI-selected graph request.",
+      request,
+    },
+  });
+
+  switch (command) {
+    case "overview": {
+      expectPositionals(command, parsed.positionals, 0);
+      const aspect = choice(parsed.values, "aspect", [
+        "all",
+        "layers",
+        "hotspots",
+        "publicApi",
+      ] as const);
+      return build("Summarize the project's compiler-resolved architecture.", {
+        type: "overview",
+        ...(aspect === undefined ? {} : { aspect }),
+      });
+    }
+    case "entrypoints": {
+      const question = expectPositionals(command, parsed.positionals, 1)[0]!;
+      return build(question, {
+        type: "entrypoints",
+        query: question,
+        ...optionalPositive(parsed.values, "limit", 8),
+        ...optionalNonNegative(parsed.values, "neighbors", 2),
+      });
+    }
+    case "lookup": {
+      const query = expectPositionals(command, parsed.positionals, 1)[0]!;
+      return build(query, {
+        type: "lookup",
+        query,
+        ...optionalPositive(parsed.values, "limit", 6),
+        ...(parsed.values.get("include_external") === true
+          ? { includeExternal: true }
+          : {}),
+      });
+    }
+    case "details": {
+      const handles = expectAtLeastOnePositional(command, parsed.positionals);
+      return build(`Inspect ${handles.join(", ")}.`, {
+        type: "details",
+        handles: [...handles],
+        ...(parsed.values.get("neighbors") === true ? { neighbors: true } : {}),
+        ...optionalPositive(parsed.values, "neighbor_limit", 3),
+        ...optionalPositive(
+          parsed.values,
+          "member_limit",
+          Number.MAX_SAFE_INTEGER,
+        ),
+        ...optionalPositive(parsed.values, "dependency_limit", 4),
+        ...(parsed.values.get("include_external") === true
+          ? { includeExternal: true }
+          : {}),
+      });
+    }
+    case "trace": {
+      const from = expectPositionals(command, parsed.positionals, 1)[0]!;
+      const to = stringOption(parsed.values, "to");
+      const direction = choice(parsed.values, "direction", [
+        "forward",
+        "reverse",
+        "impact",
+      ] as const);
+      const focus = choice(parsed.values, "focus", [
+        "all",
+        "execution",
+        "types",
+      ] as const);
+      const maxDepth = optionalPositive(
+        parsed.values,
+        "max_depth",
+        to === undefined && direction === "impact"
+          ? 4
+          : to === undefined
+            ? 8
+            : 12,
+      );
+      const maxNodes = optionalPositive(
+        parsed.values,
+        "max_nodes",
+        direction === "impact" ? 16 : 32,
+      );
+      return build(`Trace ${from}${to === undefined ? "" : ` to ${to}`}.`, {
+        type: "trace",
+        from,
+        ...(to === undefined ? {} : { to }),
+        ...(direction === undefined ? {} : { direction }),
+        ...(focus === undefined ? {} : { focus }),
+        ...maxDepth,
+        ...maxNodes,
+        ...(parsed.values.get("include_external") === true
+          ? { includeExternal: true }
+          : {}),
+      });
+    }
+    case "tour": {
+      const question = expectPositionals(command, parsed.positionals, 1)[0]!;
+      return build(question, {
+        type: "tour",
+        reinterpretations: [...(parsed.multiples.get("hint") ?? [])],
+        ...optionalPositive(parsed.values, "limit", 5),
+        ...(parsed.values.get("no_tests") === true
+          ? { includeTests: false }
+          : {}),
+      });
+    }
+    default:
+      throw new GraphArgumentError(
+        `unknown inspect request ${command}; run 'ttsc-graph inspect --help' for usage`,
+      );
+  }
+}
+
+function optionsFor(command: string): readonly IInspectOption[] {
+  switch (command) {
+    case "overview":
+      return [
+        ...SHARED_OPTIONS,
+        { key: "aspect", flags: ["--aspect"], kind: "value" },
+      ];
+    case "entrypoints":
+      return [
+        ...SHARED_OPTIONS,
+        { key: "limit", flags: ["--limit"], kind: "value" },
+        { key: "neighbors", flags: ["--neighbors"], kind: "value" },
+      ];
+    case "lookup":
+      return [
+        ...SHARED_OPTIONS,
+        { key: "limit", flags: ["--limit"], kind: "value" },
+        {
+          key: "include_external",
+          flags: ["--include-external"],
+          kind: "flag",
+        },
+      ];
+    case "details":
+      return [
+        ...SHARED_OPTIONS,
+        { key: "neighbors", flags: ["--neighbors"], kind: "flag" },
+        {
+          key: "neighbor_limit",
+          flags: ["--neighbor-limit"],
+          kind: "value",
+        },
+        {
+          key: "member_limit",
+          flags: ["--member-limit"],
+          kind: "value",
+        },
+        {
+          key: "dependency_limit",
+          flags: ["--dependency-limit"],
+          kind: "value",
+        },
+        {
+          key: "include_external",
+          flags: ["--include-external"],
+          kind: "flag",
+        },
+      ];
+    case "trace":
+      return [
+        ...SHARED_OPTIONS,
+        { key: "to", flags: ["--to"], kind: "value" },
+        { key: "direction", flags: ["--direction"], kind: "value" },
+        { key: "focus", flags: ["--focus"], kind: "value" },
+        { key: "max_depth", flags: ["--max-depth"], kind: "value" },
+        { key: "max_nodes", flags: ["--max-nodes"], kind: "value" },
+        {
+          key: "include_external",
+          flags: ["--include-external"],
+          kind: "flag",
+        },
+      ];
+    case "tour":
+      return [
+        ...SHARED_OPTIONS,
+        { key: "hint", flags: ["--hint"], kind: "value", multiple: true },
+        { key: "limit", flags: ["--limit"], kind: "value" },
+        { key: "no_tests", flags: ["--no-tests"], kind: "flag" },
+      ];
+    default:
+      return SHARED_OPTIONS;
+  }
+}
+
+function parseInspectArgs(
+  argv: readonly string[],
+  definitions: readonly IInspectOption[],
+): IParsedInspectArgs {
+  const flags = new Map<string, IInspectOption>();
+  for (const definition of definitions) {
+    for (const flag of definition.flags) flags.set(flag, definition);
+  }
+
+  const values = new Map<string, ParsedValue>();
+  const multiples = new Map<string, string[]>();
+  const positionals: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--") {
+      positionals.push(...argv.slice(i + 1));
+      break;
+    }
+    const parsed = matchOption(arg, flags);
+    if (parsed === undefined) {
+      if (arg.startsWith("-"))
+        throw new GraphArgumentError(`unknown option ${arg}`);
+      positionals.push(arg);
+      continue;
+    }
+    const { definition, flag, inline } = parsed;
+    if (definition.kind !== "value") {
+      if (inline !== undefined)
+        throw new GraphArgumentError(`${flag} does not take a value`);
+      values.set(definition.key, true);
+      continue;
+    }
+    const value = inline ?? argv[++i];
+    if (value === undefined || value.startsWith("-")) {
+      throw new GraphArgumentError(`${flag} requires a non-empty value`);
+    }
+    if (value.trim() === "") {
+      throw new GraphArgumentError(`${flag} requires a non-empty value`);
+    }
+    if (definition.multiple === true) {
+      const list = multiples.get(definition.key) ?? [];
+      list.push(value);
+      multiples.set(definition.key, list);
+    } else {
+      values.set(definition.key, value);
+    }
+  }
+  return { values, multiples, positionals };
+}
+
+function matchOption(
+  arg: string,
+  flags: ReadonlyMap<string, IInspectOption>,
+): { definition: IInspectOption; flag: string; inline?: string } | undefined {
+  const exact = flags.get(arg);
+  if (exact !== undefined) return { definition: exact, flag: arg };
+  for (const [flag, definition] of flags) {
+    const prefix = `${flag}=`;
+    if (arg.startsWith(prefix)) {
+      return { definition, flag, inline: arg.slice(prefix.length) };
+    }
+  }
+  return undefined;
+}
+
+function expectPositionals(
+  command: string,
+  positionals: readonly string[],
+  count: number,
+): readonly string[] {
+  if (positionals.length !== count) {
+    throw new GraphArgumentError(
+      `inspect ${command} requires ${String(count)} positional argument${count === 1 ? "" : "s"}`,
+    );
+  }
+  if (positionals.some((value) => value.trim() === "")) {
+    throw new GraphArgumentError(
+      `inspect ${command} requires non-empty arguments`,
+    );
+  }
+  return positionals;
+}
+
+function expectAtLeastOnePositional(
+  command: string,
+  positionals: readonly string[],
+): readonly string[] {
+  if (
+    positionals.length === 0 ||
+    positionals.some((value) => value.trim() === "")
+  ) {
+    throw new GraphArgumentError(
+      `inspect ${command} requires at least one handle`,
+    );
+  }
+  return positionals;
+}
+
+function optionalPositive(
+  values: ReadonlyMap<string, ParsedValue>,
+  key: string,
+  maximum: number,
+): Record<string, number> {
+  return values.has(key)
+    ? { [camelCase(key)]: positiveIntegerOption(values, key, maximum) }
+    : {};
+}
+
+function optionalNonNegative(
+  values: ReadonlyMap<string, ParsedValue>,
+  key: string,
+  maximum: number,
+): Record<string, number> {
+  return values.has(key)
+    ? { [camelCase(key)]: nonNegativeIntegerOption(values, key, maximum) }
+    : {};
+}
+
+function choice<T extends string>(
+  values: ReadonlyMap<string, ParsedValue>,
+  key: string,
+  options: readonly T[],
+): T | undefined {
+  const value = stringOption(values, key);
+  if (value === undefined) return undefined;
+  if ((options as readonly string[]).includes(value)) return value as T;
+  throw new GraphArgumentError(
+    `--${key.replaceAll("_", "-")} must be one of ${options.join(", ")}`,
+  );
+}
+
+function stringOption(
+  values: ReadonlyMap<string, ParsedValue>,
+  key: string,
+): string | undefined {
+  const value = values.get(key);
+  return typeof value === "string" ? value : undefined;
+}
+
+function camelCase(key: string): string {
+  return key.replace(/_([a-z])/g, (_match, letter: string) =>
+    letter.toUpperCase(),
+  );
+}

--- a/tests/test-graph/src/features/test_ttscgraph_inspect_cli_exposes_semantic_requests.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_inspect_cli_exposes_semantic_requests.ts
@@ -97,6 +97,17 @@ export const test_ttscgraph_inspect_cli_exposes_semantic_requests = () => {
     `overview includes the requested public API facet: ${JSON.stringify(overview.result)}`,
   );
 
+  const inlineOverview = run([
+    "overview",
+    `--cwd=${root}`,
+    "--aspect=publicApi",
+  ]);
+  assertResult(inlineOverview, "overview");
+  assert.ok(
+    Array.isArray(inlineOverview.result.publicApi),
+    `inline option values reach overview: ${JSON.stringify(inlineOverview.result)}`,
+  );
+
   const entrypoints = run([
     "entrypoints",
     "How does Service.run reach helper?",
@@ -122,6 +133,24 @@ export const test_ttscgraph_inspect_cli_exposes_semantic_requests = () => {
     `lookup resolves a concrete symbol: ${JSON.stringify(lookup.result)}`,
   );
 
+  const escapedLookup = run([
+    "lookup",
+    "--cwd",
+    root,
+    "--",
+    "--literal-handle",
+  ]);
+  assertResult(escapedLookup, "lookup");
+
+  const externalLookup = run([
+    "lookup",
+    "Service",
+    "--cwd",
+    root,
+    "--include-external",
+  ]);
+  assertResult(externalLookup, "lookup");
+
   const details = run([
     "details",
     "Service.run",
@@ -137,6 +166,21 @@ export const test_ttscgraph_inspect_cli_exposes_semantic_requests = () => {
       (node) => node.name === "Service.run",
     ),
     `details resolves the requested handle: ${JSON.stringify(details.result)}`,
+  );
+
+  const multipleDetails = run([
+    "details",
+    "Service.run",
+    "helper",
+    "--cwd",
+    root,
+  ]);
+  assertResult(multipleDetails, "details");
+  const detailNames = (multipleDetails.result.nodes as Array<{ name?: string }>)
+    .map((node) => node.name);
+  assert.ok(
+    detailNames.includes("Service.run") && detailNames.includes("helper"),
+    `details preserves every supplied handle: ${JSON.stringify(multipleDetails.result)}`,
   );
 
   const trace = run([

--- a/tests/test-graph/src/features/test_ttscgraph_inspect_cli_exposes_semantic_requests.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_inspect_cli_exposes_semantic_requests.ts
@@ -1,0 +1,178 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  resolveGraphLauncher,
+  resolveTtscgraphBinary,
+} from "../internal/ttsgraph";
+
+interface InspectOutput {
+  audit: string;
+  next: { action: string };
+  result: { type: string; [key: string]: unknown };
+}
+
+/**
+ * Verifies the command-line projection calls the same semantic graph branches
+ * the MCP server exposes, rather than making callers reconstruct a request
+ * envelope or consume the native protocol directly.
+ *
+ * 1. Materialize a small call chain and run every graph-reading request through
+ *    `ttsc-graph inspect`.
+ * 2. Assert the compiler-resolved output keeps the MCP envelope and each branch
+ *    returns facts for the supplied project.
+ * 3. Leave `escape` MCP-only: it deliberately performs no graph work and has no
+ *    shell inspection equivalent.
+ */
+export const test_ttscgraph_inspect_cli_exposes_semantic_requests = () => {
+  const root = TestProject.createProject({
+    "tsconfig.json": JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          rootDir: "src",
+          outDir: "dist",
+        },
+        include: ["src"],
+      },
+      null,
+      2,
+    ),
+    "src/app.ts": [
+      "export function helper(): void {}",
+      "",
+      "export class Service {",
+      "  run(): void {",
+      "    helper();",
+      "  }",
+      "}",
+      "",
+      "export function start(): void {",
+      "  new Service().run();",
+      "}",
+      "",
+    ].join("\n"),
+    "src/app.test.ts": [
+      "import { Service } from './app';",
+      "",
+      "export function coversRun(): void {",
+      "  new Service().run();",
+      "}",
+      "",
+    ].join("\n"),
+  });
+  const run = (args: readonly string[]): InspectOutput => {
+    const result = TestProject.spawn(
+      process.execPath,
+      [resolveGraphLauncher(), "inspect", ...args],
+      {
+        cwd: root,
+        env: { ...process.env, TTSC_GRAPH_BINARY: resolveTtscgraphBinary() },
+        timeout: 120_000,
+      },
+    );
+    assert.equal(
+      result.status,
+      0,
+      `ttsc-graph inspect ${args.join(" ")} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    return JSON.parse(result.stdout) as InspectOutput;
+  };
+  const assertResult = (output: InspectOutput, type: string): void => {
+    assert.equal(output.result.type, type, `result: ${JSON.stringify(output)}`);
+    assert.equal(typeof output.audit, "string", "the MCP audit is preserved");
+    assert.equal(
+      typeof output.next.action,
+      "string",
+      "the MCP next is preserved",
+    );
+  };
+
+  const overview = run(["overview", "--cwd", root, "--aspect", "publicApi"]);
+  assertResult(overview, "overview");
+  assert.ok(
+    Array.isArray(overview.result.publicApi),
+    `overview includes the requested public API facet: ${JSON.stringify(overview.result)}`,
+  );
+
+  const entrypoints = run([
+    "entrypoints",
+    "How does Service.run reach helper?",
+    "--cwd",
+    root,
+    "--neighbors",
+    "1",
+  ]);
+  assertResult(entrypoints, "entrypoints");
+  assert.ok(
+    (entrypoints.result.hits as Array<{ name?: string }>).some(
+      (hit) => hit.name === "Service.run",
+    ),
+    `entrypoints resolves the question's handle: ${JSON.stringify(entrypoints.result)}`,
+  );
+
+  const lookup = run(["lookup", "Service", "--cwd", root, "--limit", "1"]);
+  assertResult(lookup, "lookup");
+  assert.ok(
+    (lookup.result.hits as Array<{ name?: string }>).some(
+      (hit) => hit.name === "Service",
+    ),
+    `lookup resolves a concrete symbol: ${JSON.stringify(lookup.result)}`,
+  );
+
+  const details = run([
+    "details",
+    "Service.run",
+    "--cwd",
+    root,
+    "--neighbors",
+    "--neighbor-limit",
+    "1",
+  ]);
+  assertResult(details, "details");
+  assert.ok(
+    (details.result.nodes as Array<{ name?: string }>).some(
+      (node) => node.name === "Service.run",
+    ),
+    `details resolves the requested handle: ${JSON.stringify(details.result)}`,
+  );
+
+  const trace = run([
+    "trace",
+    "Service.run",
+    "--to",
+    "helper",
+    "--cwd",
+    root,
+    "--focus",
+    "execution",
+  ]);
+  assertResult(trace, "trace");
+  assert.ok(
+    (trace.result.path as Array<{ name?: string }>).some(
+      (node) => node.name === "helper",
+    ),
+    `trace follows the requested path: ${JSON.stringify(trace.result)}`,
+  );
+
+  const tour = run([
+    "tour",
+    "How does Service.run reach helper?",
+    "--cwd",
+    root,
+    "--hint",
+    "Service.run",
+    "--hint",
+    "helper",
+    "--no-tests",
+  ]);
+  assertResult(tour, "tour");
+  assert.ok(
+    (tour.result.entrypoints as Array<{ name?: string }>).some(
+      (node) => node.name === "Service.run",
+    ),
+    `tour uses repeated symbol hints: ${JSON.stringify(tour.result)}`,
+  );
+};

--- a/tests/test-graph/src/features/test_ttscgraph_launcher_rejects_malformed_arguments.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_launcher_rejects_malformed_arguments.ts
@@ -13,7 +13,8 @@ import { assert, resolveGraphLauncher } from "../internal/ttsgraph";
  * Every invalid invocation below points at a sentinel binary, so a usage error
  * must return before native resolution or graph construction can reach it.
  *
- * 1. Run malformed viewer, MCP, and dump argument vectors through the built CLI.
+ * 1. Run malformed viewer, MCP, dump, and inspect argument vectors through the
+ *    built CLI.
  * 2. Assert each exits with a usage error and leaves the sentinel untouched.
  * 3. On executable hosts, run valid dump forms and preserve the native exit code
  *    and forwarded arguments.
@@ -71,6 +72,11 @@ export const test_ttscgraph_launcher_rejects_malformed_arguments = () => {
     ["dump", "--cwd"],
     ["dump", "--tsconfig"],
     ["dump", "--tsconfig="],
+    ["inspect"],
+    ["inspect", "lookup"],
+    ["inspect", "lookup", "Service", "--limit", "0"],
+    ["inspect", "trace", "Service", "--direction", "sideways"],
+    ["inspect", "tour", "question", "--hint"],
   ];
   for (const args of malformed) {
     fs.rmSync(marker, { force: true });
@@ -96,7 +102,6 @@ export const test_ttscgraph_launcher_rejects_malformed_arguments = () => {
     for (const args of [
       ["dump", "--cwd", root, "--tsconfig", "project.json", "--pretty"],
       ["dump", `--cwd=${root}`, "--tsconfig=project.json", "--pretty=false"],
-      ["dump", "--help"],
     ]) {
       fs.rmSync(marker, { force: true });
       const result = run(args);
@@ -111,5 +116,31 @@ export const test_ttscgraph_launcher_rejects_malformed_arguments = () => {
         `${args.join(" ")} preserves the native dump argv`,
       );
     }
+  }
+
+  for (const args of [
+    ["--help"],
+    ["help"],
+    ["dump", "--help"],
+    ["view", "--help"],
+    ["inspect", "--help"],
+  ]) {
+    fs.rmSync(marker, { force: true });
+    const result = run(args);
+    assert.equal(
+      result.status,
+      0,
+      `${args.join(" ")} exits successfully without graph work\nstderr: ${result.stderr}`,
+    );
+    assert.match(
+      result.stdout ?? "",
+      /^Usage: ttsc-graph/m,
+      `${args.join(" ")} writes command help`,
+    );
+    assert.equal(
+      fs.existsSync(marker),
+      false,
+      `${args.join(" ")} does not invoke the native graph binary`,
+    );
   }
 };

--- a/tests/test-graph/src/features/test_ttscgraph_launcher_rejects_malformed_arguments.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_launcher_rejects_malformed_arguments.ts
@@ -42,6 +42,15 @@ export const test_ttscgraph_launcher_rejects_malformed_arguments = () => {
       env: { TTSC_GRAPH_BINARY: binary, TTSCGRAPH_MARKER: marker },
       timeout: 30_000,
     });
+  const runWithoutNative = (args: string[]) => {
+    const env = { ...process.env, TTSCGRAPH_MARKER: marker };
+    delete env.TTSC_GRAPH_BINARY;
+    return TestProject.spawn(process.execPath, [resolveGraphLauncher(), ...args], {
+      cwd: root,
+      env,
+      timeout: 30_000,
+    });
+  };
 
   const malformed = [
     ["view", "--max-nodes", "oops"],
@@ -74,7 +83,12 @@ export const test_ttscgraph_launcher_rejects_malformed_arguments = () => {
     ["dump", "--tsconfig="],
     ["inspect"],
     ["inspect", "lookup"],
+    ["inspect", "lookup", "--literal-handle"],
     ["inspect", "lookup", "Service", "--limit", "0"],
+    ["inspect", "lookup", "Service", "--limit", "-1"],
+    ["inspect", "lookup", "Service", "--include-external=true"],
+    ["inspect", "details"],
+    ["inspect", "overview", "--aspect=not-a-facet"],
     ["inspect", "trace", "Service", "--direction", "sideways"],
     ["inspect", "tour", "question", "--hint"],
   ];
@@ -116,12 +130,24 @@ export const test_ttscgraph_launcher_rejects_malformed_arguments = () => {
         `${args.join(" ")} preserves the native dump argv`,
       );
     }
+
+    fs.rmSync(marker, { force: true });
+    const nativeHelp = run(["dump", "--help"]);
+    assert.equal(
+      nativeHelp.status,
+      23,
+      `dump --help preserves the native exit code\nstderr: ${nativeHelp.stderr}`,
+    );
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(marker, "utf8")),
+      ["dump", "--help"],
+      "dump --help forwards to the resolved native binary",
+    );
   }
 
   for (const args of [
     ["--help"],
     ["help"],
-    ["dump", "--help"],
     ["view", "--help"],
     ["inspect", "--help"],
   ]) {
@@ -143,4 +169,22 @@ export const test_ttscgraph_launcher_rejects_malformed_arguments = () => {
       `${args.join(" ")} does not invoke the native graph binary`,
     );
   }
+
+  fs.rmSync(marker, { force: true });
+  const fallbackHelp = runWithoutNative(["dump", "--help"]);
+  assert.equal(
+    fallbackHelp.status,
+    0,
+    `dump --help falls back without a native binary\nstderr: ${fallbackHelp.stderr}`,
+  );
+  assert.match(
+    fallbackHelp.stdout ?? "",
+    /^Usage: ttsc-graph dump/m,
+    "fallback dump help writes the local summary",
+  );
+  assert.equal(
+    fs.existsSync(marker),
+    false,
+    "fallback dump help does not invoke the unavailable native binary",
+  );
 };


### PR DESCRIPTION
## Summary
- add `ttsc-graph inspect` as a one-shot CLI projection of the graph MCP request union
- add local, exit-0 help for the root, dump, view, and inspect commands
- document the CLI and cover every graph-reading request branch end to end

## Verification
- `TTSC_BUILD_SCOPE=test-graph pnpm run build:current`
- `pnpm --filter @ttsc/test-graph exec tsc --noEmit --project tsconfig.json`
- `pnpm --filter @ttsc/graph build`
- `pnpm run check:format`
- direct inspect and launcher feature tests

## Known unrelated suite result
`pnpm --filter @ttsc/test-graph start` passes the new tests but fails two macOS `/var` ↔ `/private/var` external/workspace dump cases tracked in #1050. The focused path fix is already proposed in #1052.