### PR TITLE
docs(skills): parallelize only implementation in the multi-agent issue campaign

### DIFF
--- a/.agents/skills/development/SKILL.md
+++ b/.agents/skills/development/SKILL.md
@@ -32,7 +32,7 @@ These four are never acceptable; choosing any one means the approach is already 
 - Plugin descriptors are JS; transform logic is Go. JS transform functions (e.g. `transformSource`, `transformOutput`) are not part of the public contract.
 - `shim.go` files marked `gen_shims:hand-maintained` are not regenerated.
 - When code behavior changes, update the matching page under `website/src/content/docs/` in the same change.
-- Run `pnpm format` before every ordinary commit and stage the result; never commit unformatted output. A solo issue campaign formats its unified cycle pull request. The sole exception is an active multi-agent issue campaign implementation batch: its detailed procedure owns the repository-wide formatter result and integrated cleanup.
+- Run `pnpm format` before every ordinary commit and stage the result; never commit unformatted output. An issue campaign instead formats its unified cycle pull request once, and in a multi-agent campaign only the lead runs that formatter.
 
 ## Consequence Analysis
 

--- a/.agents/skills/multi-agent/SKILL.md
+++ b/.agents/skills/multi-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multi-agent
-description: "Defines the explicitly parallel variants of ttsc review and issue campaigns. Use only when the user explicitly requests a team, parallel, or multi-agent review or campaign. Route review work to review.md and issue campaigns to issue-campaign.md. Overall Self-Review and unqualified review remain solo; the solo campaign's mandatory Individual Self-Review is a separate narrow subagent workflow. Multi-agent issue campaigns parallelize discovery and implementation by default, but an explicit request may limit parallelism to discovery and return implementation to the solo campaign."
+description: "Defines the explicitly parallel variants of ttsc review and issue campaigns. Use only when the user explicitly requests a team, parallel, or multi-agent review or campaign. Route review work to review.md and issue campaigns to issue-campaign.md. Overall Self-Review and unqualified review remain solo; the solo campaign's mandatory Individual Self-Review is a separate narrow subagent workflow. A multi-agent issue campaign differs from the solo campaign only in parallel batch implementation inside its one shared checkout, branch, and cycle pull request."
 ---
 
 # Multi-Agent Workflows
@@ -21,11 +21,15 @@ Do not load this skill merely for Individual Self-Review, Overall Self-Review, a
 - Use the smallest number of agents that adds independent evidence or owns immediately executable disjoint work. Available thread capacity is not a reason to create an agent.
 - Never create a waiter, poller, coordinator-only child, duplicate implementation owner, or agent that cannot begin useful work immediately.
 - Give every review or discovery agent the complete declared surface. Parallel review adds independent full passes; it never partitions coverage by package, file, concern, platform, or test lane.
-- Partition implementation only through verified dependency and file-ownership boundaries. One agent owns one coarse batch, branch, pull request, and worktree.
+- Partition implementation only through verified dependency and file-ownership boundaries. One agent owns one coarse batch and its disjoint file set inside the campaign's single shared checkout, topic branch, and cycle pull request.
 - Keep the lead active on fact-checking, integration, conflict resolution, and decisions that do not duplicate an assigned agent.
 - Do not let agents re-delegate.
-- Overall Self-Review remains solo for every author and every implementation branch.
-- Create worktrees only for parallel implementation batches and their integrated cleanup. Solo implementation and review use the current checkout.
-- Remove every finished worktree, local branch, process, and assignment-owned temporary asset before declaring its assignment complete.
+- Overall Self-Review remains solo. In a parallel campaign the lead alone runs it, over the integrated pull-request diff.
+- Never create a clone or worktree. Every workflow in this skill, parallel implementation included, runs in the current checkout.
+- Remove every finished local branch, process, and assignment-owned temporary asset before declaring its assignment complete.
 
-The solo campaign's [Individual Self-Review](../review/SKILL.md#individual-self-review) is a different topology and relaxes neither the full-surface rule nor the solo Overall Self-Review rule above. A parallel review gives several reviewers the entire declared surface independently and the lead adjudicates their findings. Individual Self-Review gives exactly one read-only reviewer one pushed commit's parent-to-commit diff, returns advice to the main agent while implementation continues, and leaves that main agent's whole-surface Overall Self-Review as the merge gate. A batch implementation agent here runs no Individual Self-Review because agents do not re-delegate; the mandatory carve-out in the solo development procedure belongs to a solo campaign's main agent.
+The solo campaign's [Individual Self-Review](../review/SKILL.md#individual-self-review) is a different topology and relaxes neither the full-surface rule nor the solo Overall Self-Review rule above.
+
+A parallel review gives several reviewers the entire declared surface independently, and the lead adjudicates their findings. Individual Self-Review gives exactly one read-only reviewer one pushed commit's parent-to-commit diff, returns advice to the main agent while implementation continues, and leaves that main agent's whole-surface Overall Self-Review as the merge gate.
+
+A batch implementation agent spawns no Individual Self-Review because agents do not re-delegate. It reviews its own pushed batch through [Batch Self-Review](issue-campaign.md#batch-self-review), and the solo development procedure's subagent carve-out stays with a solo campaign's main agent.

--- a/.agents/skills/multi-agent/issue-campaign.md
+++ b/.agents/skills/multi-agent/issue-campaign.md
@@ -1,81 +1,25 @@
 # Multi-Agent Issue Campaign
 
-Read this document only through the multi-agent skill for an explicitly parallel issue campaign. Read the base issue-campaign, project, development, pull-request, review, and [multi-agent review](review.md) procedures before acting.
+A multi-agent issue campaign is the [solo issue campaign](../issue-campaign/SKILL.md) with one difference: implementation runs as parallel batches. Discovery, publication, and the entire [development procedure](../issue-campaign/development.md) stay exactly as written there.
 
-The base issue-campaign skill owns authorization, the knowledge base, candidate adjudication, self-contained issue bodies, and the clean full-scope completion gate. This document overrides only discovery and implementation topology.
+Read this document only through the multi-agent skill for an explicitly parallel issue campaign.
 
-## Select The Parallel Boundary
+The batches share the campaign's one checkout, topic branch, and cycle pull request. Nothing here adds a worktree, a per-batch branch, or a second pull request.
 
-A multi-agent issue campaign parallelizes both discovery and implementation by default.
+## Parallel Batches
 
-Switch to parallel discovery with solo implementation only when the user explicitly requests that combination. In that mode:
+Once the lead has claimed the cycle pull request, group the accepted issues by kind, cut the groups along the published-issue DAG, and hand one agent the largest cohesive batch it can own alone. Issue count never sets agent count, and concurrent batches must stay on disjoint file sets.
 
-1. Run Parallel Discovery repeatedly against the recorded pre-development integrated state until one complete parallel round is empty. Let the lead adjudicate every round and publish accepted issues when authorized.
-2. Stop every discovery agent only after the empty-round development gate passes.
-3. If the gate passes with no accepted issue, skip implementation and evaluate [Completion](#completion).
-4. Otherwise read the base issue campaign's [solo development procedure](../issue-campaign/development.md).
-5. Put every implementation-ready issue into its one empty-claim pull request, use the current checkout without a worktree, run `pnpm format`, validate through ordinary CI, and follow the solo development procedure's Individual and Overall Self-Review rules.
-6. Apply that procedure's implementation, CI, merge, branch cleanup, and temporary-asset rules, but return here for the next parallel discovery round instead of switching to solo discovery.
+Each agent implements its issues with their tests, commits and pushes them to the shared branch, runs [Batch Self-Review](#batch-self-review), and reports. It builds, tests, and formats nothing locally, and it disregards CI entirely. Every check run belongs to the lead's finishing phase.
 
-Do not infer solo implementation from quota concerns, a small issue count, or the fact that the lead performs publication. Only the user's explicit phase boundary selects it.
+### Batch Self-Review
 
-## Parallel Discovery
+Batch Self-Review replaces Individual Self-Review for a batch agent's commits, and the agent runs it itself because agents do not re-delegate.
 
-Use [review.md](review.md)'s Parallel Issue Discovery Rounds. Every discovery agent audits the whole declared scope independently. The lead alone fact-checks and publishes.
+It is [Overall Self-Review](../review/SKILL.md#overall-self-review) over one surface, the agent's own pushed commits.
 
-Pool raw candidates in `.wiki`, then reproduce and combine, split, rewrite, reject, or defer them before publication. Parallel discovery changes evidence breadth, not publication authority.
+The lead's Overall Self-Review still gates the merge.
 
-Keep implementation closed while any meaningful candidate survives a round. Accumulate accepted issues, end the current discovery team, and run another complete parallel full-scope round against the same recorded pre-development integrated state. Begin implementation only after one complete team round is empty and the accumulated accepted issue set is nonempty.
+## Finishing Phase
 
-## Build Coarse Implementation Batches
-
-When implementation is also parallel, first confirm the empty-round discovery gate and freeze the accumulated accepted issue set. Recompute the published-issue DAG before every wave. Form the smallest number of maximal cohesive batches that dependency readiness and ownership permit.
-
-Group issues only when they are ready on the same frontier, share an architectural owner or root invariant, overlap in consequence surface, use mostly the same verification, and remain understandable and reversible as one diff. Split for a named dependency, external blocker, repository or target-branch boundary, independent release contract, incompatible verification owner, destructive file overlap, or lost issue-level attribution.
-
-Topic, label, package proximity, reporter, and issue count do not justify a split. Record the original issue count, final pull-request count, DAG edges, grouping reasons, split reasons, owned files, and verification lanes in `.wiki` before opening claims.
-
-Freeze a batch once its empty claim pull request exists. Re-cut an active batch only when correctness, overlap, or invalidated evidence requires a lead decision.
-
-Open only as many implementation agents as there are immediately executable, non-overlapping batches.
-
-## Claim And Implement Parallel Batches
-
-For each immediately executable batch:
-
-1. Create one isolated worktree and topic branch.
-2. Create `<worktree>/.campaign-tmp/go-cache` and `<worktree>/.campaign-tmp/go-tmp`. Every Go command for that batch must set `GOCACHE` and `GOTMPDIR` to those exact directories.
-3. Create an implementation-free commit with `git commit --allow-empty`.
-4. Push and open a draft pull request linking every batch issue and stating its owned files.
-5. Cancel that exact branch's queued or running campaign Actions and record the terminal cancellation state. Never disable repository Actions or a workflow, and never cancel another branch's run.
-6. Install dependencies asynchronously when needed, then implement the full consequence surface and near-100% positive, negative, boundary, and regression coverage.
-7. Commit and push coherent increments, cancelling only the new runs for that exact branch.
-8. Run the narrowest local proving commands followed by the broader locally owned lanes.
-9. Freeze the head and complete solo Overall Self-Review. If code changes, rerun the necessary local gates and restart the full review.
-10. Let the lead independently verify issue fit, dispositions, evidence, and batch scope.
-11. If any campaign pull-request run reaches red, diagnose and repair it in the same pull request, then commit and push the repair even when the failure predates the campaign or is unrelated to its original issues.
-12. Merge only with user authorization after local verification, lead review, the final campaign-run cancellation record, and any red-CI repair are complete.
-
-Measure each batch from its empty pull request's GitHub `createdAt` through `mergedAt`, including installation, dependency waiting, implementation, validation, review, rebases, cancellation, and merge. Keep outliers and record issue count beside the duration.
-
-Start long local commands asynchronously and continue useful independent work. Do not reserve an agent solely to watch installation, build, test, CI, or cancellation.
-
-When batches overlap unexpectedly, stop the later mutation, report the exact file and invariant conflict, and let the lead serialize or re-cut the work. Agents never edit another batch's owned files.
-
-## Integrated Cleanup
-
-After every parallel implementation batch is resolved and its worktree and external assets are removed:
-
-1. Create one cleanup worktree and topic branch from the integrated target.
-2. Install dependencies when needed and run `pnpm format`.
-3. Run the full integrated local validation required by the project skill.
-4. If formatting changes files, open one ordinary cleanup pull request, let all CI checks run, and perform solo Overall Self-Review while they run.
-5. Repair every CI or review finding in the same cleanup pull request, including a red lane unrelated to the campaign's original changes, and repeat until the same head is green and clean.
-6. Merge with authorization, then remove the cleanup worktree, branch, and assignment-owned external assets.
-7. If formatting produces no diff, complete solo Overall Self-Review over the integrated target, then remove the unused cleanup worktree and branch without opening a pull request.
-
-## Completion
-
-After the selected implementation flow is resolved, start the next cycle against the integrated repository. Repeat complete parallel full-scope rounds against that state until a full team round is empty, accumulating every accepted issue before any new implementation begins.
-
-The campaign succeeds only when every reviewer completes the whole scope, no meaningful candidate survives lead verification, no accepted issue remains unresolved, and every campaign worktree and assignment-owned temporary asset is removed. Report an external blocker as blocked, not complete.
+Once every agent has reported, rejoin the solo procedure at its formatted integrated snapshot. Start the lead's Overall Self-Review rounds at once instead of waiting for CI, and carry the cycle through CI repair and merge.

--- a/.agents/skills/multi-agent/review.md
+++ b/.agents/skills/multi-agent/review.md
@@ -27,7 +27,7 @@ Each reviewer still inspects the complete change surface and relevant sources in
 
 ## Parallel Issue Discovery Rounds
 
-Use this mode only through the multi-agent issue-campaign procedure.
+Use this mode only when the user explicitly asks for parallel issue discovery. A multi-agent issue campaign parallelizes implementation only, so its discovery rounds stay solo.
 
 1. Give every discovery reviewer the entire declared campaign scope.
 2. Each reviewer independently audits source, tests, documentation, CI, packaging, generated artifacts, platform behavior, upstream or downstream provenance, and open and closed issue or pull-request history. Audit the current implementation and history against the development skill's **Forbidden** section.

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -17,7 +17,7 @@ Solo work never creates a clone or worktree. If the current checkout contains un
 
 Use one commit per coherent unit when the diff is large. Follow the repository's `<type>(<scope>): <subject>` history with an imperative lowercase subject and no trailing period.
 
-Run the validation required by the development skill. Run `pnpm format` before ordinary commits. A solo issue campaign formats its unified implementation branch. Only an explicit multi-agent campaign implementation batch defers the repository-wide formatter result to its integrated cleanup.
+Run the validation required by the development skill. Run `pnpm format` before ordinary commits. An issue campaign formats its unified implementation branch once, and in a multi-agent campaign that formatter run belongs to the lead's finishing phase.
 
 Stage explicit paths when the worktree is mixed. Never include unrelated user changes silently.
 
@@ -31,14 +31,16 @@ Push only the topic branch with upstream tracking. Use a file-backed body for mu
 
 ## Issue Campaign Override
 
-Before any issue-campaign push or pull request, complete `.agents/skills/issue-campaign/development.md`. A solo campaign uses one formatted pull request and the ordinary check loop. Only the explicit multi-agent procedure overrides that flow with worktree batches, exact-SHA campaign-run cancellation, local implementation gates, and integrated cleanup.
+Before any issue-campaign push or pull request, complete `.agents/skills/issue-campaign/development.md`. Every campaign uses one formatted pull request and the ordinary check loop. The explicit multi-agent procedure overrides only the topology: parallel batch agents share that one checkout, topic branch, and pull request, and each records its own Batch Self-Review there.
 
 ## Watch Checks After Every Ordinary Push
 
-After each ordinary push, including every multi-agent integrated-cleanup push, monitor the pull-request checks until every check settles. Solo issue-campaign implementation commits and CI-suspended campaign implementation waves skip this per-push wait. The solo campaign main agent starts the required Individual Self-Review and immediately implements the next ready issue, then reads CI once the integrated head settles as its development procedure requires. On failure, fetch the relevant job log, diagnose the real cause, fix it in place, push a new commit, and resume monitoring. Do not treat a green unrelated job as acceptance for a failed required surface.
+After each ordinary push, monitor the pull-request checks until every check settles. On failure, fetch the relevant job log, diagnose the real cause, fix it in place, push a new commit, and resume monitoring. Do not treat a green unrelated job as acceptance for a failed required surface.
+
+Issue-campaign implementation commits skip that per-push wait. The solo main agent starts the required Individual Self-Review and immediately implements the next ready issue, while a multi-agent batch agent continues its batch and leaves every check to the lead. Both read CI once the integrated head settles, as the development procedure requires.
 
 ## Merge On Explicit Request Or Standing Autonomous Mandate
 
 Do not merge, squash-merge, rebase, or update the target branch on unprompted initiative. Merge when the user explicitly asks, or when a standing autonomous mandate authorizes end-to-end delivery; use the repository's established merge method unless another is specified. Under an autonomous mandate the author that owns the pull request merges it themselves once the merge gate below passes, without separate approval.
 
-Before merging an ordinary or multi-agent integrated-cleanup pull request, confirm required checks pass. For a campaign implementation pull request whose automatic CI is deliberately suspended, confirm the issue-campaign local-verification and lead-review gates instead. If branch protection blocks the requested merge, report the blocker rather than bypassing it.
+Before merging, confirm the required checks pass on the exact head being merged. A campaign implementation pull request also needs its complete clean Overall Self-Review round on that same head. If branch protection blocks the requested merge, report the blocker rather than bypassing it.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -62,3 +62,5 @@ An empty round can open development while accepted issues remain, but an unresol
 ## Explicit Multi-Agent Reviews
 
 When the user explicitly asks for a team, parallel, or multi-agent review, load the [multi-agent skill](../multi-agent/SKILL.md) and its [review procedure](../multi-agent/review.md) instead of this workflow. It inherits the same whole-surface and fresh-round law while defining independent parallel reviewers and lead adjudication.
+
+A parallel issue campaign's implementation agents use [Batch Self-Review](../multi-agent/issue-campaign.md#batch-self-review) in place of Individual Self-Review. Each agent reviews its own pushed batch under the law above and spawns nothing, and the lead still performs the solo Overall Self-Review over the integrated pull-request diff as the merge gate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Default solo Overall Self-Review, mandatory advisory Individual Self-Review for 
 
 ### Multi-Agent Workflows
 
-Explicitly parallel review and issue-campaign variants live under one entry point, `.agents/skills/multi-agent/SKILL.md`. Read it only when the user explicitly asks for a team, parallel, or multi-agent workflow. Multi-agent issue campaigns parallelize discovery and implementation by default and switch to solo implementation only on an explicit discovery-only parallel request. Overall Self-Review remains solo, while Individual Self-Review is the solo campaign's mandatory per-commit advisory subagent workflow.
+Explicitly parallel review and issue-campaign variants live under one entry point, `.agents/skills/multi-agent/SKILL.md`. Read it only when the user explicitly asks for a team, parallel, or multi-agent workflow. A multi-agent issue campaign differs from the solo campaign only in parallel batch implementation inside its one shared checkout, branch, and pull request. Overall Self-Review remains solo, while Individual Self-Review is the solo campaign's mandatory per-commit advisory subagent workflow.
 
 ### Discussion
 


### PR DESCRIPTION
Rewrites the multi-agent issue-campaign skill so it differs from the solo campaign only in parallel batch implementation, inside the campaign's one checkout, topic branch, and cycle pull request.

- Batches group issues by kind and cut along the published-issue DAG; issue count never sets agent count.
- Batch agents commit and push to the shared branch, run Batch Self-Review, and report; they build, test, and format nothing locally and disregard CI.
- After every agent reports, the lead starts Overall Self-Review at once and carries the cycle through CI repair and merge.
- Discovery, publication, and the development procedure stay solo; worktrees, per-batch branches, per-batch pull requests, and the cleanup pull request are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4N4u2r8HEGvwpECbPVxq6