### PR TITLE
fix: ttsx dependency path identity, graph external edge sources, and benchmark harness references

### DIFF
--- a/.agents/skills/benchmark/graph.md
+++ b/.agents/skills/benchmark/graph.md
@@ -56,7 +56,7 @@ Never let concurrent runners write `graph.json` directly.
 
 ## Trace Audit
 
-Codex suites write `codex-trace-audit.json` automatically. Use the `graph:audit` package command only to re-audit existing output or compare before and after runs.
+Codex suites write `codex-trace-audit.json` automatically. Use the `audit` package command only to re-audit existing output or compare before and after runs.
 
 The audit records exposed assistant messages, shell and MCP calls in timeline order, per-turn usage, and `reasoning_output_tokens`. Codex does not expose hidden reasoning text; never invent it.
 

--- a/.agents/skills/benchmark/graph.md
+++ b/.agents/skills/benchmark/graph.md
@@ -52,7 +52,7 @@ pnpm --dir benchmarks/graph run publish -- --from <out-dir>
 
 Never let concurrent runners write `graph.json` directly.
 
-A relative `--out` and a relative `--from` resolve against the same directory, so name the run the same way in both. Publication refuses a source directory that holds no report instead of writing a dashboard nothing contributed to; that refusal is what keeps `--reset` from replacing the served cells with an empty set.
+A relative `--out` and a relative `--from` resolve against the same directory, so name the run the same way in both. Publication refuses a source directory that contributes no measurement, the defaulted one included, instead of writing a dashboard nothing added to; that refusal is what keeps `--reset` from replacing the served cells with an empty set.
 
 `benchmarks/graph/src/TtscBenchmarkGraphWebsiteCell.ts` is the single published-cell key. Key only by fields the website renders. Metadata such as fixture branch, reasoning effort, or setup time must not create a second visible copy of the same cell.
 

--- a/.agents/skills/benchmark/graph.md
+++ b/.agents/skills/benchmark/graph.md
@@ -52,6 +52,8 @@ pnpm --dir benchmarks/graph run publish -- --from <out-dir>
 
 Never let concurrent runners write `graph.json` directly.
 
+A relative `--out` and a relative `--from` resolve against the same directory, so name the run the same way in both. Publication refuses a source directory that holds no report instead of writing a dashboard nothing contributed to; that refusal is what keeps `--reset` from replacing the served cells with an empty set.
+
 `benchmarks/graph/src/TtscBenchmarkGraphWebsiteCell.ts` is the single published-cell key. Key only by fields the website renders. Metadata such as fixture branch, reasoning effort, or setup time must not create a second visible copy of the same cell.
 
 ## Trace Audit

--- a/.agents/skills/benchmark/performance.md
+++ b/.agents/skills/benchmark/performance.md
@@ -15,7 +15,7 @@ Cell ID is `project:branch:op:threading`.
 | Operation | `build`, `noEmit`, `eslint` (legacy only), `format` |
 | Threading | `single`, `checkers2`, `checkers4`, `checkers8`; format uses `single` and default `multi` |
 
-The detailed methodology and dashboard interpretation live in `website/src/content/docs/benchmark/performance.mdx`. The full flag and environment-variable table lives in `benchmarks/README.md`.
+The detailed methodology and dashboard interpretation live in `website/src/content/docs/benchmark/performance.mdx`. The full flag and environment-variable table lives in `benchmarks/performance/README.md`.
 
 ## Fixture Contract
 

--- a/benchmarks/graph/README.md
+++ b/benchmarks/graph/README.md
@@ -123,7 +123,7 @@ Use `pnpm --dir benchmarks/graph run audit -- --compare=<before>,<after>` on aud
 
 ## Environment overrides
 
-This table is the list. Every variable either runner reads is here.
+This table is the list. Every environment variable this package consults, `PATH` aside, is here.
 
 | Variable | Default | Meaning |
 | --- | --- | --- |

--- a/benchmarks/graph/README.md
+++ b/benchmarks/graph/README.md
@@ -23,6 +23,8 @@ pnpm --dir benchmarks/graph run publish -- --from <out-dir>             # publis
 
 `publish` is also a pnpm subcommand, so always spell these as `pnpm run <script>` rather than `pnpm <script>`.
 
+Every directory these commands take — `--out`, `--from`, `--dir`, `--report` — resolves against the current directory, which `pnpm --dir benchmarks/graph` sets to this package. A `--from` directory holding no report is refused rather than published as a run that contributed nothing.
+
 ## Layout
 
 - `src/executable/`: Short, export-free CLI bootstraps.

--- a/benchmarks/graph/README.md
+++ b/benchmarks/graph/README.md
@@ -21,9 +21,9 @@ pnpm --dir benchmarks/graph run index-time -- --all                     # cold i
 pnpm --dir benchmarks/graph run publish -- --from <out-dir>             # publish a completed --no-website suite
 ```
 
-`publish` is also a pnpm subcommand, so always spell these as `pnpm run <script>` rather than `pnpm <script>`.
+`publish` and `audit` are also pnpm subcommands, so always spell these as `pnpm run <script>` rather than `pnpm <script>`. `pnpm audit` reports dependency vulnerabilities; it is not this package's trace auditor.
 
-Every directory these commands take — `--out`, `--from`, `--dir`, `--report` — resolves against the current directory, which `pnpm --dir benchmarks/graph` sets to this package. A `--from` directory holding no report is refused rather than published as a run that contributed nothing.
+Every directory these commands take (`--out`, `--from`, `--dir`, `--report`) resolves against the current directory, which `pnpm --dir benchmarks/graph` sets to this package. A source directory that contributes no measurement, named or defaulted, is refused rather than published as a run that added nothing.
 
 ## Layout
 
@@ -123,12 +123,23 @@ Use `pnpm --dir benchmarks/graph run audit -- --compare=<before>,<after>` on aud
 
 ## Environment overrides
 
+This table is the list. Every variable either runner reads is here.
+
 | Variable | Default | Meaning |
 | --- | --- | --- |
 | `TTSC_GRAPH_BENCH_WORK` | `../graph-benchmark-work` | Fixture clone directory, checkouts only. It defaults outside the repo so a measured agent does not inherit ttsc's `CLAUDE.md` / `AGENTS.md` from a parent directory. Reports never follow it; they stay under `.work/`. |
 | `TTSC_GRAPH_BENCH_OUT` | `.work/graph/<timestamp>` | Report directory for `src/executable/index.ts`, below `--out` and above the default. |
-| `TTSC_GRAPH_BENCH_TIMEOUT_MS` | `1800000` | Per-child timeout for an agent sample (`src/executable/index.ts`) and a cold-index build step (`src/executable/index-time.ts`). |
+| `TTSC_GRAPH_BENCH_TIMEOUT_MS` | `1800000` | Timeout on every child either runner spawns: an agent cell, a comparator index build, a fixture clone or install, the trace-audit pass, and the `ttscgraph` build. Not a per-sample budget: one agent child runs `arms × --runs` samples. |
+| `TTSC_BENCH_CONCURRENCY` | unlimited | Cap on concurrently launched agent samples. A low cap keeps the host quiet enough for per-run timings and token counts to settle. |
+| `TTSC_BENCH_REQUIRE_QUIET` | - | `1` turns `src/executable/index-time.ts`'s host-load warning into a hard error. Set it for every publication run. |
+| `TTSC_BENCH_SKIP_LOAD_CHECK` | - | `1` disables that host-load check. It only ever bites on POSIX; `os.loadavg()` reports zeros on Windows. |
+| `TTSC_CLAUDE_RUN_TIMEOUT_MS` | `900000` | Budget for one Claude Code sample, when `--claude-run-timeout-ms` is not passed. |
+| `TTSC_CLAUDE_STARTUP_GRACE_MS` | `5000` | Delay before the prompt reaches a graph-arm Claude Code sample, so its MCP server is up first. `--claude-startup-grace-ms` overrides it; `0` disables the delay. |
+| `CODEX_MCP_STARTUP_TIMEOUT_SEC` | Codex's own | MCP startup timeout written into the generated Codex config, when `--mcp-startup-timeout-sec` is not passed. |
+| `CODEX_MCP_TOOL_TIMEOUT_SEC` | Codex's own | MCP tool-call timeout written into the generated Codex config, when `--mcp-tool-timeout-sec` is not passed. |
 | `CODEBASE_MEMORY_MCP_BINARY` | `codebase-memory-mcp` | Binary used by the `codebase-memory` comparator when `--codebase-memory-binary` is not passed. |
+| `TTSC_BENCH_CBM_MODE` | codebase-memory's own (`full`) | Index mode passed to `codebase-memory-mcp` (`full`, `moderate`, `fast`). `fast` is the only mode that indexes `vscode` without the full mode's memory blowup, and the mode is recorded on the cell. |
+| `CBM_LOG_LEVEL` | `warn` | Log level of the `codebase-memory` comparator's index build. |
 | `SERENA_MCP_COMMAND` | `uvx` | Command used to launch Serena when `--serena-command` is not passed. |
 | `SERENA_MCP_ARGS` | Serena's `uvx --from git+https://github.com/oraios/serena ...` args | Argument list used to launch Serena when `--serena-args` is not passed. |
 | `SERENA_SOURCE` | `git+https://github.com/oraios/serena` | Package source the Serena launcher installs from when `--serena-source` is not passed. |

--- a/benchmarks/graph/README.md
+++ b/benchmarks/graph/README.md
@@ -123,7 +123,7 @@ Use `pnpm --dir benchmarks/graph run audit -- --compare=<before>,<after>` on aud
 
 ## Environment overrides
 
-This table is the list. Every environment variable this package consults, `PATH` aside, is here.
+Every environment variable this package consults, `PATH` aside, is here.
 
 | Variable | Default | Meaning |
 | --- | --- | --- |

--- a/benchmarks/graph/README.md
+++ b/benchmarks/graph/README.md
@@ -123,7 +123,9 @@ Use `pnpm --dir benchmarks/graph run audit -- --compare=<before>,<after>` on aud
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `TTSC_GRAPH_BENCH_WORK` | `../graph-benchmark-work` | Fixture clone directory. It defaults outside the repo so a measured agent does not inherit ttsc's `CLAUDE.md` / `AGENTS.md` from a parent directory. |
+| `TTSC_GRAPH_BENCH_WORK` | `../graph-benchmark-work` | Fixture clone directory, checkouts only. It defaults outside the repo so a measured agent does not inherit ttsc's `CLAUDE.md` / `AGENTS.md` from a parent directory. Reports never follow it; they stay under `.work/`. |
+| `TTSC_GRAPH_BENCH_OUT` | `.work/graph/<timestamp>` | Report directory for `src/executable/index.ts`, below `--out` and above the default. |
+| `TTSC_GRAPH_BENCH_TIMEOUT_MS` | `1800000` | Per-child timeout for an agent sample (`src/executable/index.ts`) and a cold-index build step (`src/executable/index-time.ts`). |
 | `CODEBASE_MEMORY_MCP_BINARY` | `codebase-memory-mcp` | Binary used by the `codebase-memory` comparator when `--codebase-memory-binary` is not passed. |
 | `SERENA_MCP_COMMAND` | `uvx` | Command used to launch Serena when `--serena-command` is not passed. |
 | `SERENA_MCP_ARGS` | Serena's `uvx --from git+https://github.com/oraios/serena ...` args | Argument list used to launch Serena when `--serena-args` is not passed. |
@@ -136,6 +138,7 @@ Use `pnpm --dir benchmarks/graph run audit -- --compare=<before>,<after>` on aud
 | `.work/graph/<timestamp>/report.json` | Per-cell agent samples: tokens, cached and reasoning tokens, turns, tool calls, reads, greps, shell calls, graph calls, source touches, cost, wall time, and attempt counts. |
 | `.work/graph/<timestamp>/codex-trace-audit.json` | Codex trace audit written automatically for Codex cells: full exposed message timeline, tool-call ledger, reasoning token counts, visible-input ledger, baseline-median savings, duplicate-output exact savings, graph-replaceable shell-output surface, candidate MCP overfetch estimates, and observed later-turn prompt replay exposure. |
 | `.work/graph/structural/report.json` | Deterministic structural metrics from `src/executable/bench.ts`: load time, graph build time, and the share the build adds on top of the load it rides. |
+| `.work/graph-index/<timestamp>/report.json` | Cold index build time per (tool × fixture) from `src/executable/index-time.ts`, with the per-fixture scale block and the host it ran on. |
 | `website/public/benchmark/graph.json` | Graph dashboard data consumed by https://ttsc.dev/benchmark. `src/executable/index.ts` upserts measured agent cells by the visible axes: harness, tool, repo, prompt id or family, stable model tier, and daemon mode. Fixture branch, effort, and setup time remain metadata and never fork a visible cell. `src/executable/publish.ts` folds local reports in, replacing the `structural` block whole and upserting agent cells by key. `src/executable/index-time.ts` owns only the top-level `index` key (`{ host, scale, cells }`), upserted by (project, tool). |
 
 `.work/` is git-ignored; results are an ephemeral artifact and never committed. For parallel `--no-website` runs, publish afterward with `pnpm --dir benchmarks/graph run publish -- --from <out-dir>`; never let concurrent runners write `graph.json` directly.

--- a/benchmarks/graph/src/TtscBenchmarkGraphClaudeAgent.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphClaudeAgent.ts
@@ -25,9 +25,9 @@
 // `claude` and `go` on PATH, and a built `@ttsc/graph` (packages/graph/lib).
 //
 // Usage:
-//   pnpm --dir benchmarks/graph agent:claude -- --prompt-family=dedicated --repo=excalidraw --runs=2
-//   pnpm --dir benchmarks/graph agent:claude -- --prompt-family=common --repo=vscode --runs=4 --model=opus
-//   pnpm --dir benchmarks/graph agent:claude -- --prompt-id=typeorm-dedicated-v1 --runs=2
+//   pnpm --dir benchmarks/graph run agent:claude -- --prompt-family=dedicated --repo=excalidraw --runs=2
+//   pnpm --dir benchmarks/graph run agent:claude -- --prompt-family=common --repo=vscode --runs=4 --model=opus
+//   pnpm --dir benchmarks/graph run agent:claude -- --prompt-id=typeorm-dedicated-v1 --runs=2
 import cp from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";

--- a/benchmarks/graph/src/TtscBenchmarkGraphCodexAgent.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphCodexAgent.ts
@@ -29,9 +29,9 @@
 // `codex` (logged in) and `go` on PATH, and a built `@ttsc/graph` (packages/graph/lib).
 //
 // Usage:
-//   pnpm --dir benchmarks/graph agent:codex -- --prompt-family=dedicated --repo=excalidraw --runs=4
-//   pnpm --dir benchmarks/graph agent:codex -- --prompt-family=common --repo=vscode --runs=4
-//   pnpm --dir benchmarks/graph agent:codex -- --prompt-id=typeorm-dedicated-v1 --runs=4
+//   pnpm --dir benchmarks/graph run agent:codex -- --prompt-family=dedicated --repo=excalidraw --runs=4
+//   pnpm --dir benchmarks/graph run agent:codex -- --prompt-family=common --repo=vscode --runs=4
+//   pnpm --dir benchmarks/graph run agent:codex -- --prompt-id=typeorm-dedicated-v1 --runs=4
 import cp from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";

--- a/benchmarks/graph/src/TtscBenchmarkGraphIndexTime.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphIndexTime.ts
@@ -147,8 +147,14 @@ export namespace TtscBenchmarkGraphIndexTime {
     const tools = selectTools(
       parsed.values.tools ?? parsed.values.tool ?? "all",
     );
+    // A report is an artifact of this package, so it lands under the package
+    // work root like every sibling harness's. `workDir` is the fixture clone
+    // root, and it sits outside the repository for a reason that belongs to
+    // checkouts alone: a measured agent walks parent directories for
+    // `CLAUDE.md` and `AGENTS.md`.
     const outDir = path.resolve(
-      parsed.values.out ?? path.join(workDir, "graph-index", timestamp()),
+      parsed.values.out ??
+        path.join(TtscBenchmarkConstant.WORK_ROOT, "graph-index", timestamp()),
     );
     const reportPath = path.join(outDir, "report.json");
     const runRoot = path.join(outDir, `.run-${process.pid}`);

--- a/benchmarks/graph/src/TtscBenchmarkGraphIndexTime.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphIndexTime.ts
@@ -2,10 +2,10 @@
  * Cold index build-time benchmark for the graph tool axis: what _readiness_
  * costs before a tool can answer its first question, per (tool × fixture).
  *
- * The agent benchmark (`src/executable/graph/index.ts`) measures what a
- * question costs once a tool is ready; this runner measures the readiness
- * itself. Per cell it deletes the tool's index, runs its build step once, and
- * takes wall time:
+ * The agent benchmark (`src/executable/index.ts`) measures what a question
+ * costs once a tool is ready; this runner measures the readiness itself. Per
+ * cell it deletes the tool's index, runs its build step once, and takes wall
+ * time:
  *
  * - `ttsc-graph`: `ttscgraph dump --cwd <fixture> --tsconfig <tsconfig>` — the
  *   MCP launcher runs exactly this at startup, so the agent's first question
@@ -114,7 +114,6 @@ export namespace TtscBenchmarkGraphIndexTime {
     // Counting was correct only while the executables sat one directory deeper,
     // and it failed silently when they moved: every path below stayed a valid
     // string and pointed one level outside the repository.
-    const benchmarkRoot = TtscBenchmarkConstant.ROOT;
     const repoRoot = TtscBenchmarkConstant.REPOSITORY_ROOT;
     const ttscDir = path.join(repoRoot, "packages", "ttsc");
     const workDir = TtscBenchmarkGraph.resolveWorkDir(repoRoot);

--- a/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
@@ -215,14 +215,18 @@ export namespace TtscBenchmarkGraphPublisher {
   }
 
   /**
-   * Folds one source directory, reporting whether it changed the document.
+   * Folds one source directory, reporting whether it carried a measurement.
    *
-   * The answer counts upserted cells and a replaced structural block, not files
-   * that happened to be present. A run that produced a `report.json` whose
-   * every cell was rejected contributed nothing, and a publish that accepted it
-   * would report success for a document it did not add to - which with
-   * `--reset`, already emptied before the first fold, is how the served
-   * dashboard loses its cells.
+   * The answer counts measured cells and a structural report, not files that
+   * happened to be present: a `report.json` whose sample sets are all empty is
+   * a run that measured nothing, and a publish that accepted it would report
+   * success for a document it did not add to - which with `--reset`, already
+   * emptied before the first fold, is how the served dashboard loses its
+   * cells.
+   *
+   * A cell the publisher measured and then deliberately kept out, because what
+   * is already published is thicker, still counts. That skip is the publisher's
+   * own rule working, not an empty directory.
    */
   function foldSourceDir(
     context: IPublisherContext,
@@ -292,14 +296,22 @@ export namespace TtscBenchmarkGraphPublisher {
     );
   }
 
-  /** Folds a suite report, reporting how many cells it actually upserted. */
+  /**
+   * Folds a suite report, reporting how many of its cells carried a
+   * measurement.
+   *
+   * A cell the publisher considered and deliberately kept out of the document -
+   * one thinner than the sample set already published - still counted: the run
+   * measured it, and refusing the directory over a policy the publisher applied
+   * on purpose would fail a publish for succeeding at its own rule.
+   */
   function foldSuite(
     context: IPublisherContext,
     report: ISuiteReport,
     sourceDir: string,
   ): number {
     const seenReports = new Set<string>();
-    let upserted = 0;
+    let measured = 0;
     for (const cell of report.cells) {
       const sourceReportPath = resolveReportPath(cell.report, sourceDir);
       const reportKey = pathIdentity(sourceReportPath);
@@ -330,6 +342,11 @@ export namespace TtscBenchmarkGraphPublisher {
       const version = modelVersionId(rawModel);
       const samples = sanitizeSamples(sourceReport.samples, sourceReport.runs);
       if (samples.baseline.length === 0 && samples.graph.length === 0) {
+        // Named, not dropped in silence. The count below would otherwise be the
+        // only trace of a cell the suite listed and that measured nothing, and
+        // the difference between the two numbers is what a reader has to
+        // explain.
+        console.warn(`skip cell with no measured sample: ${sourceReportPath}`);
         continue;
       }
       const toolSetupMs =
@@ -359,7 +376,7 @@ export namespace TtscBenchmarkGraphPublisher {
         typeof sourceReport.daemon === "boolean"
           ? sourceReport.daemon
           : undefined;
-      const changed = upsertAgentCell(context, {
+      upsertAgentCell(context, {
         harness,
         tool,
         ...(toolSetupMs !== undefined ? { toolSetupMs } : {}),
@@ -376,17 +393,17 @@ export namespace TtscBenchmarkGraphPublisher {
         question: sourceReport.question,
         samples,
       });
-      if (changed) upserted += 1;
+      measured += 1;
     }
     console.log(
-      `suite: ${path.relative(context.repositoryRoot, sourceDir)} (${upserted} of ${
+      `suite: ${path.relative(context.repositoryRoot, sourceDir)} (${measured} of ${
         report.cells.length
       } cell(s))`,
     );
-    return upserted;
+    return measured;
   }
 
-  /** Folds one agent report, reporting whether it upserted a cell. */
+  /** Folds one agent report, reporting whether it carried a measurement. */
   function foldAgentFile(
     context: IPublisherContext,
     file: string,
@@ -400,7 +417,7 @@ export namespace TtscBenchmarkGraphPublisher {
     return foldAgent(context, report, harness);
   }
 
-  /** Folds one agent report, reporting whether it upserted a cell. */
+  /** Folds one agent report, reporting whether it carried a measurement. */
   function foldAgent(
     context: IPublisherContext,
     report: Record<string, unknown>,
@@ -433,7 +450,7 @@ export namespace TtscBenchmarkGraphPublisher {
     const daemon =
       typeof report.daemon === "boolean" ? report.daemon : undefined;
     const toolSetupMs = numberValueOrUndefined(report.toolSetupMs);
-    const changed = upsertAgentCell(context, {
+    upsertAgentCell(context, {
       harness: websiteHarness,
       tool,
       repo,
@@ -459,7 +476,7 @@ export namespace TtscBenchmarkGraphPublisher {
         stringValue(report.model) ?? rawModel
       } (${n} graph runs)`,
     );
-    return changed;
+    return true;
   }
 
   function stableAgentModel(
@@ -498,11 +515,10 @@ export namespace TtscBenchmarkGraphPublisher {
     return `codex-${tier}`;
   }
 
-  /** Upserts one agent cell, reporting whether the document changed. */
   function upsertAgentCell(
     context: IPublisherContext,
     cell: IPublishedAgentCell,
-  ): boolean {
+  ): void {
     // A manifest promptId narrows the cell within a family, so two prompt variants
     // of the same family upsert separately instead of clobbering. Plain --repo
     // runs (no promptId) keep keying by family, as before.
@@ -525,11 +541,10 @@ export namespace TtscBenchmarkGraphPublisher {
             cell.promptFamily ?? "project-specific"
           } (${nextBaseline}/${nextGraph} < ${existingBaseline}/${existingGraph})`,
         );
-        return false;
+        return;
       }
       context.out.agent.cells[at] = { ...existing, ...cell };
     } else context.out.agent.cells.push(cell);
-    return true;
   }
 
   function sanitizeSamples(

--- a/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
@@ -301,7 +301,7 @@ export namespace TtscBenchmarkGraphPublisher {
    * measurement.
    *
    * A cell the publisher considered and deliberately kept out of the document -
-   * one thinner than the sample set already published - still counted: the run
+   * one thinner than the sample set already published - still counts: the run
    * measured it, and refusing the directory over a policy the publisher applied
    * on purpose would fail a publish for succeeding at its own rule.
    */
@@ -398,7 +398,7 @@ export namespace TtscBenchmarkGraphPublisher {
     console.log(
       `suite: ${path.relative(context.repositoryRoot, sourceDir)} (${measured} of ${
         report.cells.length
-      } cell(s))`,
+      } cell(s) measured)`,
     );
     return measured;
   }
@@ -424,8 +424,13 @@ export namespace TtscBenchmarkGraphPublisher {
     harness: string,
   ): boolean {
     const samples = sanitizeSamples(report.samples, report.runs);
-    if (samples.baseline.length === 0 && samples.graph.length === 0)
+    if (samples.baseline.length === 0 && samples.graph.length === 0) {
+      // Named for the same reason its twin in `foldSuite` is: a report that
+      // measured nothing is otherwise indistinguishable from one the publisher
+      // never looked at.
+      console.warn(`skip ${harness} report with no measured sample`);
       return false;
+    }
     const rawModel =
       stringValue(report.modelVersion) ??
       stringValue(report.model) ??
@@ -515,6 +520,13 @@ export namespace TtscBenchmarkGraphPublisher {
     return `codex-${tier}`;
   }
 
+  /**
+   * Upserts one agent cell, declining when the published sample set is thicker.
+   *
+   * The decline is the rule this namespace's header states, not a failure, so
+   * it warns and returns rather than reporting anything the caller must act
+   * on.
+   */
   function upsertAgentCell(
     context: IPublisherContext,
     cell: IPublishedAgentCell,

--- a/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
@@ -359,7 +359,7 @@ export namespace TtscBenchmarkGraphPublisher {
         typeof sourceReport.daemon === "boolean"
           ? sourceReport.daemon
           : undefined;
-      upsertAgentCell(context, {
+      const changed = upsertAgentCell(context, {
         harness,
         tool,
         ...(toolSetupMs !== undefined ? { toolSetupMs } : {}),
@@ -376,7 +376,7 @@ export namespace TtscBenchmarkGraphPublisher {
         question: sourceReport.question,
         samples,
       });
-      upserted += 1;
+      if (changed) upserted += 1;
     }
     console.log(
       `suite: ${path.relative(context.repositoryRoot, sourceDir)} (${upserted} of ${
@@ -433,7 +433,7 @@ export namespace TtscBenchmarkGraphPublisher {
     const daemon =
       typeof report.daemon === "boolean" ? report.daemon : undefined;
     const toolSetupMs = numberValueOrUndefined(report.toolSetupMs);
-    upsertAgentCell(context, {
+    const changed = upsertAgentCell(context, {
       harness: websiteHarness,
       tool,
       repo,
@@ -459,7 +459,7 @@ export namespace TtscBenchmarkGraphPublisher {
         stringValue(report.model) ?? rawModel
       } (${n} graph runs)`,
     );
-    return true;
+    return changed;
   }
 
   function stableAgentModel(
@@ -498,10 +498,11 @@ export namespace TtscBenchmarkGraphPublisher {
     return `codex-${tier}`;
   }
 
+  /** Upserts one agent cell, reporting whether the document changed. */
   function upsertAgentCell(
     context: IPublisherContext,
     cell: IPublishedAgentCell,
-  ): void {
+  ): boolean {
     // A manifest promptId narrows the cell within a family, so two prompt variants
     // of the same family upsert separately instead of clobbering. Plain --repo
     // runs (no promptId) keep keying by family, as before.
@@ -524,10 +525,11 @@ export namespace TtscBenchmarkGraphPublisher {
             cell.promptFamily ?? "project-specific"
           } (${nextBaseline}/${nextGraph} < ${existingBaseline}/${existingGraph})`,
         );
-        return;
+        return false;
       }
       context.out.agent.cells[at] = { ...existing, ...cell };
     } else context.out.agent.cells.push(cell);
+    return true;
   }
 
   function sanitizeSamples(

--- a/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
@@ -157,7 +157,6 @@ export namespace TtscBenchmarkGraphPublisher {
     const dryRun: boolean = args.includes("--dry-run");
     const sourceDirs: string[] = parseSourceDirs(
       args,
-      repositoryRoot,
       path.join(benchmarkRoot, ".work"),
     );
 
@@ -186,7 +185,16 @@ export namespace TtscBenchmarkGraphPublisher {
     };
 
     for (const sourceDir of sourceDirs) {
-      foldSourceDir(context, sourceDir);
+      if (!foldSourceDir(context, sourceDir)) {
+        // Publication writes a committed file. A source directory that
+        // contributed nothing is indistinguishable from one whose cells were
+        // already present, so accepting it reported a successful publish of
+        // nothing - and with `--reset`, which empties the agent block before
+        // the first fold, it replaced the served dashboard with an empty one.
+        throw new Error(
+          `graph benchmark source directory holds no report: ${sourceDir}`,
+        );
+      }
     }
 
     if (!dryRun) {
@@ -201,12 +209,18 @@ export namespace TtscBenchmarkGraphPublisher {
     );
   }
 
-  function foldSourceDir(context: IPublisherContext, sourceDir: string): void {
+  /** Folds one source directory, reporting whether it contributed a report. */
+  function foldSourceDir(
+    context: IPublisherContext,
+    sourceDir: string,
+  ): boolean {
     const mainReportPath = path.join(sourceDir, "report.json");
     const mainReport = readJson(mainReportPath);
+    let folded = false;
     let structuralReport: IStructuralReport | null = null;
     if (mainReport !== null && isSuiteReport(mainReport)) {
       foldSuite(context, mainReport, sourceDir);
+      folded = true;
     } else if (mainReport !== null && isStructuralReport(mainReport)) {
       structuralReport = mainReport;
     } else if (mainReport !== null) {
@@ -232,19 +246,25 @@ export namespace TtscBenchmarkGraphPublisher {
       }
       structuralReport = nestedStructural;
     }
-    if (structuralReport !== null) foldStructural(context, structuralReport);
+    if (structuralReport !== null) {
+      foldStructural(context, structuralReport);
+      folded = true;
+    }
 
     // Agent cells: upsert each available report by harness/tool/repo/model.
-    foldAgentFile(
-      context,
-      path.join(sourceDir, "agent-ab-report.json"),
-      "claude-code",
-    );
-    foldAgentFile(
-      context,
-      path.join(sourceDir, "agent-ab-codex-report.json"),
-      "codex",
-    );
+    folded =
+      foldAgentFile(
+        context,
+        path.join(sourceDir, "agent-ab-report.json"),
+        "claude-code",
+      ) || folded;
+    folded =
+      foldAgentFile(
+        context,
+        path.join(sourceDir, "agent-ab-codex-report.json"),
+        "codex",
+      ) || folded;
+    return folded;
   }
 
   function foldStructural(
@@ -266,11 +286,7 @@ export namespace TtscBenchmarkGraphPublisher {
   ): void {
     const seenReports = new Set<string>();
     for (const cell of report.cells) {
-      const sourceReportPath = resolveReportPath(
-        cell.report,
-        sourceDir,
-        context.repositoryRoot,
-      );
+      const sourceReportPath = resolveReportPath(cell.report, sourceDir);
       const reportKey = pathIdentity(sourceReportPath);
       if (seenReports.has(reportKey)) {
         throw new Error(`duplicate suite cell report: ${cell.report}`);
@@ -353,17 +369,19 @@ export namespace TtscBenchmarkGraphPublisher {
     );
   }
 
+  /** Folds one agent report, reporting whether the file was there to fold. */
   function foldAgentFile(
     context: IPublisherContext,
     file: string,
     harness: string,
-  ): void {
+  ): boolean {
     const report = readJson(file);
-    if (report === null) return;
+    if (report === null) return false;
     if (!isAgentReport(report)) {
       throw new TypeError(`invalid graph agent report: ${file}`);
     }
     foldAgent(context, report, harness);
+    return true;
   }
 
   function foldAgent(
@@ -552,21 +570,35 @@ export namespace TtscBenchmarkGraphPublisher {
     return parseJsonFile(file);
   }
 
-  function resolveReportPath(
-    reportPath: string,
-    sourceDir: string,
-    repositoryRoot: string,
-  ): string {
+  /**
+   * Resolves a suite cell's recorded report path against the suite file that
+   * recorded it, which is `<sourceDir>/report.json`.
+   *
+   * `TtscBenchmarkGraphSuite` resolves the same field against the same
+   * directory when it republishes a suite of its own, so one relative spelling
+   * cannot mean two files depending on which entrypoint reads it. Suites this
+   * repository writes record absolute paths, so only a hand-edited or foreign
+   * suite reaches the relative branch at all.
+   */
+  function resolveReportPath(reportPath: string, sourceDir: string): string {
     if (!reportPath) return "";
-    if (path.isAbsolute(reportPath)) return reportPath;
-    const fromRoot = path.resolve(repositoryRoot, reportPath);
-    if (fs.existsSync(fromRoot)) return fromRoot;
-    return path.resolve(sourceDir, reportPath);
+    return path.isAbsolute(reportPath)
+      ? reportPath
+      : path.resolve(sourceDir, reportPath);
   }
 
+  /**
+   * Selects the run directories to fold, defaulting to the package work root.
+   *
+   * A relative operator-supplied directory resolves against the current
+   * directory, the way `--out` on both runners and `--dir` / `--report` /
+   * `--out` on the trace auditor already resolve one. Resolving it against the
+   * repository root instead made the same relative string name the run
+   * directory on the way out and a different, non-existent one on the way in,
+   * which is the whole documented parallel-sweep workflow.
+   */
   function parseSourceDirs(
     argv: readonly string[],
-    repositoryRoot: string,
     workRoot: string,
   ): string[] {
     const dirs: string[] = [];
@@ -575,11 +607,11 @@ export namespace TtscBenchmarkGraphPublisher {
       if (arg === "--from" || arg === "--source") {
         const next = argv[++i];
         if (!next) throw new Error(`${arg} requires a directory`);
-        dirs.push(path.resolve(repositoryRoot, next));
+        dirs.push(path.resolve(next));
       } else if (arg.startsWith("--from=")) {
-        dirs.push(path.resolve(repositoryRoot, arg.slice("--from=".length)));
+        dirs.push(path.resolve(arg.slice("--from=".length)));
       } else if (arg.startsWith("--source=")) {
-        dirs.push(path.resolve(repositoryRoot, arg.slice("--source=".length)));
+        dirs.push(path.resolve(arg.slice("--source=".length)));
       }
     }
     const selected = dirs.length > 0 ? dirs : [path.join(workRoot, "graph")];

--- a/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
@@ -19,10 +19,10 @@
 // https://ttsc.dev/docs/benchmark#code-graph-mcp.
 //
 // Usage:
-//   pnpm --dir benchmarks/graph publish
-//   pnpm --dir benchmarks/graph publish -- --from <dir>
-//   pnpm --dir benchmarks/graph publish -- --reset
-//   pnpm --dir benchmarks/graph publish -- --dry-run
+//   pnpm --dir benchmarks/graph run publish
+//   pnpm --dir benchmarks/graph run publish -- --from <dir>
+//   pnpm --dir benchmarks/graph run publish -- --reset
+//   pnpm --dir benchmarks/graph run publish -- --dry-run
 import fs from "node:fs";
 import path from "node:path";
 

--- a/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
@@ -23,6 +23,11 @@
 //   pnpm --dir benchmarks/graph run publish -- --from <dir>
 //   pnpm --dir benchmarks/graph run publish -- --reset
 //   pnpm --dir benchmarks/graph run publish -- --dry-run
+//
+// A relative --from resolves against the current directory, the same base the
+// runners' --out uses. Every source directory must contribute a measurement,
+// the defaulted `.work/graph` included; one that contributes none fails before
+// the website JSON is written.
 import fs from "node:fs";
 import path from "node:path";
 
@@ -186,13 +191,13 @@ export namespace TtscBenchmarkGraphPublisher {
 
     for (const sourceDir of sourceDirs) {
       if (!foldSourceDir(context, sourceDir)) {
-        // Publication writes a committed file. A source directory that
-        // contributed nothing is indistinguishable from one whose cells were
-        // already present, so accepting it reported a successful publish of
-        // nothing - and with `--reset`, which empties the agent block before
-        // the first fold, it replaced the served dashboard with an empty one.
+        // Publication writes a committed file. A source directory that added
+        // nothing is indistinguishable from one whose cells were already
+        // present, so accepting it reported a successful publish of nothing -
+        // and with `--reset`, which empties the agent block before the first
+        // fold, it replaced the served dashboard with an empty one.
         throw new Error(
-          `graph benchmark source directory holds no report: ${sourceDir}`,
+          `graph benchmark source directory contributed no measurement: ${sourceDir}`,
         );
       }
     }
@@ -209,7 +214,16 @@ export namespace TtscBenchmarkGraphPublisher {
     );
   }
 
-  /** Folds one source directory, reporting whether it contributed a report. */
+  /**
+   * Folds one source directory, reporting whether it changed the document.
+   *
+   * The answer counts upserted cells and a replaced structural block, not files
+   * that happened to be present. A run that produced a `report.json` whose
+   * every cell was rejected contributed nothing, and a publish that accepted it
+   * would report success for a document it did not add to - which with
+   * `--reset`, already emptied before the first fold, is how the served
+   * dashboard loses its cells.
+   */
   function foldSourceDir(
     context: IPublisherContext,
     sourceDir: string,
@@ -219,8 +233,7 @@ export namespace TtscBenchmarkGraphPublisher {
     let folded = false;
     let structuralReport: IStructuralReport | null = null;
     if (mainReport !== null && isSuiteReport(mainReport)) {
-      foldSuite(context, mainReport, sourceDir);
-      folded = true;
+      folded = foldSuite(context, mainReport, sourceDir) !== 0;
     } else if (mainReport !== null && isStructuralReport(mainReport)) {
       structuralReport = mainReport;
     } else if (mainReport !== null) {
@@ -279,12 +292,14 @@ export namespace TtscBenchmarkGraphPublisher {
     );
   }
 
+  /** Folds a suite report, reporting how many cells it actually upserted. */
   function foldSuite(
     context: IPublisherContext,
     report: ISuiteReport,
     sourceDir: string,
-  ): void {
+  ): number {
     const seenReports = new Set<string>();
+    let upserted = 0;
     for (const cell of report.cells) {
       const sourceReportPath = resolveReportPath(cell.report, sourceDir);
       const reportKey = pathIdentity(sourceReportPath);
@@ -361,15 +376,17 @@ export namespace TtscBenchmarkGraphPublisher {
         question: sourceReport.question,
         samples,
       });
+      upserted += 1;
     }
     console.log(
-      `suite: ${path.relative(context.repositoryRoot, sourceDir)} (${
+      `suite: ${path.relative(context.repositoryRoot, sourceDir)} (${upserted} of ${
         report.cells.length
       } cell(s))`,
     );
+    return upserted;
   }
 
-  /** Folds one agent report, reporting whether the file was there to fold. */
+  /** Folds one agent report, reporting whether it upserted a cell. */
   function foldAgentFile(
     context: IPublisherContext,
     file: string,
@@ -380,17 +397,18 @@ export namespace TtscBenchmarkGraphPublisher {
     if (!isAgentReport(report)) {
       throw new TypeError(`invalid graph agent report: ${file}`);
     }
-    foldAgent(context, report, harness);
-    return true;
+    return foldAgent(context, report, harness);
   }
 
+  /** Folds one agent report, reporting whether it upserted a cell. */
   function foldAgent(
     context: IPublisherContext,
     report: Record<string, unknown>,
     harness: string,
-  ): void {
+  ): boolean {
     const samples = sanitizeSamples(report.samples, report.runs);
-    if (samples.baseline.length === 0 && samples.graph.length === 0) return;
+    if (samples.baseline.length === 0 && samples.graph.length === 0)
+      return false;
     const rawModel =
       stringValue(report.modelVersion) ??
       stringValue(report.model) ??
@@ -441,6 +459,7 @@ export namespace TtscBenchmarkGraphPublisher {
         stringValue(report.model) ?? rawModel
       } (${n} graph runs)`,
     );
+    return true;
   }
 
   function stableAgentModel(
@@ -571,14 +590,15 @@ export namespace TtscBenchmarkGraphPublisher {
   }
 
   /**
-   * Resolves a suite cell's recorded report path against the suite file that
-   * recorded it, which is `<sourceDir>/report.json`.
+   * Resolves a cell's recorded report path against the report that recorded it,
+   * which is `<sourceDir>/report.json`.
    *
-   * `TtscBenchmarkGraphSuite` resolves the same field against the same
-   * directory when it republishes a suite of its own, so one relative spelling
-   * cannot mean two files depending on which entrypoint reads it. Suites this
-   * repository writes record absolute paths, so only a hand-edited or foreign
-   * suite reaches the relative branch at all.
+   * Both writers record the field absolute, so the relative branch is for a
+   * hand-edited or older report. It resolves against the recording report
+   * rather than the repository root or the current directory, which is the one
+   * base `TtscBenchmarkGraphSuite` and the trace auditor also use, so a
+   * relative spelling cannot mean two files depending on which entrypoint reads
+   * it.
    */
   function resolveReportPath(reportPath: string, sourceDir: string): string {
     if (!reportPath) return "";

--- a/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphPublisher.ts
@@ -414,7 +414,16 @@ export namespace TtscBenchmarkGraphPublisher {
     if (!isAgentReport(report)) {
       throw new TypeError(`invalid graph agent report: ${file}`);
     }
-    return foldAgent(context, report, harness);
+    const measured = foldAgent(context, report, harness);
+    if (!measured) {
+      // Named the way its twin in `foldSuite` names a cell, and named here
+      // because this is where the file is: a report that measured nothing is
+      // otherwise indistinguishable from one the publisher never looked at,
+      // and with several `--from` directories the harness alone does not say
+      // which one lost its cell.
+      console.warn(`skip report with no measured sample: ${file}`);
+    }
+    return measured;
   }
 
   /** Folds one agent report, reporting whether it carried a measurement. */
@@ -425,10 +434,6 @@ export namespace TtscBenchmarkGraphPublisher {
   ): boolean {
     const samples = sanitizeSamples(report.samples, report.runs);
     if (samples.baseline.length === 0 && samples.graph.length === 0) {
-      // Named for the same reason its twin in `foldSuite` is: a report that
-      // measured nothing is otherwise indistinguishable from one the publisher
-      // never looked at.
-      console.warn(`skip ${harness} report with no measured sample`);
       return false;
     }
     const rawModel =
@@ -521,7 +526,8 @@ export namespace TtscBenchmarkGraphPublisher {
   }
 
   /**
-   * Upserts one agent cell, declining when the published sample set is thicker.
+   * Upserts one agent cell, declining when either arm of the stored cell holds
+   * more samples than the one offered.
    *
    * The decline is the rule this namespace's header states, not a failure, so
    * it warns and returns rather than reporting anything the caller must act

--- a/benchmarks/graph/src/TtscBenchmarkGraphRunner.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphRunner.ts
@@ -32,9 +32,9 @@ import { ITtscBenchmarkGraphWebsiteAgentCell } from "./structures/ITtscBenchmark
  * Runs the complete graph-agent benchmark while keeping its executable a
  * location-only bootstrap.
  *
- * All harness paths derive from the supplied executable directory so moving
- * this implementation out of `src/executable/graph` does not change which child
- * entrypoints are launched.
+ * All harness paths derive from the supplied executable directory, so
+ * relocating this implementation never changes which child entrypoints are
+ * launched.
  */
 export namespace TtscBenchmarkGraphRunner {
   /**

--- a/benchmarks/graph/src/TtscBenchmarkGraphRunner.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphRunner.ts
@@ -32,9 +32,11 @@ import { ITtscBenchmarkGraphWebsiteAgentCell } from "./structures/ITtscBenchmark
  * Runs the complete graph-agent benchmark while keeping its executable a
  * location-only bootstrap.
  *
- * All harness paths derive from the supplied executable directory, so
- * relocating this implementation never changes which child entrypoints are
- * launched.
+ * Every child entrypoint it launches is derived from the supplied executable
+ * directory, so relocating this implementation never changes which bootstrap
+ * runs. Roots the harness reads or writes — the repository, the fixture work
+ * directory, the report directory, the website JSON — come from
+ * `TtscBenchmarkConstant` instead and are unaffected either way.
  */
 export namespace TtscBenchmarkGraphRunner {
   /**
@@ -622,7 +624,15 @@ export namespace TtscBenchmarkGraphRunner {
           repoDir,
           tsconfig: spec.tsconfig,
           log: path.relative(repoRoot, `${path.join(outDir, logStem)}.out.log`),
-          report: path.relative(repoRoot, copyPath),
+          // Absolute, like the suite runner already records the same field.
+          // Every reader of a cell report - the publisher, the trace auditor,
+          // the suite - then needs no base at all, and a run directory named by
+          // `--out` stays readable from whatever directory the publish is typed
+          // in. Recorded relative to the repository root it was readable from
+          // exactly one place, and only by a reader that knew to try that base.
+          // `log` stays repository-relative: it is provenance a human reads,
+          // and nothing resolves it.
+          report: copyPath,
           summary: summarize(data),
         },
         websiteCell,

--- a/benchmarks/graph/src/TtscBenchmarkGraphTraceAuditor.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphTraceAuditor.ts
@@ -495,33 +495,29 @@ export namespace TtscBenchmarkGraphTraceAuditor {
           .filter(
             (cell) => cell.harness === undefined || cell.harness === "codex",
           )
-          .map((cell) => optionalString(cell.report))
-          .filter(
-            (reportPath): reportPath is string => reportPath !== undefined,
-          )
-          // A relative cell path resolves against the report that recorded it,
-          // the one base every reader of this field now uses. Resolving against
-          // the current directory made the answer depend on where the audit was
-          // typed: it worked only because the runner spawns this from the
-          // repository root, and the documented `pnpm --dir benchmarks/graph run
-          // audit -- --report ...` invocation audited zero cells in silence.
-          .map((reportPath) =>
-            path.isAbsolute(reportPath)
+          // A cell the suite listed and this audit cannot reach is a failure to
+          // report, not one to drop. Silence here was the other half of the
+          // zero-cell audit: whatever went wrong, the run exited zero and the
+          // reader could not tell an empty suite from an unreadable one.
+          .map((cell) => {
+            const reportPath = optionalString(cell.report);
+            if (reportPath === undefined) {
+              throw new Error(`suite cell records no report path in ${file}`);
+            }
+            // Resolved against the report that recorded it, the one base every
+            // reader of this field uses. Against the current directory it named
+            // a different file whenever the run directory was not the directory
+            // the audit was typed in, which the documented `pnpm --dir
+            // benchmarks/graph run audit -- --report ...` invocation always is.
+            const resolved = path.isAbsolute(reportPath)
               ? reportPath
-              : path.resolve(path.dirname(file), reportPath),
-          )
-          // A cell the suite listed and this audit cannot open is a failure to
-          // report, not one to drop. Discarding it silently is the other half
-          // of the zero-cell audit: with the paths wrong the run still exited
-          // zero, and the reader had no way to tell an empty suite from an
-          // unreadable one.
-          .map((reportPath) => {
-            if (!fs.existsSync(reportPath)) {
+              : path.resolve(path.dirname(file), reportPath);
+            if (!fs.existsSync(resolved)) {
               throw new Error(
-                `suite cell report is missing: ${reportPath} (recorded in ${file})`,
+                `suite cell report is missing: ${resolved} (recorded in ${file})`,
               );
             }
-            return reportPath;
+            return resolved;
           })
       );
     }
@@ -551,10 +547,14 @@ export namespace TtscBenchmarkGraphTraceAuditor {
 
       const cell: AuditCell = {
         // Absolute, so this audit's own `cells[].report` reads back under the
-        // same rule the runner's does. Recorded against the current directory
-        // it named a different file the moment the audit was read from
-        // anywhere else, and this file is itself accepted as a `--report`
-        // input.
+        // same rule the runner's does - and this file is itself accepted as a
+        // `--report` input. Recorded against the current directory it named a
+        // different file whenever the run directory was not the directory the
+        // audit was typed in, which is every documented invocation.
+        //
+        // `traceDir` and `runsDetail[].file` stay current-directory relative on
+        // purpose: nothing resolves them, they are provenance a human reads,
+        // and a short path reads better than an absolute one.
         report: reportPath,
         traceDir: path.relative(process.cwd(), traceDir),
         repo: report.repo,
@@ -3381,7 +3381,9 @@ export namespace TtscBenchmarkGraphTraceAuditor {
         ...parsed,
       };
       const cell: AuditCell = {
-        report: path.relative(process.cwd(), reportPath),
+        // Same spelling the real audit path records, so the self-test models
+        // the shape this file actually produces rather than a superseded one.
+        report: reportPath,
         traceDir: path.relative(process.cwd(), report.traceDir),
         repo: report.repo,
         fixtureBranch: report.fixtureBranch,

--- a/benchmarks/graph/src/TtscBenchmarkGraphTraceAuditor.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphTraceAuditor.ts
@@ -510,7 +510,19 @@ export namespace TtscBenchmarkGraphTraceAuditor {
               ? reportPath
               : path.resolve(path.dirname(file), reportPath),
           )
-          .filter((reportPath) => fs.existsSync(reportPath))
+          // A cell the suite listed and this audit cannot open is a failure to
+          // report, not one to drop. Discarding it silently is the other half
+          // of the zero-cell audit: with the paths wrong the run still exited
+          // zero, and the reader had no way to tell an empty suite from an
+          // unreadable one.
+          .map((reportPath) => {
+            if (!fs.existsSync(reportPath)) {
+              throw new Error(
+                `suite cell report is missing: ${reportPath} (recorded in ${file})`,
+              );
+            }
+            return reportPath;
+          })
       );
     }
 
@@ -538,7 +550,12 @@ export namespace TtscBenchmarkGraphTraceAuditor {
       });
 
       const cell: AuditCell = {
-        report: path.relative(process.cwd(), reportPath),
+        // Absolute, so this audit's own `cells[].report` reads back under the
+        // same rule the runner's does. Recorded against the current directory
+        // it named a different file the moment the audit was read from
+        // anywhere else, and this file is itself accepted as a `--report`
+        // input.
+        report: reportPath,
         traceDir: path.relative(process.cwd(), traceDir),
         repo: report.repo,
         fixtureBranch: report.fixtureBranch,

--- a/benchmarks/graph/src/TtscBenchmarkGraphTraceAuditor.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphTraceAuditor.ts
@@ -502,13 +502,16 @@ export namespace TtscBenchmarkGraphTraceAuditor {
           .map((cell) => {
             const reportPath = optionalString(cell.report);
             if (reportPath === undefined) {
-              throw new Error(`suite cell records no report path in ${file}`);
+              throw new Error(
+                `${file} holds a cell with no report path, so it is not an auditable suite report`,
+              );
             }
             // Resolved against the report that recorded it, the one base every
             // reader of this field uses. Against the current directory it named
             // a different file whenever the run directory was not the directory
-            // the audit was typed in, which the documented `pnpm --dir
-            // benchmarks/graph run audit -- --report ...` invocation always is.
+            // the audit was typed in, which is every documented invocation:
+            // `pnpm --dir benchmarks/graph` puts the audit in the package while
+            // the run directory is always somewhere below it.
             const resolved = path.isAbsolute(reportPath)
               ? reportPath
               : path.resolve(path.dirname(file), reportPath);
@@ -528,10 +531,25 @@ export namespace TtscBenchmarkGraphTraceAuditor {
     ): AuditCell {
       const report = readRawCellReport(reportPath);
       const traceDir = path.resolve(report.traceDir);
+      // The last link of the same chain. A cell whose traces are unreachable
+      // used to die on a bare ENOENT that named neither the cell nor the report
+      // recording it, and a cell whose trace directory is empty audited as
+      // `runs: 0` at exit zero - folding a median of zero into the suite
+      // summary, which is a published number stating something no trace says.
+      if (!fs.existsSync(traceDir)) {
+        throw new Error(
+          `cell trace directory is missing: ${traceDir} (recorded in ${reportPath})`,
+        );
+      }
       const traces = fs
         .readdirSync(traceDir)
         .filter((file) => file.endsWith(".stream.jsonl"))
         .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+      if (traces.length === 0) {
+        throw new Error(
+          `cell trace directory holds no trace: ${traceDir} (recorded in ${reportPath})`,
+        );
+      }
       const runs: AuditRun[] = traces.map((file) => {
         const match = /^(.*)-run-(\d+)\.stream\.jsonl$/.exec(file);
         const parsed = parseTrace(
@@ -3257,6 +3275,15 @@ export namespace TtscBenchmarkGraphTraceAuditor {
         throw new Error("self-test setup did not produce expected audit data");
       }
       assertSelf(reasoningText.available, "reasoning text should be detected");
+      // `auditSyntheticCell` rebuilds the cell literal instead of calling
+      // `auditCell`, and that duplication is how the recorded spelling drifted
+      // apart in the first place: an audit's own cells are read back through
+      // `--report`, so a relative one names a different file. Pin the property
+      // rather than the duplicate.
+      assertSelf(
+        path.isAbsolute(cell.report),
+        "an audit cell must record its report path absolute",
+      );
       assertSelf(
         comparisonDelta.deltaFromFirst.medianTokens === -12,
         "comparison should track median token deltas",

--- a/benchmarks/graph/src/TtscBenchmarkGraphTraceAuditor.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphTraceAuditor.ts
@@ -530,12 +530,16 @@ export namespace TtscBenchmarkGraphTraceAuditor {
       baselineIndex: Map<string, Baseline> | null,
     ): AuditCell {
       const report = readRawCellReport(reportPath);
-      const traceDir = path.resolve(report.traceDir);
-      // The last link of the same chain. A cell whose traces are unreachable
-      // used to die on a bare ENOENT that named neither the cell nor the report
-      // recording it, and a cell whose trace directory is empty audited as
-      // `runs: 0` at exit zero - folding a median of zero into the suite
-      // summary, which is a published number stating something no trace says.
+      // Against the report that recorded it, the base `cells[].report` uses
+      // three functions up. Both harnesses record this absolute, so the base
+      // only decides what a relative one means - and it decides what the error
+      // below is allowed to name.
+      const traceDir = path.resolve(path.dirname(reportPath), report.traceDir);
+      // The last link of the per-cell reachability chain. A cell whose traces
+      // are unreachable used to die on a bare ENOENT that named neither the
+      // cell nor the report recording it, and a cell whose trace directory is
+      // empty audited as `runs: 0` at exit zero - folding a median of zero into
+      // the suite summary, a recorded number stating something no trace says.
       if (!fs.existsSync(traceDir)) {
         throw new Error(
           `cell trace directory is missing: ${traceDir} (recorded in ${reportPath})`,
@@ -547,7 +551,7 @@ export namespace TtscBenchmarkGraphTraceAuditor {
         .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
       if (traces.length === 0) {
         throw new Error(
-          `cell trace directory holds no trace: ${traceDir} (recorded in ${reportPath})`,
+          `cell trace directory holds no *.stream.jsonl: ${traceDir} (recorded in ${reportPath})`,
         );
       }
       const runs: AuditRun[] = traces.map((file) => {

--- a/benchmarks/graph/src/TtscBenchmarkGraphTraceAuditor.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphTraceAuditor.ts
@@ -490,16 +490,28 @@ export namespace TtscBenchmarkGraphTraceAuditor {
       if (cells === undefined) {
         throw new Error(`report has neither traceDir nor cells: ${file}`);
       }
-      return cells
-        .filter(
-          (cell) => cell.harness === undefined || cell.harness === "codex",
-        )
-        .map((cell) => optionalString(cell.report))
-        .filter((reportPath): reportPath is string => reportPath !== undefined)
-        .map((reportPath) =>
-          path.isAbsolute(reportPath) ? reportPath : path.resolve(reportPath),
-        )
-        .filter((reportPath) => fs.existsSync(reportPath));
+      return (
+        cells
+          .filter(
+            (cell) => cell.harness === undefined || cell.harness === "codex",
+          )
+          .map((cell) => optionalString(cell.report))
+          .filter(
+            (reportPath): reportPath is string => reportPath !== undefined,
+          )
+          // A relative cell path resolves against the report that recorded it,
+          // the one base every reader of this field now uses. Resolving against
+          // the current directory made the answer depend on where the audit was
+          // typed: it worked only because the runner spawns this from the
+          // repository root, and the documented `pnpm --dir benchmarks/graph run
+          // audit -- --report ...` invocation audited zero cells in silence.
+          .map((reportPath) =>
+            path.isAbsolute(reportPath)
+              ? reportPath
+              : path.resolve(path.dirname(file), reportPath),
+          )
+          .filter((reportPath) => fs.existsSync(reportPath))
+      );
     }
 
     function auditCell(

--- a/benchmarks/graph/src/TtscBenchmarkGraphTraceAuditor.ts
+++ b/benchmarks/graph/src/TtscBenchmarkGraphTraceAuditor.ts
@@ -530,10 +530,10 @@ export namespace TtscBenchmarkGraphTraceAuditor {
       baselineIndex: Map<string, Baseline> | null,
     ): AuditCell {
       const report = readRawCellReport(reportPath);
-      // Against the report that recorded it, the base `cells[].report` uses
-      // three functions up. Both harnesses record this absolute, so the base
-      // only decides what a relative one means - and it decides what the error
-      // below is allowed to name.
+      // Against the report that recorded it, the base `cells[].report` uses in
+      // `rawReportsFromSuiteReport` just above. Both harnesses record this
+      // absolute, so the base only decides what a relative one would mean - and
+      // it decides what the error below is allowed to name.
       const traceDir = path.resolve(path.dirname(reportPath), report.traceDir);
       // The last link of the per-cell reachability chain. A cell whose traces
       // are unreachable used to die on a bare ENOENT that named neither the

--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -96,7 +96,7 @@ Per-project commands, install/prepare overrides, and prerequisites live in `src/
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `TTSC_BENCH_WORK` | `benchmarks/performance/.work` | Working directory for this run: clones, report, and checkpoint. Each benchmark package resolves its own root, so this package never writes into a sibling's. |
+| `TTSC_BENCH_WORK` | `benchmarks/performance/.work` | Working directory for this run: clones, report, and checkpoint. `<WORK>` below is its resolved value. Each benchmark package resolves its own root, so this package never writes into a sibling's. |
 | `TTSC_BENCH_TGZ` | `<tmpdir>/ttsc-tgz-<pid>` (`<tmpdir>/ttsc-tgz` with `--no-pack`) | Tarball staging directory. |
 | `TTSC_BENCH_OUT` | `<WORK>/report.md` | Report destination; sibling `.json` is written alongside. |
 | `TTSC_BENCH_CHECKPOINT` | `<WORK>/benchmark.checkpoint.json` | Intermediate snapshot rewritten after each cell so an interrupted run is resumable. |

--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -96,9 +96,9 @@ Per-project commands, install/prepare overrides, and prerequisites live in `src/
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `TTSC_BENCH_WORK` | `benchmarks/performance/.work` | Clone working directory. Each benchmark package resolves its own root, so this package never writes into a sibling's. |
+| `TTSC_BENCH_WORK` | `benchmarks/performance/.work` | Working directory for this run: clones, report, and checkpoint. Each benchmark package resolves its own root, so this package never writes into a sibling's. |
 | `TTSC_BENCH_TGZ` | `<tmpdir>/ttsc-tgz-<pid>` (`<tmpdir>/ttsc-tgz` with `--no-pack`) | Tarball staging directory. |
-| `TTSC_BENCH_OUT` | `benchmarks/performance/.work/report.md` | Report destination; sibling `.json` is written alongside. |
+| `TTSC_BENCH_OUT` | `<WORK>/report.md` | Report destination; sibling `.json` is written alongside. |
 | `TTSC_BENCH_CHECKPOINT` | `<WORK>/benchmark.checkpoint.json` | Intermediate snapshot rewritten after each cell so an interrupted run is resumable. |
 | `TTSC_BENCH_RUNS` | `5` | Measured runs per cell. |
 | `TTSC_BENCH_WARMUP` | `1` | Warmup runs per cell (excluded from reported samples). |
@@ -123,9 +123,9 @@ Per-project commands, install/prepare overrides, and prerequisites live in `src/
 
 | File | Contents |
 | --- | --- |
-| `.work/report.md` | Per-project Markdown table (`Branch \| Op \| Threading \| Min \| lint timings \| Samples \| Failure`) preceded by a `Host` block (OS, kernel, CPU, RAM, `node` / `ttsc` / `typescript` / `tsgo` versions). |
-| `.work/report.json` | Same content plus per-sample timings, retry counts, and exit statuses. |
-| `.work/benchmark.checkpoint.json` | Same shape as `report.json`, rewritten after every cell so a Ctrl-C run leaves a resumable snapshot. |
+| `<WORK>/report.md` | Per-project Markdown table (`Branch \| Op \| Threading \| Min \| lint timings \| Samples \| Failure`) preceded by a `Host` block (OS, kernel, CPU, RAM, `node` / `ttsc` / `typescript` / `tsgo` versions). |
+| `<WORK>/report.json` | Same content plus per-sample timings, retry counts, and exit statuses. |
+| `<WORK>/benchmark.checkpoint.json` | Same shape as `report.json`, rewritten after every cell so a Ctrl-C run leaves a resumable snapshot. |
 | `website/public/benchmark/performance.json` | Dashboard view consumed by https://ttsc.dev/benchmark. Merged in place, cells not re-measured in this run keep their previous values. Skip with `--no-website`, wipe and replace with `--reset`. |
 
 `.work/` is git-ignored; results are an ephemeral artifact and never committed.

--- a/benchmarks/performance/src/TtscBenchmarkPerformanceExecutable.ts
+++ b/benchmarks/performance/src/TtscBenchmarkPerformanceExecutable.ts
@@ -43,9 +43,12 @@ export namespace TtscBenchmarkPerformanceExecutable {
         os.tmpdir(),
         flags.has("--no-pack") ? "ttsc-tgz" : `ttsc-tgz-${process.pid}`,
       );
+    // Anchored to the root this run resolved, not to the package constant.
+    // `TTSC_BENCH_WORK` exists so a sweep can put its clones on another volume;
+    // leaving the report behind splits one run's state across two roots and
+    // lets two runs isolated by that variable overwrite each other's report.
     const outputMarkdown =
-      process.env.TTSC_BENCH_OUT ??
-      path.resolve(TtscBenchmarkConstant.WORK_ROOT, "report.md");
+      process.env.TTSC_BENCH_OUT ?? path.resolve(workRoot, "report.md");
     const websiteJson = path.resolve(
       repositoryRoot,
       "website",

--- a/packages/ttsc/cmd/ttscgraph/serve_answers_a_project_that_implements_its_own_ambient_declaration_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_answers_a_project_that_implements_its_own_ambient_declaration_test.go
@@ -53,7 +53,7 @@ patched = (message: string): void => {
   if initial.Error != "" {
     t.Fatalf("shard assembly refused a project that implements its own ambient declaration: %s", initial.Error)
   }
-  if initial.Mode != serveModeInitial || !initial.Changed || initial.Snapshot == nil {
+  if initial.Mode != serveModeInitial || !initial.Changed || initial.Dump != nil || initial.Snapshot == nil {
     t.Fatalf("negotiated initial response: %#v", initial)
   }
   if len(initial.Snapshot.Manifest) == 0 ||

--- a/packages/ttsc/cmd/ttscgraph/serve_answers_a_project_that_implements_its_own_ambient_declaration_test.go
+++ b/packages/ttsc/cmd/ttscgraph/serve_answers_a_project_that_implements_its_own_ambient_declaration_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+  "bytes"
+  "encoding/json"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// TestServeAnswersAProjectThatImplementsItsOwnAmbientDeclaration verifies shard
+// assembly succeeds for a project that declares an ambient global in its own
+// `.d.ts` and assigns the implementation elsewhere.
+//
+// Shard partition indexes edge sources by non-external node, and external nodes
+// live in a non-source shard that may own no edges. An edge leaving one is
+// therefore not a wrong fact but an unassemblable snapshot: the session refused
+// the whole transaction with "edge source node is absent from shard facts", so
+// every request failed before it ran while `dump`, which applies no such check,
+// still emitted the graph.
+//
+//  1. Serve a project whose `src/globals.d.ts` declares `var patched` and whose
+//     `src/index.ts` assigns an arrow function to it.
+//  2. Request one negotiated shard snapshot.
+//  3. Assert the response carries a complete transaction and no error.
+func TestServeAnswersAProjectThatImplementsItsOwnAmbientDeclaration(t *testing.T) {
+  root := t.TempDir()
+  writeGraphFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": { "target": "ES2022", "module": "commonjs", "strict": true },
+  "include": ["src"]
+}`)
+  writeGraphFile(t, filepath.Join(root, "src", "globals.d.ts"), `declare global {
+  var patched: (message: string) => void;
+}
+export {};
+`)
+  writeGraphFile(t, filepath.Join(root, "src", "index.ts"), `export function helper(): void {}
+patched = (message: string): void => {
+  helper();
+};
+`)
+
+  input := strings.NewReader("{\"id\":1,\"graphSnapshotVersion\":1}\n")
+  var output bytes.Buffer
+  if code := serveSnapshots(input, &output, root, "tsconfig.json"); code != 0 {
+    t.Fatalf("serveSnapshots exited %d: %s", code, output.String())
+  }
+
+  var initial serveResponse
+  if err := json.NewDecoder(&output).Decode(&initial); err != nil {
+    t.Fatal(err)
+  }
+  if initial.Error != "" {
+    t.Fatalf("shard assembly refused a project that implements its own ambient declaration: %s", initial.Error)
+  }
+  if initial.Mode != serveModeInitial || !initial.Changed || initial.Snapshot == nil {
+    t.Fatalf("negotiated initial response: %#v", initial)
+  }
+  if len(initial.Snapshot.Manifest) == 0 ||
+    len(initial.Snapshot.Upserts) != len(initial.Snapshot.Manifest) ||
+    len(initial.Snapshot.Deletes) != 0 {
+    t.Fatalf(
+      "initial transaction is not complete: manifest=%d upserts=%d deletes=%d",
+      len(initial.Snapshot.Manifest),
+      len(initial.Snapshot.Upserts),
+      len(initial.Snapshot.Deletes),
+    )
+  }
+}

--- a/packages/ttsc/internal/graph/assigned_implementations_of_declaration_file_symbols_leave_no_edge_source_test.go
+++ b/packages/ttsc/internal/graph/assigned_implementations_of_declaration_file_symbols_leave_no_edge_source_test.go
@@ -1,0 +1,84 @@
+package graph
+
+import (
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// ambientGlobalFixtureTSConfig compiles a project that declares an ambient
+// global in its own `.d.ts` and assigns the implementation in a sibling source.
+// Both files are named because a global augmentation only reaches the program
+// when its declaration file is an input.
+const ambientGlobalFixtureTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "files": ["src/globals.d.ts", "src/main.ts"]
+}
+`
+
+// TestAssignedImplementationsOfDeclarationFileSymbolsLeaveNoEdgeSource verifies
+// that assigning a function to a symbol declared in a declaration file records
+// no edge leaving the external boundary leaf that symbol enters the graph as.
+//
+// An external leaf has no outgoing side: the graph never walks a dependency's
+// internals, and no shard may hold an edge whose source is one — an external
+// node is owned by the non-source external shard, which is forbidden to own
+// edges. Attributing the assigned body to it therefore did not merely misplace
+// facts (with evidence offsets from the implementation read against the
+// declaration file); it produced a snapshot `ttscgraph serve` could not
+// assemble, so every request against such a project failed. The calls the body
+// makes are not lost by refusing it: the module that runs the assignment owns
+// them.
+//
+//  1. Compile a fixture whose `src/globals.d.ts` declares `var patched` in a
+//     global augmentation and whose `src/main.ts` assigns an arrow function to
+//     it that calls a local `helper`.
+//  2. Build the graph.
+//  3. Assert no edge leaves an external node, and that `main.ts`'s module node
+//     still owns the value-call edge to `helper`.
+func TestAssignedImplementationsOfDeclarationFileSymbolsLeaveNoEdgeSource(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), ambientGlobalFixtureTSConfig)
+  writeFile(t, filepath.Join(root, "src", "globals.d.ts"), `declare global {
+  var patched: (message: string) => void;
+}
+export {};
+`)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), `export function helper(): void {}
+patched = (message: string): void => {
+  helper();
+};
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diags)
+  }
+  defer func() { _ = prog.Close() }()
+
+  graph := Build(prog)
+  mainPath := sourceFile(t, prog, "main.ts").FileName()
+
+  for _, edge := range graph.Edges {
+    node, ok := graph.Nodes[edge.From]
+    if ok && node.External {
+      t.Fatalf("edge leaves the external boundary: %s -> %s (%s), source declared in %s", edge.From, edge.To, edge.Kind, node.File)
+    }
+  }
+
+  module := moduleID(mainPath)
+  helper := nodeID(mainPath, "helper", NodeFunction)
+  if !hasEdge(graph, module, helper, EdgeValueCall) {
+    t.Fatalf("the assigned body's call to helper is not owned by the running module; edges: %v", graph.Edges)
+  }
+}

--- a/packages/ttsc/internal/graph/assigned_implementations_of_node_modules_symbols_leave_no_edge_source_test.go
+++ b/packages/ttsc/internal/graph/assigned_implementations_of_node_modules_symbols_leave_no_edge_source_test.go
@@ -1,0 +1,85 @@
+package graph
+
+import (
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// nodeModulesGlobalFixtureTSConfig compiles a project whose ambient global is
+// declared by a dependency's raw `.ts` source. Both inputs are named because
+// the declaring file is reached by neither an import nor a glob, and no
+// `rootDir` or `outDir` is set because a `node_modules` input under one would
+// be an input outside the root.
+const nodeModulesGlobalFixtureTSConfig = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true
+  },
+  "files": ["node_modules/dep/globals.ts", "src/main.ts"]
+}
+`
+
+// TestAssignedImplementationsOfNodeModulesSymbolsLeaveNoEdgeSource verifies the
+// other half of the external boundary: a symbol declared under `node_modules`
+// gains no outgoing edge from an assignment either.
+//
+// `IsWorkspaceSourceFile` refuses a file for two disjoint reasons, and only one
+// of them is being a declaration file. A dependency that ships raw TypeScript
+// is not a declaration file and still owns no facts in this graph, so an
+// assignment to something it declares must be refused by the same rule. Without
+// this case the fix is pinned on one branch of the classifier and a change to
+// the other would pass.
+//
+//  1. Compile a fixture whose `node_modules/dep/globals.ts` declares `var
+//     patched` in a global augmentation and whose `src/main.ts` assigns an arrow
+//     function to it that calls a local `helper`.
+//  2. Build the graph.
+//  3. Assert no edge leaves an external node, and that `main.ts`'s module node
+//     still owns the value-call edge to `helper`.
+func TestAssignedImplementationsOfNodeModulesSymbolsLeaveNoEdgeSource(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), nodeModulesGlobalFixtureTSConfig)
+  writeFile(t, filepath.Join(root, "node_modules", "dep", "package.json"), `{
+  "name": "dep",
+  "version": "1.0.0"
+}
+`)
+  writeFile(t, filepath.Join(root, "node_modules", "dep", "globals.ts"), `declare global {
+  var patched: (message: string) => void;
+}
+export {};
+`)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), `export function helper(): void {}
+patched = (message: string): void => {
+  helper();
+};
+`)
+
+  prog, diags, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %v", diags)
+  }
+  defer func() { _ = prog.Close() }()
+
+  graph := Build(prog)
+  mainPath := sourceFile(t, prog, "main.ts").FileName()
+
+  for _, edge := range graph.Edges {
+    node, ok := graph.Nodes[edge.From]
+    if ok && node.External {
+      t.Fatalf("edge leaves the external boundary: %s -> %s (%s), source declared in %s", edge.From, edge.To, edge.Kind, node.File)
+    }
+  }
+
+  module := moduleID(mainPath)
+  helper := nodeID(mainPath, "helper", NodeFunction)
+  if !hasEdge(graph, module, helper, EdgeValueCall) {
+    t.Fatalf("the assigned body's call to helper is not owned by the running module; edges: %v", graph.Edges)
+  }
+}

--- a/packages/ttsc/internal/graph/edges.go
+++ b/packages/ttsc/internal/graph/edges.go
@@ -46,6 +46,17 @@ func (g *Graph) addEdge(from, to string, kind EdgeKind) {
 }
 
 func (g *Graph) addEdgeAt(from, to string, kind EdgeKind, origin string, pos, end int) {
+  // An external leaf is a boundary, and a boundary has no outgoing side. The
+  // graph never walks a dependency's internals, so it holds no fact about what
+  // one does — and an edge claiming otherwise has nowhere to live: an external
+  // node is owned by the non-source external shard, and no non-source shard may
+  // own edges (`serve_shards.go`, `TtscGraphShardStore.assertShardContents`).
+  // The producer of such an edge is `assignedFunctionTarget`, which now refuses
+  // one; this is the invariant that outlives any single producer, because a
+  // violation is not a wrong edge but a snapshot no session can assemble.
+  if node, ok := g.lookupNode(from); ok && node.External {
+    return
+  }
   // Key on the emitted wire kind, not the internal kind, so two uses of one
   // target that surface as different relationships (a call and a `new`, an
   // `extends` and an `implements` of the same base) are both kept, while
@@ -604,6 +615,20 @@ func (g *Graph) callsWithin(checker *shimchecker.Checker, from string, node *shi
   })
 }
 
+// assignedFunctionTarget returns the graph node an `x.y = function` assignment
+// implements, or "" when the assignment implements no node this graph owns.
+//
+// A declaration outside the workspace is not such a node. `globalThis.assert =
+// …` against a `declare global { function assert(…) }`, or a patched member of
+// a dependency's `@types`, resolves to a symbol whose only declaration is in a
+// declaration file — which has no body, holds no facts, and enters the graph as
+// an external boundary leaf. Re-attributing the assigned body to it moved the
+// implementation's calls and type references onto a node that never ran them,
+// under offsets read against the wrong file: `recordImplementation` already
+// refuses an external node, so the evidence file stayed unset and the spans
+// pointed at neither the declaration nor the implementation. And the edge
+// itself was unassemblable, so every request against such a project failed at
+// shard partition.
 func (g *Graph) assignedFunctionTarget(checker *shimchecker.Checker, from string, node *shimast.Node) string {
   binary := node.AsBinaryExpression()
   if binary == nil ||
@@ -614,7 +639,7 @@ func (g *Graph) assignedFunctionTarget(checker *shimchecker.Checker, from string
     return ""
   }
   target := g.resolve(checker, binary.Left)
-  if target == nil || target.Symbol == nil {
+  if target == nil || target.Symbol == nil || target.External {
     return ""
   }
   to := g.ensureTargetNode(target)

--- a/packages/ttsc/internal/graph/edges.go
+++ b/packages/ttsc/internal/graph/edges.go
@@ -46,17 +46,6 @@ func (g *Graph) addEdge(from, to string, kind EdgeKind) {
 }
 
 func (g *Graph) addEdgeAt(from, to string, kind EdgeKind, origin string, pos, end int) {
-  // An external leaf is a boundary, and a boundary has no outgoing side. The
-  // graph never walks a dependency's internals, so it holds no fact about what
-  // one does — and an edge claiming otherwise has nowhere to live: an external
-  // node is owned by the non-source external shard, and no non-source shard may
-  // own edges (`serve_shards.go`, `TtscGraphShardStore.assertShardContents`).
-  // The producer of such an edge is `assignedFunctionTarget`, which now refuses
-  // one; this is the invariant that outlives any single producer, because a
-  // violation is not a wrong edge but a snapshot no session can assemble.
-  if node, ok := g.lookupNode(from); ok && node.External {
-    return
-  }
   // Key on the emitted wire kind, not the internal kind, so two uses of one
   // target that surface as different relationships (a call and a `new`, an
   // `extends` and an `implements` of the same base) are both kept, while

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -1427,12 +1427,14 @@ export function readDependencyCache(
     moduleOptions: projectModuleOptions(
       meta.moduleOptions as Record<string, unknown>,
     ),
-    // Resolved on the way out, not trusted as written. The pass is idempotent —
-    // a physical path resolves to itself — so it costs one realpath on a hit
-    // and makes a marker written by an earlier ttsc usable instead of
-    // rebuilding. That only arises under the shared `os.tmpdir()/ttsx-dep`
-    // fallback root: the manifest's own `depCacheDir` is per-process and
-    // removed with the run.
+    // Resolved on the way out, not trusted as written. `rootDir` never gated
+    // reuse — the marker's generation, module options, and a non-empty emit do
+    // — so a marker carrying an unresolved spelling was already being reused,
+    // and then served every file of that dependency through the whole-tree stem
+    // rescan. The pass is idempotent and runs only on a hit, which
+    // `ensureProjectBuilt` memoizes per tsconfig. A marker from an earlier ttsc
+    // survives only under the shared `os.tmpdir()/ttsx-dep` fallback root; the
+    // manifest's own `depCacheDir` is per-process and removed with the run.
     rootDir: resolvePhysicalPath(meta.rootDir),
   };
 }
@@ -2064,15 +2066,28 @@ export function realPath(target: string): string {
  * be compared against are produced.
  *
  * `createFilesystemPathIdentityContext` is the same resolver the entry lane
- * uses (`prepareExecution.ts::resolveRuntimeSourceRoot`), and it answers for a
- * path that does not exist yet by resolving as far as the filesystem goes and
- * keeping the rest — so a root the build has not created is still normalized
- * rather than thrown on.
+ * uses (`prepareExecution.ts::resolveRuntimeSourceRoot`). For a path that
+ * exists it is one `realpathSync.native`. For one that does not it resolves as
+ * far as the filesystem goes and folds the missing tail by the case semantics
+ * of the surviving ancestor, which costs a directory read and, on Windows, can
+ * cost an `fsutil` query — worth knowing, but off the path a real dependency
+ * root takes.
+ *
+ * Total on purpose. `throwOnRealpathError: false` silences a failed realpath,
+ * but the case-sensitivity probe can still fail on its own (an unreadable
+ * ancestor, a denied alternate-case `lstat`), and neither caller has anywhere
+ * to put that: `readDependencyCache` is contracted to answer `null` rather than
+ * throw, and `buildDependency` has already produced its emit. The unresolved
+ * spelling is exactly what both had before this pass, so it is the fallback.
  */
 function resolvePhysicalPath(location: string): string {
-  return createFilesystemPathIdentityContext({
-    throwOnRealpathError: false,
-  }).resolve(location).path;
+  try {
+    return createFilesystemPathIdentityContext({
+      throwOnRealpathError: false,
+    }).resolve(location).path;
+  } catch {
+    return location;
+  }
 }
 
 /**
@@ -2091,7 +2106,9 @@ function resolvePhysicalPath(location: string): string {
  * tree per file because a dependency build publishes no emitted-file list.
  *
  * This is the pass the entry lane settled on for the same mixed pair; the two
- * lanes now read alike.
+ * lanes now read alike, `path.isAbsolute` guard included. `readProjectConfig`
+ * absolutizes every path option against the config that declared it, so that
+ * guard is a mirror of the entry lane rather than a live branch.
  */
 function resolveDependencySourceRoot(
   project: ReturnType<typeof readProjectConfig>,

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -1427,7 +1427,13 @@ export function readDependencyCache(
     moduleOptions: projectModuleOptions(
       meta.moduleOptions as Record<string, unknown>,
     ),
-    rootDir: meta.rootDir,
+    // Resolved on the way out, not trusted as written. The pass is idempotent —
+    // a physical path resolves to itself — so it costs one realpath on a hit
+    // and makes a marker written by an earlier ttsc usable instead of
+    // rebuilding. That only arises under the shared `os.tmpdir()/ttsx-dep`
+    // fallback root: the manifest's own `depCacheDir` is per-process and
+    // removed with the run.
+    rootDir: resolvePhysicalPath(meta.rootDir),
   };
 }
 
@@ -1566,10 +1572,7 @@ function buildDependency(
         .join("\n"),
     );
   }
-  const rootDir =
-    typeof project.compilerOptions.rootDir === "string"
-      ? project.compilerOptions.rootDir
-      : project.root;
+  const rootDir = resolveDependencySourceRoot(project);
   const moduleOptions = projectModuleOptions(project.compilerOptions);
   publishDependencyMeta(metaPath, { generation, moduleOptions, rootDir });
   return { emitDir, emittedFiles: undefined, moduleOptions, rootDir };
@@ -2054,6 +2057,53 @@ export function realPath(target: string): string {
   } catch {
     return target;
   }
+}
+
+/**
+ * The physical spelling of a path, produced the way the served sources it will
+ * be compared against are produced.
+ *
+ * `createFilesystemPathIdentityContext` is the same resolver the entry lane
+ * uses (`prepareExecution.ts::resolveRuntimeSourceRoot`), and it answers for a
+ * path that does not exist yet by resolving as far as the filesystem goes and
+ * keeping the rest — so a root the build has not created is still normalized
+ * rather than thrown on.
+ */
+function resolvePhysicalPath(location: string): string {
+  return createFilesystemPathIdentityContext({
+    throwOnRealpathError: false,
+  }).resolve(location).path;
+}
+
+/**
+ * The source-tree root a dependency's emit mirrors, in the spelling
+ * `resolveEmittedJavaScript` compares a served source against.
+ *
+ * Both branches need the pass, for different reasons. A declared `rootDir`
+ * arrives from `readProjectConfig` joined against the config that declared it
+ * but never resolved, so a `rootDir` that is itself a symlinked directory stays
+ * unresolved. `project.root` arrives through plain `fs.realpathSync`, which
+ * follows reparse points but leaves a Windows 8.3 component alone — and
+ * {@link realPath} uses `fs.realpathSync.native`, which expands it. Either way
+ * `path.relative` puts a `..` in front of an in-project source,
+ * `resolveExactEmittedFiles` returns nothing, and every served file of that
+ * dependency falls to the trailing-stem matcher, which rescans the whole emit
+ * tree per file because a dependency build publishes no emitted-file list.
+ *
+ * This is the pass the entry lane settled on for the same mixed pair; the two
+ * lanes now read alike.
+ */
+function resolveDependencySourceRoot(
+  project: ReturnType<typeof readProjectConfig>,
+): string {
+  const rootDir = project.compilerOptions.rootDir;
+  return resolvePhysicalPath(
+    typeof rootDir !== "string"
+      ? project.root
+      : path.isAbsolute(rootDir)
+        ? rootDir
+        : path.resolve(project.root, rootDir),
+  );
 }
 
 /**

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dependency_cache_reads_a_marker_root_in_its_physical_spelling.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_dependency_cache_reads_a_marker_root_in_its_physical_spelling.ts
@@ -1,0 +1,68 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  fs,
+  path,
+  readDependencyCache,
+} from "../../internal/dependency-cache";
+
+/**
+ * Verifies a dependency-cache marker's `rootDir` is read in its physical
+ * spelling, whatever spelling it was written in.
+ *
+ * `rootDir` never gated reuse, so a marker naming a symlinked directory was
+ * always a hit; it just handed `serveBuiltDependency` a root that
+ * `path.relative` could not place the served source under, dropping the
+ * exact-mirror lane for every file of that dependency. The reader is where an
+ * old spelling has to be tolerated, because the persistent fallback cache under
+ * the system temp directory outlives the process that wrote the marker.
+ *
+ * 1. Seed a complete generation whose marker names `src`, a symlink to the real
+ *    `sources` directory.
+ * 2. Read the cache.
+ * 3. Assert the hit reports the real directory, which is its own physical path.
+ */
+export const test_ttsx_dependency_cache_reads_a_marker_root_in_its_physical_spelling =
+  () => {
+    const root = TestProject.tmpdir("ttsx-depcache-root-");
+    const cacheDir = path.join(root, "entry");
+    const metaPath = path.join(root, "entry.json");
+    const generation = "e".repeat(32);
+    const generationDir = path.join(cacheDir, `gen-${generation}`);
+    const realRoot = path.join(root, "sources");
+    const linkedRoot = path.join(root, "src");
+
+    fs.mkdirSync(generationDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(generationDir, "index.js"),
+      "exports.value = 'built';\n",
+    );
+    fs.mkdirSync(realRoot, { recursive: true });
+    try {
+      fs.symlinkSync(realRoot, linkedRoot, "junction");
+    } catch {
+      // Without symlink permission the two spellings never diverge, and the
+      // contract this pins cannot be exercised.
+      return;
+    }
+
+    fs.writeFileSync(
+      metaPath,
+      JSON.stringify({
+        generation,
+        moduleOptions: { module: "commonjs" },
+        rootDir: linkedRoot,
+      }),
+      "utf8",
+    );
+
+    const built = readDependencyCache(cacheDir, metaPath);
+    assert.notEqual(built, null, "the seeded generation should be a hit");
+    assert.equal(
+      built!.rootDir,
+      fs.realpathSync.native(built!.rootDir),
+      "a marker root must be read in the spelling the served sources carry",
+    );
+    assert.equal(built!.rootDir, fs.realpathSync.native(realRoot));
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_is_a_symlink.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_is_a_symlink.ts
@@ -1,0 +1,139 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Verifies a built dependency's published `rootDir` is the physical spelling of
+ * the source path it will be compared against.
+ *
+ * The dependency lane looks a served source up by mirroring
+ * `path.relative(rootDir, source)` into the emit directory, and the source
+ * arrives through `fs.realpathSync.native`. A `rootDir` the owning tsconfig
+ * declares is joined but never resolved, so a `rootDir` that is itself a
+ * symlinked directory makes the pair two spellings of one place:
+ * `path.relative` answers `../sources/index.ts`, the exact-mirror lane is
+ * dropped, and every served file of that dependency falls to the trailing-stem
+ * matcher, which rescans the whole emit tree per file. The marker the build
+ * publishes carries that spelling, so the state outlives the process that
+ * wrote it.
+ *
+ * The run still produces the right file either way, so the marker is what makes
+ * this observable: a `rootDir` equal to its own physical path is exactly the
+ * property the lookup needs.
+ *
+ * 1. Install a dependency whose `rootDir` is `src`, a symlink to the real
+ *    `sources` directory holding its entry.
+ * 2. Run ttsx against an entry that requires it, then prints every dependency
+ *    marker's `rootDir`.
+ * 3. Assert the dependency ran and every published `rootDir` is its own
+ *    physical path.
+ */
+export const test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_is_a_symlink =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({ private: true }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "nodenext",
+          moduleResolution: "nodenext",
+          strict: true,
+          rootDir: "src",
+        },
+        include: ["src"],
+      }),
+      "node_modules/dep/package.json": JSON.stringify({
+        name: "dep",
+        version: "1.0.0",
+        main: "src/index.ts",
+      }),
+      // `files` is taken verbatim by tsgo, so the emit mirrors the declared
+      // `src` spelling whether or not the walker would have resolved a glob.
+      "node_modules/dep/tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          outDir: "lib",
+          rootDir: "src",
+        },
+        files: ["src/index.ts"],
+      }),
+      "node_modules/dep/sources/index.ts": `export const VALUE: string = "dep-value";\n`,
+      // The entry reads the runtime manifest to find the shared dependency
+      // cache, then reports the `rootDir` of every marker the run published.
+      // The markers live under a per-process directory ttsx deletes when the
+      // child exits, so the child is the only place they can be observed.
+      "src/main.ts": [
+        `declare function require<T = unknown>(name: string): T;`,
+        `declare const process: { env: Record<string, string | undefined> };`,
+        ``,
+        `const dep = require<{ VALUE: string }>("dep");`,
+        `const fs = require<{`,
+        `  readFileSync(file: string, encoding: string): string;`,
+        `  readdirSync(directory: string): string[];`,
+        `}>("node:fs");`,
+        `const path = require<{ join(...parts: string[]): string }>(`,
+        `  "node:path",`,
+        `);`,
+        ``,
+        `const manifest = JSON.parse(`,
+        `  fs.readFileSync(process.env.TTSX_RUNTIME_MANIFEST ?? "", "utf8"),`,
+        `) as { depCacheDir: string };`,
+        `const roots = fs`,
+        `  .readdirSync(manifest.depCacheDir)`,
+        `  .filter((name) => name.endsWith(".json"))`,
+        `  .map(`,
+        `    (name) =>`,
+        `      (`,
+        `        JSON.parse(`,
+        `          fs.readFileSync(path.join(manifest.depCacheDir, name), "utf8"),`,
+        `        ) as { rootDir: string }`,
+        `      ).rootDir,`,
+        `  );`,
+        ``,
+        `console.log("VALUE:" + dep.VALUE);`,
+        `console.log("ROOTS:" + JSON.stringify(roots));`,
+        ``,
+      ].join("\n"),
+    });
+    try {
+      fs.symlinkSync(
+        path.join(root, "node_modules", "dep", "sources"),
+        path.join(root, "node_modules", "dep", "src"),
+        "junction",
+      );
+    } catch {
+      // Without symlink permission the declared and physical spellings never
+      // diverge, and the contract this pins cannot be exercised.
+      return;
+    }
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/main.ts"],
+      { cwd: root },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /VALUE:dep-value/);
+
+    const line = result.stdout
+      .split(/\r?\n/)
+      .find((text) => text.startsWith("ROOTS:"));
+    assert.notEqual(line, undefined, result.stdout);
+    const roots = JSON.parse(line!.slice("ROOTS:".length)) as string[];
+    assert.ok(
+      roots.length !== 0,
+      `the dependency lane published no build marker: ${result.stdout}`,
+    );
+    for (const published of roots) {
+      assert.equal(
+        fs.realpathSync.native(published),
+        published,
+        "a published dependency rootDir is not its own physical path, so the " +
+          "exact-mirror lookup compares two spellings of one directory",
+      );
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_is_a_symlink.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_is_a_symlink.ts
@@ -22,12 +22,18 @@ import path from "node:path";
  * this observable: a `rootDir` equal to its own physical path is exactly the
  * property the lookup needs.
  *
- * 1. Install a dependency whose `rootDir` is `src`, a symlink to the real
- *    `sources` directory holding its entry.
- * 2. Run ttsx against an entry that requires it, then prints every dependency
+ * Both branches are covered. One dependency declares `rootDir: "src"`, a
+ * symlink to the real `sources` directory, which diverges on every platform.
+ * The other declares no `rootDir` at all and falls back to the project root,
+ * which diverges only on Windows, where the runner's temp root carries an 8.3
+ * component that plain `fs.realpathSync` keeps and `fs.realpathSync.native`
+ * expands.
+ *
+ * 1. Install those two dependencies.
+ * 2. Run ttsx against an entry that requires both, then prints every dependency
  *    marker's `rootDir`.
- * 3. Assert the dependency ran and every published `rootDir` is its own physical
- *    path.
+ * 3. Assert both dependencies ran and every published `rootDir` is its own
+ *    physical path.
  */
 export const test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_is_a_symlink =
   () => {
@@ -61,6 +67,27 @@ export const test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_
         files: ["src/index.ts"],
       }),
       "node_modules/dep/sources/index.ts": `export const VALUE: string = "dep-value";\n`,
+      // A second dependency that declares no `rootDir`, so the build falls back
+      // to the project root. That arrives through plain `fs.realpathSync`,
+      // which leaves a Windows 8.3 component alone while the served source
+      // arrives through `fs.realpathSync.native`, which expands it. The two
+      // spellings diverge only on Windows, where the temp root really is
+      // `C:\\Users\\RUNNER~1\\...` on a GitHub runner.
+      "node_modules/dep2/package.json": JSON.stringify({
+        name: "dep2",
+        version: "1.0.0",
+        main: "index.ts",
+      }),
+      "node_modules/dep2/tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "commonjs",
+          strict: true,
+          outDir: "lib",
+        },
+        files: ["index.ts"],
+      }),
+      "node_modules/dep2/index.ts": `export const VALUE2: string = "dep2-value";\n`,
       // The entry reads the runtime manifest to find the shared dependency
       // cache, then reports the `rootDir` of every marker the run published.
       // The markers live under a per-process directory ttsx deletes when the
@@ -70,6 +97,7 @@ export const test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_
         `declare const process: { env: Record<string, string | undefined> };`,
         ``,
         `const dep = require<{ VALUE: string }>("dep");`,
+        `const dep2 = require<{ VALUE2: string }>("dep2");`,
         `const fs = require<{`,
         `  readFileSync(file: string, encoding: string): string;`,
         `  readdirSync(directory: string): string[];`,
@@ -93,7 +121,7 @@ export const test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_
         `      ).rootDir,`,
         `  );`,
         ``,
-        `console.log("VALUE:" + dep.VALUE);`,
+        `console.log("VALUE:" + dep.VALUE + "/" + dep2.VALUE2);`,
         `console.log("ROOTS:" + JSON.stringify(roots));`,
         ``,
       ].join("\n"),
@@ -117,16 +145,17 @@ export const test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_
     );
 
     assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /VALUE:dep-value/);
+    assert.match(result.stdout, /VALUE:dep-value\/dep2-value/);
 
     const line = result.stdout
       .split(/\r?\n/)
       .find((text) => text.startsWith("ROOTS:"));
     assert.notEqual(line, undefined, result.stdout);
     const roots = JSON.parse(line!.slice("ROOTS:".length)) as string[];
-    assert.ok(
-      roots.length !== 0,
-      `the dependency lane published no build marker: ${result.stdout}`,
+    assert.equal(
+      roots.length,
+      2,
+      `the dependency lane did not publish a marker per dependency: ${result.stdout}`,
     );
     for (const published of roots) {
       assert.equal(

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_is_a_symlink.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_is_a_symlink.ts
@@ -15,8 +15,8 @@ import path from "node:path";
  * `path.relative` answers `../sources/index.ts`, the exact-mirror lane is
  * dropped, and every served file of that dependency falls to the trailing-stem
  * matcher, which rescans the whole emit tree per file. The marker the build
- * publishes carries that spelling, so the state outlives the process that
- * wrote it.
+ * publishes carries that spelling, so the state outlives the process that wrote
+ * it.
  *
  * The run still produces the right file either way, so the marker is what makes
  * this observable: a `rootDir` equal to its own physical path is exactly the
@@ -26,8 +26,8 @@ import path from "node:path";
  *    `sources` directory holding its entry.
  * 2. Run ttsx against an entry that requires it, then prints every dependency
  *    marker's `rootDir`.
- * 3. Assert the dependency ran and every published `rootDir` is its own
- *    physical path.
+ * 3. Assert the dependency ran and every published `rootDir` is its own physical
+ *    path.
  */
 export const test_ttsx_publishes_a_physical_root_for_a_dependency_whose_rootdir_is_a_symlink =
   () => {


### PR DESCRIPTION
Single cycle pull request for the issue campaign over #1073, #1080, and #1082, plus the two issues its discovery rounds published.

## Cycle scope

| Issue | Subject |
| --- | --- |
| #1073 | ttsx's dependency lane compares an unresolved `rootDir` against a resolved source path |
| #1080 | Stale references left by the benchmark package split |
| #1082 | `@ttsc/graph` shards exclude external nodes but keep the edges leaving them |
| #1083 | Benchmark run reports land under a root neither harness designates for them |
| #1084 | graph benchmark `publish` resolves a relative `--from` against the repository root, then reports success after folding nothing |

## Discovery gate

Two complete full-scope rounds ran against `master` @ `9450025b4`. Round 1 published #1083 and #1084; Round 2 produced no meaningful candidate, which froze the accepted set above.

## What landed

- **#1082** — `assignedFunctionTarget` no longer re-attributes an assigned function body to a symbol declared outside the workspace. That single cause produced all three reported symptoms: the unassemblable shard, the evidence spans pointing at neither file, and the unset implementation source. Two Go tests cover both branches of the externality classifier, plus one serve-level test for the reported symptom.
- **#1073** — a dependency's `rootDir` is now produced by the same pass the served source is, in both the declared and the undeclared branch, and a marker's root is resolved on read. One e2e test covering both branches, one deterministic test for the reader.
- **#1080** — six stale references corrected, and the usage-header rule widened to the two script names pnpm actually shadows.
- **#1083** — each harness's report now lands under the root that run resolved, and the graph environment table lists every variable the package consults.
- **#1084** — a cell report path is absolute at the writer, so the publisher, the trace auditor, and the suite share one base; a source directory that contributes no measurement is refused instead of publishing an empty dashboard; the auditor no longer drops an unreadable cell in silence.

## Review

One read-only Individual Self-Review per pushed issue-implementation commit, each adjudicated and recorded as a formal `COMMENT` review below. One of them caught a blocking regression before it shipped: dropping the publisher's repository-root probe would have aborted every publish, because the field it resolves is written by the agent runner rather than by the suite runner. Overall Self-Review runs solo over the whole base-to-head diff and restarts after every correction.

Closing keywords are carried by the commits that earn them, so the merge closes exactly what landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
