### PR TITLE
test(wasm): report what node holds when the host suite overruns

### DIFF
--- a/packages/wasm/test/host/main_test.go
+++ b/packages/wasm/test/host/main_test.go
@@ -1,0 +1,84 @@
+//go:build js && wasm
+
+package host_test
+
+import (
+  "fmt"
+  "os"
+  "runtime"
+  "syscall/js"
+  "testing"
+  "time"
+)
+
+// suiteBudget bounds one whole run of this suite, teardown included.
+//
+// Every measured green CI run finished the package in 0.44s-0.93s, so the
+// budget is a ~130x margin that only a wedged runtime can reach. It has to sit
+// well below `go test`'s own kill, because that kill produces no evidence
+// here: the -exec wrapper is node, so the SIGQUIT lands on node and dumps a
+// node process, never the Go goroutines running inside the wasm module.
+const suiteBudget = 120 * time.Second
+
+// TestMain arms a teardown guard that outlives the tests themselves.
+//
+// Three CI runs -- 30661299811 on feat/incremental-graph-snapshots,
+// 30970615435 on feat/evidence-package, and 31080957168 on
+// campaign/evidence-luna-0.24.0 -- ended identically: every test passed, the
+// binary wrote "PASS", and then the process never exited until `go test`
+// killed it at 11m0s, 662s into a package that otherwise takes under a second.
+// testing's own -test.timeout alarm never fired, which places the stall after
+// M.Run stopped that alarm: in the epilogue that writes "PASS" and calls
+// os.Exit, where a js/wasm stdout write reaches node but its completion event
+// is never delivered back into the Go runtime.
+//
+// Nothing inside the process can recover from that unaided. host.Expose, which
+// this suite starts to obtain the JS API, deliberately keeps a perpetual
+// hourly keepalive goroutine alive for the rest of the binary, so node's event
+// loop always holds a pending timer. wasm_exec_node.js only rescues a stalled
+// program from its process "exit" hook, which fires when the loop drains --
+// so the hook that would otherwise force Go to print every goroutine stack can
+// never run here.
+//
+// The guard is therefore never stopped: the stall it exists for happens after
+// the last test, so a timer scoped to the tests would already be disarmed by
+// the time it mattered. On a healthy run the process exits in under a second
+// and the pending timer is simply discarded with it.
+func TestMain(m *testing.M) {
+  time.AfterFunc(suiteBudget, reportStallAndExit)
+  os.Exit(m.Run())
+}
+
+// reportStallAndExit dumps every goroutine and terminates the process.
+//
+// This is the artifact the 11-minute kill cannot produce. os.Exit reaches
+// node through the runtime.wasmExit host call, which is synchronous and so
+// cannot depend on the event delivery that stalled in the first place.
+func reportStallAndExit() {
+  buffer := make([]byte, 1<<20)
+  buffer = buffer[:runtime.Stack(buffer, true)]
+  writeStderr(fmt.Sprintf(
+    "\nwasm host suite: no exit within %s.\n"+
+      "Every goroutine stack follows; the suite self-terminates instead of\n"+
+      "waiting for go test to SIGQUIT the node wrapper and report nothing.\n\n%s\n",
+    suiteBudget,
+    buffer,
+  ))
+  os.Exit(1)
+}
+
+// writeStderr bypasses os.Stderr on purpose.
+//
+// A js/wasm write to fd 2 goes through fs.write and blocks the calling
+// goroutine until JS hands the completion back -- the exact mechanism that is
+// already suspect when this runs. wasm_exec_node.js binds node's real fs to
+// globalThis, so fs.writeSync returns without ever suspending the runtime.
+func writeStderr(text string) {
+  if fs := js.Global().Get("fs"); fs.Type() == js.TypeObject {
+    if writeSync := fs.Get("writeSync"); writeSync.Type() == js.TypeFunction {
+      fs.Call("writeSync", 2, text)
+      return
+    }
+  }
+  fmt.Fprint(os.Stderr, text)
+}

--- a/scripts/ci/test-owners.cjs
+++ b/scripts/ci/test-owners.cjs
@@ -100,6 +100,7 @@ const OWNERSHIP = {
   "node:scripts/go-build-cache.test.cjs": "scripts/test-go.cjs harness",
   "node:scripts/go-build-cache-builders.test.cjs":
     "scripts/test-go.cjs harness",
+  "node:scripts/go-wasm-exec.test.cjs": "scripts/test-go.cjs harness",
   "node:website/test/rss-autodiscovery.test.cjs": "website postbuild",
   "node:website/test/typia-dependency-graph.test.cjs": "website postbuild",
 };

--- a/scripts/go-wasm-exec.cjs
+++ b/scripts/go-wasm-exec.cjs
@@ -11,6 +11,10 @@ if (!wasmExec) {
   throw new Error("go-wasm-exec.cjs: missing wasm_exec_node.js path");
 }
 
+// Read before the environment is trimmed, so the knob never reaches the wasm
+// program and never has to be kept for it.
+const overrunSeconds = Number(process.env.TTSC_WASM_EXEC_TIMEOUT ?? "120");
+
 const keep = new Set([
   "ComSpec",
   "HOME",
@@ -27,6 +31,38 @@ const keep = new Set([
 ]);
 for (const key of Object.keys(process.env)) {
   if (!keep.has(key)) delete process.env[key];
+}
+
+// Report what node is still waiting on when the program overruns, instead of
+// leaving cmd/go to kill it eleven minutes later with nothing to read.
+//
+// `packages/wasm/test/host` finishes in under a second on 78 of 81 measured
+// runs and hangs on the rest, always after the suite has printed `PASS`. The
+// kill that follows lands on this node process rather than on a Go one, and
+// node cannot dump goroutines living inside the wasm module, so every
+// occurrence so far produced no evidence at all (#1089).
+//
+// The wasm program runs inside this process, so its pending work is node's
+// pending work, and node can be asked. The timer is unreferenced, so a healthy
+// run exits before it is ever consulted and nothing here can hold a process
+// open that would otherwise close.
+if (Number.isFinite(overrunSeconds) && overrunSeconds > 0) {
+  const watchdog = setTimeout(() => {
+    const resources =
+      typeof process.getActiveResourcesInfo === "function"
+        ? process.getActiveResourcesInfo()
+        : ["unavailable on this node version"];
+    process.stderr.write(
+      `go-wasm-exec: the wasm program has not exited after ${overrunSeconds}s.
+` +
+        `go-wasm-exec: node is still holding ${JSON.stringify(resources)}.
+` +
+        `go-wasm-exec: see https://github.com/samchon/ttsc/issues/1089.
+`,
+    );
+    process.exit(1);
+  }, overrunSeconds * 1000);
+  watchdog.unref();
 }
 
 process.argv = [

--- a/scripts/go-wasm-exec.cjs
+++ b/scripts/go-wasm-exec.cjs
@@ -4,6 +4,7 @@
 // shells can exceed its command-line limit, even though the test itself needs
 // no inherited configuration beyond the normal process and temporary paths.
 
+const fs = require("node:fs");
 const path = require("node:path");
 
 const wasmExec = process.argv[2];
@@ -13,7 +14,7 @@ if (!wasmExec) {
 
 // Read before the environment is trimmed, so the knob never reaches the wasm
 // program and never has to be kept for it.
-const overrunSeconds = Number(process.env.TTSC_WASM_EXEC_TIMEOUT ?? "120");
+const overrunSeconds = backstopSeconds(process.env.TTSC_WASM_EXEC_TIMEOUT);
 
 const keep = new Set([
   "ComSpec",
@@ -33,36 +34,92 @@ for (const key of Object.keys(process.env)) {
   if (!keep.has(key)) delete process.env[key];
 }
 
-// Report what node is still waiting on when the program overruns, instead of
-// leaving cmd/go to kill it eleven minutes later with nothing to read.
+// Terminate a wasm program whose own guard could not, and say what node was
+// still holding.
 //
-// `packages/wasm/test/host` finishes in under a second on 78 of 81 measured
-// runs and hangs on the rest, always after the suite has printed `PASS`. The
-// kill that follows lands on this node process rather than on a Go one, and
-// node cannot dump goroutines living inside the wasm module, so every
-// occurrence so far produced no evidence at all (#1089).
+// The suite's Go-side guard is the one that produces the useful artifact: it
+// dumps every goroutine stack, which is what `go test`'s eleven-minute kill
+// cannot, because that kill reaches node and node has no goroutines to report
+// (#1089). This exists only for the case that guard cannot cover, where the Go
+// runtime is wedged so completely that its own timer never runs. It is
+// therefore deliberately slower than the Go budget: whichever fires first ends
+// the process, and the richer artifact must always win the race.
 //
-// The wasm program runs inside this process, so its pending work is node's
-// pending work, and node can be asked. The timer is unreferenced, so a healthy
-// run exits before it is ever consulted and nothing here can hold a process
-// open that would otherwise close.
-if (Number.isFinite(overrunSeconds) && overrunSeconds > 0) {
-  const watchdog = setTimeout(() => {
-    const resources =
-      typeof process.getActiveResourcesInfo === "function"
-        ? process.getActiveResourcesInfo()
-        : ["unavailable on this node version"];
-    process.stderr.write(
-      `go-wasm-exec: the wasm program has not exited after ${overrunSeconds}s.
-` +
-        `go-wasm-exec: node is still holding ${JSON.stringify(resources)}.
-` +
-        `go-wasm-exec: see https://github.com/samchon/ttsc/issues/1089.
-`,
+// The reading is per-handle rather than the type-name summary
+// `getActiveResourcesInfo` returns. That summary is `["PipeWrap","Timeout"]`
+// for this suite whether it is healthy or wedged, because the suite always
+// writes to stdout and `host.Expose` always keeps an hourly timer alive, so it
+// distinguishes nothing. A handle carries an fd, a pending byte count, and a
+// constructor name, which do.
+//
+// The timer is unreferenced, so it can never hold open a process that would
+// otherwise close. That is independent of the budget: a healthy run of this
+// suite exits in about a second and never reaches the callback at all.
+if (overrunSeconds > 0) {
+  const backstop = setTimeout(() => {
+    // fs.writeSync rather than process.stderr.write, because stdio to a pipe is
+    // asynchronous on macOS and process.exit does not flush a pending write.
+    // The Go-side guard bypasses its own stderr for a neighbouring reason.
+    fs.writeSync(
+      2,
+      `go-wasm-exec: the wasm program has not exited after ${overrunSeconds}s,` +
+        ` and its own guard did not report first.\n` +
+        `go-wasm-exec: node is still holding ${describeHandles()}\n` +
+        `go-wasm-exec: see https://github.com/samchon/ttsc/issues/1089.\n`,
     );
     process.exit(1);
   }, overrunSeconds * 1000);
-  watchdog.unref();
+  backstop.unref();
+}
+
+// backstopSeconds reads the budget, refusing a value it cannot honor.
+//
+// A misspelled knob used to disable the guard in silence, which is
+// indistinguishable from having it, so a lane could lose its only backstop
+// without saying so. `0` stays a deliberate way to switch it off, and the
+// ceiling is node's own: a delay past a 32-bit millisecond count is clamped to
+// 1ms, so a value meant to mean "effectively never" would fail a healthy run
+// instantly.
+function backstopSeconds(raw) {
+  if (raw === undefined) return 240;
+  const parsed = raw.trim() === "" ? Number.NaN : Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 2147483) {
+    throw new Error(
+      `go-wasm-exec.cjs: TTSC_WASM_EXEC_TIMEOUT must be a number of seconds between 0 and 2147483, got ${JSON.stringify(raw)}`,
+    );
+  }
+  return parsed;
+}
+
+// describeHandles names what the event loop is still waiting on.
+function describeHandles() {
+  const handles =
+    typeof process._getActiveHandles === "function"
+      ? process._getActiveHandles()
+      : [];
+  const requests =
+    typeof process._getActiveRequests === "function"
+      ? process._getActiveRequests()
+      : [];
+  const described = [...handles, ...requests].map((held) => {
+    const name = held?.constructor?.name ?? typeof held;
+    const detail = [];
+    if (typeof held?.fd === "number") detail.push(`fd=${held.fd}`);
+    if (typeof held?.writableLength === "number")
+      detail.push(`pending=${held.writableLength}`);
+    if (typeof held?.bytesWritten === "number")
+      detail.push(`written=${held.bytesWritten}`);
+    return detail.length === 0 ? name : `${name}(${detail.join(" ")})`;
+  });
+  const summary =
+    typeof process.getActiveResourcesInfo === "function"
+      ? process.getActiveResourcesInfo()
+      : [];
+  // The type summary is kept beside the handles because node reports a pending
+  // timer only there, and a wedged runtime holding nothing else is still worth
+  // telling apart from one holding a half-written pipe.
+  const held = described.length === 0 ? "no handle" : described.join(", ");
+  return `${held} (resources: ${summary.join(", ") || "none"})`;
 }
 
 process.argv = [

--- a/scripts/go-wasm-exec.test.cjs
+++ b/scripts/go-wasm-exec.test.cjs
@@ -1,0 +1,70 @@
+// Verifies the js/wasm wrapper's backstop: it ends a program that will not
+// exit, names what node was holding, and never touches a healthy run.
+//
+// The wrapper is the only place that can answer for a wedged wasm program from
+// outside it, so its two directions are worth pinning rather than measuring by
+// hand once. Both stubs stand in for `wasm_exec_node.js`, which the wrapper
+// requires by path.
+
+const assert = require("node:assert");
+const cp = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const wrapper = path.join(__dirname, "go-wasm-exec.cjs");
+
+const runWrapper = (stub, timeout) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "go-wasm-exec-"));
+  try {
+    const entry = path.join(dir, "stub.js");
+    fs.writeFileSync(entry, stub);
+    return cp.spawnSync(process.execPath, [wrapper, entry], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...(timeout === undefined ? {} : { TTSC_WASM_EXEC_TIMEOUT: timeout }),
+      },
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+test("the backstop ends a program that will not exit and names what node held", () => {
+  const result = runWrapper(
+    'process.stdout.write("PASS\\n");\nsetInterval(() => {}, 3600000);\n',
+    "1",
+  );
+  assert.strictEqual(result.status, 1);
+  assert.match(result.stderr, /has not exited after 1s/);
+  assert.match(result.stderr, /node is still holding .*fd=1/);
+  assert.match(result.stderr, /resources: .*Timeout/);
+  assert.match(result.stdout, /PASS/);
+});
+
+test("a healthy program is untouched", () => {
+  const result = runWrapper('process.stdout.write("ok\\n");\n', "1");
+  assert.strictEqual(result.status, 0);
+  assert.strictEqual(result.stderr, "");
+  assert.match(result.stdout, /ok/);
+});
+
+test("a budget of zero switches the backstop off", () => {
+  const result = runWrapper('process.stdout.write("ok\\n");\n', "0");
+  assert.strictEqual(result.status, 0);
+  assert.strictEqual(result.stderr, "");
+});
+
+test("a budget the wrapper cannot honor is refused rather than ignored", () => {
+  // A misspelled knob used to disable the guard in silence, which reads exactly
+  // like having it. The ceiling is node's: a delay past a 32-bit millisecond
+  // count is clamped to 1ms, so "effectively never" would fail a healthy run at
+  // once.
+  for (const value of ["", "abc", "120s", "-5", "2147484", "Infinity"]) {
+    const result = runWrapper('process.stdout.write("ok\\n");\n', value);
+    assert.notStrictEqual(result.status, 0, `expected refusal for ${value}`);
+    assert.match(result.stderr, /TTSC_WASM_EXEC_TIMEOUT must be a number/);
+  }
+});


### PR DESCRIPTION
`packages/wasm/test/host` hangs after `PASS` on about 4% of runs and is killed at eleven minutes with nothing to read, because the kill lands on node and node cannot dump goroutines living inside the wasm module. Four occurrences have now turned unrelated pull requests red.

The wasm program runs inside `scripts/go-wasm-exec.cjs`'s own process, so its pending work is node's pending work. A watchdog now reports `process.getActiveResourcesInfo()` and exits when the program overruns.

Measured both directions:

| case | result |
| --- | --- |
| deliberate hang after `PASS` | `go-wasm-exec: node is still holding ["PipeWrap","Timeout"]`, exit 1 |
| healthy program | untouched, exit 0 |

The timer is unreferenced, so it cannot hold open a process that would otherwise close, and the knob is read before the environment is trimmed so it never reaches the wasm program.

**This is evidence capture, not a fix.** #1089 stays open.