### PR TITLE
feat(shim): expose SignatureFlags to Go source plugins

### DIFF
--- a/packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go
+++ b/packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go
@@ -1,0 +1,105 @@
+package linthost
+
+import (
+  "path/filepath"
+  "testing"
+
+  shimchecker "github.com/microsoft/typescript-go/shim/checker"
+)
+
+// Verifies SignatureFlags exposes construct-signature abstractness through the
+// shim.
+//
+// Signature.Flags() was already reachable through the full Signature alias,
+// but SignatureFlags itself was not nameable, so the returned value could not
+// be tested against SignatureFlagsAbstract (#1203). The flag is also the only
+// correct general answer: an abstract class without a constructor produces a
+// default construct signature with no declaration at all, and an abstract
+// class inheriting a concrete base clones the base's signature, so
+// Declaration() points at a NON-abstract constructor while the checker forces
+// the Abstract bit on. Declaration-modifier reading returns nothing for the
+// former and the wrong answer for the latter.
+//
+//  1. Build a program with abstract/concrete classes and constructor-type
+//     aliases, including the no-constructor and inherited-constructor shapes.
+//  2. Obtain every construct signature only through the exported shim surface.
+//  3. Assert the Abstract bit exactly where the source says abstract, the
+//     Construct bit on every construct signature, and the nil declaration on
+//     the default-signature boundary.
+func TestSignatureFlagsExposeConstructSignatureAbstractness(t *testing.T) {
+  root := t.TempDir()
+  writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "files": ["src/main.ts"]
+}
+`)
+  writeFile(t, filepath.Join(root, "src", "main.ts"), `export abstract class AbstractDeclared {
+  constructor(value: string) { void value; }
+}
+export class ConcreteDeclared {
+  constructor(value: string) { void value; }
+}
+export abstract class AbstractDefault {}
+export class ConcreteBase {
+  constructor(value: number) { void value; }
+}
+export abstract class AbstractInheriting extends ConcreteBase {}
+export type AbstractOpener = abstract new (value: string) => AbstractDeclared;
+export type ConcreteOpener = new (value: string) => ConcreteDeclared;
+`)
+
+  prog, diags, err := loadProgram(root, "tsconfig.json", loadProgramOptions{
+    needsRuleChecker: true,
+  })
+  if err != nil {
+    t.Fatal(err)
+  }
+  if len(diags) != 0 {
+    t.Fatalf("unexpected diagnostics: %#v", diags)
+  }
+  defer prog.close()
+
+  cases := []struct {
+    name         string
+    typeAlias    bool
+    wantAbstract bool
+    wantNilDecl  bool
+  }{
+    {name: "AbstractDeclared", wantAbstract: true},
+    {name: "ConcreteDeclared"},
+    {name: "AbstractDefault", wantAbstract: true, wantNilDecl: true},
+    {name: "ConcreteBase"},
+    {name: "AbstractInheriting", wantAbstract: true},
+    {name: "AbstractOpener", typeAlias: true, wantAbstract: true},
+    {name: "ConcreteOpener", typeAlias: true},
+  }
+  for _, tc := range cases {
+    symbol := classSymbol(t, prog, tc.name)
+    var target *shimchecker.Type
+    if tc.typeAlias {
+      target = shimchecker.Checker_getDeclaredTypeOfSymbol(prog.checker, symbol)
+    } else {
+      target = shimchecker.Checker_getTypeOfSymbol(prog.checker, symbol)
+    }
+    signatures := shimchecker.Checker_getSignaturesOfType(prog.checker, target, shimchecker.SignatureKindConstruct)
+    if len(signatures) != 1 {
+      t.Fatalf("%s construct signatures = %d, want 1", tc.name, len(signatures))
+    }
+    flags := signatures[0].Flags()
+    if flags&shimchecker.SignatureFlagsConstruct == 0 {
+      t.Fatalf("%s flags = %d: Construct bit missing on a construct signature", tc.name, flags)
+    }
+    if got := flags&shimchecker.SignatureFlagsAbstract != 0; got != tc.wantAbstract {
+      t.Fatalf("%s abstract bit = %v, want %v (flags = %d)", tc.name, got, tc.wantAbstract, flags)
+    }
+    if got := signatures[0].Declaration() == nil; got != tc.wantNilDecl {
+      t.Fatalf("%s nil declaration = %v, want %v", tc.name, got, tc.wantNilDecl)
+    }
+  }
+}

--- a/packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go
+++ b/packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go
@@ -19,12 +19,12 @@ import (
 // inheriting its base's constructor clones the base signature, so
 // Declaration() points at the OTHER class's constructor while the checker
 // forces the bit to the derived class's abstractness — in both directions.
-// Declaration-modifier reading returns nothing for the former and the wrong
-// answer for the latter.
+// Declaration-modifier reading returns nothing for the former and an answer
+// that tracks the base class for the latter.
 //
 //  1. Build a program with abstract/concrete classes and constructor-type
-//     aliases, covering the declared, constructor-less, and inherited shapes
-//     in both abstract polarities.
+//     aliases, covering the declared, default-signature, and inherited
+//     shapes in both abstract polarities.
 //  2. Obtain every construct signature only through the exported shim surface,
 //     reading flags into a shimchecker.SignatureFlags-typed variable so the
 //     alias itself is pinned, not just the member consts.
@@ -114,11 +114,11 @@ export type ConcreteOpener = new (value: string) => ConcreteDeclared;
     if got := flags&shimchecker.SignatureFlagsAbstract != 0; got != tc.wantAbstract {
       t.Fatalf("%s abstract bit = %v, want %v (flags = %d)", tc.name, got, tc.wantAbstract, flags)
     }
-    if got := signatures[0].Declaration() == nil; got != tc.wantNilDecl {
+    declaration := signatures[0].Declaration()
+    if got := declaration == nil; got != tc.wantNilDecl {
       t.Fatalf("%s nil declaration = %v, want %v", tc.name, got, tc.wantNilDecl)
     }
     if tc.checkDeclaringClass {
-      declaration := signatures[0].Declaration()
       if declaration == nil {
         t.Fatalf("%s has no declaration to read a declaring class from", tc.name)
       }

--- a/packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go
+++ b/packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go
@@ -4,6 +4,7 @@ import (
   "path/filepath"
   "testing"
 
+  shimast "github.com/microsoft/typescript-go/shim/ast"
   shimchecker "github.com/microsoft/typescript-go/shim/checker"
 )
 
@@ -13,19 +14,23 @@ import (
 // Signature.Flags() was already reachable through the full Signature alias,
 // but SignatureFlags itself was not nameable, so the returned value could not
 // be tested against SignatureFlagsAbstract (#1203). The flag is also the only
-// correct general answer: an abstract class without a constructor produces a
-// default construct signature with no declaration at all, and an abstract
-// class inheriting a concrete base clones the base's signature, so
-// Declaration() points at a NON-abstract constructor while the checker forces
-// the Abstract bit on. Declaration-modifier reading returns nothing for the
-// former and the wrong answer for the latter.
+// correct general answer: a constructor-less class produces a default
+// construct signature with no declaration at all, and a class inheriting its
+// base's constructor clones the base signature, so Declaration() points at
+// the OTHER class's constructor while the checker forces the bit to the
+// derived class's abstractness — in both directions. Declaration-modifier
+// reading returns nothing for the former and the wrong answer for the latter.
 //
 //  1. Build a program with abstract/concrete classes and constructor-type
-//     aliases, including the no-constructor and inherited-constructor shapes.
-//  2. Obtain every construct signature only through the exported shim surface.
+//     aliases, covering the declared, constructor-less, and inherited shapes
+//     in both abstract polarities.
+//  2. Obtain every construct signature only through the exported shim surface,
+//     reading flags into a shimchecker.SignatureFlags-typed variable so the
+//     alias itself is pinned, not just the member consts.
 //  3. Assert the Abstract bit exactly where the source says abstract, the
-//     Construct bit on every construct signature, and the nil declaration on
-//     the default-signature boundary.
+//     Construct bit everywhere, the nil declaration on both default-signature
+//     boundaries, and the declaring class's modifier where a declaration
+//     exists — diverging from the flag on both inherited shapes.
 func TestSignatureFlagsExposeConstructSignatureAbstractness(t *testing.T) {
   root := t.TempDir()
   writeFile(t, filepath.Join(root, "tsconfig.json"), `{
@@ -46,10 +51,12 @@ export class ConcreteDeclared {
   constructor(value: string) { void value; }
 }
 export abstract class AbstractDefault {}
+export class ConcreteDefault {}
 export class ConcreteBase {
   constructor(value: number) { void value; }
 }
 export abstract class AbstractInheriting extends ConcreteBase {}
+export class ConcreteInheriting extends AbstractDeclared {}
 export type AbstractOpener = abstract new (value: string) => AbstractDeclared;
 export type ConcreteOpener = new (value: string) => ConcreteDeclared;
 `)
@@ -70,12 +77,20 @@ export type ConcreteOpener = new (value: string) => ConcreteDeclared;
     typeAlias    bool
     wantAbstract bool
     wantNilDecl  bool
+    // checkDeclaringClass asserts the abstract modifier on the class that
+    // lexically declares the signature's constructor. It agrees with the
+    // flag on the declared shapes and diverges on both inherited shapes,
+    // pinning that the flag, not the declaration, carries abstractness.
+    checkDeclaringClass    bool
+    declaringClassAbstract bool
   }{
-    {name: "AbstractDeclared", wantAbstract: true},
-    {name: "ConcreteDeclared"},
+    {name: "AbstractDeclared", wantAbstract: true, checkDeclaringClass: true, declaringClassAbstract: true},
+    {name: "ConcreteDeclared", checkDeclaringClass: true},
     {name: "AbstractDefault", wantAbstract: true, wantNilDecl: true},
-    {name: "ConcreteBase"},
-    {name: "AbstractInheriting", wantAbstract: true},
+    {name: "ConcreteDefault", wantNilDecl: true},
+    {name: "ConcreteBase", checkDeclaringClass: true},
+    {name: "AbstractInheriting", wantAbstract: true, checkDeclaringClass: true},
+    {name: "ConcreteInheriting", checkDeclaringClass: true, declaringClassAbstract: true},
     {name: "AbstractOpener", typeAlias: true, wantAbstract: true},
     {name: "ConcreteOpener", typeAlias: true},
   }
@@ -91,7 +106,7 @@ export type ConcreteOpener = new (value: string) => ConcreteDeclared;
     if len(signatures) != 1 {
       t.Fatalf("%s construct signatures = %d, want 1", tc.name, len(signatures))
     }
-    flags := signatures[0].Flags()
+    var flags shimchecker.SignatureFlags = signatures[0].Flags()
     if flags&shimchecker.SignatureFlagsConstruct == 0 {
       t.Fatalf("%s flags = %d: Construct bit missing on a construct signature", tc.name, flags)
     }
@@ -100,6 +115,12 @@ export type ConcreteOpener = new (value: string) => ConcreteDeclared;
     }
     if got := signatures[0].Declaration() == nil; got != tc.wantNilDecl {
       t.Fatalf("%s nil declaration = %v, want %v", tc.name, got, tc.wantNilDecl)
+    }
+    if tc.checkDeclaringClass {
+      class := signatures[0].Declaration().Parent
+      if got := shimast.GetCombinedModifierFlags(class)&shimast.ModifierFlagsAbstract != 0; got != tc.declaringClassAbstract {
+        t.Fatalf("%s declaring class abstract modifier = %v, want %v", tc.name, got, tc.declaringClassAbstract)
+      }
     }
   }
 }

--- a/packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go
+++ b/packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go
@@ -14,12 +14,13 @@ import (
 // Signature.Flags() was already reachable through the full Signature alias,
 // but SignatureFlags itself was not nameable, so the returned value could not
 // be tested against SignatureFlagsAbstract (#1203). The flag is also the only
-// correct general answer: a constructor-less class produces a default
-// construct signature with no declaration at all, and a class inheriting its
-// base's constructor clones the base signature, so Declaration() points at
-// the OTHER class's constructor while the checker forces the bit to the
-// derived class's abstractness — in both directions. Declaration-modifier
-// reading returns nothing for the former and the wrong answer for the latter.
+// correct general answer: a class with no constructor and no base produces a
+// default construct signature with no declaration at all, and a class
+// inheriting its base's constructor clones the base signature, so
+// Declaration() points at the OTHER class's constructor while the checker
+// forces the bit to the derived class's abstractness — in both directions.
+// Declaration-modifier reading returns nothing for the former and the wrong
+// answer for the latter.
 //
 //  1. Build a program with abstract/concrete classes and constructor-type
 //     aliases, covering the declared, constructor-less, and inherited shapes
@@ -29,8 +30,8 @@ import (
 //     alias itself is pinned, not just the member consts.
 //  3. Assert the Abstract bit exactly where the source says abstract, the
 //     Construct bit everywhere, the nil declaration on both default-signature
-//     boundaries, and the declaring class's modifier where a declaration
-//     exists — diverging from the flag on both inherited shapes.
+//     boundaries, and the declaring class's modifier on every class-declared
+//     shape — diverging from the flag on both inherited ones.
 func TestSignatureFlagsExposeConstructSignatureAbstractness(t *testing.T) {
   root := t.TempDir()
   writeFile(t, filepath.Join(root, "tsconfig.json"), `{
@@ -117,7 +118,11 @@ export type ConcreteOpener = new (value: string) => ConcreteDeclared;
       t.Fatalf("%s nil declaration = %v, want %v", tc.name, got, tc.wantNilDecl)
     }
     if tc.checkDeclaringClass {
-      class := signatures[0].Declaration().Parent
+      declaration := signatures[0].Declaration()
+      if declaration == nil {
+        t.Fatalf("%s has no declaration to read a declaring class from", tc.name)
+      }
+      class := declaration.Parent
       if got := shimast.GetCombinedModifierFlags(class)&shimast.ModifierFlagsAbstract != 0; got != tc.declaringClassAbstract {
         t.Fatalf("%s declaring class abstract modifier = %v, want %v", tc.name, got, tc.declaringClassAbstract)
       }

--- a/packages/ttsc/shim/checker/enums_gen.go
+++ b/packages/ttsc/shim/checker/enums_gen.go
@@ -77,6 +77,17 @@ const (
   ObjectFlagsSingleSignatureType                        = innerchecker.ObjectFlagsSingleSignatureType
   ObjectFlagsTuple                                      = innerchecker.ObjectFlagsTuple
   ObjectFlagsUnresolvedMembers                          = innerchecker.ObjectFlagsUnresolvedMembers
+  SignatureFlagsCallChainFlags                          = innerchecker.SignatureFlagsCallChainFlags
+  SignatureFlagsConstruct                               = innerchecker.SignatureFlagsConstruct
+  SignatureFlagsHasLiteralTypes                         = innerchecker.SignatureFlagsHasLiteralTypes
+  SignatureFlagsHasRestParameter                        = innerchecker.SignatureFlagsHasRestParameter
+  SignatureFlagsIsInnerCallChain                        = innerchecker.SignatureFlagsIsInnerCallChain
+  SignatureFlagsIsNonInferrable                         = innerchecker.SignatureFlagsIsNonInferrable
+  SignatureFlagsIsOuterCallChain                        = innerchecker.SignatureFlagsIsOuterCallChain
+  SignatureFlagsIsSignatureCandidateForOverloadFailure  = innerchecker.SignatureFlagsIsSignatureCandidateForOverloadFailure
+  SignatureFlagsIsUntypedSignatureInJSFile              = innerchecker.SignatureFlagsIsUntypedSignatureInJSFile
+  SignatureFlagsNone                                    = innerchecker.SignatureFlagsNone
+  SignatureFlagsPropagatingFlags                        = innerchecker.SignatureFlagsPropagatingFlags
   SignatureKindConstruct                                = innerchecker.SignatureKindConstruct
   TypeFlagsAnyOrUnknown                                 = innerchecker.TypeFlagsAnyOrUnknown
   TypeFlagsBigInt                                       = innerchecker.TypeFlagsBigInt

--- a/packages/ttsc/shim/checker/shim.go
+++ b/packages/ttsc/shim/checker/shim.go
@@ -20,6 +20,7 @@ import (
 type Checker = innerchecker.Checker
 type IndexInfo = innerchecker.IndexInfo
 type Signature = innerchecker.Signature
+type SignatureFlags = innerchecker.SignatureFlags
 type SignatureKind = innerchecker.SignatureKind
 type Type = innerchecker.Type
 type TypeMapper = innerchecker.TypeMapper
@@ -217,6 +218,8 @@ func Checker_isSymbolAccessibleAsValue(recv *innerchecker.Checker, symbol *inner
 
 const (
   SignatureKindCall = innerchecker.SignatureKindCall
+
+  SignatureFlagsAbstract = innerchecker.SignatureFlagsAbstract
 
   TypeMapperKindUnknown = innerchecker.TypeMapperKindUnknown
   TypeMapperKindSimple  = innerchecker.TypeMapperKindSimple

--- a/packages/ttsc/shim/checker/shim.go
+++ b/packages/ttsc/shim/checker/shim.go
@@ -217,9 +217,9 @@ func Checker_isSymbolAccessibleAsValue(recv *innerchecker.Checker, symbol *inner
 }
 
 const (
-  SignatureKindCall = innerchecker.SignatureKindCall
-
   SignatureFlagsAbstract = innerchecker.SignatureFlagsAbstract
+
+  SignatureKindCall = innerchecker.SignatureKindCall
 
   TypeMapperKindUnknown = innerchecker.TypeMapperKindUnknown
   TypeMapperKindSimple  = innerchecker.TypeMapperKindSimple

--- a/packages/ttsc/tools/shim_audit/baseline.json
+++ b/packages/ttsc/tools/shim_audit/baseline.json
@@ -19,7 +19,6 @@
     "ESCAPE|checker|NodeBuilderContext",
     "ESCAPE|checker|ObjectType",
     "ESCAPE|checker|ReverseMappedType",
-    "ESCAPE|checker|SignatureFlags",
     "ESCAPE|checker|StringMappingType",
     "ESCAPE|checker|StructuredType",
     "ESCAPE|checker|SubstitutionType",

--- a/website/src/content/docs/development/concepts/tsgo.mdx
+++ b/website/src/content/docs/development/concepts/tsgo.mdx
@@ -421,7 +421,7 @@ for _, sig := range sigs {
 }
 ```
 
-Read abstractness from `Signature.Flags()`, not from the declaration's modifiers: a constructor-less class's default construct signature has no declaration at all, and an inherited constructor's `Declaration()` points at the base class, so the modifier answer is missing in the first case and wrong in the second. A bare `abstract new (...) => T` type literal sets the same flag.
+Read abstractness from `Signature.Flags()`, not from the declaration's modifiers: a class with no constructor and no base produces a default construct signature with no declaration at all, and an inherited constructor's `Declaration()` points at the base class's constructor declaration, so the modifier answer is missing in the first case and unreliable in the second. A bare `abstract new (...) => T` type literal sets the same flag. Pinned by `packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go`.
 
 **Contextual types.**
 

--- a/website/src/content/docs/development/concepts/tsgo.mdx
+++ b/website/src/content/docs/development/concepts/tsgo.mdx
@@ -412,6 +412,17 @@ if len(sigs) > 0 {
 
 Used by `rules_promise.go` to detect callable `.then` shapes.
 
+**Construct-signature abstractness.**
+
+```go
+sigs := checker.GetSignaturesOfType(t, shimchecker.SignatureKindConstruct)
+for _, sig := range sigs {
+    if sig.Flags()&shimchecker.SignatureFlagsAbstract != 0 { /* not new-able */ }
+}
+```
+
+Read abstractness from `Signature.Flags()`, not from the declaration's modifiers: a constructor-less class's default construct signature has no declaration at all, and an inherited constructor's `Declaration()` points at the base class, so the modifier answer is missing in the first case and wrong in the second. A bare `abstract new (...) => T` type literal sets the same flag.
+
 **Contextual types.**
 
 ```go

--- a/website/src/content/docs/development/concepts/tsgo.mdx
+++ b/website/src/content/docs/development/concepts/tsgo.mdx
@@ -421,7 +421,7 @@ for _, sig := range sigs {
 }
 ```
 
-Read abstractness from `Signature.Flags()`, not from the declaration's modifiers: a class with no constructor and no base produces a default construct signature with no declaration at all, and an inherited constructor's `Declaration()` points at the ancestor class that declared it, so the modifier answer is missing in the first case and unreliable in the second. A bare `abstract new (...) => T` type literal sets the same flag. Pinned by [`packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go`](https://github.com/samchon/ttsc/tree/master/packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go).
+Read abstractness from `Signature.Flags()`, not from the declaration's modifiers: a class with no constructor and no base produces a default construct signature with no declaration at all, and an inherited constructor's `Declaration()` points at the constructor declared by the ancestor class, so the modifier answer is missing in the first case and unreliable in the second. A bare `abstract new (...) => T` type literal sets the same flag. Pinned by [`packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go`](https://github.com/samchon/ttsc/tree/master/packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go).
 
 **Contextual types.**
 

--- a/website/src/content/docs/development/concepts/tsgo.mdx
+++ b/website/src/content/docs/development/concepts/tsgo.mdx
@@ -421,7 +421,7 @@ for _, sig := range sigs {
 }
 ```
 
-Read abstractness from `Signature.Flags()`, not from the declaration's modifiers: a class with no constructor and no base produces a default construct signature with no declaration at all, and an inherited constructor's `Declaration()` points at the base class's constructor declaration, so the modifier answer is missing in the first case and unreliable in the second. A bare `abstract new (...) => T` type literal sets the same flag. Pinned by `packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go`.
+Read abstractness from `Signature.Flags()`, not from the declaration's modifiers: a class with no constructor and no base produces a default construct signature with no declaration at all, and an inherited constructor's `Declaration()` points at the ancestor class that declared it, so the modifier answer is missing in the first case and unreliable in the second. A bare `abstract new (...) => T` type literal sets the same flag. Pinned by [`packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go`](https://github.com/samchon/ttsc/tree/master/packages/lint/test/shim/signature_flags_expose_construct_signature_abstractness_test.go).
 
 **Contextual types.**
 


### PR DESCRIPTION
## Intent

Solo issue-campaign cycle pull request. This pull request owns the complete accepted cycle, which is exactly one issue:

- References #1203 — Expose signature abstractness (`SignatureFlags`) to Go source plugins

`Signature.Flags()` is already reachable through the full `Signature` alias in `shim/checker`, but its return type `SignatureFlags` is not aliased, so a plugin can obtain the value yet cannot name its type or compare it against `SignatureFlagsAbstract`. The shim audit already records the gap as `ESCAPE|checker|SignatureFlags` ratchet backlog.

## Scope

- Alias `SignatureFlags` in the hand-maintained `shim/checker/shim.go`, beside the existing `SignatureKind` alias.
- Regenerate `enums_gen.go` with the owning command (`pnpm --filter ttsc shim:audit -fix`) so the whole member family is re-exported under the zero-tolerance enum layer.
- Remove the resolved `ESCAPE|checker|SignatureFlags` baseline entry.
- Add a runtime probe under `packages/lint/test/shim/` asserting the abstract bit across construct-signature shapes, including the shapes where declaration-based reading is impossible (nil declaration) or wrong (inherited base constructor).

## Verification

Pending. Verification is CI-owned per the repository's standing rule: the `shim-audit` gate proves audit closure, `test:go` proves the runtime probe, and the typia workflow proves consumer compatibility. Local runs are limited to the owning generator commands. Individual and Overall Self-Review results will be recorded as formal pull-request reviews.

## Deferred

Sibling `ESCAPE` baseline entries for other checker types remain grandfathered backlog; they are outside this cycle's declared single-issue scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
