### PR TITLE
fix(graph): answer dump --help when the native binary is absent

### DIFF
--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -83,6 +83,37 @@ export function runGraph(
   );
 }
 
+/** The help spellings `ttscgraph` itself accepts, mirrored for the fallback. */
+const DUMP_HELP_FLAGS = new Set(["--help", "-help", "-h"]);
+
+/**
+ * Print a `dump` usage summary when the native binary cannot be resolved.
+ *
+ * This is a fallback, not a second contract: `cmd/ttscgraph/main.go` owns these
+ * flags and answers whenever it is installed. Keep this short and point at that
+ * authority, so a drift degrades to a stale summary rather than a wrong
+ * answer.
+ */
+function printDumpHelp(): void {
+  process.stdout.write(
+    [
+      "Usage: ttsc-graph dump [options]",
+      "",
+      "Write the whole compiler graph as JSON to stdout: every node and edge,",
+      "none of the MCP response caps.",
+      "",
+      "Options:",
+      "  --cwd <dir>        Project root (default: current directory).",
+      "  --tsconfig <path>  Project tsconfig path (default: tsconfig.json).",
+      "  --pretty           Indent the JSON output.",
+      "",
+      "The native `ttscgraph` binary owns these flags and is not installed here,",
+      "so this summary may lag it. Install `ttsc` and rerun for the exact list.",
+      "",
+    ].join("\n"),
+  );
+}
+
 /**
  * Pass `dump` through to the native binary, inheriting stdio so the JSON lands
  * on this process's stdout. Returns the child's exit code.
@@ -93,6 +124,15 @@ function runDump(argv: readonly string[]): number {
   const { cwd } = projectOptions(parseLauncherOptions(argv, DUMP_OPTIONS));
   const binary = resolveGraphBinary(process.env, cwd);
   if (binary === null) {
+    // `ttscgraph` owns the flag contract, so a resolvable binary always answers
+    // `--help` itself and stays the single source of truth. It cannot answer
+    // when it is absent, and that is exactly when a caller is most likely to be
+    // asking what the command needs — so fall back to a summary that names the
+    // authority rather than making usage unreachable behind an install error.
+    if (argv.some((argument) => DUMP_HELP_FLAGS.has(argument))) {
+      printDumpHelp();
+      return 0;
+    }
     process.stderr.write(
       "@ttsc/graph: could not resolve the ttscgraph binary. " +
         "Install `ttsc` so its platform package is present, " +

--- a/tests/test-graph/src/features/test_ttscgraph_dump_help_survives_a_missing_binary.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_dump_help_survives_a_missing_binary.ts
@@ -1,0 +1,102 @@
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import path from "node:path";
+
+import { assert, resolveGraphLauncher } from "../internal/ttsgraph";
+
+/**
+ * Verifies `dump --help` still answers when the native binary cannot be found.
+ *
+ * `dump` forwards every flag to `ttscgraph`, which owns the contract and
+ * answers `--help` itself. When no platform package is installed the launcher
+ * used to fail resolution first, so the one command that could tell a caller
+ * what to install was reachable only by callers who had already installed it.
+ * The fallback must stay a fallback: an ordinary `dump` with no binary is still
+ * an error, and a resolvable binary must keep owning help.
+ *
+ * 1. Point `TTSC_GRAPH_BINARY` at a path that does not exist.
+ * 2. Assert every help spelling exits 0 with usage naming the native authority.
+ * 3. Assert an ordinary `dump` still fails, and that a resolvable binary receives
+ *    `--help` instead of the launcher answering for it.
+ */
+export const test_ttscgraph_dump_help_survives_a_missing_binary = () => {
+  const root = TestProject.tmpdir("ttscgraph-dump-help-");
+  const absent = path.join(root, "does-not-exist", "ttscgraph");
+
+  const run = (args: string[], binary: string, marker?: string) =>
+    TestProject.spawn(process.execPath, [resolveGraphLauncher(), ...args], {
+      cwd: root,
+      env: {
+        TTSC_GRAPH_BINARY: binary,
+        ...(marker === undefined ? {} : { TTSCGRAPH_MARKER: marker }),
+      },
+      timeout: 30_000,
+    });
+
+  for (const flag of ["--help", "-help", "-h"]) {
+    const result = run(["dump", flag], absent);
+    assert.equal(
+      result.status,
+      0,
+      `dump ${flag} without a binary exits successfully\nstderr: ${result.stderr}`,
+    );
+    assert.match(
+      result.stdout ?? "",
+      /^Usage: ttsc-graph dump/m,
+      `dump ${flag} writes usage`,
+    );
+    // The summary is not the contract. A reader has to be told where the real
+    // list lives, or a drifted copy silently becomes the answer.
+    assert.match(
+      result.stdout ?? "",
+      /ttscgraph/,
+      `dump ${flag} names the native authority`,
+    );
+  }
+
+  // The fallback is scoped to help. Resolution failure is still an error for
+  // the command that actually needs the binary.
+  const ordinary = run(["dump", "--pretty"], absent);
+  assert.notEqual(
+    ordinary.status,
+    0,
+    `an ordinary dump without a binary still fails\nstdout: ${ordinary.stdout}`,
+  );
+  assert.match(
+    ordinary.stderr ?? "",
+    /could not resolve the ttscgraph binary/,
+    "the resolution error is preserved",
+  );
+
+  // A resolvable binary keeps owning help, so the two texts cannot diverge for
+  // anyone who has it installed.
+  const sentinel = TestProject.tmpdir("ttscgraph-dump-help-sentinel-");
+  const marker = path.join(sentinel, "native-marker.json");
+  const binary = path.join(sentinel, "ttscgraph");
+  fs.writeFileSync(
+    binary,
+    [
+      "#!/usr/bin/env node",
+      "const fs = require('node:fs');",
+      "fs.writeFileSync(process.env.TTSCGRAPH_MARKER, JSON.stringify(process.argv.slice(2)));",
+      "process.exit(23);",
+      "",
+    ].join("\n"),
+  );
+  fs.chmodSync(binary, 0o755);
+  // Windows cannot mark the sentinel executable, so the forwarding half only
+  // runs where spawning it can actually succeed.
+  if (process.platform !== "win32") {
+    const forwarded = run(["dump", "--help"], binary, marker);
+    assert.equal(
+      forwarded.status,
+      23,
+      `a resolvable binary answers dump --help itself\nstdout: ${forwarded.stdout}`,
+    );
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(marker, "utf8")) as string[],
+      ["dump", "--help"],
+      "the help flag reaches the native binary unchanged",
+    );
+  }
+};

--- a/tests/test-graph/src/features/test_ttscgraph_dump_help_survives_a_missing_binary.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_dump_help_survives_a_missing_binary.ts
@@ -14,27 +14,32 @@ import { assert, resolveGraphLauncher } from "../internal/ttsgraph";
  * The fallback must stay a fallback: an ordinary `dump` with no binary is still
  * an error, and a resolvable binary must keep owning help.
  *
- * 1. Point `TTSC_GRAPH_BINARY` at a path that does not exist.
+ * 1. Run from an empty project with no resolvable binary and no override.
  * 2. Assert every help spelling exits 0 with usage naming the native authority.
  * 3. Assert an ordinary `dump` still fails, and that a resolvable binary receives
  *    `--help` instead of the launcher answering for it.
  */
 export const test_ttscgraph_dump_help_survives_a_missing_binary = () => {
+  // An empty temporary project: no `ttsc` to resolve a platform package from,
+  // and no `TTSC_GRAPH_BINARY` override. Pointing the override at a missing
+  // file would not model this — `resolveGraphBinary` returns an absolute
+  // override unchecked, so that produces a spawn failure, not an unresolved
+  // binary, and would exercise the wrong branch entirely.
   const root = TestProject.tmpdir("ttscgraph-dump-help-");
-  const absent = path.join(root, "does-not-exist", "ttscgraph");
 
-  const run = (args: string[], binary: string, marker?: string) =>
+  const run = (args: string[], binary?: string, marker?: string) =>
     TestProject.spawn(process.execPath, [resolveGraphLauncher(), ...args], {
       cwd: root,
       env: {
-        TTSC_GRAPH_BINARY: binary,
+        ...process.env,
+        TTSC_GRAPH_BINARY: binary ?? "",
         ...(marker === undefined ? {} : { TTSCGRAPH_MARKER: marker }),
       },
       timeout: 30_000,
     });
 
   for (const flag of ["--help", "-help", "-h"]) {
-    const result = run(["dump", flag], absent);
+    const result = run(["dump", flag]);
     assert.equal(
       result.status,
       0,
@@ -56,7 +61,7 @@ export const test_ttscgraph_dump_help_survives_a_missing_binary = () => {
 
   // The fallback is scoped to help. Resolution failure is still an error for
   // the command that actually needs the binary.
-  const ordinary = run(["dump", "--pretty"], absent);
+  const ordinary = run(["dump", "--pretty"]);
   assert.notEqual(
     ordinary.status,
     0,


### PR DESCRIPTION
## Intent

`ttsc-graph dump --help` was unreachable without an installed platform package. `dump` forwards every flag to `ttscgraph`, which owns the flag contract and answers `--help` itself, but resolution ran first — so the one command that could tell a caller what to install only worked for callers who had already installed it.

## Scope

Help falls back to a short summary on the resolution-failure path only.

- A resolvable binary keeps answering help, so the two texts cannot diverge for anyone who has it installed.
- The fallback names `ttscgraph` as the authority, so a drift degrades to a stale summary rather than a wrong answer.
- An ordinary `dump` with no binary still fails with the same resolution error.

## Provenance

Found while reviewing #1054, which proposed answering help locally in every case and deleting the assertion that `dump --help` forwards. That PR was withdrawn by its author. This takes only the part that was a real defect on `master` and keeps the native binary authoritative.

## Verification

Pending CI. Locally: `tsc --noEmit` on `@ttsc/graph` and `@ttsc/test-graph`, and formatting on the changed files.

Regression covers all three help spellings without a binary, the preserved failure for an ordinary `dump`, and — on hosts that can mark a sentinel executable — that `--help` still reaches the native binary unchanged.
