### PR TITLE
docs(evidence): name the markdown checklist in the readme

### DIFF
--- a/packages/evidence/README.md
+++ b/packages/evidence/README.md
@@ -106,6 +106,16 @@ One claim: the components under `src` implement the docs, so every H2 and H3 und
 
 [The rule reference](https://ttsc.dev/docs/evidence/rules) has four more rules beside `evidence/graph`, and [the claim reference](https://ttsc.dev/docs/evidence/claims) has every claim option.
 
+### Checklists
+
+Coverage asks its question once per unit: has anyone cited this. Where a document is read down a column, such as development rules or a release gate, the question is whether each file answered each item.
+
+```ts
+{ type: "markdown", files: ["docs/rules.md"], symbol: "h2", checklist: true }
+```
+
+Every selected host then owes every item, and a file carrying no tag owes the whole list.
+
 ### Tags
 
 The configuration is written once. The tags are written forever: `@evidence` cites, `@evidenceReview` verifies, and `@evidenceExclude` declines. [The tag reference](https://ttsc.dev/docs/evidence/tags) has the full grammar.


### PR DESCRIPTION
## Intent

`@ttsc/evidence`'s readme states one coverage guarantee, "Leave one uncited and the build stops". That is the population-wide question, and it reads as the only question the graph asks. A `checklist` reference asks a different one: a unit that *is* cited still fails the build for every host that stayed silent. The readme therefore promised a guarantee that a checklist consumer does not get.

`checklist` is not a fifth cardinality option beside `uniqueEvidence`, `singleEvidencePerSymbol`, `noEvidenceExclude`, and `requireReview`. Those four tighten a count inside the per-reference obligation; this one moves the obligation onto each host, changing the readme's central noun from a spec unit to a (host, spec unit) pair. That is why it belongs above the configuration surface the readme hands to the guides.

## Scope

One subsection, `### Checklists`, under `## Setup` between `### Configure` (the claim it varies) and `### Tags` (what satisfies it). Ten added lines, no other file touched.

It names `checklist: true` once and states the rest as a guarantee rather than as an option row, which keeps the readme's existing boundary: it explains mechanisms that change what the build promises, in the language of what the author writes, and never enumerates reference policies.

## Verification

- `npx prettier --check packages/evidence/README.md` passes.
- Documentation-only change; no source, test, or configuration file is touched, so no build or test surface moves.
- Per the requested fast path, repo-wide `pnpm format`, typecheck, and the post-push check wait were skipped. The single-file Prettier check above stands in for the formatter on the one file this changes.

## Deferred

Three guide-side gaps were found in the same review and are **not** in this pull request:

- `website/src/content/docs/evidence/rules.mdx:41` — the `evidence/graph` Coverage question still reads "at least one acknowledgement in this claim", which is exactly the population-wide question a checklist replaces. `:40` likewise omits the checklist Unhosted finding.
- `website/src/content/docs/evidence/tags.mdx:172` — "Where an exclusion may sit" teaches that carrier eligibility is wider than the selected-host set, without noting that under a checklist that wider position buys nothing: an exclusion on a non-selected host answers no item and is reported unhosted.
- `website/src/content/docs/evidence/examples.mdx` — no checklist appears in the completed-graph page.

`claims.mdx` and `tags.mdx` already carry the full semantics from #1210 and #1217 and need no revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
