### PR TITLE
fix(wasm): keep the healthy path away from live libuv objects

### DIFF
--- a/packages/wasm/test/host/stall_reading_refuses_a_forged_verdict_test.go
+++ b/packages/wasm/test/host/stall_reading_refuses_a_forged_verdict_test.go
@@ -3,7 +3,6 @@
 package host_test
 
 import (
-  "strings"
   "syscall/js"
   "testing"
 )
@@ -18,16 +17,11 @@ import (
 // and reading an absent `length` off it yields zero, so the loop never runs
 // and the rendering is indistinguishable from the verdict.
 func TestStallReadingRefusesAForgedVerdict(t *testing.T) {
-  process := js.Global().Get("process")
-  original := process.Get("_getActiveHandles")
-  defer process.Set("_getActiveHandles", original)
-  js.Global().Call("eval", "process._getActiveHandles = () => ({})")
-
-  reading := nodePendingWork()
-  if strings.Contains(reading, "_getActiveHandles=[]") {
-    t.Fatalf("a non-list reading spelled the verdict: %s", reading)
+  rendered := describeJSList(js.Global().Call("eval", "({})"))
+  if rendered == "[]" {
+    t.Fatal("a non-list reading spelled the verdict")
   }
-  if !strings.Contains(reading, "_getActiveHandles=<not a list>") {
-    t.Fatalf("a non-list reading was not named: %s", reading)
+  if rendered != "<not a list>" {
+    t.Fatalf("a non-list reading was not named: %s", rendered)
   }
 }

--- a/packages/wasm/test/host/stall_reading_survives_a_broken_source_test.go
+++ b/packages/wasm/test/host/stall_reading_survives_a_broken_source_test.go
@@ -22,14 +22,34 @@ import (
 // rather than returning a bad shape, because a bad shape is now named instead
 // of panicking, and the path this case exists for is the one that still ends
 // in a panic: `Value.Call` routes a JS throw back into Go as one.
+//
+// All three sources are planted, not just the failing one, so the reading
+// walks nothing live. The two internals return libuv handle and request
+// wrappers, and the guard holds those only when the process is already lost;
+// a case on the healthy path is not making that trade.
 func TestStallReadingSurvivesABrokenSource(t *testing.T) {
   process := js.Global().Get("process")
-  original := process.Get("_getActiveHandles")
-  defer process.Set("_getActiveHandles", original)
-  js.Global().Call("eval", "process._getActiveHandles = () => { throw new Error('boom') }")
+  originals := map[string]js.Value{}
+  for _, name := range []string{
+    "getActiveResourcesInfo",
+    "_getActiveRequests",
+    "_getActiveHandles",
+  } {
+    originals[name] = process.Get(name)
+  }
+  defer func() {
+    for name, original := range originals {
+      process.Set(name, original)
+    }
+  }()
+  js.Global().Call("eval", `
+    process.getActiveResourcesInfo = () => ["Planted"];
+    process._getActiveRequests = () => [];
+    process._getActiveHandles = () => { throw new Error("boom") };
+  `)
 
   reading := nodePendingWork()
-  if !strings.HasPrefix(reading, "getActiveResourcesInfo=[") {
+  if !strings.Contains(reading, "getActiveResourcesInfo=[Planted]") {
     t.Fatalf("a later failure took the discriminator with it: %s", reading)
   }
   if !strings.Contains(reading, "panicked") {


### PR DESCRIPTION
`windows-go` failed on master at `1ab3da04d` with a libuv assertion rather than a hang:

```
unrelated-process-sentinelPASS
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
```

Same window as #1089, right after `PASS`, but seven seconds instead of six hundred.

I cannot prove what produced it. Thirty local runs did not reproduce it, and the lane has no green baseline on the preceding merges to compare against. What is true is that the commit before it put two cases on the healthy path that call `process._getActiveRequests` and `process._getActiveHandles`, which return live libuv handle and request wrappers that then enter Go's value table on every green run.

The guard may hold those: it runs when the process is already lost and the stacks are already written. A case that runs on every healthy build is not making that trade for anything, because what it pins is the renderer and the accumulation, neither of which needs a real handle.

The forged-verdict case now calls the renderer directly with a planted value, and the broken-source case plants all three sources rather than only the one that throws. Both repairs stay pinned, verified in both directions: reverting the gate fails the first, reverting the accumulation fails the second.

This narrows rather than fixes. If the assertion returns with these cases gone, it is #1089 wearing another face, and the guard will say so.