### PR TITLE
feat(website): publish Marp slide decks

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -847,6 +847,9 @@ importers:
         specifier: catalog:samchon
         version: 13.2.0(@types/node@20.19.41)(ttsc@packages+ttsc)
     devDependencies:
+      '@marp-team/marp-cli':
+        specifier: ^4.5.0
+        version: 4.5.0(typescript@5.9.3)
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
@@ -999,6 +1002,24 @@ packages:
 
   '@corex/deepmerge@4.0.43':
     resolution: {integrity: sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==}
+
+  '@csstools/postcss-is-pseudo-class@5.0.3':
+    resolution: {integrity: sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/selector-resolve-nested@3.1.0':
+    resolution: {integrity: sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss-selector-parser: ^7.0.0
+
+  '@csstools/selector-specificity@5.0.0':
+    resolution: {integrity: sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss-selector-parser: ^7.0.0
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -1680,6 +1701,28 @@ packages:
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
 
+  '@marp-team/marp-cli@4.5.0':
+    resolution: {integrity: sha512-ZOd9eVwxqx1yL6S6OpEkYKnOTeeWbVCSJaOx8e5lUCcA8jGf7NJU2XkDMkvDTk0wvxwhIdda8zriunhau+Gmrg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@marp-team/marp-core@4.4.0':
+    resolution: {integrity: sha512-YTiS0oIo25KiqjfMtDchTMc/uuFhR48weKNVw4QPPAM/9UQ71QI0JnDkC1qenJSmFPMlXQK72wQ8vlhmgQS3Cg==}
+    engines: {node: '>=18'}
+
+  '@marp-team/marpit-svg-polyfill@2.1.0':
+    resolution: {integrity: sha512-VqCoAKwv1HJdzZp36dDPxznz2JZgRjkVSSPHpCzk72G2N753F0HPKXjevdjxmzN6gir9bUGBgMD1SguWJIi11A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@marp-team/marpit': '>=0.5.0'
+    peerDependenciesMeta:
+      '@marp-team/marpit':
+        optional: true
+
+  '@marp-team/marpit@3.2.2':
+    resolution: {integrity: sha512-7LJ6vuAA1jovkTMso2MLyhdjqtJAzjievCAF2PpIqHGH7CFG0e3a0hXQ++zMXinUggKt0pbhqa/q8UEdcYq5Pw==}
+    engines: {node: '>=18'}
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
@@ -1929,6 +1972,11 @@ packages:
 
   '@prisma/prisma-schema-wasm@7.10.0-2.d0368e25c88e68caa4d283b5f2d88d1b76ed9356':
     resolution: {integrity: sha512-loEbWBr+xUSqtIYaoJCrIuDeVs/fSY29Efshp+3rrTgQtyEqJ2iGuLTt9XnRZYBUE+eWC8ps0nOblyckgBehJQ==}
+
+  '@puppeteer/browsers@2.13.2':
+    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@react-aria/focus@3.22.0':
     resolution: {integrity: sha512-ZfDOVuVhqDsM9mkNji3QUZ/d40JhlVgXrDkrfXylM1035QCrcTHN7m2DpbE95sU2A8EQb4wikvt5jM6K/73BPg==}
@@ -2468,6 +2516,9 @@ packages:
   '@theguild/remark-npm2yarn@0.3.3':
     resolution: {integrity: sha512-ma6DvR03gdbvwqfKx1omqhg9May/VYGdMHvTzB4VuxkyS7KzfZ/lzrj43hmcsggpMje0x7SADA/pcMph0ejRnA==}
 
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
   '@trivago/prettier-plugin-sort-imports@6.0.2':
     resolution: {integrity: sha512-3DgfkukFyC/sE/VuYjaUUWoFfuVjPK55vOFDsxD56XXynFMCZDYFogH2l/hDfOsQAm1myoU/1xByJ3tWqtulXA==}
     engines: {node: '>= 20'}
@@ -2732,6 +2783,9 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -3096,6 +3150,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -3113,6 +3171,14 @@ packages:
   azure-devops-node-api@12.5.0:
     resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -3123,6 +3189,43 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.8.0:
+    resolution: {integrity: sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==}
+    engines: {bare: '>=1.28.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.1:
+    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.5.2:
+    resolution: {integrity: sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3130,6 +3233,10 @@ packages:
     resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
@@ -3231,6 +3338,10 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
@@ -3271,6 +3382,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
@@ -3281,6 +3396,11 @@ packages:
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
+
+  chromium-bidi@14.0.0:
+    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
+    peerDependencies:
+      devtools-protocol: '*'
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -3300,6 +3420,10 @@ packages:
   clipboardy@4.0.0:
     resolution: {integrity: sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==}
     engines: {node: '>=18'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -3424,6 +3548,15 @@ packages:
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
+  cosmiconfig@9.0.2:
+    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -3434,6 +3567,14 @@ packages:
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  cssfilter@0.0.10:
+    resolution: {integrity: sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -3608,6 +3749,10 @@ packages:
     resolution: {integrity: sha512-QmU3lyEnbENQPo0M1F9BMu4s6cqNNp8iJA+b/HP2sSb7pf3dxwF3+EP1eO69rwBfH9kFJ1apmzrtogAmVt2/Xw==}
     engines: {node: '>=12'}
 
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
   dayjs@1.11.20:
     resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
@@ -3664,6 +3809,10 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
@@ -3699,6 +3848,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  devtools-protocol@0.0.1608973:
+    resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -3784,9 +3936,16 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -3845,6 +4004,11 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -3852,6 +4016,11 @@ packages:
   esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
     engines: {node: '>=6'}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -3892,12 +4061,19 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -3943,8 +4119,16 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -3962,6 +4146,9 @@ packages:
   faye-websocket@0.11.4:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
     engines: {node: '>=0.8.0'}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -4051,6 +4238,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -4059,9 +4250,17 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   gh-pages@6.3.0:
     resolution: {integrity: sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==}
@@ -4185,6 +4384,10 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  highlight.js@11.12.0:
+    resolution: {integrity: sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==}
+    engines: {node: '>=12.0.0'}
+
   hono@4.12.27:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
@@ -4275,6 +4478,10 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
@@ -4325,6 +4532,9 @@ packages:
 
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -4443,6 +4653,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -4476,6 +4689,10 @@ packages:
 
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  katex@0.17.0:
+    resolution: {integrity: sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==}
     hasBin: true
 
   keytar@7.9.0:
@@ -4567,6 +4784,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
@@ -4599,6 +4819,9 @@ packages:
   lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
+  lodash.kebabcase@4.1.1:
+    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
@@ -4630,6 +4853,10 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -4645,8 +4872,15 @@ packages:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
 
+  markdown-it-front-matter@0.2.4:
+    resolution: {integrity: sha512-25GUs0yjS2hLl8zAemVndeEzThB1p42yxuDEKbd4JlL3jiz+jsm6e56Ya8B0VREOkNxLYB4TTwaoPJ3ElMmW+w==}
+
   markdown-it@14.1.1:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
 
   markdown-table@3.0.4:
@@ -4926,6 +5160,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mj-context-menu@0.6.1:
     resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
 
@@ -4974,6 +5211,10 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
 
   next-sitemap@4.2.3:
     resolution: {integrity: sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==}
@@ -5152,6 +5393,14 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -5162,11 +5411,19 @@ packages:
     resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
     hasBin: true
 
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse-imports-exports@0.2.4:
     resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
@@ -5283,6 +5540,16 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
+  postcss-nesting@13.0.2:
+    resolution: {integrity: sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-selector-parser@7.1.5:
+    resolution: {integrity: sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==}
+    engines: {node: '>=4'}
+
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5311,6 +5578,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -5318,12 +5589,23 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
+
+  puppeteer-core@24.43.1:
+    resolution: {integrity: sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==}
+    engines: {node: '>=18'}
 
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
@@ -5408,6 +5690,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -5484,12 +5770,20 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -5709,8 +6003,20 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5763,6 +6069,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -5859,9 +6168,18 @@ packages:
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
+  tar-fs@3.1.3:
+    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   terminal-link@4.0.0:
     resolution: {integrity: sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==}
@@ -5914,6 +6232,9 @@ packages:
     resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
     engines: {node: '>=10'}
     hasBin: true
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -6043,6 +6364,9 @@ packages:
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
+
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
 
   typed-rest-client@1.8.11:
     resolution: {integrity: sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==}
@@ -6266,6 +6590,9 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  webdriver-bidi-protocol@0.4.1:
+    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
   webpack-bundle-analyzer@4.10.2:
     resolution: {integrity: sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==}
     engines: {node: '>= 10.13.0'}
@@ -6339,6 +6666,10 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -6378,6 +6709,15 @@ packages:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
 
+  xss@1.0.15:
+    resolution: {integrity: sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==}
+    engines: {node: '>= 0.10.0'}
+    hasBin: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
@@ -6385,6 +6725,17 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yauzl@3.3.1:
     resolution: {integrity: sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==}
@@ -6397,6 +6748,9 @@ packages:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.0.0-beta.20250424T163858:
     resolution: {integrity: sha512-fKhW+lEJnfUGo0fvQjmam39zUytARR2UdCEh7/OXJSBbKScIhD343K74nW+UUHu/r6dkzN6Uc/GqwogFjzpCXg==}
@@ -6582,6 +6936,20 @@ snapshots:
   '@chevrotain/types@11.1.2': {}
 
   '@corex/deepmerge@4.0.43': {}
+
+  '@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.23)':
+    dependencies:
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.5)
+      postcss: 8.5.23
+      postcss-selector-parser: 7.1.5
+
+  '@csstools/selector-resolve-nested@3.1.0(postcss-selector-parser@7.1.5)':
+    dependencies:
+      postcss-selector-parser: 7.1.5
+
+  '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.5)':
+    dependencies:
+      postcss-selector-parser: 7.1.5
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
@@ -7101,6 +7469,50 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
+  '@marp-team/marp-cli@4.5.0(typescript@5.9.3)':
+    dependencies:
+      '@marp-team/marp-core': 4.4.0
+      '@marp-team/marpit': 3.2.2
+      chokidar: 4.0.3
+      cosmiconfig: 9.0.2(typescript@5.9.3)
+      puppeteer-core: 24.43.1
+      serve-index: 1.9.2
+      tmp: 0.2.7
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@marp-team/marp-core@4.4.0':
+    dependencies:
+      '@marp-team/marpit': 3.2.2
+      '@marp-team/marpit-svg-polyfill': 2.1.0(@marp-team/marpit@3.2.2)
+      highlight.js: 11.12.0
+      katex: 0.17.0
+      mathjax-full: 3.2.2
+      postcss-selector-parser: 7.1.5
+      xss: 1.0.15
+
+  '@marp-team/marpit-svg-polyfill@2.1.0(@marp-team/marpit@3.2.2)':
+    optionalDependencies:
+      '@marp-team/marpit': 3.2.2
+
+  '@marp-team/marpit@3.2.2':
+    dependencies:
+      '@csstools/postcss-is-pseudo-class': 5.0.3(postcss@8.5.23)
+      cssesc: 3.0.0
+      js-yaml: 4.3.1
+      lodash.kebabcase: 4.1.1
+      markdown-it: 14.3.0
+      markdown-it-front-matter: 0.2.4
+      postcss: 8.5.23
+      postcss-nesting: 13.0.2(postcss@8.5.23)
+
   '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.9
@@ -7329,6 +7741,21 @@ snapshots:
   '@polka/url@1.0.0-next.29': {}
 
   '@prisma/prisma-schema-wasm@7.10.0-2.d0368e25c88e68caa4d283b5f2d88d1b76ed9356': {}
+
+  '@puppeteer/browsers@2.13.2':
+    dependencies:
+      debug: 4.4.3
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.8.5
+      tar-fs: 3.1.3
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
 
   '@react-aria/focus@3.22.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -7847,6 +8274,8 @@ snapshots:
       npm-to-yarn: 3.0.1
       unist-util-visit: 5.1.0
 
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
+
   '@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.8.3)':
     dependencies:
       '@babel/generator': 7.29.1
@@ -8154,6 +8583,11 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.41
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 20.19.41
+    optional: true
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -8497,6 +8931,10 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
   astral-regex@2.0.0: {}
 
   astring@1.9.0: {}
@@ -8510,15 +8948,48 @@ snapshots:
       tunnel: 0.0.6
       typed-rest-client: 1.8.11
 
+  b4a@1.8.1: {}
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
+  bare-events@2.9.1: {}
+
+  bare-fs@4.8.0:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.1.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.5.2
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-path@3.1.1: {}
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.5.2:
+    dependencies:
+      bare-path: 3.1.1
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.32: {}
+
+  basic-ftp@5.3.1: {}
 
   batch@0.6.1: {}
 
@@ -8661,6 +9132,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  callsites@3.1.0: {}
+
   caniuse-lite@1.0.30001793: {}
 
   ccount@2.0.1: {}
@@ -8717,6 +9190,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -8725,6 +9202,12 @@ snapshots:
     optional: true
 
   chrome-trace-event@1.0.4: {}
+
+  chromium-bidi@14.0.0(devtools-protocol@0.0.1608973):
+    dependencies:
+      devtools-protocol: 0.0.1608973
+      mitt: 3.0.1
+      zod: 3.25.76
 
   cli-cursor@3.1.0:
     dependencies:
@@ -8741,6 +9224,12 @@ snapshots:
       execa: 8.0.1
       is-wsl: 3.1.1
       is64bit: 2.0.0
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clone@1.0.4: {}
 
@@ -8835,6 +9324,15 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
+  cosmiconfig@9.0.2(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.3.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -8850,6 +9348,10 @@ snapshots:
       nth-check: 2.1.1
 
   css-what@6.2.2: {}
+
+  cssesc@3.0.0: {}
+
+  cssfilter@0.0.10: {}
 
   csstype@3.2.3: {}
 
@@ -9053,6 +9555,8 @@ snapshots:
     dependencies:
       accessor-fn: 1.5.3
 
+  data-uri-to-buffer@6.0.2: {}
+
   dayjs@1.11.20: {}
 
   debounce@1.2.1: {}
@@ -9094,6 +9598,12 @@ snapshots:
 
   defu@6.1.7: {}
 
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
   delaunator@5.1.0:
     dependencies:
       robust-predicates: 3.0.3
@@ -9117,6 +9627,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  devtools-protocol@0.0.1608973: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -9186,7 +9698,6 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-    optional: true
 
   enhanced-resolve@5.22.0:
     dependencies:
@@ -9199,7 +9710,13 @@ snapshots:
 
   entities@7.0.1: {}
 
+  env-paths@2.2.1: {}
+
   environment@1.1.0: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-define-property@1.0.1: {}
 
@@ -9302,12 +9819,22 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
   esm@3.2.25: {}
+
+  esprima@4.0.1: {}
 
   esrecurse@4.3.0:
     dependencies:
@@ -9356,9 +9883,17 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  esutils@2.0.3: {}
+
   etag@1.8.1: {}
 
   eventemitter3@4.0.7: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
 
   events@3.3.0: {}
 
@@ -9463,7 +9998,19 @@ snapshots:
 
   extend@3.0.2: {}
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -9486,6 +10033,10 @@ snapshots:
   faye-websocket@0.11.4:
     dependencies:
       websocket-driver: 0.7.5
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -9575,6 +10126,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -9593,7 +10146,19 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-stream@8.0.1: {}
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   gh-pages@6.3.0:
     dependencies:
@@ -9819,6 +10384,8 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  highlight.js@11.12.0: {}
+
   hono@4.12.27: {}
 
   hosted-git-info@4.1.0:
@@ -9923,6 +10490,11 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
   import-meta-resolve@4.2.0: {}
 
   import2@1.0.3: {}
@@ -9994,6 +10566,8 @@ snapshots:
     dependencies:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
+
+  is-arrayish@0.2.1: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -10081,6 +10655,8 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -10124,6 +10700,10 @@ snapshots:
       lodash-es: 4.18.1
 
   katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  katex@0.17.0:
     dependencies:
       commander: 8.3.0
 
@@ -10195,6 +10775,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lines-and-columns@1.2.4: {}
+
   linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
@@ -10218,6 +10800,8 @@ snapshots:
   lodash.isplainobject@4.0.6: {}
 
   lodash.isstring@4.0.1: {}
+
+  lodash.kebabcase@4.1.1: {}
 
   lodash.once@4.1.1: {}
 
@@ -10244,6 +10828,8 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
+  lru-cache@7.18.3: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -10256,7 +10842,18 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
+  markdown-it-front-matter@0.2.4: {}
+
   markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  markdown-it@14.3.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
@@ -10846,6 +11443,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mitt@3.0.1: {}
+
   mj-context-menu@0.6.1: {}
 
   mkdirp-classic@0.5.3:
@@ -10878,6 +11477,8 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
+
+  netmask@2.1.1: {}
 
   next-sitemap@4.2.3(next@16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
@@ -11111,6 +11712,24 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+
   package-json-from-dist@1.0.1: {}
 
   package-manager-detector@1.6.0: {}
@@ -11125,6 +11744,10 @@ snapshots:
       '@pagefind/windows-arm64': 1.5.2
       '@pagefind/windows-x64': 1.5.2
 
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -11138,6 +11761,13 @@ snapshots:
   parse-imports-exports@0.2.4:
     dependencies:
       parse-statements: 1.0.11
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
 
   parse-json@8.3.0:
     dependencies:
@@ -11242,6 +11872,18 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
+  postcss-nesting@13.0.2(postcss@8.5.23):
+    dependencies:
+      '@csstools/selector-resolve-nested': 3.1.0(postcss-selector-parser@7.1.5)
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.5)
+      postcss: 8.5.23
+      postcss-selector-parser: 7.1.5
+
+  postcss-selector-parser@7.1.5:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.5.23:
     dependencies:
       nanoid: 3.3.18
@@ -11279,6 +11921,8 @@ snapshots:
 
   process@0.11.10: {}
 
+  progress@2.0.3: {}
+
   property-information@7.1.0: {}
 
   proxy-addr@2.0.7:
@@ -11286,13 +11930,44 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
-    optional: true
 
   punycode.js@2.3.1: {}
+
+  puppeteer-core@24.43.1:
+    dependencies:
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
+      debug: 4.4.3
+      devtools-protocol: 0.0.1608973
+      typed-query-selector: 2.12.2
+      webdriver-bidi-protocol: 0.4.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
 
   qs@6.15.2:
     dependencies:
@@ -11417,6 +12092,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
 
@@ -11574,9 +12251,13 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   requires-port@1.0.0: {}
+
+  resolve-from@4.0.0: {}
 
   resolve@1.22.12:
     dependencies:
@@ -11919,11 +12600,26 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
+  smart-buffer@4.2.0: {}
+
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.5
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.4.0
+      smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
 
@@ -11984,6 +12680,15 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
+
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   string-width@4.2.3:
     dependencies:
@@ -12079,6 +12784,18 @@ snapshots:
       tar-stream: 2.2.0
     optional: true
 
+  tar-fs@3.1.3:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.2.0
+    optionalDependencies:
+      bare-fs: 4.8.0
+      bare-path: 3.1.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -12087,6 +12804,24 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
     optional: true
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.8.0
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   terminal-link@4.0.0:
     dependencies:
@@ -12120,6 +12855,12 @@ snapshots:
       acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   text-table@0.2.0: {}
 
@@ -12252,6 +12993,8 @@ snapshots:
       content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typed-query-selector@2.12.2: {}
 
   typed-rest-client@1.8.11:
     dependencies:
@@ -12498,6 +13241,8 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  webdriver-bidi-protocol@0.4.1: {}
+
   webpack-bundle-analyzer@4.10.2:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
@@ -12673,6 +13418,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
 
   ws@7.5.11: {}
@@ -12690,9 +13441,33 @@ snapshots:
 
   xmlbuilder@11.0.1: {}
 
+  xss@1.0.15:
+    dependencies:
+      commander: 2.20.3
+      cssfilter: 0.0.10
+
+  y18n@5.0.8: {}
+
   yallist@4.0.0: {}
 
   yaml@2.9.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yauzl@3.3.1:
     dependencies:
@@ -12706,6 +13481,8 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.0.0-beta.20250424T163858:
     dependencies:

--- a/scripts/ci/test-owners.cjs
+++ b/scripts/ci/test-owners.cjs
@@ -103,6 +103,7 @@ const OWNERSHIP = {
     "scripts/test-go.cjs harness",
   "node:scripts/go-wasm-exec.test.cjs": "scripts/test-go.cjs harness",
   "node:website/test/rss-autodiscovery.test.cjs": "website postbuild",
+  "node:website/test/slides.test.cjs": "website postbuild",
   "node:website/test/typia-dependency-graph.test.cjs": "website postbuild",
 };
 

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -33,5 +33,8 @@ compiler/playground
 # Auto-generated blog RSS feed
 public/blog/rss.xml
 
+# Marp HTML compiled from src/slides by build/slides.cjs.
+public/slides-static/
+
 # PNG re-exports of benchmark charts for dev.to (build/svg-to-png.cjs)
 build/png-out/

--- a/website/build/slides-metadata.cjs
+++ b/website/build/slides-metadata.cjs
@@ -1,0 +1,64 @@
+const fs = require("fs");
+const path = require("path");
+
+const SLIDES_DIR =
+  [
+    path.join(process.cwd(), "src", "slides"),
+    path.join(process.cwd(), "website", "src", "slides"),
+    path.join(__dirname, "..", "src", "slides"),
+  ].find((candidate) => fs.existsSync(candidate)) ??
+  path.join(process.cwd(), "src", "slides");
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+const parseFrontmatter = (content) => {
+  const match = content.match(FRONTMATTER_PATTERN);
+  if (!match) return {};
+
+  const metadata = {};
+  for (const rawLine of match[1].split(/\r?\n/)) {
+    const keyValueMatch = rawLine.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/);
+    if (!keyValueMatch) continue;
+
+    const [, key, rawValue] = keyValueMatch;
+    const value = rawValue
+      .trim()
+      .replace(/^(?:"([\s\S]*)"|'([\s\S]*)')$/, "$1$2");
+    metadata[key] = value;
+  }
+  return metadata;
+};
+
+const readSlides = () =>
+  fs
+    .readdirSync(SLIDES_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => {
+      const file = path.join(SLIDES_DIR, entry.name);
+      const slug = entry.name.replace(/\.md$/, "");
+      const metadata = parseFrontmatter(fs.readFileSync(file, "utf8"));
+      for (const key of ["title", "description", "image", "url"]) {
+        if (!metadata[key])
+          throw new Error(
+            `${entry.name} is missing required '${key}' metadata.`,
+          );
+      }
+      return {
+        file,
+        slug,
+        route: `/slides/${slug}`,
+        staticRoute: `/slides-static/${slug}/index.html`,
+        ...metadata,
+      };
+    })
+    .sort((a, b) => a.title.localeCompare(b.title));
+
+const readSlide = (slug) =>
+  readSlides().find((slide) => slide.slug === slug) ?? null;
+
+module.exports = {
+  FRONTMATTER_PATTERN,
+  SLIDES_DIR,
+  parseFrontmatter,
+  readSlide,
+  readSlides,
+};

--- a/website/build/slides.cjs
+++ b/website/build/slides.cjs
@@ -1,0 +1,49 @@
+const fs = require("fs");
+const path = require("path");
+
+const { readSlides } = require("./slides-metadata.cjs");
+
+const WEBSITE_ROOT = path.resolve(__dirname, "..");
+const OUTPUT_DIR = path.join(WEBSITE_ROOT, "public", "slides-static");
+const THEME_FILE = path.join(
+  WEBSITE_ROOT,
+  "src",
+  "slides",
+  "themes",
+  "ttsc.css",
+);
+
+async function main() {
+  const { marpCli } = await import("@marp-team/marp-cli");
+  const slides = readSlides();
+
+  fs.rmSync(OUTPUT_DIR, { force: true, recursive: true });
+  for (const slide of slides) {
+    const output = path.join(OUTPUT_DIR, slide.slug, "index.html");
+    fs.mkdirSync(path.dirname(output), { recursive: true });
+    const status = await marpCli([
+      slide.file,
+      "--output",
+      output,
+      "--html",
+      "--theme-set",
+      THEME_FILE,
+      "--no-config-file",
+    ]);
+    if (status !== 0)
+      throw new Error(`Marp failed to compile ${slide.file} (exit ${status}).`);
+  }
+  console.log(
+    `[build:slides] wrote ${slides.length} deck(s) to ${path.relative(
+      WEBSITE_ROOT,
+      OUTPUT_DIR,
+    )}`,
+  );
+}
+
+if (require.main === module) main().catch(fail);
+
+function fail(error) {
+  console.error(error);
+  process.exitCode = 1;
+}

--- a/website/package.json
+++ b/website/package.json
@@ -5,11 +5,13 @@
   "private": true,
   "scripts": {
     "build": "pnpm run prebuild && pnpm run build:next && pnpm run postbuild",
-    "prebuild": "rimraf .next && rimraf out && pnpm run build:compiler && pnpm run build:blog:rss && pnpm run build:benchmark:png && pnpm run build:benchmark:evidence:png",
+    "prebuild": "rimraf .next && rimraf out && pnpm run build:compiler && pnpm run build:blog:rss && pnpm run build:slides && pnpm run build:benchmark:png && pnpm run build:benchmark:evidence:png",
     "build:next": "next build",
     "build:compiler": "node build/compiler.cjs",
     "build:blog:rss": "node build/blog.cjs",
+    "build:slides": "node build/slides.cjs",
     "test:rss-autodiscovery": "node --test test/rss-autodiscovery.test.cjs",
+    "test:slides": "node --test test/slides.test.cjs",
     "test:typia-dependency-graph": "node --test test/typia-dependency-graph.test.cjs",
     "build:benchmark:evidence": "node build/evidence-benchmark-data.cjs",
     "build:benchmark:evidence:png": "node build/evidence-benchmark-data.cjs --png",
@@ -17,11 +19,11 @@
     "build:benchmark:png": "node build/graph-benchmark-svg.cjs --png",
     "charts:png": "node build/svg-to-png.cjs",
     "prepare": "pnpm run build:benchmark:graph",
-    "postbuild": "pnpm run test:rss-autodiscovery && pnpm run test:typia-dependency-graph && pnpm run build:pagefind && pnpm run build:sitemap",
+    "postbuild": "pnpm run test:rss-autodiscovery && pnpm run test:slides && pnpm run test:typia-dependency-graph && pnpm run build:pagefind && pnpm run build:sitemap",
     "build:pagefind": "pagefind --site .next/server/app --output-path out/_pagefind",
     "build:sitemap": "next-sitemap",
     "deploy": "node build/deploy.cjs",
-    "dev": "pnpm run build:compiler && pnpm run build:benchmark:evidence && next dev"
+    "dev": "pnpm run build:compiler && pnpm run build:benchmark:evidence && pnpm run build:slides && next dev"
   },
   "repository": {
     "type": "git",
@@ -60,6 +62,7 @@
     "typia": "catalog:samchon"
   },
   "devDependencies": {
+    "@marp-team/marp-cli": "^4.5.0",
     "@resvg/resvg-js": "^2.6.2",
     "@rspack/cli": "^1.3.0",
     "@rspack/core": "^1.3.0",

--- a/website/src/app/slides/[slug]/SlideFrame.jsx
+++ b/website/src/app/slides/[slug]/SlideFrame.jsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export default function SlideFrame({ src, title }) {
+  const frame = useRef(null);
+
+  useEffect(() => {
+    frame.current?.focus();
+  }, []);
+
+  return (
+    <iframe
+      ref={frame}
+      src={src}
+      title={title}
+      allow="fullscreen"
+      allowFullScreen
+      onLoad={() => frame.current?.focus()}
+      tabIndex={0}
+    />
+  );
+}

--- a/website/src/app/slides/[slug]/page.jsx
+++ b/website/src/app/slides/[slug]/page.jsx
@@ -1,0 +1,48 @@
+import { notFound } from "next/navigation";
+
+import { getSlide, getSlides } from "../get-slides";
+import SlideFrame from "./SlideFrame";
+
+export function generateStaticParams() {
+  return getSlides().map((slide) => ({ slug: slide.slug }));
+}
+
+export async function generateMetadata(props) {
+  const { slug } = await props.params;
+  const slide = getSlide(slug);
+  if (!slide) return {};
+
+  return {
+    title: slide.title,
+    description: slide.description,
+    alternates: { canonical: slide.url },
+    openGraph: {
+      title: slide.title,
+      description: slide.description,
+      type: "website",
+      url: slide.url,
+      images: [{ url: slide.image }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: slide.title,
+      description: slide.description,
+      images: [slide.image],
+    },
+  };
+}
+
+export default async function SlidePage(props) {
+  const { slug } = await props.params;
+  const slide = getSlide(slug);
+  if (!slide) notFound();
+
+  return (
+    <div className="ttsc-slide-viewer">
+      <SlideFrame
+        src={slide.staticRoute}
+        title={`${slide.title} presentation`}
+      />
+    </div>
+  );
+}

--- a/website/src/app/slides/get-slides.js
+++ b/website/src/app/slides/get-slides.js
@@ -1,0 +1,20 @@
+import slidesMetadata from "../../../build/slides-metadata.cjs";
+
+const { readSlide, readSlides } = slidesMetadata;
+
+const localImage = (image) => {
+  const url = new URL(image, "https://ttsc.dev");
+  return url.origin === "https://ttsc.dev" ? url.pathname : url.href;
+};
+
+export function getSlides() {
+  return readSlides().map((slide) => ({
+    ...slide,
+    imagePath: localImage(slide.image),
+  }));
+}
+
+export function getSlide(slug) {
+  const slide = readSlide(slug);
+  return slide ? { ...slide, imagePath: localImage(slide.image) } : null;
+}

--- a/website/src/app/slides/layout.jsx
+++ b/website/src/app/slides/layout.jsx
@@ -1,0 +1,11 @@
+import "./slides.css";
+
+export const metadata = {
+  title: "Slides",
+  description:
+    "Presentations about ttsc compiler tooling, Evidence Graph, and the TypeScript compiler knowledge graph.",
+};
+
+export default function SlidesLayout(props) {
+  return <div className="ttsc-slides-root">{props.children}</div>;
+}

--- a/website/src/app/slides/page.jsx
+++ b/website/src/app/slides/page.jsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+
+import { getSlides } from "./get-slides";
+
+export default function SlidesPage() {
+  const slides = getSlides();
+
+  return (
+    <section className="ttsc-slides-page">
+      <div className="ttsc-slides-heading">
+        <p className="ttsc-slides-eyebrow">Presentations</p>
+        <h1>ttsc Slides</h1>
+        <p>
+          Talks about compiler-powered tooling for TypeScript and coding agents.
+          Open a deck and use the arrow keys, swipe, or the on-screen controls
+          to navigate.
+        </p>
+      </div>
+      <div className="ttsc-slides-grid">
+        {slides.map((slide) => (
+          <Link key={slide.slug} href={slide.route} className="ttsc-slide-card">
+            <img
+              src={slide.imagePath}
+              alt=""
+              className="ttsc-slide-card-image"
+            />
+            <div className="ttsc-slide-card-body">
+              <h2>{slide.title}</h2>
+              <p>{slide.description}</p>
+              <span className="ttsc-slide-card-action">
+                Open presentation <span aria-hidden="true">→</span>
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/website/src/app/slides/slides.css
+++ b/website/src/app/slides/slides.css
@@ -1,0 +1,121 @@
+.ttsc-slides-page {
+  width: min(1180px, calc(100vw - 2rem));
+  margin: 0 auto;
+  padding: 3.5rem 1.5rem 4rem;
+}
+
+.ttsc-slides-heading {
+  max-width: 760px;
+}
+
+.ttsc-slides-heading h1 {
+  margin: 0.2rem 0 1rem;
+  color: #102a43;
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  letter-spacing: -0.045em;
+  line-height: 1;
+}
+
+.ttsc-slides-heading > p:last-child {
+  color: #526b82;
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.ttsc-slides-eyebrow {
+  margin: 0;
+  color: #3178c6;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.ttsc-slides-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 430px), 1fr));
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+}
+
+.ttsc-slide-card {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid #d8e7f4;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 12px 35px rgb(16 42 67 / 8%);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.ttsc-slide-card:hover {
+  border-color: #9cc5e8;
+  box-shadow: 0 18px 44px rgb(16 42 67 / 14%);
+  transform: translateY(-3px);
+}
+
+.ttsc-slide-card-image {
+  width: 100%;
+  aspect-ratio: 1200 / 630;
+  object-fit: cover;
+  background: #07111f;
+}
+
+.ttsc-slide-card-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding: 1.35rem 1.45rem 1.5rem;
+}
+
+.ttsc-slide-card-body h2 {
+  margin: 0;
+  color: #102a43;
+  font-size: 1.35rem;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+}
+
+.ttsc-slide-card-body p {
+  margin: 0.8rem 0 1.3rem;
+  color: #526b82;
+  line-height: 1.65;
+}
+
+.ttsc-slide-card-action {
+  margin-top: auto;
+  color: #3178c6;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+body:has(.ttsc-slide-viewer) {
+  overflow: hidden;
+}
+
+.ttsc-slide-viewer {
+  position: fixed;
+  z-index: 9999;
+  inset: 0;
+  background: #07111f;
+}
+
+.ttsc-slide-viewer iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .ttsc-slides-page {
+    padding: 2.5rem 0.25rem 3rem;
+  }
+}

--- a/website/src/slides/evidence.md
+++ b/website/src/slides/evidence.md
@@ -1,339 +1,495 @@
 ---
 marp: true
-theme: ttsc
+theme: default
 paginate: true
 size: 16:9
 title: "Evidence Graph"
-description: "Turn requirements into compiler-enforced obligations so coding agents cannot finish with missing code, tests, screens, or documentation."
-author: "Jeongho Nam"
-keywords: "ttsc, evidence graph, spec-driven development, coding agents"
+description: "Enforce 100% specification coverage as compile errors so coding agents cannot skip an obligation."
 url: "https://ttsc.dev/slides/evidence/"
 image: "https://ttsc.dev/og-evidence.png"
-footer: "@ttsc/evidence · ttsc.dev/docs/evidence"
+style: |
+  section {
+    font-family: "Pretendard", "Apple SD Gothic Neo", "Malgun Gothic", "Noto Sans KR", sans-serif;
+    font-size: 32px;
+    line-height: 1.6;
+    padding: 60px 70px;
+    background: #ffffff;
+    color: #14161a;
+  }
+  h1 {
+    font-size: 50px;
+    color: #0f1115;
+    border-bottom: 4px solid #14284b;
+    padding-bottom: 14px;
+    margin-bottom: 34px;
+  }
+  ul, ol { margin-top: 10px; }
+  li { margin-bottom: 22px; }
+  strong { color: #14284b; }
+  code { font-family: "D2Coding", "Consolas", "Menlo", monospace; }
+  pre { font-size: 26px; line-height: 1.5; border-radius: 10px; }
+  table { font-size: 30px; width: 100%; }
+  th { background: #14284b; color: #ffffff; }
+  td, th { padding: 14px 18px; }
+  blockquote {
+    border-left: 8px solid #ffb020;
+    background: #fff8e8;
+    color: #2b3038;
+    padding: 18px 26px;
+    font-size: 32px;
+  }
+  footer { color: #9aa4b2; font-size: 17px; }
+  footer a { color: #9aa4b2; text-decoration: none; }
+  section::after { color: #9aa4b2; font-size: 17px; }
+  a { color: #1a5fb4; }
+  a:hover { color: #0d3d7a; }
+
+  /* Dark slides */
+  section.dark {
+    background: #0f1115;
+    color: #f4f5f7;
+    justify-content: center;
+  }
+  section.dark h1 { color: #ffffff; border-bottom: none; font-size: 60px; }
+  section.dark h2 { color: #8ab4ff; font-size: 34px; font-weight: 600; }
+  section.dark strong { color: #ffd479; }
+  section.dark li { color: #f4f5f7; }
+  section.dark code { background: #262b36; color: #ffd479; }
+  section.dark .note { color: #a7b0be; }
+  section.dark a { color: #8ab4ff; }
+  section.divider {
+    background: #14284b;
+    color: #ffffff;
+    justify-content: center;
+    text-align: center;
+  }
+  section.divider h1 { color: #ffffff; border-bottom: none; font-size: 56px; }
+  section.divider p { color: #b9c9e6; font-size: 30px; }
+  section.divider .note { color: #b9c9e6; }
+
+  /* Single-line emphasis */
+  .punch { display: block; font-size: 46px; font-weight: 700; line-height: 1.45; color: #ffd479; }
+  .punch-lead {
+    display: block; font-size: 40px; font-weight: 600;
+    line-height: 1.5; color: #e3e6ea; margin-bottom: 34px;
+  }
+  .note { font-size: 24px; color: #5b6674; }
+
+  /* Cards */
+  .cards { display: flex; gap: 22px; margin-top: 20px; }
+  .card {
+    flex: 1;
+    background: #f3f6fb;
+    border-top: 7px solid #4a76b8;
+    border-radius: 10px;
+    padding: 22px 24px;
+    font-size: 27px;
+    line-height: 1.5;
+  }
+  .card b { display: block; font-size: 40px; color: #14284b; margin-bottom: 8px; }
+  .card .note { font-size: 22px; }
+  .card.warm { border-top-color: #f08a24; }
+  .card.warm b { color: #b35c00; }
+
+  /* Bars */
+  .track {
+    display: inline-block; width: 240px; height: 20px;
+    background: #e6eaf0; border-radius: 10px; overflow: hidden;
+    vertical-align: middle; margin-left: 14px;
+  }
+  .track i { display: block; height: 100%; background: #4a76b8; }
+  .track.on i { background: #f08a24; }
+  .track i.w855 { width: 85.5%; }
+  .track i.w803 { width: 80.3%; }
+  .track i.w631 { width: 63.1%; }
+  .track i.w500 { width: 50%; }
+  .track i.w100 { width: 100%; }
+
+  /* Development and review split bars */
+  .split {
+    display: inline-flex; width: 210px; height: 20px;
+    border-radius: 10px; overflow: hidden;
+    vertical-align: middle; margin-right: 12px;
+  }
+  .split i { display: block; height: 100%; background: #14284b; }
+  .split i.rev { flex: 1; background: #c3d3ea; }
+  .split.on i { background: #b35c00; }
+  .split.on i.rev { background: #ffd6a5; }
+  .d97 { width: 9.7%; }
+  .d54 { width: 5.4%; }
+  .d47 { width: 4.7%; }
+  .d205 { width: 20.5%; }
+  .d720 { width: 72%; }
+  .d808 { width: 80.8%; }
+  .d586 { width: 58.6%; }
+  .d846 { width: 84.6%; }
+
+  /* Token bars by subject */
+  .rows { margin-top: 26px; }
+  .row { display: flex; align-items: center; margin-bottom: 20px; }
+  .row .lbl { width: 150px; font-size: 28px; }
+  .row .bars { flex: 1; }
+  .row .bars i { display: block; height: 18px; border-radius: 9px; margin: 4px 0; }
+  .row .bars i.p { background: #4a76b8; }
+  .row .bars i.e { background: #f08a24; }
+  .row .val { width: 230px; text-align: right; font-size: 25px; color: #5b6674; }
+  .b310 { width: 31%; }
+  .b33 { width: 3.3%; }
+  .b422 { width: 42.2%; }
+  .b88 { width: 8.8%; }
+  .b542 { width: 54.2%; }
+  .b97 { width: 9.7%; }
+  .b1000 { width: 100%; }
+  .b147 { width: 14.7%; }
+  .kp { color: #4a76b8; font-weight: 700; }
+  .ke { color: #b35c00; font-weight: 700; }
 ---
 
-<!-- _class: lead evidence -->
+<!-- _class: dark -->
 <!-- _paginate: false -->
-
-<div class="eyebrow">@ttsc/evidence</div>
 
 # Evidence Graph
 
-## Turn every missing obligation into a compile error
+## Enforcing 100% specification coverage with compile errors
 
-<p class="lede">Requirements become named graph nodes. Code, tests, schemas, APIs, screens, and documents must acknowledge the nodes they answer for.</p>
-
----
-
-<!-- _class: lead evidence -->
-
-<span class="punch">A coding agent can only fix what it notices.</span>
-
-<p class="lede">A requirement omitted from the implementation creates no failing test, no type error, and no search result.</p>
+<span class="note">https://github.com/samchon/ttsc/tree/master/packages/evidence</span>
 
 ---
 
-# The four omissions left to review
+<!-- _class: dark -->
 
-- A requirement exists, but nobody implemented it.
-- A feature exists, but nobody verified it.
-- A capability exists, but no screen reaches it.
-- A document changed, but the code depending on it did not.
+<span class="punch-lead">
+Write the specification, build to the specification, and verify against the specification.<br/>Spec Driven Development.
+</span>
 
-> These are coverage failures without a denominator.
+<span class="punch">
+That specification becomes the compile error.
+</span>
+
+<span class="note">your spec as a compile error no coding agent can skip</span>
 
 ---
 
-# Retrieval cannot supply the denominator
+<!-- _class: dark -->
 
-<div class="cols">
-<div>
+<span class="punch-lead">
+One meeting note. One idea note.
+</span>
 
-## Retrieval
+<span class="punch">
+That alone produces a full-stack, full-spec product.
+</span>
 
-- Answers the query it was given
-- Finds relevant passages
-- Never returns the section nobody asked about
-
-</div>
-<div>
-
-## Coverage
-
-- Starts from every declared unit
-- Tracks who owes each answer
-- Fails while any obligation is open
-
-</div>
-</div>
+<span class="note">The ultimate form of Goal Mode: provide only the goal, and the graph catches the rest.<br/>Requirement coverage from 50% to 100%, 6.8× fewer tokens, and 4.4× less time.</span>
 
 ---
 
 <!-- _class: divider -->
 
-# Make the specification executable
+# So what do humans do?
 
-## The graph owns the lower layers
-
----
-
-# One graph, many artifact kinds
-
-<div class="flow">
-  <span>Requirements</span><i>→</i><span>Prisma</span><i>→</i><span>API</span><i>→</i><span>SDK</span><i>→</i><span>Tests</span>
-</div>
-
-<div class="flow">
-  <span>Requirements</span><i>→</i><span>Screens</span><i>→</i><span>Journeys</span>
-</div>
-
-<p class="note center">Each arrow is an independently complete claim-reference obligation.</p>
+<span class="note">One document layer. Delegate everything else</span>
 
 ---
 
-# Declare who owes what
+# First, divide the documents into layers
 
-```ts
-export default {
-  claims: [{
-    type: "typescript",
-    files: ["src/components/**/*.tsx"],
-    symbol: "function",
-    reference: {
-      type: "markdown",
-      files: ["docs/requirements/**/*.md"],
-      symbol: ["h2", "h3"],
-    },
-  }],
-};
+```
+Meeting notes · Idea notes
+      ↓
+requirements      What is needed
+      ↓
+specifications    What to build
+      ↓
+Implementation · Tests
 ```
 
-**Every selected component must answer every selected requirement section.**
+- A lower layer can exist **only on the evidence of the layer above it**
+- Humans need to touch **only one layer**
 
 ---
 
-# Code cites the exact unit it answers
+# Method A: Humans write the requirements
+
+- Humans **review `docs/requirements` directly**
+- Specifications, implementation, and tests are **fully delegated**
+- Film production automation solution: **about 450K LoC**, working as-is on its first run
+
+> The four benchmark subjects use this method as well.
+
+---
+
+# Method B: Hand over only the raw material
+
+- Hand over meeting notes and idea notes **as-is, without organizing them**
+- **Delegate everything**, starting with writing the requirements
+- If anything decided in the meeting is omitted, **the build breaks immediately**
+
+> In either method, the graph protects the lower layers.<br/>Humans review only the one layer they chose.
+
+---
+
+# Even requirements cite their evidence
+
+```md
+## Coupon stacking limit {#coupon-stacking}
+
+<!-- @evidence docs/meetings/2026-01-12.md#discount-policy
+     Carries over the per-issuer limit agreed upon in that meeting. -->
+```
+
+- If anything decided in the meeting **is missing from the requirements, the build breaks**
+- Idea notes, interview records, and existing internal documents occupy the same layer
+- Citations are HTML comments, so **the rendered document stays clean**
+
+---
+
+# The backend and frontend work like this
+
+```
+requirements ─▶ specifications
+     │                │
+     └───────┬────────┘
+             ├─▶ DB schema
+             ├─▶ API operations ─▶ Generated SDK ─▶ Tests
+             └─▶ Hooks ─▶ Screens ─▶ Journeys
+```
+
+- Specifications stand on requirements as evidence,<br/>and **both layers together** impose obligations downward
+- **Both tests and hooks** discharge the generated SDK's obligations
+
+**"The backend is done, but there is no screen" becomes a compile error.**
+
+---
+
+<!-- _class: divider -->
+
+# So how does that work?
+
+<span class="note">We attached a compiler to specifications, too</span>
+
+---
+
+# Code cites the specification
 
 ```tsx
 /**
  * @evidence docs/discount.md#coupon-stacking
- *           Shows the per-issuer stacking limit defined by this section.
+ *           Explains the stacking limit defined by this section.
  * @evidence POST:/orders/{orderId}/coupons
- *           Renders the refusal returned by this API operation.
+ *           Explains the rejection response from this endpoint.
  */
 export function CouponStackingNotice(props: IProps): JSX.Element;
 ```
 
-`@evidence <target> <reason>` records responsibility and rationale.
+**`@evidence <target> <reason>`**: what it is responsible for, and why.
 
 ---
 
-# No citation, no build
+# Without a citation, the build stops
 
-```text
+```bash
 $ npx ttsc
 error TS16411: [evidence/graph]
-  Missing acknowledgement for
-  'docs/discount.md#coupon-stacking'
+  Missing acknowledgement for 'docs/discount.md#coupon-stacking'
   (Markdown H2 'Coupon Stacking' at docs/discount.md:3)
 ```
 
-- The compiler reports the exact missing unit.
-- The agent must build the artifact or record a justified exclusion.
+- One error per requirement → **the error list is the task list**
+- It appears alongside type errors. There is no additional check to attach
 
 ---
 
-# Four artifact kinds
+# There is only one thing an agent obeys
 
-| Artifact          | Units                             | Citation host  |
-| ----------------- | --------------------------------- | -------------- |
-| Markdown          | file, H1 to H4 section            | HTML comment   |
-| Prisma            | model, column, relation           | `///` comment  |
-| TypeScript        | exported type, function, property | JSDoc          |
-| Swagger / OpenAPI | operation under `paths`           | reference-only |
+- When told to read documents, it **pretends to have read them**
+- In a review, it **says everything is done**
+- But it **cannot get past a compile error**
 
-<p class="note">Documents, schemas, code, and API contracts share one addressable grammar.</p>
+> Documents are good to read.<br/>Compile errors have to be read.
 
 ---
 
-# Hierarchy makes one citation useful
+# The configuration is one sentence
 
-```text
-docs/discount.md
-└─ # pricing
-   ├─ ## coupon-stacking
-   └─ ## issuer-limits
+```ts
+type: "typescript",
+files: ["src/components/**/*.tsx"],  // The side that discharges the obligation
+symbol: "function",
+reference: {
+  type: "markdown",
+  files: ["docs/**/*.md"],           // The targets whose obligations must be discharged
+  symbol: ["h2", "h3"],
+},
 ```
 
-- Citing a scope acknowledges its selected descendants.
-- The denominator still contains each selected leaf.
-- Structural identity, not a dotted-name guess, defines ancestry.
+**Components implement documents. Therefore, every H2 and H3 must be cited.**
 
 ---
 
-# Obligations never pool
+# Four kinds of citation targets
+
+| Kind          | Unit                         |
+| ------------- | ---------------------------- |
+| 📄 Markdown   | file, H1-H4 section          |
+| 🗄️ Prisma     | model, column, relation      |
+| 🔤 TypeScript | type, function, property     |
+| 🌐 Swagger    | each operation under `paths` |
+
+<span class="note">Documents, schemas, code, and API specifications are connected by one grammar.</span>
+
+---
+
+# Who determines 100%?
 
 <div class="cards">
-<div class="card"><b>Backend</b>Implements the pricing rule.</div>
-<div class="card warm"><b>Frontend</b>Forgets to expose the rule.</div>
-<div class="card accent"><b>Result</b>The frontend claim still fails.</div>
+<div class="card"><b>Denominator</b>The configuration declares it</div>
+<div class="card"><b>Numerator</b>The developer records it with tags</div>
+<div class="card warm"><b>Decision</b>The compiler makes it every time</div>
 </div>
 
-<br />
+<br/>
 
-One implementation cannot hide another consumer's omission.
-
----
-
-# A recorded “no” is also an answer
-
-```ts
-/**
- * @evidenceExclude docs/discount.md#internal-ledger
- * The public screen never exposes the settlement ledger;
- * finance operations own it in the admin application.
- */
-export function CustomerDiscountPanel(): JSX.Element;
-```
-
-- The reason is mandatory.
-- The exclusion belongs to one claim only.
-- `noEvidenceExclude` can prohibit this path entirely.
+Entrust any one of the three to diligence, and 100% is merely **self-reported**.
 
 ---
 
-# Policies prevent fake coverage
+# It prevents a false 100%
 
-| Policy                    | What it stops                               |
-| ------------------------- | ------------------------------------------- |
-| `noEvidenceExclude`       | Dismissing an obligation as out of scope    |
-| `uniqueEvidence`          | Reusing one semantic host several times     |
-| `singleEvidencePerSymbol` | Parking an entire spec on one declaration   |
-| `requireReview`           | Keeping a citation after its target changes |
+| Option | What it prevents |
+| --- | --- |
+| `noEvidenceExclude` | Escaping with "not applicable" |
+| `uniqueEvidence` | Multiple places passing responsibility to one another |
+| `singleEvidencePerSymbol` | Piling every citation onto one place |
+| `requireReview` | Letting the specification change after it was cited |
 
----
-
-# Reviews expire when evidence changes
-
-```ts
-/**
- * @evidence docs/discount.md#coupon-stacking Explains the limit.
- * @evidenceReview docs/discount.md#coupon-stacking #a1b2c3d4e5f6
- *                 Checked the copy against policy section 3.
- */
-```
-
-- The fingerprint covers the cited unit and its structural subtree.
-- A changed requirement, API operation, schema, or symbol invalidates the review.
-- The compiler reports the expected replacement fingerprint.
-
----
-
-# What the agent experiences
-
-<div class="flow">
-  <span>Build</span><i>→</i><span>Named errors</span><i>→</i><span>Implement</span><i>→</i><span>Cite</span><i>→</i><span>Green</span>
-</div>
-
-The graph turns an open-ended search for omissions into a finite error list.
-
-> The agent does not aim at 100%. It reaches 100% as the residue of closing every error.
+<span class="note">An exclusion requires a reason, and a review carries a fingerprint of the document content.</span>
 
 ---
 
 <!-- _class: divider -->
 
-# Does it change the result?
+# So how much does it change?
 
-## Same engine, same requirements, one changed arm
-
----
-
-# Benchmark design
-
-- One coding engine built four applications from frozen requirements.
-- Plain and Evidence arms used the same template, model, effort, and instruction sequence.
-- Plain coverage was counted over thirteen provenance edges.
-- Evidence coverage is **100% by construction** after a successful compile.
-
-<p class="note">Repository aggregate generated 2026-08-12. One bounded cohort, not a universal estimate.</p>
+<span class="note">Same requirements · Same engine · Same model, with only the plugin changed</span>
 
 ---
 
-# Provenance coverage
+# Coverage
 
-| Subject  | Plain | Evidence |
-| -------- | ----: | -------: |
-| Todo     | 85.5% | **100%** |
-| Reddit   | 80.3% | **100%** |
-| Shopping | 63.1% | **100%** |
-| ERP      | 50.0% | **100%** |
+| Subject | Plain | Evidence |
+| --- | --- | --- |
+| todo | 85.5% <span class="track"><i class="w855"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| reddit | 80.3% <span class="track"><i class="w803"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| shopping | 63.1% <span class="track"><i class="w631"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| erp | 50.0% <span class="track"><i class="w500"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
 
-The gap grows with the consequence surface.
-
----
-
-# Token use fell with the search space
-
-<div class="bar-row"><b>Todo</b><span class="bar"><i style="width: 100%"></i></span><span>866M → 92M</span></div>
-<div class="bar-row"><b>Reddit</b><span class="bar"><i style="width: 100%"></i></span><span>1,179M → 245M</span></div>
-<div class="bar-row"><b>Shopping</b><span class="bar"><i style="width: 100%"></i></span><span>1,516M → 271M</span></div>
-<div class="bar-row"><b>ERP</b><span class="bar"><i style="width: 100%"></i></span><span>2,795M → 411M</span></div>
-
-<p class="note">Labels show Plain → Evidence total tokens. Bar length is illustrative; use the labels for comparison.</p>
+The larger the project, the more it misses.<br/>**It does not even know that it missed something.**
 
 ---
 
-# ERP: more complete, less expensive
+# Yet it becomes cheaper
 
-<div class="cards">
-<div class="card"><span class="metric">6.8×</span>fewer tokens<br /><span class="note">2,795M → 411M</span></div>
-<div class="card"><span class="metric">7.0×</span>lower API cost<br /><span class="note">$34.65 → $4.96</span></div>
-<div class="card accent"><span class="metric">4.4×</span>less work time<br /><span class="note">60.5h → 13.6h</span></div>
+<div class="rows">
+<div class="row"><span class="lbl">todo</span><span class="bars"><i class="p b310"></i><i class="e b33"></i></span><span class="val">866M → 92M</span></div>
+<div class="row"><span class="lbl">reddit</span><span class="bars"><i class="p b422"></i><i class="e b88"></i></span><span class="val">1,179M → 245M</span></div>
+<div class="row"><span class="lbl">shopping</span><span class="bars"><i class="p b542"></i><i class="e b97"></i></span><span class="val">1,516M → 271M</span></div>
+<div class="row"><span class="lbl">erp</span><span class="bars"><i class="p b1000"></i><i class="e b147"></i></span><span class="val">2,795M → 411M</span></div>
 </div>
 
-<br />
+Token consumption for <span class="kp">Plain</span> and <span class="ke">Evidence</span>.<br/>The gap widens as the project grows.
 
-The graph replaces repeated rediscovery with a compiler-owned work queue.
-
----
-
-# Start with one valuable edge
-
-1. Install `ttsc`, `@ttsc/lint`, and `@ttsc/evidence`.
-2. Choose one claim population and one reference population.
-3. Run `ttsc --noEmit` and inspect the first missing obligations.
-4. Add true citations only after the corresponding artifact exists.
-5. Expand the graph when the first edge is stable.
+<span class="note">Original charts by phase: [https://ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)</span>
 
 ---
 
-# What it does not do
+# Cost and time decreased as well: erp
 
-- It does not judge whether prose is sincere.
-- It does not prove runtime behavior without tests.
-- It does not auto-exclude, auto-retarget, or delete obligations.
-- It does not replace review; it gives review a complete, named surface.
+<div class="cards">
+<div class="card"><b>6.8×</b>fewer tokens<br/><span class="note">2,795M → 411M</span></div>
+<div class="card"><b>7.0×</b>lower cost<br/><span class="note">$34.65 → $4.96</span></div>
+<div class="card warm"><b>4.4×</b>less time<br/><span class="note">60h → 14h</span></div>
+</div>
 
----
+<br/>
 
-<!-- _class: lead evidence -->
-
-# Evidence Graph
-
-- Humans own the requirements.
-- The compiler owns the denominator.
-- Agents close named obligations until none remain.
-
-<span class="punch">Coverage becomes a build property.</span>
+This was not a cost paid for quality.<br/>**It built more and finished for less.**
 
 ---
 
-<!-- _class: lead evidence -->
+# What if it lies?
+
+```ts
+/**
+ * @evidence docs/discount.md#coupon-stacking Explains the per-issuer limit.
+ * @evidenceReview docs/discount.md#coupon-stacking #a1b2c3d4e5f6
+ *                 Verified that the screen copy matches the limit in policy section 3.
+ */
+```
+
+- Inexpensive models **sometimes write facts that do not exist**
+- Requiring fingerprinted reviews makes this **converge toward zero**<br/>but takes more time
+
+> A false tag removes the error, not the problem.
+
+---
+
+# Ultimately, the review must run
+
+Review Loop until Dry
+
+```
+① Read everything again from the beginning
+② If there is even one thing to fix → ①
+③ Stop only after a round finds nothing
+```
+
+<span class="note">Both arms were measured under this discipline.</span>
+
+---
+
+# But the review consumes all the money
+
+| Subject | Plain | Evidence |
+| --- | --- | --- |
+| todo | <span class="split"><i class="d97"></i><i class="rev"></i></span> Review 90% | <span class="split on"><i class="d720"></i><i class="rev"></i></span> Review 28% |
+| reddit | <span class="split"><i class="d54"></i><i class="rev"></i></span> Review 95% | <span class="split on"><i class="d808"></i><i class="rev"></i></span> Review 19% |
+| shopping | <span class="split"><i class="d47"></i><i class="rev"></i></span> Review 95% | <span class="split on"><i class="d586"></i><i class="rev"></i></span> Review 41% |
+| erp | <span class="split"><i class="d205"></i><i class="rev"></i></span> Review 80% | <span class="split on"><i class="d846"></i><i class="rev"></i></span> Review 15% |
+
+Plain **starts quickly, but its review never ends.**<br/>Evidence is the opposite.
+
+<span class="note">Dark is development, light is review. Each cell represents 100% of its tokens.</span>
+
+---
+
+# In return, the review becomes narrower
+
+|  | Plain | Evidence |
+| --- | --- | --- |
+| What to inspect | All code, documents, and tests | The truthfulness of citations |
+| Scope | Start over in every round | The tag list is the checklist |
+| What is missing | Humans and AI must search to find out | The compiler has already reported it |
+
+**The compiler handles "omissions"; humans handle "falsehoods."**
+
+---
+
+<!-- _class: dark -->
+
+# Summary
+
+- Humans review **only one document layer**
+- The **compiler protects everything below it**
+- 100% is not the goal, but **what remains after every error is closed**
+
+---
+
+<!-- _class: dark -->
 <!-- _paginate: false -->
 
 # Q & A
 
-- [ttsc.dev/docs/evidence](https://ttsc.dev/docs/evidence)
-- [ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)
-- [github.com/samchon/ttsc](https://github.com/samchon/ttsc)
+- [https://github.com/samchon/ttsc](https://github.com/samchon/ttsc)
+- [https://ttsc.dev/docs/evidence](https://ttsc.dev/docs/evidence)
+- [https://ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)

--- a/website/src/slides/evidence.md
+++ b/website/src/slides/evidence.md
@@ -1,0 +1,339 @@
+---
+marp: true
+theme: ttsc
+paginate: true
+size: 16:9
+title: "Evidence Graph"
+description: "Turn requirements into compiler-enforced obligations so coding agents cannot finish with missing code, tests, screens, or documentation."
+author: "Jeongho Nam"
+keywords: "ttsc, evidence graph, spec-driven development, coding agents"
+url: "https://ttsc.dev/slides/evidence/"
+image: "https://ttsc.dev/og-evidence.png"
+footer: "@ttsc/evidence · ttsc.dev/docs/evidence"
+---
+
+<!-- _class: lead evidence -->
+<!-- _paginate: false -->
+
+<div class="eyebrow">@ttsc/evidence</div>
+
+# Evidence Graph
+
+## Turn every missing obligation into a compile error
+
+<p class="lede">Requirements become named graph nodes. Code, tests, schemas, APIs, screens, and documents must acknowledge the nodes they answer for.</p>
+
+---
+
+<!-- _class: lead evidence -->
+
+<span class="punch">A coding agent can only fix what it notices.</span>
+
+<p class="lede">A requirement omitted from the implementation creates no failing test, no type error, and no search result.</p>
+
+---
+
+# The four omissions left to review
+
+- A requirement exists, but nobody implemented it.
+- A feature exists, but nobody verified it.
+- A capability exists, but no screen reaches it.
+- A document changed, but the code depending on it did not.
+
+> These are coverage failures without a denominator.
+
+---
+
+# Retrieval cannot supply the denominator
+
+<div class="cols">
+<div>
+
+## Retrieval
+
+- Answers the query it was given
+- Finds relevant passages
+- Never returns the section nobody asked about
+
+</div>
+<div>
+
+## Coverage
+
+- Starts from every declared unit
+- Tracks who owes each answer
+- Fails while any obligation is open
+
+</div>
+</div>
+
+---
+
+<!-- _class: divider -->
+
+# Make the specification executable
+
+## The graph owns the lower layers
+
+---
+
+# One graph, many artifact kinds
+
+<div class="flow">
+  <span>Requirements</span><i>→</i><span>Prisma</span><i>→</i><span>API</span><i>→</i><span>SDK</span><i>→</i><span>Tests</span>
+</div>
+
+<div class="flow">
+  <span>Requirements</span><i>→</i><span>Screens</span><i>→</i><span>Journeys</span>
+</div>
+
+<p class="note center">Each arrow is an independently complete claim-reference obligation.</p>
+
+---
+
+# Declare who owes what
+
+```ts
+export default {
+  claims: [{
+    type: "typescript",
+    files: ["src/components/**/*.tsx"],
+    symbol: "function",
+    reference: {
+      type: "markdown",
+      files: ["docs/requirements/**/*.md"],
+      symbol: ["h2", "h3"],
+    },
+  }],
+};
+```
+
+**Every selected component must answer every selected requirement section.**
+
+---
+
+# Code cites the exact unit it answers
+
+```tsx
+/**
+ * @evidence docs/discount.md#coupon-stacking
+ *           Shows the per-issuer stacking limit defined by this section.
+ * @evidence POST:/orders/{orderId}/coupons
+ *           Renders the refusal returned by this API operation.
+ */
+export function CouponStackingNotice(props: IProps): JSX.Element;
+```
+
+`@evidence <target> <reason>` records responsibility and rationale.
+
+---
+
+# No citation, no build
+
+```text
+$ npx ttsc
+error TS16411: [evidence/graph]
+  Missing acknowledgement for
+  'docs/discount.md#coupon-stacking'
+  (Markdown H2 'Coupon Stacking' at docs/discount.md:3)
+```
+
+- The compiler reports the exact missing unit.
+- The agent must build the artifact or record a justified exclusion.
+
+---
+
+# Four artifact kinds
+
+| Artifact          | Units                             | Citation host  |
+| ----------------- | --------------------------------- | -------------- |
+| Markdown          | file, H1 to H4 section            | HTML comment   |
+| Prisma            | model, column, relation           | `///` comment  |
+| TypeScript        | exported type, function, property | JSDoc          |
+| Swagger / OpenAPI | operation under `paths`           | reference-only |
+
+<p class="note">Documents, schemas, code, and API contracts share one addressable grammar.</p>
+
+---
+
+# Hierarchy makes one citation useful
+
+```text
+docs/discount.md
+└─ # pricing
+   ├─ ## coupon-stacking
+   └─ ## issuer-limits
+```
+
+- Citing a scope acknowledges its selected descendants.
+- The denominator still contains each selected leaf.
+- Structural identity, not a dotted-name guess, defines ancestry.
+
+---
+
+# Obligations never pool
+
+<div class="cards">
+<div class="card"><b>Backend</b>Implements the pricing rule.</div>
+<div class="card warm"><b>Frontend</b>Forgets to expose the rule.</div>
+<div class="card accent"><b>Result</b>The frontend claim still fails.</div>
+</div>
+
+<br />
+
+One implementation cannot hide another consumer's omission.
+
+---
+
+# A recorded “no” is also an answer
+
+```ts
+/**
+ * @evidenceExclude docs/discount.md#internal-ledger
+ * The public screen never exposes the settlement ledger;
+ * finance operations own it in the admin application.
+ */
+export function CustomerDiscountPanel(): JSX.Element;
+```
+
+- The reason is mandatory.
+- The exclusion belongs to one claim only.
+- `noEvidenceExclude` can prohibit this path entirely.
+
+---
+
+# Policies prevent fake coverage
+
+| Policy                    | What it stops                               |
+| ------------------------- | ------------------------------------------- |
+| `noEvidenceExclude`       | Dismissing an obligation as out of scope    |
+| `uniqueEvidence`          | Reusing one semantic host several times     |
+| `singleEvidencePerSymbol` | Parking an entire spec on one declaration   |
+| `requireReview`           | Keeping a citation after its target changes |
+
+---
+
+# Reviews expire when evidence changes
+
+```ts
+/**
+ * @evidence docs/discount.md#coupon-stacking Explains the limit.
+ * @evidenceReview docs/discount.md#coupon-stacking #a1b2c3d4e5f6
+ *                 Checked the copy against policy section 3.
+ */
+```
+
+- The fingerprint covers the cited unit and its structural subtree.
+- A changed requirement, API operation, schema, or symbol invalidates the review.
+- The compiler reports the expected replacement fingerprint.
+
+---
+
+# What the agent experiences
+
+<div class="flow">
+  <span>Build</span><i>→</i><span>Named errors</span><i>→</i><span>Implement</span><i>→</i><span>Cite</span><i>→</i><span>Green</span>
+</div>
+
+The graph turns an open-ended search for omissions into a finite error list.
+
+> The agent does not aim at 100%. It reaches 100% as the residue of closing every error.
+
+---
+
+<!-- _class: divider -->
+
+# Does it change the result?
+
+## Same engine, same requirements, one changed arm
+
+---
+
+# Benchmark design
+
+- One coding engine built four applications from frozen requirements.
+- Plain and Evidence arms used the same template, model, effort, and instruction sequence.
+- Plain coverage was counted over thirteen provenance edges.
+- Evidence coverage is **100% by construction** after a successful compile.
+
+<p class="note">Repository aggregate generated 2026-08-12. One bounded cohort, not a universal estimate.</p>
+
+---
+
+# Provenance coverage
+
+| Subject  | Plain | Evidence |
+| -------- | ----: | -------: |
+| Todo     | 85.5% | **100%** |
+| Reddit   | 80.3% | **100%** |
+| Shopping | 63.1% | **100%** |
+| ERP      | 50.0% | **100%** |
+
+The gap grows with the consequence surface.
+
+---
+
+# Token use fell with the search space
+
+<div class="bar-row"><b>Todo</b><span class="bar"><i style="width: 100%"></i></span><span>866M → 92M</span></div>
+<div class="bar-row"><b>Reddit</b><span class="bar"><i style="width: 100%"></i></span><span>1,179M → 245M</span></div>
+<div class="bar-row"><b>Shopping</b><span class="bar"><i style="width: 100%"></i></span><span>1,516M → 271M</span></div>
+<div class="bar-row"><b>ERP</b><span class="bar"><i style="width: 100%"></i></span><span>2,795M → 411M</span></div>
+
+<p class="note">Labels show Plain → Evidence total tokens. Bar length is illustrative; use the labels for comparison.</p>
+
+---
+
+# ERP: more complete, less expensive
+
+<div class="cards">
+<div class="card"><span class="metric">6.8×</span>fewer tokens<br /><span class="note">2,795M → 411M</span></div>
+<div class="card"><span class="metric">7.0×</span>lower API cost<br /><span class="note">$34.65 → $4.96</span></div>
+<div class="card accent"><span class="metric">4.4×</span>less work time<br /><span class="note">60.5h → 13.6h</span></div>
+</div>
+
+<br />
+
+The graph replaces repeated rediscovery with a compiler-owned work queue.
+
+---
+
+# Start with one valuable edge
+
+1. Install `ttsc`, `@ttsc/lint`, and `@ttsc/evidence`.
+2. Choose one claim population and one reference population.
+3. Run `ttsc --noEmit` and inspect the first missing obligations.
+4. Add true citations only after the corresponding artifact exists.
+5. Expand the graph when the first edge is stable.
+
+---
+
+# What it does not do
+
+- It does not judge whether prose is sincere.
+- It does not prove runtime behavior without tests.
+- It does not auto-exclude, auto-retarget, or delete obligations.
+- It does not replace review; it gives review a complete, named surface.
+
+---
+
+<!-- _class: lead evidence -->
+
+# Evidence Graph
+
+- Humans own the requirements.
+- The compiler owns the denominator.
+- Agents close named obligations until none remain.
+
+<span class="punch">Coverage becomes a build property.</span>
+
+---
+
+<!-- _class: lead evidence -->
+<!-- _paginate: false -->
+
+# Q & A
+
+- [ttsc.dev/docs/evidence](https://ttsc.dev/docs/evidence)
+- [ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)
+- [github.com/samchon/ttsc](https://github.com/samchon/ttsc)

--- a/website/src/slides/graph.md
+++ b/website/src/slides/graph.md
@@ -1,0 +1,335 @@
+---
+marp: true
+theme: ttsc
+paginate: true
+size: 16:9
+title: "TypeScript Compiler Knowledge Graph"
+description: "Give coding agents the exact symbol graph TypeScript already resolved, cutting repository-orientation tokens without returning source bodies."
+author: "Jeongho Nam"
+keywords: "ttsc, TypeScript, compiler graph, MCP, coding agents"
+url: "https://ttsc.dev/slides/graph/"
+image: "https://ttsc.dev/og-graph.png"
+footer: "@ttsc/graph · ttsc.dev/docs/graph"
+---
+
+<!-- _class: lead graph -->
+<!-- _paginate: false -->
+
+<div class="eyebrow">@ttsc/graph</div>
+
+# TypeScript Compiler Knowledge Graph
+
+## Give your coding agent the index the compiler already drew
+
+<p class="lede">Declarations, signatures, calls, types, decorators, tests, diagnostics, and source spans through one typed MCP tool.</p>
+
+---
+
+<!-- _class: lead graph -->
+
+<span class="punch">Do not make the agent read the whole repository.</span>
+
+<p class="lede">Most orientation starts as grep, file read, import chase, another grep, and another file read.</p>
+
+---
+
+# The repository crawl loop
+
+<div class="flow">
+  <span>Question</span><i>→</i><span>grep</span><i>→</i><span>Read</span><i>→</i><span>import</span><i>→</i><span>Read</span>
+</div>
+
+- Each hop replays context.
+- Text matches do not resolve aliases, re-exports, or types.
+- Broad questions grow with repository size.
+
+---
+
+# The compiler already knows the graph
+
+<div class="cards">
+<div class="card"><b>Program</b>Source files, modules, compiler options, diagnostics</div>
+<div class="card"><b>TypeChecker</b>Symbols, types, signatures, declarations</div>
+<div class="card accent"><b>@ttsc/graph</b>Resolved nodes, edges, tests, and spans</div>
+</div>
+
+<br />
+
+`@ttsc/graph` reads the resident TypeScript-Go compiler session.
+
+---
+
+# Compiler-exact relationships
+
+- `tsconfig` path aliases land on the real declaration.
+- Barrel re-exports preserve symbol identity.
+- pnpm workspace packages and project references resolve normally.
+- Symlinks and module-resolution rules are already settled.
+- Diagnostics and graph facts describe the same `Program`.
+
+> A syntax index can infer these edges. The compiler has already proved them.
+
+---
+
+# It returns an index, never source bodies
+
+```text
+CheckoutService.place
+  signature  place(input: IOrderInput): Promise<IOrder>
+  declared   src/checkout/CheckoutService.ts:41-88
+  calls      Inventory.reserve, Payment.authorize
+  testedBy   test_checkout_place
+```
+
+- Names, signatures, edges, decorators, tests, and source spans
+- No implementation body in the MCP response
+- Read the smallest span only when body text is actually needed
+
+---
+
+# Why “index only” matters
+
+<div class="cols">
+<div>
+
+## Source bodies
+
+- Output grows with every selected file
+- Broad queries spill large context
+- The agent must interpret raw implementation again
+
+</div>
+<div>
+
+## Graph index
+
+- Output grows with the answer
+- Relationships arrive resolved
+- A span anchors any necessary follow-up
+
+</div>
+</div>
+
+---
+
+<!-- _class: divider -->
+
+# One tool, with an escape hatch
+
+## Guide the decision without replacing the agent's workflow
+
+---
+
+# One MCP surface
+
+```ts
+inspect_typescript_graph({
+  question,
+  draft: { type, reason },
+  review,
+  request,
+});
+```
+
+The request is a discriminated union. Choosing its `type` chooses the operation.
+
+---
+
+# The schema carries the reasoning path
+
+<div class="flow">
+  <span>Question</span><i>→</i><span>Draft</span><i>→</i><span>Review</span><i>→</i><span>Request</span>
+</div>
+
+- `draft` names the smallest operation that looks sufficient.
+- `review` can correct an over-broad or off-graph plan.
+- `request` commits exactly one typed operation.
+
+Free prose can skip a step. A required schema field cannot.
+
+---
+
+# Seven request types
+
+| Type          | Use it for                         |
+| ------------- | ---------------------------------- |
+| `tour`        | Broad, one-call architecture tour  |
+| `entrypoints` | Where to start reading             |
+| `lookup`      | Find a symbol by name              |
+| `trace`       | Follow calls, data flow, or impact |
+| `details`     | Signature, members, and neighbors  |
+| `overview`    | Repository-level structure         |
+| `escape`      | The evidence is outside the graph  |
+
+---
+
+# Escape is a first-class success
+
+Use the graph when the answer depends on TypeScript symbols, calls, or types.
+
+Use `escape` when the answer depends on:
+
+- exact implementation text;
+- configuration or documentation;
+- runtime state or external systems;
+- a non-TypeScript project.
+
+---
+
+# Fresh on every operation
+
+- No separate `init` command
+- No repository-local index to remember or commit
+- Unchanged calls reuse warm in-memory indexes
+- Safe edits reuse the incremental compiler `Program`
+- Config, roots, deletion, or resolution changes trigger a reload
+- Refresh failure returns an error, never a stale graph
+
+---
+
+# The same graph is visible in 3D
+
+![3D TypeScript code graph](/graph/vscode.png)
+
+<p class="note center">Every node is a declaration. Every edge is a compiler-resolved relationship.</p>
+
+---
+
+<!-- _class: divider -->
+
+# Does the index reduce agent cost?
+
+## Empty-MCP baseline versus four graph tools
+
+---
+
+# Benchmark design
+
+- Eight TypeScript repositories, from 51k to 3.1M lines
+- Common onboarding prompt and repository-specific prompts
+- Empty-MCP baseline plus `@ttsc/graph`, codegraph, codebase-memory, and serena
+- Codex and Claude Code model lanes at high reasoning effort
+- One published run per cell; repository breadth is the sample
+
+<p class="note">This is one person's bounded benchmark. It is not a universal performance guarantee.</p>
+
+---
+
+# The headline
+
+<div class="cards">
+<div class="card accent"><span class="metric">~10×</span>fewer tokens<br /><span class="note">conservative median</span></div>
+<div class="card"><span class="metric">8</span>repositories<br /><span class="note">51k to 3.1M lines</span></div>
+<div class="card"><span class="metric">1</span>typed tool<br /><span class="note">index, never bodies</span></div>
+</div>
+
+<br />
+
+Answer quality was manually inspected; free-text matching was not used as an oracle.
+
+---
+
+# Cost stays flat as repositories grow
+
+```text
+small TypeScript project  ─┐
+medium monorepo           ├─ answer-sized graph response
+3M-line VS Code           ┘
+```
+
+- Baseline and comparator costs swing with repository size.
+- `@ttsc/graph` stays near the cost of the requested index.
+- Some comparator cells cost more than running with no MCP.
+
+---
+
+# Cold time matters too
+
+On the three-million-line VS Code fixture:
+
+<div class="cards">
+<div class="card accent"><span class="metric">&lt;30s</span>`@ttsc/graph` compiler index</div>
+<div class="card warm"><span class="metric">~12m</span>codegraph index build</div>
+<div class="card warm"><span class="metric">~5m</span>serena project indexing</div>
+</div>
+
+<br />
+
+The published chart adds index readiness and LLM answer time in the order a developer waits.
+
+---
+
+# The trade
+
+| Tool shape | Strength | Cost |
+| --- | --- | --- |
+| `@ttsc/graph` | compiler-exact TS graph, one tool | TypeScript only |
+| codegraph | one default tool, many languages | text-inferred edges, source bodies |
+| codebase-memory | broad multi-language graph | many tools and explicit indexing |
+| serena | LSP-resolved symbols, editing suite | broad tool surface and setup |
+
+---
+
+# Add it in four lines
+
+```bash
+npm install -D ttsc @ttsc/graph typescript
+```
+
+```json
+{
+  "mcpServers": {
+    "ttsc-graph": {
+      "command": "npx",
+      "args": ["-y", "@ttsc/graph"]
+    }
+  }
+}
+```
+
+---
+
+# Explore your graph in the browser
+
+```bash
+npx @ttsc/graph view
+```
+
+- Opens the project graph in a 3D viewer.
+- Color and filter by declaration or edge kind.
+- Inspect incoming and outgoing relationships.
+- Export a snapshot for sharing.
+
+---
+
+# Boundaries are deliberate
+
+- TypeScript only: compiler depth is tied to one language.
+- An index is not the implementation body.
+- Graph evidence cannot answer config, prose, runtime, or external-state questions.
+- The benchmark result can be lower or negative on a different workload.
+
+The tool steps aside when its evidence is not the right evidence.
+
+---
+
+<!-- _class: lead graph -->
+
+# TypeScript Compiler Knowledge Graph
+
+- Trust compiler-resolved relationships.
+- Return the index, never the source bodies.
+- Shape one tool so the agent can choose well.
+
+<span class="punch">Exact → trusted → done.</span>
+
+---
+
+<!-- _class: lead graph -->
+<!-- _paginate: false -->
+
+# Q & A
+
+- [ttsc.dev/docs/graph](https://ttsc.dev/docs/graph)
+- [ttsc.dev/docs/benchmark/graph](https://ttsc.dev/docs/benchmark/graph)
+- [github.com/samchon/ttsc](https://github.com/samchon/ttsc)

--- a/website/src/slides/themes/ttsc.css
+++ b/website/src/slides/themes/ttsc.css
@@ -1,0 +1,338 @@
+/* @theme ttsc */
+
+@import "default";
+
+:root {
+  --ink: #102a43;
+  --muted: #627d98;
+  --line: #d8e7f4;
+  --panel: #f4f9fd;
+  --blue: #3178c6;
+  --cyan: #00b8d9;
+  --green: #24d69b;
+  --orange: #ff9f43;
+  --night: #07111f;
+}
+
+section {
+  box-sizing: border-box;
+  padding: 56px 68px;
+  background: #fff;
+  color: var(--ink);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  font-size: 29px;
+  line-height: 1.45;
+}
+
+section::after {
+  right: 30px;
+  bottom: 22px;
+  color: #9fb3c8;
+  font-size: 15px;
+}
+
+h1,
+h2,
+h3,
+p,
+ul,
+ol,
+pre,
+table {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 28px;
+  color: var(--ink);
+  font-size: 48px;
+  letter-spacing: -0.035em;
+}
+
+h2 {
+  color: var(--blue);
+  font-size: 30px;
+}
+
+strong {
+  color: var(--blue);
+}
+
+a {
+  color: var(--blue);
+}
+
+li {
+  margin-bottom: 14px;
+}
+
+code {
+  border-radius: 6px;
+  background: #eaf3fb;
+  color: #174f80;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+pre {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #0b1727;
+  color: #e7f2ff;
+  font-size: 21px;
+  line-height: 1.45;
+}
+
+pre code {
+  background: transparent;
+  color: inherit;
+}
+
+table {
+  width: 100%;
+  font-size: 24px;
+}
+
+th {
+  background: var(--ink);
+  color: #fff;
+}
+
+td,
+th {
+  padding: 10px 14px;
+}
+
+blockquote {
+  margin: 24px 0 0;
+  border-left: 7px solid var(--orange);
+  background: #fff7e8;
+  color: #334e68;
+  font-size: 27px;
+}
+
+footer {
+  left: 68px;
+  bottom: 20px;
+  color: #9fb3c8;
+  font-size: 14px;
+}
+
+section.lead,
+section.divider {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background: radial-gradient(
+    circle at 72% 35%,
+    #12355a 0,
+    var(--night) 45%,
+    #040a12 100%
+  );
+  color: #e7f2ff;
+}
+
+section.lead h1,
+section.divider h1 {
+  color: #fff;
+  font-size: 62px;
+}
+
+section.lead h2,
+section.divider h2 {
+  color: #7dd3fc;
+  font-size: 32px;
+}
+
+section.lead strong,
+section.divider strong {
+  color: var(--green);
+}
+
+section.lead code,
+section.divider code {
+  background: #15263a;
+  color: #7dd3fc;
+}
+
+section.divider {
+  text-align: center;
+}
+
+section.evidence {
+  background-image:
+    radial-gradient(circle at 82% 22%, rgb(36 214 155 / 18%), transparent 32%),
+    radial-gradient(circle at 70% 75%, rgb(0 184 217 / 16%), transparent 34%),
+    linear-gradient(135deg, #06101d, #07111f 60%, #02070d);
+}
+
+section.graph {
+  background-image:
+    radial-gradient(circle at 72% 34%, rgb(49 120 198 / 30%), transparent 34%),
+    radial-gradient(circle at 78% 74%, rgb(36 214 155 / 16%), transparent 30%),
+    linear-gradient(135deg, #050c16, #07111f 62%, #02070d);
+}
+
+.eyebrow {
+  margin-bottom: 14px;
+  color: var(--green);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 26px;
+  font-weight: 700;
+}
+
+.lede {
+  max-width: 940px;
+  color: #b9c9dc;
+  font-size: 31px;
+}
+
+.note {
+  color: var(--muted);
+  font-size: 20px;
+}
+
+.lead .note,
+.divider .note {
+  color: #9fb3c8;
+}
+
+.punch {
+  display: block;
+  color: var(--green);
+  font-size: 48px;
+  font-weight: 800;
+  letter-spacing: -0.035em;
+  line-height: 1.25;
+}
+
+.cols {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 28px;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.card {
+  border: 1px solid var(--line);
+  border-top: 6px solid var(--blue);
+  border-radius: 12px;
+  background: var(--panel);
+  padding: 20px 22px;
+  font-size: 23px;
+}
+
+.card b {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--ink);
+  font-size: 31px;
+}
+
+.card.accent {
+  border-top-color: var(--green);
+}
+
+.card.warm {
+  border-top-color: var(--orange);
+}
+
+.metric {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--blue);
+  font-size: 45px;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.accent .metric {
+  color: #128765;
+}
+
+.warm .metric {
+  color: #b96812;
+}
+
+.flow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin: 34px 0;
+  font-size: 25px;
+  font-weight: 700;
+}
+
+.flow span {
+  border: 1px solid #b8d5ed;
+  border-radius: 10px;
+  background: #edf6fc;
+  padding: 14px 18px;
+}
+
+.flow i {
+  color: var(--blue);
+  font-style: normal;
+  font-size: 34px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 120px 1fr 140px;
+  align-items: center;
+  gap: 14px;
+  margin: 14px 0;
+  font-size: 22px;
+}
+
+.bar {
+  height: 18px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e3edf5;
+}
+
+.bar i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--blue);
+}
+
+.bar.green i {
+  background: var(--green);
+}
+
+.center {
+  text-align: center;
+}
+
+.small {
+  font-size: 21px;
+}
+
+.tight li {
+  margin-bottom: 8px;
+}
+
+.screenshot {
+  display: block;
+  max-width: 720px;
+  max-height: 470px;
+  margin: 0 auto;
+  border: 1px solid #b8d5ed;
+  border-radius: 14px;
+  box-shadow: 0 20px 50px rgb(16 42 67 / 18%);
+}

--- a/website/test/slides.test.cjs
+++ b/website/test/slides.test.cjs
@@ -1,0 +1,60 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { readSlides } = require("../build/slides-metadata.cjs");
+
+/**
+ * Verifies website export: every declared slide has one navigable deck and one
+ * social card.
+ *
+ * The list page, dynamic route, and Marp output read the same frontmatter, so
+ * this assertion checks the exported consequence rather than trusting three
+ * source-only integrations that could drift independently.
+ *
+ * 1. Read every source deck and the exported slides index.
+ * 2. Assert each card links to a generated Marp presentation with its own image.
+ * 3. Assert each route exports the deck-specific title, summary, and Open Graph
+ *    image.
+ */
+test("static slide routes publish their decks and social metadata", () => {
+  const websiteRoot = path.resolve(__dirname, "..");
+  const outputRoot = path.join(websiteRoot, "out");
+  const indexHtml = fs.readFileSync(
+    path.join(outputRoot, "slides", "index.html"),
+    "utf8",
+  );
+  const slides = readSlides();
+
+  assert.deepEqual(slides.map((slide) => slide.slug).sort(), [
+    "evidence",
+    "graph",
+  ]);
+  for (const slide of slides) {
+    const source = fs.readFileSync(slide.file, "utf8");
+    const deckHtml = fs.readFileSync(
+      path.join(outputRoot, "slides-static", slide.slug, "index.html"),
+      "utf8",
+    );
+    const routeHtml = fs.readFileSync(
+      path.join(outputRoot, "slides", slide.slug, "index.html"),
+      "utf8",
+    );
+
+    assert.match(indexHtml, new RegExp(`href="${slide.route}/?"`));
+    assert.ok(indexHtml.includes(slide.description));
+    assert.ok(indexHtml.includes(new URL(slide.image).pathname));
+    assert.match(deckHtml, /data-bespoke-marp/);
+    assert.ok(deckHtml.includes(slide.title));
+    assert.ok(routeHtml.includes(slide.staticRoute));
+    assert.ok(routeHtml.includes(slide.description));
+    assert.ok(routeHtml.includes(slide.image));
+    if (slide.slug === "evidence")
+      assert.doesNotMatch(
+        source,
+        /[가-힣]/,
+        "evidence.md must stay in English",
+      );
+  }
+});


### PR DESCRIPTION
## Intent

Publish the repository's Marp presentations at stable ttsc.dev routes and give visitors a browsable slide index with module-specific social images.

## Scope

- compile every `website/src/slides/*.md` deck into generated Marp HTML during website development and deployment builds;
- publish `/slides`, `/slides/evidence`, and `/slides/graph` as statically exported Next.js routes;
- use each deck's frontmatter as the shared source for list copy, canonical metadata, Open Graph metadata, and Marp metadata;
- rewrite the Evidence Graph deck in English and add the TypeScript Compiler Knowledge Graph deck;
- reuse the existing `og-evidence.png` and `og-graph.png` assets as module-specific list thumbnails and social cards;
- assert the exported cards, routes, deck HTML, metadata, and English-only Evidence source in a website regression test.

## User impact

Visitors can browse presentations at `https://ttsc.dev/slides/` and present either deck full-screen with Marp keyboard, touch, overview, and presenter controls. Direct links carry deck-specific titles, summaries, canonicals, and Open Graph images.

## Verification

- `pnpm format`
- `pnpm --dir website run build:slides`
- `pnpm --dir website exec tsc --noEmit -p tsconfig.json`
- `pnpm --dir website run test:slides`
- `pnpm --dir website run test:rss-autodiscovery`
- `pnpm --dir website run test:typia-dependency-graph`
- browser screenshots of `/slides/`, `/slides/evidence/`, and `/slides/graph/`
- HTTP 200 responses from all three routes under `next dev`

A direct `next build --webpack` completed before the request to move full build validation to CI. No local `pnpm build` was run after that request. GitHub Actions is the final deployment-build gate.

## Deferred

None.
