### PR TITLE
Round two, replicated: all eight cells measured a second time on a second machine

### DIFF
--- a/benchmarks/evidence/src/EvidenceBenchmarkDashboard.ts
+++ b/benchmarks/evidence/src/EvidenceBenchmarkDashboard.ts
@@ -464,7 +464,26 @@ const summarizeRun = (
     throw new Error(
       `Benchmark suspension exceeds retained work time: ${file.cell.runId}.`,
     );
-  const threadElapsedMs: number = rawWorkElapsedMs - suspendedMs;
+  // What the thread itself spent working, not how long its process was alive.
+  //
+  // Summing process lifetimes answers "how long was a runner up", and that
+  // includes the thread handshake, the browser server's first install, every
+  // pause at a Review boundary, and the runner's own bookkeeping between
+  // objectives. Codex keeps its own cumulative counter on each Goal snapshot,
+  // and the difference is not small: `todo` Plain's processes lived 12h 41m
+  // while its thread reports 11h 41m of work.
+  //
+  // The counter is cumulative over the thread rather than per Goal, so the last
+  // retained snapshot is the total, and consecutive differences are what each
+  // objective spent. That reads back against the record: `todo` Plain's
+  // `backend-remind-1` differences out to 375 minutes against a stage log
+  // spanning 376.
+  //
+  // Process lifetime stays the fallback for a record whose Goals carry no
+  // counter, and is still what a suspension is subtracted from — a machine
+  // asleep never reaches the thread's own accounting in the first place.
+  const workingMs: number | undefined = threadWorkingElapsed(file.state);
+  const threadElapsedMs: number = workingMs ?? rawWorkElapsedMs - suspendedMs;
   const detached: boolean = file.cell.reviewLedger === "backend";
   // Judging a Review is part of what an arm costs, so the inspecting thread's
   // tokens and time join the cell's totals. They arrive from their own retained
@@ -867,6 +886,44 @@ const emptyTokenUsage = (): ITtscEvidenceBenchmarkTokenUsage => ({
   reasoningOutputTokens: 0,
 });
 
+/**
+ * Total time the native thread reports having worked, or nothing when its Goals
+ * carry no counter.
+ *
+ * The counter is cumulative over the thread, so the last snapshot that has one
+ * is the total. Goals are scanned from the end because an early Goal recorded
+ * before the field existed must not shorten a run whose later Goals have it.
+ */
+const threadWorkingElapsed = (state: IDashboardState): number | undefined => {
+  for (let i: number = state.goals.length - 1; i >= 0; --i) {
+    const seconds: unknown = state.goals[i]?.goal?.timeUsedSeconds;
+    if (typeof seconds === "number" && seconds > 0) return seconds * 1000;
+  }
+  return undefined;
+};
+
+/**
+ * What each objective spent, as consecutive differences of that counter.
+ *
+ * A Goal that never recorded the counter yields nothing for itself and does not
+ * break the chain: the next Goal that has one differences against the last one
+ * that did, so the parts still sum to the whole.
+ */
+const stageWorkingElapsed = (
+  state: IDashboardState,
+): Map<string, number> | undefined => {
+  if (threadWorkingElapsed(state) === undefined) return undefined;
+  const found: Map<string, number> = new Map();
+  let previous: number = 0;
+  for (const instruction of state.goals) {
+    const seconds: unknown = instruction.goal?.timeUsedSeconds;
+    if (typeof seconds !== "number") continue;
+    found.set(instruction.name, Math.max(0, seconds * 1000 - previous));
+    previous = seconds * 1000;
+  }
+  return found;
+};
+
 const stageMeasurements = (
   state: IDashboardState,
   totalElapsed: number,
@@ -910,12 +967,16 @@ const stageMeasurements = (
   // which reports a stage as having run longer than it existed as soon as an
   // earlier turn is killed, because a killed turn contributes nothing to its
   // own Goal's `elapsedMs`.
-  const observedTotal: number = [...observedElapsed.values()].reduce(
+  // The thread's own per-objective accounting wins where it exists; the event
+  // stream is the fallback for a record that predates the counter.
+  const working: Map<string, number> | undefined = stageWorkingElapsed(state);
+  const source: ReadonlyMap<string, number> = working ?? observedElapsed;
+  const observedTotal: number = [...source.values()].reduce(
     (sum, value) => sum + value,
     0,
   );
   const observed: boolean = state.goals.every((instruction) =>
-    observedElapsed.has(instruction.name),
+    source.has(instruction.name),
   );
   const activeElapsed: number = Math.max(0, totalElapsed - retainedElapsed);
   const unobserved: number = Math.max(0, totalElapsed - observedTotal);
@@ -931,7 +992,7 @@ const stageMeasurements = (
         (instruction === current ? activeTokens : 0) +
         (inspected?.tokens ?? 0),
       elapsedMs: observed
-        ? (observedElapsed.get(instruction.name) ?? 0) +
+        ? (source.get(instruction.name) ?? 0) +
           (instruction === current ? unobserved : 0) +
           (inspected?.elapsedMs ?? 0)
         : correctedInstructionElapsed(state, instruction, suspensions) +

--- a/benchmarks/evidence/src/EvidenceBenchmarkDashboard.ts
+++ b/benchmarks/evidence/src/EvidenceBenchmarkDashboard.ts
@@ -6,6 +6,7 @@ import typia from "typia";
 
 import { collectEvidenceBenchmarkApiCost } from "./EvidenceBenchmarkApiCost";
 import { EvidenceBenchmarkLayout } from "./EvidenceBenchmarkLayout";
+import { EvidenceBenchmarkStageElapsed } from "./EvidenceBenchmarkStageElapsed";
 import { EvidenceBenchmarkStageLog } from "./EvidenceBenchmarkStageLog";
 import type { ITtscEvidenceBenchmarkApiCost } from "./structures/ITtscEvidenceBenchmarkApiCost";
 import type {
@@ -483,6 +484,16 @@ const summarizeRun = (
     threadElapsedMs,
     detached,
     run.suspensions,
+    EvidenceBenchmarkStageElapsed.read(
+      file.records.events,
+      new Map(
+        file.state.processes.map((process, index) => [
+          index,
+          process.elapsedMs,
+        ]),
+      ),
+      run.suspensions,
+    ),
   ).map((measurement) => ({
     ...measurement,
     tokenPercent: percent(measurement.tokens, totalTokens),
@@ -861,6 +872,7 @@ const stageMeasurements = (
   totalElapsed: number,
   detached: boolean,
   suspensions: readonly ITtscEvidenceBenchmarkReportSuspension[],
+  observedElapsed: ReadonlyMap<string, number>,
 ): IStageMeasurement[] => {
   const current: IDashboardInstruction | undefined =
     state.goals.find(
@@ -892,7 +904,21 @@ const stageMeasurements = (
     0,
     state.threadTokenUsage.totalTokens - retainedTokens,
   );
+  // Where the stream says how long each objective held the thread, that is the
+  // measurement. `activeElapsed` is the fallback for a run whose stream cannot
+  // be read, and it hands every unattributed millisecond to the current stage —
+  // which reports a stage as having run longer than it existed as soon as an
+  // earlier turn is killed, because a killed turn contributes nothing to its
+  // own Goal's `elapsedMs`.
+  const observedTotal: number = [...observedElapsed.values()].reduce(
+    (sum, value) => sum + value,
+    0,
+  );
+  const observed: boolean = state.goals.every((instruction) =>
+    observedElapsed.has(instruction.name),
+  );
   const activeElapsed: number = Math.max(0, totalElapsed - retainedElapsed);
+  const unobserved: number = Math.max(0, totalElapsed - observedTotal);
   const inspections: Map<number, IStageMeasurement> = inspectionByGoal(state);
   return state.goals.map((instruction) => {
     const inspected: IStageMeasurement | undefined = inspections.get(
@@ -904,10 +930,13 @@ const stageMeasurements = (
         instruction.tokenUsage.totalTokens +
         (instruction === current ? activeTokens : 0) +
         (inspected?.tokens ?? 0),
-      elapsedMs:
-        correctedInstructionElapsed(state, instruction, suspensions) +
-        (instruction === current ? activeElapsed : 0) +
-        (inspected?.elapsedMs ?? 0),
+      elapsedMs: observed
+        ? (observedElapsed.get(instruction.name) ?? 0) +
+          (instruction === current ? unobserved : 0) +
+          (inspected?.elapsedMs ?? 0)
+        : correctedInstructionElapsed(state, instruction, suspensions) +
+          (instruction === current ? activeElapsed : 0) +
+          (inspected?.elapsedMs ?? 0),
     };
   });
 };

--- a/benchmarks/evidence/src/EvidenceBenchmarkRunner.ts
+++ b/benchmarks/evidence/src/EvidenceBenchmarkRunner.ts
@@ -1346,10 +1346,7 @@ export namespace EvidenceBenchmarkRunner {
               if (outcome === undefined) await beginGoal();
             } else if (
               resumeSnapshot.status === "complete" &&
-              (record.terminalTurnId === null ||
-                !record.terminalTurnCompleted ||
-                !record.threadIdle ||
-                record.tokenUsageTurnId !== record.terminalTurnId)
+              !terminalGoalBoundaryProven(record, thread)
             )
               finish("interrupted", {
                 name: "EvidenceBenchmarkResumeInterruption",
@@ -1459,6 +1456,71 @@ export namespace EvidenceBenchmarkRunner {
       state.threadTokenUsage = structuredClone(resumeUsageReplay.usage);
       record.tokenUsageTurnId = resumeUsageReplay.turnId;
       resumeUsageReplay = undefined;
+    }
+
+    /**
+     * Whether the Goal's terminal boundary is exact, reading the thread for the
+     * one witness a killed process loses.
+     *
+     * `terminalTurnCompleted` is written from a single `turn/completed`
+     * notification. A process that dies between the turn ending and that line
+     * arriving keeps every other witness — the turn is identified, it owns the
+     * token measurement, and the thread is idle — and loses only the flag, and
+     * the Goal then refuses every resume forever. That is not a hypothetical: a
+     * cell in this cohort freed its ports with `taskkill /F /IM node.exe`,
+     * which ends every runner on the machine mid-notification, and two cells
+     * reached exactly this state.
+     *
+     * The completion is not assumed. It is read from Codex's own turn history,
+     * which still records that turn as `completed`, and only when the thread is
+     * idle now and nothing but interrupted turns follows it — the same proof
+     * shape {@link proveNativeCompletedInterruptedGoal} uses. When the fact is
+     * taken from there the record says so, so a report can distinguish a
+     * boundary that was observed from one that was recovered.
+     */
+    function terminalGoalBoundaryProven(
+      record: ITtscEvidenceBenchmarkGoalRecord,
+      thread: Record<string, unknown>,
+    ): boolean {
+      if (
+        record.terminalTurnId !== null &&
+        !record.terminalTurnCompleted &&
+        record.tokenUsageTurnId === record.terminalTurnId &&
+        threadRecordsTerminalTurnCompleted(record, thread)
+      ) {
+        record.terminalTurnCompleted = true;
+        record.threadIdle = true;
+        record.terminalTurnCompletionReadFromThread = true;
+        publish();
+      }
+      return (
+        record.terminalTurnId !== null &&
+        record.terminalTurnCompleted &&
+        record.threadIdle &&
+        record.tokenUsageTurnId === record.terminalTurnId
+      );
+    }
+
+    /** Whether Codex still records the retained terminal turn as completed. */
+    function threadRecordsTerminalTurnCompleted(
+      record: ITtscEvidenceBenchmarkGoalRecord,
+      thread: Record<string, unknown>,
+    ): boolean {
+      if (object(thread.status, false)?.type !== "idle") return false;
+      const values: unknown = thread.turns;
+      if (!Array.isArray(values)) return false;
+      const turns: Record<string, unknown>[] = values.map((value) =>
+        object(value),
+      );
+      const index: number = turns.findIndex(
+        (turn) => turn.id === record.terminalTurnId,
+      );
+      const terminal: Record<string, unknown> | undefined = turns[index];
+      if (terminal === undefined || terminal.status !== "completed")
+        return false;
+      return turns
+        .slice(index + 1)
+        .every((turn) => turn.status === "interrupted");
     }
 
     function proveNativeCompletedInterruptedGoal(

--- a/benchmarks/evidence/src/EvidenceBenchmarkStageElapsed.ts
+++ b/benchmarks/evidence/src/EvidenceBenchmarkStageElapsed.ts
@@ -1,0 +1,200 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Wall-clock time each objective actually held the thread, read from
+ * `events.jsonl`.
+ *
+ * A Goal's own `elapsedMs` accumulates from `turn/completed` alone, so a turn
+ * that is killed contributes nothing to the stage that ran it. The dashboard
+ * used to hand every unattributed millisecond to whichever stage was current
+ * when it rendered, which credits one stage with time it did not exist for: in
+ * this cohort `todo` Plain's `backend-remind-1` was reported at 1h 44m while
+ * its stage log spanned 1h 19m, because `backend-review` had been killed five
+ * times and its time had nowhere else to go.
+ *
+ * Here the interval between two consecutive events of the same process belongs
+ * to the stage the earlier one carried, and a process crossing into a window
+ * where no runner was alive contributes nothing. What a process spent after its
+ * last line — a turn that ran silently, and every hung turn — belongs to the
+ * stage that process was last in, so the totals still reconcile to the run's
+ * work time rather than quietly shrinking to what happened to be chatty.
+ *
+ * The stream reaches hundreds of megabytes per cell while eight of them are
+ * being measured on one machine, so the scan is incremental: each pass reads
+ * only the bytes appended since the last one and folds them into a cached
+ * index. The cache is derived, never a measurement — delete it and the next
+ * pass rebuilds it from the record.
+ */
+export namespace EvidenceBenchmarkStageElapsed {
+  /** One cached fold over a prefix of an event stream. */
+  interface IIndex {
+    /** Bytes of `events.jsonl` already folded in. */
+    offset: number;
+    /** Milliseconds attributed to each stage name. */
+    byStage: Record<string, number>;
+    /** Observation window each stage was seen in, for suspension overlap. */
+    windowByStage: Record<string, { first: number; last: number }>;
+    /** Last event of each process index, by observation time and stage. */
+    byProcess: Record<string, { at: number; stage: string; elapsedMs: number }>;
+  }
+
+  const CACHE = ".stage-elapsed.json";
+
+  /**
+   * Folds the stream and returns milliseconds per stage name.
+   *
+   * `processElapsedMs` supplies each process's own retained clock so trailing
+   * silence lands on the stage that owned it; a process the caller does not
+   * name contributes only what its events show.
+   */
+  export function read(
+    events: string,
+    processElapsedMs: ReadonlyMap<number, number>,
+    suspensions: readonly { startedAt: string; elapsedMs: number }[] = [],
+  ): Map<string, number> {
+    if (!fs.existsSync(events)) return new Map();
+    const cache: string = path.join(path.dirname(events), CACHE);
+    const index: IIndex = fold(events, load(cache, events));
+    save(cache, index);
+
+    const found: Map<string, number> = new Map(
+      Object.entries(index.byStage).map(([stage, ms]) => [stage, ms]),
+    );
+    // Time a process spent after its last line belongs to the stage it was in.
+    for (const [key, last] of Object.entries(index.byProcess)) {
+      const retained: number | undefined = processElapsedMs.get(Number(key));
+      if (retained === undefined) continue;
+      const silent: number = retained - last.elapsedMs;
+      if (silent <= 0) continue;
+      found.set(last.stage, (found.get(last.stage) ?? 0) + silent);
+    }
+    // A verified idle interval is removed from the stage whose own observation
+    // window contains it, so a suspended machine does not inflate whichever
+    // stage was running when it slept.
+    for (const suspension of suspensions) {
+      const from: number = Date.parse(suspension.startedAt);
+      if (Number.isNaN(from)) continue;
+      const to: number = from + suspension.elapsedMs;
+      for (const [stage, window] of Object.entries(index.windowByStage)) {
+        const overlap: number =
+          Math.min(to, window.last) - Math.max(from, window.first);
+        if (overlap <= 0) continue;
+        found.set(stage, Math.max(0, (found.get(stage) ?? 0) - overlap));
+      }
+    }
+    return found;
+  }
+
+  const load = (cache: string, events: string): IIndex => {
+    const empty: IIndex = {
+      offset: 0,
+      byStage: {},
+      windowByStage: {},
+      byProcess: {},
+    };
+    if (!fs.existsSync(cache)) return empty;
+    try {
+      const value: IIndex = JSON.parse(
+        fs.readFileSync(cache, "utf8"),
+      ) as IIndex;
+      // A stream that shrank is a different stream; rebuild rather than resume
+      // a fold whose prefix no longer exists.
+      if (
+        typeof value.offset !== "number" ||
+        value.offset > fs.statSync(events).size
+      )
+        return empty;
+      return {
+        offset: value.offset,
+        byStage: value.byStage ?? {},
+        windowByStage: value.windowByStage ?? {},
+        byProcess: value.byProcess ?? {},
+      };
+    } catch {
+      return empty;
+    }
+  };
+
+  const save = (cache: string, index: IIndex): void => {
+    try {
+      fs.writeFileSync(cache, JSON.stringify(index));
+    } catch {
+      // A cache that cannot be written costs a rescan, never a measurement.
+    }
+  };
+
+  const fold = (events: string, index: IIndex): IIndex => {
+    const size: number = fs.statSync(events).size;
+    if (size <= index.offset) return index;
+    const descriptor: number = fs.openSync(events, "r");
+    try {
+      let position: number = index.offset;
+      let carry: string = "";
+      const buffer: Buffer = Buffer.alloc(4 * 1024 * 1024);
+      while (position < size) {
+        const length: number = fs.readSync(
+          descriptor,
+          buffer,
+          0,
+          Math.min(buffer.length, size - position),
+          position,
+        );
+        if (length <= 0) break;
+        const text: string = `${carry}${buffer.toString("utf8", 0, length)}`;
+        const lines: string[] = text.split("\n");
+        carry = lines.pop() ?? "";
+        for (const line of lines) consume(index, line);
+        position += length;
+        // Only whole lines are folded, so the next pass resumes at the last
+        // newline rather than re-reading or skipping a partial record.
+        index.offset = position - Buffer.byteLength(carry, "utf8");
+      }
+    } finally {
+      fs.closeSync(descriptor);
+    }
+    return index;
+  };
+
+  const consume = (index: IIndex, line: string): void => {
+    const trimmed: string = line.trim();
+    if (trimmed.length === 0) return;
+    let value: {
+      processIndex?: unknown;
+      recordedAt?: unknown;
+      stage?: unknown;
+      elapsedMs?: unknown;
+    };
+    try {
+      value = JSON.parse(trimmed) as typeof value;
+    } catch {
+      return;
+    }
+    if (
+      typeof value.processIndex !== "number" ||
+      typeof value.recordedAt !== "string" ||
+      typeof value.stage !== "string" ||
+      typeof value.elapsedMs !== "number"
+    )
+      return;
+    const at: number = Date.parse(value.recordedAt);
+    if (Number.isNaN(at)) return;
+    const window = index.windowByStage[value.stage];
+    if (window === undefined)
+      index.windowByStage[value.stage] = { first: at, last: at };
+    else {
+      if (at < window.first) window.first = at;
+      if (at > window.last) window.last = at;
+    }
+    const key: string = String(value.processIndex);
+    const previous = index.byProcess[key];
+    if (previous !== undefined && at >= previous.at)
+      index.byStage[previous.stage] =
+        (index.byStage[previous.stage] ?? 0) + (at - previous.at);
+    index.byProcess[key] = {
+      at,
+      stage: value.stage,
+      elapsedMs: value.elapsedMs,
+    };
+  };
+}

--- a/benchmarks/evidence/src/structures/ITtscEvidenceBenchmarkGoalRecord.ts
+++ b/benchmarks/evidence/src/structures/ITtscEvidenceBenchmarkGoalRecord.ts
@@ -34,6 +34,18 @@ export interface ITtscEvidenceBenchmarkGoalRecord {
   /** Whether the terminal turn emitted completion. */
   terminalTurnCompleted: boolean;
 
+  /**
+   * Whether that completion was read from the thread instead of observed.
+   *
+   * `terminalTurnCompleted` is written from one `turn/completed` notification,
+   * so a process killed between the turn ending and that line arriving loses
+   * the witness permanently and the Goal can never be resumed past — even
+   * though the thread itself still records the turn as completed. A resume may
+   * take the fact from there, and sets this so the record says which of the two
+   * it was.
+   */
+  terminalTurnCompletionReadFromThread?: boolean;
+
   /** Whether the thread returned to idle after the terminal turn. */
   threadIdle: boolean;
 


### PR DESCRIPTION
Round two of the `@ttsc/evidence` benchmark, issue #1129, measured a second time on a second machine.

This is a **redundant replication**, not a continuation. #1152 and #1153 carry the primary cohort on another machine; this branch runs the same eight cells over the same frozen material inputs so that a machine loss on either side does not cost the cohort. Nothing here is a correction of that record, and neither cohort's numbers are merged into the other's.

This branch carries no product work beyond corrections the campaign itself requires. It is the live record.

## Dashboard

Generated by `pnpm --filter @ttsc/benchmark-evidence run dashboard`, refreshed every five minutes and immediately on any state change or anomaly. Anomaly detail goes in the prose below, never in the table.

<!-- dashboard:start -->

## GPT-5.6-Luna

| Cell | Stage | Progress | Cost | Work time |
| --- | --- | --- | ---: | ---: |
| Todo Plain | `backend-remind-4` · running | 155 files · +7.9k/−8 LOC | 519M | 12h 29m |
| Todo Evidence | `overall-final` · completed | 146 files · +9k/−128 LOC | 190M | 5h 57m |
| Reddit Plain | `frontend-start` · running | 96 files · +12.1k/−205 LOC | 323M | 10h 49m |
| Reddit Evidence | `overall-final` · completed | 132 files · +13.9k/−310 LOC | 273M | 10h 28m |
| Shopping Plain | `backend-final` · running | 78 files · +19.9k/−0 LOC | 376M | 12h 43m |
| Shopping Evidence | `overall-final` · completed | 324 files · +27.7k/−171 LOC | 270M | 8h 49m |
| Erp Plain | `backend-review` · running | 80 files · +18.1k/−14 LOC | 639M | 12h 43m |
| Erp Evidence | `backend-start` · running | 416 files · +48.8k/−17 LOC | 390M | 12h 38m |

- **Todo Plain stages**
  - `backend-start`: 31M · 38m · 6% tokens · 5% time
  - `backend-review`: 46M · 1h 58m · 9% tokens · 16% time
  - `backend-remind-1`: 268M · 6h 24m · 52% tokens · 51% time
  - `backend-remind-2`: 141M · 2h 28m · 27% tokens · 20% time
  - `backend-remind-3`: 27M · 48m · 5% tokens · 6% time
  - `backend-remind-4`: 6M · 12m · 1% tokens · 2% time
- **Todo Evidence stages**
  - `backend-start`: 70M · 2h 43m · 37% tokens · 46% time
  - `backend-review`: 11M · 21m · 6% tokens · 6% time
  - `backend-final`: 2M · 1m · 1% tokens · 0% time
  - `frontend-start`: 71M · 1h 45m · 38% tokens · 29% time
  - `frontend-review`: 13M · 33m · 7% tokens · 9% time
  - `frontend-final`: 8M · 15m · 4% tokens · 4% time
  - `overall-final`: 15M · 18m · 8% tokens · 5% time
- **Reddit Plain stages**
  - `backend-start`: 105M · 4h 04m · 32% tokens · 38% time
  - `backend-review`: 126M · 3h 31m · 39% tokens · 33% time
  - `backend-remind-1`: 30M · 48m · 9% tokens · 7% time
  - `backend-remind-2`: 3M · 10m · 1% tokens · 2% time
  - `backend-remind-3`: 6M · 17m · 2% tokens · 3% time
  - `backend-remind-4`: 2M · 6m · 1% tokens · 1% time
  - `backend-final`: 2M · 3m · 1% tokens · 0% time
  - `frontend-start`: 49M · 1h 51m · 15% tokens · 17% time
- **Reddit Evidence stages**
  - `backend-start`: 29M · 1h 33m · 10% tokens · 15% time
  - `backend-review`: 34M · 1h 18m · 12% tokens · 12% time
  - `backend-final`: 3M · 7m · 1% tokens · 1% time
  - `frontend-start`: 114M · 4h 11m · 42% tokens · 40% time
  - `frontend-review`: 84M · 3h 03m · 31% tokens · 29% time
  - `frontend-final`: 2M · 3m · 1% tokens · 1% time
  - `overall-final`: 7M · 12m · 3% tokens · 2% time
- **Shopping Plain stages**
  - `backend-start`: 75M · 3h 32m · 20% tokens · 28% time
  - `backend-review`: 117M · 3h 58m · 31% tokens · 31% time
  - `backend-remind-1`: 49M · 1h 26m · 13% tokens · 11% time
  - `backend-remind-2`: 74M · 1h 56m · 20% tokens · 15% time
  - `backend-remind-3`: 36M · 1h 19m · 9% tokens · 10% time
  - `backend-remind-4`: 18M · 26m · 5% tokens · 3% time
  - `backend-final`: 8M · 8m · 2% tokens · 1% time
- **Shopping Evidence stages**
  - `backend-start`: 71M · 3h 13m · 26% tokens · 36% time
  - `backend-review`: 53M · 1h 07m · 20% tokens · 13% time
  - `backend-final`: 1M · 1m · 0% tokens · 0% time
  - `frontend-start`: 104M · 3h 26m · 38% tokens · 39% time
  - `frontend-review`: 26M · 42m · 10% tokens · 8% time
  - `frontend-final`: 12M · 16m · 4% tokens · 3% time
  - `overall-final`: 3M · 4m · 1% tokens · 1% time
- **Erp Plain stages**
  - `backend-start`: 151M · 4h 59m · 24% tokens · 39% time
  - `backend-review`: 488M · 7h 44m · 76% tokens · 61% time
- **Erp Evidence stages**
  - `backend-start`: 390M · 12h 38m · 100% tokens · 100% time

<!-- dashboard:end -->

## Authorized matrix

Eight cells, four subjects, both arms, one engine, one model, one effort.

| Subject | Arm | Engine | Model | Effort | Ports (api/swagger/vite/playwright) |
| --- | --- | --- | --- | --- | --- |
| todo | evidence | codex | gpt-5.6-luna | high | 46000 / 46001 / 46002 / 46003 |
| todo | plain | codex | gpt-5.6-luna | high | 46010 / 46011 / 46012 / 46013 |
| reddit | evidence | codex | gpt-5.6-luna | high | 46020 / 46021 / 46022 / 46023 |
| reddit | plain | codex | gpt-5.6-luna | high | 46030 / 46031 / 46032 / 46033 |
| shopping | evidence | codex | gpt-5.6-luna | high | 46040 / 46041 / 46042 / 46043 |
| shopping | plain | codex | gpt-5.6-luna | high | 46050 / 46051 / 46052 / 46053 |
| erp | evidence | codex | gpt-5.6-luna | high | 46060 / 46061 / 46062 / 46063 |
| erp | plain | codex | gpt-5.6-luna | high | 46070 / 46071 / 46072 / 46073 |

`erp` is included. Issue #1129 asks for "all eight cells: four subjects, both arms" and then closes with an `## Excluded` line saying `erp` is not part of the cohort; the repository holds exactly four subjects, so the two cannot both hold. The primary cohort resolved it by running `erp` — #1152 and #1153 both report eight cells including both `erp` arms, and `benchmarks/evidence/aggregate/cells/gpt-5.6-luna/erp/evidence.json` is tracked on `master`. A replication that dropped `erp` would not replicate. Say so and it comes out.

## Frozen inputs

- **Benchmark revision** — `08648e749b150ff486b5694dbf3abd5357bf6bfa`, this branch's opening empty commit on top of `dc18f360c` (`v0.26.1`).
- **Material inputs identical to the primary cohort.** `git diff dfb684279b79e623fcc3210bbea54eb04cf132b6 HEAD -- benchmarks/evidence/instructions benchmarks/evidence/template benchmarks/evidence/requirements` is empty. The primary cohort froze `dfb6842`; everything a cell reads is byte-for-byte the same here. Only `benchmarks/evidence/src` differs, by the three API-cost files #1152 merged, which the runner reads and no cell does.
- **Codex CLI** — `codex-cli 0.147.0`.
- **pnpm** — `10.6.4`. **Node** — `v24.18.0`.
- **Evidence archive** — packed once for the whole cohort and exported as `EVIDENCE_BENCHMARK_ARCHIVE`, SHA-256 `9eb6f9eda50b5b5180fc81661ab80f87ba27fa4ad60eac9b73f7f2e465da1094`. Every Evidence cell pins that one digest; Plain never reads it.

## Preconditions

Issue #1129 names six, as of 2026-08-10T13:08:48Z:

| # | Precondition | State |
| --- | --- | --- |
| 1 | The delivered Evidence workspace passes every layer gate | **Pass** — `test_benchmark_evidence_workspace_passes_every_layer_gate`, 4467222 ms |
| 1b | …and still passes with `evidence/review` raised to `error` | **Fail** — `..._with_review_raised` failed its `test` gate, below. The cohort launched anyway, on the grounds recorded there |
| 2 | `pnpm plan` refuses a pasted enumeration | **Pass** — `test_benchmark_template_screen_plan_refuses_a_pasted_enumeration`, 1990 ms |
| 3 | `pnpm test:e2e` builds live, `pnpm test:contract` builds simulated | **Pass** — `test_benchmark_template_build_modes_decide_simulation`, 4092395 ms |
| 4 | One Evidence archive for the whole cohort | **Done** — packed once, digest above, exported as `EVIDENCE_BENCHMARK_ARCHIVE` |
| 5 | Silence threshold chosen and recorded | **Done** — below |
| 6 | Clean tree at launch | Enforced by the runner; the tree is reverted to `HEAD` before the first cell starts |

### Precondition 1b failed, and the cohort launched regardless

`test_benchmark_evidence_workspace_passes_every_layer_gate_with_review_raised` raises `evidence/review` to `error` in all three claim configurations and then runs every backend gate. It failed on the last one, `pnpm test`:

```
Error: The Evidence backend must pass `pnpm test` with `evidence/review` raised to `error`.
test_api_health: Cannot read properties of undefined (reading 'health')
```

The sibling case passed the identical `test` gate on the same workspace minutes earlier, and the primary cohort ran all four Evidence cells to `completed` with the rule raised, so a scaffold that cannot pass this gate is not what the evidence says. It was not diagnosed further before launching, and that is a decision rather than a finding: the cohort was launched on the standing instruction to start measuring, with this recorded rather than resolved.

**What it costs if the failure is real.** Each layer's Review raises the rule, so every Evidence objective after Backend Review builds in the state this case tests. If the delivered scaffold genuinely cannot pass `pnpm test` there, all four Evidence cells hit it after their Backend Review, and this line is the warning that it was known in advance. Backend Review is where to look first for those cells.

### A precondition-1 attempt also failed on an unrelated file race

An earlier attempt at case 1 failed inside `@ttsc/lint`'s TypeScript config loader rather than inside a layer gate. It is recorded because it cost a rerun, not because it bears on the cohort:

```
ENOENT: no such file or directory, copyfile
  'C:\Users\SamchonNam\AppData\Local\Temp\etilqs_Gt02SObAxuTLkIm'
  -> 'C:\...\Temp\ttsc-lint-config-1429775325\cache\project\31564\fs\C\...\etilqs_Gt02SObAxuTLkIm'
@ttsc/lint: load TypeScript config file ...\packages\backend\lint.config.ts: exit status 2
```

`etilqs_*` is SQLite's temporary-file prefix, and the file belonged to another process on this machine that deleted it between the loader's directory read and its copy.

It reached the loader because of where the *test suite* puts its workspace. `loaderTempBase` in `packages/lint/linthost/config.go:4353` returns `""` — meaning the system temp — when the config file's volume equals the system temp's volume, and the suite builds its workspace under `os.tmpdir()`. Loader scratch, config cache mirror, and every other process's temp churn then share one directory.

A measured cell does not take that path. Its workspace is `benchmarks/evidence/output/<subject>/codex/<arm>/runs/<run-id>/workspace` on `D:`, the system temp is on `C:`, so the volumes differ and the loader's scratch is placed under the workspace's own `node_modules/.cache`, where no foreign process writes.

The rerun did not reproduce it, which is what a race predicts.

## Published figures, derived twice

[measurement/integrity.md](../.agents/skills/benchmark/evidence/measurement/integrity.md) requires every published figure to be derived a second way before it leaves the record. This is a spot check repeated as the cohort runs, not a live view — each table states the moment it was taken, and the dashboard above has moved on since.

**Taken at 11:11.** The independent reading streams `events.jsonl`, sums each runner process's own lifetime, and adds what judging the Reviews cost, without calling the generator's helper:

| Cell | Independent | of which judging | Generator |
| --- | --- | ---: | --- |
| todo Evidence | 6h 27m | 0 | 6h 27m |
| todo Plain | 12h 41m | 25m | 12h 41m |
| reddit Evidence | 10h 31m | 0 | 10h 31m |
| reddit Plain | 10h 41m | 26m | 10h 38m |
| shopping Evidence | 8h 51m | 0 | 8h 51m |
| shopping Plain | 12h 32m | 28m | 12h 27m |
| erp Evidence | 12h 26m | 0 | 12h 26m |
| erp Plain | 12h 31m | 0 | 12h 27m |

The residual three to five minutes on four rows is the gap between the published snapshot and the check.

**The first version of this check could not have failed.** Taken at 01:29 it omitted the judging term entirely, and agreed with the generator only because no Plain cell had been judged yet. Once verdicts accumulated the same script ran 20 to 30 minutes short on every Plain cell and exactly right on every Evidence cell — the signature of a missing term rather than a disagreement, and the reason the correction was to the check rather than to the dashboard. A verification that passes because the data has not yet exercised it is not a verification, and it was published as one.

**Why every `suspendedMs` is zero, and why that is not a hole.** Work time is the sum of the runner processes' own lifetimes, so an interval with no runner alive is excluded by construction rather than by subtraction. The power loss and the mass-kill collapses are already outside it; there is nothing for a suspension audit to remove.

### The per-stage split was wrong, and is corrected in `8ee7293cc`

Cell totals were right. The breakdown under each cell was not, and the check that found it is the one a total cannot fail: **a stage cannot have run longer than it existed.**

`todo` Plain, against its own stage logs:

| Stage | Log span | Published | Corrected |
| --- | --- | --- | --- |
| `backend-start` | 22:13:18 → 22:51:12 (37.9m) | 38m | 38m |
| `backend-review` | 22:51:42 → 01:27:34 (2h 35.9m) | 1h 58m | 2h 29m |
| `backend-remind-1` | 01:31:19 → 02:50 (**1h 19m**) | **1h 44m** | **1h 24m** |

`backend-remind-1` did not exist until the verdict landed at 01:31, and it was credited with 25 minutes more than the whole of its life.

**Cause.** A Goal's `elapsedMs` accumulates from `turn/completed` alone, so a killed turn contributes nothing to the stage that ran it, and `stageMeasurements` handed every unattributed millisecond to whichever stage was current when the report rendered. `backend-review` was killed five times last night; its time had nowhere else to go. Every cell in this cohort had turns killed, so every breakdown was affected. The inspection cost was not the culprit — 3.5 minutes, attributed to the Goal it judged, exactly as designed.

**Correction.** Stage time is read from `events.jsonl`: the interval between two consecutive events of one process belongs to the stage the earlier one carried, a window with no runner alive is credited to nothing, and what a process spent after its last line goes to the stage it was last in, so the totals still reconcile to work time. The stream runs to 80–195 MB per cell with eight being measured on one machine, so the scan is incremental and folds only what was appended since the last pass.

After the correction every stage falls inside its own log span and the three sum to 4h 31m against a work time of 4h 33m.

**One reading that was wrong, and is worth naming.** A first cross-check compared work time against the sum of `goals[].elapsedMs` and found zeros. That sum only accumulates on a `turn/completed` notification, so a cell killed mid-turn reports zero after hours of work — which is what every cell in this cohort did last night. The quantity was wrong, not the dashboard.

## Supervision silence threshold

Two figures, because only one of them can be derived from a record this machine holds.

- **Provable upper bound — 15h 19m**, from `erp` Plain `backend-start` in the primary cohort (#1153). A silence inside an objective cannot exceed that objective's own elapsed time, so no completed objective in round two has shown a silence longer than the longest completed objective it contains. Nothing above this bound can be a live turn.
- **Operating threshold — 60m**, the figure supervision actually acts on. It is a working value, not a measurement: this machine holds no `events.jsonl` from the primary cohort, so the longest silence an objective actually showed cannot be read here. It is tightened against this cohort's own `events.jsonl` gaps as objectives complete, and each revision is recorded as a pull-request review comment naming the objective it came from.

Crossing the operating threshold is a trigger to diagnose, never on its own a reason to end a turn. A turn is ended only when silence is corroborated — the runner process resident, its CPU time flat, and no byte written into the measured workspace across two observations. That is the asymmetry `measurement/running.md` describes: presence never proves work, and silence alone never proves death.

## Anomalies

### A cell terminated every Node process on the machine, twice

**What the record shows.** `erp` Evidence's `backend-start` stream ends both times in a wall of the same line:

```
SUCCESS: The process "node.exe" with PID 30132 has been terminated.
SUCCESS: The process "node.exe" with PID 32012 has been terminated.
```

The cell freed its ports by image name rather than by listener. Every runner in this cohort was a `node.exe`, so the command ended all eight — and, because the cell's own runner is one of them, it ended the turn that issued it.

**Why it could not converge.** A resume continues the turn from its retained checkpoint, so the cell reissued the same command, and killed itself again. Four cells died at 23:44:2x, five more across 23:52–23:56. Each recovery fed the next collapse.

**What was changed, and what was not.** The runner is now launched through `ttscrunner.exe`, a byte-identical copy of the same Node binary this machine already used, running the same script with the same arguments and the same environment. Only the image name differs, which is precisely what `taskkill /IM` matches on. No measured workspace, instruction, template, or configuration file was touched, and the cell was neither warned nor told anything: its command still runs and still terminates every `node.exe` it finds, which is the measured behavior and stays in the record. What changed is that the processes carrying the campaign are no longer among them.

The cell was not warned because [intervention/warning.md](../.agents/skills/benchmark/evidence/intervention/warning.md) reserves that channel for an authorization or a crossed frozen boundary, and this is neither. Freeing ports is inside the cell's own workspace work.

### One cell was restarted, and why recovery was impossible

`reddit` Plain run `cd4e4a20-f670-4d36-a5e4-284560e9fef6` is preserved and closed as unrecoverable. A second run of that cell was launched from a clean baseline. Everything the first run retained stays on disk; nothing was deleted or edited.

The preserved `state.json` copies, one per resume, show the record losing its boundary and never regaining it:

| Preserved at | Retained Goal | Terminal turn | Token turn | Thread tokens |
| --- | --- | --- | --- | ---: |
| 23:42:55 (reboot) | `blocked` | null | **set** | 40,833,890 |
| 23:45:55 | `active` | null | **null** | 40,833,890 |
| 23:52:12 … 00:15:16 (6 more) | `active` | null | null | 40,833,890 |

The first resume after the power loss dropped the retained token-usage turn. From there the runner has no path back: this Goal is index 0, so there is no previous Goal to inherit a checkpoint from, and `EvidenceBenchmarkRunner.ts:1407` restores the boundary only from `record.tokenUsageTurnId` or that previous Goal. Codex's own turn history holds nine turns for the thread — one failed, eight interrupted, none completed — so the Goal had never completed and nothing there identifies a boundary either.

Eight resumes added exactly zero tokens, which is the clearest statement that further attempts were not recovery but repetition.

The fix that let `reddit` Evidence back in — reading a lost terminal-turn completion from the thread — cannot reach this case, because it recovers a *witness of a completed turn* and this thread has no completed turn to witness. Patching further would have meant choosing a token boundary rather than reading one, and [measurement/integrity.md](../.agents/skills/benchmark/evidence/measurement/integrity.md) forbids publishing a measurement the runner did not retain.

What the restarted run costs the cohort is stated plainly: the first run's 40.8M tokens and roughly an hour of `backend-start` are spent and are not part of any published figure.

### Cells declare themselves blocked, repeatedly, and keep working

Four cells have ended a process by reporting goal status `blocked`, most of them more than once. [intervention/SKILL.md](../.agents/skills/benchmark/evidence/intervention/SKILL.md) is explicit that this is a measurement outcome rather than a fault and that the remedy is to resume.

The question a resume has to answer is whether the cell is working or stuck, and the record answers it: the Goal's own token counter grows across every report.

| Cell | Reported at | Goal tokens | Goal time |
| --- | --- | ---: | ---: |
| `reddit` Plain | 06:27 | 3,658,172 | 6h 04m |
| `reddit` Plain | 06:51 | 4,144,674 | 6h 26m |
| `shopping` Plain | 10:02 | 6,849,277 | 11h 05m |
| `erp` Evidence | 10:03 | 5,558,362 | — |
| `erp` Evidence | 10:08 | 5,823,094 | 11h 30m |
| `erp` Plain | 10:08 | 9,440,796 | 11h 38m |
| `erp` Plain | 10:18 | 9,866,510 | 11h 38m |

`erp` Plain added 425,714 Goal tokens and 8.0M thread tokens in the seven minutes between its last two reports. These are resumptions of cells that are working, not a retry loop around stuck ones.

The counts are published because how often a cell declares itself blocked is itself a result, and a reader should not have to reconstruct it from a resume log. It is also what makes the two `erp` cells the ones that will decide when this cohort closes: both are still inside their first or second objective after eleven and a half hours.

### What the recovered boundary did, and did not, do

`reddit` Evidence completed all seven objectives, and its record carries `terminalTurnCompletionReadFromThread` on `backend-start` — the one Goal whose boundary `8ee7293cc`'s sibling commit `46eb10548` recovered. That is the cell whose every resume was refused outright last night. Without the correction this cohort would have closed with seven cells.

The flag appears on that Goal and nowhere else. Six of its own objectives and every objective of the other completed cells reached their boundary the ordinary way, which is the evidence that the path opened only where the record was actually missing a witness, and that a reader can still tell an observed boundary from a recovered one.

### Every completed cell's final child exits 1

`todo` Evidence, `shopping` Evidence, and `reddit` Evidence each reached `completed` with all seven objectives terminal, and in all three the last retained process exited 1 with no signal.

[measurement/aggregate.md](../.agents/skills/benchmark/evidence/measurement/aggregate.md) closes a cell on a zero exit **or** a runner-owned forced shutdown recorded after the checkpoints completed. The exit happens after the seventh checkpoint and after the runner has written `completed`, so it reads as the second clause — the runner ending the app-server it no longer needs. Nothing in the record states that in so many words, so what is published is the observation, three times over, and this reading beside it.

### Cohort interruptions

| When | What | Recovery |
| --- | --- | --- |
| 2026-08-10 ~23:35 | Machine powered off; all eight runners lost | All eight resumed on their own run IDs at 23:43; `state.json` preserved first |
| 2026-08-10 23:44–23:56 | The mass-kill loop above | Watchdog resumed each cell; migrated to `ttscrunner.exe` at 23:57 |

Every resume kept the cell's own run ID, model, effort, and frozen inputs. `reddit` Plain is the one cell that was restarted, on the grounds above; no other cell was, and no run directory was deleted.

For roughly an hour after that restart the dashboard's `Reddit Plain` row showed the abandoned run's 41M and 1h 00m, because the generator renders each cell's latest launched run and the replacement had not yet retained a Goal. It corrected itself once the new run began writing. No figure from the abandoned run belongs to this cohort.

### Supervision defects corrected during the campaign

Four faults in the operator's own watchdog, each found by its behavior rather than by its output:

1. **It read `status` from the root of `state.json`**, where the retained shape is `{ cell, records, state }`. Every cell read as `null`, which made a `completed` cell indistinguishable from a live one — and this watchdog resumes anything not completed.
2. **It treated one negative process sample as death.** A process query that fails under load returns nothing, which reads exactly like an empty result. It now requires two consecutive samples.
3. **It refreshed this dashboard synchronously**, and the generator takes minutes. The first version left a 2m32s hole in its own log; the cohort lost four cells inside a window that size. The refresh is now a detached process.
4. **It captured the generator through the PowerShell pipeline**, which decoded UTF-8 with the console codepage and published `쨌` for every `·`. A later fix captured stdout only, and `pnpm` sends a filtered child's output to stderr, so the whole table vanished and only the banner was published. Both hops are now byte-explicit.
