### PR TITLE
Round two complete: all eight cells of the gpt-5.6-luna cohort

### DIFF
--- a/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/erp/plain.json
+++ b/benchmarks/evidence/aggregate/cells/gpt-5.6-luna/erp/plain.json
@@ -6,46 +6,46 @@
   "benchmarkRevision": "dfb684279b79e623fcc3210bbea54eb04cf132b6",
   "model": "gpt-5.6-luna",
   "effort": "high",
-  "status": "running",
-  "stage": "overall-remind-4",
+  "status": "completed",
+  "stage": "overall-final",
   "launchedAt": "2026-08-09T18:17:34.421Z",
-  "tokens": 5359662131,
+  "tokens": 5449487580,
   "tokenUsage": {
-    "totalTokens": 5359662131,
-    "inputTokens": 5351626696,
-    "cachedInputTokens": 5238173184,
+    "totalTokens": 5449487580,
+    "inputTokens": 5441307460,
+    "cachedInputTokens": 5326763264,
     "cacheWriteInputTokens": 0,
-    "outputTokens": 8035435,
-    "reasoningOutputTokens": 1825496
+    "outputTokens": 8180120,
+    "reasoningOutputTokens": 1870305
   },
   "inspection": {
-    "attempts": 14,
+    "attempts": 15,
     "failures": 0,
     "tokenUsage": {
-      "totalTokens": 48606836,
-      "inputTokens": 48429499,
-      "cachedInputTokens": 45562368,
+      "totalTokens": 53117910,
+      "inputTokens": 52926638,
+      "cachedInputTokens": 49844992,
       "cacheWriteInputTokens": 0,
-      "outputTokens": 177337,
-      "reasoningOutputTokens": 93261
+      "outputTokens": 191272,
+      "reasoningOutputTokens": 99716
     },
-    "elapsedMs": 5214801.0243999995
+    "elapsedMs": 5649526.665999999
   },
   "apiCost": {
     "provider": "openrouter",
     "pricingAsOf": "2026-08-01",
     "priceSource": "https://openrouter.ai/api/v1/models",
     "currency": "USD",
-    "amountUsd": 67.70923462,
-    "requests": 39781,
-    "shortContextRequests": 39780,
+    "amountUsd": 68.71837608,
+    "requests": 40359,
+    "shortContextRequests": 40358,
     "longContextRequests": 1,
     "longContextThresholdTokens": 272000,
     "replayedUpdates": 0
   },
   "suspendedMs": 0,
   "suspensions": [],
-  "workElapsedMs": 360879223.245,
+  "workElapsedMs": 367882103.4479,
   "worktree": {
     "files": 452,
     "additions": 88511,
@@ -261,140 +261,162 @@
       "verdictRelativePath": "supervision/13-overall-3-verdict.json",
       "verdictSha256": "4c2fef2ba4c8b710710da73727af6193c90c21ff4bc1d58a51ae869d43e38fe7",
       "workspaceMaterialSha256": "7328883c99394515f6f1fe948ede7b04ed9c116eef8a9c0662d8fe29c9d6b3c0"
+    },
+    {
+      "scope": "overall",
+      "attempt": 4,
+      "decision": "fail",
+      "action": "final",
+      "goalIndex": 18,
+      "terminalTurnId": "e23bd05d-4adb-405f-b7e3-4de4cbdced08",
+      "rationale": "The final traversal is evidenced in overall-remind-4.log:87675-103892 (requirements reread, MANIFEST_COUNT=507, and one-file FULL_READ commands through the final file), with no later file changes before the completion message at :104219. However, the required AGENTS.md read is not evidenced; the new review setup reads only SKILL.md/backend.md/frontend.md/overall.md at :95, :250, :434, and :629. More decisively, tests are not proper: testing instructions require every published operation and persisted-mutation follow-up assertions (.agents/skills/backend/testing.md:132-145, 158; 138 specifically requires observable follow-up state). Twelve published accessors have no references anywhere under packages/backend/test, including control_ops automation (packages/api/src/functional/erp/control_ops/automation/index.ts:16,78), credit-memo apply/refund/void, MRP recommendation actions, asset activate/submit, departmentUpdate, and tax_return.reject (their generated files/lines are present, but no matching test calls exist). Additionally, test_api_erp_operation_coverage.ts:23-30 claims item erasure but only checks returned identity, not the required deactivation state.",
+      "pausedAt": "2026-08-14T02:45:59.188Z",
+      "decidedAt": "2026-08-14T02:53:29.955Z",
+      "resumedAt": "2026-08-14T02:53:29.992Z",
+      "verdictRelativePath": "supervision/14-overall-4-verdict.json",
+      "verdictSha256": "9bb704b9f3ddcc8d0ae6daf3324ba47342cf854d6bbbafba25a46181500754ce",
+      "workspaceMaterialSha256": "19edc1d59b1ec37a0218d8b7233c0c5ec334d5bee3a54f5a4057e00e6a3e2d2f"
     }
   ],
   "stages": [
     {
       "name": "backend-start",
       "tokens": 544228917,
-      "elapsedMs": 55121000,
+      "elapsedMs": 55644610.90895567,
       "tokenPercent": 10,
       "timePercent": 15
     },
     {
       "name": "backend-review",
       "tokens": 523010157,
-      "elapsedMs": 42027654.7284,
+      "elapsedMs": 42421020.73663378,
       "tokenPercent": 10,
       "timePercent": 12
     },
     {
       "name": "backend-remind-1",
       "tokens": 44991625,
-      "elapsedMs": 3950115.8663,
+      "elapsedMs": 3984161.357087488,
       "tokenPercent": 1,
       "timePercent": 1
     },
     {
       "name": "backend-remind-2",
       "tokens": 8627055,
-      "elapsedMs": 782645.4894000001,
+      "elapsedMs": 786806.182749587,
       "tokenPercent": 0,
       "timePercent": 0
     },
     {
       "name": "backend-remind-3",
       "tokens": 18968106,
-      "elapsedMs": 1794206.6759,
+      "elapsedMs": 1808341.6341287338,
       "tokenPercent": 0,
       "timePercent": 0
     },
     {
       "name": "backend-remind-4",
       "tokens": 132029222,
-      "elapsedMs": 6602042.5572,
+      "elapsedMs": 6660301.763394102,
       "tokenPercent": 2,
       "timePercent": 2
     },
     {
       "name": "backend-final",
       "tokens": 8656428,
-      "elapsedMs": 1071000,
+      "elapsedMs": 1081173.7501767299,
       "tokenPercent": 0,
       "timePercent": 0
     },
     {
       "name": "frontend-start",
       "tokens": 28836461,
-      "elapsedMs": 3011000,
+      "elapsedMs": 3039602.391953439,
       "tokenPercent": 1,
       "timePercent": 1
     },
     {
       "name": "frontend-review",
       "tokens": 61761807,
-      "elapsedMs": 4477304.8948,
+      "elapsedMs": 4515596.572636039,
       "tokenPercent": 1,
       "timePercent": 1
     },
     {
       "name": "frontend-remind-1",
       "tokens": 67847130,
-      "elapsedMs": 3687617.0896,
+      "elapsedMs": 3720655.6545996885,
       "tokenPercent": 1,
       "timePercent": 1
     },
     {
       "name": "frontend-remind-2",
       "tokens": 140351522,
-      "elapsedMs": 8549493.7308,
+      "elapsedMs": 8627226.50175815,
       "tokenPercent": 3,
       "timePercent": 2
     },
     {
       "name": "frontend-remind-3",
       "tokens": 60326958,
-      "elapsedMs": 4290611.9195,
+      "elapsedMs": 4328238.646344096,
       "tokenPercent": 1,
       "timePercent": 1
     },
     {
       "name": "frontend-remind-4",
       "tokens": 39029924,
-      "elapsedMs": 3280571.2816,
+      "elapsedMs": 3307995.760367711,
       "tokenPercent": 1,
       "timePercent": 1
     },
     {
       "name": "frontend-final",
       "tokens": 15335215,
-      "elapsedMs": 2288000,
+      "elapsedMs": 2309734.3981366553,
       "tokenPercent": 0,
       "timePercent": 1
     },
     {
       "name": "overall-review",
       "tokens": 36725780,
-      "elapsedMs": 3540224.4318,
+      "elapsedMs": 3571239.645924204,
       "tokenPercent": 1,
       "timePercent": 1
     },
     {
       "name": "overall-remind-1",
       "tokens": 2955860040,
-      "elapsedMs": 177354104.0307,
-      "tokenPercent": 55,
+      "elapsedMs": 179035385.11732876,
+      "tokenPercent": 54,
       "timePercent": 49
     },
     {
       "name": "overall-remind-2",
       "tokens": 606699282,
-      "elapsedMs": 30257729.0483,
+      "elapsedMs": 30541967.09945603,
       "tokenPercent": 11,
       "timePercent": 8
     },
     {
       "name": "overall-remind-3",
       "tokens": 39772933,
-      "elapsedMs": 3773479.2801,
+      "elapsedMs": 3805615.411610623,
       "tokenPercent": 1,
       "timePercent": 1
     },
     {
       "name": "overall-remind-4",
-      "tokens": 26603569,
-      "elapsedMs": 5020422.220600009,
-      "tokenPercent": 0,
+      "tokens": 74025948,
+      "elapsedMs": 5598314.560511272,
+      "tokenPercent": 1,
+      "timePercent": 2
+    },
+    {
+      "name": "overall-final",
+      "tokens": 42403070,
+      "elapsedMs": 3094115.3541472238,
+      "tokenPercent": 1,
       "timePercent": 1
     }
   ]

--- a/benchmarks/evidence/aggregate/coverage-input-erp.round-two.json
+++ b/benchmarks/evidence/aggregate/coverage-input-erp.round-two.json
@@ -5,9 +5,9 @@
   "runId": "0b9deae2-9926-49f4-9b6c-d454844a4470",
   "state": "counted",
   "method": {
-    "read": "A later frozen snapshot of the same workspace, taken while the cell was still running. The earlier snapshot the first count used is still present, and that count's own scripts were recovered and re-run unmodified against the new tree, so the two counts share one implementation. On the earlier snapshot those scripts reproduce the first count's populations exactly: 135 models, 1316 scalar columns, 445 accessors, 349 published types, 166 tests, 439 hooks, 13 screens, 3 journey cases, and the 921-to-931 column band.",
-    "grouping": "The six requirement-rooted edges are counted per family, the 253 `##` anchors, not per requirement. `docs/analysis/**`, `packages/frontend/wiki/screen-plan.md`, and `packages/frontend/wiki/omissions.md` are byte-identical to the earlier snapshot, so the eligible sets are held at the first count's values and only reach was re-derived.",
-    "requirementRooted": "Each of the six was counted twice in independent passes and the lower rate kept, after mapping each pass's findings onto the retained eligible sets."
+    "read": "The completed workspace, frozen after the cell reached `overall-final`. Two earlier snapshots of the same cell were counted while it was still running and are retained for comparison; the counting inventories are byte-identical between the second and third, so the three counts read very nearly the same artefact.",
+    "grouping": "The six requirement-rooted edges are counted per family, the 253 `##` anchors, not per requirement.",
+    "requirementRooted": "Each of the six was counted twice in independent passes and the lower rate kept."
   },
   "populations": {
     "requirementAnchors": 1487,
@@ -18,7 +18,7 @@
     "publishedTypes": 352,
     "hooks": 439,
     "screens": 13,
-    "backendTests": 175,
+    "backendTests": 177,
     "journeyCases": 3
   },
   "cells": [
@@ -27,15 +27,15 @@
       "subject": "erp",
       "runId": "0b9deae2-9926-49f4-9b6c-d454844a4470",
       "edges": {
-        "requirementToModel": { "eligible": 101, "reached": 98 },
-        "requirementToOperation": { "eligible": 98, "reached": 95 },
-        "requirementToDto": { "eligible": 192, "reached": 186 },
-        "requirementToTest": { "eligible": 252, "reached": 225 },
-        "requirementToScreen": { "eligible": 98, "reached": 19 },
-        "requirementToJourney": { "eligible": 105, "reached": 9 },
+        "requirementToModel": { "eligible": 101, "reached": 99 },
+        "requirementToOperation": { "eligible": 98, "reached": 97 },
+        "requirementToDto": { "eligible": 192, "reached": 190 },
+        "requirementToTest": { "eligible": 252, "reached": 247 },
+        "requirementToScreen": { "eligible": 98, "reached": 20 },
+        "requirementToJourney": { "eligible": 105, "reached": 11 },
         "modelToOperation": { "eligible": 135, "reached": 135 },
         "modelToDto": { "eligible": 135, "reached": 133 },
-        "accessorToTest": { "eligible": 446, "reached": 432 },
+        "accessorToTest": { "eligible": 446, "reached": 433 },
         "accessorToHook": { "eligible": 446, "reached": 424 },
         "hookToScreen": { "eligible": 439, "reached": 24 },
         "screenToJourney": { "eligible": 13, "reached": 13 },
@@ -44,83 +44,78 @@
     }
   ],
   "eligibilityRules": {
-    "requirementToModel": "The family declares organizational state the system must persist.",
-    "requirementToOperation": "The family describes an action a principal performs or a result the system returns on request.",
-    "requirementToDto": "The family's information crosses the HTTP boundary as a request or response payload.",
-    "requirementToTest": "The family's obligation is decidable through the backend API. One family is outside it, asserting a delivery-process property no feature test settles.",
-    "requirementToScreen": "The family names a capability a human performs in the browser.",
-    "requirementToJourney": "The family owes a browser-observable flow."
+    "requirementToModel": "The family declares organizational state the system must persist. The set of 101 reconstructs exactly as the 94 REQ-DOM families plus the 7 REQ-AUTH families.",
+    "requirementToOperation": "The family describes an action a principal performs or a result the system returns on request. The set of 98 reconstructs exactly as the 91 REQ-FUN families plus the 7 REQ-AUTH families.",
+    "requirementToDto": "The family's information crosses the HTTP boundary as a request or response payload. The set of 192 reconstructs exactly as REQ-DOM plus REQ-FUN plus REQ-AUTH.",
+    "requirementToTest": "The family's obligation is decidable through the backend API. One family is outside it, REQ-NFR-DELIVERY, whose REQ-NFR-DELIVERY-001 asserts the delivered product runs as a production-grade backend. The set of 252 is all 253 families less that one.",
+    "requirementToScreen": "The family names a capability a human performs in the browser. The set of 98 reconstructs exactly as REQ-FUN plus REQ-AUTH.",
+    "requirementToJourney": "The family owes a browser-observable flow. The set of 105 reconstructs exactly as REQ-FUN plus REQ-JRN plus REQ-AUTH."
   },
   "unreached": {
     "requirementToModel": [
-      "REQ-DOM-ASSET-CATEGORY: no asset_categories model, no category column on assets, and the name appears nowhere under packages",
-      "REQ-DOM-BUDGET: budgets persists {id, organization_id, name, version, status, created_at} and nothing else; the fiscal year, business dimensions, and the planned, committed, actual, and remaining line amounts the family declares have no columns and no table",
-      "REQ-DOM-ROUTING: routings persists {id, organization_id, finished_item_id, version, status, created_at}; the ordered operation sequence with work center, times, labor grade, machine, rate, and instructions has no table, where the parallel boms model does have bom_lines"
+      "REQ-DOM-ASSET-CATEGORY: no asset_categories model among the 135, assets carries no category column and no category-derived default asset, accumulated-depreciation, or expense account, and the only category columns in the schema belong to units and items",
+      "REQ-DOM-BUDGET: budgets persists {id, organization_id, name, version, status, created_at} and nothing else; there is no budget_lines table and no fiscal-year, dimension, or planned, committed, actual, and remaining amount column"
     ],
     "requirementToOperation": [
-      "REQ-AUTH-PRINCIPAL: the family is a classification catalog and no accessor returns or administers it",
-      "REQ-FUN-BUDGET: budgetCreate takes {name} and there is no budget update accessor, so REQ-FUN-BUDGET-001, creates and edits a draft budget and lines, and -007, views planned, committed, actual, have no operation; only create, index, activate, and close exist",
-      "REQ-FUN-ROUTING: routingCreate takes {finishedItemId} and there is no routing update accessor, so REQ-FUN-ROUTING-001, creates and edits a draft routing version and operations, has no operation; only create, index, and activate exist"
+      "REQ-FUN-BUDGET: the budget namespace publishes only budgetCreate, budgetIndex, budgetActivate, and budgetClose, and IBudget.ICreate is {name}, so REQ-FUN-BUDGET-001, creates and edits a draft budget and lines, and -007, views planned, committed, actual, have no accessor"
     ],
     "requirementToDto": [
-      "REQ-DOM-ASSET-CATEGORY: no IAssetCategory type and IAsset carries no category field",
-      "REQ-DOM-LOT: only an opaque lotId crosses, on IStockMovement, IStockBalance, IQuarantine, and the line bodies; no published type carries a lot's code, status, or item",
-      "REQ-DOM-BUDGET: IBudget is {id, name, version, status}",
-      "REQ-DOM-ROUTING: IRouting is {id, finishedItemId, version, status}, against IBom which does publish ILine[]",
-      "REQ-FUN-BUDGET: IBudget.ICreate is {name}, so fiscal year, currency, dimensions, and commitment-versus-actual are not representable in any request or response",
-      "REQ-FUN-ROUTING: IRouting.ICreate is {finishedItemId}, so ordered operations, work centers, times, labor grades, machines, rates, and instructions appear in no published type"
+      "REQ-DOM-ASSET-CATEGORY: no IAssetCategory type and IAsset publishes id, tag, name, acquisitionCost, sourceType, sourceId, residualValue, usefulLifeMonths, depreciationMethod, and status with no category reference",
+      "REQ-DOM-LOT: no ILot type; a lot crosses only as the opaque uuid lotId on IStockBalance, IStockMovement, IQuarantine, and the line bodies, while the lots columns code, status, and item_id are published nowhere"
     ],
     "requirementToTest": [
-      "27 of 252 families. Ten are structural, where the obligation has no implementation to settle: REQ-DOM-ASSET-CATEGORY, REQ-DOM-BUDGET, REQ-DOM-ROUTING, REQ-DOM-LOT, REQ-FUN-BUDGET, REQ-FUN-ROUTING, REQ-RULE-LOT, REQ-RULE-ROUTING, REQ-RULE-BOM, REQ-RULE-CREDIT-MEMO",
-      "REQ-NFR-TENANT: no test function in the suite creates a second organization, verified by scanning every exported test for a second create_owner or auth.organization call and finding none, so cross-tenant refusal is never observed; REQ-RULE-ORG-ACCESS and REQ-RULE-MEMBERSHIP fail on the same absence",
-      "REQ-RULE-CONCURRENCY: no test issues a concurrent request anywhere in the suite; there is no Promise.all over two accessors in packages/backend/test",
-      "REQ-NFR-AUTOMATION: control_ops.automation.index and .retry are called by no test",
-      "The remainder are obligations a test touches without settling: REQ-AUTH-SESSION, REQ-AUTH-MEMBERSHIP, REQ-AUTH-PRINCIPAL, REQ-DOM-PURCHASE-RETURN, REQ-FUN-PURCHASE-RETURN, REQ-RULE-ROLE, REQ-RULE-SERVICE, REQ-RULE-EMPLOYEE, REQ-RULE-PROJECT, REQ-RULE-TIMELOG, REQ-JRN-H2R, REQ-JRN-QUALITY-SERVICE"
+      "5 of 252. REQ-DOM-ASSET-CATEGORY: the concept has no model, no type, and no accessor, so no feature test can reference one",
+      "REQ-RULE-CONCURRENCY: no feature test issues a concurrent command; Promise.all appears nowhere under packages/backend/test/features, and document numbering is asserted with two strictly sequential numberIssue calls",
+      "REQ-RULE-PROJECT: the timelog tests only create a timelog on an active project the employee is assigned to; no test attempts a timelog without an assignment or on a completed or archived project",
+      "REQ-NFR-AUTOMATION: the string automation occurs nowhere under packages/backend/test/features, control_ops.automation.index and .retry are called by no test, and automation_runs is never read",
+      "REQ-AUTH-PRINCIPAL: organizations.system_user_id and system_membership_id are never read by any test, the automation accessors are untested, and the party test asserts only that kind is not vendor, never that an external party cannot obtain credentials"
     ],
     "requirementToScreen": [
-      "79 of 98 families. The reached nineteen are REQ-AUTH-PROVISION, REQ-AUTH-SESSION, REQ-AUTH-ACCOUNT, REQ-FUN-ORG, REQ-FUN-ACCOUNT, REQ-FUN-JOURNAL, REQ-FUN-STOCK-VIEW, REQ-FUN-INVENTORY-ADJUSTMENT, REQ-FUN-MRP, REQ-FUN-MRP-RECOMMENDATION, REQ-FUN-APPROVAL, REQ-FUN-AUDIT, and the seven REQ-FUN-REPORT-* families",
-      "Procurement, sales, inventory master data, manufacturing, quality, service, projects, payroll, and every finance master family reach no screen; membership administration, role composition, and manager positions reach none either",
-      "REQ-FUN-PROJECT is individually notable: screen-plan.md claims people-page.tsx owns it with eight child rows, but that page calls only useReport('headcount'), useReport('contract_history'), and useReport('timesheet_status') and renders label-and-value tiles, delivering no project capability"
+      "78 of 98 families. The reached twenty are REQ-AUTH-PROVISION, REQ-AUTH-SESSION, REQ-AUTH-ACCOUNT, REQ-AUTH-MEMBERSHIP, REQ-FUN-ORG, REQ-FUN-ACCOUNT, REQ-FUN-JOURNAL, REQ-FUN-STOCK-VIEW, REQ-FUN-INVENTORY-ADJUSTMENT, REQ-FUN-MRP, REQ-FUN-MRP-RECOMMENDATION, REQ-FUN-APPROVAL, REQ-FUN-AUDIT, and the seven REQ-FUN-REPORT-* families",
+      "Procurement, sales, inventory master data, manufacturing, quality, service, projects, payroll, and every finance master family reach no screen; role composition, the acting-principal catalog, and manager positions reach none either",
+      "REQ-FUN-PROJECT is individually notable: screen-plan.md claims people-page.tsx owns it, but that page calls only useReport('headcount'), useReport('contract_history'), and useReport('timesheet_status') and renders label-and-value tiles, delivering no project capability"
     ],
     "requirementToJourney": [
-      "96 of 105 families. The reached nine are REQ-AUTH-PROVISION, REQ-AUTH-ACCOUNT, REQ-FUN-ACCOUNT, REQ-FUN-JOURNAL, REQ-FUN-REPORT-FIN, REQ-FUN-STOCK-VIEW, REQ-FUN-INVENTORY-ADJUSTMENT, REQ-FUN-APPROVAL, REQ-FUN-AUDIT",
+      "94 of 105 families. The reached eleven are REQ-AUTH-PROVISION, REQ-AUTH-SESSION, REQ-AUTH-ACCOUNT, REQ-AUTH-MEMBERSHIP, REQ-FUN-ACCOUNT, REQ-FUN-JOURNAL, REQ-FUN-REPORT-FIN, REQ-FUN-STOCK-VIEW, REQ-FUN-INVENTORY-ADJUSTMENT, REQ-FUN-APPROVAL, REQ-FUN-AUDIT",
       "All seven REQ-JRN-* end-to-end families are unwalked",
-      "REQ-FUN-MRP and REQ-FUN-MRP-RECOMMENDATION are notable: planning-page.tsx implements Run MRP and the accept and dismiss commands, and the journey waits only for the 'Recommendations' and 'Maintenance backlog' labels without pressing any of them"
+      "REQ-FUN-MRP and REQ-FUN-MRP-RECOMMENDATION remain notable: planning-page.tsx implements Run MRP and the accept and dismiss commands, and the journey waits only for the 'Recommendations' and 'Maintenance backlog' tile labels without pressing any of them. People and Planning are visited but only waited on for static Metric labels, so REQ-FUN-EMPLOYEE, REQ-FUN-CONTRACT, REQ-FUN-TIMESHEET, REQ-FUN-MAINTENANCE-ORDER, and the six non-financial report families stay unreached"
     ],
     "modelToDto": [
-      "recovery_deliveries: the recovery request deliberately returns a random identifier so no column reaches a response",
-      "vendor_credit_refunds: still written and never read back; VendorCreditProvider.refund holds the only reference and it is a create, and IVendorCredit.IRefund is a request type of {amount, bankAccountId}, while the credit-memo side publishes ICreditMemo.refunds with id and refundedAt"
+      "recovery_deliveries: recoveryRequest deliberately returns { id: randomUUID() } and recoveryComplete returns IUser.IAuthorized, so no column of the row reaches a response",
+      "vendor_credit_refunds: still written and never read back; VendorCreditProvider.refund holds the only reference and it is a create returning the vendor_credits row, and IVendorCredit.IRefund is a request type of {amount, bankAccountId}"
     ],
     "accessorToTest": [
-      "14 of 446: the whole automation pair, four of six credit-memo accessors, the three MRP recommendation decisions, the two asset transitions, projects.department.departmentUpdate, the new tax_return.reject, and auth.organization, which is named only by helpers/ErpFixtures.ts and by no feature test"
+      "13 of 446: the whole automation pair, three of six credit-memo accessors, the three MRP recommendation decisions, the two asset transitions, projects.department.departmentUpdate, tax_return.reject, and auth.organization, which is named only by helpers/ErpFixtures.ts and by no feature test"
     ],
-    "accessorToHook": ["22 of 446, the prior 21 plus the new tax_return.reject"],
+    "accessorToHook": [
+      "22 of 446: the automation pair, four credit-memo accessors, the six asset transitions, the three production cost postings, projects.department.departmentUpdate, quarantine.approve, the four service-order accessors, and tax_return.reject"
+    ],
     "hookToScreen": [
-      "415 of 439. All 17 authored hooks are called by a screen; of the generated per-accessor wrappers 7 are, the five inventory-adjustment and catalog wrappers plus the two new stock balance and movement wrappers the traceability panel added"
+      "415 of 439. All 17 authored hooks are called by a screen; of the 422 generated per-accessor wrappers 7 are, the five inventory-adjustment and catalog wrappers plus the two stock balance and movement wrappers the traceability panel added"
     ],
     "columnToProperty": [
       "391 of 1357: 116 created_at, 99 organization_id, 39 updated_at, and 137 domain columns. recovery_deliveries publishes no column at all, and production_reservations publishes none either, its quantity and consumed_quantity reaching only the derived IAvailability.allocated aggregate"
     ]
   },
   "unsettled": {
-    "eligibility": "docs/analysis/**, packages/frontend/wiki/screen-plan.md, and packages/frontend/wiki/omissions.md are byte-identical between the two snapshots, so the six requirement-rooted eligible sets are held at 101, 98, 192, 252, 98, and 105 and only reach was re-derived. Both passes re-derived eligibility independently and both diverged from those sets and from each other, most sharply on requirementToOperation, 253 against 169, and requirementToJourney, 70 against 94; their findings were mapped onto the held sets rather than their own denominators.",
-    "requirementToModel": "Both passes independently named the same three unreached families, where the first count named only REQ-DOM-ASSET-CATEGORY. The budgets and routings models are byte-identical to the earlier snapshot, so 100 to 98 is a re-judgment of unchanged evidence, not a regression. The same re-judgment carries REQ-DOM-BUDGET and REQ-DOM-ROUTING into requirementToDto and REQ-FUN-BUDGET and REQ-FUN-ROUTING into requirementToOperation and requirementToDto.",
-    "requirementToOperation": "The passes disagreed completely. Pass B named REQ-FUN-BUDGET and REQ-FUN-ROUTING; pass A named only REQ-DOM families, all outside this eligible set, and counted REQ-AUTH-PRINCIPAL reached without argument. The lower rate keeps pass B's two plus REQ-AUTH-PRINCIPAL, which the first count found unreached and neither pass contradicted with evidence. Pass A's mapped figure is 97.",
-    "requirementToDto": "The passes disagreed on REQ-DOM-LOT: pass A named it unreached, pass B did not. The lower rate keeps pass A at 186. Neither pass reproduced the first count's REQ-DOM-SERIAL, though the identical argument applies to it, serials.code escaping only as serialCode on movement, balance, and quarantine types; adding it would make this 185.",
-    "requirementToTest": "The passes disagreed on the count as well as the members: pass A 225 of 252, pass B 229. Both name REQ-NFR-TENANT, REQ-RULE-CONCURRENCY, REQ-NFR-AUTOMATION, and the budget, routing, and asset-category families; pass B additionally counts the five smoke-only report families unreached, and pass A additionally counts eleven rule and journey families. The lower figure is kept. Direct evidence supports the shared core: no test function calls create_owner twice, and packages/backend/test contains no Promise.all over two accessors.",
-    "requirementToScreen": "Both passes independently reached 19, the same nineteen families the first count named, so the new traceability panel on operations-page.tsx added no family: REQ-FUN-STOCK-VIEW was already reached.",
-    "requirementToJourney": "Both passes reached 7 on their own smaller denominators. Mapped onto the held 105, both add REQ-FUN-AUDIT and REQ-FUN-REPORT-FIN, which they excluded on eligibility rather than reach, and both accept that the new steps fill and submit the traceability search and assert a 'balance rows' result, which carries REQ-FUN-STOCK-VIEW from unreached to reached. Pass B would additionally add REQ-AUTH-MEMBERSHIP for 10; the lower rate keeps 9.",
-    "screenToJourney": "13 of 13 remains a source-level count. The journey still waits at the Operations step for /Draft adjustment/, and the string 'Draft adjustment' appears nowhere in packages/frontend/src; the screen renders 'Adjustment <id> · draft'. The case still times out there and the last four screens never execute, so the executable count is still 9. The two new traceability waits sit before that point and do not move it.",
-    "columnToProperty": "966 is the first count's three-signal attribution script re-run unmodified; that same script scored the earlier snapshot at 924 while the cell published 928, a point estimate inside its stated 921-to-931 band. The band here is 963 to 972, the ends being the strict primary-DTO reading and the root-namespace-expanded one, and the expanded end reproduces the earlier snapshot at 931 exactly. All 41 new columns are published except the four journal membership-attribution columns, and four columns that were unreached became reached, so the unreached total is unchanged at 385 under the expanded reading.",
-    "accessorToTest": "432 applies the first count's rule that an accessor named only by a fixture helper is not settled by a test; the purely mechanical count over the whole test tree is 433, the difference being api.functional.erp.auth.organization, which still appears only in helpers/ErpFixtures.ts.",
-    "modelToDto": "133 of 135 again, but one member changed: vendor_credit_refunds is unreached on the response rule, as before, while production_reservations publishes no column either and is unreached on the column rule the first count applied to recovery_deliveries. Under a request-inclusive reading vendor_credit_refunds is reached through IVendorCredit.IRefund.amount and the figure is the same 133 with production_reservations as the second member.",
-    "codeShape": "packages/backend/src/providers/*.ts are committed as transpiled JavaScript under a .ts extension with @ts-nocheck. This affected no count, since model attribution reads prisma and tx call sites that survive transpilation, but it is worth knowing when reading reach evidence."
+    "judgementDominance": "Four of the six requirement-rooted edges read byte-identical evidence across the second and third counts, yet every one of them moved. On unchanged bytes requirementToModel has now been counted 100, 98, and 99; requirementToDto 186 and now 190, the second count naming six unreached families where both passes here name two; requirementToOperation 95 and now 97. These are re-judgements of the same evidence by different judges, not changes in the artefact. The published figures are the lower of the two passes as the method requires, but this spread is the dominant uncertainty in this cell and is larger than any supplementation the cell performed. Read the score as a whole percent and read the per-edge populations as the durable result.",
+    "evidenceBase": "The counting inventories are byte-identical between the second and third snapshots: the model, published-type, accessor, and anchor inventories all match exactly, as do packages/api/src, packages/backend/prisma, and docs/analysis. Only 12 files under packages/backend/src, 3 backend test files, packages/frontend/src/components/controls/controls-page.tsx, and packages/frontend/tests/journeys/workspace.spec.ts differ.",
+    "eligibility": "docs/analysis/**, packages/frontend/wiki/screen-plan.md, and packages/frontend/wiki/omissions.md are byte-identical across all three snapshots, verified by digest, so the six eligible sets are held at 101, 98, 192, 252, 98, and 105. Unlike the second count, they were reconstructed to exact member lists, and every reconstruction hits the held number exactly and is consistent with every member the earlier counts named, so both passes worked on the same denominators.",
+    "requirementToModel": "The passes disagreed. Pass A named only REQ-DOM-ASSET-CATEGORY for 100; pass B added REQ-DOM-BUDGET for 99. Neither named REQ-DOM-ROUTING, which the second count named, and routings is byte-identical: {id, organization_id, finished_item_id, version, status, created_at} with no operation-sequence table, against boms which does have bom_lines. Carrying it would make this 98.",
+    "requirementToOperation": "The passes disagreed. Pass A named nothing for 98; pass B named REQ-FUN-BUDGET for 97. Neither named REQ-FUN-ROUTING or REQ-AUTH-PRINCIPAL, both of which the second count counted unreached, and packages/api/src is byte-identical. Carrying both would make this 95.",
+    "requirementToDto": "The passes agreed exactly, both reaching 190 and naming the same two families. Neither reproduced the second count's four budget and routing families, though IBudget is still {id, name, version, status} and IRouting still {id, finishedItemId, version, status} against IBom which publishes ILine[]. Neither named REQ-DOM-SERIAL, whose serials.code escapes only as serialCode; adding it would make this 189.",
+    "requirementToTest": "The passes disagreed on both count and membership: pass A 247, pass B 248, sharing three members. Pass A additionally names REQ-RULE-CONCURRENCY and REQ-RULE-PROJECT; pass B additionally names REQ-NFR-TENANT. The union of both is 246. Direct evidence supports both disjoint additions: no test function calls create_owner twice or names auth.organization outside the fixture helper, so no second organization ever exists, and Promise.all appears nowhere under packages/backend/test/features. This edge carries the only real movement from the cell's last supplementation: a new test settles REQ-RULE-BOM-003 against an implementation that does enforce it, and a changed credit-memo test asserts a return-reason memo reaching settled.",
+    "requirementToScreen": "Both passes independently reached 20 and named the identical twenty families. The one family beyond the second count's nineteen is REQ-AUTH-MEMBERSHIP, credited to a page byte-identical to both earlier snapshots; this is a re-judgement, not a new screen.",
+    "requirementToJourney": "Both passes independently reached 11 and named the identical eleven. The two beyond the second count's nine are REQ-AUTH-SESSION and REQ-AUTH-MEMBERSHIP, judged from journey steps unchanged since the second snapshot, so this too is re-judgement rather than new walking.",
+    "screenToJourney": "13 of 13 remains a source-level count, and the executable count moves from 9 to 13. The blocker the second count flagged is fixed: the Operations step no longer waits for a string the screens never render but for a status role matching the markup the page emits, and the provider writes exactly the draft and posted states it waits on. Both passes checked every remaining wait against the rendered markup and found none that targets absent text. Two residual risks are data-dependent rather than source-level: one wait needs an audit event still inside an eight-row window, and one click needs a prepared pending approval of a matching target type.",
+    "columnToProperty": "966 reproduces the second count exactly, column for column, which is expected because packages/backend/prisma and packages/api/src are byte-identical. The three readings give 963 strict, 966 three-signal, and 972 root-namespace-expanded.",
+    "modelToDto": "133 of 135 under either reading. Under the response rule the unreached pair is recovery_deliveries and vendor_credit_refunds; under the column rule it is recovery_deliveries and production_reservations.",
+    "accessorToTest": "433 applies the rule that an accessor named only by a fixture helper is not settled by a test; the mechanical count is 434. The gain of one over the second count is real: credit_memo.creditMemoIndex is now called by a test asserting a sales-return refund settles the linked memo.",
+    "codeShape": "The second count's caveat has expired. Three providers were committed as transpiled JavaScript under a .ts extension with @ts-nocheck in the second snapshot; here 0 of 41 provider files carry @ts-nocheck and all are TypeScript source."
   },
   "moved": {
-    "scalarColumns": "1316 to 1357, plus 41. Nineteen on the ledger models, seventeen on operations, three on employment_contracts, one on closing_snapshots, one on credit_memos.",
-    "accessors": "445 to 446, plus 1, api.functional.erp.tax_return.reject.",
-    "publishedTypes": "349 to 352, plus 3.",
-    "backendTests": "166 to 175, plus 9.",
-    "unchanged": "requirementAnchors 1487, requirementFamilies 253, models 135, hooks 439, screens 13, journeyCases 3."
+    "backendTests": "175 to 177, plus 2, and none removed.",
+    "executableScreens": "9 to 13. The journey no longer times out at the Operations step.",
+    "unchanged": "requirementAnchors 1487, requirementFamilies 253, models 135, scalarColumns 1357, accessors 446, publishedTypes 352, hooks 439, screens 13, journeyCases 3. Every one was re-derived from the completed workspace rather than carried."
   }
 }

--- a/benchmarks/evidence/aggregate/coverage.json
+++ b/benchmarks/evidence/aggregate/coverage.json
@@ -511,7 +511,7 @@
       "coverage": {
         "arm": "plain",
         "measured": true,
-        "score": 0.49075808848248204,
+        "score": 0.5156672634960949,
         "wholeness": {
           "test": 1,
           "journey": 1,
@@ -519,51 +519,51 @@
           "dto": 0.711864406779661,
           "screen": 1,
           "hook": 0.05466970387243736,
-          "api": 0.5102914287465398,
-          "model": 0.605804848083251
+          "api": 0.5114125049797236,
+          "model": 0.6063653861998429
         },
         "obligations": [
           {
             "name": "model",
             "edge": "requirementToModel",
-            "rate": 0.9702970297029703,
-            "wholeness": 0.605804848083251,
-            "value": 0.5878106446748376
+            "rate": 0.9801980198019802,
+            "wholeness": 0.6063653861998429,
+            "value": 0.594358150829549
           },
           {
             "name": "operation",
             "edge": "requirementToOperation",
-            "rate": 0.9693877551020408,
-            "wholeness": 0.5102914287465398,
-            "value": 0.4946702625604212
+            "rate": 0.9897959183673469,
+            "wholeness": 0.5114125049797236,
+            "value": 0.5061940100309509
           },
           {
             "name": "dto",
             "edge": "requirementToDto",
-            "rate": 0.96875,
+            "rate": 0.9895833333333334,
             "wholeness": 0.711864406779661,
-            "value": 0.6896186440677966
+            "value": 0.704449152542373
           },
           {
             "name": "test",
             "edge": "requirementToTest",
-            "rate": 0.8928571428571429,
+            "rate": 0.9801587301587301,
             "wholeness": 1,
-            "value": 0.8928571428571429
+            "value": 0.9801587301587301
           },
           {
             "name": "screen",
             "edge": "requirementToScreen",
-            "rate": 0.19387755102040816,
+            "rate": 0.20408163265306123,
             "wholeness": 1,
-            "value": 0.19387755102040816
+            "value": 0.20408163265306123
           },
           {
             "name": "journey",
             "edge": "requirementToJourney",
-            "rate": 0.08571428571428572,
+            "rate": 0.10476190476190476,
             "wholeness": 1,
-            "value": 0.08571428571428572
+            "value": 0.10476190476190476
           }
         ],
         "edges": [
@@ -588,8 +588,8 @@
           {
             "name": "accessorToTest",
             "eligible": 446,
-            "reached": 432,
-            "rate": 0.968609865470852
+            "reached": 433,
+            "rate": 0.9708520179372198
           },
           {
             "name": "accessorToHook",
@@ -612,38 +612,38 @@
           {
             "name": "requirementToModel",
             "eligible": 101,
-            "reached": 98,
-            "rate": 0.9702970297029703
+            "reached": 99,
+            "rate": 0.9801980198019802
           },
           {
             "name": "requirementToOperation",
             "eligible": 98,
-            "reached": 95,
-            "rate": 0.9693877551020408
+            "reached": 97,
+            "rate": 0.9897959183673469
           },
           {
             "name": "requirementToDto",
             "eligible": 192,
-            "reached": 186,
-            "rate": 0.96875
+            "reached": 190,
+            "rate": 0.9895833333333334
           },
           {
             "name": "requirementToTest",
             "eligible": 252,
-            "reached": 225,
-            "rate": 0.8928571428571429
+            "reached": 247,
+            "rate": 0.9801587301587301
           },
           {
             "name": "requirementToScreen",
             "eligible": 98,
-            "reached": 19,
-            "rate": 0.19387755102040816
+            "reached": 20,
+            "rate": 0.20408163265306123
           },
           {
             "name": "requirementToJourney",
             "eligible": 105,
-            "reached": 9,
-            "rate": 0.08571428571428572
+            "reached": 11,
+            "rate": 0.10476190476190476
           }
         ]
       },
@@ -677,8 +677,8 @@
     "origin": "samchon/ttsc",
     "symbol": "COVERAGE_EDGES in benchmarks/evidence/src/EvidenceBenchmarkCoverage.ts",
     "method": "Thirteen reference-graph edges read from each completed Plain workspace of round two, composed so serial hops multiply and branches average. See ttsc#1088 for the derivation.",
-    "precision": "Each requirement-rooted edge was counted twice, broad and narrow, and the lower rate kept; no requirement identifier appears in a Plain workspace, so its eligibility is a judgement and the two passes differed by up to a quarter on some denominators. Read a score as a whole percent. The per-subject inputs, their eligibility rules, their unreached members, and the judgements that could move a figure are retained beside this file as coverage-input-<subject>.round-two.json.",
+    "precision": "Each requirement-rooted edge was counted twice, broad and narrow, and the lower rate kept; no requirement identifier appears in a Plain workspace, so its eligibility is a judgement. Read a score as a whole percent. The per-subject inputs, their eligibility rules, their unreached members, and the judgements that could move a figure are retained beside this file as coverage-input-<subject>.round-two.json.",
     "evidenceArm": "Complete by construction and never counted.",
-    "erp": "Counted twice on two frozen snapshots of the erp workspace taken while its cell was still running, the second after a further 1418M tokens and 20h 46m of work. The eligible sets are held at the first count, whose requirement corpus and screen plan are byte-identical in both snapshots, and only reach was re-derived. Its six requirement-rooted edges are counted over the 253 families the requirements document declares, not its 1487 anchors. The figure moves again when the cell completes."
+    "judgement": "The erp cell was counted three times, twice while it ran and once on the finished workspace, and its figure read 50.0, 49.1, and 51.6 percent. Four of its six requirement-rooted edges moved between the last two counts while reading byte-identical evidence, so the spread between judges exceeds what the cell changed in that interval. Its coverage-input file names every such disagreement. The other three subjects were counted once each, so their figures carry the same judgement risk without a second reading to expose it."
   }
 }

--- a/benchmarks/evidence/aggregate/summary.json
+++ b/benchmarks/evidence/aggregate/summary.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-14T01:48:06.841Z",
+  "generatedAt": "2026-08-14T03:47:26.737Z",
   "origin": "samchon/ttsc",
   "cells": [
     {
@@ -1597,46 +1597,46 @@
       "benchmarkRevision": "dfb684279b79e623fcc3210bbea54eb04cf132b6",
       "model": "gpt-5.6-luna",
       "effort": "high",
-      "status": "running",
-      "stage": "overall-remind-4",
+      "status": "completed",
+      "stage": "overall-final",
       "launchedAt": "2026-08-09T18:17:34.421Z",
-      "tokens": 5359662131,
+      "tokens": 5449487580,
       "tokenUsage": {
-        "totalTokens": 5359662131,
-        "inputTokens": 5351626696,
-        "cachedInputTokens": 5238173184,
+        "totalTokens": 5449487580,
+        "inputTokens": 5441307460,
+        "cachedInputTokens": 5326763264,
         "cacheWriteInputTokens": 0,
-        "outputTokens": 8035435,
-        "reasoningOutputTokens": 1825496
+        "outputTokens": 8180120,
+        "reasoningOutputTokens": 1870305
       },
       "inspection": {
-        "attempts": 14,
+        "attempts": 15,
         "failures": 0,
         "tokenUsage": {
-          "totalTokens": 48606836,
-          "inputTokens": 48429499,
-          "cachedInputTokens": 45562368,
+          "totalTokens": 53117910,
+          "inputTokens": 52926638,
+          "cachedInputTokens": 49844992,
           "cacheWriteInputTokens": 0,
-          "outputTokens": 177337,
-          "reasoningOutputTokens": 93261
+          "outputTokens": 191272,
+          "reasoningOutputTokens": 99716
         },
-        "elapsedMs": 5214801.0243999995
+        "elapsedMs": 5649526.665999999
       },
       "apiCost": {
         "provider": "openrouter",
         "pricingAsOf": "2026-08-01",
         "priceSource": "https://openrouter.ai/api/v1/models",
         "currency": "USD",
-        "amountUsd": 67.70923462,
-        "requests": 39781,
-        "shortContextRequests": 39780,
+        "amountUsd": 68.71837608,
+        "requests": 40359,
+        "shortContextRequests": 40358,
         "longContextRequests": 1,
         "longContextThresholdTokens": 272000,
         "replayedUpdates": 0
       },
       "suspendedMs": 0,
       "suspensions": [],
-      "workElapsedMs": 360879223.245,
+      "workElapsedMs": 367882103.4479,
       "worktree": {
         "files": 452,
         "additions": 88511,
@@ -1852,140 +1852,162 @@
           "verdictRelativePath": "supervision/13-overall-3-verdict.json",
           "verdictSha256": "4c2fef2ba4c8b710710da73727af6193c90c21ff4bc1d58a51ae869d43e38fe7",
           "workspaceMaterialSha256": "7328883c99394515f6f1fe948ede7b04ed9c116eef8a9c0662d8fe29c9d6b3c0"
+        },
+        {
+          "scope": "overall",
+          "attempt": 4,
+          "decision": "fail",
+          "action": "final",
+          "goalIndex": 18,
+          "terminalTurnId": "e23bd05d-4adb-405f-b7e3-4de4cbdced08",
+          "rationale": "The final traversal is evidenced in overall-remind-4.log:87675-103892 (requirements reread, MANIFEST_COUNT=507, and one-file FULL_READ commands through the final file), with no later file changes before the completion message at :104219. However, the required AGENTS.md read is not evidenced; the new review setup reads only SKILL.md/backend.md/frontend.md/overall.md at :95, :250, :434, and :629. More decisively, tests are not proper: testing instructions require every published operation and persisted-mutation follow-up assertions (.agents/skills/backend/testing.md:132-145, 158; 138 specifically requires observable follow-up state). Twelve published accessors have no references anywhere under packages/backend/test, including control_ops automation (packages/api/src/functional/erp/control_ops/automation/index.ts:16,78), credit-memo apply/refund/void, MRP recommendation actions, asset activate/submit, departmentUpdate, and tax_return.reject (their generated files/lines are present, but no matching test calls exist). Additionally, test_api_erp_operation_coverage.ts:23-30 claims item erasure but only checks returned identity, not the required deactivation state.",
+          "pausedAt": "2026-08-14T02:45:59.188Z",
+          "decidedAt": "2026-08-14T02:53:29.955Z",
+          "resumedAt": "2026-08-14T02:53:29.992Z",
+          "verdictRelativePath": "supervision/14-overall-4-verdict.json",
+          "verdictSha256": "9bb704b9f3ddcc8d0ae6daf3324ba47342cf854d6bbbafba25a46181500754ce",
+          "workspaceMaterialSha256": "19edc1d59b1ec37a0218d8b7233c0c5ec334d5bee3a54f5a4057e00e6a3e2d2f"
         }
       ],
       "stages": [
         {
           "name": "backend-start",
           "tokens": 544228917,
-          "elapsedMs": 55121000,
+          "elapsedMs": 55644610.90895567,
           "tokenPercent": 10,
           "timePercent": 15
         },
         {
           "name": "backend-review",
           "tokens": 523010157,
-          "elapsedMs": 42027654.7284,
+          "elapsedMs": 42421020.73663378,
           "tokenPercent": 10,
           "timePercent": 12
         },
         {
           "name": "backend-remind-1",
           "tokens": 44991625,
-          "elapsedMs": 3950115.8663,
+          "elapsedMs": 3984161.357087488,
           "tokenPercent": 1,
           "timePercent": 1
         },
         {
           "name": "backend-remind-2",
           "tokens": 8627055,
-          "elapsedMs": 782645.4894000001,
+          "elapsedMs": 786806.182749587,
           "tokenPercent": 0,
           "timePercent": 0
         },
         {
           "name": "backend-remind-3",
           "tokens": 18968106,
-          "elapsedMs": 1794206.6759,
+          "elapsedMs": 1808341.6341287338,
           "tokenPercent": 0,
           "timePercent": 0
         },
         {
           "name": "backend-remind-4",
           "tokens": 132029222,
-          "elapsedMs": 6602042.5572,
+          "elapsedMs": 6660301.763394102,
           "tokenPercent": 2,
           "timePercent": 2
         },
         {
           "name": "backend-final",
           "tokens": 8656428,
-          "elapsedMs": 1071000,
+          "elapsedMs": 1081173.7501767299,
           "tokenPercent": 0,
           "timePercent": 0
         },
         {
           "name": "frontend-start",
           "tokens": 28836461,
-          "elapsedMs": 3011000,
+          "elapsedMs": 3039602.391953439,
           "tokenPercent": 1,
           "timePercent": 1
         },
         {
           "name": "frontend-review",
           "tokens": 61761807,
-          "elapsedMs": 4477304.8948,
+          "elapsedMs": 4515596.572636039,
           "tokenPercent": 1,
           "timePercent": 1
         },
         {
           "name": "frontend-remind-1",
           "tokens": 67847130,
-          "elapsedMs": 3687617.0896,
+          "elapsedMs": 3720655.6545996885,
           "tokenPercent": 1,
           "timePercent": 1
         },
         {
           "name": "frontend-remind-2",
           "tokens": 140351522,
-          "elapsedMs": 8549493.7308,
+          "elapsedMs": 8627226.50175815,
           "tokenPercent": 3,
           "timePercent": 2
         },
         {
           "name": "frontend-remind-3",
           "tokens": 60326958,
-          "elapsedMs": 4290611.9195,
+          "elapsedMs": 4328238.646344096,
           "tokenPercent": 1,
           "timePercent": 1
         },
         {
           "name": "frontend-remind-4",
           "tokens": 39029924,
-          "elapsedMs": 3280571.2816,
+          "elapsedMs": 3307995.760367711,
           "tokenPercent": 1,
           "timePercent": 1
         },
         {
           "name": "frontend-final",
           "tokens": 15335215,
-          "elapsedMs": 2288000,
+          "elapsedMs": 2309734.3981366553,
           "tokenPercent": 0,
           "timePercent": 1
         },
         {
           "name": "overall-review",
           "tokens": 36725780,
-          "elapsedMs": 3540224.4318,
+          "elapsedMs": 3571239.645924204,
           "tokenPercent": 1,
           "timePercent": 1
         },
         {
           "name": "overall-remind-1",
           "tokens": 2955860040,
-          "elapsedMs": 177354104.0307,
-          "tokenPercent": 55,
+          "elapsedMs": 179035385.11732876,
+          "tokenPercent": 54,
           "timePercent": 49
         },
         {
           "name": "overall-remind-2",
           "tokens": 606699282,
-          "elapsedMs": 30257729.0483,
+          "elapsedMs": 30541967.09945603,
           "tokenPercent": 11,
           "timePercent": 8
         },
         {
           "name": "overall-remind-3",
           "tokens": 39772933,
-          "elapsedMs": 3773479.2801,
+          "elapsedMs": 3805615.411610623,
           "tokenPercent": 1,
           "timePercent": 1
         },
         {
           "name": "overall-remind-4",
-          "tokens": 26603569,
-          "elapsedMs": 5020422.220600009,
-          "tokenPercent": 0,
+          "tokens": 74025948,
+          "elapsedMs": 5598314.560511272,
+          "tokenPercent": 1,
+          "timePercent": 2
+        },
+        {
+          "name": "overall-final",
+          "tokens": 42403070,
+          "elapsedMs": 3094115.3541472238,
+          "tokenPercent": 1,
           "timePercent": 1
         }
       ]


### PR DESCRIPTION
Round two of the `@ttsc/evidence` benchmark, issue #1129, is complete. All eight cells of the gpt-5.6-luna cohort have finished.

## Result

| Subject | Arm | Tokens | Work time | Cost | Coverage |
| --- | --- | ---: | ---: | ---: | ---: |
| todo | evidence | 92M | 3h 00m | $1.24 | 100% by construction |
| todo | plain | 866M | 16h 54m | $10.22 | 85.5% |
| reddit | evidence | 245M | 6h 43m | $3.30 | 100% by construction |
| reddit | plain | 1179M | 22h 44m | $14.31 | 80.3% |
| shopping | evidence | 271M | 7h 26m | $3.48 | 100% by construction |
| shopping | plain | 1516M | 29h 28m | $19.10 | 63.1% |
| erp | evidence | 411M | 13h 38m | $4.96 | 100% by construction |
| erp | plain | 5449M | 102h 11m | $68.72 | 51.6% |

```
Plain      9010M   $112.36
Evidence   1019M    $12.98
           8.8x tokens, 8.7x cost
```

On `erp` alone: **13.3x the tokens, 13.9x the price, 7.5x the work time**, and the Evidence arm delivered a complete provenance graph while the Plain arm reached 51.6%.

The gap widens with the subject's size. Plain coverage falls 85.5 → 80.3 → 63.1 → 51.6 as the requirement corpus grows from 44 families to 253, while the Evidence arm is complete at every size because its compiler rejects a missing edge.

## The last cell

`erp plain` reached `overall-final` after 20 objectives. Its Overall review spent all four supplementations and failed every verdict; across the cohort's four Plain cells, 56 review verdicts are retained and one is a pass.

Its final supplementation did real work: the frontend journey no longer times out at its Operations step, so all thirteen screens execute where nine did, and two new backend tests settle obligations that had none. Coverage moved 49.1% → 51.6% between the second count and the third.

What it never reached: 78 of 98 browser-facing families have no screen, all seven end-to-end journey families are unwalked, and of 422 generated hooks 7 are called by a screen.

## Integrity

- `audit-suspensions`: 0 disconnected intervals across 8 runs, 0 corrections.
- Every cell's work time closes exactly against the sum of its stages; #1191 removed the last residual.
- `erp plain` was counted three times — 50.0%, 49.1%, 51.6%. **Four of its six requirement-rooted edges moved between the last two counts while reading byte-identical evidence**, so the spread between judges is larger than what the cell changed in that interval. `coverage.json` records this in its source block, and the per-subject input names every disagreement. The other three subjects were counted once each and carry the same risk without a second reading to expose it.

## Artifacts

The eight delivered applications are published at [samchon/evidence-benchmark-results](https://github.com/samchon/evidence-benchmark-results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XagFAwbVR1RMDpxMWnuct
