### PR TITLE
feat(ttsx): add typed Node preload registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ npx ttsc --watch        # rebuild on save
 
 `ttsx` runs a file the way `tsx` or `ts-node` does, but it type-checks the whole project first, so a type error stops the run before anything executes.
 
+Preload the same checked runtime when Node or a test runner owns the process:
+
+```bash
+node --require ttsc/register src/index.ts
+mocha --require ttsc/register --extension ts,tsx "test/**/*.ts"
+```
+
+`ttsc/register` discovers the nearest `tsconfig.json` for each TypeScript root, applies its plugins, and refuses to execute when the project does not type-check.
+
 That covers the CLI. The integrations each have a short guide:
 
 - [`@ttsc/unplugin`](https://ttsc.dev/docs/setup/unplugin): Vite, Rollup, Rolldown, esbuild, webpack, Rspack, Next.js, Turbopack, Farm, and Bun.

--- a/packages/ttsc/package.json
+++ b/packages/ttsc/package.json
@@ -18,6 +18,10 @@
       "types": "./src/internal/projectInputPathIdentity.ts",
       "default": "./lib/internal/projectInputPathIdentity.js"
     },
+    "./register": {
+      "types": "./src/register.ts",
+      "default": "./lib/register.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -31,6 +35,10 @@
       "./path-identity": {
         "types": "./lib/internal/projectInputPathIdentity.d.ts",
         "default": "./lib/internal/projectInputPathIdentity.js"
+      },
+      "./register": {
+        "types": "./lib/register.d.ts",
+        "default": "./lib/register.js"
       },
       "./package.json": "./package.json"
     }
@@ -69,7 +77,7 @@
     "@ttsc/win32-x64": "workspace:*",
     "@ttsc/win32-arm64": "workspace:*"
   },
-  "sideEffects": false,
+  "sideEffects": ["./lib/register.js", "./src/register.ts"],
   "files": [
     "README.md",
     "cmd",

--- a/packages/ttsc/src/compiler/internal/resolveEmittedJavaScript.ts
+++ b/packages/ttsc/src/compiler/internal/resolveEmittedJavaScript.ts
@@ -20,6 +20,8 @@ import { isOutsideRelativePath } from "./paths";
  * Returns `null` when no matching output file is found on disk.
  */
 export function resolveEmittedJavaScript(options: {
+  /** Skip trailing-stem recovery when exact source ownership is required. */
+  allowStemFallback?: boolean;
   /** Pre-computed list of emitted paths; when absent `outDir` is scanned. */
   emittedFiles?: readonly string[];
   outDir: string;
@@ -43,6 +45,10 @@ export function resolveEmittedJavaScript(options: {
     if (fs.existsSync(candidate)) {
       return candidate;
     }
+  }
+
+  if (options.allowStemFallback === false) {
+    return null;
   }
 
   // Score the pre-computed emit list first (cheap). When it yields nothing —

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -10,8 +10,6 @@ import { createFilesystemPathIdentityContext } from "../../internal/projectInput
 import type { TtscCommonOptions } from "../../structures/internal/TtscCommonOptions";
 import { type OwningModuleOptions, projectModuleOptions } from "./runtimeHooks";
 
-/** Subdirectory name that isolates concurrent ttsx processes by PID. */
-const PROCESS_CACHE_KEY = String(process.pid);
 /**
  * Maximum number of ancestor directories above the project root that the
  * virtual filesystem overlay mirrors. Three levels covers the common monorepo
@@ -32,6 +30,8 @@ export function prepareExecution(
   options: TtscCommonOptions & {
     cacheDir?: string;
     project?: string;
+    /** Internal cache key for more than one checked entry in this process. */
+    runtimeCacheKey?: string;
   } = {},
 ): {
   cleanupDir: string;
@@ -148,6 +148,19 @@ function resolveEntrySpelling(cwd: string, entryFile: string): string {
 }
 
 /**
+ * Directory-safe identity for one prepared runtime. Direct `ttsx` retains its
+ * historical PID directory; the public preload supplies a distinct key for
+ * every late TypeScript root so one preparation cannot erase another's emit.
+ */
+function resolveRuntimeCacheKey(runtimeCacheKey: string | undefined): string {
+  const key = runtimeCacheKey ?? String(process.pid);
+  if (!/^[A-Za-z0-9._-]+$/.test(key) || key === "." || key === "..") {
+    throw new Error(`ttsx: invalid runtime cache key ${JSON.stringify(key)}`);
+  }
+  return key;
+}
+
+/**
  * @param discoveryFile - The entry as the user named it. Project discovery
  *   walks up from here, so it must not be retargeted through a symlink.
  */
@@ -171,7 +184,8 @@ function createProjectContext(
   const cacheDir =
     explicitCacheDir ??
     path.join(root, "node_modules", ".cache", "ttsc", "ttsx");
-  const processDir = path.join(cacheDir, "project", PROCESS_CACHE_KEY);
+  const runtimeCacheKey = resolveRuntimeCacheKey(options.runtimeCacheKey);
+  const processDir = path.join(cacheDir, "project", runtimeCacheKey);
   const virtualRoot = path.join(processDir, "fs");
   // Resolved once: it now costs a realpath (and, for a missing directory on
   // Windows, a case-sensitivity probe) rather than a string join.
@@ -181,6 +195,7 @@ function createProjectContext(
     tsconfig,
     root,
     cacheDir,
+    runtimeCacheKey,
     processDir,
     pluginCacheDir: explicitCacheDir,
     virtualRoot,
@@ -361,7 +376,7 @@ function buildEntryProject(
   const rootDir = commonAncestorDirectory(path.dirname(entry), context.root);
   const tsconfig = path.join(
     context.root,
-    `.ttsx-entry.${PROCESS_CACHE_KEY}.tsconfig.json`,
+    `.ttsx-entry.${context.runtimeCacheKey}.tsconfig.json`,
   );
   fs.writeFileSync(
     tsconfig,
@@ -430,8 +445,8 @@ function buildEntryProject(
       fs.rmSync(tsconfig, { force: true });
     } catch {
       // Best effort: a leftover synthesized tsconfig must not mask a build
-      // failure, and it is PID-scoped so it can never be mistaken for a real
-      // project config.
+      // failure, and it is runtime-scoped so it can never be mistaken for a
+      // real project config.
     }
   }
 }
@@ -575,6 +590,9 @@ function isDirectorySymlinkTarget(realEntry: string): boolean {
  */
 function collectLinkDirectories(projectRoot: string): string[] {
   const out: string[] = [];
+  const identities = createFilesystemPathIdentityContext({
+    throwOnRealpathError: false,
+  });
   let current = projectRoot;
   for (let depth = 0; depth <= MAX_VIRTUAL_PARENT_DEPTH; depth += 1) {
     out.push(current);
@@ -586,7 +604,7 @@ function collectLinkDirectories(projectRoot: string): string[] {
       break;
     }
     const parent = path.dirname(current);
-    if (parent === current || isUnsafeVirtualParent(parent)) {
+    if (parent === current || isUnsafeVirtualParent(parent, identities)) {
       break;
     }
     current = parent;
@@ -594,10 +612,19 @@ function collectLinkDirectories(projectRoot: string): string[] {
   return out.reverse();
 }
 
-function isUnsafeVirtualParent(directory: string): boolean {
-  const resolved = path.resolve(directory);
-  const root = path.parse(resolved).root;
-  return resolved === root || resolved === path.resolve(os.tmpdir());
+/**
+ * Whether mirroring `directory` would reach a filesystem or temporary root.
+ * Identity comparison is required on Windows, where `os.tmpdir()` can carry an
+ * 8.3 component while a project created below it is returned in long spelling.
+ */
+function isUnsafeVirtualParent(
+  directory: string,
+  identities: ReturnType<typeof createFilesystemPathIdentityContext>,
+): boolean {
+  const resolved = identities.resolve(directory);
+  const root = identities.resolve(path.parse(resolved.path).root);
+  const temporaryRoot = identities.resolve(os.tmpdir());
+  return resolved.key === root.key || resolved.key === temporaryRoot.key;
 }
 
 /**

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -38,6 +38,7 @@ export function prepareExecution(
   emitDir: string;
   emittedFiles?: readonly string[];
   entryFile: string;
+  entrySource: string;
   moduleOptions: OwningModuleOptions;
   projectRoot: string;
   rootDir: string;
@@ -74,6 +75,7 @@ export function prepareExecution(
       emitDir: context.emitDir,
       emittedFiles: context.emittedFiles ?? undefined,
       entryFile: emittedEntry,
+      entrySource: entry,
       moduleOptions: context.moduleOptions,
       projectRoot: context.root,
       rootDir: context.runtimeRootDir,

--- a/packages/ttsc/src/launcher/internal/runTtsx.ts
+++ b/packages/ttsc/src/launcher/internal/runTtsx.ts
@@ -278,6 +278,8 @@ function runPreparedEntry(
         depCacheDir,
         emitDir: execution.emitDir,
         emittedFiles: execution.emittedFiles,
+        entryFile: execution.entryFile,
+        entrySource: execution.entrySource,
         moduleOptions: execution.moduleOptions,
         projectRoot: execution.projectRoot,
         rootDir: execution.rootDir,

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -603,15 +603,22 @@ function resolveServedSource(
   prepareAsEntry: boolean = false,
 ): ServedSource {
   const real = realPath(filename);
+  // Only the public preload can prepare a newly discovered root. Direct ttsx
+  // has one pre-built manifest and historically relies on trailing-stem
+  // recovery when Windows presents the same source through its short and long
+  // temp-path spellings (the lint TypeScript-config loader is one such case).
+  // Treating that boundary as prepare-only would discard the existing emit and
+  // feed ESM source into CommonJS interop, producing ERR_REQUIRE_CYCLE_MODULE.
+  const shouldPrepare = prepareAsEntry && prepareRuntimeEntry !== undefined;
   // A JavaScript-to-TypeScript boundary is a new checked root unless an
   // existing manifest proves exact ownership. Trailing-stem recovery is not
   // ownership evidence: two out-of-include `index.ts` roots can otherwise map
   // to the first manifest's `index.js`, skipping the second root's diagnostics.
-  let served = serveEntryEmit(real, !prepareAsEntry);
+  let served = serveEntryEmit(real, !shouldPrepare);
   if (served !== null) {
     return withInlineSourceMap(served);
   }
-  if (prepareAsEntry && prepareRuntimeEntry !== undefined) {
+  if (shouldPrepare) {
     registeredManifests.push(prepareRuntimeEntry(real));
     served = serveEntryEmit(real);
     if (served === null) {

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -609,17 +609,17 @@ function resolveServedSource(
   // temp-path spellings (the lint TypeScript-config loader is one such case).
   // Treating that boundary as prepare-only would discard the existing emit and
   // feed ESM source into CommonJS interop, producing ERR_REQUIRE_CYCLE_MODULE.
-  const shouldPrepare = prepareAsEntry && prepareRuntimeEntry !== undefined;
+  const prepareEntry = prepareAsEntry ? prepareRuntimeEntry : undefined;
   // A JavaScript-to-TypeScript boundary is a new checked root unless an
   // existing manifest proves exact ownership. Trailing-stem recovery is not
   // ownership evidence: two out-of-include `index.ts` roots can otherwise map
   // to the first manifest's `index.js`, skipping the second root's diagnostics.
-  let served = serveEntryEmit(real, !shouldPrepare);
+  let served = serveEntryEmit(real, prepareEntry === undefined);
   if (served !== null) {
     return withInlineSourceMap(served);
   }
-  if (shouldPrepare) {
-    registeredManifests.push(prepareRuntimeEntry(real));
+  if (prepareEntry !== undefined) {
+    registeredManifests.push(prepareEntry(real));
     served = serveEntryEmit(real);
     if (served === null) {
       throw new Error(`ttsx: prepared entry emit not found for ${filename}`);

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -126,6 +126,10 @@ export interface RuntimeManifest {
   emitDir: string;
   /** Emitted file list from the entry build, for source→output matching. */
   emittedFiles?: readonly string[];
+  /** Physical TypeScript root whose checked preparation created this manifest. */
+  entrySource?: string;
+  /** Exact JavaScript emitted for `entrySource`. */
+  entryFile?: string;
   /**
    * The entry tsconfig's `module` and `target`, deciding emit CJS/ESM per file.
    * `target` is not decoration: an absent `module` makes tsgo derive the module
@@ -334,9 +338,7 @@ function installCommonJsHook(): void {
  */
 export function entryModuleFormat(entryFile: string): "module" | "commonjs" {
   const real = realPath(entryFile);
-  const owner = runtimeManifests().find(
-    (candidate) => entryEmitPath(candidate, real) !== null,
-  );
+  const owner = findEntryEmit(real)?.manifest;
   return moduleFormat(
     entryFile,
     owner === undefined ? null : (owner.moduleOptions ?? {}),
@@ -543,10 +545,9 @@ function owningModuleOptions(filename: string): OwningModuleOptions | null {
     return null;
   }
   const real = realPath(filename);
-  for (const candidate of runtimeManifests()) {
-    if (entryEmitPath(candidate, real) !== null) {
-      return candidate.moduleOptions ?? {};
-    }
+  const owner = findEntryEmit(real)?.manifest;
+  if (owner !== undefined) {
+    return owner.moduleOptions ?? {};
   }
   const tsconfig = nearestTsconfig(real);
   if (tsconfig === null) {
@@ -602,7 +603,11 @@ function resolveServedSource(
   prepareAsEntry: boolean = false,
 ): ServedSource {
   const real = realPath(filename);
-  let served = serveEntryEmit(real);
+  // A JavaScript-to-TypeScript boundary is a new checked root unless an
+  // existing manifest proves exact ownership. Trailing-stem recovery is not
+  // ownership evidence: two out-of-include `index.ts` roots can otherwise map
+  // to the first manifest's `index.js`, skipping the second root's diagnostics.
+  let served = serveEntryEmit(real, !prepareAsEntry);
   if (served !== null) {
     return withInlineSourceMap(served);
   }
@@ -1252,20 +1257,59 @@ function isIdentifierName(name: string): boolean {
  * `rootDir` cannot have a mirrored emit, so it falls through to the dependency
  * paths.
  */
-function serveEntryEmit(real: string): ServedSource | null {
-  for (const candidate of runtimeManifests()) {
-    const emitted = entryEmitPath(candidate, real);
-    if (emitted === null) {
-      continue;
-    }
-    const source = readFileOrNull(emitted);
-    if (source !== null) {
-      return {
-        emittedFile: emitted,
-        moduleOptions: candidate.moduleOptions ?? {},
+function serveEntryEmit(
+  real: string,
+  allowStemFallback: boolean = true,
+): ServedSource | null {
+  const owner = findEntryEmit(real, allowStemFallback);
+  if (owner === null) {
+    return null;
+  }
+  const source = readFileOrNull(owner.emittedFile);
+  return source === null
+    ? null
+    : {
+        emittedFile: owner.emittedFile,
+        moduleOptions: owner.manifest.moduleOptions ?? {},
         source,
         sourceFile: real,
       };
+}
+
+/**
+ * Find the manifest that owns `real`. Explicit prepared roots win, followed by
+ * exact mirrored paths across every manifest. Only then may legacy stem
+ * recovery run, so one manifest's approximate match cannot shadow another's
+ * exact emit.
+ */
+function findEntryEmit(
+  real: string,
+  allowStemFallback: boolean = true,
+): { emittedFile: string; manifest: RuntimeManifest } | null {
+  const manifests = runtimeManifests();
+  for (const candidate of manifests) {
+    if (
+      candidate.entrySource !== undefined &&
+      candidate.entryFile !== undefined &&
+      realPath(candidate.entrySource) === real &&
+      fs.existsSync(candidate.entryFile)
+    ) {
+      return { emittedFile: candidate.entryFile, manifest: candidate };
+    }
+  }
+  for (const candidate of manifests) {
+    const emitted = entryEmitPath(candidate, real, false);
+    if (emitted !== null) {
+      return { emittedFile: emitted, manifest: candidate };
+    }
+  }
+  if (!allowStemFallback) {
+    return null;
+  }
+  for (const candidate of manifests) {
+    const emitted = entryEmitPath(candidate, real, true);
+    if (emitted !== null) {
+      return { emittedFile: emitted, manifest: candidate };
     }
   }
   return null;
@@ -1276,17 +1320,25 @@ function serveEntryEmit(real: string): ServedSource | null {
  * project did not emit it. Shared with `owningModuleOptions` so "the entry
  * project owns this file" means exactly one thing in both places.
  */
-function entryEmitPath(m: RuntimeManifest, real: string): string | null {
-  let manifestCache = entryEmitPathCache.get(m);
+function entryEmitPath(
+  m: RuntimeManifest,
+  real: string,
+  allowStemFallback: boolean = true,
+): string | null {
+  const cache = allowStemFallback
+    ? entryEmitPathCache
+    : exactEntryEmitPathCache;
+  let manifestCache = cache.get(m);
   if (manifestCache === undefined) {
     manifestCache = new Map<string, string | null>();
-    entryEmitPathCache.set(m, manifestCache);
+    cache.set(m, manifestCache);
   }
   if (manifestCache.has(real)) {
     return manifestCache.get(real) ?? null;
   }
   const resolved = isWithin(real, m.rootDir)
     ? resolveEmittedJavaScript({
+        allowStemFallback,
         emittedFiles: m.emittedFiles,
         outDir: m.emitDir,
         projectRoot: m.rootDir,
@@ -1306,6 +1358,10 @@ function entryEmitPath(m: RuntimeManifest, real: string): string | null {
  * identity as well as the source path.
  */
 const entryEmitPathCache = new WeakMap<
+  RuntimeManifest,
+  Map<string, string | null>
+>();
+const exactEntryEmitPathCache = new WeakMap<
   RuntimeManifest,
   Map<string, string | null>
 >();

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -117,7 +117,7 @@ type NextLoad = (url: string, context: LoadContext) => LoadResult;
  * Runtime manifest written by `runTtsx` (the parent) and read once here. It
  * describes the already-built entry project so the hooks can serve its emit.
  */
-interface RuntimeManifest {
+export interface RuntimeManifest {
   /** Project root of the entry's owning tsconfig. */
   projectRoot: string;
   /** Source-tree root the emit mirrors (tsgo strips this prefix). */
@@ -136,25 +136,34 @@ interface RuntimeManifest {
   depCacheDir: string;
 }
 
-let manifestCache: RuntimeManifest | null | undefined;
+let environmentManifestCache: RuntimeManifest | null | undefined;
+const registeredManifests: RuntimeManifest[] = [];
 
-function manifest(): RuntimeManifest | null {
-  if (manifestCache !== undefined) {
-    return manifestCache;
+function environmentManifest(): RuntimeManifest | null {
+  if (environmentManifestCache !== undefined) {
+    return environmentManifestCache;
   }
   const file = process.env.TTSX_RUNTIME_MANIFEST;
   if (file === undefined || file.length === 0) {
-    manifestCache = null;
-    return manifestCache;
+    environmentManifestCache = null;
+    return environmentManifestCache;
   }
   try {
-    manifestCache = JSON.parse(
+    environmentManifestCache = JSON.parse(
       fs.readFileSync(file, "utf8"),
     ) as RuntimeManifest;
   } catch {
-    manifestCache = null;
+    environmentManifestCache = null;
   }
-  return manifestCache;
+  return environmentManifestCache;
+}
+
+/** Every checked entry emit available to this runtime, in ownership order. */
+function runtimeManifests(): readonly RuntimeManifest[] {
+  const inherited = environmentManifest();
+  return inherited === null
+    ? registeredManifests
+    : [inherited, ...registeredManifests];
 }
 
 /**
@@ -235,6 +244,12 @@ function assertNodeRuntimeSupport(): void {
 }
 
 let installed = false;
+let prepareRuntimeEntry: ((filename: string) => RuntimeManifest) | undefined;
+
+export interface RuntimeHookOptions {
+  /** Prepare and type-check a TypeScript root discovered after registration. */
+  prepareEntry?: (filename: string) => RuntimeManifest;
+}
 
 /**
  * Install the source-loading hooks on the current (main) thread. Idempotent:
@@ -249,7 +264,10 @@ let installed = false;
  * graph goes through `Module._extensions` — the canonical loader extension
  * point `ts-node`/`tsx` use for the same reason.
  */
-export function installRuntimeHooks(): void {
+export function installRuntimeHooks(options: RuntimeHookOptions = {}): void {
+  if (options.prepareEntry !== undefined) {
+    prepareRuntimeEntry = options.prepareEntry;
+  }
   if (installed) {
     return;
   }
@@ -277,17 +295,31 @@ function installCommonJsHook(): void {
       _extensions: Record<
         string,
         (
-          module: { _compile(source: string, filename: string): void },
+          module: {
+            _compile(source: string, filename: string): void;
+            parent?: { filename?: string | null } | null;
+          },
           filename: string,
         ) => void
       >;
     }
   )._extensions;
   const compile = (
-    module: { _compile(source: string, filename: string): void },
+    module: {
+      _compile(source: string, filename: string): void;
+      parent?: { filename?: string | null } | null;
+    },
     filename: string,
   ): void => {
-    module._compile(resolveServedSource(filename).source, filename);
+    const parent = module.parent?.filename;
+    module._compile(
+      resolveServedSource(
+        filename,
+        pathToFileURL(filename).href,
+        typeof parent !== "string" || !isTypeScriptSource(parent),
+      ).source,
+      filename,
+    );
   };
   for (const extension of [".ts", ".tsx", ".cts"]) {
     extensions[extension] = compile;
@@ -301,14 +333,20 @@ function installCommonJsHook(): void {
  * `require` or an ESM `import`.
  */
 export function entryModuleFormat(entryFile: string): "module" | "commonjs" {
-  const m = manifest();
+  const real = realPath(entryFile);
+  const owner = runtimeManifests().find(
+    (candidate) => entryEmitPath(candidate, real) !== null,
+  );
   return moduleFormat(
     entryFile,
-    m === null ? null : (m.moduleOptions ?? {}),
+    owner === undefined ? null : (owner.moduleOptions ?? {}),
   ) === "module"
     ? "module"
     : "commonjs";
 }
+
+/** TypeScript URLs resolved at a JavaScript-to-TypeScript entry boundary. */
+const runtimeEntryUrls = new Set<string>();
 
 /**
  * Rescue an extensionless or directory relative specifier that Node's resolver
@@ -322,10 +360,13 @@ function resolve(
   nextResolve: NextResolve,
 ): ResolveResult {
   try {
-    return rememberCommonJsNamedInterop(
-      restoreStrippedNodeBuiltinScheme(
-        specifier,
-        nextResolve(specifier, context),
+    return rememberRuntimeEntry(
+      rememberCommonJsNamedInterop(
+        restoreStrippedNodeBuiltinScheme(
+          specifier,
+          nextResolve(specifier, context),
+        ),
+        context,
       ),
       context,
     );
@@ -334,11 +375,31 @@ function resolve(
     if (rescued === null) {
       throw error;
     }
-    return rememberCommonJsNamedInterop(
-      { shortCircuit: true, url: rescued },
+    return rememberRuntimeEntry(
+      rememberCommonJsNamedInterop(
+        { shortCircuit: true, url: rescued },
+        context,
+      ),
       context,
     );
   }
+}
+
+/** Remember an ESM root until its synchronous load hook prepares the project. */
+function rememberRuntimeEntry(
+  result: ResolveResult,
+  context: ResolveContext,
+): ResolveResult {
+  if (
+    result.url.startsWith("file:") &&
+    isTypeScriptSource(fileURLToPath(result.url)) &&
+    (context.parentURL === undefined ||
+      !context.parentURL.startsWith("file:") ||
+      !isTypeScriptSource(fileURLToPath(context.parentURL)))
+  ) {
+    runtimeEntryUrls.add(result.url);
+  }
+  return result;
 }
 
 /**
@@ -386,7 +447,11 @@ function load(
   if (!isTypeScriptSource(filename)) {
     return nextLoad(url, context);
   }
-  const { format, source } = resolveRuntimeSource(filename, url);
+  const { format, source } = resolveRuntimeSource(
+    filename,
+    url,
+    runtimeEntryUrls.delete(url) || isProcessEntry(filename),
+  );
   return {
     format,
     shortCircuit: true,
@@ -397,8 +462,9 @@ function load(
 function resolveRuntimeSource(
   filename: string,
   url: string = pathToFileURL(filename).href,
+  prepareAsEntry: boolean = false,
 ): { format: string; source: string } {
-  const served = resolveServedSource(filename, url);
+  const served = resolveServedSource(filename, url, prepareAsEntry);
   const format = moduleFormat(filename, served.moduleOptions);
   return {
     format,
@@ -411,6 +477,16 @@ function resolveRuntimeSource(
           )
         : served.source,
   };
+}
+
+/** Whether `filename` is the TypeScript main module named on Node's argv. */
+function isProcessEntry(filename: string): boolean {
+  const entry = process.argv[1];
+  return (
+    entry !== undefined &&
+    isTypeScriptSource(entry) &&
+    realPath(path.resolve(entry)) === realPath(filename)
+  );
 }
 
 function rememberCommonJsNamedInterop(
@@ -467,9 +543,10 @@ function owningModuleOptions(filename: string): OwningModuleOptions | null {
     return null;
   }
   const real = realPath(filename);
-  const m = manifest();
-  if (m !== null && entryEmitPath(m, real) !== null) {
-    return m.moduleOptions ?? {};
+  for (const candidate of runtimeManifests()) {
+    if (entryEmitPath(candidate, real) !== null) {
+      return candidate.moduleOptions ?? {};
+    }
   }
   const tsconfig = nearestTsconfig(real);
   if (tsconfig === null) {
@@ -522,10 +599,19 @@ export function projectModuleOptions(
 function resolveServedSource(
   filename: string,
   url: string = pathToFileURL(filename).href,
+  prepareAsEntry: boolean = false,
 ): ServedSource {
   const real = realPath(filename);
-  const served = serveEntryEmit(real);
+  let served = serveEntryEmit(real);
   if (served !== null) {
+    return withInlineSourceMap(served);
+  }
+  if (prepareAsEntry && prepareRuntimeEntry !== undefined) {
+    registeredManifests.push(prepareRuntimeEntry(real));
+    served = serveEntryEmit(real);
+    if (served === null) {
+      throw new Error(`ttsx: prepared entry emit not found for ${filename}`);
+    }
     return withInlineSourceMap(served);
   }
   const built = serveDependencyEmit(real);
@@ -1167,23 +1253,22 @@ function isIdentifierName(name: string): boolean {
  * paths.
  */
 function serveEntryEmit(real: string): ServedSource | null {
-  const m = manifest();
-  if (m === null) {
-    return null;
-  }
-  const emitted = entryEmitPath(m, real);
-  if (emitted === null) {
-    return null;
-  }
-  const source = readFileOrNull(emitted);
-  return source === null
-    ? null
-    : {
+  for (const candidate of runtimeManifests()) {
+    const emitted = entryEmitPath(candidate, real);
+    if (emitted === null) {
+      continue;
+    }
+    const source = readFileOrNull(emitted);
+    if (source !== null) {
+      return {
         emittedFile: emitted,
-        moduleOptions: m.moduleOptions ?? {},
+        moduleOptions: candidate.moduleOptions ?? {},
         source,
         sourceFile: real,
       };
+    }
+  }
+  return null;
 }
 
 /**
@@ -1192,9 +1277,13 @@ function serveEntryEmit(real: string): ServedSource | null {
  * project owns this file" means exactly one thing in both places.
  */
 function entryEmitPath(m: RuntimeManifest, real: string): string | null {
-  const cached = entryEmitPathCache.get(real);
-  if (cached !== undefined) {
-    return cached;
+  let manifestCache = entryEmitPathCache.get(m);
+  if (manifestCache === undefined) {
+    manifestCache = new Map<string, string | null>();
+    entryEmitPathCache.set(m, manifestCache);
+  }
+  if (manifestCache.has(real)) {
+    return manifestCache.get(real) ?? null;
   }
   const resolved = isWithin(real, m.rootDir)
     ? resolveEmittedJavaScript({
@@ -1204,7 +1293,7 @@ function entryEmitPath(m: RuntimeManifest, real: string): string | null {
         sourceFile: real,
       })
     : null;
-  entryEmitPathCache.set(real, resolved);
+  manifestCache.set(real, resolved);
   return resolved;
 }
 
@@ -1212,10 +1301,14 @@ function entryEmitPath(m: RuntimeManifest, real: string): string | null {
  * Memo for `entryEmitPath`, because it is now on the `resolve` hook's path
  * through `owningModuleOptions` — once per import specifier — and a miss inside
  * `resolveEmittedJavaScript` walks the whole emit tree. The entry emit is
- * written once before the run starts and never changes under it, so one answer
- * per path is the only one there is.
+ * written once before the run starts and never changes under it. Registration
+ * can add several independent entry emits, so the manifest is part of the cache
+ * identity as well as the source path.
  */
-const entryEmitPathCache = new Map<string, string | null>();
+const entryEmitPathCache = new WeakMap<
+  RuntimeManifest,
+  Map<string, string | null>
+>();
 
 /**
  * True when `real` is `directory` itself or sits beneath it. Handles a root
@@ -1613,9 +1706,11 @@ function publishDependencyMeta(
 }
 
 function dependencyCacheRoot(): string {
-  const m = manifest();
-  return m !== null && m.depCacheDir.length !== 0
-    ? m.depCacheDir
+  const owner = runtimeManifests().find(
+    (candidate) => candidate.depCacheDir.length !== 0,
+  );
+  return owner !== undefined
+    ? owner.depCacheDir
     : path.join(os.tmpdir(), "ttsx-dep");
 }
 

--- a/packages/ttsc/src/register.ts
+++ b/packages/ttsc/src/register.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { prepareExecution } from "./launcher/internal/prepareExecution";
+import {
+  type RuntimeManifest,
+  installRuntimeHooks,
+} from "./launcher/internal/runtimeHooks";
+
+const cleanupDirectories = new Set<string>();
+let runtimeSequence = 0;
+
+/**
+ * Prepare one TypeScript root with the same checked compiler pipeline as ttsx,
+ * then expose its transient emit to the already-installed runtime hooks.
+ */
+function prepareEntry(filename: string): RuntimeManifest {
+  const execution = prepareExecution(filename, {
+    runtimeCacheKey: `register-${process.pid}-${++runtimeSequence}`,
+  });
+  cleanupDirectories.add(execution.cleanupDir);
+  return {
+    depCacheDir: path.join(execution.cleanupDir, "deps"),
+    emitDir: execution.emitDir,
+    emittedFiles: execution.emittedFiles,
+    moduleOptions: execution.moduleOptions,
+    projectRoot: execution.projectRoot,
+    rootDir: execution.rootDir,
+  };
+}
+
+/** Remove every register-owned transient emit when the JavaScript host exits. */
+function cleanupRuntimeOutputs(): void {
+  for (const directory of cleanupDirectories) {
+    try {
+      fs.rmSync(directory, { force: true, recursive: true });
+    } catch {
+      // Best effort: cleanup must not replace the host process exit status.
+    }
+  }
+  cleanupDirectories.clear();
+}
+
+process.once("exit", cleanupRuntimeOutputs);
+installRuntimeHooks({ prepareEntry });

--- a/packages/ttsc/src/register.ts
+++ b/packages/ttsc/src/register.ts
@@ -23,6 +23,8 @@ function prepareEntry(filename: string): RuntimeManifest {
     depCacheDir: path.join(execution.cleanupDir, "deps"),
     emitDir: execution.emitDir,
     emittedFiles: execution.emittedFiles,
+    entryFile: execution.entryFile,
+    entrySource: execution.entrySource,
     moduleOptions: execution.moduleOptions,
     projectRoot: execution.projectRoot,
     rootDir: execution.rootDir,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ catalogs:
       specifier: ^2.9.0
       version: 2.9.0
 
+overrides:
+  mocha>serialize-javascript: 7.0.3
+
 importers:
 
   .:
@@ -696,6 +699,9 @@ importers:
       '@types/node':
         specifier: catalog:utils
         version: 25.9.1
+      mocha:
+        specifier: ^11
+        version: 11.8.0
       ttsc:
         specifier: workspace:*
         version: link:../../packages/ttsc
@@ -1538,6 +1544,10 @@ packages:
   '@internationalized/string@3.2.8':
     resolution: {integrity: sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1923,6 +1933,10 @@ packages:
     resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3065,6 +3079,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   ansis@4.3.0:
     resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
     engines: {node: '>=14'}
@@ -3181,6 +3199,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browser-stdout@1.3.1:
+    resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -3231,6 +3252,10 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
@@ -3271,6 +3296,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
@@ -3300,6 +3329,10 @@ packages:
   clipboardy@4.0.0:
     resolution: {integrity: sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==}
     engines: {node: '>=18'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -3631,6 +3664,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@4.0.0:
+    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
+    engines: {node: '>=10'}
+
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
@@ -3700,6 +3737,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@7.0.0:
+    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+    engines: {node: '>=0.3.1'}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -3739,6 +3780,9 @@ packages:
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -3757,6 +3801,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -4007,6 +4054,14 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat@5.0.2:
+    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
+    hasBin: true
+
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
@@ -4015,6 +4070,10 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
 
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
@@ -4050,6 +4109,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -4090,6 +4153,11 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -4184,6 +4252,10 @@ packages:
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   hono@4.12.27:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
@@ -4377,6 +4449,14 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
+
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+
   is-plain-obj@3.0.0:
     resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==}
     engines: {node: '>=10'}
@@ -4416,6 +4496,9 @@ packages:
   istextorbinary@9.5.0:
     resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
     engines: {node: '>=4'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   javascript-natural-sort@0.7.1:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
@@ -4577,6 +4660,10 @@ packages:
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
@@ -4932,6 +5019,11 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
+  mocha@11.8.0:
+    resolution: {integrity: sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+
   monaco-editor@0.52.2:
     resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
 
@@ -5136,9 +5228,17 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   p-map@7.0.4:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
@@ -5217,6 +5317,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -5408,6 +5512,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -5483,6 +5591,10 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -5621,6 +5733,10 @@ packages:
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  serialize-javascript@7.0.3:
+    resolution: {integrity: sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==}
+    engines: {node: '>=20.0.0'}
 
   serve-index@1.9.2:
     resolution: {integrity: sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==}
@@ -5768,6 +5884,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
@@ -5792,6 +5912,10 @@ packages:
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
 
   strip-outer@1.0.1:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
@@ -6335,9 +6459,20 @@ packages:
   wicked-good-xpath@1.3.0:
     resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
 
+  workerpool@9.3.4:
+    resolution: {integrity: sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -6378,6 +6513,10 @@ packages:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
@@ -6386,12 +6525,28 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs-unparser@2.0.0:
+    resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
+    engines: {node: '>=10'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
   yauzl@3.3.1:
     resolution: {integrity: sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==}
     engines: {node: '>=12'}
 
   yazl@2.5.1:
     resolution: {integrity: sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -6568,7 +6723,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6948,6 +7103,15 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.21
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -7326,6 +7490,9 @@ snapshots:
   '@pagefind/windows-x64@1.5.2':
     optional: true
 
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
   '@polka/url@1.0.0-next.29': {}
 
   '@prisma/prisma-schema-wasm@7.10.0-2.d0368e25c88e68caa4d283b5f2d88d1b76ed9356': {}
@@ -7612,7 +7779,7 @@ snapshots:
       '@secretlint/resolver': 10.2.2
       '@secretlint/types': 10.2.2
       ajv: 8.20.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       rc-config-loader: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -7621,7 +7788,7 @@ snapshots:
     dependencies:
       '@secretlint/profiler': 10.2.2
       '@secretlint/types': 10.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       structured-source: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -7634,7 +7801,7 @@ snapshots:
       '@textlint/module-interop': 15.7.1
       '@textlint/types': 15.7.1
       chalk: 5.6.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       pluralize: 8.0.0
       strip-ansi: 7.2.0
       table: 6.9.0
@@ -7650,7 +7817,7 @@ snapshots:
       '@secretlint/profiler': 10.2.2
       '@secretlint/source-creator': 10.2.2
       '@secretlint/types': 10.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       p-map: 7.0.4
     transitivePeerDependencies:
       - supports-color
@@ -7817,7 +7984,7 @@ snapshots:
       '@textlint/resolver': 15.7.1
       '@textlint/types': 15.7.1
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       js-yaml: 4.3.1
       lodash: 4.18.1
       pluralize: 2.0.0
@@ -8217,7 +8384,7 @@ snapshots:
 
   '@typescript/vfs@1.6.4(typescript@5.9.3)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -8474,6 +8641,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.3: {}
+
   ansis@4.3.0: {}
 
   anymatch@3.1.3:
@@ -8562,7 +8731,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -8592,6 +8761,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browser-stdout@1.3.1: {}
 
   browserslist@4.28.2:
     dependencies:
@@ -8661,6 +8832,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  camelcase@6.3.0: {}
+
   caniuse-lite@1.0.30001793: {}
 
   ccount@2.0.1: {}
@@ -8717,6 +8890,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -8741,6 +8918,12 @@ snapshots:
       execa: 8.0.1
       is-wsl: 3.1.1
       is64bit: 2.0.0
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clone@1.0.4: {}
 
@@ -9061,9 +9244,13 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
+
+  decamelize@4.0.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -9118,6 +9305,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff@7.0.0: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -9160,6 +9349,8 @@ snapshots:
 
   duplexer@0.1.2: {}
 
+  eastasianwidth@0.2.0: {}
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -9175,6 +9366,8 @@ snapshots:
   email-addresses@5.0.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -9434,7 +9627,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -9523,7 +9716,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -9543,7 +9736,19 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat@5.0.2: {}
+
   follow-redirects@1.16.0: {}
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
 
   form-data@4.0.6:
     dependencies:
@@ -9574,6 +9779,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -9621,6 +9828,15 @@ snapshots:
       tslib: 2.8.1
 
   glob-to-regexp@0.4.1: {}
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   glob@13.0.6:
     dependencies:
@@ -9819,6 +10035,8 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  he@1.2.0: {}
+
   hono@4.12.27: {}
 
   hosted-git-info@4.1.0:
@@ -9870,7 +10088,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9897,7 +10115,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10029,6 +10247,10 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-path-inside@3.0.3: {}
+
+  is-plain-obj@2.1.0: {}
+
   is-plain-obj@3.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -10060,6 +10282,12 @@ snapshots:
       binaryextensions: 6.11.0
       editions: 6.22.0
       textextensions: 6.11.0
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   javascript-natural-sort@0.7.1: {}
 
@@ -10204,6 +10432,10 @@ snapshots:
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
 
   lodash-es@4.18.1: {}
 
@@ -10787,7 +11019,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -10850,6 +11082,30 @@ snapshots:
 
   mkdirp-classic@0.5.3:
     optional: true
+
+  mocha@11.8.0:
+    dependencies:
+      browser-stdout: 1.3.1
+      chokidar: 4.0.3
+      debug: 4.4.3(supports-color@8.1.1)
+      diff: 7.0.0
+      escape-string-regexp: 4.0.0
+      find-up: 5.0.0
+      glob: 10.5.0
+      he: 1.2.0
+      is-path-inside: 3.0.3
+      js-yaml: 4.3.1
+      log-symbols: 4.1.0
+      minimatch: 9.0.9
+      ms: 2.1.3
+      picocolors: 1.1.1
+      serialize-javascript: 7.0.3
+      strip-json-comments: 3.1.1
+      supports-color: 8.1.1
+      workerpool: 9.3.4
+      yargs: 17.7.3
+      yargs-parser: 21.1.1
+      yargs-unparser: 2.0.0
 
   monaco-editor@0.52.2: {}
 
@@ -11097,9 +11353,17 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
 
   p-map@7.0.4: {}
 
@@ -11188,6 +11452,11 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -11323,7 +11592,7 @@ snapshots:
 
   rc-config-loader@4.1.4:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       js-yaml: 4.3.1
       json5: 2.2.3
       require-from-string: 2.0.2
@@ -11417,6 +11686,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
 
@@ -11574,6 +11845,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   requires-port@1.0.0: {}
@@ -11668,7 +11941,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -11719,7 +11992,7 @@ snapshots:
       '@secretlint/formatter': 10.2.2
       '@secretlint/node': 10.2.2
       '@secretlint/profiler': 10.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       globby: 14.1.0
       read-pkg: 9.0.1
     transitivePeerDependencies:
@@ -11760,7 +12033,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -11773,6 +12046,8 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  serialize-javascript@7.0.3: {}
 
   serve-index@1.9.2:
     dependencies:
@@ -11954,7 +12229,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -11965,7 +12240,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -11990,6 +12265,12 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
 
   string_decoder@1.1.1:
     dependencies:
@@ -12016,6 +12297,8 @@ snapshots:
 
   strip-json-comments@2.0.1:
     optional: true
+
+  strip-json-comments@3.1.1: {}
 
   strip-outer@1.0.1:
     dependencies:
@@ -12667,11 +12950,25 @@ snapshots:
 
   wicked-good-xpath@1.3.0: {}
 
+  workerpool@9.3.4: {}
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 
@@ -12690,9 +12987,30 @@ snapshots:
 
   xmlbuilder@11.0.1: {}
 
+  y18n@5.0.8: {}
+
   yallist@4.0.0: {}
 
   yaml@2.9.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs-unparser@2.0.0:
+    dependencies:
+      camelcase: 6.3.0
+      decamelize: 4.0.0
+      flat: 5.0.2
+      is-plain-obj: 2.1.0
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yauzl@3.3.1:
     dependencies:
@@ -12702,6 +13020,8 @@ snapshots:
   yazl@2.5.1:
     dependencies:
       buffer-crc32: 0.2.13
+
+  yocto-queue@0.1.0: {}
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,11 @@ packages:
 # and Expo transformers as optional peers, which is what they are, and pnpm
 # installs them anyway; `peerDependenciesMeta.optional` does not exempt them.
 autoInstallPeers: false
+# Mocha 11 still ranges over serialize-javascript 6, whose serializer has a
+# code-injection advisory. Its public call shape is unchanged in the patched
+# release, so keep the real Mocha register defense without accepting that edge.
+overrides:
+  "mocha>serialize-javascript": 7.0.3
 catalogs:
   typescript:
     typescript: ^7.0.2

--- a/tests/test-ttsc/package.json
+++ b/tests/test-ttsc/package.json
@@ -14,6 +14,7 @@
     "@ttsc/strip": "workspace:*",
     "@ttsc/testing": "workspace:*",
     "@types/node": "catalog:utils",
+    "mocha": "^11",
     "ttsc": "workspace:*",
     "typescript": "catalog:typescript"
   }

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_register_runs_checked_commonjs_and_esm_node_entries.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_register_runs_checked_commonjs_and_esm_node_entries.ts
@@ -1,0 +1,56 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import { TTSX_REGISTER, linkTtscPackage } from "../../internal/ttsx-register";
+
+/**
+ * Verifies ttsx register runs checked CommonJS and ESM Node entries.
+ *
+ * The public preload has to own Node's main-module boundary in both module
+ * systems. The enum in each source also proves the compiler's emitted
+ * JavaScript ran instead of Node's erasable-syntax TypeScript stripping.
+ *
+ * 1. Create equivalent CommonJS and ESM consumer projects.
+ * 2. Run each with `node --require ttsc/register` and its `.ts` main file.
+ * 3. Assert both checked emits execute and print their module-specific result.
+ */
+export const test_ttsx_register_runs_checked_commonjs_and_esm_node_entries =
+  () => {
+    for (const fixture of [
+      { module: "commonjs", name: "commonjs", packageType: "commonjs" },
+      { module: "nodenext", name: "esm", packageType: "module" },
+    ]) {
+      const root = TestProject.createProject({
+        "package.json": JSON.stringify({
+          name: `ttsx-register-${fixture.name}`,
+          type: fixture.packageType,
+          version: "1.0.0",
+        }),
+        "tsconfig.json": JSON.stringify({
+          compilerOptions: {
+            module: fixture.module,
+            outDir: "dist",
+            rootDir: "src",
+            strict: true,
+            target: "ES2022",
+          },
+          include: ["src"],
+        }),
+        "src/main.ts": [
+          `enum RuntimeKind { Value = ${JSON.stringify(fixture.name)} }`,
+          `const value: string = RuntimeKind.Value;`,
+          `console.log(value);`,
+          "",
+        ].join("\n"),
+      });
+      linkTtscPackage(root);
+
+      const result = TestProject.spawn(
+        process.execPath,
+        ["--require", TTSX_REGISTER, "src/main.ts"],
+        { cwd: root },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout.trim(), fixture.name);
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_register_runs_multiple_out_of_include_mocha_roots.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_register_runs_multiple_out_of_include_mocha_roots.ts
@@ -30,11 +30,11 @@ export const test_ttsx_register_runs_multiple_out_of_include_mocha_roots =
       }),
       "one/tsconfig.json": projectConfig(),
       "one/src/value.ts": `export enum Value { One = "one" }\n`,
-      "one/test/first.ts": mochaTest("first", "one"),
-      "one/test/second.ts": mochaTest("second", "one"),
+      "one/test/first/index.ts": mochaTest("first", "one"),
+      "one/test/second/index.ts": mochaTest("second", "one"),
       "two/tsconfig.json": projectConfig(),
       "two/src/value.ts": `export enum Value { Two = "two" }\n`,
-      "two/test/third.ts": mochaTest("third", "two", true),
+      "two/test/third/index.ts": mochaTest("third", "two", true),
     });
     linkTtscPackage(root);
 
@@ -46,14 +46,17 @@ export const test_ttsx_register_runs_multiple_out_of_include_mocha_roots =
         TTSX_REGISTER,
         "--extension",
         "ts",
-        "one/test/first.ts",
-        "one/test/second.ts",
-        "two/test/third.ts",
+        "one/test/first/index.ts",
+        "one/test/second/index.ts",
+        "two/test/third/index.ts",
       ],
       { cwd: root },
     );
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /3 passing/);
+    for (const suite of ["first", "second", "third"]) {
+      assert.match(result.stdout, new RegExp(`\\b${suite}\\b`));
+    }
     for (const project of ["one", "two"]) {
       const runtimeRoot = path.join(
         root,

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_register_runs_multiple_out_of_include_mocha_roots.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_register_runs_multiple_out_of_include_mocha_roots.ts
@@ -1,0 +1,115 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  MOCHA_BIN,
+  TTSX_REGISTER,
+  linkTtscPackage,
+} from "../../internal/ttsx-register";
+
+/**
+ * Verifies ttsx register runs multiple out-of-include Mocha roots.
+ *
+ * Mocha is a JavaScript host that loads every TypeScript test after the public
+ * preload runs. Each excluded test therefore needs its own checked entry emit,
+ * and those emits must coexist until Mocha has loaded the complete suite.
+ *
+ * 1. Create two strict projects whose `include` covers only `src`, not tests.
+ * 2. Run real Mocha with three `.ts` tests and `--require ttsc/register`.
+ * 3. Assert all pass, same-project emits coexist, and exit cleans both caches.
+ */
+export const test_ttsx_register_runs_multiple_out_of_include_mocha_roots =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({
+        name: "ttsx-register-mocha",
+        type: "commonjs",
+        version: "1.0.0",
+      }),
+      "one/tsconfig.json": projectConfig(),
+      "one/src/value.ts": `export enum Value { One = "one" }\n`,
+      "one/test/first.ts": mochaTest("first", "one"),
+      "one/test/second.ts": mochaTest("second", "one"),
+      "two/tsconfig.json": projectConfig(),
+      "two/src/value.ts": `export enum Value { Two = "two" }\n`,
+      "two/test/third.ts": mochaTest("third", "two", true),
+    });
+    linkTtscPackage(root);
+
+    const result = TestProject.spawn(
+      process.execPath,
+      [
+        MOCHA_BIN,
+        "--require",
+        TTSX_REGISTER,
+        "--extension",
+        "ts",
+        "one/test/first.ts",
+        "one/test/second.ts",
+        "two/test/third.ts",
+      ],
+      { cwd: root },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /3 passing/);
+    for (const project of ["one", "two"]) {
+      const runtimeRoot = path.join(
+        root,
+        project,
+        "node_modules",
+        ".cache",
+        "ttsc",
+        "ttsx",
+        "project",
+      );
+      assert.deepEqual(
+        fs.existsSync(runtimeRoot) ? fs.readdirSync(runtimeRoot) : [],
+        [],
+      );
+    }
+  };
+
+function projectConfig(): string {
+  return JSON.stringify({
+    compilerOptions: {
+      module: "commonjs",
+      outDir: "dist",
+      rootDir: "src",
+      strict: true,
+      target: "ES2022",
+    },
+    include: ["src"],
+  });
+}
+
+function mochaTest(
+  suite: string,
+  expected: string,
+  assertCoexistence: boolean = false,
+): string {
+  const coexistence = !assertCoexistence
+    ? ""
+    : [
+        `    const fs = require("node:fs");`,
+        `    const path = require("node:path");`,
+        `    const cache = (project: string) => path.join(process.cwd(), project, "node_modules", ".cache", "ttsc", "ttsx", "project");`,
+        `    if (fs.readdirSync(cache("one")).length !== 2) throw new Error("expected two coexisting roots in project one");`,
+        `    if (fs.readdirSync(cache("two")).length !== 1) throw new Error("expected one independent root in project two");`,
+      ].join("\n");
+  return [
+    `declare function describe(name: string, body: () => void): void;`,
+    `declare function it(name: string, body: () => void): void;`,
+    `declare function require(name: string): any;`,
+    `declare const process: { cwd(): string };`,
+    `enum Expected { Value = ${JSON.stringify(expected)} }`,
+    `describe(${JSON.stringify(suite)}, () => {`,
+    `  it("uses the checked emit", () => {`,
+    `    if (Expected.Value !== ${JSON.stringify(expected)}) throw new Error("wrong value");`,
+    coexistence,
+    `  });`,
+    `});`,
+    "",
+  ].join("\n");
+}

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_register_stops_diagnostics_before_entry_effects.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_register_stops_diagnostics_before_entry_effects.ts
@@ -1,0 +1,56 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { TTSX_REGISTER, linkTtscPackage } from "../../internal/ttsx-register";
+
+/**
+ * Verifies ttsx register stops diagnostics before entry effects.
+ *
+ * Installing the private runtime hook alone would compile a newly discovered
+ * source through the dependency lane, whose diagnostics are deliberately
+ * skipped. The public preload must instead establish the same checked entry
+ * gate as the ttsx CLI before any user statement can execute.
+ *
+ * 1. Create an included entry with a type error before a marker write.
+ * 2. Run it through `node --require ttsc/register` with an explicit cache.
+ * 3. Assert the diagnostic, absent marker, and cleaned runtime directory.
+ */
+export const test_ttsx_register_stops_diagnostics_before_entry_effects = () => {
+  const root = TestProject.commonJsProject({
+    "src/main.ts": [
+      `import fs from "node:fs";`,
+      `const marker = process.env.TTSX_REGISTER_MARKER!;`,
+      `const invalid: string = 123;`,
+      `fs.writeFileSync(marker, invalid);`,
+      "",
+    ].join("\n"),
+  });
+  linkTtscPackage(root);
+  const marker = path.join(root, "executed.txt");
+  const cacheDir = path.join(root, "node_modules", ".cache", "ttsc", "ttsx");
+
+  const result = TestProject.spawn(
+    process.execPath,
+    ["--require", TTSX_REGISTER, "src/main.ts"],
+    {
+      cwd: root,
+      env: {
+        TTSX_REGISTER_MARKER: marker,
+      },
+    },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /project check failed/);
+  assert.match(
+    result.stderr,
+    /Type 'number' is not assignable to type 'string'/,
+  );
+  assert.equal(fs.existsSync(marker), false);
+  const runtimeRoot = path.join(cacheDir, "project");
+  assert.deepEqual(
+    fs.existsSync(runtimeRoot) ? fs.readdirSync(runtimeRoot) : [],
+    [],
+  );
+};

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_register_stops_diagnostics_before_entry_effects.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_register_stops_diagnostics_before_entry_effects.ts
@@ -14,8 +14,9 @@ import { TTSX_REGISTER, linkTtscPackage } from "../../internal/ttsx-register";
  * gate as the ttsx CLI before any user statement can execute.
  *
  * 1. Create an included entry with a type error before a marker write.
- * 2. Run it through `node --require ttsc/register` with an explicit cache.
- * 3. Assert the diagnostic, absent marker, and cleaned runtime directory.
+ * 2. Assert the diagnostic, absent marker, and cleaned runtime directory.
+ * 3. Repeat through a JS host with same-basename out-of-include roots, proving the
+ *    first root's stem-matched emit cannot hide the second's diagnostic.
  */
 export const test_ttsx_register_stops_diagnostics_before_entry_effects = () => {
   const root = TestProject.commonJsProject({
@@ -53,4 +54,49 @@ export const test_ttsx_register_stops_diagnostics_before_entry_effects = () => {
     fs.existsSync(runtimeRoot) ? fs.readdirSync(runtimeRoot) : [],
     [],
   );
+
+  const repeatedRoot = TestProject.createProject({
+    "host.cjs": [
+      `require("./test/first/index.ts");`,
+      `require("./test/second/index.ts");`,
+      "",
+    ].join("\n"),
+    "package.json": JSON.stringify({ type: "commonjs" }),
+    "src/value.ts": `export const value = "included";\n`,
+    "test/first/index.ts": `console.log("FIRST");\n`,
+    "test/second/index.ts": [
+      `import fs from "node:fs";`,
+      `const invalid: string = 123;`,
+      `fs.writeFileSync(process.env.TTSX_REGISTER_MARKER!, invalid);`,
+      "",
+    ].join("\n"),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        module: "commonjs",
+        outDir: "dist",
+        rootDir: "src",
+        strict: true,
+        target: "ES2022",
+      },
+      include: ["src"],
+    }),
+  });
+  linkTtscPackage(repeatedRoot);
+  const repeatedMarker = path.join(repeatedRoot, "executed.txt");
+  const repeated = TestProject.spawn(
+    process.execPath,
+    ["--require", TTSX_REGISTER, "host.cjs"],
+    {
+      cwd: repeatedRoot,
+      env: { TTSX_REGISTER_MARKER: repeatedMarker },
+    },
+  );
+  assert.notEqual(repeated.status, 0);
+  assert.equal(repeated.stdout.trim(), "FIRST");
+  assert.match(repeated.stderr, /entry check failed/);
+  assert.match(
+    repeated.stderr,
+    /Type 'number' is not assignable to type 'string'/,
+  );
+  assert.equal(fs.existsSync(repeatedMarker), false);
 };

--- a/tests/test-ttsc/src/internal/ttsx-register.ts
+++ b/tests/test-ttsc/src/internal/ttsx-register.ts
@@ -1,0 +1,24 @@
+import { TestProject } from "@ttsc/testing";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+/** Public preload specifier exercised by the register end-to-end tests. */
+export const TTSX_REGISTER = "ttsc/register";
+
+/** Mocha's JavaScript entry, resolved from the test package that owns it. */
+export const MOCHA_BIN = createRequire(import.meta.url).resolve(
+  "mocha/bin/mocha.js",
+);
+
+/** Link the built workspace ttsc package into an isolated consumer project. */
+export function linkTtscPackage(root: string): void {
+  const modules = path.join(root, "node_modules");
+  const link = path.join(modules, "ttsc");
+  fs.mkdirSync(modules, { recursive: true });
+  fs.symlinkSync(
+    path.join(TestProject.WORKSPACE_ROOT, "packages", "ttsc"),
+    link,
+    "junction",
+  );
+}

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_ttsx_register_executes_source_plugin_output_end_to_end.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_ttsx_register_executes_source_plugin_output_end_to_end.ts
@@ -1,0 +1,38 @@
+import { SHARED_PLUGIN_CACHE_DIR } from "../../internal/plugin-cache";
+import {
+  assert,
+  copyProject,
+  goPath,
+  spawn,
+} from "../../internal/plugin-corpus";
+import { TTSX_REGISTER, linkTtscPackage } from "../../internal/ttsx-register";
+
+/**
+ * Verifies plugin corpus: ttsx register executes source plugin output.
+ *
+ * Plain TypeScript execution cannot prove the preload reused ttsx's compiler
+ * preparation. This fixture's Go-source transform rewrites the runtime value,
+ * so its output pins the complete plugin build and transformed-emit path.
+ *
+ * 1. Copy the native Go-source plugin fixture and link the workspace package.
+ * 2. Run its TypeScript entry with `node --require ttsc/register`.
+ * 3. Assert the transformed uppercase value is the code that executes.
+ */
+export const test_plugin_corpus_ttsx_register_executes_source_plugin_output_end_to_end =
+  () => {
+    const root = copyProject("go-source-plugin");
+    linkTtscPackage(root);
+    const result = spawn(
+      process.execPath,
+      ["--require", TTSX_REGISTER, "src/main.ts"],
+      {
+        cwd: root,
+        env: {
+          PATH: goPath(),
+          TTSC_CACHE_DIR: SHARED_PLUGIN_CACHE_DIR,
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "PLUGIN");
+  };

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_ttsx_register_executes_source_plugin_output_end_to_end.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_ttsx_register_executes_source_plugin_output_end_to_end.ts
@@ -2,29 +2,55 @@ import { SHARED_PLUGIN_CACHE_DIR } from "../../internal/plugin-cache";
 import {
   assert,
   copyProject,
+  fs,
   goPath,
+  path,
   spawn,
 } from "../../internal/plugin-corpus";
-import { TTSX_REGISTER, linkTtscPackage } from "../../internal/ttsx-register";
+import {
+  MOCHA_BIN,
+  TTSX_REGISTER,
+  linkTtscPackage,
+} from "../../internal/ttsx-register";
 
 /**
  * Verifies plugin corpus: ttsx register executes source plugin output.
  *
  * Plain TypeScript execution cannot prove the preload reused ttsx's compiler
  * preparation. This fixture's Go-source transform rewrites the runtime value,
- * so its output pins the complete plugin build and transformed-emit path.
+ * while real Mocha loads that root from outside the project's `include`, so its
+ * output pins the complete fallback, plugin build, and transformed-emit path.
  *
- * 1. Copy the native Go-source plugin fixture and link the workspace package.
- * 2. Run its TypeScript entry with `node --require ttsc/register`.
+ * 1. Copy the native Go-source plugin fixture and add an excluded entry root.
+ * 2. Load it through real Mocha with `--require ttsc/register`.
  * 3. Assert the transformed uppercase value is the code that executes.
  */
 export const test_plugin_corpus_ttsx_register_executes_source_plugin_output_end_to_end =
   () => {
     const root = copyProject("go-source-plugin");
     linkTtscPackage(root);
+    const testDir = path.join(root, "test");
+    fs.mkdirSync(testDir);
+    fs.writeFileSync(
+      path.join(testDir, "main.ts"),
+      [
+        `export const value: string = goUpper("plugin");`,
+        `console.log(value);`,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    makeFixtureReadSyntheticEntry(root);
     const result = spawn(
       process.execPath,
-      ["--require", TTSX_REGISTER, "src/main.ts"],
+      [
+        MOCHA_BIN,
+        "--require",
+        TTSX_REGISTER,
+        "--extension",
+        "ts",
+        "test/main.ts",
+      ],
       {
         cwd: root,
         env: {
@@ -34,5 +60,37 @@ export const test_plugin_corpus_ttsx_register_executes_source_plugin_output_end_
       },
     );
     assert.equal(result.status, 0, result.stderr);
-    assert.equal(result.stdout.trim(), "PLUGIN");
+    assert.match(result.stdout, /^PLUGIN$/m);
   };
+
+/** Make the fixture host honor the synthetic entry config used by ttsx. */
+function makeFixtureReadSyntheticEntry(root: string): void {
+  const source = path.join(root, "go-plugin", "main.go");
+  const original = fs.readFileSync(source, "utf8");
+  const modified = original
+    .replace(
+      `_ = fs.String("tsconfig", "", "")`,
+      `tsconfig := fs.String("tsconfig", "", "")`,
+    )
+    .replace(
+      `source := filepath.Join(root, "src", "main.ts")`,
+      [
+        `source := filepath.Join(root, "src", "main.ts")`,
+        `  if strings.Contains(filepath.Base(*tsconfig), ".ttsx-entry.") {`,
+        `    raw, readErr := os.ReadFile(*tsconfig)`,
+        `    if readErr != nil {`,
+        `      fmt.Fprintln(os.Stderr, readErr)`,
+        `      return 2`,
+        `    }`,
+        `    var config struct { Files []string }`,
+        `    if jsonErr := json.Unmarshal(raw, &config); jsonErr != nil || len(config.Files) != 1 {`,
+        `      fmt.Fprintln(os.Stderr, "go-source-plugin: invalid entry config")`,
+        `      return 2`,
+        `    }`,
+        `    source = config.Files[0]`,
+        `  }`,
+      ].join("\n"),
+    );
+  assert.notEqual(modified, original);
+  fs.writeFileSync(source, modified, "utf8");
+}

--- a/website/src/content/docs/ttsc/execute.mdx
+++ b/website/src/content/docs/ttsc/execute.mdx
@@ -16,6 +16,23 @@ npx ttsx src/index.ts
 
 Type errors stop execution. So do `@ttsc/lint` errors (warnings don't).
 
+## Register in Node and test runners
+
+When Node, Mocha, or another JavaScript tool owns the process, preload the ttsx runtime from the `ttsc` package:
+
+```bash
+node --require ttsc/register src/index.ts
+mocha --require ttsc/register --extension ts,tsx "test/**/*.ts"
+```
+
+The package is named `ttsc`, even though its typed execution command is `ttsx`, so the resolvable preload is `ttsc/register`. The short Node spelling `-r ttsc/register` is equivalent to `--require ttsc/register`.
+
+The preload installs the same runtime hooks as `ttsx`. When a TypeScript main module or a TypeScript file loaded by a JavaScript host first enters the runtime, `ttsc/register` discovers its nearest `tsconfig.json`, checks the project, applies configured plugins, and executes the compiler-owned JavaScript. A test file outside the config's `include` still inherits that config's compiler options and plugins, just like an out-of-include `ttsx` entry. A diagnostic stops that root before any of its statements execute.
+
+Several roots and tsconfigs can enter one runner process. Their temporary emits coexist for that process and are removed on exit. Register-owned output uses the same project-local ttsx cache as an ordinary run and stays temporary.
+
+Registration is a one-shot load contract, not watch mode. Editing a source after the host has loaded it does not invalidate Node's module cache or re-run the compiler. Restart the runner for a fresh check. To propagate the preload to Node child processes, put `--require ttsc/register` in `NODE_OPTIONS`.
+
 ## Scripts your tsconfig does not include
 
 `ttsc` and `ttsx` select different things from the same `tsconfig.json`. `ttsc` selects a **file set**: a project whose `include` is `["src"]` compiles only `src` into `outDir`, and a `clear.ts`, a `build/release.ts`, or a `lint.config.ts` sitting beside the tsconfig stays out of the output. `ttsx` selects an **entry**: it needs that project's compiler options, not its file list.


### PR DESCRIPTION
## Intent

Implement the typed Node preload requested in #1181 and discussed in [Discussion #1178](https://github.com/samchon/ttsc/discussions/1178).

The public surface will be `ttsc/register`. A TypeScript root entering from Node or a JavaScript runner such as Mocha will go through the same checked, plugin-aware preparation as a direct `ttsx` entry. The existing runtime dependency policy remains in place after that root gate.

## Campaign state

- Fixed baseline: `a781b883f2e0ff845e9ca7d29e08a256a14ffe1f`
- Discovery round 1: issue #1181 accepted and published
- Fresh discovery round 2: empty
- This initial commit is implementation-free and claims the issue before code changes

## Planned verification

- Direct Node preload for CommonJS and ESM roots
- Real Mocha preload, including out-of-`include` files
- Diagnostics stop execution before side effects
- Multiple roots/configurations coexist in one host process
- Native Go-source transform plugin output executes
- Package export resolution and existing ttsx regressions

Watch-mode invalidation remains explicitly outside this first contract.
