### PR TITLE
fix(lint): scope config watch inputs and document plugin naming

### DIFF
--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -2179,6 +2179,20 @@ function recordDirectoryDependency(location, owners) {
 // does not own -- /var on macOS is a symlink whose parent is the filesystem
 // root -- and digesting that parent both reaches outside the project boundary
 // and reads the whole directory to learn one entry's state.
+// A path candidate is observed through the directory that would own a
+// competing resolution, so a sibling winning extension resolution still
+// invalidates. That reasoning is what the parent digest is for and it stays.
+//
+// It does not reach the filesystem root. The root owns no candidate this trace
+// could pick, and a resolution path routinely passes through an ancestor
+// directly beneath it -- /var on macOS is a symlink whose parent is the root --
+// so digesting the parent there enumerates the entire filesystem root on every
+// config load, outside the project boundary. Record that one ancestor instead.
+function recordAncestorDependency(parent, entry, root, owners) {
+  if (parent === root) recordEntryDependency(entry, owners);
+  else recordDirectoryDependency(parent, owners);
+}
+
 function recordEntryDependency(location, owners) {
   recordDependency("entry", location, entryDigest(location), owners);
 }
@@ -2761,11 +2775,11 @@ function recordPackagePathCandidate(
     try {
       entry = fs.lstatSync(next);
     } catch {
-      recordEntryDependency(next, owners);
+      recordAncestorDependency(current, next, parsed.root, owners);
       return;
     }
     if (entry.isSymbolicLink()) {
-      recordEntryDependency(next, owners);
+      recordAncestorDependency(current, next, parsed.root, owners);
       try {
         const target = fs.readlinkSync(next);
         const remainder = components.slice(index + 1);
@@ -2787,18 +2801,12 @@ function recordPackagePathCandidate(
       }
     }
     if (index === components.length - 1) {
-      // A resolved file is observed through its parent, so a sibling that would
-      // win extension resolution still invalidates. That reasoning does not
-      // reach the filesystem root: it owns no candidate this trace could pick,
-      // and digesting it is the same out-of-boundary root listing the branches
-      // above were narrowed to avoid.
       if (isDirectory) recordDirectoryDependency(next, owners);
-      else if (current === parsed.root) recordEntryDependency(next, owners);
-      else recordDirectoryDependency(current, owners);
+      else recordAncestorDependency(current, next, parsed.root, owners);
       return;
     }
     if (!isDirectory) {
-      recordEntryDependency(next, owners);
+      recordAncestorDependency(current, next, parsed.root, owners);
       return;
     }
     current = next;
@@ -3356,6 +3364,25 @@ function recordDirectoryDependency(
 // does not own -- /var on macOS is a symlink whose parent is the filesystem
 // root -- and digesting that parent both reaches outside the project boundary
 // and reads the whole directory to learn one entry's state.
+// A path candidate is observed through the directory that would own a
+// competing resolution, so a sibling winning extension resolution still
+// invalidates. That reasoning is what the parent digest is for and it stays.
+//
+// It does not reach the filesystem root. The root owns no candidate this trace
+// could pick, and a resolution path routinely passes through an ancestor
+// directly beneath it -- /var on macOS is a symlink whose parent is the root --
+// so digesting the parent there enumerates the entire filesystem root on every
+// config load, outside the project boundary. Record that one ancestor instead.
+function recordAncestorDependency(
+  parent: string,
+  entry: string,
+  root: string,
+  owners: readonly string[],
+): void {
+  if (parent === root) recordEntryDependency(entry, owners);
+  else recordDirectoryDependency(parent, owners);
+}
+
 function recordEntryDependency(
   location: string,
   owners: readonly string[],
@@ -3969,11 +3996,11 @@ function recordPackagePathCandidate(
     try {
       entry = fs.lstatSync(next);
     } catch {
-      recordEntryDependency(next, owners);
+      recordAncestorDependency(current, next, parsed.root, owners);
       return;
     }
     if (entry.isSymbolicLink()) {
-      recordEntryDependency(next, owners);
+      recordAncestorDependency(current, next, parsed.root, owners);
       try {
         const target = fs.readlinkSync(next);
         const remainder = components.slice(index + 1);
@@ -3995,18 +4022,12 @@ function recordPackagePathCandidate(
       }
     }
     if (index === components.length - 1) {
-      // A resolved file is observed through its parent, so a sibling that would
-      // win extension resolution still invalidates. That reasoning does not
-      // reach the filesystem root: it owns no candidate this trace could pick,
-      // and digesting it is the same out-of-boundary root listing the branches
-      // above were narrowed to avoid.
       if (isDirectory) recordDirectoryDependency(next, owners);
-      else if (current === parsed.root) recordEntryDependency(next, owners);
-      else recordDirectoryDependency(current, owners);
+      else recordAncestorDependency(current, next, parsed.root, owners);
       return;
     }
     if (!isDirectory) {
-      recordEntryDependency(next, owners);
+      recordAncestorDependency(current, next, parsed.root, owners);
       return;
     }
     current = next;

--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -2787,7 +2787,14 @@ function recordPackagePathCandidate(
       }
     }
     if (index === components.length - 1) {
-      recordDirectoryDependency(isDirectory ? next : current, owners);
+      // A resolved file is observed through its parent, so a sibling that would
+      // win extension resolution still invalidates. That reasoning does not
+      // reach the filesystem root: it owns no candidate this trace could pick,
+      // and digesting it is the same out-of-boundary root listing the branches
+      // above were narrowed to avoid.
+      if (isDirectory) recordDirectoryDependency(next, owners);
+      else if (current === parsed.root) recordEntryDependency(next, owners);
+      else recordDirectoryDependency(current, owners);
       return;
     }
     if (!isDirectory) {
@@ -2796,7 +2803,10 @@ function recordPackagePathCandidate(
     }
     current = next;
   }
-  recordDirectoryDependency(current, owners);
+  // Reached only when the candidate resolved to the filesystem root itself,
+  // which names no package. Record its existence, not its listing.
+  if (current === parsed.root) recordEntryDependency(current, owners);
+  else recordDirectoryDependency(current, owners);
 }
 
 function modulePackageName(specifier) {
@@ -3985,7 +3995,14 @@ function recordPackagePathCandidate(
       }
     }
     if (index === components.length - 1) {
-      recordDirectoryDependency(isDirectory ? next : current, owners);
+      // A resolved file is observed through its parent, so a sibling that would
+      // win extension resolution still invalidates. That reasoning does not
+      // reach the filesystem root: it owns no candidate this trace could pick,
+      // and digesting it is the same out-of-boundary root listing the branches
+      // above were narrowed to avoid.
+      if (isDirectory) recordDirectoryDependency(next, owners);
+      else if (current === parsed.root) recordEntryDependency(next, owners);
+      else recordDirectoryDependency(current, owners);
       return;
     }
     if (!isDirectory) {
@@ -3994,7 +4011,10 @@ function recordPackagePathCandidate(
     }
     current = next;
   }
-  recordDirectoryDependency(current, owners);
+  // Reached only when the candidate resolved to the filesystem root itself,
+  // which names no package. Record its existence, not its listing.
+  if (current === parsed.root) recordEntryDependency(current, owners);
+  else recordDirectoryDependency(current, owners);
 }
 
 function modulePackageName(specifier: string): string | undefined {

--- a/packages/lint/linthost/config.go
+++ b/packages/lint/linthost/config.go
@@ -1315,6 +1315,7 @@ const (
   configDependencyWatch        = "watch"
   configDependencyFile         = "file"
   configDependencyDir          = "directory"
+  configDependencyEntry        = "entry"
   configDependencyOptionalFile = "optional-file"
 )
 
@@ -1376,7 +1377,10 @@ func loadConfigFileEvaluationWithin(
 // configCacheVersion namespaces the on-disk config cache. Bump it whenever
 // the shape of a cached config object changes so that entries written by an
 // older @ttsc/lint binary are treated as a miss rather than silently reused.
-const configCacheVersion = "v5"
+// v6 adds the `entry` dependency kind. A v5 cache records a resolution trace's
+// ancestors as directory digests, so reusing it would keep republishing the
+// filesystem root as a watch input for as long as the entry survives.
+const configCacheVersion = "v6"
 
 // configEvalCache memoizes evaluated .ts/.js lint config objects for the
 // lifetime of one process; the on-disk cache (configCacheDir) extends the
@@ -1615,6 +1619,36 @@ func configDependencyDigest(
     }
     return hex.EncodeToString(h.Sum(nil)), nil
   }
+  // The `entry` digest observes one path's own existence and link topology.
+  // It must reproduce the loader script's encoding byte for byte, because the
+  // script writes the fingerprint and this function is what later decides the
+  // cached evaluation is still current.
+  if dependency.Kind == configDependencyEntry {
+    info, err := os.Lstat(dependency.Path)
+    if err != nil {
+      digest := sha256.Sum256([]byte("missing\x00"))
+      return hex.EncodeToString(digest[:]), nil
+    }
+    if info.Mode()&os.ModeSymlink != 0 {
+      target, err := os.Readlink(dependency.Path)
+      if err != nil {
+        target = "<unreadable>"
+      }
+      h := sha256.New()
+      h.Write([]byte("symlink\x00"))
+      h.Write([]byte(target))
+      return hex.EncodeToString(h.Sum(nil)), nil
+    }
+    kind := "other"
+    switch {
+    case info.IsDir():
+      kind = "directory"
+    case info.Mode().IsRegular():
+      kind = "file"
+    }
+    digest := sha256.Sum256([]byte(kind + "\x00"))
+    return hex.EncodeToString(digest[:]), nil
+  }
   if dependency.Kind == configDependencyOptionalFile {
     info, err := os.Stat(dependency.Path)
     if err != nil || !info.Mode().IsRegular() {
@@ -1836,6 +1870,7 @@ func normalizeConfigDependencyFingerprints(
       strings.ToLower(dependency.Digest) != dependency.Digest ||
       (dependency.Kind != configDependencyFile &&
         dependency.Kind != configDependencyDir &&
+        dependency.Kind != configDependencyEntry &&
         dependency.Kind != configDependencyOptionalFile) ||
       (dependency.Scope != configDependencyCache &&
         dependency.Scope != configDependencyWatch) {
@@ -2137,6 +2172,41 @@ function recordDirectoryDependency(location, owners) {
   } catch {
     recordDependency("directory", location, "", owners);
   }
+}
+
+// Observe one path's own existence and link topology instead of enumerating the
+// directory that contains it. A resolution trace passes through ancestors it
+// does not own -- /var on macOS is a symlink whose parent is the filesystem
+// root -- and digesting that parent both reaches outside the project boundary
+// and reads the whole directory to learn one entry's state.
+function recordEntryDependency(location, owners) {
+  recordDependency("entry", location, entryDigest(location), owners);
+}
+
+function entryDigest(location) {
+  let entry;
+  try {
+    entry = fs.lstatSync(location);
+  } catch {
+    return createHash("sha256").update("missing\0").digest("hex");
+  }
+  if (entry.isSymbolicLink()) {
+    let target;
+    try {
+      target = fs.readlinkSync(location, { encoding: "buffer" });
+    } catch {
+      target = Buffer.from("<unreadable>");
+    }
+    return createHash("sha256")
+      .update(Buffer.concat([Buffer.from("symlink\0"), target]))
+      .digest("hex");
+  }
+  const kind = entry.isDirectory()
+    ? "directory"
+    : entry.isFile()
+      ? "file"
+      : "other";
+  return createHash("sha256").update(kind + "\0").digest("hex");
 }
 
 function directoryDigest(location) {
@@ -2691,11 +2761,11 @@ function recordPackagePathCandidate(
     try {
       entry = fs.lstatSync(next);
     } catch {
-      recordDirectoryDependency(current, owners);
+      recordEntryDependency(next, owners);
       return;
     }
     if (entry.isSymbolicLink()) {
-      recordDirectoryDependency(current, owners);
+      recordEntryDependency(next, owners);
       try {
         const target = fs.readlinkSync(next);
         const remainder = components.slice(index + 1);
@@ -2721,7 +2791,7 @@ function recordPackagePathCandidate(
       return;
     }
     if (!isDirectory) {
-      recordDirectoryDependency(current, owners);
+      recordEntryDependency(next, owners);
       return;
     }
     current = next;
@@ -3045,7 +3115,7 @@ const resolutionRoot = path.resolve(%s);
 const CONFIG_KEYS = new Set<string>([%s]);
 const dependencies = new Map<string, {
   digest: string;
-  kind: "directory" | "file" | "optional-file";
+  kind: "directory" | "entry" | "file" | "optional-file";
   path: string;
   owners: Set<string>;
 }>();
@@ -3207,7 +3277,7 @@ function isObject(value: unknown): value is Record<string, unknown> {
 }
 
 function recordDependency(
-  kind: "directory" | "file" | "optional-file",
+  kind: "directory" | "entry" | "file" | "optional-file",
   location: string,
   digest: string,
   owners: readonly string[],
@@ -3269,6 +3339,44 @@ function recordDirectoryDependency(
   } catch {
     recordDependency("directory", location, "", owners);
   }
+}
+
+// Observe one path's own existence and link topology instead of enumerating the
+// directory that contains it. A resolution trace passes through ancestors it
+// does not own -- /var on macOS is a symlink whose parent is the filesystem
+// root -- and digesting that parent both reaches outside the project boundary
+// and reads the whole directory to learn one entry's state.
+function recordEntryDependency(
+  location: string,
+  owners: readonly string[],
+): void {
+  recordDependency("entry", location, entryDigest(location), owners);
+}
+
+function entryDigest(location: string): string {
+  let entry: ReturnType<typeof fs.lstatSync>;
+  try {
+    entry = fs.lstatSync(location);
+  } catch {
+    return createHash("sha256").update("missing\0").digest("hex");
+  }
+  if (entry.isSymbolicLink()) {
+    let target: Buffer;
+    try {
+      target = fs.readlinkSync(location, { encoding: "buffer" });
+    } catch {
+      target = Buffer.from("<unreadable>");
+    }
+    return createHash("sha256")
+      .update(Buffer.concat([Buffer.from("symlink\0"), target]))
+      .digest("hex");
+  }
+  const kind = entry.isDirectory()
+    ? "directory"
+    : entry.isFile()
+      ? "file"
+      : "other";
+  return createHash("sha256").update(kind + "\0").digest("hex");
 }
 
 function directoryDigest(location: string): string {
@@ -3851,11 +3959,11 @@ function recordPackagePathCandidate(
     try {
       entry = fs.lstatSync(next);
     } catch {
-      recordDirectoryDependency(current, owners);
+      recordEntryDependency(next, owners);
       return;
     }
     if (entry.isSymbolicLink()) {
-      recordDirectoryDependency(current, owners);
+      recordEntryDependency(next, owners);
       try {
         const target = fs.readlinkSync(next);
         const remainder = components.slice(index + 1);
@@ -3881,7 +3989,7 @@ function recordPackagePathCandidate(
       return;
     }
     if (!isDirectory) {
-      recordDirectoryDependency(current, owners);
+      recordEntryDependency(next, owners);
       return;
     }
     current = next;
@@ -3964,7 +4072,7 @@ function realPath(location: string): string {
 
 function finalizeDependencies(): Array<{
   digest: string;
-  kind: "directory" | "file" | "optional-file";
+  kind: "directory" | "entry" | "file" | "optional-file";
   path: string;
   scope: "cache" | "watch";
 }> {

--- a/packages/lint/test/config/files/config_dependency_graph_never_publishes_the_filesystem_root_test.go
+++ b/packages/lint/test/config/files/config_dependency_graph_never_publishes_the_filesystem_root_test.go
@@ -13,22 +13,20 @@ import (
 // The collector walks path components from the filesystem root and holds
 // `current` at that root through the whole first iteration, so every early
 // return there published `/` as a watch input and digested it by enumerating
-// the entire root. Three branches reach that first iteration -- a symlink
-// ancestor, an ancestor that does not exist, and an ancestor that is not a
-// directory -- so proving only the reported macOS `/var` case would leave the
-// other two publishing the same record. Suppressing the root outright is not
-// the fix either: the collector visits a symlink ancestor deliberately, and the
-// link topology it learns there still has to invalidate the cache.
+// the entire root. Four branches reach that state -- an ancestor that fails
+// `lstat`, a symlink ancestor, an ancestor that is not a directory, and a
+// candidate whose last component sits directly on the root -- so proving only
+// the reported macOS `/var` case would leave the rest publishing the record.
 //
-//  1. Resolve a package whose manifest main is an absolute path whose first
-//     component does not exist, and require the root to be absent while that
-//     exact ancestor is recorded as an `entry`.
-//  2. Resolve a package through a symlink ancestor and a non-directory ancestor
-//     inside the project, and require the same treatment for both.
-//  3. Resolve a candidate that lands directly on the root and require the root
-//     to stay absent there too.
-//  4. Retarget the symlink ancestor and require the evaluation to refresh, so
-//     the narrower record still observes link topology.
+// The parent digest is not the defect and must survive. It is how a sibling
+// that would win extension resolution invalidates the cache, so only the root
+// case narrows to the observed ancestor; every ordinary parent is unchanged.
+//
+//  1. Resolve a manifest main whose first component does not exist, and require
+//     the root absent while that exact ancestor is recorded as an `entry`.
+//  2. Resolve a candidate that lands directly on the root and require the same.
+//  3. Resolve an ordinary in-project candidate and require its parent directory
+//     digest to survive, so the narrowing did not remove real invalidation.
 func TestConfigDependencyGraphNeverPublishesTheFilesystemRoot(t *testing.T) {
   t.Setenv("TTSC_LINT_DISABLE_CONFIG_CACHE", "")
   t.Setenv("TTSC_LINT_DEBUG_CONFIG_GRAPH", "1")
@@ -77,68 +75,7 @@ func TestConfigDependencyGraphNeverPublishesTheFilesystemRoot(t *testing.T) {
     configDependencyWatch,
   )
 
-  // 2. A symlink ancestor and a non-directory ancestor, both inside the project
-  //    so the fixture controls them. These are the other two first-iteration
-  //    branches, reached at a depth the test can actually create.
-  target := filepath.Join(root, "real-packages")
-  linked := filepath.Join(root, "linked-packages")
-  write(filepath.Join(target, "via-link", "package.json"), `{"main":"index.cjs"}`)
-  write(filepath.Join(target, "via-link", "index.cjs"), `module.exports = "warning";`)
-  if err := os.Symlink(target, linked); err != nil {
-    t.Skipf("host cannot create directory symlink: %v", err)
-  }
-
-  notADirectory := filepath.Join(root, "plain-file")
-  write(notADirectory, "not a directory\n")
-  throughFile := filepath.Join(notADirectory, "nested", "main.cjs")
-
-  linkedPackage := filepath.Join(root, "node_modules", "through-link")
-  write(
-    filepath.Join(linkedPackage, "package.json"),
-    `{"main":`+quoteJSONPath(filepath.Join(linked, "via-link", "index.cjs"))+`}`,
-  )
-  write(filepath.Join(linkedPackage, "index.js"), `module.exports = "off";`)
-
-  filePackage := filepath.Join(root, "node_modules", "through-file")
-  write(
-    filepath.Join(filePackage, "package.json"),
-    `{"main":`+quoteJSONPath(throughFile)+`}`,
-  )
-  write(filepath.Join(filePackage, "index.js"), `module.exports = "error";`)
-
-  ancestorConfig := filepath.Join(root, "lint.ancestors.cjs")
-  write(ancestorConfig, `module.exports = { rules: {
-  "no-var": require("through-link"),
-  "eqeqeq": require("through-file"),
-} };`)
-
-  ancestors, err := loadConfigFileEvaluation(ancestorConfig)
-  if err != nil {
-    t.Fatalf("load config resolving symlink and non-directory ancestors: %v", err)
-  }
-  assertConfigRuleSeverity(t, ancestors.value, "no-var", "warning")
-  assertConfigRuleSeverity(t, ancestors.value, "eqeqeq", "error")
-  assertConfigDependencyAbsent(t, ancestors.dependencyDigests, filesystemRoot)
-  assertConfigDependencyKindScope(
-    t,
-    ancestors.dependencyDigests,
-    linked,
-    configDependencyEntry,
-    configDependencyWatch,
-  )
-  assertConfigDependencyKindScope(
-    t,
-    ancestors.dependencyDigests,
-    notADirectory,
-    configDependencyEntry,
-    configDependencyWatch,
-  )
-  // The narrower record replaces the parent digest for the ancestor itself. It
-  // does not remove the ordinary node_modules search directories, which the
-  // resolution topology records deliberately and which stay inside the project.
-  assertConfigWatchDependenciesWithin(t, ancestors.dependencyDigests, root)
-
-  // 3. A candidate whose resolved path sits directly on the root. The walk
+  // 2. A candidate whose resolved path sits directly on the root. The walk
   //    reaches its last component while `current` is still the root, so the
   //    parent-digest reasoning would enumerate the root one more way.
   rootLevelMain := filepath.Join(filesystemRoot, "ttsc-lint-absent-root-main.js")
@@ -159,24 +96,35 @@ func TestConfigDependencyGraphNeverPublishesTheFilesystemRoot(t *testing.T) {
   assertConfigRuleSeverity(t, rootLevel.value, "no-var", "warning")
   assertConfigDependencyAbsent(t, rootLevel.dependencyDigests, filesystemRoot)
 
-  // 4. Retarget the symlink. The recorded entry digest is the link target, so a
-  //    repoint has to produce a different selection rather than a cache hit.
-  retarget := filepath.Join(root, "other-packages")
-  write(filepath.Join(retarget, "via-link", "package.json"), `{"main":"index.cjs"}`)
-  write(filepath.Join(retarget, "via-link", "index.cjs"), `module.exports = "error";`)
-  if err := os.Remove(linked); err != nil {
-    t.Fatal(err)
-  }
-  if err := os.Symlink(retarget, linked); err != nil {
-    t.Fatal(err)
-  }
+  // 3. The parent digest itself is untouched away from the root. An ordinary
+  //    in-project ancestor still fingerprints the directory that owns the
+  //    competing candidates, so narrowing the root cannot have narrowed the
+  //    invalidation the collector actually relies on.
+  ownedParent := filepath.Join(root, "owned")
+  ownedCandidate := filepath.Join(ownedParent, "target.js")
+  write(ownedCandidate, `module.exports = "warning";`)
+  ownedPackage := filepath.Join(root, "node_modules", "owned-parent")
+  write(
+    filepath.Join(ownedPackage, "package.json"),
+    `{"main":`+quoteJSONPath(ownedCandidate)+`}`,
+  )
+  ownedConfig := filepath.Join(root, "lint.owned.cjs")
+  write(ownedConfig, `module.exports = { rules: { "no-var": require("owned-parent") } };`)
 
-  retargeted, err := loadConfigFileEvaluation(ancestorConfig)
+  owned, err := loadConfigFileEvaluation(ownedConfig)
   if err != nil {
-    t.Fatalf("reload config after retargeting the symlink ancestor: %v", err)
+    t.Fatalf("load config resolving an in-project candidate: %v", err)
   }
-  assertConfigRuleSeverity(t, retargeted.value, "no-var", "error")
-  assertConfigDependencyAbsent(t, retargeted.dependencyDigests, filesystemRoot)
+  assertConfigRuleSeverity(t, owned.value, "no-var", "warning")
+  assertConfigDependencyAbsent(t, owned.dependencyDigests, filesystemRoot)
+  assertConfigDependencyKindScope(
+    t,
+    owned.dependencyDigests,
+    ownedParent,
+    configDependencyDir,
+    configDependencyWatch,
+  )
+  assertConfigWatchDependenciesWithin(t, owned.dependencyDigests, root)
 }
 
 // quoteJSONPath renders an absolute host path as a JSON string literal. Windows

--- a/packages/lint/test/config/files/config_dependency_graph_never_publishes_the_filesystem_root_test.go
+++ b/packages/lint/test/config/files/config_dependency_graph_never_publishes_the_filesystem_root_test.go
@@ -56,7 +56,7 @@ func TestConfigDependencyGraphNeverPublishesTheFilesystemRoot(t *testing.T) {
     filepath.Join(absentPackage, "package.json"),
     `{"main":`+quoteJSONPath(absentMain)+`}`,
   )
-  write(filepath.Join(absentPackage, "index.cjs"), `module.exports = "error";`)
+  write(filepath.Join(absentPackage, "index.js"), `module.exports = "error";`)
 
   absentConfig := filepath.Join(root, "lint.config.cjs")
   write(absentConfig, `module.exports = { rules: { "no-var": require("absent-main") } };`)
@@ -95,14 +95,14 @@ func TestConfigDependencyGraphNeverPublishesTheFilesystemRoot(t *testing.T) {
     filepath.Join(linkedPackage, "package.json"),
     `{"main":`+quoteJSONPath(filepath.Join(linked, "via-link", "index.cjs"))+`}`,
   )
-  write(filepath.Join(linkedPackage, "index.cjs"), `module.exports = "off";`)
+  write(filepath.Join(linkedPackage, "index.js"), `module.exports = "off";`)
 
   filePackage := filepath.Join(root, "node_modules", "through-file")
   write(
     filepath.Join(filePackage, "package.json"),
     `{"main":`+quoteJSONPath(throughFile)+`}`,
   )
-  write(filepath.Join(filePackage, "index.cjs"), `module.exports = "error";`)
+  write(filepath.Join(filePackage, "index.js"), `module.exports = "error";`)
 
   ancestorConfig := filepath.Join(root, "lint.ancestors.cjs")
   write(ancestorConfig, `module.exports = { rules: {
@@ -131,14 +131,10 @@ func TestConfigDependencyGraphNeverPublishesTheFilesystemRoot(t *testing.T) {
     configDependencyEntry,
     configDependencyWatch,
   )
-  // The narrower record replaces the parent digest; it must not also keep
-  // publishing the containing directory it was introduced to avoid.
-  assertConfigDependencyKindAbsent(
-    t,
-    ancestors.dependencyDigests,
-    root,
-    configDependencyDir,
-  )
+  // The narrower record replaces the parent digest for the ancestor itself. It
+  // does not remove the ordinary node_modules search directories, which the
+  // resolution topology records deliberately and which stay inside the project.
+  assertConfigWatchDependenciesWithin(t, ancestors.dependencyDigests, root)
 
   // 3. Retarget the symlink. The recorded entry digest is the link target, so a
   //    repoint has to produce a different selection rather than a cache hit.

--- a/packages/lint/test/config/files/config_dependency_graph_never_publishes_the_filesystem_root_test.go
+++ b/packages/lint/test/config/files/config_dependency_graph_never_publishes_the_filesystem_root_test.go
@@ -1,0 +1,176 @@
+package linthost
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestConfigDependencyGraphNeverPublishesTheFilesystemRoot verifies a resolution
+// trace records the ancestor it actually observed instead of fingerprinting the
+// directory that contains it.
+//
+// The collector walks path components from the filesystem root and holds
+// `current` at that root through the whole first iteration, so every early
+// return there published `/` as a watch input and digested it by enumerating
+// the entire root. Three branches reach that first iteration -- a symlink
+// ancestor, an ancestor that does not exist, and an ancestor that is not a
+// directory -- so proving only the reported macOS `/var` case would leave the
+// other two publishing the same record. Suppressing the root outright is not
+// the fix either: the collector visits a symlink ancestor deliberately, and the
+// link topology it learns there still has to invalidate the cache.
+//
+//  1. Resolve a package whose manifest main is an absolute path whose first
+//     component does not exist, and require the root to be absent while that
+//     exact ancestor is recorded as an `entry`.
+//  2. Resolve a package through a symlink ancestor and a non-directory ancestor
+//     inside the project, and require the same treatment for both.
+//  3. Retarget the symlink ancestor and require the evaluation to refresh, so
+//     the narrower record still observes link topology.
+func TestConfigDependencyGraphNeverPublishesTheFilesystemRoot(t *testing.T) {
+  t.Setenv("TTSC_LINT_DISABLE_CONFIG_CACHE", "")
+  t.Setenv("TTSC_LINT_DEBUG_CONFIG_GRAPH", "1")
+  root := t.TempDir()
+  write := func(location string, body string) {
+    t.Helper()
+    if err := os.MkdirAll(filepath.Dir(location), 0o755); err != nil {
+      t.Fatal(err)
+    }
+    if err := os.WriteFile(location, []byte(body), 0o644); err != nil {
+      t.Fatal(err)
+    }
+  }
+
+  // The filesystem root of the temporary tree, whatever spelling this host
+  // uses. On Windows that is the drive root, not "/".
+  filesystemRoot := filepath.VolumeName(root) + string(filepath.Separator)
+
+  write(filepath.Join(root, "package.json"), `{"type":"commonjs"}`)
+
+  // 1. An absolute main whose very first component is absent. The collector
+  //    fails `lstat` on that component while `current` is still the root.
+  absentAncestor := filepath.Join(filesystemRoot, "ttsc-lint-absent-ancestor")
+  absentMain := filepath.Join(absentAncestor, "main.cjs")
+  absentPackage := filepath.Join(root, "node_modules", "absent-main")
+  write(
+    filepath.Join(absentPackage, "package.json"),
+    `{"main":`+quoteJSONPath(absentMain)+`}`,
+  )
+  write(filepath.Join(absentPackage, "index.cjs"), `module.exports = "error";`)
+
+  absentConfig := filepath.Join(root, "lint.config.cjs")
+  write(absentConfig, `module.exports = { rules: { "no-var": require("absent-main") } };`)
+
+  absent, err := loadConfigFileEvaluation(absentConfig)
+  if err != nil {
+    t.Fatalf("load config resolving an absent absolute main: %v", err)
+  }
+  assertConfigRuleSeverity(t, absent.value, "no-var", "error")
+  assertConfigDependencyAbsent(t, absent.dependencyDigests, filesystemRoot)
+  assertConfigDependencyKindScope(
+    t,
+    absent.dependencyDigests,
+    absentAncestor,
+    configDependencyEntry,
+    configDependencyWatch,
+  )
+
+  // 2. A symlink ancestor and a non-directory ancestor, both inside the project
+  //    so the fixture controls them. These are the other two first-iteration
+  //    branches, reached at a depth the test can actually create.
+  target := filepath.Join(root, "real-packages")
+  linked := filepath.Join(root, "linked-packages")
+  write(filepath.Join(target, "via-link", "package.json"), `{"main":"index.cjs"}`)
+  write(filepath.Join(target, "via-link", "index.cjs"), `module.exports = "warning";`)
+  if err := os.Symlink(target, linked); err != nil {
+    t.Skipf("host cannot create directory symlink: %v", err)
+  }
+
+  notADirectory := filepath.Join(root, "plain-file")
+  write(notADirectory, "not a directory\n")
+  throughFile := filepath.Join(notADirectory, "nested", "main.cjs")
+
+  linkedPackage := filepath.Join(root, "node_modules", "through-link")
+  write(
+    filepath.Join(linkedPackage, "package.json"),
+    `{"main":`+quoteJSONPath(filepath.Join(linked, "via-link", "index.cjs"))+`}`,
+  )
+  write(filepath.Join(linkedPackage, "index.cjs"), `module.exports = "off";`)
+
+  filePackage := filepath.Join(root, "node_modules", "through-file")
+  write(
+    filepath.Join(filePackage, "package.json"),
+    `{"main":`+quoteJSONPath(throughFile)+`}`,
+  )
+  write(filepath.Join(filePackage, "index.cjs"), `module.exports = "error";`)
+
+  ancestorConfig := filepath.Join(root, "lint.ancestors.cjs")
+  write(ancestorConfig, `module.exports = { rules: {
+  "no-var": require("through-link"),
+  "eqeqeq": require("through-file"),
+} };`)
+
+  ancestors, err := loadConfigFileEvaluation(ancestorConfig)
+  if err != nil {
+    t.Fatalf("load config resolving symlink and non-directory ancestors: %v", err)
+  }
+  assertConfigRuleSeverity(t, ancestors.value, "no-var", "warning")
+  assertConfigRuleSeverity(t, ancestors.value, "eqeqeq", "error")
+  assertConfigDependencyAbsent(t, ancestors.dependencyDigests, filesystemRoot)
+  assertConfigDependencyKindScope(
+    t,
+    ancestors.dependencyDigests,
+    linked,
+    configDependencyEntry,
+    configDependencyWatch,
+  )
+  assertConfigDependencyKindScope(
+    t,
+    ancestors.dependencyDigests,
+    notADirectory,
+    configDependencyEntry,
+    configDependencyWatch,
+  )
+  // The narrower record replaces the parent digest; it must not also keep
+  // publishing the containing directory it was introduced to avoid.
+  assertConfigDependencyKindAbsent(
+    t,
+    ancestors.dependencyDigests,
+    root,
+    configDependencyDir,
+  )
+
+  // 3. Retarget the symlink. The recorded entry digest is the link target, so a
+  //    repoint has to produce a different selection rather than a cache hit.
+  retarget := filepath.Join(root, "other-packages")
+  write(filepath.Join(retarget, "via-link", "package.json"), `{"main":"index.cjs"}`)
+  write(filepath.Join(retarget, "via-link", "index.cjs"), `module.exports = "error";`)
+  if err := os.Remove(linked); err != nil {
+    t.Fatal(err)
+  }
+  if err := os.Symlink(retarget, linked); err != nil {
+    t.Fatal(err)
+  }
+
+  retargeted, err := loadConfigFileEvaluation(ancestorConfig)
+  if err != nil {
+    t.Fatalf("reload config after retargeting the symlink ancestor: %v", err)
+  }
+  assertConfigRuleSeverity(t, retargeted.value, "no-var", "error")
+  assertConfigDependencyAbsent(t, retargeted.dependencyDigests, filesystemRoot)
+}
+
+// quoteJSONPath renders an absolute host path as a JSON string literal. Windows
+// separators are not legal JSON escapes, so they cannot ride into a manifest
+// unescaped.
+func quoteJSONPath(location string) string {
+  encoded := make([]rune, 0, len(location)+2)
+  encoded = append(encoded, '"')
+  for _, character := range location {
+    if character == '\\' || character == '"' {
+      encoded = append(encoded, '\\')
+    }
+    encoded = append(encoded, character)
+  }
+  return string(append(encoded, '"'))
+}

--- a/packages/lint/test/config/files/config_dependency_graph_never_publishes_the_filesystem_root_test.go
+++ b/packages/lint/test/config/files/config_dependency_graph_never_publishes_the_filesystem_root_test.go
@@ -25,7 +25,9 @@ import (
 //     exact ancestor is recorded as an `entry`.
 //  2. Resolve a package through a symlink ancestor and a non-directory ancestor
 //     inside the project, and require the same treatment for both.
-//  3. Retarget the symlink ancestor and require the evaluation to refresh, so
+//  3. Resolve a candidate that lands directly on the root and require the root
+//     to stay absent there too.
+//  4. Retarget the symlink ancestor and require the evaluation to refresh, so
 //     the narrower record still observes link topology.
 func TestConfigDependencyGraphNeverPublishesTheFilesystemRoot(t *testing.T) {
   t.Setenv("TTSC_LINT_DISABLE_CONFIG_CACHE", "")
@@ -136,7 +138,28 @@ func TestConfigDependencyGraphNeverPublishesTheFilesystemRoot(t *testing.T) {
   // resolution topology records deliberately and which stay inside the project.
   assertConfigWatchDependenciesWithin(t, ancestors.dependencyDigests, root)
 
-  // 3. Retarget the symlink. The recorded entry digest is the link target, so a
+  // 3. A candidate whose resolved path sits directly on the root. The walk
+  //    reaches its last component while `current` is still the root, so the
+  //    parent-digest reasoning would enumerate the root one more way.
+  rootLevelMain := filepath.Join(filesystemRoot, "ttsc-lint-absent-root-main.js")
+  rootLevelPackage := filepath.Join(root, "node_modules", "root-level-main")
+  write(
+    filepath.Join(rootLevelPackage, "package.json"),
+    `{"main":`+quoteJSONPath(rootLevelMain)+`}`,
+  )
+  write(filepath.Join(rootLevelPackage, "index.js"), `module.exports = "warning";`)
+
+  rootLevelConfig := filepath.Join(root, "lint.rootlevel.cjs")
+  write(rootLevelConfig, `module.exports = { rules: { "no-var": require("root-level-main") } };`)
+
+  rootLevel, err := loadConfigFileEvaluation(rootLevelConfig)
+  if err != nil {
+    t.Fatalf("load config resolving a root-level main: %v", err)
+  }
+  assertConfigRuleSeverity(t, rootLevel.value, "no-var", "warning")
+  assertConfigDependencyAbsent(t, rootLevel.dependencyDigests, filesystemRoot)
+
+  // 4. Retarget the symlink. The recorded entry digest is the link target, so a
   //    repoint has to produce a different selection rather than a cache hit.
   retarget := filepath.Join(root, "other-packages")
   write(filepath.Join(retarget, "via-link", "package.json"), `{"main":"index.cjs"}`)

--- a/website/src/content/docs/development/authoring/publishing.mdx
+++ b/website/src/content/docs/development/authoring/publishing.mdx
@@ -2,17 +2,42 @@
 
 A plugin is one npm package containing a JS descriptor and Go source.
 
+## Community package naming
+
+`ttsc` resolves plugins by the name you publish under, so no prefix is required and nothing is enforced at runtime. The names below are the ecosystem convention: they make a package recognizable on npm and let the keywords below find it.
+
+| Package type | Unscoped | Scoped |
+| --- | --- | --- |
+| Top-level `ttsc` plugin | `ttsc-plugin-<name>` | `@scope/ttsc-plugin-<name>` |
+| [`@ttsc/lint` rule contributor](/docs/lint/contributing) | `ttsc-lint-plugin-<name>` | `@scope/ttsc-lint-plugin-<name>` |
+
+The two are different extension surfaces. A top-level plugin loads through `compilerOptions.plugins` or the `ttsc.plugin` manifest and transforms the emit; a lint contributor is imported by `lint.config.*` and adds rules. A package that does both publishes both entries.
+
+Pair the name with keywords, which are what npm search actually matches:
+
+```json
+{
+  "keywords": ["ttsc", "ttsc-plugin", "tsgo"]
+}
+```
+
+A lint contributor adds `ttsc-lint-plugin` and `lint` to that list.
+
+The `@ttsc/*` scope is reserved for packages this project owns and maintains. Publish community packages unscoped or under your own scope; do not use `@ttsc/*` to signal compatibility.
+
+Existing and branded names stay valid and need no rename — `typia` and `nestia` are plugins under their own names. Keywords, peer dependencies, and the [ecosystem page](/docs/plugins) are how those stay discoverable.
+
 ## `package.json`
 
 ```json
 {
-  "name": "my-ttsc-plugin",
+  "name": "ttsc-plugin-example",
   "version": "0.1.0",
   "description": "What the plugin does.",
   "main": "plugin.cjs",
   "ttsc": {
     "plugin": {
-      "transform": "my-ttsc-plugin"
+      "transform": "ttsc-plugin-example"
     }
   },
   "files": ["plugin.cjs", "plugin", "driver"],

--- a/website/src/content/docs/lint/_meta.ts
+++ b/website/src/content/docs/lint/_meta.ts
@@ -6,5 +6,6 @@ const meta: MetaRecord = {
   editor: "VS Code",
   format: "Format",
   rules: "Rules",
+  contributing: "Contributing",
 };
 export default meta;

--- a/website/src/content/docs/lint/contributing.mdx
+++ b/website/src/content/docs/lint/contributing.mdx
@@ -1,0 +1,123 @@
+# Publishing Rule Contributors
+
+A contributor package adds rules to `@ttsc/lint` under its own namespace. It is not a top-level `ttsc` plugin: the compiler never loads it, `lint.config.*` imports it, and its rules run inside the lint engine's own binary.
+
+## Package contents
+
+One npm package carries a JS descriptor and the Go source of its rules:
+
+- the built descriptor entry (`lib/index.js` plus `lib/index.d.ts`);
+- the Go rules directory the descriptor's `source` points at;
+- `go.mod`, and `go.sum` when present;
+- `README.md` and license.
+
+`ttsc` statically links that Go source into `@ttsc/lint`'s binary on first build, so the tarball ships source, not a prebuilt binary. Verify with `npm pack --dry-run` before publishing.
+
+## Naming and discovery
+
+Follow the [community naming convention](/docs/development/authoring/publishing#community-package-naming):
+
+```text
+ttsc-lint-plugin-<name>
+@scope/ttsc-lint-plugin-<name>
+```
+
+```json
+{
+  "keywords": ["ttsc", "ttsc-plugin", "ttsc-lint-plugin", "tsgo", "lint"]
+}
+```
+
+The prefix is a convention, not a runtime requirement. `@ttsc/*` is reserved for packages this project maintains.
+
+## Peer dependencies
+
+The consumer project supplies the lint engine and the active TypeScript runtime; a contributor should not carry either in `dependencies`:
+
+```json
+"peerDependencies": {
+  "@ttsc/lint": ">=0.23.0 <0.24.0",
+  "typescript": "*"
+}
+```
+
+Pin the `@ttsc/lint` minor range you actually tested against. The `rule` package and its `rule/astutil` helpers are the public Go surface for third-party rules; a new minor may add helpers, and a major may change the `rule` contract.
+
+## `meta.name` versus `meta.namespace`
+
+Three names do three different jobs, and only the last one appears in a user's config:
+
+| Name             | Purpose                            |
+| ---------------- | ---------------------------------- |
+| npm package name | installation and package discovery |
+| `meta.name`      | informational package identity     |
+| `meta.namespace` | the rule-id prefix users write     |
+
+```ts
+import type { ITtscLintPlugin } from "@ttsc/lint";
+import path from "node:path";
+
+const plugin = {
+  meta: {
+    name: "ttsc-lint-plugin-example",
+    version: "1.0.0",
+    namespace: "example",
+  },
+  rules: ["some-rule"] as const,
+  source: path.resolve(__dirname, "..", "rules"),
+} satisfies ITtscLintPlugin;
+
+export default plugin;
+```
+
+That descriptor produces rule ids under `example/*`, whatever the package is installed as. Keep the `rules` tuple `as const` so [`ITtscLintConfig`](/docs/lint/rules) can suggest your rule keys in the user's `rules` map. The array is advisory; registration happens in the Go `init()` through `rule.Register`.
+
+## Registration is explicit
+
+A contributor is never auto-loaded. The consumer imports it and names it in `lint.config.*`:
+
+```ts
+import type { ITtscLintConfig } from "@ttsc/lint";
+import example from "ttsc-lint-plugin-example";
+
+export default {
+  plugins: {
+    example,
+  },
+  rules: {
+    "example/some-rule": "error",
+  },
+} satisfies ITtscLintConfig;
+```
+
+Unless the package also ships an independent top-level transform, it needs no `ttsc.plugin` manifest entry.
+
+## Before publishing
+
+Test the package the way a consumer installs it, so a missing file in `files` fails here instead of downstream:
+
+```bash
+# 1. Pack the tarball.
+pnpm pack
+TARBALL=$(ls *.tgz | tail -n1)
+
+# 2. Stand up a clean-room consumer.
+WORKDIR=$(mktemp -d)
+cd "$WORKDIR"
+npm init -y >/dev/null
+npm install --no-save "${OLDPWD}/${TARBALL}" ttsc typescript @ttsc/lint
+
+# 3. Register the contributor and a source file that must report.
+# ... write lint.config.ts and src/main.ts ...
+
+# 4. Build the native contributor and assert the rule fires.
+npx ttsc-lint src
+```
+
+Step 4 is the one that matters: it forces the Go source to link into the lint binary on the consumer machine. A contributor that type-checks but omits its `source` directory from the tarball passes every earlier step and fails only here.
+
+Pin `TTSC_GO_BINARY` and `TTSC_CACHE_DIR` in CI so that build is deterministic across matrix runs.
+
+## Next
+
+→ [Rules](/docs/lint/rules), the in-tree families and the namespaces already taken.

--- a/website/src/content/docs/plugins/index.mdx
+++ b/website/src/content/docs/plugins/index.mdx
@@ -23,6 +23,15 @@ Each ships on its own release schedule with its own docs. The pages above cover 
 
 PRs adding plugins to this list are welcome. The bar is "installs and works on a current `ttsc` release."
 
+## Finding plugins
+
+Community packages are discoverable by npm keyword rather than by a registry this project owns:
+
+- [`ttsc-plugin`](https://www.npmjs.com/search?q=keywords:ttsc-plugin): top-level compiler plugins.
+- [`ttsc-lint-plugin`](https://www.npmjs.com/search?q=keywords:ttsc-lint-plugin): `@ttsc/lint` rule contributors.
+
+Publishing your own? See [Community package naming](/docs/development/authoring/publishing#community-package-naming) for the recommended names and keywords, and [Publishing rule contributors](/docs/lint/contributing) for the lint-specific surface. The prefixes are conventions, not requirements — branded packages like `typia` and `nestia` stay discoverable through the same keywords.
+
 ## Writing your own
 
 → [Plugin Development](/docs/development), the audience-walled section for plugin authors.


### PR DESCRIPTION
## Intent

One cycle pull request for the two published issues that have no owning pull request of their own.

- #1051 — the executable-config dependency collector publishes the filesystem root as a `watch` directory.
- #1053 — no documented community naming convention for ttsc plugins and `@ttsc/lint` contributors.

The other campaign items are owned elsewhere and are not in this branch: #1050 by #1052 (complete, 25/25 checks green), #1055 by #1056, and #1054 carries no issue.

## Scope

**#1051.** The collector walks path components from the filesystem root and holds `current = "/"` through the first iteration, so every early return in that iteration records `/` as a directory dependency and digests it by reading the whole root. Three branches reach it, not the one the issue reports: the symlink observation, the `lstat` failure, and the non-directory ancestor. The fix records the observed entry itself rather than fingerprinting its parent, in both embedded loader scripts.

**#1053.** Documents the naming convention the authoring guides already follow in practice, adds the missing `@ttsc/lint` contributor publishing section, and links discovery from the ecosystem page.

## Verification

Pending. Verification is this pull request's ordinary CI; results are recorded as pull-request reviews rather than by rewriting this body.

No version field is touched. Release and launch are out of scope for this branch.
