### PR TITLE
test(wasm): read both sides of the stall from one stop

### DIFF
--- a/packages/wasm/test/host/main_test.go
+++ b/packages/wasm/test/host/main_test.go
@@ -59,11 +59,11 @@ func reportStallAndExit() {
   buffer := make([]byte, 1<<20)
   buffer = buffer[:runtime.Stack(buffer, true)]
   // The stacks go out on their own write, before anything else is attempted.
-  // Reading the JS side means calling into node, and a JS exception crossing
-  // back through syscall/js is a panic; composing both halves into one message
-  // would let that panic destroy the half already in hand, and the runtime's
-  // own panic output travels through os.Stderr, the asynchronous write path
-  // this guard exists because it is already suspect.
+  // Reading the JS side means calling into node, and the runtime does not
+  // catch every way that can end: a throwing property accessor reached through
+  // `Value.Get` leaves as an uncaught JS exception and takes the process with
+  // it, printing nothing from Go. Composing both halves into one message would
+  // let that destroy the half already in hand.
   writeStderr(fmt.Sprintf(
     "\nwasm host suite: no exit within %s.\n"+
       "Every goroutine stack follows, and what node was still holding after\n"+
@@ -93,40 +93,55 @@ func reportStallAndExit() {
 // The call is synchronous, in the sense fs.writeSync is, so it cannot depend on
 // the event delivery that is already suspect.
 func nodePendingWork() (reading string) {
-  // A reading that fails says so, rather than taking the process down through
-  // a path that cannot report why. Every operation below crosses into JS, and
-  // a JS exception arrives here as a panic.
+  readings := []string{}
+  // A reading that fails says so and keeps the ones already taken.
+  //
+  // `getActiveResourcesInfo` is collected first and is the discriminator; the
+  // two underscore-prefixed internals after it are the ones likelier to
+  // misbehave, so a failure there must not carry the answer away with it.
+  //
+  // The recover covers less than it looks like it does. `Value.Call` routes a
+  // JS throw back as a Go panic, but `Value.Get` is a bare `Reflect.get` in
+  // the runtime's import table with no catch around it, so a throwing property
+  // accessor escapes as an uncaught JS exception and ends the process without
+  // reaching any Go code at all. That is why the stacks are written before
+  // this runs: the artifact already in hand cannot be lost to it.
   defer func() {
     if recovered := recover(); recovered != nil {
-      reading = fmt.Sprintf("unavailable: reading node panicked (%v)", recovered)
+      reading = strings.Join(append(
+        readings,
+        fmt.Sprintf("(reading panicked: %v)", recovered),
+      ), " ")
     }
   }()
   process := js.Global().Get("process")
   if process.Type() != js.TypeObject {
     return "unavailable: no process object"
   }
-  readings := []string{}
   for _, name := range []string{
     "getActiveResourcesInfo",
     "_getActiveRequests",
     "_getActiveHandles",
   } {
     if process.Get(name).Type() != js.TypeFunction {
+      readings = append(readings, name+"=<absent>")
       continue
     }
     readings = append(readings, name+"="+describeJSList(process.Call(name)))
-  }
-  if len(readings) == 0 {
-    return "unavailable: node exposes none of the resource readings"
   }
   return strings.Join(readings, " ")
 }
 
 // describeJSList renders one reading, naming each entry by constructor and by
-// the fields that tell a wedged pipe from a drained one.
+// the fields that would tell a wedged pipe from a drained one.
+//
+// A list that is not a list is named as such rather than rendered empty. An
+// empty list is not a neutral value here: it is the affirmative verdict that
+// node holds nothing, which is the whole of one candidate cause, so a reading
+// that merely failed to produce a list must not be able to spell it.
 func describeJSList(list js.Value) string {
   if list.Type() != js.TypeObject {
-    return "[]"
+    return "<not a list>"
   }
   entries := []string{}
   for index := 0; index < list.Length(); index++ {
@@ -140,6 +155,12 @@ func describeJSList(list js.Value) string {
   return "[" + strings.Join(entries, ", ") + "]"
 }
 
+// describeJSHandle names one held resource.
+//
+// The detail fields are absent on the pending file request this guard expects
+// to meet, so it usually renders the same token `getActiveResourcesInfo`
+// already printed. They are read anyway because a held socket carries them,
+// and a socket appearing here at all would itself be the finding.
 func describeJSHandle(handle js.Value) string {
   name := "unknown"
   if constructor := handle.Get("constructor"); constructor.Type() == js.TypeObject ||

--- a/packages/wasm/test/host/main_test.go
+++ b/packages/wasm/test/host/main_test.go
@@ -6,6 +6,7 @@ import (
   "fmt"
   "os"
   "runtime"
+  "strings"
   "syscall/js"
   "testing"
   "time"
@@ -59,12 +60,90 @@ func reportStallAndExit() {
   buffer = buffer[:runtime.Stack(buffer, true)]
   writeStderr(fmt.Sprintf(
     "\nwasm host suite: no exit within %s.\n"+
-      "Every goroutine stack follows; the suite self-terminates instead of\n"+
-      "waiting for go test to SIGQUIT the node wrapper and report nothing.\n\n%s\n",
+      "Every goroutine stack follows, and beneath it what node was still\n"+
+      "holding; the suite self-terminates instead of waiting for go test to\n"+
+      "SIGQUIT the node wrapper and report nothing.\n\n%s\nnode was holding: %s\n",
     suiteBudget,
     buffer,
+    nodePendingWork(),
   ))
   os.Exit(1)
+}
+
+// nodePendingWork asks node what its event loop is still waiting on.
+//
+// The goroutine stacks alone cannot finish the diagnosis. Both candidate
+// causes park the main goroutine in the same place, a channel receive inside
+// syscall.fsCall, so the Go side reads identically whether node never fired
+// the write completion or fired it and the runtime failed to route it. What
+// separates them is whether node still holds a pending file request, and only
+// node can answer that.
+//
+// It is asked from here rather than from the wrapper's own timer, because
+// whichever guard fires first ends the process: a reading the wrapper takes at
+// a later budget is a reading that never happens on any occurrence this guard
+// catches. Both halves therefore come from one stop.
+//
+// The call is synchronous, in the sense fs.writeSync is, so it cannot depend on
+// the event delivery that is already suspect.
+func nodePendingWork() string {
+  process := js.Global().Get("process")
+  if process.Type() != js.TypeObject {
+    return "unavailable: no process object"
+  }
+  readings := []string{}
+  for _, name := range []string{
+    "getActiveResourcesInfo",
+    "_getActiveRequests",
+    "_getActiveHandles",
+  } {
+    if process.Get(name).Type() != js.TypeFunction {
+      continue
+    }
+    readings = append(readings, name+"="+describeJSList(process.Call(name)))
+  }
+  if len(readings) == 0 {
+    return "unavailable: node exposes none of the resource readings"
+  }
+  return strings.Join(readings, " ")
+}
+
+// describeJSList renders one reading, naming each entry by constructor and by
+// the fields that tell a wedged pipe from a drained one.
+func describeJSList(list js.Value) string {
+  if list.Type() != js.TypeObject {
+    return "[]"
+  }
+  entries := []string{}
+  for index := 0; index < list.Length(); index++ {
+    entry := list.Index(index)
+    if entry.Type() == js.TypeString {
+      entries = append(entries, entry.String())
+      continue
+    }
+    entries = append(entries, describeJSHandle(entry))
+  }
+  return "[" + strings.Join(entries, ", ") + "]"
+}
+
+func describeJSHandle(handle js.Value) string {
+  name := "unknown"
+  if constructor := handle.Get("constructor"); constructor.Type() == js.TypeObject ||
+    constructor.Type() == js.TypeFunction {
+    if named := constructor.Get("name"); named.Type() == js.TypeString {
+      name = named.String()
+    }
+  }
+  detail := []string{}
+  for _, field := range []string{"fd", "writableLength", "bytesWritten"} {
+    if value := handle.Get(field); value.Type() == js.TypeNumber {
+      detail = append(detail, fmt.Sprintf("%s=%d", field, value.Int()))
+    }
+  }
+  if len(detail) == 0 {
+    return name
+  }
+  return name + "(" + strings.Join(detail, " ") + ")"
 }
 
 // writeStderr bypasses os.Stderr on purpose.

--- a/packages/wasm/test/host/main_test.go
+++ b/packages/wasm/test/host/main_test.go
@@ -176,8 +176,17 @@ func describeJSList(list js.Value) string {
   entries := []string{}
   for index := 0; index < list.Length(); index++ {
     entry := list.Index(index)
+    // The summary reading is a list of type names, and those names are the
+    // discriminator, so a string entry is its own description.
     if entry.Type() == js.TypeString {
       entries = append(entries, entry.String())
+      continue
+    }
+    // Only an object can be asked for a constructor. Reading one off anything
+    // else panics, and a reading that panics costs the readings taken after
+    // it, so an entry that is neither is named by what it is instead.
+    if entry.Type() != js.TypeObject && entry.Type() != js.TypeFunction {
+      entries = append(entries, entry.Type().String())
       continue
     }
     entries = append(entries, describeJSHandle(entry))

--- a/packages/wasm/test/host/main_test.go
+++ b/packages/wasm/test/host/main_test.go
@@ -84,6 +84,16 @@ func reportStallAndExit() {
 // exposure because it runs only when the suite is already lost and the stacks
 // are already written; a case on the healthy path would be trading something
 // else entirely.
+func nodeResourceSummary() string {
+  process := js.Global().Get("process")
+  if process.Type() != js.TypeObject {
+    return "<absent>"
+  }
+  if process.Get("getActiveResourcesInfo").Type() != js.TypeFunction {
+    return "<absent>"
+  }
+  return describeJSList(process.Call("getActiveResourcesInfo"))
+}
 
 // nodePendingWork asks node what its event loop is still waiting on.
 //
@@ -107,17 +117,6 @@ func reportStallAndExit() {
 // program parked there holds nothing at all, so an all-empty reading is only
 // the verdict "node completed the write" when the stacks also show the main
 // goroutine parked in a channel receive inside syscall.fsCall.
-func nodeResourceSummary() string {
-  process := js.Global().Get("process")
-  if process.Type() != js.TypeObject {
-    return "<absent>"
-  }
-  if process.Get("getActiveResourcesInfo").Type() != js.TypeFunction {
-    return "<absent>"
-  }
-  return describeJSList(process.Call("getActiveResourcesInfo"))
-}
-
 func nodePendingWork() (reading string) {
   readings := []string{}
   // A reading that fails says so and keeps the ones already taken.

--- a/packages/wasm/test/host/main_test.go
+++ b/packages/wasm/test/host/main_test.go
@@ -76,6 +76,15 @@ func reportStallAndExit() {
   os.Exit(1)
 }
 
+// nodeResourceSummary reads the discriminator alone.
+//
+// It exists so a caller that only needs to know the reading works can take it
+// without entering the per-handle detail path, which reads properties off live
+// node objects and cannot survive one that throws. The guard accepts that
+// exposure because it runs only when the suite is already lost and the stacks
+// are already written; a case on the healthy path would be trading something
+// else entirely.
+
 // nodePendingWork asks node what its event loop is still waiting on.
 //
 // The goroutine stacks alone cannot finish the diagnosis. Both candidate
@@ -92,6 +101,23 @@ func reportStallAndExit() {
 //
 // The call is synchronous, in the sense fs.writeSync is, so it cannot depend on
 // the event delivery that is already suspect.
+//
+// Read the result together with the stacks above it, never alone. This runs
+// inside the timer callback node used to resume the runtime, and a healthy
+// program parked there holds nothing at all, so an all-empty reading is only
+// the verdict "node completed the write" when the stacks also show the main
+// goroutine parked in a channel receive inside syscall.fsCall.
+func nodeResourceSummary() string {
+  process := js.Global().Get("process")
+  if process.Type() != js.TypeObject {
+    return "<absent>"
+  }
+  if process.Get("getActiveResourcesInfo").Type() != js.TypeFunction {
+    return "<absent>"
+  }
+  return describeJSList(process.Call("getActiveResourcesInfo"))
+}
+
 func nodePendingWork() (reading string) {
   readings := []string{}
   // A reading that fails says so and keeps the ones already taken.
@@ -110,7 +136,7 @@ func nodePendingWork() (reading string) {
     if recovered := recover(); recovered != nil {
       reading = strings.Join(append(
         readings,
-        fmt.Sprintf("(reading panicked: %v)", recovered),
+        fmt.Sprintf("unavailable: a reading panicked (%v)", recovered),
       ), " ")
     }
   }()
@@ -139,8 +165,12 @@ func nodePendingWork() (reading string) {
 // empty list is not a neutral value here: it is the affirmative verdict that
 // node holds nothing, which is the whole of one candidate cause, so a reading
 // that merely failed to produce a list must not be able to spell it.
+//
+// The test is `Array.isArray` rather than a type check, because a plain object
+// is an object: `Length` on one reads an absent `length` as zero, the loop
+// never runs, and the reading renders as the verdict it is not.
 func describeJSList(list js.Value) string {
-  if list.Type() != js.TypeObject {
+  if !js.Global().Get("Array").Call("isArray", list).Bool() {
     return "<not a list>"
   }
   entries := []string{}

--- a/packages/wasm/test/host/main_test.go
+++ b/packages/wasm/test/host/main_test.go
@@ -58,15 +58,21 @@ func TestMain(m *testing.M) {
 func reportStallAndExit() {
   buffer := make([]byte, 1<<20)
   buffer = buffer[:runtime.Stack(buffer, true)]
+  // The stacks go out on their own write, before anything else is attempted.
+  // Reading the JS side means calling into node, and a JS exception crossing
+  // back through syscall/js is a panic; composing both halves into one message
+  // would let that panic destroy the half already in hand, and the runtime's
+  // own panic output travels through os.Stderr, the asynchronous write path
+  // this guard exists because it is already suspect.
   writeStderr(fmt.Sprintf(
     "\nwasm host suite: no exit within %s.\n"+
-      "Every goroutine stack follows, and beneath it what node was still\n"+
-      "holding; the suite self-terminates instead of waiting for go test to\n"+
-      "SIGQUIT the node wrapper and report nothing.\n\n%s\nnode was holding: %s\n",
+      "Every goroutine stack follows, and what node was still holding after\n"+
+      "it; the suite self-terminates instead of waiting for go test to\n"+
+      "SIGQUIT the node wrapper and report nothing.\n\n%s\n",
     suiteBudget,
     buffer,
-    nodePendingWork(),
   ))
+  writeStderr("node was holding: " + nodePendingWork() + "\n")
   os.Exit(1)
 }
 
@@ -86,7 +92,15 @@ func reportStallAndExit() {
 //
 // The call is synchronous, in the sense fs.writeSync is, so it cannot depend on
 // the event delivery that is already suspect.
-func nodePendingWork() string {
+func nodePendingWork() (reading string) {
+  // A reading that fails says so, rather than taking the process down through
+  // a path that cannot report why. Every operation below crosses into JS, and
+  // a JS exception arrives here as a panic.
+  defer func() {
+    if recovered := recover(); recovered != nil {
+      reading = fmt.Sprintf("unavailable: reading node panicked (%v)", recovered)
+    }
+  }()
   process := js.Global().Get("process")
   if process.Type() != js.TypeObject {
     return "unavailable: no process object"

--- a/packages/wasm/test/host/stall_reading_names_what_node_holds_test.go
+++ b/packages/wasm/test/host/stall_reading_names_what_node_holds_test.go
@@ -7,24 +7,28 @@ import (
   "testing"
 )
 
-// TestStallReadingNamesWhatNodeHolds proves the guard's node reading works
-// without making the guard fire.
+// TestStallReadingNamesWhatNodeHolds proves the discriminator produces a real
+// list without making the guard fire.
 //
 // The reading is pure observation, so it can be taken at any moment; a case
 // that arranged a real stall would hang the suite it exists to protect. What
-// has to hold is that the discriminator is present and named: an occurrence is
-// read by whether a pending file request appears here, so a reading that
-// silently produced nothing would look exactly like the verdict "node holds
-// nothing", which is one of the two causes.
+// has to hold is that the discriminator produces something and says so: an
+// occurrence is read by whether a pending file request appears in it, and an
+// empty list is not a neutral answer there but the affirmative verdict that
+// node holds nothing. A reading that quietly produced nothing would spell that
+// verdict, so the assertion is on content rather than on shape.
+//
+// Only the summary is taken. The full reading walks live node objects for
+// per-handle detail, and a property that throws there ends the process with no
+// Go output at all; the guard accepts that because it runs when the suite is
+// already lost and the stacks are already written, which is not the trade a
+// case on the healthy path makes.
 func TestStallReadingNamesWhatNodeHolds(t *testing.T) {
-  reading := nodePendingWork()
-  if !strings.HasPrefix(reading, "getActiveResourcesInfo=[") {
-    t.Fatalf("the discriminator is missing from the reading: %s", reading)
+  summary := nodeResourceSummary()
+  if !strings.HasPrefix(summary, "[") || !strings.HasSuffix(summary, "]") {
+    t.Fatalf("the discriminator produced no list: %s", summary)
   }
-  if strings.Contains(reading, "<not a list>") {
-    t.Fatalf("a reading did not produce a list: %s", reading)
-  }
-  if strings.Contains(reading, "panicked") {
-    t.Fatalf("the reading panicked: %s", reading)
+  if summary == "[]" {
+    t.Fatalf("the discriminator produced the verdict rather than a reading: %s", summary)
   }
 }

--- a/packages/wasm/test/host/stall_reading_names_what_node_holds_test.go
+++ b/packages/wasm/test/host/stall_reading_names_what_node_holds_test.go
@@ -1,0 +1,30 @@
+//go:build js && wasm
+
+package host_test
+
+import (
+  "strings"
+  "testing"
+)
+
+// TestStallReadingNamesWhatNodeHolds proves the guard's node reading works
+// without making the guard fire.
+//
+// The reading is pure observation, so it can be taken at any moment; a case
+// that arranged a real stall would hang the suite it exists to protect. What
+// has to hold is that the discriminator is present and named: an occurrence is
+// read by whether a pending file request appears here, so a reading that
+// silently produced nothing would look exactly like the verdict "node holds
+// nothing", which is one of the two causes.
+func TestStallReadingNamesWhatNodeHolds(t *testing.T) {
+  reading := nodePendingWork()
+  if !strings.HasPrefix(reading, "getActiveResourcesInfo=[") {
+    t.Fatalf("the discriminator is missing from the reading: %s", reading)
+  }
+  if strings.Contains(reading, "<not a list>") {
+    t.Fatalf("a reading did not produce a list: %s", reading)
+  }
+  if strings.Contains(reading, "panicked") {
+    t.Fatalf("the reading panicked: %s", reading)
+  }
+}

--- a/packages/wasm/test/host/stall_reading_names_what_node_holds_test.go
+++ b/packages/wasm/test/host/stall_reading_names_what_node_holds_test.go
@@ -12,11 +12,16 @@ import (
 //
 // The reading is pure observation, so it can be taken at any moment; a case
 // that arranged a real stall would hang the suite it exists to protect. What
-// has to hold is that the discriminator produces something and says so: an
-// occurrence is read by whether a pending file request appears in it, and an
-// empty list is not a neutral answer there but the affirmative verdict that
-// node holds nothing. A reading that quietly produced nothing would spell that
-// verdict, so the assertion is on content rather than on shape.
+// has to hold is that the reading produces a list at all, which is what tells
+// a real answer from a source that was absent or gave back something else.
+//
+// An empty list is not asserted against. `[]` is the honest reading of an
+// empty loop, and it is the likeliest thing the guard itself prints, because
+// it runs inside the timer callback node used to resume the runtime and a
+// healthy program parked there holds nothing. Calling it a broken reading here
+// would teach whoever reads the eventual dump to discard the very answer the
+// guard exists to produce, and would make this case depend on ambient loop
+// state no part of the suite controls.
 //
 // Only the summary is taken. The full reading walks live node objects for
 // per-handle detail, and a property that throws there ends the process with no
@@ -27,8 +32,5 @@ func TestStallReadingNamesWhatNodeHolds(t *testing.T) {
   summary := nodeResourceSummary()
   if !strings.HasPrefix(summary, "[") || !strings.HasSuffix(summary, "]") {
     t.Fatalf("the discriminator produced no list: %s", summary)
-  }
-  if summary == "[]" {
-    t.Fatalf("the discriminator produced the verdict rather than a reading: %s", summary)
   }
 }

--- a/packages/wasm/test/host/stall_reading_refuses_a_forged_verdict_test.go
+++ b/packages/wasm/test/host/stall_reading_refuses_a_forged_verdict_test.go
@@ -1,0 +1,33 @@
+//go:build js && wasm
+
+package host_test
+
+import (
+  "strings"
+  "syscall/js"
+  "testing"
+)
+
+// TestStallReadingRefusesAForgedVerdict proves a reading that is not a list
+// cannot spell the verdict that one of the two causes is decided by.
+//
+// `[]` says node holds nothing, which is the whole of the cause where node
+// completed the write and the runtime failed to route the event. A reading
+// that merely failed must not be able to write that sentence. A plain object
+// is the shape that gets there by accident: it is an object like an array is,
+// and reading an absent `length` off it yields zero, so the loop never runs
+// and the rendering is indistinguishable from the verdict.
+func TestStallReadingRefusesAForgedVerdict(t *testing.T) {
+  process := js.Global().Get("process")
+  original := process.Get("_getActiveHandles")
+  defer process.Set("_getActiveHandles", original)
+  js.Global().Call("eval", "process._getActiveHandles = () => ({})")
+
+  reading := nodePendingWork()
+  if strings.Contains(reading, "_getActiveHandles=[]") {
+    t.Fatalf("a non-list reading spelled the verdict: %s", reading)
+  }
+  if !strings.Contains(reading, "_getActiveHandles=<not a list>") {
+    t.Fatalf("a non-list reading was not named: %s", reading)
+  }
+}

--- a/packages/wasm/test/host/stall_reading_survives_a_broken_source_test.go
+++ b/packages/wasm/test/host/stall_reading_survives_a_broken_source_test.go
@@ -1,0 +1,35 @@
+//go:build js && wasm
+
+package host_test
+
+import (
+  "strings"
+  "syscall/js"
+  "testing"
+)
+
+// TestStallReadingSurvivesABrokenSource proves a failing reading keeps the one
+// that matters.
+//
+// `getActiveResourcesInfo` is the discriminator and is taken first; the two
+// internals after it are the ones likelier to misbehave, and an earlier
+// arrangement let a failure there replace the whole answer with the failure.
+// Losing the discriminator is losing the diagnosis, which is the only reason
+// the guard runs at all.
+//
+// The source is broken deliberately rather than waited for, because a node
+// that misbehaves on its own is exactly what cannot be arranged.
+func TestStallReadingSurvivesABrokenSource(t *testing.T) {
+  process := js.Global().Get("process")
+  original := process.Get("_getActiveHandles")
+  defer process.Set("_getActiveHandles", original)
+  js.Global().Call("eval", "process._getActiveHandles = () => [null]")
+
+  reading := nodePendingWork()
+  if !strings.HasPrefix(reading, "getActiveResourcesInfo=[") {
+    t.Fatalf("a later failure took the discriminator with it: %s", reading)
+  }
+  if !strings.Contains(reading, "panicked") {
+    t.Fatalf("the broken reading was not reported: %s", reading)
+  }
+}

--- a/packages/wasm/test/host/stall_reading_survives_a_broken_source_test.go
+++ b/packages/wasm/test/host/stall_reading_survives_a_broken_source_test.go
@@ -18,12 +18,15 @@ import (
 // the guard runs at all.
 //
 // The source is broken deliberately rather than waited for, because a node
-// that misbehaves on its own is exactly what cannot be arranged.
+// that misbehaves on its own is exactly what cannot be arranged. It throws
+// rather than returning a bad shape, because a bad shape is now named instead
+// of panicking, and the path this case exists for is the one that still ends
+// in a panic: `Value.Call` routes a JS throw back into Go as one.
 func TestStallReadingSurvivesABrokenSource(t *testing.T) {
   process := js.Global().Get("process")
   original := process.Get("_getActiveHandles")
   defer process.Set("_getActiveHandles", original)
-  js.Global().Call("eval", "process._getActiveHandles = () => [null]")
+  js.Global().Call("eval", "process._getActiveHandles = () => { throw new Error('boom') }")
 
   reading := nodePendingWork()
   if !strings.HasPrefix(reading, "getActiveResourcesInfo=[") {

--- a/scripts/go-wasm-exec.cjs
+++ b/scripts/go-wasm-exec.cjs
@@ -45,12 +45,17 @@ for (const key of Object.keys(process.env)) {
 // therefore deliberately slower than the Go budget: whichever fires first ends
 // the process, and the richer artifact must always win the race.
 //
-// The reading is per-handle rather than the type-name summary
-// `getActiveResourcesInfo` returns. That summary is `["PipeWrap","Timeout"]`
-// for this suite whether it is healthy or wedged, because the suite always
-// writes to stdout and `host.Expose` always keeps an hourly timer alive, so it
-// distinguishes nothing. A handle carries an fd, a pending byte count, and a
-// constructor name, which do.
+// The reading is per-handle as well as the type-name summary, because a handle
+// carries an fd, a pending byte count, and a constructor name that a type name
+// does not.
+//
+// An earlier note here claimed the summary reads `["PipeWrap","Timeout"]`
+// whether the suite is healthy or wedged, and so distinguishes nothing. That
+// was measured against this file's own test stub, which writes through
+// `process.stdout` and therefore materializes a socket. The wasm program does
+// not: `wasm_exec_node.js` binds node's `fs` and the program writes through
+// `fs.write`, so no such handle ever exists and the summary does discriminate.
+// The suite's own guard reads it for exactly that reason.
 //
 // The timer is unreferenced, so it can never hold open a process that would
 // otherwise close. That is independent of the budget: a healthy run of this


### PR DESCRIPTION
Follow-up to #1145, which cannot finish the diagnosis it was written for.

#1089 has two open causes — node never fired the write completion, or fired it and the runtime failed to route it. Both park the main goroutine in the same place, a channel receive inside `syscall.fsCall`, so the goroutine stacks read identically. The discriminator is whether node still holds a pending file request.

The node wrapper takes that reading and never gets to. Whichever guard fires first ends the process, and the Go guard's budget is half the wrapper's by design, so the wrapper's reading is structurally unreachable on every occurrence the Go guard catches. The two halves were mutually exclusive.

The Go guard now asks node directly, through a synchronous call in the sense `fs.writeSync` is, so it cannot depend on the delivery already under suspicion.

Measured by firing the guard deliberately:

| state | reading |
| --- | --- |
| nothing in flight | `getActiveResourcesInfo=[]` |
| a write outstanding | `["FSReqCallback","Timeout"]`, request visible through `_getActiveRequests` |

Still evidence capture, not a repair. #1089 stays open.