### PR TITLE
docs(evidence): rewrite the chapter around what the graph measures

### DIFF
--- a/packages/evidence/README.md
+++ b/packages/evidence/README.md
@@ -96,7 +96,7 @@ One sentence: the components under `src` implement the docs, so every H2 and H3 
 | Rule | Takes | What it does |
 | --- | --- | --- |
 | `evidence/graph` | [`ITtscEvidenceGraphConfig`](https://github.com/samchon/ttsc/blob/master/packages/evidence/src/structures/ITtscEvidenceGraphConfig.ts) | The graph itself. Project-scoped, so its entry declares no `files`. |
-| `evidence/documented` | nothing | Requires a JSDoc block on every selected export, since a block is the only place a citation can live. |
+| `evidence/documented` | [`ITtscEvidenceDocumentedConfig`](https://github.com/samchon/ttsc/blob/master/packages/evidence/src/structures/ITtscEvidenceDocumentedConfig.ts) | Requires a JSDoc block on every selected export, since a block is the only place a citation can live. `symbol` narrows the kinds; it defaults to all three. |
 | `evidence/singular` | nothing | Keeps one public identity per file, named after the file. |
 | `evidence/todo` | nothing | Fails on every remaining JSDoc `@todo`, with its own text. |
 

--- a/website/src/components/benchmark/evidence/TtscWebsiteBenchmarkEvidenceCoverage.tsx
+++ b/website/src/components/benchmark/evidence/TtscWebsiteBenchmarkEvidenceCoverage.tsx
@@ -65,7 +65,7 @@ export default function TtscWebsiteBenchmarkEvidenceCoverage({
       <div className="divide-y divide-[#eef4fa] px-5 py-2">
         {rows.map((row) => {
           const expandable = expandableRows && row.edges.length > 0;
-          const expanded = open === row.id;
+          const expanded = expandable && open === row.id;
           return (
             <div key={row.id} className="py-2">
               <button

--- a/website/src/components/benchmark/evidence/TtscWebsiteBenchmarkEvidenceCoverage.tsx
+++ b/website/src/components/benchmark/evidence/TtscWebsiteBenchmarkEvidenceCoverage.tsx
@@ -11,6 +11,10 @@ import useTtscWebsiteBenchmarkEvidenceTooltip, {
 } from "./TtscWebsiteBenchmarkEvidenceTooltip";
 import useTtscWebsiteBenchmarkEvidenceData from "./useTtscWebsiteBenchmarkEvidenceData";
 
+/** Why the fold produces one number, said the same way wherever it is drawn. */
+const DESCRIPTION =
+  "Thirteen reference edges, folded so serial hops multiply and branches average. Higher is better.";
+
 /**
  * How much of the provenance graph each arm's codebase satisfies.
  *
@@ -21,8 +25,19 @@ import useTtscWebsiteBenchmarkEvidenceData from "./useTtscWebsiteBenchmarkEviden
  *
  * The block draws nothing when no cohort has been counted, rather than zeroes,
  * which would be a claim about a codebase nobody read.
+ *
+ * @param className Spacing around the panel, owned by the page that places it.
+ * @param expandable Whether a row opens onto its edges. The landing draws the
+ *   composite alone and sends a reader wanting the breakdown to the benchmark
+ *   page, so the invitation to open a row has to go with the rows that open.
  */
-export default function TtscWebsiteBenchmarkEvidenceCoverage() {
+export default function TtscWebsiteBenchmarkEvidenceCoverage({
+  className = "my-6",
+  expandable: expandableRows = true,
+}: {
+  className?: string;
+  expandable?: boolean;
+}) {
   const { report, coverage, error } = useTtscWebsiteBenchmarkEvidenceData();
   const rows: CoverageRow[] = useMemo(
     () => TtscWebsiteBenchmarkEvidenceData.buildCoverage(report, coverage),
@@ -34,16 +49,22 @@ export default function TtscWebsiteBenchmarkEvidenceCoverage() {
   if (error || rows.length === 0) return null;
 
   return (
-    <div className={`not-prose my-6 ${TtscWebsiteBenchmarkGraphUi.panelClass}`}>
+    <div
+      className={`not-prose ${className} ${TtscWebsiteBenchmarkGraphUi.panelClass}`}
+    >
       <TtscWebsiteBenchmarkGraphUi.SectionHeader
         eyebrow="requirement coverage"
         title="How much of the graph each arm satisfied"
-        description="Thirteen reference edges, folded so serial hops multiply and branches average. Higher is better. Open a row for the edges behind its score."
+        description={
+          expandableRows
+            ? `${DESCRIPTION} Open a row for the edges behind its score.`
+            : DESCRIPTION
+        }
         aside="higher is better"
       />
       <div className="divide-y divide-[#eef4fa] px-5 py-2">
         {rows.map((row) => {
-          const expandable = row.edges.length > 0;
+          const expandable = expandableRows && row.edges.length > 0;
           const expanded = open === row.id;
           return (
             <div key={row.id} className="py-2">

--- a/website/src/content/docs/evidence/adoption.mdx
+++ b/website/src/content/docs/evidence/adoption.mdx
@@ -1,14 +1,12 @@
+import TtscWebsiteBenchmarkEvidenceSpend from "../../../components/benchmark/evidence/TtscWebsiteBenchmarkEvidenceSpend";
+
 # Adoption
 
 Nothing here requires a new process. If your team already keeps requirements in the repository and hands them to an agent, the graph turns those documents into a denominator.
 
-## If you already work from documents
+Keeping the versioned specification as the single source of truth is Spec-Driven Development, named by GitHub Spec Kit and built into AWS Kiro. SDD uses the specification as an input and does not count whether it was implemented. That is the gap this fills, which is why adopting it costs a configuration block rather than a workflow.
 
-Keeping the versioned specification as the single source of truth is called Spec-Driven Development. GitHub Spec Kit named the practice in September 2025, and AWS built Kiro on the same idea.
-
-SDD uses the specification as an input. It does not count whether the specification was implemented. That is the gap the evidence graph fills, and it is why adopting it costs a configuration block rather than a workflow.
-
-The smallest useful wiring is one claim:
+## Start with one claim
 
 ```ts
 {
@@ -25,20 +23,13 @@ The smallest useful wiring is one claim:
 
 Read as one sentence: the components under `src` claim to implement the requirements, so every H2 and H3 under `docs/requirements` must be cited by a component.
 
-Turn on that single block and the moment someone adds a section, the build says nobody has built it yet.
+Turn on that single block, and the moment someone adds a section the build says nobody has built it yet.
 
 ## Chain the documents to each other
 
 Code citing documents is the obvious direction. Documents citing documents is the one that changes how planning works.
 
-A document hierarchy usually flows the same way.
-
-1. A decision comes out of a meeting.
-2. The decision becomes a clause in the requirements.
-3. The clause becomes a screen flow in the feature specification.
-4. The flow becomes code and tests.
-
-Wire each step to cite the one before it and the whole chain becomes compiler-checked:
+A document hierarchy usually flows the same way: a decision comes out of a meeting, becomes a clause in the requirements, becomes a screen flow in the feature specification, and becomes code and tests. Wire each step to cite the one before it and the whole chain is compiler-checked.
 
 ```ts
 // 1. Requirements reflect what the meetings decided.
@@ -73,11 +64,7 @@ Citations are HTML comments, so the rendered document is unchanged for whoever r
 <!-- @evidence docs/requirements/pricing.md#coupon-stacking This section turns the coupon stacking rule into a screen flow. -->
 ```
 
-Three failures become build failures:
-
-- a decision made in a meeting that never reached the requirements;
-- a requirement clause no feature specification covers;
-- a feature flow no screen implements.
+Three failures become build failures: a decision made in a meeting that never reached the requirements, a requirement clause no feature specification covers, and a feature flow no screen implements.
 
 The reverse direction closes too. Delete a requirement clause and every feature specification that leaned on it breaks immediately, so a ghost specification with no basis cannot survive in the tree. A gap discovered while writing code becomes a citation that demands the document be written.
 
@@ -85,26 +72,16 @@ One thing changes for the person writing the specification. **You stop asking wh
 
 ## Put the upstream in too
 
-Anything with headings can be an evidence source. Meeting notes are the common one, and they are not the only one.
+Anything with headings can be an evidence source. Meeting notes are the common one, and they are not the only one: idea notes, user research and interview records, competitor analysis, data analysis results, support tickets and customer feedback.
 
-- Idea notes
-- User research and interview records
-- Competitor analysis
-- Data analysis results
-- Support tickets and customer feedback
-
-Idea notes are the most useful of these, precisely because most ideas never become products. Most of them end up excluded, and the exclusion is the record of why they were rejected.
-
-- An adopted idea leaves a citation naming the requirement it became.
-- A rejected idea leaves an exclusion naming why, and what would make the team revisit it.
-- An idea nobody judged blocks the build.
-
-Where an idea note used to be quietly forgotten, the history of what was taken and what was declined stays in the repository.
+Idea notes are the most useful of these, precisely because most ideas never become products. An adopted idea leaves a citation naming the requirement it became, a rejected idea leaves an exclusion naming why and what would make the team revisit it, and an idea nobody judged blocks the build.
 
 ```md
 <!-- @evidenceExclude docs/ideas/2026-q1.md#social-login
      Deferred out of this release; the identity provider contract is unsigned. Reject this exclusion once legal confirms the contract. -->
 ```
+
+Where an idea note used to be quietly forgotten, the history of what was taken and what was declined stays in the repository.
 
 ## Consume an external API specification
 
@@ -123,7 +100,7 @@ If another team hands you an OpenAPI document to implement or to consume, cite i
 
 Every operation under `paths` becomes a unit. When the other team adds an operation, your next build reports that you have not implemented it yet.
 
-A remote document is fetched once per process, so a running watch session keeps the document it started with. A one-shot `ttsc check` in CI always fetches. Pin the document locally when you need the boundary to be reviewable in a diff.
+A remote document is fetched once per process, so a running watch session keeps the document it started with, while a one-shot `ttsc check` in CI always fetches. Pin the document locally when you need the boundary to be reviewable in a diff.
 
 ## Roll it out on an existing codebase
 
@@ -153,6 +130,16 @@ Do not enable everything at once. Staged enabling is the adoption strategy.
 Step 3 is where the value shows up before any enforcement does. What accumulates in the exclusion ledger is the debt list the team had never written down.
 
 Declare `evidenceExcludeCarriers` from the start, so that ledger is one file rather than a grep. Reviewing it is the one review that cannot be skipped: an exclusion is the only acknowledgement that reports an obligation discharged with nothing built.
+
+## What it costs
+
+Clearing an obligation is work an agent has to do, so the honest question is what that does to a run. The benchmark measured both arms on four subjects of ascending size.
+
+<TtscWebsiteBenchmarkEvidenceSpend />
+
+On the three smaller subjects the arm with the graph finished for less, between a half and a quarter of the tokens, because the errors direct the work instead of a review loop searching for it. On the largest it cost about 9% more. Read it as the graph paying for itself up to a size and charging a premium past it, not as a saving you can assume.
+
+[The full benchmark](/docs/benchmark/evidence) has the phase split, the reconciled prices, and the raw counters.
 
 ## What review looks like afterwards
 

--- a/website/src/content/docs/evidence/adoption.mdx
+++ b/website/src/content/docs/evidence/adoption.mdx
@@ -4,7 +4,7 @@ import TtscWebsiteBenchmarkEvidenceSpend from "../../../components/benchmark/evi
 
 Nothing here requires a new process. If your team already keeps requirements in the repository and hands them to an agent, the graph turns those documents into a denominator.
 
-Keeping the versioned specification as the single source of truth is Spec-Driven Development, named by GitHub Spec Kit and built into AWS Kiro. SDD uses the specification as an input and does not count whether it was implemented. That is the gap this fills, which is why adopting it costs a configuration block rather than a workflow.
+Keeping the versioned specification as the single source of truth is Spec-Driven Development, the practice GitHub Spec Kit named and AWS built Kiro around. SDD uses the specification as an input and does not count whether it was implemented. That is the gap this fills, which is why adopting it costs a configuration block rather than a workflow.
 
 ## Start with one claim
 
@@ -137,7 +137,7 @@ Clearing an obligation is work an agent has to do, so the honest question is wha
 
 <TtscWebsiteBenchmarkEvidenceSpend />
 
-On the three smaller subjects the arm with the graph finished for less, between a half and a quarter of the tokens, because the errors direct the work instead of a review loop searching for it. On the largest it cost about 9% more. Read it as the graph paying for itself up to a size and charging a premium past it, not as a saving you can assume.
+On the three smaller subjects the arm with the graph finished on between a quarter and a half of the tokens. On the largest it spent about 9% more. Four subjects and one engine do not establish where the crossover sits, so treat the saving as measured on these four rather than as one you can assume.
 
 [The full benchmark](/docs/benchmark/evidence) has the phase split, the reconciled prices, and the raw counters.
 

--- a/website/src/content/docs/evidence/claims.mdx
+++ b/website/src/content/docs/evidence/claims.mdx
@@ -19,7 +19,7 @@ const graph: ITtscEvidenceGraphConfig = {
 };
 ```
 
-A **claim** selects a population of declaration hosts, the artifacts that owe answers. A **reference** selects a population of evidence units, the questions they owe. Every claim-reference pair is one independently complete obligation.
+A **claim** selects a population of declaration hosts, the artifacts that owe answers. A **reference** selects a population of evidence units, the questions they owe. Read every claim in that direction: `files` and `symbol` pick who owes, `reference` picks what.
 
 ## One obligation per pair
 
@@ -47,22 +47,22 @@ A `reference` array is not a union. Each element is its own 100% obligation, and
 }
 ```
 
-A test citing a requirement discharges nothing in obligation 2. That separation is the point: one obligation borrowing another's citation is exactly how partial work reads as complete work.
+A test citing a requirement discharges nothing in obligation 2. That separation is the point: one obligation borrowing another's citation is how partial work reads as complete work.
 
-The same applies across claims. Two claims referencing one document set are two obligations, so a section only the backend implements still owes an `@evidenceExclude` in the API package.
+The same holds across claims. Two claims referencing one document set are two obligations, so a section only the backend implements still owes an `@evidenceExclude` in the API package.
 
 ## Claim properties
 
-| Property | Applies to | Meaning |
-| --- | --- | --- |
-| `type` | all | `"markdown"`, `"prisma"`, or `"typescript"`. Swagger cannot host a claim. |
-| `files` | all | Glob patterns for the files that owe acknowledgements. Required. |
-| `symbol` | all | Which declaration kinds may host an `@evidence` tag. It does not restrict `@evidenceExclude`, whose carriers are wider. |
-| `reference` | all | One reference or an array of them. Must not be empty. |
-| `root` | all | Directory the `files` patterns resolve against. |
-| `evidenceExcludeCarriers` | all | Files allowed to host this claim's `@evidenceExclude`. |
-| `name` | all | Label shown with this claim's diagnostics. It identifies nothing and relates nothing. |
-| `disabled` | all | Validates the shape and contributes nothing else. Use it to stage a rollout. |
+| Property | Meaning |
+| --- | --- |
+| `type` | `"markdown"`, `"prisma"`, or `"typescript"`. Swagger cannot host a claim. |
+| `files` | Glob patterns for the files that owe acknowledgements. Required. |
+| `symbol` | Which declaration kinds may host an `@evidence` tag. It does not restrict `@evidenceExclude`, whose carriers are wider. |
+| `reference` | One reference or an array of them. Must not be empty. |
+| `root` | Directory the `files` patterns resolve against. |
+| `evidenceExcludeCarriers` | Files allowed to host this claim's `@evidenceExclude`. |
+| `name` | Label shown with this claim's diagnostics. It identifies nothing and relates nothing. |
+| `disabled` | Validates the shape and contributes nothing else: no populations, no obligations, no completion hints, no watched inputs. |
 
 ## Reference properties
 
@@ -78,7 +78,7 @@ The same applies across claims. Two claims referencing one document set are two 
 | `uniqueEvidence` | all | At most one claim host may cite each unit. |
 | `singleEvidencePerSymbol` | all | Each selected claim host must cite exactly one unit. |
 
-## Symbols
+## Symbol selectors
 
 | Kind | `symbol` values | Reference default | Claim default |
 | --- | --- | --- | --- |
@@ -95,13 +95,15 @@ On a reference, `symbol` sets the obligation's denominator. On a claim, it restr
 - `"function"` selects exported callables, including a `const` initialized with an arrow or function expression, public class callables, and the namespace variants of those forms.
 - `"property"` selects direct properties of exported type-level symbols, plus exported `const`, `let`, and `var` at module or namespace scope. Every variable that is not function-valued is a property, including a function-typed declaration.
 
+Only public identities materialize. A top-level declaration needs an export modifier or a local export-list alias, and a namespace member needs to be exported from that namespace unless ambient semantics make it implicitly public.
+
 Qualified identities keep their owner. `Orders.Input.id` is a property below `Orders.Input`, while `Orders.state` is namespace data. Exported object and array binding patterns expose each local binding leaf as a property, and a type-only namespace alias exposes its public type-space descendants without exposing namespace data or callables.
 
-A namespace merged with a same-named function is that function's static side, so nothing inside it materializes. That is the generated SDK accessor shape, `export async function get(...)` beside `export namespace get`, where `get.path` and `get.Output` are the accessor's own machinery rather than authored contract. One operation therefore owes one acknowledgement, cited as `{@link api.functional.health.get}`. A namespace merged with an interface or a class is unaffected.
+A namespace merged with a same-named function is that function's static side, so nothing inside it materializes. That is the generated SDK accessor shape, `export async function get(...)` beside `export namespace get`, where `get.path` and `get.Output` are the accessor's own machinery rather than authored contract. One operation therefore owes one acknowledgement, cited as `{@link api.functional.health.get}`. A namespace merged with an interface or a class is unaffected, and a `const` or `let` cannot merge with a namespace at all.
 
 ### Hierarchy
 
-Units contain units. A Markdown file contains its heading outline, a heading contains the lower-level headings under it, an interface contains its properties, a namespace contains every nested public unit, and a Prisma model contains its columns and relations. Swagger operations are independent leaves.
+Units contain units. A Markdown file contains its heading outline, a heading contains the lower-level headings under it until the next heading of equal or higher level, an interface contains its properties, a namespace contains every nested public unit, and a Prisma model contains its columns and relations. Swagger operations are independent leaves.
 
 A citation covers its target and every selected descendant. So `symbol: "property"` on a reference can still be satisfied by one `@evidence {@link IShoppingSale} ...`, and one `@evidence prisma:Sale ...` discharges every selected column and relation beneath that model.
 
@@ -111,7 +113,7 @@ An ancestor stays addressable even when its own kind is not in the selector. The
 
 A declaration whose documentation comment carries `@internal`, `@hidden`, or `@ignore` is not an evidence unit, and neither is anything nested inside it. The three tags mean the same thing here, and the tag has to open its own line, so prose mentioning `@internal` is describing something rather than declaring it.
 
-This works in both directions: such a declaration owes no acknowledgement and cannot carry one. It applies to Prisma `///` comments too, where a tagged model takes its columns and relations with it. Citing a withdrawn declaration is reported, and the diagnostic names the tag rather than claiming the target does not exist.
+This works in both directions: such a declaration owes no acknowledgement, cannot carry one, and is ineligible as an exclusion carrier. It applies to Prisma `///` comments too, where a tagged model takes its columns and relations with it. Citing a withdrawn declaration is reported, and the diagnostic names the tag rather than claiming the target does not exist.
 
 ## File patterns
 
@@ -156,7 +158,7 @@ Prisma and TypeScript targets carry no path, so a root there changes which files
 
 Everything a rooted Markdown or Prisma population reads is published to the `ttsc` host as a watched dependency, so editing a document two directories up starts the next `ttsc --watch` cycle exactly as editing one inside the project does.
 
-A TypeScript claim `root` changes only the base used to match files `ttsc` already supplied. It never scans that directory or follows imports, so the owning `tsconfig.json` must include a sibling source root before the claim can select it. TypeScript references take no `root`; `package` is the channel that reaches a population you do not own.
+A TypeScript claim `root` changes only the base used to match files `ttsc` already supplied. It never scans that directory, follows arbitrary imports, or admits `node_modules`, so the owning `tsconfig.json` must include a sibling source root before the claim can select it. TypeScript references take no `root`; `package` is the channel that reaches a population you do not own.
 
 ## TypeScript populations
 
@@ -173,15 +175,13 @@ A TypeScript claim `root` changes only the base used to match files `ttsc` alrea
 { type: "typescript", package: "@ORGANIZATION/PROJECT-api" }
 ```
 
-A unit is addressed the way a consumer reaches it, not the way the declaring file spells it. `export * as functional` nests a path segment, `export * from` flattens one, and `export { A as B }` addresses the symbol as `B`. That is what makes `api.functional.questions.get` nameable.
+A unit is addressed the way a consumer reaches it, not the way the declaring file spells it. `export * as functional` nests a path segment, `export * from` flattens one, and `export { A as B }` addresses the symbol as `B`. Matching that unit by its local binding finds nothing.
 
 Identity still belongs to the declaring file. A declaration reached through two barrels answers to both addresses and remains one coverage unit rather than two obligations. Containment follows the declaration hierarchy rather than the address text, so a type and a callable sharing one public name never become each other's scope.
 
 The cost of selecting modules is that a glob is only as narrow as what its modules publish. Matching a barrel takes in everything behind it, so narrow by the module whose surface you mean rather than by the directory it sits in.
 
-A local reference must set `files`. There is no implicit project population, and singular `file` belongs to Swagger.
-
-It also selects only what the Program already holds. A file the owning `tsconfig.json` never pulled in is unavailable to the rule and does not count as a match, so widen the project before widening the glob.
+A local reference must set `files`. There is no implicit project population, and singular `file` belongs to Swagger. It also selects only what the Program already holds, so a file the owning `tsconfig.json` never pulled in is unavailable to the rule and does not count as a match: widen the project before widening the glob.
 
 ### Installed packages
 
@@ -189,7 +189,7 @@ A `package` population is read from disk rather than from the `ttsc` Program, wh
 
 Without `files`, the package's declaration entry is the population, resolved through the `types` condition of its `exports` map, then `typesVersions`, then `types` or `typings`. Never `main`, which names the JavaScript a consumer runs rather than the declarations a citation can address.
 
-With `files`, the globs are package-relative and they narrow which units carry the obligation without changing the address those units are cited by. A unit the entry publishes as `functional.health.get` is still cited as `functional.health.get` when a glob narrows the population to the subtree that declares it, because the package entry is the only module your import specifier resolves to. A glob matching only modules the entry does not publish selects nothing and says so.
+With `files`, the globs are package-relative and they narrow which units carry the obligation without changing the address those units are cited by. A unit the entry publishes as `functional.health.get` is still cited that way when a glob narrows the population to the subtree declaring it, because the package entry is the only module your import specifier resolves to. A glob matching only modules the entry does not publish selects nothing and says so.
 
 The obligation set of a package belongs to whoever publishes it. A minor release that adds exports adds obligations, so pin the version or narrow the selection when the population is not yours.
 
@@ -287,6 +287,8 @@ Three opt-in properties tighten a single reference:
 Counting is by identity, not by text. Repeated tags for one unit count once, merged declarations and overload sets remain one host, and an aggregate target contributes every selected descendant in its scope, so citing a parent of two selected units counts as two.
 
 The constraints belong to one reference and never pool. An exclusion the package reference above refuses may still satisfy a Markdown reference in the same claim, and two references over the same files stay independent.
+
+A population that failed to load establishes no cardinality at all: the loader failure is preserved rather than turned into a count. A healthy population that is merely empty is a complete denominator, so a host still truthfully cites zero units against it.
 
 ## Exclusion carriers
 

--- a/website/src/content/docs/evidence/index.mdx
+++ b/website/src/content/docs/evidence/index.mdx
@@ -50,7 +50,7 @@ One coding engine built the same four applications twice from the same frozen re
 
 <TtscWebsiteBenchmarkEvidenceCoverage expandable={false} />
 
-The arm without the graph falls as the subject grows, which is the ceiling above, drawn. The arm with it is whole by construction: the build does not finish while an obligation is open, so coverage reaches 100% as the residue of the errors it closed rather than as a target anyone aimed at.
+The arm without the graph reached less of its own graph on every larger subject, and it ran the same review loops the arm with the graph did. The arm with it is whole by construction: the build does not finish while an obligation is open, so coverage reaches 100% as the residue of the errors it closed rather than as a target anyone aimed at.
 
 [The full benchmark](/docs/benchmark/evidence) has the thirteen edges behind each score, what both arms spent, and the method.
 
@@ -67,7 +67,9 @@ The obligation model, in the order it decides things.
 | TypeScript | exported type, function, property | yes | yes | JSDoc |
 | Swagger / OpenAPI | every operation under `paths` | no | yes | nothing, it cannot host a tag |
 
-Swagger is reference-only: an operation grounds an obligation and has nowhere to write a tag. One direction is closed the other way too. Markdown cannot cite a TypeScript symbol, because a symbol citation resolves through the citing module's imports and a document has no import scope. Wire that relation the other way and let the code cite the document.
+Swagger is reference-only: an operation grounds an obligation and has nowhere to write a tag.
+
+One pairing is refused outright. Markdown cannot cite a TypeScript symbol, because a symbol citation resolves through the citing module's imports and a document has no import scope. Wire that relation the other way and let the code cite the document.
 
 ### Obligations never pool
 

--- a/website/src/content/docs/evidence/index.mdx
+++ b/website/src/content/docs/evidence/index.mdx
@@ -1,151 +1,122 @@
+import TtscWebsiteBenchmarkEvidenceCoverage from "../../../components/benchmark/evidence/TtscWebsiteBenchmarkEvidenceCoverage";
+
 # Evidence Graph
 
-The guardrail for goal mode: your spec becomes a compile error.
+`@ttsc/evidence` turns a requirement into a compile error until some declaration cites it by name.
 
-`@ttsc/evidence` makes every requirement you configure demand an explicit acknowledgement from the code, test, or document that claims to satisfy it. A requirement nothing acknowledges is not a review comment someone may or may not write. It is a failed build that names the section.
-
-Every acknowledgement names an exact target and states why it applies. The compiler does not judge whether that reason is true. It forces a concrete claim, so a fabricated one can no longer hide inside a plausible diff: it sits beside the declaration it contradicts.
-
-An agent can still lie. It cannot lie by omission.
-
-- **Complete**: every configured obligation is accounted for, or the build fails.
-- **Tested**: every selected export is claimed by a test, by name.
-- **Documented**: decisions and code stay explicitly connected.
-- **Honest**: "done" arrives with a target and a reason.
-- **Integrity**: no citation outlives its target.
-
-## The problem
-
-### A completion report grades itself
-
-A type error is caught by the compiler. Wrong behavior is caught by a test. "The document says this and nobody built it" has always been caught by a person reading a diff, and in an unattended run that person is gone.
-
-So the agent reports done, and the four things it is most likely to have skipped leave no trace:
-
-- a requirement the document states and nobody implemented;
-- a feature that was implemented and never verified;
-- a capability no screen ever reaches;
-- a document that changed while the code leaning on it did not.
-
-### Review loops flatten out below complete
-
-The usual answer is to re-read everything and repeat until nothing new appears. Research calls it self-refine or iterative self-repair. Teams call it the review-fix-repeat loop.
-
-It works, and it stops working before it reaches complete. Most of what a loop will ever find arrives in its first few rounds, and each round after that returns less than the one before, settling on a ceiling rather than on zero.
-
-The ceiling drops as the project grows. One fix touches more surfaces, so a round gets larger at the same time as more rounds are needed, and nothing in the loop is counting either number.
-
-That is the whole defect. A reviewer finds what a reviewer happens to look at.
-
-### The first draft is fast and the last stretch is not
-
-The gap between a working prototype and a finished product is the part teams keep publishing numbers about.
-
-| Source | What it recorded |
-| --- | --- |
-| LinkedIn engineering (2024) | 80% of the target experience in the first month, then four more months to pass 95%. The early pace read as almost done. |
-| Airbnb engineering (2025) | 75% of the target files converted in four hours. The last 3% took another week. |
-| Google, Sundar Pichai (2025) | 30% of new code originates in AI suggestions, against a 10% gain in engineering velocity. |
-| Anthropic engineering (2025) | When building an agent, the final stretch becomes most of the journey. |
-| Google DORA (2025) | AI adoption raises throughput and instability together. Time saved generating is spent verifying. |
-| Stack Overflow developer survey (2025) | The top frustration is AI code that is almost right but not quite, reported by 66% of respondents. |
-| ShiftASIA (2026) | A prototype lands in an afternoon. Security surfaces in week 8, integration in week 10, edge cases in week 16, and rework cycles begin at week 18. |
-
-### Retrieval does not close it
-
-Handing the documents to the agent through embeddings does not help, because this is a counting problem rather than a search problem.
-
-Coverage needs a denominator. If the requirements hold 73 sections, the denominator is 73, and something has to stop the build on the sections that are still empty. A retriever answers the query it was given with its best matches. It never returns the sections nobody asked about, which are exactly the ones that went missing.
-
-## The answer
-
-### The compiler counts
-
-The graph moves the judgment into the build, the one authority an agent already obeys. Each of the four omissions above becomes a diagnostic, in the same stream as type errors, so the agent repairs spec drift inside the loop it already uses to repair types.
-
-There is no separate CI job. Violations surface in every `ttsc` build, every `--noEmit` check, and every `ttsx` run.
-
-### The tag is one line
+You declare the graph in `lint.config.ts`: which files owe answers, and which documents, schema models, API operations, or TypeScript symbols they owe answers to. Every pair is one independently complete obligation. A unit nothing acknowledges fails the build, in the same diagnostic stream as a type error.
 
 ```tsx
 /**
- * @evidence docs/discount.md#coupon-stacking Renders the combination limit defined by this rule.
+ * @evidence docs/discount.md#coupon-stacking
+ *           States the per-issuer stacking limit this section defines.
  */
-export function CouponStackingNotice() {
-  return <p>One seller coupon and one platform coupon may be combined.</p>;
-}
+export function CouponStackingNotice(props: IProps): JSX.Element;
 ```
 
-`@evidence <target> <reason>` states that this declaration implements, expresses, or proves that target. The target names exactly one unit. The reason is mandatory, because a citation that cannot say why it exists is filler.
-
-Without it, the next build stops:
+`@evidence <target> <reason>` names one unit of the spec and why this declaration answers for it. Without it the next build stops:
 
 ```text
 $ npx ttsc
-error TS16411: [evidence/graph] Missing acknowledgement for 'docs/discount.md#coupon-stacking' (Markdown H2 'Coupon Stacking' at docs/discount.md:3) in Claim 1 reference 1 (markdown, symbols: h2, h3). Use @evidence on a selected typescript host or @evidenceExclude on an eligible carrier.
+error TS16411: [evidence/graph] Missing acknowledgement for 'docs/discount.md#coupon-stacking'
+  (Markdown H2 'Coupon Stacking' at docs/discount.md:3)
+  in Claim 1 reference 1 (markdown, symbols: h2, h3).
 
-Found 1 error.
+  Use @evidence on a selected typescript host or @evidenceExclude on an eligible carrier.
 ```
 
-You do not write these tags. The agent writes each one as it implements, and your review shrinks from the whole diff to the list of stated reasons.
+You do not write these tags. An AI coding agent has to clear the errors to finish, and clearing one means citing the target and writing down why its code answers for it.
+
+## What it changes
+
+The omissions it closes, and what closing them measured.
+
+### The four omissions nothing else catches
+
+A type error is caught by the compiler. Wrong behavior is caught by a test. Four failures have only ever been caught by a person reading a diff:
+
+- a requirement the document states and nobody implemented;
+- a feature implemented and never verified;
+- a capability no screen reaches;
+- a document that changed while the code leaning on it did not.
+
+None of them is a search problem, which is why handing the documents to an agent through retrieval does not close them. Coverage needs a denominator. If the requirements hold 73 sections, the denominator is 73, and something has to stop the build on the sections still empty. A retriever answers the query it was given and never returns the sections nobody asked about, which are exactly the ones that went missing.
+
+A review loop does count, badly. Most of what it will ever find arrives in its first rounds, and each round after returns less than the one before, settling on a ceiling rather than on zero. The ceiling drops as the project grows, because one fix touches more surfaces while nothing in the loop is counting either number.
+
+### What that is worth, measured
+
+One coding engine built the same four applications twice from the same frozen requirements, once with the graph in the workspace and once without. Coverage is folded from thirteen reference edges, so a codebase scores on how much of its own provenance graph it actually satisfies.
+
+<TtscWebsiteBenchmarkEvidenceCoverage expandable={false} />
+
+The arm without the graph falls as the subject grows, which is the ceiling above, drawn. The arm with it is whole by construction: the build does not finish while an obligation is open, so coverage reaches 100% as the residue of the errors it closed rather than as a target anyone aimed at.
+
+[The full benchmark](/docs/benchmark/evidence) has the thirteen edges behind each score, what both arms spent, and the method.
+
+## What the graph enforces
+
+The obligation model, in the order it decides things.
+
+### Four artifact kinds
+
+| Artifact | Unit | Hosts a claim | Can be cited | Cites in |
+| --- | --- | --- | --- | --- |
+| Markdown | the file, and every H1 to H4 section | yes | yes | an HTML comment |
+| Prisma | model, column, relation | yes | yes | a `///` comment |
+| TypeScript | exported type, function, property | yes | yes | JSDoc |
+| Swagger / OpenAPI | every operation under `paths` | no | yes | nothing, it cannot host a tag |
+
+Swagger is reference-only: an operation grounds an obligation and has nowhere to write a tag. One direction is closed the other way too. Markdown cannot cite a TypeScript symbol, because a symbol citation resolves through the citing module's imports and a document has no import scope. Wire that relation the other way and let the code cite the document.
+
+### Obligations never pool
+
+A backend that honors a pricing rule and a screen that forgot it is not a 67% project. It is a compile error naming the section the screen ignored.
+
+Pooling is how partial use by several consumers reads as complete use by the project, and how two implementations of one rule drift apart with nobody noticing. So each claim-reference pair is counted on its own, and a citation toward one reference never counts toward another.
+
+A test citation is stricter than line coverage for the same reason. Line coverage credits code a test merely passed through. A citation is a statement of responsibility for a named unit.
 
 ### A recorded no is also an answer
 
-Not every requirement belongs to every layer, and the graph does not pretend otherwise. `@evidenceExclude` discharges a target with a written decision instead of an implementation.
+Not every requirement belongs to every layer. `@evidenceExclude <target> <reason>` discharges a scope with a written decision instead of an implementation.
 
-The reason carries the weight there. "Not applicable", "internal only", and "later" are conclusions rather than reasons; what belongs in one is the actual owner or the observable alternative, plus the condition that would make the exclusion wrong.
+The reason carries the weight. "Not applicable", "internal only", and "later" are conclusions rather than reasons; what belongs in one is the actual owner or the observable alternative, plus the condition that would make the exclusion wrong.
 
-An exclusion is the one acknowledgement that reports an obligation settled with nothing built, so a claim can name the single file its exclusions must live in. Reviewing that ledger is then one file to open rather than a codebase to read.
+It is the only acknowledgement that settles an obligation with nothing built, so it exists to be vetoed. A claim can name the single file its exclusions must live in, which turns reviewing them from reading a codebase into opening one file.
 
-### Coverage is counted per obligation, never pooled
+### Documents gain reference integrity
 
-A backend that honors a pricing rule and a frontend that forgot it is not a 67% project. It is a compile error naming the exact section the screen ignored.
+Code has always had it. Rename a function and every caller fails. Documents never did, which is why they rot: nothing complains when a section goes stale, so nobody trusts the spec, so nobody invests in it.
 
-Pooling is how partial use by several consumers reads as complete use by the project, and how two implementations of one rule drift apart without anyone noticing. So obligations never pool: each claim-reference pair is counted on its own.
+In an evidence graph a document is a set of units other artifacts point at by name, and the link runs both ways. A section nothing implements fails the build, a new export owes a citation to something, and a change on one side alone cannot pass because the citation dies with its target.
 
-A test citation is stricter than line coverage for the same reason. Line coverage credits code a test merely passed through. A citation is an explicit statement of responsibility for a named unit.
+## Get started
 
-### Documents gain the right to break the build
+Install, and where to read next.
 
-Code has always had reference integrity. Rename a function and every caller fails. Documents never had it, which is why they rot: nothing complains when a section goes stale, so nobody trusts the spec, so nobody invests in it.
+### Install
 
-In an evidence graph a document is a set of units other artifacts point at by name, and the link runs both ways.
+`@ttsc/evidence` is a rule contributor to [`@ttsc/lint`](/docs/lint), not a top-level `ttsc` plugin. The compiler never loads it; `lint.config.ts` does, and its four rules run inside the lint engine's own binary on the AST and types the type-check pass already built.
 
-- A strong document exposes thin code, because a section nothing implements fails the build.
-- A gap found while writing code fills the document, because the new export owes a citation to something.
-- A change on one side alone cannot pass, because the citation dies with its target.
+```bash
+npm install -D ttsc @ttsc/lint @ttsc/evidence typescript
+```
 
-That is what "docs as spec" needed all along. Not discipline. A linker.
+There is no CI job to add. Violations surface in every `ttsc` build, every `--noEmit` check, every `ttsx` run, and in the editor through `ttscserver`.
 
-## What can be wired to what
+[Setup → Evidence Graph](/docs/setup/evidence) is the ten-minute path: one claim, the first failing build, and the two ways to clear it.
 
-| Artifact | Unit | Can host a claim | Can be cited |
-| --- | --- | --- | --- |
-| Markdown | the file, and every H1 to H4 section | yes | yes |
-| TypeScript | exported type, function, property | yes | yes |
-| Prisma | model, column, relation | yes | yes |
-| Swagger / OpenAPI | every operation under `paths` | no | yes |
-
-Markdown cites in an HTML comment, TypeScript in JSDoc, Prisma in a `///` comment. Swagger is reference-only: an operation grounds an obligation but has nowhere to write a tag.
-
-One direction is closed. Markdown cannot cite a TypeScript symbol, because a symbol citation resolves through the citing module's imports and a document has no import scope. Wire that relation the other way and let the code cite the document.
-
-## Where it runs
-
-`@ttsc/evidence` is a rule contributor to [`@ttsc/lint`](/docs/lint), not a top-level `ttsc` plugin. The compiler never loads it. `lint.config.ts` does, and its four rules run inside the lint engine's own binary, on the AST and types the type-check pass already built.
-
-## The shape of the chapter
-
-Install, one claim, and the first failing build are in [Setup → Evidence Graph](/docs/setup/evidence). Ten minutes. This chapter is what comes after.
+### Where to next
 
 1. [Claims and References](/docs/evidence/claims): the whole configuration surface, from symbol selectors to monorepo roots and reference policies.
 2. [Evidence Tags](/docs/evidence/tags): the tag grammar, target forms, and where a tag may live in each artifact kind.
 3. [Rules](/docs/evidence/rules): `evidence/graph`, `evidence/documented`, `evidence/singular`, and `evidence/todo`.
-4. [Full-Stack Wiring](/docs/evidence/wiring): a real monorepo chain, from requirements through schema, API, tests, hooks, screens, and journeys.
+4. [Full-Stack Wiring](/docs/evidence/wiring): the monorepo graph the benchmark above was measured on, claim by claim.
 5. [Adoption](/docs/evidence/adoption): the smallest useful wiring, document-to-document chains, and staged rollout on a legacy codebase.
 
 ## Related
 
-- [The Evidence Graph benchmark](/docs/benchmark/evidence) measures this package the only way it can be measured: one coding engine builds the same application twice, once with the graph and once without.
+- [The Evidence Graph benchmark](/docs/benchmark/evidence) is how this package is measured: one engine builds the same application twice, once with the graph and once without.
 - [Rule contributors](/docs/lint/contributing) covers how a contributor package is built and published. `@ttsc/evidence` is the first-party example.
 - The [package README](https://github.com/samchon/ttsc/blob/master/packages/evidence/README.md) is the condensed reference for the same surface.

--- a/website/src/content/docs/evidence/rules.mdx
+++ b/website/src/content/docs/evidence/rules.mdx
@@ -21,31 +21,34 @@ export default {
 } satisfies ITtscLintConfig;
 ```
 
-One is the graph. The other three protect the conditions the graph depends on, and each is a file rule.
+| Rule | Takes | Scope |
+| --- | --- | --- |
+| `evidence/graph` | [`ITtscEvidenceGraphConfig`](/docs/evidence/claims) | the whole project |
+| `evidence/documented` | [`ITtscEvidenceDocumentedConfig`](#evidencedocumented) | one file |
+| `evidence/singular` | nothing | one file |
+| `evidence/todo` | nothing | one file |
+
+One is the graph. The other three protect the conditions the graph depends on.
 
 ## `evidence/graph`
 
-The configured graph. It takes an [`ITtscEvidenceGraphConfig`](/docs/evidence/claims) and evaluates the complete declaration once per Program, answering three separate questions.
+The configured graph. It evaluates the complete declaration once per Program and answers three separate questions.
 
 - **Resolution.** Does every declared target resolve to exactly one selected unit or structural ancestor?
 - **Host eligibility.** Does each `@evidence` sit on a symbol kind its claim selects, and each `@evidenceExclude` on an eligible carrier in a matching claim file?
 - **Coverage.** Does every selected reference unit have at least one acknowledgement in this claim, and does that acknowledgement satisfy whatever the reference's own policy demands?
 
-The rule is project-scoped, so its config entry must carry no `files` selector. The host rejects one that does. Scope a file rule in its own entry when you need to.
+The rule is project-scoped, so its config entry must carry no `files` selector; the host rejects one that does. Scope a file rule in its own entry when you need to.
 
 Claim and reference state stay separate. A declaration that satisfies one obligation never leaks coverage into another, even when the physical target is the same.
+
+While the rule reports nothing it also publishes its configured targets as [editor completions](/docs/evidence/tags#editor-completions).
 
 ### Watched inputs
 
 The rule declares its configured Markdown globs, Prisma globs, and local Swagger paths to the `ttsc` host, so editing a spec section or regenerating an OpenAPI document starts the next `ttsc --watch` cycle on its own, with no TypeScript file touched.
 
 A path stays declared while it is missing, which lets a document that has not been generated yet be observed the moment it appears. A source above the project is declared on the same terms. An `http:`/`https:` Swagger source is the one exception: a URL has no filesystem event to observe.
-
-### Editor completions
-
-While the rule reports nothing, it publishes its configured targets as completion items in `ttscserver`, so typing `@evidence docs/spec.md#` offers the anchors that actually exist. The host publishes a rule's corpus only on the cycles where that rule passes, so a broken graph never suggests targets from a stale index.
-
-At the `@evidenceExclude` trigger, a target selected only by references that refuse exclusions is omitted. A target any enabled reference still allows stays on offer, because the completion API has no cursor-specific claim context to narrow it further.
 
 ## `evidence/documented`
 
@@ -65,13 +68,11 @@ The default selects every kind a claim can use as a host, deliberately: the popu
 
 Presence is the whole check. The rule never judges what the prose says, how long it is, or whether it is sincere. A rule that tried would only teach authors to write filler that satisfies it.
 
-For a merged identity the block belongs on the first declaration by source position, which is the one every diagnostic names. Documenting only a later half is reported, because the declaration a reader meets first would otherwise stay unexplained.
-
-A citation is the opposite. `@evidence` may sit on any declaration of a merged identity, since the graph judges the identity rather than the placement.
+For a merged identity the block belongs on the first declaration by source position, which is the one every diagnostic names. Documenting only a later half is reported, because the declaration a reader meets first would otherwise stay unexplained. A citation is the opposite: `@evidence` may sit on any declaration of a merged identity, since the graph judges the identity rather than the placement.
 
 ## `evidence/singular`
 
-One public identity per file, named after the file. Takes no options, so it carries a bare severity.
+One public identity per file, named after the file.
 
 ```ts
 "evidence/singular": "error",
@@ -91,7 +92,7 @@ This matters to the graph because addresses are how citations are written. A fil
 
 ## `evidence/todo`
 
-Reports every remaining JSDoc `@todo` in a checked file, exported or not. Takes no options.
+Reports every remaining JSDoc `@todo` in a checked file, exported or not.
 
 ```ts
 "evidence/todo": "error",

--- a/website/src/content/docs/evidence/rules.mdx
+++ b/website/src/content/docs/evidence/rules.mdx
@@ -32,7 +32,7 @@ One is the graph. The other three protect the conditions the graph depends on.
 
 ## `evidence/graph`
 
-The configured graph. It evaluates the complete declaration once per Program and answers three separate questions.
+The configured graph. It evaluates the whole declared graph once per Program and answers three separate questions.
 
 - **Resolution.** Does every declared target resolve to exactly one selected unit or structural ancestor?
 - **Host eligibility.** Does each `@evidence` sit on a symbol kind its claim selects, and each `@evidenceExclude` on an eligible carrier in a matching claim file?

--- a/website/src/content/docs/evidence/tags.mdx
+++ b/website/src/content/docs/evidence/tags.mdx
@@ -7,15 +7,13 @@ Two tags satisfy every obligation the graph declares.
 @evidenceExclude <target> <reason>
 ```
 
-These are not tags you maintain by hand. Your agent writes each one as it implements, and your job is to review the stated reasons. In an agent workflow they cost nothing extra: the citation is written at the moment the author knows why it is true.
+These are not tags you maintain by hand. An agent writes each one as it implements, and your job is to review the stated reasons. In an agent workflow they cost nothing extra: the citation is written at the moment the author knows why it is true.
 
 ## Grammar
 
-The target is one whitespace-delimited token, except that a target opening with `{@link`, `{@linkcode`, or `{@linkplain` runs to its closing brace. Everything after the target is prose.
+The target is one whitespace-delimited token, except that a target opening with `{@link`, `{@linkcode`, or `{@linkplain` runs to its closing brace. Everything after the target is prose. A declaration may carry any number of tags, and each is validated on its own.
 
-The reason is required. A citation that cannot say why it exists is filler, and the reason is what makes review possible: it sits beside the exact section it claims to honor, so a misreading surfaces where a reader can see both.
-
-The compiler never judges whether a reason is true. It only forces a concrete claim. An agent can still write a false reason, and it cannot write a missing one.
+The reason is required. It sits beside the exact unit it claims to honor, so a misreading surfaces where a reader can see both. The compiler never judges whether a reason is true; it forces a concrete claim, and a claim is reviewable in a way that silence is not.
 
 A reason may run past one line. Continuation lines join it until the next `@evidence` or `@evidenceExclude`, and inside a JSDoc or Prisma comment any other line-opening `@tag` ends it too. That boundary is what keeps a neighboring `@param` or another tool's `@namespace` out of the reason above it.
 
@@ -31,7 +29,9 @@ A reason may run past one line. Continuation lines join it until the next `@evid
 | `{@link sales.IShoppingSale}` | An exported type, function, or namespace, with its selected descendants |
 | `{@link sales.IShoppingSale.price}` | One property of an exported type |
 
-A path-addressed target is one whitespace-delimited token, which is why a Swagger operation is written `POST:/members` rather than `POST /members`. The second form still parses: target `POST`, reason `/members ...`. That grammar is preserved deliberately, because `POST` may be the name of a TypeScript symbol.
+A path-addressed target is one whitespace-delimited token, which is why a Swagger operation is written `POST:/members` rather than `POST /members`. The second form still parses, as target `POST` and reason `/members ...`, and that grammar is preserved deliberately because `POST` may be the name of a TypeScript symbol.
+
+Identity is exact. Paths are case-sensitive on every host, Swagger methods canonicalize to uppercase while Swagger paths do not normalize at all, and a Prisma target always carries its `prisma:` prefix so a model named `Sale` cannot compete with a TypeScript type of the same name.
 
 ### Markdown anchors
 
@@ -94,7 +94,9 @@ model Sale {
 
 A `/* */` block comment hosts one too. Both forms reach the generated client types, which is Prisma's own rule rather than a choice made here.
 
-A `//` line comment is discarded by Prisma itself and cannot host a citation, so a tag written in one is reported rather than ignored. A comment documents whatever declaration immediately follows it: a blank line before a top-level block detaches it, and a comment above a block attribute or a closing brace documents nothing. Each of those placements is reported with the move that fixes it.
+A `//` line comment is discarded by Prisma itself and cannot host a citation, so a tag written in one is reported rather than ignored. So is one buried behind an extra slash: `//// @evidence` arrives as content beginning with a slash and opens no tag.
+
+A comment documents whatever declaration immediately follows it. A blank line before a top-level block detaches it, a blank line inside a field's run does not, an intervening `//` line does not break a run, and a comment above a block attribute or a closing brace documents nothing. Each of those placements is reported with the move that fixes it.
 
 ## Citing a TypeScript symbol
 
@@ -113,11 +115,13 @@ export function SalePrice(): null {
 
 The braces are load-bearing. TypeScript resolves a name inside an inline link and counts it as a use, so an import that exists only to carry a citation survives `noUnusedLocals`. It does not resolve names inside an unknown tag, so a bare `@evidence sales.IShoppingSale` would leave that import unreferenced and raise `TS6133`.
 
-Use `import type`. It is erased at emit, so a citation creates no runtime dependency and no import cycle.
+Use `import type`. It is erased at emit, so a citation creates no runtime dependency and no import cycle. A project also running `@typescript-eslint/no-unused-vars` still sees a false positive there, because that rule does not count JSDoc usage.
 
 ```text
 $ npx ttsc check
-error TS16411: [evidence/graph] Unimported evidence target '{@link contracts.ISale}' at src/ui/SalePrice.ts:2 for Claim 1 across reference 1 (typescript, symbols: type): 'contracts' is not imported by this module, so the citation names a symbol this file does not reference. Import it; 'import type' is enough and is erased at emit.
+error TS16411: [evidence/graph] Unimported evidence target '{@link contracts.ISale}' at src/ui/SalePrice.ts:2
+  for Claim 1 across reference 1 (typescript, symbols: type): 'contracts' is not imported by this module,
+  so the citation names a symbol this file does not reference. Import it; 'import type' is enough.
 ```
 
 Resolving through the module's own imports also removes an ambiguity that has no fix. A generated SDK puts the same leaf name in many modules, so `get` alone names several symbols. Resolved from one file's bindings, `{@link api.functional.questions.get}` names exactly one.
@@ -175,6 +179,12 @@ export const CONTROLLER_EVIDENCE_EXCLUDE = true;
 
 Never auto-exclude, auto-retarget, or delete an artifact to make a graph green. Every diagnostic names the repair, and the repair belongs to the author.
 
+## Editor completions
+
+While `evidence/graph` reports nothing, it publishes its configured targets as completion items in `ttscserver`, so typing `@evidence docs/spec.md#` offers the anchors that actually exist. The host publishes a rule's corpus only on the cycles where that rule passes, so a broken graph never suggests targets from a stale index.
+
+At the `@evidenceExclude` trigger, a target selected only by references that refuse exclusions is omitted. A target any enabled reference still allows stays on offer, because the completion API has no cursor-specific claim context to narrow it further.
+
 ## What a violation looks like
 
 ```md filename="docs/discount.md"
@@ -185,7 +195,11 @@ At most one seller coupon and one platform coupon may combine on a single order.
 
 ```text
 $ npx ttsc check
-error TS16411: [evidence/graph] Missing acknowledgement for 'docs/discount.md#coupon-stacking' (Markdown H2 'Coupon Stacking' at docs/discount.md:3) in Claim 1 reference 1 (markdown, symbols: h2, h3). Use @evidence on a selected typescript host or @evidenceExclude on an eligible carrier.
+error TS16411: [evidence/graph] Missing acknowledgement for 'docs/discount.md#coupon-stacking'
+  (Markdown H2 'Coupon Stacking' at docs/discount.md:3)
+  in Claim 1 reference 1 (markdown, symbols: h2, h3).
+
+  Use @evidence on a selected typescript host or @evidenceExclude on an eligible carrier.
 
 Found 1 error.
 ```

--- a/website/src/content/docs/evidence/tags.mdx
+++ b/website/src/content/docs/evidence/tags.mdx
@@ -121,7 +121,8 @@ Use `import type`. It is erased at emit, so a citation creates no runtime depend
 $ npx ttsc check
 error TS16411: [evidence/graph] Unimported evidence target '{@link contracts.ISale}' at src/ui/SalePrice.ts:2
   for Claim 1 across reference 1 (typescript, symbols: type): 'contracts' is not imported by this module,
-  so the citation names a symbol this file does not reference. Import it; 'import type' is enough.
+  so the citation names a symbol this file does not reference. Import it; 'import type' is enough and is
+  erased at emit.
 ```
 
 Resolving through the module's own imports also removes an ambiguity that has no fix. A generated SDK puts the same leaf name in many modules, so `get` alone names several symbols. Resolved from one file's bindings, `{@link api.functional.questions.get}` names exactly one.

--- a/website/src/content/docs/evidence/wiring.mdx
+++ b/website/src/content/docs/evidence/wiring.mdx
@@ -1,10 +1,12 @@
+import TtscWebsiteBenchmarkEvidenceCoverage from "../../../components/benchmark/evidence/TtscWebsiteBenchmarkEvidenceCoverage";
+
 # Full-Stack Wiring
 
 A complete graph over a real monorepo: a NestJS and Prisma backend, a generated SDK package, and a React frontend, with requirements in `docs/analysis/**/*.md`.
 
 This is the configuration the [Evidence Graph benchmark](/docs/benchmark/evidence) ships in its template. Two things are dropped here: the long file-header comments, and the `disabled: true` every claim carries there. The template stages claims on one at a time during a run, while this page shows the finished graph; [Adoption](/docs/evidence/adoption) covers the staging.
 
-It is worth reading as a whole because the interesting decisions are about where a claim lives and what it refuses, not about the glob syntax.
+Read it as a whole. The interesting decisions are about where a claim lives and what it refuses, not about glob syntax.
 
 ## The chain
 
@@ -42,7 +44,15 @@ Each block is one evidence population and the claims that must acknowledge it. A
 | `frontend-screens` | frontend config | page components | requirements, hooks | an API wired up with no screen behind it |
 | `frontend-journeys` | frontend config | E2E journeys | requirements, screens | a screen no journey walks |
 
-The benchmark's `todo` subject holds 73 H2 and H3 sections. Six claims cite the requirements, so the requirement side alone opens 438 cells, before the model, column, operation, hook, and screen obligations are counted.
+Eight claims, thirteen claim-reference pairs, thirteen independent obligations. The benchmark's `todo` subject holds 73 H2 and H3 sections, and six claims cite the requirements, so the requirement side alone opens 438 cells before the model, column, operation, hook, and screen obligations are counted.
+
+## What these thirteen obligations measure
+
+Those same thirteen pairs are the edges the benchmark's coverage score is folded from. Each row below is one codebase, and opening it names the pair that broke.
+
+<TtscWebsiteBenchmarkEvidenceCoverage />
+
+The Evidence rows are whole by construction, because a build carrying this configuration does not finish while a pair is open. The Plain rows are the same four applications built without it, and their edges are where a codebase that looked finished was not: an operation nothing tests and a hook nothing renders are invisible to a type checker and to a reviewer reading a diff.
 
 ## Backend
 
@@ -142,7 +152,7 @@ export default {
 
 Four decisions are worth reading.
 
-**Why the backend claims live in the test config.** `test/tsconfig.json` compiles `../src` together with the tests, so it is the only Program that holds controllers and test functions at once. The package Program sees only `src/`, and a TypeScript claim can select nothing the owning `tsconfig.json` did not already supply.
+**Why the backend claims live in the test config.** `test/tsconfig.json` compiles `../src` together with the tests, so it is the only Program holding controllers and test functions at once. The package Program sees only `src/`, and a TypeScript claim can select nothing the owning `tsconfig.json` did not already supply.
 
 **`root` is relative to the package directory.** `..` is the backend package and `../../..` is the repository root, because every backend command runs from the package directory.
 
@@ -150,7 +160,7 @@ Four decisions are worth reading.
 
 **The SDK reference refuses both escapes.** `noEvidenceExclude` denies a published operation the sentence "not applicable", and `singleEvidencePerSymbol` makes one test answer for exactly one operation. Without the second, a single omnibus test citing twenty operations would report the suite complete.
 
-The reference is declared as a `package` rather than by path on purpose. A symbol nothing imports is absent from the Program by definition, and an unconsumed operation is exactly the symbol this obligation has to name, so the generated package is read from disk.
+That reference is declared as a `package` rather than by path on purpose. A symbol nothing imports is absent from the Program by definition, and an unconsumed operation is exactly the symbol this obligation has to name, so the generated package is read from disk.
 
 A test cites the accessor through its own import:
 

--- a/website/src/content/docs/evidence/wiring.mdx
+++ b/website/src/content/docs/evidence/wiring.mdx
@@ -48,11 +48,11 @@ Eight claims, thirteen claim-reference pairs, thirteen independent obligations. 
 
 ## What these thirteen obligations measure
 
-Those same thirteen pairs are the edges the benchmark's coverage score is folded from. Each row below is one codebase, and opening it names the pair that broke.
+Those same thirteen pairs are the edges the benchmark's coverage score is folded from, so opening a Plain row below names the pair that broke in that codebase.
 
 <TtscWebsiteBenchmarkEvidenceCoverage />
 
-The Evidence rows are whole by construction, because a build carrying this configuration does not finish while a pair is open. The Plain rows are the same four applications built without it, and their edges are where a codebase that looked finished was not: an operation nothing tests and a hook nothing renders are invisible to a type checker and to a reviewer reading a diff.
+The Evidence arm is one row because every subject scored alike: a build carrying this configuration does not finish while a pair is open, so it has no edges to open onto. The Plain rows are the same four applications built without it, and their edges are where a codebase that looked finished was not. An operation nothing tests and a hook nothing renders are invisible to a type checker and to a reviewer reading a diff.
 
 ## Backend
 

--- a/website/src/movies/landing/TtscWebsiteLandingEvidenceGraph.tsx
+++ b/website/src/movies/landing/TtscWebsiteLandingEvidenceGraph.tsx
@@ -78,8 +78,8 @@ export default function TtscWebsiteLandingEvidenceGraph() {
                 declaration answers for it.
               </p>
               <p className="mt-4 max-w-xl text-base leading-relaxed text-[#526b82]">
-                An AI coding agent has to clear them to finish. Coverage reaches
-                100% on its own, as the residue of the errors it closed.
+                An AI coding agent has to clear those errors to finish. Coverage
+                reaches 100% on its own, as the residue of the ones it closed.
               </p>
 
               <div className="mt-8 flex flex-wrap gap-3">

--- a/website/src/movies/landing/TtscWebsiteLandingEvidenceGraph.tsx
+++ b/website/src/movies/landing/TtscWebsiteLandingEvidenceGraph.tsx
@@ -1,20 +1,58 @@
 "use client";
 
+import TtscWebsiteBenchmarkEvidenceCoverage from "../../components/benchmark/evidence/TtscWebsiteBenchmarkEvidenceCoverage";
 import TtscWebsiteLandingFadeIn from "./TtscWebsiteLandingFadeIn";
 import TtscWebsiteLandingSectionEyebrow from "./TtscWebsiteLandingSectionEyebrow";
 
-const SOURCES = [
-  { kind: "Markdown", unit: "file, H1 to H4 sections" },
-  { kind: "TypeScript", unit: "type, function, property" },
-  { kind: "Prisma", unit: "model, column, relation" },
-  { kind: "OpenAPI", unit: "every operation under paths" },
+const COMMENT = "text-blue-400";
+
+/**
+ * The three kinds a tag can name: a document section, an API operation and a
+ * TypeScript symbol.
+ *
+ * Every reason is a placeholder. A real one states why this declaration answers
+ * for that unit, in the author's own words, and a specimen short enough for a
+ * landing card would read as the sort of filler the rule exists to refuse.
+ */
+const TARGETS = [
+  "docs/discount.md#coupon-stacking",
+  "POST:/orders/{orderId}/coupons",
+  "{@link hooks.useCouponStacking}",
 ] as const;
 
-const CITATION = [
-  { text: "/**", tone: "text-blue-400", trailing: false },
-  { text: " * @evidence", tone: "text-emerald-300", trailing: true },
-  { text: " */", tone: "text-blue-400", trailing: false },
+/** Column the placeholder reasons align on, one space past the widest target. */
+const REASON_COLUMN = Math.max(...TARGETS.map((target) => target.length)) + 1;
+
+/** The same three targets, as the build reports them before anyone cites one. */
+const UNCITED = [
+  "'docs/discount.md#coupon-stacking'",
+  "'POST:/orders/{orderId}/coupons'",
+  "'useCouponStacking'",
 ] as const;
+
+const CARD =
+  "overflow-hidden rounded-2xl border border-[#235a97] bg-[#102a43] shadow-[0_24px_60px_rgba(35,90,151,0.22)]";
+
+/**
+ * Code type size, small enough that the widest line clears the card.
+ *
+ * The pre is a scroll container, so an overflowing line scrolls in place rather
+ * than widening its grid track, and the headline column beside it keeps the
+ * width the layout gives it.
+ */
+const PRE =
+  "overflow-x-auto p-4 font-mono text-[12px] leading-[1.65] text-blue-50 md:px-5";
+
+function CardChrome({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 border-b border-[#3f6f99] bg-[#173f66] px-4 py-2">
+      <span className="h-2.5 w-2.5 rounded-full bg-red-500/60" />
+      <span className="h-2.5 w-2.5 rounded-full bg-amber-400/60" />
+      <span className="h-2.5 w-2.5 rounded-full bg-emerald-400/60" />
+      <span className="ml-3 font-mono text-[11px] text-blue-200">{label}</span>
+    </div>
+  );
+}
 
 export default function TtscWebsiteLandingEvidenceGraph() {
   return (
@@ -22,40 +60,27 @@ export default function TtscWebsiteLandingEvidenceGraph() {
       <div className="relative mx-auto max-w-6xl">
         <TtscWebsiteLandingFadeIn>
           <TtscWebsiteLandingSectionEyebrow label="Requirement coverage" />
-          <div className="grid gap-10 lg:grid-cols-[0.86fr_1.14fr] lg:items-start">
+          <div className="grid gap-10 lg:grid-cols-[1.14fr_0.86fr] lg:items-center">
             <div>
               <h2 className="text-3xl font-bold leading-[1.08] tracking-tight text-[#102a43] md:text-5xl">
-                A requirement nobody built should not compile.
+                Your spec, as a compile error no agent can skip.
               </h2>
               <p className="mt-5 max-w-xl text-base leading-relaxed text-[#526b82]">
                 <code className="font-mono font-semibold text-[#235a97]">
                   @ttsc/evidence
                 </code>{" "}
-                makes every requirement you configure demand an acknowledgement
-                from the code, test, or document that claims to satisfy it. An
-                agent can still lie. It cannot lie by omission.
+                fails the build once per obligation, because one reference never
+                covers another.{" "}
+                <code className="font-mono font-semibold text-[#235a97]">
+                  @evidence &lt;target&gt; &lt;reason&gt;
+                </code>{" "}
+                closes one, by naming a unit of the spec and why this
+                declaration answers for it.
               </p>
               <p className="mt-4 max-w-xl text-base leading-relaxed text-[#526b82]">
-                Coverage is counted per obligation and never pooled, so a rule
-                the backend honored and the screen forgot is a compile error
-                naming that section rather than a percentage.
+                An AI coding agent has to clear them to finish. Coverage reaches
+                100% on its own, as the residue of the errors it closed.
               </p>
-
-              <dl className="mt-8 divide-y divide-[#dbeafe] border-y border-[#dbeafe]">
-                {SOURCES.map((source) => (
-                  <div
-                    key={source.kind}
-                    className="flex items-baseline justify-between gap-4 py-2.5"
-                  >
-                    <dt className="font-mono text-sm font-semibold text-[#235a97]">
-                      {source.kind}
-                    </dt>
-                    <dd className="text-right text-sm text-[#60778e]">
-                      {source.unit}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
 
               <div className="mt-8 flex flex-wrap gap-3">
                 <a
@@ -73,80 +98,71 @@ export default function TtscWebsiteLandingEvidenceGraph() {
               </div>
             </div>
 
-            <div className="space-y-4">
-              <div className="overflow-hidden rounded-2xl border border-[#235a97] bg-[#102a43] shadow-[0_24px_60px_rgba(35,90,151,0.22)]">
-                <div className="flex items-center gap-2 border-b border-[#3f6f99] bg-[#173f66] px-4 py-2.5">
-                  <span className="h-2.5 w-2.5 rounded-full bg-red-500/60" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-amber-400/60" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-emerald-400/60" />
-                  <span className="ml-3 font-mono text-xs text-blue-200">
-                    docs/requirements/discount.md
-                  </span>
-                </div>
-                <pre className="overflow-x-auto p-5 font-mono text-[13px] leading-[1.7] text-blue-50 md:px-7">
-                  <div className="text-sky-300">
-                    ## Coupon Stacking{" "}
-                    <span className="text-amber-300">
-                      &#123;#coupon-stacking&#125;
-                    </span>
-                  </div>
-                  {"\n"}
-                  <div className="text-blue-100">
-                    At most one seller coupon and one platform coupon may
-                    combine.
+            <div className="min-w-0 space-y-4">
+              <div className={CARD}>
+                <CardChrome label="CouponStackingNotice.tsx" />
+                <pre className={PRE}>
+                  <div className={COMMENT}>/**</div>
+                  {TARGETS.map((target) => (
+                    <div key={target}>
+                      <span className={COMMENT}> * </span>
+                      <span className="text-emerald-300">@evidence </span>
+                      <span className="text-amber-300">
+                        {target.padEnd(REASON_COLUMN)}
+                      </span>
+                      <span className="text-blue-100">&lt;reason...&gt;</span>
+                    </div>
+                  ))}
+                  <div className={COMMENT}> */</div>
+                  <div>
+                    <span className="text-sky-300">export function </span>
+                    CouponStackingNotice(props: IProps)
                   </div>
                 </pre>
               </div>
 
-              <div className="overflow-hidden rounded-2xl border border-[#235a97] bg-[#102a43] shadow-[0_24px_60px_rgba(35,90,151,0.22)]">
-                <div className="flex items-center gap-2 border-b border-[#3f6f99] bg-[#173f66] px-4 py-2.5">
-                  <span className="h-2.5 w-2.5 rounded-full bg-red-500/60" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-amber-400/60" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-emerald-400/60" />
-                  <span className="ml-3 font-mono text-xs text-blue-200">
-                    $ npx ttsc --noEmit
-                  </span>
-                </div>
-                <pre className="overflow-x-auto p-5 font-mono text-[13px] leading-[1.7] text-blue-50 md:px-7">
-                  <div>
-                    <span className="text-red-300">error </span>
-                    <span className="text-sky-300">TS16411</span>
-                    <span className="text-blue-50">
-                      : [evidence/graph] Missing acknowledgement for
-                    </span>
-                  </div>
-                  <div className="text-amber-300">
-                    {"  "}
-                    &apos;docs/requirements/discount.md#coupon-stacking&apos;
-                  </div>
-                  <div className="text-blue-100">
-                    {"  "}in Claim 1 reference 1 (markdown, symbols: h2, h3).
-                  </div>
-                </pre>
-                <div className="border-t border-white/10 bg-[#173f66] px-5 py-4 font-mono text-[13px] leading-[1.7] md:px-7">
-                  {CITATION.map((line) => (
-                    <div key={line.text} className={line.tone}>
-                      {line.text}
-                      {line.trailing && (
-                        <>
-                          <span className="text-amber-300">
-                            {" "}
-                            docs/requirements/discount.md#coupon-stacking
-                          </span>
-                          <span className="text-blue-100">
-                            {" "}
-                            Renders the combination limit.
-                          </span>
-                        </>
-                      )}
+              <div className={CARD}>
+                <CardChrome label="$ npx ttsc" />
+                <pre className={PRE}>
+                  {UNCITED.map((target) => (
+                    <div key={target}>
+                      <div>
+                        <span className="text-red-300">error </span>
+                        <span className="text-sky-300">TS16411</span>
+                        <span>
+                          : [evidence/graph] Missing acknowledgement for
+                        </span>
+                      </div>
+                      <div className="text-amber-300">
+                        {"  "}
+                        {target}
+                      </div>
                     </div>
                   ))}
-                  <div className="text-blue-100">
-                    export function CouponStackingNotice() &#123;...&#125;
-                  </div>
-                </div>
+                  {"\n"}
+                  <div className="text-blue-300">Found 3 errors.</div>
+                </pre>
               </div>
             </div>
+          </div>
+        </TtscWebsiteLandingFadeIn>
+
+        <TtscWebsiteLandingFadeIn delay={120}>
+          <div className="mt-12">
+            <TtscWebsiteBenchmarkEvidenceCoverage
+              className=""
+              expandable={false}
+            />
+            <p className="mt-3 font-mono text-xs text-[#60778e]">
+              codex gpt-5.6-luna, four subjects. Thirteen edges and token spend:{" "}
+              <a
+                href="/docs/benchmark/evidence"
+                className="text-[#235a97] underline-offset-2 hover:underline"
+              >
+                full benchmark
+              </a>
+              .
+            </p>
           </div>
         </TtscWebsiteLandingFadeIn>
       </div>


### PR DESCRIPTION
## Intent

`@ttsc/evidence` is the only first-party package whose guide chapter cited no measurement. `/docs/graph` states what the graph is and draws the token-cost chart inline before it asks anyone to install anything; `/docs/evidence` ran 1,300 lines of prose and linked its benchmark once, from a "Related" list at the bottom of the overview. The landing section had the same shape: the strongest claim on the page was the only one with no number behind it.

This puts the published measurement where each page's argument needs it, and rewrites the chapter around it.

## Scope

**Landing page** (`TtscWebsiteLandingEvidenceGraph`)

- Draws `TtscWebsiteBenchmarkEvidenceCoverage` under the section, rows collapsed, with the caption linking the full benchmark. Before this, the landing had no route to `/docs/benchmark/evidence` at all.
- Right column is now the README's own two artifacts, the tagged declaration and the failing build. The requirement-document card and the four-row source table are gone; the tag example carries the three target kinds that table was listing.
- Prose replaced with the README's sentences. "An agent can still lie. It cannot lie by omission." was rhetoric rather than a fact, and the paragraph under it had a broken antecedent ("31.7% of them" where *them* resolved to four applications).
- Grid ratio flipped to `[1.14fr_0.86fr]` and the card column given `min-w-0`. An `fr` track is `minmax(auto, 1fr)`, so the widest code line was widening the card column past its share and squeezing the headline beside it.

**`TtscWebsiteBenchmarkEvidenceCoverage`**

- New optional `expandable` (default `true`) and `className` (default `"my-6"`). The header description drops "Open a row for the edges behind its score" when rows do not open, so the invitation goes with the rows that honor it.
- `/docs/benchmark/evidence` calls it with no arguments and is unchanged.

**`/docs/evidence`, all six pages rewritten**

- `index`: leads with the tag and the failing build, then draws the coverage chart under the four omissions it closes. Removes the industry citation table (LinkedIn 2024 through ShiftASIA 2026), the "Complete / Tested / Documented / Honest / Integrity" list, and the duplicated Coupon Stacking walk-through that `setup/evidence` already owns.
- `wiring`: draws the same chart expandable. Its eight claims hold thirteen claim-reference pairs, which are exactly the thirteen edges the coverage score folds from, so the rows that open name the pair that broke.
- `adoption`: draws the spend chart under a new "What it costs" section.
- `claims`, `tags`, `rules`: rewritten prose, same technical surface. `tags` gains the editor-completion behavior (moved from `rules`, which now links to it) and the `//`-comment and detached-comment placements. `rules` gains the rule table and drops the completion section.

**`packages/evidence/README.md`**

- The rules table recorded `evidence/documented` as taking nothing. It takes `ITtscEvidenceDocumentedConfig`, whose `symbol` narrows the kinds that must carry a block. `/docs/evidence/rules` already had this right.

## Verification

Local, on the running dev server:

- `npx tsc -p website/tsconfig.json --noEmit` clean.
- `npx prettier --check` clean over every changed path.
- `200` on `/`, `/docs/evidence`, `/docs/evidence/{claims,tags,rules,wiring,adoption}`, `/docs/benchmark/evidence`, `/docs/setup/evidence`, `/docs/lint`, `/docs/lint/contributing`. Dev log shows no render error.
- Every internal link and anchor introduced here resolves: `tags#editor-completions`, `tags#where-an-exclusion-may-sit`, `claims#reference-policies`, `claims#exclusion-carriers`.

Figures quoted in prose were read from `website/public/benchmark/evidence.json` and `evidence-coverage.json` rather than carried over: coverage 80.1 / 62.4 / 40.1 / 31.7 percent on the Plain arm, and the ERP subject at 777.6M tokens against 714.1M, which is the +9% the adoption page states.

## Not done

- Full `pnpm build` of the website was not run. This is a docs-and-copy change and the dev server compiled every touched route; a production build also runs Pagefind and the sitemap, which nothing here affects.
- `.agents/skills/project/evidence/SKILL.md` names the reference policy `noExclude`, while the source property is `noEvidenceExclude`. It is vendored from `samchon/lint-plugin-evidence`, so correcting it belongs upstream rather than in this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X592o8v2TidsXbw82sqWbD
