### PR TITLE
feat(website): publish the Korean evidence deck and keep translations off the slides index

### DIFF
--- a/website/build/slides-metadata.cjs
+++ b/website/build/slides-metadata.cjs
@@ -10,6 +10,37 @@ const SLIDES_DIR =
   path.join(process.cwd(), "src", "slides");
 const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---/;
 
+// Deck slugs may carry a trailing `-<code>` locale suffix, e.g. `evidence-kr`.
+// The set is explicit rather than a bare two-letter match so a deck whose name
+// legitimately ends in two letters is never mistaken for a translation. It
+// holds ISO 639-1 language codes plus the ccTLD-style aliases this site uses
+// (`kr`, `jp`, `cn`, `tw`), and omits codes that collide with English words
+// (`it`, `no`, `is`, `id`, `be`, `he`, `as`, `to`).
+const SLIDE_LOCALE_CODES = Object.freeze([
+  "cn",
+  "de",
+  "en",
+  "es",
+  "fr",
+  "ja",
+  "jp",
+  "ko",
+  "kr",
+  "pt",
+  "ru",
+  "tw",
+  "vi",
+  "zh",
+]);
+const SLIDE_LOCALE_PATTERN = /^(.+)-([a-z]{2})$/;
+
+const parseSlideLocale = (slug) => {
+  const match = slug.match(SLIDE_LOCALE_PATTERN);
+  return match && SLIDE_LOCALE_CODES.includes(match[2])
+    ? { base: match[1], locale: match[2] }
+    : { base: slug, locale: null };
+};
+
 const parseFrontmatter = (content) => {
   const match = content.match(FRONTMATTER_PATTERN);
   if (!match) return {};
@@ -48,9 +79,13 @@ const readSlides = () =>
         route: `/slides/${slug}`,
         staticRoute: `/slides-static/${slug}/index.html`,
         ...metadata,
+        ...parseSlideLocale(slug),
       };
     })
     .sort((a, b) => a.title.localeCompare(b.title));
+
+const readListedSlides = () =>
+  readSlides().filter((slide) => slide.locale === null);
 
 const readSlide = (slug) =>
   readSlides().find((slide) => slide.slug === slug) ?? null;
@@ -58,7 +93,10 @@ const readSlide = (slug) =>
 module.exports = {
   FRONTMATTER_PATTERN,
   SLIDES_DIR,
+  SLIDE_LOCALE_CODES,
   parseFrontmatter,
+  parseSlideLocale,
+  readListedSlides,
   readSlide,
   readSlides,
 };

--- a/website/public/evidence/meme-checklist-kr.svg
+++ b/website/public/evidence/meme-checklist-kr.svg
@@ -1,0 +1,122 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="1080" viewBox="0 0 1080 1080">
+  <rect width="1080" height="1080" fill="#ffffff"/>
+  
+  <g>
+    <text x="40" y="84" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="56"
+          font-weight="bold" fill="#E5322B">나쁜 답변</text>
+    <text x="556" y="128" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#E5322B">- 파일 수만큼 똑같이 반복함</text><text x="556" y="200" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#E5322B">- 지루하고 잔소리 같음</text><text x="556" y="272" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#E5322B">- 조용히 있으면 안 걸림</text><text x="556" y="344" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#E5322B">- 논쟁 발생 가능성 100%</text><text x="556" y="416" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#E5322B">- 밀리면 그 규칙은 없어짐</text>
+    
+  <g>
+    <rect x="34" y="104" width="262" height="140" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 96 244 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 100 241 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="25" fill="#111111"
+          text-anchor="middle"><tspan x="165" y="164">규칙 다 지켰습니다</tspan><tspan x="165" y="201">(문서는 안 봄)</tspan></text>
+  </g>
+    
+  <g>
+    <rect x="316" y="126" width="212" height="124" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 386 250 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 390 247 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="27" fill="#111111"
+          text-anchor="middle"><tspan x="422" y="177.68">*규칙 다시</tspan><tspan x="422" y="216.68">읽어주는 중*</tspan></text>
+  </g>
+    
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="150" y1="334" x2="150" y2="312"/>
+    <circle cx="150" cy="304" r="8" fill="#111111"/>
+    <rect x="90" y="334" width="120" height="92" rx="16" fill="#fff"/>
+    <circle cx="127" cy="370" r="9" fill="#111111" stroke="none"/>
+    <circle cx="173" cy="370" r="9" fill="#111111" stroke="none"/>
+    <path d="M 128 398 q 22 16 44 0"/>
+    <rect x="102" y="432" width="96" height="64" rx="12" fill="#fff"/>
+    <path d="M 102 448 l -32 24"/>
+    <path d="M 198 448 l 32 24"/>
+    <line x1="128" y1="496" x2="128" y2="524"/>
+    <line x1="172" y1="496" x2="172" y2="524"/>
+  </g>
+    
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="415" cy="346" r="50" fill="#fff"/>
+    <circle cx="397" cy="336" r="7" fill="#111111" stroke="none"/>
+    <circle cx="433" cy="336" r="7" fill="#111111" stroke="none"/>
+    <path d="M 395 372 q 20 -14 40 0"/>
+    <path d="M 415 396 l 0 74"/>
+    <path d="M 415 412 l -46 -34"/>
+    <path d="M 415 412 l 46 -34"/>
+    <path d="M 415 470 l -30 54"/>
+    <path d="M 415 470 l 30 54"/>
+  </g>
+  </g>
+  <line x1="0" y1="540" x2="1080" y2="540" stroke="#111111" stroke-width="6"/>
+  
+  <g>
+    <text x="40" y="632" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="56"
+          font-weight="bold" fill="#1BA34C">좋은 답변</text>
+    <text x="556" y="676" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#1BA34C">- 금방 끝남</text><text x="556" y="748" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#1BA34C">- 파일마다 따로 물어봄</text><text x="556" y="820" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#1BA34C">- 조용히 있으면 전부 걸림</text><text x="556" y="892" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#1BA34C">- 팩트임 (컴파일러)</text><text x="556" y="964" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#1BA34C">- 논쟁에서 밀릴 확률 0에 수렴함</text>
+    
+  <g>
+    <rect x="34" y="652" width="262" height="140" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 96 792 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 100 789 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="25" fill="#111111"
+          text-anchor="middle"><tspan x="165" y="712">규칙 다 지켰습니다</tspan><tspan x="165" y="749">(문서는 안 봄)</tspan></text>
+  </g>
+    
+  <g>
+    <rect x="316" y="674" width="212" height="124" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 386 798 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 390 795 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="32" fill="#111111"
+          text-anchor="middle" font-weight="bold"><tspan x="422" y="746.88">그럼 죽어</tspan></text>
+  </g>
+    
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="150" y1="882" x2="150" y2="860"/>
+    <circle cx="150" cy="852" r="8" fill="#111111"/>
+    <rect x="90" y="882" width="120" height="92" rx="16" fill="#fff"/>
+    <circle cx="127" cy="918" r="9" fill="#111111" stroke="none"/>
+    <circle cx="173" cy="918" r="9" fill="#111111" stroke="none"/>
+    <path d="M 128 946 q 22 16 44 0"/>
+    <rect x="102" y="980" width="96" height="64" rx="12" fill="#fff"/>
+    <path d="M 102 996 l -32 24"/>
+    <path d="M 198 996 l 32 24"/>
+    <line x1="128" y1="1044" x2="128" y2="1072"/>
+    <line x1="172" y1="1044" x2="172" y2="1072"/>
+  </g>
+    
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="323" y="858" width="184" height="140" rx="14" fill="#fff"/>
+    <line x1="323" y1="896" x2="507" y2="896"/>
+    <circle cx="345" cy="877" r="7" fill="#111111" stroke="none"/>
+    <circle cx="369" cy="877" r="7" fill="#111111" stroke="none"/>
+    <circle cx="393" cy="877" r="7" fill="#111111" stroke="none"/>
+    <text x="349" y="954" font-family="Consolas, monospace" font-size="46"
+          font-weight="bold" fill="#E5322B" stroke="none">&gt; _</text>
+    <path d="M 355 998 l 0 30 l 120 0 l 0 -30"/>
+    <path d="M 319 1028 l 192 0" stroke-width="6"/>
+    <line x1="371" y1="1028" x2="371" y2="1072"/>
+    <line x1="459" y1="1028" x2="459" y2="1072"/>
+  </g>
+  </g>
+  <text x="1046" y="1054" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="25"
+        fill="#8b93a1" text-anchor="end">evidence graph</text>
+</svg>

--- a/website/public/evidence/meme-coverage-kr.svg
+++ b/website/public/evidence/meme-coverage-kr.svg
@@ -1,0 +1,122 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="1080" viewBox="0 0 1080 1080">
+  <rect width="1080" height="1080" fill="#ffffff"/>
+  
+  <g>
+    <text x="40" y="84" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="56"
+          font-weight="bold" fill="#E5322B">나쁜 답변</text>
+    <text x="556" y="128" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#E5322B">- 시간이 오래 걸림</text><text x="556" y="200" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#E5322B">- 매번 처음부터 다시 설명함</text><text x="556" y="272" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#E5322B">- 설명해도 세션 끝나면 잊음</text><text x="556" y="344" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#E5322B">- 논쟁 발생 가능성 100%</text><text x="556" y="416" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#E5322B">- 논쟁에서 밀리면 50%로 끝남</text>
+    
+  <g>
+    <rect x="34" y="104" width="262" height="140" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 96 244 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 100 241 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="25" fill="#111111"
+          text-anchor="middle"><tspan x="165" y="145.5">다 만든 거</tspan><tspan x="165" y="182.5">같은데요</tspan><tspan x="165" y="219.5">(50% 완성)</tspan></text>
+  </g>
+    
+  <g>
+    <rect x="316" y="126" width="212" height="124" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 386 250 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 390 247 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="27" fill="#111111"
+          text-anchor="middle"><tspan x="422" y="197.18">*설명 중*</tspan></text>
+  </g>
+    
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="150" y1="334" x2="150" y2="312"/>
+    <circle cx="150" cy="304" r="8" fill="#111111"/>
+    <rect x="90" y="334" width="120" height="92" rx="16" fill="#fff"/>
+    <circle cx="127" cy="370" r="9" fill="#111111" stroke="none"/>
+    <circle cx="173" cy="370" r="9" fill="#111111" stroke="none"/>
+    <path d="M 128 398 q 22 16 44 0"/>
+    <rect x="102" y="432" width="96" height="64" rx="12" fill="#fff"/>
+    <path d="M 102 448 l -32 24"/>
+    <path d="M 198 448 l 32 24"/>
+    <line x1="128" y1="496" x2="128" y2="524"/>
+    <line x1="172" y1="496" x2="172" y2="524"/>
+  </g>
+    
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="415" cy="346" r="50" fill="#fff"/>
+    <circle cx="397" cy="336" r="7" fill="#111111" stroke="none"/>
+    <circle cx="433" cy="336" r="7" fill="#111111" stroke="none"/>
+    <path d="M 395 372 q 20 -14 40 0"/>
+    <path d="M 415 396 l 0 74"/>
+    <path d="M 415 412 l -46 -34"/>
+    <path d="M 415 412 l 46 -34"/>
+    <path d="M 415 470 l -30 54"/>
+    <path d="M 415 470 l 30 54"/>
+  </g>
+  </g>
+  <line x1="0" y1="540" x2="1080" y2="540" stroke="#111111" stroke-width="6"/>
+  
+  <g>
+    <text x="40" y="632" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="56"
+          font-weight="bold" fill="#1BA34C">좋은 답변</text>
+    <text x="556" y="676" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#1BA34C">- 금방 끝남</text><text x="556" y="748" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#1BA34C">- 오래 기억에 남음</text><text x="556" y="820" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#1BA34C">- 팩트임 (컴파일러)</text><text x="556" y="892" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#1BA34C">- 간단하고 사전 지식이 필요X</text><text x="556" y="964" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif"
+               font-size="31" fill="#1BA34C">- 논쟁에서 밀릴 확률 0에 수렴함</text>
+    
+  <g>
+    <rect x="34" y="652" width="262" height="140" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 96 792 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 100 789 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="25" fill="#111111"
+          text-anchor="middle"><tspan x="165" y="693.5">다 만든 거</tspan><tspan x="165" y="730.5">같은데요</tspan><tspan x="165" y="767.5">(50% 완성)</tspan></text>
+  </g>
+    
+  <g>
+    <rect x="316" y="674" width="212" height="124" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 386 798 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 390 795 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="32" fill="#111111"
+          text-anchor="middle" font-weight="bold"><tspan x="422" y="746.88">그럼 죽어</tspan></text>
+  </g>
+    
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="150" y1="882" x2="150" y2="860"/>
+    <circle cx="150" cy="852" r="8" fill="#111111"/>
+    <rect x="90" y="882" width="120" height="92" rx="16" fill="#fff"/>
+    <circle cx="127" cy="918" r="9" fill="#111111" stroke="none"/>
+    <circle cx="173" cy="918" r="9" fill="#111111" stroke="none"/>
+    <path d="M 128 946 q 22 16 44 0"/>
+    <rect x="102" y="980" width="96" height="64" rx="12" fill="#fff"/>
+    <path d="M 102 996 l -32 24"/>
+    <path d="M 198 996 l 32 24"/>
+    <line x1="128" y1="1044" x2="128" y2="1072"/>
+    <line x1="172" y1="1044" x2="172" y2="1072"/>
+  </g>
+    
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="323" y="858" width="184" height="140" rx="14" fill="#fff"/>
+    <line x1="323" y1="896" x2="507" y2="896"/>
+    <circle cx="345" cy="877" r="7" fill="#111111" stroke="none"/>
+    <circle cx="369" cy="877" r="7" fill="#111111" stroke="none"/>
+    <circle cx="393" cy="877" r="7" fill="#111111" stroke="none"/>
+    <text x="349" y="954" font-family="Consolas, monospace" font-size="46"
+          font-weight="bold" fill="#E5322B" stroke="none">&gt; _</text>
+    <path d="M 355 998 l 0 30 l 120 0 l 0 -30"/>
+    <path d="M 319 1028 l 192 0" stroke-width="6"/>
+    <line x1="371" y1="1028" x2="371" y2="1072"/>
+    <line x1="459" y1="1028" x2="459" y2="1072"/>
+  </g>
+  </g>
+  <text x="1046" y="1054" font-family="Pretendard, Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR, sans-serif" font-size="25"
+        fill="#8b93a1" text-anchor="end">evidence graph</text>
+</svg>

--- a/website/src/app/slides/get-slides.js
+++ b/website/src/app/slides/get-slides.js
@@ -1,20 +1,26 @@
 import slidesMetadata from "../../../build/slides-metadata.cjs";
 
-const { readSlide, readSlides } = slidesMetadata;
+const { readListedSlides, readSlide, readSlides } = slidesMetadata;
 
 const localImage = (image) => {
   const url = new URL(image, "https://ttsc.dev");
   return url.origin === "https://ttsc.dev" ? url.pathname : url.href;
 };
 
+const withImagePath = (slide) => ({
+  ...slide,
+  imagePath: localImage(slide.image),
+});
+
 export function getSlides() {
-  return readSlides().map((slide) => ({
-    ...slide,
-    imagePath: localImage(slide.image),
-  }));
+  return readSlides().map(withImagePath);
+}
+
+export function getListedSlides() {
+  return readListedSlides().map(withImagePath);
 }
 
 export function getSlide(slug) {
   const slide = readSlide(slug);
-  return slide ? { ...slide, imagePath: localImage(slide.image) } : null;
+  return slide ? withImagePath(slide) : null;
 }

--- a/website/src/app/slides/page.jsx
+++ b/website/src/app/slides/page.jsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
 
-import { getSlides } from "./get-slides";
+import { getListedSlides } from "./get-slides";
 
 export default function SlidesPage() {
-  const slides = getSlides();
+  const slides = getListedSlides();
 
   return (
     <section className="ttsc-slides-page">

--- a/website/src/slides/evidence-kr.md
+++ b/website/src/slides/evidence-kr.md
@@ -1,0 +1,1068 @@
+---
+marp: true
+theme: default
+paginate: true
+size: 16:9
+title: "Evidence Graph (한국어)"
+description: "명세 커버리지 누락을 컴파일 에러로 만들어, 코딩 에이전트가 의무를 건너뛰지 못하게 한다."
+url: "https://ttsc.dev/slides/evidence-kr/"
+image: "https://ttsc.dev/og-evidence.png"
+style: |
+  section {
+    font-family: "Pretendard", "Apple SD Gothic Neo", "Malgun Gothic", "Noto Sans KR", sans-serif;
+    font-size: 32px;
+    line-height: 1.6;
+    padding: 60px 70px;
+    background: #ffffff;
+    color: #14161a;
+  }
+  h1 {
+    font-size: 50px;
+    color: #0f1115;
+    border-bottom: 4px solid #14284b;
+    padding-bottom: 14px;
+    margin-bottom: 34px;
+  }
+  ul, ol { margin-top: 10px; }
+  li { margin-bottom: 22px; }
+  strong { color: #14284b; }
+  code { font-family: "D2Coding", "Consolas", "Menlo", monospace; }
+  pre { font-size: 26px; line-height: 1.5; border-radius: 10px; }
+  table { font-size: 30px; width: 100%; }
+  th { background: #14284b; color: #ffffff; }
+  td, th { padding: 14px 18px; }
+  blockquote {
+    border-left: 8px solid #ffb020;
+    background: #fff8e8;
+    color: #2b3038;
+    padding: 18px 26px;
+    font-size: 32px;
+  }
+  footer { color: #9aa4b2; font-size: 17px; }
+  footer a { color: #9aa4b2; text-decoration: none; }
+  section::after { color: #9aa4b2; font-size: 17px; }
+  a { color: #1a5fb4; }
+  a:hover { color: #0d3d7a; }
+
+  /* Dark slides */
+  section.dark {
+    background: #0f1115;
+    color: #f4f5f7;
+    justify-content: center;
+  }
+  section.dark h1 { color: #ffffff; border-bottom: none; font-size: 60px; }
+  section.dark h2 { color: #8ab4ff; font-size: 34px; font-weight: 600; }
+  section.dark strong { color: #ffd479; }
+  section.dark li { color: #f4f5f7; }
+  section.dark code { background: #262b36; color: #ffd479; }
+  section.dark .note { color: #a7b0be; }
+  section.dark a { color: #8ab4ff; }
+  section.divider {
+    background: #14284b;
+    color: #ffffff;
+    justify-content: center;
+    text-align: center;
+  }
+  section.divider h1 { color: #ffffff; border-bottom: none; font-size: 72px; }
+  section.divider p { color: #b9c9e6; font-size: 40px; }
+  section.divider .note { color: #b9c9e6; font-size: 40px; }
+  section.loop-slide ul { margin-top: 32px; }
+  section.loop-slide li { margin-bottom: 18px; font-size: 40px; }
+
+  /* Opening summary */
+  .tldr-layout {
+    display: grid;
+    grid-template-columns: 60fr 40fr;
+    gap: 32px;
+    align-items: center;
+    margin-top: 24px;
+  }
+  .opening-summary {
+    font-size: 34px;
+    line-height: 1.35;
+  }
+  .opening-summary ul { margin: 0; padding-left: 1.1em; }
+  .opening-summary li { margin-bottom: 10px; }
+  .opening-summary ul ul { margin: 6px 0 12px; font-size: 28px; line-height: 1.3; }
+  .opening-summary ul ul li { margin-bottom: 4px; }
+  .benchmark-graphs { display: flex; flex-direction: column; gap: 18px; }
+  .opening-measure { padding: 16px; background: #f3f6fb; border-radius: 12px; }
+  .opening-measure-title { margin-bottom: 12px; font-size: 30px; font-weight: 700; }
+  .opening-bar-row {
+    display: grid;
+    grid-template-columns: 108px 1fr 92px;
+    gap: 8px;
+    align-items: center;
+    margin-top: 10px;
+    font-size: 26px;
+  }
+  .opening-bar-row span { white-space: nowrap; }
+  .opening-bar-row strong { text-align: right; white-space: nowrap; }
+  .opening-bar { height: 22px; overflow: hidden; background: #e2e7ef; border-radius: 11px; }
+  .opening-bar i { display: block; height: 100%; background: #4a76b8; border-radius: 10px; }
+  .opening-bar-row.evidence .opening-bar i { background: #f08a24; }
+  .opening-bar i.coverage-plain { width: 51.6%; }
+  .opening-bar i.coverage-evidence { width: 100%; }
+  .opening-bar i.token-plain { width: 100%; }
+  .opening-bar i.token-evidence { width: 7.5%; }
+  .benchmark-context { color: #5b6674; font-size: 28px; text-align: center; }
+  .note { font-size: 28px; color: #5b6674; }
+
+  /* Cumulative narrative references */
+  .narrative-graph { position: relative; height: 410px; margin-top: -12px; }
+  .narrative-group {
+    position: absolute;
+    left: 0;
+    top: 10px;
+    width: 32%;
+    height: 270px;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0;
+    box-sizing: border-box;
+    padding: 12px;
+    border: 3px solid #f08a24;
+    border-radius: 14px;
+  }
+  .narrative-node {
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    height: 84px;
+    background: #f3f6fb;
+    border: 3px solid #4a76b8;
+    border-radius: 10px;
+    color: #14284b;
+    font-size: 32px;
+    font-weight: 700;
+  }
+  .narrative-group .narrative-node { flex: none; width: 100%; border-color: #f08a24; }
+  .narrative-node.scenarios,
+  .narrative-node.storylines,
+  .narrative-node.manuscripts { position: absolute; width: 25%; }
+  .narrative-node.scenarios { left: 41%; top: 25px; }
+  .narrative-node.storylines { left: 41%; top: 181px; }
+  .narrative-node.manuscripts { left: 72%; top: 316px; }
+  .narrative-edge {
+    position: absolute;
+    z-index: 1;
+    box-sizing: border-box;
+    color: #4a76b8;
+  }
+  .narrative-edge.to-foundations {
+    left: 32%;
+    width: 9%;
+    border-top: 3px solid currentColor;
+  }
+  .narrative-edge.to-foundations::after,
+  .narrative-edge.manuscripts-scenarios::after,
+  .narrative-edge.manuscripts-storylines::after {
+    content: "";
+    position: absolute;
+    top: -8px;
+    left: -1px;
+    border-top: 7px solid transparent;
+    border-right: 12px solid currentColor;
+    border-bottom: 7px solid transparent;
+  }
+  .narrative-edge.scenarios-foundations { top: 67px; }
+  .narrative-edge.storylines-foundations { top: 223px; }
+  .narrative-edge.storylines-scenarios {
+    left: 53.5%;
+    top: 109px;
+    height: 72px;
+    border-left: 3px solid currentColor;
+  }
+  .narrative-edge.storylines-scenarios::after,
+  .narrative-edge.manuscripts-foundations::after {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: -8px;
+    border-right: 7px solid transparent;
+    border-bottom: 12px solid currentColor;
+    border-left: 7px solid transparent;
+  }
+  .narrative-edge.settings-principles {
+    position: relative;
+    left: auto;
+    top: auto;
+    flex: none;
+    align-self: center;
+    width: 0;
+    height: 72px;
+    color: #f08a24;
+    border-left: 3px solid currentColor;
+  }
+  .narrative-edge.settings-principles::after {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: -8px;
+    border-right: 7px solid transparent;
+    border-bottom: 12px solid currentColor;
+    border-left: 7px solid transparent;
+  }
+  .narrative-edge.manuscripts-scenarios {
+    left: 66%;
+    top: 67px;
+    width: 18.5%;
+    border-top: 3px solid currentColor;
+  }
+  .narrative-edge.manuscripts-storylines {
+    left: 66%;
+    top: 223px;
+    width: 18.5%;
+    border-top: 3px solid currentColor;
+  }
+  .narrative-edge.manuscripts-up {
+    left: 84.5%;
+    top: 67px;
+    height: 249px;
+    border-left: 3px solid currentColor;
+  }
+  .narrative-edge.manuscripts-foundations {
+    left: 16%;
+    top: 280px;
+    width: 56%;
+    height: 78px;
+    border-bottom: 3px solid currentColor;
+    border-left: 3px solid currentColor;
+  }
+
+  /* Application evidence circuits */
+  section.architecture-slide h1 { margin-bottom: 0; }
+  .architecture-caption {
+    margin: 12px 0 0;
+    color: #5b6674;
+    font-size: 28px;
+    line-height: 1.3;
+    text-align: center;
+    white-space: nowrap;
+  }
+  .backend-graph + .architecture-caption,
+  .frontend-graph + .architecture-caption { font-size: 32px; }
+  .architecture-node {
+    position: absolute;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    height: 72px;
+    background: #f3f6fb;
+    border: 3px solid #4a76b8;
+    border-radius: 10px;
+    color: #14284b;
+    font-size: 30px;
+    font-weight: 700;
+  }
+  .architecture-edge {
+    position: absolute;
+    z-index: 1;
+    box-sizing: border-box;
+    color: #4a76b8;
+  }
+  .architecture-edge.horizontal { border-top: 3px solid currentColor; }
+  .architecture-edge.vertical { border-left: 3px solid currentColor; }
+  .architecture-edge.arrow-left::after {
+    content: "";
+    position: absolute;
+    top: -8px;
+    left: -1px;
+    border-top: 7px solid transparent;
+    border-right: 12px solid currentColor;
+    border-bottom: 7px solid transparent;
+  }
+  .architecture-edge.arrow-up::after {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: -8px;
+    border-right: 7px solid transparent;
+    border-bottom: 12px solid currentColor;
+    border-left: 7px solid transparent;
+  }
+  .architecture-edge.arrow-down::after {
+    content: "";
+    position: absolute;
+    bottom: -1px;
+    left: -8px;
+    border-top: 12px solid currentColor;
+    border-right: 7px solid transparent;
+    border-left: 7px solid transparent;
+  }
+
+  .document-graph { position: relative; height: 305px; margin-top: 60px; }
+  .backend-graph,
+  .frontend-graph { position: relative; height: 365px; margin-top: 45px; }
+  .architecture-foundations {
+    position: absolute;
+    left: 0;
+    top: 20px;
+    width: 31%;
+    height: 264px;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 12px;
+    border: 3px solid #f08a24;
+    border-radius: 14px;
+  }
+  .architecture-foundations .architecture-node {
+    position: relative;
+    flex: none;
+    width: 100%;
+    background: #fff8e8;
+    border-color: #f08a24;
+  }
+  .architecture-foundations .specifications-requirements {
+    position: relative;
+    left: auto;
+    top: auto;
+    flex: none;
+    align-self: center;
+    width: 0;
+    height: 90px;
+    color: #f08a24;
+    border-left: 3px solid currentColor;
+  }
+  .document-foundations { left: 30%; }
+  .document-node.idea { left: 0; top: 35px; width: 22%; }
+  .document-node.implementation { left: 70%; top: 35px; width: 22%; }
+  .document-node.test { left: 70%; top: 197px; width: 22%; }
+  .document-edge.requirements-idea { left: 22%; top: 71px; width: 9.3%; }
+  .document-edge.implementation-foundations { left: 61%; top: 71px; width: 9%; }
+  .document-edge.test-implementation { left: 81%; top: 107px; height: 90px; }
+  .document-edge.test-foundations { left: 61%; top: 233px; width: 9%; }
+  .document-graph.requirements-only .document-foundations { left: 12%; }
+  .document-graph.requirements-only .document-node.implementation { left: 66%; }
+  .document-graph.requirements-only .document-node.test { left: 66%; }
+  .document-graph.requirements-only .document-edge.implementation-foundations { left: 43%; width: 23%; }
+  .document-graph.requirements-only .document-edge.test-implementation { left: 77%; }
+  .document-graph.requirements-only .document-edge.test-foundations { left: 43%; width: 23%; }
+  .backend-graph .architecture-foundations,
+  .frontend-graph .architecture-foundations { top: 55px; }
+  .backend-node.database { left: 40%; top: 70px; width: 22%; }
+  .backend-node.operation { left: 40%; top: 232px; width: 22%; }
+  .backend-node.schema { left: 70%; top: 70px; width: 22%; }
+  .backend-node.test { left: 70%; top: 232px; width: 22%; }
+  .backend-edge.database-foundations { left: 31%; top: 106px; width: 9%; }
+  .backend-edge.operation-foundations { left: 31%; top: 268px; width: 9%; }
+  .backend-edge.operation-database { left: 51%; top: 142px; height: 90px; }
+  .backend-edge.schema-database { left: 62%; top: 106px; width: 8%; }
+  .backend-edge.test-operation { left: 62%; top: 268px; width: 8%; }
+  .architecture-edge.outer-top-source { left: 81%; top: 15px; height: 55px; }
+  .architecture-edge.outer-top-horizontal { left: 15.5%; top: 15px; width: 65.5%; }
+  .architecture-edge.outer-top-target { left: 15.5%; top: 15px; height: 40px; }
+  .architecture-edge.outer-bottom-source { left: 81%; top: 304px; height: 55px; }
+  .architecture-edge.outer-bottom-horizontal { left: 15.5%; top: 359px; width: 65.5%; }
+  .architecture-edge.outer-bottom-target { left: 15.5%; top: 319px; height: 40px; }
+
+  .frontend-node.backend {
+    left: 40%;
+    top: 70px;
+    width: 22%;
+    background: #14284b;
+    border: 4px solid #14284b;
+    box-shadow: inset 0 0 0 4px #8ab4ff;
+    color: #ffffff;
+  }
+  .frontend-node.hooks { left: 40%; top: 232px; width: 22%; }
+  .frontend-node.journeys { left: 70%; top: 70px; width: 22%; }
+  .frontend-node.screens { left: 70%; top: 232px; width: 22%; }
+  .frontend-edge.backend-foundations { left: 31%; top: 106px; width: 9%; }
+  .frontend-edge.hooks-backend { left: 51%; top: 142px; height: 90px; }
+  .frontend-edge.screens-hooks { left: 62%; top: 268px; width: 8%; }
+  .frontend-edge.journeys-screens { left: 81%; top: 142px; height: 90px; }
+
+  /* Cards */
+  .cards { display: flex; gap: 22px; margin-top: 20px; }
+  .card {
+    flex: 1;
+    background: #f3f6fb;
+    border-top: 7px solid #4a76b8;
+    border-radius: 10px;
+    padding: 22px 24px;
+    font-size: 30px;
+    line-height: 1.5;
+  }
+  .card b { display: block; font-size: 40px; color: #14284b; margin-bottom: 8px; }
+  .card .note { font-size: 28px; }
+  .card.warm { border-top-color: #f08a24; }
+  .card.warm b { color: #b35c00; }
+
+  /* Review checklist */
+  section.review-checklist table {
+    display: table;
+    width: 100%;
+    max-width: none;
+    margin-right: 0;
+    margin-left: 0;
+    table-layout: fixed;
+    border-collapse: separate;
+    border-spacing: 0 10px;
+    font-size: 29px;
+  }
+  section.review-checklist th,
+  section.review-checklist td {
+    box-sizing: border-box;
+    padding: 14px 20px;
+    border: 0;
+    white-space: nowrap;
+  }
+  section.review-checklist th:first-child,
+  section.review-checklist td:first-child { width: 33.333%; }
+  section.review-checklist th:nth-child(2),
+  section.review-checklist td:nth-child(2) { width: 33.333%; }
+  section.review-checklist th:nth-child(3),
+  section.review-checklist td:nth-child(3) { width: 33.334%; }
+  section.review-checklist th {
+    background: #14284b;
+    color: #ffffff;
+    font-weight: 700;
+  }
+  section.review-checklist th:first-child { border-radius: 10px 0 0 10px; }
+  section.review-checklist th:last-child { border-radius: 0 10px 10px 0; }
+  section.review-checklist td {
+    color: #14161a;
+    font-weight: 400;
+  }
+  section.review-checklist td:first-child {
+    border-radius: 10px 0 0 10px;
+  }
+  section.review-checklist td:last-child {
+    border-radius: 0 10px 10px 0;
+  }
+  section.review-checklist td:first-child { background: #eef2f7; }
+  section.review-checklist td:nth-child(2) { background: #dce8f6; }
+  section.review-checklist td:nth-child(3) { background: #c5d9f0; }
+  .problem-measures { display: flex; flex-direction: column; gap: 12px; width: 94%; margin: 12px auto 0; }
+  .problem-measure-title { margin-bottom: 8px; font-size: 32px; font-weight: 700; }
+  .problem-bar {
+    display: flex;
+    width: 100%;
+    height: 70px;
+    overflow: hidden;
+    background: #e2e7ef;
+    border-radius: 14px;
+  }
+  .problem-bar div { display: flex; align-items: center; justify-content: center; font-weight: 800; }
+  .problem-coverage { width: 51.6%; background: #4a76b8; color: #ffffff; font-size: 38px; }
+  .problem-build { width: 10%; background: #14284b; color: #ffffff; font-size: 28px; }
+  .problem-review { width: 90%; background: #9bb4d2; color: #14284b; font-size: 38px; }
+  .problem-legend { display: flex; justify-content: center; gap: 54px; margin-top: 6px; font-size: 28px; }
+  .problem-legend i { display: inline-block; width: 20px; height: 20px; margin-right: 8px; border-radius: 4px; }
+  .problem-legend .build { background: #14284b; }
+  .problem-legend .review { background: #9bb4d2; }
+  .problem-context { margin-top: 16px; color: #5b6674; font-size: 28px; text-align: center; }
+
+  /* Bars */
+  .track {
+    display: inline-block; width: 240px; height: 20px;
+    background: #e6eaf0; border-radius: 10px; overflow: hidden;
+    vertical-align: middle; margin-left: 14px;
+  }
+  .track i { display: block; height: 100%; background: #4a76b8; }
+  .track.on i { background: #f08a24; }
+  .track i.w855 { width: 85.5%; }
+  .track i.w803 { width: 80.3%; }
+  .track i.w631 { width: 63.1%; }
+  .track i.w516 { width: 51.6%; }
+  .track i.w100 { width: 100%; }
+
+  /* Development and review split bars */
+  .split {
+    display: inline-flex; width: 210px; height: 20px;
+    border-radius: 10px; overflow: hidden;
+    vertical-align: middle; margin-right: 12px;
+  }
+  .split i { display: block; height: 100%; background: #14284b; }
+  .split i.rev { flex: 1; background: #c3d3ea; }
+  .split.on i { background: #b35c00; }
+  .split.on i.rev { background: #ffd6a5; }
+  .d97 { width: 9.7%; }
+  .d54 { width: 5.4%; }
+  .d47 { width: 4.7%; }
+  .d105 { width: 10.5%; }
+  .d720 { width: 72%; }
+  .d808 { width: 80.8%; }
+  .d586 { width: 58.6%; }
+  .d846 { width: 84.6%; }
+
+  /* Token bars by subject */
+  .rows { margin-top: 26px; }
+  .row { display: flex; align-items: center; margin-bottom: 20px; }
+  .row .lbl { width: 150px; font-size: 30px; }
+  .row .bars { flex: 1; }
+  .row .bars i { display: block; height: 18px; border-radius: 9px; margin: 4px 0; }
+  .row .bars i.p { background: #4a76b8; }
+  .row .bars i.e { background: #f08a24; }
+  .row .val { width: 230px; text-align: right; font-size: 28px; color: #5b6674; }
+  .b159 { width: 15.9%; }
+  .b17 { width: 1.7%; }
+  .b216 { width: 21.6%; }
+  .b45 { width: 4.5%; }
+  .b278 { width: 27.8%; }
+  .b50 { width: 5%; }
+  .b1000 { width: 100%; }
+  .b75 { width: 7.5%; }
+  .kp { color: #4a76b8; font-weight: 700; }
+  .ke { color: #b35c00; font-weight: 700; }
+
+  /* Meme slides */
+  section.meme {
+    padding: 24px;
+    text-align: center;
+  }
+  section.meme p { margin: 0; }
+  section.meme img {
+    display: block;
+    box-sizing: border-box;
+    width: 672px;
+    height: 672px;
+    margin: 0 auto;
+    border: 2px solid #e6eaf0;
+    border-radius: 12px;
+  }
+---
+
+<!-- _class: dark -->
+<!-- _paginate: false -->
+
+# Evidence Graph
+
+## 컴파일 에러로 강제하는 100% 명세 커버리지
+
+<span class="note">https://github.com/samchon/ttsc/tree/master/packages/evidence</span>
+
+---
+
+# TL;DR
+
+<div class="tldr-layout">
+<div class="opening-summary">
+
+- **컴파일러 하네스, Evidence Graph**
+  - Loop Until Dry 불필요
+  - `@evidence <target> <reason>`
+  - `@evidenceReview <target> <reason>`
+  - `@evidenceExclude <target> <reason>`
+- **Spec Driven Development**
+  - 사람은 요구사항만 쓰고 검토한다
+  - 나머지는 AI가 100% 커버리지로 만든다
+  - 프로그래밍뿐 아니라 강의 자료에도 적용된다
+
+</div>
+<div class="benchmark-graphs">
+<div class="opening-measure">
+<div class="opening-measure-title">요구사항 커버리지</div>
+<div class="opening-bar-row"><span>Plain</span><div class="opening-bar"><i class="coverage-plain"></i></div><strong>51.6%</strong></div>
+<div class="opening-bar-row evidence"><span>Evidence</span><div class="opening-bar"><i class="coverage-evidence"></i></div><strong>100%</strong></div>
+</div>
+<div class="opening-measure">
+<div class="opening-measure-title">토큰 사용량</div>
+<div class="opening-bar-row"><span>Plain</span><div class="opening-bar"><i class="token-plain"></i></div><strong>5,449M</strong></div>
+<div class="opening-bar-row evidence"><span>Evidence</span><div class="opening-bar"><i class="token-evidence"></i></div><strong>411M</strong></div>
+</div>
+<div class="benchmark-context">테이블 100개 이상 · 15만 줄 이상</div>
+</div>
+</div>
+
+---
+
+<!-- _class: meme -->
+
+![명세를 다 지켰냐는 물음에, 사람은 설명하고 컴파일러는 빌드를 멈춘다](https://ttsc.dev/evidence/meme-coverage-kr.svg)
+
+---
+
+<!-- _class: meme -->
+
+![규칙 문서를 다 읽었냐는 물음에, 사람은 다시 읽어주고 컴파일러는 파일마다 따로 묻는다](https://ttsc.dev/evidence/meme-checklist-kr.svg)
+
+---
+
+<!-- _class: divider -->
+
+# 현재의 한계
+
+<span class="note">Loop Until Dry</span>
+
+---
+
+<!-- _class: loop-slide -->
+
+# Loop Until Dry는 전체 검토를 다시 시작한다
+
+- 처음부터 전부 다시 읽는다
+- 발견한 문제를 전부 고친다
+- 다시 처음으로 돌아간다
+- 지적이 하나도 없는 회차에서야 멈춘다
+
+---
+
+# ERP Plain: 검토 90% · 커버리지 51.6%
+
+<div class="problem-measures">
+<div>
+<div class="problem-measure-title">요구사항 커버리지</div>
+<div class="problem-bar"><div class="problem-coverage">51.6%</div></div>
+</div>
+<div>
+<div class="problem-measure-title">시간 분포</div>
+<div class="problem-bar"><div class="problem-build">10%</div><div class="problem-review">90%</div></div>
+<div class="problem-legend"><span><i class="build"></i>최초 개발</span><span><i class="review"></i>검토 루프</span></div>
+</div>
+</div>
+
+<div class="problem-context">ERP · 테이블 100개 이상 · 15만 줄 이상</div>
+
+---
+
+<!-- _class: divider -->
+
+# Evidence Graph
+
+<span class="note">명세 커버리지 누락이 컴파일 에러가 된다</span>
+
+---
+
+<!-- _class: architecture-slide -->
+
+# 먼저 산출물을 계층으로 나눈다
+
+<div class="document-graph">
+<div class="architecture-node document-node idea">아이디어 노트</div>
+<div class="architecture-foundations document-foundations">
+<div class="architecture-node">요구사항</div>
+<div class="architecture-edge vertical arrow-up specifications-requirements"></div>
+<div class="architecture-node">설계 명세</div>
+</div>
+<div class="architecture-node document-node implementation">구현</div>
+<div class="architecture-node document-node test">테스트</div>
+<div class="architecture-edge horizontal arrow-left document-edge requirements-idea"></div>
+<div class="architecture-edge horizontal arrow-left document-edge implementation-foundations"></div>
+<div class="architecture-edge vertical arrow-up document-edge test-implementation"></div>
+<div class="architecture-edge horizontal arrow-left document-edge test-foundations"></div>
+</div>
+
+<p class="architecture-caption">각 화살표는 자신이 인용하는 근거를 가리킨다.</p>
+
+---
+
+# 관계는 규칙 하나로 선언한다
+
+```ts
+type: "typescript",
+files: ["src/components/**/*.tsx"], // sources
+symbol: "function",
+reference: {
+  type: "markdown",
+  files: ["docs/**/*.md"], // targets
+  symbol: ["h2", "h3"],
+},
+```
+
+**컴포넌트는 문서를 구현한다.**
+
+---
+
+# 하나의 문법이 네 가지 산출물을 다룬다
+
+- **Markdown**: 파일, H1-H4 섹션
+- **Prisma**: 데이터베이스 모델, 컬럼, 관계
+- **TypeScript**: 타입, 함수, 프로퍼티
+- **Swagger**: `paths` 아래의 각 오퍼레이션
+
+---
+
+# 코드가 명세를 인용한다
+
+```tsx
+/**
+ * @evidence docs/discount.md#coupon-stacking
+ *           Explains the stacking limit defined by this section.
+ * @evidence POST:/orders/{orderId}/coupons
+ *           Explains the rejection response from this endpoint.
+ */
+export function CouponStackingNotice(props: IProps): JSX.Element;
+```
+
+**`@evidence <target> <reason>`**: 이 코드가 무엇을 구현하며, 왜 그런지.
+
+---
+
+# 인용이 없으면 빌드가 멈춘다
+
+```bash
+$ npx ttsc
+error TS16411: [evidence/graph]
+  Missing acknowledgement for 'docs/discount.md#coupon-stacking'
+  (Markdown H2 'Coupon Stacking' at docs/discount.md:3)
+```
+
+- 요구사항 하나당 에러 하나 → **에러 목록이 곧 작업 목록**
+- 타입 에러와 같은 빌드에서 함께 검사된다
+
+---
+
+# 100% 커버리지에도 거짓 인용이 섞인다
+
+```ts
+/**
+ * @evidence docs/discount.md#coupon-stacking
+ *           Explains the per-issuer limit.
+ */
+export function CouponStackingNotice(props: IProps): JSX.Element;
+```
+
+- 저렴한 모델은 **존재하지 않는 사실을 적기도 한다**
+- 거짓 태그는 에러만 지울 뿐, **문제는 남긴다**
+
+---
+
+# 검토 대상은 인용의 진위뿐
+
+```ts
+/**
+ * @evidence docs/discount.md#coupon-stacking Explains the per-issuer limit.
+ * @evidenceReview docs/discount.md#coupon-stacking #a1b2c3d4e5f6
+ *                 Verified against policy section 3.
+ */
+export function CouponStackingNotice(props: IProps): JSX.Element;
+```
+
+- 검토는 **같은 선언과 같은 대상**끼리 대응한다
+- 인용한 내용이 바뀌면 지문이 만료된다
+
+<span class="note">Luna조차 한 번의 검토로 거짓 인용을 0으로 줄였다.</span>
+
+---
+
+<!-- _class: review-checklist -->
+
+# 태그 목록이 곧 검토 체크리스트
+
+| 검토 | Plain          | Evidence        |
+| ---- | -------------- | --------------- |
+| 대상 | 전부           | 인용의 진위     |
+| 루프 | 매 회차 재시작 | 태그 목록만     |
+| 누락 | 직접 찾는다    | 컴파일러가 보고 |
+
+> **누락은 컴파일러가, 거짓은 사람이 잡는다.**
+
+---
+
+<!-- _class: divider -->
+
+# Spec Driven Development
+
+<span class="note">요구사항이 인계 지점이다.<br/>그 아래는 AI가 100% 커버리지로 전부 만든다.</span>
+
+---
+
+<!-- _class: architecture-slide -->
+
+# 방법 A는 요구사항에서 시작한다
+
+<div class="document-graph requirements-only">
+<div class="architecture-foundations document-foundations">
+<div class="architecture-node">요구사항</div>
+<div class="architecture-edge vertical arrow-up specifications-requirements"></div>
+<div class="architecture-node">설계 명세</div>
+</div>
+<div class="architecture-node document-node implementation">구현</div>
+<div class="architecture-node document-node test">테스트</div>
+<div class="architecture-edge horizontal arrow-left document-edge implementation-foundations"></div>
+<div class="architecture-edge vertical arrow-up document-edge test-implementation"></div>
+<div class="architecture-edge horizontal arrow-left document-edge test-foundations"></div>
+</div>
+
+<p class="architecture-caption">요구사항이 원천 계층이다.</p>
+
+---
+
+# 방법 A: 요구사항은 사람이 쓴다
+
+- 사람은 **`docs/requirements`를 직접 검토**한다
+- 설계 명세, 구현, 테스트는 **전부 위임한다**
+
+> 벤치마크의 네 과제도 이 방법을 쓴다.
+
+---
+
+<!-- _class: architecture-slide -->
+
+# 방법 B는 아이디어 노트에서 시작한다
+
+<div class="document-graph">
+<div class="architecture-node document-node idea">아이디어 노트</div>
+<div class="architecture-foundations document-foundations">
+<div class="architecture-node">요구사항</div>
+<div class="architecture-edge vertical arrow-up specifications-requirements"></div>
+<div class="architecture-node">설계 명세</div>
+</div>
+<div class="architecture-node document-node implementation">구현</div>
+<div class="architecture-node document-node test">테스트</div>
+<div class="architecture-edge horizontal arrow-left document-edge requirements-idea"></div>
+<div class="architecture-edge horizontal arrow-left document-edge implementation-foundations"></div>
+<div class="architecture-edge vertical arrow-up document-edge test-implementation"></div>
+<div class="architecture-edge horizontal arrow-left document-edge test-foundations"></div>
+</div>
+
+<p class="architecture-caption">아이디어 노트가 원천 계층이다.</p>
+
+---
+
+# 방법 B: 요구사항까지 위임한다
+
+- 아이디어 노트를 **정리하지 않고 그대로 넘긴다**
+- 요구사항 작성부터 **전부 위임한다**
+- 아이디어 노트가 하나라도 누락되면 **즉시 빌드가 깨진다**
+
+> 사람은 원천 계층 하나만 준다.<br/>그 아래는 그래프가 지킨다.
+
+---
+
+# 요구사항도 자신의 근거를 인용한다
+
+```md
+## Coupon stacking limit {#coupon-stacking}
+
+<!-- @evidence docs/ideas/discount.md#discount-policy
+     Carries over the per-issuer limit recorded in the idea notes. -->
+```
+
+- 아이디어 노트 커버리지가 비면 **요구사항 빌드가 깨진다**
+- 아이디어 노트, 인터뷰, 사내 문서가 한 계층을 이룬다
+- 인용은 주석이라 **렌더링된 문서는 깨끗하다**
+
+---
+
+<!-- _class: architecture-slide -->
+
+# 백엔드는 이렇게 동작한다
+
+<div class="backend-graph">
+<div class="architecture-foundations">
+<div class="architecture-node">요구사항</div>
+<div class="architecture-edge vertical arrow-up specifications-requirements"></div>
+<div class="architecture-node">설계 명세</div>
+</div>
+<div class="architecture-node backend-node database">DB 스키마</div>
+<div class="architecture-node backend-node operation">API 오퍼레이션</div>
+<div class="architecture-node backend-node schema">API 스키마</div>
+<div class="architecture-node backend-node test">테스트</div>
+<div class="architecture-edge horizontal arrow-left backend-edge database-foundations"></div>
+<div class="architecture-edge horizontal arrow-left backend-edge operation-foundations"></div>
+<div class="architecture-edge vertical arrow-up backend-edge operation-database"></div>
+<div class="architecture-edge horizontal arrow-left backend-edge schema-database"></div>
+<div class="architecture-edge horizontal arrow-left backend-edge test-operation"></div>
+<div class="architecture-edge vertical outer-top-source"></div>
+<div class="architecture-edge horizontal outer-top-horizontal"></div>
+<div class="architecture-edge vertical arrow-down outer-top-target"></div>
+<div class="architecture-edge vertical outer-bottom-source"></div>
+<div class="architecture-edge horizontal outer-bottom-horizontal"></div>
+<div class="architecture-edge vertical arrow-up outer-bottom-target"></div>
+</div>
+
+<p class="architecture-caption">백엔드 산출물은 요구사항과 설계 명세로 거슬러 올라간다.</p>
+
+---
+
+<!-- _class: architecture-slide -->
+
+# 프론트엔드는 이렇게 동작한다
+
+<div class="frontend-graph">
+<div class="architecture-foundations">
+<div class="architecture-node">요구사항</div>
+<div class="architecture-edge vertical arrow-up specifications-requirements"></div>
+<div class="architecture-node">설계 명세</div>
+</div>
+<div class="architecture-node frontend-node backend">백엔드</div>
+<div class="architecture-node frontend-node hooks">Hooks</div>
+<div class="architecture-node frontend-node screens">화면</div>
+<div class="architecture-node frontend-node journeys">사용자 여정</div>
+<div class="architecture-edge horizontal arrow-left frontend-edge backend-foundations"></div>
+<div class="architecture-edge vertical arrow-up frontend-edge hooks-backend"></div>
+<div class="architecture-edge horizontal arrow-left frontend-edge screens-hooks"></div>
+<div class="architecture-edge vertical arrow-down frontend-edge journeys-screens"></div>
+<div class="architecture-edge vertical outer-top-source"></div>
+<div class="architecture-edge horizontal outer-top-horizontal"></div>
+<div class="architecture-edge vertical arrow-down outer-top-target"></div>
+<div class="architecture-edge vertical outer-bottom-source"></div>
+<div class="architecture-edge horizontal outer-bottom-horizontal"></div>
+<div class="architecture-edge vertical arrow-up outer-bottom-target"></div>
+</div>
+
+<p class="architecture-caption">프론트엔드 산출물은 문서와 백엔드로 거슬러 올라간다.</p>
+
+---
+
+<!-- _class: divider -->
+
+# 벤치마크
+
+<span class="note">동일한 입력 · 엔진 · 모델 · 플러그인만 차이</span>
+
+---
+
+# 커버리지: 51.6–85.5% → 100%
+
+| 과제 | Plain | Evidence |
+| --- | --- | --- |
+| todo | 85.5% <span class="track"><i class="w855"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| reddit | 80.3% <span class="track"><i class="w803"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| shopping | 63.1% <span class="track"><i class="w631"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| erp | 51.6% <span class="track"><i class="w516"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+
+Plain은 규모가 커질수록 커버리지가 떨어진다. **Evidence는 100%를 유지한다.**
+
+---
+
+# 토큰 사용량: 4.8–13.3배 절감
+
+<div class="rows">
+<div class="row"><span class="lbl">todo</span><span class="bars"><i class="p b159"></i><i class="e b17"></i></span><span class="val">866M → 92M</span></div>
+<div class="row"><span class="lbl">reddit</span><span class="bars"><i class="p b216"></i><i class="e b45"></i></span><span class="val">1,179M → 245M</span></div>
+<div class="row"><span class="lbl">shopping</span><span class="bars"><i class="p b278"></i><i class="e b50"></i></span><span class="val">1,516M → 271M</span></div>
+<div class="row"><span class="lbl">erp</span><span class="bars"><i class="p b1000"></i><i class="e b75"></i></span><span class="val">5,449M → 411M</span></div>
+</div>
+
+<span class="kp">Plain</span>은 파랑, <span class="ke">Evidence</span>는 주황.
+
+<span class="note">단계별 원본 차트: [https://ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)</span>
+
+---
+
+# ERP: 커버리지 100% · $4.96 · 14시간
+
+<div class="cards">
+<div class="card"><b>13.3×</b>토큰 절감<br/><span class="note">5,449M → 411M</span></div>
+<div class="card"><b>13.9×</b>비용 절감<br/><span class="note">$68.72 → $4.96</span></div>
+<div class="card warm"><b>7.5×</b>시간 단축<br/><span class="note">102h → 14h</span></div>
+</div>
+
+---
+
+# 검토 비중: 토큰의 90–95% → 15–41%
+
+| 과제 | Plain | Evidence |
+| --- | --- | --- |
+| todo | <span class="split"><i class="d97"></i><i class="rev"></i></span> 검토 90% | <span class="split on"><i class="d720"></i><i class="rev"></i></span> 검토 28% |
+| reddit | <span class="split"><i class="d54"></i><i class="rev"></i></span> 검토 95% | <span class="split on"><i class="d808"></i><i class="rev"></i></span> 검토 19% |
+| shopping | <span class="split"><i class="d47"></i><i class="rev"></i></span> 검토 95% | <span class="split on"><i class="d586"></i><i class="rev"></i></span> 검토 41% |
+| erp | <span class="split"><i class="d105"></i><i class="rev"></i></span> 검토 90% | <span class="split on"><i class="d846"></i><i class="rev"></i></span> 검토 15% |
+
+<span class="note">진한 색은 개발, 옅은 색은 검토. 각 칸이 그 과제 토큰의 100%다.</span>
+
+---
+
+<!-- _class: dark -->
+
+# 요약
+
+- 명세 커버리지 누락은 **컴파일 에러**가 된다
+- 요구사항이 **인계 지점**이다
+- 커버리지가 **51.6–85.5%에서 100%로** 오른다
+- 사람의 검토는 **인용의 진위**를 본다
+
+---
+
+<!-- _class: divider -->
+
+# 부록: 소설
+
+<span class="note">원칙과 설정이 빌드 제약이 된다</span>
+
+---
+
+# 매끄러운 장면도 거짓일 수 있다
+
+- **기억**: 인물이 알 리 없는 사실을 쓴다
+- **창작**: 역사, 지리, 동기를 어긴다
+- **개고**: 앞선 수정으로 무효가 된 장면을 남긴다
+
+> 장편의 실패는 국소적이지 않고 전역적이다.
+
+---
+
+# 모든 계층이 앞선 원천을 전부 인용한다
+
+<div class="narrative-graph">
+<div class="narrative-group">
+<div class="narrative-node principles">원칙</div>
+<div class="narrative-edge settings-principles"></div>
+<div class="narrative-node settings">설정</div>
+</div>
+<div class="narrative-node scenarios">시나리오</div>
+<div class="narrative-node storylines">스토리라인</div>
+<div class="narrative-node manuscripts">원고</div>
+<div class="narrative-edge to-foundations scenarios-foundations"></div>
+<div class="narrative-edge to-foundations storylines-foundations"></div>
+<div class="narrative-edge storylines-scenarios"></div>
+<div class="narrative-edge manuscripts-foundations"></div>
+<div class="narrative-edge manuscripts-up"></div>
+<div class="narrative-edge manuscripts-storylines"></div>
+<div class="narrative-edge manuscripts-scenarios"></div>
+</div>
+
+---
+
+# 간선마다 막는 이탈이 다르다
+
+- 스토리라인, 시나리오, 원고 → 원칙: 문학적 목적
+- 스토리라인, 시나리오, 원고 → 설정: 사실, 규칙, 지식
+- 시나리오, 원고 → 스토리라인: 원인과 결과
+- 원고 → 시나리오: 정확한 실행
+
+---
+
+# 왜 통하는가
+
+- 제한된 컨텍스트 → 이 장면이 질 정확한 의무
+- 그럴듯한 창작 → 명시적 계보와 검토
+- 개고로 인한 이탈 → 영향받은 검토가 만료
+- 잊힌 복선 → 100% 역방향 커버리지
+
+**엄격한 연속성 안에서 누리는 창작의 자유.**
+
+---
+
+# 하나의 그래프로 모든 서사를
+
+- **설정**: 역사, 세계 규칙, 인물
+- **인과**: 복선, 동기, 결과
+- **연속성**: 지식, 서사 궤적, 개고
+- 역사 소설, 판타지, SF, 미스터리, 드라마
+- **나폴레옹**: 원칙 25개, 설정 약속 350개, 장면 742개
+
+---
+
+<!-- _class: dark -->
+<!-- _paginate: false -->
+
+# 참고 자료
+
+- https://github.com/samchon/ttsc
+  - https://ttsc.dev/docs/evidence
+  - https://ttsc.dev/docs/benchmark/evidence
+- https://github.com/samchon/evidence-benchmark-results
+- https://github.com/samchon/novels
+
+---
+
+<!-- _class: divider -->
+<!-- _paginate: false -->
+
+# Q & A
+
+<span class="note">Samchon<br/>https://ttsc.dev</span>

--- a/website/test/slides.test.cjs
+++ b/website/test/slides.test.cjs
@@ -3,20 +3,37 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { test } = require("node:test");
 
-const { readSlides } = require("../build/slides-metadata.cjs");
+const {
+  FRONTMATTER_PATTERN,
+  SLIDES_DIR,
+  SLIDE_LOCALE_CODES,
+  parseSlideLocale,
+  readListedSlides,
+  readSlides,
+} = require("../build/slides-metadata.cjs");
+
+const REQUIRED_SLUGS = ["evidence", "evidence-kr", "graph"];
+const KOREAN_LOCALES = ["ko", "kr"];
+const HANGUL_PATTERN = /[가-힣]/;
 
 /**
  * Verifies website export: every declared slide has one navigable deck and one
- * social card.
+ * social card, while a locale-suffixed deck stays reachable but unlisted.
  *
  * The list page, dynamic route, and Marp output read the same frontmatter, so
  * this assertion checks the exported consequence rather than trusting three
- * source-only integrations that could drift independently.
+ * source-only integrations that could drift independently. The listing alone
+ * reads `readListedSlides`, so a filter that leaked into `readSlides` would
+ * delete `/slides/evidence-kr` instead of merely hiding its card; only the
+ * exported HTML tells those two outcomes apart.
  *
- * 1. Read every source deck and the exported slides index.
- * 2. Assert each card links to a generated Marp presentation with its own image.
- * 3. Assert each route exports the deck-specific title, summary, and Open Graph
- *    image.
+ * 1. Read every source deck, the locale rule, and the exported slides index.
+ * 2. Assert the deck set mirrors the source directory and that the listing
+ *    accessor drops exactly the locale-suffixed decks.
+ * 3. Assert each deck exports its own Marp presentation plus a route carrying its
+ *    title, summary, and Open Graph image.
+ * 4. Assert the index cards cover the default decks only, and that a Korean deck
+ *    is written in Korean while a default deck never drifts into it.
  */
 test("static slide routes publish their decks and social metadata", () => {
   const websiteRoot = path.resolve(__dirname, "..");
@@ -26,13 +43,45 @@ test("static slide routes publish their decks and social metadata", () => {
     "utf8",
   );
   const slides = readSlides();
+  const sourceSlugs = fs
+    .readdirSync(SLIDES_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => entry.name.replace(/\.md$/, ""))
+    .sort();
 
-  assert.deepEqual(slides.map((slide) => slide.slug).sort(), [
-    "evidence",
-    "graph",
-  ]);
+  assert.deepEqual(slides.map((slide) => slide.slug).sort(), sourceSlugs);
+  for (const slug of REQUIRED_SLUGS)
+    assert.ok(sourceSlugs.includes(slug), `${slug}.md must stay published`);
+
+  assert.deepEqual(parseSlideLocale("evidence-kr"), {
+    base: "evidence",
+    locale: "kr",
+  });
+  assert.deepEqual(parseSlideLocale("evidence"), {
+    base: "evidence",
+    locale: null,
+  });
+  assert.ok(
+    !SLIDE_LOCALE_CODES.includes("ab"),
+    "the negative twin below needs an unrecognized two-letter suffix",
+  );
+  assert.deepEqual(parseSlideLocale("graph-ab"), {
+    base: "graph-ab",
+    locale: null,
+  });
+
+  assert.deepEqual(
+    readListedSlides()
+      .map((slide) => slide.slug)
+      .sort(),
+    sourceSlugs.filter(
+      (slug) => !SLIDE_LOCALE_CODES.some((code) => slug.endsWith(`-${code}`)),
+    ),
+  );
+
   for (const slide of slides) {
     const source = fs.readFileSync(slide.file, "utf8");
+    const body = source.replace(FRONTMATTER_PATTERN, "");
     const deckHtml = fs.readFileSync(
       path.join(outputRoot, "slides-static", slide.slug, "index.html"),
       "utf8",
@@ -41,20 +90,45 @@ test("static slide routes publish their decks and social metadata", () => {
       path.join(outputRoot, "slides", slide.slug, "index.html"),
       "utf8",
     );
+    const cardLink = new RegExp(`href="${slide.route}/?"`);
 
-    assert.match(indexHtml, new RegExp(`href="${slide.route}/?"`));
-    assert.ok(indexHtml.includes(slide.description));
-    assert.ok(indexHtml.includes(new URL(slide.image).pathname));
     assert.match(deckHtml, /data-bespoke-marp/);
     assert.ok(deckHtml.includes(slide.title));
     assert.ok(routeHtml.includes(slide.staticRoute));
+    assert.ok(routeHtml.includes(slide.title));
     assert.ok(routeHtml.includes(slide.description));
     assert.ok(routeHtml.includes(slide.image));
-    if (slide.slug === "evidence")
+
+    if (slide.locale === null) {
+      assert.match(indexHtml, cardLink);
+      assert.ok(indexHtml.includes(slide.description));
+      assert.ok(indexHtml.includes(new URL(slide.image).pathname));
       assert.doesNotMatch(
         source,
-        /[가-힣]/,
-        "evidence.md must stay in English",
+        HANGUL_PATTERN,
+        `${slide.slug}.md must stay in English`,
+      );
+      continue;
+    }
+
+    assert.doesNotMatch(
+      indexHtml,
+      cardLink,
+      `${slide.slug} is a translation and must not be listed`,
+    );
+    assert.ok(
+      !indexHtml.includes(slide.title),
+      `${slide.slug} must not surface its title on the index`,
+    );
+    assert.ok(
+      !indexHtml.includes(slide.description),
+      `${slide.slug} must not surface its summary on the index`,
+    );
+    if (KOREAN_LOCALES.includes(slide.locale))
+      assert.match(
+        body,
+        HANGUL_PATTERN,
+        `${slide.slug}.md must be translated into Korean, not only retitled`,
       );
   }
 });


### PR DESCRIPTION
## Intent

Publish the Korean translation of the Evidence Graph deck at `/slides/evidence-kr`, and keep translations off the `/slides` index so a deck and its translation do not compete for the same row.

## Scope

**Locale filtering.** `readSlides` derives `{base, locale}` from the slug against an explicit locale-code set (`cn de en es fr ja jp ko kr pt ru tw vi zh`), deliberately omitting ISO codes that are also English words (`it no is id be he as to`) so a legitimate slug ending in two letters is never swallowed. The new `readListedSlides` filters to `locale === null` and only the listing page reads it — the Marp build, `generateStaticParams`, the route, and `generateMetadata` still read every deck.

**Korean deck.** `evidence-kr.md` mirrors `evidence.md` slide for slide, sharing its `style` block and code fences byte for byte. Two Korean-only meme slides follow the TL;DR, drawn as original SVG under `public/evidence/`.

**Test.** The hardcoded slug list is gone; `readSlides` is compared against the source directory, with a required-slug floor so a deck cannot silently vanish. The listing expectation is recomputed independently rather than compared against itself. `evidence.md` must stay free of Hangul and a `ko`/`kr` deck must contain it.

## Verification

- `node build/slides.cjs` — 3 decks, `evidence-kr` at 38 slides
- `node --test test/slides.test.cjs` — pass 1 / fail 0
- `pnpm run build` — exit 0, postbuild `test:slides` green, pagefind + next-sitemap complete
- Mutation checks: reverting `page.jsx` to `getSlides()` fails with *must not be listed*; moving the filter into `readSlides()` fails on the slug set
- Export inspected directly — `out/slides/index.html` links only `/slides/evidence/` and `/slides/graph/` and contains no `evidence-kr`, while `out/slides/evidence-kr/index.html` carries its own title, canonical, and OG image
- `npx prettier --check` on every changed source file

## Deferred

- Sitemap and pagefind still index `evidence-kr`, deliberately: the request was to drop the index card, not to make a shareable page undiscoverable.
- The meme SVG generator is not in the repository, so the assets currently have no checked-in source.
- The checklist meme names the `checklist: true` reference option, which the deck itself never introduces.
- `website/README.md` still omits `src/slides` and `src/app/slides` (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
