### PR TITLE
Round two, last cell: erp plain to completion

### DIFF
--- a/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/erp/evidence.json
+++ b/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/erp/evidence.json
@@ -56,49 +56,49 @@
     {
       "name": "backend-start",
       "tokens": 286432546,
-      "elapsedMs": 34773000,
+      "elapsedMs": 35418134.119526334,
       "tokenPercent": 70,
-      "timePercent": 71
+      "timePercent": 72
     },
     {
       "name": "backend-review",
       "tokens": 33173335,
-      "elapsedMs": 5670000,
+      "elapsedMs": 5775193.98549778,
       "tokenPercent": 8,
       "timePercent": 12
     },
     {
       "name": "backend-final",
       "tokens": 2585270,
-      "elapsedMs": 170000,
+      "elapsedMs": 173153.96429182056,
       "tokenPercent": 1,
       "timePercent": 0
     },
     {
       "name": "frontend-start",
       "tokens": 61165984,
-      "elapsedMs": 4785000,
+      "elapsedMs": 4873774.818449184,
       "tokenPercent": 15,
       "timePercent": 10
     },
     {
       "name": "frontend-review",
       "tokens": 23062367,
-      "elapsedMs": 2175000,
+      "elapsedMs": 2215352.1902041747,
       "tokenPercent": 6,
-      "timePercent": 4
+      "timePercent": 5
     },
     {
       "name": "frontend-final",
       "tokens": 2017627,
-      "elapsedMs": 288000,
+      "elapsedMs": 293343.18656496657,
       "tokenPercent": 0,
       "timePercent": 1
     },
     {
       "name": "overall-final",
       "tokens": 2591366,
-      "elapsedMs": 333000,
+      "elapsedMs": 339178.0594657426,
       "tokenPercent": 1,
       "timePercent": 1
     }

--- a/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/erp/plain.json
+++ b/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/erp/plain.json
@@ -9,14 +9,14 @@
   "status": "running",
   "stage": "overall-remind-1",
   "launchedAt": "2026-08-09T18:17:34.421Z",
-  "tokens": 4213428011,
+  "tokens": 4421326468,
   "tokenUsage": {
-    "totalTokens": 4213428011,
-    "inputTokens": 4206977767,
-    "cachedInputTokens": 4119717888,
+    "totalTokens": 4421326468,
+    "inputTokens": 4414559396,
+    "cachedInputTokens": 4321676800,
     "cacheWriteInputTokens": 0,
-    "outputTokens": 6450244,
-    "reasoningOutputTokens": 1449167
+    "outputTokens": 6767072,
+    "reasoningOutputTokens": 1519867
   },
   "inspection": {
     "attempts": 11,
@@ -36,19 +36,19 @@
     "pricingAsOf": "2026-08-01",
     "priceSource": "https://openrouter.ai/api/v1/models",
     "currency": "USD",
-    "amountUsd": 53.09396068,
-    "requests": 31271,
-    "shortContextRequests": 31270,
+    "amountUsd": 55.8659183,
+    "requests": 32878,
+    "shortContextRequests": 32877,
     "longContextRequests": 1,
     "longContextThresholdTokens": 272000,
     "replayedUpdates": 0
   },
   "suspendedMs": 0,
   "suspensions": [],
-  "workElapsedMs": 292439234.52690005,
+  "workElapsedMs": 306547646.15860003,
   "worktree": {
     "files": 452,
-    "additions": 87338,
+    "additions": 87395,
     "deletions": 136
   },
   "reviewVerdicts": [
@@ -223,8 +223,8 @@
       "name": "backend-start",
       "tokens": 544228917,
       "elapsedMs": 55121000,
-      "tokenPercent": 13,
-      "timePercent": 19
+      "tokenPercent": 12,
+      "timePercent": 18
     },
     {
       "name": "backend-review",
@@ -280,7 +280,7 @@
       "tokens": 61761807,
       "elapsedMs": 4477304.8948,
       "tokenPercent": 1,
-      "timePercent": 2
+      "timePercent": 1
     },
     {
       "name": "frontend-remind-1",
@@ -326,10 +326,10 @@
     },
     {
       "name": "overall-remind-1",
-      "tokens": 2482701704,
-      "elapsedMs": 147965745.86160004,
-      "tokenPercent": 59,
-      "timePercent": 51
+      "tokens": 2690600161,
+      "elapsedMs": 162074157.49330002,
+      "tokenPercent": 61,
+      "timePercent": 53
     }
   ]
 }

--- a/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/reddit/evidence.json
+++ b/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/reddit/evidence.json
@@ -56,49 +56,49 @@
     {
       "name": "backend-start",
       "tokens": 172779712,
-      "elapsedMs": 15908000,
+      "elapsedMs": 16148867.516013412,
       "tokenPercent": 71,
-      "timePercent": 66
+      "timePercent": 67
     },
     {
       "name": "backend-review",
       "tokens": 16278832,
-      "elapsedMs": 1904000,
+      "elapsedMs": 1932829.0011622792,
       "tokenPercent": 7,
       "timePercent": 8
     },
     {
       "name": "backend-final",
       "tokens": 3036565,
-      "elapsedMs": 222000,
+      "elapsedMs": 225361.36463131616,
       "tokenPercent": 1,
       "timePercent": 1
     },
     {
       "name": "frontend-start",
       "tokens": 25307573,
-      "elapsedMs": 2746000,
+      "elapsedMs": 2787577.960709884,
       "tokenPercent": 10,
-      "timePercent": 11
+      "timePercent": 12
     },
     {
       "name": "frontend-review",
       "tokens": 16424549,
-      "elapsedMs": 1990000,
+      "elapsedMs": 2020131.151424861,
       "tokenPercent": 7,
       "timePercent": 8
     },
     {
       "name": "frontend-final",
       "tokens": 3722475,
-      "elapsedMs": 455000,
+      "elapsedMs": 461889.2833659858,
       "tokenPercent": 2,
       "timePercent": 2
     },
     {
       "name": "overall-final",
       "tokens": 7474925,
-      "elapsedMs": 571000,
+      "elapsedMs": 579645.6720922592,
       "tokenPercent": 3,
       "timePercent": 2
     }

--- a/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/reddit/plain.json
+++ b/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/reddit/plain.json
@@ -282,140 +282,140 @@
     {
       "name": "backend-start",
       "tokens": 37147695,
-      "elapsedMs": 4071000,
+      "elapsedMs": 4118331.6701621157,
       "tokenPercent": 3,
       "timePercent": 5
     },
     {
       "name": "backend-review",
       "tokens": 82976296,
-      "elapsedMs": 5591546.8352,
+      "elapsedMs": 5652609.45659313,
       "tokenPercent": 7,
       "timePercent": 7
     },
     {
       "name": "backend-remind-1",
       "tokens": 49109000,
-      "elapsedMs": 3303948.1599,
+      "elapsedMs": 3339083.5829483694,
       "tokenPercent": 4,
       "timePercent": 4
     },
     {
       "name": "backend-remind-2",
       "tokens": 208492738,
-      "elapsedMs": 15767011.343,
+      "elapsedMs": 15944013.884524945,
       "tokenPercent": 18,
       "timePercent": 19
     },
     {
       "name": "backend-remind-3",
       "tokens": 47983418,
-      "elapsedMs": 3154986.9778,
+      "elapsedMs": 3186715.8227698877,
       "tokenPercent": 4,
       "timePercent": 4
     },
     {
       "name": "backend-remind-4",
       "tokens": 40624253,
-      "elapsedMs": 2280583.9877,
+      "elapsedMs": 2302883.703585762,
       "tokenPercent": 3,
       "timePercent": 3
     },
     {
       "name": "backend-final",
       "tokens": 10537311,
-      "elapsedMs": 786000,
+      "elapsedMs": 795138.4654255522,
       "tokenPercent": 1,
       "timePercent": 1
     },
     {
       "name": "frontend-start",
       "tokens": 26280767,
-      "elapsedMs": 3177000,
+      "elapsedMs": 3213937.537731526,
       "tokenPercent": 2,
       "timePercent": 4
     },
     {
       "name": "frontend-review",
       "tokens": 70195703,
-      "elapsedMs": 5698772.6620000005,
+      "elapsedMs": 5759893.416124845,
       "tokenPercent": 6,
       "timePercent": 7
     },
     {
       "name": "frontend-remind-1",
       "tokens": 65972171,
-      "elapsedMs": 4324102.8373,
+      "elapsedMs": 4369120.824739871,
       "tokenPercent": 6,
       "timePercent": 5
     },
     {
       "name": "frontend-remind-2",
       "tokens": 56761212,
-      "elapsedMs": 2632540.2255,
+      "elapsedMs": 2659688.211210769,
       "tokenPercent": 5,
       "timePercent": 3
     },
     {
       "name": "frontend-remind-3",
       "tokens": 43682044,
-      "elapsedMs": 2897517.9836999997,
+      "elapsedMs": 2923084.759108129,
       "tokenPercent": 4,
       "timePercent": 4
     },
     {
       "name": "frontend-remind-4",
       "tokens": 41054672,
-      "elapsedMs": 2432789.0904,
+      "elapsedMs": 2456042.1830858835,
       "tokenPercent": 3,
       "timePercent": 3
     },
     {
       "name": "frontend-final",
       "tokens": 1663517,
-      "elapsedMs": 231000,
+      "elapsedMs": 233685.73220521954,
       "tokenPercent": 0,
       "timePercent": 0
     },
     {
       "name": "overall-review",
       "tokens": 53586601,
-      "elapsedMs": 2810671.055,
+      "elapsedMs": 2839039.828076778,
       "tokenPercent": 5,
       "timePercent": 3
     },
     {
       "name": "overall-remind-1",
       "tokens": 98007034,
-      "elapsedMs": 6855693.586,
+      "elapsedMs": 6928557.151931216,
       "tokenPercent": 8,
       "timePercent": 8
     },
     {
       "name": "overall-remind-2",
       "tokens": 60876838,
-      "elapsedMs": 3958470.2195,
+      "elapsedMs": 3999104.998968581,
       "tokenPercent": 5,
       "timePercent": 5
     },
     {
       "name": "overall-remind-3",
       "tokens": 68323444,
-      "elapsedMs": 4992111.3856,
+      "elapsedMs": 5042454.331264937,
       "tokenPercent": 6,
       "timePercent": 6
     },
     {
       "name": "overall-remind-4",
       "tokens": 73372054,
-      "elapsedMs": 4506711.9823,
+      "elapsedMs": 4555078.415086637,
       "tokenPercent": 6,
       "timePercent": 6
     },
     {
       "name": "overall-final",
       "tokens": 42175361,
-      "elapsedMs": 1475000,
+      "elapsedMs": 1492149.155855839,
       "tokenPercent": 4,
       "timePercent": 2
     }

--- a/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/shopping/evidence.json
+++ b/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/shopping/evidence.json
@@ -56,49 +56,49 @@
     {
       "name": "backend-start",
       "tokens": 105617004,
-      "elapsedMs": 10082000,
+      "elapsedMs": 10164212.193342842,
       "tokenPercent": 39,
       "timePercent": 38
     },
     {
       "name": "backend-review",
       "tokens": 78806134,
-      "elapsedMs": 8685000,
+      "elapsedMs": 8755820.561315471,
       "tokenPercent": 29,
-      "timePercent": 32
+      "timePercent": 33
     },
     {
       "name": "backend-final",
       "tokens": 782876,
-      "elapsedMs": 82000,
+      "elapsedMs": 82668.65699802748,
       "tokenPercent": 0,
       "timePercent": 0
     },
     {
       "name": "frontend-start",
       "tokens": 52825873,
-      "elapsedMs": 5235000,
+      "elapsedMs": 5277688.041276511,
       "tokenPercent": 20,
       "timePercent": 20
     },
     {
       "name": "frontend-review",
       "tokens": 19862471,
-      "elapsedMs": 1662000,
+      "elapsedMs": 1675552.5357405082,
       "tokenPercent": 7,
       "timePercent": 6
     },
     {
       "name": "frontend-final",
       "tokens": 6385192,
-      "elapsedMs": 449000,
+      "elapsedMs": 452661.3047818822,
       "tokenPercent": 2,
       "timePercent": 2
     },
     {
       "name": "overall-final",
       "tokens": 6301255,
-      "elapsedMs": 370000,
+      "elapsedMs": 373017.11084475816,
       "tokenPercent": 2,
       "timePercent": 1
     }

--- a/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/shopping/plain.json
+++ b/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/shopping/plain.json
@@ -282,140 +282,140 @@
     {
       "name": "backend-start",
       "tokens": 42694073,
-      "elapsedMs": 4585000,
+      "elapsedMs": 4616508.1941089425,
       "tokenPercent": 3,
       "timePercent": 4
     },
     {
       "name": "backend-review",
       "tokens": 67535297,
-      "elapsedMs": 5284030.5624,
+      "elapsedMs": 5318232.586844974,
       "tokenPercent": 4,
       "timePercent": 5
     },
     {
       "name": "backend-remind-1",
       "tokens": 115178752,
-      "elapsedMs": 9378886.9744,
+      "elapsedMs": 9441016.872532813,
       "tokenPercent": 8,
       "timePercent": 9
     },
     {
       "name": "backend-remind-2",
       "tokens": 191241167,
-      "elapsedMs": 13844209.6011,
+      "elapsedMs": 13936301.489705002,
       "tokenPercent": 13,
       "timePercent": 13
     },
     {
       "name": "backend-remind-3",
       "tokens": 20839833,
-      "elapsedMs": 1732174.3956,
+      "elapsedMs": 1741272.9450002704,
       "tokenPercent": 1,
       "timePercent": 2
     },
     {
       "name": "backend-remind-4",
       "tokens": 75418648,
-      "elapsedMs": 4279819.1518,
+      "elapsedMs": 4305431.156040791,
       "tokenPercent": 5,
       "timePercent": 4
     },
     {
       "name": "backend-final",
       "tokens": 1471628,
-      "elapsedMs": 217000,
+      "elapsedMs": 218491.22750744614,
       "tokenPercent": 0,
       "timePercent": 0
     },
     {
       "name": "frontend-start",
       "tokens": 28745673,
-      "elapsedMs": 2752000,
+      "elapsedMs": 2770911.788481529,
       "tokenPercent": 2,
       "timePercent": 3
     },
     {
       "name": "frontend-review",
       "tokens": 69554521,
-      "elapsedMs": 5125564.1481,
+      "elapsedMs": 5159443.187785297,
       "tokenPercent": 5,
       "timePercent": 5
     },
     {
       "name": "frontend-remind-1",
       "tokens": 89918241,
-      "elapsedMs": 6077885.8759,
+      "elapsedMs": 6116369.166414739,
       "tokenPercent": 6,
       "timePercent": 6
     },
     {
       "name": "frontend-remind-2",
       "tokens": 50580818,
-      "elapsedMs": 4121590.2933,
+      "elapsedMs": 4148116.2756905165,
       "tokenPercent": 3,
       "timePercent": 4
     },
     {
       "name": "frontend-remind-3",
       "tokens": 80660547,
-      "elapsedMs": 6848706.9738,
+      "elapsedMs": 6893546.879265834,
       "tokenPercent": 5,
       "timePercent": 6
     },
     {
       "name": "frontend-remind-4",
       "tokens": 38490793,
-      "elapsedMs": 3313022.7095,
+      "elapsedMs": 3333783.0703294687,
       "tokenPercent": 3,
       "timePercent": 3
     },
     {
       "name": "frontend-final",
       "tokens": 27792651,
-      "elapsedMs": 1684000,
+      "elapsedMs": 1695572.475219075,
       "tokenPercent": 2,
       "timePercent": 2
     },
     {
       "name": "overall-review",
       "tokens": 63301123,
-      "elapsedMs": 3983393.1923,
+      "elapsedMs": 4008283.63484364,
       "tokenPercent": 4,
       "timePercent": 4
     },
     {
       "name": "overall-remind-1",
       "tokens": 116382187,
-      "elapsedMs": 6833684.1211,
+      "elapsedMs": 6878139.193660687,
       "tokenPercent": 8,
       "timePercent": 6
     },
     {
       "name": "overall-remind-2",
       "tokens": 169075457,
-      "elapsedMs": 10016109.3149,
+      "elapsedMs": 10081599.62893669,
       "tokenPercent": 11,
-      "timePercent": 9
+      "timePercent": 10
     },
     {
       "name": "overall-remind-3",
       "tokens": 56045827,
-      "elapsedMs": 4095442.888,
+      "elapsedMs": 4120786.8836104204,
       "tokenPercent": 4,
       "timePercent": 4
     },
     {
       "name": "overall-remind-4",
       "tokens": 189988869,
-      "elapsedMs": 10223837.942,
+      "elapsedMs": 10291699.101613043,
       "tokenPercent": 13,
       "timePercent": 10
     },
     {
       "name": "overall-final",
       "tokens": 21074247,
-      "elapsedMs": 1009000,
+      "elapsedMs": 1015933.8643088163,
       "tokenPercent": 1,
       "timePercent": 1
     }

--- a/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/todo/evidence.json
+++ b/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/todo/evidence.json
@@ -56,49 +56,49 @@
     {
       "name": "backend-start",
       "tokens": 36526952,
-      "elapsedMs": 4879000,
+      "elapsedMs": 4917235.1725632325,
       "tokenPercent": 40,
       "timePercent": 45
     },
     {
       "name": "backend-review",
       "tokens": 11510707,
-      "elapsedMs": 967000,
+      "elapsedMs": 974578.0717090892,
       "tokenPercent": 13,
       "timePercent": 9
     },
     {
       "name": "backend-final",
       "tokens": 2434939,
-      "elapsedMs": 352000,
+      "elapsedMs": 354758.51214229513,
       "tokenPercent": 3,
       "timePercent": 3
     },
     {
       "name": "frontend-start",
       "tokens": 29777795,
-      "elapsedMs": 3175000,
+      "elapsedMs": 3199881.4660562132,
       "tokenPercent": 32,
-      "timePercent": 29
+      "timePercent": 30
     },
     {
       "name": "frontend-review",
       "tokens": 8755740,
-      "elapsedMs": 938000,
+      "elapsedMs": 945350.8079246387,
       "tokenPercent": 10,
       "timePercent": 9
     },
     {
       "name": "frontend-final",
       "tokens": 669850,
-      "elapsedMs": 93000,
+      "elapsedMs": 93728.81144668593,
       "tokenPercent": 1,
       "timePercent": 1
     },
     {
       "name": "overall-final",
       "tokens": 2404927,
-      "elapsedMs": 323000,
+      "elapsedMs": 325531.24835784466,
       "tokenPercent": 3,
       "timePercent": 3
     }

--- a/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/todo/plain.json
+++ b/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/todo/plain.json
@@ -282,140 +282,140 @@
     {
       "name": "backend-start",
       "tokens": 32898028,
-      "elapsedMs": 3710000,
+      "elapsedMs": 3822805.3805396906,
       "tokenPercent": 4,
       "timePercent": 6
     },
     {
       "name": "backend-review",
       "tokens": 33580868,
-      "elapsedMs": 3023317.0952,
+      "elapsedMs": 3104530.8880359875,
       "tokenPercent": 4,
       "timePercent": 5
     },
     {
       "name": "backend-remind-1",
       "tokens": 18894976,
-      "elapsedMs": 1589424.6472,
+      "elapsedMs": 1628769.7044556227,
       "tokenPercent": 2,
       "timePercent": 3
     },
     {
       "name": "backend-remind-2",
       "tokens": 36281554,
-      "elapsedMs": 2271679.2040999997,
+      "elapsedMs": 2329936.6459097164,
       "tokenPercent": 4,
       "timePercent": 4
     },
     {
       "name": "backend-remind-3",
       "tokens": 52679325,
-      "elapsedMs": 2832359.1956,
+      "elapsedMs": 2906275.605328299,
       "tokenPercent": 6,
       "timePercent": 5
     },
     {
       "name": "backend-remind-4",
       "tokens": 43373718,
-      "elapsedMs": 3221239.6574999997,
+      "elapsedMs": 3308747.4432663694,
       "tokenPercent": 5,
       "timePercent": 5
     },
     {
       "name": "backend-final",
       "tokens": 4754945,
-      "elapsedMs": 290000,
+      "elapsedMs": 298817.6712551241,
       "tokenPercent": 1,
       "timePercent": 0
     },
     {
       "name": "frontend-start",
       "tokens": 50709138,
-      "elapsedMs": 3622000,
+      "elapsedMs": 3732129.673400205,
       "tokenPercent": 6,
       "timePercent": 6
     },
     {
       "name": "frontend-review",
       "tokens": 69109422,
-      "elapsedMs": 4361193.6012,
+      "elapsedMs": 4484975.462164173,
       "tokenPercent": 8,
       "timePercent": 7
     },
     {
       "name": "frontend-remind-1",
       "tokens": 63841789,
-      "elapsedMs": 4352773.5722,
+      "elapsedMs": 4469805.3537895605,
       "tokenPercent": 7,
       "timePercent": 7
     },
     {
       "name": "frontend-remind-2",
       "tokens": 3320544,
-      "elapsedMs": 364663.9853,
+      "elapsedMs": 365910.62158089684,
       "tokenPercent": 0,
       "timePercent": 1
     },
     {
       "name": "frontend-remind-3",
       "tokens": 31206831,
-      "elapsedMs": 2958068.7285,
+      "elapsedMs": 3034539.22231599,
       "tokenPercent": 4,
       "timePercent": 5
     },
     {
       "name": "frontend-remind-4",
       "tokens": 10703174,
-      "elapsedMs": 1044525.2353000001,
+      "elapsedMs": 1066539.0076748615,
       "tokenPercent": 1,
       "timePercent": 2
     },
     {
       "name": "frontend-final",
       "tokens": 53074870,
-      "elapsedMs": 2101000,
+      "elapsedMs": 2164882.5079552266,
       "tokenPercent": 6,
-      "timePercent": 3
+      "timePercent": 4
     },
     {
       "name": "overall-review",
       "tokens": 88433894,
-      "elapsedMs": 6443501.0488,
+      "elapsedMs": 6628641.739394657,
       "tokenPercent": 10,
       "timePercent": 11
     },
     {
       "name": "overall-remind-1",
       "tokens": 112108763,
-      "elapsedMs": 8449343.1564,
+      "elapsedMs": 8698852.847157063,
       "tokenPercent": 13,
       "timePercent": 14
     },
     {
       "name": "overall-remind-2",
       "tokens": 71894635,
-      "elapsedMs": 3612361.3051,
+      "elapsedMs": 3704551.5783604695,
       "tokenPercent": 8,
       "timePercent": 6
     },
     {
       "name": "overall-remind-3",
       "tokens": 34055108,
-      "elapsedMs": 1456650.6908,
+      "elapsedMs": 1491039.6086949839,
       "tokenPercent": 4,
       "timePercent": 2
     },
     {
       "name": "overall-remind-4",
       "tokens": 39169963,
-      "elapsedMs": 2596564.2998,
+      "elapsedMs": 2665707.0047453525,
       "tokenPercent": 5,
       "timePercent": 4
     },
     {
       "name": "overall-final",
       "tokens": 16107600,
-      "elapsedMs": 921000,
+      "elapsedMs": 949003.7076757562,
       "tokenPercent": 2,
       "timePercent": 2
     }

--- a/benchmarks/evidence/aggregate/summary.json
+++ b/benchmarks/evidence/aggregate/summary.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-13T06:16:50.487Z",
+  "generatedAt": "2026-08-13T10:15:44.594Z",
   "origin": "samchon/ttsc",
   "cells": [
     {
@@ -286,140 +286,140 @@
         {
           "name": "backend-start",
           "tokens": 32898028,
-          "elapsedMs": 3710000,
+          "elapsedMs": 3822805.3805396906,
           "tokenPercent": 4,
           "timePercent": 6
         },
         {
           "name": "backend-review",
           "tokens": 33580868,
-          "elapsedMs": 3023317.0952,
+          "elapsedMs": 3104530.8880359875,
           "tokenPercent": 4,
           "timePercent": 5
         },
         {
           "name": "backend-remind-1",
           "tokens": 18894976,
-          "elapsedMs": 1589424.6472,
+          "elapsedMs": 1628769.7044556227,
           "tokenPercent": 2,
           "timePercent": 3
         },
         {
           "name": "backend-remind-2",
           "tokens": 36281554,
-          "elapsedMs": 2271679.2040999997,
+          "elapsedMs": 2329936.6459097164,
           "tokenPercent": 4,
           "timePercent": 4
         },
         {
           "name": "backend-remind-3",
           "tokens": 52679325,
-          "elapsedMs": 2832359.1956,
+          "elapsedMs": 2906275.605328299,
           "tokenPercent": 6,
           "timePercent": 5
         },
         {
           "name": "backend-remind-4",
           "tokens": 43373718,
-          "elapsedMs": 3221239.6574999997,
+          "elapsedMs": 3308747.4432663694,
           "tokenPercent": 5,
           "timePercent": 5
         },
         {
           "name": "backend-final",
           "tokens": 4754945,
-          "elapsedMs": 290000,
+          "elapsedMs": 298817.6712551241,
           "tokenPercent": 1,
           "timePercent": 0
         },
         {
           "name": "frontend-start",
           "tokens": 50709138,
-          "elapsedMs": 3622000,
+          "elapsedMs": 3732129.673400205,
           "tokenPercent": 6,
           "timePercent": 6
         },
         {
           "name": "frontend-review",
           "tokens": 69109422,
-          "elapsedMs": 4361193.6012,
+          "elapsedMs": 4484975.462164173,
           "tokenPercent": 8,
           "timePercent": 7
         },
         {
           "name": "frontend-remind-1",
           "tokens": 63841789,
-          "elapsedMs": 4352773.5722,
+          "elapsedMs": 4469805.3537895605,
           "tokenPercent": 7,
           "timePercent": 7
         },
         {
           "name": "frontend-remind-2",
           "tokens": 3320544,
-          "elapsedMs": 364663.9853,
+          "elapsedMs": 365910.62158089684,
           "tokenPercent": 0,
           "timePercent": 1
         },
         {
           "name": "frontend-remind-3",
           "tokens": 31206831,
-          "elapsedMs": 2958068.7285,
+          "elapsedMs": 3034539.22231599,
           "tokenPercent": 4,
           "timePercent": 5
         },
         {
           "name": "frontend-remind-4",
           "tokens": 10703174,
-          "elapsedMs": 1044525.2353000001,
+          "elapsedMs": 1066539.0076748615,
           "tokenPercent": 1,
           "timePercent": 2
         },
         {
           "name": "frontend-final",
           "tokens": 53074870,
-          "elapsedMs": 2101000,
+          "elapsedMs": 2164882.5079552266,
           "tokenPercent": 6,
-          "timePercent": 3
+          "timePercent": 4
         },
         {
           "name": "overall-review",
           "tokens": 88433894,
-          "elapsedMs": 6443501.0488,
+          "elapsedMs": 6628641.739394657,
           "tokenPercent": 10,
           "timePercent": 11
         },
         {
           "name": "overall-remind-1",
           "tokens": 112108763,
-          "elapsedMs": 8449343.1564,
+          "elapsedMs": 8698852.847157063,
           "tokenPercent": 13,
           "timePercent": 14
         },
         {
           "name": "overall-remind-2",
           "tokens": 71894635,
-          "elapsedMs": 3612361.3051,
+          "elapsedMs": 3704551.5783604695,
           "tokenPercent": 8,
           "timePercent": 6
         },
         {
           "name": "overall-remind-3",
           "tokens": 34055108,
-          "elapsedMs": 1456650.6908,
+          "elapsedMs": 1491039.6086949839,
           "tokenPercent": 4,
           "timePercent": 2
         },
         {
           "name": "overall-remind-4",
           "tokens": 39169963,
-          "elapsedMs": 2596564.2998,
+          "elapsedMs": 2665707.0047453525,
           "tokenPercent": 5,
           "timePercent": 4
         },
         {
           "name": "overall-final",
           "tokens": 16107600,
-          "elapsedMs": 921000,
+          "elapsedMs": 949003.7076757562,
           "tokenPercent": 2,
           "timePercent": 2
         }
@@ -483,49 +483,49 @@
         {
           "name": "backend-start",
           "tokens": 36526952,
-          "elapsedMs": 4879000,
+          "elapsedMs": 4917235.1725632325,
           "tokenPercent": 40,
           "timePercent": 45
         },
         {
           "name": "backend-review",
           "tokens": 11510707,
-          "elapsedMs": 967000,
+          "elapsedMs": 974578.0717090892,
           "tokenPercent": 13,
           "timePercent": 9
         },
         {
           "name": "backend-final",
           "tokens": 2434939,
-          "elapsedMs": 352000,
+          "elapsedMs": 354758.51214229513,
           "tokenPercent": 3,
           "timePercent": 3
         },
         {
           "name": "frontend-start",
           "tokens": 29777795,
-          "elapsedMs": 3175000,
+          "elapsedMs": 3199881.4660562132,
           "tokenPercent": 32,
-          "timePercent": 29
+          "timePercent": 30
         },
         {
           "name": "frontend-review",
           "tokens": 8755740,
-          "elapsedMs": 938000,
+          "elapsedMs": 945350.8079246387,
           "tokenPercent": 10,
           "timePercent": 9
         },
         {
           "name": "frontend-final",
           "tokens": 669850,
-          "elapsedMs": 93000,
+          "elapsedMs": 93728.81144668593,
           "tokenPercent": 1,
           "timePercent": 1
         },
         {
           "name": "overall-final",
           "tokens": 2404927,
-          "elapsedMs": 323000,
+          "elapsedMs": 325531.24835784466,
           "tokenPercent": 3,
           "timePercent": 3
         }
@@ -815,140 +815,140 @@
         {
           "name": "backend-start",
           "tokens": 37147695,
-          "elapsedMs": 4071000,
+          "elapsedMs": 4118331.6701621157,
           "tokenPercent": 3,
           "timePercent": 5
         },
         {
           "name": "backend-review",
           "tokens": 82976296,
-          "elapsedMs": 5591546.8352,
+          "elapsedMs": 5652609.45659313,
           "tokenPercent": 7,
           "timePercent": 7
         },
         {
           "name": "backend-remind-1",
           "tokens": 49109000,
-          "elapsedMs": 3303948.1599,
+          "elapsedMs": 3339083.5829483694,
           "tokenPercent": 4,
           "timePercent": 4
         },
         {
           "name": "backend-remind-2",
           "tokens": 208492738,
-          "elapsedMs": 15767011.343,
+          "elapsedMs": 15944013.884524945,
           "tokenPercent": 18,
           "timePercent": 19
         },
         {
           "name": "backend-remind-3",
           "tokens": 47983418,
-          "elapsedMs": 3154986.9778,
+          "elapsedMs": 3186715.8227698877,
           "tokenPercent": 4,
           "timePercent": 4
         },
         {
           "name": "backend-remind-4",
           "tokens": 40624253,
-          "elapsedMs": 2280583.9877,
+          "elapsedMs": 2302883.703585762,
           "tokenPercent": 3,
           "timePercent": 3
         },
         {
           "name": "backend-final",
           "tokens": 10537311,
-          "elapsedMs": 786000,
+          "elapsedMs": 795138.4654255522,
           "tokenPercent": 1,
           "timePercent": 1
         },
         {
           "name": "frontend-start",
           "tokens": 26280767,
-          "elapsedMs": 3177000,
+          "elapsedMs": 3213937.537731526,
           "tokenPercent": 2,
           "timePercent": 4
         },
         {
           "name": "frontend-review",
           "tokens": 70195703,
-          "elapsedMs": 5698772.6620000005,
+          "elapsedMs": 5759893.416124845,
           "tokenPercent": 6,
           "timePercent": 7
         },
         {
           "name": "frontend-remind-1",
           "tokens": 65972171,
-          "elapsedMs": 4324102.8373,
+          "elapsedMs": 4369120.824739871,
           "tokenPercent": 6,
           "timePercent": 5
         },
         {
           "name": "frontend-remind-2",
           "tokens": 56761212,
-          "elapsedMs": 2632540.2255,
+          "elapsedMs": 2659688.211210769,
           "tokenPercent": 5,
           "timePercent": 3
         },
         {
           "name": "frontend-remind-3",
           "tokens": 43682044,
-          "elapsedMs": 2897517.9836999997,
+          "elapsedMs": 2923084.759108129,
           "tokenPercent": 4,
           "timePercent": 4
         },
         {
           "name": "frontend-remind-4",
           "tokens": 41054672,
-          "elapsedMs": 2432789.0904,
+          "elapsedMs": 2456042.1830858835,
           "tokenPercent": 3,
           "timePercent": 3
         },
         {
           "name": "frontend-final",
           "tokens": 1663517,
-          "elapsedMs": 231000,
+          "elapsedMs": 233685.73220521954,
           "tokenPercent": 0,
           "timePercent": 0
         },
         {
           "name": "overall-review",
           "tokens": 53586601,
-          "elapsedMs": 2810671.055,
+          "elapsedMs": 2839039.828076778,
           "tokenPercent": 5,
           "timePercent": 3
         },
         {
           "name": "overall-remind-1",
           "tokens": 98007034,
-          "elapsedMs": 6855693.586,
+          "elapsedMs": 6928557.151931216,
           "tokenPercent": 8,
           "timePercent": 8
         },
         {
           "name": "overall-remind-2",
           "tokens": 60876838,
-          "elapsedMs": 3958470.2195,
+          "elapsedMs": 3999104.998968581,
           "tokenPercent": 5,
           "timePercent": 5
         },
         {
           "name": "overall-remind-3",
           "tokens": 68323444,
-          "elapsedMs": 4992111.3856,
+          "elapsedMs": 5042454.331264937,
           "tokenPercent": 6,
           "timePercent": 6
         },
         {
           "name": "overall-remind-4",
           "tokens": 73372054,
-          "elapsedMs": 4506711.9823,
+          "elapsedMs": 4555078.415086637,
           "tokenPercent": 6,
           "timePercent": 6
         },
         {
           "name": "overall-final",
           "tokens": 42175361,
-          "elapsedMs": 1475000,
+          "elapsedMs": 1492149.155855839,
           "tokenPercent": 4,
           "timePercent": 2
         }
@@ -1012,49 +1012,49 @@
         {
           "name": "backend-start",
           "tokens": 172779712,
-          "elapsedMs": 15908000,
+          "elapsedMs": 16148867.516013412,
           "tokenPercent": 71,
-          "timePercent": 66
+          "timePercent": 67
         },
         {
           "name": "backend-review",
           "tokens": 16278832,
-          "elapsedMs": 1904000,
+          "elapsedMs": 1932829.0011622792,
           "tokenPercent": 7,
           "timePercent": 8
         },
         {
           "name": "backend-final",
           "tokens": 3036565,
-          "elapsedMs": 222000,
+          "elapsedMs": 225361.36463131616,
           "tokenPercent": 1,
           "timePercent": 1
         },
         {
           "name": "frontend-start",
           "tokens": 25307573,
-          "elapsedMs": 2746000,
+          "elapsedMs": 2787577.960709884,
           "tokenPercent": 10,
-          "timePercent": 11
+          "timePercent": 12
         },
         {
           "name": "frontend-review",
           "tokens": 16424549,
-          "elapsedMs": 1990000,
+          "elapsedMs": 2020131.151424861,
           "tokenPercent": 7,
           "timePercent": 8
         },
         {
           "name": "frontend-final",
           "tokens": 3722475,
-          "elapsedMs": 455000,
+          "elapsedMs": 461889.2833659858,
           "tokenPercent": 2,
           "timePercent": 2
         },
         {
           "name": "overall-final",
           "tokens": 7474925,
-          "elapsedMs": 571000,
+          "elapsedMs": 579645.6720922592,
           "tokenPercent": 3,
           "timePercent": 2
         }
@@ -1344,140 +1344,140 @@
         {
           "name": "backend-start",
           "tokens": 42694073,
-          "elapsedMs": 4585000,
+          "elapsedMs": 4616508.1941089425,
           "tokenPercent": 3,
           "timePercent": 4
         },
         {
           "name": "backend-review",
           "tokens": 67535297,
-          "elapsedMs": 5284030.5624,
+          "elapsedMs": 5318232.586844974,
           "tokenPercent": 4,
           "timePercent": 5
         },
         {
           "name": "backend-remind-1",
           "tokens": 115178752,
-          "elapsedMs": 9378886.9744,
+          "elapsedMs": 9441016.872532813,
           "tokenPercent": 8,
           "timePercent": 9
         },
         {
           "name": "backend-remind-2",
           "tokens": 191241167,
-          "elapsedMs": 13844209.6011,
+          "elapsedMs": 13936301.489705002,
           "tokenPercent": 13,
           "timePercent": 13
         },
         {
           "name": "backend-remind-3",
           "tokens": 20839833,
-          "elapsedMs": 1732174.3956,
+          "elapsedMs": 1741272.9450002704,
           "tokenPercent": 1,
           "timePercent": 2
         },
         {
           "name": "backend-remind-4",
           "tokens": 75418648,
-          "elapsedMs": 4279819.1518,
+          "elapsedMs": 4305431.156040791,
           "tokenPercent": 5,
           "timePercent": 4
         },
         {
           "name": "backend-final",
           "tokens": 1471628,
-          "elapsedMs": 217000,
+          "elapsedMs": 218491.22750744614,
           "tokenPercent": 0,
           "timePercent": 0
         },
         {
           "name": "frontend-start",
           "tokens": 28745673,
-          "elapsedMs": 2752000,
+          "elapsedMs": 2770911.788481529,
           "tokenPercent": 2,
           "timePercent": 3
         },
         {
           "name": "frontend-review",
           "tokens": 69554521,
-          "elapsedMs": 5125564.1481,
+          "elapsedMs": 5159443.187785297,
           "tokenPercent": 5,
           "timePercent": 5
         },
         {
           "name": "frontend-remind-1",
           "tokens": 89918241,
-          "elapsedMs": 6077885.8759,
+          "elapsedMs": 6116369.166414739,
           "tokenPercent": 6,
           "timePercent": 6
         },
         {
           "name": "frontend-remind-2",
           "tokens": 50580818,
-          "elapsedMs": 4121590.2933,
+          "elapsedMs": 4148116.2756905165,
           "tokenPercent": 3,
           "timePercent": 4
         },
         {
           "name": "frontend-remind-3",
           "tokens": 80660547,
-          "elapsedMs": 6848706.9738,
+          "elapsedMs": 6893546.879265834,
           "tokenPercent": 5,
           "timePercent": 6
         },
         {
           "name": "frontend-remind-4",
           "tokens": 38490793,
-          "elapsedMs": 3313022.7095,
+          "elapsedMs": 3333783.0703294687,
           "tokenPercent": 3,
           "timePercent": 3
         },
         {
           "name": "frontend-final",
           "tokens": 27792651,
-          "elapsedMs": 1684000,
+          "elapsedMs": 1695572.475219075,
           "tokenPercent": 2,
           "timePercent": 2
         },
         {
           "name": "overall-review",
           "tokens": 63301123,
-          "elapsedMs": 3983393.1923,
+          "elapsedMs": 4008283.63484364,
           "tokenPercent": 4,
           "timePercent": 4
         },
         {
           "name": "overall-remind-1",
           "tokens": 116382187,
-          "elapsedMs": 6833684.1211,
+          "elapsedMs": 6878139.193660687,
           "tokenPercent": 8,
           "timePercent": 6
         },
         {
           "name": "overall-remind-2",
           "tokens": 169075457,
-          "elapsedMs": 10016109.3149,
+          "elapsedMs": 10081599.62893669,
           "tokenPercent": 11,
-          "timePercent": 9
+          "timePercent": 10
         },
         {
           "name": "overall-remind-3",
           "tokens": 56045827,
-          "elapsedMs": 4095442.888,
+          "elapsedMs": 4120786.8836104204,
           "tokenPercent": 4,
           "timePercent": 4
         },
         {
           "name": "overall-remind-4",
           "tokens": 189988869,
-          "elapsedMs": 10223837.942,
+          "elapsedMs": 10291699.101613043,
           "tokenPercent": 13,
           "timePercent": 10
         },
         {
           "name": "overall-final",
           "tokens": 21074247,
-          "elapsedMs": 1009000,
+          "elapsedMs": 1015933.8643088163,
           "tokenPercent": 1,
           "timePercent": 1
         }
@@ -1541,49 +1541,49 @@
         {
           "name": "backend-start",
           "tokens": 105617004,
-          "elapsedMs": 10082000,
+          "elapsedMs": 10164212.193342842,
           "tokenPercent": 39,
           "timePercent": 38
         },
         {
           "name": "backend-review",
           "tokens": 78806134,
-          "elapsedMs": 8685000,
+          "elapsedMs": 8755820.561315471,
           "tokenPercent": 29,
-          "timePercent": 32
+          "timePercent": 33
         },
         {
           "name": "backend-final",
           "tokens": 782876,
-          "elapsedMs": 82000,
+          "elapsedMs": 82668.65699802748,
           "tokenPercent": 0,
           "timePercent": 0
         },
         {
           "name": "frontend-start",
           "tokens": 52825873,
-          "elapsedMs": 5235000,
+          "elapsedMs": 5277688.041276511,
           "tokenPercent": 20,
           "timePercent": 20
         },
         {
           "name": "frontend-review",
           "tokens": 19862471,
-          "elapsedMs": 1662000,
+          "elapsedMs": 1675552.5357405082,
           "tokenPercent": 7,
           "timePercent": 6
         },
         {
           "name": "frontend-final",
           "tokens": 6385192,
-          "elapsedMs": 449000,
+          "elapsedMs": 452661.3047818822,
           "tokenPercent": 2,
           "timePercent": 2
         },
         {
           "name": "overall-final",
           "tokens": 6301255,
-          "elapsedMs": 370000,
+          "elapsedMs": 373017.11084475816,
           "tokenPercent": 2,
           "timePercent": 1
         }
@@ -1600,14 +1600,14 @@
       "status": "running",
       "stage": "overall-remind-1",
       "launchedAt": "2026-08-09T18:17:34.421Z",
-      "tokens": 4213428011,
+      "tokens": 4421326468,
       "tokenUsage": {
-        "totalTokens": 4213428011,
-        "inputTokens": 4206977767,
-        "cachedInputTokens": 4119717888,
+        "totalTokens": 4421326468,
+        "inputTokens": 4414559396,
+        "cachedInputTokens": 4321676800,
         "cacheWriteInputTokens": 0,
-        "outputTokens": 6450244,
-        "reasoningOutputTokens": 1449167
+        "outputTokens": 6767072,
+        "reasoningOutputTokens": 1519867
       },
       "inspection": {
         "attempts": 11,
@@ -1627,19 +1627,19 @@
         "pricingAsOf": "2026-08-01",
         "priceSource": "https://openrouter.ai/api/v1/models",
         "currency": "USD",
-        "amountUsd": 53.09396068,
-        "requests": 31271,
-        "shortContextRequests": 31270,
+        "amountUsd": 55.8659183,
+        "requests": 32878,
+        "shortContextRequests": 32877,
         "longContextRequests": 1,
         "longContextThresholdTokens": 272000,
         "replayedUpdates": 0
       },
       "suspendedMs": 0,
       "suspensions": [],
-      "workElapsedMs": 292439234.52690005,
+      "workElapsedMs": 306547646.15860003,
       "worktree": {
         "files": 452,
-        "additions": 87338,
+        "additions": 87395,
         "deletions": 136
       },
       "reviewVerdicts": [
@@ -1814,8 +1814,8 @@
           "name": "backend-start",
           "tokens": 544228917,
           "elapsedMs": 55121000,
-          "tokenPercent": 13,
-          "timePercent": 19
+          "tokenPercent": 12,
+          "timePercent": 18
         },
         {
           "name": "backend-review",
@@ -1871,7 +1871,7 @@
           "tokens": 61761807,
           "elapsedMs": 4477304.8948,
           "tokenPercent": 1,
-          "timePercent": 2
+          "timePercent": 1
         },
         {
           "name": "frontend-remind-1",
@@ -1917,10 +1917,10 @@
         },
         {
           "name": "overall-remind-1",
-          "tokens": 2482701704,
-          "elapsedMs": 147965745.86160004,
-          "tokenPercent": 59,
-          "timePercent": 51
+          "tokens": 2690600161,
+          "elapsedMs": 162074157.49330002,
+          "tokenPercent": 61,
+          "timePercent": 53
         }
       ]
     },
@@ -1982,49 +1982,49 @@
         {
           "name": "backend-start",
           "tokens": 286432546,
-          "elapsedMs": 34773000,
+          "elapsedMs": 35418134.119526334,
           "tokenPercent": 70,
-          "timePercent": 71
+          "timePercent": 72
         },
         {
           "name": "backend-review",
           "tokens": 33173335,
-          "elapsedMs": 5670000,
+          "elapsedMs": 5775193.98549778,
           "tokenPercent": 8,
           "timePercent": 12
         },
         {
           "name": "backend-final",
           "tokens": 2585270,
-          "elapsedMs": 170000,
+          "elapsedMs": 173153.96429182056,
           "tokenPercent": 1,
           "timePercent": 0
         },
         {
           "name": "frontend-start",
           "tokens": 61165984,
-          "elapsedMs": 4785000,
+          "elapsedMs": 4873774.818449184,
           "tokenPercent": 15,
           "timePercent": 10
         },
         {
           "name": "frontend-review",
           "tokens": 23062367,
-          "elapsedMs": 2175000,
+          "elapsedMs": 2215352.1902041747,
           "tokenPercent": 6,
-          "timePercent": 4
+          "timePercent": 5
         },
         {
           "name": "frontend-final",
           "tokens": 2017627,
-          "elapsedMs": 288000,
+          "elapsedMs": 293343.18656496657,
           "tokenPercent": 0,
           "timePercent": 1
         },
         {
           "name": "overall-final",
           "tokens": 2591366,
-          "elapsedMs": 333000,
+          "elapsedMs": 339178.0594657426,
           "tokenPercent": 1,
           "timePercent": 1
         }

--- a/benchmarks/evidence/src/EvidenceBenchmarkDashboard.ts
+++ b/benchmarks/evidence/src/EvidenceBenchmarkDashboard.ts
@@ -894,7 +894,23 @@ const stageMeasurements = (
   );
   const activeElapsed: number = Math.max(0, totalElapsed - retainedElapsed);
   const inspections: Map<number, IStageMeasurement> = inspectionByGoal(state);
-  return state.goals.map((instruction) => {
+  // A cell with an instruction in flight gives that instruction the residual,
+  // and a cell that has none would otherwise drop it. The residual is real
+  // process time: the driver's Goal clock counts a turn, while writing the
+  // retained state, hashing the workspace, and composing the next objective
+  // happen between turns with the process alive, so it accrues once per turn
+  // and grows with a cell's length rather than with its process count. It
+  // belongs to the objectives that were running, in proportion to the time
+  // each of them held the process, which is what the turns it paid for track.
+  const retainedShare: readonly number[] = state.goals.map((instruction) =>
+    correctedInstructionElapsed(state, instruction, suspensions),
+  );
+  const shareTotal: number = retainedShare.reduce((sum, own) => sum + own, 0);
+  const apportion = (index: number): number =>
+    current !== undefined || shareTotal === 0
+      ? 0
+      : (activeElapsed * (retainedShare[index] ?? 0)) / shareTotal;
+  return state.goals.map((instruction, index) => {
     const inspected: IStageMeasurement | undefined = inspections.get(
       instruction.index,
     );
@@ -907,6 +923,7 @@ const stageMeasurements = (
       elapsedMs:
         correctedInstructionElapsed(state, instruction, suspensions) +
         (instruction === current ? activeElapsed : 0) +
+        apportion(index) +
         (inspected?.elapsedMs ?? 0),
     };
   });


### PR DESCRIPTION
The last cell of round two, issue #1129. Everything else is published under #1171, #1177, #1179, and #1180; what remains is `erp plain` reaching its own end.

## Dashboard

<!-- dashboard:start -->

## GPT-5.6-Luna

| Cell | Stage | Progress | Cost | Work time |
| --- | --- | --- | ---: | ---: |
| Todo Plain | `overall-final` · completed | 90 files · +8.4k/−204 LOC | 866M | 16h 54m |
| Todo Evidence | `overall-final` · completed | 129 files · +8.7k/−123 LOC | 92M | 3h 00m |
| Reddit Plain | `overall-final` · completed | 155 files · +13.4k/−140 LOC | 1179M | 22h 44m |
| Reddit Evidence | `overall-final` · completed | 137 files · +14.5k/−162 LOC | 245M | 6h 43m |
| Shopping Plain | `overall-final` · completed | 164 files · +22.7k/−127 LOC | 1516M | 29h 28m |
| Shopping Evidence | `overall-final` · completed | 323 files · +29.5k/−148 LOC | 271M | 7h 26m |
| Erp Plain | `overall-remind-1` · running | 452 files · +87.4k/−136 LOC | 4420M | 85h 07m |
| Erp Evidence | `overall-final` · completed | 2772 files · +153.8k/−142 LOC | 411M | 13h 38m |

- **Todo Plain stages**
  - `backend-start`: 33M · 1h 02m · 4% tokens · 6% time
  - `backend-review`: 34M · 50m · 4% tokens · 5% time
  - `backend-remind-1`: 19M · 26m · 2% tokens · 3% time
  - `backend-remind-2`: 36M · 38m · 4% tokens · 4% time
  - `backend-remind-3`: 53M · 47m · 6% tokens · 5% time
  - `backend-remind-4`: 43M · 54m · 5% tokens · 5% time
  - `backend-final`: 5M · 5m · 1% tokens · 0% time
  - `frontend-start`: 51M · 1h 00m · 6% tokens · 6% time
  - `frontend-review`: 69M · 1h 13m · 8% tokens · 7% time
  - `frontend-remind-1`: 64M · 1h 13m · 7% tokens · 7% time
  - `frontend-remind-2`: 3M · 6m · 0% tokens · 1% time
  - `frontend-remind-3`: 31M · 49m · 4% tokens · 5% time
  - `frontend-remind-4`: 11M · 17m · 1% tokens · 2% time
  - `frontend-final`: 53M · 35m · 6% tokens · 3% time
  - `overall-review`: 88M · 1h 47m · 10% tokens · 11% time
  - `overall-remind-1`: 112M · 2h 21m · 13% tokens · 14% time
  - `overall-remind-2`: 72M · 1h 00m · 8% tokens · 6% time
  - `overall-remind-3`: 34M · 24m · 4% tokens · 2% time
  - `overall-remind-4`: 39M · 43m · 5% tokens · 4% time
  - `overall-final`: 16M · 15m · 2% tokens · 2% time
- **Todo Evidence stages**
  - `backend-start`: 37M · 1h 21m · 40% tokens · 45% time
  - `backend-review`: 12M · 16m · 13% tokens · 9% time
  - `backend-final`: 2M · 6m · 3% tokens · 3% time
  - `frontend-start`: 30M · 53m · 32% tokens · 29% time
  - `frontend-review`: 9M · 16m · 10% tokens · 9% time
  - `frontend-final`: 1M · 2m · 1% tokens · 1% time
  - `overall-final`: 2M · 5m · 3% tokens · 3% time
- **Reddit Plain stages**
  - `backend-start`: 37M · 1h 08m · 3% tokens · 5% time
  - `backend-review`: 83M · 1h 33m · 7% tokens · 7% time
  - `backend-remind-1`: 49M · 55m · 4% tokens · 4% time
  - `backend-remind-2`: 208M · 4h 23m · 18% tokens · 19% time
  - `backend-remind-3`: 48M · 53m · 4% tokens · 4% time
  - `backend-remind-4`: 41M · 38m · 3% tokens · 3% time
  - `backend-final`: 11M · 13m · 1% tokens · 1% time
  - `frontend-start`: 26M · 53m · 2% tokens · 4% time
  - `frontend-review`: 70M · 1h 35m · 6% tokens · 7% time
  - `frontend-remind-1`: 66M · 1h 12m · 6% tokens · 5% time
  - `frontend-remind-2`: 57M · 44m · 5% tokens · 3% time
  - `frontend-remind-3`: 44M · 48m · 4% tokens · 4% time
  - `frontend-remind-4`: 41M · 41m · 3% tokens · 3% time
  - `frontend-final`: 2M · 4m · 0% tokens · 0% time
  - `overall-review`: 54M · 47m · 5% tokens · 3% time
  - `overall-remind-1`: 98M · 1h 54m · 8% tokens · 8% time
  - `overall-remind-2`: 61M · 1h 06m · 5% tokens · 5% time
  - `overall-remind-3`: 68M · 1h 23m · 6% tokens · 6% time
  - `overall-remind-4`: 73M · 1h 15m · 6% tokens · 6% time
  - `overall-final`: 42M · 25m · 4% tokens · 2% time
- **Reddit Evidence stages**
  - `backend-start`: 173M · 4h 25m · 71% tokens · 66% time
  - `backend-review`: 16M · 32m · 7% tokens · 8% time
  - `backend-final`: 3M · 4m · 1% tokens · 1% time
  - `frontend-start`: 25M · 46m · 10% tokens · 11% time
  - `frontend-review`: 16M · 33m · 7% tokens · 8% time
  - `frontend-final`: 4M · 8m · 2% tokens · 2% time
  - `overall-final`: 7M · 10m · 3% tokens · 2% time
- **Shopping Plain stages**
  - `backend-start`: 43M · 1h 16m · 3% tokens · 4% time
  - `backend-review`: 68M · 1h 28m · 4% tokens · 5% time
  - `backend-remind-1`: 115M · 2h 36m · 8% tokens · 9% time
  - `backend-remind-2`: 191M · 3h 51m · 13% tokens · 13% time
  - `backend-remind-3`: 21M · 29m · 1% tokens · 2% time
  - `backend-remind-4`: 75M · 1h 11m · 5% tokens · 4% time
  - `backend-final`: 1M · 4m · 0% tokens · 0% time
  - `frontend-start`: 29M · 46m · 2% tokens · 3% time
  - `frontend-review`: 70M · 1h 25m · 5% tokens · 5% time
  - `frontend-remind-1`: 90M · 1h 41m · 6% tokens · 6% time
  - `frontend-remind-2`: 51M · 1h 09m · 3% tokens · 4% time
  - `frontend-remind-3`: 81M · 1h 54m · 5% tokens · 6% time
  - `frontend-remind-4`: 38M · 55m · 3% tokens · 3% time
  - `frontend-final`: 28M · 28m · 2% tokens · 2% time
  - `overall-review`: 63M · 1h 06m · 4% tokens · 4% time
  - `overall-remind-1`: 116M · 1h 54m · 8% tokens · 6% time
  - `overall-remind-2`: 169M · 2h 47m · 11% tokens · 9% time
  - `overall-remind-3`: 56M · 1h 08m · 4% tokens · 4% time
  - `overall-remind-4`: 190M · 2h 50m · 13% tokens · 10% time
  - `overall-final`: 21M · 17m · 1% tokens · 1% time
- **Shopping Evidence stages**
  - `backend-start`: 106M · 2h 48m · 39% tokens · 38% time
  - `backend-review`: 79M · 2h 25m · 29% tokens · 32% time
  - `backend-final`: 1M · 1m · 0% tokens · 0% time
  - `frontend-start`: 53M · 1h 27m · 20% tokens · 20% time
  - `frontend-review`: 20M · 28m · 7% tokens · 6% time
  - `frontend-final`: 6M · 7m · 2% tokens · 2% time
  - `overall-final`: 6M · 6m · 2% tokens · 1% time
- **Erp Plain stages**
  - `backend-start`: 544M · 15h 19m · 12% tokens · 18% time
  - `backend-review`: 523M · 11h 40m · 12% tokens · 14% time
  - `backend-remind-1`: 45M · 1h 06m · 1% tokens · 1% time
  - `backend-remind-2`: 9M · 13m · 0% tokens · 0% time
  - `backend-remind-3`: 19M · 30m · 0% tokens · 1% time
  - `backend-remind-4`: 132M · 1h 50m · 3% tokens · 2% time
  - `backend-final`: 9M · 18m · 0% tokens · 0% time
  - `frontend-start`: 29M · 50m · 1% tokens · 1% time
  - `frontend-review`: 62M · 1h 15m · 1% tokens · 1% time
  - `frontend-remind-1`: 68M · 1h 01m · 2% tokens · 1% time
  - `frontend-remind-2`: 140M · 2h 22m · 3% tokens · 3% time
  - `frontend-remind-3`: 60M · 1h 12m · 1% tokens · 1% time
  - `frontend-remind-4`: 39M · 55m · 1% tokens · 1% time
  - `frontend-final`: 15M · 38m · 0% tokens · 1% time
  - `overall-review`: 37M · 59m · 1% tokens · 1% time
  - `overall-remind-1`: 2689M · 44h 59m · 61% tokens · 53% time
- **Erp Evidence stages**
  - `backend-start`: 286M · 9h 40m · 70% tokens · 71% time
  - `backend-review`: 33M · 1h 35m · 8% tokens · 12% time
  - `backend-final`: 3M · 3m · 1% tokens · 0% time
  - `frontend-start`: 61M · 1h 20m · 15% tokens · 10% time
  - `frontend-review`: 23M · 36m · 6% tokens · 4% time
  - `frontend-final`: 2M · 5m · 0% tokens · 1% time
  - `overall-final`: 3M · 6m · 1% tokens · 1% time

<!-- dashboard:end -->

## Published so far

| Subject | Arm | Tokens | Work time | Cost | Coverage |
| --- | --- | ---: | ---: | ---: | ---: |
| todo | evidence | 92M | 3h 00m | $1.24 | 100% by construction |
| todo | plain | 866M | 16h 54m | $10.22 | 85.5% |
| reddit | evidence | 245M | 6h 43m | $3.30 | 100% by construction |
| reddit | plain | 1179M | 22h 44m | $14.31 | 80.3% |
| shopping | evidence | 271M | 7h 26m | $3.48 | 100% by construction |
| shopping | plain | 1516M | 29h 28m | $19.10 | 63.1% |
| erp | evidence | 411M | 13h 38m | $4.96 | 100% by construction |
| erp | plain | 4213M | 81h 14m | $53.09 | 49.1% (snapshot, still running) |

Plain has spent 7774M tokens against Evidence's 1019M. On `erp` alone the ratio is 10.2 to 1.

## What this branch owes

1. `erp plain` runs to completion.
2. Its thirteen edges recounted a third time, on the finished workspace.
3. `audit-suspensions`, then `report` and `coverage` over all eight runs.
4. Every published figure derived a second way before it leaves the record.

## Where the cell is

`erp plain` is in `overall-remind-1`, the first supplementation of its Overall scope, and that single objective has now run **40h 11m** — longer than the whole `erp evidence` cell, whose seven objectives finished in 13h 38m. Its stage log is 3.18 GB.

`overall.md` rereads the union of the backend and frontend scopes as one indivisible round and may reuse neither, and its reminder orders the whole review again from the first requirement on any finding. Both earlier scopes spent all four supplementations and failed every verdict, so everything they left undone arrives here.

## What the second count found

Twenty hours and $18 of further work moved the measured figure from 50.0% to 49.1%. The fall is a re-judgment rather than a regression — both passes independently named `REQ-DOM-BUDGET` and `REQ-DOM-ROUTING` unreached on evidence byte-identical to the first snapshot, where the first count named only `REQ-DOM-ASSET-CATEGORY`.

What the twenty hours did produce is real and small: 41 new scalar columns, 9 new tests, one new accessor, two more generated hooks called by a screen, one more requirement family walked by a journey. Screens stay at 13 against 446 accessors, and all seven end-to-end journey families stay unwalked.

Across the cohort's four Plain cells, 56 review verdicts are retained and one is a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XagFAwbVR1RMDpxMWnuct
