### PR TITLE
fix(lint): close the formatter clause gaps and the inert functional options

### DIFF
--- a/packages/lint/linthost/fix.go
+++ b/packages/lint/linthost/fix.go
@@ -289,10 +289,12 @@ func selectTextEdits(sourceLen int, edits []TextEdit) []TextEdit {
   // insert at that same offset must be dropped: two coincident inserts both
   // pass the `edit.Pos < lastEnd` gate, then apply in reverse sort order and
   // concatenate at one point — silently corrupting the source (e.g. a `;`
-  // insert and a `\n` insert at EOF yielding `\n;`). The host contract keeps
-  // one winner and drops the rest (see rule.TextEdit). A zero-width insert
-  // sitting at the end of a prior NON-empty edit is left alone: it applies
-  // cleanly after the replacement and is a legitimate adjacency.
+  // insert and a `\n` insert at EOF yielding `\n;`). This edit-level selector
+  // keeps one winner and drops the rest; selectTextEditGroups turns that drop
+  // into a whole-finding skip, which is the contract rule.TextEdit states. A
+  // zero-width insert sitting at the end of a prior NON-empty edit is left
+  // alone: it applies cleanly after the replacement and is a legitimate
+  // adjacency.
   lastInsertAt := -1
   for _, edit := range sorted {
     if edit.Pos < lastEnd {

--- a/packages/lint/linthost/rules_format_clause_join.go
+++ b/packages/lint/linthost/rules_format_clause_join.go
@@ -155,11 +155,12 @@ func joinClauseBody(
   if body.Kind == shimast.KindBlock && !target.alwaysJoin {
     return
   }
-  // An empty-statement body (`while (x)\n;`) glues directly to the header with
-  // NO space: Prettier's adjustClause special-cases EmptyStatement and returns
-  // the bare `;` (`while (x);`), only prepending a space when the empty
-  // statement carries a leading comment. This rule's gap->" " rewrite cannot
-  // produce the spaceless `);` glue, so abstain and leave the source shape.
+  // An empty-statement body glues directly to the header with NO space:
+  // Prettier's adjustClause special-cases EmptyStatement and returns the bare
+  // `;` (`while (x);`, `else;`, `do;`, `label:;`), only prepending a space when
+  // the empty statement carries a leading comment. This rule joins with a
+  // single space and deliberately does not take on the spaceless variant, so it
+  // abstains and leaves the source shape rather than emitting `while (x) ;`.
   if body.Kind == shimast.KindEmptyStatement {
     return
   }
@@ -178,12 +179,6 @@ func joinClauseBody(
   }
   anchorStart := gapStart - len(target.anchor)
   if anchorStart < 0 || src[anchorStart:gapStart] != target.anchor {
-    return
-  }
-  // A keyword anchor must be a whole token: `else` may not be the tail of
-  // `myelse`, and `do` may not be the tail of `undo`.
-  if isClauseAnchorWord(target.anchor) &&
-    anchorStart > 0 && isClauseIdentifierByte(src[anchorStart-1]) {
     return
   }
   gap := src[gapStart:bodyStart]
@@ -232,17 +227,12 @@ func isClauseGapByte(c byte) bool {
 }
 
 // isClauseAnchorWord reports whether an anchor is a keyword rather than
-// punctuation, which decides whether it needs an identifier-boundary check and
-// whether it starts the header line the width budget is measured against.
+// punctuation, which decides where the width budget starts measuring. The
+// anchor needs no identifier-boundary check: it is read backward from the AST
+// body's own position, so the token before the gap is the clause's real keyword
+// and an identifier ending in `else` or `do` cannot reach it.
 func isClauseAnchorWord(anchor string) bool {
   return anchor == "else" || anchor == "do"
-}
-
-// isClauseIdentifierByte reports whether `c` can appear inside an identifier,
-// so a keyword anchor is only accepted as a whole token.
-func isClauseIdentifierByte(c byte) bool {
-  return c == '_' || c == '$' ||
-    (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }
 
 // visualWidth returns the display-column width of `s`: a tab expands to a flat

--- a/packages/lint/linthost/rules_format_clause_join.go
+++ b/packages/lint/linthost/rules_format_clause_join.go
@@ -13,13 +13,20 @@ import (
 //  if (a)
 //    b();
 //
-// becomes `if (a) b();` when the joined line fits printWidth. The same
-// applies to `for`, `for-in`, `for-of`, and `while` headers. A braced
-// body, a body that already shares the header line, a multi-line body,
-// or a join that would overflow printWidth is left untouched.
+// becomes `if (a) b();` when the joined line fits printWidth. The covered set
+// is Prettier's, not the set whose header happens to end in `)`: the `if`
+// consequent and alternate, the `for`, `for-in`, `for-of`, and `while` bodies,
+// the `do` body, the `with` body, and a labeled statement's body. A braced
+// body, a body that already shares the header line, a multi-line body, or a
+// join that would overflow printWidth is left untouched.
 //
-// The rule only ever rewrites the whitespace gap between a header's
-// closing `)` and the controlled statement, so its edits never overlap
+// Two clauses join unconditionally because Prettier gives them no group of
+// their own: an `else` whose alternate is another `if` (the `else if` chain),
+// and a labeled statement, which prints `label: statement` on one line whatever
+// the statement is, braces included.
+//
+// The rule only ever rewrites the whitespace gap between the clause's own
+// header token and the controlled statement, so its edits never overlap
 // `format/indent` (leading whitespace of a line) or `format/print-width`
 // (interior reflow). Idempotent: once joined the gap holds no newline
 // and the rule abstains.
@@ -46,6 +53,9 @@ func (formatClauseJoin) Visits() []shimast.Kind {
     shimast.KindForStatement,
     shimast.KindForInStatement,
     shimast.KindForOfStatement,
+    shimast.KindDoStatement,
+    shimast.KindWithStatement,
+    shimast.KindLabeledStatement,
   }
 }
 
@@ -63,24 +73,67 @@ func (formatClauseJoin) Check(ctx *Context, node *shimast.Node) {
   if opts.TabWidth != nil && *opts.TabWidth > 0 {
     tabWidth = *opts.TabWidth
   }
-  joinClauseBody(ctx, ctx.File.Text(), node, clauseControlledBody(node), printWidth, tabWidth)
+  src := ctx.File.Text()
+  for _, target := range clauseControlledBodies(node) {
+    joinClauseBody(ctx, src, node, target, printWidth, tabWidth)
+  }
 }
 
-// clauseControlledBody returns the single controlled statement of a
-// control-flow header, the `then` branch for `if`, the loop body for
-// the iteration statements. The `else` branch is intentionally excluded:
-// its body is anchored after the `else` keyword rather than a `)`, so it
-// does not share this rule's `)`-anchored join shape.
-func clauseControlledBody(node *shimast.Node) *shimast.Node {
+// clauseJoinTarget is one joinable clause body plus the token that ends the
+// clause header immediately before it. The anchor is what generalizes the rule
+// past the `)`-headed statements: `else` and `do` end in a keyword, a labeled
+// statement ends in `:`, and requiring the exact token still keeps a comment
+// between header and body from being swallowed.
+type clauseJoinTarget struct {
+  body   *shimast.Node
+  anchor string
+  // alwaysJoin marks a clause Prettier keeps on the header line regardless of
+  // the body's own line count or the joined width: an `else if` chain and a
+  // labeled statement.
+  alwaysJoin bool
+}
+
+// clauseControlledBodies returns every clause body of `node` that Prettier
+// keeps on its header line, paired with the token that header ends in. The set
+// is Prettier's, not the AST's: the `if` consequent and alternate, the loop
+// bodies, the `do` body, the `with` body, and a labeled statement's body.
+func clauseControlledBodies(node *shimast.Node) []clauseJoinTarget {
   switch node.Kind {
   case shimast.KindIfStatement:
-    return node.AsIfStatement().ThenStatement
+    stmt := node.AsIfStatement()
+    if stmt == nil {
+      return nil
+    }
+    targets := []clauseJoinTarget{{body: stmt.ThenStatement, anchor: ")"}}
+    if stmt.ElseStatement != nil {
+      targets = append(targets, clauseJoinTarget{
+        body:   stmt.ElseStatement,
+        anchor: "else",
+        // Prettier prints an `else if` chain flat, so the alternate being an
+        // `if` joins even when that nested statement spans lines.
+        alwaysJoin: stmt.ElseStatement.Kind == shimast.KindIfStatement,
+      })
+    }
+    return targets
   case shimast.KindWhileStatement:
-    return node.AsWhileStatement().Statement
+    return []clauseJoinTarget{{body: node.AsWhileStatement().Statement, anchor: ")"}}
   case shimast.KindForStatement:
-    return node.AsForStatement().Statement
+    return []clauseJoinTarget{{body: node.AsForStatement().Statement, anchor: ")"}}
   case shimast.KindForInStatement, shimast.KindForOfStatement:
-    return node.AsForInOrOfStatement().Statement
+    return []clauseJoinTarget{{body: node.AsForInOrOfStatement().Statement, anchor: ")"}}
+  case shimast.KindDoStatement:
+    return []clauseJoinTarget{{body: node.AsDoStatement().Statement, anchor: "do"}}
+  case shimast.KindWithStatement:
+    return []clauseJoinTarget{{body: node.AsWithStatement().Statement, anchor: ")"}}
+  case shimast.KindLabeledStatement:
+    // A label carries no group of its own in Prettier: `label: statement` is
+    // one line whatever the statement is, so the body may be a block and may
+    // span lines.
+    return []clauseJoinTarget{{
+      body:       node.AsLabeledStatement().Statement,
+      anchor:     ":",
+      alwaysJoin: true,
+    }}
   }
   return nil
 }
@@ -89,11 +142,17 @@ func joinClauseBody(
   ctx *Context,
   src string,
   node *shimast.Node,
-  body *shimast.Node,
+  target clauseJoinTarget,
   printWidth int,
   tabWidth int,
 ) {
-  if body == nil || body.Kind == shimast.KindBlock {
+  body := target.body
+  if body == nil {
+    return
+  }
+  // A braced body already owns its own line layout, except behind a label,
+  // where Prettier writes `label: {`.
+  if body.Kind == shimast.KindBlock && !target.alwaysJoin {
     return
   }
   // An empty-statement body (`while (x)\n;`) glues directly to the header with
@@ -110,24 +169,35 @@ func joinClauseBody(
     return
   }
   // The gap is the whitespace run immediately before the body. Walk back
-  // over horizontal whitespace and newlines; the byte before it must be
-  // the header's closing `)` so a comment between header and body (which
+  // over horizontal whitespace and newlines; the bytes before it must be the
+  // clause's own header token so a comment between header and body (which
   // SkipTrivia would have stepped over) can never be swallowed.
   gapStart := bodyStart
   for gapStart > 0 && isClauseGapByte(src[gapStart-1]) {
     gapStart--
   }
-  if gapStart == 0 || src[gapStart-1] != ')' {
+  anchorStart := gapStart - len(target.anchor)
+  if anchorStart < 0 || src[anchorStart:gapStart] != target.anchor {
+    return
+  }
+  // A keyword anchor must be a whole token: `else` may not be the tail of
+  // `myelse`, and `do` may not be the tail of `undo`.
+  if isClauseAnchorWord(target.anchor) &&
+    anchorStart > 0 && isClauseIdentifierByte(src[anchorStart-1]) {
     return
   }
   gap := src[gapStart:bodyStart]
   if !strings.Contains(gap, "\n") {
     return // body already shares the header line
   }
-  // The header and the body must each be single-line; a multi-line body
-  // (e.g. a nested clause not yet joined) waits for the cascade to settle
-  // its inner join first.
+  // The header line is measured from the token that opens the clause. For a
+  // `)`-headed statement and a label that is the statement's own start; for
+  // `else` and `do` it is the keyword, which is where Prettier starts the line
+  // it would print.
   headerStart := shimscanner.SkipTrivia(src, node.Pos())
+  if isClauseAnchorWord(target.anchor) {
+    headerStart = anchorStart
+  }
   if headerStart < 0 || headerStart > gapStart {
     return
   }
@@ -135,13 +205,17 @@ func joinClauseBody(
   if strings.ContainsRune(src[headerLineStart:gapStart], '\n') {
     return
   }
-  if strings.ContainsRune(src[bodyStart:bodyEnd], '\n') {
-    return
-  }
-  joined := visualWidth(src[headerLineStart:gapStart], tabWidth) + 1 +
-    visualWidth(src[bodyStart:bodyEnd], tabWidth)
-  if joined > printWidth {
-    return
+  if !target.alwaysJoin {
+    // The body must be single-line; a multi-line body (e.g. a nested clause
+    // not yet joined) waits for the cascade to settle its inner join first.
+    if strings.ContainsRune(src[bodyStart:bodyEnd], '\n') {
+      return
+    }
+    joined := visualWidth(src[headerLineStart:gapStart], tabWidth) + 1 +
+      visualWidth(src[bodyStart:bodyEnd], tabWidth)
+    if joined > printWidth {
+      return
+    }
   }
   ctx.ReportRangeFix(
     gapStart,
@@ -155,6 +229,20 @@ func joinClauseBody(
 // the gap between a clause header and its controlled statement.
 func isClauseGapByte(c byte) bool {
   return c == ' ' || c == '\t' || c == '\r' || c == '\n'
+}
+
+// isClauseAnchorWord reports whether an anchor is a keyword rather than
+// punctuation, which decides whether it needs an identifier-boundary check and
+// whether it starts the header line the width budget is measured against.
+func isClauseAnchorWord(anchor string) bool {
+  return anchor == "else" || anchor == "do"
+}
+
+// isClauseIdentifierByte reports whether `c` can appear inside an identifier,
+// so a keyword anchor is only accepted as a whole token.
+func isClauseIdentifierByte(c byte) bool {
+  return c == '_' || c == '$' ||
+    (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }
 
 // visualWidth returns the display-column width of `s`: a tab expands to a flat

--- a/packages/lint/linthost/rules_format_parameter_properties.go
+++ b/packages/lint/linthost/rules_format_parameter_properties.go
@@ -10,9 +10,8 @@ import (
 // formatParameterProperties breaks a constructor's parameter list onto
 // one-parameter-per-line when it declares parameter properties, matching
 // Prettier 3. Prettier forces the break whenever a constructor has more
-// than one parameter and at least one carries an accessibility or
-// `readonly` modifier (a parameter property), regardless of whether the
-// flat form fits printWidth:
+// than one parameter and at least one carries a parameter-property
+// modifier, regardless of whether the flat form fits printWidth:
 //
 //  constructor(
 //    private readonly repo: Repository,
@@ -155,26 +154,18 @@ func (formatParameterProperties) Check(ctx *Context, node *shimast.Node) {
   )
 }
 
-// anyParameterProperty reports whether any parameter carries an
-// accessibility (`public`/`private`/`protected`) or `readonly` modifier,
-// which makes it a parameter property.
+// anyParameterProperty reports whether any parameter carries a modifier
+// that makes it a parameter property. The compiler's own
+// `ModifierFlagsParameterPropertyModifier` mask is the source: restating
+// the keyword set here is what left `override` out and made the rule
+// abstain on a legal parameter property Prettier breaks.
 func anyParameterProperty(params []*shimast.Node) bool {
   for _, p := range params {
     if p == nil {
       continue
     }
-    mods := p.Modifiers()
-    if mods == nil {
-      continue
-    }
-    for _, m := range mods.Nodes {
-      switch m.Kind {
-      case shimast.KindPublicKeyword,
-        shimast.KindPrivateKeyword,
-        shimast.KindProtectedKeyword,
-        shimast.KindReadonlyKeyword:
-        return true
-      }
+    if p.ModifierFlags()&shimast.ModifierFlagsParameterPropertyModifier != 0 {
+      return true
     }
   }
   return false

--- a/packages/lint/linthost/rules_format_parameter_properties.go
+++ b/packages/lint/linthost/rules_format_parameter_properties.go
@@ -154,17 +154,14 @@ func (formatParameterProperties) Check(ctx *Context, node *shimast.Node) {
   )
 }
 
-// anyParameterProperty reports whether any parameter carries a modifier
-// that makes it a parameter property. The compiler's own
-// `ModifierFlagsParameterPropertyModifier` mask is the source: restating
-// the keyword set here is what left `override` out and made the rule
-// abstain on a legal parameter property Prettier breaks.
+// anyParameterProperty reports whether any parameter is a parameter property.
+// It defers to the package's shared `isParameterProperty` so one definition
+// answers the question for every rule that asks it; restating the modifier set
+// here is what left `override` out and made this rule abstain on a legal
+// parameter property Prettier breaks.
 func anyParameterProperty(params []*shimast.Node) bool {
   for _, p := range params {
-    if p == nil {
-      continue
-    }
-    if p.ModifierFlags()&shimast.ModifierFlagsParameterPropertyModifier != 0 {
+    if isParameterProperty(p) {
       return true
     }
   }

--- a/packages/lint/linthost/rules_functional.go
+++ b/packages/lint/linthost/rules_functional.go
@@ -143,6 +143,34 @@ type functionalNoTryOptions struct {
   AllowFinally bool `json:"allowFinally"`
 }
 
+// functionalNoMixedTypesOptions gates the two container kinds the rule visits.
+// Both default to true (an absent key leaves the container checked), so the
+// pointers distinguish "not configured" from an explicit false.
+type functionalNoMixedTypesOptions struct {
+  CheckInterfaces   *bool `json:"checkInterfaces"`
+  CheckTypeLiterals *bool `json:"checkTypeLiterals"`
+}
+
+// functionalNoReturnVoidOptions narrows what counts as a rejected return.
+//
+// `allowNull` and `allowUndefined` default to true, matching the rule's
+// existing behavior: only a declared `void` return type is rejected. Setting
+// either to false extends the rejection to that declared return type.
+// `ignoreInferredTypes` defaults to false and, when true, spares a bare
+// `return;` whose enclosing function declares no return type, which is the one
+// place the rule reports a void-ness it inferred rather than read.
+type functionalNoReturnVoidOptions struct {
+  AllowNull           *bool `json:"allowNull"`
+  AllowUndefined      *bool `json:"allowUndefined"`
+  IgnoreInferredTypes bool  `json:"ignoreInferredTypes"`
+}
+
+// functionalPreferTacitOptions gates the member-expression callee shape.
+// Defaults to true, keeping `x => service.handler(x)` reported as before.
+type functionalPreferTacitOptions struct {
+  CheckMemberExpressions *bool `json:"checkMemberExpressions"`
+}
+
 type functionalImmutableDataOptions struct {
   functionalPatternOptions
   IgnoreMapsAndSets bool `json:"ignoreMapsAndSets"`
@@ -159,8 +187,14 @@ type functionalPreferImmutableTypesOptions struct {
   functionalPatternOptions
 }
 
+// functionalPreferReadonlyTypeOptions narrows which positions the rule polices.
+// Both gates default to off, so an absent key leaves every visited position
+// checked exactly as before.
 type functionalPreferReadonlyTypeOptions struct {
   functionalPatternOptions
+  AllowMutableReturnType bool `json:"allowMutableReturnType"`
+  IgnoreCollections      bool `json:"ignoreCollections"`
+  IgnoreInterface        bool `json:"ignoreInterface"`
 }
 
 type functionalReadonlyTypeOptions struct {
@@ -332,6 +366,18 @@ func (functionalNoLoopStatements) Check(ctx *Context, node *shimast.Node) {
 }
 
 func (functionalNoMixedTypes) Check(ctx *Context, node *shimast.Node) {
+  var opts functionalNoMixedTypesOptions
+  _ = ctx.DecodeOptions(&opts)
+  switch node.Kind {
+  case shimast.KindInterfaceDeclaration:
+    if opts.CheckInterfaces != nil && !*opts.CheckInterfaces {
+      return
+    }
+  case shimast.KindTypeLiteral:
+    if opts.CheckTypeLiterals != nil && !*opts.CheckTypeLiterals {
+      return
+    }
+  }
   members := containerMembers(node)
   if len(members) < 2 {
     return
@@ -361,16 +407,48 @@ func (functionalNoPromiseReject) Check(ctx *Context, node *shimast.Node) {
 }
 
 func (functionalNoReturnVoid) Check(ctx *Context, node *shimast.Node) {
+  var opts functionalNoReturnVoidOptions
+  _ = ctx.DecodeOptions(&opts)
   if node.Kind == shimast.KindReturnStatement {
     ret := node.AsReturnStatement()
-    if ret != nil && ret.Expression == nil {
-      ctx.Report(node, "Function must return a value.")
+    if ret == nil || ret.Expression != nil {
+      return
     }
+    if opts.IgnoreInferredTypes && functionalEnclosingReturnTypeText(ctx, node) == "" {
+      return
+    }
+    ctx.Report(node, "Function must return a value.")
     return
   }
-  if functionalReturnTypeText(ctx, node) == "void" {
+  switch functionalReturnTypeText(ctx, node) {
+  case "void":
     ctx.Report(node, "Function must return a value.")
+  case "null":
+    if opts.AllowNull != nil && !*opts.AllowNull {
+      ctx.Report(node, "Function must return a value.")
+    }
+  case "undefined":
+    if opts.AllowUndefined != nil && !*opts.AllowUndefined {
+      ctx.Report(node, "Function must return a value.")
+    }
   }
+}
+
+// functionalEnclosingReturnTypeText returns the declared return type text of the
+// nearest function-like ancestor of `node`, or "" when that function declares
+// none. A bare `return;` there is the only place the rule reports a void-ness it
+// inferred instead of reading, which is what `ignoreInferredTypes` spares.
+func functionalEnclosingReturnTypeText(ctx *Context, node *shimast.Node) string {
+  for parent := node.Parent; parent != nil; parent = parent.Parent {
+    switch parent.Kind {
+    case shimast.KindFunctionDeclaration,
+      shimast.KindFunctionExpression,
+      shimast.KindArrowFunction,
+      shimast.KindMethodDeclaration:
+      return functionalReturnTypeText(ctx, parent)
+    }
+  }
+  return ""
 }
 
 func (functionalNoThisExpressions) Check(ctx *Context, node *shimast.Node) {
@@ -418,6 +496,15 @@ func (functionalPreferPropertySignatures) Check(ctx *Context, node *shimast.Node
 func (functionalPreferReadonlyType) Check(ctx *Context, node *shimast.Node) {
   var opts functionalPreferReadonlyTypeOptions
   _ = ctx.DecodeOptions(&opts)
+  if opts.IgnoreInterface && hasAncestorKind(node, shimast.KindInterfaceDeclaration) {
+    return
+  }
+  if opts.AllowMutableReturnType && isFunctionLikeReturnTypePosition(node) {
+    return
+  }
+  if opts.IgnoreCollections && isFunctionalCollectionTypeNode(node) {
+    return
+  }
   switch node.Kind {
   case shimast.KindArrayType:
     if !isReadonlyTypeNode(node) {
@@ -451,10 +538,33 @@ func (functionalPreferReadonlyType) Check(ctx *Context, node *shimast.Node) {
 }
 
 func (functionalPreferTacit) Check(ctx *Context, node *shimast.Node) {
+  var opts functionalPreferTacitOptions
+  _ = ctx.DecodeOptions(&opts)
   text := compactFunctionalWhitespace(nodeText(ctx.File, node))
-  if isTacitWrapperText(text) {
-    ctx.Report(node, "Potentially unnecessary function wrapper.")
+  if !isTacitWrapperText(text) {
+    return
   }
+  if opts.CheckMemberExpressions != nil && !*opts.CheckMemberExpressions &&
+    isTacitWrapperMemberCallee(text) {
+    return
+  }
+  ctx.Report(node, "Potentially unnecessary function wrapper.")
+}
+
+// isTacitWrapperMemberCallee reports whether the wrapper's callee is a member
+// expression (`service.handler`) rather than a bare identifier. `text` has
+// already satisfied isTacitWrapperText, so the split and the `(` are present.
+func isTacitWrapperMemberCallee(text string) bool {
+  parts := strings.Split(text, "=>")
+  if len(parts) != 2 {
+    return false
+  }
+  call := parts[1]
+  open := strings.LastIndex(call, "(")
+  if open <= 0 {
+    return false
+  }
+  return strings.Contains(call[:open], ".")
 }
 
 func (functionalReadonlyType) Check(ctx *Context, node *shimast.Node) {
@@ -755,6 +865,70 @@ func nilSafeFile(node *shimast.Node) *shimast.SourceFile {
     }
   }
   return nil
+}
+
+// hasAncestorKind reports whether any ancestor of `node` has `kind`.
+func hasAncestorKind(node *shimast.Node, kind shimast.Kind) bool {
+  for parent := node.Parent; parent != nil; parent = parent.Parent {
+    if parent.Kind == kind {
+      return true
+    }
+  }
+  return false
+}
+
+// isFunctionLikeReturnTypePosition reports whether `node` is the return-type
+// annotation of a function-like declaration or signature, or sits inside one.
+// The rule visits type nodes, so a mutable array nested in the return type is
+// the same position as the return type itself.
+func isFunctionLikeReturnTypePosition(node *shimast.Node) bool {
+  for current := node; current != nil && current.Parent != nil; current = current.Parent {
+    parent := current.Parent
+    var typeNode *shimast.Node
+    switch parent.Kind {
+    case shimast.KindFunctionDeclaration:
+      if decl := parent.AsFunctionDeclaration(); decl != nil {
+        typeNode = decl.Type
+      }
+    case shimast.KindFunctionExpression:
+      if decl := parent.AsFunctionExpression(); decl != nil {
+        typeNode = decl.Type
+      }
+    case shimast.KindArrowFunction:
+      if decl := parent.AsArrowFunction(); decl != nil {
+        typeNode = decl.Type
+      }
+    case shimast.KindMethodDeclaration:
+      if decl := parent.AsMethodDeclaration(); decl != nil {
+        typeNode = decl.Type
+      }
+    case shimast.KindMethodSignature:
+      if decl := parent.AsMethodSignatureDeclaration(); decl != nil {
+        typeNode = decl.Type
+      }
+    case shimast.KindFunctionType:
+      if decl := parent.AsFunctionTypeNode(); decl != nil {
+        typeNode = decl.Type
+      }
+    }
+    if typeNode != nil && typeNode == current {
+      return true
+    }
+  }
+  return false
+}
+
+// isFunctionalCollectionTypeNode reports whether `node` is an array, tuple, or
+// mutable built-in collection reference, the set `ignoreCollections` spares.
+func isFunctionalCollectionTypeNode(node *shimast.Node) bool {
+  switch node.Kind {
+  case shimast.KindArrayType, shimast.KindTupleType:
+    return true
+  case shimast.KindTypeReference:
+    return isMutableTypeReference(node)
+  default:
+    return false
+  }
 }
 
 func isMutableTypeReference(node *shimast.Node) bool {

--- a/packages/lint/linthost/rules_functional.go
+++ b/packages/lint/linthost/rules_functional.go
@@ -882,6 +882,12 @@ func isFunctionLikeReturnTypePosition(node *shimast.Node) bool {
 
 // signatureReturnTypeNode returns the declared return-type node of `node`, or
 // nil when `node` carries no signature or declares no return type.
+//
+// Do not replace this table with typescript-go's own FunctionLikeData().Type:
+// an index signature embeds the same base, so that accessor also returns the
+// value type of `{ [k: string]: string[] }`, which is not a return type. The
+// three kinds this table omits, a constructor, a set accessor, and an index
+// signature, are exactly the ones whose Type field means something else.
 func signatureReturnTypeNode(node *shimast.Node) *shimast.Node {
   switch node.Kind {
   case shimast.KindFunctionDeclaration:

--- a/packages/lint/linthost/rules_functional.go
+++ b/packages/lint/linthost/rules_functional.go
@@ -496,7 +496,9 @@ func (functionalPreferPropertySignatures) Check(ctx *Context, node *shimast.Node
 func (functionalPreferReadonlyType) Check(ctx *Context, node *shimast.Node) {
   var opts functionalPreferReadonlyTypeOptions
   _ = ctx.DecodeOptions(&opts)
-  if opts.IgnoreInterface && hasAncestorKind(node, shimast.KindInterfaceDeclaration) {
+  if opts.IgnoreInterface && hasAncestor(node, func(ancestor *shimast.Node) bool {
+    return ancestor.Kind == shimast.KindInterfaceDeclaration
+  }) {
     return
   }
   if opts.AllowMutableReturnType && isFunctionLikeReturnTypePosition(node) {
@@ -865,16 +867,6 @@ func nilSafeFile(node *shimast.Node) *shimast.SourceFile {
     }
   }
   return nil
-}
-
-// hasAncestorKind reports whether any ancestor of `node` has `kind`.
-func hasAncestorKind(node *shimast.Node, kind shimast.Kind) bool {
-  for parent := node.Parent; parent != nil; parent = parent.Parent {
-    if parent.Kind == kind {
-      return true
-    }
-  }
-  return false
 }
 
 // isFunctionLikeReturnTypePosition reports whether `node` is the return-type

--- a/packages/lint/linthost/rules_functional.go
+++ b/packages/lint/linthost/rules_functional.go
@@ -192,9 +192,10 @@ type functionalPreferImmutableTypesOptions struct {
 // checked exactly as before.
 type functionalPreferReadonlyTypeOptions struct {
   functionalPatternOptions
-  AllowMutableReturnType bool `json:"allowMutableReturnType"`
-  IgnoreCollections      bool `json:"ignoreCollections"`
-  IgnoreInterface        bool `json:"ignoreInterface"`
+  AllowMutableReturnType bool        `json:"allowMutableReturnType"`
+  IgnoreClass            interface{} `json:"ignoreClass"`
+  IgnoreCollections      bool        `json:"ignoreCollections"`
+  IgnoreInterface        bool        `json:"ignoreInterface"`
 }
 
 type functionalReadonlyTypeOptions struct {
@@ -438,15 +439,17 @@ func (functionalNoReturnVoid) Check(ctx *Context, node *shimast.Node) {
 // nearest function-like ancestor of `node`, or "" when that function declares
 // none. A bare `return;` there is the only place the rule reports a void-ness it
 // inferred instead of reading, which is what `ignoreInferredTypes` spares.
+//
+// The walk stops at the nearest function-like of ANY kind, including the ones
+// that cannot declare a return type at all. Skipping a constructor or an
+// accessor would attribute an enclosing function's annotation to a `return;`
+// that has nothing to do with it.
 func functionalEnclosingReturnTypeText(ctx *Context, node *shimast.Node) string {
   for parent := node.Parent; parent != nil; parent = parent.Parent {
-    switch parent.Kind {
-    case shimast.KindFunctionDeclaration,
-      shimast.KindFunctionExpression,
-      shimast.KindArrowFunction,
-      shimast.KindMethodDeclaration:
-      return functionalReturnTypeText(ctx, parent)
+    if !isFunctionLikeKind(parent) {
+      continue
     }
+    return functionalReturnTypeText(ctx, parent)
   }
   return ""
 }
@@ -499,6 +502,9 @@ func (functionalPreferReadonlyType) Check(ctx *Context, node *shimast.Node) {
   if opts.IgnoreInterface && hasAncestor(node, func(ancestor *shimast.Node) bool {
     return ancestor.Kind == shimast.KindInterfaceDeclaration
   }) {
+    return
+  }
+  if functionalIgnoreClassSkips(opts.IgnoreClass, node) {
     return
   }
   if opts.AllowMutableReturnType && isFunctionLikeReturnTypePosition(node) {
@@ -870,44 +876,102 @@ func nilSafeFile(node *shimast.Node) *shimast.SourceFile {
 }
 
 // isFunctionLikeReturnTypePosition reports whether `node` is the return-type
-// annotation of a function-like declaration or signature, or sits inside one.
-// The rule visits type nodes, so a mutable array nested in the return type is
-// the same position as the return type itself.
+// annotation of any signature-bearing declaration, or sits inside one. The rule
+// visits type nodes, so a mutable array nested in the return type is the same
+// position as the return type itself.
+//
+// Every kind that can carry a return-type annotation is listed: leaving call
+// signatures, construct signatures, constructor types, or a get accessor out
+// would let the same option answer differently for the same position depending
+// on how the signature was spelled.
 func isFunctionLikeReturnTypePosition(node *shimast.Node) bool {
   for current := node; current != nil && current.Parent != nil; current = current.Parent {
-    parent := current.Parent
-    var typeNode *shimast.Node
-    switch parent.Kind {
-    case shimast.KindFunctionDeclaration:
-      if decl := parent.AsFunctionDeclaration(); decl != nil {
-        typeNode = decl.Type
-      }
-    case shimast.KindFunctionExpression:
-      if decl := parent.AsFunctionExpression(); decl != nil {
-        typeNode = decl.Type
-      }
-    case shimast.KindArrowFunction:
-      if decl := parent.AsArrowFunction(); decl != nil {
-        typeNode = decl.Type
-      }
-    case shimast.KindMethodDeclaration:
-      if decl := parent.AsMethodDeclaration(); decl != nil {
-        typeNode = decl.Type
-      }
-    case shimast.KindMethodSignature:
-      if decl := parent.AsMethodSignatureDeclaration(); decl != nil {
-        typeNode = decl.Type
-      }
-    case shimast.KindFunctionType:
-      if decl := parent.AsFunctionTypeNode(); decl != nil {
-        typeNode = decl.Type
-      }
-    }
+    typeNode := signatureReturnTypeNode(current.Parent)
     if typeNode != nil && typeNode == current {
       return true
     }
   }
   return false
+}
+
+// signatureReturnTypeNode returns the declared return-type node of `node`, or
+// nil when `node` carries no signature or declares no return type.
+func signatureReturnTypeNode(node *shimast.Node) *shimast.Node {
+  switch node.Kind {
+  case shimast.KindFunctionDeclaration:
+    if decl := node.AsFunctionDeclaration(); decl != nil {
+      return decl.Type
+    }
+  case shimast.KindFunctionExpression:
+    if decl := node.AsFunctionExpression(); decl != nil {
+      return decl.Type
+    }
+  case shimast.KindArrowFunction:
+    if decl := node.AsArrowFunction(); decl != nil {
+      return decl.Type
+    }
+  case shimast.KindMethodDeclaration:
+    if decl := node.AsMethodDeclaration(); decl != nil {
+      return decl.Type
+    }
+  case shimast.KindMethodSignature:
+    if decl := node.AsMethodSignatureDeclaration(); decl != nil {
+      return decl.Type
+    }
+  case shimast.KindGetAccessor:
+    if decl := node.AsGetAccessorDeclaration(); decl != nil {
+      return decl.Type
+    }
+  case shimast.KindFunctionType:
+    if decl := node.AsFunctionTypeNode(); decl != nil {
+      return decl.Type
+    }
+  case shimast.KindConstructorType:
+    if decl := node.AsConstructorTypeNode(); decl != nil {
+      return decl.Type
+    }
+  case shimast.KindCallSignature:
+    if decl := node.AsCallSignatureDeclaration(); decl != nil {
+      return decl.Type
+    }
+  case shimast.KindConstructSignature:
+    if decl := node.AsConstructSignatureDeclaration(); decl != nil {
+      return decl.Type
+    }
+  }
+  return nil
+}
+
+// isFunctionalClassMemberPosition reports whether `node` sits inside a class
+// body, and whether that position is a field. `ignoreClass: true` skips the
+// whole class body; `"fieldsOnly"` skips only the field declarations, leaving
+// methods, accessors, and constructor parameters checked.
+func isFunctionalClassMemberPosition(node *shimast.Node) (inClass bool, inField bool) {
+  for parent := node.Parent; parent != nil; parent = parent.Parent {
+    switch parent.Kind {
+    case shimast.KindPropertyDeclaration:
+      inField = true
+    case shimast.KindClassDeclaration, shimast.KindClassExpression:
+      return true, inField
+    }
+  }
+  return false, false
+}
+
+// functionalIgnoreClassSkips resolves the `boolean | "fieldsOnly"` option
+// against a visited node's class position.
+func functionalIgnoreClassSkips(option interface{}, node *shimast.Node) bool {
+  if option == nil || option == false {
+    return false
+  }
+  inClass, inField := isFunctionalClassMemberPosition(node)
+  if !inClass {
+    return false
+  }
+  if option == "fieldsOnly" {
+    return inField
+  }
+  return option == true
 }
 
 // isFunctionalCollectionTypeNode reports whether `node` is an array, tuple, or

--- a/packages/lint/linthost/rules_functional.go
+++ b/packages/lint/linthost/rules_functional.go
@@ -440,10 +440,11 @@ func (functionalNoReturnVoid) Check(ctx *Context, node *shimast.Node) {
 // none. A bare `return;` there is the only place the rule reports a void-ness it
 // inferred instead of reading, which is what `ignoreInferredTypes` spares.
 //
-// The walk stops at the nearest function-like of ANY kind, including the ones
-// that cannot declare a return type at all. Skipping a constructor or an
-// accessor would attribute an enclosing function's annotation to a `return;`
-// that has nothing to do with it.
+// The walk stops at the nearest function-like of ANY kind. Skipping a
+// constructor or a set accessor, neither of which may annotate a return type,
+// would attribute an enclosing function's annotation to a `return;` that has
+// nothing to do with it. A get accessor may annotate one, and
+// functionalReturnTypeText reads it.
 func functionalEnclosingReturnTypeText(ctx *Context, node *shimast.Node) string {
   for parent := node.Parent; parent != nil; parent = parent.Parent {
     if !isFunctionLikeKind(parent) {
@@ -713,27 +714,12 @@ func isDeclarationName(node *shimast.Node) bool {
   }
 }
 
+// functionalReturnTypeText returns the declared return-type text of a
+// signature-bearing node, or "" when it declares none. It reads the same
+// signature table isFunctionLikeReturnTypePosition uses, so a get accessor is
+// not mistaken for a declaration that cannot annotate its return type.
 func functionalReturnTypeText(ctx *Context, node *shimast.Node) string {
-  var typeNode *shimast.Node
-  switch node.Kind {
-  case shimast.KindFunctionDeclaration:
-    if decl := node.AsFunctionDeclaration(); decl != nil {
-      typeNode = decl.Type
-    }
-  case shimast.KindFunctionExpression:
-    if decl := node.AsFunctionExpression(); decl != nil {
-      typeNode = decl.Type
-    }
-  case shimast.KindArrowFunction:
-    if decl := node.AsArrowFunction(); decl != nil {
-      typeNode = decl.Type
-    }
-  case shimast.KindMethodDeclaration:
-    if decl := node.AsMethodDeclaration(); decl != nil {
-      typeNode = decl.Type
-    }
-  }
-  return strings.TrimSpace(nodeText(ctx.File, typeNode))
+  return strings.TrimSpace(nodeText(ctx.File, signatureReturnTypeNode(node)))
 }
 
 func functionalFunctionLikeName(node *shimast.Node) string {
@@ -942,10 +928,11 @@ func signatureReturnTypeNode(node *shimast.Node) *shimast.Node {
   return nil
 }
 
-// isFunctionalClassMemberPosition reports whether `node` sits inside a class
-// body, and whether that position is a field. `ignoreClass: true` skips the
-// whole class body; `"fieldsOnly"` skips only the field declarations, leaving
-// methods, accessors, and constructor parameters checked.
+// isFunctionalClassMemberPosition reports whether `node` sits inside a class,
+// and whether that position is a field. `ignoreClass: true` skips anything
+// under a class, its heritage clause and type parameters included, the same
+// ancestor test `ignoreInterface` applies. `"fieldsOnly"` narrows that to field
+// declarations, leaving methods, accessors, and constructor parameters checked.
 func isFunctionalClassMemberPosition(node *shimast.Node) (inClass bool, inField bool) {
   for parent := node.Parent; parent != nil; parent = parent.Parent {
     switch parent.Kind {

--- a/packages/lint/linthost/rules_ts_extra.go
+++ b/packages/lint/linthost/rules_ts_extra.go
@@ -317,12 +317,14 @@ func parameterPropertyName(param *shimast.Node) (string, bool) {
   return name, name != ""
 }
 
+// isParameterProperty is the package's shared parameter-property predicate.
+// The compiler's own mask is the source: a restated keyword list is what left
+// `override` out of format/parameter-properties (#1131), and this predicate
+// feeds six rules, so a restatement here would be five more chances at the same
+// drift.
 func isParameterProperty(param *shimast.Node) bool {
-  return hasModifier(param, shimast.KindPublicKeyword) ||
-    hasModifier(param, shimast.KindPrivateKeyword) ||
-    hasModifier(param, shimast.KindProtectedKeyword) ||
-    hasModifier(param, shimast.KindReadonlyKeyword) ||
-    hasModifier(param, shimast.KindOverrideKeyword)
+  return param != nil &&
+    param.ModifierFlags()&shimast.ModifierFlagsParameterPropertyModifier != 0
 }
 
 func thisPropertyAssignment(stmt *shimast.Node) (property string, value string, ok bool) {

--- a/packages/lint/rule/rule.go
+++ b/packages/lint/rule/rule.go
@@ -279,9 +279,10 @@ type RelatedInformation struct {
 //
 // Emit the narrowest edits that express the rewrite. Several small
 // non-overlapping edits contend for less source than one wide replacement and
-// are the shape the atomic applier exists to support; `no-import-type-side-
-// effects`, `format/whitespace`, `format/indent`, and `format/sort-imports`
-// all ship multi-edit fixes.
+// are the shape the atomic applier exists to support. Built-ins that ship
+// multi-edit fixes include `typescript/no-import-type-side-effects`,
+// `format/whitespace`, `format/indent`, `unicorn/prevent-abbreviations`, and
+// `unicorn/template-indent`.
 type TextEdit struct {
   Pos  int
   End  int

--- a/packages/lint/rule/rule.go
+++ b/packages/lint/rule/rule.go
@@ -262,15 +262,26 @@ type RelatedInformation struct {
 // be replaced as a whole.
 //
 // Application policy: a rule may emit several `TextEdit`s in one
-// `ReportFix` / `ReportRangeFix` call, in any order. The host treats the
-// per-pass edit set as a candidate list. Within a single fix pass, edits
-// must not overlap each other; when two edits cover overlapping ranges
-// (either from one rule emitting multiple edits in one call, or from two
-// different rules in the same pass), the host applies the earliest-starting
-// / shortest edit and silently drops the rest. There is no diagnostic for
-// dropped edits, and the host does not currently report when a comment
-// falls inside a deletion range. Design fixes so each finding emits one
-// contiguous TextEdit covering the entire replacement region.
+// `ReportFix` / `ReportRangeFix` call, in any order. The unit the host
+// resolves conflicts on is the FINDING, not the individual edit. Within one
+// fix pass the host considers each finding's edits as one group, earliest
+// group first, and accepts a group only when every member coexists with the
+// edits already accepted. If any member would be dropped, the whole group is
+// skipped, so a multi-edit fix never half-applies. The skipped finding is not
+// lost: the next cascade pass re-runs the rule against the rewritten source
+// and the fix applies then, or the cascade converges without it.
+//
+// A finding's own edits must therefore not overlap each other either, or the
+// finding can never apply. Exact duplicates within one finding are collapsed
+// rather than treated as a conflict, so repeating an identical edit is
+// harmless. Nothing diagnoses a skipped group, and the host does not report
+// when a comment falls inside a deletion range.
+//
+// Emit the narrowest edits that express the rewrite. Several small
+// non-overlapping edits contend for less source than one wide replacement and
+// are the shape the atomic applier exists to support; `no-import-type-side-
+// effects`, `format/whitespace`, `format/indent`, and `format/sort-imports`
+// all ship multi-edit fixes.
 type TextEdit struct {
   Pos  int
   End  int

--- a/packages/lint/src/structures/rules/ITtscLintFunctionalRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintFunctionalRuleOptions.ts
@@ -156,8 +156,8 @@ export interface ITtscLintFunctionalPreferReadonlyTypeRuleOptions extends ITtscL
 
   /**
    * Also check property positions that have no explicit type annotation.
-   * Reserved for upstream-compatible configs; the native subset visits type
-   * nodes, and an unannotated position has none.
+   * Reserved for upstream-compatible configs; judging an unannotated position
+   * needs the type checker, which this rule does not use.
    */
   checkImplicit?: boolean;
 
@@ -169,9 +169,10 @@ export interface ITtscLintFunctionalPreferReadonlyTypeRuleOptions extends ITtscL
   ignoreCollections?: boolean;
 
   /**
-   * Skip class members. `true` skips the whole class body; `"fieldsOnly"` skips
-   * only field declarations and keeps methods, accessors, and constructor
-   * parameters checked.
+   * Skip class members. `true` skips anything under a class, its heritage
+   * clause and type parameters included; `"fieldsOnly"` narrows that to field
+   * declarations and keeps methods, accessors, and constructor parameters
+   * checked.
    *
    * @default false
    */

--- a/packages/lint/src/structures/rules/ITtscLintFunctionalRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintFunctionalRuleOptions.ts
@@ -169,9 +169,11 @@ export interface ITtscLintFunctionalPreferReadonlyTypeRuleOptions extends ITtscL
   ignoreCollections?: boolean;
 
   /**
-   * Skip class fields. Reserved for upstream-compatible configs; the native
-   * subset visits no class-member position, so class fields are already never
-   * reported.
+   * Skip class members. `true` skips the whole class body; `"fieldsOnly"` skips
+   * only field declarations and keeps methods, accessors, and constructor
+   * parameters checked.
+   *
+   * @default false
    */
   ignoreClass?: boolean | "fieldsOnly";
 

--- a/packages/lint/src/structures/rules/ITtscLintFunctionalRuleOptions.ts
+++ b/packages/lint/src/structures/rules/ITtscLintFunctionalRuleOptions.ts
@@ -80,24 +80,45 @@ export interface ITtscLintFunctionalNoThrowStatementsRuleOptions {
 
 /** `functional/no-mixed-types` rule options. */
 export interface ITtscLintFunctionalNoMixedTypesRuleOptions {
-  /** Check interface member kinds. */
+  /**
+   * Check interface member kinds.
+   *
+   * @default true
+   */
   checkInterfaces?: boolean;
 
-  /** Check type-literal member kinds. */
+  /**
+   * Check type-literal member kinds.
+   *
+   * @default true
+   */
   checkTypeLiterals?: boolean;
 }
 
 /** `functional/no-return-void` rule options. */
 export interface ITtscLintFunctionalNoReturnVoidRuleOptions {
-  /** Permit a function that returns `null` to satisfy the rule. */
+  /**
+   * Permit a function whose declared return type is `null`. Set `false` to
+   * reject it the way a declared `void` is rejected.
+   *
+   * @default true
+   */
   allowNull?: boolean;
 
-  /** Permit a function that returns `undefined` to satisfy the rule. */
+  /**
+   * Permit a function whose declared return type is `undefined`. Set `false` to
+   * reject it the way a declared `void` is rejected.
+   *
+   * @default true
+   */
   allowUndefined?: boolean;
 
   /**
-   * Skip functions whose return type is inferred to be `void` rather than
-   * declared explicitly.
+   * Skip a bare `return;` inside a function that declares no return type. That
+   * statement is the one place the rule rejects a void-ness it inferred rather
+   * than read from an annotation.
+   *
+   * @default false
    */
   ignoreInferredTypes?: boolean;
 }
@@ -105,7 +126,8 @@ export interface ITtscLintFunctionalNoReturnVoidRuleOptions {
 /** `functional/prefer-immutable-types` rule options. */
 export interface ITtscLintFunctionalPreferImmutableTypesRuleOptions extends ITtscLintFunctionalPatternOptions {
   /**
-   * Minimum accepted immutability. The native subset treats any configured
+   * Minimum accepted immutability. Reserved for upstream-compatible configs;
+   * the native subset computes no immutability level and treats any configured
    * value as readonly-required.
    */
   enforcement?:
@@ -118,31 +140,57 @@ export interface ITtscLintFunctionalPreferImmutableTypesRuleOptions extends ITts
 
 /** `functional/prefer-readonly-type` rule options. */
 export interface ITtscLintFunctionalPreferReadonlyTypeRuleOptions extends ITtscLintFunctionalPatternOptions {
-  /** Permit mutation of locals while still policing exported types. */
+  /**
+   * Permit mutation of locals while still policing exported types. Reserved for
+   * upstream-compatible configs; the native subset reads type annotations and
+   * models no local-versus-exported distinction.
+   */
   allowLocalMutation?: boolean;
 
-  /** Permit a mutable return type even when parameters must be readonly. */
+  /**
+   * Permit a mutable return type even when parameters must be readonly.
+   *
+   * @default false
+   */
   allowMutableReturnType?: boolean;
 
-  /** Also check property positions that have no explicit type annotation. */
+  /**
+   * Also check property positions that have no explicit type annotation.
+   * Reserved for upstream-compatible configs; the native subset visits type
+   * nodes, and an unannotated position has none.
+   */
   checkImplicit?: boolean;
 
-  /** Skip array / tuple / `Map` / `Set` types. */
+  /**
+   * Skip array / tuple / `Map` / `Set` types.
+   *
+   * @default false
+   */
   ignoreCollections?: boolean;
 
   /**
-   * Skip class fields. `"fieldsOnly"` keeps the rule active for non-field class
-   * members.
+   * Skip class fields. Reserved for upstream-compatible configs; the native
+   * subset visits no class-member position, so class fields are already never
+   * reported.
    */
   ignoreClass?: boolean | "fieldsOnly";
 
-  /** Skip interface members entirely. */
+  /**
+   * Skip interface members entirely.
+   *
+   * @default false
+   */
   ignoreInterface?: boolean;
 }
 
 /** `functional/prefer-tacit` rule options. */
 export interface ITtscLintFunctionalPreferTacitRuleOptions {
-  /** Check member expressions such as `x => service.map(x)`. */
+  /**
+   * Check member expressions such as `x => service.map(x)`. Set `false` to keep
+   * the rule on bare-identifier callees only.
+   *
+   * @default true
+   */
   checkMemberExpressions?: boolean;
 }
 
@@ -167,7 +215,11 @@ export interface ITtscLintFunctionalTypeDeclarationImmutabilityRule {
    */
   immutability?: "ReadonlyShallow" | "ReadonlyDeep" | "Immutable" | "Mutable";
 
-  /** Comparator applied to the immutability level above. */
+  /**
+   * Comparator applied to the immutability level above. Reserved for
+   * upstream-compatible configs alongside `immutability`: the native subset
+   * computes no immutability level, so there is nothing to compare.
+   */
   comparator?:
     | "Less"
     | "AtMost"

--- a/packages/lint/test/fix/fix_select_text_edit_groups_collapses_duplicate_edit_within_finding_test.go
+++ b/packages/lint/test/fix/fix_select_text_edit_groups_collapses_duplicate_edit_within_finding_test.go
@@ -1,0 +1,37 @@
+package linthost
+
+import "testing"
+
+// TestSelectTextEditGroupsCollapsesDuplicateEditWithinFinding verifies a finding
+// that emits the same edit twice still applies its distinct edits.
+//
+// This is the negative twin of the self-overlap case: an exact duplicate is not
+// a conflict, so `dedupeTextEdits` collapses it before the group gate counts
+// members. Without the collapse the duplicate would shrink the selected count
+// below the candidate count and reject an otherwise valid fix, which is the
+// difference between "your edits contradict each other" and "you repeated
+// yourself".
+//
+//  1. Build one group whose first edit appears twice and whose second is disjoint.
+//  2. Run selectTextEditGroups with that group alone.
+//  3. Assert both distinct edits survive, in position order, with no duplicate.
+func TestSelectTextEditGroupsCollapsesDuplicateEditWithinFinding(t *testing.T) {
+  group := []TextEdit{
+    {Pos: 2, End: 4, Text: "AA"},
+    {Pos: 2, End: 4, Text: "AA"},
+    {Pos: 6, End: 8, Text: "BB"},
+  }
+  selected := selectTextEditGroups(20, [][]TextEdit{group})
+  want := []TextEdit{
+    {Pos: 2, End: 4, Text: "AA"},
+    {Pos: 6, End: 8, Text: "BB"},
+  }
+  if len(selected) != len(want) {
+    t.Fatalf("expected %d edits, got %d: %+v", len(want), len(selected), selected)
+  }
+  for i, edit := range selected {
+    if edit != want[i] {
+      t.Fatalf("edit %d = %+v, want %+v (selected=%+v)", i, edit, want[i], selected)
+    }
+  }
+}

--- a/packages/lint/test/fix/fix_select_text_edit_groups_drops_self_overlapping_finding_test.go
+++ b/packages/lint/test/fix/fix_select_text_edit_groups_drops_self_overlapping_finding_test.go
@@ -1,0 +1,27 @@
+package linthost
+
+import "testing"
+
+// TestSelectTextEditGroupsDropsSelfOverlappingFinding verifies a finding whose
+// own edits overlap each other applies nothing at all.
+//
+// The public `rule.TextEdit` contract tells a rule author that a finding's own
+// edits must not overlap, and the reason is this: the group gate compares the
+// selected count against the candidate count, so a finding that collides with
+// itself can never be accepted. Without this case the contract's sharpest
+// consequence for a rule author is unpinned, and a future selector that
+// silently kept the surviving member would look correct.
+//
+//  1. Build one group whose two edits cover overlapping ranges.
+//  2. Run selectTextEditGroups with that group alone.
+//  3. Assert nothing is selected, not even the earlier-starting member.
+func TestSelectTextEditGroupsDropsSelfOverlappingFinding(t *testing.T) {
+  group := []TextEdit{
+    {Pos: 2, End: 6, Text: "FIRST"},
+    {Pos: 4, End: 9, Text: "SECOND"},
+  }
+  selected := selectTextEditGroups(20, [][]TextEdit{group})
+  if len(selected) != 0 {
+    t.Fatalf("self-overlapping finding applied %d edits: %+v", len(selected), selected)
+  }
+}

--- a/packages/lint/test/format/format_clause_join_charges_the_else_width_budget_at_its_limit_test.go
+++ b/packages/lint/test/format/format_clause_join_charges_the_else_width_budget_at_its_limit_test.go
@@ -2,7 +2,7 @@ package linthost
 
 import "testing"
 
-// TestFormatClauseJoinKeepsOverlongElseBodyBroken verifies the printWidth budget
+// TestFormatClauseJoinChargesTheElseWidthBudgetAtItsLimit verifies the printWidth budget
 // for an `else` clause is charged at its exact limit.
 //
 // `else stopEverything();` is 22 display columns. Prettier 3.8.3 joins it at
@@ -14,7 +14,7 @@ import "testing"
 //  1. Run format/clause-join on the same source at printWidth 22 and 21.
 //  2. Assert the join lands at 22.
 //  3. Assert nothing is reported at 21.
-func TestFormatClauseJoinKeepsOverlongElseBodyBroken(t *testing.T) {
+func TestFormatClauseJoinChargesTheElseWidthBudgetAtItsLimit(t *testing.T) {
   const source = "if (ready) run();\nelse\n  stopEverything();\n"
   assertFixSnapshotWithOptions(
     t,

--- a/packages/lint/test/format/format_clause_join_joins_do_body_test.go
+++ b/packages/lint/test/format/format_clause_join_joins_do_body_test.go
@@ -1,0 +1,22 @@
+package linthost
+
+import "testing"
+
+// TestFormatClauseJoinJoinsDoBody verifies a single-statement `do` body joins its `do` keyword.
+//
+// `KindDoStatement` was absent from the rule's visit set, so `do\n  tick();`
+// survived every format pass while Prettier 3.8.3 writes `do tick();`. The `do`
+// keyword is the clause's header token, the way `)` is for a `while`.
+//
+//  1. Parse a `do` loop whose body sits on the following line.
+//  2. Apply format/clause-join with printWidth 80.
+//  3. Assert the body joins the `do` line and the `while` tail is untouched.
+func TestFormatClauseJoinJoinsDoBody(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/clause-join",
+    "do\n  tick();\nwhile (ready);\n",
+    `{"printWidth":80,"tabWidth":2}`,
+    "do tick();\nwhile (ready);\n",
+  )
+}

--- a/packages/lint/test/format/format_clause_join_joins_else_body_test.go
+++ b/packages/lint/test/format/format_clause_join_joins_else_body_test.go
@@ -1,0 +1,22 @@
+package linthost
+
+import "testing"
+
+// TestFormatClauseJoinJoinsElseBody verifies a single-statement `else` body joins its `else` keyword line.
+//
+// The rule anchored on a header's closing `)`, which the `else` branch does not
+// have, so it abstained where Prettier 3.8.3 writes `else stop();` (#1133). The
+// anchor is now the clause's own header token.
+//
+//  1. Parse an `if`/`else` whose branches both sit on the following line.
+//  2. Apply format/clause-join with printWidth 80.
+//  3. Assert both branches join their own header line.
+func TestFormatClauseJoinJoinsElseBody(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/clause-join",
+    "if (ready)\n  run();\nelse\n  stop();\n",
+    `{"printWidth":80,"tabWidth":2}`,
+    "if (ready) run();\nelse stop();\n",
+  )
+}

--- a/packages/lint/test/format/format_clause_join_joins_else_if_chain_across_lines_test.go
+++ b/packages/lint/test/format/format_clause_join_joins_else_if_chain_across_lines_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFormatClauseJoinJoinsElseIfChainAcrossLines verifies an `else` whose alternate is an `if` joins even when that `if` spans lines.
+//
+// Prettier prints an `else if` chain flat, so the alternate being an `if` is the
+// second clause exempt from the single-line-body guard. Applying that guard here
+// would leave `else` alone on its line and the chain permanently unjoined,
+// because the inner `if` only becomes single-line on a later cascade pass.
+//
+//  1. Parse an `else` whose alternate is an `if` written across two lines.
+//  2. Apply format/clause-join with printWidth 80.
+//  3. Assert the chain collapses to `else if (b) y();`.
+func TestFormatClauseJoinJoinsElseIfChainAcrossLines(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/clause-join",
+    "if (a)\n  x();\nelse\n  if (b)\n    y();\n",
+    `{"printWidth":80,"tabWidth":2}`,
+    "if (a) x();\nelse if (b) y();\n",
+  )
+}

--- a/packages/lint/test/format/format_clause_join_joins_labeled_block_body_test.go
+++ b/packages/lint/test/format/format_clause_join_joins_labeled_block_body_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFormatClauseJoinJoinsLabeledBlockBody verifies a labeled statement joins its body even when that body is a block.
+//
+// A label has no group of its own in Prettier: `label: statement` is one line
+// whatever the statement is. That makes it the one clause where the braced-body
+// and multi-line-body abstentions must not apply, and getting it wrong leaves
+// `outer:` stranded on its own line forever.
+//
+//  1. Parse a label whose loop body spans several lines.
+//  2. Apply format/clause-join with printWidth 80.
+//  3. Assert the loop joins the label line and its interior is untouched.
+func TestFormatClauseJoinJoinsLabeledBlockBody(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/clause-join",
+    "outer:\nfor (const item of items) {\n  break outer;\n}\n",
+    `{"printWidth":80,"tabWidth":2}`,
+    "outer: for (const item of items) {\n  break outer;\n}\n",
+  )
+}

--- a/packages/lint/test/format/format_clause_join_joins_with_body_test.go
+++ b/packages/lint/test/format/format_clause_join_joins_with_body_test.go
@@ -1,0 +1,22 @@
+package linthost
+
+import "testing"
+
+// TestFormatClauseJoinJoinsWithBody verifies a single-statement `with` body joins its header line.
+//
+// `with` is a `)`-headed clause Prettier joins like `while`, and it was simply
+// missing from the visit set. The statement is rare and illegal in strict mode,
+// which is exactly why nothing else in the corpus would have caught it.
+//
+//  1. Parse a `with` statement whose body sits on the following line.
+//  2. Apply format/clause-join with printWidth 80.
+//  3. Assert the body joins the header line.
+func TestFormatClauseJoinJoinsWithBody(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/clause-join",
+    "with (scope)\n  run();\n",
+    `{"printWidth":80,"tabWidth":2}`,
+    "with (scope) run();\n",
+  )
+}

--- a/packages/lint/test/format/format_clause_join_keeps_overlong_else_body_broken_test.go
+++ b/packages/lint/test/format/format_clause_join_keeps_overlong_else_body_broken_test.go
@@ -2,21 +2,31 @@ package linthost
 
 import "testing"
 
-// TestFormatClauseJoinKeepsOverlongElseBodyBroken verifies an `else` body that would overflow printWidth stays broken.
+// TestFormatClauseJoinKeepsOverlongElseBodyBroken verifies the printWidth budget
+// for an `else` clause is charged at its exact limit.
 //
-// The width budget for the new clauses is measured from the `else` keyword's
-// line, not the enclosing `if`, because that is the line Prettier would print.
-// Measuring from the statement start would charge the wrong column and join a
-// line that does not fit.
+// `else stopEverything();` is 22 display columns. Prettier 3.8.3 joins it at
+// printWidth 22 and leaves it broken at 21, so this case walks the boundary from
+// both sides rather than picking a width comfortably past it. A budget measured
+// from the enclosing `if` instead of the `else` keyword would charge the wrong
+// column here.
 //
-//  1. Parse an `else` whose single-statement body cannot fit a narrow printWidth.
-//  2. Run format/clause-join with printWidth 20.
-//  3. Assert the rule reports nothing.
+//  1. Run format/clause-join on the same source at printWidth 22 and 21.
+//  2. Assert the join lands at 22.
+//  3. Assert nothing is reported at 21.
 func TestFormatClauseJoinKeepsOverlongElseBodyBroken(t *testing.T) {
+  const source = "if (ready) run();\nelse\n  stopEverything();\n"
+  assertFixSnapshotWithOptions(
+    t,
+    "format/clause-join",
+    source,
+    `{"printWidth":22,"tabWidth":2}`,
+    "if (ready) run();\nelse stopEverything();\n",
+  )
   assertRuleSkipsSourceWithOptions(
     t,
     "format/clause-join",
-    "if (ready) run();\nelse\n  stopEverything();\n",
-    `{"printWidth":20,"tabWidth":2}`,
+    source,
+    `{"printWidth":21,"tabWidth":2}`,
   )
 }

--- a/packages/lint/test/format/format_clause_join_keeps_overlong_else_body_broken_test.go
+++ b/packages/lint/test/format/format_clause_join_keeps_overlong_else_body_broken_test.go
@@ -1,0 +1,22 @@
+package linthost
+
+import "testing"
+
+// TestFormatClauseJoinKeepsOverlongElseBodyBroken verifies an `else` body that would overflow printWidth stays broken.
+//
+// The width budget for the new clauses is measured from the `else` keyword's
+// line, not the enclosing `if`, because that is the line Prettier would print.
+// Measuring from the statement start would charge the wrong column and join a
+// line that does not fit.
+//
+//  1. Parse an `else` whose single-statement body cannot fit a narrow printWidth.
+//  2. Run format/clause-join with printWidth 20.
+//  3. Assert the rule reports nothing.
+func TestFormatClauseJoinKeepsOverlongElseBodyBroken(t *testing.T) {
+  assertRuleSkipsSourceWithOptions(
+    t,
+    "format/clause-join",
+    "if (ready) run();\nelse\n  stopEverything();\n",
+    `{"printWidth":20,"tabWidth":2}`,
+  )
+}

--- a/packages/lint/test/format/format_clause_join_skips_braced_else_and_do_bodies_test.go
+++ b/packages/lint/test/format/format_clause_join_skips_braced_else_and_do_bodies_test.go
@@ -5,12 +5,13 @@ import "testing"
 // TestFormatClauseJoinSkipsBracedElseAndDoBodies verifies a braced `else` or
 // `do` body keeps its own line.
 //
-// This is the negative twin of the labeled-block case. A label is the one clause
-// whose braced body Prettier pulls up (`label: {`); every other clause leaves
-// `{` where it is, and the brace's placement against the preceding `}` belongs
-// to a separate concern. Without this case the braced-body gate is pinned only
-// in the direction that joins, so widening it to `else`, `do`, and `with` would
-// pass the whole suite.
+// This is the negative twin of the labeled-block case, and a scope decision
+// rather than an oracle claim: Prettier pulls a brace up for every clause
+// (`if (a) {`, `else {`, `do {`), and this rule takes on only the label, whose
+// braced body it already has to join. Brace-on-next-line style is the sibling
+// concern. Without this case the braced-body gate is pinned only in the
+// direction that joins, so widening it to `else`, `do`, and `with` would pass
+// the whole suite.
 //
 //  1. Parse an `else` and a `do` whose bodies are blocks starting on their own line.
 //  2. Run format/clause-join with printWidth 80.

--- a/packages/lint/test/format/format_clause_join_skips_braced_else_and_do_bodies_test.go
+++ b/packages/lint/test/format/format_clause_join_skips_braced_else_and_do_bodies_test.go
@@ -1,0 +1,31 @@
+package linthost
+
+import "testing"
+
+// TestFormatClauseJoinSkipsBracedElseAndDoBodies verifies a braced `else` or
+// `do` body keeps its own line.
+//
+// This is the negative twin of the labeled-block case. A label is the one clause
+// whose braced body Prettier pulls up (`label: {`); every other clause leaves
+// `{` where it is, and the brace's placement against the preceding `}` belongs
+// to a separate concern. Without this case the braced-body gate is pinned only
+// in the direction that joins, so widening it to `else`, `do`, and `with` would
+// pass the whole suite.
+//
+//  1. Parse an `else` and a `do` whose bodies are blocks starting on their own line.
+//  2. Run format/clause-join with printWidth 80.
+//  3. Assert the rule reports nothing for either.
+func TestFormatClauseJoinSkipsBracedElseAndDoBodies(t *testing.T) {
+  assertRuleSkipsSourceWithOptions(
+    t,
+    "format/clause-join",
+    "if (ready) run();\nelse\n{\n  stop();\n}\n",
+    `{"printWidth":80,"tabWidth":2}`,
+  )
+  assertRuleSkipsSourceWithOptions(
+    t,
+    "format/clause-join",
+    "do\n{\n  tick();\n} while (ready);\n",
+    `{"printWidth":80,"tabWidth":2}`,
+  )
+}

--- a/packages/lint/test/format/format_clause_join_skips_commented_else_gap_test.go
+++ b/packages/lint/test/format/format_clause_join_skips_commented_else_gap_test.go
@@ -1,0 +1,21 @@
+package linthost
+
+import "testing"
+
+// TestFormatClauseJoinSkipsCommentedElseGap verifies a comment between `else` and its body blocks the join.
+//
+// The gap walk stops at the first non-whitespace byte and requires the clause's
+// own header token there, so a comment in the gap fails the anchor test rather
+// than being swallowed by the rewrite. Prettier leaves the same source alone.
+//
+//  1. Parse an `else` whose body is preceded by a line comment.
+//  2. Run format/clause-join with printWidth 80.
+//  3. Assert the rule reports nothing.
+func TestFormatClauseJoinSkipsCommentedElseGap(t *testing.T) {
+  assertRuleSkipsSourceWithOptions(
+    t,
+    "format/clause-join",
+    "if (ready) run();\nelse\n  // note\n  stop();\n",
+    `{"printWidth":80,"tabWidth":2}`,
+  )
+}

--- a/packages/lint/test/format/format_clause_join_skips_empty_else_and_do_bodies_test.go
+++ b/packages/lint/test/format/format_clause_join_skips_empty_else_and_do_bodies_test.go
@@ -1,0 +1,28 @@
+package linthost
+
+import "testing"
+
+// TestFormatClauseJoinSkipsEmptyElseAndDoBodies verifies the empty-statement abstention covers the `else` and `do` clauses.
+//
+// Prettier glues an empty statement to its header with no space (`else;`,
+// `do;`), and this rule's gap-to-space rewrite cannot produce that. Extending the
+// visit set without extending the abstention would have emitted `else ;`, which
+// is a shape Prettier would immediately rewrite.
+//
+//  1. Parse an `else` and a `do` whose bodies are bare `;`.
+//  2. Run format/clause-join with printWidth 80.
+//  3. Assert the rule reports nothing for either.
+func TestFormatClauseJoinSkipsEmptyElseAndDoBodies(t *testing.T) {
+  assertRuleSkipsSourceWithOptions(
+    t,
+    "format/clause-join",
+    "if (ready) run();\nelse\n  ;\n",
+    `{"printWidth":80,"tabWidth":2}`,
+  )
+  assertRuleSkipsSourceWithOptions(
+    t,
+    "format/clause-join",
+    "do\n  ;\nwhile (ready);\n",
+    `{"printWidth":80,"tabWidth":2}`,
+  )
+}

--- a/packages/lint/test/format/format_parameter_properties_breaks_override_only_constructor_test.go
+++ b/packages/lint/test/format/format_parameter_properties_breaks_override_only_constructor_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestFormatParameterPropertiesBreaksOverrideOnlyConstructor verifies a
+// constructor whose only parameter-property modifier is `override` is broken
+// one-parameter-per-line.
+//
+// `override` is the fifth member of TypeScript's
+// `ModifierFlagsParameterPropertyModifier` mask, and the rule used to restate
+// the mask as four keywords. A constructor carrying only `override` therefore
+// read as having no parameter property at all, so the rule abstained where
+// Prettier 3.8.3 force-breaks (#1131).
+//
+//  1. Parse a derived class with `constructor(override rate: number, kind: string)`.
+//  2. Apply format/parameter-properties (tabWidth 2).
+//  3. Assert each parameter lands on its own indented line.
+func TestFormatParameterPropertiesBreaksOverrideOnlyConstructor(t *testing.T) {
+  assertFixSnapshotWithOptions(
+    t,
+    "format/parameter-properties",
+    "class Ctrl extends Base {\n  constructor(override rate: number, kind: string) {}\n}\n",
+    `{"tabWidth":2}`,
+    "class Ctrl extends Base {\n  constructor(\n    override rate: number,\n    kind: string\n  ) {}\n}\n",
+  )
+}

--- a/packages/lint/test/format/format_parameter_properties_ignores_decorated_plain_params_test.go
+++ b/packages/lint/test/format/format_parameter_properties_ignores_decorated_plain_params_test.go
@@ -1,0 +1,25 @@
+package linthost
+
+import "testing"
+
+// TestFormatParameterPropertiesIgnoresDecoratedPlainParams verifies a
+// constructor whose parameters carry a decorator but no parameter-property
+// modifier is left inline.
+//
+// This is the negative twin of the `override` case. A decorated parameter has a
+// non-empty modifier list, so a check that merely asks "does this parameter
+// carry modifiers?" would over-match it. `ModifierFlagsParameterPropertyModifier`
+// excludes `ModifierFlagsDecorator`, and this case is what keeps that
+// distinction pinned.
+//
+//  1. Parse a class with `constructor(@Inject() rate: number, kind: string)`.
+//  2. Run format/parameter-properties.
+//  3. Assert the rule reports nothing.
+func TestFormatParameterPropertiesIgnoresDecoratedPlainParams(t *testing.T) {
+  assertRuleSkipsSourceWithOptions(
+    t,
+    "format/parameter-properties",
+    "class A {\n  constructor(@Inject() rate: Foo, kind: Bar) {}\n}\n",
+    `{"tabWidth":2}`,
+  )
+}

--- a/packages/lint/test/format/format_parameter_properties_ignores_decorated_plain_params_test.go
+++ b/packages/lint/test/format/format_parameter_properties_ignores_decorated_plain_params_test.go
@@ -6,11 +6,12 @@ import "testing"
 // constructor whose parameters carry a decorator but no parameter-property
 // modifier is left inline.
 //
-// This is the negative twin of the `override` case. A decorated parameter has a
-// non-empty modifier list, so a check that merely asks "does this parameter
-// carry modifiers?" would over-match it. `ModifierFlagsParameterPropertyModifier`
-// excludes `ModifierFlagsDecorator`, and this case is what keeps that
-// distinction pinned.
+// A decorator is carried in the same modifier list as an accessibility keyword,
+// and `ModifierFlagsParameterPropertyModifier` deliberately excludes
+// `ModifierFlagsDecorator`. This case pins that boundary against a future
+// simplification to "does this parameter carry modifiers at all". Prettier
+// 3.8.3 leaves the same constructor inline, so the abstention is the oracle's,
+// not the implementation's.
 //
 //  1. Parse a class with `constructor(@Inject() rate: number, kind: string)`.
 //  2. Run format/parameter-properties.

--- a/packages/lint/test/format/format_parameter_properties_ignores_plain_params_test.go
+++ b/packages/lint/test/format/format_parameter_properties_ignores_plain_params_test.go
@@ -3,8 +3,7 @@ package linthost
 import "testing"
 
 // TestFormatParameterPropertiesIgnoresPlainParams verifies a constructor
-// whose parameters carry no accessibility/readonly modifier is left
-// inline.
+// whose parameters carry no parameter-property modifier is left inline.
 //
 // Only parameter properties trigger Prettier's force-break; a plain
 // `constructor(x: Foo, y: Bar)` is governed by ordinary width reflow, so

--- a/packages/lint/test/format/format_prettier_conformance_test.go
+++ b/packages/lint/test/format/format_prettier_conformance_test.go
@@ -41,6 +41,7 @@ func TestFormatPrettierConformance(t *testing.T) {
     {"format/bracket-spacing", "bindings-and-clauses", "import {read, write} from \"module\";\nexport {read, write};\nconst {value} = source;\ntype Shape = {value: string};\n", nil, false},
     {"format/bracket-spacing", "disabled", "const value = { item: 1 };\n", map[string]any{"bracketSpacing": false}, false},
     {"format/clause-join", "control-flow", "if (ready)\n  run();\nwhile (ready)\n  tick();\nfor (let i = 0; i < count; i++)\n  visit(i);\nfor (const item of items)\n  visit(item);\nfor (const key in record)\n  visit(key);\n", nil, false},
+    {"format/clause-join", "keyword-and-label-anchored", "if (ready)\n  run();\nelse\n  stop();\ndo\n  tick();\nwhile (ready);\nwith (scope)\n  visit();\nouter:\nfor (const item of items) {\n  break outer;\n}\n", nil, false},
     {"format/declaration-header", "interface", "interface Result\nextends Base {}\n", nil, false},
     {"format/declaration-header", "class", "class Result\nextends Base {}\n", nil, false},
     {"format/declaration-header", "multi-type-width", "interface Result extends First, Second, Third, Fourth, Fifth, Sixth {\n  value: number;\n}\n", map[string]any{"printWidth": 50}, false},

--- a/packages/lint/test/format/format_prettier_conformance_test.go
+++ b/packages/lint/test/format/format_prettier_conformance_test.go
@@ -49,6 +49,7 @@ func TestFormatPrettierConformance(t *testing.T) {
     {"format/jsdoc", "extension-canonical", "/**\n * @returns A value.\n */\nfunction value(): number {\n  return 1;\n}\n", map[string]any{"jsDoc": true}, true},
     {"format/orphan-semi", "asi-guard", "// guard\n;\n(bar as Baz).qux()\n", map[string]any{"semi": false}, false},
     {"format/parameter-properties", "multiple-properties", "class Value {\n  constructor(private first: First, public second: Second) {}\n}\n", map[string]any{"trailingComma": "none"}, false},
+    {"format/parameter-properties", "override-only", "class Ctrl extends Base {\n  constructor(override rate: number, kind: string) {\n    super();\n  }\n}\n", map[string]any{"trailingComma": "none"}, false},
     {"format/print-width", "object", "const value = { first: 1, second: 2, third: 3 };\n", map[string]any{"printWidth": 20}, false},
     {"format/print-width", "array", "const values = [first, second, third];\n", map[string]any{"printWidth": 20}, false},
     {"format/print-width", "call", "process(aaaaaa, bbbbbb, cccccc);\n", map[string]any{"printWidth": 24}, false},

--- a/packages/lint/test/registry/published_rule_options_are_read_or_reserved_test.go
+++ b/packages/lint/test/registry/published_rule_options_are_read_or_reserved_test.go
@@ -1,0 +1,155 @@
+package linthost
+
+import (
+  "os"
+  "path/filepath"
+  "regexp"
+  "runtime"
+  "sort"
+  "strings"
+  "testing"
+)
+
+// reservedRuleOptionMarker is the sentence a published option field carries when
+// the native subset accepts it for upstream compatibility and does not act on
+// it. It is the only sanctioned way for a field to reach a user's config and
+// change nothing.
+const reservedRuleOptionMarker = "Reserved for upstream-compatible configs"
+
+// TestPublishedRuleOptionsAreReadOrReserved pins that every option field the
+// package publishes either reaches a decision or says it does not.
+//
+// The existing parity test compares the SET of option-accepting rules against
+// the typed keys, so it cannot see a field that is declared, documented as
+// working, accepted by the config layer, and then never decoded. Seven such
+// fields shipped in the `functional/*` family (#1132): a user set them, nothing
+// warned, and the rule behaved as if the payload were absent. The sweep below is
+// what turns the next one into a failure at build time.
+//
+//  1. Read every option field and its doc comment from
+//     `src/structures/rules/ITtscLint*RuleOptions.ts`.
+//  2. Scan every Go source in the linthost package for the field's quoted name,
+//     which covers both a `json:"…"` tag and a manual map-key decoder.
+//  3. Require each field to appear in the Go sources or to carry the reserved
+//     marker in its doc comment.
+func TestPublishedRuleOptionsAreReadOrReserved(t *testing.T) {
+  fields, err := readPublishedRuleOptionFields()
+  if err != nil {
+    t.Fatalf("read published rule option fields: %v", err)
+  }
+  if len(fields) == 0 {
+    t.Fatal("no published rule option fields found; the source walk is broken")
+  }
+  sources, err := linthostGoSources()
+  if err != nil {
+    t.Fatalf("read linthost sources: %v", err)
+  }
+
+  var inert []string
+  reserved := 0
+  for name, doc := range fields {
+    if strings.Contains(sources, `"`+name+`"`) {
+      continue
+    }
+    if strings.Contains(doc, reservedRuleOptionMarker) {
+      reserved++
+      continue
+    }
+    inert = append(inert, name)
+  }
+  sort.Strings(inert)
+  if len(inert) != 0 {
+    t.Fatalf(
+      "published rule option fields that no rule reads and no doc comment marks %q: %v",
+      reservedRuleOptionMarker,
+      inert,
+    )
+  }
+  if reserved == 0 {
+    t.Fatalf("no field carries the %q marker; the escape hatch is unexercised and the sweep proves nothing", reservedRuleOptionMarker)
+  }
+}
+
+// readPublishedRuleOptionFields returns each declared option property name
+// mapped to the doc comment immediately above it.
+func readPublishedRuleOptionFields() (map[string]string, error) {
+  _, thisFile, _, ok := runtime.Caller(0)
+  if !ok {
+    return nil, errMissingCaller{}
+  }
+  // Same scratch layout the sibling parity tests rely on: the running test file
+  // sits in linthost/ with the TypeScript tree one directory up.
+  rulesDir := filepath.Join(
+    filepath.Dir(thisFile), "..", "src", "structures", "rules",
+  )
+  entries, err := os.ReadDir(rulesDir)
+  if err != nil {
+    return nil, err
+  }
+  property := regexp.MustCompile(`^\s{2}(?:readonly\s+)?"?([\w$-]+)"?\??\s*:`)
+  fields := map[string]string{}
+  for _, entry := range entries {
+    name := entry.Name()
+    if entry.IsDir() || !strings.HasSuffix(name, "RuleOptions.ts") {
+      continue
+    }
+    body, err := os.ReadFile(filepath.Join(rulesDir, name))
+    if err != nil {
+      return nil, err
+    }
+    var doc strings.Builder
+    inDoc := false
+    for _, line := range strings.Split(string(body), "\n") {
+      trimmed := strings.TrimSpace(line)
+      switch {
+      case strings.HasPrefix(trimmed, "/**"):
+        doc.Reset()
+        doc.WriteString(trimmed)
+        // A one-line `/** … */` closes on its own line; only a block form
+        // leaves the comment open for the continuation branch below. Treating
+        // the one-line form as open swallowed every property until the next
+        // block comment closed, which is how this sweep first under-reported.
+        inDoc = !strings.HasSuffix(trimmed, "*/")
+      case inDoc && strings.HasPrefix(trimmed, "*/"):
+        inDoc = false
+      case inDoc:
+        doc.WriteString(" ")
+        doc.WriteString(strings.TrimPrefix(trimmed, "* "))
+      default:
+        if match := property.FindStringSubmatch(line); match != nil {
+          fields[match[1]] = doc.String()
+          doc.Reset()
+        }
+      }
+    }
+  }
+  return fields, nil
+}
+
+// linthostGoSources concatenates every Go source in the running package
+// directory, which the scratch layout materializes next to this test.
+func linthostGoSources() (string, error) {
+  _, thisFile, _, ok := runtime.Caller(0)
+  if !ok {
+    return "", errMissingCaller{}
+  }
+  entries, err := os.ReadDir(filepath.Dir(thisFile))
+  if err != nil {
+    return "", err
+  }
+  var builder strings.Builder
+  for _, entry := range entries {
+    name := entry.Name()
+    if entry.IsDir() || !strings.HasSuffix(name, ".go") ||
+      strings.HasSuffix(name, "_test.go") {
+      continue
+    }
+    body, err := os.ReadFile(filepath.Join(filepath.Dir(thisFile), name))
+    if err != nil {
+      return "", err
+    }
+    builder.Write(body)
+    builder.WriteString("\n")
+  }
+  return builder.String(), nil
+}

--- a/packages/lint/test/registry/published_rule_options_are_read_or_reserved_test.go
+++ b/packages/lint/test/registry/published_rule_options_are_read_or_reserved_test.go
@@ -1,6 +1,7 @@
 package linthost
 
 import (
+  "fmt"
   "os"
   "path/filepath"
   "regexp"
@@ -16,22 +17,34 @@ import (
 // change nothing.
 const reservedRuleOptionMarker = "Reserved for upstream-compatible configs"
 
+// publishedRuleOptionField is one declared option property, kept per declaration
+// site rather than per name. Twenty-one option names are declared in more than
+// one family file, so a name-keyed map would let one rule's decoder exempt every
+// other rule that publishes the same key.
+type publishedRuleOptionField struct {
+  File  string
+  Line  int
+  Name  string
+  Doc   string
+  Owner string
+}
+
 // TestPublishedRuleOptionsAreReadOrReserved pins that every option field the
 // package publishes either reaches a decision or says it does not.
 //
 // The existing parity test compares the SET of option-accepting rules against
 // the typed keys, so it cannot see a field that is declared, documented as
-// working, accepted by the config layer, and then never decoded. Seven such
+// working, accepted by the config layer, and then never decoded. Fourteen such
 // fields shipped in the `functional/*` family (#1132): a user set them, nothing
 // warned, and the rule behaved as if the payload were absent. The sweep below is
 // what turns the next one into a failure at build time.
 //
-//  1. Read every option field and its doc comment from
+//  1. Read every option field, its owning interface, and its doc comment from
 //     `src/structures/rules/ITtscLint*RuleOptions.ts`.
 //  2. Scan every Go source in the linthost package for the field's quoted name,
 //     which covers both a `json:"…"` tag and a manual map-key decoder.
-//  3. Require each field to appear in the Go sources or to carry the reserved
-//     marker in its doc comment.
+//  3. Require each declaration to appear in the Go sources or to carry the
+//     reserved marker in its own doc comment.
 //
 // The quoted-name scan is a lower bound, not a proof of use: a field whose name
 // collides with an unrelated string literal somewhere in the engine passes
@@ -40,6 +53,8 @@ const reservedRuleOptionMarker = "Reserved for upstream-compatible configs"
 // reason to appear as a Go string at all. Per-rule behavioral cases carry the
 // proof that a decoded field reaches a decision.
 func TestPublishedRuleOptionsAreReadOrReserved(t *testing.T) {
+  assertReservedRuleOptionMarkerRecognizer(t)
+
   fields, err := readPublishedRuleOptionFields()
   if err != nil {
     t.Fatalf("read published rule option fields: %v", err)
@@ -53,16 +68,16 @@ func TestPublishedRuleOptionsAreReadOrReserved(t *testing.T) {
   }
 
   var inert []string
-  reserved := 0
-  for name, doc := range fields {
-    if strings.Contains(sources, `"`+name+`"`) {
+  for _, field := range fields {
+    if strings.Contains(sources, `"`+field.Name+`"`) {
       continue
     }
-    if strings.Contains(doc, reservedRuleOptionMarker) {
-      reserved++
+    if ruleOptionIsReserved(field.Doc) {
       continue
     }
-    inert = append(inert, name)
+    inert = append(inert, fmt.Sprintf(
+      "%s.%s (%s:%d)", field.Owner, field.Name, field.File, field.Line,
+    ))
   }
   sort.Strings(inert)
   if len(inert) != 0 {
@@ -72,14 +87,34 @@ func TestPublishedRuleOptionsAreReadOrReserved(t *testing.T) {
       inert,
     )
   }
-  if reserved == 0 {
-    t.Fatalf("no field carries the %q marker; the escape hatch is unexercised and the sweep proves nothing", reservedRuleOptionMarker)
+}
+
+// ruleOptionIsReserved reports whether a field's own doc comment declares it
+// accepted-but-inert.
+func ruleOptionIsReserved(doc string) bool {
+  return strings.Contains(doc, reservedRuleOptionMarker)
+}
+
+// assertReservedRuleOptionMarkerRecognizer proves the escape hatch is
+// recognized without depending on the corpus still containing a reserved field.
+// Asserting that some field is reserved would turn the sweep red the day every
+// reserved option becomes implementable, which is the outcome it exists to
+// encourage.
+func assertReservedRuleOptionMarkerRecognizer(t *testing.T) {
+  t.Helper()
+  reserved := "/** Minimum accepted immutability. " + reservedRuleOptionMarker +
+    "; the native subset computes no immutability level."
+  if !ruleOptionIsReserved(reserved) {
+    t.Fatalf("reserved marker not recognized in %q", reserved)
+  }
+  if ruleOptionIsReserved("/** Check interface member kinds. @default true") {
+    t.Fatal("an ordinary doc comment was accepted as reserved")
   }
 }
 
-// readPublishedRuleOptionFields returns each declared option property name
-// mapped to the doc comment immediately above it.
-func readPublishedRuleOptionFields() (map[string]string, error) {
+// readPublishedRuleOptionFields returns every declared option property with the
+// interface that owns it and the doc comment immediately above it.
+func readPublishedRuleOptionFields() ([]publishedRuleOptionField, error) {
   _, thisFile, _, ok := runtime.Caller(0)
   if !ok {
     return nil, errMissingCaller{}
@@ -94,7 +129,8 @@ func readPublishedRuleOptionFields() (map[string]string, error) {
     return nil, err
   }
   property := regexp.MustCompile(`^\s{2}(?:readonly\s+)?"?([\w$-]+)"?\??\s*:`)
-  fields := map[string]string{}
+  declaration := regexp.MustCompile(`^export interface (I[\w]+)`)
+  var fields []publishedRuleOptionField
   for _, entry := range entries {
     name := entry.Name()
     if entry.IsDir() || !strings.HasSuffix(name, "RuleOptions.ts") {
@@ -106,7 +142,8 @@ func readPublishedRuleOptionFields() (map[string]string, error) {
     }
     var doc strings.Builder
     inDoc := false
-    for _, line := range strings.Split(string(body), "\n") {
+    owner := ""
+    for index, line := range strings.Split(string(body), "\n") {
       trimmed := strings.TrimSpace(line)
       switch {
       case strings.HasPrefix(trimmed, "/**"):
@@ -123,10 +160,23 @@ func readPublishedRuleOptionFields() (map[string]string, error) {
         doc.WriteString(" ")
         doc.WriteString(strings.TrimPrefix(trimmed, "* "))
       default:
-        if match := property.FindStringSubmatch(line); match != nil {
-          fields[match[1]] = doc.String()
-          doc.Reset()
+        if match := declaration.FindStringSubmatch(trimmed); match != nil {
+          owner = match[1]
         }
+        if match := property.FindStringSubmatch(line); match != nil {
+          fields = append(fields, publishedRuleOptionField{
+            File:  name,
+            Line:  index + 1,
+            Name:  match[1],
+            Doc:   doc.String(),
+            Owner: owner,
+          })
+        }
+        // Any line that is neither a doc comment nor the property it documents
+        // breaks the association. Without this an interface-level doc carrying
+        // the reserved marker would be inherited by its first undocumented
+        // member and exempt it.
+        doc.Reset()
       }
     }
   }

--- a/packages/lint/test/registry/published_rule_options_are_read_or_reserved_test.go
+++ b/packages/lint/test/registry/published_rule_options_are_read_or_reserved_test.go
@@ -159,6 +159,9 @@ func readPublishedRuleOptionFields() ([]publishedRuleOptionField, error) {
       case inDoc:
         doc.WriteString(" ")
         doc.WriteString(strings.TrimPrefix(trimmed, "* "))
+      case trimmed == "":
+        // A blank line between a doc comment and the property it documents is
+        // legal and keeps the association; only real content breaks it.
       default:
         if match := declaration.FindStringSubmatch(trimmed); match != nil {
           owner = match[1]

--- a/packages/lint/test/registry/published_rule_options_are_read_or_reserved_test.go
+++ b/packages/lint/test/registry/published_rule_options_are_read_or_reserved_test.go
@@ -32,6 +32,13 @@ const reservedRuleOptionMarker = "Reserved for upstream-compatible configs"
 //     which covers both a `json:"…"` tag and a manual map-key decoder.
 //  3. Require each field to appear in the Go sources or to carry the reserved
 //     marker in its doc comment.
+//
+// The quoted-name scan is a lower bound, not a proof of use: a field whose name
+// collides with an unrelated string literal somewhere in the engine passes
+// without being decoded. It still turns the whole failure mode this test was
+// written for into a build error, because an option nobody implemented has no
+// reason to appear as a Go string at all. Per-rule behavioral cases carry the
+// proof that a decoded field reaches a decision.
 func TestPublishedRuleOptionsAreReadOrReserved(t *testing.T) {
   fields, err := readPublishedRuleOptionFields()
   if err != nil {

--- a/packages/lint/test/rules/functional/functional_no_mixed_types_check_interfaces_false_skips_interface_test.go
+++ b/packages/lint/test/rules/functional/functional_no_mixed_types_check_interfaces_false_skips_interface_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalNoMixedTypesCheckInterfacesFalseSkipsInterface verifies functional/no-mixed-types honors checkInterfaces: false.
+//
+// `checkInterfaces` was published, documented as a working gate, and never
+// decoded, so a project that turned interfaces off still got the diagnostic
+// (#1132). This pins the interface arm of the gate.
+//
+// 1. Parse an interface that mixes a property and a method.
+// 2. Enable only functional/no-mixed-types with `checkInterfaces: false`.
+// 3. Assert the interface is skipped.
+func TestFunctionalNoMixedTypesCheckInterfacesFalseSkipsInterface(t *testing.T) {
+  const ruleName = "functional/no-mixed-types"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "interface Mixed { value: string; run(): void; }",
+    "{\"checkInterfaces\":false}",
+  )
+  assertNoFunctionalFinding(t, ruleName, findings)
+}

--- a/packages/lint/test/rules/functional/functional_no_mixed_types_check_interfaces_false_still_checks_type_literal_test.go
+++ b/packages/lint/test/rules/functional/functional_no_mixed_types_check_interfaces_false_still_checks_type_literal_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalNoMixedTypesCheckInterfacesFalseStillChecksTypeLiteral verifies checkInterfaces: false leaves type literals checked.
+//
+// The negative twin of the interface gate. A gate implemented as an early
+// return before the container switch would silence both kinds at once, and
+// nothing else in the corpus would notice.
+//
+// 1. Parse a type literal that mixes a property and a method.
+// 2. Enable only functional/no-mixed-types with `checkInterfaces: false`.
+// 3. Assert the type literal still reports.
+func TestFunctionalNoMixedTypesCheckInterfacesFalseStillChecksTypeLiteral(t *testing.T) {
+  const ruleName = "functional/no-mixed-types"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "type Mixed = { value: string; run(): void };",
+    "{\"checkInterfaces\":false}",
+  )
+  assertFunctionalFinding(t, ruleName, findings, "same kind")
+}

--- a/packages/lint/test/rules/functional/functional_no_mixed_types_check_type_literals_false_skips_type_literal_test.go
+++ b/packages/lint/test/rules/functional/functional_no_mixed_types_check_type_literals_false_skips_type_literal_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalNoMixedTypesCheckTypeLiteralsFalseSkipsTypeLiteral verifies functional/no-mixed-types honors checkTypeLiterals: false.
+//
+// The type-literal arm of the same gate. Both container kinds ship their own
+// key, so both need their own witness or one can silently take the other's
+// branch.
+//
+// 1. Parse a type literal that mixes a property and a method.
+// 2. Enable only functional/no-mixed-types with `checkTypeLiterals: false`.
+// 3. Assert the type literal is skipped.
+func TestFunctionalNoMixedTypesCheckTypeLiteralsFalseSkipsTypeLiteral(t *testing.T) {
+  const ruleName = "functional/no-mixed-types"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "type Mixed = { value: string; run(): void };",
+    "{\"checkTypeLiterals\":false}",
+  )
+  assertNoFunctionalFinding(t, ruleName, findings)
+}

--- a/packages/lint/test/rules/functional/functional_no_mixed_types_check_type_literals_false_still_checks_interface_test.go
+++ b/packages/lint/test/rules/functional/functional_no_mixed_types_check_type_literals_false_still_checks_interface_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalNoMixedTypesCheckTypeLiteralsFalseStillChecksInterface verifies checkTypeLiterals: false leaves interfaces checked.
+//
+// The twin the interface gate already had and the type-literal gate did not. The
+// two keys select different container kinds, so each needs the case proving it
+// does not silence the other.
+//
+// 1. Parse an interface that mixes a property and a method.
+// 2. Enable only functional/no-mixed-types with `checkTypeLiterals: false`.
+// 3. Assert the interface still reports.
+func TestFunctionalNoMixedTypesCheckTypeLiteralsFalseStillChecksInterface(t *testing.T) {
+  const ruleName = "functional/no-mixed-types"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "interface Mixed { value: string; run(): void; }",
+    "{\"checkTypeLiterals\":false}",
+  )
+  assertFunctionalFinding(t, ruleName, findings, "same kind")
+}

--- a/packages/lint/test/rules/functional/functional_no_return_void_allow_null_false_rejects_null_return_type_test.go
+++ b/packages/lint/test/rules/functional/functional_no_return_void_allow_null_false_rejects_null_return_type_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalNoReturnVoidAllowNullFalseRejectsNullReturnType verifies functional/no-return-void honors allowNull: false.
+//
+// `allowNull` defaults to true, so its only observable effect is the explicit
+// false: a declared `null` return type joins `void` in being rejected. The
+// field was published and never decoded before #1132.
+//
+// 1. Parse a function whose declared return type is `null`.
+// 2. Enable only functional/no-return-void with `allowNull: false`.
+// 3. Assert the declaration reports.
+func TestFunctionalNoReturnVoidAllowNullFalseRejectsNullReturnType(t *testing.T) {
+  const ruleName = "functional/no-return-void"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "function run(): null { return null; }",
+    "{\"allowNull\":false}",
+  )
+  assertFunctionalFinding(t, ruleName, findings, "return")
+}

--- a/packages/lint/test/rules/functional/functional_no_return_void_allow_undefined_false_rejects_undefined_return_type_test.go
+++ b/packages/lint/test/rules/functional/functional_no_return_void_allow_undefined_false_rejects_undefined_return_type_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalNoReturnVoidAllowUndefinedFalseRejectsUndefinedReturnType verifies functional/no-return-void honors allowUndefined: false.
+//
+// The `undefined` twin of `allowNull`. The two keys select different declared
+// return types, so one implementation covering both would let a project
+// silence the wrong one.
+//
+// 1. Parse a function whose declared return type is `undefined`.
+// 2. Enable only functional/no-return-void with `allowUndefined: false`.
+// 3. Assert the declaration reports.
+func TestFunctionalNoReturnVoidAllowUndefinedFalseRejectsUndefinedReturnType(t *testing.T) {
+  const ruleName = "functional/no-return-void"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "function run(): undefined { return undefined; }",
+    "{\"allowUndefined\":false}",
+  )
+  assertFunctionalFinding(t, ruleName, findings, "return")
+}

--- a/packages/lint/test/rules/functional/functional_no_return_void_allows_null_return_type_by_default_test.go
+++ b/packages/lint/test/rules/functional/functional_no_return_void_allows_null_return_type_by_default_test.go
@@ -1,0 +1,18 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalNoReturnVoidAllowsNullReturnTypeByDefault verifies a declared null return type is accepted with no options.
+//
+// The negative twin of `allowNull: false`. Honoring the option must not turn
+// `null` into a rejected return type for every project that never set it,
+// which is the regression an option added on the reporting side would cause.
+//
+// 1. Parse a function whose declared return type is `null`.
+// 2. Enable only functional/no-return-void with no options.
+// 3. Assert nothing reports.
+func TestFunctionalNoReturnVoidAllowsNullReturnTypeByDefault(t *testing.T) {
+  const ruleName = "functional/no-return-void"
+  findings := runFunctionalRule(t, ruleName, "function run(): null { return null; }")
+  assertNoFunctionalFinding(t, ruleName, findings)
+}

--- a/packages/lint/test/rules/functional/functional_no_return_void_allows_undefined_return_type_by_default_test.go
+++ b/packages/lint/test/rules/functional/functional_no_return_void_allows_undefined_return_type_by_default_test.go
@@ -1,0 +1,18 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalNoReturnVoidAllowsUndefinedReturnTypeByDefault verifies a declared undefined return type is accepted with no options.
+//
+// The default twin of `allowUndefined: false`, matching the one `allowNull`
+// already carries. Honoring the option must not turn `undefined` into a rejected
+// return type for every project that never set it.
+//
+// 1. Parse a function whose declared return type is `undefined`.
+// 2. Enable only functional/no-return-void with no options.
+// 3. Assert nothing reports.
+func TestFunctionalNoReturnVoidAllowsUndefinedReturnTypeByDefault(t *testing.T) {
+  const ruleName = "functional/no-return-void"
+  findings := runFunctionalRule(t, ruleName, "function run(): undefined { return undefined; }")
+  assertNoFunctionalFinding(t, ruleName, findings)
+}

--- a/packages/lint/test/rules/functional/functional_no_return_void_ignore_inferred_types_keeps_annotated_bare_return_test.go
+++ b/packages/lint/test/rules/functional/functional_no_return_void_ignore_inferred_types_keeps_annotated_bare_return_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalNoReturnVoidIgnoreInferredTypesKeepsAnnotatedBareReturn verifies ignoreInferredTypes spares only the unannotated bare return.
+//
+// The negative twin. A gate that skipped every bare `return;` would read as
+// working against the positive case while quietly disabling the whole return
+// statement branch, which the annotation is what distinguishes.
+//
+// 1. Parse a function that declares a return type and still ends in a bare `return;`.
+// 2. Enable only functional/no-return-void with `ignoreInferredTypes: true`.
+// 3. Assert the bare return still reports.
+func TestFunctionalNoReturnVoidIgnoreInferredTypesKeepsAnnotatedBareReturn(t *testing.T) {
+  const ruleName = "functional/no-return-void"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "function run(): number { return; }",
+    "{\"ignoreInferredTypes\":true}",
+  )
+  assertFunctionalFinding(t, ruleName, findings, "return")
+}

--- a/packages/lint/test/rules/functional/functional_no_return_void_ignore_inferred_types_reads_a_get_accessor_annotation_test.go
+++ b/packages/lint/test/rules/functional/functional_no_return_void_ignore_inferred_types_reads_a_get_accessor_annotation_test.go
@@ -5,8 +5,8 @@ import "testing"
 // TestFunctionalNoReturnVoidIgnoreInferredTypesReadsAGetAccessorAnnotation
 // verifies a get accessor's declared return type counts as declared.
 //
-// A get accessor is the one function-like that both stops the enclosing walk and
-// may annotate its return type. Reading annotations from a four-kind table while
+// A get accessor is the one function-like outside the annotation table that both
+// stops the enclosing walk and may annotate its return type. Reading annotations from a four-kind table while
 // walking over every kind made the accessor look annotation-less, so
 // `ignoreInferredTypes` spared a bare `return;` the rule reports in the
 // identical function-declaration shape.

--- a/packages/lint/test/rules/functional/functional_no_return_void_ignore_inferred_types_reads_a_get_accessor_annotation_test.go
+++ b/packages/lint/test/rules/functional/functional_no_return_void_ignore_inferred_types_reads_a_get_accessor_annotation_test.go
@@ -1,0 +1,26 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalNoReturnVoidIgnoreInferredTypesReadsAGetAccessorAnnotation
+// verifies a get accessor's declared return type counts as declared.
+//
+// A get accessor is the one function-like that both stops the enclosing walk and
+// may annotate its return type. Reading annotations from a four-kind table while
+// walking over every kind made the accessor look annotation-less, so
+// `ignoreInferredTypes` spared a bare `return;` the rule reports in the
+// identical function-declaration shape.
+//
+// 1. Parse a get accessor that declares a return type and ends in a bare `return;`.
+// 2. Enable only functional/no-return-void with `ignoreInferredTypes: true`.
+// 3. Assert the bare return still reports.
+func TestFunctionalNoReturnVoidIgnoreInferredTypesReadsAGetAccessorAnnotation(t *testing.T) {
+  const ruleName = "functional/no-return-void"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "class Store {\n  get value(): number {\n    return;\n  }\n}",
+    `{"ignoreInferredTypes":true}`,
+  )
+  assertFunctionalFinding(t, ruleName, findings, "return")
+}

--- a/packages/lint/test/rules/functional/functional_no_return_void_ignore_inferred_types_skips_unannotated_bare_return_test.go
+++ b/packages/lint/test/rules/functional/functional_no_return_void_ignore_inferred_types_skips_unannotated_bare_return_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalNoReturnVoidIgnoreInferredTypesSkipsUnannotatedBareReturn verifies functional/no-return-void honors ignoreInferredTypes.
+//
+// A bare `return;` in a function with no return annotation is the one place
+// the rule rejects a void-ness it inferred instead of reading. That is exactly
+// what the published option offers to skip, and it decoded nothing before
+// #1132.
+//
+// 1. Parse a function with no return annotation and a bare `return;`.
+// 2. Enable only functional/no-return-void with `ignoreInferredTypes: true`.
+// 3. Assert the bare return is skipped.
+func TestFunctionalNoReturnVoidIgnoreInferredTypesSkipsUnannotatedBareReturn(t *testing.T) {
+  const ruleName = "functional/no-return-void"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "function run() { return; }",
+    "{\"ignoreInferredTypes\":true}",
+  )
+  assertNoFunctionalFinding(t, ruleName, findings)
+}

--- a/packages/lint/test/rules/functional/functional_no_return_void_ignore_inferred_types_stops_at_the_nearest_function_test.go
+++ b/packages/lint/test/rules/functional/functional_no_return_void_ignore_inferred_types_stops_at_the_nearest_function_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalNoReturnVoidIgnoreInferredTypesStopsAtTheNearestFunction verifies ignoreInferredTypes reads the nearest function-like, including one that cannot declare a return type.
+//
+// A constructor declares no return type and cannot, so a bare `return;` inside
+// one is always inferred. Walking past it to the enclosing function attributed
+// that function's annotation to the constructor's statement and reported it, the
+// exact misattribution this case pins.
+//
+// 1. Parse an annotated function containing a class whose constructor ends in a bare `return;`.
+// 2. Enable only functional/no-return-void with `ignoreInferredTypes: true`.
+// 3. Assert the constructor's bare return is skipped.
+func TestFunctionalNoReturnVoidIgnoreInferredTypesStopsAtTheNearestFunction(t *testing.T) {
+  const ruleName = "functional/no-return-void"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "function outer(): number {\n  class Inner {\n    constructor() {\n      return;\n    }\n  }\n  return 1;\n}",
+    "{\"ignoreInferredTypes\":true}",
+  )
+  assertNoFunctionalFinding(t, ruleName, findings)
+}

--- a/packages/lint/test/rules/functional/functional_prefer_readonly_type_allow_mutable_return_type_covers_call_signature_test.go
+++ b/packages/lint/test/rules/functional/functional_prefer_readonly_type_allow_mutable_return_type_covers_call_signature_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalPreferReadonlyTypeAllowMutableReturnTypeCoversCallSignature verifies allowMutableReturnType covers a call signature's return type.
+//
+// A return-type position is a return-type position however the signature is
+// spelled. The first implementation listed six declaration kinds and left call
+// signatures, construct signatures, constructor types, and get accessors
+// reporting, so the same option answered differently for the same position.
+//
+// 1. Parse an interface whose call signature returns a mutable array.
+// 2. Enable only functional/prefer-readonly-type with `allowMutableReturnType: true`.
+// 3. Assert the return annotation is skipped.
+func TestFunctionalPreferReadonlyTypeAllowMutableReturnTypeCoversCallSignature(t *testing.T) {
+  const ruleName = "functional/prefer-readonly-type"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "interface Factory {\n  (): string[];\n}",
+    "{\"allowMutableReturnType\":true}",
+  )
+  assertNoFunctionalFinding(t, ruleName, findings)
+}

--- a/packages/lint/test/rules/functional/functional_prefer_readonly_type_allow_mutable_return_type_keeps_parameter_annotation_test.go
+++ b/packages/lint/test/rules/functional/functional_prefer_readonly_type_allow_mutable_return_type_keeps_parameter_annotation_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalPreferReadonlyTypeAllowMutableReturnTypeKeepsParameterAnnotation verifies allowMutableReturnType leaves parameter annotations checked.
+//
+// The negative twin, and the one the key's own wording depends on: parameters
+// stay readonly while the return type is permitted to be mutable. A position
+// test that matched any annotation on a function would erase that difference.
+//
+// 1. Parse a function that takes a mutable array parameter.
+// 2. Enable only functional/prefer-readonly-type with `allowMutableReturnType: true`.
+// 3. Assert the parameter annotation still reports.
+func TestFunctionalPreferReadonlyTypeAllowMutableReturnTypeKeepsParameterAnnotation(t *testing.T) {
+  const ruleName = "functional/prefer-readonly-type"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "function run(values: string[]): void {}",
+    "{\"allowMutableReturnType\":true}",
+  )
+  assertFunctionalFinding(t, ruleName, findings, "readonly")
+}

--- a/packages/lint/test/rules/functional/functional_prefer_readonly_type_allow_mutable_return_type_skips_return_annotation_test.go
+++ b/packages/lint/test/rules/functional/functional_prefer_readonly_type_allow_mutable_return_type_skips_return_annotation_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalPreferReadonlyTypeAllowMutableReturnTypeSkipsReturnAnnotation verifies functional/prefer-readonly-type honors allowMutableReturnType.
+//
+// The key exists so a function may hand back a fresh mutable value while its
+// parameters stay readonly. It decoded nothing before #1132, so the return
+// annotation reported like any other position.
+//
+// 1. Parse a function whose declared return type is a mutable array.
+// 2. Enable only functional/prefer-readonly-type with `allowMutableReturnType: true`.
+// 3. Assert the return annotation is skipped.
+func TestFunctionalPreferReadonlyTypeAllowMutableReturnTypeSkipsReturnAnnotation(t *testing.T) {
+  const ruleName = "functional/prefer-readonly-type"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "function run(): string[] { return []; }",
+    "{\"allowMutableReturnType\":true}",
+  )
+  assertNoFunctionalFinding(t, ruleName, findings)
+}

--- a/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_class_fields_only_keeps_method_parameter_test.go
+++ b/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_class_fields_only_keeps_method_parameter_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalPreferReadonlyTypeIgnoreClassFieldsOnlyKeepsMethodParameter verifies ignoreClass: "fieldsOnly" spares fields and keeps other class members checked.
+//
+// The negative twin, and the whole reason the option is not a boolean. A gate
+// that treated any truthy value as the whole-body skip would silence the method
+// parameter too, and the published type would then be a lie in its own second
+// value.
+//
+// 1. Parse a class with a mutable array field and a mutable array parameter.
+// 2. Enable only functional/prefer-readonly-type with `ignoreClass: "fieldsOnly"`.
+// 3. Assert only the method parameter reports.
+func TestFunctionalPreferReadonlyTypeIgnoreClassFieldsOnlyKeepsMethodParameter(t *testing.T) {
+  const ruleName = "functional/prefer-readonly-type"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "class A {\n  values: string[] = [];\n  run(items: string[]): void {}\n}",
+    "{\"ignoreClass\":\"fieldsOnly\"}",
+  )
+  assertFunctionalFinding(t, ruleName, findings, "readonly")
+}

--- a/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_class_keeps_module_scope_checked_test.go
+++ b/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_class_keeps_module_scope_checked_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalPreferReadonlyTypeIgnoreClassKeepsModuleScopeChecked verifies
+// ignoreClass leaves everything outside a class checked.
+//
+// The two positive cases both live inside a class, so a position test that
+// answered "in a class" unconditionally would satisfy both of them and silence
+// the whole rule. This is the case that fails on that mistake.
+//
+// 1. Parse a module-scope mutable array type alias.
+// 2. Enable only functional/prefer-readonly-type with `ignoreClass: true`.
+// 3. Assert the alias still reports.
+func TestFunctionalPreferReadonlyTypeIgnoreClassKeepsModuleScopeChecked(t *testing.T) {
+  const ruleName = "functional/prefer-readonly-type"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "type Values = string[];",
+    `{"ignoreClass":true}`,
+  )
+  assertFunctionalFinding(t, ruleName, findings, "readonly")
+}

--- a/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_class_skips_class_body_test.go
+++ b/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_class_skips_class_body_test.go
@@ -1,0 +1,24 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalPreferReadonlyTypeIgnoreClassSkipsClassBody verifies functional/prefer-readonly-type honors ignoreClass: true.
+//
+// The rule dispatches by node kind with no scope filter, so a mutable type
+// inside a class body reports like any other. `ignoreClass` was published as the
+// way to turn that off and decoded nothing, and its first reserved note wrongly
+// claimed the rule visits no class-member position.
+//
+// 1. Parse a class with a mutable array field and a mutable array parameter.
+// 2. Enable only functional/prefer-readonly-type with `ignoreClass: true`.
+// 3. Assert the whole class body is skipped.
+func TestFunctionalPreferReadonlyTypeIgnoreClassSkipsClassBody(t *testing.T) {
+  const ruleName = "functional/prefer-readonly-type"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "class A {\n  values: string[] = [];\n  run(items: string[]): void {}\n}",
+    "{\"ignoreClass\":true}",
+  )
+  assertNoFunctionalFinding(t, ruleName, findings)
+}

--- a/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_collections_keeps_property_signature_test.go
+++ b/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_collections_keeps_property_signature_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalPreferReadonlyTypeIgnoreCollectionsKeepsPropertySignature verifies ignoreCollections leaves non-collection positions checked.
+//
+// The negative twin. The key names a set of type shapes, so a mutable property
+// signature whose type is not a collection must still require its readonly
+// modifier.
+//
+// 1. Parse a type literal with a non-readonly string property.
+// 2. Enable only functional/prefer-readonly-type with `ignoreCollections: true`.
+// 3. Assert the property signature still reports.
+func TestFunctionalPreferReadonlyTypeIgnoreCollectionsKeepsPropertySignature(t *testing.T) {
+  const ruleName = "functional/prefer-readonly-type"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "type Shape = { value: string };",
+    "{\"ignoreCollections\":true}",
+  )
+  assertFunctionalFinding(t, ruleName, findings, "readonly")
+}

--- a/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_collections_skips_array_type_test.go
+++ b/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_collections_skips_array_type_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalPreferReadonlyTypeIgnoreCollectionsSkipsArrayType verifies functional/prefer-readonly-type honors ignoreCollections.
+//
+// `ignoreCollections` is published as a skip for array, tuple, and mutable
+// collection references and decoded nothing before #1132, so a project that
+// set it still got every array type reported.
+//
+// 1. Parse a mutable array type alias.
+// 2. Enable only functional/prefer-readonly-type with `ignoreCollections: true`.
+// 3. Assert the array type is skipped.
+func TestFunctionalPreferReadonlyTypeIgnoreCollectionsSkipsArrayType(t *testing.T) {
+  const ruleName = "functional/prefer-readonly-type"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "type Values = string[];",
+    "{\"ignoreCollections\":true}",
+  )
+  assertNoFunctionalFinding(t, ruleName, findings)
+}

--- a/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_interface_keeps_type_alias_member_test.go
+++ b/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_interface_keeps_type_alias_member_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalPreferReadonlyTypeIgnoreInterfaceKeepsTypeAliasMember verifies ignoreInterface leaves type-alias members checked.
+//
+// The negative twin. An ancestor test that matched any declaration, or that
+// ran before the member kind was known, would silence type aliases too, and
+// the two spell the same member shape.
+//
+// 1. Parse a type alias with a non-readonly string property.
+// 2. Enable only functional/prefer-readonly-type with `ignoreInterface: true`.
+// 3. Assert the member still reports.
+func TestFunctionalPreferReadonlyTypeIgnoreInterfaceKeepsTypeAliasMember(t *testing.T) {
+  const ruleName = "functional/prefer-readonly-type"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "type Shape = { value: string };",
+    "{\"ignoreInterface\":true}",
+  )
+  assertFunctionalFinding(t, ruleName, findings, "readonly")
+}

--- a/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_interface_skips_interface_member_test.go
+++ b/packages/lint/test/rules/functional/functional_prefer_readonly_type_ignore_interface_skips_interface_member_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalPreferReadonlyTypeIgnoreInterfaceSkipsInterfaceMember verifies functional/prefer-readonly-type honors ignoreInterface.
+//
+// `ignoreInterface` is published as a whole-interface skip and decoded nothing
+// before #1132. The gate is an ancestor test, so it has to hold for a member
+// nested inside the interface rather than for the interface node itself.
+//
+// 1. Parse an interface with a non-readonly string property.
+// 2. Enable only functional/prefer-readonly-type with `ignoreInterface: true`.
+// 3. Assert the member is skipped.
+func TestFunctionalPreferReadonlyTypeIgnoreInterfaceSkipsInterfaceMember(t *testing.T) {
+  const ruleName = "functional/prefer-readonly-type"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "interface Shape { value: string; }",
+    "{\"ignoreInterface\":true}",
+  )
+  assertNoFunctionalFinding(t, ruleName, findings)
+}

--- a/packages/lint/test/rules/functional/functional_prefer_tacit_check_member_expressions_false_keeps_identifier_callee_test.go
+++ b/packages/lint/test/rules/functional/functional_prefer_tacit_check_member_expressions_false_keeps_identifier_callee_test.go
@@ -1,0 +1,22 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalPreferTacitCheckMemberExpressionsFalseKeepsIdentifierCallee verifies checkMemberExpressions: false leaves a bare callee checked.
+//
+// The negative twin. The key narrows the callee shape, not the rule, so a
+// wrapper around a plain identifier must still report while the key is off.
+//
+// 1. Parse an arrow that forwards its parameter to a bare identifier call.
+// 2. Enable only functional/prefer-tacit with `checkMemberExpressions: false`.
+// 3. Assert the wrapper still reports.
+func TestFunctionalPreferTacitCheckMemberExpressionsFalseKeepsIdentifierCallee(t *testing.T) {
+  const ruleName = "functional/prefer-tacit"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "const wrap = (value: string) => handler(value);",
+    "{\"checkMemberExpressions\":false}",
+  )
+  assertFunctionalFinding(t, ruleName, findings, "wrapper")
+}

--- a/packages/lint/test/rules/functional/functional_prefer_tacit_check_member_expressions_false_skips_member_callee_test.go
+++ b/packages/lint/test/rules/functional/functional_prefer_tacit_check_member_expressions_false_skips_member_callee_test.go
@@ -1,0 +1,23 @@
+package linthost
+
+import "testing"
+
+// TestFunctionalPreferTacitCheckMemberExpressionsFalseSkipsMemberCallee verifies functional/prefer-tacit honors checkMemberExpressions: false.
+//
+// A member callee is the wrapper whose tacit form loses its receiver, so the
+// published key exists to keep the rule off it. It decoded nothing before
+// #1132.
+//
+// 1. Parse an arrow that forwards its parameter to a member call.
+// 2. Enable only functional/prefer-tacit with `checkMemberExpressions: false`.
+// 3. Assert the wrapper is skipped.
+func TestFunctionalPreferTacitCheckMemberExpressionsFalseSkipsMemberCallee(t *testing.T) {
+  const ruleName = "functional/prefer-tacit"
+  findings := runFunctionalRuleWithOptions(
+    t,
+    ruleName,
+    "const wrap = (value: string) => service.handler(value);",
+    "{\"checkMemberExpressions\":false}",
+  )
+  assertNoFunctionalFinding(t, ruleName, findings)
+}

--- a/website/src/content/docs/development/walkthroughs/lint.mdx
+++ b/website/src/content/docs/development/walkthroughs/lint.mdx
@@ -463,11 +463,12 @@ ctx.ReportFix(node, "use const",
 
 `TextEdit` positions are **byte offsets**, identical to `node.Pos()` / `node.End()`. The host applies edits in a single pass per file; within a pass:
 
-- **No overlapping edits.** Two edits whose ranges intersect are reduced to the earliest-starting / shortest one. The host silently drops the rest. The contract is documented on `rule.TextEdit` (the public Go type).
+- **Conflicts resolve per finding, not per edit.** The host groups a finding's edits, considers the earliest group first, and accepts a group only when every member coexists with what it already accepted. One colliding member skips the whole group, so a multi-edit fix never half-applies. The skipped finding re-fires on the next cascade pass. The contract is documented on `rule.TextEdit` (the public Go type).
+- **A finding's own edits must not overlap each other**, or the finding can never apply. An exact duplicate inside one finding is collapsed, not treated as a conflict.
 - **Empty `Text` deletes the range.** No special "delete" verb.
 - **Order does not matter.** The host sorts internally and applies right-to-left so earlier edits do not shift later offsets.
 
-Designing fixes that emit one contiguous edit per finding is the safest pattern. `no-import-type-side-effects` is the one production rule that emits multiple edits per finding, and it carefully constructs the edits to be non-overlapping by position.
+Emit the narrowest edits that express the rewrite. Several small non-overlapping edits contend for less source than one wide replacement, and the atomic applier exists so that shape is safe. `no-import-type-side-effects`, `format/whitespace`, `format/indent`, `format/sort-imports`, `unicorn/prevent-abbreviations`, and `unicorn/template-indent` all ship multi-edit fixes.
 
 ## A rule with a choice of fixes: `ReportSuggestion`
 

--- a/website/src/content/docs/development/walkthroughs/lint.mdx
+++ b/website/src/content/docs/development/walkthroughs/lint.mdx
@@ -463,12 +463,12 @@ ctx.ReportFix(node, "use const",
 
 `TextEdit` positions are **byte offsets**, identical to `node.Pos()` / `node.End()`. The host applies edits in a single pass per file; within a pass:
 
-- **Conflicts resolve per finding, not per edit.** The host groups a finding's edits, considers the earliest group first, and accepts a group only when every member coexists with what it already accepted. One colliding member skips the whole group, so a multi-edit fix never half-applies. The skipped finding re-fires on the next cascade pass. The contract is documented on `rule.TextEdit` (the public Go type).
-- **A finding's own edits must not overlap each other**, or the finding can never apply. An exact duplicate inside one finding is collapsed, not treated as a conflict.
+- **Conflicts resolve per finding, not per edit.** The host groups a finding's edits, considers the earliest group first, and accepts a group only when every member coexists with what it already accepted. One colliding member skips the whole group, so a multi-edit fix never half-applies. The skipped finding is re-run on the next cascade pass and applies then, or the cascade converges without it. The contract is documented on `rule.TextEdit` (the public Go type).
+- **A finding's own edits must not overlap each other.** Siblings enter the same group, so a finding that collides with itself can never apply. An exact duplicate inside one finding is collapsed, not treated as a conflict.
 - **Empty `Text` deletes the range.** No special "delete" verb.
 - **Order does not matter.** The host sorts internally and applies right-to-left so earlier edits do not shift later offsets.
 
-Emit the narrowest edits that express the rewrite. Several small non-overlapping edits contend for less source than one wide replacement, and the atomic applier exists so that shape is safe. `no-import-type-side-effects`, `format/whitespace`, `format/indent`, `format/sort-imports`, `unicorn/prevent-abbreviations`, and `unicorn/template-indent` all ship multi-edit fixes.
+Emit the narrowest edits that express the rewrite. Several small non-overlapping edits contend for less source than one wide replacement, and the atomic applier exists so that shape is safe. Built-ins that ship multi-edit fixes include `typescript/no-import-type-side-effects`, `format/whitespace`, `format/indent`, `unicorn/prevent-abbreviations`, and `unicorn/template-indent`.
 
 ## A rule with a choice of fixes: `ReportSuggestion`
 

--- a/website/src/content/docs/lint/format.mdx
+++ b/website/src/content/docs/lint/format.mdx
@@ -44,6 +44,8 @@ Presence of the block (even empty `format: {}`) configures the format rules at P
 
 `sortImports` is **opt-in**: it only runs when you set it. Every other format behavior — including JSDoc normalization (set `jsDoc: false` to opt out) — runs as soon as a `format` block is present, along with the keyless layout passes (statement splitting, indentation, whitespace, clause joining, declaration headers, ternary and nullish parens, orphan semicolons, and parameter properties).
 
+Clause joining covers every clause body Prettier keeps on its header line: the `if` consequent and alternate, the `for`, `for-in`, `for-of`, and `while` bodies, the `do` body, the `with` body, and a labeled statement's body. A braced body, a body already sharing the header line, a comment sitting between header and body, and a join that would overflow `printWidth` are all left alone. Two clauses join regardless of width or body shape because Prettier gives them no group of their own: an `else` whose alternate is another `if`, and a label, which prints `label: statement` on one line whatever the statement is. An empty-statement body (`while (x);`) keeps its source shape, since Prettier glues the `;` with no space and this pass only rewrites the gap.
+
 `format.endOfLine` (`"lf"` by default, or `"crlf"`) sets the newline every pass synthesizes — `printWidth` reflow, statement splitting, indentation, whitespace, declaration headers, parameter properties, and import sorting all emit it — so reformatting a CRLF file never leaves mixed line endings.
 
 ### `format.severity`

--- a/website/src/content/docs/lint/rules/functional.mdx
+++ b/website/src/content/docs/lint/rules/functional.mdx
@@ -390,7 +390,7 @@ Options:
 
 - `enforcement?: | "ReadonlyShallow" | "ReadonlyDeep" | "Immutable" | "None" | false`
 
-  Minimum accepted immutability. The native subset treats any configured value as readonly-required.
+  Minimum accepted immutability. Reserved for upstream-compatible configs: the native subset computes no immutability level and treats any configured value as readonly-required.
 
 Example:
 
@@ -426,25 +426,25 @@ Options:
 
 - `allowLocalMutation?: boolean`
 
-  Permit mutation of locals while still policing exported types.
+  Permit mutation of locals while still policing exported types. Reserved for upstream-compatible configs: the native subset reads type annotations and models no local-versus-exported distinction.
 
-- `allowMutableReturnType?: boolean`
+- `allowMutableReturnType?: boolean` (default `false`)
 
-  Permit a mutable return type even when parameters must be readonly.
+  Permit a mutable return type even when parameters must be readonly. Covers every signature that can declare one, including call and construct signatures, constructor types, and a get accessor.
 
 - `checkImplicit?: boolean`
 
-  Also check property positions that have no explicit type annotation.
+  Also check property positions that have no explicit type annotation. Reserved for upstream-compatible configs: judging an unannotated position needs the type checker, which this rule does not use.
 
-- `ignoreCollections?: boolean`
+- `ignoreCollections?: boolean` (default `false`)
 
   Skip array / tuple / `Map` / `Set` types.
 
-- `ignoreClass?: boolean | "fieldsOnly"`
+- `ignoreClass?: boolean | "fieldsOnly"` (default `false`)
 
-  Skip class fields. `"fieldsOnly"` keeps the rule active for non-field class members.
+  Skip class members. `true` skips the whole class body; `"fieldsOnly"` skips only field declarations and keeps methods, accessors, and constructor parameters checked.
 
-- `ignoreInterface?: boolean`
+- `ignoreInterface?: boolean` (default `false`)
 
   Skip interface members entirely.
 

--- a/website/src/content/docs/lint/rules/functional.mdx
+++ b/website/src/content/docs/lint/rules/functional.mdx
@@ -442,7 +442,7 @@ Options:
 
 - `ignoreClass?: boolean | "fieldsOnly"` (default `false`)
 
-  Skip class members. `true` skips the whole class body; `"fieldsOnly"` skips only field declarations and keeps methods, accessors, and constructor parameters checked.
+  Skip class members. `true` skips anything under a class, its heritage clause and type parameters included; `"fieldsOnly"` narrows that to field declarations and keeps methods, accessors, and constructor parameters checked.
 
 - `ignoreInterface?: boolean` (default `false`)
 

--- a/website/src/content/docs/lint/rules/functional.mdx
+++ b/website/src/content/docs/lint/rules/functional.mdx
@@ -249,13 +249,13 @@ Reject interfaces and type literals that mix property, method, call, and index m
 
 Options:
 
-- `checkInterfaces?: boolean`
+- `checkInterfaces?: boolean` (default `true`)
 
-  Check interface member kinds.
+  Check interface member kinds. Set `false` to leave interfaces alone.
 
-- `checkTypeLiterals?: boolean`
+- `checkTypeLiterals?: boolean` (default `true`)
 
-  Check type-literal member kinds.
+  Check type-literal member kinds. Set `false` to leave type literals alone.
 
 Example:
 
@@ -288,17 +288,17 @@ Reject void returns and functions whose declared return type is `void`; function
 
 Options:
 
-- `allowNull?: boolean`
+- `allowNull?: boolean` (default `true`)
 
-  Permit a function that returns `null` to satisfy the rule.
+  Permit a function whose declared return type is `null`. Set `false` to reject it the way a declared `void` is rejected.
 
-- `allowUndefined?: boolean`
+- `allowUndefined?: boolean` (default `true`)
 
-  Permit a function that returns `undefined` to satisfy the rule.
+  Permit a function whose declared return type is `undefined`. Set `false` to reject it the way a declared `void` is rejected.
 
-- `ignoreInferredTypes?: boolean`
+- `ignoreInferredTypes?: boolean` (default `false`)
 
-  Skip functions whose return type is inferred to be `void` rather than declared explicitly.
+  Skip a bare `return;` inside a function that declares no return type. That statement is the one place the rule rejects a void-ness it inferred rather than read from an annotation.
 
 Example:
 
@@ -463,9 +463,9 @@ Reject trivial wrappers such as `x => f(x)` in favor of the tacit form `f`; redu
 
 Options:
 
-- `checkMemberExpressions?: boolean`
+- `checkMemberExpressions?: boolean` (default `true`)
 
-  Check member expressions such as `x => service.map(x)`.
+  Check member expressions such as `x => service.map(x)`. Set `false` to keep the rule on bare-identifier callees only.
 
 Example:
 
@@ -512,6 +512,8 @@ Options:
 - `ignoreInterfaces?: boolean`
 
   Skip interface declarations and only check type aliases.
+
+Each policy entry accepts `identifiers`, plus `immutability` and `comparator`. The latter two are reserved for upstream-compatible configs: the native subset computes no immutability level, so it treats every policy as readonly-required and compares nothing.
 
 Example:
 


### PR DESCRIPTION
## Intent

One `@ttsc/lint` issue-campaign cycle. This pull request owns the complete accepted set for the cycle; every issue below was published from a full-scope discovery round against `b3779c941` and frozen by a following empty round.

- #1131 `format/parameter-properties` omits `override`, so it abstains where Prettier breaks
- #1132 seven published `functional/*` options are accepted and silently do nothing
- #1133 `format/clause-join` skips the `else`, `do`, labeled, and `with` bodies Prettier joins
- #1134 `ttsc format` never places `else`/`catch`/`finally`/`while` against the closing brace
- #1135 the public `rule.TextEdit` autofix contract describes the pre-#605 per-edit applier

Closing keywords are deliberately absent from this body. The cycle's closing set is the union of the commit closing lines, so an issue this cycle later drops or disproves is not closed by the merge.

## Scope

`packages/lint` and what it owns: the native engine under `linthost/`, the public `rule` package, the published rule typings under `src/`, `packages/lint/README.md`, the lint pages under `website/src/content/docs/lint/`, the Go cases under `packages/lint/test/`, and the `lint defense 1` / `lint defense 2` lanes.

## Verification

Pending. Local evidence and CI results are recorded as formal reviews on this pull request as each commit lands.
