### PR TITLE
docs(evidence): update benchmark and narrative slides

### DIFF
--- a/website/src/slides/evidence.md
+++ b/website/src/slides/evidence.md
@@ -67,12 +67,23 @@ style: |
   section.divider p { color: #b9c9e6; font-size: 30px; }
   section.divider .note { color: #b9c9e6; }
 
-  /* Single-line emphasis */
-  .punch { display: block; font-size: 46px; font-weight: 700; line-height: 1.45; color: #ffd479; }
-  .punch-lead {
-    display: block; font-size: 40px; font-weight: 600;
-    line-height: 1.5; color: #e3e6ea; margin-bottom: 34px;
+  /* Opening claims */
+  .opening-claim {
+    font-size: 64px;
+    font-weight: 800;
+    line-height: 1.25;
+    text-align: center;
   }
+  .opening-metrics { display: flex; width: 100%; gap: 70px; }
+  .opening-metric {
+    flex: 1;
+    border-top: 8px solid #4a76b8;
+    padding-top: 32px;
+    text-align: center;
+  }
+  .opening-metric b { display: block; color: #ffd479; font-size: 104px; line-height: 1; }
+  .opening-metric span { display: block; margin-top: 22px; color: #ffffff; font-size: 38px; }
+  .opening-context { margin-top: 42px; color: #a7b0be; font-size: 28px; text-align: center; }
   .note { font-size: 24px; color: #5b6674; }
 
   /* Cumulative narrative references */
@@ -418,7 +429,7 @@ style: |
 
 # Evidence Graph
 
-## Enforcing 100% specification coverage with compile errors
+## 100% specification coverage with compile errors
 
 <span class="note">https://github.com/samchon/ttsc/tree/master/packages/evidence</span>
 
@@ -426,29 +437,20 @@ style: |
 
 <!-- _class: dark -->
 
-<span class="punch-lead">
-Write the specification, build to the specification, and verify against the specification.<br/>Spec Driven Development.
-</span>
-
-<span class="punch">
-That specification becomes the compile error.
-</span>
-
-<span class="note">your spec as a compile error no coding agent can skip</span>
+<div class="opening-claim">
+Your specification becomes<br/><strong>a compile error no agent can skip.</strong>
+</div>
 
 ---
 
 <!-- _class: dark -->
 
-<span class="punch-lead">
-One meeting note. One idea note.
-</span>
+<div class="opening-metrics">
+<div class="opening-metric"><b>100%</b><span>requirement coverage</span></div>
+<div class="opening-metric"><b>13.3×</b><span>fewer tokens</span></div>
+</div>
 
-<span class="punch">
-That alone produces a full-stack, full-spec product.
-</span>
-
-<span class="note">The ultimate form of Goal Mode: provide only the goal, and the graph catches the rest.<br/>Requirement coverage from 51.6% to 100%, 13.3× fewer tokens, and 7.5× less time.</span>
+<div class="opening-context">ERP benchmark</div>
 
 ---
 

--- a/website/src/slides/evidence.md
+++ b/website/src/slides/evidence.md
@@ -509,9 +509,9 @@ style: |
 
 <!-- _class: divider -->
 
-# The Limits of Loop Until Dry
+# Current Limitation
 
-<span class="note">More review. Diminishing returns.</span>
+<span class="note">Loop Until Dry</span>
 
 ---
 
@@ -546,15 +546,15 @@ style: |
 
 <!-- _class: divider -->
 
-# Spec Driven Development
+# Evidence Graph
 
-<span class="note">Write and review the requirements.<br/>AI builds everything with 100% coverage.</span>
+<span class="note">We attached a compiler to specifications, too</span>
 
 ---
 
 <!-- _class: architecture-slide -->
 
-# One graph connects the entire delivery
+# First, divide the documents into layers
 
 <div class="document-graph">
 <div class="architecture-node document-node meeting">Meeting notes</div>
@@ -575,7 +575,102 @@ style: |
 
 ---
 
-# Method A: Write and review the requirements
+# Code cites the specification
+
+```tsx
+/**
+ * @evidence docs/discount.md#coupon-stacking
+ *           Explains the stacking limit defined by this section.
+ * @evidence POST:/orders/{orderId}/coupons
+ *           Explains the rejection response from this endpoint.
+ */
+export function CouponStackingNotice(props: IProps): JSX.Element;
+```
+
+**`@evidence <target> <reason>`**: what it is responsible for, and why.
+
+---
+
+# Without a citation, the build stops
+
+```bash
+$ npx ttsc
+error TS16411: [evidence/graph]
+  Missing acknowledgement for 'docs/discount.md#coupon-stacking'
+  (Markdown H2 'Coupon Stacking' at docs/discount.md:3)
+```
+
+- One error per requirement → **the error list is the task list**
+- It appears alongside type errors. There is no additional check to attach
+
+---
+
+# The configuration is one sentence
+
+```ts
+type: "typescript",
+files: ["src/components/**/*.tsx"],  // The side that discharges the obligation
+symbol: "function",
+reference: {
+  type: "markdown",
+  files: ["docs/**/*.md"],           // The targets whose obligations must be discharged
+  symbol: ["h2", "h3"],
+},
+```
+
+**Components implement documents. Therefore, every H2 and H3 must be cited.**
+
+---
+
+# Four kinds of citation targets
+
+| Kind       | Unit                         |
+| ---------- | ---------------------------- |
+| Markdown   | file, H1-H4 section          |
+| Prisma     | model, column, relation      |
+| TypeScript | type, function, property     |
+| Swagger    | each operation under `paths` |
+
+<span class="note">Documents, schemas, code, and API specifications are connected by one grammar.</span>
+
+---
+
+# Who determines 100%?
+
+<div class="cards">
+<div class="card"><b>Denominator</b>The configuration declares it</div>
+<div class="card"><b>Numerator</b>The developer records it with tags</div>
+<div class="card warm"><b>Decision</b>The compiler makes it every time</div>
+</div>
+
+<br/>
+
+Entrust any one of the three to diligence, and 100% is merely **self-reported**.
+
+---
+
+# It prevents a false 100%
+
+| Option | What it prevents |
+| --- | --- |
+| `noEvidenceExclude` | Escaping with "not applicable" |
+| `uniqueEvidence` | Multiple places passing responsibility to one another |
+| `singleEvidencePerSymbol` | Piling every citation onto one place |
+| `requireReview` | Letting the specification change after it was cited |
+
+<span class="note">An exclusion requires a reason, and a review carries a fingerprint of the document content.</span>
+
+---
+
+<!-- _class: divider -->
+
+# Spec Driven Development
+
+<span class="note">Write and review the requirements.<br/>AI builds everything with 100% coverage.</span>
+
+---
+
+# Method A: Humans write the requirements
 
 - Humans **review `docs/requirements` directly**
 - Specifications, implementation, and tests are **fully delegated**
@@ -585,7 +680,7 @@ style: |
 
 ---
 
-# Method B: Delegate the requirements too
+# Method B: Hand over only the raw material
 
 - Hand over meeting notes and idea notes **as-is, without organizing them**
 - **Delegate everything**, starting with writing the requirements
@@ -595,7 +690,7 @@ style: |
 
 ---
 
-# Requirements can cite meeting notes
+# Even requirements cite their evidence
 
 ```md
 ## Coupon stacking limit {#coupon-stacking}
@@ -673,108 +768,13 @@ style: |
 
 <!-- _class: divider -->
 
-# Compile Every Omission
+# Benchmark
 
-<span class="note">Two tags are enough</span>
-
----
-
-# Code cites the specification
-
-```tsx
-/**
- * @evidence docs/discount.md#coupon-stacking
- *           Explains the stacking limit defined by this section.
- * @evidence POST:/orders/{orderId}/coupons
- *           Explains the rejection response from this endpoint.
- */
-export function CouponStackingNotice(props: IProps): JSX.Element;
-```
-
-**`@evidence <target> <reason>`**: what it is responsible for, and why.
+<span class="note">Same requirements · Same engine · Same model · Only the plugin changed</span>
 
 ---
 
-# Without a citation, the build stops
-
-```bash
-$ npx ttsc
-error TS16411: [evidence/graph]
-  Missing acknowledgement for 'docs/discount.md#coupon-stacking'
-  (Markdown H2 'Coupon Stacking' at docs/discount.md:3)
-```
-
-- One error per requirement → **the error list is the task list**
-- It runs with `ttsc`, alongside type errors
-
----
-
-# Configuration declares one relationship
-
-```ts
-type: "typescript",
-files: ["src/components/**/*.tsx"],  // The side that discharges the obligation
-symbol: "function",
-reference: {
-  type: "markdown",
-  files: ["docs/**/*.md"],           // The targets whose obligations must be discharged
-  symbol: ["h2", "h3"],
-},
-```
-
-**Components implement documents. Therefore, every H2 and H3 must be cited.**
-
----
-
-# One grammar spans four artifact types
-
-| Kind       | Unit                         |
-| ---------- | ---------------------------- |
-| Markdown   | file, H1-H4 section          |
-| Prisma     | model, column, relation      |
-| TypeScript | type, function, property     |
-| Swagger    | each operation under `paths` |
-
-<span class="note">Documents, schemas, code, and API specifications are connected by one grammar.</span>
-
----
-
-# Who determines 100%?
-
-<div class="cards">
-<div class="card"><b>Denominator</b>The configuration declares it</div>
-<div class="card"><b>Numerator</b>The developer records it with tags</div>
-<div class="card warm"><b>Decision</b>The compiler makes it every time</div>
-</div>
-
-<br/>
-
-**The compiler, not diligence, decides whether coverage is 100%.**
-
----
-
-# It prevents a false 100%
-
-| Option | What it prevents |
-| --- | --- |
-| `noEvidenceExclude` | Escaping with "not applicable" |
-| `uniqueEvidence` | Multiple places passing responsibility to one another |
-| `singleEvidencePerSymbol` | Piling every citation onto one place |
-| `requireReview` | Letting the specification change after it was cited |
-
-<span class="note">An exclusion requires a reason, and a review carries a fingerprint of the document content.</span>
-
----
-
-<!-- _class: divider -->
-
-# Measured Results
-
-<span class="note">Same requirements · Same engine · Same model<br/>Only the plugin changed</span>
-
----
-
-# Coverage reaches 100%
+# Coverage
 
 | Subject | Plain | Evidence |
 | --- | --- | --- |
@@ -783,11 +783,11 @@ reference: {
 | shopping | 63.1% <span class="track"><i class="w631"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
 | erp | 51.6% <span class="track"><i class="w516"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
 
-Plain coverage falls as scope grows. **Evidence remains at 100%.**
+The larger the project, the more it misses.<br/>**It does not even know that it missed something.**
 
 ---
 
-# Token savings grow with scope
+# Yet it becomes cheaper
 
 <div class="rows">
 <div class="row"><span class="lbl">todo</span><span class="bars"><i class="p b159"></i><i class="e b17"></i></span><span class="val">866M → 92M</span></div>
@@ -796,13 +796,13 @@ Plain coverage falls as scope grows. **Evidence remains at 100%.**
 <div class="row"><span class="lbl">erp</span><span class="bars"><i class="p b1000"></i><i class="e b75"></i></span><span class="val">5,449M → 411M</span></div>
 </div>
 
-<span class="kp">Plain</span> in blue. <span class="ke">Evidence</span> in orange. The gap widens with scope.
+Token consumption for <span class="kp">Plain</span> and <span class="ke">Evidence</span>.<br/>The gap widens as the project grows.
 
 <span class="note">Original charts by phase: [https://ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)</span>
 
 ---
 
-# ERP: more complete, cheaper, faster
+# Cost and time decreased as well: ERP
 
 <div class="cards">
 <div class="card"><b>13.3×</b>fewer tokens<br/><span class="note">5,449M → 411M</span></div>
@@ -812,11 +812,11 @@ Plain coverage falls as scope grows. **Evidence remains at 100%.**
 
 <br/>
 
-**100% coverage with less time and cost.**
+This was not a cost paid for quality.<br/>**It built more and finished for less.**
 
 ---
 
-# Review share falls from 90–95% to 15–41%
+# But the review consumes all the money
 
 | Subject | Plain | Evidence |
 | --- | --- | --- |
@@ -829,7 +829,7 @@ Plain coverage falls as scope grows. **Evidence remains at 100%.**
 
 ---
 
-# A tag can satisfy coverage and still lie
+# What if it lies?
 
 ```ts
 /**
@@ -839,14 +839,14 @@ Plain coverage falls as scope grows. **Evidence remains at 100%.**
  */
 ```
 
-- `@evidenceReview` records the checked source and its fingerprint
-- A source change invalidates the review
+- Inexpensive models **sometimes write facts that do not exist**
+- Requiring fingerprinted reviews makes this **converge toward zero**<br/>but takes more time
 
-> The compiler finds omissions. Humans judge truthfulness.
+> A false tag removes the error, not the problem.
 
 ---
 
-# Human review becomes a finite checklist
+# In return, the review becomes narrower
 
 |  | Plain | Evidence |
 | --- | --- | --- |
@@ -858,9 +858,20 @@ Plain coverage falls as scope grows. **Evidence remains at 100%.**
 
 ---
 
+<!-- _class: dark -->
+
+# Summary
+
+- Humans review **only one document layer**
+- The **compiler protects everything below it**
+- A specification can be **software requirements, historical canon, or the laws of a fictional world**
+- 100% is not the goal, but **what remains after every error is closed**
+
+---
+
 <!-- _class: divider -->
 
-# The Same Harness for Stories
+# Appendix: Stories
 
 <span class="note">Settings become build constraints</span>
 
@@ -926,17 +937,6 @@ Plain coverage falls as scope grows. **Evidence remains at 100%.**
 - **Continuity**: knowledge, arcs, revisions
 - Historical fiction, fantasy, science fiction, mystery, drama
 - **Napoleon**: one example with 25 principles, 350 settings commitments, and 742 scenes
-
----
-
-<!-- _class: dark -->
-
-# Two tags. One completion condition.
-
-- `@evidence <target> <reason>`
-- `@evidenceExclude <target> <reason>`
-- Write and review the requirements
-- AI builds everything with 100% coverage
 
 ---
 

--- a/website/src/slides/evidence.md
+++ b/website/src/slides/evidence.md
@@ -75,6 +75,132 @@ style: |
   }
   .note { font-size: 24px; color: #5b6674; }
 
+  /* Cumulative narrative references */
+  .narrative-graph { position: relative; height: 410px; margin-top: -12px; }
+  .narrative-group {
+    position: absolute;
+    left: 0;
+    top: 10px;
+    width: 32%;
+    height: 270px;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0;
+    box-sizing: border-box;
+    padding: 12px;
+    border: 3px solid #f08a24;
+    border-radius: 14px;
+  }
+  .narrative-node {
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    height: 84px;
+    background: #f3f6fb;
+    border: 3px solid #4a76b8;
+    border-radius: 10px;
+    color: #14284b;
+    font-size: 32px;
+    font-weight: 700;
+  }
+  .narrative-group .narrative-node { flex: none; width: 100%; border-color: #f08a24; }
+  .narrative-node.scenarios,
+  .narrative-node.storylines,
+  .narrative-node.manuscripts { position: absolute; width: 25%; }
+  .narrative-node.scenarios { left: 41%; top: 25px; }
+  .narrative-node.storylines { left: 41%; top: 181px; }
+  .narrative-node.manuscripts { left: 72%; top: 316px; }
+  .narrative-edge {
+    position: absolute;
+    z-index: 1;
+    box-sizing: border-box;
+    color: #4a76b8;
+  }
+  .narrative-edge.to-foundations {
+    left: 32%;
+    width: 9%;
+    border-top: 3px solid currentColor;
+  }
+  .narrative-edge.to-foundations::after,
+  .narrative-edge.manuscripts-scenarios::after,
+  .narrative-edge.manuscripts-storylines::after {
+    content: "";
+    position: absolute;
+    top: -8px;
+    left: -1px;
+    border-top: 7px solid transparent;
+    border-right: 12px solid currentColor;
+    border-bottom: 7px solid transparent;
+  }
+  .narrative-edge.scenarios-foundations { top: 67px; }
+  .narrative-edge.storylines-foundations { top: 223px; }
+  .narrative-edge.storylines-scenarios {
+    left: 53.5%;
+    top: 109px;
+    height: 72px;
+    border-left: 3px solid currentColor;
+  }
+  .narrative-edge.storylines-scenarios::after,
+  .narrative-edge.manuscripts-foundations::after {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: -8px;
+    border-right: 7px solid transparent;
+    border-bottom: 12px solid currentColor;
+    border-left: 7px solid transparent;
+  }
+  .narrative-edge.settings-principles {
+    position: relative;
+    left: auto;
+    top: auto;
+    flex: none;
+    align-self: center;
+    width: 0;
+    height: 72px;
+    color: #f08a24;
+    border-left: 3px solid currentColor;
+  }
+  .narrative-edge.settings-principles::after {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: -8px;
+    border-right: 7px solid transparent;
+    border-bottom: 12px solid currentColor;
+    border-left: 7px solid transparent;
+  }
+  .narrative-edge.manuscripts-scenarios {
+    left: 66%;
+    top: 67px;
+    width: 18.5%;
+    border-top: 3px solid currentColor;
+  }
+  .narrative-edge.manuscripts-storylines {
+    left: 66%;
+    top: 223px;
+    width: 18.5%;
+    border-top: 3px solid currentColor;
+  }
+  .narrative-edge.manuscripts-up {
+    left: 84.5%;
+    top: 67px;
+    height: 249px;
+    border-left: 3px solid currentColor;
+  }
+  .narrative-edge.manuscripts-foundations {
+    left: 16%;
+    top: 280px;
+    width: 56%;
+    height: 78px;
+    border-bottom: 3px solid currentColor;
+    border-left: 3px solid currentColor;
+  }
+
   /* Cards */
   .cards { display: flex; gap: 22px; margin-top: 20px; }
   .card {
@@ -102,7 +228,7 @@ style: |
   .track i.w855 { width: 85.5%; }
   .track i.w803 { width: 80.3%; }
   .track i.w631 { width: 63.1%; }
-  .track i.w500 { width: 50%; }
+  .track i.w516 { width: 51.6%; }
   .track i.w100 { width: 100%; }
 
   /* Development and review split bars */
@@ -118,7 +244,7 @@ style: |
   .d97 { width: 9.7%; }
   .d54 { width: 5.4%; }
   .d47 { width: 4.7%; }
-  .d205 { width: 20.5%; }
+  .d105 { width: 10.5%; }
   .d720 { width: 72%; }
   .d808 { width: 80.8%; }
   .d586 { width: 58.6%; }
@@ -133,14 +259,14 @@ style: |
   .row .bars i.p { background: #4a76b8; }
   .row .bars i.e { background: #f08a24; }
   .row .val { width: 230px; text-align: right; font-size: 25px; color: #5b6674; }
-  .b310 { width: 31%; }
-  .b33 { width: 3.3%; }
-  .b422 { width: 42.2%; }
-  .b88 { width: 8.8%; }
-  .b542 { width: 54.2%; }
-  .b97 { width: 9.7%; }
+  .b159 { width: 15.9%; }
+  .b17 { width: 1.7%; }
+  .b216 { width: 21.6%; }
+  .b45 { width: 4.5%; }
+  .b278 { width: 27.8%; }
+  .b50 { width: 5%; }
   .b1000 { width: 100%; }
-  .b147 { width: 14.7%; }
+  .b75 { width: 7.5%; }
   .kp { color: #4a76b8; font-weight: 700; }
   .ke { color: #b35c00; font-weight: 700; }
 ---
@@ -180,7 +306,7 @@ One meeting note. One idea note.
 That alone produces a full-stack, full-spec product.
 </span>
 
-<span class="note">The ultimate form of Goal Mode: provide only the goal, and the graph catches the rest.<br/>Requirement coverage from 50% to 100%, 6.8× fewer tokens, and 4.4× less time.</span>
+<span class="note">The ultimate form of Goal Mode: provide only the goal, and the graph catches the rest.<br/>Requirement coverage from 51.6% to 100%, 13.3× fewer tokens, and 7.5× less time.</span>
 
 ---
 
@@ -369,6 +495,77 @@ Entrust any one of the three to diligence, and 100% is merely **self-reported**.
 
 <!-- _class: divider -->
 
+# What if the product is a story?
+
+<span class="note">Settings become build constraints</span>
+
+---
+
+# A fluent scene can still be false
+
+- **Memory**: uses facts the character never learned
+- **Invention**: breaks history, geography, or motive
+- **Revision**: keeps scenes invalidated by an earlier edit
+
+> Long-form failure is global, not local.
+
+---
+
+# Every layer cites all prior sources
+
+<div class="narrative-graph">
+<div class="narrative-group">
+<div class="narrative-node principles">Principles</div>
+<div class="narrative-edge settings-principles"></div>
+<div class="narrative-node settings">Settings</div>
+</div>
+<div class="narrative-node scenarios">Scenarios</div>
+<div class="narrative-node storylines">Storylines</div>
+<div class="narrative-node manuscripts">Manuscripts</div>
+<div class="narrative-edge to-foundations scenarios-foundations"></div>
+<div class="narrative-edge to-foundations storylines-foundations"></div>
+<div class="narrative-edge storylines-scenarios"></div>
+<div class="narrative-edge manuscripts-foundations"></div>
+<div class="narrative-edge manuscripts-up"></div>
+<div class="narrative-edge manuscripts-storylines"></div>
+<div class="narrative-edge manuscripts-scenarios"></div>
+</div>
+
+---
+
+# Each edge blocks a different drift
+
+- Every narrative layer → principles: literary purpose
+- Every narrative unit → settings: facts, rules, knowledge
+- Scene plan and manuscript → storyline: causes and consequences
+- Manuscript → scene plan: exact execution
+- Target changes → affected reviews expire
+
+---
+
+# Why it works
+
+- Limited context → exact obligations for this scene
+- Plausible invention → explicit lineage and review
+- Revision drift → stale fingerprints
+- Forgotten promise → 100% reverse coverage
+
+**Creative freedom inside hard continuity.**
+
+---
+
+# One graph, any narrative
+
+- **Settings**: history, world rules, character
+- **Causality**: clues, motives, consequences
+- **Continuity**: knowledge, arcs, revisions
+- Historical fiction, fantasy, science fiction, mystery, drama
+- **Napoleon**: one example with 25 principles, 350 settings commitments, and 742 scenes
+
+---
+
+<!-- _class: divider -->
+
 # So how much does it change?
 
 <span class="note">Same requirements · Same engine · Same model, with only the plugin changed</span>
@@ -382,7 +579,7 @@ Entrust any one of the three to diligence, and 100% is merely **self-reported**.
 | todo | 85.5% <span class="track"><i class="w855"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
 | reddit | 80.3% <span class="track"><i class="w803"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
 | shopping | 63.1% <span class="track"><i class="w631"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-| erp | 50.0% <span class="track"><i class="w500"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| erp | 51.6% <span class="track"><i class="w516"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
 
 The larger the project, the more it misses.<br/>**It does not even know that it missed something.**
 
@@ -391,10 +588,10 @@ The larger the project, the more it misses.<br/>**It does not even know that it 
 # Yet it becomes cheaper
 
 <div class="rows">
-<div class="row"><span class="lbl">todo</span><span class="bars"><i class="p b310"></i><i class="e b33"></i></span><span class="val">866M → 92M</span></div>
-<div class="row"><span class="lbl">reddit</span><span class="bars"><i class="p b422"></i><i class="e b88"></i></span><span class="val">1,179M → 245M</span></div>
-<div class="row"><span class="lbl">shopping</span><span class="bars"><i class="p b542"></i><i class="e b97"></i></span><span class="val">1,516M → 271M</span></div>
-<div class="row"><span class="lbl">erp</span><span class="bars"><i class="p b1000"></i><i class="e b147"></i></span><span class="val">2,795M → 411M</span></div>
+<div class="row"><span class="lbl">todo</span><span class="bars"><i class="p b159"></i><i class="e b17"></i></span><span class="val">866M → 92M</span></div>
+<div class="row"><span class="lbl">reddit</span><span class="bars"><i class="p b216"></i><i class="e b45"></i></span><span class="val">1,179M → 245M</span></div>
+<div class="row"><span class="lbl">shopping</span><span class="bars"><i class="p b278"></i><i class="e b50"></i></span><span class="val">1,516M → 271M</span></div>
+<div class="row"><span class="lbl">erp</span><span class="bars"><i class="p b1000"></i><i class="e b75"></i></span><span class="val">5,449M → 411M</span></div>
 </div>
 
 Token consumption for <span class="kp">Plain</span> and <span class="ke">Evidence</span>.<br/>The gap widens as the project grows.
@@ -406,9 +603,9 @@ Token consumption for <span class="kp">Plain</span> and <span class="ke">Evidenc
 # Cost and time decreased as well: erp
 
 <div class="cards">
-<div class="card"><b>6.8×</b>fewer tokens<br/><span class="note">2,795M → 411M</span></div>
-<div class="card"><b>7.0×</b>lower cost<br/><span class="note">$34.65 → $4.96</span></div>
-<div class="card warm"><b>4.4×</b>less time<br/><span class="note">60h → 14h</span></div>
+<div class="card"><b>13.3×</b>fewer tokens<br/><span class="note">5,449M → 411M</span></div>
+<div class="card"><b>13.9×</b>lower cost<br/><span class="note">$68.72 → $4.96</span></div>
+<div class="card warm"><b>7.5×</b>less time<br/><span class="note">102h → 14h</span></div>
 </div>
 
 <br/>
@@ -455,7 +652,7 @@ Review Loop until Dry
 | todo | <span class="split"><i class="d97"></i><i class="rev"></i></span> Review 90% | <span class="split on"><i class="d720"></i><i class="rev"></i></span> Review 28% |
 | reddit | <span class="split"><i class="d54"></i><i class="rev"></i></span> Review 95% | <span class="split on"><i class="d808"></i><i class="rev"></i></span> Review 19% |
 | shopping | <span class="split"><i class="d47"></i><i class="rev"></i></span> Review 95% | <span class="split on"><i class="d586"></i><i class="rev"></i></span> Review 41% |
-| erp | <span class="split"><i class="d205"></i><i class="rev"></i></span> Review 80% | <span class="split on"><i class="d846"></i><i class="rev"></i></span> Review 15% |
+| erp | <span class="split"><i class="d105"></i><i class="rev"></i></span> Review 90% | <span class="split on"><i class="d846"></i><i class="rev"></i></span> Review 15% |
 
 Plain **starts quickly, but its review never ends.**<br/>Evidence is the opposite.
 
@@ -481,6 +678,7 @@ Plain **starts quickly, but its review never ends.**<br/>Evidence is the opposit
 
 - Humans review **only one document layer**
 - The **compiler protects everything below it**
+- A specification can be **software requirements, historical canon, or the laws of a fictional world**
 - 100% is not the goal, but **what remains after every error is closed**
 
 ---
@@ -491,5 +689,6 @@ Plain **starts quickly, but its review never ends.**<br/>Evidence is the opposit
 # Q & A
 
 - [https://github.com/samchon/ttsc](https://github.com/samchon/ttsc)
+- [https://github.com/wrtnlabs/novels](https://github.com/wrtnlabs/novels)
 - [https://ttsc.dev/docs/evidence](https://ttsc.dev/docs/evidence)
 - [https://ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)

--- a/website/src/slides/evidence.md
+++ b/website/src/slides/evidence.md
@@ -4,7 +4,7 @@ theme: default
 paginate: true
 size: 16:9
 title: "Evidence Graph"
-description: "Enforce 100% specification coverage as compile errors so coding agents cannot skip an obligation."
+description: "Enforce 100% specification coverage through compile errors so coding agents cannot skip obligations."
 url: "https://ttsc.dev/slides/evidence/"
 image: "https://ttsc.dev/og-evidence.png"
 style: |
@@ -87,14 +87,14 @@ style: |
   .opening-summary ul ul li { margin-bottom: 4px; }
   .benchmark-graphs { display: flex; flex-direction: column; gap: 18px; }
   .opening-measure { padding: 16px; background: #f3f6fb; border-radius: 12px; }
-  .opening-measure-title { margin-bottom: 12px; font-size: 28px; font-weight: 700; }
+  .opening-measure-title { margin-bottom: 12px; font-size: 30px; font-weight: 700; }
   .opening-bar-row {
     display: grid;
-    grid-template-columns: 96px 1fr 92px;
+    grid-template-columns: 108px 1fr 92px;
     gap: 8px;
     align-items: center;
     margin-top: 10px;
-    font-size: 24px;
+    font-size: 26px;
   }
   .opening-bar-row span { white-space: nowrap; }
   .opening-bar-row strong { text-align: right; white-space: nowrap; }
@@ -105,8 +105,8 @@ style: |
   .opening-bar i.coverage-evidence { width: 100%; }
   .opening-bar i.token-plain { width: 100%; }
   .opening-bar i.token-evidence { width: 7.5%; }
-  .benchmark-context { color: #5b6674; font-size: 26px; text-align: center; }
-  .note { font-size: 26px; color: #5b6674; }
+  .benchmark-context { color: #5b6674; font-size: 28px; text-align: center; }
+  .note { font-size: 28px; color: #5b6674; }
 
   /* Cumulative narrative references */
   .narrative-graph { position: relative; height: 410px; margin-top: -12px; }
@@ -258,7 +258,7 @@ style: |
     border: 3px solid #4a76b8;
     border-radius: 10px;
     color: #14284b;
-    font-size: 27px;
+    font-size: 30px;
     font-weight: 700;
   }
   .architecture-edge {
@@ -384,11 +384,11 @@ style: |
     border-top: 7px solid #4a76b8;
     border-radius: 10px;
     padding: 22px 24px;
-    font-size: 27px;
+    font-size: 30px;
     line-height: 1.5;
   }
   .card b { display: block; font-size: 40px; color: #14284b; margin-bottom: 8px; }
-  .card .note { font-size: 24px; }
+  .card .note { font-size: 28px; }
   .card.warm { border-top-color: #f08a24; }
   .card.warm b { color: #b35c00; }
   .problem-measures { display: flex; flex-direction: column; gap: 12px; width: 94%; margin: 12px auto 0; }
@@ -447,12 +447,12 @@ style: |
   /* Token bars by subject */
   .rows { margin-top: 26px; }
   .row { display: flex; align-items: center; margin-bottom: 20px; }
-  .row .lbl { width: 150px; font-size: 28px; }
+  .row .lbl { width: 150px; font-size: 30px; }
   .row .bars { flex: 1; }
   .row .bars i { display: block; height: 18px; border-radius: 9px; margin: 4px 0; }
   .row .bars i.p { background: #4a76b8; }
   .row .bars i.e { background: #f08a24; }
-  .row .val { width: 230px; text-align: right; font-size: 25px; color: #5b6674; }
+  .row .val { width: 230px; text-align: right; font-size: 28px; color: #5b6674; }
   .b159 { width: 15.9%; }
   .b17 { width: 1.7%; }
   .b216 { width: 21.6%; }
@@ -526,7 +526,7 @@ style: |
 
 ---
 
-# 90% on review. 51.6% coverage.
+# ERP Plain: 90% review · 51.6% coverage
 
 <div class="problem-measures">
 <div>
@@ -548,13 +548,13 @@ style: |
 
 # Evidence Graph
 
-<span class="note">We attached a compiler to specifications, too</span>
+<span class="note">Missing specification coverage becomes a compile error</span>
 
 ---
 
 <!-- _class: architecture-slide -->
 
-# First, divide the documents into layers
+# First, divide the artifacts into layers
 
 <div class="document-graph">
 <div class="architecture-node document-node meeting">Meeting notes</div>
@@ -571,7 +571,7 @@ style: |
 <div class="architecture-edge horizontal arrow-left document-edge test-foundations"></div>
 </div>
 
-<p class="architecture-caption">One evidence circuit connects meeting notes, documents, implementation, and tests.</p>
+<p class="architecture-caption">Each arrow points to the evidence it cites.</p>
 
 ---
 
@@ -587,7 +587,7 @@ style: |
 export function CouponStackingNotice(props: IProps): JSX.Element;
 ```
 
-**`@evidence <target> <reason>`**: what it is responsible for, and why.
+**`@evidence <target> <reason>`**: what this code implements, and why.
 
 ---
 
@@ -601,64 +601,7 @@ error TS16411: [evidence/graph]
 ```
 
 - One error per requirement → **the error list is the task list**
-- It appears alongside type errors. There is no additional check to attach
-
----
-
-# The configuration is one sentence
-
-```ts
-type: "typescript",
-files: ["src/components/**/*.tsx"],  // The side that discharges the obligation
-symbol: "function",
-reference: {
-  type: "markdown",
-  files: ["docs/**/*.md"],           // The targets whose obligations must be discharged
-  symbol: ["h2", "h3"],
-},
-```
-
-**Components implement documents. Therefore, every H2 and H3 must be cited.**
-
----
-
-# Four kinds of citation targets
-
-| Kind       | Unit                         |
-| ---------- | ---------------------------- |
-| Markdown   | file, H1-H4 section          |
-| Prisma     | model, column, relation      |
-| TypeScript | type, function, property     |
-| Swagger    | each operation under `paths` |
-
-<span class="note">Documents, schemas, code, and API specifications are connected by one grammar.</span>
-
----
-
-# Who determines 100%?
-
-<div class="cards">
-<div class="card"><b>Denominator</b>The configuration declares it</div>
-<div class="card"><b>Numerator</b>The developer records it with tags</div>
-<div class="card warm"><b>Decision</b>The compiler makes it every time</div>
-</div>
-
-<br/>
-
-Entrust any one of the three to diligence, and 100% is merely **self-reported**.
-
----
-
-# It prevents a false 100%
-
-| Option | What it prevents |
-| --- | --- |
-| `noEvidenceExclude` | Escaping with "not applicable" |
-| `uniqueEvidence` | Multiple places passing responsibility to one another |
-| `singleEvidencePerSymbol` | Piling every citation onto one place |
-| `requireReview` | Letting the specification change after it was cited |
-
-<span class="note">An exclusion requires a reason, and a review carries a fingerprint of the document content.</span>
+- It runs alongside type errors in the same build
 
 ---
 
@@ -666,7 +609,7 @@ Entrust any one of the three to diligence, and 100% is merely **self-reported**.
 
 # Spec Driven Development
 
-<span class="note">Write and review the requirements.<br/>AI builds everything with 100% coverage.</span>
+<span class="note">Requirements are the handoff.<br/>AI builds everything below them with 100% coverage.</span>
 
 ---
 
@@ -674,19 +617,18 @@ Entrust any one of the three to diligence, and 100% is merely **self-reported**.
 
 - Humans **review `docs/requirements` directly**
 - Specifications, implementation, and tests are **fully delegated**
-- ERP: **100+ tables, 150K+ LoC**, working as-is on its first run
 
 > The four benchmark subjects use this method as well.
 
 ---
 
-# Method B: Hand over only the raw material
+# Method B: Delegate the requirements, too
 
 - Hand over meeting notes and idea notes **as-is, without organizing them**
 - **Delegate everything**, starting with writing the requirements
 - If anything decided in the meeting is omitted, **the build breaks immediately**
 
-> In either method, the graph protects the lower layers.<br/>Humans review only the one layer they chose.
+> Humans provide one source layer.<br/>The graph protects everything below it.
 
 ---
 
@@ -702,6 +644,57 @@ Entrust any one of the three to diligence, and 100% is merely **self-reported**.
 - If anything decided in the meeting **is missing from the requirements, the build breaks**
 - Idea notes, interview records, and existing internal documents occupy the same layer
 - Citations are HTML comments, so **the rendered document stays clean**
+
+---
+
+# One rule declares the relationship
+
+```ts
+type: "typescript",
+files: ["src/components/**/*.tsx"], // sources
+symbol: "function",
+reference: {
+  type: "markdown",
+  files: ["docs/**/*.md"], // targets
+  symbol: ["h2", "h3"],
+},
+```
+
+**Components implement documents. Therefore, every H2 and H3 must be cited.**
+
+---
+
+# One grammar covers four artifact types
+
+| Kind       | Unit                         |
+| ---------- | ---------------------------- |
+| Markdown   | file, H1-H4 section          |
+| Prisma     | model, column, relation      |
+| TypeScript | type, function, property     |
+| Swagger    | each operation under `paths` |
+
+---
+
+# The compiler determines 100%
+
+<div class="cards">
+<div class="card"><b>Denominator</b>The configuration declares it</div>
+<div class="card"><b>Numerator</b>Tags record it</div>
+<div class="card warm"><b>Decision</b>The compiler makes it every time</div>
+</div>
+
+---
+
+# It closes mechanical loopholes
+
+| Option | What it prevents |
+| --- | --- |
+| `noEvidenceExclude` | Escaping with "not applicable" |
+| `uniqueEvidence` | Multiple places passing responsibility to one another |
+| `singleEvidencePerSymbol` | Piling every citation onto one place |
+| `requireReview` | Letting the specification change after it was cited |
+
+<span class="note">An exclusion requires a reason, and a review carries a fingerprint of the document content.</span>
 
 ---
 
@@ -774,7 +767,7 @@ Entrust any one of the three to diligence, and 100% is merely **self-reported**.
 
 ---
 
-# Coverage
+# Coverage: 51.6–85.5% → 100%
 
 | Subject | Plain | Evidence |
 | --- | --- | --- |
@@ -783,11 +776,11 @@ Entrust any one of the three to diligence, and 100% is merely **self-reported**.
 | shopping | 63.1% <span class="track"><i class="w631"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
 | erp | 51.6% <span class="track"><i class="w516"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
 
-The larger the project, the more it misses.<br/>**It does not even know that it missed something.**
+Plain coverage falls with scope. **Evidence remains at 100%.**
 
 ---
 
-# Yet it becomes cheaper
+# Token usage: 4.8–13.3× lower
 
 <div class="rows">
 <div class="row"><span class="lbl">todo</span><span class="bars"><i class="p b159"></i><i class="e b17"></i></span><span class="val">866M → 92M</span></div>
@@ -796,13 +789,13 @@ The larger the project, the more it misses.<br/>**It does not even know that it 
 <div class="row"><span class="lbl">erp</span><span class="bars"><i class="p b1000"></i><i class="e b75"></i></span><span class="val">5,449M → 411M</span></div>
 </div>
 
-Token consumption for <span class="kp">Plain</span> and <span class="ke">Evidence</span>.<br/>The gap widens as the project grows.
+<span class="kp">Plain</span> in blue. <span class="ke">Evidence</span> in orange.
 
 <span class="note">Original charts by phase: [https://ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)</span>
 
 ---
 
-# Cost and time decreased as well: ERP
+# ERP: 100% coverage · $4.96 · 14h
 
 <div class="cards">
 <div class="card"><b>13.3×</b>fewer tokens<br/><span class="note">5,449M → 411M</span></div>
@@ -810,13 +803,9 @@ Token consumption for <span class="kp">Plain</span> and <span class="ke">Evidenc
 <div class="card warm"><b>7.5×</b>less time<br/><span class="note">102h → 14h</span></div>
 </div>
 
-<br/>
-
-This was not a cost paid for quality.<br/>**It built more and finished for less.**
-
 ---
 
-# But the review consumes all the money
+# Review: 90–95% → 15–41% of tokens
 
 | Subject | Plain | Evidence |
 | --- | --- | --- |
@@ -829,7 +818,7 @@ This was not a cost paid for quality.<br/>**It built more and finished for less.
 
 ---
 
-# What if it lies?
+# 100% coverage can include false citations
 
 ```ts
 /**
@@ -846,7 +835,7 @@ This was not a cost paid for quality.<br/>**It built more and finished for less.
 
 ---
 
-# In return, the review becomes narrower
+# Human review checks citation truth
 
 |  | Plain | Evidence |
 | --- | --- | --- |
@@ -862,10 +851,10 @@ This was not a cost paid for quality.<br/>**It built more and finished for less.
 
 # Summary
 
-- Humans review **only one document layer**
-- The **compiler protects everything below it**
-- A specification can be **software requirements, historical canon, or the laws of a fictional world**
-- 100% is not the goal, but **what remains after every error is closed**
+- Missing specification coverage becomes **a compile error**
+- Requirements are **the handoff**
+- Coverage rises from **51.6–85.5% to 100%**
+- Human review checks **citation truth**
 
 ---
 
@@ -873,7 +862,7 @@ This was not a cost paid for quality.<br/>**It built more and finished for less.
 
 # Appendix: Stories
 
-<span class="note">Settings become build constraints</span>
+<span class="note">Principles and settings become build constraints</span>
 
 ---
 
@@ -915,7 +904,6 @@ This was not a cost paid for quality.<br/>**It built more and finished for less.
 - Storylines, Scenarios, Manuscripts → Settings: facts, rules, knowledge
 - Scenarios, Manuscripts → Storylines: causes and consequences
 - Manuscripts → Scenarios: exact execution
-- Target changes → affected reviews expire
 
 ---
 
@@ -923,7 +911,7 @@ This was not a cost paid for quality.<br/>**It built more and finished for less.
 
 - Limited context → exact obligations for this scene
 - Plausible invention → explicit lineage and review
-- Revision drift → stale fingerprints
+- Revision drift → affected reviews expire
 - Forgotten promise → 100% reverse coverage
 
 **Creative freedom inside hard continuity.**

--- a/website/src/slides/evidence.md
+++ b/website/src/slides/evidence.md
@@ -201,6 +201,148 @@ style: |
     border-left: 3px solid currentColor;
   }
 
+  /* Application evidence circuits */
+  section.architecture-slide h1 { margin-bottom: 0; }
+  .architecture-caption {
+    margin: 12px 0 0;
+    color: #5b6674;
+    font-size: 24px;
+    line-height: 1.3;
+    text-align: center;
+    white-space: nowrap;
+  }
+  .backend-graph + .architecture-caption,
+  .frontend-graph + .architecture-caption { font-size: 32px; }
+  .architecture-node {
+    position: absolute;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    height: 72px;
+    background: #f3f6fb;
+    border: 3px solid #4a76b8;
+    border-radius: 10px;
+    color: #14284b;
+    font-size: 27px;
+    font-weight: 700;
+  }
+  .architecture-edge {
+    position: absolute;
+    z-index: 1;
+    box-sizing: border-box;
+    color: #4a76b8;
+  }
+  .architecture-edge.horizontal { border-top: 3px solid currentColor; }
+  .architecture-edge.vertical { border-left: 3px solid currentColor; }
+  .architecture-edge.arrow-left::after {
+    content: "";
+    position: absolute;
+    top: -8px;
+    left: -1px;
+    border-top: 7px solid transparent;
+    border-right: 12px solid currentColor;
+    border-bottom: 7px solid transparent;
+  }
+  .architecture-edge.arrow-up::after {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: -8px;
+    border-right: 7px solid transparent;
+    border-bottom: 12px solid currentColor;
+    border-left: 7px solid transparent;
+  }
+  .architecture-edge.arrow-down::after {
+    content: "";
+    position: absolute;
+    bottom: -1px;
+    left: -8px;
+    border-top: 12px solid currentColor;
+    border-right: 7px solid transparent;
+    border-left: 7px solid transparent;
+  }
+
+  .document-graph { position: relative; height: 305px; margin-top: 60px; }
+  .backend-graph,
+  .frontend-graph { position: relative; height: 365px; margin-top: 45px; }
+  .architecture-foundations {
+    position: absolute;
+    left: 0;
+    top: 20px;
+    width: 31%;
+    height: 264px;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 12px;
+    border: 3px solid #f08a24;
+    border-radius: 14px;
+  }
+  .architecture-foundations .architecture-node {
+    position: relative;
+    flex: none;
+    width: 100%;
+    background: #fff8e8;
+    border-color: #f08a24;
+  }
+  .architecture-foundations .specifications-requirements {
+    position: relative;
+    left: auto;
+    top: auto;
+    flex: none;
+    align-self: center;
+    width: 0;
+    height: 90px;
+    color: #f08a24;
+    border-left: 3px solid currentColor;
+  }
+  .document-foundations { left: 30%; }
+  .document-node.meeting { left: 0; top: 35px; width: 22%; }
+  .document-node.implementation { left: 70%; top: 35px; width: 22%; }
+  .document-node.test { left: 70%; top: 197px; width: 22%; }
+  .document-edge.requirements-meeting { left: 22%; top: 71px; width: 9.3%; }
+  .document-edge.implementation-foundations { left: 61%; top: 71px; width: 9%; }
+  .document-edge.test-implementation { left: 81%; top: 107px; height: 90px; }
+  .document-edge.test-foundations { left: 61%; top: 233px; width: 9%; }
+  .backend-graph .architecture-foundations,
+  .frontend-graph .architecture-foundations { top: 55px; }
+  .backend-node.database { left: 40%; top: 70px; width: 22%; }
+  .backend-node.operation { left: 40%; top: 232px; width: 22%; }
+  .backend-node.schema { left: 70%; top: 70px; width: 22%; }
+  .backend-node.test { left: 70%; top: 232px; width: 22%; }
+  .backend-edge.database-foundations { left: 31%; top: 106px; width: 9%; }
+  .backend-edge.operation-foundations { left: 31%; top: 268px; width: 9%; }
+  .backend-edge.operation-database { left: 51%; top: 142px; height: 90px; }
+  .backend-edge.schema-database { left: 62%; top: 106px; width: 8%; }
+  .backend-edge.test-operation { left: 62%; top: 268px; width: 8%; }
+  .architecture-edge.outer-top-source { left: 81%; top: 15px; height: 55px; }
+  .architecture-edge.outer-top-horizontal { left: 15.5%; top: 15px; width: 65.5%; }
+  .architecture-edge.outer-top-target { left: 15.5%; top: 15px; height: 40px; }
+  .architecture-edge.outer-bottom-source { left: 81%; top: 304px; height: 55px; }
+  .architecture-edge.outer-bottom-horizontal { left: 15.5%; top: 359px; width: 65.5%; }
+  .architecture-edge.outer-bottom-target { left: 15.5%; top: 319px; height: 40px; }
+
+  .frontend-node.backend {
+    left: 40%;
+    top: 70px;
+    width: 22%;
+    background: #14284b;
+    border: 4px solid #14284b;
+    box-shadow: inset 0 0 0 4px #8ab4ff;
+    color: #ffffff;
+  }
+  .frontend-node.hooks { left: 40%; top: 232px; width: 22%; }
+  .frontend-node.journeys { left: 70%; top: 70px; width: 22%; }
+  .frontend-node.screens { left: 70%; top: 232px; width: 22%; }
+  .frontend-edge.backend-foundations { left: 31%; top: 106px; width: 9%; }
+  .frontend-edge.hooks-backend { left: 51%; top: 142px; height: 90px; }
+  .frontend-edge.screens-hooks { left: 62%; top: 268px; width: 8%; }
+  .frontend-edge.journeys-screens { left: 81%; top: 142px; height: 90px; }
+
   /* Cards */
   .cards { display: flex; gap: 22px; margin-top: 20px; }
   .card {
@@ -318,20 +460,26 @@ That alone produces a full-stack, full-spec product.
 
 ---
 
+<!-- _class: architecture-slide -->
+
 # First, divide the documents into layers
 
-```
-Meeting notes · Idea notes
-      ↓
-requirements      What is needed
-      ↓
-specifications    What to build
-      ↓
-Implementation · Tests
-```
+<div class="document-graph">
+<div class="architecture-node document-node meeting">Meeting notes</div>
+<div class="architecture-foundations document-foundations">
+<div class="architecture-node">Requirements</div>
+<div class="architecture-edge vertical arrow-up specifications-requirements"></div>
+<div class="architecture-node">Specifications</div>
+</div>
+<div class="architecture-node document-node implementation">Implementation</div>
+<div class="architecture-node document-node test">Test</div>
+<div class="architecture-edge horizontal arrow-left document-edge requirements-meeting"></div>
+<div class="architecture-edge horizontal arrow-left document-edge implementation-foundations"></div>
+<div class="architecture-edge vertical arrow-up document-edge test-implementation"></div>
+<div class="architecture-edge horizontal arrow-left document-edge test-foundations"></div>
+</div>
 
-- A lower layer can exist **only on the evidence of the layer above it**
-- Humans need to touch **only one layer**
+<p class="architecture-caption">One evidence circuit connects meeting notes, documents, implementation, and tests.</p>
 
 ---
 
@@ -339,7 +487,7 @@ Implementation · Tests
 
 - Humans **review `docs/requirements` directly**
 - Specifications, implementation, and tests are **fully delegated**
-- Film production automation solution: **about 450K LoC**, working as-is on its first run
+- ERP: **100+ tables, 150K+ LoC**, working as-is on its first run
 
 > The four benchmark subjects use this method as well.
 
@@ -370,21 +518,64 @@ Implementation · Tests
 
 ---
 
-# The backend and frontend work like this
+<!-- _class: architecture-slide -->
 
-```
-requirements ─▶ specifications
-     │                │
-     └───────┬────────┘
-             ├─▶ DB schema
-             ├─▶ API operations ─▶ Generated SDK ─▶ Tests
-             └─▶ Hooks ─▶ Screens ─▶ Journeys
-```
+# The backend works like this
 
-- Specifications stand on requirements as evidence,<br/>and **both layers together** impose obligations downward
-- **Both tests and hooks** discharge the generated SDK's obligations
+<div class="backend-graph">
+<div class="architecture-foundations">
+<div class="architecture-node">Requirements</div>
+<div class="architecture-edge vertical arrow-up specifications-requirements"></div>
+<div class="architecture-node">Specifications</div>
+</div>
+<div class="architecture-node backend-node database">DB schema</div>
+<div class="architecture-node backend-node operation">API operation</div>
+<div class="architecture-node backend-node schema">API schema</div>
+<div class="architecture-node backend-node test">Test</div>
+<div class="architecture-edge horizontal arrow-left backend-edge database-foundations"></div>
+<div class="architecture-edge horizontal arrow-left backend-edge operation-foundations"></div>
+<div class="architecture-edge vertical arrow-up backend-edge operation-database"></div>
+<div class="architecture-edge horizontal arrow-left backend-edge schema-database"></div>
+<div class="architecture-edge horizontal arrow-left backend-edge test-operation"></div>
+<div class="architecture-edge vertical outer-top-source"></div>
+<div class="architecture-edge horizontal outer-top-horizontal"></div>
+<div class="architecture-edge vertical arrow-down outer-top-target"></div>
+<div class="architecture-edge vertical outer-bottom-source"></div>
+<div class="architecture-edge horizontal outer-bottom-horizontal"></div>
+<div class="architecture-edge vertical arrow-up outer-bottom-target"></div>
+</div>
 
-**"The backend is done, but there is no screen" becomes a compile error.**
+<p class="architecture-caption">Backend artifacts trace back to Requirements and Specifications.</p>
+
+---
+
+<!-- _class: architecture-slide -->
+
+# The frontend works like this
+
+<div class="frontend-graph">
+<div class="architecture-foundations">
+<div class="architecture-node">Requirements</div>
+<div class="architecture-edge vertical arrow-up specifications-requirements"></div>
+<div class="architecture-node">Specifications</div>
+</div>
+<div class="architecture-node frontend-node backend">Backend</div>
+<div class="architecture-node frontend-node hooks">Hooks</div>
+<div class="architecture-node frontend-node screens">Screens</div>
+<div class="architecture-node frontend-node journeys">Journeys</div>
+<div class="architecture-edge horizontal arrow-left frontend-edge backend-foundations"></div>
+<div class="architecture-edge vertical arrow-up frontend-edge hooks-backend"></div>
+<div class="architecture-edge horizontal arrow-left frontend-edge screens-hooks"></div>
+<div class="architecture-edge vertical arrow-down frontend-edge journeys-screens"></div>
+<div class="architecture-edge vertical outer-top-source"></div>
+<div class="architecture-edge horizontal outer-top-horizontal"></div>
+<div class="architecture-edge vertical arrow-down outer-top-target"></div>
+<div class="architecture-edge vertical outer-bottom-source"></div>
+<div class="architecture-edge horizontal outer-bottom-horizontal"></div>
+<div class="architecture-edge vertical arrow-up outer-bottom-target"></div>
+</div>
+
+<p class="architecture-caption">Frontend delivery traces back to the documents and Backend.</p>
 
 ---
 

--- a/website/src/slides/evidence.md
+++ b/website/src/slides/evidence.md
@@ -63,27 +63,47 @@ style: |
     justify-content: center;
     text-align: center;
   }
-  section.divider h1 { color: #ffffff; border-bottom: none; font-size: 56px; }
-  section.divider p { color: #b9c9e6; font-size: 30px; }
-  section.divider .note { color: #b9c9e6; }
+  section.divider h1 { color: #ffffff; border-bottom: none; font-size: 72px; }
+  section.divider p { color: #b9c9e6; font-size: 40px; }
+  section.divider .note { color: #b9c9e6; font-size: 40px; }
 
-  /* Opening claims */
-  .opening-claim {
-    font-size: 64px;
-    font-weight: 800;
-    line-height: 1.25;
-    text-align: center;
+  /* Opening summary */
+  .tldr-layout {
+    display: grid;
+    grid-template-columns: 60fr 40fr;
+    gap: 32px;
+    align-items: center;
+    margin-top: 24px;
   }
-  .opening-metrics { display: flex; width: 100%; gap: 70px; }
-  .opening-metric {
-    flex: 1;
-    border-top: 8px solid #4a76b8;
-    padding-top: 32px;
-    text-align: center;
+  .opening-summary {
+    font-size: 34px;
+    line-height: 1.35;
   }
-  .opening-metric b { display: block; color: #ffd479; font-size: 104px; line-height: 1; }
-  .opening-metric span { display: block; margin-top: 22px; color: #ffffff; font-size: 38px; }
-  .opening-context { margin-top: 42px; color: #a7b0be; font-size: 28px; text-align: center; }
+  .opening-summary ul { margin: 0; padding-left: 1.1em; }
+  .opening-summary li { margin-bottom: 10px; }
+  .opening-summary ul ul { margin: 6px 0 12px; font-size: 28px; line-height: 1.3; }
+  .opening-summary ul ul li { margin-bottom: 4px; }
+  .benchmark-graphs { display: flex; flex-direction: column; gap: 18px; }
+  .opening-measure { padding: 16px; background: #f3f6fb; border-radius: 12px; }
+  .opening-measure-title { margin-bottom: 12px; font-size: 28px; font-weight: 700; }
+  .opening-bar-row {
+    display: grid;
+    grid-template-columns: 88px 1fr 92px;
+    gap: 8px;
+    align-items: center;
+    margin-top: 10px;
+    font-size: 22px;
+  }
+  .opening-bar-row span { white-space: nowrap; }
+  .opening-bar-row strong { text-align: right; white-space: nowrap; }
+  .opening-bar { height: 22px; overflow: hidden; background: #e2e7ef; border-radius: 11px; }
+  .opening-bar i { display: block; height: 100%; background: #4a76b8; border-radius: 10px; }
+  .opening-bar-row.evidence .opening-bar i { background: #f08a24; }
+  .opening-bar i.coverage-plain { width: 51.6%; }
+  .opening-bar i.coverage-evidence { width: 100%; }
+  .opening-bar i.token-plain { width: 100%; }
+  .opening-bar i.token-evidence { width: 7.5%; }
+  .benchmark-context { color: #5b6674; font-size: 24px; text-align: center; }
   .note { font-size: 24px; color: #5b6674; }
 
   /* Cumulative narrative references */
@@ -435,30 +455,42 @@ style: |
 
 ---
 
-<!-- _class: dark -->
+# TL;DR
 
-<div class="opening-claim">
-Your specification becomes<br/><strong>a compile error no agent can skip.</strong>
+<div class="tldr-layout">
+<div class="opening-summary">
+
+- **Evidence Graph, a compiler harness**
+  - No loop until dry required
+  - `@evidence <target> <reason>`
+  - `@evidenceExclude <target> <reason>`
+- **Spec Driven Development**
+  - Write and review only the requirements
+  - AI builds everything with 100% coverage
+
 </div>
-
----
-
-<!-- _class: dark -->
-
-<div class="opening-metrics">
-<div class="opening-metric"><b>100%</b><span>requirement coverage</span></div>
-<div class="opening-metric"><b>13.3×</b><span>fewer tokens</span></div>
+<div class="benchmark-graphs">
+<div class="opening-measure">
+<div class="opening-measure-title">Requirement coverage</div>
+<div class="opening-bar-row"><span>Plain</span><div class="opening-bar"><i class="coverage-plain"></i></div><strong>51.6%</strong></div>
+<div class="opening-bar-row evidence"><span>Evidence</span><div class="opening-bar"><i class="coverage-evidence"></i></div><strong>100%</strong></div>
 </div>
-
-<div class="opening-context">ERP benchmark</div>
+<div class="opening-measure">
+<div class="opening-measure-title">Token usage</div>
+<div class="opening-bar-row"><span>Plain</span><div class="opening-bar"><i class="token-plain"></i></div><strong>5,449M</strong></div>
+<div class="opening-bar-row evidence"><span>Evidence</span><div class="opening-bar"><i class="token-evidence"></i></div><strong>411M</strong></div>
+</div>
+<div class="benchmark-context">100+ tables · 150K+ LoC</div>
+</div>
+</div>
 
 ---
 
 <!-- _class: divider -->
 
-# So what do humans do?
+# The Limits of Loop Until Dry
 
-<span class="note">One document layer. Delegate everything else</span>
+<span class="note">More review. Diminishing returns.</span>
 
 ---
 

--- a/website/src/slides/evidence.md
+++ b/website/src/slides/evidence.md
@@ -66,6 +66,8 @@ style: |
   section.divider h1 { color: #ffffff; border-bottom: none; font-size: 72px; }
   section.divider p { color: #b9c9e6; font-size: 40px; }
   section.divider .note { color: #b9c9e6; font-size: 40px; }
+  section.loop-slide ul { margin-top: 32px; }
+  section.loop-slide li { margin-bottom: 18px; font-size: 40px; }
 
   /* Opening summary */
   .tldr-layout {
@@ -88,11 +90,11 @@ style: |
   .opening-measure-title { margin-bottom: 12px; font-size: 28px; font-weight: 700; }
   .opening-bar-row {
     display: grid;
-    grid-template-columns: 88px 1fr 92px;
+    grid-template-columns: 96px 1fr 92px;
     gap: 8px;
     align-items: center;
     margin-top: 10px;
-    font-size: 22px;
+    font-size: 24px;
   }
   .opening-bar-row span { white-space: nowrap; }
   .opening-bar-row strong { text-align: right; white-space: nowrap; }
@@ -103,8 +105,8 @@ style: |
   .opening-bar i.coverage-evidence { width: 100%; }
   .opening-bar i.token-plain { width: 100%; }
   .opening-bar i.token-evidence { width: 7.5%; }
-  .benchmark-context { color: #5b6674; font-size: 24px; text-align: center; }
-  .note { font-size: 24px; color: #5b6674; }
+  .benchmark-context { color: #5b6674; font-size: 26px; text-align: center; }
+  .note { font-size: 26px; color: #5b6674; }
 
   /* Cumulative narrative references */
   .narrative-graph { position: relative; height: 410px; margin-top: -12px; }
@@ -237,7 +239,7 @@ style: |
   .architecture-caption {
     margin: 12px 0 0;
     color: #5b6674;
-    font-size: 24px;
+    font-size: 28px;
     line-height: 1.3;
     text-align: center;
     white-space: nowrap;
@@ -386,9 +388,28 @@ style: |
     line-height: 1.5;
   }
   .card b { display: block; font-size: 40px; color: #14284b; margin-bottom: 8px; }
-  .card .note { font-size: 22px; }
+  .card .note { font-size: 24px; }
   .card.warm { border-top-color: #f08a24; }
   .card.warm b { color: #b35c00; }
+  .problem-measures { display: flex; flex-direction: column; gap: 12px; width: 94%; margin: 12px auto 0; }
+  .problem-measure-title { margin-bottom: 8px; font-size: 32px; font-weight: 700; }
+  .problem-bar {
+    display: flex;
+    width: 100%;
+    height: 70px;
+    overflow: hidden;
+    background: #e2e7ef;
+    border-radius: 14px;
+  }
+  .problem-bar div { display: flex; align-items: center; justify-content: center; font-weight: 800; }
+  .problem-coverage { width: 51.6%; background: #4a76b8; color: #ffffff; font-size: 38px; }
+  .problem-build { width: 10%; background: #14284b; color: #ffffff; font-size: 28px; }
+  .problem-review { width: 90%; background: #9bb4d2; color: #14284b; font-size: 38px; }
+  .problem-legend { display: flex; justify-content: center; gap: 54px; margin-top: 6px; font-size: 28px; }
+  .problem-legend i { display: inline-block; width: 20px; height: 20px; margin-right: 8px; border-radius: 4px; }
+  .problem-legend .build { background: #14284b; }
+  .problem-legend .review { background: #9bb4d2; }
+  .problem-context { margin-top: 16px; color: #5b6674; font-size: 28px; text-align: center; }
 
   /* Bars */
   .track {
@@ -494,9 +515,46 @@ style: |
 
 ---
 
+<!-- _class: loop-slide -->
+
+# Loop Until Dry restarts the full review
+
+- Read everything from the beginning
+- Fix every finding
+- Restart from the beginning
+- Stop only after an empty round
+
+---
+
+# 90% on review. 51.6% coverage.
+
+<div class="problem-measures">
+<div>
+<div class="problem-measure-title">Requirement coverage</div>
+<div class="problem-bar"><div class="problem-coverage">51.6%</div></div>
+</div>
+<div>
+<div class="problem-measure-title">Time distribution</div>
+<div class="problem-bar"><div class="problem-build">10%</div><div class="problem-review">90%</div></div>
+<div class="problem-legend"><span><i class="build"></i>Initial development</span><span><i class="review"></i>Review loops</span></div>
+</div>
+</div>
+
+<div class="problem-context">ERP · 100+ tables · 150K+ LoC</div>
+
+---
+
+<!-- _class: divider -->
+
+# Spec Driven Development
+
+<span class="note">Write and review the requirements.<br/>AI builds everything with 100% coverage.</span>
+
+---
+
 <!-- _class: architecture-slide -->
 
-# First, divide the documents into layers
+# One graph connects the entire delivery
 
 <div class="document-graph">
 <div class="architecture-node document-node meeting">Meeting notes</div>
@@ -517,7 +575,7 @@ style: |
 
 ---
 
-# Method A: Humans write the requirements
+# Method A: Write and review the requirements
 
 - Humans **review `docs/requirements` directly**
 - Specifications, implementation, and tests are **fully delegated**
@@ -527,7 +585,7 @@ style: |
 
 ---
 
-# Method B: Hand over only the raw material
+# Method B: Delegate the requirements too
 
 - Hand over meeting notes and idea notes **as-is, without organizing them**
 - **Delegate everything**, starting with writing the requirements
@@ -537,7 +595,7 @@ style: |
 
 ---
 
-# Even requirements cite their evidence
+# Requirements can cite meeting notes
 
 ```md
 ## Coupon stacking limit {#coupon-stacking}
@@ -615,9 +673,9 @@ style: |
 
 <!-- _class: divider -->
 
-# So how does that work?
+# Compile Every Omission
 
-<span class="note">We attached a compiler to specifications, too</span>
+<span class="note">Two tags are enough</span>
 
 ---
 
@@ -647,21 +705,11 @@ error TS16411: [evidence/graph]
 ```
 
 - One error per requirement → **the error list is the task list**
-- It appears alongside type errors. There is no additional check to attach
+- It runs with `ttsc`, alongside type errors
 
 ---
 
-# There is only one thing an agent obeys
-
-- When told to read documents, it **pretends to have read them**
-- In a review, it **says everything is done**
-- But it **cannot get past a compile error**
-
-> Documents are good to read.<br/>Compile errors have to be read.
-
----
-
-# The configuration is one sentence
+# Configuration declares one relationship
 
 ```ts
 type: "typescript",
@@ -678,14 +726,14 @@ reference: {
 
 ---
 
-# Four kinds of citation targets
+# One grammar spans four artifact types
 
-| Kind          | Unit                         |
-| ------------- | ---------------------------- |
-| 📄 Markdown   | file, H1-H4 section          |
-| 🗄️ Prisma     | model, column, relation      |
-| 🔤 TypeScript | type, function, property     |
-| 🌐 Swagger    | each operation under `paths` |
+| Kind       | Unit                         |
+| ---------- | ---------------------------- |
+| Markdown   | file, H1-H4 section          |
+| Prisma     | model, column, relation      |
+| TypeScript | type, function, property     |
+| Swagger    | each operation under `paths` |
 
 <span class="note">Documents, schemas, code, and API specifications are connected by one grammar.</span>
 
@@ -701,7 +749,7 @@ reference: {
 
 <br/>
 
-Entrust any one of the three to diligence, and 100% is merely **self-reported**.
+**The compiler, not diligence, decides whether coverage is 100%.**
 
 ---
 
@@ -720,7 +768,99 @@ Entrust any one of the three to diligence, and 100% is merely **self-reported**.
 
 <!-- _class: divider -->
 
-# What if the product is a story?
+# Measured Results
+
+<span class="note">Same requirements · Same engine · Same model<br/>Only the plugin changed</span>
+
+---
+
+# Coverage reaches 100%
+
+| Subject | Plain | Evidence |
+| --- | --- | --- |
+| todo | 85.5% <span class="track"><i class="w855"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| reddit | 80.3% <span class="track"><i class="w803"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| shopping | 63.1% <span class="track"><i class="w631"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| erp | 51.6% <span class="track"><i class="w516"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+
+Plain coverage falls as scope grows. **Evidence remains at 100%.**
+
+---
+
+# Token savings grow with scope
+
+<div class="rows">
+<div class="row"><span class="lbl">todo</span><span class="bars"><i class="p b159"></i><i class="e b17"></i></span><span class="val">866M → 92M</span></div>
+<div class="row"><span class="lbl">reddit</span><span class="bars"><i class="p b216"></i><i class="e b45"></i></span><span class="val">1,179M → 245M</span></div>
+<div class="row"><span class="lbl">shopping</span><span class="bars"><i class="p b278"></i><i class="e b50"></i></span><span class="val">1,516M → 271M</span></div>
+<div class="row"><span class="lbl">erp</span><span class="bars"><i class="p b1000"></i><i class="e b75"></i></span><span class="val">5,449M → 411M</span></div>
+</div>
+
+<span class="kp">Plain</span> in blue. <span class="ke">Evidence</span> in orange. The gap widens with scope.
+
+<span class="note">Original charts by phase: [https://ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)</span>
+
+---
+
+# ERP: more complete, cheaper, faster
+
+<div class="cards">
+<div class="card"><b>13.3×</b>fewer tokens<br/><span class="note">5,449M → 411M</span></div>
+<div class="card"><b>13.9×</b>lower cost<br/><span class="note">$68.72 → $4.96</span></div>
+<div class="card warm"><b>7.5×</b>less time<br/><span class="note">102h → 14h</span></div>
+</div>
+
+<br/>
+
+**100% coverage with less time and cost.**
+
+---
+
+# Review share falls from 90–95% to 15–41%
+
+| Subject | Plain | Evidence |
+| --- | --- | --- |
+| todo | <span class="split"><i class="d97"></i><i class="rev"></i></span> Review 90% | <span class="split on"><i class="d720"></i><i class="rev"></i></span> Review 28% |
+| reddit | <span class="split"><i class="d54"></i><i class="rev"></i></span> Review 95% | <span class="split on"><i class="d808"></i><i class="rev"></i></span> Review 19% |
+| shopping | <span class="split"><i class="d47"></i><i class="rev"></i></span> Review 95% | <span class="split on"><i class="d586"></i><i class="rev"></i></span> Review 41% |
+| erp | <span class="split"><i class="d105"></i><i class="rev"></i></span> Review 90% | <span class="split on"><i class="d846"></i><i class="rev"></i></span> Review 15% |
+
+<span class="note">Dark is development. Light is review. Each cell represents 100% of its tokens.</span>
+
+---
+
+# A tag can satisfy coverage and still lie
+
+```ts
+/**
+ * @evidence docs/discount.md#coupon-stacking Explains the per-issuer limit.
+ * @evidenceReview docs/discount.md#coupon-stacking #a1b2c3d4e5f6
+ *                 Verified that the screen copy matches the limit in policy section 3.
+ */
+```
+
+- `@evidenceReview` records the checked source and its fingerprint
+- A source change invalidates the review
+
+> The compiler finds omissions. Humans judge truthfulness.
+
+---
+
+# Human review becomes a finite checklist
+
+|  | Plain | Evidence |
+| --- | --- | --- |
+| What to inspect | All code, documents, and tests | The truthfulness of citations |
+| Scope | Start over in every round | The tag list is the checklist |
+| What is missing | Humans and AI must search to find out | The compiler has already reported it |
+
+**The compiler handles "omissions"; humans handle "falsehoods."**
+
+---
+
+<!-- _class: divider -->
+
+# The Same Harness for Stories
 
 <span class="note">Settings become build constraints</span>
 
@@ -760,10 +900,10 @@ Entrust any one of the three to diligence, and 100% is merely **self-reported**.
 
 # Each edge blocks a different drift
 
-- Every narrative layer → principles: literary purpose
-- Every narrative unit → settings: facts, rules, knowledge
-- Scene plan and manuscript → storyline: causes and consequences
-- Manuscript → scene plan: exact execution
+- Storylines, Scenarios, Manuscripts → Principles: literary purpose
+- Storylines, Scenarios, Manuscripts → Settings: facts, rules, knowledge
+- Scenarios, Manuscripts → Storylines: causes and consequences
+- Manuscripts → Scenarios: exact execution
 - Target changes → affected reviews expire
 
 ---
@@ -789,122 +929,14 @@ Entrust any one of the three to diligence, and 100% is merely **self-reported**.
 
 ---
 
-<!-- _class: divider -->
-
-# So how much does it change?
-
-<span class="note">Same requirements · Same engine · Same model, with only the plugin changed</span>
-
----
-
-# Coverage
-
-| Subject | Plain | Evidence |
-| --- | --- | --- |
-| todo | 85.5% <span class="track"><i class="w855"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-| reddit | 80.3% <span class="track"><i class="w803"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-| shopping | 63.1% <span class="track"><i class="w631"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-| erp | 51.6% <span class="track"><i class="w516"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-
-The larger the project, the more it misses.<br/>**It does not even know that it missed something.**
-
----
-
-# Yet it becomes cheaper
-
-<div class="rows">
-<div class="row"><span class="lbl">todo</span><span class="bars"><i class="p b159"></i><i class="e b17"></i></span><span class="val">866M → 92M</span></div>
-<div class="row"><span class="lbl">reddit</span><span class="bars"><i class="p b216"></i><i class="e b45"></i></span><span class="val">1,179M → 245M</span></div>
-<div class="row"><span class="lbl">shopping</span><span class="bars"><i class="p b278"></i><i class="e b50"></i></span><span class="val">1,516M → 271M</span></div>
-<div class="row"><span class="lbl">erp</span><span class="bars"><i class="p b1000"></i><i class="e b75"></i></span><span class="val">5,449M → 411M</span></div>
-</div>
-
-Token consumption for <span class="kp">Plain</span> and <span class="ke">Evidence</span>.<br/>The gap widens as the project grows.
-
-<span class="note">Original charts by phase: [https://ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)</span>
-
----
-
-# Cost and time decreased as well: erp
-
-<div class="cards">
-<div class="card"><b>13.3×</b>fewer tokens<br/><span class="note">5,449M → 411M</span></div>
-<div class="card"><b>13.9×</b>lower cost<br/><span class="note">$68.72 → $4.96</span></div>
-<div class="card warm"><b>7.5×</b>less time<br/><span class="note">102h → 14h</span></div>
-</div>
-
-<br/>
-
-This was not a cost paid for quality.<br/>**It built more and finished for less.**
-
----
-
-# What if it lies?
-
-```ts
-/**
- * @evidence docs/discount.md#coupon-stacking Explains the per-issuer limit.
- * @evidenceReview docs/discount.md#coupon-stacking #a1b2c3d4e5f6
- *                 Verified that the screen copy matches the limit in policy section 3.
- */
-```
-
-- Inexpensive models **sometimes write facts that do not exist**
-- Requiring fingerprinted reviews makes this **converge toward zero**<br/>but takes more time
-
-> A false tag removes the error, not the problem.
-
----
-
-# Ultimately, the review must run
-
-Review Loop until Dry
-
-```
-① Read everything again from the beginning
-② If there is even one thing to fix → ①
-③ Stop only after a round finds nothing
-```
-
-<span class="note">Both arms were measured under this discipline.</span>
-
----
-
-# But the review consumes all the money
-
-| Subject | Plain | Evidence |
-| --- | --- | --- |
-| todo | <span class="split"><i class="d97"></i><i class="rev"></i></span> Review 90% | <span class="split on"><i class="d720"></i><i class="rev"></i></span> Review 28% |
-| reddit | <span class="split"><i class="d54"></i><i class="rev"></i></span> Review 95% | <span class="split on"><i class="d808"></i><i class="rev"></i></span> Review 19% |
-| shopping | <span class="split"><i class="d47"></i><i class="rev"></i></span> Review 95% | <span class="split on"><i class="d586"></i><i class="rev"></i></span> Review 41% |
-| erp | <span class="split"><i class="d105"></i><i class="rev"></i></span> Review 90% | <span class="split on"><i class="d846"></i><i class="rev"></i></span> Review 15% |
-
-Plain **starts quickly, but its review never ends.**<br/>Evidence is the opposite.
-
-<span class="note">Dark is development, light is review. Each cell represents 100% of its tokens.</span>
-
----
-
-# In return, the review becomes narrower
-
-|  | Plain | Evidence |
-| --- | --- | --- |
-| What to inspect | All code, documents, and tests | The truthfulness of citations |
-| Scope | Start over in every round | The tag list is the checklist |
-| What is missing | Humans and AI must search to find out | The compiler has already reported it |
-
-**The compiler handles "omissions"; humans handle "falsehoods."**
-
----
-
 <!-- _class: dark -->
 
-# Summary
+# Two tags. One completion condition.
 
-- Humans review **only one document layer**
-- The **compiler protects everything below it**
-- A specification can be **software requirements, historical canon, or the laws of a fictional world**
-- 100% is not the goal, but **what remains after every error is closed**
+- `@evidence <target> <reason>`
+- `@evidenceExclude <target> <reason>`
+- Write and review the requirements
+- AI builds everything with 100% coverage
 
 ---
 


### PR DESCRIPTION
## Summary

- refresh the ERP evidence benchmark figures
- add concise narrative evidence slides and a cumulative reference graph
- link the novels repository as a narrative example

## Verification

- `pnpm exec prettier --check website/src/slides/evidence.md`
- `git diff --check -- website/src/slides/evidence.md`

## Skipped

- full `pnpm format` skipped per request for this website-only change
