### PR TITLE
fix(ttsx): rescue a JavaScript specifier on the CommonJS graph too

### DIFF
--- a/packages/banner/driver/banner.go
+++ b/packages/banner/driver/banner.go
@@ -448,7 +448,8 @@ func loadBannerScriptConfigFile(location string) (any, error) {
 
 func loadBannerScriptConfigFileWithInputs(location string) (bannerLoadedConfig, error) {
   const script = `
-const { createRequire, isBuiltin, registerHooks } = require("node:module");
+const nodeModule = require("node:module");
+const { createRequire, isBuiltin, registerHooks } = nodeModule;
 const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
@@ -644,6 +645,27 @@ registerHooks({
   },
 });
 
+// The hook above never sees a require() made from inside a CommonJS module the
+// ESM loader evaluated, which on Node 22 is every require the config makes:
+// module.registerHooks observes the import() of that module and nothing within
+// it. A config's own dependencies would then be reported without the candidates
+// that decide them, so a spelling appearing later could change what the config
+// resolves to with nothing in the envelope to notice it (samchon/ttsc#1280).
+// Wrapping the CommonJS resolver records the same two observations the hook
+// does, on the graph the hook cannot reach.
+const nextResolveFilename = nodeModule._resolveFilename;
+nodeModule._resolveFilename = function resolveFilename(request, parent, isMain, options) {
+  const parentFile = parent && typeof parent.filename === "string" ? parent.filename : undefined;
+  const parentURL = parentFile === undefined ? undefined : pathToFileURL(parentFile).href;
+  recordResolutionCandidates(request, parentURL, undefined);
+  const resolved = nextResolveFilename.call(this, request, parent, isMain, options);
+  if (path.isAbsolute(resolved)) {
+    recordResolutionCandidates(request, parentURL, pathToFileURL(resolved).href);
+    recordFile(resolved);
+  }
+  return resolved;
+};
+
 (async () => {
   const mod = await import(pathToFileURL(process.argv[1]).href);
   let current = Object.prototype.hasOwnProperty.call(mod, "default") ? mod.default : mod;
@@ -823,11 +845,11 @@ func loadBannerTypeScriptConfigFileWithInputs(location, resolutionRoot string) (
 // JSON-encoded import specifier) and writes the serialized banner value to stdout.
 func bannerTypeScriptConfigLoaderSource(importLiteral string) string {
   return fmt.Sprintf(`// @ts-nocheck
-import { createRequire, isBuiltin, registerHooks } from "node:module";
+import Module, { createRequire, isBuiltin, registerHooks } from "node:module";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const inputs = new Set<string>();
 const hashes = new Map<string, string | null>();
@@ -1033,6 +1055,43 @@ registerHooks({
     return resolved;
   },
 });
+
+// The hook above never sees a require() made from inside a CommonJS module the
+// ESM loader evaluated, which on Node 22 is every require the config makes:
+// module.registerHooks observes the import() of that module and nothing within
+// it. A config's own dependencies would then be reported without the candidates
+// that decide them, so a spelling appearing later could change what the config
+// resolves to with nothing in the envelope to notice it (samchon/ttsc#1280).
+// Wrapping the CommonJS resolver records the same two observations the hook
+// does, on the graph the hook cannot reach.
+const moduleInternals = Module as unknown as {
+  _resolveFilename(
+    request: string,
+    parent: { filename?: string | null } | null | undefined,
+    isMain: boolean,
+    options?: unknown,
+  ): string;
+};
+const nextResolveFilename = moduleInternals._resolveFilename;
+moduleInternals._resolveFilename = function resolveFilename(
+  this: unknown,
+  request: string,
+  parent: { filename?: string | null } | null | undefined,
+  isMain: boolean,
+  options?: unknown,
+): string {
+  const parentURL =
+    typeof parent?.filename === "string"
+      ? pathToFileURL(parent.filename).href
+      : undefined;
+  recordResolutionCandidates(request, parentURL, undefined);
+  const resolved = nextResolveFilename.call(this, request, parent, isMain, options);
+  if (path.isAbsolute(resolved)) {
+    recordResolutionCandidates(request, parentURL, pathToFileURL(resolved).href);
+    recordFile(resolved);
+  }
+  return resolved;
+};
 
 declare const process: {
   exitCode?: number;

--- a/packages/banner/driver/banner.go
+++ b/packages/banner/driver/banner.go
@@ -655,6 +655,12 @@ registerHooks({
 // does, on the graph the hook cannot reach.
 const nextResolveFilename = nodeModule._resolveFilename;
 nodeModule._resolveFilename = function resolveFilename(request, parent, isMain, options) {
+  // _resolveFilename is an internal entry point anything may call, so a
+  // non-string request arrives here as readily as a specifier does. Reading it
+  // would replace Node's own argument error with a TypeError from this loader.
+  if (typeof request !== "string") {
+    return nextResolveFilename.call(this, request, parent, isMain, options);
+  }
   const parentFile = parent && typeof parent.filename === "string" ? parent.filename : undefined;
   const parentURL = parentFile === undefined ? undefined : pathToFileURL(parentFile).href;
   recordResolutionCandidates(request, parentURL, undefined);
@@ -1080,6 +1086,12 @@ moduleInternals._resolveFilename = function resolveFilename(
   isMain: boolean,
   options?: unknown,
 ): string {
+  // _resolveFilename is an internal entry point anything may call, so a
+  // non-string request arrives here as readily as a specifier does. Reading it
+  // would replace Node's own argument error with a TypeError from this loader.
+  if (typeof request !== "string") {
+    return nextResolveFilename.call(this, request, parent, isMain, options);
+  }
   const parentURL =
     typeof parent?.filename === "string"
       ? pathToFileURL(parent.filename).href

--- a/packages/strip/driver/config.go
+++ b/packages/strip/driver/config.go
@@ -513,6 +513,12 @@ registerHooks({
 // does, on the graph the hook cannot reach.
 const nextResolveFilename = nodeModule._resolveFilename;
 nodeModule._resolveFilename = function resolveFilename(request, parent, isMain, options) {
+  // _resolveFilename is an internal entry point anything may call, so a
+  // non-string request arrives here as readily as a specifier does. Reading it
+  // would replace Node's own argument error with a TypeError from this loader.
+  if (typeof request !== "string") {
+    return nextResolveFilename.call(this, request, parent, isMain, options);
+  }
   const parentFile = parent && typeof parent.filename === "string" ? parent.filename : undefined;
   const parentURL = parentFile === undefined ? undefined : pathToFileURL(parentFile).href;
   recordResolutionCandidates(request, parentURL, undefined);
@@ -867,6 +873,12 @@ moduleInternals._resolveFilename = function resolveFilename(
   isMain: boolean,
   options?: unknown,
 ): string {
+  // _resolveFilename is an internal entry point anything may call, so a
+  // non-string request arrives here as readily as a specifier does. Reading it
+  // would replace Node's own argument error with a TypeError from this loader.
+  if (typeof request !== "string") {
+    return nextResolveFilename.call(this, request, parent, isMain, options);
+  }
   const parentURL =
     typeof parent?.filename === "string"
       ? pathToFileURL(parent.filename).href

--- a/packages/strip/driver/config.go
+++ b/packages/strip/driver/config.go
@@ -306,7 +306,8 @@ func parseStripJSONConfigFile(location string, body []byte) (any, error) {
 // loadStripScriptConfigFile to evaluate a .js/.cjs/.mjs strip config and
 // serialize the result to stdout as JSON.
 const stripScriptLoaderSource = `
-const { createRequire, isBuiltin, registerHooks } = require("node:module");
+const nodeModule = require("node:module");
+const { createRequire, isBuiltin, registerHooks } = nodeModule;
 const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
@@ -502,6 +503,27 @@ registerHooks({
   },
 });
 
+// The hook above never sees a require() made from inside a CommonJS module the
+// ESM loader evaluated, which on Node 22 is every require the config makes:
+// module.registerHooks observes the import() of that module and nothing within
+// it. A config's own dependencies would then be reported without the candidates
+// that decide them, so a spelling appearing later could change what the config
+// resolves to with nothing in the envelope to notice it (samchon/ttsc#1280).
+// Wrapping the CommonJS resolver records the same two observations the hook
+// does, on the graph the hook cannot reach.
+const nextResolveFilename = nodeModule._resolveFilename;
+nodeModule._resolveFilename = function resolveFilename(request, parent, isMain, options) {
+  const parentFile = parent && typeof parent.filename === "string" ? parent.filename : undefined;
+  const parentURL = parentFile === undefined ? undefined : pathToFileURL(parentFile).href;
+  recordResolutionCandidates(request, parentURL, undefined);
+  const resolved = nextResolveFilename.call(this, request, parent, isMain, options);
+  if (path.isAbsolute(resolved)) {
+    recordResolutionCandidates(request, parentURL, pathToFileURL(resolved).href);
+    recordFile(resolved);
+  }
+  return resolved;
+};
+
 (async () => {
   const mod = await import(pathToFileURL(process.argv[1]).href);
   let current = mod;
@@ -610,11 +632,11 @@ func decodeStripConfigLoaderOutput(output []byte) (stripLoadedConfig, error) {
 // `"./strip.config.ts"`) produced by json.Marshal.
 func stripTypeScriptLoaderSource(importLiteral string) string {
   return fmt.Sprintf(`// @ts-nocheck
-import { createRequire, isBuiltin, registerHooks } from "node:module";
+import Module, { createRequire, isBuiltin, registerHooks } from "node:module";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const inputs = new Set<string>();
 const hashes = new Map<string, string | null>();
@@ -820,6 +842,43 @@ registerHooks({
     return resolved;
   },
 });
+
+// The hook above never sees a require() made from inside a CommonJS module the
+// ESM loader evaluated, which on Node 22 is every require the config makes:
+// module.registerHooks observes the import() of that module and nothing within
+// it. A config's own dependencies would then be reported without the candidates
+// that decide them, so a spelling appearing later could change what the config
+// resolves to with nothing in the envelope to notice it (samchon/ttsc#1280).
+// Wrapping the CommonJS resolver records the same two observations the hook
+// does, on the graph the hook cannot reach.
+const moduleInternals = Module as unknown as {
+  _resolveFilename(
+    request: string,
+    parent: { filename?: string | null } | null | undefined,
+    isMain: boolean,
+    options?: unknown,
+  ): string;
+};
+const nextResolveFilename = moduleInternals._resolveFilename;
+moduleInternals._resolveFilename = function resolveFilename(
+  this: unknown,
+  request: string,
+  parent: { filename?: string | null } | null | undefined,
+  isMain: boolean,
+  options?: unknown,
+): string {
+  const parentURL =
+    typeof parent?.filename === "string"
+      ? pathToFileURL(parent.filename).href
+      : undefined;
+  recordResolutionCandidates(request, parentURL, undefined);
+  const resolved = nextResolveFilename.call(this, request, parent, isMain, options);
+  if (path.isAbsolute(resolved)) {
+    recordResolutionCandidates(request, parentURL, pathToFileURL(resolved).href);
+    recordFile(resolved);
+  }
+  return resolved;
+};
 
 declare const process: {
   exitCode?: number;

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -366,7 +366,8 @@ function installCommonJsHook(): void {
  * so a resolution that succeeds is never perturbed, and a request no candidate
  * satisfies rethrows Node's original error with its `MODULE_NOT_FOUND` code and
  * `requireStack` intact. `require.resolve` shares this entry point and is
- * rescued with it.
+ * rescued with it, except in its `{ paths }` form, which resolves against the
+ * caller's list rather than the parent this reads.
  */
 function installCommonJsResolveHook(): void {
   const internals = Module as unknown as {
@@ -388,7 +389,7 @@ function installCommonJsResolveHook(): void {
     try {
       return original.call(this, request, parent, isMain, options);
     } catch (error) {
-      const rescued = rescueCommonJsRequest(request, parent);
+      const rescued = rescueCommonJsRequest(request, parent, options);
       if (rescued === null) {
         throw error;
       }
@@ -403,11 +404,30 @@ function installCommonJsResolveHook(): void {
  * Only a relative or absolute request can be rescued: a bare specifier is a
  * package lookup, whose own resolver already probed every extension the
  * installed `_extensions` keys declare.
+ *
+ * Two shapes decline before that. `_resolveFilename` is an internal entry point
+ * anything may call, so a non-string request reaches here as readily as a
+ * specifier does, and reading it would replace Node's own argument error with a
+ * `TypeError` from this file. And `require.resolve(request, { paths })`
+ * resolves against the caller's list, which this rescue does not consult, so
+ * answering it from the parent's directory would be a different question's
+ * answer.
  */
 function rescueCommonJsRequest(
   request: string,
   parent: { filename?: string | null } | null | undefined,
+  options?: unknown,
 ): string | null {
+  if (typeof request !== "string") {
+    return null;
+  }
+  if (
+    typeof options === "object" &&
+    options !== null &&
+    Array.isArray((options as { paths?: unknown }).paths)
+  ) {
+    return null;
+  }
   let base: string;
   if (path.isAbsolute(request)) {
     base = request;

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -274,8 +274,16 @@ export interface RuntimeHookOptions {
  * `require()` made from inside a CommonJS module that was itself reached
  * through an ESM `import` (the interop translator loads it on the raw CJS
  * path). The ESM graph goes through `registerHooks`; the CommonJS `require`
- * graph goes through `Module._extensions` — the canonical loader extension
- * point `ts-node`/`tsx` use for the same reason.
+ * graph goes through `Module._extensions` and `Module._resolveFilename` — the
+ * canonical loader extension points `ts-node`/`tsx` use for the same reason.
+ *
+ * Both halves of that second graph are required, and they answer different
+ * questions. `_extensions` decides how a file that was _found_ is compiled, and
+ * Node reuses its keys when it probes an extensionless request, so
+ * `require("./x")` reaches `x.ts` for free. Nothing there resolves a request
+ * that already carries an extension: `require("./x.js")` backed only by `x.ts`
+ * is a resolution failure before any compiler is consulted, which is why the
+ * rescue is installed on `_resolveFilename` as well (samchon/ttsc#1280).
  */
 export function installRuntimeHooks(options: RuntimeHookOptions = {}): void {
   if (options.prepareEntry !== undefined) {
@@ -295,6 +303,7 @@ export function installRuntimeHooks(options: RuntimeHookOptions = {}): void {
   }
   registerHooks({ load, resolve });
   installCommonJsHook();
+  installCommonJsResolveHook();
 }
 
 /**
@@ -337,6 +346,86 @@ function installCommonJsHook(): void {
   for (const extension of [".ts", ".tsx", ".cts"]) {
     extensions[extension] = compile;
   }
+}
+
+/**
+ * Map a JavaScript spelling back to its TypeScript source on the CommonJS
+ * resolution path, so `require("./x.js")` finds `x.ts` when nothing emitted
+ * `x.js`.
+ *
+ * TypeScript asks authors to write the emitted `.js` extension in a relative
+ * specifier, so this spelling is the documented one rather than a mistake, and
+ * the ESM `resolve` hook has always rescued it. The CommonJS graph could not,
+ * and on Node 22 that graph is reached by every `require()` inside a CommonJS
+ * module the ESM loader evaluated — `module.registerHooks` sees the `import()`
+ * of that module and nothing within it. Node 24 routes the same `require`
+ * through the hooks, which is why the gap was only ever visible on the oldest
+ * runtime ttsx supports (`engines.node` is `>=22.15.0`).
+ *
+ * The wrapper only ever answers a request Node's own resolver already refused,
+ * so a resolution that succeeds is never perturbed, and a request no candidate
+ * satisfies rethrows Node's original error with its `MODULE_NOT_FOUND` code and
+ * `requireStack` intact. `require.resolve` shares this entry point and is
+ * rescued with it.
+ */
+function installCommonJsResolveHook(): void {
+  const internals = Module as unknown as {
+    _resolveFilename(
+      request: string,
+      parent: { filename?: string | null } | null | undefined,
+      isMain: boolean,
+      options?: unknown,
+    ): string;
+  };
+  const original = internals._resolveFilename;
+  internals._resolveFilename = function resolveFilename(
+    this: unknown,
+    request: string,
+    parent: { filename?: string | null } | null | undefined,
+    isMain: boolean,
+    options?: unknown,
+  ): string {
+    try {
+      return original.call(this, request, parent, isMain, options);
+    } catch (error) {
+      const rescued = rescueCommonJsRequest(request, parent);
+      if (rescued === null) {
+        throw error;
+      }
+      return rescued;
+    }
+  };
+}
+
+/**
+ * The TypeScript source a refused CommonJS request names, or `null`.
+ *
+ * Only a relative or absolute request can be rescued: a bare specifier is a
+ * package lookup, whose own resolver already probed every extension the
+ * installed `_extensions` keys declare.
+ */
+function rescueCommonJsRequest(
+  request: string,
+  parent: { filename?: string | null } | null | undefined,
+): string | null {
+  let base: string;
+  if (path.isAbsolute(request)) {
+    base = request;
+  } else if (isRelativeSpecifier(request)) {
+    const from = parent?.filename;
+    if (typeof from !== "string") {
+      return null;
+    }
+    base = path.resolve(path.dirname(from), request);
+  } else {
+    return null;
+  }
+  for (const candidate of typescriptSourcesForJavaScriptSpecifier(base)) {
+    if (isFile(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
 }
 
 /**

--- a/scripts/ci/validation-plan.cjs
+++ b/scripts/ci/validation-plan.cjs
@@ -125,6 +125,11 @@ const LANES = [
       "native-plugins/utility-host",
     ],
   },
+  // Every other lane runs the current Node, so the floor `engines.node`
+  // declares is checked only here. The cases this names are the ones whose
+  // behaviour the runtime itself changed between that floor and the current
+  // release: each passes on the newer Node whatever ttsx does, so only this
+  // lane can tell a working hook from one the runtime happened to cover.
   {
     id: "ttsx-node-22",
     name: "ttsx node 22.15",
@@ -132,7 +137,8 @@ const LANES = [
     build: "pnpm --filter ttsc build",
     run:
       "pnpm --filter @ttsc/test-ttsc start -- " +
-      "--include=commonjs_loads_prefix_only_node_builtins",
+      "--include=commonjs_loads_prefix_only_node_builtins " +
+      "--include=commonjs_require_rescues_a_js_specifier_inside_a_dynamic_import",
     dirs: ["features/ttsx-runtime"],
   },
   {

--- a/tests/test-lint/src/features/config/test_lint_config_file_commonjs_config_resolves_a_javascript_spelled_sibling.ts
+++ b/tests/test-lint/src/features/config/test_lint_config_file_commonjs_config_resolves_a_javascript_spelled_sibling.ts
@@ -1,0 +1,47 @@
+import { SOURCE, assert, runLint } from "../../internal/config-file";
+
+/**
+ * Verifies a CommonJS `.ts` lint config resolves a sibling written with the
+ * JavaScript spelling TypeScript asks for.
+ *
+ * A config in a CommonJS package is evaluated as CommonJS, and Node evaluates a
+ * CommonJS module reached through `import()` with the ESM translator's own
+ * `require`. On the oldest Node ttsx supports that `require` never reaches
+ * `module.registerHooks`, so `./rules.js` backed only by `rules.ts` failed to
+ * resolve and the config could not load at all — while the same config loaded
+ * on a newer Node, which routes that `require` through the hooks
+ * (samchon/ttsc#1280).
+ *
+ * 1. Materialize a CommonJS fixture whose config imports `./rules.js`.
+ * 2. Back that specifier with `rules.ts` alone.
+ * 3. Run ttsc and assert the config loaded and its rule fired.
+ */
+export const test_lint_config_file_commonjs_config_resolves_a_javascript_spelled_sibling =
+  () => {
+    const result = runLint({
+      name: "config-file-commonjs-js-spelling",
+      source: SOURCE,
+      pluginConfig: {
+        configFile: "./ttsc-lint.config.ts",
+      },
+      extraSources: {
+        "rules.ts": [
+          `export const rules = { "no-console": "error" };`,
+          ``,
+        ].join("\n"),
+        "ttsc-lint.config.ts": [
+          `import { rules } from "./rules.js";`,
+          ``,
+          `export default { rules };`,
+          ``,
+        ].join("\n"),
+      },
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.deepEqual(
+      result.diagnostics.map((d) => [d.rule, d.severity]),
+      [["no-console", "error"]],
+      result.stderr,
+    );
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_commonjs_require_rescues_a_js_specifier_inside_a_dynamic_import.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_commonjs_require_rescues_a_js_specifier_inside_a_dynamic_import.ts
@@ -1,0 +1,56 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies ttsx maps a `.js` specifier back to its TypeScript source from a
+ * CommonJS module the ESM loader evaluated.
+ *
+ * TypeScript asks authors to write the emitted `.js` extension in a relative
+ * specifier, and the ESM resolve hook has always rescued that spelling. The
+ * CommonJS graph could not: `Module._extensions` decides how a file that was
+ * found gets compiled, and Node reuses its keys only when it probes an
+ * extensionless request, so `require("./x")` reached `x.ts` for free while
+ * `require("./x.js")` failed to resolve before any compiler was consulted.
+ *
+ * That graph is reached by every `require()` inside a CommonJS module the ESM
+ * loader evaluated, which is exactly how a plugin loads a discovered config: on
+ * Node 22 `module.registerHooks` observes the `import()` of that module and
+ * nothing within it, while Node 24 routes the same `require` through the hooks.
+ * ttsx declares `engines.node` `>=22.15.0`, so the rescue belongs to ttsx
+ * rather than to the runtime (samchon/ttsc#1280).
+ *
+ * 1. Give a CommonJS project an ESM entry that reaches a sibling by `import()`.
+ * 2. Have that CommonJS sibling import `./target.js`, backed only by `target.tsx`.
+ * 3. Run the entry through the real ttsx launcher and assert it resolved.
+ */
+export const test_ttsx_commonjs_require_rescues_a_js_specifier_inside_a_dynamic_import =
+  () => {
+    const root = TestProject.commonJsProject(
+      {
+        "src/config.ts": `
+          import target from "./target.js";
+          export default target;
+        `,
+        "src/entry.mts": `
+          void (async () => {
+            const loaded = await import("./config.js");
+            console.log(JSON.stringify(loaded.default));
+          })();
+        `,
+        "src/target.tsx": `
+          export default "RESCUED";
+        `,
+      },
+      { compilerOptions: { jsx: "react-jsx" } },
+    );
+
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      ["--cwd", root, "src/entry.mts"],
+      { cwd: root },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    // The config module is CommonJS, so its `export default` arrives as
+    // `module.exports.default`; the point is that it arrived at all.
+    assert.equal(result.stdout.trim(), '{"default":"RESCUED"}');
+  };

--- a/website/src/content/docs/ttsc/execute.mdx
+++ b/website/src/content/docs/ttsc/execute.mdx
@@ -62,8 +62,10 @@ The type-check covers your whole program, but at runtime your dependencies are l
 
 `ttsx` installs Node module hooks in the run, the same approach `tsx` uses, so both cases just work without touching the dependency's `exports`, sources, or `tsconfig`:
 
-- a `resolve` hook probes the candidate extensions (and directory `index` files) for an extensionless relative import anywhere in the graph;
+- a `resolve` hook probes the candidate extensions (and directory `index` files) for an extensionless relative import anywhere in the graph, and maps a relative `.js` specifier — the spelling TypeScript asks authors to write — back to the TypeScript source it names when nothing emitted that JavaScript;
 - a `load` hook transpiles raw `.ts` files under `node_modules`, scoped so workspace neighbours keep Node's native type-stripping path.
+
+Both reaches cover the CommonJS `require` graph as well as the ESM one, and that is not something the runtime can be left to do. Node routes a `require()` made from inside a CommonJS module the ESM loader evaluated — which is how a plugin loads a config file it discovered — around `module.registerHooks` on the oldest release `ttsx` supports, and through the hooks on the current one. `ttsx` therefore installs the same probes on the CommonJS resolver itself, so a graph behaves the same way on every supported Node.
 
 These hooks are runtime-only and never weaken the compile gate: the up-front tsgo build still deep-checks the whole program, imported workspace neighbours included, so a type error in a dependency's source fails the run before anything executes. A genuinely missing module still throws `ERR_MODULE_NOT_FOUND`. This makes `ttsx` strictly stronger than `tsx`: a full type-check plus the same runtime reach.
 

--- a/website/src/content/docs/ttsc/execute.mdx
+++ b/website/src/content/docs/ttsc/execute.mdx
@@ -67,7 +67,7 @@ The type-check covers your whole program, but at runtime your dependencies are l
 
 Both reaches cover the CommonJS `require` graph as well as the ESM one, and that is not something the runtime can be left to do. Node routes a `require()` made from inside a CommonJS module the ESM loader evaluated — which is how a plugin loads a config file it discovered — around `module.registerHooks` on the oldest release `ttsx` supports, and through the hooks on the current one. `ttsx` therefore installs the same probes on the CommonJS resolver itself, so a graph behaves the same way on every supported Node.
 
-These hooks are runtime-only and never weaken the compile gate: the up-front tsgo build still deep-checks the whole program, imported workspace neighbours included, so a type error in a dependency's source fails the run before anything executes. A genuinely missing module still throws `ERR_MODULE_NOT_FOUND`. This makes `ttsx` strictly stronger than `tsx`: a full type-check plus the same runtime reach.
+These hooks are runtime-only and never weaken the compile gate: the up-front tsgo build still deep-checks the whole program, imported workspace neighbours included, so a type error in a dependency's source fails the run before anything executes. A genuinely missing module still throws `ERR_MODULE_NOT_FOUND`, or `MODULE_NOT_FOUND` with its require stack on the CommonJS graph. This makes `ttsx` strictly stronger than `tsx`: a full type-check plus the same runtime reach.
 
 On supported Node releases whose CommonJS resolver strips the `node:` scheme from prefix-only builtins such as `node:sqlite`, `ttsx` restores only that exact native result before loading it. Ordinary builtins, ESM imports, and custom module-hook remaps keep their original resolution.
 


### PR DESCRIPTION
`@ttsc/banner` cannot load a TypeScript config that imports a sibling by its JavaScript spelling on Node 22, and the utility plugins under-report what such a config consulted. Both are one gap in ttsx's CommonJS reach, found while running the `@ttsc/test-unplugin` suite on the oldest Node the package supports.

## What was wrong

TypeScript asks authors to write the emitted `.js` extension in a relative specifier. ttsx's ESM `resolve` hook has always mapped that spelling back to the source it names; the CommonJS graph never did.

`Module._extensions` decides how a file that was **already found** gets compiled, and Node reuses its keys only while probing an *extensionless* request. So `require("./x")` reached `x.ts` for free, and `require("./x.js")` backed only by `x.ts` failed to resolve before any compiler was consulted. The installer's own comment named `_extensions` as the CommonJS half of the pair — true of compilation, not of resolution.

That graph is reached by every `require()` inside a CommonJS module the ESM loader evaluated, which is exactly how a plugin loads a config file it discovered:

| runtime | `require()` inside a translator-evaluated CommonJS module |
| --- | --- |
| Node 22 | bypasses `module.registerHooks` — the hook sees the `import()` and nothing within it |
| Node 24 | routed through the hooks |

`engines.node` declares `>=22.15.0`, and every CI lane but one runs the current Node, so the floor went unchecked and this fell through it.

## What changed

**`packages/ttsc` — resolution.** The rescue is installed on `Module._resolveFilename` as well. It answers only a request Node's resolver already refused, and rethrows Node's original error untouched when no source matches, so a genuinely missing module keeps its `MODULE_NOT_FOUND` and `requireStack`. `require.resolve` shares the entry point and is fixed with it.

**`@ttsc/banner`, `@ttsc/strip` — input records.** Their loaders observe resolutions through the hook to report what a config consulted *plus the candidates that decide it*. On Node 22 a config's CommonJS requires were reported without those candidates, so a spelling appearing later could change what the config resolves to with nothing in the envelope to notice — the shape #1271 was filed for. Both now wrap the CommonJS resolver with the same two observations their hook makes, outside ttsx's own wrapper.

**`@ttsc/lint` is deliberately untouched.** The resolution half above already reaches it, since it belongs to ttsx. Its loader builds a config *graph* through a differently shaped hook; whether its own edge recording has the same gap is not established here, and changing it untested would be worse than leaving it. Worth its own investigation.

## Not widening CI

No new lane and no new OS. The `ttsx node 22.15` lane already exists as the only check of the declared floor; it gains this one case, because a case that passes on the current Node whatever ttsx does can only be judged there. The same case also runs on the default-Node lanes, so both runtimes are pinned.

## Verification

| lane | result |
| --- | --- |
| new case on the parent commit | fails with `Cannot find module './target.js'` |
| new case here | pass |
| `features/ttsx-runtime` (107 cases) | pass, except two pre-existing environment failures below |
| banner / paths / strip Go suites | pass |
| `test_transformttsc_persistent_utility_config_dependencies_invalidate_the_generation` | pass — this is what the branch repairs |
| typecheck, prettier, the Go formatter | clean |

`test_ttsx_executes_javascript_emitted_by_the_consumer_local_tsgo` and `test_ttsx_virtual_layout_mirrors_a_file_symlink_project_entry` fail on this Windows checkout for environment reasons — a stub executable that will not spawn, and a file symlink that needs elevation. Both were confirmed to fail identically with this branch's changes stashed, so neither is this work.
