### PR TITLE
fix(unplugin): publish module-faithful declarations

### DIFF
--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -5,70 +5,174 @@
   "main": "lib/index.js",
   "module": "lib/index.mjs",
   "types": "lib/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "lib/*": [
+        "lib/*"
+      ],
+      "package.json": [
+        "package.json"
+      ],
+      "*": [
+        "lib/*"
+      ]
+    }
+  },
   "exports": {
     ".": {
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./lib/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.cts",
+        "default": "./lib/index.js"
+      },
       "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
       "default": "./lib/index.js"
     },
     "./api": {
+      "import": {
+        "types": "./lib/api.d.mts",
+        "default": "./lib/api.mjs"
+      },
+      "require": {
+        "types": "./lib/api.d.cts",
+        "default": "./lib/api.js"
+      },
       "types": "./lib/api.d.ts",
-      "import": "./lib/api.mjs",
       "default": "./lib/api.js"
     },
     "./bun": {
+      "import": {
+        "types": "./lib/bun.d.mts",
+        "default": "./lib/bun.mjs"
+      },
+      "require": {
+        "types": "./lib/bun.d.cts",
+        "default": "./lib/bun.js"
+      },
       "types": "./lib/bun.d.ts",
-      "import": "./lib/bun.mjs",
       "default": "./lib/bun.js"
     },
     "./bun-register": {
+      "import": {
+        "types": "./lib/bun-register.d.mts",
+        "default": "./lib/bun-register.mjs"
+      },
+      "require": {
+        "types": "./lib/bun-register.d.cts",
+        "default": "./lib/bun-register.js"
+      },
       "types": "./lib/bun-register.d.ts",
-      "import": "./lib/bun-register.mjs",
       "default": "./lib/bun-register.js"
     },
     "./esbuild": {
+      "import": {
+        "types": "./lib/esbuild.d.mts",
+        "default": "./lib/esbuild.mjs"
+      },
+      "require": {
+        "types": "./lib/esbuild.d.cts",
+        "default": "./lib/esbuild.js"
+      },
       "types": "./lib/esbuild.d.ts",
-      "import": "./lib/esbuild.mjs",
       "default": "./lib/esbuild.js"
     },
     "./farm": {
+      "import": {
+        "types": "./lib/farm.d.mts",
+        "default": "./lib/farm.mjs"
+      },
+      "require": {
+        "types": "./lib/farm.d.cts",
+        "default": "./lib/farm.js"
+      },
       "types": "./lib/farm.d.ts",
-      "import": "./lib/farm.mjs",
       "default": "./lib/farm.js"
     },
     "./next": {
+      "import": {
+        "types": "./lib/next.d.mts",
+        "default": "./lib/next.mjs"
+      },
+      "require": {
+        "types": "./lib/next.d.cts",
+        "default": "./lib/next.js"
+      },
       "types": "./lib/next.d.ts",
-      "import": "./lib/next.mjs",
       "default": "./lib/next.js"
     },
     "./rolldown": {
+      "import": {
+        "types": "./lib/rolldown.d.mts",
+        "default": "./lib/rolldown.mjs"
+      },
+      "require": {
+        "types": "./lib/rolldown.d.cts",
+        "default": "./lib/rolldown.js"
+      },
       "types": "./lib/rolldown.d.ts",
-      "import": "./lib/rolldown.mjs",
       "default": "./lib/rolldown.js"
     },
     "./rollup": {
+      "import": {
+        "types": "./lib/rollup.d.mts",
+        "default": "./lib/rollup.mjs"
+      },
+      "require": {
+        "types": "./lib/rollup.d.cts",
+        "default": "./lib/rollup.js"
+      },
       "types": "./lib/rollup.d.ts",
-      "import": "./lib/rollup.mjs",
       "default": "./lib/rollup.js"
     },
     "./rspack": {
+      "import": {
+        "types": "./lib/rspack.d.mts",
+        "default": "./lib/rspack.mjs"
+      },
+      "require": {
+        "types": "./lib/rspack.d.cts",
+        "default": "./lib/rspack.js"
+      },
       "types": "./lib/rspack.d.ts",
-      "import": "./lib/rspack.mjs",
       "default": "./lib/rspack.js"
     },
     "./turbopack": {
+      "import": {
+        "types": "./lib/turbopack.d.mts",
+        "default": "./lib/turbopack.mjs"
+      },
+      "require": {
+        "types": "./lib/turbopack.d.cts",
+        "default": "./lib/turbopack.js"
+      },
       "types": "./lib/turbopack.d.ts",
-      "import": "./lib/turbopack.mjs",
       "default": "./lib/turbopack.js"
     },
     "./vite": {
+      "import": {
+        "types": "./lib/vite.d.mts",
+        "default": "./lib/vite.mjs"
+      },
+      "require": {
+        "types": "./lib/vite.d.cts",
+        "default": "./lib/vite.js"
+      },
       "types": "./lib/vite.d.ts",
-      "import": "./lib/vite.mjs",
       "default": "./lib/vite.js"
     },
     "./webpack": {
+      "import": {
+        "types": "./lib/webpack.d.mts",
+        "default": "./lib/webpack.mjs"
+      },
+      "require": {
+        "types": "./lib/webpack.d.cts",
+        "default": "./lib/webpack.js"
+      },
       "types": "./lib/webpack.d.ts",
-      "import": "./lib/webpack.mjs",
       "default": "./lib/webpack.js"
     },
     "./package.json": "./package.json"
@@ -77,7 +181,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "rimraf lib && tsc --emitDeclarationOnly && rollup -c"
+    "build": "rimraf lib && tsc --emitDeclarationOnly && node scripts/emit-dual-declarations.mjs && rollup -c"
   },
   "keywords": [
     "ttsc",
@@ -108,6 +212,7 @@
     "rimraf": "catalog:utils",
     "rollup": "^4.60.3",
     "tinyglobby": "^0.2.16",
+    "ts-legacy": "catalog:typescript",
     "tslib": "^2.8.1",
     "ttsc": "workspace:*",
     "typescript": "catalog:typescript",

--- a/packages/unplugin/scripts/emit-dual-declarations.mjs
+++ b/packages/unplugin/scripts/emit-dual-declarations.mjs
@@ -1,0 +1,164 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "ts-legacy";
+
+const lib = fileURLToPath(new URL("../lib", import.meta.url));
+const declarationFiles = await collectDeclarationFiles(lib);
+if (declarationFiles.length === 0) {
+  throw new Error(`No declarations found under ${lib}`);
+}
+
+for (const format of [
+  { declarationExtension: ".d.mts", moduleExtension: ".mjs" },
+  { declarationExtension: ".d.cts", moduleExtension: ".cjs" },
+]) {
+  for (const file of declarationFiles) {
+    const source = await fs.readFile(file, "utf8");
+    const output = rewriteRelativeModuleSpecifiers(
+      file,
+      source,
+      format.moduleExtension,
+    );
+    await fs.writeFile(
+      declarationVariant(file, format.declarationExtension),
+      output,
+      "utf8",
+    );
+  }
+  await verifyDeclarationGraph(
+    declarationFiles,
+    format.declarationExtension,
+    format.moduleExtension,
+  );
+}
+
+async function collectDeclarationFiles(directory) {
+  const files = [];
+  for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+    const file = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectDeclarationFiles(file)));
+    } else if (entry.isFile() && entry.name.endsWith(".d.ts")) {
+      files.push(file);
+    }
+  }
+  return files.sort();
+}
+
+function rewriteRelativeModuleSpecifiers(file, source, moduleExtension) {
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const replacements = collectRelativeModuleSpecifiers(sourceFile).map(
+    (literal) => ({
+      end: literal.getEnd() - 1,
+      start: literal.getStart(sourceFile) + 1,
+      text: formatRelativeModuleSpecifier(literal.text, moduleExtension),
+    }),
+  );
+  let output = source;
+  for (const replacement of replacements.sort((x, y) => y.start - x.start)) {
+    output =
+      output.slice(0, replacement.start) +
+      replacement.text +
+      output.slice(replacement.end);
+  }
+  return output;
+}
+
+function collectRelativeModuleSpecifiers(sourceFile) {
+  const literals = [];
+  const visit = (node) => {
+    let literal;
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier !== undefined &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      literal = node.moduleSpecifier;
+    } else if (
+      ts.isExternalModuleReference(node) &&
+      node.expression !== undefined &&
+      ts.isStringLiteralLike(node.expression)
+    ) {
+      literal = node.expression;
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteralLike(node.argument.literal)
+    ) {
+      literal = node.argument.literal;
+    } else if (
+      ts.isModuleDeclaration(node) &&
+      ts.isStringLiteralLike(node.name)
+    ) {
+      literal = node.name;
+    }
+    if (literal !== undefined && isRelativeModuleSpecifier(literal.text)) {
+      literals.push(literal);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return literals;
+}
+
+function formatRelativeModuleSpecifier(specifier, moduleExtension) {
+  const match = /^(.*?)([?#].*)?$/.exec(specifier);
+  const pathname = match[1];
+  const suffix = match[2] ?? "";
+  if (/\.(?:[cm]?js)$/.test(pathname)) {
+    return pathname.replace(/\.(?:[cm]?js)$/, moduleExtension) + suffix;
+  }
+  if (/\.(?:json|node)$/.test(pathname)) return specifier;
+  if (/\.(?:[cm]?tsx?|d\.[cm]?ts)$/.test(pathname)) {
+    throw new Error(
+      `Declaration module specifier ${JSON.stringify(specifier)} references TypeScript source`,
+    );
+  }
+  return pathname + moduleExtension + suffix;
+}
+
+async function verifyDeclarationGraph(
+  sourceFiles,
+  declarationExtension,
+  moduleExtension,
+) {
+  for (const sourceFile of sourceFiles) {
+    const outputFile = declarationVariant(sourceFile, declarationExtension);
+    const output = await fs.readFile(outputFile, "utf8");
+    const parsed = ts.createSourceFile(
+      outputFile,
+      output,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    for (const literal of collectRelativeModuleSpecifiers(parsed)) {
+      const specifier = literal.text.split(/[?#]/, 1)[0];
+      if (/\.(?:json|node)$/.test(specifier)) continue;
+      if (!specifier.endsWith(moduleExtension)) {
+        throw new Error(
+          `${outputFile} contains ${JSON.stringify(literal.text)} instead of a ${moduleExtension} specifier`,
+        );
+      }
+      const target = path.resolve(path.dirname(outputFile), specifier);
+      const declarationTarget =
+        target.slice(0, -moduleExtension.length) + declarationExtension;
+      await fs.access(declarationTarget);
+    }
+  }
+}
+
+function declarationVariant(file, extension) {
+  return file.slice(0, -".d.ts".length) + extension;
+}
+
+function isRelativeModuleSpecifier(specifier) {
+  return specifier.startsWith("./") || specifier.startsWith("../");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,6 +411,9 @@ importers:
       tinyglobby:
         specifier: ^0.2.16
         version: 0.2.16
+      ts-legacy:
+        specifier: catalog:typescript
+        version: typescript@6.0.3
       tslib:
         specifier: ^2.8.1
         version: 2.8.1

--- a/tests/test-unplugin/src/features/adapters/test_packaged_entrypoints_publish_module_faithful_declarations.ts
+++ b/tests/test-unplugin/src/features/adapters/test_packaged_entrypoints_publish_module_faithful_declarations.ts
@@ -1,0 +1,19 @@
+import { assertPackedEntrypointsProvideModuleFaithfulDeclarations } from "../../internal/packaged-host-contract";
+
+/**
+ * Verifies package declarations: runtime conditions select the same module
+ * kind.
+ *
+ * Locks the package-wide cause behind #1284. One CJS-classified `.d.ts` graph
+ * described both runtime branches, so a NodeNext ESM default import became a
+ * module namespace and the documented `ttsc()` call failed with TS2349.
+ *
+ * 1. Pack and extract `@ttsc/unplugin`, then inspect every public export
+ *    condition.
+ * 2. Compile NodeNext ESM and CommonJS consumers against the packed artifact.
+ * 3. Compile Bundler and legacy Node10 consumers against the same artifact.
+ */
+export const test_packaged_entrypoints_publish_module_faithful_declarations =
+  () => {
+    assertPackedEntrypointsProvideModuleFaithfulDeclarations();
+  };

--- a/tests/test-unplugin/src/internal/packaged-host-contract.ts
+++ b/tests/test-unplugin/src/internal/packaged-host-contract.ts
@@ -200,16 +200,19 @@ void options;
       `${config} failed against the packed declarations:\n${result.stdout}${result.stderr}`,
     );
   }
-  const node10 = TestProject.spawn(
-    process.execPath,
-    [resolveLegacyTypeScriptCompiler(), "--project", "tsconfig.node10.json"],
-    { cwd: consumer },
-  );
-  assert.equal(
-    node10.status,
-    0,
-    `tsconfig.node10.json failed against the packed declarations:\n${node10.stdout}${node10.stderr}`,
-  );
+  const legacyCompiler = resolveLegacyTypeScriptCompiler();
+  for (const config of ["tsconfig.nodenext.json", "tsconfig.node10.json"]) {
+    const result = TestProject.spawn(
+      process.execPath,
+      [legacyCompiler, "--project", config, "--pretty", "false"],
+      { cwd: consumer },
+    );
+    assert.equal(
+      result.status,
+      0,
+      `ts-legacy ${config} failed against the packed declarations:\n${result.stdout}${result.stderr}`,
+    );
+  }
 }
 
 function assertModuleFaithfulExportMap({

--- a/tests/test-unplugin/src/internal/packaged-host-contract.ts
+++ b/tests/test-unplugin/src/internal/packaged-host-contract.ts
@@ -14,33 +14,56 @@ import path from "node:path";
  * one) is what proves the contract a clean install would receive, without a
  * network install.
  */
-function readPackedManifest(): Record<string, any> {
+interface PackedUnpluginPackage {
+  manifest: Record<string, any>;
+  packageRoot: string;
+}
+
+function packUnpluginPackage(): PackedUnpluginPackage {
   const unpluginDir = path.join(
     TestProject.WORKSPACE_ROOT,
     "packages",
     "unplugin",
   );
   const dest = TestProject.tmpdir("ttsc-unplugin-pack-");
-  const pack = spawnSync("pnpm", ["pack", "--pack-destination", dest], {
-    cwd: unpluginDir,
-    encoding: "utf8",
-    shell: process.platform === "win32",
-  });
+  const packArgs = ["pack", "--pack-destination", dest];
+  const pack = spawnSync(
+    process.platform === "win32" ? "cmd.exe" : "pnpm",
+    process.platform === "win32"
+      ? ["/d", "/s", "/c", "pnpm", ...packArgs]
+      : packArgs,
+    {
+      cwd: unpluginDir,
+      encoding: "utf8",
+      windowsHide: true,
+    },
+  );
   assert.equal(pack.status, 0, `pnpm pack failed:\n${pack.stderr}`);
 
   const tarball = fs.readdirSync(dest).find((name) => name.endsWith(".tgz"));
   assert.ok(tarball, "pnpm pack produced no tarball");
 
-  // Extract just the manifest to stdout; `tar -O` is available cross-platform
-  // (bsdtar on Windows, GNU tar elsewhere) and avoids a tar library. Run with
-  // `cwd: dest` and a relative tarball name so a Windows drive-letter colon in
-  // the path is never mistaken for a remote `host:path` spec by GNU tar.
-  const show = spawnSync("tar", ["-xzOf", tarball, "package/package.json"], {
+  // Extract through the platform tar (bsdtar on Windows, GNU tar elsewhere).
+  // Run with `cwd: dest` and a relative tarball name so a Windows drive-letter
+  // colon is never mistaken for a remote `host:path` spec by GNU tar.
+  const extract = path.join(dest, "extract");
+  fs.mkdirSync(extract);
+  const unpack = spawnSync("tar", ["-xzf", tarball, "-C", "extract"], {
     cwd: dest,
     encoding: "utf8",
   });
-  assert.equal(show.status, 0, `tar extraction failed:\n${show.stderr}`);
-  return JSON.parse(show.stdout);
+  assert.equal(unpack.status, 0, `tar extraction failed:\n${unpack.stderr}`);
+  const packageRoot = path.join(extract, "package");
+  return {
+    manifest: JSON.parse(
+      fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"),
+    ),
+    packageRoot,
+  };
+}
+
+function readPackedManifest(): Record<string, any> {
+  return packUnpluginPackage().manifest;
 }
 
 /**
@@ -91,6 +114,272 @@ async function assertPackedManifestDeclaresTtscHost(): Promise<void> {
   );
 }
 
+/**
+ * Assert that the packed export map and declaration files preserve the module
+ * kind of every runtime branch, then compile representative consumers against
+ * the extracted package rather than workspace source paths.
+ */
+function assertPackedEntrypointsProvideModuleFaithfulDeclarations(): void {
+  const packed = packUnpluginPackage();
+  assertModuleFaithfulExportMap(packed);
+
+  const consumer = TestProject.tmpdir("ttsc-unplugin-types-");
+  const packageTarget = path.join(
+    consumer,
+    "node_modules",
+    "@ttsc",
+    "unplugin",
+  );
+  TestProject.copyDirectory(packed.packageRoot, packageTarget);
+  linkPackageDependency(
+    consumer,
+    "unplugin",
+    path.join(
+      TestProject.WORKSPACE_ROOT,
+      "packages",
+      "unplugin",
+      "node_modules",
+      "unplugin",
+    ),
+  );
+  materializePublishedTtscTypes(consumer);
+  TestProject.writeFiles(consumer, {
+    "package.json": JSON.stringify({ private: true, type: "module" }),
+    "tsconfig.nodenext.json": JSON.stringify({
+      compilerOptions: {
+        module: "nodenext",
+        moduleResolution: "nodenext",
+        noEmit: true,
+        skipLibCheck: true,
+        strict: true,
+        verbatimModuleSyntax: true,
+      },
+      files: ["consumer.mts", "consumer.cts"],
+    }),
+    "tsconfig.bundler.json": JSON.stringify({
+      compilerOptions: {
+        module: "esnext",
+        moduleResolution: "bundler",
+        noEmit: true,
+        skipLibCheck: true,
+        strict: true,
+        verbatimModuleSyntax: true,
+      },
+      files: ["consumer.ts"],
+    }),
+    "tsconfig.node10.json": JSON.stringify({
+      compilerOptions: {
+        ignoreDeprecations: "6.0",
+        module: "esnext",
+        moduleResolution: "node10",
+        noEmit: true,
+        skipLibCheck: true,
+        strict: true,
+      },
+      files: ["consumer.node10.ts"],
+    }),
+    "consumer.mts": esmConsumerSource(),
+    "consumer.cts": commonJsConsumerSource(),
+    "consumer.ts": esmConsumerSource(),
+    "consumer.node10.ts": `${esmConsumerSource()}
+import type { TtscUnpluginOptions } from "@ttsc/unplugin/lib/core/options";
+const options: TtscUnpluginOptions = {};
+void options;
+`,
+  });
+
+  for (const config of ["tsconfig.nodenext.json", "tsconfig.bundler.json"]) {
+    const result = TestProject.spawn(
+      TestProject.TSGO_BINARY,
+      ["--project", config, "--pretty", "false"],
+      { cwd: consumer },
+    );
+    assert.equal(
+      result.status,
+      0,
+      `${config} failed against the packed declarations:\n${result.stdout}${result.stderr}`,
+    );
+  }
+  const node10 = TestProject.spawn(
+    process.execPath,
+    [resolveLegacyTypeScriptCompiler(), "--project", "tsconfig.node10.json"],
+    { cwd: consumer },
+  );
+  assert.equal(
+    node10.status,
+    0,
+    `tsconfig.node10.json failed against the packed declarations:\n${node10.stdout}${node10.stderr}`,
+  );
+}
+
+function assertModuleFaithfulExportMap({
+  manifest,
+  packageRoot,
+}: PackedUnpluginPackage): void {
+  assert.deepEqual(manifest.typesVersions, {
+    "*": {
+      "lib/*": ["lib/*"],
+      "package.json": ["package.json"],
+      "*": ["lib/*"],
+    },
+  });
+  for (const [subpath, target] of Object.entries(manifest.exports ?? {}) as [
+    string,
+    any,
+  ][]) {
+    if (subpath === "./package.json") continue;
+    assert.equal(
+      typeof target,
+      "object",
+      `${subpath} must use conditional exports`,
+    );
+    const expectedStem = subpath === "." ? "index" : subpath.slice(2);
+    const expected = {
+      import: {
+        types: `./lib/${expectedStem}.d.mts`,
+        default: `./lib/${expectedStem}.mjs`,
+      },
+      require: {
+        types: `./lib/${expectedStem}.d.cts`,
+        default: `./lib/${expectedStem}.js`,
+      },
+      types: `./lib/${expectedStem}.d.ts`,
+      default: `./lib/${expectedStem}.js`,
+    };
+    assert.deepEqual(target, expected, `${subpath} export conditions`);
+    for (const file of [
+      expected.import.types,
+      expected.import.default,
+      expected.require.types,
+      expected.require.default,
+      expected.types,
+    ]) {
+      assert.equal(
+        fs.existsSync(path.join(packageRoot, file)),
+        true,
+        `${subpath} points at missing ${file}`,
+      );
+    }
+  }
+}
+
+function linkPackageDependency(
+  consumer: string,
+  name: string,
+  target: string,
+): void {
+  const link = path.join(consumer, "node_modules", ...name.split("/"));
+  fs.mkdirSync(path.dirname(link), { recursive: true });
+  fs.symlinkSync(
+    fs.realpathSync(target),
+    link,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+}
+
+function materializePublishedTtscTypes(consumer: string): void {
+  const source = path.join(TestProject.WORKSPACE_ROOT, "packages", "ttsc");
+  const sourceManifest = JSON.parse(
+    fs.readFileSync(path.join(source, "package.json"), "utf8"),
+  );
+  const target = path.join(consumer, "node_modules", "ttsc");
+  TestProject.copyDirectory(path.join(source, "lib"), path.join(target, "lib"));
+  TestProject.writeFiles(target, {
+    "package.json": JSON.stringify({
+      ...sourceManifest,
+      ...sourceManifest.publishConfig,
+      publishConfig: undefined,
+    }),
+  });
+}
+
+function resolveLegacyTypeScriptCompiler(): string {
+  const unplugin = path.join(
+    TestProject.WORKSPACE_ROOT,
+    "packages",
+    "unplugin",
+  );
+  const manifest = TestProject.REQUIRE_FROM_TEST.resolve(
+    "ts-legacy/package.json",
+    { paths: [unplugin] },
+  );
+  return path.join(path.dirname(manifest), "bin", "tsc");
+}
+
+function esmConsumerSource(): string {
+  return `
+import root from "@ttsc/unplugin";
+import { resolveOptions } from "@ttsc/unplugin/api";
+import bun from "@ttsc/unplugin/bun";
+import register from "@ttsc/unplugin/bun-register";
+import esbuild from "@ttsc/unplugin/esbuild";
+import farm from "@ttsc/unplugin/farm";
+import next from "@ttsc/unplugin/next";
+import rolldown from "@ttsc/unplugin/rolldown";
+import rollup from "@ttsc/unplugin/rollup";
+import rspack from "@ttsc/unplugin/rspack";
+import turbopack from "@ttsc/unplugin/turbopack";
+import vite from "@ttsc/unplugin/vite";
+import webpack from "@ttsc/unplugin/webpack";
+
+type Factory = (...args: any[]) => unknown;
+const factories = [
+  root.vite,
+  bun,
+  register,
+  esbuild,
+  farm,
+  next,
+  rolldown,
+  rollup,
+  rspack,
+  turbopack,
+  vite,
+  webpack,
+] satisfies readonly Factory[];
+vite();
+resolveOptions();
+void factories;
+`;
+}
+
+function commonJsConsumerSource(): string {
+  return `
+import root = require("@ttsc/unplugin");
+import api = require("@ttsc/unplugin/api");
+import bun = require("@ttsc/unplugin/bun");
+import register = require("@ttsc/unplugin/bun-register");
+import esbuild = require("@ttsc/unplugin/esbuild");
+import farm = require("@ttsc/unplugin/farm");
+import next = require("@ttsc/unplugin/next");
+import rolldown = require("@ttsc/unplugin/rolldown");
+import rollup = require("@ttsc/unplugin/rollup");
+import rspack = require("@ttsc/unplugin/rspack");
+import turbopack = require("@ttsc/unplugin/turbopack");
+import vite = require("@ttsc/unplugin/vite");
+import webpack = require("@ttsc/unplugin/webpack");
+
+type Factory = (...args: any[]) => unknown;
+const factories = [
+  root.default.vite,
+  bun.default,
+  register.default,
+  esbuild.default,
+  farm.default,
+  next.default,
+  rolldown.default,
+  rollup.default,
+  rspack.default,
+  turbopack.default,
+  vite.default,
+  webpack.default,
+] satisfies readonly Factory[];
+vite.default();
+api.resolveOptions();
+void factories;
+`;
+}
+
 function assertCompatibleCaretRange(range: string, dependency: string): void {
   const match =
     /^\^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.exec(
@@ -135,4 +424,7 @@ function compareVersions(
   return left[0] - right[0] || left[1] - right[1] || left[2] - right[2];
 }
 
-export { assertPackedManifestDeclaresTtscHost };
+export {
+  assertPackedEntrypointsProvideModuleFaithfulDeclarations,
+  assertPackedManifestDeclaresTtscHost,
+};

--- a/website/src/content/docs/setup/unplugin.mdx
+++ b/website/src/content/docs/setup/unplugin.mdx
@@ -33,6 +33,8 @@ Adapters ship for Vite, Rollup, Rolldown, esbuild, webpack, Rspack, Next.js, Tur
 
 Then register the adapter that matches your bundler.
 
+The package publishes matching ESM and CommonJS runtime and type branches. The default imports below type-check under both `moduleResolution: "nodenext"` and `moduleResolution: "bundler"`; CommonJS `require()` continues to expose each adapter as `.default`.
+
 ## Keep the two versions together
 
 `@ttsc/unplugin` declares `ttsc` as a peer dependency pinned to the minor it was published with. Both packages are released from one repository at one version, and the adapter compiles against `ttsc`'s exported compiler surface, so a `0.x` minor is allowed to change what it imports. The pin is what turns that into an install error instead of a runtime failure in your bundler.


### PR DESCRIPTION
## Intent

Resolve #1284 at the package boundary: every `@ttsc/unplugin` runtime export must be paired with a declaration graph of the same module kind, so NodeNext ESM consumers receive callable default adapters without weakening CommonJS support. Resolve the Node10 subpath gap found while validating that package-wide contract in #1288.

## Scope

- generate and publish module-kind-faithful ESM and CommonJS declarations for the complete public export map;
- preserve the existing `.mjs` import and CommonJS runtime entrypoints;
- preserve legacy Node10 public and existing `lib/*` resolution through a future-proof `typesVersions` fallback;
- add packed-package consumer checks for NodeNext ESM, NodeNext CommonJS, Bundler, and Node10 resolution;
- update the matching bundler setup documentation.

Closes #1284.
Closes #1288.

## Deferred

None.

## Verification

- `pnpm --filter @ttsc/unplugin build`
- original TypeScript 6.0.3 NodeNext reproduction with `tsc` and `ttsc`
- packed consumer regression across NodeNext ESM/CJS, Bundler, and Node10
- `pnpm dlx @arethetypeswrong/cli --pack packages/unplugin`: no problems for every public entrypoint
- `pnpm test:typecheck`
- `pnpm --filter @ttsc/test-unplugin start`
- `pnpm experimental:unplugin`
- `pnpm check:dependencies`
- `pnpm format` and targeted formatter verification
