### PR TITLE
docs(website): back the evidence deck with 2026 research and lead with the benchmark

### DIFF
--- a/website/public/evidence/meme-checklist.svg
+++ b/website/public/evidence/meme-checklist.svg
@@ -1,0 +1,122 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="1080" viewBox="0 0 1080 1080">
+  <rect width="1080" height="1080" fill="#ffffff"/>
+
+  <g>
+    <text x="40" y="84" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="56"
+          font-weight="bold" fill="#E5322B">Bad answer</text>
+    <text x="556" y="128" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#E5322B">- Repeated once per file</text><text x="556" y="200" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#E5322B">- Boring, and it sounds like nagging</text><text x="556" y="272" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#E5322B">- Stay quiet and nobody notices</text><text x="556" y="344" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#E5322B">- 100% chance of an argument</text><text x="556" y="416" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#E5322B">- Lose it and the rule is gone</text>
+
+  <g>
+    <rect x="34" y="104" width="262" height="140" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 96 244 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 100 241 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="25" fill="#111111"
+          text-anchor="middle"><tspan x="165" y="164">Followed every rule</tspan><tspan x="165" y="201">(docs unread)</tspan></text>
+  </g>
+
+  <g>
+    <rect x="316" y="126" width="212" height="124" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 386 250 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 390 247 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="27" fill="#111111"
+          text-anchor="middle"><tspan x="422" y="177.68">*re-reading</tspan><tspan x="422" y="216.68">the rules*</tspan></text>
+  </g>
+
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="150" y1="334" x2="150" y2="312"/>
+    <circle cx="150" cy="304" r="8" fill="#111111"/>
+    <rect x="90" y="334" width="120" height="92" rx="16" fill="#fff"/>
+    <circle cx="127" cy="370" r="9" fill="#111111" stroke="none"/>
+    <circle cx="173" cy="370" r="9" fill="#111111" stroke="none"/>
+    <path d="M 128 398 q 22 16 44 0"/>
+    <rect x="102" y="432" width="96" height="64" rx="12" fill="#fff"/>
+    <path d="M 102 448 l -32 24"/>
+    <path d="M 198 448 l 32 24"/>
+    <line x1="128" y1="496" x2="128" y2="524"/>
+    <line x1="172" y1="496" x2="172" y2="524"/>
+  </g>
+
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="415" cy="346" r="50" fill="#fff"/>
+    <circle cx="397" cy="336" r="7" fill="#111111" stroke="none"/>
+    <circle cx="433" cy="336" r="7" fill="#111111" stroke="none"/>
+    <path d="M 395 372 q 20 -14 40 0"/>
+    <path d="M 415 396 l 0 74"/>
+    <path d="M 415 412 l -46 -34"/>
+    <path d="M 415 412 l 46 -34"/>
+    <path d="M 415 470 l -30 54"/>
+    <path d="M 415 470 l 30 54"/>
+  </g>
+  </g>
+  <line x1="0" y1="540" x2="1080" y2="540" stroke="#111111" stroke-width="6"/>
+
+  <g>
+    <text x="40" y="632" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="56"
+          font-weight="bold" fill="#1BA34C">Good answer</text>
+    <text x="556" y="676" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#1BA34C">- Over in seconds</text><text x="556" y="748" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#1BA34C">- Asks again at every single file</text><text x="556" y="820" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#1BA34C">- Stay quiet and all of it trips</text><text x="556" y="892" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#1BA34C">- It is a fact (the compiler)</text><text x="556" y="964" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#1BA34C">- Chance of losing tends to zero</text>
+
+  <g>
+    <rect x="34" y="652" width="262" height="140" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 96 792 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 100 789 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="25" fill="#111111"
+          text-anchor="middle"><tspan x="165" y="712">Followed every rule</tspan><tspan x="165" y="749">(docs unread)</tspan></text>
+  </g>
+
+  <g>
+    <rect x="316" y="674" width="212" height="124" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 386 798 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 390 795 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="28" fill="#111111"
+          text-anchor="middle" font-weight="bold"><tspan x="422" y="746.88">Then perish.</tspan></text>
+  </g>
+
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="150" y1="882" x2="150" y2="860"/>
+    <circle cx="150" cy="852" r="8" fill="#111111"/>
+    <rect x="90" y="882" width="120" height="92" rx="16" fill="#fff"/>
+    <circle cx="127" cy="918" r="9" fill="#111111" stroke="none"/>
+    <circle cx="173" cy="918" r="9" fill="#111111" stroke="none"/>
+    <path d="M 128 946 q 22 16 44 0"/>
+    <rect x="102" y="980" width="96" height="64" rx="12" fill="#fff"/>
+    <path d="M 102 996 l -32 24"/>
+    <path d="M 198 996 l 32 24"/>
+    <line x1="128" y1="1044" x2="128" y2="1072"/>
+    <line x1="172" y1="1044" x2="172" y2="1072"/>
+  </g>
+
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="323" y="858" width="184" height="140" rx="14" fill="#fff"/>
+    <line x1="323" y1="896" x2="507" y2="896"/>
+    <circle cx="345" cy="877" r="7" fill="#111111" stroke="none"/>
+    <circle cx="369" cy="877" r="7" fill="#111111" stroke="none"/>
+    <circle cx="393" cy="877" r="7" fill="#111111" stroke="none"/>
+    <text x="349" y="954" font-family="Consolas, monospace" font-size="46"
+          font-weight="bold" fill="#E5322B" stroke="none">&gt; _</text>
+    <path d="M 355 998 l 0 30 l 120 0 l 0 -30"/>
+    <path d="M 319 1028 l 192 0" stroke-width="6"/>
+    <line x1="371" y1="1028" x2="371" y2="1072"/>
+    <line x1="459" y1="1028" x2="459" y2="1072"/>
+  </g>
+  </g>
+  <text x="1046" y="1054" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="25"
+        fill="#8b93a1" text-anchor="end">evidence graph</text>
+</svg>

--- a/website/public/evidence/meme-coverage.svg
+++ b/website/public/evidence/meme-coverage.svg
@@ -1,0 +1,122 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="1080" viewBox="0 0 1080 1080">
+  <rect width="1080" height="1080" fill="#ffffff"/>
+
+  <g>
+    <text x="40" y="84" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="56"
+          font-weight="bold" fill="#E5322B">Bad answer</text>
+    <text x="556" y="128" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#E5322B">- Takes a long time</text><text x="556" y="200" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#E5322B">- Explained from scratch again</text><text x="556" y="272" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#E5322B">- Forgotten when the session ends</text><text x="556" y="344" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#E5322B">- 100% chance of an argument</text><text x="556" y="416" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#E5322B">- Lose it and it ships at 50%</text>
+
+  <g>
+    <rect x="34" y="104" width="262" height="140" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 96 244 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 100 241 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="25" fill="#111111"
+          text-anchor="middle"><tspan x="165" y="164">Looks done to me</tspan><tspan x="165" y="201">(50% complete)</tspan></text>
+  </g>
+
+  <g>
+    <rect x="316" y="126" width="212" height="124" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 386 250 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 390 247 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="27" fill="#111111"
+          text-anchor="middle"><tspan x="422" y="197.18">*explaining*</tspan></text>
+  </g>
+
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="150" y1="334" x2="150" y2="312"/>
+    <circle cx="150" cy="304" r="8" fill="#111111"/>
+    <rect x="90" y="334" width="120" height="92" rx="16" fill="#fff"/>
+    <circle cx="127" cy="370" r="9" fill="#111111" stroke="none"/>
+    <circle cx="173" cy="370" r="9" fill="#111111" stroke="none"/>
+    <path d="M 128 398 q 22 16 44 0"/>
+    <rect x="102" y="432" width="96" height="64" rx="12" fill="#fff"/>
+    <path d="M 102 448 l -32 24"/>
+    <path d="M 198 448 l 32 24"/>
+    <line x1="128" y1="496" x2="128" y2="524"/>
+    <line x1="172" y1="496" x2="172" y2="524"/>
+  </g>
+
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="415" cy="346" r="50" fill="#fff"/>
+    <circle cx="397" cy="336" r="7" fill="#111111" stroke="none"/>
+    <circle cx="433" cy="336" r="7" fill="#111111" stroke="none"/>
+    <path d="M 395 372 q 20 -14 40 0"/>
+    <path d="M 415 396 l 0 74"/>
+    <path d="M 415 412 l -46 -34"/>
+    <path d="M 415 412 l 46 -34"/>
+    <path d="M 415 470 l -30 54"/>
+    <path d="M 415 470 l 30 54"/>
+  </g>
+  </g>
+  <line x1="0" y1="540" x2="1080" y2="540" stroke="#111111" stroke-width="6"/>
+
+  <g>
+    <text x="40" y="632" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="56"
+          font-weight="bold" fill="#1BA34C">Good answer</text>
+    <text x="556" y="676" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#1BA34C">- Over in seconds</text><text x="556" y="748" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#1BA34C">- Remembered for a long time</text><text x="556" y="820" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#1BA34C">- It is a fact (the compiler)</text><text x="556" y="892" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#1BA34C">- Simple, no prior context needed</text><text x="556" y="964" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif"
+               font-size="28" fill="#1BA34C">- Chance of losing tends to zero</text>
+
+  <g>
+    <rect x="34" y="652" width="262" height="140" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 96 792 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 100 789 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="25" fill="#111111"
+          text-anchor="middle"><tspan x="165" y="712">Looks done to me</tspan><tspan x="165" y="749">(50% complete)</tspan></text>
+  </g>
+
+  <g>
+    <rect x="316" y="674" width="212" height="124" rx="20"
+          fill="#fff" stroke="#111111" stroke-width="5"/>
+    <path d="M 386 798 l 12 34 l 30 -34 z"
+          fill="#fff" stroke="#111111" stroke-width="5" stroke-linejoin="round"/>
+    <path d="M 390 795 l 34 0" stroke="#fff" stroke-width="8"/>
+    <text font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="28" fill="#111111"
+          text-anchor="middle" font-weight="bold"><tspan x="422" y="746.88">Then perish.</tspan></text>
+  </g>
+
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="150" y1="882" x2="150" y2="860"/>
+    <circle cx="150" cy="852" r="8" fill="#111111"/>
+    <rect x="90" y="882" width="120" height="92" rx="16" fill="#fff"/>
+    <circle cx="127" cy="918" r="9" fill="#111111" stroke="none"/>
+    <circle cx="173" cy="918" r="9" fill="#111111" stroke="none"/>
+    <path d="M 128 946 q 22 16 44 0"/>
+    <rect x="102" y="980" width="96" height="64" rx="12" fill="#fff"/>
+    <path d="M 102 996 l -32 24"/>
+    <path d="M 198 996 l 32 24"/>
+    <line x1="128" y1="1044" x2="128" y2="1072"/>
+    <line x1="172" y1="1044" x2="172" y2="1072"/>
+  </g>
+
+  <g stroke="#111111" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="323" y="858" width="184" height="140" rx="14" fill="#fff"/>
+    <line x1="323" y1="896" x2="507" y2="896"/>
+    <circle cx="345" cy="877" r="7" fill="#111111" stroke="none"/>
+    <circle cx="369" cy="877" r="7" fill="#111111" stroke="none"/>
+    <circle cx="393" cy="877" r="7" fill="#111111" stroke="none"/>
+    <text x="349" y="954" font-family="Consolas, monospace" font-size="46"
+          font-weight="bold" fill="#E5322B" stroke="none">&gt; _</text>
+    <path d="M 355 998 l 0 30 l 120 0 l 0 -30"/>
+    <path d="M 319 1028 l 192 0" stroke-width="6"/>
+    <line x1="371" y1="1028" x2="371" y2="1072"/>
+    <line x1="459" y1="1028" x2="459" y2="1072"/>
+  </g>
+  </g>
+  <text x="1046" y="1054" font-family="Pretendard, Apple SD Gothic Neo, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="25"
+        fill="#8b93a1" text-anchor="end">evidence graph</text>
+</svg>

--- a/website/src/content/docs/benchmark/evidence.mdx
+++ b/website/src/content/docs/benchmark/evidence.mdx
@@ -46,6 +46,19 @@ Averaging the thirteen rates instead scored one subject 58.4% while 76 of its 55
 
 How much tokens, prices, times have consumed.
 
+## Applications
+
+Every application this cohort produced is published at [`samchon/evidence-benchmark-results`](https://github.com/samchon/evidence-benchmark-results).
+
+Each leaf is the complete source the agent left behind, so the two cells of a row are the same frozen requirements built twice.
+
+| Subject | Plain | Evidence |
+| --- | --- | --- |
+| todo | [`todo/plain`](https://github.com/samchon/evidence-benchmark-results/tree/master/codex/gpt-5.6-luna/todo/plain) | [`todo/evidence`](https://github.com/samchon/evidence-benchmark-results/tree/master/codex/gpt-5.6-luna/todo/evidence) |
+| reddit | [`reddit/plain`](https://github.com/samchon/evidence-benchmark-results/tree/master/codex/gpt-5.6-luna/reddit/plain) | [`reddit/evidence`](https://github.com/samchon/evidence-benchmark-results/tree/master/codex/gpt-5.6-luna/reddit/evidence) |
+| shopping | [`shopping/plain`](https://github.com/samchon/evidence-benchmark-results/tree/master/codex/gpt-5.6-luna/shopping/plain) | [`shopping/evidence`](https://github.com/samchon/evidence-benchmark-results/tree/master/codex/gpt-5.6-luna/shopping/evidence) |
+| erp | [`erp/plain`](https://github.com/samchon/evidence-benchmark-results/tree/master/codex/gpt-5.6-luna/erp/plain) | [`erp/evidence`](https://github.com/samchon/evidence-benchmark-results/tree/master/codex/gpt-5.6-luna/erp/evidence) |
+
 ## Reproduce
 
 Clone the repository and tell Claude Code to run the benchmark following the benchmark skill. That skill is the procedure this cohort was produced under, and it owns setup, launch, supervision, recovery, and publication.

--- a/website/src/slides/evidence-kr.md
+++ b/website/src/slides/evidence-kr.md
@@ -443,7 +443,7 @@ style: |
   section.review-checklist td:first-child { background: #eef2f7; }
   section.review-checklist td:nth-child(2) { background: #dce8f6; }
   section.review-checklist td:nth-child(3) { background: #c5d9f0; }
-  .problem-measures { display: flex; flex-direction: column; gap: 12px; width: 94%; margin: 12px auto 0; }
+  .problem-measures { display: flex; flex-direction: column; gap: 12px; width: 94%; margin: 4px auto 0; }
   .problem-measure-title { margin-bottom: 8px; font-size: 32px; font-weight: 700; }
   .problem-bar {
     display: flex;
@@ -461,7 +461,16 @@ style: |
   .problem-legend i { display: inline-block; width: 20px; height: 20px; margin-right: 8px; border-radius: 4px; }
   .problem-legend .build { background: #14284b; }
   .problem-legend .review { background: #9bb4d2; }
-  .problem-context { margin-top: 16px; color: #5b6674; font-size: 28px; text-align: center; }
+  .problem-spend {
+    display: flex;
+    justify-content: center;
+    gap: 60px;
+    margin-top: 14px;
+    color: #5b6674;
+    font-size: 28px;
+  }
+  .problem-spend b { margin-right: 8px; color: #14284b; font-size: 34px; }
+  .problem-context { margin-top: 10px; color: #5b6674; font-size: 28px; text-align: center; }
 
   /* Bars */
   .track {
@@ -531,6 +540,13 @@ style: |
     border: 2px solid #e6eaf0;
     border-radius: 12px;
   }
+
+  /* Citation code blocks */
+  section.cite-code pre { font-size: 23px; }
+
+  /* Evidence-backed lists */
+  section.stat-list li { font-size: 36px; margin-bottom: 14px; }
+  section.stat-list blockquote { font-size: 30px; }
 ---
 
 <!-- _class: dark -->
@@ -550,7 +566,7 @@ style: |
 <div class="opening-summary">
 
 - **컴파일러 하네스, Evidence Graph**
-  - Loop Until Dry 불필요
+  - Loop Engineering 불필요
   - `@evidence <target> <reason>`
   - `@evidenceReview <target> <reason>`
   - `@evidenceExclude <target> <reason>`
@@ -593,22 +609,50 @@ style: |
 
 # 현재의 한계
 
-<span class="note">Loop Until Dry</span>
+<span class="note">우리가 결국 루프를 돌게 된 이유</span>
+
+---
+
+<!-- _class: stat-list -->
+
+# 알겠다고 답하는 것과 지키는 것은 다르다
+
+- 최상위 모델 6종에 규칙 하나를 줬더니 **아무도** 지키지 않았다
+- **10번 중 10번** 알겠다고 답하고, **10번 중 10번** 건너뛰었다
+- 결과물만 본 사람은 정직한 실행을 **15건 중 0건** 골라냈다
+- <strong>이유를 적게 했더니 97%</strong>가 지켰다
+
+<span class="note">답변이 아니라 도구 실행 로그로 측정했다 ([2605.01771](https://arxiv.org/abs/2605.01771))</span>
+
+---
+
+<!-- _class: stat-list -->
+
+# 오래 돌릴수록 나빠진다
+
+- 목표를 한 번에 안 주고 쪼개 줬더니 **20건 중 16건**이 더 나빴다
+- 장기 작업에서 단계 **14.8%** 완료, **끝낸 프로젝트는 없음**
+- 실행의 <strong>77%</strong>에서 이미 맞던 코드가 나빠졌다
+- 남은 코드는 사람 것보다 **2.3배 길고 2배 지저분하다**
+
+<span class="note">2026년 코딩 에이전트 벤치마크 두 편 ([2603.17104](https://arxiv.org/abs/2603.17104)) ([2603.24755](https://arxiv.org/abs/2603.24755))</span>
 
 ---
 
 <!-- _class: loop-slide -->
 
-# Loop Until Dry는 전체 검토를 다시 시작한다
+# 그래서 Loop Engineering이 나왔다
 
-- 처음부터 전부 다시 읽는다
-- 발견한 문제를 전부 고친다
-- 다시 처음으로 돌아간다
-- 지적이 하나도 없는 회차에서야 멈춘다
+- 다 했다는 말은 증거가 아니다 → **전부 다시 읽는다**
+- 누락은 봐야만 드러난다 → **찾은 문제를 전부 고친다**
+- 하나 고치면 다른 게 깨진다 → **처음으로 되돌아간다**
+- 끝났다고 말해줄 게 없다 → **빈 회차가 나와야 멈춘다**
+
+> Loop Until Dry라고도 한다. 현존 최선의 수단이고, 실제로 작동한다.
 
 ---
 
-# ERP Plain: 검토 90% · 커버리지 51.6%
+# ERP Loop Engineering
 
 <div class="problem-measures">
 <div>
@@ -620,6 +664,11 @@ style: |
 <div class="problem-bar"><div class="problem-build">10%</div><div class="problem-review">90%</div></div>
 <div class="problem-legend"><span><i class="build"></i>최초 개발</span><span><i class="review"></i>검토 루프</span></div>
 </div>
+</div>
+
+<div class="problem-spend">
+<span><b>102시간</b>작업 시간</span>
+<span><b>5,449M</b>토큰</span>
 </div>
 
 <div class="problem-context">ERP · 테이블 100개 이상 · 15만 줄 이상</div>
@@ -665,12 +714,12 @@ files: ["src/components/**/*.tsx"], // sources
 symbol: "function",
 reference: {
   type: "markdown",
-  files: ["docs/**/*.md"], // targets
+  files: ["docs/specifications/*.md"], // targets
   symbol: ["h2", "h3"],
 },
 ```
 
-**컴포넌트는 문서를 구현한다.**
+**컴포넌트는 설계 명세를 구현한다.**
 
 ---
 
@@ -687,7 +736,7 @@ reference: {
 
 ```tsx
 /**
- * @evidence docs/discount.md#coupon-stacking
+ * @evidence docs/specifications/discount.md#coupon-stacking
  *           Explains the stacking limit defined by this section.
  * @evidence POST:/orders/{orderId}/coupons
  *           Explains the rejection response from this endpoint.
@@ -704,8 +753,9 @@ export function CouponStackingNotice(props: IProps): JSX.Element;
 ```bash
 $ npx ttsc
 error TS16411: [evidence/graph]
-  Missing acknowledgement for 'docs/discount.md#coupon-stacking'
-  (Markdown H2 'Coupon Stacking' at docs/discount.md:3)
+  Missing acknowledgement for
+  'docs/specifications/discount.md#coupon-stacking'
+  (Markdown H2 'Coupon Stacking' at docs/specifications/discount.md:3)
 ```
 
 - 요구사항 하나당 에러 하나 → **에러 목록이 곧 작업 목록**
@@ -717,7 +767,7 @@ error TS16411: [evidence/graph]
 
 ```ts
 /**
- * @evidence docs/discount.md#coupon-stacking
+ * @evidence docs/specifications/discount.md#coupon-stacking
  *           Explains the per-issuer limit.
  */
 export function CouponStackingNotice(props: IProps): JSX.Element;
@@ -726,15 +776,20 @@ export function CouponStackingNotice(props: IProps): JSX.Element;
 - 저렴한 모델은 **존재하지 않는 사실을 적기도 한다**
 - 거짓 태그는 에러만 지울 뿐, **문제는 남긴다**
 
+<span class="note">인용이 붙으면 거짓 주장을 86-88%로 탐지하고, 오탐은 0이다 ([2606.30689](https://arxiv.org/abs/2606.30689)).</span>
+
 ---
+
+<!-- _class: cite-code -->
 
 # 검토 대상은 인용의 진위뿐
 
 ```ts
 /**
- * @evidence docs/discount.md#coupon-stacking Explains the per-issuer limit.
- * @evidenceReview docs/discount.md#coupon-stacking #a1b2c3d4e5f6
- *                 Verified against policy section 3.
+ * @evidence docs/specifications/discount.md#coupon-stacking
+ *           Explains the per-issuer limit.
+ * @evidenceReview docs/specifications/discount.md#coupon-stacking
+ *                 #a1b2c3d4e5f6 Verified against policy section 3.
  */
 export function CouponStackingNotice(props: IProps): JSX.Element;
 ```
@@ -757,6 +812,65 @@ export function CouponStackingNotice(props: IProps): JSX.Element;
 | 누락 | 직접 찾는다    | 컴파일러가 보고 |
 
 > **누락은 컴파일러가, 거짓은 사람이 잡는다.**
+
+---
+
+<!-- _class: divider -->
+
+# 벤치마크
+
+<span class="note">동일한 입력 · 엔진 · 모델 · 플러그인만 차이</span>
+
+---
+
+# 커버리지: 51.6–85.5% → 100%
+
+| 과제 | Plain | Evidence |
+| --- | --- | --- |
+| todo | 85.5% <span class="track"><i class="w855"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| reddit | 80.3% <span class="track"><i class="w803"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| shopping | 63.1% <span class="track"><i class="w631"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| erp | 51.6% <span class="track"><i class="w516"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+
+Plain은 규모가 커질수록 커버리지가 떨어진다. **Evidence는 100%를 유지한다.**
+
+---
+
+# 토큰 사용량: 4.8–13.3배 절감
+
+<div class="rows">
+<div class="row"><span class="lbl">todo</span><span class="bars"><i class="p b159"></i><i class="e b17"></i></span><span class="val">866M → 92M</span></div>
+<div class="row"><span class="lbl">reddit</span><span class="bars"><i class="p b216"></i><i class="e b45"></i></span><span class="val">1,179M → 245M</span></div>
+<div class="row"><span class="lbl">shopping</span><span class="bars"><i class="p b278"></i><i class="e b50"></i></span><span class="val">1,516M → 271M</span></div>
+<div class="row"><span class="lbl">erp</span><span class="bars"><i class="p b1000"></i><i class="e b75"></i></span><span class="val">5,449M → 411M</span></div>
+</div>
+
+<span class="kp">Plain</span>은 파랑, <span class="ke">Evidence</span>는 주황.
+
+<span class="note">단계별 원본 차트: [https://ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)</span>
+
+---
+
+# ERP: 커버리지 100% · $4.96 · 14시간
+
+<div class="cards">
+<div class="card"><b>13.3×</b>토큰 절감<br/><span class="note">5,449M → 411M</span></div>
+<div class="card"><b>13.9×</b>비용 절감<br/><span class="note">$68.72 → $4.96</span></div>
+<div class="card warm"><b>7.5×</b>시간 단축<br/><span class="note">102h → 14h</span></div>
+</div>
+
+---
+
+# 검토 비중: 토큰의 90–95% → 15–41%
+
+| 과제 | Plain | Evidence |
+| --- | --- | --- |
+| todo | <span class="split"><i class="d97"></i><i class="rev"></i></span> 검토 90% | <span class="split on"><i class="d720"></i><i class="rev"></i></span> 검토 28% |
+| reddit | <span class="split"><i class="d54"></i><i class="rev"></i></span> 검토 95% | <span class="split on"><i class="d808"></i><i class="rev"></i></span> 검토 19% |
+| shopping | <span class="split"><i class="d47"></i><i class="rev"></i></span> 검토 95% | <span class="split on"><i class="d586"></i><i class="rev"></i></span> 검토 41% |
+| erp | <span class="split"><i class="d105"></i><i class="rev"></i></span> 검토 90% | <span class="split on"><i class="d846"></i><i class="rev"></i></span> 검토 15% |
+
+<span class="note">진한 색은 개발, 옅은 색은 검토. 각 칸이 그 과제 토큰의 100%다.</span>
 
 ---
 
@@ -794,7 +908,7 @@ export function CouponStackingNotice(props: IProps): JSX.Element;
 - 사람은 **`docs/requirements`를 직접 검토**한다
 - 설계 명세, 구현, 테스트는 **전부 위임한다**
 
-> 벤치마크의 네 과제도 이 방법을 쓴다.
+> 방금 본 네 과제 모두 이 방법을 썼다.
 
 ---
 
@@ -907,65 +1021,6 @@ export function CouponStackingNotice(props: IProps): JSX.Element;
 
 ---
 
-<!-- _class: divider -->
-
-# 벤치마크
-
-<span class="note">동일한 입력 · 엔진 · 모델 · 플러그인만 차이</span>
-
----
-
-# 커버리지: 51.6–85.5% → 100%
-
-| 과제 | Plain | Evidence |
-| --- | --- | --- |
-| todo | 85.5% <span class="track"><i class="w855"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-| reddit | 80.3% <span class="track"><i class="w803"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-| shopping | 63.1% <span class="track"><i class="w631"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-| erp | 51.6% <span class="track"><i class="w516"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-
-Plain은 규모가 커질수록 커버리지가 떨어진다. **Evidence는 100%를 유지한다.**
-
----
-
-# 토큰 사용량: 4.8–13.3배 절감
-
-<div class="rows">
-<div class="row"><span class="lbl">todo</span><span class="bars"><i class="p b159"></i><i class="e b17"></i></span><span class="val">866M → 92M</span></div>
-<div class="row"><span class="lbl">reddit</span><span class="bars"><i class="p b216"></i><i class="e b45"></i></span><span class="val">1,179M → 245M</span></div>
-<div class="row"><span class="lbl">shopping</span><span class="bars"><i class="p b278"></i><i class="e b50"></i></span><span class="val">1,516M → 271M</span></div>
-<div class="row"><span class="lbl">erp</span><span class="bars"><i class="p b1000"></i><i class="e b75"></i></span><span class="val">5,449M → 411M</span></div>
-</div>
-
-<span class="kp">Plain</span>은 파랑, <span class="ke">Evidence</span>는 주황.
-
-<span class="note">단계별 원본 차트: [https://ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)</span>
-
----
-
-# ERP: 커버리지 100% · $4.96 · 14시간
-
-<div class="cards">
-<div class="card"><b>13.3×</b>토큰 절감<br/><span class="note">5,449M → 411M</span></div>
-<div class="card"><b>13.9×</b>비용 절감<br/><span class="note">$68.72 → $4.96</span></div>
-<div class="card warm"><b>7.5×</b>시간 단축<br/><span class="note">102h → 14h</span></div>
-</div>
-
----
-
-# 검토 비중: 토큰의 90–95% → 15–41%
-
-| 과제 | Plain | Evidence |
-| --- | --- | --- |
-| todo | <span class="split"><i class="d97"></i><i class="rev"></i></span> 검토 90% | <span class="split on"><i class="d720"></i><i class="rev"></i></span> 검토 28% |
-| reddit | <span class="split"><i class="d54"></i><i class="rev"></i></span> 검토 95% | <span class="split on"><i class="d808"></i><i class="rev"></i></span> 검토 19% |
-| shopping | <span class="split"><i class="d47"></i><i class="rev"></i></span> 검토 95% | <span class="split on"><i class="d586"></i><i class="rev"></i></span> 검토 41% |
-| erp | <span class="split"><i class="d105"></i><i class="rev"></i></span> 검토 90% | <span class="split on"><i class="d846"></i><i class="rev"></i></span> 검토 15% |
-
-<span class="note">진한 색은 개발, 옅은 색은 검토. 각 칸이 그 과제 토큰의 100%다.</span>
-
----
-
 <!-- _class: dark -->
 
 # 요약
@@ -985,13 +1040,56 @@ Plain은 규모가 커질수록 커버리지가 떨어진다. **Evidence는 100%
 
 ---
 
+<!-- _class: stat-list -->
+
+# 유창함은 작가성이 아니다
+
+- **평탄화**: 못 쓴 글은 아닌데, 누구의 글도 아니다
+- **갈등 소실**: 못되게 굴 인물이 다음 문단에서 사과한다
+- **번역투**: 남의 문장 구조, 관계를 안 따르는 호칭
+
+<span class="note">스튜디오 사례: 쿨한 성격은 죄다 은발, 장르 불문 똑같은 권선징악 엔딩.</span>
+
+---
+
+<!-- _class: stat-list -->
+
+# 느낌이 아니라 측정된 실패다
+
+- 학습이 주제와 감정과 문체를 고르게 깎는다
+- 문예물이 **가장 많이** 잃는다
+- 분량이 늘수록 모순이 **꾸준히** 늘어난다
+- 사실 오류는 앞쪽(**15-30%**), 모순은 뒤쪽(**40-60%**)에 몰린다
+
+<span class="note">Narrative Flattening ([2605.27878](https://arxiv.org/abs/2605.27878)) · ConStory-Bench ([사이트](https://picrew.github.io/constory-bench.github.io/))</span>
+
+---
+
+<!-- _class: stat-list -->
+
 # 매끄러운 장면도 거짓일 수 있다
 
 - **기억**: 인물이 알 리 없는 사실을 쓴다
 - **창작**: 역사, 지리, 동기를 어긴다
+- **모순**: 앞에서 정한 숫자, 연대, 성격을 뒤에서 뒤집는다
 - **개고**: 앞선 수정으로 무효가 된 장면을 남긴다
+- **망각**: 설정 350개 중 안 쓰인 게 뭔지 알 길이 없다
 
 > 장편의 실패는 국소적이지 않고 전역적이다.
+
+---
+
+<!-- _class: stat-list -->
+
+# 여기서는 루프가 오히려 해가 된다
+
+- 회차마다 글이 **모델 자신의 평균**으로 끌려간다
+- 문체와 유창함은 오르고, **정확도는 거의 안 움직인다**
+- 목소리는 매번 평준화되고, **프롬프트로 못 막는다**
+
+> 회차를 늘리면 윤이 날 뿐, 사실이 되지는 않는다.
+
+<span class="note">2026년 개고 연구 두 편 ([2605.13368](https://arxiv.org/abs/2605.13368)) ([2604.22142](https://arxiv.org/abs/2604.22142))</span>
 
 ---
 
@@ -1050,13 +1148,39 @@ Plain은 규모가 커질수록 커버리지가 떨어진다. **Evidence는 100%
 <!-- _class: dark -->
 <!-- _paginate: false -->
 
-# 참고 자료
+# 참고 자료: `@ttsc/evidence`
 
 - https://github.com/samchon/ttsc
   - https://ttsc.dev/docs/evidence
   - https://ttsc.dev/docs/benchmark/evidence
 - https://github.com/samchon/evidence-benchmark-results
-- https://github.com/samchon/novels
+
+---
+
+<!-- _class: dark -->
+<!-- _paginate: false -->
+
+# 참고 자료: 코딩 에이전트
+
+- 명세가 쪼개져 오면 충실도가 떨어진다 ([2603.17104](https://arxiv.org/abs/2603.17104))
+- 장기 작업에서 에이전트가 자기 코드를 침식한다 ([2603.24755](https://arxiv.org/abs/2603.24755))
+- 절차 지시에 동의한 뒤 우회한다 ([2605.01771](https://arxiv.org/abs/2605.01771))
+- 인용이 있으면 지어낸 요구사항을 탐지할 수 있다 ([2606.30689](https://arxiv.org/abs/2606.30689))
+- 명세가 일차 산출물이다 ([2602.00180](https://arxiv.org/abs/2602.00180))
+
+---
+
+<!-- _class: dark -->
+<!-- _paginate: false -->
+
+# 참고 자료: 장편 서사
+
+- 사후 학습이 주제와 정서와 문체를 평탄화한다 ([2605.27878](https://arxiv.org/abs/2605.27878))
+- 결말 예측으로 서사 긴장을 측정한다 ([2604.09854](https://arxiv.org/abs/2604.09854))
+- 일관성 오류가 분량에 비례해 늘어난다 ([ConStory-Bench](https://picrew.github.io/constory-bench.github.io/))
+- 개고는 문체를 올릴 뿐 정확도는 못 올린다 ([2605.13368](https://arxiv.org/abs/2605.13368))
+- 리라이팅이 개인의 목소리를 평준화한다 ([2604.22142](https://arxiv.org/abs/2604.22142))
+- 기계 번역에서의 한국어 경어 ([LREC 2026](https://lrec.elra.info/lrec2026-ws-iaai-03))
 
 ---
 

--- a/website/src/slides/evidence.md
+++ b/website/src/slides/evidence.md
@@ -443,7 +443,7 @@ style: |
   section.review-checklist td:first-child { background: #eef2f7; }
   section.review-checklist td:nth-child(2) { background: #dce8f6; }
   section.review-checklist td:nth-child(3) { background: #c5d9f0; }
-  .problem-measures { display: flex; flex-direction: column; gap: 12px; width: 94%; margin: 12px auto 0; }
+  .problem-measures { display: flex; flex-direction: column; gap: 12px; width: 94%; margin: 4px auto 0; }
   .problem-measure-title { margin-bottom: 8px; font-size: 32px; font-weight: 700; }
   .problem-bar {
     display: flex;
@@ -461,7 +461,16 @@ style: |
   .problem-legend i { display: inline-block; width: 20px; height: 20px; margin-right: 8px; border-radius: 4px; }
   .problem-legend .build { background: #14284b; }
   .problem-legend .review { background: #9bb4d2; }
-  .problem-context { margin-top: 16px; color: #5b6674; font-size: 28px; text-align: center; }
+  .problem-spend {
+    display: flex;
+    justify-content: center;
+    gap: 60px;
+    margin-top: 14px;
+    color: #5b6674;
+    font-size: 28px;
+  }
+  .problem-spend b { margin-right: 8px; color: #14284b; font-size: 34px; }
+  .problem-context { margin-top: 10px; color: #5b6674; font-size: 28px; text-align: center; }
 
   /* Bars */
   .track {
@@ -515,6 +524,29 @@ style: |
   .b75 { width: 7.5%; }
   .kp { color: #4a76b8; font-weight: 700; }
   .ke { color: #b35c00; font-weight: 700; }
+
+  /* Meme slides */
+  section.meme {
+    padding: 24px;
+    text-align: center;
+  }
+  section.meme p { margin: 0; }
+  section.meme img {
+    display: block;
+    box-sizing: border-box;
+    width: 672px;
+    height: 672px;
+    margin: 0 auto;
+    border: 2px solid #e6eaf0;
+    border-radius: 12px;
+  }
+
+  /* Citation code blocks */
+  section.cite-code pre { font-size: 23px; }
+
+  /* Evidence-backed lists */
+  section.stat-list li { font-size: 36px; margin-bottom: 14px; }
+  section.stat-list blockquote { font-size: 30px; }
 ---
 
 <!-- _class: dark -->
@@ -534,7 +566,7 @@ style: |
 <div class="opening-summary">
 
 - **Evidence Graph, a compiler harness**
-  - No loop until dry required
+  - No Loop Engineering required
   - `@evidence <target> <reason>`
   - `@evidenceReview <target> <reason>`
   - `@evidenceExclude <target> <reason>`
@@ -561,26 +593,66 @@ style: |
 
 ---
 
+<!-- _class: meme -->
+
+![Asked whether every requirement was met, a human explains while the compiler stops the build](https://ttsc.dev/evidence/meme-coverage.svg)
+
+---
+
+<!-- _class: meme -->
+
+![Asked whether the rule document was read, a human reads it out again while the compiler asks at every file](https://ttsc.dev/evidence/meme-checklist.svg)
+
+---
+
 <!-- _class: divider -->
 
-# Current Limitation
+# Current Limitations
 
-<span class="note">Loop Until Dry</span>
+<span class="note">Why we all ended up looping</span>
+
+---
+
+<!-- _class: stat-list -->
+
+# Saying yes is not doing it
+
+- Six top models, given one simple rule: **none** kept it
+- Answered "understood" **10 of 10**, skipped it **10 of 10**
+- People reading the result spotted **0 of 15** honest runs
+- Made to **write down its reason**: **97%** kept it
+
+<span class="note">Measured on tool logs, not on answers ([2605.01771](https://arxiv.org/abs/2605.01771))</span>
+
+---
+
+<!-- _class: stat-list -->
+
+# The longer it runs, the worse it gets
+
+- Goal given in pieces, not at once: worse **16 of 20**
+- Long build: **14.8%** of steps done, **no project finished**
+- In **77%** of runs, code that was already right got worse
+- What is left is **2.3× longer** and **2× messier** than human work
+
+<span class="note">Two 2026 coding-agent benchmarks ([2603.17104](https://arxiv.org/abs/2603.17104)) ([2603.24755](https://arxiv.org/abs/2603.24755))</span>
 
 ---
 
 <!-- _class: loop-slide -->
 
-# Loop Until Dry restarts the full review
+# So we built Loop Engineering
 
-- Read everything from the beginning
-- Fix every finding
-- Restart from the beginning
-- Stop only after an empty round
+- A claim of done proves nothing → **read it all again**
+- Omissions show only when you look → **fix every finding**
+- One fix breaks another → **restart from the top**
+- Nothing else says done → **stop after an empty round**
+
+> Also called Loop Until Dry. It is the state of the art, and it works.
 
 ---
 
-# ERP Plain: 90% review · 51.6% coverage
+# ERP Loop Engineering
 
 <div class="problem-measures">
 <div>
@@ -592,6 +664,11 @@ style: |
 <div class="problem-bar"><div class="problem-build">10%</div><div class="problem-review">90%</div></div>
 <div class="problem-legend"><span><i class="build"></i>Initial development</span><span><i class="review"></i>Review loops</span></div>
 </div>
+</div>
+
+<div class="problem-spend">
+<span><b>102h</b>work time</span>
+<span><b>5,449M</b>tokens</span>
 </div>
 
 <div class="problem-context">ERP · 100+ tables · 150K+ LoC</div>
@@ -637,12 +714,12 @@ files: ["src/components/**/*.tsx"], // sources
 symbol: "function",
 reference: {
   type: "markdown",
-  files: ["docs/**/*.md"], // targets
+  files: ["docs/specifications/*.md"], // targets
   symbol: ["h2", "h3"],
 },
 ```
 
-**Components implement documents.**
+**Components implement specifications.**
 
 ---
 
@@ -659,7 +736,7 @@ reference: {
 
 ```tsx
 /**
- * @evidence docs/discount.md#coupon-stacking
+ * @evidence docs/specifications/discount.md#coupon-stacking
  *           Explains the stacking limit defined by this section.
  * @evidence POST:/orders/{orderId}/coupons
  *           Explains the rejection response from this endpoint.
@@ -676,8 +753,9 @@ export function CouponStackingNotice(props: IProps): JSX.Element;
 ```bash
 $ npx ttsc
 error TS16411: [evidence/graph]
-  Missing acknowledgement for 'docs/discount.md#coupon-stacking'
-  (Markdown H2 'Coupon Stacking' at docs/discount.md:3)
+  Missing acknowledgement for
+  'docs/specifications/discount.md#coupon-stacking'
+  (Markdown H2 'Coupon Stacking' at docs/specifications/discount.md:3)
 ```
 
 - One error per requirement → **the error list is the task list**
@@ -689,7 +767,7 @@ error TS16411: [evidence/graph]
 
 ```ts
 /**
- * @evidence docs/discount.md#coupon-stacking
+ * @evidence docs/specifications/discount.md#coupon-stacking
  *           Explains the per-issuer limit.
  */
 export function CouponStackingNotice(props: IProps): JSX.Element;
@@ -698,15 +776,20 @@ export function CouponStackingNotice(props: IProps): JSX.Element;
 - Inexpensive models **sometimes write facts that do not exist**
 - A false tag removes the error, **not the problem**
 
+<span class="note">Citations make the false claim detectable: 86-88%, no false positives ([2606.30689](https://arxiv.org/abs/2606.30689)).</span>
+
 ---
+
+<!-- _class: cite-code -->
 
 # Review only citation truth
 
 ```ts
 /**
- * @evidence docs/discount.md#coupon-stacking Explains the per-issuer limit.
- * @evidenceReview docs/discount.md#coupon-stacking #a1b2c3d4e5f6
- *                 Verified against policy section 3.
+ * @evidence docs/specifications/discount.md#coupon-stacking
+ *           Explains the per-issuer limit.
+ * @evidenceReview docs/specifications/discount.md#coupon-stacking
+ *                 #a1b2c3d4e5f6 Verified against policy section 3.
  */
 export function CouponStackingNotice(props: IProps): JSX.Element;
 ```
@@ -729,6 +812,65 @@ export function CouponStackingNotice(props: IProps): JSX.Element;
 | Omissions | Search manually     | Compiler reports them |
 
 > **The compiler handles omissions. Humans handle falsehoods.**
+
+---
+
+<!-- _class: divider -->
+
+# Benchmark
+
+<span class="note">Same inputs · engine · model · Plugin only</span>
+
+---
+
+# Coverage: 51.6–85.5% → 100%
+
+| Subject | Plain | Evidence |
+| --- | --- | --- |
+| todo | 85.5% <span class="track"><i class="w855"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| reddit | 80.3% <span class="track"><i class="w803"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| shopping | 63.1% <span class="track"><i class="w631"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+| erp | 51.6% <span class="track"><i class="w516"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
+
+Plain coverage falls with scope. **Evidence remains at 100%.**
+
+---
+
+# Token usage: 4.8–13.3× lower
+
+<div class="rows">
+<div class="row"><span class="lbl">todo</span><span class="bars"><i class="p b159"></i><i class="e b17"></i></span><span class="val">866M → 92M</span></div>
+<div class="row"><span class="lbl">reddit</span><span class="bars"><i class="p b216"></i><i class="e b45"></i></span><span class="val">1,179M → 245M</span></div>
+<div class="row"><span class="lbl">shopping</span><span class="bars"><i class="p b278"></i><i class="e b50"></i></span><span class="val">1,516M → 271M</span></div>
+<div class="row"><span class="lbl">erp</span><span class="bars"><i class="p b1000"></i><i class="e b75"></i></span><span class="val">5,449M → 411M</span></div>
+</div>
+
+<span class="kp">Plain</span> in blue. <span class="ke">Evidence</span> in orange.
+
+<span class="note">Original charts by phase: [https://ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)</span>
+
+---
+
+# ERP: 100% coverage · $4.96 · 14h
+
+<div class="cards">
+<div class="card"><b>13.3×</b>fewer tokens<br/><span class="note">5,449M → 411M</span></div>
+<div class="card"><b>13.9×</b>lower cost<br/><span class="note">$68.72 → $4.96</span></div>
+<div class="card warm"><b>7.5×</b>less time<br/><span class="note">102h → 14h</span></div>
+</div>
+
+---
+
+# Review: 90–95% → 15–41% of tokens
+
+| Subject | Plain | Evidence |
+| --- | --- | --- |
+| todo | <span class="split"><i class="d97"></i><i class="rev"></i></span> Review 90% | <span class="split on"><i class="d720"></i><i class="rev"></i></span> Review 28% |
+| reddit | <span class="split"><i class="d54"></i><i class="rev"></i></span> Review 95% | <span class="split on"><i class="d808"></i><i class="rev"></i></span> Review 19% |
+| shopping | <span class="split"><i class="d47"></i><i class="rev"></i></span> Review 95% | <span class="split on"><i class="d586"></i><i class="rev"></i></span> Review 41% |
+| erp | <span class="split"><i class="d105"></i><i class="rev"></i></span> Review 90% | <span class="split on"><i class="d846"></i><i class="rev"></i></span> Review 15% |
+
+<span class="note">Dark is development. Light is review. Each cell represents 100% of its tokens.</span>
 
 ---
 
@@ -766,7 +908,7 @@ export function CouponStackingNotice(props: IProps): JSX.Element;
 - Humans **review `docs/requirements` directly**
 - Specifications, implementation, and tests are **fully delegated**
 
-> The four benchmark subjects use this method as well.
+> The four subjects you just saw all used this method.
 
 ---
 
@@ -879,65 +1021,6 @@ export function CouponStackingNotice(props: IProps): JSX.Element;
 
 ---
 
-<!-- _class: divider -->
-
-# Benchmark
-
-<span class="note">Same inputs · engine · model · Plugin only</span>
-
----
-
-# Coverage: 51.6–85.5% → 100%
-
-| Subject | Plain | Evidence |
-| --- | --- | --- |
-| todo | 85.5% <span class="track"><i class="w855"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-| reddit | 80.3% <span class="track"><i class="w803"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-| shopping | 63.1% <span class="track"><i class="w631"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-| erp | 51.6% <span class="track"><i class="w516"></i></span> | 100% <span class="track on"><i class="w100"></i></span> |
-
-Plain coverage falls with scope. **Evidence remains at 100%.**
-
----
-
-# Token usage: 4.8–13.3× lower
-
-<div class="rows">
-<div class="row"><span class="lbl">todo</span><span class="bars"><i class="p b159"></i><i class="e b17"></i></span><span class="val">866M → 92M</span></div>
-<div class="row"><span class="lbl">reddit</span><span class="bars"><i class="p b216"></i><i class="e b45"></i></span><span class="val">1,179M → 245M</span></div>
-<div class="row"><span class="lbl">shopping</span><span class="bars"><i class="p b278"></i><i class="e b50"></i></span><span class="val">1,516M → 271M</span></div>
-<div class="row"><span class="lbl">erp</span><span class="bars"><i class="p b1000"></i><i class="e b75"></i></span><span class="val">5,449M → 411M</span></div>
-</div>
-
-<span class="kp">Plain</span> in blue. <span class="ke">Evidence</span> in orange.
-
-<span class="note">Original charts by phase: [https://ttsc.dev/docs/benchmark/evidence](https://ttsc.dev/docs/benchmark/evidence)</span>
-
----
-
-# ERP: 100% coverage · $4.96 · 14h
-
-<div class="cards">
-<div class="card"><b>13.3×</b>fewer tokens<br/><span class="note">5,449M → 411M</span></div>
-<div class="card"><b>13.9×</b>lower cost<br/><span class="note">$68.72 → $4.96</span></div>
-<div class="card warm"><b>7.5×</b>less time<br/><span class="note">102h → 14h</span></div>
-</div>
-
----
-
-# Review: 90–95% → 15–41% of tokens
-
-| Subject | Plain | Evidence |
-| --- | --- | --- |
-| todo | <span class="split"><i class="d97"></i><i class="rev"></i></span> Review 90% | <span class="split on"><i class="d720"></i><i class="rev"></i></span> Review 28% |
-| reddit | <span class="split"><i class="d54"></i><i class="rev"></i></span> Review 95% | <span class="split on"><i class="d808"></i><i class="rev"></i></span> Review 19% |
-| shopping | <span class="split"><i class="d47"></i><i class="rev"></i></span> Review 95% | <span class="split on"><i class="d586"></i><i class="rev"></i></span> Review 41% |
-| erp | <span class="split"><i class="d105"></i><i class="rev"></i></span> Review 90% | <span class="split on"><i class="d846"></i><i class="rev"></i></span> Review 15% |
-
-<span class="note">Dark is development. Light is review. Each cell represents 100% of its tokens.</span>
-
----
-
 <!-- _class: dark -->
 
 # Summary
@@ -957,13 +1040,56 @@ Plain coverage falls with scope. **Evidence remains at 100%.**
 
 ---
 
+<!-- _class: stat-list -->
+
+# Fluency is not authorship
+
+- **Flattening**: competent prose that no one could have signed
+- **Softened conflict**: the antagonist apologizes a paragraph later
+- **Translationese**: borrowed syntax, misplaced honorifics
+
+<span class="note">Studio case: every cool character got silver hair, every genre got the same moral ending.</span>
+
+---
+
+<!-- _class: stat-list -->
+
+# The failure is measured, not just felt
+
+- Training smooths out theme, emotion, and voice
+- Literary fiction loses **the most**
+- Contradictions grow **steadily** with length
+- Facts slip early (**15-30%**), contradictions late (**40-60%**)
+
+<span class="note">Narrative Flattening ([2605.27878](https://arxiv.org/abs/2605.27878)) · ConStory-Bench ([site](https://picrew.github.io/constory-bench.github.io/))</span>
+
+---
+
+<!-- _class: stat-list -->
+
 # A fluent scene can still be false
 
 - **Memory**: uses facts the character never learned
 - **Invention**: breaks history, geography, or motive
+- **Contradiction**: negates a number, a date, or a trait set earlier
 - **Revision**: keeps scenes invalidated by an earlier edit
+- **Amnesia**: 350 settings, and no way to tell which went unused
 
 > Long-form failure is global, not local.
+
+---
+
+<!-- _class: stat-list -->
+
+# Here the loop makes it worse
+
+- Every pass pulls the text toward **the model's own average**
+- Style and fluency rise, **accuracy barely moves**
+- Voice normalizes each time, and **prompts cannot stop it**
+
+> More rounds buy polish, not truth.
+
+<span class="note">Two 2026 revision studies ([2605.13368](https://arxiv.org/abs/2605.13368)) ([2604.22142](https://arxiv.org/abs/2604.22142))</span>
 
 ---
 
@@ -1022,13 +1148,39 @@ Plain coverage falls with scope. **Evidence remains at 100%.**
 <!-- _class: dark -->
 <!-- _paginate: false -->
 
-# References
+# References: `@ttsc/evidence`
 
 - https://github.com/samchon/ttsc
   - https://ttsc.dev/docs/evidence
   - https://ttsc.dev/docs/benchmark/evidence
 - https://github.com/samchon/evidence-benchmark-results
-- https://github.com/samchon/novels
+
+---
+
+<!-- _class: dark -->
+<!-- _paginate: false -->
+
+# References: Coding Agents
+
+- Faithfulness drops when the spec arrives in pieces ([2603.17104](https://arxiv.org/abs/2603.17104))
+- Agents erode their own code over long horizons ([2603.24755](https://arxiv.org/abs/2603.24755))
+- Process instructions agreed to, then bypassed ([2605.01771](https://arxiv.org/abs/2605.01771))
+- Citations make hallucinated requirements detectable ([2606.30689](https://arxiv.org/abs/2606.30689))
+- Specifications as the primary artifact ([2602.00180](https://arxiv.org/abs/2602.00180))
+
+---
+
+<!-- _class: dark -->
+<!-- _paginate: false -->
+
+# References: Long-form Narrative
+
+- Post-training flattens theme, affect, and style ([2605.27878](https://arxiv.org/abs/2605.27878))
+- Narrative tension measured by forecasting ([2604.09854](https://arxiv.org/abs/2604.09854))
+- Consistency bugs scale with story length ([ConStory-Bench](https://picrew.github.io/constory-bench.github.io/))
+- Revision improves style, not accuracy ([2605.13368](https://arxiv.org/abs/2605.13368))
+- Rewriting normalizes personal voice ([2604.22142](https://arxiv.org/abs/2604.22142))
+- Korean honorifics in automatic translation ([LREC 2026](https://lrec.elra.info/lrec2026-ws-iaai-03))
 
 ---
 


### PR DESCRIPTION
## Intent

The evidence deck asserted its premises. This grounds them in 2026 literature, reorders the sections so the proof arrives before the recommendation, and brings the Korean deck back to parity.

## Scope

### Slides, `website/src/slides/evidence.md`

**Current Limitations** now derives Loop Engineering rather than asserting it. Two measured limits come first, then the loop as their answer, then its ceiling.

- `Saying yes is not doing it` reports [2605.01771](https://arxiv.org/abs/2605.01771): six frontier models at 0% process compliance by default, agreement 10 of 10 alongside bypass 10 of 10, human reviewers identifying 0 of 15 compliant runs, and 97% once a written rationale is required.
- `The longer it runs, the worse it gets` reports [2603.17104](https://arxiv.org/abs/2603.17104) and [2603.24755](https://arxiv.org/abs/2603.24755): single-shot specification winning 16 of 20, a best agent clearing 14.8% of checkpoints with no project finished, structural erosion in 77% of trajectories.
- `So we built Loop Engineering` maps each loop step to the limit it answers and names it the state of the art. The section previously read as if the loop were a failure rather than the correct response to a real problem.
- `ERP Loop Engineering` adds the 102h work time and 5,449M tokens that reaching 51.6% consumed.

**Section order** becomes Evidence Graph, Benchmark, Spec Driven Development. The benchmark now answers the ceiling shown four slides earlier instead of eight, and Method A cites the four subjects backwards (`The four subjects you just saw all used this method.`) rather than forwards.

**Appendix: Stories** gains the plain-mode failure modes from `.wiki/AI-NOVEL-PLAIN-MODE-PROBLEM.md`, condensed to the deck's list form, plus `Here the loop makes it worse` from [2605.13368](https://arxiv.org/abs/2605.13368) and [2604.22142](https://arxiv.org/abs/2604.22142). Revision projects text toward the refiner's distribution instead of repairing it, and voice normalizes in a direction prompts cannot reverse, so the loop is the wrong instrument for prose and the graph is what remains.

**References** splits into three slides: the project, coding agents, and long-form narrative.

**Citation examples** move to `docs/specifications/`, matching the rule on the same slide. Every example previously cited `docs/discount.md`, which the declared glob does not select.

### Memes, `website/public/evidence/`

`meme-coverage.svg` and `meme-checklist.svg` mirror the Korean pair, same geometry, English text.

### Korean deck, `website/src/slides/evidence-kr.md`

Regenerated from `evidence.md` by text substitution, so both decks share one stylesheet, one slide order, and one set of `_class` directives. Prior Korean wording is preserved wherever the English is unchanged.

Two bullets needed `<strong>` instead of `**`: a closing `**` preceded by `%` and followed by a Hangul particle is not right-flanking, so CommonMark leaves the asterisks visible.

### Benchmark guide, `website/src/content/docs/benchmark/evidence.mdx`

An `Applications` section links all eight leaves of the published cohort, one per subject and treatment.

## Verification

Local, on this head:

- `node build/slides.cjs` builds all three decks.
- `node --test test/slides.test.cjs` passes.
- `npx prettier --write` reports every changed file unchanged.
- All 46 slides of both decks rendered to PNG and inspected for overflow and markup faults.
- The eight `evidence-benchmark-results` links return HTTP 200.
- Every cited paper fetched from arXiv and checked against the figure quoted.
- `102h`, `5,449M`, and `$68.72` read from `benchmarks/evidence/aggregate/summary.json`, cell `erp`/`plain`.

`pnpm check:format` was not run to completion; it exceeded a two minute budget over the whole repository. Prettier was run directly on each changed path instead.

## Not included

`website/next-env.d.ts` carries a pre-existing local modification and is left unstaged.

The meme slides reference `https://ttsc.dev/evidence/*.svg`, so they render as alt text until this deploys. This matches how the Korean pair already works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
