### PR TITLE
docs(evidence): carry the markdown checklist into the guides

### DIFF
--- a/website/src/content/docs/evidence/examples.mdx
+++ b/website/src/content/docs/evidence/examples.mdx
@@ -496,6 +496,30 @@ Editing a setting expires every review on it, so a revision leaves no stale scen
 
 Napoleon runs on 25 principles, 350 setting commitments, and 742 scenes, and the same graph fits historical fiction, fantasy, science fiction, mystery, and drama alike.
 
+## Checklist documents
+
+The three graphs above ask coverage the same way: has some declaration, anywhere, cited this unit. A [`checklist`](/docs/evidence/claims#checklist-documents) reference asks whether each host answered each item, which is the shape a rules document needs.
+
+```ts
+{
+  name: "specifications answer every review rule",
+  type: "markdown",
+  root: "docs",
+  files: ["features/**/*.md"],
+  symbol: "file",
+  reference: {
+    type: "markdown",
+    root: "docs",
+    files: ["rules/review.md"],
+    symbol: "h2",
+    checklist: true,
+    requireReview: true,
+  },
+}
+```
+
+Every feature specification owes every rule, so the denominator is documents times rules rather than rules alone, and a document carrying no tag owes the whole list. `@evidenceExclude` is how one document records that a rule does not apply to it, and `requireReview` makes each answer expire when the rule it answers is edited rather than when any other one moves.
+
 ## Next
 
 → [Adoption](/docs/evidence/adoption) for how to reach a graph like these from an existing codebase, one claim at a time, or [Claims and References](/docs/evidence/claims) for every option these examples use.

--- a/website/src/content/docs/evidence/rules.mdx
+++ b/website/src/content/docs/evidence/rules.mdx
@@ -37,8 +37,8 @@ One is the graph. The other four protect the conditions the graph depends on.
 The configured graph. It evaluates the whole declared graph once per Program and answers three separate questions.
 
 - **Resolution.** Does every declared target resolve to exactly one selected unit or structural ancestor?
-- **Host eligibility.** Does each `@evidence` sit on a symbol kind its claim selects, and each `@evidenceExclude` on an eligible carrier in a matching claim file?
-- **Coverage.** Does every selected reference unit have at least one acknowledgement in this claim, and does that acknowledgement satisfy whatever the reference's own policy demands?
+- **Host eligibility.** Does each `@evidence` sit on a symbol kind its claim selects, and each `@evidenceExclude` on an eligible carrier in a matching claim file? Under a [`checklist`](/docs/evidence/claims#checklist-documents) reference every acknowledgement answers for one selected host, so a tag sitting on no selected host answers nothing there and is reported where it sits once no other obligation consumes it.
+- **Coverage.** Does every selected reference unit have at least one acknowledgement in this claim, and does that acknowledgement satisfy whatever the reference's own policy demands? A [`checklist`](/docs/evidence/claims#checklist-documents) reference asks that question per host instead: every selected claim host owes every unit, so a unit somebody already cited still fails for every host that stayed silent.
 
 The rule is project-scoped, so its config entry must carry no `files` selector; the host rejects one that does. Scope a file rule in its own entry when you need to.
 

--- a/website/src/content/docs/evidence/tags.mdx
+++ b/website/src/content/docs/evidence/tags.mdx
@@ -176,6 +176,7 @@ Carrier eligibility is wider than ownership evidence and no wider than the claim
 - A TypeScript exclusion may sit on any supported public export in a claim file, even when that export's symbol kind is not selected by the claim. Unexported declarations, unsupported locations, and files outside the population do not qualify.
 - A Prisma exclusion may sit on a selected model or field, or in an unattached top-level `///` run in a matching claim file. That permits a lint-only `.schema` ledger outside the Prisma generation glob, which adds no model to the schema. The same unattached position never accepts `@evidence`, because ownership evidence belongs directly above the declaration that carries it.
 - A Markdown exclusion keeps the selected-symbol behavior of ownership evidence: it sits on a host kind the claim selects. Swagger hosts neither tag, because it never makes a claim in the first place.
+- Under a [`checklist`](/docs/evidence/claims#checklist-documents) reference that width stops paying. Every acknowledgement there is one host's own answer, so an exclusion on an eligible carrier that is not a selected host answers no item and is reported where it sits once no other obligation consumes it. `evidenceExcludeCarriers` is refused beside the option for the same reason.
 
 `evidenceExcludeCarriers` on the claim narrows this further to named ledger files. The benchmark template uses one per claim, so a reviewer opens `CONTROLLER_EVIDENCE_EXCLUDE.ts` instead of reading every controller:
 


### PR DESCRIPTION
## Intent

`checklist` landed with #1210 and its diagnostic surface was repaired in #1217, and both cycles documented it in `claims.mdx` and `tags.mdx`. Three pages that state the same semantics from another angle kept the pre-checklist wording, so a reader arriving from any of them learned the population-wide coverage model as the only one the graph has. This follows #1225, which fixed the same gap in the package readme.

## Scope

- **`rules.mdx:40-41`** — `evidence/graph`'s three questions. Coverage read "at least one acknowledgement in this claim", which is exactly the question a checklist replaces; it now names the per-host form, where a unit somebody already cited still fails for every host that stayed silent. Host eligibility omitted the deferred unhosted report, which is a finding in that family.
- **`tags.mdx`, "Where an exclusion may sit"** — the section teaches that carrier eligibility is wider than the selected-host set. One bullet notes that a checklist is where that width stops paying: an exclusion on an eligible carrier that is not a selected host answers no item and is reported once no other obligation consumes it. That is the same reason `evidenceExcludeCarriers` is refused beside the option.
- **`examples.mdx`** — no checklist appeared on the completed-graph page. Adds `## Checklist documents` after the three graphs, framed as the question the others do not ask rather than as a fourth domain, so the page's own "Three complete graphs" opening stays true. The example uses Markdown file hosts answering an `h2` rules document, which is the placement the novel section already describes for a file-level tag.

Every added link points at `/docs/evidence/claims#checklist-documents`, so the full semantics stay in one place and these three pages only route to it.

## Verification

- `npx prettier --check` passes on all three files.
- Documentation-only; no source, test, or configuration file is touched.
- Per the requested fast path, repo-wide `pnpm format`, typecheck, and the post-push check wait were skipped. The per-file Prettier check above stands in for the formatter.

## Notes

`claims.mdx` needed no revision: it already carries the complete semantics including the #1217 deferred-report wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
