### PR TITLE
fix(evidence): pin the live review fallback and remove its dead twin

### DIFF
--- a/packages/evidence/native/graph.go
+++ b/packages/evidence/native/graph.go
@@ -1226,6 +1226,12 @@ func reviewProblems(
 // `evidence/review` accepts. The two rules then disagreed about the same file.
 // `model.go` says as much where it defines the field.
 //
+// Reviews always carry semantic identities. Declarations are asymmetric: an
+// unattached Prisma documentation run carries an exclusion at a file position
+// that materializes no graph unit, so only lookup keeps a position fallback.
+// Indexing a review by its position too described a producer that does not
+// exist and obscured the one live exception.
+//
 // It is built once per claim rather than scanned per citation. A linear search
 // over every review, for every declaration, for every reference, is cubic in the
 // three things a large project has most of.
@@ -1241,7 +1247,7 @@ func newReviewLedger(reviews []*evidenceReview) *reviewLedger {
     if review == nil {
       continue
     }
-    for _, hostID := range reviewLedgerHostIDs(review) {
+    for _, hostID := range review.SemanticHostIDs {
       key := reviewLedgerKey(hostID, review.Reviews, review.Target)
       if ledger.byHostAndTarget[key] == nil {
         ledger.byHostAndTarget[key] = review
@@ -1251,22 +1257,12 @@ func newReviewLedger(reviews []*evidenceReview) *reviewLedger {
   return ledger
 }
 
-// reviewLedgerHostIDs is every identity a review answers on.
-//
-// The position identity is kept as a fallback for a carrier that has no semantic
-// host at all, such as an unattached Prisma documentation run, whose declarations
-// are keyed the same way.
-func reviewLedgerHostIDs(review *evidenceReview) []string {
-  if len(review.SemanticHostIDs) != 0 {
-    return review.SemanticHostIDs
-  }
-  if review.HostID == "" {
-    return nil
-  }
-  return []string{review.HostID}
-}
-
 // find locates the review bound to one declaration's identity and target.
+//
+// The position fallback is declaration-only. A Prisma file-level exclusion is
+// a valid carrier without a semantic graph host, while the review parsed from
+// the same unattached run carries the file position as a semantic ledger key.
+// Dropping this fallback makes that exclusion impossible to review.
 func (ledger *reviewLedger) find(
   declaration *evidenceDeclaration,
 ) *evidenceReview {

--- a/packages/evidence/native/graph.go
+++ b/packages/evidence/native/graph.go
@@ -1226,11 +1226,13 @@ func reviewProblems(
 // `evidence/review` accepts. The two rules then disagreed about the same file.
 // `model.go` says as much where it defines the field.
 //
-// Reviews always carry semantic identities. Declarations are asymmetric: an
+// Only reviews carrying semantic identities enter this ledger. A parser may
+// collect a review from an unsupported position with no graph identity, but
+// there is no host key to index it by. Declarations are asymmetric: an
 // unattached Prisma documentation run carries an exclusion at a file position
 // that materializes no graph unit, so only lookup keeps a position fallback.
-// Indexing a review by its position too described a producer that does not
-// exist and obscured the one live exception.
+// Indexing a review by its position too described a producer that does not exist
+// and obscured the one live exception.
 //
 // It is built once per claim rather than scanned per citation. A linear search
 // over every review, for every declaration, for every reference, is cubic in the

--- a/packages/evidence/native/graph.go
+++ b/packages/evidence/native/graph.go
@@ -1219,21 +1219,19 @@ func reviewProblems(
 //
 // Two properties are load-bearing and neither is obvious.
 //
-// The key comes from a review's SemanticHostIDs, never from a declaration's
-// HostID. On graph hosts the latter is a source position, so the two halves of a
-// merged identity carry different ones: keying on it refused a review written on
-// `namespace I` for a citation on `interface I`, which is placement the graph
-// elsewhere calls not worth a diagnostic and which `evidence/review` accepts.
-// The two rules then disagreed about the same file. `model.go` says as much where
-// it defines the fields.
+// The index side reads every ledger key from the review's SemanticHostIDs. On
+// graph hosts these are semantic identities, so the two halves of a merged
+// identity share a key. Indexing by their distinct source positions instead
+// refused a review written on `namespace I` for a citation on `interface I`,
+// which is placement the graph elsewhere calls not worth a diagnostic and which
+// `evidence/review` accepts. An unattached Prisma review has no graph identity,
+// so it stores its synthetic file-position key in SemanticHostIDs instead.
 //
-// Every indexable review supplies its ledger keys in SemanticHostIDs. Most are
-// graph identities. An unattached Prisma review instead supplies its synthetic
-// file-position key there because no graph unit owns that run. The declaration
-// from the same run is asymmetric: it leaves SemanticHostIDs empty and carries
-// the file position in HostID, so only lookup keeps a position fallback. A
-// second review-side fallback described no producer and obscured the one live
-// exception.
+// The lookup side normally reads the declaration's SemanticHostIDs. The
+// declaration from that Prisma run is asymmetric: it leaves them empty and
+// carries the file position in HostID, so `find` falls back there. Only lookup
+// needs a separate source-position field; the review-side fallback described no
+// producer. `model.go` states both field contracts.
 //
 // It is built once per claim rather than scanned per citation. A linear search
 // over every review, for every declaration, for every reference, is cubic in the

--- a/packages/evidence/native/graph.go
+++ b/packages/evidence/native/graph.go
@@ -1226,13 +1226,13 @@ func reviewProblems(
 // `evidence/review` accepts. The two rules then disagreed about the same file.
 // `model.go` says as much where it defines the field.
 //
-// Only reviews carrying semantic identities enter this ledger. A parser may
-// collect a review from an unsupported position with no graph identity, but
-// there is no host key to index it by. Declarations are asymmetric: an
-// unattached Prisma documentation run carries an exclusion at a file position
-// that materializes no graph unit, so only lookup keeps a position fallback.
-// Indexing a review by its position too described a producer that does not exist
-// and obscured the one live exception.
+// Every indexable review supplies its ledger keys in SemanticHostIDs. Most are
+// graph identities. An unattached Prisma review instead supplies its synthetic
+// file-position key there because no graph unit owns that run. The declaration
+// from the same run is asymmetric: it leaves SemanticHostIDs empty and carries
+// the file position in HostID, so only lookup keeps a position fallback. A
+// second review-side fallback described no producer and obscured the one live
+// exception.
 //
 // It is built once per claim rather than scanned per citation. A linear search
 // over every review, for every declaration, for every reference, is cubic in the

--- a/packages/evidence/native/graph.go
+++ b/packages/evidence/native/graph.go
@@ -1219,12 +1219,13 @@ func reviewProblems(
 //
 // Two properties are load-bearing and neither is obvious.
 //
-// The key is a *semantic* host identity, never `HostID`. `HostID` is a source
-// position, so the two halves of a merged identity carry different ones: keying on
-// it refused a review written on `namespace I` for a citation on `interface I`,
-// which is placement the graph elsewhere calls not worth a diagnostic and which
-// `evidence/review` accepts. The two rules then disagreed about the same file.
-// `model.go` says as much where it defines the field.
+// The key comes from a review's SemanticHostIDs, never from a declaration's
+// HostID. On graph hosts the latter is a source position, so the two halves of a
+// merged identity carry different ones: keying on it refused a review written on
+// `namespace I` for a citation on `interface I`, which is placement the graph
+// elsewhere calls not worth a diagnostic and which `evidence/review` accepts.
+// The two rules then disagreed about the same file. `model.go` says as much where
+// it defines the fields.
 //
 // Every indexable review supplies its ledger keys in SemanticHostIDs. Most are
 // graph identities. An unattached Prisma review instead supplies its synthetic
@@ -1263,7 +1264,7 @@ func newReviewLedger(reviews []*evidenceReview) *reviewLedger {
 //
 // The position fallback is declaration-only. A Prisma file-level exclusion is
 // a valid carrier without a semantic graph host, while the review parsed from
-// the same unattached run carries the file position as a semantic ledger key.
+// the same unattached run carries the file position as a synthetic ledger key.
 // Dropping this fallback makes that exclusion impossible to review.
 func (ledger *reviewLedger) find(
   declaration *evidenceDeclaration,

--- a/packages/evidence/native/markdown.go
+++ b/packages/evidence/native/markdown.go
@@ -315,7 +315,6 @@ func scanMarkdownInventory(
     }
     for _, review := range parseReviews(comment) {
       inventory.Reviews = append(inventory.Reviews, &evidenceReview{
-        HostID:          hostIDAtLine[line-1],
         SemanticHostIDs: []string{hostIDAtLine[line-1]},
         Reviews:         review.Reviews,
         Type:            artifactMarkdown,

--- a/packages/evidence/native/model.go
+++ b/packages/evidence/native/model.go
@@ -148,8 +148,10 @@ type referencePolicy struct {
 // its review spell one address, and resolving twice would let a review answer a
 // scope its citation does not name.
 type evidenceReview struct {
-  // SemanticHostIDs are the selected graph identities this review is written on,
-  // which is what a citation is matched by.
+  // SemanticHostIDs are the ledger keys this review is written on. They are
+  // normally selected graph identities; an unattached Prisma review uses its
+  // synthetic file identity so the declaration-side position fallback can meet
+  // it. A citation is matched by these keys.
   SemanticHostIDs []string
   // Reviews names which acknowledgement this review answers for. It is part of
   // the match, never inferred: verifying a citation and verifying an exclusion

--- a/packages/evidence/native/model.go
+++ b/packages/evidence/native/model.go
@@ -148,13 +148,6 @@ type referencePolicy struct {
 // its review spell one address, and resolving twice would let a review answer a
 // scope its citation does not name.
 type evidenceReview struct {
-  // HostID is the source-position identity, kept only so a carrier with no
-  // semantic identity can still be matched. It must not be the primary key: a
-  // merged identity's halves sit at different positions and therefore carry
-  // different HostIDs, so matching on it alone refuses a review written on
-  // `namespace I` for a citation on `interface I` — placement the graph
-  // elsewhere calls not worth a diagnostic, and which `evidence/review` accepts.
-  HostID string
   // SemanticHostIDs are the selected graph identities this review is written on,
   // which is what a citation is matched by.
   SemanticHostIDs []string

--- a/packages/evidence/native/model.go
+++ b/packages/evidence/native/model.go
@@ -293,8 +293,9 @@ type evidenceDeclaration struct {
   ID     string
   HostID string
   // SemanticHostIDs names the selected graph identities that physically host
-  // this declaration. HostID remains the source-position identity used only
-  // for same-block duplicate detection; policy cardinality must not confuse a
+  // this declaration. HostID remains the source-position identity used for
+  // same-block duplicate detection and as the review lookup fallback for a
+  // valid carrier with no semantic host. Policy cardinality must not confuse a
   // declaration position with the public symbol identity it represents.
   SemanticHostIDs []string
   Type            artifactKind

--- a/packages/evidence/native/prisma.go
+++ b/packages/evidence/native/prisma.go
@@ -586,7 +586,6 @@ func prismaDeclarationsFromComments(
       // nothing reads back — the same dead end the attached case just escaped.
       for _, review := range parseReviews(run.Body) {
         shared := &evidenceReview{
-          HostID:          "prisma:" + run.Path + ":file",
           SemanticHostIDs: []string{"prisma:" + run.Path + ":file"},
           Reviews:         review.Reviews,
           Type:            artifactPrisma,
@@ -664,7 +663,6 @@ func prismaDeclarationsFromComments(
     // author cannot perform.
     for _, review := range parseReviews(run.Body) {
       shared := &evidenceReview{
-        HostID:          host.ID,
         SemanticHostIDs: []string{host.ID},
         Reviews:         review.Reviews,
         Type:            artifactPrisma,

--- a/packages/evidence/native/require_review_matches_a_prisma_file_level_exclusion_test.go
+++ b/packages/evidence/native/require_review_matches_a_prisma_file_level_exclusion_test.go
@@ -1,0 +1,78 @@
+package evidence
+
+import "testing"
+
+/**
+ * Verifies `requireReview` matches a Prisma file-level exclusion to the review
+ * written in the same unattached documentation run.
+ *
+ * A file-level Prisma carrier has no semantic claim host: its exclusion reaches
+ * the review ledger only through the declaration-side source-position fallback.
+ * Every existing Prisma review test stops at parsing, so removing that fallback
+ * left every ledger exclusion permanently unreviewed while the suite stayed
+ * green. The wrong-host arm also prevents a target-only lookup from letting a
+ * review on a model answer for the file carrier.
+ *
+ *  1. Exclude one Markdown section from an unattached Prisma `///` run and read
+ *     the fingerprint from its missing-review diagnostic.
+ *  2. Put that review on a model and assert the file exclusion remains
+ *     unreviewed.
+ *  3. Move the fingerprinted review beside the exclusion and assert the graph
+ *     is clean.
+ */
+func TestRequireReviewMatchesAPrismaFileLevelExclusion(t *testing.T) {
+  config := `{"claims":[{
+    "type":"prisma",
+    "files":["prisma/**/*.prisma","prisma/exclude.schema"],
+    "symbol":"model",
+    "reference":{
+      "type":"markdown",
+      "files":["docs/**/*.md"],
+      "symbol":"h2",
+      "requireReview":true
+    }
+  }]}`
+  document := "## Pricing\n\nThe rate is capped at 30%.\n"
+  model := "model Sale {\n  id String @id\n}\n"
+  bareLedger := "/// @evidenceExclude docs/spec.md#pricing The schema stores no pricing policy.\n\n"
+  root := prismaBridgeRoot(t, nil)
+  run := func(schema string, ledger string) []string {
+    return runIndexRuleAtRoot(t, root, map[string]string{
+      "docs/spec.md":          document,
+      "prisma/schema.prisma":  schema,
+      "prisma/exclude.schema": ledger,
+    }, config)
+  }
+
+  unreviewed := run(model, bareLedger)
+  assertProblemContains(
+    t,
+    unreviewed,
+    "Unreviewed @evidenceExclude for 'docs/spec.md#pricing'",
+  )
+  fingerprint := ""
+  for _, message := range unreviewed {
+    if asksForAFingerprint(message) {
+      fingerprint = shapedFingerprint(message)
+      if fingerprint != "" {
+        break
+      }
+    }
+  }
+  if fingerprint == "" {
+    t.Fatalf("expected the exclusion finding to name a fingerprint, got:\n%v", unreviewed)
+  }
+
+  wrongHost := "/// @evidenceExcludeReview docs/spec.md#pricing #" + fingerprint +
+    " Read the section from the wrong host.\n" + model
+  assertProblemContains(
+    t,
+    run(wrongHost, bareLedger),
+    "Unreviewed @evidenceExclude for 'docs/spec.md#pricing'",
+  )
+
+  reviewedLedger := "/// @evidenceExclude docs/spec.md#pricing The schema stores no pricing policy.\n" +
+    "/// @evidenceExcludeReview docs/spec.md#pricing #" + fingerprint +
+    " Read the section: it names no stored model.\n\n"
+  assertNoProblems(t, run(model, reviewedLedger))
+}

--- a/packages/evidence/native/typescript.go
+++ b/packages/evidence/native/typescript.go
@@ -1553,7 +1553,6 @@ func collectTypeScriptDeclarations(
     // from every acknowledgement map in evaluation.
     for _, review := range parseReviews(content[entry.node.Pos():entry.node.End()]) {
       inventory.Reviews = append(inventory.Reviews, &evidenceReview{
-        HostID:          hostID,
         SemanticHostIDs: semanticHostIDs,
         Reviews:         review.Reviews,
         Type:            artifactTypeScript,


### PR DESCRIPTION
## Intent

This pull request owns the complete accepted cycle of the `evidence-review-ledger` solo issue campaign. Its accepted issue set is exactly #1218.

The branch opens implementation-free. Code, tests, and internal contract comments follow as commits on this branch.

## Scope

`reviewLedger` currently gives source-position fallback treatment to both sides of review matching even though the two sides have different invariants. A Prisma file-level exclusion declaration has no semantic host and needs its `HostID` fallback to meet the review parsed from the same unattached `///` run. Every production review already carries semantic host identities, so its position fallback and the position metadata only that branch consumes are dead.

This cycle pins the live declaration fallback through the real Prisma bridge, including its negative host boundary and fingerprinted passing state. It removes the unreachable review-side position state and rewrites the internal comments around the surviving invariant.

## Deferred

None. Open PR #1213 changes Markdown scanning but does not touch review construction or the ledger.

## Verification

Pending. The settled head will run the focused native review tests, the complete evidence native suite, workspace formatting, ordinary pull-request CI including the packaged `test-evidence` lane, Individual Self-Review for every pushed implementation commit, and a clean Overall Self-Review.
