### PR TITLE
Round two: erp plain's coverage, and the four-subject comparison

### DIFF
--- a/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/erp/plain.json
+++ b/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/erp/plain.json
@@ -9,14 +9,14 @@
   "status": "running",
   "stage": "overall-remind-1",
   "launchedAt": "2026-08-09T18:17:34.421Z",
-  "tokens": 2787341871,
+  "tokens": 2794568118,
   "tokenUsage": {
-    "totalTokens": 2787341871,
-    "inputTokens": 2782866997,
-    "cachedInputTokens": 2730154752,
+    "totalTokens": 2794568118,
+    "inputTokens": 2790076128,
+    "cachedInputTokens": 2737145600,
     "cacheWriteInputTokens": 0,
-    "outputTokens": 4474874,
-    "reasoningOutputTokens": 1053527
+    "outputTokens": 4491990,
+    "reasoningOutputTokens": 1055225
   },
   "inspection": {
     "attempts": 11,
@@ -36,19 +36,19 @@
     "pricingAsOf": "2026-08-01",
     "priceSource": "https://openrouter.ai/api/v1/models",
     "currency": "USD",
-    "amountUsd": 34.54871436,
-    "requests": 19770,
-    "shortContextRequests": 19770,
+    "amountUsd": 34.65072074,
+    "requests": 19818,
+    "shortContextRequests": 19818,
     "longContextRequests": 0,
     "longContextThresholdTokens": 272000,
     "replayedUpdates": 0
   },
   "suspendedMs": 0,
   "suspensions": [],
-  "workElapsedMs": 217268944.97810003,
+  "workElapsedMs": 217692219.73070002,
   "worktree": {
     "files": 452,
-    "additions": 85210,
+    "additions": 85219,
     "deletions": 136
   },
   "reviewVerdicts": [
@@ -223,7 +223,7 @@
       "name": "backend-start",
       "tokens": 544228917,
       "elapsedMs": 55121000,
-      "tokenPercent": 20,
+      "tokenPercent": 19,
       "timePercent": 25
     },
     {
@@ -326,8 +326,8 @@
     },
     {
       "name": "overall-remind-1",
-      "tokens": 1056615564,
-      "elapsedMs": 72795456.31280002,
+      "tokens": 1063841811,
+      "elapsedMs": 73218731.0654,
       "tokenPercent": 38,
       "timePercent": 34
     }

--- a/benchmarks/evidence/aggregate/coverage-input-erp.round-two.json
+++ b/benchmarks/evidence/aggregate/coverage-input-erp.round-two.json
@@ -1,0 +1,90 @@
+{
+  "cohort": "round two, campaign/evidence-luna-0.26.0",
+  "subject": "erp",
+  "arm": "plain",
+  "runId": "0b9deae2-9926-49f4-9b6c-d454844a4470",
+  "state": "counted",
+  "method": {
+    "read": "A snapshot of the workspace taken at 15:55, copied without node_modules, build output, and logs. The cell was still running: a first attempt to count the live tree saw the schema grow from 133 to 135 models and the accessors from 441 to 445 mid-read, so the count was moved onto a frozen copy.",
+    "grouping": "The six requirement-rooted edges are counted per family, the 253 `##` anchors, not per requirement. A family shares one obligation, and the workspace's own screen-plan script rolls an H3 decision up to its H2.",
+    "requirementRooted": "Each of the six was counted twice in independent passes and the lower rate kept."
+  },
+  "populations": {
+    "requirementAnchors": 1487,
+    "requirementFamilies": 253,
+    "models": 135,
+    "scalarColumns": 1316,
+    "accessors": 445,
+    "publishedTypes": 349,
+    "hooks": 439,
+    "screens": 13,
+    "backendTests": 166,
+    "journeyCases": 3
+  },
+  "cells": [
+    {
+      "model": "gpt-5.6-luna",
+      "subject": "erp",
+      "runId": "0b9deae2-9926-49f4-9b6c-d454844a4470",
+      "edges": {
+        "requirementToModel": { "eligible": 101, "reached": 100 },
+        "requirementToOperation": { "eligible": 98, "reached": 97 },
+        "requirementToDto": { "eligible": 192, "reached": 189 },
+        "requirementToTest": { "eligible": 252, "reached": 236 },
+        "requirementToScreen": { "eligible": 98, "reached": 19 },
+        "requirementToJourney": { "eligible": 105, "reached": 8 },
+        "modelToOperation": { "eligible": 135, "reached": 135 },
+        "modelToDto": { "eligible": 135, "reached": 133 },
+        "accessorToTest": { "eligible": 445, "reached": 432 },
+        "accessorToHook": { "eligible": 445, "reached": 424 },
+        "hookToScreen": { "eligible": 439, "reached": 22 },
+        "screenToJourney": { "eligible": 13, "reached": 13 },
+        "columnToProperty": { "eligible": 1316, "reached": 928 }
+      }
+    }
+  ],
+  "eligibilityRules": {
+    "requirementToModel": "The family declares organizational state the system must persist.",
+    "requirementToOperation": "The family describes an action a principal performs or a result the system returns on request.",
+    "requirementToDto": "The family's information crosses the HTTP boundary as a request or response payload.",
+    "requirementToTest": "The family's obligation is decidable through the backend API. One family is outside it, asserting a delivery-process property no feature test settles.",
+    "requirementToScreen": "The family names a capability a human performs in the browser.",
+    "requirementToJourney": "The family owes a browser-observable flow."
+  },
+  "unreached": {
+    "requirementToModel": [
+      "REQ-DOM-ASSET-CATEGORY: no asset_categories model, no category column on assets, and the name appears nowhere under packages"
+    ],
+    "requirementToOperation": ["REQ-AUTH-PRINCIPAL"],
+    "requirementToDto": ["REQ-DOM-LOT", "REQ-DOM-SERIAL", "REQ-DOM-ASSET-CATEGORY"],
+    "requirementToTest": [
+      "16 of 252 families, among them REQ-NFR-TENANT, which no test can settle as written because no test creates a second organization, and REQ-RULE-CONCURRENCY, which no test can settle because the suite issues no concurrent request"
+    ],
+    "requirementToScreen": [
+      "79 of 98 families. The thirteen screens deliver authentication, the organization, accounts, journals, stock views, inventory adjustment, MRP and its recommendations, approvals, audit, and the seven report families. Procurement, sales, inventory master data, manufacturing, quality, service, projects, payroll, and every finance master family reach no screen"
+    ],
+    "requirementToJourney": [
+      "97 of 105 families. Three journey cases reach provisioning, the account, journals, the financial report, approvals, audit, and inventory adjustment. All seven REQ-JRN-* end-to-end families are unwalked"
+    ],
+    "modelToDto": [
+      "recovery_deliveries: the recovery request deliberately returns a random identifier so no column reaches a response",
+      "vendor_credit_refunds: written and never read back, while the credit-memo side publishes its refunds"
+    ],
+    "accessorToTest": [
+      "13 of 445, among them the whole credit-memo group, the three MRP recommendation decisions, two asset transitions, and both automation accessors"
+    ],
+    "accessorToHook": ["21 of 445"],
+    "hookToScreen": [
+      "417 of 439. All 17 authored hooks are called by a screen; of the generated per-accessor wrappers only 5 are"
+    ],
+    "columnToProperty": [
+      "388 of 1316: 116 created_at, 101 organization_id, 39 updated_at, and 132 domain columns. recovery_deliveries and sessions publish no column at all"
+    ]
+  },
+  "unsettled": {
+    "requirementToTest": "Both passes give 236 of 252 but name different families in four places; the union of both unreached sets is 234. The evidence read directly — no second organization anywhere in the suite, no concurrent request anywhere in the suite — supports the lower figure.",
+    "modelToDto": "lots and serials are counted reached on their keys alone: no ILot or ISerial exists, and only lots.id and serials.code escape, as lotId and serialCode on movement and quarantine types. A rule requiring non-key state to be published would make this 131.",
+    "screenToJourney": "13 of 13 is a source-level count. The journey's Operations step waits for text the screen does not render, so the case times out there and the last four screens never execute; the executable count is 9. The workspace's own verification note concedes the live suite was never run.",
+    "columnToProperty": "928 is a point estimate inside a band of 921 to 931, the ends being a strict leaf-type reading and a root-namespace-expanded one."
+  }
+}

--- a/benchmarks/evidence/aggregate/coverage.json
+++ b/benchmarks/evidence/aggregate/coverage.json
@@ -503,6 +503,174 @@
         "edges": []
       },
       "runId": "33baf096-f2ea-4d07-91f7-a4cb4616ad2b"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "subject": "erp",
+      "arm": "plain",
+      "coverage": {
+        "arm": "plain",
+        "measured": true,
+        "score": 0.5001382824573022,
+        "wholeness": {
+          "test": 1,
+          "journey": 1,
+          "property": 1,
+          "dto": 0.7051671732522796,
+          "screen": 1,
+          "hook": 0.05011389521640091,
+          "api": 0.5092677433390495,
+          "model": 0.6019939977530551
+        },
+        "obligations": [
+          {
+            "name": "model",
+            "edge": "requirementToModel",
+            "rate": 0.9900990099009901,
+            "wholeness": 0.6019939977530551,
+            "value": 0.5960336611416387
+          },
+          {
+            "name": "operation",
+            "edge": "requirementToOperation",
+            "rate": 0.9897959183673469,
+            "wholeness": 0.5092677433390495,
+            "value": 0.5040711337131408
+          },
+          {
+            "name": "dto",
+            "edge": "requirementToDto",
+            "rate": 0.984375,
+            "wholeness": 0.7051671732522796,
+            "value": 0.6941489361702128
+          },
+          {
+            "name": "test",
+            "edge": "requirementToTest",
+            "rate": 0.9365079365079365,
+            "wholeness": 1,
+            "value": 0.9365079365079365
+          },
+          {
+            "name": "screen",
+            "edge": "requirementToScreen",
+            "rate": 0.19387755102040816,
+            "wholeness": 1,
+            "value": 0.19387755102040816
+          },
+          {
+            "name": "journey",
+            "edge": "requirementToJourney",
+            "rate": 0.0761904761904762,
+            "wholeness": 1,
+            "value": 0.0761904761904762
+          }
+        ],
+        "edges": [
+          {
+            "name": "columnToProperty",
+            "eligible": 1316,
+            "reached": 928,
+            "rate": 0.7051671732522796
+          },
+          {
+            "name": "screenToJourney",
+            "eligible": 13,
+            "reached": 13,
+            "rate": 1
+          },
+          {
+            "name": "hookToScreen",
+            "eligible": 439,
+            "reached": 22,
+            "rate": 0.05011389521640091
+          },
+          {
+            "name": "accessorToTest",
+            "eligible": 445,
+            "reached": 432,
+            "rate": 0.9707865168539326
+          },
+          {
+            "name": "accessorToHook",
+            "eligible": 445,
+            "reached": 424,
+            "rate": 0.952808988764045
+          },
+          {
+            "name": "modelToOperation",
+            "eligible": 135,
+            "reached": 135,
+            "rate": 1
+          },
+          {
+            "name": "modelToDto",
+            "eligible": 135,
+            "reached": 133,
+            "rate": 0.9851851851851852
+          },
+          {
+            "name": "requirementToModel",
+            "eligible": 101,
+            "reached": 100,
+            "rate": 0.9900990099009901
+          },
+          {
+            "name": "requirementToOperation",
+            "eligible": 98,
+            "reached": 97,
+            "rate": 0.9897959183673469
+          },
+          {
+            "name": "requirementToDto",
+            "eligible": 192,
+            "reached": 189,
+            "rate": 0.984375
+          },
+          {
+            "name": "requirementToTest",
+            "eligible": 252,
+            "reached": 236,
+            "rate": 0.9365079365079365
+          },
+          {
+            "name": "requirementToScreen",
+            "eligible": 98,
+            "reached": 19,
+            "rate": 0.19387755102040816
+          },
+          {
+            "name": "requirementToJourney",
+            "eligible": 105,
+            "reached": 8,
+            "rate": 0.0761904761904762
+          }
+        ]
+      },
+      "runId": "0b9deae2-9926-49f4-9b6c-d454844a4470"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "subject": "erp",
+      "arm": "evidence",
+      "coverage": {
+        "arm": "evidence",
+        "measured": false,
+        "score": 1,
+        "wholeness": {
+          "test": 1,
+          "journey": 1,
+          "property": 1,
+          "dto": 1,
+          "screen": 1,
+          "hook": 1,
+          "api": 1,
+          "model": 1
+        },
+        "obligations": [],
+        "edges": []
+      },
+      "runId": "39df34aa-3ad0-45f3-b5fb-0fb7f0b3abec"
     }
   ],
   "source": {
@@ -510,6 +678,7 @@
     "symbol": "COVERAGE_EDGES in benchmarks/evidence/src/EvidenceBenchmarkCoverage.ts",
     "method": "Thirteen reference-graph edges read from each completed Plain workspace of round two, composed so serial hops multiply and branches average. See ttsc#1088 for the derivation.",
     "precision": "Each requirement-rooted edge was counted twice, broad and narrow, and the lower rate kept; no requirement identifier appears in a Plain workspace, so its eligibility is a judgement and the two passes differed by up to a quarter on some denominators. Read a score as a whole percent. The per-subject inputs, their eligibility rules, their unreached members, and the judgements that could move a figure are retained beside this file as coverage-input-<subject>.round-two.json.",
-    "evidenceArm": "Complete by construction and never counted."
+    "evidenceArm": "Complete by construction and never counted.",
+    "erp": "Counted on a snapshot of the erp workspace taken while its cell was still running, so its figure moves when the cell completes. Its six requirement-rooted edges are counted over the 253 families the requirements document declares, not its 1487 anchors."
   }
 }

--- a/benchmarks/evidence/aggregate/summary.json
+++ b/benchmarks/evidence/aggregate/summary.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-12T07:21:22.421Z",
+  "generatedAt": "2026-08-12T07:28:32.835Z",
   "origin": "samchon/ttsc",
   "cells": [
     {
@@ -1600,14 +1600,14 @@
       "status": "running",
       "stage": "overall-remind-1",
       "launchedAt": "2026-08-09T18:17:34.421Z",
-      "tokens": 2787341871,
+      "tokens": 2794568118,
       "tokenUsage": {
-        "totalTokens": 2787341871,
-        "inputTokens": 2782866997,
-        "cachedInputTokens": 2730154752,
+        "totalTokens": 2794568118,
+        "inputTokens": 2790076128,
+        "cachedInputTokens": 2737145600,
         "cacheWriteInputTokens": 0,
-        "outputTokens": 4474874,
-        "reasoningOutputTokens": 1053527
+        "outputTokens": 4491990,
+        "reasoningOutputTokens": 1055225
       },
       "inspection": {
         "attempts": 11,
@@ -1627,19 +1627,19 @@
         "pricingAsOf": "2026-08-01",
         "priceSource": "https://openrouter.ai/api/v1/models",
         "currency": "USD",
-        "amountUsd": 34.54871436,
-        "requests": 19770,
-        "shortContextRequests": 19770,
+        "amountUsd": 34.65072074,
+        "requests": 19818,
+        "shortContextRequests": 19818,
         "longContextRequests": 0,
         "longContextThresholdTokens": 272000,
         "replayedUpdates": 0
       },
       "suspendedMs": 0,
       "suspensions": [],
-      "workElapsedMs": 217268944.97810003,
+      "workElapsedMs": 217692219.73070002,
       "worktree": {
         "files": 452,
-        "additions": 85210,
+        "additions": 85219,
         "deletions": 136
       },
       "reviewVerdicts": [
@@ -1814,7 +1814,7 @@
           "name": "backend-start",
           "tokens": 544228917,
           "elapsedMs": 55121000,
-          "tokenPercent": 20,
+          "tokenPercent": 19,
           "timePercent": 25
         },
         {
@@ -1917,8 +1917,8 @@
         },
         {
           "name": "overall-remind-1",
-          "tokens": 1056615564,
-          "elapsedMs": 72795456.31280002,
+          "tokens": 1063841811,
+          "elapsedMs": 73218731.0654,
           "tokenPercent": 38,
           "timePercent": 34
         }


### PR DESCRIPTION
Every Plain subject of round two now carries a measured coverage figure.

## Coverage

| Subject | Plain | Evidence | Requirement families | Screens | Journeys |
| --- | ---: | ---: | ---: | ---: | ---: |
| todo | 85.5% | 100% | 44 | 44/44 | 40/44 |
| reddit | 80.3% | 100% | 190 | 172/174 | 97/190 |
| shopping | 63.1% | 100% | 427 | 416/427 | 59/427 |
| erp | 50.0% | 100% | 253 | 19/98 | 8/105 |

The Evidence arm is complete by construction and never counted: its plugin fails the build on a missing edge, so a workspace that ships has every edge.

## erp's thirteen edges

| Edge | Reached | Rate |
| --- | ---: | ---: |
| requirementToModel | 100/101 | 99.0% |
| requirementToOperation | 97/98 | 99.0% |
| requirementToDto | 189/192 | 98.4% |
| requirementToTest | 236/252 | 93.7% |
| requirementToScreen | 19/98 | 19.4% |
| requirementToJourney | 8/105 | 7.6% |
| modelToOperation | 135/135 | 100% |
| modelToDto | 133/135 | 98.5% |
| accessorToTest | 432/445 | 97.1% |
| accessorToHook | 424/445 | 95.3% |
| hookToScreen | 22/439 | 5.0% |
| screenToJourney | 13/13 | 100% |
| columnToProperty | 928/1316 | 70.5% |

The backend edges sit between 93.7% and 100%. What the score is made of is the two frontend ones: thirteen screens over 445 accessors, and of the 439 exported hooks only 22 called by a screen. All seventeen authored hooks are called; of the generated per-accessor wrappers, five.

## How it was counted

The cell is still running, so the count is taken on a snapshot copied without `node_modules`, build output, and logs. A first attempt to count the live tree watched the schema grow from 133 to 135 models and the accessors from 441 to 445 mid-read. **The figure moves when the cell completes and is remeasured then.**

The six requirement-rooted edges are counted over the 253 families the requirements document declares, not its 1487 anchors: a family shares one obligation, and the workspace's own `screen-plan.mjs` rolls an H3 decision up to its H2. Each was counted twice, broad and narrow, and the lower rate kept.

Three figures could move under a different reading, and each is recorded beside the count:

- `requirementToTest` — both passes give 236/252 but name different families in four places. No test creates a second organization and no test issues a concurrent request, so `REQ-NFR-TENANT` and `REQ-RULE-CONCURRENCY` cannot be settled as written.
- `modelToDto` — `lots` and `serials` count as reached on their keys alone. No `ILot` or `ISerial` exists; only `lots.id` and `serials.code` escape, as `lotId` and `serialCode` on movement and quarantine types. A rule requiring non-key state to be published makes this 131.
- `screenToJourney` — 13/13 is a source-level count. The journey's Operations step waits for text the screen does not render, so the case times out there and the last four screens never execute; the executable count is 9. The workspace's own verification note concedes the live suite was never run.

`columnToProperty` is a point estimate of 928 inside a band of 921 to 931.

## What the count found in the workspace

- `REQ-DOM-ASSET-CATEGORY` has no model, no column on `assets`, and the name appears nowhere under `packages`.
- `lots` are never created and `serials` are only updated, never created.
- `screen-plan.mjs` reports 1487/1487 and exits 0 while 79 of 98 eligible families have no screen.
- 388 of 1316 scalar columns never reach a response, among them 116 `created_at`, 101 `organization_id`, and 39 `updated_at`.

## Where the cell is

`erp plain` is in `overall-remind-1`, the first supplementation of its Overall scope, 20h 20m and 1064M tokens into that one objective, at 2795M tokens and 60h 28m overall. Its Overall review has one retained verdict; backend and frontend each spent all four supplementations and failed every one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XagFAwbVR1RMDpxMWnuct
