### PR TITLE
fix: preserve graph and CI contract boundaries

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,19 +30,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: packages/ttsc/go.mod
           cache-dependency-path: |
             packages/ttsc/go.sum
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.6.4
 

--- a/packages/graph/src/model/TtscGraphMemory.ts
+++ b/packages/graph/src/model/TtscGraphMemory.ts
@@ -190,20 +190,22 @@ function synthesize(dump: ITtscGraphDump): {
   // small — the two copies are 17% of the document, 55 MB of VS Code's 323 MB,
   // paid again in the encode, the pipe, the parse and the validation. Nothing
   // downstream of this line sees a span without its file.
-  const nodes: ITtscGraphNode[] = dump.nodes
-    .filter((n) => n.kind !== "module")
-    .map((n) => {
-      const { evidence, implementation, ...rest } = n;
-      return {
+  const nodes: ITtscGraphNode[] = dump.nodes.flatMap((n): ITtscGraphNode[] => {
+    if (n.kind === "module") return [];
+    const { evidence, implementation, ...rest } = n;
+    return [
+      {
         ...rest,
+        kind: n.kind,
         ...(evidence !== undefined
           ? { evidence: spanIn(evidence, n.file) }
           : {}),
         ...(implementation !== undefined
           ? { implementation: spanIn(implementation, n.file) }
           : {}),
-      };
-    });
+      },
+    ];
+  });
   const edges: ITtscGraphEdge[] = dump.edges.map((edge) => {
     const { evidence, ...rest } = edge;
     const from = moduleIds.get(edge.from);

--- a/packages/graph/src/model/TtscGraphMemory.ts
+++ b/packages/graph/src/model/TtscGraphMemory.ts
@@ -27,7 +27,7 @@ export class TtscGraphMemory {
 
   /** The absolute project root the dump was built for. */
   readonly project: string;
-  /** Every node, raw plus synthesized (file containers). */
+  /** Every post-fold node, including refined properties and file containers. */
   readonly nodes: readonly ITtscGraphNode[];
   /** Every edge, raw plus synthesized containment. */
   readonly edges: readonly ITtscGraphEdge[];

--- a/packages/graph/src/server/runDetails.ts
+++ b/packages/graph/src/server/runDetails.ts
@@ -26,10 +26,9 @@ const MAX_DEPENDENCIES = 4;
 // Structural relationships are navigation, not the dependency picture details is for.
 const STRUCTURAL_KINDS = new Set<string>(["contains", "exports"]);
 // Kinds whose value is their member outline, not implementation text.
-const CONTAINER_KINDS = new Set<string>([
+const CONTAINER_KINDS = new Set<ITtscGraphNode["kind"]>([
   "class",
   "interface",
-  "module",
   "enum",
   "file",
 ]);

--- a/packages/graph/src/server/runDetails.ts
+++ b/packages/graph/src/server/runDetails.ts
@@ -24,12 +24,11 @@ const MAX_NEIGHBORS = 3;
 const DEFAULT_DEPENDENCIES = 2;
 const MAX_DEPENDENCIES = 4;
 // Structural relationships are navigation, not the dependency picture details is for.
-const STRUCTURAL_KINDS = new Set<string>(["contains", "exports", "imports"]);
+const STRUCTURAL_KINDS = new Set<string>(["contains", "exports"]);
 // Kinds whose value is their member outline, not implementation text.
 const CONTAINER_KINDS = new Set<string>([
   "class",
   "interface",
-  "namespace",
   "module",
   "enum",
   "file",
@@ -464,16 +463,13 @@ function edgeKindRank(kind: string): number {
     case "accesses":
     case "renders":
       return 2;
-    case "tests":
-      return 3;
     case "overrides":
-    case "decorates":
-      return 4;
+      return 3;
     case "extends":
     case "implements":
-      return 5;
+      return 4;
     case "type_ref":
-      return 6;
+      return 5;
     default:
       return 10;
   }

--- a/packages/graph/src/server/runEntrypoints.ts
+++ b/packages/graph/src/server/runEntrypoints.ts
@@ -12,7 +12,7 @@ const MAX_LIMIT = 8;
 const DEFAULT_NEIGHBORS = 0;
 const MAX_NEIGHBORS = 2;
 const MAX_SEEDS = 3;
-const STRUCTURAL_KINDS = new Set<string>(["contains", "exports", "imports"]);
+const STRUCTURAL_KINDS = new Set<string>(["contains", "exports"]);
 
 /**
  * Build the first source-free entrypoints list for a code question. The result
@@ -198,16 +198,13 @@ function edgeKindRank(kind: string): number {
     case "accesses":
     case "renders":
       return 2;
-    case "tests":
-      return 3;
     case "overrides":
-    case "decorates":
-      return 4;
+      return 3;
     case "extends":
     case "implements":
-      return 5;
+      return 4;
     case "type_ref":
-      return 6;
+      return 5;
     default:
       return 10;
   }

--- a/packages/graph/src/server/runLookup.ts
+++ b/packages/graph/src/server/runLookup.ts
@@ -260,7 +260,7 @@ function degree(graph: TtscGraphMemory, id: string): number {
 }
 
 function isStructural(kind: string): boolean {
-  return kind === "contains" || kind === "exports" || kind === "imports";
+  return kind === "contains" || kind === "exports";
 }
 
 function isTestFile(file: string): boolean {

--- a/packages/graph/src/server/runOverview.ts
+++ b/packages/graph/src/server/runOverview.ts
@@ -5,7 +5,7 @@ import { isPublicApiNoisePath, isSupportPath } from "./pathPolicy";
 import { IRunnerOutput, resultNext } from "./resultNext";
 
 /** Edges that express nesting/packaging, not code dependency. */
-const STRUCTURAL_KINDS = new Set<string>(["contains", "exports", "imports"]);
+const STRUCTURAL_KINDS = new Set<string>(["contains", "exports"]);
 
 /**
  * Project a compact, source-read-free architecture map: counts by kind, folder
@@ -83,8 +83,8 @@ function layers(graph: TtscGraphMemory): ITtscGraphOverview.ILayer[] {
 
 /**
  * The symbols at the center of the dependency graph, ranked by real fan-in and
- * fan-out. Structural `contains`/`exports`/`imports` edges are excluded so the
- * ranking reflects code dependency, not nesting.
+ * fan-out. Structural `contains`/`exports` edges are excluded so the ranking
+ * reflects code dependency, not nesting.
  */
 function hotspots(graph: TtscGraphMemory): ITtscGraphOverview.IHotspot[] {
   const real = (id: string, side: "in" | "out"): number => {

--- a/packages/graph/src/server/runTour.ts
+++ b/packages/graph/src/server/runTour.ts
@@ -49,7 +49,7 @@ const MAX_READ_NEXT = 14;
 const FLOW_OVERLAP = 0.6;
 const TOUR_TRACE_MAX_DEPTH = 6;
 const TOUR_TRACE_MAX_NODES = 18;
-const STRUCTURAL_KINDS = new Set<string>(["contains", "exports", "imports"]);
+const STRUCTURAL_KINDS = new Set<string>(["contains", "exports"]);
 const EXECUTION_KINDS = new Set<string>([
   "calls",
   "instantiates",
@@ -63,7 +63,6 @@ const TOUR_SEED_KINDS = new Set<string>([
   "property",
   "variable",
   "module",
-  "namespace",
   "enum",
 ]);
 
@@ -845,11 +844,11 @@ function isTourHop(graph: TtscGraphMemory, hop: ITtscGraphTrace.IHop): boolean {
 // floor makes it a no-op on small graphs that have no genuine hub. The `out <= 1`
 // guard keeps thin pass-throughs out but never prunes a real branching step.
 //
-// The fan-in counted is EXECUTION fan-in. `realDegree` also counts `type_ref`,
-// `extends`, `decorates`, and `tests`, and a widely referenced type or a
-// widely decorated symbol is not a call hub: a `Config` class named in twelve
-// parameter positions and constructed once was read as a hub and cut out of the
-// flow that constructs it. Popularity as a name is not popularity as a call.
+// The fan-in counted is EXECUTION fan-in. `realDegree` also counts `type_ref`
+// and `extends`, and a widely referenced type is not a call hub: a `Config`
+// class named in twelve parameter positions and constructed once was read as a
+// hub and cut out of the flow that constructs it. Popularity as a name is not
+// popularity as a call.
 function isSharedUtility(graph: TtscGraphMemory, id: string): boolean {
   const execution = executionDegree(graph, id);
   return execution.in >= 12 && execution.out <= 1;
@@ -932,11 +931,7 @@ function ownerOf(graph: TtscGraphMemory, id: string): string | undefined {
   for (const edge of graph.incoming(id)) {
     if (edge.kind !== "contains") continue;
     const owner = graph.node(edge.from);
-    if (
-      owner !== undefined &&
-      owner.kind !== "file" &&
-      owner.kind !== "module"
-    ) {
+    if (owner !== undefined && owner.kind !== "file") {
       return owner.id;
     }
   }

--- a/packages/graph/src/server/runTour.ts
+++ b/packages/graph/src/server/runTour.ts
@@ -56,13 +56,12 @@ const EXECUTION_KINDS = new Set<string>([
   "accesses",
   "renders",
 ]);
-const TOUR_SEED_KINDS = new Set<string>([
+const TOUR_SEED_KINDS = new Set<ITtscGraphNode["kind"]>([
   "class",
   "function",
   "method",
   "property",
   "variable",
-  "module",
   "enum",
 ]);
 

--- a/packages/graph/src/server/runTrace.ts
+++ b/packages/graph/src/server/runTrace.ts
@@ -29,11 +29,7 @@ const MAX_STEPS = 12;
 const DISPATCH_KINDS = new Set<string>(["overrides", "implements"]);
 // A declaration whose kind is a type surface never carries a body, and an
 // external leaf carries one the graph deliberately does not hold.
-const BODYLESS_KINDS = new Set<string>([
-  "interface",
-  "type",
-  "external_symbol",
-]);
+const BODYLESS_KINDS = new Set<string>(["interface", "type"]);
 // `abstract` and `declare` are the two keywords that take the body away from a
 // declaration that would otherwise have to have one.
 const BODYLESS_MODIFIERS = new Set<string>(["abstract", "declare"]);
@@ -48,11 +44,10 @@ const BODYLESS_MODIFIERS = new Set<string>(["abstract", "declare"]);
 const DISPATCH_HUB = 12;
 
 /**
- * Breadth-first trace along the dependency graph. Structural
- * (contains/exports/imports) edges are excluded so the path is real call/type
- * flow; forward walks callees, reverse and impact walk callers. Impact
- * additionally tags each reached node's role so the blast radius on the public
- * surface is legible.
+ * Breadth-first trace along the dependency graph. Structural (contains/exports)
+ * edges are excluded so the path is real call/type flow; forward walks callees,
+ * reverse and impact walk callers. Impact additionally tags each reached node's
+ * role so the blast radius on the public surface is legible.
  */
 export function runTrace(
   graph: TtscGraphMemory,
@@ -946,7 +941,7 @@ function traversable(
   kind: string,
   focus: ITtscGraphTrace.IRequest["focus"],
 ): boolean {
-  if (kind === "contains" || kind === "exports" || kind === "imports") {
+  if (kind === "contains" || kind === "exports") {
     return false;
   }
   if (kind === "dispatches") return focus !== "types";
@@ -963,8 +958,7 @@ function traversable(
       kind === "type_ref" ||
       kind === "extends" ||
       kind === "implements" ||
-      kind === "overrides" ||
-      kind === "decorates"
+      kind === "overrides"
     );
   }
   return true;
@@ -985,16 +979,13 @@ function edgeKindRank(kind: string): number {
       return 2;
     case "accesses":
       return 3;
-    case "tests":
-      return 4;
     case "overrides":
-    case "decorates":
-      return 5;
+      return 4;
     case "extends":
     case "implements":
-      return 6;
+      return 5;
     case "type_ref":
-      return 7;
+      return 6;
     default:
       return 10;
   }

--- a/packages/graph/src/structures/ITtscGraphDump.ts
+++ b/packages/graph/src/structures/ITtscGraphDump.ts
@@ -1,6 +1,8 @@
 import { ITtscGraphEdge } from "./ITtscGraphEdge";
 import { ITtscGraphNode } from "./ITtscGraphNode";
 import { ITtscGraphSpan } from "./ITtscGraphSpan";
+import { TtscGraphDumpEdgeKind } from "./TtscGraphDumpEdgeKind";
+import { TtscGraphDumpNodeKind } from "./TtscGraphDumpNodeKind";
 
 /**
  * The whole-graph export `ttscgraph dump` writes and the MCP server loads — the
@@ -229,8 +231,11 @@ export namespace ITtscGraphDump {
    */
   export interface INode extends Omit<
     ITtscGraphNode,
-    "evidence" | "implementation"
+    "evidence" | "implementation" | "kind"
   > {
+    /** Declaration kind written by the native producer. */
+    kind: TtscGraphDumpNodeKind;
+
     /** Declaration span; its file is this node's `file`. */
     evidence?: ITtscGraphSpan;
 
@@ -246,7 +251,10 @@ export namespace ITtscGraphDump {
    * names — the id is `path#Qualified.Name:kind` — so the path rode the wire a
    * second time on every edge, and edges outnumber nodes several times over.
    */
-  export interface IEdge extends Omit<ITtscGraphEdge, "evidence"> {
+  export interface IEdge extends Omit<ITtscGraphEdge, "evidence" | "kind"> {
+    /** Relationship kind written by the native producer. */
+    kind: TtscGraphDumpEdgeKind;
+
     /** Expression span; its file is the one embedded in `from`. */
     evidence?: ITtscGraphSpan;
   }

--- a/packages/graph/src/structures/ITtscGraphNode.ts
+++ b/packages/graph/src/structures/ITtscGraphNode.ts
@@ -4,8 +4,7 @@ import { TtscGraphNodeKind } from "./TtscGraphNodeKind";
 import { TtscGraphNodeModifier } from "./TtscGraphNodeModifier";
 
 /**
- * One node in the graph: a declared symbol or a structural container (file,
- * package).
+ * One node in the graph: a declared symbol or a synthesized file container.
  *
  * The `id` is position-invariant: `path#qualifiedName:kind` (e.g.
  * `src/order.ts#OrderService.create:method`), so inserting a line above a

--- a/packages/graph/src/structures/TtscGraphDumpEdgeKind.ts
+++ b/packages/graph/src/structures/TtscGraphDumpEdgeKind.ts
@@ -1,0 +1,11 @@
+/** Relationship kinds the native Go dump producer can write. */
+export type TtscGraphDumpEdgeKind =
+  | "exports"
+  | "calls"
+  | "accesses"
+  | "instantiates"
+  | "type_ref"
+  | "extends"
+  | "implements"
+  | "overrides"
+  | "renders";

--- a/packages/graph/src/structures/TtscGraphDumpNodeKind.ts
+++ b/packages/graph/src/structures/TtscGraphDumpNodeKind.ts
@@ -1,0 +1,10 @@
+/** Declaration kinds the native Go dump producer can write. */
+export type TtscGraphDumpNodeKind =
+  | "module"
+  | "function"
+  | "class"
+  | "interface"
+  | "type"
+  | "enum"
+  | "variable"
+  | "method";

--- a/packages/graph/src/structures/TtscGraphEdgeKind.ts
+++ b/packages/graph/src/structures/TtscGraphEdgeKind.ts
@@ -1,22 +1,23 @@
 /**
  * The relationship a directed edge encodes between two {@link ITtscGraphNode}s.
  *
- * Structural edges (`contains`, `exports`, `imports`) come from the declaration
- * pass. Value and type edges (`calls`, `accesses`, `instantiates`, `type_ref`,
+ * Structural `exports` edges come from the native declaration pass, while the
+ * TypeScript memory layer synthesizes `contains` ownership. Value and type
+ * edges (`calls`, `accesses`, `instantiates`, `type_ref`,
  * `extends`, `implements`, `overrides`, `renders`) are resolved by the checker
- * — `renders` is a JSX component use. `decorates` carries a decorator fact and
- * `tests` a test-to-subject relationship.
+ * — `renders` is a JSX component use. Decorators are facts on their target node,
+ * not edges.
  *
  * `dispatches` is the runtime counterpart of `overrides`/`implements`: the
  * checker resolves a call to the declaration it names, and where that
  * declaration is abstract or an interface member, the code that runs is its
  * implementation. It carries the implementation's declaration span, and a
- * traversal that follows what executes emits it in place of the dead end.
+ * traversal that follows what executes emits it in place of the dead end. It is
+ * trace-only and never appears in a native dump.
  */
 export type TtscGraphEdgeKind =
   | "contains"
   | "exports"
-  | "imports"
   | "calls"
   | "accesses"
   | "instantiates"
@@ -25,6 +26,4 @@ export type TtscGraphEdgeKind =
   | "implements"
   | "overrides"
   | "dispatches"
-  | "decorates"
-  | "renders"
-  | "tests";
+  | "renders";

--- a/packages/graph/src/structures/TtscGraphNodeKind.ts
+++ b/packages/graph/src/structures/TtscGraphNodeKind.ts
@@ -1,19 +1,15 @@
 /**
  * What a graph node represents.
  *
- * The symbol kinds (`file` through `parameter`) are declarations the TypeScript
- * program owns and the checker resolves. `external_symbol` is a
- * dependency-boundary leaf the workspace references but does not declare. The
- * graph keeps it as a named endpoint without walking into the dependency's
- * internals.
+ * The native builder emits declaration kinds from `module` through `method`.
+ * The TypeScript memory layer replaces each module with a `file` container and
+ * refines class/interface member variables to `property`. An external boundary
+ * leaf keeps its real declaration kind and sets `external: true`.
  *
  * Used as the `kind` discriminant on {@link ITtscGraphNode}.
  */
 export type TtscGraphNodeKind =
   | "file"
-  | "package"
-  | "namespace"
-  | "module"
   | "function"
   | "class"
   | "interface"
@@ -21,6 +17,4 @@ export type TtscGraphNodeKind =
   | "enum"
   | "variable"
   | "method"
-  | "property"
-  | "parameter"
-  | "external_symbol";
+  | "property";

--- a/packages/graph/src/structures/TtscGraphNodeModifier.ts
+++ b/packages/graph/src/structures/TtscGraphNodeModifier.ts
@@ -15,5 +15,4 @@ export type TtscGraphNodeModifier =
   | "const"
   | "public"
   | "private"
-  | "protected"
-  | "optional";
+  | "protected";

--- a/packages/graph/src/structures/index.ts
+++ b/packages/graph/src/structures/index.ts
@@ -21,5 +21,7 @@ export * from "./ITtscGraphSnapshot";
 export * from "./ITtscGraphSpan";
 export * from "./ITtscGraphTour";
 export * from "./TtscGraphEdgeKind";
+export * from "./TtscGraphDumpEdgeKind";
+export * from "./TtscGraphDumpNodeKind";
 export * from "./TtscGraphNodeKind";
 export * from "./TtscGraphNodeModifier";

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_commonjs_package_entry_for_esm_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_commonjs_package_entry_for_esm_test.go
@@ -39,12 +39,12 @@ func TestServeSessionReloadsCommonJSPackageEntryForESM(t *testing.T) {
     t.Fatal(err)
   }
 
-  writeGraphFile(t, filepath.Join(root, "node_modules", "fixture-package", "dist", "main.ts"), "export function winner(): void {}\nexport function packageEntryWinner(): void {}\n")
+  writeGraphFile(t, filepath.Join(root, "node_modules", "fixture-package", "dist", "main.ts"), "export function winner(): void {}\n")
   dump, mode, changed, err := session.Snapshot()
   if err != nil {
     t.Fatal(err)
   }
-  if dump == nil || mode != serveModeReload || !changed || !hasDumpNode(*dump, "packageEntryWinner") {
+  if dump == nil || mode != serveModeReload || !changed || !hasDumpNodeAt(*dump, "winner", "node_modules/fixture-package/dist/main.ts") {
     t.Fatalf("CommonJS package main.ts = dump:%v mode:%q changed:%v", dump != nil, mode, changed)
   }
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_superseding_module_candidates_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_superseding_module_candidates_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
   "path/filepath"
+  "strings"
   "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/internal/graph"
 )
 
 // TestServeSessionReloadsSupersedingModuleCandidates verifies a resident
@@ -15,8 +18,8 @@ import (
 //
 //  1. Load a project whose specifier resolves to the lower-priority target.
 //  2. Create only the absent target that precedes it in that resolver's search.
-//  3. Assert the resident snapshot reloads and exposes the new target when one
-//     carries a distinguishing declaration.
+//  3. Assert the resident snapshot reloads and the imported symbol resolves to
+//     the newly preferred file. Package internals remain external boundaries.
 func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
   cases := []struct {
     name  string
@@ -32,10 +35,10 @@ func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
 }`)
         writeGraphFile(t, filepath.Join(root, "src", "main.ts"), "import { winner } from './value';\nexport function main(): void { winner(); }\n")
         writeGraphFile(t, filepath.Join(root, "src", "value.js"), "export function winner() {}\n")
-        return "typescriptWinner"
+        return "src/value.ts"
       },
       add: func(t *testing.T, root string) {
-        writeGraphFile(t, filepath.Join(root, "src", "value.ts"), "export function winner(): void {}\nexport function typescriptWinner(): void {}\n")
+        writeGraphFile(t, filepath.Join(root, "src", "value.ts"), "export function winner(): void {}\n")
       },
     },
     {
@@ -52,10 +55,10 @@ func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
 }`)
         writeGraphFile(t, filepath.Join(root, "src", "main.ts"), "import { winner } from '@generated/value';\nexport function main(): void { winner(); }\n")
         writeGraphFile(t, filepath.Join(root, "fallback", "value.ts"), "export function winner(): void {}\n")
-        return "firstPathsWinner"
+        return "first/value.ts"
       },
       add: func(t *testing.T, root string) {
-        writeGraphFile(t, filepath.Join(root, "first", "value.ts"), "export function winner(): void {}\nexport function firstPathsWinner(): void {}\n")
+        writeGraphFile(t, filepath.Join(root, "first", "value.ts"), "export function winner(): void {}\n")
       },
     },
     {
@@ -71,10 +74,10 @@ func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
 }`)
         writeGraphFile(t, filepath.Join(root, "src", "views", "main.ts"), "import { winner } from './template';\nexport function main(): void { winner(); }\n")
         writeGraphFile(t, filepath.Join(root, "generated", "views", "template.ts"), "export function winner(): void {}\n")
-        return "rootDirsWinner"
+        return "src/views/template.ts"
       },
       add: func(t *testing.T, root string) {
-        writeGraphFile(t, filepath.Join(root, "src", "views", "template.ts"), "export function winner(): void {}\nexport function rootDirsWinner(): void {}\n")
+        writeGraphFile(t, filepath.Join(root, "src", "views", "template.ts"), "export function winner(): void {}\n")
       },
     },
     {
@@ -86,10 +89,10 @@ func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
 }`)
         writeGraphFile(t, filepath.Join(root, "src", "deep", "main.ts"), "import { winner } from 'fixture-package';\nexport function main(): void { winner(); }\n")
         writeGraphFile(t, filepath.Join(root, "node_modules", "fixture-package", "index.js"), "export function winner() {}\n")
-        return "nearerNodeModulesWinner"
+        return "src/node_modules/fixture-package/index.ts"
       },
       add: func(t *testing.T, root string) {
-        writeGraphFile(t, filepath.Join(root, "src", "node_modules", "fixture-package", "index.ts"), "export function winner(): void {}\nexport function nearerNodeModulesWinner(): void {}\n")
+        writeGraphFile(t, filepath.Join(root, "src", "node_modules", "fixture-package", "index.ts"), "export function winner(): void {}\n")
       },
     },
     {
@@ -113,7 +116,7 @@ func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
         return ""
       },
       add: func(t *testing.T, root string) {
-        writeGraphFile(t, filepath.Join(root, "node_modules", "fixture-package", "dist", "first.js"), "export function winner() {}\nexport function exportsWinner() {}\n")
+        writeGraphFile(t, filepath.Join(root, "node_modules", "fixture-package", "dist", "first.js"), "export function winner() {}\n")
       },
     },
     {
@@ -139,7 +142,7 @@ func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
   }
 }`)
         writeGraphFile(t, filepath.Join(root, "node_modules", "fixture-package", "dist", "fallback.js"), "export function winner() {}\n")
-        return ""
+        return "node_modules/fixture-package/dist/types.d.ts"
       },
       add: func(t *testing.T, root string) {
         writeGraphFile(t, filepath.Join(root, "node_modules", "fixture-package", "dist", "types.d.ts"), "export declare function winner(): void;\n")
@@ -168,7 +171,7 @@ func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
 }`)
         writeGraphFile(t, filepath.Join(root, "src", "main.ts"), "import { winner } from '#feature';\nexport function main(): void { winner(); }\n")
         writeGraphFile(t, filepath.Join(root, "generated", "fallback.js"), "export function winner() {}\n")
-        return ""
+        return "generated/types.d.ts"
       },
       add: func(t *testing.T, root string) {
         writeGraphFile(t, filepath.Join(root, "generated", "types.d.ts"), "export declare function winner(): void;\n")
@@ -183,10 +186,10 @@ func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
 }`)
         writeGraphFile(t, filepath.Join(root, "src", "main.ts"), "import { winner } from './feature';\nexport function main(): void { winner(); }\n")
         writeGraphFile(t, filepath.Join(root, "src", "feature", "index.js"), "export function winner() {}\n")
-        return "fileWinner"
+        return "src/feature.js"
       },
       add: func(t *testing.T, root string) {
-        writeGraphFile(t, filepath.Join(root, "src", "feature.js"), "export function winner() {}\nexport function fileWinner() {}\n")
+        writeGraphFile(t, filepath.Join(root, "src", "feature.js"), "export function winner() {}\n")
       },
     },
   }
@@ -208,9 +211,19 @@ func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
       if err != nil {
         t.Fatal(err)
       }
-      if dump == nil || mode != serveModeReload || !changed || (want != "" && !hasDumpNode(*dump, want)) {
-        t.Fatalf("superseding candidate = dump:%v mode:%q changed:%v want-node:%q", dump != nil, mode, changed, want)
+      if dump == nil || mode != serveModeReload || !changed || (want != "" && !hasDumpNodeAt(*dump, "winner", want)) {
+        t.Fatalf("superseding candidate = dump:%v mode:%q changed:%v want-file:%q", dump != nil, mode, changed, want)
       }
     })
   }
+}
+
+func hasDumpNodeAt(dump graph.Dump, name, fileSuffix string) bool {
+  suffix := filepath.ToSlash(fileSuffix)
+  for _, node := range dump.Nodes {
+    if node.Name == name && strings.HasSuffix(filepath.ToSlash(node.File), suffix) {
+      return true
+    }
+  }
+  return false
 }

--- a/packages/ttsc/cmd/ttscgraph/serve_session_reloads_superseding_module_candidates_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_session_reloads_superseding_module_candidates_test.go
@@ -22,9 +22,10 @@ import (
 //     the newly preferred file. Package internals remain external boundaries.
 func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
   cases := []struct {
-    name  string
-    setup func(*testing.T, string) string
-    add   func(*testing.T, string)
+    name           string
+    setup          func(*testing.T, string) string
+    add            func(*testing.T, string)
+    wantDiagnostic string
   }{
     {
       name: "relative_extension",
@@ -118,6 +119,7 @@ func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
       add: func(t *testing.T, root string) {
         writeGraphFile(t, filepath.Join(root, "node_modules", "fixture-package", "dist", "first.js"), "export function winner() {}\n")
       },
+      wantDiagnostic: "node_modules/fixture-package/dist/first.js",
     },
     {
       name: "conditional_package_exports",
@@ -211,8 +213,10 @@ func TestServeSessionReloadsSupersedingModuleCandidates(t *testing.T) {
       if err != nil {
         t.Fatal(err)
       }
-      if dump == nil || mode != serveModeReload || !changed || (want != "" && !hasDumpNodeAt(*dump, "winner", want)) {
-        t.Fatalf("superseding candidate = dump:%v mode:%q changed:%v want-file:%q", dump != nil, mode, changed, want)
+      if dump == nil || mode != serveModeReload || !changed ||
+        (want != "" && !hasDumpNodeAt(*dump, "winner", want)) ||
+        (test.wantDiagnostic != "" && !hasDumpDiagnosticContaining(*dump, test.wantDiagnostic)) {
+        t.Fatalf("superseding candidate = dump:%v mode:%q changed:%v want-file:%q want-diagnostic:%q", dump != nil, mode, changed, want, test.wantDiagnostic)
       }
     })
   }
@@ -222,6 +226,15 @@ func hasDumpNodeAt(dump graph.Dump, name, fileSuffix string) bool {
   suffix := filepath.ToSlash(fileSuffix)
   for _, node := range dump.Nodes {
     if node.Name == name && strings.HasSuffix(filepath.ToSlash(node.File), suffix) {
+      return true
+    }
+  }
+  return false
+}
+
+func hasDumpDiagnosticContaining(dump graph.Dump, fragment string) bool {
+  for _, diagnostic := range dump.Diagnostics {
+    if strings.Contains(filepath.ToSlash(diagnostic.Message), filepath.ToSlash(fragment)) {
       return true
     }
   }

--- a/packages/ttsc/cmd/ttscgraph/serve_shards.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_shards.go
@@ -1238,6 +1238,9 @@ func invalidatedGraphFiles(
 func authoredGraphFiles(program *driver.Program) map[string]bool {
   authored := map[string]bool{}
   for _, file := range program.SourceFiles() {
+    if !graph.IsWorkspaceSourceFile(file) {
+      continue
+    }
     authored[file.FileName()] = true
   }
   return authored
@@ -1248,6 +1251,9 @@ func reverseGraphDependencies(program *driver.Program) map[string][]string {
   authored := map[string]bool{}
   authoredByPath := map[string]string{}
   for _, file := range program.SourceFiles() {
+    if !graph.IsWorkspaceSourceFile(file) {
+      continue
+    }
     authored[file.FileName()] = true
     authoredByPath[string(file.Path())] = file.FileName()
   }
@@ -1263,6 +1269,9 @@ func reverseGraphDependencies(program *driver.Program) map[string][]string {
     values[dependent] = true
   }
   for _, source := range program.SourceFiles() {
+    if !graph.IsWorkspaceSourceFile(source) {
+      continue
+    }
     for _, referencedPath := range shimcompiler.GetReferencedFilePaths(program.TSProgram, source) {
       if target, ok := authoredByPath[referencedPath]; ok {
         add(target, source.FileName())
@@ -1306,7 +1315,7 @@ func serveGraphResolutionDigests(program *driver.Program, project string) (map[s
 
 func graphSourceFile(program *driver.Program, file string) *shimast.SourceFile {
   for _, source := range program.SourceFiles() {
-    if source.FileName() == file {
+    if graph.IsWorkspaceSourceFile(source) && source.FileName() == file {
       return source
     }
   }

--- a/packages/ttsc/cmd/ttscgraph/serve_shards.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_shards.go
@@ -133,7 +133,7 @@ func (s *graphSession) buildShardSnapshot(change *graphChange) (*serveGraphSnaps
   if change.full || s.graphStore == nil {
     return s.buildFullShardSnapshot()
   }
-  return s.buildIncrementalShardSnapshot(change.files, change.publicFiles)
+  return s.buildIncrementalShardSnapshot(change)
 }
 
 func (s *graphSession) buildFullShardSnapshot() (*serveGraphSnapshot, *serveGraphStore, error) {
@@ -227,15 +227,15 @@ func (s *graphSession) buildFullShardSnapshot() (*serveGraphSnapshot, *serveGrap
   return snapshot, store, nil
 }
 
-func (s *graphSession) buildIncrementalShardSnapshot(changed, publicChanged []string) (*serveGraphSnapshot, *serveGraphStore, error) {
+func (s *graphSession) buildIncrementalShardSnapshot(change *graphChange) (*serveGraphSnapshot, *serveGraphStore, error) {
   prior := s.graphStore
   program := s.compiler.Program()
-  selected := invalidatedGraphFiles(program, prior.reverseDependencies, changed, publicChanged)
+  selected := invalidatedGraphFiles(program, prior.reverseDependencies, change.files, change.publicFiles)
   if len(selected) == 0 {
     // A changed declaration or virtual input outside the authored graph can
     // alter external endpoints and global types. Rebuild when no exact source
     // owner can be established instead of publishing an empty semantic delta.
-    return s.buildFullShardSnapshot()
+    return s.buildCompleteShardFallback(change)
   }
 
   // Re-export edges can stamp a declaration owned by a forward dependency.
@@ -286,11 +286,11 @@ func (s *graphSession) buildIncrementalShardSnapshot(changed, publicChanged []st
     prior.wireProvenance,
     prior.wireSources,
     program,
-    changed,
+    change.files,
     s.diskDigests,
   )
   if !ok {
-    return s.buildFullShardSnapshot()
+    return s.buildCompleteShardFallback(change)
   }
   identity := prior.identity
   facts, err := graph.NewDumpFacts(
@@ -307,7 +307,7 @@ func (s *graphSession) buildIncrementalShardSnapshot(changed, publicChanged []st
   for _, file := range selectedFiles {
     source := graphSourceFile(program, file)
     if source == nil {
-      return s.buildFullShardSnapshot()
+      return s.buildCompleteShardFallback(change)
     }
     selectedSources = append(selectedSources, source)
   }
@@ -457,6 +457,12 @@ func (s *graphSession) buildIncrementalShardSnapshot(changed, publicChanged []st
     extractedFiles:        append([]string{}, selectedFiles...),
   }
   return snapshot, store, nil
+}
+
+func (s *graphSession) buildCompleteShardFallback(change *graphChange) (*serveGraphSnapshot, *serveGraphStore, error) {
+  change.mode = serveModeRebuild
+  change.full = true
+  return s.buildFullShardSnapshot()
 }
 
 func commitServeGraphSnapshot(

--- a/packages/ttsc/cmd/ttscgraph/serve_shards_keep_source_distributed_dependencies_at_the_boundary_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_shards_keep_source_distributed_dependencies_at_the_boundary_test.go
@@ -85,9 +85,9 @@ func TestServeShardsKeepSourceDistributedDependenciesAtTheBoundary(t *testing.T)
   if replacement == nil {
     t.Fatal("dependency edit did not publish a shard snapshot")
   }
-  if mode != serveModeIncremental || !changed || len(replacement.Upserts) != len(replacement.Manifest) {
+  if mode != serveModeRebuild || !changed || len(replacement.Upserts) != len(replacement.Manifest) {
     t.Fatalf(
-      "dependency edit should reuse the compiler and publish every shard: mode=%q changed=%v manifest=%d upserts=%d",
+      "dependency edit should report and publish a complete rebuild: mode=%q changed=%v manifest=%d upserts=%d",
       mode,
       changed,
       len(replacement.Manifest),

--- a/packages/ttsc/cmd/ttscgraph/serve_shards_keep_source_distributed_dependencies_at_the_boundary_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_shards_keep_source_distributed_dependencies_at_the_boundary_test.go
@@ -78,16 +78,17 @@ func TestServeShardsKeepSourceDistributedDependenciesAtTheBoundary(t *testing.T)
   }
 
   writeGraphFile(t, dependencyPath, "export function dependencyValue(): number { return 2; }\nexport function dependencyInternal(): number { return dependencyValue(); }\n")
-  replacement, _, changed, err := session.SnapshotShards()
+  replacement, mode, changed, err := session.SnapshotShards()
   if err != nil {
     t.Fatal(err)
   }
   if replacement == nil {
     t.Fatal("dependency edit did not publish a shard snapshot")
   }
-  if !changed || len(replacement.Upserts) != len(replacement.Manifest) {
+  if mode != serveModeIncremental || !changed || len(replacement.Upserts) != len(replacement.Manifest) {
     t.Fatalf(
-      "dependency edit should publish every shard: changed=%v manifest=%d upserts=%d",
+      "dependency edit should reuse the compiler and publish every shard: mode=%q changed=%v manifest=%d upserts=%d",
+      mode,
       changed,
       len(replacement.Manifest),
       len(replacement.Upserts),

--- a/packages/ttsc/cmd/ttscgraph/serve_shards_keep_source_distributed_dependencies_at_the_boundary_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_shards_keep_source_distributed_dependencies_at_the_boundary_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestServeShardsKeepSourceDistributedDependenciesAtTheBoundary proves the
+// incremental store owns only workspace declarations while provenance still
+// attests to every source the resident checker loaded.
+func TestServeShardsKeepSourceDistributedDependenciesAtTheBoundary(t *testing.T) {
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs", "strict": true },
+  "files": ["src/main.ts"]
+}`)
+  writeGraphFile(t, filepath.Join(root, "node_modules", "dep-src", "package.json"), `{
+  "name": "dep-src",
+  "version": "1.0.0",
+  "main": "src/index.ts"
+}`)
+  writeGraphFile(t, filepath.Join(root, "node_modules", "dep-src", "src", "index.ts"), "export function dependencyValue(): number { return 1; }\nexport function dependencyInternal(): number { return dependencyValue(); }\n")
+  writeGraphFile(t, filepath.Join(root, "src", "main.ts"), "import { dependencyValue } from 'dep-src';\nexport function workspaceValue(): number { return dependencyValue() + 1; }\n")
+
+  session, err := newGraphSession(root, "tsconfig.json")
+  if err != nil {
+    t.Fatal(err)
+  }
+  defer session.Close()
+  if snapshot, _, _, err := session.SnapshotShards(); err != nil || snapshot == nil {
+    t.Fatalf("initial shard snapshot = snapshot:%v error:%v", snapshot != nil, err)
+  }
+
+  dependencyFile := ""
+  for _, source := range session.graphStore.provenance.Sources {
+    if strings.Contains(filepath.ToSlash(source.File), "/node_modules/dep-src/") {
+      dependencyFile = source.File
+      break
+    }
+  }
+  if dependencyFile == "" {
+    t.Fatal("raw dependency source is absent from provenance")
+  }
+  for _, file := range session.graphStore.extractedFiles {
+    if file == dependencyFile {
+      t.Fatalf("raw dependency source was treated as an authored extraction: %v", session.graphStore.extractedFiles)
+    }
+  }
+  dependencyShard, ok := session.graphStore.shards[session.graphStore.sourceKeys[dependencyFile]]
+  if !ok || dependencyShard.shard.Source == nil {
+    t.Fatalf("dependency provenance shard missing for %q", dependencyFile)
+  }
+  if len(dependencyShard.shard.Nodes) != 0 || len(dependencyShard.shard.Edges) != 0 {
+    t.Fatalf("dependency provenance shard owns graph facts: nodes=%v edges=%v", dependencyShard.shard.Nodes, dependencyShard.shard.Edges)
+  }
+
+  boundaryFound := false
+  for _, node := range session.graphStore.nodes {
+    normalized := filepath.ToSlash(node.File)
+    if strings.Contains(normalized, "/node_modules/dep-src/") {
+      if !node.External || node.Name != "dependencyValue" {
+        t.Fatalf("unexpected dependency graph node: %+v", node)
+      }
+      boundaryFound = true
+    }
+  }
+  if !boundaryFound {
+    t.Fatal("referenced dependency boundary leaf is absent")
+  }
+  assertServeShardFactsMatchFullDump(t, session)
+}

--- a/packages/ttsc/cmd/ttscgraph/serve_shards_keep_source_distributed_dependencies_at_the_boundary_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_shards_keep_source_distributed_dependencies_at_the_boundary_test.go
@@ -9,8 +9,14 @@ import (
 // TestServeShardsKeepSourceDistributedDependenciesAtTheBoundary proves the
 // incremental store owns only workspace declarations while provenance still
 // attests to every source the resident checker loaded.
+//
+// 1. Snapshot one workspace source that imports a raw TypeScript package.
+// 2. Assert the dependency owns provenance but no authored graph facts.
+// 3. Edit the dependency and assert the store publishes a complete replacement.
+// 4. Compare the replacement store with the full-dump oracle.
 func TestServeShardsKeepSourceDistributedDependenciesAtTheBoundary(t *testing.T) {
   root := t.TempDir()
+  dependencyPath := filepath.Join(root, "node_modules", "dep-src", "src", "index.ts")
   writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
   "compilerOptions": { "target": "ES2022", "module": "commonjs", "strict": true },
   "files": ["src/main.ts"]
@@ -20,7 +26,7 @@ func TestServeShardsKeepSourceDistributedDependenciesAtTheBoundary(t *testing.T)
   "version": "1.0.0",
   "main": "src/index.ts"
 }`)
-  writeGraphFile(t, filepath.Join(root, "node_modules", "dep-src", "src", "index.ts"), "export function dependencyValue(): number { return 1; }\nexport function dependencyInternal(): number { return dependencyValue(); }\n")
+  writeGraphFile(t, dependencyPath, "export function dependencyValue(): number { return 1; }\nexport function dependencyInternal(): number { return dependencyValue(); }\n")
   writeGraphFile(t, filepath.Join(root, "src", "main.ts"), "import { dependencyValue } from 'dep-src';\nexport function workspaceValue(): number { return dependencyValue() + 1; }\n")
 
   session, err := newGraphSession(root, "tsconfig.json")
@@ -33,9 +39,11 @@ func TestServeShardsKeepSourceDistributedDependenciesAtTheBoundary(t *testing.T)
   }
 
   dependencyFile := ""
+  dependencyDigest := ""
   for _, source := range session.graphStore.provenance.Sources {
     if strings.Contains(filepath.ToSlash(source.File), "/node_modules/dep-src/") {
       dependencyFile = source.File
+      dependencyDigest = source.Checker
       break
     }
   }
@@ -67,6 +75,33 @@ func TestServeShardsKeepSourceDistributedDependenciesAtTheBoundary(t *testing.T)
   }
   if !boundaryFound {
     t.Fatal("referenced dependency boundary leaf is absent")
+  }
+
+  writeGraphFile(t, dependencyPath, "export function dependencyValue(): number { return 2; }\nexport function dependencyInternal(): number { return dependencyValue(); }\n")
+  replacement, _, changed, err := session.SnapshotShards()
+  if err != nil {
+    t.Fatal(err)
+  }
+  if replacement == nil {
+    t.Fatal("dependency edit did not publish a shard snapshot")
+  }
+  if !changed || len(replacement.Upserts) != len(replacement.Manifest) {
+    t.Fatalf(
+      "dependency edit should publish every shard: changed=%v manifest=%d upserts=%d",
+      changed,
+      len(replacement.Manifest),
+      len(replacement.Upserts),
+    )
+  }
+  dependencyDigestChanged := false
+  for _, source := range session.graphStore.provenance.Sources {
+    if source.File == dependencyFile && source.Checker != dependencyDigest {
+      dependencyDigestChanged = true
+      break
+    }
+  }
+  if !dependencyDigestChanged {
+    t.Fatal("raw dependency edit did not refresh checker provenance")
   }
   assertServeShardFactsMatchFullDump(t, session)
 }

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -513,8 +513,10 @@ func ApplySourcePreamble(text string, preamble string) string {
   return bom + preamble + rest
 }
 
-// SourceFiles exposes the program's user-authored source files (declaration
-// files filtered out).
+// SourceFiles exposes the program's resident non-declaration source files.
+// Imported implementation files from source-distributed dependencies can be
+// present; consumers that need project-owned files must apply their own root
+// predicate.
 func (p *Program) SourceFiles() []*ast.SourceFile {
   // Discarded on purpose; see SourceFile. `Diagnostics` carries the failure.
   _ = p.ApplyLinkedPlugins()

--- a/packages/ttsc/internal/graph/build.go
+++ b/packages/ttsc/internal/graph/build.go
@@ -9,10 +9,10 @@ import (
 )
 
 // Build walks the program's user-authored source files and records a node for
-// each top-level declaration. driver.SourceFiles already drops declaration files
-// and the program never compiles a dependency's `.ts`, so every node Build emits
-// is workspace source: External is false. External boundary leaves enter the
-// graph only as the resolved target of an edge (see Resolve).
+// each top-level declaration. The checker can load a dependency's raw `.ts`
+// entry, so IsWorkspaceSourceFile owns the declaration boundary instead of
+// assuming every non-declaration source is authored here. External boundary
+// leaves enter the graph only as the resolved target of an edge (see Resolve).
 func Build(prog *driver.Program) *Graph {
   return BuildFiles(prog, nil, nil)
 }
@@ -45,6 +45,9 @@ func BuildFiles(prog *driver.Program, selected []string, baseNodes map[string]*N
     ImplementationSources: map[string]map[string]bool{},
   }
   for _, file := range prog.SourceFiles() {
+    if !IsWorkspaceSourceFile(file) {
+      continue
+    }
     if selected != nil && !selectedFiles[file.FileName()] {
       continue
     }

--- a/packages/ttsc/internal/graph/build.go
+++ b/packages/ttsc/internal/graph/build.go
@@ -8,7 +8,7 @@ import (
   "github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
-// Build walks the program's user-authored source files and records a node for
+// Build walks the program's workspace source files and records a node for
 // each top-level declaration. The checker can load a dependency's raw `.ts`
 // entry, so IsWorkspaceSourceFile owns the declaration boundary instead of
 // assuming every non-declaration source is authored here. External boundary

--- a/packages/ttsc/internal/graph/build_keeps_source_distributed_dependencies_at_the_external_boundary_test.go
+++ b/packages/ttsc/internal/graph/build_keeps_source_distributed_dependencies_at_the_external_boundary_test.go
@@ -12,6 +12,10 @@ import (
 // package whose public entry is raw TypeScript remains a referenced leaf rather
 // than becoming authored graph content. The resident source text is retained as
 // provenance evidence even though its declarations are not walked.
+//
+// 1. Load one workspace source that imports a raw TypeScript package entry.
+// 2. Assert only the referenced dependency symbol becomes an external leaf.
+// 3. Assert provenance retains the dependency source text without its facts.
 func TestBuildKeepsSourceDistributedDependenciesAtTheExternalBoundary(t *testing.T) {
   root := t.TempDir()
   writeFile(t, filepath.Join(root, "tsconfig.json"), `{

--- a/packages/ttsc/internal/graph/build_keeps_source_distributed_dependencies_at_the_external_boundary_test.go
+++ b/packages/ttsc/internal/graph/build_keeps_source_distributed_dependencies_at_the_external_boundary_test.go
@@ -1,0 +1,70 @@
+package graph
+
+import (
+  "path/filepath"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestBuildKeepsSourceDistributedDependenciesAtTheExternalBoundary proves a
+// package whose public entry is raw TypeScript remains a referenced leaf rather
+// than becoming authored graph content. The resident source text is retained as
+// provenance evidence even though its declarations are not walked.
+func TestBuildKeepsSourceDistributedDependenciesAtTheExternalBoundary(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs", "strict": true },
+  "files": ["src/main.ts"]
+}
+`)
+  writeFile(t, filepath.Join(root, "node_modules", "dep-src", "package.json"), `{
+  "name": "dep-src",
+  "version": "1.0.0",
+  "main": "src/index.ts"
+}
+`)
+  writeFile(t, filepath.Join(root, "node_modules", "dep-src", "src", "index.ts"), `export function dependencyValue(): number { return 1; }
+export function dependencyInternal(): number { return dependencyValue(); }
+`)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), `import { dependencyValue } from "dep-src";
+export function workspaceValue(): number { return dependencyValue() + 1; }
+`)
+
+  program, diagnostics, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diagnostics) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diagnostics)
+  }
+  defer func() { _ = program.Close() }()
+
+  built := Build(program)
+  dependency := findNodeByName(built, "dependencyValue")
+  if dependency == nil || !dependency.External || !strings.Contains(filepath.ToSlash(dependency.File), "/node_modules/dep-src/") {
+    t.Fatalf("dependencyValue should be one external boundary leaf: %+v", dependency)
+  }
+  if internal := findNodeByName(built, "dependencyInternal"); internal != nil {
+    t.Fatalf("unreferenced dependency implementation leaked into the authored graph: %+v", internal)
+  }
+  workspace := findNodeByName(built, "workspaceValue")
+  if workspace == nil || workspace.External {
+    t.Fatalf("workspaceValue should remain authored source: %+v", workspace)
+  }
+  if !hasEdge(built, workspace.ID, dependency.ID, EdgeValueCall) {
+    t.Fatalf("missing workspaceValue -> dependencyValue boundary call: %v", built.Edges)
+  }
+
+  dependencyTextRetained := false
+  for file := range SourceTexts(program) {
+    if strings.Contains(filepath.ToSlash(file), "/node_modules/dep-src/") {
+      dependencyTextRetained = true
+      break
+    }
+  }
+  if !dependencyTextRetained {
+    t.Fatal("resident dependency source was removed from provenance text")
+  }
+}

--- a/packages/ttsc/internal/graph/edges.go
+++ b/packages/ttsc/internal/graph/edges.go
@@ -21,6 +21,9 @@ import (
 func (g *Graph) addEdges(prog *driver.Program, selected map[string]bool, partial bool) {
   checker := prog.Checker
   for _, file := range prog.SourceFiles() {
+    if !IsWorkspaceSourceFile(file) {
+      continue
+    }
     if partial && !selected[file.FileName()] {
       continue
     }

--- a/packages/ttsc/internal/graph/graph.go
+++ b/packages/ttsc/internal/graph/graph.go
@@ -199,10 +199,10 @@ type Graph struct {
   Nodes map[string]*Node
   Edges []*Edge
   // Decorators holds the decorators written on the workspace's declarations,
-  // captured syntactically so the JSON dump can emit `decorates` edges and a
-  // consumer can interpret `@Controller`/`@Get` conventions without re-parsing
-  // source. It is dump-only metadata, separate from Edges so the existing
-  // checker-resolved relationships are untouched.
+  // captured syntactically so the JSON dump can attach raw facts to each target
+  // node and a consumer can interpret `@Controller`/`@Get` conventions without
+  // re-parsing source. It is dump-only metadata, separate from Edges so the
+  // existing checker-resolved relationships are untouched.
   Decorators []*Decorator
   // bodyNodes tracks whether a callable node's display span is the overload
   // implementation rather than an overload signature. It is build-only metadata

--- a/packages/ttsc/internal/graph/graph_kind_contracts_match_their_producers_test.go
+++ b/packages/ttsc/internal/graph/graph_kind_contracts_match_their_producers_test.go
@@ -1,0 +1,121 @@
+package graph
+
+import (
+  "os"
+  "path/filepath"
+  "regexp"
+  "sort"
+  "testing"
+)
+
+// TestGraphKindContractsMatchTheirProducers keeps the hand-authored TypeScript
+// unions exact: raw dump kinds equal the Go producer, general kinds add only the
+// TypeScript memory/trace synthesis, and modifiers equal the emitted flag table.
+//
+// 1. Read every published graph-kind and modifier union.
+// 2. Derive raw dump values from the native constants and wire mapping.
+// 3. Apply the memory layer's module fold and synthetic kinds.
+// 4. Assert every published union equals its producer set exactly.
+func TestGraphKindContractsMatchTheirProducers(t *testing.T) {
+  structures := filepath.Join("..", "..", "..", "graph", "src", "structures")
+  rawNodes := stringUnion(t, filepath.Join(structures, "TtscGraphDumpNodeKind.ts"), "TtscGraphDumpNodeKind")
+  rawEdges := stringUnion(t, filepath.Join(structures, "TtscGraphDumpEdgeKind.ts"), "TtscGraphDumpEdgeKind")
+  nodes := stringUnion(t, filepath.Join(structures, "TtscGraphNodeKind.ts"), "TtscGraphNodeKind")
+  edges := stringUnion(t, filepath.Join(structures, "TtscGraphEdgeKind.ts"), "TtscGraphEdgeKind")
+  modifiers := stringUnion(t, filepath.Join(structures, "TtscGraphNodeModifier.ts"), "TtscGraphNodeModifier")
+
+  source, err := os.ReadFile("graph.go")
+  if err != nil {
+    t.Fatalf("read graph.go: %v", err)
+  }
+  nodeConstants := sourceConstants(t, source, `(?m)^\s*Node[A-Za-z0-9_]*\s+NodeKind\s*=\s*"([^"]+)"`)
+  edgeConstants := sourceConstants(t, source, `(?m)^\s*Edge[A-Za-z0-9_]*\s+EdgeKind\s*=\s*"([^"]+)"`)
+
+  assertStringSet(t, "raw dump node kinds", rawNodes, nodeConstants)
+  assertStringSet(t, "raw dump edge kinds", rawEdges, producedWireEdgeKinds(edgeConstants))
+  memoryNodeKinds := withoutString(nodeConstants, "module")
+  assertStringSet(t, "general graph node kinds", nodes, append(memoryNodeKinds, "file", "property"))
+  assertStringSet(t, "general graph edge kinds", edges, append(append([]string{}, producedWireEdgeKinds(edgeConstants)...), "contains", "dispatches"))
+
+  emittedModifiers := make([]string, 0, len(modifierFlagStrings))
+  for _, modifier := range modifierFlagStrings {
+    emittedModifiers = append(emittedModifiers, modifier.text)
+  }
+  assertStringSet(t, "graph node modifiers", modifiers, emittedModifiers)
+}
+
+func withoutString(values []string, excluded string) []string {
+  out := make([]string, 0, len(values))
+  for _, value := range values {
+    if value != excluded {
+      out = append(out, value)
+    }
+  }
+  return out
+}
+
+func stringUnion(t *testing.T, path, name string) []string {
+  t.Helper()
+  source, err := os.ReadFile(path)
+  if err != nil {
+    t.Fatalf("read %s: %v", path, err)
+  }
+  declaration := regexp.MustCompile(`(?s)export type ` + regexp.QuoteMeta(name) + `\s*=\s*(.*?);`).FindSubmatch(source)
+  if declaration == nil {
+    t.Fatalf("find exported union %s in %s", name, path)
+  }
+  return sourceConstants(t, declaration[1], `"([^"]+)"`)
+}
+
+func sourceConstants(t *testing.T, source []byte, pattern string) []string {
+  t.Helper()
+  matches := regexp.MustCompile(pattern).FindAllSubmatch(source, -1)
+  if len(matches) == 0 {
+    t.Fatalf("no string constants matched %q", pattern)
+  }
+  values := make([]string, 0, len(matches))
+  for _, match := range matches {
+    values = append(values, string(match[1]))
+  }
+  return values
+}
+
+func producedWireEdgeKinds(constants []string) []string {
+  values := map[string]bool{}
+  for _, constant := range constants {
+    kind := EdgeKind(constant)
+    origins := []string{""}
+    switch kind {
+    case EdgeValueCall:
+      origins = []string{"call", "new", "jsx", "tagged"}
+    case EdgeHeritage:
+      origins = []string{"extends", "implements"}
+    case EdgeMemberRelation:
+      origins = []string{"implements", "overrides"}
+    }
+    for _, origin := range origins {
+      values[wireEdgeKind(kind, origin)] = true
+    }
+  }
+  out := make([]string, 0, len(values))
+  for value := range values {
+    out = append(out, value)
+  }
+  return out
+}
+
+func assertStringSet(t *testing.T, name string, got, want []string) {
+  t.Helper()
+  got = append([]string{}, got...)
+  want = append([]string{}, want...)
+  sort.Strings(got)
+  sort.Strings(want)
+  if len(got) != len(want) {
+    t.Fatalf("%s = %v, want %v", name, got, want)
+  }
+  for i := range got {
+    if got[i] != want[i] {
+      t.Fatalf("%s = %v, want %v", name, got, want)
+    }
+  }
+}

--- a/packages/ttsc/internal/graph/node_modifiers_emit_union_strings_test.go
+++ b/packages/ttsc/internal/graph/node_modifiers_emit_union_strings_test.go
@@ -87,7 +87,7 @@ export const enum Mode {
   union := map[string]bool{
     "export": true, "default": true, "declare": true, "abstract": true,
     "static": true, "readonly": true, "async": true, "const": true,
-    "public": true, "private": true, "protected": true, "optional": true,
+    "public": true, "private": true, "protected": true,
   }
   for _, n := range dump.Nodes {
     for _, m := range n.Modifiers {

--- a/packages/ttsc/internal/graph/resolve.go
+++ b/packages/ttsc/internal/graph/resolve.go
@@ -18,8 +18,6 @@
 package graph
 
 import (
-  "strings"
-
   shimast "github.com/microsoft/typescript-go/shim/ast"
   shimchecker "github.com/microsoft/typescript-go/shim/checker"
 )
@@ -80,8 +78,7 @@ func Resolve(checker *shimchecker.Checker, ref *shimast.Node) *Target {
     target.End = declaration.End()
     if file := shimast.GetSourceFileOfNode(declaration); file != nil {
       target.File = file.FileName()
-      target.External = file.IsDeclarationFile ||
-        strings.Contains(target.File, "/node_modules/")
+      target.External = !IsWorkspaceSourceFile(file)
     }
   }
   return target

--- a/packages/ttsc/internal/graph/source.go
+++ b/packages/ttsc/internal/graph/source.go
@@ -1,0 +1,23 @@
+package graph
+
+import (
+  "strings"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+)
+
+// IsWorkspaceSourceFile reports whether file owns declarations and outgoing
+// facts in the project graph. Declaration files and sources physically resident
+// under node_modules are external boundary inputs even when the checker loads a
+// package's raw TypeScript entry for type checking.
+//
+// Symlinked workspace packages remain authored source: the checker resolves the
+// default preserveSymlinks=false path to their real workspace location before
+// this predicate sees it.
+func IsWorkspaceSourceFile(file *shimast.SourceFile) bool {
+  if file == nil || file.IsDeclarationFile {
+    return false
+  }
+  normalized := strings.ReplaceAll(file.FileName(), "\\", "/")
+  return !strings.Contains("/"+strings.TrimPrefix(normalized, "/"), "/node_modules/")
+}

--- a/packages/ttsc/test/driver/program_sources_and_raw_emit_test.go
+++ b/packages/ttsc/test/driver/program_sources_and_raw_emit_test.go
@@ -22,8 +22,8 @@ import (
 func TestDriverProgramSourcesAndRawEmit(t *testing.T) {
   root := t.TempDir()
 
-  // Scenario setup: the declaration file is included deliberately so
-  // SourceFiles can prove it exposes user-authored implementation files only.
+  // Scenario setup: the declaration file is included deliberately so this
+  // fixture can prove SourceFiles excludes declaration entries.
   writeProjectFile(t, root, "tsconfig.json", `{
   "compilerOptions": {
     "module": "commonjs",

--- a/tests/test-graph/src/features/test_ttscgraph_view_payload_drops_git_ignored_generated_code.ts
+++ b/tests/test-graph/src/features/test_ttscgraph_view_payload_drops_git_ignored_generated_code.ts
@@ -39,7 +39,7 @@ export const test_ttscgraph_view_payload_drops_git_ignored_generated_code =
         {
           id: "e",
           name: "external",
-          kind: "external_symbol",
+          kind: "function",
           file: "node_modules/x/index.d.ts",
           external: true,
         },

--- a/website/src/content/docs/development/concepts/tsgo.mdx
+++ b/website/src/content/docs/development/concepts/tsgo.mdx
@@ -99,7 +99,7 @@ diags := prog.Diagnostics()     // pre-deduped, unused-overload-signature noise 
 checker := prog.Checker         // ready to query
 ```
 
-`prog.SourceFiles()` filters declaration files for you. `prog.Diagnostics()` runs `GetDiagnosticsOfAnyProgram` + `SortAndDeduplicateDiagnostics`. Always `defer prog.Close()`, without it the checker pool fills up and subsequent loads stall.
+`prog.SourceFiles()` filters declaration files for you, but imported raw TypeScript or JavaScript dependencies can still be resident in the returned implementation-source set. `prog.Diagnostics()` runs `GetDiagnosticsOfAnyProgram` + `SortAndDeduplicateDiagnostics`. Always `defer prog.Close()`, without it the checker pool fills up and subsequent loads stall.
 
 Most shipped third-party-shaped consumers in this repo use this path:
 
@@ -112,7 +112,7 @@ For the full driver surface (rewrites, emit, source preambles, LSP host), see [R
 
 ## Finding the Target File
 
-`prog.SourceFiles()` returns every user file in the Program (declaration files are filtered). Normalize paths before comparing:
+`prog.SourceFiles()` returns every resident non-declaration implementation file in the Program, including imported raw TypeScript or JavaScript dependencies. Normalize paths before comparing:
 
 ```go
 func findSourceFile(prog *driver.Program, target string) *shimast.SourceFile {
@@ -611,7 +611,7 @@ The page-level traps:
 - Comparing raw paths without `filepath.ToSlash`.
 - Slicing `file.Text()[node.Pos():node.End()]` and accidentally including comments/whitespace.
 - Calling `AsX()` and assuming it cannot be nil.
-- Walking declaration files when you meant user code (use `prog.SourceFiles()`; it filters them).
+- Treating `prog.SourceFiles()` as project ownership: it filters declarations, but imported raw TypeScript or JavaScript dependencies can remain, so filter roots when you mean project-owned code.
 - Treating a type node as a resolved type.
 - Editing text when an AST mutation would express the same change.
 - Editing text from the start of the file toward the end.

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -31,7 +31,7 @@ checker := prog.Checker                  // type-aware queries
 - builds the tsgo `Program` through `shim/compiler.NewProgram` and leases a `*shimchecker.Checker` from the pool.
 - returns a `*driver.Program` carrying the parsed config, the host, the FS, and the lease release function.
 
-`Program.SourceFiles()` filters declaration files for you. `Program.Diagnostics()` runs `GetDiagnosticsOfAnyProgram` + `SortAndDeduplicateDiagnostics` and drops the unused-overload-signature noise that tsgo emits internally. **Always `defer prog.Close()`**, without it the checker pool fills up and subsequent loads stall.
+`Program.SourceFiles()` returns the Program's resident non-declaration implementation files. Imported raw TypeScript or JavaScript dependencies can be present, so a consumer that needs project-owned files must apply its own root predicate. `Program.Diagnostics()` runs `GetDiagnosticsOfAnyProgram` + `SortAndDeduplicateDiagnostics` and drops the unused-overload-signature noise that tsgo emits internally. **Always `defer prog.Close()`**, without it the checker pool fills up and subsequent loads stall.
 
 ## Emit
 

--- a/website/src/content/docs/development/walkthroughs/paths.mdx
+++ b/website/src/content/docs/development/walkthroughs/paths.mdx
@@ -490,7 +490,7 @@ When in doubt, set both. The cost is zero and the failure mode is silent.
 The pattern generalizes to any plugin that needs to query _project-level_ information:
 
 - Need `compilerOptions.target` / `module` / `jsx`? Read them from `prog.ParsedConfig.ParsedConfig.CompilerOptions`.
-- Need the list of user source files? `prog.SourceFiles()`.
+- Need the resident non-declaration implementation files? `prog.SourceFiles()`; imported raw TypeScript or JavaScript dependencies can be present, so apply an ownership predicate when you need project files only.
 - Need types? `prog.Checker.GetTypeAtLocation(node)`. See [AST & Checker → Checker Basics](/docs/development/concepts/tsgo#checker-basics).
 - Need `tsconfig.json` extends-chain or include paths? `prog.ParsedConfig.ParsedConfig` carries the resolved configuration.
 

--- a/website/src/content/docs/development/walkthroughs/strip.mdx
+++ b/website/src/content/docs/development/walkthroughs/strip.mdx
@@ -264,7 +264,7 @@ func (plugin) ApplyProgram(prog *driver.Program, ctx driver.PluginContext) error
 
 `loadStripConfigMap` (in `driver/config.go`) rejects unsupported inline keys on the tsconfig entry, then resolves the config file: an explicit `configFile` wins, otherwise `strip.config.*` is discovered by upward walk. The resulting map feeds `parseStrip` from step 1.
 
-`prog.SourceFiles()` already drops declaration files, so `file` is always user-authored TypeScript.
+`prog.SourceFiles()` drops declaration files, but it returns every non-declaration implementation source resident in the Program, including imported raw TypeScript or JavaScript dependencies. This plugin deliberately applies the strip rules to that complete implementation-source set; filter paths explicitly if a plugin should mutate project-owned files only.
 
 Then `(*stripRewriter).apply`:
 

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -62,7 +62,7 @@ A text search or a tree-sitter parse stops where the syntax stops. A real type c
 - **pnpm / workspace monorepos.** A `workspace:*` dependency is followed into the sibling package's real source. A call across packages lands on the true declaration, not the barrel it passed through.
 - **Path aliases.** A `@app/*` import from `tsconfig` is resolved to the real file, so the edge is right where a text tool sees only the alias string.
 - **Barrel re-exports.** An `index.ts` that only re-exports is unwrapped to the file that actually declares the symbol.
-- **Your code vs the world.** Anything in `node_modules` or a `.d.ts` is reported as an outside boundary, not walked into. The graph stays your code.
+- **Your code vs the world.** Anything in `node_modules` or a `.d.ts` is reported as an outside boundary, not walked into. This includes packages whose entry point is raw `.ts`: the compiler may load that source for type checking, but the graph still stops at the imported symbol. The graph stays your code.
 - **Generated code stays out of the way.** A source file your `.gitignore` covers, such as a Prisma client or other codegen emitted as `.ts`, is de-ranked: it never dominates a broad or keyword match, though it stays reachable as an edge target and by its exact name. The graph surfaces what you wrote, not what a generator did.
 - **Object-literal ownership.** `details` lists direct, statically named properties in declaration order. Spread properties do not promote names from another object, dynamic computed names are omitted, and nested members stay with their nested object.
 


### PR DESCRIPTION
## Intent

Resolve the complete accepted set from the residual-issue campaign: preserve the workspace boundary for source-distributed dependencies, make the published graph-kind contract match its real producers, and move the post-migration benchmark workflow onto declared Node.js 24 action runtimes.

Issues: #1057, #1059, #1061.

## Discovery gate

The campaign baseline is `228ecf0211c489f858c53fd828a358a52514de5d`. Round 1 reviewed every open issue and the complete 6,750-file repository surface, accepted the two reproduced graph reports, closed already-resolved #1055 with evidence, and published the independently verified benchmark-runtime regression as #1061.

Round 2 restarted from the unchanged baseline and independently repeated the complete scope, including all 228 files changed since the previous empty campaign, generated contracts, dependencies, workflows, package and test ownership, failure paths, public surfaces, platforms, documentation, security markers, open-issue overlap, and exact-baseline CI. It found no new candidate. There are no overlapping open pull requests.

## Implementation

1. Keep dependency-owned raw TypeScript sources in provenance while excluding them from workspace graph declarations and shard ownership. Raw dependency edits now publish a complete replacement, report `rebuild`, refresh provenance, and preserve full retry state.
2. Split raw-dump kinds from post-fold memory/trace kinds, remove members and consumer branches with no producer, type node-kind consumer sets to the published union, and add exact Go/TypeScript producer-parity coverage.
3. Change only the four action-major scalars in `.github/workflows/benchmark.yml` to `checkout@v7`, `setup-node@v7`, `setup-go@v7`, and `pnpm/action-setup@v6`.

Every coherent implementation and review-correction commit received exactly one read-only Individual Self-Review; every finding was addressed in a separate reviewed commit and recorded as a formal PR review.

## Local verification

- `pnpm format`
- `go test ./test/driver`
- `go test ./internal/graph`
- `go test ./cmd/ttscgraph`
- `pnpm --filter @ttsc/graph exec tsc --noEmit`
- `pnpm --filter @ttsc/graph build`
- `pnpm --filter @ttsc/test-graph start`
- benchmark workflow Prettier and workflow/path contract tests

The exact-head benchmark job at `8aefa2139` passed on all four new action majors with no check annotations. The final integrated exact-head CI and solo Overall Self-Review remain merge gates.
