### PR TITLE
docs: compose the root README from the package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A `typescript-go` toolchain for compiler-powered plugins and type-safe execution
 - **`ttsc`**: build, check, and transform.
 - **`ttsx`**: execute TypeScript with type checking.
 - [**`@ttsc/lint`**](https://github.com/samchon/ttsc/tree/master/packages/lint): lint violations as compiler errors.
-- [**`@ttsc/evidence`**](https://github.com/samchon/ttsc/tree/master/packages/evidence): requirements as compiler errors until code acknowledges them.
-- [**`@ttsc/graph`**](https://github.com/samchon/ttsc/tree/master/packages/graph): code knowledge graph that reduces agent token usage.
+- [**`@ttsc/evidence`**](https://github.com/samchon/ttsc/tree/master/packages/evidence): 100% requirement coverage, or the build fails.
+- [**`@ttsc/graph`**](https://github.com/samchon/ttsc/tree/master/packages/graph): compiler knowledge graph that cuts agent tokens by 92%.
 - **plugin support**: compiler-powered libraries, such as `typia`.
 
 ## Setup
@@ -38,135 +38,76 @@ That covers the CLI. The integrations each have a short guide:
 
 ## Lint
 
-Lint and format at compiler speed: up to 800x faster than ESLint.
-
-`@ttsc/lint` replaces ESLint and Prettier with rules that run inside the type-check. It shares one AST pass with the compiler, so linting and formatting add almost nothing to the build you already run.
-
-Configuration is a single file. Each rule takes `"error"`, `"warning"`, or `"off"`, and the `format` block mirrors `.prettierrc`.
-
-```bash
-npm install -D @ttsc/lint
-```
-
-```ts
-// lint.config.ts
-import type { ITtscLintConfig } from "@ttsc/lint";
-
-export default {
-  rules: {
-    "no-var": "error",
-    "prefer-const": "error",
-    "typescript/no-explicit-any": "warning",
-  },
-  format: {
-    printWidth: 100,
-    singleQuote: true,
-    trailingComma: "all",
-  },
-} satisfies ITtscLintConfig;
-```
-
-Violations surface as compiler diagnostics, in the same stream as type errors, so the CI step that already runs `ttsc --noEmit` gates lint without a second job:
+Lint and format inside the type-check you already run. 720+ rules across 21 families, plus a formatter that reproduces Prettier's output.
 
 ```ts
 // src/index.ts
-var count = 3;
-let total = count;
+var x: number = 3;
+let y: number = 4;
+const z: string = 5;
 ```
 
-```text
+```bash
 $ npx ttsc --noEmit
-src/index.ts:1:1 - error TS11966: [no-var] Unexpected var, use let or const instead.
+src/index.ts:3:7 - error TS2322: Type 'number' is not assignable to type 'string'.
 
-1 var count = 3;
-  ~~~
+3 const z: string = 5;
+        ~
 
 src/index.ts:2:5 - error TS17397: [prefer-const] Use const instead of let.
 
-2 let total = count;
-    ~~~~~
+2 let y: number = 4;
+      ~~~~~~~~~~~~~
 
-Found 2 errors in the same file, starting at: src/index.ts:1
+src/index.ts:1:1 - error TS11966: [no-var] Unexpected var, use let or const instead.
+
+1 var x: number = 3;
+  ~~~~~~~~~~~~~~~~~~
+
+Found 3 errors in the same file, starting at: src/index.ts:3
 ```
 
-Clean the project in place:
+Type errors and lint violations arrive in one stream, so the CI step that already runs `ttsc --noEmit` gates lint with no second job and no second parse. On vscode's 6,093 files the rules take 73 ms inside that check, where ESLint spends 66.7 s as its own command.
 
-```bash
-npx ttsc fix      # lint autofixes + format edits
-npx ttsc format   # format edits only, never changes behavior
-```
+`npx ttsc fix` applies autofixes and formatting; `npx ttsc format` only formats. Rules and every `format` key are in the [Lint and Format guide](https://ttsc.dev/docs/lint).
 
-The rule catalog and every `format` key are in the [Lint & Format guide](https://ttsc.dev/docs/lint).
+## Evidence Graph
 
-## Evidence
-
-Your spec becomes a compile error. An agent can still lie, but it cannot lie by omission.
-
-`@ttsc/evidence` makes every requirement you configure demand an explicit acknowledgement from the code, test, or document that claims to satisfy it. A requirement nothing acknowledges fails the build, by name.
-
-It is a rule contributor to `@ttsc/lint` rather than a top-level `ttsc` plugin, so it registers in the same `lint.config.ts`:
-
-```bash
-npm install -D @ttsc/lint @ttsc/evidence
-```
-
-```ts
-// lint.config.ts
-import { evidence, type ITtscEvidenceGraphConfig } from "@ttsc/evidence";
-import type { ITtscLintConfig } from "@ttsc/lint";
-
-const graph: ITtscEvidenceGraphConfig = {
-  claims: [
-    {
-      type: "typescript",
-      files: ["src/components/**/*.tsx"],
-      symbol: "function",
-      reference: {
-        type: "markdown",
-        files: ["docs/requirements/**/*.md"],
-        symbol: ["h2", "h3"],
-      },
-    },
-  ],
-};
-
-export default {
-  plugins: { evidence },
-  rules: { "evidence/graph": ["error", graph] },
-} satisfies ITtscLintConfig;
-```
-
-That claim reads as one sentence: the components under `src` implement the requirements, so every H2 and H3 under `docs/requirements` must be cited by a component. A citation names the target and states why it applies:
+Your spec becomes a compile error, so requirement coverage is 100% or the build does not pass. An agent can still lie, but it cannot lie by omission.
 
 ```tsx
 /**
- * @evidence docs/requirements/discount.md#coupon-stacking Renders the combination limit defined by this rule.
+ * @evidence docs/discount.md#coupon-stacking
+ *           States the per-issuer stacking limit
+ *           this section defines, in the buyer's words.
+ * @evidence POST:/orders/{orderId}/coupons
+ *           Explains the rejection this endpoint returns
+ *           for an over-stacked coupon set.
+ * @evidence {@link hooks.useCouponStacking} Renders the limit this hook resolves.
  */
-export function CouponStackingNotice() {
-  return <p>One seller coupon and one platform coupon may be combined.</p>;
-}
+export function CouponStackingNotice(props: IProps): JSX.Element;
 ```
 
-Without it, the next build stops:
-
-```text
-$ npx ttsc --noEmit
-error TS16411: [evidence/graph] Missing acknowledgement for 'docs/requirements/discount.md#coupon-stacking' (Markdown H2 'Coupon Stacking' at docs/requirements/discount.md:3) in Claim 1 reference 1 (markdown, symbols: h2, h3). Use @evidence on a selected typescript host or @evidenceExclude on an eligible carrier.
-```
-
-Markdown sections, Prisma models and columns, Swagger operations, and TypeScript symbols can all ground an obligation. Coverage is counted per obligation and never pooled, so a rule the backend honored and the frontend forgot is a compile error naming the section rather than a percentage. The claim surface, tag grammar, and adoption path are in the [Evidence Graph guide](https://ttsc.dev/docs/evidence).
-
-## Graph
-
-Your coding agent answers from the compiler, spending roughly 90% fewer tokens.
-
-`@ttsc/graph` is an MCP server that gives the agent a compiler-resolved graph of your project: what calls what, what a change would touch, and where to start reading. The agent asks the type checker instead of grepping and re-reading files.
-
-Register it with your MCP client. For Claude Code, a `.mcp.json` in the project root:
+`@evidence <target> <reason>` names one unit of the spec and why this declaration answers for it. A target is a document section, an API operation, a database schema model, or a TypeScript symbol as an inline link.
 
 ```bash
-npm install -D ttsc @ttsc/graph typescript
+$ npx ttsc
+error TS16411: [evidence/graph] Missing acknowledgement for 'docs/discount.md#coupon-stacking'
+  (Markdown H2 'Coupon Stacking' at docs/discount.md:3)
+  in Claim 1 reference 1 (markdown, symbols: h2, h3).
+
+  Use @evidence on a selected typescript host or @evidenceExclude on an eligible carrier.
+
+Found 3 errors.
 ```
+
+Without those tags, the build fails once per obligation, because one reference never covers another. An AI coding agent has to clear them to finish, and clearing them means citing each target and writing down why its code answers for it.
+
+![Coverage and token spend, Plain against Evidence](https://ttsc.dev/benchmark/png/evidence-summary.png)
+
+## Compiler Knowledge Graph
+
+Your coding agent answers from the compiler instead of grepping and re-reading files.
 
 ```json
 {
@@ -179,7 +120,9 @@ npm install -D ttsc @ttsc/graph typescript
 }
 ```
 
-On the agent-cost benchmark, Claude agents answer reading zero files, cutting tokens by roughly 90% and tool calls by 93% to 96%. The design and per-repository numbers are in the [Compiler Knowledge Graph guide](https://ttsc.dev/docs/graph) and the [benchmark](https://ttsc.dev/docs/benchmark/graph).
+One typed MCP tool over a graph the type checker resolved: what calls what, what a change would touch, where to start reading. Answers carry names, signatures, edges, and spans, never file bodies, so a large repository cannot inflate the response.
+
+Across 64 measured question and model pairs, the median answer costs 92% fewer tokens and 95% fewer tool calls than the same agent with no MCP. The design and the comparators are in [`@ttsc/graph`](https://github.com/samchon/ttsc/tree/master/packages/graph).
 
 ![Median tokens on the shared onboarding question, lower is better](https://ttsc.dev/benchmark/svg/graph-common-codex-gpt-5.6-sol.svg)
 

--- a/packages/evidence/README.md
+++ b/packages/evidence/README.md
@@ -6,39 +6,62 @@
 
 Evidence Graph, your spec as a compile error no coding agent can skip.
 
-```typescript
- * @evidence docs/discount.md#coupon-stacking States the per-issuer stacking limit
- *                                            this section defines, in the buyer's words.
- * @evidence POST:/orders/{orderId}/coupons Explains the rejection this endpoint returns
- *                                          for an over-stacked coupon set.
+```tsx
+/**
+ * @evidence docs/discount.md#coupon-stacking
+ *           States the per-issuer stacking limit
+ *           this section defines, in the buyer's words.
+ * @evidence POST:/orders/{orderId}/coupons
+ *           Explains the rejection this endpoint returns
+ *           for an over-stacked coupon set.
+ * @evidence {@link hooks.useCouponStacking} Renders the limit this hook resolves.
  */
 export function CouponStackingNotice(props: IProps): JSX.Element;
 ```
 
-`@evidence <target> <reason>` names one unit of the spec and says why this declaration answers for it. A target is a document section, a schema model, an API operation, or a TypeScript symbol written as `{@link hooks.useCouponStacking}`.
+`@evidence <target> <reason>` names one unit of the spec and why this declaration answers for it. A target is a document section, an API operation, a database schema model, or a TypeScript symbol as an inline link.
 
-```text
+```bash
 $ npx ttsc
+error TS16411: [evidence/graph] Missing acknowledgement for 'docs/discount.md#coupon-stacking'
+  (Markdown H2 'Coupon Stacking' at docs/discount.md:3)
+  in Claim 1 reference 1 (markdown, symbols: h2, h3).
+
+  Use @evidence on a selected typescript host or @evidenceExclude on an eligible carrier.
+
+error TS16411: [evidence/graph] Missing acknowledgement for 'POST:/orders/{orderId}/coupons'
+  (Swagger operation 'POST /orders/{orderId}/coupons' at api/openapi.json)
+  in Claim 1 reference 2 (swagger operations).
+
+  Use @evidence on a selected typescript host or @evidenceExclude on an eligible carrier.
+
 error TS16411: [evidence/graph] Missing acknowledgement for 'useCouponStacking'
   (TypeScript function 'useCouponStacking' at src/lib/coupons/hooks.ts:12)
   in Claim 1 reference 3 (typescript, symbols: function).
 
   Use @evidence on a selected typescript host or @evidenceExclude on an eligible carrier.
 
-Found 1 error.
+Found 3 errors.
 ```
 
-Two citations were not enough. This screen also owes the hook it renders, and the build names the obligation it skipped rather than the two it met.
+Without those tags, the build fails once per obligation, because one reference never covers another.
+
+An AI coding agent has to clear them to finish, and clearing them means citing each target and writing down why its code answers for it. Coverage reaches 100% on its own, as the residue of the errors it closed.
 
 ![Coverage and token spend across all four subjects](https://ttsc.dev/benchmark/png/evidence-summary.png)
 
-So a coding agent ships at 100% coverage every time, instead of wherever its own review loop happened to stop.
-
 ## Setup
 
+### Install
+
 ```bash
-npm install -D typescript ttsc @ttsc/lint @ttsc/evidence
+npm install -D typescript ttsc @ttsc/lint
+npm install -D @ttsc/evidence
 ```
+
+This is a rule contributor to [`@ttsc/lint`](https://github.com/samchon/ttsc/tree/master/packages/lint) 0.22 or newer, so it runs on [`ttsc`](https://github.com/samchon/ttsc) rather than on stock `tsc` with ESLint.
+
+### Configure
 
 ```ts
 // lint.config.ts
@@ -68,7 +91,176 @@ export default {
 
 One sentence: the components under `src` implement the docs, so every H2 and H3 under `docs` must be cited by a component. Violations arrive in the same stream as type errors, so there is no CI job to add.
 
-This is a rule contributor to [`@ttsc/lint`](https://github.com/samchon/ttsc/tree/master/packages/lint) 0.22 or newer, so it runs on [`ttsc`](https://github.com/samchon/ttsc) rather than on stock `tsc` with ESLint.
+### Rules
+
+| Rule | Takes | What it does |
+| --- | --- | --- |
+| `evidence/graph` | [`ITtscEvidenceGraphConfig`](https://github.com/samchon/ttsc/blob/master/packages/evidence/src/structures/ITtscEvidenceGraphConfig.ts) | The graph itself. Project-scoped, so its entry declares no `files`. |
+| `evidence/documented` | nothing | Requires a JSDoc block on every selected export, since a block is the only place a citation can live. |
+| `evidence/singular` | nothing | Keeps one public identity per file, named after the file. |
+| `evidence/todo` | nothing | Fails on every remaining JSDoc `@todo`, with its own text. |
+
+Each takes `"error"`, `"warning"`, or `"off"`.
+
+## Claims and references
+
+A claim is the population that owes a citation, a reference is what it owes, and every claim and reference pair is its own 100% obligation. Listing two references means both must be satisfied, and a citation toward one never counts toward the other. They all join the same `claims` array.
+
+| Kind | Units | Claim | Reference | Cites in |
+| --- | --- | --- | --- | --- |
+| Markdown | file, H1 to H4 sections | yes | yes | an HTML comment |
+| Prisma | model, column, relation | yes | yes | a `///` comment |
+| TypeScript | types, functions, properties | yes | yes | JSDoc |
+| Swagger / OpenAPI | each operation under `paths` | no | yes | nothing, it cannot host a tag |
+
+Every population takes glob patterns in `files`, resolved against the `ttsc` project root. Add `root` to resolve against another directory instead, inside the project, above it, or absolute, which is how several packages in a monorepo share one requirements set and write the same citation.
+
+### Documents
+
+```ts
+{
+  type: "markdown",
+  files: ["docs/requirements/**/*.md"],
+  reference: {
+    type: "markdown",
+    files: ["docs/meetings/**/*.md"],
+    symbol: ["h2", "h3"],
+  },
+}
+```
+
+Markdown grounds Markdown, so a decision taken in a meeting and never written into the requirements fails the build. Deleting a requirement breaks every document that leaned on it, which is what stops a ghost spec from outliving its own source.
+
+```md
+## Coupon Stacking {#coupon-stacking}
+
+<!-- @evidence docs/meetings/2026-01-12.md#discount-policy Carries the limit agreed in that meeting. -->
+```
+
+A citation sits in an HTML comment, so rendered prose stays clean, and a heading declares its own anchor with the `{#id}` suffix. A section citation sits under its heading; a whole-file citation sits at the top.
+
+### Database schema
+
+```ts
+{
+  type: "prisma",
+  files: ["prisma/schema/**/*.prisma"],
+  symbol: "model",
+  reference: {
+    type: "markdown",
+    files: ["docs/requirements/**/*.md"],
+    symbol: "h2",
+  },
+}
+```
+
+Every model justifies itself against a requirement, so a table nobody asked for has nothing to cite. Reverse the pair to make a provider owe the model it reads.
+
+```prisma
+/// @evidence docs/requirements/pricing.md#discount-policy Discount columns exist for this policy.
+model Sale {
+  /// @evidence docs/requirements/pricing.md#coupon-stacking The stacking limit is stored here.
+  coupon_limit Int
+}
+```
+
+A model is addressed as `prisma:Sale` and a member as `prisma:Sale.price`, never through the file it sits in, so moving a model between files cannot break a citation. Every matched file is parsed as one schema.
+
+### API operations
+
+```ts
+{
+  type: "typescript",
+  files: ["src/controllers/**/*.ts"],
+  reference: {
+    type: "swagger",
+    file: "https://raw.githubusercontent.com/samchon/shopping/refs/heads/master/packages/api/swagger.json",
+  },
+}
+```
+
+Each operation under `paths` is one obligation, so an operation the spec adds and nobody implemented is a compile error on the next build. The singular `file` names one local path or one `http:` URL, never a glob; use a `reference` array for several documents.
+
+An operation is cited as `POST:/orders`, one whitespace-free token, so the method and the path stay one target. Swagger grounds a claim and never makes one, because an operation has nowhere to host a tag.
+
+### Symbols
+
+```ts
+{
+  type: "typescript",
+  files: ["src/lib/*/hooks.ts"],
+  symbol: "function",
+  reference: {
+    type: "typescript",
+    package: "@ORGANIZATION/PROJECT-api",
+    files: ["src/functional/**/*.ts"],
+    symbol: ["function"],
+  },
+}
+```
+
+`files` selects modules and the population is what those modules publish, so a barrel carries in the surface it forwards. A `package` population is read from disk rather than from the program, because a symbol nothing imports is absent from the program and is exactly the one an obligation needs to name.
+
+A unit is addressed the way a consumer reaches it, so `export * as functional` nests a segment and `export { A as B }` answers to `B`. Only TypeScript may cite TypeScript: `{@link}` resolves through the citing module's own imports, and no document has an import scope to resolve in.
+
+### Symbol selectors
+
+`symbol` picks which units a reference materializes, and on a claim it restricts which declarations may host a tag.
+
+| Kind | Values | Default on a claim | Default on a reference |
+| --- | --- | --- | --- |
+| Markdown | `file`, `h1`, `h2`, `h3`, `h4` | all five | all five |
+| Prisma | `model`, `column`, `relation` | all three | `model` |
+| TypeScript | `type`, `function`, `property` | all three | `type` |
+| Swagger | none, every operation is selected | not applicable | every operation |
+
+Units keep their hierarchy, so a target acknowledges itself and every selected descendant: citing a heading covers its subsections, an interface covers its properties, and `prisma:Sale` covers the columns beneath it. An ancestor stays addressable even when its own kind is not selected.
+
+A declaration whose documentation carries `@internal`, `@hidden`, or `@ignore` leaves the population entirely. It owes nothing and can carry nothing, and citing one is reported rather than silently ignored.
+
+### Exclusions
+
+```md
+<!-- @evidenceExclude docs/requirements/pricing.md#coupon-stacking
+     This release ships a single coupon. Stacking waits for the settlement policy. -->
+```
+
+`@evidenceExclude <target> <reason>` records that a claim intentionally does not use a scope. It follows the same hierarchy as `@evidence`, affects only the claim it is written in, and one obligation may exclude a scope only once.
+
+It is the only acknowledgement that settles an obligation without anything being built, so it exists to be vetoed. "Not applicable" is a conclusion rather than a reason.
+
+```ts
+{
+  type: "typescript",
+  files: ["src/components/**/*.tsx", "src/components/EXCLUSIONS.ts"],
+  evidenceExcludeCarriers: ["src/components/EXCLUSIONS.ts"],
+  symbol: "function",
+  reference: { type: "markdown", files: ["docs/**/*.md"], symbol: "h2" },
+}
+```
+
+`evidenceExcludeCarriers` confines them to a named ledger. Scattered through the population, reading every exclusion means reading the population; gathered in one file it means opening one file. An exclusion written anywhere else is reported where it sits and discharges nothing.
+
+### Strict references
+
+Ordinary coverage is permissive, which is right for a document several modules honor and too weak for a proof obligation, where one exclusion or one host citing everything discharges the whole population. Three properties tighten a single reference, and they never pool across references.
+
+```ts
+{
+  type: "typescript",
+  package: "@ORGANIZATION/PROJECT-api",
+  files: ["src/functional/**/*.ts"],
+  symbol: ["function"],
+  noEvidenceExclude: true,
+  singleEvidencePerSymbol: true,
+}
+```
+
+- `noEvidenceExclude` refuses exclusions, so the target still owes positive evidence. A published accessor no hook consumes is an omission rather than a decision.
+- `uniqueEvidence` allows at most one host per unit, so one host is answerable for it rather than several.
+- `singleEvidencePerSymbol` requires exactly one unit from every selected host, so a host citing nothing and a host citing everything both fail.
+
+Counting is by identity rather than by text. Repeated tags for one unit count once, an overload set stays one host, and citing a parent of two selected units counts as two.
 
 ## Sponsors
 
@@ -82,7 +274,6 @@ Your [donation](https://github.com/sponsors/samchon) encourages `@ttsc/evidence`
 
 - [`ttsc`](https://github.com/samchon/ttsc): the TypeScript-Go toolchain this plugin runs on.
 - [`@ttsc/lint`](https://github.com/samchon/ttsc/tree/master/packages/lint): the lint engine that links this rule into the compiler.
-- [Evidence Graph guide](https://ttsc.dev/docs/evidence): claims, symbol selectors, populations above the project, and staged adoption.
-- [Evidence Graph benchmark](https://ttsc.dev/docs/benchmark/evidence): the cohort above, and how to run it.
-- [`benchmarks/evidence/template`](https://github.com/samchon/ttsc/tree/master/benchmarks/evidence/template): a full wiring across a Prisma schema, a NestJS API, a generated SDK, tests, screens, and E2E journeys.
-- Adopting it on a team? Reach me on [Discord](https://discord.gg/E94XhzrUCZ).
+- [Guide Documents](https://ttsc.dev/docs/evidence)
+- [Benchmark Diagram](https://ttsc.dev/docs/benchmark/evidence)
+- [`samchon/evidence-benchmark-results`](https://github.com/samchon/evidence-benchmark-results)


### PR DESCRIPTION
The root README wrote its own version of what each package already says, longer and worse. Lint, Evidence Graph, and Compiler Knowledge Graph now carry the same example, the same output, and the same shape their package README opens with. 238 lines to 182.

**Two claims were not supported by this repository's own data.**

| Was | Recomputed |
| --- | --- |
| `up to 800x faster than ESLint` | That is the rule-evaluation slice alone (`lintPluginSamples`). The whole command is 3x to 11x, and on nestjs and rxjs it is slower than ESLint. Now stated as what it measures: 73 ms of rules inside a check that runs anyway, against 66.7 s of ESLint on vscode. |
| `roughly 90% fewer tokens, 93% to 96% tool calls` | Recomputed from `website/public/benchmark/graph.json` over 64 paired cells: median 92% and 95%. |

**Layout.** Every lead-in above a code block is gone. A block is scanned before its prose, so the prose reads as a caption beneath it, and nothing sits below a benchmark image.

**`packages/evidence/README.md`** drops from 522 lines to a screen: the citation, the compile error it earns, the chart, and one detailed `Claims and references` section. Swagger caching keys, watch cycles, and namespace merge semantics belong to the guide. Diagnostic wording follows the real ones (`typescript.go:858`, `graph.go:1365`).

Docs only. The evidence chart resolves once the Actions outage clears and the website deploys; a local `pnpm --dir website run build` passed end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)